### PR TITLE
Pusher: one build, one encode and one compare per change; the timeline's live tick translates the plot

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -2837,7 +2837,7 @@ def declared_plan(session):
     result text (a creation-order `cN` fallback if the result is unreadable); `status` rides each
     TaskUpdate. Only TaskCreate/TaskUpdate are folded — plain TodoWrite (no durable ids) is not
     used by romp. Empty list if the session declared no plan."""
-    results = {}                                           # tool_use_id → result text (carries 'Task #N')
+    results = {}                                           # tool_use_id → result content (a TaskCreate's carries 'Task #N')
     rejected = set()                                       # tool_use_ids whose result came back is_error
     for turn in session["turns"]:
         for a in turn["atoms"]:
@@ -2845,8 +2845,7 @@ def declared_plan(session):
                 continue
             for b in (a.get("message") or {}).get("content", []) or []:
                 if isinstance(b, dict) and b.get("type") == "tool_result" and b.get("tool_use_id"):
-                    c = b.get("content")
-                    results[b["tool_use_id"]] = c if isinstance(c, str) else json.dumps(c)
+                    results[b["tool_use_id"]] = b.get("content")
                     if b.get("is_error"):
                         rejected.add(b["tool_use_id"])
     tasks, order = {}, 0
@@ -2866,7 +2865,10 @@ def declared_plan(session):
                     # could ever close. Keyed on the result's is_error, as the kernel's fold is.
                     if b.get("id") in rejected:
                         continue
-                    m = re.search(r"Task #(\d+)", results.get(b.get("id"), "") or "")
+                    # Only a TaskCreate's result is ever read, so only it is encoded, here, to the same text
+                    # the regex saw when every result was encoded up front, as the kernel's _fold_tasks does.
+                    r = results.get(b.get("id"), "")
+                    m = re.search(r"Task #(\d+)", (r if isinstance(r, str) else json.dumps(r)) or "")
                     key = m.group(1) if m else "c%d" % order
                     af = inp.get("activeForm")
                     tasks[key] = {"_order": order, "key": key, "text": str(inp.get("subject") or ""),

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -32706,12 +32706,14 @@ def _dedup_sig(msg, s):
     return s
 
 
-# The pusher's wire caches, counted: whole frames serialized per slot (a _LazyWire made; at most once per build
-# each), builds whose payload could not be keyed and took the whole dump for their signature, and values a wire
-# encoder shipped as str() (_wire_default, one per encode). Bumped through _wire_bump, under a lock: the pusher
-# bumps the fallback counters, and whichever sender thread first materializes a _LazyWire bumps its counter, so
-# a bare `+= 1` here would be a read-modify-write across threads (the tests assert exact counts).
-_wire_stats = {"feed_body": 0, "bars_body": 0, "feed_sig_fallback": 0, "bars_sig_fallback": 0, "default_str": 0}
+# The pusher's wire caches, counted: a collection's per-entry split served from _delta_split_memo (hit) or run
+# (miss, a raise included), whole frames serialized per slot (a _LazyWire made; at most once per build each),
+# builds whose payload could not be keyed and took the whole dump for their signature, and values a wire encoder
+# shipped as str() (_wire_default, one per encode). Bumped through _wire_bump, under a lock: the pusher and a
+# handler-thread connect push both split, and whichever sender thread first materializes a _LazyWire bumps its
+# counter, so a bare `+= 1` here would be a read-modify-write across threads (the tests assert exact counts).
+_wire_stats = {"split_hit": 0, "split_miss": 0, "feed_body": 0, "bars_body": 0, "feed_sig_fallback": 0,
+               "bars_sig_fallback": 0, "default_str": 0}
 _WIRE_STATS_LOCK = threading.Lock()
 _wire_default_said = set()   # type names _wire_default has written to stderr: a type is said once, not per value
 
@@ -32918,6 +32920,14 @@ _DELTA_SLOTS = {
 _DELTA_SEP = "\u001f"          # joins composite keys; never appears in an id or a sid
 _DELTA_MAX_FRACTION = 0.6      # a delta this large a fraction of the full payload is sent as the full instead
 _delta_parts_cache = {}        # frame type -> (payload object identity, parts) — one split per BUILD, shared by clients
+_delta_split_memo = {}         # (frame type, collection) -> (collection object identity, its split) — the same once-per-build
+#                                rule one level down. _push serves the feed as a COPY of the cached build with the cycle's
+#                                ledgers attached (feed = dict(feed_src)), so a cycle whose ledgers moved but whose build
+#                                did not is a new payload object around the same asks list: the payload cache misses and,
+#                                without this, every card was encoded again for a remainder-only change. Identity-keyed
+#                                on the premise the payload cache and _feed_wire already rest on — a built collection is
+#                                never mutated in place; a rebuild mints a new one. One entry per (frame type,
+#                                collection), replaced on a miss: it pins the entry graph _delta_parts_cache pins.
 _delta_unkeyable_said = set()  # (frame type, why) already written to stderr: an unkeyable shape is said once, not per cycle
 
 
@@ -32994,7 +33004,9 @@ def _delta_split(kind, value):
 
 
 def _delta_parts(ftype, payload):
-    """The payload split into its keyed collections and the remainder, computed once per payload object."""
+    """The payload split into its keyed collections and the remainder, computed once per payload object — and each
+    collection's split once per collection object (_delta_split_memo), so a payload that changed only its
+    remainder re-encodes no entry."""
     hit = _delta_parts_cache.get(ftype)
     if hit is not None and hit[0] is payload:
         return hit[1]
@@ -33002,10 +33014,18 @@ def _delta_parts(ftype, payload):
     try:
         colls = {}
         for name, kind in kinds.items():
+            value = payload.get(name)
+            m = _delta_split_memo.get((ftype, name))
+            if m is not None and m[0] is value:          # the same collection object: the same entries, the same strings
+                colls[name] = m[1]
+                _wire_bump("split_hit")
+                continue
+            _wire_bump("split_miss")
             try:
-                colls[name] = _delta_split(kind, payload.get(name))
+                colls[name] = _delta_split(kind, value)
             except ValueError as e:
                 raise ValueError("%s: %s" % (name, e)) from None     # name the collection for the log line
+            _delta_split_memo[(ftype, name)] = (value, colls[name])
     except ValueError as e:
         parts = None                                   # a payload the protocol cannot key: this build goes whole
         if (ftype, str(e)) not in _delta_unkeyable_said:   # …and says so once: a silent whole is a silent perf loss
@@ -35145,7 +35165,9 @@ def _push(targets, connect=False, tmux=None):
         feed = feed_src
         if feed is not None:
             feed = dict(feed_src)                        # copy so the per-push ledger attach never dirties the cache
-            #                                              (feed_src's identity keys the wire cache below)
+            #                                              (feed_src's identity keys the wire cache below; the asks list
+            #                                              rides through the copy, so a refill's cards are served from
+            #                                              _delta_split_memo rather than encoded again)
             # Attach `ledgers` whenever the session build RAN (want_chat or want_fleet) — even as an EMPTY list
             # for a fleet with no sessions — so the fleet can tell "the build ran, here's the data (maybe none)"
             # from "no data yet, still loading" and keep its loader up until real data lands (the user

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -23236,7 +23236,7 @@ def _chat_build_sig(sess, tm=None):
     """A cheap (transcript mtime,size, states mtime,size) signature for the chat-build cache — busts on any
     new content OR a state transition (idle/working), the two things that change a session's chat payload,
     plus the judge generation, the task store, the pending cut, and — when the caller hands the session's
-    snapshot row `tm` — the facts the build renders from it (state, model, ctx, effort, subagents, background
+    snapshot row `tm` — the facts the build renders from it (state, model, context, effort, subagents, background
     tasks, pending picks, retry count, connected, spawning). The judge generation used to advance every pass
     and so rebuilt every background tab within ~3 s whatever changed; it now advances only when a judge-
     written store moved, so the snapshot digest is what keeps a background tab's chips within one cycle of
@@ -23277,7 +23277,7 @@ def _chat_build_sig(sess, tm=None):
     sig.append(_be.pending_cut(sess.get("sid") or "") if _be else "")
     if tm is not None:
         t = tm
-        sig.append((t.get("state"), t.get("model"), t.get("ctx"), t.get("effort"), t.get("mode"), t.get("fast"), t.get("since"),
+        sig.append((t.get("state"), t.get("model"), t.get("context"), t.get("effort"), t.get("mode"), t.get("fast"), t.get("since"),
                     len(t.get("subagents") or ()), len(t.get("bgTasks") or ()), bool(t.get("interrupting")),
                     bool(t.get("modelPending")), bool(t.get("effortPending")), bool(t.get("authPending")),
                     int(t.get("retryCount") or 0), bool(t.get("connected")), bool(t.get("spawning")),
@@ -29676,10 +29676,17 @@ WIN_WEEK = 7 * 86400                           # The footer shows tokens per win
 
 def _state_intervals(sid, want, now):
     """Every [start,end] the session sat in `want` ('permission'/'picker' → awaiting candy-stripes,
-    'compacting' → cross-hatch), from states/<sid>.jsonl: an entry runs until the next transition
-    (or `now` if still in it). `want` is a single state or any collection of them (the awaiting band
-    passes both needs-input states). Forward-only — periods predating the log don't appear. File-based
-    port of the obsidian timeline's stateIntervals (the kernel reads states/, never tmux).
+    'compacting' → cross-hatch), from states/<sid>.jsonl: an entry runs until the next transition, or to
+    `now` (the build's clock) if the session is still in it. That open end IS the wire contract the
+    renderer reads (romp-timeline-view.js): an end within 2 s of the payload's `now` means open. The end
+    stays numeric on purpose: a null end would be a wire break — every already-loaded renderer (an open
+    dashboard, an installed extension) takes Math.min(null, t1) = 0 and drops the stripe for a lane
+    blocked or compacting right now. The clock-stamped end costs no per-cycle work: the lanes frame is
+    serialized once per build and deduped on content, so while the state lasts the frame goes once per
+    rebuild (the end moved), and an unchanged rebuild sends nothing. `want` is a single state or any
+    collection of them (the awaiting band passes both needs-input states). Forward-only — periods
+    predating the log don't appear. File-based port of the obsidian timeline's stateIntervals (the kernel
+    reads states/, never tmux).
     Folds the states log append-incrementally since 2026-09-03 (_fold_records): every timeline
     rebuild used to re-read and re-parse the whole file, twice per session (once per `want`); the
     intervals themselves are cheap."""
@@ -29689,7 +29696,7 @@ def _state_intervals(sid, want, now):
     for i, (t, st) in enumerate(ev):
         if st not in want:
             continue
-        end = ev[i + 1][0] if i + 1 < len(ev) else now
+        end = ev[i + 1][0] if i + 1 < len(ev) else now     # still in it: the build clock, which the renderer reads as open
         if end < cutoff:
             continue
         out.append([max(t, cutoff), end])
@@ -31752,11 +31759,13 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
     Message connectors (need the courier) and cross-pane focus/hover are later increments — emitted
     empty/null so the render's conditional paths hide them.
 
-    with_bars=False builds only the LANES SKELETON (sessions + tokens + status) — the heavy per-segment
-    bars, the judging band, the message connectors and the nudge marks are left empty. The push sends this
-    skeleton FIRST so the lanes paint instantly, then ships the bars as a separate {type:"bars"} message
-    (the user 2026-06-25, who wanted everything else loaded and the bars loaded after). build_timeline is ~95%
-    bars+judging by payload and the dominant startup cost, so the skeleton is cheap and lands immediately."""
+    with_bars=False builds only the LANES SKELETON (sessions + status) — the heavy per-segment bars, the
+    judging band and the message connectors are left empty. The push ships the lanes as a {type:"data"}
+    frame FIRST and the bars as a separate {type:"bars"} message (the user 2026-06-25, who wanted everything
+    else loaded and the bars loaded after); build_timeline is ~95% bars+judging by payload. The skeleton
+    BUILD runs only on the cold live-first connect (no cached full build yet): every warm push projects the
+    lanes frame from the cached full build instead (_timeline_skeleton; the WARM note in _push has the
+    contract and its lag), so the with_bars=False branches below are the cold-connect path."""
     if tmux is None:
         tmux = _tmux_sessions()
     alive = _timeline_sessions(now, tmux, live_only=live_only)   # living + window-dead (≤12h) lanes; per-session `live` below marks the dead ones (struck). live_only → live sessions only (cold-start first paint)
@@ -31822,16 +31831,14 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
             # ONE derivation with the chat chip (the user 2026-07-03: after an API error the chat read
             # API ERROR → READY while the lane sat on raw-snapshot 'working'): the lane state IS
             # _session_chip — same event-model working, api-error gate, compacting corroboration,
-            # interrupt stamp. The SKELETON build has no fresh parse, so it uses the CACHED one (no cold
-            # cost; the {type:"bars"} build refines a beat later); a COLD cache falls back to the raw
-            # snapshot state — the only moment the two surfaces may briefly differ, self-healing on the
-            # next build (the 2026-06-26 fast-first-paint contract).
-            # Same INPUT, not just the same formula (the user 2026-07-03): the chat chip computes over the
-            # LIVE-MERGED session, and the lane badge rides the SKELETON build (the {type:"bars"} message
-            # carries no states) — so the skeleton must merge the live tail onto the cached parse too, or
-            # a live atom that changes the answer splits the two surfaces on EVERY push (chat WORKING /
-            # lane READY, the phantom-working divergence). The merge is dict work on in-memory atoms — no
-            # parse, so the fast-first-paint contract holds.
+            # interrupt stamp. Same INPUT, not just the same formula (the user 2026-07-03): the chip
+            # computes over the LIVE-MERGED session, so the full build's lane does too (`session` above is
+            # merged). The SKELETON build — the cold live-first connect only — has no fresh parse: it uses
+            # the CACHED one with the live tail merged the same way, and a COLD cache falls back to the raw
+            # snapshot state, the one moment the two surfaces may briefly differ, self-healing on the next
+            # build (the 2026-06-26 fast-first-paint contract). Warm pushes project the lanes from the
+            # cached full build, so the lane's state trails the chat chip by at most REBUILD_MIN_S or the
+            # 5 s bucket (the WARM note in _push).
             comp_sess = session if with_bars else _parse_cached(s["path"])
             if not with_bars and comp_sess is not None:
                 try:
@@ -34977,6 +34984,29 @@ def _push(targets, connect=False, tmux=None):
         # LIVE-FIRST (the user 2026-06-26): the very first paint after a kernel start reads NO dead session — it
         # builds live sessions only (lanes + bars) so the main UI is up at once; the producer warms the full
         # build (live + dead-within-12h) and the next pusher push folds the dead lanes in, in the background.
+        # WARM: once a full build is cached, the skeleton is PROJECTED from it (_timeline_skeleton) instead of
+        # built again. Every cycle used to run build_timeline(with_bars=False) — no transcript parse, but the
+        # same per-lane derivation the full build had just done (store loads, the chip over the cached parse
+        # plus the live merge, the awaiting overlay) — and then serialized the frame and re-dumped it once more
+        # per client for the dedup compare. A cache hit now serves lanes identical to the last rebuild, so no
+        # lane moves without a rebuild; rebuilds still come on every view-sig change, on _views_dirty and at
+        # the 5 s bucket, so the lanes lag a rebuild by at most REBUILD_MIN_S, the lag the bars always had.
+        # Two visible differences from the built skeleton: the lanes' `compactions` come from the full build's
+        # parse (the built skeleton parsed nothing and always shipped []), and a dead lane's `since` is its
+        # last work end rather than the transcript mtime. Accepted too: the first regular cycle after boot
+        # serves the full build before the lanes frame (the connect push took the cold path and cached
+        # nothing), so the DEAD lanes reach the client one build later than the per-cycle skeleton showed
+        # them; the live lanes painted on the connect.
+        # The frame is serialized once per BUILD (_skel_wire, keyed on the cached object's identity like
+        # _bars_wire) and deduped on CONTENT through _dedup_sig, which strips the nested clock as it does for
+        # every {type:"data"} frame: a rebuild whose lanes are unchanged sends nothing, exactly as the bars
+        # frame behaves, and the 60 s repost (_DEDUP_REPOST_S) is what refreshes the pane's clock sample. A
+        # lane sitting in an awaiting or compacting state is the one exception: its open interval ends at the
+        # build clock (_state_intervals), so its frame goes once per rebuild while the state lasts — where the
+        # per-cycle skeleton sent it every cycle. A CONNECT push is the other: it stamps the cached lanes with
+        # the cycle's clock (below), since the pane anchors its live edge on its first sample and the cache
+        # can be hours old when no timeline client kept it warm.
+        global _skel_wire
         _PERF_STATS.stage("push.feed", time.monotonic() - _t_stage)
         _t_stage = time.monotonic()
         timeline = None
@@ -34984,16 +35014,37 @@ def _push(targets, connect=False, tmux=None):
         if want_tl:
             tl_clients = [c for c in targets if c["app"] == "timeline"]
             live_first = connect and _built_timeline[1] is None     # cold start, nothing warmed yet → live only
-            skel = build_timeline(now, tmux, with_bars=False, live_only=live_first)
-            for c in tl_clients:
-                _send_client(c, ("timeline",), {"type": "data", "data": skel})
             if live_first:
+                skel = build_timeline(now, tmux, with_bars=False, live_only=True)
+                for c in tl_clients:
+                    _send_client(c, ("timeline",), {"type": "data", "data": skel})
                 timeline = build_timeline(now, tmux, with_bars=True, live_only=True)   # live bars now (no dead reads)
                 tl_warming = True                                   # this is the PARTIAL cold build — the client keeps its loader up
                 _producer_wake.set()                                # ...if it lands empty (SDK/federation not yet merged), rather than flashing
                 #                                                     "no activity"; a later warmed push (tl_warming False) settles it (the user 2026-07-03)
             else:
                 timeline = _cached_timeline(now, tmux, fsig, connect)
+                if connect:
+                    # A CONNECT serves the cached lanes under the CYCLE's clock: the pane anchors its live edge
+                    # and its window fit on the first data.now it sees, and the cache is as old as the last
+                    # cycle that had a timeline client — a bucket on a reload, hours after the pane was closed
+                    # — so the build clock would sit the axis in the past until the next rebuild. One
+                    # serialization per connect; the new client's dedup slot is empty, so the frame always
+                    # goes, and _send_client derives its content-only sig, so the next cycle's build-clock
+                    # frame dedups against it unless the lanes changed.
+                    frame = {"type": "data", "data": {**_timeline_skeleton(timeline), "now": now}}
+                    skel_pre, skel_sig = json.dumps(frame), None
+                else:
+                    w = _skel_wire                                  # tuple snapshot — rebound whole, never mutated
+                    if w is not None and w[0] is timeline:
+                        frame, skel_pre, skel_sig = w[1], w[2], w[3]
+                    else:
+                        frame = {"type": "data", "data": _timeline_skeleton(timeline)}
+                        skel_pre = json.dumps(frame)
+                        skel_sig = _dedup_sig(frame, skel_pre)
+                        _skel_wire = (timeline, frame, skel_pre, skel_sig)
+                for c in tl_clients:
+                    _send_client(c, ("timeline",), frame, pre=skel_pre, sig=skel_sig)
         _PERF_STATS.stage("push.timeline", time.monotonic() - _t_stage)
     except Exception:
         sys.stderr.write("push build: %s\n" % traceback.format_exc())
@@ -35287,6 +35338,7 @@ _built_timeline = [None, None, 0.0, 0.0]          # [fleet_sig, payload, built_a
 # torn entry; the identity keys stay alive because these tuples (and the build caches above) hold them.
 _feed_wire = None   # (feed_src, ledgers, wire_feed, ms, sig)
 _bars_wire = None   # (timeline, warming, bars, ms, sig)
+_skel_wire = None   # (timeline, frame, pre, sig) — the lanes {type:"data"} frame projected from the same cached build
 # Each build is intrinsically ~1-1.6s (re-segments every session); the IDEAL is a per-session lane/card cache
 # (only the changed session rebuilds), but that's a big refactor of build_feed/build_timeline. Interim cap: a
 # minimum rebuild interval. With an ACTIVE fleet the fleet_sig busts on every push (the watched session keeps
@@ -35314,7 +35366,7 @@ def _next_feed_build_id():
 def _fleet_view_sig(now, tmux):
     """Cheap fingerprint of everything build_feed/build_timeline read. Busts on any transcript/names/states/
     postal change (_producer_sig), a judge pass (goal/caption via _judge_gen), a live tmux BADGE change
-    (state/model/ctx/effort — touches no file), a colormap or session-flags change, a SESSION-ORDER change
+    (state/model/context/effort — touches no file), a colormap or session-flags change, a SESSION-ORDER change
     (a tab/lane reorder writes session-order.json — the feed orders its grouped cards by it, so a reorder
     must bust the cache or the reordered cards lag behind the tabs by up to a bucket; the user 2026-07-15),
     or a 5s time bucket so 'X ago'/elapsed keeps advancing when nothing else changes."""
@@ -35332,22 +35384,57 @@ def _fleet_view_sig(now, tmux):
                  (jd.STATE / "auto-nudge.json", "__nudge__"),      # stalled section, nudge counts/failed stamps
                  (jd.STATE / "nudge-events.jsonl", "__nudgev__"),  # ⚡ marks
                  (jd.STATE / "judge-auth.json", "__jauth__"),      # judge billing refusal latch
-                 (jd.STATE / "judge-limit.json", "__jlimit__")):   # judge quota latch
+                 (jd.STATE / "judge-limit.json", "__jlimit__"),    # judge quota latch
+                 # the timeline's own file inputs: the lanes frame is projected from the cached build, so
+                 # what the lanes read must bust the cache — the usage bars (usage.json, via
+                 # _usage_for_client) and the views blob (timeline-views.json, via _views_client). The
+                 # per-cycle skeleton carried both fresh every cycle; projected from the cache, these
+                 # mtimes bring a change forward from the bucket, and the helpers' non-file inputs (remote
+                 # tags from the supervisor's /views poll, judge failures) still wait for it.
+                 (jd.STATE / "usage.json", "__usage__"),
+                 (_views_path(), "__views__"),
+                 # …the lanes' comment squares (STATE/comments/<sid>.json, _comment_markers: every write is
+                 # an _atomic_write into this directory, so its mtime moves on a create AND a rewrite) and
+                 # the kernel watches (WATCH_FILE, read by _watch_awaiting for the awaiting badge): a
+                 # resolve on a dormant thread or a watch firing changes only the store, and used to reach
+                 # the lane at the bucket
+                 (jd.STATE / "comments", "__comments__"),
+                 (WATCH_FILE, "__watches__")):
         try:
             sig[k] = os.stat(p).st_mtime
         except OSError:
             pass
     for s in sorted(tmux):
         t = tmux[s]
-        # the badge fields, plus the SDK snapshot facts the feed/timeline render that touch no file: live
-        # subagent and background-task counts (lane pill, awaiting box), an interrupt in flight, a model/
-        # effort/auth switch resolving, a retry storm. Without them a change here was visible only via
-        # the time bucket (the 2026-09-03 audit).
-        sig["t:" + s] = (t.get("state"), t.get("model"), t.get("ctx"), t.get("effort"), t.get("mode"), t.get("fast"), t.get("since"),
-                         len(t.get("subagents") or ()), len(t.get("bgTasks") or ()), bool(t.get("interrupting")),
+        # Every row field the lanes and the chat chip derive from, plus the SDK snapshot facts the feed/
+        # timeline render that touch no file (a model/effort/auth switch resolving, a retry storm, the
+        # connect and spawn bits; the 2026-09-03 audit). `context` is the row's key (the tmux vars and the
+        # SDK merge both write it); the sig read `ctx`, which no row carries, so a context-% change never
+        # busted the cache and the lane's battery waited on the bucket. Never keyed before: the fast-mode
+        # refusal reason (the chip's `fast` blanks on it), the subagent rows (the lane ships the whole
+        # list, so a count alone missed a change inside it) and the background-task ids behind the
+        # awaiting badge (a count alone missed a swap). Not keyed on purpose: `snapT` (the snapshot's
+        # clock, not a fact about the session) and `interrupting` (the merged row never carries it — the
+        # SDK merge copies an explicit key list — and the WS stop op marks the views dirty itself; the
+        # HTTP /interrupt route only wakes the pusher).
+        sig["t:" + s] = (t.get("state"), t.get("model"), t.get("context"), t.get("effort"), t.get("mode"),
+                         t.get("fast"), t.get("since"), t.get("fastReason"),
+                         _row_items_sig(t.get("subagents")), _row_ids_sig(t.get("bgTasks")),
                          bool(t.get("modelPending")), bool(t.get("effortPending")), bool(t.get("authPending")),
                          int(t.get("retryCount") or 0), bool(t.get("connected")), bool(t.get("spawning")))
     return tuple(sorted(sig.items()))
+
+
+def _row_items_sig(rows):
+    """A liveness row's list of dicts (the live subagents) as an immutable, comparable value for the view
+    signature: each dict's sorted items. The lane ships the whole list, so any field change counts."""
+    return tuple(tuple(sorted(r.items())) if isinstance(r, dict) else r for r in (rows or ()))
+
+
+def _row_ids_sig(tasks):
+    """The background-task ids off a liveness row, for the view signature: the awaiting badge and its task
+    list key on which tasks exist (toolUseId), not on a task's progress fields."""
+    return tuple(str(t.get("toolUseId") or "") for t in (tasks or ()) if isinstance(t, dict))
 
 
 def _cached_feed(now, tmux, sig, connect=False):
@@ -36091,6 +36178,16 @@ def _cached_timeline(now, tmux, sig, connect=False):
     _PERF_STATS.build("timeline", False, time.monotonic() - _t0)
     _built_timeline[:] = [sig, tl, time.time(), started]
     return tl
+
+
+def _timeline_skeleton(tl):
+    """The {type:"data"} lanes frame's body, PROJECTED from a full timeline build: the same dict minus the
+    heavy time-plotted detail — turns, judging, messages, which ride the {type:"bars"} message. It keeps
+    the BUILD's clock (`now`): the pusher dedups the frame on content with that clock stripped, and the
+    bars frame carries the same clock. A shallow copy, never a mutation: `tl` is the cached build
+    (_built_timeline[1]), shared with every later cycle and the identity key of the bars and lanes wire
+    caches."""
+    return {**tl, "turns": {}, "judging": [], "messages": []}
 
 
 def _run_tier(fn):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7086,7 +7086,8 @@ def _auto_pause_on_limit():
         _set_retry_paused(True)
         sys.stderr.write("retry-pause: auto-engaged — usage limit reached (%s) → auto-retry + judges paused until reset\n"
                          % ",".join(account))
-        _push_all()
+        # no inline push: _set_retry_paused marked the views dirty and woke the pusher, whose next cycle
+        # carries the flip in its globalRetryPaused frame (see _auto_resume_retry)
 
 
 def _spend_capped_session(now, tmux):
@@ -7117,7 +7118,8 @@ def _auto_pause_on_spend_limit(now, tmux):
         _set_retry_paused(True, reason="spend")
         sys.stderr.write("retry-pause: auto-engaged — monthly spend limit reached → auto-retry + judges "
                          "paused until the cap is raised (claude.ai/settings/usage)\n")
-        _push_all()
+        # no inline push: _set_retry_paused marked the views dirty and woke the pusher, whose next cycle
+        # carries the flip in its globalRetryPaused frame (see _auto_resume_retry)
 
 
 def _auto_resume_retry(now, tmux):
@@ -7130,7 +7132,19 @@ def _auto_resume_retry(now, tmux):
 
     Event-based recovery signal: a live session that is NOT currently blocked on an API error AND has written
     fresh transcript output since the pause began (mtime past the pause floor) is proof the account can serve
-    requests again. Clearing re-enables both auto-retry and the judges together."""
+    requests again. Clearing re-enables both auto-retry and the judges together.
+
+    Delivery (the two auto-pause siblings above do the same): no inline push from this thread.
+    _set_retry_paused ends in _mark_views_dirty, which stamps the dirty mark and sets _pusher_wake, so
+    the pusher's next cycle rebuilds past the mark and its globalRetryPaused frame (sent to every chat
+    client on every push) carries the flip, one cycle start after the write, sub-second; the active
+    tab's key stats retry-paused.json as well (_ACTIVE_SIG_FILES), so the queued-hold reason follows on
+    that same push. The inline _push_all that used to end this branch spared no rebuild — the next
+    cycle's dirty-forced build is the same one — and cost a second push's fixed work per flip. A
+    BACKGROUND chat tab's queued-hold reason still waits for its own key to move (_chat_build_sig folds
+    neither the flag's file nor the dirty mark): pre-existing, unchanged. The re-arm below is a store
+    write the cards show (a given-up card's summary sentinel goes back to None), made after the flag's
+    own stamp, so it marks the views dirty itself: the write is the new information."""
     if not _retry_paused_on():
         return
     floor = _retry_pause_ts()
@@ -7150,9 +7164,11 @@ def _auto_resume_retry(now, tmux):
                 rearmed = jd.rearm_failed_summaries(now)  # while degraded, so their summaries/briefs retry now
                 if rearmed:
                     sys.stderr.write("distiller: re-armed %d given-up card(s) after recovery\n" % rearmed)
+                    _mark_views_dirty()                  # a store write the cards show, after the flag's stamp
             except Exception:
                 sys.stderr.write("rearm-failed-summaries: %s\n" % traceback.format_exc())
-            _push_all()                                  # globalRetryPaused=false reaches the UI immediately
+            # no inline push: _set_retry_paused marked the views dirty and woke the pusher; its next cycle
+            # carries globalRetryPaused=false (docstring)
             return
 
 
@@ -7727,8 +7743,16 @@ def _interrupt_block_tick(now, tmux):
     The once-per-episode marker is VERIFIED against the store each tick, never trusted (the user
     2026-08-08): judges complete/clear the goal it points at off newer turns (or compaction archives
     it), and trusting the bare marker skipped the re-block forever — the live focus goal sat in
-    Working wearing only the badge, auto-nudge suppressed: invisible-blocked."""
-    changed = False
+    Working wearing only the badge, auto-nudge suppressed: invisible-blocked.
+
+    No inline push: both writers end in _mark_views_dirty(), which stamps the dirty mark and sets
+    _pusher_wake, so the next cycle's own _push_all rebuilds past the mark. The inline call spared no
+    rebuild (the next cycle's dirty-forced build is the same one); it delivered the flip one cycle tail
+    earlier (the jobs after this tick plus the next cycle's liveness read: sub-second) at a second
+    push's fixed cost, and on the stand-down path below (a marker whose block a judge now owns) it
+    pushed with nothing new to show. The two fault paths push nothing either: an unproved ledger
+    stands the block down before any write, and a refused marker write leaves the store write's own
+    dirty mark to carry the flip."""
     alive = _alive_sessions(now, tmux)
     for s in alive:
         sid = s["sid"]
@@ -7773,28 +7797,28 @@ def _interrupt_block_tick(now, tmux):
                                      for a in (turn.get("atoms") or [])])
                 g = _record_interrupt_block(sid, ev)
                 if g:
-                    # the block IS filed — a proved goal-store write, a needs-you flip the feed must hear —
-                    # so this pushes whatever the marker write's fate: a fault landing between the tag
-                    # check above and here refuses the marker, the next tick stands down at the check, and
-                    # the first healed tick re-mints the marker (_record_interrupt_block hands back the gid
-                    # of a card our own block already holds, appending nothing)
-                    _set_intr_blocked(sid, g); changed = True
+                    # the block IS filed — a proved goal-store write that marked the views dirty, a needs-you
+                    # flip the next cycle carries — whatever the marker write's fate: a fault landing between
+                    # the tag check above and here refuses the marker, the next tick stands down at the check,
+                    # and the first healed tick re-mints the marker (_record_interrupt_block hands back the
+                    # gid of a card our own block already holds, appending nothing)
+                    _set_intr_blocked(sid, g)
         else:                                            # working / re-engaged / machine cut → lift OUR block if any
             ib = _intr_blocked(sid)
             if ib:
                 # the re-engagement IS the newest turn's trigger — the same stamp the judges will put on
                 # every verdict about that turn, so their ruling outranks this lift on arrival order.
-                # The lift runs whatever the ledger's state — it is the user's own re-engagement — but
-                # `changed` follows the MARKER write: refused under a fault, the marker stays in the last
-                # proved snapshot, the lift re-runs as a no-op next tick, and nothing pushes every cycle.
-                # A lift that could not READ the goals store (False: its row is filed) keeps the marker
-                # too, so the next tick retries the lift rather than erasing it (the #1019 boundary)
+                # The lift runs whatever the ledger's state — it is the user's own re-engagement. Nothing
+                # pushes from here (docstring): a lift that wrote the store marked the views dirty itself;
+                # a marker write refused under a fault leaves the marker in the last proved snapshot, the
+                # lift re-runs as a no-op next tick, and a no-op marks nothing, so nothing rebuilds every
+                # cycle either. A lift that could not READ the goals store (False: its row is filed) keeps
+                # the marker too, so the next tick retries the lift rather than erasing it (the #1019 boundary)
                 if _lift_interrupt_block(sid, ib, turns[-1].get("t") if turns else 0):
-                    if _set_intr_blocked(sid, None):     # spent → the marker goes; `changed` follows the write
-                        changed = True
+                    _set_intr_blocked(sid, None)     # spent → the marker goes; refused under a fault it stays
+                #                                      in the last proved snapshot and the next tick retries
     _intr_marks_forget({s["sid"] for s in alive})       # a sid that left the alive set releases its memo entries
-    if changed:                                          # a needs-you flip should reach the feed at once
-        _push_all()
+    # a flip's writer marked the views dirty and woke the pusher: the next cycle carries it (docstring)
 
 
 def _walk_root_record(sid):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -22673,7 +22673,7 @@ def _fold_tasks(session):
     _read_task_store). Returns the tasks in creation
     order, or None if there were none. The webview renders this as a todo card (kind:'todo') and hides the
     raw Task* calls (ACK_TOOLS) — so the kernel emits the folded card and skips the raw tool events."""
-    out = {}                                              # tool_use_id → result text (carries 'Task #N')
+    out = {}                                              # tool_use_id → result content (a TaskCreate's carries 'Task #N')
     rejected = set()                                      # tool_use_ids whose result came back is_error
     for turn in session["turns"]:
         for a in turn["atoms"]:
@@ -22681,8 +22681,7 @@ def _fold_tasks(session):
                 continue
             for b in (a.get("message") or {}).get("content", []) or []:
                 if isinstance(b, dict) and b.get("type") == "tool_result" and b.get("tool_use_id"):
-                    c = b.get("content")
-                    out[b["tool_use_id"]] = c if isinstance(c, str) else json.dumps(c)
+                    out[b["tool_use_id"]] = b.get("content")
                     if b.get("is_error"):
                         rejected.add(b["tool_use_id"])
     tasks, order = {}, 0
@@ -22707,7 +22706,12 @@ def _fold_tasks(session):
                     # id, as before.
                     if b.get("id") in rejected:
                         continue
-                    m = re.search(r"Task #(\d+)", out.get(b.get("id"), "") or "")
+                    # Only a TaskCreate's result is ever read, so only it is encoded, here, to the same text
+                    # the regex saw when every result was encoded up front. Encoding every Bash and Read
+                    # output (list-shaped ones, image blocks) for a value nothing read was 0.3% of the pusher
+                    # (cProfile of the push thread on a loaded kernel, 2026-09-06).
+                    r = out.get(b.get("id"), "")
+                    m = re.search(r"Task #(\d+)", (r if isinstance(r, str) else json.dumps(r)) or "")
                     tid = m.group(1) if m else "c%d" % order
                     af = inp.get("activeForm")
                     tasks[tid] = {"_order": order, "id": tid, "subject": str(inp.get("subject") or ""),
@@ -31055,10 +31059,37 @@ def _seg_prompt(seg):
     return blocks if isinstance(blocks, str) else ""
 
 
+def _encoded_mids(content, ids=None):
+    """POSTAL_RE's matches over json.dumps(content) — the search a list-shaped tool_result gets — computed
+    without encoding the whole result, appended to `ids` in document order. Only the strings the encoding
+    would write (dict keys and string values; every other value encodes to digits, true/false/null or
+    brackets) can carry a marker, and a match cannot cross the encoder's `, ` and `: ` separators (the id
+    admits no space), so encoding just the strings that hold the marker's literal and matching each alone
+    yields the same ids in the same order. A value json.dumps would refuse (an unexpected type) contributes
+    nothing instead of raising. Encoding every list-shaped result was 2.3% of the pusher (cProfile of the
+    push thread on a loaded kernel, 2026-09-06): those lists are mostly image and tool_reference blocks that
+    never carry a marker, and a base64 image block is the expensive part."""
+    if ids is None:
+        ids = []
+    if isinstance(content, str):
+        if "romp-msg-id" in content:
+            ids += jd.em.POSTAL_RE.findall(json.dumps(content))
+    elif isinstance(content, dict):
+        for k, v in content.items():
+            if isinstance(k, str) and "romp-msg-id" in k:
+                ids += jd.em.POSTAL_RE.findall(json.dumps(k))
+            _encoded_mids(v, ids)
+    elif isinstance(content, (list, tuple)):
+        for v in content:
+            _encoded_mids(v, ids)
+    return ids
+
+
 def _seg_mids(seg):
     """Postal message ids referenced anywhere in a segment (its romp-msg-id markers, in text blocks or
     a check_inbox tool_result) — joins a recipient's WORK segment to the message that triggered it, so
-    the timeline connector can bind to the true process-start."""
+    the timeline connector can bind to the true process-start. Called per segment on every timeline
+    build, so it reads the blocks in place (_encoded_mids) rather than encoding them."""
     ids = []
     for a in seg.get("atoms", []):
         msg = a.get("message") or {}
@@ -31070,10 +31101,15 @@ def _seg_mids(seg):
                 if not isinstance(b, dict):
                     continue
                 if b.get("type") == "text":
-                    ids += jd.em.POSTAL_RE.findall(b.get("text", ""))
+                    t = b.get("text")
+                    if isinstance(t, str):                # a null text field is skipped, not a TypeError
+                        ids += jd.em.POSTAL_RE.findall(t)
                 elif b.get("type") == "tool_result":
-                    c = b.get("content")
-                    ids += jd.em.POSTAL_RE.findall(c if isinstance(c, str) else json.dumps(c))
+                    c = b.get("content")                  # str | list[dict] | None from the SDK, as passed through
+                    if isinstance(c, str):
+                        ids += jd.em.POSTAL_RE.findall(c)
+                    elif c is not None:
+                        _encoded_mids(c, ids)
     return ids
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -35256,46 +35256,69 @@ def _push(targets, connect=False, tmux=None):
     # single slot still holding it: a connect push on a handler thread (_push([client], connect=True)
     # from the ws handler) can evict that slot between this fill and the send. An unkeyable payload
     # (said once by _delta_parts) keeps the whole dump and _dedup_sig, as before.
+    # This section runs AFTER the build try above, and nothing above it on the pusher thread catches:
+    # _push_all, _pusher_cycle_jobs, _pusher_cycle (a try/finally) and _pusher (a bare while-True) have
+    # no except, so a raise here used to end the pusher thread for the life of the process — every
+    # dashboard frozen until a restart. A whole-frame dump with no `default=` met a set in a card and
+    # raised; a build slot read as None by this loop raised too. Now a fill that raises stands its slot
+    # down for THIS cycle (one traceback; the slot's other clients are skipped without another), a send
+    # that raises skips that client, and the next cycle retries both. _pusher_cycle_jobs catches around
+    # _push_all for whatever escapes _push; _pusher itself stays unwrapped, since that belt and
+    # _pusher_cycle's finally cover the cycle.
     global _feed_wire, _bars_wire
     feed_ms = feed_sig = feed_parts = bars = bars_ms = bars_sig = bars_parts = None
+    feed_down = bars_down = False                        # this cycle's fill raised: the slot's clients are skipped
     _t_stage = time.monotonic()
     for c in targets:
-        if c["app"] in ("feed", "fleet"):   # the feed pane AND the Fleet view both ride the feed payload (Fleet reads feed.ledgers)
-            if feed_ms is None:
-                w = _feed_wire                           # tuple snapshot — rebound whole, never mutated (torn reads)
-                if w is not None and w[0] is feed_src and w[1] == feed.get("ledgers"):
-                    feed, feed_ms, feed_sig, feed_parts = w[2], w[3], w[4], w[5]
+        try:
+            if c["app"] in ("feed", "fleet"):   # the feed pane AND the Fleet view both ride the feed payload (Fleet reads feed.ledgers)
+                if feed_down:
+                    continue
+                if feed_ms is None:
+                    w = _feed_wire                           # tuple snapshot — rebound whole, never mutated (torn reads)
+                    if w is not None and w[0] is feed_src and w[1] == feed.get("ledgers"):
+                        feed, feed_ms, feed_sig, feed_parts = w[2], w[3], w[4], w[5]
+                    else:
+                        feed_parts = _delta_parts("feed", feed)   # the one per-entry encode, handed down to the delta path
+                        if feed_parts is not None:
+                            feed_sig = _parts_sig(feed_parts)
+                            feed_ms = _LazyWire(lambda f=feed: json.dumps(f, default=_wire_default_in("_push feed")),
+                                                _parts_est(feed_parts), "feed_body")
+                        else:                                # unkeyable: whole frames and the string signature, as before
+                            s = json.dumps(feed, default=_wire_default_in("_push feed"))
+                            feed_ms, feed_sig = _LazyWire(None, len(s), text=s), _dedup_sig(feed, s)
+                            _wire_bump("feed_sig_fallback")
+                        _feed_wire = (feed_src, feed.get("ledgers"), feed, feed_ms, feed_sig, feed_parts)
+                _send_slot(c, "feed", feed, feed_ms, feed_sig, feed_parts)
+            elif c["app"] == "timeline" and timeline is not None:
+                if bars_down:
+                    continue
+                if bars_ms is None:
+                    w = _bars_wire
+                    if w is not None and w[0] is timeline and w[1] == tl_warming:
+                        bars, bars_ms, bars_sig, bars_parts = w[2], w[3], w[4], w[5]
+                    else:
+                        bars = {"type": "bars", "turns": timeline["turns"], "judging": timeline["judging"],
+                                "messages": timeline["messages"], "now": timeline["now"], "warming": tl_warming}
+                        bars_parts = _delta_parts("bars", bars)   # the one per-entry encode, handed down to the delta path
+                        if bars_parts is not None:
+                            bars_sig = _parts_sig(bars_parts)
+                            bars_ms = _LazyWire(lambda b=bars: json.dumps(b, default=_wire_default_in("_push bars")),
+                                                _parts_est(bars_parts), "bars_body")
+                        else:                                # unkeyable: whole frames and the string signature, as before
+                            s = json.dumps(bars, default=_wire_default_in("_push bars"))
+                            bars_ms, bars_sig = _LazyWire(None, len(s), text=s), _dedup_sig(bars, s)
+                            _wire_bump("bars_sig_fallback")
+                        _bars_wire = (timeline, tl_warming, bars, bars_ms, bars_sig, bars_parts)
+                _send_slot(c, "bars", bars, bars_ms, bars_sig, bars_parts)
+        except Exception:
+            is_feed = c["app"] in ("feed", "fleet")
+            if (feed_ms if is_feed else bars_ms) is None:    # the FILL raised (nothing assigned): stand the slot down this cycle
+                if is_feed:
+                    feed_down = True
                 else:
-                    feed_parts = _delta_parts("feed", feed)   # the one per-entry encode, handed down to the delta path
-                    if feed_parts is not None:
-                        feed_sig = _parts_sig(feed_parts)
-                        feed_ms = _LazyWire(lambda f=feed: json.dumps(f, default=_wire_default_in("_push feed")),
-                                            _parts_est(feed_parts), "feed_body")
-                    else:                                # unkeyable: whole frames and the string signature, as before
-                        s = json.dumps(feed, default=_wire_default_in("_push feed"))
-                        feed_ms, feed_sig = _LazyWire(None, len(s), text=s), _dedup_sig(feed, s)
-                        _wire_bump("feed_sig_fallback")
-                    _feed_wire = (feed_src, feed.get("ledgers"), feed, feed_ms, feed_sig, feed_parts)
-            _send_slot(c, "feed", feed, feed_ms, feed_sig, feed_parts)
-        elif c["app"] == "timeline" and timeline is not None:
-            if bars_ms is None:
-                w = _bars_wire
-                if w is not None and w[0] is timeline and w[1] == tl_warming:
-                    bars, bars_ms, bars_sig, bars_parts = w[2], w[3], w[4], w[5]
-                else:
-                    bars = {"type": "bars", "turns": timeline["turns"], "judging": timeline["judging"],
-                            "messages": timeline["messages"], "now": timeline["now"], "warming": tl_warming}
-                    bars_parts = _delta_parts("bars", bars)   # the one per-entry encode, handed down to the delta path
-                    if bars_parts is not None:
-                        bars_sig = _parts_sig(bars_parts)
-                        bars_ms = _LazyWire(lambda b=bars: json.dumps(b, default=_wire_default_in("_push bars")),
-                                            _parts_est(bars_parts), "bars_body")
-                    else:                                # unkeyable: whole frames and the string signature, as before
-                        s = json.dumps(bars, default=_wire_default_in("_push bars"))
-                        bars_ms, bars_sig = _LazyWire(None, len(s), text=s), _dedup_sig(bars, s)
-                        _wire_bump("bars_sig_fallback")
-                    _bars_wire = (timeline, tl_warming, bars, bars_ms, bars_sig, bars_parts)
-            _send_slot(c, "bars", bars, bars_ms, bars_sig, bars_parts)
+                    bars_down = True
+            sys.stderr.write("push send %s (%s): %s\n" % ("feed" if is_feed else "bars", c.get("app"), traceback.format_exc()))
     _PERF_STATS.stage("push.send", time.monotonic() - _t_stage)
     with _clients_lock:
         _clients[:] = [c for c in _clients if c.get("alive", True)]
@@ -36551,6 +36574,10 @@ def _pusher_cycle_jobs(now, tmux, any_client):
         _t_push = time.monotonic()
         try:
             _push_all(tmux=tmux)
+        except Exception:                 # _push guards its build and its sends; anything escaping it rode
+            #                               _pusher_cycle's finally into _pusher's while-True and ended the
+            #                               pusher thread for the process's life (see _push's wire section)
+            sys.stderr.write("push: %s\n" % traceback.format_exc())
         finally:
             _t_push = time.monotonic() - _t_push
             _PERF_STATS.stage("push", _t_push)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2539,7 +2539,46 @@ def _rgb(color):
         return [112, 136, 170]
 
 
+_sessions_scope_stats = {"hit": 0, "miss": 0, "wide_hit": 0, "wide_miss": 0}   # the cycle memo's counters (the
+#                                 tests read them). Bumped only under an open scope, and the scope is opened by one
+#                                 thread at a time (the pusher's cycle), so plain increments: no lock, unlike
+#                                 _intr_marks_memo_stats, which connect-time builds bump from socket threads
+
+
 def _sessions(now, window=None, forks=True):
+    """The discover() rows the surfaces build from — [{sid, name, anchor, path, mtime}], newest
+    transcript first — for every romp session touched within `window` (discover's 48h default).
+
+    Inside a pusher cycle the rows are memoized on the cycle's scope (_live_scope.sessions, opened by
+    _pusher_cycle, thread-confined like its liveness snapshot): every _alive_sessions call in the tick
+    jobs, every _path_of miss under _compacting_now, _msg_summaries, build_session and the tab/lane
+    lists each ran a discover fingerprint (a stat per names entry, three times, plus one per
+    transcript) and a stat per row — 34-37 sweeps per cycle on a profiled 30-session kernel, 4.3% of
+    the pusher's GIL, all returning the same rows. One sweep per (window, forks) key per cycle now;
+    outside a cycle every read is fresh, exactly as _tmux_sessions and _path_of behave. The key is
+    normalized the way discover normalizes its own (jd.WINDOW for None, bool(forks)).
+
+    Every call hands out a COPY of the row list, hit or miss, so no caller can grow or reorder the
+    cycle's shared list (the headless _alive_sessions fallback returns this list as its own). The row
+    dicts themselves are shared by every in-cycle consumer and read-only by contract — each filters or
+    reorders into a list of its own, and build_session copies before its one write; a consumer that
+    wrote into a row would leak the write into every other consumer of the cycle.
+
+    Within one cycle the rows' membership and `mtime` are the cycle's snapshot: a transcript that grows
+    mid-cycle keeps its start-of-cycle mtime here, so _msg_summaries' per-sid cache and
+    _timeline_sessions' dead-lane cutoff lag one cycle at most, healed by the next sweep (never an
+    under-scan: the next cycle's fresh mtime forces the rescan), and a names/ rewrite delivered by a cwd
+    op after the memo fills is seen next cycle, as _live_scope.names already behaves. Direct
+    jd.discover callers (_walk_root_record, _token_analytics) are not served by this; the wide walk in
+    _alive_sessions has its own scope memo (_discover_wide)."""
+    memo = getattr(_live_scope, "sessions", None)
+    key = (jd.WINDOW if window is None else int(window), bool(forks))
+    if memo is not None:
+        hit = memo.get(key)
+        if hit is not None:
+            _sessions_scope_stats["hit"] += 1
+            return list(hit)
+        _sessions_scope_stats["miss"] += 1
     out = []
     for fsid, path, anchor, name in jd.discover(now, window, forks):
         try:
@@ -2548,7 +2587,30 @@ def _sessions(now, window=None, forks=True):
             mtime = 0
         out.append({"sid": fsid, "name": name or fsid[:8], "anchor": anchor, "path": str(path), "mtime": mtime})
     out.sort(key=lambda s: s["mtime"], reverse=True)
+    if memo is not None:
+        memo[key] = out
+        return list(out)
     return out
+
+
+def _discover_wide(now, window):
+    """{fsid: discover row} over `window` — the wide walk _alive_sessions resolves a live session idle
+    longer than the 48h caption window through. Memoized on the pusher cycle's scope beside _sessions
+    (key ("wide", window)): whenever one such session is live, every _alive_sessions call in the cycle
+    — the two builds, the chat tabs and about eight tick jobs — repeated the walk, a fingerprint each.
+    Read-only for every caller (a dict lookup per sid), so no copy. Outside a cycle it reads fresh."""
+    memo = getattr(_live_scope, "sessions", None)
+    key = ("wide", int(window))
+    if memo is not None:
+        hit = memo.get(key)
+        if hit is not None:
+            _sessions_scope_stats["wide_hit"] += 1
+            return hit
+        _sessions_scope_stats["wide_miss"] += 1
+    wide = {f[0]: f for f in jd.discover(now, window=window)}
+    if memo is not None:
+        memo[key] = wide
+    return wide
 
 
 def _path_of(sid, now=None):
@@ -2658,7 +2720,7 @@ def _alive_sessions(now, tmux):
     have = {s["sid"] for s in alive}
     stale_live = [sid for sid in tmux if sid not in have]
     if stale_live:
-        wide = {f[0]: f for f in jd.discover(now, window=jd.DEATH_BACKFILL_WINDOW)}
+        wide = _discover_wide(now, jd.DEATH_BACKFILL_WINDOW)   # one walk per cycle (the scope memo)
         for sid in stale_live:
             ent = wide.get(sid)
             if ent is not None:
@@ -7759,7 +7821,11 @@ def _interrupt_block_tick(now, tmux):
         if _session_flag(sid, "hideFromFeed"):           # muted from the feed → no interrupt-block bookkeeping either
             continue
         st = (tmux.get(sid) or {}).get("state", "")
-        if st in _NEEDS_INPUT_STATES or st == "compacting" or _compacting_now(sid):
+        # the row's own path and live meta go in: the default _path_of searched the 48h set, so a LIVE
+        # session idle longer than that — resolved into this row by _alive_sessions' wide walk — read as
+        # having no transcript here, and an optimistic compact click on it could not be disproved by its
+        # compact_boundary for the 180 s cap
+        if st in _NEEDS_INPUT_STATES or st == "compacting" or _compacting_now(sid, tm=tmux.get(sid), path=s["path"]):
             continue                                     # awaiting you / compacting → a different needs-you path owns it
         if _api_error(s["path"]):                        # stopped on an API error → not a user stop
             continue
@@ -36678,6 +36744,9 @@ def _pusher_cycle():
     try:
         _live_scope.paths = {}                  # …and the cycle's sid→path memo (_path_of): the parked-op drain
         #                                         otherwise resolves a held sid's path once per gate per cycle
+        _live_scope.sessions = {}               # …and the cycle's discover rows (_sessions, keyed (window,
+        #                                         forks); the wide walk under ("wide", window)): ~35 sweeps
+        #                                         per cycle became one
         _live_scope.names = _names_snapshot()   # …and the cycle's NAMES snapshot, same idiom: the name/
         #                                       cwd/color helpers otherwise re-read the registry per path
         #                                       token and per postal card (~38% of pusher wall, py-spy
@@ -36688,6 +36757,7 @@ def _pusher_cycle():
         _live_scope.snapshot = None
         _live_scope.names = None
         _live_scope.paths = None
+        _live_scope.sessions = None
         _PERF_STATS.cycle(time.monotonic() - _t_cycle, time.thread_time() - _c_cycle)
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -29855,11 +29855,16 @@ WIN_WEEK = 7 * 86400                           # The footer shows tokens per win
 def _state_intervals(sid, want, now):
     """Every [start,end] the session sat in `want` ('permission'/'picker' → awaiting candy-stripes,
     'compacting' → cross-hatch), from states/<sid>.jsonl: an entry runs until the next transition, or to
-    `now` (the build's clock) if the session is still in it. That open end IS the wire contract the
-    renderer reads (romp-timeline-view.js): an end within 2 s of the payload's `now` means open. The end
-    stays numeric on purpose: a null end would be a wire break — every already-loaded renderer (an open
-    dashboard, an installed extension) takes Math.min(null, t1) = 0 and drops the stripe for a lane
-    blocked or compacting right now. The clock-stamped end costs no per-cycle work: the lanes frame is
+    `now` (the build's clock) if the session is still in it, and that open interval carries True as a
+    third element, [start, end, True]: the open mark the renderer reads (romp-timeline-view.js) to draw the
+    stripe to the live edge. The mark is the lane's own state, never a clock compare (review find,
+    2026-09-08): the renderer used to read an end within 2 s of the payload's `now` as open, and a connect
+    push re-stamps the cycle's clock over the cached build's lanes (_push), so that distance was the
+    cache's age, and a lane blocked right now drew closed on every connect over a cache older than 2 s. The
+    end stays numeric on purpose: a null end would be a wire break, since every already-loaded renderer
+    (an open dashboard, an installed extension) takes Math.min(null, t1) = 0 and drops the stripe for a
+    lane blocked or compacting right now; a third element those renderers never read breaks nothing. The
+    clock-stamped end costs no per-cycle work: the lanes frame is
     serialized once per build and deduped on content, so while the state lasts the frame goes once per
     rebuild (the end moved), and an unchanged rebuild sends nothing. `want` is a single state or any
     collection of them (the awaiting band passes both needs-input states). Forward-only — periods
@@ -29874,10 +29879,11 @@ def _state_intervals(sid, want, now):
     for i, (t, st) in enumerate(ev):
         if st not in want:
             continue
-        end = ev[i + 1][0] if i + 1 < len(ev) else now     # still in it: the build clock, which the renderer reads as open
+        open_now = i + 1 >= len(ev)                       # no later transition: the session is still in it…
+        end = now if open_now else ev[i + 1][0]           # …so the interval runs to the build clock
         if end < cutoff:
             continue
-        out.append([max(t, cutoff), end])
+        out.append([max(t, cutoff), end, True] if open_now else [max(t, cutoff), end])   # …marked open for the renderer
     return out
 
 
@@ -32905,12 +32911,18 @@ def _wire_default(o, enc="wire"):
     an entry is counted by the per-entry pass and again by the whole frame, if one goes), and the type is
     written to stderr once, naming the encoder that met it first. A value json cannot encode (a set, a datetime,
     a Path) is a builder's mistake, and str() of it is not what the pane expects; the whole-frame dumps used to
-    carry no `default` at all and raised on such a value, out of _push, on the pusher thread."""
+    carry no `default` at all and raised on such a value, out of _push, on the pusher thread. The first
+    sighting of a type also files one bell row of kind "refused" (review find, 2026-09-08): a counter and a
+    stderr line reach nobody at the dashboard, and one refused row per distinct fault is how a fault the user
+    should see is surfaced (#1020, the state readers); the type name is the fault's identity, so a repeat
+    files nothing."""
     _wire_bump("default_str")
     tn = type(o).__name__
     if tn not in _wire_default_said:
         _wire_default_said.add(tn)
         sys.stderr.write("wire: %s serialized via str() in %s\n" % (tn, enc))
+        _sync_notice("a %s value in the %s frame cannot be encoded as json; it reached the dashboard as text "
+                     "(str() of it), a builder's mistake to fix" % (tn, enc), ok=False, kind="refused")
     return str(o)
 
 
@@ -35387,7 +35399,8 @@ def _push(targets, connect=False, tmux=None):
         # build clock (_state_intervals), so its frame goes once per rebuild while the state lasts — where the
         # per-cycle skeleton sent it every cycle. A CONNECT push is the other: it stamps the cached lanes with
         # the cycle's clock (below), since the pane anchors its live edge on its first sample and the cache
-        # can be hours old when no timeline client kept it warm.
+        # can be hours old when no timeline client kept it warm, when the cache is FRESH by the kernel's own
+        # rule (_timeline_cache_fresh); a stale one gets its lanes built fresh instead (below).
         global _skel_wire
         _PERF_STATS.stage("push.feed", time.monotonic() - _t_stage)
         _t_stage = time.monotonic()
@@ -35407,14 +35420,25 @@ def _push(targets, connect=False, tmux=None):
             else:
                 timeline = _cached_timeline(now, tmux, fsig, connect)
                 if connect:
-                    # A CONNECT serves the cached lanes under the CYCLE's clock: the pane anchors its live edge
-                    # and its window fit on the first data.now it sees, and the cache is as old as the last
-                    # cycle that had a timeline client — a bucket on a reload, hours after the pane was closed
-                    # — so the build clock would sit the axis in the past until the next rebuild. One
-                    # serialization per connect; the new client's dedup slot is empty, so the frame always
-                    # goes, and _send_client derives its content-only sig, so the next cycle's build-clock
-                    # frame dedups against it unless the lanes changed.
-                    frame = {"type": "data", "data": {**_timeline_skeleton(timeline), "now": now}}
+                    if _timeline_cache_fresh(fsig):
+                        # A CONNECT serves the cached lanes under the CYCLE's clock: the pane anchors its live
+                        # edge and its window fit on the first data.now it sees, and the cache is as old as the
+                        # last cycle that had a timeline client (a bucket on a reload), so the build clock
+                        # would sit the axis in the past until the next rebuild. One serialization per connect;
+                        # the new client's dedup slot is empty, so the frame always goes, and _send_client
+                        # derives its content-only sig, so the next cycle's build-clock frame dedups against it
+                        # unless the lanes changed.
+                        frame = {"type": "data", "data": {**_timeline_skeleton(timeline), "now": now}}
+                    else:
+                        # A STALE cache, built under a view signature the world has since left or marked dirty
+                        # since, is not what the pane should paint: the cache is as old as the last cycle that
+                        # had a timeline client (hours, when the pane was closed), and re-stamping the clock over
+                        # lanes that old painted a lane dead for hours as live (and the reverse) until the next
+                        # cycle's rebuild replaced them: a flap on every reload (review find, 2026-09-08). The
+                        # lanes are built fresh here, as every connect did before the projection (no transcript
+                        # parse: the skeleton), and the next cycle's rebuild dedups against them when unchanged;
+                        # the heavy bars still come from the cache, as they always did on a connect.
+                        frame = {"type": "data", "data": build_timeline(now, tmux, with_bars=False)}
                     skel_pre, skel_sig = json.dumps(frame), None
                 else:
                     w = _skel_wire                                  # tuple snapshot — rebound whole, never mutated
@@ -36597,8 +36621,7 @@ def _consume_pending_reveal(client):
 
 def _cached_timeline(now, tmux, sig, connect=False):
     e = _built_timeline
-    dirty = not connect and _views_dirty[0] > e[3]        # start-keyed, same as _cached_feed above
-    if e[1] is not None and not dirty and (connect or e[0] == sig or (time.time() - e[2]) < REBUILD_MIN_S):
+    if e[1] is not None and (connect or _timeline_cache_fresh(sig)):
         _VIEW_STATS["tlServe"] += 1
         _PERF_STATS.build("timeline", True)
         return e[1]
@@ -36609,6 +36632,18 @@ def _cached_timeline(now, tmux, sig, connect=False):
     _PERF_STATS.build("timeline", False, time.monotonic() - _t0)
     _built_timeline[:] = [sig, tl, time.time(), started]
     return tl
+
+
+def _timeline_cache_fresh(sig):
+    """The kernel's one rule for a cached full build a cycle may serve as it stands: built under the cycle's
+    view signature (nothing a lane reads has moved since) or within REBUILD_MIN_S of now, and no writer has
+    marked the views dirty since it started (start-keyed, same as _cached_feed). _cached_timeline rebuilds
+    when this is False; a connect push, which never rebuilds the full build on the handler thread, builds
+    its LANES fresh instead of projecting a stale cache (review find, 2026-09-08; see _push)."""
+    e = _built_timeline
+    if e[1] is None or _views_dirty[0] > e[3]:
+        return False
+    return e[0] == sig or (time.time() - e[2]) < REBUILD_MIN_S
 
 
 def _timeline_skeleton(tl):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -623,24 +623,101 @@ def _machine_cut_cause(users, i, cut_t=0.0, cut_cause=""):
     return None
 
 
-def _interrupt_marks(turns, sid=""):
+# The _interrupt_marks memo: (sid, family) -> (turns, (cut_t, cut_cause), (stop_t, human_t)). One entry
+# per key, so a sid pins at most two parses (one per family); the tick's sweep (_intr_marks_forget)
+# releases a sid's entries when it leaves the alive set, and the cap is the backstop for callers that
+# run outside the tick. The counters are bumped through _intr_marks_bump, under a lock: the interrupt
+# and nudge ticks bump them on the pusher thread and a connect-time build_feed bumps them on a WS
+# thread, so a bare `+= 1` here would be a read-modify-write across threads. The memo dict itself
+# needs no lock: its ops are single dict operations on immutable tuples keyed by the parse object, so
+# a lost insert or a double clear is one extra miss, never a wrong answer.
+_intr_marks_memo = {}
+_INTR_MARKS_MEMO_MAX = 512
+_intr_marks_memo_stats = {"hit": 0, "miss": 0, "evict": 0}
+_INTR_MARKS_STATS_LOCK = threading.Lock()
+
+
+def _intr_marks_bump(key, n=1):
+    with _INTR_MARKS_STATS_LOCK:
+        _intr_marks_memo_stats[key] = _intr_marks_memo_stats.get(key, 0) + n
+
+
+def _interrupt_marks(turns, sid="", family=None):
     """(newest genuine user STOP, newest genuine human PROMPT) on this thread, in transcript time —
     the one place the two are tallied, so the predicate below and the interrupt block's EVIDENCE stamp
     read the same events. A MACHINE cut (kernel restart / process death) mints the same stop record but
     is romp's own, so it never counts as a stop (_machine_cut_cause, via the resume notice that follows
     it, or — before that notice reaches disk — the backend's machineCut stamp). The interrupt record
     itself authors 'human', so it's classified FIRST. `sid` is optional only so the pure-atom callers in
-    the tests stay pure: pass it wherever it is known, or a cut still on its way to disk reads as a stop."""
+    the tests stay pure: pass it wherever it is known, or a cut still on its way to disk reads as a stop.
+
+    MEMOIZED per (sid, family) on the IDENTITY of `turns` and the value of the machineCut pair: the
+    result is a pure function of the user atoms and (cut_t, cut_cause) — no clock, no store, no global —
+    so while the caller hands in the same list object and the stamp has not moved, the answer cannot
+    have changed. A new parse object (a transcript or states append, a rewind cut armed or cleared, a
+    live atom merged) or a moved stamp is exactly the event that can change it, and either misses. A
+    held strong reference cannot have its id recycled, so `is` is exact. The inputs are never mutated
+    in place: event_model.parse_session allocates a fresh turns list per parse and _merge_live_atoms
+    copies rather than extends (a test pins the appended-transcript case); a list mutated in place is
+    not a supported input.
+
+    `family` names the parse the caller reads, "judge" (jd.parsed_session's object: the interrupt tick
+    and the nudge tick) or "display" (the kernel _parse cache's object: build_feed's badge). The split
+    is not a correctness requirement — identity keying would make one shared entry exact too — it stops
+    the two objects from evicting each other every cycle. Display-family hits are on the _parse_cache
+    object, which build_feed reads through _merge_live_atoms: that returns the cache object itself when
+    no unlanded live atom is pending and a fresh shallow copy otherwise, so a session mid-stream misses
+    each build until its tail lands (new information; the parse that follows hits again). While a judge
+    pass frame is open the tick alternates between the frame-pinned parse and the cache object, one
+    miss per swap. No family, or an empty sid, means no memo (the pure-atom test callers; a sid-less key
+    would be one slot thrashed by every caller)."""
+    cut = _last_machine_cut(sid) if sid else (0.0, "")
+    key = (sid, family) if (sid and family) else None
+    if key is not None:
+        e = _intr_marks_memo.get(key)
+        if e is not None and e[0] is turns and e[1] == cut:
+            _intr_marks_bump("hit")
+            return e[2]
+        _intr_marks_bump("miss")
     atoms = [a for turn in turns for a in (turn.get("atoms") or [])]
-    cut_t, cut_cause = _last_machine_cut(sid) if sid else (0.0, "")
-    return _interrupt_marks_atoms(atoms, cut_t, cut_cause)
+    res = _interrupt_marks_atoms(atoms, cut[0], cut[1])
+    if key is not None:
+        if len(_intr_marks_memo) >= _INTR_MARKS_MEMO_MAX and key not in _intr_marks_memo:
+            _intr_marks_bump("evict", len(_intr_marks_memo))   # the repo's overflow idiom: clear whole
+            _intr_marks_memo.clear()
+        _intr_marks_memo[key] = (turns, cut, res)
+    return res
+
+
+def _intr_marks_forget(alive):
+    """Drop every memo entry whose sid is not in `alive`. The interrupt tick calls this with the cycle's
+    alive set, so a session leaving it (death, the recorded event) releases the parses its entries pin
+    instead of holding them for the kernel's life. Iterates a key snapshot: a connect-push build on a
+    WS thread may insert concurrently."""
+    for k in list(_intr_marks_memo):
+        if k[0] not in alive and _intr_marks_memo.pop(k, None) is not None:
+            _intr_marks_bump("evict")
 
 
 def _interrupt_marks_atoms(atoms, cut_t=0.0, cut_cause=""):
     """The pure-atom core of _interrupt_marks — `atoms` plus the backend's machineCut stamp as
     plain arguments, so the classifier is testable without a states/ file (T219's repro rides
-    this surface)."""
-    users = [a for a in atoms if a.get("type") == "user"]
+    this surface).
+
+    A user atom whose `author` key is present and None is dropped before the text scan.
+    event_model.author_of returns None for exactly one shape, a record with no text block (every
+    branch on a non-empty text returns an author; the final `_is_real_prompt` gate is the only path
+    to None), so such an atom can be neither an interrupt record (is_interrupt_record needs text) nor
+    a human prompt (author != "human"), and the forward scan in _machine_cut_cause reads past it as
+    wedge either way: dropping it changes no tally. Its reach is narrow on purpose. The file adapter
+    OMITS the key for a None author rather than writing it (measured on a 31-session state copy: all
+    19,667 text-less user atoms lack the key; none carries None), so on disk-parsed sessions this gate
+    meets nothing, and a key-less atom must NOT be skipped: an SDK live-tail atom
+    (sdk_backend.msg_to_atom sets no author on stream user messages) may carry text, and a merged
+    live interrupt record would otherwise go uncounted until a parse of the disk record replaced it —
+    on a feed-only dashboard, whose cached parse nothing refreshes promptly, an arbitrary lag on the
+    "interrupted" badge. The per-cycle scan itself is what the memo in _interrupt_marks removes."""
+    users = [a for a in atoms if a.get("type") == "user" and a.get("author", "") is not None]
     last_intr = last_human = 0
     for i, a in enumerate(users):
         t = a.get("t", 0)
@@ -653,7 +730,7 @@ def _interrupt_marks_atoms(atoms, cut_t=0.0, cut_cause=""):
     return last_intr, last_human
 
 
-def _interrupt_suppresses_nudge(turns, sid=""):
+def _interrupt_suppresses_nudge(turns, sid="", family=None):
     """True while the session's most recent USER action is a GENUINE user INTERRUPT: the user stopped
     the agent and hasn't spoken since, so they're at the controls — auto-nudge stays suppressed until
     their NEXT message (the user 2026-07-05, refined via ui: re-engage on the user-message EVENT, never
@@ -668,8 +745,9 @@ def _interrupt_suppresses_nudge(turns, sid=""):
     user 2026-07-14: restart-cut SDK sessions sat inertly in Working wearing that false badge, and
     auto-nudge stayed off so a genuine RE-stall was never caught). Such a cut is identified by the romp
     resume notice that FOLLOWS its record (_interrupt_cause) and is EXCLUDED from the user-stop tally —
-    or, in the window before that notice reaches disk, by the backend's machineCut stamp (pass `sid`)."""
-    last_intr, last_human = _interrupt_marks(turns, sid)
+    or, in the window before that notice reaches disk, by the backend's machineCut stamp (pass `sid`).
+    `family` is _interrupt_marks' memo family, passed through by the per-cycle callers."""
+    last_intr, last_human = _interrupt_marks(turns, sid, family)
     return last_intr > last_human
 
 
@@ -7651,7 +7729,8 @@ def _interrupt_block_tick(now, tmux):
     it), and trusting the bare marker skipped the re-block forever — the live focus goal sat in
     Working wearing only the badge, auto-nudge suppressed: invisible-blocked."""
     changed = False
-    for s in _alive_sessions(now, tmux):
+    alive = _alive_sessions(now, tmux)
+    for s in alive:
         sid = s["sid"]
         if _session_flag(sid, "hideFromFeed"):           # muted from the feed → no interrupt-block bookkeeping either
             continue
@@ -7664,8 +7743,9 @@ def _interrupt_block_tick(now, tmux):
             turns = jd.parsed_session(sid, [s["path"]], now)["turns"]
         except Exception:
             continue
-        stop_t, human_t = _interrupt_marks(turns, sid)   # the two EVENTS this tick reasons about — and the
-        #                                                  evidence times both writes are stamped with
+        stop_t, human_t = _interrupt_marks(turns, sid, family="judge")   # the two EVENTS this tick reasons
+        #                                                  about — and the evidence times both writes are
+        #                                                  stamped with (memo family: the judge parse)
         block_it = bool(turns) and not _session_working(turns) and stop_t > human_t
         if block_it:                                     # a GENUINE user stop → block the focus goal on them,
             snap = _auto_nudge_data()
@@ -7712,6 +7792,7 @@ def _interrupt_block_tick(now, tmux):
                 if _lift_interrupt_block(sid, ib, turns[-1].get("t") if turns else 0):
                     if _set_intr_blocked(sid, None):     # spent → the marker goes; `changed` follows the write
                         changed = True
+    _intr_marks_forget({s["sid"] for s in alive})       # a sid that left the alive set releases its memo entries
     if changed:                                          # a needs-you flip should reach the feed at once
         _push_all()
 
@@ -9890,7 +9971,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None, wake_only
     lt = turns[-1]
     if _session_working(turns):                      # still actively working (event model) → not orphaned
         return "working"
-    if _interrupt_suppresses_nudge(turns, sid):      # the user's LAST action was a GENUINE interrupt → they're
+    if _interrupt_suppresses_nudge(turns, sid, family="judge"):   # the user's LAST action was a GENUINE interrupt → they're
         return "user-interrupt"                                # driving; suppressed until their NEXT message. The stopped
         #                                              focus goal's BLOCKED-on-you flip is owned by the always-on
         #                                              _interrupt_block_tick (a needs-you rule, not a nudge feature).
@@ -28663,9 +28744,12 @@ def build_feed(now, tmux=None):
         # The user's LAST action on this session was an INTERRUPT (no message from them since): its quiet
         # is user-chosen, not a stall — auto-nudge is suppressed (same predicate, _auto_nudge_tick) and
         # the working card wears an "interrupted" badge saying so (the user 2026-07-05). Cache-only,
-        # like the working dot: the badge snaps in once _warm_fleet_bg fills the parse.
+        # like the working dot: the badge snaps in once _warm_fleet_bg fills the parse. The read is memoized
+        # on that cache object's identity (_interrupt_marks, the "display" family), so an unchanged parse
+        # costs no scan per build.
         try:
-            sess_interrupted = bool(ps) and not who_working and _interrupt_suppresses_nudge(ps["turns"], fsid)
+            sess_interrupted = bool(ps) and not who_working and \
+                _interrupt_suppresses_nudge(ps["turns"], fsid, family="display")
         except Exception:
             sess_interrupted = False
         # A user interrupt still IN FLIGHT (dispatched, not yet settled): the card wears a steady

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -32965,7 +32965,17 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
         if c.get("sent", {}).get(key, (None,))[0] == sig:      # it went (or was already held) → rebase
             states[ftype] = {"rev": 0, "rest": rest_sig,
                              "coll": {n: {kk: e[1] for kk, e in ents.items()} for n, (ents, _o) in colls.items()},
-                             "order": {n: list(o) for n, (_e, o) in colls.items()}, "at": now}
+                             "order": {n: list(o) for n, (_e, o) in colls.items()}, "at": now, "parts": parts}
+        return
+    if parts is st.get("parts") and now - st.get("at", 0) < _DEDUP_REPOST_S:
+        # `parts` is the split of the payload OBJECT (_delta_parts is a one-entry identity cache per slot), and
+        # st["parts"] is the split the client's held state was last written from or last compared equal to: the
+        # keyed full, the last delta that went, or the unchanged branch below. The same object means the same entry
+        # strings, key sets, order shape and remainder, so the compare below would end at its unchanged branch; the
+        # pusher hands an unchanged payload object across cycles (_bars_wire holds the bars by the cached timeline's
+        # identity), and that compare is what this skips. Counted as the unchanged branch counts it: built, not
+        # sent. Past the repost window the compare runs and the repost goes.
+        _PERF_STATS.send(key, "deduped", len(pre))
         return
     frame = {"type": "delta", "slot": ftype, "base": st["rev"], "rev": st["rev"] + 1, "coll": {}}
     changed = False
@@ -32998,6 +33008,14 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
     if not changed:
         if now - st.get("at", 0) < _DEDUP_REPOST_S:    # unchanged: nothing to send (the repost keeps the fade alive)
             _PERF_STATS.send(key, "deduped", len(pre))   # built and compared, not sent — the same fact
+            # Adopt this split as the held one: the compare just showed the held entry strings, key sets, order
+            # shape and remainder equal it, so the same object next cycle is an identity hit above rather than
+            # another compare. A content-equal rebuild mints a new payload object (the view sig's 5 s bucket
+            # rebuilds the timeline on a quiet system; a feed differing only in `now`); without the adoption it
+            # would be re-compared every cycle until the repost, and the previous build's split, its whole
+            # entry-object graph, would stay referenced from here meanwhile. `at` stands: the repost timer counts
+            # from the last frame that went.
+            st["parts"] = parts
             return                                         # _send_client's dedup records for a whole-frame client
     s = json.dumps(frame, default=str)
     if len(s) >= _DELTA_MAX_FRACTION * len(pre):       # not worth a delta → the full frame, rebased
@@ -33009,7 +33027,7 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
     _PERF_STATS.send(key, "delta", len(s))
     if not _client_send(c, s, key):
         return
-    st["rev"] += 1; st["rest"] = rest_sig; st["at"] = now
+    st["rev"] += 1; st["rest"] = rest_sig; st["at"] = now; st["parts"] = parts
     for name, (ents, _order) in colls.items():
         st["coll"][name] = {kk: e[1] for kk, e in ents.items()}
         st["order"][name] = next_order[name]

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -32706,6 +32706,93 @@ def _dedup_sig(msg, s):
     return s
 
 
+# The pusher's wire caches, counted: whole frames serialized per slot (a _LazyWire made; at most once per build
+# each), builds whose payload could not be keyed and took the whole dump for their signature, and values a wire
+# encoder shipped as str() (_wire_default, one per encode). Bumped through _wire_bump, under a lock: the pusher
+# bumps the fallback counters, and whichever sender thread first materializes a _LazyWire bumps its counter, so
+# a bare `+= 1` here would be a read-modify-write across threads (the tests assert exact counts).
+_wire_stats = {"feed_body": 0, "bars_body": 0, "feed_sig_fallback": 0, "bars_sig_fallback": 0, "default_str": 0}
+_WIRE_STATS_LOCK = threading.Lock()
+_wire_default_said = set()   # type names _wire_default has written to stderr: a type is said once, not per value
+
+
+def _wire_bump(key, n=1):
+    with _WIRE_STATS_LOCK:
+        _wire_stats[key] = _wire_stats.get(key, 0) + n
+
+
+def _wire_default(o, enc="wire"):
+    """json.dumps's `default` for every wire encoder: the per-entry pass (_delta_split, _delta_parts' remainder),
+    the whole frames (_push) and the delta frames (_send_slot_delta). Returns str(o), the bytes the bare
+    `default=str` the delta paths carried produced, so the wire is unchanged. What changes is that the value is
+    no longer silent: _wire_stats["default_str"] counts every value shipped this way, one per encode (a value in
+    an entry is counted by the per-entry pass and again by the whole frame, if one goes), and the type is
+    written to stderr once, naming the encoder that met it first. A value json cannot encode (a set, a datetime,
+    a Path) is a builder's mistake, and str() of it is not what the pane expects; the whole-frame dumps used to
+    carry no `default` at all and raised on such a value, out of _push, on the pusher thread."""
+    _wire_bump("default_str")
+    tn = type(o).__name__
+    if tn not in _wire_default_said:
+        _wire_default_said.add(tn)
+        sys.stderr.write("wire: %s serialized via str() in %s\n" % (tn, enc))
+    return str(o)
+
+
+def _wire_default_in(enc):
+    """_wire_default bound to the encoder's name, for its `default=`."""
+    return lambda o: _wire_default(o, enc)
+
+
+class _LazyWire:
+    """A whole-frame serialization produced on the first send that needs it and kept for every later one: the
+    chat payload's `ms` (see _send_chat: None until a client takes the full-send branch, then materialized once
+    and reused) applied to the feed and the bars. Between rebuilds a frame's bytes are consumed only as a
+    LENGTH — the deduped byte counts, _send_slot_delta's size guard — and the whole frame itself goes a few
+    times an hour: a fresh socket, a re-base, a client without deltas, a delta past the guard. Serializing every
+    build for that was a second whole encode of each payload per rebuild.
+
+    text() materializes (once; two threads racing here compute the same bytes and one write wins) and size()
+    answers the length: exact once materialized, before that the caller's ESTIMATE — the per-entry strings'
+    byte total (_parts_est), which sits under the whole frame by what the entries do not carry, the frame's key
+    names and separators. The estimate only makes the size guard fall back to a whole frame slightly more
+    eagerly and the deduped byte counts read a little low; it never changes a frame's bytes.
+
+    The cell sits inside a wire tuple (_feed_wire, _bars_wire), which is rebound whole and never mutated:
+    materializing mutates the cell, not the tuple, so a handler-thread serve that materializes never clobbers
+    a refill the pusher made meanwhile. `stat` names the _wire_stats counter bumped on materialization; `text`
+    pre-fills the cell (an unkeyable build, whose whole dump the signature needed anyway)."""
+    __slots__ = ("_fn", "_s", "_est", "_stat")
+
+    def __init__(self, fn, est, stat=None, text=None):
+        self._fn, self._s, self._est, self._stat = fn, text, est, stat
+
+    def text(self):
+        s = self._s
+        if s is None:
+            s = self._fn()
+            self._s = s
+            if self._stat:
+                _wire_bump(self._stat)
+        return s
+
+    def size(self):
+        s = self._s
+        return len(s) if s is not None else self._est
+
+    def materialized(self):
+        return self._s is not None
+
+
+def _wire_text(pre):
+    """The bytes of a wire form that is either a str or a _LazyWire (materializing the latter)."""
+    return pre if isinstance(pre, str) else pre.text()
+
+
+def _wire_len(pre):
+    """The length of a wire form that is either a str or a _LazyWire — the latter's estimate until it is made."""
+    return len(pre) if isinstance(pre, str) else pre.size()
+
+
 # A dropped client is LOUD. _mk_ws_send raises when a client is WS_QUEUE_BYTES behind, and every caller
 # caught that with a bare `c["alive"] = False` — so a dashboard dropped every few minutes for a day (the
 # flashing "may be stale" prompt) left NO trace in the kernel log, the shim logged nothing on its side, and
@@ -32834,18 +32921,35 @@ _delta_parts_cache = {}        # frame type -> (payload object identity, parts) 
 _delta_unkeyable_said = set()  # (frame type, why) already written to stderr: an unkeyable shape is said once, not per cycle
 
 
-def _delta_key(kind, it, prefix=""):
-    """The key of one list item under `kind` ('byid' / 'bykeys:…'), or None when the item cannot be keyed
-    (then the caller falls back to a positional key, which is still exact)."""
-    if not isinstance(it, dict):
-        return None
+def _delta_keyer(kind):
+    """The key function of one collection kind — key(item, prefix="") gives the item's key under the table
+    above, or None when the item cannot be keyed (the caller then takes a positional key, still exact). The
+    kind string is parsed HERE, once per _delta_split call, not once per item: splitting "bykeys:sid,t,judge,t1"
+    and running its generator per entry was a visible share of the per-entry pass on a board of thousands of
+    bars. The keys are byte-identical to the per-item form's (_delta_key)."""
     if kind.startswith(("byid", "dictlist:")):
         field = "id" if kind == "byid" else kind.split(":", 1)[1]
-        v = it.get(field)
-        return None if v is None or v == "" else prefix + str(v)   # "" would spell a lane's bare-prefix marker
+
+        def key(it, prefix=""):
+            if not isinstance(it, dict):
+                return None
+            v = it.get(field)
+            return None if v is None or v == "" else prefix + str(v)   # "" would spell a lane's bare-prefix marker
+        return key
     if kind.startswith("bykeys:"):
-        return prefix + _DELTA_SEP.join(str(it.get(f)) for f in kind.split(":", 1)[1].split(","))
-    return None
+        fields = tuple(kind.split(":", 1)[1].split(","))
+
+        def key(it, prefix=""):
+            if not isinstance(it, dict):
+                return None
+            return prefix + _DELTA_SEP.join([str(it.get(f)) for f in fields])
+        return key
+    return lambda it, prefix="": None
+
+
+def _delta_key(kind, it, prefix=""):
+    """The key of one list item under `kind` ('byid' / 'bykeys:…'): _delta_keyer's per-item form."""
+    return _delta_keyer(kind)(it, prefix)
 
 
 def _delta_split(kind, value):
@@ -32853,7 +32957,8 @@ def _delta_split(kind, value):
     list item that cannot be keyed, or a duplicate key, takes a positional key ('#n') — exact, since the
     shim rebuilds in key order, just less delta-friendly."""
     ents, order = {}, []
-    enc = json.JSONEncoder(default=str).encode          # one encoder for the thousand entries, not one each
+    enc = json.JSONEncoder(default=_wire_default_in("_delta_split")).encode   # one encoder for the thousand entries, not one each
+    key = _delta_keyer(kind)                            # …and the kind parsed once, not per item
     def put(kk, v, pre=""):
         if kk is None or kk in ents:
             n = len(order)
@@ -32868,7 +32973,7 @@ def _delta_split(kind, value):
             put(str(kk), v)
     elif kind.startswith(("byid", "bykeys:")) and isinstance(value, list):
         for it in value:
-            put(_delta_key(kind, it), it)
+            put(key(it), it)
     elif kind.startswith("dictlist:") and isinstance(value, dict):
         for dk, lst in value.items():
             if _DELTA_SEP in str(dk):
@@ -32878,7 +32983,7 @@ def _delta_split(kind, value):
                 put(pre, lst)                      # an empty or non-list lane: one entry under its bare prefix
                 continue
             for it in lst:
-                put(_delta_key(kind, it, pre), it, pre)
+                put(key(it, pre), it, pre)
     else:
         # a value the kind cannot key (None where a list belongs, a list where a dict does): NOT zero entries —
         # that split carried the value nowhere, and the client kept its assembled [] / {} while the kernel held
@@ -32908,10 +33013,33 @@ def _delta_parts(ftype, payload):
             sys.stderr.write("view-delta %s: payload cannot be keyed (%s); sending whole frames\n" % (ftype, e))
     else:
         rest = {kk: v for kk, v in payload.items() if kk not in kinds}
-        rest_sig = json.dumps({kk: v for kk, v in rest.items() if kk not in _DEDUP_VOLATILE}, sort_keys=True, default=str)
+        rest_sig = json.dumps({kk: v for kk, v in rest.items() if kk not in _DEDUP_VOLATILE}, sort_keys=True,
+                              default=_wire_default_in("_delta_parts"))
         parts = (colls, rest, rest_sig)
     _delta_parts_cache[ftype] = (payload, parts)
     return parts
+
+
+def _parts_sig(parts):
+    """A slot payload's dedup signature from the split _delta_parts already made at the wire fill —
+    (rest_sig, ((collection, key order, entry strings), ...)) — in place of json.dumps(payload) plus _dedup_sig's
+    sort_keys re-dump of the payload minus its clock. The key order carries the lanes and ids, the entry strings
+    the entries themselves, rest_sig the remainder minus `now`/`buildId`: equal tuples mean equal bytes in every
+    entry and the remainder, so a suppressed change is impossible. Stricter than the sort_keys form in one way:
+    that dump was key-order-insensitive at every level (a turns lane dict included), so an equal-content reorder
+    deduped where it now re-sends once — an order-only delta for a delta client, one whole frame for a legacy
+    client, never a stale one — and then dedups. An unkeyable payload (parts None) keeps _dedup_sig over the
+    whole dump. A client's `sent` slot holds the tuple as it held the string; its strings are the split's own."""
+    colls, _rest, rest_sig = parts
+    return (rest_sig, tuple((name, tuple(order), tuple(e[1] for e in ents.values()))
+                            for name, (ents, order) in colls.items()))
+
+
+def _parts_est(parts):
+    """A whole frame's length before it is serialized (_LazyWire.size): the entry strings' byte total plus the
+    remainder's — the frame's key names and separators are not counted, so it reads a little under the frame."""
+    colls, _rest, rest_sig = parts
+    return sum(len(e[1]) for ents, _o in colls.values() for e in ents.values()) + len(rest_sig)
 
 
 def _js_key_order(keys):
@@ -32947,10 +33075,13 @@ def _order_shape(kind, order):
     return list(groups.items())
 
 
-def _send_slot(c, ftype, payload, pre, sig):
+def _send_slot(c, ftype, payload, pre, sig, parts=None):
     """Send a bars/feed payload to one client: whole for a client without delta support (exactly as before),
-    else as a delta against what that client holds. `pre`/`sig` are the shared full serialization and
-    dedup signature the pusher computed once per build.
+    else as a delta against what that client holds. `pre`/`sig` are the shared full serialization (a str, or a
+    _LazyWire serialized only if a whole frame goes) and dedup signature the pusher computed once per build;
+    `parts` is the payload's _delta_parts split when the caller made it at the wire fill (the pusher does), so
+    the delta path neither re-splits nor depends on _delta_parts_cache's single slot still holding it (a
+    handler-thread connect push can evict that between the fill and the send).
     One thread at a time per client (review find, 2026-09-04): the socket handler's connect push (`ready` →
     _push_one, on the handler thread) and the pusher's cycle both reach here for the same client, and both
     read and write its held delta state. Unserialized, one interleaving — both find nothing held, a rebuild
@@ -32959,16 +33090,16 @@ def _send_slot(c, ftype, payload, pre, sig):
     divergence until the next full. Before deltas the same race touched only the dedup dict, where a double
     full was harmless. Re-entrant: the size fallback in _send_slot_delta calls back in on the same thread."""
     with _client_lock(c):                             # one per client, made by _new_ws_client
-        _send_slot_locked(c, ftype, payload, pre, sig)
+        _send_slot_locked(c, ftype, payload, pre, sig, parts)
 
 
-def _send_slot_locked(c, ftype, payload, pre, sig):
+def _send_slot_locked(c, ftype, payload, pre, sig, parts=None):
     key = _DELTA_SLOTS[ftype][0]
     if not c.get("delta"):
         _send_client(c, key, payload, pre=pre, sig=sig)
         return
     try:
-        _send_slot_delta(c, key, ftype, payload, pre, sig)
+        _send_slot_delta(c, key, ftype, payload, pre, sig, parts)
     except Exception:
         # One client's frame must never take the pusher down with it (every dashboard would freeze until a
         # restart): say so, forget what that client holds, and send the whole payload — which carries no
@@ -32979,13 +33110,14 @@ def _send_slot_locked(c, ftype, payload, pre, sig):
         _send_client(c, key, payload, pre=pre, sig=sig)
 
 
-def _send_slot_delta(c, key, ftype, payload, pre, sig):
+def _send_slot_delta(c, key, ftype, payload, pre, sig, parts=None):
     rs = c.get("resync")
     if rs and ftype in rs:                             # the shim said it could not apply a delta (a base it does
         rs.discard(ftype)                              # not hold): forget what we believe it holds; whole, re-based
         c.get("dstate", {}).pop(ftype, None)
         c.get("sent", {}).pop(key, None)
-    parts = _delta_parts(ftype, payload)
+    if parts is None:
+        parts = _delta_parts(ftype, payload)
     states = c.setdefault("dstate", {})
     if parts is None:                                  # cannot be keyed: whole, and the client holds nothing
         states.pop(ftype, None)
@@ -32999,7 +33131,9 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
         # bundle sees the message): every key is minted HERE, once — a shim deriving keys from field values
         # would spell null/None, true/True, 1/1.0 differently from Python and hold keys the kernel never sent.
         keys = json.dumps({n: o for n, (_e, o) in colls.items()})
-        pre_k = pre[:-1] + ',"_keys":' + keys + "}" if pre.endswith("}") else json.dumps(dict(payload, _keys=json.loads(keys)), default=str)
+        ps = _wire_text(pre)                           # a whole frame goes: the build's one whole encode, if not yet made
+        pre_k = (ps[:-1] + ',"_keys":' + keys + "}" if ps.endswith("}")
+                 else json.dumps(dict(payload, _keys=json.loads(keys)), default=_wire_default_in("_send_slot_delta")))
         # The keyed full must actually GO: a whole frame sent moments ago without keys (the failure path, or an
         # unkeyable build) filled the dedup slot with this same signature, and a deduped keyed full would leave
         # the kernel holding state for a client that holds nothing (review 2026-09-03).
@@ -33018,7 +33152,7 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
         # pusher hands an unchanged payload object across cycles (_bars_wire holds the bars by the cached timeline's
         # identity), and that compare is what this skips. Counted as the unchanged branch counts it: built, not
         # sent. Past the repost window the compare runs and the repost goes.
-        _PERF_STATS.send(key, "deduped", len(pre))
+        _PERF_STATS.send(key, "deduped", _wire_len(pre))
         return
     frame = {"type": "delta", "slot": ftype, "base": st["rev"], "rev": st["rev"] + 1, "coll": {}}
     changed = False
@@ -33050,7 +33184,7 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
             frame["coll"][name] = entry; changed = True
     if not changed:
         if now - st.get("at", 0) < _DEDUP_REPOST_S:    # unchanged: nothing to send (the repost keeps the fade alive)
-            _PERF_STATS.send(key, "deduped", len(pre))   # built and compared, not sent — the same fact
+            _PERF_STATS.send(key, "deduped", _wire_len(pre))   # built and compared, not sent — the same fact
             # Adopt this split as the held one: the compare just showed the held entry strings, key sets, order
             # shape and remainder equal it, so the same object next cycle is an identity hit above rather than
             # another compare. A content-equal rebuild mints a new payload object (the view sig's 5 s bucket
@@ -33060,11 +33194,11 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
             # from the last frame that went.
             st["parts"] = parts
             return                                         # _send_client's dedup records for a whole-frame client
-    s = json.dumps(frame, default=str)
-    if len(s) >= _DELTA_MAX_FRACTION * len(pre):       # not worth a delta → the full frame, rebased
-        states.pop(ftype, None)
+    s = json.dumps(frame, default=_wire_default_in("_send_slot_delta"))   # the entry OBJECTS ride: re-encoded here
+    if len(s) >= _DELTA_MAX_FRACTION * _wire_len(pre):   # not worth a delta → the full frame, rebased (a lazy `pre`
+        states.pop(ftype, None)                          # answers its estimate here: a slightly eager fallback, never wrong)
         c.get("sent", {}).pop(key, None)
-        _send_slot(c, ftype, payload, pre, sig)
+        _send_slot(c, ftype, payload, pre, sig, parts)
         return
     _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=0, delta=1)
     _PERF_STATS.send(key, "delta", len(s))
@@ -33182,9 +33316,20 @@ def _send_client(c, key, msg, pre=None, sig=None, kind="full"):
     WebSocket client; the log makes the next one obvious.
 
     `kind` is the /perf sends class the frame is counted under when it goes: "full" (the default: a
-    whole frame) or "delta" for a caller whose frame is a suffix or a diff (_send_chat's chatTail)."""
-    s = pre if pre is not None else json.dumps(msg)
-    sig = sig if sig is not None else _dedup_sig(msg, s)
+    whole frame) or "delta" for a caller whose frame is a suffix or a diff (_send_chat's chatTail).
+
+    `pre` may also be a _LazyWire (the feed, the bars): its bytes are produced only if the frame GOES — a
+    deduped frame costs its size() and nothing else."""
+    if pre is None:
+        s = json.dumps(msg)
+    elif isinstance(pre, str):
+        s = pre
+    else:
+        s = None                                          # lazy: serialized below only if the frame goes
+    if sig is None:
+        if s is None:
+            s = pre.text()
+        sig = _dedup_sig(msg, s)
     seqs = getattr(_VIEWS_SERVED, "seqs", None)
     if seqs is not None:
         # the ready handler is capturing ITS connect push (the caps frame's viewsSeq, see KERNEL_WS_CAPS):
@@ -33197,13 +33342,18 @@ def _send_client(c, key, msg, pre=None, sig=None, kind="full"):
         prev = c.setdefault("sent", {}).get(key)      # reset (_client_reset_chat_base) — one writer at a time
         now = time.time()
         if prev is not None and prev[0] == sig and (now - prev[1]) < _DEDUP_REPOST_S:
-            _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=1)
-            _PERF_STATS.send(key, "deduped", len(s))
+            n = len(s) if s is not None else pre.size()   # deduped: the length only; a lazy frame stays unserialized
+            _perf("send", slot=_perf_slot(key), bytes=n, deduped=1)
+            _PERF_STATS.send(key, "deduped", n)
             return
+        if s is None:
+            s = pre.text()                            # the frame goes: the build's one whole encode (the cell keeps it) —
+            #                                           BEFORE the slot is written, so a raise here leaves it for a retry
         c["sent"][key] = (sig, now)
         _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=0)
         _PERF_STATS.send(key, kind, len(s))
-        _client_send(c, s, key)                       # enqueue only (never blocks): the lock is held for microseconds
+        _client_send(c, s, key)                       # enqueue only (never blocks): the lock is held for microseconds,
+        #                                               or for the one whole encode when a lazy frame goes
 
 
 def _send_chat(c, m, ms, change_from, led_changed):
@@ -35088,39 +35238,64 @@ def _push(targets, connect=False, tmux=None):
     # Serialize the shared payloads once per BUILD, not per cycle (the 2026-08-10 CPU fix, round
     # three). Round two had brought feed/bars down to one dumps each per cycle — measured on a QUIET
     # fleet that was still ~357KB (feed) + ~1.65MB (bars) of json.dumps every cycle, ~4MB/s, nearly
-    # all of it discarded by the dedup because nothing had changed. The serialization is now keyed on
-    # the EVENT that can change the bytes: for bars, the cached timeline object's identity (a rebuild
+    # all of it discarded by the dedup because nothing had changed. The wire form is keyed on the
+    # EVENT that can change the bytes: for bars, the cached timeline object's identity (a rebuild
     # mints a new object; the cache slot holds the ref, so identity is stable and safe) + the warming
     # flag; for the feed, the cached pre-copy feed object's identity + a DEEP-EQUALITY check on the
     # per-cycle ledgers attach (rebuilt fresh each cycle around the always-rebuilt active tab, so its
     # OBJECT is always new but its content only changes when a session's ledger/status genuinely
     # moved — dict == is C-speed and allocation-free, far cheaper than re-serializing).
+    # And once per build means ONE encode. A rebuild used to serialize each payload three times over
+    # on this thread: the whole frame, _dedup_sig's sort_keys re-dump of the payload minus its clock
+    # (both frames carry `now`, so it always ran), and the per-entry split the delta path made on the
+    # first delta client's send. The per-entry split (_delta_parts) is now the one encode per build:
+    # the dedup signature is a tuple of its strings (_parts_sig), and the whole frame is a _LazyWire
+    # cell made on the first send that needs one — a fresh socket, a re-base, a client without deltas,
+    # a delta past the size guard — and kept in the wire tuple for the rest of the build. The split is
+    # handed down to _send_slot so the delta path neither re-splits nor depends on _delta_parts_cache's
+    # single slot still holding it: a connect push on a handler thread (_push([client], connect=True)
+    # from the ws handler) can evict that slot between this fill and the send. An unkeyable payload
+    # (said once by _delta_parts) keeps the whole dump and _dedup_sig, as before.
     global _feed_wire, _bars_wire
-    feed_ms = feed_sig = bars = bars_ms = bars_sig = None
+    feed_ms = feed_sig = feed_parts = bars = bars_ms = bars_sig = bars_parts = None
     _t_stage = time.monotonic()
     for c in targets:
         if c["app"] in ("feed", "fleet"):   # the feed pane AND the Fleet view both ride the feed payload (Fleet reads feed.ledgers)
             if feed_ms is None:
                 w = _feed_wire                           # tuple snapshot — rebound whole, never mutated (torn reads)
                 if w is not None and w[0] is feed_src and w[1] == feed.get("ledgers"):
-                    feed, feed_ms, feed_sig = w[2], w[3], w[4]
+                    feed, feed_ms, feed_sig, feed_parts = w[2], w[3], w[4], w[5]
                 else:
-                    feed_ms = json.dumps(feed)
-                    feed_sig = _dedup_sig(feed, feed_ms)
-                    _feed_wire = (feed_src, feed.get("ledgers"), feed, feed_ms, feed_sig)
-            _send_slot(c, "feed", feed, feed_ms, feed_sig)
+                    feed_parts = _delta_parts("feed", feed)   # the one per-entry encode, handed down to the delta path
+                    if feed_parts is not None:
+                        feed_sig = _parts_sig(feed_parts)
+                        feed_ms = _LazyWire(lambda f=feed: json.dumps(f, default=_wire_default_in("_push feed")),
+                                            _parts_est(feed_parts), "feed_body")
+                    else:                                # unkeyable: whole frames and the string signature, as before
+                        s = json.dumps(feed, default=_wire_default_in("_push feed"))
+                        feed_ms, feed_sig = _LazyWire(None, len(s), text=s), _dedup_sig(feed, s)
+                        _wire_bump("feed_sig_fallback")
+                    _feed_wire = (feed_src, feed.get("ledgers"), feed, feed_ms, feed_sig, feed_parts)
+            _send_slot(c, "feed", feed, feed_ms, feed_sig, feed_parts)
         elif c["app"] == "timeline" and timeline is not None:
             if bars_ms is None:
                 w = _bars_wire
                 if w is not None and w[0] is timeline and w[1] == tl_warming:
-                    bars, bars_ms, bars_sig = w[2], w[3], w[4]
+                    bars, bars_ms, bars_sig, bars_parts = w[2], w[3], w[4], w[5]
                 else:
                     bars = {"type": "bars", "turns": timeline["turns"], "judging": timeline["judging"],
                             "messages": timeline["messages"], "now": timeline["now"], "warming": tl_warming}
-                    bars_ms = json.dumps(bars)
-                    bars_sig = _dedup_sig(bars, bars_ms)
-                    _bars_wire = (timeline, tl_warming, bars, bars_ms, bars_sig)
-            _send_slot(c, "bars", bars, bars_ms, bars_sig)
+                    bars_parts = _delta_parts("bars", bars)   # the one per-entry encode, handed down to the delta path
+                    if bars_parts is not None:
+                        bars_sig = _parts_sig(bars_parts)
+                        bars_ms = _LazyWire(lambda b=bars: json.dumps(b, default=_wire_default_in("_push bars")),
+                                            _parts_est(bars_parts), "bars_body")
+                    else:                                # unkeyable: whole frames and the string signature, as before
+                        s = json.dumps(bars, default=_wire_default_in("_push bars"))
+                        bars_ms, bars_sig = _LazyWire(None, len(s), text=s), _dedup_sig(bars, s)
+                        _wire_bump("bars_sig_fallback")
+                    _bars_wire = (timeline, tl_warming, bars, bars_ms, bars_sig, bars_parts)
+            _send_slot(c, "bars", bars, bars_ms, bars_sig, bars_parts)
     _PERF_STATS.stage("push.send", time.monotonic() - _t_stage)
     with _clients_lock:
         _clients[:] = [c for c in _clients if c.get("alive", True)]
@@ -35368,12 +35543,13 @@ _VIEW_STATS = {"feedBuild": 0, "feedServe": 0, "tlBuild": 0, "tlServe": 0,
                "chatBuildActive": 0, "chatBuildBg": 0, "chatServeActive": 0, "chatServeBg": 0}
 _built_timeline = [None, None, 0.0, 0.0]          # [fleet_sig, payload, built_at, build_started_at]
 # Wire-form caches for the two heavy shared payloads (the 2026-08-10 CPU fix, round three): the last
-# (source-identity key, serialized bytes, dedup sig) for the feed and the timeline bars, so an unchanged
-# build is never re-serialized cycle after cycle (~357KB + ~1.65MB per cycle measured on a quiet fleet).
+# (source-identity key, lazy serialization, dedup sig, per-entry split) for the feed and the timeline bars,
+# so an unchanged build is never re-serialized cycle after cycle (~357KB + ~1.65MB per cycle measured with
+# every session quiet), and a rebuild is serialized once (see _push's wire section).
 # TUPLES, rebound whole — a concurrent connect push on a WS thread snapshots the ref and can never see a
 # torn entry; the identity keys stay alive because these tuples (and the build caches above) hold them.
-_feed_wire = None   # (feed_src, ledgers, wire_feed, ms, sig)
-_bars_wire = None   # (timeline, warming, bars, ms, sig)
+_feed_wire = None   # (feed_src, ledgers, wire_feed, ms, sig, parts) — ms = a _LazyWire of json.dumps(wire_feed), made on the first whole-frame send; sig = _parts_sig(parts), or _dedup_sig over the whole dump when parts is None (unkeyable); parts = _delta_parts("feed", wire_feed), handed to _send_slot
+_bars_wire = None   # (timeline, warming, bars, ms, sig, parts) — the same shape for the bars
 _skel_wire = None   # (timeline, frame, pre, sig) — the lanes {type:"data"} frame projected from the same cached build
 # Each build is intrinsically ~1-1.6s (re-segments every session); the IDEAL is a per-session lane/card cache
 # (only the changed session rebuilds), but that's a big refactor of build_feed/build_timeline. Interim cap: a

--- a/tests/test_bg_scan_fold.py
+++ b/tests/test_bg_scan_fold.py
@@ -226,7 +226,7 @@ class TimelineReaders(unittest.TestCase):
         p = jd.STATE / "states" / (SID + ".jsonl")
         _append(str(p), {"t": now - 300, "state": "working"}, {"t": now - 200, "state": "permission"})
         self.assertEqual(km._state_intervals(SID, "permission", now), [[now - 200, now]],
-                         "an open awaiting interval runs to now")
+                         "an open awaiting interval runs to now (the build clock the renderer reads as open)")
         _append(str(p), {"t": now - 100, "state": "working"}, {"awaiting": False})
         self.assertEqual(km._state_intervals(SID, "permission", now), [[now - 200, now - 100]])
         self.assertEqual(km._state_intervals(SID, "compacting", now), [])

--- a/tests/test_bg_scan_fold.py
+++ b/tests/test_bg_scan_fold.py
@@ -225,8 +225,8 @@ class TimelineReaders(unittest.TestCase):
         now = 1_000_000
         p = jd.STATE / "states" / (SID + ".jsonl")
         _append(str(p), {"t": now - 300, "state": "working"}, {"t": now - 200, "state": "permission"})
-        self.assertEqual(km._state_intervals(SID, "permission", now), [[now - 200, now]],
-                         "an open awaiting interval runs to now (the build clock the renderer reads as open)")
+        self.assertEqual(km._state_intervals(SID, "permission", now), [[now - 200, now, True]],
+                         "an open awaiting interval runs to now (the build clock) and carries the open mark the renderer reads")
         _append(str(p), {"t": now - 100, "state": "working"}, {"awaiting": False})
         self.assertEqual(km._state_intervals(SID, "permission", now), [[now - 200, now - 100]])
         self.assertEqual(km._state_intervals(SID, "compacting", now), [])
@@ -239,7 +239,7 @@ class TimelineReaders(unittest.TestCase):
         with open(p, "a") as f:
             f.write(json.dumps({"t": now - 200, "state": "permission"}))
         _bump(str(p))
-        self.assertEqual(km._state_intervals(SID, "permission", now), [[now - 200, now]])
+        self.assertEqual(km._state_intervals(SID, "permission", now), [[now - 200, now, True]])
         self.assertEqual(km._state_ev_cache[str(p)][0], 1, "provisional: not folded into the cache")
 
     def test_postal_event_without_its_newline_still_counts(self):

--- a/tests/test_chat_delta_resync.py
+++ b/tests/test_chat_delta_resync.py
@@ -181,6 +181,21 @@ def test_build_sig_still_tracks_the_fsid_states_file(tmp_path):
     assert before != km._chat_build_sig(sess)
 
 
+def test_build_sig_keys_the_rows_context_percentage(tmp_path):
+    """The snapshot row's context-% is `context`, the key the merged liveness row writes; the sig read `ctx`,
+    which no row carries, so a background tab's context change never busted its chat cache."""
+    jd._rebind_state(tmp_path)
+    km.jd = jd
+    sid = "11111111-2222-3333-4444-555555555555"
+    tx = tmp_path / (sid + ".jsonl")
+    tx.write_text('{"type":"user"}\n')
+    sess = {"sid": sid, "path": str(tx), "anchor": sid}
+    row = {"state": "working", "model": "m", "context": 10, "effort": "", "mode": "", "fast": "", "since": 1}
+    before = km._chat_build_sig(sess, tm=dict(row))
+    assert before == km._chat_build_sig(sess, tm=dict(row))
+    assert before != km._chat_build_sig(sess, tm={**row, "context": 20}), "a context-% step busts the chat build sig"
+
+
 # ───────────────────────── the lost-first-frame class (the user 2026-09-02) ─────────────────────────
 
 def test_ready_forgets_the_whole_chat_base_so_the_repush_is_full_frames():

--- a/tests/test_goal_store_fault_boundary.py
+++ b/tests/test_goal_store_fault_boundary.py
@@ -364,7 +364,7 @@ class NudgeTickBoundary(_World):
                   mock.patch.object(km, "_compacting_now", lambda sid: False),
                   mock.patch.object(km, "_api_error", lambda path: None),
                   mock.patch.object(km, "_session_working", lambda turns: False),
-                  mock.patch.object(km, "_interrupt_suppresses_nudge", lambda turns, sid="": False),
+                  mock.patch.object(km, "_interrupt_suppresses_nudge", lambda turns, sid="", **k: False),
                   mock.patch.object(km, "_backend_queued", lambda sid: False),
                   mock.patch.object(km, "_backend_rewind_pending", lambda sid: False),
                   mock.patch.object(km, "_last_state", lambda sid: ("", 0)),

--- a/tests/test_interrupt_lift_evidence_time.py
+++ b/tests/test_interrupt_lift_evidence_time.py
@@ -195,10 +195,10 @@ class TheNudgeIsNotHeldByTheLift(unittest.TestCase):
                       "(and the sweep pops it on the turn's own end) — no silent card since 2026-08-13")
 
 
-class EndToEndThroughTheTick(unittest.TestCase):
-    """Through the parse: a genuine stop blocks the focus goal, the user's next message lifts it — and
-    the closer's verdict about THAT message's turn puts the card back in needs-you, where the six-minute
-    silent Working card should have been."""
+class _TickFixture(unittest.TestCase):
+    """The shared world for the tick tests: a hermetic state root, one session whose transcript ends in
+    a user interrupt, its focus goal in Working, and the re-engagement append. No tests of its own: the
+    concrete classes below derive from it, so each test is collected once."""
 
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
@@ -246,6 +246,12 @@ class EndToEndThroughTheTick(unittest.TestCase):
                                      "a2", "u3", "end_turn")) + "\n")
         km._parse_cache.clear()
 
+
+class EndToEndThroughTheTick(_TickFixture):
+    """Through the parse: a genuine stop blocks the focus goal, the user's next message lifts it — and
+    the closer's verdict about THAT message's turn puts the card back in needs-you, where the six-minute
+    silent Working card should have been."""
+
     def test_the_lift_records_the_reengagement_turns_trigger(self):
         km._interrupt_block_tick(NOW, self.tmux)
         self.assertEqual(jd.load_goals(SID)["status"][GID], "blocked")
@@ -285,6 +291,66 @@ class EndToEndThroughTheTick(unittest.TestCase):
         jd.save_goals(SID, st)
         self.assertEqual(jd.load_goals(SID)["status"][GID], "blocked",
                          "a restart-cut session that comes back and asks a question still reaches the user")
+
+
+class TheTickPushesNothingInline(_TickFixture):
+    """The tick's flips reach the feed through the writers' own dirty mark
+    and pusher wake — the next cycle's rebuild — never through an inline _push_all on the tick. The
+    stand-down lift (a marker whose block a judge now owns) writes nothing and so moves nothing.
+    _views_dirty is a module global shared across the suite: each test records its own floor."""
+
+    def setUp(self):
+        super().setUp()
+        self.pushes = []
+        self._push = km._push_all
+        km._push_all = lambda *a, **k: self.pushes.append(1)
+        self._was_set = km._pusher_wake.is_set()
+        km._pusher_wake.clear()
+
+    def tearDown(self):
+        km._push_all = self._push
+        if self._was_set:
+            km._pusher_wake.set()
+        else:
+            km._pusher_wake.clear()
+        super().tearDown()
+
+    def test_the_block_marks_the_views_dirty_wakes_the_pusher_and_pushes_nothing_inline(self):
+        floor = time.time()
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertEqual(jd.load_goals(SID)["status"][GID], "blocked")
+        self.assertEqual(self.pushes, [], "no inline push from the tick")
+        self.assertTrue(km._pusher_wake.is_set(), "the writer woke the pusher; its next cycle carries the flip")
+        self.assertGreater(km._views_dirty[0], floor, "…and marked the views dirty, so that cycle rebuilds")
+
+    def test_the_lift_does_the_same(self):
+        km._interrupt_block_tick(NOW, self.tmux)
+        km._pusher_wake.clear()
+        self._reengage()
+        floor = time.time()
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertEqual(jd.load_goals(SID)["status"][GID], "working")
+        self.assertEqual(self.pushes, [])
+        self.assertTrue(km._pusher_wake.is_set())
+        self.assertGreater(km._views_dirty[0], floor)
+
+    def test_a_stand_down_lift_moves_nothing(self):
+        km._interrupt_block_tick(NOW, self.tmux)
+        st = jd.load_goals(SID)                          # a judge now owns the block: the diary's last block
+        self.assertTrue(jd.record_verdict(st, st["nodes"][GID], "closer", "block", RESUME_T,
+                                          why="which host for prod?"))
+        jd.rollup_status(st, False)
+        jd.save_goals(SID, st)
+        self.assertEqual(km._intr_blocked(SID), GID, "the marker still points at the card")
+        self._reengage()
+        km._pusher_wake.clear()
+        floor = km._views_dirty[0]
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertIsNone(km._intr_blocked(SID), "the marker is retired")
+        self.assertEqual(jd.load_goals(SID)["status"][GID], "blocked", "…and the judge's block stands")
+        self.assertEqual(self.pushes, [], "nothing new to show: no push")
+        self.assertEqual(km._views_dirty[0], floor, "no store write, no dirty mark")
+        self.assertFalse(km._pusher_wake.is_set(), "and no wake")
 
 
 if __name__ == "__main__":

--- a/tests/test_interrupt_marks_memo.py
+++ b/tests/test_interrupt_marks_memo.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""_interrupt_marks on the pusher thread: the author gate and the memo.
+
+The interrupt tick, the nudge tick and build_feed's badge each tallied a session's user atoms every
+cycle: a flatten, then a per-atom is_interrupt_record text join (most of the cost, and most user
+records are tool_result-only harness lines that can never be an interrupt record or a human prompt).
+
+The gate drops the atoms the file adapter marked text-less (author None) before the text scan; exact,
+because author_of returns None on no other shape. The memo keys on the parse object's identity plus
+the machineCut stamp, per (sid, parse family).
+
+Synthetic fixtures only: placeholder UUIDs, invented prompt text, hostname-free paths.
+"""
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+em = SourceFileLoader("romp_event_model_imm", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge_imm", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_imm", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_imm", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+jd = km.jd
+
+NOW = 1781100000
+# A sid of this module's own (the goal-store fixture rule, 2026-08-24): the override journal is
+# per-sid and process-shared across every kernel test copy.
+SID = "11111111-2222-3333-4444-777777777777"
+T0 = NOW - 3600
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent, stop):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}], "stop_reason": stop}}
+
+
+def uatom(t, text, author="human"):
+    return {"type": "user", "t": t, "author": author, "message": {"role": "user", "content": text}}
+
+
+def intr(t):
+    return uatom(t, "[Request interrupted by user]", author="human")
+
+
+def tool_result_atom(t):
+    """The file adapter's shape for a tool_result-only harness line: author None, no text block."""
+    return {"type": "user", "t": t, "author": None,
+            "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu1",
+                                                     "content": "ok"}]}}
+
+
+class _Counter:
+    """Wrap a module attribute with a call counter; restore on close."""
+
+    def __init__(self, mod, name):
+        self.mod, self.name, self.orig, self.calls = mod, name, getattr(mod, name), []
+
+        def wrapped(*a, **k):
+            self.calls.append((a, k))
+            return self.orig(*a, **k)
+        setattr(mod, name, wrapped)
+
+    def close(self):
+        setattr(self.mod, self.name, self.orig)
+
+
+class AuthorNoneAtomsAreSkipped(unittest.TestCase):
+    """A user atom carrying author None (author_of's answer for a text-less record) is dropped before
+    the text scan; no tally changes. The file adapter OMITS the key for that answer rather than writing
+    it (pinned below), so the gate's reach on disk-parsed sessions is nil and a key-less atom is still
+    scanned: the SDK live tail carries texty user atoms without the key."""
+
+    def test_a_text_less_author_none_atom_never_changes_the_marks(self):
+        base = [uatom(T0, "wire the thing"), intr(T0 + 60)]
+        with_tr = [uatom(T0, "wire the thing"), tool_result_atom(T0 + 30), intr(T0 + 60),
+                   tool_result_atom(T0 + 70), tool_result_atom(T0 + 80)]
+        self.assertEqual(km._interrupt_marks_atoms(with_tr), km._interrupt_marks_atoms(base))
+        # …and past the stop: a genuine stop with only harness lines after it is still the user's
+        self.assertEqual(km._interrupt_marks_atoms(with_tr), (T0 + 60, T0))
+
+    def test_a_text_less_atom_between_the_stop_and_the_notice_stays_wedge(self):
+        # the forward scan read such an atom as wedge before; dropping it reads the same notice
+        atoms = [uatom(T0, "wire the thing"), intr(T0 + 60), tool_result_atom(T0 + 61),
+                 uatom(T0 + 62, sb.BOOT_RESUME_NUDGE, "romp")]
+        self.assertEqual(km._interrupt_marks_atoms(atoms), (0, T0),
+                         "the machine cut is still named by the notice past the harness line")
+        atoms = [uatom(T0, "wire the thing"), intr(T0 + 60), tool_result_atom(T0 + 61)]
+        self.assertEqual(km._interrupt_marks_atoms(atoms, cut_t=T0 + 64, cut_cause="restart"), (0, T0),
+                         "the stamp still settles an inconclusive scan that ends in harness lines")
+
+    def test_a_tool_result_only_atom_is_never_text_scanned(self):
+        c = _Counter(km.em, "is_interrupt_record")
+        try:
+            atoms = [uatom(T0, "wire the thing")] + [tool_result_atom(T0 + i) for i in range(1, 40)] + \
+                    [intr(T0 + 60), tool_result_atom(T0 + 61)]
+            km._interrupt_marks_atoms(atoms)
+            self.assertEqual(len(c.calls), 2, "only the two authored atoms reach is_interrupt_record")
+        finally:
+            c.close()
+
+    def test_an_atom_without_an_author_key_is_still_classified(self):
+        # an SDK live-tail atom (msg_to_atom) carries no author key at all and may carry text; a merged
+        # live interrupt record must count the moment it is merged, so absence is never a skip
+        live_stop = {"type": "user", "t": T0 + 90,
+                     "message": {"role": "user", "content": "[Request interrupted by user]"}}
+        atoms = [uatom(T0, "wire the thing"), live_stop]
+        self.assertEqual(km._interrupt_marks_atoms(atoms), (T0 + 90, T0))
+
+    def test_the_file_adapter_omits_the_key_for_a_text_less_record(self):
+        # the premise the docstring states: a tool_result-only line parses to a user atom with NO
+        # author key (not author None), so the gate above meets nothing on a disk-parsed session
+        td = tempfile.mkdtemp()
+        path = os.path.join(td, SID + ".jsonl")
+        recs = [uline(T0, "wire the thing", "u1"),
+                {"type": "assistant", "timestamp": iso(T0 + 5), "uuid": "a1", "parentUuid": "u1",
+                 "message": {"role": "assistant", "stop_reason": "tool_use",
+                             "content": [{"type": "tool_use", "id": "tu1", "name": "Bash", "input": {}}]}},
+                {"type": "user", "timestamp": iso(T0 + 6), "uuid": "u2", "parentUuid": "a1",
+                 "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu1",
+                                                          "content": "ok"}]}}]
+        with open(path, "w") as f:
+            f.write("\n".join(json.dumps(r) for r in recs) + "\n")
+        try:
+            sess = em.parse_session(path, rompuuid=SID, now=NOW)
+        finally:
+            os.remove(path); os.rmdir(td)
+        users = [a for t in sess["turns"] for a in t.get("atoms") or [] if a.get("type") == "user"]
+        by_uuid = {a.get("uuid"): a for a in users}
+        self.assertIn("u2", by_uuid, "the tool_result-only line is a user atom of its own")
+        self.assertNotIn("author", by_uuid["u2"], "…with the author key omitted, not None")
+        self.assertEqual(by_uuid["u1"].get("author"), "human")
+
+    def test_author_none_means_no_text_in_the_file_adapter(self):
+        # the exactness claim, checked against author_of itself: across every promptSource the
+        # adapter sees, a None author is returned ONLY for a content list with no text block
+        texty = [{"type": "text", "text": "hello there"}]
+        stop = [{"type": "text", "text": "[Request interrupted by user]"}]
+        tr_only = [{"type": "tool_result", "tool_use_id": "tu1", "content": "ok"}]
+        for blocks in (texty, stop, tr_only, []):
+            for ps in (None, "typed", "queued", "sdk", "system"):
+                for sdk_human in (False, True):
+                    a = em.author_of(blocks, ps, {}, sdk_human)
+                    if a is None:
+                        self.assertEqual(em._text_of(blocks), "",
+                                         "author None with text present would make the gate inexact (%r %r)" % (blocks, ps))
+                    if em._text_of(blocks):
+                        self.assertIsNotNone(a, "every branch on a non-empty text returns an author (%r)" % ps)
+
+
+class _MemoHarness(unittest.TestCase):
+    """A real transcript with a genuine stop, a goal store, a names entry and a rebound judge state
+    (jd._rebind_state, so STATESDIR follows and a states append re-keys jd.parsed_session — a fixture
+    that rebinds jd.STATE alone never exercises the new-object case)."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        pdir = proj / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        pdir.mkdir(parents=True)
+        self.tpath = pdir / (SID + ".jsonl")
+        names = td / "names"; names.mkdir()
+        (names / SID).write_text("api\t%s\t#abcdef\n" % str(cdir))
+        self.saved = (jd.STATE, jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATESDIR, km.NAMES, jd.CLOSER_ON)
+        jd._rebind_state(td)
+        jd.NAMES, jd.PROJECTS = names, proj
+        km.NAMES = names
+        jd.CLOSER_ON = False
+        jd.GOALDIR.mkdir(parents=True)
+        (td / "states").mkdir()
+        self._reset()
+        km._write_auto_nudge({"enabled": True, "nudged": {}, "intrBlocked": {}})
+        recs = [uline(T0, "wire up the reconnect banner", "u1"),
+                aline(T0 + 20, "on it", "a1", "u1", "tool_use"),
+                uline(T0 + 60, "[Request interrupted by user]", "u2", "a1")]
+        self.tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        g = {"id": SID + ":g1", "text": "Ship the reconnect banner", "parentId": None, "nodeComplete": False,
+             "blocked": False, "cleared": False, "trail": [], "t": T0}
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
+            {"rompUuid": SID, "seq": 1, "lastNode": g["id"], "closedTurns": [], "nodes": {g["id"]: g},
+             "placements": {}, "status": {g["id"]: "working"}}))
+        self.tmux = {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
+                           "context": None, "compactPct": None, "color": None}}
+
+    def _reset(self):
+        km._parse_cache.clear()
+        km._machine_cut_cache.clear()
+        km._autonudge_cache.clear()
+        km._pending_ops.clear()
+        km._intr_marks_memo.clear()
+        jd._PARSE_CACHE.clear()
+
+    def tearDown(self):
+        jd._rebind_state(self.saved[0])
+        (jd.STATE, jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATESDIR, km.NAMES, jd.CLOSER_ON) = self.saved
+        self._reset()
+        self.td.cleanup()
+
+    def _judge_turns(self):
+        return jd.parsed_session(SID, [str(self.tpath)], NOW)["turns"]
+
+    def _stamp(self, t, cause="restart"):
+        with open(jd.STATESDIR / (SID + ".jsonl"), "a") as f:
+            f.write(json.dumps({"t": t, "machineCut": cause}) + "\n")
+
+    @staticmethod
+    def _stats():
+        return dict(km._intr_marks_memo_stats)
+
+
+class MemoHitsAndMisses(_MemoHarness):
+    def test_two_calls_on_the_same_turns_scan_once(self):
+        turns = self._judge_turns()
+        c = _Counter(km.em, "is_interrupt_record")
+        try:
+            first = km._interrupt_marks(turns, SID, family="judge")
+            n = len(c.calls)
+            self.assertGreater(n, 0, "the first call scanned the atoms")
+            s0 = self._stats()
+            self.assertEqual(km._interrupt_marks(turns, SID, family="judge"), first)
+            self.assertEqual(len(c.calls), n, "the same list object with the same stamp: no scan")
+            self.assertEqual(self._stats()["hit"], s0["hit"] + 1)
+            self.assertEqual(self._stats()["miss"], s0["miss"])
+        finally:
+            c.close()
+        self.assertEqual(first, (T0 + 60, T0), "a genuine stop, no notice, no stamp")
+
+    def test_a_new_list_recomputes(self):
+        turns = self._judge_turns()
+        km._interrupt_marks(turns, SID, family="judge")
+        s0 = self._stats()
+        self.assertEqual(km._interrupt_marks(list(turns), SID, family="judge"), (T0 + 60, T0))
+        self.assertEqual(self._stats()["miss"], s0["miss"] + 1, "equal content, new identity → recompute")
+
+    def test_a_moved_machine_cut_stamp_recomputes_on_the_same_object(self):
+        turns = self._judge_turns()
+        self.assertEqual(km._interrupt_marks(turns, SID, family="judge"), (T0 + 60, T0))
+        s0 = self._stats()
+        self._stamp(T0 + 64)                            # the backend's own record: that stop was romp's cut
+        self.assertEqual(km._interrupt_marks(turns, SID, family="judge"), (0, T0),
+                         "the SAME turns object, a moved stamp → recomputed, and the stop is now the cut's")
+        self.assertEqual(self._stats()["miss"], s0["miss"] + 1)
+
+    def test_a_new_parse_of_an_appended_transcript_is_a_new_object(self):
+        # the identity key's standing assumption: the parsers allocate fresh lists, never extend in place
+        t1 = self._judge_turns()
+        d1 = km._parse(str(self.tpath), SID, NOW)["turns"]
+        with open(self.tpath, "a") as f:
+            f.write(json.dumps(uline(T0 + 200, "keep going with plan B", "u3", "u2")) + "\n")
+        self.assertIsNot(self._judge_turns(), t1, "jd.parsed_session re-keyed on the transcript append")
+        self.assertIsNot(km._parse(str(self.tpath), SID, NOW)["turns"], d1, "…and so did the kernel parse")
+        # …and a states append re-keys the judge parse too (STATESDIR is rebound in this harness)
+        t2 = self._judge_turns()
+        self._stamp(T0 + 64)
+        self.assertIsNot(self._judge_turns(), t2, "a states append is a new parse object")
+
+    def test_results_equal_the_unmemoized_function_on_the_fixtures(self):
+        cases = [
+            [uatom(T0, "wire the thing"), intr(T0 + 60), uatom(T0 + 61, sb.BOOT_RESUME_NUDGE, "romp")],
+            [uatom(T0, "wire the thing"), intr(T0 + 60)],
+            [uatom(T0, "wire the thing"), intr(T0 + 10), uatom(T0 + 11, sb.BOOT_RESUME_NUDGE, "romp"),
+             intr(T0 + 30)],
+            [uatom(T0, "wire the thing"), uatom(T0 + 60, "[Request interrupted by user for tool use]"),
+             intr(T0 + 63), uatom(T0 + 80, sb.BOOT_RESUME_NUDGE, "romp")],
+            [uatom(T0, "wire the thing"), uatom(T0 + 60, "[Request interrupted by user for tool use]"),
+             intr(T0 + 63)],
+        ]
+        for atoms in cases:
+            turns = [{"atoms": atoms}]
+            pure = km._interrupt_marks_atoms(atoms)
+            self.assertEqual(km._interrupt_marks(turns, SID, family="judge"), pure)
+            self.assertEqual(km._interrupt_marks(turns, SID, family="judge"), pure, "the hit answers the same")
+        # with the stamp on disk the memoized read equals the pure read GIVEN that stamp
+        self._stamp(T0 + 64)
+        atoms = cases[4]
+        turns = [{"atoms": atoms}]
+        self.assertEqual(km._interrupt_marks(turns, SID, family="judge"),
+                         km._interrupt_marks_atoms(atoms, cut_t=T0 + 64, cut_cause="restart"))
+        self.assertEqual(km._interrupt_marks(turns, SID, family="judge"), (0, T0))
+
+    def test_at_most_one_entry_per_sid_and_family(self):
+        turns = self._judge_turns()
+        for _ in range(5):
+            km._interrupt_marks(list(turns), SID, family="judge")
+            km._interrupt_marks(list(turns), SID, family="display")
+        keys = [k for k in km._intr_marks_memo if k[0] == SID]
+        self.assertEqual(sorted(keys), [(SID, "display"), (SID, "judge")])
+
+    def test_sid_less_and_family_less_calls_bypass_the_memo(self):
+        turns = self._judge_turns()
+        km._interrupt_marks(turns, "", family="judge")
+        km._interrupt_marks(turns, SID)
+        km._interrupt_marks(turns)
+        km._interrupt_suppresses_nudge(turns, SID)
+        self.assertEqual(km._intr_marks_memo, {}, "no family or no sid: computed, never stored")
+
+
+class MemoAcrossTheCycle(_MemoHarness):
+    def test_the_tick_and_build_feed_hit_on_the_second_cycle(self):
+        km._parse(str(self.tpath), SID, NOW)                       # warm the display cache (_warm_fleet_bg)
+        km._interrupt_block_tick(NOW, self.tmux)
+        km.build_feed(NOW, self.tmux)
+        self.assertEqual(sorted(k for k in km._intr_marks_memo if k[0] == SID),
+                         [(SID, "display"), (SID, "judge")], "one entry per family after a cycle")
+        s0 = self._stats()
+        km._interrupt_block_tick(NOW, self.tmux)
+        km.build_feed(NOW, self.tmux)
+        s1 = self._stats()
+        self.assertEqual(s1["miss"], s0["miss"], "the second cycle recomputes nothing")
+        self.assertGreaterEqual(s1["hit"] - s0["hit"], 2, "the tick hit and build_feed hit")
+
+    def test_the_families_do_not_evict_each_other(self):
+        km._parse(str(self.tpath), SID, NOW)
+        km._interrupt_block_tick(NOW, self.tmux)
+        km.build_feed(NOW, self.tmux)
+        judge = km._intr_marks_memo[(SID, "judge")]
+        disp = km._intr_marks_memo[(SID, "display")]
+        self.assertIsNot(judge[0], disp[0], "two distinct parse objects, one slot each")
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertIs(km._intr_marks_memo[(SID, "display")], disp, "the tick left the display slot alone")
+        km.build_feed(NOW, self.tmux)
+        self.assertIs(km._intr_marks_memo[(SID, "judge")], judge, "build_feed left the judge slot alone")
+
+    def test_a_sid_leaving_the_alive_set_loses_its_entries(self):
+        km._parse(str(self.tpath), SID, NOW)
+        km._interrupt_block_tick(NOW, self.tmux)
+        km.build_feed(NOW, self.tmux)
+        dead = ("11111111-2222-3333-4444-888888888888", "judge")
+        km._intr_marks_memo[dead] = ([], (0.0, ""), (0, 0))
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertNotIn(dead, km._intr_marks_memo, "a sid outside the alive set is swept")
+        self.assertIn((SID, "judge"), km._intr_marks_memo, "…the alive one stays")
+        s0 = self._stats()
+        saved = km._has_tmux
+        km._has_tmux = lambda: True                     # an empty map is a genuine zero, not headless
+        try:
+            km._interrupt_block_tick(NOW, {})
+        finally:
+            km._has_tmux = saved
+        self.assertEqual([k for k in km._intr_marks_memo if k[0] == SID], [],
+                         "the session left the alive set: both of its entries are released")
+        self.assertEqual(self._stats()["evict"], s0["evict"] + 2)
+
+    def test_the_nudge_tick_reads_the_judge_entry_without_a_scan(self):
+        # the third per-cycle caller: the nudge tick's interrupt gate reads the judge parse through the memo, so after
+        # the interrupt tick has filled the (sid, "judge") entry the nudge tick text-scans no atom
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertIn((SID, "judge"), km._intr_marks_memo)
+        row = next(r for r in km._alive_sessions(NOW, self.tmux) if r["sid"] == SID)
+        s0 = self._stats()
+        c = _Counter(km.em, "is_interrupt_record")
+        try:
+            verdict = km._auto_nudge_session(row, NOW, self.tmux, {}, {}, alive_ids={SID})
+        finally:
+            c.close()
+        self.assertEqual(verdict, "user-interrupt", "the gate ruled on the interrupt")
+        self.assertEqual(len(c.calls), 0, "the nudge tick read the judge entry: no atom was text-scanned")
+        s1 = self._stats()
+        self.assertEqual(s1["hit"], s0["hit"] + 1); self.assertEqual(s1["miss"], s0["miss"])
+        self.assertEqual(sorted(k for k in km._intr_marks_memo if k[0] == SID), [(SID, "judge")], "no second entry was minted")
+
+    def test_the_cap_clears_the_memo(self):
+        saved = km._INTR_MARKS_MEMO_MAX
+        km._INTR_MARKS_MEMO_MAX = 4
+        try:
+            for i in range(4):
+                km._intr_marks_memo[("11111111-2222-3333-4444-%012d" % i, "judge")] = ([], (0.0, ""), (0, 0))
+            s0 = self._stats()
+            km._interrupt_marks(self._judge_turns(), SID, family="judge")
+            self.assertEqual(list(km._intr_marks_memo), [(SID, "judge")], "at the cap the memo is cleared whole")
+            self.assertEqual(self._stats()["evict"], s0["evict"] + 4)
+        finally:
+            km._INTR_MARKS_MEMO_MAX = saved
+
+
+class CounterBumpsAreAtomic(unittest.TestCase):
+    """The memo's counters are bumped from the pusher thread and from connect-time builds on socket threads at once,
+    so they go through _intr_marks_bump under a lock; a bare `+= 1` is a read-modify-write that loses increments.
+    Under the GIL alone the loss is rare, so a dict whose reads yield the thread forces the interleaving."""
+
+    def test_concurrent_bumps_lose_nothing(self):
+        class _Yielding(dict):
+            def get(self, k, d=None):
+                v = dict.get(self, k, d); time.sleep(0); return v
+
+            def __getitem__(self, k):
+                v = dict.__getitem__(self, k); time.sleep(0); return v
+        saved = km._intr_marks_memo_stats
+        km._intr_marks_memo_stats = _Yielding(saved)
+        try:
+            s0 = km._intr_marks_memo_stats["hit"]
+
+            def run():
+                for _ in range(300):
+                    km._intr_marks_bump("hit")
+            ts = [threading.Thread(target=run, daemon=True) for _ in range(8)]
+            for t in ts:
+                t.start()
+            for t in ts:
+                t.join(60)
+            self.assertFalse(any(t.is_alive() for t in ts))
+            self.assertEqual(km._intr_marks_memo_stats["hit"] - s0, 8 * 300)
+        finally:
+            km._intr_marks_memo_stats = saved
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -5809,8 +5809,8 @@ class ViewBuilder(unittest.TestCase):
             {"message": {"content": [{"type": "text", "text": "hi <!-- romp-msg-id: m1 -->"}]}},
             {"message": {"content": [{"type": "tool_result", "content": "inbox: <!-- romp-msg-id: m2 -->"}]}},
             {"message": {"content": "plain <!-- romp-msg-id: m3 -->"}}]}
-        self.assertEqual(set(km._seg_mids(seg)), {"m1", "m2", "m3"},
-                         "msg ids from text blocks, check_inbox tool_results, and string content")
+        self.assertEqual(km._seg_mids(seg), ["m1", "m2", "m3"],
+                         "msg ids from text blocks, check_inbox tool_results, and string content, in document order")
 
     def test_bind_message_exec_id_join(self):
         """A connector binds its exec to the recipient segment that carries its msg id (process-start),

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -485,6 +485,30 @@ class ViewBuilder(unittest.TestCase):
         s = {"turns": [{"atoms": created + pending}]}
         self.assertEqual(km._fold_tasks(s)[0]["status"], "completed", "no result yet is not a rejection")
 
+    def test_declared_plan_encodes_only_the_taskcreate_result_it_reads(self):
+        # event_model.declared_plan is this fold's twin (the #942 review asked that the two stay identical),
+        # so it takes the same read-side change: every result is stored as it came and only the TaskCreate
+        # result is encoded, at its one read. Before, both encoded every result up front, so a Bash result
+        # carrying a value json.dumps refuses aborted the fold; a list-shaped TaskCreate result yields the
+        # same Task #N in both, as it did when the whole result was encoded.
+        def _tu(name, inp, rid):
+            return {"type": "tool_use", "id": rid, "name": name, "input": inp}
+        def _tr(rid, content):
+            return {"type": "user", "message": {"content": [{"type": "tool_result", "tool_use_id": rid, "content": content}]}}
+        def _asst(*blocks):
+            return {"type": "assistant", "message": {"content": list(blocks)}}
+        s = {"turns": [{"atoms": [
+            _asst(_tu("Bash", {"command": "ls"}, "toolu_TEST0021")),
+            _tr("toolu_TEST0021", [{"type": "image", "source": {"data": object()}}]),
+            _asst(_tu("TaskCreate", {"subject": "vet the pairs", "activeForm": "Vetting the pairs"}, "toolu_TEST0022")),
+            _tr("toolu_TEST0022", [{"type": "text", "text": "Task #3 created successfully. Use TaskUpdate to update it."}]),
+            _asst(_tu("TaskUpdate", {"taskId": "3", "status": "in_progress"}, "toolu_TEST0023")),
+            _tr("toolu_TEST0023", "Task #3 updated.")]}]}
+        self.assertEqual([(t["key"], t["text"], t["activeForm"], t["status"]) for t in em.declared_plan(s)],
+                         [("3", "vet the pairs", "Vetting the pairs", "in_progress")])
+        self.assertEqual([(t["id"], t["subject"], t["activeForm"], t["status"]) for t in km._fold_tasks(s)],
+                         [("3", "vet the pairs", "Vetting the pairs", "in_progress")], "the kernel's fold reads the same")
+
     def test_fully_completed_store_drops_the_todo_card(self):
         # a done list is not a live to-do (the user 2026-06-10). At `track`'s screenshot time the store was
         # already all-completed, so the store-based card is correctly ABSENT — not a stale "3/5".

--- a/tests/test_kernel_pusher_snapshot.py
+++ b/tests/test_kernel_pusher_snapshot.py
@@ -12,6 +12,7 @@ SYNTHETIC fixtures only: placeholder UUIDs, invented names.
 import json
 import os
 import tempfile
+import time
 import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
@@ -31,9 +32,15 @@ jd = km.jd
 
 NOW = 1781100000
 SID = "11111111-2222-3333-4444-555555555555"
+SID2 = "11111111-2222-3333-4444-565656565656"   # a second session: the per-sid misses the discover memo removes
 
 
-class OneSnapshotPerCycle(unittest.TestCase):
+class _CycleFixture(unittest.TestCase):
+    """The shared world for the cycle tests: a hermetic state root, two sessions on disk (transcripts,
+    names, live rows), the kernel globals the tests replace saved and restored, and every scope slot
+    cleared after each test. No tests of its own: the concrete classes below derive from it, so each
+    test is collected once."""
+
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         td = Path(self.td.name)
@@ -57,11 +64,14 @@ class OneSnapshotPerCycle(unittest.TestCase):
         rec = {"type": "user", "timestamp": "2026-06-11T00:00:00.000Z", "uuid": "u1",
                "parentUuid": None, "promptSource": "typed",
                "message": {"role": "user", "content": "hello there"}}
-        (pdir / (SID + ".jsonl")).write_text(json.dumps(rec) + "\n")
-        (names / SID).write_text("web\t%s\t#abcdef\n" % str(cdir))
-        self.row = {SID: {"state": "waiting", "since": NOW - 5, "model": "", "effort": "",
-                          "context": None, "compactPct": None, "color": None, "mode": "",
-                          "backend": "tmux"}}
+        self.paths = {}
+        for sid, name in ((SID, "web"), (SID2, "api")):
+            self.paths[sid] = str(pdir / (sid + ".jsonl"))
+            (pdir / (sid + ".jsonl")).write_text(json.dumps(rec) + "\n")
+            (names / sid).write_text("%s\t%s\t#abcdef\n" % (name, str(cdir)))
+        meta = {"state": "waiting", "since": NOW - 5, "model": "", "effort": "", "context": None,
+                "compactPct": None, "color": None, "mode": "", "backend": "tmux"}
+        self.row = {SID: dict(meta), SID2: dict(meta)}
         self.saved_clients = list(km._clients)
 
     def tearDown(self):
@@ -70,8 +80,17 @@ class OneSnapshotPerCycle(unittest.TestCase):
          km._auto_nudge_tick, km._clear_done_working_notes) = self.saved
         with km._clients_lock:
             km._clients[:] = self.saved_clients
+        # every scope slot, so a failing test cannot leak a cycle's memo into the next on this thread
         km._live_scope.snapshot = None
+        km._live_scope.sessions = None
+        km._live_scope.paths = None
+        km._live_scope.names = None
+        km._compact_clicked.clear()
         self.td.cleanup()
+
+
+class OneSnapshotPerCycle(_CycleFixture):
+    """One liveness snapshot per cycle, handed to every job (the module docstring's fix)."""
 
     def test_one_cycle_reads_liveness_once_however_deep_the_call(self):
         # count REAL liveness reads (Sessions.live — the tmux fork + reg sweep), not the delegator:
@@ -109,6 +128,250 @@ class OneSnapshotPerCycle(unittest.TestCase):
         m = km.build_session(SID, NOW, dict(self.row))
         self.assertIsNotNone(m)
         self.assertEqual(reads, [], "a provided snapshot is enough — no fresh liveness reads")
+
+
+class OneDiscoverPerCycle(_CycleFixture):
+    """The cycle's discover rows are memoized on the scope, so the tick jobs' _alive_sessions calls, the
+    _path_of misses under _compacting_now and the builders share ONE _sessions sweep per (window, forks)
+    key — one fingerprint through _sessions — with or without a client. Fingerprints are attributed
+    through _sessions, not counted globally: direct jd.discover callers exist (the wide walk, postal
+    enrichment, analytics) and a global count is fixture-fragile."""
+
+    def _cycle(self, client):
+        depth, inside, outside, keys = [0], [], [], set()
+        orig_sessions, orig_fp = km._sessions, jd._discover_fingerprint
+
+        def sessions(now, window=None, forks=True):
+            keys.add((jd.WINDOW if window is None else int(window), bool(forks)))
+            depth[0] += 1
+            try:
+                return orig_sessions(now, window, forks)
+            finally:
+                depth[0] -= 1
+
+        def fp(*a, **k):
+            (inside if depth[0] else outside).append(1)
+            return orig_fp(*a, **k)
+        km._sessions, jd._discover_fingerprint = sessions, fp
+        km.Sessions.live = lambda: dict(self.row)
+        with km._clients_lock:
+            km._clients[:] = [client] if client else []
+        s0 = dict(km._sessions_scope_stats)
+        try:
+            km._pusher_cycle()
+        finally:
+            km._sessions, jd._discover_fingerprint = orig_sessions, orig_fp
+        s1 = km._sessions_scope_stats
+        return len(inside), keys, {k: s1[k] - s0[k] for k in s1}
+
+    def test_one_sweep_per_key_per_cycle_without_a_client(self):
+        fps, keys, d = self._cycle(None)
+        self.assertEqual(d["miss"], len(keys), "one _sessions sweep per (window, forks) key")
+        self.assertIn((jd.WINDOW, True), keys)
+        self.assertEqual(fps, d["miss"], "…and one discover fingerprint per sweep")
+        self.assertGreaterEqual(d["hit"], 5, "the tick jobs and the _path_of misses were served from the memo")
+        self.assertIsNone(km._live_scope.sessions, "the memo ends with the cycle")
+
+    def test_one_sweep_per_key_per_cycle_with_a_chat_client(self):
+        sent = []
+        fps, keys, d = self._cycle({"app": "chat", "alive": True, "wid": "", "qbytes": 0, "send": sent.append})
+        self.assertTrue(any('"type": "session"' in m for m in sent), "the push leg really built the sessions")
+        self.assertEqual(d["miss"], len(keys))
+        self.assertEqual(fps, d["miss"])
+        self.assertGreaterEqual(d["hit"], 5)
+        self.assertIsNone(km._live_scope.sessions)
+
+    def test_outside_a_cycle_every_read_is_fresh(self):
+        # the _tmux_sessions half of the idiom: a WS handler must never see a stale cycle's rows
+        km._live_scope.sessions = None
+        fps = []
+        orig = jd._discover_fingerprint
+        jd._discover_fingerprint = lambda *a, **k: fps.append(1) or orig(*a, **k)
+        s0 = dict(km._sessions_scope_stats)
+        try:
+            km._sessions(int(time.time()))
+            km._sessions(int(time.time()))
+        finally:
+            jd._discover_fingerprint = orig
+        self.assertEqual(len(fps), 2, "no scope, no memo: two reads are two sweeps")
+        self.assertEqual(dict(km._sessions_scope_stats), s0,
+                         "…and no counter moved: the stats are bumped only under an open scope, which is why they need no lock")
+
+    def test_a_hit_hands_out_a_copy_too(self):
+        # the docstring says hit OR miss: a consumer that appends to the FIRST hit's list must not grow the memo either
+        km._live_scope.sessions = {}
+        try:
+            now = int(time.time())
+            km._sessions(now)                                   # the miss
+            b = km._sessions(now)                               # the first hit
+            b.append({"sid": "11111111-2222-3333-4444-999999999999"})
+            c = km._sessions(now)
+            self.assertIsNot(c, b)
+            self.assertEqual(sorted(r["sid"] for r in c), sorted([SID, SID2]), "the mutation stayed with the hit's caller")
+        finally:
+            km._live_scope.sessions = None
+
+    def test_an_empty_window_is_still_one_sweep_per_cycle(self):
+        # an empty row list is a valid memo value: a kernel with no session in the window (and none live) must not
+        # re-sweep on every read of the cycle
+        old = time.time() - 3 * 86400
+        for path in self.paths.values():
+            os.utime(path, (old, old))
+        self.row = {}
+        fps, keys, d = self._cycle(None)
+        self.assertEqual(d["miss"], len(keys), "one sweep per key, the empty result memoized")
+        self.assertEqual(fps, d["miss"])
+        self.assertGreaterEqual(d["hit"], 5, "the tick jobs were served the empty list from the memo")
+
+    def test_the_key_is_normalized_like_discover(self):
+        # the memo key is normalized the way discover normalizes its own: None, the default window and a float
+        # spelling of it, with forks given as a truthy int, are one key (the docstring's promise; no in-cycle caller
+        # passes an explicit window today)
+        km._live_scope.sessions = {}
+        try:
+            s0 = dict(km._sessions_scope_stats)
+            now = int(time.time())
+            km._sessions(now)
+            km._sessions(now, window=jd.WINDOW)
+            km._sessions(now, window=float(jd.WINDOW), forks=1)
+            d = {k: km._sessions_scope_stats[k] - s0[k] for k in s0}
+            self.assertEqual((d["miss"], d["hit"]), (1, 2))
+            self.assertEqual(list(km._live_scope.sessions), [(jd.WINDOW, True)])
+        finally:
+            km._live_scope.sessions = None
+
+    def test_build_session_does_not_write_into_the_cycles_row(self):
+        # the row dicts are shared read-only across the cycle; build_session's one write (path_override) goes to a copy,
+        # or the override would leak into every later consumer of the cycle's rows
+        km._live_scope.sessions = {}
+        km.Sessions.live = lambda: dict(self.row)
+        try:
+            now = int(time.time())
+            m = km.build_session(SID, now, tmux=self.row, path_override=self.paths[SID2])
+            self.assertIsNotNone(m)
+            row = next(r for r in km._sessions(now) if r["sid"] == SID)
+            self.assertEqual(row["path"], self.paths[SID], "the override stayed with that build")
+        finally:
+            km._live_scope.sessions = None
+
+    def test_a_read_hands_out_a_copy_of_the_cycles_rows(self):
+        # the headless _alive_sessions fallback returns _sessions' list as its own; a consumer that
+        # appends to it must not grow the cycle's shared list for every later reader
+        km._live_scope.sessions = {}
+        try:
+            a = km._sessions(int(time.time()))
+            self.assertEqual(sorted(r["sid"] for r in a), sorted([SID, SID2]))
+            a.append({"sid": "11111111-2222-3333-4444-999999999999"})
+            b = km._sessions(int(time.time()))
+            self.assertIsNot(b, a)
+            self.assertEqual(sorted(r["sid"] for r in b), sorted([SID, SID2]), "the mutation stayed with the caller")
+            self.assertIs(b[0], km._sessions(int(time.time()))[0], "the row dicts themselves are shared")
+        finally:
+            km._live_scope.sessions = None
+
+    def test_a_live_session_older_than_the_window_walks_wide_once(self):
+        # a live sid idle longer than 48h is resolved by _alive_sessions' wide walk, which every
+        # _alive_sessions call in the cycle repeated before the memo (a fingerprint each)
+        old = time.time() - 3 * 86400
+        os.utime(self.paths[SID2], (old, old))
+        wide_calls = []
+        orig = jd.discover
+
+        def discover(now, window=None, forks=True):
+            if window == jd.DEATH_BACKFILL_WINDOW:
+                wide_calls.append(1)
+            return orig(now, window, forks)
+        jd.discover = discover
+        got = {}
+        km._clear_done_working_notes = lambda now, tmux: got.setdefault("alive", km._alive_sessions(now, tmux))
+        try:
+            fps, keys, d = self._cycle(None)
+        finally:
+            jd.discover = orig
+        self.assertEqual(sorted(r["sid"] for r in got["alive"]), sorted([SID, SID2]),
+                         "the old live session is still on every surface")
+        self.assertEqual(len(wide_calls), 1, "one wide walk per cycle")
+        self.assertEqual(d["wide_miss"], 1)
+        self.assertGreaterEqual(d["wide_hit"], 5, "…served to every other _alive_sessions call")
+        self.assertEqual(fps, d["miss"], "the 48h sweep still ran once")
+
+
+class TickReadsTheRowsPath(_CycleFixture):
+    """_interrupt_block_tick hands _compacting_now the row's own path and live meta. Beyond the saved
+    _path_of sweep, this is a behaviour change for a LIVE session idle longer than 48h: _path_of searched
+    only the 48h set and answered None, so the gate read an empty parse, and an optimistic compact click
+    could not be disproved by the session's own compact_boundary for the 180 s cap — the tick skipped the
+    row that long. With the row's path the gate reads the cached parse, and the boundary (the event)
+    retires the click."""
+
+    def _boundary_transcript(self, offset=0):
+        """SID2's transcript with a compact_boundary at now + offset (its mtime set idle longer than the caption
+        window), parsed into the cache as the background warm leaves it. Returns (path, now)."""
+        t = int(time.time())
+        recs = [{"type": "user", "timestamp": "2026-06-11T00:00:00.000Z", "uuid": "u1", "parentUuid": None,
+                 "promptSource": "typed", "message": {"role": "user", "content": "hello there"}},
+                {"type": "assistant", "timestamp": "2026-06-11T00:00:05.000Z", "uuid": "a1", "parentUuid": "u1",
+                 "message": {"role": "assistant", "content": [{"type": "text", "text": "hi"}],
+                             "stop_reason": "end_turn"}},
+                {"type": "system", "subtype": "compact_boundary", "uuid": "cb1", "parentUuid": None,
+                 "logicalParentUuid": "a1", "isMeta": False,
+                 "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(t + offset)),
+                 "compactMetadata": {"trigger": "manual", "preTokens": 1000, "postTokens": 100}}]
+        path = self.paths[SID2]
+        Path(path).write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        old = time.time() - 3 * 86400
+        os.utime(path, (old, old))                       # idle longer than the caption window
+        km._parse_cache.clear()
+        km._parse(path, SID2, int(time.time()))          # the cached parse holds the boundary, as the background warm leaves it
+        return path, t
+
+    def test_the_rows_path_lets_the_boundary_disprove_an_optimistic_click(self):
+        path, t = self._boundary_transcript()
+        km.Sessions.live = lambda: dict(self.row)
+        km._compact_clicked[SID2] = t - 10               # the kernel sent /compact just before the boundary
+        self.assertTrue(km._compacting_now(SID2), "without the row's path the 48h search finds no transcript: "
+                                                 "the click stands unproven for the whole cap (the old read)")
+        km._compact_clicked[SID2] = t - 10
+        self.assertFalse(km._compacting_now(SID2, tm=self.row[SID2], path=path),
+                         "with the row's path the cached parse's boundary retires the click")
+        self.assertNotIn(SID2, km._compact_clicked, "…on the event, not a timer")
+
+    def test_the_tick_reads_the_rows_own_live_meta(self):
+        # The tick hands _compacting_now the row's live meta beside its path, so the gate reads the CYCLE's `since`
+        # (when the row's state began) rather than refetching liveness per row. Visible when the two diverge: a
+        # boundary that landed after the row's state began but BEFORE the click does not retire the click by itself,
+        # and it is the row's `since` that reads the compaction as over (a boundary since the state's start); a
+        # refetched meta whose `since` postdates the boundary would keep the session reading as compacting, and the
+        # tick would skip the row.
+        path, t = self._boundary_transcript(offset=-20)        # the boundary 20 s ago
+        fetched = {sid: dict(m) for sid, m in self.row.items()}
+        fetched[SID2]["since"] = t + 3600                       # a fresh liveness read: a state that began after the boundary
+        km.Sessions.live = lambda: dict(fetched)
+        self.row[SID2]["since"] = NOW - 5                       # the cycle's row: its state began before the boundary
+        km._compact_clicked[SID2] = t - 10                      # clicked after the boundary: the boundary alone leaves it standing
+        seen = []
+        saved = km._api_error
+        km._api_error = lambda p: seen.append(p) or {"text": "overloaded"}   # truthy: the tick stops at this gate
+        try:
+            km._interrupt_block_tick(int(time.time()), self.row)
+        finally:
+            km._api_error = saved
+        self.assertIn(path, seen, "with the row's own meta the gate read the compaction as over: the tick reached the next gate")
+        self.assertIn(SID2, km._compact_clicked, "the click itself stands: no boundary followed it")
+
+    def test_the_tick_no_longer_skips_the_old_live_session(self):
+        path, t = self._boundary_transcript()
+        km.Sessions.live = lambda: dict(self.row)
+        km._compact_clicked[SID2] = t - 10
+        seen = []
+        saved = km._api_error
+        km._api_error = lambda p: seen.append(p) or {"text": "overloaded"}   # truthy: the tick stops at this gate
+        try:
+            km._interrupt_block_tick(int(time.time()), self.row)
+        finally:
+            km._api_error = saved
+        self.assertIn(path, seen, "the tick reached the row's next gate: the compacting gate read the real parse")
+        self.assertNotIn(SID2, km._compact_clicked)
 
 
 class LazyChatSerialization(unittest.TestCase):

--- a/tests/test_kernel_pusher_snapshot.py
+++ b/tests/test_kernel_pusher_snapshot.py
@@ -170,8 +170,12 @@ class LazyChatSerialization(unittest.TestCase):
             km._built_timeline[:] = [None, None, 0.0, 0.0]
             km._pusher_cycle()
             w_feed, w_bars = km._feed_wire, km._bars_wire
-            self.assertIsNotNone(w_feed, "the first cycle serialized the feed once")
-            self.assertIsInstance(w_feed[3], str)
+            self.assertIsNotNone(w_feed, "the first cycle made the feed's wire form once")
+            # the body is a lazy cell: this feed client announces no delta, so its whole frame went and the cell
+            # holds the one whole encode of the build; the signature is the split's tuple
+            self.assertIsInstance(w_feed[3], km._LazyWire)
+            self.assertTrue(w_feed[3].materialized(), "a legacy client took the whole frame: serialized once")
+            self.assertEqual(w_feed[4], km._parts_sig(w_feed[5]))
             n = len(frames)
             km._pusher_cycle()
             self.assertIs(km._feed_wire, w_feed, "unchanged feed → the SAME wire tuple, no re-dump")

--- a/tests/test_kernel_timeline_split.py
+++ b/tests/test_kernel_timeline_split.py
@@ -5,10 +5,17 @@ build_timeline(with_bars=False) builds only the LANES SKELETON (sessions/status,
 nudges); _push sends it as {type:"data"} FIRST, then the cached full build's detail rides a {type:"bars"}
 message. Profiling drove this: the timeline was 551ms/1940KB and ~95% of that is bars+judging, so the
 skeleton is tiny and lands immediately. (The dead `tokens` field — nothing reads it — was dropped too.)
+
+The skeleton BUILD runs only on the cold live-first connect. A warm push PROJECTS the skeleton from the cached
+full build (_timeline_skeleton), serializes the frame once per build (_skel_wire) and dedups it on content the
+way every {type:"data"} frame is deduped (the nested clock stripped) — see SkeletonFromCache below. An interval
+a session is still in ends at the build's clock on the wire (OpenIntervals below); the renderer reads an end
+within 2 s of data.now as open.
 """
 import inspect
 import json
 import os
+import time
 import unittest
 from importlib.machinery import SourceFileLoader
 import tempfile
@@ -85,7 +92,7 @@ class TimelinePageLoader(unittest.TestCase):
 
 class PushSplit(unittest.TestCase):
     def test_push_ships_the_lanes_skeleton_before_the_bars(self):
-        sent = []
+        sent, builds = [], []
         client = {"app": "timeline", "send": sent.append, "sent": {}, "alive": True}
         SKEL = {"type": "timeline", "sessions": [{"id": "S"}], "turns": {}, "judging": [],
                 "messages": [], "now": 1, "usage": {}}
@@ -93,7 +100,8 @@ class PushSplit(unittest.TestCase):
                 "judging": [{"k": "planner"}], "messages": [{"m": 1}], "now": 1}
         o_bt, o_ct, o_tmux, o_sig = (km.build_timeline, km._cached_timeline,
                                      km._tmux_sessions, km._fleet_view_sig)
-        km.build_timeline = lambda now, tmux, with_bars=True, live_only=False: (FULL if with_bars else SKEL)
+        km.build_timeline = lambda now, tmux, with_bars=True, live_only=False: (
+            builds.append(with_bars) or (FULL if with_bars else SKEL))
         km._cached_timeline = lambda now, tmux, sig, connect=False: FULL
         km._tmux_sessions = lambda: {}
         km._fleet_view_sig = lambda now, tmux: ("sig",)
@@ -113,6 +121,8 @@ class PushSplit(unittest.TestCase):
         self.assertEqual(bars["turns"], {"S": [{"id": "b1"}]}, "the heavy bars ride the {type:bars} message")
         for k in ("judging", "messages"):
             self.assertIn(k, bars, "the whole time-plotted detail rides the bars message")
+        self.assertEqual(builds, [], "a warm push builds no skeleton: the lanes are projected from the cache")
+        self.assertEqual(skel["sessions"], FULL["sessions"], "…and they are the cached build's lanes")
 
     def test_a_steady_push_of_an_unchanged_timeline_sends_no_bars_and_a_rebuilt_one_sends_a_slotted_delta(self):
         """The pusher hands _send_slot the same bars object while the cached timeline's identity holds (_bars_wire),
@@ -155,6 +165,410 @@ class PushSplit(unittest.TestCase):
         self.assertEqual([k for k, _m in bars], [("timelinebars",), ("timelinebars",)],
                          "both bars frames went with the slot key on the client")
         self.assertEqual(set(bars[1][1]["coll"]["turns"]["set"]), {"S\u001fb2"}, "one bar crosses")
+
+
+class SkeletonFromCache(unittest.TestCase):
+    """The warm-path skeleton is a PROJECTION of the cached full build. Every pusher cycle used to run
+    build_timeline(with_bars=False) — no parse, but the same per-lane derivation the cached full build had just
+    done — and then serialized the frame and re-dumped it once more per client for the dedup compare. A hit
+    now serves the last rebuild's lanes byte-for-byte, so a lane moves only when the timeline rebuilds: on a
+    view-sig change, on _mark_views_dirty, or at the 5 s bucket. The frame is deduped on CONTENT, the nested
+    clock stripped, as every {type:"data"} frame is: a rebuild whose lanes are unchanged sends nothing, and the
+    60 s repost is what refreshes the pane's clock sample."""
+
+    FULL = {"type": "timeline", "now": 1,
+            "sessions": [{"id": "S", "name": "web", "state": "working", "context": 10,
+                          "compactions": [{"t": 5}]}],
+            "turns": {"S": [{"id": "b1"}]}, "judging": [{"k": "planner"}], "messages": [{"m": 1}],
+            "views": {"active": "all"}, "usage": {"five": {"pct": 3}}}
+
+    class _Clock:
+        """km's `time` with a settable skew on time() — so two pushes can carry different clocks without
+        sleeping, and everything else (monotonic, sleep) passes through."""
+        def __init__(self, real):
+            self._real, self.skew = real, 0.0
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+        def time(self):
+            return self._real.time() + self.skew
+
+    def setUp(self):
+        self.saved = (km.build_timeline, km._cached_timeline, km._tmux_sessions, km._fleet_view_sig, km.time)
+        self.saved_built, self.saved_dirty = list(km._built_timeline), km._views_dirty[0]
+        self.saved_wire = (km._bars_wire, km._skel_wire)
+        km._bars_wire = km._skel_wire = None
+        self.builds = []
+        km.build_timeline = lambda now, tmux, with_bars=True, live_only=False: (
+            self.builds.append((with_bars, live_only)) or self.rebuilt())
+        km._cached_timeline = lambda now, tmux, sig, connect=False: self.FULL
+        km._tmux_sessions = lambda: {}
+        km._fleet_view_sig = lambda now, tmux: ("sig",)
+        self.clock = km.time = self._Clock(time)
+
+    def tearDown(self):
+        (km.build_timeline, km._cached_timeline, km._tmux_sessions, km._fleet_view_sig, km.time) = self.saved
+        km._built_timeline[:] = self.saved_built
+        km._views_dirty[0] = self.saved_dirty
+        km._bars_wire, km._skel_wire = self.saved_wire
+
+    def rebuilt(self, now=2):
+        return dict(self.FULL, now=now, sessions=[dict(self.FULL["sessions"][0], state="ready")])
+
+    @staticmethod
+    def _client():
+        frames = []
+        return {"app": "timeline", "send": frames.append, "sent": {}, "alive": True}, frames
+
+    @staticmethod
+    def _data_frames(frames):
+        return [json.loads(f) for f in frames if json.loads(f)["type"] == "data"]
+
+    def test_two_pushes_over_an_unchanged_cache_build_nothing_and_resend_no_lanes(self):
+        c, frames = self._client()
+        km._push([c])
+        first = list(frames)
+        self.clock.skew = 7.0                       # a later second AND a later 5 s bucket: only the clock moved
+        km._push([c])
+        self.assertEqual(self.builds, [], "a warm push runs no build_timeline at all — no skeleton build")
+        data = self._data_frames(first)
+        self.assertEqual(len(data), 1, "the first push ships the lanes frame")
+        self.assertEqual(data[0]["data"]["sessions"], self.FULL["sessions"], "…as the cached build's lanes")
+        self.assertEqual(data[0]["data"]["now"], self.FULL["now"], "…stamped with the BUILD's clock, not the cycle's")
+        self.assertEqual(data[0]["data"]["turns"], {})
+        self.assertEqual(data[0]["data"]["judging"], [])
+        self.assertEqual(data[0]["data"]["messages"], [])
+        self.assertEqual(data[0]["data"]["usage"], self.FULL["usage"], "usage rides the projected skeleton")
+        second = frames[len(first):]
+        self.assertEqual(sum(len(f) for f in second if json.loads(f)["type"] == "data"), 0,
+                         "the second push sent zero bytes on the lanes slot: the same cached build, nothing new")
+        self.assertEqual(self.FULL["turns"], {"S": [{"id": "b1"}]}, "the cached build itself is never mutated")
+        self.assertEqual(self.FULL["now"], 1)
+
+    def test_the_projection_is_a_copy_with_the_build_clock_and_dedups_on_content(self):
+        skel = km._timeline_skeleton(self.FULL)
+        self.assertEqual(skel["now"], self.FULL["now"], "the projected frame carries the build's clock")
+        self.assertEqual((skel["turns"], skel["judging"], skel["messages"]), ({}, [], []))
+        self.assertEqual(skel["sessions"], self.FULL["sessions"])
+        self.assertIsNot(skel, self.FULL)
+        self.assertEqual(self.FULL["turns"], {"S": [{"id": "b1"}]}, "a projection is a copy, not a mutation")
+
+        def sig(tl):
+            frame = {"type": "data", "data": km._timeline_skeleton(tl)}
+            return km._dedup_sig(frame, json.dumps(frame))
+        self.assertEqual(sig(self.FULL), sig(dict(self.FULL, now=2)),
+                         "two builds whose lanes agree dedup whatever their clocks: the nested `now` is stripped")
+        self.assertNotEqual(sig(self.FULL), sig(self.rebuilt(now=1)), "a lane state change compares different")
+
+    def test_a_rebuild_with_unchanged_lanes_sends_nothing_and_a_changed_one_sends_one_frame(self):
+        # The frame dedups on content, so a rebuild is not by itself a send: the 5 s bucket rolling on a quiet
+        # timeline rebuilds once and ships nothing (the 60 s repost, _DEDUP_REPOST_S, refreshes the clock), a
+        # rebuild that moved a lane ships exactly one frame carrying the new build's clock, and the cycles
+        # between rebuilds send nothing at all.
+        km._cached_timeline = self.saved[1]             # the real cache
+        sig, lanes = [("sig",)], [self.FULL["sessions"]]
+        km._fleet_view_sig = lambda now, tmux: sig[0]
+        km.build_timeline = lambda now, tmux, with_bars=True, live_only=False: (
+            self.builds.append((with_bars, live_only)) or dict(self.FULL, now=now, sessions=lanes[0]))
+        t = time.time()
+        km._built_timeline[:] = [("sig",), self.FULL, t, t]
+        km._views_dirty[0] = 0.0
+        c, frames = self._client()
+        km._push([c])                                   # cycle 1: a hit → the client's first frame
+        self.clock.skew = 1.0
+        km._push([c])                                   # cycle 2: the same build → nothing
+        self.assertEqual(self.builds, [])
+        data = self._data_frames(frames)
+        self.assertEqual(len(data), 1, "two cycles on one cached build send the lanes frame once")
+        self.assertEqual(data[0]["data"]["now"], self.FULL["now"])
+        n = len(frames)
+        self.clock.skew, sig[0] = 7.0, ("sig", "next bucket")   # the bucket rolled: a rebuild with identical lanes
+        km._push([c])
+        self.assertEqual(self.builds, [(True, False)], "the rebuild ran once, and built no skeleton")
+        self.assertEqual(frames[n:], [], "identical lanes under a new clock: no lanes frame, no bars frame")
+        n = len(frames)
+        self.clock.skew, sig[0] = 14.0, ("sig", "a lane moved")
+        lanes[0] = self.rebuilt()["sessions"]
+        km._push([c])
+        self.assertEqual(self.builds, [(True, False), (True, False)])
+        data = self._data_frames(frames[n:])
+        self.assertEqual(len(data), 1, "a rebuild that changed a lane sends the lanes frame once")
+        self.assertEqual(data[0]["data"]["sessions"][0]["state"], "ready", "…carrying the rebuild's lanes")
+        self.assertGreaterEqual(data[0]["data"]["now"], int(t + 14), "…stamped with the new build's clock")
+        self.assertLessEqual(data[0]["data"]["now"], int(self.clock.time()))
+        n = len(frames)
+        self.clock.skew = 15.0
+        km._push([c])                                   # a cycle between rebuilds → nothing
+        self.assertEqual(self.builds, [(True, False), (True, False)])
+        self.assertEqual(frames[n:], [], "an unchanged cycle between rebuilds sends nothing at all")
+
+    def test_a_connect_push_stamps_the_cached_lanes_with_the_cycle_clock(self):
+        # A fresh pane anchors its live edge and window fit on the first data.now it sees, and the cache is as
+        # old as the last cycle that had a timeline client (a bucket on a reload; hours after the pane was
+        # closed), so the build clock would sit the axis in the past. The connect frame carries the cycle's
+        # clock; the next regular cycle's build-clock frame has the same content once the clock is stripped,
+        # so it dedups and the pane keeps the sample it anchored on.
+        km._built_timeline[:] = [("sig",), self.FULL, 1.0, 1.0]     # a warm cache whose build clock (FULL["now"] = 1) is ancient
+        c, frames = self._client()
+        km._push([c], connect=True)
+        self.assertEqual(self.builds, [], "a warm connect builds nothing: the cached lanes are served")
+        data = self._data_frames(frames)
+        self.assertEqual(len(data), 1)
+        self.assertGreaterEqual(data[0]["data"]["now"], int(time.time()) - 1, "…under the cycle's clock, not the cached build's")
+        self.assertEqual(data[0]["data"]["sessions"], self.FULL["sessions"], "…over the cached lanes")
+        self.assertEqual(self.FULL["now"], 1, "the cached build is not restamped")
+        n = len(frames)
+        km._push([c])                                   # the next regular cycle: the same lanes under the build clock
+        self.assertEqual(self._data_frames(frames[n:]), [], "…which dedups: the same content, the clock stripped")
+        n = len(frames)
+        km._push([c])
+        self.assertEqual(self._data_frames(frames[n:]), [], "…and unchanged cycles send nothing after that")
+
+    def test_a_dirty_mark_between_two_pushes_rebuilds_and_ships_the_new_lanes(self):
+        km._cached_timeline = self.saved[1]             # the real cache, warmed with FULL under the stubbed sig
+        km._built_timeline[:] = [("sig",), self.FULL, time.time(), time.time()]
+        km._views_dirty[0] = 0.0
+        c, frames = self._client()
+        km._push([c])
+        self.assertEqual(self.builds, [], "an unchanged sig on a warm cache is a hit")
+        n = len(frames)
+        km._mark_views_dirty()                          # an optimistic kernel-side mutation: the deciding event
+        km._push([c])
+        self.assertEqual(self.builds, [(True, False)], "the dirty mark rebuilt the FULL timeline, once, and no skeleton")
+        data = self._data_frames(frames[n:])
+        self.assertEqual(len(data), 1, "the rebuilt lanes ship")
+        self.assertEqual(data[0]["data"]["sessions"][0]["state"], "ready", "…carrying the rebuild's state")
+
+    def test_the_skeleton_carries_the_cached_builds_compactions(self):
+        # The built skeleton set session = {"turns": []}, so its `compactions` was always [] and the
+        # timeline never drew a compaction marker; the projection carries the full build's list, which
+        # comes from the fresh parse (the authoritative source). The stub below is the OLD skeleton's
+        # shape (no compactions), so a push that built a skeleton would ship [] here.
+        km.build_timeline = lambda now, tmux, with_bars=True, live_only=False: (
+            self.rebuilt() if with_bars else dict(self.FULL, turns={}, judging=[], messages=[],
+                                                  sessions=[dict(self.FULL["sessions"][0], compactions=[])]))
+        c, frames = self._client()
+        km._push([c])
+        lane = self._data_frames(frames)[0]["data"]["sessions"][0]
+        self.assertEqual(lane["compactions"], [{"t": 5}])
+
+    def test_the_view_sig_keys_every_row_field_the_lanes_read(self):
+        # The sig read `ctx`, which no liveness row carries (rows write `context`), so a context-% change
+        # never busted the cache; the fast-mode reason, the subagent rows and the task ids were never keyed.
+        # With the skeleton projected from the cache, each of these must bust it or the lane holds the old
+        # value until the bucket.
+        sig = self.saved[3]
+        row = {"state": "working", "model": "m", "effort": "high", "mode": "", "fast": "on", "since": 100,
+               "context": 10, "fastReason": "", "modelPending": False, "effortPending": False,
+               "authPending": False, "retryCount": 0, "connected": True, "spawning": False,
+               "subagents": [], "bgTasks": []}
+        base = sig(1000, {"S": dict(row)})
+        self.assertEqual(base, sig(1000, {"S": dict(row)}), "stable on identical rows")
+        for k, v in (("context", 20), ("fastReason", "cooldown"), ("modelPending", True),
+                     ("effortPending", True), ("authPending", True), ("retryCount", 3),
+                     ("connected", False), ("spawning", True),
+                     ("subagents", [{"type": "Explore", "since": 90}]),
+                     ("bgTasks", [{"toolUseId": "t1", "desc": "watch the build", "since": 90}])):
+            self.assertNotEqual(base, sig(1000, {"S": {**row, k: v}}), "%s must bust the view sig" % k)
+        one = {**row, "subagents": [{"type": "Explore", "since": 90}]}
+        self.assertNotEqual(sig(1000, {"S": one}), sig(1000, {"S": {**row, "subagents": [{"type": "Explore", "since": 95}]}}),
+                            "a subagent row's fields count, not only how many rows there are: the lane ships the list")
+        self.assertEqual(sig(1000, {"S": {**row, "bgTasks": [{"toolUseId": "t1", "lastTool": "Read"}]}}),
+                         sig(1000, {"S": {**row, "bgTasks": [{"toolUseId": "t1", "lastTool": "Grep"}]}}),
+                         "a task's progress fields are not a lane fact: keyed on the task ids only")
+        self.assertNotEqual(sig(1000, {"S": {**row, "bgTasks": [{"toolUseId": "t1"}]}}),
+                            sig(1000, {"S": {**row, "bgTasks": [{"toolUseId": "t2"}]}}),
+                            "…and a swapped task with the same count busts it")
+        self.assertEqual(base, sig(1000, {"S": {**row, "snapT": 123456.0}}), "the snapshot's clock stays out")
+        self.assertEqual(base, sig(1000, {"S": {**row, "interrupting": True}}),
+                         "`interrupting` is not keyed: the merged liveness row never carries it (the SDK merge copies "
+                         "an explicit key list), and the WS stop op marks the views dirty itself")
+
+    def test_the_view_sig_stats_the_files_the_lanes_read(self):
+        sig = self.saved[3]
+        st = km.jd.STATE
+        st.mkdir(parents=True, exist_ok=True)
+        usage, views, watches = st / "usage.json", km._views_path(), km.WATCH_FILE
+        csid = "33333333-4444-4444-4444-555555555555"     # a private synthetic sid: a comment thread's parent
+        cdir, cfile = st / "comments", km._comments_path(csid)
+        for f in (usage, views, watches, cfile):
+            if f.exists():
+                f.unlink()
+        try:
+            base = sig(1000, {})
+            usage.write_text(json.dumps({"five_hour": {"pct": 12}}))
+            with_usage = sig(1000, {})
+            self.assertNotEqual(base, with_usage, "a usage.json write busts the sig: the lanes frame carries the usage bars")
+            views.write_text(json.dumps({"active": "all", "tags": []}))
+            with_views = sig(1000, {})
+            self.assertNotEqual(with_usage, with_views, "a timeline-views.json write busts the sig: the views blob rides every frame")
+            km._save_comments(csid, {"threads": [{"tid": "t1", "status": "open", "createdT": 900}]})
+            with_comment = sig(1000, {})
+            self.assertNotEqual(with_views, with_comment, "a first comment thread busts the sig: the lane's squares read the store")
+            # a REWRITE of the same file (a resolve on a dormant thread changes only the store): the atomic
+            # replace lands in the comments directory, so its mtime moves — aged first, so the check does
+            # not ride on the clock's granularity
+            os.utime(cdir, (1_000_000, 1_000_000))
+            aged = sig(1000, {})
+            km._save_comments(csid, {"threads": [{"tid": "t1", "status": "resolved", "createdT": 900}]})
+            self.assertNotEqual(aged, sig(1000, {}), "a resolve on an existing thread busts the sig too")
+            before_watch = sig(1000, {})
+            watches.write_text("[]")
+            self.assertNotEqual(before_watch, sig(1000, {}), "a watches.json write busts the sig: the awaiting badge reads the watches")
+        finally:
+            for f in (usage, views, watches, cfile):
+                if f.exists():
+                    f.unlink()
+            try:
+                cdir.rmdir()
+            except OSError:
+                pass
+
+
+class SkeletonSerializedOncePerBuild(unittest.TestCase):
+    """The lanes frame is serialized once per BUILD (_skel_wire) and every timeline client is handed that
+    serialization and its signature (pre=skel_pre, sig=skel_sig): a warm cycle over an unchanged cache encodes
+    nothing on the lanes slot, however many clients are connected. Pinned on json.dumps calls through the real
+    _push (a memo dropped, or a client re-dumping the frame for its own compare, both show up as calls)."""
+
+    FULL = SkeletonFromCache.FULL
+
+    class _Json:
+        """km's `json` with dumps() counted; everything else passes through."""
+        def __init__(self, real):
+            self._real, self.dumps_calls = real, 0
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+        def dumps(self, *a, **k):
+            self.dumps_calls += 1
+            return self._real.dumps(*a, **k)
+
+    def setUp(self):
+        self.saved = (km.build_timeline, km._cached_timeline, km._tmux_sessions, km._fleet_view_sig, km.json)
+        self.saved_wire = (km._skel_wire, km._bars_wire)
+        km._skel_wire = km._bars_wire = None
+        km.build_timeline = lambda *a, **k: self.fail("a warm push builds nothing")
+        km._cached_timeline = lambda now, tmux, sig, connect=False: self.FULL
+        km._tmux_sessions = lambda: {}
+        km._fleet_view_sig = lambda now, tmux: ("sig",)
+        self.json = km.json = self._Json(json)
+
+    def tearDown(self):
+        (km.build_timeline, km._cached_timeline, km._tmux_sessions, km._fleet_view_sig, km.json) = self.saved
+        km._skel_wire, km._bars_wire = self.saved_wire
+
+    def test_two_clients_share_one_serialization_and_a_warm_cycle_encodes_nothing(self):
+        c1, f1 = SkeletonFromCache._client()
+        c2, f2 = SkeletonFromCache._client()
+        km._push([c1, c2])
+        d1 = [f for f in f1 if json.loads(f)["type"] == "data"]
+        d2 = [f for f in f2 if json.loads(f)["type"] == "data"]
+        self.assertEqual(len(d1), 1); self.assertEqual(len(d2), 1)
+        self.assertEqual(d1[0], d2[0], "byte-identical: the one serialization went to both")
+        self.json.dumps_calls = 0
+        km._push([c1, c2])
+        self.assertEqual(self.json.dumps_calls, 0,
+                         "the second cycle encoded nothing: the frame, its signature and the bars all came from the wire caches")
+        self.assertEqual(len([f for f in f1 + f2 if json.loads(f)["type"] == "data"]), 2, "…and sent no lanes frame")
+
+
+class ProjectionMatchesColdSkeleton(unittest.TestCase):
+    """The warm projection (_timeline_skeleton over the full build) and the cold-connect skeleton build
+    (build_timeline(with_bars=False)) are ONE wire shape: the same keys, the same lane fields and values, differing
+    only where the commit says they may — a lane's `compactions` (the built skeleton parses nothing and ships [])
+    and a dead lane's `since` — since the renderer reads both frames through one code path."""
+
+    SID = "66666666-7777-8888-9999-bbbbbbbbbbbb"      # a private synthetic sid
+
+    def setUp(self):
+        self.now = int(time.time())
+        d = km.jd.STATE / "synthetic-transcripts"
+        d.mkdir(parents=True, exist_ok=True)
+        self.path = d / (self.SID + ".jsonl")
+        iso = lambda t: time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(t))
+        recs = [{"type": "user", "timestamp": iso(self.now - 600), "uuid": "u1", "parentUuid": None,
+                 "promptSource": "typed", "message": {"role": "user", "content": "wire up the reconnect banner"}},
+                {"type": "assistant", "timestamp": iso(self.now - 590), "uuid": "a1", "parentUuid": "u1",
+                 "message": {"role": "assistant", "content": [{"type": "text", "text": "done"}], "stop_reason": "end_turn"}}]
+        self.path.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        self.saved = km._timeline_sessions
+        km._timeline_sessions = lambda now, tmux, live_only=False: [
+            {"sid": self.SID, "name": "web", "anchor": None, "path": str(self.path), "mtime": self.now - 590}]
+        self.live = {self.SID: {"state": "working", "since": self.now - 590, "model": "m", "effort": "high",
+                                "context": 42, "compactPct": None, "color": None, "mode": ""}}
+
+    def tearDown(self):
+        km._timeline_sessions = self.saved
+        km._parse_cache.pop(str(self.path), None)
+        if self.path.exists():
+            self.path.unlink()
+
+    def test_the_projection_and_the_cold_skeleton_are_one_wire_shape(self):
+        full = km.build_timeline(self.now, self.live, with_bars=True)     # the full build first: the cold path reads its cached parse
+        cold = km.build_timeline(self.now, self.live, with_bars=False)
+        proj = km._timeline_skeleton(full)
+        self.assertEqual(set(proj), set(cold), "the same top-level keys")
+        self.assertEqual((proj["turns"], proj["judging"], proj["messages"]),
+                         (cold["turns"], cold["judging"], cold["messages"]), "the heavy fields are empty on both")
+        self.assertEqual(len(proj["sessions"]), 1); self.assertEqual(len(cold["sessions"]), 1)
+        p, c = proj["sessions"][0], cold["sessions"][0]
+        self.assertEqual(set(p), set(c), "the same lane fields")
+        self.assertLessEqual({k for k in p if p[k] != c[k]}, {"compactions", "since"},
+                             "…with the same values, but for the two documented differences")
+        self.assertEqual(p["state"], c["state"], "the cold path derives the chip over the cached parse, as the full build did")
+        self.assertNotEqual(p["state"], "working", "…not the raw snapshot state (the turn ended)")
+        self.assertEqual(p["context"], 42); self.assertTrue(p["live"])
+
+
+class OpenIntervals(unittest.TestCase):
+    """An interval the session is STILL in ends at the build's clock on the wire — the contract the
+    renderer's open detection reads (an end within 2 s of the payload's `now` is open). Pinned because a null
+    end would be a wire break: every already-loaded renderer (an open dashboard, an installed extension) takes
+    Math.min(null, t1) = 0 and drops the stripe for a lane blocked or compacting right now. The clock-stamped
+    end costs no per-cycle work: the lanes frame is serialized once per build, and while the state lasts the
+    frame goes once per rebuild — where the per-cycle skeleton sent it every cycle."""
+
+    SID = "66666666-7777-8888-9999-aaaaaaaaaaaa"      # a private synthetic sid
+
+    def setUp(self):
+        self.p = km.jd.STATE / "states" / (self.SID + ".jsonl")
+        self.p.parent.mkdir(parents=True, exist_ok=True)
+        km._state_ev_cache.pop(str(self.p), None)
+        self.now = 1_000_000
+        with open(self.p, "w") as f:
+            for row in ({"t": self.now - 400, "state": "permission"}, {"t": self.now - 300, "state": "working"},
+                        {"t": self.now - 100, "state": "permission"}):
+                f.write(json.dumps(row) + "\n")
+
+    def tearDown(self):
+        if self.p.exists():
+            self.p.unlink()
+        km._state_ev_cache.pop(str(self.p), None)
+
+    def test_an_open_interval_ends_at_the_build_clock_and_a_closed_one_at_its_transition(self):
+        now = self.now
+        self.assertEqual(km._state_intervals(self.SID, km._NEEDS_INPUT_STATES, now),
+                         [[now - 400, now - 300], [now - 100, now]])
+        self.assertEqual(km._state_intervals(self.SID, "compacting", now), [])
+        wire = json.loads(json.dumps(km._state_intervals(self.SID, "permission", now)))
+        self.assertEqual(wire[-1][1], now, "the open end serializes as the numeric clock, never null")
+
+    def test_the_lane_payload_ends_the_open_interval_at_its_own_clock(self):
+        o_ts = km._timeline_sessions
+        km._timeline_sessions = lambda now, tmux, live_only=False: [
+            {"sid": self.SID, "name": "web", "path": "/no/such/transcript-web"}]
+        live = {self.SID: {"state": "permission", "since": self.now - 100, "model": "", "effort": "",
+                           "context": None, "compactPct": None, "color": None, "mode": ""}}
+        try:
+            tl = km.build_timeline(self.now, live, with_bars=False)
+        finally:
+            km._timeline_sessions = o_ts
+        lane = tl["sessions"][0]
+        self.assertEqual(lane["awaiting"], [[self.now - 400, self.now - 300], [self.now - 100, self.now]])
+        self.assertEqual(lane["awaiting"][-1][1], tl["now"], "the open end equals the payload's clock: what the renderer reads as open")
 
 
 class DeadLaneWindow(unittest.TestCase):

--- a/tests/test_kernel_timeline_split.py
+++ b/tests/test_kernel_timeline_split.py
@@ -9,8 +9,10 @@ skeleton is tiny and lands immediately. (The dead `tokens` field — nothing rea
 The skeleton BUILD runs only on the cold live-first connect. A warm push PROJECTS the skeleton from the cached
 full build (_timeline_skeleton), serializes the frame once per build (_skel_wire) and dedups it on content the
 way every {type:"data"} frame is deduped (the nested clock stripped) — see SkeletonFromCache below. An interval
-a session is still in ends at the build's clock on the wire (OpenIntervals below); the renderer reads an end
-within 2 s of data.now as open.
+a session is still in ends at the build's clock on the wire and carries an explicit open mark as its third
+element (OpenIntervals below); the renderer reads the mark, never the distance between the end and data.now
+(review find, 2026-09-08: a connect frame re-stamps the cycle clock over a cached build, so that distance is
+the cache's age, not a fact about the lane).
 """
 import inspect
 import json
@@ -310,6 +312,8 @@ class SkeletonFromCache(unittest.TestCase):
         # clock; the next regular cycle's build-clock frame has the same content once the clock is stripped,
         # so it dedups and the pane keeps the sample it anchored on.
         km._built_timeline[:] = [("sig",), self.FULL, 1.0, 1.0]     # a warm cache whose build clock (FULL["now"] = 1) is ancient
+        km._views_dirty[0] = 0.0                        # …and FRESH by the kernel's own rule: built under the cycle's sig, no
+        #                                                 dirty mark since (a stale cache builds its lanes fresh: the tests below)
         c, frames = self._client()
         km._push([c], connect=True)
         self.assertEqual(self.builds, [], "a warm connect builds nothing: the cached lanes are served")
@@ -324,6 +328,36 @@ class SkeletonFromCache(unittest.TestCase):
         n = len(frames)
         km._push([c])
         self.assertEqual(self._data_frames(frames[n:]), [], "…and unchanged cycles send nothing after that")
+
+    def test_a_connect_over_a_stale_cache_builds_the_lanes_fresh_and_serves_the_cached_bars(self):
+        # The cache is as old as the last cycle that had a timeline client (hours, when the pane was closed),
+        # and a connect never rebuilds the full build. Re-stamping the cycle clock over lanes that old painted
+        # a lane dead for hours as live (and the reverse) until the next cycle's rebuild replaced them: a flap
+        # on every reload. The kernel's own freshness rule decides (_timeline_cache_fresh: built under the
+        # cycle's view signature or within REBUILD_MIN_S, no dirty mark since): a fresh cache is projected as
+        # above; a stale one gets its lanes built fresh, as every connect did before the projection, while the
+        # heavy bars still come from the cache (review find, 2026-09-08).
+        km._built_timeline[:] = [("older",), self.FULL, 1.0, 1.0]   # built under a signature the world has since left
+        km._views_dirty[0] = 0.0
+        c, frames = self._client()
+        km._push([c], connect=True)
+        self.assertEqual(self.builds, [(False, False)], "the lanes are built fresh (no bars); the full build is not")
+        data = self._data_frames(frames)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["data"]["sessions"], self.rebuilt()["sessions"], "…and the fresh lanes are what goes")
+        self.assertEqual(data[0]["data"]["now"], self.rebuilt()["now"],
+                         "under the fresh build's own clock (the real build_timeline takes the cycle's), not a re-stamp")
+        bars = [json.loads(f) for f in frames if json.loads(f)["type"] == "bars"]
+        self.assertEqual(len(bars), 1)
+        self.assertEqual(bars[0]["turns"], self.FULL["turns"], "the bars are the cached build's, as before")
+
+    def test_a_connect_over_a_cache_marked_dirty_since_its_build_builds_the_lanes_fresh(self):
+        km._built_timeline[:] = [("sig",), self.FULL, 1.0, 1.0]     # the cycle's own signature…
+        km._views_dirty[0] = 1.5                        # …but a writer marked the views dirty after the build started
+        c, frames = self._client()
+        km._push([c], connect=True)
+        self.assertEqual(self.builds, [(False, False)], "a dirty mark is staleness too")
+        self.assertEqual(self._data_frames(frames)[0]["data"]["sessions"], self.rebuilt()["sessions"])
 
     def test_a_dirty_mark_between_two_pushes_rebuilds_and_ships_the_new_lanes(self):
         km._cached_timeline = self.saved[1]             # the real cache, warmed with FULL under the stubbed sig
@@ -524,8 +558,11 @@ class ProjectionMatchesColdSkeleton(unittest.TestCase):
 
 
 class OpenIntervals(unittest.TestCase):
-    """An interval the session is STILL in ends at the build's clock on the wire — the contract the
-    renderer's open detection reads (an end within 2 s of the payload's `now` is open). Pinned because a null
+    """An interval the session is STILL in ends at the build's clock on the wire AND carries True as a third
+    element, the open mark the renderer's open detection reads (review find, 2026-09-08). The mark is the
+    lane's own state, not a clock compare: the renderer used to read an end within 2 s of the payload's `now`
+    as open, and a connect frame re-stamps the cycle clock over the cached build, so that distance was the
+    cache's age and a lane blocked right now drew closed. Pinned because a null
     end would be a wire break: every already-loaded renderer (an open dashboard, an installed extension) takes
     Math.min(null, t1) = 0 and drops the stripe for a lane blocked or compacting right now. The clock-stamped
     end costs no per-cycle work: the lanes frame is serialized once per build, and while the state lasts the
@@ -551,10 +588,11 @@ class OpenIntervals(unittest.TestCase):
     def test_an_open_interval_ends_at_the_build_clock_and_a_closed_one_at_its_transition(self):
         now = self.now
         self.assertEqual(km._state_intervals(self.SID, km._NEEDS_INPUT_STATES, now),
-                         [[now - 400, now - 300], [now - 100, now]])
+                         [[now - 400, now - 300], [now - 100, now, True]])
         self.assertEqual(km._state_intervals(self.SID, "compacting", now), [])
         wire = json.loads(json.dumps(km._state_intervals(self.SID, "permission", now)))
-        self.assertEqual(wire[-1][1], now, "the open end serializes as the numeric clock, never null")
+        self.assertEqual(wire[-1], [now - 100, now, True], "the open end serializes as the numeric clock, never null, marked open")
+        self.assertEqual(len(wire[0]), 2, "a closed interval carries no mark")
 
     def test_the_lane_payload_ends_the_open_interval_at_its_own_clock(self):
         o_ts = km._timeline_sessions
@@ -567,8 +605,48 @@ class OpenIntervals(unittest.TestCase):
         finally:
             km._timeline_sessions = o_ts
         lane = tl["sessions"][0]
-        self.assertEqual(lane["awaiting"], [[self.now - 400, self.now - 300], [self.now - 100, self.now]])
-        self.assertEqual(lane["awaiting"][-1][1], tl["now"], "the open end equals the payload's clock: what the renderer reads as open")
+        self.assertEqual(lane["awaiting"], [[self.now - 400, self.now - 300], [self.now - 100, self.now, True]])
+        self.assertEqual(lane["awaiting"][-1][1], tl["now"], "the open end equals the payload's clock")
+        self.assertIs(lane["awaiting"][-1][2], True, "…and the open mark is what the renderer reads as open")
+
+    def test_a_connect_frame_restamped_over_a_cached_build_keeps_the_open_mark(self):
+        # The connect push serves the cached lanes under the CYCLE's clock (SkeletonFromCache), so the open
+        # interval's end, still at the BUILD clock, sits behind the frame's `now` by the cache's age. The mark
+        # travels with the interval, so the renderer draws the stripe to the live edge however old the cache is
+        # (review find, 2026-09-08: the 2 s tolerance read a lane blocked right now as closed on every connect
+        # over a cache older than that).
+        built = int(time.time()) - 10                   # the cached build's clock: 10 s behind the connect
+        km._state_ev_cache.pop(str(self.p), None)
+        with open(self.p, "w") as f:
+            for row in ({"t": built - 400, "state": "permission"}, {"t": built - 300, "state": "working"},
+                        {"t": built - 100, "state": "permission"}):
+                f.write(json.dumps(row) + "\n")
+        live = {self.SID: {"state": "permission", "since": built - 100, "model": "", "effort": "",
+                           "context": None, "compactPct": None, "color": None, "mode": ""}}
+        saved = (km._timeline_sessions, km._tmux_sessions, km._fleet_view_sig, list(km._built_timeline),
+                 km._views_dirty[0], km._skel_wire, km._bars_wire)
+        try:
+            km._timeline_sessions = lambda now, tmux, live_only=False: [
+                {"sid": self.SID, "name": "web", "path": "/no/such/transcript-web"}]
+            cached = km.build_timeline(built, live, with_bars=False)
+            km._built_timeline[:] = [("sig",), cached, time.time(), time.time()]   # fresh by the kernel's own rule
+            km._views_dirty[0] = 0.0
+            km._skel_wire = km._bars_wire = None
+            km._tmux_sessions = lambda: {}
+            km._fleet_view_sig = lambda now, tmux: ("sig",)
+            frames = []
+            km._push([{"app": "timeline", "send": frames.append, "sent": {}, "alive": True}], connect=True)
+        finally:
+            km._timeline_sessions, km._tmux_sessions, km._fleet_view_sig = saved[0], saved[1], saved[2]
+            km._built_timeline[:] = saved[3]
+            km._views_dirty[0] = saved[4]
+            km._skel_wire, km._bars_wire = saved[5], saved[6]
+        data = [json.loads(f) for f in frames if json.loads(f)["type"] == "data"]
+        self.assertEqual(len(data), 1, "the connect frame went")
+        d = data[0]["data"]
+        span = d["sessions"][0]["awaiting"][-1]
+        self.assertGreater(d["now"] - span[1], 2, "the frame's clock is the cycle's, the open end the build's: the old tolerance read this closed")
+        self.assertEqual(span, [built - 100, built, True], "the open mark rides the re-stamped frame")
 
 
 class DeadLaneWindow(unittest.TestCase):

--- a/tests/test_kernel_timeline_split.py
+++ b/tests/test_kernel_timeline_split.py
@@ -114,6 +114,48 @@ class PushSplit(unittest.TestCase):
         for k in ("judging", "messages"):
             self.assertIn(k, bars, "the whole time-plotted detail rides the bars message")
 
+    def test_a_steady_push_of_an_unchanged_timeline_sends_no_bars_and_a_rebuilt_one_sends_a_slotted_delta(self):
+        """The pusher hands _send_slot the same bars object while the cached timeline's identity holds (_bars_wire),
+        so a delta client's unchanged cycle runs no per-entry compare and sends nothing. When the timeline is
+        rebuilt the bars cross as a delta frame, with the slot key on the client while it goes."""
+        sent = []
+        client = {"app": "timeline", "sent": {}, "alive": True, "delta": True}
+        client["send"] = lambda s: sent.append((client.get("curSlot"), json.loads(s)))
+        SKEL = {"type": "timeline", "sessions": [{"id": "S"}], "turns": {}, "judging": [],
+                "messages": [], "now": 1, "usage": {}}
+        FULL1 = {"type": "timeline", "sessions": [{"id": "S"}], "turns": {"S": [{"id": "b1"}]},
+                 "judging": [], "messages": [], "now": 1}
+        FULL2 = {"type": "timeline", "sessions": [{"id": "S"}], "turns": {"S": [{"id": "b1"}, {"id": "b2"}]},
+                 "judging": [], "messages": [], "now": 2}
+        holder = {"tl": FULL1}
+        calls = []
+        o_bt, o_ct, o_tmux, o_sig, o_frac, o_order, o_wire = (km.build_timeline, km._cached_timeline, km._tmux_sessions,
+                                                             km._fleet_view_sig, km._DELTA_MAX_FRACTION, km._client_order,
+                                                             km._bars_wire)
+        km.build_timeline = lambda now, tmux, with_bars=True, live_only=False: (holder["tl"] if with_bars else SKEL)
+        km._cached_timeline = lambda now, tmux, sig, connect=False: holder["tl"]
+        km._tmux_sessions = lambda: {}
+        km._fleet_view_sig = lambda now, tmux: ("sig",)
+        km._DELTA_MAX_FRACTION = 10.0         # synthetic payloads are tiny: the size guard would send the whole instead
+        km._client_order = lambda *a: calls.append(1) or o_order(*a)
+        try:
+            km._push([client])                # the skeleton and the keyed full bars
+            km._push([client])                # the same timeline object: the same bars object
+            n_sent, n_calls = len(sent), len(calls)
+            km._push([client])
+            self.assertEqual(len(sent), n_sent, "an unchanged timeline sends no bars frame")
+            self.assertEqual(len(calls), n_calls, "…and runs no per-entry compare to find that out")
+            holder["tl"] = FULL2              # a rebuild: a new timeline object with one more bar
+            km._push([client])
+        finally:
+            (km.build_timeline, km._cached_timeline, km._tmux_sessions, km._fleet_view_sig, km._DELTA_MAX_FRACTION,
+             km._client_order, km._bars_wire) = o_bt, o_ct, o_tmux, o_sig, o_frac, o_order, o_wire
+        bars = [(k, m) for k, m in sent if m["type"] in ("bars", "delta")]
+        self.assertEqual([m["type"] for _k, m in bars], ["bars", "delta"])
+        self.assertEqual([k for k, _m in bars], [("timelinebars",), ("timelinebars",)],
+                         "both bars frames went with the slot key on the client")
+        self.assertEqual(set(bars[1][1]["coll"]["turns"]["set"]), {"S\u001fb2"}, "one bar crosses")
+
 
 class DeadLaneWindow(unittest.TestCase):
     """Dead lanes default to a 12h window and the FIRST cold paint reads no dead session at all (the user

--- a/tests/test_kernel_tool_result_scan.py
+++ b/tests/test_kernel_tool_result_scan.py
@@ -1,0 +1,252 @@
+"""_seg_mids and _fold_tasks read a tool_result's content in place instead of json.dumps-ing every block.
+
+Both functions searched tool_result blocks for text — _seg_mids for romp-msg-id markers on every timeline
+build (once per segment), _fold_tasks for the 'Task #N' in a TaskCreate result on every chat build — and
+both encoded every list-shaped result to do it. A list-shaped result is mostly image blocks (base64) and
+tool_reference blocks that can never carry either string, and the encoding was 2.6% of the pusher
+(push-thread cProfile, 2026-09-06). _seg_mids now walks the strings the encoding would write and encodes only a
+string that carries the marker literal; _fold_tasks stores the raw content and encodes only the TaskCreate
+result it reads. The match semantics are the encoding's, exactly: these tests pin that with the pre-change
+_seg_mids kept below as the oracle, over every content shape the SDK passes through (str, list of block
+dicts, None) and the shapes it does not (a dict, an int, an object).
+
+Synthetic content throughout: invented text, a placeholder message id shaped like the postal service's
+(ASCII letters, digits, dots and underscores), hostname TESTHOST.
+"""
+import base64
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from unittest import mock
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the load — the kernel resolves its state root at import time, and only pytest runs
+# conftest's floor (a bare unittest run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+POSTAL_RE = km.jd.em.POSTAL_RE
+
+MID = "1700000000.1_12345.TESTHOST"          # the emitters' id shape; never a real message id
+MID2 = "1700000000.2_12345.TESTHOST"
+IMAGE_DATA = base64.b64encode(bytes(range(256)) * 160).decode()   # a 40 KB image (about 55 KB of base64), no marker
+
+
+def marker(mid):
+    return "<!-- romp-msg-id: %s -->" % mid
+
+
+def _seg_mids_encoding(seg):
+    """The pre-change _seg_mids, verbatim: the oracle for what the encoding-based search returned."""
+    ids = []
+    for a in seg.get("atoms", []):
+        msg = a.get("message") or {}
+        content = msg.get("content")
+        if isinstance(content, str):
+            ids += POSTAL_RE.findall(content)
+        elif isinstance(content, list):
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                if b.get("type") == "text":
+                    ids += POSTAL_RE.findall(b.get("text", ""))
+                elif b.get("type") == "tool_result":
+                    c = b.get("content")
+                    ids += POSTAL_RE.findall(c if isinstance(c, str) else json.dumps(c))
+    return ids
+
+
+def result_seg(*contents):
+    """A segment of user atoms, one tool_result block per content value."""
+    return {"atoms": [{"type": "user", "message": {"content": [
+        {"type": "tool_result", "tool_use_id": "t%d" % i, "content": c}]}} for i, c in enumerate(contents)]}
+
+
+def text_block(t):
+    return {"type": "text", "text": t}
+
+
+IMAGE_BLOCK = {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": IMAGE_DATA}}
+REFERENCE_BLOCKS = [{"type": "tool_reference", "tool_name": "Read", "id": "ref%d" % i} for i in range(3)]
+
+
+class SegMidsShapes(unittest.TestCase):
+    """Each shape the SDK's ToolResultBlock.content can take (str | list[dict] | None), plus the ones it
+    cannot, gives the ids the encoding gave, as a list (order and duplicates included)."""
+
+    def assertSameAsEncoding(self, seg, expected):
+        self.assertEqual(km._seg_mids(seg), expected)
+        self.assertEqual(_seg_mids_encoding(seg), expected, "the oracle agrees with the expectation")
+
+    def test_plain_string_result(self):
+        # how check_inbox results are stored: the marker in a string, no encoding either way
+        self.assertSameAsEncoding(result_seg("inbox:\n" + marker(MID) + "\nbody"), [MID])
+
+    def test_list_of_text_blocks_beside_image_and_tool_reference_blocks(self):
+        seg = result_seg([text_block("before " + marker(MID)), IMAGE_BLOCK, *REFERENCE_BLOCKS,
+                          text_block("after " + marker(MID2))])
+        self.assertSameAsEncoding(seg, [MID, MID2])
+
+    def test_bare_string_items_in_a_list(self):
+        self.assertSameAsEncoding(result_seg([marker(MID), "no marker here", marker(MID2)]), [MID, MID2])
+
+    def test_nested_dicts_are_walked(self):
+        # a marker in a nested field was found by the encoding, so it is found by the walk too — and
+        # in a dict KEY, which the encoding also wrote out
+        seg = result_seg([{"type": "other", "meta": {"note": marker(MID), "list": [{"deep": marker(MID2)}]}}],
+                         {marker("1700000000.3_1.TESTHOST"): 1})
+        self.assertSameAsEncoding(seg, [MID, MID2, "1700000000.3_1.TESTHOST"])
+
+    def test_none_content_yields_nothing(self):
+        # sdk_backend passes ToolResultBlock.content through unchanged, so a live-tail atom can carry None
+        self.assertSameAsEncoding(result_seg(None), [])
+
+    def test_unexpected_types_do_not_raise(self):
+        for c in (7, 2.5, True, b"bytes", object(), {"k": object()}, [object(), 3, None]):
+            with self.subTest(content=type(c).__name__):
+                self.assertEqual(km._seg_mids(result_seg(c)), [])
+
+    def test_text_block_with_null_text_is_skipped(self):
+        # a text block whose `text` is null raised a TypeError in findall before
+        seg = {"atoms": [{"type": "assistant", "message": {"content": [{"type": "text", "text": None},
+                                                                        text_block(marker(MID))]}}]}
+        self.assertEqual(km._seg_mids(seg), [MID])
+
+    def test_order_and_duplicates_are_kept(self):
+        seg = {"atoms": [
+            {"type": "user", "message": {"content": [text_block("a " + marker(MID))]}},
+            {"type": "user", "message": {"content": [{"type": "tool_result", "tool_use_id": "t1",
+                                                     "content": [text_block(marker(MID2)), text_block(marker(MID))]}]}},
+            {"type": "user", "message": {"content": "plain " + marker(MID2)}}]}
+        self.assertSameAsEncoding(seg, [MID, MID2, MID, MID2])
+
+    def test_agrees_with_the_encoding_on_every_marker_shape(self):
+        # The exactness claim, including the shapes no emitter writes (zero instances in observed
+        # transcripts): a newline before the close, a tab after the open, a quote or a non-ASCII character
+        # inside the id. The encoding turns those into escape sequences before matching, so its answer
+        # differs from a raw match; the walk returns the encoding's answer, whatever it is, so nothing a
+        # timeline connector binds to can move.
+        shapes = [
+            [text_block(marker(MID))],
+            [text_block("<!-- romp-msg-id: abc\n-->")],
+            [text_block(marker("abc").replace("<!-- ", "<!--\t"))],   # a tab after the open, not a space
+            [text_block('<!-- romp-msg-id: a"b -->')],
+            [text_block("<!-- romp-msg-id: a\\b -->")],
+            [text_block("<!-- romp-msg-id: café -->")],
+            [text_block("<!-- romp-msg-id: \n -->")],
+            [text_block("<!-- romp-msg-id: abc"), text_block("-->")],
+            [text_block("<!-- romp-msg-id: abc"), "-->"],
+            [{"type": "image", "source": {"data": marker(MID)}}],
+            [{"type": "tool_reference", "tool_name": marker(MID)}, IMAGE_BLOCK],
+            ["<!-- romp-msg-id: x -->  <!-- romp-msg-id: y -->"],
+            [{"nested": [[[marker(MID)]]]}],
+            [],
+            [{}],
+            [[]],
+            {"type": "text", "text": marker(MID)},
+        ]
+        for c in shapes:
+            with self.subTest(content=json.dumps(c)[:60]):
+                seg = result_seg(c)
+                self.assertEqual(km._seg_mids(seg), _seg_mids_encoding(seg))
+
+    def test_the_blocks_are_not_encoded(self):
+        # A value json.dumps refuses beside a marker: encoding the whole result raised, the walk reads the
+        # marker and passes the value by. This is the pin that the image and reference blocks are no longer
+        # serialized on every build (the saving), not just that the answer is unchanged.
+        seg = result_seg([text_block(marker(MID)), {"type": "image", "source": {"data": object()}}])
+        with self.assertRaises(TypeError):
+            _seg_mids_encoding(seg)
+        self.assertEqual(km._seg_mids(seg), [MID])
+
+    def test_only_strings_carrying_the_literal_are_encoded(self):
+        # the saving itself: json.dumps runs on the one string that holds the marker literal — never on the image data
+        # string, the block dicts or the marker-free text (test_the_blocks_are_not_encoded pins the container; this pins
+        # the prefilter, which is what the micro-benchmark's saving comes from)
+        seen = []; real = json.dumps
+
+        def spy(obj, *a, **k):
+            seen.append(obj)
+            return real(obj, *a, **k)
+        seg = result_seg([text_block("before " + marker(MID)), IMAGE_BLOCK, *REFERENCE_BLOCKS, text_block("after")])
+        with mock.patch.object(json, "dumps", spy):
+            ids = km._seg_mids(seg)
+        self.assertEqual(ids, [MID])
+        self.assertEqual(seen, ["before " + marker(MID)], "one encode, of the one string that carries the literal")
+
+    def test_string_result_content_is_matched_raw_not_encoded(self):
+        # a str tool_result content is matched as it is, never encoded — for the marker shapes the encoding would
+        # escape too, where an encoded match would come back changed (a\"b, a\\\\b, caf\\u00e9); the plain-string case
+        # above only exercises an id that encodes to itself
+        for c in ('<!-- romp-msg-id: a"b -->', "<!-- romp-msg-id: a\\b -->", "<!-- romp-msg-id: café -->"):
+            with self.subTest(content=c):
+                seg = result_seg(c)
+                self.assertEqual(km._seg_mids(seg), POSTAL_RE.findall(c), "the raw match")
+                self.assertEqual(km._seg_mids(seg), _seg_mids_encoding(seg), "…which is what the oracle did for a str")
+
+    def test_encoded_mids_covers_keys_values_and_nesting_in_document_order(self):
+        # every string the encoding writes: keys, values, inside lists, tuples and dicts, in the order the
+        # encoding writes them; a non-string key and the scalars contribute nothing
+        m = ["1700000000.%d_1.TESTHOST" % i for i in range(6)]
+        obj = {"a": marker(m[0]), marker(m[1]): [1, marker(m[2]), {"c": marker(m[3]), 4: marker(m[4])}, None, True],
+               "d": (marker(m[5]),), "e": {}}
+        self.assertEqual(km._encoded_mids(obj), m)
+        self.assertEqual(km._encoded_mids(obj), POSTAL_RE.findall(json.dumps(obj)))
+        sink = ["seed"]
+        self.assertIs(km._encoded_mids([marker(m[0])], sink), sink, "appends to the list it is given")
+        self.assertEqual(sink, ["seed", m[0]])
+        self.assertEqual(km._encoded_mids(None), [])
+        self.assertEqual(km._encoded_mids(object()), [])
+
+
+def asst(bid, name, inp):
+    return {"type": "assistant", "message": {"content": [{"type": "tool_use", "id": bid, "name": name, "input": inp}]}}
+
+
+def user_result(tid, content):
+    return {"type": "user", "message": {"content": [{"type": "tool_result", "tool_use_id": tid, "content": content}]}}
+
+
+def session_of(*atoms):
+    return {"turns": [{"atoms": list(atoms)}]}
+
+
+class FoldTasksResultRead(unittest.TestCase):
+    """_fold_tasks encodes only the TaskCreate result it reads for 'Task #N'; every other result is stored
+    as it came and never serialized."""
+
+    def test_other_results_are_never_encoded(self):
+        # a Bash result carrying a value json.dumps refuses: encoding every result up front raised here
+        session = session_of(
+            asst("b1", "Bash", {"command": "ls"}), user_result("b1", [{"type": "image", "source": {"data": object()}}]),
+            asst("tc1", "TaskCreate", {"subject": "Wire the picker", "activeForm": "Wiring the picker"}),
+            user_result("tc1", "Task #4 created successfully: Wire the picker"),
+            asst("tu1", "TaskUpdate", {"taskId": "4", "status": "in_progress"}))
+        self.assertEqual(km._fold_tasks(session),
+                         [{"id": "4", "subject": "Wire the picker", "activeForm": "Wiring the picker", "status": "in_progress"}])
+
+    def test_task_create_result_as_text_blocks_is_encoded_at_the_read(self):
+        # a list-shaped TaskCreate result still yields the id the encoding found in it
+        session = session_of(
+            asst("tc1", "TaskCreate", {"subject": "Run the suite"}),
+            user_result("tc1", [{"type": "text", "text": "Task #7 created successfully: Run the suite"}]))
+        self.assertEqual([t["id"] for t in km._fold_tasks(session)], ["7"])
+
+    def test_task_create_result_none_or_missing_falls_back_to_creation_order(self):
+        session = session_of(
+            asst("tc1", "TaskCreate", {"subject": "first"}), user_result("tc1", None),
+            asst("tc2", "TaskCreate", {"subject": "second"}))
+        self.assertEqual([t["id"] for t in km._fold_tasks(session)], ["c0", "c1"])
+
+    def test_no_task_calls_gives_none(self):
+        session = session_of(asst("b1", "Bash", {"command": "ls"}), user_result("b1", [{"type": "text", "text": "ok"}]))
+        self.assertIsNone(km._fold_tasks(session))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_usage_limit.py
+++ b/tests/test_kernel_usage_limit.py
@@ -101,19 +101,49 @@ class UsageLimitSignal(unittest.TestCase):
 
 
 class AutoPauseOnLimit(unittest.TestCase):
+    """The flip's delivery: the tick job builds nothing inline. Its writer, _set_retry_paused, marks the
+    views dirty and wakes the pusher, whose next cycle rebuilds and carries the flag in its
+    globalRetryPaused frame; an inline _push_all is the regression the tripwire in setUp catches. The
+    idempotent path (already paused) writes nothing, so it neither wakes nor dirties. _views_dirty is a
+    module global shared across the suite, so each test records its own floor rather than asserting an
+    absolute value."""
+
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         self.saved = jd.STATE
         jd.STATE = Path(self.td.name)
         self._usage = km._usage
         self._push = km._push_all
-        km._push_all = lambda: None
+        km._push_all = lambda *a, **k: self.fail("a tick job built a push inline; it should wake the pusher")
+        self._was_set = km._pusher_wake.is_set()
+        km._pusher_wake.clear()
 
     def tearDown(self):
         jd.STATE = self.saved
         km._usage = self._usage
         km._push_all = self._push
+        if self._was_set:
+            km._pusher_wake.set()
+        else:
+            km._pusher_wake.clear()
         self.td.cleanup()
+
+    def test_the_flip_wakes_the_pusher_and_marks_the_views_dirty(self):
+        km._usage = lambda: {"limited": {"fiveHour": True, "sevenDay": False, "fable": False}}
+        floor = km._views_dirty[0]
+        km._auto_pause_on_limit()
+        self.assertTrue(km._retry_paused_on())
+        self.assertTrue(km._pusher_wake.is_set(), "the flip wakes the pusher; the next cycle carries it")
+        self.assertGreater(km._views_dirty[0], floor, "the writer's own mark: that cycle rebuilds past the sig")
+
+    def test_the_idempotent_path_neither_wakes_nor_dirties(self):
+        km._set_retry_paused(True)                       # already paused: the write is skipped
+        km._pusher_wake.clear()                          # the pre-pause's own wake, not the tick's
+        km._usage = lambda: {"limited": {"fiveHour": True, "sevenDay": False, "fable": False}}
+        floor = km._views_dirty[0]
+        km._auto_pause_on_limit()
+        self.assertFalse(km._pusher_wake.is_set(), "nothing written, nothing to deliver")
+        self.assertEqual(km._views_dirty[0], floor)
 
     def test_hitting_a_limit_engages_the_retry_pause(self):
         km._usage = lambda: {"limited": {"fiveHour": True, "sevenDay": False, "fable": False}}
@@ -153,11 +183,40 @@ class AutoPauseOnSpendLimit(unittest.TestCase):
         self.td = tempfile.TemporaryDirectory()
         self.saved = (jd.STATE, km._alive_sessions, km._api_error, km._push_all)
         jd.STATE = Path(self.td.name)
-        km._push_all = lambda: None
+        km._push_all = lambda *a, **k: self.fail("a tick job built a push inline; it should wake the pusher")
+        self._was_set = km._pusher_wake.is_set()
+        km._pusher_wake.clear()
 
     def tearDown(self):
         jd.STATE, km._alive_sessions, km._api_error, km._push_all = self.saved
+        if self._was_set:
+            km._pusher_wake.set()
+        else:
+            km._pusher_wake.clear()
         self.td.cleanup()
+
+    def test_the_flip_wakes_the_pusher_and_marks_the_views_dirty(self):
+        # the same delivery as AutoPauseOnLimit: the writer's wake and dirty mark, no inline push
+        self._sessions({"spendLimit": True, "text": "spend limit"})
+        floor = km._views_dirty[0]
+        km._auto_pause_on_spend_limit(0, {})
+        self.assertTrue(km._retry_paused_on())
+        self.assertTrue(km._pusher_wake.is_set(), "the flip wakes the pusher; the next cycle carries it")
+        self.assertGreater(km._views_dirty[0], floor, "the writer's own mark: that cycle rebuilds past the sig")
+
+    def test_the_no_op_paths_neither_wake_nor_dirty(self):
+        floor = km._views_dirty[0]
+        self._sessions(None, {"spendLimit": False, "text": "500"})   # no capped session
+        km._auto_pause_on_spend_limit(0, {})
+        self.assertFalse(km._pusher_wake.is_set())
+        self.assertEqual(km._views_dirty[0], floor)
+        km._set_retry_paused(True)                       # already paused: the write is skipped
+        km._pusher_wake.clear()                          # the pre-pause's own wake, not the tick's
+        floor = km._views_dirty[0]
+        self._sessions({"spendLimit": True, "text": "spend limit"})
+        km._auto_pause_on_spend_limit(0, {})
+        self.assertFalse(km._pusher_wake.is_set(), "nothing written, nothing to deliver")
+        self.assertEqual(km._views_dirty[0], floor)
 
     def _sessions(self, *errs):
         sess = [{"sid": "s%d" % i, "path": "/tmp/s%d.jsonl" % i} for i in range(len(errs))]

--- a/tests/test_ledger_unproved_reads.py
+++ b/tests/test_ledger_unproved_reads.py
@@ -464,7 +464,7 @@ class _InterruptTickRig(unittest.TestCase):
         jd.parsed_session = lambda sid, paths, now: {"turns": [{"id": "t1", "t": 1000, "atoms": []}]}
         km._session_working = lambda turns: False
         self.marks = (1200, 900)                           # the stop is newer than the last human message: a user stop
-        km._interrupt_marks = lambda turns, sid="": self.marks
+        km._interrupt_marks = lambda turns, sid="", **k: self.marks   # the tick names its memo family
         self.recorded, self.lifted, self.pushes = [], [], []
         km._record_interrupt_block = lambda sid, ev: self.recorded.append((sid, ev)) or GID
         km._lift_interrupt_block = lambda sid, gid, ev: self.lifted.append((sid, gid, ev)) or True   # spent; the real

--- a/tests/test_ledger_unproved_reads.py
+++ b/tests/test_ledger_unproved_reads.py
@@ -445,7 +445,12 @@ class CorruptBytes(_Ledger):
 
 class _InterruptTickRig(unittest.TestCase):
     """The interrupt tick's collaborators as recording stubs, the rig the two classes below share
-    (unittest collects inherited test_ names, so the fixture lives apart from either's tests)."""
+    (unittest collects inherited test_ names, so the fixture lives apart from either's tests).
+
+    The tick pushes nothing inline: a flip reaches the next cycle through its WRITER's dirty mark and pusher
+    wake (_record_interrupt_block and _lift_interrupt_block end in _mark_views_dirty), so the rig reads those
+    two signals and keeps _push_all as a tripwire. _views_dirty is a module global shared across the suite:
+    each test records its own floor (_refloor), and the wake is put back on the way out."""
 
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
@@ -470,7 +475,9 @@ class _InterruptTickRig(unittest.TestCase):
         km._lift_interrupt_block = lambda sid, gid, ev: self.lifted.append((sid, gid, ev)) or True   # spent; the real
         #                                            one returns False only on a goal-store read fault, keeping the marker (PR #1019)
         km._intr_block_stands = lambda sid, gid: True
-        km._push_all = lambda *a, **k: self.pushes.append(1)
+        km._push_all = lambda *a, **k: self.pushes.append(1)   # a tripwire: the tick never pushes inline
+        self._wake_was = km._pusher_wake.is_set()
+        self._refloor()
         self._undo = []
         _reset_ledger_state()
 
@@ -479,6 +486,10 @@ class _InterruptTickRig(unittest.TestCase):
             undo()
         for n, v in self.saved.items():
             setattr(km, n, v)
+        if self._wake_was:
+            km._pusher_wake.set()
+        else:
+            km._pusher_wake.clear()
         jd.parsed_session = self.saved_parsed
         _reset_ledger_state()
         jd.STATE = self.saved_state
@@ -496,6 +507,17 @@ class _InterruptTickRig(unittest.TestCase):
         for _ in range(n):
             km._interrupt_block_tick(2000, {SID: {"state": ""}})
 
+    def _refloor(self):
+        """Forget the marks so far: _marked and _woken then read only what the ticks after this do."""
+        self.floor = km._views_dirty[0]
+        km._pusher_wake.clear()
+
+    def _marked(self):
+        return km._views_dirty[0] > self.floor
+
+    def _woken(self):
+        return km._pusher_wake.is_set()
+
 
 class InterruptBlockTickUnderAFault(_InterruptTickRig):
     """_interrupt_block_tick runs every push OUTSIDE the paused nudge pass. Under an unproved snapshot its
@@ -504,8 +526,11 @@ class InterruptBlockTickUnderAFault(_InterruptTickRig):
     episode stood until a judge happened to unblock it; and its lift arm, with the marker clear refused,
     set `changed` every cycle and pushed every cycle. Now the block arm files nothing under a fault (the
     stop is re-evaluated from the transcript every push, so the block lands on the first tick after the
-    file reads again), the lift still runs (it is the user's own re-engagement), and `changed` follows the
-    marker write. Control flow only: every collaborator is a recording stub."""
+    file reads again), the lift still runs (it is the user's own re-engagement), and nothing pushes inline
+    from the tick at all: a writer's own dirty mark and pusher wake carry a flip to the next cycle (the real
+    writers run in MidTickFaultThenHeal below; the recording stubs here mark nothing), and a refused marker
+    write marks nothing, so a fault repeats nothing every cycle. Control flow only: every collaborator is a
+    recording stub."""
 
     def test_a_stop_during_a_fault_files_no_block_until_the_ledger_reads_again(self):
         self.p.write_text(json.dumps(DEFAULT))
@@ -516,7 +541,8 @@ class InterruptBlockTickUnderAFault(_InterruptTickRig):
         with contextlib.redirect_stderr(err):
             self._tick(5)
         self.assertEqual(self.recorded, [], "no block whose marker cannot be minted: unmarked, it could never be lifted")
-        self.assertEqual(self.pushes, [], "…and nothing pushes")
+        self.assertEqual(self.pushes, [], "…and nothing pushes inline")
+        self.assertFalse(self._marked() or self._woken(), "…or marks the views dirty or wakes the pusher: nothing to show")
         self.assertEqual(self.p.read_bytes(), before)
         self.assertEqual(err.getvalue().count("paused"), 1, "loud once per fault episode, on the pass's latch")
         self._heal()
@@ -524,12 +550,14 @@ class InterruptBlockTickUnderAFault(_InterruptTickRig):
             self._tick()
         self.assertEqual(len(self.recorded), 1, "the stop is re-evaluated every push: the block lands on the first tick after the file reads")
         self.assertEqual(json.loads(self.p.read_text())["intrBlocked"], {SID: GID}, "…with its once-per-episode marker")
-        self.assertEqual(len(self.pushes), 1)
+        self.assertEqual(self.pushes, [], "no inline push: the block's own store write is what marks the views dirty "
+                                          "(the real writer, in MidTickFaultThenHeal; this rig's stub marks nothing)")
 
-    def test_a_fault_landing_mid_tick_still_pushes_the_block_it_filed_and_then_stands_down(self):
+    def test_a_fault_landing_mid_tick_leaves_the_block_it_filed_to_its_writers_mark_and_then_stands_down(self):
         # the tag check at the arm's top proves; the fault lands before the marker write. The block IS in
-        # the goal store — a proved write, a needs-you flip the feed must hear — so this tick pushes once
-        # whatever the marker's fate; every later faulted tick stands down at the check: no storm
+        # the goal store — a proved write, whose writer marks the views dirty (the real one; MidTickFaultThenHeal
+        # pins the mark) — so the flip reaches the next cycle whatever the marker's fate, and the tick pushes
+        # nothing inline; every later faulted tick stands down at the check: no storm
         self.p.write_text(json.dumps(DEFAULT))
         km._autonudge_cache.clear()
         real, calls, ledger, test = km._auto_nudge_data, [0], self.p, self
@@ -545,10 +573,11 @@ class InterruptBlockTickUnderAFault(_InterruptTickRig):
         with contextlib.redirect_stderr(io.StringIO()):
             self._tick(5)
         self.assertEqual(len(self.recorded), 1, "the block was filed once")
-        self.assertEqual(self.pushes, [1], "…and pushed exactly once, marker or no marker")
+        self.assertEqual(self.pushes, [], "…and nothing pushed inline, marker or no marker: the writer's mark carries it")
+        self.assertFalse(self._marked() or self._woken(), "the stubbed writer marks nothing, and the tick adds no mark of its own")
         self.assertNotIn("intrBlocked", json.loads(self.p.read_bytes()), "the marker write was refused")
 
-    def test_a_re_engagement_during_a_fault_lifts_our_block_and_pushes_once_the_marker_clears(self):
+    def test_a_re_engagement_during_a_fault_lifts_our_block_and_marks_nothing_while_the_marker_clear_is_refused(self):
         marked = dict(DEFAULT, intrBlocked={SID: GID})
         self.p.write_text(json.dumps(marked))
         km._autonudge_cache.clear()
@@ -560,12 +589,15 @@ class InterruptBlockTickUnderAFault(_InterruptTickRig):
         with contextlib.redirect_stderr(io.StringIO()):
             self._tick(5)
         self.assertGreaterEqual(len(self.lifted), 1, "the lift is the user's own re-engagement: it runs whatever the ledger's state")
-        self.assertEqual(self.pushes, [], "the marker clear was refused: no push storm (one per cycle before)")
+        self.assertEqual(self.pushes, [], "the marker clear was refused: no inline push (one per cycle before)")
+        self.assertFalse(self._marked() or self._woken(),
+                         "…and no dirty mark or wake either: a refused clear marks nothing, so no rebuild storm takes the push storm's place")
         self.assertEqual(self.p.read_bytes(), before)
         self._heal()
         self._tick()
         self.assertNotIn(SID, json.loads(self.p.read_text()).get("intrBlocked", {}), "the marker clears on the first tick after the file reads")
-        self.assertEqual(len(self.pushes), 1, "…and that is the one push")
+        self.assertEqual(self.pushes, [], "…with no inline push: the lift's own store write is what marks the views dirty "
+                                          "(the real writer, in MidTickFaultThenHeal)")
 
 
 B = 1_700_000_000   # an epoch base for the store class below: the diary is an evidence-time ledger
@@ -631,7 +663,11 @@ class MidTickFaultThenHeal(_InterruptTickRig):
         self.assertEqual(self._store()["status"][GID], "blocked", "the block was filed in the goal store")
         self.assertEqual(self._block_rows(), ["interrupt"])
         self.assertNotIn("intrBlocked", json.loads(self.p.read_bytes()), "…and the marker write was refused")
-        self.assertEqual(self.pushes, [1], "the block's push")
+        self.assertEqual(self.pushes, [], "no inline push from the tick")
+        self.assertTrue(self._marked() and self._woken(),
+                        "the block's own store write marked the views dirty and woke the pusher: the next cycle carries the "
+                        "flip, marker or no marker")
+        self._refloor()
         self._heal()
 
     def _re_engage(self):
@@ -646,15 +682,19 @@ class MidTickFaultThenHeal(_InterruptTickRig):
         self.assertEqual(json.loads(self.p.read_text()).get("intrBlocked"), {SID: GID},
                          "the marker our own block is owed is minted on the first tick after the file reads")
         self.assertEqual(self._block_rows(), ["interrupt"], "…without a second block row: the diary already says it")
-        self.assertEqual(self.pushes, [1, 1], "the block's push, and the marker's")
+        self.assertEqual(self.pushes, [], "nothing pushes inline")
+        self.assertFalse(self._marked() or self._woken(),
+                         "…and the re-mint marks nothing: the card already shows the block (the ledger's mtime is in the view signature)")
         with contextlib.redirect_stderr(io.StringIO()):
             self._tick(3)
-        self.assertEqual(self.pushes, [1, 1], "settled: the marker stands and the block holds, nothing more to push")
+        self.assertFalse(self._marked() or self._woken(), "settled: the marker stands and the block holds, nothing marks or wakes")
         self._re_engage()
         with contextlib.redirect_stderr(io.StringIO()):
             self._tick()
         self.assertEqual(self._store()["status"][GID], "working", "the re-engagement lifts our block: the card leaves Needs-you")
         self.assertNotIn(SID, json.loads(self.p.read_text()).get("intrBlocked", {}), "…and the marker clears")
+        self.assertTrue(self._marked() and self._woken(), "the lift's store write marked the views dirty and woke the pusher")
+        self.assertEqual(self.pushes, [], "…and pushed nothing inline")
 
     def test_a_judge_block_filed_since_is_left_alone(self):
         self._fault_on_the_marker_write()
@@ -666,7 +706,8 @@ class MidTickFaultThenHeal(_InterruptTickRig):
             self._tick(3)
         self.assertNotIn("intrBlocked", json.loads(self.p.read_text()), "a card a judge has blocked is theirs: no marker")
         self.assertEqual(self._block_rows(), ["interrupt", "closer"], "…and nothing appended")
-        self.assertEqual(self.pushes, [1], "…and nothing pushed")
+        self.assertEqual(self.pushes, [], "…and nothing pushed inline")
+        self.assertFalse(self._marked() or self._woken(), "…or marked or woken: a judge's card is not ours to move")
         self._re_engage()
         with contextlib.redirect_stderr(io.StringIO()):
             self._tick()

--- a/tests/test_ledger_unproved_reads.py
+++ b/tests/test_ledger_unproved_reads.py
@@ -464,7 +464,7 @@ class _InterruptTickRig(unittest.TestCase):
         self.saved_parsed = jd.parsed_session
         km._alive_sessions = lambda now, tmux: [{"sid": SID, "path": "/nonexistent.jsonl"}]
         km._session_flag = lambda sid, flag: False
-        km._compacting_now = lambda sid: False
+        km._compacting_now = lambda sid, **k: False   # the tick hands in the row's path and live meta
         km._api_error = lambda path: None
         jd.parsed_session = lambda sid, paths, now: {"turns": [{"id": "t1", "t": 1000, "atoms": []}]}
         km._session_working = lambda turns: False

--- a/tests/test_nudge_bundle.py
+++ b/tests/test_nudge_bundle.py
@@ -265,7 +265,7 @@ class AutoNudgeBundlesSameTick(unittest.TestCase):
         km._compacting_now = lambda sid: False
         km._api_error = lambda path: None
         km._session_working = lambda turns: False
-        km._interrupt_suppresses_nudge = lambda turns, sid="": False
+        km._interrupt_suppresses_nudge = lambda turns, sid="", **k: False
         km._backend_queued = lambda sid: False
         km._backend_rewind_pending = lambda sid: False
         km._last_state = lambda sid: ("", 0)

--- a/tests/test_nudge_fresh_guard.py
+++ b/tests/test_nudge_fresh_guard.py
@@ -67,7 +67,7 @@ class FreshGuard(unittest.TestCase):
         km._compacting_now = lambda sid: False
         km._api_error = lambda path: None
         km._session_working = lambda turns: False
-        km._interrupt_suppresses_nudge = lambda turns, sid="": False
+        km._interrupt_suppresses_nudge = lambda turns, sid="", **k: False
         km._backend_queued = lambda sid: False
         km._backend_rewind_pending = lambda sid: False
         km._last_state = lambda sid: ("", 0)

--- a/tests/test_nudge_injected_turn_arm.py
+++ b/tests/test_nudge_injected_turn_arm.py
@@ -147,7 +147,7 @@ class InjectedTurnDeadlockEndToEnd(unittest.TestCase):
         km._compacting_now = lambda sid: False
         km._api_error = lambda path: None
         km._session_working = lambda turns: False
-        km._interrupt_suppresses_nudge = lambda turns, sid="": False
+        km._interrupt_suppresses_nudge = lambda turns, sid="", **k: False
         km._backend_queued = lambda sid: False
         km._backend_rewind_pending = lambda sid: False
         km._last_state = lambda sid: ("", 0)

--- a/tests/test_nudge_memo_deadlock.py
+++ b/tests/test_nudge_memo_deadlock.py
@@ -65,7 +65,7 @@ class MemoDeadlock(unittest.TestCase):
         km._compacting_now = lambda sid: False
         km._api_error = lambda path: None
         km._session_working = lambda turns: False
-        km._interrupt_suppresses_nudge = lambda turns, sid="": False
+        km._interrupt_suppresses_nudge = lambda turns, sid="", **k: False
         km._backend_queued = lambda sid: False
         km._backend_rewind_pending = lambda sid: False
         km._last_state = lambda sid: ("", 0)

--- a/tests/test_post_push_coalescing.py
+++ b/tests/test_post_push_coalescing.py
@@ -16,6 +16,7 @@ import unittest
 from http.server import ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
+from unittest import mock
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -27,10 +28,12 @@ os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 km = SourceFileLoader("romp_kernel_postpush", os.path.join(BIN, "romp-kernel")).load_module()
 
-# The ONLY functions allowed to build inline: the pusher's own cycle and the tick jobs that run ON
-# the pusher thread (see _pusher_cycle_jobs). Everything request-side pokes instead.
-PUSHER_THREAD_FNS = {"_push_all", "_pusher_cycle_jobs", "_auto_pause_on_limit",
-                     "_auto_pause_on_spend_limit", "_auto_resume_retry", "_interrupt_block_tick"}
+# The ONLY functions allowed to build inline: the pusher's own cycle. Everything request-side pokes
+# instead, and so do the tick jobs that run ON the pusher thread (_pusher_cycle_jobs): their writers
+# mark the views dirty and wake the pusher, whose next cycle carries the change (the interrupt tick's
+# inline push rebuilt nothing the next cycle would not, and the retry-pause flag is read by no view).
+# A tick job that builds inline is the regression this census catches.
+PUSHER_THREAD_FNS = {"_push_all", "_pusher_cycle_jobs"}
 
 
 class PushCallerCensus(unittest.TestCase):
@@ -56,6 +59,32 @@ class PokeCoalescing(unittest.TestCase):
         self.assertTrue(km._pusher_wake.is_set(), "the poke wakes the pusher immediately")
         km._pusher_wake.clear()                       # ONE cycle consumes the whole burst
         self.assertFalse(km._pusher_wake.is_set(), "50 pokes = 1 wakeup = 1 build — coalesced")
+
+
+class MidCycleWakeStartsTheNextCycle(unittest.TestCase):
+    """A tick job's writer sets the wake DURING the cycle (_mark_views_dirty, after that cycle's push): the loop
+    must take it as the NEXT cycle's event, not clear it on the way out. The tick jobs' inline pushes were
+    removed on the strength of this ordering (wait, then clear), which nothing pinned behaviourally."""
+
+    class _Stop(Exception):
+        pass
+
+    def test_a_wake_set_during_the_cycle_is_the_next_cycles_event(self):
+        kinds, n = [], [0]
+
+        def cycle():
+            n[0] += 1
+            if n[0] == 1:
+                km._pusher_wake.set()          # a tick job's writer, after this cycle's push
+            else:
+                raise self._Stop()             # the second cycle: end the while-True loop
+        km._pusher_wake.clear()
+        with mock.patch.object(km, "_pusher_cycle", cycle), \
+                mock.patch.object(km._PERF_STATS, "wake_kind", side_effect=kinds.append), \
+                self.assertRaises(self._Stop):
+            km._pusher()
+        self.assertEqual(kinds, [True], "the loop woke on the event, not on the 0.5 s backstop")
+        self.assertFalse(km._pusher_wake.is_set(), "…and consumed it")
 
 
 class ControlRouteLatency(unittest.TestCase):

--- a/tests/test_retry_pause_autoresume.py
+++ b/tests/test_retry_pause_autoresume.py
@@ -34,13 +34,22 @@ class RetryPauseAutoResume(unittest.TestCase):
         self._orig_alive = km._alive_sessions
         self._orig_apierr = km._api_error
         self._orig_push = km._push_all
-        km._push_all = lambda *a, **k: None             # no clients in the test
+        km._push_all = lambda *a, **k: self.fail("a tick job built a push inline; it should wake the pusher")
+        self._orig_rearm = km.jd.rearm_failed_summaries
+        km.jd.rearm_failed_summaries = lambda now, **k: 0   # no given-up cards unless a test says so
+        self._was_set = km._pusher_wake.is_set()
+        km._pusher_wake.clear()
 
     def tearDown(self):
         km.jd.STATE = self._orig_state
         km._alive_sessions = self._orig_alive
         km._api_error = self._orig_apierr
         km._push_all = self._orig_push
+        km.jd.rearm_failed_summaries = self._orig_rearm
+        if self._was_set:
+            km._pusher_wake.set()
+        else:
+            km._pusher_wake.clear()
         self.td.cleanup()
 
     def _transcript(self, name, mtime):
@@ -95,6 +104,57 @@ class RetryPauseAutoResume(unittest.TestCase):
         km._alive_sessions = lambda now, tmux: called.append(1) or []
         km._auto_resume_retry(int(time.time()), {})
         self.assertEqual(called, [], "not paused → the resume check does no work")
+
+    # --- delivery: the writer's wake and dirty mark, a second mark for the re-arm's write, no inline push ---
+    def _recovered(self):
+        km._set_retry_paused(True)
+        km._pusher_wake.clear()                          # the pre-pause's own wake, not the clear's
+        floor = km._retry_pause_ts()
+        path = self._transcript("healthy.jsonl", floor + 5)
+        km._alive_sessions = lambda now, tmux: [{"sid": "s1", "path": path}]
+        km._api_error = lambda p: None
+
+    def test_the_clear_wakes_the_pusher_and_marks_the_views_dirty(self):
+        self._recovered()
+        floor = km._views_dirty[0]
+        km._auto_resume_retry(int(time.time()), {})
+        self.assertFalse(km._retry_paused_on())
+        self.assertTrue(km._pusher_wake.is_set(), "the clear wakes the pusher; globalRetryPaused rides its push")
+        self.assertGreater(km._views_dirty[0], floor, "the writer's own mark: that cycle rebuilds past the sig")
+
+    def test_a_re_arm_marks_the_views_dirty_after_its_write(self):
+        # the store write on this path the cards show (a given-up card's summary sentinel goes back to
+        # None) lands after the flag's own stamp, so the branch stamps again once the write is made
+        self._recovered()
+        seen = []
+
+        def rearm(now, **k):
+            seen.append(km._views_dirty[0])              # the clear's stamp, already placed
+            return 2
+        km.jd.rearm_failed_summaries = rearm
+        km._auto_resume_retry(int(time.time()), {})
+        self.assertEqual(len(seen), 1)
+        self.assertGreater(km._views_dirty[0], seen[0], "a second mark, after the write")
+        self.assertTrue(km._pusher_wake.is_set())
+
+    def test_the_no_op_paths_neither_wake_nor_dirty(self):
+        km._set_retry_paused(False)
+        km._pusher_wake.clear()                          # the test's own write, not the tick's
+        floor = km._views_dirty[0]
+        km._auto_resume_retry(int(time.time()), {})
+        self.assertFalse(km._pusher_wake.is_set(), "not paused: nothing to deliver")
+        self.assertEqual(km._views_dirty[0], floor)
+        km._set_retry_paused(True)
+        km._pusher_wake.clear()
+        pfloor = km._retry_pause_ts()
+        path = self._transcript("stale.jsonl", pfloor - 60)
+        km._alive_sessions = lambda now, tmux: [{"sid": "s1", "path": path}]
+        km._api_error = lambda p: None
+        floor = km._views_dirty[0]
+        km._auto_resume_retry(int(time.time()), {})
+        self.assertTrue(km._retry_paused_on())
+        self.assertFalse(km._pusher_wake.is_set(), "still paused: nothing to deliver")
+        self.assertEqual(km._views_dirty[0], floor)
 
 
 if __name__ == "__main__":

--- a/tests/test_stage0_log_readers.py
+++ b/tests/test_stage0_log_readers.py
@@ -301,8 +301,8 @@ class BackendOwnsIsMemoized(unittest.TestCase):
 class ViewSignatureKeysOnExactInputs(_StateSandbox):
     """The feed/timeline signature used to bust every ≤3 s because the judge generation advanced after
     EVERY producer pass, changed store or not — and the per-session tuple missed the SDK snapshot facts the
-    views render (subagent counts, an interrupt, a switch resolving), so those surfaced only via the 5 s
-    time bucket. Now the generation moves only when a pass moved a store, a judge call starting or ending
+    views render (subagent rows, a switch resolving), so those surfaced only via the 5 s time bucket. Now the
+    generation moves only when a pass moved a store, a judge call starting or ending
     is its own signature input, and the snapshot facts are in the tuple."""
 
     SID = "11111111-2222-3333-4444-999999999931"
@@ -338,11 +338,13 @@ class ViewSignatureKeysOnExactInputs(_StateSandbox):
 
     def test_c_snapshot_facts_move_the_signature_without_a_file_or_the_clock(self):
         now = NOW - (NOW % 5)                                 # inside one time bucket throughout
-        base = {"state": "working", "model": "m", "ctx": 10, "effort": "", "mode": "", "fast": "", "since": NOW - 60,
-                "subagents": [], "bgTasks": [], "interrupting": False, "modelPending": False, "retryCount": 0}
+        base = {"state": "working", "model": "m", "context": 10, "effort": "", "mode": "", "fast": "", "since": NOW - 60,
+                "subagents": [], "bgTasks": [], "modelPending": False, "retryCount": 0}
         s1 = km._fleet_view_sig(now, {self.SID: dict(base)})
         self.assertEqual(s1, km._fleet_view_sig(now + 1, {self.SID: dict(base)}), "same inputs, same bucket → same sig")
-        for k, v in (("subagents", [{"id": "a1"}]), ("bgTasks", [{"toolUseId": "t1"}]), ("interrupting", True),
+        # `interrupting` is not in the tuple: no liveness row carries it, and the WS stop op marks the views
+        # dirty itself (tests/test_kernel_timeline_split.py::SkeletonFromCache pins the keyed set)
+        for k, v in (("subagents", [{"id": "a1"}]), ("bgTasks", [{"toolUseId": "t1"}]), ("context", 20),
                      ("modelPending", True), ("retryCount", 3)):
             changed = dict(base); changed[k] = v
             self.assertNotEqual(s1, km._fleet_view_sig(now, {self.SID: changed}), k)

--- a/tests/test_stage0_log_readers.py
+++ b/tests/test_stage0_log_readers.py
@@ -168,7 +168,7 @@ class StatesReaders(_StateSandbox):
         with _OpenCounter(self.path) as c:
             _append_rows(self.path, [{"t": NOW - 10, "state": "working"}])
             self.assertEqual(km._last_state(SID), ("working", NOW - 10))
-            self.assertEqual(km._state_intervals(SID, "working", NOW)[-1], [NOW - 10, NOW])
+            self.assertEqual(km._state_intervals(SID, "working", NOW)[-1], [NOW - 10, NOW, True])   # open: the build clock, marked
         self.assertEqual(c.n, 1, "the grown file is opened once, for its tail")
 
     def test_e_a_missing_file_reads_as_before(self):

--- a/tests/test_timeline_msg_hover.py
+++ b/tests/test_timeline_msg_hover.py
@@ -41,13 +41,15 @@ class TimelineMessageHover(unittest.TestCase):
         pass1 = self.src[start:end]
         self.assertIn("u.hit = hit", pass1, "the connector pass should hand its hit target to the final pass")
         self.assertNotIn(
-            "svg.appendChild(hit)", pass1,
+            "plot.appendChild(hit)", pass1,
             "appending the hit path in the connector pass buries it under every dot drawn afterwards, "
             "which is exactly the vertical-run hover bug",
         )
 
     def test_hit_paths_are_appended_after_the_arrival_dots(self):
-        """Z-order contract: arrival dots (PASS 2) → connector hit targets (PASS 3) → prompt dots."""
+        """Z-order contract: arrival dots (PASS 2) → connector hit targets (PASS 3) → prompt dots. All three
+        go into the plot group the live tick translates, which keeps the old svg paint order within it, so
+        the pin reads `plot.appendChild`."""
         i_dots = self.src.index("PASS 2: message arrival dots")
         i_hits = self.src.index("PASS 3: the connector hit targets")
         i_prompt = self.src.index("turn process-start (prompt) dots")
@@ -55,7 +57,7 @@ class TimelineMessageHover(unittest.TestCase):
         self.assertLess(i_hits, i_prompt, "prompt dots are appended last so they keep their own hover")
         # the final pass actually appends the stashed hit targets
         tail = self.src[i_hits:i_prompt]
-        self.assertRegex(tail, r"svg\.appendChild\(u\.hit\)", "the final pass must append each stashed hit path")
+        self.assertRegex(tail, r"plot\.appendChild\(u\.hit\)", "the final pass must append each stashed hit path")
 
     def test_hit_stroke_is_wide_and_round_capped(self):
         """A short vertical run needs a generous, fully-covering target."""

--- a/tests/test_timeline_skeleton_dedup.py
+++ b/tests/test_timeline_skeleton_dedup.py
@@ -57,6 +57,9 @@ class SkeletonDedup(unittest.TestCase):
         import inspect
         src = inspect.getsource(km._push)
         self.assertIn('_send_client(c, ("timeline",), {"type": "data", "data": skel})', src)
+        # the warm path (the frame projected from the cached build, serialized once per build and deduped on
+        # content) is driven, not pinned: tests/test_kernel_timeline_split.py SkeletonFromCache and
+        # SkeletonSerializedOncePerBuild
 
 
 if __name__ == "__main__":

--- a/tests/test_view_deltas.py
+++ b/tests/test_view_deltas.py
@@ -821,6 +821,249 @@ class TwoThreadsOneClient(unittest.TestCase):
         self.assertEqual(st.c["dstate"]["bars"]["rev"], 0)
 
 
+def _bar(i):
+    return {"id": "seg-%d" % i, "t": i, "end": i + 1, "open": False}
+
+
+def _sig(p):
+    return km._parts_sig(km._delta_parts("bars", p))
+
+
+class TupleSignatureForTheSlots(unittest.TestCase):
+    """The pusher dedups a slot payload on _parts_sig — (rest_sig, the split's (collection, key order, entry
+    strings)) from the _delta_parts split it makes at the wire fill — not on json.dumps(payload) plus a sort_keys
+    re-dump of the payload minus its clock. Equal tuples mean equal entries, key order and remainder."""
+
+    def test_the_tuple_ignores_the_clock_and_moves_on_any_entry_lane_or_remainder(self):
+        p = _bars({S1: [_bar(1)], S2: [_bar(2)]}, [{"sid": S1, "judge": "closer", "t": 1, "t1": 2}], [{"id": "m1", "sent": 1}])
+        self.assertEqual(_sig(p), _sig(dict(p, now=2000)), "the clock is not part of the signature")
+        self.assertEqual(_sig(p), _sig(json.loads(json.dumps(p))), "an equal payload in a new object compares equal")
+        r = json.loads(json.dumps(p)); r["turns"][S1][0]["end"] = 9
+        self.assertNotEqual(_sig(p), _sig(r), "a bar's field")
+        r = json.loads(json.dumps(p)); r["turns"][S1].append(_bar(3))
+        self.assertNotEqual(_sig(p), _sig(r), "a bar appended")
+        r = json.loads(json.dumps(p)); r["turns"][S3] = r["turns"].pop(S1)
+        self.assertNotEqual(_sig(p), _sig(r), "the same bars under another lane: the key order carries the lane")
+        self.assertNotEqual(_sig(p), _sig(dict(p, warming=True)), "the remainder")
+        r = json.loads(json.dumps(p)); r["judging"][0]["t1"] = 3
+        self.assertNotEqual(_sig(p), _sig(r), "a judging entry")
+        r = json.loads(json.dumps(p)); r["messages"] = []
+        self.assertNotEqual(_sig(p), _sig(r), "a message removed")
+        self.assertEqual(_sig(p)[0], km._delta_parts("bars", p)[2])
+        self.assertEqual([name for name, _o, _e in _sig(p)[1]], ["turns", "judging", "messages"], "collections in table order")
+
+    def test_a_lane_reorder_is_stricter_than_the_old_signature_and_stays_exact_on_both_paths(self):
+        p = _bars({S1: [_bar(1)], S2: [_bar(2)]}, [], [])
+        q = _bars({S2: [_bar(2)], S1: [_bar(1)]}, [], [], now=1001)
+        self.assertEqual(km._dedup_sig(p, json.dumps(p)), km._dedup_sig(q, json.dumps(q)), "the sort_keys form hid dict order")
+        self.assertNotEqual(_sig(p), _sig(q), "the tuple does not: a reorder re-sends (towards more sends, never fewer)")
+        frac = km._DELTA_MAX_FRACTION; km._DELTA_MAX_FRACTION = 10.0   # synthetic payloads are tiny: the size guard would send wholes
+        self.addCleanup(setattr, km, "_DELTA_MAX_FRACTION", frac)
+        st = _Stream("bars")                          # a delta client: an order-only delta, no set, no del
+        st.push(p)
+        fr = st.push(q)
+        self.assertEqual([f["type"] for f in fr], ["delta"])
+        self.assertEqual(fr[0]["coll"], {"turns": {"order": [S2 + SEP + "seg-2", S1 + SEP + "seg-1"]}})
+        self.assertEqual(list(st.held["turns"]), [S2, S1], "the mirror assembles the new lane order")
+        c = _Client(); c.pop("delta")                 # a legacy client: one full frame, then deduped
+        km._send_slot(c, "bars", p, json.dumps(p), _sig(p))
+        km._send_slot(c, "bars", q, json.dumps(q), _sig(q))
+        q2 = dict(q, now=1002)
+        km._send_slot(c, "bars", q2, json.dumps(q2), _sig(q2))
+        self.assertEqual([f["type"] for f in c.frames], ["bars", "bars"])
+        self.assertEqual(list(c.frames[1]["turns"]), [S2, S1])
+
+    def test_the_split_made_at_the_fill_is_handed_down_and_recorded_by_identity(self):
+        p = _bars({S1: [_bar(1)]}, [], [])
+        parts = km._delta_parts("bars", p)
+        km._delta_parts_cache.clear()                 # a connect push on another thread evicted the single slot
+        c = _Client()
+        with mock.patch.object(km, "_delta_parts", side_effect=AssertionError("re-split")):
+            km._send_slot(c, "bars", p, json.dumps(p), km._parts_sig(parts), parts)
+            self.assertIs(c["dstate"]["bars"]["parts"], parts, "the keyed full records the split it was handed")
+            km._send_slot(c, "bars", p, json.dumps(p), km._parts_sig(parts), parts)
+            self.assertEqual(len(c.frames), 1, "the same split: the identity short-circuit, no compare, no re-split")
+        # without a split handed down the path splits for itself, as every caller before the fill did
+        q = _bars({S1: [_bar(1), _bar(2)]}, [], [], now=1001)
+        frac = km._DELTA_MAX_FRACTION; km._DELTA_MAX_FRACTION = 10.0
+        self.addCleanup(setattr, km, "_DELTA_MAX_FRACTION", frac)
+        km._send_slot(c, "bars", q, json.dumps(q), _sig(q))
+        self.assertEqual([f["type"] for f in c.frames], ["bars", "delta"])
+        self.assertIs(c["dstate"]["bars"]["parts"], km._delta_parts("bars", q))
+
+    def test_a_lazy_pre_is_serialized_only_when_a_whole_frame_goes(self):
+        frac = km._DELTA_MAX_FRACTION; km._DELTA_MAX_FRACTION = 10.0
+        self.addCleanup(setattr, km, "_DELTA_MAX_FRACTION", frac)
+        p = _bars({S1: [_bar(1)]}, [], []); parts = km._delta_parts("bars", p); calls = []
+        lazy = km._LazyWire(lambda: (calls.append("p"), json.dumps(p))[1], km._parts_est(parts))
+        c = _Client()
+        km._send_slot(c, "bars", p, lazy, km._parts_sig(parts), parts)      # the keyed full: made once, keyed
+        self.assertEqual(calls, ["p"]); self.assertIn("_keys", c.frames[0]); self.assertEqual(lazy.size(), len(json.dumps(p)))
+        km._send_slot(c, "bars", p, lazy, km._parts_sig(parts), parts)      # unchanged: the size only
+        self.assertEqual(calls, ["p"])
+        q = _bars({S1: [_bar(1), _bar(2)]}, [], [], now=1001); qparts = km._delta_parts("bars", q)
+        qlazy = km._LazyWire(lambda: (calls.append("q"), json.dumps(q))[1], km._parts_est(qparts))
+        km._send_slot(c, "bars", q, qlazy, km._parts_sig(qparts), qparts)   # a delta goes: the whole frame is never made
+        self.assertEqual([f["type"] for f in c.frames], ["bars", "delta"])
+        self.assertEqual(calls, ["p"]); self.assertFalse(qlazy.materialized())
+        self.assertLess(qlazy.size(), len(json.dumps(q)), "unmade: the estimate (the frame's own keys are not in it)")
+        self.assertGreater(qlazy.size(), 0)
+        legacy = _Client(); legacy.pop("delta")                            # a whole-frame client makes it, once
+        km._send_slot(legacy, "bars", q, qlazy, km._parts_sig(qparts), qparts)
+        km._send_slot(legacy, "bars", q, qlazy, km._parts_sig(qparts), qparts)
+        self.assertEqual(calls, ["p", "q"]); self.assertEqual([f["type"] for f in legacy.frames], ["bars"])
+        self.assertEqual(legacy.frames[0], q)
+
+    def test_the_size_guard_reads_the_estimate_and_falls_back_to_a_whole_frame(self):
+        # _DELTA_MAX_FRACTION at its real value: a near-total change against a lazy `pre` crosses whole (the
+        # estimate a little under the frame only makes that slightly more eager), and the whole frame is then
+        # made — once — for the keyed full
+        st = _Stream("bars")
+        st.push(_bars({S1: [_bar(1)]}, [], []))
+        big = _bars({S1: [_bar(i) for i in range(40)], S2: [_bar(i) for i in range(40)]}, [], [], now=1020)
+        parts = km._delta_parts("bars", big); calls = []
+        lazy = km._LazyWire(lambda: (calls.append(1), json.dumps(big))[1], km._parts_est(parts))
+        n0 = len(st.c.frames)
+        km._send_slot(st.c, "bars", big, lazy, km._parts_sig(parts), parts)
+        self.assertEqual([f["type"] for f in st.c.frames[n0:]], ["bars"], "a near-total change crosses whole")
+        self.assertEqual(calls, [1]); self.assertIn("_keys", st.c.frames[-1])
+
+    def test_the_feed_slot_takes_the_same_tuple_and_a_reordered_card_re_sends_once_then_dedups(self):
+        def card(i, **f):
+            d = {"itemId": "%s:g%d" % (S1, i), "sid": S1, "text": "Synthetic goal %d" % i, "t": i, "column": "working",
+                 "tree": [{"id": "%s:g%d.1" % (S1, i), "text": "step", "status": "done"}]}
+            d.update(f)
+            return d
+        fsig = lambda p: km._parts_sig(km._delta_parts("feed", p))
+        p = _feed([card(1), card(2)])
+        self.assertEqual(fsig(p), fsig(_feed([card(1), card(2)], now=2000, buildId=2)), "the clock and the build id are not in it")
+        self.assertNotEqual(fsig(p), fsig(_feed([card(1), card(2, text="changed")])), "a card's field")
+        self.assertNotEqual(fsig(p), fsig(_feed([card(1), card(2), card(3)])), "a card appended")
+        self.assertNotEqual(fsig(p), fsig(_feed([card(1), card(2)], working=[S1])), "the remainder")
+        self.assertEqual([name for name, _o, _e in fsig(p)[1]], ["asks"])
+        # the sort_keys form was key-order-insensitive at every level; the tuple compares the strings a client
+        # receives, so a card whose nested keys are reordered with equal content is one spurious frame (never a
+        # stale client), then deduped — on the legacy path a whole frame, on the delta path a one-card set
+        f1 = _feed([card(1), card(2), card(3)])
+        f2 = _feed([card(1), dict(reversed(list(card(2).items()))), card(3)], now=1001)
+        f3 = _feed([dict(a) for a in f2["asks"]], now=1002)
+        self.assertEqual(km._dedup_sig(f1, json.dumps(f1)), km._dedup_sig(f2, json.dumps(f2)), "the old signature deduped this")
+        self.assertNotEqual(fsig(f1), fsig(f2)); self.assertEqual(fsig(f2), fsig(f3))
+        c = _Client(); c.pop("delta")
+        for f in (f1, f2, f3):
+            km._send_slot(c, "feed", f, json.dumps(f), fsig(f))
+        self.assertEqual([f["type"] for f in c.frames], ["feed", "feed"], "the reordered card re-sends once, then dedups")
+        self.assertEqual(list(c.frames[1]["asks"][1]), list(f2["asks"][1]), "the frame carries the new order")
+        frac = km._DELTA_MAX_FRACTION; km._DELTA_MAX_FRACTION = 10.0
+        self.addCleanup(setattr, km, "_DELTA_MAX_FRACTION", frac)
+        d = _Client()
+        for f in (f1, f2, f3):
+            km._send_slot(d, "feed", f, json.dumps(f), fsig(f))
+        self.assertEqual([f["type"] for f in d.frames], ["feed", "delta"])
+        self.assertEqual(d.frames[1]["coll"], {"asks": {"set": {S1 + ":g2": f2["asks"][1]}}}, "the one card whose string moved")
+
+    def test_a_lane_renamed_in_place_with_equal_bars_moves_the_tuple_and_re_sends(self):
+        # the key order carries the lanes: the same bars under another lane name, in the same position, are the same
+        # entry strings in the same order — only the keys tell them apart (the lane-move case above pops and appends,
+        # which reorders the strings too, so it passes without the key order)
+        p = _bars({S1: [_bar(1)], S2: [_bar(2)]}, [], [])
+        r = _bars({S3: [_bar(1)], S2: [_bar(2)]}, [], [], now=1001)
+        self.assertEqual([e for _n, _o, e in _sig(p)[1]], [e for _n, _o, e in _sig(r)[1]], "equal entry strings, in order")
+        self.assertNotEqual(_sig(p), _sig(r), "…and the key order tells the lanes apart")
+        c = _Client(); c.pop("delta")                 # a legacy client dedups on the tuple alone
+        km._send_slot(c, "bars", p, json.dumps(p), _sig(p))
+        km._send_slot(c, "bars", r, json.dumps(r), _sig(r))
+        self.assertEqual([list(f["turns"]) for f in c.frames], [[S1, S2], [S3, S2]], "the renamed lane crosses; the client is not left holding the old one")
+
+    def test_a_deduped_whole_frame_client_never_materializes_a_fresh_cell(self):
+        # a content-equal rebuild mints a new payload and a new lazy cell; a legacy client that holds the frame dedups on
+        # the tuple, and the dedup costs the cell its size() only — the frame is never serialized
+        p = _bars({S1: [_bar(1)]}, [], []); parts = km._delta_parts("bars", p)
+        legacy = _Client(); legacy.pop("delta")
+        a = km._LazyWire(lambda: json.dumps(p), km._parts_est(parts))
+        km._send_slot(legacy, "bars", p, a, km._parts_sig(parts), parts)
+        self.assertTrue(a.materialized()); self.assertEqual(len(legacy.frames), 1, "the first frame goes, made once")
+        q = json.loads(json.dumps(p)); q["now"] = 1001; qparts = km._delta_parts("bars", q); calls = []
+        b = km._LazyWire(lambda: (calls.append(1), json.dumps(q))[1], km._parts_est(qparts))
+        km._send_slot(legacy, "bars", q, b, km._parts_sig(qparts), qparts)
+        self.assertEqual(len(legacy.frames), 1, "deduped"); self.assertEqual(calls, [], "…without serializing the new cell")
+        self.assertFalse(b.materialized()); self.assertEqual(b.size(), km._parts_est(qparts), "the estimate answered the size guard")
+
+    def test_a_whole_frame_whose_encode_raises_leaves_the_dedup_slot_for_a_retry(self):
+        # _send_client materializes a lazy frame BEFORE it writes the client's dedup slot: an encode that raises leaves
+        # the slot empty, so the next cycle's send is not deduped against a frame that never went
+        p = _bars({S1: [_bar(1)]}, [], []); parts = km._delta_parts("bars", p)
+        legacy = _Client(); legacy.pop("delta")
+        boom = [True]
+
+        def encode():
+            if boom[0]:
+                boom[0] = False
+                raise ValueError("synthetic encode failure")
+            return json.dumps(p)
+        cell = km._LazyWire(encode, km._parts_est(parts))
+        with self.assertRaises(ValueError):
+            km._send_slot(legacy, "bars", p, cell, km._parts_sig(parts), parts)
+        self.assertEqual(legacy.frames, []); self.assertFalse(cell.materialized())
+        self.assertNotIn(("timelinebars",), legacy.get("sent", {}), "no frame went: the dedup slot is not written")
+        km._send_slot(legacy, "bars", p, cell, km._parts_sig(parts), parts)      # the retry: the encode works, the frame goes
+        self.assertEqual([f["type"] for f in legacy.frames], ["bars"]); self.assertTrue(cell.materialized())
+        self.assertEqual(legacy["sent"][("timelinebars",)][0], km._parts_sig(parts))
+
+
+class KeyerParsesTheKindOnce(unittest.TestCase):
+    """_delta_split parses a collection's kind once (_delta_keyer) instead of once per item; the keys are
+    byte-identical to the per-item form (_delta_key, kept as its wrapper)."""
+
+    def test_delta_key_and_the_keyer_agree_on_every_kind_and_shape(self):
+        items = [{"id": "a"}, {"id": ""}, {"id": None}, {"id": 1.0}, {"id": "#1"}, {"itemId": "x:g1"}, {"itemId": ""},
+                 {"sid": S1, "t": 1, "judge": "closer", "t1": None}, {"sid": S1}, "not a dict", 7, None, {}]
+        for kind in ("byid", "byid:itemId", "dictlist:id", "bykeys:sid,t,judge,t1", "dict", "weird"):
+            keyer = km._delta_keyer(kind)
+            for it in items:
+                for prefix in ("", "lane" + SEP):
+                    self.assertEqual(keyer(it, prefix), km._delta_key(kind, it, prefix), (kind, it, prefix))
+        self.assertEqual(km._delta_keyer("bykeys:sid,t,judge,t1")({"sid": S1, "t": 1, "judge": "closer", "t1": None}),
+                         S1 + SEP + "1" + SEP + "closer" + SEP + "None")
+        self.assertEqual(km._delta_keyer("bykeys:sid,t,judge,t1")({"sid": S1}, "p"), "p" + S1 + SEP + "None" + SEP + "None" + SEP + "None")
+        self.assertEqual(km._delta_keyer("byid:itemId")({"itemId": 1.0}, "p"), "p1.0")
+        self.assertIsNone(km._delta_keyer("byid")({"id": ""}), "an empty id would spell the bare-prefix marker")
+        self.assertIsNone(km._delta_keyer("dict")({"id": "a"}))
+
+    def test_delta_split_output_is_pinned_on_duplicate_unkeyable_and_empty_entries(self):
+        # the (entries, key order) a split produces, spelled out: positional keys for a duplicate or unkeyable
+        # item, a bare-prefix entry for an empty or non-list lane — the shape the shim reassembles from
+        enc = lambda v: json.dumps(v, default=str)
+        ents, order = km._delta_split("dictlist:id", {S1: [_bar(1), _bar(1), {"t": 3}, "str"], S2: [], S3: None})
+        self.assertEqual(order, [S1 + SEP + "seg-1", S1 + SEP + "#1", S1 + SEP + "#2", S1 + SEP + "#3", S2 + SEP, S3 + SEP])
+        self.assertEqual(ents[S1 + SEP + "seg-1"], (_bar(1), enc(_bar(1))))
+        self.assertEqual(ents[S1 + SEP + "#1"], (_bar(1), enc(_bar(1))), "the duplicate keeps a positional key")
+        self.assertEqual(ents[S1 + SEP + "#2"], ({"t": 3}, enc({"t": 3})))
+        self.assertEqual(ents[S1 + SEP + "#3"], ("str", '"str"'))
+        self.assertEqual(ents[S2 + SEP], ([], "[]")); self.assertEqual(ents[S3 + SEP], (None, "null"))
+        ents, order = km._delta_split("byid", [{"id": "a"}, {"id": "a"}, {"id": ""}, {"id": "#1"}, 5])
+        self.assertEqual(order, ["a", "#1", "#2", "#3", "#4"])
+        self.assertEqual(ents["#1"][0], {"id": "a"}); self.assertEqual(ents["#3"][0], {"id": "#1"}, "a real id spelling #1 is displaced, never overwritten")
+        self.assertEqual(ents["#4"], (5, "5"))
+        j = {"sid": S1, "t": 1, "judge": "j", "t1": 2}
+        ents, order = km._delta_split("bykeys:sid,t,judge,t1", [j, dict(j), {"sid": S1, "t": 1, "judge": "j", "t1": 2.0}])
+        self.assertEqual(order, [S1 + SEP + "1" + SEP + "j" + SEP + "2", "#1", S1 + SEP + "1" + SEP + "j" + SEP + "2.0"])
+        ents, order = km._delta_split("dict", {"b": 1, "a": [2]})
+        self.assertEqual(order, ["b", "a"]); self.assertEqual(ents["a"], ([2], "[2]"))
+        with self.assertRaises(ValueError):
+            km._delta_split("byid", None)
+        with self.assertRaises(ValueError):
+            km._delta_split("dictlist:id", {"la" + SEP + "ne": []})
+
+    def test_the_keyer_is_built_once_per_split(self):
+        # the perf claim itself: one _delta_keyer call per _delta_split, however many items — parsing the kind string
+        # per item was a visible share of the per-entry pass on a board of thousands of bars
+        calls = []; real = km._delta_keyer
+        with mock.patch.object(km, "_delta_keyer", side_effect=lambda kind: calls.append(kind) or real(kind)):
+            ents, order = km._delta_split("dictlist:id", {S1: [_bar(i) for i in range(50)], S2: [_bar(i) for i in range(50)]})
+        self.assertEqual(len(order), 100); self.assertEqual(len(ents), 100)
+        self.assertEqual(calls, ["dictlist:id"], "the kind is parsed once per split, not once per item")
+
 
 
 if __name__ == "__main__":

--- a/tests/test_view_deltas.py
+++ b/tests/test_view_deltas.py
@@ -332,6 +332,80 @@ class BarsDeltas(unittest.TestCase):
         fr = st.push(_bars({S1: self._turn(S1, 2)}, [], [], now=1005))
         self.assertEqual([f["type"] for f in fr], ["delta"], "…and the stream continues as deltas the client can apply")
 
+    def test_n_the_same_payload_object_pushed_again_skips_the_per_entry_compare_until_the_repost(self):
+        """The builders reuse an unchanged payload object across cycles (the pusher holds the bars by the cached
+        timeline's identity), so the split the client's state was last written from is the split this cycle would
+        compare against it: the compare is skipped and nothing is sent. Past the repost window the compare runs and
+        the repost goes. An EQUAL payload in a new object (a content-equal rebuild) is compared once, which adopts its
+        split, and that object is short-circuited from then on."""
+        st = _Stream("bars")
+        p = _bars({S1: self._turn(S1, 3), S2: self._turn(S2, 2)}, [{"sid": S1, "judge": "closer", "t": 1, "t1": 2}], [])
+        st.push(p)
+        self.assertIs(st.c["dstate"]["bars"]["parts"], km._delta_parts("bars", p), "the keyed full records the split it went from")
+        real_order, real_shape, calls = km._client_order, km._order_shape, []
+        def order(*a): calls.append("_client_order"); return real_order(*a)
+        def shape(*a): calls.append("_order_shape"); return real_shape(*a)
+        with mock.patch.object(km, "_client_order", order), mock.patch.object(km, "_order_shape", shape):
+            self.assertEqual(st.push(p), [], "the same object: nothing to send")
+            self.assertEqual(st.push(p), [])
+            self.assertEqual(calls, [], "…and no per-entry compare ran to find that out")
+            st.c["dstate"]["bars"]["at"] -= km._DEDUP_REPOST_S + 1
+            fr = st.push(p)
+            self.assertEqual(len(fr), 1); self.assertEqual(fr[0]["type"], "delta"); self.assertEqual(fr[0]["coll"], {})
+            self.assertTrue(calls, "past the repost window the same object is compared and the repost goes")
+            self.assertIs(st.c["dstate"]["bars"]["parts"], km._delta_parts("bars", p), "a delta that went records its split")
+            del calls[:]
+            q = dict(p, now=1002)                              # an equal payload in a NEW object: a content-equal rebuild
+            self.assertEqual(st.push(q), [], "an equal payload in a new object still sends nothing…")
+            self.assertTrue(calls, "…by comparing once: identity is the short-circuit, not equality")
+            self.assertIs(st.c["dstate"]["bars"]["parts"], km._delta_parts("bars", q), "…and the compare adopts the new split")
+            del calls[:]
+            self.assertEqual(st.push(q), [], "the same new object again: nothing to send")
+            self.assertEqual(calls, [], "…and no compare: the adopted split is an identity hit")
+        p2 = json.loads(json.dumps(p)); p2["turns"][S2] = self._turn(S2, 3); p2["now"] = 1005
+        self.assertEqual([f["type"] for f in st.push(p2)], ["delta"])
+        self.assertIs(st.c["dstate"]["bars"]["parts"], km._delta_parts("bars", p2), "the held split follows the change")
+        self.assertEqual(st.push(p2), []); self.assertEqual(st.held, p2)
+
+    def test_o_a_raising_send_on_the_delta_path_leaves_the_revision_and_the_held_split_unchanged(self):
+        """A frame that did not go does not advance what the client holds: the revision stays, and the held split
+        stays the one the last frame that went was written from, so the payload that failed is not an identity hit
+        next cycle and the compare runs against the state the client really holds."""
+        st = _Stream("bars")
+        st.push(_bars({S1: self._turn(S1, 1)}, [], []))
+        fr = st.push(_bars({S1: self._turn(S1, 2)}, [], [], now=1005))
+        self.assertEqual([f["type"] for f in fr], ["delta"])
+        rev, held = st.c["dstate"]["bars"]["rev"], st.c["dstate"]["bars"]["parts"]
+        def boom(s): raise RuntimeError("synthetic socket failure")   # not a "bytes behind" drop: no bell row
+        st.c["send"] = boom
+        p3 = _bars({S1: self._turn(S1, 3)}, [], [], now=1010)
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(st.push(p3), [])
+        self.assertFalse(st.c["alive"], "a failed send marks the client dead")
+        self.assertEqual(st.c["dstate"]["bars"]["rev"], rev, "a frame that did not go does not advance what the client holds")
+        self.assertIs(st.c["dstate"]["bars"]["parts"], held, "…nor the split its state was written from")
+        self.assertIsNot(st.c["dstate"]["bars"]["parts"], km._delta_parts("bars", p3))
+
+    def test_p_an_unchanged_compare_leaves_the_repost_timer_on_the_last_frame_that_went(self):
+        """The unchanged branch adopts the split but leaves `at` alone, and so does the identity short-circuit: the
+        repost timer counts from the last frame that WENT, so a content-equal rebuild every cycle cannot postpone the
+        repost that keeps the pane's clock and fade alive."""
+        st = _Stream("bars")
+        p = _bars({S1: self._turn(S1, 2)}, [], [])
+        st.push(p)                                                 # the keyed full: the frame that went
+        ds = st.c["dstate"]["bars"]
+        ds["at"] -= km._DEDUP_REPOST_S - 5                         # …55 s ago
+        at0 = ds["at"]
+        q = dict(p, now=1002)                                      # a content-equal rebuild: compared once, adopted
+        self.assertEqual(st.push(q), [])
+        self.assertIs(ds["parts"], km._delta_parts("bars", q), "the compare adopted the new split")
+        self.assertEqual(st.push(q), [], "…so the same object is an identity hit")
+        self.assertEqual(ds["at"], at0, "neither branch moved the repost timer")
+        with mock.patch.object(km, "_DEDUP_REPOST_S", km._DEDUP_REPOST_S - 10):   # the window closes on the 55 s old frame
+            fr = st.push(q)
+        self.assertEqual([f["type"] for f in fr], ["delta"], "the repost goes, timed from the frame that went")
+        self.assertEqual(fr[0]["coll"], {}); self.assertEqual(fr[0]["rest"], {"now": 1002})
+
 
     def test_g_a_bar_appended_to_an_earlier_lane_crosses_alone_and_lands_in_its_lane(self):
         """The flat key order changes (the new bar sits before the later lanes' bars) but the assembled

--- a/tests/test_wake_deadman_toggle.py
+++ b/tests/test_wake_deadman_toggle.py
@@ -76,7 +76,7 @@ class _Base(unittest.TestCase):
         km._compacting_now = lambda sid: False
         km._api_error = lambda path: None
         km._session_working = lambda turns: False
-        km._interrupt_suppresses_nudge = lambda turns, sid="": False
+        km._interrupt_suppresses_nudge = lambda turns, sid="", **k: False
         km._backend_rewind_pending = lambda sid: False
         km._last_state = lambda sid: ("", 0)
         km._session_awaiting = lambda *a, **k: None

--- a/tests/test_wire_once_per_build.py
+++ b/tests/test_wire_once_per_build.py
@@ -424,6 +424,21 @@ class ANonJsonValueOnTheWireIsCountedAndSaidOnce(unittest.TestCase):
                                          "wire: frozenset serialized via str() in synthetic\n",
                          "one line per type, naming the encoder")
 
+    def test_the_first_sighting_of_a_type_files_one_refused_bell_row(self):
+        # A counter and a stderr line reach nobody at the dashboard: the repo's convention for a fault the
+        # user should see is one bell row of kind "refused" per distinct fault (#1020, the state readers).
+        # The type name is the fault's identity, so the row files once per type, beside the stderr line
+        # (review find, 2026-09-08).
+        notices = []
+        with mock.patch.object(km, "_sync_notice", lambda text, ok=True, kind="sync": notices.append((text, ok, kind))), \
+                redirect_stderr(io.StringIO()):
+            km._wire_default({1}, "synthetic"); km._wire_default({2}, "synthetic")
+            km._wire_default(frozenset(), "bars.body")
+        self.assertEqual([(ok, k) for _t, ok, k in notices], [(False, "refused"), (False, "refused")],
+                         "one row per distinct type, none for a repeat")
+        self.assertIn("set", notices[0][0]); self.assertIn("synthetic", notices[0][0])
+        self.assertIn("frozenset", notices[1][0]); self.assertIn("bars.body", notices[1][0])
+
     def test_a_bars_payload_carrying_a_set_ships_the_string_to_a_legacy_timeline_client(self):
         tl_build = _timeline(); tl_build["turns"][SID][0]["tags"] = {"a"}
         _World(self, timeline=tl_build)

--- a/tests/test_wire_once_per_build.py
+++ b/tests/test_wire_once_per_build.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""One encode per payload per build on the pusher thread.
+
+Each rebuild used to serialize the feed and the bars THREE times on the pusher thread: the whole frame
+(json.dumps in _push), the dedup signature (_dedup_sig: a sort_keys re-dump of the payload minus its clock,
+which both frames carry) and the per-entry pass the view-delta path needs (_delta_parts, on the first delta
+client's send). Now the per-entry pass is the only encode: the signature is a tuple of its strings
+(_parts_sig), and the whole frame is a _LazyWire cell made on the first send that actually needs one — a
+client without deltas, a fresh socket, a re-base, a delta past the size guard — and kept in the wire tuple
+(_feed_wire, _bars_wire) for the next. The split is handed down to _send_slot, so a connect push on another
+thread evicting _delta_parts_cache's single slot between the fill and the send costs no re-split.
+
+Synthetic only: placeholder ids, the notes-api demo world, TESTHOST.
+"""
+import collections
+import io
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+from contextlib import redirect_stderr
+from importlib.machinery import SourceFileLoader
+from unittest import mock
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_wireonce", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+NOW = 1781100000
+
+
+def _card(i, text=None):
+    t = NOW - i * 60
+    return {"itemId": "%s:g%d" % (SID, i), "sid": SID, "name": "web", "color": None,
+            "text": text or "Synthetic goal %d on the notes-api board" % i, "t": t, "live": True,
+            "trgb": [10, 20, 30], "column": "working", "summary": "s" * 200,
+            "tree": [{"id": "%s:g%d.%d" % (SID, i, j), "text": "step %d" % j, "status": "done", "t": t, "last": t,
+                      "trgb": [10, 20, 30], "children": []} for j in range(4)]}
+
+
+def _feed(n=5, build_id=1, now=NOW, asks=None):
+    return {"type": "feed", "asks": asks if asks is not None else [_card(i) for i in range(n)], "now": now,
+            "buildId": build_id, "order": [SID], "working": ["web"], "awaiting": [],
+            "sessions": [{"sid": SID, "name": "web", "color": None}], "userTodos": {}, "views": {},
+            "clearNotices": [], "syncNotices": [], "sdkNotices": [], "selfHost": "TESTHOST"}
+
+
+def _timeline(nbars=2, now=1, unkeyable=False):
+    turns = {SID: [{"id": "b%d" % i, "t": i, "end": i + 1, "open": False} for i in range(nbars)]}
+    return {"type": "timeline", "sessions": [{"id": SID, "name": "web"}],
+            "turns": None if unkeyable else turns,        # None where a dict belongs: _delta_parts cannot key it
+            "judging": [], "messages": [], "now": now}
+
+
+def _bars_of(tl, warming=False):
+    return {"type": "bars", "turns": tl["turns"], "judging": tl["judging"], "messages": tl["messages"],
+            "now": tl["now"], "warming": warming}
+
+
+def _client(app, delta=True):
+    """A ws client as _push sees it, its frames captured; `delta` is the ?delta=1 announcement every browser
+    pane makes — False is a pipe or a relay that takes whole frames."""
+    c = {"app": app, "alive": True, "wid": "w-" + app, "qbytes": 0, "sent": {}, "delta": delta, "frames": []}
+    c["send"] = lambda s: c["frames"].append(json.loads(s))
+    return c
+
+
+def _delta(after, before):
+    return {k: after[k] - before[k] for k in after if after[k] != before[k]}
+
+
+def _wire_lines(err):
+    """_wire_default's stderr lines only: a process's first _push also writes the backends' start-up notices."""
+    return [l for l in err.getvalue().splitlines() if l.startswith("wire: ")]
+
+
+class _World:
+    """Stub the builders so _push serves synthetic feed and timeline builds — the recipe
+    tests/test_kernel_timeline_split.py uses, plus _cached_feed — with every wire cache emptied first and
+    restored after. `feed`/`timeline` are what the next push builds; reassign them for a rebuild."""
+
+    NAMES = ("_cached_feed", "_cached_timeline", "build_timeline", "_tmux_sessions", "_fleet_view_sig", "_DELTA_MAX_FRACTION")
+
+    def __init__(self, test, feed=None, timeline=None):
+        self.feed, self.timeline = feed, timeline
+        saved = {n: getattr(km, n) for n in self.NAMES}
+        saved_wire = (km._feed_wire, km._bars_wire, km._skel_wire, dict(km._delta_parts_cache))
+        saved_built = (list(km._built_feed), list(km._built_timeline))
+        km._cached_feed = lambda now, tmux, sig, connect=False: self.feed
+        km._cached_timeline = lambda now, tmux, sig, connect=False: self.timeline
+        km.build_timeline = lambda now, tmux, with_bars=True, live_only=False: self.timeline
+        km._tmux_sessions = lambda: {}
+        km._fleet_view_sig = lambda now, tmux: ("sig",)
+        km._DELTA_MAX_FRACTION = 10.0        # synthetic payloads are tiny: the size guard would send wholes
+        km._feed_wire = km._bars_wire = km._skel_wire = None
+        km._delta_parts_cache.clear()
+        km._built_timeline[:] = [None, timeline, time.time(), time.time()]   # warmed: a connect push serves the cache
+
+        def restore():
+            for n, v in saved.items():
+                setattr(km, n, v)
+            km._feed_wire, km._bars_wire, km._skel_wire = saved_wire[:3]
+            km._delta_parts_cache.clear(); km._delta_parts_cache.update(saved_wire[3])
+            km._built_feed[:] = saved_built[0]; km._built_timeline[:] = saved_built[1]
+        test.addCleanup(restore)
+
+
+class OneEncodePerBuild(unittest.TestCase):
+
+    def test_a_rebuild_encodes_each_payload_once_and_whole_frames_only_where_one_goes(self):
+        w = _World(self, feed=_feed(), timeline=_timeline())
+        dfeed = _client("feed")                                   # the feed pane: slot deltas
+        legacy = _client("feed", delta=False)                     # a pipe, a relay: whole frames
+        tl = _client("timeline")                                  # every timeline pane: slot deltas
+        splits = collections.Counter()
+        real_split = km._delta_split
+        with mock.patch.object(km, "_delta_split", side_effect=lambda kind, v: splits.update([kind]) or real_split(kind, v)):
+            s0 = dict(km._wire_stats)
+            km._push([dfeed, legacy, tl])
+            self.assertEqual(sum(splits.values()), 4, "one per-entry pass per payload: the feed's one collection, the bars' three")
+            self.assertEqual([f["type"] for f in dfeed["frames"]], ["feed"]); self.assertIn("_keys", dfeed["frames"][0])
+            self.assertEqual([f["type"] for f in legacy["frames"]], ["feed"]); self.assertNotIn("_keys", legacy["frames"][0])
+            self.assertEqual([f["type"] for f in tl["frames"]], ["data", "bars"]); self.assertIn("_keys", tl["frames"][1])
+            self.assertEqual(_delta(km._wire_stats, s0), {"feed_body": 1, "bars_body": 1},
+                             "one whole frame each, shared by the keyed full and the legacy client")
+            self.assertEqual(km._feed_wire[4], km._parts_sig(km._feed_wire[5]), "the feed's signature is the split's tuple")
+            self.assertEqual(km._bars_wire[4], km._parts_sig(km._bars_wire[5]), "so is the bars'")
+            self.assertEqual(legacy["sent"][("feed",)][0], km._feed_wire[4])
+            self.assertEqual(dfeed["sent"][("feed",)][0], km._feed_wire[4])
+            # a second cycle over the same builds: nothing encoded, nothing made, nothing sent
+            splits.clear(); s0 = dict(km._wire_stats); n = [len(c["frames"]) for c in (dfeed, legacy, tl)]
+            km._push([dfeed, legacy, tl])
+            self.assertEqual(dict(splits), {})
+            self.assertEqual(_delta(km._wire_stats, s0), {})
+            self.assertEqual([len(c["frames"]) for c in (dfeed, legacy, tl)], n)
+            # a rebuild seen only by delta clients: the per-entry pass runs, no whole frame is ever made
+            w.feed = _feed(build_id=2, asks=[_card(i, text="changed" if i == 2 else None) for i in range(5)])
+            w.timeline = _timeline(nbars=3, now=2)
+            splits.clear(); s0 = dict(km._wire_stats)
+            km._push([dfeed, tl])
+            self.assertEqual(sum(splits.values()), 4)
+            self.assertEqual(_delta(km._wire_stats, s0), {})
+            self.assertEqual(dfeed["frames"][-1]["type"], "delta")
+            self.assertEqual(list(dfeed["frames"][-1]["coll"]["asks"]["set"]), ["%s:g2" % SID])
+            self.assertEqual(tl["frames"][-1]["type"], "delta")
+            self.assertFalse(km._feed_wire[3].materialized(), "no client took a whole feed frame")
+            self.assertFalse(km._bars_wire[3].materialized(), "…or a whole bars frame")
+            # the legacy client joins the next cycle: this build's whole frame is made now, once
+            splits.clear(); s0 = dict(km._wire_stats)
+            km._push([dfeed, legacy, tl])
+            self.assertEqual(dict(splits), {})
+            self.assertEqual(_delta(km._wire_stats, s0), {"feed_body": 1})
+            self.assertEqual(legacy["frames"][-1]["buildId"], 2)
+            self.assertTrue(km._feed_wire[3].materialized())
+            self.assertEqual(km._feed_wire[3].size(), len(json.dumps(w.feed)), "size() is exact once made")
+
+    def test_the_split_made_at_the_fill_is_the_one_the_delta_path_records(self):
+        _World(self, feed=_feed(), timeline=_timeline())
+        dfeed, tl = _client("feed"), _client("timeline")
+        km._push([dfeed, tl])
+        fparts, bparts = km._feed_wire[5], km._bars_wire[5]
+        self.assertIsNotNone(fparts); self.assertIsNotNone(bparts)
+        self.assertIs(dfeed["dstate"]["feed"]["parts"], fparts, "handed down, not re-split")
+        self.assertIs(tl["dstate"]["bars"]["parts"], bparts,
+                      "handed down, not re-split (single-threaded here; the hand-down is what makes it hold under a "
+                      "concurrent connect push, which can evict _delta_parts_cache's single slot)")
+        self.assertEqual(km._feed_wire[4], km._parts_sig(fparts)); self.assertEqual(km._bars_wire[4], km._parts_sig(bparts))
+        km._delta_parts_cache.clear()                 # a connect push on another thread evicted the slot
+        with mock.patch.object(km, "_delta_parts", side_effect=AssertionError("re-split")):
+            km._push([dfeed, tl])                     # the wire hit hands the split down: no re-split, nothing sent
+        self.assertEqual([f["type"] for f in dfeed["frames"]], ["feed"])
+        self.assertEqual([f["type"] for f in tl["frames"]], ["data", "bars"])
+
+    def test_an_unkeyable_bars_build_takes_whole_frames_and_the_string_signature(self):
+        w = _World(self, timeline=_timeline(unkeyable=True))   # turns None where a dict belongs: _delta_parts gives None
+        tl = _client("timeline")
+        km._delta_unkeyable_said.clear()
+        s0 = dict(km._wire_stats); err = io.StringIO()
+        with redirect_stderr(err):
+            km._push([tl]); km._push([tl])
+        self.assertEqual([f["type"] for f in tl["frames"]], ["data", "bars"], "the whole frame went once; the repeat deduped")
+        self.assertNotIn("_keys", tl["frames"][1])
+        self.assertIsNone(tl["frames"][1]["turns"])
+        self.assertIsInstance(km._bars_wire[4], str, "the sort_keys fallback signature, as before")
+        self.assertIsNone(km._bars_wire[5])
+        self.assertTrue(km._bars_wire[3].materialized(), "the whole dump the signature needed pre-fills the cell")
+        self.assertEqual(_delta(km._wire_stats, s0), {"bars_sig_fallback": 1})
+        self.assertEqual(err.getvalue().count("cannot be keyed"), 1, "said once, as before")
+        w.timeline = _timeline(unkeyable=True, now=2)            # a rebuild: the whole frame goes again
+        w.timeline["judging"] = [{"sid": SID, "judge": "closer", "t": 1, "t1": 2}]
+        with redirect_stderr(err):
+            km._push([tl])
+        self.assertEqual([f["type"] for f in tl["frames"]], ["data", "bars", "bars"],
+                         "a rebuild with unchanged lanes: no lanes frame, and the whole bars frame again")
+
+
+class LazyWireCell(unittest.TestCase):
+
+    def test_text_once_size_estimate_then_exact_and_the_counter(self):
+        calls = []
+        cell = km._LazyWire(lambda: (calls.append(1), "x" * 100)[1], 90, "feed_body")
+        s0 = dict(km._wire_stats)
+        self.assertFalse(cell.materialized()); self.assertEqual(cell.size(), 90)
+        self.assertEqual(cell.text(), "x" * 100); self.assertEqual(cell.text(), "x" * 100)
+        self.assertEqual(calls, [1], "made once")
+        self.assertEqual(cell.size(), 100); self.assertTrue(cell.materialized())
+        self.assertEqual(_delta(km._wire_stats, s0), {"feed_body": 1})
+        pre = km._LazyWire(None, 5, text="abc")
+        self.assertTrue(pre.materialized()); self.assertEqual(pre.size(), 3); self.assertEqual(pre.text(), "abc")
+        self.assertEqual(km._wire_text("s"), "s"); self.assertEqual(km._wire_len("abcd"), 4)
+        self.assertEqual(km._wire_text(pre), "abc"); self.assertEqual(km._wire_len(cell), 100)
+
+    def test_the_estimates_sit_under_the_whole_frame_but_within_ten_percent(self):
+        f = _feed(n=40); fp = km._delta_parts("feed", f); whole = json.dumps(f)
+        self.assertLess(km._parts_est(fp), len(whole))
+        self.assertGreater(km._parts_est(fp), 0.9 * len(whole))
+        bars = _bars_of(_timeline(nbars=60)); bp = km._delta_parts("bars", bars); whole = json.dumps(bars)
+        self.assertLess(km._parts_est(bp), len(whole))
+        self.assertGreater(km._parts_est(bp), 0.9 * len(whole))
+
+    def test_wire_stats_count_exactly(self):
+        # A cell is made by the pusher and materialized by whichever sender thread first needs the whole frame, so
+        # its counter is bumped from many threads at once; a bare `+= 1` is a read-modify-write that drifts low
+        # without the GIL, which is why the counters go through _wire_bump under a lock.
+        s0 = km._wire_stats["feed_body"]
+        errs = []
+
+        def run():
+            try:
+                for _ in range(2000):
+                    km._LazyWire(lambda: "{}", 2, "feed_body").text()
+            except Exception as e:                     # noqa: BLE001 — surfaced below
+                errs.append(e)
+        ts = [threading.Thread(target=run, daemon=True) for _ in range(8)]
+        for t in ts:
+            t.start()
+        for t in ts:
+            t.join(60)
+        self.assertEqual(errs, [])
+        self.assertFalse(any(t.is_alive() for t in ts))
+        self.assertEqual(km._wire_stats["feed_body"] - s0, 8 * 2000)
+
+    def test_wire_bump_is_exact_under_a_forced_interleaving(self):
+        # the test above stays green without the lock: under the GIL a `+= 1` rarely loses its switch inside the
+        # read-modify-write. A dict whose reads yield the thread forces that switch, so only the lock keeps the count.
+        class _Yielding(dict):
+            def get(self, k, d=None):
+                v = dict.get(self, k, d); time.sleep(0); return v
+
+            def __getitem__(self, k):
+                v = dict.__getitem__(self, k); time.sleep(0); return v
+        saved = km._wire_stats
+        km._wire_stats = _Yielding(saved)
+        try:
+            s0 = km._wire_stats["feed_body"]
+
+            def run():
+                for _ in range(300):
+                    km._wire_bump("feed_body")
+            ts = [threading.Thread(target=run, daemon=True) for _ in range(8)]
+            for t in ts:
+                t.start()
+            for t in ts:
+                t.join(60)
+            self.assertFalse(any(t.is_alive() for t in ts))
+            self.assertEqual(km._wire_stats["feed_body"] - s0, 8 * 300)
+        finally:
+            km._wire_stats = saved
+
+
+class ANonJsonValueOnTheWireIsCountedAndSaidOnce(unittest.TestCase):
+    """The delta paths' encoders carried a bare `default=str`, which turned a value json cannot encode into a
+    silent str() on the wire, and the whole-frame dumps had no `default` at all and raised. _wire_default keeps
+    the delta paths' bytes and adds the evidence: _wire_stats["default_str"] counts each value per encode, and
+    stderr names the type once. Every encoder on the path is driven through the REAL _push here — the per-entry
+    pass, the whole frame, the delta frame."""
+
+    def setUp(self):
+        saved = set(km._wire_default_said)
+        km._wire_default_said.clear()
+        self.addCleanup(lambda: (km._wire_default_said.clear(), km._wire_default_said.update(saved)))
+
+    def test_wire_default_returns_str_counts_each_call_and_says_each_type_once(self):
+        s0 = dict(km._wire_stats); err = io.StringIO()
+        with redirect_stderr(err):
+            self.assertEqual(json.dumps({"a": {1, 2}, "b": {3}}, default=km._wire_default_in("synthetic")),
+                             '{"a": "{1, 2}", "b": "{3}"}', "the bytes default=str produced")
+            self.assertEqual(km._wire_default(frozenset(), "synthetic"), "frozenset()")
+        self.assertEqual(_delta(km._wire_stats, s0), {"default_str": 3}, "one per value encoded")
+        self.assertEqual(err.getvalue(), "wire: set serialized via str() in synthetic\n"
+                                         "wire: frozenset serialized via str() in synthetic\n",
+                         "one line per type, naming the encoder")
+
+    def test_a_bars_payload_carrying_a_set_ships_the_string_to_a_legacy_timeline_client(self):
+        tl_build = _timeline(); tl_build["turns"][SID][0]["tags"] = {"a"}
+        _World(self, timeline=tl_build)
+        legacy = _client("timeline", delta=False)
+        s0 = dict(km._wire_stats); err = io.StringIO()
+        with redirect_stderr(err):
+            km._push([legacy])
+        self.assertEqual([f["type"] for f in legacy["frames"]], ["data", "bars"])
+        self.assertEqual(legacy["frames"][1]["turns"][SID][0]["tags"], "{'a'}", "shipped as str(), as the delta path did")
+        self.assertNotIn("_keys", legacy["frames"][1])
+        self.assertEqual(_delta(km._wire_stats, s0), {"bars_body": 1, "default_str": 2},
+                         "one per encode of the value: the per-entry pass (_delta_split) and the whole frame (_push)")
+        self.assertEqual(_wire_lines(err), ["wire: set serialized via str() in _delta_split"],
+                         "said once, naming the encoder that met it first; the whole frame's encode adds no line")
+        s0 = dict(km._wire_stats)
+        with redirect_stderr(err):
+            km._push([legacy])                                   # an unchanged cycle: nothing encoded, nothing said
+        self.assertEqual(_delta(km._wire_stats, s0), {})
+        self.assertEqual(len(_wire_lines(err)), 1)
+
+    def test_a_feed_card_carrying_a_set_ships_the_string_to_a_legacy_feed_client(self):
+        # the whole-frame dump had no `default`: this raised inside _push, on the pusher thread
+        odd = _feed(n=2); odd["asks"][0]["when"] = {1, 2}
+        _World(self, feed=odd)
+        legacy = _client("feed", delta=False)
+        s0 = dict(km._wire_stats); err = io.StringIO()
+        with redirect_stderr(err):
+            km._push([legacy])
+        self.assertEqual([f["type"] for f in legacy["frames"]], ["feed"])
+        self.assertEqual(legacy["frames"][0]["asks"][0]["when"], "{1, 2}", "shipped as str(), as the delta path did")
+        self.assertIn('"when": "{1, 2}"', km._feed_wire[5][0]["asks"][0]["%s:g0" % SID][1],
+                      "the per-card string carries the same bytes")
+        self.assertEqual(_delta(km._wire_stats, s0), {"feed_body": 1, "default_str": 2},
+                         "one per encode of the value: the per-entry pass and the whole frame")
+        self.assertEqual(_wire_lines(err), ["wire: set serialized via str() in _delta_split"])
+
+    def test_a_delta_frame_re_encodes_the_changed_entry_and_counts_it(self):
+        tl_build = _timeline(); tl_build["turns"][SID][0]["tags"] = {"a"}
+        w = _World(self, timeline=tl_build)
+        tl = _client("timeline")                                 # a delta client: keyed full first, then deltas
+        s0 = dict(km._wire_stats); err = io.StringIO()
+        with redirect_stderr(err):
+            km._push([tl])
+        self.assertIn("_keys", tl["frames"][1])
+        self.assertEqual(tl["frames"][1]["turns"][SID][0]["tags"], "{'a'}")
+        self.assertEqual(_delta(km._wire_stats, s0), {"bars_body": 1, "default_str": 2}, "the split and the keyed full")
+        nxt = _timeline(nbars=3, now=2); nxt["turns"][SID][0]["tags"] = {"a"}; nxt["turns"][SID][1]["tags"] = {"b"}
+        w.timeline = nxt
+        s0 = dict(km._wire_stats)
+        with redirect_stderr(err):
+            km._push([tl])
+        self.assertEqual(tl["frames"][-1]["type"], "delta")
+        sent = tl["frames"][-1]["coll"]["turns"]["set"]
+        self.assertEqual(sorted(sent), ["%s%sb1" % (SID, km._DELTA_SEP), "%s%sb2" % (SID, km._DELTA_SEP)],
+                         "the unchanged bar (same entry string) does not ride")
+        self.assertEqual(sent["%s%sb1" % (SID, km._DELTA_SEP)]["tags"], "{'b'}", "the delta frame ships the same str()")
+        self.assertEqual(_delta(km._wire_stats, s0), {"default_str": 3},
+                         "two sets in the per-entry pass, and the changed entry's set again in the delta frame; no whole frame")
+        self.assertEqual(_wire_lines(err), ["wire: set serialized via str() in _delta_split"], "still said once")
+
+    def test_a_set_in_the_remainder_is_counted_by_the_parts_encoder_and_named(self):
+        # the remainder's dump (rest_sig) is a wire encoder too: a value outside every collection meets _wire_default
+        # there, counted once and named for that encoder
+        _World(self)
+        p = _bars_of(_timeline()); p["extra"] = {"x"}
+        s0 = dict(km._wire_stats); err = io.StringIO()
+        with redirect_stderr(err):
+            parts = km._delta_parts("bars", p)
+        self.assertIsNotNone(parts, "the payload keys: the set is in the remainder, not a collection")
+        self.assertEqual(_delta(km._wire_stats, s0)["default_str"], 1)
+        self.assertEqual(_wire_lines(err), ["wire: set serialized via str() in _delta_parts"])
+        self.assertIn('"extra": "{\'x\'}"', parts[2], "the remainder's signature carries the str() bytes")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wire_once_per_build.py
+++ b/tests/test_wire_once_per_build.py
@@ -104,7 +104,7 @@ class _World:
     def __init__(self, test, feed=None, timeline=None):
         self.feed, self.timeline = feed, timeline
         saved = {n: getattr(km, n) for n in self.NAMES}
-        saved_wire = (km._feed_wire, km._bars_wire, km._skel_wire, dict(km._delta_parts_cache))
+        saved_wire = (km._feed_wire, km._bars_wire, km._skel_wire, dict(km._delta_parts_cache), dict(km._delta_split_memo))
         saved_built = (list(km._built_feed), list(km._built_timeline))
         km._cached_feed = lambda now, tmux, sig, connect=False: self.feed
         km._cached_timeline = lambda now, tmux, sig, connect=False: self.timeline
@@ -113,7 +113,7 @@ class _World:
         km._fleet_view_sig = lambda now, tmux: ("sig",)
         km._DELTA_MAX_FRACTION = 10.0        # synthetic payloads are tiny: the size guard would send wholes
         km._feed_wire = km._bars_wire = km._skel_wire = None
-        km._delta_parts_cache.clear()
+        km._delta_parts_cache.clear(); km._delta_split_memo.clear()
         km._built_timeline[:] = [None, timeline, time.time(), time.time()]   # warmed: a connect push serves the cache
 
         def restore():
@@ -121,6 +121,7 @@ class _World:
                 setattr(km, n, v)
             km._feed_wire, km._bars_wire, km._skel_wire = saved_wire[:3]
             km._delta_parts_cache.clear(); km._delta_parts_cache.update(saved_wire[3])
+            km._delta_split_memo.clear(); km._delta_split_memo.update(saved_wire[4])
             km._built_feed[:] = saved_built[0]; km._built_timeline[:] = saved_built[1]
         test.addCleanup(restore)
 
@@ -141,8 +142,8 @@ class OneEncodePerBuild(unittest.TestCase):
             self.assertEqual([f["type"] for f in dfeed["frames"]], ["feed"]); self.assertIn("_keys", dfeed["frames"][0])
             self.assertEqual([f["type"] for f in legacy["frames"]], ["feed"]); self.assertNotIn("_keys", legacy["frames"][0])
             self.assertEqual([f["type"] for f in tl["frames"]], ["data", "bars"]); self.assertIn("_keys", tl["frames"][1])
-            self.assertEqual(_delta(km._wire_stats, s0), {"feed_body": 1, "bars_body": 1},
-                             "one whole frame each, shared by the keyed full and the legacy client")
+            self.assertEqual(_delta(km._wire_stats, s0), {"feed_body": 1, "bars_body": 1, "split_miss": 4},
+                             "one whole frame each, shared by the keyed full and the legacy client; four collections split")
             self.assertEqual(km._feed_wire[4], km._parts_sig(km._feed_wire[5]), "the feed's signature is the split's tuple")
             self.assertEqual(km._bars_wire[4], km._parts_sig(km._bars_wire[5]), "so is the bars'")
             self.assertEqual(legacy["sent"][("feed",)][0], km._feed_wire[4])
@@ -159,7 +160,7 @@ class OneEncodePerBuild(unittest.TestCase):
             splits.clear(); s0 = dict(km._wire_stats)
             km._push([dfeed, tl])
             self.assertEqual(sum(splits.values()), 4)
-            self.assertEqual(_delta(km._wire_stats, s0), {})
+            self.assertEqual(_delta(km._wire_stats, s0), {"split_miss": 4}, "new collection objects: every split ran")
             self.assertEqual(dfeed["frames"][-1]["type"], "delta")
             self.assertEqual(list(dfeed["frames"][-1]["coll"]["asks"]["set"]), ["%s:g2" % SID])
             self.assertEqual(tl["frames"][-1]["type"], "delta")
@@ -204,7 +205,8 @@ class OneEncodePerBuild(unittest.TestCase):
         self.assertIsInstance(km._bars_wire[4], str, "the sort_keys fallback signature, as before")
         self.assertIsNone(km._bars_wire[5])
         self.assertTrue(km._bars_wire[3].materialized(), "the whole dump the signature needed pre-fills the cell")
-        self.assertEqual(_delta(km._wire_stats, s0), {"bars_sig_fallback": 1})
+        self.assertEqual(_delta(km._wire_stats, s0), {"bars_sig_fallback": 1, "split_miss": 1},
+                         "the turns split ran and raised; the collections after it were never reached")
         self.assertEqual(err.getvalue().count("cannot be keyed"), 1, "said once, as before")
         w.timeline = _timeline(unkeyable=True, now=2)            # a rebuild: the whole frame goes again
         w.timeline["judging"] = [{"sid": SID, "judge": "closer", "t": 1, "t1": 2}]
@@ -212,6 +214,117 @@ class OneEncodePerBuild(unittest.TestCase):
             km._push([tl])
         self.assertEqual([f["type"] for f in tl["frames"]], ["data", "bars", "bars"],
                          "a rebuild with unchanged lanes: no lanes frame, and the whole bars frame again")
+
+
+class ALedgersOnlyRefillEncodesNoCard(unittest.TestCase):
+    """_push copies the cached feed build (feed = dict(feed_src)) and attaches the cycle's ledgers to the copy, so a
+    cycle whose ledgers moved but whose build did not misses the wire tuple and splits the payload again: a new dict
+    around the SAME asks list. _delta_parts memoizes each collection's split on the collection object's identity
+    (_delta_split_memo), so that refill re-encodes the remainder and no card."""
+
+    def test_a_refill_with_the_same_asks_object_and_a_changed_remainder_makes_no_split(self):
+        _World(self)                                              # empties the parts cache and the split memo; restores after
+        src = _feed(n=6)
+        first = dict(src, ledgers=[{"sid": SID, "name": "web", "status": "idle"}])
+        refill = dict(src, ledgers=[{"sid": SID, "name": "web", "status": "working"}])   # the same asks list, another remainder
+        splits = collections.Counter(); real_split = km._delta_split
+        with mock.patch.object(km, "_delta_split", side_effect=lambda kind, v: splits.update([kind]) or real_split(kind, v)):
+            s0 = dict(km._wire_stats)
+            p1 = km._delta_parts("feed", first)
+            self.assertEqual(dict(splits), {"byid:itemId": 1}); self.assertEqual(_delta(km._wire_stats, s0), {"split_miss": 1})
+            splits.clear(); s0 = dict(km._wire_stats)
+            p2 = km._delta_parts("feed", refill)
+            self.assertEqual(dict(splits), {}, "the asks list is the same object: no card encoded")
+            self.assertEqual(_delta(km._wire_stats, s0), {"split_hit": 1})
+            self.assertIs(p2[0]["asks"], p1[0]["asks"], "the split is shared, not copied")
+            self.assertEqual(p2[1]["ledgers"], refill["ledgers"]); self.assertNotEqual(p2[2], p1[2], "the remainder was re-encoded")
+            self.assertNotEqual(km._parts_sig(p1), km._parts_sig(p2), "and the signature moves with it")
+            # a new asks object (a rebuild, or any copy) splits again, and the memo follows it
+            rebuilt = dict(refill, asks=list(src["asks"]))
+            splits.clear(); s0 = dict(km._wire_stats)
+            p3 = km._delta_parts("feed", rebuilt)
+            self.assertEqual(dict(splits), {"byid:itemId": 1}); self.assertEqual(_delta(km._wire_stats, s0), {"split_miss": 1})
+            self.assertEqual(km._parts_sig(p3), km._parts_sig(p2), "equal cards in a new list: an equal signature")
+            self.assertIs(km._delta_split_memo[("feed", "asks")][0], rebuilt["asks"])
+            splits.clear(); s0 = dict(km._wire_stats)
+            km._delta_parts("feed", dict(rebuilt, now=NOW + 5))
+            self.assertEqual(dict(splits), {}); self.assertEqual(_delta(km._wire_stats, s0), {"split_hit": 1})
+            self.assertEqual(len(km._delta_split_memo), 1, "one entry per (frame type, collection): replaced, never grown")
+
+    def test_through_push_a_refill_that_misses_the_wire_tuple_on_its_ledgers_re_encodes_no_card(self):
+        w = _World(self, feed=_feed())
+        board, dfeed = _client("fleet"), _client("feed")
+        splits = collections.Counter(); real_split = km._delta_split
+        with mock.patch.object(km, "_delta_split", side_effect=lambda kind, v: splits.update([kind]) or real_split(kind, v)):
+            s0 = dict(km._wire_stats)
+            km._push([board])                                     # an app="fleet" client: the cycle attaches ledgers to the copy
+            self.assertEqual(dict(splits), {"byid:itemId": 1}); self.assertEqual(km._feed_wire[1], [])
+            self.assertEqual(_delta(km._wire_stats, s0), {"feed_body": 1, "split_miss": 1})
+            splits.clear(); s0 = dict(km._wire_stats)
+            km._push([dfeed])                                     # the same build without the attach: the wire tuple misses on its ledgers
+            self.assertEqual(dict(splits), {}, "the refill served the cards from the memo")
+            self.assertEqual(_delta(km._wire_stats, s0), {"feed_body": 1, "split_hit": 1})
+            self.assertIsNone(km._feed_wire[1]); self.assertIs(km._feed_wire[0], w.feed)
+            self.assertEqual([f["type"] for f in dfeed["frames"]], ["feed"]); self.assertNotIn("ledgers", dfeed["frames"][0])
+            self.assertEqual([f["type"] for f in board["frames"]], ["feed"]); self.assertEqual(board["frames"][0]["ledgers"], [])
+            w.feed = _feed(build_id=2)                            # a rebuild: a new asks list, split again
+            splits.clear(); s0 = dict(km._wire_stats)
+            km._push([dfeed])
+            self.assertEqual(dict(splits), {"byid:itemId": 1}); self.assertEqual(_delta(km._wire_stats, s0), {"split_miss": 1})
+
+    def test_a_bars_payload_around_unchanged_collections_splits_no_bar(self):
+        # the same path for the bars: a new bars dict around the SAME turns/judging/messages objects (a warming flip, or
+        # any other remainder) is a memo hit for all three collections; a rebuild's new lanes object splits alone
+        _World(self)
+        tl = _timeline(nbars=3)
+        splits = collections.Counter(); real_split = km._delta_split
+        with mock.patch.object(km, "_delta_split", side_effect=lambda kind, v: splits.update([kind]) or real_split(kind, v)):
+            s0 = dict(km._wire_stats)
+            p1 = km._delta_parts("bars", _bars_of(tl, warming=True))
+            self.assertEqual(sum(splits.values()), 3); self.assertEqual(_delta(km._wire_stats, s0), {"split_miss": 3})
+            splits.clear(); s0 = dict(km._wire_stats)
+            p2 = km._delta_parts("bars", _bars_of(tl, warming=False))
+            self.assertEqual(dict(splits), {}, "the same collection objects: no bar encoded")
+            self.assertEqual(_delta(km._wire_stats, s0), {"split_hit": 3})
+            for name in ("turns", "judging", "messages"):
+                self.assertIs(p2[0][name], p1[0][name], name + ": the split is shared")
+            self.assertIs(p2[1]["warming"], False); self.assertNotEqual(km._parts_sig(p1), km._parts_sig(p2), "the remainder moved the signature")
+            nxt = dict(tl, turns={SID: [dict(b) for b in tl["turns"][SID]]}, now=2)   # a rebuild's lanes: split again; the rest hit
+            splits.clear(); s0 = dict(km._wire_stats)
+            km._delta_parts("bars", _bars_of(nxt))
+            self.assertEqual(dict(splits), {"dictlist:id": 1}); self.assertEqual(_delta(km._wire_stats, s0), {"split_hit": 2, "split_miss": 1})
+            self.assertEqual(len(km._delta_split_memo), 3, "one entry per (frame type, collection)")
+
+    def test_split_hit_and_miss_are_exact_under_a_forced_interleaving(self):
+        # the memo's counters go through _wire_bump like the rest: the pusher and a handler-thread connect push both
+        # fill, so a bare `+= 1` would lose increments. A dict whose reads yield the thread forces the interleaving the
+        # lock is for (under the GIL alone the race is rare enough to stay green without it).
+        _World(self)
+        src = _feed(n=3)
+
+        class _Yielding(dict):
+            def get(self, k, d=None):
+                v = dict.get(self, k, d); time.sleep(0); return v
+
+            def __getitem__(self, k):
+                v = dict.__getitem__(self, k); time.sleep(0); return v
+        saved = km._wire_stats
+        km._wire_stats = _Yielding(saved)
+        try:
+            s0 = km._wire_stats["split_hit"] + km._wire_stats["split_miss"]
+
+            def run():
+                for i in range(300):
+                    km._delta_parts("feed", dict(src, now=NOW + i))   # a new payload each: the asks list hits after the first miss
+            ts = [threading.Thread(target=run, daemon=True) for _ in range(8)]
+            for t in ts:
+                t.start()
+            for t in ts:
+                t.join(60)
+            self.assertFalse(any(t.is_alive() for t in ts))
+            self.assertEqual(km._wire_stats["split_hit"] + km._wire_stats["split_miss"] - s0, 8 * 300, "every fill bumped exactly one of the two")
+        finally:
+            km._wire_stats = saved
 
 
 class LazyWireCell(unittest.TestCase):
@@ -321,7 +434,7 @@ class ANonJsonValueOnTheWireIsCountedAndSaidOnce(unittest.TestCase):
         self.assertEqual([f["type"] for f in legacy["frames"]], ["data", "bars"])
         self.assertEqual(legacy["frames"][1]["turns"][SID][0]["tags"], "{'a'}", "shipped as str(), as the delta path did")
         self.assertNotIn("_keys", legacy["frames"][1])
-        self.assertEqual(_delta(km._wire_stats, s0), {"bars_body": 1, "default_str": 2},
+        self.assertEqual(_delta(km._wire_stats, s0), {"bars_body": 1, "default_str": 2, "split_miss": 3},
                          "one per encode of the value: the per-entry pass (_delta_split) and the whole frame (_push)")
         self.assertEqual(_wire_lines(err), ["wire: set serialized via str() in _delta_split"],
                          "said once, naming the encoder that met it first; the whole frame's encode adds no line")
@@ -343,7 +456,7 @@ class ANonJsonValueOnTheWireIsCountedAndSaidOnce(unittest.TestCase):
         self.assertEqual(legacy["frames"][0]["asks"][0]["when"], "{1, 2}", "shipped as str(), as the delta path did")
         self.assertIn('"when": "{1, 2}"', km._feed_wire[5][0]["asks"][0]["%s:g0" % SID][1],
                       "the per-card string carries the same bytes")
-        self.assertEqual(_delta(km._wire_stats, s0), {"feed_body": 1, "default_str": 2},
+        self.assertEqual(_delta(km._wire_stats, s0), {"feed_body": 1, "default_str": 2, "split_miss": 1},
                          "one per encode of the value: the per-entry pass and the whole frame")
         self.assertEqual(_wire_lines(err), ["wire: set serialized via str() in _delta_split"])
 
@@ -356,7 +469,7 @@ class ANonJsonValueOnTheWireIsCountedAndSaidOnce(unittest.TestCase):
             km._push([tl])
         self.assertIn("_keys", tl["frames"][1])
         self.assertEqual(tl["frames"][1]["turns"][SID][0]["tags"], "{'a'}")
-        self.assertEqual(_delta(km._wire_stats, s0), {"bars_body": 1, "default_str": 2}, "the split and the keyed full")
+        self.assertEqual(_delta(km._wire_stats, s0), {"bars_body": 1, "default_str": 2, "split_miss": 3}, "the split and the keyed full")
         nxt = _timeline(nbars=3, now=2); nxt["turns"][SID][0]["tags"] = {"a"}; nxt["turns"][SID][1]["tags"] = {"b"}
         w.timeline = nxt
         s0 = dict(km._wire_stats)
@@ -367,7 +480,7 @@ class ANonJsonValueOnTheWireIsCountedAndSaidOnce(unittest.TestCase):
         self.assertEqual(sorted(sent), ["%s%sb1" % (SID, km._DELTA_SEP), "%s%sb2" % (SID, km._DELTA_SEP)],
                          "the unchanged bar (same entry string) does not ride")
         self.assertEqual(sent["%s%sb1" % (SID, km._DELTA_SEP)]["tags"], "{'b'}", "the delta frame ships the same str()")
-        self.assertEqual(_delta(km._wire_stats, s0), {"default_str": 3},
+        self.assertEqual(_delta(km._wire_stats, s0), {"default_str": 3, "split_miss": 3},
                          "two sets in the per-entry pass, and the changed entry's set again in the delta frame; no whole frame")
         self.assertEqual(_wire_lines(err), ["wire: set serialized via str() in _delta_split"], "still said once")
 

--- a/tests/test_wire_once_per_build.py
+++ b/tests/test_wire_once_per_build.py
@@ -73,6 +73,18 @@ def _client(app, delta=True):
     return c
 
 
+class _RaisingLock:
+    """A client slot lock whose acquire raises, so a send fails inside _send_slot's `with _client_lock(c)` and the
+    test asserts on THIS message. A bare object() in the slot raises there too, but as AttributeError before 3.11
+    and TypeError from 3.11, so the interpreter's wording is not a stable marker across the CI matrix."""
+
+    def __enter__(self):
+        raise RuntimeError("synthetic send failure")
+
+    def __exit__(self, *exc):
+        return False
+
+
 def _delta(after, before):
     return {k: after[k] - before[k] for k in after if after[k] != before[k]}
 
@@ -371,6 +383,138 @@ class ANonJsonValueOnTheWireIsCountedAndSaidOnce(unittest.TestCase):
         self.assertEqual(_delta(km._wire_stats, s0)["default_str"], 1)
         self.assertEqual(_wire_lines(err), ["wire: set serialized via str() in _delta_parts"])
         self.assertIn('"extra": "{\'x\'}"', parts[2], "the remainder's signature carries the str() bytes")
+
+
+class ARaisingSerializerLeavesThePusherAlive(unittest.TestCase):
+    """The wire section of _push runs after its build try, and _push_all, _pusher_cycle_jobs, _pusher_cycle and
+    _pusher have no except around it: a raise there used to end the pusher thread for the life of the process,
+    every dashboard frozen until a restart. A fill that raises now stands its slot down for the cycle (one
+    traceback; the slot's other clients skipped without another), a send that raises skips that client, and the
+    next cycle retries; _pusher_cycle_jobs catches whatever escapes _push_all. Every raise here is synthetic and
+    asserted on its own marker text, never the interpreter's."""
+
+    TICK_JOBS = ("_apply_pending_ops", "_turn_notify_tick", "_lift_spent_awaiting", "_death_sweep_tick",
+                 "_end_on_idle_sweep", "_deferral_sweep_tick", "_auto_nudge_tick", "_interrupt_block_tick",
+                 "_auto_pause_on_limit", "_usage_poll_tick", "_auto_pause_on_spend_limit", "_auto_resume_retry",
+                 "_auto_resume_session_retry", "_auto_retry_tick", "_idle_queue_drive_tick",
+                 "_clear_done_working_notes")
+
+    @staticmethod
+    def _split_raising_for(ftype):
+        real = km._delta_parts
+
+        def split(kind, payload):
+            if kind == ftype:
+                raise KeyError("synthetic fill failure")
+            return real(kind, payload)
+        return split
+
+    def test_a_fill_that_raises_stands_its_slot_down_for_the_cycle_and_the_other_slot_is_served(self):
+        w = _World(self, feed=_feed(), timeline=_timeline())
+        dfeed, dfeed2, tl = _client("feed"), _client("feed"), _client("timeline")
+        err = io.StringIO()
+        with mock.patch.object(km, "_delta_parts", side_effect=self._split_raising_for("feed")), redirect_stderr(err):
+            km._push([dfeed, tl, dfeed2])                        # returns: nothing escapes
+        self.assertEqual(err.getvalue().count("push send feed (feed)"), 1,
+                         "one traceback for the fill; the slot's other client is skipped without another")
+        self.assertIn("synthetic fill failure", err.getvalue())
+        self.assertEqual(dfeed["frames"], []); self.assertEqual(dfeed2["frames"], [])
+        self.assertEqual([f["type"] for f in tl["frames"]], ["data", "bars"], "the bars slot is unaffected")
+        self.assertIsNone(km._feed_wire, "a fill that raised cached nothing")
+        w.feed = _feed(build_id=2)                               # the next build is sound: served
+        with redirect_stderr(err):
+            km._push([dfeed, tl, dfeed2])
+        self.assertEqual([f["type"] for f in dfeed["frames"]], ["feed"]); self.assertEqual([f["type"] for f in dfeed2["frames"]], ["feed"])
+        self.assertEqual(err.getvalue().count("push send"), 1, "the sound build logged nothing")
+
+    def test_a_bars_fill_that_raises_stands_the_bars_slot_down_and_the_feed_is_served(self):
+        w = _World(self, feed=_feed(), timeline=_timeline())
+        tl, dfeed, tl2 = _client("timeline"), _client("feed"), _client("timeline")
+        err = io.StringIO()
+        with mock.patch.object(km, "_delta_parts", side_effect=self._split_raising_for("bars")), redirect_stderr(err):
+            km._push([tl, dfeed, tl2])
+        self.assertEqual(err.getvalue().count("push send bars (timeline)"), 1)
+        self.assertIn("synthetic fill failure", err.getvalue())
+        self.assertEqual([f["type"] for f in tl["frames"]], ["data"], "the lanes frame went from the build section; no bars")
+        self.assertEqual([f["type"] for f in tl2["frames"]], ["data"])
+        self.assertEqual([f["type"] for f in dfeed["frames"]], ["feed"], "the feed slot is unaffected")
+        self.assertIsNone(km._bars_wire)
+        w.timeline = _timeline(now=2)
+        with redirect_stderr(err):
+            km._push([tl, dfeed, tl2])
+        self.assertEqual([f["type"] for f in tl["frames"]], ["data", "bars"]); self.assertEqual([f["type"] for f in tl2["frames"]], ["data", "bars"])
+
+    def test_a_board_clients_failed_fill_stands_the_feed_slot_down_not_the_bars(self):
+        # the sessions board (app "fleet", the pane's existing name) rides the feed payload: its fill's raise is the
+        # FEED slot's, logged once as such, and stands that slot down for the cycle (the second board client skipped
+        # without another traceback) while the bars slot is served
+        w = _World(self, feed=_feed(), timeline=_timeline())
+        board, tl, board2 = _client("fleet"), _client("timeline"), _client("fleet")
+        err = io.StringIO()
+        with mock.patch.object(km, "_delta_parts", side_effect=self._split_raising_for("feed")), redirect_stderr(err):
+            km._push([board, tl, board2])
+        self.assertEqual(err.getvalue().count("push send feed (fleet)"), 1, "logged as the feed slot, once")
+        self.assertEqual(err.getvalue().count("push send"), 1)
+        self.assertIn("synthetic fill failure", err.getvalue())
+        self.assertEqual(board["frames"], []); self.assertEqual(board2["frames"], [])
+        self.assertEqual([f["type"] for f in tl["frames"]], ["data", "bars"], "the bars slot is served")
+        self.assertIsNone(km._feed_wire); self.assertIsNotNone(km._bars_wire)
+        w.feed = _feed(build_id=2)
+        with redirect_stderr(err):
+            km._push([board, tl, board2])
+        self.assertEqual([f["type"] for f in board["frames"]], ["feed"]); self.assertEqual([f["type"] for f in board2["frames"]], ["feed"])
+        self.assertEqual(err.getvalue().count("push send"), 1, "the sound build logged nothing")
+
+    def test_a_send_that_raises_skips_that_client_and_the_next_is_served(self):
+        _World(self, feed=_feed())
+        c1, c2 = _client("feed"), _client("feed")
+        c1["dlock"] = _RaisingLock()                             # a synthetic raise inside this client's send path
+        err = io.StringIO()
+        with redirect_stderr(err):
+            km._push([c1, c2])
+        self.assertIn("push send feed (feed)", err.getvalue()); self.assertIn("synthetic send failure", err.getvalue())
+        self.assertEqual(c1["frames"], [])
+        self.assertEqual([f["type"] for f in c2["frames"]], ["feed"], "the next client is served")
+        self.assertIsNotNone(km._feed_wire, "the fill stood: only the send failed")
+
+    def test_a_whole_frame_whose_encode_raises_leaves_the_slot_for_a_retry(self):
+        _World(self, feed=_feed())
+        legacy, dfeed = _client("feed", delta=False), _client("feed")   # both take a whole frame on their first send
+
+        def encode_raises(cell):
+            raise ValueError("synthetic encode failure")
+        err = io.StringIO()
+        with mock.patch.object(km._LazyWire, "text", new=encode_raises), redirect_stderr(err):
+            km._push([legacy, dfeed])
+        self.assertEqual(err.getvalue().count("push send feed (feed)"), 2, "each whole-frame client's send raised, was logged, skipped")
+        self.assertIn("synthetic encode failure", err.getvalue())
+        self.assertEqual(err.getvalue().count("view-delta feed:"), 1,
+                         "the delta client's own fallback (a whole frame) met the same raise; the belt caught it")
+        self.assertEqual(legacy["frames"], []); self.assertEqual(dfeed["frames"], [])
+        self.assertNotIn(("feed",), legacy["sent"], "the dedup slot was not written: the next cycle retries")
+        self.assertNotIn(("feed",), dfeed["sent"]); self.assertNotIn("feed", dfeed.get("dstate", {}))
+        self.assertIsNotNone(km._feed_wire, "the fill stood"); self.assertFalse(km._feed_wire[3].materialized())
+        km._push([legacy, dfeed])                                # the encode works again: the same build's frame goes
+        self.assertEqual([f["type"] for f in legacy["frames"]], ["feed"]); self.assertEqual([f["type"] for f in dfeed["frames"]], ["feed"])
+        self.assertIn("_keys", dfeed["frames"][0])
+        self.assertTrue(km._feed_wire[3].materialized())
+
+    def test_the_cycle_loop_survives_a_push_all_that_raises(self):
+        err = io.StringIO()
+        with mock.patch.multiple(km, **{nm: lambda *a, **k: None for nm in self.TICK_JOBS}), \
+                mock.patch.object(km, "_push_all", side_effect=RuntimeError("synthetic push failure")), redirect_stderr(err):
+            km._pusher_cycle_jobs(NOW, {}, True)                 # returns: the belt logged it
+        self.assertIn("push: ", err.getvalue()); self.assertIn("synthetic push failure", err.getvalue())
+
+    def test_the_wire_section_and_the_belt_are_in_the_source(self):
+        src = open(os.path.join(BIN, "romp-kernel"), encoding="utf-8").read()
+        push = src[src.index("def _push(targets"):]; push = push[:push.index("\ndef ")]
+        i = push.index("for c in targets:")
+        self.assertIn("        try:\n            if c[\"app\"] in (\"feed\", \"fleet\"):", push[i:])
+        self.assertIn('sys.stderr.write("push send %s (%s): %s\\n"', push[i:])
+        jobs = src[src.index("def _pusher_cycle_jobs("):]; jobs = jobs[:jobs.index("\ndef ")]
+        i = jobs.index("_push_all(tmux=tmux)")
+        self.assertLess(i, jobs.index("except Exception:", i)); self.assertLess(jobs.index("except Exception:", i), jobs.index("finally:", i))
 
 
 if __name__ == "__main__":

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -1837,14 +1837,22 @@ class TimelinePanel {
     // Click-safe: don't rebuild the SVG under a pressed pointer (a click in progress). The release event
     // (_release) restarts the loop — no polling for it. See the constructor.
     if (this._pointerHeld) { this._liveResume = true; return; }
-    const g = this._geom;
+    const g = this._geom, nowS = this._liveNow();
     // The look MOVES the view, it does not rebuild it: the last full build left a plot group and its live-edge
     // riders (draw(), `_tickPlot`), and advancing the edge is one transform write on that group plus a width write
     // per rider — _tickTranslate, which also owns the LIVE_MIN_PX guard, in COMPRESSED movement (inside a
     // collapsed trailing gap the edge does not move on screen at all, where a real-seconds guard redrew for
     // nothing). The full draw() stays for what a translate cannot express — no build yet, a glyph riding the live
-    // edge, the next gridline entering the window, a drift into the gutter — never for the clock's advance.
-    if (!g || this._lastLiveNow == null || !this._tickTranslate(this._liveNow())) this.draw();
+    // edge, the next gridline entering the window, a drift into the gutter, never for the clock's advance. A
+    // build that left NO handle (a glyph rode the live edge) has only the full draw for a look, and that look
+    // keeps the guard the loop always had (review find, 2026-09-08): the edge must have moved LIVE_MIN_PX since
+    // the build (_lastLiveNow, set by draw()). Without it such a board redrew the whole svg on every look, every
+    // 2 s at a wide window, where the edge moves a fraction of a pixel between looks and the redraw showed
+    // nothing new. The hand-backs from a handle (a gridline due, the drift cap) are events, not drift: they draw.
+    const tp = this._tickPlot;
+    if (!g || this._lastLiveNow == null) this.draw();
+    else if (!tp || !tp.g || !tp.g.parentNode) { if ((nowS - this._lastLiveNow) / g.winSec * g.plotW >= LIVE_MIN_PX) this.draw(); }
+    else if (!this._tickTranslate(nowS)) this.draw();
     this._sleep(this._liveWaitMs());
   }
   // Advance the live edge to `nowS` by moving the plot group (see draw()'s plot group and `_tickPlot`). Returns
@@ -4905,13 +4913,17 @@ class TimelinePanel {
       // input (historical, from the state-transition log), plus the current open one. The
       // dashed white overlay reads as a distinct texture vs a solid "still working" bar.
       const aw = (s.awaiting && s.awaiting.length) ? s.awaiting
-                 : ((s.live && (s.state === 'permission' || s.state === 'needsInput' || s.state === 'awaiting') && s.since != null) ? [[s.since, t1]] : []);
+                 : ((s.live && (s.state === 'permission' || s.state === 'needsInput' || s.state === 'awaiting') && s.since != null) ? [[s.since, t1, true]] : []);
       for (const span of aw) {
-        // OPEN = the session is STILL in the state: the kernel (_state_intervals) ends such a span at the
-        // payload's own clock, so an end within 2 s of data.now (or a null one) means open. Draw it to the
-        // live edge, the way barEndT draws an open work bar, so the stripe glides with the edge instead of
-        // sitting at the build clock until the next kernel rebuild.
-        const open = span[1] == null || span[1] >= data.now - 2;
+        // OPEN = the session is STILL in the state, which the kernel says outright: an interval with no later
+        // transition carries true as its third element ([start, end, true], _state_intervals) beside its
+        // numeric end at the build clock. Draw it to the live edge, the way barEndT draws an open work bar,
+        // so the stripe glides with the edge instead of sitting at the build clock until the next kernel
+        // rebuild. The mark, never the end's distance from data.now (review find, 2026-09-08): a connect
+        // frame carries the cycle's clock over the cached build's lanes, so that distance is the cache's age,
+        // and the 2 s tolerance this read used to be drew a lane blocked right now closed on every connect
+        // over a cache older than that. A null end reads open too (a span this renderer made itself, above).
+        const open = span[1] == null || span[2] === true;
         const a0 = span[0], b0 = open ? Math.max(nowS, a0) : span[1];
         const sa = Math.max(a0, t0), sb = Math.min(b0, t1); if (sb <= sa) continue;
         // The awaiting interval (state log) and the work bars (transcript) come from different
@@ -4951,9 +4963,9 @@ class TimelinePanel {
       // compacting RIGHT NOW. This is the in-progress indicator; the isCompactSummary marker below is the
       // after-the-fact one. Same figure-ground as the awaiting candy-cane.
       const comp = (s.compacting && s.compacting.length) ? s.compacting
-                   : ((s.live && s.state === 'compacting' && s.since != null) ? [[s.since, t1]] : []);
+                   : ((s.live && s.state === 'compacting' && s.since != null) ? [[s.since, t1, true]] : []);
       for (const span of comp) {
-        const open = span[1] == null || span[1] >= data.now - 2;   // still compacting: to the live edge (see the awaiting loop)
+        const open = span[1] == null || span[2] === true;   // still compacting (the kernel's open mark): to the live edge (see the awaiting loop)
         const a0 = span[0], b0 = open ? Math.max(nowS, a0) : span[1];
         const sa = Math.max(a0, t0), sb = Math.min(b0, t1); if (sb <= sa) continue;
         const eh = BAR_H + 5, cx = x(sa), cwRaw = x(sb) - x(sa), cw = Math.max(2, cwRaw);

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -4823,7 +4823,12 @@ class TimelinePanel {
       const aw = (s.awaiting && s.awaiting.length) ? s.awaiting
                  : ((s.live && (s.state === 'permission' || s.state === 'needsInput' || s.state === 'awaiting') && s.since != null) ? [[s.since, t1]] : []);
       for (const span of aw) {
-        const a0 = span[0], b0 = span[1];
+        // OPEN = the session is STILL in the state: the kernel (_state_intervals) ends such a span at the
+        // payload's own clock, so an end within 2 s of data.now (or a null one) means open. Draw it to the
+        // live edge, the way barEndT draws an open work bar, so the stripe glides with the edge instead of
+        // sitting at the build clock until the next kernel rebuild.
+        const open = span[1] == null || span[1] >= data.now - 2;
+        const a0 = span[0], b0 = open ? Math.max(nowS, a0) : span[1];
         const sa = Math.max(a0, t0), sb = Math.min(b0, t1); if (sb <= sa) continue;
         // The awaiting interval (state log) and the work bars (transcript) come from different
         // sources, so a bar can end a few seconds BEFORE the permission prompt → a gap (made worse by
@@ -4847,7 +4852,7 @@ class TimelinePanel {
         const stripe = el('rect', { x: x(sa), y: y - BAR_H / 2, width: Math.max(2, x(sb) - x(sa)), height: BAR_H, fill: 'url(#vault-await-hatch)' });
         svg.appendChild(stripe);
         const sh = el('rect', { x: bx0, y: y - 7, width: Math.max(2, bx1 - bx0), height: 14, fill: 'transparent' }); sh.style.cursor = 'pointer';
-        const end = b0 >= data.now - 2 ? 'now' : clock(b0);
+        const end = open ? 'now' : clock(b0);
         const shtml = () => '<div class="r"><span class="chip" style="background:' + BADGE.attention.bg + '"></span><span class="who" style="color:' + s.color + '">' + esc(s.name) + '</span><span class="k">blocked</span></div><div class="b">blocked on your input · ' + clock(a0) + '–' + end + '</div>';
         const grow = (h) => { for (const r of [back, stripe]) { r.setAttribute('y', y - h / 2); r.setAttribute('height', h); } };
         sh.addEventListener('mouseenter', (e) => { grow(eh); this.showTip(shtml(), e); });
@@ -4863,7 +4868,8 @@ class TimelinePanel {
       const comp = (s.compacting && s.compacting.length) ? s.compacting
                    : ((s.live && s.state === 'compacting' && s.since != null) ? [[s.since, t1]] : []);
       for (const span of comp) {
-        const a0 = span[0], b0 = span[1];
+        const open = span[1] == null || span[1] >= data.now - 2;   // still compacting: to the live edge (see the awaiting loop)
+        const a0 = span[0], b0 = open ? Math.max(nowS, a0) : span[1];
         const sa = Math.max(a0, t0), sb = Math.min(b0, t1); if (sb <= sa) continue;
         const eh = BAR_H + 5, cx = x(sa), cw = Math.max(2, x(sb) - x(sa));
         const cback = el('rect', { x: cx, y: y - BAR_H / 2, width: cw, height: BAR_H, rx: 2, fill: s.color, opacity: 0.9 });
@@ -4871,7 +4877,7 @@ class TimelinePanel {
         const chx = el('rect', { x: cx, y: y - BAR_H / 2, width: cw, height: BAR_H, rx: 2, fill: 'url(#vault-compact-hatch)' });
         svg.appendChild(chx);
         const ch = el('rect', { x: cx, y: y - 7, width: cw, height: 14, fill: 'transparent' }); ch.style.cursor = 'pointer';
-        const live = b0 >= data.now - 2;
+        const live = open;
         const cw2 = live ? 'compacting' : 'compacted';
         const chtml = () => '<div class="r"><span class="chip" style="background:#86e1ff"></span><span class="who" style="color:' + s.color + '">' + esc(s.name) + '</span><span class="k">' + cw2 + '</span></div><div class="b">context ' + cw2 + ' · ' + clock(a0) + '–' + (live ? 'now' : clock(b0)) + '</div>';
         const cgrow = (h) => { for (const r of [cback, chx]) { r.setAttribute('y', y - h / 2); r.setAttribute('height', h); } };

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -453,10 +453,12 @@ const MAX_INTERP_AHEAD = 150;  // seconds the edge may glide past the last data.
                                // sooner, since 2026-09-04 the skeleton dedups too), so a healthy kernel never
                                // stalls the edge; a dead one is announced by the socket, not by this cap
 // The live edge advances in whole-pixel steps: the loop looks once the edge could have moved this far at the
-// current zoom (see _liveWaitMs, 100-2000 ms between looks) and rebuilds then. It used to be 0.15 px on every
-// animation frame — a full SVG rebuild about twice a second at a one-hour window, on the main thread every
-// pane shares, which is what a chat tab click waited behind (measured 2026-09-04). A sub-pixel glide would
-// need the now-line and open bars translated between rebuilds, not a lower threshold.
+// current zoom (see _liveWaitMs, 100-2000 ms between looks) and moves the plot then — one translate on the
+// plot group plus a width per live-edge rider (_tickTranslate), where a look used to rebuild the whole SVG.
+// Before the pacing it was 0.15 px on every animation frame: a full rebuild about twice a second at a one-hour
+// window, on the main thread every pane shares, which is what a chat tab click waited behind (measured
+// 2026-09-04). A smoother glide is now a pacing choice (a smaller step, a shorter sleep), not a rebuild cost;
+// the pacing stays at a whole pixel.
 const LIVE_MIN_PX = 1;
 function perfNow() { return (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now(); }
 function interpNow(baseSec, baseMs, nowMs, live, maxAheadSec) {
@@ -1036,10 +1038,11 @@ class TimelinePanel {
     // time-baseline (epoch sec + the monotonic ms when it was observed); the edge FREE-RUNS off this fixed
     // pair and shouldReanchorEdge re-snaps it only on a genuine step, so per-poll arrival jitter no longer
     // hiccups the edge. _wasLive = were we live-following at the last poll (→ re-anchor on re-entry).
-    // _lastLiveNow = effective-now of the last live repaint (sub-pixel guard so we only repaint when the
-    // edge would actually move). Re-armed each poll; self-stops when not live.
+    // _lastLiveNow = effective-now of the last live move. _tickPlot = the last full build's handle for the
+    // tick (its plot group, live-edge riders and scale; draw()): the tick moves that group by a transform
+    // instead of rebuilding the svg (_tickTranslate). Re-armed each poll; self-stops when not live.
     this._nowBaseSec = null; this._nowBaseMs = null; this._wasLive = false;
-    this._liveRAF = null; this._liveTO = null; this._liveResume = false; this._lastLiveNow = null;
+    this._liveRAF = null; this._liveTO = null; this._liveResume = false; this._lastLiveNow = null; this._tickPlot = null;
     // Newest data.now sample ever seen this page-lifetime (see isFreshNowSample): a push carrying an
     // OLDER now is a RE-EMISSION — federation re-emits the STORED local payload whenever a remote host
     // pushes, and _cached_timeline re-serves its build-time now — never a fresh clock sample, so it must
@@ -1799,13 +1802,13 @@ class TimelinePanel {
   // Arm the rAF loop (no-op if already running or not currently live+visible). Re-armed each poll by
   // update(), so even after the loop self-stops it returns within one poll once we're live again. NOT
   // called from draw() — draw() runs inside the tick, and re-arming there would double the loop.
-  // The live-follow loop: a look (draw if the edge moved LIVE_MIN_PX; see _tickLive), then a sleep sized to
-  // the edge's speed, then the next look on an animation frame. Restarted by update()/applyBars() (each frame
-  // re-paces it: a pending sleep computed for the old zoom or data is dropped), by gestures, and by the
-  // pointer release when a look was skipped under a held pointer. Hidden pane: the loop STOPS (its old 2 s
-  // sleep re-entered _isVisible()'s forced offsetParent layout every wake, for a pane nobody could see —
-  // 2026-09-07) and the paint hold's release (_releasePaintHold) re-arms it; not live-following: it stops
-  // until a gesture pins the edge again.
+  // The live-follow loop: a look (a translate if the edge moved LIVE_MIN_PX, a draw where a translate cannot
+  // express the frame; see _tickLive), then a sleep sized to the edge's speed, then the next look on an
+  // animation frame. Restarted by update()/applyBars() (each frame re-paces it: a pending sleep computed for
+  // the old zoom or data is dropped), by gestures, and by the pointer release when a look was skipped under a
+  // held pointer. Hidden pane: the loop STOPS (its old 2 s sleep re-entered _isVisible()'s forced offsetParent
+  // layout every wake, for a pane nobody could see — 2026-09-07) and the paint hold's release
+  // (_releasePaintHold) re-arms it; not live-following: it stops until a gesture pins the edge again.
   _startLiveTick() {
     if (!this._liveFollowing() || !this._isVisible()) return;
     if (this._liveRAF != null) return;                                        // a look is already imminent
@@ -1816,10 +1819,11 @@ class TimelinePanel {
     this._liveTO = setTimeout(() => { this._liveTO = null; this._liveRAF = requestAnimationFrame(() => this._tickLive()); }, ms);
   }
   // How long until the live edge has moved LIVE_MIN_PX at the current zoom — the loop sleeps exactly that
-  // long between looks instead of waking every animation frame. A full redraw is what a look costs, so at a
-  // one-hour window over a few hundred px that is a redraw every several seconds, not two a second; and the
-  // sleeping loop touches no layout (the old per-frame _isVisible() read forced one — measured 2026-09-04:
-  // ~40% of the main thread on an idle four-pane dashboard, on the thread the chat pane's clicks share).
+  // long between looks instead of waking every animation frame. A look is a translate now (_tickTranslate; it
+  // was a full redraw) and the pacing is unchanged: at a one-hour window over a few hundred px that is a look
+  // every several seconds, not two a second; and the sleeping loop touches no layout (the old per-frame
+  // _isVisible() read forced one — measured 2026-09-04: ~40% of the main thread on an idle four-pane
+  // dashboard, on the thread the chat pane's clicks share).
   _liveWaitMs() {
     const g = this._geom;
     if (!g || !g.winSec || !g.plotW) return 1000;
@@ -1834,10 +1838,46 @@ class TimelinePanel {
     // (_release) restarts the loop — no polling for it. See the constructor.
     if (this._pointerHeld) { this._liveResume = true; return; }
     const g = this._geom;
-    if (!g || this._lastLiveNow == null || ((this._liveNow() - this._lastLiveNow) / g.winSec * g.plotW) >= LIVE_MIN_PX) {
-      this.draw();
-    }
+    // The look MOVES the view, it does not rebuild it: the last full build left a plot group and its live-edge
+    // riders (draw(), `_tickPlot`), and advancing the edge is one transform write on that group plus a width write
+    // per rider — _tickTranslate, which also owns the LIVE_MIN_PX guard, in COMPRESSED movement (inside a
+    // collapsed trailing gap the edge does not move on screen at all, where a real-seconds guard redrew for
+    // nothing). The full draw() stays for what a translate cannot express — no build yet, a glyph riding the live
+    // edge, the next gridline entering the window, a drift into the gutter — never for the clock's advance.
+    if (!g || this._lastLiveNow == null || !this._tickTranslate(this._liveNow())) this.draw();
     this._sleep(this._liveWaitMs());
+  }
+  // Advance the live edge to `nowS` by moving the plot group (see draw()'s plot group and `_tickPlot`). Returns
+  // true when the frame is expressed — including the no-op of a sub-LIVE_MIN_PX move, or no movement in
+  // compressed time (a collapsed trailing gap) — and false when only a full draw() can: no handle (the loader, or
+  // a glyph riding the live edge was drawn); the clock has reached the next axis gridline (`nextTick`: nothing is
+  // pre-drawn outside the window, so an entering gridline and its clock ARE a rebuild, and the build dated the
+  // event rather than leaving it to the next kernel frame — the kernel dedups an unchanged skeleton and reposts
+  // it every 60 s, so a quiet board would otherwise show a stale axis for up to a minute); or the drift since the
+  // build has reached the gutter gap (no frame has rebuilt since — a quiet or disconnected kernel). The window
+  // geometry the handlers read (_geom's cT0/t0/t1, the held right edge) follows the move, so a pan or a focus
+  // jump begun between builds starts from what is on screen, and the hover re-arms as after a rebuild: the
+  // content moved under a pointer that did not.
+  _tickTranslate(nowS) {
+    const tp = this._tickPlot, g = this._geom;
+    if (!tp || !g || !tp.g || !tp.g.parentNode) return false;
+    if (!tp.trailing && nowS >= tp.nextTick) return false;    // a gridline enters at the right edge: the full draw draws it (inside a trailing gap the axis does not move, so none can)
+    const dc = tp.trailing ? 0 : (g.compress(nowS) - tp.cNow);   // compressed seconds the edge moved since the build
+    const px = dc * tp.k;
+    if (px < 0 || px >= tp.maxDrift) return false;
+    this._lastLiveNow = nowS;
+    if (Math.abs(px - tp.applied) < LIVE_MIN_PX) return true;   // the sub-pixel guard: nothing visible to write yet
+    tp.applied = px;
+    tp.g.setAttribute('transform', 'translate(' + (-px) + ' 0)');
+    for (const r of tp.riders) { if (r.fn) r.fn(px); else r.el.setAttribute(r.attr, Math.max(r.min || 0, r.base + px)); }   // the build's floor applies to the grown extent, so the frame matches a full draw
+    for (const e of tp.edge) {   // an anchored glyph whose anchor crossed the left edge: hidden, as a full draw culls it (inWin) — and hidden takes no pointer
+      const out = e.x - px < tp.left;
+      if (out !== !!e.out) { e.out = out; if (out) e.el.setAttribute('visibility', 'hidden'); else e.el.removeAttribute('visibility'); }
+    }
+    g.cT0 = tp.cT0 + dc; g.t0 = g.decompress(g.cT0); g.t1 = g.decompress(g.cT0 + g.winSec);
+    this._holdReal = g.t1;
+    this._rehover();
+    return true;
   }
   _stopLiveTick() {
     if (this._liveRAF != null) { cancelAnimationFrame(this._liveRAF); this._liveRAF = null; }
@@ -2516,7 +2556,15 @@ class TimelinePanel {
     const i = (this._vis || []).findIndex((s) => s.id === sid);
     if (i < 0) return;
     const y = g.top + i * LANE_GAP + LANE_GAP * 0.5;
-    const X = (tt) => g.ml + ((g.compress ? g.compress(tt) : tt) - g.cT0) / g.winSec * g.plotW;   // compressed-time x
+    // The outline goes INTO the live plot group when the last build left one (_tickPlot): the tick translates
+    // that group, so the outline rides along with its target instead of drifting off it. It is positioned in
+    // the group's own frame (the build's cT0), the translate carrying the rest; with no group (the loader, or
+    // a build with a glyph riding the live edge) it goes on the svg in the screen frame, as before.
+    const tp = this._tickPlot, grp = (tp && tp.g && tp.g.parentNode) ? tp : null;
+    const host = grp ? grp.g : this.svg;
+    const cT0 = grp ? grp.cT0 : g.cT0;
+    const X = (tt) => g.ml + ((g.compress ? g.compress(tt) : tt) - cT0) / g.winSec * g.plotW;   // compressed-time x, in the host's frame
+    const gone = (node) => !node.parentNode || (node.parentNode !== this.svg && !node.parentNode.parentNode);   // detached, or its group left the svg (a rebuild)
     const startMs = (typeof performance !== 'undefined' && performance.now) ? performance.now() : null;
     const DUR = 1400;
     if (workTurn) {
@@ -2524,10 +2572,10 @@ class TimelinePanel {
       const xs = X(workTurn.t), xe = X(workTurn.end != null && workTurn.end > workTurn.t ? workTurn.end : workTurn.t);
       const bw = Math.max(6, xe - xs), h = BAR_H + 6;
       const box = el('rect', { x: xs - 3, y: y - h / 2, width: bw + 6, height: h, rx: h / 2, fill: 'none', stroke: '#ffd166', 'stroke-width': 2.5, opacity: 0.95 });
-      this.svg.appendChild(box);
+      host.appendChild(box);
       try { box.scrollIntoView({ block: 'center', behavior: 'smooth' }); } catch (e) {}
       const step = (nowMs) => {
-        if (!box.parentNode) return;
+        if (gone(box)) return;
         const p = startMs != null ? Math.min(1, (nowMs - startMs) / DUR) : 1;
         const ph = (p * 2) % 1;                        // two pulses
         box.setAttribute('stroke-width', String(2.5 + ph * 2.5));
@@ -2540,10 +2588,10 @@ class TimelinePanel {
     }
     const cx = X(t);
     const ring = el('circle', { cx, cy: y, r: 5, fill: 'none', stroke: '#ffd166', 'stroke-width': 2.5, opacity: 0.95 });
-    this.svg.appendChild(ring);
+    host.appendChild(ring);
     try { ring.scrollIntoView({ block: 'center', behavior: 'smooth' }); } catch (e) {}
     const step = (nowMs) => {
-      if (!ring.parentNode) return;                  // a poll redraw cleared it → stop
+      if (gone(ring)) return;                        // a poll redraw cleared it → stop
       const p = startMs != null ? Math.min(1, (nowMs - startMs) / DUR) : 1;
       const ph = (p * 2) % 1;                         // two expanding pulses
       ring.setAttribute('r', String(5 + ph * 16));
@@ -2555,6 +2603,7 @@ class TimelinePanel {
   }
 
   drawMessage(msg) {
+    this._tickPlot = null;   // the plot group goes with the wipe; the tick has nothing to move until the next build
     while (this.svg.firstChild) this.svg.removeChild(this.svg.firstChild);
     this.svg.setAttribute('height', '60');
     const t = el('text', { x: 14, y: 34, fill: 'var(--text-muted)', 'font-size': 13 }); t.textContent = msg; this.svg.appendChild(t);
@@ -4452,6 +4501,7 @@ class TimelinePanel {
     applyPal();   // refresh the theme palette bindings — a body.theme-light flip lands on this repaint
     if (this.controls) this.controls.style.color = MODEL_FG;   // persistent controls row re-inks per theme (dark: the same #9aa0a6 it was built with)
     this._drawSeq = (this._drawSeq || 0) + 1;   // per-paint nonce: memoizes the overlay scale reflow (_ovScaleNow)
+    this._tickPlot = null;                       // the live tick's translate target — set at the end of a full build (below)
     // LOADING (the user 2026-06-26): until the heavy bars arrive, show ONLY the romp wordmark loader (R +
     // spinning swirl-o + m + p + dots) — NO lanes, NO gridlines. Partial data + empty gridlines read as
     // "broken", so suppress the SVG entirely and show the loader until applyBars sets _barsLoaded. (Data that
@@ -4476,6 +4526,31 @@ class TimelinePanel {
     // that breathes between two tones on a sine ease. That's a per-<text> SMIL `<animate fill>` (added
     // where the chip is drawn below), so no gradient def is needed here.
     svg.appendChild(defs);
+    // THE PLOT GROUP (the live tick as a transform write). Every element positioned by TIME through x() below
+    // goes into this one <g> — bars and their hits, the awaiting/compacting spans, clear seams, branch and
+    // message connectors, arrival and prompt dots, comment squares, the judging runs, the axis gridlines, clocks
+    // and gap squiggles — while the chrome that sits at the window's edges or in the gutter (row hits, lane
+    // lines, names, gear, chips, batteries, the judge rails, the now line, the lock) stays on the svg. Between
+    // builds the live edge advances with the clock, and moving the view by Δc compressed seconds is one attribute
+    // write on this group (translate(-Δc·plotW/winSec, 0)) plus a width write on each element whose right edge
+    // rides the live now (`riders`): the tick (_tickLive → _tickTranslate) does exactly that and nothing else,
+    // where every look of the live loop used to wipe and rebuild the whole svg. The group is APPENDED after the
+    // lane chrome so its paint order matches the old one: over the rows' hit rects and lane lines (a bar must
+    // take the hover), under the lock and the jump button. Clipping stays arithmetic (this file has no clipPath;
+    // see the stub comment): content the build clamped at the window's left edge pokes into the gutter gap by
+    // the drift since that build, which the next frame's rebuild resets, and _tickTranslate hands the tick back
+    // to a full draw() before the drift reaches the battery column. Glyphs are anchored rather than clamped and
+    // overhang their anchor, so the ones anchored within that cap of the edge are listed (`edge`) and the tick
+    // hides each once its anchor crosses the edge, where a full draw would have culled it. Nothing is painted
+    // over the gutter either way. The tick only moves what the build drew — nothing is pre-drawn outside the
+    // window — so what enters or changes between builds waits for a full draw: a gridline and its clock reaching
+    // the right edge get one the moment the clock reaches it (the build dates that, `nextTick`); a lane aging
+    // out or a time-latched visual waits for the next kernel frame — the next push on a changed board, the 60 s
+    // repost of an unchanged skeleton on a quiet one.
+    const plot = el('g', { 'data-tl-plot': '1' });
+    const riders = [];          // {el, attr, base, min} or {el, fn}: the live-edge riders — an open bar's/span's/run's width (or x2) is max(min, base + the drift), base the UN-clamped extent so the floor applies to the grown value; fn re-derives a placement the build centred
+    const edge = [];            // {el, x}: glyphs anchored within the drift cap of the plot's left edge — the tick hides one once its anchor crosses the edge (_tickTranslate), the event a full draw culls it on
+    let liveRiders = false;     // a message glyph or a pending prompt drawn AT the live edge — a path the translate cannot express; the tick then keeps its full draw
     // Pan: the window's RIGHT edge is `now` minus the offset slider; the actual live `now` (nowS)
     // is separate, so pending events still ride the true now (off-screen to the right when panned back).
     const nowS = this._liveNow(), winSec = this.winSec();   // effective now: glides between polls while live-following
@@ -4501,6 +4576,7 @@ class TimelinePanel {
     const cT1 = cNow - off, cT0 = cT1 - winSec;
     const t1 = decompress(cT1), t0 = decompress(cT0);         // real-time window edges (for clip filters)
     this._holdReal = t1;                                      // remember the absolute right edge for the next poll's hold
+    const edgeLive = off === 0;                               // the window's right edge IS the live now: open spans end there and their width rides the tick (riders)
 
     const inWin = (t) => t >= t0 && t <= t1;
     const overlaps = (a, b) => b >= t0 && a <= t1;
@@ -4629,6 +4705,7 @@ class TimelinePanel {
     const chipColX = modelColX + (maxModel > 0 ? Math.ceil(maxModel) + COLGAP : 0);
     const ctxColX = chipColX + (maxChip > 0 ? Math.ceil(maxChip) + COLGAP : 0);
     M.left = ctxColX + (maxCtx > 0 ? Math.ceil(maxCtx) + COLGAP : 4);
+    const maxDrift = Math.max(2, (maxCtx > 0 ? COLGAP : 4) - 1);   // how far the tick may translate the plot before a full draw (_tickPlot, below): the gutter gap left of it, less a pixel
     // (the compacting cue is now a solid teal "compression" rect drawn per-lane below — no shared gradient)
 
     // judging band height: a compact judge row per JUDGES entry, shown only when there's judging
@@ -4655,6 +4732,10 @@ class TimelinePanel {
     // x is LINEAR in compressed time → smooth pan (only zoom rescales). Identity compress = plain linear.
     const x = (t) => M.left + (compress(t) - cT0) / winSec * plotW;
     const laneY = (i) => M.top + i * LANE_GAP + LANE_GAP * 0.5;
+    // A glyph is ANCHORED at its x, not clamped at the edge — a dot overhangs by DOT_R, a comment square by half its
+    // side, a seam or a branch bar by its hit — so the drift cap alone does not keep one anchored just inside the
+    // edge off the battery column: the tick hides each listed glyph once its anchor crosses M.left (`edge`).
+    const nearEdge = (node, ax) => { if (ax - M.left < maxDrift) edge.push({ el: node, x: ax }); return node; };
     this._geom = { ml: M.left, plotW, W, H, top: M.top, t0, t1, cT0, winSec, compress, decompress };
 
     // axis — gridlines + time labels. Ticks at real nice intervals, drawn at their compressed x (evenly
@@ -4673,11 +4754,11 @@ class TimelinePanel {
     placedLabels.push([lockCx - lockHalf, lockCx + lockHalf]);
     for (let tk = Math.ceil(t0 / step) * step; tk <= t1; tk += step) {
       if (inGap(tk)) continue;
-      svg.appendChild(el('line', { x1: x(tk), y1: M.top, x2: x(tk), y2: axisY, stroke: PAL().grid, 'stroke-width': 1 }));
+      nearEdge(plot.appendChild(el('line', { x1: x(tk), y1: M.top, x2: x(tk), y2: axisY, stroke: PAL().grid, 'stroke-width': 1, 'pointer-events': 'none' })), x(tk));   // in the plot group it paints OVER the row hits it used to sit under: the row keeps the pointer
       this._mc.font = '10px ' + this._fontFace();
       const hw = this._mc.measureText(clock(tk)).width / 2;
       if (!placeLabel(x(tk) - hw, x(tk) + hw)) continue;
-      const tx = el('text', { x: x(tk), y: axisY + 14, 'text-anchor': 'middle', fill: 'var(--text-muted)', 'font-size': 10 }); tx.textContent = clock(tk); svg.appendChild(tx);
+      const tx = el('text', { x: x(tk), y: axisY + 14, 'text-anchor': 'middle', fill: 'var(--text-muted)', 'font-size': 10 }); tx.textContent = clock(tk); nearEdge(plot.appendChild(tx), x(tk));
     }
     svg.appendChild(el('line', { x1: x(t1), y1: M.top, x2: x(t1), y2: axisY, stroke: PAL().gridStrong, 'stroke-width': 1 }));
     // broken-axis squiggle(s): one per collapsed gap visible in the window (real edges → compressed x).
@@ -4688,7 +4769,7 @@ class TimelinePanel {
       for (const g of cmap.gaps) if (g.rb > t0 && g.ra < t1) {
         const rx0 = x(g.ra), rx1 = x(g.rb);
         const gx0 = Math.max(M.left, rx0), gx1 = Math.min(plotR, rx1);
-        if (gx1 > gx0 + 0.5) this._drawGapBreak(svg, gx0, gx1, g.ra, g.rb, M.top, axisY, rx0 >= M.left - 0.5, !g.trailing && rx1 <= plotR + 0.5, placeLabel);
+        if (gx1 > gx0 + 0.5) this._drawGapBreak(plot, gx0, gx1, g.ra, g.rb, M.top, axisY, rx0 >= M.left - 0.5, !g.trailing && rx1 <= plotR + 0.5, placeLabel);
       }
     }
     if (!vis.length) { const tx = el('text', { x: M.left, y: M.top + 16, fill: 'var(--text-muted)', 'font-size': 12 }); tx.textContent = 'no romp activity in this window'; svg.appendChild(tx); }
@@ -4762,14 +4843,15 @@ class TimelinePanel {
         // (same ask before & after), so it does NOT split the work — it's an overlay (candy-stripe
         // below). Only a new ASK (typed/queued/absorbed/drain) starts a new period. The bar's color
         // also backs the candy-stripe.
-        const bx = x(a), bw = Math.max(2, x(b) - x(a)), eh = BAR_H + 5;
+        const bx = x(a), bwRaw = x(b) - x(a), bw = Math.max(2, bwRaw), eh = BAR_H + 5;
         // Cross-hover focus on this work period — a DAG journey event (card hover) or the single event
         // hovered in the feed modal — draws EXACTLY like the native bar hover below: the bar itself
         // grown to eh and fully opaque, in its own color. No white outline (the user 2026-07-17).
         const lit = barLit(t, dagOrHover);
         const bh = lit ? eh : BAR_H;
         const bar = el('rect', { x: bx, y: y - bh / 2, width: bw, height: bh, rx: bh / 2, fill: s.color, opacity: lit ? 1 : 0.9 });
-        svg.appendChild(bar);
+        plot.appendChild(bar);
+        const liveEdge = barEndT(t, nowS, data.now) >= t1;   // an OPEN bar ends at the live edge → its width rides the tick (riders, below)
         const act = s.state === 'working' || s.state === 'permission' || s.state === 'needsInput' || s.state === 'awaiting' || s.state === 'awaitingBg' || s.state === 'compacting' || s.state === 'clearing';
         const ongoing = s.live && act && t.end > t.start && (data.now - t.end) <= 5;
         const hit = el('rect', { x: bx, y: y - 7, width: bw, height: 14, fill: 'transparent' }); hit.style.cursor = 'pointer';
@@ -4783,7 +4865,8 @@ class TimelinePanel {
         // work-bar click visibly did nothing while prompt-dot clicks worked (the user, 2026-06-12).
         // The prompt dot keeps the prompt-line uuid.
         hit.addEventListener('click', () => { this._select(s.id); this.openChat(t.tid || this._laneTid(s), workAnchorOf(t), false, false, t.start); });
-        svg.appendChild(hit);
+        plot.appendChild(hit);
+        if (liveEdge) riders.push({ el: bar, attr: 'width', base: bwRaw, min: 2 }, { el: hit, attr: 'width', base: bwRaw, min: 2 });   // the un-clamped extent with the 2 px floor: a just-opened bar grows as a full draw would draw it
       });
       // AWAITING a background task while the main thread is idle (the user 2026-07-13): a full-thickness
       // segment (BAR_H, the work-bar reference) in the lane color from the last work period's end to the
@@ -4799,7 +4882,7 @@ class TimelinePanel {
         if (lx2 - lx1 > 3) {
           const ln = el('line', { x1: lx1, y1: y, x2: lx2, y2: y, stroke: s.color, 'stroke-width': BAR_H,
             'stroke-linecap': 'round', opacity: 0.4, 'pointer-events': 'none' });
-          svg.appendChild(ln);
+          plot.appendChild(ln);
           const rows = ((s.awaitingTasks && s.awaitingTasks.length) ? s.awaitingTasks : [s.awaitingBg])
             .map((d) => '<div class="b" style="opacity:.85">' + esc(d) + '</div>').join('');
           const tip = '<div class="r"><span class="chip" style="background:' + s.color + '"></span><span class="who" style="color:' + s.color + '">' + esc(s.name)
@@ -4814,7 +4897,8 @@ class TimelinePanel {
             if (this._suppressClick) { this._suppressClick = false; return; }
             this._select(s.id); this.openChat(this._laneTid(s), null, true);
           });
-          svg.appendChild(wh);
+          plot.appendChild(wh);
+          if (edgeLive) riders.push({ el: ln, attr: 'x2', base: lx2 }, { el: wh, attr: 'width', base: lx2 - lx1 });
         }
       }
       // AWAITING (permission) → candy-stripe every span the session sat blocked on your
@@ -4847,10 +4931,10 @@ class TimelinePanel {
         const eh = BAR_H + 5;
         // colored backing bridges the gap (square caps so it merges with the rounded bars on either side)
         const back = el('rect', { x: bx0, y: y - BAR_H / 2, width: Math.max(2, bx1 - bx0), height: BAR_H, fill: s.color, opacity: 0.9 });
-        svg.appendChild(back);
+        plot.appendChild(back);
         // candy-cane stripes over the ACTUAL awaiting span (shows the session color THROUGH the stripes)
         const stripe = el('rect', { x: x(sa), y: y - BAR_H / 2, width: Math.max(2, x(sb) - x(sa)), height: BAR_H, fill: 'url(#vault-await-hatch)' });
-        svg.appendChild(stripe);
+        plot.appendChild(stripe);
         const sh = el('rect', { x: bx0, y: y - 7, width: Math.max(2, bx1 - bx0), height: 14, fill: 'transparent' }); sh.style.cursor = 'pointer';
         const end = open ? 'now' : clock(b0);
         const shtml = () => '<div class="r"><span class="chip" style="background:' + BADGE.attention.bg + '"></span><span class="who" style="color:' + s.color + '">' + esc(s.name) + '</span><span class="k">blocked</span></div><div class="b">blocked on your input · ' + clock(a0) + '–' + end + '</div>';
@@ -4859,7 +4943,8 @@ class TimelinePanel {
         sh.addEventListener('mousemove', (e) => this.moveTip(e));
         sh.addEventListener('mouseleave', () => { grow(BAR_H); this.hideTip(); });
         sh.addEventListener('click', () => { this._select(s.id); this.openChat(this._laneTid(s), null, true); });
-        svg.appendChild(sh);
+        plot.appendChild(sh);
+        if (open && edgeLive) riders.push({ el: back, attr: 'width', base: bx1 - bx0, min: 2 }, { el: stripe, attr: 'width', base: x(sb) - x(sa), min: 2 }, { el: sh, attr: 'width', base: bx1 - bx0, min: 2 });
       }
       // CONTEXT COMPACTING (LIVE) → cyan cross-hatch over the session color for every span the session
       // sat compacting (PreCompact→PostCompact from the state log), plus the current open one if it's
@@ -4871,11 +4956,11 @@ class TimelinePanel {
         const open = span[1] == null || span[1] >= data.now - 2;   // still compacting: to the live edge (see the awaiting loop)
         const a0 = span[0], b0 = open ? Math.max(nowS, a0) : span[1];
         const sa = Math.max(a0, t0), sb = Math.min(b0, t1); if (sb <= sa) continue;
-        const eh = BAR_H + 5, cx = x(sa), cw = Math.max(2, x(sb) - x(sa));
+        const eh = BAR_H + 5, cx = x(sa), cwRaw = x(sb) - x(sa), cw = Math.max(2, cwRaw);
         const cback = el('rect', { x: cx, y: y - BAR_H / 2, width: cw, height: BAR_H, rx: 2, fill: s.color, opacity: 0.9 });
-        svg.appendChild(cback);
+        plot.appendChild(cback);
         const chx = el('rect', { x: cx, y: y - BAR_H / 2, width: cw, height: BAR_H, rx: 2, fill: 'url(#vault-compact-hatch)' });
-        svg.appendChild(chx);
+        plot.appendChild(chx);
         const ch = el('rect', { x: cx, y: y - 7, width: cw, height: 14, fill: 'transparent' }); ch.style.cursor = 'pointer';
         const live = open;
         const cw2 = live ? 'compacting' : 'compacted';
@@ -4885,7 +4970,8 @@ class TimelinePanel {
         ch.addEventListener('mousemove', (e) => this.moveTip(e));
         ch.addEventListener('mouseleave', () => { cgrow(BAR_H); this.hideTip(); });
         ch.addEventListener('click', () => { this._select(s.id); this.openChat(this._laneTid(s), null, true); });
-        svg.appendChild(ch);
+        plot.appendChild(ch);
+        if (open && edgeLive) riders.push({ el: cback, attr: 'width', base: cwRaw, min: 2 }, { el: chx, attr: 'width', base: cwRaw, min: 2 }, { el: ch, attr: 'width', base: cwRaw, min: 2 });
       }
       // CONTEXT COMPACTION → a cyan cross-hatch SPAN over the session color (same figure-ground as the
       // awaiting candy-cane: identity color behind, texture in front). The span runs from compaction
@@ -4898,9 +4984,9 @@ class TimelinePanel {
         const ce = Math.min(cp.t, t1);
         const cx = x(cs), cw = Math.max(6, x(ce) - cx), eh = BAR_H + 5;
         const cback = el('rect', { x: cx, y: y - BAR_H / 2, width: cw, height: BAR_H, rx: 2, fill: s.color, opacity: 0.9 });
-        svg.appendChild(cback);
+        plot.appendChild(cback);
         const chx = el('rect', { x: cx, y: y - BAR_H / 2, width: cw, height: BAR_H, rx: 2, fill: 'url(#vault-compact-hatch)' });
-        svg.appendChild(chx);
+        plot.appendChild(chx);
         const ch = el('rect', { x: cx, y: y - 7, width: cw, height: 14, fill: 'transparent' }); ch.style.cursor = 'pointer';
         const chtml = () => '<div class="r"><span class="chip" style="background:#86e1ff"></span><span class="who" style="color:' + s.color + '">' + esc(s.name) + '</span><span class="k">compacted</span></div><div class="b">context compacted · ' + clock(cp.t) + '</div>';
         const cgrow = (h) => { for (const r of [cback, chx]) { r.setAttribute('y', y - h / 2); r.setAttribute('height', h); } };
@@ -4908,7 +4994,7 @@ class TimelinePanel {
         ch.addEventListener('mousemove', (e) => this.moveTip(e));
         ch.addEventListener('mouseleave', () => { cgrow(BAR_H); this.hideTip(); });
         ch.addEventListener('click', () => { this._select(s.id); this.openChat(this._laneTid(s), null, true); });
-        svg.appendChild(ch);
+        plot.appendChild(ch);
       }
       // A /CLEAR SEAM — an episode boundary: the conversation ended here and a blank one began. Drawn
       // as a film-splice cut through the lane (two short slanted strokes), quiet by default with the
@@ -4918,15 +5004,15 @@ class TimelinePanel {
         if (cl.t < t0 || cl.t > t1) continue;
         const sx = x(cl.t), sh = BAR_H + 6;
         for (const dx of [-1.6, 1.6]) {
-          svg.appendChild(el('line', { x1: sx + dx - 2, y1: y + sh / 2, x2: sx + dx + 2, y2: y - sh / 2,
-                                       stroke: '#ffffff', 'stroke-width': 1.2, opacity: 0.55, 'pointer-events': 'none' }));
+          nearEdge(plot.appendChild(el('line', { x1: sx + dx - 2, y1: y + sh / 2, x2: sx + dx + 2, y2: y - sh / 2,
+                                                stroke: '#ffffff', 'stroke-width': 1.2, opacity: 0.55, 'pointer-events': 'none' })), sx);
         }
         const hh = el('rect', { x: sx - 6, y: y - 10, width: 12, height: 20, fill: 'transparent' });
         const html = () => '<div class="r"><span class="chip" style="background:#9cd2ff"></span><span class="who" style="color:' + s.color + '">' + esc(s.name) + '</span><span class="k">cleared</span></div><div class="b">conversation cleared · a fresh one starts here · ' + clock(cl.t) + '</div>';
         hh.addEventListener('mouseenter', (e) => this.showTip(html(), e));
         hh.addEventListener('mousemove', (e) => this.moveTip(e));
         hh.addEventListener('mouseleave', () => this.hideTip());
-        svg.appendChild(hh);
+        nearEdge(plot.appendChild(hh), sx);
       }
       // name left-aligned; status chip in the shared chip column to its right. ENDED or idle >1h
       // (s.faded) → name/chip/ctx blended toward the surface bg to a uniform low luminance (perceptual
@@ -5167,6 +5253,7 @@ class TimelinePanel {
     this._reapCompactBars(compactSeen);   // drop overlay scan-bars for lanes no longer compacting / off-screen
     this._reapWorkLabels(workSeen);        // drop overlay WORKING labels for lanes no longer working / off-screen
     this._reapMetaDots(metaSeen);          // drop switching-dots overlays for lanes whose /model pick has landed / off-screen
+    svg.appendChild(plot);   // the plot group takes its place now: over every row's hit rect and lane line, under the lock and the jump button (drawn last)
 
     // ── branch connectors (the user 2026-08-14): a fork drawn like a git graph — one thick
     // perpendicular bar, work-bar weight (BAR_H), from the parent's lane to the child's at the fork
@@ -5181,7 +5268,7 @@ class TimelinePanel {
       if (y1 === y2) return;
       const bTop = Math.min(y1, y2), bH = Math.abs(y2 - y1);
       const bbar = el('rect', { x: bx - BAR_H / 2, y: bTop, width: BAR_H, height: bH, rx: BAR_H / 2, fill: s.color, opacity: 0.85 });
-      svg.appendChild(bbar);
+      nearEdge(plot.appendChild(bbar), bx);
       const bhit = el('rect', { x: bx - 9, y: bTop - 4, width: 18, height: bH + 8, fill: 'transparent' });
       bhit.style.cursor = 'pointer';
       const pname = (data.sessions.find((p) => p.id === br.fromId) || {}).name || '';
@@ -5192,7 +5279,7 @@ class TimelinePanel {
       bhit.addEventListener('mousemove', (e) => this.moveTip(e));
       bhit.addEventListener('mouseleave', () => { bbar.setAttribute('opacity', '0.85'); this.hideTip(); });
       bhit.addEventListener('click', () => { this._select(s.id); this.openChat(s.id, br.cut ? 'branch:' + br.cut : '', false, false, br.t); });
-      svg.appendChild(bhit);
+      nearEdge(plot.appendChild(bhit), bx);
     });
 
     // obstacles for routing — at each event's process-start (a pending event rides `now` via execAt/startAt)
@@ -5345,14 +5432,15 @@ class TimelinePanel {
       const attrs = { d, fill: 'none', stroke: col, 'stroke-width': STUB_W, opacity: 0.45,
                       'stroke-linecap': 'round', 'stroke-linejoin': 'round', 'pointer-events': 'none' };
       if (!arrived) attrs['stroke-dasharray'] = '1 4';   // in flight — the pending-connector dash (same key as the span)
-      svg.appendChild(el('path', attrs));
+      if (!arrived && !mm.toThreadT) liveRiders = true;   // an un-arrived stub spans to the live edge: the tick cannot translate that
+      plot.appendChild(el('path', attrs));
       // same affordances as a full connector: own-color highlight overlay + wide transparent hit —
       // the SAME path each, so highlight and hover cover the whole half-elbow as one unit —
       // co-lit with the arrival dot (PASS 2 links via msgUI), tooltip + click → where it landed
       const msgLit = dagOrHoverMsg(mm.id);
       const hl = el('path', { d, fill: 'none', stroke: col, 'stroke-width': STUB_W + 3, opacity: msgLit ? 0.95 : 0,
                               'stroke-linecap': 'round', 'stroke-linejoin': 'round', 'pointer-events': 'none' });
-      svg.appendChild(hl);
+      plot.appendChild(hl);
       const u = (msgUI[i] = { hl, dot: null, lit: msgLit });
       const hit = el('path', { d, fill: 'none', stroke: 'transparent', 'stroke-width': MSG_HIT_W,
                                'stroke-linecap': 'round', 'stroke-linejoin': 'round' });
@@ -5394,13 +5482,14 @@ class TimelinePanel {
       const arrived = mm.hasExec || mm.exec !== mm.sent;
       const lineAttr = { d, fill: 'none', stroke: col, 'stroke-width': MSG_W0, opacity: arrived ? 0.5 : 0.4, 'stroke-linecap': 'round', 'stroke-linejoin': 'round' };
       if (!arrived) lineAttr['stroke-dasharray'] = '1 4';
-      svg.appendChild(el('path', lineAttr));
+      if (mm.pending && !mm.toThreadT) liveRiders = true;   // a pending message lands AT the live edge (execAt): not a translate
+      plot.appendChild(el('path', lineAttr));
       // A connector in the focused journey (DAG card hover) or the hovered subtree's delegation messages
       // lights EXACTLY like its native hover: the own-color highlight overlay at full strength — no white
       // casing (the user 2026-07-17). msgLit remembers the drawn state so a local mouseleave restores it.
       const msgLit = dagOrHoverMsg(mm.id);
       const hl = el('path', { d, fill: 'none', stroke: col, 'stroke-width': MSG_W0 + 3, opacity: msgLit ? 0.95 : 0, 'stroke-linecap': 'round', 'stroke-linejoin': 'round' });
-      svg.appendChild(hl);
+      plot.appendChild(hl);
       const u = (msgUI[i] = { hl, dot: null, lit: msgLit });
       // The hit target is BUILT here but APPENDED in a final pass below, after the arrival dots
       // (the user 2026-07-21, who found that hovering the vertical part didn't pop up the tooltip and they had to hit
@@ -5439,7 +5528,7 @@ class TimelinePanel {
         ? () => { const u0 = msgUI[msgI]; msgSetLight((u0 && u0.hoverSet) || [msgI], false); if (u0) u0.hoverSet = null; c.setAttribute('r', lit ? DOT_R + 2 : DOT_R); this.hideTip(); }
         : () => { c.setAttribute('r', lit ? DOT_R + 2 : DOT_R); if (linkedHl) linkedHl.setAttribute('opacity', lit ? '0.95' : '0'); this.hideTip(); });
       if (onClick) c.addEventListener('click', onClick);
-      svg.appendChild(c);
+      nearEdge(plot.appendChild(c), cx);
       return c;
     };
 
@@ -5450,6 +5539,7 @@ class TimelinePanel {
       if (vidx[mm.toId] == null || !inWin(landXT(mm))) return;
       const col = colorOf(mm.fromId), cy = laneY(vidx[mm.toId]);
       const u = msgUI[i];
+      if (mm.pending && !mm.toThreadT) liveRiders = true;   // its arrival dot rides the live edge (execAt)
       const c = dot(x(landXT(mm)), cy, col, msgHtml(mm), msgNav(mm), u && u.hl, dagOrHoverMsg(mm.id), i);
       if (u) u.dot = c;
     });
@@ -5459,7 +5549,7 @@ class TimelinePanel {
     // Nothing is lost by sitting over a message dot: the dot's tooltip, growth and click are the same
     // message's, and mEnter grows the linked dot too. Prompt dots are drawn after this pass, so they
     // keep their own hover.
-    Object.keys(msgUI).forEach((k) => { const u = msgUI[k]; if (u && u.hit) svg.appendChild(u.hit); });
+    Object.keys(msgUI).forEach((k) => { const u = msgUI[k]; if (u && u.hit) plot.appendChild(u.hit); });
 
     // turn process-start (prompt) dots — at startAt; CLICKABLE → jump to the prompt that started
     // the period. Skipped where a PROCESSED message dot coincides (the message dot stands in).
@@ -5474,6 +5564,7 @@ class TimelinePanel {
       turnsOf(s.id).forEach((t) => {
         if (t.cont) return;                  // a post-sleep continuation piece of one segment: its prompt dot belongs to the FIRST piece, not here
         if (!inWin(startAt(t))) return;
+        if (t.pending) liveRiders = true;    // a pending prompt's dot rides the live edge (startAt): not a translate
         if (execNear(s.id, startAt(t))) return;
         const dx = x(startAt(t));
         // cross-hover focus (dot GROWN in place, via dot()'s lit param): DAG journey node, a coarse card
@@ -5495,7 +5586,7 @@ class TimelinePanel {
         dot(dx, y, isRomp ? '#000' : s.color, tip, () => { this._select(s.id); this.openChat(t.tid || s.id, t.uuid, false, false, startAt(t), 'user'); }, null, dotLit(t, dagOrHover));   // romp message → a black dot (the swirl reads on it); prompt-intent → time fallback restricted to user turns
         if (isRomp) {                                    // the romp favicon swirl INSIDE the black dot; pointer-events:none → the dot keeps its hover/click
           const sz = DOT_R * 1.9;
-          svg.appendChild(el('image', { x: dx - sz / 2, y: y - sz / 2, width: sz, height: sz, href: mediaUrl('romp-swirl-glyph.svg'), 'pointer-events': 'none' }));
+          nearEdge(plot.appendChild(el('image', { x: dx - sz / 2, y: y - sz / 2, width: sz, height: sz, href: mediaUrl('romp-swirl-glyph.svg'), 'pointer-events': 'none' })), dx);
         }
       });
     });
@@ -5522,7 +5613,7 @@ class TimelinePanel {
         sq.addEventListener('mousemove', (e) => this.moveTip(e));
         sq.addEventListener('mouseleave', () => { qGrow(0); this.hideTip(); });
         sq.addEventListener('click', () => { this._select(s.id); this.openChat(s.id, c.uuid, false, false, c.t); });
-        svg.appendChild(sq);
+        nearEdge(plot.appendChild(sq), cx);
       });
     });
 
@@ -5534,16 +5625,16 @@ class TimelinePanel {
       const jY = (i) => jb0 + i * JROW + JROW * 0.5;
       const nameOf = (sid) => { const s = data.sessions.find((z) => z.id === sid); return s ? s.name : sid; };
       const sepY = jb0 - JB_TOPGAP * 0.5;
-      svg.appendChild(el('line', { x1: M.left, y1: sepY, x2: x(t1), y2: sepY, stroke: '#ffffff14', 'stroke-width': 1, 'pointer-events': 'none' }));
+      svg.insertBefore(el('line', { x1: M.left, y1: sepY, x2: x(t1), y2: sepY, stroke: '#ffffff14', 'stroke-width': 1, 'pointer-events': 'none' }), plot);   // the band's fixed chrome goes UNDER the plot group, where it painted before
       // vertical "judges" section label in the freed gutter space, just left of the right-justified judge names
       const jcx = Math.max(12, M.left - 72), jcy = (jY(0) + jY(shownJudges.length - 1)) / 2;
-      const hd = el('text', { x: jcx, y: jcy, fill: 'var(--text-faint)', 'font-size': 9, 'font-weight': 700, 'letter-spacing': '.08em', 'text-anchor': 'middle', transform: 'rotate(-90 ' + jcx + ' ' + jcy + ')' }); hd.textContent = 'judges'; svg.appendChild(hd);
+      const hd = el('text', { x: jcx, y: jcy, fill: 'var(--text-faint)', 'font-size': 9, 'font-weight': 700, 'letter-spacing': '.08em', 'text-anchor': 'middle', transform: 'rotate(-90 ' + jcx + ' ' + jcy + ')' }); hd.textContent = 'judges'; svg.insertBefore(hd, plot);
       shownJudges.forEach((J, ji) => {
         const y = jY(ji);
         // baseline rail through the row, faintly tinted in the judge's colour so each row is identifiable
-        svg.appendChild(el('line', { x1: M.left, y1: y, x2: x(t1), y2: y, stroke: J.color, 'stroke-opacity': 0.28, 'stroke-width': 2, 'stroke-linecap': 'round', 'pointer-events': 'none' }));
+        svg.insertBefore(el('line', { x1: M.left, y1: y, x2: x(t1), y2: y, stroke: J.color, 'stroke-opacity': 0.28, 'stroke-width': 2, 'stroke-linecap': 'round', 'pointer-events': 'none' }), plot);
         // judge name right-justified so it sits right beside the start of its rail
-        const lbl = el('text', { x: M.left - 6, y: y + 3, 'text-anchor': 'end', fill: J.color, 'font-size': 10, 'font-weight': 600 }); lbl.textContent = J.key; svg.appendChild(lbl);
+        const lbl = el('text', { x: M.left - 6, y: y + 3, 'text-anchor': 'end', fill: J.color, 'font-size': 10, 'font-weight': 600 }); lbl.textContent = J.key; svg.insertBefore(lbl, plot);
         // merge this judge's in-window marks into same-session blocks (a stretch of attention)
         // each mark is a RUN SPAN [t, t1] = [sent, recv] (g70): the real wall-clock the judge call ran, not
         // a point back-placed onto the work. Merge adjacent same-session spans into a stretch of attention.
@@ -5561,9 +5652,10 @@ class TimelinePanel {
         for (const b of blocks) {
           // an OPEN run (still in flight) has no recv yet — grow its bar to the live edge so it appears WHEN
           // it starts and advances with the axis, instead of popping in (back-dated) only once it ends.
-          let bx1 = x(b.start), bx2 = x(b.open ? Math.max(b.end, nowS) : b.end);
+          const rx1 = x(b.start), rx2 = x(b.open ? Math.max(b.end, nowS) : b.end);   // the run's own extent; a narrow one draws centred at JMARK_MINW
+          let bx1 = rx1, bx2 = rx2;
           if (bx2 - bx1 < JMARK_MINW) { const c = (bx1 + bx2) / 2; bx1 = c - JMARK_MINW / 2; bx2 = c + JMARK_MINW / 2; }
-          b._x1 = bx1; b._x2 = bx2;
+          b._x1 = bx1; b._x2 = bx2; b._rx1 = rx1; b._rw = rx2 - rx1;
           let lane = laneEnds.findIndex((endX) => bx1 >= endX);
           if (lane === -1) { lane = laneEnds.length; laneEnds.push(bx2); } else laneEnds[lane] = bx2;
           b._lane = lane;
@@ -5581,7 +5673,7 @@ class TimelinePanel {
           // opaque bar; a settled one is slightly dimmed — that's the only cue, no stroke.
           const r = el('rect', { x: x1, y: by - barH / 2, width: x2 - x1, height: barH, rx: Math.min(2.5, barH / 2),
             fill: col, 'fill-opacity': active ? 1 : 0.82, 'data-judge': J.key });
-          svg.appendChild(r);
+          plot.appendChild(r);
           const html = () => {
             const span = b.open ? clock(b.start) + '– running…' : (b.start === b.end ? clock(b.start) : clock(b.start) + '–' + clock(b.end));
             // elapsed (total judge compute) + tokens for this stretch, summed from each mark's matched run
@@ -5599,12 +5691,34 @@ class TimelinePanel {
           hit.addEventListener('mouseenter', (e) => this.showTip(html(), e));
           hit.addEventListener('mousemove', (e) => this.moveTip(e));
           hit.addEventListener('mouseleave', () => this.hideTip());
-          svg.appendChild(hit);
+          plot.appendChild(hit);
+          if (b.open && edgeLive) {   // an open run grows to the live edge: the rider re-derives the full draw's placement from the un-centred extent, so the centring goes once the run is wider than JMARK_MINW
+            const rx1 = b._rx1, rw = b._rw;
+            riders.push({ el: r, base: rw, x0: rx1, fn: (px) => {
+              const w = rw + px, narrow = w < JMARK_MINW, ax = narrow ? rx1 + (w - JMARK_MINW) / 2 : rx1, aw = narrow ? JMARK_MINW : w;
+              r.setAttribute('x', ax); r.setAttribute('width', aw); hit.setAttribute('x', ax - 2); hit.setAttribute('width', aw + 4);
+            } });
+          }
         }
       });
       // (auto-nudge ⚡ marks were removed from the judge band entirely — the user 2026-06-23. An auto-nudge
       // still surfaces as a romp-logo dot on its own lane; the band is now judge run-spans only.)
     }
+
+    // The live tick's handle on this build (see the plot group above and _tickTranslate): the group, its riders,
+    // the compressed now the build stood at and the px-per-compressed-second scale. A message glyph riding the
+    // live edge leaves it null — the tick then does the full draw it always did. The drift cap is the gutter gap
+    // left of the plot (COLGAP past the battery column, 4 px without one): content the build clamped at the
+    // window's left edge may poke that far into the gap before the tick hands back to a full draw; the glyphs
+    // anchored within the cap of the edge (`edge`, nearEdge) overhang their anchor, and the tick hides each once
+    // its anchor crosses the edge (`left`), so none reaches the battery column either. nextTick is the first axis
+    // tick past the window's right edge, in real seconds: the same interval the axis pass above draws at, so the
+    // tick hands back for a full draw exactly when a gridline and its clock would enter.
+    this._tickPlot = liveRiders ? null : {
+      g: plot, riders, edge, left: M.left, cNow, cT0, winSec, k: plotW / winSec, applied: 0,
+      trailing: !!(cmap && cmap.gaps.length && cmap.gaps[cmap.gaps.length - 1].trailing),
+      maxDrift, nextTick: (Math.floor(t1 / step) + 1) * step,
+    };
 
     // far-right ⟩⟩ jump-to-now button — only when held back off the live edge (unpinned)
     if (!this._pinned) this._drawNowButton(svg);

--- a/ui/timeline-hidden-stub.test.ts
+++ b/ui/timeline-hidden-stub.test.ts
@@ -277,7 +277,9 @@ test("a hidden-sender message draws the mirror stub: horizontal just ABOVE the l
   near(r._attrs.y1, s._attrs.y2, "…from the track");
   near(r._attrs.y2, laneY(panel)(0), "…down to the bar, meeting the arrival dot");
   assert.equal(r._attrs["stroke-dasharray"], undefined, "solid, like its arrived stub");
-  const kids = panel.svg.children;
+  // the time-positioned glyphs live in draw()'s plot group (the live tick translates it); the paint order
+  // inside it is the one this test has always pinned
+  const kids = panel.svg.children.find((n: any) => n._attrs["data-tl-plot"]).children;
   const dotI = kids.findIndex((n: any) => n.tag === "circle" && Math.abs(n._attrs.cx - X(panel)(now - 100)) < 1e-6);
   assert.ok(dotI >= 0, "the arrival dot still draws on the recipient lane");
   const hitI = kids.findIndex((n: any) => n.tag === "path" && n._attrs.stroke === "transparent" && n._attrs["stroke-width"] === 18);

--- a/ui/timeline-open-interval.test.ts
+++ b/ui/timeline-open-interval.test.ts
@@ -1,0 +1,194 @@
+// An awaiting or compacting interval the session is STILL in arrives with its end at the payload's own
+// clock (kernel _state_intervals ends an open span at `now`): the renderer reads an end within 2 s of
+// data.now — or a null end — as OPEN and draws it to the live edge, the way barEndT draws an open work
+// bar, so the stripe glides with the edge instead of sitting at the kernel's build clock until the next
+// rebuild (the lanes frame is projected from the cached build, so its clock can trail the live edge by
+// up to a rebuild). The end stays numeric on the wire: a null end was a wire break for every already-loaded
+// renderer (Math.min(null, t1) = 0 dropped the stripe). Headless draw() over a minimal DOM shim (the
+// timeline-render.test.ts pattern), with the live edge pushed MAX_INTERP_AHEAD past data.now so "to the
+// live edge" and "to the payload's end" land on different pixels.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+function makeNode(tag: string): any {
+  const n: any = {
+    tag, _attrs: {}, children: [] as any[], style: {}, dataset: {}, textContent: "", parentNode: null,
+    classList: { _s: new Set<string>(), add(...a: string[]) { a.forEach((c) => this._s.add(c)); },
+      remove(...a: string[]) { a.forEach((c) => this._s.delete(c)); },
+      toggle(c: string, f?: boolean) { f ? this._s.add(c) : this._s.delete(c); }, contains(c: string) { return this._s.has(c); } },
+    setAttribute(k: string, v: any) { this._attrs[k] = v; }, getAttribute(k: string) { return this._attrs[k]; },
+    setAttributeNS(_n: any, k: string, v: any) { this._attrs[k] = v; }, removeAttribute(k: string) { delete this._attrs[k]; },
+    appendChild(c: any) { c.parentNode = n; this.children.push(c); return c; },
+    insertBefore(c: any, ref: any) { c.parentNode = n; const i = this.children.indexOf(ref); i < 0 ? this.children.push(c) : this.children.splice(i, 0, c); return c; },
+    removeChild(c: any) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); return c; },
+    get firstChild() { return this.children[0] || null; },
+    _ls: {} as any,
+    addEventListener(t: string, fn: any) { (n._ls[t] = n._ls[t] || []).push(fn); }, removeEventListener() {},
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    getBoundingClientRect() { return { width: 1400, height: 420, left: 0, top: 0, right: 1400, bottom: 420 }; },
+    closest() { return null; }, focus() {},
+    createEl(t: string, o: any) { const e = makeNode(t); if (o && o.cls) e.classList.add(o.cls); if (o && o.text) e.textContent = o.text; this.appendChild(e); return e; },
+    createDiv(o: any) { return this.createEl("div", o); }, createSpan(o: any) { return this.createEl("span", o); },
+  };
+  return n;
+}
+const g: any = global;
+g.document = {
+  createElement(t: string) { return t === "canvas" ? { getContext() { return { font: "", measureText(s: string) { return { width: (s ? s.length : 0) * 6 }; } }; } } : makeNode(t); },
+  createElementNS(_n: any, t: string) { return makeNode(t); },
+  body: makeNode("body"), documentElement: makeNode("html"), head: makeNode("head"),
+  getElementById() { return null; },
+  addEventListener() {}, removeEventListener() {},
+};
+g.localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} };
+g.getComputedStyle = () => ({ backgroundColor: "rgb(30,30,30)" });
+g.requestAnimationFrame = () => 0;
+g.addEventListener = () => {}; g.removeEventListener = () => {};
+g.matchMedia = () => ({ matches: false, addEventListener() {}, addListener() {} });
+g.window = g;
+g.innerWidth = 1400; g.innerHeight = 800;
+
+const viewPath = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
+const { TimelinePanel } = createRequire(__filename)(viewPath);
+const SRC = fs.readFileSync(viewPath, "utf8");
+
+const NOW = 1_781_000_000;
+// The view's glide cap, read from the source: how far the live edge is pushed past data.now below.
+const AHEAD = Number(/const MAX_INTERP_AHEAD = (\d+);/.exec(SRC)![1]);
+function lane(id: string, name: string, extra: any) {
+  return {
+    id, name, color: "#7aa2f7", state: "working", live: true, model: "m", effort: "high",
+    context: 40, since: NOW - 60, awaiting: [], compacting: [], compactions: [], pendingMail: 0, faded: false, stale: false, ...extra,
+  };
+}
+function turn(id: string) {
+  return { id, promptId: id + "#p", workId: id + "#w", start: NOW - 400, end: NOW - 200, prompt: "do the thing", src: "typed",
+    mids: [], pending: false, summary: "did the thing", tid: "fork-" + id, uuid: "u-" + id, workUuid: "w-" + id, replyUuid: "r-" + id };
+}
+function collect(node: any, pred: (n: any) => boolean, out: any[] = []): any[] {
+  if (pred(node)) out.push(node);
+  for (const c of node.children || []) collect(c, pred, out);
+  return out;
+}
+const hatch = (fill: string) => (n: any) => n.tag === "rect" && n.getAttribute("fill") === fill;
+const right = (r: any) => Number(r.getAttribute("x")) + Number(r.getAttribute("width"));
+const width = (r: any) => Number(r.getAttribute("width"));
+// The transparent hover rect drawn right after a stripe (the same parent, the next child) — the stripe's hit
+// target; entering it shows the tip, which the panel is stubbed to hand back as html.
+function tipOf(panel: any, stripe: any): string {
+  const kids = stripe.parentNode.children, hit = kids[kids.indexOf(stripe) + 1];
+  assert.ok(hit && hit.tag === "rect" && hit.getAttribute("fill") === "transparent" && hit._ls.mouseenter, "a hover rect follows the stripe");
+  const tips: string[] = [];
+  panel.showTip = (html: string) => tips.push(html);
+  hit._ls.mouseenter[0]({ clientX: 10, clientY: 10 });
+  assert.equal(tips.length, 1, "one tip per enter");
+  return tips[0];
+}
+
+// A panel live-following with its edge AHEAD s past data.now (the glide the view does between kernel
+// frames, at its cap), gaps uncollapsed so x is linear in time.
+function livePanel(data: any) {
+  const panel: any = new TimelinePanel(makeNode("div"));
+  panel.data = data;
+  panel._collapseGaps = false;
+  panel._pinned = true; panel._frozeFromPin = false;
+  panel._nowBaseSec = NOW; panel._nowBaseMs = performance.now() - 5 * AHEAD * 1000;   // clamps to AHEAD
+  return panel;
+}
+
+test("an open interval (end at the payload clock) draws to the live edge; a closed one stops at its end; a null end draws the same", () => {
+  const ids = ["S1", "S2", "S3", "S4", "S5", "S6", "S7"];
+  const panel = livePanel({
+    now: NOW,
+    sessions: [
+      lane("S1", "web", { state: "needsInput", awaiting: [[NOW - 100, NOW]] }),        // OPEN: the kernel's shape, end == now
+      lane("S2", "api", { awaiting: [[NOW - 100, NOW - 30]] }),                        // closed 30 s ago
+      lane("S3", "tests", { awaiting: [[NOW - 100, NOW - 60]] }),                      // closed 60 s ago (with S2: px per second)
+      lane("S4", "docs", { state: "needsInput", awaiting: [[NOW - 100, null]] }),      // a null end still reads as open
+      lane("S5", "build", { compactions: [{ t: NOW }] }),                              // a marker ending at x(now): the reference pixel
+      lane("S6", "lint", { state: "needsInput", awaiting: [[NOW - 100, NOW - 1]] }),   // an end within 2 s of the clock: open (the kernel's clock and the payload's can differ by a second)
+      lane("S7", "deploy", { awaiting: [[NOW - 100, NOW - 3]] }),                      // 3 s: closed
+    ],
+    turns: Object.fromEntries(ids.map((id) => [id, [turn(id + ":1")]])),
+    messages: [], activeChat: null, focus: null, hover: null, usage: null,
+  });
+  assert.doesNotThrow(() => panel.draw(), "draw() accepts numeric and null interval ends");
+  const stripes = collect(panel.svg, hatch("url(#vault-await-hatch)"));
+  assert.equal(stripes.length, 6, "every awaiting span draws (a null end used to draw nothing)");
+  const [open, closed30, closed60, openNull, open1, closed3] = stripes;
+  const marker = collect(panel.svg, hatch("url(#vault-compact-hatch)"));
+  assert.equal(marker.length, 1, "one compaction marker");
+  const xNow = right(marker[0]);
+  const pps = (width(closed30) - width(closed60)) / 30;
+  assert.ok(pps > 0.05, "the window resolves seconds to pixels: " + pps);
+  assert.ok(Math.abs(right(closed30) - (xNow - 30 * pps)) < 1, "a closed span stops at its own end");
+  assert.ok(Math.abs(right(open) - (xNow + AHEAD * pps)) < 1,
+    "the open span reaches the live edge, " + AHEAD + " s past the payload's now (it used to stop at x(now), the build clock)");
+  assert.ok(Math.abs(right(openNull) - right(open)) < 0.01, "a null end lands on the same live edge");
+  assert.equal(open.getAttribute("x"), openNull.getAttribute("x"), "…starting where the payload says");
+  assert.ok(Math.abs(right(open1) - (xNow + AHEAD * pps)) < 1, "an end 1 s before the clock reads open: to the live edge");
+  assert.ok(Math.abs(right(closed3) - (xNow - 3 * pps)) < 1, "an end 3 s before the clock reads closed: at its own end");
+});
+
+test("the awaiting tooltip reads 'now' for an open span (a payload-clock or null end) and a clock time for a closed one", () => {
+  const panel = livePanel({
+    now: NOW,
+    sessions: [
+      lane("S1", "web", { state: "needsInput", awaiting: [[NOW - 100, NOW]] }),
+      lane("S2", "api", { awaiting: [[NOW - 100, NOW - 30]] }),
+      lane("S3", "tests", { state: "needsInput", awaiting: [[NOW - 100, null]] }),
+    ],
+    turns: { S1: [turn("S1:1")], S2: [turn("S2:1")], S3: [turn("S3:1")] },
+    messages: [], activeChat: null, focus: null, hover: null, usage: null,
+  });
+  panel.draw();
+  const stripes = collect(panel.svg, hatch("url(#vault-await-hatch)"));
+  assert.equal(stripes.length, 3);
+  const [open, closed, openNull] = stripes.map((st) => tipOf(panel, st));
+  assert.match(open, /blocked on your input · \d\d:\d\d(:\d\d)?–now</, "open: to now");
+  assert.match(openNull, /blocked on your input · \d\d:\d\d(:\d\d)?–now</, "a null end: to now");
+  assert.match(closed, /blocked on your input · \d\d:\d\d(:\d\d)?–\d\d:\d\d/, "closed: to its end");
+  assert.doesNotMatch(closed, /–now</);
+});
+
+test("an open compacting interval draws its cross-hatch to the live edge; a null end draws the same", () => {
+  const panel = livePanel({
+    now: NOW,
+    sessions: [
+      lane("S1", "web", { state: "compacting", compacting: [[NOW - 50, NOW]] }),    // open: end at the payload clock
+      lane("S2", "api", { compactions: [{ t: NOW }] }),                             // the x(now) reference marker
+      lane("S3", "tests", { state: "compacting", compacting: [[NOW - 50, null]] }), // a null end reads as open too
+    ],
+    turns: { S1: [turn("S1:1")], S2: [turn("S2:1")], S3: [turn("S3:1")] },
+    messages: [], activeChat: null, focus: null, hover: null, usage: null,
+  });
+  assert.doesNotThrow(() => panel.draw());
+  const hx = collect(panel.svg, hatch("url(#vault-compact-hatch)"));
+  assert.equal(hx.length, 3, "the two live compacting stripes and the marker (a null end used to draw nothing)");
+  const [stripe, marker, nullStripe] = hx;
+  assert.ok(right(stripe) > right(marker) + 2, "the open compacting stripe runs past x(now) to the live edge");
+  assert.ok(Math.abs(right(nullStripe) - right(stripe)) < 0.01, "a null end lands on the same live edge");
+  assert.equal(nullStripe.getAttribute("x"), stripe.getAttribute("x"));
+});
+
+test("the compacting tooltip reads 'compacting' for an open span and 'compacted' for a closed one", () => {
+  const panel = livePanel({
+    now: NOW,
+    sessions: [
+      lane("S1", "web", { state: "compacting", compacting: [[NOW - 50, NOW]] }),
+      lane("S2", "api", { compacting: [[NOW - 100, NOW - 30]] }),
+    ],
+    turns: { S1: [turn("S1:1")], S2: [turn("S2:1")] },
+    messages: [], activeChat: null, focus: null, hover: null, usage: null,
+  });
+  panel.draw();
+  const hx = collect(panel.svg, hatch("url(#vault-compact-hatch)"));
+  assert.equal(hx.length, 2);
+  const [open, closed] = hx.map((st) => tipOf(panel, st));
+  assert.match(open, /<span class="k">compacting<\/span>.*context compacting · \d\d:\d\d(:\d\d)?–now</, "open: still compacting, to now");
+  assert.match(closed, /<span class="k">compacted<\/span>.*context compacted · \d\d:\d\d(:\d\d)?–\d\d:\d\d/, "closed: compacted, to its end");
+  assert.doesNotMatch(closed, /–now</);
+});

--- a/ui/timeline-open-interval.test.ts
+++ b/ui/timeline-open-interval.test.ts
@@ -1,12 +1,15 @@
 // An awaiting or compacting interval the session is STILL in arrives with its end at the payload's own
-// clock (kernel _state_intervals ends an open span at `now`): the renderer reads an end within 2 s of
-// data.now — or a null end — as OPEN and draws it to the live edge, the way barEndT draws an open work
-// bar, so the stripe glides with the edge instead of sitting at the kernel's build clock until the next
-// rebuild (the lanes frame is projected from the cached build, so its clock can trail the live edge by
-// up to a rebuild). The end stays numeric on the wire: a null end was a wire break for every already-loaded
-// renderer (Math.min(null, t1) = 0 dropped the stripe). Headless draw() over a minimal DOM shim (the
-// timeline-render.test.ts pattern), with the live edge pushed MAX_INTERP_AHEAD past data.now so "to the
-// live edge" and "to the payload's end" land on different pixels.
+// clock (kernel _state_intervals ends an open span at `now`) AND an open mark as its third element
+// ([start, end, true]): the renderer reads the mark (or a null end) as OPEN and draws the stripe to the
+// live edge, the way barEndT draws an open work bar, so it glides with the edge instead of sitting at the
+// kernel's build clock until the next rebuild (the lanes frame is projected from the cached build, so its
+// clock can trail the live edge by up to a rebuild). The mark, not a clock compare (review find,
+// 2026-09-08): the renderer used to read an end within 2 s of data.now as open, and a connect frame
+// re-stamps the cycle clock over the cached build's lanes, so that distance was the cache's age and a lane
+// blocked right now drew closed. The end stays numeric on the wire: a null end was a wire break for every
+// already-loaded renderer (Math.min(null, t1) = 0 dropped the stripe). Headless draw() over a minimal DOM
+// shim (the timeline-render.test.ts pattern), with the live edge pushed MAX_INTERP_AHEAD past data.now so
+// "to the live edge" and "to the payload's end" land on different pixels.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -99,18 +102,18 @@ function livePanel(data: any) {
   return panel;
 }
 
-test("an open interval (end at the payload clock) draws to the live edge; a closed one stops at its end; a null end draws the same", () => {
+test("a marked-open interval draws to the live edge however far its end sits behind the clock; an unmarked one stops at its end; a null end draws open", () => {
   const ids = ["S1", "S2", "S3", "S4", "S5", "S6", "S7"];
   const panel = livePanel({
     now: NOW,
     sessions: [
-      lane("S1", "web", { state: "needsInput", awaiting: [[NOW - 100, NOW]] }),        // OPEN: the kernel's shape, end == now
+      lane("S1", "web", { state: "needsInput", awaiting: [[NOW - 100, NOW, true]] }),  // OPEN: the kernel's shape, end == now, marked
       lane("S2", "api", { awaiting: [[NOW - 100, NOW - 30]] }),                        // closed 30 s ago
       lane("S3", "tests", { awaiting: [[NOW - 100, NOW - 60]] }),                      // closed 60 s ago (with S2: px per second)
       lane("S4", "docs", { state: "needsInput", awaiting: [[NOW - 100, null]] }),      // a null end still reads as open
       lane("S5", "build", { compactions: [{ t: NOW }] }),                              // a marker ending at x(now): the reference pixel
-      lane("S6", "lint", { state: "needsInput", awaiting: [[NOW - 100, NOW - 1]] }),   // an end within 2 s of the clock: open (the kernel's clock and the payload's can differ by a second)
-      lane("S7", "deploy", { awaiting: [[NOW - 100, NOW - 3]] }),                      // 3 s: closed
+      lane("S6", "lint", { state: "needsInput", awaiting: [[NOW - 100, NOW - 30, true]] }),   // a connect frame: the cycle clock re-stamped over a cached build 30 s old; the mark says open
+      lane("S7", "deploy", { awaiting: [[NOW - 100, NOW - 1]] }),                      // unmarked, 1 s before the clock: closed (no clock tolerance)
     ],
     turns: Object.fromEntries(ids.map((id) => [id, [turn(id + ":1")]])),
     messages: [], activeChat: null, focus: null, hover: null, usage: null,
@@ -118,7 +121,7 @@ test("an open interval (end at the payload clock) draws to the live edge; a clos
   assert.doesNotThrow(() => panel.draw(), "draw() accepts numeric and null interval ends");
   const stripes = collect(panel.svg, hatch("url(#vault-await-hatch)"));
   assert.equal(stripes.length, 6, "every awaiting span draws (a null end used to draw nothing)");
-  const [open, closed30, closed60, openNull, open1, closed3] = stripes;
+  const [open, closed30, closed60, openNull, openMarked, closed1] = stripes;
   const marker = collect(panel.svg, hatch("url(#vault-compact-hatch)"));
   assert.equal(marker.length, 1, "one compaction marker");
   const xNow = right(marker[0]);
@@ -129,15 +132,17 @@ test("an open interval (end at the payload clock) draws to the live edge; a clos
     "the open span reaches the live edge, " + AHEAD + " s past the payload's now (it used to stop at x(now), the build clock)");
   assert.ok(Math.abs(right(openNull) - right(open)) < 0.01, "a null end lands on the same live edge");
   assert.equal(open.getAttribute("x"), openNull.getAttribute("x"), "…starting where the payload says");
-  assert.ok(Math.abs(right(open1) - (xNow + AHEAD * pps)) < 1, "an end 1 s before the clock reads open: to the live edge");
-  assert.ok(Math.abs(right(closed3) - (xNow - 3 * pps)) < 1, "an end 3 s before the clock reads closed: at its own end");
+  assert.ok(Math.abs(right(openMarked) - (xNow + AHEAD * pps)) < 1,
+    "a marked span whose end sits 30 s behind the clock (a re-stamped connect frame) reads open: to the live edge");
+  assert.ok(Math.abs(right(closed1) - (xNow - 1 * pps)) < 1, "an unmarked end 1 s before the clock reads closed: at its own end (no clock tolerance)");
+  assert.ok(right(closed1) < right(openMarked) - 1, "…nowhere near the live edge");
 });
 
-test("the awaiting tooltip reads 'now' for an open span (a payload-clock or null end) and a clock time for a closed one", () => {
+test("the awaiting tooltip reads 'now' for an open span (a marked or null end) and a clock time for a closed one", () => {
   const panel = livePanel({
     now: NOW,
     sessions: [
-      lane("S1", "web", { state: "needsInput", awaiting: [[NOW - 100, NOW]] }),
+      lane("S1", "web", { state: "needsInput", awaiting: [[NOW - 100, NOW - 30, true]] }),   // marked, its end 30 s behind the clock (a connect frame): still 'now'
       lane("S2", "api", { awaiting: [[NOW - 100, NOW - 30]] }),
       lane("S3", "tests", { state: "needsInput", awaiting: [[NOW - 100, null]] }),
     ],
@@ -154,31 +159,33 @@ test("the awaiting tooltip reads 'now' for an open span (a payload-clock or null
   assert.doesNotMatch(closed, /–now</);
 });
 
-test("an open compacting interval draws its cross-hatch to the live edge; a null end draws the same", () => {
+test("an open compacting interval draws its cross-hatch to the live edge; a null end draws the same; an unmarked recent end stops", () => {
   const panel = livePanel({
     now: NOW,
     sessions: [
-      lane("S1", "web", { state: "compacting", compacting: [[NOW - 50, NOW]] }),    // open: end at the payload clock
-      lane("S2", "api", { compactions: [{ t: NOW }] }),                             // the x(now) reference marker
-      lane("S3", "tests", { state: "compacting", compacting: [[NOW - 50, null]] }), // a null end reads as open too
+      lane("S1", "web", { state: "compacting", compacting: [[NOW - 50, NOW, true]] }),   // open: end at the payload clock, marked
+      lane("S2", "api", { compactions: [{ t: NOW }] }),                                  // the x(now) reference marker
+      lane("S3", "tests", { state: "compacting", compacting: [[NOW - 50, null]] }),      // a null end reads as open too
+      lane("S4", "docs", { state: "compacting", compacting: [[NOW - 50, NOW - 1]] }),    // unmarked, 1 s before the clock: closed; the wire's mark decides, not the chip and not a tolerance
     ],
-    turns: { S1: [turn("S1:1")], S2: [turn("S2:1")], S3: [turn("S3:1")] },
+    turns: { S1: [turn("S1:1")], S2: [turn("S2:1")], S3: [turn("S3:1")], S4: [turn("S4:1")] },
     messages: [], activeChat: null, focus: null, hover: null, usage: null,
   });
   assert.doesNotThrow(() => panel.draw());
   const hx = collect(panel.svg, hatch("url(#vault-compact-hatch)"));
-  assert.equal(hx.length, 3, "the two live compacting stripes and the marker (a null end used to draw nothing)");
-  const [stripe, marker, nullStripe] = hx;
+  assert.equal(hx.length, 4, "the three compacting stripes and the marker (a null end used to draw nothing)");
+  const [stripe, marker, nullStripe, recent] = hx;
   assert.ok(right(stripe) > right(marker) + 2, "the open compacting stripe runs past x(now) to the live edge");
   assert.ok(Math.abs(right(nullStripe) - right(stripe)) < 0.01, "a null end lands on the same live edge");
   assert.equal(nullStripe.getAttribute("x"), stripe.getAttribute("x"));
+  assert.ok(right(recent) <= right(marker) + 0.01, "an unmarked span ending 1 s before the clock stops at its end, not the live edge");
 });
 
 test("the compacting tooltip reads 'compacting' for an open span and 'compacted' for a closed one", () => {
   const panel = livePanel({
     now: NOW,
     sessions: [
-      lane("S1", "web", { state: "compacting", compacting: [[NOW - 50, NOW]] }),
+      lane("S1", "web", { state: "compacting", compacting: [[NOW - 50, NOW, true]] }),
       lane("S2", "api", { compacting: [[NOW - 100, NOW - 30]] }),
     ],
     turns: { S1: [turn("S1:1")], S2: [turn("S2:1")] },

--- a/ui/timeline-transform-tick.test.ts
+++ b/ui/timeline-transform-tick.test.ts
@@ -1,0 +1,452 @@
+// The live tick as a transform write. While the timeline follows the live edge, every look of the paced
+// live loop (_tickLive) advanced the clock by wiping and rebuilding the whole svg: about 30 ms a draw in the
+// browser at a few dozen lanes, once every 0.1-2 s, the pane's largest cost while visible and outside every
+// handler bracket. draw() now puts every time-positioned element in one plot group, and the tick writes one
+// translate on that group plus a width on each element whose right edge rides the live now (an open bar, an
+// open awaiting or compacting span, an open judging run); a full draw() stays only for what a translate cannot
+// express. Headless, on the DOM stand-in timeline-render.test.ts uses: the stand-in counts element creation,
+// so a rebuild is observable. (ui/timeline-live-tick.test.ts pins the loop's pacing; this file pins the look.)
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+function makeNode(tag: string): any {
+  const n: any = {
+    tag, _attrs: {}, children: [] as any[], style: {}, dataset: {}, textContent: "", parentNode: null,
+    classList: { _s: new Set<string>(), add(...a: string[]) { a.forEach((c) => this._s.add(c)); },
+      remove(...a: string[]) { a.forEach((c) => this._s.delete(c)); },
+      toggle(c: string, f?: boolean) { f ? this._s.add(c) : this._s.delete(c); }, contains(c: string) { return this._s.has(c); } },
+    setAttribute(k: string, v: any) { this._attrs[k] = v; }, getAttribute(k: string) { return this._attrs[k]; },
+    setAttributeNS(_n: any, k: string, v: any) { this._attrs[k] = v; }, removeAttribute(k: string) { delete this._attrs[k]; },
+    appendChild(c: any) { c.parentNode = n; this.children.push(c); return c; },
+    insertBefore(c: any, ref: any) { c.parentNode = n; const i = this.children.indexOf(ref); i < 0 ? this.children.push(c) : this.children.splice(i, 0, c); return c; },
+    removeChild(c: any) { const i = this.children.indexOf(c); if (i >= 0) { this.children.splice(i, 1); c.parentNode = null; } return c; },
+    get firstChild() { return this.children[0] || null; },
+    addEventListener() {}, removeEventListener() {}, querySelector() { return null; }, querySelectorAll() { return []; },
+    getBoundingClientRect() { return { width: 1400, height: 420, left: 0, top: 0, right: 1400, bottom: 420 }; },
+    closest() { return null; }, focus() {},
+    createEl(t: string, o: any) { const e = makeNode(t); if (o && o.cls) e.classList.add(o.cls); if (o && o.text) e.textContent = o.text; this.appendChild(e); return e; },
+    createDiv(o: any) { return this.createEl("div", o); }, createSpan(o: any) { return this.createEl("span", o); },
+  };
+  return n;
+}
+let created = 0;   // every element the view creates: a full draw() makes hundreds, a tick must make none
+const g: any = global;
+g.document = {
+  createElement(t: string) { created++; return t === "canvas" ? { getContext() { return { font: "", measureText(s: string) { return { width: (s ? s.length : 0) * 6 }; } }; } } : makeNode(t); },
+  createElementNS(_n: any, t: string) { created++; return makeNode(t); },
+  body: makeNode("body"), documentElement: makeNode("html"), head: makeNode("head"),
+  getElementById() { return null; },
+  addEventListener() {}, removeEventListener() {},
+  elementFromPoint() { return null; },
+};
+g.localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} };
+g.getComputedStyle = () => ({ backgroundColor: "rgb(30,30,30)" });
+g.requestAnimationFrame = () => 0;
+g.cancelAnimationFrame = () => {};
+g.addEventListener = () => {}; g.removeEventListener = () => {};
+g.matchMedia = () => ({ matches: false, addEventListener() {}, addListener() {} });
+g.window = g;
+g.innerWidth = 1400; g.innerHeight = 800;
+
+const viewPath = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
+const { TimelinePanel } = createRequire(__filename)(viewPath);
+
+const NOW = 1_781_000_000;
+const SID1 = "11111111-2222-3333-4444-aaaaaaaaaaa1", SID2 = "11111111-2222-3333-4444-aaaaaaaaaaa2";
+function turn(id: string, start: number, end: number, extra: any = {}) {
+  return { id, promptId: id + "#p", workId: id + "#w", start, end, prompt: "do the thing", src: "typed", mids: [],
+           pending: false, summary: "did the thing", reply: "did it", tid: "fork-" + id, uuid: "u-" + id, workUuid: "w-" + id, replyUuid: "r-" + id, ...extra };
+}
+function sess(id: string, name: string, state: string, now: number) {
+  return { id, name, color: "#7aa2f7", state, live: true, model: "Opus 4.8", effort: "xhigh", context: 40, since: now - 60,
+           awaiting: [], compacting: [], pendingMail: 0, compactions: [], faded: false, stale: false };
+}
+/** Two lanes: web has an OPEN turn (its bar ends at the live edge), api a closed one. */
+function liveData(now: number = NOW): any {
+  return {
+    now,
+    sessions: [sess(SID1, "web", "working", now), sess(SID2, "api", "idle", now)],
+    turns: { [SID1]: [turn("a", now - 900, now - 700), turn("b", now - 300, now, { open: true })], [SID2]: [turn("c", now - 600, now - 400)] },
+    messages: [], judging: [], activeChat: null, focus: null, hover: null, usage: null,
+  };
+}
+/** A panel following the live edge, built once; `advance` moves its clock by `sec` for the next tick. */
+function livePanel(data: any, winSec: number): any {
+  const panel: any = new TimelinePanel(makeNode("div"));
+  panel._lockNow = true; panel._pinned = true;
+  panel._winSec = winSec; panel.fitted = true;
+  panel.update(data);
+  assert.ok(panel._liveFollowing(), "the panel follows the live edge");
+  assert.ok(panel._tickPlot, "a full build leaves the tick its handle");
+  return panel;
+}
+const advance = (panel: any, sec: number) => { panel._nowBaseMs = performance.now() - sec * 1000; };
+// one look of the paced loop; the sleep it arms for the next look is cleared so the test does not wait on it
+const tick = (panel: any) => { panel._tickLive(); panel._stopLiveTick(); };
+const plotOf = (panel: any) => panel._tickPlot.g;
+const widthOf = (el: any) => Number(el.getAttribute("width"));
+
+test("a tick moves the plot group by a transform and creates no element; the open bar's width rides the edge", () => {
+  const panel = livePanel(liveData(), 3600);
+  const tp = panel._tickPlot, geom0 = { ...panel._geom };
+  const openBar = tp.riders.find((r: any) => r.el.tag === "rect" && r.attr === "width");
+  assert.ok(openBar, "the open bar registered as a live-edge rider");
+  const w0 = widthOf(openBar.el);
+  const closedBar = plotOf(panel).children.find((c: any) => c.tag === "rect" && c._attrs.fill === "#7aa2f7" && widthOf(c) !== w0 && !tp.riders.some((r: any) => r.el === c));
+  assert.ok(closedBar, "a closed bar is in the plot group and is not a rider");
+  const cw0 = widthOf(closedBar);
+  advance(panel, 10);   // a whole pixel and a half at this zoom: past LIVE_MIN_PX
+  const before = created;
+  tick(panel);
+  assert.equal(created, before, "the tick created no element: no rebuild");
+  // the build itself stood a few ms past data.now (its own interpolation), so the drift is 10 s less that
+  const px = tp.applied, want = 10 / geom0.winSec * geom0.plotW;
+  assert.ok(px >= 1 && Math.abs(px - want) < 0.01, "the edge moved about 10 s worth of pixels: " + px + " vs " + want);
+  assert.equal(plotOf(panel).getAttribute("transform"), "translate(" + (-px) + " 0)", "one translate on the plot group");
+  assert.equal(widthOf(openBar.el), w0 + px, "the open bar grew by the drift: its right edge stays at the live now");
+  assert.equal(widthOf(closedBar), cw0, "a closed bar's geometry is untouched");
+  assert.ok(Math.abs((panel._geom.t1 - geom0.t1) - px / tp.k) < 1e-6, "the window geometry the handlers read follows the move");
+  assert.equal(panel._geom.plotW, geom0.plotW);
+  assert.equal(panel._holdReal, panel._geom.t1);
+});
+
+test("a move under LIVE_MIN_PX writes nothing; the translate is measured from the build, not the last tick", () => {
+  const panel = livePanel(liveData(), 43200);   // 12 h: 0.1 s is far under a pixel
+  advance(panel, 0.1);
+  const before = created;
+  tick(panel);
+  assert.equal(created, before);
+  assert.equal(plotOf(panel).getAttribute("transform"), undefined, "nothing to write yet");
+  advance(panel, 120);   // well past the guard now, and inside the edge's glide cap
+  tick(panel);
+  const px = panel._tickPlot.applied, want = 120 / panel._geom.winSec * panel._geom.plotW;
+  assert.ok(px >= 1 && Math.abs(px - want) < 0.01, "about 120 s worth: " + px + " vs " + want);
+  assert.equal(plotOf(panel).getAttribute("transform"), "translate(" + (-px) + " 0)");
+});
+
+test("a message glyph riding the live edge leaves the tick its full draw (a translate cannot express it)", () => {
+  const data = liveData();
+  data.messages = [{ id: "m1", fromId: SID2, toId: SID1, from: "api", to: "web", sent: NOW - 100, exec: NOW - 100, pending: true, text: "please review" }];
+  const panel: any = new TimelinePanel(makeNode("div"));
+  panel._lockNow = true; panel._pinned = true; panel._winSec = 3600; panel.fitted = true;
+  panel.update(data);
+  assert.equal(panel._tickPlot, null, "the pending message's dot lands AT the live edge, so the build hands the tick no translate handle");
+  advance(panel, 10);
+  const before = created;
+  tick(panel);
+  assert.ok(created > before, "the tick fell back to a full draw");
+});
+
+test("a drift reaching the gutter gap hands the tick back to a full draw (no frame has rebuilt since the build)", () => {
+  const panel = livePanel(liveData(), 60);   // 1 min window: 3 s is tens of pixels
+  const tp = panel._tickPlot;
+  assert.ok(tp.maxDrift >= 2 && tp.maxDrift < 10, "the cap is the gutter gap, a few px");
+  advance(panel, 3);
+  const before = created;
+  tick(panel);
+  assert.ok(created > before, "the drift would have poked clamped content into the battery column: a full draw instead");
+  assert.ok(panel._tickPlot, "the rebuild leaves a fresh handle");
+  assert.equal(panel._tickPlot.applied, 0);
+});
+
+test("inside a collapsed trailing gap the edge does not move on screen: the tick writes nothing and redraws nothing", () => {
+  // every lane quiet for longer than GAP_MIN (20 min): _buildCompressMap appends a trailing gap whose compressed
+  // width is fixed, so compress(now) is constant while now advances — a real-seconds guard would redraw anyway
+  const data = liveData();
+  data.sessions[0].state = "idle";
+  data.turns = { [SID1]: [turn("a", NOW - 5000, NOW - 4000)], [SID2]: [turn("c", NOW - 4800, NOW - 4500)] };
+  const panel = livePanel(data, 7200);
+  assert.equal(panel._tickPlot.trailing, true, "the build saw the trailing gap");
+  advance(panel, 5);
+  const before = created;
+  tick(panel);
+  assert.equal(created, before, "no rebuild");
+  assert.equal(plotOf(panel).getAttribute("transform"), undefined, "no translate: compressed movement is zero");
+  // at this window 5 s is under a pixel of REAL movement too; 30 s (a few px) would be a translate under a
+  // real-seconds guard and 60 s would pass the drift cap and rebuild — inside the gap neither is real movement
+  for (const sec of [30, 60]) {
+    advance(panel, sec);
+    tick(panel);
+    assert.equal(created, before, "no rebuild at " + sec + " s");
+    assert.equal(plotOf(panel).getAttribute("transform"), undefined, "no translate at " + sec + " s");
+    assert.equal(panel._tickPlot.applied, 0);
+  }
+});
+
+test("an open awaiting span and an open judging run ride the edge too; the lane chrome stays out of the plot group", () => {
+  const data = liveData();
+  data.sessions[1].state = "needsInput"; data.sessions[1].since = NOW - 120;   // an open blocked stripe on api, to the live edge
+  data.judging = [{ sid: SID1, judge: "closer", t: NOW - 30, t1: NOW - 30, open: true, kind: "k", text: "" }];
+  const getItem = g.localStorage.getItem;
+  g.localStorage.getItem = (k: string) => (k === "romp:settings" ? JSON.stringify({ showTriageJudges: true }) : null);   // the band is off by default
+  const panel: any = new TimelinePanel(makeNode("div"));
+  panel._lockNow = true; panel._pinned = true; panel._winSec = 3600; panel.fitted = true;
+  try { panel.update(data); } finally { g.localStorage.getItem = getItem; }
+  const tp = panel._tickPlot;
+  assert.ok(tp, "no live-edge message: the handle exists");
+  const kinds = tp.riders.map((r: any) => r.el.tag + ":" + r.attr + ":" + (r.el._attrs["data-judge"] || r.el._attrs.fill || ""));
+  assert.ok(kinds.some((k: string) => k.startsWith("rect:width:url(#vault-await-hatch)")), "the awaiting stripe is a rider: " + kinds.join(", "));
+  assert.ok(tp.riders.some((r: any) => r.el._attrs["data-judge"] === "closer"), "the open judging run is a rider");
+  // the gutter chrome and the rows' hit rects are on the svg itself, not in the moving group
+  const plotTags = new Set(plotOf(panel).children.map((c: any) => c.tag));
+  const names = panel.svg.children.filter((c: any) => c.tag === "text" && (c.textContent === "web" || c.textContent === "api"));
+  assert.equal(names.length, 2, "lane names are direct svg children (fixed)");
+  assert.ok(!plotOf(panel).children.some((c: any) => c.tag === "text" && (c.textContent === "web" || c.textContent === "api")), "and not in the plot group");
+  assert.ok(plotTags.has("rect") && plotTags.has("line"), "bars and axis gridlines are in the plot group");
+  const idx = panel.svg.children.indexOf(plotOf(panel));
+  const rowHit = panel.svg.children.findIndex((c: any) => c.tag === "rect" && c._attrs.fill === "transparent" && c._attrs.x === 0);
+  assert.ok(rowHit >= 0 && rowHit < idx, "the plot group paints over the rows' hit rects (a bar must take the hover)");
+  const rail = panel.svg.children.findIndex((c: any) => c.tag === "line" && c._attrs.stroke === "#C0392B");
+  assert.ok(rail >= 0 && rail < idx, "the judge band's rail is under the plot group, where it painted before");
+  const lock = panel.svg.children.findIndex((c: any) => c.tag === "g" && c.children.some((k: any) => k.tag === "rect" && k._attrs.x === -2 && k._attrs.width === 19));
+  assert.ok(lock >= 0 && idx < lock, "the lock toggle paints over the plot group, where it painted before");
+  // the axis gridlines moved INTO the group, over the row hit rects they used to sit under: they take no pointer,
+  // or a hover along a gridline would lose the row (and the bar) beneath it
+  const grid = plotOf(panel).children.filter((c: any) => c.tag === "line" && c._attrs.y1 === panel._geom.top && c._attrs.x1 === c._attrs.x2);
+  assert.ok(grid.length >= 2, "the axis gridlines are in the plot group: " + grid.length);
+  for (const l of grid) assert.equal(l._attrs["pointer-events"], "none", "a gridline over the row hits takes no pointer");
+});
+
+test("held back off the live edge, the jump button paints over the plot group too", () => {
+  const panel: any = new TimelinePanel(makeNode("div"));
+  panel._lockNow = false; panel._pinned = false; panel._winSec = 3600; panel.fitted = true;
+  panel._offSec = 120; panel._offDirty = true;   // a pan: the window's right edge sits 2 min behind now
+  panel.update(liveData());
+  assert.equal(panel._pinned, false, "the pan held");
+  const kids = panel.svg.children;
+  const plot = kids.findIndex((c: any) => c.tag === "g" && c._attrs["data-tl-plot"]);
+  const jump = kids.findIndex((c: any) => c.tag === "g" && c.children.some((k: any) => k.tag === "rect" && k._attrs.width === 16 && k._attrs.height === 46));
+  const lock = kids.findIndex((c: any) => c.tag === "g" && c.children.some((k: any) => k.tag === "rect" && k._attrs.x === -2 && k._attrs.width === 19));
+  assert.ok(plot >= 0 && jump >= 0 && lock >= 0, "the plot group, the jump button and the lock are all drawn: " + [plot, jump, lock]);
+  assert.ok(plot < jump && jump < lock, "the plot group is under both: " + [plot, jump, lock]);
+});
+
+test("a glyph anchored near the left edge hides once its anchor crosses it (where a full draw culls it), so no dot drifts onto the battery column", () => {
+  // a 10-minute window: about a pixel a second, a 9 px drift cap (the battery column's gap). The closed turn on api
+  // starts about 3 s inside the left edge: its prompt dot (DOT_R 6) already overhangs the edge by about 3 px at
+  // build time, and translated by the cap it would paint several px over the battery and take its /compact pointer.
+  const data = liveData();
+  data.turns = { [SID1]: [turn("a", NOW - 300, NOW - 100)], [SID2]: [turn("c", NOW - 596.8, NOW - 500)] };
+  const panel = livePanel(data, 600);
+  const tp = panel._tickPlot, g = panel._geom;
+  const bat = panel.svg.children.find((c: any) => c.tag === "rect" && c._attrs.width === 48 && c._attrs.height === 14 && c._attrs.fill !== "transparent");
+  assert.ok(bat, "the lanes carry a context battery, so the gap left of the plot is COLGAP");
+  const batRight = bat._attrs.x + 48;
+  assert.equal(tp.maxDrift, 9);
+  assert.equal(tp.left, g.ml);
+  const dots = plotOf(panel).children.filter((c: any) => c.tag === "circle");
+  const edgeDot = dots.reduce((a: any, b: any) => (a._attrs.cx < b._attrs.cx ? a : b));
+  const farDot = dots.reduce((a: any, b: any) => (a._attrs.cx > b._attrs.cx ? a : b));
+  const inside = edgeDot._attrs.cx - g.ml;
+  assert.ok(inside > 2 && inside < 4, "the edge dot's anchor sits about 3 s inside the plot: " + inside + " px");
+  assert.ok(tp.edge.some((e: any) => e.el === edgeDot), "the build listed it as an edge glyph");
+  assert.ok(!tp.edge.some((e: any) => e.el === farDot), "a dot well inside the window is not listed");
+  const paintedLeft = (dot: any) => dot._attrs.cx - tp.applied - 6;   // the dot's left edge on screen: anchor, less the translate, less DOT_R
+  // a small drift, the anchor still inside the plot: visible, and its overhang still short of the battery
+  advance(panel, inside / 2 / tp.k);
+  let before = created; tick(panel);
+  assert.equal(created, before, "no rebuild");
+  assert.ok(tp.applied >= 1 && tp.applied < inside, "applied " + tp.applied);
+  assert.equal(edgeDot.getAttribute("visibility"), undefined, "anchor inside: visible");
+  assert.ok(paintedLeft(edgeDot) >= batRight, "and off the battery column");
+  // just under the cap: the anchor has crossed the edge, so the dot is hidden, exactly where a full draw drops it
+  advance(panel, (tp.maxDrift - 0.3) / tp.k);
+  before = created; tick(panel);
+  assert.equal(created, before, "still no rebuild: the drift is under the cap");
+  assert.ok(tp.applied > tp.maxDrift - 1 && tp.applied < tp.maxDrift, "applied " + tp.applied);
+  assert.equal(edgeDot.getAttribute("visibility"), "hidden", "the dot whose anchor crossed the edge is hidden (and takes no pointer)");
+  assert.ok(edgeDot.getAttribute("visibility") === "hidden" || paintedLeft(edgeDot) >= batRight, "its painted left edge never reaches the battery");
+  assert.equal(farDot.getAttribute("visibility"), undefined, "a dot inside the window stays");
+});
+
+test("a rider's floor applies to the grown extent: a just-opened bar grows as a full draw draws it, and a narrow judging run stays centred only until it is wider than JMARK_MINW", () => {
+  const data = liveData();
+  data.turns[SID1] = [turn("a", NOW - 300, NOW - 100), turn("b", NOW, NOW, { open: true })];   // opened this instant: drawn at the 2 px floor
+  data.judging = [{ sid: SID1, judge: "closer", t: NOW, t1: NOW, open: true, kind: "k", text: "" }];
+  const getItem = g.localStorage.getItem;
+  g.localStorage.getItem = (k: string) => (k === "romp:settings" ? JSON.stringify({ showTriageJudges: true }) : null);
+  const panel: any = new TimelinePanel(makeNode("div"));
+  panel._lockNow = true; panel._pinned = true; panel._winSec = 600; panel.fitted = true;
+  try { panel.update(data); } finally { g.localStorage.getItem = getItem; }
+  const tp = panel._tickPlot;
+  assert.ok(tp, "the handle exists");
+  const bar = tp.riders.find((r: any) => r.el.tag === "rect" && r.attr === "width" && r.el._attrs.fill === "#7aa2f7");
+  assert.ok(bar && bar.min === 2 && bar.base >= 0 && bar.base < 0.1, "the open bar's rider carries its un-clamped extent and the floor: " + JSON.stringify({ base: bar && bar.base, min: bar && bar.min }));
+  assert.equal(widthOf(bar.el), 2, "drawn at the floor");
+  const run = tp.riders.find((r: any) => r.el._attrs["data-judge"] === "closer");
+  assert.ok(run && run.fn && run.base >= 0 && run.base < 0.1, "the open run's rider re-derives its placement from the un-centred extent");
+  assert.equal(widthOf(run.el), 6, "drawn centred at JMARK_MINW");
+  assert.ok(Math.abs(run.el._attrs.x - (run.x0 + (run.base - 6) / 2)) < 1e-9, "the build's centring");
+  // a drift under the floor: the bar stays at 2 px (a full draw would also draw max(2, 1.2)); the run stays centred and its centre moves by half the drift
+  advance(panel, 1.2 / tp.k);
+  tick(panel);
+  assert.ok(tp.applied > 1 && tp.applied < 1.3, "applied " + tp.applied);
+  assert.equal(widthOf(bar.el), 2, "the floor holds: not 2 + the drift");
+  assert.equal(widthOf(run.el), 6, "still narrower than JMARK_MINW: still centred");
+  assert.ok(Math.abs(run.el._attrs.x - (run.x0 + (run.base + tp.applied - 6) / 2)) < 1e-9, "centred on the grown extent, as a full draw places it");
+  // past the floor: the true extent, as a full draw would draw it, and the run's centring is gone
+  advance(panel, 7 / tp.k);
+  tick(panel);
+  assert.ok(tp.applied > 6.5 && tp.applied < 7.1 && tp.applied < tp.maxDrift, "applied " + tp.applied);
+  assert.ok(Math.abs(widthOf(bar.el) - (bar.base + tp.applied)) < 1e-9, "the un-clamped extent plus the drift: " + widthOf(bar.el));
+  assert.ok(widthOf(bar.el) < 2 + tp.applied - 1.5, "not the floor plus the drift");
+  assert.ok(Math.abs(run.el._attrs.x - run.x0) < 1e-9 && Math.abs(widthOf(run.el) - (run.base + tp.applied)) < 1e-9, "the run starts at its own x and spans to the edge");
+  const hit = tp.riders.find((r: any) => r.el === run.el);
+  assert.ok(hit, "one rider carries both the run and its hit");
+});
+
+test("the focus pulse is drawn into the live plot group, in the group's frame, so it rides the tick with its target", () => {
+  const panel = livePanel(liveData(), 3600);
+  const plot = plotOf(panel);
+  advance(panel, 10);
+  tick(panel);
+  assert.ok(panel._tickPlot.applied > 0, "the plot is translated");
+  const n0 = plot.children.length;
+  panel._pulseFocus(SID2, NOW - 600, null);   // api's closed turn c: a prompt focus rings its start dot
+  const ring = plot.children[plot.children.length - 1];
+  assert.equal(plot.children.length, n0 + 1, "the ring went into the plot group, not onto the svg");
+  assert.ok(ring.tag === "circle" && ring._attrs.stroke === "#ffd166");
+  const dotC = plot.children.find((c: any) => c.tag === "circle" && c !== ring && c._attrs.fill === "#7aa2f7" && Math.abs(c._attrs.cx - ring._attrs.cx) < 1e-6);
+  assert.ok(dotC, "positioned in the build's frame: it sits on the prompt dot it rings (both then move by the translate)");
+  panel._pulseFocus(SID1, NOW - 900, { t: NOW - 900, end: NOW - 700 });   // a work focus outlines the bar
+  const box = plot.children[plot.children.length - 1];
+  assert.ok(box.tag === "rect" && box._attrs.stroke === "#ffd166" && box.parentNode === plot);
+  const barA = plot.children.filter((c: any) => c.tag === "rect" && c._attrs.fill === "#7aa2f7").reduce((a: any, b: any) => (a._attrs.x < b._attrs.x ? a : b));
+  assert.ok(Math.abs((box._attrs.x + 3) - barA._attrs.x) < 1e-6, "the outline hugs the bar in the group's frame");
+  // with no live group (the loader wiped the svg) the pulse goes on the svg as before
+  panel.drawMessage("no lanes");
+  panel._pulseFocus(SID2, NOW - 600, null);
+  assert.equal(panel.svg.children[panel.svg.children.length - 1].parentNode, panel.svg);
+});
+
+test("a gridline entering the window gets its full draw: the tick translates until the clock reaches the next axis tick, then hands back", () => {
+  // Nothing is pre-drawn outside the window, so a gridline (and its clock) entering at the right edge is a
+  // rebuild. The build dates it — the next axis tick past the window's edge — and the tick hands back the moment
+  // the clock reaches it, instead of waiting for the next kernel frame (a quiet board sees one every 60 s).
+  // The window ends 20 s before a whole hour: every step this zoom can pick has a tick there.
+  const NOW2 = (Math.floor(NOW / 3600) + 1) * 3600 - 20;
+  const panel = livePanel(liveData(NOW2), 3600);
+  const tp = panel._tickPlot;
+  assert.ok(Math.abs(tp.nextTick - (NOW2 + 20)) < 1e-6, "the build recorded when the next gridline enters: " + (tp.nextTick - NOW2) + " s on");
+  assert.ok(20 * tp.k < tp.maxDrift, "…which is before the drift cap would hand back: " + 20 * tp.k + " px of " + tp.maxDrift);
+  assert.equal(panel._tickTranslate(NOW2 + 19), true, "just before: a translate");
+  assert.ok(Math.abs(tp.applied - 19 * tp.k) < 0.01, "applied " + tp.applied);
+  assert.equal(panel._tickTranslate(NOW2 + 20), false, "the gridline is due: a full draw");
+  // through the loop: the look draws, and the fresh build dates the next gridline a whole interval on
+  advance(panel, 20.5);
+  const before = created;
+  tick(panel);
+  assert.ok(created > before, "the loop did the full draw");
+  assert.ok(panel._tickPlot && panel._tickPlot.nextTick >= NOW2 + 20 + 60, "the rebuild's next gridline is at least a minute on: " + (panel._tickPlot.nextTick - NOW2));
+  assert.equal(panel._tickPlot.applied, 0);
+});
+
+test("sub-pixel looks add up: the drift is measured from the build, not the last look, so the edge advances once they reach a pixel", () => {
+  // a 12 h window: a 5 s look is a fraction of a pixel, under LIVE_MIN_PX every time. Re-basing the drift on each
+  // look would leave the edge stuck at any zoom where one look is under a pixel; measured from the build, the
+  // looks accumulate and the first whose drift reaches a pixel writes it.
+  const panel = livePanel(liveData(), 43200);
+  const tp = panel._tickPlot, step = 5 * panel._geom.plotW / panel._geom.winSec;   // px per 5 s look
+  assert.ok(step < 0.2, "one look is well under a pixel: " + step);
+  const expected: number[] = [];   // the writes a drift measured from the build makes: each the first look a pixel past the last write
+  for (let i = 1, last = 0; i <= 20; i++) { const d = i * step; if (d - last >= 1 - 1e-9) { expected.push(d); last = d; } }
+  assert.ok(expected.length >= 1, "20 looks reach a pixel at this zoom");
+  const before = created, writes: number[] = [];
+  for (let i = 1; i <= 20; i++) {
+    advance(panel, 5 * i);
+    tick(panel);
+    if (tp.applied !== (writes.length ? writes[writes.length - 1] : 0)) writes.push(tp.applied);
+  }
+  assert.equal(created, before, "no look rebuilt");
+  assert.ok(tp.applied >= 1, "the looks added up and the edge moved: applied " + tp.applied);
+  assert.equal(writes.length, expected.length, "writes: " + writes.join(", ") + " vs " + expected.join(", "));
+  writes.forEach((w, i) => assert.ok(Math.abs(w - expected[i]) < 0.05, "write " + i + ": " + w + " vs " + expected[i]));
+  assert.equal(plotOf(panel).getAttribute("transform"), "translate(" + (-tp.applied) + " 0)");
+});
+
+test("the hover re-arms after a tick: the content moved under a pointer that did not", () => {
+  const panel = livePanel(liveData(), 3600);
+  const calls: any[] = [];
+  const target = { __tlHoverIn: (e: any) => calls.push(e), parentNode: null };   // what elementFromPoint finds under the tracked pointer
+  panel._ptr = { x: 500, y: 40 };
+  panel.svg.ownerDocument = { elementFromPoint: () => target };
+  advance(panel, 10);
+  const before = created;
+  tick(panel);
+  assert.equal(created, before, "a translate, not a rebuild");
+  assert.equal(calls.length, 1, "the element now under the pointer got its hover-in, once");
+  assert.equal(calls[0].clientX, 500); assert.equal(calls[0].currentTarget, target);
+});
+
+test("a pending prompt's dot at the live edge leaves the build no handle either", () => {
+  const data = liveData();
+  data.turns[SID2].push(turn("p", NOW, NOW, { pending: true, open: true }));   // queued, not yet started: its dot is drawn at startAt = the live now
+  const panel: any = new TimelinePanel(makeNode("div"));
+  panel._lockNow = true; panel._pinned = true; panel._winSec = 3600; panel.fitted = true;
+  panel.update(data);
+  assert.equal(panel._tickPlot, null, "a pending prompt's dot rides the live edge: the build hands the tick no translate handle");
+  advance(panel, 10);
+  const before = created;
+  tick(panel);
+  assert.ok(created > before, "the tick fell back to a full draw");
+});
+
+test("an un-arrived stub to a hidden lane spans to the live edge, so the build leaves the tick no handle", () => {
+  const HID = "11111111-2222-3333-4444-aaaaaaaaaaa3";
+  const data = liveData();
+  data.sessions.push(sess(HID, "pool", "idle", NOW));
+  data.turns[HID] = [turn("h", NOW - 500, NOW - 400)];
+  data.views = { active: "untagged", hidden: [], tags: [{ id: "gx", name: "pool", color: "", members: [HID] }] };   // tag-hidden
+  data.messages = [{ id: "m2", fromId: SID1, toId: HID, from: "web", to: "pool", sent: NOW - 200, exec: NOW - 200, hasExec: false, pending: true, text: "please review" }];
+  const panel: any = new TimelinePanel(makeNode("div"));
+  panel._lockNow = true; panel._pinned = true; panel._winSec = 3600; panel.fitted = true;
+  panel.update(data);
+  assert.equal(panel._vis.length, 2, "the tagged lane is hidden");
+  const plot = panel.svg.children.find((c: any) => c.tag === "g" && c._attrs["data-tl-plot"]);
+  assert.ok(plot, "the plot group is drawn");
+  assert.ok(plot.children.some((c: any) => c.tag === "path" && c._attrs["stroke-dasharray"] === "1 4"), "the in-flight stub is drawn, dashed, in the group");
+  assert.equal(panel._tickPlot, null, "…and it ends at the live edge: no translate handle");
+  advance(panel, 10);
+  const before = created;
+  tick(panel);
+  assert.ok(created > before, "the tick fell back to a full draw");
+});
+
+test("an open compacting span rides the edge too", () => {
+  const data = liveData();
+  data.sessions[1].state = "compacting"; data.sessions[1].compacting = [[NOW - 50, NOW]];   // the kernel's open-interval shape: the end at the payload clock
+  const panel: any = new TimelinePanel(makeNode("div"));
+  panel._lockNow = true; panel._pinned = true; panel._winSec = 3600; panel.fitted = true;
+  panel.update(data);
+  const tp = panel._tickPlot;
+  assert.ok(tp, "the handle exists");
+  const hatch = tp.riders.filter((r: any) => r.el._attrs.fill === "url(#vault-compact-hatch)");
+  assert.equal(hatch.length, 1, "the cross-hatch stripe is a rider");
+  const w0 = widthOf(hatch[0].el);
+  assert.ok(w0 > 2, "drawn wider than the floor: " + w0);
+  advance(panel, 10);
+  tick(panel);
+  assert.ok(tp.applied >= 1, "applied " + tp.applied);
+  assert.equal(widthOf(hatch[0].el), w0 + tp.applied, "…and grows by the drift: its right edge stays at the live now");
+});
+
+test("the focus pulse's step stops once a rebuild detached its group", () => {
+  const panel = livePanel(liveData(), 3600);
+  const frames: any[] = [];
+  const raf = g.requestAnimationFrame;
+  g.requestAnimationFrame = (cb: any) => { frames.push(cb); return 1; };
+  try {
+    panel._pulseFocus(SID2, NOW - 600, null);
+    assert.equal(frames.length, 1, "the pulse armed its first frame");
+    const plot = plotOf(panel), ring = plot.children[plot.children.length - 1];
+    assert.ok(ring.tag === "circle" && ring._attrs.stroke === "#ffd166" && ring.parentNode === plot);
+    panel.draw();   // the wipe detaches the old group; the ring is still that group's child, off the svg
+    assert.equal(ring.parentNode, plot); assert.equal(plot.parentNode, null, "the ring's group left the svg");
+    frames[0](performance.now() + 100);   // mid-pulse: a live ring would arm its next frame here
+    assert.equal(frames.length, 1, "no further frame: the step saw its group gone");
+  } finally {
+    g.requestAnimationFrame = raf;
+  }
+});

--- a/ui/timeline-transform-tick.test.ts
+++ b/ui/timeline-transform-tick.test.ts
@@ -393,6 +393,27 @@ test("a pending prompt's dot at the live edge leaves the build no handle either"
   assert.ok(created > before, "the tick fell back to a full draw");
 });
 
+test("a look the build left no handle for still honours LIVE_MIN_PX: a sub-pixel move redraws nothing", () => {
+  // The full-draw fallback is paced by the same guard the translate has (review find, 2026-09-08): without it a
+  // board with a pending prompt (no handle) rebuilt the whole svg on every look, every 2 s at a wide window,
+  // where the edge moves a fraction of a pixel between looks and the redraw shows nothing new.
+  const data = liveData();
+  data.turns[SID2].push(turn("p", NOW, NOW, { pending: true, open: true }));
+  const panel: any = new TimelinePanel(makeNode("div"));
+  panel._lockNow = true; panel._pinned = true; panel._winSec = 43200; panel.fitted = true;   // 12 h: 5 s is a fraction of a pixel
+  panel.update(data);
+  assert.equal(panel._tickPlot, null, "no handle: every look is a full draw or nothing");
+  assert.ok(5 / panel._geom.winSec * panel._geom.plotW < 1, "5 s is under a pixel at this zoom");
+  advance(panel, 5);
+  let before = created;
+  tick(panel);
+  assert.equal(created, before, "a sub-pixel move: no rebuild");
+  advance(panel, 120);   // a few pixels on
+  before = created;
+  tick(panel);
+  assert.ok(created > before, "a whole pixel moved: the full draw");
+});
+
 test("an un-arrived stub to a hidden lane spans to the live edge, so the build leaves the tick no handle", () => {
   const HID = "11111111-2222-3333-4444-aaaaaaaaaaa3";
   const data = liveData();
@@ -416,7 +437,7 @@ test("an un-arrived stub to a hidden lane spans to the live edge, so the build l
 
 test("an open compacting span rides the edge too", () => {
   const data = liveData();
-  data.sessions[1].state = "compacting"; data.sessions[1].compacting = [[NOW - 50, NOW]];   // the kernel's open-interval shape: the end at the payload clock
+  data.sessions[1].state = "compacting"; data.sessions[1].compacting = [[NOW - 50, NOW, true]];   // the kernel's open-interval shape: the end at the payload clock, the open mark third
   const panel: any = new TimelinePanel(makeNode("div"));
   panel._lockNow = true; panel._pinned = true; panel._winSec = 3600; panel.fitted = true;
   panel.update(data);


### PR DESCRIPTION
Twelve performance changes on the pusher thread and the timeline pane, each a separable commit, ordered by dependency. They share one principle: work is done once per event that can change the result, and a cycle that changes nothing costs nothing. On the kernel side that means one timeline build per rebuild (the lanes frame is projected from the cached full build instead of built again every cycle), one serialization per payload per rebuild (the per-entry split is the encode; the dedup signature and the whole frame derive from it), one compare per changed payload (a client that already holds the state derived from this payload object skips the per-entry compare), one discover sweep and one interrupt scan per session per cycle (memoized on the cycle's scope and on the parse object's identity), and no inline push from a tick job whose writer already marked the views dirty. On the browser side, the timeline's live-follow loop moves the plot by one transform write instead of rebuilding the svg on every look. Two robustness commits ride along because the same code path exposed them: a raise in the pusher's wire section used to end the pusher thread for the life of the process, and a tool result the encoder refuses used to abort the timeline build. They are one PR because the first, the seventh and the eighth commits edit the lines the kernel perf counters (#1003, on main) added in `_send_slot_delta`, `_send_client`, `_push` and `_pusher_cycle_jobs`, and the rest edit the same functions in sequence; opening them separately would mean a dozen textual rebases of the same hunks. About 4,500 changed lines, three in four of them tests. No `/perf` key is added: the three module-level counter dicts the commits carry are read by their tests only, and wiring them into `GET /perf` is a follow-up now that #1003 is on main.

Rebased onto main on 2026-09-08 (e9eb27ff, the merge of #1065); the previous version sat on 04391202. Since the first version main took the two changes this series was stacked on, the kernel perf counters (#1003) and the pane telemetry (#1009), so the diff is the twelve commits alone, and #1019 and #1020 landed beside it without a conflict. This rebase crosses 28 more merges, three of which met these commits; nothing was dropped, one commit was reworked. #1018 (the auto-nudge and retry-suppress ledgers are never rewritten from a fabricated default after a read fault) had rewritten `_interrupt_block_tick` so that its inline push followed the marker write, because a refused marker clear under a fault used to push every cycle. Commit 11 removes that push and the `changed` flag altogether, which covers the same concern: a refused marker write or clear marks nothing, so under a fault neither a push nor a rebuild repeats. The tick keeps #1018's fault logic as it landed (the unproved-snapshot stand-down before any write, the paused nudge pass, the refused marker write and its re-mint on heal); its two comments and the docstring now describe the dirty-mark and wake delivery, and the commit message says so (the review commit verified the resolution: the tick keeps both marker writes, carried by `_mark_views_dirty` and the `auto-nudge.json` view-signature key). The five tests in #1018's `tests/test_ledger_unproved_reads.py` that pinned the inline push were extended, not dropped: the rig keeps `_push_all` as a tripwire, records the `_views_dirty` floor and `_pusher_wake`, and asserts that the block's and the lift's store writes mark the views dirty and wake the pusher while a refused marker write or clear, the marker's re-mint, a settled tick and a judge-owned card neither mark nor wake; two test names changed to say what they now test. The same rig's stubs of `_interrupt_marks(turns, sid=)` and `_compacting_now(sid)` accept the keywords commits 10 and 12 pass (`**k`), as does the `_interrupt_suppresses_nudge` stub in `tests/test_goal_store_fault_boundary.py`. #1007 (tag edits as acknowledged writes with a write sequence) added the `_VIEWS_SERVED.seqs` capture to `_send_client` on the lines commit 7 makes lazy; both stand, the capture sitting inside the lazy `_send_client` and reading the frame dict, and the connect frame's views blob and the caps `viewsSeq` are read off the same served frame (the review commit verified the resolution, no change). #1063 (a live session stays listed while its transcript is briefly unreadable) changed `_alive_sessions` beside commit 12's memoized wide walk; the walk runs first and the live stub follows it. The mutation pass from the previous version stands (31 tests added and 5 extended, each red under the mutation it names and green at its commit); the full suites were re-run at the rebased head, below.

## Commits

1. **View deltas: a client whose held state came from this payload object skips the per-entry compare.** `_send_slot_delta` records on the client's held state the parts object that state was last written from or last compared equal to (the keyed full, the last delta that went, the unchanged branch), and returns before the per-entry compare when the pusher hands the same payload object again inside the repost window; the short-circuit is counted as deduped, as the unchanged branch is. Past the window the compare runs and the repost goes, so the pane's clock still advances. A content-equal rebuild mints a new object, is compared once, adopted, then short-circuited; a failed send adopts nothing. Sound because `_delta_parts` is an identity cache per slot and a built payload is never mutated in place (`_bars_wire` and `_feed_wire` already rest on that). Measured in-process on this branch with a synthetic 26,612-entry, 7.5 MB bars payload (median of 9 same-object cycles): 15.0 ms -> 0.002 ms per timeline client; on the fork's kernel, a 7.1 MB payload of the same entry count read 14.7 ms -> 0. A pusher-cycle bench over a copy of a 31-session state directory (3 iterations) moved the steady cycle 358 -> 345 ms median, within noise, since that row is dominated by the builders. `kernel/kernel.py`; `tests/test_view_deltas.py::BarsDeltas` (+3, one pinning that neither the short-circuit nor the unchanged branch moves the repost timer), `tests/test_kernel_timeline_split.py::PushSplit` (+1, through the real `_push`).

2. **Pusher: the timeline's lane skeleton is projected from the cached build and deduped on content, and the view signature keys the fields a lane reads.** Every cycle with a timeline client ran `build_timeline(with_bars=False)` beside the cached full build (no transcript parse, but the same per-lane derivation: store loads, the chip over the cached parse plus the live merge, the awaiting overlay) and then serialized the frame and re-dumped it per client for the dedup compare. On a warm cycle the lanes frame is now a shallow projection of the cached full build (`_timeline_skeleton`), serialized once per build (`_skel_wire`) and deduped on content through the existing `_dedup_sig` with the nested clock stripped, so an unchanged rebuild sends nothing and the 60 s repost refreshes the pane's clock, as for the bars frame. A connect push stamps the cached lanes with the cycle clock when the cache is fresh by the kernel's own rule (`_timeline_cache_fresh`, added by the review commit: built under the cycle's view signature or within `REBUILD_MIN_S`, and no dirty mark since it started), because a connect never rebuilds and the cache can be hours old; a connect over a cache that rule calls stale builds its lanes fresh (`build_timeline(with_bars=False)`, no transcript parse) and serves the cached bars, instead of re-stamping the clock over hours-old lanes. The cold live-first connect keeps its own live-only skeleton build, reading every lane's goal store as before. `_fleet_view_sig` keys `context` (it read `ctx`, which no liveness row carries, so a context-% change waited on the 5 s bucket), `fastReason`, each subagent row's items and the background-task ids, and stats `usage.json`, `timeline-views.json`, the comments directory and the watches file; the dead `interrupting` key is dropped. `_chat_build_sig` gets the same `ctx` -> `context` fix. An open awaiting or compacting interval ends at the build clock on the wire and, since the review commit, carries `True` as a third element (`[start, end, True]`, `_state_intervals`), the open mark the renderer reads; the end stays numeric because a null end would break every already-loaded renderer through `Math.min(null, t1) = 0`, and a third element those renderers never read breaks nothing. Measured on the fork's kernel with an offline pusher bench over a 31-session state copy (3 iterations, against a base that lacked upstream's nested-clock dedup): steady cycle 374 -> 104 ms, timeline connect push 219 -> 16 ms, lane-only build 195 -> 95 ms. On this branch the base's lane-only build costs 102 ms per call (one-iteration run of the same bench), which a warm cycle no longer pays; bytes per unchanged cycle were already 0 here and stay 0, so the byte saving is not claimed. `kernel/kernel.py`; `tests/test_kernel_timeline_split.py::SkeletonFromCache` (10, two of them the review commit's: a connect over a cache built under an older view signature, and over one marked dirty since its build, each building the lanes fresh and serving the cached bars), `::SkeletonSerializedOncePerBuild` (two clients, one serialization, zero encodes on a warm cycle, counted on `json.dumps` through the real `_push`), `::ProjectionMatchesColdSkeleton` (the projection and the cold-connect build are one wire shape over a synthetic transcript) and `::OpenIntervals` (3: the marked open end in `_state_intervals` and in the lane payload, and the review commit's connect frame re-stamped over a cached build keeping the mark), `tests/test_timeline_skeleton_dedup.py` (a comment pointing the warm path at those tests), `tests/test_chat_delta_resync.py` (+1), `tests/test_stage0_log_readers.py` (the `interrupting` bust pin becomes a `context` one; its open-interval pin expects the mark), `tests/test_bg_scan_fold.py` (1 message; two open-interval assertions expect the mark).

3. **Timeline: an awaiting or compacting interval that ends at the frame's clock is drawn open to the live edge.** The renderer reads the kernel's open mark (the interval's third element `true`, or a null end) as open and draws the stripe to the live edge the way an open work bar is drawn, so it glides with the edge instead of sitting at the build clock until the next rebuild. Companion to commit 2: with the lanes projected from the cached build, an open interval's wire end is the build clock, up to a rebuild behind the cycle clock. As posted, this commit read an end within 2 s of the frame's `now` as open; the review commit replaced that read with the wire mark, because a connect frame carries the cycle's clock over the cached build's lanes, so that distance was the cache's age, and a lane blocked right now drew closed on every connect over a cache older than 2 s. There is no clock tolerance now: an unmarked end 1 s before the clock reads closed. No measurement. `ui/romp-timeline-view.js`; `ui/timeline-open-interval.test.ts` (4, a headless draw: a marked span whose end sits 30 s behind the clock drawn to the live edge, unmarked ends stopping at their own end, the null ends, and the awaiting and compacting tooltips entered through the shim's recorded listeners).

4. **Timeline: the live tick translates the plot group instead of redrawing the svg.** `draw()` puts every time-positioned element (bars and hits, awaiting and compacting spans, seams, connectors, dots, comment squares, judging runs, gridlines and clocks) in one `<g data-tl-plot>` group and lists the elements whose right edge rides the live now; the paced live loop's look becomes one translate on the group plus a width per rider (`_tickTranslate`), and the window geometry the handlers read follows the move. The full `draw()` stays for what a translate cannot express: no build yet, a glyph drawn at the live edge, a drift reaching the gutter gap, and the next axis gridline entering the window, which the build dates as `nextTick` (without it a quiet board shows a stale axis until the 60 s repost). A build that left no handle (a glyph rode the live edge) has only the full draw for a look, and since the review commit that look keeps the loop's `LIVE_MIN_PX` guard: the edge must have moved a pixel since the build (`_lastLiveNow`), so a board with a pending prompt no longer redraws the whole svg on every look at a wide window, where the edge moves a fraction of a pixel between looks (as posted, that fallback drew unguarded). The hand-backs from a handle (a gridline due, the drift cap) are events, not drift: they draw. Gridlines get `pointer-events: none` because inside the group they paint over the row hit rects they used to sit under. The pacing (`LIVE_MIN_PX = 1`, 0.1-2 s sleep), the hidden long sleep and the held-pointer rule are unchanged, and upstream's six source pins on the loop stay green. Measured on this branch in headless Chromium 151 on a synthetic 32-lane board (500 svg children plus 3,196 in the plot group, 32 riders), each sample a call plus a forced layout read, medians: a look 37-38 ms -> 0.3 ms; in the test files' node DOM stand-in 14-15 ms -> 0.004 ms. At the loop's 0.5-10 looks per second that is roughly 19-380 ms of main thread per second per live-following pane. The fork's kernel read 7.68 ms per draw against 0.046 ms per tick, headless. `ui/romp-timeline-view.js`; `ui/timeline-transform-tick.test.ts` (18: the translate, the sub-pixel guard and its accumulation from the build, the hand-backs, the trailing gap, the riders including an open compacting span, the edge glyphs, the paint order under the lock and the jump button, the gridlines' pointer, the hover re-arm, the focus pulse, and the review commit's no-handle look under a sub-pixel move redrawing nothing), `ui/timeline-hidden-stub.test.ts` (the pin reads the group's children), `tests/test_timeline_msg_hover.py` (the hit-path pin reads `plot.appendChild`).

5. **Timeline: `_seg_mids` and `_fold_tasks` read tool_result content in place instead of encoding every block.** `_seg_mids` runs once per segment on every timeline build and called `json.dumps` on every list-shaped tool result to search it for a message-id marker; those results are mostly base64 image and tool_reference blocks that never carry one. A new `_encoded_mids` walks the result and visits only the strings the encoding would write, encoding a string only when it holds the marker literal; the ids come back the same and in the same order (a match cannot cross the encoder's separators because the id admits no space, and no non-string value encodes to text that can hold one). `_fold_tasks` stores each result as it came and encodes only the TaskCreate result at its one read; the is_error skips are untouched. Two inputs that raised now yield no ids: a value `json.dumps` refuses, and a text block whose `text` is null. Measured on this branch: a micro-benchmark over 200 synthetic image-bearing segments 21.0 -> 4.5 ms median (the fork's kernel read 42.7 -> 14.2 ms for the same shape); `build_timeline(with_bars=True)` against a copy of a 31-session state directory, 5 iterations, two runs per side interleaved: 787.8 / 792.7 -> 747.8 / 730.2 ms median (the lane-only row was flat; the feed row also moved 5-7% although the change is not on its path, so part of this is load noise; the fork's own bench read 754.7 -> 734.7 ms). The chat's displayed tool output (`json.dumps(c))[:16000]`) is left alone: that string is displayed, not only searched. `kernel/kernel.py`; `tests/test_kernel_tool_result_scan.py` (17 tests, 27 subtests; a verbatim copy of the old `_seg_mids` is the oracle, and a `json.dumps` spy pins that the one marker-bearing string is the only encode), `tests/test_kernel.py` (list equality in the seg_mids test).

6. **Event model: `declared_plan` encodes only the TaskCreate result it reads, matching the kernel's fold.** The same read-side change as `_fold_tasks`, so the two folds stay identical (the #942 review asked for that) and a Bash result `json.dumps` refuses no longer aborts the event-model fold. Parity, no saving measured; droppable on its own, in which case `declared_plan` is out of scope beside the display site. `kernel/event_model.py` (+6/-4); `tests/test_kernel.py::ViewBuilder` (+1, both folds on the same session).

7. **Pusher: one encode per payload per build, with the delta split as the dedup signature and the whole frame serialized only when a send needs it.** A rebuild serialized the feed and the bars three times on the pusher thread: the whole frame, `_dedup_sig`'s sort_keys re-dump of the payload minus its clock, and the per-entry split the delta path made on the first delta client's send. The per-entry split (`_delta_parts`) is now the one encode: its strings are the dedup signature (`_parts_sig`), and the whole frame is a `_LazyWire` cell made on the first send that needs one (a fresh socket, a re-base, a client without deltas, a delta past the size guard) and kept in the wire tuple, so a rebuild whose clients all hold a base never serializes the frame. The split is handed down to `_send_slot` so the delta path neither re-splits nor depends on the single-slot `_delta_parts_cache` surviving a connect push on a handler thread. `_delta_split` parses a collection's kind once (`_delta_keyer`) instead of per item. An unkeyable payload keeps the whole dump and `_dedup_sig`. The signature is key-order-sensitive where the sorted dump was not, so an equal-content reorder re-sends once (an order-only delta, or one whole frame for a legacy client) and then dedups: more sends, never a stale one. The size guard reads the entries' byte total until the frame exists, so the fallback to a whole frame is marginally more eager. Every wire encoder takes `_wire_default`, which returns `str(o)` (the bytes the delta paths' `default=str` already produced), counts the value, names the type once on stderr and, since the review commit, files one bell row of kind `refused` per distinct type beside that line (the #1020 convention for a fault the user should see; the type name is the fault's identity, so a repeat files nothing), so a wire fault reaches the dashboard; the whole-frame dumps carried no `default` before and raised. Measured in-process on this branch with synthetic payloads (a fresh object per fill, median of 10): feed fill (800 cards, 1.43 MB) 30 -> 10 ms per rebuild, bars fill (26,240 entries, 2.85 MB) 152 -> 82 ms; an earlier build of the same change measured on the fork's kernel against a copy of a live state directory (802 cards, 31 lanes) read 120 -> 34 ms and 150 -> 63 ms, bytes per slot identical. `kernel/kernel.py`; `tests/test_wire_once_per_build.py` (new; 24, one of them the review commit's refused row), `tests/test_view_deltas.py::TupleSignatureForTheSlots` (including a lane renamed in place, a deduped whole frame that never serializes its cell, and an encode that raises leaving the dedup slot for a retry) and `::KeyerParsesTheKindOnce`, `tests/test_kernel_pusher_snapshot.py::LazyChatSerialization` (the wire tuple holds the cell).

8. **Pusher: a fill or send that raises stands its slot or client down for the cycle instead of ending the pusher thread.** The wire section runs after `_push`'s build `try`, and `_push_all`, `_pusher_cycle_jobs`, `_pusher_cycle` and `_pusher` have no `except`, so a raise there ended the pusher thread for the life of the process and froze every dashboard until a restart; a set in a card met a whole-frame dump with no `default`, and a build slot read as None by the loop was another such raise. Each client's branch now runs under its own `try`: a fill that raises stands its slot down for the cycle (one traceback, its clients skipped, the other slot served), a send that raises skips that client, a whole frame whose encode raises leaves the dedup slot unwritten so the next cycle retries, and `_pusher_cycle_jobs` catches around `_push_all`. `_pusher` itself stays unwrapped: that belt and `_pusher_cycle`'s `finally` cover the cycle. Robustness only, no measurement. `kernel/kernel.py`; `tests/test_wire_once_per_build.py::ARaisingSerializerLeavesThePusherAlive` (7, one for the sessions board, which rides the feed payload).

9. **Pusher: the delta split is memoized per collection on the collection object's identity, so a ledgers-only feed refill encodes no card.** `_push` serves the feed as a copy of the cached build with the cycle's per-session status list (`ledgers`) attached, so a cycle where that list moved but the build did not is a new payload object around the same cards list, and the payload-identity cache missed: every card was encoded again for a remainder-only change. `_delta_parts` now memoizes each collection's split on the collection object's identity (`_delta_split_memo`, one entry per frame type and collection, counted as `split_hit` / `split_miss`), on the same premise the payload cache rests on. Measured in-process on this branch on a synthetic 800-card feed (920 KB), median of 10 fills: a ledgers-only refill 7.5 -> 0.09 ms; a fresh build's fill unchanged within noise. An earlier build measured on the fork's kernel against a copy of a live state directory (802 cards) read 34 -> 0.4 ms. Separate so it can be dropped in review. `kernel/kernel.py`; `tests/test_wire_once_per_build.py::ALedgersOnlyRefillEncodesNoCard` (4: the feed, one through the real `_push`, the bars around unchanged collections, and the counters exact under a forced interleaving).

10. **Kernel: `_interrupt_marks` is memoized per (sid, parse family) on the turns object's identity and the machine-cut stamp.** The interrupt tick, the nudge tick and `build_feed`'s interrupted badge re-tallied every alive session's user atoms every cycle over parse objects that had not changed. The result is a pure function of the atoms and the (cut_t, cut_cause) pair, so a new parse object or a moved stamp is the only event that can change it, and no clock enters the key. One entry per family ("judge" for the judge's parse object, "display" for the kernel parse cache's), so the two objects stop evicting each other; the interrupt tick drops entries for sids that left the alive set; a 512-entry cap clears the memo whole. Sound because `event_model.parse_session` allocates a fresh turns list per parse and `_merge_live_atoms` copies rather than extends (a test pins the appended-transcript case). The pure core also drops user atoms whose author key is present and None before the text scan; exact because `author_of` returns None only for a text-less record, which can be neither an interrupt record nor a human prompt, and key-less live-tail atoms are kept. Measured in-process on this branch on a synthetic 4,801-user-atom transcript parsed through the file adapter: 5.2-5.8 ms per miss -> 0.013 ms per hit; an earlier build measured on the fork's kernel read 2.80 -> 0.015 ms on a hit (2.93 ms per miss), with a 98.5% hit rate once live. `kernel/kernel.py`; `tests/test_interrupt_marks_memo.py` (19, the nudge tick's read through the judge entry and the counter lock among them), one-line stub updates in seven test modules (the nudge and wake ticks' rigs, `tests/test_goal_store_fault_boundary.py` and `tests/test_ledger_unproved_reads.py`).

11. **Kernel: the tick jobs wake the pusher instead of pushing inline.** The interrupt tick and the three retry-pause jobs (`_auto_pause_on_limit`, `_auto_pause_on_spend_limit`, `_auto_resume_retry`) each ended a flip with their own `_push_all`. Every writer they served already ends in `_mark_views_dirty` (the interrupt writers, and `_set_retry_paused` since the 2026-09-05 review), which stamps the dirty mark and wakes the pusher, so the next cycle rebuilds past the mark either way; the inline call spared no rebuild and added a second push's fixed work per flip, and on the interrupt tick's stand-down path pushed with nothing new. The four calls are removed; the re-arm of given-up cards after a recovery marks the views dirty itself (a store write the cards show). The flip reaches the feed one cycle start later, sub-second; phone push stays on its client gate. The push-caller census in `tests/test_post_push_coalescing.py` now admits only `_push_all` and `_pusher_cycle_jobs`, so a future tick job that pushes inline fails it; the same module drives `_pusher` to pin that a wake set during a cycle is the next cycle's event (wait, then clear), the ordering this delivery rests on. The tick's fault paths from #1018 push nothing and mark nothing either: an unproved auto-nudge snapshot stands the block down before any write, and a refused marker write or clear leaves the store write's own dirty mark to carry the flip, so a fault repeats neither a push nor a rebuild every cycle; the five tests in `tests/test_ledger_unproved_reads.py` that pinned the inline push now read the dirty mark and the pusher wake (the rebase paragraph above has the detail). Not re-measured (an inline push per flip is event-rate); the fork estimated it from a 120 s cProfile of a 30-session kernel at 40-90 pusher-thread samples at the observed flip rate. `kernel/kernel.py`; `tests/test_interrupt_lift_evidence_time.py`, `tests/test_kernel_usage_limit.py`, `tests/test_retry_pause_autoresume.py`, `tests/test_post_push_coalescing.py`, `tests/test_ledger_unproved_reads.py` (5 extended).

12. **Kernel: `_sessions` runs one discover sweep per pusher cycle on the cycle's scope, and the interrupt tick hands `_compacting_now` the row's own path.** `_sessions` ran a discover fingerprint (a stat per names entry, three times, plus one per transcript) and a stat per row on every call, 34-37 times per cycle on the fork's profiled 30-session kernel (every `_alive_sessions` read in the tick jobs, every `_path_of` miss, `_msg_summaries`, `build_session`, the tab and lane lists), 4.3% of the pusher's GIL, all returning the same rows. The rows are memoized on the cycle's thread-local scope (`_live_scope.sessions`, opened and cleared by `_pusher_cycle` beside `.paths` and `.names`), one sweep per (window, forks) key per cycle; the wide walk `_alive_sessions` takes for a live session idle longer than 48 h is memoized on the same scope (`_discover_wide`). Every read hands out a copy; outside a cycle every read is fresh. Within a cycle the rows are the cycle's snapshot, so `_msg_summaries`' per-sid cache and the timeline's dead-lane cutoff lag one cycle at most, never an under-scan. The tick also hands `_compacting_now` the row's own path and live meta: `_path_of` searched only the 48 h set, so a live session idle longer than that read as having no transcript, and an optimistic compact click on it could not be disproved by its own compact_boundary for the 180 s cap while the tick skipped the row. Measured on this branch with a tick micro-bench over a copy of a 31-session state directory (medians of 7): `_interrupt_block_tick` 62.7 -> 5.3 ms per cycle for this commit alone, 151 -> 5.3 ms from the series base; ten `_alive_sessions` reads 18.3 -> 2.0 ms. The fork's kernel read 128.7 -> 7.3 and 18.7 -> 2.0 ms on the same bench, and its offline builder bench moved `build_feed` 784 -> 651 ms (-17%) and the steady push cycle -7.6% across the three tick commits (10-12); those two rows were not re-measured here. `kernel/kernel.py`; `tests/test_kernel_pusher_snapshot.py::OneDiscoverPerCycle` (10) and `::TickReadsTheRowsPath` (3), one stub in `tests/test_ledger_unproved_reads.py`.

13. **Review fixes: an open stripe is the lane's own state, the live guard is back, a stale connect frame says so.** The review commit, not one of the twelve: an open awaiting or compacting interval carries an explicit open mark on the wire and the renderer reads the mark, never the end's distance from `data.now`; the live look's full-draw fallback honours `LIVE_MIN_PX` again; a connect over a cache the kernel's own rule calls stale builds its lanes fresh; `_wire_default` files one refused bell row per distinct non-json type. `kernel/kernel.py`, `ui/romp-timeline-view.js`, six test files (+236/-68).

**Review commit.** The branch tip is the review commit. It changed four things: (1) an awaiting or compacting interval the session is still in carries an explicit open mark on the wire (`[start, end, True]`, `_state_intervals`), and the renderer reads the mark, never the end's distance from `data.now`, which on a connect frame (the cycle clock re-stamped over the cached build) was the cache's age; (2) the live look's full-draw fallback, for a build that left no handle, honours `LIVE_MIN_PX` again, so a board with a pending prompt no longer redraws every look at a wide window (`_live`); (3) a connect over a cache the kernel's own rule calls stale (`_timeline_cache_fresh`: view signature moved, or a dirty mark since the build) builds its lanes fresh instead of re-stamping the cycle clock over hours-old lanes (`_push`, `_cached_timeline`); (4) `_wire_default` files one bell row of kind `refused` per distinct non-json type beside its stderr line, so a wire fault reaches the dashboard. It verified the rebase resolution with no change: the `_VIEWS_SERVED` capture sits inside the lazy `_send_client` and reads the frame dict, `_interrupt_block_tick` keeps both marker writes, and the connect frame's views blob and the caps `viewsSeq` are read off the same served frame. It also found that the dead-lane-only goal-store load an earlier version of this body claimed for commit 2 is not in the diff; that load is left unimplemented (it would break main's live-lane fault-row test) and this body no longer claims it.

## What changes for a user

- A timeline lane moves only when the timeline rebuilds: on a view-signature change, on a dirty mark, or at the 5 s bucket. A lane therefore trails live state by at most `REBUILD_MIN_S` (2 s), the lag the bars always had; before, the per-cycle skeleton carried fresh row values every 0.5 s. A context-% change, a fast-mode refusal reason, a subagent row change, a background-task swap, a usage or views write, a comment write and a watch firing now bust the cache directly instead of waiting on the bucket.
- A reload over a cache the kernel calls stale (the view signature moved, or a writer marked the views dirty since the build) gets its lanes built fresh on the connect rather than the cache re-stamped with the cycle clock, so a lane dead for hours does not paint live (or the reverse) until the next cycle's rebuild; a fresh cache is still served under the cycle clock.
- Compaction markers appear on lanes (the per-cycle skeleton parsed nothing and always shipped an empty list), and a dead lane's `since` is its last work end rather than the transcript mtime. Please eyeball a live timeline with a session that has compacted: the headless test covers this path, but no live data ever exercised it before.
- On the first regular cycle after a kernel start, dead lanes reach the client one build later than before (the connect push took the cold live-only path and cached nothing).
- An awaiting or compacting stripe glides to the live edge instead of sitting at the build clock until the next rebuild, and draws open on a connect frame however old the cache it came from (the open mark rides the interval); a closed stripe ending a second before the clock stays closed.
- The live-follow loop keeps its pacing but each look is a translate; a board whose build left the tick no handle (a glyph at the live edge) redraws only once the edge has moved a pixel; the axis gains a gridline the moment the clock reaches it; a lane aging out or a time-latched visual waits for the next kernel frame (on a quiet board, the 60 s repost).
- A needs-you flip from the interrupt tick, and the retry-pause flag, reach the dashboard on the next pusher cycle (sub-second) rather than inline. A background chat tab's queued-hold reason still waits for its own signature key to move, as before.
- A live session idle longer than 48 h that is clicked to compact optimistically is now disproved by its own compact boundary instead of sitting behind the 180 s cap.
- A non-JSON value in a frame ships as `str(o)`, is named once on stderr and files one refused bell row per distinct type, so the fault reaches the dashboard, instead of ending the pusher thread; a fill or send that raises costs that slot or client one cycle. A tool result the encoder refuses, or a text block with a null text, yields no message ids instead of aborting the timeline build (and the event-model fold, commit 6).

## Tests

Every commit landed red-first against the kernel or renderer it changes, then green (the counts are the first version's; the mutation pass named above added its tests to the same commits):

- Commit 1: 3 red (KeyError `parts` on the held state twice; 6 != 3 per-entry compares on an unchanged cycle through `_push`).
- Commit 2: 13 red (the per-cycle skeleton build ran; equal signatures on a context change and after a `usage.json` write; AttributeError on `_skel_wire`; the projection and compactions tests on their own assertions with a scratch `_skel_wire` probe).
- Commit 3: 3/3 red (the open stripe stopped at x(now); the source pins absent).
- Commit 4: 10/10 red (no `_tickPlot`); the hidden-stub pin red (no plot group); the msg-hover pin red.
- Commit 5: 8 red plus 4 red subtests (TypeError from `json.dumps` and `findall`, AttributeError on `_encoded_mids`); the oracle-agreement tests pass on both sides by design.
- Commit 6: 1 red (TypeError at `declared_plan`'s encode-every-result line).
- Commit 7: 18 red (no `_wire_stats`, `_parts_sig`, `_delta_keyer`, `_LazyWire`; the wire tuple's third slot a str).
- Commit 8: 6 red (a KeyError, a RuntimeError and a ValueError escape `_push`; a RuntimeError escapes `_pusher_cycle_jobs`; no `try` after `for c in targets:`).
- Commit 9: 2 red at the zero-calls assertion (`{'byid:itemId': 1} != {}`, one split per refill).
- Commit 10: 12 red (the memo classes; the pure core scans the 39 author-None atoms).
- Commit 11: 13 red (the census reports the four inline pushers; inline pushes counted; the tripwires fire).
- Commit 12: 5 red (no `_sessions_scope_stats`; 7 != 1 wide walks per cycle; the row's path not seen by the compaction gate).
- Review commit: three connect tests in `tests/test_kernel_timeline_split.py` (a cache built under an older view signature, a cache marked dirty since its build, a re-stamped connect frame keeping the open mark), one refused-row test in `tests/test_wire_once_per_build.py`, one sub-pixel no-handle look in `ui/timeline-transform-tick.test.ts`; `ui/timeline-open-interval.test.ts` retargeted at the mark (a marked span 30 s behind the clock reads open, unmarked spans 1 s behind read closed); the `_state_intervals` pins in `tests/test_bg_scan_fold.py`, `tests/test_stage0_log_readers.py` and `::OpenIntervals` expect the mark.

Full suites on the rebased branch before the review commit (2026-09-08, the twelve commits on e9eb27ff; not re-run here at the review commit's head): pytest 8824 passed, 47 skipped, 1430 subtests, 1 failed, not this branch's: `tests/test_tag_edit_ack.py::ReaderRestampUnwritable::test_a_read_only_state_dir_is_served_not_raised_and_logged_once`, a FileNotFoundError on its fixture's state directory before the test's first write under `-n 8`, which passes 94/94 alone and reads nothing this branch changes (these commits stat `timeline-views.json` for the view signature and touch no views write); vscode-extension `npm test` 3305/3305 with `tsc --noEmit` clean; `tests/romp-perf.bats` 15/15. New modules: `tests/test_kernel_tool_result_scan.py` (17 + 27 subtests), `tests/test_wire_once_per_build.py` (24 with the review commit's), `tests/test_interrupt_marks_memo.py` (19), `ui/timeline-open-interval.test.ts` (4), `ui/timeline-transform-tick.test.ts` (18 with the review commit's); upstream's `ui/timeline-live-tick.test.ts` pins are untouched and green.

## Measurements

Figures marked "branch" were taken on this branch on a loaded 32-core box under `nice`, with the method given; figures marked "fork" were measured on the fork's kernel (an earlier build of the same change) and are cited as such.

| Commit | What was timed | Before | After | Where |
|---|---|---|---|---|
| 1 | Unchanged same-object cycle per timeline client, synthetic 26,612-entry 7.5 MB bars payload, median of 9 | 15.0 ms | 0.002 ms | branch |
| 1 | Same, 7.1 MB payload of the same entry count | 14.7 ms | 0 | fork |
| 1 | Steady pusher cycle, copy of a 31-session state directory, 3 iterations | 358 ms | 345 ms (noise) | branch |
| 2 | Steady pusher cycle, 31-session state copy, base without the nested-clock dedup | 374 ms | 104 ms | fork |
| 2 | Timeline connect push, same bench | 219 ms | 16 ms | fork |
| 2 | Lane-only build per call, same bench | 195 ms | 95 ms | fork |
| 2 | Lane-only build per call at the base, one iteration (no longer paid on a warm cycle) | 102 ms | not run | branch |
| 4 | One live look, headless Chromium 151, synthetic 32-lane board, call plus forced layout | 37-38 ms | 0.3 ms | branch |
| 4 | Same, node DOM stand-in | 14-15 ms | 0.004 ms | branch |
| 4 | Full draw vs tick, headless, 32 lanes | 7.68 ms | 0.046 ms | fork |
| 5 | `_seg_mids` over 200 synthetic image-bearing segments, median of 25 | 21.0 ms | 4.5 ms | branch |
| 5 | Same shape | 42.7 ms | 14.2 ms | fork |
| 5 | `build_timeline(with_bars=True)`, copy of a 31-session state directory, 5 iterations, two runs per side | 787.8 / 792.7 ms | 747.8 / 730.2 ms | branch (feed row moved 5-7% too: noise of that order) |
| 5 | Same row | 754.7 ms | 734.7 ms | fork |
| 7 | Feed wire fill per rebuild, synthetic 800 cards, 1.43 MB | 30 ms | 10 ms | branch |
| 7 | Bars wire fill per rebuild, synthetic 26,240 entries, 2.85 MB | 152 ms | 82 ms | branch |
| 7 | Feed / bars fill, copy of a live state directory, 802 cards, 31 lanes | 120 / 150 ms | 34 / 63 ms | fork |
| 9 | Ledgers-only feed refill, synthetic 800 cards, median of 10 | 7.5 ms | 0.09 ms | branch |
| 9 | Same, 802 cards, copy of a live state directory | 34 ms | 0.4 ms | fork |
| 10 | `_interrupt_marks`, synthetic 4,801-user-atom transcript, miss vs hit | 5.2-5.8 ms | 0.013 ms | branch |
| 10 | Same, hit (miss 2.93 ms); live hit rate 98.5% | 2.80 ms | 0.015 ms | fork |
| 12 | `_interrupt_block_tick` per cycle, copy of a 31-session state directory, medians of 7 (commit 12 alone; from the series base: 151 ms) | 62.7 ms | 5.3 ms | branch |
| 12 | Ten `_alive_sessions` reads, same bench | 18.3 ms | 2.0 ms | branch |
| 12 | Same two rows | 128.7 / 18.7 ms | 7.3 / 2.0 ms | fork |
| 10-12 | `build_feed` / steady push cycle, offline builder bench, 31-session state copy | 784 ms / base | 651 ms (-17%) / -7.6% | fork |

Not attributed to this PR: the fork's `push_steady_rebuild` pair for commit 1 (3023 -> 1380 ms) compares unlike rebuild samples on both sides, and the 27 KB -> 0 byte figure for commit 2 was already 0 here (upstream's nested-clock dedup). Live, on the fork, a profile of the whole performance round (this PR's pusher commits plus the store and judge memos offered separately) read the kernel process at 115% -> 85% of a core in the boot regime with a dashboard connected, and the pusher's GIL time at 70.8% -> 61.0% of wall; its steady-state pusher figures are not comparable across that merge because the pre-merge window had no dashboard client.

## Contracts changed

- `_feed_wire` and `_bars_wire` grow from 5 to 6 entries (`parts` appended); their `ms` slot is a `_LazyWire` cell (`.text()`, `.size()`, `.materialized()`), not a str; a slot payload's dedup signature is a tuple (`_parts_sig`), not a string, and is key-order-sensitive (an equal-content reorder re-sends once, then dedups). `_skel_wire` is a new 4-tuple with a str serialization.
- `_send_slot`, `_send_slot_locked` and `_send_slot_delta` take `parts=None`; `_send_client` accepts a `_LazyWire` as `pre` and serializes it only when the frame goes; `_delta_key` is now `_delta_keyer(kind)`'s per-item form.
- Every wire encoder's `default` is `_wire_default` (`str(o)`, counted, named once on stderr, one `_sync_notice(..., ok=False, kind="refused")` row per distinct type) where the whole-frame dumps had none and raised.
- `_interrupt_marks` and `_interrupt_suppresses_nudge` take `family=None`; test stubs of either need `**k`. `_interrupt_marks_atoms` drops user atoms whose `author` key is present and None.
- `_fleet_view_sig` drops `interrupting` and keys `context`, `fastReason`, subagent items, background-task ids and four more files; a test that expects an `interrupting` change to bust the view signature no longer holds.
- `_sessions` returns a copy of its list and is memoized within a pusher cycle on `_live_scope.sessions`; row dicts are shared read-only within a cycle. `_interrupt_block_tick` calls `_compacting_now(sid, tm=..., path=...)`; a stub of it needs `**k`.
- `PUSHER_THREAD_FNS` in `tests/test_post_push_coalescing.py` is `{_push_all, _pusher_cycle_jobs}`: a tick job that pushes inline fails the census.
- `draw()` places time-positioned elements in a `<g data-tl-plot>` group; the judge band's rails and labels are inserted before it. Tests that read `svg.children` for those elements read the group's children instead.
- `_state_intervals` returns `[start, end, True]` for an interval the session is still in (a numeric end at the build clock plus the open mark) and `[start, end]` for a closed one, so a lane's `awaiting` and `compacting` carry the mark on the wire; the renderer reads the mark (or a null end) as open and applies no clock tolerance. A test that expects a two-element open interval no longer holds; an already-loaded renderer ignores the third element.
- `_timeline_cache_fresh(sig)` is the one freshness rule for the cached full build (`_cached_timeline` rebuilds when it is False); a connect push over a cache it calls stale serves `build_timeline(now, tmux, with_bars=False)` as the lanes frame, under the cycle's clock as the build's own, and the cached bars.
- `_live`'s full-draw fallback for a build that left no `_tickPlot` handle redraws only when the edge has moved `LIVE_MIN_PX` since the build.
- Three module-level counter dicts, read by tests only: `_wire_stats`, `_intr_marks_memo_stats` (under a lock: connect-time builds bump it from socket threads), `_sessions_scope_stats` (pusher-thread only).

## Not included

- A goal-store load on the cold live-first connect for dead lanes only: an earlier version of this body claimed it for commit 2, but it is not in the diff; every lane's store is read as before, and it stays unimplemented because main's live-lane fault-row test depends on that load.
- Exposure of `_wire_stats`, `_intr_marks_memo_stats` and `_sessions_scope_stats` on `GET /perf`: one follow-up PR, so the memo keys land together.
- Folding `_skel_wire` into `_LazyWire`: the lanes frame is small and always serialized, so the cell would add an allocation for no change in behaviour; easy to add if one type family is preferred.
- A `feed is None` guard in the wire loop: the None race in the cached feed slot is caught and logged by commit 8's belt, not fixed; the guard belongs to a later thread-safety pass over the pusher's caches, two of whose lock hunks (`_WIRE_STATS_LOCK`, `_INTR_MARKS_STATS_LOCK`) already travel here.
- The chat's displayed tool output still encodes list-shaped results (`json.dumps(c))[:16000]`): displayed, not only searched.
- `_chat_build_sig` keeps its dead `interrupting` key (always False on the merged row); only `ctx` -> `context` is fixed there.
- The other browser-side cuts from the same round (the lane array identity in the pane shim, the chat's fence-highlight cache and tab-strip signature) are a separate PR; it touches `tests/test_view_deltas.py` and `tests/test_kernel_timeline_split.py` in different classes from this one.
- The tools that produced the bench rows (an offline pusher and builder bench, a browser replay bench) are a separate PR; the rows above name the method and the state copy's size instead.

## Questions

1. Commit 7: a non-JSON value in a whole frame ships as `str(o)`, counted and named once on stderr (the bytes the delta paths' `default=str` already produced), and since the review commit files one refused bell row per type. The alternative was raise-and-skip: stand the slot down for the cycle and log, so a builder's mistake never reaches a pane as a string. The review commit kept `str(o)` and made the fault visible; open only if raise-and-skip is still preferred.
2. Commit 4: the tick hands back to a full draw when the clock reaches the next axis gridline (`nextTick`), skipped inside a collapsed trailing gap where the axis does not move. Without it a quiet board shows a stale axis until the 60 s repost. Keep, or wait for the next kernel frame?
3. Commit 11: the retry-pause sites delete their inline push rather than replace it with a wake, because `_set_retry_paused` already ends in `_mark_views_dirty` (the 2026-09-05 review line). If that line is meant to go, these three sites need a `_push_soon()` each.
4. Commits 6 and 9 are separable: drop 6 if `declared_plan` should stay as is (commit 5's message then stands as written, naming it a follow-up), drop 9 if the split memo is one identity cache too many.
5. Commit 2's lane lag (up to 2 s behind the chat chip) and the one-build-later dead lanes after boot are the two behaviour changes worth a deliberate yes.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
