### PR TITLE
Panes: direct frame delivery, and chat and feed renders that repaint only what changed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,49 @@ produced confusing failures:
   assertion — only the last command's status counts — so a stale assertion can
   pass silently for months. Linux CI runs bash 5 and is the arbiter; two
   assertions went stale exactly this way while CI was offline.
+
+## A message listener from another world clones every frame it can see
+
+The pane pages receive the kernel's frames as `message` events on `window`.
+Blink hands a listener in the page's own JavaScript world the event's data
+object itself, but a listener in another world, a browser extension's content
+script, that reads `event.data` receives a structured clone of the whole
+object, made synchronously inside the dispatch: 35-46 ms and about 7 MB of
+garbage per dispatch of a 7 MB frame in a Chromium probe, against 0 ms for a
+direct call. The live `romp perf client` rows show it as a `fed:<type>` share
+far above federation's own compute (about 1 ms per frame).
+
+`federation.js` therefore hands its merged frames (`feed`, `tabOrder`, `data`,
+`bars`) to the pane's handler by direct call (`window.__rompFed.onFrame`,
+through `ui/webview/frame-listener.ts`) and dispatches them on `window` only
+when nothing registered. Every other frame still arrives as a `window` event,
+so a foreign listener still sees those, and a new frame type that grows large
+should go through the registry too.
+
+To check a browser for such a listener before or after a deploy: open DevTools
+on the dashboard, pick the feed iframe in the console's context selector, and
+time a dispatch of a large frame:
+
+```js
+const big = Array.from({ length: 150000 }, (_, i) => ({ i, s: "x" }));
+const t = performance.now();
+window.dispatchEvent(new MessageEvent("message", { data: big }));
+performance.now() - t
+```
+
+Under a millisecond means no foreign reader: only same-world listeners saw the
+event. Tens of milliseconds means a listener in another world read
+`event.data` and paid for the clone. This timing is the detection step.
+`getEventListeners(window).message` cannot be, because it is per-world: it
+lists only the listeners registered from the world whose context the console
+is running in, so in the page's own context it shows romp's listeners and
+nothing else, whether or not a content script is present. To see a content
+script's listener, switch the console's context selector to that extension's
+context (listed under the frame by extension name) and run the enumeration
+there. Every romp listener on a kernel pane page comes from that page's pane
+bundle (`feed.js` on the feed page, `render.js` on the chat, and so on; the
+kernel-served timeline's is its inline boot; under a dev build with source
+maps DevTools may show the source file names), and any other URL, in
+particular a `chrome-extension://` one, is the foreign listener. With no
+foreign listener present, a large `fed:<type>` share in the live rows is not
+the clone and needs another explanation before anything is built on this one.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1087,11 +1087,22 @@ frames it received is measured in the panes themselves, by
   too. The federation layer, which every kernel page loads, times its
   own prefixing, delta application and merge of each frame as `fed:<type>`,
   nested outside the pane's handler; each level records its own time, so
-  `fed:feed` and `feed` add up to the frame's cost. The timeline's listener is
-  wrapped the same way on both hosts (the VS Code bundle directly; the kernel
-  page's inline boot through the `window.__rompPerf` that `federation.js`
-  publishes before it runs), so `data`, `bars`, `hover`, `activeChat`,
-  `revealEvent` and `models` are timed like any pane's frames.
+  `fed:feed` and `feed` add up to the frame's cost. The federation layer hands
+  its merged frames (`feed`, `tabOrder`, `data`, `bars`) to the pane's handler
+  by direct call once the pane has registered it (`window.__rompFed.onFrame`,
+  through `ui/webview/frame-listener.ts`), so `fed:<type>` is that layer's own
+  compute; it dispatches them on `window` only when nothing registered, and
+  every other frame still arrives as a `window` `message` event. A `message`
+  listener from another JavaScript world (a browser extension's content
+  script) that reads `event.data` receives a structured clone of every frame
+  dispatched on `window`, tens of milliseconds for a multi-megabyte board; the
+  direct call keeps the merged frames out of its reach. See "A message
+  listener from another world" in `CONTRIBUTING.md` for the check that finds
+  such a listener. The timeline's listener is wrapped the same way on both
+  hosts (the VS Code bundle directly; the kernel page's inline boot through
+  the `window.__rompPerf` that `federation.js` publishes before it runs), so
+  `data`, `bars`, `hover`, `activeChat`, `revealEvent` and `models` are timed
+  like any pane's frames.
 - Per type and minute: count, summed and maximum handler time, the exact
   number of frames over 16.7 ms (one dropped frame at 60 Hz) and at or over
   100 ms, and a 14-bucket log2 histogram (under 1 ms, 1-2, 2-4, ..., 2048-4096,

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14216,8 +14216,12 @@ def _fire_api_retry(sid, be, manual=False):
     # message, force-pinning a junk goal per retry via the never-skip hard guard ("retry — kept on the
     # board…", 71 of them in one API-error storm). The marker makes author_of return 'romp' (ROMP_INJECT_RE)
     # so the echo + transcript render gray and the planner skips a work-less retry instead of minting a goal.
-    be.send(sid, RETRY_MSG)
+    delivered = be.send(sid, RETRY_MSG)
     _note_retry_sent(sid, manual=manual)
+    # the send's own verdict, for the manual route's reply (review find, 2026-09-08): SdkBackend.send and
+    # CodexBackend.send return False for a session they cannot reach (no live registry row, no client);
+    # TmuxBackend.send always True. Only an explicit False is a refusal; a backend answering None sent.
+    return delivered is not False
 
 
 def _auto_retry_tick(now, tmux):
@@ -14442,8 +14446,12 @@ def _refuse_drive(client, op, sid, msg):
         # `sid` rides along so the shell's error-center entry carries the session it was meant for, the way
         # every card-badge entry does — the bell is a log you read later, and "which one?" is the first thing
         # you ask of it.
+        # `op` and `itemId` name the REQUEST (review find, 2026-09-08): the feed latches a button on the click
+        # (Retry → "Retrying…", Continue → "Sent") and re-arms it on the kernel's reply for that post alone,
+        # not every latch the session holds, and never on a clock, so the reply says which post it answers.
         client["send"](json.dumps({"type": "err", "title": "That %s was not delivered" % what,
-                                   "text": detail, "copy": text, "sid": sid}))
+                                   "text": detail, "copy": text, "sid": sid,
+                                   "op": op, "itemId": msg.get("itemId") or ""}))
     except Exception:
         pass
 
@@ -14698,7 +14706,14 @@ def _drive(msg, client):
         # ONE retry decision, all of it kernel state — see _fire_api_retry (shared with the kernel's own
         # _auto_retry_tick, which drives recovery unattended since 2026-08-11; this route remains for the
         # manual Retry-now button and the dashboard tick's redundant asks, both idempotent against it).
-        _fire_api_retry(sid, be, manual=bool(msg.get("manual")))
+        if not _fire_api_retry(sid, be, manual=bool(msg.get("manual"))) and msg.get("manual"):
+            # the backend refused the send (review find, 2026-09-08): the feed's Retry latched "Retrying…" on
+            # the click and re-arms on the kernel's reply for that request, matched by sid. Nothing answered a
+            # refused send before, so the button stayed latched until the card happened to be re-sent. A SOFT
+            # refusal (nothing typed was lost), so a typed reply the feed toasts, not the must-dismiss `err`.
+            # The auto path stays silent: no pane asked, and the kernel's own tick asks again.
+            client["send"](json.dumps({"type": "retryRefused", "sid": sid,
+                                       "text": "Couldn't retry: the session isn't connected right now."}))
     elif t == "setModel" and msg.get("value"):
         # mid-compaction → parked as a queued command; `floating` is the version submenu's Latest row —
         # forget the family's remembered pin and send the alias
@@ -15069,8 +15084,12 @@ def _revive_session(sid, client=None):
     refusal = _claim_session_name(name, "revive", sid, own=sid)
     if refusal:
         sys.stderr.write("revive '%s' (%s): refused — %s\n" % (name, sid, refusal))
-        _send_to_view("chat", {"type": "reviveFailed", "id": sid, "name": name, "text": refusal},
-                      (client or {}).get("wid") or "")
+        # the asking dashboard's chat AND feed, like every other revive refusal (_revive_session_inner): the
+        # feed's parked card latched "Reviving…" on the click and re-arms only on the reply for its own sid.
+        failed = {"type": "reviveFailed", "id": sid, "name": name, "text": refusal}
+        wid = (client or {}).get("wid") or ""
+        _send_to_view("chat", failed, wid)
+        _send_to_view("feed", failed, wid)
         return
     try:
         _revive_session_inner(sid, client)
@@ -15123,8 +15142,15 @@ def _revive_session_inner(sid, client=None):
         ok, detail = False, str(e)[:200]
     if not ok:
         sys.stderr.write("revive '%s' (%s): %s\n" % (name, sid, detail))
-        _send_to_view("chat", {"type": "reviveFailed", "id": sid, "name": name,
-                               "text": detail or "unknown error"}, (client or {}).get("wid") or "")
+        failed = {"type": "reviveFailed", "id": sid, "name": name, "text": detail or "unknown error"}
+        wid = (client or {}).get("wid") or ""
+        _send_to_view("chat", failed, wid)
+        # …and the same dashboard's FEED (review find, 2026-09-08): its parked-handoff card latched "Reviving…"
+        # on the click and re-arms on this reply, the reply for ITS request, matched by the revived sid, which
+        # is the card's own. With the notice aimed at the chat alone the feed heard nothing, and since the feed
+        # repaints a card only when the kernel re-sends it, a refusal that changes no card left that button
+        # latched until the parked card's colour ticked: never, past the colour ramp's ceiling.
+        _send_to_view("feed", failed, wid)
         return
     _kept_open.discard(sid)       # it's live again → no longer a read-only kept tab
     _push_soon()                  # surface it promptly — the woken pusher builds it off this thread
@@ -46982,7 +47008,7 @@ class Handler(BaseHTTPRequestHandler):
             # Human verdict on a DIRECTED peer's held message (per-host trust): approve delivers it
             # (optionally with human-edited text), deny drops it. The bus owns delivery + the held-message
             # store, so proxy there; on success the bus removes the held file, so _quarantine_cards drops
-            # the card on the next build (event-based — no cleared.jsonl needed). Failure warn-toasts.
+            # the card on the next build (event-based — no cleared.jsonl needed). Failure answers the asker by mid.
             _qmid = str(msg["mid"])
             _qbody = {"mid": _qmid, "action": str(msg.get("action") or "").strip().lower()}
             if msg.get("text") is not None:
@@ -46993,7 +47019,12 @@ class Handler(BaseHTTPRequestHandler):
             if _qok:
                 _mark_views_dirty()
             else:
-                client["send"](json.dumps({"type": "warn", "text": "quarantine: " + _qerr}))
+                # the refusal answers the asking pane BY THE MESSAGE it was about (review find, 2026-09-08): the
+                # feed latched Approve/Deny ("Delivering…") on the click and re-arms them on this reply, matched
+                # by mid. It was a bare `warn` before, which the feed never handled, so a refused verdict left
+                # both buttons disabled until the card was re-sent, and a card the bus refused to act on is
+                # exactly the one that is never re-sent. The feed is the only poster of this op.
+                client["send"](json.dumps({"type": "quarantineRefused", "mid": _qmid, "text": "quarantine: " + _qerr}))
         elif msg and msg.get("type") == "nodeOverride" and msg.get("sid") and msg.get("nodeId"):
             # modal surgical override: cross a node off (op:resolve → nodeComplete) or drop it
             # (op:clear → the user-authority clear verdict, same seam as a card Clear, scoped to the

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -40118,8 +40118,19 @@ if(kind==="dict"){items[kk]=v[kk];}
 else if(kind.indexOf("dictlist:")===0){var cut=kk.indexOf(SEP),dk=cut<0?kk:kk.slice(0,cut),rest=cut<0?"":kk.slice(cut+1),lane=v[dk];if(rest===""){items[kk]=lane;}else{var j=pos[dk]||0;pos[dk]=j+1;items[kk]=lane[j];}}
 else{items[kk]=v[i];}}
 maps[name]={order:order,items:items};}return maps;}
-function assemble(kind,map){var i,kk;if(kind==="dict"){var o={};for(i=0;i<map.order.length;i++){kk=map.order[i];if(map.items.hasOwnProperty(kk))o[kk]=map.items[kk];}return o;}
+// dictlist lanes keep their ARRAY IDENTITY across a delta that did not touch them: the lane prefix of
+// every set/del key names a touched lane, and an order that crosses touches every lane whose key
+// subsequence differs from the held order. An untouched lane assembles elementwise-identical to the
+// array the pane already holds, so assemble hands back that same array — turns[sid] identity then means
+// "unchanged", and a per-lane cache in the pane can key on it. The assembled VALUE is what it always
+// was; only object identity differs.
+function laneOf(kk){var cut=kk.indexOf(SEP);return cut<0?kk:kk.slice(0,cut);}
+function laneSeqs(order){var s={};for(var i=0;i<order.length;i++){var kk=order[i],ln=laneOf(kk);(s[ln]||(s[ln]=[])).push(kk);}return s;}
+function touchedLanes(c,oldOrder,newOrder){var t={},k;if(c.del)for(k=0;k<c.del.length;k++)t[laneOf(c.del[k])]=1;if(c.set)for(k in c.set)t[laneOf(k)]=1;
+if(c.order){var a=laneSeqs(oldOrder),b=laneSeqs(newOrder),ln;for(ln in a)if(!(ln in b)||JSON.stringify(a[ln])!==JSON.stringify(b[ln]))t[ln]=1;for(ln in b)if(!(ln in a))t[ln]=1;}return t;}
+function assemble(kind,map,prev,touched){var i,kk;if(kind==="dict"){var o={};for(i=0;i<map.order.length;i++){kk=map.order[i];if(map.items.hasOwnProperty(kk))o[kk]=map.items[kk];}return o;}
 if(kind.indexOf("dictlist:")===0){var d={};for(i=0;i<map.order.length;i++){kk=map.order[i];if(!map.items.hasOwnProperty(kk))continue;var cut=kk.indexOf(SEP);var dk=cut<0?kk:kk.slice(0,cut),rest=cut<0?"":kk.slice(cut+1);
+if(prev&&touched&&!touched[dk]&&Object.prototype.hasOwnProperty.call(prev,dk)){if(!d.hasOwnProperty(dk))d[dk]=prev[dk];continue;}   // an untouched lane: the held array itself, not a copy
 if(rest===""){d[dk]=map.items[kk];continue;}   // a bare-prefix entry: the lane's own (empty or non-list) value
 if(!d.hasOwnProperty(dk))d[dk]=[];d[dk].push(map.items[kk]);}return d;}
 var out=[];for(i=0;i<map.order.length;i++){kk=map.order[i];if(map.items.hasOwnProperty(kk))out.push(map.items[kk]);}return out;}
@@ -40129,7 +40140,8 @@ var coll=d.coll||{};for(var name in coll){var kind=kinds[name];if(!kind)continue
 if(c.del){for(var x=0;x<c.del.length;x++){delete items[c.del[x]];}}
 if(c.set){for(var sk in c.set){if(!items.hasOwnProperty(sk))order.push(sk);items[sk]=c.set[sk];}}
 if(c.order){order=c.order.slice();}else{order=order.filter(function(kk){return items.hasOwnProperty(kk);});}
-last.maps[name]={order:order,items:items};m[name]=assemble(kind,last.maps[name]);}
+var touched=kind.indexOf("dictlist:")===0?touchedLanes(c,map.order,order):null;
+last.maps[name]={order:order,items:items};m[name]=assemble(kind,last.maps[name],last.msg[name],touched);}
 last.rev=d.rev;last.msg=m;return m;}
 window.__rompLocalSend=send;window.__rompApp=APP;   // federation.ts (the multi-kernel manager) routes local sends + knows the app through these
 var SK="romp-vscode-state-%s";   // persist webview state to localStorage so UI prefs survive a refresh

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -40601,7 +40601,11 @@ else if(m.type==="caps"&&panel.setCaps)panel.setCaps(m);
 else if(m.type==="unknownOp"&&panel.unknownOp)panel.unknownOp(m);
 else if(m.type==="tagEditFailed"&&panel.tagEditFailed)panel.tagEditFailed(m);
 else if(m.type==="openViewsDialog"&&panel._openViewsDialog)panel._openViewsDialog(null);};
-window.addEventListener("message",(window.__rompPerf&&window.__rompPerf.wrapFrameHandler)?window.__rompPerf.wrapFrameHandler(onFrame):onFrame);
+var frameListener=(window.__rompPerf&&window.__rompPerf.wrapFrameHandler)?window.__rompPerf.wrapFrameHandler(onFrame):onFrame;
+window.addEventListener("message",frameListener);
+// the merged data/bars frames come by direct call from federation.js once the listener is registered with it (federation.ts
+// onFrame/emit; the pane bundles register through frame-listener.ts) — without the registry the window dispatch carries them
+if(window.__rompFed&&window.__rompFed.onFrame)window.__rompFed.onFrame(frameListener);
 window.__rompTimelineOpenExternal=function(url){try{var u=new URL(url);if(u.protocol==="vscode:"){var q=u.searchParams;
 post({type:"deepLink",session:q.get("session"),anchor:q.get("anchor")||undefined,anchorT:Number(q.get("anchorT"))||undefined,anchorKind:q.get("anchorKind")||undefined,compose:q.get("compose")==="1"});
 if(window.parent!==window)window.parent.postMessage({romp:"reveal",pane:"chat"},"*");return;}}catch(e){}window.open(url,"_blank");};

--- a/tests/test_drive_foreign_sid.py
+++ b/tests/test_drive_foreign_sid.py
@@ -92,6 +92,10 @@ class RefusesForeignDriveOps(unittest.TestCase):
         self.assertEqual(msg["copy"], "did you get this?")
         # …and the sid rides along, so the shell's error-center entry says WHICH session it was meant for
         self.assertEqual(msg["sid"], THEIRS)
+        # …and the REQUEST it answers (review find, 2026-09-08): the feed latches a button on the click (Retry →
+        # "Retrying…", Continue → "Sent") and re-arms it on the kernel's reply for THAT post, never every latch
+        # the session holds, and never on a clock, so the reply names the op and the card it was for
+        self.assertEqual((msg["op"], msg["itemId"]), ("sendMessage", ""))
 
     def test_a_card_reply_is_refused_the_same_way(self):
         # the exact shape that lost real messages: askFollowUp derives its sid from the itemId
@@ -100,6 +104,8 @@ class RefusesForeignDriveOps(unittest.TestCase):
         self.assertEqual(self.sent[0]["type"], "err")
         self.assertEqual(self.sent[0]["copy"], "and the fix?")
         self.assertIn("reply", self.sent[0]["title"])
+        self.assertEqual((self.sent[0]["op"], self.sent[0]["itemId"]), ("askFollowUp", THEIRS + ":g4"),
+                         "the card's own latch is the one this refusal releases")
 
     def test_our_own_session_is_untouched(self):
         km._drive({"type": "sendMessage", "id": OURS, "text": "hello"}, self.client)

--- a/tests/test_kernel_apiretry.py
+++ b/tests/test_kernel_apiretry.py
@@ -7,6 +7,7 @@ Also covers auto-retry IDEMPOTENCY (the user 2026-07-08): the 10s auto-loop must
 when the one romp already sent is still queued and unconsumed — that piled N bare "retry"s into the SDK
 queue during one API-error storm (the "retry retry retry retry…" card). A MANUAL "Retry now" still fires.
 """
+import json
 import os
 import types
 import unittest
@@ -134,6 +135,65 @@ class ApiRetryIdempotency(unittest.TestCase):
         be = FakeBackend(pending=[RETRY])
         self._drive_retry(be, manual=True)
         self.assertEqual(be.sent, [RETRY], "a manual retry is not deduped by the pending-queue guard")
+
+
+class RefusingBackend(FakeBackend):
+    """A backend whose send is refused: SdkBackend.send returns False for a session with no live registry
+    row (a dead client the retry cannot reach), CodexBackend.send likewise."""
+    def send(self, sid, text):
+        self.sent.append(text)
+        return False
+
+
+class ManualRetryRefusal(unittest.TestCase):
+    """A MANUAL Retry the backend cannot deliver answers the pane that asked (review find, 2026-09-08). The
+    feed's Retry latches "Retrying…" on the click and re-arms on the kernel's reply for that request; a send
+    the backend refused used to answer nothing at all, so the button stayed latched until the card happened
+    to be re-sent. The auto path stays silent: no pane asked, and the kernel's own tick asks again."""
+    def setUp(self):
+        self._saved = (km.Sessions, km._name_of, km._retry_paused_on, km._session_retry_suppressed,
+                       km._api_error, km._path_of)
+        km._name_of = lambda sid: "web"          # a session this kernel HAS; _drive refuses a foreign one earlier
+        km._retry_paused_on = lambda: False
+        km._session_retry_suppressed = lambda sid: False
+        km._api_error = lambda path: {"text": "500", "status": 500, "category": "server_error", "uuid": "ep-r",
+                                      "tooLong": False, "spendLimit": False}
+        km._path_of = lambda sid, now=None: "/TESTDIR/x.jsonl"
+        km._auto_retried.clear()
+        km._auto_retry_state.clear()
+        self.sent = []
+        self.client = {"app": "feed", "wid": "w1", "alive": True, "send": lambda raw: self.sent.append(json.loads(raw))}
+
+    def tearDown(self):
+        (km.Sessions, km._name_of, km._retry_paused_on, km._session_retry_suppressed,
+         km._api_error, km._path_of) = self._saved
+        km._auto_retried.clear()
+        km._auto_retry_state.clear()
+
+    def _drive(self, be, **msg):
+        km.Sessions = types.SimpleNamespace(backend_for=lambda sid: be)
+        m = {"type": "apiRetry", "id": "s1"}
+        m.update(msg)
+        km._drive(m, self.client)
+
+    def test_a_refused_manual_retry_answers_the_asker_by_session(self):
+        be = RefusingBackend(pending=[])
+        self._drive(be, manual=True)
+        self.assertEqual(be.sent, [RETRY], "the manual retry was attempted")
+        self.assertEqual([(m["type"], m["sid"]) for m in self.sent], [("retryRefused", "s1")],
+                         "the refusal names the session whose Retry was clicked, so that latch alone re-arms")
+        self.assertTrue(self.sent[0]["text"], "…and says why")
+
+    def test_a_delivered_manual_retry_answers_nothing(self):
+        # the retry is in the session's queue: the card's next frame (the turn opening, or a new error record)
+        # is the reply, as before
+        self._drive(FakeBackend(pending=[]), manual=True)
+        self.assertEqual(self.sent, [])
+
+    def test_a_refused_auto_retry_stays_silent(self):
+        # nobody clicked: the dashboard tick and the kernel's own driver ask again on their next cycle
+        self._drive(RefusingBackend(pending=[]))
+        self.assertEqual(self.sent, [])
 
 
 class KernelAutoRetryTick(unittest.TestCase):

--- a/tests/test_kernel_names.py
+++ b/tests/test_kernel_names.py
@@ -610,7 +610,10 @@ class ReviveDoor(_Base):
         self.live = {"web": SID2}
         km._revive_session(SID, self.client)
         self.assertEqual([c[:3] for c in self.sdk.calls], [], "the dead session came up beside a live namesake")
-        self.assertEqual([(a, m["type"], m["id"], w) for a, m, w in self.sent], [("chat", "reviveFailed", SID, "win-A")])
+        # the asker's chat AND feed hear it (the feed's parked card latched Revive on the click and re-arms
+        # on the refusal for its own sid; review find 2026-09-08), the shape every other revive refusal takes
+        self.assertEqual([(a, m["type"], m["id"], w) for a, m, w in self.sent],
+                         [("chat", "reviveFailed", SID, "win-A"), ("feed", "reviveFailed", SID, "win-A")])
         self.assertIn("already running", self.sent[0][1]["text"])
         self.assertEqual(self.reveals, [], "a refused revive focuses nothing")
 
@@ -619,6 +622,7 @@ class ReviveDoor(_Base):
         self.hold("web")
         km._revive_session(SID, self.client)
         self.assertEqual(self.sdk.calls, [])
+        self.assertEqual([a for a, _, _ in self.sent], ["chat", "feed"], "the asker's chat and feed both hear it")
         self.assertIn("being created", self.sent[0][1]["text"])
 
     def test_a_free_name_is_held_through_the_resume_and_released_after(self):

--- a/tests/test_kernel_revive.py
+++ b/tests/test_kernel_revive.py
@@ -88,10 +88,14 @@ class ReviveSession(unittest.TestCase):
         km._sdk = lambda: FakeSdk(connect_ok=False)
         km._revive_session(SID, CLIENT)
         self.assertEqual(self.focused, [], "a failed revive must not focus a still-dead session")
-        self.assertEqual(len(self.sent), 1)
-        app, msg, wid = self.sent[0]
-        self.assertEqual((app, msg["type"], msg["id"], wid), ("chat", "reviveFailed", SID, "win-A"),
-                         "the failure notice goes to the window whose revive loader is up")
+        # BOTH panes of the asking dashboard hear it (review find, 2026-09-08): the chat clears its revive
+        # loader, and the feed re-arms the parked card's Revive button it latched on the click. A refusal that
+        # reached the chat alone left that button "Reviving…" until the card happened to be re-sent, which
+        # for a parked handoff older than the colour ramp's ceiling is never.
+        self.assertEqual([(app, msg["type"], msg["id"], wid) for app, msg, wid in self.sent],
+                         [("chat", "reviveFailed", SID, "win-A"), ("feed", "reviveFailed", SID, "win-A")],
+                         "the failure notice goes to the window whose revive loader and latched button are up")
+        self.assertEqual(self.sent[0][1], self.sent[1][1], "one notice, the same words, to both panes")
 
     def test_tmux_session_revives_via_romp_resume_detach(self):
         km._sdk = lambda: None
@@ -111,6 +115,7 @@ class ReviveSession(unittest.TestCase):
         self._stub_run(returncode=3, stderr="no transcript for that uuid")
         km._revive_session(SID, CLIENT)
         self.assertEqual(self.focused, [])
+        self.assertEqual([app for app, _, _ in self.sent], ["chat", "feed"], "the asker's chat and feed both hear it")
         _, msg, _ = self.sent[0]
         self.assertEqual(msg["type"], "reviveFailed")
         self.assertIn("no transcript", msg["text"], "the launcher's stderr reaches the user, not DEVNULL")

--- a/tests/test_kernel_timeline_split.py
+++ b/tests/test_kernel_timeline_split.py
@@ -17,6 +17,8 @@ the cache's age, not a fact about the lane).
 import inspect
 import json
 import os
+import shutil
+import subprocess
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
@@ -70,6 +72,48 @@ class BuildGating(unittest.TestCase):
         self.assertIn("if(window.__rompFed&&window.__rompFed.onFrame)window.__rompFed.onFrame(frameListener);", boot)
         self.assertLess(boot.index('window.addEventListener("message",frameListener);'),
                         boot.index("window.__rompFed.onFrame(frameListener)"), "window first, the registry after it")
+
+    def test_the_host_shim_run_one_wrapped_listener_registered_with_federation_reaches_the_panel(self):
+        # The boot RUN (review find, 2026-09-08; moved here from the TypeScript lane, which must not break on a
+        # kernel edit): the self-contained IIFE under node's vm with the three window slots it reads stood in.
+        # One window listener, the perf-wrapped one; the registry gets that same function, so a frame arrives
+        # once whichever path carries it; a frame through the registry reaches the connected panel.
+        node = shutil.which("node")
+        if not node:
+            self.skipTest("node not installed")
+        fx = tempfile.mkdtemp()
+        with open(os.path.join(fx, "boot.js"), "w") as f:
+            f.write(km._TIMELINE_BOOT)
+        with open(os.path.join(fx, "run.js"), "w") as f:
+            f.write(r"""
+var vm = require("vm"), fs = require("fs");
+var boot = fs.readFileSync(process.argv[2], "utf8");
+var listeners = [], registered = [], updates = [], posted = [], wrapped = new Map();
+var win = {
+  acquireVsCodeApi: function () { return { postMessage: function (m) { posted.push(m); } }; },
+  addEventListener: function (t, h) { if (t === "message") listeners.push(h); },
+  __rompPerf: { wrapFrameHandler: function (h) { var w = function (e) { return h(e); }; wrapped.set(w, h); return w; } },
+  __rompFed: { onFrame: function (h) { registered.push(h); return function () {}; } },
+};
+win.window = win;
+vm.runInNewContext(boot, { window: win, HTMLElement: { prototype: {} }, document: {}, URL: URL });
+var out = { listeners: listeners.length, wrappedIsListener: wrapped.has(listeners[0]),
+            registeredSame: registered.length === 1 && registered[0] === listeners[0] };
+win.__rompConnectTimeline({ update: function (d) { updates.push(d); } });
+out.posted = posted.map(function (m) { return m.type; });
+registered[0]({ data: { type: "data", data: { lanes: 1 } } });
+out.updates = updates;
+process.stdout.write(JSON.stringify(out));
+""")
+        r = subprocess.run([node, os.path.join(fx, "run.js"), os.path.join(fx, "boot.js")],
+                           capture_output=True, text=True, timeout=60)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        out = json.loads(r.stdout)
+        self.assertEqual(out["listeners"], 1, "one window listener")
+        self.assertTrue(out["wrappedIsListener"], "…the wrapped one, so its frames are timed by type")
+        self.assertTrue(out["registeredSame"], "the SAME function is registered with federation: no frame arrives twice")
+        self.assertEqual(out["posted"], ["ready"], "the connect handshake")
+        self.assertEqual(out["updates"], [{"lanes": 1}], "a frame through the registry reached the panel")
 
     def test_the_lanes_skeleton_does_not_parse_any_transcript(self):
         # cold-start speed (the user 2026-06-26): a fresh kernel (the refresh button = POST /restart) re-parses

--- a/tests/test_kernel_timeline_split.py
+++ b/tests/test_kernel_timeline_split.py
@@ -55,9 +55,21 @@ class BuildGating(unittest.TestCase):
         # (2026-09-06); without a collector the plain listener is registered.
         boot = km._TIMELINE_BOOT
         self.assertIn("var onFrame=function(ev){var m=ev.data;if(!m||!panel)return;", boot)
-        self.assertIn('window.addEventListener("message",(window.__rompPerf&&window.__rompPerf.wrapFrameHandler)'
-                      "?window.__rompPerf.wrapFrameHandler(onFrame):onFrame);", boot)
+        self.assertIn('var frameListener=(window.__rompPerf&&window.__rompPerf.wrapFrameHandler)'
+                      "?window.__rompPerf.wrapFrameHandler(onFrame):onFrame;", boot)
+        self.assertIn('window.addEventListener("message",frameListener);', boot)
         self.assertEqual(boot.count('addEventListener("message"'), 1, "one listener, the wrapped one")
+
+    def test_the_host_shim_registers_the_same_listener_with_federation_for_direct_delivery(self):
+        # federation.js hands its merged data/bars frames to the handlers registered through window.__rompFed.onFrame
+        # by direct call, and dispatches them on window only when nothing registered (ui/webview/federation.ts
+        # emit): a "message" listener in another JavaScript world that reads event.data forces a structured clone of
+        # the frame on every window dispatch. The boot registers the SAME wrapped listener it puts on window, so a
+        # frame reaches it once, timed the same way; a page without the slot (an older federation.js) is unchanged.
+        boot = km._TIMELINE_BOOT
+        self.assertIn("if(window.__rompFed&&window.__rompFed.onFrame)window.__rompFed.onFrame(frameListener);", boot)
+        self.assertLess(boot.index('window.addEventListener("message",frameListener);'),
+                        boot.index("window.__rompFed.onFrame(frameListener)"), "window first, the registry after it")
 
     def test_the_lanes_skeleton_does_not_parse_any_transcript(self):
         # cold-start speed (the user 2026-06-26): a fresh kernel (the refresh button = POST /restart) re-parses

--- a/tests/test_kernel_trust.py
+++ b/tests/test_kernel_trust.py
@@ -218,6 +218,40 @@ class QuarantineCards(unittest.TestCase):
         self.assertEqual(km._quarantine_cards(2000, set()), [])
 
 
+class QuarantineRefusal(unittest.TestCase):
+    """The bus refusing a verdict answers the asking pane BY THE MESSAGE it was about (review find,
+    2026-09-08). The feed latches Approve/Deny ("Delivering…") on the click and re-arms them on the kernel's
+    reply for that request. The reply used to be a bare `warn`, which the feed never handled, so a refused
+    verdict left both buttons disabled until the card was re-sent, and a held message the bus refused to
+    act on is exactly the card that is never re-sent."""
+
+    def setUp(self):
+        self._saved = km._bus_quarantine_act, km._mark_views_dirty
+        self.sent, self.dirtied = [], []
+        km._mark_views_dirty = lambda: self.dirtied.append(True)
+        self.client = {"app": "feed", "wid": "w1", "alive": True,
+                       "send": lambda raw: self.sent.append(json.loads(raw))}
+
+    def tearDown(self):
+        km._bus_quarantine_act, km._mark_views_dirty = self._saved
+
+    def test_a_refused_verdict_names_the_message_it_answers(self):
+        km._bus_quarantine_act = lambda body: (False, "the recipient is no longer live")
+        km.Handler._dispatch_ws(None, {"type": "quarantineDecision", "mid": "qc-7", "action": "approve",
+                                       "sid": "11111111-2222-3333-4444-555555555555"}, self.client)
+        self.assertEqual(self.sent, [{"type": "quarantineRefused", "mid": "qc-7",
+                                      "text": "quarantine: the recipient is no longer live"}],
+                         "the reply carries the held message's id, so the feed re-arms that card's buttons alone")
+        self.assertEqual(self.dirtied, [], "a refused verdict changes no view")
+
+    def test_an_accepted_verdict_answers_nothing_and_rebuilds_the_views(self):
+        # the bus removed the held file: the next build drops the card (event-based), nothing to say
+        km._bus_quarantine_act = lambda body: (True, "")
+        km.Handler._dispatch_ws(None, {"type": "quarantineDecision", "mid": "qc-8", "action": "deny"}, self.client)
+        self.assertEqual(self.sent, [])
+        self.assertEqual(self.dirtied, [True])
+
+
 class MirrorTrust(unittest.TestCase):
     """mirror_trust (the user 2026-07-26): sets OUR level for a host as ITS level for US, through the
     tunnel forward + that machine's serve token — the human with both tokens acting on both kernels.

--- a/tests/test_view_deltas.py
+++ b/tests/test_view_deltas.py
@@ -550,6 +550,120 @@ process.stdout.write(JSON.stringify(out));"""
             self.assertEqual(out[i], payloads[i], "frame %d reassembled differently in the shim than the kernel built" % i)
         self.assertTrue(any("dictlist" in f.get("coll", {}).get("turns", {}).__class__.__name__ or True for f in frames))
 
+    def test_c_untouched_lanes_keep_their_array_identity_across_a_delta(self):
+        """A delta renews only the lane arrays it touched: the lane prefix of every set/del key, plus — when the
+        frame carries an `order` — every lane whose key subsequence changed. Every other lane's array is the very
+        object the previous message held (===), so a pane can read `turns[sid]` identity as "unchanged". The
+        assembled VALUE is unchanged either way (test_a pins that)."""
+        node = shutil.which("node")
+        if not node:
+            self.skipTest("node not installed")
+        km._delta_parts_cache.clear()
+        frac = km._DELTA_MAX_FRACTION; km._DELTA_MAX_FRACTION = 10.0
+        self.addCleanup(setattr, km, "_DELTA_MAX_FRACTION", frac)
+        S4 = "11111111-2222-3333-4444-aaaaaaaaaaa4"
+        st = _Stream("bars")
+        t0 = 1000
+        def turn(sid, n): return [{"id": "s%s-%d" % (sid[-1], i), "t": t0 - 60 * i, "end": t0 - 60 * i + 30} for i in range(n)]
+        s3rev = list(reversed(turn(S3, 3)))                       # the same three bars, the other way round
+        payloads = [
+            _bars({S1: turn(S1, 2), S2: turn(S2, 1), S3: turn(S3, 3)}, [], []),
+            _bars({S1: turn(S1, 3), S2: turn(S2, 1), S3: turn(S3, 3)}, [], [], now=1005),                   # S1 grows
+            _bars({S1: turn(S1, 3), S2: [{"id": "s2-0", "t": t0, "end": t0 + 45}], S3: turn(S3, 3)}, [], [], now=1010),   # S2's bar changes
+            _bars({S1: [], S2: [{"id": "s2-0", "t": t0, "end": t0 + 45}], S3: turn(S3, 3)}, [], [], now=1015),           # S1 empties
+            _bars({S1: [], S2: [{"id": "s2-0", "t": t0, "end": t0 + 45}], S3: s3rev}, [], [], now=1020),                 # S3 reorders
+            _bars({S1: [], S2: [{"id": "s2-0", "t": t0, "end": t0 + 45}], S3: s3rev, S4: turn(S4, 1)}, [], [], now=1025),   # S4 appears
+        ]
+        frames = []
+        for p in payloads:
+            frames += st.push(p)
+        deltas = [f for f in frames if f["type"] == "delta"]
+        self.assertEqual(len(deltas), len(payloads) - 1, "every step after the first must have shipped as a delta")
+        self.assertIn("order", deltas[3].get("coll", {}).get("turns", {}), "a within-lane reorder must ship an order")
+        fx = tempfile.mkdtemp()
+        with open(os.path.join(fx, "frames.json"), "w") as f:
+            json.dump(frames, f)
+        script = self._shim_functions() + r"""
+var frames=JSON.parse(require("fs").readFileSync(process.argv[2],"utf8"));var out=[];var prev=null;
+for(var i=0;i<frames.length;i++){var msg=frames[i];
+if(msg.type==="delta"){var full=applyDelta(msg);if(!full){out.push({error:"rejected",at:i});break;}
+var same=[],renewed=[];for(var ln in full.turns){if(prev&&Object.prototype.hasOwnProperty.call(prev.turns,ln)&&prev.turns[ln]===full.turns[ln])same.push(ln);else renewed.push(ln);}
+same.sort();renewed.sort();out.push({same:same,renewed:renewed,turns:full.turns});prev=full;}
+else if(DELTA_KINDS[msg.type]){var keys=msg._keys;delete msg._keys;LAST[msg.type]={rev:0,msg:msg,maps:buildMaps(msg,keys)};prev=msg;out.push({full:true});}}
+process.stdout.write(JSON.stringify(out));"""
+        with open(os.path.join(fx, "run.js"), "w") as f:
+            f.write(script)
+        r = subprocess.run([node, os.path.join(fx, "run.js"), os.path.join(fx, "frames.json")], capture_output=True, text=True, timeout=60)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        out = json.loads(r.stdout)
+        self.assertEqual(out[0], {"full": True})
+        steps = out[1:]
+        self.assertEqual(len(steps), 5)
+        for k, step in enumerate(steps):
+            self.assertEqual(step["turns"], payloads[k + 1]["turns"], "step %d assembled a different value" % (k + 1))
+        self.assertEqual((steps[0]["same"], steps[0]["renewed"]), (sorted([S2, S3]), [S1]))       # S1 grew
+        self.assertEqual((steps[1]["same"], steps[1]["renewed"]), (sorted([S1, S3]), [S2]))       # S2's bar changed
+        self.assertEqual((steps[2]["same"], steps[2]["renewed"]), (sorted([S2, S3]), [S1]))       # S1 emptied to the bare marker
+        self.assertEqual(steps[2]["turns"][S1], [], "an emptied lane carries the kernel's [] value")
+        self.assertEqual((steps[3]["same"], steps[3]["renewed"]), (sorted([S1, S2]), [S3]))       # S3's keys reordered: same set, new array
+        self.assertEqual((steps[4]["same"], steps[4]["renewed"]), (sorted([S1, S2, S3]), [S4]))   # S4 appeared; nothing else moved
+
+    def test_d_a_lane_that_only_loses_a_bar_is_renewed_and_carries_the_shorter_array(self):
+        """A lane whose delta is `del` alone (no `set`, no `order`: a bar retired with nothing replacing it and
+        no key crossing another) is a TOUCHED lane: it is renewed and carries the shorter array. Without the
+        `del` clause in touchedLanes the shim would hand the pane the held array, so the timeline kept showing
+        a bar the kernel removed, a value bug the identity test above never reaches because every shrinking
+        lane there also gets a `set` or an `order`."""
+        node = shutil.which("node")
+        if not node:
+            self.skipTest("node not installed")
+        km._delta_parts_cache.clear()
+        frac = km._DELTA_MAX_FRACTION; km._DELTA_MAX_FRACTION = 10.0
+        self.addCleanup(setattr, km, "_DELTA_MAX_FRACTION", frac)
+        st = _Stream("bars")
+        t0 = 1000
+        def turn(sid, n): return [{"id": "s%s-%d" % (sid[-1], i), "t": t0 - 60 * i, "end": t0 - 60 * i + 30} for i in range(n)]
+        payloads = [
+            _bars({S1: turn(S1, 2), S2: turn(S2, 1), S3: turn(S3, 3)}, [], []),
+            _bars({S1: turn(S1, 2), S2: turn(S2, 1), S3: turn(S3, 3)[:2]}, [], [], now=1005),      # S3 loses its last bar
+            _bars({S1: turn(S1, 2), S2: turn(S2, 1), S3: [turn(S3, 3)[1]]}, [], [], now=1010),     # S3 loses its first bar
+            _bars({S1: [turn(S1, 2)[1]], S2: turn(S2, 1), S3: [turn(S3, 3)[1]]}, [], [], now=1015),   # S1 loses its first bar
+        ]
+        frames = []
+        for p in payloads:
+            frames += st.push(p)
+        deltas = [f for f in frames if f["type"] == "delta"]
+        self.assertEqual(len(deltas), len(payloads) - 1, "every step after the first must have shipped as a delta")
+        for k, d in enumerate(deltas):
+            turns = d.get("coll", {}).get("turns", {})
+            self.assertIn("del", turns, "step %d must retire a key" % (k + 1))
+            self.assertNotIn("set", turns, "step %d is del-only by construction: no value changed" % (k + 1))
+            self.assertNotIn("order", turns, "step %d is del-only by construction: no key crossed another" % (k + 1))
+        fx = tempfile.mkdtemp()
+        with open(os.path.join(fx, "frames.json"), "w") as f:
+            json.dump(frames, f)
+        script = self._shim_functions() + r"""
+var frames=JSON.parse(require("fs").readFileSync(process.argv[2],"utf8"));var out=[];var prev=null;
+for(var i=0;i<frames.length;i++){var msg=frames[i];
+if(msg.type==="delta"){var full=applyDelta(msg);if(!full){out.push({error:"rejected",at:i});break;}
+var same=[],renewed=[];for(var ln in full.turns){if(prev&&Object.prototype.hasOwnProperty.call(prev.turns,ln)&&prev.turns[ln]===full.turns[ln])same.push(ln);else renewed.push(ln);}
+same.sort();renewed.sort();out.push({same:same,renewed:renewed,turns:full.turns});prev=full;}
+else if(DELTA_KINDS[msg.type]){var keys=msg._keys;delete msg._keys;LAST[msg.type]={rev:0,msg:msg,maps:buildMaps(msg,keys)};prev=msg;out.push({full:true});}}
+process.stdout.write(JSON.stringify(out));"""
+        with open(os.path.join(fx, "run.js"), "w") as f:
+            f.write(script)
+        r = subprocess.run([node, os.path.join(fx, "run.js"), os.path.join(fx, "frames.json")], capture_output=True, text=True, timeout=60)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        out = json.loads(r.stdout)
+        self.assertEqual(out[0], {"full": True})
+        steps = out[1:]
+        self.assertEqual(len(steps), 3)
+        for k, step in enumerate(steps):
+            self.assertEqual(step["turns"], payloads[k + 1]["turns"], "step %d assembled a different value (a retired bar still shown?)" % (k + 1))
+        self.assertEqual((steps[0]["same"], steps[0]["renewed"]), (sorted([S1, S2]), [S3]))       # S3 shrank from the end
+        self.assertEqual((steps[1]["same"], steps[1]["renewed"]), (sorted([S1, S2]), [S3]))       # S3 shrank from the front
+        self.assertEqual((steps[2]["same"], steps[2]["renewed"]), (sorted([S2, S3]), [S1]))       # S1 shrank; S3 kept its new array
+
     def test_b_a_delta_whose_base_is_not_held_is_refused(self):
         node = shutil.which("node")
         if not node:

--- a/tests/test_view_deltas.py
+++ b/tests/test_view_deltas.py
@@ -608,6 +608,48 @@ process.stdout.write(JSON.stringify(out));"""
         self.assertEqual((steps[3]["same"], steps[3]["renewed"]), (sorted([S1, S2]), [S3]))       # S3's keys reordered: same set, new array
         self.assertEqual((steps[4]["same"], steps[4]["renewed"]), (sorted([S1, S2, S3]), [S4]))   # S4 appeared; nothing else moved
 
+    def test_e_untouched_feed_cards_keep_their_object_identity_across_a_delta(self):
+        """The feed's per-card update gate (ui/webview/feed-card-gate.ts) repaints a card when its OBJECT changed,
+        so the shim's reassembly must hand every untouched card through as the very object the previous message
+        held (===) and mint a new one only for a card the delta set. Held here, in the lane that owns the shim
+        (review find, 2026-09-08: the TypeScript lane had lifted kernel.py's shim by source text to check this,
+        and a kernel edit must not break that lane). The assembled VALUE is the kernel's payload either way."""
+        node = shutil.which("node")
+        if not node:
+            self.skipTest("node not installed")
+        km._delta_parts_cache.clear()
+        frac = km._DELTA_MAX_FRACTION; km._DELTA_MAX_FRACTION = 10.0
+        self.addCleanup(setattr, km, "_DELTA_MAX_FRACTION", frac)
+        def ask(i, column="working"):
+            return {"itemId": "awaiting:g%d" % i, "sid": S1, "column": column, "text": "do the thing", "color": None, "trail": [1, 2, 3]}
+        st = _Stream("feed")
+        payloads = [_feed([ask(1), ask(2), ask(3)]),
+                    _feed([ask(1), ask(2, column="done"), ask(3)], now=1005)]   # one card moves; the other two are untouched
+        frames = []
+        for p in payloads:
+            frames += st.push(p)
+        self.assertEqual([f["type"] for f in frames], ["feed", "delta"])
+        self.assertEqual(set(frames[1]["coll"]["asks"]["set"]), {"awaiting:g2"}, "only the moved card crosses")
+        fx = tempfile.mkdtemp()
+        with open(os.path.join(fx, "frames.json"), "w") as f:
+            json.dump(frames, f)
+        script = self._shim_functions() + r"""
+var frames=JSON.parse(require("fs").readFileSync(process.argv[2],"utf8"));
+var full=frames[0],keys=full._keys;delete full._keys;LAST[full.type]={rev:0,msg:full,maps:buildMaps(full,keys)};
+var next=applyDelta(frames[1]);if(!next){process.stdout.write(JSON.stringify({error:"rejected"}));process.exit(0);}
+var same=[];for(var i=0;i<next.asks.length;i++)same.push(next.asks[i]===full.asks[i]);
+process.stdout.write(JSON.stringify({newMessage:next!==full,same:same,asks:next.asks}));"""
+        with open(os.path.join(fx, "run.js"), "w") as f:
+            f.write(script)
+        r = subprocess.run([node, os.path.join(fx, "run.js"), os.path.join(fx, "frames.json")], capture_output=True, text=True, timeout=60)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        out = json.loads(r.stdout)
+        self.assertNotIn("error", out, "the delta applies over the keyed full frame")
+        self.assertTrue(out["newMessage"], "a delta builds a NEW message object (the bundle may still hold the previous one)")
+        self.assertEqual(out["same"], [True, False, True],
+                         "the untouched cards are the same objects (the gate skips them); the moved card is a new one (the gate repaints it)")
+        self.assertEqual(out["asks"], payloads[1]["asks"], "…and the value is the kernel's")
+
     def test_d_a_lane_that_only_loses_a_bar_is_renewed_and_carries_the_shorter_array(self):
         """A lane whose delta is `del` alone (no `set`, no `order`: a bar retired with nothing replacing it and
         no key crossing another) is a TOUCHED lane: it is renewed and carries the shorter array. Without the

--- a/ui/webview/awaiting-box-sync.test.ts
+++ b/ui/webview/awaiting-box-sync.test.ts
@@ -80,7 +80,7 @@ test("the chip and the box gist take the kind word from ONE count (T225 rider)",
   assert.match(RENDER, /const word = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, items\);/);   // `s` is narrowed by the one renderer's gate since 2026-09-06 (no `s!`)
   assert.match(RENDER, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace/);
   // the feed pill and the spin caption derive their word the same way
-  assert.match(FEED, /import \{ spinFor, waitedSuffix, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);
+  assert.match(FEED, /import \{ spinFor, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);
   assert.match(FEED, /const pillWord = awaitWord\(awKind, \(it\.awaiting && it\.awaiting\.count\) \?\? taskRows\.length, taskRows\);/);
   assert.match(SPIN, /const word = kindWord\(aw\.kind, aw\.count\);/);
   assert.match(SPIN, /export function kindWord\(kind: string \| null \| undefined, count: number \| null \| undefined\): string \{/);

--- a/ui/webview/brief-parts.test.ts
+++ b/ui/webview/brief-parts.test.ts
@@ -61,8 +61,8 @@ test("the trailing still-open paragraph renders unstamped, and only the item par
   assert.ok(FEED.includes("if (stampOk && i < bp!.length) {"),
     "the chip is appended only for paragraphs that HAVE a part; the extra one gets none");
   const block = FEED.slice(FEED.indexOf("// PER-PARAGRAPH ages"), FEED.indexOf("// The distiller line is a LINK"));
-  assert.ok(/paras\.forEach\(\(p, i\) => \{[\s\S]*?if \(stampOk && i < bp!\.length\) \{[\s\S]*?relAge\(nowS - \(bp!\[i\]\.since/.test(block),
-    "the guard wraps the relAge lookup itself, so bp[i] is never read past the end");
+  assert.ok(/paras\.forEach\(\(p, i\) => \{[\s\S]*?if \(stampOk && i < bp!\.length\) \{[\s\S]*?if \(bp!\[i\]\.since\) stampAge\(age, bp!\[i\]\.since/.test(block),
+    "the guard wraps the stamp's since lookup itself, so bp[i] is never read past the end");
   assert.ok(block.includes("ONE EXTRA TRAILING PARAGRAPH"), "the why is recorded where the gate lives");
 });
 
@@ -72,8 +72,9 @@ test("the trailing still-open paragraph renders unstamped, and only the item par
 
 test("each paragraph wears its own live age chip", () => {
   assert.ok(FEED.includes('el("span", "fask-para-age")'));
-  assert.ok(FEED.includes("relAge(nowS - (bp![i].since || nowS))"),
-    "the ask's OWN block-event age, via the shared relAge vocabulary");
+  assert.ok(FEED.includes('if (bp![i].since) stampAge(age, bp![i].since, "plain", false, nowS, relAge, ageColorReadable);'),
+    "the ask's OWN block-event age, via the shared relAge vocabulary — stamped, so the 15 s live pass moves it on a card the update gate does not repaint");
+  assert.ok(FEED.includes('else age.textContent = relAge(0);'), "no event time → the static chip it always showed, unstamped (nothing to count from)");
 });
 
 test("the chip inherits the brief's font size — dimness is the only differentiation", () => {

--- a/ui/webview/chat-exact-tail-exec.test.ts
+++ b/ui/webview/chat-exact-tail-exec.test.ts
@@ -1,0 +1,248 @@
+// The chat's exact tail path, EXECUTED: chatTail and patchWorkedFooters lifted from render.ts and driven over
+// stubs and a minimal fake DOM, the way tab-strip-skip-exec.test.ts lifts renderTabs. chat-exact-tail.test.ts
+// pins the SHAPE of what no harness lifts (syncViewInner, reconcileRewind, the frame paths); this file drives
+// the BEHAVIOUR of the two functions it can: the kernel's `from` is where the tail re-renders from, a shrunken
+// tail or a change inside a window the reader scrolled away from still rebuilds the window, chatTail hands its
+// `from` to the rewind pass as the bound, a gap asks for the full session; and the footer patch adds, removes
+// and re-homes the fork spot by unit, skips a day divider sharing its turn's unit number, maps compact-mode
+// units, and marks the view stale for a reply folded into a run. Synthetic events; epochs are seconds.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import { workedFooterPlan } from "./worked-footer";
+
+const requireCjs = createRequire(__filename);
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+/** A render.ts function, transpiled (TS → JS) with esbuild at run time, required dynamically so the test bundle
+ *  does not try to bundle esbuild itself (the models-rev.test.ts pattern). */
+function liftBetween(startAnchor: string, endAnchor: string): string {
+  const a = RENDER.indexOf(startAnchor), b = RENDER.indexOf(endAnchor, a);
+  assert.ok(a > 0 && b > a, `anchors not found: ${startAnchor.slice(0, 40)} or ${endAnchor.slice(0, 40)} moved; re-anchor`);
+  return requireCjs("esbuild").transformSync(RENDER.slice(a, b), { loader: "ts" }).code;
+}
+
+// ── chatTail ──────────────────────────────────────────────────────────────────────────────────────
+
+type TailHooks = { fulls: string[]; strips: number; rewinds: [string, number | undefined][]; optRecs: number;
+                   tabRenders: number; appends: number; bgRenders: number; prebuilds: number };
+type TailApi = { chatTail: (msg: any) => void; set: (p: { sessions?: Map<string, any>; views?: Map<string, any>; activeId?: string | null }) => void };
+
+function liftChatTail(): (hooks: TailHooks) => TailApi {
+  const js = liftBetween("function chatTail(msg: any) {", "// Older history streaming in from a loadOlder request");
+  const prelude = `
+    let sessions = new Map(), views = new Map(), activeId = null;
+    const ledgers = new Map();
+    const H = HOOKS;
+    const requestFullSession = (id) => { H.fulls.push(id); };
+    const isOptimistic = (e) => !!e.opt;
+    const stripOptimistic = (s) => { s.events = s.events.filter((e) => !e.opt); H.strips++; };
+    const reconcileRewind = (s, bound) => { H.rewinds.push([s.id, bound]); };
+    const reconcileOptimistic = () => { H.optRecs++; };
+    const awaitKey = (st) => JSON.stringify((st && st.awaitingWhy) || "");
+    const scheduleRenderTabs = () => { H.tabRenders++; };
+    const scheduleAppendActive = () => { H.appends++; };
+    const renderBgTasks = () => { H.bgRenders++; };
+    const schedulePrebuild = () => { H.prebuilds++; };
+  `;
+  const epilogue = `
+    return { chatTail, set: (p) => { if (p.sessions) sessions = p.sessions; if (p.views) views = p.views; if ("activeId" in p) activeId = p.activeId; } };
+  `;
+  return new Function("HOOKS", prelude + js + epilogue) as (hooks: TailHooks) => TailApi;
+}
+
+const kernelEvents = (n: number) => Array.from({ length: n }, (_, i) => ({ kind: i % 2 ? "assistant" : "user", uuid: "e" + i }));
+function tailWorld(opts: { rendered: number; winEnd: number; unitTotal: number; active: boolean; headFrom?: number; opt?: boolean }) {
+  const H: TailHooks = { fulls: [], strips: 0, rewinds: [], optRecs: 0, tabRenders: 0, appends: 0, bgRenders: 0, prebuilds: 0 };
+  const api = liftChatTail()(H);
+  const events: any[] = kernelEvents(10);
+  if (opts.opt) events.splice(6, 0, { kind: "user", uuid: "opt-1", opt: true });   // a bubble at its send slot, mid-array
+  const s: any = { id: "A", events, status: { state: "working" }, headFrom: opts.headFrom };
+  const v: any = { rendered: opts.rendered, stale: false, winStart: 0, winEnd: opts.winEnd, unitTotal: opts.unitTotal, el: {} };
+  api.set({ sessions: new Map([["A", s]]), views: new Map([["A", v]]), activeId: opts.active ? "A" : "B" });
+  return { H, api, s, v };
+}
+
+test("the active view re-renders from the kernel's exact first changed event; the rewind pass is bounded there", () => {
+  const { H, api, s, v } = tailWorld({ rendered: 10, winEnd: 10, unitTotal: 10, active: true });
+  api.chatTail({ id: "A", from: 7, events: [{ kind: "assistant", uuid: "e7b" }, { kind: "user", uuid: "e8b" }, { kind: "assistant", uuid: "e9b" }] });
+  assert.equal(v.rendered, 7, "repaint from the exact changed point, not a trailing window");
+  assert.equal(v.stale, false, "nothing earlier changed: no window rebuild");
+  assert.deepEqual(s.events.slice(7).map((e: any) => e.uuid), ["e7b", "e8b", "e9b"], "the suffix is replaced from `from`");
+  assert.deepEqual(H.rewinds, [["A", 7]], "chatTail passes its from as the bound: the editable set is judged below the tail's start");
+  assert.equal(H.appends, 1, "one paint scheduled"); assert.equal(H.tabRenders, 1); assert.deepEqual(H.fulls, []);
+  api.chatTail({ id: "A", from: 9, events: [{ kind: "assistant", uuid: "e9c" }] });
+  assert.equal(v.rendered, 7, "an earlier re-render start stands: min(rendered, from)");
+});
+
+test("a tail that shrinks the transcript rebuilds the window: rendered would equal the length and the fast path would skip the repaint", () => {
+  const { api, s, v } = tailWorld({ rendered: 10, winEnd: 10, unitTotal: 10, active: true });
+  api.chatTail({ id: "A", from: 9, events: [] });   // the last queued message retired with nothing in its place
+  assert.equal(s.events.length, 9);
+  assert.equal(v.rendered, 9);
+  assert.equal(v.stale, true, "a pure truncation marks the view stale");
+});
+
+/** A suffix replacing events [from, 10) one for one: the transcript keeps its length, so the shrink rule (its own
+ *  test above) stays out of these cases and what they show is the window rule alone. */
+const sameLengthFrom = (from: number) => Array.from({ length: 10 - from }, (_, i) => ({ kind: (from + i) % 2 ? "assistant" : "user", uuid: "r" + (from + i) }));
+
+test("a background view: a change inside a window the reader scrolled away from rebuilds it; one below the window, or at the tail, repaints from `from`", () => {
+  const away = tailWorld({ rendered: 10, winEnd: 6, unitTotal: 10, active: false });   // window [0,6) of 10 units: not at the tail
+  away.api.chatTail({ id: "A", from: 8, events: sameLengthFrom(8) });
+  assert.equal(away.v.stale, false, "the change lies below the window: the incremental path's assumption holds");
+  assert.equal(away.v.rendered, 8);
+  away.api.chatTail({ id: "A", from: 4, events: sameLengthFrom(4) });
+  assert.equal(away.v.stale, true, "the change landed inside the scrolled-away window (nothing shrank): rebuild");
+  assert.equal(away.H.prebuilds, 2, "the off-screen view is rebuilt in idle either way");
+  assert.equal(away.H.appends, 0, "no active paint for a background tab");
+  const atTail = tailWorld({ rendered: 10, winEnd: 10, unitTotal: 10, active: false });
+  atTail.api.chatTail({ id: "A", from: 4, events: sameLengthFrom(4) });
+  assert.equal(atTail.v.stale, false, "at the tail, an exact repaint from `from` is enough");
+  assert.equal(atTail.v.rendered, 4);
+});
+
+test("a delta starting past what the client holds is a desync: ask for the full session, touch nothing; below the loaded head, nothing", () => {
+  const { H, api, s, v } = tailWorld({ rendered: 10, winEnd: 10, unitTotal: 10, active: true });
+  api.chatTail({ id: "A", from: 11, events: [{ kind: "user", uuid: "q" }] });
+  assert.deepEqual(H.fulls, ["A"]);
+  assert.equal(s.events.length, 10); assert.equal(v.rendered, 10); assert.deepEqual(H.rewinds, []);
+  api.chatTail({ id: "Z", from: 0, events: [] });
+  assert.deepEqual(H.fulls, ["A", "Z"], "a session the client holds no base for asks too");
+  const headed = tailWorld({ rendered: 10, winEnd: 10, unitTotal: 10, active: true, headFrom: 5 });
+  headed.api.chatTail({ id: "A", from: 3, events: [] });   // global index 3 < headFrom 5: our resident tail is still valid
+  assert.equal(headed.s.events.length, 10); assert.deepEqual(headed.H.rewinds, []);
+  headed.api.chatTail({ id: "A", from: 12, events: [{ kind: "user", uuid: "n" }] });   // global 12 → local 7
+  assert.equal(headed.v.rendered, 7, "msg.from is a global index: mapped through headFrom");
+});
+
+test("an optimistic bubble is not in the kernel's coordinate space: the gap check counts kernel events, and the bubble is stripped before the delta applies", () => {
+  const { H, api, s, v } = tailWorld({ rendered: 11, winEnd: 11, unitTotal: 11, active: true, opt: true });
+  assert.equal(s.events.length, 11);
+  api.chatTail({ id: "A", from: 10, events: [{ kind: "user", uuid: "e10" }] });   // one past the kernel's ten: an append, not a gap
+  assert.deepEqual(H.fulls, [], "ten kernel events held: from = 10 is the next one");
+  assert.equal(H.strips, 1);
+  assert.deepEqual(s.events.map((e: any) => e.uuid).slice(9), ["e9", "e10"], "the bubble is gone and the delta appended in kernel coordinates");
+  assert.equal(H.optRecs, 1, "…and the in-flight send is re-asserted or retired after");
+  assert.equal(v.rendered, 10);
+});
+
+test("a status-only tail (empty suffix) replaces the status and re-renders the awaiting box only when the awaited fields changed", () => {
+  const { H, api, s, v } = tailWorld({ rendered: 10, winEnd: 10, unitTotal: 10, active: true });
+  api.chatTail({ id: "A", from: 10, events: [], status: { state: "ready" } });
+  assert.equal(s.status.state, "ready"); assert.equal(v.rendered, 10); assert.equal(v.stale, false);
+  assert.equal(H.bgRenders, 0, "no awaited field changed");
+  api.chatTail({ id: "A", from: 10, events: [], status: { state: "working", awaitingWhy: "agents" } });
+  assert.equal(H.bgRenders, 1, "the awaiting box renders from the same frame that flips the chip");
+});
+
+// ── patchWorkedFooters ────────────────────────────────────────────────────────────────────────────
+
+/** Enough of Element for the footer patch: children, a class list, data-unit, and the two selector shapes it uses. */
+class FakeEl {
+  children: FakeEl[] = []; parent: FakeEl | null = null; dataset: Record<string, string> = {}; textContent = ""; title = "";
+  constructor(public tag: string, public className = "") {}
+  has(c: string): boolean { return this.className.split(/\s+/).includes(c); }
+  appendChild(c: FakeEl): FakeEl { c.parent?.removeChild(c); c.parent = this; this.children.push(c); return c; }
+  removeChild(c: FakeEl): void { this.children = this.children.filter((x) => x !== c); c.parent = null; }
+  remove(): void { this.parent?.removeChild(this); }
+  querySelector(sel: string): FakeEl | null {
+    // ':scope > [data-unit="N"]:not(.day-divider)' and ':scope > .cls', the patch's two shapes
+    const m = /^:scope > (.+)$/.exec(sel);
+    if (!m) throw new Error("unsupported selector " + sel);
+    const attr = /\[data-unit="([^"]*)"\]/.exec(m[1]), cls = /^\.([\w-]+)/.exec(m[1]), not = /:not\(\.([\w-]+)\)/.exec(m[1]);
+    return this.children.find((c) => (!attr || c.dataset.unit === attr[1]) && (!cls || c.has(cls[1])) && (!not || !c.has(not[1]))) ?? null;
+  }
+}
+type FootHooks = { FakeEl: typeof FakeEl; workedFooterPlan: typeof workedFooterPlan };
+type Patch = (v: any, s: any, from: number, working: boolean, items?: any[] | null) => void;
+
+function liftPatch(): (hooks: FootHooks) => Patch {
+  const js = liftBetween("function patchWorkedFooters(", "// prevEpoch for event i");
+  const prelude = `
+    const H = HOOKS;
+    const workedFooterPlan = H.workedFooterPlan;
+    const eventEpoch = (ev) => (ev.t == null ? null : ev.t);
+    const itemFirstEvent = (it) => (it.kind === "toolgroup" || it.kind === "retrygroup" ? it.indices[0] : it.index);
+    const elapsedFooter = (secs) => { const f = new H.FakeEl("div", "turn-elapsed"); f.textContent = String(secs); return f; };
+  `;
+  return new Function("HOOKS", prelude + js + "\nreturn patchWorkedFooters;") as (hooks: FootHooks) => Patch;
+}
+
+const user = (t: number) => ({ kind: "user", human: true, t });
+const reply = (t: number) => ({ kind: "assistant", t });
+const tool = (t: number) => ({ kind: "tool", t });
+/** A rendered window: one node per unit tagged data-unit, unit `spotOn` carrying a fork spot. */
+function footWorld(events: any[], units: number, spotOn: number) {
+  const patch = liftPatch()({ FakeEl, workedFooterPlan });
+  const el = new FakeEl("div");
+  const nodes: FakeEl[] = [];
+  for (let u = 0; u < units; u++) { const n = new FakeEl("div", "turn"); n.dataset.unit = String(u); el.appendChild(n); nodes.push(n); }
+  const spot = new FakeEl("span", "fork-spot"); nodes[spotOn].appendChild(spot);
+  const v: any = { el, winStart: 0, stale: false };
+  return { patch, v, s: { events }, nodes, spot };
+}
+
+test("the footer patch adds the elapsed row to the turn's last reply once its turn completes, moving the fork spot into it; a repeat adds nothing", () => {
+  const events = [user(100), tool(110), reply(160), user(200)];
+  const { patch, v, s, nodes, spot } = footWorld(events, 4, 2);
+  patch(v, s, 3, true);                                          // the prompt at 3 just landed: the tail re-rendered [3, 4)
+  const f = nodes[2].querySelector(":scope > .turn-elapsed");
+  assert.ok(f, "the reply before `from` gained its footer"); assert.equal(f!.textContent, "60");
+  assert.equal(spot.parent, f, "the fork spot moved into the new elapsed row, where applyForkSpots places it");
+  assert.equal(nodes[3].querySelector(":scope > .turn-elapsed"), null, "the prompt carries none");
+  patch(v, s, 3, true);
+  assert.equal(nodes[2].children.filter((c) => c.has("turn-elapsed")).length, 1, "already there: not added twice");
+  assert.equal(v.stale, false);
+});
+
+test("…and takes it off when a reply lands in the same turn (the footer moved to the new last reply), the spot back onto the turn", () => {
+  const { patch, v, s, nodes, spot } = footWorld([user(100), tool(110), reply(160), user(200)], 4, 2);
+  patch(v, s, 3, true);
+  s.events = [user(100), tool(110), reply(160), reply(170)];   // the kernel replaced the suffix: another reply, same turn
+  patch(v, s, 3, true);
+  assert.equal(nodes[2].querySelector(":scope > .turn-elapsed"), null, "demoted: no longer the turn's last reply");
+  assert.equal(spot.parent, nodes[2], "the fork spot is back on the turn itself");
+});
+
+test("the session going idle with an empty suffix (from = len) completes the final turn; going back to work takes the footer off again", () => {
+  const events = [user(100), tool(110), reply(160)];
+  const { patch, v, s, nodes } = footWorld(events, 3, 2);
+  patch(v, s, 3, true);
+  assert.equal(nodes[2].querySelector(":scope > .turn-elapsed"), null, "still working: the live spinner owns the final turn");
+  patch(v, s, 3, false);
+  assert.equal(nodes[2].querySelector(":scope > .turn-elapsed")?.textContent, "60", "idle: the footer");
+  patch(v, s, 3, true);
+  assert.equal(nodes[2].querySelector(":scope > .turn-elapsed"), null, "a nudge put it back to work on the same turn");
+});
+
+test("a day divider shares its turn's unit number and is never the footer's home", () => {
+  const { patch, v, s, nodes } = footWorld([user(100), tool(110), reply(160), user(200)], 4, 2);
+  const divider = new FakeEl("div", "day-divider"); divider.dataset.unit = "2";
+  v.el.children.splice(2, 0, divider); divider.parent = v.el;   // the divider precedes its turn in the DOM
+  patch(v, s, 3, true);
+  assert.equal(divider.children.length, 0, "the divider got nothing");
+  assert.ok(nodes[2].querySelector(":scope > .turn-elapsed"), "the turn did");
+});
+
+test("compact mode: the window start is a unit and the plan wants an event index; the reply's event maps back to its unit; a reply folded into a run marks the view stale", () => {
+  const events = [user(100), tool(110), tool(120), reply(160), user(200)];
+  // units: the prompt, one folded tool run, the reply, the prompt
+  const items = [{ kind: "event", index: 0 }, { kind: "toolgroup", indices: [1, 2] }, { kind: "event", index: 3 }, { kind: "event", index: 4 }];
+  const { patch, v, s, nodes } = footWorld(events, 4, 2);
+  patch(v, s, 4, true, items);
+  assert.ok(nodes[2].querySelector(":scope > .turn-elapsed"), "event 3 is unit 2: the footer lands on the reply's unit");
+  assert.equal(v.stale, false);
+  // the reply itself folded into a retry run: no unit is addressable → the window path re-renders
+  const folded = [{ kind: "event", index: 0 }, { kind: "retrygroup", indices: [1, 2, 3] }, { kind: "event", index: 4 }];
+  const w2 = footWorld(events, 3, 1);
+  w2.patch(w2.v, w2.s, 4, true, folded);
+  assert.equal(w2.v.stale, true, "unit < 0: stale, so the window path draws the footer");
+  assert.ok(w2.nodes.every((n) => !n.querySelector(":scope > .turn-elapsed")), "…and nothing was patched by hand");
+  // a window whose start unit is past the items: winEv falls to the event count, so the plan sees no reply before it
+  const w3 = footWorld(events, 4, 2); w3.v.winStart = 9;
+  w3.patch(w3.v, w3.s, 4, true, items);
+  assert.ok(w3.nodes.every((n) => !n.querySelector(":scope > .turn-elapsed")));
+});

--- a/ui/webview/chat-exact-tail.test.ts
+++ b/ui/webview/chat-exact-tail.test.ts
@@ -3,8 +3,9 @@
 // trailing window that was most of a tail's render and stood in for two signals the client can give itself:
 // a reconcile pass that touched a prefix event (the editable set, the rewind dim) marks the view stale, and a
 // full session frame for a held session rebuilds the window. The one render that depends on later events, the
-// "worked …" footer, is patched by unit (worked-footer.ts, its own executed tests). Source pins: no harness
-// executes render.ts.
+// "worked …" footer, is patched by unit (worked-footer.ts, its own executed tests). chatTail and
+// patchWorkedFooters are lifted and RUN by chat-exact-tail-exec.test.ts (review find, 2026-09-08); the pins
+// here cover what no harness lifts: syncViewInner's wiring, reconcileRewind's delegation, the frame paths.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -43,13 +44,12 @@ test("a full frame for a held session and a wholesale events replacement rebuild
   assert.match(upd, /if \(msg\.events\) \{ const v0 = views\.get\(msg\.id\); if \(v0\) v0\.stale = true; \}/);
 });
 
-test("the footer patch adds, removes and re-homes the fork spot with the elapsed row, by unit and never a divider", () => {
-  const fn = RENDER.slice(RENDER.indexOf("function patchWorkedFooters("), RENDER.indexOf("function patchWorkedFooters(") + 1500);
-  assert.match(fn, /workedFooterPlan\(s\.events, from, winEv, working, eventEpoch\)/);
-  assert.match(fn, /:scope > \[data-unit="\$\{unit\}"\]:not\(\.day-divider\)/, "a day divider shares its turn's unit number");
-  assert.match(fn, /if \(secs != null && !have\) \{[\s\S]*?node\.appendChild\(f\);\s*\n\s*if \(spot\) f\.appendChild\(spot\);/, "the fork spot moves into the new elapsed row, where applyForkSpots places it");
-  assert.match(fn, /\} else if \(secs == null && have\) \{[\s\S]*?if \(spot\) node\.appendChild\(spot\);\s*\n\s*have\.remove\(\);/, "…and back onto the turn when the footer comes off");
+test("the render and the footer patch share one elapsed rule", () => {
+  // the patch itself (add, remove, the fork spot's re-homing, the day-divider skip, compact-mode units) runs in
+  // chat-exact-tail-exec.test.ts; this pins that the render's per-turn footer reads the same module rule
   assert.match(RENDER, /function turnWorkedSecs\(events: ChatEvent\[\], i: number, working: boolean\): number \| null \{\s*\n\s*return workedSecsOf\(events, i, working, eventEpoch\);/, "one rule for the render and the patch");
+  const fn = RENDER.slice(RENDER.indexOf("function patchWorkedFooters("), RENDER.indexOf("function patchWorkedFooters(") + 1500);
+  assert.match(fn, /workedFooterPlan\(s\.events, from, winEv, working, eventEpoch\)/, "the patch takes its plan from the module");
 });
 
 test("a status-only tail reaches the footer: the view remembers the working state, and a flip patches from the fast path with from = len", () => {
@@ -60,10 +60,6 @@ test("a status-only tail reaches the footer: the view remembers the working stat
   assert.match(sync, /const workFlip = v\.working != null && v\.working !== working;\s*\n\s*v\.working = working;/);
   assert.match(sync, /if \(workFlip && v\.rendered === len && !v\.stale && v\.el\.childNodes\.length > 0\) \{\s*\n\s*patchWorkedFooters\(v, s, len, working, settings\.compact \? items : null\);\s*\n\s*\}\s*\n\s*if \(v\.rendered === len && !v\.stale && v\.el\.childNodes\.length > 0\) return v;/,
     "the flip patches just ahead of the fast path under its predicate, and the fast path (its line pinned by other tests) still returns; a patch that could not address the unit marks stale, so the window path re-renders");
-  const fn = RENDER.slice(RENDER.indexOf("function patchWorkedFooters("), RENDER.indexOf("function patchWorkedFooters(") + 2200);
-  assert.match(fn, /const winEv = items \? \(items\[winStart\] \? itemFirstEvent\(items\[winStart\]\) : s\.events\.length\) : winStart;/, "compact mode: the window start is a unit, the plan wants an event index");
-  assert.match(fn, /items\.findIndex\(\(it\) => it\.kind === "event" && it\.index === i\)/, "…and the reply's event index maps back to its unit");
-  assert.match(fn, /if \(unit < 0\) \{ v\.stale = true; continue; \}/, "a reply folded into a run: the window path re-renders");
 });
 
 test("a plain human-prompt append does not set stale: the signature reads the prefix below the tail's re-render start", () => {
@@ -71,10 +67,6 @@ test("a plain human-prompt append does not set stale: the signature reads the pr
   // rebuilt the whole window; the tail renders everything at or past `from` itself (executed:
   // rewind-reconcile.test.ts; here, that chatTail hands its `from` over as the bound)
   assert.match(RENDER, /function reconcileRewind\(s: Session, bound\?: number\): void \{/);
-  const tail = RENDER.slice(RENDER.indexOf("function chatTail(msg: any) {"), RENDER.indexOf("function statusOnly(msg: any) {"));
-  assert.match(tail, /reconcileRewind\(s, from\);/, "chatTail passes its from as the bound");
-  // the base's own rules for when the exact tail is NOT enough stand: a shrunken tail, and a change inside a
-  // window the reader scrolled away from, still rebuild the window
-  assert.match(tail, /v\.rendered = Math\.min\(v\.rendered, from\);\s*\/\/ repaint from the exact changed point/);
-  assert.match(tail, /if \(shrank \|\| \(!atTail && from < \(v\.winEnd \?\? 0\)\)\) v\.stale = true;/);
+  // (that chatTail hands its `from` over as the bound, lowers v.rendered to it, and still rebuilds the window on a
+  // shrunken tail or a change inside a scrolled-away window, runs in chat-exact-tail-exec.test.ts)
 });

--- a/ui/webview/chat-exact-tail.test.ts
+++ b/ui/webview/chat-exact-tail.test.ts
@@ -1,0 +1,80 @@
+// The chat's tail path re-renders exactly what changed. The kernel's chatTail names the first changed event;
+// the client used to re-render from min(that, len - 25) "in case an earlier event mutated in place" — a
+// trailing window that was most of a tail's render and stood in for two signals the client can give itself:
+// a reconcile pass that touched a prefix event (the editable set, the rewind dim) marks the view stale, and a
+// full session frame for a held session rebuilds the window. The one render that depends on later events, the
+// "worked …" footer, is patched by unit (worked-footer.ts, its own executed tests). Source pins: no harness
+// executes render.ts.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("the tail path starts at the exact first changed event; the trailing re-check window is gone", () => {
+  assert.doesNotMatch(RENDER, /const TAIL_RECHECK = \d+;/);
+  assert.doesNotMatch(RENDER, /len - TAIL_RECHECK/);
+  const sync = RENDER.slice(RENDER.indexOf("function syncViewInner("), RENDER.indexOf("function patchWorkedFooters("));
+  assert.match(sync, /const from = Math\.max\(v\.rendered, v\.winStart \?\? 0\);/);
+  assert.match(sync, /patchWorkedFooters\(v, s, from, working\);\s*\n\s*v\.winEnd = total;/, "the footers are reconciled after the exact re-render, before the bookkeeping");
+});
+
+test("reconcileRewind delegates to the pure pass and marks the view stale on its signal, on every path", () => {
+  // the pass and the stale signal are rewind-reconcile.ts, executed by rewind-reconcile.test.ts (a compaction at
+  // `from`, a TTL expiry on a full or partial tail, a plain prompt append); render.ts keeps the session's set,
+  // the pending entry and the view mark
+  const fn = RENDER.slice(RENDER.indexOf("function reconcileRewind("), RENDER.indexOf("// Tab name+color from the kernel's tabOrder push"));
+  assert.match(fn, /const r = reconcileRewindPass\(s\.events as RewindEvent\[\], \(s as any\)\._editable, pendingRewind\.get\(s\.id\),\s*\n\s*\{ sdk: s\.status\?\.backend === "sdk", now: Date\.now\(\), ttlMs: REWIND_TTL_MS, optPrefix: OPT_PREFIX, bound \}\);/);
+  assert.match(fn, /\(s as any\)\._editable = r\.editable;/);
+  assert.match(fn, /if \(!r\.pending\) pendingRewind\.delete\(s\.id\);/);
+  assert.match(fn, /if \(v && r\.stale\) v\.stale = true;/);
+  assert.doesNotMatch(fn, /\n\s*return;\s*\n/, "no early return skips the mark");
+  assert.doesNotMatch(RENDER, /function rewindSig\(/, "one signature, in the module");
+});
+
+test("a full frame for a held session and a wholesale events replacement rebuild the window (the tail path trusts v.rendered)", () => {
+  const up = RENDER.slice(RENDER.indexOf("function upsert(msg: any) {"), RENDER.indexOf("function update(msg: any) {"));
+  // `!kept`: a frame that carried no events for a session with content keeps the resident events (T249b,
+  // frame-merge.ts) — nothing was replaced, so a status-shaped frame leaves the view as it is
+  assert.match(up, /\} else if \(existed && !kept\) \{[\s\S]{0,900}?const v = views\.get\(msg\.id\);\s*\n\s*if \(v\) v\.stale = true;\s*\n\s*\}/);
+  assert.ok(up.indexOf("const kept = keepResidentEvents(") < up.indexOf("} else if (existed && !kept) {"), "the keep decision precedes the stale mark");
+  const upd = RENDER.slice(RENDER.indexOf("function update(msg: any) {"), RENDER.indexOf("function update(msg: any) {") + 1200);
+  assert.match(upd, /if \(msg\.events\) \{ const v0 = views\.get\(msg\.id\); if \(v0\) v0\.stale = true; \}/);
+});
+
+test("the footer patch adds, removes and re-homes the fork spot with the elapsed row, by unit and never a divider", () => {
+  const fn = RENDER.slice(RENDER.indexOf("function patchWorkedFooters("), RENDER.indexOf("function patchWorkedFooters(") + 1500);
+  assert.match(fn, /workedFooterPlan\(s\.events, from, winEv, working, eventEpoch\)/);
+  assert.match(fn, /:scope > \[data-unit="\$\{unit\}"\]:not\(\.day-divider\)/, "a day divider shares its turn's unit number");
+  assert.match(fn, /if \(secs != null && !have\) \{[\s\S]*?node\.appendChild\(f\);\s*\n\s*if \(spot\) f\.appendChild\(spot\);/, "the fork spot moves into the new elapsed row, where applyForkSpots places it");
+  assert.match(fn, /\} else if \(secs == null && have\) \{[\s\S]*?if \(spot\) node\.appendChild\(spot\);\s*\n\s*have\.remove\(\);/, "…and back onto the turn when the footer comes off");
+  assert.match(RENDER, /function turnWorkedSecs\(events: ChatEvent\[\], i: number, working: boolean\): number \| null \{\s*\n\s*return workedSecsOf\(events, i, working, eventEpoch\);/, "one rule for the render and the patch");
+});
+
+test("a status-only tail reaches the footer: the view remembers the working state, and a flip patches from the fast path with from = len", () => {
+  // chatTail with an empty suffix leaves v.rendered === len, so syncViewInner's no-op fast path is the only
+  // code that runs for it; the footer's one non-event input is the session's working state
+  assert.match(RENDER, /^interface View \{[^\n]*working\?: boolean;/m);
+  const sync = RENDER.slice(RENDER.indexOf("function syncViewInner("), RENDER.indexOf("function patchWorkedFooters("));
+  assert.match(sync, /const workFlip = v\.working != null && v\.working !== working;\s*\n\s*v\.working = working;/);
+  assert.match(sync, /if \(workFlip && v\.rendered === len && !v\.stale && v\.el\.childNodes\.length > 0\) \{\s*\n\s*patchWorkedFooters\(v, s, len, working, settings\.compact \? items : null\);\s*\n\s*\}\s*\n\s*if \(v\.rendered === len && !v\.stale && v\.el\.childNodes\.length > 0\) return v;/,
+    "the flip patches just ahead of the fast path under its predicate, and the fast path (its line pinned by other tests) still returns; a patch that could not address the unit marks stale, so the window path re-renders");
+  const fn = RENDER.slice(RENDER.indexOf("function patchWorkedFooters("), RENDER.indexOf("function patchWorkedFooters(") + 2200);
+  assert.match(fn, /const winEv = items \? \(items\[winStart\] \? itemFirstEvent\(items\[winStart\]\) : s\.events\.length\) : winStart;/, "compact mode: the window start is a unit, the plan wants an event index");
+  assert.match(fn, /items\.findIndex\(\(it\) => it\.kind === "event" && it\.index === i\)/, "…and the reply's event index maps back to its unit");
+  assert.match(fn, /if \(unit < 0\) \{ v\.stale = true; continue; \}/, "a reply folded into a run: the window path re-renders");
+});
+
+test("a plain human-prompt append does not set stale: the signature reads the prefix below the tail's re-render start", () => {
+  // a landing prompt is a new editable bubble, so an unbounded editable set differed on every prompt and
+  // rebuilt the whole window; the tail renders everything at or past `from` itself (executed:
+  // rewind-reconcile.test.ts; here, that chatTail hands its `from` over as the bound)
+  assert.match(RENDER, /function reconcileRewind\(s: Session, bound\?: number\): void \{/);
+  const tail = RENDER.slice(RENDER.indexOf("function chatTail(msg: any) {"), RENDER.indexOf("function statusOnly(msg: any) {"));
+  assert.match(tail, /reconcileRewind\(s, from\);/, "chatTail passes its from as the bound");
+  // the base's own rules for when the exact tail is NOT enough stand: a shrunken tail, and a change inside a
+  // window the reader scrolled away from, still rebuild the window
+  assert.match(tail, /v\.rendered = Math\.min\(v\.rendered, from\);\s*\/\/ repaint from the exact changed point/);
+  assert.match(tail, /if \(shrank \|\| \(!atTail && from < \(v\.winEnd \?\? 0\)\)\) v\.stale = true;/);
+});

--- a/ui/webview/chat-windowing.test.ts
+++ b/ui/webview/chat-windowing.test.ts
@@ -12,13 +12,14 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
-test("windowing constants are sane: tail > recheck, a render radius and a re-window margin, a switch cap", () => {
+test("windowing constants are sane: a tail, a render radius and a re-window margin, a switch cap", () => {
+  // (the trailing re-check window, TAIL_RECHECK, is gone: the tail path re-renders exactly from the kernel's
+  // first changed event — chat-exact-tail.test.ts)
   const tail = Number(/const WINDOW_TAIL = (\d+);/.exec(RENDER)?.[1]);
-  const recheck = Number(/const TAIL_RECHECK = (\d+);/.exec(RENDER)?.[1]);
   const radius = Number(/const WINDOW_RADIUS = (\d+);/.exec(RENDER)?.[1]);
   const margin = Number(/const REVIRT_MARGIN = (\d+);/.exec(RENDER)?.[1]);
   const cap = Number(/const WINDOW_CAP = (\d+);/.exec(RENDER)?.[1]);
-  assert.ok(tail > recheck, `WINDOW_TAIL ${tail} > TAIL_RECHECK ${recheck}`);
+  assert.ok(tail > 0, "a tail window");
   assert.ok(radius > margin && margin > 0, "radius > margin > 0");
   assert.ok(cap > tail, "cap > tail");
 });

--- a/ui/webview/codeblock-copy.test.ts
+++ b/ui/webview/codeblock-copy.test.ts
@@ -11,11 +11,16 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
+const HL = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "highlight-cache.ts"), "utf8");
+
 test("highlight() captures the raw source then adds a Copy button to each <pre>", () => {
-  // raw is captured BEFORE innerHTML is rewritten, and hljs highlights that same captured string
+  // raw is captured BEFORE innerHTML is rewritten, and hljs highlights that same captured string — through
+  // the (language, source) cache (highlight-cache.ts), which still names a grammar for a labeled fence and
+  // auto-detects an unlabeled one
   assert.match(RENDER, /const raw = code\.textContent \|\| "";/);
-  assert.match(RENDER, /hljs\.highlight\(raw, \{ language: lang \}\)/);
-  assert.match(RENDER, /hljs\.highlightAuto\(raw\)/);
+  assert.match(RENDER, /code\.innerHTML = highlightHtml\(hljs, lang, raw\);/);
+  assert.match(HL, /hl\.highlight\(raw, \{ language: lang as string \}\)/);
+  assert.match(HL, /hl\.highlightAuto\(raw\)/);
   // the button is added per code block, to its parent <pre>, with the captured raw
   assert.match(RENDER, /if \(pre && pre\.tagName === "PRE"\) addCopyBtn\(pre as HTMLElement, raw\)/);
 });

--- a/ui/webview/federation-direct-delivery.test.ts
+++ b/ui/webview/federation-direct-delivery.test.ts
@@ -14,7 +14,6 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import * as vm from "node:vm";
 import { FederationManager, reportListenerError } from "./federation";
 import { listenForFrames } from "./frame-listener";
 
@@ -292,7 +291,9 @@ test("listenForFrames installs the one handler on window and in the registry; wi
   }
 });
 
-// ── source pins: every pane installs through the helper; the kernel's inline boot registers the same way ──
+// ── source pins: every pane installs through the helper. (The kernel's inline timeline boot registers the same way;
+// that is the Python lane's to hold (tests/test_kernel_timeline_split.py pins the registration and RUNS the boot
+// under node), so a kernel edit cannot break this lane. Review find, 2026-09-08.) ──
 
 test("feed, Outline, chat and the VS Code timeline install their frame handler through listenForFrames, none through a bare window listener", () => {
   for (const [file, app] of [["feed.ts", "feed"], ["fleet.ts", "fleet"], ["render.ts", "chat"], ["timeline-main.ts", "timeline"]]) {
@@ -304,42 +305,6 @@ test("feed, Outline, chat and the VS Code timeline install their frame handler t
   const helper = fs.readFileSync(path.join(UI, "frame-listener.ts"), "utf8");
   assert.doesNotMatch(helper, /^import /m, "the helper stays import-free: importing federation.ts would boot a second manager in the pane bundle");
   assert.ok(helper.indexOf('window.addEventListener("message", handler)') < helper.indexOf("fed.onFrame(handler)"), "window first, the registry after");
-});
-
-test("the kernel's inline timeline boot registers its wrapped listener with the registry when federation.js published one", () => {
-  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
-  const bootStart = KERNEL.indexOf("_TIMELINE_BOOT = ");
-  const boot = KERNEL.slice(bootStart, KERNEL.indexOf('"""', bootStart + 60));
-  assert.match(boot, /var frameListener=\(window\.__rompPerf&&window\.__rompPerf\.wrapFrameHandler\)\?window\.__rompPerf\.wrapFrameHandler\(onFrame\):onFrame;\nwindow\.addEventListener\("message",frameListener\);/);
-  assert.ok(boot.includes("if(window.__rompFed&&window.__rompFed.onFrame)window.__rompFed.onFrame(frameListener);"), "the same listener, registered");
-  assert.equal((boot.match(/addEventListener\("message"/g) || []).length, 1, "one window listener");
-});
-
-test("the kernel's inline timeline boot, RUN: the one window listener is the perf-wrapped one, the registry gets that same function, and a frame through the registry reaches the panel", () => {
-  // the boot is a self-contained IIFE (kernel.py _TIMELINE_BOOT, served inline on the browser's timeline page);
-  // it runs here in a bare vm context with the three window slots it reads stood in
-  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
-  const open = '_TIMELINE_BOOT = """';
-  const bootStart = KERNEL.indexOf(open);
-  assert.ok(bootStart > 0, "kernel _TIMELINE_BOOT block not found");
-  const boot = KERNEL.slice(bootStart + open.length, KERNEL.indexOf('"""', bootStart + open.length));
-  const listeners: Function[] = [], registered: Function[] = [], updates: any[] = [], posted: any[] = [];
-  const wrapped = new Map<Function, Function>();
-  const win: any = {
-    acquireVsCodeApi: () => ({ postMessage: (m: any) => posted.push(m) }),
-    addEventListener: (t: string, h: Function) => { if (t === "message") listeners.push(h); },
-    __rompPerf: { wrapFrameHandler: (h: Function) => { const w = (e: any) => h(e); wrapped.set(w, h); return w; } },   // perf-telemetry.ts's slot
-    __rompFed: { onFrame: (h: Function) => { registered.push(h); return () => {}; } },                               // federation.ts's slot
-  };
-  win.window = win;
-  vm.runInNewContext(boot, { window: win, HTMLElement: { prototype: {} }, document: {}, URL });
-  assert.equal(listeners.length, 1, "one window listener");
-  assert.ok(wrapped.has(listeners[0]), "…the wrapped one, so its frames are timed by type");
-  assert.deepEqual(registered, listeners, "the SAME function is registered with federation: the brackets nest on both paths, and no frame arrives twice");
-  win.__rompConnectTimeline({ update: (d: any) => updates.push(d) });
-  assert.equal(posted.length, 1); assert.equal(posted[0].type, "ready");   // (built in the vm realm: compared by field, not by prototype)
-  registered[0]({ data: { type: "data", data: { lanes: 1 } } });   // federation's direct call: a merged lanes frame
-  assert.deepEqual(updates, [{ lanes: 1 }], "the frame reached the panel through the registered function");
 });
 
 test("the three merged emissions go through emit and no other dispatch does", () => {

--- a/ui/webview/federation-direct-delivery.test.ts
+++ b/ui/webview/federation-direct-delivery.test.ts
@@ -1,0 +1,355 @@
+// federation.ts hands its MERGED frames (feed, tabOrder, data, bars) to the pane's handler by direct call once the
+// pane registers it (onFrame, published as window.__rompFed.onFrame; frame-listener.ts is how a pane registers),
+// and dispatches them on window only when nothing registered (emit).
+//
+// Why: the live `fed:feed` bracket ran 15-25 ms per feed push in every feed-consuming pane (75-110 ms in slow
+// minutes) while federation's own compute is under a millisecond. Blink hands a same-world "message" listener the
+// event's data object itself, but a listener in ANOTHER JavaScript world (a browser extension's content script)
+// that reads event.data receives a structured clone of the whole frame, made synchronously inside dispatchEvent:
+// 35-46 ms and about 7 MB of garbage per dispatch of a 7 MB frame in the probe, 0 ms for a direct call. The pane
+// receives the same merged object, in the same order, once per frame; only the delivery changes. Executed against
+// the real manager on the bare stand-in federation-closed-store.test.ts uses, extended with a dispatch counter.
+// Synthetic only (host TESTHOST, placeholder ids).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as vm from "node:vm";
+import { FederationManager, reportListenerError } from "./federation";
+import { listenForFrames } from "./frame-listener";
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const U = "11111111-2222-3333-4444-555555555555";
+const V = "99999999-8888-7777-6666-555555555555";
+
+/** The bare manager over a stand-in window: `windowed` collects every frame that reaches window.dispatchEvent,
+ *  `reported` every exception the subscriber path reported (reportError stood in). */
+function withManager(fn: (fm: any, windowed: any[], reported: unknown[]) => void): void {
+  const windowed: any[] = [];
+  const reported: unknown[] = [];
+  const store = new Map<string, string>();
+  const g: any = globalThis;
+  const hadWindow = "window" in g, prevWindow = g.window;
+  const hadLS = "localStorage" in g, prevLS = g.localStorage;
+  const hadRE = "reportError" in g, prevRE = g.reportError;
+  g.window = { dispatchEvent: (ev: any) => { if (ev && ev.data) windowed.push(ev.data); } };
+  g.localStorage = { getItem: (k: string) => store.get(k) ?? null, setItem: (k: string, v: string) => { store.set(k, v); } };
+  g.reportError = (e: unknown) => { reported.push(e); };
+  try { fn(new FederationManager(), windowed, reported); } finally {
+    if (hadWindow) g.window = prevWindow; else delete g.window;
+    if (hadLS) g.localStorage = prevLS; else delete g.localStorage;
+    if (hadRE) g.reportError = prevRE; else delete g.reportError;
+  }
+}
+const types = (frames: any[]) => frames.map((m) => m && m.type);
+const ask = (itemId: string, sid: string, extra: Record<string, unknown> = {}) => ({ itemId, sid, kind: "ask", text: "which port?", t: 1000, ...extra });
+const feedFrame = (asks: any[], buildId: number) => ({ type: "feed", now: 1_700_000_000, buildId, asks, ledgers: [], items: [], working: [], order: [] });
+const laneData = (sids: string[]) => ({ type: "data", data: { now: 1_700_000_000, sessions: sids.map((id) => ({ id, name: "web" })), lanes: [] } });
+
+// ── the direct path ──
+
+test("a registered handler receives the merged frame by direct call: the same objects, in order, and nothing reaches window", () => {
+  withManager((fm, windowed) => {
+    const got: MessageEvent[] = [];
+    fm.onFrame((e: MessageEvent) => got.push(e));
+    const a = ask("a1", U), b = ask("b1", U);
+    fm.inbound("", feedFrame([a, b], 1));
+    const b2 = ask("b1", U, { text: "which port, again?" });
+    fm.inbound("", feedFrame([a, b2], 2));
+    assert.deepEqual(types(got.map((e) => e.data)), ["feed", "feed"], "each push is re-emitted as a merged feed frame, as before");
+    assert.ok(got[0] instanceof MessageEvent, "the handler sees a MessageEvent, the window listener's own shape");
+    // by identity: what the merge built is what the pane holds — no copy, no clone on the way
+    assert.equal(got[0].data.asks[0], a, "the first frame's card is the wire object itself");
+    assert.equal(got[1].data.asks[0], a, "…and so is the second frame's");
+    assert.equal(got[1].data.asks[1], b2, "the changed card is the second push's object");
+    assert.notEqual(got[1].data.asks[1], b);
+    assert.deepEqual(types(windowed), [], "no merged frame was dispatched on window");
+  });
+});
+
+test("with no handler registered every frame still goes to window.dispatchEvent — a pane bundle from before the registry keeps working", () => {
+  withManager((fm, windowed) => {
+    fm.inbound("", feedFrame([ask("a1", U)], 1));
+    fm.inbound("", feedFrame([], 2));
+    fm.inbound("", { type: "tabOrder", order: [U], tabs: [{ id: U, name: "web" }] });
+    fm.inbound("", laneData([U]));
+    fm.inbound("", { type: "bars", turns: [] });
+    assert.deepEqual(types(windowed), ["feed", "feed", "tabOrder", "data", "bars"]);
+    assert.deepEqual(windowed[1].asks, [], "the second push replaced the first on this path too");
+  });
+});
+
+test("tabOrder, data and bars follow the same rule as feed: direct to the handler, never on window", () => {
+  withManager((fm, windowed) => {
+    const got: any[] = [];
+    fm.onFrame((e: MessageEvent) => got.push(e.data));
+    fm.inbound("", { type: "tabOrder", order: [U], tabs: [{ id: U, name: "web" }], selfHost: "TESTHOST" });
+    fm.inbound("", laneData([U]));
+    fm.inbound("", { type: "bars", turns: [] });
+    assert.deepEqual(types(got), ["tabOrder", "data", "bars"]);
+    assert.deepEqual(got[0].order, [U]);
+    assert.equal(got[0].freshHost, "", "a host's own push is a fresh emission, as before");
+    assert.deepEqual(got[1].data.sessions.map((s: any) => s.id), [U]);
+    assert.deepEqual(types(windowed), []);
+  });
+});
+
+test("the frames that stay on window keep going there with a handler registered: the passthrough, closed, hostUp — and never to the handler", () => {
+  withManager((fm, windowed) => {
+    const got: any[] = [];
+    fm.onFrame((e: MessageEvent) => got.push(e.data));
+    fm.inbound("", { type: "tabOrder", order: [U], tabs: [{ id: U, name: "web" }] });
+    fm.inbound("", { type: "dirListing", path: "src", entries: [] });   // the passthrough (file-browse.ts reads it on window)
+    fm.inbound("", { type: "usage", usage: {} });                        // strip.ts reads it on window
+    fm.inbound("", { type: "settingsSync", settings: {} });              // settings.ts reads it on window
+    fm.inbound("", { type: "session", id: U, events: [] });              // the chat's frames pass through too
+    fm.inbound("", { type: "closed", id: U });                           // the pane's teardown frame, then a merged re-emit
+    assert.deepEqual(types(windowed), ["dirListing", "usage", "settingsSync", "session", "closed"]);
+    assert.deepEqual(types(got), ["tabOrder", "tabOrder"], "the merged order after the closed fold reached the handler directly");
+    assert.equal(got[1].reemit, true);
+    assert.deepEqual(got[1].order, []);
+  });
+});
+
+test("a detach's hostDrop `closed` frames and an undeliverable send's `warn` stay on window with a handler registered, and never reach the handler", () => {
+  withManager((fm, windowed) => {
+    const got: any[] = [];
+    fm.onFrame((e: MessageEvent) => got.push(e.data));
+    // an attached host whose socket is not open: its sessions are on screen, its tunnel is down
+    fm.conns.set("TESTHOST", { host: "TESTHOST", ws: null, url: "", closed: false, live: false, lastRecv: 0, resumeProvisional: 0, connT: 0, pending: new Map() });
+    fm.hostSeq.push("TESTHOST");
+    fm.perHostSids["TESTHOST"] = new Set(["TESTHOST:" + V]);
+    fm.sendRemote("TESTHOST", { type: "reply", id: "TESTHOST:" + V, text: "which port?" });   // not a queued setting: dropped, with a warn
+    assert.deepEqual(types(windowed), ["warn"], "the drop is said on window (render.ts toasts it there)");
+    assert.match(windowed[0].text, /TESTHOST is unreachable/);
+    fm.closeRemote("TESTHOST");   // /tunnels no longer lists it: its sessions close with hostDrop, then the merged re-emits
+    assert.deepEqual(types(windowed), ["warn", "closed"]);
+    assert.deepEqual(windowed[1], { type: "closed", id: "TESTHOST:" + V, hostDrop: true });
+    assert.deepEqual(types(got), ["tabOrder", "feed"], "the detach's merged re-emits reached the handler directly (no lanes were held for the host)");
+    assert.ok(!got.some((m) => m.type === "closed" || m.type === "warn"), "neither window-path frame reached the handler");
+  });
+});
+
+test("the registration returns an unsubscribe; after it the window path carries the frames again", () => {
+  withManager((fm, windowed) => {
+    const got: any[] = [];
+    const off = fm.onFrame((e: MessageEvent) => got.push(e.data));
+    fm.inbound("", { type: "tabOrder", order: [], tabs: [] });
+    off();
+    fm.inbound("", { type: "tabOrder", order: [], tabs: [] });
+    assert.equal(got.length, 1);
+    assert.deepEqual(types(windowed), ["tabOrder"]);
+  });
+});
+
+test("two handlers both receive the ONE event object, in registration order; a handler unsubscribed mid-delivery still runs once", () => {
+  withManager((fm, windowed) => {
+    const order: string[] = [];
+    const events: MessageEvent[] = [];
+    let offSecond = () => {};
+    fm.onFrame((e: MessageEvent) => { order.push("first"); events.push(e); offSecond(); });   // unsubscribes its sibling while delivering
+    offSecond = fm.onFrame((e: MessageEvent) => { order.push("second"); events.push(e); });
+    fm.inbound("", { type: "tabOrder", order: [], tabs: [] });
+    assert.deepEqual(order, ["first", "second"], "the snapshot taken before delivery still reaches the second handler once (deliberately unlike dispatchEvent, which skips a listener removed during dispatch)");
+    assert.equal(events[0], events[1], "one MessageEvent for the frame");
+    fm.inbound("", { type: "tabOrder", order: [], tabs: [] });
+    assert.deepEqual(order, ["first", "second", "first"], "…and the unsubscribe holds from the next frame");
+    assert.deepEqual(types(windowed), []);
+  });
+});
+
+// ── report-and-continue: a throwing handler behaves as a throwing window listener does ──
+
+test("a throwing handler is reported through reportError alone (not the console as well), the next handler still runs, and inbound returns normally", () => {
+  withManager((fm, windowed, reported) => {
+    const realError = console.error;
+    const logged: unknown[] = [];
+    console.error = (...args: unknown[]) => { logged.push(args[0]); };
+    try {
+      const got: string[] = [];
+      fm.onFrame(() => { throw new Error("pane bug"); });
+      fm.onFrame((e: MessageEvent) => got.push(e.data.type));
+      assert.doesNotThrow(() => fm.inbound("", { type: "tabOrder", order: [], tabs: [] }));
+      assert.deepEqual(got, ["tabOrder"]);
+      assert.equal(reported.length, 1);
+      assert.match(String((reported[0] as Error).message), /pane bug/);
+      assert.deepEqual(logged, [], "with reportError on the page the console is not written too: one report per throw");
+      assert.deepEqual(types(windowed), []);
+    } finally {
+      console.error = realError;
+    }
+  });
+});
+
+test("a throw on a detach's lanes emission still lets its bars emission run", () => {
+  withManager((fm, windowed, reported) => {
+    const got: string[] = [];
+    fm.onFrame((e: MessageEvent) => { got.push(e.data.type); if (e.data.type === "data") throw new Error("lanes bug"); });
+    fm.inbound("", laneData([U]));
+    fm.inbound("", { type: "bars", turns: [] });
+    fm.inbound("TESTHOST", laneData([V]));
+    fm.inbound("TESTHOST", { type: "bars", turns: [] });
+    assert.deepEqual(got, ["data", "bars", "data", "bars"]);
+    assert.equal(reported.length, 2, "each lanes emission threw and was reported");
+    // the detach (poll: /tunnels no longer lists the host) — closeRemote re-emits order, feed, lanes, bars in that order
+    fm.conns.set("TESTHOST", { host: "TESTHOST", ws: null, url: "", closed: false, live: false, lastRecv: 0, connT: 0, pending: new Map() });
+    got.length = 0;
+    fm.closeRemote("TESTHOST");
+    assert.deepEqual(got, ["tabOrder", "feed", "data", "bars"], "the bars emission ran after the throwing lanes emission");
+    assert.equal(reported.length, 3);
+    assert.deepEqual(got.filter((t) => t === "bars").length, 1);
+    assert.deepEqual(types(windowed), []);
+  });
+});
+
+test("reportListenerError falls back to console.error when the page has no reportError, and never throws", () => {
+  const g: any = globalThis;
+  const hadRE = "reportError" in g, prevRE = g.reportError;
+  const realError = console.error;
+  const logged: unknown[] = [];
+  delete g.reportError;
+  console.error = (...args: unknown[]) => { logged.push(args[0]); };
+  try {
+    assert.doesNotThrow(() => reportListenerError(new Error("no reportError here")));
+    assert.equal(logged.length, 1);
+    assert.match(String((logged[0] as Error).message), /no reportError here/);
+    // a reportError that itself throws is not the pane's problem either
+    g.reportError = () => { throw new Error("broken reporter"); };
+    assert.doesNotThrow(() => reportListenerError(new Error("x")));
+    assert.equal(logged.length, 2, "…the console got it instead");
+  } finally {
+    console.error = realError;
+    if (hadRE) g.reportError = prevRE; else delete g.reportError;
+  }
+});
+
+// ── the storage re-emit (a drag in another pane) through start() ──
+
+test("a view-order storage event re-emits all three merged frames to the registered handler, once each, and none on window", () => {
+  const g: any = globalThis;
+  const saved: Record<string, [boolean, unknown]> = {};
+  for (const k of ["window", "document", "localStorage", "setInterval", "fetch"]) saved[k] = [k in g, g[k]];
+  const win: any = new EventTarget();
+  const onWindow: any[] = [];
+  win.addEventListener("message", (e: any) => onWindow.push(e.data));   // what an unregistered listener would see
+  win.__rompApp = "feed";
+  const store = new Map<string, string>();
+  g.window = win;
+  g.document = Object.assign(new EventTarget(), { visibilityState: "visible" });
+  g.localStorage = { getItem: (k: string) => store.get(k) ?? null, setItem: (k: string, v: string) => { store.set(k, v); } };
+  g.setInterval = () => 0;                                   // start()'s poll and watchdog timers: never armed here
+  g.fetch = () => Promise.reject(new Error("no kernel"));    // start()'s first /tunnels poll: returns quietly
+  try {
+    const fm: any = new FederationManager();
+    fm.start();
+    assert.equal(typeof win.__rompFed.onFrame, "function", "the registration is published on the window slot");
+    const got: any[] = [];
+    const h = (e: MessageEvent) => got.push(e.data);
+    listenForFrames(h);   // the pane's install: window AND the registry, one function
+    fm.inbound("", { type: "tabOrder", order: [U], tabs: [{ id: U, name: "web" }] });
+    fm.inbound("", feedFrame([ask("a1", U)], 1));
+    fm.inbound("", laneData([U]));
+    // (the first host report adopts U into the view order, and that write fires VIEW_ORDER_EVENT on this window, so the
+    // reorder re-emit runs once before the fresh order — the same as on a real page; the counts below start after it)
+    assert.deepEqual(types(got).slice(-3), ["tabOrder", "feed", "data"]);
+    got.length = 0;
+    win.dispatchEvent(new Event("storage"));   // another pane's drag (no key = the whole store; VIEW_ORDER_KEY otherwise)
+    assert.deepEqual(types(got), ["tabOrder", "feed", "data"], "each merged frame re-emitted exactly once");
+    assert.equal(got[0].reemit, true, "a synthetic re-emit, never a fresh host report");
+    assert.deepEqual(onWindow, [], "nothing rode the window path");
+  } finally {
+    for (const k of Object.keys(saved)) { const [had, v] = saved[k]; if (had) g[k] = v; else delete g[k]; }
+  }
+});
+
+// ── frame-listener.ts: the pane's install ──
+
+test("listenForFrames installs the one handler on window and in the registry; without a registry, on window only; an older slot without onFrame does not throw", () => {
+  const g: any = globalThis;
+  const hadWindow = "window" in g, prevWindow = g.window;
+  try {
+    const win: any = new EventTarget();
+    const subs: unknown[] = [];
+    win.__rompFed = { onFrame: (h: unknown) => { subs.push(h); return () => {}; } };
+    g.window = win;
+    const seen: any[] = [];
+    const h = (e: MessageEvent) => seen.push(e.data);
+    assert.equal(listenForFrames(h), h);
+    assert.deepEqual(subs, [h], "the SAME function is registered — the perf wrapper included, so the brackets nest on both paths");
+    win.dispatchEvent(new MessageEvent("message", { data: { romp: "paneFocus" } }));
+    assert.deepEqual(seen, [{ romp: "paneFocus" }], "…and it is on window for the shell's posts");
+    // no federation.js on the page (a VS Code webview)
+    const bare: any = new EventTarget();
+    g.window = bare;
+    assert.doesNotThrow(() => listenForFrames(h));
+    // a federation.js from before the registry
+    const older: any = new EventTarget();
+    older.__rompFed = { inbound: () => {}, outbound: () => {} };
+    g.window = older;
+    assert.doesNotThrow(() => listenForFrames(h));
+  } finally {
+    if (hadWindow) g.window = prevWindow; else delete g.window;
+  }
+});
+
+// ── source pins: every pane installs through the helper; the kernel's inline boot registers the same way ──
+
+test("feed, Outline, chat and the VS Code timeline install their frame handler through listenForFrames, none through a bare window listener", () => {
+  for (const [file, app] of [["feed.ts", "feed"], ["fleet.ts", "fleet"], ["render.ts", "chat"], ["timeline-main.ts", "timeline"]]) {
+    const src = fs.readFileSync(path.join(UI, file), "utf8");
+    assert.ok(src.includes(`listenForFrames(perfFrameHandler("${app}", `), `${file}: installs through the helper`);
+    assert.ok(!src.includes('window.addEventListener("message", perfFrameHandler('), `${file}: no bare window install of the frame handler`);
+    assert.match(src, /import \{ listenForFrames \} from "\.\/frame-listener";/, `${file}: imports the helper`);
+  }
+  const helper = fs.readFileSync(path.join(UI, "frame-listener.ts"), "utf8");
+  assert.doesNotMatch(helper, /^import /m, "the helper stays import-free: importing federation.ts would boot a second manager in the pane bundle");
+  assert.ok(helper.indexOf('window.addEventListener("message", handler)') < helper.indexOf("fed.onFrame(handler)"), "window first, the registry after");
+});
+
+test("the kernel's inline timeline boot registers its wrapped listener with the registry when federation.js published one", () => {
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  const bootStart = KERNEL.indexOf("_TIMELINE_BOOT = ");
+  const boot = KERNEL.slice(bootStart, KERNEL.indexOf('"""', bootStart + 60));
+  assert.match(boot, /var frameListener=\(window\.__rompPerf&&window\.__rompPerf\.wrapFrameHandler\)\?window\.__rompPerf\.wrapFrameHandler\(onFrame\):onFrame;\nwindow\.addEventListener\("message",frameListener\);/);
+  assert.ok(boot.includes("if(window.__rompFed&&window.__rompFed.onFrame)window.__rompFed.onFrame(frameListener);"), "the same listener, registered");
+  assert.equal((boot.match(/addEventListener\("message"/g) || []).length, 1, "one window listener");
+});
+
+test("the kernel's inline timeline boot, RUN: the one window listener is the perf-wrapped one, the registry gets that same function, and a frame through the registry reaches the panel", () => {
+  // the boot is a self-contained IIFE (kernel.py _TIMELINE_BOOT, served inline on the browser's timeline page);
+  // it runs here in a bare vm context with the three window slots it reads stood in
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  const open = '_TIMELINE_BOOT = """';
+  const bootStart = KERNEL.indexOf(open);
+  assert.ok(bootStart > 0, "kernel _TIMELINE_BOOT block not found");
+  const boot = KERNEL.slice(bootStart + open.length, KERNEL.indexOf('"""', bootStart + open.length));
+  const listeners: Function[] = [], registered: Function[] = [], updates: any[] = [], posted: any[] = [];
+  const wrapped = new Map<Function, Function>();
+  const win: any = {
+    acquireVsCodeApi: () => ({ postMessage: (m: any) => posted.push(m) }),
+    addEventListener: (t: string, h: Function) => { if (t === "message") listeners.push(h); },
+    __rompPerf: { wrapFrameHandler: (h: Function) => { const w = (e: any) => h(e); wrapped.set(w, h); return w; } },   // perf-telemetry.ts's slot
+    __rompFed: { onFrame: (h: Function) => { registered.push(h); return () => {}; } },                               // federation.ts's slot
+  };
+  win.window = win;
+  vm.runInNewContext(boot, { window: win, HTMLElement: { prototype: {} }, document: {}, URL });
+  assert.equal(listeners.length, 1, "one window listener");
+  assert.ok(wrapped.has(listeners[0]), "…the wrapped one, so its frames are timed by type");
+  assert.deepEqual(registered, listeners, "the SAME function is registered with federation: the brackets nest on both paths, and no frame arrives twice");
+  win.__rompConnectTimeline({ update: (d: any) => updates.push(d) });
+  assert.equal(posted.length, 1); assert.equal(posted[0].type, "ready");   // (built in the vm realm: compared by field, not by prototype)
+  registered[0]({ data: { type: "data", data: { lanes: 1 } } });   // federation's direct call: a merged lanes frame
+  assert.deepEqual(updates, [{ lanes: 1 }], "the frame reached the panel through the registered function");
+});
+
+test("the three merged emissions go through emit and no other dispatch does", () => {
+  const src = fs.readFileSync(path.join(UI, "federation.ts"), "utf8");
+  assert.equal((src.match(/this\.emit\(/g) || []).length, 3, "emitMergedFeed, emitMergedTimeline, emitMergedOrder");
+  for (const stays of ['window.dispatchEvent(new MessageEvent("message", { data: m }));',                       // closed, passthrough
+                       'window.dispatchEvent(new MessageEvent("message", { data: { type: "hostUp", hosts: recovered } }));',
+                       'window.dispatchEvent(new MessageEvent("message", { data: { type: "closed", id: sid, hostDrop: true } }));',
+                       'window.dispatchEvent(new Event("romp-hosts"));']) {
+    assert.ok(src.includes(stays), "stays on window: " + stays);
+  }
+  assert.ok(src.includes('onFrame: (h: FrameHandler) => this.onFrame(h)'), "published on window.__rompFed");
+});

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -638,6 +638,19 @@ export function socketVerdict(readyState: number, lastRecv: number, connT: numbe
 // and window.__rompFed.outbound(m) for sends (both no-ops when this module isn't loaded, e.g. the timeline
 // pane), and exposes window.__rompLocalSend + window.__rompApp.
 
+/** A pane's frame handler: the window "message" listener's signature, so one function serves both paths. */
+export type FrameHandler = (e: MessageEvent) => void;
+
+/** Report a subscriber's exception the way the DOM reports a listener's: through reportError where the page has
+ *  it (window.onerror / the console, as an uncaught exception), else console.error. Never throws. */
+export function reportListenerError(e: unknown): void {
+  const g: any = globalThis;
+  try {
+    if (typeof g.reportError === "function") { g.reportError(e); return; }
+  } catch (_) { /* fall through to the console */ }
+  try { console.error(e); } catch (_) { /* nothing left to report to */ }
+}
+
 interface Conn {
   host: string;
   ws: WebSocket | null;
@@ -679,6 +692,49 @@ export class FederationManager {
   // merge and dispatch through it as fed:<type>, nested outside the pane's handler. Public so a test can hand
   // it a stand-in.
   perf: RompPerf | null = null;
+  // The pane's frame handlers, registered through onFrame (window.__rompFed.onFrame): the merged frames this
+  // layer emits reach them by direct call, never as a window "message" event. See emit() for why.
+  private frameSubs: FrameHandler[] = [];
+
+  /** Register a handler for the merged frames this manager emits (`feed`, `tabOrder`, `data`, `bars`); returns
+   *  the unsubscribe. The pane registers the SAME wrapped handler it installs on window (frame-listener.ts), so
+   *  the perf brackets nest as before and every frame reaches it exactly once: federation picks one path per
+   *  frame (emit). Every other frame — the passthrough, `closed`, `hostUp`, `warn`, the shell's `romp:` posts —
+   *  still arrives through the window listener. */
+  onFrame(handler: FrameHandler): () => void {
+    this.frameSubs.push(handler);
+    return () => {
+      const i = this.frameSubs.indexOf(handler);
+      if (i >= 0) this.frameSubs.splice(i, 1);
+    };
+  }
+
+  /** Hand one merged frame to the pane. With a subscriber registered: ONE MessageEvent, called into each handler
+   *  directly, in registration order, over a snapshot of the list. Here the direct path deliberately differs from
+   *  dispatchEvent on removal: the DOM skips a listener removed during dispatch, while a handler unsubscribed by
+   *  an earlier handler in the same frame still runs once here (the snapshot is simpler, and nobody unsubscribes
+   *  mid-delivery today). With none: window.dispatchEvent, exactly as before, so a pane bundle that predates the
+   *  registry keeps working.
+   *
+   *  Why not always dispatch on window: Blink hands a same-world listener the event's data object itself, but a
+   *  "message" listener in ANOTHER JavaScript world — a browser extension's content script on the pane's page —
+   *  that reads event.data receives a STRUCTURED CLONE of it, made synchronously inside dispatchEvent. For a
+   *  merged feed of several megabytes that is tens of milliseconds and as many megabytes of garbage per frame, in
+   *  every feed-consuming pane, counted under this layer's fed:<type> bracket (its own work is under a
+   *  millisecond); a probe measured 35-46 ms per dispatch of a 7 MB frame and 0 ms for a direct call. Nothing
+   *  outside romp's bundles receives a merged frame now, so nothing can clone it.
+   *
+   *  A throwing handler is reported and the rest still run — the DOM's report-and-continue for event listeners.
+   *  Without this a throw would propagate through inbound into the shim's socket callback and skip this layer's
+   *  remaining work (the bars emission after a detach's lanes emission). */
+  private emit(data: any): void {
+    const ev = new MessageEvent("message", { data });
+    const subs = this.frameSubs;
+    if (!subs.length) { window.dispatchEvent(ev); return; }
+    for (const h of subs.slice()) {
+      try { h(ev); } catch (e) { reportListenerError(e); }
+    }
+  }
 
   start(): void {
     const w = window as any;
@@ -690,6 +746,7 @@ export class FederationManager {
     w.__rompFed = {
       inbound: (h: string, m: any) => this.inbound(h, m),
       outbound: (m: any) => this.outbound(m),
+      onFrame: (h: FrameHandler) => this.onFrame(h),   // the pane's direct-delivery registration (emit)
       hosts: () => this.hostSeq.filter((h) => h !== LOCAL), // attached hosts (the + modal's host picker)
       // Hosts that are attached but NOT reachable right now. Their sessions stay on screen — dropping
       // them would lose the thread — but every surface that shows one has to say the link is down, or
@@ -959,7 +1016,7 @@ export class FederationManager {
     }
     this.publishPending();
     const dead = this.deadHosts();
-    window.dispatchEvent(new MessageEvent("message", { data: mergeHostFeeds(this.perHostFeed, this.hostSeq, this.view(), dead, this.perHostFeedAt) }));
+    this.emit(mergeHostFeeds(this.perHostFeed, this.hostSeq, this.view(), dead, this.perHostFeedAt));
   }
 
   // the hosts whose link is DOWN right now (this manager knows its sockets) — the merges' pendingDead input
@@ -1014,7 +1071,7 @@ export class FederationManager {
       // the bars message carries no lanes — hand the merged lane list in for the connector stitch
       ? mergeHostBars(this.perHostTlBars, this.hostSeq, mergeHostTimelines(this.perHostTl, this.hostSeq, this.view()).sessions)
       : { type: "data", data: mergeHostTimelines(this.perHostTl, this.hostSeq, this.view(), this.deadHosts()) };
-    window.dispatchEvent(new MessageEvent("message", { data }));
+    this.emit(data);
   }
 
   // Every caller re-emits WITHOUT touching the stored arrangement — a drag landing here through the
@@ -1035,7 +1092,7 @@ export class FederationManager {
     // confirms a close by absence like any order, but is never evidence that a kernel still has a tab.
     if (fresh) data.freshHost = freshHost;
     else data.reemit = true;
-    window.dispatchEvent(new MessageEvent("message", { data }));
+    this.emit(data);
   }
 
   // Fold a host's OWN report — the one moment with fresh evidence about what exists — into the stored

--- a/ui/webview/feed-age.test.ts
+++ b/ui/webview/feed-age.test.ts
@@ -1,8 +1,21 @@
-// The live clock a pane runs its ages on (feed-age.ts liveNow): the kernel's `now` on the last frame plus the
-// local time elapsed since that frame ARRIVED. Pure, so node --test runs it without a DOM.
+// The live clock a pane runs its ages on (feed-age.ts liveNow: the kernel's `now` on the last frame plus the
+// local time elapsed since that frame ARRIVED) and the feed's age refresh, RUN: a quiet board sends a pane
+// nothing between frames, so the pane keeps the clock moving itself and one 15 s pass repaints every stamped
+// age — and, since the per-card update gate repaints a card only when its inputs change, every running
+// duration too. Pure functions here (node --test runs them without a DOM), plus source pins on feed.ts's
+// wiring; feed-render-incremental.test.ts runs the pass itself under a DOM stand-in. Synthetic only.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { liveNow } from "./feed-age";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { liveNow, liveRefresher, paintAge, refreshAges, stampAge, type AgeEl } from "./feed-age";
+import { ageColorReadable } from "./age-color";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+// feed.ts's relAge, in shape (feed-relage.test.ts pins the real one); the refresh takes it as a parameter
+const rel = (s: number) => s < 60 ? "<1m ago" : s < 3600 ? Math.round(s / 60) + "m ago" : s < 86400 ? Math.round(s / 3600) + "h ago" : Math.round(s / 86400) + "d ago";
+const tint = ageColorReadable;
+const mk = (): AgeEl => ({ textContent: null, style: { color: "" }, dataset: {} });
 
 test("liveNow adds only the local clock's DELTAS to the kernel's clock — skew between the two never enters", () => {
   const hostNow = 1_000_000;                    // the kernel's clock, as of the frame (epoch s)
@@ -10,7 +23,29 @@ test("liveNow adds only the local clock's DELTAS to the kernel's clock — skew 
   assert.equal(liveNow(hostNow, arrivedMs, arrivedMs), hostNow, "at the arrival the kernel clock IS the frame's `now`");
   assert.equal(liveNow(hostNow, arrivedMs, arrivedMs + 15_000), hostNow + 15, "15 s later, 15 s older");
   assert.equal(liveNow(hostNow, arrivedMs, arrivedMs + 999), hostNow, "whole seconds only: ages never read ahead of the tick");
+  assert.equal(liveNow(hostNow, arrivedMs, arrivedMs + 15_500), hostNow + 15, "15.5 s later: +15, the fraction dropped");
   assert.equal(liveNow(hostNow, arrivedMs, arrivedMs - 5_000), hostNow, "a local clock that steps BACK cannot make an age negative");
+});
+
+test("a quiet board's ages advance: every stamped element repaints from the live clock, tinted ones re-tint", () => {
+  const T = 1_000_000, t = T - 240;                         // everything 4 minutes old at the payload
+  const cardTime = mk(), groupTime = mk(), parenRow = mk(), tintedAge = mk();
+  stampAge(cardTime, t, "plain", false, T, rel, tint);      // an ask card's stamp
+  stampAge(groupTime, t, "plain", false, T, rel, tint);     // a group card's stamp
+  stampAge(parenRow, t, "paren", true, T, rel, tint);       // a parenthesized, recency-tinted "(4m ago)"
+  stampAge(tintedAge, t, "plain", true, T, rel, tint);      // a tinted "4m ago"
+  assert.equal(cardTime.textContent, "4m ago"); assert.equal(groupTime.textContent, "4m ago");
+  assert.equal(parenRow.textContent, "(4m ago)"); assert.equal(tintedAge.textContent, "4m ago");
+  assert.equal(cardTime.style.color, "", "card stamps keep their own colour");
+  assert.equal(parenRow.style.color, tint(240));
+  // an hour passes with no payload: the 15 s tick's pass, from the live clock
+  const n = refreshAges([cardTime, groupTime, parenRow, tintedAge], T + 3600, rel, tint);
+  assert.equal(n, 4, "every stamped element is repainted (every label changed)");
+  assert.equal(cardTime.textContent, "1h ago"); assert.equal(groupTime.textContent, "1h ago");
+  assert.equal(parenRow.textContent, "(1h ago)"); assert.equal(tintedAge.textContent, "1h ago");
+  assert.equal(parenRow.style.color, tint(3840)); assert.notEqual(parenRow.style.color, tint(240), "the tint aged");
+  assert.equal(tintedAge.style.color, tint(3840));
+  assert.equal(cardTime.style.color, "", "…and an untinted stamp stays untinted");
 });
 
 test("the anchor is a (now, nowAt) pair that travels with the frame: a re-emit after a quiet hour reads the same live clock as the arrival", () => {
@@ -20,8 +55,122 @@ test("the anchor is a (now, nowAt) pair that travels with the frame: a re-emit a
   // age would go back by the quiet period.
   const T = 1_000_000, arrivedMs = 5_000_000, hourLater = arrivedMs + 3_600_000;
   const anchor = (m: { now: number; nowAt?: number }, handledMs: number) =>
-    liveNow(m.now, typeof m.nowAt === "number" ? m.nowAt : handledMs, handledMs);   // fleet.ts's rule
+    liveNow(m.now, typeof m.nowAt === "number" ? m.nowAt : handledMs, handledMs);   // feed.ts's rule, pinned below
   assert.equal(anchor({ now: T, nowAt: arrivedMs }, arrivedMs), T, "at the arrival");
   assert.equal(anchor({ now: T, nowAt: arrivedMs }, hourLater), T + 3600, "the re-emit keeps the hour");
   assert.equal(anchor({ now: T }, hourLater), T, "a frame with no pair anchors on the handling — the VS Code pipe's frames, which are never re-emitted");
+});
+
+test("an unstamped element is left alone", () => {
+  const plain = mk(); plain.textContent = "Blocked";       // a question node's meta carries no age
+  assert.equal(paintAge(plain, 5, rel, tint), false);
+  assert.equal(plain.textContent, "Blocked");
+  const junk = mk(); junk.dataset.ageT = "not-a-number";
+  assert.equal(refreshAges([plain, junk], 5, rel, tint), 0);
+});
+
+test("a second pass at the same `now` writes NOTHING, and a pass across a minute boundary writes exactly the labels that crossed it", () => {
+  // Blink treats an identical textContent write as a real Text-node replacement once the document has created
+  // a MutationObserver (gear.js does at boot), so the compare is what keeps a quiet 15 s pass off the layout.
+  const T = 1_000_000;
+  const writes = (init: number) => {
+    let n = 0;
+    const e = { _text: "" as string | null, style: { color: "" }, dataset: {} as AgeEl["dataset"],
+      get textContent() { return this._text; }, set textContent(v: string | null) { this._text = v; n++; } };
+    stampAge(e, T - init, "plain", true, T, rel, tint);
+    return { e, count: () => n };
+  };
+  const a = writes(100), b = writes(150), c = writes(4 * 60);   // "2m ago", "3m ago" (rounded), "4m ago"
+  const c0 = a.count() + b.count() + c.count();
+  assert.equal(c0, 3, "the stamp paints once each");
+  assert.equal(refreshAges([a.e, b.e, c.e], T, rel, tint), 0, "same now: nothing rewritten");
+  assert.equal(a.count() + b.count() + c.count(), c0, "…and no textContent setter ran");
+  assert.equal(a.e.style.color, tint(100));
+  // 20 s later: a (120 s → "2m ago") and c (260 s → "4m ago") read the same; b (170 s) rounds to "3m ago" still — a
+  // tinted colour may move on the ramp, so a tinted label rewrites its colour at most, never its text
+  const nText = { a: a.count(), b: b.count(), c: c.count() };
+  refreshAges([a.e, b.e, c.e], T + 20, rel, tint);
+  assert.deepEqual({ a: a.count(), b: b.count(), c: c.count() }, nText, "no text changed: no textContent write");
+  // untinted stamps (card time stamps) have only their text: a pass that moves no label writes nothing at all
+  let wrote = 0;
+  const plain = { _text: "" as string | null, style: { color: "" }, dataset: {} as AgeEl["dataset"],
+    get textContent() { return this._text; }, set textContent(v: string | null) { this._text = v; wrote++; } };
+  stampAge(plain, T - 100, "plain", false, T, rel, tint);          // "2m ago"
+  assert.equal(refreshAges([plain], T + 20, rel, tint), 0);          // 120 s: still "2m ago"
+  assert.equal(refreshAges([plain], T + 40, rel, tint), 0);          // 140 s: "2m ago"
+  assert.equal(refreshAges([plain], T + 50, rel, tint), 1, "150 s rounds to 3m: the one label that crossed is rewritten");
+  assert.equal(plain.textContent, "3m ago");
+  assert.equal(wrote, 2, "one write at the stamp, one at the crossing");
+});
+
+test("the tint compares against a shadow of what was written, not the CSSOM read-back: a style that re-serialises the colour is still written once", () => {
+  const T = 1_000_000;
+  let sets = 0;
+  const style = { _c: "", get color() { return this._c; }, set color(v: string) { sets++; this._c = v.replace(/\s+/g, ""); } };   // a browser's read-back need not equal the string written
+  const e: AgeEl = { textContent: null, style, dataset: {} };
+  stampAge(e, T - 240, "plain", true, T, rel, tint);
+  assert.equal(sets, 1);
+  assert.notEqual(e.style.color, tint(240), "the read-back differs from what was written");
+  assert.equal(refreshAges([e], T, rel, tint), 0, "same now: nothing rewritten…");
+  assert.equal(sets, 1, "…the colour included — compared against the shadow, so the re-serialised read-back does not force a write every pass");
+});
+
+test("a running DURATION is a stamp too (fmt 'dur'): workingFor's minutes-then-hours vocabulary, moving with the clock", () => {
+  const T = 1_000_000;
+  const d = mk();
+  stampAge(d, T - 42 * 60, "dur", false, T, rel, tint);
+  assert.equal(d.textContent, "42m", "the awaiting box's / narration's duration, bare — the caller places the separator");
+  refreshAges([d], T + 18 * 60, rel, tint);
+  assert.equal(d.textContent, "1h 0m", "past sixty minutes it splits out the hours, as workingFor always did");
+  assert.equal(refreshAges([d], T + 18 * 60 + 30, rel, tint), 0, "within the same minute nothing is written");
+  assert.equal(d.style.color, "", "untinted");
+});
+
+test("liveRefresher: a hidden pane skips the pass and catches up exactly once when shown; an ordinary resize runs nothing", () => {
+  let hidden = false, passes = 0;
+  const live = liveRefresher({ hidden: () => hidden, pass: () => { passes++; } });
+  live.tick(); assert.equal(passes, 1, "visible: the tick runs the pass");
+  live.catchUp(); assert.equal(passes, 1, "nothing owed: a resize or visibility flip runs nothing");
+  hidden = true;
+  live.tick(); live.tick(); assert.equal(passes, 1, "hidden: two ticks, no pass");
+  live.catchUp(); assert.equal(passes, 1, "still hidden: the catch-up waits");
+  hidden = false;
+  live.catchUp(); assert.equal(passes, 2, "shown: ONE catch-up pass for the two skipped ticks");
+  live.catchUp(); assert.equal(passes, 2, "…and only one");
+  live.tick(); assert.equal(passes, 3, "the cadence resumes");
+});
+
+test("feed.ts reads a card's clock only through nowSec(), stamps every age and duration on the card face, and the live pass repaints them all", () => {
+  assert.match(FEED, /import \{ liveNow, liveRefresher, refreshAges, stampAge \} from "\.\/feed-age";/);
+  assert.match(FEED, /function nowSec\(\): number \{ return liveNow\(hostNow, hostNowAt, Date\.now\(\)\); \}/);
+  assert.match(FEED, /if \(typeof m\.now === "number"\) \{\n\s*hostNow = m\.now;\n\s*hostNowAt = typeof m\.nowAt === "number" \? m\.nowAt : Date\.now\(\);/,
+    "the payload's clock is recorded with when THAT FRAME ARRIVED (federation's `nowAt`) — never with when this handler ran");
+  assert.equal((FEED.match(/hostNowAt = Date\.now\(\)/g) || []).length, 2,
+    "the bare arrival time anchors only a frame with no `nowAt` (no federation layer) or no `now` at all (an older kernel)");
+  // the card stamps: the ask card's and the group card's time — nothing on a card face reads hostNow raw any
+  // more (a raw read is an age frozen at the frame); the provenance popovers and the sub-goal rows keep the
+  // frame's clock at their own repaint, as before
+  assert.match(FEED, /stampAge\(a\._time, it\.t, "plain", false, nowSec\(\), relAge, ageColorReadable\);/);
+  assert.match(FEED, /stampAge\(a\._time, g\.t, "plain", false, nowSec\(\), relAge, ageColorReadable\);/);
+  assert.doesNotMatch(FEED, /a\._time\.textContent = relAge\(/, "the time label is a stamp, not a one-off write");
+  assert.match(FEED, /relAge\(nowSec\(\) - at\)/, "the latched Continue's title ages on the same clock");
+  // the running DURATIONS: the awaiting box, the Awaiting-task pill, the waiting-on chip, the working narration
+  // and the per-paragraph ages are stamped too — the per-card update gate repaints a card only when its inputs
+  // change, so a duration baked into a caption would freeze on a card never re-sent
+  assert.match(FEED, /function durSpan\(since: number\): HTMLElement \{\n\s*const d = el\("span", "fask-dur"\);\n\s*stampAge\(d, since, "dur", false, nowSec\(\), relAge, ageColorReadable\);/);
+  assert.doesNotMatch(FEED, /, Date\.now\(\) \/ 1000\)/, "no elapsed label reads the browser clock any more (the clock anchor itself still does, feed-age.ts liveNow)");
+  assert.match(FEED, /if \(bp!\[i\]\.since\) stampAge\(age, bp!\[i\]\.since, "plain", false, nowS, relAge, ageColorReadable\);/);
+  // the 15 s live pass: the latched Continue's title, then every stamped age, writing only what changed,
+  // through the shared visibility gate
+  const pass = FEED.slice(FEED.indexOf("function livePass(): void {"), FEED.indexOf("const live = liveRefresher("));
+  assert.ok(pass.length > 0, "the live pass exists");
+  assert.match(pass, /const now = nowSec\(\);/);
+  assert.match(pass, /if \(cont && cont\.disabled && \(it\.followupPending \|\| it\.recheck \|\| it\.rejudging\)\) \{\n\s*const ct = contTitle\(true, "a continue", it\.followupAt\);\n\s*if \(cont\.title !== ct\) cont\.title = ct;/);
+  assert.match(pass, /refreshAges\(document\.querySelectorAll<HTMLElement>\("\[data-age-t\]"\), now, relAge, ageColorReadable\);/);
+  assert.doesNotMatch(FEED, /t\.textContent = relAge\(now - it\.t\);/, "the old tick, which rewrote every label on the browser clock, is gone");
+  // "hidden" is the paint gate's decision over its two measures (paint-gate.ts: the tab's visibility and the
+  // observer's word on #feed-list), not a second probe of the pane's viewport; both release events catch up
+  assert.match(FEED, /const live = liveRefresher\(\{ hidden: \(\) => paintHeld\(document\.hidden, feedIntersecting, true\), pass: livePass \}\);\nsetInterval\(live\.tick, 15000\);\ndocument\.addEventListener\("visibilitychange", live\.catchUp\);\n/);
+  assert.match(FEED, /feedIntersecting = entries\.some\(\(e\) => e\.isIntersecting\);\n\s*releasePaint\(\);\n\s*live\.catchUp\(\);/);
+  assert.doesNotMatch(FEED, /window\.innerWidth === 0 \|\| window\.innerHeight === 0/, "no zero-viewport probe beside the gate");
 });

--- a/ui/webview/feed-age.ts
+++ b/ui/webview/feed-age.ts
@@ -1,13 +1,90 @@
-// The kernel's LIVE clock for a pane that rides the feed payload. Every age a pane shows — "Xm ago", the
-// current goal's elapsed time, a recency cutoff — is the difference between a timestamp the KERNEL wrote and
-// "now", and the browser's clock can sit minutes from the kernel's (a phone, a laptop back from sleep): read
-// against Date.now(), every age on the board is off by that skew. The payload carries the kernel's `now`, but
-// only as of the frame, and on the delta path a quiet board sends a pane nothing between the 60 s reposts.
-// So the pane keeps the kernel's clock moving itself: it records WHEN the frame arrived and adds the local
-// time elapsed since — skew between the two clocks never enters, only the local clock's deltas do. Pure:
-// node --test runs it without a DOM.
+// The kernel's LIVE clock for a pane that rides the feed payload, and the feed's age refresh. Every age a pane
+// shows — "Xm ago", a running duration, a recency cutoff — is the difference between a timestamp the KERNEL
+// wrote and "now", and the browser's clock can sit minutes from the kernel's (a phone, a laptop back from
+// sleep): read against Date.now(), every age on the board is off by that skew. The payload carries the
+// kernel's `now`, but only as of the frame, and on the delta path a quiet board sends a pane nothing between
+// the 60 s reposts. So the pane keeps the kernel's clock moving itself: it records WHEN the frame arrived and
+// adds the local time elapsed since (liveNow) — skew between the two clocks never enters, only the local
+// clock's deltas do. Age-bearing elements are STAMPED with their timestamp (data-age-t) and format, so one
+// refresh pass (refreshAges) repaints every one of them from the same clock, rather than each render path
+// owning a copy of the formatting. Pure functions: node --test runs them without a DOM.
+//
+// The refresh WRITES ONLY WHAT CHANGED. Setting every stamped label's textContent every 15 s, changed or
+// not, cost 69-119 ms of style and layout per tick on an 800-card board in a headless-Chromium replay
+// (10-12 ms of it script, the rest layout) for the handful of labels whose minute actually rolled over
+// (relAge rounds to the minute, then the hour: 2-13 of 810 labels per tick). The compare is needed, and must
+// stay: Blink short-circuits an identical textContent write only in a document that has never created a
+// MutationObserver. gear.js creates several at boot (the settings modal's pickers), and the flag is
+// permanent once set — any other observer, a browser extension's included, sets it too — so in every romp
+// pane an identical textContent write replaces the Text node and dirties layout. The colour compares against
+// a shadow of the value written, not the CSSOM read-back: a browser may re-serialise a colour string (a hex
+// or hsl() value reads back as rgb(...)), and a compare against the read-back would then never match.
+import { workingFor } from "./spin-caption";
 
 /** The kernel clock now, in epoch seconds: the last payload's `now` plus the local time since it landed. */
 export function liveNow(hostNow: number, hostNowAtMs: number, nowMs: number): number {
   return hostNow + Math.max(0, Math.floor((nowMs - hostNowAtMs) / 1000));
+}
+
+/** "3m ago" | "(3m ago)" | a running DURATION "42m" / "1h 5m" (the awaiting box's waited time, the
+ *  working narration's elapsed time, the waiting-on chip) — the labels that used to be baked into
+ *  caption strings and moved only because every card re-rendered on every frame. */
+export type AgeFmt = "plain" | "paren" | "dur";
+
+/** The slice of an element the refresh reads and writes — HTMLElement satisfies it; tests use a plain object. */
+export interface AgeEl {
+  textContent: string | null;
+  style: { color: string };
+  dataset: { ageT?: string; ageFmt?: string; ageTint?: string };
+  _ageC?: string;   // the last tint written (a shadow: the CSSOM may re-serialise a colour, so the read-back is not what was written)
+}
+
+/** Stamp `el` with its timestamp and format, and paint it for `now`. `tinted` colours the text on the
+ *  recency ramp as well; card time stamps stay in their own colour. */
+export function stampAge(el: AgeEl, t: number, fmt: AgeFmt, tinted: boolean, now: number,
+                         rel: (secs: number) => string, tint: (secs: number) => string): void {
+  el.dataset.ageT = String(t);
+  el.dataset.ageFmt = fmt;
+  el.dataset.ageTint = tinted ? "1" : "";
+  paintAge(el, now, rel, tint);
+}
+
+/** Repaint one stamped element for `now`, writing only what differs from what it shows. Returns true when
+ *  something was written. An element with no stamp (or a non-numeric one) is left alone. */
+export function paintAge(el: AgeEl, now: number, rel: (secs: number) => string, tint: (secs: number) => string): boolean {
+  const t = Number(el.dataset.ageT);
+  if (el.dataset.ageT === undefined || !Number.isFinite(t)) return false;
+  const fmt = el.dataset.ageFmt;
+  const s = fmt === "dur" ? workingFor(now - t) : rel(now - t);
+  const text = fmt === "paren" ? "(" + s + ")" : s;
+  let wrote = false;
+  if (el.textContent !== text) { el.textContent = text; wrote = true; }
+  if (el.dataset.ageTint) {
+    const c = tint(now - t);
+    if (el._ageC !== c) { el._ageC = c; el.style.color = c; wrote = true; }
+  }
+  return wrote;
+}
+
+/** Repaint every stamped element for `now`; returns how many were actually rewritten. */
+export function refreshAges(els: Iterable<AgeEl>, now: number, rel: (secs: number) => string, tint: (secs: number) => string): number {
+  let n = 0;
+  for (const el of els) if (paintAge(el, now, rel, tint)) n++;
+  return n;
+}
+
+/** The live pass's visibility gate — the Outline pane's pattern for its own clock, factored so the feed
+ *  runs the same one and a test can drive it: `tick` runs the pass unless the pane is hidden (a hidden tab, or a
+ *  zero-size iframe the shell has display:none'd), in which case it remembers that a pass was skipped;
+ *  `catchUp` (wired to visibilitychange and resize) runs ONE pass if and only if one was skipped and the
+ *  pane is visible now — an ordinary resize, or a visibility flip with no skipped pass behind it, runs
+ *  nothing. */
+export function liveRefresher(opts: { hidden: () => boolean; pass: () => void }): { tick: () => void; catchUp: () => void } {
+  let skipped = false;
+  const tick = () => {
+    if (opts.hidden()) { skipped = true; return; }
+    skipped = false;
+    opts.pass();
+  };
+  return { tick, catchUp: () => { if (skipped) tick(); } };
 }

--- a/ui/webview/feed-awaiting-swirl.test.ts
+++ b/ui/webview/feed-awaiting-swirl.test.ts
@@ -21,12 +21,15 @@ test("the swirl element is built in the body, right after the distiller line, an
 });
 
 test("the swirl is driven by spinFor's caption — shown when there is one, else hidden", () => {
-  assert.match(FEED, /import \{ spinFor, waitedSuffix, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);   // the rows' vocabulary too (slice 2)
+  assert.match(FEED, /import \{ spinFor, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);   // the rows' vocabulary too (slice 2)
   assert.match(FEED, /const spin = spinFor\(it, distillPending\(dCompleted, dBlocked, it\.summary, it\.blockSummary, !!it\.blocked\),/);
   assert.match(FEED, /const spinCaption = spin\.caption, spinTip = spin\.tip, awaitingBg = spin\.awaitingBg;/);
   assert.match(FEED, /import \{ distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote \} from "\.\/distiller-line";/);
   assert.match(FEED, /a\._awaitSpin\.style\.display = spinCaption \? "" : "none";/);
-  assert.match(FEED, /\} else a\._awaitWhy\.textContent = spinCaption;\n\s*a\._awaitSpin\.title = spinTip \|\| spinCaption;/);
+  // a caption that ends in a running duration renders the duration as its own stamped element (feed-age.ts
+  // fmt "dur") so the live pass keeps it moving on a card the per-card update gate does not repaint
+  assert.match(FEED, /\} else if \(spin\.dur\) a\._awaitWhy\.replaceChildren\(spin\.dur\.text, durSpan\(spin\.dur\.since\)\);/);
+  assert.match(FEED, /else a\._awaitWhy\.textContent = spinCaption;\n\s*a\._awaitSpin\.title = spinTip \|\| spinCaption;/);
 });
 
 test("a bg-task wait wears the compact 'Awaiting task' pill that expands the task list (the user 2026-07-13)", () => {
@@ -40,8 +43,9 @@ test("a bg-task wait wears the compact 'Awaiting task' pill that expands the tas
   assert.match(FEED, /pillLbl\.replaceChildren\("Awaiting "\);/);
   assert.match(FEED, /\} else pillLbl\.append\(pillWord\);/);
   assert.doesNotMatch(FEED, /"Waiting on task"/);
-  // the pill carries the wait's elapsed time, same readout as the awaiting box (the user 2026-08-23)
-  assert.match(FEED, /pillLbl\.append\(pillWaited\);/);   // appended after the (possibly coloured) word since slice 2
+  // the pill carries the wait's elapsed time, same readout as the awaiting box (the user 2026-08-23) —
+  // as a stamped duration element, so the 15 s live pass moves it (durNodes mirrors waitedSuffix's rule)
+  assert.match(FEED, /pillLbl\.append\(\.\.\.durNodes\(it\.awaiting && it\.awaiting\.since\)\);\s*\/\/ the waited time, live/);   // appended after the (possibly coloured) word since slice 2
   assert.match(FEED, /taskBtn\.onclick = pick\("tasks"\);/);
   // expanded rows render in the checklist spot, same view as Sub-goals, the swirl as each row's mark
   assert.match(FEED, /if \(choice === "tasks"\) \{[\s\S]*?el\("div", "fcheck ftask"\)[\s\S]*?ftask-swirl/);
@@ -92,9 +96,9 @@ test("a DELEGATION wait names its peers like the ↪ from line — identity colo
   assert.match(FEED, /nm\.replaceChildren\(\.\.\.hostPartsNodes\(p\.host, p\.name\)\);/);
   assert.match(FEED, /if \(p\.color && p\.color\.bg\) nm\.style\.color = p\.color\.bg;/);
   // the elapsed readout survives the structured path (the pill/box parity rule of 2026-08-23)
-  assert.match(FEED, /a\._awaitWhy\.append\(waitedSuffix\(it\.awaiting && it\.awaiting\.since, Date\.now\(\) \/ 1000\)\);/);
+  assert.match(FEED, /a\._awaitWhy\.append\(\.\.\.durNodes\(it\.awaiting && it\.awaiting\.since\)\);/);
   // older kernels ship no peers → the ladder's plain caption is the fallback
-  assert.match(FEED, /\} else a\._awaitWhy\.textContent = spinCaption;/);
+  assert.match(FEED, /else a\._awaitWhy\.textContent = spinCaption;/);
   // federation attributes a kernel-local peer to that kernel and prefixes its sid, exactly as it
   // does for origin.peerSid — a merged card's peer name keeps its host and its click routes home
   const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");

--- a/ui/webview/feed-cap-offer.test.ts
+++ b/ui/webview/feed-cap-offer.test.ts
@@ -40,6 +40,6 @@ test("the offer retires with the window and rides beside the auto-retry, never i
   assert.match(KERNEL, /\(w\.get\("resets_at"\) or 0\) > now/, "resets_at passing ends the mint — the deciding event");
   assert.match(KERNEL, /_cap_off = _cap_switch_offer\(fsid, aerr\) if aerr else None/);
   assert.match(KERNEL, /\*\*\(\{"capOffer": _cap_off\} if _cap_off else \{\}\),/, "sparse — absent payloads are byte-identical");
-  // the auto-retry contract is untouched: the retry button + auto ladder read exactly as before
-  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "apiRetry", id: it\.sid \}\);/);
+  // the auto-retry contract is untouched: the retry button (a manual retry, as the chat pane sends) + auto ladder stay
+  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "apiRetry", id: it\.sid, manual: true \}\);/);
 });

--- a/ui/webview/feed-card-gate.test.ts
+++ b/ui/webview/feed-card-gate.test.ts
@@ -2,14 +2,13 @@
 // outside the ask object must flip the key, equal inputs must give equal keys, a quarantine card must
 // never skip, and cardNeedsUpdate must fire on a new object OR a new key. A missed input here is a stale
 // badge on an unchanged card, so the test walks the inputs one at a time. The gate's premise — an unchanged
-// card keeps its OBJECT through the delivery path — is run against the pane shim's delta reassembly (the JS
-// kernel.py inlines into every pane page, lifted and executed in a sandbox) and pinned on federation's
-// merge. Synthetic notes-api world.
+// card keeps its OBJECT through the delivery path — is run against the pane shim's delta reassembly in the
+// lane that owns the shim (tests/test_view_deltas.py, under node) and pinned here on federation's merge.
+// Synthetic notes-api world.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import * as vm from "node:vm";
 import { cardInputsKey, cardNeedsUpdate, type GateEnv, type GateItem } from "./feed-card-gate";
 
 const WEB = "11111111-2222-3333-4444-555555555555";
@@ -112,72 +111,11 @@ test("cardNeedsUpdate: false for the same object under the same key; true for a 
 });
 
 // --- the gate's premise: an unchanged card keeps its OBJECT through the delivery path -----------------
-// The pane shim (kernel.py _shim) applies a `{type:"delta"}` frame itself and hands the bundle a full
-// message; its template is lifted from the kernel source the way pane-shim-stale.test.ts does and run in a
-// sandbox with a fake socket, so what reaches the bundle is what the shim's own code builds.
-const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
-function shimJs(app: string): string {
-  const def = KERNEL.indexOf("def _shim(app, v=0):");
-  assert.ok(def > 0, "the shim renderer exists");
-  const start = KERNEL.indexOf('return """', def) + 'return """'.length;
-  const end = KERNEL.indexOf('""" % (app, int(v), app, app)', start);
-  assert.ok(end > start, "the template's format tuple is the one the test substitutes");
-  const args = [app, "5", app, app];
-  let i = 0;
-  return KERNEL.slice(start, end).replace(/%[sd]/g, () => args[i++]).replace(/%%/g, "%");
-}
-
-test("the pane shim reassembles a feed delta reusing every untouched card object; only the re-sent card is a new one — the identity the gate reads", () => {
-  const toBundle: any[] = [];
-  const sockets: any[] = [];
-  class FakeWS {
-    url: string; readyState = 0; onopen: any; onmessage: any; onclose: any; onerror: any;
-    constructor(url: string) { this.url = url; sockets.push(this); }
-    send() {}
-    close() {}
-    open() { this.readyState = 1; this.onopen?.(); }
-    msg(o: any) { this.onmessage?.({ data: JSON.stringify(o) }); }
-  }
-  const sandbox: any = {
-    window: {
-      parent: { postMessage() {} },
-      sessionStorage: { getItem: () => "" },
-      dispatchEvent: (e: any) => { if (e && e.data !== undefined) toBundle.push(e.data); return true; },   // no federation on this page: the shim dispatches on window
-      addEventListener() {}, innerWidth: 800, innerHeight: 600,
-    },
-    document: { addEventListener() {}, visibilityState: "visible", getElementById: () => null },
-    localStorage: { getItem: () => null, setItem() {} },
-    location: { protocol: "http:", host: "TESTHOST:29855", search: "" },
-    URLSearchParams: class { get() { return ""; } },
-    WebSocket: FakeWS, Date, JSON, console, encodeURIComponent,
-    Event: class { type: string; constructor(t: string) { this.type = t; } },
-    MessageEvent: class { type: string; data: any; constructor(t: string, o: any) { this.type = t; this.data = o.data; } },
-    setTimeout: () => 1, clearTimeout() {}, setInterval: () => 1,
-    // the shim hands frames to the bundle through a MessageChannel-flushed queue (deltas are still reassembled
-    // synchronously, in wire order, before they are queued); delivered synchronously here so `toBundle` reads
-    // in wire order. `performance` backs the shim's page-load breadcrumb. The same stubs as pane-shim-stale.test.ts.
-    MessageChannel: class { port1: any = { onmessage: null }; port2: any; constructor() { const p1 = this.port1; this.port2 = { postMessage: (d: any) => { p1.onmessage?.({ data: d }); } }; } },
-    performance: { getEntriesByType: () => [] },
-  };
-  sandbox.window.window = sandbox.window;
-  vm.runInNewContext(shimJs("feed"), sandbox);
-  const ws = sockets[0];
-  assert.match(ws.url, /[?&]delta=1(&|$)/, "the page asks for deltas");
-  ws.open();
-  const a = card({ itemId: "g1" }), b = card({ itemId: "g2", sid: API, name: "api" });
-  ws.msg({ type: "feed", asks: [a, b], _keys: { asks: ["g1", "g2"] } });          // the keyed full frame
-  ws.msg({ type: "delta", slot: "feed", base: 0, rev: 1, coll: { asks: { set: { g2: { ...b, column: "completed" } } } } });
-  assert.equal(toBundle.length, 2, "both frames reached the bundle as full messages");
-  const [full, next] = toBundle;
-  assert.equal(next.type, "feed");
-  assert.notEqual(next, full, "a delta builds a NEW message object (the bundle may still hold the previous one)");
-  assert.equal(next.asks.length, 2);
-  assert.equal(next.asks[0], full.asks[0], "the untouched card is the same object: the gate skips it");
-  assert.notEqual(next.asks[1], full.asks[1], "the re-sent card is a new object: the gate repaints it");
-  assert.equal(next.asks[1].column, "completed");
-  assert.equal(next.asks[1].itemId, "g2");
-});
-
+// The pane shim (kernel.py _shim) applies a `{type:"delta"}` frame itself and hands the bundle a full message,
+// reusing every untouched card object and minting a new one only for a card the delta set. That is the shim's
+// behaviour, so its own lane holds it: tests/test_view_deltas.py runs the kernel's shim JavaScript under node
+// against the kernel's own frames (review find, 2026-09-08: a kernel edit must not break this lane, and a test
+// that lifts kernel.py by source text is one that can). Federation's merge, the other hop, is pinned below.
 test("federation's merge pushes each host's cards by reference (a defensive copy there would silently turn the gate into always-update)", () => {
   const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
   assert.match(FED, /if \(Array\.isArray\(f\.asks\)\) merged\.asks\.push\(\.\.\.f\.asks\);/);

--- a/ui/webview/feed-card-gate.test.ts
+++ b/ui/webview/feed-card-gate.test.ts
@@ -1,0 +1,184 @@
+// The per-card update gate (feed-card-gate.ts), EXECUTED: every board-level input updateAskCard reads
+// outside the ask object must flip the key, equal inputs must give equal keys, a quarantine card must
+// never skip, and cardNeedsUpdate must fire on a new object OR a new key. A missed input here is a stale
+// badge on an unchanged card, so the test walks the inputs one at a time. The gate's premise — an unchanged
+// card keeps its OBJECT through the delivery path — is run against the pane shim's delta reassembly (the JS
+// kernel.py inlines into every pane page, lifted and executed in a sandbox) and pinned on federation's
+// merge. Synthetic notes-api world.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as vm from "node:vm";
+import { cardInputsKey, cardNeedsUpdate, type GateEnv, type GateItem } from "./feed-card-gate";
+
+const WEB = "11111111-2222-3333-4444-555555555555";
+const API = "11111111-2222-3333-4444-666666666666";
+const card = (over: Partial<GateItem> = {}): GateItem => ({
+  itemId: "g1", sid: WEB, name: "web", color: { bg: "#3366cc" },
+  tree: [
+    { kind: "ask", who: "web", whoSid: WEB },
+    { kind: "handoff", who: "api", whoSid: API },
+  ],
+  delegTracked: [{ name: "tests" }],
+  ...over,
+});
+const env = (over: Partial<GateEnv> = {}): GateEnv => ({
+  dot: () => "",
+  working: () => false,
+  focusId: null,
+  pinnedId: null,
+  notifyOn: () => false,
+  prefs: { grouped: true, collapsed: false, colormap: "aurora" },
+  hostDown: () => false,
+  selfHost: "TESTHOST",
+  repo: () => null,
+  seq: 1,
+  ...over,
+});
+
+test("identical inputs give an identical key, across renders and across a fresh env object", () => {
+  const it = card();
+  assert.equal(cardInputsKey(it, env()), cardInputsKey(it, env()));
+  assert.equal(cardInputsKey(it, env({ seq: 7 })), cardInputsKey(it, env({ seq: 9 })),
+    "the per-render counter reaches only quarantine cards");
+});
+
+test("each board-level input flips the key on its own", () => {
+  const it = card();
+  const base = cardInputsKey(it, env());
+  const flips: Record<string, Partial<GateEnv>> = {
+    "the card's own working dot":      { dot: (n) => (n === "web" ? "work" : "") },
+    "the card's own awaiting dot":     { dot: (n) => (n === "web" ? "await" : "") },
+    "the card's own unknown ring":     { dot: (n) => (n === "web" ? "unknown" : "") },
+    "a tracked delegation peer's dot": { dot: (n) => (n === "tests" ? "work" : "") },
+    "a handoff recipient working":     { working: (n) => n === "api" },
+    "hover focus on this card":        { focusId: "g1" },
+    "a pin on this card":              { pinnedId: "g1" },
+    "the bell":                        { notifyOn: () => true },
+    "grouped mode":                    { prefs: { grouped: false, collapsed: false, colormap: "aurora" } },
+    "the collapsed default":           { prefs: { grouped: true, collapsed: true, colormap: "aurora" } },
+    "the colormap":                    { prefs: { grouped: true, collapsed: false, colormap: "viridis" } },
+    "the session's host going down":   { hostDown: (sid) => sid === WEB },
+    "this machine's own name":         { selfHost: "OTHERHOST" },
+    "the session's GitHub repository": { repo: (sid) => (sid === WEB ? "example/notes-api" : null) },
+  };
+  const seen = new Set<string>([base]);
+  for (const [what, over] of Object.entries(flips)) {
+    const k = cardInputsKey(it, env(over));
+    assert.notEqual(k, base, what + " must flip the key");
+    assert.ok(!seen.has(k), what + " must not collide with another input's key");
+    seen.add(k);
+  }
+});
+
+test("inputs that belong to OTHER sessions leave this card's key alone", () => {
+  const it = card();
+  const base = cardInputsKey(it, env());
+  assert.equal(cardInputsKey(it, env({ dot: (n) => (n === "api" ? "work" : "") })), base,
+    "api working: not this card's session, not a tracked peer — the handoff line reads workingSet, tested separately");
+  assert.equal(cardInputsKey(it, env({ focusId: "g2", pinnedId: "g2" })), base, "focus and pin on another card");
+  assert.equal(cardInputsKey(it, env({ hostDown: (sid) => sid === API })), base, "another host down");
+  assert.equal(cardInputsKey(it, env({ repo: (sid) => (sid === API ? "example/notes-api" : null) })), base,
+    "another session's repository");
+});
+
+test("the colour echo's in-place write reaches the gate through the key (the object identity cannot carry it)", () => {
+  const it = card();
+  const before = cardInputsKey(it, env());
+  it.color = { bg: "#cc3366" };   // feed.ts applyColorEcho writes the shared ask object in place, by design
+  assert.notEqual(cardInputsKey(it, env()), before);
+  assert.equal(cardNeedsUpdate({ _it: it, _ik: before }, it, cardInputsKey(it, env())), true,
+    "same object, echoed colour: the card repaints");
+});
+
+test("a quarantine card never yields an equal key across renders", () => {
+  const q = card({ blocked: { state: "quarantine" } });
+  assert.notEqual(cardInputsKey(q, env({ seq: 1 })), cardInputsKey(q, env({ seq: 2 })));
+  assert.equal(cardInputsKey(q, env({ seq: 3 })), cardInputsKey(q, env({ seq: 3 })),
+    "…within one render it is stable (the counter is per render, not per call)");
+  const plain = card({ blocked: { state: "permission" } });
+  assert.equal(cardInputsKey(plain, env({ seq: 1 })), cardInputsKey(plain, env({ seq: 2 })),
+    "an ordinary block reads no per-name colour map: it skips like any card");
+});
+
+test("cardNeedsUpdate: false for the same object under the same key; true for a copy, or for a new key", () => {
+  const it = card();
+  const k = cardInputsKey(it, env());
+  assert.equal(cardNeedsUpdate({ _it: it, _ik: k }, it, k), false, "nothing changed: skip");
+  assert.equal(cardNeedsUpdate({ _it: it, _ik: k }, { ...it }, k), true, "a new object (the kernel re-sent it): update");
+  assert.equal(cardNeedsUpdate({ _it: it, _ik: k }, it, k + "|x"), true, "a board-level input changed: update");
+  assert.equal(cardNeedsUpdate({}, it, k), true, "a freshly minted card has neither: update");
+});
+
+// --- the gate's premise: an unchanged card keeps its OBJECT through the delivery path -----------------
+// The pane shim (kernel.py _shim) applies a `{type:"delta"}` frame itself and hands the bundle a full
+// message; its template is lifted from the kernel source the way pane-shim-stale.test.ts does and run in a
+// sandbox with a fake socket, so what reaches the bundle is what the shim's own code builds.
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+function shimJs(app: string): string {
+  const def = KERNEL.indexOf("def _shim(app, v=0):");
+  assert.ok(def > 0, "the shim renderer exists");
+  const start = KERNEL.indexOf('return """', def) + 'return """'.length;
+  const end = KERNEL.indexOf('""" % (app, int(v), app, app)', start);
+  assert.ok(end > start, "the template's format tuple is the one the test substitutes");
+  const args = [app, "5", app, app];
+  let i = 0;
+  return KERNEL.slice(start, end).replace(/%[sd]/g, () => args[i++]).replace(/%%/g, "%");
+}
+
+test("the pane shim reassembles a feed delta reusing every untouched card object; only the re-sent card is a new one — the identity the gate reads", () => {
+  const toBundle: any[] = [];
+  const sockets: any[] = [];
+  class FakeWS {
+    url: string; readyState = 0; onopen: any; onmessage: any; onclose: any; onerror: any;
+    constructor(url: string) { this.url = url; sockets.push(this); }
+    send() {}
+    close() {}
+    open() { this.readyState = 1; this.onopen?.(); }
+    msg(o: any) { this.onmessage?.({ data: JSON.stringify(o) }); }
+  }
+  const sandbox: any = {
+    window: {
+      parent: { postMessage() {} },
+      sessionStorage: { getItem: () => "" },
+      dispatchEvent: (e: any) => { if (e && e.data !== undefined) toBundle.push(e.data); return true; },   // no federation on this page: the shim dispatches on window
+      addEventListener() {}, innerWidth: 800, innerHeight: 600,
+    },
+    document: { addEventListener() {}, visibilityState: "visible", getElementById: () => null },
+    localStorage: { getItem: () => null, setItem() {} },
+    location: { protocol: "http:", host: "TESTHOST:29855", search: "" },
+    URLSearchParams: class { get() { return ""; } },
+    WebSocket: FakeWS, Date, JSON, console, encodeURIComponent,
+    Event: class { type: string; constructor(t: string) { this.type = t; } },
+    MessageEvent: class { type: string; data: any; constructor(t: string, o: any) { this.type = t; this.data = o.data; } },
+    setTimeout: () => 1, clearTimeout() {}, setInterval: () => 1,
+    // the shim hands frames to the bundle through a MessageChannel-flushed queue (deltas are still reassembled
+    // synchronously, in wire order, before they are queued); delivered synchronously here so `toBundle` reads
+    // in wire order. `performance` backs the shim's page-load breadcrumb. The same stubs as pane-shim-stale.test.ts.
+    MessageChannel: class { port1: any = { onmessage: null }; port2: any; constructor() { const p1 = this.port1; this.port2 = { postMessage: (d: any) => { p1.onmessage?.({ data: d }); } }; } },
+    performance: { getEntriesByType: () => [] },
+  };
+  sandbox.window.window = sandbox.window;
+  vm.runInNewContext(shimJs("feed"), sandbox);
+  const ws = sockets[0];
+  assert.match(ws.url, /[?&]delta=1(&|$)/, "the page asks for deltas");
+  ws.open();
+  const a = card({ itemId: "g1" }), b = card({ itemId: "g2", sid: API, name: "api" });
+  ws.msg({ type: "feed", asks: [a, b], _keys: { asks: ["g1", "g2"] } });          // the keyed full frame
+  ws.msg({ type: "delta", slot: "feed", base: 0, rev: 1, coll: { asks: { set: { g2: { ...b, column: "completed" } } } } });
+  assert.equal(toBundle.length, 2, "both frames reached the bundle as full messages");
+  const [full, next] = toBundle;
+  assert.equal(next.type, "feed");
+  assert.notEqual(next, full, "a delta builds a NEW message object (the bundle may still hold the previous one)");
+  assert.equal(next.asks.length, 2);
+  assert.equal(next.asks[0], full.asks[0], "the untouched card is the same object: the gate skips it");
+  assert.notEqual(next.asks[1], full.asks[1], "the re-sent card is a new object: the gate repaints it");
+  assert.equal(next.asks[1].column, "completed");
+  assert.equal(next.asks[1].itemId, "g2");
+});
+
+test("federation's merge pushes each host's cards by reference (a defensive copy there would silently turn the gate into always-update)", () => {
+  const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+  assert.match(FED, /if \(Array\.isArray\(f\.asks\)\) merged\.asks\.push\(\.\.\.f\.asks\);/);
+});

--- a/ui/webview/feed-card-gate.ts
+++ b/ui/webview/feed-card-gate.ts
@@ -1,0 +1,106 @@
+// The feed pane's per-card UPDATE GATE: reconcileCol calls updateAskCard only for a card whose inputs
+// changed since it was last painted. The paint key this replaces serialised every card on every render
+// (JSON.stringify per card) and carried two whole-board terms — a fifteen-second clock, and an epoch bumped
+// by every change to the working/awaiting/unknown sets and by every settings write — so the first frame in
+// each 15 s window, and every frame during activity, repainted EVERY card: the className rewrite, the tint,
+// the name nodes minted anew, the delegation lines rebuilt (a whole-board style invalidation), and then the
+// scroll restore at the end of render() forced a synchronous layout of all of it. This key is O(1) per
+// card and names only what that card reads, so a change repaints the cards it reaches and no others.
+//
+// What a card's face depends on, and how each dependency reaches the gate:
+//   - the ask object itself. An unchanged card keeps its OBJECT through the delivery path: the pane shim
+//     reassembles a `{type:"delta"}` frame reusing every untouched item (kernel.py _shim, applyDelta), and
+//     federation's merge pushes each host's items through by reference (federation.ts mergeHostFeeds) —
+//     both pinned by tests, because a defensive copy anywhere on that path would silently turn this gate
+//     into always-update. So a new object means the kernel re-sent this card: `card._it !== it`
+//     (updateAskCard stashes `_it`).
+//   - every board-level input updateAskCard reads OUTSIDE the ask object: cardInputsKey folds them into
+//     one string, computed from an env the render builds once. The list below is the complete set (a
+//     source scan of updateAskCard, applySections, quarWho, dotFor and prRepoOf); a missed input shows as
+//     a stale badge on an unchanged card, so keep it complete.
+//   - a local gesture (a section toggle, the bell, hover/pin): its handler writes the DOM directly and,
+//     where a column could change, calls render(); hover/pin are also in the key.
+//   - time: the 15 s tick rewrites every card's age label itself; a duration baked into a caption string
+//     (the awaiting box, the waiting-on chip, a paragraph age) moves on the card's next repaint.
+// The card's column and its place in the column are NOT gated — reconcileCol re-applies both every
+// render — so a card whose column or sort key changed still moves (a column change always arrives as a
+// new object; a follow-move prediction is a copy, see applyFollowMove).
+//
+// Deliberately NOT in the key: secChoice / cardTreeExpanded (their handlers repaint the card locally; the
+// settings-driven reset rides prefs.collapsed), pendingDone (the modal's tree reads it, the card's checklist
+// does not). Pure: node --test runs it without a DOM.
+
+/** The slice of an ask the key reads. Structural, so tests pass plain objects. */
+export interface GateItem {
+  itemId: string;
+  sid: string;
+  name: string;
+  color?: { bg: string } | null;
+  blocked?: { state: string } | null;
+  tree?: { kind: string; who: string; whoSid?: string }[] | null;
+  delegTracked?: { name: string }[] | null;
+}
+
+/** The board-level inputs, resolved by the render once per pass. */
+export interface GateEnv {
+  /** dotFor: the working / awaiting / unknown state of a session by name — the card's own dot, the
+   *  apiRecovered rule (working or awaiting), and each tracked delegation peer's dot. */
+  dot: (name: string) => string;
+  /** workingSet membership by name: the handoff delegation lines show only live-working recipients. */
+  working: (name: string) => boolean;
+  /** hoverAskId ?? pinnedAskId, and pinnedAskId: the .focused / .pinned classes. */
+  focusId: string | null;
+  pinnedId: string | null;
+  /** cardNotifyOn: the bell's effective state (pendingNotify over the payload's notify). */
+  notifyOn: (it: GateItem) => boolean;
+  /** feedPrefs: grouped hides the name row, collapsed is the section default (resolveSec), and a
+   *  colormap pick repaints every card once, as the settings epoch did (the tint is the kernel's trgb and
+   *  follows on its rebuild; the term keeps the key complete for the one settings write about tints). */
+  prefs: { grouped: boolean; collapsed: boolean; colormap: string };
+  /** hostIsDown(sid): the struck "host:" prefix on a remote session's name. */
+  hostDown: (sid: string) => boolean;
+  /** feedSelfHost: the quarantine route's recipient host. */
+  selfHost: string;
+  /** prRepoOf(sid): the GitHub repository (owner/repo, or null) the card's session works in, read off the
+   *  frame's session rows; the title, checklist, takeaway and tree link their `#123` to it (pr-links.ts). A
+   *  session whose repository arrives or changes must relink an otherwise unchanged card. */
+  repo: (sid: string) => string | null;
+  /** A per-render counter for cards that must never skip: a quarantine card reads sessionColors by
+   *  name, a map the payload rebuilds every frame, so its key is unique per render. */
+  seq: number;
+}
+
+/** One string of every board-level input this card's face reads. Two renders with equal inputs
+ *  give equal keys; a change in any one of them changes the key. */
+export function cardInputsKey(it: GateItem, env: GateEnv): string {
+  const parts: string[] = [
+    env.dot(it.name),
+    it.itemId === env.focusId ? "f" : "",
+    it.itemId === env.pinnedId ? "p" : "",
+    env.notifyOn(it) ? "n" : "",
+    env.prefs.grouped ? "g" : "",
+    env.prefs.collapsed ? "c" : "",
+    env.prefs.colormap,
+    env.hostDown(it.sid) ? "d" : "",
+    env.selfHost,
+    env.repo(it.sid) || "",
+    // the colour echo (feed.ts applyColorEcho) writes `a.color` IN PLACE — the one write into a shared
+    // ask object — so identity cannot carry it; the colour rides the key instead
+    (it.color && it.color.bg) || "",
+  ];
+  for (const n of it.tree || []) {
+    if (n.kind !== "handoff" || !n.whoSid) continue;
+    parts.push(n.whoSid + (env.working(n.who) ? "w" : ""));
+  }
+  for (const d of it.delegTracked || []) parts.push(env.dot(d.name));
+  if (it.blocked && it.blocked.state === "quarantine") parts.push("q" + env.seq);
+  return parts.join("|");
+}
+
+/** The card element's gate fields, as updateAskCard and reconcileCol keep them. */
+export interface GatedCard { _it?: unknown; _ik?: string }
+
+/** True when the card was last painted from a different object, or under different inputs. */
+export function cardNeedsUpdate(card: GatedCard, it: unknown, key: string): boolean {
+  return card._it !== it || card._ik !== key;
+}

--- a/ui/webview/feed-card-prefs.test.ts
+++ b/ui/webview/feed-card-prefs.test.ts
@@ -15,8 +15,10 @@ test("feed prefs from romp:settings: newestFirst/collapsed default OFF, grouped 
   // newestFirst + collapsed default OFF (=== true); grouped defaults ON (!== false — the user 2026-07-13:
   // by-session grouping is the feed's normal reading mode, the footer Group toggle opts OUT).
   // `subgoals` is no longer a feed-wide pref (per-card button now).
-  assert.match(FEED, /return \{ newestFirst: s\.newestFirst === true, collapsed: s\.collapsed === true, grouped: s\.grouped !== false,\s*\n\s*stacked: s\.stacked === true \};/);
-  assert.match(FEED, /catch \{ return \{ newestFirst: false, collapsed: false, grouped: true, stacked: false \}; \}/);
+  assert.match(FEED, /prefsMemo = \{ newestFirst: s\.newestFirst === true, collapsed: s\.collapsed === true, grouped: s\.grouped !== false,\s*\n\s*stacked: s\.stacked === true, colormap: String\(s\.colormap \|\| "aurora"\)\.toLowerCase\(\) \};/);
+  assert.match(FEED, /const PREFS_DEFAULT: FeedPrefs = \{ newestFirst: false, collapsed: false, grouped: true, stacked: false, colormap: "aurora" \};/);
+  // memoised on the raw settings string: the same string returns the same object, a changed one re-parses
+  assert.match(FEED, /if \(raw === prefsRaw\) return prefsMemo;/);
   assert.doesNotMatch(FEED, /s\.subgoals/, "no feed-wide subgoals pref — it's a per-card toggle now");
   assert.doesNotMatch(FEED, /explanations/);   // every trace of the old pref is gone from the feed
 });

--- a/ui/webview/feed-counts.test.ts
+++ b/ui/webview/feed-counts.test.ts
@@ -36,8 +36,8 @@ test("expansion invariance, executed: folding moves cards onto the header withou
 });
 
 test("just the number — the word 'cards' never renders; words live on hover", () => {
-  assert.match(FEED, /foldn\.textContent = String\(e\.folded\);/);
-  assert.ok(!/foldn\.textContent = [^;]*card/.test(FEED), "no wording variant survives");
+  assert.match(FEED, /setText\(foldn, String\(e\.folded\)\);/);   // compare-first: headers repaint every render
+  assert.ok(!/setText\(foldn, [^;]*card/.test(FEED), "no wording variant survives");
   assert.match(FEED, /foldn\.title = e\.folded === 1 \? "1 card folded under this session"/,
     "the tooltip keeps the words the visible chip dropped");
 });

--- a/ui/webview/feed-flip.test.ts
+++ b/ui/webview/feed-flip.test.ts
@@ -58,9 +58,11 @@ test("a card repaints only when its object or a board-level input it reads chang
   // the env, built once per render from everything a card's paint reads outside its object
   assert.match(SRC, /const gate: GateEnv = \{\n\s*dot: dotFor, working: \(n\) => workingSet\.has\(n\),\n\s*focusId: hoverAskId \?\? pinnedAskId, pinnedId: pinnedAskId, notifyOn: cardNotifyOn,\n\s*prefs: \{ grouped: gprefs\.grouped, collapsed: gprefs\.collapsed, colormap: gprefs\.colormap \},\n\s*hostDown: hostIsDown, selfHost: feedSelfHost, repo: prRepoOf, seq: \+\+renderSeq,\n\s*\};/);
   assert.match(SRC, /reconcileCol\(cols\.asks, buckets\.asks, desired, gate\);\n\s*reconcileCol\(cols\.needsInput, buckets\.needsInput, desired, gate\);\n\s*reconcileCol\(cols\.completed, buckets\.completed, desired, gate\);/);
-  // the latches: the card's Retry is a manual retry, and Retry and Revive re-arm on the kernel's err frame for the session
+  // the latches: the card's Retry is a manual retry, and each latch re-arms on the kernel's reply for ITS request
+  // (review find, 2026-09-08): a refused apiRetry names the session, reviveFailed names the revived id
   assert.match(SRC, /vscodeApi\?\.postMessage\(\{ type: "apiRetry", id: it\.sid, manual: true \}\);/);
-  assert.match(SRC, /showErrDialog\(title, m\.text, copy\);\n\s*rearmLatches\(typeof m\.sid === "string" \? m\.sid : typeof m\.id === "string" \? m\.id : ""\);/);
+  assert.match(SRC, /showErrDialog\(title, m\.text, copy\);[\s\S]*?if \(op === "apiRetry" && sid\) rearmLatches\(\{ kind: "retry", sid \}\);/);
+  assert.match(SRC, /m\.type === "reviveFailed" && typeof m\.id === "string" && m\.id\) \{[\s\S]*?rearmLatches\(\{ kind: "revive", id: m\.id \}\)/);
   assert.match(SRC, /\(a\._revive as any\)\._idle = a\._revive\.textContent;/);
   // Undo takes .dismissing off a card restored inside its collapse window (the class rewrite no longer does)
   assert.match(SRC, /askEls\.get\(it\.itemId\)\?\.classList\.remove\("dismissing"\);/);

--- a/ui/webview/feed-flip.test.ts
+++ b/ui/webview/feed-flip.test.ts
@@ -45,17 +45,23 @@ test("the fly reads every rect before it writes any transform", () => {
   assert.match(body, /const moves: \{ c: HTMLElement; dx: number; dy: number; crossed: boolean \}\[\] = \[\];/);
 });
 
-test("a card whose data and display state did not change is not repainted", () => {
-  assert.match(SRC, /function cardPaintKey\(it: AskItem\): string \{\n\s*return JSON\.stringify\(it\) \+ "\|"/);
-  assert.match(SRC, /const pk = cardPaintKey\(it\);[\s\S]*?if \(a\._paintKey === pk && !card\.querySelector\("button\[disabled\]"\)\) return;/,
-    "a latched (disabled) button always repaints: the next paint is what re-enables it");
-  // the inputs every card reads that live outside its item: prefs, the status sets + self host, the clock
-  assert.match(SRC, /\+ "\|" \+ paintEpoch \+ "\|" \+ Math\.floor\(Date\.now\(\) \/ 15000\);/);
-  assert.match(SRC, /function onSettingsChanged\(\): void \{\n\s*paintEpoch\+\+;/);
-  assert.match(SRC, /function noteStatusInputs\(\): void \{\n\s*const sig = \[\.\.\.workingSet\]\.sort\(\)\.join\(","\) \+ "\|" \+ \[\.\.\.awaitingSet\][\s\S]*?\[\.\.\.unknownSet\][\s\S]*?feedSelfHost;\n\s*if \(sig !== statusSig\) \{ statusSig = sig; paintEpoch\+\+; \}/);
-  assert.match(SRC, /unknownSet = new Set\([\s\S]*?\n\s*noteStatusInputs\(\);/, "the payload handler notes the sets right after setting them");
-  // the display-side inputs the paint reads are part of the key (a hover, a pin, a pending bell, a done tick)
-  assert.match(SRC, /hoverAskId \?\? pinnedAskId/);
-  assert.match(SRC, /pendingNotify\.has\(it\.itemId\)/);
-  assert.match(SRC, /\[\.\.\.pendingDone\]\.join\(","\)/, "an optimistic done tick anywhere repaints every card: the set is usually empty");
+test("a card repaints only when its object or a board-level input it reads changed (feed-card-gate.ts)", () => {
+  // the paint key that gated here before serialised every card per render and carried two whole-board terms
+  // (a 15 s clock, an epoch bumped by every status-set and settings change); none of it remains
+  assert.doesNotMatch(SRC, /cardPaintKey|paintEpoch|noteStatusInputs|_paintKey|button\[disabled\]/);
+  assert.match(SRC, /import \{ cardInputsKey, cardNeedsUpdate, type GateEnv \} from "\.\/feed-card-gate";/);
+  // reconcileCol gates the ask branch: a new object OR a new key repaints; the key is stored after the paint
+  assert.match(SRC, /function reconcileCol\(listEl: HTMLElement, entries: Entry\[\], globalDesired: Set<string>, gate: GateEnv\)/);
+  assert.match(SRC, /const ik = cardInputsKey\(e\.ask, gate\);\n\s*if \(cardNeedsUpdate\(card as any, e\.ask, ik\)\) \{ updateAskCard\(card, e\.ask\); \(card as any\)\._ik = ik; \}/);
+  assert.match(SRC, /function updateAskCard\(card: HTMLElement, it: AskItem\) \{\n\s*const a = card as any;\n\s*a\._it = it;/,
+    "updateAskCard stashes the object the gate compares, first thing");
+  // the env, built once per render from everything a card's paint reads outside its object
+  assert.match(SRC, /const gate: GateEnv = \{\n\s*dot: dotFor, working: \(n\) => workingSet\.has\(n\),\n\s*focusId: hoverAskId \?\? pinnedAskId, pinnedId: pinnedAskId, notifyOn: cardNotifyOn,\n\s*prefs: \{ grouped: gprefs\.grouped, collapsed: gprefs\.collapsed, colormap: gprefs\.colormap \},\n\s*hostDown: hostIsDown, selfHost: feedSelfHost, repo: prRepoOf, seq: \+\+renderSeq,\n\s*\};/);
+  assert.match(SRC, /reconcileCol\(cols\.asks, buckets\.asks, desired, gate\);\n\s*reconcileCol\(cols\.needsInput, buckets\.needsInput, desired, gate\);\n\s*reconcileCol\(cols\.completed, buckets\.completed, desired, gate\);/);
+  // the latches: the card's Retry is a manual retry, and Retry and Revive re-arm on the kernel's err frame for the session
+  assert.match(SRC, /vscodeApi\?\.postMessage\(\{ type: "apiRetry", id: it\.sid, manual: true \}\);/);
+  assert.match(SRC, /showErrDialog\(title, m\.text, copy\);\n\s*rearmLatches\(typeof m\.sid === "string" \? m\.sid : typeof m\.id === "string" \? m\.id : ""\);/);
+  assert.match(SRC, /\(a\._revive as any\)\._idle = a\._revive\.textContent;/);
+  // Undo takes .dismissing off a card restored inside its collapse window (the class rewrite no longer does)
+  assert.match(SRC, /askEls\.get\(it\.itemId\)\?\.classList\.remove\("dismissing"\);/);
 });

--- a/ui/webview/feed-handoff-badge.test.ts
+++ b/ui/webview/feed-handoff-badge.test.ts
@@ -12,7 +12,7 @@ import * as path from "node:path";
 
 const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 const BLK = SRC.slice(SRC.indexOf("if (it.handoffTo && it.handoffTo.peerSid) {"),
-                      SRC.indexOf("a._time.textContent"));
+                      SRC.indexOf("stampAge(a._time, it.t"));
 
 test("the badge is additive on the type — a payload without it renders exactly as before", () => {
   assert.match(SRC, /handoffTo\?: \{ peer: string; peerSid: string; peerHost\?: string; color\?: \{ bg: string; fg: string \} \| null \} \| null;/);

--- a/ui/webview/feed-hidden-paint.test.ts
+++ b/ui/webview/feed-hidden-paint.test.ts
@@ -131,7 +131,11 @@ test("render() is gated first, on the shared pure decision, and nothing else in 
   assert.match(SRC, /import \{ paintHeld, paintReleased \} from "\.\/paint-gate";/);
   assert.match(SRC, /function render\(\) \{\n  const list = document\.getElementById\("feed-list"\)!;\n  if \(!feedWatching\) \{ feedWatching = true; watchFeedVisibility\(list\); \}\n  if \(paintHeld\(document\.hidden, feedIntersecting, list\.childElementCount > 0\)\) \{ paintDirty = true; return; \}\n  pruneTip\(\);/,
     "the gate precedes every paint-side step (pruneTip, applyFollowMove, the footer, the columns)");
-  assert.equal(SRC.split("paintHeld(").length - 1, 1, "one gate, in render(): no other path is withheld");
+  // two gates, both PAINTS: render(), and the 15 s age pass (feed-age.ts liveRefresher) that rewrites the stamped
+  // labels on the cards render() did not repaint — it reads the same decision, so the feed has one meaning of
+  // "hidden"; no state path is withheld
+  assert.equal(SRC.split("paintHeld(").length - 1, 2, "two gates: render() and the age pass; no other path is withheld");
+  assert.match(SRC, /const live = liveRefresher\(\{ hidden: \(\) => paintHeld\(document\.hidden, feedIntersecting, true\), pass: livePass \}\);/);
   assert.match(SRC, /let feedIntersecting = true;/, "visible until the observer says otherwise: no observer → the tab alone gates");
 });
 
@@ -146,7 +150,7 @@ test("the flip is skipped exactly once after a release, and prevCols still recor
 test("BOTH release events run the same release: visibilitychange→visible and the observer's callback", () => {
   assert.match(SRC, /document\.addEventListener\("visibilitychange", \(\) => \{ if \(!document\.hidden\) releasePaint\(\); \}\);/);
   const watch = body("watchFeedVisibility");
-  assert.match(watch, /new IntersectionObserver\(\(entries\) => \{\n\s*feedIntersecting = entries\.some\(\(e\) => e\.isIntersecting\);\n\s*releasePaint\(\);\n\s*\}\)\.observe\(list\);/);
+  assert.match(watch, /new IntersectionObserver\(\(entries\) => \{\n\s*feedIntersecting = entries\.some\(\(e\) => e\.isIntersecting\);\n\s*releasePaint\(\);\n\s*live\.catchUp\(\);[^\n]*\n\s*\}\)\.observe\(list\);/);
   assert.match(watch, /if \(typeof IntersectionObserver === "undefined"\) return;/);
 });
 

--- a/ui/webview/feed-render-incremental.test.ts
+++ b/ui/webview/feed-render-incremental.test.ts
@@ -7,7 +7,10 @@
 // fail: a re-dispatch of the same objects across a 15 s boundary rebuilds nothing (the key carried a
 // fifteen-second clock term, so the first frame of every window repainted every card), and one session's
 // `working` change repaints that session's cards alone (the key carried an epoch every status-set change
-// bumped, so every card repainted).
+// bumped, so every card repainted). The last cases pin what the gate leaves to the animations themselves,
+// now that no per-render className rewrite strips their classes: a fly ends on its own event or a backstop,
+// skips a folded column's zero rect at either end, and one fly owns a card at a time; a reveal pulse ends;
+// a session header's name nodes are minted only when what they show changes.
 //
 // The stand-in is the tree of plain objects the Outline pane's live-clock test boots its bundle under, grown to
 // what feed.ts's boot and render paths touch: a small selector engine (descendant chains, classes, ids, attribute presence and
@@ -65,6 +68,7 @@ class El extends EventTarget {
   style = new Style();
   rc = 0;                                   // replaceChildren calls (the name nodes' rebuild)
   tc = 0;                                   // textContent sets
+  ac = 0;                                   // setAttribute calls (a same-value write still queues a mutation record in a browser)
   private attrs = new Map<string, string>();
   private classes = new Set<string>();
   private _html = "";
@@ -117,7 +121,7 @@ class El extends EventTarget {
   get lastChild(): El | Txt | null { return this.childNodes[this.childNodes.length - 1] ?? null; }
   get childElementCount(): number { return this.children.length; }
   contains(x: El | Txt | null): boolean { for (let n: El | Txt | null = x; n; n = n.parentNode) if (n === this) return true; return false; }
-  setAttribute(k: string, v: string): void { this.attrs.set(k, String(v)); if (k.startsWith("data-")) this.dataset[camel(k.slice(5))] = String(v); if (k === "id") this.id = v; }
+  setAttribute(k: string, v: string): void { this.ac++; this.attrs.set(k, String(v)); if (k.startsWith("data-")) this.dataset[camel(k.slice(5))] = String(v); if (k === "id") this.id = v; }
   getAttribute(k: string): string | null { return this.attrs.get(k) ?? (k.startsWith("data-") ? this.dataset[camel(k.slice(5))] ?? null : k === "title" && this.title ? this.title : null); }
   hasAttribute(k: string): boolean { return this.getAttribute(k) !== null; }
   removeAttribute(k: string): void { this.attrs.delete(k); if (k === "title") this.title = ""; }
@@ -283,9 +287,17 @@ test("frame B: only the card whose object changed repaints; it moves column; the
 
 test("frame C: the same frame re-dispatched (a federation re-emit) rebuilds nothing and reads no rects", async () => {
   // frame B emptied api's run in Working, so its session header left as a ghost (re-keyed x:N until its exit
-  // animation ends, or the 600 ms backstop); 700 ms later the backstop has fired
-  mock.timers.tick(700);
+  // animation ends, or the 600 ms backstop) and g2 flew to Completed; 700 ms later both backstops have fired:
+  // no transition ends under the stand-in, so the fly's own backstop is what takes the card out of the back
+  // layer (before it, a card whose transitionend never came kept pointer-events:none until its next repaint)
+  // (two ticks: a timer created inside a mock tick is stamped with the tick's END time, so one 700 ms tick
+  // would run the nested animation frame AFTER the 650 ms backstop — the reverse of a browser's order)
+  mock.timers.tick(20);
+  assert.equal(card("g2").style.transform, "translate(0, 0)", "the frame after the invert releases the offset");
+  mock.timers.tick(680);
   assert.equal(body.querySelectorAll(".sess-exit").length, 0, "the exited header is gone");
+  assert.ok(!card("g2").classList.contains("fitem-flying"), "the fly ended by its backstop");
+  assert.equal(card("g2").style.transform, "", "…and the card is back in normal flow");
   await dispatch(frame([g1, { ...g2, column: "completed" }, g3]));   // a fresh copy of g2 IS a new object: it repaints — that is the contract
   assert.deepEqual(nameRebuilds(), { g1: 1, g2: 3, g3: 1 });
   const readsBefore = rectReads;
@@ -615,6 +627,106 @@ test("Undo inside a card's 180 ms collapse keeps the restored card: the gesture 
   assert.equal(colOf("g3"), "col-asks-list");
 });
 
+test("a card moving into a FOLDED column (display:none, a zero rect) gets no fly: nothing to glide to, and the class it would wear turns the pointer off", async () => {
+  body.byId("col-completed-list")!.style.display = "none";   // the Completed section folded to its header
+  const g3done = { ...card("g3")._it, column: "completed" };
+  await dispatch(frame([g1, card("g2")._it, g3done], { working: ["web"] }));
+  assert.equal(colOf("g3"), "col-completed-list", "the card moved");
+  assert.ok(!card("g3").classList.contains("fitem-flying"), "no fly into a column nobody can see");
+  assert.equal(card("g3").style.transform ?? "", "", "no inverted transform left on it");
+  body.byId("col-completed-list")!.style.display = "";
+});
+
+test("…and a card LEAVING a folded column (a zero First rect) gets no fly either: nothing to glide from", async () => {
+  body.byId("col-completed-list")!.style.display = "none";   // g3 sits in the folded Completed section
+  await dispatch(frame([g1, card("g2")._it, { ...card("g3")._it, column: "working" }], { working: ["web"] }));
+  assert.equal(colOf("g3"), "col-asks-list", "the card moved back to Working");
+  assert.ok(!card("g3").classList.contains("fitem-flying"), "no fly from a spot nobody could see");
+  assert.equal(card("g3").style.transform ?? "", "", "no inverted transform from the pane's corner");
+  body.byId("col-completed-list")!.style.display = "";
+});
+
+test("a second fly of the same card while the first still runs keeps its own Invert through the first fly's cancel, and the first fly's backstop leaves it alone", async () => {
+  const c2 = card("g2");
+  await dispatch(frame([g1, { ...c2._it, column: "working" }, card("g3")._it], { working: ["web"] }));   // fly 1: Completed → Working
+  assert.ok(c2.classList.contains("fitem-flying"));
+  mock.timers.tick(20);                                        // fly 1 plays: its transition is running
+  assert.equal(c2.style.transform, "translate(0, 0)");
+  await dispatch(frame([g1, { ...c2._it, column: "completed" }, card("g3")._it], { working: ["web"] }));   // fly 2, mid-flight: back to Completed
+  const inverted = c2.style.transform;
+  assert.match(inverted, /^translate\(-?\d/, "fly 2 inverted the card to its old spot");
+  assert.notEqual(inverted, "translate(0, 0)");
+  // the browser cancels fly 1's transition on that write and tells EVERY listener before fly 2's Play frame
+  c2.dispatchEvent(Object.assign(new Event("transitioncancel"), { propertyName: "transform" }));
+  assert.equal(c2.style.transform, inverted, "fly 1's cancel handler is superseded; fly 2's ignores an event before its own Play — the Invert survives");
+  assert.ok(c2.classList.contains("fitem-flying"), "…and the back layer stays on for the crossing");
+  mock.timers.tick(20);                                        // fly 2 plays
+  assert.equal(c2.style.transform, "translate(0, 0)");
+  assert.match(c2.style.transition, /transform \.42s/);
+  mock.timers.tick(610);                                       // fly 1's 650 ms backstop falls due: superseded, a no-op
+  assert.match(c2.style.transition, /transform \.42s/, "fly 2 is still in flight");
+  assert.ok(c2.classList.contains("fitem-flying"));
+  mock.timers.tick(20);                                        // fly 2's own backstop ends it
+  assert.equal(c2.style.transform, "");
+  assert.equal(c2.style.transition, "");
+  assert.ok(!c2.classList.contains("fitem-flying"));
+});
+
+test("a fly ends on its own transitionend; another property's transitionend is not this fly's", async () => {
+  const c2 = card("g2");
+  await dispatch(frame([g1, { ...c2._it, column: "working" }, card("g3")._it], { working: ["web"] }));   // Completed → Working
+  assert.ok(c2.classList.contains("fitem-flying"));
+  mock.timers.tick(20);                                        // played
+  assert.equal(c2.style.transform, "translate(0, 0)");
+  c2.dispatchEvent(Object.assign(new Event("transitionend"), { propertyName: "opacity" }));
+  assert.ok(c2.classList.contains("fitem-flying"), "another property's end is not this fly's");
+  assert.equal(c2.style.transform, "translate(0, 0)");
+  c2.dispatchEvent(Object.assign(new Event("transitionend"), { propertyName: "transform" }));
+  assert.ok(!c2.classList.contains("fitem-flying"), "the transform's end takes the card out of the back layer");
+  assert.equal(c2.style.transform, ""); assert.equal(c2.style.transition, "");
+  mock.timers.tick(700);
+  assert.equal(c2.style.transform, "", "…and the backstop that follows has nothing to do");
+});
+
+test("a fly ends on a transitioncancel AFTER its Play: a card hidden or re-inserted mid-flight gets cancel, never end", async () => {
+  const c2 = card("g2");
+  await dispatch(frame([g1, { ...c2._it, column: "completed" }, card("g3")._it], { working: ["web"] }));   // Working → Completed
+  assert.ok(c2.classList.contains("fitem-flying"));
+  mock.timers.tick(20);                                        // played: the cancel is now this fly's own
+  c2.dispatchEvent(Object.assign(new Event("transitioncancel"), { propertyName: "transform" }));
+  assert.ok(!c2.classList.contains("fitem-flying"), "the cancel of its own transition ends the fly");
+  assert.equal(c2.style.transform, ""); assert.equal(c2.style.transition, "");
+});
+
+test("the release frame stands down when the backstop already ended the fly: no identity transform is left on a settled card", async () => {
+  const c2 = card("g2");
+  await dispatch(frame([g1, { ...c2._it, column: "working" }, card("g3")._it], { working: ["web"] }));   // Completed → Working
+  assert.ok(c2.classList.contains("fitem-flying"));
+  mock.timers.tick(700);   // ONE tick: a timer created inside a tick is stamped at its end, so the nested animation frame runs AFTER the 650 ms backstop — a hidden tab's order
+  assert.ok(!c2.classList.contains("fitem-flying"), "the backstop ended the fly");
+  assert.equal(c2.style.transform, "", "the release frame found it ended and wrote nothing");
+  assert.equal(c2.style.transition, "");
+});
+
+test("the back-layer class comes off whichever fly added it: a crossing fly superseded by an in-place shift of the same card", async () => {
+  const c2 = card("g2");
+  await dispatch(frame([g1, { ...c2._it, column: "completed" }, card("g3")._it], { working: ["web"] }));   // fly 1: Working → Completed, crossing
+  assert.ok(c2.classList.contains("fitem-flying"));
+  mock.timers.tick(20);                                        // fly 1 plays
+  // fly 2: web's card lands in Completed above api's run, so g2 shifts within its column — no crossing
+  await dispatch(frame([{ ...g1, column: "completed" }, card("g2")._it, card("g3")._it], { working: ["web"] }));
+  assert.equal(colOf("g2"), "col-completed-list");
+  assert.match(c2.style.transform, /^translate\(-?\d/, "fly 2 inverted the shift");
+  c2.dispatchEvent(Object.assign(new Event("transitioncancel"), { propertyName: "transform" }));   // fly 1's transition was interrupted: its cancel
+  assert.ok(c2.classList.contains("fitem-flying"), "fly 1 is superseded and touches nothing: the class stays for the fly that owns the card");
+  mock.timers.tick(20);                                        // fly 2 plays
+  mock.timers.tick(650);                                       // fly 2's backstop
+  assert.ok(!c2.classList.contains("fitem-flying"), "fly 2 did not cross, and still takes the class off: whichever fly added it");
+  assert.equal(c2.style.transform, ""); assert.equal(c2.style.transition, "");
+  await dispatch(frame([g1, card("g2")._it, card("g3")._it], { working: ["web"] }));   // g1 back to Working
+  mock.timers.tick(700);
+});
+
 test("Retry latches on the click and re-arms only on a deciding event: the kernel's reply frame, or a repaint of the card", async () => {
   const blockedG1 = { ...g1, blocked: { state: "apiError", what: "the API returned 529", status: 529 } };
   await dispatch(frame([blockedG1, card("g2")._it, card("g3")._it]));   // web is NOT working: the API-error unit shows
@@ -638,5 +750,99 @@ test("Retry latches on the click and re-arms only on a deciding event: the kerne
   assert.equal(retry.disabled, false, "a repaint re-arms it too");
   await dispatch(frame([g1, card("g2")._it, card("g3")._it]));   // the block is gone: the unit hides
   assert.equal(card("g1")._apiRetry.style.display, "none");
+});
+
+test("a reveal pulse comes off when its animation ends, and a child's animation ending inside the card does not end it", async () => {
+  const c1 = card("g1");
+  await dispatch({ type: "revealCards", keys: ["g1"] });
+  assert.ok(c1.classList.contains("card-pulse"));
+  // animationend bubbles: a button's acted flash inside the card reaches the card's listener too
+  c1.dispatchEvent(Object.assign(new Event("animationend"), { animationName: "romp-acted-pulse" }));
+  assert.ok(c1.classList.contains("card-pulse"), "another animation's end is not this pulse's");
+  c1.dispatchEvent(Object.assign(new Event("animationend"), { animationName: "romp-card-pulse" }));
+  assert.ok(!c1.classList.contains("card-pulse"), "the pulse's own end takes the class off");
+  mock.timers.tick(1600);
+  assert.ok(!c1.classList.contains("card-pulse"), "…and the backstop that follows has nothing to do");
+});
+
+test("a second reveal pulse inside the first's window is not cut short by the first's backstop", async () => {
+  const c1 = card("g1");
+  await dispatch({ type: "revealCards", keys: ["g1"] });
+  assert.ok(c1.classList.contains("card-pulse"));
+  mock.timers.tick(600);
+  await dispatch({ type: "revealCards", keys: ["g1"] });        // pulse again, 600 ms in
+  mock.timers.tick(1000);                                       // the FIRST backstop's moment (1500 ms after it armed)
+  assert.ok(c1.classList.contains("card-pulse"), "the second pulse still shows: one handle per element");
+  mock.timers.tick(600);                                        // the second backstop
+  assert.ok(!c1.classList.contains("card-pulse"), "…and it comes off at its own end");
+});
+
+test("a pulse ended by its animationend leaves no backstop behind: a later reveal inside 1500 ms is not cut short by it", async () => {
+  const c1 = card("g1");
+  await dispatch({ type: "revealCards", keys: ["g1"] });
+  c1.dispatchEvent(Object.assign(new Event("animationend"), { animationName: "romp-card-pulse" }));
+  assert.ok(!c1.classList.contains("card-pulse"));
+  mock.timers.tick(600);
+  await dispatch({ type: "revealCards", keys: ["g1"] });        // pulse again
+  mock.timers.tick(1000);                                       // the first backstop's moment, had it survived the end
+  assert.ok(c1.classList.contains("card-pulse"), "the second pulse still shows");
+  mock.timers.tick(600);
+  assert.ok(!c1.classList.contains("card-pulse"), "…and ends at its own backstop");
+});
+
+test("a session header's name nodes are minted only when what they show changes: an unchanged header re-mints nothing", async () => {
+  // grouped mode's headers are not behind the per-card gate: updateSessHead runs for every header on every
+  // render, and minted the name nodes each time (a Text-node replacement per header per render)
+  const heads = () => Object.fromEntries(body.querySelectorAll(".feed-sess-head").filter((h: any) => !h.classList.contains("sess-exit"))
+    .map((h: any) => [h.getAttribute("data-fsid"), h._name.rc]));
+  const same = frame([g1, card("g2")._it, card("g3")._it]);   // the objects the cards were painted from
+  await dispatch(same);
+  const before = heads();
+  assert.equal(Object.keys(before).length, 3, "one header per session run");
+  await dispatch(same);
+  await dispatch(same);
+  assert.deepEqual(heads(), before, "an unchanged header re-mints nothing");
+  await dispatch(frame([{ ...g1, name: "web-2" }, card("g2")._it, card("g3")._it]));   // web's card renamed: its header follows
+  assert.deepEqual(heads(), { ...before, [WEB]: before[WEB] + 1 }, "the renamed session's header re-minted once; the others did not");
+  assert.equal((body.querySelector(`.feed-sess-head[data-fsid="${WEB}"]`) as any)._name.textContent, "web-2");
+});
+
+test("a header's data-fsid is written only when it differs", async () => {
+  const heads = () => body.querySelectorAll(".feed-sess-head").filter((h) => !h.classList.contains("sess-exit"));
+  const same = frame([{ ...g1, name: "web-2" }, card("g2")._it, card("g3")._it]);   // the objects the cards were painted from
+  await dispatch(same);
+  const before = heads().map((h) => [h.getAttribute("data-fsid"), h.ac]);
+  assert.equal(before.length, 3);
+  await dispatch(same); await dispatch(same);
+  assert.deepEqual(heads().map((h) => [h.getAttribute("data-fsid"), h.ac]), before, "an unchanged sid is compared and not re-set");
+});
+
+test("a header re-mints its name nodes when its host's link goes down or comes back, and only then", async () => {
+  let downList: string[] = [];
+  (globalThis as any).__rompFed = { down: () => downList };                 // what hostIsDown reads (federation.js publishes it)
+  const REMOTE = "remote:11111111-2222-3333-4444-888888888888";
+  const g4 = cardOf("g4", REMOTE, "remote:docs", "#996633", "Draft the notes-api docs", "working");
+  const four = () => frame([{ ...g1, name: "web-2" }, card("g2")._it, card("g3")._it, g4],
+    { order: [WEB, API, TESTS, REMOTE], sessions: [{ sid: WEB, name: "web-2", color: g1.color }, { sid: API, name: "api", color: g2.color }, { sid: TESTS, name: "tests", color: g3.color }, { sid: REMOTE, name: "remote:docs", color: g4.color }] });
+  await dispatch(four());
+  const head = () => body.querySelector(`.feed-sess-head[data-fsid="${REMOTE}"]`) as any;
+  assert.equal(head()._name.rc, 1, "minted once");
+  assert.equal(head()._name.querySelector(".host-prefix").textContent, "remote:");
+  assert.ok(!head()._name.querySelector(".host-prefix").classList.contains("off"));
+  await dispatch(four());
+  assert.equal(head()._name.rc, 1, "the same name, sid and link state: nothing re-minted");
+  downList = ["remote"];
+  await dispatch(four());
+  assert.equal(head()._name.rc, 2, "the link went down: re-minted once…");
+  assert.ok(head()._name.querySelector(".host-prefix").classList.contains("off"), "…with the off mark");
+  await dispatch(four());
+  assert.equal(head()._name.rc, 2, "still down: nothing");
+  downList = [];
+  await dispatch(four());
+  assert.equal(head()._name.rc, 3, "back up: re-minted once…");
+  assert.ok(!head()._name.querySelector(".host-prefix").classList.contains("off"), "…the mark gone");
+  delete (globalThis as any).__rompFed;
+  await dispatch(frame([g1, card("g2")._it, card("g3")._it]));
+  mock.timers.tick(700);
   mock.timers.reset();
 });

--- a/ui/webview/feed-render-incremental.test.ts
+++ b/ui/webview/feed-render-incremental.test.ts
@@ -1,0 +1,476 @@
+// The feed pane's per-card update gate, RUN: feed.ts booted under a DOM stand-in, fed synthetic frames through
+// the window message it listens on, and watched for what each render REBUILT. The invariant these frames pin:
+// a card repaints when the kernel sent it (a new object), when a board-level input it reads changed (the
+// key), or when a gesture touched it; its column and order are re-applied on every render regardless;
+// nothing else touches it. Two of the assertions are the regressions the paint key this gate replaced would
+// fail: a re-dispatch of the same objects across a 15 s boundary rebuilds nothing (the key carried a
+// fifteen-second clock term, so the first frame of every window repainted every card), and one session's
+// `working` change repaints that session's cards alone (the key carried an epoch every status-set change
+// bumped, so every card repainted).
+//
+// The stand-in is the tree of plain objects the Outline pane's live-clock test boots its bundle under, grown to
+// what feed.ts's boot and render paths touch: a small selector engine (descendant chains, classes, ids, attribute presence and
+// equality; every pseudo-class, :hover included, matches nothing), insertBefore/sibling walks, dataset-backed
+// data-* attributes, a style object with custom properties, EventTarget elements, and counters for the
+// writes the gate is about (replaceChildren on a card's name node, textContent sets, getBoundingClientRect
+// reads, scrollTop writes). gear.js's initGear returns at once when #rsettings already exists, so the
+// settings modal never mounts. Synthetic only: the notes-api demo world, placeholder sids, hostname TESTHOST.
+import { test, mock, after } from "node:test";
+import * as assert from "node:assert/strict";
+
+// ── a DOM stand-in ─────────────────────────────────────────────────────────────────────────────────
+class Style {
+  [key: string]: any;
+  private props = new Map<string, string>();
+  setProperty(k: string, v: string): void { this.props.set(k, v); }
+  removeProperty(k: string): void { this.props.delete(k); }
+  getPropertyValue(k: string): string { return this.props.get(k) ?? ""; }
+}
+class Txt {
+  nodeType = 3;
+  parentNode: El | null = null;
+  constructor(public textContent: string) {}
+  get nextSibling(): El | Txt | null { return sib(this, 1); }
+  remove(): void { this.parentNode?.removeChild(this); }
+}
+function sib(n: El | Txt, d: number): El | Txt | null {
+  const p = n.parentNode; if (!p) return null;
+  const i = p.childNodes.indexOf(n); return p.childNodes[i + d] ?? null;
+}
+const camel = (s: string) => s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+type Compound = { tag: string | null; id: string | null; classes: string[]; attrs: { name: string; value: string | null }[]; pseudo: boolean };
+function parseCompound(s: string): Compound {
+  const c: Compound = { tag: null, id: null, classes: [], attrs: [], pseudo: false };
+  const m = /^([a-zA-Z][\w-]*)?(.*)$/.exec(s)!;
+  c.tag = m[1] ? m[1].toUpperCase() : null;
+  const re = /\.([\w-]+)|#([\w-]+)|\[([\w-]+)(?:="([^"]*)")?\]|:[\w-]+(?:\([^)]*\))?/g;
+  let t: RegExpExecArray | null;
+  while ((t = re.exec(m[2]))) {
+    if (t[1]) c.classes.push(t[1]);
+    else if (t[2]) c.id = t[2];
+    else if (t[3]) c.attrs.push({ name: t[3], value: t[4] ?? null });
+    else c.pseudo = true;
+  }
+  return c;
+}
+class El extends EventTarget {
+  nodeType = 1;
+  id = ""; title = ""; hidden = false; value = ""; type = ""; checked = false; disabled = false;
+  offsetWidth = 0; offsetHeight = 0; clientWidth = 800; clientHeight = 600; isContentEditable = false;
+  onclick: ((ev: any) => void) | null = null;
+  parentNode: El | null = null;
+  childNodes: Array<El | Txt> = [];
+  dataset: Record<string, string | undefined> = {};
+  style = new Style();
+  rc = 0;                                   // replaceChildren calls (the name nodes' rebuild)
+  tc = 0;                                   // textContent sets
+  private attrs = new Map<string, string>();
+  private classes = new Set<string>();
+  private _html = "";
+  private _scrollTop = 0;
+  classList = {
+    add: (...c: string[]) => { for (const x of c) this.classes.add(x); },
+    remove: (...c: string[]) => { for (const x of c) this.classes.delete(x); },
+    toggle: (c: string, force?: boolean) => {
+      const on = force === undefined ? !this.classes.has(c) : force;
+      if (on) this.classes.add(c); else this.classes.delete(c);
+      return on;
+    },
+    contains: (c: string) => this.classes.has(c),
+  };
+  constructor(public tagName: string) { super(); this.tagName = tagName.toUpperCase(); }
+  get className(): string { return [...this.classes].join(" "); }
+  set className(v: string) { this.classes = new Set(v.split(/\s+/).filter(Boolean)); }
+  get textContent(): string { return this.childNodes.map((c) => c.textContent).join(""); }
+  set textContent(v: string | null) { this.tc++; this.detachAll(); if (v !== null && v !== "") this.appendChild(new Txt(String(v))); }
+  get innerHTML(): string { return this._html; }
+  set innerHTML(v: string) { this.detachAll(); this._html = v; }
+  get scrollTop(): number { return this._scrollTop; }
+  set scrollTop(v: number) { scrollWrites.push(v); this._scrollTop = v; }
+  get children(): El[] { return this.childNodes.filter((c): c is El => c instanceof El); }
+  get firstChild(): El | Txt | null { return this.childNodes[0] ?? null; }
+  get nextSibling(): El | Txt | null { return sib(this, 1); }
+  get parentElement(): El | null { return this.parentNode; }
+  get previousElementSibling(): El | null { for (let n = sib(this, -1); n; n = sib(n, -1)) if (n instanceof El) return n; return null; }
+  get nextElementSibling(): El | null { for (let n = sib(this, 1); n; n = sib(n, 1)) if (n instanceof El) return n; return null; }
+  get isConnected(): boolean { return this === body || body.contains(this); }
+  private detachAll(): void { for (const c of this.childNodes) c.parentNode = null; this.childNodes = []; }
+  private adopt(c: El | Txt | string): El | Txt { const n = typeof c === "string" ? new Txt(c) : c; n.parentNode?.removeChild(n); n.parentNode = this; return n; }
+  appendChild<T extends El | Txt>(c: T): T { this.childNodes.push(this.adopt(c) as T); return c; }
+  append(...cs: Array<El | Txt | string>): void { for (const c of cs) this.childNodes.push(this.adopt(c)); }
+  prepend(...cs: Array<El | Txt | string>): void { this.childNodes.unshift(...cs.map((c) => this.adopt(c))); }
+  replaceChildren(...cs: Array<El | Txt | string>): void { this.rc++; this.detachAll(); this.append(...cs); }
+  insertBefore<T extends El | Txt>(node: T, ref: El | Txt | null): T {
+    const n = this.adopt(node);
+    const i = ref ? this.childNodes.indexOf(ref) : -1;
+    if (i < 0) this.childNodes.push(n); else this.childNodes.splice(i, 0, n);
+    return node;
+  }
+  removeChild(c: El | Txt): void { const i = this.childNodes.indexOf(c); if (i >= 0) { this.childNodes.splice(i, 1); c.parentNode = null; } }
+  remove(): void { this.parentNode?.removeChild(this); }
+  after(...cs: Array<El | Txt | string>): void { const p = this.parentNode; if (!p) return; const ref = sib(this, 1); for (const c of cs) p.insertBefore(typeof c === "string" ? new Txt(c) : c, ref); }
+  before(...cs: Array<El | Txt | string>): void { const p = this.parentNode; if (!p) return; for (const c of cs) p.insertBefore(typeof c === "string" ? new Txt(c) : c, this); }
+  replaceWith(c: El | Txt): void { const p = this.parentNode; if (!p) return; p.insertBefore(c, this); this.remove(); }
+  get firstElementChild(): El | null { return this.children[0] ?? null; }
+  get lastElementChild(): El | null { const c = this.children; return c[c.length - 1] ?? null; }
+  get lastChild(): El | Txt | null { return this.childNodes[this.childNodes.length - 1] ?? null; }
+  get childElementCount(): number { return this.children.length; }
+  contains(x: El | Txt | null): boolean { for (let n: El | Txt | null = x; n; n = n.parentNode) if (n === this) return true; return false; }
+  setAttribute(k: string, v: string): void { this.attrs.set(k, String(v)); if (k.startsWith("data-")) this.dataset[camel(k.slice(5))] = String(v); if (k === "id") this.id = v; }
+  getAttribute(k: string): string | null { return this.attrs.get(k) ?? (k.startsWith("data-") ? this.dataset[camel(k.slice(5))] ?? null : k === "title" && this.title ? this.title : null); }
+  hasAttribute(k: string): boolean { return this.getAttribute(k) !== null; }
+  removeAttribute(k: string): void { this.attrs.delete(k); if (k === "title") this.title = ""; }
+  getBoundingClientRect() {
+    // a rendered element gets a rect from its place: a column's cards stack 100 px apart and each column sits
+    // at its own left, so a card that changed column or slot has a different rect and one that did not has
+    // the same; anything hidden (display:none on it or an ancestor) or detached is a zero rect, as in a browser
+    rectReads++;
+    for (let n: El | null = this; n; n = n.parentNode) if (n.style.display === "none") return { left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 };
+    if (!this.isConnected) return { left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 };
+    const p = this.parentNode!;
+    const top = p.children.indexOf(this) * 100, left = p.id.length * 10;
+    return { left, top, right: left + 300, bottom: top + 90, width: 300, height: 90 };
+  }
+  scrollIntoView(): void {}
+  focus(): void {}
+  blur(): void {}
+  matchesCompound(c: Compound): boolean {
+    if (c.pseudo) return false;
+    if (c.tag && c.tag !== this.tagName) return false;
+    if (c.id && c.id !== this.id) return false;
+    for (const k of c.classes) if (!this.classes.has(k)) return false;
+    for (const a of c.attrs) { const v = this.getAttribute(a.name); if (v === null) return false; if (a.value !== null && v !== a.value) return false; }
+    return true;
+  }
+  matches(sel: string): boolean {
+    return sel.split(",").some((one) => {
+      const parts = one.trim().split(/\s+/).map(parseCompound);
+      if (!this.matchesCompound(parts[parts.length - 1])) return false;
+      let anc: El | null = this.parentNode;
+      for (let i = parts.length - 2; i >= 0; i--) {
+        while (anc && !anc.matchesCompound(parts[i])) anc = anc.parentNode;
+        if (!anc) return false;
+        anc = anc.parentNode;
+      }
+      return true;
+    });
+  }
+  closest(sel: string): El | null { for (let n: El | null = this; n; n = n.parentNode) if (n.matches(sel)) return n; return null; }
+  querySelectorAll(sel: string): El[] { return [...this.walk()].filter((e) => e.matches(sel)); }
+  querySelector(sel: string): El | null { for (const e of this.walk()) if (e.matches(sel)) return e; return null; }
+  *walk(): Generator<El> { for (const c of this.childNodes) if (c instanceof El) { yield c; yield* c.walk(); } }
+  byId(id: string): El | null { for (const e of this.walk()) if (e.id === id) return e; return null; }
+}
+let rectReads = 0;
+const scrollWrites: number[] = [];
+const posted: any[] = [];
+const body = new El("body");
+const head = new El("div"); head.id = "feed-head";
+const list = new El("div"); list.id = "feed-list";
+const foot = new El("div"); foot.id = "feed-foot";
+const gearGuard = new El("div"); gearGuard.id = "rsettings";   // initGear's idempotence check: present → the modal never mounts
+body.append(head, list, foot, gearGuard);
+const stores = { local: new Map<string, string>(), session: new Map<string, string>() };
+const storage = (m: Map<string, string>) => ({
+  getItem: (k: string) => (m.has(k) ? m.get(k)! : null),
+  setItem: (k: string, v: string) => { m.set(k, String(v)); },
+  removeItem: (k: string) => { m.delete(k); },
+});
+const win: any = new EventTarget();
+win.parent = win; win.top = win;
+win.location = { hash: "", search: "", protocol: "http:" };
+win.innerWidth = 1200; win.innerHeight = 800;
+win.setTimeout = (...a: Parameters<typeof setTimeout>) => setTimeout(...a);
+win.clearTimeout = (t: ReturnType<typeof setTimeout>) => clearTimeout(t);
+win.setInterval = (...a: Parameters<typeof setInterval>) => setInterval(...a);
+win.requestAnimationFrame = (cb: () => void) => setTimeout(cb, 0);
+win.matchMedia = () => ({ matches: false, addEventListener() {}, addListener() {} });
+win.getComputedStyle = () => ({ flexDirection: "row", order: "0" });
+win.postMessage = () => {};
+win.acquireVsCodeApi = () => ({ postMessage: (m: any) => posted.push(m) });
+(globalThis as any).window = win;
+(globalThis as any).requestAnimationFrame = win.requestAnimationFrame;
+(globalThis as any).getComputedStyle = win.getComputedStyle;
+(globalThis as any).MouseEvent = class MouseEvent extends Event { clientX = 0; clientY = 0; };
+const doc: any = new EventTarget();
+Object.assign(doc, {
+  body, head: new El("head"), documentElement: new El("html"), hidden: false, activeElement: body,
+  createElement: (tag: string) => new El(tag),
+  createTextNode: (s: string) => new Txt(s),
+  getElementById: (id: string) => body.byId(id),
+  querySelectorAll: (sel: string) => body.querySelectorAll(sel),
+  querySelector: (sel: string) => body.querySelector(sel),
+  contains: (x: El) => body.contains(x),
+});
+(globalThis as any).document = doc;
+(globalThis as any).localStorage = storage(stores.local);
+(globalThis as any).sessionStorage = storage(stores.session);
+
+// ── the world: three sessions of a notes-api project, three cards ─────────────────────────────────
+const T0 = 1781100000;                      // the browser clock at boot
+const K0 = T0 - 300;                        // the kernel clock, five minutes behind — the age label follows it
+const WEB = "11111111-2222-3333-4444-555555555555", API = "11111111-2222-3333-4444-666666666666", TESTS = "11111111-2222-3333-4444-777777777777";
+const node = (id: string, text: string, who: string, whoSid: string, children: string[] = []) =>
+  ({ id, kind: "ask", text, who, whoSid, whoColor: null, status: "open", t: K0 - 240, last: K0 - 240, children });
+const cardOf = (itemId: string, sid: string, name: string, bg: string, text: string, column: string, extra: Record<string, unknown> = {}) => ({
+  itemId, sid, name, color: { bg, fg: "#ffffff" }, text, t: K0 - 240, trgb: [96, 128, 160], live: true, turnId: "turn-" + itemId, column,
+  summary: null, blockSummary: null, tree: [node(itemId, text, name, sid)], ...extra,
+});
+const g1 = cardOf("g1", WEB, "web", "#3366cc", "Wire the notes-api health route", "working",
+  { tree: [node("g1", "Wire the notes-api health route", "web", WEB, ["g1a"]), node("g1a", "Add the /health handler", "web", WEB)] });
+const g2 = cardOf("g2", API, "api", "#cc6633", "Write the notes-api README", "working");
+const g3 = cardOf("g3", TESTS, "tests", "#33cc66", "Run the notes-api test suite", "working",
+  { awaiting: { why: "", kind: "agents", count: 2, since: K0 - 600 } });
+// upstream's frame shape: the kernel's `now`, per-card `trgb`, the status sets, the session order and list
+const frame = (asks: any[], over: Record<string, unknown> = {}) => ({
+  type: "feed", now: K0, buildId: 1, asks,
+  working: [], awaiting: [], stateUnknown: [], order: [WEB, API, TESTS], selfHost: "TESTHOST",
+  sessions: [{ sid: WEB, name: "web", color: g1.color }, { sid: API, name: "api", color: g2.color }, { sid: TESTS, name: "tests", color: g3.color }],
+  bgServices: {}, ...over,
+});
+const listenerErrors: Error[] = [];
+process.on("uncaughtException", (e) => { listenerErrors.push(e); });
+const settle = () => new Promise<void>((r) => setImmediate(r));   // let a deferred listener exception land before the assertions
+const dispatch = async (f: any) => {
+  win.dispatchEvent(new MessageEvent("message", { data: f }));
+  await settle();
+  if (listenerErrors.length) { const es = listenerErrors.splice(0); throw new Error("a listener threw: " + es.map((e) => e.stack || e.message).join("\n---\n")); }
+};
+after(() => { assert.deepEqual(listenerErrors.map((e) => e.stack || e.message), [], "no listener threw outside a dispatch (a gesture handler, a timer)"); });
+const card = (id: string): any => body.querySelector(`[data-key="a:${id}"]`);
+const colOf = (id: string) => card(id)?.parentNode?.id;
+const nameRebuilds = () => ({ g1: card("g1")._name.rc, g2: card("g2")._name.rc, g3: card("g3")._name.rc });
+const ev = { stopPropagation() {}, preventDefault() {} };
+
+test("frame A: three cards are built once each, in the Working column", async () => {
+  mock.timers.enable({ apis: ["Date", "setTimeout", "setInterval"], now: T0 * 1000 });
+  await import("./feed");                   // module load: gear (a no-op here), listeners, the 15 s tick
+  assert.equal(posted.filter((m) => m.type === "ready").length, 1, "the ready handshake");
+  await dispatch(frame([g1, g2, g3]));
+  assert.deepEqual(nameRebuilds(), { g1: 1, g2: 1, g3: 1 }, "each name node was built exactly once");
+  assert.deepEqual({ g1: colOf("g1"), g2: colOf("g2"), g3: colOf("g3") }, { g1: "col-asks-list", g2: "col-asks-list", g3: "col-asks-list" });
+  assert.equal(card("g1")._time.textContent, "4m ago", "on the kernel's clock (the browser clock is five minutes ahead)");
+  assert.match(card("g3")._awaitWhy.textContent, /^Awaiting /, "the awaiting box shows the wait");
+  // open card 1's Sub-goals section (a gesture): the section state must survive the renders below untouched
+  card("g1")._subBtn.onclick(ev);
+  assert.equal(card("g1")._subBtn.getAttribute("aria-pressed"), "true");
+  assert.equal(card("g1")._checklist.children.length, 1, "one sub-goal row");
+});
+
+test("frame B: only the card whose object changed repaints; it moves column; the other cards keep their DOM and their open section", async () => {
+  const row = card("g1")._checklist.children[0];
+  const readsBefore = rectReads;
+  list.scrollTop = 120; scrollWrites.length = 0;
+  const g2done = { ...g2, column: "completed" };
+  await dispatch(frame([g1, g2done, g3]));
+  assert.deepEqual(nameRebuilds(), { g1: 1, g2: 2, g3: 1 }, "exactly one name rebuild: the re-sent card");
+  assert.equal(colOf("g2"), "col-completed-list", "the changed card moved to Completed");
+  assert.equal(colOf("g1"), "col-asks-list"); assert.equal(colOf("g3"), "col-asks-list");
+  assert.equal(body.byId("col-asks-count")!.textContent, "2"); assert.equal(body.byId("col-completed-count")!.textContent, "1");
+  assert.equal(card("g1")._subBtn.getAttribute("aria-pressed"), "true", "the open section stayed open");
+  assert.equal(card("g1")._checklist.children[0], row, "…and its rows are the same nodes, not a rebuild");
+  assert.equal(scrollWrites[scrollWrites.length - 1], 120, "the scroll position is restored");
+  assert.ok(rectReads > readsBefore, "a column changed, so the FLIP passes read rects");
+  assert.ok(card("g2").classList.contains("fitem-flying"), "the card that crossed columns flies in the back layer");
+  assert.match(card("g2").style.transform, /^translate\(/, "…inverted to its old spot first");
+});
+
+test("frame C: the same frame re-dispatched (a federation re-emit) rebuilds nothing and reads no rects", async () => {
+  // frame B emptied api's run in Working, so its session header left as a ghost (re-keyed x:N until its exit
+  // animation ends, or the 600 ms backstop); 700 ms later the backstop has fired
+  mock.timers.tick(700);
+  assert.equal(body.querySelectorAll(".sess-exit").length, 0, "the exited header is gone");
+  await dispatch(frame([g1, { ...g2, column: "completed" }, g3]));   // a fresh copy of g2 IS a new object: it repaints — that is the contract
+  assert.deepEqual(nameRebuilds(), { g1: 1, g2: 3, g3: 1 });
+  const readsBefore = rectReads;
+  const tcBefore = { g1: card("g1")._title.tc, g2: card("g2")._title.tc, g3: card("g3")._title.tc };
+  const same = frame([g1, card("g2")._it, g3]);              // now the very objects the cards were painted from
+  await dispatch(same);
+  await dispatch(same);
+  assert.deepEqual(nameRebuilds(), { g1: 1, g2: 3, g3: 1 }, "zero rebuilds on identical objects under identical inputs");
+  assert.deepEqual({ g1: card("g1")._title.tc, g2: card("g2")._title.tc, g3: card("g3")._title.tc }, tcBefore,
+    "no title text was rewritten either");
+  assert.equal(rectReads, readsBefore, "no card changed column or place: the FLIP passes read nothing");
+});
+
+test("…and across a 15 s boundary: the clock is not a paint input", async () => {
+  // the key this gate replaced carried a fifteen-second term, so the first frame in every 15 s window
+  // repainted every card. The tick that fires inside this window rewrites the age labels (its own business);
+  // it rebuilds no card.
+  const before = nameRebuilds(), readsBefore = rectReads;
+  const same = frame([g1, card("g2")._it, g3]);
+  mock.timers.tick(16_000);
+  await dispatch(same);
+  assert.deepEqual(nameRebuilds(), before, "the same objects across a 15 s boundary: zero rebuilds");
+  assert.equal(rectReads, readsBefore);
+});
+
+test("frame D: `working` naming card 1's session repaints card 1 (its dot) and leaves the other sessions' cards alone", async () => {
+  // the key this gate replaced carried an epoch every status-set change bumped: every card repainted
+  const g2now = card("g2")._it;
+  await dispatch(frame([g1, g2now, g3], { working: ["web"] }));
+  assert.deepEqual(nameRebuilds(), { g1: 2, g2: 3, g3: 1 }, "the key changed for web's card only");
+  assert.ok(card("g1")._name.previousElementSibling?.classList.contains("fwork-dot"), "the working dot sits before the name");
+  await dispatch(frame([g1, g2now, g3], { working: ["web"] }));
+  assert.deepEqual(nameRebuilds(), { g1: 2, g2: 3, g3: 1 }, "…and the same inputs again change nothing");
+});
+
+test("column placement and the order walk are not gated: a changed session order moves the cards, and no card repaints", async () => {
+  const same = frame([g1, card("g2")._it, g3], { working: ["web"] });
+  await dispatch(same);                                          // settle on the objects the cards were painted from
+  const before = nameRebuilds();
+  const keys = () => body.byId("col-asks-list")!.children.map((c) => c.dataset.key).filter((k) => k && k.startsWith("a:"));
+  assert.deepEqual(keys(), ["a:g1", "a:g3"], "web's run, then tests' — the kernel's session order");
+  await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"], order: [TESTS, API, WEB] }));
+  assert.deepEqual(keys(), ["a:g3", "a:g1"], "the runs swapped places");
+  assert.deepEqual(nameRebuilds(), before, "…and no card repainted: a card's column and slot are re-applied every render, outside the gate");
+  await dispatch(same);
+  assert.deepEqual(keys(), ["a:g1", "a:g3"]);
+  assert.deepEqual(nameRebuilds(), before);
+});
+
+test("Revive latches on the click and re-arms on the kernel's err frame for the card's session, its idle label restored; a re-emit and another session's err leave the latch", async () => {
+  const parked = { ...card("g3")._it, blocked: { state: "parkedHandoff", toSid: API, toName: "api", what: "api is offline" } };
+  await dispatch(frame([g1, card("g2")._it, parked], { working: ["web"] }));
+  const revive = card("g3")._revive;
+  assert.equal(revive.style.display, ""); assert.equal(revive.disabled, false); assert.equal(revive.textContent, "Revive api");
+  const sent = posted.length;
+  revive.onclick(ev);
+  assert.deepEqual(posted.slice(sent).filter((m) => m.type === "reviveSession"), [{ type: "reviveSession", id: API }]);
+  assert.equal(revive.disabled, true); assert.equal(revive.textContent, "Reviving…");
+  await dispatch(frame([g1, card("g2")._it, parked], { working: ["web"] }));   // the same objects again: nothing decided
+  assert.equal(revive.disabled, true, "a re-emit is not a deciding event");
+  await dispatch({ type: "err", sid: API, text: "the recipient's own business" });
+  assert.equal(revive.disabled, true, "an err for another session is not this card's event");
+  await dispatch({ type: "err", sid: TESTS, text: "the revive was refused" });
+  assert.equal(revive.disabled, false, "the kernel's reply for the card's session re-arms it");
+  assert.equal(revive.textContent, "Revive api", "…with the label it wore before the click");
+  await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"] }));   // the handoff is no longer parked: the button hides
+  assert.equal(card("g3")._revive.style.display, "none");
+});
+
+test("the bell: a click acknowledges at once and its optimistic state is a paint input, so that card alone repaints on the next frame; a refused toggle releases the latch and repaints that card alone", async () => {
+  const before = nameRebuilds();
+  const bell = card("g1")._bell;
+  assert.equal(bell._bellOn, false);
+  const sent = posted.length;
+  bell.onclick(ev);
+  assert.equal(bell._bellOn, true, "acknowledged before the round-trip");
+  assert.deepEqual(posted.slice(sent).filter((m) => m.type === "cardNotify"), [{ type: "cardNotify", itemId: "g1", sid: WEB, value: true }]);
+  await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"] }));   // the same objects: the latch rides the key
+  assert.equal(bell._bellOn, true, "the payload does not carry it yet; the latch holds");
+  assert.deepEqual(nameRebuilds(), { ...before, g1: before.g1 + 1 }, "web's card repainted under its new key, the others did not");
+  await dispatch({ type: "settingRefused", gesture: "bell", itemId: "g1", sid: WEB, text: "the settings store could not be read" });
+  assert.equal(bell._bellOn, false, "the refusal ends the optimistic state: the bell shows what the payload holds");
+  assert.deepEqual(nameRebuilds(), { ...before, g1: before.g1 + 2 }, "…by repainting that card, and no other");
+});
+
+test("the grouped pref is a paint input through feedPrefs: grouping off repaints every card once (the name row shows, the headers leave), and the same inputs again repaint nothing", async () => {
+  const before = nameRebuilds();
+  const nameRow = (id: string) => card(id)._name.parentNode.style.display;
+  const heads = () => body.querySelectorAll(".feed-sess-head").filter((h) => !h.classList.contains("sess-exit")).length;
+  assert.equal(nameRow("g1"), "none", "grouped: the session header carries the name"); assert.ok(heads() > 0);
+  const setPrefs = (v: string) => { stores.local.set("romp:settings", v); win.dispatchEvent(Object.assign(new Event("storage"), { key: "romp:settings", newValue: v })); };
+  setPrefs(JSON.stringify({ grouped: false }));                  // the gear in another pane
+  assert.deepEqual(nameRebuilds(), { g1: before.g1 + 1, g2: before.g2 + 1, g3: before.g3 + 1 }, "every card reads the pref: each repainted once");
+  assert.deepEqual([nameRow("g1"), nameRow("g2"), nameRow("g3")], ["", "", ""], "each card carries its own name again");
+  assert.equal(heads(), 0, "no session headers");
+  await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"] }));
+  assert.deepEqual(nameRebuilds(), { g1: before.g1 + 1, g2: before.g2 + 1, g3: before.g3 + 1 }, "the same inputs again: nothing repainted");
+  setPrefs("{}");
+  assert.equal(nameRow("g1"), "none");
+  assert.deepEqual(nameRebuilds(), { g1: before.g1 + 2, g2: before.g2 + 2, g3: before.g3 + 2 });
+});
+
+test("a quarantine card never skips: its sender's colour, looked up by name in the per-frame colour map, follows a re-coloured sender card although its own object is unchanged", async () => {
+  const q1 = cardOf("q1", WEB, "web", "#3366cc", "New message", "needs_input",
+    { blocked: { state: "quarantine", mid: "m1", frm: "api", origin: "", to: "web", body: "the README draft is ready for a look", gist: "the README draft is ready" } });
+  await dispatch(frame([g1, card("g2")._it, g3, q1], { working: ["web"] }));
+  const sender = () => card("q1")._qBody.querySelectorAll(".fq-name")[0];
+  assert.equal(sender().textContent, "api");
+  assert.equal(sender().style.color, card("g2")._it.color.bg, "the sender's identity colour, read from api's card");
+  const recoloured = { ...card("g2")._it, color: { bg: "#112233", fg: "#ffffff" } };
+  await dispatch(frame([g1, recoloured, g3, q1], { working: ["web"] }));   // q1 is the very same object
+  assert.equal(sender().style.color, "#112233", "the held-mail card repainted although nothing of its own changed");
+  await dispatch(frame([g1, { ...recoloured, color: g2.color }, g3], { working: ["web"] }));   // decided elsewhere; api's colour as before
+  assert.equal(card("q1"), null);
+});
+
+test("a handoff recipient's working state is a paint input: the delegating card repaints and its delegation line appears when the recipient starts working; an idle session's card does not repaint", async () => {
+  const handoff = { id: API + ":h1", kind: "handoff", text: "write the README section", who: "api", whoSid: API, whoColor: null, status: "open", t: K0 - 200, last: K0 - 200, children: [] };
+  const g1h = { ...g1, tree: [...g1.tree, handoff] };
+  await dispatch(frame([g1h, card("g2")._it, g3], { working: ["web"] }));
+  assert.equal(card("g1")._delegations.style.display, "none", "api is idle: no delegation line");
+  const before = nameRebuilds();
+  await dispatch(frame([g1h, card("g2")._it, g3], { working: ["web", "api"] }));   // the same objects; api starts working
+  assert.equal(card("g1")._delegations.children.length, 1);
+  assert.equal(card("g1")._delegations.querySelector(".fask-delegation")!.textContent, "api");
+  assert.deepEqual(nameRebuilds(), { g1: before.g1 + 1, g2: before.g2 + 1, g3: before.g3 }, "web's card (its recipient's state) and api's own card (its dot); tests' card is untouched");
+  await dispatch(frame([g1h, card("g2")._it, g3], { working: ["web"] }));
+  assert.equal(card("g1")._delegations.style.display, "none", "idle again: the line is gone");
+  await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"] }));   // the tree as before
+});
+
+test("a remote host going down is a paint input: that host's card repaints (its host prefix takes the off mark) and no other card does", async () => {
+  const downs: string[] = [];
+  (globalThis as any).__rompFed = { down: () => downs };                    // what hostIsDown reads (federation.js publishes it)
+  const r1 = cardOf("r1", "remote:" + API, "remote:api", "#996633", "Draft the notes-api docs", "working");
+  await dispatch(frame([g1, card("g2")._it, g3, r1], { working: ["web"] }));
+  const prefix = () => card("r1")._name.querySelector(".host-prefix")!;
+  assert.equal(prefix().textContent, "remote:"); assert.ok(!prefix().classList.contains("off"));
+  const before = { ...nameRebuilds(), r1: card("r1")._name.rc };
+  downs.push("remote");
+  await dispatch(frame([g1, card("g2")._it, g3, r1], { working: ["web"] }));   // the same objects: only the host's reachability changed
+  assert.ok(prefix().classList.contains("off"), "the link is marked down");
+  assert.deepEqual({ ...nameRebuilds(), r1: card("r1")._name.rc }, { ...before, r1: before.r1 + 1 }, "the remote card alone repainted");
+  delete (globalThis as any).__rompFed;
+  await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"] }));
+  assert.equal(card("r1"), null);
+});
+
+test("a colour echo (an in-place write into the shared objects) repaints that session's cards through the key, once", async () => {
+  const before = nameRebuilds();
+  win.dispatchEvent(Object.assign(new Event("storage"), { key: "romp:color-echo", newValue: JSON.stringify({ sid: API, bg: "#cc3366" }) }));
+  assert.deepEqual(nameRebuilds(), { g1: before.g1, g2: before.g2 + 1, g3: before.g3 }, "api's card repainted, the others did not");
+  assert.equal(card("g2")._name.style.color, "#cc3366");
+  await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"] }));   // the same objects again, colour still echoed
+  assert.deepEqual(nameRebuilds(), { g1: before.g1, g2: before.g2 + 1, g3: before.g3 }, "the echoed colour is in the key: no flap, no second rebuild");
+});
+
+test("Undo inside a card's 180 ms collapse keeps the restored card: the gesture strips .dismissing, which the class rewrite used to do", () => {
+  const c3 = card("g3");
+  c3._clr.onclick(ev);                      // Clear: .dismissing + a 180 ms removal timer, the id held back from pushes
+  assert.ok(c3.classList.contains("dismissing"));
+  assert.equal(posted.filter((m) => m.type === "askClear").length, 1);
+  body.byId("feed-undoclear")!.onclick!(ev);   // Undo before the collapse ends: the same object, the same key
+  assert.ok(!c3.classList.contains("dismissing"), "Undo took the class off");
+  mock.timers.tick(200);                    // the collapse timer fires and finds nothing to remove
+  assert.equal(card("g3"), c3, "the restored card is still on the board, the same element");
+  assert.equal(colOf("g3"), "col-asks-list");
+});
+
+test("Retry latches on the click and re-arms only on a deciding event: the kernel's reply frame, or a repaint of the card", async () => {
+  const blockedG1 = { ...g1, blocked: { state: "apiError", what: "the API returned 529", status: 529 } };
+  await dispatch(frame([blockedG1, card("g2")._it, card("g3")._it]));   // web is NOT working: the API-error unit shows
+  const retry = card("g1")._apiRetry;
+  assert.equal(retry.style.display, ""); assert.equal(retry.disabled, false); assert.equal(retry.textContent, "Retry");
+  const sent = posted.length;
+  retry.onclick(ev);
+  assert.deepEqual(posted.slice(sent).filter((m) => m.type === "apiRetry"), [{ type: "apiRetry", id: WEB, manual: true }],
+    "a MANUAL retry: the kernel fires it past every auto gate, as the chat pane's button does");
+  assert.equal(retry.disabled, true); assert.equal(retry.textContent, "Retrying…");
+  await dispatch(frame([blockedG1, card("g2")._it, card("g3")._it]));   // the same objects again: nothing decided
+  assert.equal(retry.disabled, true, "a re-emit is not a deciding event");
+  await dispatch({ type: "err", sid: API, text: "another session's business" });
+  assert.equal(retry.disabled, true, "another session's reply is not this card's event");
+  await dispatch({ type: "err", sid: WEB, text: "the retry was not delivered" });
+  assert.equal(retry.disabled, false, "the kernel's reply for this session re-arms it");
+  assert.equal(retry.textContent, "Retry");
+  retry.onclick(ev);
+  assert.equal(retry.disabled, true);
+  await dispatch(frame([{ ...blockedG1 }, card("g2")._it, card("g3")._it]));   // a new object for the card: it repaints
+  assert.equal(retry.disabled, false, "a repaint re-arms it too");
+  await dispatch(frame([g1, card("g2")._it, card("g3")._it]));   // the block is gone: the unit hides
+  assert.equal(card("g1")._apiRetry.style.display, "none");
+  mock.timers.reset();
+});

--- a/ui/webview/feed-render-incremental.test.ts
+++ b/ui/webview/feed-render-incremental.test.ts
@@ -347,24 +347,33 @@ test("column placement and the order walk are not gated: a changed session order
   assert.deepEqual(nameRebuilds(), before);
 });
 
-test("Revive latches on the click and re-arms on the kernel's err frame for the card's session, its idle label restored; a re-emit and another session's err leave the latch", async () => {
-  const parked = { ...card("g3")._it, blocked: { state: "parkedHandoff", toSid: API, toName: "api", what: "api is offline" } };
-  await dispatch(frame([g1, card("g2")._it, parked], { working: ["web"] }));
-  const revive = card("g3")._revive;
+test("Revive latches on the click and re-arms on the kernel's reviveFailed for the revived session, its idle label restored and the reason toasted; a re-emit, another session's failure and an err for a different request leave the latch", async () => {
+  // the kernel's parked-handoff card (build_feed): its sid IS the recipient the button revives (sid and blocked.toSid
+  // are both the parked message's toId), so the kernel's reviveFailed, keyed by the revived id, names this card
+  const p1 = cardOf("parked:m1", API, "api", "#cc6633", "Hand-off parked for api (offline)", "needs_input",
+    { live: false, tree: [], blocked: { state: "parkedHandoff", toSid: API, toName: "api", what: "a handoff from web is parked: revive api to deliver it" } });
+  await dispatch(frame([g1, card("g2")._it, g3, p1], { working: ["web"] }));
+  const revive = card("parked:m1")._revive;
   assert.equal(revive.style.display, ""); assert.equal(revive.disabled, false); assert.equal(revive.textContent, "Revive api");
   const sent = posted.length;
   revive.onclick(ev);
   assert.deepEqual(posted.slice(sent).filter((m) => m.type === "reviveSession"), [{ type: "reviveSession", id: API }]);
   assert.equal(revive.disabled, true); assert.equal(revive.textContent, "Reviving…");
-  await dispatch(frame([g1, card("g2")._it, parked], { working: ["web"] }));   // the same objects again: nothing decided
+  await dispatch(frame([g1, card("g2")._it, g3, p1], { working: ["web"] }));   // the same objects again: nothing decided
   assert.equal(revive.disabled, true, "a re-emit is not a deciding event");
-  await dispatch({ type: "err", sid: API, text: "the recipient's own business" });
-  assert.equal(revive.disabled, true, "an err for another session is not this card's event");
-  await dispatch({ type: "err", sid: TESTS, text: "the revive was refused" });
-  assert.equal(revive.disabled, false, "the kernel's reply for the card's session re-arms it");
+  const toastBefore = body.querySelector(".feed-toast")?.textContent ?? null;
+  await dispatch({ type: "reviveFailed", id: WEB, name: "web", text: "the SDK backend could not resume it" });
+  assert.equal(revive.disabled, true, "another session's revive failing is not this card's event");
+  assert.equal(body.querySelector(".feed-toast")?.textContent ?? null, toastBefore, "…and nothing to say about it here");
+  await dispatch({ type: "err", sid: API, op: "sendMessage", title: "That message was not delivered", text: "Nothing was sent." });
+  assert.equal(revive.disabled, true, "a refusal of a DIFFERENT request on the same session is not this button's reply");
+  await dispatch({ type: "reviveFailed", id: API, name: "api", text: "the SDK backend could not resume it (see the kernel log)" });
+  assert.equal(revive.disabled, false, "the kernel's reply to the revive this page asked for re-arms it");
   assert.equal(revive.textContent, "Revive api", "…with the label it wore before the click");
-  await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"] }));   // the handoff is no longer parked: the button hides
-  assert.equal(card("g3")._revive.style.display, "none");
+  assert.equal(body.querySelector(".feed-toast")?.textContent, "Couldn't revive api: the SDK backend could not resume it (see the kernel log)",
+    "…and says why here, where the button is (the chat pane shows the same failure in the session's own pane)");
+  await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"] }));   // delivered or dismissed elsewhere: the parked card leaves
+  assert.ok(!card("parked:m1"));
 });
 
 test("the bell: a click acknowledges at once and its optimistic state is a paint input, so that card alone repaints on the next frame; a refused toggle releases the latch and repaints that card alone", async () => {
@@ -411,6 +420,26 @@ test("a quarantine card never skips: its sender's colour, looked up by name in t
   await dispatch(frame([g1, recoloured, g3, q1], { working: ["web"] }));   // q1 is the very same object
   assert.equal(sender().style.color, "#112233", "the held-mail card repainted although nothing of its own changed");
   await dispatch(frame([g1, { ...recoloured, color: g2.color }, g3], { working: ["web"] }));   // decided elsewhere; api's colour as before
+  assert.ok(!card("q1"));
+});
+
+test("Approve and Deny latch on the click and re-arm on the kernel's quarantineRefused for that held message, the reason toasted; another message's refusal leaves them", async () => {
+  const q1 = cardOf("q1", WEB, "web", "#3366cc", "New message", "needs_input",
+    { blocked: { state: "quarantine", mid: "m1", frm: "api", origin: "", to: "web", body: "the README draft is ready for a look", gist: "the README draft is ready" } });
+  await dispatch(frame([g1, card("g2")._it, g3, q1], { working: ["web"] }));
+  const approve = card("q1")._qApprove, deny = card("q1")._qDeny;
+  assert.deepEqual([approve.disabled, deny.disabled, approve.textContent, deny.textContent], [false, false, "Approve", "Deny"]);
+  const sent = posted.length;
+  approve.onclick(ev);
+  assert.deepEqual(posted.slice(sent).filter((m) => m.type === "quarantineDecision").map((m) => [m.mid, m.action, m.sid]), [["m1", "approve", WEB]]);
+  assert.deepEqual([approve.disabled, deny.disabled, approve.textContent], [true, true, "Delivering…"], "both latch; the one clicked says what it is doing");
+  await dispatch({ type: "quarantineRefused", mid: "m2", text: "quarantine: not that one" });
+  assert.equal(approve.disabled, true, "another held message's refusal is not this card's reply");
+  await dispatch({ type: "quarantineRefused", mid: "m1", text: "quarantine: the recipient is no longer live" });
+  assert.deepEqual([approve.disabled, deny.disabled, approve.textContent, deny.textContent], [false, false, "Approve", "Deny"],
+    "the kernel's reply for this message re-arms both");
+  assert.equal(body.querySelector(".feed-toast")?.textContent, "quarantine: the recipient is no longer live", "…and says why (the bare warn it replaced had no handler here)");
+  await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"] }));
   assert.ok(!card("q1"));
 });
 
@@ -739,17 +768,54 @@ test("Retry latches on the click and re-arms only on a deciding event: the kerne
   assert.equal(retry.disabled, true); assert.equal(retry.textContent, "Retrying…");
   await dispatch(frame([blockedG1, card("g2")._it, card("g3")._it]));   // the same objects again: nothing decided
   assert.equal(retry.disabled, true, "a re-emit is not a deciding event");
-  await dispatch({ type: "err", sid: API, text: "another session's business" });
+  await dispatch({ type: "err", sid: API, op: "apiRetry", text: "another session's business" });
   assert.equal(retry.disabled, true, "another session's reply is not this card's event");
-  await dispatch({ type: "err", sid: WEB, text: "the retry was not delivered" });
-  assert.equal(retry.disabled, false, "the kernel's reply for this session re-arms it");
+  await dispatch({ type: "err", text: "a reply that names no session" });
+  assert.equal(retry.disabled, true, "a reply naming no session answers no request: nothing re-arms");
+  await dispatch({ type: "err", sid: WEB, op: "askFollowUp", itemId: "g1", text: "this session's reply to a DIFFERENT request" });
+  assert.equal(retry.disabled, true, "the reply to another request of this session is not this button's");
+  await dispatch({ type: "err", sid: WEB, op: "apiRetry", text: "the retry was not delivered" });
+  assert.equal(retry.disabled, false, "the kernel's refusal of THIS session's retry re-arms it");
   assert.equal(retry.textContent, "Retry");
+  retry.onclick(ev);
+  assert.equal(retry.disabled, true);
+  await dispatch({ type: "retryRefused", sid: WEB, text: "Couldn't retry: the session isn't connected right now." });
+  assert.equal(retry.disabled, false, "the backend's refusal of the manual retry (the kernel's retryRefused) re-arms it");
+  assert.equal(body.querySelector(".feed-toast")?.textContent, "Couldn't retry: the session isn't connected right now.", "…and says why");
+  retry.onclick(ev);
+  assert.equal(retry.disabled, true);
+  await dispatch({ type: "err", sid: WEB, text: "an older kernel's refusal names the session and no request" });
+  assert.equal(retry.disabled, false, "a reply naming the session but no request releases the session's Retry, as before the op field");
   retry.onclick(ev);
   assert.equal(retry.disabled, true);
   await dispatch(frame([{ ...blockedG1 }, card("g2")._it, card("g3")._it]));   // a new object for the card: it repaints
   assert.equal(retry.disabled, false, "a repaint re-arms it too");
   await dispatch(frame([g1, card("g2")._it, card("g3")._it]));   // the block is gone: the unit hides
   assert.equal(card("g1")._apiRetry.style.display, "none");
+});
+
+test("Continue latches on the click and predicts the move; the kernel's refusal of THAT post re-arms it and returns the card, a refusal of another card's post leaves both", async () => {
+  const needsG1 = { ...g1, column: "needs_input" };
+  await dispatch(frame([needsG1, card("g2")._it, card("g3")._it], { working: ["api"] }));   // web is live and waiting on you, no live ask
+  const cont = card("g1")._cont;
+  assert.equal(cont.style.display, ""); assert.equal(cont.disabled, false); assert.equal(cont.textContent, "Continue");
+  assert.equal(colOf("g1"), "col-needsInput-list");
+  const sent = posted.length;
+  cont.onclick(ev);
+  assert.deepEqual(posted.slice(sent).filter((m) => m.type === "askFollowUp"), [{ type: "askFollowUp", itemId: "g1", sid: WEB, cont: true }]);
+  assert.equal(cont.disabled, true); assert.equal(cont.textContent, "Sent");
+  assert.equal(colOf("g1"), "col-asks-list", "the predicted move: the card goes to Working ahead of the kernel");
+  await dispatch(frame([needsG1, card("g2")._it, card("g3")._it], { working: ["api"] }));   // the same objects: nothing decided
+  assert.equal(cont.disabled, true, "a re-emit is not a deciding event");
+  assert.equal(colOf("g1"), "col-asks-list", "…and the prediction holds");
+  await dispatch({ type: "err", sid: WEB, op: "askFollowUp", itemId: "g1a", title: "That reply was not delivered", text: "Nothing was sent." });
+  assert.equal(cont.disabled, true, "a refusal of another card's post is not this button's reply");
+  await dispatch({ type: "err", sid: WEB, op: "askFollowUp", itemId: "g1", title: "That reply was not delivered", text: "Nothing was sent." });
+  assert.equal(cont.disabled, false, "the kernel's refusal of this card's post re-arms it");
+  assert.equal(cont.textContent, "Continue");
+  assert.equal(colOf("g1"), "col-needsInput-list", "…and the predicted move yields to the kernel's answer: the card is back where the payload says");
+  await dispatch(frame([g1, card("g2")._it, card("g3")._it]));   // web back to Working
+  assert.equal(colOf("g1"), "col-asks-list");
 });
 
 test("a reveal pulse comes off when its animation ends, and a child's animation ending inside the card does not end it", async () => {

--- a/ui/webview/feed-render-incremental.test.ts
+++ b/ui/webview/feed-render-incremental.test.ts
@@ -1,8 +1,9 @@
 // The feed pane's per-card update gate, RUN: feed.ts booted under a DOM stand-in, fed synthetic frames through
 // the window message it listens on, and watched for what each render REBUILT. The invariant these frames pin:
 // a card repaints when the kernel sent it (a new object), when a board-level input it reads changed (the
-// key), or when a gesture touched it; its column and order are re-applied on every render regardless;
-// nothing else touches it. Two of the assertions are the regressions the paint key this gate replaced would
+// key), or when a gesture touched it; its column and order are re-applied on every render regardless; and
+// the 15 s live pass moves its ages and durations on the kernel's clock, writing only the labels whose text
+// changed. Two of the assertions are the regressions the paint key this gate replaced would
 // fail: a re-dispatch of the same objects across a 15 s boundary rebuilds nothing (the key carried a
 // fifteen-second clock term, so the first frame of every window repainted every card), and one session's
 // `working` change repaints that session's cards alone (the key carried an epoch every status-set change
@@ -192,6 +193,9 @@ win.acquireVsCodeApi = () => ({ postMessage: (m: any) => posted.push(m) });
 (globalThis as any).requestAnimationFrame = win.requestAnimationFrame;
 (globalThis as any).getComputedStyle = win.getComputedStyle;
 (globalThis as any).MouseEvent = class MouseEvent extends Event { clientX = 0; clientY = 0; };
+// the paint gate's second measure: render() observes #feed-list once; a test drives the callback by hand
+const observers: { cb: (entries: { isIntersecting: boolean }[]) => void }[] = [];
+(globalThis as any).IntersectionObserver = class { cb: any; constructor(cb: any) { this.cb = cb; observers.push(this); } observe() {} disconnect() {} };
 const doc: any = new EventTarget();
 Object.assign(doc, {
   body, head: new El("head"), documentElement: new El("html"), hidden: false, activeElement: body,
@@ -220,10 +224,11 @@ const g1 = cardOf("g1", WEB, "web", "#3366cc", "Wire the notes-api health route"
   { tree: [node("g1", "Wire the notes-api health route", "web", WEB, ["g1a"]), node("g1a", "Add the /health handler", "web", WEB)] });
 const g2 = cardOf("g2", API, "api", "#cc6633", "Write the notes-api README", "working");
 const g3 = cardOf("g3", TESTS, "tests", "#33cc66", "Run the notes-api test suite", "working",
-  { awaiting: { why: "", kind: "agents", count: 2, since: K0 - 600 } });
-// upstream's frame shape: the kernel's `now`, per-card `trgb`, the status sets, the session order and list
+  { awaiting: { why: "", kind: "agents", count: 2, since: K0 - 600 } });   // a wait ten minutes old: its duration must move without a frame
+// the frame shape: the kernel's `now` and federation's `nowAt` (when the frame landed, the pane's clock anchor),
+// per-card `trgb`, the status sets, the session order and list
 const frame = (asks: any[], over: Record<string, unknown> = {}) => ({
-  type: "feed", now: K0, buildId: 1, asks,
+  type: "feed", now: K0, nowAt: T0 * 1000, buildId: 1, asks,
   working: [], awaiting: [], stateUnknown: [], order: [WEB, API, TESTS], selfHost: "TESTHOST",
   sessions: [{ sid: WEB, name: "web", color: g1.color }, { sid: API, name: "api", color: g2.color }, { sid: TESTS, name: "tests", color: g3.color }],
   bgServices: {}, ...over,
@@ -244,13 +249,14 @@ const ev = { stopPropagation() {}, preventDefault() {} };
 
 test("frame A: three cards are built once each, in the Working column", async () => {
   mock.timers.enable({ apis: ["Date", "setTimeout", "setInterval"], now: T0 * 1000 });
-  await import("./feed");                   // module load: gear (a no-op here), listeners, the 15 s tick
+  await import("./feed");                   // module load: gear (a no-op here), listeners, the 15 s live pass
   assert.equal(posted.filter((m) => m.type === "ready").length, 1, "the ready handshake");
   await dispatch(frame([g1, g2, g3]));
   assert.deepEqual(nameRebuilds(), { g1: 1, g2: 1, g3: 1 }, "each name node was built exactly once");
   assert.deepEqual({ g1: colOf("g1"), g2: colOf("g2"), g3: colOf("g3") }, { g1: "col-asks-list", g2: "col-asks-list", g3: "col-asks-list" });
   assert.equal(card("g1")._time.textContent, "4m ago", "on the kernel's clock (the browser clock is five minutes ahead)");
-  assert.match(card("g3")._awaitWhy.textContent, /^Awaiting /, "the awaiting box shows the wait");
+  assert.equal(card("g3")._awaitWhy.textContent, "Awaiting agents · 10m", "the awaiting box, with the wait's duration on the kernel's clock");
+  assert.equal(card("g3")._awaitWhy.querySelector(".fask-dur")?.dataset.ageFmt, "dur", "…as a stamped element the live pass can reach");
   // open card 1's Sub-goals section (a gesture): the section state must survive the renders below untouched
   card("g1")._subBtn.onclick(ev);
   assert.equal(card("g1")._subBtn.getAttribute("aria-pressed"), "true");
@@ -295,8 +301,8 @@ test("frame C: the same frame re-dispatched (a federation re-emit) rebuilds noth
 
 test("…and across a 15 s boundary: the clock is not a paint input", async () => {
   // the key this gate replaced carried a fifteen-second term, so the first frame in every 15 s window
-  // repainted every card. The tick that fires inside this window rewrites the age labels (its own business);
-  // it rebuilds no card.
+  // repainted every card. The live pass that fires inside this window moves the labels whose minute rolled
+  // over (its own business, pinned below); it rebuilds no card.
   const before = nameRebuilds(), readsBefore = rectReads;
   const same = frame([g1, card("g2")._it, g3]);
   mock.timers.tick(16_000);
@@ -393,7 +399,7 @@ test("a quarantine card never skips: its sender's colour, looked up by name in t
   await dispatch(frame([g1, recoloured, g3, q1], { working: ["web"] }));   // q1 is the very same object
   assert.equal(sender().style.color, "#112233", "the held-mail card repainted although nothing of its own changed");
   await dispatch(frame([g1, { ...recoloured, color: g2.color }, g3], { working: ["web"] }));   // decided elsewhere; api's colour as before
-  assert.equal(card("q1"), null);
+  assert.ok(!card("q1"));
 });
 
 test("a handoff recipient's working state is a paint input: the delegating card repaints and its delegation line appears when the recipient starts working; an idle session's card does not repaint", async () => {
@@ -425,7 +431,7 @@ test("a remote host going down is a paint input: that host's card repaints (its 
   assert.deepEqual({ ...nameRebuilds(), r1: card("r1")._name.rc }, { ...before, r1: before.r1 + 1 }, "the remote card alone repainted");
   delete (globalThis as any).__rompFed;
   await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"] }));
-  assert.equal(card("r1"), null);
+  assert.ok(!card("r1"));
 });
 
 test("a colour echo (an in-place write into the shared objects) repaints that session's cards through the key, once", async () => {
@@ -435,6 +441,166 @@ test("a colour echo (an in-place write into the shared objects) repaints that se
   assert.equal(card("g2")._name.style.color, "#cc3366");
   await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"] }));   // the same objects again, colour still echoed
   assert.deepEqual(nameRebuilds(), { g1: before.g1, g2: before.g2 + 1, g3: before.g3 }, "the echoed colour is in the key: no flap, no second rebuild");
+});
+
+test("the 15 s live pass moves ages and durations on cards no frame touched, writing only the labels whose text changed", () => {
+  // 16.7 s have elapsed since boot (frame C's 700 ms, the 16 s boundary), so one pass has run, at 15 s. The pass
+  // runs at every 15 s multiple on the kernel's clock — the frame's `now` plus the local time since its `nowAt`.
+  // The cards are 240 s old at the frame and relAge rounds to the nearest minute, so "4m ago" becomes "5m ago" at
+  // 270 s (30 s elapsed); the wait is 600 s old and workingFor floors, so "10m" becomes "11m" at 660 s (60 s).
+  const before = nameRebuilds();
+  const time1 = card("g1")._time, dur3 = card("g3")._awaitWhy.querySelector(".fask-dur")!;
+  const t1 = time1.tc, d3 = dur3.tc;
+  assert.equal(time1.textContent, "4m ago"); assert.equal(dur3.textContent, "10m");
+  mock.timers.tick(15_000);                 // the pass at 30 s: the age label crossed its minute, the duration did not
+  assert.equal(time1.textContent, "5m ago"); assert.equal(time1.tc, t1 + 1, "one write, at the minute it crossed");
+  assert.equal(dur3.textContent, "10m"); assert.equal(dur3.tc, d3, "an unchanged label is not written");
+  mock.timers.tick(30_000);                 // the passes at 45 s and 60 s: only the duration crossed, at 60 s
+  assert.equal(dur3.textContent, "11m"); assert.equal(dur3.tc, d3 + 1);
+  assert.equal(time1.textContent, "5m ago"); assert.equal(time1.tc, t1 + 1);
+  mock.timers.tick(15_000);                 // the pass at 75 s: nothing crossed, nothing written
+  assert.equal(time1.tc, t1 + 1); assert.equal(dur3.tc, d3 + 1);
+  assert.deepEqual(nameRebuilds(), before, "the pass repaints labels, never cards");
+  // a pane nobody can see skips the pass and catches up once when shown
+  doc.hidden = true;
+  mock.timers.tick(60_000);                 // the passes at 90-135 s: the age reads 6m from 90 s (330 s) on — nothing written while hidden
+  assert.equal(time1.textContent, "5m ago"); assert.equal(time1.tc, t1 + 1);
+  assert.equal(dur3.textContent, "11m"); assert.equal(dur3.tc, d3 + 1);
+  doc.hidden = false;
+  doc.dispatchEvent(new Event("visibilitychange"));
+  assert.equal(time1.textContent, "6m ago", "shown: one catch-up pass"); assert.equal(time1.tc, t1 + 2);
+  assert.equal(dur3.textContent, "12m"); assert.equal(dur3.tc, d3 + 1 + 1);   // 735 s
+  doc.dispatchEvent(new Event("visibilitychange"));
+  assert.equal(time1.tc, t1 + 2, "a second visibility flip with no skipped pass behind it runs nothing");
+  // the other measure the paint gate reads: #feed-list off screen by the observer's word (the pane the shell has
+  // display:none'd, for which document.hidden stays false) skips the pass the same way, and the observer's
+  // callback is what catches it up — a same-size re-show fires no resize
+  assert.equal(observers.length, 1, "render() observes #feed-list once");
+  observers[0].cb([{ isIntersecting: false }]);
+  mock.timers.tick(60_000);                 // the passes at 150-195 s: the age reads 7m from 150 s (390 s) on — nothing written off screen
+  assert.equal(time1.textContent, "6m ago"); assert.equal(time1.tc, t1 + 2);
+  assert.equal(dur3.textContent, "12m"); assert.equal(dur3.tc, d3 + 2);
+  observers[0].cb([{ isIntersecting: true }]);
+  assert.equal(time1.textContent, "7m ago", "on screen by the observer's word: one catch-up pass"); assert.equal(time1.tc, t1 + 3);
+  assert.equal(dur3.textContent, "13m"); assert.equal(dur3.tc, d3 + 3);   // 795 s
+  observers[0].cb([{ isIntersecting: true }]);
+  assert.equal(time1.tc, t1 + 3, "a second callback with no skipped pass behind it runs nothing");
+  assert.deepEqual(nameRebuilds(), before);
+});
+
+// The kernel clock as a card painted NOW reads it: the frame's `now` plus the local seconds since its `nowAt`
+// (feed-age.ts liveNow). The tests below stamp their fixtures relative to it and tick 15 s at a time, one pass
+// per tick (the pass runs at every 15 s of local time since the module loaded). Under the mock a pass fired
+// inside a tick reads the clock at the tick's END (frame C's note), so each 15 s tick moves every label's clock
+// by 15 s. Ages round to the minute (relAge), durations floor (workingFor).
+const kernelNow = () => K0 + Math.floor((Date.now() - T0 * 1000) / 1000);
+const dur = (el: any) => el.querySelector(".fask-dur");
+
+test("the grouped-mode headers write their labels compare-first: three renders of one frame write no text; a background process appearing writes that header's chip alone", async () => {
+  const same = frame([g1, card("g2")._it, g3], { working: ["web"] });
+  await dispatch(same);
+  const heads = () => body.querySelectorAll(".feed-sess-head").filter((h) => !h.classList.contains("sess-exit"));
+  const writes = () => Object.fromEntries(heads().map((h: any) => [h.getAttribute("data-fsid"), h._fold.tc + h._foldn.tc + h._svc.tc]));
+  const before = writes();
+  assert.equal(Object.keys(before).length, 3, "one header per session run");
+  await dispatch(same); await dispatch(same);
+  assert.deepEqual(writes(), before, "the caret, the folded count and the process chip: compared and skipped");
+  await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"], bgServices: { web: ["dev server on :3000"] } }));
+  const webHead = heads().find((h: any) => h.getAttribute("data-fsid") === WEB) as any;
+  assert.equal(webHead._svc.textContent, "background process"); assert.equal(webHead._svc.style.display, "");
+  assert.deepEqual(writes(), { ...before, [WEB]: before[WEB] + 1 }, "one write, on the header whose chip changed");
+  await dispatch(same);                                          // the process is gone: the chip's count text and display change back
+  assert.equal(webHead._svc.style.display, "none");
+  assert.deepEqual(writes(), { ...before, [WEB]: before[WEB] + 2 });
+});
+
+test("the Awaiting-task pill's waited time and the waiting-on chip's elapsed time are stamped durations the pass moves, writing once at the minute they cross; a wait with no `since` carries no duration", async () => {
+  const kNow = kernelNow();
+  const g4 = cardOf("g4", TESTS, "tests", "#33cc66", "Run the lint pass", "working",
+    { awaiting: { why: "", kind: "tasks", tasks: ["run the suite"], count: 1, since: kNow - 595 } });   // 9m 55s into the wait
+  const g5 = cardOf("g5", API, "api", "#cc6633", "Ask web for the route list", "working",
+    { waitingOn: { peerSid: WEB, name: "web", color: null, inCycle: false, since: kNow - 595 },
+      awaiting: { why: "", kind: "tasks", tasks: ["lint"], count: 1 } });                             // a wait with no since
+  await dispatch(frame([g1, card("g2")._it, g3, g4, g5], { working: ["web"] }));
+  const pill = card("g4")._taskLbl, pillDur = dur(pill);
+  assert.equal(card("g4")._taskBtn.style.display, "", "live tasks: the pill shows");
+  assert.ok(pillDur, "…with the wait's duration as a stamped element");
+  assert.equal(pillDur.dataset.ageFmt, "dur"); assert.equal(pillDur.dataset.ageT, String(kNow - 595));
+  assert.equal(pillDur.textContent, "9m"); assert.match(pill.textContent, /^Awaiting .* · 9m$/);
+  const chip = card("g5")._waitOn, chipDur = chip.querySelector(".fask-waiton-dur .fask-dur"), chipName = chip.querySelector(".fask-waiton-name");
+  assert.equal(chipDur.textContent, "9m"); assert.equal(chipDur.dataset.ageT, String(kNow - 595));
+  assert.equal(chipName.textContent, "web");
+  assert.ok(!dur(card("g5")._taskLbl), "no since: no duration node, no guess");
+  assert.doesNotMatch(card("g5")._taskLbl.textContent, / · /, "the label ends with the word alone");
+  const w0 = { pill: pillDur.tc, chip: chipDur.tc, name: chipName.tc };
+  mock.timers.tick(15_000);                                      // 610 s into both waits → "10m"
+  assert.equal(pillDur.textContent, "10m"); assert.equal(chipDur.textContent, "10m");
+  assert.deepEqual({ pill: pillDur.tc, chip: chipDur.tc, name: chipName.tc }, { pill: w0.pill + 1, chip: w0.chip + 1, name: w0.name }, "one write each; the peer's name node untouched");
+  mock.timers.tick(15_000);                                      // 625 s → still "10m"
+  assert.deepEqual({ pill: pillDur.tc, chip: chipDur.tc, name: chipName.tc }, { pill: w0.pill + 1, chip: w0.chip + 1, name: w0.name }, "no crossing, no write");
+  await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"] }));
+  assert.ok(!card("g4") && !card("g5"), "the fixtures left with the frame");
+});
+
+let g7: any;   // the needs-you card the next two tests share
+test("per-paragraph ages of a multi-item brief are stamps the pass moves; a paragraph with no event time is the static '<1m ago' chip", async () => {
+  const kNow = kernelNow();
+  g7 = cardOf("g7", WEB, "web", "#3366cc", "Decide the auth scheme", "needs_input",
+    { blockSummary: "Pick between sessions and tokens.\n\nName the cookie domain.\n\nStill open: the refresh interval.",
+      briefParts: [{ id: "g7a", since: kNow - 260 }, { id: "g7b", since: kNow - 600 }, { id: "g7c", since: null }] });
+  await dispatch(frame([g1, card("g2")._it, g3, g7], { working: ["web"] }));
+  const ages = (): any[] => card("g7")._distill.querySelectorAll(".fask-para-age");
+  assert.equal(ages().length, 3, "one chip per paragraph");
+  assert.deepEqual(ages().map((a) => a.textContent), ["4m ago", "10m ago", "<1m ago"]);
+  assert.deepEqual(ages().map((a) => a.dataset.ageT), [String(kNow - 260), String(kNow - 600), undefined], "the third carries no stamp: nothing to count from");
+  const w0 = ages().map((a) => a.tc);
+  mock.timers.tick(15_000);                                      // 275 s rounds to 5m; 615 s stays 10m
+  assert.deepEqual(ages().map((a) => a.textContent), ["5m ago", "10m ago", "<1m ago"]);
+  assert.deepEqual(ages().map((a) => a.tc), [w0[0] + 1, w0[1], w0[2]]);
+  mock.timers.tick(30_000);                                      // 305 s stays 5m; 645 s rounds to 11m
+  assert.deepEqual(ages().map((a) => a.textContent), ["5m ago", "11m ago", "<1m ago"]);
+  assert.deepEqual(ages().map((a) => a.tc), [w0[0] + 1, w0[1] + 1, w0[2]], "the unstamped chip is never written");
+});
+
+test("the latched Continue's hover title is refreshed by the pass once the payload carries the latch, compare-then-write", async () => {
+  const cont = card("g7")._cont;
+  assert.equal(cont.style.display, "", "a live needs-you card offers Continue");
+  let sets = 0, held = "";
+  const watch = () => { held = cont.title; Object.defineProperty(cont, "title", { get: () => held, set: () => { sets++; }, configurable: true }); };
+  const unwatch = () => { delete cont.title; cont.title = held; };
+  cont.onclick(ev);                                              // posts the gesture, latches the button, predicts the move to Working
+  assert.equal(cont.disabled, true);
+  assert.match(cont.title, /^a continue sent — /); assert.doesNotMatch(cont.title, /ago/, "no age: the click's own object carries no followupAt");
+  watch(); mock.timers.tick(14_000); unwatch();                  // one pass, inside the prediction's 15 s ack window
+  assert.equal(sets, 0, "the payload does not carry the latch yet: the pass has nothing to move and writes nothing");
+  const kNow = kernelNow();
+  await dispatch(frame([g1, card("g2")._it, g3, { ...g7, column: "working", followupPending: true, followupAt: kNow - 100 }], { working: ["web"] }));   // the kernel confirms, stamping the follow-up 100 s ago
+  assert.equal(cont.disabled, true, "still latched: the judge has not ruled");
+  assert.match(cont.title, /^a continue sent 2m ago — /, "the payload's stamp is the title's age now");
+  watch(); mock.timers.tick(15_000); mock.timers.tick(15_000); unwatch();   // 115 s, 130 s: both round to 2m
+  assert.equal(sets, 0, "two passes, no crossing: the title is compared and left alone");
+  mock.timers.tick(30_000);                                      // 160 s rounds to 3m
+  assert.match(cont.title, /^a continue sent 3m ago — /, "the pass moved the title's age");
+  await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"] }));
+  assert.ok(!card("g7"));
+});
+
+test("the group card's time label is a stamp the pass moves: the newest member's time", async () => {
+  const kNow = kernelNow();
+  const h1 = cardOf("h1", API, "api", "#cc6633", "Ship the README", "working", { turnId: "turn-shared", groupTitle: "Ship the README and the CHANGELOG", t: kNow - 260 });
+  const h2 = cardOf("h2", API, "api", "#cc6633", "Ship the CHANGELOG", "working", { turnId: "turn-shared", groupTitle: "Ship the README and the CHANGELOG", t: kNow - 300 });
+  await dispatch(frame([g1, card("g2")._it, g3, h1, h2], { working: ["web"] }));
+  const group = body.querySelector('[data-key="g:turn-shared"]') as any;
+  assert.ok(group, "two asks of one typed turn fold into a group card"); assert.ok(!card("h1"), "the members are folded into it");
+  assert.equal(group._time.textContent, "4m ago"); assert.equal(group._time.dataset.ageT, String(kNow - 260));
+  const w0 = group._time.tc;
+  mock.timers.tick(15_000);                                      // 275 s → 5m
+  assert.equal(group._time.textContent, "5m ago"); assert.equal(group._time.tc, w0 + 1);
+  mock.timers.tick(15_000);                                      // 290 s → still 5m
+  assert.equal(group._time.tc, w0 + 1, "no crossing, no write");
+  await dispatch(frame([g1, card("g2")._it, g3], { working: ["web"] }));
+  assert.ok(!body.querySelector('[data-key="g:turn-shared"]'));
+  mock.timers.tick(700);                                         // the in-place glides this frame started end (their backstop) before the fly cases below
 });
 
 test("Undo inside a card's 180 ms collapse keeps the restored card: the gesture strips .dismissing, which the class rewrite used to do", () => {

--- a/ui/webview/feed-thread-fold.test.ts
+++ b/ui/webview/feed-thread-fold.test.ts
@@ -21,7 +21,7 @@ test("the caret sits to the RIGHT of the session name, where it was asked for", 
 });
 
 test("it is a caret, and it says which way it will go", () => {
-  assert.match(FEED, /fold\.textContent = shut \? "▸" : "▾";/);
+  assert.match(FEED, /setText\(fold, shut \? "▸" : "▾"\);/);   // compare-first: headers repaint every render
   assert.match(FEED, /fold\.setAttribute\("aria-expanded", shut \? "false" : "true"\);/);
   assert.match(FEED, /fold\.setAttribute\("aria-label", \(shut \? "expand " : "collapse "\) \+ e\.name\);/);
 });
@@ -29,7 +29,7 @@ test("it is a caret, and it says which way it will go", () => {
 test("folding hides that thread's cards and counts them onto the header", () => {
   // the header stands in for the run: entries are counted, not rendered
   assert.match(FEED, /if \(collapsedThreads\.has\(s\)\) \{ if \(head\) head\.folded \+= entryCards\(e\); continue; \}/);
-  assert.match(FEED, /foldn\.textContent = String\(e\.folded\);/, "bare number (the user 2026-08-26) — words on hover only");
+  assert.match(FEED, /setText\(foldn, String\(e\.folded\)\);/, "bare number (the user 2026-08-26) — words on hover only");
   assert.match(FEED, /foldn\.style\.display = shut && e\.folded \? "" : "none";/);
 });
 

--- a/ui/webview/feed-tracked.test.ts
+++ b/ui/webview/feed-tracked.test.ts
@@ -20,7 +20,7 @@ test("the default board hides satellites; the session filter is the one-click pa
 
 test("the primary names its recipients with the board's own live dot, STACKING after any ↪ from", () => {
   const BLK = SRC.slice(SRC.indexOf("if (it.delegTracked && it.delegTracked.length) {"),
-                        SRC.indexOf("a._time.textContent"));
+                        SRC.indexOf("stampAge(a._time, it.t"));
   // an else-if hid a MIDDLEMAN's tracked handoff behind its own ↪ from badge (review 2026-08-24):
   // origin and delegTracked are different facts about one card, so they stack on the slot
   assert.match(BLK, /const hadOrigin = !!\(it\.origin && it\.origin\.peer\);/);

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3501,9 +3501,15 @@ function makeSessHead(): HTMLElement {
   return h;
 }
 function updateSessHead(h: HTMLElement, e: Entry & { kind: "sess" }): void {
-  h.setAttribute("data-fsid", e.sid);   // the hover-freeze badge painter finds headers by sid
+  // the hover-freeze badge painter finds headers by sid; compare first, like the labels below — the DOM's
+  // change-an-attribute steps queue a mutation record for a same-value write too
+  if (h.getAttribute("data-fsid") !== e.sid) h.setAttribute("data-fsid", e.sid);
   const nm = (h as any)._name as HTMLElement;
-  nm.replaceChildren(...hostNameNodes(e.name, e.sid));
+  // the name nodes are minted only when what they show changes: headers repaint every render (they are not
+  // behind the per-card update gate), and each mint is a Text-node replacement — the same reason cards are
+  // gated. hostNameNodes reads the name, the sid's host prefix and whether that host's link is down.
+  const nmSig = e.name + "\u0000" + e.sid + "\u0000" + (hostIsDown(e.sid) ? "d" : "");
+  if ((h as any)._nmSig !== nmSig) { (h as any)._nmSig = nmSig; nm.replaceChildren(...hostNameNodes(e.name, e.sid)); }
   if (e.color) nm.style.color = e.color.bg;
   nm.classList.toggle("dead", !e.live);
   nm.onclick = (ev) => { ev.stopPropagation(); openOrReviveSession(e.sid, e.live, e.name); };
@@ -4381,6 +4387,7 @@ function columnsOf(buckets: Record<Column, Entry[]>): Map<string, string> {
   return m;
 }
 const FLY_COLS: ("asks" | "needsInput" | "completed")[] = ["asks", "needsInput", "completed"];
+let flySeq = 0;   // the fly token: the element remembers the newest fly's number (see the write phase)
 function captureCardRects(cols: ReturnType<typeof ensureCols>): Map<string, FlipState> {
   const m = new Map<string, FlipState>();
   for (const key of FLY_COLS) {
@@ -4404,35 +4411,64 @@ function flyColumnChanges(first: Map<string, FlipState>, cols: ReturnType<typeof
       const k = c.dataset.key; if (!k) continue;
       const prev = first.get(k);
       if (!prev) continue;                                 // brand-new card → no FLIP (nothing to glide from)
+      // a card nobody could see — its column folded to the header (display:none) — has a zero First rect:
+      // nothing to glide from, and a fly from (0,0) zooms in from the pane's corner
+      if (!prev.rect.width && !prev.rect.height) continue;
       const now = c.getBoundingClientRect();
+      // …and a target nobody can see has a zero Last rect and no transition to run, so a fly written to it
+      // would never end: the class it wears, pointer-events:none, stayed until the card's next repaint, and
+      // the per-card update gate no longer rewrites className every render. Nothing to glide to; leave it.
+      if (!now.width && !now.height) continue;
       const dx = prev.rect.left - now.left, dy = prev.rect.top - now.top;
       if (!dx && !dy) continue;                            // didn't move → leave it alone
       moves.push({ c, dx, dy, crossed: prev.col !== colEl.id });
     }
   }
   for (const { c, dx, dy, crossed } of moves) {
-    {
-      // Two flavors of move, ONE FLIP (the user 2026-06-29): a card that CHANGED COLUMN flies in the BACK
-      // layer (z-index:-1 → behind the other cards, so it never sails over them); a card that STAYED in its
-      // column but shifted — because the card that left it vacated a slot — glides IN PLACE in normal flow, so
-      // the remaining cards reflow smoothly to their new spots instead of snapping there in a discrete jump.
-      if (crossed) c.classList.add("fitem-flying");
-      // Invert: jump the card back to its old spot, instantly.
-      c.style.transition = "none";
-      c.style.transform = `translate(${dx}px, ${dy}px)`;
-      // Play: next frame, release the offset with a transition → it glides to its new home.
-      requestAnimationFrame(() => requestAnimationFrame(() => {
-        c.style.transition = "transform .42s cubic-bezier(.22, .61, .36, 1)";
-        c.style.transform = "translate(0, 0)";
-      }));
-      const done = (ev: TransitionEvent) => {
-        if (ev.propertyName !== "transform") return;
-        c.removeEventListener("transitionend", done);
-        if (crossed) c.classList.remove("fitem-flying");
-        c.style.transition = ""; c.style.transform = "";   // back to normal flow + stacking
-      };
-      c.addEventListener("transitionend", done);
-    }
+    // Two flavors of move, ONE FLIP (the user 2026-06-29): a card that CHANGED COLUMN flies in the BACK
+    // layer (z-index:-1 → behind the other cards, so it never sails over them); a card that STAYED in its
+    // column but shifted — because the card that left it vacated a slot — glides IN PLACE in normal flow, so
+    // the remaining cards reflow smoothly to their new spots instead of snapping there in a discrete jump.
+    // ONE fly owns an element at a time: a second render can fly the same card while the first fly's 420 ms
+    // transition still runs — two deltas within half a second on an active board. The second Invert cancels
+    // the first transition, and the browser delivers that transitioncancel to EVERY listener on the element
+    // before the second fly's Play frame. Two guards: a per-element token, so a superseded fly's
+    // end/cancel/backstop removes its own listeners and touches nothing else; and `played`, so a fly ignores
+    // transition events that arrive before its own Play wrote the transition — those belong to the fly it
+    // cancelled. Without them the older fly's cancel handler wiped the newer Invert and the card snapped
+    // where it should have glided (reproduced in Chromium).
+    const mine = ++flySeq;
+    (c as any)._flySeq = mine;
+    if (crossed) c.classList.add("fitem-flying");
+    // Invert: jump the card back to its old spot, instantly.
+    c.style.transition = "none";
+    c.style.transform = `translate(${dx}px, ${dy}px)`;
+    // the fly ends on its own event — end OR cancel (a card re-inserted or hidden mid-flight gets
+    // transitioncancel, never transitionend) — with a backstop so a lost event can never leave the card in
+    // the back layer, pointer-events off (absorbIntoParent's idiom). Idempotent: whichever fires first.
+    let flown = false, played = false;
+    const done = (ev?: TransitionEvent) => {
+      if (flown) return;
+      if (ev && (ev.propertyName !== "transform" || !played)) return;   // not this fly's transition
+      flown = true;
+      c.removeEventListener("transitionend", done);
+      c.removeEventListener("transitioncancel", done);
+      if ((c as any)._flySeq !== mine) return;             // superseded: the newer fly owns the element's styles
+      c.classList.remove("fitem-flying");                  // whichever fly added it — the element is settled now
+      c.style.transition = ""; c.style.transform = "";     // back to normal flow + stacking
+    };
+    c.addEventListener("transitionend", done);
+    c.addEventListener("transitioncancel", done);
+    window.setTimeout(done, 650);
+    // Play: next frame, release the offset with a transition → it glides to its new home. Unless the fly
+    // already ended or was superseded (a hidden tab pauses animation frames while the backstop's timer
+    // still runs): a release after that would leave an inline identity transform on a settled card.
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      if (flown || (c as any)._flySeq !== mine) return;
+      played = true;
+      c.style.transition = "transform .42s cubic-bezier(.22, .61, .36, 1)";
+      c.style.transform = "translate(0, 0)";
+    }));
   }
 }
 
@@ -5748,6 +5784,21 @@ function revealCards(keys: Set<string>) {
     c.classList.remove("card-pulse");
     void c.offsetWidth;
     c.classList.add("card-pulse");
+    // and off again when the animation ends (the per-card update gate no longer rewrites className every
+    // render, which used to strip it); under reduced motion no animation runs and the class paints a steady
+    // accent ring, so a backstop a little past the animation's 1.4 s takes it off. animationend bubbles, so
+    // only the pulse's own end counts — a button's acted flash inside the card must not end it. One pulse per
+    // element at a time: a second reveal inside the window re-arms the same handle, so the first reveal's
+    // backstop cannot cut the second's animation short.
+    const prev = (c as any)._pulse as { off: (ev?: AnimationEvent) => void; t: number } | undefined;
+    if (prev) { window.clearTimeout(prev.t); c.removeEventListener("animationend", prev.off); }
+    const off = (ev?: AnimationEvent) => {
+      if (ev && ev.animationName !== "romp-card-pulse") return;
+      c.removeEventListener("animationend", off); window.clearTimeout(cur.t); (c as any)._pulse = undefined; c.classList.remove("card-pulse");
+    };
+    const cur = { off, t: window.setTimeout(off, 1500) };
+    (c as any)._pulse = cur;
+    c.addEventListener("animationend", off);
   }
 }
 

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -257,6 +257,9 @@ function reconcilePendingDone(asks: AskItem[]) {
 }
 type MoveKind = "followup" | "answer";
 const pendingMoveKind = new Map<string, MoveKind>();
+// card itemId → the payload's own object the predicted copy replaced in `asks` (applyFollowMove), so the
+// kernel's refusal of the post can put it back (revertFollowMove) instead of waiting for the next frame
+const predictedFrom = new Map<string, AskItem>();
 // COLUMN-FLIP TRIPWIRE (the user 2026-07-28, who watched a just-replied card bounce Working →
 // Completed → Working and could not be told afterwards WHICH layer bounced it — every candidate
 // mechanism checked out sound post-hoc, and no surface records what the view actually SHOWED).
@@ -297,7 +300,19 @@ function auditShownColumns(list: AskItem[]) {
 function clearFollowMove(itemId: string, why = "") {
   const t = pendingFollowMove.get(itemId); if (t) clearTimeout(t);
   pendingFollowMove.delete(itemId); pendingMoveKind.delete(itemId); pendingMoveAck.delete(itemId);
+  predictedFrom.delete(itemId);
   if (why) lastFeedEvent = "clear:" + why;             // tripwire attribution only; behavior unchanged
+}
+// The kernel REFUSED the post a prediction rode on (an `err` naming the card's askFollowUp; review find,
+// 2026-09-08): the card goes back to what the payload says NOW, on that reply, rather than sitting in Working
+// until the next frame. The refusal is the event the no-answer backstop only approximated; the backstop's own
+// toast blamed silence, and here the kernel has spoken. Puts the payload's object back in the slot the copy
+// took, so the render shows the kernel's state and the gate repaints that card alone (a new identity).
+function revertFollowMove(itemId: string): void {
+  const orig = predictedFrom.get(itemId);
+  clearFollowMove(itemId, "refused");
+  if (orig) { const i = asks.findIndex((a) => a.itemId === itemId); if (i >= 0 && asks[i] !== orig) asks[i] = orig; }
+  render();
 }
 function optimisticFollowMove(itemId: string, kind: MoveKind = "followup") {
   const prev = pendingFollowMove.get(itemId); if (prev) clearTimeout(prev);
@@ -398,6 +413,7 @@ function applyFollowMove(list: AskItem[]) {
     const c: AskItem = { ...a, column: "working" };
     if ((pendingMoveKind.get(a.itemId) ?? "followup") === "followup") { c.recheck = true; c.followupPending = true; }   // plain move / answer: no chip
     if (c.t < nowSec) c.t = nowSec;   // sort to the bottom (newest); the group's repr follows via buildGroup
+    predictedFrom.set(a.itemId, a);   // what a refusal of the post puts back (revertFollowMove)
     list[i] = c;
   }
 }
@@ -976,21 +992,48 @@ function setCardNotify(card: HTMLElement, it: AskItem, value: boolean): void {
   vscodeApi?.postMessage({ type: "cardNotify", itemId: it.itemId, sid: it.sid, value });
 }
 
-// Re-arm the card-face latches (Retry's "Retrying…", Revive's "Reviving…") on the kernel's reply to the
-// click: an err frame for the session, or for no session in particular. The click-safe rule holds the
-// acknowledgement until a deciding event; the per-card update gate no longer repaints every card on every
-// push, so the reply frame and a repaint of the card (a new object, a key flip) are those events. A refusal
-// the kernel answers with neither frame nor payload change leaves the latch until the card next repaints.
-function rearmLatches(sid: string): void {
+// The kernel's reply to a latched click re-arms THAT button (review find, 2026-09-08). Each card-face latch
+// (Retry → "Retrying…", Revive → "Reviving…", Approve/Deny → "Delivering…", Continue → "Sent") holds the
+// acknowledgement until the kernel answers its own post (the click-safe rule), and since the per-card update
+// gate repaints a card only when the kernel re-sends it, the reply IS the event on a refusal (a success
+// re-sends the card, and that repaint re-arms it). Every refusal names the request it answers, and only the
+// latch that made that request lets go: `reviveFailed` names the revived id (the parked card's sid IS that id,
+// and its blocked.toSid), `retryRefused` and an `err` whose op is apiRetry name the session, `quarantineRefused`
+// names the held message's mid, an `err` whose op is askFollowUp names the card. A reply that names a session
+// but no request (an `err` from a kernel older than the op field) releases the session's Retry and Revive, as
+// it did before; one that names neither releases nothing: it answers no request, so every latch stays a
+// request the kernel has not answered. No clock anywhere. Returns how many buttons let go, so a caller can
+// speak only when this page's own click was the one answered (the chat pane voices its own).
+type LatchReply =
+  | { kind: "revive"; id: string }
+  | { kind: "retry"; sid: string }
+  | { kind: "quarantine"; mid: string }
+  | { kind: "followup"; itemId: string }
+  | { kind: "session"; sid: string };
+function rearmLatches(reply: LatchReply): number {
+  let n = 0;
+  const arm = (b: HTMLButtonElement | undefined, label: string) => {
+    if (b && b.disabled) { b.disabled = false; b.textContent = label; n++; }
+  };
   for (const card of askEls.values()) {
     const a = card as any;
     const it = a._it as AskItem | undefined;
-    if (sid && it && it.sid !== sid) continue;
-    const r = a._apiRetry as HTMLButtonElement | undefined;
-    if (r && r.disabled) { r.disabled = false; r.textContent = "Retry"; }
-    const v = a._revive as HTMLButtonElement | undefined;
-    if (v && v.disabled) { v.disabled = false; v.textContent = (v as any)._idle || "Revive"; }
+    if (!it) continue;
+    const reviveIdle = () => (a._revive && (a._revive as any)._idle) || "Revive";
+    switch (reply.kind) {
+      case "revive": if ((it.blocked?.toSid || it.sid) === reply.id) arm(a._revive, reviveIdle()); break;
+      case "retry": if (it.sid === reply.sid) arm(a._apiRetry, "Retry"); break;
+      case "quarantine": if (it.blocked?.mid === reply.mid) { arm(a._qApprove, "Approve"); arm(a._qDeny, "Deny"); } break;
+      case "followup":
+        if (it.itemId === reply.itemId && a._cont && (a._cont as HTMLButtonElement).disabled) {
+          arm(a._cont, "Continue");
+          (a._cont as HTMLButtonElement).title = contTitle(false, "a continue", it.followupAt);
+        }
+        break;
+      case "session": if (it.sid === reply.sid) { arm(a._apiRetry, "Retry"); arm(a._revive, reviveIdle()); } break;
+    }
   }
+  return n;
 }
 
 function showCardMenu(e: MouseEvent, card: HTMLElement): void {
@@ -2262,10 +2305,11 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
     setTip(a._apiBadge as HTMLElement, (spendLimit || refusal) ? it.blocked.what : (it.blocked.text || it.blocked.what));
     // The latched "Retrying…" re-arms on any repaint of this card — a new object or a key flip; the expected
     // path is the session resuming, which moves the working set (the key) and hides the whole unit — and on
-    // the kernel's reply to the click (an err frame for the session, rearmLatches). Before the per-card update
-    // gate it re-armed on the next push of any card. The click is a MANUAL retry (the chat pane sends the
-    // same): the kernel fires it past every auto gate, so the button is never a dead no-op on a paused or
-    // suppressed thread. Revive below latches and re-arms the same way.
+    // the kernel's reply to THIS click (rearmLatches): `retryRefused` when the backend could not take the
+    // send, or an `err` naming this session's apiRetry when the kernel has no such session. Before the
+    // per-card update gate it re-armed on the next push of any card. The click is a MANUAL retry (the chat
+    // pane sends the same): the kernel fires it past every auto gate, so the button is never a dead no-op on
+    // a paused or suppressed thread. Revive below latches the same way and re-arms on `reviveFailed`.
     a._apiRetry.disabled = false; a._apiRetry.textContent = "Retry";
     a._apiRetry.onclick = (ev: Event) => {
       ev.stopPropagation();
@@ -2325,7 +2369,7 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   if (isParked && it.blocked) {
     const toSid = it.blocked.toSid || it.sid;
     a._revive.disabled = false; a._revive.textContent = `Revive ${it.blocked.toName || it.name}`;
-    (a._revive as any)._idle = a._revive.textContent;   // the label rearmLatches restores
+    (a._revive as any)._idle = a._revive.textContent;   // the label rearmLatches restores on the kernel's reviveFailed for toSid
     a._revive.onclick = (ev: Event) => {
       ev.stopPropagation();
       vscodeApi?.postMessage({ type: "reviveSession", id: toSid });
@@ -5573,6 +5617,22 @@ listenForFrames(perfFrameHandler("feed", (m) => vscodeApi?.postMessage(m), (e: M
                                  sid: typeof m.sid === "string" ? m.sid : "",
                                  itemId: typeof m.itemId === "string" ? m.itemId : "" }, "*");
     feedToast(m.text);
+  } else if (m.type === "reviveFailed" && typeof m.id === "string" && m.id) {
+    // the kernel's reply to a Revive (review find, 2026-09-08): the parked card whose button this page latched
+    // lets go, and the reason rides the fading toast, only when a latch here was the one answered; the chat
+    // pane of the same dashboard shows the failure in the revived session's own pane either way, so a revive
+    // clicked there says nothing twice.
+    if (rearmLatches({ kind: "revive", id: m.id })) {
+      feedToast("Couldn't revive " + String(m.name || m.id) + ": " + String(m.text || "unknown error"));
+    }
+  } else if (m.type === "retryRefused" && typeof m.sid === "string" && m.sid) {
+    // the backend could not take the manual retry's send: the Retry this page latched lets go, and says why
+    if (rearmLatches({ kind: "retry", sid: m.sid })) feedToast(String(m.text || "Couldn't retry: the kernel refused it."));
+  } else if (m.type === "quarantineRefused" && typeof m.mid === "string" && m.mid) {
+    // the bus refused a verdict on a held message: that card's Approve and Deny let go, and the reason is said
+    // (this was a bare `warn` before, which this page never handled). The feed is the only poster of verdicts.
+    rearmLatches({ kind: "quarantine", mid: m.mid });
+    feedToast(String(m.text || "the held message could not be acted on"));
   } else if (m.type === "err" && typeof m.text === "string" && m.text) {
     // the dialog interrupts; the bell KEEPS it (the user 2026-07-29) — dismissing the modal must not erase
     // the fact that a message never landed. Same {romp:'notify'} bridge the card-badge mirror below uses.
@@ -5582,7 +5642,19 @@ listenForFrames(perfFrameHandler("feed", (m) => vscodeApi?.postMessage(m), (e: M
                                  text: copy ? title + ": " + copy : title,
                                  sid: typeof m.sid === "string" ? m.sid : "" }, "*");
     showErrDialog(title, m.text, copy);
-    rearmLatches(typeof m.sid === "string" ? m.sid : typeof m.id === "string" ? m.id : "");   // the kernel's reply IS the event
+    const sid = typeof m.sid === "string" ? m.sid : typeof m.id === "string" ? m.id : "";
+    // the kernel's reply IS the event, for the request it names (rearmLatches): a refused apiRetry releases
+    // that session's Retry; a refused askFollowUp releases that card's Continue, and its predicted move yields
+    // to the kernel's answer (revertFollowMove; the no-answer backstop would have bounced it later with a toast
+    // that blamed silence). A reply naming a session and no request is an older kernel's: the session's Retry
+    // and Revive, as before. One naming neither answers no request here.
+    const op = typeof m.op === "string" ? m.op : "";
+    const itemId = typeof m.itemId === "string" ? m.itemId : "";
+    if (op === "apiRetry" && sid) rearmLatches({ kind: "retry", sid });
+    else if (op === "askFollowUp" && itemId) {
+      rearmLatches({ kind: "followup", itemId });
+      if (pendingFollowMove.has(itemId)) revertFollowMove(itemId);
+    } else if (!op && sid) rearmLatches({ kind: "session", sid });
   } else if (m.type === "pickerOptions" && typeof m.name === "string") {
     // the host read the blocked session's live resume-picker screen — show the
     // same options in-page; a choice goes back as keystrokes (transport only,

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -33,6 +33,7 @@ import { initFileBrowse, openFileBrowse } from "./file-browse";
 import { VIEW_STATE_KEY, parseViewState, serializeViewState, pruneViewState, capViewState, type FeedViewState } from "./feed-view-state";
 import { wireTip, setTip, pruneTip } from "./tip";
 import { perfFrameHandler } from "./perf-telemetry";
+import { listenForFrames } from "./frame-listener";
 
 // (The standalone-deliverable "FeedItem" subsystem was REMOVED 2026-07-07: the kernel had emitted
 // items: [] permanently — goal cards are the only feed unit — so its types, renderers, expand/detail
@@ -5361,7 +5362,8 @@ function applyFeedPayload(m: any): void {
 
 // every frame's synchronous handling time is measured (perf-telemetry.ts: one clientDiag row a
 // minute, read by `romp perf client`); the handler itself is unchanged
-window.addEventListener("message", perfFrameHandler("feed", (m) => vscodeApi?.postMessage(m), (e: MessageEvent) => {
+// …and handed the merged frames by direct call from federation.js when this page has it (frame-listener.ts)
+listenForFrames(perfFrameHandler("feed", (m) => vscodeApi?.postMessage(m), (e: MessageEvent) => {
   const m = e.data;
   if (!m) return;
   if (m.type === "pipeState") { pipeBanner(!!m.up, Number(m.queued) || 0); return; }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -7,15 +7,15 @@
 // pushes and updated in place — never torn down — so hovering one doesn't flicker
 // when the sessions stream new deliverables in. A kept card is REPAINTED only when
 // its inputs changed (feed-card-gate.ts): the kernel re-sent it, a board-level input
-// it reads moved, or a gesture touched it. Its column and order are re-applied on
-// every render regardless.
+// it reads moved, a gesture touched it, or the 15 s live pass aged it. Its column and
+// order are re-applied on every render regardless.
 import { distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote } from "./distiller-line";
 import { flipNeeded } from "./feed-flip";
 import { delegate } from "./actions";
 import { paintHeld, paintReleased } from "./paint-gate";
 import { linkifyPrRefs, setLinkedText, senderPrRepo, installPrLinkOpener } from "./pr-links";
 import { cardInputsKey, cardNeedsUpdate, type GateEnv } from "./feed-card-gate";
-import { spinFor, waitedSuffix, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow } from "./spin-caption";
+import { spinFor, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { searchMatches, searchSids } from "./feed-search";
 import { TagLens, lensAll, lensLabel, lensVisible, lensUnions } from "./tag-lens";
@@ -26,6 +26,7 @@ import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote, hostOf } from 
 import { extHoverMatches } from "./card-key";
 import { provenanceRows, provenanceGroupRows, rootStart, type ProvFmt, type ProvRow } from "./provenance";
 import { ageColorReadable } from "./age-color";
+import { liveNow, liveRefresher, refreshAges, stampAge } from "./feed-age";
 import { badgeNotices, clearBoundaryNotices, sdkProblemNotices, syncNotices,
   type ClearNoticeRow, type SdkNoticeRow, type SyncNoticeRow } from "./badge-mirror";
 import { initStrip } from "./strip";
@@ -700,6 +701,12 @@ function setWorkDot(nameEl: HTMLElement | null, state: DotState | boolean) {
 }
 
 let hostNow = Math.floor(Date.now() / 1000);
+// …and WHEN that clock was read (ms, the browser's clock): the frame's `nowAt` when federation stamped one,
+// else the handling. Every age and duration on a card reads the kernel's clock through nowSec() (feed-age.ts
+// liveNow): the frame's `now` plus the local time since it landed, so the browser's skew from the kernel
+// never enters an age, and a quiet board's ages keep moving between frames.
+let hostNowAt = Date.now();
+function nowSec(): number { return liveNow(hostNow, hostNowAt, Date.now()); }
 let showDismissed = false;
 let dismissedCount = 0;
 let canUndoClear = false;   // host: cleared.jsonl has rows → the UndoClear button shows
@@ -717,6 +724,11 @@ function el(tag: string, cls?: string): HTMLElement {
   if (cls) e.className = cls;
   return e;
 }
+// A text write that compares first. In a document that has created a MutationObserver — gear.js creates
+// several at boot — Blink treats an identical textContent write as a real Text-node replacement and dirties
+// layout (feed-age.ts has the mechanism). The grouped-mode session headers repaint on every render (they are
+// not behind the per-card update gate), so their labels write through here.
+function setText(e: HTMLElement, s: string): void { if (e.textContent !== s) e.textContent = s; }
 
 // A lightweight yes/no overlay for the feed. Separate from the ask #feed-modal
 // (a different state machine); Esc or a backdrop click cancels.
@@ -846,7 +858,7 @@ function clockHM(t: number): string {
 // a disabled control (the buttons rule) — the label itself stays one word.
 function contTitle(latched: boolean, verb: string, at?: number | null): string {
   return latched
-    ? verb + " sent" + (at ? " " + relAge(hostNow - at) : "") +
+    ? verb + " sent" + (at ? " " + relAge(nowSec() - at) : "") +
       " — waiting for the session's reply to be judged; this re-arms then, and the card moves on its own"
     : verb === "a continue"
       ? "nothing needed from you — asks the session to keep going"
@@ -861,6 +873,22 @@ function relAge(sec: number): string {
   if (s < 3600) return `${Math.round(s / 60)}m ago`;
   if (s < 86400) return `${Math.round(s / 3600)}h ago`;
   return `${Math.round(s / 86400)}d ago`;
+}
+
+// A RUNNING duration as its own stamped element (feed-age.ts fmt "dur"): "42m" / "1h 5m" since an event
+// time, repainted by the 15 s live pass like every other age. Every elapsed label on a card renders through
+// here — the awaiting box, the Awaiting-task pill, the waiting-on chip, the working narration — because the
+// per-card update gate repaints a card only when its inputs change, and a duration baked into a caption
+// string would freeze on a card the kernel has no reason to re-send (a long wait whose record does not
+// change). On the kernel's clock (nowSec), like every other age here; these read Date.now() before.
+function durSpan(since: number): HTMLElement {
+  const d = el("span", "fask-dur");
+  stampAge(d, since, "dur", false, nowSec(), relAge, ageColorReadable);
+  return d;
+}
+/** waitedSuffix's live twin: [" · ", <duration>] for a known start, [] otherwise — no since, no duration, never a guess. */
+function durNodes(since: number | null | undefined): (string | HTMLElement)[] {
+  return since && since > 0 ? [" · ", durSpan(since)] : [];
 }
 
 function dayLabel(t: number, now: number): string {
@@ -1606,9 +1634,6 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
   // class in the visible label (tooltips are dead on the touch PWA). ONE rule with the chat chip and
   // the awaiting box (awaitWord, slice 2): one row → its word, several of a kind → count + word, mixed
   // kinds → the number alone ("Awaiting 4"); a single named peer → its name in identity colour.
-  // the wait's elapsed time rides the pill exactly as it rides the awaiting box and the working
-  // narration — a stuck wait must be glanceable everywhere the state shows (the user 2026-08-23)
-  const pillWaited = waitedSuffix(it.awaiting && it.awaiting.since, Date.now() / 1000);
   const pillPeers = (it.awaiting && it.awaiting.peers) || [];
   const pillWord = awaitWord(awKind, (it.awaiting && it.awaiting.count) ?? taskRows.length, taskRows);
   const pillLbl = a._taskLbl as HTMLElement;
@@ -1619,7 +1644,10 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
     if (pillPeers[0].color && pillPeers[0].color.bg) nm.style.color = pillPeers[0].color.bg;
     pillLbl.appendChild(nm);
   } else pillLbl.append(pillWord);
-  pillLbl.append(pillWaited);
+  // the wait's elapsed time rides the pill exactly as it rides the awaiting box and the working
+  // narration — a stuck wait must be glanceable everywhere the state shows (the user 2026-08-23) —
+  // as a stamped duration the 15 s live pass keeps moving (durNodes, the live twin of waitedSuffix)
+  pillLbl.append(...durNodes(it.awaiting && it.awaiting.since));   // the waited time, live (durSpan)
   taskBtn.classList.toggle("on", choice === "tasks");
   taskBtn.setAttribute("aria-pressed", choice === "tasks" ? "true" : "false");
   taskBtn.title = choice === "tasks" ? "hide the tasks" : "show the tasks";
@@ -1881,7 +1909,7 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
       og.append(peer);
     });
   }
-  a._time.textContent = relAge(hostNow - it.t);
+  stampAge(a._time, it.t, "plain", false, nowSec(), relAge, ageColorReadable);   // stamped: the 15 s live pass moves it
   // hover the stamp for provenance (the user 2026-07-27): the age marks the NEWEST event (a done card's
   // age is its completion), so the popover tells where the thread came from — started when, each sub +
   // its time, what the stamp marks.
@@ -1959,10 +1987,10 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
     a._waitOn.append(woPre, woName);
     // elapsed since the unanswered ask went out (kernel _wait_for_graph's since) — the same readout the
     // working narration and awaiting box wear, so a wait stuck for hours is glanceable (the user 2026-08-23)
-    const woWaited = waitedSuffix(wo.since, Date.now() / 1000);
-    if (woWaited) {
-      const woDur = el("span", "fask-waiton-dur"); woDur.textContent = woWaited;
-      a._waitOn.append(woDur);
+    const woDur = durNodes(wo.since);
+    if (woDur.length) {
+      const woWrap = el("span", "fask-waiton-dur"); woWrap.append(...woDur);
+      a._waitOn.append(woWrap);
     }
     a._waitOn.title = wo.inCycle
       ? "MUTUAL WAIT — this session and " + wo.name + " are each waiting on the other (a deadlock); auto-nudge surfaces it instead of nudging"
@@ -1992,7 +2020,7 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // The card is not left mute in that window: the Working displacement only happens under recheck/rejudging,
   // and both raise the "Analyzing…" swirl below, which says the judge is looking at it again.
   const spin = spinFor(it, distillPending(dCompleted, dBlocked, it.summary, it.blockSummary, !!it.blocked),
-                       dCompleted, Date.now() / 1000);
+                       dCompleted, nowSec());
   const spinCaption = spin.caption, spinTip = spin.tip, awaitingBg = spin.awaitingBg;
   a._awaitSpin.style.display = spinCaption ? "" : "none";
   // The AWAITING case gets a rounded box (its distinct read); the swirl spins in every case now —
@@ -2021,8 +2049,9 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
         }
         a._awaitWhy.appendChild(nm);
       });
-      a._awaitWhy.append(waitedSuffix(it.awaiting && it.awaiting.since, Date.now() / 1000));
-    } else a._awaitWhy.textContent = spinCaption;
+      a._awaitWhy.append(...durNodes(it.awaiting && it.awaiting.since));
+    } else if (spin.dur) a._awaitWhy.replaceChildren(spin.dur.text, durSpan(spin.dur.since));   // the caption's running duration, live
+    else a._awaitWhy.textContent = spinCaption;
     a._awaitSpin.title = spinTip || spinCaption;
     // HONEST fallback (the user 2026-08-26): a peer-kind wait with no named session says WHY the
     // name is missing, instead of presenting "peer" as a style — identity is only truly unknowable
@@ -2100,13 +2129,14 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
     if (stampOk || anchOk) {
       const dle = a._distill as HTMLElement;
       dle.textContent = "";
-      const nowS = Date.now() / 1000;
+      const nowS = nowSec();
       paras.forEach((p, i) => {
         const para = el("div", "fask-para");
         para.textContent = p;
         if (stampOk && i < bp!.length) {
           const age = el("span", "fask-para-age");
-          age.textContent = relAge(nowS - (bp![i].since || nowS));
+          if (bp![i].since) stampAge(age, bp![i].since, "plain", false, nowS, relAge, ageColorReadable);   // stamped: the live pass moves it
+          else age.textContent = relAge(0);   // no event time → the static "<1m ago" this chip always showed; nothing to count from
           para.append(" ", age);
         }
         // T220 first: the paragraph's own citation, with its located span riding the landing
@@ -2590,7 +2620,7 @@ function updateGroupCard(card: HTMLElement, g: AskGroup) {
   a._name.replaceChildren(...hostNameNodes(g.name, g.sid));
   if (g.color) a._name.style.color = g.color.bg;
   setWorkDot(a._name, dotFor(g.name));   // working/awaiting dot before the session name
-  a._time.textContent = relAge(hostNow - g.t);
+  stampAge(a._time, g.t, "plain", false, nowSec(), relAge, ageColorReadable);
   wireAgeTip(a._time, () => provenanceGroupRows(g.members.map(rootStart), g.t, hostNow, PROV_FMT));
   // member lines — rebuilt only when the member set or any member's status changes
   const memSig = g.members.map((m) => m.itemId + ":" + memberStatus(m)).join("|");
@@ -3482,13 +3512,13 @@ function updateSessHead(h: HTMLElement, e: Entry & { kind: "sess" }): void {
   const fold = (h as any)._fold as HTMLElement, foldn = (h as any)._foldn as HTMLElement;
   const shut = collapsedThreads.has(e.sid);
   h.classList.toggle("folded", shut);
-  fold.textContent = shut ? "▸" : "▾";           // ▸ folded / ▾ open
+  setText(fold, shut ? "▸" : "▾");               // ▸ folded / ▾ open
   fold.title = shut ? "show this session's cards" : "collapse this session to its name — new cards stay folded too";
   fold.setAttribute("aria-expanded", shut ? "false" : "true");
   fold.setAttribute("aria-label", (shut ? "expand " : "collapse ") + e.name);
   foldn.style.display = shut && e.folded ? "" : "none";
   // just the number (the user 2026-08-26) — the section chips' own vocabulary; the words live on hover
-  foldn.textContent = String(e.folded);
+  setText(foldn, String(e.folded));
   foldn.title = e.folded === 1 ? "1 card folded under this session" : e.folded + " cards folded under this session";
   fold.onclick = (ev) => {
     ev.stopPropagation();   // the fold IS the acknowledgement: local state + an immediate re-render
@@ -3506,7 +3536,7 @@ function updateSessHead(h: HTMLElement, e: Entry & { kind: "sess" }): void {
   const procs = e.live ? bgServicesMap[e.name] || [] : [];
   const open = procs.length > 0 && openBgSvc.has(e.sid);
   svc.style.display = procs.length ? "" : "none";
-  svc.textContent = procs.length === 1 ? "background process" : procs.length + " background processes";
+  setText(svc, procs.length === 1 ? "background process" : procs.length + " background processes");
   svc.title = open ? "hide the processes" : "processes this session keeps running — click to list";
   svc.classList.toggle("on", open);
   svc.setAttribute("aria-pressed", open ? "true" : "false");
@@ -4667,6 +4697,7 @@ function watchFeedVisibility(list: HTMLElement): void {
   new IntersectionObserver((entries) => {
     feedIntersecting = entries.some((e) => e.isIntersecting);
     releasePaint();
+    live.catchUp();   // the 15 s age pass skipped while off screen (feed-age.ts liveRefresher); one pass, same measure
   }).observe(list);
 }
 // The owed paint, settled the moment both measures say the pane can be seen. Synchronous on purpose (no
@@ -5384,7 +5415,13 @@ function applyFeedPayload(m: any): void {
     // event: the session left the tab list), rather than leaving the board silently pinned to nothing
     if (feedOnlySid && !sessionsMeta.some((s) => s.sid === feedOnlySid)) setFeedOnly(null);
   }
-  hostNow = typeof m.now === "number" ? m.now : Math.floor(Date.now() / 1000);
+  if (typeof m.now === "number") {
+    hostNow = m.now;
+    hostNowAt = typeof m.nowAt === "number" ? m.nowAt : Date.now();   // the pair travels together: the frame's clock, and when THAT frame arrived (federation stamps it, so a re-emit of a held frame does not re-anchor)
+  } else {
+    hostNow = Math.floor(Date.now() / 1000);   // an older kernel's frame carries no clock: the browser's own, from here
+    hostNowAt = Date.now();
+  }
   mirrorBadges(incomingAsks, Array.isArray(m.clearNotices) ? m.clearNotices : [],
     Array.isArray(m.sdkNotices) ? m.sdkNotices : [],
     Array.isArray(m.syncNotices) ? m.syncNotices : []);   // card trouble chips + /clear drops + SDK failures + fleet syncs also log in the shell's bell (chips stay on the cards)
@@ -5714,15 +5751,43 @@ function revealCards(keys: Set<string>) {
   }
 }
 
-// Keep "Xm ago" honest between host pushes (host reposts ~1×/min for color fade).
-setInterval(() => {
-  const now = Math.floor(Date.now() / 1000);
-  for (const [id, card] of askEls) {
-    const it = asks.find((a) => a.itemId === id);
-    const t = (card as any)._time as HTMLElement | undefined;
-    if (it && t) t.textContent = relAge(now - it.t);
+// ── the 15 s LIVE PASS ────────────────────────────────────────────────────────────────────────────
+// Keep every "Xm ago" and every running duration honest between host pushes, on the kernel's clock (nowSec):
+// on the delta path a quiet board sends a pane nothing between the 60 s reposts, and the per-card update gate
+// (feed-card-gate.ts) repaints a card only when its inputs change, so this pass is what moves time on every
+// card the kernel does not re-send. Every age-bearing label on a card face is stamped (feed-age.ts stampAge)
+// and the pass repaints them all from one clock, rather than each render path owning a copy of the
+// formatting.
+//
+// The pass WRITES ONLY WHAT CHANGED: relAge rounds to the minute and then the hour, so a handful of labels
+// move per tick on a board of hundreds, and in a document that has ever created a MutationObserver — gear.js
+// creates several at boot — Blink treats an identical textContent write as a real Text-node replacement that
+// dirties layout (paintAge compares first). A pane nobody can see skips the pass and catches up once when
+// shown (liveRefresher, the Outline pane's pattern), by the paint gate's own two measures (paint-gate.ts):
+// the tab hidden, or #feed-list off screen by the observer's word, which is how a pane the shell has
+// display:none'd reads. The two events that release an owed paint catch the pass up, so the feed has one
+// definition of "hidden".
+function livePass(): void {
+  const now = nowSec();
+  for (const card of askEls.values()) {
+    const it = (card as any)._it as AskItem | undefined;
+    if (!it) continue;
+    // the latched Continue's hover title names how long ago it was sent (contTitle, T150): a title, so it
+    // cannot be stamped — refreshed here for the few latched buttons, compare-then-write like the rest, and
+    // only once the payload itself carries the latch (the same test updateAskCard re-arms on): a click
+    // latches the button before any frame lands, and the stale object's followupAt would name an older
+    // follow-up
+    const cont = (card as any)._cont as HTMLButtonElement | undefined;
+    if (cont && cont.disabled && (it.followupPending || it.recheck || it.rejudging)) {
+      const ct = contTitle(true, "a continue", it.followupAt);
+      if (cont.title !== ct) cont.title = ct;
+    }
   }
-}, 15000);
+  refreshAges(document.querySelectorAll<HTMLElement>("[data-age-t]"), now, relAge, ageColorReadable);
+}
+const live = liveRefresher({ hidden: () => paintHeld(document.hidden, feedIntersecting, true), pass: livePass });
+setInterval(live.tick, 15000);
+document.addEventListener("visibilitychange", live.catchUp);
 
 initFileView((m) => vscodeApi?.postMessage(m));   // the file browser opens the viewer in this pane (and saves ride the poster)
 // …and how the viewer names the session a file was opened from: this pane's session list (the same tab

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -5,12 +5,16 @@
 //
 // Rendering is KEYED + INCREMENTAL: cards are kept alive across the host's live
 // pushes and updated in place — never torn down — so hovering one doesn't flicker
-// when the fleet streams new deliverables in.
+// when the sessions stream new deliverables in. A kept card is REPAINTED only when
+// its inputs changed (feed-card-gate.ts): the kernel re-sent it, a board-level input
+// it reads moved, or a gesture touched it. Its column and order are re-applied on
+// every render regardless.
 import { distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote } from "./distiller-line";
 import { flipNeeded } from "./feed-flip";
 import { delegate } from "./actions";
 import { paintHeld, paintReleased } from "./paint-gate";
 import { linkifyPrRefs, setLinkedText, senderPrRepo, installPrLinkOpener } from "./pr-links";
+import { cardInputsKey, cardNeedsUpdate, type GateEnv } from "./feed-card-gate";
 import { spinFor, waitedSuffix, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { searchMatches, searchSids } from "./feed-search";
@@ -488,9 +492,19 @@ onExternalSettingsChange((s) => { applyTheme(document, s); render(); });
 // Card-display prefs read straight from the shared 'romp:settings' (the kernel's ⛭ gear writes it; same
 // document as this feed bundle). Default ON. These gate the CARDS only — the modal always shows everything
 // (the user 2026-06-17). `!== false` so a missing key defaults to shown.
-function feedPrefs(): { newestFirst: boolean; collapsed: boolean; grouped: boolean; stacked: boolean } {
+// Memoised on the RAW settings string: called per card per render, and each call parsed the blob. Keyed on
+// the raw string, the memo is exact and needs no invalidation. `colormap` rides along for the per-card
+// update gate (feed-card-gate.ts): a colormap pick repaints every card once, as the settings epoch did.
+type FeedPrefs = { newestFirst: boolean; collapsed: boolean; grouped: boolean; stacked: boolean; colormap: string };
+const PREFS_DEFAULT: FeedPrefs = { newestFirst: false, collapsed: false, grouped: true, stacked: false, colormap: "aurora" };
+let prefsRaw: string | null | undefined;
+let prefsMemo: FeedPrefs = PREFS_DEFAULT;
+function feedPrefs(): FeedPrefs {
+  let raw: string | null = null;
+  try { raw = localStorage.getItem("romp:settings"); } catch { return PREFS_DEFAULT; }
+  if (raw === prefsRaw) return prefsMemo;
   try {
-    const s = JSON.parse(localStorage.getItem("romp:settings") || "{}");
+    const s = JSON.parse(raw || "{}");
     // newestFirst + collapsed default OFF (=== true): the feed's natural order is oldest-first, and cards
     // arrive with their summary open (the user 2026-07-07). collapsed is the DEFAULT section state new cards
     // inherit — a per-card expand overrides just that card without turning the mode off. (Sub-goals is now one
@@ -498,9 +512,11 @@ function feedPrefs(): { newestFirst: boolean; collapsed: boolean; grouped: boole
     // grouped (the user 2026-07-13): each column groups its cards by SESSION (tab/lane order), a session-name
     // header on the backdrop between runs, the per-card name dropped — the compact by-session read.
     // Default ON (!== false, same day): grouping is the feed's normal reading mode; the toggle opts OUT.
-    return { newestFirst: s.newestFirst === true, collapsed: s.collapsed === true, grouped: s.grouped !== false,
-             stacked: s.stacked === true };
-  } catch { return { newestFirst: false, collapsed: false, grouped: true, stacked: false }; }
+    prefsMemo = { newestFirst: s.newestFirst === true, collapsed: s.collapsed === true, grouped: s.grouped !== false,
+                  stacked: s.stacked === true, colormap: String(s.colormap || "aurora").toLowerCase() };
+  } catch { prefsMemo = PREFS_DEFAULT; }
+  prefsRaw = raw;
+  return prefsMemo;
 }
 // The kernel's session order (session-order.json — the SAME order the chat tabs + timeline lanes hold; the
 // user 2026-07-13: grouped-mode sessions must match it). Rides every feed push; federation concatenates
@@ -594,6 +610,10 @@ function setFeedSearch(q: string): void {
 // same pair settings sync rides): the browser's same-origin iframes hear the localStorage write
 // (`storage` fires cross-document), and VS Code's extension fans {colorSync} to its other panels.
 // Apply it to every copy this pane holds and re-render; the kernel's own re-broadcast reconciles.
+// IN PLACE, deliberately: these objects are federation's held frame, so the write lands in the cache too
+// and a re-emit before the kernel's own rebuild keeps the new colour (copies in this pane's list alone
+// would hand the old colour back on the next merged emission). The per-card update gate cannot see an
+// in-place write through object identity, so the colour rides the card key instead (feed-card-gate.ts).
 function applyColorEcho(sid: string, bg: string): void {
   if (!sid || !bg) return;
   const color = { bg, fg: "#ffffff" };   // fg fixed white, matching the kernel's _name_color
@@ -689,6 +709,8 @@ let canUndoClear = false;   // host: cleared.jsonl has rows → the UndoClear bu
 // node) can't slide it and it would pop. We map the new card back to its predecessor's old rect so it slides
 // from there instead of appearing from nowhere. Rebuilt every render.
 let prevItemKey = new Map<string, string>();
+// Counts renders: the per-card update gate's key for a quarantine card carries it, so those cards never skip.
+let renderSeq = 0;
 
 function el(tag: string, cls?: string): HTMLElement {
   const e = document.createElement(tag);
@@ -900,7 +922,7 @@ function cardBellSvg(off: boolean): string {
     + '<path d="M6.6 11.6 A1.5 1.5 0 0 0 9.4 11.6"/>' + slash + "</svg>";
 }
 
-function cardNotifyOn(it: AskItem): boolean {
+function cardNotifyOn(it: { itemId: string; notify?: boolean | null }): boolean {
   return pendingNotify.has(it.itemId) ? !!pendingNotify.get(it.itemId) : !!it.notify;
 }
 
@@ -924,6 +946,23 @@ function setCardNotify(card: HTMLElement, it: AskItem, value: boolean): void {
   pendingNotify.set(it.itemId, value);               // sticky until the kernel's payload carries it
   paintCardBell(card, value);                        // acknowledge instantly, before the round-trip
   vscodeApi?.postMessage({ type: "cardNotify", itemId: it.itemId, sid: it.sid, value });
+}
+
+// Re-arm the card-face latches (Retry's "Retrying…", Revive's "Reviving…") on the kernel's reply to the
+// click: an err frame for the session, or for no session in particular. The click-safe rule holds the
+// acknowledgement until a deciding event; the per-card update gate no longer repaints every card on every
+// push, so the reply frame and a repaint of the card (a new object, a key flip) are those events. A refusal
+// the kernel answers with neither frame nor payload change leaves the latch until the card next repaints.
+function rearmLatches(sid: string): void {
+  for (const card of askEls.values()) {
+    const a = card as any;
+    const it = a._it as AskItem | undefined;
+    if (sid && it && it.sid !== sid) continue;
+    const r = a._apiRetry as HTMLButtonElement | undefined;
+    if (r && r.disabled) { r.disabled = false; r.textContent = "Retry"; }
+    const v = a._revive as HTMLButtonElement | undefined;
+    if (v && v.disabled) { v.disabled = false; v.textContent = (v as any)._idle || "Revive"; }
+  }
 }
 
 function showCardMenu(e: MouseEvent, card: HTMLElement): void {
@@ -1257,7 +1296,7 @@ function makeAskCard(it: AskItem): HTMLElement {
     card.dispatchEvent(new MouseEvent("mouseleave"));
     dressHeaderIfLast(card, it.sid);   // the run's last card takes its header with it — one motion (2026-08-24)
     pendingCleared.add(it.itemId);   // suppress from incoming pushes until the kernel confirms the clear
-    clearedStack.push([it]);         // cache for an instant optimistic Undo
+    clearedStack.push([(card as any)._it ?? it]);   // cache the FRESHEST payload copy for an instant optimistic Undo (the closure's `it` is the card's creation-time object)
     card.classList.add("dismissing");
     vscodeApi?.postMessage({ type: "askClear", itemId: it.itemId, sid: it.sid });
     setTimeout(() => { if (askEls.get(it.itemId) === card && card.classList.contains("dismissing")) { card.remove(); askEls.delete(it.itemId); dropDismissed([it.itemId]); } }, 180);
@@ -1715,36 +1754,13 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
   renderTree();
 }
 
-// The payload copy a card was last painted from, serialized — a card whose data did not change since is not
-// repainted. Every feed frame used to rewrite all ~155 cards (about a hundred DOM writes each) when the frame
-// changed one of them (2026-09-04). The display-side state a paint also reads (hover/pin focus, the pending
-// bell, the done ticks) is folded into the key, so a change to any of it repaints as before.
-// Bumped whenever a display-side input EVERY card reads changes: the view prefs (grouped, collapsed), the
-// working/awaiting/unknown status sets and the self host that the session dots and delegation lines read.
-// A card's key carries it, so such a change repaints every card once, as before. The coarse clock repaints
-// each card at most every 15 s so the durations it renders (waited, working for, paragraph ages) keep
-// ticking — the old cadence was every kernel push, at most 60 s apart.
-let paintEpoch = 0;
-let statusSig = "";
-function noteStatusInputs(): void {
-  const sig = [...workingSet].sort().join(",") + "|" + [...awaitingSet].sort().join(",") + "|" + [...unknownSet].sort().join(",") + "|" + feedSelfHost;
-  if (sig !== statusSig) { statusSig = sig; paintEpoch++; }
-}
-function cardPaintKey(it: AskItem): string {
-  return JSON.stringify(it) + "|" + (it.itemId === (hoverAskId ?? pinnedAskId) ? "f" : "") + (it.itemId === pinnedAskId ? "p" : "")
-    + "|" + (pendingNotify.has(it.itemId) ? String(pendingNotify.get(it.itemId)) : "") + "|" + [...pendingDone].join(",")
-    + "|" + paintEpoch + "|" + Math.floor(Date.now() / 15000);
-}
-
+// Paints a card's face from its payload copy. Whether to call it at all is reconcileCol's decision (the
+// per-card update gate, feed-card-gate.ts): a card is repainted when its object is a new one or a
+// board-level input it reads changed, and left alone otherwise. Everything this function reads outside
+// `it` is therefore in that key — an input added here is added there.
 function updateAskCard(card: HTMLElement, it: AskItem) {
   const a = card as any;
-  a._it = it;   // the freshest payload copy — the right-click bell menu reads this, never a stale closure
-  const pk = cardPaintKey(it);
-  // Nothing this card shows has changed → leave its DOM alone. Except a card with a LATCHED button (Approve →
-  // Delivering…, Retry → Retrying…, Revive → Reviving…): those rely on the next paint to re-enable when the
-  // refused action left the payload unchanged, so a card with a disabled button always repaints.
-  if (a._paintKey === pk && !card.querySelector("button[disabled]")) return;
-  a._paintKey = pk;
+  a._it = it;   // the freshest payload copy — the right-click bell menu reads this, never a stale closure; and the gate's identity
   // per-card bell: retire the optimistic value once the kernel's payload agrees (event-based, no timer),
   // then render whichever stands. Same sticky-optimism shape as the timeline lane's _pendingFlags.
   if (pendingNotify.has(it.itemId) && !!it.notify === pendingNotify.get(it.itemId)) pendingNotify.delete(it.itemId);
@@ -2214,10 +2230,16 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
       : it.blocked.status ? `⚠ API error · ${it.blocked.status}` : "⚠ API error";
     // a refusal's raw CLI text buries the remedy — the kernel's `what` states it plainly, so tip with that
     setTip(a._apiBadge as HTMLElement, (spendLimit || refusal) ? it.blocked.what : (it.blocked.text || it.blocked.what));
+    // The latched "Retrying…" re-arms on any repaint of this card — a new object or a key flip; the expected
+    // path is the session resuming, which moves the working set (the key) and hides the whole unit — and on
+    // the kernel's reply to the click (an err frame for the session, rearmLatches). Before the per-card update
+    // gate it re-armed on the next push of any card. The click is a MANUAL retry (the chat pane sends the
+    // same): the kernel fires it past every auto gate, so the button is never a dead no-op on a paused or
+    // suppressed thread. Revive below latches and re-arms the same way.
     a._apiRetry.disabled = false; a._apiRetry.textContent = "Retry";
     a._apiRetry.onclick = (ev: Event) => {
       ev.stopPropagation();
-      vscodeApi?.postMessage({ type: "apiRetry", id: it.sid });
+      vscodeApi?.postMessage({ type: "apiRetry", id: it.sid, manual: true });
       a._apiRetry.disabled = true; a._apiRetry.textContent = "Retrying…";
     };
   }
@@ -2273,6 +2295,7 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   if (isParked && it.blocked) {
     const toSid = it.blocked.toSid || it.sid;
     a._revive.disabled = false; a._revive.textContent = `Revive ${it.blocked.toName || it.name}`;
+    (a._revive as any)._idle = a._revive.textContent;   // the label rearmLatches restores
     a._revive.onclick = (ev: Event) => {
       ev.stopPropagation();
       vscodeApi?.postMessage({ type: "reviveSession", id: toSid });
@@ -3520,6 +3543,10 @@ function makeUndoClearBtn(): HTMLElement {
       for (const it of batch) {
         pendingCleared.delete(it.itemId);
         pendingRestored.set(it.itemId, it);                                  // stay sticky until the kernel push carries it
+        // a card still inside its 180 ms collapse keeps its element AND its object, so the per-card update
+        // gate would leave `.dismissing` on it and the collapse timer would then remove the restored card:
+        // the Undo gesture is the event that takes the class off
+        askEls.get(it.itemId)?.classList.remove("dismissing");
         if (!asks.some((a) => a.itemId === it.itemId)) asks.push(it);        // show it NOW
       }
       render();
@@ -4250,7 +4277,7 @@ function clearSessionCards(sid: string): void {
   }, 180);
 }
 
-function reconcileCol(listEl: HTMLElement, entries: Entry[], globalDesired: Set<string>) {
+function reconcileCol(listEl: HTMLElement, entries: Entry[], globalDesired: Set<string>, gate: GateEnv) {
   const existing = new Map<string, HTMLElement>();
   for (const c of Array.from(listEl.children) as HTMLElement[]) {
     const k = c.dataset.key;
@@ -4264,7 +4291,14 @@ function reconcileCol(listEl: HTMLElement, entries: Entry[], globalDesired: Set<
       key = "a:" + e.ask.itemId;
       card = askEls.get(e.ask.itemId) || makeAskCard(e.ask);
       askEls.set(e.ask.itemId, card);
-      updateAskCard(card, e.ask);
+      // THE UPDATE GATE (feed-card-gate.ts): repaint only a card the kernel re-sent (a new object — the pane
+      // shim's delta reassembly and federation's merge keep an unchanged card's object by reference) or whose
+      // board-level inputs changed (the key). Everything below — placement, the insertBefore order walk, the
+      // cross-column removal — stays unconditional, so a card whose column or sort changed still moves. The
+      // key is stored only after updateAskCard returns: a throw mid-update leaves the card marked for another
+      // try, not recorded as painted.
+      const ik = cardInputsKey(e.ask, gate);
+      if (cardNeedsUpdate(card as any, e.ask, ik)) { updateAskCard(card, e.ask); (card as any)._ik = ik; }
     } else if (e.kind === "sess") {
       // grouped-mode session header — keyed per (column, sid): one session can head a run in EVERY column
       key = "s:" + listEl.id + ":" + e.sid;
@@ -4771,10 +4805,21 @@ function render() {
   prevCols = nextCols;
   const flipFirst = needFlip ? captureCardRects(cols) : new Map<string, FlipState>();
 
+  // The per-card update gate's inputs, resolved ONCE for this render (feed-card-gate.ts cardInputsKey):
+  // everything updateAskCard reads outside the ask object. A card is repainted when its object or this key
+  // changed, so a frame's cost scales with the cards the kernel re-sent and the cards a changed input
+  // reaches, not with the board.
+  const gprefs = feedPrefs();
+  const gate: GateEnv = {
+    dot: dotFor, working: (n) => workingSet.has(n),
+    focusId: hoverAskId ?? pinnedAskId, pinnedId: pinnedAskId, notifyOn: cardNotifyOn,
+    prefs: { grouped: gprefs.grouped, collapsed: gprefs.collapsed, colormap: gprefs.colormap },
+    hostDown: hostIsDown, selfHost: feedSelfHost, repo: prRepoOf, seq: ++renderSeq,
+  };
   const desired = new Set<string>();
-  reconcileCol(cols.asks, buckets.asks, desired);
-  reconcileCol(cols.needsInput, buckets.needsInput, desired);
-  reconcileCol(cols.completed, buckets.completed, desired);
+  reconcileCol(cols.asks, buckets.asks, desired, gate);
+  reconcileCol(cols.needsInput, buckets.needsInput, desired, gate);
+  reconcileCol(cols.completed, buckets.completed, desired, gate);
   // the count chip shows the number only when there ARE cards; an empty column shows nothing — not "0"
   // (the user 2026-06-25). Empty string collapses the chip (it has no padding/background of its own).
   const setCount = (elc: HTMLElement, n: number) => { elc.textContent = n ? String(n) : ""; elc.style.display = n ? "" : "none"; };
@@ -5007,7 +5052,6 @@ window.addEventListener("blur", () => { if (kbMode) kbExit(); });   // shell mov
 // same-page toggle both land here).
 let lastCollapsedPref = feedPrefs().collapsed;
 function onSettingsChanged(): void {
-  paintEpoch++;   // grouped/collapsed/stacked reach into every card's paint (name row, row2, sections)
   const p = feedPrefs();
   if (p.collapsed !== lastCollapsedPref) { lastCollapsedPref = p.collapsed; secChoice.clear(); }
   applyStacked(p.stacked);
@@ -5328,7 +5372,6 @@ function applyFeedPayload(m: any): void {
   }
   awaitingSet = new Set(Array.isArray(m.awaiting) ? m.awaiting : []);   // await-green awaiting dots (the user 2026-07-13)
   unknownSet = new Set(Array.isArray(m.stateUnknown) ? m.stateUnknown : []);   // listed-but-unreadable → gray ring, never a blank
-  noteStatusInputs();   // the dots and delegation lines every card paints read these → a change repaints every card
   bgServicesMap = m.bgServices && typeof m.bgServices === "object" ? m.bgServices : {};   // session name -> judge-classified service descs → the session-header chip (2026-07-24)
   if (Array.isArray(m.order)) sessionOrder = m.order.filter((x: any) => typeof x === "string");   // grouped-mode session rank (tab/lane order)
   pendingHosts = Array.isArray(m.pendingHosts) ? m.pendingHosts.filter((h: any) => typeof h === "string") : [];
@@ -5447,7 +5490,7 @@ listenForFrames(perfFrameHandler("feed", (m) => vscodeApi?.postMessage(m), (e: M
   } else if (m.type === "settingRefused" && typeof m.text === "string" && m.text) {
     // the kernel refused a bell toggle this page posted (its store could not be read): end the optimistic
     // state ON THIS EVENT — the card's sticky latch drops and the bell repaints to what the payload holds
-    // (the paint key reads the latch) — and say why. A SOFT refusal: nothing typed was lost, so the fading
+    // (the card gate's key reads the latch through cardNotifyOn) — and say why. A SOFT refusal: nothing typed was lost, so the fading
     // toast (the chat's weight for the same class), never the must-dismiss dialog; the shell's bell keeps the
     // durable record under its own `refused` kind, so muting judge warnings never mutes these. A `warn`
     // frame had no handler on this page, so the bell stayed painted as if the click had landed until a reload.
@@ -5466,6 +5509,7 @@ listenForFrames(perfFrameHandler("feed", (m) => vscodeApi?.postMessage(m), (e: M
                                  text: copy ? title + ": " + copy : title,
                                  sid: typeof m.sid === "string" ? m.sid : "" }, "*");
     showErrDialog(title, m.text, copy);
+    rearmLatches(typeof m.sid === "string" ? m.sid : typeof m.id === "string" ? m.id : "");   // the kernel's reply IS the event
   } else if (m.type === "pickerOptions" && typeof m.name === "string") {
     // the host read the blocked session's live resume-picker screen — show the
     // same options in-page; a choice goes back as keystrokes (transport only,

--- a/ui/webview/fleet.ts
+++ b/ui/webview/fleet.ts
@@ -20,6 +20,7 @@ import { liveNow } from "./feed-age";
 import { TIP_GRACE_MS } from "./tip";
 import { perfFrameHandler } from "./perf-telemetry";
 import { linkifyPrRefs, installPrLinkOpener } from "./pr-links";
+import { listenForFrames } from "./frame-listener";
 
 type Color = { bg: string; fg: string } | null;
 interface LedgerNode {
@@ -725,7 +726,8 @@ function mountControls() {
 
 // every frame's synchronous handling time is measured (perf-telemetry.ts: one clientDiag row a
 // minute, read by `romp perf client`); the handler itself is unchanged
-window.addEventListener("message", perfFrameHandler("fleet", (m) => vscodeApi?.postMessage(m), (e: MessageEvent) => {
+// …and handed the merged frames by direct call from federation.js when this page has it (frame-listener.ts)
+listenForFrames(perfFrameHandler("fleet", (m) => vscodeApi?.postMessage(m), (e: MessageEvent) => {
   const m = e.data;
   if (!m) return;
   if (m.type === "delta") {

--- a/ui/webview/fold-persist.test.ts
+++ b/ui/webview/fold-persist.test.ts
@@ -1,5 +1,5 @@
 // Expand/collapse state must SURVIVE the incremental re-render a send/turn triggers (the user 2026-06-19):
-// a short transcript rebuilds from index 0, a long one re-renders the trailing TAIL_RECHECK turns, so a
+// a short transcript rebuilds from index 0, a long one re-renders from the first changed event, so a
 // DOM-only `.open`/`.expanded` silently snaps shut whatever the user had opened (the reported bug: expand
 // the system-context card, type, hit ⏎ → it collapses). We persist open-state in a module Set keyed by a
 // stable id and reapply on rebuild. No jsdom harness for the renderer, so pin the wiring at the source.

--- a/ui/webview/follow-move-cache-echo.test.ts
+++ b/ui/webview/follow-move-cache-echo.test.ts
@@ -1,8 +1,9 @@
 // The optimistic follow-up move must never WRITE into the payload it renders (the user 2026-08-02, who
 // replied to a blocked card and watched it bounce working → blocked → working). On the federated page the
 // ask objects in a `feed` payload ARE the FederationManager's cached per-host frames: mergeHostFeeds
-// concatenates the cached arrays element-by-reference, and the merged frame reaches the pane through a
-// same-realm MessageEvent (window.dispatchEvent — no structured clone). So applyFollowMove's old in-place
+// concatenates the cached arrays element-by-reference, and the merged frame reaches the pane by direct call
+// from federation's emit (a same-realm window dispatch only when no handler is registered), so no structured
+// clone severs the references. So applyFollowMove's old in-place
 // `a.column = "working"` edited the manager's cache; the next merged re-emit — fired by ANY host's frame,
 // seconds later — served the pane its own edit back as kernel truth, reconcileFollowMove read it as the
 // kernel confirming the move ("confirmed") and dropped the prediction, and the next local build already in
@@ -38,8 +39,9 @@ test("applyFollowMove replaces the list slot with a copy — it never mutates th
 test("the shared-reference premise holds: the merge reuses cached frame elements, delivered same-realm", () => {
   // mergeHostFeeds concatenates the cached asks arrays by reference (no per-element copy)…
   assert.match(FED, /if \(Array\.isArray\(f\.asks\)\) merged\.asks\.push\(\.\.\.f\.asks\);/);
-  // …and the merged frame is dispatched in-realm, so no structured clone severs the references
-  assert.match(FED, /window\.dispatchEvent\(new MessageEvent\("message", \{ data: mergeHostFeeds\(/);
+  // …and the merged frame is handed to the pane by direct call (emit: the registered handler, else a same-realm
+  // window dispatch), so no structured clone severs the references
+  assert.match(FED, /this\.emit\(mergeHostFeeds\(/);
 });
 
 // Executed replica: the exact scenario off the diagnosed trail. A cached host frame holds the blocked

--- a/ui/webview/frame-listener.ts
+++ b/ui/webview/frame-listener.ts
@@ -1,0 +1,24 @@
+// A pane's one frame listener, installed on both delivery paths.
+//
+// Every pane handles the frames it receives in ONE window "message" handler: the kernel's frames (through the
+// shim and federation.js on a kernel page, the extension host's pipe in VS Code) and the shell's `romp:` posts.
+// federation.js emits its MERGED frames (`feed`, `tabOrder`, `data`, `bars`) by direct call to the handlers
+// registered with it and dispatches on window only when none is registered (federation.ts emit): a "message"
+// listener in another JavaScript world (a browser extension's content script) that reads event.data forces a
+// structured clone of the frame on every window dispatch, tens of milliseconds for a large board. So the pane
+// installs the SAME handler on window and in the registry; federation picks one path per frame, so each frame
+// arrives exactly once, and the perf brackets (perf-telemetry.ts) nest the same way on either path.
+//
+// Kept import-free: federation.ts must never be imported by a pane bundle (federation-single-instance.test.ts),
+// so the registry is reached through the window slot federation.js publishes before the bundle loads. Without
+// the slot (a VS Code webview, an older federation.js) the window listener carries every frame, as before.
+
+/** Install `handler` as the pane's frame listener on window and, when the page's federation manager is present,
+ *  in its direct-delivery registry. Returns the handler. */
+export function listenForFrames(handler: (e: MessageEvent) => void): (e: MessageEvent) => void {
+  window.addEventListener("message", handler);
+  // no registry on this page (a VS Code webview, an older federation.js): the window path carries every frame
+  const fed = (window as any).__rompFed;
+  if (fed && typeof fed.onFrame === "function") fed.onFrame(handler);
+  return handler;
+}

--- a/ui/webview/heal-on-hostup.test.ts
+++ b/ui/webview/heal-on-hostup.test.ts
@@ -33,8 +33,9 @@ test("the recovery set is computed BEFORE downHosts is overwritten with this pol
 });
 
 test("render.ts's message listener heals previews unconditionally at the top, so hostUp needs no case of its own", () => {
-  // the listener is installed through perf-telemetry's per-frame timing wrapper; the handler body is unchanged
-  const at = RENDER.indexOf('window.addEventListener("message", perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: MessageEvent) => {');
+  // the listener is installed through perf-telemetry's per-frame timing wrapper and frame-listener.ts (window + federation's
+  // direct-delivery registry); the handler body is unchanged
+  const at = RENDER.indexOf('listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: MessageEvent) => {');
   assert.ok(at >= 0);
   const heal = RENDER.indexOf("retryFailedPreviews();", at);
   const firstCase = RENDER.indexOf('if (m.type === "session")', at);

--- a/ui/webview/highlight-cache.test.ts
+++ b/ui/webview/highlight-cache.test.ts
@@ -1,0 +1,92 @@
+// The fence highlight cache (highlight-cache.ts): the same (language, source) tokenizes once
+// while its entry is held; an unlabeled fence still goes through auto-detection over every grammar (the
+// detection is kept — only the repeat work goes); the cache is bounded by entries and by output size.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { highlightHtml, newHighlightCache, CAP, BUDGET, MAX_RAW } from "./highlight-cache";
+
+function stub() {
+  const calls = { highlight: 0, auto: 0 };
+  const hl = {
+    getLanguage: (name: string) => (name === "python" || name === "bash" ? {} : undefined),
+    highlight: (raw: string, o: { language: string }) => { calls.highlight++; return { value: `<${o.language}>${raw}</${o.language}>` }; },
+    highlightAuto: (raw: string) => { calls.auto++; return { value: `<auto>${raw}</auto>` }; },
+  };
+  return { hl, calls };
+}
+
+test("the same fence twice tokenizes once; a labeled fence goes to its grammar, an unlabeled one to auto-detection", () => {
+  const { hl, calls } = stub();
+  const c = newHighlightCache();
+  assert.equal(highlightHtml(hl, "python", "print(1)", c), "<python>print(1)</python>");
+  assert.equal(highlightHtml(hl, "python", "print(1)", c), "<python>print(1)</python>");
+  assert.deepEqual(calls, { highlight: 1, auto: 0 });
+  assert.equal(highlightHtml(hl, undefined, "print(1)", c), "<auto>print(1)</auto>", "no label: auto-detected, and a separate entry from the labeled one");
+  assert.equal(highlightHtml(hl, undefined, "print(1)", c), "<auto>print(1)</auto>");
+  assert.deepEqual(calls, { highlight: 1, auto: 1 });
+});
+
+test("an unknown language is auto-detected and shares the unlabeled entry (both mean: no grammar named)", () => {
+  const { hl, calls } = stub();
+  const c = newHighlightCache();
+  highlightHtml(hl, "klingon", "x = 1", c);
+  highlightHtml(hl, undefined, "x = 1", c);
+  assert.deepEqual(calls, { highlight: 0, auto: 1 });
+});
+
+test("a different source, or the same source in another language, is its own entry", () => {
+  const { hl, calls } = stub();
+  const c = newHighlightCache();
+  highlightHtml(hl, "python", "a", c); highlightHtml(hl, "python", "b", c); highlightHtml(hl, "bash", "a", c);
+  assert.deepEqual(calls, { highlight: 3, auto: 0 });
+  assert.equal(c.map.size, 3);
+});
+
+test("bounded by entries: the oldest goes first, and a hit counts as newest", () => {
+  const { hl, calls } = stub();
+  const c = newHighlightCache();
+  for (let i = 0; i < CAP; i++) highlightHtml(hl, "python", "line " + i, c);
+  assert.equal(c.map.size, CAP);
+  highlightHtml(hl, "python", "line 0", c);            // a hit: "line 0" is newest now
+  highlightHtml(hl, "python", "one more", c);          // pushes out the oldest, which is "line 1"
+  assert.equal(c.map.size, CAP);
+  const before = calls.highlight;
+  highlightHtml(hl, "python", "line 0", c);
+  assert.equal(calls.highlight, before, "the refreshed entry survived");
+  highlightHtml(hl, "python", "line 1", c);
+  assert.equal(calls.highlight, before + 1, "the evicted entry tokenizes again");
+});
+
+test("bounded by output size, and a very large source is highlighted but never kept", () => {
+  const { hl, calls } = stub();
+  const c = newHighlightCache();
+  // BUDGET bounds the highlighted OUTPUT and MAX_RAW the source, so the stub's output is what has to be large: a
+  // short source highlighted to OUT characters per character; three of `each` characters overrun the budget together
+  const OUT = 50_000;
+  const wide = { ...hl, highlight: (raw: string) => { calls.highlight++; return { value: raw.repeat(OUT) }; } };
+  const each = Math.floor(BUDGET / 3 / OUT) + 1;
+  highlightHtml(wide, "python", "a".repeat(each), c); highlightHtml(wide, "python", "b".repeat(each), c); highlightHtml(wide, "python", "c".repeat(each), c);
+  assert.equal(c.map.size, 2, "the third output pushed the total past the budget, so the oldest went");
+  assert.equal(c.chars, 2 * each * OUT, "the evicted entry's characters were subtracted");
+  highlightHtml(wide, "python", "a".repeat(each), c);
+  assert.equal(calls.highlight, 4, "the evicted source tokenizes again");
+  assert.equal(c.map.size, 2); assert.equal(c.chars, 2 * each * OUT);
+  const one = newHighlightCache();
+  highlightHtml(wide, "python", "z".repeat(Math.floor(BUDGET / OUT) + 1), one);   // over the budget by itself
+  assert.equal(one.map.size, 1, "a single entry is kept even when it alone exceeds the budget");
+  const huge = "y".repeat(MAX_RAW + 1);
+  const n = c.map.size, before = calls.highlight;
+  assert.equal(highlightHtml(hl, "python", huge, c), `<python>${huge}</python>`);
+  assert.equal(c.map.size, n, "not kept");
+  highlightHtml(hl, "python", huge, c);
+  assert.equal(calls.highlight, before + 2, "…so it tokenizes each time");
+});
+
+test("with no cache argument (render.ts's call) the module-level cache holds across calls: the same fence tokenizes once per page, not once per call", () => {
+  const { hl, calls } = stub();
+  // a source no other test uses: the shared cache persists across the tests of one process
+  const src = "shared_default_probe = 1  # highlight-cache.test.ts";
+  const first = highlightHtml(hl, "python", src);
+  assert.equal(highlightHtml(hl, "python", src), first);
+  assert.deepEqual(calls, { highlight: 1, auto: 0 }, "the second call was a hit on the module-level cache");
+});

--- a/ui/webview/highlight-cache.ts
+++ b/ui/webview/highlight-cache.ts
@@ -1,0 +1,45 @@
+// Highlighted HTML for a fenced code block, cached by (language, source).
+//
+// hljs.highlightAuto over the ten registered grammars is the single largest cost of a chat tail that
+// re-renders a fence (63% of a compact-mode tail in one deployment's profile), and every window rebuild on
+// a tab switch or a scroll-back tokenizes the same fences again. The result is a pure function of the two
+// strings, so the repeat work is the only thing this removes: an unlabeled fence still gets the full grammar
+// set (a narrower subset is a product change, not an optimization), and a labeled one still goes to its
+// grammar.
+// Bounded: at most CAP entries and about BUDGET characters of output, oldest out first (a Map keeps
+// insertion order; a hit is re-inserted so it counts as newest). Very large sources are not cached at all.
+export interface Highlighter {
+  getLanguage(name: string): unknown;
+  highlight(raw: string, opts: { language: string }): { value: string };
+  highlightAuto(raw: string): { value: string };
+}
+
+export const CAP = 256;               // entries
+export const BUDGET = 4_000_000;      // characters of highlighted HTML held, all entries together
+export const MAX_RAW = 64_000;        // a source longer than this is highlighted but never kept
+
+export interface HighlightCache { map: Map<string, string>; chars: number }
+export function newHighlightCache(): HighlightCache { return { map: new Map(), chars: 0 }; }
+const shared = newHighlightCache();
+
+/** The highlighted HTML for `raw` in `lang` (unknown or missing → auto-detected), tokenized at most once
+ *  per distinct (lang, raw) while the entry is held. */
+export function highlightHtml(hl: Highlighter, lang: string | undefined, raw: string, cache: HighlightCache = shared): string {
+  const known = !!(lang && hl.getLanguage(lang));
+  const key = (known ? lang : "") + " " + raw;
+  const hit = cache.map.get(key);
+  if (hit !== undefined) {
+    cache.map.delete(key); cache.map.set(key, hit);   // newest again
+    return hit;
+  }
+  const html = known ? hl.highlight(raw, { language: lang as string }).value : hl.highlightAuto(raw).value;
+  if (raw.length <= MAX_RAW) {
+    cache.map.set(key, html); cache.chars += html.length;
+    while (cache.map.size > CAP || (cache.chars > BUDGET && cache.map.size > 1)) {
+      const oldest = cache.map.keys().next().value as string;
+      cache.chars -= (cache.map.get(oldest) as string).length;
+      cache.map.delete(oldest);
+    }
+  }
+  return html;
+}

--- a/ui/webview/outline-visibility.test.ts
+++ b/ui/webview/outline-visibility.test.ts
@@ -44,8 +44,9 @@ test("BOTH release events run the same synchronous release: the observer's callb
 
 test("the payload is applied whatever the visibility — only the rebuild waits", () => {
   // the message handler swaps the model before render() decides whether to paint; no visibility check on the way
-  // (the listener is installed through perf-telemetry's per-frame timing wrapper; the handler body is unchanged)
-  const handler = /window\.addEventListener\("message", perfFrameHandler\("fleet", \(m\) => vscodeApi\?\.postMessage\(m\), \(e: MessageEvent\) => \{[\s\S]*?\n\}\)\);/.exec(SRC)![0];
+  // (the listener is installed through frame-listener.ts's helper, on window and in federation's registry, wrapped
+  // by perf-telemetry's per-frame timing; the handler body is unchanged)
+  const handler = /listenForFrames\(perfFrameHandler\("fleet", \(m\) => vscodeApi\?\.postMessage\(m\), \(e: MessageEvent\) => \{[\s\S]*?\n\}\)\);/.exec(SRC)![0];
   assert.match(handler, /loaded = true;\n\s*sessions = m\.ledgers as FleetSession\[\];/);
   assert.doesNotMatch(handler, /document\.hidden|paneVisible|paneDirty|paintHeld/);
 });

--- a/ui/webview/perf-telemetry.test.ts
+++ b/ui/webview/perf-telemetry.test.ts
@@ -603,6 +603,46 @@ test("federation times its inbound work as fed:<wire type> around the pane's han
   }
 });
 
+test("the direct delivery path records the same two levels as the window path: fed:<type> around the pane's nested bracket", () => {
+  // federation hands a merged frame to the registered handler by direct call (federation.ts emit); the pane registers the
+  // perf-wrapped handler it also puts on window, so the call stack is fed:<type> > <type> exactly as through dispatchEvent
+  const g: any = globalThis;
+  const hadWindow = "window" in g, prevWindow = g.window;
+  const hadLS = "localStorage" in g, prevLS = g.localStorage;
+  const emitted: any[] = [];
+  g.window = { dispatchEvent: (ev: any) => { if (ev && ev.data) emitted.push(ev.data); } };
+  g.localStorage = { getItem: () => null, setItem: () => {} };
+  try {
+    const h = harness();
+    const p = createPerfTelemetry("feed", h.deps);
+    const fm = new FederationManager();
+    fm.perf = p;
+    const seen: string[] = [];
+    fm.onFrame(p.wrapFrameHandler((e) => { seen.push(e.data.type); h.clock.t += 4; }));
+    // federation's own work costs nothing on the fake clock: a timed stand-in around inboundNow is not reachable, so the
+    // layer's own time shows as the outer bracket's total minus the pane's; the clock only moves inside the pane here
+    fm.inbound("", { type: "feed", asks: [], now: 1 });
+    fm.inbound("", { type: "feed", asks: [], now: 2 });
+    assert.deepEqual(seen, ["feed", "feed"], "both frames reached the handler directly");
+    assert.deepEqual(emitted, [], "and none was dispatched on window");
+    const frames = (p.snapshot() as any).frames;
+    assert.equal(frames["feed"].n, 2);
+    assert.equal(frames["feed"].ms_sum, 8, "the pane's bracket: its own 4 ms per frame");
+    assert.equal(frames["fed:feed"].n, 2);
+    assert.equal(frames["fed:feed"].ms_sum, 0, "the layer's own time: the total minus the nested pane bracket");
+    // a slow frame is attributed to the wire type at the outermost bracket, as on the window path
+    fm.onFrame(() => { h.clock.t += 120; });
+    fm.inbound("", { type: "feed", asks: [], now: 3 });
+    const rows = h.posted.filter((m) => m.what === "slowframe");
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].data.type, "feed");
+    assert.equal(rows[0].data.ms, 124, "the whole synchronous handling, both handlers, federation's bracket included");
+  } finally {
+    if (hadWindow) g.window = prevWindow; else delete g.window;
+    if (hadLS) g.localStorage = prevLS; else delete g.localStorage;
+  }
+});
+
 // ── the browser install ──
 
 test("installPerfTelemetry: null without a window or without performance.now; the handler is handed back unwrapped", () => {
@@ -698,14 +738,20 @@ test("installPerfTelemetry: one collector per page on window.__rompPerf, wired t
 const UI = path.resolve(process.cwd(), "..", "ui", "webview");
 const readUi = (f: string) => fs.readFileSync(path.join(UI, f), "utf8");
 
-test("each pane bundle's one window message listener is installed through perfFrameHandler under its own app name", () => {
+test("each pane bundle's one frame listener is installed through listenForFrames, wrapped by perfFrameHandler under its own app name", () => {
+  // the pane hands ONE handler to frame-listener.ts, which puts it on window and in federation's registry; a bare
+  // window listener beside that call would be a second delivery path, and an unwrapped one a frame the collector
+  // never sees (the import line has no paren, so the call is the only match for the count)
   const panes: Array<[string, string]> = [["render.ts", "chat"], ["feed.ts", "feed"], ["fleet.ts", "fleet"], ["timeline-main.ts", "timeline"]];
   for (const [file, app] of panes) {
     const src = readUi(file);
     assert.match(src, /import \{ perfFrameHandler \} from "\.\/perf-telemetry";/, file + " imports the wrapper");
-    const listeners = src.match(/window\.addEventListener\("message", /g) || [];
-    assert.equal(listeners.length, 1, file + " has one window message listener");
-    assert.ok(src.includes('window.addEventListener("message", perfFrameHandler("' + app + '", '),
+    assert.match(src, /import \{ listenForFrames \} from "\.\/frame-listener";/, file + " imports the helper");
+    const installs = src.match(/listenForFrames\(/g) || [];
+    assert.equal(installs.length, 1, file + " installs its frame listener once");
+    const bare = src.match(/window\.addEventListener\("message", /g) || [];
+    assert.equal(bare.length, 0, file + " has no bare window message listener");
+    assert.ok(src.includes('listenForFrames(perfFrameHandler("' + app + '", '),
       file + " installs it through perfFrameHandler as app " + app);
   }
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5063,6 +5063,13 @@ let renderPendingAfterRename = false;
 // dispatches right after pointerup, fires against the still-present node first.
 let tabPointerHeld = false;
 let renderPendingWhilePressed = false;
+// The strip's last rendered SIGNATURE (renderTabs): every input the strip paints, as one string. renderTabs
+// runs on every kernel push, and on a board of a few dozen tabs most pushes are tails for tabs that are not
+// active; rebuilding every tab node with its listeners and then reading each one's offsetTop
+// (paintTabRowLines forces a layout) was those tails' whole 2-4 ms floor. An unchanged signature returns
+// before the rebuild. Reset ("") wherever the strip's DOM is changed outside renderTabs — a tab drag's live
+// reorder — so the next render rebuilds whatever the inputs say.
+let tabStripSig = "";
 // Release the press-hold and flush any deferred rebuild. Hoisted so the DRAG handlers can call it
 // too: a native drag swallows the pointerup, so without this a finished drag would leave the strip
 // frozen against pushes until the next unrelated press (see the dragend handler).
@@ -5345,18 +5352,6 @@ function renderTabs() {
   if (tabPointerHeld) { renderPendingWhilePressed = true; return; }   // don't destroy a tab mid-click (see tabPointerHeld)
   const bar = document.getElementById("tabs");
   if (!bar) return;
-  // Preserve TAB-MODE keyboard focus across the rebuild (the user 2026-06-29). renderTabs runs on EVERY kernel
-  // push (0.5–3s), and replaceChildren() destroys the focused tab — dropping focus out of the strip (often out
-  // of the chat iframe entirely), which silently killed ←/→/Enter nav after a send or any push: you were left
-  // focused on nothing, so the keyboard model was dead until you clicked again. If a tab held focus, re-focus
-  // the active tab after the rebuild so "tab mode" survives the repaint.
-  // A focused section HEADER (a label the keyboard folds; headers live only in this bar) re-focuses by
-  // its group name after the rebuild, so a push mid-read does not kick the user from the header onto
-  // the active tab. Captured before the tab rule below, which keeps its pinned two-line shape.
-  const focusedEl = document.activeElement as HTMLElement | null;
-  const focusedGroup = (focusedEl?.closest(".tab-group-head") as HTMLElement | null)?.dataset.group;
-  const refocusTab = bar.contains(document.activeElement);
-  bar.replaceChildren();
   // TABS-FIRST (the user 2026-06-26): render the WHOLE strip up front, in `order` — the kernel's order
   // verbatim (applyTabOrder), plus any just-arrived tab not yet pushed. An id whose session hasn't landed yet
   // draws as a placeholder (name+color, non-interactive) that fills in when build_session arrives — so tabs
@@ -5406,6 +5401,50 @@ function renderTabs() {
   const plan = planStrip(visibleIds, unions, readTabGroups(unions), activeId, phoneLayout(),
                          provisionalId ? { id: provisionalId, tags: provisionalTags } : null);
   collapsedTabIds = plan.folded;
+  // AN UNCHANGED STRIP IS NOT REBUILT. The signature is every input the loop below and the controls after
+  // it paint: the active and peek tabs, the ids and the visible ids in order, whether the active tab is in
+  // view (the all-hidden blank reads it), the strip plan — each section's tag, color and members, whether
+  // it is folded or holds the active tab, and the members its folded header stands in for (the header's
+  // chip, count and pip read those; the pip's state and names come from the per-id records) — and per
+  // visible id either a placeholder's meta or the session's name, color, state and its tab class, faded,
+  // context and its tint, viewer flag, host-down mark and note; plus the context-gauge setting, the theme
+  // and the colormap (the gauge's tone and fallback read the theme — pickTone, ctxFallbackColor — and the
+  // compacting sweep's gradient the colormap, so a settings change repaints through this signature), the +
+  // tab's key hint, and the tag lens and unions the filter chips render. Equal string, same DOM: the guards
+  // above (a rename in flight, a pressed tab) still stand, the placeholder and the all-hidden blank still
+  // reconcile (stripAftermath), and the mobile slot's once-only mount still happens. Anything that mutates
+  // the strip's DOM outside this function resets tabStripSig (the tab dragstart: its live reorder moves
+  // nodes; a group drag moves none — its drop is a views write the plan reads). scheduleRenderTabs already
+  // folds one frame's pushes into one call; this is the complement, for the call that finds nothing
+  // changed. Any input the strip gains later joins this list — tab-strip-skip.test.ts is the list, and an
+  // input missing here is a repaint that never happens.
+  const stripSig = JSON.stringify([
+    activeId, peekId, ids, visibleIds, activeId ? tabInView(activeId) : null, plan.items,
+    settings.tabCtx, settings.theme, settings.colormap, titleWithKey("Open a session", "session.new"),
+    surfaceLens(effViews(), "chat"), unions,
+    visibleIds.map((id) => {
+      const s = sessions.get(id), down = hostIsDown(id), note = down ? hostDownNote(id) : "";
+      if (!s) { const m = tabMeta.get(id); return ["p", m?.name, m?.color?.bg, m?.color?.fg, down, note]; }   // makePlaceholderTab's reads
+      const st = s.status;
+      return [s.name, s.color?.bg, s.color?.fg, st.state, tabStateClass(st), !!st.faded,
+              st.ctx, st.ctxColor, st.ctxTone, !!s.sub, down, note];
+    }),
+  ]);
+  const mslotEl = document.getElementById("mtag-slot");
+  if (stripSig === tabStripSig && !(mslotEl && !mslotEl.firstChild)) { stripAftermath(visibleIds, ids); return; }
+  tabStripSig = stripSig;
+  // Preserve TAB-MODE keyboard focus across the rebuild (the user 2026-06-29). renderTabs runs on EVERY kernel
+  // push (0.5–3s), and replaceChildren() destroys the focused tab — dropping focus out of the strip (often out
+  // of the chat iframe entirely), which silently killed ←/→/Enter nav after a send or any push: you were left
+  // focused on nothing, so the keyboard model was dead until you clicked again. If a tab held focus, re-focus
+  // the active tab after the rebuild so "tab mode" survives the repaint.
+  // A focused section HEADER (a label the keyboard folds; headers live only in this bar) re-focuses by
+  // its group name after the rebuild, so a push mid-read does not kick the user from the header onto
+  // the active tab. Captured before the tab rule below, which keeps its pinned two-line shape.
+  const focusedEl = document.activeElement as HTMLElement | null;
+  const focusedGroup = (focusedEl?.closest(".tab-group-head") as HTMLElement | null)?.dataset.group;
+  const refocusTab = bar.contains(document.activeElement);
+  bar.replaceChildren();
   // A session under several tags has a COPY in each group (T264b, the user 2026-09-08: tags are
   // equivalent, none takes precedence). Every copy below is the full tab of the ONE session — same
   // identity colour, same state class and dot, the active highlight on all of them (the loop reads
@@ -5447,6 +5486,7 @@ function renderTabs() {
     // snapshots it), hence the fixed off-viewport 1px div installed once below.
     tab.addEventListener("dragstart", (e) => {
       draggedId = id; draggedEl = tab; tabDragCommitted = false;
+      tabStripSig = "";   // the drag live-reorders the strip's DOM: whatever the order ends up, the next render rebuilds
       if (e.dataTransfer) { e.dataTransfer.effectAllowed = "move"; e.dataTransfer.setDragImage(dragImageBlank(), 0, 0); }
       tab.classList.add("dragging");
       hideTabTip();                        // defect 2 (2026-08-28): the hover popover pinned open through the gesture
@@ -5477,7 +5517,8 @@ function renderTabs() {
     const st = s.status.state;
     // the state class — working gold, an on-YOU block alarm-red dashed vs a transient API error's
     // amber auto-retry, awaiting, compacting, closed — is tab-state.ts's rule, shared with the
-    // folded section header's pip so the two can never disagree on what is red
+    // folded section header's pip so the two can never disagree on what is red, and read by the
+    // strip's signature above so a state whose class changed always repaints
     const stateCls = tabStateClass(s.status);
     if (stateCls) tab.classList.add(stateCls);
     if (s.status.faded) tab.classList.add("at-rest");
@@ -5537,7 +5578,7 @@ function renderTabs() {
     // Rich hover tooltip (custom DOM — a native title can't colour/bold): backend in its own colour, the
     // full dir path, and mode/model/effort/context each on a line (the user 2026-06-23). See showTabTip.
     if (!s.sub) {   // the rich tip reads a real session's dir/branch/model; a viewer has none of them
-      tab.addEventListener("mouseenter", () => showTabTip(tab, s));
+      tab.addEventListener("mouseenter", () => showTabTip(tab, sessions.get(id) ?? s));   // fresh: the node outlives a frame that replaced the session object (the unchanged-strip skip)
       tab.addEventListener("mouseleave", hideTabTip);
     }
     const close = el("span", "tab-close");
@@ -5569,7 +5610,7 @@ function renderTabs() {
   // tooltip carries the CURRENT binding (the user 2026-08-10: shortcuts discoverable by hover). True on
   // every surface: the shell dispatches the effective chord from the same store this reads, and outside
   // the shell (VS Code / standalone, their own localStorage → the default) the in-page Cmd+O fallback
-  // below answers it. Rebuilt with the strip each push, so a rebind shows on the next render.
+  // below answers it. The hint is in the strip's signature, so a rebind shows on the next render.
   add.title = titleWithKey("Open a session", "session.new");
   add.addEventListener("click", () => openPicker());
   bar.appendChild(add);
@@ -5641,12 +5682,22 @@ function renderTabs() {
   }
   paintTabRowLines(bar);
   ensureTabRowObserver(bar);
-  // Restore tab-mode focus if a tab held it before this rebuild (see the top of renderTabs).
+  // Restore tab-mode focus if a tab held it before this rebuild (see the focus capture above the wipe).
   if (focusedGroup !== undefined) {
     const h = Array.from(bar.querySelectorAll<HTMLElement>(".tab-group-head")).find((x) => x.dataset.group === focusedGroup);
     // the group gone, or now holding the active tab (no stop): the old rule
     if (h && h.tabIndex >= 0) h.focus(); else focusActiveTab();
   } else if (refocusTab) focusActiveTab();
+  stripAftermath(visibleIds, ids);
+  // (The Fleet toggle that briefly lived here as a tab-bar pill was removed 2026-06-24: Fleet/Chat are now
+  // the rotated toggles in the chat pane's vertical strip — see _LANDING_FLEET_JS — so the pill was redundant.)
+  // (The collapse caret moved OFF the tab bar into the #ledger strip's title row — the strip now always
+  // shows the session title + caret, expanding to goals / working-on / done. See renderLedger. 2026-06-16)
+}
+/** What follows a strip render whether or not the strip was rebuilt: the no-sessions placeholder and the
+ *  all-hidden blank. Both are idempotent, and both read live state a skipped rebuild must not leave behind:
+ *  the active view is built lazily, so it can appear between two renders whose strips are equal. */
+function stripAftermath(visibleIds: readonly string[], ids: readonly string[]): void {
   syncNoSessionsPlaceholder(visibleIds.length, ids.length);
   // Hiding the LAST visible session must also blank its transcript: a strip with no tabs cannot sit
   // over a hidden session's live chat (the ghost would show exactly what the hide asked to put away).
@@ -5657,10 +5708,6 @@ function renderTabs() {
     if (av && blank && av.el.style.display !== "none") { av.el.style.display = "none"; allHiddenBlanked = true; }
     else if (av && !blank && allHiddenBlanked) { av.el.style.display = ""; allHiddenBlanked = false; }
   }
-  // (The Fleet toggle that briefly lived here as a tab-bar pill was removed 2026-06-24: Fleet/Chat are now
-  // the rotated toggles in the chat pane's vertical strip — see _LANDING_FLEET_JS — so the pill was redundant.)
-  // (The collapse caret moved OFF the tab bar into the #ledger strip's title row — the strip now always
-  // shows the session title + caret, expanding to goals / working-on / done. See renderLedger. 2026-06-16)
 }
 
 // Right-click context menu on a tab. Webviews can't use VS Code's native menus,

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -70,6 +70,7 @@ import { agentCount, replyOwed, threadsByAnchor, threadBusy, threadStuck, findAn
 import { dragSlotIndex } from "./dragslot";
 import { perfFrameHandler } from "./perf-telemetry";
 import { linkifyPrRefs, senderPrRepo, postalSenderHost } from "./pr-links";
+import { listenForFrames } from "./frame-listener";
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -14060,7 +14061,8 @@ function pipeBanner(up: boolean, queued: number): void {
 
 // every frame's synchronous handling time is measured (perf-telemetry.ts: one clientDiag row a
 // minute, read by `romp perf client`); the handler itself is unchanged
-window.addEventListener("message", perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: MessageEvent) => {
+// …and handed the merged frames by direct call from federation.js when this page has it (frame-listener.ts)
+listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: MessageEvent) => {
   const m = e.data;
   if (!m) return;
   // the shell's palette: "Fork this session…" → the fork modal for the ACTIVE session, from the tip

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -71,6 +71,7 @@ import { dragSlotIndex } from "./dragslot";
 import { perfFrameHandler } from "./perf-telemetry";
 import { linkifyPrRefs, senderPrRepo, postalSenderHost } from "./pr-links";
 import { listenForFrames } from "./frame-listener";
+import { highlightHtml } from "./highlight-cache";
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -1128,9 +1129,7 @@ function highlight(container: HTMLElement, lineNos = true) {
     const raw = code.textContent || "";   // capture BEFORE we rewrite innerHTML: line-wrapping drops the \n joins, so the on-screen markup's textContent is NOT copy-safe
     const lang = (code.className.match(/language-([\w-]+)/) || [])[1];
     try {
-      code.innerHTML = lang && hljs.getLanguage(lang)
-        ? hljs.highlight(raw, { language: lang }).value
-        : hljs.highlightAuto(raw).value;
+      code.innerHTML = highlightHtml(hljs, lang, raw);   // by (language, source): a fence re-rendered by a tail, a tab switch or a scroll-back tokenizes once (highlight-cache.ts)
       code.classList.add("hljs");
       if (lineNos) wrapCodeLines(code);   // per-line gutter so a soft-wrap reads distinctly from a real newline
     } catch { /* leave as-is */ }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -72,6 +72,8 @@ import { perfFrameHandler } from "./perf-telemetry";
 import { linkifyPrRefs, senderPrRepo, postalSenderHost } from "./pr-links";
 import { listenForFrames } from "./frame-listener";
 import { highlightHtml } from "./highlight-cache";
+import { turnWorkedSecs as workedSecsOf, workedFooterPlan } from "./worked-footer";
+import { reconcileRewindPass, type RewindEvent } from "./rewind-reconcile";
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -514,43 +516,16 @@ const pendingRewind = new Map<string, { uuid: string; text: string; ts: number; 
 // the CLI only addresses post-boundary records, so older bubbles get no edit affordance (the kernel
 // re-validates regardless). Runs beside reconcileOptimistic on every ingest path; the rewound flags
 // are stripped first because a chatTail delta REUSES prefix event objects across pushes.
-function reconcileRewind(s: Session): void {
-  for (const e of s.events) if ((e as any).rewound) delete (e as any).rewound;
-  let lastCompact = -1;
-  for (let i = 0; i < s.events.length; i++) if (s.events[i].kind === "compact") lastCompact = i;
-  const editable = new Set<string>();
-  if (s.status?.backend === "sdk") {
-    for (let i = lastCompact + 1; i < s.events.length; i++) {
-      const e = s.events[i] as any;
-      if (e.kind === "user" && e.human && e.uuid && !e.romp && !e.interruptMarker
-          && !e.uuid.startsWith(OPT_PREFIX)) editable.add(e.uuid);
-    }
-  }
-  (s as any)._editable = editable;
-  const pr = pendingRewind.get(s.id);
-  if (!pr) return;
-  const idx = s.events.findIndex((e) => e.kind === "user" && (e as any).uuid === pr.uuid);
-  if (idx < 0 || Date.now() - pr.ts > REWIND_TTL_MS) {
-    pendingRewind.delete(s.id);          // the branch landed (old uuid gone) — or the backstop expired
-    return;
-  }
-  if (pr.bare) {
-    // DELETE rollback: the deleted bubble goes too — dim from it onward. No text replacement and no
-    // queued-chip suppression (nothing was sent; the kernel's cut payload retires this in a beat).
-    for (let j = idx; j < s.events.length; j++) (s.events[j] as any).rewound = true;
-  } else {
-    s.events[idx] = { ...(s.events[idx] as any), md: pr.text, pending: true, images: undefined };
-    for (let j = idx + 1; j < s.events.length; j++) (s.events[j] as any).rewound = true;
-    for (let j = s.events.length - 1; j > idx; j--) {
-      const e = s.events[j] as any;
-      if (e.kind === "queued" && Array.isArray(e.texts)) {
-        e.texts = e.texts.filter((t: any) => t.md !== pr.text);
-        if (!e.texts.length) s.events.splice(j, 1);
-      }
-    }
-  }
+function reconcileRewind(s: Session, bound?: number): void {
+  // The pass itself is rewind-reconcile.ts (pure, executed by its own tests); this keeps the session's
+  // editable set, the pending-rewind entry and the view's stale mark. `bound` is the tail path's re-render
+  // start (chatTail's `from`): the stale signal reads the prefix below it — see the module for why.
+  const r = reconcileRewindPass(s.events as RewindEvent[], (s as any)._editable, pendingRewind.get(s.id),
+                                { sdk: s.status?.backend === "sdk", now: Date.now(), ttlMs: REWIND_TTL_MS, optPrefix: OPT_PREFIX, bound });
+  (s as any)._editable = r.editable;
+  if (!r.pending) pendingRewind.delete(s.id);
   const v = views.get(s.id);
-  if (v) v.stale = true;                 // the overlay touches MID-window turns — the append fast path won't repaint them
+  if (v && r.stale) v.stale = true;   // the overlay or the editable set changed: MID-window turns repaint (the tail path never reaches them)
 }
 // Tab name+color from the kernel's tabOrder push (the user 2026-06-26): lets renderTabs paint the WHOLE
 // strip as placeholders BEFORE each session's build_session arrives, so tabs don't pop in one-by-one.
@@ -1010,7 +985,7 @@ let landTrail: string[] = [];
 // count is NOT len − winStart + spacer: a unit may own more than one node (the day
 // divider that opens a new day precedes its turn), so anything mapping DOM back to
 // units reads data-unit off the node rather than counting children.
-interface View { el: HTMLElement; rendered: number; scrollTop: number; stick: boolean; shown: boolean; stale: boolean; winStart: number; winEnd?: number; avgTurnH?: number; spacerCount?: number; spacerCountBot?: number; unitTotal?: number; ro?: ResizeObserver; }
+interface View { el: HTMLElement; rendered: number; scrollTop: number; stick: boolean; shown: boolean; stale: boolean; winStart: number; winEnd?: number; avgTurnH?: number; spacerCount?: number; spacerCountBot?: number; unitTotal?: number; working?: boolean; ro?: ResizeObserver; }   // working: the session's state at the last sync, the "worked …" footer's one non-event input (syncViewInner)
 const views = new Map<string, View>();
 
 // Pending pickers (AskUserQuestion / tool-permission) keyed by session id. These
@@ -1357,8 +1332,8 @@ function inlineFold(head: HTMLElement, turn: HTMLElement, label: string, content
 }
 
 // Expand/collapse state must SURVIVE the incremental re-render that every send/turn triggers (the user
-// 2026-06-19): a short transcript rebuilds from index 0, a long one re-renders the trailing TAIL_RECHECK
-// turns — either way a DOM-only `.open` silently resets whatever the user had opened (e.g. they expand
+// 2026-06-19): a short transcript rebuilds from index 0, a long one re-renders from the first changed
+// event — either way a DOM-only `.open` silently resets whatever the user had opened (e.g. they expand
 // the system-context card, type a message, hit ⏎, and it snaps shut). So we persist open-state in a Set
 // keyed by a stable id (the turn uuid, or the session id for the pinned system card) and reapply it on
 // rebuild — the same trick `expandedGroups` uses for collapsed tool runs. A keyless fold (no stable id)
@@ -9630,15 +9605,9 @@ function warnToast(msg: string) {
   setTimeout(() => t.remove(), 12000);
 }
 
-// Trailing events to re-render on each sync, in case they mutated in place
-// (e.g. a tool's output arriving after its tool_use was first shown). Earlier
-// events are immutable in an append-only transcript, so they stay cached.
-const TAIL_RECHECK = 25;
-
 // Tail-windowing (see the View comment): a fresh/rewound view renders only the
 // last WINDOW_TAIL events; scrolling within EXPAND_TRIGGER_PX of the top reveals
-// the next EXPAND_CHUNK older ones. WINDOW_TAIL > TAIL_RECHECK so the trailing
-// re-check window is always fully rendered.
+// the next EXPAND_CHUNK older ones.
 const WINDOW_TAIL = 80;
 const EXPAND_CHUNK = 80;
 const EXPAND_TRIGGER_PX = 600;
@@ -9679,9 +9648,9 @@ function ensureView(id: string): View {
   return v;
 }
 
-// Bring this view's DOM up to date with its session's events: append new ones
-// and re-render a bounded trailing window (cheap), or rebuild fully on a shrink
-// (rewind). Does NOT touch scroll. No-op cost when nothing changed is ~O(TAIL).
+// Bring this view's DOM up to date with its session's events: re-render from the
+// first changed event (cheap), or rebuild fully on a shrink (rewind). Does NOT
+// touch scroll. A sync with nothing changed reveals the cached DOM and renders nothing.
 // The wrapper re-anchors comment highlights after EVERY sync (the user 2026-08-13): marks live in
 // the rebuilt DOM, and hanging the re-apply only on inbound messages missed the renders that run
 // off them (a tab switch, a prebuild) — idempotent and ~free for sessions with no threads.
@@ -9749,6 +9718,11 @@ function syncViewInner(id: string, atBottom?: boolean): View {
     return v;
   }
   const working = s.status.state === "working" || s.status.state === "compacting";
+  // The footer on the current turn's last reply reads the session's working state (on once idle, off while
+  // it works), and a status-only tail changes that with no event change — the no-op fast path below would
+  // leave the footer as it was. So the state is remembered per view, and a flip patches the footer there.
+  const workFlip = v.working != null && v.working !== working;
+  v.working = working;
   const items = displayItems(s);   // units: one per event (normal) or one folded compactDisplay item (compact)
   const total = items.length;
   const len = s.events.length;
@@ -9766,6 +9740,12 @@ function syncViewInner(id: string, atBottom?: boolean): View {
   // WITHOUT this, every showActive() re-built the trailing window (markdown + highlight.js) — the big-session
   // switch lag (the user 2026-06-25). A REAL change lowers v.rendered (delta-send sets it to the change index;
   // an append grows len past it) or sets v.stale, so this never skips an actual update.
+  // …except the "worked …" footer on a status-only tail: nothing re-rendered, and the footer follows the flip.
+  // (The patch marks the view stale when the reply's unit is not addressable — a folded run — so the fast
+  // path stands down and the window path below re-renders it.)
+  if (workFlip && v.rendered === len && !v.stale && v.el.childNodes.length > 0) {
+    patchWorkedFooters(v, s, len, working, settings.compact ? items : null);
+  }
   if (v.rendered === len && !v.stale && v.el.childNodes.length > 0) return v;
   const wasAtTail = (v.winEnd ?? total) >= (v.unitTotal ?? total);   // window was covering the OLD end
   // An in-place change (tool-group toggle, off-screen update) OR compact mode → re-render the CURRENT window
@@ -9786,9 +9766,15 @@ function syncViewInner(id: string, atBottom?: boolean): View {
     v.spacerCountBot = total - (v.winEnd ?? total); v.unitTotal = total; v.rendered = len; sizeSpacers(v); return v;
   }
   // Normal mode, append AT the tail (unit === event, top spacer only): the cheap incremental hot path —
-  // append the new turns + re-check a trailing window, tagging data-unit so the scroll↔unit map stays valid.
-  let from = Math.min(v.rendered, Math.max(0, len - TAIL_RECHECK));
-  from = Math.max(from, v.winStart ?? 0);
+  // re-render EXACTLY from the first changed event, tagging data-unit so the scroll↔unit map stays valid.
+  // v.rendered is exact: the kernel's chatTail names the first changed index (its _chat_diff compares by
+  // identity first, then equality, and the fold never writes an event in place), and every client pass that
+  // touches a prefix event marks the view stale instead — reconcileRewind (the editable set, the rewind dim),
+  // reconcileOptimistic (the echo set), a full session frame (upsert) — which takes the window rebuild above.
+  // A trailing window of 25 events re-rendered on every tail used to stand in for those signals, and was
+  // most of a tail's render. The one render that depends on LATER events, the "worked …" footer of a turn's
+  // last reply, is patched by unit after the loop (patchWorkedFooters).
+  const from = Math.max(v.rendered, v.winStart ?? 0);
   // Drop every node from unit `from` onward, then re-render that span. Trim by DATA-UNIT, never by
   // child COUNT: a unit can put more than one node in the thread (a day divider precedes the turn
   // that opens a new day), so `keep = spacer + (from - winStart)` counted one node per unit and the
@@ -9809,8 +9795,43 @@ function syncViewInner(id: string, atBottom?: boolean): View {
     node.dataset.unit = String(i);   // unit === event in normal mode
     v.el.appendChild(node);
   }
+  patchWorkedFooters(v, s, from, working);
   v.winEnd = total; v.spacerCount = v.winStart ?? 0; v.spacerCountBot = 0; v.unitTotal = total; v.rendered = len;
   return v;
+}
+
+// The "worked …" footer is the one render on a turn that depends on LATER events and on the session's state:
+// it appears once the turn is complete (a genuine prompt landed after its last reply) or the session is idle.
+// With the tail rendered exactly from `from`, the events that change a reply's footer leave that reply BEFORE
+// `from` — a human prompt landing completes its turn, a later reply in the same turn demotes it — and a
+// status-only tail (empty suffix: the session went idle, or back to work on the same turn after a nudge or a
+// postal push) changes it with no event at all, which syncViewInner's fast path hands here with from = len.
+// worked-footer.ts names the reply and the seconds; the footer goes on or comes off by unit. applyForkSpots
+// homes a turn's fork spot inside its elapsed row when the turn has one, so the spot moves with the footer
+// either way. `items` is compact mode's unit list: there a unit is a display item (a folded run, or one event),
+// so the window's start maps to its first event and the reply's event index back to the unit whose node carries
+// it; a reply folded into a run has no node of its own, and the view goes stale for the window path instead.
+function patchWorkedFooters(v: View, s: Session, from: number, working: boolean, items: DisplayItem[] | null = null): void {
+  const winStart = v.winStart ?? 0;
+  const winEv = items ? (items[winStart] ? itemFirstEvent(items[winStart]) : s.events.length) : winStart;
+  const unitOfEvent = (i: number): number => items ? items.findIndex((it) => it.kind === "event" && it.index === i) : i;
+  for (const { unit: ev, secs } of workedFooterPlan(s.events, from, winEv, working, eventEpoch)) {
+    const unit = unitOfEvent(ev);
+    if (unit < 0) { v.stale = true; continue; }
+    const node = v.el.querySelector(`:scope > [data-unit="${unit}"]:not(.day-divider)`) as HTMLElement | null;
+    if (!node) continue;
+    const have = node.querySelector(":scope > .turn-elapsed") as HTMLElement | null;
+    if (secs != null && !have) {
+      const f = elapsedFooter(secs);
+      const spot = node.querySelector(":scope > .fork-spot");
+      node.appendChild(f);
+      if (spot) f.appendChild(spot);
+    } else if (secs == null && have) {
+      const spot = have.querySelector(":scope > .fork-spot");
+      if (spot) node.appendChild(spot);
+      have.remove();
+    }
+  }
 }
 
 // prevEpoch for event i = the most recent EARLIER timed event's epoch (untimed todo/queued skipped so the
@@ -10066,34 +10087,13 @@ function lastTurnStart(events: ChatEvent[]): number {
 }
 
 // If event i is the LAST reply of a COMPLETED prompt-turn, return the seconds the
-// session worked on it (the IMMEDIATE trigger → this reply); else null. A turn is
-// "completed" when a new GENUINE prompt follows it (injected user-role lines — postal
-// pushes, /command stdout — are skipped, NOT treated as the next prompt), or it's the
-// final turn and the session is no longer working (the live spinner owns it).
-// The elapsed is measured from the most recent user-role line of ANY author — the
-// thing that ACTUALLY triggered this reply — NOT the older human prompt: a nudge or
-// postal push that prompted the work is the start, so a nudge-triggered reply doesn't
-// inherit the original prompt's elapsed (the user 2026-06-22, who saw worked 23m for a
-// 2-min-old nudge — the clock had run from a much older human prompt). Drives the
-// "worked …" rail footer.
+// session worked on it (the IMMEDIATE trigger → this reply); else null. Drives the
+// "worked …" rail footer. The rule — which reply counts as a turn's last, what ends
+// a turn, which user line the clock runs from — lives in worked-footer.ts (pure,
+// node-tested), so the tail path's footer patch reads the same one; this binds it
+// to the chat's event clock.
 function turnWorkedSecs(events: ChatEvent[], i: number, working: boolean): number | null {
-  const ev = events[i];
-  if (ev.kind === "user") return null;                 // a prompt, not a reply
-  let completed = false;
-  for (let j = i + 1; j < events.length; j++) {
-    const e = events[j];
-    if (e.kind !== "user") return null;                // another reply in this turn → i isn't its last
-    if (e.human) { completed = true; break; }          // next genuine prompt → the turn ended at i
-    // injected user line (postal push, /command stdout, …) → same turn, keep scanning
-  }
-  if (!completed && working) return null;              // final turn still in progress → spinner owns it
-  const end = eventEpoch(ev);
-  if (end == null) return null;
-  let start: number | null = null;                     // the IMMEDIATE trigger: the most recent user line, ANY
-  for (let j = i; j >= 0; j--) { const e = events[j]; if (e.kind === "user") { start = eventEpoch(e); break; } }   // author (human / nudge / postal) — not the older human prompt
-  if (start == null) return null;
-  const secs = end - start;
-  return secs > 0 ? secs : null;
+  return workedSecsOf(events, i, working, eventEpoch);
 }
 
 // Show only the active session's (lazily built) view and set its scroll: a
@@ -13620,6 +13620,15 @@ function upsert(msg: any) {
   if (forked) {
     const v = views.get(msg.id);
     if (v) { v.ro?.disconnect(); v.el.remove(); views.delete(msg.id); }
+  } else if (existed && !kept) {
+    // A full frame replaces every event object and can differ from what this view rendered ANYWHERE (it is
+    // what the kernel sends a client it believes is behind): the tail path trusts v.rendered as the exact
+    // first changed index, so the whole window rebuilds here instead. Full frames for a held session are the
+    // reconnect and the repair, not the steady state; deltas (chatTail) are. Not when the frame carried no
+    // events for a session with content (`kept`, frame-merge.ts): the resident events stand, nothing was
+    // replaced, and a status-shaped frame must leave the view as it is.
+    const v = views.get(msg.id);
+    if (v) v.stale = true;
   }
   if ("ledger" in msg) ledgers.set(msg.id, msg.ledger ?? null);
   if (!existed) order.push(msg.id);
@@ -13668,6 +13677,7 @@ function update(msg: any) {
   s.events = msg.events || s.events;
   const before = awaitKey(s.status);
   s.status = msg.status || s.status;
+  if (msg.events) { const v0 = views.get(msg.id); if (v0) v0.stale = true; }   // events replaced wholesale: the window rebuilds (the tail path trusts v.rendered)
   reconcileRewind(s);                    // pending-rewind overlay + the editable-bubble set, from the fresh payload
   reconcileOptimistic(s);                // re-assert (or retire) any in-flight optimistic sends on this push
   renderTabs();                          // status/chip change only — repaint, never re-order (the user 2026-06-27)
@@ -13753,7 +13763,7 @@ function chatTail(msg: any) {
   const wasLen = s.events.length;
   s.events.length = from;                          // drop the (now superseded) tail...
   for (const e of (msg.events || [])) s.events.push(e);   // ...and append the freshly-changed suffix
-  reconcileRewind(s);                              // pending-rewind overlay + the editable-bubble set
+  reconcileRewind(s, from);                        // pending-rewind overlay + the editable-bubble set, judged below the tail's start (see there)
   reconcileOptimistic(s);                          // re-assert (or retire) any in-flight optimistic sends
   // A delta that SHRINKS the tail (an event retired with nothing replacing it — cancelling the last queued
   // message is the everyday case) lands on `from === new length`, so lowering v.rendered to `from` leaves it

--- a/ui/webview/rewind-delete.test.ts
+++ b/ui/webview/rewind-delete.test.ts
@@ -40,8 +40,10 @@ test("the armed second click fires rewindDelete and paints the bare overlay", ()
 });
 
 test("the bare overlay dims the deleted bubble itself, not just the tail", () => {
-  assert.match(RENDER, /if \(pr\.bare\) \{/);
-  assert.match(RENDER, /for \(let j = idx; j < s\.events\.length; j\+\+\) \(s\.events\[j\] as any\)\.rewound = true;/);
+  // the pass lives in rewind-reconcile.ts (executed there: "a bare delete dims from the deleted bubble itself")
+  const PASS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "rewind-reconcile.ts"), "utf8");
+  assert.match(PASS, /\} else if \(pr\.bare\) \{/);
+  assert.match(PASS, /for \(let j = idx; j < events\.length; j\+\+\) events\[j\]\.rewound = true;/);
 });
 
 test("the delete button dresses like edit, with a destructive armed state", () => {

--- a/ui/webview/rewind-edit.test.ts
+++ b/ui/webview/rewind-edit.test.ts
@@ -17,9 +17,11 @@ test("the edit affordance renders only on bubbles the backend can address", () =
   // gate: genuine human bubble + transcript uuid + the session's _editable set (reconcileRewind:
   // SDK backend only, newer than the last compaction, not an optimistic echo)
   assert.match(RENDER, /if \(!romp && !injected && ev\.uuid && editSid\s*\n\s*&& \(sessions\.get\(editSid\) as any\)\?\._editable\?\.has\(ev\.uuid\)\)/);
-  assert.match(RENDER, /if \(s\.status\?\.backend === "sdk"\) \{/);           // tmux sessions get no edit affordance
-  assert.match(RENDER, /if \(s\.events\[i\]\.kind === "compact"\) lastCompact = i;/);   // pre-compaction bubbles excluded
-  assert.match(RENDER, /!e\.uuid\.startsWith\(OPT_PREFIX\)/);                 // optimistic echoes excluded
+  // the set is computed by rewind-reconcile.ts (executed there); render.ts hands it the backend and the echo prefix
+  assert.match(RENDER, /sdk: s\.status\?\.backend === "sdk", now: Date\.now\(\), ttlMs: REWIND_TTL_MS, optPrefix: OPT_PREFIX/);   // tmux sessions get no edit affordance; echoes are excluded
+  const PASS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "rewind-reconcile.ts"), "utf8");
+  assert.match(PASS, /if \(events\[i\]\.kind === "compact"\) lastCompact = i;/);   // pre-compaction bubbles excluded
+  assert.match(PASS, /!e\.uuid\.startsWith\(opts\.optPrefix\)/);              // optimistic echoes excluded
   // the button arms the composer's edit mode
   assert.match(RENDER, /edit\.addEventListener\("click", \(e\) => \{ e\.stopPropagation\(\); beginComposerEdit\(editSid, uuid, orig\); \}\);/);
 });
@@ -46,12 +48,16 @@ test("the composer edit chip cancels via its x and via Escape", () => {
 });
 
 test("the pending-rewind overlay is wired into every ingest path and repaints mid-window", () => {
-  const calls = RENDER.match(/reconcileRewind\(s\);/g) || [];
+  const calls = RENDER.match(/reconcileRewind\(s(, from)?\);/g) || [];   // chatTail passes its from: the signature's bound (chat-exact-tail.test.ts)
   assert.ok(calls.length >= 4, "reconcileRewind wired into upsert + update + chatTail + the edit send, got " + calls.length);
-  // the overlay touches MID-window turns — the append fast path won't repaint them without stale
-  assert.match(RENDER, /if \(v\) v\.stale = true;\s*\/\/ the overlay touches MID-window turns/);
-  // chatTail reuses prefix event objects across pushes → stale rewound flags are stripped first
-  assert.match(RENDER, /for \(const e of s\.events\) if \(\(e as any\)\.rewound\) delete \(e as any\)\.rewound;/);
+  // the overlay touches MID-window turns — the append fast path won't repaint them without stale; stale is set
+  // when the overlay or the editable set CHANGED (the tail path re-renders exactly what the kernel named, so
+  // this signal is what repaints a prefix bubble — chat-exact-tail.test.ts)
+  assert.match(RENDER, /if \(v && r\.stale\) v\.stale = true;\s*\/\/ the overlay or the editable set changed: MID-window turns repaint/);
+  // chatTail reuses prefix event objects across pushes → stale rewound flags are stripped first (the pass
+  // itself is rewind-reconcile.ts, executed by its own tests)
+  const PASS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "rewind-reconcile.ts"), "utf8");
+  assert.match(PASS, /for \(const e of events\) if \(e\.rewound\) delete e\.rewound;/);
   // abandoned turns dim via a class on the rendered turn
   assert.match(RENDER, /if \(\(ev as any\)\.rewound\) turn\.classList\.add\("rewound"\);/);
   assert.match(CSS, /\.turn\.rewound \{ opacity: 0\.35;/);

--- a/ui/webview/rewind-reconcile.test.ts
+++ b/ui/webview/rewind-reconcile.test.ts
@@ -1,0 +1,103 @@
+// The pending-rewind pass (rewind-reconcile.ts), RUN: the editable set, the overlay, the pending edit's
+// retirement, and the STALE signal the chat's exact tail path rests on — a prefix bubble below the tail's
+// re-render start whose edit affordance or dim changed marks the view stale; a plain human-prompt append at
+// the tail does not. `now` is injected; nothing sleeps. Synthetic events, placeholder uuids.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { reconcileRewindPass, rewindSig, type PendingRewind, type RewindEvent } from "./rewind-reconcile";
+
+type Ev = RewindEvent & { kind: string; uuid?: string };
+const OPT = "optimistic:";
+const user = (uuid: string, md = "ask " + uuid): Ev => ({ kind: "user", human: true, uuid, md });
+const reply = (uuid: string): Ev => ({ kind: "assistant", uuid, md: "reply" });
+const opts = (over: Partial<{ sdk: boolean; now: number; ttlMs: number; bound: number }> = {}) =>
+  ({ sdk: true, now: 100_000, ttlMs: 30_000, optPrefix: OPT, ...over });
+const A = "11111111-2222-3333-4444-aaaaaaaaaaaa", B = "11111111-2222-3333-4444-bbbbbbbbbbbb", C = "11111111-2222-3333-4444-cccccccccccc";
+
+test("the editable set: genuine human prompts with a uuid after the last compaction, on an SDK session; an optimistic echo, an injected line and a non-SDK session get none", () => {
+  const evs: Ev[] = [user(A), reply("r1"), { kind: "user", human: true, uuid: OPT + "5", md: "echo" }, { kind: "user", romp: true, uuid: "n1", md: "nudge" }, user(B)];
+  const r = reconcileRewindPass(evs, undefined, null, opts());
+  assert.deepEqual([...r.editable].sort(), [A, B].sort());
+  assert.equal(r.pending, null);
+  assert.equal(r.stale, true, "the first pass (no previous set) reads as a change");
+  assert.deepEqual([...reconcileRewindPass(evs, r.editable, null, opts({ sdk: false })).editable], [], "a CLI session: nothing addressable");
+});
+
+test("a compaction landing at the tail's `from` strips the affordance from every earlier bubble: stale, though nothing below `from` was re-rendered", () => {
+  const evs: Ev[] = [user(A), reply("r1"), user(B), reply("r2")];
+  const first = reconcileRewindPass(evs, undefined, null, opts());
+  assert.deepEqual([...first.editable].sort(), [A, B].sort());
+  evs.push({ kind: "compact" });                                    // the chatTail appended it at index 4
+  const r = reconcileRewindPass(evs, first.editable, null, opts({ bound: 4 }));
+  assert.deepEqual([...r.editable], [], "nothing after the boundary is a human prompt");
+  assert.equal(r.stale, true, "the bubbles below `from` lost their edit buttons: the tail cannot repaint them, this signal does");
+});
+
+test("a plain human-prompt append does NOT mark the view stale: the signature reads the prefix below the tail's re-render start", () => {
+  const evs: Ev[] = [user(A), reply("r1")];
+  const first = reconcileRewindPass(evs, undefined, null, opts());
+  evs.push(user(C));                                                // the landing prompt, at from = 2
+  const r = reconcileRewindPass(evs, first.editable, null, opts({ bound: 2 }));
+  assert.deepEqual([...r.editable].sort(), [A, C].sort(), "the new bubble is editable…");
+  assert.equal(r.stale, false, "…and it is at or past `from`, so the tail renders it itself: no whole-window rebuild");
+  const again = reconcileRewindPass(evs, r.editable, null, opts());   // an unchanged re-pass, unbounded
+  assert.equal(again.stale, false);
+  assert.equal(reconcileRewindPass(evs, r.editable, null, opts({ bound: evs.length })).stale, false, "the same with bound = len (a status-only tail)");
+});
+
+test("a pending edit dims every later event and replaces the bubble's text; an unchanged re-pass while it stands is NOT stale (the signature is taken before the strip)", () => {
+  const evs: Ev[] = [user(A), reply("r1"), user(B, "old text"), reply("r2"), { kind: "queued", texts: [{ md: "new text" }, { md: "another" }] }];
+  const pr: PendingRewind = { uuid: B, text: "new text", ts: 100_000 };
+  const first = reconcileRewindPass(evs, new Set([A, B]), pr, opts());
+  assert.equal(first.pending, pr, "the edit stands: the old uuid is still in the transcript and the TTL has not run out");
+  assert.equal(first.stale, true, "the overlay appeared");
+  assert.deepEqual(evs.map((e) => !!e.rewound), [false, false, false, true, true], "everything after the edited bubble dims");
+  assert.equal(evs[2].md, "new text"); assert.equal(evs[2].pending, true);
+  assert.deepEqual(evs[4].texts, [{ md: "another" }], "the queued echo of the edit's own text is suppressed (the overlay shows it in place)");
+  const again = reconcileRewindPass(evs, first.editable, first.pending, opts({ now: 110_000 }));
+  assert.equal(again.stale, false, "the same edit, the same dims: a pass that changes nothing marks nothing stale");
+  assert.deepEqual(evs.map((e) => !!e.rewound), [false, false, false, true, true], "the flags were stripped and re-applied, not doubled or lost");
+  // a queued echo whose only text was the edit's leaves the transcript
+  const evs2: Ev[] = [user(B, "old"), { kind: "queued", texts: [{ md: "new text" }] }];
+  reconcileRewindPass(evs2, undefined, pr, opts());
+  assert.equal(evs2.length, 1, "the emptied queued event is spliced out");
+});
+
+test("a bare delete dims from the deleted bubble itself, with no text replacement", () => {
+  const evs: Ev[] = [user(A), reply("r1"), user(B, "gone"), reply("r2")];
+  const r = reconcileRewindPass(evs, new Set([A, B]), { uuid: B, text: "", ts: 100_000, bare: true }, opts());
+  assert.deepEqual(evs.map((e) => !!e.rewound), [false, false, true, true]);
+  assert.equal(evs[2].md, "gone"); assert.equal(evs[2].pending, undefined);
+  assert.equal(r.stale, true);
+  assert.equal(rewindSig(evs, r.editable, r.pending).endsWith("|" + B + ":b"), true, "the signature names the delete as such");
+});
+
+test("the TTL backstop retires a failed rewind and lifts its dim: stale, with nothing rewound and the entry gone", () => {
+  const evs: Ev[] = [user(A), reply("r1"), user(B, "new text"), reply("r2"), reply("r3")];
+  const pr: PendingRewind = { uuid: B, text: "new text", ts: 100_000 };
+  const live = reconcileRewindPass(evs, new Set([A, B]), pr, opts({ now: 120_000 }));
+  assert.equal(live.pending, pr); assert.deepEqual(evs.map((e) => !!e.rewound), [false, false, false, true, true]);
+  const r = reconcileRewindPass(evs, live.editable, live.pending, opts({ now: 130_001, bound: evs.length }));   // a status-only tail after the TTL
+  assert.equal(r.pending, null, "expired");
+  assert.deepEqual(evs.map((e) => !!e.rewound), [false, false, false, false, false], "the dim is lifted");
+  assert.equal(r.stale, true, "no `from` reaches back to those turns: this signal repaints them");
+});
+
+test("the retirement is stale on a PARTIAL tail too: the pending edit is unbounded in the signature (no dimmed event lies below the tail's start)", () => {
+  const evs: Ev[] = [user(A), reply("r1"), user(B, "new text"), reply("r2"), reply("r3")];
+  const pr: PendingRewind = { uuid: B, text: "new text", ts: 100_000 };
+  const live = reconcileRewindPass(evs, new Set([A, B]), pr, opts({ now: 120_000 }));
+  // the tail re-renders from 3 (the first dimmed event), so the dims below the bound are empty before and after;
+  // only the pending part of the signature can carry the change — and it must
+  const r = reconcileRewindPass(evs, live.editable, live.pending, opts({ now: 130_001, bound: 3 }));
+  assert.equal(r.pending, null);
+  assert.equal(r.stale, true, "the edited bubble at 2 lost its pending text: below `from`, repainted by this signal");
+});
+
+test("the branch landing (the old uuid gone from the payload) retires the edit the same way", () => {
+  const evs: Ev[] = [user(A), reply("r1"), user(C, "new text")];   // the kernel's new transcript: B is gone, C is the rewound prompt
+  const r = reconcileRewindPass(evs, new Set([A, B]), { uuid: B, text: "new text", ts: 100_000 }, opts({ bound: 2 }));
+  assert.equal(r.pending, null);
+  assert.deepEqual([...r.editable].sort(), [A, C].sort());
+  assert.equal(r.stale, true, "the prefix's editable set changed (B left it)");
+});

--- a/ui/webview/rewind-reconcile.ts
+++ b/ui/webview/rewind-reconcile.ts
@@ -1,0 +1,100 @@
+// The pending-rewind overlay and the editable-bubble set, as one pass over a session's events — pure, so
+// node --test runs it without a DOM (render.ts reconcileRewind delegates here the way turnWorkedSecs
+// delegates to worked-footer.ts).
+//
+// The pass has three outputs. The EDITABLE set: genuine human messages with a transcript uuid, after the
+// last compaction (the CLI only addresses post-boundary records, so older bubbles get no edit affordance;
+// the kernel re-validates regardless). The OVERLAY for a pending rewind: the edited bubble carries the new
+// text and `pending`, every later event is dimmed (`rewound`); a bare delete dims from the deleted bubble
+// on. The pending entry itself is retired when the branch landed (the old uuid is gone) or the TTL backstop
+// expired. The `rewound` flags are stripped first because a chatTail delta REUSES prefix event objects
+// across pushes.
+//
+// And the STALE signal the chat's exact tail path rests on. The tail re-renders exactly the events the
+// kernel's `from` names (render.ts syncViewInner), so a prefix bubble whose edit buttons or dim depend on
+// these outputs is repainted by THIS signal: a compaction landing at `from` strips the affordance from
+// every earlier bubble; a failed rewind's TTL expiry lifts a dim no later `from` reaches back to. The
+// signature is taken BEFORE the pass — its dim and editable parts describe the previous pass — and
+// compared after it, on every path (a retired edit and a session with no edit pending both reach the
+// comparison). `bound` is the tail's re-render start (chatTail's `from`): events at or past it are
+// re-rendered anyway, so only the prefix below it counts as a change — unbounded, every human prompt
+// landing (a new editable bubble) would mark the view stale and rebuild the whole window instead of taking
+// the exact tail. The pending edit stays unbounded: its retirement lifts a dim that no `from` reaches back
+// to.
+export interface RewindEvent {
+  kind: string;
+  uuid?: string;
+  human?: boolean;
+  romp?: boolean;
+  interruptMarker?: boolean;
+  rewound?: boolean;
+  md?: string;
+  pending?: boolean;
+  images?: unknown;
+  texts?: { md: string }[];
+}
+export interface PendingRewind { uuid: string; text: string; ts: number; bare?: boolean }
+export interface RewindOpts {
+  sdk: boolean;         // the session's backend is the SDK: only its transcripts are addressable, so only they get an editable set
+  now: number;          // Date.now() — injected so a test never sleeps
+  ttlMs: number;        // the pending edit's backstop
+  optPrefix: string;    // an optimistic echo's uuid prefix: never editable (send-pending.ts OPT_PREFIX)
+  bound?: number;       // the tail's re-render start; the signature reads events below it (default: all)
+}
+export interface RewindResult { editable: Set<string>; pending: PendingRewind | null; stale: boolean }
+
+/** The editable set and the rewind overlay as one string: which bubbles may be edited, which events are
+ *  dimmed, and the pending edit (its uuid; its text, or "b" for a delete). "?" before the first pass. The
+ *  editable and dimmed parts read events below `bound` only; the pending edit is unbounded. */
+export function rewindSig(events: readonly RewindEvent[], editable: Set<string> | undefined,
+                          pending: PendingRewind | null | undefined, bound: number = events.length): string {
+  const eds: string[] = [], dim: number[] = [];
+  const n = Math.min(bound, events.length);
+  for (let i = 0; i < n; i++) {
+    const e = events[i];
+    if (editable && e.uuid && editable.has(e.uuid)) eds.push(e.uuid);
+    if (e.rewound) dim.push(i);
+  }
+  return (editable ? eds.join(",") : "?") + "|" + dim.join(",") + "|" + (pending ? pending.uuid + ":" + (pending.bare ? "b" : pending.text) : "");
+}
+
+/** One pass over `events` (mutated in place: flags, the edited bubble's replacement, a queued echo's removal).
+ *  `prevEditable` is the set the previous pass produced (undefined before the first), `pending` the session's
+ *  pending rewind (null or undefined for none). Returns the new editable set, the pending entry still in force
+ *  (null once retired) and whether the prefix below `bound` changed. */
+export function reconcileRewindPass<E extends RewindEvent>(events: E[], prevEditable: Set<string> | undefined,
+                                                            pending: PendingRewind | null | undefined, opts: RewindOpts): RewindResult {
+  const before = rewindSig(events, prevEditable, pending, opts.bound);
+  for (const e of events) if (e.rewound) delete e.rewound;
+  let lastCompact = -1;
+  for (let i = 0; i < events.length; i++) if (events[i].kind === "compact") lastCompact = i;
+  const editable = new Set<string>();
+  if (opts.sdk) {
+    for (let i = lastCompact + 1; i < events.length; i++) {
+      const e = events[i];
+      if (e.kind === "user" && e.human && e.uuid && !e.romp && !e.interruptMarker && !e.uuid.startsWith(opts.optPrefix)) editable.add(e.uuid);
+    }
+  }
+  let pr: PendingRewind | null = pending || null;
+  if (pr) {
+    const idx = events.findIndex((e) => e.kind === "user" && e.uuid === pr!.uuid);
+    if (idx < 0 || opts.now - pr.ts > opts.ttlMs) {
+      pr = null;                           // the branch landed (old uuid gone) — or the backstop expired
+    } else if (pr.bare) {
+      // DELETE rollback: the deleted bubble goes too — dim from it onward. No text replacement and no
+      // queued-chip suppression (nothing was sent; the kernel's cut payload retires this in a beat).
+      for (let j = idx; j < events.length; j++) events[j].rewound = true;
+    } else {
+      events[idx] = { ...events[idx], md: pr.text, pending: true, images: undefined };
+      for (let j = idx + 1; j < events.length; j++) events[j].rewound = true;
+      for (let j = events.length - 1; j > idx; j--) {
+        const e = events[j];
+        if (e.kind === "queued" && Array.isArray(e.texts)) {
+          e.texts = e.texts.filter((t) => t.md !== pr!.text);
+          if (!e.texts.length) events.splice(j, 1);
+        }
+      }
+    }
+  }
+  return { editable, pending: pr, stale: rewindSig(events, editable, pr, opts.bound) !== before };
+}

--- a/ui/webview/setting-refused.test.ts
+++ b/ui/webview/setting-refused.test.ts
@@ -21,6 +21,7 @@ const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
 const VIEW = fs.readFileSync(path.join(ROOT, "ui", "romp-timeline-view.js"), "utf8");
 const FEED = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.ts"), "utf8");
 const RENDER = fs.readFileSync(path.join(ROOT, "ui", "webview", "render.ts"), "utf8");
+const GATE = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed-card-gate.ts"), "utf8");
 const BOOT = fs.readFileSync(path.join(ROOT, "ui", "webview", "timeline-boot.ts"), "utf8");
 
 test("the kernel answers a refused store write on the DELIVERING socket, addressed to the gesture", () => {
@@ -130,14 +131,18 @@ test("feed: the card bell's latch drops, the card repaints, the reason toasts (s
   assert.ok(i > 0, "the feed page handles the frame");
   const arm = FEED.slice(i, FEED.indexOf('} else if (m.type === "err"', i));
   assert.match(arm, /if \(m\.gesture === "bell" && typeof m\.itemId === "string" && m\.itemId\) pendingNotify\.delete\(m\.itemId\);/);
-  assert.match(arm, /\n\s+render\(\);/, "the repaint follows the release: the paint key reads the latch");
+  assert.match(arm, /\n\s+render\(\);/, "the repaint follows the release: the card gate's key reads the latch");
   // a bell toggle is a SOFT refusal (nothing typed was lost): the fading toast, never the must-dismiss dialog
   assert.match(arm, /feedToast\(m\.text\);/);
   assert.doesNotMatch(arm, /showErrDialog/);
   assert.match(arm, /window\.parent\?\.postMessage\(\{ romp: "notify", kind: "refused", text: m\.text,/);
-  // the release precedes the paint, and the paint key still reads the latch (else the bell would not repaint)
+  // the release precedes the paint, and the card's update gate still reads the latch (else the bell would not
+  // repaint): cardNotifyOn — pendingNotify over the payload's notify — is the gate env's notifyOn input, and
+  // the inputs key folds it in (feed-card-gate.ts cardInputsKey), so the released latch changes the key
   assert.ok(arm.indexOf("pendingNotify.delete") < arm.indexOf("render();"));
-  assert.match(FEED, /\+ "\|" \+ \(pendingNotify\.has\(it\.itemId\) \? String\(pendingNotify\.get\(it\.itemId\)\) : ""\)/);
+  assert.match(FEED, /^function cardNotifyOn\(it: \{ itemId: string; notify\?: boolean \| null \}\): boolean \{\n\s+return pendingNotify\.has\(it\.itemId\) \? !!pendingNotify\.get\(it\.itemId\) : !!it\.notify;/m);
+  assert.match(FEED, /notifyOn: cardNotifyOn,/, "the gate env reads the bell through the latch");
+  assert.match(GATE, /env\.notifyOn\(it\) \? "n" : ""/, "the key carries the bell's effective state");
   // and the page still has NO warn handler: undelivered-err.test.ts pins that, and it stays true on purpose
   assert.doesNotMatch(FEED, /m\.type === "warn"/);
 });

--- a/ui/webview/spin-caption.test.ts
+++ b/ui/webview/spin-caption.test.ts
@@ -7,7 +7,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { spinFor, kindWord } from "./spin-caption";
+import { spinFor, kindWord, workingFor } from "./spin-caption";
 import { distillInputs, distillText, distillPending } from "./distiller-line";
 
 // --- THE REGRESSION: a re-judging card always spins ----------------------------------------------
@@ -167,11 +167,16 @@ test("a settled card displaced to Working loses its line but never its caption",
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
 test("feed.ts routes the card's swirl through spinFor and keeps no inline copy of the ladder", () => {
-  assert.match(FEED, /import \{ spinFor, waitedSuffix, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);   // slice 2: the rows' vocabulary rides the same import
+  assert.match(FEED, /import \{ spinFor, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);   // slice 2: the rows' vocabulary rides the same import
   // the elapsed readout reaches the OTHER two awaiting surfaces through the same helper: the
-  // "Awaiting task" pill and the "Awaiting <peer>" chip (the user 2026-08-23)
-  assert.match(FEED, /const pillWaited = waitedSuffix\(it\.awaiting && it\.awaiting\.since, Date\.now\(\) \/ 1000\);/);
-  assert.match(FEED, /const woWaited = waitedSuffix\(wo\.since, Date\.now\(\) \/ 1000\);/);
+  // "Awaiting task" pill and the "Awaiting <peer>" chip (the user 2026-08-23). That helper is durNodes —
+  // waitedSuffix's rule (" · " + the duration for a known start, nothing otherwise) rendered as a stamped
+  // element the 15 s live pass keeps moving (feed-age.ts fmt "dur")
+  assert.match(FEED, /function durNodes\(since: number \| null \| undefined\): \(string \| HTMLElement\)\[\] \{\n\s*return since && since > 0 \? \[" · ", durSpan\(since\)\] : \[\];/);
+  assert.match(FEED, /pillLbl\.append\(\.\.\.durNodes\(it\.awaiting && it\.awaiting\.since\)\);\s*\/\/ the waited time, live/);
+  assert.match(FEED, /const woDur = durNodes\(wo\.since\);/);
+  // …and the ladder itself runs on the kernel's clock, like every other age on the board
+  assert.match(FEED, /dCompleted, nowSec\(\)\);/);
   assert.match(FEED, /const spin = spinFor\(it, distillPending\(/);
   assert.match(FEED, /const spinCaption = spin\.caption, spinTip = spin\.tip, awaitingBg = spin\.awaitingBg;/);
   // the inline ladder is gone — no second, drifting copy of the rule
@@ -181,7 +186,7 @@ test("feed.ts routes the card's swirl through spinFor and keeps no inline copy o
   // …and it still drives the same DOM
   assert.match(FEED, /a\._awaitSpin\.style\.display = spinCaption \? "" : "none";/);
   assert.match(FEED, /a\._awaitSpin\.classList\.toggle\("await-paused", awaitingBg\);/);
-  assert.match(FEED, /\} else a\._awaitWhy\.textContent = spinCaption;\n\s*a\._awaitSpin\.title = spinTip \|\| spinCaption;/);
+  assert.match(FEED, /else a\._awaitWhy\.textContent = spinCaption;\n\s*a\._awaitSpin\.title = spinTip \|\| spinCaption;/);
 });
 
 // --- the working narration (the user 2026-08-13): the previously-mute ordinary working card ---------
@@ -317,4 +322,39 @@ test("the spin caption derives its word from the kernel's count", () => {
   assert.equal(two.caption, "Awaiting agents");
   const legacy = spinFor({ awaiting: { why: "", kind: "agents" }, column: "working" }, false, false);
   assert.equal(legacy.caption, "Awaiting agents", "an older kernel with no count reads as before");
+});
+
+// --- the caption's running duration as a separate part -----------------------------------------------
+test("a caption that ends in a duration also says where the duration starts: caption === dur.text + workingFor(now - since)", () => {
+  const NOW = 100_000;
+  const check = (s: ReturnType<typeof spinFor>) => {
+    assert.ok(s.dur, "the duration part is present");
+    assert.equal(s.caption, s.dur!.text + workingFor(NOW - s.dur!.since), "the two renderings agree to the character");
+  };
+  check(spinFor({ awaiting: { why: "", since: NOW - 42 * 60 }, column: "working" }, false, false, NOW));
+  check(spinFor({ awaiting: { why: "waiting on 3 subagents", since: NOW - 3 * 3600 - 5 * 60 }, column: "working" }, false, false, NOW));
+  check(spinFor({ column: "working", working: { since: NOW - 8 * 60, toolUses: 23 } }, false, false, NOW));
+  check(spinFor({ column: "working", working: { since: NOW - 3 * 60, toolUses: 0 } }, false, false, NOW));
+  assert.equal(spinFor({ column: "working", working: { since: NOW - 3 * 60, toolUses: 0 } }, false, false, NOW).dur!.text, "Working — ",
+    "no count: the duration alone follows the dash");
+  assert.equal(spinFor({ column: "working", working: { since: NOW - 8 * 60, toolUses: 23 } }, false, false, NOW).dur!.text, "Working — 23 tool uses · ");
+});
+
+test("a wait that started this very second, or whose clock runs ahead of the kernel's, reads 0m — still a live part", () => {
+  const NOW = 100_000;
+  for (const since of [NOW, NOW + 30]) {
+    const s = spinFor({ awaiting: { why: "", since }, column: "working" }, false, false, NOW);
+    assert.equal(s.caption, "Awaiting agents · 0m");
+    assert.deepEqual(s.dur, { text: "Awaiting agents · ", since });
+    const w = spinFor({ column: "working", working: { since, toolUses: 1 } }, false, false, NOW);
+    assert.equal(w.caption, "Working — 1 tool use · 0m");
+    assert.deepEqual(w.dur, { text: "Working — 1 tool use · ", since });
+  }
+});
+
+test("no start, no duration part: the caption stands alone", () => {
+  assert.equal(spinFor({ awaiting: { why: "" }, column: "working" }, false, false, 5000).dur, null);
+  assert.equal(spinFor({ awaiting: { why: "", since: 1000 }, column: "working" }, false, false).dur, null, "no clock, no duration");
+  assert.equal(spinFor({ column: "working", working: { toolUses: 2 } }, false, false, 5000).dur, null);
+  assert.equal(spinFor({ column: "working", judging: true }, false, false, 5000).dur, undefined, "the other rungs carry none");
 });

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -65,6 +65,12 @@ export interface Spin {
   tip: string;
   awaitingBg: boolean;
   still?: boolean;   // the at-rest floor: glyph present but NOT spinning — spin reads as in-flight, and quiet/unknown are states of rest
+  /** A caption that ENDS in a running duration, split for a live label: `caption` is
+   *  `text + workingFor(nowS - since)` exactly, and the renderer stamps the duration on its own element
+   *  (feed-age.ts fmt "dur") so the 15 s live pass keeps it moving. The feed's per-card update gate
+   *  repaints a card only when its inputs change, so a duration baked into one string would freeze on a
+   *  card the kernel has no reason to re-send (a long wait whose record does not change). */
+  dur?: { text: string; since: number } | null;
 }
 
 const NONE: Spin = { caption: null, tip: "", awaitingBg: false };
@@ -205,12 +211,13 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
     // how long the wait has held, from the kernel's event time — the same live readout the working
     // narration wears, so a stuck wait is visible at a glance (the user 2026-08-23)
     const waited = waitedSuffix(aw.since, nowS);
+    const head = /^waiting on/i.test(why) ? why.charAt(0).toUpperCase() + why.slice(1) : "Awaiting " + word;
     return {
-      caption: (/^waiting on/i.test(why) ? why.charAt(0).toUpperCase() + why.slice(1)
-                                         : "Awaiting " + word) + waited,
+      caption: head + waited,
       tip: why ? why + ". Not on you; paused until the background work lands."
                : "Paused, waiting on background work it dispatched (not on you). Clears when the result lands.",
       awaitingBg: true,
+      dur: waited ? { text: head + " · ", since: aw.since as number } : null,
     };
   }
   if (it.provisional && it.column === "working" && !aw) {
@@ -286,12 +293,14 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
     const dur = nowS && it.working.since ? workingFor(nowS - it.working.since) : "";
     // zero tool uses says nothing worth reading ("0 tool uses" was noise — the user 2026-08-13):
     // the count appears once there is one, and until then the timer alone carries the narration
-    const parts = [n >= 1 ? `${n} tool ${n === 1 ? "use" : "uses"}` : "", dur].filter(Boolean);
+    const count = n >= 1 ? `${n} tool ${n === 1 ? "use" : "uses"}` : "";
+    const parts = [count, dur].filter(Boolean);
     return {
       caption: parts.length ? `Working — ${parts.join(" · ")}` : "Working…",
       tip: "The open turn's live progress: tool calls made so far, and how long this stretch has been "
          + "running. If the count freezes while the timer climbs, something is worth a look.",
       awaitingBg: false,
+      dur: dur ? { text: "Working — " + (count ? count + " · " : ""), since: it.working.since as number } : null,
     };
   }
   if (it.column === "working") {

--- a/ui/webview/tab-backend-tooltip.test.ts
+++ b/ui/webview/tab-backend-tooltip.test.ts
@@ -16,7 +16,9 @@ test("the session Status type carries the backend the kernel publishes", () => {
 
 test("the tab tooltip is a custom DOM tooltip shown on hover, not a native title", () => {
   assert.match(RENDER, /function showTabTip\(tab: HTMLElement, s: Session\)/);
-  assert.match(RENDER, /tab\.addEventListener\("mouseenter", \(\) => showTabTip\(tab, s\)\)/);
+  // the session is looked up fresh at hover time: an unchanged strip is no longer rebuilt (tab-strip-skip), so
+  // the tab node can outlive a frame that replaced the session object it was built from
+  assert.match(RENDER, /tab\.addEventListener\("mouseenter", \(\) => showTabTip\(tab, sessions\.get\(id\) \?\? s\)\)/);
   assert.match(RENDER, /tab\.addEventListener\("mouseleave", hideTabTip\)/);
   assert.doesNotMatch(RENDER, /tab\.title = s\.name \+ " · " \+ beLabel/);
 });

--- a/ui/webview/tab-strip-skip-exec.test.ts
+++ b/ui/webview/tab-strip-skip-exec.test.ts
@@ -1,0 +1,352 @@
+// renderTabs EXECUTED: the unchanged-strip skip, its input list, and what still runs on the skip path — driven
+// over a minimal fake DOM (no jsdom), the way models-rev.test.ts and thread-selection-scope.test.ts lift a
+// render.ts function. tab-strip-skip.test.ts pins the SHAPE at the source; this file drives the BEHAVIOUR, so a
+// change that keeps the pinned text but defeats the skip (a signature reset, a nonce in the signature, an input
+// dropped from the per-tab array while its helper call stays) fails here. The strip's pure rules run for real:
+// the plan (tab-groups.ts planStrip, over a stored tab-groups blob the test hands it) and the state → class rule
+// (tab-state.ts); the group header builder is a stub that records what it was handed, since the signature — not
+// the header's DOM — is what this file tests (tab-groups.test.ts executes the header).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import { planStrip, parseTabGroups, headWords } from "./tab-groups";
+import { tabStateClass, sectionPip, sectionPipMembers, sectionPipTitle } from "./tab-state";
+import type { TagUnion } from "./session-views";
+
+const requireCjs = createRequire(__filename);
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+/** Enough of Element for the strip's paint: children, classList, dataset, style, listeners (fired by hand). */
+class FakeEl {
+  tag: string; className: string; children: FakeEl[] = []; parent: FakeEl | null = null;
+  dataset: Record<string, string> = {}; styleProps: Record<string, string> = {}; attrs: Record<string, string> = {};
+  listeners: Record<string, Function[]> = {}; textContent = ""; title = ""; tabIndex = -1; draggable = false;
+  wipes = 0;   // replaceChildren() calls: the strip's rebuild count when this is #tabs
+  style: any; classList: any;
+  constructor(tag: string, cls = "") {
+    this.tag = tag; this.className = cls;
+    const self = this;
+    this.style = { display: "", color: "", padding: "", height: "", background: "", animationDelay: "", borderColor: "",
+                   setProperty(k: string, v: string) { self.styleProps[k] = v; } };
+    this.classList = {
+      add(...c: string[]) { for (const x of c) if (!self.has(x)) self.className = (self.className + " " + x).trim(); },
+      remove(...c: string[]) { for (const x of c) self.className = self.className.split(/\s+/).filter((y) => y !== x).join(" "); },
+      contains(x: string) { return self.has(x); },
+      toggle(x: string, on?: boolean) { if (on) this.add(x); else this.remove(x); },
+    };
+  }
+  has(x: string): boolean { return this.className.split(/\s+/).includes(x); }
+  appendChild(c: FakeEl): FakeEl { c.parent = this; this.children.push(c); return c; }
+  append(...cs: FakeEl[]): void { for (const c of cs) this.appendChild(c); }
+  replaceChildren(...cs: FakeEl[]): void { this.wipes++; this.children = []; this.append(...cs); }
+  get firstChild(): FakeEl | null { return this.children[0] ?? null; }
+  contains(n: unknown): boolean { return n === this || this.children.some((c) => c.contains(n)); }
+  setAttribute(k: string, v: string): void { this.attrs[k] = v; }
+  addEventListener(t: string, f: Function): void { (this.listeners[t] ??= []).push(f); }
+  fire(t: string, ev: any = {}): void { for (const f of this.listeners[t] ?? []) f(ev); }
+  remove(): void { if (this.parent) this.parent.children = this.parent.children.filter((c) => c !== this); }
+  tabs(): FakeEl[] { return this.children.filter((c) => c.has("tab") && !c.has("tab-add")); }
+  heads(): FakeEl[] { return this.children.filter((c) => c.has("tab-group-head")); }
+}
+
+/** A recorded call of the group-header stub: what renderTabs handed makeGroupHead for one section. */
+type HeadCall = { name: string | null; color: string; ids: string[]; folded: boolean; active: boolean; hidden: string[] };
+
+type Hooks = {
+  FakeEl: typeof FakeEl; bar: FakeEl; mslot: FakeEl | null; only: string; hidden: Set<string>; down: Set<string>;
+  notes: Record<string, string>; keyHint: string; lens: unknown; unions: TagUnion[]; tips: unknown[];
+  aftermaths: [number, number][]; rowPaints: number; tagSyncs: number; placeholders: number;
+  groupsRaw: string | null;   // the stored tab-groups blob the plan reads (localStorage's, in the page)
+  phone: boolean;             // the phone layout: the plan is the flat strip there
+  heads: HeadCall[];          // every group header the paint minted, in order
+  planStrip: typeof planStrip; parseTabGroups: typeof parseTabGroups; headWords: typeof headWords;
+  tabStateClass: typeof tabStateClass; sectionPip: typeof sectionPip; sectionPipMembers: typeof sectionPipMembers; sectionPipTitle: typeof sectionPipTitle;
+};
+type Api = {
+  renderTabs: () => void; sig: () => string; folded: () => Set<string>;
+  set: (patch: Record<string, unknown>) => void; pending: () => { renderPendingAfterRename: boolean; renderPendingWhilePressed: boolean };
+};
+
+// renderTabs + stripAftermath, transpiled (TS → JS) with esbuild at run time — required dynamically so the test
+// bundle does not try to bundle esbuild itself (models-rev.test.ts's pattern).
+function lift(): (hooks: Hooks) => Api {
+  const a = RENDER.indexOf("function renderTabs() {"), b = RENDER.indexOf("// Right-click context menu on a tab.", a);
+  assert.ok(a > 0 && b > a, "anchors not found — renderTabs or the context-menu comment moved; re-anchor");
+  const js = requireCjs("esbuild").transformSync(RENDER.slice(a, b), { loader: "ts" }).code;
+  const prelude = `
+    let renameActive = false, renderPendingAfterRename = false, tabPointerHeld = false, renderPendingWhilePressed = false;
+    let tabStripSig = "", activeId = null, peekId = null, allHiddenBlanked = false, draggedId = null, tabDragCommitted = false;
+    let order = [], closingTabs = new Set(), tabMeta = new Map(), sessions = new Map(), views = new Map();
+    let collapsedTabIds = new Set(), draggedGroup = null, provisionalId = null, provisionalTags = [];
+    let settings = { tabCtx: "over50", theme: "classic", colormap: "aurora" };
+    const H = HOOKS;
+    const el = (tag, cls) => new H.FakeEl(tag, cls);
+    const document = { activeElement: null,
+      getElementById: (id) => id === "tabs" ? H.bar : id === "mtag-slot" ? H.mslot : null,
+      createTextNode: (t) => { const n = new H.FakeEl("#text"); n.textContent = t; return n; } };
+    const auditTabOrder = () => {}; const onlyTag = () => H.only; const matchesOnly = (name, only) => name.includes(only);
+    const tabInView = (id) => id === peekId || !H.hidden.has(id);
+    const setActive = () => {}; const setTimeout = () => 0;
+    const titleWithKey = () => H.keyHint; const surfaceLens = () => H.lens; const effViews = () => null; const viewTagUnion = () => H.unions;
+    const hostIsDown = (id) => H.down.has(id); const hostDownNote = (id) => H.notes[id] ?? "";
+    function makePlaceholderTab(id) { const t = el("div", "tab tab-placeholder"); t.dataset.id = id; H.placeholders++; return t; }
+    // the sectioned strip's pure rules, for real; the header builder a recorder
+    const planStrip = H.planStrip; const headWords = H.headWords;
+    const readTabGroups = (u) => H.parseTabGroups(H.groupsRaw, u);
+    const tabGroups = () => readTabGroups(H.unions); const writeTabGroups = () => {};
+    const phoneLayout = () => H.phone;
+    const tabStateClass = H.tabStateClass, sectionPip = H.sectionPip, sectionPipMembers = H.sectionPipMembers, sectionPipTitle = H.sectionPipTitle;
+    function makeGroupHead(sec, folded, active, hidden) {
+      const h = el("div", "tab-group-head" + (folded ? " collapsed" : ""));
+      h.dataset.group = String(sec.name);
+      H.heads.push({ name: sec.name, color: sec.color, ids: sec.ids.slice(), folded, active, hidden: hidden.slice() });
+      return h;
+    }
+    const onTabKey = () => {}; const dragImageBlank = () => el("div"); const hideTabTip = () => {}; const snapshotDragGeometry = () => {};
+    const flipTabs = (f) => f(); const applyCompactSweep = () => {};
+    const hostNameNodes = (name) => [document.createTextNode(name)]; const fadedColor = (h) => h;
+    const tabCtxGauge = () => el("span", "tab-ctx"); const pickTone = (a, b) => b ?? a;
+    const showTabTip = (tab, s) => { H.tips.push(s); }; const toggleLedgerCollapsed = () => {}; const showTabMenu = () => {}; const openPicker = () => {};
+    const tagMenuButton = () => el("span", "tag-btn"); const openTagMenu = () => {}; const postLens = () => {}; const vscodeApi = null;
+    const syncTagFilter = () => { H.tagSyncs++; }; const paintTabRowLines = () => { H.rowPaints++; }; const ensureTabRowObserver = () => {};
+    const focusActiveTab = () => {}; const syncNoSessionsPlaceholder = (v, t) => { H.aftermaths.push([v, t]); };
+  `;
+  const epilogue = `
+    return { renderTabs, sig: () => tabStripSig, folded: () => collapsedTabIds,
+      set: (p) => { for (const k of Object.keys(p)) {
+        if (k === "activeId") activeId = p[k]; else if (k === "peekId") peekId = p[k]; else if (k === "order") order = p[k];
+        else if (k === "sessions") sessions = p[k]; else if (k === "tabMeta") tabMeta = p[k]; else if (k === "settings") settings = p[k];
+        else if (k === "views") views = p[k]; else if (k === "renameActive") renameActive = p[k]; else if (k === "tabPointerHeld") tabPointerHeld = p[k];
+        else if (k === "provisionalId") provisionalId = p[k]; else if (k === "provisionalTags") provisionalTags = p[k];
+        else throw new Error("unknown knob " + k); } },
+      pending: () => ({ renderPendingAfterRename, renderPendingWhilePressed }) };
+  `;
+  return new Function("HOOKS", prelude + js + epilogue) as (hooks: Hooks) => Api;
+}
+
+const session = (name: string, state: string, extra: Record<string, unknown> = {}) =>
+  ({ name, color: { bg: "#336699", fg: "#ffffff" }, status: { state, ...extra } });
+/** A tag union as viewTagUnion builds one: the plan reads name, color, members and the local id. */
+const union = (name: string, color: string, members: string[]): TagUnion =>
+  ({ name, color, members, ids: ["t-" + name], localId: "t-" + name, locals: [], remotes: [] });
+const groups = (patch: Record<string, unknown>) => JSON.stringify({ on: true, collapsed: [], expanded: [], pinned: [], ...patch });
+
+/** Two landed sessions and one placeholder, the first active; every knob at a quiet default (no tags: the
+ *  flat strip). */
+function world(): { H: Hooks; api: Api; sessions: Map<string, any>; tabMeta: Map<string, any>; settings: any } {
+  const H: Hooks = { FakeEl, bar: new FakeEl("div"), mslot: null, only: "", hidden: new Set(), down: new Set(), notes: {},
+                     keyHint: "Open a session (K)", lens: { all: true }, unions: [], tips: [], aftermaths: [], rowPaints: 0, tagSyncs: 0, placeholders: 0,
+                     groupsRaw: null, phone: false, heads: [],
+                     planStrip, parseTabGroups, headWords, tabStateClass, sectionPip, sectionPipMembers, sectionPipTitle };
+  const api = lift()(H);
+  const sessions = new Map<string, any>([["a", session("web", "ready")], ["b", session("api", "working")]]);
+  const tabMeta = new Map<string, any>([["p", { name: "tests", color: { bg: "#112233", fg: "#ffffff" } }]]);
+  const settings = { tabCtx: "over50", theme: "classic", colormap: "aurora" };
+  api.set({ order: ["a", "b", "p"], sessions, tabMeta, settings, activeId: "a" });
+  return { H, api, sessions, tabMeta, settings };
+}
+
+/** The same world sectioned: `a` and `b` home in the tag `backend`, the placeholder `p` untagged, and the
+ *  UNTAGGED placeholder active — so the backend section may fold (the active tab's section never does). */
+function sectionedWorld() {
+  const w = world();
+  w.H.unions = [union("backend", "#aa0000", ["a", "b"])];
+  w.api.set({ activeId: "p" });
+  return w;
+}
+
+/** Drive one change: it repaints the strip exactly once, and an unchanged render after it does not. */
+function repaintsOnce(H: Hooks, api: Api, what: string, change: () => void): void {
+  change();
+  const before = H.bar.wipes;
+  api.renderTabs();
+  assert.equal(H.bar.wipes, before + 1, what + " changed: the strip repaints");
+  api.renderTabs();
+  assert.equal(H.bar.wipes, before + 1, what + " unchanged since: no repaint");
+}
+
+test("an unchanged strip is not rebuilt, and the aftermath runs on both paths", () => {
+  const { H, api } = world();
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 1);
+  assert.equal(H.rowPaints, 1);
+  assert.deepEqual(H.aftermaths, [[3, 3]]);
+  const nodes = [...H.bar.children];
+  assert.equal(H.bar.tabs().length, 3, "two sessions and a placeholder");
+  assert.equal(H.heads.length, 0, "no tags: the flat strip, no header");
+  api.renderTabs();
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 1, "the second and third render found nothing changed: no wipe");
+  assert.equal(H.rowPaints, 1, "no layout read either");
+  assert.equal(H.placeholders, 1, "no node minted");
+  assert.deepEqual(H.bar.children, nodes, "the same DOM nodes");
+  assert.equal(H.aftermaths.length, 3, "the no-sessions placeholder reconciles on the skip path too");
+});
+
+test("every input the strip paints repaints it, once, when it changes", () => {
+  const { H, api, sessions, tabMeta, settings } = world();
+  api.renderTabs();
+  const a = sessions.get("a");
+  const changes: [string, () => void][] = [
+    ["a session's state", () => { a.status.state = "working"; }],
+    ["a state's tab class with the state unchanged (blocked: transient → on-you)", () => { a.status = { state: "blocked" }; api.renderTabs(); a.status = { state: "blocked", apiRefusal: true }; }],
+    ["a session's name", () => { a.name = "web2"; }],
+    ["a session's color", () => { a.color = { bg: "#993366", fg: "#ffffff" }; }],
+    ["faded", () => { a.status.faded = true; }],
+    ["context percent", () => { a.status.ctx = "72"; }],
+    ["context color", () => { a.status.ctxColor = [200, 100, 0]; }],
+    ["context tone", () => { a.status.ctxTone = [20, 20, 220]; }],
+    ["the viewer flag", () => { a.sub = true; }],
+    ["the host-down mark", () => { H.down.add("a"); }],
+    ["the host-down note while the mark stands", () => { H.notes.a = "web-host is disconnected, last reached 10:00"; }],
+    ["the active tab", () => { api.set({ activeId: "b" }); }],
+    ["the peek tab", () => { api.set({ peekId: "b" }); }],
+    ["the order", () => { api.set({ order: ["b", "a", "p"] }); }],
+    ["a tab hidden by the views filter", () => { H.hidden.add("p"); }],
+    ["the context-gauge setting", () => { settings.tabCtx = "always"; }],
+    ["the theme", () => { settings.theme = "yatharth"; }],
+    ["the colormap", () => { settings.colormap = "hawaii"; }],
+    ["the + tab's key hint", () => { H.keyHint = "Open a session (J)"; }],
+    ["the tag lens", () => { H.lens = { all: false, tags: ["t1"] }; }],
+    ["the tag unions (a tag holding no visible tab: the filter chips read it)", () => { H.unions = [union("u", "#000000", ["zz"])]; }],
+    ["a placeholder's name", () => { H.hidden.delete("p"); api.renderTabs(); tabMeta.get("p").name = "tests2"; }],
+    ["a placeholder's color", () => { tabMeta.get("p").color = { bg: "#445566", fg: "#000000" }; }],
+    ["a placeholder's session landing", () => { sessions.set("p", session("tests2", "opening")); }],
+  ];
+  for (const [what, change] of changes) repaintsOnce(H, api, what, change);
+});
+
+test("the sectioned strip: every input a group header paints repaints it, once, when it changes", () => {
+  const { H, api, sessions } = sectionedWorld();
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 1);
+  assert.deepEqual(H.heads.map((h) => [h.name, h.folded, h.active, h.hidden]), [["backend", false, false, []], [null, false, true, []]],
+    "a backend header, open, then the untagged separator (which holds the active placeholder)");
+  const headNodes = H.bar.heads();
+  assert.equal(headNodes.length, 2);
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 1, "equal plan, equal tabs: skipped");
+  assert.deepEqual(H.bar.heads(), headNodes, "the header nodes were kept");
+  const changes: [string, () => void][] = [
+    ["a section folds", () => { H.groupsRaw = groups({ collapsed: ["backend"] }); }],
+    ["a hidden member's state (the folded header's pip)", () => { sessions.get("a").status.state = "blocked"; }],
+    ["a hidden member's name (the pip's tooltip)", () => { sessions.get("a").name = "web-renamed"; }],
+    ["a member pinned to show under its folded header", () => { H.groupsRaw = groups({ collapsed: ["backend"], pinned: [{ sid: "b", name: "backend", id: "t-backend" }] }); }],
+    ["the section unfolds", () => { H.groupsRaw = groups({}); }],
+    ["the tag's color (the header's chip)", () => { H.unions = [union("backend", "#00aa00", ["a", "b"])]; }],
+    ["a tab's home tag (membership)", () => { H.unions = [union("backend", "#00aa00", ["a"])]; }],
+    ["the group order", () => { H.unions = [union("frontend", "#0000aa", ["b"]), union("backend", "#00aa00", ["a"])]; api.renderTabs(); H.unions = [union("backend", "#00aa00", ["a"]), union("frontend", "#0000aa", ["b"])]; }],
+    ["the active tab's section (unfoldable while it holds it)", () => { H.groupsRaw = groups({ collapsed: ["backend"] }); api.renderTabs(); api.set({ activeId: "a" }); }],
+    ["a provisional tab's tags (it sections under its future home)", () => { api.set({ provisionalId: "p", provisionalTags: ["frontend"] }); }],
+    ["sectioning switched off", () => { H.groupsRaw = groups({ on: false }); }],
+    ["the phone layout (the flat strip there)", () => { H.groupsRaw = groups({}); api.renderTabs(); H.phone = true; }],
+  ];
+  for (const [what, change] of changes) repaintsOnce(H, api, what, change);
+});
+
+test("the folded set the plan yields is published on the skip path too (keyboard cycling reads it)", () => {
+  const { H, api } = sectionedWorld();
+  H.groupsRaw = groups({ collapsed: ["backend"] });
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 1);
+  assert.deepEqual([...api.folded()].sort(), ["a", "b"], "both members hidden under the folded header");
+  assert.deepEqual(H.heads.map((h) => [h.name, h.folded, h.hidden]), [["backend", true, ["a", "b"]], [null, false, []]]);
+  assert.equal(H.bar.tabs().length, 1, "only the untagged placeholder is a tab node");
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 1, "skipped");
+  assert.deepEqual([...api.folded()].sort(), ["a", "b"], "the set stands across the skip");
+});
+
+test("the paint wears the shared state → class rule (tab-state.ts), and the signature reads the same rule", () => {
+  const { H, api, sessions } = world();
+  sessions.get("a").status = { state: "blocked", apiSpendLimit: true };
+  api.renderTabs();
+  const tab = H.bar.tabs().find((t) => t.dataset.id === "a")!;
+  assert.ok(tab.has("tab-blocked") && !tab.has("tab-retrying"), "an on-you block: alarm-red");
+  assert.equal(tabStateClass(sessions.get("a").status), "tab-blocked");
+  // the same state under a different class (the transient API error) is a different signature
+  sessions.get("a").status = { state: "blocked" };
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 2);
+  const tab2 = H.bar.tabs().find((t) => t.dataset.id === "a")!;
+  assert.ok(tab2.has("tab-retrying") && !tab2.has("tab-blocked"), "a transient API error auto-retries: amber");
+});
+
+test("a render held by the pressed-tab or rename guard is not lost to the skip", () => {
+  const { H, api, sessions } = world();
+  api.renderTabs();
+  sessions.get("a").name = "renamed";
+  api.set({ tabPointerHeld: true });
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 1, "held: no rebuild mid-click");
+  assert.equal(api.pending().renderPendingWhilePressed, true);
+  api.set({ tabPointerHeld: false });
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 2, "released: the change that arrived while held is painted");
+  sessions.get("b").name = "renamed too";
+  api.set({ renameActive: true });
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 2);
+  assert.equal(api.pending().renderPendingAfterRename, true);
+  api.set({ renameActive: false });
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 3);
+});
+
+test("a tab drag resets the signature: the next render rebuilds even with nothing else changed", () => {
+  const { H, api } = world();
+  api.renderTabs();
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 1);
+  H.bar.tabs().find((t) => t.dataset.id === "a")!.fire("dragstart", { dataTransfer: null });
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 2, "the drag live-reordered the DOM outside renderTabs");
+});
+
+test("the hover tooltip reads the session fresh: a tab node outlives a frame that replaced the session object", () => {
+  const { H, api, sessions } = world();
+  api.renderTabs();
+  const fresh = session("web", "ready");   // same painted fields, new object (a kernel frame's upsert)
+  sessions.set("a", fresh);
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 1, "equal signature: the node was kept");
+  H.bar.tabs().find((t) => t.dataset.id === "a")!.fire("mouseenter");
+  assert.equal(H.tips.length, 1);
+  assert.equal(H.tips[0], fresh, "the tooltip got the session that is current, not the one the node was built from");
+});
+
+test("the mobile tag slot mounts once, and an empty slot is a reason to rebuild", () => {
+  const { H, api } = world();
+  H.mslot = new FakeEl("div");
+  api.renderTabs();
+  assert.equal(H.mslot.children.length, 2, "button + chips mounted");
+  assert.equal(H.bar.wipes, 1);
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 1, "mounted slot, equal strip: skipped");
+  assert.equal(H.mslot.children.length, 2, "not mounted twice");
+  H.mslot.children = [];
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 2, "an empty slot forces the rebuild that mounts it");
+  assert.equal(H.mslot.children.length, 2);
+});
+
+test("the all-hidden blank lands on the skip path when the active view appears between two equal strips", () => {
+  const { H, api } = world();
+  H.hidden.add("a"); H.hidden.add("b"); H.hidden.add("p");
+  const views = new Map<string, any>();
+  api.set({ views });
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 1);
+  assert.deepEqual(H.aftermaths.at(-1), [0, 3], "no visible tab, three sessions");
+  const av = { el: new FakeEl("div") };
+  views.set("a", av);   // the lazily built active view
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 1, "equal strip: skipped");
+  assert.equal(av.el.style.display, "none", "the transcript is blanked from the aftermath, not the rebuild");
+  H.hidden.delete("a");
+  api.renderTabs();
+  assert.equal(H.bar.wipes, 2);
+  assert.equal(av.el.style.display, "", "restored once anything is visible");
+});

--- a/ui/webview/tab-strip-skip.test.ts
+++ b/ui/webview/tab-strip-skip.test.ts
@@ -1,0 +1,81 @@
+// renderTabs skips an unchanged strip. It runs on every kernel push; on a board of a few dozen tabs most
+// tails go to tabs that are not active, and rebuilding every tab node with its listeners and then reading
+// each one's offsetTop (paintTabRowLines forces a layout) was those tails' whole 2-4 ms floor. The strip
+// now computes a signature of every input it paints and returns before the rebuild when it equals the last
+// one. scheduleRenderTabs already coalesces the pushes of one animation frame into one call; the skip is
+// the complement, for the frames whose call finds nothing changed.
+// No DOM harness executes render.ts (the other render tests say so), so the rule is pinned at the source:
+// the signature sits before the wipe, it names each input the strip renders — the strip PLAN among them,
+// since tab groups (2026-09-04) section the strip by tag and a header's fold, chip, count and pip are paint
+// too — and the one place that mutates the strip's DOM outside renderTabs, a tab drag's live reorder,
+// resets it (a group drag moves no node: its drop is a views write the plan reads). The correctness of a
+// signature skip rests on the input list being complete; this test is the list, so a new input the strip
+// renders has to land here too. tab-strip-skip-exec.test.ts drives the same rule over a fake element tree.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const fn = RENDER.slice(RENDER.indexOf("function renderTabs() {"), RENDER.indexOf("function stripAftermath("));
+const sig = fn.slice(fn.indexOf("const stripSig = JSON.stringify(["), fn.indexOf("const mslotEl = "));
+
+test("the signature is computed before the wipe, and an equal one returns before any node is built", () => {
+  assert.ok(fn.indexOf("const stripSig = JSON.stringify([") > 0, "renderTabs computes a signature");
+  assert.ok(fn.indexOf("const stripSig = JSON.stringify([") < fn.indexOf("bar.replaceChildren();"), "signature before the wipe");
+  assert.match(fn, /if \(stripSig === tabStripSig && !\(mslotEl && !mslotEl\.firstChild\)\) \{ stripAftermath\(visibleIds, ids\); return; \}\s*\n\s*tabStripSig = stripSig;/,
+    "an equal signature keeps the DOM; the mobile slot's once-only mount still happens; the aftermath still reconciles");
+  // the guards that already stood keep standing, ahead of the signature
+  assert.ok(fn.indexOf("if (renameActive)") < fn.indexOf("const stripSig") && fn.indexOf("if (tabPointerHeld)") < fn.indexOf("const stripSig"));
+  // the strip PLAN is computed ahead of the signature (it is an input), and the folded set it yields is
+  // published before the skip: keyboard cycling (visibleOrder) reads it whether or not the strip rebuilt
+  assert.ok(fn.indexOf("const plan = planStrip(") < fn.indexOf("const stripSig"), "the plan before the signature");
+  assert.ok(fn.indexOf("collapsedTabIds = plan.folded;") < fn.indexOf("if (stripSig === tabStripSig"), "the folded set before the skip");
+  // the focus capture + wipe keep their shape, now after the check: the header capture (tab-groups.test pins
+  // its pair with the tab rule) then the tab rule, then the wipe
+  assert.ok(fn.indexOf("const focusedGroup = ") > fn.indexOf("tabStripSig = stripSig;"), "the focus capture follows the skip");
+  assert.match(fn, /const refocusTab = bar\.contains\(document\.activeElement\);\s*\n\s*bar\.replaceChildren\(\);/);
+});
+
+test("every input the strip renders is in the signature", () => {
+  // the theme and colormap are inputs too: the context gauge's tone and fallback read the theme (pickTone,
+  // ctxFallbackColor) and the compacting sweep's gradient the colormap, and a settings change repaints the
+  // strip only through this signature. The plan's items carry each section's tag, color, members, fold
+  // state, active mark and hidden members — what a group header paints (tab-groups.ts planStrip) — and
+  // `unions` is the tag unions the filter chips render (the same viewTagUnion(effViews()) the plan read).
+  for (const needle of [
+    "activeId", "peekId", "ids", "visibleIds", "tabInView(activeId)", "plan.items",
+    "settings.tabCtx", "settings.theme", "settings.colormap", 'titleWithKey("Open a session", "session.new")',
+    'surfaceLens(effViews(), "chat")', "unions",
+    "m?.name", "m?.color?.bg", "m?.color?.fg",
+    "s.name", "s.color?.bg", "s.color?.fg", "st.state", "tabStateClass(st)", "!!st.faded",
+    "st.ctx", "st.ctxColor", "st.ctxTone", "!!s.sub", "hostIsDown(id)", "hostDownNote(id)",
+  ]) assert.ok(sig.includes(needle), "the signature reads " + needle);
+  assert.match(fn, /const unions = viewTagUnion\(effViews\(\)\);\s*\n\s*const plan = planStrip\(visibleIds, unions, readTabGroups\(unions\), activeId, phoneLayout\(\),/,
+    "the plan reads the unions the signature carries");
+  assert.match(sig, /visibleIds\.map\(\(id\) => \{/, "per visible id: a placeholder's meta or the session's painted fields");
+  // the state class the paint adds is the signature's own reading of the state: one rule for both — and for
+  // the folded header's pip (tab-state.ts, the shared module)
+  assert.match(fn, /const stateCls = tabStateClass\(s\.status\);\s*\n\s*if \(stateCls\) tab\.classList\.add\(stateCls\);/);
+  assert.match(RENDER, /^import \{ tabStateClass, sectionPip, sectionPipMembers, sectionPipTitle \} from "\.\/tab-state";/m);
+});
+
+test("a tab drag resets the signature (its live reorder changes the strip's DOM outside renderTabs), and the tooltip reads the session fresh", () => {
+  assert.match(fn, /tab\.addEventListener\("dragstart", \(e\) => \{\s*\n\s*draggedId = id; draggedEl = tab; tabDragCommitted = false;\s*\n\s*tabStripSig = "";/);
+  assert.match(fn, /showTabTip\(tab, sessions\.get\(id\) \?\? s\)/, "a tab node now outlives a frame that replaced the session object");
+  assert.match(RENDER, /^let tabStripSig = "";/m);
+  // a GROUP drag needs no reset: its dragover only marks the drop target (no live reorder of headers — the
+  // order is a kernel write) and its drop posts the tag order, which the plan reads on the next render
+  const drag = RENDER.slice(RENDER.indexOf('tabs.addEventListener("dragover", (e) => {'), RENDER.indexOf('tabs.addEventListener("drop", (e) => {'));
+  assert.match(drag, /if \(draggedGroup\) \{[^]*?No live reorder of headers[^]*?return;\s*\n\s*\}/);
+});
+
+test("what follows a render runs on both paths: the placeholder and the all-hidden blank", () => {
+  assert.match(RENDER, /function stripAftermath\(visibleIds: readonly string\[\], ids: readonly string\[\]\): void \{\s*\n\s*syncNoSessionsPlaceholder\(visibleIds\.length, ids\.length\);/);
+  assert.equal((fn.match(/stripAftermath\(visibleIds, ids\)/g) || []).length, 2, "the skip path and the rebuild path");
+  // the all-hidden blank reads the active view, which is built lazily and can appear between two equal
+  // strips: it lives in the aftermath, not behind the skip (session-views pins the block's shape)
+  const after = RENDER.slice(RENDER.indexOf("function stripAftermath("), RENDER.indexOf("// Right-click context menu on a tab."));
+  assert.match(after, /const blank = !visibleIds\.length && ids\.length > 0 && !tabInView\(activeId\);/);
+  assert.ok(!fn.includes("allHiddenBlanked"), "renderTabs itself does not blank or restore: only the aftermath, which both paths reach");
+});

--- a/ui/webview/timeline-boot.test.ts
+++ b/ui/webview/timeline-boot.test.ts
@@ -217,7 +217,7 @@ test("dispatchFrame routes tagEditFailed to the panel — the LOUD half of remot
   const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
   // (the listener body ends there; the boot registers it wrapped through the page's performance collector when one
   // is published on window.__rompPerf, the way every pane bundle wraps its own — perf-telemetry.ts)
-  assert.match(KERNEL, /else if\(m\.type==="tagEditFailed"&&panel\.tagEditFailed\)panel\.tagEditFailed\(m\);\nelse if\(m\.type==="openViewsDialog"&&panel\._openViewsDialog\)panel\._openViewsDialog\(null\);\};\nwindow\.addEventListener\("message",\(window\.__rompPerf&&window\.__rompPerf\.wrapFrameHandler\)\?window\.__rompPerf\.wrapFrameHandler\(onFrame\):onFrame\);/);
+  assert.match(KERNEL, /else if\(m\.type==="tagEditFailed"&&panel\.tagEditFailed\)panel\.tagEditFailed\(m\);\nelse if\(m\.type==="openViewsDialog"&&panel\._openViewsDialog\)panel\._openViewsDialog\(null\);\};\nvar frameListener=\(window\.__rompPerf&&window\.__rompPerf\.wrapFrameHandler\)\?window\.__rompPerf\.wrapFrameHandler\(onFrame\):onFrame;\nwindow\.addEventListener\("message",frameListener\);/);
   assert.match(KERNEL, /window\.__rompTimelineEditTag=function\(edit\)\{post\(\{type:"editTag",edit:edit\}\);\};/);
   const BOOT = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "timeline-boot.ts"), "utf8");
   assert.match(BOOT, /__rompTimelineEditTag: \(edit: unknown\) => post\(\{ type: "editTag", edit \}\),/);

--- a/ui/webview/timeline-main.ts
+++ b/ui/webview/timeline-main.ts
@@ -7,6 +7,7 @@ import { installDomHelpers, dispatchFrame, bridgeFunctions } from "./timeline-bo
 import { installSettingsSync, loadSettings, onExternalSettingsChange } from "./settings";
 import { applyTheme } from "./theme";
 import { perfFrameHandler } from "./perf-telemetry";
+import { listenForFrames } from "./frame-listener";
 
 // CJS view module — esbuild inlines it into this bundle at build time.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -25,7 +26,9 @@ Object.assign(window, bridgeFunctions(post));
 let panel: any = null;
 // wrapped through the pane's performance collector like every pane's listener (ui/webview/perf-telemetry.ts):
 // each frame's handling is timed by type, and the kernel page's inline boot twin does the same
-window.addEventListener("message", perfFrameHandler("timeline", post, (ev: MessageEvent) => { dispatchFrame(panel, ev.data); }));
+// …and installed through the same helper as every pane (frame-listener.ts): there is no federation.js in a VS Code
+// webview, so only the window listener is installed here; the kernel page's inline boot twin registers with it
+listenForFrames(perfFrameHandler("timeline", post, (ev: MessageEvent) => { dispatchFrame(panel, ev.data); }));
 
 // the overall theme (2026-08-28): body classes at boot + on settings writes, like every pane
 installSettingsSync();

--- a/ui/webview/worked-footer.test.ts
+++ b/ui/webview/worked-footer.test.ts
@@ -1,0 +1,74 @@
+// The "worked …" footer's rule and the tail path's footer plan (worked-footer.ts). The chat's tail
+// path re-renders exactly the events the kernel names as changed, so the one render that depends on later
+// events — the footer on a turn's last reply — is patched from this plan. Synthetic events; epochs are seconds.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { turnWorkedSecs, workedFooterPlan } from "./worked-footer";
+
+type Ev = { kind: string; human?: boolean; t?: number };
+const epoch = (e: Ev) => (e.t == null ? null : e.t);
+const user = (t: number, human = true): Ev => ({ kind: "user", human, t });
+const reply = (t: number): Ev => ({ kind: "assistant", t });
+const tool = (t: number): Ev => ({ kind: "tool", t });
+
+test("turnWorkedSecs: the turn's last reply carries the footer once a genuine prompt follows or the session is idle", () => {
+  const evs = [user(100), tool(110), reply(160), user(200), reply(230)];
+  assert.equal(turnWorkedSecs(evs, 2, true, epoch), 60, "a completed turn's last reply: prompt to reply");
+  assert.equal(turnWorkedSecs(evs, 1, true, epoch), null, "not the turn's last reply");
+  assert.equal(turnWorkedSecs(evs, 4, true, epoch), null, "the final turn while working: the spinner owns it");
+  assert.equal(turnWorkedSecs(evs, 4, false, epoch), 30, "…and idle: the footer");
+  assert.equal(turnWorkedSecs(evs, 0, false, epoch), null, "a prompt carries none");
+  assert.equal(turnWorkedSecs([user(100), reply(100)], 1, false, epoch), null, "a zero elapsed carries no footer");
+  assert.equal(turnWorkedSecs([user(100), reply(90)], 1, false, epoch), null, "…nor a negative one (a clock skew between the two stamps)");
+});
+
+test("turnWorkedSecs: the elapsed runs from the immediate trigger, and an injected user line does not end a turn", () => {
+  const evs = [user(100), reply(140), user(1000, false), reply(1030), user(2000)];
+  assert.equal(turnWorkedSecs(evs, 1, false, epoch), null, "a nudge followed the reply: the same turn continues, so this reply is not its last");
+  assert.equal(turnWorkedSecs(evs, 3, false, epoch), 30, "measured from the nudge that prompted the work, not the older prompt");
+});
+
+test("plan: a status-only tail (from = len) names the current turn's last reply; idle puts the footer on, working takes it off", () => {
+  const evs = [user(100), tool(110), reply(160), user(200), tool(205), reply(230)];
+  assert.deepEqual(workedFooterPlan(evs, evs.length, 0, false, epoch), [{ unit: 5, secs: 30 }]);
+  assert.deepEqual(workedFooterPlan(evs, evs.length, 0, true, epoch), [{ unit: 5, secs: null }],
+    "back at work on the same turn: the current reply's footer comes off (null); the completed turn at 2 is not named, nothing about it changed");
+});
+
+test("plan: a prompt landing at the tail completes the previous turn, whose reply sits before `from`", () => {
+  const evs = [user(100), reply(160), user(200)];
+  assert.deepEqual(workedFooterPlan(evs, 2, 0, true, epoch), [{ unit: 1, secs: 60 }]);
+});
+
+test("plan (case B, completed): two prompts in one tail still name the reply the first of them completed", () => {
+  // the old two-prompt walk spent its budget on the two new prompts and never reached the reply
+  const evs = [user(100), reply(160), user(200), user(210)];
+  assert.deepEqual(workedFooterPlan(evs, 2, 0, true, epoch), [{ unit: 1, secs: 60 }]);
+  const evs2 = [user(100), reply(160), user(200), reply(230), user(300)];
+  assert.deepEqual(workedFooterPlan(evs2, 2, 0, true, epoch), [{ unit: 1, secs: 60 }], "…however many turns the suffix carries");
+});
+
+test("plan (case A, demoted): a reply landing in the same turn takes the footer off the reply it follows", () => {
+  // idle after the reply at 1: it wore the footer; the tail appends a tool call, so it is no longer its turn's last
+  const evs = [user(100), reply(160), tool(170)];
+  assert.deepEqual(workedFooterPlan(evs, 2, 0, true, epoch), [{ unit: 1, secs: null }]);
+  // the same through an injected user line (a postal push) that sat before the tail: the turn continued
+  const evs2 = [user(100), reply(160), user(1000, false), reply(1030)];
+  assert.deepEqual(workedFooterPlan(evs2, 3, 0, true, epoch), [{ unit: 1, secs: null }], "the injected line is skipped: the reply at 1 is named, and it carries no footer now");
+  assert.deepEqual(workedFooterPlan(evs2, 3, 0, false, epoch), [{ unit: 1, secs: null }], "idle or not: a later reply in the turn owns the footer");
+});
+
+test("plan: replies at or past `from` were just rendered with their footer, so only the one before is named", () => {
+  const evs = [user(100), reply(160), user(200), tool(205), reply(230)];
+  assert.deepEqual(workedFooterPlan(evs, 3, 0, false, epoch), [{ unit: 1, secs: 60 }], "a tool fill at 3 re-rendered 3..4: the turn's reply at 4 is fresh; only the previous turn's reply is patched");
+  assert.deepEqual(workedFooterPlan(evs, 1, 0, false, epoch), [], "everything from 1 was rendered: nothing to patch");
+  assert.deepEqual(workedFooterPlan(evs, 0, 0, false, epoch), [], "a rebuild from 0: nothing before it");
+});
+
+test("plan: exactly one reply is named, and none below the rendered window's start", () => {
+  const evs = [user(0), reply(10), user(20), reply(30), user(40), reply(50), user(60), tool(65), reply(70)];
+  assert.deepEqual(workedFooterPlan(evs, evs.length, 0, false, epoch), [{ unit: 8, secs: 10 }], "the earlier turns' replies are complete already; the tool at 7 is not its turn's last reply");
+  assert.deepEqual(workedFooterPlan(evs, evs.length, 6, false, epoch), [{ unit: 8, secs: 10 }]);
+  assert.deepEqual(workedFooterPlan(evs, evs.length, 9, false, epoch), [], "the reply is outside the rendered window");
+  assert.deepEqual(workedFooterPlan([user(0), reply(10), user(20)], 2, 2, true, epoch), [], "…and so is the one a landing prompt completed");
+});

--- a/ui/webview/worked-footer.ts
+++ b/ui/webview/worked-footer.ts
@@ -1,0 +1,52 @@
+// The "worked …" footer's rule, pure: which reply carries the footer, and how long it says.
+//
+// A reply's footer depends on LATER events — the turn has to be complete (a genuine human prompt landed
+// after it) or the session idle — which made it the one thing on a rendered turn that a later event could
+// change without the kernel naming that turn in a chatTail. The chat's tail path re-renders exactly the
+// events the kernel names as changed (render.ts syncViewInner), so the footer is patched by unit from this
+// plan instead of a trailing window re-rendered on every tail.
+export interface WorkedEvent { kind: string; human?: boolean }
+export type Epoch<E> = (ev: E) => number | null;
+
+/** Seconds the session worked on the prompt that reply `i` answers, or null when `i` carries no footer:
+ *  a prompt itself; a reply that is not its turn's last (a later reply exists before the next genuine
+ *  prompt); the final turn while the session is still working (the live spinner owns it); no clock on
+ *  either end. The elapsed runs from the IMMEDIATE trigger — the most recent user-role line of ANY author
+ *  (a nudge or a postal push that prompted the work, not the older human prompt: the user 2026-06-22, who
+ *  saw "worked 23m" on a two-minute-old nudge) — to the reply's own stamp. Injected user lines (a postal
+ *  push, /command stdout) belong to the same turn: the scan for the turn's end skips them. */
+export function turnWorkedSecs<E extends WorkedEvent>(events: readonly E[], i: number, working: boolean, epoch: Epoch<E>): number | null {
+  const ev = events[i];
+  if (ev.kind === "user") return null;
+  let completed = false;
+  for (let j = i + 1; j < events.length; j++) {
+    const e = events[j];
+    if (e.kind !== "user") return null;
+    if (e.human) { completed = true; break; }
+  }
+  if (!completed && working) return null;
+  const end = epoch(ev);
+  if (end == null) return null;
+  let start: number | null = null;
+  for (let j = i; j >= 0; j--) { const e = events[j]; if (e.kind === "user") { start = epoch(e); break; } }
+  if (start == null) return null;
+  const secs = end - start;
+  return secs > 0 ? secs : null;
+}
+
+/** The footer to reconcile after a tail re-rendered events [from, len): the one reply BEFORE `from` whose
+ *  footer the tail can have changed, and its seconds — null when it carries no footer now. That reply is the
+ *  last non-prompt event before `from`, when it sits inside the rendered window (at or past `winStart`).
+ *  No earlier reply can change: before `from` it is followed either by a non-prompt event (never a footer,
+ *  before or after the tail) or by a genuine prompt (its turn was already complete, and a complete turn's
+ *  footer reads nothing past that prompt). The tail changes that one reply's footer in four ways: a prompt
+ *  landing completes its turn (the footer goes on); the session going idle with an empty suffix (`from` =
+ *  len) completes it too; a reply landing in the same turn demotes it (the footer comes off, the new reply
+ *  having been rendered with its own); the session going back to work on the same turn — a nudge, say —
+ *  takes it off again. Replies at or past `from` were just rendered with their footer and are not named. */
+export function workedFooterPlan<E extends WorkedEvent>(events: readonly E[], from: number, winStart: number, working: boolean, epoch: Epoch<E>): Array<{ unit: number; secs: number | null }> {
+  for (let j = Math.min(from, events.length) - 1; j >= Math.max(0, winStart); j--) {
+    if (events[j].kind !== "user") return [{ unit: j, secs: turnWorkedSecs(events, j, working, epoch) }];
+  }
+  return [];
+}

--- a/vscode-extension/src/feed-fly.test.ts
+++ b/vscode-extension/src/feed-fly.test.ts
@@ -44,14 +44,21 @@ test("flyColumnChanges FLIPs any moved card (not new cards / non-movers); only c
   // in the read pass and carried to the write pass — feed-flip.test.ts pins the read-then-write order)
   assert.match(FEED, /crossed: prev\.col !== colEl\.id/);
   assert.match(FEED, /if \(crossed\) c\.classList\.add\("fitem-flying"\);/);
+  const fly = FEED.slice(FEED.indexOf("function flyColumnChanges("), FEED.indexOf("// ── Absorb:"));
+  const at = (s: string) => { const i = fly.indexOf(s); assert.ok(i >= 0, "present: " + s); return i; };
+  assert.ok(at("moves.push(") < at("c.style.transform ="), "every read (into `moves`) precedes the first write");
+  assert.equal((fly.match(/getBoundingClientRect/g) || []).length, 1, "one read per card, all in the read phase");
+  // The fly's ends — transitionend, transitioncancel, the 650 ms backstop — its per-element ownership token
+  // and `played` guard, the release frame's stand-down, the zero-rect skips at either end (a folded column)
+  // and the back-layer class coming off whichever fly added it are BEHAVIOUR, run under a DOM stand-in in
+  // ui/webview/feed-render-incremental.test.ts; they are not pinned as source text here.
 });
 
 test("FLIP: invert to the old spot instantly, then release with a transition (two rAFs)", () => {
   assert.match(FEED, /c\.style\.transition = "none";\s*\n\s*c\.style\.transform = `translate\(\$\{dx\}px, \$\{dy\}px\)`;/);
   assert.match(FEED, /requestAnimationFrame\(\(\) => requestAnimationFrame\(\(\) => \{[\s\S]*?c\.style\.transform = "translate\(0, 0\)";/);
-  // cleans up on transitionend so the card returns to normal flow + stacking (the back-layer class only on a crosser)
-  assert.match(FEED, /ev\.propertyName !== "transform"/);
-  assert.match(FEED, /if \(crossed\) c\.classList\.remove\("fitem-flying"\)/);
+  // (how the fly ends, and that the card returns to normal flow and stacking whichever fly added the class,
+  // is run in ui/webview/feed-render-incremental.test.ts — see the note above)
 });
 
 test("respects prefers-reduced-motion", () => {


### PR DESCRIPTION
Eight browser-side performance changes to the dashboard panes, one commit each, ordered by dependency, with the review commit ninth on the branch (see Review commit below the list): how the federation layer delivers a merged frame to a pane (1); the view-delta shim's lane identity (2); three cuts in the chat pane's render path (3-5); and the feed pane's repaint gate (6) with the two changes that keep the feed correct once it stops rewriting every card on every push (7, 8). They are one PR because they share a chain: commit 1 edits the frame-handler lines the pane telemetry (#1009, on main) wraps, commit 6 adds a latch re-arm inside the handler commit 1 installs, and 7 and 8 depend on 6. Each is separable; dropping a commit leaves the ones before it whole. Browser-only except the kernel's inline timeline boot (1), the shim's delta JavaScript (2) and the review commit's kernel replies (a refused revive, manual retry or quarantine verdict now answers the pane that asked). The performance counters (#1003) and the pane telemetry (#1009) are on main; this PR wires no collector and adds no telemetry row. Every line below names its measurement and how it was taken. A figure from the fork this was ported from is labelled as such and was not re-measured here unless the line says so.

## Commits

1. **Federation hands its merged frames to a pane by direct call, dispatching on window only when nothing registered.** Blink hands a same-world `message` listener the event's data object itself, but a listener in another JavaScript world (a browser extension's content script) that reads `event.data` receives a structured clone of the whole frame, made synchronously inside `window.dispatchEvent`; federation re-emitted every merged `feed`, `tabOrder`, `data` and `bars` frame that way. `FederationManager.onFrame(handler)` (published as `window.__rompFed.onFrame`; returns an unsubscribe) and `emit()` call the registered handlers directly over a snapshot of the list and dispatch on window only when nothing registered, so an older pane bundle keeps working; a throwing handler is reported and the rest still run. Each pane installs the same perf-wrapped handler on window and in the registry through a new import-free `frame-listener.ts`, and the kernel's inline timeline boot registers the same way; #1009's pane-wrap pin in `perf-telemetry.test.ts` is re-spelled for the helper install, and `outline-visibility.test.ts`'s payload-applied case slices the board pane's handler at the same install. Every other frame (passthrough, `closed`, `hostUp`, `warn`, the shell's posts) stays on window. Measured on the fork this was ported from with a Chromium probe (an isolated-world listener reading `event.data`, one 6.7 MB feed frame): `fed:feed` 61.3 ms and +9.6 MB heap per frame before, 0.15 ms and no heap growth after; that deployment's telemetry had put the federation bracket at 15-25 ms per feed push in every feed-consuming pane and about 40 ms per `bars` frame. Not re-measured here: the probe is not committed and a headless run has no foreign listener, so CONTRIBUTING gains the reproducible check (a timed dispatch of a 150k-object MessageEvent in the feed iframe's console). Without a foreign listener the change is neutral.

2. **The timeline delta shim keeps an untouched lane's array across a delta.** `applyDelta` rebuilt every lane's `turns[sid]` array on every bars delta, so the pane had no identity to key a per-lane cache on. It now computes the touched lanes (the lane prefix of each set/del key, plus the lanes whose key subsequence differs when the frame carries an order) and hands an untouched lane the very array the previous message held. Removes one array allocation per lane per bars delta; the assembled value is unchanged (the existing reassembly test pins it frame by frame). No timing claimed; no cache is built here.

3. **Chat: fence highlighting is cached by language and source.** `highlight-cache.ts` keeps the highlighted HTML by (language, source), bounded by 256 entries and about 4 MB of output; a source over 64 KB is highlighted but never kept; a labeled fence still goes to its grammar and an unlabeled one to full auto-detection. Measured on this branch (node 22, one 40-line Python fence of 2138 characters, the ten grammars render.ts registers, three runs): `hljs.highlightAuto` 4.0-4.4 ms per call over 300 iterations, `hljs.highlight` with the language named 0.50 ms, a cache hit 0.004 ms over 200,000 iterations. In one deployment's profile that auto-detection was 63% of a compact-mode tail. The chat has no replay row in the pane bench.

4. **Chat: an unchanged tab strip is not rebuilt; a signature of every input it paints decides.** `renderTabs` rebuilt every tab node and read every `offsetTop` (a forced layout) on each kernel push. It now computes a signature of every input it paints (active and peek tabs, ids and visible ids, active-in-view, the strip plan from #1007's `planStrip` — each section's tag, color and members, whether it is folded or holds the active tab, and the members its folded header stands in for — and per visible id the placeholder meta or name/color/state/tab class/faded/context/tint/viewer flag/host-down mark and note, the gauge setting, theme and colormap, the + tab's key hint, the tag lens and unions) and returns before the wipe when equal. The plan is computed once ahead of the signature and the folded set it yields is published before the skip, since keyboard cycling reads it whether or not the strip rebuilt; the focus capture (a focused header or tab) moves below the skip with the wipe. A tab drag resets the signature; a group drag does not (it moves no node, and its drop is a views write the plan reads). The tooltip looks the session up fresh, the placeholder and all-hidden blank reconcile on both paths (`stripAftermath`), and the state-to-class rule is `tab-state.ts`'s `tabStateClass` (#1007), read by the paint, the folded header's pip and the signature. Measured in one deployment's browser telemetry on its own tree (33 tabs): about 1500 of 2554 chat tails in an hour went to inactive tabs at a 2-4 ms floor each; the signature took 0.018 ms. Not re-measured here (no chat replay row). Any strip input added later must join the signature; `tab-strip-skip.test.ts` is the list.

5. **Chat: a tail re-renders exactly from the kernel's first changed event, and the worked footer is patched by unit.** The normal-mode tail path re-rendered the last 25 events on every chatTail (`TAIL_RECHECK`) in case an earlier one had changed in place. The kernel names the index exactly (`_chat_diff` compares by identity first, then equality; no event is written in place; chatTail carries it as `from`), so the tail now starts there. The three signals that window stood in for are explicit: the rewind pass (`rewind-reconcile.ts`, pure; render.ts's `reconcileRewind` delegates to it) marks the view stale only when the editable set or rewind overlay below the tail start changed (chatTail passes `from` as the bound; every path reaches the comparison); a full frame for a held session or a wholesale events replacement marks the view stale (not the frame that replaces nothing: a session frame with no events for a session that has them, which the pane has kept as status-shaped since #1049, leaves the view as it is); and the one render that depends on later events, the "worked …" footer on a turn's last reply, is patched by unit from `worked-footer.ts`, whose plan names exactly one reply (the last non-prompt event before `from` inside the window), also on a status-only tail through the view's remembered working state and in compact mode through the display items. Saving: at least 25 fewer `renderEvent` calls per normal-mode tail paint by construction (for an append, the new events alone); since #996's `scheduleAppendActive` the active tab's tails are coalesced into one paint per animation frame, so the saving applies to each paint. No harness executes `renderEvent` (the review commit's `chat-exact-tail-exec.test.ts` runs `chatTail` with the render stubbed), so the count was not re-measured.

6. **Feed pane: a card repaints only when its object or a board-level input it reads changed.** Since #934 an unchanged paint key skips the repaint, but two terms in that key still repainted the whole board of a pane on screen (a pane the paint gate from #1016 holds does not paint at all): a 15 s clock, so the first frame in every window repainted every card and the scroll restore then forced one layout of all of it; and an epoch bumped by any session's state change or settings write. The key itself was a `JSON.stringify` of every card per render. `feed-card-gate.ts` replaces it: a card repaints when its object identity changed (the shim's delta reassembly and federation's merge hand unchanged cards through by reference, both pinned) or when one string of the board-level inputs its face reads changed (dot, handoff recipients' working state, tracked peers' dots, hover and pin, the bell, grouped/collapsed/colormap, host reachability, the self host, and the card's colour because the echo writes it in place); a quarantine card never skips. A refused bell toggle (#1020's `settingRefused` frame) releases the latch and repaints that card alone. Column placement, the order walk and cross-column removal stay unconditional; `flipNeeded` is untouched. Two consequences of no className rewrite: Undo strips `.dismissing` from a card restored inside its 180 ms collapse (latent since #934), and a card-face latch (Retry, Revive, Approve/Deny, Continue) re-arms on the kernel's reply for its own request (`rearmLatches`; the review commit made every refusal name the request it answers, see Contracts changed) or on a repaint of the card; the card's Retry sends `manual: true`. Measured with the pane bench, commit 5's build against this commit's alone, on the pre-rebase tree (base 564000ec, before the paint gate; the replay keeps the pane on screen, where the gate does not hold): delta handler p50 16.7→14.5 and 17.9→12.6 ms over two alternating pairs, first content frame unchanged within noise; the three feed commits together are in Measurements.

7. **Feed pane: ages and durations are stamped and moved by a compare-first 15 s pass on the kernel's clock.** Every age and running duration on a card face (the time label, the awaiting box, the Awaiting-task pill, the waiting-on chip, the working narration, the per-paragraph ages) is a stamped element (`feed-age.ts`), moved by one 15 s pass on the kernel's clock (the frame's `now` plus local elapsed, from the `(now, nowAt)` pair federation already stamps) that compares before every write and skips a pane the paint gate holds (#1016's two measures: the tab hidden, or `#feed-list` off screen by the observer's word), catching up once on the event that shows it; `spinFor` returns a caption's duration as a separate part; the grouped-mode headers write their labels through the same compare-first rule. The old tick, which rewrote every card's label from the browser clock, is gone. Measured on the fork this was ported from, as context: that tick cost 69-119 ms of style and layout per tick on an 800-card board for the 2-13 labels that changed. The back-to-back replay does not exercise the tick; the DOM grows by the stamped duration spans (+554 elements on the 800-card stream). In the paced replay (63 s, four ticks) the base's tick is a `setInterval` attribution row of 42 and 34 ms over the four ticks and the head's does not reach the report's listing threshold; cumulative layout time falls from 1372 and 750 ms to 426 and 397 ms with the layout count unchanged.

8. **Feed pane: a fly ends on transitionend, transitioncancel or a backstop, one fly owns an element, and headers mint their name nodes only on change.** Three things relied on the per-render className rewrite commit 6 removed. The fly skips a folded column's zero rect at either end, ends on `transitionend` or `transitioncancel` with a 650 ms backstop, and one fly owns a card at a time (a per-element token and a `played` guard), so a second delta mid-glide no longer snaps the card or leaves it in `fitem-flying` with pointer events off; the reveal pulse comes off on its own `animationend` (not a child's) or a 1500 ms backstop, one handle per element; a session header's name nodes are minted only when the name, sid or host link state changes, and `data-fsid` is written only when it differs. The FLIP gate stays upstream's board-wide `flipNeeded`. Robustness only; no timing figure.

9. **Review fixes: a refused revive re-arms its button, every latch re-arms on its own reply, kernel-text pins leave the TypeScript lane, the exact-tail wiring runs.** The review commit (b9087b45), not one of the eight: the kernel's refusals name the request they answer and the feed re-arms only that latch; the tests that read kernel.py from TypeScript move to the Python lane; `chatTail` and `patchWorkedFooters` are lifted and run.

**Review commit.** The review commit changes the latch contract, moves two tests between lanes and adds an executed test for the chat tail; the tab strip it leaves as is. Every card-face latch (Retry "Retrying…", Revive "Reviving…", Approve/Deny "Delivering…", Continue "Sent") re-arms on the kernel's reply for ITS request, never on a clock and never every latch: the kernel's `reviveFailed` reaches the asking dashboard's feed as well as its chat (`_revive_session`), and the feed re-arms the parked card's Revive by the revived id (the card's own sid) and toasts the reason; `_refuse_drive`'s `err` names `op` and `itemId`; a refused MANUAL `apiRetry` answers `retryRefused` (`_fire_api_retry` returns the send's verdict, `_drive` sends it); a refused quarantine verdict answers `quarantineRefused` by mid where it was a bare `warn` (`Handler._dispatch_ws`); the feed routes each reply to the one latch (Retry by sid, Approve/Deny by mid, Continue by itemId, whose predicted move yields to the refusal in `revertFollowMove`); an `err` naming a session and no request releases that session's Retry and Revive as before, one naming neither releases nothing. Tab strip: no change; the rebased head's signature already carries the plan's items and the unions, and `tab-strip-skip-exec.test.ts` drives the sectioned inputs. Tests: `chat-exact-tail-exec.test.ts` lifts `chatTail` and `patchWorkedFooters` out of render.ts and runs them, `chat-exact-tail.test.ts` keeps only the pins nothing lifts; the kernel-text pins leave the TypeScript lane (the timeline boot's registration is pinned and run under node in `tests/test_kernel_timeline_split.py`, the shim's card identity across a feed delta in `tests/test_view_deltas.py`), so `federation-direct-delivery.test.ts` and `feed-card-gate.test.ts` no longer read kernel.py. The details are folded into the sections below.

## Rebased onto main (66bb933e, 2026-09-08)

The branch is on main at 66bb933e, after #1059, #1075, #1092 and #1091. Commits, oldest first: 4a35b783 (1), bf7c03f1 (2), 1f50d985 (3), efd82d56 (4), 4266fab1 (5), 9c92420f (6), 1c649f88 (7), 9f0e222f (8), b9087b45 (the review commit). Nothing was dropped; every commit keeps its author and message, and `git range-diff` against the previous head (31161251, on main at 76f325d0) shows one commit changed, commit 4, in the two hunks below.

- **Commit 4 against #1091 (a session under several tags has a tab copy in every group).** Both sides add code after `collapsedTabIds = plan.folded` in `renderTabs`: this PR's signature, skip and focus capture come first, then main's `copyGroup` declaration ahead of the loop; and main's `draggedEl = tab` sits on the dragstart line beside this PR's `tabStripSig = ""` reset. The signature needs no new term: the copies, the `data-copy` group each tab wears and the ✕ tip's copy count all derive from `plan.items`, which the signature already carries, so a tag added to or removed from a session repaints the strip once through the plan. `tab-strip-skip.test.ts`'s dragstart pin is re-spelled for `draggedEl`; `tab-strip-skip-exec.test.ts` runs main's `planStrip` as is.
- `kernel/kernel.py` and `docs/reference.md` (#1059's store memos, #1092's usage modal, #1075's views read) merged without conflict; they touch none of this series' hunks.

The rebase that carried the review commit (onto main at 76f325d0, after #1060 to #1093) is described in that commit's message: import adjacency in render.ts, feed.ts and the board pane's entry file (main's pr-links imports beside the frame-listener and feed-card-gate imports, both kept), `import time` beside shutil and subprocess in `tests/test_kernel_timeline_split.py`, the feed card gate reading the session's GitHub repository (`prRepoOf`, #1004) as a board-level input, and the name-claim refusal in `_revive_session` sending its `reviveFailed` to the asker's feed as well as its chat. #1087's row break ahead of each group header rides commit 4's loop unchanged.

On the rebased head (b9087b45): `cd vscode-extension && npm run typecheck` clean, `npm test` 3576 tests, 3576 pass; `pytest tests/ -n 8` 9718 passed, 47 skipped, 1670 subtests passed, 8 failed, all in `tests/test_kernel_deferral_sweep.py`, a module this PR does not touch, which passes alone (12 passed); its failures under the parallel run are load-sensitive on the machine that ran it.

Before these, the branch was rebuilt twice: first after #1003, #1009, #1016, #1019, #1020 and #1024 merged, then onto the main at e9eb27ff that carries the tab groups (#1007, #997, #1037, #1039), the empty-build fix (#1049), the mid-turn send placement (#1044), the chat scroll changes (#1036, #1040), the live-omission fix (#1063) and the restart and tag-updater work (#1027, #1031). The second of those dropped nothing; two commits were reworked and one re-verified:

- **Commit 4 is re-derived on upstream's sectioned strip.** #1007's `renderTabs` paints a strip planned by `tab-groups.ts` (`planStrip`: one header per home tag with its chip, count, fold state and a member-derived pip; a focused header is refocused after the rebuild) and reads the state-to-class rule from `tab-state.ts`. The signature now includes the plan's items and the unions beside the per-tab inputs; the plan is computed once ahead of the signature; the folded set is published before the skip (keyboard cycling reads it on both paths); the focus capture moves below the skip with the wipe, and the tail restores focus by upstream's header-or-tab rule before `stripAftermath`. The render.ts-local `tabStateClass` this PR used to add is gone (`tab-state.ts`'s rule serves the paint, the header's pip and the signature), so the three test files it re-pinned (`apierror-refusal`, `apierror-spend-limit`, `retrying-state`) are no longer touched; upstream's pins on `tab-state.ts` stand. A group drag needs no signature reset: its dragover only marks a drop target, and the drop is a views write the plan reads. `tab-strip-skip-exec.test.ts` runs the real `planStrip`, `parseTabGroups`, `headWords` and `tabStateClass` and adds a sectioned world (12 inputs each repainting once, the folded set holding across a skip, the paint wearing the shared class).
- **Commit 5 follows #1049's keep decision.** The pane never takes an empty session frame as a transcript wipe (`kept = keepResidentEvents(prev.events, msg.events)`), so the upsert's stale mark is `else if (existed && !kept)`: when the frame carried no events for a session with content, the resident events stand, nothing was replaced, and a status-shaped frame must not force a window rebuild. `chat-exact-tail.test.ts` pins the guard and the keep decision preceding it. Checked against #1036/#1040 (the scroll keep is `showActive`/`landActive`, orthogonal to `syncViewInner`) and #1044 (`reconcileOptimistic` now places optimistic bubbles mid-transcript, and a slot change marks the view stale, so the premise that every client pass touching a prefix marks the view stale holds).
- **Commit 1 applies with context only.** #1007's `caps`/`unknownOp` lines sit above the kernel's inline boot hunk; after #1035's and #1063's federation changes every merged-frame emission (`emitMergedFeed`, `emitMergedOrder`, `emitMergedTimeline`) still routes through `emit()`, and passthrough, `closed`, `hostUp` and `warn` stay on window.
- #1041, #1042 and #1065 (the test conftest) and #1027 and #1031 (restart, tag updater) touch nothing this PR reads.

From the first rebase, still in force:

- A ninth commit, a federation-level hold that withheld a hidden pane's merged frames until the pane showed, was dropped. #1016 solves the same problem at pane level with the opposite principle (every payload is applied on arrival; only the paint is held: `paint-gate.ts` in the feed and Outline panes, `_hiddenForPaint` in the timeline view, the shim coalescing whole frames), and this branch keeps to it. Its one distinct piece, an observer-keyed `window.__rompPaneHidden` for the shim's stale-banner gate and the telemetry, has no consumer left here; it can come separately if wanted.
- Commit 6's shim-in-vm pin, which the first rebase re-stubbed (`MessageChannel` and `performance`, the way `pane-shim-stale.test.ts` does) because #1016's shim hands frames to the bundle through a MessageChannel-flushed queue, is gone with the review commit: the by-reference check runs in `tests/test_view_deltas.py` against the shim's own delta functions under node, so no TypeScript test reads kernel.py. Commit 6's 15 s clock-term premise is qualified to a pane on screen.
- Commit 7 keys its live pass on the paint gate's two measures and catches up from the observer's callback, so the feed has one definition of "hidden" (no zero-viewport probe beside the gate); `feed-hidden-paint.test.ts`'s gate count names the pass as the second paint the gate decides.
- Commit 6 re-anchors #1020's `setting-refused.test.ts` pin to the gate's `notifyOn` input (the latch reaches the paint decision through `cardNotifyOn`); commit 5 keeps #1026's `ro` field on the View interface and its `disconnect()` on the forked-view removal line; commit 1's `outline-visibility.test.ts` pin follows the helper install.
- #1019 (goal-store quarantine) and #1024 touch nothing this PR reads.

## What changes for a user

Mostly nothing visible. Invariants: a frame reaches a pane exactly once, on the same call stack, as the same MessageEvent shape, carrying the merge's own objects; the assembled timeline value is unchanged; a fence's highlighted HTML is unchanged; the strip paints identically whenever any input changed; the chat renders the same events. What is visible:

- Feed: the awaiting box, the Awaiting pill, the waiting-on chip, the working narration and paragraph ages advance every 15 s on the kernel's clock even when no frame arrives, instead of advancing only on a repaint and from the browser's clock (7). Retry sends `manual: true`; Retry, Revive, Approve/Deny and Continue re-arm on the kernel's reply for that click, or on the card's repaint, rather than on any push (6, the review commit). What a refusal now shows in the feed: a Revive the kernel cannot perform re-arms the parked card's button and toasts the reason (before, only the chat pane heard `reviveFailed`, so the feed's button stayed "Reviving…"); a manual Retry the backend cannot deliver re-arms and toasts (before, nothing answered); a refused Approve/Deny re-arms both buttons and toasts (before, a bare `warn` the feed did not handle, so both stayed disabled); a refused Continue re-arms and puts the card back where the payload says at once, rather than after the no-answer backstop. Undo inside a card's 180 ms collapse keeps the card (6). A card that flew into or out of a folded column no longer sticks with its pointer events off, a second delta mid-glide no longer snaps it, and the reveal pulse ends (8).
- Feed: cards below a card whose height changed snap into place instead of gliding (the passes key on membership and order), and the border colour fallback for a colourless session ages only on repaint (8).
- Chat: the "worked …" footer on a turn's last reply appears and disappears as before; only how it gets there changed (5).

## Tests

Each of the eight commits' tests were written first and run red on the code before it, then green after. The behavioural tests added on the rebase were each checked against a mutation of the line they cover (red on the mutation, green on the commit); where a behavioural test now covers a claim, the source-text pin for that claim was removed. The review commit's tests are listed with the items they extend (1, 2, 5, 6).

1. `federation-direct-delivery.test.ts` (14 cases since the review commit, the real manager over a stand-in window): identity of the delivered objects, the no-registration fallback, the frames that stay on window with a detach's hostDrop `closed` frames and an undeliverable send's `warn` driven through `closeRemote` and `sendRemote`, unsubscribe, snapshot iteration, report-and-continue on the detach path with the console left alone when `reportError` exists, the storage re-emit through `start()`, the helper, and the pin that every pane installs through it; `perf-telemetry.test.ts`'s new case and re-spelled pane-wrap pin; the follow-move, heal-on-hostup and outline-visibility pins. The kernel's inline boot is the Python lane's: `tests/test_kernel_timeline_split.py` pins its registration and, since the review commit, runs it under node in a bare vm context (its one window listener is the wrapped one, the registry gets that same function, a frame through it reaches the panel); the two cases that read kernel.py from the TypeScript file are gone. When commit 1 was written, with only the type and `reportListenerError` export in place so the file bundles, 3 of its then 14 cases passed and 11 failed.
2. `tests/test_view_deltas.py::ShimDecoderMatchesTheKernel`: the identity test (grow, change, empty-to-marker, within-lane reorder, new lane; before, `(same, renewed) == ([], [S1, S2, S3])`) and a del-only test (three deltas that each retire a bar with no `set` and no `order`; the shrunken lane is renewed and carries the shorter array, the case where the untouched-lane branch would otherwise hand the pane a stale array). Module: 31 passed at commit 2; the review commit adds the feed-card identity check to the same class (`test_e_untouched_feed_cards_keep_their_object_identity_across_a_delta`, under 6 below), 32 tests in the module.
3. `highlight-cache.test.ts` (6: tokenize-once, the shared unlabeled entry, the entry and size bounds, the never-kept large source, and the module-level cache holding across calls made with no cache argument, render.ts's) plus the re-pinned `codeblock-copy.test.ts`.
4. `tab-strip-skip-exec.test.ts` (10) lifts `renderTabs` and `stripAftermath` out of render.ts, transpiled at run time, and runs them over a fake element tree with the real `planStrip`, `parseTabGroups`, `headWords` and `tabStateClass` imported: an unchanged strip is not rebuilt across three renders while the aftermath runs each time; each of 24 flat-strip inputs and 12 sectioned-strip inputs (a fold, a hidden member's state and name, a pin, the tag's color, membership, group order, the active tab's section, a provisional tab's tags, sectioning off, the phone layout) repaints the strip exactly once when it changes and not again; the folded set holds across a skip; the paint wears the shared state class; a render held by the pressed-tab or rename guard is painted on release; the drag reset; the fresh tooltip lookup; the mobile slot's once-only mount; the all-hidden blank on the skip path. `tab-strip-skip.test.ts` (4) pins the shape (the signature ahead of the wipe, the plan and the folded set ahead of the skip, the input list with the plan, theme and colormap named, the tab drag reset and the group drag's lack of one, the fresh lookup, the two-path aftermath); the tooltip pin moves to the fresh lookup.
5. `worked-footer.test.ts` (8 executed cases, including a non-positive elapsed carrying no footer); `rewind-reconcile.test.ts` (8) executes the rewind pass: the editable set, the overlay and a bare delete, a pending edit's retirement by TTL and by the branch landing, and the stale signal (a compaction at `from` and a retirement on a full or a partial tail mark the view stale; a plain prompt append and an unchanged re-pass do not); `chat-exact-tail-exec.test.ts` (11, the review commit) lifts `chatTail` and `patchWorkedFooters` out of render.ts, transpiled at run time the way `tab-strip-skip-exec.test.ts` lifts `renderTabs`, and runs them: the exact `from` with the rewind pass bounded there, the shrunken-tail and scrolled-away-window rebuilds, the gap ask for a full session, the optimistic strip before the delta applies, a status-only tail's awaiting-box rule, and the footer's add, remove and re-homing of the fork spot by unit, the from = len completion, the day-divider skip, and compact-mode units with a folded reply marking the view stale. `chat-exact-tail.test.ts` (6) keeps the pins nothing lifts: the exact `from` in `syncViewInner`, `reconcileRewind`'s delegation and stale signal on every path, the upsert/update stale marks with the upsert's `!kept` guard behind #1049's keep decision, the render and the patch sharing one elapsed rule, and the status-only flip from the fast path. chat-windowing, rewind-edit and rewind-delete update their pins.
6. `feed-render-incremental.test.ts` boots feed.ts under a plain-object DOM stand-in: three cards built once; a re-sent card alone repaints and moves column; an identical re-dispatch rebuilds nothing and reads no rects, across a 15 s boundary too; one session's working change repaints only its card; a changed session order moves the cards with no repaint; the Revive latch re-arms on the kernel's `reviveFailed` for the revived session with its idle label restored and the reason toasted, while a re-emit, another session's failure and an `err` for a different request leave it; the bell's optimistic state is a paint input and a refused toggle (`settingRefused`) repaints that card alone; the grouped pref repaints every card once through `feedPrefs`; a quarantine card follows a re-coloured sender though its own object is unchanged; a handoff recipient's working state and a remote host's link state each repaint the one card that reads them; the colour echo repaints once; Undo inside the collapse keeps the card; the Retry latch re-arms only on its deciding events (an `err` naming this session's `apiRetry`, the kernel's `retryRefused`, an older kernel's `err` naming the session and no request, or a repaint; not another session's reply, a reply naming no session, or this session's reply to a different request); Approve and Deny latch together and re-arm on `quarantineRefused` for that held message's mid with the reason toasted, another message's refusal leaving them; Continue latches, predicts the move, and on the kernel's refusal of that card's post re-arms and returns the card to the column the payload names, another card's refusal leaving both. On the base: frame C (rc 2 vs 3 under #934's key), the 15 s boundary, frame D, Undo and Retry are red. `feed-card-gate.test.ts` (7: six pure cases and the federation push pin; since the review commit the shim's by-reference reassembly runs in `tests/test_view_deltas.py` under node against the kernel's own frames, one card moved and the two untouched cards the same objects); `feed-flip.test.ts` (its latch pin re-anchored to the per-request routing: an `err` naming `apiRetry` releases Retry by sid, `reviveFailed` releases Revive by id), `feed-cap-offer`, `feed-card-prefs` and `setting-refused` re-pinned. Kernel side, the review commit: `tests/test_kernel_revive.py` (a failed revive reaches the asking dashboard's chat and feed, one notice to both), `tests/test_kernel_apiretry.py` (`ManualRetryRefusal`: a refused manual retry answers `retryRefused` by session, a delivered one answers nothing, a refused auto retry stays silent), `tests/test_kernel_trust.py` (`QuarantineRefusal`: a refused verdict answers `quarantineRefused` by mid and dirties no view, an accepted one answers nothing and rebuilds the views), `tests/test_drive_foreign_sid.py` (the `err` names its `op` and `itemId`).
7. `feed-age.test.ts` (9: a same-`now` pass writes nothing, a minute-boundary pass writes exactly the crossers, the "dur" stamp, `liveRefresher`, the tint compared against a shadow of the value written when the style re-serialises it, and a source pin that every card-face age is stamped and read through `nowSec`); `spin-caption.test.ts`; `feed-render-incremental.test.ts` runs the pass with mock timers: the age label and the duration each move once at the minute they cross with one write each, a pass at which nothing crossed writes nothing, a pane the gate holds by either measure skips the pass and catches up once when shown; the grouped-mode headers' labels are written compare-first; the Awaiting-task pill's and waiting-on chip's durations, the per-paragraph ages (an unstamped paragraph never written) and the group card's time each move once at the crossing and are left alone otherwise; the latched Continue's title is refreshed once the payload carries the latch, compared before every write. Before: `feed-age.test.ts` could not bundle against the old module, `spin-caption` 27/31, awaiting-swirl 5/8, awaiting-box-sync 4/5, brief-parts 6/8, feed-counts 3/4, feed-thread-fold 6/8.
8. `feed-render-incremental.test.ts` fly, folded-column, superseded-fly, reveal-pulse and header cases: the backstop takes a card out of the back layer; a card moving into or out of a folded column gets no fly; a second fly keeps its Invert through the first's cancel and outlives its backstop; a fly ends on its own `transitionend` and not another property's, and on a `transitioncancel` after its Play; the release frame stands down once the backstop has ended the fly; the back-layer class comes off a superseded crossing fly's card when the in-place fly that replaced it settles; a pulse ends on its own `animationend` and not a child's, a second pulse outlives the first's backstop, and a pulse ended by its `animationend` leaves no backstop behind; a header's `data-fsid` is written only when it differs; an unchanged header re-mints no name nodes, a renamed session's re-mints once, and a header re-mints when its host's link goes down or comes back and only then. `feed-fly.test.ts` keeps its structural read-before-write pin and points at those runs.

On the head as posted (6606184b, commit 8, before the review commit): `cd vscode-extension && npm run typecheck` clean and `npm test` 3395 tests, 3395 pass (the base 3284; each commit's tree in turn: 3301, 3301, 3307, 3321, 3343, 3366, 3382, 3395, all pass, typecheck clean at each). `pytest tests/ -n 8` 8715 passed, 47 skipped, 1403 subtests, 1 failed: `test_kernel_nudge_last_resort.py::StalledGoals::test_a_paused_tiers_record_retires_on_resume`, in a module this PR does not touch, a load-sensitive test on the machine that ran it; the module passes alone (34 passed). The review commit adds 15 TypeScript cases and removes 5 (`chat-exact-tail-exec` 11 new; `feed-render-incremental` three new and one replaced; `chat-exact-tail` one replaced; `federation-direct-delivery` two and `feed-card-gate` one moved to the Python lane) and 7 Python tests (`test_kernel_timeline_split` 1, `test_view_deltas` 1, `test_kernel_apiretry` 3, `test_kernel_trust` 2); the suite totals above are the posted head's and were not re-run for this body. Commands: `cd vscode-extension && npm run typecheck && npm test`; `pytest tests/test_kernel_timeline_split.py tests/test_view_deltas.py tests/test_kernel_disconnect_banner.py tests/test_pane_shim_return.py tests/test_client_diag_rotation.py tests/test_perf_stats.py tests/test_kernel_revive.py tests/test_kernel_apiretry.py tests/test_kernel_trust.py tests/test_drive_foreign_sid.py` (the modules that read the boot, the shim and the kernel hunks, the review commit's included).

## Measurements

| Commit | Before → after | How |
|---|---|---|
| 1 | `fed:feed` 61.3 ms and +9.6 MB heap per frame → 0.15 ms and no growth; the foreign listener saw no merged frame after | Chromium probe with an isolated-world `message` listener reading `event.data`, one 6.7 MB feed frame, on the fork this was ported from; not re-measured here (the probe is not committed; a headless run has no foreign listener). Neutral without a foreign listener. |
| 2 | one array allocation per lane per bars delta removed; identity of untouched lanes kept | no timing claimed |
| 3 | `hljs.highlightAuto` 4.0-4.4 ms per call; `hljs.highlight` with the language named 0.50 ms; cache hit 0.004 ms | this branch, node 22, one 40-line Python fence (2138 characters), ten grammars, 300 and 200,000 iterations, three runs. One deployment's profile: 63% of a compact-mode tail. |
| 4 | signature 0.018 ms against a 2-4 ms floor per background tail; about 1500 of 2554 chat tails in an hour to inactive tabs | one deployment's browser telemetry on its own tree (33 tabs); not re-measured (no chat replay row) |
| 5 | at least 25 fewer `renderEvent` calls per normal-mode tail paint | by construction; not counted (no harness executes `renderEvent`; the exec test runs `chatTail` with the render stubbed) |
| 6 alone | delta handler p50 16.7→14.5 and 17.9→12.6 ms; delta settle p50 501→430 and 579→345 ms; long-frame blocking 1114→989 and 1217→882 ms; script 803→649 and 809→606 ms; heap after GC 7.16→6.10 and 7.15→6.07 MB; first content frame handler 370→369 and 366→357 ms; DOM and layouts unchanged | the replay below, commit 5's build vs commit 6's build, two pairs in alternating order; measured on the pre-rebase tree (base 564000ec, before #1016's paint gate; the pane stays on screen in the replay, where the gate does not hold) and not re-taken on the current base |
| 6-8 together, back-to-back | over five alternating pairs, every pair down: delta handler p50 18.4-32.3 → 12.9-14.6 ms (-29% to -55%), delta handler p90 122-184 → 57-99 ms, long-frame blocking 1075-1636 → 874-1066 ms (-15% to -35%), script 837-1272 → 675-740 ms (-18% to -42%), heap after GC 7.0-7.1 → 6.0-6.4 MB (-9% to -15%), slow-frame rows 13-15 → 7-10. Mixed: delta settle p50 (two pairs down 39-57%, three up 3-35%, p90 down in four of five; back-to-back settle overlaps frames). Unchanged: first content frame handler 375-465 → 390-397 ms (-3% to +5%, except the pair whose base ran under a load spike), layouts 32-37 → 34-35. Cost: DOM 44,414 → 44,968 elements (+1.2%, the stamped spans). | headless Chromium 151.0.7922.34 replay (the pane bench, offered separately) of a synthesized 800-card feed stream, 32 frames and 841.6 KB (one 768.7 KB full frame, 24 `delta` frames of one to three changed cards with the working set changing every seventh, 7 keepalives), back-to-back (`--fast`), 3 iterations per replay, commit 5's build against commit 8's build served by the branch's kernel, on a shared machine, on the pre-rebase tree (base 564000ec). The 15 s tick does not fire in a back-to-back replay. |
| 6-8 together, paced | two alternating pairs, one iteration each: delta handler p50 43.9→36.1 and 34.4→29.1 ms (-18%, -15%); delta settle p50 103→88 and 75→72 ms, p90 266→254 and 216→133 ms; long-frame blocking 3240→1620 and 1574→950 ms (-50%, -40%); cumulative layout time 1372→426 and 750→397 ms with the layout count unchanged at 43 (as many layouts, each over a smaller dirtied tree); script 1711→1195 and 1255→881 ms (-30% both); heap after GC -18% and -8%; first content frame handler 610→404 ms (that base run's page start was slow, 552 ms to ready) and 428→414 ms. The base's 15 s tick appears as a `setInterval` attribution row of 42 and 34 ms over its four ticks; the head's tick does not reach the report's listing threshold. | the same stream at its recorded pacing (63 s), 1 iteration per replay, two alternating pairs, on the pre-rebase tree |
| 7 | 69-119 ms of style and layout per 15 s tick on an 800-card board for the 2-13 labels that changed | on the fork this was ported from; context only |
| 8 | none | robustness |

## Contracts changed

- `window.__rompFed.onFrame(handler)` is a new published slot. `emit()` iterates a snapshot, so a handler unsubscribed by an earlier handler in the same frame still runs once (dispatchEvent would skip it; nothing unsubscribes mid-delivery today), and a throwing handler is reported through `reportError` rather than surfacing as an uncaught listener exception whose stack names `dispatchEvent`. A VS Code webview has no federation.js and stays on the window path; mixed old/new pairs fall back to window.
- The shim's `applyDelta` keeps `turns[sid]` identity for untouched lanes; a consumer may key on it, and a consumer that mutated a lane array in place would now share that state across messages (the timeline pane does not).
- Feed repaint contract: under #934 a re-sent card with byte-identical content was not repainted (JSON key); under the gate it is (identity), bounded by what the kernel re-sends (`_delta_split` compares item JSON, so identical cards are not re-sent). A defensive copy anywhere on the shim or federation path would silently turn the gate into always-update; the shim's reassembly is run (`tests/test_view_deltas.py`) and federation's merge is pinned (`feed-card-gate.test.ts`).
- Latch semantics and the replies that drive them (the review commit): every refusal names the request it answers, and only the latch that made that request lets go. On the wire: `_refuse_drive`'s `err` carries `op` and `itemId` beside `sid`; a new `retryRefused {sid, text}` answers a MANUAL `apiRetry` whose backend send returned False (`_fire_api_retry` now returns the send's verdict, an explicit False being the only refusal; the auto path sends nothing, since no pane asked and the kernel's own tick asks again); a new `quarantineRefused {mid, text}` answers a refused quarantine verdict where a bare `warn` did (the feed is the only poster of that op); `reviveFailed` goes to the asking dashboard's feed as well as its chat (`_send_to_view` by wid). In the feed, `rearmLatches` takes a typed reply: `reviveFailed` releases Revive by the revived id (the parked card's sid and `blocked.toSid`), `retryRefused` and an `err` with op `apiRetry` release Retry by sid, `quarantineRefused` releases Approve and Deny by mid, an `err` with op `askFollowUp` releases Continue by itemId and reverts its predicted move (`revertFollowMove` puts the payload's own object back, so the gate repaints that card alone); an `err` naming a session and no request (an older kernel's) releases the session's Retry and Revive as before; one naming neither releases nothing. A latch still re-arms on a repaint of its card. The feed's `apiRetry` post carries `manual: true`; it toasts a revive's or retry's refusal only when a latch on that page was the one answered (the chat pane voices its own revives), and a quarantine refusal either way, being that op's only poster.
- `TAIL_RECHECK` is gone; the chat trusts chatTail's `from` as the exact first changed index (kernel precondition: `_chat_diff` identity-first then equality, no in-place event writes). The rewind pass is a pure module (`rewind-reconcile.ts`); render.ts keeps the session's editable set, the pending entry and the view mark.
- `renderTabs` skips on its signature: any new strip input must join it (`tab-strip-skip.test.ts` is the list, `tab-strip-skip-exec.test.ts` runs it). #1007's plan and #997's header inputs are in it, and #1091's copies ride the plan; the open #994 adds one (#1010 was closed unmerged). The state-to-class rule is `tab-state.ts`'s `tabStateClass` (#1007), shared by the paint, the folded header's pip and the signature; this PR adds no second copy.

## Not included

- The timeline's live tick (one transform write instead of a redraw per look): a separate PR.
- A per-lane cache in the timeline pane keyed on commit 2's identity: not built.
- A federation-level hold for hidden panes: dropped on the rebase (see above); #1016's pane-level paint gate is what this branch keeps to.
- Client-side card tint: the kernel's `trgb` stays; the age-colour module is untouched. (`stampAge` takes a `tinted` flag no card-face caller passes yet; the tests cover it.)
- Per-column FLIP: upstream's board-wide `flipNeeded` is kept as the outer gate.
- The sub-goal rows, the history gist and the open modal in the feed keep the frame's clock at their own repaint, as before.
- No performance-counter wiring, no new telemetry rows, no bench tool (offered separately; CONTRIBUTING's detection step is a console check).

## Questions

1. Commit 6 replaces #934's `cardPaintKey` rather than extending it. If extending is preferred, what this removes is the key's two whole-board terms (the 15 s clock and the epoch) and the per-card `JSON.stringify`; `flipNeeded` is untouched either way.
2. Commit 7 puts a live clock in the feed pane (the kernel's clock plus local elapsed). The alternative is stamping on the frame's `now` alone, which advances only when frames arrive and brings back the freeze on a quiet board.
3. Commit 4: the open #994 adds a strip input and needs one line in the signature and its tests when it lands (#997, #1007 and #1091 are in it already; #1010 was closed unmerged); I can add it then.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
