### PR TITLE
Judge: an evidence gate for all six tiers and three correctness fixes at the judge's head

### DIFF
--- a/docs/goal-state.md
+++ b/docs/goal-state.md
@@ -163,9 +163,11 @@ within a beat it reverts with a toast, never silently.
 5. Every verdict goes through `record_verdict`. A reopen carries `unblock`
    events for blocked descendants and ancestors; every unblock is an
    event.
-6. Reopens un-resolve only auto-rolled (`rolledUp`) children;
-   genuinely-done leaves keep their state. Re-completions re-summarize
-   only the new stretch (`deltaSince`).
+6. Reopens un-resolve only auto-rolled (`rolledUp`) children, and so
+   does the dissolution of a container above them (the marker mirrors a
+   resolved ancestor and is dropped once none remains); genuinely-done
+   leaves keep their state. Re-completions re-summarize only the new
+   stretch (`deltaSince`).
 7. Identity: identical prompts in different turns are different work
    (twins); same-second identical bursts plan once; any seg-id-derivation
    change ships a placements migration (`placementsV`, currently v12);

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -472,8 +472,17 @@ permission/API-error floors: one interrupt at a time, the present event first.
   store-unwritable: a goals file whose publish failed under a user gesture,
   store-quarantined: a goals file whose bytes did not parse, moved aside,
   frozen-store-write: a read-only site wrote to the shared store view, naming
-  the site, after which the shared cache is off for the process, and
-  frozen-store-save: a shared store view was handed to `save_goals`, refused).
+  the site, after which the shared cache is off for the process,
+  frozen-store-save: a shared store view was handed to `save_goals`, refused,
+  unroll-heal: a top left rolled up with settle rows and no done in its
+  diary, given one reopen row so it can be judged again, gate-stamp: the
+  evidence gate could not write a tier's stamp after a complete run, so the
+  session stays due, and the seven `*-unreadable` kinds of the gate's side
+  files, states-unreadable, cleared-unreadable, stall-unreadable,
+  captions-unreadable, episodes-unreadable, marker-unreadable and
+  archive-unreadable: a file the gate stat'd into a tier's signature exists
+  and could not be read or parsed by the stage, so the run is marked
+  incomplete and stamps nothing, one row per failure episode).
   A file that does not parse is never deleted: it is moved beside its path as
   `<file>.corrupt-<utc stamp>` (a `-n` suffix when two land in the same second)
   before a fresh one is written, so the bytes survive for inspection, and the

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -463,6 +463,29 @@ permission/API-error floors: one interrupt at a time, the present event first.
   read fresh each pass; empty = `ROMP_JUDGE_CONCURRENCY` as read at load,
   else 6). Every pool reads it at call time (`_conc`, or `_judge_concurrency()`
   directly); `DEATH_DRAIN_PER_PASS` alone stays on the load-time value.
+- Skips: the six triage tiers (planner, closer, unblocker, grouper,
+  consolidator, distiller) run behind an evidence gate. Before a session is
+  submitted, the runner takes the tier's signature: the identity (inode,
+  mtime, size) of every file the tier's decision path reads, the store with
+  its journal and archive among them, and for the planner, closer and
+  unblocker the pass's pinned parse pair. A session whose signature equals
+  the one the tier stamped after its last complete run is skipped, and its
+  pass watermark is stamped as for a pass that found nothing to do. A run
+  stamps only when it returned normally and set no completeness bit; a
+  deferral without a write, an empty reply, a failed call, a raise, or a side
+  file that exists and did not read leaves no stamp, and the session runs
+  again next pass. The stamps are process state, so the first pass after a
+  restart is a full walk. The planner has a second gate inside
+  `_plan_session`: a session whose inputs have not moved since a pass that
+  placed nothing, left the store's key where it was and ran to completion
+  returns before the store read. The evidence gate keys on the same inputs
+  (the reg by its `spawnedAt` and backend values rather than by identity) and
+  on `cleared.jsonl`, the death marker and the stall records besides, so an
+  idle session stops at the evidence gate; the inner gate's counters
+  (`memos.plannerSkip` on `GET /perf`, see `docs/reference.md`) count only
+  the sessions the evidence gate ran. Outside
+  a pass frame (`romp-judge --plan`) the evidence gate stamps nothing, and
+  the inner gate does the skipping.
 - Logs: `STATE/judge-usage.jsonl` (per-call cost, one name per prompt),
   `STATE/judge-errors.jsonl` (the row contract above; kinds are parse,
   call, give-up, sweep-cut, cite-miss, rate-limited, task-store, history-unreadable,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -974,14 +974,34 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   while they stand (`served`, `built`); `captions` and `goalArchive` are the
   per-file read memos behind the index tier's caption readers and the re-plan's
   cleared context, each parsed once per file state (`served`, `parsed` or
-  `loaded`); `plannerSkip` is the planner's change gate (`skipped`, `planned`,
-  `recorded`: a session whose parse, store, journal, archive, episode log,
-  its leaf's task store, captions file and reg have not moved since a pass
-  that had nothing to do, and none of whose running background launches has
-  crossed its deadline, is not planned again). The compaction sweep after
-  each judge pass evicts from `pass` and `shared` the entries of stores no
-  session in the discover window owns, so both stay bounded by the live
-  board; the gate memo is bounded by the session count.
+  `loaded`). `goalArchive` memoizes a readable archive only: an archive that
+  exists and cannot be read or parsed is answered empty, marks the running
+  judge stage incomplete, and is not memoized, so the next call reads the file
+  again. `plannerSkip` is the planner's inner change gate (`skipped`,
+  `planned`, `recorded`). The planner runs behind two gates. The outer gate is
+  the judge's evidence gate around `_plan_session` (`docs/judges.md`, "Ops and
+  knobs"): a session whose signature equals the one the planner stamped after
+  its last complete run is skipped before it is submitted. It keys on the
+  inner gate's inputs, the reg by its `spawnedAt` and backend values rather
+  than by identity, plus `cleared.jsonl`, the death marker and the session's
+  stall records. The inner gate
+  sits inside `_plan_session` and sees only the sessions the outer gate ran: a
+  session whose parse, store, journal, archive, episode log, its leaf's task
+  store, captions file and reg have not moved since a pass that had nothing to
+  do, and none of whose running background launches has crossed its deadline,
+  is not planned again. The inner gate records a pass only when it placed
+  nothing, left the store's key where it was, and ran to completion; a
+  deferral without a write, or a side file that exists and did not read,
+  marks the run incomplete, and that session is planned again next pass. So
+  `plannerSkip` counts the sessions the outer gate let through, not every
+  planner skip: an idle session stops at the outer gate and appears in neither
+  `skipped` nor `planned`. Outside a pass frame (`romp-judge --plan`) the
+  outer gate stamps nothing, and the inner gate does the skipping. The
+  compaction sweep after each judge pass evicts from `pass` and `shared` the
+  entries of stores no session in the discover window owns, so both stay
+  bounded by the live board; the courier's and the planner's change-gate
+  tables are pruned to the sessions each pass discovers, and the evidence
+  gate's stamps are cleared at a fixed cap.
 - `judge`: `passes`, `ms_sum`, `ms_last`, `ms_mean` (wall time; a pass waits
   on model calls), `cpu_ms_sum` (CPU time of the judge tier threads and every
   per-session worker they run; the workers' share is `cpu_ms_workers`).

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -254,12 +254,22 @@ _RESULT_CAP = 16000
 # notification can never arrive (the CLI died with the monitor out, and the transcript never learns).
 # Consumers apply this with THEIR now — baking it into the scan would freeze inside the mtime caches,
 # which an idle transcript never busts. The grace absorbs kill/notify latency.
-def _bg_expired(task, now, grace=120.0):
+def _bg_expiry_t(task, grace=120.0):
+    """The instant a scan row starts reading as expired: deadline + grace, or None for a row with no
+    deadline (it never expires by the clock). One definition for the predicate below and for the judge
+    gate's clock input (judge._settle_not_before), so the two cannot drift."""
     dl = (task or {}).get("deadline")
+    if not dl:
+        return None
     if (task or {}).get("deadlineSrc") == "hook":
         grace = 5.0   # a hook-recorded deadline is the harness's own kill moment (Monitor's
         #               required timeout_ms, journaled at launch) — exact, so only clock skew
-    return bool(dl) and now > dl + grace
+    return dl + grace
+
+
+def _bg_expired(task, now, grace=120.0):
+    x = _bg_expiry_t(task, grace)
+    return x is not None and now > x
 
 
 # The detail an agent/workflow row expands to (the Agent prompt / the Workflow script) is clipped:
@@ -3003,6 +3013,37 @@ def parse_session(leaf_path, rompuuid=None, name=None, color="#888888", dir=None
             "landedTextUuids": sorted(landed)}
 
 
+def task_store_dir(fsid):
+    """Claude Code's task store for one transcript stem: <CLAUDE_CONFIG_DIR or ~/.claude>/tasks/<fsid>,
+    resolved at call time (the env var, as task_store_plan reads it)."""
+    return Path(os.environ.get("CLAUDE_CONFIG_DIR") or str(HOME / ".claude")) / "tasks" / str(fsid)
+
+
+def task_store_fp(fsid):
+    """The task store's identity for the judge gate: None when the stem has no store dir (task_store_plan
+    returns None too, and the caller folds the transcript instead), else the sorted (name, mtime_ns, size)
+    of its item files. An item created, deleted or flipped in place moves it. A dir that exists but cannot
+    be listed raises OSError, as task_store_plan does: the gate then runs the stage and stamps nothing,
+    and the stage surfaces the failure loudly. Item files are stat'd by name, never read: a stat is all
+    identity needs."""
+    if not fsid:
+        return None
+    d = task_store_dir(fsid)
+    if not d.is_dir():
+        return None
+    out = []
+    with os.scandir(d) as it:                              # raises OSError → the caller's bypass
+        for e in it:
+            if not e.name.endswith(".json"):
+                continue
+            try:
+                st = e.stat()
+            except FileNotFoundError:
+                continue                                   # deleted between the listing and the stat
+            out.append((e.name, st.st_mtime_ns, st.st_size))
+    return tuple(sorted(out))
+
+
 def task_store_plan(fsid):
     """The agent's to-do list read from Claude Code's LIVE task store (<config>/tasks/<fsid>/<N>.json,
     honoring $CLAUDE_CONFIG_DIR) — the AUTHORITATIVE state TaskList/TaskGet read, updated by EVERY
@@ -3017,7 +3058,7 @@ def task_store_plan(fsid):
     it loudly, never silently fold (repo policy). A single corrupt item file is skipped."""
     if not fsid:
         return None
-    d = Path(os.environ.get("CLAUDE_CONFIG_DIR") or str(HOME / ".claude")) / "tasks" / fsid
+    d = task_store_dir(fsid)
     if not d.is_dir():
         return None
     items = []

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2479,8 +2479,11 @@ def _sdk_owned(fsid):
 # goal/caption stores keep flowing through the pass — they are the pipeline's own dataflow (the closer
 # must see this pass's planner verdicts). Shared across tier threads AND their worker pools on
 # purpose: one frame, one world, first touch wins under the lock.
-_frame = None                    # {"parses": {fsid: session}, "keys": {tag: fileset-key}} while a pass runs
+_frame = None                    # {"parses": {fsid: session}, "keys": {tag: pinned value}, "served": {fsid: pair}}
+#                                  while a pass runs: "keys" holds the pass's ("parse", fsid) pairs
+#                                  (_frame_parse_key), "served" the pair each pinned parse was made under
 _frame_lock = threading.Lock()
+_NO_PIN = object()               # "no entry" in a frame's keys: a pinned None (a failed stat) IS an entry
 
 
 def begin_pass_frame():
@@ -2490,7 +2493,7 @@ def begin_pass_frame():
     with _frame_lock:
         if _frame is not None:
             return False                             # a joiner shares the creator's pass — and its key gate
-        _frame = {"parses": {}, "keys": {}}
+        _frame = {"parses": {}, "keys": {}, "served": {}}
         return True
 
 
@@ -2503,22 +2506,69 @@ def end_pass_frame(owned=True):
         _frame = None
 
 
-def _pinned_fileset_key(tag, files):
-    """The fileset key as of this pass's FIRST look (frame-pinned), else the live key. Keeps a
-    memo written mid-pass consistent with the frame's content: a live key over a file that grew
-    mid-pass would stamp stale derived data under the NEW key, and the next pass would trust it."""
+def _parse_key_files(fsid, files):
+    """The files the judge parse of `fsid` reads, as the filesystem shows them now: the candidate
+    transcripts (_judge_candidates over the RAW leaf list every caller hands in) plus states/<fsid>.jsonl
+    when it exists. Takes the raw list on purpose: _judge_candidates over an already-expanded list would
+    append a fork lane's anchor a second time, and a key computed that way would never equal the one the
+    parse cache holds (one spurious parse per fork lane per pass)."""
+    cands = _judge_candidates(fsid, files)
+    states = STATESDIR / (fsid + ".jsonl")
+    return cands, states, list(cands) + ([str(states)] if states.exists() else [])
+
+
+def _frame_parse_key(fsid, files):
+    """The (fileset key, pending cut) pair this pass judges `fsid` under, pinned in the pass frame
+    (2026-09-07).
+
+    Under a frame the FIRST caller pins it (tag ("parse", fsid)) and every later caller in the pass gets
+    the pinned pair back, whatever the files look like now. The pin is taken BEFORE anything is read, so a
+    reader holding the pair sees content at least as new as the pair describes, never older; that
+    ordering is what lets a stamp keyed on the pair stand for the content a stage judged (the evidence
+    gate, _stage_sig): the judged content can be newer than the stamped key, which costs one redundant
+    run next pass, never older, which would be a missed run. The fileset component is what the frame
+    fixes; the CUT the parse runs under stays LIVE (parsed_session reads it at parse time, as before the
+    frame existed), and the pair the parse was actually served under is recorded beside it
+    (fr["served"]) so the gate can withhold its stamp when the two disagree.
+
+    A stat that fails pins None: the tag is PRESENT with value None, the pass parses uncached, and the
+    gate reads a pinned None as run-and-do-not-stamp. Pinning None rather than leaving the tag absent
+    closes the hole where a later caller in the same pass would pin a fresh key over a parse read
+    earlier (a candidate _judge_candidates just saw can be renamed or removed before its stat, so the
+    exists() and the stat can disagree). No frame: the live pair, no pin.
+
+    Returns (pair, cut, fr): the pinned (or live) pair, or None; the LIVE cut this call read, or None when
+    an existing pin answered and nothing was read (the caller reads its own); and the frame dict the pin
+    lives in (None without a frame), so a caller pinning its parse pins into the SAME frame the key went
+    into rather than into whatever frame stands when its parse returns (a parse can span a pass
+    boundary). An existing pin costs one dict read: no stat, no cut read."""
     fr = _frame
     if fr is not None:
         with _frame_lock:
-            hit = fr["keys"].get(tag)
-        if hit is not None:
-            return hit
-    k = _fileset_key(files)
+            hit = fr["keys"].get(("parse", fsid), _NO_PIN)
+        if hit is not _NO_PIN:
+            return hit, None, fr
+    _cands, _states, key_files = _parse_key_files(fsid, files)
+    cut = _pending_cut(fsid)
+    try:
+        key = (_fileset_key(key_files), cut)
+    except OSError:
+        key = None
     fr = _frame
     if fr is not None:
         with _frame_lock:
-            return fr["keys"].setdefault(tag, k)
-    return k
+            return fr["keys"].setdefault(("parse", fsid), key), cut, fr
+    return key, cut, None
+
+
+def _frame_pin_parse(fr, fsid, session, key):
+    """Under _frame_lock: pin `session` as the frame's parse of fsid unless a concurrent first toucher
+    already did (first touch wins), and record the pair the WINNING parse was made under for the gate's
+    served-pair check. Returns the pinned parse."""
+    won = fr["parses"].setdefault(fsid, session)
+    if won is session:
+        fr["served"][fsid] = key
+    return won
 
 
 def parsed_session(fsid, files, now):
@@ -2530,7 +2580,14 @@ def parsed_session(fsid, files, now):
 
     Under an open PASS FRAME (begin_pass_frame) the FIRST parse of a session is pinned and every later
     call in the pass returns it — even after the file grew — so all stages judge one frozen world
-    (the user 2026-07-21); first touch wins across the tier's worker threads.
+    (the user 2026-07-21); first touch wins across the tier's worker threads. The parse's KEY is pinned
+    with it (_frame_parse_key): the fileset component is read before this function reads anything, the
+    cache slot is (pinned fileset key, live cut), and the pair the pinned parse was served under is
+    recorded in the frame. A gate that pinned the key earlier in the pass fixes the fileset component for
+    every parse of the pass; the content read here can then be newer than the key, never older, which is
+    the property the gate's stamp needs. The cache slot stays exact for the cache's own contract: a later
+    lookup hits it only when the live key equals the pinned one, which means the file has not moved since
+    the pin, so the cached content is that key's content.
 
     Passes states/<fsid>.jsonl so REAL idle transitions become idle atoms — without them _session_closed()
     is permanently False and a discharged focus goal never settles to completed (the settled gate, the
@@ -2542,6 +2599,10 @@ def parsed_session(fsid, files, now):
             hit = fr["parses"].get(fsid)
         if hit is not None:
             return hit
+    # The pass's (fileset key, cut) pair, pinned BEFORE this read: a gate that pinned first fixes the
+    # fileset component for the pass; a first toucher pins the live one here. `fr` is the frame the pin
+    # went into, and the parse below is pinned into that same frame.
+    pair, cut, fr = _frame_parse_key(fsid, files)
     states = STATESDIR / (fsid + ".jsonl")
     # A FORKED leaf (SDK /clear: discover hands the lastSid file under the stable romp sid) parses with
     # the session's anchor transcript among the candidates, so a fork whose chain back-links across files
@@ -2555,19 +2616,17 @@ def parsed_session(fsid, files, now):
     # and clearing both change the parse with NO file change. No PLACEMENTS_V bump: the override only
     # SHRINKS the atom set, transiently, while a cut is armed — segment identity for everything kept is
     # unchanged, and no previously-invisible atom ever becomes a fresh plannable segment (the two drift
-    # shapes the version exists for).
-    cut = _pending_cut(fsid)
-    key_files = list(files) + ([str(states)] if states.exists() else [])
-    try:
-        key = (_fileset_key(key_files), cut)
-    except OSError:
-        key = None
+    # shapes the version exists for). The cut is read LIVE here (the user's call, 2026-09-07): the
+    # judged world is the one the cut wire was built for, and a cut that moved since the gate's pin
+    # shows up as a served pair that differs from the pinned one, which withholds the gate's stamp.
+    if cut is None:                        # a pin answered and read nothing: the live cut is ours to read
+        cut = _pending_cut(fsid)
+    key = (pair[0], cut) if pair is not None else None
     hit = _PARSE_CACHE.get(fsid)
     if key is not None and hit and hit[0] == key:
-        fr = _frame
         if fr is not None:                 # a WARM first touch pins too (review 2026-09-06): this path used to
             with _frame_lock:              #  return unpinned, so a session already in the cache froze nothing
-                return fr["parses"].setdefault(fsid, hit[1])   # and a mid-pass append reached a later stage
+                return _frame_pin_parse(fr, fsid, hit[1], key)   # and a mid-pass append reached a later stage
         return hit[1]                      #  only - the two-worlds shape the frame exists to prevent
     session = em.parse_session(files[0], rompuuid=fsid, candidate_files=list(files),
                                states=str(states), postal_log=str(MESSAGES), now=now,
@@ -2577,24 +2636,29 @@ def parsed_session(fsid, files, now):
         if len(_PARSE_CACHE) > 256:        # bounded by fleet size; a wholesale clear on overflow is fine
             _PARSE_CACHE.clear()
         _PARSE_CACHE[fsid] = (key, session)
-    fr = _frame
-    if fr is not None:                     # pin under the frame; a concurrent first toucher already
-        with _frame_lock:                  #  there wins, so every stage shares ONE canonical parse
-            return fr["parses"].setdefault(fsid, session)
+    if fr is not None:                     # pin under the frame the KEY went into (never a re-read _frame: a
+        with _frame_lock:                  #  parse spanning a pass boundary must not land keyless in the next
+            return _frame_pin_parse(fr, fsid, session, key)   # frame); a concurrent first toucher wins
     return session
 
 
 def tasks_for(fsid, leaf, files, now):
     """The transcript's ready caption tasks [{text, writes:[{id,grain,t}]}], memoized on disk
-    by the file set's (mtime, size) — repeated passes don't re-parse an unchanged transcript
-    (ports the romp-events cache; the per-second-polling / 14MB-transcript guard). The key rides
-    the PASS FRAME (_pinned_fileset_key): under a frame the memo is checked and written with the
-    key of the content the pass actually judged, so a file growing mid-pass can't stamp stale
-    tasks under its new key (which the next pass would then trust)."""
-    try:
-        key = _pinned_fileset_key(("tasks", fsid) + tuple(str(f) for f in files), files)
-    except OSError:
+    by the pass's parse pair — repeated passes don't re-parse an unchanged transcript
+    (ports the romp-events cache; the per-second-polling / 14MB-transcript guard). The memo key IS
+    the pair the parse it derives from was pinned under (_frame_parse_key: the fileset key of the
+    candidates plus the states file, and the cut), so it can never be newer than that parse: under a
+    frame the pair is pinned at the pass's first touch, before any read, and a file growing mid-pass
+    can't stamp stale tasks under its new key (which the next pass would then trust). Keying the memo
+    on its own separate stat (the pre-2026-09-07 shape) let a gate pin the parse at K0, the turn's
+    final record land, and this memo stat K1: the entry then held K0's tasks under K1's key, and the
+    turn's final caption was never queued until the transcript moved again. A pair that could not be
+    computed (a stat failed) memoizes nothing. The key's shape changed with the pinning (a list of
+    [mtime, size] rows plus the cut, JSON-shaped), so older entries miss once and regenerate."""
+    pair, _cut, _fr = _frame_parse_key(fsid, files)
+    if pair is None:
         return []
+    key = list(pair)                                   # as JSON reads it back: [[[mtime, size], ...], cut]
     cf = PCACHE / (fsid + ".json")
     try:
         o = json.loads(cf.read_text())

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -180,6 +180,12 @@ def _rebind_state(path):
         _ABSENT_FLAGS.clear()   # the absent-store predicate memo: same full-path keys, same reasoning
     _shared_clear()             # the shared read-only store cache: same path keying, same reason; also lifts
     #                         a test's deliberate write-guard trip (the poison flag) so the next class starts clean
+    with _STAGE_LOCK:
+        _STAGE_STAMP.clear()    # the evidence gate's stamps describe the OLD root's files; a new root is a new world
+    with _TIER_LOCK:
+        for _d in _TIER_STATS.values():
+            for _k in _d:
+                _d[_k] = 0      # a test reads the gate's counters from zero
     # (the override journal needs no rebinding: _overrides_dir() derives from GOALDIR at call time, so
     #  ANY isolation style — _rebind_state OR a bare GOALDIR reassignment — scopes it automatically)
 
@@ -1030,6 +1036,232 @@ def pass_done(tier, fsid):
 def pass_watermark(tier, fsid):
     """When `tier` last completed a per-session pass over fsid this boot, or None."""
     return _PASS_DONE.get((str(tier), str(fsid)))
+
+
+# ── the EVIDENCE GATE (2026-09-07) ─────────────────────────────────────────────────────────────────
+# Every planner and closer pass ran every discovered session in full: a parse, a store load, the unit
+# walk, the closed-turn walk, a rollup and an unconditional save, per session, per pass, with about
+# two of thirty-three sessions holding anything new per pass on the live kernel. The gate skips a
+# (tier, session) run when nothing it would read has changed. It is exact by construction, not a
+# heuristic: a run is skipped only when EVERY input the tier's decision path reads is identical, by
+# identity, to what the tier last judged TO COMPLETION, and no clock input it holds has crossed its
+# recorded instant. Three rules carry that:
+#  1. Key before read, one key per pass. The transcript component is the (fileset, cut) pair the pass
+#     pinned together with the parse it judged (_frame_parse_key), captured no later than the parse's
+#     content was read, so judged content can be newer than the stamped key (one redundant run next
+#     pass) and never older (a missed run). Every other component is stat'd by the gate before the
+#     stage reads it, at the tier's own moment: stores flow through the pass on purpose (the closer
+#     must see the planner's publish), so each tier keys on what it is about to read.
+#  2. The stamp is written after the stage returns normally with a clean completeness bit
+#     (_judge_ctx.stage_incomplete, set by the _judge_run wrapper on any empty reply and by the stage
+#     sites that defer without writing), from the signature computed BEFORE the run. A stage that
+#     deferred, was paused, failed a call, had a reply rejected without a write, raised, or was cut
+#     leaves no stamp, and so runs again next pass.
+#  3. Every writer re-arms by moving an identity: a judge publish is a rename (save_goals), a user
+#     gesture appends the override journal, kernel-side blocks and lifts publish through save_goals,
+#     a rewind appends the transcript or the states file, a bare rollback rides the cut in the pinned
+#     pair, a death marker is rewritten, a to-do item moves its file. A write racing the stat-then-run
+#     window is stamped under the pre-write identity and costs one redundant run; the tier's OWN write
+#     re-arms it once (the follow-on run makes no call, writes nothing, and stamps). Stamping a
+#     post-write identity would assume the tier is a fixpoint of its own output, which nothing
+#     guarantees.
+# The one clock input is a background launch's deadline (em._bg_expiry_t): the stamp carries the
+# earliest future expiry, and the run is due once the pass's `now` passes it. The invariant every test
+# of this protects (CLAUDE.md, cards move on new information): the gate never withholds a verdict the
+# ungated pass would have filed from NEW evidence. In-memory only, empty at boot: the first pass after a
+# restart is a full walk, as before.
+# Accepted lag, stated once: under an open frame every parsed_session caller sees the pass-start world
+# (a cache hit too, since the warm-touch pin of 2026-09-06), so the six pusher tick jobs that read the
+# judge parse (_interrupt_block_tick, _closer_pending, _awaiting_wake_outcomes, _deferral_sweep_tick,
+# _auto_nudge_session, _clear_done_working_notes) see a world up to one pass old for every session, and
+# a turn that ends after a pass's first touch is judged next pass, whole. That is the frame's design
+# (2026-07-21); the gate adds no lag of its own beyond the producer's 3 s backstop for the clock input.
+GATED_TIERS = ("plan", "close", "unblock", "group", "consolidate", "distill")
+_STAGE_STAMP = {}        # (tier, fsid) -> (sig, not_before): the inputs the tier last judged to completion
+_STAGE_LOCK = threading.Lock()
+_STAGE_STAMP_MAX = 4096  # belt: a wholesale clear at the cap (one full walk next pass)
+_TIER_STATS = {t: {"ran": 0, "skipped": 0, "stamped": 0, "bypassed": 0, "incomplete": 0, "due_clock": 0}
+               for t in GATED_TIERS}
+_TIER_LOCK = threading.Lock()
+
+
+def _tier_bump(tier, key, n=1):
+    with _TIER_LOCK:
+        _TIER_STATS[tier][key] += n
+
+
+def tier_stats():
+    """The gate's counters, per tier: ran (stage runs), skipped (runs the gate declined:
+    stamp matched, clock not due), stamped (runs that ended complete and wrote a stamp), bypassed (runs
+    with no signature to stamp, or whose parse was served under another cut), incomplete (runs the
+    completeness bit voided), due_clock (runs the clock input made due); plus `stamps`, the number of
+    stamps held. ran == stamped + bypassed + incomplete over any window."""
+    with _TIER_LOCK:
+        out = {t: dict(d) for t, d in _TIER_STATS.items()}
+    with _STAGE_LOCK:
+        out["stamps"] = len(_STAGE_STAMP)
+    return out
+
+
+def _ident(p):
+    """(st_ino, st_mtime_ns, st_size) of `p`, None when absent. Every other OSError propagates: the
+    gate reads it as run-and-do-not-stamp."""
+    try:
+        st = os.stat(p)
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+    return (st.st_ino, st.st_mtime_ns, st.st_size)
+
+
+def _reg_spawned_at(fsid):
+    """The spawnedAt VALUE of STATE/sdk/<fsid>.json, the only field _cli_epoch reads from it: model
+    picks, task writes, push notes and subagent events rewrite the reg and leave spawnedAt alone (40
+    rewrites in 90 s live), and keying the signature on the value rather than the file's identity is
+    what keeps those from re-arming the planner and closer. Read directly each time, never through an
+    identity memo: (inode, mtime_ns, size) is exact for the rename and append writers the identity
+    components rely on, but a rewrite in place of equal size within one mtime tick keeps all three, and a
+    memo keyed on them served the previous content (the kernel publishes the reg by os.replace, so it
+    never does that; a test fixture writing in place did, 2026-09-07). The reg is small; one read per
+    session per tier is the whole cost. None when the reg is absent, unreadable, or carries no number
+    (the value _cli_epoch derives too)."""
+    try:
+        v = json.loads((STATE / "sdk" / (fsid + ".json")).read_text()).get("spawnedAt")
+    except Exception:
+        return None
+    return v if isinstance(v, (int, float)) else None
+
+
+def _stall_slice(fsid):
+    """This session's stall records as a comparable tuple: what rollup_status's stall-warn retire reads
+    (stalled_facts). A record appearing or ending for THIS sid moves it; another sid's does not. Read by
+    value from the file each time, for the reason _reg_spawned_at gives."""
+    return tuple(sorted((g, r.get("why"), r.get("since")) for g, r in stalled_facts(fsid).items()))
+
+
+def _pair_key(pair):
+    """A parse pair as a comparable tuple: _fileset_key returns lists."""
+    return (tuple(tuple(x) for x in pair[0]), pair[1])
+
+
+def _sig_inputs(tier, fsid, path):
+    """The side files `tier`'s signature reads for `fsid` beyond the parse pair: (by_identity, by_value).
+    by_identity are stat'd; by_value are read for one derived value (the sdk reg for spawnedAt through
+    _reg_spawned_at, auto-nudge.json for this sid's stall slice, the task-store dir for its item
+    fingerprint). Exactly the files the tier's decision path reads: load_goals reads the store, the
+    override journal and (for restore rows) the archive; the planner's heal reads captions
+    (_prompt_gist), its pre-episode retire reads the episode log (episode_floor), _cli_epoch reads the
+    gone marker and the reg, plan_units reads cleared.jsonl (_live_anchor_gone -> _view_cleared),
+    rollup_status reads the stall slice, _sync_declared_plan reads the LEAF stem's task store; the
+    closer's idle path is the parse, the store, the marker, the reg, cleared.jsonl and the stall slice.
+    Kept apart from _stage_sig so the completeness test can hold a stage's reads against it."""
+    ident = [GOALDIR / (fsid + ".json"), _overrides_dir() / (fsid + ".jsonl"), GOALARCHDIR / (fsid + ".json")]
+    value = []
+    if tier in ("plan", "close"):
+        ident += [GONEDIR / (fsid + ".json"), STATE / "cleared.jsonl"]
+        value += [STATE / "sdk" / (fsid + ".json"), STATE / "auto-nudge.json"]
+    if tier == "plan":
+        ident += [CAPDIR / (fsid + ".jsonl"), EPIDIR / (fsid + ".jsonl")]
+        value += [em.task_store_dir(Path(path).stem)]
+    return ident, value
+
+
+def _stage_sig(tier, fsid, path):
+    """The identity of every input `tier`'s decision path reads for `fsid`, taken BEFORE the stage runs:
+    the pass's pinned parse pair with the candidate files it names (a path swap with a coincidentally
+    equal fileset key cannot match), the store trio, and the tier's side files (_sig_inputs). Raises
+    OSError when a component cannot be computed (a vanished candidate, an unlistable task dir, a pinned
+    None pair): the caller runs the stage and stamps nothing, never a raise out of the submit loop."""
+    pair, _cut, _fr = _frame_parse_key(fsid, [path])
+    if pair is None:
+        raise OSError("no parse pair for %s this pass" % fsid)
+    parse = (tuple(_judge_candidates(fsid, [path])), _pair_key(pair))
+    ident, _value = _sig_inputs(tier, fsid, path)
+    side = tuple(_ident(p) for p in ident)
+    extra = ()
+    if tier in ("plan", "close"):
+        extra = (_reg_spawned_at(fsid), _sdk_owned(fsid), _stall_slice(fsid))
+    if tier == "plan":
+        extra += (em.task_store_fp(Path(path).stem),)
+    return (parse, side, extra)
+
+
+def _gate_check(tier, fsid, path, now):
+    """Runner thread, before submit: (skip, sig). skip: the stamp matches and the clock input has not
+    crossed, so the runner stamps pass_done (a skip is a completed no-op pass: the wedged-reviver bound
+    in the kernel reads it) and submits nothing. sig None with skip False: no signature could be
+    computed; run, stamp nothing."""
+    try:
+        sig = _stage_sig(tier, fsid, path)
+    except OSError:
+        return False, None
+    with _STAGE_LOCK:
+        st = _STAGE_STAMP.get((tier, fsid))
+    if st is not None and st[0] == sig:
+        if st[1] is None or now <= st[1]:              # <=: em._bg_expired reads `now > expiry`, so at the
+            _tier_bump(tier, "skipped")                #  instant itself nothing has changed yet
+            pass_done(tier, fsid)
+            return True, None
+        _tier_bump(tier, "due_clock")
+    return False, sig
+
+
+def _gated(tier, fn, fsid, path, now, sig, settle=True, parse=True):
+    """Pool worker: run the stage, then stamp `sig` when the run was COMPLETE: it returned normally, set
+    no completeness bit, and (parse tiers) the frame served its parse under the very pair the signature
+    holds (a cut that moved between the pin and the parse means the judged world is not the stamped
+    one: no stamp). `settle`: the tier rolls up, so the stamp carries the clock input
+    (_settle_not_before). A stage that raises is counted `incomplete` (the run did not complete and
+    keyed nothing new) and the exception goes on to the runner's pass-crash row, so ran == stamped +
+    bypassed + incomplete holds through a crash.
+
+    No frame, no stamp: the served pair the frame records is what makes a stamp exact. A runner
+    outside a pass frame (romp-judge's --plan, a test calling run_plan alone) therefore never writes a
+    stamp: every session runs and counts as bypassed, and the signature's stats are still paid. It DOES
+    honour a stamp a framed pass left: _gate_check reads the live signature either way, so an unframed
+    run after a framed one skips the sessions nothing has changed for, exactly as a framed run would."""
+    _judge_ctx.stage_incomplete = False
+    _tier_bump(tier, "ran")
+    try:
+        out = fn(fsid, path, now)
+    except Exception:
+        _tier_bump(tier, "incomplete")                # the run did not complete; the runner logs the crash
+        raise
+    try:
+        if sig is None:
+            _tier_bump(tier, "bypassed")
+            return out
+        if getattr(_judge_ctx, "stage_incomplete", False):
+            _tier_bump(tier, "incomplete")
+            return out
+        if parse:
+            fr = _frame
+            served = None
+            if fr is not None:
+                with _frame_lock:
+                    served = fr["served"].get(fsid)
+            if served is None or _pair_key(served) != sig[0][1]:
+                _tier_bump(tier, "bypassed")
+                return out
+        nb = _settle_not_before(fsid, path, now) if settle else None
+        with _STAGE_LOCK:
+            if len(_STAGE_STAMP) >= _STAGE_STAMP_MAX:
+                _STAGE_STAMP.clear()
+            _STAGE_STAMP[(tier, fsid)] = (sig, nb)
+        _tier_bump(tier, "stamped")
+    except Exception as e:                            # a stamping failure is never a failed pass
+        _tier_bump(tier, "bypassed")
+        _log_judge_error(tier, fsid, "gate-stamp", note=repr(e))
+    return out
+
+
+def _gate_evict(tier, keep):
+    """After a tier's pass: drop the stamps of sids the pass did not list (a session outside the discover
+    window, or hidden from the feed, leaves and its stamp with it)."""
+    with _STAGE_LOCK:
+        for k in [k for k in _STAGE_STAMP if k[0] == tier and k[1] not in keep]:
+            del _STAGE_STAMP[k]
+
+
 _active_lock = threading.Lock()
 _active_seq = [0]
 _active_change = [0]      # bumped on EVERY begin and end — the exact "the set of in-flight judge calls
@@ -1499,6 +1731,18 @@ def _call_shape(model, sys_prompt, user, sent):
 
 
 def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", mark=None):
+    """Run ONE judge model call (_judge_run_impl) and mark the stage INCOMPLETE when it comes back empty
+    (the evidence gate's belt): a pause skip, the rate gate, a scratch refusal, a subprocess error, a
+    dead CLI, an error envelope, a timeout, and a whitespace-only reply all leave the stage's work
+    undone, so the gate must not stamp the pass as having judged this session. Stages set the same bit
+    at their own no-write deferrals (the suites patch the helpers above this belt)."""
+    out = _judge_run_impl(model, sys_prompt, user, effort=effort, judge=judge, tier=tier, mark=mark)
+    if not (out or "").strip():
+        _judge_ctx.stage_incomplete = True
+    return out
+
+
+def _judge_run_impl(model, sys_prompt, user, effort=None, judge=None, tier="triage", mark=None):
     """Run ONE judge model call. `mark` is the caller's per-call section mark (see _mark/_sec): passing
     it appends UNTRUSTED_SYS, which tells the model that marked sections are material, not orders. It
     rides the SYSTEM prompt, the half no transcript content can reach, and goes on LAST — see below."""
@@ -5988,6 +6232,10 @@ def apply_plan_guarded(fsid, path, store, seg_id, seg_t, ops, menu, place_key=No
     fresh parses carry the leaf_override, so the deferred unit never reaches the nudge gate."""
     away = _rewound_away(fsid, path, prompt_uuid) if prompt_uuid else False
     if away == "pending":
+        _judge_ctx.stage_incomplete = True         # deferred with no write: the evidence gate must not stamp
+        #                                             this run, or the unit waits for an unrelated re-arm
+        #                                             (a rollback arming during the model call reaches this
+        #                                             leg past the unit loop's own check; review 2026-09-07)
         _log_judge_error("planner", fsid, "rewind-stand-down-pending", seg=seg_id,
                          note="the unit's prompt is abandoned only under a still-pending cut — "
                               "deferred, not retired (the rewind can still fail)")
@@ -7416,8 +7664,9 @@ def _bg_unresolved(path, now=None):
     """The transcript's still-RUNNING background launches (em._scan_bg_tasks pairing), folded append-incrementally.
     The DURABLE awaited-work source: the pairing lives in the transcript, so unlike any live backend
     snapshot it survives a kernel restart and covers tmux CLIs whose tasks outlive the kernel.
-    `now`: the pass's clock when the planner hands it in (one clock for its key's expiry term and the
-    settle that term gates, so the two cannot disagree at the crossing); the wall clock otherwise."""
+    `now`: the pass's clock when a gated tier hands it in (one clock for the stage's expiry view, the
+    planner key's expiry term and the gate's not-before, so none of them can disagree at the crossing);
+    the wall clock otherwise."""
     # folds append-incrementally since 2026-09-03: a changed transcript steps only its appended records
     tasks = em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)
     # expiry is applied OUTSIDE the cache with a fresh now: a monitor whose CLI died mid-watch has no
@@ -7445,6 +7694,32 @@ def _bg_expiry_key(path, now):
                             for t in em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)))
     except Exception:
         return object()
+
+
+def _settle_not_before(fsid, path, now):
+    """The evidence gate's one clock input: the earliest instant AT OR AFTER `now` at which one of this
+    session's running background launches expires (em._bg_expiry_t) and the settle can change with no
+    file moving, or None. At-or-after, because em._bg_expired is strict (`now > expiry`): a launch whose
+    expiry equals this pass's `now` has NOT expired yet, the run that just completed judged it as still
+    running, and the pass after this one is the first that sees it expired, so the stamp must carry it
+    (the review's boundary case, 2026-09-07: run_triage's `now` is a whole second and transcript
+    timestamps are whole seconds, so an expiry equal to `now` is an ordinary pass, and dropping it left a
+    stamp with no clock that skipped every later pass while the settle waited). Ghost launches (before
+    the live CLI's epoch) are filtered by the rule _awaiting_bg_hold applies, so an expiry that could not
+    change a verdict never re-arms one. Read after a complete run from the live fold, which holds every
+    launch the judged world held (the transcript is append-only; a launch that landed after the pass's
+    pin moves the parse pair anyway). Never recomputed on a skip: with an unchanged signature the task
+    set is unchanged, so the stored instant is exact."""
+    tasks = em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)
+    sp = _cli_epoch(fsid)
+    nb = None
+    for t in tasks:
+        if sp and t.get("t") and t["t"] < sp:
+            continue
+        x = em._bg_expiry_t(t)
+        if x is not None and x >= now and (nb is None or x < nb):
+            nb = x
+    return nb
 
 
 def _death_marker(sid):
@@ -7530,7 +7805,8 @@ def _awaiting_bg_hold(fsid, path, session, store, now=None):
 def _session_settled(fsid, path, session, store, now=None):
     """The rollup's settled gate: the turn ended AND nothing the session dispatched is still awaited.
     _session_closed alone read the 'ended' proxy; this keys the settle on the event it was
-    approximating — the session actually handing back the floor."""
+    approximating — the session actually handing back the floor. `now`: the pass's clock (the gated
+    planner and closer hand theirs in, so the expiry they judge under is the one their stamp holds)."""
     return _session_closed(session) and not _awaiting_bg_hold(fsid, path, session, store, now)
 
 
@@ -9371,6 +9647,7 @@ def _plan_session(fsid, path, now):
             # abandoned only under an ARMED, unconsumed cut: DEFER without writing — a retirement
             # is permanent, and this rewind can still fail/dissolve (the apply_plan_guarded
             # contract's pending leg). The next pass re-decides from the resolved world.
+            _judge_ctx.stage_incomplete = True         # deferred without a write: the gate must not stamp
             _log_judge_error("planner", fsid, "rewind-stand-down-pending", seg=seg_id,
                              note="the unit's prompt is abandoned only under a still-pending cut — "
                                   "deferred, not retired (the rewind can still fail)")
@@ -9675,6 +9952,7 @@ def _plan_session(fsid, path, now):
         raw = plan_llm(text, _menu_text(store, menu), human=human, goal_num=pgi)
         ops = _parse_plan(raw, len(menu))
         if not ops and not raw:
+            _judge_ctx.stage_incomplete = True         # the unit stays due: no stamp for this pass
             continue                                   # the CALL failed (gate skip / error envelope / timeout),
             #                                            already logged upstream — retry next pass. It must not
             #                                            burn a PLAN_PARSE_RETRIES try: a rate-limit window
@@ -9751,6 +10029,7 @@ def _plan_session(fsid, path, now):
         # parse with an on-chain anchor. (Task-store mirrors of abandoned-turn to-dos are otherwise
         # LEFT AS-IS by decision: the task store is the authoritative source and a rewind does not
         # roll it back — the agent may genuinely still hold those to-dos.)
+        _judge_ctx.stage_incomplete = True             # skipped without a write: the gate must not stamp
         _log_judge_error("planner", fsid, "rewind-stand-down",
                          note="plan-sync skipped this pass: the latest segment was rewound away mid-pass")
     elif _sync_declared_plan(store, session, (latest_seg or {}).get("id"), (latest_seg or {}).get("t") or now,
@@ -9802,13 +10081,18 @@ def run_plan(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=Fal
         _PLANNER_SEEN.pop(_gone, None)                # the planner gate, bounded by the sessions this pass discovered
     placed = 0
     with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
-        futs = {ex.submit(_plan_session, fsid, str(path), now): fsid for fsid, path, anchor, name in fleet}
+        futs = {}
+        for fsid, path, anchor, name in fleet:
+            skip, sig = _gate_check("plan", fsid, str(path), now)   # the evidence gate: nothing new, no run
+            if not skip:
+                futs[ex.submit(_gated, "plan", _plan_session, fsid, str(path), now, sig)] = fsid
         for fut in as_completed(futs):
             try:
                 placed += fut.result()
                 pass_done("plan", futs[fut])          # the pass over THIS fsid completed (W2c's event)
             except Exception as e:                    # fail LOUDLY, never silently skip the store (T111)
                 _log_judge_error("planner", futs[fut], "pass-crash", note=repr(e))
+    _gate_evict("plan", {f[0] for f in fleet})
     if verbose:
         sys.stderr.write("romp-judge: planner placed %d segments across %d sessions\n" % (placed, len(fleet)))
     return placed
@@ -11845,6 +12129,11 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
         _judge_ctx.close_menu = None                   # …nor a stale menu shape describe this turn's call
         res = _close_turn(store, turn, seg_by_id=seg_by_id)
         if res is None:
+            # Every leg below is "retry next pass" for this turn (a failed call, a parse reject under
+            # the cap, a strike under the cap, a transient cut): the walk is incomplete, so the evidence
+            # gate must not stamp it. The at-cap adoptions write the store and re-arm on their own; the
+            # mark costs them one extra run.
+            _judge_ctx.stage_incomplete = True
             # SAFEGUARDS TOMBSTONE (the user 2026-08-18): a safeguards refusal is the filter ruling on
             # this turn's CONTENT — deterministic per prompt — so the retry-next-pass contract for
             # transient failures burned one doomed call per pass, forever (2,955 refusals in six days,
@@ -11939,7 +12228,7 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
         swept.add(tid); sig[tid] = fp; did += 1        # remember the size we judged at → detect later growth
     store["closedTurns"] = sorted(swept)
     store["closedSig"] = sig
-    settled = _session_settled(fsid, path, session, store)
+    settled = _session_settled(fsid, path, session, store, now)
     rollup_status(store, settled)
     save_goals(fsid, store)
     # A CUT walk left end-known turns unswept, and a dead session is swept ONLY through the death drain
@@ -12108,14 +12397,22 @@ def run_close(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=Fa
                     _write_death_marker(sid, m)
     n = 0
     with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
-        futs = {ex.submit(_close_session, fsid, str(path), now): fsid
-                for fsid, path, anchor, name in fleet}
+        futs = {}
+        for fsid, path, anchor, name in fleet:
+            # the evidence gate, the death drain's sids included: a pending marker without endedAt is
+            # ordinary evidence (_death_finalize is a function of the parse, the store, the marker, the
+            # states file and the clock input, all in the closer's signature), and _death_rotate's utime
+            # moves the marker's identity, so a cut walk stays due through the marker as well
+            skip, sig = _gate_check("close", fsid, str(path), now)
+            if not skip:
+                futs[ex.submit(_gated, "close", _close_session, fsid, str(path), now, sig)] = fsid
         for fut in as_completed(futs):
             try:
                 n += len(fut.result())
                 pass_done("close", futs[fut])         # the pass over THIS fsid completed (W2c's event)
             except Exception as e:                    # fail LOUDLY, never silently skip the store (T111)
                 _log_judge_error("closer", futs[fut], "pass-crash", note=repr(e))
+    _gate_evict("close", {f[0] for f in fleet})
     if verbose:
         sys.stderr.write("romp-judge: closer completed %d nodes\n" % n)
     return n

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -42,10 +42,15 @@ def judge_worker_cpu_ms():
 
 
 class _TimedPool(ThreadPoolExecutor):
-    """ThreadPoolExecutor whose submitted callables account their CPU to _JUDGE_CPU."""
+    """ThreadPoolExecutor whose submitted callables account their CPU to _JUDGE_CPU, and whose workers are
+    PASS THREADS (_pass_frame): a tier fans its per-session stages through these pools, and a worker must
+    see the frame the tier thread opened or joined, so every submitted run carries the mark (review find,
+    2026-09-08). Thread-locals do not cross into pool workers on their own, which is why the mark rides
+    the submit rather than the tier."""
 
     def submit(self, fn, /, *args, **kwargs):
         def run():
+            _judge_ctx.in_pass = True
             c0 = time.thread_time()
             try:
                 return fn(*args, **kwargs)
@@ -966,7 +971,13 @@ def _log_judge_error(judge, fsid, err, note=None, goal=None, seg=None):
              then failed under a user gesture, the save path's own strict read or the write itself; filed
              once per fault episode by save_goals_or_fault, and the gesture is answered on its socket),
              "unroll-heal" (a top left the rolled-up state with settle rows and no done in its diary; a romp
-             reopen row ended that settled episode so the node can be judged again — _heal_settle_without_done)
+             reopen row ended that settled episode so the node can be judged again — _heal_settle_without_done),
+             "gate-stamp" (the evidence gate could not write a tier's stamp after a complete run; the run
+             counts bypassed and the session stays due: _gated), "states-unreadable", "cleared-unreadable",
+             "stall-unreadable", "captions-unreadable", "episodes-unreadable", "marker-unreadable",
+             "archive-unreadable" (a side file the evidence gate stat'd into a tier's signature exists and
+             could not be read or parsed by the stage: the run is marked incomplete and stamps nothing, one
+             row per failure episode: _read_failed)
       note   the evidence — reply tail, error message, exception name, or the give-up scope + re-arm
              event. Callers must pass it; an empty note means the caller has nothing at all to show.
       goal   the node id (or list of node ids) the judge was ruling on, when one exists — the feed's
@@ -1076,12 +1087,13 @@ def pass_watermark(tier, fsid):
 # of this protects (CLAUDE.md, cards move on new information): the gate never withholds a verdict the
 # ungated pass would have filed from NEW evidence. In-memory only, empty at boot: the first pass after a
 # restart is a full walk, as before.
-# Accepted lag, stated once: under an open frame every parsed_session caller sees the pass-start world
-# (a cache hit too, since the warm-touch pin of 2026-09-06), so the six pusher tick jobs that read the
-# judge parse (_interrupt_block_tick, _closer_pending, _awaiting_wake_outcomes, _deferral_sweep_tick,
-# _auto_nudge_session, _clear_done_working_notes) see a world up to one pass old for every session, and
-# a turn that ends after a pass's first touch is judged next pass, whole. That is the frame's design
-# (2026-07-21); the gate adds no lag of its own beyond the producer's 3 s backstop for the clock input.
+# Accepted lag, stated once: under an open frame every PASS-THREAD caller of parsed_session sees the
+# pass-start world (a cache hit too, since the warm-touch pin of 2026-09-06), so a turn that ends after a
+# pass's first touch is judged next pass, whole. That is the frame's design (2026-07-21). The six pusher
+# tick jobs that read the judge parse (_interrupt_block_tick, _closer_pending, _awaiting_wake_outcomes,
+# _deferral_sweep_tick, _auto_nudge_session, _clear_done_working_notes) are NOT pass threads
+# (_pass_frame, review find 2026-09-08): they read the live world at every cycle, so the frame costs them
+# nothing, and the gate adds no lag of its own beyond the producer's 3 s backstop for the clock input.
 #
 # SIGNATURE INPUTS PER TIER (the planner and closer first; the four store-only tiers added 2026-09-07).
 # Each list is what the tier's DECISION path reads, enumerated by reading the stage end to end; a read on
@@ -1122,10 +1134,14 @@ def pass_watermark(tier, fsid):
 # that cannot be read raises at the stage's load (no stamp, a pass-crash row), and an unparseable one is
 # moved aside by load_goals, so the fresh store the stage judges is what the path holds. The same holds
 # for the side files a stage reads after the gate stat'd them (cleared.jsonl, the states file, the stall
-# records): a read that fails on a file that exists marks the run incomplete and logs a row (_read_failed).
+# records, and since the review of 2026-09-08 the captions, the episode log, the death marker and the
+# archive): a read that fails on a file that exists marks the run incomplete and logs a row (_read_failed).
 GATED_TIERS = ("plan", "close", "unblock", "group", "consolidate", "distill")
 PARSE_TIERS = ("plan", "close", "unblock")   # the tiers whose decision path reads the parse: their signature
 #                                              carries the pinned pair, and _gated checks the served pair
+_TIER_JUDGE = {"plan": "planner", "close": "closer", "unblock": "unblocker", "group": "grouper",
+               "consolidate": "consolidator", "distill": "distiller"}   # the judge name a tier's rows wear
+#                                              (_log_judge_error's contract: the judge, never a tier key)
 _STAGE_STAMP = {}        # (tier, fsid) -> (sig, not_before): the inputs the tier last judged to completion
 _STAGE_LOCK = threading.Lock()
 _STAGE_STAMP_MAX = 4096  # belt: a wholesale clear at the cap (one full walk next pass)
@@ -1337,7 +1353,7 @@ def _gated(tier, fn, fsid, path, now, sig, settle=True, parse=None):
         if parse is None:
             parse = tier in PARSE_TIERS
         if parse:
-            fr = _frame
+            fr = _pass_frame()
             if fr is None:
                 _tier_bump(tier, "bypassed")          # no frame: no served pair to make the stamp exact
                 return out
@@ -1358,7 +1374,7 @@ def _gated(tier, fn, fsid, path, now, sig, settle=True, parse=None):
         _tier_bump(tier, "stamped")
     except Exception as e:                            # a stamping failure is never a failed pass
         _tier_bump(tier, "bypassed")
-        _log_judge_error(tier, fsid, "gate-stamp", note=repr(e))
+        _log_judge_error(_TIER_JUDGE.get(tier, tier), fsid, "gate-stamp", note=repr(e))
     return out
 
 
@@ -2831,7 +2847,15 @@ def _sdk_owned(fsid):
 # end; the next pass sees the new world and runs every stage over it in order. Only EVIDENCE freezes:
 # goal/caption stores keep flowing through the pass — they are the pipeline's own dataflow (the closer
 # must see this pass's planner verdicts). Shared across tier threads AND their worker pools on
-# purpose: one frame, one world, first touch wins under the lock.
+# purpose: one frame, one world, first touch wins under the lock. Shared with those threads ONLY
+# (review find, 2026-09-08): the frame is a module global, and the kernel's pusher thread calls
+# parsed_session too (its six tick jobs), so before the scoping a tick job's first touch of a session,
+# cold or (since the warm-hit pin of 2026-09-06) warm, pinned that job to the pass-start world for as
+# long as the tiers ran, model calls included: a needs-you block, a working-note lift or a nudge
+# decision waited out the pass. The pin now applies to PASS THREADS (_pass_frame): the thread that
+# opened or joined the frame (the producer, run_index, run_triage, a test's own thread) and this
+# module's pool workers (_TimedPool). Any other thread reads the live world at every call and pins
+# nothing, as every thread did before the frame existed.
 _frame = None                    # {"parses": {fsid: session}, "keys": {tag: pinned value}, "served": {fsid: pair}}
 #                                  while a pass runs: "keys" holds the pass's ("parse", fsid) pairs
 #                                  (_frame_parse_key), "served" the pair each pinned parse was made under
@@ -2841,8 +2865,11 @@ _NO_PIN = object()               # "no entry" in a frame's keys: a pinned None (
 
 def begin_pass_frame():
     """Open a pass frame; True when this call CREATED it (the creator must end it), False when one is
-    already active (a tier running under the kernel producer's frame joins it instead)."""
+    already active (a tier running under the kernel producer's frame joins it instead). Either way the
+    calling thread is a PASS THREAD from here on (_pass_frame): the pins below are for it and for the
+    pool workers its runners submit."""
     global _frame
+    _judge_ctx.in_pass = True
     with _frame_lock:
         if _frame is not None:
             return False                             # a joiner shares the creator's pass — and its key gate
@@ -2851,12 +2878,24 @@ def begin_pass_frame():
 
 
 def end_pass_frame(owned=True):
-    """Drop the pass frame (creator only — a joiner passes its begin_pass_frame() result through)."""
+    """Drop the pass frame (creator only — a joiner passes its begin_pass_frame() result through, and its
+    end is a no-op: the thread is still inside the creator's pass). The creator's end also unmarks the
+    calling thread (_pass_frame): its pass work is over."""
     global _frame
     if not owned:
         return
+    _judge_ctx.in_pass = False
     with _frame_lock:
         _frame = None
+
+
+def _pass_frame():
+    """The open pass frame for a PASS THREAD, None for any other thread (and when no pass runs). A pass
+    thread is one that opened or joined the frame (begin_pass_frame) or runs in one of this module's pools
+    (_TimedPool marks every submitted run); the kernel's pusher thread, whose tick jobs read parsed_session
+    between and during passes, is neither, so it reads the live world and pins nothing (the frame's
+    comment above; review find, 2026-09-08). Every reader of the frame goes through here."""
+    return _frame if getattr(_judge_ctx, "in_pass", False) else None
 
 
 def _parse_key_files(fsid, files):
@@ -2895,7 +2934,7 @@ def _frame_parse_key(fsid, files):
     lives in (None without a frame), so a caller pinning its parse pins into the SAME frame the key went
     into rather than into whatever frame stands when its parse returns (a parse can span a pass
     boundary). An existing pin costs one dict read: no stat, no cut read."""
-    fr = _frame
+    fr = _pass_frame()
     if fr is not None:
         with _frame_lock:
             hit = fr["keys"].get(("parse", fsid), _NO_PIN)
@@ -2907,7 +2946,7 @@ def _frame_parse_key(fsid, files):
         key = (_fileset_key(key_files), cut)
     except OSError:
         key = None
-    fr = _frame
+    fr = _pass_frame()
     if fr is not None:
         with _frame_lock:
             return fr["keys"].setdefault(("parse", fsid), key), cut, fr
@@ -2931,9 +2970,11 @@ def parsed_session(fsid, files, now):
     kernel runs every judge in-process, so the cache lives across a producer pass. An unchanged transcript
     now costs 0 parses; a changed one costs 1. Falls through to a fresh parse if the files can't be stat'd.
 
-    Under an open PASS FRAME (begin_pass_frame) the FIRST parse of a session is pinned and every later
-    call in the pass returns it — even after the file grew — so all stages judge one frozen world
-    (the user 2026-07-21); first touch wins across the tier's worker threads. The parse's KEY is pinned
+    Under an open PASS FRAME (begin_pass_frame) the FIRST parse of a session by a PASS THREAD is pinned
+    and every later pass-thread call in the pass returns it — even after the file grew — so all stages
+    judge one frozen world (the user 2026-07-21); first touch wins across the tier's worker threads. A
+    thread outside the pass (the kernel's pusher tick jobs) sees no frame here: it reads live and pins
+    nothing (_pass_frame, review find 2026-09-08). The parse's KEY is pinned
     with it (_frame_parse_key): the fileset component is read before this function reads anything, the
     cache slot is (pinned fileset key, live cut), and the pair the pinned parse was served under is
     recorded in the frame. A gate that pinned the key earlier in the pass fixes the fileset component for
@@ -2946,7 +2987,7 @@ def parsed_session(fsid, files, now):
     is permanently False and a discharged focus goal never settles to completed (the settled gate, the
     user's bug 2026-06-17). The states file's (mtime,size) is folded into the cache key so an idle-only
     transition (which doesn't touch the transcript) still busts the cache and re-rolls status."""
-    fr = _frame
+    fr = _pass_frame()
     if fr is not None:
         with _frame_lock:
             hit = fr["parses"].get(fsid)
@@ -3051,9 +3092,11 @@ def tasks_for(fsid, leaf, files, now):
 # BEFORE the read (the chain-memo rule), so a row appended during the read moves the key the next call
 # takes and content read mid-write is served no further than that call; an absent file is never cached
 # (its key is None); a stat error (a fresh sentinel key) never matches. An existing file that cannot be
-# read is [] and never cached by the captions memo; the archive memo caches load_goal_archive's answer
-# for it, the empty shape, the same answer the fresh loader gives every archiver for that file. Bounded
-# at _FILE_MEMO_MAX entries, oldest-inserted out, the eviction and the insert under _FILE_MEMO_LOCK; a
+# read is [] and never cached by the captions memo; the archive memo answers the empty shape for it, the
+# same answer the fresh loader gives every archiver for that file, and does not cache it either: the read
+# marked the running stage incomplete (_read_failed, archive-unreadable), and a permission fix moves no
+# file key, so a cached failure would be served after the file reads again (2026-09-09, the evidence gate).
+# Bounded at _FILE_MEMO_MAX entries, oldest-inserted out, the eviction and the insert under _FILE_MEMO_LOCK; a
 # rebound state root clears both. The captions memo serves the three readers from one parse; the archive
 # memo serves READERS only (load_goal_archive_shared): every archiver keeps load_goal_archive, a fresh
 # private object it mutates and saves.
@@ -5045,9 +5088,12 @@ def save_goals(fsid, store):
     saves its store several times per pass, _distill_session saves after titling and again after distilling
     — took the unconditional branch, wrote over whatever a concurrent writer (the nudge tick, the unblocker,
     a peer tier) had published in between, and skipped the no-op check as well. The base is popped before
-    the CAS loop and re-stamped only after the rename, so a raise between the two leaves the object without
-    a base (its next save is unconditional, as every save was before this change); a refusal before the pop
-    (the frozen-store check, the no-op check) leaves it untouched.
+    the CAS loop and stamped again once the loop and the write are over: the written revision after the
+    rename, or the base it was loaded at when the publish did not happen (a revision read inside the loop,
+    the write or the rename raised), so the holder's retry is CAS-protected too (review find, 2026-09-08;
+    the first version of the re-stamp left that raise window documented instead, and a raise there made
+    the next save unconditional). A refusal before the pop (the frozen-store check, the no-op check)
+    leaves the object untouched.
 
     A publish that would write back EXACTLY what the file already holds is skipped (the user 2026-07-22).
     Callers save unconditionally on purpose — `_plan_session` ends every pass with a rollup + save whether or
@@ -5081,31 +5127,39 @@ def save_goals(fsid, store):
     if mine is not None and _matches_disk(fsid, store, mine):
         return                                       # nothing of ours to publish → leave the file (and its
     base = store.pop("_baseRev", None)               # mtime) alone.  transient: never serialized
-    store.pop("_unread", None)                       # likewise transient (_replay_overrides' unread-journal mark)
-    rebased = False
-    if base is not None:
-        disk = 0
-        for _ in range(4):                           # a busy store settles in a pass or two
-            disk = _disk_rev(fsid)
-            if disk == base:
-                break                                # nobody published since we loaded → ours is current
-            _rebase_onto_disk(fsid, store)           # fold their events in, then re-check
-            rebased = True
-            base = disk
-        store["rev"] = disk + 1                      # the revision the loop settled on; no second parse
-    else:
-        store["rev"] = int(store.get("rev") or 0) + 1
-    _goal_io_bump("writes")
-    tmp = _publish_tmp(GOALDIR, fsid)
-    tmp.write_text(json.dumps(store))
-    if mine is not None and not rebased:             # a rebase changed the content `mine` describes
-        _disk_seed(GOALDIR / (fsid + ".json"), tmp, mine)
-    tmp.rename(GOALDIR / (fsid + ".json"))            # atomic publish
-    _shared_forget(str(GOALDIR / (fsid + ".json")))   # the shared read-only view of the old version goes with
-    #                                                   it (its identity check would miss anyway; this frees the bytes)
-    if base is not None:
-        store["_baseRev"] = store["rev"]             # the file holds exactly this content at this revision:
-        #                                              the holder's NEXT save compares against it (docstring)
+    unread = store.pop("_unread", None)              # likewise transient (_replay_overrides' unread-journal mark)
+    rebased = published = False
+    try:
+        if base is not None:
+            disk = 0
+            for _ in range(4):                       # a busy store settles in a pass or two
+                disk = _disk_rev(fsid)
+                if disk == base:
+                    break                            # nobody published since we loaded → ours is current
+                _rebase_onto_disk(fsid, store)       # fold their events in, then re-check
+                rebased = True
+                base = disk
+            store["rev"] = disk + 1                  # the revision the loop settled on; no second parse
+        else:
+            store["rev"] = int(store.get("rev") or 0) + 1
+        _goal_io_bump("writes")
+        tmp = _publish_tmp(GOALDIR, fsid)
+        tmp.write_text(json.dumps(store))
+        if mine is not None and not rebased:         # a rebase changed the content `mine` describes
+            _disk_seed(GOALDIR / (fsid + ".json"), tmp, mine)
+        tmp.rename(GOALDIR / (fsid + ".json"))        # atomic publish
+        published = True
+        _shared_forget(str(GOALDIR / (fsid + ".json")))   # the shared read-only view of the old version goes
+        #                                               with it (its identity check would miss anyway; this frees the bytes)
+    finally:
+        if base is not None:
+            # published: the file holds exactly this content at this revision, so the holder's NEXT save
+            # compares against it. Not published (a raise above): the object is what it was when loaded, or
+            # that plus the disk events a rebase folded in, and `base` is the revision either state stands
+            # on, so the retry stays CAS-protected instead of stomping (review find, 2026-09-08)
+            store["_baseRev"] = store["rev"] if published else base
+        if not published and unread is not None:
+            store["_unread"] = unread                # the mark describes the object still held
 
 
 def load_goal_archive(fsid):
@@ -5116,31 +5170,61 @@ def load_goal_archive(fsid):
     _GOAL_ARCH_LOCK. The judge's readers (_cleared_context for the live re-plan's <recently-cleared> block,
     the override replay, the peer-node joins, the propagate pass) take load_goal_archive_shared, its twin,
     which serves one loaded object per file state; the re-plan's placements dedup and view-cleared sealing
-    keep it from ever re-minting an archived node. Any failure to read or decode an existing file answers the
-    empty shape, and the shared twin memoizes that answer for the file as it stands."""
+    keep it from ever re-minting an archived node.
+
+    An archive that exists and cannot be read or parsed answers the empty archive, as before, and marks the
+    running stage incomplete with one `archive-unreadable` row per failure episode (_read_failed, review
+    find 2026-09-08): every tier's signature carries the archive by identity (load_goals reads it for a
+    journaled restore row, the planner for its <recently-cleared> block), and a stamp over an answer that
+    never read it would skip the session until the archive moved. The shared twin does not memoize that
+    answer (a permission fix moves no file key, so a cached failure would be served after the file reads
+    again); it learns the outcome from _judge_ctx.archive_read_ok, set here for the calling thread, which
+    keeps its call to this function by name (tests count the archive reads through it). The empty answer
+    itself stays: the kernel's compaction sweep and undo-clear restore read through here too, and a raise
+    into their paths (#1019's shape for the goal stores) is the separate change the PR's body defers."""
+    path_s = str(GOALARCHDIR / (fsid + ".json"))
+    fresh = {"rompUuid": fsid, "nodes": {}, "status": {}}
+    _judge_ctx.archive_read_ok = True
     try:
-        return _guard_nodes(json.loads((GOALARCHDIR / (fsid + ".json")).read_text()))
-    except Exception:
-        return {"rompUuid": fsid, "nodes": {}, "status": {}}
+        text = Path(path_s).read_text()
+    except (FileNotFoundError, NotADirectoryError):
+        _read_ok(path_s)                               # absent is the common case and a real state
+        return fresh
+    except OSError as e:
+        _read_failed(path_s, "archive-unreadable", fsid, e)
+        _judge_ctx.archive_read_ok = False
+        return fresh
+    try:
+        arch = _guard_nodes(json.loads(text))
+    except Exception as e:                             # not a JSON document, or not a store shape
+        _read_failed(path_s, "archive-unreadable", fsid, e)
+        _judge_ctx.archive_read_ok = False
+        return fresh
+    _read_ok(path_s)
+    return arch
 
 
 def load_goal_archive_shared(fsid):
     """load_goal_archive for READERS: the guarded archive store, loaded once per file state and served while
     the file stands (2026-09-09), the key its stat taken before the read. The object is shared and read-only
     by contract; every archiver (a compaction, a rewind sweep, an undo restore) keeps load_goal_archive, a
-    fresh private object it mutates and saves under the archive lock."""
+    fresh private object it mutates and saves under the archive lock. A read that failed (a file that exists
+    and cannot be read or parsed: load_goal_archive leaves _judge_ctx.archive_read_ok False) is answered
+    empty and never memoized: the failure marked the running stage incomplete, and the next call must read
+    the file again to find out whether it still does."""
     p = GOALARCHDIR / (fsid + ".json")
     key = _file_key(str(p))
     ent = _GOALARCH_MEMO.get(fsid)
     if ent is not None and isinstance(key, tuple) and ent[0] == key:
         _GOALARCH_STATS["served"] += 1
         return ent[1]
+    _judge_ctx.archive_read_ok = True                  # a patched loader that never sets it reads as ok
     store = load_goal_archive(fsid)
+    ok = getattr(_judge_ctx, "archive_read_ok", True)
     _GOALARCH_STATS["loaded"] += 1
-    if isinstance(key, tuple):
+    if ok and isinstance(key, tuple):
         _memo_put(_GOALARCH_MEMO, fsid, key, store)
     return store
-
 
 def save_goal_archive(fsid, store):
     GOALARCHDIR.mkdir(parents=True, exist_ok=True)
@@ -7287,11 +7371,21 @@ def transcript_head(path):
 
 def _episode_read(sid):
     """One memoized read of the episodes log: (head rows oldest-first, settle annotations by head).
-    mtime-memoized like _sdk_last_sid — the log only grows at a /clear, so per-pass reads are a stat."""
+    mtime-memoized like _sdk_last_sid — the log only grows at a /clear, so per-pass reads are a stat.
+    A file that exists and does not read answers empty, is NOT memoized (the old code memoized the empty
+    read under the file's mtime, so the rows stayed invisible until the log grew), marks the running stage
+    incomplete and logs an `episodes-unreadable` row (_read_failed, review find 2026-09-08): the planner's
+    signature carries this file by identity, and a stamp over a floor that never read it would skip the
+    session until the file moved."""
     p = EPIDIR / (sid + ".jsonl")
     try:
         mt = p.stat().st_mtime
-    except OSError:
+    except (FileNotFoundError, NotADirectoryError):
+        _read_ok(str(p))                               # absent is a real state, and ends a failure episode
+        _episode_memo.pop(sid, None)
+        return [], {}
+    except OSError as e:
+        _read_failed(str(p), "episodes-unreadable", sid, e)
         _episode_memo.pop(sid, None)
         return [], {}
     hit = _episode_memo.get(sid)
@@ -7299,20 +7393,28 @@ def _episode_read(sid):
         return hit[1], hit[2]
     rows, settles = [], {}
     try:
-        for line in p.read_text(errors="replace").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                r = json.loads(line)
-            except ValueError:
-                continue
-            if isinstance(r, dict) and r.get("head"):
-                rows.append(r)
-            elif isinstance(r, dict) and r.get("settleFor"):
-                settles[r["settleFor"]] = r           # newest annotation per boundary head wins
-    except OSError:
-        pass
+        text = p.read_text(errors="replace")
+    except (FileNotFoundError, NotADirectoryError):
+        _read_ok(str(p))                               # gone between the stat and the read: absent is a real state
+        _episode_memo.pop(sid, None)
+        return rows, settles
+    except OSError as e:
+        _read_failed(str(p), "episodes-unreadable", sid, e)
+        _episode_memo.pop(sid, None)
+        return rows, settles
+    _read_ok(str(p))
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            r = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(r, dict) and r.get("head"):
+            rows.append(r)
+        elif isinstance(r, dict) and r.get("settleFor"):
+            settles[r["settleFor"]] = r               # newest annotation per boundary head wins
     _episode_memo[sid] = (mt, rows, settles)
     return rows, settles
 
@@ -7852,13 +7954,23 @@ def _settle_not_before(fsid, path, now):
 
 def _death_marker(sid):
     """STATE/gone/<sid>.json — the recorded death event, or None. Reg-file read cost by design: this
-    sits on _cli_epoch's per-push path, so it must never scan the growing states stream."""
+    sits on _cli_epoch's per-push path, so it must never scan the growing states stream. A marker that
+    exists and cannot be read or parsed answers None too, and marks the running stage incomplete with one
+    `marker-unreadable` row per failure episode (_read_failed, review find 2026-09-08): the planner's and
+    closer's signatures carry the marker by identity, and a stamp over an epoch or a finalize that never
+    read it would skip the session until the marker moved, which a permission bit never makes it do."""
+    path_s = str(GONEDIR / (sid + ".json"))
     try:
-        with open(GONEDIR / (sid + ".json")) as f:
+        with open(path_s) as f:
             m = json.load(f)
-        return m if isinstance(m, dict) else None
-    except Exception:
+    except (FileNotFoundError, NotADirectoryError):
+        _read_ok(path_s)                               # absent is the common case and a real state
         return None
+    except Exception as e:                             # unreadable, or not a JSON document
+        _read_failed(path_s, "marker-unreadable", sid, e)
+        return None
+    _read_ok(path_s)
+    return m if isinstance(m, dict) else None
 
 
 def _cli_epoch(sid):
@@ -8311,18 +8423,28 @@ def _heal_floor_titles(fsid, store):
 def _prompt_gist(fsid, seg_id):
     """The persisted INDEX-tier gist of this segment's user message (captions/<fsid>.jsonl, id
     '<seg_id>#p', last-wins) — the same phrase the timeline dot and the Analyzing card show. '' when
-    the index pass hasn't captioned the message yet, or the file is unreadable."""
+    the index pass hasn't captioned the message yet, or the file is unreadable; a file that exists and
+    does not read also marks the running stage incomplete and logs a `captions-unreadable` row
+    (_read_failed, review find 2026-09-08): the planner's signature carries this file by identity, and a
+    stamp over a heal that never read it would skip the session until the file moved."""
     out = ""
+    path_s = str(CAPDIR / (fsid + ".jsonl"))
     try:
-        for line in (CAPDIR / (fsid + ".jsonl")).read_text(errors="replace").splitlines():
-            try:
-                o = json.loads(line)
-            except Exception:
-                continue
-            if o.get("id") == seg_id + "#p" and (o.get("caption") or "").strip():
-                out = o["caption"].strip()
-    except OSError:
-        pass
+        text = Path(path_s).read_text(errors="replace")
+    except (FileNotFoundError, NotADirectoryError):
+        _read_ok(path_s)                               # absent is a real state, and ends a failure episode
+        return out
+    except OSError as e:
+        _read_failed(path_s, "captions-unreadable", fsid, e)
+        return out
+    _read_ok(path_s)
+    for line in text.splitlines():
+        try:
+            o = json.loads(line)
+        except Exception:
+            continue
+        if o.get("id") == seg_id + "#p" and (o.get("caption") or "").strip():
+            out = o["caption"].strip()
     return out
 
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1080,7 +1080,48 @@ def pass_watermark(tier, fsid):
 # _auto_nudge_session, _clear_done_working_notes) see a world up to one pass old for every session, and
 # a turn that ends after a pass's first touch is judged next pass, whole. That is the frame's design
 # (2026-07-21); the gate adds no lag of its own beyond the producer's 3 s backstop for the clock input.
+#
+# SIGNATURE INPUTS PER TIER (the planner and closer first; the four store-only tiers added 2026-09-07).
+# Each list is what the tier's DECISION path reads, enumerated by reading the stage end to end; a read on
+# a path that ends in a write (or a completeness mark) is not listed, because the write moves the store
+# identity and re-arms the tier on its own. `_sig_inputs` carries the file lists, `_stage_sig` the
+# derived values.
+#  plan        parse pair + candidates; store, journal, archive; captions (_prompt_gist), episodes
+#              (episode_floor), gone marker + reg spawnedAt + _sdk_owned (_cli_epoch), cleared.jsonl
+#              (plan_units -> _live_anchor_gone -> _view_cleared), this sid's stall slice (rollup), the
+#              LEAF stem's task store (_sync_declared_plan). Clock: the bg-launch expiry.
+#  close       parse pair + candidates; store trio; gone marker, reg spawnedAt, _sdk_owned, cleared.jsonl,
+#              stall slice. Clock: the bg-launch expiry.
+#  unblock     parse pair + candidates (due = the parse's ended turns); store trio (load_goals,
+#              _blocked_sub_candidates, _newest_done_at, _completed_since). The candidate scan comes
+#              first, so about half the sessions never reach the parse, yet the pair re-arms them on
+#              every transcript append at one load each: accepted (about 10 ms per pass), stated here.
+#  group       store trio (_group_tops, _overgrown_tops, _group_sig read the store), cleared.jsonl
+#              (_group_tops -> _view_cleared). NO parse: it is read only after a relink, which follows a
+#              model call, which follows a store change. The archive stays in: compaction rewrites it
+#              without a journal row, and a store with a journaled restore row replays from it.
+#  consolidate store trio (_consolidate_tops), cleared.jsonl. NO parse, same reasoning as the grouper.
+#  distill     store trio (todo is a function of status, confirming, the nodes' stamps and diaries), the
+#              states file (_live_prompt_since), this sid's stall slice (stalled_facts, by value). NO
+#              parse and no peer store on the idle path: _title_mirror_tops reads the parse
+#              (_user_ask_text -> _session_user_prompt_record) and a peer's store and archive
+#              (_deleg_frame) only for an UNTITLED mirror top, and every such path ends in a write
+#              (titledT, the caller's save) or the paused incomplete mark; the todo loop reads the parse
+#              only after `if not todo`, and every branch of it writes or marks. `_drain_undiscovered`
+#              calls _distill_session directly for absent stores and is not gated (a straggler never
+#              holds a stamp to be skipped on).
+# Not in any signature, on purpose: MESSAGES (the parse cache key excludes it too: a delivery appends to
+# the transcript); retry-paused.json and usage.json (a skip on either is a "" call, so the belt marks the
+# run incomplete); session-flags.json (_hidden_from_feed filters run_plan's, run_close's and run_unblock's
+# session lists, and the post-pool eviction drops a hidden sid's stamps, so an unmute costs one full run;
+# the other three runners do not filter on it). A store loaded with the `_unread` mark (its override
+# journal exists and did not read) marks the run incomplete wherever it happens (_mark_unread), so a run
+# judged from a fallback view never stamps under the identity of files it did not read; a store file
+# that cannot be read raises at the stage's load (no stamp, a pass-crash row), and an unparseable one is
+# moved aside by load_goals, so the fresh store the stage judges is what the path holds.
 GATED_TIERS = ("plan", "close", "unblock", "group", "consolidate", "distill")
+PARSE_TIERS = ("plan", "close", "unblock")   # the tiers whose decision path reads the parse: their signature
+#                                              carries the pinned pair, and _gated checks the served pair
 _STAGE_STAMP = {}        # (tier, fsid) -> (sig, not_before): the inputs the tier last judged to completion
 _STAGE_LOCK = threading.Lock()
 _STAGE_STAMP_MAX = 4096  # belt: a wholesale clear at the cap (one full walk next pass)
@@ -1156,8 +1197,10 @@ def _sig_inputs(tier, fsid, path):
     (_prompt_gist), its pre-episode retire reads the episode log (episode_floor), _cli_epoch reads the
     gone marker and the reg, plan_units reads cleared.jsonl (_live_anchor_gone -> _view_cleared),
     rollup_status reads the stall slice, _sync_declared_plan reads the LEAF stem's task store; the
-    closer's idle path is the parse, the store, the marker, the reg, cleared.jsonl and the stall slice.
-    Kept apart from _stage_sig so the completeness test can hold a stage's reads against it."""
+    closer's idle path is the parse, the store, the marker, the reg, cleared.jsonl and the stall slice;
+    the unblocker's is the parse and the store; the grouper's and consolidator's the store and
+    cleared.jsonl; the distiller's the store, the states file and the stall slice (the inventory above
+    GATED_TIERS). Kept apart from _stage_sig so the completeness test can hold a stage's reads against it."""
     ident = [GOALDIR / (fsid + ".json"), _overrides_dir() / (fsid + ".jsonl"), GOALARCHDIR / (fsid + ".json")]
     value = []
     if tier in ("plan", "close"):
@@ -1166,19 +1209,29 @@ def _sig_inputs(tier, fsid, path):
     if tier == "plan":
         ident += [CAPDIR / (fsid + ".jsonl"), EPIDIR / (fsid + ".jsonl")]
         value += [em.task_store_dir(Path(path).stem)]
+    if tier in ("group", "consolidate"):
+        ident += [STATE / "cleared.jsonl"]
+    if tier == "distill":
+        ident += [STATESDIR / (fsid + ".jsonl")]
+        value += [STATE / "auto-nudge.json"]
     return ident, value
 
 
 def _stage_sig(tier, fsid, path):
     """The identity of every input `tier`'s decision path reads for `fsid`, taken BEFORE the stage runs:
-    the pass's pinned parse pair with the candidate files it names (a path swap with a coincidentally
-    equal fileset key cannot match), the store trio, and the tier's side files (_sig_inputs). Raises
-    OSError when a component cannot be computed (a vanished candidate, an unlistable task dir, a pinned
-    None pair): the caller runs the stage and stamps nothing, never a raise out of the submit loop."""
-    pair, _cut, _fr = _frame_parse_key(fsid, [path])
-    if pair is None:
-        raise OSError("no parse pair for %s this pass" % fsid)
-    parse = (tuple(_judge_candidates(fsid, [path])), _pair_key(pair))
+    for the parse tiers (PARSE_TIERS) the pass's pinned parse pair with the candidate files it names (a
+    path swap with a coincidentally equal fileset key cannot match), else None (the grouper, consolidator
+    and distiller read no parse on their decision paths, and pinning a key they never parse under would
+    cost four stats per session for nothing); the store trio; and the tier's side files (_sig_inputs)
+    and derived values. Raises OSError when a component cannot be computed (a vanished candidate, an
+    unlistable task dir, a pinned None pair): the caller runs the stage and stamps nothing, never a raise
+    out of the submit loop."""
+    parse = None
+    if tier in PARSE_TIERS:
+        pair, _cut, _fr = _frame_parse_key(fsid, [path])
+        if pair is None:
+            raise OSError("no parse pair for %s this pass" % fsid)
+        parse = (tuple(_judge_candidates(fsid, [path])), _pair_key(pair))
     ident, _value = _sig_inputs(tier, fsid, path)
     side = tuple(_ident(p) for p in ident)
     extra = ()
@@ -1186,6 +1239,8 @@ def _stage_sig(tier, fsid, path):
         extra = (_reg_spawned_at(fsid), _sdk_owned(fsid), _stall_slice(fsid))
     if tier == "plan":
         extra += (em.task_store_fp(Path(path).stem),)
+    if tier == "distill":
+        extra = (_stall_slice(fsid),)
     return (parse, side, extra)
 
 
@@ -1209,20 +1264,26 @@ def _gate_check(tier, fsid, path, now):
     return False, sig
 
 
-def _gated(tier, fn, fsid, path, now, sig, settle=True, parse=True):
+def _gated(tier, fn, fsid, path, now, sig, settle=True, parse=None):
     """Pool worker: run the stage, then stamp `sig` when the run was COMPLETE: it returned normally, set
-    no completeness bit, and (parse tiers) the frame served its parse under the very pair the signature
-    holds (a cut that moved between the pin and the parse means the judged world is not the stamped
-    one: no stamp). `settle`: the tier rolls up, so the stamp carries the clock input
-    (_settle_not_before). A stage that raises is counted `incomplete` (the run did not complete and
-    keyed nothing new) and the exception goes on to the runner's pass-crash row, so ran == stamped +
-    bypassed + incomplete holds through a crash.
+    no completeness bit, and (parse tiers) any parse the frame served for this sid was served under the
+    very pair the signature holds (a cut that moved between the pin and the parse means the judged world
+    is not the stamped one: no stamp; a stage that read no parse at all judged the store alone, and the
+    pinned pair stands for the transcript world it did not need). `settle`: the tier rolls up on its idle
+    path, so the stamp carries the clock input (_settle_not_before); the store tiers pass False (they
+    consult the settle on write paths only).
+    `parse`: whether to hold the served pair against the signature; None means `tier in PARSE_TIERS`.
+    A stage that raises is counted `incomplete` (the run did not complete and keyed nothing new) and the
+    exception goes on to the runner's pass-crash row, so ran == stamped + bypassed + incomplete holds
+    through a crash.
 
-    No frame, no stamp: the served pair the frame records is what makes a stamp exact. A runner
-    outside a pass frame (romp-judge's --plan, a test calling run_plan alone) therefore never writes a
-    stamp: every session runs and counts as bypassed, and the signature's stats are still paid. It DOES
-    honour a stamp a framed pass left: _gate_check reads the live signature either way, so an unframed
-    run after a framed one skips the sessions nothing has changed for, exactly as a framed run would."""
+    No frame, no stamp, for the parse tiers: the served pair the frame records is what makes their stamp
+    exact. A parse-tier runner outside a pass frame (romp-judge's --plan, a test calling run_plan alone)
+    therefore never writes a stamp: every session runs and counts as bypassed, and the signature's stats
+    are still paid. The store-only tiers have no frame-pinned component (every input is stat'd by the
+    gate itself), so they stamp with or without a frame. Either kind DOES honour a stamp a framed pass
+    left: _gate_check reads the live signature either way, so an unframed run after a framed one skips
+    the sessions nothing has changed for, exactly as a framed run would."""
     _judge_ctx.stage_incomplete = False
     _tier_bump(tier, "ran")
     try:
@@ -1237,13 +1298,20 @@ def _gated(tier, fn, fsid, path, now, sig, settle=True, parse=True):
         if getattr(_judge_ctx, "stage_incomplete", False):
             _tier_bump(tier, "incomplete")
             return out
+        if parse is None:
+            parse = tier in PARSE_TIERS
         if parse:
             fr = _frame
-            served = None
-            if fr is not None:
-                with _frame_lock:
-                    served = fr["served"].get(fsid)
-            if served is None or _pair_key(served) != sig[0][1]:
+            if fr is None:
+                _tier_bump(tier, "bypassed")          # no frame: no served pair to make the stamp exact
+                return out
+            with _frame_lock:
+                served = fr["served"].get(fsid, _NO_PIN)
+            # NO parse served for this sid in the pass means the stage never read one (its own read would
+            # have pinned it): the decision depended on the store alone, and the pinned pair the signature
+            # carries is exact for it (the unblocker with no blocked candidate, about half the sessions).
+            # A pair that WAS served must equal the pinned one; a pinned None (a failed stat) never matches.
+            if served is not _NO_PIN and (served is None or _pair_key(served) != sig[0][1]):
                 _tier_bump(tier, "bypassed")
                 return out
         nb = _settle_not_before(fsid, path, now) if settle else None
@@ -2153,6 +2221,7 @@ def _title_mirror_tops(store, fsid, path, now):
         out = mirror_title_llm(nd.get("text") or "", frame=_deleg_frame(store, nid),
                                user_ask=_user_ask_text(store, nid, fsid, path, now))
         if not out and getattr(_judge_ctx, "paused", False):
+            _judge_ctx.stage_incomplete = True         # nothing stamped, nothing written: the gate must not stamp
             continue                                   # skipped, not tried — retry next pass
         nd["titledT"] = int(now)
         titled += 1
@@ -3705,6 +3774,24 @@ def _fresh_store(fsid):
     return store
 
 
+def _mark_unread(store, reason):
+    """The store is NOT what its files say (see load_goals): carry `reason` as the transient `_unread` mark
+    and mark the running stage incomplete. The one load that answers with less than the files hold is a
+    parsed store whose override journal exists and did not read (`reason` "journal", set by
+    _replay_overrides: the user's gestures are missing from this view). A store FILE that cannot be read
+    RAISES out of load_goals instead (the stage dies at its load, _gated counts the run incomplete and the
+    runner files its pass-crash row), and unparseable bytes are moved aside with the fresh store as the
+    path's legitimate content, so neither is marked. Every reader tests the mark's truth; the string says
+    which file failed. The stage mark: the evidence gate stamps a complete run under the identity of the
+    files the stage read, and a run judged from a fallback view would stamp that identity without having
+    read those files; nothing on disk need change before the next read succeeds (an EMFILE, an EIO), so a
+    stamp over a fallback view would skip the session until the file moved, and the per-load judge-errors
+    row and the retry would become once per boot per tier. The mark keeps both per pass (2026-09-07).
+    Thread-local, so a load on the pusher thread marks nothing a stage reads."""
+    store["_unread"] = reason
+    _judge_ctx.stage_incomplete = True
+
+
 def _finish_load(fsid, store, lines=None):
     """The tail every loader runs on a freshly parsed, node-guarded store: replay the override journal
     (`lines` when the caller already read it, else from the file), re-derive the rollup when the replay
@@ -4112,8 +4199,9 @@ def _replay_overrides(fsid, store, lines=None):
                              note="override journal unreadable: %s — user actions may show undone until it reads" % e)
             # the store parsed but the journal exists and did not read: the user's gestures are missing from
             # this view until it does. The journal replays on every load, so a publish of this store loses
-            # nothing durable; the mark tells an identity-keyed reader not to cache it (see the docstring).
-            store["_unread"] = "journal"
+            # nothing durable; the mark tells an identity-keyed reader not to cache it (see the docstring)
+            # and the running stage not to stamp (_mark_unread)
+            _mark_unread(store, "journal")
             return False
     applied = False                                    # any write → load_goals re-runs rollup (one truth)
     arch_nodes = None                                  # the archive is read once, only if a restore entry needs it
@@ -10737,6 +10825,8 @@ def _group_store(store, fsid, now):
             if _sig_fail(store, "group", sig, "grouper", fsid,
                          "grouping this open-top set skipped until the set changes"):
                 store["groupedSig"] = sig              # give-up: adopt the set so the gate closes
+        else:
+            _judge_ctx.stage_incomplete = True         # a failed call writes nothing: the gate must not stamp
         return 0                                       # under the cap the sig stays stale → retry next call
     _sig_fail_clear(store, "group")
     relinks = apply_group(store, menu, ops, now)
@@ -10769,13 +10859,21 @@ def run_group(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=Fa
     fleet = discover(now)[:sessions_cap]
     n = 0
     with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
-        futs = {ex.submit(_group_session, fsid, str(path), now): fsid
-                for fsid, path, anchor, name in fleet}
+        futs = {}
+        for fsid, path, anchor, name in fleet:
+            # the evidence gate: the store trio and cleared.jsonl are the whole decision path (the parse
+            # is read only after a relink); identities taken at THIS tier's moment, so the courier's and
+            # propagate's publishes earlier in the pass are seen
+            skip, sig = _gate_check("group", fsid, str(path), now)
+            if not skip:
+                futs[ex.submit(_gated, "group", _group_session, fsid, str(path), now, sig, settle=False)] = fsid
         for fut in as_completed(futs):
             try:
                 n += fut.result()
+                pass_done("group", futs[fut])
             except Exception as e:                    # fail LOUDLY, never silently skip the store (T111)
                 _log_judge_error("grouper", futs[fut], "pass-crash", note=repr(e))
+    _gate_evict("group", {f[0] for f in fleet})
     if verbose:
         sys.stderr.write("romp-judge: grouper relinked %d top goals\n" % n)
     return n
@@ -10831,6 +10929,8 @@ def _consolidate_store(store, fsid, now):
             if _sig_fail(store, "consolidate", sig, "consolidator", fsid,
                          "consolidating this completed-top set skipped until the set changes"):
                 store["consolidatedSig"] = sig         # give-up: adopt the set so the gate closes
+        else:
+            _judge_ctx.stage_incomplete = True         # a failed call writes nothing: the gate must not stamp
         return changed                                 # under the cap the sig stays stale → retry next pass
     _sig_fail_clear(store, "consolidate")
     relinks = apply_group(store, cmenu, ops, now)
@@ -10863,13 +10963,18 @@ def run_consolidate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verb
     fleet = discover(now)[:sessions_cap]
     n = 0
     with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
-        futs = {ex.submit(_consolidate_session, fsid, str(path), now): fsid
-                for fsid, path, anchor, name in fleet}
+        futs = {}
+        for fsid, path, anchor, name in fleet:
+            skip, sig = _gate_check("consolidate", fsid, str(path), now)   # the evidence gate: store trio + cleared.jsonl
+            if not skip:
+                futs[ex.submit(_gated, "consolidate", _consolidate_session, fsid, str(path), now, sig, settle=False)] = fsid
         for fut in as_completed(futs):
             try:
                 n += fut.result()
+                pass_done("consolidate", futs[fut])
             except Exception as e:                    # fail LOUDLY, never silently skip the store (T111)
                 _log_judge_error("consolidator", futs[fut], "pass-crash", note=repr(e))
+    _gate_evict("consolidate", {f[0] for f in fleet})
     if verbose:
         sys.stderr.write("romp-judge: consolidator reorganized %d completed columns\n" % n)
     return n
@@ -12675,6 +12780,7 @@ def _unblock_session(fsid, path, now):
                             for i, (_nid, nd, _bt) in enumerate(due, 1))
     raw = unblock_llm(blocks_text, since, completed)   # ← seconds; no store copy held across this
     if not raw:
+        _judge_ctx.stage_incomplete = True             # nothing written: the evidence gate must not stamp
         return []                                      # call failed / paused (logged) → retry next pass
     lifts = _parse_unblock(raw, len(due))
     store = load_goals(fsid)                           # FRESH load: apply onto the current store, never the
@@ -12731,13 +12837,20 @@ def run_unblock(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=
     fleet = [s for s in discover(now) if not _hidden_from_feed(s[0])][:sessions_cap]
     n = 0
     with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
-        futs = {ex.submit(_unblock_session, fsid, str(path), now): fsid
-                for fsid, path, anchor, name in fleet}
+        futs = {}
+        for fsid, path, anchor, name in fleet:
+            # the evidence gate: the parse pair (due = the parse's ended turns) and the store trio are
+            # the whole decision path; no rollup on the idle path, so no clock input (settle=False)
+            skip, sig = _gate_check("unblock", fsid, str(path), now)
+            if not skip:
+                futs[ex.submit(_gated, "unblock", _unblock_session, fsid, str(path), now, sig, settle=False)] = fsid
         for fut in as_completed(futs):
             try:
                 n += len(fut.result())
+                pass_done("unblock", futs[fut])
             except Exception as e:                    # fail LOUDLY, never silently skip the store (T111)
                 _log_judge_error("unblocker", futs[fut], "pass-crash", note=repr(e))
+    _gate_evict("unblock", {f[0] for f in fleet})
     if verbose:
         sys.stderr.write("romp-judge: unblocker lifted %d stale blocks\n" % n)
     return n
@@ -13984,6 +14097,7 @@ def _distill_session(fsid, path, now):
             out = stall_llm(nodes[top].get("text", ""), work, holding)
             if not out:
                 if getattr(_judge_ctx, "paused", False):   # pause-skip, not a real failure (see the briefer)
+                    _judge_ctx.stage_incomplete = True     # deferred with no write: the gate must not stamp
                     continue
                 fails = nodes[top].get("stallFails", 0) + 1
                 _fail_log(nodes[top], "stall", now)    # the chip's attempt history: model + literal error
@@ -14108,6 +14222,7 @@ def _distill_session(fsid, path, now):
                                   user_ask=_user_ask_text(store, top, fsid, path, now)))
             if not out:
                 if getattr(_judge_ctx, "paused", False):   # the call was SKIPPED (global retry-pause on), not
+                    _judge_ctx.stage_incomplete = True     # deferred with no write: the gate must not stamp
                     continue                               # tried — never count a pause-skip toward give-up, else
                     # a retry-pause (esp. one that flaps on/off mid-pass) permanently blanks the card's brief to
                     # the "" sentinel though the API was never actually asked (the user 2026-07-03). Leave
@@ -14153,7 +14268,10 @@ def _distill_session(fsid, path, now):
                     if not _r2 and getattr(_judge_ctx, "paused", False):
                         # the retry was SKIPPED, not tried — the standing pause discipline: leave
                         # the brief null and re-enter next pass once the pause clears; a pause-skip
-                        # never counts as a verdict (the 2026-07-03 rule, met again here)
+                        # never counts as a verdict (the 2026-07-03 rule, met again here). The eager
+                        # promptBriefedT stamp above may already have set `changed`; either way the
+                        # brief is still owed, so the gate must not stamp this run
+                        _judge_ctx.stage_incomplete = True
                         changed = True
                         continue
                     _o2, _s2, _q2 = _split_source(_r2 or "")
@@ -14244,6 +14362,7 @@ def _distill_session(fsid, path, now):
                           user_ask=_user_ask_text(store, top, fsid, path, now))
         if not out:
             if getattr(_judge_ctx, "paused", False):   # pause-skip, not a real failure — don't count it toward
+                _judge_ctx.stage_incomplete = True     # deferred with no write: the gate must not stamp
                 continue                               # give-up (leave summary null → re-enters once unpaused)
             fails = nodes[top].get("distillFails", 0) + 1   # the failed call itself was logged by _judge_run
             _fail_log(nodes[top], "summary", now)      # the chip's attempt history: model + literal error
@@ -14651,12 +14770,20 @@ def run_distill(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=
     fleet = discover(now)[:sessions_cap]
     n = 0
     with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
-        futs = {ex.submit(_distill_session, fsid, str(path), now): fsid for fsid, path, anchor, name in fleet}
+        futs = {}
+        for fsid, path, anchor, name in fleet:
+            # the evidence gate: the store trio, the states file and this sid's stall records are the whole
+            # decision path (the inventory above GATED_TIERS); the drain below stays ungated
+            skip, sig = _gate_check("distill", fsid, str(path), now)
+            if not skip:
+                futs[ex.submit(_gated, "distill", _distill_session, fsid, str(path), now, sig, settle=False)] = fsid
         for fut in as_completed(futs):
             try:
                 n += fut.result()
+                pass_done("distill", futs[fut])
             except Exception as e:                     # fail LOUDLY, never silently skip the store
                 _log_judge_error("distiller", futs[fut], "pass-crash", note=repr(e))
+    _gate_evict("distill", {f[0] for f in fleet})
     n += _drain_undiscovered(now, {fsid for fsid, _p, _a, _n2 in fleet})
     if verbose:
         sys.stderr.write("romp-judge: distiller summarized %d completed goals\n" % n)

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2562,7 +2562,11 @@ def parsed_session(fsid, files, now):
         key = None
     hit = _PARSE_CACHE.get(fsid)
     if key is not None and hit and hit[0] == key:
-        return hit[1]
+        fr = _frame
+        if fr is not None:                 # a WARM first touch pins too (review 2026-09-06): this path used to
+            with _frame_lock:              #  return unpinned, so a session already in the cache froze nothing
+                return fr["parses"].setdefault(fsid, hit[1])   # and a mid-pass append reached a later stage
+        return hit[1]                      #  only - the two-worlds shape the frame exists to prevent
     session = em.parse_session(files[0], rompuuid=fsid, candidate_files=list(files),
                                states=str(states), postal_log=str(MESSAGES), now=now,
                                sdk_human=_sdk_owned(fsid),   # SDK session → composer input is promptSource "sdk" = the human (mirrors the kernel)

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -952,7 +952,9 @@ def _log_judge_error(judge, fsid, err, note=None, goal=None, seg=None):
              that loads a store strictly instead raises into the pass wrapper's "pass-crash" row),
              "store-unwritable" (a goals store that read but whose publish
              then failed under a user gesture, the save path's own strict read or the write itself; filed
-             once per fault episode by save_goals_or_fault, and the gesture is answered on its socket)
+             once per fault episode by save_goals_or_fault, and the gesture is answered on its socket),
+             "unroll-heal" (a top left the rolled-up state with settle rows and no done in its diary; a romp
+             reopen row ended that settled episode so the node can be judged again — _heal_settle_without_done)
       note   the evidence — reply tail, error message, exception name, or the give-up scope + re-arm
              event. Callers must pass it; an empty note means the caller has nothing at all to show.
       goal   the node id (or list of node ids) the judge was ruling on, when one exists — the feed's
@@ -5985,7 +5987,7 @@ def rollup_status(store, session_closed, now=None):
     never a competing truth. The tree layers (roll-down, moot-block clearing, settled/sticky,
     followupPending) run after, as cache maintenance over the fold's node states."""
     nodes = store["nodes"]
-    folds = _materialize_from_log(nodes)               # P3.3: history → flags; the log is the authority
+    folds = _materialize_from_log(nodes, store)        # P3.3: history → flags; the log is the authority
     #                                                    (migration is a BOOT sweep now — migrate_all_stores)
     # DONE-BY-ASSOCIATION GUARD (the user 2026-08-24): before the roll-down loops can fold them, the
     # OPEN children of every COMPLETED handoff tracking node move up beside it (_lift_handoff_children)
@@ -6043,11 +6045,29 @@ def rollup_status(store, session_closed, now=None):
             while p in _umbrellas and p not in _seen:   # nested containers dissolve to the first
                 _seen.add(p); p = _uparent.get(p)       # NON-container ancestor (usually None)
             return None if p in _umbrellas else p
+        _kids = {}                                      # parentIds before any re-parenting: the walk below
+        for _k, _v in nodes.items():                    # descends from a promoted child, whose own subtree
+            _kids.setdefault(_v.get("parentId"), []).append(_k)   # the move does not change
         for _uid in _umbrellas:
             newp = _solid_parent(_uid)
-            for _cn in nodes.values():
+            for _cid, _cn in nodes.items():
                 if isinstance(_cn, dict) and _cn.get("parentId") == _uid:
                     _cn["parentId"] = newp              # usually None → its own card again
+                    # A child the roll-down had folded under the container (rolledUp) is judged by its
+                    # OWN diary from here, not by the container's verdict: the marker mirrored a
+                    # resolved ancestor, and this sweep removes that ancestor. Kept, the marker made the
+                    # promoted child a top nothing re-derived (_materialize_from_log and record_verdict
+                    # both skip rolledUp nodes): is_complete read its stale done flag, settledDone never
+                    # landed, and the settle branch below appended a settle row and a seam on EVERY
+                    # rollup. One live node reached LOG_CAP (64 settle rows, logTrunc) with its store's
+                    # seams at cap and about 1 MB republished per pass (review 2026-09-06). The child's
+                    # rolled-up DESCENDANTS mirrored the same ancestor, so the whole promoted subtree is
+                    # unrolled and folded, each node from its own diary; an unroll that stopped at the
+                    # child left them done under a now-open top. A node whose new solid ancestor is
+                    # itself resolved is re-folded by this rollup's roll-down. The folds are recorded so
+                    # the held-open rule sees the promoted nodes like any other, and a promoted TOP
+                    # whose diary holds the bug's settle rows is reopened once (_heal_settle_without_done).
+                    _unroll_subtree(store, nodes, _kids, _cid, folds)
             nodes.pop(_uid, None)
             store.get("status", {}).pop(_uid, None)
         _pl = store.get("placements") or {}
@@ -8044,11 +8064,8 @@ def _reopen(store, gid, by="?", now=None, msg=False):
     while stack:
         c = stack.pop()
         nd = nodes.get(c)
-        if nd and dict.pop(nd, "rolledUp", None):  # (dict.pop: the guarded pop needs authority)
-            with _authority():
-                nd["nodeComplete"] = nd["blocked"] = nd["cleared"] = False   # undo roll-down's tree cache
-            if "log" in nd:
-                _materialize_node(nd)                  # back under fold ownership: its own history (usually
+        if nd:
+            _unroll_node(nd)                           # back under fold ownership: its own history (usually
         stack.extend(kids.get(c, []))                  # none → open; a rolled-away block resurfaces) rules
 
 
@@ -8672,27 +8689,157 @@ def migrate_all_stores():
     return n
 
 
-def _materialize_from_log(nodes):
+def _unroll_node(nd, materialize=True):
+    """Drop roll-down's tree-derived cache from `nd`: the rolledUp marker and the three flags it set, then
+    (with a diary present, unless the caller materializes itself) rewrite the flags from that diary.
+    Returns True when the marker was there. The marker means "a resolved ANCESTOR's roll-down set these
+    flags", so it is dropped exactly when no resolved ancestor remains above the node: the ancestor is
+    reopened (_reopen), the container above it dissolves (rollup_status's dissolution sweep), or the node
+    has the marker with no resolved ancestor left (_materialize_from_log's repair of a store published
+    that way). Eventless, like the roll-down that set it: the node's own history decides its flags from
+    here (usually no rows, so open; a rolled-away block is blocked again), and the same rollup's roll-down
+    re-derives the cache when a resolved ancestor is still above the node."""
+    if not dict.pop(nd, "rolledUp", None):             # (dict.pop: the guarded pop needs authority)
+        return False
+    with _authority():
+        nd["nodeComplete"] = nd["blocked"] = nd["cleared"] = False   # undo roll-down's tree cache
+    if materialize and "log" in nd:
+        _materialize_node(nd)
+    return True
+
+
+def _resolved_ancestor(nodes, nd):
+    """True when an ancestor of `nd` that is NOT itself rolled up reads complete or cleared: the
+    resolution a rolledUp marker mirrors. A rolled-up ancestor's flags are the same mirror, so they are
+    not evidence; a top's or a solid interior node's flags come from its own diary (materialized before
+    this is asked). A missing ancestor reads as none."""
+    x, seen = nd.get("parentId"), set()
+    while x is not None and x not in seen:
+        seen.add(x)
+        a = nodes.get(x)
+        if a is None:
+            return False
+        if not a.get("rolledUp") and (a.get("nodeComplete") or a.get("cleared")):
+            return True
+        x = a.get("parentId")
+    return False
+
+
+def _unroll_subtree(store, nodes, kids, root, folds):
+    """Unroll `root` and every rolled-up node under it (`kids`: parentId -> child ids), fold each from its
+    own diary and record the fold in `folds`; a TOP among them whose diary holds the bug's settle rows is
+    reopened (_heal_settle_without_done). The dissolution sweep calls this for each child it promotes: the
+    child's marker and its descendants' markers all mirrored the container being removed, so all of them
+    are dropped together; an unroll that stopped at the child left its descendants done under a now-open
+    top (review 2026-09-06). A node without the marker is skipped, so a node reached twice through nested
+    containers is folded once. The same rollup's roll-down re-marks any node that still has a resolved
+    ancestor after the re-parenting."""
+    stack = [root]
+    while stack:
+        nid = stack.pop()
+        nd = nodes.get(nid)
+        if nd is None:
+            continue
+        stack.extend(kids.get(nid, []))
+        if not _unroll_node(nd, materialize=False):
+            continue
+        f = _materialize_node(nd)
+        if f is None:
+            continue
+        if nd.get("parentId") is None:
+            f = _heal_settle_without_done(store, nd, f)
+        folds[nid] = f
+
+
+def _heal_settle_without_done(store, nd, fold):
+    """Reopen a TOP that has just lost the rolledUp marker when its fold reads a settled episode on a node
+    that is not done, and return the fold after the reopen (the given fold otherwise).
+
+    The shape is the marker bug's product. rollup_status appends a settle row when a top reads complete
+    and settled, and a rolledUp node is never materialized, so a promoted child with a stale done flag got
+    one settle row per rollup and settledDone never latched (which is what stops the appends). A node
+    that is not done cannot settle otherwise: a non-umbrella top reads complete only through its own done
+    verdict, or through a settledDone it already carries. Once the marker is gone the fold turns those
+    rows into settledDone on an open (or blocked) node: the card reads Working, but every settledDone
+    reader (open_menu's seal, the closer's and planner's candidate filters) treats the node as sealed, so
+    no judge can move it and nothing shows why. A blocked top with the same rows is one unblock away from
+    that state (_blocked_sub_candidates does not read settledDone, and the lift's unblock row leaves the
+    settle in place), so it is healed the same way.
+
+    The heal is a romp-authored reopen row (record_verdict; may_apply admits a reopen from any source
+    unless the node is view-cleared, in which case the node stays sealed as the user left it). In the fold
+    a reopen moves the current settle to deltaSince and clears settledAt, so settledDone drops, the state
+    reads open and the node is judged like any other open top. ev_t is the store's latest evidence
+    moment, and at least the settle's own, so the row folds after the rows it ends. One judge-errors row
+    ("unroll-heal") names the node and the row count, so the heal is visible where the diary is inspected.
+    It runs once per node: the marker is gone after the unroll, so no later rollup reaches this point for
+    the same node.
+
+    One legitimate shape can reach here: a bottom-up-era top (its settle row landed with no done of its
+    own, under the settledDone grandfather in is_complete) that the retired grouper filed under a
+    container, and the container's roll-down then marked. The heal wakes it as Working; its children are
+    all done, so the closer's all-children-done trigger rules it again on its next pass."""
+    if nd.get("parentId") is not None or fold is None or fold["state"] == "done" or not fold["settledAt"]:
+        return fold
+    nodes = (store or {}).get("nodes") or {}
+    latest = max((max(n.get("mt", 0) or 0, n.get("t", 0) or 0) for n in nodes.values()), default=0)
+    ev = max(int(fold["settledAt"]), int(latest))
+    n_settle = sum(1 for e in (nd.get("log") or []) if e.get("kind") == "settle")
+    if not record_verdict(store, nd, "romp", "reopen", ev,
+                          why="reopened: the settle rows landed while this node was not done"):
+        return fold
+    _log_judge_error("romp", str(nd.get("id") or "?").split(":")[0], "unroll-heal", goal=nd.get("id"),
+                     note="top left the rolled-up state with %d settle row(s) and fold state %r; a romp "
+                          "reopen row ended the settled episode so the node can be judged again"
+                          % (n_settle, fold["state"]))
+    return _fold_node(nd)
+
+
+def _materialize_from_log(nodes, store=None):
     """P3.3 AUTHORITY (the user 2026-07-06): the verdict log IS the node's verdict state; the flags are
     a materialized cache the read side keeps consuming unchanged. Rewriting them from the fold every
     rollup gives the flip its teeth — any flag mutation that bypassed record_verdict is overwritten by
     history on the next pass. Tree-level effects (roll-down display, moot-block clearing, the settled /
     sticky machinery) run AFTER this in rollup_status, layering tree truth over node truth — they are
-    cache maintenance now, not competing authorities. rolledUp children keep their tree-derived cache
-    (their flags were never node-level verdicts).
+    cache maintenance now, not competing authorities. rolledUp nodes under a resolved ancestor keep their
+    tree-derived cache (their flags were never node-level verdicts); one with no resolved ancestor left
+    is unrolled and folded like any other (the repair below).
 
     Since the P3.4 follow-through (the user 2026-07-07) the DERIVED STAMPS are cache too: followupAt,
     followupPending, settledAt/settledDone, deltaSince are rewritten from the fold here — their old
     write/pop sites (optimistic_followup, _reopen's un-stick dance, rollup's deadlock heals)
     are gone. Returns {nid: fold} so rollup_status reuses the folds (the held-open rule) without
-    re-folding."""
+    re-folding. `store` is what the repair below needs to record a verdict (rollup_status passes its
+    own)."""
     folds = {}
+    rolled = []
     for nid, nd in nodes.items():
         if nd.get("rolledUp"):
-            continue                                   # tree-derived display state; roll-down owns it
+            rolled.append(nid)                         # after the solid nodes: the ancestor check below
+            continue                                   # reads flags this loop has just rewritten
         f = _materialize_node(nd)
         if f is not None:
             folds[nid] = f
+    for nid in rolled:
+        nd = nodes[nid]
+        if _resolved_ancestor(nodes, nd):
+            continue                                   # tree-derived display state; roll-down owns it
+        # A rolled-up node with NO resolved ancestor has nothing left to mirror: a container was
+        # dissolved above it and the store was published with the marker still set (the dissolution
+        # sweep dropped no markers before the 2026-09-06 fix). Left alone it was a node nothing
+        # re-derived (this skip, and record_verdict's), so a stale done flag settled a top again on every
+        # rollup and kept a descendant done under an open top. Drop the cache and fold the node from its
+        # own diary, like any other; a TOP whose diary holds the bug's settle rows is reopened once. The
+        # check reads only ancestors that are not themselves rolled up, so the order of this loop does
+        # not matter: a rolled-up ancestor is either unrolled here too or re-marked by this rollup's
+        # roll-down.
+        _unroll_node(nd, materialize=False)
+        f = _materialize_node(nd)
+        if f is None:
+            continue
+        if nd.get("parentId") is None:
+            f = _heal_settle_without_done(store, nd, f)
+        folds[nid] = f
     return folds
 
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2562,11 +2562,16 @@ _COURIER_SEEN = {}         # fsid -> the scan key of its last pass that found no
 # the leaf fsid's directory, which a /clear forks away from an SDK session's sid), the reg file's key, the
 # captions file's key (the floor-title heal reads it), each running background launch with whether it has
 # crossed its deadline under the pass clock (the settle's one input no file records; see _bg_expiry_key),
-# and the transcript path. Recorded only when the pass did nothing and the store's key after the pass
-# equals the one before it (a heal, a mint, a retirement or a rollup change moves it); a pass with units,
-# placements or a moved store is planned again next pass whatever the key says. A parse the cache does not
-# hold is never keyed, nor is an expiry view that cannot be computed. Pruned to the sessions the pass
-# discovered; a rebound root clears.
+# and the transcript path. Recorded only when the pass did nothing, the store's key after the pass
+# equals the one before it (a heal, a mint, a retirement or a rollup change moves it), and the pass was
+# COMPLETE by the evidence gate's bit (_judge_ctx.stage_incomplete, reset by _gated before the run: a
+# deferral without a write or a side file that exists and did not read sets it); a pass with units,
+# placements, a moved store or that bit is planned again next pass whatever the key says. A parse the cache
+# does not hold is never keyed, nor is an expiry view that cannot be computed. Pruned to the sessions the
+# pass discovered; a rebound root clears. This gate sits INSIDE _plan_session; the evidence gate
+# (GATED_TIERS, _gate_check and _gated in run_plan) sits around it and keys on a superset of these inputs
+# (cleared.jsonl, the death marker, the reg's spawnedAt value and the stall slice as well), so most skips
+# happen there and this table sees the sessions it let through.
 _PLANNER_SEEN = {}         # fsid -> the plan key of its last pass that had nothing to do
 _PLANNER_STATS = {"skipped": 0, "planned": 0, "recorded": 0}
 
@@ -10299,11 +10304,18 @@ def _plan_session(fsid, path, now):
     rollup_status(store, _session_settled(fsid, path, session, store, now))
     save_goals(fsid, store)
     if pkey is not None:
-        if placed == 0 and not units and not retired and _store_key(fsid) == pkey[2]:
+        if placed == 0 and not units and not retired and _store_key(fsid) == pkey[2] \
+                and not getattr(_judge_ctx, "stage_incomplete", False):
             _PLANNER_SEEN[fsid] = pkey               # nothing to do and nothing written: skipped until an input moves
             _PLANNER_STATS["recorded"] += 1
         else:
-            _PLANNER_SEEN.pop(fsid, None)            # work done or the store moved: planned again next pass
+            _PLANNER_SEEN.pop(fsid, None)            # work done, the store moved, or the pass was INCOMPLETE (the
+            #                                          completeness bit the evidence gate reads, _gated: a stand-down
+            #                                          without a write, or a side file that exists and did not read):
+            #                                          planned again next pass. A recorded incomplete pass would skip
+            #                                          the session until an input moved, which a permission bit never
+            #                                          does, and would let the outer gate stamp the short-circuit
+            #                                          as a complete run (2026-09-09).
     return placed
 
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -182,6 +182,8 @@ def _rebind_state(path):
         _VIEW_CLEARED_MEMO.clear()   # the cleared.jsonl replay memo and the states-log scan memo: full-path
     with _LIVE_PROMPT_LOCK:          # keys, so an old root's entries could never hit under the new one;
         _LIVE_PROMPT_MEMO.clear()    # cleared anyway so a rebind starts empty
+    with _UNREADABLE_LOCK:
+        _UNREADABLE_LOGGED.clear()   # the read-failure episodes are per path too
     _shared_clear()             # the shared read-only store cache: same path keying, same reason; also lifts
     #                         a test's deliberate write-guard trip (the poison flag) so the next class starts clean
     with _STAGE_LOCK:
@@ -1118,7 +1120,9 @@ def pass_watermark(tier, fsid):
 # journal exists and did not read) marks the run incomplete wherever it happens (_mark_unread), so a run
 # judged from a fallback view never stamps under the identity of files it did not read; a store file
 # that cannot be read raises at the stage's load (no stamp, a pass-crash row), and an unparseable one is
-# moved aside by load_goals, so the fresh store the stage judges is what the path holds.
+# moved aside by load_goals, so the fresh store the stage judges is what the path holds. The same holds
+# for the side files a stage reads after the gate stat'd them (cleared.jsonl, the states file, the stall
+# records): a read that fails on a file that exists marks the run incomplete and logs a row (_read_failed).
 GATED_TIERS = ("plan", "close", "unblock", "group", "consolidate", "distill")
 PARSE_TIERS = ("plan", "close", "unblock")   # the tiers whose decision path reads the parse: their signature
 #                                              carries the pinned pair, and _gated checks the served pair
@@ -1158,6 +1162,37 @@ def _ident(p):
     return (st.st_ino, st.st_mtime_ns, st.st_size)
 
 
+_UNREADABLE_LOGGED = set()   # path strings whose last read failed and was logged: one row per failure episode
+_UNREADABLE_LOCK = threading.Lock()
+
+
+def _read_failed(path_s, err, fsid, exc):
+    """A file the signature stat'd (or reads by value) could not be READ by the stage: mark the running
+    stage incomplete and log one judge-errors row. An absent file is a real state (_ident's None, the
+    scans' FileNotFoundError) and is never this; every other failure (a permission bit, EMFILE, EIO, an
+    unparseable document) means the stage decided WITHOUT an input the signature says it saw, and a stamp
+    would skip the session until that file moved, which a permission or descriptor failure never does
+    (review finding, 2026-09-07; before the memos the same hole stood in the planner's and closer's
+    cleared.jsonl read). One row per failure episode, the first failed read after a good or an absent one
+    (_read_ok: absence is a real state, so a file removed and recreated unreadable is a new episode), not
+    one per call: the stall slice alone is read three times per session per pass, and a wedged shared file
+    would otherwise write a row for every one of them."""
+    _judge_ctx.stage_incomplete = True
+    with _UNREADABLE_LOCK:
+        first = path_s not in _UNREADABLE_LOGGED
+        _UNREADABLE_LOGGED.add(path_s)
+    if first:
+        _log_judge_error("romp", fsid or "", err,
+                         note="%s unreadable: %r — the pass judged without it and stays due until it reads"
+                              % (os.path.basename(path_s), exc))
+
+
+def _read_ok(path_s):
+    """A read of `path_s` succeeded, or found it absent: the next failure is a new episode and logs again."""
+    with _UNREADABLE_LOCK:
+        _UNREADABLE_LOGGED.discard(path_s)
+
+
 def _reg_spawned_at(fsid):
     """The spawnedAt VALUE of STATE/sdk/<fsid>.json, the only field _cli_epoch reads from it: model
     picks, task writes, push notes and subagent events rewrite the reg and leave spawnedAt alone (40
@@ -1179,8 +1214,9 @@ def _reg_spawned_at(fsid):
 def _stall_slice(fsid):
     """This session's stall records as a comparable tuple: what rollup_status's stall-warn retire reads
     (stalled_facts). A record appearing or ending for THIS sid moves it; another sid's does not. Read by
-    value from the file each time, for the reason _reg_spawned_at gives."""
-    return tuple(sorted((g, r.get("why"), r.get("since")) for g, r in stalled_facts(fsid).items()))
+    value from the file each time, for the reason _reg_spawned_at gives; strict, so a file that exists and
+    does not read raises and the gate runs the stage without a stamp instead of matching an empty slice."""
+    return tuple(sorted((g, r.get("why"), r.get("since")) for g, r in stalled_facts(fsid, strict=True).items()))
 
 
 def _pair_key(pair):
@@ -10402,13 +10438,16 @@ def _view_cleared():
     mute-seal paths and the judge's echo clears all open it "a"), so no two versions share a size; the one
     write an identity memo cannot see, a rewrite in place of equal size within one mtime tick, is a pattern
     nothing uses on this file. Stat before read, so a row landing between the two costs one extra replay,
-    never a stale answer; an unreadable file answers empty and is not memoized. Returns a frozenset: every
-    caller tests membership, and a mutation of the shared memo would be a silent corruption, so it raises
-    instead."""
+    never a stale answer. A file that exists and cannot be read answers empty, is not memoized, marks the
+    running stage incomplete and logs a `cleared-unreadable` row (_read_failed): the evidence gate stat'd
+    this file into the signature, and a stamp over an answer that never read it would skip the session
+    until the file moved. Returns a frozenset: every caller tests membership, and a mutation of the shared
+    memo would be a silent corruption, so it raises instead."""
     path_s = str(STATE / "cleared.jsonl")
     try:
         st = os.stat(path_s)
     except OSError:
+        _read_ok(path_s)                           # absent (as this branch reads any failed stat) ends an episode
         with _VIEW_CLEARED_LOCK:
             _VIEW_CLEARED_MEMO.pop(path_s, None)
         return frozenset()
@@ -10419,8 +10458,13 @@ def _view_cleared():
         return hit[1]
     try:
         cur = frozenset(_view_cleared_scan(path_s))
-    except OSError:
+    except FileNotFoundError:
+        _read_ok(path_s)
+        return frozenset()                         # gone between the stat and the read: absent is a real state
+    except OSError as e:
+        _read_failed(path_s, "cleared-unreadable", getattr(_judge_ctx, "fsid", ""), e)
         return frozenset()
+    _read_ok(path_s)
     with _VIEW_CLEARED_LOCK:
         _VIEW_CLEARED_MEMO[path_s] = (key, cur)
     return cur
@@ -13696,16 +13740,31 @@ def stall_llm(goal_text, work_text, holding):
 WHY_IN_FLIGHT = (WHY_JUDGING, _WHY_JUDGING_LEGACY, WHY_TURN_IN_FLIGHT, WHY_UNBLOCK_UNSETTLED)
 
 
-def stalled_facts(fsid):
+def stalled_facts(fsid, strict=False):
     """{gid: {"why", "since"}} for THIS session's goals the kernel's nudge gate is holding on a reviver that
     isn't retiring — the mechanical stall reasons it records in auto-nudge.json (kernel _stalled_goals is the
     twin read). Read from the FILE rather than imported: the kernel imports this module, never the reverse.
-    {} on an absent/unreadable file — a stall note is an extra surface, never a reason to fail a pass."""
+    {} on an absent file — a stall note is an extra surface, never a reason to fail a pass. A file that
+    exists and cannot be read or parsed marks the running stage incomplete and logs a `stall-unreadable`
+    row (_read_failed), then answers {} too, unless `strict`, when it raises OSError: the evidence gate
+    reads this file by value into the planner's, closer's and distiller's signatures (_stall_slice), and a
+    signature computed from a failed read would equal the last good one whenever the records were empty,
+    so the gate would skip a session over a file it could not see; raising makes the gate run the stage
+    and stamp nothing, as it does for any other unreadable component. The stage's own read then fails the
+    same way and marks the run, so a read that fails AFTER a good signature read cannot stamp either."""
     out = {}
+    path_s = str(STATE / "auto-nudge.json")
     try:
-        d = json.loads((STATE / "auto-nudge.json").read_text())
-    except Exception:
+        d = json.loads(Path(path_s).read_text())
+    except FileNotFoundError:
+        _read_ok(path_s)                               # absent is a real state, and ends a failure episode
         return out
+    except Exception as e:                             # unreadable, or not a JSON document
+        _read_failed(path_s, "stall-unreadable", fsid, e)
+        if strict:
+            raise OSError("auto-nudge.json unreadable: %r" % (e,))
+        return out
+    _read_ok(path_s)
     for gid, rec in ((d.get("deferred") if isinstance(d, dict) else None) or {}).items():
         if not isinstance(rec, dict) or not str(gid).startswith(fsid + ":"):
             continue                                   # a legacy bare-int record predates the why → nothing to say
@@ -13742,11 +13801,15 @@ def _live_prompt_since(fsid):
     rewrite in place of equal size within one mtime tick, is a pattern nothing uses on this file (the
     evidence gate's value inputs are read by value because their fixtures did). Stat before read: a row
     landing between the two pairs an old identity with new content, which costs one extra scan next
-    time, never a stale answer. An unreadable file answers None and is not memoized."""
+    time, never a stale answer. A file that exists and cannot be read answers None, is not memoized, marks
+    the running stage incomplete and logs a `states-unreadable` row (_read_failed): the distiller's
+    signature carries this file by identity, and a stamp over an answer that never read it would skip the
+    session until the file moved (a brief owed to a parked session would wait on an unrelated row)."""
     path_s = str(STATESDIR / (fsid + ".jsonl"))
     try:
         st = os.stat(path_s)
     except OSError:
+        _read_ok(path_s)                           # absent (as this branch reads any failed stat) ends an episode
         with _LIVE_PROMPT_LOCK:
             _LIVE_PROMPT_MEMO.pop(path_s, None)
         return None
@@ -13757,8 +13820,13 @@ def _live_prompt_since(fsid):
         return hit[1]
     try:
         since = _live_prompt_since_scan(path_s)
-    except OSError:
+    except FileNotFoundError:
+        _read_ok(path_s)
+        return None                                # gone between the stat and the read: absent is a real state
+    except OSError as e:
+        _read_failed(path_s, "states-unreadable", fsid, e)
         return None
+    _read_ok(path_s)
     with _LIVE_PROMPT_LOCK:
         _LIVE_PROMPT_MEMO[path_s] = (key, since)
     return since

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -12112,7 +12112,7 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
     _judge_ctx.fsid = fsid                            # usage logging: attribute this session's judge calls
     session = parsed_session(fsid, [path], now)
     store = load_goals(fsid)
-    seg_by_id = {seg["id"]: seg for turn in session["turns"] for seg in _segs(turn, store)}
+    seg_by_id = None                                  # built on the first turn the walk judges (below)
     swept = _closed_turns(store)
     sig = dict(store.get("closedSig") or {})
     turns = session["turns"]
@@ -12127,6 +12127,15 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
             break                                      # an explicit caller (a test) can still bound a backfill
         _judge_ctx.last_call_fail = None               # a stale stash must never charge THIS turn (below)
         _judge_ctx.close_menu = None                   # …nor a stale menu shape describe this turn's call
+        if seg_by_id is None:
+            # The seam-aware segment index over EVERY turn, built once, on the first turn the walk judges
+            # (2026-09-07): its only consumer is _close_turn's goal-history block, which a session whose
+            # every end-known turn is already swept never reaches, and that walk was one _segs call per
+            # turn per pass for every session. Built here it equals the dict the walk used to build before
+            # the loop: nothing between load_goals and the first judged turn writes seams (apply_close
+            # never touches them; rollup_status stamps them after the walk). A dict, never None:
+            # _close_turn skips the history block when handed None.
+            seg_by_id = {seg["id"]: seg for t in turns for seg in _segs(t, store)}
         res = _close_turn(store, turn, seg_by_id=seg_by_id)
         if res is None:
             # Every leg below is "retry next pass" for this turn (a failed call, a parse reject under

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -4602,6 +4602,17 @@ def save_goals(fsid, store):
     the override journal still backstops the state. Stores built without load_goals carry no `_baseRev`
     and keep the old unconditional behavior (nothing to rebase onto).
 
+    A store that came through load_goals keeps a base across saves (the design review of 2026-09-06): after
+    a successful publish the object carries the revision just written as its base, which the file now holds
+    with exactly this content, so the holder's next save is CAS-protected too. Before the re-stamp, the first
+    publish popped the base and nothing restored it, so every later save of the same object — _plan_session
+    saves its store several times per pass, _distill_session saves after titling and again after distilling
+    — took the unconditional branch, wrote over whatever a concurrent writer (the nudge tick, the unblocker,
+    a peer tier) had published in between, and skipped the no-op check as well. The base is popped before
+    the CAS loop and re-stamped only after the rename, so a raise between the two leaves the object without
+    a base (its next save is unconditional, as every save was before this change); a refusal before the pop
+    (the frozen-store check, the no-op check) leaves it untouched.
+
     A publish that would write back EXACTLY what the file already holds is skipped (the user 2026-07-22).
     Callers save unconditionally on purpose — `_plan_session` ends every pass with a rollup + save whether or
     not the pass placed anything — so an idle fleet rewrote ~24 stores with byte-identical content about ten
@@ -4656,6 +4667,9 @@ def save_goals(fsid, store):
     tmp.rename(GOALDIR / (fsid + ".json"))            # atomic publish
     _shared_forget(str(GOALDIR / (fsid + ".json")))   # the shared read-only view of the old version goes with
     #                                                   it (its identity check would miss anyway; this frees the bytes)
+    if base is not None:
+        store["_baseRev"] = store["rev"]             # the file holds exactly this content at this revision:
+        #                                              the holder's NEXT save compares against it (docstring)
 
 
 def load_goal_archive(fsid):
@@ -15228,14 +15242,16 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbos
     exactly as several publishes did). A raise mid-loop publishes the senders reached before it and
     re-raises, the sender being applied dropped unpublished; a failed publish does not stop the others,
     and the first is raised once the rest are out (review find, 2026-09-08: the per-ref save this
-    replaced persisted each verdict as it was reached). A saved object leaves `loaded` in a finally: it
-    is dropped so the next touch reloads with a fresh CAS base (save_goals pops the base on publish), and
-    a failed publish drops it too, never leaving a base-less object for the sender loop. The absent-store
-    sweep answers from _absent_store_flags, memoized across passes on file identity. The per-session
-    catches stand around the shared read: a store that raises files its `pass-crash` row where it is
-    reached (the recipient scan, a ref's sender read, the sender loop) and is not kept, so the next touch
-    retries the read; _ref_goal's recipient read goes through the store-fault boundary (_or_fault) as
-    before."""
+    replaced persisted each verdict as it was reached). A saved object leaves `loaded` in a finally:
+    save_goals re-stamps `_baseRev` after a publish, so the object could serve a second save, but
+    `idents[sid]` (the pre-read identity _absent_store_flags evaluates `loaded[sid]` under, and memoizes
+    under) describes the pre-publish file, so the object is dropped and the next touch reads the published
+    file; a failed publish drops it too (a raise after save_goals' pop leaves the object without a base),
+    never leaving a base-less object for the sender loop. The absent-store sweep answers from
+    _absent_store_flags, memoized across passes on file identity. The per-session catches stand around the
+    shared read: a store that raises files its `pass-crash` row where it is reached (the recipient scan, a
+    ref's sender read, the sender loop) and is not kept, so the next touch retries the read; _ref_goal's
+    recipient read goes through the store-fault boundary (_or_fault) as before."""
     if now is None:
         now = int(time.time())
     n = 0
@@ -15259,8 +15275,10 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbos
         return a
 
     def _publish(sid):
-        """Save the shared object once and forget it: the next touch reloads with a fresh CAS base
-        (save_goals pops the base on publish)."""
+        """Save the shared object once and forget it: the next touch reads the published file. save_goals
+        re-stamps `_baseRev` after a publish, so the object could serve a second save; it is dropped anyway
+        because `idents[sid]` describes the pre-publish file (the absent-store memo would otherwise fill
+        from post-publish content under that identity), and a failed publish drops it too."""
         try:
             save_goals(sid, loaded[sid])
         finally:

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -178,6 +178,10 @@ def _rebind_state(path):
     #                         entries could never hit under the new one; cleared anyway so a rebind starts empty
     with _ABSENT_FLAGS_LOCK:
         _ABSENT_FLAGS.clear()   # the absent-store predicate memo: same full-path keys, same reasoning
+    with _VIEW_CLEARED_LOCK:
+        _VIEW_CLEARED_MEMO.clear()   # the cleared.jsonl replay memo and the states-log scan memo: full-path
+    with _LIVE_PROMPT_LOCK:          # keys, so an old root's entries could never hit under the new one;
+        _LIVE_PROMPT_MEMO.clear()    # cleared anyway so a rebind starts empty
     _shared_clear()             # the shared read-only store cache: same path keying, same reason; also lifts
     #                         a test's deliberate write-guard trip (the poison flag) so the next class starts clean
     with _STAGE_LOCK:
@@ -10301,20 +10305,56 @@ def _view_cleared():
     cleared.jsonl (a 'clear' row adds, an 'undo' removes, newest-wins). The grouper consults this so it
     NEVER re-organizes a card the user cleared: a relink mints a fresh umbrella whose new id is not in
     cleared.jsonl, so the card escapes the clear and reappears (the user 2026-06-18). Ids are globally
-    unique (<rompUuid>:gN), so no per-session scoping. Decoupled mirror of the kernel's _cleared_ids."""
-    cur = set()
+    unique (<rompUuid>:gN), so no per-session scoping. Decoupled mirror of the kernel's _cleared_ids.
+
+    Memoized on the file's (ino, mtime_ns, size) since 2026-09: seven call sites read it (open_menu,
+    _cleared_under, may_apply's reopen guard, the planner's follow-up pivot, _group_tops, _consolidate_tops,
+    the model-fallback mint), several once per session per pass, and each replayed the whole file. The key
+    is exact for this file's writers: every one APPENDS (the kernel's clear, undo, boundary-settle and
+    mute-seal paths and the judge's echo clears all open it "a"), so no two versions share a size; the one
+    write an identity memo cannot see, a rewrite in place of equal size within one mtime tick, is a pattern
+    nothing uses on this file. Stat before read, so a row landing between the two costs one extra replay,
+    never a stale answer; an unreadable file answers empty and is not memoized. Returns a frozenset: every
+    caller tests membership, and a mutation of the shared memo would be a silent corruption, so it raises
+    instead."""
+    path_s = str(STATE / "cleared.jsonl")
     try:
-        for line in (STATE / "cleared.jsonl").read_text().splitlines():
-            try:
-                o = json.loads(line)
-            except Exception:
-                continue
-            iid = o.get("id")
-            if not iid:
-                continue
-            cur.discard(iid) if o.get("op") == "undo" else cur.add(iid)
+        st = os.stat(path_s)
     except OSError:
-        pass
+        with _VIEW_CLEARED_LOCK:
+            _VIEW_CLEARED_MEMO.pop(path_s, None)
+        return frozenset()
+    key = (st.st_ino, st.st_mtime_ns, st.st_size)
+    with _VIEW_CLEARED_LOCK:
+        hit = _VIEW_CLEARED_MEMO.get(path_s)
+    if hit is not None and hit[0] == key:
+        return hit[1]
+    try:
+        cur = frozenset(_view_cleared_scan(path_s))
+    except OSError:
+        return frozenset()
+    with _VIEW_CLEARED_LOCK:
+        _VIEW_CLEARED_MEMO[path_s] = (key, cur)
+    return cur
+
+
+_VIEW_CLEARED_MEMO = {}    # cleared.jsonl path string -> ((ino, mtime_ns, size), frozenset of ids): see _view_cleared
+_VIEW_CLEARED_LOCK = threading.Lock()
+
+
+def _view_cleared_scan(path):
+    """The unmemoized replay behind _view_cleared over the log at `path`: a 'clear' row adds its id, an
+    'undo' row removes it, newest wins. Raises OSError when the file cannot be read."""
+    cur = set()
+    for line in Path(path).read_text().splitlines():
+        try:
+            o = json.loads(line)
+        except Exception:
+            continue
+        iid = o.get("id")
+        if not iid:
+            continue
+        cur.discard(iid) if o.get("op") == "undo" else cur.add(iid)
     return cur
 
 
@@ -13579,29 +13619,64 @@ def _live_prompt_since(fsid):
     EPISODES too (nothing lands in the store mid-turn), so a second prompt in the same open turn kept the
     first prompt's stale brief (the user 2026-07-24: a reply answered the parked question, the session
     asked a NEW one, and the card still briefed the answered one). Consecutive prompt states
-    (picker→permission) are ONE run — the episode starts where the run does."""
-    p = STATESDIR / (fsid + ".jsonl")
-    since, prev = None, ""
+    (picker→permission) are ONE run — the episode starts where the run does.
+
+    Memoized on the states file's (ino, mtime_ns, size) since 2026-09: the scan read every session's whole
+    states log on every distiller pass, 31 ms of the tier's 135 ms idle pass on a 31-session state copy
+    against under 1 ms of stats. The key is exact for this file's writers: every one APPENDS a row (the
+    tmux and SDK status hooks, the kernel's picker watcher and its interrupt idle row, the idle-dots CLI
+    all open it "a"), so no two versions share a size; the one write an identity memo cannot see, a
+    rewrite in place of equal size within one mtime tick, is a pattern nothing uses on this file (the
+    evidence gate's value inputs are read by value because their fixtures did). Stat before read: a row
+    landing between the two pairs an old identity with new content, which costs one extra scan next
+    time, never a stale answer. An unreadable file answers None and is not memoized."""
+    path_s = str(STATESDIR / (fsid + ".jsonl"))
     try:
-        with open(p, errors="replace") as f:
-            for line in f:
-                if '"state"' not in line:
-                    continue
-                try:
-                    rec = json.loads(line)
-                except ValueError:
-                    continue
-                if not (isinstance(rec, dict) and isinstance(rec.get("state"), str)):
-                    continue
-                s = rec["state"]
-                if s in ("picker", "permission"):
-                    if prev not in ("picker", "permission"):
-                        since = rec.get("t") or 0      # entered a prompt run → the episode's own event
-                else:
-                    since = None                       # left the prompt → that episode is over
-                prev = s
+        st = os.stat(path_s)
+    except OSError:
+        with _LIVE_PROMPT_LOCK:
+            _LIVE_PROMPT_MEMO.pop(path_s, None)
+        return None
+    key = (st.st_ino, st.st_mtime_ns, st.st_size)
+    with _LIVE_PROMPT_LOCK:
+        hit = _LIVE_PROMPT_MEMO.get(path_s)
+    if hit is not None and hit[0] == key:
+        return hit[1]
+    try:
+        since = _live_prompt_since_scan(path_s)
     except OSError:
         return None
+    with _LIVE_PROMPT_LOCK:
+        _LIVE_PROMPT_MEMO[path_s] = (key, since)
+    return since
+
+
+_LIVE_PROMPT_MEMO = {}     # states path string -> ((ino, mtime_ns, size), since): see _live_prompt_since
+_LIVE_PROMPT_LOCK = threading.Lock()
+
+
+def _live_prompt_since_scan(path):
+    """The unmemoized scan behind _live_prompt_since over the states log at `path`: the `t` of the
+    transition into the trailing picker/permission run, else None. Raises OSError when the file cannot be
+    opened, so the memo never records an answer under an identity it did not read."""
+    since, prev = None, ""
+    with open(path, errors="replace") as f:
+        for line in f:
+            if '"state"' not in line:
+                continue
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            if not (isinstance(rec, dict) and isinstance(rec.get("state"), str)):
+                continue
+            s = rec["state"]
+            if s in ("picker", "permission"):
+                if prev not in ("picker", "permission"):
+                    since = rec.get("t") or 0          # entered a prompt run → the episode's own event
+            else:
+                since = None                           # left the prompt → that episode is over
+            prev = s
     return since
 
 
@@ -13678,7 +13753,16 @@ def _deleg_frame(store, nid):
     return " | ".join(p for p in parts if p)[:360]
 
 
-def _distill_due_t(store, nid, blocked):
+def _kids_map(nodes):
+    """parentId -> [nid, ...] over every node (None keys the tops), in store order: the index every
+    subtree walk over a goal store uses (_distill_due_t, _distill_session's descendant gather)."""
+    kids = {}
+    for x, d in nodes.items():
+        kids.setdefault(d.get("parentId"), []).append(x)
+    return kids
+
+
+def _distill_due_t(store, nid, blocked, kids=None):
     """The authoritative "this goal (re)resolved" time the distiller/brief gate compares against —
     never `mt` (the user 2026-07-08, the Proton-card regression): since the diary flip an event-only
     reopen→settle cycle bumps no cache stamp, so an mt-keyed gate slept through re-completions and the
@@ -13702,12 +13786,17 @@ def _distill_due_t(store, nid, blocked):
     summary written at done is already right); only a reopen→re-done lands a NEWER done event and
     re-fires — the worst case the user accepted is one re-distill when work actually resumes. Subtree,
     not the top's own log: a bottom-up-completed umbrella carries no done verdict of its own — its
-    children's do. settledAt stays as the fallback for stores whose diary predates done events."""
+    children's do. settledAt stays as the fallback for stores whose diary predates done events.
+
+    `kids`: the store's parent -> children map (_kids_map over these nodes), built ONCE per store by
+    _distill_session and handed through _done_owed (2026-09): rebuilding it here on every call was 40 of
+    the distiller's 135 ms per idle pass on a 31-session state copy (690 calls). None builds it here, as
+    before; the answer is the same either way (pure over the nodes, pinned by
+    tests/test_judge_identity_memos.py), so the kernel's three callers pass nothing."""
     nodes = store["nodes"]
     nd = nodes.get(nid) or {}
-    kids = {}
-    for x, d in nodes.items():
-        kids.setdefault(d.get("parentId"), []).append(x)
+    if kids is None:
+        kids = _kids_map(nodes)
     best = None
     stack = [nid]
     while stack:
@@ -13724,14 +13813,15 @@ def _distill_due_t(store, nid, blocked):
     return best or nd.get("mt")
 
 
-def _done_owed(store, nid):
+def _done_owed(store, nid, kids=None):
     """True when a completed/confirming top owes a (re)distill: no summary yet, or the goal has
-    (re)resolved since the stamp (distilledMt != the newest done event, _distill_due_t)."""
+    (re)resolved since the stamp (distilledMt != the newest done event, _distill_due_t). `kids`: the
+    caller's per-store children map for _distill_due_t, or None to build one."""
     nd = store["nodes"][nid]
     if nd.get("summary") is None:
         return True
     _dmt = nd.get("distilledMt")
-    due = _distill_due_t(store, nid, False)
+    due = _distill_due_t(store, nid, False, kids)
     # A stamp equal to the goal's settle time is ALSO current: pre-07-24 stamps were the settle event,
     # and re-keying the due on the done event must not re-enter every already-distilled card in the
     # deployment at once (a re-distill storm). Match the settledAt cache OR any settle event in the
@@ -13801,9 +13891,12 @@ def _distill_session(fsid, path, now):
     # changes nothing; only a reopen→re-done moves the due and re-fires (the one-re-distill worst case the
     # user accepted).
     confirming = set(store.get("confirming") or ())
+    kids = _kids_map(nodes)                            # one parent -> children map per store, shared by every
+    #                                                    _distill_due_t below and the descendant gather (built
+    #                                                    AFTER the title save: a rebase there can add nodes)
     todo = [nid for nid, st in status.items() if nodes.get(nid) and (
-            ((st == "completed" or nid in confirming) and _done_owed(store, nid)) or
-            (st == "blocked" and (nodes[nid].get("briefedMt") != _distill_due_t(store, nid, True)
+            ((st == "completed" or nid in confirming) and _done_owed(store, nid, kids)) or
+            (st == "blocked" and (nodes[nid].get("briefedMt") != _distill_due_t(store, nid, True, kids)
                                   or nodes[nid].get("blockSummary") is None)))]
     # LIVE picker/permission floor (the user 2026-06-29): a session parked RIGHT NOW on a live prompt is
     # blocked-on-you, but the planner hasn't classified its focus goal — its stored status is still 'working',
@@ -13845,9 +13938,7 @@ def _distill_session(fsid, path, now):
         return 0
     session = parsed_session(fsid, [path], now)
     seg_by_id = {seg["id"]: seg for turn in session["turns"] for seg in _segs(turn, store)}
-    children = {}
-    for nid, nd in nodes.items():
-        children.setdefault(nd.get("parentId"), []).append(nid)
+    children = kids                                    # the same map: no node was added since it was built
     n, changed = 0, False
     for top in todo:
         blocked = status.get(top) == "blocked" or top in live_brief   # live-picker focus → brief it like a block
@@ -13856,7 +13947,7 @@ def _distill_session(fsid, path, now):
         # either — its verdict is in; it entered todo for the takeaway.
         stalled = (not blocked) and status.get(top) == "working" and top in stalls and top not in confirming
         due = (stalls[top]["since"] if stalled            # the stall's own start event, not a settle/block
-               else _distill_due_t(store, top, blocked))  # the event time this (re)resolution stamps back
+               else _distill_due_t(store, top, blocked, kids))  # the event time this (re)resolution stamps back
         stack, sub = [top], []                         # the top + all descendants (its whole subtree) — still
         while stack:                                   # needed below for blkd, so kept alongside _goal_work_text
             x = stack.pop(); sub.append(x); stack.extend(children.get(x, []))

--- a/tests/test_courier_link.py
+++ b/tests/test_courier_link.py
@@ -153,6 +153,7 @@ class DormantHandoffConverts(unittest.TestCase):
     def setUp(self):
         self._td = tempfile.TemporaryDirectory()      # a private root: see CourierLinkRepair.setUp
         self._state = jd.STATE
+        self._shared_before = self._shared_sid_leftovers()   # the run-wide root's state, read before the rebind
         jd._rebind_state(Path(self._td.name))
         _seed_sender()
         d = jd.STATE / "states"
@@ -170,6 +171,27 @@ class DormantHandoffConverts(unittest.TestCase):
         # returns None (reg-less sid, no owner answer) and the sweep rightly stands down.
         km._TMUX.available = lambda: True
         km._TMUX.alive_sids = lambda t=3: set()
+        self.addCleanup(self._assert_no_shared_sid_leftovers)   # runs AFTER tearDown: the run-wide root is as it was
+
+    @staticmethod
+    def _shared_sid_leftovers():
+        # the two files the dead-wait block writes under the shared placeholder sid, as (exists, mtime_ns)
+        # at whatever root the judge is bound to: the journal row for SENDER:g1 (append_block) and the
+        # nudge record in auto-nudge.json. Either one left at the run-wide root reaches every later
+        # goal-store test under that sid in this process: load_goals replays the row onto their fresh g1
+        # (blocked) and the distiller takes the staller path instead of distilling. Sixteen test_judge.py
+        # tests (the distiller and procedural-block classes) went red when xdist placed them after this one
+        # in a worker; the two modules in one process, this one first, reproduced it.
+        out = []
+        for p in (jd._overrides_dir() / (SENDER + ".jsonl"), jd.STATE / "auto-nudge.json"):
+            out.append((p.exists(), p.stat().st_mtime_ns if p.exists() else None))
+        return tuple(out)
+
+    def _assert_no_shared_sid_leftovers(self):
+        # checked once tearDown has rebound the judge to the run-wide root: both files land under the
+        # private root and go with the tempdir, so the run-wide root's pair is exactly as setUp read it
+        self.assertEqual(self._shared_sid_leftovers(), self._shared_before,
+                         "the sender's journal row or the nudge record reached the run-wide root")
 
     def tearDown(self):
         for nm in ("available", "alive_sids"):

--- a/tests/test_distill_tier.py
+++ b/tests/test_distill_tier.py
@@ -68,7 +68,7 @@ class DistillTierResolution(unittest.TestCase):
             self.assertIn('tier="distill"', src, fn.__name__)
         full = inspect.getsource(jd)
         self.assertIn('_judge_run(_distill_model(), STALL_BRIEF_SYS', full)
-        self.assertIn('_distill_effort() if tier == "distill"', inspect.getsource(jd._judge_run))
+        self.assertIn('_distill_effort() if tier == "distill"', inspect.getsource(jd._judge_run_impl))
 
 
 if __name__ == "__main__":

--- a/tests/test_file_read_memos.py
+++ b/tests/test_file_read_memos.py
@@ -8,7 +8,8 @@ Measured on the maintainer's box (py-spy, the judge tier thread): the three capt
 file three times per session per index pass (19% of the thread), the archive loader decoded per call (11%).
 Pins: parsed once then served; the derived readers equal the direct derivations; an append re-derives, including
 one the file clock cannot see; a write landing during the read is served no further than that call; an absent
-file is empty and never cached; a malformed line is skipped; the memos are bounded; the archive's writers get a
+file is empty and never cached, and so is an existing archive that cannot be read or parsed (the read marked the
+running stage incomplete); a malformed line is skipped; the memos are bounded; the archive's writers get a
 fresh object; the switched callers; a rebound root forgets; the counters; two fills at the cap on two
 threads neither raise nor overflow it.
 
@@ -227,6 +228,49 @@ class GoalArchiveMemo(_Memo):
         self.assertEqual((a["nodes"], a["status"]), ({}, {}))
         self.assertNotIn(SID, jd._GOALARCH_MEMO)
         self.assertEqual(jd._GOALARCH_STATS, {"served": 0, "loaded": 1})
+
+    def _error_rows(self, err):
+        try:
+            rows = [json.loads(l) for l in jd.ERRORS.read_text().splitlines() if l.strip()]
+        except FileNotFoundError:
+            return []
+        return [r for r in rows if r.get("err") == err]
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_an_unreadable_archive_is_the_empty_shape_and_never_cached(self):
+        # the evidence gate's rule: a read that failed marked the running stage incomplete, and a permission fix
+        # moves no file key, so a cached failure would be served after the file reads again. Every call reads.
+        self._write({SID + ":g1": self._node(SID + ":g1", "Ship the banner")})
+        os.chmod(self.arch, 0)
+        try:
+            reads = self.counting()
+            jd._judge_ctx.stage_incomplete = False
+            a = jd.load_goal_archive_shared(SID)
+            self.assertEqual((a["nodes"], a["status"]), ({}, {}))
+            self.assertTrue(jd._judge_ctx.stage_incomplete, "the failed read marks the running stage incomplete")
+            self.assertNotIn(SID, jd._GOALARCH_MEMO)
+            b = jd.load_goal_archive_shared(SID)
+            self.assertEqual((b["nodes"], b["status"]), ({}, {}))
+            self.assertNotIn(SID, jd._GOALARCH_MEMO)
+            self.assertEqual(reads, [SID + ".json", SID + ".json"], "each call reads the file again")
+            self.assertEqual(jd._GOALARCH_STATS, {"served": 0, "loaded": 2})
+            self.assertEqual(len(self._error_rows("archive-unreadable")), 1, "one row per failure episode")
+        finally:
+            os.chmod(self.arch, 0o644)
+        c = jd.load_goal_archive_shared(SID)
+        self.assertEqual(set(c["nodes"]), {SID + ":g1"}, "readable again with the same key: read, and cached now")
+        self.assertIs(jd.load_goal_archive_shared(SID), c)
+        self.assertEqual(jd._GOALARCH_STATS, {"served": 1, "loaded": 3})
+        self.assertEqual(len(self._error_rows("archive-unreadable")), 1)
+
+    def test_an_archive_that_does_not_parse_is_the_empty_shape_and_never_cached(self):
+        self.arch.write_text("{not json")
+        a = jd.load_goal_archive_shared(SID)
+        self.assertEqual((a["nodes"], a["status"]), ({}, {}))
+        self.assertNotIn(SID, jd._GOALARCH_MEMO)
+        jd.load_goal_archive_shared(SID)
+        self.assertEqual(jd._GOALARCH_STATS, {"served": 0, "loaded": 2})
+        self.assertEqual(len(self._error_rows("archive-unreadable")), 1)
 
     def test_the_readers_take_the_shared_loader_and_the_archivers_keep_the_fresh_one(self):
         src = open(os.path.join(BIN, "romp-judge")).read()

--- a/tests/test_judge_close_riders.py
+++ b/tests/test_judge_close_riders.py
@@ -317,5 +317,99 @@ class SweepCutDrain(_Riders):
         self.assertIn("kill 1 of %d" % jd.DISTILL_FAIL_CAP, cuts[0]["note"], "…and the row carries the class")
 
 
+class LazySegmentIndex(_Riders):
+    """_close_session builds its seam-aware segment index once, on the first turn the walk judges
+    (2026-09-07), instead of before the walk for every session every pass. Pinned on the OUTPUT the index
+    feeds: the <goal-history> block handed to _judge_run equals the one the index built before the walk
+    would give (verdict equality alone proves nothing under a patched model, and {} and None differ:
+    _close_turn skips the block when handed None)."""
+
+    def _two_turn_fixture(self):
+        path = os.path.join(self.td, SID + ".jsonl")
+        recs = [_uline(T0, "look at the search index", "u1"),
+                _aline(T0 + 30, "Looked; nothing to change.", "a1", "u1"),
+                _uline(T0 + 200, "and the tests?", "u2", "a1"),
+                _aline(T0 + 230, "Suite green.", "a2", "u2")]
+        Path(path).write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        s = _store()
+        turns = jd.parsed_session(SID, [path], T0 + 5000)["turns"]
+        segs = [jd._segs(t, s)[0]["id"] for t in turns]
+        _node(s, "P", "Ship the notes-api search", trail=segs)          # both turns' work is P's history
+        s["placements"] = {segs[0]: SID + ":P", segs[1]: SID + ":P"}
+        return path, s, turns, segs
+
+    def test_the_index_is_never_built_for_an_all_swept_session(self):
+        path, s, turns, segs = self._two_turn_fixture()
+        s["closedTurns"] = sorted(t["id"] for t in turns)
+        s["closedSig"] = {t["id"]: len(t["atoms"]) for t in turns}
+        jd.save_goals(SID, s)
+        real, calls = jd._segs, []
+
+        def counting(turn, store):
+            calls.append(turn["id"])
+            return real(turn, store)
+        jd._segs = counting
+        try:
+            jd._close_session(SID, path, T0 + 5000)
+        finally:
+            jd._segs = real
+        self.assertEqual(calls, [], "every end-known turn already swept: no segment walk at all")
+        self.assertEqual(self.menus, [], "and no call")
+
+    def test_the_goal_history_block_equals_the_eager_index_and_covers_unjudged_turns(self):
+        # turn 1 is already swept, turn 2 is judged: the index is built at turn 2 over EVERY turn, so
+        # the history block carries turn 1's work as well, exactly as the pre-walk build did
+        path, s, turns, segs = self._two_turn_fixture()
+        s["closedTurns"] = [turns[0]["id"]]
+        s["closedSig"] = {turns[0]["id"]: len(turns[0]["atoms"])}
+        jd.save_goals(SID, s)
+        store = jd.load_goals(SID)
+        eager = {seg["id"]: seg for t in turns for seg in jd._segs(t, store)}
+        menu = jd._turn_menu(turns[1], store)
+        self.assertEqual([nd["id"] for nd in menu], [SID + ":P"], "fixture: the judged turn's menu is P")
+        expected = jd._menu_history_text(store, eager, menu, jd.CLOSE_HISTORY_CHARS)
+        self.assertIn("look at the search index", expected, "fixture: turn 1's work is in P's history")
+        self.assertIn("and the tests?", expected)
+        jd.closer_llm = self._llm                                        # the real helper: the block reaches _judge_run
+        saved, prompts = jd._judge_run, []
+        jd._judge_run = lambda model, sysp, user, **kw: (prompts.append(user) or '{"done": [], "block": []}')
+        try:
+            jd._close_session(SID, path, T0 + 5000)
+        finally:
+            jd._judge_run = saved
+        self.assertEqual(len(prompts), 1, "one call, for the unswept turn")
+        self.assertIn(expected, prompts[0], "the <goal-history> block handed to the model is the eager index's")
+        self.assertEqual(sorted(jd.load_goals(SID)["closedTurns"]), sorted(t["id"] for t in turns))
+
+    def test_the_index_is_built_once_per_walk_and_handed_to_every_judged_turn(self):
+        # both turns unswept: the index is built at the FIRST judged turn, over every turn, and the same
+        # dict reaches every _close_turn of the walk. A build per judged turn would be the pre-walk cost
+        # again, spread over the loop; the all-swept case above cannot see that, and the eager build passes
+        # here too (this case is the once-per-walk half of the claim)
+        path, s, turns, segs = self._two_turn_fixture()
+        jd.save_goals(SID, s)
+        real_segs, real_close, calls, handed = jd._segs, jd._close_turn, [], []
+
+        def counting(turn, store):
+            calls.append(turn["id"])
+            return real_segs(turn, store)
+
+        def recording(store, turn, samples=None, seg_by_id=None):
+            handed.append((turn["id"], seg_by_id, len(calls)))          # at entry
+            try:
+                return real_close(store, turn, samples=samples, seg_by_id=seg_by_id)
+            finally:
+                handed.append((turn["id"], seg_by_id, len(calls)))      # at exit
+        jd._segs, jd._close_turn = counting, recording
+        try:
+            jd._close_session(SID, path, T0 + 5000)
+        finally:
+            jd._segs, jd._close_turn = real_segs, real_close
+        self.assertEqual([h[0] for h in handed[::2]], [t["id"] for t in turns], "both turns judged, in order")
+        self.assertEqual(calls[:handed[0][2]], [t["id"] for t in turns], "built over every turn, before the first judgment")
+        self.assertIs(handed[0][1], handed[2][1], "the same index object is handed to every judged turn")
+        self.assertEqual(handed[1][2], handed[2][2], "no _segs call between the first judgment's exit and the second's entry")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_judge_dissolution_rolledup.py
+++ b/tests/test_judge_dissolution_rolledup.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""A dissolved container's rolled-up child is judged by its own diary, and appends no settle row without a
+done verdict of its own (review 2026-09-06). rollup_status's roll-down folds a resolved top's open children
+into an eventless display cache (nodeComplete plus the rolledUp marker); _materialize_from_log and
+record_verdict both skip a rolledUp node, because an ANCESTOR's resolution owns those flags. Umbrella
+dissolution (T101) re-parented such a child to top level without dropping the marker, so the promoted top
+kept a done flag nothing ever re-derived: is_complete read it, the settle branch never found settledDone
+(the settle row it appended never materialized), and every rollup appended one more settle row plus one
+more seam. One live node reached LOG_CAP (64 settle rows, logTrunc) with its store's seams at cap,
+republishing about 1 MB per pass. An unroll that stopped at the promoted child would leave the child's own
+rolled-up descendants done under a now-open top; and a healed top whose diary holds the bug's settle rows
+would fold to settledDone on an open node, which reads Working but is sealed for every judge.
+
+Pins: (1) the dissolving rollup drops the marker on the child AND its rolled-up descendants, and each
+node's own diary decides (no row: open; a rolled-away block: blocked), with no settle row, no seam and no
+change on later rollups; (2) a promoted child with its OWN done verdict settles exactly once, and a
+descendant under it stays folded; (3) a child re-parented under a still-resolved solid ancestor is
+re-folded by the same rollup's roll-down; (4) a store already published with the stale marker, on the
+top or on a descendant, is repaired on its next rollup (one publish) and later rollups publish nothing;
+(5) a top whose diary holds the bug's settle rows is reopened once, by a romp reopen row plus one
+judge-errors row, and is unsealed. SYNTHETIC fixtures only; a private synthetic sid (goal-store tests
+never share the placeholder sid)."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_dissolve_rolledup", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "d1550001-1111-4222-8333-000000000001"    # private synthetic sid, never the shared placeholder
+T = 1781100000
+UMB, CHILD, OTHER, TOP, GRAND = (SID + ":g%d" % i for i in (1, 2, 3, 4, 5))
+
+
+def _row(kind, ev, src="closer", why=None):
+    return {"ev_t": ev, "src": src, "kind": kind, **({"why": why} if why else {}), "at": ev}
+
+
+def _node(nid, text, parent, t=T, **kw):
+    nd = {"id": nid, "text": text, "parentId": parent, "nodeComplete": False, "blocked": False,
+          "cleared": False, "trail": [], "t": t, "mt": t, "log": []}
+    nd.update(kw)
+    return nd
+
+
+def _rolled(nid, text, parent, log=None):
+    """A child the roll-down folded: display-cache done plus the marker, no done verdict of its own."""
+    return _node(nid, text, parent, nodeComplete=True, rolledUp=True, log=list(log or []))
+
+
+def _settles(nd):
+    return [e for e in (nd.get("log") or []) if e.get("kind") == "settle"]
+
+
+def _reopens(nd):
+    return [e for e in (nd.get("log") or []) if e.get("kind") == "reopen"]
+
+
+def _menu_ids(st):
+    return {nd["id"] for nd in jd.open_menu(st)}
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self._saved = jd.STATE
+        self.td = tempfile.TemporaryDirectory()
+        jd._rebind_state(Path(self.td.name))
+
+    def tearDown(self):
+        try:
+            (jd._overrides_dir() / (SID + ".jsonl")).unlink()
+        except OSError:
+            pass
+        jd._rebind_state(self._saved)
+        self.td.cleanup()
+
+    def _store(self, nodes):
+        st = {"rompUuid": SID, "seq": len(nodes) + 1, "placements": {}, "status": {},
+              "placementsV": jd.PLACEMENTS_V, "lastNode": OTHER, "nodes": {}}
+        for nd in nodes:
+            st["nodes"][nd["id"]] = nd
+        st["nodes"][OTHER] = _node(OTHER, "tests for the api", None, t=T + 10)   # the focus: unrelated, open
+        return jd._guard_nodes(st)
+
+    def _umbrella_world(self, child_log=None, grand=False):
+        """The live shape: a closer-ruled-done container over one child the roll-down folded (and, with
+        `grand`, one folded sub under that child)."""
+        nodes = [_node(UMB, "round of notes-api work", None, umbrella=True, nodeComplete=True,
+                       log=[_row("done", T, why="the round shipped")]),
+                 _rolled(CHILD, "add the web pane", UMB, child_log)]
+        if grand:
+            nodes.append(_rolled(GRAND, "wire the pane's route", CHILD))
+        return self._store(nodes)
+
+    def _error_rows(self):
+        if not jd.ERRORS.exists():
+            return []
+        return [json.loads(line) for line in jd.ERRORS.read_text().splitlines() if line.strip()]
+
+
+class DissolutionDropsTheMarker(_Base):
+    def test_the_promoted_child_reads_its_own_diary_and_appends_no_settle_row(self):
+        st = self._umbrella_world()
+        jd.rollup_status(st, True)
+        c = st["nodes"][CHILD]
+        self.assertNotIn(UMB, st["nodes"], "premise: the container dissolved")
+        self.assertIsNone(c.get("parentId"), "premise: the child is a top now")
+        self.assertNotIn("rolledUp", c, "the marker is dropped with the container whose resolution it mirrored")
+        self.assertFalse(c.get("nodeComplete"), "no verdict of its own: its diary says open")
+        self.assertEqual(st["status"][CHILD], "working")
+        self.assertEqual(_settles(c), [], "nothing completed, so nothing settles: no settle row")
+        self.assertEqual(st.get("seams") or [], [], "and no seam")
+        self.assertNotIn("settledDone", c)
+        before = jd._store_content(st)
+        jd.rollup_status(st, True)
+        self.assertEqual(jd._store_content(st), before, "a second rollup changes nothing")
+
+    def test_a_rolled_away_block_is_blocked_again_on_the_promoted_child(self):
+        st = self._umbrella_world(child_log=[_row("block", T - 5, why="which pane layout?")])
+        jd.rollup_status(st, True)
+        c = st["nodes"][CHILD]
+        self.assertNotIn("rolledUp", c)
+        self.assertTrue(c.get("blocked"), "its own diary decides: the block the roll-down hid is blocked again")
+        self.assertEqual(st["status"][CHILD], "blocked")
+        self.assertEqual(_settles(c), [])
+
+    def test_the_promoted_childs_rolled_up_descendants_are_unrolled_with_it(self):
+        # the live shape one level deeper: the container's roll-down marked the child AND the child's own
+        # sub. An unroll that stopped at the child would leave the sub done under an open top
+        st = self._umbrella_world(grand=True)
+        jd.rollup_status(st, True)
+        g = st["nodes"][GRAND]
+        self.assertEqual(g.get("parentId"), CHILD, "premise: the sub stays under the promoted child")
+        self.assertNotIn("rolledUp", g, "the marker mirrored the container, which is gone")
+        self.assertFalse(g.get("nodeComplete"), "its own diary has no done row")
+        self.assertEqual(st["status"][CHILD], "working")
+        self.assertIn(CHILD, _menu_ids(st))
+        self.assertIn(GRAND, _menu_ids(st), "an open sub under an open top is in the planner's menu")
+        self.assertEqual(_settles(st["nodes"][CHILD]), [])
+        before = jd._store_content(st)
+        jd.rollup_status(st, True)
+        self.assertEqual(jd._store_content(st), before, "a second rollup changes nothing")
+
+    def test_a_promoted_child_with_its_own_done_verdict_settles_exactly_once(self):
+        # the roll-down never marks a child that is already complete, so this child carries no marker:
+        # the legitimately-done sibling settles ONCE (one row, one seam, settledDone) and then holds
+        st = self._store([
+            _node(UMB, "round of notes-api work", None, umbrella=True),
+            _node(CHILD, "add the web pane", UMB, nodeComplete=True,
+                  log=[_row("done", T, why="the pane shipped")])])
+        jd.rollup_status(st, True)
+        jd.rollup_status(st, True)
+        c = st["nodes"][CHILD]
+        self.assertIsNone(c.get("parentId"))
+        self.assertEqual(st["status"][CHILD], "completed")
+        self.assertTrue(c.get("settledDone"), "the settle row materialized on the promoted top")
+        self.assertEqual(len(_settles(c)), 1, "one settle row across two rollups")
+        self.assertEqual(len(st.get("seams") or []), 1, "one seam across two rollups")
+        before = jd._store_content(st)
+        jd.rollup_status(st, True)
+        self.assertEqual(jd._store_content(st), before)
+
+    def test_a_descendant_under_a_still_done_intermediate_stays_rolled(self):
+        # the child has a done verdict of its own (so the roll-down never marked it) and its sub was
+        # marked. Promoted, the child is still done by its own diary, so its interior roll-down keeps the
+        # sub folded: the sub is not in the menu, and the child settles once as a top
+        st = self._store([
+            _node(UMB, "round of notes-api work", None, umbrella=True, nodeComplete=True,
+                  log=[_row("done", T, why="the round shipped")]),
+            _node(CHILD, "add the web pane", UMB, nodeComplete=True,
+                  log=[_row("done", T - 1, why="the pane shipped")]),
+            _rolled(GRAND, "wire the pane's route", CHILD)])
+        jd.rollup_status(st, True)
+        jd.rollup_status(st, True)
+        g = st["nodes"][GRAND]
+        self.assertTrue(g.get("rolledUp") and g.get("nodeComplete"),
+                        "a done ancestor is still above it: the roll-down re-marks it")
+        self.assertNotIn(GRAND, _menu_ids(st))
+        self.assertEqual(st["status"][CHILD], "completed")
+        self.assertEqual(len(_settles(st["nodes"][CHILD])), 1, "the promoted child settles once")
+        self.assertEqual(_settles(g), [], "a sub never settles")
+
+    def test_a_child_under_a_still_resolved_solid_ancestor_is_refolded_by_the_same_rollup(self):
+        # nested: a solid done top over a container over a folded child. The child re-parents to the
+        # top, whose own roll-down re-derives the cache in this very rollup (the marker is a mirror of
+        # the nearest resolved ancestor, and that ancestor is still resolved)
+        st = self._store([
+            _node(TOP, "ship the notes-api release", None, nodeComplete=True,
+                  log=[_row("done", T, why="released")]),
+            _node(UMB, "round of notes-api work", TOP, umbrella=True, nodeComplete=True, rolledUp=True),
+            _rolled(CHILD, "add the web pane", UMB)])
+        jd.rollup_status(st, True)
+        c = st["nodes"][CHILD]
+        self.assertEqual(c.get("parentId"), TOP, "re-parented to the first solid ancestor")
+        self.assertTrue(c.get("rolledUp") and c.get("nodeComplete"),
+                        "a resolved ancestor is still above it: the roll-down re-folds it")
+        self.assertEqual(_settles(c), [], "a sub never settles")
+        self.assertEqual(len(_settles(st["nodes"][TOP])), 1, "the top settles once")
+
+    def test_a_rolled_child_with_no_diary_key_unrolls_to_open(self):
+        # a pre-migration straggler: the roll-down marked a child that has no diary key at all. The unroll
+        # resets the three flags BEFORE the fold asks, so the node reads open; without the reset, the
+        # unmigrated-node guard meets a done flag with no history, freezes it (an unroll no later pass
+        # repairs, the marker being gone) and files a row
+        st = self._umbrella_world()
+        with jd._authority():
+            del st["nodes"][CHILD]["log"]
+        jd.rollup_status(st, True)
+        c = st["nodes"][CHILD]
+        self.assertIsNone(c.get("parentId"), "premise: promoted")
+        self.assertNotIn("rolledUp", c)
+        self.assertFalse(c.get("nodeComplete"), "no diary, no marker: open, not frozen done")
+        self.assertEqual(st["status"][CHILD], "working")
+        self.assertEqual(self._error_rows(), [], "no unmigrated-node row: the flags were reset before the fold")
+
+
+class StaleMarkerHeals(_Base):
+    def test_a_store_published_with_the_stale_marker_is_repaired_on_its_next_rollup(self):
+        # the shape the bug left on disk: the container already gone, the child a top still marked, its
+        # diary holding the settle rows earlier rollups appended, seams stamped alongside
+        spam = [_row("settle", T + 10, src="romp") for _ in range(3)]
+        st = self._store([_rolled(CHILD, "add the web pane", None, spam)])
+        st["seams"] = [{"t": T + 100 + i, "top": CHILD, "text": "add the web pane", "segs": []}
+                       for i in range(3)]
+        jd.save_goals(SID, st)
+        rev0 = jd._disk_rev(SID)
+        s1 = jd.load_goals(SID)
+        jd.rollup_status(s1, True)
+        jd.save_goals(SID, s1)                                   # the repair is one publish
+        c = s1["nodes"][CHILD]
+        self.assertNotIn("rolledUp", c, "a top has no ancestor to mirror: the marker is dropped")
+        self.assertFalse(c.get("nodeComplete"), "its own diary has no done row")
+        self.assertEqual(s1["status"][CHILD], "working")
+        self.assertEqual(len(_settles(c)), 3, "no settle row appended")
+        self.assertEqual(len(s1["seams"]), 3, "no seam appended")
+        rev1 = jd._disk_rev(SID)
+        self.assertGreater(rev1, rev0, "the repair is a real change: one publish")
+        s2 = jd.load_goals(SID)
+        jd.rollup_status(s2, True)
+        jd.save_goals(SID, s2)
+        self.assertEqual(jd._disk_rev(SID), rev1, "later passes republish nothing")
+
+    def test_a_stale_descendant_under_a_stale_top_is_unrolled_through_the_file(self):
+        # both marked, no settle rows (the top's rows are the next test's subject). The sub is inserted
+        # FIRST so the repair meets it before its ancestor: the ancestor check must not read a rolled-up
+        # ancestor's stale done flag as a resolution, or the sub would need a second pass
+        st = self._store([_rolled(GRAND, "wire the pane's route", CHILD),
+                          _rolled(CHILD, "add the web pane", None)])
+        jd.save_goals(SID, st)
+        rev0 = jd._disk_rev(SID)
+        s1 = jd.load_goals(SID)
+        jd.rollup_status(s1, True)
+        jd.save_goals(SID, s1)
+        c, g = s1["nodes"][CHILD], s1["nodes"][GRAND]
+        self.assertNotIn("rolledUp", c)
+        self.assertNotIn("rolledUp", g, "no resolved ancestor is left: the sub's marker is dropped too")
+        self.assertFalse(g.get("nodeComplete"))
+        self.assertEqual(s1["status"][CHILD], "working")
+        self.assertEqual(_menu_ids(s1) & {CHILD, GRAND}, {CHILD, GRAND})
+        self.assertEqual(self._error_rows(), [], "no settle rows: nothing to reopen, nothing to report")
+        rev1 = jd._disk_rev(SID)
+        self.assertGreater(rev1, rev0, "the repair is one publish")
+        s2 = jd.load_goals(SID)
+        jd.rollup_status(s2, True)
+        jd.save_goals(SID, s2)
+        self.assertEqual(jd._disk_rev(SID), rev1, "later passes republish nothing")
+
+    def test_a_stale_top_with_the_bugs_settle_rows_is_reopened_once_and_unsealed(self):
+        # the live store's shape: settle rows appended while the node was rolled up, no done row. With
+        # the marker gone the fold made those rows settledDone on an open node: Working on the board,
+        # sealed for every judge (open_menu, the candidate filters), with nothing saying so
+        spam = [_row("settle", T + 10, src="romp") for _ in range(3)]
+        st = self._store([_rolled(CHILD, "add the web pane", None, spam)])
+        jd.save_goals(SID, st)
+        s1 = jd.load_goals(SID)
+        jd.rollup_status(s1, True)
+        jd.save_goals(SID, s1)
+        c = s1["nodes"][CHILD]
+        self.assertEqual(len(_reopens(c)), 1, "one reopen row ends the settled episode")
+        self.assertEqual(_reopens(c)[0].get("src"), "romp")
+        self.assertEqual(len(_settles(c)), 3, "the settle rows stay: the diary is append-only")
+        self.assertNotIn("settledDone", c, "the reopen ended the settle in the fold")
+        self.assertEqual(c.get("deltaSince"), T + 10, "the ended settle is the delta boundary")
+        self.assertEqual(s1["status"][CHILD], "working")
+        self.assertIn(CHILD, _menu_ids(s1), "unsealed: the planner's menu lists it")
+        rows = self._error_rows()
+        self.assertEqual([r.get("err") for r in rows], ["unroll-heal"], "one visible row names the heal")
+        self.assertEqual(rows[0].get("goal"), CHILD)
+        self.assertEqual(rows[0].get("fsid"), SID)
+        rev1 = jd._disk_rev(SID)
+        s2 = jd.load_goals(SID)
+        jd.rollup_status(s2, True)
+        jd.save_goals(SID, s2)
+        self.assertEqual(len(_reopens(s2["nodes"][CHILD])), 1, "a second pass appends nothing")
+        self.assertEqual(len(self._error_rows()), 1, "and reports nothing")
+        self.assertEqual(jd._disk_rev(SID), rev1, "and republishes nothing")
+
+    def test_the_dissolving_rollup_reopens_a_promoted_top_whose_diary_holds_the_rows(self):
+        # the same rows reached through the dissolution site: a stale save-rebase republished the child's
+        # old parentId after it had been promoted and settled by the bug, so the sweep re-dissolves the
+        # container and promotes a child that already carries the rows
+        spam = [_row("settle", T + 10, src="romp") for _ in range(2)]
+        st = self._umbrella_world(child_log=spam)
+        jd.rollup_status(st, True)
+        c = st["nodes"][CHILD]
+        self.assertIsNone(c.get("parentId"))
+        self.assertEqual(len(_reopens(c)), 1)
+        self.assertNotIn("settledDone", c)
+        self.assertEqual(st["status"][CHILD], "working")
+        self.assertIn(CHILD, _menu_ids(st))
+        self.assertEqual([r.get("err") for r in self._error_rows()], ["unroll-heal"])
+        before = jd._store_content(st)
+        jd.rollup_status(st, True)
+        self.assertEqual(jd._store_content(st), before, "a second rollup changes nothing")
+
+    def test_a_rolled_away_block_under_the_rows_is_reopened_too(self):
+        # blocked plus the rows is one unblock away from the sealed-Working shape (the unblocker's
+        # candidate filter does not read settledDone, and a lift's unblock row leaves the settle in the
+        # fold), so the heal reopens it as well: the block row stays in the diary, the state is open
+        log = [_row("block", T - 5, why="which pane layout?"), _row("settle", T + 10, src="romp")]
+        st = self._store([_rolled(CHILD, "add the web pane", None, log)])
+        jd.rollup_status(st, True)
+        c = st["nodes"][CHILD]
+        self.assertFalse(c.get("blocked"))
+        self.assertNotIn("settledDone", c)
+        self.assertEqual(st["status"][CHILD], "working")
+        self.assertTrue(any(e.get("kind") == "block" for e in c["log"]), "the diary keeps the block row")
+        self.assertIn(CHILD, _menu_ids(st))
+        self.assertEqual([r.get("err") for r in self._error_rows()], ["unroll-heal"])
+
+    def test_a_promoted_child_without_the_rows_is_not_reopened(self):
+        # no settle rows: the plain unroll is the whole repair; no reopen row, no judge-errors row
+        st = self._umbrella_world(grand=True)
+        jd.rollup_status(st, True)
+        self.assertEqual(_reopens(st["nodes"][CHILD]), [])
+        self.assertEqual(_reopens(st["nodes"][GRAND]), [])
+        self.assertEqual(self._error_rows(), [])
+
+    def test_the_heal_reopen_is_at_least_as_new_as_the_settle_it_ends(self):
+        # the store's newest mt belonged to the dissolved container, now gone: every remaining node is
+        # older than the settle rows. The reopen's ev_t has the settle's own moment as its floor, so the
+        # row folds AFTER the settles it ends; a reopen dated by the store's latest node alone would sort
+        # before them and the node would stay sealed
+        spam = [_row("settle", T + 500, src="romp") for _ in range(2)]
+        st = self._store([_rolled(CHILD, "add the web pane", None, spam)])
+        self.assertLessEqual(max(max(n["t"], n["mt"]) for n in st["nodes"].values()), T + 10, "premise")
+        jd.rollup_status(st, True)
+        c = st["nodes"][CHILD]
+        self.assertEqual(len(_reopens(c)), 1)
+        self.assertGreaterEqual(_reopens(c)[0]["ev_t"], T + 500, "the reopen is at least as new as the settle")
+        self.assertNotIn("settledDone", c)
+        self.assertEqual(st["status"][CHILD], "working")
+        self.assertIn(CHILD, _menu_ids(st))
+
+    def test_the_heal_reopen_carries_the_stores_latest_evidence_moment(self):
+        # when the store holds newer evidence than the settle, the reopen is dated by it: the row lands
+        # where the store's history has reached, not back at the settle's moment
+        spam = [_row("settle", T + 10, src="romp") for _ in range(2)]
+        st = self._store([_rolled(CHILD, "add the web pane", None, spam)])
+        st["nodes"][OTHER]["t"] = st["nodes"][OTHER]["mt"] = T + 200
+        jd.rollup_status(st, True)
+        c = st["nodes"][CHILD]
+        self.assertEqual(len(_reopens(c)), 1)
+        self.assertEqual(_reopens(c)[0]["ev_t"], T + 200, "the store's latest evidence moment")
+
+    def test_a_view_cleared_stale_top_stays_sealed_and_reports_nothing(self):
+        # the user crossed the card off the feed: may_apply refuses a reopen from any source, so the heal
+        # drops the marker and leaves the node as the user left it, with nothing to report
+        (jd.STATE / "cleared.jsonl").parent.mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "cleared.jsonl").write_text(json.dumps({"id": CHILD, "op": "clear"}) + "\n")
+        spam = [_row("settle", T + 10, src="romp") for _ in range(2)]
+        st = self._store([_rolled(CHILD, "add the web pane", None, spam)])
+        jd.rollup_status(st, True)
+        c = st["nodes"][CHILD]
+        self.assertNotIn("rolledUp", c, "the marker is still dropped")
+        self.assertEqual(_reopens(c), [], "no reopen: the seal the user set holds")
+        self.assertTrue(c.get("settledDone"), "sealed as the user left it")
+        self.assertNotIn(CHILD, _menu_ids(st))
+        self.assertEqual(self._error_rows(), [], "a refused heal reports nothing")
+
+    def test_a_solid_ancestors_stale_done_flag_is_rewritten_before_the_ancestor_check(self):
+        # the sub is inserted BEFORE its solid parent, whose done flag has no history behind it (the fold
+        # demotes it to open on every rollup). The repair materializes the solid nodes first, so the
+        # ancestor check reads the parent's fold-derived state, not the stale flag: the sub is unrolled in
+        # this pass, not left done under an open top
+        st = self._store([_rolled(GRAND, "wire the pane's route", TOP),
+                          _node(TOP, "ship the notes-api release", None, nodeComplete=True, log=[])])
+        jd.rollup_status(st, True)
+        self.assertFalse(st["nodes"][TOP].get("nodeComplete"), "premise: the fold demoted the flag")
+        g = st["nodes"][GRAND]
+        self.assertNotIn("rolledUp", g, "checked against the rewritten ancestor, not its stale flag")
+        self.assertFalse(g.get("nodeComplete"))
+        self.assertIn(GRAND, _menu_ids(st))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge_distill_early_save.py
+++ b/tests/test_judge_distill_early_save.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""_distill_session saves its store twice when a mirror top gets its one-shot title: once right after
+_title_mirror_tops and again after the distills. The first publish popped the store's CAS base (_baseRev)
+and nothing restored it, so the tail save took save_goals' unconditional branch and wrote over anything a
+concurrent writer published during the distiller's model call (review 2026-09-06). Pins that the tail
+save REBASES: the kernel-side block filed during the call and the distiller's own summary both survive.
+SYNTHETIC fixtures only; a private synthetic sid."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_distill_twosave", os.path.join(BIN, "romp-judge")).load_module()
+em = jd.em
+
+NOW = 1_787_700_000
+T0 = NOW - 3600
+SID = "d1570001-1111-4222-8333-000000000001"    # private synthetic sid, never the shared placeholder
+DONE, MIRROR, OPEN = (SID + ":g%d" % i for i in (1, 2, 3))
+MIRROR_WHY = "declared in the agent's own to-do list"   # _title_mirror_tops' mirror-top predicate
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None, ps="typed"):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": ps, "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+RECORDS = [uline(T0, "please ship the demo ask", "u1"),
+           aline(T0 + 60, "Shipped: the demo ask is done, with a regression test.", "a1", "u1")]
+
+
+def _node(nid, text, t=T0, **kw):
+    nd = {"id": nid, "text": text, "parentId": None, "nodeComplete": False, "blocked": False,
+          "cleared": False, "trail": [], "t": t, "mt": t, "log": []}
+    nd.update(kw)
+    return jd.GuardedNode(nd)
+
+
+class TailSaveRebases(unittest.TestCase):
+    def setUp(self):
+        self._saved = jd.STATE
+        self.td = tempfile.TemporaryDirectory()
+        jd._rebind_state(Path(self.td.name))
+        self.path = Path(self.td.name) / (SID + ".jsonl")
+        self.path.write_text("\n".join(json.dumps(r) for r in RECORDS) + "\n")
+        s = em.parse_session(str(self.path), rompuuid=SID, candidate_files=[str(self.path)], now=NOW)
+        self.segs = [sg["id"] for turn in s["turns"] for sg in em.segments(turn)]
+        self._title, self._distill = jd.mirror_title_llm, jd.distill_llm
+        jd.mirror_title_llm = lambda *a, **k: "Wire the notes web pane"
+        jd.distill_llm = self._distill_with_a_concurrent_writer
+
+    def tearDown(self):
+        jd.mirror_title_llm, jd.distill_llm = self._title, self._distill
+        try:
+            (jd._overrides_dir() / (SID + ".jsonl")).unlink()
+        except OSError:
+            pass
+        jd._rebind_state(self._saved)
+        self.td.cleanup()
+
+    def _distill_with_a_concurrent_writer(self, *a, **k):
+        # the kernel's nudge tick runs during the distiller's model call: it blocks the open top and
+        # publishes while the distiller holds its already-once-saved store across the call
+        ks = jd.load_goals(SID)
+        jd.record_verdict(ks, ks["nodes"][OPEN], "nudge", "block", T0 + 200, why="which pane layout?")
+        jd.rollup_status(ks, False)
+        jd.save_goals(SID, ks)
+        self.assertEqual(jd.load_goals(SID)["status"].get(OPEN), "blocked", "premise: the block landed")
+        return "BACKGROUND: b.\n\nTAKEAWAY: it shipped."
+
+    def _world(self):
+        st = {"rompUuid": SID, "seq": 3, "nodes": {}, "placements": {}, "status": {},
+              "placementsV": jd.PLACEMENTS_V}
+        st["nodes"][DONE] = _node(DONE, "the finished ask", trail=list(self.segs))
+        st["nodes"][MIRROR] = _node(MIRROR, "web pane", why=MIRROR_WHY)      # untitled mirror top
+        st["nodes"][OPEN] = _node(OPEN, "tests for the api")
+        jd.record_verdict(st, st["nodes"][DONE], "closer", "done", T0 + 100, why="shipped with a test")
+        jd.rollup_status(st, False)
+        jd.save_goals(SID, st)
+
+    def test_the_tail_save_rebases_onto_a_publish_made_during_the_model_call(self):
+        self._world()
+        n = jd._distill_session(SID, str(self.path), NOW)
+        self.assertEqual(n, 1, "premise: the distiller ran for the done top")
+        after = jd.load_goals(SID)
+        self.assertEqual(after["nodes"][MIRROR].get("text"), "Wire the notes web pane",
+                         "the early save's title landed")
+        self.assertEqual(after["nodes"][DONE].get("summary"), "it shipped.", "the tail save's summary landed")
+        self.assertTrue(any(e.get("kind") == "block" for e in after["nodes"][OPEN].get("log") or []),
+                        "the block published during the model call survives the tail save")
+        self.assertEqual(after["status"].get(OPEN), "blocked")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge_identity_memos.py
+++ b/tests/test_judge_identity_memos.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Three identity memos on the distiller's and grouper's read paths (2026-09), each pinned against the
+function it memoizes:
+
+- _distill_due_t builds a parent -> children map per call; _distill_session now builds one per store
+  (_kids_map) and hands it through _done_owed. Pure over the nodes, so the answer must not depend on
+  who built the map.
+- _live_prompt_since scanned every session's whole states log every pass; it is memoized on the file's
+  (ino, mtime_ns, size).
+- _view_cleared replayed cleared.jsonl at each of seven call sites; same memo, same key.
+
+The two file memos are exact because both files are APPEND-ONLY logs (every kernel writer opens them
+"a"): no two versions share a size, so the identity moves on every write. The one write an identity memo
+cannot see is a rewrite in place of equal size within one mtime tick, which no writer of these files
+does; the tests below cover the rewrite that lands in a later tick (the shape a test fixture produces)
+and the changed, unchanged, absent and unreadable cases against the unmemoized scan.
+
+PRIVATE synthetic sid, invented text; nothing here mints goals through the store loader."""
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_identity_memos", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "cccccccc-1111-2222-3333-444444444444"      # a private synthetic sid, never the shared placeholder
+T0 = 1781100000
+
+
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def _aline(t, text, uuid, parent):
+    return {"type": "assistant", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}], "stop_reason": "end_turn"}}
+
+
+def _rewrite_same_size_later_tick(path, text):
+    """Rewrite `path` in place with `text` of the SAME size and move its mtime one second on, the shape a
+    fixture's write_text produces when the tick has moved: same inode, same size, new mtime."""
+    st = os.stat(path)
+    Path(path).write_text(text)
+    assert os.stat(path).st_size == st.st_size, "the rewrite must keep the size for this case to mean anything"
+    os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+
+
+class _Memos(unittest.TestCase):
+    def setUp(self):
+        self.td = Path(tempfile.mkdtemp())
+        self._saved_state = jd.STATE
+        jd._rebind_state(self.td)
+        jd.STATESDIR.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        jd._rebind_state(self._saved_state)
+        shutil.rmtree(self.td, ignore_errors=True)
+
+    def _count(self, name):
+        """Patch the unmemoized scan `name` with a counting wrapper; returns the counter list."""
+        real = getattr(jd, name)
+        calls = []
+
+        def counted(path):
+            calls.append(path)
+            return real(path)
+        setattr(jd, name, counted)
+        self.addCleanup(setattr, jd, name, real)
+        return calls
+
+
+class KidsMap(_Memos):
+    """_distill_due_t and _done_owed answer the same with a caller-built map as with their own."""
+
+    def _store(self):
+        def nd(nid, parent, **kw):
+            d = {"id": nid, "parentId": parent, "text": "step %s" % nid, "t": T0, "mt": T0 + 10, "log": []}
+            d.update(kw)
+            return d
+        g = lambda n: "%s:g%d" % (SID, n)
+        nodes = {
+            g(1): nd(g(1), None, settledAt=T0 + 400, summary="done", distilledMt=T0 + 300),
+            g(2): nd(g(2), g(1), log=[{"kind": "done", "ev_t": T0 + 200, "at": T0 + 201}]),
+            g(3): nd(g(3), g(1), blocked=True,
+                     log=[{"kind": "block", "ev_t": T0 + 150, "at": T0 + 150},
+                          {"kind": "done", "ev_t": T0 + 300, "at": T0 + 305}]),
+            g(4): nd(g(4), g(3), blocked=True, log=[{"kind": "block", "ev_t": T0 + 250, "at": T0 + 250}]),
+            g(5): nd(g(5), None, settledAt=None, summary=None),                    # no events: the mt fallback
+            g(6): nd(g(6), g(5), log=[{"kind": "block", "ev_t": T0 + 50, "at": T0 + 50}]),   # blocked flag unset
+            g(7): nd(g(7), None, summary="s", distilledMt=T0 + 10,
+                     log=[{"kind": "settle", "ev_t": T0 + 10, "at": T0 + 10}]),
+        }
+        return {"rompUuid": SID, "nodes": nodes, "status": {g(1): "completed", g(5): "working", g(7): "completed"}}
+
+    def test_kids_map_is_the_inline_build(self):
+        store = self._store()
+        inline = {}
+        for x, d in store["nodes"].items():
+            inline.setdefault(d.get("parentId"), []).append(x)
+        self.assertEqual(jd._kids_map(store["nodes"]), inline)
+
+    def test_due_t_and_done_owed_agree_with_and_without_a_caller_map(self):
+        store = self._store()
+        kids = jd._kids_map(store["nodes"])
+        for nid in store["nodes"]:
+            for blocked in (False, True):
+                self.assertEqual(jd._distill_due_t(store, nid, blocked, kids),
+                                 jd._distill_due_t(store, nid, blocked), (nid, blocked))
+        for nid in [n for n, d in store["nodes"].items() if d["parentId"] is None]:
+            self.assertEqual(jd._done_owed(store, nid, kids), jd._done_owed(store, nid), nid)
+        # the values themselves, so the fixture is known to exercise every branch: subtree done, subtree
+        # still-blocked blocks, the mt and settledAt fallbacks
+        g = lambda n: "%s:g%d" % (SID, n)
+        self.assertEqual(jd._distill_due_t(store, g(1), False, kids), T0 + 300, "newest done in the subtree")
+        self.assertEqual(jd._distill_due_t(store, g(1), True, kids), T0 + 250, "newest block among STILL-blocked nodes")
+        self.assertEqual(jd._distill_due_t(store, g(5), False, kids), T0 + 10, "no done event, no settledAt: mt")
+        self.assertEqual(jd._distill_due_t(store, g(5), True, kids), T0 + 10, "g6's block does not count: it is not blocked now")
+        self.assertTrue(jd._done_owed(store, g(5), kids), "no summary: owed")
+        self.assertFalse(jd._done_owed(store, g(7), kids), "the stamp matches a settle event and no newer done exists")
+
+
+class KidsMapOncePerStore(_Memos):
+    """_distill_session builds ONE parent -> children map per store and hands it to every _distill_due_t
+    of the pass, through _done_owed too: the saving this commit claims, pinned on the call shape (the
+    KidsMap class pins that the answer does not depend on who built the map)."""
+
+    def test_one_kids_map_per_store_and_no_bare_due_t_call(self):
+        path = self.td / (SID + ".jsonl")
+        path.write_text("\n".join(json.dumps(r) for r in [
+            _uline(T0, "wire the picker", "u1"), _aline(T0 + 30, "Wired and checked in.", "a1", "u1")]) + "\n")
+        (jd.STATESDIR / (SID + ".jsonl")).write_text(json.dumps({"t": T0 + 40, "state": "working"}) + "\n")
+        seg = jd.em.segments(jd.parsed_session(SID, [str(path)], T0 + 5000)["turns"][0])[0]["id"]
+        g = lambda n: "%s:g%d" % (SID, n)
+
+        def nd(nid, parent, text):
+            return {"id": nid, "text": text, "parentId": parent, "nodeComplete": True, "blocked": False,
+                    "cleared": False, "trail": [seg], "t": T0, "mt": T0 + 30, "summary": None,
+                    "log": [{"kind": "done", "src": "closer", "ev_t": T0 + 30, "at": T0 + 31}]}
+        jd.save_goals(SID, {"rompUuid": SID, "seq": 3, "placementsV": jd.PLACEMENTS_V, "lastNode": g(2),
+                            "nodes": {g(1): nd(g(1), None, "Wire the picker"), g(2): nd(g(2), None, "Ship the search"),
+                                      g(3): nd(g(3), g(1), "Wire the picker's route")},
+                            "placements": {}, "status": {g(1): "completed", g(2): "completed"}})
+        saved = (jd.distill_llm, jd.brief_llm, jd._kids_map, jd._distill_due_t)
+        self.addCleanup(lambda: setattr(jd, "distill_llm", saved[0]) or setattr(jd, "brief_llm", saved[1])
+                        or setattr(jd, "_kids_map", saved[2]) or setattr(jd, "_distill_due_t", saved[3]))
+        jd.distill_llm = lambda text, work, why, **kw: "Shipped the picker wiring."
+        jd.brief_llm = lambda *a, **k: self.fail("a completed top must not take the brief path")
+        kids_calls, bare = [], []
+
+        def counting_kids(nodes):
+            kids_calls.append(len(nodes))
+            return saved[2](nodes)
+
+        def recording_due(store, nid, blocked, kids=None):
+            if kids is None:
+                bare.append(nid)
+            return saved[3](store, nid, blocked, kids)
+        jd._kids_map, jd._distill_due_t = counting_kids, recording_due
+        n = jd._distill_session(SID, str(path), T0 + 5000)
+        self.assertGreaterEqual(n, 1, "fixture: the completed tops were distilled")
+        self.assertEqual(len(kids_calls), 1, "one parent -> children map per store")
+        self.assertEqual(bare, [], "every _distill_due_t call of the pass was handed that map")
+
+
+class LivePromptSince(_Memos):
+    def _rows(self, *rows):
+        return "\n".join(json.dumps(r) for r in rows) + "\n"
+
+    def test_changed_unchanged_absent_and_the_later_tick_rewrite_agree_with_the_scan(self):
+        p = jd.STATESDIR / (SID + ".jsonl")
+        self.assertIsNone(jd._live_prompt_since(SID), "no states file: None, no entry")
+        self.assertNotIn(str(p), jd._LIVE_PROMPT_MEMO)
+        p.write_text(self._rows({"t": T0 + 10, "state": "working"}, {"t": T0 + 50, "state": "picker"},
+                                {"t": T0 + 60, "state": "permission"}))
+        calls = self._count("_live_prompt_since_scan")
+        self.assertEqual(jd._live_prompt_since(SID), jd._live_prompt_since_scan(p))
+        self.assertEqual(jd._live_prompt_since(SID), T0 + 50, "the run's start")
+        self.assertEqual(len(calls), 2, "one scan for the memo fill, one for the comparison; the second call was a hit")
+        with open(p, "a") as f:                                          # the kernel's shape: a row appended
+            f.write(json.dumps({"t": T0 + 90, "state": "idle"}) + "\n")
+        self.assertEqual(jd._live_prompt_since(SID), jd._live_prompt_since_scan(p))
+        self.assertIsNone(jd._live_prompt_since(SID), "left the prompt: no episode")
+        self.assertEqual(len(calls), 4, "the append moved the identity: one scan, then a hit")
+        # a same-size rewrite in place that lands in a later mtime tick (a fixture's write_text): the mtime
+        # moves, the memo misses, the new content is served. Same byte count, and the trailing row now
+        # re-enters a prompt run at T0 + 91, so the answer changes with the content
+        _rewrite_same_size_later_tick(p, self._rows({"t": T0 + 10, "state": "working"}, {"t": T0 + 50, "state": "picker"},
+                                                    {"t": T0 + 60, "state": "permission"}, {"t": T0 + 91, "state": "pick"}))
+        self.assertEqual(jd._live_prompt_since(SID), jd._live_prompt_since_scan(p), "a later-tick rewrite is seen")
+        self.assertIsNone(jd._live_prompt_since(SID), '"pick" is not a prompt state: the control case')
+        _rewrite_same_size_later_tick(p, self._rows({"t": T0 + 10, "state": "worki"}, {"t": T0 + 50, "state": "picker"},
+                                                    {"t": T0 + 60, "state": "permission"}, {"t": T0 + 91, "state": "picker"}))
+        self.assertEqual(jd._live_prompt_since(SID), jd._live_prompt_since_scan(p))
+        self.assertEqual(jd._live_prompt_since(SID), T0 + 50,
+                         "picker, permission, picker is ONE run: the rewritten tail re-opened the episode at its start")
+        p.unlink()
+        self.assertIsNone(jd._live_prompt_since(SID))
+        self.assertNotIn(str(p), jd._LIVE_PROMPT_MEMO, "an absent file drops its entry")
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_an_unreadable_file_answers_none_and_is_not_memoized(self):
+        p = jd.STATESDIR / (SID + ".jsonl")
+        p.write_text(self._rows({"t": T0 + 50, "state": "picker"}))
+        os.chmod(p, 0)
+        try:
+            self.assertIsNone(jd._live_prompt_since(SID))
+            self.assertNotIn(str(p), jd._LIVE_PROMPT_MEMO)
+        finally:
+            os.chmod(p, 0o644)
+        self.assertEqual(jd._live_prompt_since(SID), T0 + 50, "readable again: the real answer, no stale None")
+
+    def test_a_same_tick_append_is_seen(self):
+        # the key is (ino, mtime_ns, size), exact for an append-only log: a row that lands in the SAME mtime
+        # tick as the memoized read moved the size, so it is seen (an (ino, mtime) key would serve the old
+        # answer until the next tick)
+        p = jd.STATESDIR / (SID + ".jsonl")
+        p.write_text(self._rows({"t": T0 + 50, "state": "picker"}))
+        self.assertEqual(jd._live_prompt_since(SID), T0 + 50)
+        st = os.stat(p)
+        with open(p, "a") as f:
+            f.write(json.dumps({"t": T0 + 90, "state": "idle"}) + "\n")
+        os.utime(p, ns=(st.st_atime_ns, st.st_mtime_ns))               # back on the memoized tick
+        self.assertEqual(os.stat(p).st_mtime_ns, st.st_mtime_ns, "fixture: the mtime did not move")
+        self.assertEqual(jd._live_prompt_since(SID), jd._live_prompt_since_scan(p))
+        self.assertIsNone(jd._live_prompt_since(SID), "the size moved: the appended idle row is seen")
+
+    def test_a_row_landing_after_the_read_is_seen_next_call(self):
+        # stat BEFORE read: a row landing between the read and the memo fill pairs the pre-row identity with
+        # the pre-row answer (honest: the read predates the row), and the next call sees the row because the
+        # live identity has moved past the memoized one. A key stat'd after the read would pair the
+        # post-row identity with the pre-row answer and serve it stale.
+        p = jd.STATESDIR / (SID + ".jsonl")
+        p.write_text(self._rows({"t": T0 + 50, "state": "picker"}))
+        real, n = jd._live_prompt_since_scan, []
+
+        def landing(path):
+            out = real(path)
+            n.append(1)
+            if len(n) == 1:
+                with open(path, "a") as f:                                # the row lands after the read
+                    f.write(json.dumps({"t": T0 + 90, "state": "idle"}) + "\n")
+            return out
+        jd._live_prompt_since_scan = landing
+        self.addCleanup(setattr, jd, "_live_prompt_since_scan", real)
+        self.assertEqual(jd._live_prompt_since(SID), T0 + 50, "the read predates the row: its answer is honest")
+        self.assertIsNone(jd._live_prompt_since(SID), "the next call sees the row (the identity moved past the memo's)")
+
+
+class ViewCleared(_Memos):
+    def test_changed_unchanged_absent_and_the_later_tick_rewrite_agree_with_the_scan(self):
+        p = jd.STATE / "cleared.jsonl"
+        self.assertEqual(jd._view_cleared(), frozenset(), "no file: empty")
+        a, b = SID + ":g1", SID + ":g2"
+        p.write_text(json.dumps({"id": a, "t": T0, "op": "clear"}) + "\n")
+        calls = self._count("_view_cleared_scan")
+        self.assertEqual(jd._view_cleared(), jd._view_cleared_scan(p))
+        self.assertEqual(jd._view_cleared(), {a})
+        self.assertEqual(len(calls), 2, "the second call was a hit")
+        with open(p, "a") as f:                                          # the kernel's shape: rows appended
+            f.write(json.dumps({"id": b, "t": T0 + 1, "op": "clear"}) + "\n")
+            f.write(json.dumps({"id": a, "t": T0 + 2, "op": "undo"}) + "\n")
+        self.assertEqual(jd._view_cleared(), jd._view_cleared_scan(p))
+        self.assertEqual(jd._view_cleared(), {b}, "undo removes, newest wins")
+        self.assertEqual(len(calls), 4)
+        # a same-size rewrite in place landing in a later tick: seen
+        text = p.read_text().replace('"op": "undo"', '"op": "redo"')      # same length; "redo" is not an undo
+        _rewrite_same_size_later_tick(p, text)
+        self.assertEqual(jd._view_cleared(), jd._view_cleared_scan(p))
+        self.assertEqual(jd._view_cleared(), {a, b})
+        p.unlink()
+        self.assertEqual(jd._view_cleared(), frozenset())
+        self.assertNotIn(str(p), jd._VIEW_CLEARED_MEMO)
+
+    def test_a_same_tick_append_is_seen(self):
+        # (ino, mtime_ns, size): a clear row landing in the same mtime tick as the memoized read is seen
+        # because the size moved
+        p = jd.STATE / "cleared.jsonl"
+        a, b = SID + ":g1", SID + ":g2"
+        p.write_text(json.dumps({"id": a, "t": T0, "op": "clear"}) + "\n")
+        self.assertEqual(jd._view_cleared(), {a})
+        st = os.stat(p)
+        with open(p, "a") as f:
+            f.write(json.dumps({"id": b, "t": T0 + 1, "op": "clear"}) + "\n")
+        os.utime(p, ns=(st.st_atime_ns, st.st_mtime_ns))               # back on the memoized tick
+        self.assertEqual(os.stat(p).st_mtime_ns, st.st_mtime_ns, "fixture: the mtime did not move")
+        self.assertEqual(jd._view_cleared(), jd._view_cleared_scan(p))
+        self.assertEqual(jd._view_cleared(), {a, b}, "the size moved: the appended row is seen")
+
+    def test_a_row_landing_after_the_read_is_seen_next_call(self):
+        # stat before read (see LivePromptSince's twin): the pre-row answer is served once, honestly, and
+        # the next call sees the row
+        p = jd.STATE / "cleared.jsonl"
+        a, b = SID + ":g1", SID + ":g2"
+        p.write_text(json.dumps({"id": a, "t": T0, "op": "clear"}) + "\n")
+        real, n = jd._view_cleared_scan, []
+
+        def landing(path):
+            out = real(path)
+            n.append(1)
+            if len(n) == 1:
+                with open(path, "a") as f:
+                    f.write(json.dumps({"id": b, "t": T0 + 1, "op": "clear"}) + "\n")
+            return out
+        jd._view_cleared_scan = landing
+        self.addCleanup(setattr, jd, "_view_cleared_scan", real)
+        self.assertEqual(jd._view_cleared(), {a}, "the read predates the row")
+        self.assertEqual(jd._view_cleared(), {a, b}, "the next call sees it")
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_an_unreadable_file_answers_empty_and_is_not_memoized(self):
+        # the twin of LivePromptSince's: an unreadable log answers empty and leaves no entry, so the real
+        # answer comes back the moment the file reads again (chmod moves ctime, not mtime: a memoized empty
+        # would be served after the restore too)
+        p = jd.STATE / "cleared.jsonl"
+        a = SID + ":g1"
+        p.write_text(json.dumps({"id": a, "t": T0, "op": "clear"}) + "\n")
+        os.chmod(p, 0)
+        try:
+            self.assertEqual(jd._view_cleared(), frozenset())
+            self.assertNotIn(str(p), jd._VIEW_CLEARED_MEMO)
+        finally:
+            os.chmod(p, 0o644)
+        self.assertEqual(jd._view_cleared(), {a}, "readable again: the real answer, no stale empty")
+
+    def test_the_answer_is_immutable_and_a_rebind_starts_empty(self):
+        p = jd.STATE / "cleared.jsonl"
+        p.write_text(json.dumps({"id": SID + ":g1", "t": T0, "op": "clear"}) + "\n")
+        vc = jd._view_cleared()
+        with self.assertRaises(AttributeError):
+            vc.add("x")                                                  # a caller mutating the shared memo fails loudly
+        self.assertIn(str(p), jd._VIEW_CLEARED_MEMO)
+        sp = jd.STATESDIR / (SID + ".jsonl")
+        sp.write_text(json.dumps({"t": T0 + 50, "state": "picker"}) + "\n")
+        self.assertEqual(jd._live_prompt_since(SID), T0 + 50)
+        self.assertIn(str(sp), jd._LIVE_PROMPT_MEMO, "premise: both memos hold an entry before the rebind")
+        other = Path(tempfile.mkdtemp())
+        try:
+            jd._rebind_state(other)
+            self.assertEqual(jd._VIEW_CLEARED_MEMO, {})
+            self.assertEqual(jd._LIVE_PROMPT_MEMO, {}, "the rebind clears the live-prompt memo too")
+            self.assertEqual(jd._view_cleared(), frozenset(), "the new root has no cleared.jsonl")
+        finally:
+            jd._rebind_state(self.td)
+            shutil.rmtree(other, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge_pass_frame.py
+++ b/tests/test_judge_pass_frame.py
@@ -6,6 +6,11 @@ freshly-ended turn against a tree the planner had not yet ruled on (the ui g139 
 pins parsed_session from first touch to pass end (first touch wins across worker threads), pins the
 caption memo's fileset key so a mid-pass write can't stamp stale tasks under a fresh key, and only
 freezes EVIDENCE — goal/caption stores keep flowing (the closer must see this pass's planner verdicts).
+
+The parse's KEY is pinned with the parse (2026-09-07; _frame_parse_key): the first toucher of a
+session pins its (fileset key, cut) pair BEFORE reading, every later caller in the pass gets that pair,
+and the caption memo keys on it, so a key can never be newer than the content it stands for. The cut the
+parse runs under stays live; the pair a parse was actually served under is recorded beside it.
 SYNTHETIC fixtures only."""
 import json
 import os
@@ -52,13 +57,28 @@ class PassFrame(unittest.TestCase):
                 aline(T0 + 10, "Working on it now, first step underway.", "a1", "u1", stop="tool_use")]
         self.path.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
         jd.end_pass_frame(True)          # belt: never inherit a frame a crashed test left open
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()   # a test's cache-hit premise must not ride an earlier test's entry
+        self._saved = (jd._PENDING_CUT_FN, jd.em.parse_session, jd._fileset_key)
 
     def tearDown(self):
         jd.end_pass_frame(True)
+        jd._PENDING_CUT_FN, jd.em.parse_session, jd._fileset_key = self._saved
 
     def _append(self, rec):
         with open(self.path, "a") as f:
             f.write(json.dumps(rec) + "\n")
+
+    def _states_row(self, t, state):
+        jd.STATESDIR.mkdir(parents=True, exist_ok=True)
+        with open(jd.STATESDIR / (SID + ".jsonl"), "a") as f:
+            f.write(json.dumps({"t": t, "state": state}) + "\n")
+
+    def _live_pair(self):
+        # the pair a frameless call computes: the candidates plus the states file when it exists, and the cut
+        return (jd._fileset_key(jd._parse_key_files(SID, [str(self.path)])[2]), jd._pending_cut(SID))
+
+    def _ended_work_tasks(self, tasks):
+        return [t for t in tasks if t["kind"] == "work" and not t.get("live")]
 
     def test_frame_pins_the_parse_across_a_mid_pass_write(self):
         self.assertTrue(jd.begin_pass_frame())
@@ -112,7 +132,7 @@ class PassFrame(unittest.TestCase):
         # caller is handed the peer's parse, so no two stages of the pass ever hold different objects
         jd.parsed_session(SID, [str(self.path)], T0 + 100)             # frameless: fills the cache
         self.assertTrue(jd.begin_pass_frame())
-        peer = {"turns": [], "peer": True}
+        peer, peer_pair = {"turns": [], "peer": True}, ("peer-pair", "")
 
         class RacedCache(dict):
             # parsed_session reads the cache BEFORE it takes _frame_lock, so a peer pinning here is the
@@ -120,6 +140,7 @@ class PassFrame(unittest.TestCase):
             def get(self, k, default=None):
                 with jd._frame_lock:
                     jd._frame["parses"].setdefault(SID, peer)
+                    jd._frame["served"][SID] = peer_pair
                 return dict.get(self, k, default)
         real = jd._PARSE_CACHE
         jd._PARSE_CACHE = RacedCache(real)
@@ -129,6 +150,7 @@ class PassFrame(unittest.TestCase):
             jd._PARSE_CACHE = real
         self.assertIs(got, peer, "first touch wins: the hit path yields to the peer's pin")
         self.assertIs(jd._frame["parses"][SID], peer, "and the peer's pin stands")
+        self.assertEqual(jd._frame["served"][SID], peer_pair, "the served pair stays the winner's")
 
     def test_frame_ownership_nests(self):
         self.assertTrue(jd.begin_pass_frame(), "first opener owns the frame")
@@ -160,6 +182,223 @@ class PassFrame(unittest.TestCase):
         ids = {w["id"] for t in v2 for w in t["writes"]}
         self.assertGreater(len(ids), len({w["id"] for t in v1 for w in t["writes"]}),
                            "the next pass captions the growth — the memo never went stale")
+
+    # ── the parse KEY rides the frame with the parse ──
+
+    def test_the_first_touch_pins_the_pair_of_the_files_as_they_were_before_the_read(self):
+        self.assertTrue(jd.begin_pass_frame())
+        before = self._live_pair()
+        jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertEqual(jd._frame["keys"][("parse", SID)], before,
+                         "the pair pinned is the files' key as they were BEFORE the parse read them")
+        self.assertEqual(jd._frame["served"][SID], before, "and the parse was served under that same pair")
+
+    def test_a_gate_pin_holds_the_pre_append_pair_while_the_parse_holds_the_appended_content(self):
+        # a gate (the evidence gate's _stage_sig) pins the pair before the stage's first parse; an append in
+        # between leaves the pinned pair alone and the parse reads the newer content: content newer than the
+        # key (one redundant run next pass), never older (a missed run)
+        self.assertTrue(jd.begin_pass_frame())
+        pair, cut, fr = jd._frame_parse_key(SID, [str(self.path)])     # standing in for the gate
+        self.assertEqual(cut, "", "a first toucher reads the live cut")
+        self.assertIs(fr, jd._frame, "and is told which frame it pinned into")
+        self._append(aline(T0 + 60, "All done: shipped and verified.", "a2", "a1", stop="end_turn"))
+        sess = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertTrue(sess["turns"][-1]["ended"], "the parse holds the appended content")
+        self.assertEqual(jd._frame["keys"][("parse", SID)], pair, "the pinned pair stays at the pre-append value")
+        self.assertEqual(jd._frame["served"][SID], pair, "the parse was served under the pinned pair")
+        self.assertEqual(jd._PARSE_CACHE[SID][0], pair, "the cache slot is the pinned pair")
+        again = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertIs(again, sess, "every later look in the pass returns the pinned parse")
+        jd.end_pass_frame(True)
+        fresh = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertIsNot(fresh, sess, "the entry stored under the pre-append pair is never served for the grown file's key")
+        self.assertEqual(jd._PARSE_CACHE[SID][0], self._live_pair(), "the frameless look re-keys the cache on the live pair")
+
+    def test_the_parse_runs_under_the_live_cut_and_the_served_pair_records_it(self):
+        # the cut rule (the user's call, 2026-09-07): the judged world is the LIVE cut's, as before the frame
+        # existed; a cut that arms between a gate's pin and the stage's parse shows as a served pair that
+        # differs from the pinned one (the gate then withholds its stamp), and the cache slot carries the cut
+        # the parse was made under
+        self._append(aline(T0 + 60, "All done: shipped and verified.", "a2", "a1", stop="end_turn"))
+        self.assertTrue(jd.begin_pass_frame())
+        pair, _cut, _fr = jd._frame_parse_key(SID, [str(self.path)])
+        self.assertEqual(pair[1], "", "premise: no cut when the gate pinned")
+        jd._PENDING_CUT_FN = lambda fsid: "a1"                            # a bare rollback arms, cutting a2 away
+        sess = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertEqual([a["uuid"] for t in sess["turns"] for a in t["atoms"] if a.get("uuid")], ["u1", "a1"],
+                         "the parse honours the live cut: the rolled-back tail is not judged")
+        served = jd._frame["served"][SID]
+        self.assertEqual(served, (pair[0], "a1"), "the served pair carries the cut the parse was made under")
+        self.assertNotEqual(served, jd._frame["keys"][("parse", SID)], "and differs from the pinned pair")
+        self.assertEqual(jd._PARSE_CACHE[SID][0], served, "the cache slot is (pinned fileset key, live cut)")
+
+    def test_without_a_frame_the_live_pair_is_returned_and_nothing_is_pinned(self):
+        pair, cut, fr = jd._frame_parse_key(SID, [str(self.path)])
+        self.assertEqual(pair, self._live_pair())
+        self.assertEqual(cut, "")
+        self.assertIsNone(fr)
+        self.assertIsNone(jd._frame, "no frame was opened")
+
+    def test_a_failed_stat_pins_none_for_the_whole_pass(self):
+        # the tag is PRESENT with None: a later caller in the same pass whose stat would succeed still gets
+        # None, so no fresh key is ever pinned over a parse that was read earlier (the keyless-parse hole)
+        self.assertTrue(jd.begin_pass_frame())
+        real = jd._fileset_key
+
+        def vanished(files):
+            raise OSError("a candidate vanished between the exists() and the stat")
+        jd._fileset_key = vanished
+        pair, cut, fr = jd._frame_parse_key(SID, [str(self.path)])
+        jd._fileset_key = real
+        self.assertIsNone(pair)
+        self.assertEqual(cut, "", "the cut was read (the pin is the first toucher's)")
+        self.assertIn(("parse", SID), fr["keys"], "the tag is present ...")
+        self.assertIsNone(fr["keys"][("parse", SID)], "... with value None")
+        self._append(aline(T0 + 60, "All done: shipped and verified.", "a2", "a1", stop="end_turn"))
+        pair2, cut2, _fr = jd._frame_parse_key(SID, [str(self.path)])
+        self.assertIsNone(pair2, "a later call whose stat would succeed still returns the pinned None")
+        self.assertIsNone(cut2, "and reads nothing")
+        sess = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertNotIn(SID, jd._PARSE_CACHE, "the parse ran uncached")
+        self.assertIs(jd._frame["parses"][SID], sess, "but is pinned under the frame")
+        self.assertIsNone(jd._frame["served"][SID], "served under no pair: the gate reads this as run-and-do-not-stamp")
+
+    def test_the_key_and_the_parse_pin_into_the_same_frame(self):
+        # a parse can span a pass boundary (a pusher tick job's parse while the producer ends frame A and
+        # begins frame B): the parse must land in the frame its key went into, never keyless in the next one
+        real = jd.em.parse_session
+        crossed = {}
+
+        def boundary_inside(*a, **k):
+            crossed["a"] = jd._frame
+            jd.end_pass_frame(True)
+            jd.begin_pass_frame()
+            crossed["b"] = jd._frame
+            return real(*a, **k)
+        jd.em.parse_session = boundary_inside
+        self.assertTrue(jd.begin_pass_frame())
+        sess = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        a, b = crossed["a"], crossed["b"]
+        self.assertIsNot(a, b)
+        self.assertIn(("parse", SID), a["keys"]); self.assertIs(a["parses"].get(SID), sess)
+        self.assertNotIn(("parse", SID), b["keys"], "the new frame holds no key for the session ...")
+        self.assertNotIn(SID, b["parses"], "... and no parse: neither, never a parse alone")
+
+    def test_a_fork_lane_keys_the_frame_and_the_frameless_cache_alike(self):
+        # a /clear fork lane's leaf is not the anchor file: _judge_candidates adds the anchor once; the frame's
+        # key is computed from the RAW leaf list exactly as the frameless cache key is, so the two agree
+        fork = self.td / "99999999-8888-7777-6666-555555555555.jsonl"
+        fork.write_text("\n".join(json.dumps(r) for r in [
+            uline(T0 + 500, "fresh start after the clear", "u9"),
+            aline(T0 + 510, "Picking it up from here.", "a9", "u9", stop="end_turn")]) + "\n")
+        warm = jd.parsed_session(SID, [str(fork)], T0 + 600)             # frameless: fills the cache
+        frameless_key = jd._PARSE_CACHE[SID][0]
+        self.assertEqual(len(frameless_key[0]), 2, "premise: the leaf plus the anchor, once")
+        self.assertTrue(jd.begin_pass_frame())
+        pair, _cut, _fr = jd._frame_parse_key(SID, [str(fork)])
+        self.assertEqual(pair, frameless_key, "the framed key equals the frameless one")
+        self.assertIs(jd.parsed_session(SID, [str(fork)], T0 + 600), warm, "so the pass's first touch is a cache hit")
+
+    def test_a_warm_hit_records_its_served_pair_and_holds_when_the_slot_moves(self):
+        # the hit path's pin (the warm-first-touch case above) is what writes fr["served"] for a warm session,
+        # which the evidence gate's served-pair check reads, and what keeps answering when the cache slot moves
+        # under the pass. With the KEY pinned too, an unchanged slot answers the same object with or without
+        # the pin, so this case moves the slot between the touches: a wholesale clear (the overflow eviction)
+        # and a bare rollback arming mid-pass (the live cut is part of the slot's key)
+        warm = jd.parsed_session(SID, [str(self.path)], T0 + 100)     # frameless: fills the cache
+        self.assertTrue(jd.begin_pass_frame())
+        first = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertIs(first, warm, "premise: the pass's first touch is a cache hit")
+        self.assertIs(jd._frame["parses"][SID], first, "the hit is pinned")
+        self.assertEqual(jd._frame["served"][SID], jd._frame["keys"][("parse", SID)],
+                         "and recorded as served under the pinned pair, which the gate's served-pair check reads")
+        self._append(aline(T0 + 60, "All done: shipped and verified.", "a2", "a1", stop="end_turn"))
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()                                          # the overflow eviction
+        again = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertIs(again, first, "the slot is gone: the pinned parse still answers")
+        jd._PENDING_CUT_FN = lambda fsid: "a1"                            # a bare rollback arms mid-pass
+        again = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertIs(again, first, "the live cut moved the slot's key: the pinned parse still answers")
+        self.assertFalse(again["turns"][-1]["ended"], "the mid-pass append stays out of this pass")
+
+    def test_a_losing_parse_never_overwrites_the_winners_served_pair(self):
+        # two readers race a first touch on the miss path; a bare rollback arms between them. The
+        # competitor parses under the live cut, pins first and records served=(K, cut). The outer reader
+        # parsed under the pre-cut world (its pair equals the pinned one); it loses and must leave
+        # fr["served"] alone: were the loser's pair recorded, the gate would read a served pair equal to the
+        # pinned one and stamp the cut world as if it were the pinned one
+        self._append(aline(T0 + 60, "All done: shipped and verified.", "a2", "a1", stop="end_turn"))
+        real, competitor = jd.em.parse_session, {}
+
+        def race(*a, **k):
+            jd.em.parse_session = real                                   # the competitor parses for real
+            jd._PENDING_CUT_FN = lambda fsid: "a1"                       # a bare rollback arms between the two
+            competitor["parse"] = jd.parsed_session(SID, [str(self.path)], T0 + 100)   # pins FIRST
+            return real(*a, **k)                                         # the outer's own parse, pre-cut
+        jd.em.parse_session = race
+        self.assertTrue(jd.begin_pass_frame())
+        got = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        pinned = jd._frame["keys"][("parse", SID)]
+        self.assertEqual(pinned[1], "", "premise: the pair was pinned before the cut armed")
+        self.assertIs(got, competitor["parse"], "the outer reader lost and is handed the winner's parse")
+        self.assertIs(jd._frame["parses"][SID], competitor["parse"])
+        served = jd._frame["served"][SID]
+        self.assertEqual(served, (pinned[0], "a1"), "the served pair is the WINNER's: the cut it parsed under")
+        self.assertNotEqual(served, pinned, "so a gate reading it withholds its stamp")
+
+    def test_a_pair_that_cannot_be_computed_memoizes_nothing(self):
+        # a failed stat pins None for the pass; tasks_for then answers [] and writes no memo, because a memo
+        # under a None key would be served to nobody (and one written under a made-up key would be trusted)
+        self.assertTrue(jd.begin_pass_frame())
+        real = jd._fileset_key
+
+        def vanished(files):
+            raise OSError("a candidate vanished between the exists() and the stat")
+        jd._fileset_key = vanished
+        self.assertEqual(jd.tasks_for(SID, str(self.path), [str(self.path)], T0 + 100), [])
+        self.assertFalse((jd.PCACHE / (SID + ".json")).exists(), "no memo is written under a None key")
+        jd._fileset_key = real
+        self.assertEqual(jd.tasks_for(SID, str(self.path), [str(self.path)], T0 + 100), [],
+                         "the pinned None holds for the pass: nothing is served, nothing memoized")
+        self.assertFalse((jd.PCACHE / (SID + ".json")).exists())
+
+    # ── the caption memo keys on the pinned pair (tasks_for re-keyed on the frame's pair) ──
+
+    def test_the_caption_memo_keys_on_the_gate_pinned_pair_not_its_own_stat(self):
+        # the last turn is OPEN when the gate pins; the turn's final record and the idle row land; the index
+        # tier's tasks_for must memo under the PRE-append pair, so the next pass (live key K1 != K0) recomputes
+        # and queues the turn's final caption. A memo keyed on its own live stat wrote {key: K1, tasks: K0's}
+        # and the final caption was never queued until the transcript moved again.
+        self.assertTrue(jd.begin_pass_frame())
+        pair, _cut, _fr = jd._frame_parse_key(SID, [str(self.path)])     # the gate's pin, before any read
+        self._append(aline(T0 + 60, "All done: shipped and verified.", "a2", "a1", stop="end_turn"))
+        self._states_row(T0 + 61, "idle")
+        jd.tasks_for(SID, str(self.path), [str(self.path)], T0 + 100)
+        o = json.loads((jd.PCACHE / (SID + ".json")).read_text())
+        self.assertEqual(o["key"], json.loads(json.dumps(list(pair))), "the memo's key is the pre-append pair")
+        jd.end_pass_frame(True)
+        v2 = jd.tasks_for(SID, str(self.path), [str(self.path)], T0 + 300)
+        self.assertTrue(self._ended_work_tasks(v2), "the next pass queues the ended turn's work caption")
+        self.assertNotEqual(json.loads((jd.PCACHE / (SID + ".json")).read_text())["key"], o["key"],
+                            "under the live key, which the memo now carries")
+
+    def test_a_warm_tick_job_first_touch_then_an_append_then_the_caption_memo(self):
+        # the tick-job variant: a pusher job's parsed_session is the pass's first toucher on a cache HIT (the
+        # turn open), the final record lands, then tasks_for. The frozen world (turn open) is what the memo
+        # holds, under the frozen key; the next pass sees the ended turn whole.
+        warm = jd.parsed_session(SID, [str(self.path)], T0 + 100)     # frameless: fills the cache, turn open
+        self.assertTrue(jd.begin_pass_frame())
+        self.assertIs(jd.parsed_session(SID, [str(self.path)], T0 + 100), warm, "premise: a cache hit pins")
+        pinned = jd._frame["keys"][("parse", SID)]
+        self._append(aline(T0 + 60, "All done: shipped and verified.", "a2", "a1", stop="end_turn"))
+        self._states_row(T0 + 61, "idle")
+        v1 = jd.tasks_for(SID, str(self.path), [str(self.path)], T0 + 100)
+        self.assertFalse(self._ended_work_tasks(v1), "the frozen world: the turn is still open, no final caption yet")
+        o = json.loads((jd.PCACHE / (SID + ".json")).read_text())
+        self.assertEqual(o["key"], json.loads(json.dumps(list(pinned))), "memoized under the frozen pair")
+        jd.end_pass_frame(True)
+        v2 = jd.tasks_for(SID, str(self.path), [str(self.path)], T0 + 300)
+        self.assertTrue(self._ended_work_tasks(v2), "the next pass captions the ended turn: nothing dropped")
 
     def test_tier_entries_and_producer_are_frame_wrapped(self):
         jsrc = open(jd.__file__).read()

--- a/tests/test_judge_pass_frame.py
+++ b/tests/test_judge_pass_frame.py
@@ -15,6 +15,7 @@ SYNTHETIC fixtures only."""
 import json
 import os
 import tempfile
+import threading
 import unittest
 from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
@@ -382,10 +383,11 @@ class PassFrame(unittest.TestCase):
         self.assertNotEqual(json.loads((jd.PCACHE / (SID + ".json")).read_text())["key"], o["key"],
                             "under the live key, which the memo now carries")
 
-    def test_a_warm_tick_job_first_touch_then_an_append_then_the_caption_memo(self):
-        # the tick-job variant: a pusher job's parsed_session is the pass's first toucher on a cache HIT (the
+    def test_a_warm_pass_thread_first_touch_then_an_append_then_the_caption_memo(self):
+        # the index-tier variant: a pass thread's parsed_session is the pass's first toucher on a cache HIT (the
         # turn open), the final record lands, then tasks_for. The frozen world (turn open) is what the memo
-        # holds, under the frozen key; the next pass sees the ended turn whole.
+        # holds, under the frozen key; the next pass sees the ended turn whole. (A pusher tick job's touch is
+        # not this case: it is not a pass thread and pins nothing, see the two tests below.)
         warm = jd.parsed_session(SID, [str(self.path)], T0 + 100)     # frameless: fills the cache, turn open
         self.assertTrue(jd.begin_pass_frame())
         self.assertIs(jd.parsed_session(SID, [str(self.path)], T0 + 100), warm, "premise: a cache hit pins")
@@ -399,6 +401,60 @@ class PassFrame(unittest.TestCase):
         jd.end_pass_frame(True)
         v2 = jd.tasks_for(SID, str(self.path), [str(self.path)], T0 + 300)
         self.assertTrue(self._ended_work_tasks(v2), "the next pass captions the ended turn: nothing dropped")
+
+    def _elsewhere(self, fn, *a):
+        """Run fn on a fresh plain thread (the kernel's pusher, say): no pass mark, whatever the frame's state."""
+        out, err = [], []
+
+        def run():
+            try:
+                out.append(fn(*a))
+            except BaseException as e:               # surfaced on the test thread, never swallowed by the worker
+                err.append(e)
+        t = threading.Thread(target=run, name="pusher")
+        t.start(); t.join(10)
+        self.assertFalse(t.is_alive(), "the thread finished")
+        if err:
+            raise err[0]
+        return out[0]
+
+    def test_a_thread_outside_the_pass_reads_live_and_pins_nothing(self):
+        # the pin is scoped to PASS THREADS (review find, 2026-09-08): the frame is a module global, so before
+        # this a pusher tick job's first touch, warm or cold, pinned that job to the pass-start world for as
+        # long as the tiers ran, model calls included. A thread that neither opened nor joined the frame nor
+        # runs in a judge pool sees no frame: it reads the live file at every call and leaves no pin behind.
+        warm = jd.parsed_session(SID, [str(self.path)], T0 + 100)     # frameless: fills the cache, turn open
+        self.assertTrue(jd.begin_pass_frame())
+        self.assertIs(jd._pass_frame(), jd._frame, "the opener is a pass thread")
+        self.assertIsNone(self._elsewhere(jd._pass_frame), "a plain thread is not")
+        self.assertIs(self._elsewhere(jd.parsed_session, SID, [str(self.path)], T0 + 100), warm,
+                      "a cache hit from outside the pass answers the cached parse...")
+        self.assertNotIn(SID, jd._frame["parses"], "...and pins nothing")
+        self._append(aline(T0 + 60, "All done: shipped and verified.", "a2", "a1", stop="end_turn"))
+        live = self._elsewhere(jd.parsed_session, SID, [str(self.path)], T0 + 100)
+        self.assertTrue(live["turns"][-1]["ended"], "outside the pass the mid-pass append shows through")
+        self.assertNotIn(SID, jd._frame["parses"], "still nothing pinned")
+        pinned = jd.parsed_session(SID, [str(self.path)], T0 + 100)   # the pass thread's own first touch
+        self.assertIs(jd._frame["parses"].get(SID), pinned, "the pass thread pins (the live parse the cache now holds)")
+        self.assertIs(pinned, live)
+        jd.end_pass_frame(True)
+        self.assertIsNone(jd._pass_frame(), "the end unmarks the caller")
+
+    def test_a_pool_worker_is_a_pass_thread_and_a_joiner_too(self):
+        # the tiers fan their per-session work through this module's pools; a worker pins into the frame like
+        # the tier thread that submitted it (the _TimedPool mark), and a thread that JOINS the frame
+        # (begin_pass_frame answering False: run_index and run_triage under the kernel producer) is a pass
+        # thread from then on
+        self.assertTrue(self._elsewhere(jd.begin_pass_frame), "the producer's thread opens the frame")
+        self.assertIsNone(jd._pass_frame(), "this thread has not joined: not a pass thread yet")
+        with jd.ThreadPoolExecutor(max_workers=1) as ex:
+            got = ex.submit(jd.parsed_session, SID, [str(self.path)], T0 + 100).result()
+            self.assertIs(jd._frame["parses"].get(SID), got, "a pool worker's touch pins")
+            self.assertIs(ex.submit(jd._pass_frame).result(), jd._frame)
+        self.assertFalse(jd.begin_pass_frame(), "this thread joins the open frame")
+        self.assertIs(jd._pass_frame(), jd._frame, "a joiner is a pass thread")
+        self.assertIs(jd.parsed_session(SID, [str(self.path)], T0 + 100), got, "and reads the pinned world")
+        jd.end_pass_frame(True)
 
     def test_tier_entries_and_producer_are_frame_wrapped(self):
         jsrc = open(jd.__file__).read()

--- a/tests/test_judge_pass_frame.py
+++ b/tests/test_judge_pass_frame.py
@@ -78,6 +78,58 @@ class PassFrame(unittest.TestCase):
         fresh = jd.parsed_session(SID, [str(self.path)], T0 + 100)
         self.assertIsNot(fresh, first, "no frame → each look re-reads reality (the pre-frame behavior)")
 
+    def test_a_warm_first_touch_pins_the_cached_parse(self):
+        # The cache-HIT path returned without pinning (found in review 2026-09-06): a session whose parse
+        # was already in _PARSE_CACHE froze nothing under the frame, so a turn ending mid-pass was visible
+        # to a later stage and invisible to an earlier one - the same two-worlds shape the frame exists
+        # to prevent, for every warm session (idle sessions are warm nearly always).
+        warm = jd.parsed_session(SID, [str(self.path)], T0 + 100)     # frameless: fills the cache
+        self.assertTrue(jd.begin_pass_frame())
+        first = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertIs(first, warm, "premise: the pass's first touch is a cache hit")
+        self._append(aline(T0 + 60, "All done: shipped and verified.", "a2", "a1", stop="end_turn"))
+        again = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertIs(again, first, "the hit was pinned: a later stage sees the SAME frozen parse")
+        self.assertFalse(again["turns"][-1]["ended"], "the mid-pass append stays out of this pass")
+        jd.end_pass_frame(True)
+        fresh = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertIsNot(fresh, first)
+        self.assertTrue(fresh["turns"][-1]["ended"], "the next pass sees the ended turn, whole")
+
+    def test_a_warm_cache_without_a_frame_still_reads_live(self):
+        # the no-frame path is unchanged: an unchanged file hits the cache, a grown one re-parses at once
+        warm = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertIs(jd.parsed_session(SID, [str(self.path)], T0 + 100), warm,
+                      "an unchanged file is served from the cache")
+        self._append(aline(T0 + 60, "All done: shipped and verified.", "a2", "a1", stop="end_turn"))
+        fresh = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertIsNot(fresh, warm)
+        self.assertTrue(fresh["turns"][-1]["ended"], "no frame: the appended turn shows on the next look")
+
+    def test_a_warm_hit_yields_to_a_concurrent_first_toucher(self):
+        # first touch wins on the HIT path too: the pin is a setdefault, never an overwrite. A worker thread
+        # that pinned the session between this caller's cache read and its lock take keeps its pin, and this
+        # caller is handed the peer's parse, so no two stages of the pass ever hold different objects
+        jd.parsed_session(SID, [str(self.path)], T0 + 100)             # frameless: fills the cache
+        self.assertTrue(jd.begin_pass_frame())
+        peer = {"turns": [], "peer": True}
+
+        class RacedCache(dict):
+            # parsed_session reads the cache BEFORE it takes _frame_lock, so a peer pinning here is the
+            # concurrent first toucher, and the lock is free to take
+            def get(self, k, default=None):
+                with jd._frame_lock:
+                    jd._frame["parses"].setdefault(SID, peer)
+                return dict.get(self, k, default)
+        real = jd._PARSE_CACHE
+        jd._PARSE_CACHE = RacedCache(real)
+        try:
+            got = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        finally:
+            jd._PARSE_CACHE = real
+        self.assertIs(got, peer, "first touch wins: the hit path yields to the peer's pin")
+        self.assertIs(jd._frame["parses"][SID], peer, "and the peer's pin stands")
+
     def test_frame_ownership_nests(self):
         self.assertTrue(jd.begin_pass_frame(), "first opener owns the frame")
         pinned = jd.parsed_session(SID, [str(self.path)], T0 + 100)

--- a/tests/test_judge_stage_gate.py
+++ b/tests/test_judge_stage_gate.py
@@ -1680,6 +1680,375 @@ class StoreCompleteness(_Gate):
         self._pass(tiers=STORE_TIERS)
         self.assertEqual(self._st4("stamped"), (1, 1, 1, 1), "readable again: complete runs stamp")
 
+    def _focus(self):
+        store = jd.load_goals(SID)
+        f = store.get("lastNode")
+        while f and store["nodes"][f].get("parentId") is not None:
+            f = store["nodes"][f]["parentId"]
+        return store["nodes"][f]
+
+    def _rows(self, err):
+        return [r for r in (json.loads(l) for l in open(jd.ERRORS) if l.strip()) if r.get("err") == err]
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_an_unreadable_states_file_never_stamps(self):
+        # the review's reproduction: the gate stats the states file into the distiller's signature, then the
+        # stage's open fails. Before the fix the run answered "no live prompt", completed and stamped, and
+        # the brief owed to the parked session waited until the file moved for an unrelated reason
+        self._session(SID)
+        self._converge()
+        self._states_row(SID, T0 + 300, "picker")
+        sp = jd.STATESDIR / (SID + ".jsonl")
+        os.chmod(sp, 0)
+        try:
+            self._reset()
+            self._pass(tiers=("distill",))
+            s = self._st("distill")
+            self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0),
+                             "a states read that fails after a good stat marks the run incomplete")
+            self.assertEqual(len(self._rows("states-unreadable")), 1, "one loud row")
+            self._reset()
+            self._pass(tiers=("distill",))
+            self.assertEqual((self._st("distill")["ran"], self._st("distill")["incomplete"]), (1, 1), "still due")
+            self.assertEqual(len(self._rows("states-unreadable")), 1, "one row per failure episode, not per pass")
+        finally:
+            os.chmod(sp, 0o644)
+        self._reset()
+        self._pass(tiers=("distill",))
+        s = self._st("distill")
+        self.assertEqual((s["ran"], s["stamped"]), (1, 1), "readable again, nothing on disk moved: the run happens and stamps")
+        self.assertTrue(self._focus().get("blockSummary"), "the parked session's brief landed")
+        self._states_row(SID, T0 + 400, "picker")                        # a new picker run re-arms the distiller
+        os.chmod(sp, 0)
+        self._reset()
+        self._pass(tiers=("distill",))
+        self.assertEqual(len(self._rows("states-unreadable")), 2, "a second episode opens")
+        sp.unlink()                                                      # removed while the episode is open
+        self._reset()
+        self._pass(tiers=("distill",))
+        self.assertEqual(self._st("distill")["stamped"], 1, "no states file: absent is a real state, the run completes and stamps")
+        self._states_row(SID, T0 + 500, "picker")
+        os.chmod(sp, 0)
+        try:
+            self._reset()
+            self._pass(tiers=("distill",))
+            self.assertEqual(len(self._rows("states-unreadable")), 3, "recreated unreadable: absence ended the episode, a third row")
+        finally:
+            os.chmod(sp, 0o644)
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_an_unreadable_cleared_file_never_stamps(self):
+        self._session(SID)
+        self._converge()
+        cp = jd.STATE / "cleared.jsonl"
+        with open(cp, "a") as f:                                         # a row: the grouper re-arms and reads it
+            f.write(json.dumps({"id": SID2 + ":g1", "op": "clear", "t": NOW}) + "\n")
+        os.chmod(cp, 0)
+        try:
+            self._reset()
+            self._pass(tiers=("group",))
+            s = self._st("group")
+            self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0),
+                             "a cleared.jsonl read that fails after a good stat marks the run incomplete")
+            self.assertEqual(len(self._rows("cleared-unreadable")), 1)
+        finally:
+            os.chmod(cp, 0o644)
+        self._reset()
+        self._pass(tiers=("group",))
+        self.assertEqual((self._st("group")["ran"], self._st("group")["stamped"]), (1, 1), "readable again: the run stamps")
+        with open(cp, "a") as f:                                         # another row re-arms the grouper
+            f.write(json.dumps({"id": SID2 + ":g2", "op": "clear", "t": NOW + 1}) + "\n")
+        os.chmod(cp, 0)
+        self._reset()
+        self._pass(tiers=("group",))
+        self.assertEqual(len(self._rows("cleared-unreadable")), 2, "a second episode opens")
+        cp.unlink()                                                      # removed while the episode is open
+        self._reset()
+        self._pass(tiers=("group",))
+        self.assertEqual(self._st("group")["stamped"], 1, "no cleared.jsonl: absent is a real state, the run completes and stamps")
+        with open(cp, "a") as f:
+            f.write(json.dumps({"id": SID2 + ":g3", "op": "clear", "t": NOW + 2}) + "\n")
+        os.chmod(cp, 0)
+        try:
+            self._reset()
+            self._pass(tiers=("group",))
+            self.assertEqual(len(self._rows("cleared-unreadable")), 3, "recreated unreadable: absence ended the episode, a third row")
+        finally:
+            os.chmod(cp, 0o644)
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_an_unreadable_stall_file_never_stamps(self):
+        # the by-value input: the signature's own read fails too, and an empty slice would EQUAL the last
+        # good one whenever the records were empty, so the gate would skip a session over a file it cannot
+        # see. The signature read is strict (raises), so the gate runs the stage without a stamp (bypassed);
+        # the stage's own failed read marks the run; one row per failure episode either way
+        self._session(SID)
+        self._converge()
+        an = jd.STATE / "auto-nudge.json"
+        rec = {"enabled": False, "deferred": {SID + ":g999": {"why": "the build has not finished", "at": T0 + 10}}}
+        an.write_text(json.dumps(rec))                 # a record for this sid moves the slice: the distiller is due
+        os.chmod(an, 0)
+        try:
+            for _ in range(2):
+                self._reset()
+                self._pass(tiers=("distill",))
+                s = self._st("distill")
+                self.assertEqual((s["ran"], s["bypassed"], s["stamped"]), (1, 1, 0),
+                                 "the stage ran (no skip over an unreadable input) and did not stamp")
+                self.assertEqual(len(self._rows("stall-unreadable")), 1, "one row per failure episode, not per pass")
+        finally:
+            os.chmod(an, 0o644)
+        self._reset()
+        self._pass(tiers=("distill",))
+        self.assertEqual((self._st("distill")["ran"], self._st("distill")["stamped"]), (1, 1), "readable again: the run stamps")
+        an.write_text("{ not a document")              # exists, unparseable: the same shape, a new episode
+        self._reset()
+        self._pass(tiers=("distill",))
+        s = self._st("distill")
+        self.assertEqual((s["ran"], s["bypassed"], s["stamped"]), (1, 1, 0), "an unparseable file is not a real state")
+        self.assertEqual(len(self._rows("stall-unreadable")), 2, "a new failure episode: a second row")
+        an.write_text(json.dumps(rec))                 # the same records again: nothing the last complete run did not judge
+        self._reset()
+        self._pass(tiers=("distill",))
+        self.assertEqual((self._st("distill")["ran"], self._st("distill")["skipped"]), (0, 1), "the stamp survived the episode")
+        an.write_text("{ not a document")              # a third episode opens ...
+        self._reset()
+        self._pass(tiers=("distill",))
+        self.assertEqual(len(self._rows("stall-unreadable")), 3)
+        an.unlink()                                    # ... and the file is removed while it is open: absent is a real state
+        self._reset()
+        self._pass(tiers=("distill",))
+        self.assertEqual(self._st("distill")["stamped"], 1, "no stall file: an empty slice, the run completes and stamps")
+        an.write_text("{ not a document")              # recreated unparseable: absence ended the episode
+        self._reset()
+        self._pass(tiers=("distill",))
+        self.assertEqual(len(self._rows("stall-unreadable")), 4, "a fourth row")
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_a_stall_read_failing_after_a_good_signature_read_marks_the_run(self):
+        # the other half of the strict rule: the signature's read succeeded (the file was readable at gate
+        # time), so the run carries a signature; the stage's own, non-strict stalled_facts read then fails
+        # (the mode flips between the two reads, here under the mirror-top titling that precedes it). That
+        # read marks the run incomplete on its own, so no stamp; a _read_failed that fired only under
+        # strict would let the run stamp over a file it never saw
+        self._session(SID)
+        self._converge()
+        an = jd.STATE / "auto-nudge.json"
+        an.write_text(json.dumps({"enabled": False, "deferred": {}}))  # readable when the gate reads it
+        self._mirror_top(SID, "add tests+docs for the search endpoint")   # titled BEFORE the stage's stall read
+
+        def title_then_flip(subject, frame=None, user_ask=None):
+            os.chmod(an, 0)                                             # the mode flips between the two reads
+            return "Write the api tests"
+        jd.mirror_title_llm = title_then_flip
+        try:
+            self._reset()
+            self._pass(tiers=("distill",))
+            s = self._st("distill")
+            self.assertEqual((s["ran"], s["bypassed"], s["incomplete"], s["stamped"]), (1, 0, 1, 0),
+                             "a signature was computed, and the stage's own failed read voided the stamp")
+            self.assertEqual(len(self._rows("stall-unreadable")), 1, "one loud row")
+        finally:
+            os.chmod(an, 0o644)
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_a_rebind_starts_the_failure_episodes_afresh(self):
+        # _rebind_state clears the per-path failure episodes with the rest of the per-root state: the same
+        # path string after a rebind is a new episode and logs again
+        self._session(SID)
+        self._converge()
+        self._states_row(SID, T0 + 300, "picker")
+        sp = jd.STATESDIR / (SID + ".jsonl")
+        os.chmod(sp, 0)
+        try:
+            self._reset()
+            self._pass(tiers=("distill",))
+            self.assertEqual(len(self._rows("states-unreadable")), 1)
+            jd._rebind_state(self.td)                                   # the SAME root: the path string is unchanged
+            self._reset()
+            self._pass(tiers=("distill",))
+            self.assertEqual(len(self._rows("states-unreadable")), 2, "the rebind ended the episode: a new row")
+        finally:
+            os.chmod(sp, 0o644)
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_a_cleared_file_vanishing_between_the_stat_and_the_read_ends_the_episode(self):
+        # the race the stat-before-read order admits: the gate stat'd the file and the stage's read finds it
+        # gone. Absent is a real state, so an open episode ends there (as an absent stat ends it), and a file
+        # recreated unreadable logs a new row; a scan failure read as unreadable would keep the episode open
+        # and swallow that row. Fault-injected at the scan seam, since the window is a race
+        self._session(SID)
+        self._converge()
+        cp = jd.STATE / "cleared.jsonl"
+        with open(cp, "a") as f:
+            f.write(json.dumps({"id": SID2 + ":g1", "op": "clear", "t": NOW}) + "\n")
+        os.chmod(cp, 0)
+        self._reset()
+        self._pass(tiers=("group",))
+        self.assertEqual(len(self._rows("cleared-unreadable")), 1, "premise: an episode is open")
+        os.chmod(cp, 0o644)
+        real = jd._view_cleared_scan
+
+        def vanish_then_scan(path_s):
+            os.unlink(path_s)                                           # gone between the stat and the read
+            return real(path_s)                                         # FileNotFoundError, as the read of a vanished file
+        jd._view_cleared_scan = vanish_then_scan
+        try:
+            self._reset()
+            self._pass(tiers=("group",))
+        finally:
+            jd._view_cleared_scan = real
+        self.assertEqual(len(self._rows("cleared-unreadable")), 1, "a vanished file is not a failed read")
+        with open(cp, "a") as f:
+            f.write(json.dumps({"id": SID2 + ":g2", "op": "clear", "t": NOW + 1}) + "\n")
+        os.chmod(cp, 0)
+        try:
+            self._reset()
+            self._pass(tiers=("group",))
+            self.assertEqual(len(self._rows("cleared-unreadable")), 2, "recreated unreadable: the vanish ended the episode")
+        finally:
+            os.chmod(cp, 0o644)
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_a_states_file_vanishing_between_the_stat_and_the_read_ends_the_episode(self):
+        # the states twin of the case above, at _live_prompt_since's scan seam
+        self._session(SID)
+        self._converge()
+        self._states_row(SID, T0 + 300, "picker")
+        sp = jd.STATESDIR / (SID + ".jsonl")
+        os.chmod(sp, 0)
+        self._reset()
+        self._pass(tiers=("distill",))
+        self.assertEqual(len(self._rows("states-unreadable")), 1, "premise: an episode is open")
+        os.chmod(sp, 0o644)
+        real = jd._live_prompt_since_scan
+
+        def vanish_then_scan(path_s):
+            os.unlink(path_s)
+            return real(path_s)
+        jd._live_prompt_since_scan = vanish_then_scan
+        try:
+            self._reset()
+            self._pass(tiers=("distill",))
+        finally:
+            jd._live_prompt_since_scan = real
+        self.assertEqual(len(self._rows("states-unreadable")), 1, "a vanished file is not a failed read")
+        self._states_row(SID, T0 + 400, "picker")
+        os.chmod(sp, 0)
+        try:
+            self._reset()
+            self._pass(tiers=("distill",))
+            self.assertEqual(len(self._rows("states-unreadable")), 2, "recreated unreadable: the vanish ended the episode")
+        finally:
+            os.chmod(sp, 0o644)
+
+    # ── the stage-site marks, one test per site, each forcing the early return past the _judge_run belt ──
+    def test_the_unblockers_failed_call_site_marks_the_run(self):
+        self._blocked_with_a_new_turn()
+        jd.unblock_llm = lambda blocks, since, completed="": ""        # the helper, not the belt: the site alone marks
+        self._reset()
+        io0 = dict(self.io)
+        self._pass(tiers=("unblock",))
+        s = self._st("unblock")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0))
+        self.assertEqual(self.io["saves"] - io0["saves"], 0)
+
+    def test_the_groupers_failed_call_site_marks_the_run(self):
+        self._session(SID)
+        self._pass(tiers=("plan", "close"))
+        store = jd.load_goals(SID)
+        store.pop("groupedSig", None)
+        jd.save_goals(SID, store)
+        jd.group_llm = lambda menu, judge="grouper": ""
+        self._reset()
+        io0 = dict(self.io)
+        self._pass(tiers=("group",))
+        s = self._st("group")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0))
+        self.assertEqual(self.io["saves"] - io0["saves"], 0)
+        self.assertFalse(jd.load_goals(SID).get("groupFails"))
+
+    def test_the_consolidators_failed_call_site_marks_the_run(self):
+        self._session(SID)
+        self._converge()
+        store = jd.load_goals(SID)
+        for top in self._tops():
+            store["status"][top["id"]] = "completed"
+        store["confirming"] = []
+        jd.save_goals(SID, store)
+        jd.group_llm = lambda menu, judge="grouper": ""
+        self._reset()
+        io0 = dict(self.io)
+        self._pass(tiers=("consolidate",))
+        s = self._st("consolidate")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0))
+        self.assertEqual(self.io["saves"] - io0["saves"], 0)
+        self.assertFalse(jd.load_goals(SID).get("consolidateFails"))
+
+    def test_the_titlers_paused_site_marks_the_run(self):
+        self._session(SID)
+        self._converge()
+        nid = self._mirror_top(SID, "add tests+docs for the search endpoint")
+
+        def paused_title(subject, frame=None, user_ask=None):
+            jd._judge_ctx.paused = True
+            return ""
+        jd.mirror_title_llm = paused_title
+        self._reset()
+        io0 = dict(self.io)
+        self._pass(tiers=("distill",))
+        s = self._st("distill")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0))
+        self.assertEqual(self.io["saves"] - io0["saves"], 0)
+        self.assertFalse(jd.load_goals(SID)["nodes"][nid].get("titledT"))
+
+    def test_the_stallers_paused_site_marks_the_run(self):
+        self._session(SID)
+        self._converge()
+        top = self._tops()[0]
+        (jd.STATE / "auto-nudge.json").write_text(json.dumps(
+            {"deferred": {top["id"]: {"why": "the build has not finished", "at": T0 + 100}}}))
+
+        def paused_stall(text, work, holding):
+            jd._judge_ctx.paused = True
+            return ""
+        jd.stall_llm = paused_stall
+        self._reset()
+        io0 = dict(self.io)
+        self._pass(tiers=("distill",))
+        s = self._st("distill")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0))
+        self.assertEqual(self.io["saves"] - io0["saves"], 0)
+        self.assertIsNone(jd.load_goals(SID)["nodes"][top["id"]].get("stallSummary"))
+
+    def test_the_briefers_paused_shortfall_retry_marks_the_run(self):
+        self._session(SID)
+        self._converge()
+        top = self._tops()[0]
+        store = jd.load_goals(SID)
+        kid = "%s:g%d" % (SID, 91)                                        # a sub-goal: two blocked nodes make owed a list
+        store["nodes"][kid] = {"id": kid, "text": "pick the test database", "parentId": top["id"], "t": T0 + 120,
+                               "mt": T0 + 120, "log": [], "trail": [], "nodeComplete": False, "cleared": False}
+        store["status"][kid] = "working"
+        jd.save_goals(SID, store)
+        self._block(SID, top["id"], T0 + 150, why="Which port should the api bind?")
+        self._block(SID, kid, T0 + 160, why="Which database should the tests use?")
+        calls = []
+
+        def brief(text, work, owed, frame=None, user_ask=None, shortfall=None):
+            calls.append(shortfall)
+            if shortfall:                                                # the retry is skipped under the pause
+                jd._judge_ctx.paused = True
+                return ""
+            return "One paragraph for two owed decisions."
+        jd.brief_llm = brief
+        self._reset()
+        self._pass(tiers=("distill",))
+        s = self._st("distill")
+        self.assertEqual(calls, [None, (1, 2)], "two owed decisions, one paragraph: the corrective retry ran")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0))
+        self.assertIsNone(jd.load_goals(SID)["nodes"][top["id"]].get("blockSummary"), "the brief is still owed")
+
 
 class UnblockerHazard(_Gate):
     def test_a_turn_ending_after_the_first_touch_is_judged_next_pass_by_the_unblocker(self):

--- a/tests/test_judge_stage_gate.py
+++ b/tests/test_judge_stage_gate.py
@@ -445,12 +445,16 @@ class TheCut(_Gate):
                          "the unit loop's own row, and no other stand-down")
 
     def test_the_plan_sync_stand_down_alone_leaves_no_stamp(self):
-        # the plan-sync stand-down's mark, isolated: a cleared row re-arms the planner with no new unit, so
-        # the unit loop checks nothing, and the latest segment's trigger reads as rewound away
+        # the plan-sync stand-down's mark, isolated: a clear re-arms the planner with no new unit, so the unit
+        # loop checks nothing, and the latest segment's trigger reads as rewound away. A clear is the cleared.jsonl
+        # row plus the journal row append_clear writes before the save (2026-09-09): the gate keys cleared.jsonl,
+        # the planner's own change gate inside _plan_session (_plan_key) keys the journal, and both must move
+        # for the run to reach the sync; the row names a node this store does not hold, so the replay skips it
         self._session(SID)
         self._converge()
         with open(jd.STATE / "cleared.jsonl", "a") as f:
             f.write(json.dumps({"id": SID3 + ":g1", "op": "clear", "t": NOW}) + "\n")
+        jd.append_clear(SID, SID3 + ":g1", "user", "cleared from the feed", NOW)
         jd._rewound_away = lambda fsid, p, uuid: "pending"
         self._reset()
         self._pass(tiers=("plan",))

--- a/tests/test_judge_stage_gate.py
+++ b/tests/test_judge_stage_gate.py
@@ -1,0 +1,1095 @@
+#!/usr/bin/env python3
+"""The judge tiers' EVIDENCE GATE (2026-09-07): the planner and closer skip a
+session's per-pass run when nothing their decision path reads has changed since the run that last judged
+it to completion.
+
+Why: every pass ran every discovered session in full (a parse, a store load, the unit walk, the closed-turn
+walk, a rollup, an unconditional save), with about two of thirty-three sessions holding anything new per
+pass on the live kernel; the planner and closer were more than half of an idle pass's CPU.
+
+What exact means here, and what every test below protects (CLAUDE.md, cards move on new information):
+the gate never withholds a verdict the ungated pass would have filed from NEW evidence. A run is skipped
+only when every input the tier reads is identical by identity to what it last judged to completion:
+the parse pair pinned with the parse BEFORE it is read (_frame_parse_key, so judged content can be newer
+than the stamp, never older), the store trio (store, override journal, archive), the tier's side files
+(captions, episodes, the death marker, the sdk reg's spawnedAt value, cleared.jsonl, this sid's stall
+records, the LEAF stem's task store), and the one clock input (a background launch's deadline). A stage
+that deferred, was paused, failed a call, had a reply rejected without a write, raised, or was cut sets
+the completeness bit and leaves no stamp. The probes the design review ran, each a test here: a poke
+mid-pass (a turn ending after the pass's first touch), an unpoked background task, a rewind and a cut, a
+journal gesture, a nudge block, two concurrent writers, a restart (fresh process state), the death drain,
+the archive path.
+
+Accepted lag, recorded here as the design asks: under an open frame every parsed_session caller sees the
+pass-start world (a cache hit too), so the six pusher tick jobs that read the judge parse
+(_interrupt_block_tick, _closer_pending, _awaiting_wake_outcomes, _deferral_sweep_tick,
+_auto_nudge_session, _clear_done_working_notes) see a world up to one pass old for every session, and a
+turn that ends after a pass's first touch is judged next pass, whole. That is the frame's design
+(2026-07-21); the gate adds no lag beyond the producer's 3 s backstop for the clock input.
+
+PRIVATE synthetic sids (goal-minting fixtures never share the placeholder sid: its override journal is
+replayed on every load), invented text, a notes-api with web/api sessions; the journals are removed in
+tearDown."""
+import builtins
+import io
+import json
+import os
+import re
+import shutil
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_stage_gate", os.path.join(BIN, "romp-judge")).load_module()
+em = jd.em
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"      # private synthetic sids, never the shared placeholder
+SID2 = "bbbbbbbb-1111-2222-3333-444444444444"
+SID3 = "dddddddd-1111-2222-3333-444444444444"     # a sid with no session of its own (signature-level cases)
+T0 = 1781100000
+NOW = T0 + 5000
+MINT = '{"ops":[{"why":"x","do":"mint","text":"Goal"}]}'
+EMPTY_CLOSE = '{"done": [], "block": []}'
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None, ps="typed"):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": ps, "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None, stop="end_turn"):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": stop}}
+
+
+def tool_use_line(t, uuid, parent, tool_id, name, inp):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "stop_reason": "tool_use",
+                        "content": [{"type": "tool_use", "id": tool_id, "name": name, "input": inp}]}}
+
+
+def tool_result_line(t, uuid, parent, tool_id, text):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": tool_id, "content": text}]}}
+
+
+def boundary(t, uuid, parent):
+    """A compaction boundary record: the event model opens a trigger-less turn on it."""
+    return {"type": "system", "subtype": "compact_boundary", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent}
+
+
+TWO_TURNS = [uline(T0, "task A", "u1"), aline(T0 + 30, "did A", "a1", "u1"),
+             uline(T0 + 100, "task B", "u2", "a1"), aline(T0 + 130, "did B", "a2", "u2")]
+
+
+class _Gate(unittest.TestCase):
+    def setUp(self):
+        self.td = Path(tempfile.mkdtemp())
+        jd._rebind_state(self.td)                    # clears the stamps, the value memos and the counters
+        jd.end_pass_frame(True)                      # belt: never inherit a frame a crashed test left open
+        for c in (jd._PARSE_CACHE, jd._CHAIN_MEMO, jd._BG_SCAN_CACHE, jd._RECON_MEMO, jd._gone_memo):
+            c.clear()
+        self.cdir = self.td / "launchdir"; self.cdir.mkdir()
+        self.proj = self.td / "projects"
+        self.pdir = self.proj / re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(self.cdir)))
+        self.pdir.mkdir(parents=True)
+        jd.NAMES.mkdir(parents=True, exist_ok=True)
+        self.claude = self.td / "claude-config"; (self.claude / "tasks").mkdir(parents=True)
+        self._env = os.environ.get("CLAUDE_CONFIG_DIR")
+        os.environ["CLAUDE_CONFIG_DIR"] = str(self.claude)   # the task store, resolved at call time
+        self._saved = (jd.PROJECTS, jd.plan_llm, jd.closer_llm, jd.group_llm, jd.opener_llm, jd._PENDING_CUT_FN,
+                       jd._judge_run_impl, jd._rewound_away, jd._judge_run, jd._fileset_key, jd._close_turn,
+                       jd._STAGE_STAMP_MAX, jd.load_goals, jd.save_goals)
+        jd.PROJECTS = self.proj
+        # store I/O spies: the stages reach load_goals/save_goals through the module globals, so a
+        # counting wrapper over each sees every load and save a pass makes for the fixture's sids
+        self.io = {"loads": 0, "saves": 0}
+        real_load, real_save = jd.load_goals, jd.save_goals
+
+        def counting_load(*a, **k):
+            self.io["loads"] += 1
+            return real_load(*a, **k)
+
+        def counting_save(*a, **k):
+            self.io["saves"] += 1
+            return real_save(*a, **k)
+        jd.load_goals, jd.save_goals = counting_load, counting_save
+        self.plan_calls, self.close_calls = [], []
+        jd.plan_llm = lambda text, menu, human=False, **kw: (self.plan_calls.append(text) or MINT)
+        jd.opener_llm = lambda text, menu, **kw: (self.plan_calls.append(text) or MINT)
+        jd.closer_llm = lambda tt, mt, *a, **k: (self.close_calls.append(tt) or EMPTY_CLOSE)
+        jd.group_llm = lambda menu, judge="grouper": '{"ops":[]}'
+        jd._PENDING_CUT_FN = None
+        jd._judge_ctx.paused, jd._judge_ctx.last_call_fail, jd._judge_ctx.stage_incomplete = False, None, False
+
+    def tearDown(self):
+        jd.end_pass_frame(True)
+        (jd.PROJECTS, jd.plan_llm, jd.closer_llm, jd.group_llm, jd.opener_llm, jd._PENDING_CUT_FN,
+         jd._judge_run_impl, jd._rewound_away, jd._judge_run, jd._fileset_key, jd._close_turn,
+         jd._STAGE_STAMP_MAX, jd.load_goals, jd.save_goals) = self._saved
+        if self._env is None:
+            os.environ.pop("CLAUDE_CONFIG_DIR", None)
+        else:
+            os.environ["CLAUDE_CONFIG_DIR"] = self._env
+        for sid in (SID, SID2):
+            try:
+                (jd._overrides_dir() / (sid + ".jsonl")).unlink()   # a sid's journal never outlives its test
+            except OSError:
+                pass
+        jd._judge_ctx.paused, jd._judge_ctx.last_call_fail, jd._judge_ctx.stage_incomplete = False, None, False
+        shutil.rmtree(self.td, ignore_errors=True)
+
+    # ── fixture helpers ──
+    def _session(self, sid, recs=None, name="web"):
+        path = self.pdir / (sid + ".jsonl")
+        path.write_text("\n".join(json.dumps(r) for r in (TWO_TURNS if recs is None else recs)) + "\n")
+        (jd.NAMES / sid).write_text("%s\t%s\t#abcdef\n" % (name, str(self.cdir)))
+        return path
+
+    def _append(self, path, *recs):
+        with open(path, "a") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+
+    def _states_row(self, sid, t, state):
+        jd.STATESDIR.mkdir(parents=True, exist_ok=True)
+        with open(jd.STATESDIR / (sid + ".jsonl"), "a") as f:
+            f.write(json.dumps({"t": t, "state": state}) + "\n")
+
+    def _pass(self, now=NOW, tiers=("plan", "close")):
+        """One gated pass over the fixture: the planner then the closer under one frame, as run_triage."""
+        jd._discover_cache.clear()                   # discover's list is cached behind a dir fingerprint, not `now`
+        own = jd.begin_pass_frame()
+        try:
+            if "plan" in tiers:
+                jd.run_plan(now=now)
+            if "close" in tiers:
+                jd.run_close(now=now)
+        finally:
+            jd.end_pass_frame(own)
+
+    def _converge(self, now=NOW, limit=4):
+        """Passes until both tiers skip: the working pass, the follow-on run that finds nothing to write
+        (the tier's own publish re-armed it once), then the skip. Leaves the counters zeroed."""
+        for _ in range(limit):
+            self._reset()
+            self._pass(now)
+            if all(self._st(t)["ran"] == 0 for t in ("plan", "close")):
+                self._reset()
+                return
+        self.fail("the fixture did not converge in %d passes" % limit)
+
+    def _st(self, tier):
+        return dict(jd._TIER_STATS[tier])
+
+    def _reset(self):
+        for d in jd._TIER_STATS.values():
+            for k in d:
+                d[k] = 0
+
+    def _stamp(self, tier, sid=SID):
+        return jd._STAGE_STAMP.get((tier, sid))
+
+    def _tops(self, sid=SID):
+        store = jd.load_goals(sid)
+        return sorted((nd for nd in store["nodes"].values() if nd["parentId"] is None), key=lambda nd: nd["t"])
+
+
+class Convergence(_Gate):
+    def test_two_idle_passes_run_once_then_skip_with_no_store_io(self):
+        # the working pass places and sweeps; the tier's own publish re-arms it once (the stamp holds the
+        # pre-run identity); the follow-on run makes no call and writes nothing; the third pass skips both
+        # tiers, loads and saves nothing for the sid, and still stamps pass_done (a skip is a completed
+        # no-op pass: the kernel's wedged-reviver bound reads that watermark)
+        self._session(SID)
+        self._pass()
+        self.assertEqual(len(self.plan_calls), 2, "two ended turns: two work units placed")
+        self.assertEqual(len(self.close_calls), 2, "and two turns swept")
+        self.assertEqual((self._st("plan")["ran"], self._st("close")["ran"]), (1, 1))
+        self.assertEqual((self._st("plan")["stamped"], self._st("close")["stamped"]), (1, 1),
+                         "complete runs stamp what they judged")
+        self._reset()
+        self._pass()                                                    # the idle follow-on: runs, no calls, no write
+        self.assertEqual((len(self.plan_calls), len(self.close_calls)), (2, 2), "no model call")
+        self.assertEqual((self._st("plan")["ran"], self._st("close")["ran"]), (1, 1),
+                         "the tiers' own publishes re-armed them once")
+        self._reset()
+        for t in ("plan", "close"):                                     # the earlier passes' watermarks go: the skip
+            self.assertIsNotNone(jd._PASS_DONE.pop((t, SID), None), t)  #  must write its own, not inherit one
+        io0 = dict(self.io)
+        self._pass()                                                    # the skip
+        io1 = dict(self.io)
+        self.assertEqual((self._st("plan")["ran"], self._st("close")["ran"]), (0, 0))
+        self.assertEqual((self._st("plan")["skipped"], self._st("close")["skipped"]), (1, 1))
+        self.assertEqual((io1["loads"] - io0["loads"], io1["saves"] - io0["saves"]), (0, 0),
+                         "a skipped session costs no store load and no save")
+        self.assertIsNotNone(jd.pass_watermark("plan", SID), "a skip stamps pass_done")
+        self.assertIsNotNone(jd.pass_watermark("close", SID))
+        self.assertEqual((len(self.plan_calls), len(self.close_calls)), (2, 2))
+
+    def test_a_restart_is_a_full_walk(self):
+        # the stamps are process state: a kernel restart mid-pass loses them and the first pass after boot
+        # judges every session, as before the gate
+        self._session(SID)
+        self._converge()
+        jd._STAGE_STAMP.clear()                                         # what a restart does
+        self._pass()
+        self.assertEqual((self._st("plan")["ran"], self._st("close")["ran"]), (1, 1))
+        self.assertEqual((len(self.plan_calls), len(self.close_calls)), (2, 2), "nothing new: no call either way")
+
+    def test_counters_add_up(self):
+        self._session(SID)
+        self._pass(); self._pass(); self._pass()
+        for t in ("plan", "close"):
+            s = self._st(t)
+            self.assertEqual(s["ran"], s["stamped"] + s["bypassed"] + s["incomplete"], t)
+        ts = jd.tier_stats()
+        self.assertEqual(set(ts), set(jd.GATED_TIERS) | {"stamps"})
+        self.assertEqual(ts["stamps"], 2, "one stamp per (tier, sid)")
+
+
+class ATurnEndingMidPass(_Gate):
+    def test_a_turn_ending_after_the_first_touch_is_judged_next_pass_whole(self):
+        # the review's hazard: a tick job (or the index tier) touches the session while its last turn is
+        # OPEN; the turn's final record and the idle row land; the gated planner and closer check the gate.
+        # The transcript component is the pair the pass PINNED at that first touch, which equals the stamp
+        # the converged run left, so the mid-pass check is a SKIP (no stat of the grown file, no run), the
+        # stamps keep the pre-append pair, and the next pass runs both stages over the ended turn, whole.
+        # A gate reading the live key at its own moment would run here over the frozen (pre-append) parse
+        # and bypass, or stamp the post-append key over a world that never judged the ended turn.
+        path = self._session(SID, [uline(T0, "task A", "u1"), aline(T0 + 30, "did A", "a1", "u1"),
+                                   uline(T0 + 100, "task B", "u2", "a1"),
+                                   aline(T0 + 110, "starting on B", "a2", "u2", stop="tool_use")])
+        self._converge()
+        own = jd.begin_pass_frame()
+        try:
+            jd.parsed_session(SID, [str(path)], NOW)                    # the tick job's first touch, turn open
+            pre = jd._frame["keys"][("parse", SID)]
+            self._append(path, aline(T0 + 140, "did B", "a3", "a2"))
+            self._states_row(SID, T0 + 141, "idle")
+            jd.run_plan(now=NOW)
+            jd.run_close(now=NOW)
+            for t in ("plan", "close"):
+                self.assertEqual((self._st(t)["ran"], self._st(t)["skipped"]), (0, 1),
+                                 "%s: the pinned pair matches the stamp, so the mid-pass check skips (a live-key "
+                                 "gate would run and bypass instead)" % t)
+        finally:
+            jd.end_pass_frame(own)
+        for t in ("plan", "close"):
+            st = self._stamp(t)
+            self.assertIsNotNone(st, "%s: the converged run's stamp stands" % t)
+            self.assertEqual(st[0][0][1], jd._pair_key(pre), "%s: the stamp holds the PRE-append pair" % t)
+        self._reset()
+        self._pass()
+        self.assertEqual((self._st("plan")["ran"], self._st("close")["ran"]), (1, 1),
+                         "the next pass runs both stages: the live pair differs from the stamped one")
+        self.assertIn("did B", " ".join(self.plan_calls), "the planner judged the ended turn's work")
+        turns = jd.parsed_session(SID, [str(path)], NOW)["turns"]
+        self.assertTrue(turns[-1]["ended"])
+        self.assertIn(turns[-1]["id"], jd.load_goals(SID).get("closedTurns") or [], "the closer swept it")
+
+
+class TheCut(_Gate):
+    def test_a_cut_arming_between_the_pin_and_the_parse_withholds_the_stamp(self):
+        # the user's cut rule (2026-09-07): the parse runs under the LIVE cut, and a cut that arms after
+        # the gate pinned makes the served pair differ from the pinned one, so the run is not stamped
+        # (bypassed) and the sid stays due. Then: with the cut standing, the cut world converges and is
+        # stamped under the cut; the cut clearing with no file change re-arms both tiers, and the
+        # previously cut turn is judged. The invariant: no verdict the ungated pass would file is lost.
+        path = self._session(SID)
+        self._converge()
+        self._append(path, uline(T0 + 200, "task C", "u3", "a2"), aline(T0 + 230, "did C", "a3", "u3"))
+        before = self._stamp("plan")
+        own = jd.begin_pass_frame()
+        try:
+            pinned, _cut, _fr = jd._frame_parse_key(SID, [str(path)])   # the gate's pin (also run_plan's)
+            self.assertEqual(pinned[1], "")
+            jd._PENDING_CUT_FN = lambda fsid: "a2"                       # a bare rollback arms: u3/a3 abandoned
+            jd.run_plan(now=NOW)
+            jd.run_close(now=NOW)
+        finally:
+            jd.end_pass_frame(own)
+        self.assertEqual(self._st("plan")["ran"], 1, "the transcript grew: the planner ran")
+        self.assertEqual(self._st("plan")["bypassed"], 1, "but the served cut differs from the pinned one: no stamp")
+        self.assertEqual(self._stamp("plan"), before, "the old stamp stands (it describes the last COMPLETE run)")
+        self.assertNotIn("task C", " ".join(self.plan_calls), "the planner judged the cut world: the tail is not planned")
+        self._reset()
+        self._pass()                                                    # the cut world, pinned and parsed alike
+        self.assertEqual(self._st("plan")["stamped"], 1, "a pin and a parse under the same cut stamp")
+        self.assertEqual(self._stamp("plan")[0][0][1][1], "a2", "the stamp holds the cut")
+        self._reset()
+        self._pass()
+        self.assertEqual((self._st("plan")["skipped"], self._st("close")["skipped"]), (1, 1))
+        jd._PENDING_CUT_FN = None                                        # the rollback dissolves: no file change
+        self._reset()
+        self._pass()
+        self.assertEqual((self._st("plan")["ran"], self._st("close")["ran"]), (1, 1),
+                         "the cut clearing re-arms both tiers with no file change")
+        self.assertIn("task C", " ".join(self.plan_calls), "and the un-cut tail is judged")
+
+    def test_a_rewind_pending_defers_without_a_stamp_and_a_durable_rewind_retires(self):
+        path = self._session(SID)
+        self._converge()
+        self._append(path, uline(T0 + 200, "task C", "u3", "a2"), aline(T0 + 230, "did C", "a3", "u3"))
+        jd._rewound_away = lambda fsid, p, uuid: "pending"
+        self._pass()
+        self.assertIsNone(self._stamp("plan") if self._st("plan")["stamped"] else None)
+        self.assertEqual(self._st("plan")["incomplete"], 1, "a pending rewind defers the unit: no stamp")
+        self._reset()
+        self._pass()
+        self.assertEqual(self._st("plan")["ran"], 1, "still due")
+        self.assertEqual(self._st("plan")["incomplete"], 1)
+        calls = []
+
+        def durable_then_live(fsid, p, uuid):
+            calls.append(uuid)
+            return "durable" if len(calls) == 1 else False              # the unit's check; the plan-sync's is live
+        jd._rewound_away = durable_then_live
+        self._reset()
+        self._pass()
+        self.assertEqual(self._st("plan")["stamped"], 1, "a durable rewind retires the unit: a complete run")
+        store = jd.load_goals(SID)
+        retired = [k for k, v in store["placements"].items() if v is None]
+        self.assertTrue(retired, "the unit is retired, not planned")
+        self.assertNotIn("task C", " ".join(self.plan_calls))
+
+    def test_the_unit_loop_pending_leg_alone_leaves_no_stamp(self):
+        # the unit loop's own pending mark, isolated: the latest segment is trigger-less (a compaction
+        # boundary), so the plan-sync stand-down cannot fire, and the deferred unit is the only reason the
+        # run is incomplete. The rewind-pending case above trips both marks at once.
+        path = self._session(SID, TWO_TURNS + [boundary(T0 + 300, "cb1", "a2")])
+        self._converge()
+        store = jd.load_goals(SID)
+        segs = [sg for t in jd.parsed_session(SID, [str(path)], NOW)["turns"] for sg in jd._segs(t, store)]
+        self.assertIsNone(max(segs, key=lambda sg: sg.get("t") or 0).get("trigger"), "fixture: no trigger on the latest segment")
+        seg2 = next(sg for sg in segs if sg.get("trigger") == "u2")
+        del store["placements"][seg2["id"]]                            # turn 2's unit falls due again
+        jd.save_goals(SID, store)
+        jd._rewound_away = lambda fsid, p, uuid: "pending"
+        n_calls = len(self.plan_calls)
+        self._reset()
+        self._pass(tiers=("plan",))
+        st = self._st("plan")
+        self.assertEqual((st["ran"], st["incomplete"], st["stamped"]), (1, 1, 0), "the deferred unit alone voids the stamp")
+        self.assertEqual(len(self.plan_calls), n_calls, "deferred before any model call")
+        rows = [json.loads(l) for l in open(jd.ERRORS) if l.strip()]
+        self.assertEqual([r["err"] for r in rows if "rewind" in str(r.get("err"))], ["rewind-stand-down-pending"],
+                         "the unit loop's own row, and no other stand-down")
+
+    def test_the_plan_sync_stand_down_alone_leaves_no_stamp(self):
+        # the plan-sync stand-down's mark, isolated: a cleared row re-arms the planner with no new unit, so
+        # the unit loop checks nothing, and the latest segment's trigger reads as rewound away
+        self._session(SID)
+        self._converge()
+        with open(jd.STATE / "cleared.jsonl", "a") as f:
+            f.write(json.dumps({"id": SID3 + ":g1", "op": "clear", "t": NOW}) + "\n")
+        jd._rewound_away = lambda fsid, p, uuid: "pending"
+        self._reset()
+        self._pass(tiers=("plan",))
+        st = self._st("plan")
+        self.assertEqual((st["ran"], st["incomplete"], st["stamped"]), (1, 1, 0), "the skipped sync alone voids the stamp")
+        rows = [json.loads(l) for l in open(jd.ERRORS) if l.strip()]
+        self.assertEqual([r["err"] for r in rows if "rewind" in str(r.get("err"))], ["rewind-stand-down"],
+                         "the plan-sync's own row, and no unit-loop row")
+
+
+class ARollbackArmingDuringTheCall(_Gate):
+    def test_the_apply_time_pending_leg_leaves_no_stamp(self):
+        # the review's second finding (2026-09-07): a bare rollback arming DURING the planner's model call
+        # reaches apply_plan_guarded's pending leg past the unit loop's own check; the leg defers the unit
+        # with no write, so the run must mark itself incomplete or the stamp holds the deferred unit until
+        # an unrelated re-arm. The latest segment is trigger-less (a compaction boundary) so the plan-sync
+        # stand-down, the other pending mark, cannot fire: the mark seen here is the apply leg's own.
+        path = self._session(SID, TWO_TURNS + [boundary(T0 + 300, "cb1", "a2")])
+        self._converge()
+        store = jd.load_goals(SID)
+        segs = [s for t in jd.parsed_session(SID, [str(path)], NOW)["turns"] for s in jd._segs(t, store)]
+        self.assertIsNone(max(segs, key=lambda s: s.get("t") or 0).get("trigger"), "fixture: the latest segment has no trigger")
+        seg2 = next(s for s in segs if s.get("trigger") == "u2")
+        self.assertIn(seg2["id"], store["placements"], "fixture: turn 2's unit was placed")
+        del store["placements"][seg2["id"]]                            # turn 2's unit falls due again
+        jd.save_goals(SID, store)
+        real = jd.plan_llm
+
+        def arm_during_call(text, menu, human=False, **kw):
+            jd._PENDING_CUT_FN = lambda fsid: "a1"                        # the rollback arms while the model thinks
+            return real(text, menu, human=human, **kw)
+        jd.plan_llm = arm_during_call
+        self._reset()
+        self._pass(tiers=("plan",))
+        jd.plan_llm = real
+        s = self._st("plan")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0), "deferred at apply time: no stamp")
+        rows = [json.loads(l) for l in open(jd.ERRORS) if l.strip()]
+        self.assertEqual([r["err"] for r in rows if "rewind" in str(r.get("err"))], ["rewind-stand-down-pending"],
+                         "the apply leg's own row, and no other stand-down")
+        self.assertNotIn(seg2["id"], jd.load_goals(SID)["placements"], "deferred: no write, the key stays absent")
+        jd._PENDING_CUT_FN = None                                       # the rollback dissolves: no file change
+        self._reset()
+        self._pass(tiers=("plan",))
+        self.assertEqual(self._st("plan")["ran"], 1, "still due: the deferred run left no stamp")
+        self.assertIn(seg2["id"], jd.load_goals(SID)["placements"], "and the unit is placed")
+        self.assertEqual(self._st("plan")["stamped"], 1)
+
+
+class ReArms(_Gate):
+    """Each input re-arms exactly its tiers and only its sid."""
+
+    def _rearms(self, plan, close, msg):
+        self._reset()
+        self._pass()
+        self.assertEqual((self._st("plan")["ran"], self._st("close")["ran"]), (plan, close), msg)
+
+    def test_transcript_and_states_re_arm_both(self):
+        path = self._session(SID)
+        self._converge()
+        self._append(path, uline(T0 + 200, "task C", "u3", "a2"), aline(T0 + 230, "did C", "a3", "u3"))
+        self._rearms(1, 1, "a transcript append")
+        self._converge()
+        self._states_row(SID, T0 + 300, "idle")
+        self._rearms(1, 1, "a states row (the states file is in the parse key)")
+
+    def test_store_journal_and_archive_re_arm_both(self):
+        self._session(SID)
+        self._converge()
+        store = jd.load_goals(SID)
+        top = self._tops()[0]
+        store["nodes"][top["id"]]["text"] = "Renamed by a kernel-side writer"
+        jd.save_goals(SID, store)
+        self._rearms(1, 1, "a save_goals publish (a rename: new identity)")
+        self._converge()
+        jd.append_override(SID, top["id"], "resolve", NOW + 1)          # the user's gesture: the journal only
+        self._rearms(1, 1, "a journal append with no store write")
+        self.assertEqual(jd.load_goals(SID)["status"].get(top["id"]), "completed", "the replayed resolve took")
+        self._converge()
+        jd.save_goal_archive(SID, {"rompUuid": SID, "nodes": {}, "status": {}})
+        self._rearms(1, 1, "an archive write")
+
+    def test_a_nudge_block_re_arms_both(self):
+        # the kernel's nudge block: a journal row plus a publish through save_goals
+        self._session(SID)
+        self._converge()
+        top = self._tops()[0]
+        store = jd.load_goals(SID)
+        jd.append_block(SID, top["id"], "nudge", "Which port should the api bind?", NOW + 2)
+        jd.record_verdict(store, store["nodes"][top["id"]], "nudge", "block", NOW + 2, why="Which port should the api bind?")
+        jd.rollup_status(store, False)
+        jd.save_goals(SID, store)
+        self._rearms(1, 1, "a nudge block")
+        self.assertEqual(jd.load_goals(SID)["status"].get(top["id"]), "blocked")
+
+    def test_captions_and_episodes_re_arm_the_planner_only(self):
+        self._session(SID)
+        self._converge()
+        jd.CAPDIR.mkdir(parents=True, exist_ok=True)
+        with open(jd.CAPDIR / (SID + ".jsonl"), "a") as f:
+            f.write(json.dumps({"id": "seg-x#p", "caption": "Ship the notes-api search"}) + "\n")
+        self._rearms(1, 0, "a captions append")
+        self._converge()
+        jd.EPIDIR.mkdir(parents=True, exist_ok=True)
+        with open(jd.EPIDIR / (SID + ".jsonl"), "a") as f:
+            f.write(json.dumps({"head": "u1", "fsid": SID, "t": T0}) + "\n")
+        self._rearms(1, 0, "an episodes row")
+
+    def test_the_death_marker_and_spawned_at_re_arm_both_and_a_reg_rewrite_re_arms_nothing(self):
+        self._session(SID)
+        self._converge()
+        jd._write_death_marker(SID, {"t": T0 + 500, "by": "probe", "endedAt": T0 + 500})   # finalized: no epilogue
+        self._rearms(1, 1, "a death marker")
+        self._converge()
+        reg = jd.STATE / "sdk" / (SID + ".json")
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        reg.write_text(json.dumps({"spawnedAt": T0 + 600, "model": "sonnet"}))
+        self._rearms(1, 1, "a spawnedAt change (a revival)")
+        self._converge()
+        reg.write_text(json.dumps({"spawnedAt": T0 + 600, "model": "opus", "pushNote": "x"}))
+        self._rearms(0, 0, "a reg rewrite that keeps spawnedAt (a model pick, a push note)")
+        reg.write_text(json.dumps({"spawnedAt": T0 + 700, "model": "opus"}))
+        self._rearms(1, 1, "the next revival")
+
+    def test_a_reg_appearing_or_vanishing_re_arms_both_through_sdk_owned(self):
+        # _sdk_owned (the reg's existence) is its own input: the parse authors the composer's input as the
+        # human only for an SDK session, so a reg with no spawnedAt still re-arms when it appears or goes
+        self._session(SID)
+        self._converge()
+        reg = jd.STATE / "sdk" / (SID + ".json")
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        reg.write_text(json.dumps({"model": "sonnet"}))                 # no spawnedAt: only the existence changes
+        self.assertIsNone(jd._reg_spawned_at(SID), "premise: the value memo reads None either way")
+        self._rearms(1, 1, "a reg appearing")
+        self._converge()
+        reg.unlink()
+        self._rearms(1, 1, "a reg vanishing")
+
+    def test_the_task_store_re_arms_the_planner_under_the_leaf_stem(self):
+        # a to-do item created, then flipped in place, under the LEAF stem (what _sync_declared_plan reads:
+        # a /clear fork lane's leaf is not the romp sid); a dir under the romp sid on a fork lane is not read
+        path = self._session(SID)
+        self._converge()
+        d = self.claude / "tasks" / SID                                  # stem == sid here: the plain lane
+        plan0, close0 = jd._stage_sig("plan", SID, str(path)), jd._stage_sig("close", SID, str(path))
+        d.mkdir()
+        (d / "1.json").write_text(json.dumps({"id": "1", "subject": "write the api tests", "status": "pending"}))
+        plan1 = jd._stage_sig("plan", SID, str(path))
+        self.assertNotEqual(plan1, plan0, "a to-do item created moves the planner's signature")
+        self.assertEqual(jd._stage_sig("close", SID, str(path)), close0, "the closer does not read the task store")
+        self._reset()
+        self._pass()
+        self.assertEqual(self._st("plan")["ran"], 1, "the planner runs (and mirrors the open item, which re-arms the closer)")
+        self.assertTrue(any(nd.get("agentTask") for nd in jd.load_goals(SID)["nodes"].values()), "the mirror landed")
+        self._converge()
+        plan2 = jd._stage_sig("plan", SID, str(path))
+        (d / "1.json").write_text(json.dumps({"id": "1", "subject": "write the api tests", "status": "completed"}))
+        os.utime(d / "1.json", ns=(time.time_ns() + 5_000_000, time.time_ns() + 5_000_000))
+        self.assertNotEqual(jd._stage_sig("plan", SID, str(path)), plan2, "an item flipped in place moves it too")
+        self._reset()
+        self._pass()
+        self.assertEqual(self._st("plan")["ran"], 1)
+        # the leaf-stem rule at the signature level, on a fork-lane path whose stem is not the sid
+        fork = self.pdir / "cccccccc-1111-2222-3333-444444444444.jsonl"
+        fork.write_text(json.dumps(uline(T0 + 900, "after the clear", "u9")) + "\n")
+        s1 = jd._stage_sig("plan", SID, str(fork))
+        (self.claude / "tasks" / fork.stem).mkdir()
+        (self.claude / "tasks" / fork.stem / "1.json").write_text(json.dumps({"id": "1", "subject": "x", "status": "pending"}))
+        s2 = jd._stage_sig("plan", SID, str(fork))
+        self.assertNotEqual(s1, s2, "the LEAF stem's task store is in the planner's signature")
+        (d / "2.json").write_text(json.dumps({"id": "2", "subject": "y", "status": "pending"}))
+        self.assertEqual(jd._stage_sig("plan", SID, str(fork)), s2, "the romp sid's dir is not read on a fork lane")
+
+    def test_cleared_rows_re_arm_both_and_a_second_sid_stays_stamped(self):
+        self._session(SID)
+        self._session(SID2, name="api")
+        self._converge()
+        with open(jd.STATE / "cleared.jsonl", "a") as f:
+            f.write(json.dumps({"id": SID2 + ":g1", "op": "clear", "t": NOW}) + "\n")
+        self._rearms(2, 2, "a cleared.jsonl row re-arms every session's planner and closer (whole-file identity)")
+        self._converge()
+        self._append(self.pdir / (SID2 + ".jsonl"), uline(T0 + 200, "task C", "u3", "a2"), aline(T0 + 230, "did C", "a3", "u3"))
+        self._rearms(1, 1, "the second sid's append")
+        self.assertIsNotNone(self._stamp("plan", SID))
+        self.assertEqual(self._st("plan")["skipped"], 1, "the first sid skipped")
+
+    def test_value_inputs_are_read_by_value_not_by_file_identity(self):
+        # the reg's spawnedAt and this sid's stall records are VALUE inputs: a rewrite in place that keeps
+        # the file's (inode, mtime_ns, size) must still be seen. The kernel publishes both files by rename,
+        # so identity moves there; a test fixture (or another writer) rewriting in place within one
+        # mtime tick does not, and an identity memo served the previous content (17 distiller tests went
+        # red under xdist for it, 2026-09-07)
+        self._session(SID)
+        an = jd.STATE / "auto-nudge.json"
+        an.write_text(json.dumps({"enabled": False, "deferred": {SID2 + ":g1": {"at": NOW, "why": "waiting on the closer", "sid": SID2}}}))
+        st = os.stat(an)
+        self.assertEqual(jd._stall_slice(SID), ())
+        body = json.dumps({"enabled": False, "deferred": {SID + ":g1": {"at": NOW, "why": "waiting on the closer", "sid": SID}}})
+        self.assertEqual(len(body), st.st_size, "fixture: the rewrite keeps the size (the sids have one length)")
+        an.write_text(body)
+        os.utime(an, ns=(st.st_atime_ns, st.st_mtime_ns))              # ...and the mtime: identity unchanged
+        self.assertEqual(os.stat(an).st_ino, st.st_ino, "fixture: written in place")
+        self.assertEqual(jd._stall_slice(SID), ((SID + ":g1", "waiting on the closer", NOW),),
+                         "the slice follows the content, not the identity")
+        reg = jd.STATE / "sdk" / (SID + ".json")
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        reg.write_text(json.dumps({"spawnedAt": 1781100600}))
+        st = os.stat(reg)
+        self.assertEqual(jd._reg_spawned_at(SID), 1781100600)
+        reg.write_text(json.dumps({"spawnedAt": 1781100700}))          # same length, a revival
+        os.utime(reg, ns=(st.st_atime_ns, st.st_mtime_ns))
+        self.assertEqual(jd._reg_spawned_at(SID), 1781100700, "the value follows the content, not the identity")
+
+    def test_a_stall_record_for_this_sid_re_arms_and_another_sids_does_not(self):
+        self._session(SID)
+        self._converge()
+        top = self._tops()[0]
+        an = jd.STATE / "auto-nudge.json"
+        an.write_text(json.dumps({"enabled": False, "deferred": {SID2 + ":g1": {"at": NOW, "why": "the closer has not settled the turn", "sid": SID2}}}))
+        self._rearms(0, 0, "another sid's stall record")
+        an.write_text(json.dumps({"enabled": False, "deferred": {top["id"]: {"at": NOW, "why": "the closer has not settled the turn", "sid": SID}}}))
+        self._rearms(1, 1, "this sid's stall record (rollup_status reads it to retire a stall warn)")
+
+    def test_the_parse_component_names_the_candidate_files(self):
+        # two lanes with byte-identical content and equal (mtime, size) rows have one fileset key; the
+        # signature carries the candidate paths beside it, so a path swap cannot match a stamp
+        x, y = self.pdir / "x-lane.jsonl", self.pdir / "y-lane.jsonl"
+        x.write_text("\n".join(json.dumps(r) for r in TWO_TURNS) + "\n")
+        shutil.copy2(x, y)
+        self.assertEqual(jd._fileset_key([str(x)]), jd._fileset_key([str(y)]), "fixture: one fileset key for both")
+        jd.end_pass_frame(True)                                         # no frame: the live pair
+        self.assertNotEqual(jd._stage_sig("plan", SID3, str(x)), jd._stage_sig("plan", SID3, str(y)),
+                            "the candidate files are named in the signature")
+
+    @unittest.skipIf(os.geteuid() == 0, "root ignores mode bits")
+    def test_an_unlistable_task_dir_bypasses_the_gate(self):
+        # task_store_fp raises on a dir that exists and cannot be listed (as task_store_plan does), so the
+        # gate runs the stage and stamps nothing; a fingerprint that swallowed the error would read as
+        # "no store" and match the stamp of a run that saw none
+        path = self._session(SID)
+        self._converge()
+        d = self.claude / "tasks" / SID
+        d.mkdir()
+        (d / "1.json").write_text(json.dumps({"id": "1", "subject": "write the api tests", "status": "pending"}))
+        os.chmod(d, 0)
+        try:
+            jd.end_pass_frame(True)
+            self.assertEqual(jd._gate_check("plan", SID, str(path), NOW), (False, None),
+                             "run, and stamp nothing: the signature could not be computed")
+        finally:
+            os.chmod(d, 0o700)
+
+
+class ConcurrentWriters(_Gate):
+    def test_a_kernel_side_publish_during_the_stage_is_never_skipped_over(self):
+        # a second writer publishes while the planner holds its store across a model call: the planner's
+        # stamp holds the pre-run identity, so the next pass re-reads the store (the other writer's work
+        # rebased in) and stamps only when nothing moves
+        path = self._session(SID)
+        self._converge()
+        self._append(path, uline(T0 + 200, "task C", "u3", "a2"), aline(T0 + 230, "did C", "a3", "u3"))
+        real = jd.plan_llm
+
+        def plan_and_race(text, menu, human=False, **kw):
+            side = jd.load_goals(SID)                                   # the nudge tick, on its own thread
+            side["nodes"][SID + ":side"] = {"id": SID + ":side", "text": "Answer the port question", "parentId": None,
+                                            "nodeComplete": False, "blocked": True, "cleared": False, "trail": [],
+                                            "t": NOW, "log": []}
+            jd.save_goals(SID, side)
+            return real(text, menu, human=human, **kw)
+        jd.plan_llm = plan_and_race
+        self._pass()
+        jd.plan_llm = real
+        self.assertIn(SID + ":side", jd.load_goals(SID)["nodes"], "the racing publish survived the planner's save")
+        self._reset()
+        self._pass()
+        self.assertEqual(self._st("plan")["ran"], 1, "the identity moved under the stamp: the planner runs again")
+        self._reset()
+        self._pass()
+        self.assertEqual((self._st("plan")["skipped"], self._st("close")["skipped"]), (1, 1))
+
+
+class Completeness(_Gate):
+    """A stage that did not finish leaves no stamp, so the sid stays due."""
+
+    def test_an_empty_or_whitespace_reply_keeps_the_planner_due_without_a_parse_fail(self):
+        # the stripped-reply case patches _judge_run_impl, not plan_llm: plan_llm strips the reply, so a
+        # whitespace reply reaches the stage as "" and the belt in _judge_run marks the stage incomplete
+        path = self._session(SID)
+        self._converge()
+        self._append(path, uline(T0 + 200, "task C", "u3", "a2"), aline(T0 + 230, "did C", "a3", "u3"))
+        jd.plan_llm = self._saved[1]                                    # the real planner helper, over the belt
+        for reply in ("", "   "):
+            jd._judge_run_impl = lambda *a, **k: reply
+            self._reset()
+            self._pass(tiers=("plan",))
+            self.assertEqual(self._st("plan")["ran"], 1)
+            self.assertEqual(self._st("plan")["incomplete"], 1, "reply %r: the call failed, the stage is incomplete" % reply)
+            self.assertEqual(self._st("plan")["stamped"], 0)
+            self.assertFalse(jd.load_goals(SID).get("parseFails"), "no parse try burned on a failed call")
+        self.assertIsNotNone(self._stamp("plan"), "the earlier complete run's stamp stands")
+
+    def test_a_failed_closer_call_and_a_rejected_reply_keep_the_closer_due(self):
+        path = self._session(SID)
+        self._converge()
+        self._append(path, uline(T0 + 200, "task C", "u3", "a2"), aline(T0 + 230, "did C", "a3", "u3"))
+        jd.closer_llm = lambda *a, **k: ""                              # a cut: the call failed
+        self._pass()
+        self.assertEqual((self._st("close")["ran"], self._st("close")["incomplete"]), (1, 1))
+        self._reset()
+        jd.closer_llm = lambda *a, **k: "not a verdict at all"          # a parse reject under the cap
+        self._pass()
+        self.assertEqual((self._st("close")["ran"], self._st("close")["incomplete"]), (1, 1))
+        self._reset()
+        jd.closer_llm = lambda tt, mt, *a, **k: EMPTY_CLOSE             # a served reply
+        self._pass()
+        self.assertEqual(self._st("close")["stamped"], 1)
+
+    def test_a_raising_stage_stamps_nothing(self):
+        path = self._session(SID)
+        self._converge()
+        self._append(path, uline(T0 + 200, "task C", "u3", "a2"), aline(T0 + 230, "did C", "a3", "u3"))
+        before = self._stamp("close")
+
+        def boom(*a, **k):
+            raise RuntimeError("closer down")
+        jd._close_turn = boom
+        self._reset()
+        self._pass()
+        self.assertEqual(self._stamp("close"), before, "no stamp from a raised run")
+        rows = [json.loads(l) for l in open(jd.ERRORS) if l.strip()]
+        self.assertTrue(any(r.get("err") == "pass-crash" for r in rows), "the crash is logged, as before")
+        s = self._st("close")
+        self.assertEqual((s["ran"], s["incomplete"]), (1, 1), "a raised run counts as incomplete")
+        self.assertEqual(s["ran"], s["stamped"] + s["bypassed"] + s["incomplete"], "the identity romp perf reads holds through a crash")
+
+    def test_a_vanished_candidate_runs_the_stage_and_stamps_nothing(self):
+        path = self._session(SID)
+        self._converge()
+        self._append(path, uline(T0 + 200, "task C", "u3", "a2"), aline(T0 + 230, "did C", "a3", "u3"))
+        before = self._stamp("plan")
+
+        def vanished(files):
+            raise OSError("a candidate vanished between the exists() and the stat")
+        jd._fileset_key = vanished
+        self._pass(tiers=("plan",))
+        self.assertEqual((self._st("plan")["ran"], self._st("plan")["bypassed"]), (1, 1))
+        self.assertEqual(self._stamp("plan"), before)
+        self.assertIn("task C", " ".join(self.plan_calls), "the stage ran over the live world")
+
+    def test_the_belt_marks_an_empty_reply_incomplete(self):
+        # _judge_run is a belt over _judge_run_impl: an empty, whitespace or None reply marks the running
+        # stage incomplete; a served reply leaves the bit alone. Every stage site also marks its own failed
+        # call, so no pass-level case isolates the belt; this one drives it directly.
+        for reply in ("", "   ", None, "ok"):
+            jd._judge_run_impl = lambda *a, **k: reply
+            jd._judge_ctx.stage_incomplete = False
+            self.assertEqual(jd._judge_run("sonnet", "sys", "user"), reply)
+            self.assertEqual(jd._judge_ctx.stage_incomplete, reply != "ok", "reply %r" % (reply,))
+
+    def test_gated_resets_the_completeness_bit_per_run(self):
+        # the bit is thread state: a run that left it set on a pool thread must not void the NEXT session's
+        # stamp on the same thread, so _gated clears it before each run
+        path = self._session(SID)
+        self._reset()
+        jd._judge_ctx.stage_incomplete = True                           # left by an earlier session's run
+        out = jd._gated("group", lambda f, p, n: 7, SID, str(path), NOW, ("sig",), settle=False, parse=False)
+        self.assertEqual(out, 7)
+        self.assertEqual(jd._STAGE_STAMP[("group", SID)], (("sig",), None), "stamped: the stale bit was reset")
+        self.assertEqual((self._st("group")["stamped"], self._st("group")["incomplete"]), (1, 0))
+
+    def test_the_planners_failed_call_site_alone_marks_the_run(self):
+        # the work-run's failed-call `continue` marks the run on its own: plan_llm is patched ABOVE the
+        # belt (the belt never sees the call), so the site's mark is the only one in play
+        path = self._session(SID)
+        self._converge()
+        self._append(path, uline(T0 + 200, "task C", "u3", "a2"), aline(T0 + 230, "did C", "a3", "u3"))
+        jd.plan_llm = lambda text, menu, human=False, **kw: ""
+        self._reset()
+        self._pass(tiers=("plan",))
+        st = self._st("plan")
+        self.assertEqual((st["ran"], st["incomplete"], st["stamped"]), (1, 1, 0), "the failed call alone voids the stamp")
+        self.assertFalse(jd.load_goals(SID).get("parseFails"), "no parse try burned on a failed call")
+
+    @unittest.skipIf(os.geteuid() == 0, "root ignores mode bits")
+    def test_a_side_file_stat_that_fails_runs_the_stage_without_a_stamp(self):
+        # _ident treats ABSENCE as None and lets every other OSError propagate: a stat that fails for
+        # another reason (here a permission bit on the marker directory) must not read as "absent", or it
+        # would match the stamp of a run that saw no marker and skip the session
+        path = self._session(SID)
+        jd.GONEDIR.mkdir(parents=True, exist_ok=True)
+        self._converge()
+        os.chmod(jd.GONEDIR, 0)
+        try:
+            jd.end_pass_frame(True)
+            self.assertEqual(jd._gate_check("plan", SID, str(path), NOW), (False, None),
+                             "run, and stamp nothing: a failed stat is not an absent file")
+        finally:
+            os.chmod(jd.GONEDIR, 0o700)
+
+    def test_a_stamping_failure_is_not_a_failed_pass(self):
+        # the stamp is written after the stage's work landed; a failure computing it (the clock input
+        # here) counts the run bypassed, logs one gate-stamp row, and is never a pass-crash: pass_done is
+        # stamped and the planner's placements stand
+        path = self._session(SID)
+        self._converge()
+        self._append(path, uline(T0 + 200, "task C", "u3", "a2"), aline(T0 + 230, "did C", "a3", "u3"))
+        real = jd._settle_not_before
+
+        def boom(fsid, p, now):
+            raise RuntimeError("the clock input could not be read")
+        jd._settle_not_before = boom
+        jd._PASS_DONE.pop(("plan", SID), None)
+        self._reset()
+        try:
+            self._pass(tiers=("plan",))
+        finally:
+            jd._settle_not_before = real
+        st = self._st("plan")
+        self.assertEqual((st["ran"], st["bypassed"], st["stamped"]), (1, 1, 0))
+        rows = [json.loads(l) for l in open(jd.ERRORS) if l.strip()]
+        self.assertEqual([r["err"] for r in rows if r.get("err") in ("gate-stamp", "pass-crash")], ["gate-stamp"])
+        self.assertIsNotNone(jd.pass_watermark("plan", SID), "the pass over the sid completed")
+        self.assertIn("task C", " ".join(self.plan_calls), "and the stage's work landed")
+
+
+class TheClock(_Gate):
+    def _monitor_fixture(self):
+        # turn 1: a non-persistent Monitor launched with a 60 s timeout_ms, its ack, then the turn ends: the
+        # launch is running with a deadline (its t + 60); the closer stamps the wait on that turn's top.
+        # turn 2: task A, done by the closer; its top is the last placement, so it is the FOCUS whose settle
+        # waits on the hold (rollup_status: settled = not the focus, or the session settled).
+        launch_t = T0 + 100
+        recs = [uline(T0 + 90, "watch the deploy log", "u1"),
+                tool_use_line(launch_t, "a1", "u1", "toolu_m1", "Monitor", {"command": "tail -f deploy.log", "timeout_ms": 60000}),
+                tool_result_line(launch_t + 1, "r1", "a1", "toolu_m1", "Monitor started"),
+                aline(launch_t + 5, "Watching the deploy log in the background.", "a2", "r1"),
+                uline(T0 + 200, "task A", "u3", "a2"), aline(T0 + 230, "did A", "a3", "u3")]
+        path = self._session(SID, recs)
+
+        def closer(tt, mt, *a, **k):
+            self.close_calls.append(tt)
+            if "did A" in tt:
+                return '{"done": [{"goal": 1, "why": "task A shipped"}], "block": []}'
+            return '{"done": [], "block": [], "awaiting": [{"goal": 1, "why": "the deploy log is still being watched"}]}'
+        jd.closer_llm = closer
+        return path, launch_t + 60.0 + 120.0                            # the expiry: deadline + grace
+
+    def test_the_stamp_carries_the_next_expiry_and_the_run_is_due_once_the_clock_passes_it(self):
+        path, expiry = self._monitor_fixture()
+        now0 = int(expiry) - 100
+        self._converge(now0)
+        watch, g1 = self._tops()                                        # the monitor's top, then task A's
+        store = jd.load_goals(SID)
+        self.assertTrue(store["nodes"][g1["id"]]["nodeComplete"], "premise: the closer filed task A done")
+        self.assertTrue(store["nodes"][watch["id"]].get("awaitingWhy"), "premise: the closer stamped the wait")
+        self.assertIn(g1["id"], store.get("confirming") or [], "the settle is held: the monitor is awaited")
+        self.assertEqual(self._stamp("plan")[1], expiry, "the planner's stamp carries the launch's expiry")
+        self.assertEqual(self._stamp("close")[1], expiry)
+        self._reset()
+        self._pass(int(expiry))                                         # at the instant: not yet expired
+        self.assertEqual((self._st("plan")["skipped"], self._st("close")["skipped"]), (1, 1),
+                         "skipped at the expiry instant (em._bg_expired reads now > expiry)")
+        self._reset()
+        self._pass(int(expiry) + 1)
+        self.assertEqual(self._st("plan")["due_clock"], 1, "past the expiry the planner runs on the clock alone")
+        self.assertEqual(self._st("plan")["ran"], 1)
+        store = jd.load_goals(SID)
+        self.assertEqual(store["status"].get(g1["id"]), "completed", "the expired wait released the settle")
+        self.assertIsNone(self._stamp("plan")[1], "no future expiry left: the stamp's not-before is None")
+
+    def test_a_complete_run_at_the_expiry_instant_keeps_the_clock(self):
+        # the review's boundary case (2026-09-07): run_triage's now is int(time.time()) and transcript
+        # timestamps are whole seconds, so a pass lands in the expiry's own second routinely. At that
+        # instant the launch has not expired (em._bg_expired is strict), the run holds the settle, and the
+        # stamp must still carry the expiry: a stamp with no clock would skip every later pass while the
+        # ungated pass at now > expiry releases the hold and completes the top.
+        path, expiry = self._monitor_fixture()
+        self.assertEqual(expiry, int(expiry), "fixture: an integral expiry (launch t + timeout + grace)")
+        self._converge(int(expiry) - 100)
+        watch, g1 = self._tops()
+        with open(jd.STATE / "cleared.jsonl", "a") as f:               # an unrelated re-arm in the expiry's second
+            f.write(json.dumps({"id": "cccccccc-1111-2222-3333-444444444444:g7", "op": "clear", "t": int(expiry)}) + "\n")
+        self._reset()
+        self._pass(int(expiry))
+        self.assertEqual(self._st("plan")["ran"], 1, "re-armed: the planner ran at the instant")
+        self.assertEqual(self._st("plan")["stamped"], 1, "a complete run")
+        self.assertIn(g1["id"], jd.load_goals(SID).get("confirming") or [], "at the instant the wait still holds")
+        self.assertEqual(self._stamp("plan")[1], expiry, "the stamp keeps the expiry that equals now")
+        self.assertEqual(self._stamp("close")[1], expiry)
+        self._reset()
+        self._pass(int(expiry) + 1)
+        self.assertEqual((self._st("plan")["ran"], self._st("plan")["due_clock"]), (1, 1), "past it: run on the clock")
+        self.assertEqual(jd.load_goals(SID)["status"].get(g1["id"]), "completed", "the released settle completes the top")
+        self.assertIsNone(self._stamp("plan")[1])
+
+    def test_the_expiry_helper_and_the_predicate_agree(self):
+        self.assertEqual(em._bg_expiry_t({"deadline": 1000.0}), 1120.0)
+        self.assertEqual(em._bg_expiry_t({"deadline": 1000.0, "deadlineSrc": "hook"}), 1005.0, "hook grace 5")
+        self.assertIsNone(em._bg_expiry_t({"id": "x"}), "no deadline: never expires by the clock")
+        for t in ({"deadline": 1000.0}, {"deadline": 1000.0, "deadlineSrc": "hook"}):
+            x = em._bg_expiry_t(t)
+            self.assertFalse(em._bg_expired(t, x), "at the instant: not expired")
+            self.assertTrue(em._bg_expired(t, x + 0.001), "past it: expired")
+        self.assertFalse(em._bg_expired({"id": "x"}, 1e12))
+
+    def test_not_before_is_the_earliest_future_non_ghost_expiry(self):
+        path, expiry = self._monitor_fixture()
+        self.assertEqual(jd._settle_not_before(SID, str(path), expiry - 10), expiry)
+        self.assertEqual(jd._settle_not_before(SID, str(path), expiry), expiry,
+                         "at the instant the launch has not expired yet (em._bg_expired is strict), so it stays on the stamp")
+        self.assertIsNone(jd._settle_not_before(SID, str(path), expiry + 1), "past it nothing lies ahead")
+        reg = jd.STATE / "sdk" / (SID + ".json")
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        reg.write_text(json.dumps({"spawnedAt": T0 + 400}))            # a CLI spawned after the launch: a ghost
+        self.assertIsNone(jd._settle_not_before(SID, str(path), expiry - 10),
+                          "a ghost launch's expiry can change no verdict, so it arms no clock")
+
+
+class DeathDrain(_Gate):
+    def _dead(self):
+        # a session outside the discover window with a pending death marker: run_close reaches it only
+        # through the death drain
+        path = self._session(SID)
+        self._converge()
+        later = int(time.time()) + 49 * 3600                            # the transcript falls out of the 48 h window
+        jd._discover_cache.clear()                                      # (the list is cached behind a dir fingerprint)
+        self.assertFalse([s for s in jd.discover(later) if s[0] == SID], "premise: not discovered")
+        jd._discover_cache.clear()
+        return path, later
+
+    def test_a_pending_marker_finalizes_on_the_first_drain_run_and_the_sid_then_skips(self):
+        path, later = self._dead()
+        jd._write_death_marker(SID, {"t": T0 + 1000, "by": "probe"})
+        self._reset()
+        self._pass(later, tiers=("close",))
+        self.assertEqual(self._st("close")["ran"], 1, "the drain's sid runs through the gate")
+        m = json.loads((jd.GONEDIR / (SID + ".json")).read_text())
+        self.assertIn("endedAt", m, "the settled dead store finalized its marker")
+        self.assertEqual((self._st("close")["ran"], self._st("close")["stamped"]), (1, 1),
+                         "a complete drain run stamps (the drain's sids carry a signature)")
+        self.assertIsNotNone(self._stamp("close"))
+        self._reset()
+        self._pass(later + 1, tiers=("close",))
+        self.assertEqual((self._st("close")["ran"], self._st("close")["skipped"]), (0, 0),
+                         "a finalized marker leaves the drain: the sid is not listed at all")
+        self.assertIsNone(self._stamp("close"), "...and its stamp is evicted with it")
+
+    def test_a_marker_superseded_by_a_newer_states_row_retires(self):
+        path, later = self._dead()
+        jd._write_death_marker(SID, {"t": T0 + 1000, "by": "probe"})
+        self._states_row(SID, T0 + 2000, "idle")                        # a revival's row, newer than the marker
+        self._pass(later, tiers=("close",))
+        m = json.loads((jd.GONEDIR / (SID + ".json")).read_text())
+        self.assertTrue(m.get("superseded"))
+
+    def test_a_cut_walk_leaves_the_marker_pending_and_the_sid_due(self):
+        path, later = self._dead()
+        self._append(path, uline(T0 + 200, "task C", "u3", "a2"), aline(T0 + 230, "did C", "a3", "u3"))
+
+        def dead_call(*a, **k):
+            jd._judge_ctx.last_call_fail = {"note": "the model CLI died with no output (exit -14)",
+                                            "model": "sonnet", "kill": True}
+            return ""
+        jd.closer_llm = dead_call
+        self._pass()                                                    # the planner places task C; the closer's call dies
+        self.assertEqual(self._st("close")["incomplete"], 1, "premise: the cut walk is incomplete while alive too")
+        jd._write_death_marker(SID, {"t": T0 + 1000, "by": "probe"})
+        self._reset()
+        self._pass(later, tiers=("close",))
+        self.assertEqual((self._st("close")["ran"], self._st("close")["incomplete"]), (1, 1))
+        m = json.loads((jd.GONEDIR / (SID + ".json")).read_text())
+        self.assertNotIn("endedAt", m, "a cut walk never finalizes the marker")
+        self._reset()
+        self._pass(later + 1, tiers=("close",))
+        self.assertEqual(self._st("close")["ran"], 1, "still due: the cut run stamped nothing, so there is no stamp to match")
+
+
+class Bounds(_Gate):
+    def test_rebind_empties_the_stamps_and_eviction_follows_discover(self):
+        self._session(SID)
+        self._session(SID2, name="api")
+        self._converge()
+        self.assertEqual(len(jd._STAGE_STAMP), 4)
+        (jd.NAMES / SID2).unlink()                                      # the session leaves discover
+        jd._namefp_memo.clear()
+        self._pass()
+        self.assertEqual({k for k in jd._STAGE_STAMP}, {("plan", SID), ("close", SID)}, "the gone sid's stamps evicted")
+        jd._rebind_state(self.td)
+        self.assertEqual(jd._STAGE_STAMP, {}, "a new root is a new world")
+
+    def test_the_cap_clears(self):
+        self._session(SID)
+        self._session(SID2, name="api")
+        jd._STAGE_STAMP_MAX = 1
+        self._pass()
+        self.assertEqual(len(jd._STAGE_STAMP), 1, "a wholesale clear at the cap: one full walk next pass")
+
+    def test_an_unframed_runner_never_stamps(self):
+        # no frame, no stamp: the served pair the frame records is what makes a stamp exact, so a runner
+        # outside a pass frame (romp-judge --plan, a bare run_plan) runs every session and counts it
+        # bypassed; the same runner under a frame stamps
+        self._session(SID)
+        jd.end_pass_frame(True)
+        jd._discover_cache.clear()
+        jd.run_plan(now=NOW)
+        st = self._st("plan")
+        self.assertEqual((st["ran"], st["bypassed"], st["stamped"]), (1, 1, 0))
+        self.assertIsNone(self._stamp("plan"), "no frame: nothing stamped")
+        self._reset()
+        self._pass(tiers=("plan",))
+        self.assertEqual(self._st("plan")["stamped"], 1, "under a frame the same work stamps")
+
+
+class FsCompleteness(_Gate):
+    """The loud guard for a missing input: wrap the filesystem for one idle run of each stage over a
+    two-session fixture (a task store, captions, episodes, a finalized death marker and an sdk reg present)
+    and hold every path touched under the state root, the transcript directory and the task store against
+    the tier's signature file set plus a fixed allowlist. A stage that starts reading a file the signature
+    does not carry fails here."""
+
+    ALLOW_NAMES = {"usage.json", "retry-paused.json", "judge-errors.jsonl", "session-flags.json"}
+
+    def _touched(self, fn):
+        seen = set()
+
+        def note(p):
+            if isinstance(p, (str, bytes, os.PathLike)):
+                seen.add(os.path.abspath(os.fsdecode(p)))
+        reals = {(os, "stat"): os.stat, (os, "lstat"): os.lstat, (os, "open"): os.open, (os, "scandir"): os.scandir,
+                 (os, "listdir"): os.listdir, (builtins, "open"): builtins.open, (io, "open"): io.open}
+
+        def wrap(real):
+            def w(p, *a, **k):
+                note(p)
+                return real(p, *a, **k)
+            return w
+        for (mod, name), real in reals.items():
+            setattr(mod, name, wrap(real))
+        try:
+            fn()
+        finally:
+            for (mod, name), real in reals.items():
+                setattr(mod, name, real)
+        return seen
+
+    def _fixture(self):
+        self._session(SID)
+        self._session(SID2, name="api")
+        jd.CAPDIR.mkdir(parents=True, exist_ok=True)
+        (jd.CAPDIR / (SID + ".jsonl")).write_text(json.dumps({"id": "seg#p", "caption": "Ship the search"}) + "\n")
+        jd.EPIDIR.mkdir(parents=True, exist_ok=True)
+        (jd.EPIDIR / (SID + ".jsonl")).write_text(json.dumps({"head": "u1", "fsid": SID, "t": T0}) + "\n")
+        jd._write_death_marker(SID2, {"t": T0 + 500, "by": "probe", "endedAt": T0 + 500})
+        reg = jd.STATE / "sdk" / (SID + ".json"); reg.parent.mkdir(parents=True, exist_ok=True)
+        reg.write_text(json.dumps({"spawnedAt": T0 - 10}))
+        d = self.claude / "tasks" / SID; d.mkdir()
+        (d / "1.json").write_text(json.dumps({"id": "1", "subject": "write the api tests", "status": "pending"}))
+        self._states_row(SID, T0 + 131, "idle")
+        (jd.STATE / "cleared.jsonl").write_text("")
+        (jd.STATE / "auto-nudge.json").write_text(json.dumps({"enabled": False, "deferred": {}}))
+        self._converge()
+
+    def _allowed(self, tier, sid, path):
+        ident, value = jd._sig_inputs(tier, sid, str(path))
+        cands, states, key_files = jd._parse_key_files(sid, [str(path)])
+        allowed = {os.path.abspath(str(p)) for p in ident + value + key_files + [states, jd.MESSAGES]}
+        allowed |= {os.path.abspath(str(jd.STATE / n)) for n in self.ALLOW_NAMES}
+        return allowed
+
+    def _check(self, tier, stage):
+        self._fixture()
+        for sid in (SID, SID2):
+            path = self.pdir / (sid + ".jsonl")
+            own = jd.begin_pass_frame()                                 # a fresh frame: the parse hits the filesystem
+            try:
+                touched = self._touched(lambda: stage(sid, str(path), NOW))
+            finally:
+                jd.end_pass_frame(own)
+            allowed = self._allowed(tier, sid, path)
+            roots = (str(jd.STATE), str(self.pdir), str(self.claude / "tasks"))
+            scratch = (str(jd.JUDGE_SCRATCH), str(jd.NAMES), str(self.claude / "tasks" / Path(path).stem))
+            stray = sorted(p for p in touched
+                           if p.startswith(roots) and p not in allowed and not os.path.isdir(p)
+                           and not p.startswith(scratch))
+            self.assertEqual(stray, [], "%s read files its signature does not carry for %s" % (tier, sid))
+
+    def test_the_planners_idle_reads_are_all_in_its_signature(self):
+        self._check("plan", jd._plan_session)
+
+    def test_the_closers_idle_reads_are_all_in_its_signature(self):
+        self._check("close", jd._close_session)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge_stage_gate.py
+++ b/tests/test_judge_stage_gate.py
@@ -24,12 +24,13 @@ mid-pass (a turn ending after the pass's first touch), an unpoked background tas
 journal gesture, a nudge block, two concurrent writers, a restart (fresh process state), the death drain,
 the archive path.
 
-Accepted lag, recorded here as the design asks: under an open frame every parsed_session caller sees the
-pass-start world (a cache hit too), so the six pusher tick jobs that read the judge parse
-(_interrupt_block_tick, _closer_pending, _awaiting_wake_outcomes, _deferral_sweep_tick,
-_auto_nudge_session, _clear_done_working_notes) see a world up to one pass old for every session, and a
-turn that ends after a pass's first touch is judged next pass, whole. That is the frame's design
-(2026-07-21); the gate adds no lag beyond the producer's 3 s backstop for the clock input.
+Accepted lag, recorded here as the design asks: under an open frame every PASS-THREAD caller of
+parsed_session sees the pass-start world (a cache hit too), so a turn that ends after a pass's first touch is
+judged next pass, whole. That is the frame's design (2026-07-21). The kernel's six pusher tick jobs that read
+the judge parse (_interrupt_block_tick, _closer_pending, _awaiting_wake_outcomes, _deferral_sweep_tick,
+_auto_nudge_session, _clear_done_working_notes) are NOT pass threads (jd._pass_frame; review find,
+2026-09-08): they read the live world every cycle, so the frame costs them nothing, and the gate adds no lag
+beyond the producer's 3 s backstop for the clock input.
 
 PRIVATE synthetic sids (goal-minting fixtures never share the placeholder sid: its override journal is
 replayed on every load), invented text, a notes-api with web/api sessions; the journals are removed in
@@ -253,6 +254,10 @@ class _Gate(unittest.TestCase):
     def _stamp(self, tier, sid=SID):
         return jd._STAGE_STAMP.get((tier, sid))
 
+    def _rows(self, err):
+        """The judge-errors rows of kind `err` (the file exists once any row was logged)."""
+        return [r for r in (json.loads(l) for l in open(jd.ERRORS) if l.strip()) if r.get("err") == err]
+
     def _tops(self, sid=SID):
         store = jd.load_goals(sid)
         return sorted((nd for nd in store["nodes"].values() if nd["parentId"] is None), key=lambda nd: nd["t"])
@@ -313,8 +318,8 @@ class Convergence(_Gate):
 
 class ATurnEndingMidPass(_Gate):
     def test_a_turn_ending_after_the_first_touch_is_judged_next_pass_whole(self):
-        # the review's hazard: a tick job (or the index tier) touches the session while its last turn is
-        # OPEN; the turn's final record and the idle row land; the gated planner and closer check the gate.
+        # the review's hazard: a pass thread (the index tier's captioner, say) touches the session while its
+        # last turn is OPEN; the turn's final record and the idle row land; the gated planner and closer check the gate.
         # The transcript component is the pair the pass PINNED at that first touch, which equals the stamp
         # the converged run left, so the mid-pass check is a SKIP (no stat of the grown file, no run), the
         # stamps keep the pre-append pair, and the next pass runs both stages over the ended turn, whole.
@@ -326,7 +331,7 @@ class ATurnEndingMidPass(_Gate):
         self._converge()
         own = jd.begin_pass_frame()
         try:
-            jd.parsed_session(SID, [str(path)], NOW)                    # the tick job's first touch, turn open
+            jd.parsed_session(SID, [str(path)], NOW)                    # the index tier's first touch, turn open
             pre = jd._frame["keys"][("parse", SID)]
             self._append(path, aline(T0 + 140, "did B", "a3", "a2"))
             self._states_row(SID, T0 + 141, "idle")
@@ -868,6 +873,9 @@ class Completeness(_Gate):
         self.assertEqual((st["ran"], st["bypassed"], st["stamped"]), (1, 1, 0))
         rows = [json.loads(l) for l in open(jd.ERRORS) if l.strip()]
         self.assertEqual([r["err"] for r in rows if r.get("err") in ("gate-stamp", "pass-crash")], ["gate-stamp"])
+        self.assertEqual([r["judge"] for r in rows if r.get("err") == "gate-stamp"], ["planner"],
+                         "the row wears the judge's name like every other row (review find, 2026-09-08: it carried "
+                         "the tier key, which no reader of the log joins on)")
         self.assertIsNotNone(jd.pass_watermark("plan", SID), "the pass over the sid completed")
         self.assertIn("task C", " ".join(self.plan_calls), "and the stage's work landed")
 
@@ -1074,6 +1082,41 @@ class Bounds(_Gate):
         self._pass(tiers=("plan",))
         self.assertEqual(self._st("plan")["stamped"], 1, "under a frame the same work stamps")
 
+    def test_a_muted_sid_leaves_the_parse_tiers_and_an_unmute_costs_one_full_run(self):
+        # session-flags.json is in no signature on purpose (the inventory above GATED_TIERS): _hidden_from_feed
+        # filters run_plan's, run_close's and run_unblock's lists before any stage runs, so a muted sid is not
+        # listed and the post-pool eviction drops its stamps for those three tiers; the other three runners do
+        # not filter on it and keep skipping it. An unmute lists the sid again with no stamp to match: one
+        # full run (a load, the walk, a stamp), then the skips resume (review find, 2026-09-08: stated, untested)
+        self._session(SID)
+        self._session(SID2, name="api")
+        self._converge()
+        flags = jd.STATE / "session-flags.json"
+        flags.write_text(json.dumps({SID2: {"hideFromFeed": True}}))     # the timeline's mute checkbox
+        self._reset()
+        self._pass(tiers=ALL_TIERS)
+        self.assertEqual({k for k in jd._STAGE_STAMP if k[1] == SID2},
+                         {(t, SID2) for t in ("group", "consolidate", "distill")},
+                         "the muted sid's planner, closer and unblocker stamps are evicted; the store tiers keep theirs")
+        for t in ("plan", "close", "unblock"):
+            self.assertEqual((self._st(t)["ran"], self._st(t)["skipped"]), (0, 1), "%s: the muted sid is not listed" % t)
+        for t in ("group", "consolidate", "distill"):
+            self.assertEqual((self._st(t)["ran"], self._st(t)["skipped"]), (0, 2), "%s: both sids skip" % t)
+        flags.write_text(json.dumps({}))                                  # the unmute
+        self._reset()
+        io0 = dict(self.io)
+        self._pass(tiers=ALL_TIERS)
+        for t in ("plan", "close", "unblock"):
+            self.assertEqual((self._st(t)["ran"], self._st(t)["stamped"], self._st(t)["skipped"]), (1, 1, 1),
+                             "%s: the unmuted sid runs once, in full, and stamps; the other sid skips" % t)
+        for t in ("group", "consolidate", "distill"):
+            self.assertEqual((self._st(t)["ran"], self._st(t)["skipped"]), (0, 2), "%s: nothing changed for either sid" % t)
+        self.assertGreater(self.io["loads"] - io0["loads"], 0, "a full run loads the store")
+        self.assertEqual({k for k in jd._STAGE_STAMP if k[1] == SID2}, {(t, SID2) for t in ALL_TIERS})
+        self._reset()
+        self._pass(tiers=ALL_TIERS)
+        self.assertTrue(all(self._st(t)["ran"] == 0 for t in ALL_TIERS), "and the skips resume")
+
 
 class FsCompleteness(_Gate):
     """The loud guard for a missing input: wrap the filesystem for one idle run of each stage over a
@@ -1082,7 +1125,11 @@ class FsCompleteness(_Gate):
     the tier's signature file set plus a fixed allowlist. A stage that starts reading a file the signature
     does not carry fails here."""
 
-    ALLOW_NAMES = {"usage.json", "retry-paused.json", "judge-errors.jsonl", "session-flags.json"}
+    # what a stage may touch beyond its signature: the model-call gate's two files (a skip on either is a ""
+    # call, so the belt marks the run incomplete) and the errors log it writes to. session-flags.json is NOT
+    # here: no stage reads it (the runners filter their lists on it before any stage runs; Bounds has the
+    # muted-sid test), so a stage that started to would fail here (review find, 2026-09-08)
+    ALLOW_NAMES = {"usage.json", "retry-paused.json", "judge-errors.jsonl"}
 
     def _touched(self, fn):
         seen = set()
@@ -1687,9 +1734,6 @@ class StoreCompleteness(_Gate):
             f = store["nodes"][f]["parentId"]
         return store["nodes"][f]
 
-    def _rows(self, err):
-        return [r for r in (json.loads(l) for l in open(jd.ERRORS) if l.strip()) if r.get("err") == err]
-
     @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
     def test_an_unreadable_states_file_never_stamps(self):
         # the review's reproduction: the gate stats the states file into the distiller's signature, then the
@@ -2048,6 +2092,154 @@ class StoreCompleteness(_Gate):
         self.assertEqual(calls, [None, (1, 2)], "two owed decisions, one paragraph: the corrective retry ran")
         self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0))
         self.assertIsNone(jd.load_goals(SID)["nodes"][top["id"]].get("blockSummary"), "the brief is still owed")
+
+
+class SignatureFileReads(_Gate):
+    """The four signature files whose stage readers answered EMPTY on a read failure and let the run stamp
+    (review find, 2026-09-08): the captions (_prompt_gist), the episode log (_episode_read), the death marker
+    (_death_marker) and the archive (load_goal_archive). Each now goes through _read_failed like the states
+    file, cleared.jsonl and the stall records: the run is marked incomplete, one row per failure episode, and
+    the session stays due until the file reads. A stamp over an answer that never read the file would skip
+    the session until the file moved, which a permission bit, an EMFILE or an EIO never makes it do."""
+
+    def _coerced_top(self, sid, quote, seg, n=80):
+        """A coerce-floor node still wearing its verbatim head as its title: the shape _heal_floor_titles
+        retitles from the persisted prompt caption once one exists, reading captions/<sid>.jsonl every run
+        until it does."""
+        store = jd.load_goals(sid)
+        nid = "%s:g%d" % (sid, n)
+        store["nodes"][nid] = {"id": nid, "text": jd._seg_label(quote), "quote": quote, "parentId": None,
+                               "why": jd._COERCE_WHY, "t": T0 + 300, "mt": T0 + 300, "log": [], "trail": [seg],
+                               "nodeComplete": False, "cleared": False}
+        store["status"][nid] = "working"
+        jd.save_goals(sid, store)
+        return nid
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_an_unreadable_captions_file_never_stamps_the_planner(self):
+        # the caption the heal waits for lands (a new identity: the planner runs), and the read fails after
+        # the gate stat'd it. Before the fix the heal read '' and the run stamped, so the title healed only
+        # when the file moved again; now the run is incomplete and the heal lands as soon as the file reads
+        self._session(SID)
+        quote = "Ship the search endpoint for the notes api"
+        nid = self._coerced_top(SID, quote, "seg-x")
+        self._converge()                                                 # no captions file yet: the heal reads nothing
+        cp = jd.CAPDIR / (SID + ".jsonl")
+        jd.CAPDIR.mkdir(parents=True, exist_ok=True)
+        cp.write_text(json.dumps({"id": "seg-x#p", "caption": "Ship the search"}) + "\n")
+        os.chmod(cp, 0)
+        try:
+            self._reset()
+            self._pass(tiers=("plan",))
+            s = self._st("plan")
+            self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0),
+                             "the heal's read failed after a good stat: the run is incomplete, no stamp")
+            self.assertEqual(len(self._rows("captions-unreadable")), 1, "one loud row")
+            self.assertEqual(jd.load_goals(SID)["nodes"][nid]["text"], jd._seg_label(quote), "premise: not healed")
+            self._reset()
+            self._pass(tiers=("plan",))
+            self.assertEqual((self._st("plan")["ran"], self._st("plan")["incomplete"]), (1, 1), "still due")
+            self.assertEqual(len(self._rows("captions-unreadable")), 1, "one row per failure episode, not per pass")
+        finally:
+            os.chmod(cp, 0o644)
+        self._converge(tiers=("plan",))                                  # readable, nothing moved: the run happens
+        self.assertEqual(jd.load_goals(SID)["nodes"][nid]["text"], "Ship the search",
+                         "the heal landed once the file read (a stamp over the failed read would have skipped it)")
+        self.assertEqual(len(self._rows("captions-unreadable")), 1)
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_an_unreadable_episode_log_never_stamps_the_planner_and_is_not_memoized(self):
+        # a /clear boundary at T0 + 50 makes task A pre-episode: the planner's retire reads the floor for
+        # every new unit. After a restart (empty stamps, empty mtime memo) the read fails: before the fix the
+        # run answered "no floor", stamped, AND memoized the empty read under the file's mtime, so the rows
+        # stayed invisible until the log grew; now the run is incomplete and the next read sees the rows
+        path = self._session(SID)
+        jd.EPIDIR.mkdir(parents=True, exist_ok=True)
+        ep = jd.EPIDIR / (SID + ".jsonl")
+        ep.write_text(json.dumps({"head": "u1", "fsid": SID, "t": T0}) + "\n"
+                      + json.dumps({"head": "u2", "fsid": SID, "t": T0 + 50}) + "\n")
+        self._converge()
+        self.assertEqual(len(self.plan_calls), 1, "premise: task A predates the boundary and was retired; task B placed")
+        self._append(path, uline(T0 + 200, "task C", "u3", "a2"), aline(T0 + 230, "did C", "a3", "u3"))
+        jd._STAGE_STAMP.clear(); jd._episode_memo.clear()                # what a restart does
+        os.chmod(ep, 0)
+        try:
+            self._reset()
+            self._pass(tiers=("plan",))
+            s = self._st("plan")
+            self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0),
+                             "the floor read failed after a good stat: the run is incomplete, no stamp")
+            self.assertEqual(len(self._rows("episodes-unreadable")), 1, "one loud row")
+            self.assertEqual(jd.episode_rows(SID), [], "while unreadable the log answers empty")
+        finally:
+            os.chmod(ep, 0o644)
+        self.assertEqual(len(jd.episode_rows(SID)), 2,
+                         "the failed read was not memoized under the file's mtime: the next read sees the rows")
+        self._converge(tiers=("plan",))
+        self.assertIsNotNone(self._stamp("plan"), "readable again: the planner completes and stamps")
+        self.assertEqual(len(self._rows("episodes-unreadable")), 1)
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_an_unreadable_death_marker_never_stamps_the_closer(self):
+        # _death_finalize reads the marker at the end of every _close_session (a finalized one is read and
+        # left alone), so the marker is on the closer's idle path; another sid's cleared row re-arms the
+        # closer without giving it anything to write
+        self._session(SID)
+        jd._write_death_marker(SID, {"t": T0 + 1000, "by": "probe", "endedAt": T0 + 1000})
+        self._converge()
+        mp = jd.GONEDIR / (SID + ".json")
+        with open(jd.STATE / "cleared.jsonl", "a") as f:
+            f.write(json.dumps({"id": SID2 + ":g1", "op": "clear", "t": NOW}) + "\n")
+        os.chmod(mp, 0)
+        try:
+            self._reset()
+            self._pass(tiers=("close",))
+            s = self._st("close")
+            self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0),
+                             "the marker read failed after a good stat: the run is incomplete, no stamp")
+            self.assertEqual(len(self._rows("marker-unreadable")), 1, "one loud row")
+            self._reset()
+            self._pass(tiers=("close",))
+            self.assertEqual((self._st("close")["ran"], self._st("close")["incomplete"]), (1, 1), "still due")
+            self.assertEqual(len(self._rows("marker-unreadable")), 1, "one row per failure episode, not per pass")
+        finally:
+            os.chmod(mp, 0o644)
+        self._reset()
+        self._pass(tiers=("close",))
+        self.assertEqual((self._st("close")["ran"], self._st("close")["stamped"]), (1, 1),
+                         "readable again, nothing on disk moved: the run happens and stamps")
+        self.assertEqual(len(self._rows("marker-unreadable")), 1)
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_an_unreadable_archive_never_stamps_any_tier(self):
+        # every tier's signature carries the archive; load_goals reads it for a journaled restore row, so a
+        # restore row puts the read on every tier's load. One failure episode, one row, six incomplete runs
+        self._session(SID)
+        self._converge()
+        top = self._tops()[0]
+        ap = jd.GOALARCHDIR / (SID + ".json")
+        jd.save_goal_archive(SID, {"rompUuid": SID, "nodes": {}, "status": {}})
+        jd.append_restore(SID, {top["id"]: dict(jd.load_goals(SID)["nodes"][top["id"]])}, {top["id"]: "working"}, NOW)
+        os.chmod(ap, 0)
+        try:
+            self._reset()
+            self._pass(tiers=ALL_TIERS)
+            for t in ALL_TIERS:
+                s = self._st(t)
+                self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0),
+                                 "%s: the archive read failed after a good stat: incomplete, no stamp" % t)
+            self.assertEqual(len(self._rows("archive-unreadable")), 1, "one row for the episode, not one per tier")
+            self._reset()
+            self._pass(tiers=ALL_TIERS)
+            for t in ALL_TIERS:
+                s = self._st(t)
+                self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0),
+                                 "%s: still due, and the shared archive memo did not serve the failed read" % t)
+            self.assertEqual(len(self._rows("archive-unreadable")), 1)
+        finally:
+            os.chmod(ap, 0o644)
+        self._converge()
+        self.assertEqual(len(self._rows("archive-unreadable")), 1, "readable again: every tier completed and stamped")
 
 
 class UnblockerHazard(_Gate):

--- a/tests/test_judge_stage_gate.py
+++ b/tests/test_judge_stage_gate.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """The judge tiers' EVIDENCE GATE (2026-09-07): the planner and closer skip a
 session's per-pass run when nothing their decision path reads has changed since the run that last judged
-it to completion.
+it to completion. The four store-only tiers went on the same gate the same day: the unblocker (the parse
+pair and the store trio), the grouper and consolidator (the store trio and cleared.jsonl, no parse), the
+distiller (the store trio, the states file and this sid's stall records, no parse); the StoreTiers,
+StoreReArms, StoreOwnWrites, StoreCompleteness, UnblockerHazard and DrainStaysUngated classes and the four
+FsCompleteness checks below are its tests.
 
 Why: every pass ran every discovered session in full (a parse, a store load, the unit walk, the closed-turn
 walk, a rollup, an unconditional save), with about two of thirty-three sessions holding anything new per
@@ -59,6 +63,11 @@ T0 = 1781100000
 NOW = T0 + 5000
 MINT = '{"ops":[{"why":"x","do":"mint","text":"Goal"}]}'
 EMPTY_CLOSE = '{"done": [], "block": []}'
+HOLD_ALL = '{"verdicts":[]}'
+LIFT_ONE = '{"verdicts":[{"n":1,"do":"lift","why":"the port was named two messages later"}]}'
+MIRROR_WHY = "declared in the agent's own to-do list"          # the mirror top's mint reason (_title_mirror_tops)
+STORE_TIERS = ("unblock", "group", "consolidate", "distill")
+ALL_TIERS = ("plan", "close") + STORE_TIERS                     # run_triage's order
 
 
 def iso(t):
@@ -134,6 +143,20 @@ class _Gate(unittest.TestCase):
         jd.closer_llm = lambda tt, mt, *a, **k: (self.close_calls.append(tt) or EMPTY_CLOSE)
         jd.group_llm = lambda menu, judge="grouper": '{"ops":[]}'
         jd._PENDING_CUT_FN = None
+        # the store tiers' helpers: hold every block, land every distill, title every mirror top; and a belt
+        # under all of them, since no test here may reach the real model call
+        self._saved_store = (jd.unblock_llm, jd.distill_llm, jd.brief_llm, jd.stall_llm, jd.mirror_title_llm,
+                             jd.parsed_session)
+        self.unblock_calls, self.distill_calls, self.title_calls = [], [], []
+        jd.unblock_llm = lambda blocks, since, completed="": (self.unblock_calls.append(blocks) or HOLD_ALL)
+        jd.distill_llm = lambda text, work, why, **kw: (self.distill_calls.append(text) or "Shipped the search endpoint.")
+        jd.brief_llm = lambda text, work, owed, **kw: (self.distill_calls.append(text) or "Pick the port the api binds.")
+        jd.stall_llm = lambda text, work, holding: (self.distill_calls.append(text) or "The build has not finished.")
+        jd.mirror_title_llm = lambda subject, frame=None, user_ask=None: (self.title_calls.append(subject) or "Write the api tests")
+
+        def no_model(*a, **k):
+            raise AssertionError("a stage reached the real model call; patch the helper above the belt")
+        jd._judge_run_impl = no_model
         jd._judge_ctx.paused, jd._judge_ctx.last_call_fail, jd._judge_ctx.stage_incomplete = False, None, False
 
     def tearDown(self):
@@ -141,6 +164,8 @@ class _Gate(unittest.TestCase):
         (jd.PROJECTS, jd.plan_llm, jd.closer_llm, jd.group_llm, jd.opener_llm, jd._PENDING_CUT_FN,
          jd._judge_run_impl, jd._rewound_away, jd._judge_run, jd._fileset_key, jd._close_turn,
          jd._STAGE_STAMP_MAX, jd.load_goals, jd.save_goals) = self._saved
+        (jd.unblock_llm, jd.distill_llm, jd.brief_llm, jd.stall_llm, jd.mirror_title_llm,
+         jd.parsed_session) = self._saved_store
         if self._env is None:
             os.environ.pop("CLAUDE_CONFIG_DIR", None)
         else:
@@ -171,27 +196,51 @@ class _Gate(unittest.TestCase):
             f.write(json.dumps({"t": t, "state": state}) + "\n")
 
     def _pass(self, now=NOW, tiers=("plan", "close")):
-        """One gated pass over the fixture: the planner then the closer under one frame, as run_triage."""
+        """One gated pass over the fixture: the named tiers in run_triage's order under one frame."""
         jd._discover_cache.clear()                   # discover's list is cached behind a dir fingerprint, not `now`
+        runners = {"plan": jd.run_plan, "close": jd.run_close, "unblock": jd.run_unblock, "group": jd.run_group,
+                   "consolidate": jd.run_consolidate, "distill": jd.run_distill}
         own = jd.begin_pass_frame()
         try:
-            if "plan" in tiers:
-                jd.run_plan(now=now)
-            if "close" in tiers:
-                jd.run_close(now=now)
+            for t in ALL_TIERS:
+                if t in tiers:
+                    runners[t](now=now)
         finally:
             jd.end_pass_frame(own)
 
-    def _converge(self, now=NOW, limit=4):
-        """Passes until both tiers skip: the working pass, the follow-on run that finds nothing to write
-        (the tier's own publish re-armed it once), then the skip. Leaves the counters zeroed."""
+    def _converge(self, now=NOW, limit=6, tiers=ALL_TIERS):
+        """Passes over `tiers` until every one skips: the working pass, the follow-on run that finds nothing
+        to write (the tier's own publish re-armed it once), then the skip. Leaves the counters zeroed."""
         for _ in range(limit):
             self._reset()
-            self._pass(now)
-            if all(self._st(t)["ran"] == 0 for t in ("plan", "close")):
+            self._pass(now, tiers=tiers)
+            if all(self._st(t)["ran"] == 0 for t in tiers):
                 self._reset()
                 return
         self.fail("the fixture did not converge in %d passes" % limit)
+
+    def _st4(self, key="ran"):
+        """The four store tiers' `key` counters, in STORE_TIERS order."""
+        return tuple(self._st(t)[key] for t in STORE_TIERS)
+
+    def _block(self, sid, nid, t, why="Which port should the api bind?"):
+        """A kernel-side nudge block on `nid` at `t`: the journal row plus a publish through save_goals."""
+        store = jd.load_goals(sid)
+        jd.append_block(sid, nid, "nudge", why, t)
+        jd.record_verdict(store, store["nodes"][nid], "nudge", "block", t, why=why)
+        jd.rollup_status(store, False)
+        jd.save_goals(sid, store)
+
+    def _mirror_top(self, sid, text, n=90):
+        """An untitled to-do MIRROR top (the agent's own TaskCreate subject, verbatim): the one node shape
+        that makes _title_mirror_tops call the model before the distiller's todo is built."""
+        store = jd.load_goals(sid)
+        nid = "%s:g%d" % (sid, n)
+        store["nodes"][nid] = {"id": nid, "text": text, "parentId": None, "why": MIRROR_WHY, "t": T0 + 300,
+                               "mt": T0 + 300, "log": [], "trail": [], "nodeComplete": False, "cleared": False}
+        store["status"][nid] = "working"
+        jd.save_goals(sid, store)
+        return nid
 
     def _st(self, tier):
         return dict(jd._TIER_STATS[tier])
@@ -893,6 +942,21 @@ class TheClock(_Gate):
         self.assertEqual(jd.load_goals(SID)["status"].get(g1["id"]), "completed", "the released settle completes the top")
         self.assertIsNone(self._stamp("plan")[1])
 
+    def test_the_store_tiers_stamps_carry_no_clock_input(self):
+        # settle=False for the four store tiers: they consult the settle on write paths only, so their stamps
+        # hold no not-before and a background launch's expiry makes none of them due on the clock (the
+        # planner's stamp, on the same fixture, does carry it)
+        path, expiry = self._monitor_fixture()
+        self._converge(int(expiry) - 100)
+        self.assertEqual(self._stamp("plan")[1], expiry, "premise: the planner's stamp carries the expiry")
+        for t in STORE_TIERS:
+            self.assertIsNone(self._stamp(t)[1], "%s: no clock input in the stamp" % t)
+        self._reset()
+        self._pass(int(expiry) + 1, tiers=STORE_TIERS)                 # the planner NOT run: no publish re-arms them
+        self.assertEqual(self._st4("due_clock"), (0, 0, 0, 0), "past the expiry no store tier is due on the clock")
+        self.assertEqual(self._st4("ran"), (0, 0, 0, 0))
+        self.assertEqual(self._st4("skipped"), (1, 1, 1, 1))
+
     def test_the_expiry_helper_and_the_predicate_agree(self):
         self.assertEqual(em._bg_expiry_t({"deadline": 1000.0}), 1120.0)
         self.assertEqual(em._bg_expiry_t({"deadline": 1000.0, "deadlineSrc": "hook"}), 1005.0, "hook grace 5")
@@ -980,11 +1044,11 @@ class Bounds(_Gate):
         self._session(SID)
         self._session(SID2, name="api")
         self._converge()
-        self.assertEqual(len(jd._STAGE_STAMP), 4)
+        self.assertEqual(len(jd._STAGE_STAMP), len(ALL_TIERS) * 2, "one stamp per gated tier per sid")
         (jd.NAMES / SID2).unlink()                                      # the session leaves discover
         jd._namefp_memo.clear()
-        self._pass()
-        self.assertEqual({k for k in jd._STAGE_STAMP}, {("plan", SID), ("close", SID)}, "the gone sid's stamps evicted")
+        self._pass(tiers=ALL_TIERS)
+        self.assertEqual({k for k in jd._STAGE_STAMP}, {(t, SID) for t in ALL_TIERS}, "the gone sid's stamps evicted")
         jd._rebind_state(self.td)
         self.assertEqual(jd._STAGE_STAMP, {}, "a new root is a new world")
 
@@ -1062,13 +1126,20 @@ class FsCompleteness(_Gate):
 
     def _allowed(self, tier, sid, path):
         ident, value = jd._sig_inputs(tier, sid, str(path))
-        cands, states, key_files = jd._parse_key_files(sid, [str(path)])
-        allowed = {os.path.abspath(str(p)) for p in ident + value + key_files + [states, jd.MESSAGES]}
+        allowed = {os.path.abspath(str(p)) for p in ident + value}
+        if tier in jd.PARSE_TIERS:
+            cands, states, key_files = jd._parse_key_files(sid, [str(path)])
+            allowed |= {os.path.abspath(str(p)) for p in key_files + [states, jd.MESSAGES]}
+        # the grouper, consolidator and distiller carry NO parse pair, so a transcript read on their idle
+        # path is exactly what this test must catch: the transcript stays out of their allowed set
         allowed |= {os.path.abspath(str(jd.STATE / n)) for n in self.ALLOW_NAMES}
         return allowed
 
-    def _check(self, tier, stage):
+    def _check(self, tier, stage, prep=None):
         self._fixture()
+        if prep is not None:
+            prep()
+            self._converge()
         for sid in (SID, SID2):
             path = self.pdir / (sid + ".jsonl")
             own = jd.begin_pass_frame()                                 # a fresh frame: the parse hits the filesystem
@@ -1089,6 +1160,581 @@ class FsCompleteness(_Gate):
 
     def test_the_closers_idle_reads_are_all_in_its_signature(self):
         self._check("close", jd._close_session)
+
+    def test_the_unblockers_idle_reads_are_all_in_its_signature(self):
+        # with a blocked candidate whose examine is current (the block postdates every ended turn), so the
+        # run reaches the parse and stops at `due` empty: the parse and the store, nothing else
+        self._check("unblock", jd._unblock_session,
+                    prep=lambda: self._block(SID, self._tops()[0]["id"], T0 + 150))
+
+    def test_the_groupers_idle_reads_are_all_in_its_signature(self):
+        self._check("group", jd._group_session)
+
+    def test_the_consolidators_idle_reads_are_all_in_its_signature(self):
+        self._check("consolidate", jd._consolidate_session)
+
+    def test_the_distillers_idle_reads_are_all_in_its_signature(self):
+        # the distiller's idle run, as the design review defines it: no untitled mirror top and an empty
+        # todo; a transcript or peer-store read here would be a signature hole
+        self._check("distill", jd._distill_session)
+
+
+class StoreTiers(_Gate):
+    """The four store-only tiers on the gate: two idle passes run once, then skip with no store I/O."""
+
+    def test_two_idle_passes_run_once_then_skip_with_no_store_io(self):
+        self._session(SID)
+        self._pass(tiers=("plan", "close"))                            # the planner mints two tops, the closer sweeps
+        self._reset()
+        for t in STORE_TIERS:
+            jd._PASS_DONE.pop((t, SID), None)                           # so the run path's own pass_done shows
+        self._pass(tiers=STORE_TIERS)
+        self.assertEqual(self._st4("ran"), (1, 1, 1, 1), "first pass: every store tier runs")
+        self.assertEqual(self._st4("stamped"), (1, 1, 1, 1), "each ran to completion")
+        self.assertEqual(self._st4("skipped"), (0, 0, 0, 0))
+        for t in STORE_TIERS:
+            self.assertIsNotNone(jd.pass_watermark(t, SID), "%s: a completed run stamps pass_done" % t)
+        # the grouper and the consolidator each recorded their signature on first sight (groupedSig,
+        # consolidatedSig: a store-level write, no relink): those publishes moved the store identity after
+        # the unblocker's stamp and their own, and before the distiller's, which keyed on the final identity
+        self._reset()
+        self._pass(tiers=STORE_TIERS)
+        self.assertEqual(self._st4("ran"), (1, 1, 1, 0), "the publishes re-armed the tiers stamped before them, once")
+        self.assertEqual(self._st4("skipped"), (0, 0, 0, 1))
+        self._reset()
+        for t in STORE_TIERS:                                           # the earlier passes' watermarks go: the skip
+            self.assertIsNotNone(jd._PASS_DONE.pop((t, SID), None), t)  #  must write its own, not inherit one
+        io0 = dict(self.io)
+        self._pass(tiers=STORE_TIERS)
+        io1 = dict(self.io)
+        self.assertEqual(self._st4("ran"), (0, 0, 0, 0), "the third pass skips every store tier")
+        self.assertEqual(self._st4("skipped"), (1, 1, 1, 1))
+        self.assertEqual((io1["loads"] - io0["loads"], io1["saves"] - io0["saves"]), (0, 0),
+                         "a skipped session costs no store load and no save")
+        for t in STORE_TIERS:
+            self.assertIsNotNone(jd.pass_watermark(t, SID), "%s: a skip stamps pass_done" % t)
+        self.assertEqual(self.unblock_calls, [], "no blocked goal, no unblocker call")
+
+    def test_counters_add_up_over_the_store_tiers(self):
+        self._session(SID)
+        self._converge()
+        for t in STORE_TIERS:
+            self.assertIsNotNone(self._stamp(t), t)
+        stats = jd.tier_stats()
+        for t in STORE_TIERS:
+            s = stats[t]
+            self.assertEqual(s["ran"], s["stamped"] + s["bypassed"] + s["incomplete"], t)
+        self.assertGreaterEqual(stats["stamps"], 6, "one stamp per tier for the sid")
+
+    def test_an_unframed_pass_stamps_the_store_only_tiers_and_bypasses_the_parse_tiers(self):
+        # the rule split (_gated): a parse tier's stamp needs the frame's served pair, so without a frame it
+        # runs and bypasses; a store-only tier has no frame-pinned component (the gate stats every input
+        # itself), so it stamps with or without one, and its next unframed run skips
+        self._session(SID)
+        self._converge()
+        store = jd.load_goals(SID)
+        top = self._tops()[0]
+        store["nodes"][top["id"]]["text"] = "Renamed by a kernel-side writer"
+        jd.save_goals(SID, store)                                       # re-arms all six tiers by identity
+        runners = {"plan": jd.run_plan, "close": jd.run_close, "unblock": jd.run_unblock, "group": jd.run_group,
+                   "consolidate": jd.run_consolidate, "distill": jd.run_distill}
+        jd.end_pass_frame(True)
+        self._reset()
+        jd._discover_cache.clear()
+        for t in ALL_TIERS:
+            runners[t](now=NOW)                                         # no begin_pass_frame anywhere
+        for t in ("plan", "close", "unblock"):
+            st = self._st(t)
+            self.assertEqual((st["ran"], st["bypassed"], st["stamped"]), (1, 1, 0), "%s: no frame, no stamp" % t)
+        for t in ("group", "consolidate", "distill"):
+            st = self._st(t)
+            self.assertEqual((st["ran"], st["bypassed"], st["stamped"]), (1, 0, 1), "%s: stamps without a frame" % t)
+        for _ in range(3):                                              # the store tiers' own writes re-arm once or twice
+            self._reset()
+            jd._discover_cache.clear()
+            for t in ("group", "consolidate", "distill"):
+                runners[t](now=NOW)
+            if all(self._st(t)["ran"] == 0 for t in ("group", "consolidate", "distill")):
+                break
+            for t in ("group", "consolidate", "distill"):
+                self.assertEqual(self._st(t)["bypassed"], 0, "%s: an unframed run that completes stamps" % t)
+        for t in ("group", "consolidate", "distill"):
+            self.assertEqual((self._st(t)["ran"], self._st(t)["skipped"]), (0, 1), "%s: the unframed stamp is honoured" % t)
+
+
+class StoreReArms(_Gate):
+    """Each input re-arms exactly the store tiers that read it (the runs, in STORE_TIERS order)."""
+
+    def _rearms(self, expect, msg):
+        self._reset()
+        self._pass(tiers=STORE_TIERS)
+        self.assertEqual(self._st4("ran"), expect, msg)
+
+    def test_a_store_publish_a_journal_append_and_an_archive_write_re_arm_all_four(self):
+        self._session(SID)
+        self._converge()
+        store = jd.load_goals(SID)
+        top = self._tops()[0]
+        store["nodes"][top["id"]]["text"] = "Renamed by a kernel-side writer"
+        jd.save_goals(SID, store)
+        self._rearms((1, 1, 1, 1), "a save_goals publish (a rename: new identity)")
+        self._converge()
+        jd.append_override(SID, top["id"], "resolve", NOW + 1)           # the user's gesture: the journal only
+        self._rearms((1, 1, 1, 1), "a journal append with no store write")
+        self.assertEqual(jd.load_goals(SID)["status"].get(top["id"]), "completed", "the replayed resolve took")
+        self._converge()
+        jd.save_goal_archive(SID, {"rompUuid": SID, "nodes": {}, "status": {}})
+        self._rearms((1, 1, 1, 1), "an archive write: in the grouper's and consolidator's signatures too "
+                                   "(compaction rewrites it with no journal row)")
+
+    def test_a_cleared_row_re_arms_the_grouper_and_consolidator_only(self):
+        self._session(SID)
+        self._converge()
+        with open(jd.STATE / "cleared.jsonl", "a") as f:
+            f.write(json.dumps({"id": SID2 + ":g1", "op": "clear", "t": NOW}) + "\n")
+        self._rearms((0, 1, 1, 0), "a cleared.jsonl row (whole-file identity): the two tiers whose candidate "
+                                   "forests read the view-cleared set")
+
+    def test_a_transcript_append_re_arms_the_unblocker_only(self):
+        path = self._session(SID)
+        self._converge()
+        self._append(path, uline(T0 + 200, "task C", "u3", "a2"), aline(T0 + 230, "did C", "a3", "u3"))
+        self._rearms((1, 0, 0, 0), "a transcript append: the parse pair is the unblocker's key and no one else's")
+        self.assertEqual(self.unblock_calls, [], "no blocked goal: the re-armed run made no call")
+
+    def test_a_states_row_re_arms_the_distiller_and_the_unblocker_not_the_grouper_or_consolidator(self):
+        self._session(SID)
+        self._converge()
+        self._states_row(SID, T0 + 300, "picker")
+        self._rearms((1, 0, 0, 1), "a states row entering picker: the distiller reads the states file, and the "
+                                   "unblocker's parse key names it")
+
+    def test_a_stall_record_for_this_sid_re_arms_the_distiller_and_another_sids_does_not(self):
+        self._session(SID)
+        self._converge()
+        top = self._tops()[0]
+        an = jd.STATE / "auto-nudge.json"
+        an.write_text(json.dumps({"enabled": False, "deferred": {SID2 + ":g1": {"at": NOW, "why": "the closer has not settled the turn", "sid": SID2}}}))
+        self._rearms((0, 0, 0, 0), "another sid's stall record")
+        an.write_text(json.dumps({"enabled": False, "deferred": {top["id"]: {"at": NOW, "why": "the closer has not settled the turn", "sid": SID}}}))
+        self._rearms((0, 0, 0, 1), "this sid's stall record: the staller owes the card a note")
+        self.assertIsNotNone(jd.load_goals(SID)["nodes"][top["id"]].get("stallSummary"), "and wrote it")
+
+
+class StoreOwnWrites(_Gate):
+    """A tier's own publish re-arms it once (the stamp holds the pre-run identity); the follow-on run finds
+    nothing to write and stamps; the third pass skips."""
+
+    def test_the_unblockers_lift_re_arms_it_once_then_it_skips(self):
+        path = self._session(SID)
+        self._converge()
+        top = self._tops()[0]
+        self._block(SID, top["id"], T0 + 150)
+        self._append(path, uline(T0 + 200, "the api binds 8080", "u3", "a2"), aline(T0 + 230, "noted", "a3", "u3"))
+        jd.unblock_llm = lambda blocks, since, completed="": (self.unblock_calls.append(blocks) or LIFT_ONE)
+        self._reset()
+        self._pass(tiers=("unblock",))
+        self.assertEqual(len(self.unblock_calls), 1, "one examine over the new turn")
+        self.assertNotEqual(jd.load_goals(SID)["status"].get(top["id"]), "blocked", "the lift filed")
+        self.assertEqual((self._st("unblock")["ran"], self._st("unblock")["stamped"]), (1, 1))
+        self._reset()
+        self._pass(tiers=("unblock",))
+        self.assertEqual((self._st("unblock")["ran"], self._st("unblock")["stamped"]), (1, 1),
+                         "the own publish re-armed it once; the follow-on run found nothing due")
+        self.assertEqual(len(self.unblock_calls), 1, "and made no call")
+        self._reset()
+        self._pass(tiers=("unblock",))
+        self.assertEqual((self._st("unblock")["ran"], self._st("unblock")["skipped"]), (0, 1))
+
+    def test_a_titling_re_arms_the_distiller_once_and_the_third_pass_skips(self):
+        # the design review's cross-tier convergence probe: _title_mirror_tops titles a mirror top and the
+        # caller saves, so the distiller's own publish re-arms it once; the follow-on run reads no
+        # transcript, writes nothing and stamps; the third pass skips
+        self._session(SID)
+        self._converge()
+        nid = self._mirror_top(SID, "add tests+docs for the search endpoint")
+        parses = []
+        real = self._saved_store[5]
+        jd.parsed_session = lambda *a, **k: (parses.append(a[0]) or real(*a, **k))
+        self._reset()
+        self._pass(tiers=("distill",))
+        self.assertEqual(self.title_calls, ["add tests+docs for the search endpoint"])
+        nd = jd.load_goals(SID)["nodes"][nid]
+        self.assertEqual((nd.get("text"), nd.get("declaredSubject")), ("Write the api tests", "add tests+docs for the search endpoint"))
+        self.assertTrue(nd.get("titledT"))
+        self.assertEqual((self._st("distill")["ran"], self._st("distill")["stamped"]), (1, 1), "the titling run completed")
+        self._reset()
+        io0 = dict(self.io)
+        parses.clear()
+        self._pass(tiers=("distill",))
+        io1 = dict(self.io)
+        self.assertEqual((self._st("distill")["ran"], self._st("distill")["stamped"]), (1, 1),
+                         "the own publish re-armed it once; the follow-on run stamps")
+        self.assertEqual(parses, [], "no transcript read on the idle path")
+        self.assertEqual(io1["saves"] - io0["saves"], 0, "nothing written")
+        self.assertEqual(len(self.title_calls), 1, "titled once, never re-derived")
+        self._reset()
+        self._pass(tiers=("distill",))
+        self.assertEqual((self._st("distill")["ran"], self._st("distill")["skipped"]), (0, 1))
+
+
+class StoreCompleteness(_Gate):
+    """A store-tier run that did not finish leaves no stamp, so the sid stays due."""
+
+    def _blocked_with_a_new_turn(self):
+        path = self._session(SID)
+        self._converge()
+        top = self._tops()[0]
+        self._block(SID, top["id"], T0 + 150)
+        self._append(path, uline(T0 + 200, "the api binds 8080", "u3", "a2"), aline(T0 + 230, "noted", "a3", "u3"))
+        return top
+
+    def test_a_stripped_unblocker_reply_keeps_the_sid_due_without_a_strike(self):
+        # patches _judge_run_impl, not unblock_llm: the helper strips its reply, so "   " reaches the stage as
+        # "" and takes the no-write return (a truthy raw would take the parse-strike path instead)
+        top = self._blocked_with_a_new_turn()
+        jd.unblock_llm = self._saved_store[0]                            # the real helper, over the belt
+        for reply in ("", "   "):
+            jd._judge_run_impl = lambda *a, **k: reply
+            self._reset()
+            io0 = dict(self.io)
+            self._pass(tiers=("unblock",))
+            s = self._st("unblock")
+            self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0), "reply %r" % reply)
+            self.assertEqual(self.io["saves"] - io0["saves"], 0, "no save")
+            self.assertFalse(jd.load_goals(SID).get("unblockFails"), "no strike burned on a failed call")
+        jd.unblock_llm = lambda blocks, since, completed="": ""         # the helper itself returned nothing, above
+        self._reset()                                                    # the belt: the stage's own mark decides
+        io0 = dict(self.io)
+        self._pass(tiers=("unblock",))
+        s = self._st("unblock")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0), "an empty helper reply")
+        self.assertEqual(self.io["saves"] - io0["saves"], 0, "no save")
+        jd.unblock_llm = self._saved_store[0]
+        jd._judge_run_impl = lambda *a, **k: LIFT_ONE
+        self._reset()
+        self._pass(tiers=("unblock",))
+        self.assertEqual(self._st("unblock")["stamped"], 1, "a served reply completes the run")
+        self.assertNotEqual(jd.load_goals(SID)["status"].get(top["id"]), "blocked")
+
+    def test_a_stripped_grouper_or_consolidator_reply_keeps_the_sid_due_without_a_strike(self):
+        self._session(SID)
+        self._pass(tiers=("plan", "close"))                            # two open tops: the grouper has a menu
+        store = jd.load_goals(SID)
+        store.pop("groupedSig", None)                                    # the planner groups inline after each placement
+        jd.save_goals(SID, store)                                        # and recorded the set already: re-open the gate
+        jd.group_llm = self._saved[3]                                    # the real helper, over the belt
+        for reply in ("", "   "):
+            jd._judge_run_impl = lambda *a, **k: reply
+            self._reset()
+            io0 = dict(self.io)
+            self._pass(tiers=("group",))
+            s = self._st("group")
+            self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0), "grouper, reply %r" % reply)
+            self.assertEqual(self.io["saves"] - io0["saves"], 0, "no save")
+            self.assertFalse(jd.load_goals(SID).get("groupFails"), "no strike")
+        jd.group_llm = lambda menu, judge="grouper": ""                  # the helper itself returned nothing, above
+        self._reset()                                                    # the belt: the stage's own mark decides
+        io0 = dict(self.io)
+        self._pass(tiers=("group",))
+        s = self._st("group")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0), "grouper, an empty helper reply")
+        self.assertEqual(self.io["saves"] - io0["saves"], 0, "no save")
+        jd.group_llm = self._saved[3]
+        jd._judge_run_impl = lambda *a, **k: '{"ops":[]}'
+        self._reset()
+        self._pass(tiers=("group",))
+        self.assertEqual(self._st("group")["stamped"], 1, "a served reply completes the run (groupedSig written)")
+        # the consolidator: two COMPLETED tops (resolved, and the focus top's pending settle forced through:
+        # a done verdict on the last node exports as confirming until the session settles, and the
+        # consolidator's menu is the completed status alone), then the same probe over that menu
+        for top in self._tops():
+            jd.append_override(SID, top["id"], "resolve", NOW + 1)
+        store = jd.load_goals(SID)
+        for top in self._tops():
+            store["status"][top["id"]] = "completed"
+        store["confirming"] = []
+        jd.save_goals(SID, store)
+        self.assertEqual(len(jd._consolidate_tops(jd.load_goals(SID))), 2, "fixture: the consolidator has a menu")
+        for reply in ("", "   "):
+            jd._judge_run_impl = lambda *a, **k: reply
+            self._reset()
+            io0 = dict(self.io)
+            self._pass(tiers=("consolidate",))
+            s = self._st("consolidate")
+            self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0), "consolidator, reply %r" % reply)
+            self.assertEqual(self.io["saves"] - io0["saves"], 0, "no save")
+            self.assertFalse(jd.load_goals(SID).get("consolidateFails"), "no strike")
+        jd.group_llm = lambda menu, judge="grouper": ""
+        self._reset()
+        io0 = dict(self.io)
+        self._pass(tiers=("consolidate",))
+        s = self._st("consolidate")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0), "consolidator, an empty helper reply")
+        self.assertEqual(self.io["saves"] - io0["saves"], 0, "no save")
+        jd.group_llm = self._saved[3]
+        jd._judge_run_impl = lambda *a, **k: '{"ops":[]}'
+        self._reset()
+        self._pass(tiers=("consolidate",))
+        self.assertEqual(self._st("consolidate")["stamped"], 1)
+
+    def test_a_paused_title_call_keeps_the_distiller_due(self):
+        self._session(SID)
+        self._converge()
+        nid = self._mirror_top(SID, "add tests+docs for the search endpoint")
+        jd.mirror_title_llm = self._saved_store[4]                       # the real helper, over the belt
+
+        def paused(*a, **k):
+            jd._judge_ctx.paused = True                                  # what the real call does under retry-paused.json
+            return ""
+        jd._judge_run_impl = paused
+        self._reset()
+        io0 = dict(self.io)
+        self._pass(tiers=("distill",))
+        s = self._st("distill")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0), "a pause-skipped titling leaves the sid due")
+        self.assertEqual(self.io["saves"] - io0["saves"], 0)
+        self.assertFalse(jd.load_goals(SID)["nodes"][nid].get("titledT"), "not stamped: the next pass retries")
+        jd.mirror_title_llm = paused                                     # the helper itself pause-skipped, above the
+        self._reset()                                                    # belt: _title_mirror_tops' own mark decides
+        self._pass(tiers=("distill",))
+        s = self._st("distill")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0), "a pause-skip above the belt")
+        self.assertFalse(jd.load_goals(SID)["nodes"][nid].get("titledT"))
+        jd.mirror_title_llm = self._saved_store[4]
+
+        def served(*a, **k):
+            jd._judge_ctx.paused = False
+            return "Write the api tests"
+        jd._judge_run_impl = served
+        self._reset()
+        self._pass(tiers=("distill",))
+        self.assertEqual(self._st("distill")["stamped"], 1)
+        self.assertEqual(jd.load_goals(SID)["nodes"][nid].get("text"), "Write the api tests")
+
+    def test_a_paused_stall_brief_or_brief_retry_call_keeps_the_distiller_due(self):
+        # the distiller's three other paused continues, each reached with the helper patched ABOVE the belt so
+        # the stage's own mark is the one that decides: the staller (a stall record for this sid), the briefer
+        # (a blocked top owed one decision) and the briefer's shortfall retry (two blocked nodes under one top:
+        # the draft covers one, the corrective retry is pause-skipped)
+        self._session(SID)
+        self._converge()
+        top = self._tops()[0]["id"]
+
+        def paused(*a, **k):
+            jd._judge_ctx.paused = True
+            return ""
+        an = jd.STATE / "auto-nudge.json"
+        an.write_text(json.dumps({"enabled": False, "deferred": {top: {"at": NOW, "why": "the closer has not settled the turn", "sid": SID}}}))
+        jd.stall_llm = paused
+        self._reset()
+        self._pass(tiers=("distill",))
+        s = self._st("distill")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0), "the staller's paused continue marks the run")
+        nd = jd.load_goals(SID)["nodes"][top]
+        self.assertIsNone(nd.get("stallSummary"))
+        self.assertFalse(nd.get("stallFails"), "a pause-skip is not a strike")
+        jd._judge_ctx.paused = False
+        an.write_text(json.dumps({"enabled": False, "deferred": {}}))    # the stall ends; the top is blocked instead
+        self._block(SID, top, T0 + 150)
+        jd.brief_llm = paused
+        self._reset()
+        self._pass(tiers=("distill",))
+        s = self._st("distill")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0), "the briefer's paused continue marks the run")
+        nd = jd.load_goals(SID)["nodes"][top]
+        self.assertIsNone(nd.get("blockSummary"))
+        self.assertFalse(nd.get("briefFails"), "a pause-skip is not a strike")
+        jd._judge_ctx.paused = False
+        store = jd.load_goals(SID)                                       # a second owed decision under the same top
+        kid = SID + ":g91"
+        store["nodes"][kid] = {"id": kid, "text": "Choose the api's auth scheme", "parentId": top, "why": "x",
+                               "t": T0 + 300, "mt": T0 + 300, "log": [], "trail": [], "nodeComplete": False, "cleared": False}
+        jd.save_goals(SID, store)
+        self._block(SID, kid, T0 + 160, why="Which auth scheme should the api use?")
+        shortfalls = []
+
+        def draft_then_paused_retry(text, work, owed, **kw):
+            shortfalls.append(kw.get("shortfall"))
+            if kw.get("shortfall") is not None:                          # the corrective retry: pause-skipped
+                jd._judge_ctx.paused = True
+                return ""
+            return "Pick the port the api binds."                        # one paragraph for two owed decisions
+        jd.brief_llm = draft_then_paused_retry
+        self._reset()
+        self._pass(tiers=("distill",))
+        s = self._st("distill")
+        self.assertEqual(shortfalls, [None, (1, 2)], "the draft, then the retry naming the shortfall")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0), "the retry's paused continue marks the run")
+        self.assertIsNone(jd.load_goals(SID)["nodes"][top].get("blockSummary"), "the brief stays owed")
+        jd._judge_ctx.paused = False
+        jd.brief_llm = lambda text, work, owed, **kw: "Pick the port the api binds.\n\nUse bearer tokens."
+        self._converge(tiers=("distill",))
+        self.assertTrue(jd.load_goals(SID)["nodes"][top].get("blockSummary"), "unpaused, the brief lands and the tier settles")
+
+    def test_a_paused_distill_call_keeps_the_sid_due_and_a_failed_one_writes_the_strike(self):
+        self._session(SID)
+        self._converge()
+        top = self._tops()[0]
+        jd.append_override(SID, top["id"], "resolve", NOW + 1)           # completed: a summary is owed
+
+        def paused(*a, **k):
+            jd._judge_ctx.paused = True
+            return ""
+        jd.distill_llm = paused
+        self._reset()
+        self._pass(tiers=("distill",))
+        s = self._st("distill")
+        self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0), "the paused continue marks the run")
+        nd = jd.load_goals(SID)["nodes"][top["id"]]
+        self.assertIsNone(nd.get("summary"))
+        self.assertFalse(nd.get("distillFails"), "a pause-skip is not a strike")
+        jd._judge_ctx.paused = False
+        jd.distill_llm = lambda *a, **k: ""                              # a real failure, past the belt
+        self._reset()
+        self._pass(tiers=("distill",))
+        self.assertEqual(jd.load_goals(SID)["nodes"][top["id"]].get("distillFails"), 1, "the strike is written")
+        self.assertEqual(self._st("distill")["ran"], 1)
+        self._reset()
+        self._pass(tiers=("distill",))
+        self.assertEqual(self._st("distill")["ran"], 1, "the strike's publish re-armed the tier by identity")
+        self.assertEqual(jd.load_goals(SID)["nodes"][top["id"]].get("distillFails"), 2, "and it retried")
+        jd.distill_llm = lambda *a, **k: "Shipped the search endpoint."
+        self._reset()
+        self._pass(tiers=("distill",))
+        self.assertEqual(jd.load_goals(SID)["nodes"][top["id"]].get("summary"), "Shipped the search endpoint.")
+        self._converge(tiers=("distill",))
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_a_store_that_does_not_read_never_stamps(self):
+        # a goals file that exists and cannot be read RAISES out of load_goals (never an empty fallback): every
+        # tier dies at its load, _gated counts the run incomplete, the runner files its pass-crash row and
+        # nothing is written, so the sid stays due until the file reads. Nothing on disk moves when a
+        # permission bit or a descriptor failure clears, so a stamp here would skip the session for good
+        self._session(SID)
+        self._converge()
+        gp = jd.GOALDIR / (SID + ".json")
+        good = gp.read_bytes()
+        os.chmod(gp, 0)
+        try:
+            os.utime(gp, ns=(os.stat(gp).st_atime_ns, os.stat(gp).st_mtime_ns + 1_000_000_000))   # re-arm: chmod moves ctime only
+            for _ in range(2):
+                self._reset()
+                self._pass(tiers=ALL_TIERS)
+                for t in ALL_TIERS:
+                    s = self._st(t)
+                    self.assertEqual((s["ran"], s["incomplete"], s["stamped"]), (1, 1, 0),
+                                     "%s: a load that raises counts the run incomplete, so the sid stays due" % t)
+            rows = [json.loads(l) for l in open(jd.ERRORS) if l.strip()]
+            self.assertEqual(sum(r.get("err") == "pass-crash" for r in rows), 2 * len(ALL_TIERS),
+                             "one pass-crash row per tier per pass, as for any raised run")
+        finally:
+            os.chmod(gp, 0o644)
+        self.assertEqual(gp.read_bytes(), good, "no tier wrote")
+        self._reset()
+        self._pass(tiers=ALL_TIERS)
+        self.assertEqual(tuple(self._st(t)["stamped"] for t in ALL_TIERS), (1,) * len(ALL_TIERS),
+                         "readable again: every tier runs to completion and stamps")
+
+    def test_a_store_that_does_not_parse_is_moved_aside_and_the_fresh_store_is_judged(self):
+        # bytes that do not parse are quarantined aside by load_goals (<file>.corrupt-<stamp>, one
+        # store-quarantined row) and the fresh store is then what the path holds, so the tiers run to
+        # completion over it and stamp: no run is judged from a view the files contradict, and no tier crashes
+        self._session(SID)
+        self._converge()
+        gp = jd.GOALDIR / (SID + ".json")
+        gp.write_text("{ not the store")
+        self._reset()
+        self._pass(tiers=STORE_TIERS)
+        self.assertEqual(self._st4("ran"), (1, 1, 1, 1))
+        self.assertEqual(self._st4("incomplete"), (0, 0, 0, 0), "the fresh store is the files' content: no mark")
+        aside = sorted(jd.GOALDIR.glob(SID + ".json.corrupt-*"))
+        self.assertEqual(len(aside), 1, "the bad bytes were moved aside once")
+        self.assertEqual(aside[0].read_text(), "{ not the store")
+        rows = [json.loads(l) for l in open(jd.ERRORS) if l.strip()]
+        self.assertEqual(sum(r.get("err") == "store-quarantined" for r in rows), 1)
+        self.assertEqual(sum(r.get("err") == "pass-crash" for r in rows), 0, "no tier crashed")
+        self._converge(tiers=STORE_TIERS)                                # and the fresh store converges like any other
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_an_unreadable_journal_never_stamps(self):
+        self._session(SID)
+        self._converge()
+        top = self._tops()[0]
+        jd.append_override(SID, top["id"], "resolve", NOW + 1)
+        self._converge()
+        jp = jd._overrides_dir() / (SID + ".jsonl")
+        os.chmod(jp, 0)
+        try:
+            os.utime(jp, ns=(os.stat(jp).st_atime_ns, os.stat(jp).st_mtime_ns + 1_000_000_000))   # re-arm: chmod moves ctime only
+            self._reset()
+            self._pass(tiers=STORE_TIERS)
+            self.assertEqual(self._st4("ran"), (1, 1, 1, 1))
+            self.assertEqual(self._st4("incomplete"), (1, 1, 1, 1), "_replay_overrides' unreadable branch marks the run")
+            self.assertEqual(self._st4("stamped"), (0, 0, 0, 0))
+            rows = [json.loads(l) for l in open(jd.ERRORS) if l.strip()]
+            self.assertTrue(any(r.get("err") == "history-unreadable" for r in rows), "the loud row stays per pass")
+        finally:
+            os.chmod(jp, 0o644)
+        self._reset()
+        self._pass(tiers=STORE_TIERS)
+        self.assertEqual(self._st4("stamped"), (1, 1, 1, 1), "readable again: complete runs stamp")
+
+
+class UnblockerHazard(_Gate):
+    def test_a_turn_ending_after_the_first_touch_is_judged_next_pass_by_the_unblocker(self):
+        # the design review's hazard, on the unblocker: a tick job touches the session while its last turn is
+        # OPEN and a top is blocked; the turn's final record and the idle row land; the gated unblocker runs
+        # and finds nothing due under the pinned parse. Its stamp must hold the PRE-append pair, so the next
+        # pass runs it over the ended turn and the lift files. Without the frame's parse-key pin
+        # (_frame_parse_key) this test fails.
+        path = self._session(SID)
+        self._converge(tiers=("plan", "close"))
+        top = self._tops()[0]
+        self._block(SID, top["id"], T0 + 150)                            # after both ended turns
+        self._append(path, uline(T0 + 200, "use port 8080 for the api", "u3", "a2"),
+                     aline(T0 + 210, "starting on it", "a3", "u3", stop="tool_use"))
+        jd.unblock_llm = lambda blocks, since, completed="": (self.unblock_calls.append(since) or LIFT_ONE)
+        own = jd.begin_pass_frame()
+        try:
+            jd.parsed_session(SID, [str(path)], NOW)                     # the tick job's first touch, turn open
+            pre = jd._frame["keys"][("parse", SID)]
+            self._append(path, aline(T0 + 240, "bound to 8080", "a4", "a3"))
+            self._states_row(SID, T0 + 241, "idle")
+            jd.run_unblock(now=NOW)
+        finally:
+            jd.end_pass_frame(own)
+        self.assertEqual(self.unblock_calls, [], "under the pinned parse the turn is open: nothing due, no call")
+        st = self._stamp("unblock")
+        self.assertIsNotNone(st, "the run completed and stamped")
+        self.assertEqual(st[0][0][1], jd._pair_key(pre), "the stamp holds the PRE-append pair")
+        self._reset()
+        self._pass(tiers=("unblock",))
+        self.assertEqual(self._st("unblock")["ran"], 1, "the live pair differs from the stamped one: the tier runs")
+        self.assertEqual(len(self.unblock_calls), 1, "and examines the ended turn")
+        self.assertIn("bound to 8080", self.unblock_calls[0])
+        self.assertNotEqual(jd.load_goals(SID)["status"].get(top["id"]), "blocked", "the lift filed")
+
+
+class DrainStaysUngated(_Gate):
+    def test_the_drain_distills_an_absent_stuck_store_regardless_of_stamps(self):
+        # a store no discovered session owns (no transcript for SID2) holding a completed top with a null
+        # summary: _drain_undiscovered reaches it on every distill pass; it never holds a stamp to skip on
+        self._session(SID)
+        self._converge()
+        nid = SID2 + ":g1"
+        store = jd.load_goals(SID2)
+        store["nodes"][nid] = {"id": nid, "text": "Ship the search", "parentId": None, "nodeComplete": True,
+                               "cleared": False, "t": T0, "mt": T0 + 60, "trail": [],
+                               "log": [{"kind": "done", "ev_t": T0 + 60, "at": T0 + 60, "src": "closer", "why": "landed"}]}
+        store["status"][nid] = "completed"
+        jd.save_goals(SID2, store)
+        self._reset()
+        self._pass(tiers=("distill",))
+        self.assertEqual(jd.load_goals(SID2)["nodes"][nid].get("summary"), "",
+                         "no transcript, no work: the sentinel, written by the ungated drain")
+        self.assertIsNone(self._stamp("distill", SID2), "the drain leaves no stamp")
+        self.assertEqual(self._st("distill")["ran"], 0, "the discovered sid skipped; the drain is not a gated run")
 
 
 if __name__ == "__main__":

--- a/tests/test_judge_store_cas.py
+++ b/tests/test_judge_store_cas.py
@@ -358,15 +358,17 @@ class ReadFaultCas(unittest.TestCase):
         self.assertEqual(self._file().read_bytes(), before,
                          "the publish did not go ahead over bytes it failed to compare against")
 
-    def test_a_raise_inside_the_cas_loop_leaves_the_object_base_less(self):
-        # the documented window (save_goals' docstring, 2026-09-06): the base is popped before the CAS loop
-        # and re-stamped only after the rename, so a raise between the two leaves the object without a base
-        # and its next save unconditional, as every save was before the re-stamp. The read-fault cases
-        # above raise inside _matches_disk, BEFORE the pop, so they do not reach this window; here the
-        # revision read inside the loop is what fails
+    def test_a_raise_inside_the_cas_loop_keeps_the_object_cas_protected(self):
+        # the window save_goals' docstring left documented on 2026-09-06 (the base popped before the CAS loop,
+        # re-stamped only after the rename, so a raise between the two left the object base-less and its next
+        # save unconditional) is closed (review find, 2026-09-08): when the publish did not happen the object
+        # keeps the base it was loaded at, so the holder's retry is CAS-protected too. The read-fault cases
+        # above raise inside _matches_disk, BEFORE the pop; here the revision read inside the loop fails, then
+        # the rename itself, and then a retry meets a concurrent publish
         self._seed()
         before = self._file().read_bytes()
         s = jd.load_goals(self.FSID)
+        base = s["_baseRev"]
         jd.record_verdict(s, s["nodes"][self._gid()], "planner", "done", T0 + 30, why="shipped")
         real = jd._disk_rev
 
@@ -378,8 +380,26 @@ class ReadFaultCas(unittest.TestCase):
                 jd.save_goals(self.FSID, s)
         finally:
             jd._disk_rev = real
-        self.assertNotIn("_baseRev", s, "popped before the loop, and the raise came before the re-stamp")
+        self.assertEqual(s.get("_baseRev"), base, "a raise inside the loop: the object keeps the base it was loaded at")
         self.assertEqual(self._file().read_bytes(), before, "nothing was published")
+
+        def no_rename(path, target):
+            raise OSError(errno.EIO, "Input/output error", str(target))
+        with mock.patch.object(Path, "rename", no_rename):
+            with self.assertRaises(OSError):
+                jd.save_goals(self.FSID, s)
+        self.assertEqual(s.get("_baseRev"), base, "a raise at the rename: the base is restored too")
+        self.assertEqual(self._file().read_bytes(), before, "nothing was published")
+        other = jd.load_goals(self.FSID)             # a concurrent writer publishes between the failure and the retry
+        jd.apply_plan(other, "s2", T0 + 40, [{"do": "mint", "why": "x", "text": "Their new goal"}],
+                      jd.open_menu(other))
+        jd.save_goals(self.FSID, other)
+        jd.save_goals(self.FSID, s)                  # the retry: CAS-protected, so it rebases instead of stomping
+        after = jd.load_goals(self.FSID)
+        self.assertIn("%s:g2" % self.FSID, after["nodes"], "the other writer's node survives the retried save")
+        kinds = {(e.get("src"), e.get("kind")) for e in after["nodes"][self._gid()].get("log") or []}
+        self.assertIn(("planner", "done"), kinds, "and our verdict landed")
+        self.assertEqual(s.get("_baseRev"), after["rev"], "the retry re-stamped the written revision as the base")
 
     def test_a_file_corrupted_after_load_is_not_overwritten_by_the_save(self):
         """The save path never quarantines (that is load's job, after the evidence is preserved): a store

--- a/tests/test_judge_store_cas.py
+++ b/tests/test_judge_store_cas.py
@@ -225,6 +225,55 @@ class StoreCas(unittest.TestCase):
         blocks = [e for e in log if e.get("kind") == "block" and int(e.get("ev_t") or 0) == T0 + 100]
         self.assertEqual(len(blocks), 1, "the same verdict from both writers folds to one entry")
 
+    def test_a_second_save_of_the_same_store_still_rebases(self):
+        # One holder saving the SAME store twice (the planner saves its store several times per pass;
+        # the distiller saves after titling and again after distilling): the first publish popped the
+        # base and nothing restored it, so every later save of the object took the unconditional branch
+        # and wrote over whatever a concurrent writer published in between (review 2026-09-06).
+        self._seed()
+        gid = self._nid(1)
+        s = jd.load_goals(SID)
+        jd.record_verdict(s, s["nodes"][gid], "planner", "done", T0 + 30, why="shipped")
+        jd.save_goals(SID, s)                        # our first publish
+        other = jd.load_goals(SID)                   # a kernel-side writer, between our two saves
+        jd.apply_plan(other, "s2", T0 + 40, [{"do": "mint", "why": "x", "text": "Their new goal"}],
+                      jd.open_menu(other))
+        jd.save_goals(SID, other)
+        s["nodes"][gid]["summary"] = "Shipped the exporter end to end."   # our second change, SAME object
+        s["nodes"][gid]["distilledMt"] = T0 + 500
+        jd.save_goals(SID, s)                        # must rebase onto their publish, not clobber it
+        after = jd.load_goals(SID)
+        self.assertIn(self._nid(2), after["nodes"], "the other writer's node survives our second save")
+        self.assertEqual(after["nodes"][gid].get("summary"), "Shipped the exporter end to end.",
+                         "and our second change landed too")
+        self.assertNotIn("_baseRev", json.loads((jd.GOALDIR / (SID + ".json")).read_text()),
+                         "the re-stamped base is still never written to disk")
+
+    def test_a_second_uncontended_save_of_the_same_object_does_not_rebase(self):
+        # the re-stamp is exact: the base after a publish is the revision that publish wrote, so a second
+        # save with nobody else publishing in between finds disk == base and never rebases (a stale
+        # re-stamp would rebase every second save; no re-stamp would leave the object base-less)
+        self._seed()
+        gid = self._nid(1)
+        s = jd.load_goals(SID)
+        jd.record_verdict(s, s["nodes"][gid], "planner", "done", T0 + 30, why="shipped")
+        jd.save_goals(SID, s)                        # our first publish
+        r1 = jd._disk_rev(SID)
+        s["nodes"][gid]["summary"] = "Shipped the exporter end to end."   # our second change, SAME object
+        calls, real = [], jd._rebase_onto_disk
+
+        def spy(fsid, store):
+            calls.append(fsid)
+            return real(fsid, store)
+        jd._rebase_onto_disk = spy
+        try:
+            jd.save_goals(SID, s)
+        finally:
+            jd._rebase_onto_disk = real
+        self.assertEqual(calls, [], "nobody else published: the base is the revision the first save wrote")
+        self.assertEqual(jd._disk_rev(SID), r1 + 1)
+        self.assertEqual(s.get("_baseRev"), r1 + 1, "and the object now carries that revision as its base")
+
     def test_an_uncontended_save_does_not_rebase(self):
         self._seed()
         gid = self._nid(1)
@@ -308,6 +357,29 @@ class ReadFaultCas(unittest.TestCase):
                 jd.save_goals(self.FSID, s)
         self.assertEqual(self._file().read_bytes(), before,
                          "the publish did not go ahead over bytes it failed to compare against")
+
+    def test_a_raise_inside_the_cas_loop_leaves_the_object_base_less(self):
+        # the documented window (save_goals' docstring, 2026-09-06): the base is popped before the CAS loop
+        # and re-stamped only after the rename, so a raise between the two leaves the object without a base
+        # and its next save unconditional, as every save was before the re-stamp. The read-fault cases
+        # above raise inside _matches_disk, BEFORE the pop, so they do not reach this window; here the
+        # revision read inside the loop is what fails
+        self._seed()
+        before = self._file().read_bytes()
+        s = jd.load_goals(self.FSID)
+        jd.record_verdict(s, s["nodes"][self._gid()], "planner", "done", T0 + 30, why="shipped")
+        real = jd._disk_rev
+
+        def faulting(fsid):
+            raise OSError(errno.EIO, "Input/output error", fsid)
+        jd._disk_rev = faulting
+        try:
+            with self.assertRaises(OSError):
+                jd.save_goals(self.FSID, s)
+        finally:
+            jd._disk_rev = real
+        self.assertNotIn("_baseRev", s, "popped before the loop, and the raise came before the re-stamp")
+        self.assertEqual(self._file().read_bytes(), before, "nothing was published")
 
     def test_a_file_corrupted_after_load_is_not_overwritten_by_the_save(self):
         """The save path never quarantines (that is load's job, after the evidence is preserved): a store

--- a/tests/test_judge_store_noop_publish.py
+++ b/tests/test_judge_store_noop_publish.py
@@ -100,6 +100,33 @@ class NoOpPublish(unittest.TestCase):
         jd.save_goals(SID, raw)
         self.assertGreater(jd._disk_rev(SID), rev)
 
+    def test_a_store_built_without_load_goals_stays_unconditional_across_saves(self):
+        """The post-publish re-stamp of `_baseRev` (2026-09-06) is for stores that carried a base: a save
+        stamps none on a hand-built store, so its second save is still published unconditionally, not
+        no-op-checked against a base it never had."""
+        self._seed()
+        raw = json.loads(self._file().read_text())      # hand-built store, never through load_goals
+        jd.save_goals(SID, raw)
+        rev = jd._disk_rev(SID)
+        self.assertNotIn("_baseRev", raw, "a save stamps no base on a store that never carried one")
+        jd.save_goals(SID, raw)                          # no change at all
+        self.assertEqual(jd._disk_rev(SID), rev + 1,
+                         "a hand-built store is still published unconditionally, not no-op-checked")
+
+    def test_a_second_unchanged_save_of_the_same_object_is_a_no_op(self):
+        """A loaded store keeps its base across saves (2026-09-06), so the holder's later saves reach the
+        no-op check: the planner's rollup-and-save at the end of a pass that changed nothing after its
+        earlier save rewrites no bytes."""
+        self._seed()
+        s = jd.load_goals(SID)
+        gid = "%s:g1" % SID
+        jd.record_verdict(s, s["nodes"][gid], "planner", "done", T0 + 30, why="shipped")
+        jd.save_goals(SID, s)                            # a real publish
+        rev, mt = jd._disk_rev(SID), os.stat(self._file()).st_mtime_ns
+        jd.save_goals(SID, s)                            # the same object, unchanged since
+        self.assertEqual(jd._disk_rev(SID), rev, "the second save is a no-op: no revision")
+        self.assertEqual(os.stat(self._file()).st_mtime_ns, mt, "...and the file is untouched")
+
     def test_a_no_op_save_cannot_clobber_a_concurrent_writer(self):
         """Pass A loads and changes nothing; writer B publishes a real event meanwhile. The skip compares
         against DISK, and disk has moved, so A does NOT skip here — it takes the rebase path and folds B's

--- a/tests/test_kernel_tick_jobs_under_frame.py
+++ b/tests/test_kernel_tick_jobs_under_frame.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""A pusher tick job that parses a session while a judge pass frame is open reads the frame's world, on a
+cache HIT as on a miss (the hit-path pin, review 2026-09-06). The frame is a module global in the judge, so
+the kernel's tick jobs (_clear_done_working_notes, _interrupt_block_tick, _closer_pending, ...) share it
+with the pass: a warm session they touch mid-pass is the pass's frozen parse, not the live file, and a turn
+that ends after the pass's first touch is judged whole in the next pass. Before the pin, a warm hit returned
+unpinned and the job read the live transcript under an open frame (the two-worlds shape).
+SYNTHETIC fixtures only."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_tickframe", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-555555555555"
+T0 = 1781100000
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None, stop="end_turn"):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": stop}}
+
+
+class WarmTickJobUnderAFrame(unittest.TestCase):
+    """_clear_done_working_notes lifts a session's working note once its last turn has ENDED with no open
+    top goal; an open turn keeps it. That decision is the job's read of parsed_session, so it shows which
+    world the job saw."""
+
+    def setUp(self):
+        self.td = Path(tempfile.mkdtemp())
+        jd._rebind_state(self.td)
+        self.path = self.td / (SID + ".jsonl")
+        recs = [uline(T0, "start the work", "u1"),
+                aline(T0 + 10, "Working on it now, first step underway.", "a1", "u1", stop="tool_use")]
+        self.path.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        jd.end_pass_frame(True)          # belt: never inherit a frame a crashed test left open
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()   # the cache-hit premise must not ride an earlier test's entry
+        self.lifted = []
+        self._saved = (km._working_notes, km._alive_sessions, km._open_top_goal, km._set_working_note,
+                       km._suspended_after)
+        km._working_notes = lambda: {SID: "owns the api worktree"}
+        km._alive_sessions = lambda now, tmux: [{"sid": SID, "path": str(self.path)}]
+        km._open_top_goal = lambda sid: False
+        km._set_working_note = lambda sid, text: self.lifted.append((sid, text))
+        km._suspended_after = lambda t: False
+
+    def tearDown(self):
+        jd.end_pass_frame(True)
+        (km._working_notes, km._alive_sessions, km._open_top_goal, km._set_working_note,
+         km._suspended_after) = self._saved
+
+    def _append(self, rec):
+        with open(self.path, "a") as f:
+            f.write(json.dumps(rec) + "\n")
+
+    def test_a_warm_hit_holds_the_open_turn_for_the_whole_pass(self):
+        warm = jd.parsed_session(SID, [str(self.path)], T0 + 100)     # frameless: fills the cache, turn open
+        self.assertFalse(warm["turns"][-1]["ended"], "premise: the cached parse holds an open turn")
+        self.assertTrue(jd.begin_pass_frame())
+        km._clear_done_working_notes(T0 + 100, {})                      # the pass's first touch: a cache HIT
+        self.assertEqual(self.lifted, [], "premise: an open turn keeps the note")
+        self.assertIs(jd._frame["parses"].get(SID), warm, "the tick job's warm hit is pinned into the pass frame")
+        self._append(aline(T0 + 60, "All done: shipped and verified.", "a2", "a1", stop="end_turn"))
+        km._clear_done_working_notes(T0 + 100, {})
+        self.assertEqual(self.lifted, [], "mid-pass the job reads the frame's world, where the turn is still open")
+        self.assertFalse(jd._frame["parses"][SID]["turns"][-1]["ended"], "the mid-pass append stays out of this pass")
+        jd.end_pass_frame(True)
+        km._clear_done_working_notes(T0 + 100, {})
+        self.assertEqual(self.lifted, [(SID, "")], "the next pass sees the ended turn, whole, and lifts the claim")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_tick_jobs_under_frame.py
+++ b/tests/test_kernel_tick_jobs_under_frame.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
-"""A pusher tick job that parses a session while a judge pass frame is open reads the frame's world, on a
-cache HIT as on a miss (the hit-path pin, review 2026-09-06). The frame is a module global in the judge, so
-the kernel's tick jobs (_clear_done_working_notes, _interrupt_block_tick, _closer_pending, ...) share it
-with the pass: a warm session they touch mid-pass is the pass's frozen parse, not the live file, and a turn
-that ends after the pass's first touch is judged whole in the next pass. Before the pin, a warm hit returned
-unpinned and the job read the live transcript under an open frame (the two-worlds shape).
+"""A pusher tick job that parses a session while a judge pass frame is open reads the LIVE world (review find,
+2026-09-08). The frame is a module global in the judge, but its pin is scoped to the pass's own threads
+(jd._pass_frame: the thread that opened or joined the frame, and the judge's pool workers). The kernel's tick
+jobs (_clear_done_working_notes, _interrupt_block_tick, _closer_pending, ...) run on the pusher thread, which
+never joins a frame, so a turn that ends mid-pass reaches them at the next cycle instead of after the tiers'
+whole run, model calls included. Before the scoping, the warm-hit pin (2026-09-06) froze every tick job to the
+pass-start world for as long as the tiers ran; before that pin, a cold first touch by a tick job did the same
+for the session it parsed. The frame's own job is untouched: the judge stages share one world, and a pass
+thread's touch pins what a tick job just read live.
 SYNTHETIC fixtures only."""
 import json
 import os
 import tempfile
+import threading
 import unittest
 from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
@@ -44,10 +48,11 @@ def aline(t, text, uuid, parent=None, stop="end_turn"):
                         "stop_reason": stop}}
 
 
-class WarmTickJobUnderAFrame(unittest.TestCase):
+class TickJobUnderAFrame(unittest.TestCase):
     """_clear_done_working_notes lifts a session's working note once its last turn has ENDED with no open
     top goal; an open turn keeps it. That decision is the job's read of parsed_session, so it shows which
-    world the job saw."""
+    world the job saw. Three threads, as in the kernel: the producer opens the frame, the pusher runs the
+    tick job, and the test thread stands in for a tier (it joins the frame when a pass thread is needed)."""
 
     def setUp(self):
         self.td = Path(tempfile.mkdtemp())
@@ -76,20 +81,53 @@ class WarmTickJobUnderAFrame(unittest.TestCase):
         with open(self.path, "a") as f:
             f.write(json.dumps(rec) + "\n")
 
-    def test_a_warm_hit_holds_the_open_turn_for_the_whole_pass(self):
+    def _on(self, name, fn, *a):
+        """Run fn on a fresh thread called `name` and hand back its result (an exception re-raises here)."""
+        out, err = [], []
+
+        def run():
+            try:
+                out.append(fn(*a))
+            except BaseException as e:
+                err.append(e)
+        t = threading.Thread(target=run, name=name)
+        t.start(); t.join(10)
+        self.assertFalse(t.is_alive(), "%s finished" % name)
+        if err:
+            raise err[0]
+        return out[0]
+
+    def _tick(self):
+        return self._on("pusher", km._clear_done_working_notes, T0 + 100, {})
+
+    def test_a_tick_job_reads_the_live_world_under_an_open_frame(self):
         warm = jd.parsed_session(SID, [str(self.path)], T0 + 100)     # frameless: fills the cache, turn open
         self.assertFalse(warm["turns"][-1]["ended"], "premise: the cached parse holds an open turn")
-        self.assertTrue(jd.begin_pass_frame())
-        km._clear_done_working_notes(T0 + 100, {})                      # the pass's first touch: a cache HIT
+        self.assertTrue(self._on("producer", jd.begin_pass_frame), "the producer opens the pass frame")
+        self._tick()                                                    # the pass's first touch of this sid: a cache HIT
         self.assertEqual(self.lifted, [], "premise: an open turn keeps the note")
-        self.assertIs(jd._frame["parses"].get(SID), warm, "the tick job's warm hit is pinned into the pass frame")
+        self.assertNotIn(SID, jd._frame["parses"], "a tick job is not a pass thread: it pins nothing")
         self._append(aline(T0 + 60, "All done: shipped and verified.", "a2", "a1", stop="end_turn"))
-        km._clear_done_working_notes(T0 + 100, {})
-        self.assertEqual(self.lifted, [], "mid-pass the job reads the frame's world, where the turn is still open")
-        self.assertFalse(jd._frame["parses"][SID]["turns"][-1]["ended"], "the mid-pass append stays out of this pass")
-        jd.end_pass_frame(True)
-        km._clear_done_working_notes(T0 + 100, {})
-        self.assertEqual(self.lifted, [(SID, "")], "the next pass sees the ended turn, whole, and lifts the claim")
+        self._tick()
+        self.assertEqual(self.lifted, [(SID, "")],
+                         "mid-pass the job reads the live file: the ended turn lifts the claim at this cycle, not "
+                         "after the tiers' run")
+        self.assertNotIn(SID, jd._frame["parses"], "and still nothing pinned")
+
+    def test_a_pass_thread_pins_what_the_tick_job_read_live_and_the_tick_job_keeps_reading_live(self):
+        self.assertTrue(self._on("producer", jd.begin_pass_frame))
+        self._tick()                                                    # live, unpinned: fills the cache
+        self.assertEqual(self.lifted, [])
+        self.assertFalse(jd.begin_pass_frame(), "this thread joins the frame: a tier's thread from here on")
+        pinned = jd.parsed_session(SID, [str(self.path)], T0 + 100)
+        self.assertIs(jd._frame["parses"].get(SID), pinned, "the pass thread's first touch pins the cached parse")
+        self._append(aline(T0 + 60, "All done: shipped and verified.", "a2", "a1", stop="end_turn"))
+        self.assertIs(jd.parsed_session(SID, [str(self.path)], T0 + 100), pinned,
+                      "the pass thread keeps the frozen world: the append is next pass's evidence for the judges")
+        self.assertFalse(pinned["turns"][-1]["ended"])
+        self._tick()
+        self.assertEqual(self.lifted, [(SID, "")], "while the same append reaches the tick job now")
+        self.assertIs(jd._frame["parses"].get(SID), pinned, "and the tick job's live read moved no pin")
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_tick_jobs_under_frame.py
+++ b/tests/test_kernel_tick_jobs_under_frame.py
@@ -56,6 +56,7 @@ class TickJobUnderAFrame(unittest.TestCase):
 
     def setUp(self):
         self.td = Path(tempfile.mkdtemp())
+        self._saved_state = jd.STATE                     # restored in tearDown: the shared judge's root is checked
         jd._rebind_state(self.td)
         self.path = self.td / (SID + ".jsonl")
         recs = [uline(T0, "start the work", "u1"),
@@ -76,6 +77,7 @@ class TickJobUnderAFrame(unittest.TestCase):
         jd.end_pass_frame(True)
         (km._working_notes, km._alive_sessions, km._open_top_goal, km._set_working_note,
          km._suspended_after) = self._saved
+        jd._rebind_state(self._saved_state)
 
     def _append(self, rec):
         with open(self.path, "a") as f:

--- a/tests/test_planner_skip.py
+++ b/tests/test_planner_skip.py
@@ -6,7 +6,8 @@ session's segmentation, plan units and placement normalization on every pass. Th
 every input the pass reads, taken before the store read: the parse cache's key bound to the session object,
 the store with its journal and archive, the episode log, the leaf's task-store files, the reg file and the
 transcript path, the captions file and each running background launch's expiry under the pass clock; it records
-only when the pass placed nothing, collected no unit and left the store's key unchanged. Pins: unchanged inputs
+only when the pass placed nothing, collected no unit, left the store's key unchanged and was complete (the
+evidence gate's bit). Pins: unchanged inputs
 skip after a pass that had nothing to do; a moved store, a fresh parse, a task-store change alone (under the
 session's own sid, and under its forked leaf's), a reg change alone, a prompt caption landing (which heals a
 floor title) and a running launch crossing its deadline (which completes a done focus top) each un-skip that
@@ -14,7 +15,7 @@ session; the expiry term holds while a launch is inside its ceiling, and for a l
 however far the clock runs; the settle reads the wall clock when no pass clock is handed in; a write landing
 during the pass is seen next pass; three sessions with one moved leave placements and nodes byte-identical to
 the ungated passes (two fresh worlds); a parse the cache does not hold is never skipped, nor is an expiry view
-that cannot be computed; a rebound root forgets; the counters.
+that cannot be computed; a pass that stood down is planned again, not recorded; a rebound root forgets; the counters.
 
 Synthetic sids and text; a temp state root, a temp Claude config root for the task store; the planner's model
 calls are stubs, deterministic, so two worlds agree byte for byte."""
@@ -191,6 +192,28 @@ class PlannerSkip(_World):
         jd.SDKDIR.mkdir(parents=True, exist_ok=True)
         (jd.SDKDIR / (A + ".json")).write_text(json.dumps({"sid": A, "name": "worker0", "cwd": "/tmp", "auth": "login"}))
         self.assertEqual(self.run_pass()[0:2], (1, 2), "A's reg appeared: A alone planned")
+
+    def test_a_pass_that_stood_down_is_not_recorded(self):
+        # the evidence gate's completeness bit (_judge_ctx.stage_incomplete, reset by _gated before every run): a
+        # deferral without a write, or a side file that exists and did not read, marks the pass incomplete. A
+        # recorded incomplete pass would skip the session until an input moved, which a permission bit never does
+        self.settle()
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        (jd.SDKDIR / (A + ".json")).write_text(json.dumps({"sid": A, "name": "worker0", "cwd": "/tmp", "auth": "login"}))
+        real = jd._latch_ask_anchors
+
+        def stand_down(fsid, session, store):
+            jd._judge_ctx.stage_incomplete = True          # what a deferral or an unreadable side file does
+            return real(fsid, session, store)
+        jd._latch_ask_anchors = stand_down
+        try:
+            self.assertEqual(self.run_pass(), (1, 2, 0), "A planned with nothing to do, but incomplete: not recorded")
+            self.assertNotIn(A, jd._PLANNER_SEEN)
+            self.assertEqual(self.run_pass(), (1, 2, 0), "still incomplete: planned again, still not recorded")
+        finally:
+            jd._latch_ask_anchors = real
+        self.assertEqual(self.run_pass(), (1, 2, 1), "complete with nothing to do: recorded")
+        self.assertEqual(self.run_pass(), (0, 3, 0), "and skipped")
 
     def test_a_write_landing_during_the_pass_is_seen_next_pass(self):
         # INTERLEAVED WRITE: the key is taken before the store read; a journal row lands while the pass reads

--- a/ui/webview/feed-limit-banner.test.ts
+++ b/ui/webview/feed-limit-banner.test.ts
@@ -68,7 +68,9 @@ test("the gate, the clear, and the envelope mark all scope to LOGIN-billed calls
   // usage.json's windows are the login account's; a judge call bills the JUDGED session's account
   // (the 2026-08-12 rule) — so a key-billed call (pay-per-token, no windows) is never gated, its
   // success never clears the login latch, and its limit-shaped 429 never mints one.
-  const run = JUDGE.slice(JUDGE.indexOf("def _judge_run(")).split("\ndef ", 1)[0];
+  // the call's body is _judge_run_impl: the evidence gate wrapped _judge_run around it to mark an
+  // empty reply as an incomplete stage, and the wrapper holds none of the billing or the gate
+  const run = JUDGE.slice(JUDGE.indexOf("def _judge_run_impl(")).split("\ndef ", 1)[0];
   const billing = run.indexOf('auth = "codex" if engine == "codex" else _judge_auth(fsid)');
   const gate = run.indexOf('u = json.loads((STATE / "usage.json").read_text()) if auth == "login" else {}');
   assert.ok(billing >= 0 && gate > billing,


### PR DESCRIPTION
#1059 (the goal-store memos: `_unread`, `load_goals_shared`, the file-identity memos) merged as 9c9a926a, so this diff is its own ten commits, listed below, followed by the review commit and, since the rebase of 2026-09-09, two more: the planner's inner change gate records only a complete pass (12), and the docs (13).

The judge's six tiers (planner, closer, unblocker, grouper, consolidator, distiller) ran every discovered session in full every pass, while on a kernel with about thirty sessions two of them held anything new per pass. This PR gives every tier an evidence gate: a (tier, session) run is skipped only when every input the tier's decision path reads is identical, by identity, to what the tier last judged to completion. Around the gate sit three correctness fixes at the judge's head, found by the design review that preceded it. The ten commits are in dependency order: 1 and 4 pin the parse and its key under the pass frame, which the gate's signature (5) stands on; 8 memoizes the three reads the store tiers repeat, and 9 puts those tiers on the gate 5 built; 10 closes a hole in 9 (a side file the gate stat'd but the stage never read); 2, 3, 6 and 7 are independent of the rest. Each commit is reviewable on its own. About 4,700 changed lines in the ten, about 5,500 with the review commit and the two after the rebase, three in four of them tests. The kernel performance counters (#1003) and the pane telemetry (#1009) are on main; this PR adds no `/perf` rows of its own (see "Not included").

Rebased onto main at c7b175c9 (2026-09-09). Of the 25 PRs merged between 3e4398a3 (the #1166 merge, the base before this rebase) and this base (#1167, #1169 to #1171, #1173 to #1179, #1181 to #1192, #1195, #1199), twelve touch a file this PR changes and five bear on what it does. What moved:

- **The planner gate layering.** #1173 landed a change gate of main's own inside `_plan_session` (`_PLANNER_SEEN`, `_plan_key`: a session whose inputs have not moved since a pass that had nothing to do returns before the store read; its counters are `memos.plannerSkip` on `/perf`), and #1179 added three terms to its key (the leaf's task store, the captions file, each running launch's deadline crossing) and threaded the pass clock through `_bg_unresolved`, `_awaiting_bg_hold` and `_session_settled`, the lines commit 5 threads. Both gates are kept, one inside the other: commit 5's evidence gate around `_plan_session` keys on the inner gate's inputs (the reg by its `spawnedAt` and backend values rather than by identity, so a reg rewrite that changes neither re-arms the inner gate alone) and on `cleared.jsonl`, the death marker and the stall slice besides, and records only a complete run; the inner gate sees only the sessions the outer one ran. Commit 5 no longer adds the `now` parameters (main's since #1179), only rewords their docstrings, and its `tests/test_bg_scan_monitor.py` pin retarget is gone (main made the same change). Commit 12 fixes what the layering broke: the inner gate recorded any pass that placed nothing and left the store's key where it was, a stand-down or an unreadable side file included, so the next pass returned before the sync or the read and the evidence gate stamped that short-circuit as a complete run; three gate cases (the plan-sync stand-down, an unreadable captions file, an unreadable archive) stamped where they must stay due. The inner gate's record rule now also requires the completeness bit unset (`_judge_ctx.stage_incomplete`, which `_gated` resets before every run). Consequence for `memos.plannerSkip`: it counts the sessions the evidence gate let through, not every planner skip; an input only the outer gate keys (a `cleared.jsonl` row alone, a stall record, the death marker) re-arms the outer gate while the inner one returns before the planner runs.
- **The archive read memo.** #1171 gave the archive's readers `load_goal_archive_shared`, one loaded object per file state (`memos.goalArchive`). The review commit's `load_goal_archive` marks the running stage incomplete for a file that exists and does not read or parse, and the memo would have cached that empty answer under the file's key; a permission fix moves no key, so the failure would have been served after the file read again. `load_goal_archive` now sets `_judge_ctx.archive_read_ok` for the calling thread and the shared twin memoizes only when it is set. `tests/test_file_read_memos.py` 16 to 18: an unreadable archive and one that does not parse are the empty shape, never cached, read again on every call, one `archive-unreadable` row per episode, and cached once readable again under the same key; the gate module's archive case now asserts the second pass ran incomplete and unstamped for every tier.
- **The merged docstrings.** Commit 2's `_log_judge_error` kinds text, re-applied over main's reworded `store-unreadable` entry; commit 5's `now` docstrings on the three settle helpers; the review commit's file-memo header comment and `load_goal_archive`'s docstring, merged with #1171's shared-twin paragraph. Content unchanged except as the two points above say.
- **Tests meeting main's fixtures.** `tests/test_kernel_tick_jobs_under_frame.py` restores the judge's state root in tearDown, which main's conftest checks after every test since #1176. The plan-sync stand-down case in `tests/test_judge_stage_gate.py` writes the journal row a clear writes since #1187 beside its `cleared.jsonl` row, so both gates re-arm and the run reaches the sync.
- **Commit 13, docs only.** `docs/reference.md`'s `plannerSkip` and `goalArchive` entries describe the two gates, what the counters count and the readable-only memo; `docs/judges.md` gains a Skips entry under Ops and knobs naming the evidence gate the `gate-stamp` and `*-unreadable` kinds refer to, its signature, its stamp rule and the planner's inner gate.

The range-diff against the previous head: commits 1, 3, 4 and 6 to 10 identical; 2, 5 and 11 differ only as named here. Full suite at commit 12 on this base, `pytest tests/ -n 8`: 10313 passed, 61 skipped, 1671 subtests, 0 failed. At commit 13 the docs pins and the gate modules (thirteen modules): 294 passed.

Rebased onto main at b01fbbe0 (the #1140 merge) on 2026-09-09. One conflict, in `kernel/judge.py`: #1140 (judge concurrency is a knob) resolves every pool's width at call time, `_conc(concurrency)`, on the same lines where commits 5 and 9 replace the six triage pools' submit comprehensions with the evidence-gated loops (planner, closer, grouper, consolidator, unblocker, distiller); both kept, so the gated loops run at the setting's width. `docs/judges.md` merged on its own (#1140's pool-width note sits above this PR's error-row kinds). The eleven commits are otherwise unchanged; the review commit stays last.

Rebased onto main at 0fa3ad5d on 2026-09-09, after #1128 (romp's own API-key providers retired) merged. One conflict, in `begin_pass_frame`: this PR's commit 4 adds the `served` key to the pass frame where #1128 removes the pass-generation counter line beneath it; both kept. `docs/judges.md` merged on its own. The eleven commits are otherwise unchanged; the review commit stays last.

Rebased onto main at 66bb933e (the #1091 merge) on 2026-09-08, directly, now that #1059 is in. Of the forty PRs merged between the old base and this one (#991, #998, #1004, #1033, #1038, #1043, #1044, #1051 to #1053, #1055, #1056, #1058 to #1060, #1063 to #1070, #1072, #1074 to #1076, #1078 to #1083, #1086 to #1089, #1091 to #1093), four touch a file this PR changes. #1059 itself, re-applied on main with its review commit: its `docs/judges.md` kinds list (`frozen-store-write`, `frozen-store-save`) and its `run_propagate` mid-loop publish stand beside this PR's review commit's kinds and commit 3's docstrings. #1068 (the closer's lift horizon at the turn's last event time) edits `_close_turn`'s `apply_close` call, while commit 6 edits the caller that builds the segment index, so both stand in the same function. #1060 edits `kernel/event_model.py`'s `FileAdapter` and `declared_plan`, apart from commit 5's `_bg_expiry_t` and task-store helpers. #1056 (postal rows keyed by the recipient's stable id) is a region of `kernel/judge.py` this series leaves alone. All eleven commits applied without a conflict and the range-diff against the previous head is identical for every one; nothing was dropped, reworked or resolved by hand. On this head, on the same loaded machine: `pytest tests/ -n 8` 9859 passed, 47 skipped, 1670 subtests, 0 failed (the four browser-driven modules that failed at the earlier head passed this time); the 75 judge-side modules alone (`tests/test_judge*.py`, the twelve in the diff and their neighbours) 1507 passed; `npm test` 3455/3455, `npm run typecheck` clean; no shell surface in the diff. The two rebases before this one, both on 2026-09-08, reached db8776fb (the #1031 merge) through #1059's branch; the restack onto #1059's review commit kept the ten commits' content unchanged except two docstring splices that keep both sides (the judge-errors kinds list in `docs/judges.md` in the review commit, `run_propagate`'s in commit 3), and the second rebase carried all ten unchanged (of the twenty-five PRs it crossed, only #1029 touched a file this PR changes, one line in `kernel/judge.py`'s key gate, `KEY_CMD_TIMEOUT`, a region this series leaves alone). #1018 (the auto-nudge and retry-suppress readers proved before a rewrite) is in the base; it reworks the kernel's `auto-nudge.json` reader, and on the judge side commit 10's `stalled_facts` reads that file, so a file #1018 has moved aside reads as absent there, the unmarked path. The first rebase, onto the #1019 merge, is the one that shaped the series. Main's goal-store quarantine (#1019: a goals file that exists and cannot be read raises into a per-session boundary, `load_goals_or_fault`, and unparseable bytes are moved aside) covers the data loss two further commits of this series addressed by refusal, so both came off: the `save_goals` refusal of a store that loaded as a fallback for an unreadable file, `_disk_rev`'s None answer, the archive mark and its refusal, the six stages' stand-downs, the kernel's undo-clear stand-down with its `undoClearResult` frame, and the once-per-episode warn frame. With them gone this PR touches no `kernel/kernel.py` and no `ui/` runtime file (one TypeScript source pin is retargeted). Commit 9 was reworked onto #1019: `_mark_unread` keeps the one fallback load left (a parsed store whose override journal exists and did not read); its docstring and the gate's input inventory say that a store file that cannot be read raises at the stage's load (the run counts incomplete and the runner files its `pass-crash` row) and that an unparseable one is moved aside; and its unparseable-store test became two, a store that cannot be read never stamps, and a store that does not parse is moved aside and the fresh store judged to completion. Commit 4's two new `_PARSE_CACHE.clear()` sites clear the chain memo beside them, the rule main's corpus scan enforces. Two docstring conflicts (the judge-errors kinds list in commit 2, `run_propagate`'s in commit 3) were resolved by keeping both sides. #1016 (hidden panes paint once on return), #1020 (state readers proved before a flag, order or bell write) and #1024 (main-drift converge) touch nothing this PR changes.

## Commits

1. **Judge: pin a cache-hit parse under the pass frame.** `parsed_session` pinned the pass frame's parse only on the `_PARSE_CACHE` miss path; a hit returned the cached parse unpinned, so a warm session (every idle one, most of the time) froze nothing under an open frame, and a turn that ended after the pass's first touch was visible to a later stage and invisible to an earlier one. The hit path now pins into the same frame. At this commit the pin also reached the kernel's six tick jobs that call `parsed_session` while a frame is open (`_frame` is a module global); the review commit scopes the pin to pass threads, so those jobs read the live world at every cycle (see "Review commit"). Accepted lag, for the judge stages: a turn that ends after the pass's first touch is judged whole in the next pass, for warm sessions as the miss path already implied for cold ones. A judgment-consistency fix, no figure. `kernel/judge.py`; `tests/test_judge_pass_frame.py` +3, `tests/test_kernel_tick_jobs_under_frame.py` (1, new, at this commit: the kernel's `_clear_done_working_notes` under an open frame keeps a working note across a mid-pass append and lifts it next pass; the review commit rewrites the module to two cases that assert the opposite for a tick job, a lift at the cycle the turn ends).

2. **Judge: drop the rolledUp marker when a container dissolves, and repair stores published with it.** Umbrella dissolution promoted a container's children to top level without clearing `rolledUp`, and both re-derivers stand aside for a rolled-up node, so a promoted child kept its stale done flag and every rollup appended one settle row and one seam. The dissolution now unrolls each promoted child's whole rolled-up subtree through one helper (`_unroll_node`, the code `_reopen` already ran inline), `_materialize_from_log` repairs stores already published with the marker (one publish at the next rollup, then no-ops), and a top whose diary holds the bug's settle rows gets one romp-authored reopen row plus one judge-errors row (`unroll-heal`) so it is judgeable again. Invariant: the marker means a resolved ancestor's roll-down set these flags, and it is dropped exactly when no resolved ancestor remains. Measured on the self-hosted kernel by inspecting live stores, not benched: one node at `LOG_CAP` with 64 settle rows, and 0.6 to 1.1 MB republished per pass per affected store once its session revives. `kernel/judge.py`, `docs/goal-state.md` (rule 6); `tests/test_judge_dissolution_rolledup.py` (17, new).

3. **Judge: keep a loaded store CAS-protected across every save.** `save_goals` popped the CAS base (`_baseRev`) on every real publish and never restored it, so every later save of the same store object (`_plan_session` saves several times per pass; `_distill_session` saves after titling and again after distilling, with the model call between) ran unconditionally and overwrote concurrent publishes. After a successful publish the object now carries the written revision as its base (the review commit restores the loaded base when the publish did not happen, so a raise inside the loop or at the rename leaves the holder CAS-protected too); the file still never holds the key; stores built without `load_goals` are unchanged. A lost-write fix, no figure; a secondary, unmeasured effect is that later saves in a pass reach the no-op check. `kernel/judge.py` (also rewords `run_propagate`'s docstrings; its drop-after-publish stays); `tests/test_judge_store_cas.py` +3, `tests/test_judge_store_noop_publish.py` +2, `tests/test_judge_distill_early_save.py` (1, new).

4. **Judge: pin the parse key with the parse under a pass frame.** The frame pinned a session's parse but never the (fileset key, pending cut) pair it was read under, so a stamp keyed on the transcript had nothing exact to stand for. `_frame_parse_key(fsid, files)` pins the pair before anything is read (the first toucher wins; a failed stat pins None); `parsed_session` pins hit and miss into the same frame and records the pair each parse was served under; `tasks_for` keys its disk memo on the pinned pair instead of its own stat, which closes a caption-memo race. No figure of its own: it is what makes the gate's stamp exact. One-time cost: the memo key changes shape, so every judge-units-cache entry regenerates once (one parse per session on the first pass). `kernel/judge.py`; `tests/test_judge_pass_frame.py` +12 (one case guards commit 1's hit-path pin by moving the cache slot mid-pass, since commit 1's own case stops depending on it once the key is pinned).

5. **Judge: an evidence gate for the planner and closer.** A (tier, session) run is skipped only when every input the tier's decision path reads is identical by identity to what it last judged to completion: the pinned parse pair and its candidate files, the store, the override journal and the archive, and per tier the captions, episodes, death marker, cleared rows, the registry's `spawnedAt` value, the session's stall records and the leaf's task store. A deferred, failed, empty-reply, raising or cut run leaves no stamp (`_judge_run` is now a belt over `_judge_run_impl` that marks an empty reply incomplete); a background launch's deadline is the one clock input, through one shared expiry helper (`em._bg_expiry_t`); a skip still stamps the pass watermark; the stamps are process state, so the first pass after a restart is a full walk. Invariant: the gate never withholds a verdict the ungated pass would have filed from new evidence, because every writer re-arms by moving an identity. Since the rebase onto c7b175c9 this gate sits around main's own change gate inside `_plan_session` (commit 12 and the dated paragraph above): the outer gate keys on the inner gate's inputs and more (the reg by two values rather than by identity), so the inner gate sees only the sessions the outer one ran. Measured on the self-hosted kernel (31-session state copy, judge paused, sealed placements, two warm-ups then six timed passes, six-worker pools, `process_time` per pass; the harness is ad hoc and not in the repo): planner+closer idle CPU 1.303 s to 0.494 s per pass, store loads and saves 62 to 6 per pass, whole triage pass 2.251 s to 1.437 s; planner skipped 81% of sessions, closer 100%. The six planner sessions that ran every pass held units the paused model answered with an empty reply, which the gate refuses to stamp; live, those place and stamp. `kernel/judge.py`, `kernel/event_model.py`; `tests/test_judge_stage_gate.py` (43, new); two source pins retargeted (`tests/test_distill_tier.py`, `ui/webview/feed-limit-banner.test.ts`).

6. **Judge: build the closer's segment index on the first turn it judges.** The seam-aware index (its only consumer is `_close_turn`'s goal-history block) is built on the first judged turn instead of before the walk, so an all-swept session pays no `_segs` call per turn; the block handed to the model is unchanged because nothing between the store load and the first judged turn writes seams (`rollup_status` stamps them after the walk). About 0.06 CPU-s of an idle pass, measured on the self-hosted live kernel with about thirty sessions. `kernel/judge.py`; `tests/test_judge_close_riders.py` +3.

7. **Tests: the courier dead-wait test removes the journal row and nudge record it leaves.** Its tearDown now removes the override-journal row and the auto-nudge record the test writes under the shared placeholder sid, and a cleanup registered in setUp asserts both are gone; without the removal, sixteen `test_judge.py` distiller and procedural-block tests fail whenever xdist places them after it in a worker, which the gate module of commit 5 does. Reproduced by running the two modules in one process: 16 failed before, 0 after. No behaviour change. `tests/test_courier_link.py`.

8. **Judge: three identity memos on the store tiers' read paths.** `_view_cleared` and `_live_prompt_since` are memoized on their file's `(ino, mtime_ns, size)`, exact because every writer of `cleared.jsonl` and `states/<sid>.jsonl` appends (the commit lists the writers; an unreadable file is never memoized, an absent one drops the entry, `_view_cleared` returns a frozenset); the distiller's parent-to-children map is built once per store (`_kids_map`, threaded to `_distill_due_t` with `kids=None` keeping the kernel's callers unchanged). Measured on the self-hosted kernel (the bench of commit 5): the four store tiers' idle CPU 0.60 to 0.44 s per pass with loads unchanged at 124 (distill 0.210 to 0.108, group 0.117 to 0.079, consolidate 0.109 to 0.077, unblock 0.155 to 0.136), and planner+closer 0.69 to 0.62 s with no code change of their own. Re-measured on this branch with a synthetic micro-bench (min of five, `process_time`): 690 `_distill_due_t` calls over a 104-node store 9.4 to 2.2 ms; 217 `_view_cleared` calls over a 500-row `cleared.jsonl` 202 to 2 ms; 31 `_live_prompt_since` calls over 2000-row states logs 106 to 0.3 ms. `kernel/judge.py`; `tests/test_judge_identity_memos.py` (12, new).

9. **Judge: the unblocker, grouper, consolidator and distiller run through the evidence gate.** Each is keyed on its own decision path's inputs: the unblocker on the pinned parse pair plus the store trio; the grouper and consolidator on the store trio plus `cleared.jsonl`, no parse; the distiller on the store trio, the states file and this session's stall records, no parse. A completeness mark sits at every no-write deferral, and `_mark_unread` marks the one fallback load left: a parsed store whose override journal exists and did not read. A store file that cannot be read raises at the stage's load (#1019, on main), so the run counts incomplete and the runner files its `pass-crash` row; unparseable bytes are moved aside and the fresh store is judged. One rule change, for the planner and closer too: a frame that served no parse for a session now lets a parse-tier stamp stand (the stage's own read would have pinned a pair, so no served pair means the decision depended on the store alone; no frame at all still means no stamp for a parse tier, while the store-only tiers stamp with or without one), which stops the unblocker bypassing about half the sessions every pass, at the cost of re-arming those sessions on every transcript append (about 10 ms per pass on the bench). Measured on the self-hosted kernel (the same bench, before = commit 8): the four tiers' idle CPU 0.436 s to 0.165/0.182 s per pass and their loads 124 to 20; whole triage 1.371/1.769 to 1.130/1.187 s and 199 to 96-98 loads; skipped: grouper 90%, consolidator 97%, distiller 100%, unblocker 48% (a paused-bench floor: 16 sessions hold blocks the paused model cannot examine). `kernel/judge.py`; `tests/test_judge_stage_gate.py` 43 to 68.

10. **Judge: a side-file read that fails after the gate stat'd it marks the run incomplete.** `_live_prompt_since`, `_view_cleared` and `stalled_facts` answered empty on any `OSError` without marking the stage, so a complete-looking run stamped the identity of a file the stage never read, and the session skipped until that file moved, which a permission bit, an EMFILE or an EIO never makes it do. All three now go through `_read_failed`: the stage is marked incomplete and one judge-errors row (`states-unreadable`, `cleared-unreadable`, `stall-unreadable`) is logged per failure episode; `stalled_facts` gains `strict`, so the signature's own failed read runs the stage without a stamp; the review commit puts the four remaining signature files on the same path (see "Review commit"). An absent file ends an open episode as a good read does, so a side file removed while unreadable and recreated unreadable logs a new row. New behaviour: an `auto-nudge.json` that exists and does not parse now writes a row where it was silent. A gate correctness fix, no figure. `kernel/judge.py`; `tests/test_judge_stage_gate.py` 68 to 81.

11. **Review fixes: an unreadable signature is a fault not silence, the warm pin covers only the judge stages, the error rows and docs agree.** The review commit, not one of the ten; what it changed is summarised below. `kernel/judge.py`, `docs/judges.md`; `tests/test_judge_stage_gate.py` 81 to 86, `tests/test_judge_pass_frame.py` 20 to 22, `tests/test_kernel_tick_jobs_under_frame.py` 1 to 2 (rewritten), `tests/test_judge_store_cas.py` (one case rewritten), and since the rebase `tests/test_file_read_memos.py` 16 to 18 (the archive memo, see the dated paragraph).

12. **Judge: the planner's change gate records only a complete pass.** After the rebase onto c7b175c9 (the dated paragraph). `_plan_session`'s record rule, main's inner gate, requires the completeness bit unset besides placing nothing and leaving the store's key where it was: a pass that stood down without a write, or read a side file that exists and did not read, is planned again next pass instead of recorded. Without it a recorded incomplete pass short-circuited the next run before the sync or the read, and the evidence gate stamped that short-circuit as a complete run. The gate's header comment names the two gates and their order. `kernel/judge.py`; `tests/test_planner_skip.py` 16 to 17, `tests/test_judge_stage_gate.py` (one case rewritten; 86), `tests/test_kernel_tick_jobs_under_frame.py` (tearDown).

13. **Docs: the planner's two gates, what plannerSkip counts, and the archive memo's readable-only rule.** `docs/reference.md`, `docs/judges.md`; no code.

**Review commit.** Six changes, in the commit's terms. The pass frame's pin, a warm cache hit too, applies to pass threads only: the thread that opened or joined the frame and this module's pool workers (`_pass_frame`, `_TimedPool.submit`, `begin_pass_frame`, `end_pass_frame`); the kernel's pusher tick jobs read the live world at every cycle instead of the pass-start world for the tiers' whole run, model calls included. The four signature files whose readers answered empty on a read failure go through `_read_failed` like the states file, `cleared.jsonl` and the stall records: `_prompt_gist` (`captions-unreadable`), `_episode_read` (`episodes-unreadable`; a failed read is no longer memoized under the file's mtime), `_death_marker` (`marker-unreadable`), `load_goal_archive` (`archive-unreadable`; since the rebase its shared twin memoizes only a read that succeeded); an absent file ends an episode. The `gate-stamp` judge-errors row wears the judge's name (`_TIER_JUDGE`), not the tier key. `docs/judges.md`'s judge-errors kinds list and `_log_judge_error`'s docstring carry `unroll-heal`, `gate-stamp` and the seven `*-unreadable` kinds. `save_goals` stamps the base again in a `finally`: the written revision after a publish, the loaded base when the publish did not happen, so a raise inside the CAS loop or at the rename keeps the holder's retry CAS-protected; the `_unread` mark is restored with it. In the tests, the `FsCompleteness` allowlist drops `session-flags.json` (no stage reads it; the runners filter their lists on it before any stage runs), and a new case pins the hidden-session eviction the gate's input inventory states: a muted sid's planner, closer and unblocker stamps are evicted, the store tiers keep theirs, and an unmute costs one full run before the skips resume. The sections below describe this head; where the review commit changed a claim, the change is named.

## What changes for a user

Cards, lanes and chat pages render the same rows from the same data, and the gate's tests pin that a skip never withholds a verdict a full pass would have filed. Four things are visible:

- A goal store already published with the stale `rolledUp` marker gets one repair publish at its next rollup, and a top whose diary holds the bug's settle rows gets one reopen row and one judge-errors row; its card moves from a stale done, or a Working that every settled-done reader treated as sealed, to an open top the closer re-rules. Once per node (commit 2).
- A turn that ends after a pass's first touch of a warm session is judged in the next pass, whole, rather than by the later stages of the current one (commit 1). The kernel's tick jobs (a needs-you block, a working-note lift, a nudge decision) are not held to that world: they read the live transcript at every cycle (the review commit).
- The first judge pass after a kernel restart is a full walk; after that an idle session costs each tier a signature check per pass (a few stats and two small value reads), with no store load, parse or save (commits 5, 9). The planner's inner change gate (on main since #1173) sees only the sessions the evidence gate ran, so `memos.plannerSkip` on `/perf` counts those alone (commit 12). Every judge-units-cache entry regenerates once after commit 4 lands.
- Seven new judge-errors rows for signature files that exist and do not read or parse (`states-unreadable`, `cleared-unreadable`, `stall-unreadable` from commit 10; `captions-unreadable`, `episodes-unreadable`, `marker-unreadable`, `archive-unreadable` from the review commit), one per failure episode; each fires where its reader was silent, and the run stamps nothing until the file reads.

## Tests

Red first: every commit's tests were run against the code before its change, then green after it. After that, each commit's finished code was mutated one line at a time (a mark removed, a guard inverted, a key component dropped, a rule reverted) and a test was added for every mutation the existing cases let through; each such case fails under its mutation and passes on the commit. The counts below include those cases.

- Commit 1: the warm-first-touch case fails at its second-touch `assertIs` (a different parse object, with the appended turn ended); the no-frame control passes on both; the concurrent first-toucher case fails when the hit path's pin is an overwrite instead of a setdefault; the kernel tick-job module fails on the code before the change (the job re-parses mid-pass and lifts a working note under the open frame). After: 8/8 and 1/1 in the two modules. The review commit rewrites the tick-job module to two cases: under an open frame the job reads the live file and lifts the note at the cycle the turn ends, and a pass thread's pin does not move it.
- Commit 2: 8 of the first 12 cases fail before (the marker still on the promoted top, settle rows appended through the file, no reopen row, `rev` advancing across rollups); the other 4 pin behaviour that must not change; 5 more pin the heal's edges (the reopen's `ev_t` floor and its latest-evidence moment, a view-cleared top staying sealed, a solid ancestor's stale flag rewritten before the ancestor check, a rolled child with no diary key unrolling to open). After: 17/17.
- Commit 3: the second-save test fails (the other writer's node is gone) and the distiller test fails (the block published during the model call is dropped by the tail save); the re-stamp's edges are pinned in both store modules (a second uncontended save never rebases, a raise inside the CAS loop leaves the object base-less, a hand-built store stays unconditional, a loaded store's second unchanged save is a no-op); the review commit rewrites the raise case: the base is kept at the loop and at the rename, and a retry after a concurrent publish rebases instead of stomping. After: 20 across the CAS and distiller modules; 53 across the CAS and no-op modules.
- Commit 4: 9 of the first 10 cases fail (seven with `AttributeError`, no `_frame_parse_key` or `_parse_key_files`; two on the missing pinned key). The tenth, a warm hit's pin recording its served pair and holding when the cache slot moves, passes at this commit and fails with the hit path returning unpinned. It guards commit 1's pin, which commit 1's own case stops exercising once the key is pinned (an unchanged slot answers the same object either way). Two more pin that a losing parse never overwrites the winner's served pair and that a pair that cannot be computed memoizes nothing. After: 20/20.
- Commit 5: the 43 gate cases fail in setUp (no `_judge_run_impl`), and the two kernel-side pins fail on the old text. After: 43/43 in the module. Ten of the cases each pin one rule against a one-line mutation (the belt, the per-run reset of the completeness bit, the two pending marks alone, the failed-call site alone, the candidate files in the signature, a failed side-file stat and an unlistable task dir bypassing, an unframed runner never stamping, a stamping failure not being a failed pass). The `feed-limit-banner` source pin slices the model-call body and failed on the belt split; it is re-anchored to `_judge_run_impl` in this commit (fails before, 6/6 after).
- Commit 6: the all-swept case counts 2 eager `_segs` calls where 0 are expected; the equality control passes on both; the once-per-walk case fails when the index is rebuilt per judged turn. After: 9/9.
- Commit 7: no new behaviour. The leak reproduced by running `test_courier_link.py` then `test_judge.py` in one process: 16 failed before the change; 533 passed at this head. The setUp cleanup fails the test on its own when either unlink is dropped.
- Commit 8: 6/6 of the first cases fail with `AttributeError` (no `_kids_map`, `_view_cleared_scan`, `_live_prompt_since_scan`); 6 more pin one property each (one kids map per store, a same-tick append seen, a row landing after the read seen next call, an unreadable `cleared.jsonl` not memoized, the rebind clearing the live-prompt memo). After: 12/12.
- Commit 9: 25 fail before (the new store-tier cases plus the eviction and planner/closer signature cases this commit rewrote: the four tiers ungated, so the skip pass still loads and every counter reads 0). After: 68/68. Then fifteen mutations of the finished code, one at a time (a completeness mark removed, the served-pair rule reverted, a file dropped from a tier's inputs, every tier bypassing without a frame, a store tier submitted with the clock input, `pass_done` dropped from the run path), each failing its named test.
- Commit 10: the three unreadable-side-file cases fail before (the tier stamps over the unread file; the gate skips over an unreadable stall file); each case's removal leg (the file removed while an episode is open, then recreated unreadable, a new row) fails without the absent-branch `_read_ok`. The six stage-site tests pass at commit 9, which landed the marks; their red is the mutation set (each mark replaced by `pass`, each test fails). Four more pin a stall read failing after a good signature read, the rebind clearing the failure episodes, and a file vanishing between the stat and the read (cleared and states) ending an open episode. After: 81/81.
- Review commit: `SignatureFileReads` (4 cases: an unreadable captions file never stamps the planner, an unreadable episode log never stamps the planner and is not memoized, an unreadable death marker never stamps the closer, an unreadable archive never stamps any tier; one row per failure episode, and the heal or the run lands once the file reads), `Bounds`' muted-sid case, the `gate-stamp` row's judge name in `Completeness`, two pass-frame cases (a thread outside the pass reads live and pins nothing; a pool worker and a joiner are pass threads), the two tick-job cases, and the CAS case above. `tests/test_judge_stage_gate.py` 81 to 86, `tests/test_judge_pass_frame.py` 20 to 22, `tests/test_kernel_tick_jobs_under_frame.py` 1 to 2. Since the rebase, two archive-memo cases in `tests/test_file_read_memos.py` (16 to 18): an unreadable archive and one that does not parse are never cached and read again on every call, one `archive-unreadable` row per episode; without the `archive_read_ok` check both fail at their first memo assertion (the failed read is memoized under the file's key).
- Commit 12: on the rebased head without the rule, three gate cases (the plan-sync stand-down, an unreadable captions file, an unreadable archive) stamp where they must stay due; with it, 86/86. `tests/test_planner_skip.py` gains one case at the gate's own level: a pass with the completeness bit set is planned again next pass and never recorded, and recorded once complete (fails with the bit dropped from the rule). The plan-sync stand-down case writes the journal row a clear writes since #1187 beside its `cleared.jsonl` row, so both gates re-arm and the run reaches the sync.
- Commit 13: docs only. The docs pins and the gate modules (`tests/test_perf_stats.py`'s memo keys, `tests/test_judge_store_cache.py`'s kinds list, `tests/test_reference_billing_label.py`, `tests/test_postal_hydrate_scope.py`, `tests/test_path_links.py`, the three gate modules and five neighbours): 294 passed.

Full suites at the head of the ten commits, before the review commit, on a loaded machine that self-hosts a kernel: `pytest tests/ -n 8` 8975 passed, 47 skipped, 1403 subtests, 4 failed: `test_paste_to_focus_browser::ServedPaste`, the two `test_scroll_marks_growth::ServedNotchFollowsGrowth` tests and `test_awaiting_box_sync::ServedSync`, Playwright-driven modules that fail identically at the base commit on this machine (the hermetic kernel they start has no Agent SDK) and pass in CI. The twelve test modules in the diff alone: 219 passed (227 cases at the review commit's head; the eight it adds were not part of this run). `vscode-extension`: `npm test` 3274/3274, `npm run typecheck` clean. No shell surface changed (no `.bats` file or script in the diff). At commit 12 on the current base: `pytest tests/ -n 8` 10313 passed, 61 skipped, 1671 subtests, 0 failed.

## Measurements

Every judge-pass figure is the self-hosted deployment's measurement, not re-measured on this branch: the harness is ad hoc (not in the repo) and runs over private copies of a 31-session state directory with the judge paused (no model calls), placements sealed and every end-known turn marked swept, two warm-ups then six timed `run_triage` passes on real six-worker pools, CPU = `process_time` over the pass, legs back to back. The three rows marked "this branch" are a synthetic micro-bench run here. Nothing was re-measured after the review commit or the rebase; the idle-pass figures were taken before main's inner gate (#1173) existed, and that gate runs only for the sessions the evidence gate lets through.

| Change | Before | After | How |
|---|---|---|---|
| Planner + closer, idle pass (commit 5) | CPU 1.303 s; loads 62; saves 62 | 0.494 s; 6; 6 | deployment bench; skipped: planner 81%, closer 100% |
| Whole triage pass (commit 5) | CPU 2.251 s; loads 255; saves 62 | 1.437 s; 199; 6.5 | same legs |
| Closer segment index (commit 6) | one `_segs` call per turn per pass | none for an all-swept session | self-hosted live kernel, about thirty sessions: about 0.06 CPU-s per idle pass |
| Four store tiers, idle pass (commit 8, memos alone) | CPU 0.604/0.573 s; loads 124 | 0.436 s; 124 | deployment bench, two legs; per tier unblock 0.155 to 0.136, group 0.117 to 0.079, consolidate 0.109 to 0.077, distill 0.210 to 0.108 |
| `_distill_due_t` x690, 104-node store (commit 8) | 9.4 ms | 2.2 ms | this branch, synthetic, min of five |
| `_view_cleared` x217, 500-row `cleared.jsonl` (commit 8) | 202 ms | 2 ms | this branch, synthetic, min of five |
| `_live_prompt_since` x31, 2000-row states logs (commit 8) | 106 ms | 0.3 ms | this branch, synthetic, min of five |
| Four store tiers, idle pass (commit 9, over commit 8) | CPU 0.436 s; loads 124 | 0.165/0.182 s; 20 | deployment bench, two pairs in opposite order; skipped: group 90%, consolidate 97%, distill 100%, unblock 48% (paused floor) |
| Whole triage pass (commit 9) | CPU 1.371/1.769 s; loads 199 | 1.130/1.187 s; 96 to 98 | same legs |
| Store with the stale `rolledUp` marker (commit 2) | 0.6 to 1.1 MB republished per pass per affected store; one node at `LOG_CAP` | one repair publish, then no-ops | self-hosted live stores, inspected, not benched |

On the self-hosted deployment where these changes first ran, after they landed together with the store-side and pusher-side changes that went in as separate PRs (#1059 and #1060, both on main now, so not attributable to this PR alone), at the same pass cadence: the judge threads went from 81% to 35% of a core steady (38 to 43% in windows where passes ran at 7 to 9 per 30 s), the planner and closer skipped 97% of sessions steady, and goal-store loads per pass fell from about 455 to 246 plain loads plus 98 served by the shared cache.

## Contracts changed

- `parsed_session` pins a cache hit into the open pass frame as the miss path did, for pass threads only: `_pass_frame()` is the one reader of `_frame`, and answers it for the thread that opened or joined the frame (`begin_pass_frame` marks `_judge_ctx.in_pass`; the creator's `end_pass_frame` clears it) and for this module's pool workers (`_TimedPool.submit` marks every run); any other thread, the kernel's pusher included, reads the live world and pins nothing (the review commit). The frame (`_frame`) gains `"keys"` (the pinned (fileset key, cut) pair per session) and `"served"` (the pair each pinned parse was made under). `_frame_parse_key(fsid, files)` returns `(pair, cut, frame)`; `_pinned_fileset_key` is removed; `tasks_for`'s memo key is the pinned pair, so every judge-units-cache entry regenerates once.
- `_judge_run` is a belt over `_judge_run_impl`, which holds the model call, the billing resolution and the login gate. A test that patches `_judge_run` bypasses the completeness belt; patch `_judge_run_impl` to keep it.
- New module state in `kernel/judge.py`: `_STAGE_STAMP`, `GATED_TIERS`, `PARSE_TIERS`, `_TIER_JUDGE` (tier key to judge name, so the `gate-stamp` row wears the judge's name like every other row), `_TIER_STATS` with `tier_stats()` (ran, skipped, stamped, bypassed, incomplete, due_clock per tier plus the stamp count; read by tests only, not exported), `_VIEW_CLEARED_MEMO`, `_LIVE_PROMPT_MEMO`, `_UNREADABLE_LOGGED`; `_rebind_state` clears them all. `_judge_ctx.stage_incomplete` is the completeness bit; `pass_done` is stamped on a skip.
- The planner's inner change gate (main's `_PLANNER_SEEN`, `_plan_key`, `_plan_session`'s record rule) records a pass only when `_judge_ctx.stage_incomplete` is unset as well (commit 12); its table, key and `planner_skip_stats()` are unchanged in shape. `load_goal_archive` sets `_judge_ctx.archive_read_ok` for the calling thread (True on a read that succeeded or an absent file, False on a file that exists and does not read or parse), and `load_goal_archive_shared` memoizes only when it is True. No signature changes.
- `_bg_unresolved(path, now=None)`, `_awaiting_bg_hold(..., now=None)` and `_session_settled(..., now=None)` take the pass's clock (on main since #1179; this PR's gated planner and closer hand theirs in); `em._bg_expiry_t` is the one expiry definition (`_bg_expired` and `_settle_not_before` share it); `em.task_store_dir` and `em.task_store_fp` are new.
- `_materialize_from_log(nodes, store=None)`; `_unroll_node`, `_unroll_subtree`, `_heal_settle_without_done` and `_resolved_ancestor` are new; `_reopen` uses `_unroll_node`. New judge-errors kinds: `unroll-heal`, `gate-stamp` (a complete run whose stamp could not be written; the session stays due) and seven `*-unreadable` kinds (`states-unreadable`, `cleared-unreadable`, `stall-unreadable`, `captions-unreadable`, `episodes-unreadable`, `marker-unreadable`, `archive-unreadable`); `docs/judges.md`'s kinds list and `_log_judge_error`'s docstring carry them all. `_prompt_gist`, `_episode_read`, `_death_marker` and `load_goal_archive` keep their empty answers for a file that exists and cannot be read or parsed, and now mark the running stage incomplete through `_read_failed`; `_episode_read` no longer memoizes a failed read under the file's mtime, and neither does `load_goal_archive_shared`.
- `save_goals` stamps `_baseRev` again in a `finally` for stores that carried one: the written revision after a publish, the loaded base when the publish did not happen (a raise inside the CAS loop, at the write or at the rename), and the `_unread` mark is restored when nothing was published; a refusal before the pop leaves the object untouched (pinned by `ReadFaultCas`). `_mark_unread(store, reason)` sets the `_unread` mark (`"journal"`, the one reason left since #1019) and marks the running stage incomplete; `_read_failed` and `_read_ok` keep the per-episode set, and an absent read ends an episode as a good one does.
- `_view_cleared()` returns a frozenset (the seven callers test membership; none mutates). `_distill_due_t(store, nid, blocked, kids=None)`; `_kids_map(nodes)`. `stalled_facts(fsid, strict=False)`: strict raises `OSError` for a file that exists and does not read.
- `docs/goal-state.md` rule 6 names container dissolution as the second un-resolver of `rolledUp` children. `docs/reference.md`'s `plannerSkip` and `goalArchive` entries and `docs/judges.md`'s Skips entry describe the gates as they stand (commit 13).

## Not included

- No `GET /perf` or `romp perf` rows of this PR's own. `memos.plannerSkip` (main's, #1173) now counts only the sessions the evidence gate ran, so on a quiet kernel its `skipped` stays low while the evidence gate does the skipping; `tier_stats()` holds the evidence gate's per-tier counters, and the memo counters are module state read by their tests. Wiring them into the counter route #1003 landed is a follow-up PR that wires every judge counter at once. `save_goals`' no-op hash timing and the kernel-side judge wake counters wait for the same PR.
- #1019 (on main) made two further commits of this series moot: a goals file that exists and cannot be read now raises into the per-session boundary, and unparseable bytes are quarantined aside, so the `save_goals` refusal of a fallback store, the kernel's undo-clear stand-down and the once-per-episode warn frame were dropped in the rebase (see the note under the summary). One hole #1019 leaves is taken up here only on the judge's side: since the review commit `load_goal_archive` marks the running stage incomplete and logs an `archive-unreadable` row for a file that exists and cannot be read or parsed, so no tier stamps over an archive it never read, and since the rebase the readers' shared memo does not keep that answer either. Its answer is still the empty archive, and `save_goal_archive` overwrites blindly, so the kernel's compaction pass and undo-clear restore, which read through the same function, would still publish over an unreadable archive. A raise into their paths wants #1019's shape (a read fault raises into a boundary, unparseable bytes are moved aside), in a PR of its own.
- The inner change gate stays as main landed it (its table, key terms and counters); this PR only aligns its record rule with the completeness bit. Retiring it in favour of the evidence gate is Question 1.

## Questions

1. The planner now runs behind two gates, one inside the other. The evidence gate around `_plan_session` keys on the inner gate's inputs and more (the reg by its `spawnedAt` and backend values rather than by identity) and records only a complete run, so in a framed pass the inner gate sees only the sessions the outer one ran and `memos.plannerSkip` counts those alone; outside a pass frame (`romp-judge --plan`) the inner gate is the one that skips, since a parse tier never stamps there. Both are kept here, and commit 12 aligns the inner gate's record rule with the completeness bit. Keep both, or retire the inner gate (its table, key and counters) once the evidence gate's per-tier counters reach `/perf` in the follow-up?
2. Commit 9's served-pair rule applies to the planner and closer too: a run that never called `parsed_session` for a session now stamps where it previously bypassed. The exactness argument is in the commit (the stage's own read would have pinned a pair); the cost is a re-arm on every transcript append for sessions with no blocked candidate. Is that the rule you want, or should the parse tiers keep bypassing?
3. Commit 1's lag for warm sessions (a turn ending mid-pass is judged whole in the next pass) is stated, not measured. The review commit removed it for the kernel's tick jobs, which read live; the question is about the judge stages only. Acceptable as is?
4. Closed by the review commit. Commit 3 left one window documented: a raise inside `save_goals`' CAS loop (after the base is popped, before the rename) left the store object without a base, so the holder's next save was unconditional. The base is now restored in a `finally` when the publish did not happen, so the retry stays CAS-protected, and `ReadFaultCas` pins it at the loop and at the rename.
5. `_materialize_from_log(nodes, store=None)`: the store is optional so callers that pass nodes only keep working. Would you rather it be required?
6. The per-tier counters (`tier_stats()`) arrive ahead of any route that reports them. Keep them for the follow-up that wires the judge counters into #1003's route, or land them with the wiring?

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
