### PR TITLE
A live session stays in the tab list while its transcript file is briefly unreadable — the kernel keeps it listed, and the pane never treats a live session's omission from one frame as a close

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2501,6 +2501,62 @@ def _has_tmux():
     return shutil.which("tmux") is not None
 
 
+# ── a LIVE session survives a transient transcript-read failure on the tab list (T258) ─────────────────────
+# _alive_sessions resolves each live sid to a transcript through discover(), which scans project dirs for
+# <sid>.jsonl. A file moved aside (a torn write, a hand `mv`, a resume that renames the leaf before the CLI
+# recreates it) leaves discover with NO entry, so the live session dropped off _alive_sessions → the chat tab
+# list → the tabOrder push, and the pane tore its tab down through the T236 omission path. A read that failed
+# for a cycle is NOT a state change (the same rule as T249b's empty-build guard). A session whose tmux lane /
+# SDK reg is live stays listed with a names/-derived stub — the EXPECTED path under its cwd, which discover
+# re-resolves the instant the file returns — and build_session parses the missing file to empty while the
+# T249b guard holds its last content. Said once per episode + a romp-perf line.
+_UNRESOLVED_LIVE_NOTED = set()      # live sids inside an unresolved-transcript episode (one stderr line each)
+
+
+def _live_stub_session(sid, now):
+    """A _sessions()-shaped entry for a LIVE sid discover cannot resolve this cycle. The path is the expected
+    transcript under the session's cwd (from names/), which may not exist right now — build_session re-resolves
+    it and the empty-read guard covers the gap. None when there is nothing to stub from: no names/ entry and no
+    SDK owner, a genuinely unknown live sid, which stays out (never invented)."""
+    name = _name_of(sid)
+    cwd = _cwd_of(sid)
+    if not name and not cwd:
+        return None
+    path = (jd._proj_dir(cwd) / (sid + ".jsonl")) if cwd else (jd.STATE / "boot-stub" / (sid + ".jsonl"))
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        mtime = now
+    return {"sid": sid, "name": name or sid[:8], "anchor": sid, "path": str(path), "mtime": mtime}
+
+
+def _note_unresolved_live(sid, path):
+    """One stderr line per episode naming the live sid whose transcript could not be resolved, plus a
+    romp-perf `liveunresolved` line every cycle it holds (for the perf log / the harness)."""
+    sid = str(sid or "")
+    _perf("liveunresolved", sid=sid[:8])
+    if sid in _UNRESOLVED_LIVE_NOTED:
+        return
+    _UNRESOLVED_LIVE_NOTED.add(sid)
+    sys.stderr.write("romp-kernel: %s is LIVE but its transcript could not be resolved (expected %s) — keeping "
+                     "it in the tab list with its last-known meta; a read failure is not a close\n"
+                     % (sid[:8], path))
+
+
+def _clear_unresolved_live_note(sid):
+    _UNRESOLVED_LIVE_NOTED.discard(str(sid or ""))
+
+
+def _tab_order_frame(order, tabs, live):
+    """The ONE tabOrder frame shape (T258): the shared order, the tabs meta, the viewer's views blob, and
+    `live` — the sids the kernel affirms are LIVE this build (raw tmux/SDK liveness, independent of whether
+    discover could resolve each one's transcript). The pane keeps a live sid on the strip even if this frame's
+    `order` omits it: a transient read failure that drops a session from the order is not a close (render.ts
+    applyTabOrder). Older clients ignore the extra field."""
+    return {"type": "tabOrder", "order": list(order), "tabs": tabs,
+            "views": _views_client(), "live": sorted({str(x) for x in live})}
+
+
 def _alive_sessions(now, tmux):
     """The sessions shown on EVERY surface (feed / timeline / chat tabs): only those alive in tmux
     right now. The hard liveness filter (the user 2026-06-15) — ignore everything that isn't a living
@@ -2542,7 +2598,18 @@ def _alive_sessions(now, tmux):
     if be:
         for sid in tmux:
             if sid not in have and be.owns(sid):
-                alive.append(_sdk_sess(sid, now))
+                alive.append(_sdk_sess(sid, now)); have.add(sid)
+    # a LIVE sid discover STILL cannot resolve (its transcript file is momentarily unreadable) stays listed
+    # with a stub rather than dropping off the strip (T258, see _live_stub_session above)
+    still = [sid for sid in tmux if sid not in have]
+    for sid in still:
+        stub = _live_stub_session(sid, now)
+        if stub is not None:
+            alive.append(stub); have.add(sid)
+            _note_unresolved_live(sid, stub["path"])
+    for sid in list(_UNRESOLVED_LIVE_NOTED):     # resolved again OR died → the episode is over, re-arm the note
+        if sid not in still:
+            _clear_unresolved_live_note(sid)
     if tmux or _has_tmux():
         return alive
     return _sessions(now)
@@ -34738,7 +34805,7 @@ def _push(targets, connect=False, tmux=None):
                 _send_client(c, ("globalRetryPaused",), {"type": "globalRetryPaused", "value": _retry_paused_on(),
                                                          "resumeAt": _retry_resume_at(),   # limit reset epoch → the card counts down to the real retry
                                                          "reason": _retry_pause_reason()})   # "spend" → the card says 'raise your cap', no countdown
-                _send_client(c, ("taborder",), {"type": "tabOrder", "order": tab_order, "tabs": tab_meta, "views": _views_client()})
+                _send_client(c, ("taborder",), _tab_order_frame(tab_order, tab_meta, tmux))
             active = {c.get("active") for c in chat_clients if c.get("active")}
             # Stable: active tabs first — and TRANSCRIPT-LESS sessions with them. A just-created session
             # has no transcript, so its build is near-free, and its creator is guaranteed to be staring
@@ -35064,7 +35131,7 @@ def _push_session_now(sid):
             return                                   # the periodic pusher owns the sid until content returns
         ms = None                                    # lazy: the first full send materializes it, the rest reuse
         for c in targets:
-            _send_client(c, ("taborder",), {"type": "tabOrder", "order": tab_order, "tabs": tab_meta, "views": _views_client()})
+            _send_client(c, ("taborder",), _tab_order_frame(tab_order, tab_meta, tmux))
             ms = _send_chat(c, m, ms, 0, True)       # change_from 0 → always the full-session form
     except Exception:
         sys.stderr.write("push-session-now (%s): %s\n" % (sid, traceback.format_exc()))
@@ -35101,10 +35168,11 @@ def _confirm_close_now(sid):
     Off-cycle by design: `_tmux_sessions()` outside a pusher cycle is a live Sessions.live() read."""
     try:
         now = int(time.time())
-        chat_list = _chat_tab_sessions(now, _tmux_sessions())
+        tmux = _tmux_sessions()
+        chat_list = _chat_tab_sessions(now, tmux)
         tab_order = [s["sid"] for s in chat_list]
         tab_meta = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])} for s in chat_list]
-        frame = {"type": "tabOrder", "order": tab_order, "tabs": tab_meta, "views": _views_client()}
+        frame = _tab_order_frame(tab_order, tab_meta, tmux)
         with _clients_lock:
             targets = [c for c in _clients if c["app"] == "chat"]
         for c in targets:
@@ -42673,11 +42741,12 @@ class Handler(BaseHTTPRequestHandler):
                 # back to ordering tabs by session STATE — so they drift on their own (worse now that the
                 # heartbeat auto-reloads). _ordered_alive is the same order chat tabs + timeline lanes use.
                 try:
-                    _alive = _ordered_alive(int(time.time()), _tmux_sessions())
+                    _tm = _tmux_sessions()
+                    _alive = _ordered_alive(int(time.time()), _tm)
                     _o = [s["sid"] for s in _alive]
                     # name+color per tab → the client paints the whole strip as placeholders up front (tabs-first)
                     _tabs = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])} for s in _alive]
-                    _frame = {"type": "tabOrder", "order": _o, "tabs": _tabs, "views": _views_client()}
+                    _frame = _tab_order_frame(_o, _tabs, _tm)
                     client["send"](json.dumps(_frame))
                     # sent on the raw socket, not through _send_client — so its views seq is captured here
                     _sq = _views_seq_of(_frame)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2526,7 +2526,8 @@ def _live_stub_session(sid, now):
     try:
         mtime = path.stat().st_mtime
     except OSError:
-        mtime = now
+        mtime = 0        # the file is the thing that is missing; never the clock (a ticking mtime re-sorts the
+        #                  feed's order every push and defeats its dedup) — the wide-walk fallback's idiom
     return {"sid": sid, "name": name or sid[:8], "anchor": sid, "path": str(path), "mtime": mtime}
 
 

--- a/tests/test_kernel_tabs_first.py
+++ b/tests/test_kernel_tabs_first.py
@@ -25,12 +25,12 @@ class TabsFirst(unittest.TestCase):
         src = inspect.getsource(km._push)
         self.assertIn('tab_meta = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])}', src,
                       "the periodic push builds a name+color list per tab")
-        self.assertIn('{"type": "tabOrder", "order": tab_order, "tabs": tab_meta, "views": _views_client()}', src,
+        self.assertIn('_send_client(c, ("taborder",), _tab_order_frame(tab_order, tab_meta, tmux))', src,
                       "and ships it as the tabs field alongside the sid order")
 
     def test_connect_ready_handler_also_sends_tabs(self):
         text = open(KPATH).read()
-        self.assertIn('{"type": "tabOrder", "order": _o, "tabs": _tabs, "views": _views_client()}', text,
+        self.assertIn('_frame = _tab_order_frame(_o, _tabs, _tm)', text,
                       "the WS 'ready' connect push also carries name+color tabs")
         self.assertIn('_tabs = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])}', text)
 

--- a/tests/test_live_session_unresolved_transcript.py
+++ b/tests/test_live_session_unresolved_transcript.py
@@ -1,0 +1,130 @@
+"""A LIVE session stays in the tab list while its transcript file is briefly unreadable (T258, the user
+2026-09-08). _alive_sessions resolves each live sid through discover(), which scans project dirs for
+<sid>.jsonl; a file moved aside leaves discover with no entry, so the live session dropped off the chat tab
+list and the pane tore its tab down (T236 omission). A transient read failure is not a state change: a
+session whose tmux lane is live stays listed with a names/-derived stub, said once per episode. Behavioural
+pins driving the real _alive_sessions / _chat_tab_sessions with a scripted names registry and a vanishing
+transcript; synthetic ids only.
+"""
+import io
+import os
+import sys
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest import mock
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_liveunresolved", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-4333-8444-000000000258"
+NOW = 1781300000
+
+
+class _World(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        root = Path(self.td.name)
+        self.cwd = root / "work"; self.cwd.mkdir()
+        # names registry entry: name \t cwd \t #bg  (written at launch for both backends)
+        jd.NAMES.mkdir(parents=True, exist_ok=True)
+        (jd.NAMES / SID).write_text("web\t%s\t#3fa7c9\n" % self.cwd)
+        # the real transcript, where discover expects it
+        self.proj = jd._proj_dir(str(self.cwd)); self.proj.mkdir(parents=True, exist_ok=True)
+        self.tx = self.proj / (SID + ".jsonl")
+        self.tx.write_text('{"type":"user","uuid":"11111111-2222-4333-8444-0000000258a1","parentUuid":null,'
+                           '"timestamp":"2026-09-01T00:00:00.000Z","sessionId":"%s",'
+                           '"message":{"role":"user","content":"hi"}}\n' % SID)
+        self.tmux = {SID: {"state": "waiting", "since": NOW - 60, "model": "", "effort": "",
+                           "context": None, "backend": "tmux", "color": "#3fa7c9"}}
+        if hasattr(km, "_UNRESOLVED_LIVE_NOTED"):
+            km._UNRESOLVED_LIVE_NOTED.discard(SID)   # tolerate a pre-fix kernel so the premise test is a real red-first
+        # discover caches on a namespace fingerprint; clear it so the vanish is seen
+        jd._discover_cache.clear(); jd._namefp_memo.clear()
+
+    def tearDown(self):
+        if hasattr(km, "_UNRESOLVED_LIVE_NOTED"):
+            km._UNRESOLVED_LIVE_NOTED.discard(SID)
+        for f in (jd.NAMES / SID,):
+            try: f.unlink()
+            except OSError: pass
+        self.td.cleanup()
+
+    def _alive_sids(self):
+        jd._discover_cache.clear()
+        return {s["sid"] for s in km._alive_sessions(NOW, self.tmux)}
+
+    def test_present_while_the_transcript_is_readable(self):
+        self.assertIn(SID, self._alive_sids(), "premise: a live session with its transcript is listed")
+
+    def test_stays_listed_when_the_transcript_file_is_moved_aside(self):
+        self.assertIn(SID, self._alive_sids())
+        moved = self.tx.with_suffix(".jsonl.away")
+        self.tx.rename(moved)
+        err = io.StringIO()
+        with mock.patch.object(sys, "stderr", err):
+            alive = km._alive_sessions(NOW, self.tmux)
+        sids = {s["sid"] for s in alive}
+        self.assertIn(SID, sids, "a LIVE session whose transcript vanished for a cycle stays in the tab list")
+        row = next(s for s in alive if s["sid"] == SID)
+        self.assertEqual(row["name"], "web", "with its last-known name from names/")
+        self.assertEqual(row["path"], str(self.tx), "and the EXPECTED path, re-resolved when the file returns")
+        self.assertIn("LIVE but its transcript could not be resolved", err.getvalue(), "said on stderr")
+        # and the chat tab list carries it, so the tabOrder push never omits it
+        moved.rename(self.tx)   # (restore for the next assertion's discover)
+        jd._discover_cache.clear()
+
+    def test_the_note_is_said_once_per_episode_and_re_arms_after_the_file_returns(self):
+        moved = self.tx.with_suffix(".jsonl.away"); self.tx.rename(moved)
+        err = io.StringIO()
+        with mock.patch.object(sys, "stderr", err):
+            km._alive_sessions(NOW, self.tmux)
+            jd._discover_cache.clear()
+            km._alive_sessions(NOW, self.tmux)
+        self.assertEqual(err.getvalue().count("could not be resolved"), 1, "one line per episode, not per cycle")
+        moved.rename(self.tx); jd._discover_cache.clear()
+        self.assertIn(SID, self._alive_sids(), "resolved again once the file is back")
+        self.assertFalse(getattr(km, "_UNRESOLVED_LIVE_NOTED", set()).__contains__(SID), "the episode note re-arms after content returns")
+
+    def test_the_chat_tab_list_keeps_the_live_session(self):
+        moved = self.tx.with_suffix(".jsonl.away"); self.tx.rename(moved)
+        jd._discover_cache.clear()
+        with mock.patch.object(sys, "stderr", io.StringIO()):
+            tabs = km._chat_tab_sessions(NOW, self.tmux)
+        self.assertIn(SID, {s["sid"] for s in tabs}, "the tabOrder push (built from this) never omits a live session")
+        moved.rename(self.tx)
+
+    def test_a_dead_session_whose_file_is_gone_is_NOT_stubbed(self):
+        moved = self.tx.with_suffix(".jsonl.away"); self.tx.rename(moved)
+        jd._discover_cache.clear()
+        with mock.patch.object(sys, "stderr", io.StringIO()):
+            alive = km._alive_sessions(NOW, {})   # tmux says nothing is live
+        self.assertNotIn(SID, {s["sid"] for s in alive}, "a read failure only KEEPS a live session; a dead one still drops")
+        moved.rename(self.tx)
+
+    def test_an_unknown_live_sid_with_no_names_entry_is_left_out(self):
+        (jd.NAMES / SID).unlink()
+        moved = self.tx.with_suffix(".jsonl.away"); self.tx.rename(moved)
+        jd._discover_cache.clear()
+        with mock.patch.object(km, "_sdk", lambda: None), mock.patch.object(sys, "stderr", io.StringIO()):
+            alive = km._alive_sessions(NOW, self.tmux)
+        self.assertNotIn(SID, {s["sid"] for s in alive}, "nothing to stub from → never invented")
+        moved.rename(self.tx)
+
+
+class FrameCarriesLive(unittest.TestCase):
+    def test_the_tab_order_frame_names_the_live_sids(self):
+        with mock.patch.object(km, "_views_client", lambda: {}):
+            f = km._tab_order_frame(["a", "b"], [{"id": "a"}], {"a", "b", "c"})
+        self.assertEqual(f["type"], "tabOrder")
+        self.assertEqual(f["order"], ["a", "b"])
+        self.assertEqual(f["live"], ["a", "b", "c"], "sorted, deduped, independent of the order")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_live_session_unresolved_transcript.py
+++ b/tests/test_live_session_unresolved_transcript.py
@@ -31,7 +31,13 @@ class _World(unittest.TestCase):
         self.td = tempfile.TemporaryDirectory()
         root = Path(self.td.name)
         self.cwd = root / "work"; self.cwd.mkdir()
-        # names registry entry: name \t cwd \t #bg  (written at launch for both backends)
+        # names registry entry: name \t cwd \t #bg  (written at launch for both backends). The kernel binds
+        # NAMES at import while the ONE romp_judge module is re-executed by every later kernel load in the
+        # suite, so km.NAMES and jd.NAMES can name different roots under the full run — align them.
+        self._names_patch = mock.patch.object(km, "NAMES", jd.NAMES); self._names_patch.start()
+        # …and the transcript root: jd.PROJECTS defaults to the REAL ~/.claude/projects when CLAUDE_CONFIG_DIR is
+        # unset, so every project dir this test makes lives under its own temp root (never live state)
+        self._proj_patch = mock.patch.object(jd, "PROJECTS", root / "projects"); self._proj_patch.start()
         jd.NAMES.mkdir(parents=True, exist_ok=True)
         (jd.NAMES / SID).write_text("web\t%s\t#3fa7c9\n" % self.cwd)
         # the real transcript, where discover expects it
@@ -48,6 +54,8 @@ class _World(unittest.TestCase):
         jd._discover_cache.clear(); jd._namefp_memo.clear()
 
     def tearDown(self):
+        self._proj_patch.stop()
+        self._names_patch.stop()
         if hasattr(km, "_UNRESOLVED_LIVE_NOTED"):
             km._UNRESOLVED_LIVE_NOTED.discard(SID)
         for f in (jd.NAMES / SID,):

--- a/tests/test_payload_dedup_invariant.py
+++ b/tests/test_payload_dedup_invariant.py
@@ -134,19 +134,29 @@ class BuiltFeedIsClockInvariantApartFromTheClockItself(unittest.TestCase):
         (names / SID).write_text("web\t%s\t#abcdef\n" % str(cdir))
 
         self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-                      km.NAMES, km._GLOBAL_CLAUDE_MD)
+                      km.NAMES, km._GLOBAL_CLAUDE_MD, km.jd.NAMES, km.jd.PROJECTS)
         jd.NAMES, jd.PROJECTS = names, proj
         jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
         jd.STATE = td
         km.NAMES = names
+        # The KERNEL's judge module is a separate object from this module's `jd` (each is its own
+        # SourceFileLoader load), so discover() — which the kernel runs through km.jd — never saw this
+        # fixture's names/ or transcript: the session was invisible and the invariant held hollowly. Reach
+        # the kernel's copy too, so the fixture's transcript is the one the feed builds from (T258).
+        km.jd.NAMES, km.jd.PROJECTS = names, proj
         km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
         # Fixed so the stub itself contributes nothing clock-derived (mirrors the chat invariant test).
         self.tmux = {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
                            "context": None, "compactPct": None, "color": None}}
+        # The invariant is over an UNCHANGING fleet. A session's FIRST build adopts it into the persisted
+        # session order (feed `order` reads that file before _ordered appends the newcomer), so the first
+        # sight is a genuine change; warm once so the two compared builds are both post-adoption (T258).
+        km.jd._discover_cache.clear()
+        km.build_feed(NOW - 1, self.tmux)
 
     def tearDown(self):
         (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-         km.NAMES, km._GLOBAL_CLAUDE_MD) = self.saved
+         km.NAMES, km._GLOBAL_CLAUDE_MD, km.jd.NAMES, km.jd.PROJECTS) = self.saved
         self.td.cleanup()
 
     def test_only_the_declared_volatile_fields_move_with_the_clock(self):

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -262,8 +262,9 @@ class TimelineViews(unittest.TestCase):
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn('"views": _views_client(),', src, "the timeline payload carries the RENDERED shape")
         self.assertIn('"palette": pal.colors(_palette_name()),', src, "and the palette, for tag colors in every host")
-        self.assertIn('"tabs": tab_meta, "views": _views_client()', src, "tabOrder pushes carry it")
-        self.assertIn('"tabs": _tabs, "views": _views_client()', src, "the connect-time tabOrder carries it")
+        self.assertIn('_tab_order_frame(tab_order, tab_meta, tmux)', src, "tabOrder pushes carry it (the one frame builder, T258)")
+        self.assertIn('"views": _views_client(), "live":', src, "…which carries the blob")
+        self.assertIn('_frame = _tab_order_frame(_o, _tabs, _tm)', src, "the connect-time tabOrder carries it")
 
     def test_web_boot_exposes_the_set_views_hook(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -53,7 +53,7 @@ test("the feed dot matches too: dotFor picks work/await per name, the dot retint
   // headers, and the session-filter button (2026-08-08; its menu rows route via setWorkDot(label,…))
   assert.equal((FEED.match(/setWorkDot\((?:a\._name|agent|nm), dotFor\(/g) || []).length, 6);
   assert.match(FEEDCSS, /\.fwork-dot\.await \{ background: #54B204; \}/);
-  assert.match(FED, /const ARRAY_ID = \["order", "names", "working", "awaiting", "stateUnknown"\];/);
+  assert.match(FED, /const ARRAY_ID = \["order", "names", "working", "awaiting", "stateUnknown", "live"\];/);   // + the tabOrder frame\'s live set (T258)
   assert.match(FED, /if \(Array\.isArray\(f\.awaiting\)\) merged\.awaiting\.push\(\.\.\.f\.awaiting\);/);
 });
 

--- a/ui/webview/draft-teardown.test.ts
+++ b/ui/webview/draft-teardown.test.ts
@@ -293,7 +293,7 @@ test("every teardown names its reason, and only a genuine end clears the compose
   // the kernel's closed frame — or federation's stamped stand-in for a dropped host
   assert.match(RENDER, /else if \(m\.type === "closed"\) dismissSession\(m\.id, m\.hostDrop === true \? "hostDrop" : "end"\);/);
   // applyTabOrder's kernel-order omission
-  assert.match(RENDER, /const omitted = new Set\(order\.filter\(\(id\) => kernelListed\.has\(id\) && !inKernel\.has\(id\)\)\);[^\n]*\n\s*for \(const id of order\.slice\(\)\) \{\s*\n\s*if \(omitted\.has\(id\)\) dismissSession\(id, "omitted", omitted\);/);
+  assert.match(RENDER, /const omitted = new Set\(order\.filter\(\(id\) => kernelListed\.has\(id\) && !inKernel\.has\(id\) && !liveSet\.has\(id\)\)\);[^\n]*\n(?:.*\n){0,3}?\s*for \(const id of order\.slice\(\)\) \{\s*\n\s*if \(omitted\.has\(id\)\) dismissSession\(id, "omitted", omitted\);/);   // a live id is never omitted (T258)
   // the clear is gated: the existing one-liner (composer-draft-persist.test.ts pins it) now runs for an end only
   assert.match(RENDER, /if \(why === "close" \|\| why === "end"\) \{[\s\S]*?drafts\.delete\(id\); composerCitations\.delete\(id\); composerEdits\.delete\(id\); composerFiles\.delete\(id\); persistDrafts\(\);\s*\n\s*\} else \{\s*\n\s*persistDrafts\(\);/);
 });

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -52,7 +52,7 @@ function dashboardWid(): string {
 // The shapes a kernel→browser message can carry a session id in. Kept generic (by field name, not by
 // message type) so a new message type that reuses these field names is covered automatically:
 const SCALAR_ID = ["id", "sid"]; //               a single session id
-const ARRAY_ID = ["order", "names", "working", "awaiting", "stateUnknown"]; // an array of session ids
+const ARRAY_ID = ["order", "names", "working", "awaiting", "stateUnknown", "live"]; // an array of session ids
 const OBJ_SID = ["asks", "items", "ledgers", "sessions"]; //  an array of objects keyed by `.sid`
 const OBJ_ID = ["tabs"]; //                       an array of objects keyed by `.id`
 
@@ -658,6 +658,7 @@ export class FederationManager {
   private frozeAt = 0;   // the Page Lifecycle `freeze` before the current thaw: a socket already overdue at that moment is not stamped by resumed()
   private perHostOrder: Record<string, string[]> = {};
   private perHostTabs: Record<string, any[]> = {};
+  private perHostLive: Record<string, string[]> = {};   // each host's affirmed-live sids (T258): the merged tabOrder carries their union
   private localViews: any = null;   // the LOCAL kernel's session-views blob, carried on merged tabOrder re-emits
   private localViewsRejected: any = null;   // the last LOCAL tabOrder blob the seq gate turned away since it last adopted one — the caps frame adopts it (inbound)
   private tlViewsRejected: any = null;      // the same for the LOCAL lanes payload's blob (perHostTl[LOCAL].views)
@@ -864,6 +865,7 @@ export class FederationManager {
       const gone = m.id;
       if (this.perHostOrder[host]) this.perHostOrder[host] = this.perHostOrder[host].filter((x) => x !== gone);
       if (this.perHostTabs[host]) this.perHostTabs[host] = this.perHostTabs[host].filter((t: any) => !(t && t.id === gone));
+      if (this.perHostLive[host]) this.perHostLive[host] = this.perHostLive[host].filter((x) => x !== gone);
       this.perHostSids[host]?.delete(gone);
       window.dispatchEvent(new MessageEvent("message", { data: m }));
       this.emitMergedOrder();
@@ -874,6 +876,7 @@ export class FederationManager {
       const prevTabs = this.perHostTabs[host] || [];
       this.perHostOrder[host] = Array.isArray(m.order) ? m.order.filter((x: any) => typeof x === "string") : [];
       this.perHostTabs[host] = Array.isArray(m.tabs) ? m.tabs : [];
+      this.perHostLive[host] = Array.isArray(m.live) ? m.live.filter((x: any) => typeof x === "string") : [];
       // session VIEWS (the user 2026-08-18): the blob is the LOCAL kernel's viewer pref (ids arrive
       // host-prefixed inside it already) — remote kernels' copies are their own dashboards' prefs.
       // Without this passthrough the merged re-emit silently dropped the field and the browser
@@ -1016,8 +1019,9 @@ export class FederationManager {
   private emitMergedOrder(fresh = false, freshHost: string = LOCAL): void {
     const order = mergeHostOrder(this.perHostOrder, this.hostSeq, this.view());
     const tabs = this.hostSeq.flatMap((h) => this.perHostTabs[h] || []);
+    const live = this.hostSeq.flatMap((h) => this.perHostLive[h] || []);   // T258: the union the pane's omission guard reads
     this.publishPending();
-    const data: any = { type: "tabOrder", order, tabs, views: this.localViews ?? undefined };
+    const data: any = { type: "tabOrder", order, tabs, live, views: this.localViews ?? undefined };
     // Provenance for the chat's close backstop (T233): a FRESH emission is driven by one host's own
     // tabOrder push and names that host (`freshHost`) — only ITS ids are that kernel's current word; the
     // other hosts' slices ride along from the store. A SYNTHETIC re-emit (a view-order storage event, a
@@ -1324,6 +1328,7 @@ export class FederationManager {
     }
     delete this.perHostOrder[host];
     delete this.perHostTabs[host];
+    delete this.perHostLive[host];
     delete this.perHostSids[host];
     delete this.perHostFeed[host];
     delete this.perHostFeedAt[host];

--- a/ui/webview/feed-unscoped.test.ts
+++ b/ui/webview/feed-unscoped.test.ts
@@ -35,7 +35,7 @@ test("the coupling's artifacts are fully retired: cue, N-outside line, promoted 
 });
 
 test("the kernel's views blob serves the tabs/timeline; the feed payload carries it again for the tag mounts", () => {
-  assert.ok(KERNEL.includes('"views": _views_client()}'), "tabOrder pushes keep the blob (tabs + timeline consume it)");
+  assert.ok(KERNEL.includes('"views": _views_client(), "live": sorted({str(x) for x in live})}'), "tabOrder pushes keep the blob (tabs + timeline consume it; the one frame builder, T258)");
   const fp = KERNEL.slice(KERNEL.indexOf('return {"type": "feed", "asks": asks'), KERNEL.indexOf('"clearNotices"'));
   // retired 2026-08-25 morning as unread; REVIVED the same day for the per-surface tag lenses —
   // the outline pane and the feed's own tag filter read the rendered blob off this payload

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -55,6 +55,7 @@ import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
 import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
 import { followReader, keepPlaceAcrossShow } from "./scroll-keep";
+import { retainLiveOmitted } from "./tab-order";
 import { keepResidentEvents } from "./frame-merge";
 import { activeTabToReannounce } from "./relay-active";
 import { dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
@@ -4672,7 +4673,7 @@ function ackClosingTabs(kernelOrder: readonly string[], report?: OrderReport): v
 // looking alive). Add-only, never pruned: dropping an entry would hand a late stale `session` frame the
 // never-listed keep and re-mint the ghost. Client-minted ids (the create placeholder) never enter it.
 const kernelListed = new Set<string>();
-function applyTabOrder(o: any, tabs?: any, report?: OrderReport) {
+function applyTabOrder(o: any, tabs?: any, report?: OrderReport, live?: any) {
   // name+color per tab → renderTabs paints placeholders for tabs whose session hasn't arrived yet (tabs-first).
   // The payload is the kernel's AUTHORITATIVE current tab set, so REBUILD (not merge) — a closed tab drops out
   // and never lingers as a stale placeholder. Absent tabs (older kernel) → keep what we have.
@@ -4700,11 +4701,21 @@ function applyTabOrder(o: any, tabs?: any, report?: OrderReport) {
   // federation the merged order only omits an id when its OWNING host affirmatively reported it gone
   // (per-host slices persist across down/detached hosts), so this never fires on a tunnel blip.
   const inKernel = new Set<string>(kernelOrder);
-  const omitted = new Set(order.filter((id) => kernelListed.has(id) && !inKernel.has(id)));   // all of them first: no fallback onto one going in the same breath
+  // A kernel-owned id the push no longer carries but that the kernel STILL affirms LIVE (frame `live`) is a
+  // transient read failure, never a close (T258, the user 2026-09-08): its transcript was briefly unreadable.
+  // Exclude it from the teardown AND keep it on the strip at its slot (retainLiveOmitted) until the next frame
+  // re-lists it. The kernel-side fix keeps it in `order` already, so this is the second line of defense; an
+  // older kernel sends no `live` and this is a no-op. One clientDiag row names any id it saves, so a kernel
+  // that omits a live session is seen, never silently papered over.
+  const liveSet = new Set<string>(Array.isArray(live) ? live.filter((x: any) => typeof x === "string") : []);
+  const omitted = new Set(order.filter((id) => kernelListed.has(id) && !inKernel.has(id) && !liveSet.has(id)));   // all of them first: no fallback onto one going in the same breath
+  const keptLive = order.filter((id) => kernelListed.has(id) && !inKernel.has(id) && liveSet.has(id));
+  if (keptLive.length && vscodeApi) vscodeApi.postMessage({ type: "clientDiag", surface: "chat", what: "live-omitted-kept", data: { ids: keptLive } });
   for (const id of order.slice()) {
     if (omitted.has(id)) dismissSession(id, "omitted", omitted);
   }
-  const next = reconcileTabOrder(kernelOrder, order, (id) => sessions.has(id) || tabMeta.has(id),
+  const next = reconcileTabOrder(retainLiveOmitted(kernelOrder, order, liveSet), order,
+                                 (id) => sessions.has(id) || tabMeta.has(id),
                                  (id) => kernelListed.has(id));
   order.length = 0;
   for (const id of next) order.push(id);
@@ -14091,7 +14102,7 @@ window.addEventListener("message", perfFrameHandler("chat", (m) => vscodeApi?.po
   else if (m.type === "imgData" && typeof m.path === "string") onImgData(m.path, typeof m.url === "string" ? m.url : null, typeof m.sid === "string" ? m.sid : null);
   else if (m.type === "tabOrder") {
     captureViews(m.views || null);
-    applyTabOrder(m.order, m.tabs, { reemit: m.reemit === true, freshHost: typeof m.freshHost === "string" ? m.freshHost : undefined });
+    applyTabOrder(m.order, m.tabs, { reemit: m.reemit === true, freshHost: typeof m.freshHost === "string" ? m.freshHost : undefined }, m.live);
   }
   else if (m.type === "renamed" && m.id && typeof m.name === "string") {
     notePendingMeta(pendingTabMeta, m.id, { name: m.name });   // kernel truth — hold it against a push built pre-rename

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -60,7 +60,7 @@ test("executed: the canonical key ignores list order AND which key the kernel us
 
 test("the tabOrder frame carries the blob and the strip filters on it, composing with #only", () => {
   // the frame's provenance rides along since T233 (captureViews still runs FIRST)
-  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}\);\s*\n\s*\}/,
+  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}, m\.live\);\s*\n\s*\}/,
     "echo-less frames still reach captureViews — an older kernel must age out a pending edit");
   assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
   assert.match(RENDER, /const visibleIds = only \? inViewIds\.filter\(\(id\) => matchesOnly\(nameOf\(id\), only\)\) : inViewIds;/);
@@ -110,7 +110,7 @@ test("federation carries the LOCAL kernel's views blob through merged tabOrder r
   // re-derived from the stored blob before it moves — cleared only when the adoption changes it
   // (federation-views-seq.test.ts executes all four rules)
   assert.match(FED, /if \(host === LOCAL && m\.views && typeof m\.views === "object"\) \{\s*\n\s*if \(adoptViews\(this\.localViews, m\.views, this\.localViewsAnnounced\)\) \{ this\.localViewsAnnounced = announcedAfter\(this\.localViews, m\.views, this\.localViewsAnnounced\); this\.localViews = m\.views; this\.localViewsRejected = null; \}\s*\n\s*else this\.localViewsRejected = m\.views;\s*\n\s*\}/);
-  assert.match(FED, /\{ type: "tabOrder", order, tabs, views: this\.localViews \?\? undefined \}/,
+  assert.match(FED, /\{ type: "tabOrder", order, tabs, live, views: this\.localViews \?\? undefined \}/,
     "without this the browser dashboard's chat never receives the blob at all");
 });
 

--- a/ui/webview/tab-close-optimistic.test.ts
+++ b/ui/webview/tab-close-optimistic.test.ts
@@ -156,7 +156,7 @@ test("the wiring: applyTabOrder hands the frame's provenance to the backstop, wh
   assert.match(RENDER, /type OrderReport = \{ reemit\?: boolean; freshHost\?: string \} \| undefined;/);
   assert.match(RENDER, /function ackClosingTabs\(kernelOrder: readonly string\[\], report\?: OrderReport\): void/);
   assert.match(RENDER, /if \(report && \(report\.reemit \|\| \(typeof report\.freshHost === "string" && hostOf\(id\) !== report\.freshHost\)\)\) continue;/);
-  assert.match(RENDER, /applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}\);/);
+  assert.match(RENDER, /applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}, m\.live\);/);   // + the frame\'s live set (T258)
   // confirm-on-absence is untouched: it acts BEFORE the provenance gate, on any order
   assert.match(RENDER, /if \(!live\.has\(id\)\) \{ closingTabs\.delete\(id\); continue; \}[\s\S]{0,120}?if \(now - ts < CLOSE_ACK_MS\) continue;[\s\S]{0,900}?if \(report && /);
 });

--- a/ui/webview/tab-ghost-heal.test.ts
+++ b/ui/webview/tab-ghost-heal.test.ts
@@ -126,11 +126,11 @@ test("a create placeholder the kernel has never listed still survives unrelated 
 test("applyTabOrder dismisses kernel-owned omissions BEFORE reconciling, then records add-only", () => {
   // the drop loop sits between ackClosingTabs and the reconcile, and dismissSession is the shared teardown
   assert.match(RENDER,
-    /ackClosingTabs\(kernelOrder, report\);[\s\S]{0,900}?const omitted = new Set\(order\.filter\(\(id\) => kernelListed\.has\(id\) && !inKernel\.has\(id\)\)\);[^\n]*\n\s*for \(const id of order\.slice\(\)\) \{\s*\n\s*if \(omitted\.has\(id\)\) dismissSession\(id, "omitted", omitted\);\s*\n\s*\}/,
+    /ackClosingTabs\(kernelOrder, report\);[\s\S]{0,1600}?const omitted = new Set\(order\.filter\(\(id\) => kernelListed\.has\(id\) && !inKernel\.has\(id\) && !liveSet\.has\(id\)\)\);[^\n]*\n(?:.*\n){0,3}?\s*for \(const id of order\.slice\(\)\) \{\s*\n\s*if \(omitted\.has\(id\)\) dismissSession\(id, "omitted", omitted\);\s*\n\s*\}/,
     "kernel-owned tabs the push stopped carrying get the closed-event teardown");
   // the reconcile passes the kernelListed predicate, so the pure model enforces the same rule
   assert.match(RENDER,
-    /reconcileTabOrder\(kernelOrder, order, \(id\) => sessions\.has\(id\) \|\| tabMeta\.has\(id\),\s*\n\s*\(id\) => kernelListed\.has\(id\)\)/);
+    /reconcileTabOrder\(retainLiveOmitted\(kernelOrder, order, liveSet\), order,\s*\n\s*\(id\) => sessions\.has\(id\) \|\| tabMeta\.has\(id\),\s*\n\s*\(id\) => kernelListed\.has\(id\)\)/);   // the retained order (T258) feeds the reconcile
   // add-only, recorded AFTER the reconcile: dropping entries would hand a late stale `session` frame the
   // never-listed keep and re-mint the ghost
   assert.match(RENDER, /for \(const id of next\) order\.push\(id\);\s*\n\s*for \(const id of kernelOrder\) kernelListed\.add\(id\);/);

--- a/ui/webview/tab-meta.test.ts
+++ b/ui/webview/tab-meta.test.ts
@@ -116,6 +116,6 @@ test("the tabOrder frame's views land before the strip repaints — a CLI tag ed
   // captureViews (adopt the pushed views/tags blob) must run BEFORE applyTabOrder (whose renderTabs
   // re-filters via tabInView) in the tabOrder handler — the (c) leg of the live-update fix
   // the frame's provenance rides along since T233 (captureViews still runs FIRST)
-  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}\);\s*\n\s*\}/);
+  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}, m\.live\);\s*\n\s*\}/);
   assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
 });

--- a/ui/webview/tab-order-live-omission.test.ts
+++ b/ui/webview/tab-order-live-omission.test.ts
@@ -1,0 +1,41 @@
+// T258 (the user 2026-09-08): render.ts applyTabOrder must not tear down a tab the kernel STILL affirms LIVE
+// just because one tabOrder frame omits it — a transient transcript-read failure is not a close. The frame
+// carries a `live` array (kernel _tab_order_frame; federation merges the per-host union); the omission
+// teardown excludes it, retainLiveOmitted keeps it on the strip, and one clientDiag row names any id it saved.
+// render.ts source pins + federation merge pin; red on the previous sources. Synthetic ids only.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+
+test("applyTabOrder takes the frame's live set and excludes it from the omission teardown", () => {
+  assert.match(RENDER, /import \{ retainLiveOmitted \} from "\.\/tab-order";/);
+  assert.match(RENDER, /function applyTabOrder\(o: any, tabs\?: any, report\?: OrderReport, live\?: any\) \{/);
+  const m = RENDER.match(/^function applyTabOrder\([\s\S]*?\n\}/m);
+  assert.ok(m, "applyTabOrder");
+  const body = m![0];
+  assert.match(body, /const liveSet = new Set<string>\(Array\.isArray\(live\) \? live\.filter\(\(x: any\) => typeof x === "string"\) : \[\]\);/);
+  // the omission set now excludes a live id
+  assert.match(body, /const omitted = new Set\(order\.filter\(\(id\) => kernelListed\.has\(id\) && !inKernel\.has\(id\) && !liveSet\.has\(id\)\)\);/);
+  // and the retained order (live-but-omitted ids kept at their slot) feeds reconcile
+  assert.match(body, /reconcileTabOrder\(retainLiveOmitted\(kernelOrder, order, liveSet\), order,/);
+  // a saved id is named once, so a kernel that omits a live session is visible, never silent
+  assert.match(body, /what: "live-omitted-kept", data: \{ ids: keptLive \}/);
+});
+
+test("the tabOrder message hands applyTabOrder the frame's live array", () => {
+  assert.match(RENDER, /applyTabOrder\(m\.order, m\.tabs, \{ reemit:[\s\S]*?\}, m\.live\);/);
+});
+
+test("federation carries the live set through the per-host merge, prunes it on close, drops it on detach", () => {
+  assert.match(FED, /const ARRAY_ID = \["order", "names", "working", "awaiting", "stateUnknown", "live"\];/);
+  assert.match(FED, /private perHostLive: Record<string, string\[\]> = \{\};/);
+  assert.match(FED, /this\.perHostLive\[host\] = Array\.isArray\(m\.live\) \? m\.live\.filter\(\(x: any\) => typeof x === "string"\) : \[\];/);
+  assert.match(FED, /if \(this\.perHostLive\[host\]\) this\.perHostLive\[host\] = this\.perHostLive\[host\]\.filter\(\(x\) => x !== gone\);/);
+  assert.match(FED, /delete this\.perHostLive\[host\];/);
+  assert.match(FED, /const live = this\.hostSeq\.flatMap\(\(h\) => this\.perHostLive\[h\] \|\| \[\]\);/);
+  assert.match(FED, /const data: any = \{ type: "tabOrder", order, tabs, live, views:/);
+});

--- a/ui/webview/tab-order.test.ts
+++ b/ui/webview/tab-order.test.ts
@@ -5,7 +5,7 @@
 // own order tests never reached, which is why the jumping survived every "fix".
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { reconcileTabOrder } from "./tab-order";
+import { reconcileTabOrder, retainLiveOmitted } from "./tab-order";
 
 // A tiny stand-in for the client's tab state: the order array + the set of ids whose session is known. The
 // real render.ts drives the SAME three ops (append on a session push, remove on close, reconcile on a kernel
@@ -143,4 +143,33 @@ test("a revived session (same sid re-listed after a drop) is adopted back cleanl
   assert.deepEqual(m.list(), ["A"]);
   m.onKernelOrder(["A", "B"]);            // B revived (dead sessions revive with their history)
   assert.deepEqual(m.list(), ["A", "B"]);
+});
+
+// T258 (the user 2026-09-08): a live session the kernel STILL affirms live but whose tabOrder push omits it
+// (its transcript file was briefly unreadable) is kept at its slot, never dropped or moved. The kernel-side
+// fix keeps it in `order`; this is the pane's second line of defense.
+test("retainLiveOmitted keeps a live-but-omitted local id at its slot; drops nothing else; a no-op without a marker", () => {
+  // B is live per the marker but missing from the kernel order → spliced back after A (its local predecessor)
+  assert.deepEqual(retainLiveOmitted(["A", "C"], ["A", "B", "C"], new Set(["B"])), ["A", "B", "C"]);
+  // a genuinely gone id (NOT in live) is not retained — the omission stands
+  assert.deepEqual(retainLiveOmitted(["A", "C"], ["A", "B", "C"], new Set()), ["A", "C"]);
+  // the kernel order otherwise wins verbatim (a drag/reorder is honored); a retained id sits at its local slot
+  assert.deepEqual(retainLiveOmitted(["C", "A"], ["A", "B", "C"], new Set(["B"])), ["C", "A", "B"]);
+  // first-position live-omitted id lands at the front (no surviving predecessor)
+  assert.deepEqual(retainLiveOmitted(["C"], ["B", "C"], new Set(["B"])), ["B", "C"]);
+  // an id already in the kernel order is never duplicated even if the marker also names it
+  assert.deepEqual(retainLiveOmitted(["A", "B"], ["A", "B"], new Set(["A", "B"])), ["A", "B"]);
+});
+
+// End to end through reconcileTabOrder: a push that omits a live id must not tear the tab down (the property
+// render.ts's applyTabOrder relies on — omitted excludes live, and the retained order feeds reconcile).
+test("a kernel push omitting a LIVE id keeps its tab; omitting a non-live id removes it", () => {
+  const kernelSeen = new Set(["A", "B"]);
+  const seen = (id: string) => kernelSeen.has(id);
+  // B live but omitted → retained order lists it → reconcile keeps it (kernel-owned, so it would otherwise drop)
+  const keptOrder = retainLiveOmitted(["A"], ["A", "B"], new Set(["B"]));
+  assert.deepEqual(reconcileTabOrder(keptOrder, ["A", "B"], (id) => id === "A" || id === "B", seen), ["A", "B"]);
+  // B NOT live and omitted → not retained → reconcile drops it (the genuine close)
+  const goneOrder = retainLiveOmitted(["A"], ["A", "B"], new Set());
+  assert.deepEqual(reconcileTabOrder(goneOrder, ["A", "B"], (id) => id === "A" || id === "B", seen), ["A"]);
 });

--- a/ui/webview/tab-order.ts
+++ b/ui/webview/tab-order.ts
@@ -29,6 +29,33 @@
  * @param known       whether the client actually has a tab for this id (a session arrived / is a placeholder)
  * @param kernelSeen  whether ANY kernel tabOrder push has ever carried this id (kernel-owned → no keep)
  */
+/**
+ * A live session the kernel affirms (frame `live`) but that this tabOrder push's `order` OMITS is a
+ * TRANSIENT read failure, never a close (T258, the user 2026-09-08: a live session whose transcript file was
+ * briefly unreadable dropped off the kernel's order and the pane tore its tab down through the T236 omission
+ * path). The kernel-side fix keeps such a session in `order`, so this is defense in depth: return the kernel
+ * order with every live-but-omitted local id spliced back in at the slot it holds locally (after its nearest
+ * surviving predecessor), so the tab neither tears down nor jumps while the next frame re-lists it in place.
+ * `live` empty (an older kernel that sends no marker) → the kernel order verbatim, exactly as before.
+ */
+export function retainLiveOmitted(
+  kernelOrder: readonly string[],
+  local: readonly string[],
+  live: ReadonlySet<string>,
+): string[] {
+  if (!live.size) return kernelOrder.filter((id): id is string => typeof id === "string");
+  const inKernel = new Set(kernelOrder.filter((id): id is string => typeof id === "string"));
+  const out = kernelOrder.filter((id): id is string => typeof id === "string");
+  for (let i = 0; i < local.length; i++) {
+    const id = local[i];
+    if (typeof id !== "string" || inKernel.has(id) || !live.has(id) || out.includes(id)) continue;
+    let at = 0;                                   // insert after the nearest preceding local id that survived
+    for (let j = i - 1; j >= 0; j--) { const k = out.indexOf(local[j]); if (k >= 0) { at = k + 1; break; } }
+    out.splice(at, 0, id);
+  }
+  return out;
+}
+
 export function reconcileTabOrder(
   kernelOrder: readonly string[],
   local: readonly string[],

--- a/vscode-extension/src/tabs-first.test.ts
+++ b/vscode-extension/src/tabs-first.test.ts
@@ -19,7 +19,7 @@ test("applyTabOrder REBUILDS tabMeta from the authoritative payload (closed tabs
   assert.match(RENDER, /function applyTabOrder\(o: any, tabs\?: any, report\?: OrderReport, live\?: any\)/);
   assert.match(RENDER, /if \(Array\.isArray\(tabs\)\) \{\s*tabMeta\.clear\(\);/);
   // the frame's provenance rides along since T233 (captureViews still runs FIRST)
-  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}\);\s*\n\s*\}/);
+  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}, m\.live\);\s*\n\s*\}/);   // + the frame\'s live set (T258)
 });
 
 test("renderTabs renders the union of arrived sessions and tabMeta, placeholders for the rest", () => {

--- a/vscode-extension/src/tabs-first.test.ts
+++ b/vscode-extension/src/tabs-first.test.ts
@@ -16,7 +16,7 @@ test("a tabMeta map holds the kernel's name+color per tab", () => {
 
 test("applyTabOrder REBUILDS tabMeta from the authoritative payload (closed tabs don't linger)", () => {
   // report = the frame's provenance for the close backstop (T233)
-  assert.match(RENDER, /function applyTabOrder\(o: any, tabs\?: any, report\?: OrderReport\)/);
+  assert.match(RENDER, /function applyTabOrder\(o: any, tabs\?: any, report\?: OrderReport, live\?: any\)/);
   assert.match(RENDER, /if \(Array\.isArray\(tabs\)\) \{\s*tabMeta\.clear\(\);/);
   // the frame's provenance rides along since T233 (captureViews still runs FIRST)
   assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}\);\s*\n\s*\}/);


### PR DESCRIPTION
## What

A LIVE session must stay in the tab list while its transcript file is briefly unreadable. The T249b harness showed the opposite: move a live tmux session's transcript aside for a few pusher cycles and the kernel drops the session from the tab list, the pane dismisses the tab through the T236 omission path and shows the neighbour. Same class as romp-on/romp#1049: a transient read failure reported as a state change.

**Kernel-side cause.** `_alive_sessions` resolves every live sid through `discover()`, which scans project dirs for `<sid>.jsonl`. A file that is gone for a cycle (a torn write, a hand `mv`, a resume that renames the leaf before the CLI recreates it) leaves discover with no entry; the wide-window backfill and the SDK fallback both resolve through discover too, so a live tmux session simply fell out of the list, and with it out of every tabOrder push.

**Fix, kernel.** A live sid discover cannot resolve stays in `_alive_sessions` with a names/-derived stub: the expected transcript path under its cwd, which discover re-resolves the instant the file returns. `build_session` already parses a missing file to empty, and the #1049 guard holds the last content, so the tab neither leaves nor blanks. Said once per episode on stderr, a `romp-perf liveunresolved` line every cycle it holds. A dead session whose file is gone still drops; a live sid with no names entry and no SDK owner has nothing to stub from and is left out (never invented).

**Fix, pane (defense in depth).** The tabOrder frame now carries `live`: the sids the kernel affirms live this build (raw tmux/SDK liveness, independent of discover). One `_tab_order_frame` builder feeds all four emitters; federation prefixes it (`ARRAY_ID`), stores it per host, prunes it on `closed`, drops it on detach and merges the union into the re-emitted frame. `applyTabOrder` excludes a live id from the omission teardown and keeps it at its slot (`retainLiveOmitted`, pure in tab-order.ts) until the next frame re-lists it, filing one `clientDiag` row per saved id so a kernel that omits a live session is seen, never silently absorbed. An older kernel sends no `live` and the path is byte-for-byte what it was.

Event-based throughout: the file's return re-resolves through discover; nothing is aged or retried on a timer.

## Verified live

The T249b two-kernel harness (kernel A serves the page, kernel B attached through A's relay, headless browser, live tmux lanes) on a frozen copy of this branch, two runs, the **move** trigger (transcript file gone for two pusher cycles, then back), reader at the bottom and reader scrolled up:

| after B's restart, transcript moved aside | main today | this branch |
|---|---|---|
| the session leaves the tab list / the pane dismisses the tab | yes (`tabLost`, neighbour shown) | **no** |
| any `session` frame with 0 events, any placeholder flash | no | no |
| scroll position | the neighbour's | unchanged |

(The "main today" column is the T249b harness's earlier runs on the same trigger; this PR's runs are `t258-1`/`t258-2`. Kernel B logged the `liveunresolved` note once per episode.)

## Tier

- [ ] tests-only
- [x] fix — a bug fix with a test that fails before it
- [ ] feature
- [ ] major-feature

## Tests

New `tests/test_live_session_unresolved_transcript.py`: drives the real `_alive_sessions`/`_chat_tab_sessions` with a scripted names registry and a vanishing transcript (present → moved → listed with the stub and the expected path → the note once per episode, re-armed after the file returns → the chat tab list keeps it → a dead session is not stubbed → an unknown sid is left out → the frame names the live sids); the behaviour tests are red on main, the premise passes there. New `ui/webview/tab-order-live-omission.test.ts` + `tab-order.test.ts`: execute `retainLiveOmitted` (kept at its slot, a non-live omission still removes, no marker → verbatim) and pin the render.ts and federation wiring, red on main.

Two fixtures were hollow and became honest: the payload-dedup invariant test's own judge module never reached the kernel's discover, so its live session was invisible — it now patches the kernel's copy and warms one build (a session's first build adopts it into the persisted order, a genuine change). Suites: node 3275 passed (`npm test`, typecheck clean); Python 8670 passed, 0 failed (`env -u ROMP_API_KEY_CMD`, the session-environment gotcha noted on #1049).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
