### PR TITLE
T248c: kernel-side settings converge in both directions of a one-way poll, and never across an isolated peer

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18863,12 +18863,15 @@ def _tunnel_supervisor():
                     # row and may spawn a worker. Runs here, in the one supervisor, so an advance is pushed
                     # exactly once no matter how many dashboards are open.
                     _maybe_auto_push(r)
-                    # Kernel-side settings converge without a click (T248b): a peer whose stamp for a
-                    # setting is newer than ours, with a different value, is adopted through the setting's
-                    # own gt-gated setter. Outside the lock too: the setters take their own locks and write
-                    # their stores. Loud on a fault, never fatal to the supervisor.
+                    # Kernel-side settings converge without a click (T248b/T248c): a peer whose stamp for a
+                    # setting is newer than ours is adopted through the setting's own gt-gated setter; a peer
+                    # whose stamp is OLDER is handed ours through its gesture route (the default topology polls
+                    # one way — the hub polls the machine it attached, which has no row for the hub until
+                    # Share my sessions is on). Both legs gate on the peer's trust. Outside the lock too: the
+                    # setters take their own locks and write their stores. Loud on a fault, never fatal to
+                    # the supervisor.
                     try:
-                        _adopt_peer_settings(r.get("host") or "?", rver)
+                        _converge_peer_settings(r, rver)
                     except Exception:
                         _tunnel_log(r.get("host") or "?", "adopt-settings", error=traceback.format_exc()[-400:])
                     # tag federation v2, the reattach half (also outside the lock — it round-trips the
@@ -33461,6 +33464,96 @@ def _mesh_settings_snapshot():
     return values, stamps
 
 
+_MESH_SAID = set()   # (host, why) said once on stderr: an isolated peer, a peer without the route
+
+
+def _mesh_say_once(host, why, line):
+    if (host, why) in _MESH_SAID:
+        return
+    _MESH_SAID.add((host, why))
+    sys.stderr.write(line + "\n")
+
+
+def _converge_peer_settings(r, rver, sync=False):
+    """One supervisor pass for one up peer (`r` its remotes row, `rver` its polled /version): adopt what the
+    peer holds under a NEWER stamp (_adopt_peer_settings), and PUSH what we hold under a newer stamp than the
+    peer's through the peer's gesture route (/mesh-settings, gt-gated by the peer's own setters), so
+    latest-wins holds in both directions of a one-way poll (T248c). Both legs gate on trust: an isolated
+    peer's stored state is neither read into this kernel's stores nor written over the tunnel — isolation is
+    a boundary both ways, and for fileEditing the inbound leg alone could open this kernel's save route
+    (the manager's review of the merged convergence, 2026-09-08). The push rides a daemon thread unless
+    `sync` (tests): the supervisor pass must not wait on a peer's HTTP round trip. Returns what moved."""
+    host = r.get("host") or "?"
+    if (r.get("trust") or "directed") == "isolated":
+        _mesh_say_once(host, "isolated", "settings: %s is isolated — its picks are neither adopted here nor pushed to it "
+                       "(isolation is a boundary both ways)" % host)
+        return {"adopted": [], "pushed": []}
+    adopted = _adopt_peer_settings(host, rver)
+    older = _older_peer_settings(rver)
+    if not older:
+        return {"adopted": adopted, "pushed": []}
+    if not sync:
+        threading.Thread(target=_push_settings_to_peer, args=(dict(r), older), daemon=True).start()
+        return {"adopted": adopted, "pushed": [store for store, _b in older]}
+    return {"adopted": adopted, "pushed": _push_settings_to_peer(r, older)}
+
+
+def _older_peer_settings(rver):
+    """[(store, body)] for every adopted store the peer reports under an OLDER stamp than ours: the body is
+    our (value, stamp) in the /mesh-settings shape. A peer that sends no stamps (an older kernel) or junk
+    teaches nothing and is told nothing — there is nothing to compare."""
+    st = (rver or {}).get("settings") if isinstance(rver, dict) else None
+    gts = (rver or {}).get("settingsGt") if isinstance(rver, dict) else None
+    if not isinstance(st, dict) or not isinstance(gts, dict):
+        return []
+    values, stamps = _mesh_settings_snapshot()
+    out = []
+    for key, store, _setter in _MESH_ADOPTED_SETTINGS:
+        pgt, mine = gts.get(store), stamps.get(store) or 0
+        if isinstance(pgt, bool) or not isinstance(pgt, (int, float)) or not math.isfinite(pgt) or pgt < 0:
+            continue
+        if mine > int(pgt):
+            out.append((store, {key: values[key], "gt": mine}))
+    return out
+
+
+def _push_settings_to_peer(r, older):
+    """Hand each (store, body) to the peer's /mesh-settings over its tunnel + its own token (mirror_trust's
+    transport). Counted as pushed only when the peer's ack shows our stamp holding: its setter stands down on
+    anything newer it has since applied (a click on that machine between our poll and this push), and the
+    next pass adopts that instead. A peer that refuses the route (an older kernel: 404, or a non-JSON answer)
+    is said once and skipped — its copy stays until it updates or the next click reaches it."""
+    host = r.get("host") or "?"
+    pushed = []
+    for store, body in older:
+        st, j, err = _remote_kernel_call(r, "POST", "/mesh-settings", body, timeout=8)
+        if err or st != 200 or not isinstance(j, dict) or not j.get("ok"):
+            _mesh_say_once(host, "no-route", "settings: %s did not take the push (%s) — an older kernel? its copy stays "
+                           "until it updates or the next click reaches it" % (host, err or ("HTTP %s" % st)))
+            return pushed
+        if (j.get("settingsGt") or {}).get(store) == body["gt"]:
+            pushed.append(store)
+            sys.stderr.write("setting %s: pushed our newer pick (%s, gesture %d) to %s — one value, one stamp across machines\n"
+                             % (store, body[[k for k in body if k != "gt"][0]], body["gt"], host))
+    return pushed
+
+
+def _apply_mesh_settings(body):
+    """The peer-side half of the push (POST /mesh-settings, behind the serve token like /judge-settings):
+    apply any of the three adopted booleans in `body` through their own gt-gated setters under the body's
+    `gt` — a stale stamp stands down per field, a non-bool is ignored — and answer with the CURRENT snapshot
+    (values and stamps), so the sender can see what actually holds. No socket delivered this, so the
+    stand-down verdict is consumed here."""
+    gt = _gesture_ms(body)
+    if isinstance(body, dict):
+        for key, _store, setter in _MESH_ADOPTED_SETTINGS:
+            if key in body and isinstance(body.get(key), bool):
+                setter(body[key], gt=gt)
+    _pop_stale_notice()
+    values, stamps = _mesh_settings_snapshot()
+    return {"ok": True, "settings": values, "settingsGt": stamps}
+
+
 def _adopt_peer_settings(host, rver):
     """Adopt every kernel-side boolean in `rver` (_poll_remote_version's dict for a peer) whose stamp is
     newer than the local store's — the value when it differs, the stamp alone when it agrees. Returns
@@ -42550,6 +42643,15 @@ class Handler(BaseHTTPRequestHandler):
                     fwd = {k: v for k, v in body.items() if k != "propagate"}
                     threading.Thread(target=_propagate_judge_settings, args=(fwd,), daemon=True).start()
                 return self._send(200, json.dumps(res), "application/json")
+            if u.path == "/mesh-settings":
+                # The gesture route a PEER's supervisor pushes its newer kernel-side booleans through (T248c:
+                # compactSuggest / autoNudge / fileEditing with the origin stamp), behind this kernel's serve
+                # token like /judge-settings. Our own gt-gated setters decide; the ack is the current snapshot.
+                try:
+                    body = json.loads(raw_body or b"{}")
+                except Exception:
+                    body = None
+                return self._send(200, json.dumps(_apply_mesh_settings(body if isinstance(body, dict) else {})), "application/json")
             return self._send(404, "not found", "text/plain")
         except (BrokenPipeError, ConnectionResetError):
             pass

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -33464,7 +33464,7 @@ def _mesh_settings_snapshot():
     return values, stamps
 
 
-_MESH_SAID = set()   # (host, why) said once on stderr: an isolated peer, a peer without the route
+_MESH_SAID = set()   # (host, why) said once on stderr: an isolated peer, a peer that did not take a push
 
 
 def _mesh_say_once(host, why, line):
@@ -33528,8 +33528,11 @@ def _push_settings_to_peer(r, older):
     for store, body in older:
         st, j, err = _remote_kernel_call(r, "POST", "/mesh-settings", body, timeout=8)
         if err or st != 200 or not isinstance(j, dict) or not j.get("ok"):
-            _mesh_say_once(host, "no-route", "settings: %s did not take the push (%s) — an older kernel? its copy stays "
-                           "until it updates or the next click reaches it" % (host, err or ("HTTP %s" % st)))
+            # an older kernel answers the unknown route with a text 404, which the transport reports as a
+            # parse error, not a status — so the line names the shape it saw and both likely causes
+            _mesh_say_once(host, "push-failed", "settings: %s did not take the push (%s) — an older kernel without the "
+                           "route, or unreachable; its copy stays until it updates or the next click reaches it"
+                           % (host, err or ("HTTP %s" % st)))
             return pushed
         if (j.get("settingsGt") or {}).get(store) == body["gt"]:
             pushed.append(store)

--- a/tests/test_mesh_settings_adopt.py
+++ b/tests/test_mesh_settings_adopt.py
@@ -302,15 +302,159 @@ class TheEmitterIsOneSnapshotPerStore(unittest.TestCase):
         self.assertEqual(set(stamps), {"auto-nudge", "compact-suggest", "file-editing"})
 
 
+class _Mesh:
+    """Two kernels and a stubbed tunnel: A's pushes to B land in B's /mesh-settings applier under B's state root
+    (the peer's gesture route, gt-gated like every setting). `refuse` makes B an older kernel with no such route."""
+
+    def __init__(self, a, b, refuse=False):
+        self.a, self.b, self.refuse, self.calls = a, b, refuse, []
+        self._saved = km._remote_kernel_call
+
+        def call(r, method, path, payload=None, timeout=8):
+            self.calls.append((r.get("host"), method, path, payload))
+            if self.refuse:
+                return 404, {}, None
+            with self.b:
+                return 200, km._apply_mesh_settings(payload if isinstance(payload, dict) else {}), None
+        km._remote_kernel_call = call
+
+    def close(self):
+        km._remote_kernel_call = self._saved
+
+    def row(self, trust="directed"):
+        return {"host": "TESTHOST", "local_port": 51000, "token": "tok", "trust": trust, "status": "up"}
+
+    def converge(self, trust="directed"):
+        """A's supervisor step against B's /version — synchronously, so the test reads the outcome."""
+        with self.a:
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                out = km._converge_peer_settings(self.row(trust), self.b.version(), sync=True)
+            return out, err.getvalue()
+
+
+class OneDirectionalAttach(unittest.TestCase):
+    """The default topology polls ONE way: the hub polls the machine it attached; that machine has no row for
+    the hub until Share my sessions is on. Convergence therefore also PUSHES: a peer whose stamp is OLDER than
+    ours receives our (value, stamp) through its gesture route, so latest-wins holds in both directions (the
+    manager's review of the merged convergence, 2026-09-08)."""
+
+    def setUp(self):
+        self.a, self.b = _Kernel(), _Kernel()
+        self.m = _Mesh(self.a, self.b)
+
+    def tearDown(self):
+        self.m.close(); self.a.close(); self.b.close()
+
+    def test_the_hubs_newer_pick_reaches_a_peer_that_never_polls_it_within_one_pass(self):
+        # the user's incident: the hub clicked compactSuggest OFF, then attached a machine whose copy was ON
+        # under an older stamp; the hub polled, saw an older stamp, adopted nothing; the machine never polled back
+        self.a.set("compact-suggest", False, 9_000)
+        self.b.set("compact-suggest", True, 5_000)
+        out, err = self.m.converge()
+        self.assertEqual(out["pushed"], ["compact-suggest"])
+        self.assertEqual(out["adopted"], [])
+        self.assertEqual(self.b.read("compact-suggest"), (False, 9_000), "b holds the hub's pick under the hub's stamp")
+        self.assertIn("TESTHOST", err)
+        self.assertEqual([c[2] for c in self.m.calls], ["/mesh-settings"])
+        # the next pass: equal stamps, nothing moves in either direction — no ping-pong
+        out, _ = self.m.converge()
+        self.assertEqual((out["pushed"], out["adopted"]), ([], []))
+        self.assertEqual(len(self.m.calls), 1, "one push, once")
+
+    def test_a_newer_peer_is_still_adopted_and_nothing_is_pushed_to_it(self):
+        self.a.set("compact-suggest", False, 5_000)
+        self.b.set("compact-suggest", True, 9_000)
+        out, _ = self.m.converge()
+        self.assertEqual((out["adopted"], out["pushed"]), (["compact-suggest"], []))
+        self.assertEqual(self.a.read("compact-suggest"), (True, 9_000))
+        self.assertEqual(self.m.calls, [])
+
+    def test_a_push_stands_down_on_the_peer_when_the_peer_clicked_in_between(self):
+        # the peer's own gt-gated setter decides: a click on b newer than a's stamp, landing between a's poll and
+        # a's push, keeps — and a adopts it on the next pass
+        self.a.set("compact-suggest", False, 9_000)
+        self.b.set("compact-suggest", True, 5_000)
+        rver = self.b.version()
+        self.b.set("compact-suggest", True, 9_500)
+        with self.a:
+            out = km._converge_peer_settings(self.m.row(), rver, sync=True)
+        self.assertEqual(out["pushed"], [], "the peer refused the older stamp: not counted as pushed")
+        self.assertEqual(self.b.read("compact-suggest"), (True, 9_500))
+        out, _ = self.m.converge()
+        self.assertEqual(out["adopted"], ["compact-suggest"])
+        self.assertEqual(self.a.read("compact-suggest"), (True, 9_500))
+
+    def test_an_older_kernel_that_has_no_route_is_said_once_and_skipped(self):
+        self.m.refuse = True
+        self.a.set("compact-suggest", False, 9_000)
+        self.b.set("compact-suggest", True, 5_000)
+        out1, err1 = self.m.converge()
+        out2, err2 = self.m.converge()
+        self.assertEqual((out1["pushed"], out2["pushed"]), ([], []))
+        self.assertIn("TESTHOST", err1, "the refusal is said, naming the machine")
+        self.assertEqual(err2.count("did not take"), 0, "…once per peer, not every pass")
+        self.assertEqual(self.b.read("compact-suggest"), (True, 5_000), "the peer keeps its copy until it updates or the next click")
+
+    def test_all_three_settings_push_the_same_way(self):
+        for store in ("compact-suggest", "auto-nudge", "file-editing"):
+            default = self.b.read(store)[0]
+            self.a.set(store, not default, 9_000)
+            self.b.set(store, default, 5_000)
+            out, _ = self.m.converge()
+            self.assertIn(store, out["pushed"], store)
+            self.assertEqual(self.b.read(store), (not default, 9_000), store)
+
+
+class TrustGate(unittest.TestCase):
+    """Adoption is an INBOUND leg — a peer's stored state, read off its auth-exempt /version, applied to this
+    kernel's stores with no gesture — and the push is a new outbound one. Both gate on the peer's trust not being
+    "isolated": for fileEditing an isolated peer could otherwise open this kernel's write-any-file save route."""
+
+    def setUp(self):
+        self.a, self.b = _Kernel(), _Kernel()
+        self.m = _Mesh(self.a, self.b)
+
+    def tearDown(self):
+        self.m.close(); self.a.close(); self.b.close()
+
+    def test_an_isolated_peers_newer_pick_is_neither_adopted_nor_pushed_to_and_that_is_said_once(self):
+        self.b.set("file-editing", True, 9_000)
+        self.a.set("compact-suggest", True, 9_000)
+        self.b.set("compact-suggest", False, 5_000)
+        out1, err1 = self.m.converge(trust="isolated")
+        out2, err2 = self.m.converge(trust="isolated")
+        self.assertEqual(out1, {"adopted": [], "pushed": []})
+        self.assertEqual(out2, {"adopted": [], "pushed": []})
+        self.assertEqual(self.a.read("file-editing"), (False, 0), "the gate on this kernel's save route stays shut")
+        self.assertEqual(self.b.read("compact-suggest"), (False, 5_000), "nothing pushed either")
+        self.assertEqual(self.m.calls, [])
+        self.assertIn("isolated", err1); self.assertIn("TESTHOST", err1)
+        self.assertEqual(err2.strip(), "", "said once per peer")
+
+    def test_the_route_applies_with_the_stamp_and_answers_the_current_snapshot(self):
+        with self.b:
+            self.b.set("compact-suggest", True, 5_000)
+            ack = km._apply_mesh_settings({"compactSuggest": False, "gt": 9_000})
+            self.assertEqual(ack["ok"], True)
+            self.assertEqual((ack["settings"]["compactSuggest"], ack["settingsGt"]["compact-suggest"]), (False, 9_000))
+            stale = km._apply_mesh_settings({"compactSuggest": True, "gt": 8_000})
+            self.assertEqual((stale["settings"]["compactSuggest"], stale["settingsGt"]["compact-suggest"]), (False, 9_000), "a stale stamp stands down; the ack shows what holds")
+            self.assertIsNone(km._pop_stale_notice(), "no socket delivered this: no verdict left for the next gesture")
+            junk = km._apply_mesh_settings({"compactSuggest": "yes", "gt": 9_500})
+            self.assertEqual(junk["settings"]["compactSuggest"], False, "a non-bool is ignored")
+
+
 class ThePollSeam(unittest.TestCase):
     def test_the_supervisor_lifts_the_stamps_and_adopts_outside_the_lock(self):
         sup = KERNEL_SRC.split("def _tunnel_supervisor():")[1].split("\ndef ")[0]
         self.assertIn('r["settings"] = (rver or {}).get("settings")', sup)
         self.assertIn('r["settingsGt"] = (rver or {}).get("settingsGt")', sup, "the stamps ride the row beside the values")
-        self.assertIn("_adopt_peer_settings(r.get(\"host\") or \"?\", rver)", sup)
+        self.assertIn("_converge_peer_settings(r, rver)", sup, "the supervisor hands the ROW over, so trust is read at the seam")
         # the setters take their own locks and write files: they run in the OUTSIDE-the-lock block, like the auto update
         before_lock_exit = sup.split("if auto_check:")[0]
-        self.assertNotIn("_adopt_peer_settings(", before_lock_exit, "never under _remotes_lock")
+        self.assertNotIn("_converge_peer_settings(", before_lock_exit, "never under _remotes_lock")
+        self.assertIn('if u.path == "/mesh-settings":', KERNEL_SRC, "the peer-side gesture route the push lands on")
 
     def test_the_table_names_exactly_the_three_broadcast_booleans(self):
         self.assertEqual([row[0] for row in km._MESH_ADOPTED_SETTINGS], ["compactSuggest", "autoNudge", "fileEditing"])

--- a/tests/test_mesh_settings_adopt.py
+++ b/tests/test_mesh_settings_adopt.py
@@ -54,16 +54,19 @@ class _Kernel:
     def __init__(self):
         self.td = tempfile.TemporaryDirectory()
         self.root = Path(self.td.name)
+        self._saved = []   # a STACK: `with k:` nests (a helper called inside a block re-enters the same
+        #                    kernel), and a single slot left jd.STATE on this root after the outer exit — the
+        #                    next module then wrote under a deleted temp dir (CI + the full run, 2026-09-08)
 
     def __enter__(self):
-        self._saved = jd.STATE
+        self._saved.append(jd.STATE)
         jd.STATE = self.root
         km._autonudge_cache.clear()
         return self
 
     def __exit__(self, *a):
         km._autonudge_cache.clear()
-        jd.STATE = self._saved
+        jd.STATE = self._saved.pop()
 
     def version(self):
         """What this kernel's /version says to a polling peer: the settings dict + every store's stamp."""

--- a/tests/test_mesh_settings_adopt.py
+++ b/tests/test_mesh_settings_adopt.py
@@ -312,8 +312,8 @@ class _Mesh:
 
         def call(r, method, path, payload=None, timeout=8):
             self.calls.append((r.get("host"), method, path, payload))
-            if self.refuse:
-                return 404, {}, None
+            if self.refuse:   # the real shape: an older kernel's text 404 fails the transport's JSON parse
+                return None, None, "could not reach TESTHOST's kernel: Expecting value: line 1 column 1 (char 0)"
             with self.b:
                 return 200, km._apply_mesh_settings(payload if isinstance(payload, dict) else {}), None
         km._remote_kernel_call = call
@@ -393,6 +393,7 @@ class OneDirectionalAttach(unittest.TestCase):
         out2, err2 = self.m.converge()
         self.assertEqual((out1["pushed"], out2["pushed"]), ([], []))
         self.assertIn("TESTHOST", err1, "the refusal is said, naming the machine")
+        self.assertIn("older kernel without the route, or unreachable", err1, "…and both likely causes, since the transport cannot tell them apart")
         self.assertEqual(err2.count("did not take"), 0, "…once per peer, not every pass")
         self.assertEqual(self.b.read("compact-suggest"), (True, 5_000), "the peer keeps its copy until it updates or the next click")
 


### PR DESCRIPTION
Follow-up to the merged convergence (#1045), from the manager's adversarial review of it.

**Convergence was pull-only.** `_adopt_peer_settings` ran only for rows this kernel polls and only adopted a newer peer stamp. The default topology polls one way (the hub polls the machine it attached; that machine has no row for the hub until *Share my sessions* is on), so the user's incident stayed: hub clicks off, attaches a machine whose copy is on under an older stamp, the hub adopts nothing, the machine never polls back. Now `_converge_peer_settings` also **pushes**: a peer with an **older** stamp is handed our (value, stamp) through its new gesture route `POST /mesh-settings` (serve-token gated like `/judge-settings`); its own gt-gated setter applies it and stands down on anything newer. Latest-wins in both directions regardless of check-in; no ping-pong. An older kernel without the route is logged once and skipped.

**Adoption ignored trust.** Both legs (inbound adoption, outbound push) now gate on the peer's trust not being `isolated`, said once per peer. For `fileEditing` the inbound leg alone could otherwise open this kernel's save route. The dashboard's gesture broadcast is unchanged.

**Tests (red before)**: `tests/test_mesh_settings_adopt.py` — `OneDirectionalAttach` (hub's newer pick reaches a non-polling peer in one pass, no ping-pong; newer peer adopted, nothing pushed; a push stands down on a fresher click and the next pass adopts it; an older kernel is said once and skipped; all three settings), `TrustGate` (isolated peer neither adopted nor pushed to, said once; the route applies with the stamp and answers the snapshot), and the seam pins.
