### PR TITLE
T252b: an earlier send's landing is a floor for a later one, a send queues below the kernel's foreign texts, and the docs match

### DIFF
--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -236,8 +236,11 @@ never-delivered verdict, or the user's ✕), and a record the CLI wrote from sev
 back-to-back sends retires one bubble per text block (`blocks` on the user event).
 While the socket is down the bubble is labelled "not confirmed", until a kernel
 copy of the send clears the label. A send that landed mid-turn (`absorbed` and
-`landedAt` on the user chat event) wears a "joined mid-turn" header and, when its
-bubble sat at the tail, leaves a cue where the bubble was. The CLI extracts
+`landedAt` on the user chat event) is placed at its send time, and the chat's
+pending bubble is drawn at that same slot from the press — right after the last
+kernel event at the press, below an earlier send's echo or landing and below any
+texts the kernel already held queued — so the landing replaces it in place; there
+is no header and no cue (T252). The CLI extracts
 no image paths on the stream-json route (its only image-path test belongs to the
 interactive composer's paste handler), so an image path in an SDK send lands as
 typed and the echo's text matches. `_path_bearing` and the extension set it tests

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -319,9 +319,12 @@ const order: string[] = [];           // positional tab order (for cycling)
 const pendingSent = new Map<string, PendingSend[]>();
 const isOptimistic = (e: ChatEvent): boolean => isOptimisticUuid(e.uuid);
 
-// The kernel's own queued group, if one is at the tail. Ours merges INTO it when present: the session is
-// provably holding messages, so this send will queue behind them — no reason to show it as a separate lone
-// bubble (the user 2026-07-16). Tail-scanned; a queued group only ever sits at the bottom.
+// The kernel's own queued group, if one is at the tail. Since T252 ours is never merged into it: a copy of
+// OUR text in it is hidden (hideQueuedCopy — one bubble per message, ours at its send slot), and
+// a group holding OTHER texts is a floor — a send pressed while they were queued runs after them, so its
+// bubble is drawn below the group (send-pending.ts placementIndex, T252b; the user's 2026-07-16 rule that
+// a send queues behind what the session already holds, kept in placement rather than by merging).
+// Tail-scanned; a queued group only ever sits at the bottom.
 function tailQueuedIdx(evs: ChatEvent[]): number {
   for (let i = evs.length - 1, n = 0; i >= 0 && n < 10; i--, n++) if (evs[i].kind === "queued") return i;
   return -1;

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -394,9 +394,13 @@ test("foreign and floor texts match the kernel's landed shapes: a nudge's quote 
   const z = newPending("mine", undefined, T0 + 2);
   reconcilePending([...tail, { kind: "queued", texts: [{ md: "F" }, { md: "mine" }] }], [z]);
   const again: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1" }, { kind: "tool", uuid: "t1" }, { kind: "queued", texts: [{ md: "mine", hiddenByPending: true }, { md: "F" }] }];
-  assert.deepEqual(injectionGroups(again, reconcilePending(again, [z]).inject), [{ idx: 2, sends: [z] }], "below the first F, above the newer queued F");
+  // the kernel's queued copies carry no identity, so a copy still shown in the group is read as the press-time one
+  // (fourth review): the group holds the bubble below it while it shows a copy of the key — the fed-copy case, where
+  // an identical text the kernel had already forwarded lands first, is the common one; a same-text copy re-queued by
+  // another client after the press-time one landed keeps ours below the group until ours lands — the known limit
+  assert.deepEqual(injectionGroups(again, reconcilePending(again, [z]).inject), [{ idx: 4, sends: [z] }], "below the group while it still shows a copy of F");
   const echoed: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1" }, { kind: "tool", uuid: "t1" }, { kind: "user", md: "F", uuid: "echo:F2" }];
-  assert.deepEqual(injectionGroups(echoed, reconcilePending(echoed, [z]).inject), [{ idx: 2, sends: [z] }], "…and above the newer F's echo");
+  assert.deepEqual(injectionGroups(echoed, reconcilePending(echoed, [z]).inject), [{ idx: 4, sends: [z] }], "…and, uF1 having been learned as someone else's while the group showed F, below the newer F's echo until this send lands");
   // two copies of F at the press: the second landing is the floor
   const w = newPending("mine", undefined, T0 + 3);
   reconcilePending([...tail, { kind: "queued", texts: [{ md: "F" }, { md: "F" }, { md: "mine" }] }], [w]);
@@ -461,7 +465,9 @@ test("empty keys, retired verdicts, a verdict seen first, and the CLI's delimite
   const withVerdict: TailEvent[] = [tail[0], { kind: "user", md: "F", uuid: "echo:F0", undelivered: true }, { kind: "queued", texts: [{ md: "F" }] }];
   const c = newPending("mine", undefined, T0 + 1); reconcilePending(withVerdict, [c]);
   const verdictGone: TailEvent[] = [tail[0], { kind: "user", md: "F", uuid: "uF" }, { kind: "tool", uuid: "t1" }, { kind: "queued", texts: [{ md: "F" }] }];
-  assert.deepEqual(injectionGroups(verdictGone, reconcilePending(verdictGone, [c]).inject), [{ idx: 2, sends: [c] }], "right after the press-time copy's landing; the newer F is later");
+  // the group still shows a copy of F, so uF is read as someone else's landing and the bubble stays below the group
+  // (the known limit: the kernel's queued copies carry no identity — fourth review)
+  assert.deepEqual(injectionGroups(verdictGone, reconcilePending(verdictGone, [c]).inject), [{ idx: 4, sends: [c] }], "below the group while it shows a copy of F");
   // (3) an earlier send's never-delivered verdict, seen already flagged (a reconnect): a floor for the later send
   const [p3, b3] = press([tail[0]], "first", "second");
   const lostFirst: TailEvent[] = [tail[0], { kind: "user", md: "first", uuid: "echo:P", undelivered: true }];
@@ -473,6 +479,33 @@ test("empty keys, retired verdicts, a verdict seen first, and the CLI's delimite
   for (const [q, l] of [["look (/tmp/a.png)", "look ()"], ["look `/tmp/a.png`", "look ``"], ["look '/tmp/a.png'", "look ''"], ["look \"/tmp/a.png\"", "look \"\""], ["look /tmp/a.png,", "look ,"]])
     assert.equal(foreignKey(q), foreignKey(l), q);
   assert.notEqual(foreignKey("design.png.bak notes"), foreignKey("notes"), "not a path: an ordinary token stays");
+});
+
+test("a copy still shown in the group holds the bubble below it, and copies are counted per block (T252b fourth review)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  // (1) an identical text the kernel had already FED lands first (its echo was hidden behind the queued copy): that
+  // landing is not the queued copy's — the group still shows the press-time F, so the bubble stays below the group,
+  // and below the queued copy's own atom once it lands
+  const fed: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "F" }] }];
+  const a = newPending("mine", undefined, T0); reconcilePending(fed, [a]);
+  const fedLanded: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1", absorbed: true }, { kind: "queued", texts: [{ md: "F" }, { md: "mine", hiddenByPending: true }] }];
+  assert.deepEqual(injectionGroups(fedLanded, reconcilePending(fedLanded, [a]).inject), [{ idx: 3, sends: [a] }], "still below the group");
+  const bothLanded: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1", absorbed: true }, { kind: "tool", uuid: "t1" }, { kind: "user", md: "F", uuid: "uF2" }, { kind: "tool", uuid: "t2" }];
+  assert.deepEqual(injectionGroups(bothLanded, reconcilePending(bothLanded, [a]).inject), [{ idx: 4, sends: [a] }], "below the second F once the group has drained");
+  // (2) two press-time copies of F land as ONE record with two blocks: that is two carriers, so a third F queued
+  // after the press is later than the send
+  const two: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "F" }, { md: "F" }] }];
+  const b = newPending("mine", undefined, T0 + 1); reconcilePending(two, [b]);
+  const oneRecord: TailEvent[] = [...tail, { kind: "user", md: "F F", uuid: "uFF", blocks: ["F", "F"] }, { kind: "tool", uuid: "t1" }];
+  assert.deepEqual(injectionGroups(oneRecord, reconcilePending(oneRecord, [b]).inject), [{ idx: 2, sends: [b] }], "after the record that holds both copies");
+  const thirdLanded: TailEvent[] = [...tail, { kind: "user", md: "F F", uuid: "uFF", blocks: ["F", "F"] }, { kind: "tool", uuid: "t1" }, { kind: "user", md: "F", uuid: "uF3" }, { kind: "tool", uuid: "t2" }];
+  assert.deepEqual(injectionGroups(thirdLanded, reconcilePending(thirdLanded, [b]).inject), [{ idx: 2, sends: [b] }], "…and above a third F queued after the send");
+  // a floor's ordinal counts blocks the same way: X's landing in a two-block record with an older same-text copy
+  const [x, y] = press(tail, "first", "second");
+  const xTwice: TailEvent[] = [...tail, { kind: "user", md: "first first", uuid: "uXX", blocks: ["first", "first"] }, { kind: "tool", uuid: "t1" }];
+  const r = reconcilePending(xTwice, [x, y]);
+  assert.deepEqual(y.floors?.map((f) => [f.uuid, f.ord]), [["uXX", 2]], "two copies in the record count as two");
+  assert.deepEqual(injectionGroups(xTwice, r.inject), [{ idx: 2, sends: [y] }]);
 });
 
 test("a bubble that changes slot marks the view stale, so the incremental repaint never trusts a shifted prefix (second review)", () => {

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -21,7 +21,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { newPending, pendingBody, reconcilePending, dropPending, injectionGroups, scanFrom, queuedCopyToHide, landedIn, provisionalIn, bareGroupLabel, type TailEvent, type PendingSend } from "./send-pending";
+import { newPending, pendingBody, reconcilePending, dropPending, injectionGroups, scanFrom, queuedCopyToHide, foreignKey, landedIn, provisionalIn, bareGroupLabel, type TailEvent, type PendingSend } from "./send-pending";
 
 const read = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
 const RENDER = read("render.ts");
@@ -205,7 +205,7 @@ test("several pending sends: each after its own anchor, in send order; same anch
   const none = press([], "hello");
   assert.deepEqual(injectionGroups([], reconcilePending([], none).inject), [{ idx: 0, sends: [none[0]] }]);
   // an anchor that left the resident window: everything resident is later than the send, so the slot is the head
-  assert.equal(scanFrom([{ kind: "tool", uuid: "zz" }], { after: "gone", place: null, queuedForeign: [], seen: [], queued: 0 }), 0);
+  assert.equal(scanFrom([{ kind: "tool", uuid: "zz" }], { after: "gone", place: null, queuedForeign: [], queuedResident: {}, seen: [], queued: 0 }), 0);
 });
 
 test("a send pressed while an earlier send's echo is the newest event is placed BELOW that echo (review of the first cut)", () => {
@@ -344,8 +344,8 @@ test("a send pressed while the kernel's queue holds OTHER texts is drawn below t
   const queued: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "a nudge from elsewhere" }, { md: "mine" }] }];
   const mine = newPending("mine", undefined, T0);
   let r = reconcilePending(queued, [mine]);
-  assert.deepEqual(mine.at?.queuedForeign, ["a nudge from elsewhere"], "the foreign texts at the press are recorded");
-  assert.equal(mine.at?.queued, 1, "…and our own copy is background as before");
+  assert.deepEqual(mine.at?.queuedForeign, ["a nudge from elsewhere", "mine"], "every copy the queue held at the press is ahead of the send — a same-text copy included: it predates the press, so it is an older send's (second review)");
+  assert.equal(mine.at?.queued, 1, "…and it is background for the landing scan as before");
   assert.deepEqual(injectionGroups(queued, r.inject), [{ idx: 2, sends: [mine] }], "below the queue, not above it");
   // our copy hidden (render.ts) leaves the foreign text visible: still below
   const hidden: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "a nudge from elsewhere" }, { md: "mine", hiddenByPending: true }] }];
@@ -354,12 +354,21 @@ test("a send pressed while the kernel's queue holds OTHER texts is drawn below t
   const landed: TailEvent[] = [...tail, { kind: "user", md: "a nudge from elsewhere", uuid: "uN" }, { kind: "tool", uuid: "t1" }];
   r = reconcilePending(landed, [mine]);
   assert.deepEqual(injectionGroups(landed, r.inject), [{ idx: 2, sends: [mine] }]);
-  // a queue holding only OUR text keeps the in-place rule (right after the anchor)
-  const ours: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "mine" }] }];
+  // OUR copy is the one the kernel lists AFTER the press: not in the frame at the press, hidden by render.ts
+  // when it appears — the in-place rule (right after the anchor) holds for it
   const mine2 = newPending("mine", undefined, T0 + 1);
-  r = reconcilePending(ours, [mine2]);
+  r = reconcilePending(tail, [mine2]);
   assert.deepEqual(mine2.at?.queuedForeign, []);
-  assert.deepEqual(injectionGroups(ours, r.inject), [{ idx: 1, sends: [mine2] }]);
+  const listed: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "mine" }] }];
+  r = reconcilePending(listed, [mine2]);
+  assert.deepEqual(r.unqueue, [mine2], "the copy that appears after the press is this send's: hidden, ours drawn");
+  assert.deepEqual(injectionGroups(listed, r.inject), [{ idx: 1, sends: [mine2] }]);
+  // a same-text copy PRESENT at the press is an older send's (another client, an earlier press): ahead, below the group
+  const older: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "mine" }] }];
+  const mine3 = newPending("mine", undefined, T0 + 2);
+  r = reconcilePending(older, [mine3]);
+  assert.deepEqual(mine3.at?.queuedForeign, ["mine"]);
+  assert.deepEqual(injectionGroups(older, r.inject), [{ idx: 2, sends: [mine3] }]);
   // render.ts: the stale merge-into-the-group comment is gone; the tail group is described as a floor
   assert.doesNotMatch(RENDER, /Ours merges INTO it when present/);
   assert.match(RENDER, /a group holding OTHER texts is a floor/);
@@ -372,7 +381,7 @@ test("foreign and floor texts match the kernel's landed shapes: a nudge's quote 
   const full = "> the goal's context line\n\n" + body + "\n\n<!-- romp-goal-id: g1 --><!-- romp-injected -->";
   const x = newPending("mine", undefined, T0);
   reconcilePending([...tail, { kind: "queued", texts: [{ md: body }, { md: "mine" }] }], [x]);
-  assert.deepEqual(x.at?.queuedForeign, [body]);
+  assert.deepEqual(x.at?.queuedForeign, [body, "mine"], "every copy present at the press is ahead (the same-text one is an older send's)");
   const nudgeLanded: TailEvent[] = [...tail, { kind: "user", md: full, uuid: "uN" }, { kind: "assistant", md: "…", uuid: "a2" }, { kind: "queued", texts: [{ md: "mine", hiddenByPending: true }] }];
   assert.deepEqual(injectionGroups(nudgeLanded, reconcilePending(nudgeLanded, [x]).inject), [{ idx: 2, sends: [x] }], "below the landed nudge, whatever wrapping the kernel kept");
   // (2) a multi-block record: two foreign texts taken at one boundary land as ONE user record
@@ -403,6 +412,38 @@ test("foreign and floor texts match the kernel's landed shapes: a nudge's quote 
   dropPending([x4, y4], "first", x4.ts);   // the ✕ the kernel could not honour: the CLI had taken it
   const afterX: TailEvent[] = [...tail, { kind: "user", md: "first", uuid: "uX", absorbed: true }, { kind: "tool", uuid: "t1" }];
   assert.deepEqual(injectionGroups(afterX, reconcilePending(afterX, [y4]).inject), [{ idx: 2, sends: [y4] }], "below X's atom, under its new uuid");
+});
+
+test("the queue's copies count as they were at the press: a later press matching a queued text, resident carriers, and the key's gates (T252b second review)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  // (1) another client's "y" queued; A presses "x", then B presses "y": both run after that y, and A before B
+  const foreignY: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "y" }] }];
+  const a = newPending("x", undefined, T0); reconcilePending(foreignY, [a]);
+  const b = newPending("y", undefined, T0 + 1); let r = reconcilePending(foreignY, [a, b]);
+  assert.deepEqual(b.at?.queuedForeign, ["y"], "the copy predates B's press: ahead of B, whatever its text");
+  assert.deepEqual(injectionGroups(foreignY, r.inject), [{ idx: 2, sends: [a, b] }], "both below the group, in send order");
+  // (2) a carrier of the text already resident at the press (a never-delivered verdict for an earlier F) is not
+  // the press-time copy's landing: the group holding F stays the floor
+  const resident: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "echo:F0", undelivered: true }, { kind: "queued", texts: [{ md: "F" }] }];
+  const c = newPending("mine", undefined, T0 + 2); r = reconcilePending(resident, [c]);
+  assert.deepEqual(injectionGroups(resident, r.inject), [{ idx: 3, sends: [c] }], "below the group, not at the group's own index");
+  const residentLanded: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "echo:F0", undelivered: true }, { kind: "user", md: "F", uuid: "uF" }, { kind: "tool", uuid: "t1" }];
+  assert.deepEqual(injectionGroups(residentLanded, reconcilePending(residentLanded, [c]).inject), [{ idx: 3, sends: [c] }], "…and below the copy's landing once it lands");
+  // (3) the key: a leading quote block is set aside only for a romp-marked text (the kernel's own gate); a
+  // user's blockquote is part of the text; image chips and image paths are set aside like the kernel strips them
+  assert.equal(foreignKey("> the goal\n\nbody\n\n<!-- romp-goal-id: g1 -->"), "body");
+  assert.notEqual(foreignKey("> hi\nok"), foreignKey("ok"), "a typed blockquote is not wrapping");
+  assert.equal(foreignKey("look /tmp/shot.png"), foreignKey("look"));
+  assert.equal(foreignKey("look [Image #1]"), foreignKey("look"));
+  // an image-bearing foreign message (tmux route): queued with the path, landed with the chips stripped
+  const imgQueued: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "look /tmp/shot.png" }] }];
+  const d = newPending("mine", undefined, T0 + 3); reconcilePending(imgQueued, [d]);
+  const imgLanded: TailEvent[] = [...tail, { kind: "user", md: "look", uuid: "uI", images: [{}] }, { kind: "tool", uuid: "t1" }];
+  assert.deepEqual(injectionGroups(imgLanded, reconcilePending(imgLanded, [d]).inject), [{ idx: 2, sends: [d] }]);
+  // a copy whose text is a user's blockquote plus ours: still a copy present at the press, still ahead
+  const quoted: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "> hi\nok" }] }];
+  const e = newPending("ok", undefined, T0 + 4); r = reconcilePending(quoted, [e]);
+  assert.deepEqual(injectionGroups(quoted, r.inject), [{ idx: 2, sends: [e] }]);
 });
 
 test("a bubble that changes slot marks the view stale, so the incremental repaint never trusts a shifted prefix (second review)", () => {
@@ -710,7 +751,7 @@ test("a send pressed against no frame (a placeholder tab): the first frame's cop
   // a first frame that predates the send entirely stamps exactly as a press-time stamp would
   list = [late()];
   reconcilePending([frame[0], frame[1]], list);
-  assert.deepEqual(list[0].at, { after: "a1", place: "u-old", placeText: TEXT, placeOrd: 0, queuedForeign: [], seen: ["u-old"], queued: 0 });
+  assert.deepEqual(list[0].at, { after: "a1", place: "u-old", placeText: TEXT, placeOrd: 0, queuedForeign: [], queuedResident: {}, seen: ["u-old"], queued: 0 });
   // a press-time stamp reads no stamp: its frame predates the press by construction, so an identical
   // message that landed within the press's own second is still background
   const prompt = press([frame[1], { kind: "user", md: TEXT, uuid: "u-same-second", ts: isoAt(Math.floor(T0 / 1000)) }], TEXT);
@@ -760,7 +801,7 @@ test("a late stamp presumes the first frame's newest queued copy of the text is 
   // follows covers it, exactly as at a press-time stamp
   const early = [late()];
   let r = reconcilePending([step], early);
-  assert.deepEqual(early[0].at, { after: "a1", place: null, placeText: undefined, placeOrd: 0, queuedForeign: [], seen: [], queued: 0 });
+  assert.deepEqual(early[0].at, { after: "a1", place: null, placeText: undefined, placeOrd: 0, queuedForeign: [], queuedResident: {}, seen: [], queued: 0 });
   assert.equal(r.inject.length, 1);
   r = reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }] }], early);
   assert.equal(r.inject.length, 1);

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -446,6 +446,35 @@ test("the queue's copies count as they were at the press: a later press matching
   assert.deepEqual(injectionGroups(quoted, r.inject), [{ idx: 2, sends: [e] }]);
 });
 
+test("empty keys, retired verdicts, a verdict seen first, and the CLI's delimiters (T252b third review)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }, { kind: "tool", uuid: "t1" }];
+  // (1) an image-only queued copy keys to nothing: a reminders-only user record (md "") that lands after the press
+  // is not its carrier — only an event that carries images can be
+  const imgQueued: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "/tmp/shot.png" }] }];
+  const b = newPending("typed after", undefined, T0); reconcilePending(imgQueued, [b]);
+  const notified: TailEvent[] = [...tail, { kind: "user", md: "", uuid: "uR" }, { kind: "tool", uuid: "t2" }, { kind: "queued", texts: [{ md: "/tmp/shot.png" }] }];
+  assert.deepEqual(injectionGroups(notified, reconcilePending(notified, [b]).inject), [{ idx: 5, sends: [b] }], "below the group, not after the notification");
+  const imgLanded: TailEvent[] = [...tail, { kind: "user", md: "", uuid: "uR" }, { kind: "tool", uuid: "t2" }, { kind: "user", md: "", uuid: "uImg", images: [{}] }, { kind: "tool", uuid: "t3" }];
+  assert.deepEqual(injectionGroups(imgLanded, reconcilePending(imgLanded, [b]).inject), [{ idx: 5, sends: [b] }], "below the image's atom once it lands");
+  // (2) a resident verdict counted at the press may be retired by the kernel: the group test must not then read a
+  // copy queued AFTER the press as a press-time one
+  const withVerdict: TailEvent[] = [tail[0], { kind: "user", md: "F", uuid: "echo:F0", undelivered: true }, { kind: "queued", texts: [{ md: "F" }] }];
+  const c = newPending("mine", undefined, T0 + 1); reconcilePending(withVerdict, [c]);
+  const verdictGone: TailEvent[] = [tail[0], { kind: "user", md: "F", uuid: "uF" }, { kind: "tool", uuid: "t1" }, { kind: "queued", texts: [{ md: "F" }] }];
+  assert.deepEqual(injectionGroups(verdictGone, reconcilePending(verdictGone, [c]).inject), [{ idx: 2, sends: [c] }], "right after the press-time copy's landing; the newer F is later");
+  // (3) an earlier send's never-delivered verdict, seen already flagged (a reconnect): a floor for the later send
+  const [p3, b3] = press([tail[0]], "first", "second");
+  const lostFirst: TailEvent[] = [tail[0], { kind: "user", md: "first", uuid: "echo:P", undelivered: true }];
+  const r = reconcilePending(lostFirst, [p3, b3]);
+  assert.deepEqual(r.lost, [p3]);
+  assert.deepEqual(b3.floors?.map((f) => f.uuid), ["echo:P"]);
+  assert.deepEqual(injectionGroups(lostFirst, r.inject), [{ idx: 2, sends: [b3] }], "below the verdict bubble, exactly as below the unflagged echo");
+  // (4) the CLI replaces only the path and leaves the delimiters: both sides keep them
+  for (const [q, l] of [["look (/tmp/a.png)", "look ()"], ["look `/tmp/a.png`", "look ``"], ["look '/tmp/a.png'", "look ''"], ["look \"/tmp/a.png\"", "look \"\""], ["look /tmp/a.png,", "look ,"]])
+    assert.equal(foreignKey(q), foreignKey(l), q);
+  assert.notEqual(foreignKey("design.png.bak notes"), foreignKey("notes"), "not a path: an ordinary token stays");
+});
+
 test("a bubble that changes slot marks the view stale, so the incremental repaint never trusts a shifted prefix (second review)", () => {
   // chatTail lowers v.rendered to the kernel index and the normal-mode append path re-renders from there, assuming
   // the DOM prefix still matches s.events — which also requires the bubble's SLOT to be unchanged. The settle

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -205,7 +205,7 @@ test("several pending sends: each after its own anchor, in send order; same anch
   const none = press([], "hello");
   assert.deepEqual(injectionGroups([], reconcilePending([], none).inject), [{ idx: 0, sends: [none[0]] }]);
   // an anchor that left the resident window: everything resident is later than the send, so the slot is the head
-  assert.equal(scanFrom([{ kind: "tool", uuid: "zz" }], { after: "gone", place: null, seen: [], queued: 0 }), 0);
+  assert.equal(scanFrom([{ kind: "tool", uuid: "zz" }], { after: "gone", place: null, queuedForeign: [], seen: [], queued: 0 }), 0);
 });
 
 test("a send pressed while an earlier send's echo is the newest event is placed BELOW that echo (review of the first cut)", () => {
@@ -300,6 +300,69 @@ test("the text fallback finds the floor by ORDINAL, so a later send of the same 
   assert.equal(d.at?.placeOrd, 0, "no same-text event after the anchor: the floor is not in play");
   const stepsAfterLater: TailEvent[] = [...stepsAfter, { kind: "tool", uuid: "t3" }, { kind: "user", md: "ok", uuid: "echo:D" }];
   assert.deepEqual(injectionGroups(stepsAfterLater, reconcilePending(stepsAfterLater, [d]).inject), [{ idx: 3, sends: [d] }], "right after the anchor");
+});
+
+test("an earlier pending send's landing or echo is a floor for every later send, whatever its text (T252b)", () => {
+  // X then Y pressed against [a1], both with no floor; the kernel ships X's absorbed atom: Y's bubble must sit
+  // BELOW it. Landings were recorded into `seen` for same-text entries only and placement never read them, so Y
+  // was spliced before uX and read above the first message until it landed — the very move this work ends.
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const [x, y] = press(tail, "first", "second");
+  assert.equal(y.at?.place, null);
+  let frame: TailEvent[] = [...tail, { kind: "user", md: "first", uuid: "uX", absorbed: true }, { kind: "tool", uuid: "t1" }];
+  let r = reconcilePending(frame, [x, y]);
+  assert.deepEqual(r.landed.map((l) => l.p), [x]);
+  assert.deepEqual(r.keep, [y]);
+  assert.deepEqual(y.floors, ["uX"], "X's landing is recorded as Y's floor");
+  assert.deepEqual(injectionGroups(frame, r.inject), [{ idx: 2, sends: [y] }], "below uX, above t1");
+  // the echo variant: X's echo arrives while both are pending — Y sits below it, and X is covered
+  const [x2, y2] = press(tail, "first", "second");
+  frame = [...tail, { kind: "user", md: "first", uuid: "echo:X" }];
+  r = reconcilePending(frame, [x2, y2]);
+  assert.deepEqual(r.inject, [y2]);
+  assert.deepEqual(y2.floors, ["echo:X"]);
+  assert.deepEqual(injectionGroups(frame, r.inject), [{ idx: 2, sends: [y2] }]);
+  // …and when that echo becomes the landed atom, the landing takes over as the floor
+  frame = [...tail, { kind: "user", md: "first", uuid: "uX2", absorbed: true }, { kind: "tool", uuid: "t1" }];
+  r = reconcilePending(frame, [x2, y2]);
+  assert.deepEqual(y2.floors, ["echo:X", "uX2"]);
+  assert.deepEqual(injectionGroups(frame, r.inject), [{ idx: 2, sends: [y2] }]);
+  // a LATER send never becomes a floor for an earlier one: Z pressed after Y, lands first (a different route)
+  const [y3, z3] = press(tail, "second", "third");
+  frame = [...tail, { kind: "user", md: "third", uuid: "uZ" }];
+  r = reconcilePending(frame, [y3, z3]);
+  assert.deepEqual(r.landed.map((l) => l.p), [z3]);
+  assert.equal(y3.floors, undefined, "z3 was registered after y3: its landing is not y3's floor");
+  assert.deepEqual(injectionGroups(frame, r.inject), [{ idx: 1, sends: [y3] }], "y3 stays above the later send's atom");
+});
+
+test("a send pressed while the kernel's queue holds OTHER texts is drawn below that queue, and below their atoms once they land (T252b)", () => {
+  // the kernel's queued group has no uuid and is no user event, so it was never the anchor nor the floor: a send
+  // pressed while it held a romp nudge, another client's message, or a queue predating a page reload was spliced
+  // ABOVE the queue although it runs after those texts, and dropped down when one of them landed
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const queued: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "a nudge from elsewhere" }, { md: "mine" }] }];
+  const mine = newPending("mine", undefined, T0);
+  let r = reconcilePending(queued, [mine]);
+  assert.deepEqual(mine.at?.queuedForeign, ["a nudge from elsewhere"], "the foreign texts at the press are recorded");
+  assert.equal(mine.at?.queued, 1, "…and our own copy is background as before");
+  assert.deepEqual(injectionGroups(queued, r.inject), [{ idx: 2, sends: [mine] }], "below the queue, not above it");
+  // our copy hidden (render.ts) leaves the foreign text visible: still below
+  const hidden: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "a nudge from elsewhere" }, { md: "mine", hiddenByPending: true }] }];
+  assert.deepEqual(injectionGroups(hidden, reconcilePending(hidden, [mine]).inject), [{ idx: 2, sends: [mine] }]);
+  // the foreign text lands and the queue drains: the bubble sits below its atom, above what streams after
+  const landed: TailEvent[] = [...tail, { kind: "user", md: "a nudge from elsewhere", uuid: "uN" }, { kind: "tool", uuid: "t1" }];
+  r = reconcilePending(landed, [mine]);
+  assert.deepEqual(injectionGroups(landed, r.inject), [{ idx: 2, sends: [mine] }]);
+  // a queue holding only OUR text keeps the in-place rule (right after the anchor)
+  const ours: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "mine" }] }];
+  const mine2 = newPending("mine", undefined, T0 + 1);
+  r = reconcilePending(ours, [mine2]);
+  assert.deepEqual(mine2.at?.queuedForeign, []);
+  assert.deepEqual(injectionGroups(ours, r.inject), [{ idx: 1, sends: [mine2] }]);
+  // render.ts: the stale merge-into-the-group comment is gone; the tail group is described as a floor
+  assert.doesNotMatch(RENDER, /Ours merges INTO it when present/);
+  assert.match(RENDER, /a group holding OTHER texts is a floor/);
 });
 
 test("a bubble that changes slot marks the view stale, so the incremental repaint never trusts a shifted prefix (second review)", () => {
@@ -607,7 +670,7 @@ test("a send pressed against no frame (a placeholder tab): the first frame's cop
   // a first frame that predates the send entirely stamps exactly as a press-time stamp would
   list = [late()];
   reconcilePending([frame[0], frame[1]], list);
-  assert.deepEqual(list[0].at, { after: "a1", place: "u-old", placeText: TEXT, placeOrd: 0, seen: ["u-old"], queued: 0 });
+  assert.deepEqual(list[0].at, { after: "a1", place: "u-old", placeText: TEXT, placeOrd: 0, queuedForeign: [], seen: ["u-old"], queued: 0 });
   // a press-time stamp reads no stamp: its frame predates the press by construction, so an identical
   // message that landed within the press's own second is still background
   const prompt = press([frame[1], { kind: "user", md: TEXT, uuid: "u-same-second", ts: isoAt(Math.floor(T0 / 1000)) }], TEXT);
@@ -657,7 +720,7 @@ test("a late stamp presumes the first frame's newest queued copy of the text is 
   // follows covers it, exactly as at a press-time stamp
   const early = [late()];
   let r = reconcilePending([step], early);
-  assert.deepEqual(early[0].at, { after: "a1", place: null, placeText: undefined, placeOrd: 0, seen: [], queued: 0 });
+  assert.deepEqual(early[0].at, { after: "a1", place: null, placeText: undefined, placeOrd: 0, queuedForeign: [], seen: [], queued: 0 });
   assert.equal(r.inject.length, 1);
   r = reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }] }], early);
   assert.equal(r.inject.length, 1);

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -313,19 +313,19 @@ test("an earlier pending send's landing or echo is a floor for every later send,
   let r = reconcilePending(frame, [x, y]);
   assert.deepEqual(r.landed.map((l) => l.p), [x]);
   assert.deepEqual(r.keep, [y]);
-  assert.deepEqual(y.floors, ["uX"], "X's landing is recorded as Y's floor");
+  assert.deepEqual(y.floors?.map((f) => f.uuid), ["uX"], "X's landing is recorded as Y's floor");
   assert.deepEqual(injectionGroups(frame, r.inject), [{ idx: 2, sends: [y] }], "below uX, above t1");
   // the echo variant: X's echo arrives while both are pending — Y sits below it, and X is covered
   const [x2, y2] = press(tail, "first", "second");
   frame = [...tail, { kind: "user", md: "first", uuid: "echo:X" }];
   r = reconcilePending(frame, [x2, y2]);
   assert.deepEqual(r.inject, [y2]);
-  assert.deepEqual(y2.floors, ["echo:X"]);
+  assert.deepEqual(y2.floors?.map((f) => f.uuid), ["echo:X"]);
   assert.deepEqual(injectionGroups(frame, r.inject), [{ idx: 2, sends: [y2] }]);
   // …and when that echo becomes the landed atom, the landing takes over as the floor
   frame = [...tail, { kind: "user", md: "first", uuid: "uX2", absorbed: true }, { kind: "tool", uuid: "t1" }];
   r = reconcilePending(frame, [x2, y2]);
-  assert.deepEqual(y2.floors, ["echo:X", "uX2"]);
+  assert.deepEqual(y2.floors?.map((f) => f.uuid), ["echo:X", "uX2"]);
   assert.deepEqual(injectionGroups(frame, r.inject), [{ idx: 2, sends: [y2] }]);
   // a LATER send never becomes a floor for an earlier one: Z pressed after Y, lands first (a different route)
   const [y3, z3] = press(tail, "second", "third");
@@ -363,6 +363,46 @@ test("a send pressed while the kernel's queue holds OTHER texts is drawn below t
   // render.ts: the stale merge-into-the-group comment is gone; the tail group is described as a floor
   assert.doesNotMatch(RENDER, /Ours merges INTO it when present/);
   assert.match(RENDER, /a group holding OTHER texts is a floor/);
+});
+
+test("foreign and floor texts match the kernel's landed shapes: a nudge's quote and markers, a multi-block record, and by ordinal (T252b review)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  // (1) a goal-marked romp nudge: the queued group ships the split BODY, the landed atom keeps the full text
+  const body = "where does this stand?";
+  const full = "> the goal's context line\n\n" + body + "\n\n<!-- romp-goal-id: g1 --><!-- romp-injected -->";
+  const x = newPending("mine", undefined, T0);
+  reconcilePending([...tail, { kind: "queued", texts: [{ md: body }, { md: "mine" }] }], [x]);
+  assert.deepEqual(x.at?.queuedForeign, [body]);
+  const nudgeLanded: TailEvent[] = [...tail, { kind: "user", md: full, uuid: "uN" }, { kind: "assistant", md: "…", uuid: "a2" }, { kind: "queued", texts: [{ md: "mine", hiddenByPending: true }] }];
+  assert.deepEqual(injectionGroups(nudgeLanded, reconcilePending(nudgeLanded, [x]).inject), [{ idx: 2, sends: [x] }], "below the landed nudge, whatever wrapping the kernel kept");
+  // (2) a multi-block record: two foreign texts taken at one boundary land as ONE user record
+  const y = newPending("mine", undefined, T0 + 1);
+  reconcilePending([...tail, { kind: "queued", texts: [{ md: "F" }, { md: "G" }, { md: "mine" }] }], [y]);
+  const blocks: TailEvent[] = [...tail, { kind: "user", md: "F G", uuid: "uFG", blocks: ["F", "G"] }, { kind: "tool", uuid: "t1" }];
+  assert.deepEqual(injectionGroups(blocks, reconcilePending(blocks, [y]).inject), [{ idx: 2, sends: [y] }], "below the record that holds both");
+  // (3) by ordinal: one copy of F queued at the press; F lands; another client queues F AGAIN, and later echoes it —
+  // the press-time copy is the first landing, and the newer copies are later than this send
+  const z = newPending("mine", undefined, T0 + 2);
+  reconcilePending([...tail, { kind: "queued", texts: [{ md: "F" }, { md: "mine" }] }], [z]);
+  const again: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1" }, { kind: "tool", uuid: "t1" }, { kind: "queued", texts: [{ md: "mine", hiddenByPending: true }, { md: "F" }] }];
+  assert.deepEqual(injectionGroups(again, reconcilePending(again, [z]).inject), [{ idx: 2, sends: [z] }], "below the first F, above the newer queued F");
+  const echoed: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1" }, { kind: "tool", uuid: "t1" }, { kind: "user", md: "F", uuid: "echo:F2" }];
+  assert.deepEqual(injectionGroups(echoed, reconcilePending(echoed, [z]).inject), [{ idx: 2, sends: [z] }], "…and above the newer F's echo");
+  // two copies of F at the press: the second landing is the floor
+  const w = newPending("mine", undefined, T0 + 3);
+  reconcilePending([...tail, { kind: "queued", texts: [{ md: "F" }, { md: "F" }, { md: "mine" }] }], [w]);
+  const twoLanded: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1" }, { kind: "user", md: "F", uuid: "uF2" }, { kind: "tool", uuid: "t1" }];
+  assert.deepEqual(injectionGroups(twoLanded, reconcilePending(twoLanded, [w]).inject), [{ idx: 3, sends: [w] }]);
+  const oneLanded: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1" }, { kind: "queued", texts: [{ md: "F" }, { md: "mine", hiddenByPending: true }] }];
+  assert.deepEqual(injectionGroups(oneLanded, reconcilePending(oneLanded, [w]).inject), [{ idx: 3, sends: [w] }], "one press-time copy still queued: below the group");
+  // (4) an earlier send's ECHO floor survives the earlier send's ✕: when its atom lands under a new uuid the floor
+  // is followed by text and ordinal, with no entry left to record the landing
+  const [x4, y4] = press(tail, "first", "second");
+  reconcilePending([...tail, { kind: "user", md: "first", uuid: "echo:X" }], [x4, y4]);
+  assert.deepEqual(y4.floors?.map((f) => [f.uuid, f.text, f.ord]), [["echo:X", "first", 1]]);
+  dropPending([x4, y4], "first", x4.ts);   // the ✕ the kernel could not honour: the CLI had taken it
+  const afterX: TailEvent[] = [...tail, { kind: "user", md: "first", uuid: "uX", absorbed: true }, { kind: "tool", uuid: "t1" }];
+  assert.deepEqual(injectionGroups(afterX, reconcilePending(afterX, [y4]).inject), [{ idx: 2, sends: [y4] }], "below X's atom, under its new uuid");
 });
 
 test("a bubble that changes slot marks the view stale, so the incremental repaint never trusts a shifted prefix (second review)", () => {

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -47,11 +47,17 @@ export type SendBase = {
                           //   landed in place, so the k-th match stays the floor while a LATER send of the same text
                           //   (its echo, its atom) lands beyond it and is never taken (third review). 0 → the floor sits
                           //   at or above the anchor, which already covers it: no fallback
-  queuedForeign: string[]; // texts the kernel's tail queue held at the press that are NOT this client's pending
-                          //   sends (a queued romp nudge, another client's message, a queue predating a page
-                          //   reload): the send runs after them, so its bubble is drawn below that group while it
-                          //   holds them and below their atoms once they land (T252b). The group carries no uuid
-                          //   and is no user event, so neither the anchor nor the floor ever saw it
+  queuedForeign: string[]; // the texts of every visible copy the kernel's tail queue held at the press, one entry
+                          //   per copy (a queued romp nudge, another client's message, an earlier press of this
+                          //   client, a queue predating a page reload): at a press-time stamp every one of them
+                          //   predates the press, so the send runs after them all — its bubble is drawn below that
+                          //   group while a press-time copy is still queued and below their atoms once they land
+                          //   (T252b). A LATE stamp leaves out the newest `own` copies of this send's text, the
+                          //   ones the queued presumption reads as this press's. The group carries no uuid and is
+                          //   no user event, so neither the anchor nor the floor ever saw it
+  queuedResident?: Record<string, number>; // per foreign key: user events after the anchor that already carried the
+                          //   text AT THE PRESS (a never-delivered verdict for an earlier copy) — not the queued
+                          //   copies' landings, so placement's ordinal counts them out (second review)
   seen: string[];         // uuids of the user events carrying the text that are background for this send: what
                           //   the press found, and what an earlier same-text entry claimed since — ONE ENTRY PER
                           //   COPY (a record of several sends lists its uuid once per spoken-for block)
@@ -104,12 +110,26 @@ export const OPT_PREFIX = "optimistic:";
 export const isOptimisticUuid = (u?: string): boolean => !!u && u.startsWith(OPT_PREFIX);
 export const isKernelEchoUuid = (u?: string): boolean => !!u && u.startsWith("echo:");
 const collapse = (s: string): string => s.replace(/\s+/g, " ").trim();
-/** The text a kernel event and a queued copy share once the kernel's wrapping is set aside: the queued group
- *  ships a romp nudge's split BODY, the landed atom keeps the full text — a leading `> ` goal quote, the body,
- *  and `<!-- … -->` marker comments (the kernel splits a landed record only for a human author). Compared on
- *  this key, the two are one text (T252b review). */
-const foreignKey = (s: string): string =>
-  collapse(s.replace(/<!--[\s\S]*?-->/g, " ").split("\n").filter((l) => !/^\s*>/.test(l)).join("\n"));
+/** The text a kernel event and a queued copy share once the kernel's wrapping is set aside (T252b review):
+ *  - a romp-marked text (a nudge, a follow-up: `<!-- romp-… -->` in its tail) is queued as its split BODY but
+ *    landed with the full text — a LEADING `> ` goal-quote block, the body, the marker comments (the kernel
+ *    splits a landed record only for a human author). The comments go, and the leading quote block goes only
+ *    when a romp marker is present — the kernel's own gate; a blockquote the user typed is part of their text;
+ *  - the CLI's image chips (`[Image #N]`) and image paths go: an image-bearing message is queued with the path
+ *    or the chip and landed with the chips stripped (kernel.py, images present), the same asymmetry
+ *    landedCopies sets aside for this client's own sends. */
+export const foreignKey = (s: string): string => {
+  const marked = /<!--\s*romp-/.test(s);
+  let t = s.replace(/<!--[\s\S]*?-->/g, " ");
+  if (marked) {
+    const lines = t.split("\n");
+    let i = 0;
+    while (i < lines.length && (/^\s*>/.test(lines[i]) || (i > 0 && !lines[i].trim()))) i++;
+    if (i > 0 && lines.slice(0, i).some((l) => /^\s*>/.test(l))) t = lines.slice(i).join("\n");
+  }
+  t = t.replace(/\[Image #\d+\]/g, " ").replace(/"?\S+\.(?:png|jpe?g|gif|webp)"?/gi, " ");
+  return collapse(t);
+};
 /** Whether a user event carries `text` (on the foreignKey) in its md or any of its blocks — a record the CLI
  *  wrote from several queued messages taken at one boundary lists each as a block (T252b review). */
 const carriesText = (e: TailEvent, text: string): boolean => {
@@ -246,7 +266,7 @@ const eventSecond = (e: TailEvent): number | null => {
  *  is confined to the late stamp because that is the only stamp that can meet the send's own records,
  *  and because at a press-time stamp it could only misfire (an identical message that landed within
  *  the press's second would read as this send's). */
-export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.late ? 1 : 0, pendingTexts?: Set<string>): SendBase {
+export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.late ? 1 : 0): SendBase {
   const pressS = p.late ? Math.floor(p.ts / 1000) : Infinity;
   const beforeSend = (e: TailEvent): boolean => { const s = eventSecond(e); return s === null || s < pressS; };
   let after: string | null = null;
@@ -273,22 +293,39 @@ export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.l
     const n = copiesIn(e, p);
     for (let k = 0; k < n; k++) seen.push(e.uuid);   // once per COPY: a record of several sends is several
   }
-  // the texts the tail queue holds that are nobody's pending send here: the send runs after them (T252b)
+  // every visible copy the tail queue held at the press is ahead of this send (T252b): a press-time frame
+  // predates the press by construction, so none of them is this send's — a same-text copy is an older send's
+  // (another client, an earlier press). A late stamp leaves out the newest `own` copies of this text (the
+  // queued presumption). Beside them, the carriers of each text already resident after the anchor: those
+  // are not the queued copies' landings, so placement counts them out (second review).
   const queuedForeign: string[] = [];
+  const queuedResident: Record<string, number> = {};
   for (let i = events.length - 1; i >= 0; i--) {
     const e = events[i];
     if (e.kind !== "queued") continue;
-    for (const t of e.texts || []) {
-      if (typeof t.md !== "string" || t.hiddenByPending) continue;
-      if (foreignKey(t.md) === foreignKey(p.text) || (pendingTexts && [...pendingTexts].some((x) => foreignKey(t.md!) === foreignKey(x)))) continue;
-      queuedForeign.push(t.md);
+    let skipOwn = p.late ? own : 0;
+    const copies = (e.texts || []).filter((t) => typeof t.md === "string" && !t.hiddenByPending).map((t) => t.md as string);
+    for (let k = copies.length - 1; k >= 0; k--) {
+      if (skipOwn > 0 && foreignKey(copies[k]) === foreignKey(p.text)) { skipOwn--; continue; }
+      queuedForeign.unshift(copies[k]);
     }
     break;
+  }
+  if (queuedForeign.length) {
+    let anchorIdx = -1;
+    if (after !== null) for (let i = events.length - 1; i >= 0; i--) if (events[i].uuid === after) { anchorIdx = i; break; }
+    for (const f of queuedForeign) {
+      const k = foreignKey(f);
+      if (k in queuedResident) continue;
+      let n = 0;
+      for (let i = anchorIdx + 1; i < events.length; i++) if (carriesText(events[i], f)) n++;
+      queuedResident[k] = n;
+    }
   }
   // the queued presumption (above): a late stamp's newest `own` copies are this press's, so the count of
   // background copies stops short of them — at zero when the frame lists fewer than presumed (the kernel
   // had not received every press yet; the copies still to come cover those entries in order)
-  return { after, place, placeText, placeOrd, queuedForeign, seen, queued: Math.max(0, queued - (p.late ? own : 0)) };
+  return { after, place, placeText, placeOrd, queuedForeign, queuedResident, seen, queued: Math.max(0, queued - (p.late ? own : 0)) };
 }
 
 /** The first index AFTER the send's anchor — or 0 when there is no anchor, or when the anchor has left the
@@ -340,8 +377,7 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
   // identical sends pressed against the same placeholder frame own as many copies as there were presses.
   const lateOwn = new Map<string, number>();
   for (const p of list) if (!p.at && p.late) lateOwn.set(p.text, (lateOwn.get(p.text) || 0) + 1);
-  const pendingTexts = new Set(list.map((q) => q.text));
-  for (const p of list) if (!p.at) p.at = stampBase(events, p, p.late ? lateOwn.get(p.text) || 1 : 0, pendingTexts);
+  for (const p of list) if (!p.at) p.at = stampBase(events, p, p.late ? lateOwn.get(p.text) || 1 : 0);
   const r: Reconciled = { keep: [], inject: [], unqueue: [], landed: [], lost: [] };
   const claimed = new Map<string, number>();           // "index\0text" → copies of that text in that landing taken by earlier entries THIS push
   const takenCopies = new Map<string, Set<number>>();  // text → queued-copy positions taken by an earlier entry THIS push
@@ -511,7 +547,8 @@ export function placementIndex(events: TailEvent[], p: PendingSend): number {
     for (const f of at.queuedForeign) { const k = foreignKey(f); const c = counts.get(k); if (c) c.n++; else counts.set(k, { text: f, n: 1 }); }
     let groupIdx = -1;
     for (let j = events.length - 1; j >= base; j--) if (events[j].kind === "queued") { groupIdx = j; break; }
-    for (const { text, n } of counts.values()) {
+    for (const { text, n: copies } of counts.values()) {
+      const n = copies + ((at.queuedResident || {})[foreignKey(text)] || 0);   // the carriers resident at the press come first
       const k = kthCarrier(text, n);
       let floor = k.idx >= 0 ? k.idx + 1 : -1;
       if (k.count < n && groupIdx >= 0) {

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -573,9 +573,12 @@ export function placementIndex(events: TailEvent[], p: PendingSend): number {
       // GROUP (fourth review): while it still shows a copy of the key, the press-time copy has not landed, so every
       // carrier landed so far was someone else's — an identical text the kernel had already forwarded (canned
       // texts: the Continue button, a retry, a repeated nudge) — and is learned as a resident, so the count keeps
-      // looking past it. The cost, stated: a same-text copy another client queues after the press-time one landed
-      // reads as the press-time one and keeps this bubble below it until this send lands. A stamp on each queued
-      // copy would make the reading exact.
+      // looking past it. Two costs, stated: a same-text copy another client queues after the press-time one landed
+      // reads as the press-time one and keeps this bubble below it until this send lands; and the learning needs the
+      // frame in which the group still shows the key — a socket down from before the fed copy landed until after the
+      // press-time copy was taken (a laptop asleep for a whole turn) delivers both landings at once, nothing is
+      // learned, and the bubble sits between them until this send lands (fifth review). A stamp on each queued copy
+      // would make both readings exact.
       const groupShows = groupIdx >= 0 && (events[groupIdx].texts || []).some((t) => typeof t.md === "string" && !t.hiddenByPending && foreignKey(t.md) === key);
       if (groupShows) for (let j = base; j < events.length; j++) { const e = events[j]; if (e.uuid && carriedCopies(e, text) && !residents.includes(e.uuid)) residents.push(e.uuid); }
       const resident = residents.reduce((acc, u) => { const e = events.find((x) => x.uuid === u); return acc + (e ? carriedCopies(e, text) : 0); }, 0);

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -136,15 +136,21 @@ export const foreignKey = (s: string): string => {
 };
 /** Whether a user event carries `text` (on the foreignKey) in its md or any of its blocks — a record the CLI
  *  wrote from several queued messages taken at one boundary lists each as a block (T252b review). */
-const carriesText = (e: TailEvent, text: string): boolean => {
-  if (e.kind !== "user" || isOptimisticUuid(e.uuid)) return false;
+const carriesText = (e: TailEvent, text: string): boolean => carriedCopies(e, text) > 0;
+/** How many copies of `text` (on the foreignKey) a user event carries: one when its md IS the text, else one per
+ *  matching block — a record the CLI wrote from several queued messages taken at one boundary is as many copies
+ *  as it has matching blocks, the shape textCopies reads for this client's own sends (fourth review). */
+const carriedCopies = (e: TailEvent, text: string): number => {
+  if (e.kind !== "user" || isOptimisticUuid(e.uuid)) return 0;
   const k = foreignKey(text);
   // an image-only text keys to nothing: only an event that carries images can be its carrier — a reminders-only
   // user record (a task notification landed mid-turn, md "") is not (the kernel's own by-text prune refuses an
   // empty key the same way; third review)
-  if (!k) return Array.isArray(e.images) && e.images.length > 0 && (!e.md || !foreignKey(e.md));
-  if (typeof e.md === "string" && foreignKey(e.md) === k) return true;
-  return Array.isArray(e.blocks) && e.blocks.some((b) => typeof b === "string" && foreignKey(b) === k);
+  if (!k) return Array.isArray(e.images) && e.images.length > 0 && (!e.md || !foreignKey(e.md)) ? 1 : 0;
+  if (typeof e.md === "string" && foreignKey(e.md) === k) return 1;
+  let n = 0;
+  if (Array.isArray(e.blocks)) for (const b of e.blocks) if (typeof b === "string" && foreignKey(b) === k) n++;
+  return n;
 };
 
 /** `text` with its shipped image paths removed (quoted or bare, however the composer joined them). */
@@ -399,9 +405,9 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
     for (const q of list.slice(i + 1)) {
       if (!q.floors) q.floors = [];
       if (q.floors.some((f) => f.uuid === u)) continue;
-      const text = typeof events[at].md === "string" ? events[at].md : undefined;
+      const text = owner.text;   // the earlier SEND's own text — a record of several sends carries it as a block, and its md is the blocks joined
       let ord = 0;
-      if (text !== undefined && q.at) for (let j = scanFrom(events, q.at); j <= at; j++) if (carriesText(events[j], text)) ord++;
+      if (q.at) for (let j = scanFrom(events, q.at); j <= at; j++) ord += carriedCopies(events[j], text);
       q.floors.push({ uuid: u, text, ord });
     }
   };
@@ -537,7 +543,12 @@ export function placementIndex(events: TailEvent[], p: PendingSend): number {
   // LATER copy of the same words; -1 when fewer than k have landed
   const kthCarrier = (text: string, k: number): { idx: number; count: number } => {
     let n = 0, last = -1;
-    for (let j = base; j < events.length; j++) if (carriesText(events[j], text)) { n++; last = j; if (n === k) return { idx: j, count: n }; }
+    for (let j = base; j < events.length; j++) {
+      const c = carriedCopies(events[j], text);
+      if (!c) continue;
+      n += c; last = j;
+      if (n >= k) return { idx: j, count: n };
+    }
     return { idx: last, count: n };
   };
   // an earlier pending send's echo or landed atom: below it, whatever its text — by uuid, else by its text's ordinal
@@ -556,14 +567,22 @@ export function placementIndex(events: TailEvent[], p: PendingSend): number {
     let groupIdx = -1;
     for (let j = events.length - 1; j >= base; j--) if (events[j].kind === "queued") { groupIdx = j; break; }
     for (const { text, n: copies } of counts.values()) {
-      const resident = ((at.queuedResident || {})[foreignKey(text)] || []).filter((u) => events.some((e) => e.uuid === u)).length;
-      const n = copies + resident;   // the carriers resident at the press, while still present, come first
+      const key = foreignKey(text);
+      const residents = (at.queuedResident ||= {})[key] ||= [];
+      // The kernel's queued copies carry no identity, so which landing is the press-time copy's is read off the
+      // GROUP (fourth review): while it still shows a copy of the key, the press-time copy has not landed, so every
+      // carrier landed so far was someone else's — an identical text the kernel had already forwarded (canned
+      // texts: the Continue button, a retry, a repeated nudge) — and is learned as a resident, so the count keeps
+      // looking past it. The cost, stated: a same-text copy another client queues after the press-time one landed
+      // reads as the press-time one and keeps this bubble below it until this send lands. A stamp on each queued
+      // copy would make the reading exact.
+      const groupShows = groupIdx >= 0 && (events[groupIdx].texts || []).some((t) => typeof t.md === "string" && !t.hiddenByPending && foreignKey(t.md) === key);
+      if (groupShows) for (let j = base; j < events.length; j++) { const e = events[j]; if (e.uuid && carriedCopies(e, text) && !residents.includes(e.uuid)) residents.push(e.uuid); }
+      const resident = residents.reduce((acc, u) => { const e = events.find((x) => x.uuid === u); return acc + (e ? carriedCopies(e, text) : 0); }, 0);
+      const n = copies + resident;   // the carriers resident at the press, and those learned since, come first
       const k = kthCarrier(text, n);
       let floor = k.idx >= 0 ? k.idx + 1 : -1;
-      if (k.count < n && groupIdx >= 0) {
-        const g = events[groupIdx];
-        if ((g.texts || []).some((t) => typeof t.md === "string" && !t.hiddenByPending && foreignKey(t.md) === foreignKey(text))) floor = Math.max(floor, groupIdx + 1);
-      }
+      if (groupShows) floor = Math.max(floor, groupIdx + 1);
       if (floor > idx) idx = floor;
     }
   }

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -55,9 +55,11 @@ export type SendBase = {
                           //   (T252b). A LATE stamp leaves out the newest `own` copies of this send's text, the
                           //   ones the queued presumption reads as this press's. The group carries no uuid and is
                           //   no user event, so neither the anchor nor the floor ever saw it
-  queuedResident?: Record<string, number>; // per foreign key: user events after the anchor that already carried the
-                          //   text AT THE PRESS (a never-delivered verdict for an earlier copy) — not the queued
-                          //   copies' landings, so placement's ordinal counts them out (second review)
+  queuedResident?: Record<string, string[]>; // per foreign key: the uuids of user events after the anchor that
+                          //   already carried the text AT THE PRESS (a never-delivered verdict for an earlier copy) —
+                          //   not the queued copies' landings, so placement's ordinal counts them out while they are
+                          //   still present; the kernel retires a verdict once a same-text record lands, and a
+                          //   retired one must not keep the count unreachable (second and third reviews)
   seen: string[];         // uuids of the user events carrying the text that are background for this send: what
                           //   the press found, and what an earlier same-text entry claimed since — ONE ENTRY PER
                           //   COPY (a record of several sends lists its uuid once per spoken-for block)
@@ -127,14 +129,20 @@ export const foreignKey = (s: string): string => {
     while (i < lines.length && (/^\s*>/.test(lines[i]) || (i > 0 && !lines[i].trim()))) i++;
     if (i > 0 && lines.slice(0, i).some((l) => /^\s*>/.test(l))) t = lines.slice(i).join("\n");
   }
-  t = t.replace(/\[Image #\d+\]/g, " ").replace(/"?\S+\.(?:png|jpe?g|gif|webp)"?/gi, " ");
-  return collapse(t);
+  // the CLI's own extraction (kernel _IMG_PATH_RE): a leading delimiter, a path from `/` or `~/`, the extension
+  // at a word boundary — only the PATH is replaced, so whatever delimiter wrapped it stays on both sides
+  t = t.replace(/\[Image #\d+\]/g, "").replace(/(^|[\s'"`(])((?:~\/|\/)[^\s'"`()]+\.(?:png|jpe?g|gif|webp))\b/gi, "$1");
+  return collapse(t.replace(/"/g, ""));   // a quoted path may leave its quotes behind: set aside on both sides (noq)
 };
 /** Whether a user event carries `text` (on the foreignKey) in its md or any of its blocks — a record the CLI
  *  wrote from several queued messages taken at one boundary lists each as a block (T252b review). */
 const carriesText = (e: TailEvent, text: string): boolean => {
   if (e.kind !== "user" || isOptimisticUuid(e.uuid)) return false;
   const k = foreignKey(text);
+  // an image-only text keys to nothing: only an event that carries images can be its carrier — a reminders-only
+  // user record (a task notification landed mid-turn, md "") is not (the kernel's own by-text prune refuses an
+  // empty key the same way; third review)
+  if (!k) return Array.isArray(e.images) && e.images.length > 0 && (!e.md || !foreignKey(e.md));
   if (typeof e.md === "string" && foreignKey(e.md) === k) return true;
   return Array.isArray(e.blocks) && e.blocks.some((b) => typeof b === "string" && foreignKey(b) === k);
 };
@@ -299,7 +307,7 @@ export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.l
   // queued presumption). Beside them, the carriers of each text already resident after the anchor: those
   // are not the queued copies' landings, so placement counts them out (second review).
   const queuedForeign: string[] = [];
-  const queuedResident: Record<string, number> = {};
+  const queuedResident: Record<string, string[]> = {};
   for (let i = events.length - 1; i >= 0; i--) {
     const e = events[i];
     if (e.kind !== "queued") continue;
@@ -317,9 +325,9 @@ export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.l
     for (const f of queuedForeign) {
       const k = foreignKey(f);
       if (k in queuedResident) continue;
-      let n = 0;
-      for (let i = anchorIdx + 1; i < events.length; i++) if (carriesText(events[i], f)) n++;
-      queuedResident[k] = n;
+      const us: string[] = [];
+      for (let i = anchorIdx + 1; i < events.length; i++) if (carriesText(events[i], f) && events[i].uuid) us.push(events[i].uuid!);
+      queuedResident[k] = us;
     }
   }
   // the queued presumption (above): a late stamp's newest `own` copies are this press's, so the count of
@@ -436,7 +444,7 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
       floorFor(p, landedIdx);
       continue;
     }
-    if (lostIdx >= 0) { r.lost.push(p); continue; }
+    if (lostIdx >= 0) { r.lost.push(p); floorFor(p, lostIdx); continue; }   // the verdict IS the earlier send's echo: a floor for later sends
     r.keep.push(p);
     // The kernel's ECHO atom covers ours: the kernel draws that atom itself, at the send time. A QUEUED copy
     // does not: it sits in the kernel's group at the tail, and the bubble the user watches is ours, at its
@@ -548,7 +556,8 @@ export function placementIndex(events: TailEvent[], p: PendingSend): number {
     let groupIdx = -1;
     for (let j = events.length - 1; j >= base; j--) if (events[j].kind === "queued") { groupIdx = j; break; }
     for (const { text, n: copies } of counts.values()) {
-      const n = copies + ((at.queuedResident || {})[foreignKey(text)] || 0);   // the carriers resident at the press come first
+      const resident = ((at.queuedResident || {})[foreignKey(text)] || []).filter((u) => events.some((e) => e.uuid === u)).length;
+      const n = copies + resident;   // the carriers resident at the press, while still present, come first
       const k = kthCarrier(text, n);
       let floor = k.idx >= 0 ? k.idx + 1 : -1;
       if (k.count < n && groupIdx >= 0) {

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -58,6 +58,10 @@ export type SendBase = {
   queued: number;         // copies of the text the kernel's queued bubble(s) already listed at the press
 };
 
+/** A placement floor recorded from an earlier send's kernel event: found by uuid, else by the `ord`-th user
+ *  event after the anchor carrying `text` (the echo → landed swap keeps the position, changes the uuid). */
+export type Floor = { uuid: string; text?: string; ord: number };
+
 export type PendingSend = {
   text: string;        // the sent body, byte for byte — what the kernel echoes and the transcript lands
   body: string;        // `text` minus its image paths, whitespace-collapsed: an image send lands with the
@@ -70,9 +74,11 @@ export type PendingSend = {
   imgPaths?: string[]; // dragged images → the bubble's thumbnails, and the image-aware landing match
   lost?: string;       // an event after the press that makes non-delivery LIKELY ("connection": the
                        //   socket dropped) — the bubble says "not confirmed" instead of "sending…"
-  floors?: string[];   // uuids of kernel user events that belong to EARLIER-registered pending sends — their
-                       //   covering echoes and their landed atoms, recorded as they are claimed (T252b): an earlier
-                       //   send's message sits above this one whatever its text, so its bubble is drawn below them
+  floors?: Floor[];    // kernel user events that belong to EARLIER-registered pending sends — their covering
+                       //   echoes and their landed atoms, recorded as they are claimed (T252b): an earlier send's
+                       //   message sits above this one whatever its text, so its bubble is drawn below them. Each
+                       //   carries the event's text and its ordinal among same-text user events after this send's
+                       //   anchor, so the echo → landed swap is followed even when the earlier entry is gone (its ✕)
   received?: boolean;  // the kernel has shown a copy of the text attributed to THIS send (an echo atom or
                        //   a queued copy after the press that no earlier same-text send claimed): the send
                        //   reached it, so a connection drop before or after cannot have lost it — `lost` is
@@ -98,6 +104,20 @@ export const OPT_PREFIX = "optimistic:";
 export const isOptimisticUuid = (u?: string): boolean => !!u && u.startsWith(OPT_PREFIX);
 export const isKernelEchoUuid = (u?: string): boolean => !!u && u.startsWith("echo:");
 const collapse = (s: string): string => s.replace(/\s+/g, " ").trim();
+/** The text a kernel event and a queued copy share once the kernel's wrapping is set aside: the queued group
+ *  ships a romp nudge's split BODY, the landed atom keeps the full text — a leading `> ` goal quote, the body,
+ *  and `<!-- … -->` marker comments (the kernel splits a landed record only for a human author). Compared on
+ *  this key, the two are one text (T252b review). */
+const foreignKey = (s: string): string =>
+  collapse(s.replace(/<!--[\s\S]*?-->/g, " ").split("\n").filter((l) => !/^\s*>/.test(l)).join("\n"));
+/** Whether a user event carries `text` (on the foreignKey) in its md or any of its blocks — a record the CLI
+ *  wrote from several queued messages taken at one boundary lists each as a block (T252b review). */
+const carriesText = (e: TailEvent, text: string): boolean => {
+  if (e.kind !== "user" || isOptimisticUuid(e.uuid)) return false;
+  const k = foreignKey(text);
+  if (typeof e.md === "string" && foreignKey(e.md) === k) return true;
+  return Array.isArray(e.blocks) && e.blocks.some((b) => typeof b === "string" && foreignKey(b) === k);
+};
 
 /** `text` with its shipped image paths removed (quoted or bare, however the composer joined them). */
 export function pendingBody(text: string, imgPaths?: string[]): string {
@@ -260,7 +280,7 @@ export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.l
     if (e.kind !== "queued") continue;
     for (const t of e.texts || []) {
       if (typeof t.md !== "string" || t.hiddenByPending) continue;
-      if (sameText(t.md, p.text) || (pendingTexts && [...pendingTexts].some((x) => sameText(t.md!, x)))) continue;
+      if (foreignKey(t.md) === foreignKey(p.text) || (pendingTexts && [...pendingTexts].some((x) => foreignKey(t.md!) === foreignKey(x)))) continue;
       queuedForeign.push(t.md);
     }
     break;
@@ -325,11 +345,21 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
   const r: Reconciled = { keep: [], inject: [], unqueue: [], landed: [], lost: [] };
   const claimed = new Map<string, number>();           // "index\0text" → copies of that text in that landing taken by earlier entries THIS push
   const takenCopies = new Map<string, Set<number>>();  // text → queued-copy positions taken by an earlier entry THIS push
-  // an earlier entry's covering echo / landed atom is a FLOOR for every entry registered after it (T252b)
-  const floorFor = (owner: PendingSend, u: string | undefined) => {
+  // an earlier entry's covering echo / landed atom is a FLOOR for every entry registered after it (T252b),
+  // recorded with its text and its ordinal among same-text user events after THAT entry's anchor, so the
+  // echo → landed swap can be followed by text when the earlier entry is gone before its atom lands (its ✕)
+  const floorFor = (owner: PendingSend, at: number) => {
+    const u = events[at].uuid;
     if (!u) return;
     const i = list.indexOf(owner);
-    for (const q of list.slice(i + 1)) { if (!q.floors) q.floors = []; if (!q.floors.includes(u)) q.floors.push(u); }
+    for (const q of list.slice(i + 1)) {
+      if (!q.floors) q.floors = [];
+      if (q.floors.some((f) => f.uuid === u)) continue;
+      const text = typeof events[at].md === "string" ? events[at].md : undefined;
+      let ord = 0;
+      if (text !== undefined && q.at) for (let j = scanFrom(events, q.at); j <= at; j++) if (carriesText(events[j], text)) ord++;
+      q.floors.push({ uuid: u, text, ord });
+    }
   };
   for (const p of list) {
     const at = p.at!;
@@ -355,7 +385,7 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
       covered = true;
       const u = events[echoIdx].uuid;
       if (u) for (const q of list) if (q !== p && q.at && q.text === p.text && !q.at.seen.includes(u)) q.at.seen.push(u);
-      floorFor(p, u);
+      floorFor(p, echoIdx);
     } else if (copies > at.queued) {
       const taken = takenCopies.get(p.text) || new Set<number>();
       for (let k = at.queued; k < copies; k++) if (!taken.has(k)) { taken.add(k); covered = true; byQueued = true; break; }
@@ -367,7 +397,7 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
       const ck = landedIdx + "\0" + p.text;             // per text: a record of two DIFFERENT sends is one landing for each
       claimed.set(ck, (claimed.get(ck) || 0) + 1);
       r.landed.push({ p, idx: landedIdx });
-      floorFor(p, events[landedIdx].uuid);
+      floorFor(p, landedIdx);
       continue;
     }
     if (lostIdx >= 0) { r.lost.push(p); continue; }
@@ -459,22 +489,36 @@ export function placementIndex(events: TailEvent[], p: PendingSend): number {
     }
     if (found > idx) idx = found;
   }
-  // an earlier pending send's echo or landed atom: below it, whatever its text
-  for (const u of p.floors || []) {
-    for (let j = events.length - 1; j >= base; j--) if (events[j].uuid === u) { if (j + 1 > idx) idx = j + 1; break; }
+  // the k-th user event after the anchor carrying `text` (md or a block) — the ordinal reading that never takes a
+  // LATER copy of the same words; -1 when fewer than k have landed
+  const kthCarrier = (text: string, k: number): { idx: number; count: number } => {
+    let n = 0, last = -1;
+    for (let j = base; j < events.length; j++) if (carriesText(events[j], text)) { n++; last = j; if (n === k) return { idx: j, count: n }; }
+    return { idx: last, count: n };
+  };
+  // an earlier pending send's echo or landed atom: below it, whatever its text — by uuid, else by its text's ordinal
+  for (const f of p.floors || []) {
+    let found = -1;
+    for (let j = events.length - 1; j >= base; j--) if (events[j].uuid === f.uuid) { found = j + 1; break; }
+    if (found < 0 && f.text !== undefined && f.ord > 0) { const k = kthCarrier(f.text, f.ord); if (k.idx >= 0) found = k.idx + 1; }
+    if (found > idx) idx = found;
   }
-  // the texts the kernel's queue held at the press: below the group while it holds them, below their atoms after
+  // the texts the kernel's queue held at the press, COUNTED per text: the press-time copies are the first k
+  // landings of that text, so the floor is the k-th carrier (never a later copy another client sent), and the
+  // group is a floor only while a press-time copy is still queued (fewer than k have landed)
   if (at.queuedForeign && at.queuedForeign.length) {
-    for (let j = events.length - 1; j >= base; j--) {
-      const e = events[j];
-      if (e.kind === "queued") {
-        if ((e.texts || []).some((t) => typeof t.md === "string" && !t.hiddenByPending && at.queuedForeign.some((f) => sameText(t.md!, f)))) { if (j + 1 > idx) idx = j + 1; }
-        break;
+    const counts = new Map<string, { text: string; n: number }>();
+    for (const f of at.queuedForeign) { const k = foreignKey(f); const c = counts.get(k); if (c) c.n++; else counts.set(k, { text: f, n: 1 }); }
+    let groupIdx = -1;
+    for (let j = events.length - 1; j >= base; j--) if (events[j].kind === "queued") { groupIdx = j; break; }
+    for (const { text, n } of counts.values()) {
+      const k = kthCarrier(text, n);
+      let floor = k.idx >= 0 ? k.idx + 1 : -1;
+      if (k.count < n && groupIdx >= 0) {
+        const g = events[groupIdx];
+        if ((g.texts || []).some((t) => typeof t.md === "string" && !t.hiddenByPending && foreignKey(t.md) === foreignKey(text))) floor = Math.max(floor, groupIdx + 1);
       }
-    }
-    for (let j = events.length - 1; j >= base; j--) {
-      const e = events[j];
-      if (e.kind === "user" && !isOptimisticUuid(e.uuid) && typeof e.md === "string" && at.queuedForeign.some((f) => sameText(e.md!, f))) { if (j + 1 > idx) idx = j + 1; break; }
+      if (floor > idx) idx = floor;
     }
   }
   return idx;

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -47,6 +47,11 @@ export type SendBase = {
                           //   landed in place, so the k-th match stays the floor while a LATER send of the same text
                           //   (its echo, its atom) lands beyond it and is never taken (third review). 0 → the floor sits
                           //   at or above the anchor, which already covers it: no fallback
+  queuedForeign: string[]; // texts the kernel's tail queue held at the press that are NOT this client's pending
+                          //   sends (a queued romp nudge, another client's message, a queue predating a page
+                          //   reload): the send runs after them, so its bubble is drawn below that group while it
+                          //   holds them and below their atoms once they land (T252b). The group carries no uuid
+                          //   and is no user event, so neither the anchor nor the floor ever saw it
   seen: string[];         // uuids of the user events carrying the text that are background for this send: what
                           //   the press found, and what an earlier same-text entry claimed since — ONE ENTRY PER
                           //   COPY (a record of several sends lists its uuid once per spoken-for block)
@@ -65,6 +70,9 @@ export type PendingSend = {
   imgPaths?: string[]; // dragged images → the bubble's thumbnails, and the image-aware landing match
   lost?: string;       // an event after the press that makes non-delivery LIKELY ("connection": the
                        //   socket dropped) — the bubble says "not confirmed" instead of "sending…"
+  floors?: string[];   // uuids of kernel user events that belong to EARLIER-registered pending sends — their
+                       //   covering echoes and their landed atoms, recorded as they are claimed (T252b): an earlier
+                       //   send's message sits above this one whatever its text, so its bubble is drawn below them
   received?: boolean;  // the kernel has shown a copy of the text attributed to THIS send (an echo atom or
                        //   a queued copy after the press that no earlier same-text send claimed): the send
                        //   reached it, so a connection drop before or after cannot have lost it — `lost` is
@@ -80,7 +88,7 @@ export type TailEvent = {
   absorbed?: boolean;
   undelivered?: boolean;
   images?: unknown[];
-  texts?: { md?: string }[];
+  texts?: { md?: string; hiddenByPending?: boolean }[];   // hiddenByPending: render.ts hid this copy for a send drawn in place
   blocks?: string[];    // a user record the CLI wrote from SEVERAL sends taken at one boundary: one text per
                         //   block (kernel.py build_session ships them when there are two or more); `md` is
                         //   the blocks joined, so each block is a copy of its own send
@@ -218,7 +226,7 @@ const eventSecond = (e: TailEvent): number | null => {
  *  is confined to the late stamp because that is the only stamp that can meet the send's own records,
  *  and because at a press-time stamp it could only misfire (an identical message that landed within
  *  the press's second would read as this send's). */
-export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.late ? 1 : 0): SendBase {
+export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.late ? 1 : 0, pendingTexts?: Set<string>): SendBase {
   const pressS = p.late ? Math.floor(p.ts / 1000) : Infinity;
   const beforeSend = (e: TailEvent): boolean => { const s = eventSecond(e); return s === null || s < pressS; };
   let after: string | null = null;
@@ -245,10 +253,22 @@ export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.l
     const n = copiesIn(e, p);
     for (let k = 0; k < n; k++) seen.push(e.uuid);   // once per COPY: a record of several sends is several
   }
+  // the texts the tail queue holds that are nobody's pending send here: the send runs after them (T252b)
+  const queuedForeign: string[] = [];
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.kind !== "queued") continue;
+    for (const t of e.texts || []) {
+      if (typeof t.md !== "string" || t.hiddenByPending) continue;
+      if (sameText(t.md, p.text) || (pendingTexts && [...pendingTexts].some((x) => sameText(t.md!, x)))) continue;
+      queuedForeign.push(t.md);
+    }
+    break;
+  }
   // the queued presumption (above): a late stamp's newest `own` copies are this press's, so the count of
   // background copies stops short of them — at zero when the frame lists fewer than presumed (the kernel
   // had not received every press yet; the copies still to come cover those entries in order)
-  return { after, place, placeText, placeOrd, seen, queued: Math.max(0, queued - (p.late ? own : 0)) };
+  return { after, place, placeText, placeOrd, queuedForeign, seen, queued: Math.max(0, queued - (p.late ? own : 0)) };
 }
 
 /** The first index AFTER the send's anchor — or 0 when there is no anchor, or when the anchor has left the
@@ -300,10 +320,17 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
   // identical sends pressed against the same placeholder frame own as many copies as there were presses.
   const lateOwn = new Map<string, number>();
   for (const p of list) if (!p.at && p.late) lateOwn.set(p.text, (lateOwn.get(p.text) || 0) + 1);
-  for (const p of list) if (!p.at) p.at = stampBase(events, p, p.late ? lateOwn.get(p.text) || 1 : 0);
+  const pendingTexts = new Set(list.map((q) => q.text));
+  for (const p of list) if (!p.at) p.at = stampBase(events, p, p.late ? lateOwn.get(p.text) || 1 : 0, pendingTexts);
   const r: Reconciled = { keep: [], inject: [], unqueue: [], landed: [], lost: [] };
   const claimed = new Map<string, number>();           // "index\0text" → copies of that text in that landing taken by earlier entries THIS push
   const takenCopies = new Map<string, Set<number>>();  // text → queued-copy positions taken by an earlier entry THIS push
+  // an earlier entry's covering echo / landed atom is a FLOOR for every entry registered after it (T252b)
+  const floorFor = (owner: PendingSend, u: string | undefined) => {
+    if (!u) return;
+    const i = list.indexOf(owner);
+    for (const q of list.slice(i + 1)) { if (!q.floors) q.floors = []; if (!q.floors.includes(u)) q.floors.push(u); }
+  };
   for (const p of list) {
     const at = p.at!;
     const from = scanFrom(events, at);
@@ -328,6 +355,7 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
       covered = true;
       const u = events[echoIdx].uuid;
       if (u) for (const q of list) if (q !== p && q.at && q.text === p.text && !q.at.seen.includes(u)) q.at.seen.push(u);
+      floorFor(p, u);
     } else if (copies > at.queued) {
       const taken = takenCopies.get(p.text) || new Set<number>();
       for (let k = at.queued; k < copies; k++) if (!taken.has(k)) { taken.add(k); covered = true; byQueued = true; break; }
@@ -339,6 +367,7 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
       const ck = landedIdx + "\0" + p.text;             // per text: a record of two DIFFERENT sends is one landing for each
       claimed.set(ck, (claimed.get(ck) || 0) + 1);
       r.landed.push({ p, idx: landedIdx });
+      floorFor(p, events[landedIdx].uuid);
       continue;
     }
     if (lostIdx >= 0) { r.lost.push(p); continue; }
@@ -404,22 +433,49 @@ export function injectionGroups(events: TailEvent[], inject: PendingSend[]): Inj
  *  covered by the anchor. Never by comparing the client's clock with the kernel's stamps: the frame
  *  resident at the press is older than the send by construction, and a clock comparison re-inverted the
  *  order whenever the kernel clock led the client by more than the gap between two presses (second
- *  review). A user event that arrives after the press is a later send and stays below the bubble. */
+ *  review). A user event that arrives after the press is a later send and stays below the bubble — with two
+ *  exceptions that are older than the send all the same (T252b): an EARLIER pending send's covering echo or
+ *  landed atom (`floors`, recorded as reconcilePending claims them, whatever their text), and the texts the
+ *  kernel's tail queue held at the press (`queuedForeign`: the bubble sits below that group while it holds
+ *  them, and below their atoms once they land — the group carries no uuid and is no user event, so the
+ *  anchor and the floor never saw it, and a send was drawn above texts it runs after). */
 export function placementIndex(events: TailEvent[], p: PendingSend): number {
   const at = p.at!;
-  let idx = scanFrom(events, at);
-  if (!at.place || !(at.placeOrd && at.placeOrd > 0)) return idx;   // no floor after the anchor: the anchor rules
-  for (let j = events.length - 1; j >= idx; j--) if (events[j].uuid === at.place) return j + 1;
-  if (at.placeText !== undefined) {
-    let n = 0, last = -1;
-    for (let j = idx; j < events.length; j++) {
+  const base = scanFrom(events, at);
+  let idx = base;
+  if (at.place && at.placeOrd && at.placeOrd > 0) {
+    let found = -1;
+    for (let j = events.length - 1; j >= base; j--) if (events[j].uuid === at.place) { found = j + 1; break; }
+    if (found < 0 && at.placeText !== undefined) {
+      let n = 0, last = -1;
+      for (let j = base; j < events.length; j++) {
+        const e = events[j];
+        if (e.kind === "user" && !isOptimisticUuid(e.uuid) && typeof e.md === "string" && sameText(e.md, at.placeText)) {
+          n++; last = j;
+          if (n === at.placeOrd) { found = j + 1; break; }   // the floor, under its landed uuid
+        }
+      }
+      if (found < 0 && last >= 0) found = last + 1;         // fewer matches than at the press (a pruned echo): the newest stands in
+    }
+    if (found > idx) idx = found;
+  }
+  // an earlier pending send's echo or landed atom: below it, whatever its text
+  for (const u of p.floors || []) {
+    for (let j = events.length - 1; j >= base; j--) if (events[j].uuid === u) { if (j + 1 > idx) idx = j + 1; break; }
+  }
+  // the texts the kernel's queue held at the press: below the group while it holds them, below their atoms after
+  if (at.queuedForeign && at.queuedForeign.length) {
+    for (let j = events.length - 1; j >= base; j--) {
       const e = events[j];
-      if (e.kind === "user" && !isOptimisticUuid(e.uuid) && typeof e.md === "string" && sameText(e.md, at.placeText)) {
-        n++; last = j;
-        if (n === at.placeOrd) return j + 1;              // the floor, under its landed uuid
+      if (e.kind === "queued") {
+        if ((e.texts || []).some((t) => typeof t.md === "string" && !t.hiddenByPending && at.queuedForeign.some((f) => sameText(t.md!, f)))) { if (j + 1 > idx) idx = j + 1; }
+        break;
       }
     }
-    if (last >= 0) return last + 1;                       // fewer matches than at the press (a pruned echo): the newest stands in
+    for (let j = events.length - 1; j >= base; j--) {
+      const e = events[j];
+      if (e.kind === "user" && !isOptimisticUuid(e.uuid) && typeof e.md === "string" && at.queuedForeign.some((f) => sameText(e.md!, f))) { if (j + 1 > idx) idx = j + 1; break; }
+    }
   }
   return idx;
 }


### PR DESCRIPTION
Follow-up to the merged in-place pending bubble (#1044), from the manager's adversarial review of it.

- **Ordering between two pending sends.** An earlier-registered entry's covering echo and landed atom are now recorded as `floors` on every later entry, whatever their text, and placement sits below them. Before, X's landing was recorded only for same-text entries and Y's bubble was spliced above X's atom until Y landed.
- **A send above a kernel queue holding other texts.** The press records the tail queue's foreign texts (`queuedForeign`); the bubble sits below that group while it holds them and below their atoms once they land. A queue holding only our text keeps the in-place rule. The stale merge-into-the-group comment is rewritten.
- **docs/read-side.md** describes the in-place bubble instead of the removed header and cue.

**Tests (red before)**: `ui/webview/send-pending.test.ts` — the two-send ordering (landing, echo, echo→landed handover, a later send never a floor) and the foreign-queue placement (queued, own copy hidden, landed, own-text-only), plus the comment pin.
