### PR TITLE
Awaiting gates compare lifts by the evidence they ruled on, not arrival

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -7294,11 +7294,15 @@ def record_verdict(store, nd, src, kind, ev_t=None, why=None, seg=None, msg=Fals
     (flags stay AUTHORITATIVE until the P3.3 flip; the log is the shadow history the fold reads).
     Fusing gate+record means a future writer cannot pass the gate yet skip the history — one call does
     both. `ev_t` = EVIDENCE time (segment/turn/user-action moment); `at` = arrival, forensics only.
-    `end_ev` (2026-09-07) = the EVIDENCE HORIZON a lift ruled on — the newest evidence time it cites (the
-    return that came back, the peer's reply, the last in-harness ending) — journaled as `endEv`, so the
-    gates that ask "did a lift end this wait AFTER the evidence I hold?" compare evidence to evidence
-    (_wait_end_ev), never to the lift's arrival: read as arrival, a lift filed late for old evidence
+    `end_ev` (2026-09-07) = the EVIDENCE HORIZON an ending ruled on: a lift's newest cited evidence (the
+    return that came back, the peer's reply, the last in-harness ending, the clock a "nothing through now"
+    ruling read) or the closer's done's audited turn end, journaled as `endEv`, so the gates that ask
+    "did an ending close this wait AFTER the evidence I hold?" compare evidence to evidence
+    (_wait_end_ev), never to the row's arrival: read as arrival, a lift filed late for old evidence
     suppressed a fresh assert on evidence it never ruled on, and the card stayed down on new information.
+    Journaled AS GIVEN, never truncated (review find, 2026-09-08): the sweep's inclusive stand-down
+    compares the raw evidence it measured against this value, and int() of a fractional Monitor ceiling
+    (timeout_ms not a whole second) disowned the very ceiling the lift cited, so it re-lifted every pass.
 
     The migration window is CLOSED (2026-07-07): every store was swept by migrate_all_stores at kernel
     boot, so an unmigrated node here means the sweep missed one — surface it loudly (judge-errors.jsonl)
@@ -7318,7 +7322,7 @@ def record_verdict(store, nd, src, kind, ev_t=None, why=None, seg=None, msg=Fals
                     **({"msg": True} if msg else {}),  # a user message rides this reopen (chip derivation)
                     **({"undo": True} if undo else {}),   # an undo-restore reopen: not a "not done" assertion
                     **({"lift": True} if lift else {}),   # an `awaiting` row that ENDS the wait, not asserts it
-                    **({"endEv": int(end_ev)} if end_ev else {}),   # …and the newest evidence that lift ruled on
+                    **({"endEv": end_ev} if end_ev else {}),        # …and the newest evidence it ruled on, as given
                     # what an `awaiting` assert waits ON (AWAIT_KINDS; "kind" is taken by the verdict kind).
                     # Absent = a kindless legacy stamp, which every rule treats exactly as before the enum.
                     **({"awaitKind": await_kind} if await_kind else {}),
@@ -7341,15 +7345,23 @@ def _wait_end_ev(e):
     """The EVIDENCE HORIZON of a diary row — the newest evidence time the writer of `e` ruled on, for the
     gates that ask whether a row ended a wait AFTER the evidence they hold (apply_close's awaiting-assert
     stand-down; the sweep's re-lift stand-down in kernel._lift_spent_awaiting). Fallback order, on purpose:
-      `endEv` — a lift naming the return / reply / last ending it cited (record_verdict end_ev, 2026-09-07);
-      `ev_t`  — the row's own evidence time. For a lift that is the ANCHOR of the wait it retracts
-                (_lift_ev_t): a horizon that can never disown evidence newer than that wait's own start;
-      `at`    — arrival, for a legacy row carrying no evidence time at all.
-    Arrival comes LAST because it is forensics (record_verdict's own rule), and reading it first was the
+      `endEv`: the horizon the writer journaled (record_verdict end_ev, 2026-09-07): a lift's newest cited
+                return / reply / ending, or the closer's done's audited turn end. Every lift writer a gate
+                reads journals one now (the rolled-up retirement in kernel._lift_spent_awaiting journals
+                none: no reader consults a rolled-up node's rows), and so does the closer's done;
+      `at`:    arrival, for a row that carries NO horizon: a lift or done filed before horizons were
+                journaled, or a done from a writer that passes none (the planner's, the user's, the
+                propagate link-back). That is exactly the compare these gates made before 2026-09-07, so the
+                upgrade changes nothing for those rows (review find, 2026-09-08). The alternative, reading
+                such a row's ev_t, which for a lift is the ANCHOR of the wait it retracted, could never
+                disown a re-assert, and admitted stale ones main suppressed: the sweep then re-lifted them on
+                the next pass, a card move on no new information, and each re-lift re-armed the nudge ladder;
+      `ev_t`:  the row's own evidence time, for a hand-written legacy row with no arrival at all.
+    For a row WITH a horizon, arrival is forensics (record_verdict's own rule), and reading it was the
     2026-09-07 defect: a lift filed late for evidence up to T_ev read as having ruled on everything before
     its arrival, so a fresh assert whose evidence lay between T_ev and that arrival was suppressed — the
     card stayed down on new information."""
-    return e.get("endEv") or e.get("ev_t") or e.get("at") or 0
+    return e.get("endEv") or e.get("at") or e.get("ev_t") or 0
 
 
 def _block_since(nd):
@@ -10049,10 +10061,14 @@ def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None, t
     anchor (ev_t = the standing awaitingAt), so the classification catches up while the since-time, the
     wake's patience, and the supersede ordering stay keyed to the first assertion.
 
-    `t_end` (2026-09-08) = the audited turn's END, when the caller has it (_close_turn: turn["end"]): the
-    closer's lift ruled on the WHOLE segment, so that is the evidence horizon it journals (record_verdict
-    end_ev) — its ev_t is the turn's trigger, the segment's START, and left as the horizon it understated
-    what the lift saw. Absent (a caller without the turn) the fallback reads ev_t, as before."""
+    `t_end` (2026-09-08) = the audited turn's last EVENT time, when the caller has it (_close_turn): the
+    closer's lift AND its done both ruled on the WHOLE turn, so that is the evidence horizon each journals
+    (record_verdict end_ev): their ev_t is the turn's trigger, the segment's START, and left as the
+    horizon it understated what the closer saw. The done carries it too (review find, 2026-09-08): the
+    awaiting-assert gate below consults done rows as endings, and a closer's done with no horizon read as
+    its arrival, later than the turn by the closer's own latency, so it silenced an assert from a turn
+    triggered in that gap. Absent (a caller without the turn) a row with no horizon reads its arrival, the
+    pre-2026-09-07 compare, unchanged."""
     done, block = verdicts.get("done", {}), verdicts.get("block", {})
     awaiting = verdicts.get("awaiting", {})
     newly = []
@@ -10087,7 +10103,7 @@ def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None, t
                 # nomination for free. (Same posture as the peer-kind awaiting gate below: a claim
                 # whose ending event belongs to another writer is not this closer's to file.)
                 continue
-            if not record_verdict(store, nd, "closer", "done", ev, why=done[i] or None):
+            if not record_verdict(store, nd, "closer", "done", ev, why=done[i] or None, end_ev=t_end):
                 continue                              # the user's follow-up/move postdates this turn's evidence
             if ev is not None:                        # (the event materialized the flags + doneWhy)
                 nd["mt"] = ev
@@ -10122,7 +10138,9 @@ def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None, t
                 # "After" is evidence against evidence — the horizon the ending RULED ON (_wait_end_ev),
                 # never the row's arrival: a lift filed late for older evidence must not silence an
                 # assert on evidence it never saw (2026-09-07). Strict: an assert whose evidence EQUALS
-                # the horizon does not predate it, and stands.
+                # the horizon does not predate it, and stands. Done rows are endings here too: the
+                # closer's done journals the audited turn's end (t_end), and a done from a writer that
+                # journals no horizon reads its arrival, the compare it always had (review find, 2026-09-08).
                 continue
             if nd.get("awaitingWhy") != aw_why:
                 # a changed why is a real event → new row, new anchor (as ever)
@@ -10351,8 +10369,14 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
                                  note="a %s anchored to ev_t %s is shadowed by newer diary rows on "
                                       "%s — the writer stands down; the newer evidence's own turn "
                                       "carries the ruling" % (kind, ev, nd.get("id")))
+    # the horizon the closer's lift and done journal is the turn's last EVENT time (review find,
+    # 2026-09-08): turn["end"] stretches over a trailing idle atom to the NEXT state record (or, for the
+    # tail turn, to the parse clock), and a horizon at the clock is arrival by another name. Every atom's
+    # `t` is a recorded event (a transcript record, or the idle span's Stop transition), so the newest is
+    # the last thing the closer's transcript could have shown it.
+    t_end = max((a.get("t") or 0 for a in turn.get("atoms") or ()), default=0) or turn.get("end")
     newly = apply_close(store, menu, out, t=turn.get("t"), touched=n_touched, t_overrides=t_overrides,
-                        t_end=turn.get("end"))
+                        t_end=t_end)
     # The reply LANDED → the closer considered every menu node (a verdict or a considered omission).
     # ONE look-stamp replaces the retired umbSig/starvedSig signatures (2026-08-13): the newest row
     # FILED in each node's top subtree as of this look, stamped BELOW apply_close so the reply's own

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -7287,13 +7287,18 @@ LOG_CAP = 64                             # per-node verdict-log bound (a node ra
 
 
 def record_verdict(store, nd, src, kind, ev_t=None, why=None, seg=None, msg=False, undo=False, lift=False,
-                   await_kind=None, await_peers=None):
+                   await_kind=None, await_peers=None, end_ev=None):
     """P3.1 DUAL-WRITE (the user 2026-07-06): the gate AND the recorder, fused into the one seam every
     verdict write goes through. Asks may_apply; when allowed, appends the event to the node's
     append-only verdict LOG and returns True — the caller then writes the flags exactly as before
     (flags stay AUTHORITATIVE until the P3.3 flip; the log is the shadow history the fold reads).
     Fusing gate+record means a future writer cannot pass the gate yet skip the history — one call does
     both. `ev_t` = EVIDENCE time (segment/turn/user-action moment); `at` = arrival, forensics only.
+    `end_ev` (2026-09-07) = the EVIDENCE HORIZON a lift ruled on — the newest evidence time it cites (the
+    return that came back, the peer's reply, the last in-harness ending) — journaled as `endEv`, so the
+    gates that ask "did a lift end this wait AFTER the evidence I hold?" compare evidence to evidence
+    (_wait_end_ev), never to the lift's arrival: read as arrival, a lift filed late for old evidence
+    suppressed a fresh assert on evidence it never ruled on, and the card stayed down on new information.
 
     The migration window is CLOSED (2026-07-07): every store was swept by migrate_all_stores at kernel
     boot, so an unmigrated node here means the sweep missed one — surface it loudly (judge-errors.jsonl)
@@ -7313,6 +7318,7 @@ def record_verdict(store, nd, src, kind, ev_t=None, why=None, seg=None, msg=Fals
                     **({"msg": True} if msg else {}),  # a user message rides this reopen (chip derivation)
                     **({"undo": True} if undo else {}),   # an undo-restore reopen: not a "not done" assertion
                     **({"lift": True} if lift else {}),   # an `awaiting` row that ENDS the wait, not asserts it
+                    **({"endEv": int(end_ev)} if end_ev else {}),   # …and the newest evidence that lift ruled on
                     # what an `awaiting` assert waits ON (AWAIT_KINDS; "kind" is taken by the verdict kind).
                     # Absent = a kindless legacy stamp, which every rule treats exactly as before the enum.
                     **({"awaitKind": await_kind} if await_kind else {}),
@@ -7329,6 +7335,21 @@ def record_verdict(store, nd, src, kind, ev_t=None, why=None, seg=None, msg=Fals
     return True                                        # updated here, so callers keep NO mirror writes
     #                                                    (a FROZEN unmigrated node keeps its flags — deriving
     #                                                     from its partial log would wipe real legacy state)
+
+
+def _wait_end_ev(e):
+    """The EVIDENCE HORIZON of a diary row — the newest evidence time the writer of `e` ruled on, for the
+    gates that ask whether a row ended a wait AFTER the evidence they hold (apply_close's awaiting-assert
+    stand-down; the sweep's re-lift stand-down in kernel._lift_spent_awaiting). Fallback order, on purpose:
+      `endEv` — a lift naming the return / reply / last ending it cited (record_verdict end_ev, 2026-09-07);
+      `ev_t`  — the row's own evidence time. For a lift that is the ANCHOR of the wait it retracts
+                (_lift_ev_t): a horizon that can never disown evidence newer than that wait's own start;
+      `at`    — arrival, for a legacy row carrying no evidence time at all.
+    Arrival comes LAST because it is forensics (record_verdict's own rule), and reading it first was the
+    2026-09-07 defect: a lift filed late for evidence up to T_ev read as having ruled on everything before
+    its arrival, so a fresh assert whose evidence lay between T_ev and that arrival was suppressed — the
+    card stayed down on new information."""
+    return e.get("endEv") or e.get("ev_t") or e.get("at") or 0
 
 
 def _block_since(nd):
@@ -10007,7 +10028,7 @@ def _menu_history_text(store, seg_by_id, menu, char_cap):
     return "\n\n".join(parts)
 
 
-def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None):
+def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None, t_end=None):
     """Apply the closer's turn-end verdicts over the touched open tops: COMPLETE each in verdicts["done"]
     (recording doneWhy, clearing any soft block), BLOCK each in verdicts["block"] (recording blockWhy =
     the question owed to the user), and STAMP each in verdicts["awaiting"] (the ⏳ annotation: waiting on
@@ -10026,7 +10047,12 @@ def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None):
     since-time and a long poll loop never chews through LOG_CAP. ONE exception rides that rule without
     breaking it: a same-why re-assert whose kind fills a KINDLESS stamp lands once, AT the original
     anchor (ev_t = the standing awaitingAt), so the classification catches up while the since-time, the
-    wake's patience, and the supersede ordering stay keyed to the first assertion."""
+    wake's patience, and the supersede ordering stay keyed to the first assertion.
+
+    `t_end` (2026-09-08) = the audited turn's END, when the caller has it (_close_turn: turn["end"]): the
+    closer's lift ruled on the WHOLE segment, so that is the evidence horizon it journals (record_verdict
+    end_ev) — its ev_t is the turn's trigger, the segment's START, and left as the horizon it understated
+    what the lift saw. Absent (a caller without the turn) the fallback reads ev_t, as before."""
     done, block = verdicts.get("done", {}), verdicts.get("block", {})
     awaiting = verdicts.get("awaiting", {})
     newly = []
@@ -10087,12 +10113,16 @@ def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None):
                 # (a stand-down is not new information in either direction).
                 continue
             if any(e.get("kind") in ("awaiting", "done") and (e.get("lift") or e.get("kind") == "done")
-                   and (e.get("at") or e.get("ev_t") or 0) > (ev or 0) for e in nd.get("log") or []):
+                   and _wait_end_ev(e) > (ev or 0) for e in nd.get("log") or []):
                 # the wait this assert describes already ENDED in the diary AFTER this turn's evidence
                 # (2026-08-25 audit: a closer auditing the pre-merge segment re-asserted a watch whose
                 # lift AND whose goal's done were both already filed — the stamp then stood for hours
                 # with the job kind exempt from every mail retire). The writer's world is older than
                 # the diary: stand down; a REAL new wait re-asserts from the next pass's fresh evidence.
+                # "After" is evidence against evidence — the horizon the ending RULED ON (_wait_end_ev),
+                # never the row's arrival: a lift filed late for older evidence must not silence an
+                # assert on evidence it never saw (2026-09-07). Strict: an assert whose evidence EQUALS
+                # the horizon does not predate it, and stands.
                 continue
             if nd.get("awaitingWhy") != aw_why:
                 # a changed why is a real event → new row, new anchor (as ever)
@@ -10107,7 +10137,7 @@ def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None):
                 record_verdict(store, nd, "closer", "awaiting", nd.get("awaitingAt"),
                                why=aw_why, await_kind=aw_kind, await_peers=aw_peers)
         elif nd.get("awaitingWhy") and (touched is None or i <= touched):
-            record_verdict(store, nd, "closer", "awaiting", t, lift=True)
+            record_verdict(store, nd, "closer", "awaiting", t, lift=True, end_ev=t_end)
     return newly
 
 
@@ -10321,7 +10351,8 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
                                  note="a %s anchored to ev_t %s is shadowed by newer diary rows on "
                                       "%s — the writer stands down; the newer evidence's own turn "
                                       "carries the ruling" % (kind, ev, nd.get("id")))
-    newly = apply_close(store, menu, out, t=turn.get("t"), touched=n_touched, t_overrides=t_overrides)
+    newly = apply_close(store, menu, out, t=turn.get("t"), touched=n_touched, t_overrides=t_overrides,
+                        t_end=turn.get("end"))
     # The reply LANDED → the closer considered every menu node (a verdict or a considered omission).
     # ONE look-stamp replaces the retired umbSig/starvedSig signatures (2026-08-13): the newest row
     # FILED in each node's top subtree as of this look, stamped BELOW apply_close so the reply's own

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8648,10 +8648,13 @@ def _lift_ev_t(nd, now):
 
 
 def _bg_ended_after(every, tombs, sp, anchor, now, kind="task"):
-    """Did some in-harness background item END after `anchor`? The watermark for the dispatch-less
-    task/job lift in _lift_spent_awaiting: the registry says nothing runs NOW, and this says the
-    emptiness ARRIVED after the stamp — so the stamp stood over live work that has since ended, rather
-    than over a world already empty when the judge stamped (a wait on something outside the harness).
+    """The NEWEST in-harness background ending after `anchor` — its recorded time (truthy), or 0 when
+    nothing ended. The watermark for the dispatch-less task/job/agents lift in _lift_spent_awaiting: the
+    registry says nothing runs NOW, and this says the emptiness ARRIVED after the stamp — so the stamp
+    stood over live work that has since ended, rather than over a world already empty when the judge
+    stamped (a wait on something outside the harness). The TIME is that lift's evidence horizon
+    (record_verdict end_ev, 2026-09-07): the newest ending it cites, which a later assert's evidence is
+    measured against — a bool said only that the lift may fire, not what it ruled on.
     Every source is a recorded event, never a clock: a task's terminal record (`endT`), a Monitor's
     recorded ceiling passing (its kill moment — em._bg_expired, deadline past the anchor), a launch-
     ledger stop tombstone (`at`; a TaskStop suppresses the notification the transcript would pair), or
@@ -8661,14 +8664,16 @@ def _bg_ended_after(every, tombs, sp, anchor, now, kind="task"):
     a remote queue) a CLI respawn and a Monitor's ceiling are CARRIER deaths, not the job ending — a
     routine kernel restart alone used to lift a correctly-labelled job stamp that owned nothing (review
     find on #936, 2026-09-07). A job lifts only on a real terminal record or a ledger stop tombstone."""
-    if kind != "job" and sp > anchor:
-        return True
+    best = sp if (kind != "job" and sp > anchor) else 0
     for t in every:
         if (t.get("endT") or 0) > anchor:
-            return True
+            best = max(best, t.get("endT") or 0)
         if kind != "job" and t.get("status") == "running" and em._bg_expired(t, now) and (t.get("deadline") or 0) > anchor:
-            return True
-    return any((e.get("at") or 0) > anchor for e in tombs if isinstance(e, dict))
+            best = max(best, t.get("deadline") or 0)
+    for e in tombs:
+        if isinstance(e, dict) and (e.get("at") or 0) > anchor:
+            best = max(best, e.get("at") or 0)
+    return best
 
 
 def _stamp_written_at(nd):
@@ -8809,9 +8814,13 @@ def _lift_spent_awaiting(now, tmux):
             # on purpose (2026-08-23) and owns that ending.
             answered = _peer_answered(sid)
             for nd in (list(stamped) if answered[0] else ()):
-                if not _peer_stamp_superseded(nd, answered):
+                reply_t = _peer_stamp_superseded(nd, answered)   # the superseding reply's time, or 0
+                if not reply_t:
                     continue
-                if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True):
+                # the reply IS the evidence this lift rules on: journal it as the horizon, so a later
+                # closer assert on evidence newer than the reply stands whatever this row's arrival
+                if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True,
+                                     end_ev=reply_t):
                     changed = True
                     stamped.remove(nd)
                     _drop_auto_nudge_rec(_top_of(nd.get("id")))
@@ -8903,18 +8912,26 @@ def _lift_spent_awaiting(now, tmux):
                     #    the goal's OWN to protect, and this branch has none.
                     _kind, _anchor0 = nd.get("awaitingKind"), nd.get("awaitingAt") or 0
                     _empty = reg_ids is not None and not reg_ids and not snap.get("subagents") and not running
-                    if _empty and (
-                            (_kind == "agents"
-                             and (sp > _anchor0 or not any(t.get("status") == "running" for t in every)))
-                            or (_kind in ("task", "job") and not _kernel_watch_armed(sid)
-                                # endings are measured from the stamp's WRITE time (_stamp_written_at), not
-                                # the audited turn's trigger: an item that returned mid-turn, before the
-                                # closer even wrote the stamp, is not the world emptying after it (review
-                                # find on #936, 2026-09-07)
-                                and _bg_ended_after(every, tombs, sp, _stamp_written_at(nd), now, kind=_kind))):
-                        if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True):
-                            changed = True
-                            _drop_auto_nudge_rec(top)
+                    # `_ended` = the newest in-harness ending this lift cites — its EVIDENCE HORIZON
+                    # (record_verdict end_ev, 2026-09-07). 0 when the lift rests on no recorded ending
+                    # at all (an agents stamp over a transcript where nothing ever ran and no respawn
+                    # past the anchor): then NO horizon is journaled and the gates fall back to the
+                    # row's own anchor — a horizon nothing on record supports is worse than none.
+                    _ended, _lift = 0, False
+                    if _empty and _kind == "agents" \
+                            and (sp > _anchor0 or not any(t.get("status") == "running" for t in every)):
+                        _ended, _lift = _bg_ended_after(every, tombs, sp, _anchor0, now, kind=_kind), True
+                    elif _empty and _kind in ("task", "job") and not _kernel_watch_armed(sid):
+                        # endings are measured from the stamp's WRITE time (_stamp_written_at), not
+                        # the audited turn's trigger: an item that returned mid-turn, before the
+                        # closer even wrote the stamp, is not the world emptying after it (review
+                        # find on #936, 2026-09-07)
+                        _ended = _bg_ended_after(every, tombs, sp, _stamp_written_at(nd), now, kind=_kind)
+                        _lift = bool(_ended)
+                    if _lift and jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now),
+                                                   lift=True, end_ev=_ended or None):
+                        changed = True
+                        _drop_auto_nudge_rec(top)
                     continue
                 live_set = running_job if nd.get("awaitingKind") == "job" else running
                 if any(t.get("id") in live_set for t in own):
@@ -8949,12 +8966,36 @@ def _lift_spent_awaiting(now, tmux):
                 # stamp keeps the designed audit-lag lift: the write postdates the whole audited
                 # turn, and returns the judge never saw must still lift (the suite pins those).
                 _aw = [e for e in (nd.get("log") or []) if e.get("kind") == "awaiting"]
+                # the RE-ASSERT test asks about the diary's write order — was the wait re-affirmed after
+                # the lift was FILED — so arrival is the right timebase for these two…
                 _last_lift = max((e.get("at") or e.get("ev_t") or 0 for e in _aw if e.get("lift")), default=0)
                 _last_assert = max((e.get("at") or e.get("ev_t") or 0 for e in _aw if not e.get("lift")), default=0)
-                _evidence = max((max(t.get("endT") or 0, t.get("t") or 0, t.get("deadline") or 0,
-                                     sp if t.get("id") in dead else 0)
-                                 for t in own), default=0)
-                if _last_lift and _last_assert > _last_lift and _evidence <= _last_lift:
+                # …but the EVIDENCE test compares evidence to evidence: the newest return this lift can
+                # cite against the newest evidence any prior lift RULED ON (its journaled horizon,
+                # jd._wait_end_ev), never that lift's arrival. Read as arrival, a lift filed late for
+                # evidence up to T_ev claimed everything before its filing, so a return landing between
+                # T_ev and the filing was never citable and the stamp stayed on new information
+                # (2026-09-07). `<=`: a return AT the horizon is the very return that lift cited.
+                _horizon = max((jd._wait_end_ev(e) for e in _aw if e.get("lift")), default=0)
+
+                def _return_ev(t):
+                    # the evidence time of this dispatch's RETURN, conditioned exactly as _returned_after
+                    # conditions its evidence: a terminal record's endT; for a task the pairing still
+                    # shows running, the respawn that killed it (dead) or its recorded ceiling once that
+                    # has PASSED (expired); the launch as the floor (a launch past the anchor returned
+                    # past it). A ceiling that has not passed is never evidence: the completion path
+                    # leaves `deadline` in place, so a watcher that fired early carries a FUTURE ceiling,
+                    # and folding it unconditionally pushed the horizon past the clock — a min() floor
+                    # then journaled the tick time, arrival by another name (review find, 2026-09-08).
+                    ev = max(t.get("endT") or 0, t.get("t") or 0)
+                    if t.get("status") == "running":
+                        if t.get("id") in dead:
+                            ev = max(ev, sp)
+                        if em._bg_expired(t, now):
+                            ev = max(ev, t.get("deadline") or 0)
+                    return ev
+                _evidence = max((_return_ev(t) for t in own), default=0)
+                if _last_lift and _last_assert > _last_lift and _evidence <= _horizon:
                     continue                          # every citable return was already ruled on by that
                     #                                   lift — re-lifting off it is the flap. A return
                     #                                   NEWER than the last lift is new information even
@@ -8963,7 +9004,10 @@ def _lift_spent_awaiting(now, tmux):
                     #                                   landed (2026-08-25 audit — a watcher's stamp written
                     #                                   17s after its merge notification stood 9.5h because
                     #                                   write-time was read as the epistemic boundary)
-                if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True):
+                # this lift's own horizon: the newest return it cites — the very `_evidence` the gate
+                # above measured, so what a lift journals is by construction what its stand-down compares
+                if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True,
+                                     end_ev=_evidence):
                     changed = True
                     # The lift is NEW INFORMATION for the escalation ladder: the wait this goal's last
                     # nudge/wake episode ended on has returned. Drop the goal's spent ledger record
@@ -9425,7 +9469,12 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux, wake_only=F
             return False
         _sn = next((n for n in _fresh.get("nodes", {}).values()
                     if n.get("awaitingWhy") and n.get("awaitingAt") == at and not n.get("rolledUp")), None)
-        if _sn is None or not jd.record_verdict(_fresh, _sn, "romp", "awaiting", at, lift=True):
+        # this lift's ruling is "no ending event arrived through NOW", so the clock IS its evidence
+        # horizon (record_verdict end_ev; review 2026-09-08): with none journaled the fallback read the
+        # row's ev_t — the stamp's anchor — and a closer auditing a segment triggered anywhere inside
+        # (anchor, wake) re-asserted the wait across the whole dead-man window
+        if _sn is None or not jd.record_verdict(_fresh, _sn, "romp", "awaiting", at, lift=True,
+                                                end_ev=int(now)):
             return False
         jd.rollup_status(_fresh, False)
         jd.save_goals(sid, _fresh)
@@ -29739,9 +29788,11 @@ def _peer_stamp_superseded(nd, answered):
     HERE (2026-08-24), never inline a compare. `answered` = _peer_answered(sid), or a bare scalar
     from a legacy caller (kept pair-blind). Peer-scoped exactly as before: job/agents/task/timer
     stamps stand through mail; write-time keyed (the 2026-08-19 audit): a stamp filed after the
-    reply survives — the closer's verdict is fresher than the answer it already saw."""
+    reply survives — the closer's verdict is fresher than the answer it already saw. Returns the
+    superseding reply's TIME (truthy) or 0 (2026-09-07): every reader keeps the predicate it had, and
+    the sweep's lift journals that time as the evidence horizon it ruled on (record_verdict end_ev)."""
     if nd.get("awaitingKind") not in (None, "peer"):
-        return False
+        return 0
     if isinstance(answered, tuple):
         any_t, per = answered
     else:
@@ -29749,7 +29800,9 @@ def _peer_stamp_superseded(nd, answered):
         #                                      it carries no pair map to match an identity against
     peers = nd.get("awaitingPeers")
     ans = (max((per.get(pk, 0) for pk in peers), default=0) if (peers and per is not None) else any_t)
-    return bool((nd.get("awaitingAt") or 0) and ans and _stamp_written_at(nd) < ans)
+    if not ((nd.get("awaitingAt") or 0) and ans and _stamp_written_at(nd) < ans):
+        return 0
+    return int(ans)
 
 
 # ───────────────────────── view-builder: goals → feed (parity: feed = ADAPT; minimal here) ─────────────────────────

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8913,14 +8913,23 @@ def _lift_spent_awaiting(now, tmux):
                     _kind, _anchor0 = nd.get("awaitingKind"), nd.get("awaitingAt") or 0
                     _empty = reg_ids is not None and not reg_ids and not snap.get("subagents") and not running
                     # `_ended` = the newest in-harness ending this lift cites — its EVIDENCE HORIZON
-                    # (record_verdict end_ev, 2026-09-07). 0 when the lift rests on no recorded ending
-                    # at all (an agents stamp over a transcript where nothing ever ran and no respawn
-                    # past the anchor): then NO horizon is journaled and the gates fall back to the
-                    # row's own anchor — a horizon nothing on record supports is worse than none.
+                    # (record_verdict end_ev, 2026-09-07). An agents lift resting on no recorded ending
+                    # at all (a stamp over a transcript where nothing ever ran, no respawn past the
+                    # anchor: the misread-peers-as-agents shape) rules "the authoritative registry shows
+                    # nothing running NOW and nothing ever ended", so the registry read's moment is what
+                    # it ruled through, the dead-man lift's own choice for the same shape of ruling
+                    # (_wake_goal), and journaled as read, never floored to the second: the gates compare
+                    # a horizon against raw evidence times, and int(now) disowned an assert triggered in
+                    # the read's own second. Journaling none instead (review find, 2026-09-08) left the gates
+                    # reading the row's anchor, which disowns nothing: a lagging closer's re-assert from a
+                    # segment triggered inside (anchor, lift) stood, the next pass re-lifted on the same
+                    # empty world, and every re-lift re-armed the nudge ladder: a permanent flap on no
+                    # new information, where main's arrival compare had suppressed the re-assert.
                     _ended, _lift = 0, False
                     if _empty and _kind == "agents" \
                             and (sp > _anchor0 or not any(t.get("status") == "running" for t in every)):
-                        _ended, _lift = _bg_ended_after(every, tombs, sp, _anchor0, now, kind=_kind), True
+                        _ended = _bg_ended_after(every, tombs, sp, _anchor0, now, kind=_kind) or now
+                        _lift = True
                     elif _empty and _kind in ("task", "job") and not _kernel_watch_armed(sid):
                         # endings are measured from the stamp's WRITE time (_stamp_written_at), not
                         # the audited turn's trigger: an item that returned mid-turn, before the
@@ -8929,7 +8938,7 @@ def _lift_spent_awaiting(now, tmux):
                         _ended = _bg_ended_after(every, tombs, sp, _stamp_written_at(nd), now, kind=_kind)
                         _lift = bool(_ended)
                     if _lift and jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now),
-                                                   lift=True, end_ev=_ended or None):
+                                                   lift=True, end_ev=_ended):
                         changed = True
                         _drop_auto_nudge_rec(top)
                     continue
@@ -8950,10 +8959,29 @@ def _lift_spent_awaiting(now, tmux):
                 # parking the card in Working with no reviver left (an idle experiment session,
                 # 2026-08-16).
                 _anchor = nd.get("awaitingAt") or 0
+
+                def _return_ev(t):
+                    # the evidence time of this dispatch's RETURN, the ONE conditioning both the "did
+                    # anything return after the anchor" test and the horizon this lift journals read
+                    # (review find, 2026-09-08: two hand-kept copies had drifted, and the older one still
+                    # counted an UNSPENT ceiling, so a dead watcher whose ceiling lay ahead lifted off a
+                    # horizon older than the anchor it retracted). A terminal record's endT; for a task
+                    # the pairing still shows running, the respawn that killed it (dead) or its recorded
+                    # ceiling once that has PASSED (expired); the launch as the floor (a launch past the
+                    # anchor returned past it). A ceiling that has not passed is never evidence: the
+                    # completion path leaves `deadline` in place, so a watcher that fired early carries a
+                    # FUTURE ceiling, and folding it unconditionally pushed the horizon past the clock;
+                    # a min() floor then journaled the tick time, arrival by another name.
+                    ev = max(t.get("endT") or 0, t.get("t") or 0)
+                    if t.get("status") == "running":
+                        if t.get("id") in dead:
+                            ev = max(ev, sp)
+                        if em._bg_expired(t, now):
+                            ev = max(ev, t.get("deadline") or 0)
+                    return ev
+
                 def _returned_after(t):
-                    return ((t.get("endT") or 0) > _anchor or (t.get("t") or 0) > _anchor
-                            or (t.get("status") == "running" and (t.get("deadline") or 0) > _anchor)
-                            or (t.get("id") in dead and sp > _anchor))
+                    return _return_ev(t) > _anchor
                 if not any(_returned_after(t) for t in own):
                     continue
                 # THE STAND-DOWN RULE, joined (the 2026-08-19 audit): a writer whose evidence
@@ -8977,24 +9005,7 @@ def _lift_spent_awaiting(now, tmux):
                 # T_ev and the filing was never citable and the stamp stayed on new information
                 # (2026-09-07). `<=`: a return AT the horizon is the very return that lift cited.
                 _horizon = max((jd._wait_end_ev(e) for e in _aw if e.get("lift")), default=0)
-
-                def _return_ev(t):
-                    # the evidence time of this dispatch's RETURN, conditioned exactly as _returned_after
-                    # conditions its evidence: a terminal record's endT; for a task the pairing still
-                    # shows running, the respawn that killed it (dead) or its recorded ceiling once that
-                    # has PASSED (expired); the launch as the floor (a launch past the anchor returned
-                    # past it). A ceiling that has not passed is never evidence: the completion path
-                    # leaves `deadline` in place, so a watcher that fired early carries a FUTURE ceiling,
-                    # and folding it unconditionally pushed the horizon past the clock — a min() floor
-                    # then journaled the tick time, arrival by another name (review find, 2026-09-08).
-                    ev = max(t.get("endT") or 0, t.get("t") or 0)
-                    if t.get("status") == "running":
-                        if t.get("id") in dead:
-                            ev = max(ev, sp)
-                        if em._bg_expired(t, now):
-                            ev = max(ev, t.get("deadline") or 0)
-                    return ev
-                _evidence = max((_return_ev(t) for t in own), default=0)
+                _evidence = max((_return_ev(t) for t in own), default=0)   # conditioned as _returned_after
                 if _last_lift and _last_assert > _last_lift and _evidence <= _horizon:
                     continue                          # every citable return was already ruled on by that
                     #                                   lift — re-lifting off it is the flap. A return
@@ -9472,9 +9483,11 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux, wake_only=F
         # this lift's ruling is "no ending event arrived through NOW", so the clock IS its evidence
         # horizon (record_verdict end_ev; review 2026-09-08): with none journaled the fallback read the
         # row's ev_t — the stamp's anchor — and a closer auditing a segment triggered anywhere inside
-        # (anchor, wake) re-asserted the wait across the whole dead-man window
+        # (anchor, wake) re-asserted the wait across the whole dead-man window. Journaled as read, never
+        # floored to the second (review find, 2026-09-08): a horizon compares against raw evidence times,
+        # and int(now) disowned an assert triggered in the wake's own second, which stood and was re-lifted
         if _sn is None or not jd.record_verdict(_fresh, _sn, "romp", "awaiting", at, lift=True,
-                                                end_ev=int(now)):
+                                                end_ev=now):
             return False
         jd.rollup_status(_fresh, False)
         jd.save_goals(sid, _fresh)
@@ -29790,7 +29803,18 @@ def _peer_stamp_superseded(nd, answered):
     stamps stand through mail; write-time keyed (the 2026-08-19 audit): a stamp filed after the
     reply survives — the closer's verdict is fresher than the answer it already saw. Returns the
     superseding reply's TIME (truthy) or 0 (2026-09-07): every reader keeps the predicate it had, and
-    the sweep's lift journals that time as the evidence horizon it ruled on (record_verdict end_ev)."""
+    the sweep's lift journals that time as the evidence horizon it ruled on (record_verdict end_ev).
+
+    The WRITE time, not the assert's evidence time (the audited turn's trigger), is the right side of
+    this compare, and deliberately so (review 2026-09-08, asked whether the lift-horizon rule reaches
+    here): a peer-kind stamp's own write gate (judge.apply_close → _open_ask_peers) reads the live
+    postal log AT the write, and files nothing when any named peer has already replied, so a peer
+    stamp standing certifies that no reply existed when it was written, and a reply is new information
+    exactly when it postdates that read. Keyed on the trigger instead, a reply the gate had already
+    weighed (it landed mid-turn, before the write) would read as superseding a stamp written in full
+    knowledge of it: the 2026-08-19 defect, back. The one residue is a KINDLESS stamp, which has no
+    peer gate and may be superseded by a reply from anyone: the known, tested legacy trade
+    (_goal_awaiting_stamp_full's kindless note), untouched here."""
     if nd.get("awaitingKind") not in (None, "peer"):
         return 0
     if isinstance(answered, tuple):
@@ -29802,7 +29826,7 @@ def _peer_stamp_superseded(nd, answered):
     ans = (max((per.get(pk, 0) for pk in peers), default=0) if (peers and per is not None) else any_t)
     if not ((nd.get("awaitingAt") or 0) and ans and _stamp_written_at(nd) < ans):
         return 0
-    return int(ans)
+    return ans                               # as recorded: a horizon is never truncated (record_verdict end_ev)
 
 
 # ───────────────────────── view-builder: goals → feed (parity: feed = ADAPT; minimal here) ─────────────────────────

--- a/tests/test_awaiting_audit_classes.py
+++ b/tests/test_awaiting_audit_classes.py
@@ -210,22 +210,46 @@ class LiftHorizon(_Base):
         self._reassert(s, t=self.T_EV)
         self.assertIsNotNone(s["nodes"][gid].get("awaitingWhy"), "equal evidence does not predate — stands")
 
-    def test_c_a_row_without_a_horizon_falls_back_to_its_evidence_time_never_its_filing(self):
-        # a pre-horizon lift row: ev_t (the anchor it retracted) is its horizon; the filing time is not
+    def test_c_a_row_without_a_horizon_keeps_the_arrival_compare_it_always_had(self):
+        # a lift row filed before horizons were journaled (no endEv): its arrival is its horizon, the
+        # compare this gate made before 2026-09-07, so the upgrade changes nothing for it (review find,
+        # 2026-09-08). Reading its ev_t instead (the anchor of the wait it retracted) disowned nothing:
+        # a stale re-assert inside (anchor, filing) was admitted, and the sweep re-lifted it next pass
         s, gid = self._stamped_then_lifted()                       # ev_t = T0+500, at = T_ARR, no endEv
         self._reassert(s, t=T0 + 700)                              # between the row's ev_t and its filing
-        self.assertIsNotNone(s["nodes"][gid].get("awaitingWhy"),
-                             "ev_t is the horizon of a row with no endEv — not its arrival")
-        # the accessor itself, in order: endEv, then ev_t, then at, then nothing
+        self.assertIsNone(s["nodes"][gid].get("awaitingWhy"),
+                          "no horizon → arrival is the horizon, as before: the re-assert yields")
+        self._reassert(s, t=self.T_ARR + 1)                        # evidence past the filing: new information
+        self.assertIsNotNone(s["nodes"][gid].get("awaitingWhy"), "…and one past the filing stands, as before")
+        # the accessor itself, in order: endEv, then at, then ev_t, then nothing
         self.assertEqual(jd._wait_end_ev({"endEv": 5, "ev_t": 7, "at": 9}), 5)
-        self.assertEqual(jd._wait_end_ev({"ev_t": 7, "at": 9}), 7)
-        self.assertEqual(jd._wait_end_ev({"at": 9}), 9)
+        self.assertEqual(jd._wait_end_ev({"ev_t": 7, "at": 9}), 9)
+        self.assertEqual(jd._wait_end_ev({"ev_t": 7}), 7)
         self.assertEqual(jd._wait_end_ev({}), 0)
 
+    def test_c2_the_horizon_keeps_its_fraction(self):
+        # a Monitor's recorded ceiling is t + timeout_ms/1000, fractional when timeout_ms is not a whole
+        # second. int()-truncated at the journal, the ceiling the lift cited was disowned: the sweep's
+        # inclusive stand-down measured 600.5 against 600 and re-lifted every pass (pinned through the
+        # sweep in test_kernel_awaiting_lift), and this gate admitted an assert from the ceiling's own
+        # second (review find, 2026-09-08; pre-fix: endEv 600 and the T_EV assert stands)
+        self._log([_msg(1, SID, PEER, T0 + 10, "question")])
+        s, gid = self._store()
+        self._close_peer(s)
+        nd = s["nodes"][gid]
+        nd["log"][-1]["at"] = T0 + 550                             # the closer's write, pinned (synthetic diary)
+        self.assertTrue(jd.record_verdict(s, nd, "romp", "awaiting", T0 + 500, lift=True, end_ev=self.T_EV + 0.5))
+        self.assertEqual(nd["log"][-1].get("endEv"), self.T_EV + 0.5, "journaled as given, never truncated")
+        self.assertIsNone(nd.get("awaitingWhy"), "fixture: the lift ended the wait")
+        self._reassert(s, t=self.T_EV)                             # the ceiling's own second: predates it
+        self.assertIsNone(nd.get("awaitingWhy"), "evidence at int(horizon) still predates a fractional horizon")
+        self._reassert(s, t=self.T_EV + 1)
+        self.assertIsNotNone(nd.get("awaitingWhy"), "the next second is past it: stands")
+
     def test_e_the_closers_own_lift_journals_the_audited_turns_end(self):
-        # the closer's lift ruled on the WHOLE turn, so its horizon is the turn's END (t_end, threaded
-        # from turn["end"] by _close_turn), not its trigger: a re-assert ruled from an anchor inside
-        # the audited span then yields (pre-fold: the fallback read ev_t = the trigger, so it stood)
+        # the closer's lift ruled on the WHOLE turn, so its horizon is the turn's last event (t_end,
+        # threaded by _close_turn, exercised in test_judge_close_standdown's CloserLiftHorizon), not its
+        # trigger: a re-assert ruled from an anchor inside the audited span then yields
         self._log([_msg(1, SID, PEER, T0 + 10, "question")])
         s, gid = self._store()
         self._close_peer(s)                                        # stamped at T0+500
@@ -236,8 +260,58 @@ class LiftHorizon(_Base):
                          "the closer's lift: anchored at the trigger, horizon at the turn's end")
         self._reassert(s, t=T0 + 800)                              # evidence inside the audited span
         self.assertIsNone(s["nodes"][gid].get("awaitingWhy"), "the lift ruled past this evidence — yields")
-        src = open(os.path.join(BIN, "romp-judge")).read()
-        self.assertIn('t_end=turn.get("end")', src, "_close_turn hands the turn's end to apply_close")
+
+    def test_e2_the_closers_done_journals_the_turns_end_and_the_gate_reads_it(self):
+        # done rows are endings for this gate too. The closer's done ruled on the whole audited turn, so
+        # it journals the horizon its lift does (t_end); with none, a row reads its arrival, later than
+        # the turn by the closer's own latency, and silenced an assert from a turn triggered in that gap
+        # (review find, 2026-09-08; pre-fix: no endEv on the done, and the T0+550 assert stood)
+        s, gid = self._store()
+        nd = s["nodes"][gid]
+        jd.apply_close(s, jd.open_menu(s), {"done": {1: "shipped the exporter"}, "block": {}, "awaiting": {}},
+                       t=T0 + 500, t_end=T0 + 600)
+        row = nd["log"][-1]
+        self.assertEqual((row.get("kind"), row.get("ev_t"), row.get("endEv")), ("done", T0 + 500, T0 + 600),
+                         "the closer's done: anchored at the trigger, horizon at the turn's end")
+        row["at"] = T0 + 900                                       # a late filing, pinned (synthetic diary)
+        jd.record_verdict(s, nd, "agent", "reopen", T0 + 650, why="the agent re-opened its own to-do")
+        self.assertFalse(nd.get("nodeComplete"), "fixture: reopened, so the closer may stamp it again")
+        self._reassert(s, t=T0 + 550)                              # inside the done's audited span
+        self.assertIsNone(nd.get("awaitingWhy"), "the done ruled past this evidence: yields")
+        self._reassert(s, t=T0 + 700)                              # past the turn, before the filing
+        self.assertEqual(nd.get("awaitingWhy"), "the rebuild is running again; holding",
+                         "evidence the done never ruled on stands: its arrival is not its horizon")
+
+    def test_e3_a_done_with_no_horizon_keeps_the_arrival_compare_it_always_had(self):
+        # a done from a writer that journals no horizon (the planner's, the user's, the link-back): its
+        # arrival is its horizon, exactly the compare the gate made before 2026-09-07, so the upgrade
+        # changes nothing for it (review find, 2026-09-08; pre-fix: ev_t was read, and the assert stood)
+        s, gid = self._store()
+        nd = s["nodes"][gid]
+        self.assertTrue(jd.record_verdict(s, nd, "planner", "done", T0 + 500, why="shipped"))
+        nd["log"][-1]["at"] = T0 + 900                             # filed late, pinned (synthetic diary)
+        jd.record_verdict(s, nd, "agent", "reopen", T0 + 650, why="the agent re-opened its own to-do")
+        self.assertFalse(nd.get("nodeComplete"), "fixture: reopened")
+        self._reassert(s, t=T0 + 700)                              # between the done's evidence and its filing
+        self.assertIsNone(nd.get("awaitingWhy"), "no horizon → arrival, as before: the re-assert yields")
+        self._reassert(s, t=T0 + 901)
+        self.assertIsNotNone(nd.get("awaitingWhy"), "…and one past the filing stands, as before")
+
+    def test_f_a_peer_stamps_write_is_the_moment_its_own_gate_read_the_log(self):
+        # why the peer supersede (kernel._peer_stamp_superseded) compares the reply to the stamp's WRITE
+        # time and not to the assert's evidence time (review 2026-09-08): the peer-kind write gate reads
+        # the postal log AT the write, so a reply that landed after the audited turn's trigger but before
+        # the write already stands the assert down: a standing peer stamp certifies no reply existed when
+        # it was written, and a reply is new information exactly when it postdates that read
+        self._log([_msg(1, SID, PEER, T0 + 10, "question"), _msg(2, PEER, SID, T0 + 700, "coordinate")])
+        s, gid = self._store()
+        self._close_peer(s)                                        # the audited turn's trigger, T0+500 < the reply
+        self.assertIsNone(s["nodes"][gid].get("awaitingWhy"),
+                          "the reply predates the write: the gate saw it, nothing is filed")
+        self._log([_msg(1, SID, PEER, T0 + 10, "question")])      # no reply yet when the closer writes
+        s, gid = self._store()
+        self._close_peer(s)
+        self.assertEqual(s["nodes"][gid].get("awaitingKind"), "peer", "an open ask at the write admits the stamp")
 
     def test_d_record_verdict_journals_the_horizon_exactly_when_given(self):
         s, gid = self._store()

--- a/tests/test_awaiting_audit_classes.py
+++ b/tests/test_awaiting_audit_classes.py
@@ -158,5 +158,95 @@ class KindBoundaries(_Base):
             self.assertIn(phrase, jd.CLOSER_SYS)
 
 
+class LiftHorizon(_Base):
+    """The diary stand-down compares EVIDENCE to EVIDENCE (2026-09-07). A lift row carries two times:
+    `at`, when it was filed (forensics, per record_verdict), and — since this change — `endEv`, the
+    newest evidence it RULED ON (the return that came back, the peer's reply, the last in-harness
+    ending). The gate used to read `at`, so a lift filed late for old evidence silenced every fresh
+    assert whose evidence lay between what the lift saw and when it was filed: the card stayed down on
+    new information. The lift rows here are written BY HAND so both times are deterministic
+    (record_verdict stamps `at` from the clock); ev_t is the anchor the lift retracts, as _lift_ev_t
+    writes it. SYNTHETIC fixtures."""
+
+    T_EV, T_ARR = T0 + 600, T0 + 900          # what the lift ruled on, and its (late) filing
+
+    def _stamped_then_lifted(self, **row):
+        self._log([_msg(1, SID, PEER, T0 + 10, "question")])
+        s, gid = self._store()
+        self._close_peer(s)
+        nd = s["nodes"][gid]
+        nd["log"][-1]["at"] = T0 + 550          # the closer's write, pinned (the fixture's diary is all synthetic)
+        nd["log"].append({"ev_t": T0 + 500, "src": "romp", "kind": "awaiting", "lift": True,
+                          "at": self.T_ARR, **row})
+        jd._materialize_node(nd)
+        self.assertIsNone(nd.get("awaitingWhy"), "fixture: the lift ended the wait")
+        return s, gid
+
+    def _reassert(self, s, t):
+        # a closer pass on a turn triggered at `t` re-asserts (kind=task: no peer admit gate in the way)
+        jd.apply_close(s, jd.open_menu(s), {"done": {}, "block": {},
+                                            "awaiting": {1: {"why": "the rebuild is running again; holding",
+                                                             "kind": "task"}}}, t=t)
+
+    def test_a_an_assert_on_evidence_the_lift_never_ruled_on_stands(self):
+        # THE case: horizon T_ev < the assert's evidence T_x < the lift's filing T_arr. Read by filing
+        # time the lift looked "after" the assert and suppressed it (main: the stamp is missing); its
+        # own horizon says it ruled on nothing past T_ev — the assert is new information and stands.
+        s, gid = self._stamped_then_lifted(endEv=self.T_EV)
+        self._reassert(s, t=self.T_EV + 100)
+        self.assertEqual(s["nodes"][gid].get("awaitingWhy"), "the rebuild is running again; holding",
+                         "evidence past the lift's horizon is new information — the assert stands")
+
+    def test_b_an_assert_on_evidence_the_lift_ruled_on_still_stands_down(self):
+        s, gid = self._stamped_then_lifted(endEv=self.T_EV)
+        self._reassert(s, t=self.T_EV - 50)
+        self.assertIsNone(s["nodes"][gid].get("awaitingWhy"),
+                          "the diary ended this wait after the audited evidence — the writer yields")
+
+    def test_b2_the_boundary_is_strict_an_assert_at_the_horizon_stands(self):
+        # "predates" is strict: evidence EQUAL to the horizon is not older than what the lift ruled on
+        # (the closer's audit reaches past its own trigger). Pins `>` — a `>=` mutant suppresses this.
+        s, gid = self._stamped_then_lifted(endEv=self.T_EV)
+        self._reassert(s, t=self.T_EV)
+        self.assertIsNotNone(s["nodes"][gid].get("awaitingWhy"), "equal evidence does not predate — stands")
+
+    def test_c_a_row_without_a_horizon_falls_back_to_its_evidence_time_never_its_filing(self):
+        # a pre-horizon lift row: ev_t (the anchor it retracted) is its horizon; the filing time is not
+        s, gid = self._stamped_then_lifted()                       # ev_t = T0+500, at = T_ARR, no endEv
+        self._reassert(s, t=T0 + 700)                              # between the row's ev_t and its filing
+        self.assertIsNotNone(s["nodes"][gid].get("awaitingWhy"),
+                             "ev_t is the horizon of a row with no endEv — not its arrival")
+        # the accessor itself, in order: endEv, then ev_t, then at, then nothing
+        self.assertEqual(jd._wait_end_ev({"endEv": 5, "ev_t": 7, "at": 9}), 5)
+        self.assertEqual(jd._wait_end_ev({"ev_t": 7, "at": 9}), 7)
+        self.assertEqual(jd._wait_end_ev({"at": 9}), 9)
+        self.assertEqual(jd._wait_end_ev({}), 0)
+
+    def test_e_the_closers_own_lift_journals_the_audited_turns_end(self):
+        # the closer's lift ruled on the WHOLE turn, so its horizon is the turn's END (t_end, threaded
+        # from turn["end"] by _close_turn), not its trigger: a re-assert ruled from an anchor inside
+        # the audited span then yields (pre-fold: the fallback read ev_t = the trigger, so it stood)
+        self._log([_msg(1, SID, PEER, T0 + 10, "question")])
+        s, gid = self._store()
+        self._close_peer(s)                                        # stamped at T0+500
+        jd.apply_close(s, jd.open_menu(s), {"done": {}, "block": {}, "awaiting": {}},
+                       t=T0 + 700, touched=1, t_end=T0 + 900)      # a later turn of its own, not re-asserted
+        row = s["nodes"][gid]["log"][-1]
+        self.assertEqual((row.get("lift"), row.get("ev_t"), row.get("endEv")), (True, T0 + 700, T0 + 900),
+                         "the closer's lift: anchored at the trigger, horizon at the turn's end")
+        self._reassert(s, t=T0 + 800)                              # evidence inside the audited span
+        self.assertIsNone(s["nodes"][gid].get("awaitingWhy"), "the lift ruled past this evidence — yields")
+        src = open(os.path.join(BIN, "romp-judge")).read()
+        self.assertIn('t_end=turn.get("end")', src, "_close_turn hands the turn's end to apply_close")
+
+    def test_d_record_verdict_journals_the_horizon_exactly_when_given(self):
+        s, gid = self._store()
+        nd = s["nodes"][gid]
+        self.assertTrue(jd.record_verdict(s, nd, "romp", "awaiting", T0 + 500, lift=True, end_ev=self.T_EV))
+        self.assertEqual(nd["log"][-1].get("endEv"), self.T_EV, "the horizon rides the row it explains")
+        self.assertTrue(jd.record_verdict(s, nd, "closer", "awaiting", T0 + 510, why="a fresh wait"))
+        self.assertNotIn("endEv", nd["log"][-1], "no horizon given → none journaled")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_judge_close_standdown.py
+++ b/tests/test_judge_close_standdown.py
@@ -16,6 +16,11 @@ Two defects, both from the post-outage forensics:
     retires the ride — an unstamped rider would re-nominate every pass forever, the exact one-shot
     defect this cluster deletes.
 
+CloserLiftHorizon (review find, 2026-09-08): the closer's own endings, its lift and its done, journal
+the audited turn's last EVENT time as the evidence horizon they ruled on, threaded by _close_turn into
+apply_close as t_end. Exercised through the real turn parse (the one production caller had been pinned
+by source text alone), including the idle-terminated tail turn whose `end` is the parse clock.
+
 All fixtures synthetic (placeholder UUIDs, invented text).
 """
 import json
@@ -54,13 +59,15 @@ def aline(t, text, uuid, parent=None):
                         "stop_reason": "end_turn"}}
 
 
-def _turn():
+def _turn(states=None):
+    # `states`: optional states/<sid>.jsonl rows (idle transitions), parsed with the clock at NOW
     with tempfile.TemporaryDirectory() as td:
         p = Path(td) / (SID + ".jsonl")
         recs = [uline(T0, "wire the widget end to end", "u1"),
                 aline(T0 + 20, "Shipped: the widget wiring merged and deployed.", "a1", "u1")]
         p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
-        return em.parse_session(str(p), rompuuid=SID, candidate_files=[str(p)], now=NOW)["turns"][0]
+        return em.parse_session(str(p), rompuuid=SID, candidate_files=[str(p)], now=NOW,
+                                states=states)["turns"][0]
 
 
 def _store():
@@ -198,6 +205,65 @@ class LiftRiders(unittest.TestCase):
         s = self._lifted_store()
         jd.rollup_status(s, session_closed=False)
         self.assertNotEqual(s["status"].get(SID + ":g1"), "completed")
+
+
+class CloserLiftHorizon(unittest.TestCase):
+    """The closer's endings, its lift and its done, journal the audited turn's last EVENT time as the
+    evidence horizon they ruled on (record_verdict end_ev), threaded by _close_turn into apply_close as
+    t_end (review find, 2026-09-08: the one production caller was pinned by source text only). Through
+    the real turn parse, so a wrong field threaded (the trigger, the clock, or none) fails here."""
+
+    WHY = "watching the rebuild; picks the result up when it lands"
+
+    def setUp(self):
+        self._llm = jd.closer_llm
+
+    def tearDown(self):
+        jd.closer_llm = self._llm
+
+    def _stamped(self, turn):
+        # a task-kind stamp from an EARLIER turn, on a goal THIS turn touched (placed on its segment)
+        s = _store()
+        nd = _node(s, "g1", "rebuild the notes-api index")
+        jd.apply_close(s, [nd], {"done": {}, "block": {},
+                                 "awaiting": {1: {"why": self.WHY, "kind": "task"}}}, t=T0 - 50, touched=1)
+        self.assertEqual(nd.get("awaitingWhy"), self.WHY, "fixture: stamped on an earlier turn")
+        s["placements"][em.segments(turn)[0]["id"]] = nd["id"]
+        return s, nd
+
+    def test_a_the_closers_lift_through_close_turn_journals_the_turns_last_event(self):
+        turn = _turn()
+        s, nd = self._stamped(turn)
+        self.assertNotEqual(turn["t"], turn["end"], "fixture: a trigger-for-horizon mutant must be visible")
+        jd.closer_llm = lambda tt, mt, *_a: '{"done": [], "block": []}'   # no re-assert: the wait is lifted
+        self.assertEqual(jd._close_turn(s, turn), [])
+        row = nd["log"][-1]
+        self.assertEqual((row.get("kind"), row.get("lift"), row.get("ev_t"), row.get("endEv")),
+                         ("awaiting", True, turn["t"], T0 + 20),
+                         "anchored at the trigger; the horizon is the reply, the turn's last event")
+
+    def test_b_the_closers_done_through_close_turn_journals_the_same_horizon(self):
+        turn = _turn()
+        s, nd = self._stamped(turn)
+        jd.closer_llm = lambda tt, mt, *_a: ('{"done": [{"goal": 1, "why": "the index rebuilt and shipped"}],'
+                                             ' "block": []}')
+        self.assertEqual(jd._close_turn(s, turn), [nd["id"]])
+        row = next(e for e in reversed(nd["log"]) if e.get("kind") == "done")
+        self.assertEqual((row.get("src"), row.get("ev_t"), row.get("endEv")), ("closer", turn["t"], T0 + 20),
+                         "the done ruled on the whole turn too: the same horizon as the lift")
+
+    def test_c_an_idle_tail_turns_horizon_is_the_stop_transition_not_the_parse_clock(self):
+        # the session went idle after the reply (a real Stop transition in states/) and nothing followed:
+        # the idle atom runs to the parse clock, so turn["end"] IS the clock, arrival by another name.
+        # The horizon is the newest recorded EVENT the closer's transcript could show it: the transition
+        turn = _turn(states=[{"t": T0 + 25, "state": "waiting"}])
+        self.assertEqual(turn["end"], NOW, "fixture: the tail turn's end is the parse clock")
+        s, nd = self._stamped(turn)
+        jd.closer_llm = lambda tt, mt, *_a: '{"done": [], "block": []}'
+        self.assertEqual(jd._close_turn(s, turn), [])
+        row = nd["log"][-1]
+        self.assertTrue(row.get("lift"), "fixture: the closer's lift")
+        self.assertEqual(row.get("endEv"), T0 + 25, "the Stop transition, a recorded event, never the clock")
 
 
 class DeadlockedChainHeals(unittest.TestCase):

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -594,6 +594,213 @@ class RestartReconcile(unittest.TestCase):
         self.assertIsNotNone(self._stamp(), "live subagents ARE the wait — never lifted from under them")
 
 
+class _HorizonBase(unittest.TestCase):
+    """Fixture for the evidence-HORIZON tests (2026-09-07): a live session on a PRIVATE sid (the
+    goal-store fixture rule), every outside fact the sweep reads stubbed at its documented seam — the
+    CLI epoch (_sdk_spawned_at), placement (_bg_placed_tops), the peer reply (_peer_answered_at, the
+    scalar seam _peer_answered names) — and the diary read back from the STORE, the row the gates
+    themselves read. SYNTHETIC fixtures."""
+
+    PSID = "55555555-6666-7777-8888-aaaaaaaaaaaa"
+    REPLY = STAMP + 50                                # a peer's answer after the stamp was written
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self.saved = {k: getattr(km, k) for k in
+                      ("_alive_sessions", "_mark_views_dirty", "_sdk_spawned_at", "_bg_placed_tops",
+                       "_peer_answered_at", "_postal_wait_maps")}
+        self.saved_jd = (km.jd.STATE, km.jd.GOALDIR)
+        km.jd.STATE = td
+        km.jd.GOALDIR = td / "goals"
+        km.jd.GOALDIR.mkdir(parents=True)
+        self.path = str(td / (self.PSID + ".jsonl"))
+        km._alive_sessions = lambda now, tmux: [{"sid": self.PSID, "path": self.path}]
+        km._mark_views_dirty = lambda *a, **k: None
+        km._sdk_spawned_at = lambda sid: self.spawn
+        self.spawn = STAMP - 50                       # default: the CLI predates the stamp — no respawn story
+        self.gid, self.other = self.PSID + ":g1", self.PSID + ":g2"
+        km._peer_answered_at = lambda sid: self.reply
+        self.reply = 0                                # default: no peer ever answered
+        km._postal_wait_maps = lambda: ({}, {})
+        self._saved_watches = list(km._pr_watches)
+        km._lift_seen.pop(self.PSID, None)
+        km._SESSION_STAMP_CACHE.clear(); km._bgall_cache.clear(); km._bgtasks_cache.clear()
+
+    def tearDown(self):
+        for k, v in self.saved.items():
+            setattr(km, k, v)
+        km._pr_watches[:] = self._saved_watches
+        try:                                          # while STATE is still the tempdir — after the restore
+            (km.jd._overrides_dir() / (self.PSID + ".jsonl")).unlink()   # this resolves to the shared floor
+        except OSError:
+            pass
+        km.jd.STATE, km.jd.GOALDIR = self.saved_jd
+        km._lift_seen.pop(self.PSID, None)
+        km._SESSION_STAMP_CACHE.clear(); km._bgall_cache.clear(); km._bgtasks_cache.clear()
+        self.td.cleanup()
+
+    def _transcript(self, recs):
+        with open(self.path, "w") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+        km._bgall_cache.clear(); km._bgtasks_cache.clear()
+
+    def _write(self, nd):
+        (km.jd.GOALDIR / (self.PSID + ".json")).write_text(json.dumps(
+            {"rompUuid": self.PSID, "seq": 1, "placements": {}, "status": {}, "nodes": {self.gid: nd}}))
+
+    def _seed(self, kind, why="watching the rebuild; will pick the result up when it lands", written=None):
+        self._write({"id": self.gid, "text": "rebuild the notes-api index", "parentId": None,
+                     "nodeComplete": False, "blocked": False, "cleared": False, "trail": [],
+                     "t": BORN, "mt": BORN, "awaitingWhy": why, "awaitingAt": STAMP,
+                     **({"awaitingKind": kind} if kind else {}),
+                     "log": [{"ev_t": STAMP, "src": "closer", "kind": "awaiting", "why": why,
+                              **({"awaitKind": kind} if kind else {}),
+                              "at": STAMP if written is None else written}]})
+
+    def _node(self):
+        return json.loads((km.jd.GOALDIR / (self.PSID + ".json")).read_text())["nodes"][self.gid]
+
+    def _stamp(self):
+        return self._node().get("awaitingWhy") or None
+
+    def _lifts(self):
+        return [e for e in self._node().get("log") or [] if e.get("kind") == "awaiting" and e.get("lift")]
+
+    def _tick(self, snap=None, now=BACK + 100):
+        km._lift_seen.pop(self.PSID, None)
+        km._lift_spent_awaiting(now, {self.PSID: snap if snap is not None else {"state": ""}})
+
+
+class LiftHorizonJournaled(_HorizonBase):
+    """Each sweep lift that rests on a recorded ending journals that ending's time as its evidence
+    horizon (`endEv`, record_verdict end_ev) — the value the stand-down gates compare fresh evidence
+    against, in place of the row's arrival (the 2026-09-07 defect: a lift filed late for old evidence
+    silenced a fresh assert on evidence it never ruled on). One test per leg, through the real sweep,
+    asserting the journaled row: a leg that drops end_ev leaves the key missing."""
+
+    def test_a_the_dispatch_return_lift_journals_its_newest_citable_return(self):
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed(None)
+        self._tick()
+        self.assertIsNone(self._stamp(), "fixture: the return lifted the stamp")
+        self.assertEqual(self._lifts()[-1].get("endEv"), BACK,
+                         "the horizon is the return the lift cites (min with the clock)")
+
+    def test_b_the_peer_supersede_lift_journals_the_reply_time(self):
+        self._transcript([])
+        self._seed("peer", why="asked the web session to verify; holding for the answer")
+        self.reply = self.REPLY
+        self._tick()
+        self.assertIsNone(self._stamp(), "fixture: the reply superseded the stamp")
+        self.assertEqual(self._lifts()[-1].get("endEv"), self.REPLY,
+                         "the reply is the evidence this lift ruled on")
+
+    def test_c_the_empty_world_lift_journals_the_newest_ending_it_cites(self):
+        # the agents shape whose deciding event is the CLI respawn past the anchor
+        self._transcript([])
+        self._seed("agents", why="workers still building the pieces; merges when they report")
+        self.spawn = BACK
+        self._tick({"state": "", "bgTasks": []})
+        self.assertIsNone(self._stamp(), "fixture: the orphaned agents stamp lifted")
+        self.assertEqual(self._lifts()[-1].get("endEv"), BACK, "the respawn is the ending it cites")
+        # the task/job shape (2026-09-05): every launch placed on a sibling top, the world emptied
+        # after the stamp — the horizon is the newest terminal record
+        km._bg_placed_tops = lambda sid, path, tids: {t: self.other for t in tids}
+        self.spawn = STAMP - 50
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed("job")
+        self._tick({"state": "", "bgTasks": []})
+        self.assertIsNone(self._stamp(), "fixture: the in-harness world emptied after the stamp")
+        self.assertEqual(self._lifts()[-1].get("endEv"), BACK, "the last in-harness ending it cites")
+
+    def test_d_an_agents_lift_resting_on_no_recorded_ending_journals_no_horizon(self):
+        # the misread-peers-as-agents shape: nothing ever ran, no respawn past the anchor — the lift
+        # is right (the notification can never arrive) but cites no ending, so it claims no horizon:
+        # the gates fall back to the row's own anchor rather than trust a time nothing on record supports
+        self._transcript([])
+        self._seed("agents", why="workers still building the pieces; merges when they report")
+        self._tick({"state": "", "bgTasks": []})
+        self.assertIsNone(self._stamp(), "fixture: lifted — the wait can never end")
+        self.assertNotIn("endEv", self._lifts()[-1], "no ending on record → no horizon journaled")
+
+    def test_f_a_returned_watchers_unspent_ceiling_is_not_the_horizon(self):
+        # a Monitor keeps its recorded ceiling after it returns (the completion path sets endT and
+        # leaves `deadline`): a watcher that fired at 400 under a 600 ceiling journals 400 — the
+        # return — never the ceiling, and never the clock a min() floor falls to (pre-fold: 500)
+        self._transcript([_monitor("t1", LAUNCH, timeout_ms=400_000), _notification("t1", BACK)])
+        self._seed(None)
+        self._tick(now=500)
+        self.assertIsNone(self._stamp(), "fixture: the return lifted the stamp")
+        self.assertEqual(self._lifts()[-1].get("endEv"), BACK, "the return — not the ceiling, not the clock")
+
+    def test_e_the_peer_supersede_predicate_returns_the_reply_time(self):
+        nd = {"awaitingWhy": "w", "awaitingAt": STAMP,
+              "log": [{"ev_t": STAMP, "src": "closer", "kind": "awaiting", "why": "w", "at": STAMP}]}
+        self.assertEqual(km._peer_stamp_superseded(nd, (self.REPLY, {})), self.REPLY,
+                         "the superseding reply's time, not a bare True")
+        self.assertEqual(km._peer_stamp_superseded(nd, self.REPLY), self.REPLY, "a legacy scalar too")
+        self.assertEqual(km._peer_stamp_superseded(dict(nd, awaitingPeers=["p1"]), (0, {"p1": self.REPLY + 20})),
+                         self.REPLY + 20, "pair-aware: the awaited pair's own reply")
+        self.assertEqual(km._peer_stamp_superseded(nd, (STAMP - 10, {})), 0, "a reply before the write: not superseded")
+        self.assertEqual(km._peer_stamp_superseded(dict(nd, awaitingKind="job"), (self.REPLY, {})), 0,
+                         "peer-scoped: a job stamp stands through mail")
+
+
+class LiftHorizonGate(_HorizonBase):
+    """The sweep's own stand-down (the 2026-08-19 rule) mirrors the closer's: after a re-assert, a lift
+    fires only on a return NEWER than what the prior lift RULED ON — its journaled horizon — never newer
+    than that lift's filing. The diary: assert → a lift filed late (at T_ARR) for evidence up to T_EV →
+    the closer re-asserts after the filing. The watcher's return lands at T_X."""
+
+    T_EV, T_ARR, REASSERT_AT, NOW = 350, 420, 470, 500
+
+    def _diary(self, t_x, why="the re-armed watcher; reports when it lands", monitor=False):
+        self._transcript([_monitor("t1", LAUNCH, timeout_ms=400_000) if monitor else _launch("t1", LAUNCH),
+                          _notification("t1", t_x)])
+        self._write({"id": self.gid, "text": "a goal", "parentId": None, "nodeComplete": False,
+                     "blocked": False, "cleared": False, "trail": [], "t": BORN, "mt": BORN,
+                     "awaitingWhy": why, "awaitingAt": STAMP, "log": [
+                         {"ev_t": STAMP, "src": "closer", "kind": "awaiting", "why": why, "at": STAMP},
+                         {"ev_t": STAMP, "src": "romp", "kind": "awaiting", "lift": True,
+                          "endEv": self.T_EV, "at": self.T_ARR},
+                         {"ev_t": STAMP, "src": "closer", "kind": "awaiting", "why": why,
+                          "at": self.REASSERT_AT}]})
+
+    def test_a_a_return_past_the_lifts_horizon_lifts_even_though_it_predates_the_filing(self):
+        # T_EV < T_X < T_ARR: read by filing time, the return was "already ruled on" and the stamp
+        # stayed (main: the stamp is still standing); the lift's horizon says it never saw this return
+        self._diary(t_x=380)
+        self._tick(now=self.NOW)
+        self.assertIsNone(self._stamp(), "a return the prior lift never ruled on is new information — lift")
+        self.assertEqual(self._lifts()[-1].get("endEv"), 380, "…and the new lift journals that return")
+
+    def test_b_a_return_the_lift_already_ruled_on_stands_the_re_lift_down(self):
+        self._diary(t_x=340)
+        self._tick(now=self.NOW)
+        self.assertIsNotNone(self._stamp(), "every citable return predates the horizon — the flap, yielded")
+        self.assertEqual(len(self._lifts()), 1, "no second lift row")
+
+    def test_c_a_returned_watchers_unspent_ceiling_does_not_defeat_the_stand_down(self):
+        # the gate measures the same conditioned return evidence the lift journals: a watcher returned
+        # at 340 (before the 350 horizon) under a 600 ceiling cites 340, so the re-lift stands down.
+        # Folding the ceiling made every re-lift of a returned watcher look like new information
+        # (pre-fold: the stamp is lifted — the flap the 2026-08-19 rule exists to stop)
+        self._diary(t_x=340, monitor=True)
+        self._tick(now=self.NOW)
+        self.assertIsNotNone(self._stamp(), "a ceiling that never passed is not a return — yield")
+        self.assertEqual(len(self._lifts()), 1)
+
+    def test_b2_the_boundary_is_inclusive_a_return_at_the_horizon_is_the_one_already_cited(self):
+        # `<=`: a return AT the horizon is the very return the prior lift cited (its own end_ev is
+        # min(newest return, now)) — re-lifting off it is the flap. A `<` mutant lifts here.
+        self._diary(t_x=self.T_EV)
+        self._tick(now=self.NOW)
+        self.assertIsNotNone(self._stamp(), "equal evidence was ruled on — yield")
+        self.assertEqual(len(self._lifts()), 1)
+
+
 if __name__ == "__main__":
     unittest.main()
 
@@ -716,12 +923,12 @@ class InHarnessWaitLift(unittest.TestCase):
         for k, v in self.saved.items():
             setattr(km, k, v)
         km._pr_watches[:] = self._saved_watches
-        km.jd.STATE, km.jd.GOALDIR = self.saved_jd
-        km._SESSION_STAMP_CACHE.clear(); km._bgall_cache.clear(); km._bgtasks_cache.clear()
-        try:
-            (km.jd._overrides_dir() / (self.PSID + ".jsonl")).unlink()
+        try:                                          # while STATE is still the tempdir — after the restore
+            (km.jd._overrides_dir() / (self.PSID + ".jsonl")).unlink()   # this resolves to the shared floor
         except OSError:
             pass
+        km.jd.STATE, km.jd.GOALDIR = self.saved_jd
+        km._SESSION_STAMP_CACHE.clear(); km._bgall_cache.clear(); km._bgtasks_cache.clear()
         self.td.cleanup()
 
     def _transcript(self, recs):

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -622,7 +622,7 @@ class _HorizonBase(unittest.TestCase):
         self.gid, self.other = self.PSID + ":g1", self.PSID + ":g2"
         km._peer_answered_at = lambda sid: self.reply
         self.reply = 0                                # default: no peer ever answered
-        km._postal_wait_maps = lambda: ({}, {})
+        km._postal_wait_maps = lambda: ({}, {}, {})   # main returns (last_any, last_ask, last_await) since #1056
         self._saved_watches = list(km._pr_watches)
         km._lift_seen.pop(self.PSID, None)
         km._SESSION_STAMP_CACHE.clear(); km._bgall_cache.clear(); km._bgtasks_cache.clear()
@@ -685,8 +685,7 @@ class LiftHorizonJournaled(_HorizonBase):
         self._seed(None)
         self._tick()
         self.assertIsNone(self._stamp(), "fixture: the return lifted the stamp")
-        self.assertEqual(self._lifts()[-1].get("endEv"), BACK,
-                         "the horizon is the return the lift cites (min with the clock)")
+        self.assertEqual(self._lifts()[-1].get("endEv"), BACK, "the horizon is the return the lift cites")
 
     def test_b_the_peer_supersede_lift_journals_the_reply_time(self):
         self._transcript([])
@@ -715,15 +714,52 @@ class LiftHorizonJournaled(_HorizonBase):
         self.assertIsNone(self._stamp(), "fixture: the in-harness world emptied after the stamp")
         self.assertEqual(self._lifts()[-1].get("endEv"), BACK, "the last in-harness ending it cites")
 
-    def test_d_an_agents_lift_resting_on_no_recorded_ending_journals_no_horizon(self):
-        # the misread-peers-as-agents shape: nothing ever ran, no respawn past the anchor — the lift
-        # is right (the notification can never arrive) but cites no ending, so it claims no horizon:
-        # the gates fall back to the row's own anchor rather than trust a time nothing on record supports
+    def test_d_an_agents_lift_resting_on_no_recorded_ending_journals_the_registry_read(self):
+        # the misread-peers-as-agents shape: nothing ever ran, no respawn past the anchor. The lift is
+        # right (the notification can never arrive), and its ruling is "the registry shows nothing
+        # running NOW", so the registry read's moment is its horizon, as the dead-man journals its wake.
+        # Journaling none left the gates on the row's anchor, which disowns nothing: a lagging closer's
+        # re-assert from a segment triggered inside (anchor, lift) stood, and the next pass re-lifted the
+        # same empty world: a permanent flap on no new information, each re-lift re-arming the nudge
+        # ladder (review find, 2026-09-08; pre-fix: no endEv, the re-assert stands, two lift rows). The
+        # clock is journaled as read, fraction and all: floored to the second it disowned an assert
+        # triggered in the read's own second, which stood and was re-lifted (pre-fix: int(now), 500)
+        why = "workers still building the pieces; merges when they report"
         self._transcript([])
-        self._seed("agents", why="workers still building the pieces; merges when they report")
-        self._tick({"state": "", "bgTasks": []})
+        self._seed("agents", why=why)
+        self._tick({"state": "", "bgTasks": []}, now=500.5)
         self.assertIsNone(self._stamp(), "fixture: lifted — the wait can never end")
-        self.assertNotIn("endEv", self._lifts()[-1], "no ending on record → no horizon journaled")
+        self.assertEqual(self._lifts()[-1].get("endEv"), 500.5,
+                         "the registry read, as read, is what the lift ruled through")
+        # the lagging closer: a segment triggered inside (anchor, lift) re-asserts the same wait
+        s = km.jd.load_goals(self.PSID)
+        km.jd.apply_close(s, km.jd.open_menu(s), {"done": {}, "block": {},
+                                                  "awaiting": {1: {"why": why, "kind": "agents"}}}, t=STAMP + 50)
+        self.assertIsNone(s["nodes"][self.gid].get("awaitingWhy"),
+                          "a segment inside (anchor, lift) predates the registry read: the writer yields")
+        km.jd.save_goals(self.PSID, s)
+        self._tick({"state": "", "bgTasks": []}, now=505.5)
+        self.assertEqual(len(self._lifts()), 1, "nothing stood, so nothing re-lifts: one row, no flap")
+        # …and a segment triggered AFTER the lift is a new wait: it stands
+        km.jd.apply_close(s, km.jd.open_menu(s), {"done": {}, "block": {},
+                                                  "awaiting": {1: {"why": why, "kind": "agents"}}}, t=600)
+        self.assertEqual(s["nodes"][self.gid].get("awaitingWhy"), why, "a later turn's ruling stands")
+
+    def test_g_a_dead_watchers_unspent_ceiling_is_not_a_return(self):
+        # a Monitor the pairing still shows running, absent from a PRESENT registry (dead), whose CLI
+        # spawn predates the stamp and whose ceiling lies AHEAD: nothing it can cite postdates the anchor.
+        # The "returned after the anchor" test and the horizon the lift journals read ONE conditioning
+        # (_return_ev); the older hand-kept copy still counted the unspent ceiling, so this lifted off a
+        # horizon (the spawn, 250) OLDER than the anchor it retracted (300): a lift citing evidence from
+        # before the wait began (review find, 2026-09-08). The ceiling passing is the event: it lifts then.
+        self._transcript([_monitor("t1", LAUNCH, timeout_ms=400_000)])      # ceiling 600
+        self._seed(None)
+        self._tick({"state": "", "bgTasks": []}, now=500)          # registry present and empty: t1 is dead
+        self.assertIsNotNone(self._stamp(), "nothing returned after the anchor yet: the stamp stands")
+        self.assertEqual(self._lifts(), [], "no lift, so no horizon older than the wait it would retract")
+        self._tick({"state": "", "bgTasks": []}, now=800)          # the ceiling passed: a recorded ending
+        self.assertIsNone(self._stamp(), "the spent ceiling is the return")
+        self.assertEqual(self._lifts()[-1].get("endEv"), 600, "…and the horizon is that ceiling")
 
     def test_f_a_returned_watchers_unspent_ceiling_is_not_the_horizon(self):
         # a Monitor keeps its recorded ceiling after it returns (the completion path sets endT and
@@ -756,7 +792,7 @@ class LiftHorizonGate(_HorizonBase):
 
     T_EV, T_ARR, REASSERT_AT, NOW = 350, 420, 470, 500
 
-    def _diary(self, t_x, why="the re-armed watcher; reports when it lands", monitor=False):
+    def _diary(self, t_x, why="the re-armed watcher; reports when it lands", monitor=False, legacy=False):
         self._transcript([_monitor("t1", LAUNCH, timeout_ms=400_000) if monitor else _launch("t1", LAUNCH),
                           _notification("t1", t_x)])
         self._write({"id": self.gid, "text": "a goal", "parentId": None, "nodeComplete": False,
@@ -764,7 +800,7 @@ class LiftHorizonGate(_HorizonBase):
                      "awaitingWhy": why, "awaitingAt": STAMP, "log": [
                          {"ev_t": STAMP, "src": "closer", "kind": "awaiting", "why": why, "at": STAMP},
                          {"ev_t": STAMP, "src": "romp", "kind": "awaiting", "lift": True,
-                          "endEv": self.T_EV, "at": self.T_ARR},
+                          **({} if legacy else {"endEv": self.T_EV}), "at": self.T_ARR},
                          {"ev_t": STAMP, "src": "closer", "kind": "awaiting", "why": why,
                           "at": self.REASSERT_AT}]})
 
@@ -793,12 +829,45 @@ class LiftHorizonGate(_HorizonBase):
         self.assertEqual(len(self._lifts()), 1)
 
     def test_b2_the_boundary_is_inclusive_a_return_at_the_horizon_is_the_one_already_cited(self):
-        # `<=`: a return AT the horizon is the very return the prior lift cited (its own end_ev is
-        # min(newest return, now)) — re-lifting off it is the flap. A `<` mutant lifts here.
+        # `<=`: a return AT the horizon is the very return the prior lift cited (its own end_ev is the
+        # newest return it cited); re-lifting off it is the flap. A `<` mutant lifts here.
         self._diary(t_x=self.T_EV)
         self._tick(now=self.NOW)
         self.assertIsNotNone(self._stamp(), "equal evidence was ruled on — yield")
         self.assertEqual(len(self._lifts()), 1)
+
+    def test_d_a_legacy_lift_row_keeps_the_arrival_compare_it_always_had(self):
+        # a lift filed before horizons were journaled (no endEv): its arrival is its horizon, the compare
+        # this stand-down made before 2026-09-07, so the upgrade changes nothing for it (review find,
+        # 2026-09-08). Read as its ev_t (the anchor) instead, every citable return looked new, and the
+        # re-assert was re-lifted once at the first pass after the upgrade, re-arming the nudge ladder
+        self._diary(t_x=380, legacy=True)                          # a T_EV horizon would admit 380; T_ARR does not
+        self._tick(now=self.NOW)
+        self.assertIsNotNone(self._stamp(), "a return before the legacy row's filing was ruled on: yield")
+        self.assertEqual(len(self._lifts()), 1, "no second lift row")
+        self._diary(t_x=430, legacy=True)                          # past the filing: new information, as ever
+        self._tick(now=self.NOW)
+        self.assertIsNone(self._stamp(), "a return past the legacy row's filing lifts, as before")
+
+    def test_e_a_fractional_ceiling_is_journaled_whole_so_the_stand_down_holds(self):
+        # a Monitor's recorded ceiling is t + timeout_ms/1000, fractional when timeout_ms is not a whole
+        # second. The lift journals the ceiling it cites; int()-truncated at the journal, the next pass
+        # measured 600.5 against 600, the inclusive stand-down never held, and the stamp was re-lifted on
+        # the same ceiling after every re-assert (review find, 2026-09-08; pre-fix: endEv 600, two lifts)
+        why = "the re-armed watcher; reports when it lands"
+        self._transcript([_monitor("t1", LAUNCH, timeout_ms=400_500)])      # ceiling 600.5, no notification
+        self._seed("task", why=why)
+        self._tick(now=800.5)                                      # past ceiling + grace: the watcher expired
+        self.assertIsNone(self._stamp(), "fixture: the spent ceiling lifted the stamp")
+        self.assertEqual(self._lifts()[-1].get("endEv"), 600.5, "the ceiling as recorded, fraction and all")
+        nd = self._node()                                          # the closer re-asserts after the filing
+        nd["log"].append({"ev_t": STAMP, "src": "closer", "kind": "awaiting", "why": why, "awaitKind": "task",
+                          "at": nd["log"][-1]["at"] + 1})
+        nd["awaitingWhy"], nd["awaitingAt"], nd["awaitingKind"] = why, STAMP, "task"
+        self._write(nd)
+        self._tick(now=805.5)
+        self.assertIsNotNone(self._stamp(), "the ceiling it cites is the one already ruled on: yield")
+        self.assertEqual(len(self._lifts()), 1, "no second lift row")
 
 
 if __name__ == "__main__":

--- a/tests/test_wake_deadman_toggle.py
+++ b/tests/test_wake_deadman_toggle.py
@@ -166,11 +166,14 @@ class DeadmanIgnoresTheToggle(_Base):
         # the dead-man's ruling is "no ending event arrived through NOW", so the clock is the horizon
         # it journals (record_verdict end_ev). A closer auditing a segment triggered anywhere inside
         # (anchor, wake) then stands down — with no horizon the fallback read the row's ev_t, the
-        # stamp's anchor, and that re-assert stood across the whole 6h window (pre-fold: it files)
+        # stamp's anchor, and that re-assert stood across the whole 6h window (pre-fold: it files).
+        # Journaled as read, fraction and all (review find, 2026-09-08): floored to the second, the
+        # horizon disowned an assert triggered in the wake's own second, which stood and was re-lifted
         self._toggle(False)
         self._seed(kind="job", age=7 * H)
-        self._tick()
-        self.assertEqual(self._lifts()[-1].get("endEv"), NOW, "the wake moment is what the lift ruled through")
+        self._tick(now=NOW + 0.5)
+        self.assertEqual(self._lifts()[-1].get("endEv"), NOW + 0.5,
+                         "the wake moment, as read, is what the lift ruled through")
         s = jd.load_goals(SID)
         jd.apply_close(s, jd.open_menu(s), {"done": {}, "block": {},
                                             "awaiting": {1: {"why": "still watching the rebuild", "kind": "job"}}},

--- a/tests/test_wake_deadman_toggle.py
+++ b/tests/test_wake_deadman_toggle.py
@@ -162,6 +162,22 @@ class DeadmanIgnoresTheToggle(_Base):
                          "no block — every procedural block copy would misstate what happened")
         self.assertNotIn(self.gid, km._auto_nudge_data()["nudged"], "no injection → no wake record")
 
+    def test_the_lift_journals_the_wake_moment_as_its_horizon(self):
+        # the dead-man's ruling is "no ending event arrived through NOW", so the clock is the horizon
+        # it journals (record_verdict end_ev). A closer auditing a segment triggered anywhere inside
+        # (anchor, wake) then stands down — with no horizon the fallback read the row's ev_t, the
+        # stamp's anchor, and that re-assert stood across the whole 6h window (pre-fold: it files)
+        self._toggle(False)
+        self._seed(kind="job", age=7 * H)
+        self._tick()
+        self.assertEqual(self._lifts()[-1].get("endEv"), NOW, "the wake moment is what the lift ruled through")
+        s = jd.load_goals(SID)
+        jd.apply_close(s, jd.open_menu(s), {"done": {}, "block": {},
+                                            "awaiting": {1: {"why": "still watching the rebuild", "kind": "job"}}},
+                       t=NOW - 3 * H)
+        self.assertIsNone(s["nodes"][self.gid].get("awaitingWhy"),
+                          "a segment inside (anchor, wake) predates the dead-man's ruling — the writer yields")
+
     def test_a_second_cycle_does_not_file_again(self):
         self._toggle(False)
         self._seed(kind="job", age=7 * H)


### PR DESCRIPTION
Verified on `main`: two gates decided whether a fresh awaiting assert may stand by comparing the new evidence's time against a previous lift's arrival time, the diary row's `at`, which `record_verdict`'s own docstring calls forensics only, instead of against the evidence horizon that lift ruled on. A lift filed late for evidence only up to one point suppressed a legitimate assert whose evidence fell between that point and the lift's arrival: the card stayed down on new information. Nothing journaled a horizon, and the peer-supersede check returned a boolean where its caller needed the reply time.

## What changes

`record_verdict` takes an evidence horizon, journaled as `endEv`. A small reader, `_wait_end_ev`, answers a row's horizon: `endEv` when journaled, else the row's own evidence time, else its arrival, so older rows keep working. Both gates, the closer's awaiting-assert gate in the judge and the sweep's `_lift_spent_awaiting`, compare through it. The sweep's lift legs pass the horizon each ruled on: the dispatch-return leg the return's evidence, the peer-supersede leg the reply time (`_peer_stamp_superseded` now returns it, falsy when nothing superseded), the empty-world leg the ending's time. The dispatch-return leg measures its evidence from the tasks that returned, a dead task's spent deadline, or the launch as the floor, never from a still-future ceiling; both its stand-down gate and the horizon it journals use that value, since a returned watcher's unspent ceiling had made every re-lift look like new information. The six-hour dead-man lift, which rules that no ending arrived through now, journals now as its horizon. The re-assert detection stays on arrival, because it asks about diary write order, not evidence.

## Judgment calls

- The closer's gate stays strict and the sweep's stays inclusive, each pinned with an equality test, because they ask complementary questions of the same horizon.
- The closer's own lift journals the audited turn's end as its horizon; its evidence time is the turn's trigger, the start of the segment, not its end.
- The rolled-up leg journals no horizon: it has none it can read, and no reader consults rolled-up rows.
- Rows filed before this change carry no horizon and read their own evidence time, the start of the wait they retracted, before their arrival. For those rows a lagging closer's stale re-assert inside that window is admitted once and re-lifted on the next pass: a one-cycle flap on old information, transitional, and cheaper than the suppression it replaces.

## Tests

`tests/test_awaiting_audit_classes.py`: a lift with a horizon earlier than its arrival, then an assert with evidence between them stands (on `main` it is suppressed); evidence at or before the horizon still stands down; evidence exactly at the horizon pins the operator; an old row without a horizon reads its evidence time before its arrival; the horizon is journaled exactly when given. `tests/test_kernel_awaiting_lift.py`: one test per sweep leg through the real sweep asserting the journaled horizon; the leg with no ending journals none; a returned Monitor with a ceiling still ahead journals its return, not the clock, and stands a re-lift down; the closer's lift journals the turn's end and a re-assert inside the turn yields; after the dead-man wake a stale segment stays suppressed; the peer-supersede reader returns the reply time; the sweep gate admits a return after the horizon, stands down before it, and pins the boundary. Mutants (arrival read first, a leg dropping its horizon, either operator flipped, the reader back to a boolean) each fail a test.

Module counts on this tree, one runner at a time: `tests/test_awaiting_audit_classes.py` 12; `tests/test_kernel_awaiting_lift.py` 62; `tests/test_wake_deadman_toggle.py` 23; `tests/test_decline_never_closes.py` 11; `tests/test_awaiting_peer_matrix.py` 22; `tests/test_paused_matrix.py` 19 (12 subtests); `tests/test_stage0_log_readers.py` 37; `tests/test_interrupt_lift_evidence_time.py` 13; `tests/test_judge_nudge_awaiting_op.py` 6; `tests/test_kernel_parked_ops_liveness.py` 27; `tests/test_kernel_parked_ops_lock.py` 19; `tests/test_perf_stats.py` 41. On `main` five of the audit-class tests, seven of the lift tests and the new dead-man test fail, each with the first error the commit body names; the boundary pins main already satisfies pass there by design. Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
