### PR TITLE
Timeline tag edits: remote halves first; the local half waits for them

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3060,19 +3060,41 @@ class TimelinePanel {
     }
   }
 
+  // the host hook a remote-tag edit rides (the web dashboard, VS Code); the Obsidian panel has none
+  _remoteBridge() {
+    return typeof window !== 'undefined' && typeof window.__rompTimelineEditTag === 'function';
+  }
+
+  // the refusal for homes this panel cannot reach: ONE notice however many, every host named, and
+  // a remedy that covers each of them and, when the local half was held back too (`local`), that
+  // half (review find, 2026-09-08: the per-host notice overwrote itself across a fan-out, so a tag
+  // homed on two kernels named only the second and gave a remedy for it alone). The dialog's
+  // disabled actions and the chip wear the same text as their tooltip, so a gesture that can only
+  // end here says so before the click.
+  _unreachableText(hosts, local) {
+    const named = hosts.map((h) => h || 'the owner');
+    const cmds = hosts.map((h) => 'romp tag --host ' + (h || '<kernel>'));
+    if (local) cmds.push('romp tag (no --host) for this kernel');
+    return 'this panel cannot reach ' + named.join(' or ') + ', so nothing was changed. Edit with: ' + cmds.join(', then ');
+  }
+
+  _refuseUnreachable(hosts, name, local) {
+    this._tagEditErr = { host: hosts.filter(Boolean).join(', '), name: name, error: this._unreachableText(hosts, local) };
+    this.draw();
+  }
+
   // one remote-tag edit, dispatched to its HOME kernel and rendered optimistically meanwhile.
   // Ids ride viewer-relative; the kernel sends only the bare sid tails (sids are global) and the
   // owner resolves them into ITS frame. No hook (the Obsidian panel) → the tag stays read-only
   // and the refusal is immediate and visible, never a silent drop — and, since _editTagUnion
-  // holds the local half back until every remote half was taken, the refusal IS the outcome:
-  // nothing was changed anywhere, which the text says.
+  // holds the local half back when a remote half is refused HERE, that refusal IS the outcome:
+  // nothing was changed anywhere, which the text says. With a hook the `true` answers for the
+  // POST, not for the owner's verdict: the bridge's editTag frame carries no id, and the kernel
+  // answers it only on failure (tagEditFailed, later) and never with an ack a caller could wait
+  // on, so a bridged home's refusal reverts its own overlay and nothing else (federation v1;
+  // review find, 2026-09-08).
   _editRemoteTag(rt, edit) {
-    if (typeof window === 'undefined' || typeof window.__rompTimelineEditTag !== 'function') {
-      this._tagEditErr = { host: rt.host, name: rt.name,
-                           error: 'this panel cannot reach ' + (rt.host || 'the owner') + ", so nothing was changed — edit with: romp tag --host " + (rt.host || '<kernel>') };
-      this.draw();
-      return false;
-    }
+    if (!this._remoteBridge()) { this._refuseUnreachable([rt.host], rt.name, false); return false; }
     let next = null;
     if (!edit.delete) {
       next = { id: rt.id, host: rt.host, name: edit.rename || rt.name, color: edit.color || rt.color,
@@ -3141,11 +3163,14 @@ class TimelinePanel {
   // rename went looking for the name the rename would have given the tag and found the other tag
   // that already had it); remote writes ride _editRemoteTag (optimistic overlay + loud
   // tagEditFailed, federation v1). The REMOTE halves go first, and the local half commits only
-  // once every one of them was taken (review find, 2026-09-08): with no remote bridge (the
-  // Obsidian panel) _editRemoteTag refuses at once, and before this the local half had already
+  // once every one of them was DISPATCHED (review find, 2026-09-08): with no remote bridge (the
+  // Obsidian panel) the dispatch is refused at once, and before this the local half had already
   // been written — the tag renamed, its member dropped or the tag deleted in the local store
-  // alone, under an error that named only the remote. A refusal now leaves every store as it
-  // was, and the error text says so.
+  // alone, under an error that named only the remote. That synchronous refusal now leaves every
+  // store as it was, names every home it could not reach, and the error text says so. It is the
+  // dispatch the local half waits for, not the owner's verdict: a bridged home answers only on
+  // failure and only later (tagEditFailed, no ack to wait on), so its refusal reverts that home's
+  // overlay and finds the local half already posted (federation v1's optimistic design, unchanged).
   _editTagUnion(g, edit) {
     // a create still in flight has no id to address (its row wears the placeholder the ack
     // replaces): the builders offer no gesture on it, and one that arrives anyway does nothing
@@ -3155,6 +3180,18 @@ class TimelinePanel {
     // the local half's optimistic copy, taken BEFORE the remote fan-out: _curViews overlays the
     // remote halves' pending copies, and those must not ride a local post
     const localCopy = () => (g.localId ? JSON.parse(JSON.stringify(this._curViews())) : null);
+    // the fan-out to the remote halves a gesture reaches: every one is dispatched, and the local half
+    // rides only if every one was taken. The refused halves make ONE notice naming each of them and
+    // whether the local half was held back too (review find, 2026-09-08: each half's own notice
+    // overwrote the last, so a tag homed on two kernels named only the second and gave a remedy for
+    // it alone). The only synchronous refusal today is the no-bridge one, which refuses every half
+    // alike; a refusal with a bridge present keeps its own notice
+    const fanOut = (targets, mk, local) => {
+      const refused = [];
+      for (const rt of targets) if (!this._editRemoteTag(rt, mk())) refused.push(rt.host);
+      if (refused.length && !this._remoteBridge()) this._refuseUnreachable(refused, g.name, local);
+      return !refused.length;
+    };
     if (edit.add && edit.add.length) {
       const nv = localCopy();
       if (nv) {
@@ -3167,13 +3204,12 @@ class TimelinePanel {
     }
     if (edit.remove && edit.remove.length) {
       const nv = localCopy();
-      let ok = true;
-      for (const rt of g.remotes)
-        if ((rt.members || []).some((m) => edit.remove.indexOf(m) >= 0))
-          ok = this._editRemoteTag(rt, { remove: edit.remove.slice() }) && ok;
+      const t = nv ? viewTags(nv).find((x) => x.id === g.localId) : null;
+      const localHit = !!(t && (t.members || []).some((m) => edit.remove.indexOf(m) >= 0));
+      const ok = fanOut(g.remotes.filter((rt) => (rt.members || []).some((m) => edit.remove.indexOf(m) >= 0)),
+                        () => ({ remove: edit.remove.slice() }), localHit);
       if (ok && nv) {
-        const t = viewTags(nv).find((x) => x.id === g.localId);
-        if (t && (t.members || []).some((m) => edit.remove.indexOf(m) >= 0)) {
+        if (localHit) {
           t.members = (t.members || []).filter((m) => edit.remove.indexOf(m) < 0);
           this._postTagEdit(nv, { op: 'removeMember', tid: g.localId, sids: edit.remove.slice() }, meta);
         }
@@ -3181,9 +3217,7 @@ class TimelinePanel {
     }
     if (edit.rename || edit.color || edit.delete) {
       const nv = localCopy();
-      let ok = true;
-      for (const rt of g.remotes)
-        ok = this._editRemoteTag(rt, { rename: edit.rename, color: edit.color, delete: !!edit.delete }) && ok;
+      const ok = fanOut(g.remotes, () => ({ rename: edit.rename, color: edit.color, delete: !!edit.delete }), !!g.localId);
       if (ok && nv) {
         if (edit.delete) {
           nv.tags = viewTags(nv).filter((x) => x.id !== g.localId); delete nv.groups;
@@ -3205,7 +3239,8 @@ class TimelinePanel {
   // the chips for ONE session — one solid chip per union tag holding it, ✕ = remove-everywhere.
   // Home-kernel detail lives in the tooltip at most (kernels are plumbing).
   _tagChips(box, s, rebuild) {
-    for (const g of viewTagUnion(this._curViews())) {
+    const cur = this._curViews();
+    for (const g of viewTagUnion(cur)) {
       if (g.members.indexOf(s.id) < 0) continue;
       const tc = g.color || MENU_FG;
       const ch = box.createSpan();
@@ -3220,6 +3255,17 @@ class TimelinePanel {
         // tag (the 2026-09-05 review) — the "creating…" the inputs read, in the tooltip
         ch.style.cursor = 'default';
         ch.setAttribute('title', 'creating "' + g.name + '"…');
+        ch.setAttribute('aria-disabled', 'true');
+        continue;
+      }
+      // the ✕ takes the pair off EVERY store holding it: with a remote half holding this session and
+      // no bridge, _editTagUnion can only refuse it, so the chip wears no ✕ and its tooltip says why
+      // (review find, 2026-09-08)
+      const homesHolding = (g.remotes || []).filter((rt) => (rt.members || []).indexOf(s.id) >= 0).map((rt) => rt.host);
+      if (homesHolding.length && !this._remoteBridge()) {
+        const localHolds = !!g.localId && viewTags(cur).some((t) => t.id === g.localId && (t.members || []).indexOf(s.id) >= 0);
+        ch.style.cursor = 'default';
+        ch.setAttribute('title', 'tagged "' + g.name + '": ' + this._unreachableText(homesHolding, localHolds));
         ch.setAttribute('aria-disabled', 'true');
         continue;
       }
@@ -3817,7 +3863,7 @@ class TimelinePanel {
       // NAME-KEYED (user ruling 2026-08-24): whichever store's id opened this, the header is the
       // tag's ONE identity — rename/recolor/delete fan out to every kernel defining the name
       // (_editTagUnion), and no host prefix appears; kernels are plumbing.
-      const canEdit = typeof window !== 'undefined' && typeof window.__rompTimelineEditTag === 'function';
+      const canEdit = this._remoteBridge();
       const head = card.createDiv();
       head.setAttribute('style', 'display:flex;align-items:center;gap:8px;margin:0 0 8px;');
       const ttl = head.createDiv({ text: 'Sessions & tags' });
@@ -3848,8 +3894,17 @@ class TimelinePanel {
         const tgrid = card.createDiv();
         tgrid.setAttribute('style', 'display:grid;grid-template-columns:max-content max-content max-content 1fr;'
           + 'column-gap:14px;row-gap:4px;align-items:center;margin:2px 0 6px;');
-        const action = (row, text, title) => {
+        // `held`: the reason a gesture cannot be honoured here; the action renders disabled (dim, no
+        // pointer, aria-disabled) wearing that reason as its tooltip, in place of a click that could
+        // only end in the refusal notice (review find, 2026-09-08)
+        const action = (row, text, title, held) => {
           const a = row.createSpan({ text });
+          if (held) {
+            a.setAttribute('style', 'cursor:default;opacity:0.35;color:' + MENU_FG + ';');
+            a.setAttribute('title', held);
+            a.setAttribute('aria-disabled', 'true');
+            return a;
+          }
           a.setAttribute('style', 'cursor:pointer;opacity:0.7;color:' + MENU_FG + ';');
           a.setAttribute('title', title);
           return a;
@@ -3859,6 +3914,11 @@ class TimelinePanel {
           // the placeholder id the ack replaces, and an op addressed by it would be refused as a tag
           // that does not exist (the 2026-09-05 review) — it reads "creating…" instead
           const editable = !tg.pending && (tg.localId || canEdit);
+          // rename, recolor and delete fan out to EVERY home the name is defined on: with remote halves
+          // and no bridge, _editTagUnion can only refuse them (the remote halves go first), so the row
+          // shows the three disabled with the refusal as their tooltip (review find, 2026-09-08)
+          const held = editable && !canEdit && (tg.remotes || []).length
+            ? this._unreachableText((tg.remotes || []).map((rt) => rt.host), !!tg.localId) : '';
           const tc = tg.color || MODEL_FG;
           // the tag itself: the normal pill, NO ✕ — actions live beside it, never on it.
           // DRAGGABLE (the user 2026-08-25): grab a pill to reorder the tags — the drop writes
@@ -3968,7 +4028,8 @@ class TimelinePanel {
           // delete — the destructive convention: dim at rest, red on hover
           const del = tgrid.createDiv();
           if (editable) {
-            const d = action(del, 'delete', 'DELETE the tag \u201c' + tg.name + '\u201d everywhere (members keep running, just untagged)');
+            const d = action(del, 'delete', 'DELETE the tag \u201c' + tg.name + '\u201d everywhere (members keep running, just untagged)', held);
+            if (!held) {
             d.addEventListener('mouseenter', () => { d.style.color = '#F85B5A'; d.style.opacity = '1'; });
             d.addEventListener('mouseleave', () => { d.style.color = MENU_FG; d.style.opacity = '0.7'; });
             d.addEventListener('click', () => {
@@ -3976,14 +4037,17 @@ class TimelinePanel {
               this._editTagUnion(tg, { delete: true });
               build();
             });
+            }
           }
           // rename — turns the pill into an input
           const ren = tgrid.createDiv();
           if (editable) {
-            const r = action(ren, 'rename', 'rename this tag (everywhere it is defined)');
+            const r = action(ren, 'rename', 'rename this tag (everywhere it is defined)', held);
+            if (!held) {
             r.addEventListener('mouseenter', () => { r.style.opacity = '1'; });
             r.addEventListener('mouseleave', () => { r.style.opacity = '0.7'; });
             r.addEventListener('click', () => { this._tagEditorFor = this._tagEditorFor === unionKey(tg) ? null : unionKey(tg); this._tagRenameDraft = null; build(); });
+            }
           }
           // the color — the identity-palette swatches inline in the row's last column
           const colCell = tgrid.createDiv();
@@ -3994,11 +4058,12 @@ class TimelinePanel {
           colCell.setAttribute('style', 'display:grid;grid-template-columns:repeat(' + swCols
             + ',14px);gap:6px;align-items:center;');
           if (editable) {
+            if (held) { colCell.setAttribute('title', held); colCell.setAttribute('aria-disabled', 'true'); }
             for (const c of (this._palette && this._palette.length ? this._palette : [tc])) {
               const sw = colCell.createSpan();
-              sw.setAttribute('style', 'width:14px;height:14px;border-radius:50%;cursor:pointer;background:' + c + ';'
-                + (c === tg.color ? 'outline:2px solid #ffffff;outline-offset:1px;' : 'opacity:0.7;'));
-              sw.addEventListener('click', () => { this._editTagUnion(tg, { color: c }); build(); });
+              sw.setAttribute('style', 'width:14px;height:14px;border-radius:50%;cursor:' + (held ? 'default' : 'pointer') + ';background:' + c + ';'
+                + (c === tg.color ? 'outline:2px solid #ffffff;outline-offset:1px;' : held ? 'opacity:0.35;' : 'opacity:0.7;'));
+              if (!held) sw.addEventListener('click', () => { this._editTagUnion(tg, { color: c }); build(); });
             }
           }
         }

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3063,11 +3063,13 @@ class TimelinePanel {
   // one remote-tag edit, dispatched to its HOME kernel and rendered optimistically meanwhile.
   // Ids ride viewer-relative; the kernel sends only the bare sid tails (sids are global) and the
   // owner resolves them into ITS frame. No hook (the Obsidian panel) → the tag stays read-only
-  // and the refusal is immediate and visible, never a silent drop.
+  // and the refusal is immediate and visible, never a silent drop — and, since _editTagUnion
+  // holds the local half back until every remote half was taken, the refusal IS the outcome:
+  // nothing was changed anywhere, which the text says.
   _editRemoteTag(rt, edit) {
     if (typeof window === 'undefined' || typeof window.__rompTimelineEditTag !== 'function') {
       this._tagEditErr = { host: rt.host, name: rt.name,
-                           error: 'this panel cannot reach ' + (rt.host || 'the owner') + " — edit with: romp tag --host " + (rt.host || '<kernel>') };
+                           error: 'this panel cannot reach ' + (rt.host || 'the owner') + ", so nothing was changed — edit with: romp tag --host " + (rt.host || '<kernel>') };
       this.draw();
       return false;
     }
@@ -3138,16 +3140,24 @@ class TimelinePanel {
   // write, and the renames and assignments were lost; by NAME, a recolor queued behind a refused
   // rename went looking for the name the rename would have given the tag and found the other tag
   // that already had it); remote writes ride _editRemoteTag (optimistic overlay + loud
-  // tagEditFailed, federation v1).
+  // tagEditFailed, federation v1). The REMOTE halves go first, and the local half commits only
+  // once every one of them was taken (review find, 2026-09-08): with no remote bridge (the
+  // Obsidian panel) _editRemoteTag refuses at once, and before this the local half had already
+  // been written — the tag renamed, its member dropped or the tag deleted in the local store
+  // alone, under an error that named only the remote. A refusal now leaves every store as it
+  // was, and the error text says so.
   _editTagUnion(g, edit) {
     // a create still in flight has no id to address (its row wears the placeholder the ack
     // replaces): the builders offer no gesture on it, and one that arrives anyway does nothing
     // rather than posting a tid the kernel refuses as a tag that does not exist
     if (g.pending) return;
     const meta = { name: g.name, tid: g.localId };
+    // the local half's optimistic copy, taken BEFORE the remote fan-out: _curViews overlays the
+    // remote halves' pending copies, and those must not ride a local post
+    const localCopy = () => (g.localId ? JSON.parse(JSON.stringify(this._curViews())) : null);
     if (edit.add && edit.add.length) {
-      if (g.localId) {
-        const nv = JSON.parse(JSON.stringify(this._curViews()));
+      const nv = localCopy();
+      if (nv) {
         const t = viewTags(nv).find((x) => x.id === g.localId);
         if (t) {
           t.members = Array.from(new Set((t.members || []).concat(edit.add)));
@@ -3156,21 +3166,25 @@ class TimelinePanel {
       } else if (g.remotes.length) this._editRemoteTag(g.remotes[0], { add: edit.add.slice() });
     }
     if (edit.remove && edit.remove.length) {
-      if (g.localId) {
-        const nv = JSON.parse(JSON.stringify(this._curViews()));
+      const nv = localCopy();
+      let ok = true;
+      for (const rt of g.remotes)
+        if ((rt.members || []).some((m) => edit.remove.indexOf(m) >= 0))
+          ok = this._editRemoteTag(rt, { remove: edit.remove.slice() }) && ok;
+      if (ok && nv) {
         const t = viewTags(nv).find((x) => x.id === g.localId);
         if (t && (t.members || []).some((m) => edit.remove.indexOf(m) >= 0)) {
           t.members = (t.members || []).filter((m) => edit.remove.indexOf(m) < 0);
           this._postTagEdit(nv, { op: 'removeMember', tid: g.localId, sids: edit.remove.slice() }, meta);
         }
       }
-      for (const rt of g.remotes)
-        if ((rt.members || []).some((m) => edit.remove.indexOf(m) >= 0))
-          this._editRemoteTag(rt, { remove: edit.remove.slice() });
     }
     if (edit.rename || edit.color || edit.delete) {
-      if (g.localId) {
-        const nv = JSON.parse(JSON.stringify(this._curViews()));
+      const nv = localCopy();
+      let ok = true;
+      for (const rt of g.remotes)
+        ok = this._editRemoteTag(rt, { rename: edit.rename, color: edit.color, delete: !!edit.delete }) && ok;
+      if (ok && nv) {
         if (edit.delete) {
           nv.tags = viewTags(nv).filter((x) => x.id !== g.localId); delete nv.groups;
           if (nv.active === g.localId) nv.active = 'all';
@@ -3185,8 +3199,6 @@ class TimelinePanel {
           }
         }
       }
-      for (const rt of g.remotes)
-        this._editRemoteTag(rt, { rename: edit.rename, color: edit.color, delete: !!edit.delete });
     }
   }
 

--- a/ui/timeline-flags.test.ts
+++ b/ui/timeline-flags.test.ts
@@ -79,6 +79,24 @@ test("setSessionFlag still posts via the web host hook, with a Node-fs fallback 
   assert.match(SRC, /session-flags\.json/, "Obsidian/headless writes the same file the kernel reads");
 });
 
+test("the Obsidian fallback wears the discipline of its two sibling writers (PR #1020; audited 2026-09-07)", () => {
+  // Pinned on the writer's OWN slice: the guard the order writer's pin (timeline-render.test.ts) matches
+  // anywhere in the file is required HERE too. The audited writer had none, wrote a hardcoded
+  // ~/.local/state/romp the kernel never reads under ROMP_STATE_DIR, folded a read fault into an empty
+  // store, and truncated the live file in place. The write itself is RUN with a stubbed fs from
+  // tests/test_kernel_session_flags.py (TimelineFallbackFlagWriter): a read fault, torn bytes or the
+  // wrong shape write nothing; a missing store publishes through tmp + rename under ROMP_STATE_DIR.
+  const w = SRC.slice(SRC.indexOf("_setSessionFlag(s, flag, value) {"), SRC.indexOf("_dismissLane(id) {"));
+  assert.ok(w.length > 0 && w.length < 4000, "the writer's slice");
+  assert.match(w, /if \(typeof process === 'undefined' \|\| !process\.versions \|\| !process\.versions\.electron\) return;/,
+    "Electron-or-nothing: a bare-node run never touches the real file");
+  assert.match(w, /process\.env\.ROMP_STATE_DIR\n?\s*\|\| path\.join\(process\.env\.XDG_STATE_HOME \|\| path\.join\(os\.homedir\(\), '\.local', 'state'\), 'romp'\)/,
+    "the kernel's state root, resolved as the kernel resolves it");
+  assert.match(w, /fs\.writeFileSync\(tmp, JSON\.stringify\(cur\)\);\s*\n\s*fs\.renameSync\(tmp, fp\);/, "tmp + rename: a reader never sees a torn or empty file");
+  assert.doesNotMatch(w, /fs\.writeFileSync\(fp,/, "never the live file in place");
+  assert.doesNotMatch(w, /catch \(e\) \{\}/, "a read fault is never folded into an empty store");
+});
+
 test("the sticky-flag machinery survives: pendingFlags reconcile on every update (no flicker-back)", () => {
   assert.match(SRC, /this\._pendingFlags = \{\};/);
   assert.match(SRC, /this\.data = data;\s*\n(?:[^\n]*\n){0,4}\s*this\._reconcilePendingFlags\(\);/);

--- a/ui/timeline-flags.test.ts
+++ b/ui/timeline-flags.test.ts
@@ -79,24 +79,6 @@ test("setSessionFlag still posts via the web host hook, with a Node-fs fallback 
   assert.match(SRC, /session-flags\.json/, "Obsidian/headless writes the same file the kernel reads");
 });
 
-test("the Obsidian fallback wears the discipline of its two sibling writers (PR #1020; audited 2026-09-07)", () => {
-  // Pinned on the writer's OWN slice: the guard the order writer's pin (timeline-render.test.ts) matches
-  // anywhere in the file is required HERE too. The audited writer had none, wrote a hardcoded
-  // ~/.local/state/romp the kernel never reads under ROMP_STATE_DIR, folded a read fault into an empty
-  // store, and truncated the live file in place. The write itself is RUN with a stubbed fs from
-  // tests/test_kernel_session_flags.py (TimelineFallbackFlagWriter): a read fault, torn bytes or the
-  // wrong shape write nothing; a missing store publishes through tmp + rename under ROMP_STATE_DIR.
-  const w = SRC.slice(SRC.indexOf("_setSessionFlag(s, flag, value) {"), SRC.indexOf("_dismissLane(id) {"));
-  assert.ok(w.length > 0 && w.length < 4000, "the writer's slice");
-  assert.match(w, /if \(typeof process === 'undefined' \|\| !process\.versions \|\| !process\.versions\.electron\) return;/,
-    "Electron-or-nothing: a bare-node run never touches the real file");
-  assert.match(w, /process\.env\.ROMP_STATE_DIR\n?\s*\|\| path\.join\(process\.env\.XDG_STATE_HOME \|\| path\.join\(os\.homedir\(\), '\.local', 'state'\), 'romp'\)/,
-    "the kernel's state root, resolved as the kernel resolves it");
-  assert.match(w, /fs\.writeFileSync\(tmp, JSON\.stringify\(cur\)\);\s*\n\s*fs\.renameSync\(tmp, fp\);/, "tmp + rename: a reader never sees a torn or empty file");
-  assert.doesNotMatch(w, /fs\.writeFileSync\(fp,/, "never the live file in place");
-  assert.doesNotMatch(w, /catch \(e\) \{\}/, "a read fault is never folded into an empty store");
-});
-
 test("the sticky-flag machinery survives: pendingFlags reconcile on every update (no flicker-back)", () => {
   assert.match(SRC, /this\._pendingFlags = \{\};/);
   assert.match(SRC, /this\.data = data;\s*\n(?:[^\n]*\n){0,4}\s*this\._reconcilePendingFlags\(\);/);

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -474,6 +474,61 @@ test("executed: the union dispatcher — add prefers local, remove reaches every
   assert.deepEqual(remote.map((r: any) => r[1].delete), [true, true], "…and every remote home");
 });
 
+test("executed: with no remote bridge, a union edit leaves the LOCAL half untouched and says why (review find, 2026-09-08)", () => {
+  // The Obsidian panel has no window.__rompTimelineEditTag, so _editRemoteTag refuses synchronously. Before
+  // 2026-09-08 _editTagUnion had already committed the local half by then — the tag renamed, its member
+  // dropped or the tag deleted in the local store alone, the remote halves untouched — under an error that
+  // named only the remote. The remote halves go first now and the local half commits only when every one
+  // of them was taken, so the error's "nothing was changed" is the truth.
+  const w = (globalThis as any).window;
+  assert.notEqual(typeof (w && w.__rompTimelineEditTag), "function", "this harness has no remote bridge (the Obsidian panel's shape)");
+  const p: any = Object.create(TimelinePanel.prototype);
+  const local: any[] = [];
+  p._setViews = (v: any) => local.push(v);   // the legacy local write _postTagEdit falls to without a targeted bridge
+  p.draw = () => {};
+  p._pendingViews = null; p._pendingTagEdits = {}; p._tagEditErr = null;
+  const rtA = { id: "TESTHOST-A:g1", host: "TESTHOST-A", name: "team", color: "#123456", members: ["m1"] };
+  const localTag = { id: "gL", name: "team", color: "#123456", members: ["m1", "m2"] };
+  p._views = { active: "all", hidden: [], tags: [localTag], remoteTags: [rtA] };
+  const g = { name: "team", color: "#123456", members: ["m1", "m2"], ids: ["gL", rtA.id], localId: "gL",
+              homes: ["TESTHOST-A"], remotes: [rtA] };
+  const refused = (gesture: string) => {
+    assert.equal(local.length, 0, gesture + ": the remote half was refused, so the local half did not commit");
+    assert.ok(p._tagEditErr, gesture + ": the refusal shows");
+    assert.equal(p._tagEditErr.host, "TESTHOST-A", gesture + ": it names the remote");
+    assert.match(p._tagEditErr.error, /cannot reach TESTHOST-A/, gesture + ": …and why");
+    assert.match(p._tagEditErr.error, /nothing was changed/, gesture + ": …and that the edit landed nowhere");
+    assert.match(p._tagEditErr.error, /romp tag --host TESTHOST-A/, gesture + ": …and the way to make it");
+    p._tagEditErr = null;
+  };
+  p._editTagUnion(g, { rename: "crew" }); refused("rename");
+  p._editTagUnion(g, { color: "#DD42FF" }); refused("recolor");
+  p._editTagUnion(g, { delete: true }); refused("delete");
+  p._editTagUnion(g, { remove: ["m1"] }); refused("remove of a member both halves hold");
+  assert.deepEqual(p._curViews().tags[0], localTag, "the local tag reads exactly as the store has it");
+  // a REMOVE of a member only the local half holds asks nothing of the remotes: the local half commits, as before
+  p._editTagUnion(g, { remove: ["m2"] });
+  assert.equal(local.length, 1, "no remote holds m2, nothing to refuse — the local half commits");
+  assert.deepEqual(local[0].tags[0].members, ["m1"]);
+  assert.equal(p._tagEditErr, null, "…and nothing is said");
+  // WITH a bridge (the web dashboard) both halves post — every remote half first, the local commit last; one
+  // refused remote half among several still holds the local half back
+  local.length = 0;
+  const order: string[] = [];
+  const rtB = { id: "TESTHOST-B:g7", host: "TESTHOST-B", name: "team", color: "#123456", members: ["m1"] };
+  const g2 = { ...g, ids: ["gL", rtA.id, rtB.id], homes: ["TESTHOST-A", "TESTHOST-B"], remotes: [rtA, rtB] };
+  p._editRemoteTag = (rt: any) => { order.push(rt.host); return rt.host !== "TESTHOST-B"; };
+  p._setViews = (v: any) => { order.push("local"); local.push(v); };
+  p._editTagUnion(g2, { rename: "crew" });
+  assert.deepEqual(order, ["TESTHOST-A", "TESTHOST-B"], "every remote half is still attempted; the local half waits");
+  assert.equal(local.length, 0, "one refused remote half: no local commit");
+  order.length = 0;
+  p._editRemoteTag = (rt: any) => { order.push(rt.host); return true; };
+  p._editTagUnion(g2, { rename: "crew" });
+  assert.deepEqual(order, ["TESTHOST-A", "TESTHOST-B", "local"], "all taken: remote halves first, the local commit last");
+  assert.equal(local[0].tags[0].name, "crew");
+});
+
 test("the lane gear carries the SAME tag editor — the shared builders, never a fork (the user 2026-08-24)", () => {
   // both surfaces call the one chip builder and the one join menu
   assert.ok((SRC.match(/this\._tagChips\(/g) || []).length >= 2, "dialog rows AND the gear");

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -429,7 +429,8 @@ test("federation v1+ruling source pins: header/chips route through the UNION dis
   assert.match(SRC, /this\._editTagUnion\(g, \{ add: rowIds\.filter\(\(id\) => g\.members\.indexOf\(id\) < 0\) \}\); rebuild\(\);/);
   // the remote transport underneath is unchanged: no hook (the Obsidian panel) → read-only + an
   // immediate visible refusal; the error line is dismissible and names the owner
-  assert.match(SRC, /typeof window\.__rompTimelineEditTag !== 'function'/);
+  assert.match(SRC, /_remoteBridge\(\) \{\n\s*return typeof window !== 'undefined' && typeof window\.__rompTimelineEditTag === 'function';/);
+  assert.match(SRC, /if \(!this\._remoteBridge\(\)\) \{ this\._refuseUnreachable\(\[rt\.host\], rt\.name, false\); return false; \}/);
   assert.match(SRC, /er\.createSpan\(\{ text: '⚠ ' \+ \(this\._tagEditErr\.host \? this\._tagEditErr\.host \+ ': ' : ''\) \+ this\._tagEditErr\.error \}\);/);
   // a NEW tag still mints locally, posting the whole blob (zero local-path change)
   assert.match(SRC, /nv\.tags = viewTags\(nv\)\.concat/);
@@ -511,22 +512,113 @@ test("executed: with no remote bridge, a union edit leaves the LOCAL half untouc
   assert.equal(local.length, 1, "no remote holds m2, nothing to refuse — the local half commits");
   assert.deepEqual(local[0].tags[0].members, ["m1"]);
   assert.equal(p._tagEditErr, null, "…and nothing is said");
-  // WITH a bridge (the web dashboard) both halves post — every remote half first, the local commit last; one
-  // refused remote half among several still holds the local half back
-  local.length = 0;
-  const order: string[] = [];
+  // the remedy covers the LOCAL half too: it was held back, so the CLI has to make that half as well
+  p._editTagUnion(g, { rename: "crew" });
+  assert.match(p._tagEditErr.error, /romp tag \(no --host\) for this kernel/, "the local half is named in the remedy");
+  p._tagEditErr = null;
+  // …but a remote-only union asks nothing of a local half, so the remedy names the remotes alone
+  p._editTagUnion({ ...g, ids: [rtA.id], localId: null, members: ["m1"] }, { rename: "crew" });
+  assert.doesNotMatch(p._tagEditErr.error, /for this kernel/);
+  p._tagEditErr = null;
+  // TWO remote homes, the REAL _editRemoteTag (review find, 2026-09-08): before, each half's refusal
+  // overwrote the last, so the notice named only TESTHOST-B and gave a remedy for it alone. One notice
+  // names every home the panel cannot reach, with a remedy that covers each of them and the local half
   const rtB = { id: "TESTHOST-B:g7", host: "TESTHOST-B", name: "team", color: "#123456", members: ["m1"] };
   const g2 = { ...g, ids: ["gL", rtA.id, rtB.id], homes: ["TESTHOST-A", "TESTHOST-B"], remotes: [rtA, rtB] };
-  p._editRemoteTag = (rt: any) => { order.push(rt.host); return rt.host !== "TESTHOST-B"; };
-  p._setViews = (v: any) => { order.push("local"); local.push(v); };
-  p._editTagUnion(g2, { rename: "crew" });
-  assert.deepEqual(order, ["TESTHOST-A", "TESTHOST-B"], "every remote half is still attempted; the local half waits");
-  assert.equal(local.length, 0, "one refused remote half: no local commit");
-  order.length = 0;
-  p._editRemoteTag = (rt: any) => { order.push(rt.host); return true; };
-  p._editTagUnion(g2, { rename: "crew" });
-  assert.deepEqual(order, ["TESTHOST-A", "TESTHOST-B", "local"], "all taken: remote halves first, the local commit last");
-  assert.equal(local[0].tags[0].name, "crew");
+  p._views = { active: "all", hidden: [], tags: [localTag], remoteTags: [rtA, rtB] };
+  local.length = 0;   // the m2 remove above committed, rightly; the recorder starts clean here
+  for (const [gesture, edit] of [["rename", { rename: "crew" }], ["recolor", { color: "#DD42FF" }],
+                                 ["delete", { delete: true }], ["remove", { remove: ["m1"] }]] as any[]) {
+    p._editTagUnion(g2, edit);
+    assert.equal(local.length, 0, gesture + ": no local commit");
+    assert.equal(p._tagEditErr.host, "TESTHOST-A, TESTHOST-B", gesture + ": the notice is headed by every unreachable home");
+    assert.match(p._tagEditErr.error, /cannot reach TESTHOST-A or TESTHOST-B, so nothing was changed/, gesture + ": both named, and the outcome");
+    assert.match(p._tagEditErr.error, /romp tag --host TESTHOST-A, then romp tag --host TESTHOST-B, then romp tag \(no --host\) for this kernel/,
+      gesture + ": a remedy for each home and for the local half");
+    p._tagEditErr = null;
+  }
+  // a remove only ONE remote holds names that one home alone: the other was never asked
+  p._editTagUnion({ ...g2, remotes: [rtA, { ...rtB, members: ["zz"] }] }, { remove: ["m1"] });
+  assert.equal(p._tagEditErr.host, "TESTHOST-A", "the home that does not hold the member is not named");
+  assert.deepEqual(p._curViews().tags[0], localTag, "the local tag still reads exactly as the store has it");
+});
+
+test("executed: WITH a bridge the REAL _editRemoteTag posts every remote half through it, then the local half commits (review find, 2026-09-08)", () => {
+  // The dispatcher's gate is _editRemoteTag's return: `true` once the bridge took the post. Before this test the
+  // bridge branch ran only through stubs, so a `return;` there would have passed the suite while every bridged
+  // union edit silently lost its local half. Here the bridge is the web dashboard's shape: a window hook that
+  // records the frame (ui/webview/timeline-boot.ts posts it as editTag).
+  const g: any = globalThis;
+  const had = "window" in g; const prev = g.window;
+  const frames: any[] = []; const order: string[] = []; const local: any[] = [];
+  g.window = { __rompTimelineEditTag: (e: any) => { frames.push(e); order.push(e.host); } };
+  try {
+    const p: any = Object.create(TimelinePanel.prototype);
+    p._setViews = (v: any) => { order.push("local"); local.push(v); };
+    p.draw = () => {}; p._pendingViews = null; p._pendingTagEdits = {}; p._tagEditErr = null;
+    p._viewsDialog = null; p._viewsDialogBuild = null; p._laneMenu = null;
+    const rtA = { id: "TESTHOST-A:g1", host: "TESTHOST-A", name: "team", color: "#123456", members: ["m1"] };
+    const rtB = { id: "TESTHOST-B:g7", host: "TESTHOST-B", name: "team", color: "#123456", members: ["m1"] };
+    const localTag = { id: "gL", name: "team", color: "#123456", members: ["m1", "m2"] };
+    p._views = { active: "all", hidden: [], tags: [localTag], remoteTags: [rtA, rtB] };
+    const u = { name: "team", color: "#123456", members: ["m1", "m2"], ids: ["gL", rtA.id, rtB.id], localId: "gL",
+                homes: ["TESTHOST-A", "TESTHOST-B"], remotes: [rtA, rtB] };
+    p._editTagUnion(u, { rename: "crew" });
+    assert.deepEqual(order, ["TESTHOST-A", "TESTHOST-B", "local"], "every remote half is posted first; the local half commits last");
+    assert.deepEqual(frames.map((f) => [f.host, f.name, f.rename, f.delete]),
+      [["TESTHOST-A", "team", "crew", false], ["TESTHOST-B", "team", "crew", false]], "the frames name the home and the tag, and carry the edit");
+    assert.equal(local.length, 1); assert.equal(local[0].tags[0].name, "crew");
+    assert.equal(p._pendingTagEdits["TESTHOST-A:g1"].tag.name, "crew", "each remote half renders its optimistic copy meanwhile");
+    assert.equal(p._pendingTagEdits["TESTHOST-B:g7"].tag.name, "crew");
+    assert.equal(p._tagEditErr, null, "nothing was refused");
+    // the wait is for the DISPATCH, not the owner's verdict (federation v1, pinned so a change here is deliberate):
+    // the bridge answers only on failure and only later; that refusal reverts ITS home's overlay and finds the
+    // local half already posted. Holding the local half on the owner's answer needs an ack the editTag frame does
+    // not have today.
+    p.tagEditFailed({ host: "TESTHOST-B", name: "team", error: "a tag named \"crew\" already exists there" });
+    assert.deepEqual(Object.keys(p._pendingTagEdits), ["TESTHOST-A:g1"], "only the refusing home's overlay reverts");
+    assert.equal(local.length, 1, "the local write stands; nothing here claims otherwise");
+    assert.equal(p._tagEditErr.host, "TESTHOST-B");
+    assert.doesNotMatch(p._tagEditErr.error, /nothing was changed/, "…and the notice does not say nothing changed, because something did");
+    // a REMOVE and a DELETE ride the same gate
+    frames.length = 0; order.length = 0; local.length = 0; p._tagEditErr = null;
+    p._editTagUnion(u, { remove: ["m1"] });
+    assert.deepEqual(order, ["TESTHOST-A", "TESTHOST-B", "local"]);
+    assert.deepEqual(frames.map((f) => f.remove), [["m1"], ["m1"]]);
+    frames.length = 0; order.length = 0; local.length = 0;
+    p._editTagUnion(u, { delete: true });
+    assert.deepEqual(order, ["TESTHOST-A", "TESTHOST-B", "local"]);
+    assert.deepEqual(frames.map((f) => f.delete), [true, true]);
+    assert.equal(local[0].tags.length, 0);
+  } finally {
+    if (had) g.window = prev; else delete g.window;
+  }
+});
+
+test("a gesture the host cannot honour is DISABLED with the reason as its tooltip, never offered (review find, 2026-09-08)", () => {
+  // executed: the one text the refusal notice and the tooltips share
+  const p: any = Object.create(TimelinePanel.prototype);
+  assert.equal(p._unreachableText(["TESTHOST-A"], false),
+    "this panel cannot reach TESTHOST-A, so nothing was changed. Edit with: romp tag --host TESTHOST-A");
+  assert.equal(p._unreachableText(["TESTHOST-A", "TESTHOST-B"], true),
+    "this panel cannot reach TESTHOST-A or TESTHOST-B, so nothing was changed. Edit with: romp tag --host TESTHOST-A, then romp tag --host TESTHOST-B, then romp tag (no --host) for this kernel");
+  assert.equal(p._unreachableText([""], false), "this panel cannot reach the owner, so nothing was changed. Edit with: romp tag --host <kernel>",
+    "a host-less remote falls back to the placeholder, as before");
+  // the dialog: rename, recolor and delete on a union with remote halves are held in a bridge-less host:
+  // the action renders disabled wearing the reason, and takes no click
+  assert.match(SRC, /const held = editable && !canEdit && \(tg\.remotes \|\| \[\]\)\.length\n\s*\? this\._unreachableText\(\(tg\.remotes \|\| \[\]\)\.map\(\(rt\) => rt\.host\), !!tg\.localId\) : '';/);
+  assert.match(SRC, /if \(held\) \{\n\s*a\.setAttribute\('style', 'cursor:default;opacity:0\.35;color:' \+ MENU_FG \+ ';'\);\n\s*a\.setAttribute\('title', held\);\n\s*a\.setAttribute\('aria-disabled', 'true'\);\n\s*return a;/,
+    "the disabled action: dim, no pointer, the reason as tooltip, no listeners");
+  assert.match(SRC, /action\(del, 'delete', [^\n]*, held\);\n\s*if \(!held\) \{/, "delete's hover and click ride only when not held");
+  assert.match(SRC, /action\(ren, 'rename', 'rename this tag \(everywhere it is defined\)', held\);\n\s*if \(!held\) \{/, "rename's too");
+  assert.match(SRC, /if \(held\) \{ colCell\.setAttribute\('title', held\); colCell\.setAttribute\('aria-disabled', 'true'\); \}/, "the swatch cell says why");
+  assert.match(SRC, /if \(!held\) sw\.addEventListener\('click', \(\) => \{ this\._editTagUnion\(tg, \{ color: c \}\); build\(\); \}\);/, "…and its swatches take no click");
+  // the chip: a ✕ that would remove the pair from a remote half no bridge can reach is not drawn; the tooltip says why
+  assert.match(SRC, /const homesHolding = \(g\.remotes \|\| \[\]\)\.filter\(\(rt\) => \(rt\.members \|\| \[\]\)\.indexOf\(s\.id\) >= 0\)\.map\(\(rt\) => rt\.host\);\n\s*if \(homesHolding\.length && !this\._remoteBridge\(\)\) \{/);
+  assert.match(SRC, /ch\.setAttribute\('title', 'tagged "' \+ g\.name \+ '": ' \+ this\._unreachableText\(homesHolding, localHolds\)\);\n\s*ch\.setAttribute\('aria-disabled', 'true'\);\n\s*continue;/);
+  // a local-only tag (no remote halves) keeps every gesture in every host: `held` is empty without remotes
+  const p2: any = Object.create(TimelinePanel.prototype);
+  assert.equal(p2._remoteBridge(), false, "this harness has no bridge");
 });
 
 test("the lane gear carries the SAME tag editor — the shared builders, never a fork (the user 2026-08-24)", () => {


### PR DESCRIPTION
Verified on `main`: in the Obsidian panel, which has no kernel bridge, a tag edit on a union tag (one with a local half and remote halves) committed the local half first, through `_setViews`, and then fanned out to the remotes with `_editRemoteTag`, whose return was ignored. Without a bridge `_editRemoteTag` refuses synchronously, so the local half changed and the remote halves silently did not: a half-applied edit with no error path. Rename, recolor, delete and the chip remove all reach it, because a tag with a local half is editable even with no bridge. The targeted-op rewrite did not close this: `_postTagEdit` needs the bridge too, so the panel falls to the legacy local write.

The sibling finding from the same audit, the session-flag fallback writer that hardcoded the state directory and wrote in place, is already fixed on `main` by #1020's fold and covered by an executed test there; this PR adds only a slice-scoped pin for it.

## What changes

`_editTagUnion` snapshots the optimistic local copy, attempts every remote half first, and posts the local half only when every remote half took it. When a remote half is refused, the existing error path says which host the panel cannot reach and that nothing was changed, and names the CLI that can do it.

## Judgment calls

With a bridge present, an asynchronous kernel refusal still arrives after the local half posted; that is the optimistic-overlay design of federation v1, not the synchronous half-apply fixed here. The VS Code twin always has a bridge, so it has no synchronous refusal path. The three writers' shared path and atomic-write logic were left as three copies: the exact lines of two of them are pinned by unrelated tests, so a helper would be a tests-only follow-up.

## Tests

`ui/timeline-views-panel.test.ts`: an executed test on a bare panel with `_setViews` recording and no `window`: rename, recolor, delete and a shared-member remove each leave zero local writes and set an error naming the host; a remove of a member only the local half holds still commits; with a bridge stub the order is remote, remote, local, and one refused host among two holds the local half back. On `main` the first assertion fails because the local half posted before the refusal. `ui/timeline-flags.test.ts`: a pin on the session-flag fallback's guard, root expression and atomic write, a guard that passes on `main`.

TypeScript test files on this tree, run one at a time: `ui/timeline-views-panel.test.ts` 36; `ui/timeline-flags.test.ts` 10; `ui/timeline-views-ack.test.ts` 37; `ui/timeline-render.test.ts` 47. On `main` the new executed test fails at its first assertion (the local half committed before the remote refusal); the flags pin passes there, as a guard. Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
