### PR TITLE
GET /feed.json reads the feed without moving the bells, badge or cache

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -1255,7 +1255,7 @@ st = {k: dl("stages_ms", k) for k in ("jobs", "push", "push.chat", "push.feed", 
 print("stages    jobs %s   push %s  (chat %s  feed %s  timeline %s  send %s)"
       % tuple(share(st[k]) for k in ("jobs", "push", "push.chat", "push.feed", "push.timeline", "push.send")))
 parts = []
-for k in ("chat", "feed", "timeline"):
+for k in ("chat", "feed", "timeline", "feedJson"):     # feedJson: GET /feed.json's own reads, apart from the pusher's feed
     built, cached, ms = dl("builds", k, "built"), dl("builds", k, "cached"), dl("builds", k, "ms")
     parts.append("%s %d built / %d cached%s" % (k, built, cached, (" (%.0f ms avg)" % (ms / built)) if built else ""))
 print("builds    " + "   ".join(parts))

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -204,8 +204,10 @@ class _PerfStats:
                                    sends). The push.* stages are measured inside _push for EVERY
                                    caller, connect pushes on handler threads included, so their sum
                                    can exceed `push`
-      builds                       chat / feed / timeline -> {cached, built, ms}: served from the
-                                   build cache vs rebuilt, and the rebuild time
+      builds                       chat / feed / timeline / feedJson -> {cached, built, ms}: served
+                                   from the build cache vs rebuilt, and the rebuild time. feedJson is
+                                   GET /feed.json's own reads (_pure_feed), kept apart from `feed`,
+                                   the pusher's (review find, 2026-09-08)
       sends                        full / delta / deduped -> {slot: {count, bytes}} per dedup-slot
                                    name (chat, feed, bars, taborder, ...; at most SLOTS names, the rest
                                    under "other"). A deduped frame was built and compared, not sent
@@ -234,7 +236,7 @@ class _PerfStats:
     HTTP_PATHS = 256
     SLOTS = 32
     STAGES = ("jobs", "push", "push.chat", "push.feed", "push.timeline", "push.send")
-    BUILDS = ("chat", "feed", "timeline")
+    BUILDS = ("chat", "feed", "timeline", "feedJson")
     SEND_KINDS = ("full", "delta", "deduped")
 
     def __init__(self):
@@ -35347,7 +35349,7 @@ def _push(targets, connect=False, tmux=None):
     # chat client is open — previously the fleet rode app=feed and got ledgers only as a side effect of a chat
     # build (want_chat), so opening the fleet alone showed an empty/loading screen until a chat push happened.
     want_fleet = any(c["app"] == "fleet" for c in targets)
-    want_feed = any(c["app"] in ("feed", "fleet", "chat") for c in targets)   # fleet rides the feed payload; chat needs feed["working"]
+    want_feed = _feed_audience(targets)          # the Sessions pane (app "fleet") rides the feed payload; chat needs feed["working"]
     want_tl = any(c["app"] == "timeline" for c in targets)
     chat_clients = [c for c in targets if c["app"] == "chat"]
     try:
@@ -35830,7 +35832,10 @@ _built_feed = [None, None, 0.0, 0.0]              # [fleet_sig, payload, built_a
 # "the timeline rebuilt 900 times in 30 min with 12 sessions idle" instead of inferred from top. A
 # rebuild is justified only by a changed input; a rising build count on a quiet board is a bug signature.
 _VIEW_STATS = {"feedBuild": 0, "feedServe": 0, "tlBuild": 0, "tlServe": 0,
-               "chatBuildActive": 0, "chatBuildBg": 0, "chatServeActive": 0, "chatServeBg": 0}
+               "chatBuildActive": 0, "chatBuildBg": 0, "chatServeActive": 0, "chatServeBg": 0,
+               # GET /feed.json's reads (_pure_feed), apart: a poller's builds under the pusher's numbers
+               # would forge the bug signature above, or bury a pusher regression (review find, 2026-09-08)
+               "feedJsonBuild": 0, "feedJsonServe": 0}
 _built_timeline = [None, None, 0.0, 0.0]          # [fleet_sig, payload, built_at, build_started_at]
 # Wire-form caches for the two heavy shared payloads (the 2026-08-10 CPU fix, round three): the last
 # (source-identity key, serialized bytes, dedup sig) for the feed and the timeline bars, so an unchanged
@@ -35968,27 +35973,50 @@ def _cached_feed(now, tmux, sig, connect=False):
 # never fills _built_feed — every GET took the cold branch, and a script's read pruned the bell's card
 # overrides on disk, advanced the notification baseline past changes nobody had been told about, pushed
 # a badge to the shells, and filled the pusher's cache. This slot holds the pure path's own build,
-# (payload, built_at, build_started_at) — a TUPLE rebound whole, so a concurrent reader never sees a
-# torn entry (the _feed_wire discipline). Never _built_feed: a pure build in that slot would satisfy the
+# (payload, built_at, build_started_at, view_sig), a TUPLE rebound whole, so a concurrent reader never
+# sees a torn entry (the _feed_wire discipline). Never _built_feed: a pure build in that slot would satisfy the
 # pusher's REBUILD_MIN_S reuse, so a 1 Hz poller would keep the pusher on its serve branch and MUTE
-# every bell and badge for as long as it polled (the build branch is where they fire). Its two gates
-# are the pusher's own — REBUILD_MIN_S (build cost) and _views_dirty (a mutation the sig cannot see);
-# no new clocks, no view sig (its 5s bucket buys nothing past the rebuild window a poller already pays).
-_PURE_FEED = None
+# every bell and badge for as long as it polled (the build branch is where they fire). Its reuse
+# question is the pusher's own (_cached_feed's, minus the connect arm): a _views_dirty mark (a mutation
+# the sig cannot see) rebuilds at once; inside REBUILD_MIN_S the copy is reused whatever the inputs did
+# (the floor caps build cost on an active board, as it does for the pusher); past the floor an UNCHANGED
+# view sig reuses, so an idle board rebuilds at the sig's own cadence (its 5 s bucket) and no faster,
+# the pusher's cost with a pane open. The first cut reused on the clock alone (review find, 2026-09-08):
+# a headless idle board then rebuilt every 2 s for as long as anything polled, where the pusher would
+# have reused; the sig is the event that clock was approximating.
+_PURE_FEED = None                                 # (payload, built_at, build_started_at, view_sig)
+# ONE build on the route's behalf at a time (review find, 2026-09-08). The pusher coalesces by being one
+# thread; the route runs on a handler thread per GET, so without this every GET arriving mid-build started
+# a build_feed of its own (the 2026-08-30 pile-up class: inline builds stacking on handler threads), and
+# the older build, finishing last, rebound the slot, so buildId went backwards inside the window. A GET
+# that queues here re-reads the slot under the lock and finds the build it waited for, fresh inside the
+# floor. Held across the sig sweep and the build: nothing under it takes _clients_lock or re-enters here.
+_pure_feed_lock = threading.Lock()
+
+
+def _feed_audience(clients):
+    """Whether any of `clients` rides the feed payload: the Sessions pane (app id "fleet") rides it, the
+    chat needs feed["working"]. The ONE question _push asks of its targets (want_feed) and the route asks
+    of the connected set (_pusher_has_feed_audience). The first cut kept two copies of the app tuple, held
+    together by a source-text pin (review find, 2026-09-08)."""
+    return any(c["app"] in ("feed", "fleet", "chat") for c in clients)
 
 
 def _pusher_has_feed_audience():
-    """Whether the pusher is MAINTAINING _built_feed right now: _push's own `want_feed` predicate — some
-    connected client rides the feed payload. Without one the pusher stops building the feed and the slot
-    freezes at the last disconnect, so a route that served it unconditionally would answer a poller with
-    an hours-old board that looks current. The audience is the event that decides whose copy is fresh."""
+    """Whether the pusher is MAINTAINING _built_feed right now: _feed_audience over the connected clients,
+    the question _push's want_feed asks of its targets. Without one the pusher stops building the feed
+    and the slot freezes at the last disconnect, so a route that served it unconditionally would answer a
+    poller with an hours-old board that looks current. The audience is the event that decides whose copy
+    is fresh."""
     with _clients_lock:
-        return any(c["app"] in ("feed", "fleet", "chat") for c in _clients)
+        return _feed_audience(_clients)
 
 
 def _pure_feed(now, tmux):
     """The feed payload for GET /feed.json: the pusher's warmed copy while the pusher has an audience
-    (byte-identical to what the panes see), else this path's own recent build, else a fresh build_feed
+    (the feed_src under the panes' payload: their frame is a per-push copy of it with _push's `ledgers`
+    attach on top, so this is the board's cards without that attach), else this path's own copy while
+    the pusher's reuse question says it is fresh, else a fresh build_feed shared by every GET in flight
     — served, never handed to the pusher. What this path never does is _cached_feed's cold-branch
     work: the bell diff, the notify-cards prune, the badge push, the pusher's cache fill. build_feed's
     OWN housekeeping is as it was on the old path and is not this path's to change: a session-order
@@ -35997,27 +36025,43 @@ def _pure_feed(now, tmux):
     runs only with a client connected and no chat/timeline client parsing; a goal store that cannot be
     read files its fault row (load_goals_or_fault: loud by design, and only on a fault).
     The build id IS claimed (a consumer reads buildId like any payload); the counter is monotonic and a
-    card-move ack only needs the pusher's next build to outrank whatever was claimed before it."""
+    card-move ack only needs the pusher's next build to outrank whatever was claimed before it.
+    Counted under the route's own numbers (feedJson*, never the pusher's feed*): those read as the
+    pusher's cost, and a poller's reads under them would forge or bury a pusher bug signature."""
     global _PURE_FEED
+
+    def _served(payload):
+        _VIEW_STATS["feedJsonServe"] += 1
+        _PERF_STATS.build("feedJson", True)
+        return payload
+
     e = _built_feed
     if e[1] is not None and _pusher_has_feed_audience():
-        _VIEW_STATS["feedServe"] += 1
-        _PERF_STATS.build("feed", True)
-        return e[1]
-    pf = _PURE_FEED
-    if pf is not None and (time.time() - pf[1]) < REBUILD_MIN_S and not _views_dirty[0] > pf[2]:
-        _VIEW_STATS["feedServe"] += 1
-        _PERF_STATS.build("feed", True)
-        return pf[0]
-    _VIEW_STATS["feedBuild"] += 1
-    bid = _next_feed_build_id()
-    started = time.time()                # the dirty floor for the next GET: a mutation after this may be missed below
-    _t0 = time.monotonic()
-    feed = build_feed(now, tmux)
-    _PERF_STATS.build("feed", False, time.monotonic() - _t0)
-    feed["buildId"] = bid
-    _PURE_FEED = (feed, time.time(), started)
-    return feed
+        return _served(e[1])
+    with _pure_feed_lock:
+        pf = _PURE_FEED                  # read UNDER the lock: a GET that queued behind a build finds that build
+        sig = None
+        # _cached_feed's question minus the connect arm. Never a copy a dirty mark postdates (start-keyed,
+        # as there: a mutation landing mid-build may have been missed by it). Inside the floor the clock
+        # answers and no sig is swept; past it, an unchanged sig answers (the idle board's case).
+        if pf is not None and not _views_dirty[0] > pf[2]:
+            if (time.time() - pf[1]) < REBUILD_MIN_S:
+                return _served(pf[0])
+            sig = _fleet_view_sig(now, tmux)
+            if pf[3] == sig:
+                return _served(pf[0])
+        _VIEW_STATS["feedJsonBuild"] += 1
+        bid = _next_feed_build_id()
+        if sig is None:
+            sig = _fleet_view_sig(now, tmux)     # sampled BEFORE the read, as the pusher's fsig is: an input
+            #                                      that moves during the build busts the next check
+        started = time.time()                # the dirty floor for the next GET: a mutation after this may be missed below
+        _t0 = time.monotonic()
+        feed = build_feed(now, tmux)
+        _PERF_STATS.build("feedJson", False, time.monotonic() - _t0)
+        feed["buildId"] = bid
+        _PURE_FEED = (feed, time.time(), started, sig)
+        return feed
 
 
 # ── system notifications: the bell toggles (the user 2026-07-28) ──────────────────────────────────
@@ -41567,8 +41611,8 @@ class Handler(BaseHTTPRequestHandler):
             if p == "/feed.json":
                 # The feed's card payload as JSON, for scripts/agents diagnosing card state (both
                 # teams' surveys, 2026-08-24): EXACTLY what build_feed ships to the board — the
-                # pusher's warmed build while the pusher has an audience, else a build of its own
-                # (_pure_feed). NOT _cached_feed: that is the pusher's door, whose cold branch diffs
+                # pusher's warmed build while the pusher has an audience, else its own copy, one
+                # build at a time (_pure_feed). NOT _cached_feed: the pusher's door, whose cold branch diffs
                 # the bells, prunes notify-cards.json, pushes the badge and fills the pusher's cache
                 # — so on a headless kernel a script's GET did all four (2026-09-08). Token-gated
                 # like its stateful siblings; a read that moves none of those four (build_feed's own

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -35959,6 +35959,67 @@ def _cached_feed(now, tmux, sig, connect=False):
     return feed
 
 
+# GET /feed.json's copy of the feed: a READ that changes nothing (2026-09-08). _cached_feed is the PUSHER's
+# door, and its build branch is where the bells diff (_feed_notifications advances _NOTIFY_PREV and prunes
+# notify-cards.json on disk), the app badge moves (_badge_push sends a frame) and the pusher's own cache
+# fills — a fresh build IS the transition event there, by design. A monitoring script's GET is not that
+# event, yet the route used to answer through that door with connect=True: fine on a warmed kernel (the
+# connect arm serves the pusher's copy), but on a HEADLESS one — no client rides the feed payload, so the pusher
+# never fills _built_feed — every GET took the cold branch, and a script's read pruned the bell's card
+# overrides on disk, advanced the notification baseline past changes nobody had been told about, pushed
+# a badge to the shells, and filled the pusher's cache. This slot holds the pure path's own build,
+# (payload, built_at, build_started_at) — a TUPLE rebound whole, so a concurrent reader never sees a
+# torn entry (the _feed_wire discipline). Never _built_feed: a pure build in that slot would satisfy the
+# pusher's REBUILD_MIN_S reuse, so a 1 Hz poller would keep the pusher on its serve branch and MUTE
+# every bell and badge for as long as it polled (the build branch is where they fire). Its two gates
+# are the pusher's own — REBUILD_MIN_S (build cost) and _views_dirty (a mutation the sig cannot see);
+# no new clocks, no view sig (its 5s bucket buys nothing past the rebuild window a poller already pays).
+_PURE_FEED = None
+
+
+def _pusher_has_feed_audience():
+    """Whether the pusher is MAINTAINING _built_feed right now: _push's own `want_feed` predicate — some
+    connected client rides the feed payload. Without one the pusher stops building the feed and the slot
+    freezes at the last disconnect, so a route that served it unconditionally would answer a poller with
+    an hours-old board that looks current. The audience is the event that decides whose copy is fresh."""
+    with _clients_lock:
+        return any(c["app"] in ("feed", "fleet", "chat") for c in _clients)
+
+
+def _pure_feed(now, tmux):
+    """The feed payload for GET /feed.json: the pusher's warmed copy while the pusher has an audience
+    (byte-identical to what the panes see), else this path's own recent build, else a fresh build_feed
+    — served, never handed to the pusher. What this path never does is _cached_feed's cold-branch
+    work: the bell diff, the notify-cards prune, the badge push, the pusher's cache fill. build_feed's
+    OWN housekeeping is as it was on the old path and is not this path's to change: a session-order
+    persist when the living set moved, the views store's re-stamp, a fork's tag inheritance heal, and
+    _warm_fleet_bg (a background parse warm that then drops the pusher's cache and wakes it), which
+    runs only with a client connected and no chat/timeline client parsing; a goal store that cannot be
+    read files its fault row (load_goals_or_fault: loud by design, and only on a fault).
+    The build id IS claimed (a consumer reads buildId like any payload); the counter is monotonic and a
+    card-move ack only needs the pusher's next build to outrank whatever was claimed before it."""
+    global _PURE_FEED
+    e = _built_feed
+    if e[1] is not None and _pusher_has_feed_audience():
+        _VIEW_STATS["feedServe"] += 1
+        _PERF_STATS.build("feed", True)
+        return e[1]
+    pf = _PURE_FEED
+    if pf is not None and (time.time() - pf[1]) < REBUILD_MIN_S and not _views_dirty[0] > pf[2]:
+        _VIEW_STATS["feedServe"] += 1
+        _PERF_STATS.build("feed", True)
+        return pf[0]
+    _VIEW_STATS["feedBuild"] += 1
+    bid = _next_feed_build_id()
+    started = time.time()                # the dirty floor for the next GET: a mutation after this may be missed below
+    _t0 = time.monotonic()
+    feed = build_feed(now, tmux)
+    _PERF_STATS.build("feed", False, time.monotonic() - _t0)
+    feed["buildId"] = bid
+    _PURE_FEED = (feed, time.time(), started)
+    return feed
+
+
 # ── system notifications: the bell toggles (the user 2026-07-28) ──────────────────────────────────
 # The master bell (bottom-right → notify-cards.json "*"), a session's bell (timeline lane / tab menu →
 # session-flags "notify") or a card's bell (right-click → notify-cards.json) arm OS-level notifications
@@ -41505,12 +41566,14 @@ class Handler(BaseHTTPRequestHandler):
                                  for k, v in pal.PALETTES.items()]}), "application/json", cache="no-cache")
             if p == "/feed.json":
                 # The feed's card payload as JSON, for scripts/agents diagnosing card state (both
-                # teams' surveys, 2026-08-24): EXACTLY what build_feed ships to the board — served
-                # from the pusher's warmed build (the connect semantics: never triggers a rebuild;
-                # a cold kernel builds once, a read like any client connect). Token-gated like its
-                # stateful siblings; read-only, no side effects.
-                return self._send(200, json.dumps(_cached_feed(time.time(), _tmux_sessions(), None,
-                                                               connect=True)),
+                # teams' surveys, 2026-08-24): EXACTLY what build_feed ships to the board — the
+                # pusher's warmed build while the pusher has an audience, else a build of its own
+                # (_pure_feed). NOT _cached_feed: that is the pusher's door, whose cold branch diffs
+                # the bells, prunes notify-cards.json, pushes the badge and fills the pusher's cache
+                # — so on a headless kernel a script's GET did all four (2026-09-08). Token-gated
+                # like its stateful siblings; a read that moves none of those four (build_feed's own
+                # housekeeping — an order persist, a views re-stamp — is as on the old path).
+                return self._send(200, json.dumps(_pure_feed(time.time(), _tmux_sessions())),
                                   "application/json", cache="no-cache")
             if p == "/classify":
                 # One session's LIVE classification as the kernel derives it right now (both teams'

--- a/tests/romp-perf.bats
+++ b/tests/romp-perf.bats
@@ -34,8 +34,8 @@ setup() {
     # A and B: the same kernel process ten seconds apart. Over the window: 20 cycles, 60 wakes, 6 s of
     # cycle time (4 s of it in push, 3 s of that in the chat block), 300 ms of pusher CPU and 50 ms of
     # judge CPU inside 500 ms of process CPU, 2 chat rebuilds against 18 cache hits, 1 MB sent as chat
-    # full frames, 100 goal loads, 2 judge passes totalling 2400 ms, 5 /tick requests and 3 WebSocket
-    # connects. B's lifetime figures (cycle_ms_max 900, ms_mean 1012.5) differ from the window's
+    # full frames, one GET /feed.json build (150 ms) against 4 of its cache hits, 100 goal loads, 2 judge
+    # passes totalling 2400 ms, 5 /tick requests and 3 WebSocket connects. B's lifetime figures (cycle_ms_max 900, ms_mean 1012.5) differ from the window's
     # (ring max 700, mean 1200) so a line printing the wrong one is caught.
     cat > "$SNAP_A" <<'JSON'
 {"now": 1000.0, "since": 900.0, "uptime_s": 100.0, "log": false,
@@ -44,7 +44,7 @@ setup() {
             "cycle_ms_max": 900.0, "cycle_ms_last": 200.0, "cycle_cpu_ms_sum": 10000.0,
             "cycle_ms_p50": 180.0, "cycle_ms_p90": 400.0, "cycle_ms_ring_max": 900.0, "ring_n": 100},
  "stages_ms": {"jobs": 5000.0, "push": 20000.0, "push.chat": 15000.0, "push.feed": 3000.0, "push.timeline": 1000.0, "push.send": 500.0},
- "builds": {"chat": {"cached": 80, "built": 20, "ms": 800.0}, "feed": {"cached": 90, "built": 10, "ms": 5000.0}, "timeline": {"cached": 95, "built": 5, "ms": 4000.0}},
+ "builds": {"chat": {"cached": 80, "built": 20, "ms": 800.0}, "feed": {"cached": 90, "built": 10, "ms": 5000.0}, "timeline": {"cached": 95, "built": 5, "ms": 4000.0}, "feedJson": {"cached": 5, "built": 1, "ms": 300.0}},
  "sends": {"full": {"chat": {"count": 10, "bytes": 1000000}}, "delta": {"chat": {"count": 100, "bytes": 50000}}, "deduped": {"feed": {"count": 90, "bytes": 9000000}}},
  "goals": {"loads": 1000, "saves": 200, "writes": 50},
  "judge": {"passes": 30, "ms_sum": 30000.0, "ms_last": 1000.0, "ms_mean": 1000.0, "cpu_ms_sum": 2000.0, "cpu_ms_workers": 1500.0},
@@ -57,7 +57,7 @@ JSON
             "cycle_ms_max": 900.0, "cycle_ms_last": 250.0, "cycle_cpu_ms_sum": 10300.0,
             "cycle_ms_p50": 190.0, "cycle_ms_p90": 420.0, "cycle_ms_ring_max": 700.0, "ring_n": 120},
  "stages_ms": {"jobs": 6000.0, "push": 24000.0, "push.chat": 18000.0, "push.feed": 3600.0, "push.timeline": 1200.0, "push.send": 600.0},
- "builds": {"chat": {"cached": 98, "built": 22, "ms": 880.0}, "feed": {"cached": 108, "built": 12, "ms": 6000.0}, "timeline": {"cached": 114, "built": 6, "ms": 4800.0}},
+ "builds": {"chat": {"cached": 98, "built": 22, "ms": 880.0}, "feed": {"cached": 108, "built": 12, "ms": 6000.0}, "timeline": {"cached": 114, "built": 6, "ms": 4800.0}, "feedJson": {"cached": 9, "built": 2, "ms": 450.0}},
  "sends": {"full": {"chat": {"count": 12, "bytes": 2048576}}, "delta": {"chat": {"count": 120, "bytes": 60000}}, "deduped": {"feed": {"count": 108, "bytes": 10800000}}},
  "goals": {"loads": 1100, "saves": 220, "writes": 55},
  "judge": {"passes": 32, "ms_sum": 32400.0, "ms_last": 1200.0, "ms_mean": 1012.5, "cpu_ms_sum": 2050.0, "cpu_ms_workers": 1540.0},
@@ -129,6 +129,8 @@ teardown() { rm -rf "$TEST_DIR"; }
     run "$ROMP_SCRIPT" perf --interval 0
     [ "$status" -eq 0 ]
     [[ "$output" == *"chat 2 built / 18 cached (40 ms avg)"* ]]
+    # GET /feed.json's own reads print beside the pusher's feed, never folded into it (review find, 2026-09-08)
+    [[ "$output" == *"feedJson 1 built / 4 cached (150 ms avg)"* ]]
     [[ "$output" == *"full 102 KB/s (chat 2 frames 102 KB/s)"* ]]        # 1048576 bytes over 10 s, bytes beside the count
     [[ "$output" == *"deduped 176 KB/s (feed 18 frames 176 KB/s)"* ]]
     [[ "$output" == *"10.0 loads/s   2.0 saves/s   0.5 writes/s"* ]]

--- a/tests/test_kernel_fleet_ledgers.py
+++ b/tests/test_kernel_fleet_ledgers.py
@@ -15,8 +15,10 @@ SRC = open(os.path.join(os.path.dirname(HERE), "bin", "romp-kernel")).read()
 class FleetLedgers(unittest.TestCase):
     def test_fleet_is_its_own_app_in_the_push(self):
         self.assertIn('want_fleet = any(c["app"] == "fleet" for c in targets)', SRC)
-        # the fleet rides the feed payload, so want_feed must include it
-        self.assertIn('want_feed = any(c["app"] in ("feed", "fleet", "chat") for c in targets)', SRC)
+        # the Sessions pane (app id "fleet") rides the feed payload, so the ONE audience question want_feed
+        # asks (shared with GET /feed.json's _pusher_has_feed_audience, review find 2026-09-08) must include it
+        self.assertIn('want_feed = _feed_audience(targets)', SRC)
+        self.assertIn('return any(c["app"] in ("feed", "fleet", "chat") for c in clients)', SRC)
 
     def test_chat_sessions_are_built_for_a_fleet_only_push(self):
         # the ledger slices come from chat_sessions; build them for want_chat OR want_fleet (not chat-only)

--- a/tests/test_observability_routes.py
+++ b/tests/test_observability_routes.py
@@ -3,7 +3,16 @@
 build_feed ships to the board — and GET /classify?id=<sid> — one session's live classification as
 the kernel derives it, a JOIN over reads that already exist (never a second predicate
 implementation). Both serve-token-gated, read-only, no side effects. Drives the REAL Handler over
-HTTP (the test_tag_route idiom). Synthetic only."""
+HTTP (the test_tag_route idiom). Synthetic only.
+
+/feed.json answers through _pure_feed, never _cached_feed (2026-09-08): the pusher's door diffs the
+bells on its cold branch (_feed_notifications advances _NOTIFY_PREV and prunes notify-cards.json),
+pushes the app badge and fills the pusher's cache — so on a headless kernel, where nothing ever
+warms _built_feed, a monitoring script's GET did all four. The pure path serves the pusher's copy
+while the pusher has an audience, else its own build, gated on the pusher's REBUILD_MIN_S and
+_views_dirty; it never fills _built_feed (a 1 Hz poller would otherwise keep the pusher on its
+serve branch and mute every bell)."""
+import inspect
 import json
 import os
 import tempfile
@@ -28,6 +37,12 @@ km = SourceFileLoader("romp_kernel_obs", os.path.join(BIN, "romp-kernel")).load_
 jd = km.jd
 
 SID = "11111111-2222-3333-4444-555555555555"
+
+
+def _client(app):
+    """A fake WS client of `app` whose frames land in the returned list (the test_close_confirm shape)."""
+    frames = []
+    return {"app": app, "alive": True, "send": lambda s: frames.append(json.loads(s))}, frames
 
 
 def _state_snapshot(root):
@@ -56,12 +71,19 @@ class ObservabilityRoutes(unittest.TestCase):
         self._state = jd.STATE
         jd.STATE = Path(self.td.name)
         km._flags_cache.clear()
-        self._saved = km._tmux_sessions
+        self._saved = (km._tmux_sessions, km.build_feed, km._NOTIFY_PREV[0], km._BADGE_LAST[0],
+                       getattr(km, "_PURE_FEED", None), km._views_dirty[0], list(km._clients))
         km._tmux_sessions = lambda: {}
-        km._built_feed[:] = [None, None, 0, 0]     # a cold cache: /feed.json builds once, like a connect
+        km._built_feed[:] = [None, None, 0, 0]     # a cold pusher cache: headless, nothing warmed it
+        km._PURE_FEED = None                        # …and no earlier GET's build either
+        km._views_dirty[0] = 0.0
+        del km._clients[:]
 
     def tearDown(self):
-        km._tmux_sessions = self._saved
+        (km._tmux_sessions, km.build_feed, km._NOTIFY_PREV[0], km._BADGE_LAST[0],
+         km._PURE_FEED, km._views_dirty[0], clients) = self._saved
+        del km._clients[:]
+        km._clients.extend(clients)
         jd.STATE = self._state
         km._flags_cache.clear()
         km._built_feed[:] = [None, None, 0, 0]
@@ -89,7 +111,96 @@ class ObservabilityRoutes(unittest.TestCase):
         self.assertEqual(d.get("type"), "feed", "the exact build_feed shape, not a re-derivation")
         self.assertIn("asks", d)
         self.assertIn("now", d)
+        # the top-level keys a reader of this route can lean on: build_feed's, plus the build id
+        # every served payload carries (the pure path claims one like the pusher's builds do)
+        for key in ("type", "asks", "working", "awaiting", "now", "buildId", "order", "sessions", "selfHost"):
+            self.assertIn(key, d, "the answer shape is build_feed's own")
         self.assertEqual(_state_snapshot(self.td.name), before, "a GET writes nothing")
+
+    def test_feed_json_on_a_cold_kernel_moves_nothing(self):
+        """The defect (2026-09-08): a headless kernel never warms _built_feed, so every GET took
+        _cached_feed's cold branch — which is the PUSHER's transition event: it pruned the bell's
+        per-card overrides on disk, advanced the notification baseline past changes nobody had been
+        told about, pushed a badge frame to the shells, and filled the pusher's cache. A read does
+        none of that."""
+        armed = json.dumps({"*": True, SID + ":g1": True}, sort_keys=True)   # a master bell + one armed
+        (jd.STATE / "notify-cards.json").write_text(armed)                    # card no feed lists any more
+        sentinel = {SID + ":g0": "working"}          # the baseline the next PUSHER build must diff against
+        km._NOTIFY_PREV[0] = sentinel
+        km._BADGE_LAST[0] = None                     # nothing sent since boot: a push here would be a first
+        shell, frames = _client("shell")
+        km._clients.append(shell)
+        st, d = self._get("/feed.json")
+        self.assertEqual(st, 200)
+        self.assertEqual(d.get("type"), "feed")
+        self.assertEqual((jd.STATE / "notify-cards.json").read_text(), armed,
+                         "the armed card survives: pruning is the pusher's event, not a read's")
+        self.assertIs(km._NOTIFY_PREV[0], sentinel, "the notification baseline did not advance")
+        self.assertEqual(frames, [], "no badge frame reached the shell")
+        self.assertIsNone(km._BADGE_LAST[0])
+        self.assertIsNone(km._built_feed[1], "the pusher's cache is not filled by a read")
+
+    def test_feed_json_reuses_its_build_inside_the_rebuild_window_and_rebuilds_on_dirty(self):
+        """A poller hitting the route every second must not pay a build per hit: the pure path keeps
+        its own copy, gated on the pusher's existing REBUILD_MIN_S and _views_dirty — a mutation the
+        sig cannot see rebuilds at once, and an aged copy rebuilds; nothing else does."""
+        calls = []
+
+        def counting_build(now, tmux):
+            calls.append(now)
+            return {"type": "feed", "asks": [], "working": [], "awaiting": [], "now": now}
+
+        km.build_feed = counting_build
+        self.assertEqual(self._get("/feed.json")[0], 200)
+        self.assertEqual(self._get("/feed.json")[0], 200)
+        self.assertEqual(len(calls), 1, "two GETs inside REBUILD_MIN_S: one build")
+        km._views_dirty[0] = time.time()             # an optimistic kernel-side mutation postdates the build
+        self.assertEqual(self._get("/feed.json")[0], 200)
+        self.assertEqual(len(calls), 2, "a dirty mark rebuilds")
+        payload, built_at, started = km._PURE_FEED
+        km._PURE_FEED = (payload, built_at - km.REBUILD_MIN_S - 1, started)   # age the copy past the window
+        self.assertEqual(self._get("/feed.json")[0], 200)
+        self.assertEqual(len(calls), 3, "past REBUILD_MIN_S the copy is stale and rebuilds")
+        self.assertIsNone(km._built_feed[1], "none of those builds reached the pusher's slot")
+
+    def test_the_routes_audience_predicate_is_the_pushers(self):
+        # the route serves the pusher's copy only while the pusher would build one: the two must ask
+        # the same question, or the route serves a frozen board (or builds needlessly) the day _push's
+        # want_feed changes. Pinned as text: one tuple, two sites.
+        src = inspect.getsource(km)
+        want = 'any(c["app"] in ("feed", "fleet", "chat") for c in targets)'
+        ours = 'any(c["app"] in ("feed", "fleet", "chat") for c in _clients)'
+        self.assertIn(want, src, "_push's want_feed predicate")
+        self.assertIn(ours, src, "_pusher_has_feed_audience's predicate")
+        self.assertEqual(want.replace("targets", ""), ours.replace("_clients", ""),
+                         "the route's audience question is _push's, over the same app ids")
+
+    def test_feed_json_serves_the_pushers_copy_only_while_the_pusher_has_an_audience(self):
+        """With a client riding the feed payload the pusher maintains _built_feed, and the route
+        serves exactly that — what the panes see, no build. When the audience leaves the pusher stops
+        rebuilding and the slot freezes at the last disconnect, so it is no longer the answer: the
+        route builds its own copy and leaves the pusher's slot as it found it."""
+        calls = []
+
+        def counting_build(now, tmux):
+            calls.append(now)
+            return {"type": "feed", "asks": [], "working": [], "awaiting": [], "now": now, "fresh": True}
+
+        km.build_feed = counting_build
+        warm = {"type": "feed", "asks": [], "working": [], "awaiting": [], "now": 1, "buildId": 7, "warm": True}
+        km._built_feed[:] = [("SIG",), warm, time.time(), time.time()]
+        feed_client, _ = _client("feed")
+        km._clients.append(feed_client)
+        st, d = self._get("/feed.json")
+        self.assertEqual(st, 200)
+        self.assertEqual(d, warm, "the pusher's copy, exactly")
+        self.assertEqual(calls, [], "no build while the pusher maintains the slot")
+        km._clients.remove(feed_client)              # the last pane closes: the pusher stops rebuilding
+        st, d = self._get("/feed.json")
+        self.assertEqual(st, 200)
+        self.assertEqual(len(calls), 1, "a frozen copy is not served: the route builds its own")
+        self.assertTrue(d.get("fresh"))
+        self.assertIs(km._built_feed[1], warm, "…and the pusher's slot is untouched")
 
     def test_classify_requires_an_id(self):
         st, _ = self._get("/classify")

--- a/tests/test_observability_routes.py
+++ b/tests/test_observability_routes.py
@@ -2,19 +2,24 @@
 """The read-only observability GETs (both teams' surveys, 2026-08-24): GET /feed.json — exactly what
 build_feed ships to the board — and GET /classify?id=<sid> — one session's live classification as
 the kernel derives it, a JOIN over reads that already exist (never a second predicate
-implementation). Both serve-token-gated, read-only, no side effects. Drives the REAL Handler over
-HTTP (the test_tag_route idiom). Synthetic only.
+implementation). Both serve-token-gated. /classify is read-only, no side effects; /feed.json moves
+none of the pusher's transition-event work (below), while build_feed's own housekeeping (a
+session-order persist when the living set moved, the views store's re-stamp, a fork's inheritance
+heal) runs as it did on the old path. Drives the REAL Handler over HTTP (the test_tag_route idiom).
+Synthetic only.
 
 /feed.json answers through _pure_feed, never _cached_feed (2026-09-08): the pusher's door diffs the
 bells on its cold branch (_feed_notifications advances _NOTIFY_PREV and prunes notify-cards.json),
 pushes the app badge and fills the pusher's cache — so on a headless kernel, where nothing ever
 warms _built_feed, a monitoring script's GET did all four. The pure path serves the pusher's copy
-while the pusher has an audience, else its own build, gated on the pusher's REBUILD_MIN_S and
-_views_dirty; it never fills _built_feed (a 1 Hz poller would otherwise keep the pusher on its
-serve branch and mute every bell)."""
-import inspect
+while the pusher has an audience (the same _feed_audience question _push asks), else its own copy
+on the pusher's own reuse question (the view sig, the REBUILD_MIN_S floor, the _views_dirty mark),
+else one build shared by every GET in flight; it never fills _built_feed (a 1 Hz poller would
+otherwise keep the pusher on its serve branch and mute every bell), and its reads count under the
+route's own counters, not the pusher's."""
 import json
 import os
+import queue
 import tempfile
 import threading
 import time
@@ -42,7 +47,7 @@ SID = "11111111-2222-3333-4444-555555555555"
 def _client(app):
     """A fake WS client of `app` whose frames land in the returned list (the test_close_confirm shape)."""
     frames = []
-    return {"app": app, "alive": True, "send": lambda s: frames.append(json.loads(s))}, frames
+    return {"app": app, "alive": True, "sent": {}, "send": lambda s: frames.append(json.loads(s))}, frames
 
 
 def _state_snapshot(root):
@@ -72,7 +77,8 @@ class ObservabilityRoutes(unittest.TestCase):
         jd.STATE = Path(self.td.name)
         km._flags_cache.clear()
         self._saved = (km._tmux_sessions, km.build_feed, km._NOTIFY_PREV[0], km._BADGE_LAST[0],
-                       getattr(km, "_PURE_FEED", None), km._views_dirty[0], list(km._clients))
+                       getattr(km, "_PURE_FEED", None), km._views_dirty[0], list(km._clients),
+                       km._fleet_view_sig, getattr(km, "_pure_feed_lock", None))
         km._tmux_sessions = lambda: {}
         km._built_feed[:] = [None, None, 0, 0]     # a cold pusher cache: headless, nothing warmed it
         km._PURE_FEED = None                        # …and no earlier GET's build either
@@ -81,7 +87,7 @@ class ObservabilityRoutes(unittest.TestCase):
 
     def tearDown(self):
         (km._tmux_sessions, km.build_feed, km._NOTIFY_PREV[0], km._BADGE_LAST[0],
-         km._PURE_FEED, km._views_dirty[0], clients) = self._saved
+         km._PURE_FEED, km._views_dirty[0], clients, km._fleet_view_sig, km._pure_feed_lock) = self._saved
         del km._clients[:]
         km._clients.extend(clients)
         jd.STATE = self._state
@@ -140,10 +146,15 @@ class ObservabilityRoutes(unittest.TestCase):
         self.assertIsNone(km._BADGE_LAST[0])
         self.assertIsNone(km._built_feed[1], "the pusher's cache is not filled by a read")
 
-    def test_feed_json_reuses_its_build_inside_the_rebuild_window_and_rebuilds_on_dirty(self):
-        """A poller hitting the route every second must not pay a build per hit: the pure path keeps
-        its own copy, gated on the pusher's existing REBUILD_MIN_S and _views_dirty — a mutation the
-        sig cannot see rebuilds at once, and an aged copy rebuilds; nothing else does."""
+    def test_feed_json_reuses_its_copy_on_the_pushers_own_question(self):
+        """A poller hitting the route every second must not pay a build per hit, and an idle board
+        must not pay one per REBUILD_MIN_S either: the route's copy is reused on the pusher's own
+        question (_cached_feed's, minus the connect arm). Inside the floor it is reused whatever the
+        inputs did (the floor caps build cost, as it does for the pusher); a _views_dirty mark (a
+        mutation the sig cannot see) rebuilds at once; past the floor an UNCHANGED view sig reuses
+        and a changed one rebuilds. The first cut reused on the clock alone (review find,
+        2026-09-08): a headless idle board rebuilt every 2 s for as long as anything polled, where
+        the pusher's own copy would have been reused."""
         calls = []
 
         def counting_build(now, tmux):
@@ -151,35 +162,159 @@ class ObservabilityRoutes(unittest.TestCase):
             return {"type": "feed", "asks": [], "working": [], "awaiting": [], "now": now}
 
         km.build_feed = counting_build
+        sig = ["a"]
+        km._fleet_view_sig = lambda now, tmux: ("SIG", sig[0])   # the inputs' fingerprint, under the test's hand
+
+        def age_past_the_floor():
+            pf = km._PURE_FEED
+            km._PURE_FEED = (pf[0], pf[1] - km.REBUILD_MIN_S - 1) + tuple(pf[2:])
+
         self.assertEqual(self._get("/feed.json")[0], 200)
         self.assertEqual(self._get("/feed.json")[0], 200)
         self.assertEqual(len(calls), 1, "two GETs inside REBUILD_MIN_S: one build")
         km._views_dirty[0] = time.time()             # an optimistic kernel-side mutation postdates the build
         self.assertEqual(self._get("/feed.json")[0], 200)
         self.assertEqual(len(calls), 2, "a dirty mark rebuilds")
-        payload, built_at, started = km._PURE_FEED
-        km._PURE_FEED = (payload, built_at - km.REBUILD_MIN_S - 1, started)   # age the copy past the window
+        age_past_the_floor()
         self.assertEqual(self._get("/feed.json")[0], 200)
-        self.assertEqual(len(calls), 3, "past REBUILD_MIN_S the copy is stale and rebuilds")
+        self.assertEqual(len(calls), 2, "past the floor with the inputs unchanged: reused, as the pusher would")
+        sig[0] = "b"                                 # the inputs moved
+        self.assertEqual(self._get("/feed.json")[0], 200)
+        self.assertEqual(len(calls), 3, "past the floor, a changed view sig rebuilds")
+        sig[0] = "c"                                 # ...and moved again, inside the floor this time
+        self.assertEqual(self._get("/feed.json")[0], 200)
+        self.assertEqual(len(calls), 3, "inside the floor the clock caps build cost, whatever the inputs did")
         self.assertIsNone(km._built_feed[1], "none of those builds reached the pusher's slot")
 
     def test_the_routes_audience_predicate_is_the_pushers(self):
-        # the route serves the pusher's copy only while the pusher would build one: the two must ask
-        # the same question, or the route serves a frozen board (or builds needlessly) the day _push's
-        # want_feed changes. Pinned as text: one tuple, two sites.
-        src = inspect.getsource(km)
-        want = 'any(c["app"] in ("feed", "fleet", "chat") for c in targets)'
-        ours = 'any(c["app"] in ("feed", "fleet", "chat") for c in _clients)'
-        self.assertIn(want, src, "_push's want_feed predicate")
-        self.assertIn(ours, src, "_pusher_has_feed_audience's predicate")
-        self.assertEqual(want.replace("targets", ""), ours.replace("_clients", ""),
-                         "the route's audience question is _push's, over the same app ids")
+        """The route serves the pusher's copy exactly while the pusher would maintain one, so both
+        must ask ONE question of a client list (_feed_audience), or the route serves a frozen board
+        (or builds needlessly) the day _push's want_feed changes. The first cut held two copies of
+        the app tuple together with a source-text pin (review find, 2026-09-08; the pin could not
+        pass on main, where the route's copy did not exist). Now the REAL _push is driven per app id
+        and whether it built the feed is compared with the route's answer for the same client, with
+        the shared question wrapped to witness that both of them asked it."""
+        stubs = ("_cached_feed", "_fleet_view_sig", "_chat_tab_sessions", "_retry_parked_creates",
+                 "build_timeline", "_cached_timeline", "_feed_audience")
+        saved = {nm: getattr(km, nm) for nm in stubs}
+        saved_state = (list(km._last_tab_order), km._feed_wire, km._bars_wire)
+        asked, consulted = [], []
+
+        def recording_feed(now, tmux, sig, connect=False):
+            asked.append(sig)
+            return {"type": "feed", "asks": [], "working": [], "awaiting": [], "now": now, "buildId": 1}
+
+        def witnessed_audience(clients, _real=km._feed_audience):
+            consulted.append([c["app"] for c in clients])
+            return _real(clients)
+
+        km._cached_feed = recording_feed
+        km._feed_audience = witnessed_audience
+        km._fleet_view_sig = lambda now, tmux: ("SIG",)
+        km._chat_tab_sessions = lambda now, tmux: []
+        km._retry_parked_creates = lambda: None
+        timeline = lambda now, tmux, *a, **kw: {"lanes": [], "turns": {}, "judging": [], "messages": [], "now": now}
+        km.build_timeline = timeline
+        km._cached_timeline = timeline
+        pusher_built, route_says = {}, {}
+        try:
+            for app in ("feed", "fleet", "chat", "timeline", "shell"):
+                c, _ = _client(app)
+                del asked[:]
+                del consulted[:]
+                km._push([c], connect=True)               # the pusher's own connect push for this one client
+                pusher_built[app] = bool(asked)
+                self.assertEqual(consulted, [[app]], "_push asked the shared question of its targets")
+                del km._clients[:]
+                km._clients.append(c)
+                del consulted[:]
+                route_says[app] = km._pusher_has_feed_audience()
+                self.assertEqual(consulted, [[app]], "the route asked the same question of the connected set")
+        finally:
+            for nm, v in saved.items():
+                setattr(km, nm, v)
+            km._last_tab_order[:], km._feed_wire, km._bars_wire = saved_state
+        self.assertEqual(route_says, pusher_built, "one question, asked by the pusher and the route alike")
+        self.assertEqual({app for app, rides in route_says.items() if rides}, {"feed", "fleet", "chat"},
+                         "who rides the feed payload: the Sessions pane (app id fleet), the chat for feed['working']")
+
+    def test_concurrent_feed_json_reads_share_one_build(self):
+        """Two GETs in flight together build ONCE (review find, 2026-09-08). The server runs a handler
+        thread per GET, and the pusher coalesces by being one thread, not by a lock, so without one
+        every GET arriving mid-build started a build_feed of its own (the 2026-08-30 pile-up class:
+        inline builds stacking on handler threads), and the older build, finishing last, rebound the
+        slot so buildId went backwards inside the window. The second GET queues behind the first's
+        build and is served it. Event-driven: the build blocks on an Event until the second GET has
+        queued, and queuing is observed through the lock's own __enter__ (no sleeps)."""
+        parked = queue.Queue()                       # each thread reports where it stopped: "lock" or "build"
+        release = threading.Event()
+
+        class SignallingLock:                        # the route's lock, naming each acquirer BEFORE it blocks
+            def __init__(self):
+                self.real = threading.Lock()
+
+            def __enter__(self):
+                parked.put("lock")
+                return self.real.__enter__()
+
+            def __exit__(self, *exc):
+                return self.real.__exit__(*exc)
+
+        calls = []
+
+        def blocking_build(now, tmux):
+            calls.append(now)
+            parked.put("build")
+            release.wait(10)
+            return {"type": "feed", "asks": [], "working": [], "awaiting": [], "now": now}
+
+        km.build_feed = blocking_build
+        km._pure_feed_lock = SignallingLock()
+        out = []
+        first = threading.Thread(target=lambda: out.append(self._get("/feed.json")))
+        first.start()
+        stops = [parked.get(timeout=10)]             # the first GET takes the lock...
+        if stops[-1] == "lock":
+            stops.append(parked.get(timeout=10))     # ...and enters its build
+        self.assertEqual(stops[-1], "build")
+        second = threading.Thread(target=lambda: out.append(self._get("/feed.json")))
+        second.start()
+        where = parked.get(timeout=10)               # the second GET: queued behind the lock, or in a build of its own
+        release.set()
+        first.join(10)
+        second.join(10)
+        self.assertEqual(where, "lock", "the second GET queued behind the first's build instead of building")
+        self.assertEqual(len(calls), 1, "two GETs in flight together: one build, served to both")
+        self.assertEqual([st for st, _ in out], [200, 200])
+        self.assertEqual(len({d["buildId"] for _, d in out}), 1, "both were served the same build")
+
+    def test_feed_json_reads_count_under_the_routes_counters_not_the_pushers(self):
+        """A route build or serve moves the route's OWN numbers (review find, 2026-09-08). feedBuild /
+        feedServe on /version and the `feed` build kind on /perf are the PUSHER's cost, read as 'a
+        rising build count on a quiet board is a bug signature'; a monitoring poller's builds under
+        those numbers would forge that signature, or bury a pusher regression in a poller's noise."""
+        km.build_feed = lambda now, tmux: {"type": "feed", "asks": [], "working": [], "awaiting": [], "now": now}
+        views0 = dict(km._VIEW_STATS)
+        builds0 = km._PERF_STATS.snapshot()["builds"]
+        self.assertEqual(self._get("/feed.json")[0], 200)     # cold: a build
+        self.assertEqual(self._get("/feed.json")[0], 200)     # inside the floor: a serve
+        views1 = dict(km._VIEW_STATS)
+        builds1 = km._PERF_STATS.snapshot()["builds"]
+        self.assertEqual(views1["feedJsonBuild"] - views0["feedJsonBuild"], 1)
+        self.assertEqual(views1["feedJsonServe"] - views0["feedJsonServe"], 1)
+        self.assertEqual((views1["feedBuild"], views1["feedServe"]), (views0["feedBuild"], views0["feedServe"]),
+                         "the pusher's counters did not move")
+        self.assertEqual(builds1["feedJson"]["built"] - builds0["feedJson"]["built"], 1)
+        self.assertEqual(builds1["feedJson"]["cached"] - builds0["feedJson"]["cached"], 1)
+        self.assertEqual(builds1["feed"], builds0["feed"], "the pusher's /perf build kind did not move")
 
     def test_feed_json_serves_the_pushers_copy_only_while_the_pusher_has_an_audience(self):
         """With a client riding the feed payload the pusher maintains _built_feed, and the route
-        serves exactly that — what the panes see, no build. When the audience leaves the pusher stops
-        rebuilding and the slot freezes at the last disconnect, so it is no longer the answer: the
-        route builds its own copy and leaves the pusher's slot as it found it."""
+        serves exactly that, no build: the feed_src under the panes' frame (their copy carries _push's
+        per-push ledgers attach on top, so not byte-identical to a pane's; review find, 2026-09-08).
+        When the audience leaves the pusher stops rebuilding and the slot freezes at the last
+        disconnect, so it is no longer the answer: the route builds its own copy and leaves the
+        pusher's slot as it found it."""
         calls = []
 
         def counting_build(now, tmux):

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -108,7 +108,7 @@ class Collector(unittest.TestCase):
             self.assertEqual(p[k], 0.0, k)
         self.assertEqual(p["ring_n"], 0)
         self.assertEqual(set(snap["stages_ms"]), set(km._PerfStats.STAGES))
-        self.assertEqual(set(snap["builds"]), {"chat", "feed", "timeline"})
+        self.assertEqual(set(snap["builds"]), {"chat", "feed", "timeline", "feedJson"})
         self.assertEqual(set(snap["sends"]), {"full", "delta", "deduped"})
         self.assertEqual(snap["judge"]["ms_mean"], 0.0, "no passes: the mean is 0, not a division error")
         self.assertIn("cpu_ms_sum", snap["judge"])


### PR DESCRIPTION
`GET /feed.json` answered through the pusher's cache under a comment claiming "read-only, no side effects". Verified on `main`, the cache's cold branch built the feed, filled the pusher's slot, advanced the notification baseline, pruned the bell's cards on disk, and pushed a badge frame to the shell. A headless kernel never warms that cache, since the pusher builds the feed only for a connected feed, board or chat client, so a monitoring script's first read did all of that.

## What changes

The route reads through `_pure_feed`. While the pusher has an audience it serves the pusher's own copy, byte-identical to what the panes see. Otherwise it builds the feed directly, keeps the result in its own short cache gated on the existing rebuild threshold and the existing views-dirty event, and never touches the pusher's slot, the notification baseline, the bell's cards or the badge. The comment now names what the cache's cold branch does.

## Judgment calls

- The pure path never fills the pusher's slot: a pure build there would satisfy the pusher's reuse window, and a one-hertz poller would keep the pusher on its serve branch, muting every bell and badge.
- The pusher's copy is served only while the pusher has an audience. Once the last feed client disconnects the slot freezes at that moment, and serving it would answer a poller with an hours-old board that looks current.
- The two cache gates are the existing threshold and dirty event; no new clock, and no view signature, whose bucket buys nothing past the rebuild window and costs a stat sweep per read.
- The pure build claims a build id so the payload keeps its `buildId`; a card-move acknowledgement only needs the pusher's next build to outrank it.
- `build_feed` itself starts a background parse warm only when a client is connected, and files a fault row only when a goal store cannot be read, which is loud by design.

## Tests

`tests/test_observability_routes.py`: on a cold kernel with a seeded bell-cards file, a sentinel baseline and a fake shell client, a read leaves the file's bytes, the baseline, the badge and the pusher's slot untouched (on `main` the armed card is pruned and the file rewritten); two reads within the window build once and a dirty mark rebuilds; the pusher's copy is served exactly while a feed client is connected and rebuilt once it leaves; the payload's nine top-level keys are pinned. Mutants (the route back on the cache, the pure path filling the slot, either gate removed, the audience gate removed) each fail a test.

Module counts on this tree, one runner at a time: `tests/test_observability_routes.py` 9; `tests/test_kernel_fleet_cache.py` 8; `tests/test_notify_bells.py` 53; `tests/test_kernel_notify_popover.py` 53; `tests/test_kernel_webpush.py` 50; `tests/test_perf_stats.py` 41; the two TypeScript files that slice the kernel source around the feed cache, 10 of 10. On `main` the three new behavioral tests fail with the first errors the commit body names; the shape guard and the predicate pin pass there. Review folds: the docstring and route comment no longer claim the build reads only, since `build_feed`'s own housekeeping (a session-order persist when the living set moved, the views store's re-stamp, a fork's inheritance heal) is as it was on the old path and out of this change's scope; a source pin ties the route's audience predicate to the pusher's so the two cannot drift apart silently. Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
