### PR TITLE
Postal: row before delete, atomic stores, 128-bit ids, bad file skipped

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -195,9 +195,15 @@ romp mail remote                 # legacy singleton scheme only (ROMP_POSTAL_PEE
 ### When a send is refused
 
 A send whose record cannot be written, or that cannot be placed in the
-recipient's inbox, is refused, never half-done: the bus answers `503` with
-`ok: false` and the reason, nothing is delivered and nothing is recorded, and
-the sender still holds the text to retry. `check_sent` and `romp mail sent`
+recipient's inbox, is refused: the bus answers `503` with `ok: false` and the
+reason, nothing is delivered and nothing is recorded, and the sender still
+holds the text to retry. Two outcomes are not refusals, because the message is
+already in the recipient's hands: the recipient read it in the instant before
+its record failed, or the bus could not take it back out of the inbox. The
+send then answers the id, and the bus says on stderr and on the dashboard that
+the message log has no record of that message. A bus stopped between placing a
+message and recording it writes the missing record from the message's own
+headers at its next start. `check_sent` and `romp mail sent`
 show a message the bus had to give up on later (a cross-host record it could
 not write, a file it could not read, a write a restart found unfinished) as
 `bounced`, marked `refused` with the reason; a peer's refusal that did come

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -192,6 +192,18 @@ romp mail remote                 # legacy singleton scheme only (ROMP_POSTAL_PEE
 | `check_sent()` | Whether your sent messages were read yet |
 | `recall_message(to, id?)` | Unsend a message the recipient hasn't read |
 
+### When a send is refused
+
+A send whose record cannot be written is refused, never half-done: the bus
+answers `503` with `ok: false` and the reason, nothing is delivered, and the
+sender still holds the text to retry. `check_sent` and `romp mail sent` show
+a message the bus refused, or could not place, as `bounced`, marked `refused`
+with the reason; a peer's refusal that did come back as a note still reads
+`undeliverable, returned to you`. A message file the bus cannot read, in a
+recipient's inbox or in the cross-host outbox, is moved aside once (see the
+state files below), its sender's receipt reads refused, and the dashboard's
+error center says so under the `refused` kind.
+
 ### Claude Code 2.1.224 or newer
 
 Mail to a terminal (tmux) session delivers through Claude Code's per-session
@@ -1499,6 +1511,19 @@ lands in the same second; the `remotes.json` sidecar is 0600, since its rows
 carry tokens), the file is rewritten without them, and one stderr line plus one
 Log entry under the `refused` kind names each host as a clipped repr, never the
 raw string.
+
+The postal service's own files live under `postal/` there: `mail/<session>/`
+(a maildir per recipient), `outbox/<host>/` and `readbox/<host>/` (cross-host
+mail and read receipts awaiting their peer). A record or message file the bus
+cannot parse or read is moved aside once, never deleted, to
+`<name>.corrupt-<UTC stamp>` beside the original (an inbox file lands beside
+its `new/` directory, out of every listing; a `-1`, `-2` suffix when two land
+in the same second), the rest of the store is served, the sender's receipt for
+that message reads refused, and the error center says so under the `refused`
+kind. At start the bus removes the temporary files a crash left behind (a
+message written but never placed, a store record never finished), closes each
+one's receipt as refused, and says so once. The sidecars are yours to inspect
+or delete.
 
 ## Switches
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -194,12 +194,14 @@ romp mail remote                 # legacy singleton scheme only (ROMP_POSTAL_PEE
 
 ### When a send is refused
 
-A send whose record cannot be written is refused, never half-done: the bus
-answers `503` with `ok: false` and the reason, nothing is delivered, and the
-sender still holds the text to retry. `check_sent` and `romp mail sent` show
-a message the bus refused, or could not place, as `bounced`, marked `refused`
-with the reason; a peer's refusal that did come back as a note still reads
-`undeliverable, returned to you`. A message file the bus cannot read, in a
+A send whose record cannot be written, or that cannot be placed in the
+recipient's inbox, is refused, never half-done: the bus answers `503` with
+`ok: false` and the reason, nothing is delivered and nothing is recorded, and
+the sender still holds the text to retry. `check_sent` and `romp mail sent`
+show a message the bus had to give up on later (a cross-host record it could
+not write, a file it could not read, a write a restart found unfinished) as
+`bounced`, marked `refused` with the reason; a peer's refusal that did come
+back as a note still reads `undeliverable, returned to you`. A message file the bus cannot read, in a
 recipient's inbox or in the cross-host outbox, is moved aside once (see the
 state files below), its sender's receipt reads refused, and the dashboard's
 error center says so under the `refused` kind.

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -9553,19 +9553,27 @@ def _postal_ask_maps():
     if _PEER_ASK_CACHE[0] == key:
         return _PEER_ASK_CACHE[1]
     last_any, last_ask, rows, alias = {}, {}, [], {}
+    ended = set()   # ids a terminal `bounced` row closed: mail that never reached anyone
     try:
         for line in MESSAGES.read_text(errors="replace").splitlines():
             try:
                 o = json.loads(line)
             except Exception:
                 continue
+            if not isinstance(o, dict):
+                continue
             rows.append(o)
             _learn_alias(alias, o)
+            if o.get("ev") == "bounced" and o.get("id"):
+                ended.add(str(o["id"]))
         _alias_settle(alias)
         for o in rows:
             f, t_, ts = o.get("from_id"), o.get("to_id"), o.get("t")
             if not (f and t_ and ts):
                 continue
+            if str(o.get("id") or "") in ended:
+                continue   # refused or destroyed: never reached the recipient, so neither an ask nor an
+                #            answer (review find, 2026-09-08): the kernel's _postal_wait_maps rule, mirrored
             ts = int(ts)
             if isinstance(t_, str) and t_.startswith("peer:"):
                 if o.get("to_sid"):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -30412,9 +30412,10 @@ def _postal_wait_maps():
                 continue
             if str(o.get("id") or "") in ended:
                 # A REFUSED or DESTROYED send is neither an ask nor an answer (review find,
-                # 2026-09-08): the bus writes the sent row BEFORE it publishes and closes a publish
-                # that then failed, or a peer's refusal, or the orphan sweep's destroy, with a
-                # terminal `bounced` row on the same id. The recipient never saw that message, so
+                # 2026-09-08): the bus closes a message it had to give up on — a peer's refusal, the
+                # orphan sweep's destroy, an inbox file it could not read, a write a crash cut short
+                # — with a terminal `bounced` row on the same id (a publish it refuses outright
+                # writes no row at all). The recipient never saw that message, so
                 # counting its row here made the asker wear an open ask (and the debt reminder
                 # count a debt) that no reply could ever close, and let a bounced reply read as
                 # answering the pair. The judge's _postal_ask_maps applies the same rule.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -30394,11 +30394,14 @@ def _postal_wait_maps():
     try:
         rows = []
         alias = {}   # "host:name" -> [(t, sid), …], learned from every row a remote sender stamped
+        ended = set()   # ids a terminal `bounced` row closed: mail that never reached anyone
         for o in _messages_rows():                    # append-incremental rows (2026-09-03); the fold
             if not isinstance(o, dict):               # itself stays whole-log: aliases learned from LATER
                 continue                              # rows resolve EARLIER peer: rows
             rows.append(o)
             jd._learn_alias(alias, o)
+            if o.get("ev") == "bounced" and o.get("id"):
+                ended.add(str(o["id"]))
         jd._alias_settle(alias)
         for hn, hist in alias.items():                # the peer's own stamps, inverted: sid -> what it wore
             for at, sid in hist:
@@ -30406,6 +30409,15 @@ def _postal_wait_maps():
         for o in rows:
             f, t_, ts = o.get("from_id"), o.get("to_id"), o.get("t")
             if not (f and t_ and ts):
+                continue
+            if str(o.get("id") or "") in ended:
+                # A REFUSED or DESTROYED send is neither an ask nor an answer (review find,
+                # 2026-09-08): the bus writes the sent row BEFORE it publishes and closes a publish
+                # that then failed, or a peer's refusal, or the orphan sweep's destroy, with a
+                # terminal `bounced` row on the same id. The recipient never saw that message, so
+                # counting its row here made the asker wear an open ask (and the debt reminder
+                # count a debt) that no reply could ever close, and let a bounced reply read as
+                # answering the pair. The judge's _postal_ask_maps applies the same rule.
                 continue
             ts = int(ts)
             # a CROSS-HOST row is addressed to the RELAY ("peer:<host>"), not the recipient's sid —
@@ -45402,6 +45414,22 @@ class Handler(BaseHTTPRequestHandler):
                 h = str(body.get("host") or "")
                 if h:
                     _demand_redial(h, "timeout")
+                return self._send(200, json.dumps({"ok": True}), "application/json")
+            if u.path == "/postal-notice":
+                # The postal bus files a fault the USER should see (review find, 2026-09-08): a mail
+                # file it had to move aside, a return note it could not deliver, temps a crash left.
+                # The bus has no dashboard surface of its own, so the text lands here as one row on
+                # the ring the bell mirrors, under its `refused` kind, the kind a state file that
+                # could not be read or written wears, so a mute on machine-sync notices never hides
+                # it. The kernel adds nothing to the text: the bus wrote it for the user. Bounded to
+                # what the ring serves whole; a body with no text is a 400 that files nothing.
+                body, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
+                text = " ".join(str(body.get("text") or "").split())
+                if not text:
+                    return self._send(400, json.dumps({"ok": False, "error": "text required"}), "application/json")
+                _sync_notice(text[:300], ok=False, kind="refused")
                 return self._send(200, json.dumps({"ok": True}), "application/json")
             if u.path == "/tunnels/autoupdate":
                 # The popover's "Automatically update" checkbox. Body: {"on": bool}. Fleet-wide, not per-host

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -434,10 +434,12 @@ def _tl_append(fname, obj):
         return False
 
 class DeliveryNotRecorded(Exception):
-    """deliver() refused: nothing reached the recipient. Either the sent row could not land (so the
-    mail was never published — the sender still holds the text and retries), or the publish itself
-    failed after the row (a terminal 'bounced' row then closes the ledger on that id). The message
-    text is written for the SENDER's eyes: the /send route answers it as the refusal body."""
+    """deliver() refused: nothing reached the recipient, and NO row names the attempt. Either the
+    publish was refused — the name already stands in the inbox (a collision), or the filesystem said
+    no — so the name was never this message's and nothing is written under it; or the publish landed
+    and the sent row could not, and the mail was taken back out of new/ before anyone read it. The
+    sender still holds the text and retries. The message text is written for the SENDER's eyes: the
+    /send route answers it as the refusal body."""
 
 NOT_RECORDED_TEXT = ("the send was not recorded (the message log could not be written), so it was not "
                      "delivered — nothing is lost; retry")
@@ -445,6 +447,9 @@ NOT_RECORDED_TEXT = ("the send was not recorded (the message log could not be wr
 # The `why` of a terminal `bounced` row that records a REFUSAL — nothing left this machine and no
 # return note exists — as opposed to a peer's refusal, which _bounce_apply returns to the sender as
 # a note. format_receipts phrases the two apart (2026-09-08): a refusal must not promise a note.
+# deliver() itself writes no WHY_NOT_PUBLISHED row: a publish it refuses records nothing (the name
+# was never its own — see deliver). The prefix remains for the start sweep's close of a temp whose
+# sent row stood open (WHY_STOPPED_BEFORE_PUBLISH).
 WHY_NOT_PUBLISHED = "not published: "
 WHY_NOT_PARKED = "not parked: the outbox record could not be written"
 WHY_OUTBOX_UNREADABLE = "outbox record unreadable, moved aside"
@@ -497,8 +502,8 @@ def _publish_new(tmp, dst):
     visible under exactly one name at every instant. A filesystem that refuses hard links falls
     back to an exists-check + rename, said once: that check is not atomic, but a collision there
     needs two writers minting the same 128-bit name in the same instant, so the protection is the
-    same in practice. Raises OSError (FileExistsError on a collision); the caller accounts and
-    refuses.
+    same in practice. Raises OSError (FileExistsError on a collision); the caller refuses and
+    records nothing — the name was never this delivery's (see deliver).
 
     EVERY link() refusal but a collision takes the fallback (review find, 2026-09-08). The first
     cut named six errnos as "no hard links here" (EPERM, EOPNOTSUPP, ENOTSUP, ENOSYS, EMLINK,
@@ -615,34 +620,56 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
         # receiving courier reads it off this row (_postal_row) as walk-proved provenance
         ev["userAsk"] = {"text": str(user_ask["text"])[:1200], "sid": str(user_ask.get("sid") or ""),
                          "host": str(user_ask.get("host") or "")}
-    # The row lands BEFORE the mail is published (2026-09-08). The row is the ONE record the
-    # sender's receipts, the timeline and the kernel's courier read; before this the publish came
-    # first and the row was best-effort after it, so a failed append left mail in the recipient's
-    # inbox that nothing else knew about. When the row can't land the mail does not go out: the
-    # temp is removed and the caller answers a retryable refusal — the sender still holds the text.
-    if not _tl_append("messages.jsonl", ev):
+    # The PUBLISH is the claim on the name, and the row follows it (2026-09-08). The row is the ONE
+    # record the sender's receipts, the timeline and the kernel's courier read — and a row is a
+    # statement about a NAME. Until link() has granted this delivery the name, the name may be
+    # somebody else's: a row-first order under a collision filed the refused message's `sent` row
+    # and then the refusal's `bounced` row under the STANDING message's id, and every reader of the
+    # ledger saw a delivered message as bounced. link() refuses an existing target atomically, so
+    # the publish is the one act that proves the name is ours; a refused publish therefore records
+    # nothing (the retry lands under a fresh name with its own row). The sender-side rule "row
+    # before park" is not contradicted: that row is the sender's receipt under the sender's OWN mid;
+    # this one is the recipient's record of a message that landed. What keeps new/ honest — before
+    # 2026-09-08 a best-effort append after the publish left mail in the inbox that nothing else
+    # knew about — is the take-back below: a row that cannot land pulls the mail back out before
+    # it is read, and the caller answers a retryable refusal while the sender still holds the text.
+    dst = mb / "new" / name
+    try:
+        _publish_new(tmp, dst)
+    except Exception as e:
         try:
             tmp.unlink()
         except OSError:
             pass
-        raise DeliveryNotRecorded(NOT_RECORDED_TEXT)
-    try:
-        _publish_new(tmp, mb / "new" / name)
-    except Exception as e:
-        # The ledger says "sent" and the mail never landed: close the ledger on this id (the
-        # terminal-row rule _sweep_orphans follows), remove the temp, and refuse loudly. A collision
-        # — a standing new/<name> — is the one case named apart: impossible in practice with 128-bit
-        # ids, so if it ever shows up it is evidence of something badly wrong, not a tiebreak.
+        # A collision — a standing new/<name> — is the one case named apart: impossible in practice
+        # with 128-bit ids, so if it ever shows up it is evidence of something badly wrong, not a
+        # tiebreak. Either way the name was never this message's, so nothing is written under it.
         why = ("a message with this id already stands in the recipient's inbox; refusing to replace it"
                if isinstance(e, FileExistsError) else str(e))
-        _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": name,
-                                      "to_id": to_id, "why": WHY_NOT_PUBLISHED + why})
-        try:
-            tmp.unlink()
-        except OSError:
-            pass
+        _log("deliver to %s: %s was not published (%s) — refused, nothing recorded" % (to_id, name, why))
         raise DeliveryNotRecorded("the message could not be placed in the recipient's inbox (%s) — "
                                   "nothing was delivered; retry" % why)
+    if not _tl_append("messages.jsonl", ev):
+        # The mail is out but its row is not: take it back, so nothing stands in new/ that the
+        # ledger does not know, and refuse — the sender still holds the text. The one interleaving
+        # the take-back cannot undo is a reader claiming the file in the instant between the publish
+        # and the row (read_box renames it into cur/): the message IS in the recipient's hands then,
+        # so the truthful answer is the id — said loudly, by name, because the ledger will never
+        # carry this message (the log fault itself was already said by _tl_append).
+        try:
+            dst.unlink()
+        except FileNotFoundError:
+            _log("deliver to %s: %s was read before its row could be written — delivered, and the "
+                 "ledger has no record of it" % (to_id, name))
+            _mark_pending(to_id)
+            return name
+        except OSError as e:
+            _log("deliver to %s: %s stands in the inbox without its row and could not be taken back "
+                 "(%s) — the ledger has no record of it" % (to_id, name, e))
+            _mark_pending(to_id)
+            return name
+        _mark_pending(to_id)        # new/ may be empty again -> reconcile the marker
+        raise DeliveryNotRecorded(NOT_RECORDED_TEXT)
     _mark_pending(to_id)            # new/ is now non-empty -> raise the marker (covers park + live)
     return name   # the message id (maildir filename); joins to the log + status-bar prefix
 
@@ -2466,10 +2493,12 @@ WHY_STOPPED_BEFORE_PARK = "not parked: the mail service stopped before the outbo
 
 def _sweep_unfinished_writes():
     """Bus start: the one event at which no writer of ours is running, so every temp on disk is a
-    write that never finished (review find, 2026-09-08). deliver() writes the sent row and THEN
-    publishes: a crash between the two left the row saying "sent" and the message in <mailbox>/tmp/,
-    where nothing lists it, a phantom the sender's receipt read as pending forever. The relay leg
-    (row, then outbox_put) had the same window, leaving a `<mid>.json.tmp-*` temp and no record;
+    write that never finished (review find, 2026-09-08). A maildir temp is a message that stopped
+    before its publish; deliver() publishes first and writes its row second (the collision fold),
+    so such a temp normally has no row and is simply removed — a row saying "sent" beside one (a
+    bus that wrote row-first) is closed the same way, so no receipt reads pending forever for a
+    message nothing lists. The relay leg (row, then outbox_put) has that window still, leaving a
+    `<mid>.json.tmp-*` temp and no record;
     _atomic_json_put's own failure path removes its temp, so only a crash leaves one. Each temp is
     removed (never published: it may be half-written), its id's ledger is closed with a terminal
     `bounced` row when a sent row stands with no terminal row yet, each is said on stderr, and one

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -374,7 +374,13 @@ def _unique():
     # self_host(), not raw gethostname: the mid is a path component under mail/ and the peer's
     # outbox (_safe_id-checked at outbox_put), so a stomped hostname baked in here silently killed
     # every OUTBOUND cross-host send too — same 2026-08-11 breakage as self_host's docstring.
-    return f"{int(time.time())}.{os.getpid()}_{random.randint(0, 99999)}.{self_host()}"
+    # 128 bits from os.urandom, not random.randint(0, 99999) (2026-09-08): five decimal digits gave
+    # 100k names per second per process, and deliver()'s publish renamed OVER a standing new/<name>
+    # on a collision — somebody's unread mail replaced without a trace. The same id keys the outbox
+    # record and the quarantine file, so it has to be unique ACROSS processes and hosts, not merely
+    # within one process's second. Still digits, ".", "_", hex and the host, so _safe_id passes it
+    # (a DNS label is at most 63 chars; the whole id stays under the 128 cap).
+    return f"{int(time.time())}.{os.getpid()}_{os.urandom(16).hex()}.{self_host()}"
 
 def _mark_pending(sid):
     """Reconcile the on-disk pending-mail marker with reality: mail-pending/<sid>
@@ -399,14 +405,96 @@ def _mark_pending(sid):
     except Exception:
         pass
 
+_TL_FAULT = [False]      # transition-only logging for _tl_append (the _PRESENCE_SERVE_WARNED idiom)
+
 def _tl_append(fname, obj):
-    """Append one JSON line to a timeline log (best-effort; never raises)."""
+    """Append one JSON line to a timeline log. Returns True iff the row LANDED (the OS accepted the
+    write), False on any fault — with ONE stderr line per fault episode (and one when it writes
+    again), never per call. Never raises.
+
+    The return matters to the writers whose accounting IS the row (2026-09-08): deliver()'s sent
+    row, the relay park's sent row, and the outbox terminal rows (relayed / bounced). Before this the
+    append was best-effort with no return, so mail was published with no row anybody could see, and
+    an outbox record was deleted before its receipt existed. The exec / unexec / recall rows keep
+    ignoring the return: each is an annotation on a message that already exists, not the record of
+    whether it does."""
     try:
         TLDIR.mkdir(parents=True, exist_ok=True)
         with open(TLDIR / fname, "a") as fh:
             fh.write(json.dumps(obj) + "\n")
-    except Exception:
-        pass
+        if _TL_FAULT[0]:
+            _TL_FAULT[0] = False
+            _log("timeline log %s writes again" % fname)
+        return True
+    except Exception as e:
+        if not _TL_FAULT[0]:
+            _TL_FAULT[0] = True
+            _log("timeline log %s: append failed (%s) — sends are refused until it writes again"
+                 % (fname, e))
+        return False
+
+class DeliveryNotRecorded(Exception):
+    """deliver() refused: nothing reached the recipient. Either the sent row could not land (so the
+    mail was never published — the sender still holds the text and retries), or the publish itself
+    failed after the row (a terminal 'bounced' row then closes the ledger on that id). The message
+    text is written for the SENDER's eyes: the /send route answers it as the refusal body."""
+
+NOT_RECORDED_TEXT = ("the send was not recorded (the message log could not be written), so it was not "
+                     "delivered — nothing is lost; retry")
+
+# The `why` of a terminal `bounced` row that records a REFUSAL — nothing left this machine and no
+# return note exists — as opposed to a peer's refusal, which _bounce_apply returns to the sender as
+# a note. format_receipts phrases the two apart (2026-09-08): a refusal must not promise a note.
+WHY_NOT_PUBLISHED = "not published: "
+WHY_NOT_PARKED = "not parked: the outbox record could not be written"
+WHY_OUTBOX_UNREADABLE = "outbox record unreadable, moved aside"
+REFUSAL_WHYS = (WHY_NOT_PUBLISHED, "not parked:", WHY_OUTBOX_UNREADABLE)
+
+_REFUSAL_SAID = {}       # site -> True while that site's refusal episode is open (said once, not per pass)
+
+def _say_refused_once(site, what, exc):
+    """One _log line per refusal EPISODE at a periodic site (the orphan sweep, the stuck-mail warning):
+    the pass that met the refusal says it, the passes that meet it again stay quiet, and the first
+    pass whose send lands again (_refusal_over) re-arms it."""
+    if _REFUSAL_SAID.get(site):
+        return
+    _REFUSAL_SAID[site] = True
+    _log("%s: %s was refused (%s) — kept for the next pass" % (site, what, exc))
+
+def _refusal_over(site):
+    _REFUSAL_SAID.pop(site, None)
+
+_LINK_FALLBACK_SAID = [False]
+
+def _publish_new(tmp, dst):
+    """Publish a finished temp as new/<name> WITHOUT ever replacing a standing message. rename()
+    silently overwrites an existing target, so a name collision destroyed somebody's unread mail
+    with no trace (2026-09-08). link() refuses an existing target atomically (FileExistsError) — the
+    maildir protocol's own answer to this — and the temp is unlinked after, so the message is
+    visible under exactly one name at every instant. A filesystem that refuses hard links falls
+    back to an exists-check + rename, said once: that check is not atomic, but a collision there
+    needs two writers minting the same 128-bit name in the same instant, so the protection is the
+    same in practice. Raises OSError (FileExistsError on a collision); the caller accounts and
+    refuses."""
+    try:
+        os.link(tmp, dst)
+    except FileExistsError:
+        raise
+    except OSError as e:
+        if e.errno not in (errno.EPERM, errno.EOPNOTSUPP, errno.ENOTSUP, errno.ENOSYS,
+                           errno.EMLINK, errno.EXDEV):
+            raise                                    # a real fault (EIO, ENOSPC…), not "no links here"
+        if not _LINK_FALLBACK_SAID[0]:
+            _LINK_FALLBACK_SAID[0] = True
+            _log("mail publish: hard links unavailable here (%s) — falling back to a checked rename" % e)
+        if dst.exists():
+            raise FileExistsError(str(dst))
+        tmp.rename(dst)
+        return
+    try:
+        tmp.unlink()
+    except OSError as e:
+        _log("mail publish: %s is out but its temp could not be removed (%s)" % (dst.name, e))
 
 def _walk_root_record(frm_id):
     """The sending session's kernel-walked root-ask record, fetched at SEND time for a cross-host
@@ -469,8 +557,6 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
     if h["relay_mid"] and h["relay_via"]:
         hdr += "X-Peer-Mid: %s\nX-Peer-Via: %s\n" % (h["relay_mid"], h["relay_via"])
     tmp.write_text(hdr + "\n" + body + "\n")
-    tmp.rename(mb / "new" / name)   # atomic within the same filesystem
-    _mark_pending(to_id)            # new/ is now non-empty -> raise the marker (covers park + live)
     # Timeline log: a message was SENT (the matching exec event is logged when
     # the recipient consumes it in read_box). id = maildir filename joins the two.
     ev = {"t": int(time.time()), "ev": "sent", "id": name,
@@ -498,8 +584,49 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
         # receiving courier reads it off this row (_postal_row) as walk-proved provenance
         ev["userAsk"] = {"text": str(user_ask["text"])[:1200], "sid": str(user_ask.get("sid") or ""),
                          "host": str(user_ask.get("host") or "")}
-    _tl_append("messages.jsonl", ev)
+    # The row lands BEFORE the mail is published (2026-09-08). The row is the ONE record the
+    # sender's receipts, the timeline and the kernel's courier read; before this the publish came
+    # first and the row was best-effort after it, so a failed append left mail in the recipient's
+    # inbox that nothing else knew about. When the row can't land the mail does not go out: the
+    # temp is removed and the caller answers a retryable refusal — the sender still holds the text.
+    if not _tl_append("messages.jsonl", ev):
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise DeliveryNotRecorded(NOT_RECORDED_TEXT)
+    try:
+        _publish_new(tmp, mb / "new" / name)
+    except Exception as e:
+        # The ledger says "sent" and the mail never landed: close the ledger on this id (the
+        # terminal-row rule _sweep_orphans follows), remove the temp, and refuse loudly. A collision
+        # — a standing new/<name> — is the one case named apart: impossible in practice with 128-bit
+        # ids, so if it ever shows up it is evidence of something badly wrong, not a tiebreak.
+        why = ("a message with this id already stands in the recipient's inbox; refusing to replace it"
+               if isinstance(e, FileExistsError) else str(e))
+        _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": name,
+                                      "to_id": to_id, "why": WHY_NOT_PUBLISHED + why})
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise DeliveryNotRecorded("the message could not be placed in the recipient's inbox (%s) — "
+                                  "nothing was delivered; retry" % why)
+    _mark_pending(to_id)            # new/ is now non-empty -> raise the marker (covers park + live)
     return name   # the message id (maildir filename); joins to the log + status-bar prefix
+
+_UNREADABLE_SAID = set()   # (path, errno) already logged this bus run — said once, not per poll
+
+def _say_unreadable_once(path, exc, where):
+    """One _log line per (file, errno) per bus run for a file a listing had to skip. A poll loop
+    (/inbox, /drain, every exchange) re-meets the same file every pass; the registry keeps the
+    fact loud and the log readable."""
+    key = (str(path), getattr(exc, "errno", None))
+    if key in _UNREADABLE_SAID:
+        return
+    _UNREADABLE_SAID.add(key)
+    _log("%s: %s is unreadable (errno %s: %s) — skipped and left in place; the rest is served"
+         % (where, path.name, exc.errno, exc.strerror or exc))
 
 def read_box(sid, consume):
     if not _safe_id(sid):            # reject traversal in the id from /inbox, /drain
@@ -516,7 +643,16 @@ def read_box(sid, consume):
     for f in sorted(newd.iterdir(), key=lambda p: p.name):   # oldest first
         if not f.is_file():
             continue
-        text = f.read_text(errors="replace")
+        try:
+            text = f.read_text(errors="replace")
+        except OSError as e:
+            # One unreadable file (EACCES, EIO) used to raise out of the whole read — and do_GET
+            # has no handler, so /inbox and /drain answered NOTHING, on every poll, and the session
+            # got no mail at all while the Stop-hook drain hid the traceback (2026-09-08). Skip the
+            # file and serve the rest. It stays in place as evidence, never deleted, and is said
+            # ONCE per file per bus run — not per poll.
+            _say_unreadable_once(f, e, "inbox %s" % sid)
+            continue
         head, _, body = text.partition("\n\n")
         meta = {}
         for line in head.splitlines():
@@ -695,7 +831,13 @@ def format_receipts(recs):
         elif r.get("recalled"):
             st = "recalled %s" % _hhmm_epoch(r["recalled"])
         elif r.get("bounced"):
-            st = "bounced %s — undeliverable, returned to you" % _hhmm_epoch(r["bounced"])
+            why = str(r.get("bouncedWhy") or "")
+            if why.startswith(REFUSAL_WHYS):
+                # a REFUSAL (2026-09-08): nothing left this machine and no return note exists, so the
+                # refusal is the whole story — never promise a note that is not coming
+                st = "bounced %s — refused — %s" % (_hhmm_epoch(r["bounced"]), why)
+            else:
+                st = "bounced %s — undeliverable, returned to you" % _hhmm_epoch(r["bounced"])
         elif r.get("parked"):                  # cross-host, still in the outbox awaiting relay
             # "(unreachable)" ONLY when the link is actually down (the user 2026-08-24): a healthy
             # queue is normal transit, not a failure. An older bus omits parkedUp — claim nothing.
@@ -1239,7 +1381,7 @@ def _sent_receipts(mid):
     log = TLDIR / "messages.jsonl"
     if not mid or not log.exists():
         return []
-    sent, execs, recalls, relays, bounced = {}, {}, {}, {}, {}
+    sent, execs, recalls, relays, bounced, bounced_why = {}, {}, {}, {}, {}, {}
     for line in log.read_text(errors="replace").splitlines():
         try: e = json.loads(line)
         except Exception: continue
@@ -1256,6 +1398,7 @@ def _sent_receipts(mid):
             relays[e["id"]] = e["t"]
         elif ev == "bounced":                        # peer-bus: definitively undeliverable, returned
             bounced[e["id"]] = e["t"]
+            bounced_why[e["id"]] = str(e.get("why") or "")   # a REFUSAL's why renders apart (format_receipts)
 
     def _parked(i, e):                               # still in the outbox → honestly parked, not lost
         tid = e.get("to_id", "")
@@ -1277,6 +1420,8 @@ def _sent_receipts(mid):
         r = {"to": e.get("toName") or _name(e.get("to_id", "")), "id": i, "sent": e["t"],
              "exec": execs.get(i), "recalled": recalls.get(i),
              "relayed": relays.get(i), "bounced": bounced.get(i), "parked": h}
+        if r["bounced"]:
+            r["bouncedWhy"] = bounced_why.get(i, "")   # additive: an older client ignores it
         if h:
             # the LINK state rides along (the user 2026-08-24): outbox residency alone is not
             # unreachability — a message queued ahead of the next exchange on a healthy link is
@@ -1365,18 +1510,28 @@ def _sweep_orphans():
                 try:
                     deliver(s["id"], "Romp Postal Service", "", bounce)
                     threading.Thread(target=_push, args=(s["id"], s), daemon=True).start()
+                except DeliveryNotRecorded as e:
+                    # The bounce note was REFUSED (its row could not land). Destroying the orphan now
+                    # would lose the mail with no notice and no row — deliver() never refused before
+                    # 2026-09-08, so this arm is new. Keep the file; the next sweep retries.
+                    _say_refused_once("orphan sweep", "the bounce note for %s" % f.name, e)
+                    continue
                 except Exception as e:
                     _log("bounce to %s failed: %s" % (s["name"], e))
+                _refusal_over("orphan sweep")
+            # the destroy is the message's TERMINAL EVENT — record it on the original mid, the
+            # way _bounce_apply records a peer's refusal (the user 2026-08-24): without this row
+            # the ledger's last word stayed "sent", and the timeline's pending flag had to lean
+            # on an age window / recipient liveness — which a same-sid REVIVAL then flips back
+            # to pending for mail that no longer exists. The ledger is now terminal-complete.
+            # The row lands BEFORE the unlink (2026-09-08), the batch's rule: a destroy that could
+            # not be recorded does not happen; the file waits for the next sweep.
+            if not _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": f.name,
+                                                 "to": recip or "?",
+                                                 "why": "recipient exited; unread mail destroyed by the orphan sweep"}):
+                continue
             try:
                 f.unlink()
-                # the destroy is the message's TERMINAL EVENT — record it on the original mid, the
-                # way _bounce_apply records a peer's refusal (the user 2026-08-24): without this row
-                # the ledger's last word stayed "sent", and the timeline's pending flag had to lean
-                # on an age window / recipient liveness — which a same-sid REVIVAL then flips back
-                # to pending for mail that no longer exists. The ledger is now terminal-complete.
-                _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": f.name,
-                                              "to": recip or "?",
-                                              "why": "recipient exited; unread mail destroyed by the orphan sweep"})
             except Exception:
                 pass
         _mark_pending(box.name)                         # bounced orphans may have emptied new/
@@ -1447,8 +1602,14 @@ def _warn_stuck_mail():
                 try:
                     deliver(s["id"], "Romp Postal Service", "", warn)
                     threading.Thread(target=_push, args=(s["id"], s), daemon=True).start()
+                except DeliveryNotRecorded as e:
+                    # REFUSED (its row could not land): touching the one-time marker now would mean
+                    # the sender never hears the warning. Leave it; the next pass fires it.
+                    _say_refused_once("stuck-mail warning", "the warning for %s" % f.name, e)
+                    continue
                 except Exception as e:
                     _log("stuck-warn to %s failed: %s" % (s.get("name", "?"), e))
+                _refusal_over("stuck-mail warning")
             try:                                        # mark one-time even if the sender was dead/absent → no re-scan churn
                 WARNED.mkdir(parents=True, exist_ok=True)
                 marker.touch()
@@ -1534,9 +1695,19 @@ def _bounce_oversize(sid, m):
         to = _name_for_id(sid) or sid
         why = ("your message is %d bytes as delivered, over the %d-byte limit for delivery into a session"
                % (n, _PUSH_MAX_BYTES))
-        deliver(frm_id, "romp-postal", "", "undeliverable to '%s': %s. Send a shorter message, or write "
-                "the text to a file and send its path. (The message is not echoed here because of its "
-                "size.)" % (to, why), kind="coordinate")
+        try:
+            deliver(frm_id, "romp-postal", "", "undeliverable to '%s': %s. Send a shorter message, or write "
+                    "the text to a file and send its path. (The message is not echoed here because of its "
+                    "size.)" % (to, why), kind="coordinate")
+        except DeliveryNotRecorded as e:
+            # The note was REFUSED (its row could not land). The drain already claimed the message, so
+            # letting the refusal out here (into _push's catch-all) would leave it in cur/ with no note
+            # and no row — the arm the orphan sweep grew the same day (2026-09-08). Put it back under
+            # its own id; the next pass re-claims it and retries the bounce once the log writes again.
+            restore(sid, mid)
+            _say_refused_once("oversize bounce", "the note for %s" % mid, e)
+            return
+        _refusal_over("oversize bounce")
         _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": mid, "to": to,
                                       "host": "", "why": why})
         _log("push to %s: message %s is %d bytes, over the %d-byte /deliver limit; bounced to its sender %s"
@@ -1958,19 +2129,33 @@ class Handler(BaseHTTPRequestHandler):
                     ua = _walk_root_record(frm_id)
                     if ua:
                         relay_msg["userAsk"] = ua
-                outbox_put(phost, relay_msg)
                 # `to_sid` (2026-09-08): the recipient's STABLE id, the same value the wire's toId
                 # carries. The row used to name the recipient only ("<host>:<name>"), so every
                 # reader of the wait (the kernel's wait maps, the judge's ask maps) had to join it
                 # back to a sid through a name→sid alias learned from the peer's own rows — and a
                 # name reused by a NEW session re-keyed every OLD message to the new sid. With the
                 # sid on the row the join is exact; the alias stays the fallback for older rows.
-                _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "sent", "id": mid,
-                                              "from": frm, "from_id": frm_id,
-                                              "to_id": "peer:%s" % phost,
-                                              "toName": "%s:%s" % (phost, hit.get("name") or to),
-                                              "to_sid": str(hit.get("id") or ""),
-                                              "body": body, "kind": kind})
+                # The sent row lands BEFORE the park, and the park's own failure is answered
+                # (2026-09-08): the row is what the sender's receipts and the timeline read, so a
+                # park with no row was mail nobody could see, and answering ok regardless of the
+                # append was a "sent" the sender could not trust. A row that can't land refuses the
+                # send; a park that fails after the row closes the ledger on the id and refuses —
+                # either way the sender still holds the text. 503 + ok:false, because _http raises
+                # BusError only on a non-2xx: a 200 would read as "Delivered" in the tool and CLI.
+                if not _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "sent", "id": mid,
+                                                     "from": frm, "from_id": frm_id,
+                                                     "to_id": "peer:%s" % phost,
+                                                     "toName": "%s:%s" % (phost, hit.get("name") or to),
+                                                     "to_sid": str(hit.get("id") or ""),
+                                                     "body": body, "kind": kind}):
+                    return self._send({"ok": False, "error": NOT_RECORDED_TEXT}, 503)
+                if not outbox_put(phost, relay_msg):
+                    _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": mid,
+                                                  "to": hit.get("name") or to, "host": phost,
+                                                  "why": WHY_NOT_PARKED})
+                    return self._send({"ok": False, "error": "the message could not be parked for %s "
+                                       "(the outbox could not be written), so it was not sent — "
+                                       "nothing is lost; retry" % phost}, 503)
                 if PEERS.get(phost, {}).get("up"):
                     return self._send({"ok": True, "id": mid,
                                        "note": "relaying to '%s' on %s%s" % (hit.get("name") or to, phost, tnote)})
@@ -1981,7 +2166,11 @@ class Handler(BaseHTTPRequestHandler):
                                    "note": ("parked for %s (unreachable) — delivers on reconnect, "
                                             "or bounces back to you" % phost) + tnote})
             a0 = res["agent"]
-            mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked)
+            try:
+                mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked)
+            except DeliveryNotRecorded as e:
+                # 503 + ok:false (see the relay leg): nothing was published; the sender retries.
+                return self._send({"ok": False, "error": str(e)}, 503)
             if not a0.get("remote", False):
                 # All through the kernel (it owns the tmux status bar + the wake), off-thread so send latency
                 # stays low: paint the recipient's "📬 from X" badge; record correspondence (peer chips) + the
@@ -2621,33 +2810,117 @@ def peer_seen_add(mid):
     except Exception as e:
         _log("peer-seen append failed: %s" % e)     # dedupe degrades to the in-memory window
 
+def _atomic_json_put(path, obj):
+    """Publish one JSON store record atomically: a uniquely named temp in the SAME directory (never
+    a `*.json`, so the listings' glob cannot see it) → write → fsync → os.replace → best-effort
+    directory fsync. A reader (outbox_list on every exchange, the kernel reading the dir) sees the
+    old bytes or the new, never a torn file; a crash mid-write leaves a stray temp, not a record the
+    listing has to refuse. (2026-09-08: the plain write_text the stores used was the one writer
+    that could leave a half-record, and the listings then skipped it silently, every pass, forever.)
+    Raises OSError; the caller says so."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name("%s.tmp-%d-%s" % (path.name, os.getpid(), os.urandom(4).hex()))
+    try:
+        with open(tmp, "w") as fh:
+            fh.write(json.dumps(obj))
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+    try:
+        dfd = os.open(str(path.parent), os.O_RDONLY)
+        try:
+            os.fsync(dfd)
+        finally:
+            os.close(dfd)
+    except OSError:
+        pass
+
+def _list_json_records(d, where, close_ledger_for=None):
+    """Every parseable `*.json` record under `d`, sorted by name. A record that cannot be parsed
+    (or is not an object) is moved aside ONCE to `<name>.corrupt-<utc stamp>[-n]` — the kernel
+    stores' quarantine naming, so the `*.json` glob never sees it again — with one _log line, and the
+    listing goes on with the rest. It used to skip such a file silently on every pass, forever: a torn
+    outbox record was mail parked for nobody with no trace anywhere (2026-09-08). The file's stat is
+    fingerprinted BEFORE the read: if it changed by the time the parse failed, a writer's atomic
+    rewrite raced the read and the file is left alone for the next pass — a torn read of a healthy
+    record is never moved aside. An unreadable file (EACCES, EIO) is not corruption: skipped, said
+    once per bus run.
+
+    `close_ledger_for` (the OUTBOX's host): a parked message's filename IS its mid, and moving the
+    record aside is that message's terminal event — without a row the sender's receipt reads
+    "pending (not read yet)" forever. A terminal `bounced` row (WHY_OUTBOX_UNREADABLE) is appended
+    best-effort after the move; the quarantine itself never depends on the row landing."""
+    out = []
+    try:
+        files = sorted(d.glob("*.json"))
+    except OSError:
+        return out
+    for f in files:
+        try:
+            st = f.stat()
+            rec = json.loads(f.read_text())
+            if not isinstance(rec, dict):
+                raise ValueError("not a JSON object")
+            out.append(rec)
+            continue
+        except FileNotFoundError:
+            continue                                 # gone between the glob and the read (deleted, moved)
+        except OSError as e:
+            _say_unreadable_once(f, e, where)
+            continue
+        except ValueError as e:
+            reason = e
+        try:
+            cur = f.stat()
+            if (cur.st_ino, cur.st_mtime_ns, cur.st_size) != (st.st_ino, st.st_mtime_ns, st.st_size):
+                continue                             # rewritten under us: a torn read, not a torn file
+            stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+            aside, n = f.with_name("%s.corrupt-%s" % (f.name, stamp)), 0
+            while aside.exists():                    # a second corrupt file in the same second
+                n += 1
+                aside = f.with_name("%s.corrupt-%s-%d" % (f.name, stamp, n))
+            os.replace(f, aside)
+        except FileNotFoundError:
+            continue                                 # a sibling lister moved it first
+        except OSError as e:
+            _log("%s: %s could not be parsed (%s) and could not be moved aside (%s)" % (where, f.name, reason, e))
+            continue
+        _log("%s: %s could not be parsed (%s); moved aside to %s — the rest is served"
+             % (where, f.name, reason, aside.name))
+        if close_ledger_for:
+            _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": f.stem,
+                                          "host": close_ledger_for, "why": WHY_OUTBOX_UNREADABLE})
+    return out
+
 def outbox_put(host, msg):
     """Park one cross-host message for `host` and poke its exchange (long-poll release + dialer).
+    Returns True iff the record is on disk (atomic publish); False, said in the log, when it is not.
     `host` and the message `mid` become path components, so both MUST clear _safe_id first: a
     peer-crafted `mid` like `../../../foo` over the unauthenticated bus would otherwise write
     outside OUTBOX (arbitrary-file-write). Legit ids (short hostnames, `_unique()` mids) pass."""
     mid = (msg or {}).get("mid") or ""
     if not (_safe_id(host) and _safe_id(mid)):
         _log("outbox_put: refusing unsafe host/mid %r/%r" % (host, mid))
-        return
-    d = OUTBOX / host
-    d.mkdir(parents=True, exist_ok=True)
-    (d / (mid + ".json")).write_text(json.dumps(msg))
+        return False
+    try:
+        _atomic_json_put(OUTBOX / host / (mid + ".json"), msg)
+    except OSError as e:
+        _log("outbox_put %s/%s: the record could not be written (%s) — nothing parked" % (host, mid, e))
+        return False
     _peer_wake(host).set()
+    return True
 
 def outbox_list(host):
     if not _safe_id(host):
         return []
-    try:
-        out = []
-        for f in sorted((OUTBOX / host).glob("*.json")):
-            try:
-                out.append(json.loads(f.read_text()))
-            except Exception:
-                pass
-        return out
-    except Exception:
-        return []
+    return _list_json_records(OUTBOX / host, "outbox %s" % host, close_ledger_for=host)
 
 def outbox_get(host, mid):
     if not (_safe_id(host) and _safe_id(mid)):   # host/mid are path components — block traversal
@@ -2674,25 +2947,19 @@ def readbox_put(host, rec):
     mid = (rec or {}).get("mid") or ""
     if not (_safe_id(host) and _safe_id(mid)):   # host/mid are path components — block traversal
         _log("readbox_put: refusing unsafe host/mid %r/%r" % (host, mid))
-        return
-    d = READBOX / host
-    d.mkdir(parents=True, exist_ok=True)
-    (d / (mid + ".json")).write_text(json.dumps(rec))
+        return False
+    try:
+        _atomic_json_put(READBOX / host / (mid + ".json"), rec)
+    except OSError as e:
+        _log("readbox_put %s/%s: the receipt could not be written (%s) — not parked" % (host, mid, e))
+        return False
     _peer_wake(host).set()
+    return True
 
 def readbox_list(host):
     if not _safe_id(host):
         return []
-    try:
-        out = []
-        for f in sorted((READBOX / host).glob("*.json")):
-            try:
-                out.append(json.loads(f.read_text()))
-            except Exception:
-                pass
-        return out
-    except Exception:
-        return []
+    return _list_json_records(READBOX / host, "readbox %s" % host)
 
 def readbox_del(host, rec):
     """Clear one CONFIRMED receipt — only if the file still says what the peer confirmed (the unread
@@ -2735,20 +3002,33 @@ def _read_arrived(host, r):
 
 def _bounce_apply(host, b):
     """A peer refused one of our parked messages — return it to the SENDER as a bus-authored note,
-    loudly, and drop it from the outbox. Parking never outlives a definitive refusal."""
+    loudly, and drop it from the outbox. Parking never outlives a definitive refusal.
+
+    Order (2026-09-08): the terminal row, then the return note, then the delete. The record leaves
+    the outbox only once the ledger holds its last word and the sender holds the note; before this
+    the delete came FIRST and a crash between it and the row lost the accounting entirely. If either
+    step fails the record stays: the next exchange re-relays it, the peer's dedupe re-bounces it,
+    and the attempt repeats (a repeated terminal row is harmless — _sent_receipts keys by id)."""
     mid = (b or {}).get("mid") or ""
     msg = outbox_get(host, mid)
-    outbox_del(host, mid)
     if not msg:
+        return                                       # nothing parked under that id (recalled, or a torn
+        #                                              record the listing moves aside) → nothing to account
+    why = (b or {}).get("why") or "refused"
+    if not _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": mid,
+                                          "to": msg.get("to") or "?", "host": host, "why": why}):
+        _log("bounce for %s from %s: the terminal row did not land — the record stays parked" % (mid, host))
         return
-    note = "undeliverable to '%s' on %s: %s" % (msg.get("to") or "?", host, (b or {}).get("why") or "refused")
-    if not (b or {}).get("omitBody"):   # a SIZE bounce (_budget_relays) names the problem instead of repeating it
-        note += "\n\n(your message follows)\n%s" % (msg.get("body") or "")
     if msg.get("frm_id"):
-        deliver(msg["frm_id"], "romp-postal", "", note, kind="coordinate")
-    _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": mid,
-                                  "to": msg.get("to") or "?", "host": host,
-                                  "why": (b or {}).get("why") or "refused"})
+        note = "undeliverable to '%s' on %s: %s" % (msg.get("to") or "?", host, why)
+        if not (b or {}).get("omitBody"):   # a SIZE bounce (_budget_relays) names the problem instead of repeating it
+            note += "\n\n(your message follows)\n%s" % (msg.get("body") or "")
+        try:
+            deliver(msg["frm_id"], "romp-postal", "", note, kind="coordinate")
+        except DeliveryNotRecorded as e:
+            _log("bounce for %s from %s: the return note was refused (%s) — the record stays parked" % (mid, host, e))
+            return
+    outbox_del(host, mid)
 
 _LOCAL_PRESENCE_GOOD = [[], False]   # [rows, ever_answered] — the last ANSWERED local listing
 _PRESENCE_SERVE_WARNED = [False]     # transition-only logging, the _REG_SERVE_WARNED idiom
@@ -2965,10 +3245,13 @@ def quarantine_decide(mid, action, text=None, feedback=None):
             if not match:
                 return False, "recipient '%s' is no longer a live local session" % (rec.get("to") or "?")
             to_id = match[0]["id"]
-        deliver(to_id, rec.get("frm") or "?", rec.get("frmId") or "", body, kind=rec.get("kind") or "",
-                from_host=rec.get("origin") or "",
-                relay_mid=rec.get("mid") or "", relay_via=rec.get("via") or rec.get("origin") or "",
-                user_ask=rec.get("userAsk"))
+        try:
+            deliver(to_id, rec.get("frm") or "?", rec.get("frmId") or "", body, kind=rec.get("kind") or "",
+                    from_host=rec.get("origin") or "",
+                    relay_mid=rec.get("mid") or "", relay_via=rec.get("via") or rec.get("origin") or "",
+                    user_ask=rec.get("userAsk"))
+        except DeliveryNotRecorded as e:
+            return False, "%s — the held message is untouched" % e
         quarantine_del(mid)
         return True, None
     return False, "unknown action '%s' (approve|deny)" % action
@@ -3036,10 +3319,16 @@ def _relay_in(host, m, token_proven=False):
                 htrust = "trusted"                   # token possession is already full control here (see docstring)
             trust = least_trust(trust, htrust)
         if trust == "trusted":
-            deliver(match[0]["id"], m.get("frm") or "?", m.get("frm_id") or "", m.get("body") or "",
-                    kind=m.get("kind") or "", from_host=origin,
-                    relay_mid=mid, relay_via=host,       # read-receipt route: back through the direct peer
-                    user_ask=m.get("userAsk"))           # origin-kernel walked record rides through (T126)
+            try:
+                deliver(match[0]["id"], m.get("frm") or "?", m.get("frm_id") or "", m.get("body") or "",
+                        kind=m.get("kind") or "", from_host=origin,
+                        relay_mid=mid, relay_via=host,       # read-receipt route: back through the direct peer
+                        user_ask=m.get("userAsk"))           # origin-kernel walked record rides through (T126)
+            except DeliveryNotRecorded as e:
+                # nothing landed → NOT acked and not marked seen: silence crosses the wire as
+                # 'retry', the sender's outbox keeps it parked and re-relays it next exchange
+                _log("relay %s from %s: local delivery refused (%s) — the sender re-relays" % (mid, host, e))
+                return "retry", None
         elif trust == "directed":
             _quarantine_put(origin, m, match[0]["id"], via=host, wire_id=to_id)   # HELD for human approve/deny/edit;
             #                                                                        never injects; remembers whether
@@ -3084,30 +3373,35 @@ def _relay_in(host, m, token_proven=False):
 
 def _ack_arrived(host, mid):
     """An end-to-end ack for outbox/<host>/<mid>: clear it. If we only FORWARDED it, relay the ack
-    backward to the origin host; if it was ours, log the delivered receipt."""
+    backward to the origin host; if it was ours, log the delivered receipt. The receipt (or the
+    backward ack) comes FIRST and the delete last (2026-09-08): a record that leaves the outbox
+    before its receipt exists is a delivery the sender never hears of if the row then fails. A row
+    that does not land keeps the record; the next exchange re-relays it, the peer's dedupe re-acks
+    it, and the receipt is retried."""
     msg = outbox_get(host, mid)
-    outbox_del(host, mid)
     if not msg:
-        return
+        return                                       # nothing parked under that id → nothing to account
     if msg.get("origin"):
         p = _pending(msg["origin"])
         with _peer_lock:
             p["acks"].append(mid)
         _peer_wake(msg["origin"]).set()
-    else:
-        _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "relayed", "id": mid, "host": host})
+    elif not _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "relayed", "id": mid, "host": host}):
+        _log("ack for %s from %s: the delivered receipt did not land — the record stays parked" % (mid, host))
+        return
+    outbox_del(host, mid)
 
 def _bounce_arrived(host, b):
     """A bounce for outbox/<host>/<mid>: relay it backward if we only forwarded the message, else
-    return it to our local sender."""
+    return it to our local sender. The backward bounce is queued BEFORE the delete (2026-09-08)."""
     mid = (b or {}).get("mid") or ""
     msg = outbox_get(host, mid)
     if msg and msg.get("origin"):
-        outbox_del(host, mid)
         p = _pending(msg["origin"])
         with _peer_lock:
             p["bounces"].append(b)
         _peer_wake(msg["origin"]).set()
+        outbox_del(host, mid)
     else:
         _bounce_apply(host, b)
 

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -629,10 +629,13 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
     # the publish is the one act that proves the name is ours; a refused publish therefore records
     # nothing (the retry lands under a fresh name with its own row). The sender-side rule "row
     # before park" is not contradicted: that row is the sender's receipt under the sender's OWN mid;
-    # this one is the recipient's record of a message that landed. What keeps new/ honest — before
-    # 2026-09-08 a best-effort append after the publish left mail in the inbox that nothing else
-    # knew about — is the take-back below: a row that cannot land pulls the mail back out before
-    # it is read, and the caller answers a retryable refusal while the sender still holds the text.
+    # this one is the recipient's record of a message that landed. What keeps new/ honest while the
+    # bus runs (before 2026-09-08 a best-effort append after the publish left mail in the inbox that
+    # nothing else knew about) is the take-back below: a row that cannot land pulls the mail back out
+    # before it is read, and the caller answers a retryable refusal while the sender still holds the
+    # text. The one gap the take-back cannot reach is a bus killed between the publish and the row:
+    # that message stands in new/ with no record until _sweep_unfinished_writes rebuilds its row from
+    # the file's headers at the next start (review find, 2026-09-08).
     dst = mb / "new" / name
     try:
         _publish_new(tmp, dst)
@@ -644,28 +647,43 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
         # A collision — a standing new/<name> — is the one case named apart: impossible in practice
         # with 128-bit ids, so if it ever shows up it is evidence of something badly wrong, not a
         # tiebreak. Either way the name was never this message's, so nothing is written under it.
+        # No row says this, so the log says it on every refusal, and the USER hears it once per
+        # recipient episode as a bell row (review find, 2026-09-08: a refusal on the relay leg has
+        # the dialer re-relay the message every exchange while the sender's receipt reads queued, so
+        # a fault that lasted had no surface anyone watched); the next publish to that recipient
+        # that lands re-arms it.
         why = ("a message with this id already stands in the recipient's inbox; refusing to replace it"
                if isinstance(e, FileExistsError) else str(e))
-        _log("deliver to %s: %s was not published (%s) — refused, nothing recorded" % (to_id, name, why))
+        text = "deliver to %s: %s was not published (%s): refused, nothing recorded" % (to_id, name, why)
+        site = "deliver:%s" % to_id
+        if _REFUSAL_SAID.get(site):
+            _log(text)
+        else:
+            _REFUSAL_SAID[site] = True
+            _refused_notice(text + "; the sender holds the text and retries until the inbox can be written")
         raise DeliveryNotRecorded("the message could not be placed in the recipient's inbox (%s) — "
                                   "nothing was delivered; retry" % why)
+    _refusal_over("deliver:%s" % to_id)          # a publish landed: the next refusal here is a new episode
     if not _tl_append("messages.jsonl", ev):
         # The mail is out but its row is not: take it back, so nothing stands in new/ that the
-        # ledger does not know, and refuse — the sender still holds the text. The one interleaving
-        # the take-back cannot undo is a reader claiming the file in the instant between the publish
-        # and the row (read_box renames it into cur/): the message IS in the recipient's hands then,
-        # so the truthful answer is the id — said loudly, by name, because the ledger will never
-        # carry this message (the log fault itself was already said by _tl_append).
+        # ledger does not know, and refuse: the sender still holds the text. Two outcomes the
+        # take-back cannot undo leave a DELIVERED message the ledger will never carry, and each
+        # answers the id, because the message is in (or on its way to) the recipient's hands: a
+        # reader claimed the file in the instant between the publish and the row (read_box renamed
+        # it into cur/), or the unlink itself was refused (the file stands in new/ and the next read
+        # gets it; the start sweep rebuilds that one's row if the bus restarts first). Both are said
+        # by name on stderr AND as a bell row, since no row will ever say it (the log fault itself
+        # was already said by _tl_append).
         try:
             dst.unlink()
         except FileNotFoundError:
-            _log("deliver to %s: %s was read before its row could be written — delivered, and the "
-                 "ledger has no record of it" % (to_id, name))
+            _refused_notice("deliver to %s: %s was read before its row could be written; delivered, and "
+                            "the ledger has no record of it" % (to_id, name))
             _mark_pending(to_id)
             return name
         except OSError as e:
-            _log("deliver to %s: %s stands in the inbox without its row and could not be taken back "
-                 "(%s) — the ledger has no record of it" % (to_id, name, e))
+            _refused_notice("deliver to %s: %s stands in the inbox without its row and could not be taken "
+                            "back (%s); delivered, and the ledger has no record of it" % (to_id, name, e))
             _mark_pending(to_id)
             return name
         _mark_pending(to_id)        # new/ may be empty again -> reconcile the marker
@@ -754,16 +772,23 @@ def read_box(sid, consume):
         for line in head.splitlines():
             k, _, v = line.partition(": ")
             meta[k.lower()] = v
-        out.append({"from": meta.get("from", "?"), "from_id": meta.get("from-id", ""),
-                    "date": meta.get("date", ""), "body": body.rstrip("\n"), "id": f.name,
-                    "park": bool(meta.get("x-park")), "kind": meta.get("x-kind", ""),
-                    "from_host": meta.get("x-from-host", "")})
         if consume:
-            f.rename(mb / "cur" / f.name)
+            try:
+                f.rename(mb / "cur" / f.name)
+            except FileNotFoundError:
+                # gone between the read and the claim: recalled, taken back by a deliver() whose row
+                # could not land, or claimed by a second reader (2026-09-08). Nobody's to hand over,
+                # so no exec row and no entry; the rest of the box is served (an unguarded rename
+                # here raised out of the whole read, and /inbox and /drain answered nothing).
+                continue
             _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "exec", "id": f.name})
             _queue_read_receipt(meta, dmid=f.name)   # cross-host mail: the sender's host learns it was read
             #   dmid = THIS host's delivery mid — the id the recipient's transcript markers carry, so the
             #   sender's timeline can join the connector to the true process turn (the user 2026-08-06)
+        out.append({"from": meta.get("from", "?"), "from_id": meta.get("from-id", ""),
+                    "date": meta.get("date", ""), "body": body.rstrip("\n"), "id": f.name,
+                    "park": bool(meta.get("x-park")), "kind": meta.get("x-kind", ""),
+                    "from_host": meta.get("x-from-host", "")})
     if consume:
         _mark_pending(sid)         # cleared the box -> drop the marker (no-op if more arrived)
     return out
@@ -2491,19 +2516,94 @@ def _reconcile_markers():
 WHY_STOPPED_BEFORE_PUBLISH = WHY_NOT_PUBLISHED + "the mail service stopped before the message reached the inbox"
 WHY_STOPPED_BEFORE_PARK = "not parked: the mail service stopped before the outbox record was written"
 
+def _rebuild_rows_for_rowless_mail(box, sent, ended):
+    """The start sweep's pass over <box>/new/ (see _sweep_unfinished_writes): every file whose id the
+    ledger has never heard of gets its sent row now, rebuilt from the headers deliver() wrote (From,
+    From-Id, Date, X-Park, X-Kind, X-From-Host, X-Peer-Mid) and the body after the blank line, and
+    marked `recovered`. The file is never removed and never bounced. Returns how many rows landed."""
+    newd = box / "new"
+    try:
+        files = sorted((f for f in newd.iterdir() if f.is_file()), key=lambda p: p.name) if newd.is_dir() else []
+    except OSError:
+        return 0
+    n = 0
+    for f in files:
+        if f.name in sent or f.name in ended:
+            continue
+        try:
+            text = f.read_text(errors="replace")
+        except FileNotFoundError:
+            continue
+        except OSError as e:
+            _mail_unreadable(f, box.name, e)         # its fields cannot be recovered: aside, said, closed
+            continue
+        head, _, body = text.partition("\n\n")
+        meta = {}
+        for ln in head.splitlines():
+            k, _, v = ln.partition(": ")
+            meta[k.lower()] = v
+        try:
+            t = int(datetime.strptime(meta.get("date", ""), "%Y-%m-%dT%H:%M:%S%z").timestamp())
+        except (ValueError, TypeError, OverflowError):
+            try:
+                t = int(f.stat().st_mtime)
+            except OSError:
+                t = int(time.time())
+        row = {"t": t, "ev": "sent", "id": f.name, "from": meta.get("from", "?"),
+               "from_id": meta.get("from-id", ""), "to_id": box.name,
+               "body": body[:-1] if body.endswith("\n") else body,   # deliver() adds exactly one newline
+               "recovered": True}                                    # written at start, not by the send
+        if meta.get("x-park"):
+            row["park"] = True
+        if meta.get("x-kind"):
+            row["kind"] = meta["x-kind"]
+        row["from_host"] = meta.get("x-from-host", "")
+        if meta.get("x-peer-mid"):
+            row["originMid"] = meta["x-peer-mid"]
+        if not _tl_append("messages.jsonl", row):
+            _log("mail %s for %s stands in the inbox with no record of it and its row could not be "
+                 "written at start; it stays for the next start" % (f.name, box.name))
+            continue
+        sent.add(f.name)
+        n += 1
+        if row.get("originMid"):
+            peer_seen_add(row["originMid"])         # the dialer's re-relay of the unacked mid: a duplicate
+        _log("mail %s for %s stood in the inbox with no record of it (the restart cut the delivery "
+             "between the publish and the row); sent row written at start from its headers (a tracked "
+             "flag or a user-ask record lived only on the row and cannot be recovered)" % (f.name, box.name))
+    return n
+
 def _sweep_unfinished_writes():
-    """Bus start: the one event at which no writer of ours is running, so every temp on disk is a
-    write that never finished (review find, 2026-09-08). A maildir temp is a message that stopped
-    before its publish; deliver() publishes first and writes its row second (the collision fold),
-    so such a temp normally has no row and is simply removed — a row saying "sent" beside one (a
-    bus that wrote row-first) is closed the same way, so no receipt reads pending forever for a
-    message nothing lists. The relay leg (row, then outbox_put) has that window still, leaving a
-    `<mid>.json.tmp-*` temp and no record;
-    _atomic_json_put's own failure path removes its temp, so only a crash leaves one. Each temp is
-    removed (never published: it may be half-written), its id's ledger is closed with a terminal
-    `bounced` row when a sent row stands with no terminal row yet, each is said on stderr, and one
-    bell row reports the sweep. A readbox temp is removed and said; a receipt is not a message. The
-    `.corrupt-*` sidecars are evidence and are never touched."""
+    """Bus start: the one event at which no writer of ours is running, so what a crash left on disk
+    is reconciled with the ledger (review find, 2026-09-08). Three passes.
+
+    A maildir temp is a message that stopped before its publish, or the leftover of one that landed.
+    deliver() publishes first (link, then the temp's unlink) and writes its row second, so a temp
+    with no row is a message that never reached the inbox and is simply removed. A temp beside a
+    message that STANDS in new/ or cur/ is a publish that landed whose temp could not be removed
+    (_publish_new tolerates that unlink's failure): the temp goes and the ledger is left alone. The
+    first cut closed such an id as refused, so a message the recipient had already read read refused
+    to its sender after every restart. A temp beside a sent row with the message nowhere (a bus that
+    wrote row-first) is closed with a terminal `bounced` row, so no receipt reads pending forever for
+    a message nothing lists.
+
+    A message in new/ with NO sent row is the residual of the publish-first order: a bus killed
+    between the publish and the row, or a take-back whose unlink was refused. The mail is legitimate
+    and the next read delivers it, so it is never removed and never bounced (a bounced row with no
+    sent row is invisible to the sender's receipts): its sent row is rebuilt from the file's headers
+    (_rebuild_rows_for_rowless_mail), marked `recovered`, so the sender's receipt, the timeline and
+    the courier see it. A tracked flag or a user-ask record lived only on the row and cannot be
+    recovered. A relayed message's origin mid is marked seen, so the dialer's re-relay of the unacked
+    mid is acked as a duplicate instead of delivered twice. A file that cannot be read goes aside the
+    way read_box sends one (_mail_unreadable). A row that cannot be written now leaves the file for
+    the next start.
+
+    The relay leg (row, then outbox_put) has its window still, leaving a `<mid>.json.tmp-*` temp and
+    no record; _atomic_json_put's own failure path removes its temp, so only a crash leaves one. Each
+    temp is removed (never published: it may be half-written), its id's ledger is closed when a sent
+    row stands with no terminal row yet, each is said on stderr, and one bell row reports the sweep.
+    A readbox temp is removed and said; a receipt is not a message. The `.corrupt-*` sidecars are
+    evidence and are never touched."""
     sent, ended = set(), set()
     try:
         for line in (TLDIR / "messages.jsonl").read_text(errors="replace").splitlines():
@@ -2528,7 +2628,7 @@ def _sweep_unfinished_writes():
                 return True
         return False
 
-    removed, closed = 0, 0
+    removed, closed, standing, recovered = 0, 0, 0, 0
     try:
         boxes = [b for b in MAILROOT.iterdir() if b.is_dir()] if MAILROOT.is_dir() else []
     except OSError:
@@ -2538,19 +2638,26 @@ def _sweep_unfinished_writes():
         try:
             temps = [f for f in tmpd.iterdir() if f.is_file()] if tmpd.is_dir() else []
         except OSError:
-            continue
+            temps = []
         for f in temps:
+            published = (box / "new" / f.name).exists() or (box / "cur" / f.name).exists()
             try:
                 f.unlink()
             except OSError as e:
                 _log("unfinished mail %s for %s could not be removed (%s)" % (f.name, box.name, e))
                 continue
             removed += 1
+            if published:
+                standing += 1
+                _log("unfinished mail %s for %s removed at start; the message itself had reached the inbox "
+                     "(a temp its publish could not remove), its ledger left alone" % (f.name, box.name))
+                continue
             done = _close(f.name, {"to_id": box.name, "why": WHY_STOPPED_BEFORE_PUBLISH})
             closed += done
             _log("unfinished mail %s for %s removed at start%s"
                  % (f.name, box.name, "; its sent row stood with no message published, now closed as refused"
                     if done else ""))
+        recovered += _rebuild_rows_for_rowless_mail(box, sent, ended)
     for store, why in ((OUTBOX, WHY_STOPPED_BEFORE_PARK), (READBOX, None)):
         try:
             hostdirs = [h for h in store.iterdir() if h.is_dir()] if store.is_dir() else []
@@ -2572,9 +2679,18 @@ def _sweep_unfinished_writes():
                 if why:
                     closed += _close(mid, {"host": hostdir.name, "why": why})
                 _log("unfinished %s record %s for %s removed at start" % (store.name, f.name, hostdir.name))
+    parts = []
     if removed:
-        _refused_notice("mail service start: %d unfinished mail write(s) from before the restart removed; "
-                        "%d sender receipt(s) now read refused (the log names each)" % (removed, closed))
+        parts.append("%d unfinished mail write(s) from before the restart removed; %d sender receipt(s) now "
+                     "read refused" % (removed, closed))
+        if standing:
+            parts.append("%d of them the temp of a message that had reached the inbox, its ledger left alone"
+                         % standing)
+    if recovered:
+        parts.append("%d delivered message(s) stood in an inbox with no sent row (the restart cut the delivery "
+                     "after the publish); each has its row now" % recovered)
+    if parts:
+        _refused_notice("mail service start: %s (the log names each)" % "; ".join(parts))
 
 def serve():
     STATE.mkdir(parents=True, exist_ok=True)

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -448,7 +448,30 @@ NOT_RECORDED_TEXT = ("the send was not recorded (the message log could not be wr
 WHY_NOT_PUBLISHED = "not published: "
 WHY_NOT_PARKED = "not parked: the outbox record could not be written"
 WHY_OUTBOX_UNREADABLE = "outbox record unreadable, moved aside"
-REFUSAL_WHYS = (WHY_NOT_PUBLISHED, "not parked:", WHY_OUTBOX_UNREADABLE)
+WHY_INBOX_UNREADABLE = "inbox file unreadable, moved aside"    # read_box's move-aside (review find, 2026-09-08)
+REFUSAL_WHYS = (WHY_NOT_PUBLISHED, "not parked:", WHY_OUTBOX_UNREADABLE, WHY_INBOX_UNREADABLE)
+
+_DASHBOARD_MISSED = [False]   # transition-only logging for _refused_notice's kernel leg
+
+def _refused_notice(text):
+    """A fault the USER should see, not only whoever reads server.log (review find, 2026-09-08): the
+    bus has no dashboard surface of its own, so the text goes to the kernel (POST /postal-notice),
+    which files it as one bell row under the `refused` kind, the kind every state file the kernel
+    could not read or write already wears, so a mute on machine-sync notices never hides it. The
+    stderr line is written here too: a caller says a fault once, in one place, and both surfaces
+    carry it. Best-effort toward the kernel: one that is down, or too old to know the route, leaves
+    the log line and the ledger row standing, and the miss is said once per episode."""
+    _log(text)
+    r = _kernel_post("/postal-notice", {"text": text})
+    if r is not None and r.get("ok"):
+        if _DASHBOARD_MISSED[0]:
+            _DASHBOARD_MISSED[0] = False
+            _log("the dashboard hears the mail service's notices again")
+        return
+    if not _DASHBOARD_MISSED[0]:
+        _DASHBOARD_MISSED[0] = True
+        _log("the dashboard could not be told (the kernel %s); the log and the ledger still carry it"
+             % ("refused the notice" if r else "did not answer"))
 
 _REFUSAL_SAID = {}       # site -> True while that site's refusal episode is open (said once, not per pass)
 
@@ -475,21 +498,29 @@ def _publish_new(tmp, dst):
     back to an exists-check + rename, said once: that check is not atomic, but a collision there
     needs two writers minting the same 128-bit name in the same instant, so the protection is the
     same in practice. Raises OSError (FileExistsError on a collision); the caller accounts and
-    refuses."""
+    refuses.
+
+    EVERY link() refusal but a collision takes the fallback (review find, 2026-09-08). The first
+    cut named six errnos as "no hard links here" (EPERM, EOPNOTSUPP, ENOTSUP, ENOSYS, EMLINK,
+    EXDEV) and re-raised the rest as real faults, but filesystems answer that question in more
+    ways than six (EACCES and EINVAL on some network and FUSE mounts), and an errno off the list
+    turned EVERY send on such a machine into a refusal. The checked rename is the right answer to
+    all of them: a real fault (EIO, ENOSPC) fails the rename the same way, so nothing is ever
+    delivered over a fault, and the fallback line names the errno so a fault reads as one."""
     try:
         os.link(tmp, dst)
     except FileExistsError:
         raise
     except OSError as e:
-        if e.errno not in (errno.EPERM, errno.EOPNOTSUPP, errno.ENOTSUP, errno.ENOSYS,
-                           errno.EMLINK, errno.EXDEV):
-            raise                                    # a real fault (EIO, ENOSPC…), not "no links here"
         if not _LINK_FALLBACK_SAID[0]:
             _LINK_FALLBACK_SAID[0] = True
             _log("mail publish: hard links unavailable here (%s) — falling back to a checked rename" % e)
         if dst.exists():
             raise FileExistsError(str(dst))
-        tmp.rename(dst)
+        # os.rename, not Path.rename: on Python 3.10 pathlib binds os.rename at import, so a fault
+        # staged on os.rename never reaches Path.rename there and a real fault would publish over it
+        # (review find, 2026-09-08: the fallback test was green on 3.11+ and red on 3.10 for this alone).
+        os.rename(tmp, dst)
         return
     try:
         tmp.unlink()
@@ -618,15 +649,51 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
 _UNREADABLE_SAID = set()   # (path, errno) already logged this bus run — said once, not per poll
 
 def _say_unreadable_once(path, exc, where):
-    """One _log line per (file, errno) per bus run for a file a listing had to skip. A poll loop
-    (/inbox, /drain, every exchange) re-meets the same file every pass; the registry keeps the
-    fact loud and the log readable."""
+    """One _log line per (file, errno) per bus run for a file a listing had to skip AND could not move
+    aside (the fallback under _mail_unreadable / _list_json_records). A poll loop (/inbox, /drain,
+    every exchange) re-meets the same file every pass; the registry keeps the fact loud and the log
+    readable."""
     key = (str(path), getattr(exc, "errno", None))
     if key in _UNREADABLE_SAID:
         return
     _UNREADABLE_SAID.add(key)
-    _log("%s: %s is unreadable (errno %s: %s) — skipped and left in place; the rest is served"
-         % (where, path.name, exc.errno, exc.strerror or exc))
+    _log("%s: %s is unreadable (errno %s: %s) and could not be moved aside: skipped and left in place; "
+         "the rest is served" % (where, path.name, exc.errno, exc.strerror or exc))
+
+def _aside_name(f):
+    """`<name>.corrupt-<utc stamp>[-n]` beside `f`: the kernel stores' quarantine naming, so one
+    convention reads across every store romp moves a bad file aside in."""
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    aside, n = f.with_name("%s.corrupt-%s" % (f.name, stamp)), 0
+    while aside.exists():                            # a second one in the same second
+        n += 1
+        aside = f.with_name("%s.corrupt-%s-%d" % (f.name, stamp, n))
+    return aside
+
+def _mail_unreadable(f, sid, exc):
+    """One inbox file in new/ that cannot be read (EACCES, EIO): moved ASIDE, once, to
+    `<mailbox>/<name>.corrupt-<utc stamp>`, beside new/, so no listing (read_box, the sweeps,
+    restore) meets it again, and never deleted, so the evidence survives; with a terminal
+    `bounced` row (WHY_INBOX_UNREADABLE) closing the sender's receipt as refused, one stderr line
+    and one bell row on the dashboard (review find, 2026-09-08). The first cut skipped the file in
+    place and said it once in the log: that left the pending marker latched (the retry pass
+    re-pushed a no-op every interval), the sender's receipt pending forever, the stuck-mail
+    warning and the orphan sweep unable to touch it, and nothing the user could see. A file that
+    cannot be moved either is the fallback: skipped, said once per (file, errno)."""
+    aside = _aside_name(f.parent.parent / f.name)
+    try:
+        os.replace(f, aside)
+    except FileNotFoundError:
+        return                                       # consumed or recalled meanwhile: nothing to account
+    except OSError:
+        _say_unreadable_once(f, exc, "inbox %s" % sid)
+        return
+    who = _name_for_id(sid) or sid[:8]
+    _refused_notice("mail for %s: %s could not be read (errno %s: %s); moved aside to %s; the sender's "
+                    "receipt reads refused" % (who, f.name, exc.errno, exc.strerror or exc, aside.name))
+    _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": f.name, "to_id": sid,
+                                  "why": "%s (errno %s)" % (WHY_INBOX_UNREADABLE, exc.errno)})
+    _mark_pending(sid)                               # new/ may be empty now → drop the marker
 
 def read_box(sid, consume):
     if not _safe_id(sid):            # reject traversal in the id from /inbox, /drain
@@ -645,13 +712,15 @@ def read_box(sid, consume):
             continue
         try:
             text = f.read_text(errors="replace")
+        except FileNotFoundError:
+            continue                                 # consumed or recalled between the listing and the read
         except OSError as e:
             # One unreadable file (EACCES, EIO) used to raise out of the whole read — and do_GET
             # has no handler, so /inbox and /drain answered NOTHING, on every poll, and the session
-            # got no mail at all while the Stop-hook drain hid the traceback (2026-09-08). Skip the
-            # file and serve the rest. It stays in place as evidence, never deleted, and is said
-            # ONCE per file per bus run — not per poll.
-            _say_unreadable_once(f, e, "inbox %s" % sid)
+            # got no mail at all while the Stop-hook drain hid the traceback (2026-09-08). The file
+            # is moved aside once, said once, and its ledger closed (_mail_unreadable); the rest of
+            # the box is served.
+            _mail_unreadable(f, sid, e)
             continue
         head, _, body = text.partition("\n\n")
         meta = {}
@@ -1489,6 +1558,14 @@ def _sweep_orphans():
                 continue
             try:
                 text = f.read_text(errors="replace")
+            except FileNotFoundError:
+                continue
+            except OSError as e:
+                # a dead recipient's box has no drain to meet an unreadable file, so the sweep moves
+                # it aside the way read_box does (review find, 2026-09-08); before, it skipped the
+                # file on every pass and the marker stayed latched for a session that will never read
+                _mail_unreadable(f, box.name, e)
+                continue
             except Exception:
                 continue
             meta = {}
@@ -1536,7 +1613,10 @@ def _sweep_orphans():
                 pass
         _mark_pending(box.name)                         # bounced orphans may have emptied new/
         try:                                            # tidy: drop the mailbox if nothing's left
-            if all(not any((box / d).iterdir()) for d in ("new", "cur", "tmp") if (box / d).is_dir()):
+            if all(not any((box / d).iterdir()) for d in ("new", "cur", "tmp") if (box / d).is_dir()) \
+                    and not any(p.is_file() for p in box.iterdir()):
+                # …and no `.corrupt-*` sidecar beside the three dirs: a file moved aside is evidence
+                # the tidy must not sweep away with the empty box (review find, 2026-09-08)
                 shutil.rmtree(box, ignore_errors=True)
         except Exception:
             pass
@@ -2381,10 +2461,97 @@ def _reconcile_markers():
     except Exception as e:
         _log("marker reconcile failed: %s" % e)
 
+WHY_STOPPED_BEFORE_PUBLISH = WHY_NOT_PUBLISHED + "the mail service stopped before the message reached the inbox"
+WHY_STOPPED_BEFORE_PARK = "not parked: the mail service stopped before the outbox record was written"
+
+def _sweep_unfinished_writes():
+    """Bus start: the one event at which no writer of ours is running, so every temp on disk is a
+    write that never finished (review find, 2026-09-08). deliver() writes the sent row and THEN
+    publishes: a crash between the two left the row saying "sent" and the message in <mailbox>/tmp/,
+    where nothing lists it, a phantom the sender's receipt read as pending forever. The relay leg
+    (row, then outbox_put) had the same window, leaving a `<mid>.json.tmp-*` temp and no record;
+    _atomic_json_put's own failure path removes its temp, so only a crash leaves one. Each temp is
+    removed (never published: it may be half-written), its id's ledger is closed with a terminal
+    `bounced` row when a sent row stands with no terminal row yet, each is said on stderr, and one
+    bell row reports the sweep. A readbox temp is removed and said; a receipt is not a message. The
+    `.corrupt-*` sidecars are evidence and are never touched."""
+    sent, ended = set(), set()
+    try:
+        for line in (TLDIR / "messages.jsonl").read_text(errors="replace").splitlines():
+            try:
+                o = json.loads(line)
+            except ValueError:
+                continue
+            if not isinstance(o, dict) or not o.get("id"):
+                continue
+            if o.get("ev") == "sent":
+                sent.add(str(o["id"]))
+            elif o.get("ev") in ("bounced", "recall"):
+                ended.add(str(o["id"]))
+    except OSError:
+        pass
+
+    def _close(mid, row):
+        if mid in sent and mid not in ended:
+            row.update({"t": int(time.time()), "ev": "bounced", "id": mid})
+            if _tl_append("messages.jsonl", row):
+                ended.add(mid)
+                return True
+        return False
+
+    removed, closed = 0, 0
+    try:
+        boxes = [b for b in MAILROOT.iterdir() if b.is_dir()] if MAILROOT.is_dir() else []
+    except OSError:
+        boxes = []
+    for box in boxes:
+        tmpd = box / "tmp"
+        try:
+            temps = [f for f in tmpd.iterdir() if f.is_file()] if tmpd.is_dir() else []
+        except OSError:
+            continue
+        for f in temps:
+            try:
+                f.unlink()
+            except OSError as e:
+                _log("unfinished mail %s for %s could not be removed (%s)" % (f.name, box.name, e))
+                continue
+            removed += 1
+            done = _close(f.name, {"to_id": box.name, "why": WHY_STOPPED_BEFORE_PUBLISH})
+            closed += done
+            _log("unfinished mail %s for %s removed at start%s"
+                 % (f.name, box.name, "; its sent row stood with no message published, now closed as refused"
+                    if done else ""))
+    for store, why in ((OUTBOX, WHY_STOPPED_BEFORE_PARK), (READBOX, None)):
+        try:
+            hostdirs = [h for h in store.iterdir() if h.is_dir()] if store.is_dir() else []
+        except OSError:
+            continue
+        for hostdir in hostdirs:
+            try:
+                temps = sorted(hostdir.glob("*.json.tmp-*"))
+            except OSError:
+                continue
+            for f in temps:
+                try:
+                    f.unlink()
+                except OSError as e:
+                    _log("unfinished %s record %s could not be removed (%s)" % (store.name, f.name, e))
+                    continue
+                removed += 1
+                mid = f.name.split(".json.tmp-", 1)[0]
+                if why:
+                    closed += _close(mid, {"host": hostdir.name, "why": why})
+                _log("unfinished %s record %s for %s removed at start" % (store.name, f.name, hostdir.name))
+    if removed:
+        _refused_notice("mail service start: %d unfinished mail write(s) from before the restart removed; "
+                        "%d sender receipt(s) now read refused (the log names each)" % (removed, closed))
+
 def serve():
     STATE.mkdir(parents=True, exist_ok=True)
     MAILROOT.mkdir(parents=True, exist_ok=True)
     _reconcile_markers()
+    _sweep_unfinished_writes()             # temps a crash left: removed, said, their ledgers closed (2026-09-08)
     if peers_on():
         _seed_peers_from_kernel()          # a restarted bus re-learns its peers without waiting for a transition
     try:
@@ -2850,19 +3017,23 @@ def _list_json_records(d, where, close_ledger_for=None):
     outbox record was mail parked for nobody with no trace anywhere (2026-09-08). The file's stat is
     fingerprinted BEFORE the read: if it changed by the time the parse failed, a writer's atomic
     rewrite raced the read and the file is left alone for the next pass — a torn read of a healthy
-    record is never moved aside. An unreadable file (EACCES, EIO) is not corruption: skipped, said
-    once per bus run.
+    record is never moved aside. An unreadable file (EACCES, EIO) is moved aside the same way
+    (review find, 2026-09-08): the first cut skipped it in place, said once, which re-skipped it
+    on every exchange with its mail parked for nobody, the shape the quarantine exists to end. Only
+    a file that cannot be moved either stays, skipped and said once per (file, errno).
 
     `close_ledger_for` (the OUTBOX's host): a parked message's filename IS its mid, and moving the
     record aside is that message's terminal event — without a row the sender's receipt reads
     "pending (not read yet)" forever. A terminal `bounced` row (WHY_OUTBOX_UNREADABLE) is appended
-    best-effort after the move; the quarantine itself never depends on the row landing."""
+    best-effort after the move; the quarantine itself never depends on the row landing. The move is
+    said on stderr and as one bell row on the dashboard (_refused_notice)."""
     out = []
     try:
         files = sorted(d.glob("*.json"))
     except OSError:
         return out
     for f in files:
+        st = None
         try:
             st = f.stat()
             rec = json.loads(f.read_text())
@@ -2873,27 +3044,30 @@ def _list_json_records(d, where, close_ledger_for=None):
         except FileNotFoundError:
             continue                                 # gone between the glob and the read (deleted, moved)
         except OSError as e:
-            _say_unreadable_once(f, e, where)
-            continue
+            if st is None:                           # the stat itself failed: no fingerprint to move by
+                _say_unreadable_once(f, e, where)
+                continue
+            reason = "unreadable, errno %s: %s" % (e.errno, e.strerror or e)
+            fault = e
         except ValueError as e:
-            reason = e
+            reason, fault = e, None
         try:
             cur = f.stat()
             if (cur.st_ino, cur.st_mtime_ns, cur.st_size) != (st.st_ino, st.st_mtime_ns, st.st_size):
                 continue                             # rewritten under us: a torn read, not a torn file
-            stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
-            aside, n = f.with_name("%s.corrupt-%s" % (f.name, stamp)), 0
-            while aside.exists():                    # a second corrupt file in the same second
-                n += 1
-                aside = f.with_name("%s.corrupt-%s-%d" % (f.name, stamp, n))
+            aside = _aside_name(f)
             os.replace(f, aside)
         except FileNotFoundError:
             continue                                 # a sibling lister moved it first
         except OSError as e:
-            _log("%s: %s could not be parsed (%s) and could not be moved aside (%s)" % (where, f.name, reason, e))
+            if fault is not None:
+                _say_unreadable_once(f, fault, where)
+            else:
+                _say_unreadable_once(f, e, where)    # said once per (file, errno), not per pass
             continue
-        _log("%s: %s could not be parsed (%s); moved aside to %s — the rest is served"
-             % (where, f.name, reason, aside.name))
+        _refused_notice("%s: %s could not be %s (%s); moved aside to %s; the rest is served%s"
+                        % (where, f.name, "read" if fault is not None else "parsed", reason, aside.name,
+                           "; the sender's receipt reads refused" if close_ledger_for else ""))
         if close_ledger_for:
             _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": f.stem,
                                           "host": close_ledger_for, "why": WHY_OUTBOX_UNREADABLE})
@@ -2979,10 +3153,18 @@ def _read_arrived(host, r):
     """One read receipt from a peer: ours → log the exec (or its unexec retraction) into
     messages.jsonl, where _sent_receipts joins it to the cross-host sent event by the relay mid.
     Origin-stamped (the mail was forwarded through us) → re-queue one hop backward with the stamp
-    stripped, so it can never loop — the same one-hop-max rule relays live by."""
+    stripped, so it can never loop — the same one-hop-max rule relays live by.
+
+    Returns True iff the receipt was APPLIED (the row landed, or the forward is parked) and False
+    when it was not, so the caller keeps it ON THE WIRE (review find, 2026-09-08): the dialer
+    withholds its readAck, the dialed side names it in the response's `readsKept`, and the peer
+    re-sends it next exchange. Before this readbox_put's new False was ignored: a forwarded receipt
+    the store could not take was acked and gone, where the base's raised OSError had aborted the
+    exchange and left it to retry. A receipt that can NEVER apply (an unaddressable mid, an origin
+    no peer of ours owns) reads as applied: there is nothing a retry could change."""
     mid = (r or {}).get("mid") or ""
     if not _safe_id(mid):
-        return
+        return True
     origin = str((r or {}).get("origin") or "")
     if origin and origin != self_host():
         if PEERS.get(origin):                    # only toward a peer the kernel told us about
@@ -2991,14 +3173,14 @@ def _read_arrived(host, r):
                 fwd["dmid"] = r.get("dmid")
             if r.get("unread"):
                 fwd["unread"] = True
-            readbox_put(origin, fwd)
-        return
+            return readbox_put(origin, fwd)      # False (said by readbox_put) → the peer re-sends it
+        return True
     ev = "unexec" if r.get("unread") else "exec"
     row = {"t": int(r.get("t") or time.time()), "ev": ev, "id": mid}
     d = str((r or {}).get("dmid") or "")
     if _safe_id(d):
         row["dmid"] = d   # the recipient's own delivery mid → the timeline's exact turn join (2026-08-06)
-    _tl_append("messages.jsonl", row)
+    return _tl_append("messages.jsonl", row)
 
 def _bounce_apply(host, b):
     """A peer refused one of our parked messages — return it to the SENDER as a bus-authored note,
@@ -3008,7 +3190,15 @@ def _bounce_apply(host, b):
     the outbox only once the ledger holds its last word and the sender holds the note; before this
     the delete came FIRST and a crash between it and the row lost the accounting entirely. If either
     step fails the record stays: the next exchange re-relays it, the peer's dedupe re-bounces it,
-    and the attempt repeats (a repeated terminal row is harmless — _sent_receipts keys by id)."""
+    and the attempt repeats (a repeated terminal row is harmless — _sent_receipts keys by id).
+
+    Any OTHER failure of the note is bounded the same way (review find, 2026-09-08): a mailbox that
+    cannot be made, a temp that cannot be written (ENOSPC lands here, before the row), an unsafe
+    sender id: each used to escape this function and abort the WHOLE exchange, and with the record
+    now kept until it is accounted the peer re-bounced it next exchange and the abort recurred
+    forever, every other relay, ack and receipt in that exchange lost with it. The record stays, the
+    exchange goes on, the next one retries the note; said once per message, on stderr and as a bell
+    row, since a fault that recurs on every exchange is one the user should see."""
     mid = (b or {}).get("mid") or ""
     msg = outbox_get(host, mid)
     if not msg:
@@ -3028,7 +3218,18 @@ def _bounce_apply(host, b):
         except DeliveryNotRecorded as e:
             _log("bounce for %s from %s: the return note was refused (%s) — the record stays parked" % (mid, host, e))
             return
+        except Exception as e:
+            if mid not in _NOTE_FAILED_SAID:
+                _NOTE_FAILED_SAID.add(mid)
+                _refused_notice("bounce for %s from %s: the return note to %s could not be delivered (%s: %s); "
+                                "the record stays parked and the note is retried next exchange"
+                                % (mid, host, _name_for_id(msg["frm_id"]) or str(msg["frm_id"])[:8],
+                                   type(e).__name__, e))
+            return
+        _NOTE_FAILED_SAID.discard(mid)
     outbox_del(host, mid)
+
+_NOTE_FAILED_SAID = set()   # mids whose return note failed outright (not a refusal); said once each
 
 _LOCAL_PRESENCE_GOOD = [[], False]   # [rows, ever_answered] — the last ANSWERED local listing
 _PRESENCE_SERVE_WARNED = [False]     # transition-only logging, the _REG_SERVE_WARNED idiom
@@ -3192,7 +3393,6 @@ def quarantine_decide(mid, action, text=None, feedback=None):
     if rec is None:
         return False, "no held message '%s'" % mid
     if action == "deny":
-        quarantine_del(mid)
         note = " ".join(str(feedback or "").split())
         if note and rec.get("origin") and rec.get("frm"):
             gist = " ".join(str(rec.get("body") or "").split())[:60]
@@ -3200,9 +3400,18 @@ def quarantine_decide(mid, action, text=None, feedback=None):
                     "delivered. Note from the reviewer: %s"
                     % (rec.get("to") or "?", gist, "…" if len(gist) == 60 else "", note))
             fb_mid = _unique()
-            outbox_put(rec["origin"], {"mid": fb_mid, "to": rec["frm"], "frm": "Romp Postal Service",
-                                       "frm_id": "", "body": body, "kind": "coordinate"})
+            # The note parks BEFORE the hold is dropped, and a park that fails refuses the deny
+            # (review find, 2026-09-08): outbox_put's False was ignored here, so a deny whose note
+            # the outbox could not take dropped the held message, answered ok, and the reviewer's
+            # words went nowhere with nothing saying so. The hold stands; the user retries, or
+            # denies without a note.
+            if not outbox_put(rec["origin"], {"mid": fb_mid, "to": rec["frm"], "frm": "Romp Postal Service",
+                                              "frm_id": "", "body": body, "kind": "coordinate"}):
+                return False, ("the note to the sender could not be parked for %s (the outbox could not be "
+                               "written), so nothing was done: the held message is untouched; retry, or "
+                               "deny without a note" % rec["origin"])
             _peer_wake(rec["origin"]).set()
+        quarantine_del(mid)
         return True, None
     if action == "approve":
         body = str(text) if (text is not None and str(text).strip()) else (rec.get("body") or "")
@@ -3353,7 +3562,11 @@ def _relay_in(host, m, token_proven=False):
         fh, hit = (peer_route(to_id) if to_id else peer_route(to))
         if fh and fh != host and not (hit or {}).get("via"):
             if outbox_get(fh, mid) is None:          # a resend while we hold it forwards nothing twice
-                outbox_put(fh, dict(m, origin=host))
+                if not outbox_put(fh, dict(m, origin=host)):
+                    # not parked (said by outbox_put): 'hold' would tell the sender its mail is on
+                    # its way when nothing holds it (review find, 2026-09-08); silence instead, so
+                    # the sender's outbox keeps it and re-relays it next exchange
+                    return "retry", None
             return "hold", None
     # death-ruling gate — the relay leg's honesty arms (2026-08-31; the sending resolver got these
     # in the answered-but-absent round, this inbound leg never did): an UNANSWERED listing proves
@@ -3507,9 +3720,11 @@ def peer_exchange_handle(data):
         _bounce_arrived(host, b)
     for ra in data.get("readAcks") or []:            # the dialer confirmed response-carried receipts
         readbox_del(host, ra)
-    for r in data.get("reads") or []:                # read receipts flowing back — ours or one hop onward
-        _read_arrived(host, r)
-    acks, bounces = [], []
+    reads_kept = []                                  # request-carried receipts we could NOT apply: named in
+    for r in data.get("reads") or []:                # the response so the dialer keeps them for its next
+        if not _read_arrived(host, r):               # request (additive; an older dialer ignores the key
+            reads_kept.append({"mid": (r or {}).get("mid"), "unread": bool((r or {}).get("unread"))})
+    acks, bounces = [], []                           # and drops them, exactly as before)
     for m in data.get("relays") or []:
         verdict, bounce = _relay_in(host, m, token_proven=True)   # past the HTTP gate = showed OUR serve token
         if verdict == "ack":
@@ -3540,7 +3755,8 @@ def peer_exchange_handle(data):
     return {"host": self_host(), "epoch": BUS_EPOCH, "proto": PEER_PROTO, "busId": BUS_ID,
             "presence": fleet_presence(host), "holds": holds_payload(host),
             "tier": my_tier_of(host),                # how WE hold the dialer's mail (display/mirror, never the gate)
-            "relays": rel, "acks": acks, "bounces": bounces, "reads": reads}, 200
+            "relays": rel, "acks": acks, "bounces": bounces, "reads": reads,
+            "readsKept": reads_kept}, 200            # see _read_arrived (2026-09-08)
 
 def build_exchange_request(host, wait=True):
     """The DIALER's request for one exchange. The relays are the outbox's oldest-first prefix under
@@ -3562,13 +3778,20 @@ def peer_exchange_apply(host, req_sent, resp):
     """The DIALER's half: fold one exchange response in. `req_sent` is the request that produced it —
     its included acks/bounces/readAcks are now delivered and leave the pending queue (kept on send
     failure), and its reads leave the readbox: a response means the dialed side processed the whole
-    request before answering, so request-carried receipts need no explicit ack."""
+    request before answering, so request-carried receipts need no explicit ack, except the ones the
+    dialed side names in `readsKept` (review find, 2026-09-08): those it could not apply, and they
+    stay parked for the next request. Likewise a response-carried read WE could not apply gets no
+    readAck, so the dialed side keeps it and re-sends it."""
     p = _pending(host)
     with _peer_lock:
         p["acks"] = [a for a in p["acks"] if a not in (req_sent.get("acks") or [])]
         p["bounces"] = [b for b in p["bounces"] if b not in (req_sent.get("bounces") or [])]
         p["readAcks"] = [a for a in p.get("readAcks") or [] if a not in (req_sent.get("readAcks") or [])]
+    kept = {(str(k.get("mid") or ""), bool(k.get("unread")))
+            for k in (resp.get("readsKept") or []) if isinstance(k, dict)}
     for r in req_sent.get("reads") or []:
+        if (str((r or {}).get("mid") or ""), bool((r or {}).get("unread"))) in kept:
+            continue                                 # the dialed side could not take it: it rides again
         readbox_del(host, r)
     PEER_STATE[host] = {"presence": resp.get("presence") or [], "epoch": resp.get("epoch"),
                         "holds": resp.get("holds") or [], "seenAt": int(time.time())}
@@ -3584,7 +3807,8 @@ def peer_exchange_apply(host, req_sent, resp):
     for b in resp.get("bounces") or []:
         _bounce_arrived(host, b)
     for r in resp.get("reads") or []:                # response-carried receipts: apply, ack on the NEXT dial
-        _read_arrived(host, r)
+        if not _read_arrived(host, r):
+            continue                                 # not applied → no readAck: the dialed side re-sends it
         with _peer_lock:
             p["readAcks"].append({"mid": r.get("mid"), "unread": bool(r.get("unread"))})
     for m in resp.get("relays") or []:

--- a/tests/test_awaiting_peer_matrix.py
+++ b/tests/test_awaiting_peer_matrix.py
@@ -39,6 +39,11 @@ def _msg(i, f, t_, ts, kind=None, body="x"):
     return json.dumps(r)
 
 
+def _bounced(i, ts, why="not published: the mail service stopped before the message reached the inbox"):
+    """The bus's terminal row for message m<i>: refused, or destroyed unread (review find, 2026-09-08)."""
+    return json.dumps({"id": "m%d" % i, "ev": "bounced", "t": ts, "why": why})
+
+
 class _Base(unittest.TestCase):
     def setUp(self):
         self._saved = jd.STATE
@@ -178,6 +183,8 @@ class MatrixCloserGate(_Base):
             [_msg(1, SID, MGR, T0, "question"), _msg(2, MGR, SID, T0 + 5, "delegate")],
             [_msg(1, SID, MGR, T0, None, "QUESTION: which port?")],       # legacy kindless ask
             [_msg(1, SID, "peer:otherbox", T0, "question")],              # cross-host, relay-keyed
+            [_msg(1, SID, MGR, T0, "question"), _bounced(1, T0 + 1)],     # refused: never reached anyone
+            [_msg(1, SID, MGR, T0, "question"), _msg(2, MGR, SID, T0 + 5, "coordinate"), _bounced(2, T0 + 6)],
         ]
         for rows in grid:
             self._log(rows)
@@ -186,6 +193,23 @@ class MatrixCloserGate(_Base):
         # and where the peer IS alive, the user-facing graph agrees with the gate too
         self._log([_msg(1, SID, MGR, T0, "question")])
         self.assertTrue(jd._open_peer_asks(SID) and SID in km._wait_for_graph(NOW, {SID, MGR}))
+
+    def test_a_refused_question_is_no_open_ask_for_either_reader(self):
+        # A sent row a terminal `bounced` row closed never reached the recipient (review find,
+        # 2026-09-08): the bus refused it (its publish failed after the row) or destroyed it unread, so
+        # neither reader counts it as an ask, nor as an answer. Mutant: either reader's `ended` filter
+        # removed (the agreement test above would still pass with both wrong).
+        def km_open(sid):
+            last_any, last_ask, _aw = km._postal_wait_maps()
+            return any(f == sid and last_any.get((p, sid), 0) < meta[0]
+                       for (f, p), meta in last_ask.items())
+        self._log([_msg(1, SID, MGR, T0, "question"), _bounced(1, T0 + 1)])
+        self.assertFalse(jd._open_peer_asks(SID), "the gate: no open ask")
+        self.assertFalse(km_open(SID), "the wait maps: no open ask")
+        self.assertNotIn(SID, km._wait_for_graph(NOW, {SID, MGR}), "the card wears none")
+        self._log([_msg(1, SID, MGR, T0, "question"), _msg(2, MGR, SID, T0 + 5, "coordinate"), _bounced(2, T0 + 6)])
+        self.assertTrue(jd._open_peer_asks(SID), "a bounced reply answers nothing: the gate")
+        self.assertTrue(km_open(SID), "a bounced reply answers nothing: the wait maps")
 
 
 class TwinsKeyMailByStableId(_Base):

--- a/tests/test_awaiting_peer_matrix.py
+++ b/tests/test_awaiting_peer_matrix.py
@@ -196,7 +196,8 @@ class MatrixCloserGate(_Base):
 
     def test_a_refused_question_is_no_open_ask_for_either_reader(self):
         # A sent row a terminal `bounced` row closed never reached the recipient (review find,
-        # 2026-09-08): the bus refused it (its publish failed after the row) or destroyed it unread, so
+        # 2026-09-08): the bus gave up on it (a write a crash cut short, a file it could not read) or
+        # destroyed it unread, so
         # neither reader counts it as an ask, nor as an answer. Mutant: either reader's `ended` filter
         # removed (the agreement test above would still pass with both wrong).
         def km_open(sid):

--- a/tests/test_kernel_await_release.py
+++ b/tests/test_kernel_await_release.py
@@ -256,8 +256,9 @@ class MailKeyedByStableId(_AwaitBase):
 
 class RefusedSendsAreNoAsk(_AwaitBase):
     """A sent row whose id a terminal `bounced` row closed never reached the recipient (review find,
-    2026-09-08): the bus writes the sent row BEFORE it publishes and closes a failed publish, a peer's
-    refusal or the orphan sweep's destroy with a `bounced` row on the same id. The readers ignored `ev`,
+    2026-09-08): the bus closes a message it had to give up on — a peer's refusal, the orphan sweep's
+    destroy, an unreadable inbox file, a write a crash cut short — with a `bounced` row on the same id
+    (a publish it refuses outright writes no row at all). The readers ignored `ev`,
     so a refused QUESTION read as an open ask (the asker's card wore it, the debt reminder counted it)
     until the recipient happened to send anything, and a bounced reply read as answering the pair.
     Mutant: the `ended` filter removed."""

--- a/tests/test_kernel_await_release.py
+++ b/tests/test_kernel_await_release.py
@@ -254,5 +254,46 @@ class MailKeyedByStableId(_AwaitBase):
         self.assertEqual(last_await.get((A, self.X)), 100)
 
 
+class RefusedSendsAreNoAsk(_AwaitBase):
+    """A sent row whose id a terminal `bounced` row closed never reached the recipient (review find,
+    2026-09-08): the bus writes the sent row BEFORE it publishes and closes a failed publish, a peer's
+    refusal or the orphan sweep's destroy with a `bounced` row on the same id. The readers ignored `ev`,
+    so a refused QUESTION read as an open ask (the asker's card wore it, the debt reminder counted it)
+    until the recipient happened to send anything, and a bounced reply read as answering the pair.
+    Mutant: the `ended` filter removed."""
+
+    BOUNCED = "not published: the mail service stopped before the message reached the inbox"
+
+    def test_a_bounced_question_is_no_open_ask(self):
+        self._write([
+            {"ev": "sent", "id": "m1", "from_id": A, "to_id": B, "t": 100, "kind": "question", "body": "which port?"},
+            {"ev": "bounced", "id": "m1", "t": 101, "to_id": B, "why": self.BOUNCED},
+        ])
+        last_any, last_ask, _aw = km._postal_wait_maps()
+        self.assertNotIn((A, B), last_ask, "a refused question is no ask: no reply can ever close it")
+        self.assertNotIn((A, B), last_any, "and no message, either")
+        self.assertEqual(km._wait_for_graph(1000, {A, B}), {}, "so the asker wears no open ask")
+
+    def test_a_standing_question_beside_a_bounced_one_still_asks(self):
+        self._write([
+            {"ev": "sent", "id": "m1", "from_id": A, "to_id": B, "t": 100, "kind": "question", "body": "which port?"},
+            {"ev": "bounced", "id": "m1", "t": 101, "to_id": B, "why": self.BOUNCED},
+            {"ev": "sent", "id": "m2", "from_id": A, "to_id": B, "t": 200, "kind": "question", "body": "which port? (retry)"},
+        ])
+        _any, last_ask, _aw = km._postal_wait_maps()
+        self.assertEqual(last_ask[(A, B)][0], 200, "the retry that did land is the open ask")
+        self.assertEqual(km._wait_for_graph(1000, {A, B})[A]["since"], 200)
+
+    def test_a_bounced_reply_answers_nothing(self):
+        self._write([
+            {"ev": "sent", "id": "m1", "from_id": B, "to_id": A, "t": 100, "kind": "question", "body": "status?"},
+            {"ev": "sent", "id": "m2", "from_id": A, "to_id": B, "t": 200, "kind": "coordinate", "body": "all green"},
+            {"ev": "bounced", "id": "m2", "t": 201, "to_id": B, "why": self.BOUNCED},
+        ])
+        graph = km._wait_for_graph(1000, {A, B})
+        self.assertEqual(graph[B]["peerSid"], A, "the asker still waits: the reply never reached it")
+        self.assertEqual(km._peer_answered_at(B), 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_kernel_deliver.py
+++ b/tests/test_kernel_deliver.py
@@ -154,5 +154,58 @@ class Chrome(unittest.TestCase):
         self.assertEqual(len(prefixes), 2, "the directional message indicator is set on both ends")
 
 
+class PostalNoticeRoute(unittest.TestCase):
+    """POST /postal-notice: the bus's one door to the dashboard (review find, 2026-09-08). A mail file
+    it had to move aside, a return note it could not deliver, temps a crash left: each lands as one
+    row on the ring the bell mirrors, under the `refused` kind, with the bus's own text. Token-gated
+    like every POST; a body with no text files nothing."""
+
+    @classmethod
+    def setUpClass(cls):
+        import threading
+        from http.server import ThreadingHTTPServer
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+        cls.srv.server_close()
+
+    def _post(self, body, token=True):
+        import http.client
+        c = http.client.HTTPConnection("127.0.0.1", self.port, timeout=5)
+        hdrs = {"Content-Type": "application/json"}
+        if token:
+            hdrs["X-Romp-Token"] = km.TOKEN
+        c.request("POST", "/postal-notice", json.dumps(body), hdrs)
+        r = c.getresponse()
+        raw = r.read().decode()
+        c.close()
+        try:
+            return r.status, json.loads(raw or "{}")
+        except ValueError:
+            return r.status, raw
+
+    def test_a_notice_files_one_refused_row_and_an_empty_one_files_nothing(self):
+        before = km._sync_notice_count()
+        status, out = self._post({"text": "mail for web: 1.2_ab.TESTHOST could not be read (errno 13); moved aside"})
+        self.assertEqual((status, out.get("ok")), (200, True))
+        self.assertEqual(km._sync_notice_count(), before + 1, "exactly one row")
+        row = km._sync_notice_rows()[-1]
+        self.assertEqual((row["kind"], row["ok"]), ("refused", False), "the kind a fault wears, never a machine sync")
+        self.assertIn("moved aside", row["text"], "the bus's own text, unchanged")
+        status, out = self._post({"text": "   "})
+        self.assertEqual((status, out.get("ok")), (400, False))
+        self.assertIn("text required", out.get("error", ""))
+        status, out = self._post("not an object")
+        self.assertEqual(status, 400)
+        self.assertEqual(km._sync_notice_count(), before + 1, "a refused body files nothing")
+        status, _ = self._post({"text": "anonymous"}, token=False)
+        self.assertEqual(status, 403, "token-gated like every POST")
+        self.assertEqual(km._sync_notice_count(), before + 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_postal_peers.py
+++ b/tests/test_postal_peers.py
@@ -151,8 +151,8 @@ class _TwoBusHarness(unittest.TestCase):
                        pm.local_agents_checked, pmb.local_agents_checked)
         pm.self_host = lambda: "hosta"
         pmb.self_host = lambda: "hostb"
-        pm.local_agents = lambda: [{"name": "alpha", "id": "sid-a", "dir": ""}]
-        pmb.local_agents = lambda: [{"name": "beta", "id": "sid-b", "dir": ""}]
+        pm.local_agents = lambda threads=False: [{"name": "alpha", "id": "sid-a", "dir": ""}]
+        pmb.local_agents = lambda threads=False: [{"name": "beta", "id": "sid-b", "dir": ""}]
         # _relay_in and fleet_presence rule from the CHECKED seam now (2026-08-31): same stub
         # rows, answered=True — the harness's world is authoritative
         pm.local_agents_checked = lambda threads=False: (pm.local_agents(), True)
@@ -301,9 +301,9 @@ class ThreeBusRelay(unittest.TestCase):
         pm.self_host = lambda: "hosta"
         pmb.self_host = lambda: "hostb"
         pmc.self_host = lambda: "hostc"
-        pm.local_agents = lambda: [{"name": "alpha", "id": "sid-a", "dir": ""}]
-        pmb.local_agents = lambda: [{"name": "beta", "id": "sid-b", "dir": ""}]
-        pmc.local_agents = lambda: [{"name": "carol", "id": "sid-c", "dir": ""}]
+        pm.local_agents = lambda threads=False: [{"name": "alpha", "id": "sid-a", "dir": ""}]
+        pmb.local_agents = lambda threads=False: [{"name": "beta", "id": "sid-b", "dir": ""}]
+        pmc.local_agents = lambda threads=False: [{"name": "carol", "id": "sid-c", "dir": ""}]
         # _relay_in and fleet_presence rule from the CHECKED seam now (2026-08-31)
         pm.local_agents_checked = lambda threads=False: (pm.local_agents(), True)
         pmb.local_agents_checked = lambda threads=False: (pmb.local_agents(), True)
@@ -405,7 +405,7 @@ class ThreeBusRelay(unittest.TestCase):
         pm.outbox_put("hub", {"mid": "r2", "to": "carol", "frm": "alpha", "frm_id": "sid-a",
                               "body": "too late", "kind": "", "t": 1})
         self._xchg(pm, pmb, "hub")                   # forwarded
-        pmc.local_agents = lambda: []                # carol died before delivery
+        pmc.local_agents = lambda threads=False: []                # carol died before delivery
         self._xchg(pmc, pmb, "hub")                  # C receives the relay → bounces it
         self._xchg(pmc, pmb, "hub")                  # C's bounce rides its next request → B routes backward
         self._xchg(pm, pmb, "hub")                   # A picks the bounce up → sender gets the note
@@ -949,3 +949,215 @@ class RefusalArms(unittest.TestCase):
                              "could not land while the log was down — that window is what restore() is for)")
         finally:
             pm._name_for_id = saved_name
+
+
+class _LoudBus(unittest.TestCase):
+    """Fixture for the review fixes of 2026-09-08: clean stores, the log captured, the kernel leg of
+    _refused_notice captured (`told`), the once-per-episode registries reset. No tests of its own."""
+
+    def setUp(self):
+        os.environ["ROMP_POSTAL_PEERS"] = "1"
+        import shutil
+        for d in (pm.OUTBOX, pm.READBOX, pm.MAILROOT, pm.MAILPENDING):
+            shutil.rmtree(d, ignore_errors=True)
+        self._saved = (pm.TLDIR, pm._log, pm._kernel_post, pm.local_agents, pm.local_agents_checked)
+        self.logged, self.told = [], []
+        pm._log = lambda m: self.logged.append(m)
+        pm._kernel_post = lambda path, body, timeout=2: self.told.append((path, body)) or {"ok": True}
+        pm.local_agents = lambda threads=False: []
+        pm.local_agents_checked = lambda threads=False: ([], True)
+        try:
+            (pm.TLDIR / "messages.jsonl").unlink()
+        except OSError:
+            pass
+        pm._TL_FAULT[0] = False
+        pm._DASHBOARD_MISSED[0] = False
+        pm._NOTE_FAILED_SAID.clear()
+        pm._UNREADABLE_SAID.clear()
+        pm._peer_pending.clear()
+
+    def tearDown(self):
+        pm.TLDIR, pm._log, pm._kernel_post, pm.local_agents, pm.local_agents_checked = self._saved
+        pm._TL_FAULT[0] = False
+        pm._DASHBOARD_MISSED[0] = False
+        pm._NOTE_FAILED_SAID.clear()
+        pm._peer_pending.clear()
+        os.environ.pop("ROMP_POSTAL_PEERS", None)
+
+    def _rows(self):
+        p = pm.TLDIR / "messages.jsonl"
+        return [json.loads(l) for l in p.read_text().splitlines() if l] if p.exists() else []
+
+    def _notices(self):
+        return [b["text"] for p, b in self.told if p == "/postal-notice"]
+
+
+class OneBadRelayNeverAbortsTheExchange(_LoudBus):
+    """_bounce_apply bounds the return note's failure (review find, 2026-09-08). With the record kept
+    until it is accounted, a deliver() exception other than a refusal escaped the handler and aborted
+    the WHOLE exchange; the peer re-bounced the still-parked record next exchange, so the abort
+    recurred forever and every other relay, ack and receipt in those exchanges was lost with it.
+    Mutant: the generic except removed (RuntimeError escapes peer_exchange_handle)."""
+
+    def _exchange(self):
+        return pm.peer_exchange_handle({"host": "srv", "proto": pm.PEER_PROTO, "epoch": 1, "busId": "b" * 32,
+                                        "presence": [], "holds": [], "relays": [], "acks": ["n2"],
+                                        "bounces": [{"mid": "n1", "why": "no live session named 'beta'"}],
+                                        "reads": [], "readAcks": []})
+
+    def test_a_note_that_raises_keeps_the_record_says_once_and_the_exchange_completes(self):
+        for mid in ("n1", "n2"):
+            pm.outbox_put("srv", {"mid": mid, "to": "beta", "frm": "alpha", "frm_id": _SND,
+                                  "body": "ship it", "kind": "", "t": 1})
+        saved = pm.deliver
+        pm.deliver = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("mailbox on fire"))
+        try:
+            payload, status = self._exchange()                         # must not raise
+            self.assertEqual(status, 200, "the exchange completes")
+            self.assertIsNotNone(pm.outbox_get("srv", "n1"), "the bounced record stays parked for the next exchange")
+            self.assertIsNone(pm.outbox_get("srv", "n2"), "the ack in the same exchange was processed")
+            evs = {(r["ev"], r["id"]) for r in self._rows()}
+            self.assertIn(("bounced", "n1"), evs, "the terminal row landed before the note was tried")
+            self.assertIn(("relayed", "n2"), evs)
+            said = [m for m in self.logged if "n1" in m and "could not be delivered" in m]
+            self.assertEqual(len(said), 1)
+            self.assertIn("RuntimeError: mailbox on fire", said[0], "the line names the fault")
+            self.assertEqual(len(self._notices()), 1, "one bell row for a fault that would recur every exchange")
+            self._exchange()                                           # the peer re-bounces it
+            self.assertEqual((len([m for m in self.logged if "could not be delivered" in m]), len(self._notices())),
+                             (1, 1), "said once per message, not per exchange")
+        finally:
+            pm.deliver = saved
+        self._exchange()                                               # the note lands
+        self.assertIsNone(pm.outbox_get("srv", "n1"), "and the record leaves once the note is delivered")
+        self.assertEqual(len(pm.read_box(_SND, consume=False)), 1)
+
+
+class NewFalseReturnsAreHonoured(_LoudBus):
+    """The False the stores learned to return is read everywhere it was ignored (review find,
+    2026-09-08). Mutants: outbox_put's False ignored at the relay forward ('hold' with nothing
+    parked); the forwarded-ack order reverted (delete before the backward queue)."""
+
+    def test_relay_in_answers_retry_when_the_forward_cannot_be_parked(self):
+        saved = (pm.peer_route, pm.outbox_put)
+        pm.peer_route = lambda to: ("farhost", {"name": "carol", "id": ""})
+        pm.outbox_put = lambda h, m: False
+        m = {"mid": "px-fwd", "to": "carol", "frm": "alpha", "frm_id": _SND, "body": "hi", "kind": ""}
+        try:
+            verdict = pm._relay_in("srv", m)
+        finally:
+            pm.peer_route, pm.outbox_put = saved
+        self.assertEqual(verdict, ("retry", None), "silence on the wire: the sender re-relays")
+        self.assertIsNone(pm.outbox_get("farhost", "px-fwd"))
+        pm.peer_route = lambda to: ("farhost", {"name": "carol", "id": ""})
+        try:
+            self.assertEqual(pm._relay_in("srv", m), ("hold", None), "and a park that lands forwards as before")
+        finally:
+            pm.peer_route = saved[0]
+        self.assertEqual(pm.outbox_get("farhost", "px-fwd")["origin"], "srv")
+
+    def test_ack_arrived_queues_the_backward_ack_before_the_delete(self):
+        pm.outbox_put("hub", {"mid": "fa1", "to": "carol", "frm": "alpha", "frm_id": _SND,
+                              "body": "hi", "kind": "", "t": 1, "origin": "originhost"})
+        at_delete = []
+        saved = pm.outbox_del
+        pm.outbox_del = lambda h, m: at_delete.append(list(pm._pending("originhost")["acks"])) or saved(h, m)
+        try:
+            pm._ack_arrived("hub", "fa1")
+        finally:
+            pm.outbox_del = saved
+        self.assertEqual(at_delete, [["fa1"]], "the backward ack is already queued at the moment of the delete")
+        self.assertIsNone(pm.outbox_get("hub", "fa1"), "and the forward does leave the outbox")
+
+
+class StoreFaultsAreLoud(_LoudBus):
+    """_atomic_json_put's failure path and _list_json_records' unreadable arm (review find,
+    2026-09-08). An unreadable record is moved aside like a torn one, once, with its ledger closed
+    and a bell row; the first cut skipped it in place on every exchange."""
+
+    def test_a_failed_replace_raises_and_leaves_no_temp(self):
+        import errno
+        d = pm.OUTBOX / "srv"
+        saved = os.replace
+        os.replace = lambda *a, **k: (_ for _ in ()).throw(OSError(errno.ENOSPC, "staged by the test"))
+        try:
+            with self.assertRaises(OSError):
+                pm._atomic_json_put(d / "x.json", {"mid": "x"})
+            self.assertEqual([p.name for p in d.iterdir()], [], "no temp and no record")
+            self.assertFalse(pm.outbox_put("srv", {"mid": "x", "to": "beta", "body": "hi"}), "the put reports it")
+        finally:
+            os.replace = saved
+        self.assertTrue(any("could not be written" in m for m in self.logged), "and says it")
+        self.assertEqual([p.name for p in d.iterdir()], [])
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-0 file; the fault cannot be staged")
+    def test_an_unreadable_record_is_moved_aside_once_and_closes_its_ledger(self):
+        pm._tl_append("messages.jsonl", {"t": 10, "ev": "sent", "id": "px-locked", "from": "alpha",
+                                         "from_id": _SND, "to_id": "peer:srv", "toName": "srv:beta",
+                                         "body": "hi", "kind": "question"})
+        pm.outbox_put("srv", {"mid": "px-locked", "to": "beta", "frm": "alpha", "frm_id": _SND, "body": "hi"})
+        pm.outbox_put("srv", {"mid": "good", "to": "beta", "frm": "alpha", "frm_id": _SND, "body": "hi"})
+        os.chmod(pm.OUTBOX / "srv" / "px-locked.json", 0)
+        self.assertEqual([r["mid"] for r in pm.outbox_list("srv")], ["good"], "the rest of the store is served")
+        self.assertFalse((pm.OUTBOX / "srv" / "px-locked.json").exists())
+        aside = [p.name for p in (pm.OUTBOX / "srv").iterdir() if p.name.startswith("px-locked.json.corrupt-")]
+        self.assertEqual(len(aside), 1, "moved aside, kept as evidence")
+        term = [r for r in self._rows() if r.get("ev") == "bounced" and r.get("id") == "px-locked"]
+        self.assertEqual([(r["host"], r["why"]) for r in term], [("srv", pm.WHY_OUTBOX_UNREADABLE)])
+        self.assertEqual(len([m for m in self.logged if "px-locked.json" in m]), 1)
+        self.assertEqual(len(self._notices()), 1, "one bell row")
+        self.assertIn("could not be read", self._notices()[0])
+        self.assertEqual([r["mid"] for r in pm.outbox_list("srv")], ["good"])
+        self.assertEqual((len([m for m in self.logged if "px-locked.json" in m]), len(self._notices())), (1, 1),
+                         "the second pass moves nothing and says nothing")
+        self.assertIn("refused", pm.format_receipts([pm._sent_receipts(_SND)[-1]]))
+
+
+class BusStartSweepsUnfinishedWrites(_LoudBus):
+    """A crash between the sent row and the publish (or the park) left a phantom: a row that says
+    "sent" and a temp nothing listed, nothing removed, nothing reported (review find, 2026-09-08).
+    At bus start every temp is a write that never finished: removed, its ledger closed once when a
+    sent row stands open, said once per file and once as a bell row. Sidecars are evidence and stay."""
+
+    def test_temps_are_removed_ledgers_closed_and_said_once_and_sidecars_kept(self):
+        for mid, to in (("m-tmp", _RCP), ("m-done", _RCP), ("px-tmp", "peer:srv")):
+            pm._tl_append("messages.jsonl", {"t": 10, "ev": "sent", "id": mid, "from": "alpha", "from_id": _SND,
+                                             "to_id": to, "body": "hi", "kind": "question"})
+        pm._tl_append("messages.jsonl", {"t": 11, "ev": "bounced", "id": "m-done", "why": "already closed"})
+        tmpd = pm.MAILROOT / _RCP / "tmp"
+        tmpd.mkdir(parents=True)
+        (tmpd / "m-tmp").write_text("From: alpha\n\nhalf")
+        (tmpd / "m-done").write_text("From: alpha\n\nhalf")
+        pm.outbox_put("srv", {"mid": "good", "to": "beta", "frm": "alpha", "frm_id": _SND, "body": "hi"})
+        (pm.OUTBOX / "srv" / "px-tmp.json.tmp-1-abcd").write_text('{"mid": "px-t')
+        (pm.OUTBOX / "srv" / "old.json.corrupt-20260101T000000Z").write_text("{torn")
+        (pm.READBOX / "srv").mkdir(parents=True)
+        (pm.READBOX / "srv" / "r1.json.tmp-2-beef").write_text("{")
+        pm._sweep_unfinished_writes()
+        self.assertEqual([p.name for p in tmpd.iterdir()], [], "the maildir temps are gone")
+        self.assertEqual(sorted(p.name for p in (pm.OUTBOX / "srv").iterdir()),
+                         ["good.json", "old.json.corrupt-20260101T000000Z"], "the store temp is gone; the record and the sidecar stay")
+        self.assertEqual([p.name for p in (pm.READBOX / "srv").iterdir()], [])
+        term = {r["id"]: r for r in self._rows() if r.get("ev") == "bounced"}
+        self.assertEqual(term["m-tmp"]["why"], pm.WHY_STOPPED_BEFORE_PUBLISH)
+        self.assertEqual(term["m-tmp"]["to_id"], _RCP)
+        self.assertEqual((term["px-tmp"]["host"], term["px-tmp"]["why"]), ("srv", pm.WHY_STOPPED_BEFORE_PARK))
+        self.assertEqual(len([r for r in self._rows() if r.get("ev") == "bounced" and r.get("id") == "m-done"]), 1,
+                         "an id already closed is not closed again")
+        self.assertEqual(len([m for m in self.logged if "removed at start" in m]), 4, "one line per file")
+        self.assertEqual(len(self._notices()), 1, "one bell row for the sweep")
+        self.assertIn("4 unfinished mail write(s)", self._notices()[0])
+        self.assertIn("2 sender receipt(s) now read refused", self._notices()[0])
+        recs = {r["id"]: r for r in pm._sent_receipts(_SND)}
+        for mid in ("m-tmp", "px-tmp"):
+            self.assertIn("refused", pm.format_receipts([recs[mid]]), mid)
+        pm._sweep_unfinished_writes()
+        self.assertEqual((len([m for m in self.logged if "removed at start" in m]), len(self._notices())), (4, 1),
+                         "a second start with nothing to sweep says nothing")
+
+    def test_serve_runs_the_sweep_before_it_binds(self):
+        import inspect
+        src = inspect.getsource(pm.serve)
+        self.assertIn("_sweep_unfinished_writes()", src)
+        self.assertLess(src.index("_sweep_unfinished_writes()"), src.index("ThreadingHTTPServer("),
+                        "the sweep runs at start, before any writer of ours can run")

--- a/tests/test_postal_peers.py
+++ b/tests/test_postal_peers.py
@@ -581,3 +581,371 @@ class RecallAndReceipts(unittest.TestCase):
                          "no tunnel record at all reads down, matching the send path's branch")
         row = pm._sent_receipts("sid-a")[-1]
         self.assertEqual(row["parked"], "srv", "the parked key keeps its host-string shape")
+
+
+_SND = "11111111-2222-3333-4444-555555555555"
+_RCP = "22222222-3333-4444-5555-666666666666"
+
+
+class LedgerBeforeTheDelete(unittest.TestCase):
+    """The accounting rows are the ONE record anyone reads (the sender's receipts, the timeline, the
+    kernel's courier), so they land before the irreversible step, never after it (2026-09-08):
+    deliver() writes the sent row and only then publishes — a row that cannot land refuses the send
+    with nothing in new/ — and _bounce_apply / _ack_arrived write the terminal row and only then
+    delete the outbox record. On origin/main the publish and the delete came first and the row was
+    best-effort after them: mail with no row anywhere, and records gone before their receipt existed."""
+
+    def setUp(self):
+        os.environ["ROMP_POSTAL_PEERS"] = "1"
+        import shutil
+        shutil.rmtree(pm.OUTBOX, ignore_errors=True)
+        shutil.rmtree(pm.MAILROOT, ignore_errors=True)
+        shutil.rmtree(pm.MAILPENDING, ignore_errors=True)
+        self._tl, self._log = pm.TLDIR, pm._log
+        self.logged = []
+        pm._log = lambda m: self.logged.append(m)
+        try:
+            (pm.TLDIR / "messages.jsonl").unlink()
+        except OSError:
+            pass
+        if hasattr(pm, "_TL_FAULT"):
+            pm._TL_FAULT[0] = False
+
+    def tearDown(self):
+        pm.TLDIR, pm._log = self._tl, self._log
+        if hasattr(pm, "_TL_FAULT"):
+            pm._TL_FAULT[0] = False
+        os.environ.pop("ROMP_POSTAL_PEERS", None)
+
+    def _break_the_log(self):
+        # TLDIR under a regular FILE: mkdir raises (ENOTDIR), so the REAL _tl_append fails the way a
+        # full or read-only disk fails it — no stub stands in for the function under test
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.addCleanup(lambda: os.unlink(path))
+        pm.TLDIR = type(pm.TLDIR)(path) / "timeline"
+
+    def test_tl_append_reports_whether_the_row_landed(self):
+        self.assertTrue(pm._tl_append("messages.jsonl", {"t": 1, "ev": "sent", "id": "r1"}))
+        self._break_the_log()
+        self.assertFalse(pm._tl_append("messages.jsonl", {"t": 1, "ev": "sent", "id": "r2"}))
+        self.assertFalse(pm._tl_append("messages.jsonl", {"t": 1, "ev": "sent", "id": "r3"}))
+        self.assertEqual(len([m for m in self.logged if "append failed" in m]), 1,
+                         "one line per fault episode, not per call")
+
+    def test_a_send_whose_row_cannot_land_is_refused_with_nothing_in_new(self):
+        self._break_the_log()
+        with self.assertRaises(pm.DeliveryNotRecorded) as cm:
+            pm.deliver(_RCP, "web", _SND, "please review the schema", kind="question")
+        self.assertIn("not delivered", str(cm.exception))
+        self.assertIn("retry", str(cm.exception))
+        newd, tmpd = pm.MAILROOT / _RCP / "new", pm.MAILROOT / _RCP / "tmp"
+        self.assertEqual([p.name for p in newd.iterdir()] if newd.is_dir() else [], [],
+                         "no mail is published without its row")
+        self.assertEqual([p.name for p in tmpd.iterdir()] if tmpd.is_dir() else [], [], "the temp is removed")
+        self.assertFalse((pm.MAILPENDING / _RCP).exists(), "no pending marker for mail that never landed")
+
+    def test_the_sent_row_precedes_the_publish(self):
+        # the order pin, executed: a recording _tl_append sees new/ still EMPTY at the moment the
+        # sent row is written
+        seen = []
+        saved = pm._tl_append
+        newd = pm.MAILROOT / _RCP / "new"
+        pm._tl_append = lambda f, o: seen.append(
+            (o["ev"], sorted(p.name for p in newd.iterdir()) if newd.is_dir() else [])) or True
+        try:
+            mid = pm.deliver(_RCP, "web", _SND, "hello")
+        finally:
+            pm._tl_append = saved
+        self.assertEqual(seen, [("sent", [])], "the row is written before the mail is visible in new/")
+        self.assertTrue((newd / mid).exists(), "…and the mail is published once the row landed")
+
+    def test_bounce_apply_writes_the_terminal_row_and_the_note_before_the_delete(self):
+        pm.outbox_put("srv", {"mid": "b1", "to": "beta", "frm": "alpha", "frm_id": _SND,
+                              "body": "ship it", "kind": "", "t": 1})
+        calls = []
+        saved = (pm._tl_append, pm.outbox_del, pm.deliver)
+        pm._tl_append = lambda f, o: calls.append("row:" + o["ev"]) or True
+        pm.outbox_del = lambda h, m: calls.append("del:" + m) or saved[1](h, m)
+        pm.deliver = lambda *a, **k: calls.append("note") or "m-note"
+        try:
+            pm._bounce_apply("srv", {"mid": "b1", "why": "no live session named 'beta'"})
+        finally:
+            pm._tl_append, pm.outbox_del, pm.deliver = saved
+        self.assertEqual(calls, ["row:bounced", "note", "del:b1"],
+                         "terminal row, then the return note, then — only then — the delete")
+        self.assertIsNone(pm.outbox_get("srv", "b1"), "the record does leave the outbox once accounted")
+
+    def test_bounce_apply_keeps_the_record_when_the_row_cannot_land(self):
+        pm.outbox_put("srv", {"mid": "b2", "to": "beta", "frm": "alpha", "frm_id": _SND,
+                              "body": "ship it", "kind": "", "t": 1})
+        self._break_the_log()
+        pm._bounce_apply("srv", {"mid": "b2", "why": "no live session named 'beta'"})
+        self.assertIsNotNone(pm.outbox_get("srv", "b2"),
+                             "an unaccounted refusal keeps the record — the next exchange re-relays it")
+        self.assertTrue(any("stays parked" in m for m in self.logged), "…and says so")
+        newd = pm.MAILROOT / _SND / "new"
+        self.assertFalse(newd.is_dir() and any(newd.iterdir()),
+                         "no return note either: nothing is published without its row")
+
+    def test_ack_arrived_writes_the_receipt_before_the_delete(self):
+        pm.outbox_put("srv", {"mid": "a1", "to": "beta", "frm": "alpha", "frm_id": _SND,
+                              "body": "hi", "kind": "", "t": 1})
+        calls = []
+        saved = (pm._tl_append, pm.outbox_del)
+        pm._tl_append = lambda f, o: calls.append("row:" + o["ev"]) or True
+        pm.outbox_del = lambda h, m: calls.append("del:" + m) or saved[1](h, m)
+        try:
+            pm._ack_arrived("srv", "a1")
+        finally:
+            pm._tl_append, pm.outbox_del = saved
+        self.assertEqual(calls, ["row:relayed", "del:a1"], "the delivered receipt, then the delete")
+        self._break_the_log()
+        pm.outbox_put("srv", {"mid": "a2", "to": "beta", "frm": "alpha", "frm_id": _SND,
+                              "body": "hi", "kind": "", "t": 1})
+        pm._ack_arrived("srv", "a2")
+        self.assertIsNotNone(pm.outbox_get("srv", "a2"), "a receipt that did not land keeps the record")
+
+
+class StoresPublishAtomicallyAndQuarantineTornRecords(unittest.TestCase):
+    """outbox_put / readbox_put publish through a same-directory temp + os.replace, so a reader never
+    sees a half-written record; a record that still cannot be parsed is moved aside ONCE to
+    `<name>.corrupt-<utc stamp>` with one log line, and the rest of the store is listed. On
+    origin/main the put was a plain write_text and the list skipped an unparseable file silently on
+    every pass, forever."""
+
+    def setUp(self):
+        import shutil
+        shutil.rmtree(pm.OUTBOX, ignore_errors=True)
+        shutil.rmtree(pm.READBOX, ignore_errors=True)
+        self._log = pm._log
+        self.logged = []
+        pm._log = lambda m: self.logged.append(m)
+
+    def tearDown(self):
+        pm._log = self._log
+
+    def test_puts_go_through_os_replace_and_leave_no_temp(self):
+        replaced = []
+        saved = os.replace
+        os.replace = lambda a, b, *r, **k: replaced.append((str(a), str(b))) or saved(a, b, *r, **k)
+        try:
+            self.assertTrue(pm.outbox_put("srv", {"mid": "p1", "to": "beta", "body": "hi"}))
+            self.assertTrue(pm.readbox_put("srv", {"mid": "p2", "t": 1}))
+        finally:
+            os.replace = saved
+        self.assertEqual([os.path.basename(b) for _a, b in replaced], ["p1.json", "p2.json"],
+                         "each record is published by an atomic replace of a finished temp")
+        for a, b in replaced:
+            self.assertEqual(os.path.dirname(a), os.path.dirname(b), "the temp lives in the store's own directory")
+            self.assertFalse(a.endswith(".json"), "…under a name the *.json listing can never see")
+        self.assertEqual([p.name for p in (pm.OUTBOX / "srv").iterdir()], ["p1.json"], "no temp left behind")
+        self.assertEqual([p.name for p in (pm.READBOX / "srv").iterdir()], ["p2.json"])
+        self.assertEqual([r["mid"] for r in pm.outbox_list("srv")], ["p1"])
+        self.assertEqual([r["mid"] for r in pm.readbox_list("srv")], ["p2"])
+
+    def test_a_torn_record_is_moved_aside_once_and_the_rest_is_listed(self):
+        pm.outbox_put("srv", {"mid": "good", "to": "beta", "body": "hi"})
+        (pm.OUTBOX / "srv" / "torn.json").write_text('{"mid": "torn", "to": "be')     # a half-written record
+        self.assertEqual([r["mid"] for r in pm.outbox_list("srv")], ["good"], "the rest of the store is served")
+        aside = sorted(p.name for p in (pm.OUTBOX / "srv").iterdir() if p.name.startswith("torn.json.corrupt-"))
+        self.assertEqual(len(aside), 1, "the torn record is moved aside, kept as evidence")
+        self.assertFalse((pm.OUTBOX / "srv" / "torn.json").exists())
+        said = [m for m in self.logged if "torn.json" in m]
+        self.assertEqual(len(said), 1, "one log line names it")
+        self.assertIn(aside[0], said[0], "…and where it went")
+        self.assertEqual([r["mid"] for r in pm.outbox_list("srv")], ["good"])
+        self.assertEqual(sorted(p.name for p in (pm.OUTBOX / "srv").iterdir() if "corrupt" in p.name), aside,
+                         "the second pass moves nothing again")
+        self.assertEqual(len([m for m in self.logged if "torn.json" in m]), 1, "…and says nothing again")
+
+    def test_readbox_shares_the_quarantine(self):
+        pm.readbox_put("srv", {"mid": "good", "t": 1})
+        (pm.READBOX / "srv" / "torn.json").write_text("[1, 2")
+        self.assertEqual([r["mid"] for r in pm.readbox_list("srv")], ["good"])
+        self.assertTrue(any(p.name.startswith("torn.json.corrupt-") for p in (pm.READBOX / "srv").iterdir()))
+
+    def test_a_record_rewritten_under_the_read_is_left_for_the_next_pass(self):
+        # the fingerprint guard: the parse fails because a writer REPLACED the file between the stat
+        # and the read — a torn READ of a healthy record, never a torn record — and it must not be
+        # moved aside. Pins the new mechanism against moving a live record; main had no move to guard.
+        pm.outbox_put("srv", {"mid": "live", "to": "beta", "body": "v1"})
+        target = pm.OUTBOX / "srv" / "live.json"
+        real_json = pm.json
+
+        class _Shim:
+            dumps = staticmethod(real_json.dumps)
+            fired = [False]
+
+            @staticmethod
+            def loads(text, *a, **k):
+                if not _Shim.fired[0]:
+                    _Shim.fired[0] = True
+                    pm._atomic_json_put(target, {"mid": "live", "to": "beta", "body": "v2"})   # a concurrent rewrite
+                    raise ValueError("torn read")
+                return real_json.loads(text, *a, **k)
+
+        pm.json = _Shim
+        try:
+            first = pm.outbox_list("srv")
+        finally:
+            pm.json = real_json
+        self.assertEqual(first, [], "this pass skips the record it could not read whole")
+        self.assertTrue(target.exists(), "…and leaves it in place")
+        self.assertEqual([p.name for p in (pm.OUTBOX / "srv").iterdir() if "corrupt" in p.name], [],
+                         "a rewritten record is never moved aside")
+        self.assertEqual([r["body"] for r in pm.outbox_list("srv")], ["v2"], "the next pass lists the new bytes")
+        self.assertEqual(self.logged, [], "nothing to say: no fault happened")
+
+
+class RefusalArms(unittest.TestCase):
+    """The arms the review found claimed but untested (2026-09-08), each named with the mutant it kills."""
+
+    def setUp(self):
+        os.environ["ROMP_POSTAL_PEERS"] = "1"
+        import shutil
+        for d in (pm.OUTBOX, pm.READBOX, pm.MAILROOT):
+            shutil.rmtree(d, ignore_errors=True)
+        self._tl, self._log = pm.TLDIR, pm._log
+        self.logged = []
+        pm._log = lambda m: self.logged.append(m)
+        try:
+            (pm.TLDIR / "messages.jsonl").unlink()
+        except OSError:
+            pass
+        pm._TL_FAULT[0] = False
+        pm._peer_pending.clear()
+
+    def tearDown(self):
+        pm.TLDIR, pm._log = self._tl, self._log
+        pm._TL_FAULT[0] = False
+        pm._peer_pending.clear()
+        os.environ.pop("ROMP_POSTAL_PEERS", None)
+
+    def _break_the_log(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.addCleanup(lambda: os.unlink(path))
+        pm.TLDIR = type(pm.TLDIR)(path) / "timeline"
+
+    def _rows(self):
+        p = self._tl / "messages.jsonl"
+        return [json.loads(l) for l in p.read_text().splitlines() if l] if p.exists() else []
+
+    def test_tl_append_says_once_when_the_log_writes_again(self):
+        # mutant: the three recovery lines deleted → no "writes again" line and _TL_FAULT stays set
+        self._break_the_log()
+        self.assertFalse(pm._tl_append("messages.jsonl", {"t": 1, "ev": "sent", "id": "r1"}))
+        self.assertTrue(pm._TL_FAULT[0])
+        pm.TLDIR = self._tl
+        self.assertTrue(pm._tl_append("messages.jsonl", {"t": 1, "ev": "sent", "id": "r2"}))
+        self.assertTrue(pm._tl_append("messages.jsonl", {"t": 1, "ev": "sent", "id": "r3"}))
+        self.assertEqual(len([m for m in self.logged if m == "timeline log messages.jsonl writes again"]), 1,
+                         "exactly one recovery line (the fault line also ends in the phrase; pin the whole line)")
+        self.assertFalse(pm._TL_FAULT[0], "the fault flag clears with it")
+
+    def test_relay_in_answers_retry_when_the_local_delivery_is_refused(self):
+        # mutant: no except → falls through to peer_seen_add + "ack": the mail is acked, marked seen, gone
+        saved = (pm.local_agents_checked, pm._postal_off, dict(pm.PEERS), pm._seen_ids)
+        pm.local_agents_checked = lambda threads=False: ([{"id": _RCP, "name": "api", "remote": False}], True)
+        pm._postal_off = lambda sid: False
+        pm.PEERS["TESTHOST"] = {"trust": "trusted", "up": True}
+        pm._seen_ids = set()
+        self._break_the_log()
+        mid = "px-1700000000.1_" + "ab" * 16 + ".TESTHOST"
+        try:
+            verdict, bounce = pm._relay_in("TESTHOST", {"mid": mid, "to": "api", "frm": "web", "frm_id": _SND,
+                                                        "body": "ship it", "kind": "coordinate"})
+            seen = pm.peer_seen_check(mid)
+        finally:
+            pm.local_agents_checked, pm._postal_off, peers, pm._seen_ids = saved
+            pm.PEERS.clear()
+            pm.PEERS.update(peers)
+        self.assertEqual((verdict, bounce), ("retry", None), "silence on the wire: the sender re-relays")
+        self.assertFalse(seen, "not marked seen, so the re-relay is processed in full")
+        newd = pm.MAILROOT / _RCP / "new"
+        self.assertEqual([p.name for p in newd.iterdir()] if newd.is_dir() else [], [], "nothing landed")
+
+    def test_bounce_arrived_queues_the_backward_bounce_before_the_delete(self):
+        # mutant: delete first (main's order) → at the delete the backward queue is still empty
+        pm.outbox_put("hub", {"mid": "f1", "to": "carol", "frm": "alpha", "frm_id": _SND,
+                              "body": "hi", "kind": "", "t": 1, "origin": "originhost"})
+        at_delete = []
+        saved = pm.outbox_del
+        pm.outbox_del = lambda h, m: at_delete.append(list(pm._pending("originhost")["bounces"])) or saved(h, m)
+        b = {"mid": "f1", "why": "no live session named 'carol'"}
+        try:
+            pm._bounce_arrived("hub", b)
+        finally:
+            pm.outbox_del = saved
+        self.assertEqual(at_delete, [[b]], "the backward bounce is already queued at the moment of the delete")
+        self.assertIsNone(pm.outbox_get("hub", "f1"), "…and the forward does leave the outbox")
+
+    def test_no_readable_record_means_no_delete(self):
+        # mutant: main's get → del → check: the unparseable record is destroyed, evidence gone
+        d = pm.OUTBOX / "srv"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "torn.json").write_text('{"mid": "torn", "to": "be')
+        pm._bounce_apply("srv", {"mid": "torn", "why": "refused"})
+        self.assertTrue((d / "torn.json").exists(), "a bounce for a record we cannot read deletes nothing")
+        pm._ack_arrived("srv", "torn")
+        self.assertTrue((d / "torn.json").exists(), "…nor does an ack")
+        pm.outbox_list("srv")                                # the listing is what moves it aside
+        self.assertTrue(any(p.name.startswith("torn.json.corrupt-") for p in d.iterdir()), "evidence kept")
+
+    def test_a_torn_outbox_record_closes_its_ledger_and_the_receipt_says_refused(self):
+        # mutant: no terminal row → check_sent reads "pending (not read yet)" forever
+        pm._tl_append("messages.jsonl", {"t": 10, "ev": "sent", "id": "px-torn", "from": "alpha",
+                                         "from_id": "sid-a", "to_id": "peer:srv",
+                                         "toName": "srv:beta", "body": "hi", "kind": ""})
+        d = pm.OUTBOX / "srv"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "px-torn.json").write_text("{torn")
+        self.assertEqual(pm.outbox_list("srv"), [])
+        term = [r for r in self._rows() if r.get("ev") == "bounced" and r.get("id") == "px-torn"]
+        self.assertEqual(len(term), 1, "one terminal row for the mid the filename names")
+        self.assertEqual((term[0]["host"], term[0]["why"]), ("srv", pm.WHY_OUTBOX_UNREADABLE))
+        row = pm._sent_receipts("sid-a")[-1]
+        self.assertTrue(row["bounced"])
+        self.assertEqual(row["bouncedWhy"], pm.WHY_OUTBOX_UNREADABLE)
+        txt = pm.format_receipts([row])
+        self.assertIn("refused — " + pm.WHY_OUTBOX_UNREADABLE, txt)
+        self.assertNotIn("returned to you", txt, "no return note exists for a refusal")
+        pm.outbox_list("srv")
+        self.assertEqual(len([r for r in self._rows() if r.get("ev") == "bounced"]), 1, "the second pass adds nothing")
+
+    def test_a_torn_readbox_record_closes_no_ledger(self):
+        pm.readbox_put("srv", {"mid": "good", "t": 1})
+        (pm.READBOX / "srv" / "torn.json").write_text("[1, 2")
+        self.assertEqual([r["mid"] for r in pm.readbox_list("srv")], ["good"])
+        self.assertEqual([r for r in self._rows() if r.get("ev") == "bounced"], [], "a receipt is not a message")
+
+    def test_a_refused_oversize_bounce_puts_the_claimed_message_back(self):
+        # the rebase onto the oversize-bounce change (PR #1038) created this arm: _bounce_oversize drops a
+        # claimed message and mails its local sender a note; with the note REFUSED the message must not
+        # sit in cur/ with no note and no row. Mutant: no except → the refusal escapes into _push's
+        # catch-all and the message is stranded.
+        saved_name = pm._name_for_id
+        pm._name_for_id = lambda sid: "api"
+        try:
+            mid = pm.deliver(_RCP, "web", _SND, "x" * 64, kind="coordinate")
+            m = pm.read_box(_RCP, consume=True)[0]                # the drain claims it (new/ → cur/)
+            self.assertEqual(m["id"], mid)
+            self._break_the_log()
+            pm._bounce_oversize(_RCP, m)                          # must not raise
+            self.assertTrue((pm.MAILROOT / _RCP / "new" / mid).exists(), "put back for the next pass")
+            self.assertEqual(pm.read_box(_SND, consume=False), [], "no note was published without its row")
+            self.assertEqual(len([x for x in self.logged if "kept for the next pass" in x]), 1)
+            pm.TLDIR = self._tl                                    # the log writes again: the next pass
+            m = pm.read_box(_RCP, consume=True)[0]
+            pm._bounce_oversize(_RCP, m)
+            self.assertFalse((pm.MAILROOT / _RCP / "new" / mid).exists(), "…and the bounce completes")
+            notes = pm.read_box(_SND, consume=False)
+            self.assertEqual(len(notes), 1)
+            self.assertIn("undeliverable to 'api'", notes[0]["body"])
+            evs = [r["ev"] for r in self._rows() if r.get("id") == mid]
+            self.assertEqual((evs[-1], evs.count("bounced")), ("bounced", 1),
+                             "one terminal row, written only once the note had landed (the roll-back's unexec "
+                             "could not land while the log was down — that window is what restore() is for)")
+        finally:
+            pm._name_for_id = saved_name

--- a/tests/test_postal_peers.py
+++ b/tests/test_postal_peers.py
@@ -6,6 +6,7 @@ import json
 import os
 import tempfile
 import threading
+import time
 import unittest
 from http.server import ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
@@ -683,11 +684,14 @@ _RCP = "22222222-3333-4444-5555-666666666666"
 
 class LedgerBeforeTheDelete(unittest.TestCase):
     """The accounting rows are the ONE record anyone reads (the sender's receipts, the timeline, the
-    kernel's courier), so they land before the irreversible step, never after it (2026-09-08):
-    deliver() writes the sent row and only then publishes — a row that cannot land refuses the send
-    with nothing in new/ — and _bounce_apply / _ack_arrived write the terminal row and only then
-    delete the outbox record. On origin/main the publish and the delete came first and the row was
-    best-effort after them: mail with no row anywhere, and records gone before their receipt existed."""
+    kernel's courier), so nothing irreversible stands without its row (2026-09-08): deliver()
+    publishes first (the publish is the claim on the name) and writes the sent row second, and a row
+    that cannot land takes the mail back out of new/ and refuses the send; _bounce_apply / _ack_arrived
+    write the terminal row and only then delete the outbox record. On origin/main the row after the
+    publish was best-effort and the delete came before its row: mail with no row anywhere, and records
+    gone before their receipt existed. The two take-back outcomes that leave a delivered message with
+    no row (a reader claimed it first; the file could not be removed) answer the id and are said to
+    the user (a bell row), not only on stderr."""
 
     def setUp(self):
         os.environ["ROMP_POSTAL_PEERS"] = "1"
@@ -695,21 +699,29 @@ class LedgerBeforeTheDelete(unittest.TestCase):
         shutil.rmtree(pm.OUTBOX, ignore_errors=True)
         shutil.rmtree(pm.MAILROOT, ignore_errors=True)
         shutil.rmtree(pm.MAILPENDING, ignore_errors=True)
-        self._tl, self._log = pm.TLDIR, pm._log
-        self.logged = []
+        self._tl, self._log, self._post = pm.TLDIR, pm._log, pm._kernel_post
+        self.logged, self.told = [], []
         pm._log = lambda m: self.logged.append(m)
+        pm._kernel_post = lambda path, body, timeout=2: self.told.append((path, body)) or {"ok": True}
         try:
             (pm.TLDIR / "messages.jsonl").unlink()
         except OSError:
             pass
         if hasattr(pm, "_TL_FAULT"):
             pm._TL_FAULT[0] = False
+        pm._DASHBOARD_MISSED[0] = False
+        pm._REFUSAL_SAID.clear()
 
     def tearDown(self):
-        pm.TLDIR, pm._log = self._tl, self._log
+        pm.TLDIR, pm._log, pm._kernel_post = self._tl, self._log, self._post
         if hasattr(pm, "_TL_FAULT"):
             pm._TL_FAULT[0] = False
+        pm._DASHBOARD_MISSED[0] = False
+        pm._REFUSAL_SAID.clear()
         os.environ.pop("ROMP_POSTAL_PEERS", None)
+
+    def _notices(self):
+        return [b["text"] for p, b in self.told if p == "/postal-notice"]
 
     def _break_the_log(self):
         # TLDIR under a regular FILE: mkdir raises (ENOTDIR), so the REAL _tl_append fails the way a
@@ -735,7 +747,7 @@ class LedgerBeforeTheDelete(unittest.TestCase):
         self.assertIn("retry", str(cm.exception))
         newd, tmpd = pm.MAILROOT / _RCP / "new", pm.MAILROOT / _RCP / "tmp"
         self.assertEqual([p.name for p in newd.iterdir()] if newd.is_dir() else [], [],
-                         "no mail is published without its row")
+                         "mail whose row cannot land is taken back out of new/")
         self.assertEqual([p.name for p in tmpd.iterdir()] if tmpd.is_dir() else [], [], "the temp is removed")
         self.assertFalse((pm.MAILPENDING / _RCP).exists(), "no pending marker for mail that never landed")
 
@@ -778,6 +790,116 @@ class LedgerBeforeTheDelete(unittest.TestCase):
         self.assertEqual(claimed, [mid], "the reader took the message")
         self.assertTrue((pm.MAILROOT / _RCP / "cur" / mid).is_file(), "…and holds it")
         self.assertTrue(any(mid in m and "no record" in m for m in self.logged), "the missing row is said, by id")
+        self.assertEqual(len([n for n in self._notices() if mid in n and "no record" in n]), 1,
+                         "…and to the user, as one bell row (a delivered message the ledger will never carry)")
+
+    def test_a_row_that_fails_when_the_mail_cannot_be_taken_back_answers_the_id_and_says_so(self):
+        # the take-back's other failure: the row failed (the REAL _tl_append against a broken log) and
+        # new/<id> stands, but its unlink is refused with something other than ENOENT (EROFS staged
+        # on that one path; no chmod, so root runs it too). The message WILL be read, so the answer
+        # is the id, the marker stands, no row was written, and the gap is said by name on stderr
+        # AND as a bell row. Mutants: the arm removed (the error escapes deliver and the sender
+        # delivers it twice); the arm returning without _mark_pending (mail in new/ with no marker).
+        import errno
+        import pathlib
+        self._break_the_log()
+        newd = pm.MAILROOT / _RCP / "new"
+        real, refused = pathlib.Path.unlink, []
+
+        def refuse_in_new(p, *a, **k):
+            if p.parent == newd:
+                refused.append(p.name)
+                raise OSError(errno.EROFS, os.strerror(errno.EROFS), str(p))
+            return real(p, *a, **k)
+
+        pathlib.Path.unlink = refuse_in_new
+        try:
+            mid = pm.deliver(_RCP, "web", _SND, "hello")
+        finally:
+            pathlib.Path.unlink = real
+        self.assertEqual(refused, [mid], "the take-back was attempted on the published name and refused")
+        self.assertTrue((newd / mid).is_file(), "the message stands in new/: it could not be taken back")
+        self.assertTrue((pm.MAILPENDING / _RCP).exists(), "the pending marker stands: the mail will be delivered")
+        self.assertFalse((pm.TLDIR / "messages.jsonl").exists(), "no row was written")
+        said = [m for m in self.logged if mid in m and "could not be taken back" in m]
+        self.assertEqual(len(said), 1, "the failed take-back is said, by id, with the errno")
+        self.assertIn("[Errno %d]" % errno.EROFS, said[0])
+        self.assertEqual(len([n for n in self._notices() if mid in n and "could not be taken back" in n]), 1,
+                         "…and as one bell row")
+
+    def test_a_refused_publish_rings_the_bell_once_per_recipient_episode(self):
+        # a refused publish writes no row, so the log says every refusal, and the USER hears it once
+        # per recipient episode: the first refusal to a recipient is a bell row, the refusals that
+        # follow it are log lines only, another recipient's refusal is its own episode, and a publish
+        # to that recipient that lands re-arms it. Mutants: a bell per refusal (the dialer re-relays
+        # a refused message every exchange, so a lasting fault would ring every few seconds); no
+        # re-arm (the second episode is silent); one gate for every recipient.
+        other = "33333333-4444-5555-6666-777777777777"
+        first = pm.deliver(_RCP, "web", _SND, "the standing message")
+        second = pm.deliver(other, "web", _SND, "another standing message")
+        saved = pm._unique
+
+        def collide(mid, to):
+            pm._unique = lambda: mid                                   # the publish meets a standing name
+            try:
+                with self.assertRaises(pm.DeliveryNotRecorded):
+                    pm.deliver(to, "web", _SND, "an impostor")
+            finally:
+                pm._unique = saved
+
+        def bells():
+            return [n for n in self._notices() if "refused, nothing recorded" in n]
+
+        collide(first, _RCP)
+        collide(first, _RCP)
+        self.assertEqual(len([m for m in self.logged if "refused, nothing recorded" in m]), 2,
+                         "the log says every refusal (no row does)")
+        self.assertEqual(len(bells()), 1, "the user hears the recipient's episode once")
+        self.assertIn(_RCP, bells()[0])
+        self.assertIn("retries", bells()[0])
+        collide(second, other)
+        self.assertEqual(len(bells()), 2, "another recipient's refusal is its own episode")
+        self.assertIn(other, bells()[1])
+        collide(first, _RCP)
+        self.assertEqual(len(bells()), 2, "the first recipient's episode is still open: no new bell")
+        pm.deliver(_RCP, "web", _SND, "this one lands")               # re-arms that recipient's episode
+        collide(first, _RCP)
+        self.assertEqual(len(bells()), 3, "a refusal after a publish that landed is a new episode")
+        self.assertEqual(len([m for m in self.logged if "refused, nothing recorded" in m]), 5)
+        self.assertEqual(sorted(m["body"] for m in pm.read_box(_RCP, consume=False)),
+                         ["the standing message", "this one lands"], "no impostor ever replaced the standing mail")
+
+    def test_read_box_tolerates_a_file_the_take_back_removed_under_it(self):
+        # the take-back is a deleter of new/ files on the live path (recall and the orphan sweep
+        # already were): a reader that listed and read a file the instant before it vanished used to
+        # raise out of the whole read at the rename into cur/, so /inbox and /drain answered nothing
+        # for the rest of the box. The vanished message is nobody's to hand over (its sender was
+        # refused and retries; a recalled one was unsent; a second reader has it), so it is dropped
+        # from the listing with no exec row, and the rest of the box is served.
+        kept = pm.deliver(_RCP, "web", _SND, "the one that stays")
+        gone = pm.deliver(_RCP, "web", _SND, "the one taken back")
+        newd = pm.MAILROOT / _RCP / "new"
+        from pathlib import Path
+        orig = Path.read_text
+
+        def read_then_vanish(self_, *a, **k):
+            text = orig(self_, *a, **k)
+            if self_.name == gone and self_.parent.name == "new":
+                os.unlink(self_)                                  # the take-back races in after the read
+            return text
+
+        Path.read_text = read_then_vanish
+        try:
+            got = pm.read_box(_RCP, consume=True)
+        finally:
+            Path.read_text = orig
+        self.assertEqual([m["id"] for m in got], [kept], "the vanished message is not handed over; the rest is")
+        curd = pm.MAILROOT / _RCP / "cur"
+        self.assertEqual(sorted(p.name for p in curd.iterdir()), [kept])
+        self.assertEqual(sorted(p.name for p in newd.iterdir()), [])
+        rows = [json.loads(l) for l in (pm.TLDIR / "messages.jsonl").read_text().splitlines() if l]
+        self.assertEqual([r["id"] for r in rows if r["ev"] == "exec"], [kept], "no exec row for a message nobody got")
+        self.assertFalse((pm.MAILPENDING / _RCP).exists(), "the box is empty: the marker is dropped")
 
     def test_bounce_apply_writes_the_terminal_row_and_the_note_before_the_delete(self):
         pm.outbox_put("srv", {"mid": "b1", "to": "beta", "frm": "alpha", "frm_id": _SND,
@@ -1093,6 +1215,7 @@ class _LoudBus(unittest.TestCase):
         pm._DASHBOARD_MISSED[0] = False
         pm._NOTE_FAILED_SAID.clear()
         pm._UNREADABLE_SAID.clear()
+        pm._REFUSAL_SAID.clear()
         pm._peer_pending.clear()
 
     def tearDown(self):
@@ -1100,6 +1223,7 @@ class _LoudBus(unittest.TestCase):
         pm._TL_FAULT[0] = False
         pm._DASHBOARD_MISSED[0] = False
         pm._NOTE_FAILED_SAID.clear()
+        pm._REFUSAL_SAID.clear()
         pm._peer_pending.clear()
         os.environ.pop("ROMP_POSTAL_PEERS", None)
 
@@ -1233,10 +1357,172 @@ class StoreFaultsAreLoud(_LoudBus):
 
 
 class BusStartSweepsUnfinishedWrites(_LoudBus):
-    """A crash between the sent row and the publish (or the park) left a phantom: a row that says
-    "sent" and a temp nothing listed, nothing removed, nothing reported (review find, 2026-09-08).
-    At bus start every temp is a write that never finished: removed, its ledger closed once when a
-    sent row stands open, said once per file and once as a bell row. Sidecars are evidence and stay."""
+    """Bus start is the one moment no writer of ours runs, so the sweep reconciles what a crash left
+    (review find, 2026-09-08): a temp is removed, and its id is closed as refused only when a sent
+    row stands with the message nowhere (a phantom whichever order wrote it); a temp beside a message
+    that stands in new/ or cur/ is the leftover of a publish that landed (deliver tolerates a temp
+    it cannot remove), so the ledger is left alone; a message in new/ with no sent row is the crash
+    window between the publish and the row, and gets its row now; each is said once per file and
+    once as a bell row. Sidecars are evidence and stay."""
+
+    def _rows_for(self, mid):
+        return [r["ev"] for r in self._rows() if r.get("id") == mid]
+
+    def test_a_temp_beside_a_standing_message_is_removed_and_its_ledger_left_alone(self):
+        # the planted state: two delivered messages (one read, one not) whose publish could not remove
+        # its temp, the only way this writer leaves a temp beside a sent row. Before the fix the sweep
+        # closed both as refused: a message the recipient had READ read refused to its sender and
+        # dropped out of the kernel's ask maps after every bus restart.
+        mb = pm._mailbox(_RCP)
+        for mid in ("m-read", "m-unread"):
+            pm._tl_append("messages.jsonl", {"t": 10, "ev": "sent", "id": mid, "from": "alpha", "from_id": _SND,
+                                             "to_id": _RCP, "body": "hi", "kind": "question"})
+            (mb / "tmp" / mid).write_text("From: alpha\n\nhi\n")
+        pm._tl_append("messages.jsonl", {"t": 11, "ev": "exec", "id": "m-read"})
+        (mb / "cur" / "m-read").write_text("From: alpha\n\nhi\n")
+        (mb / "new" / "m-unread").write_text("From: alpha\n\nhi\n")
+        pm._sweep_unfinished_writes()
+        self.assertEqual([p.name for p in (mb / "tmp").iterdir()], [], "the temps are gone")
+        self.assertTrue((mb / "cur" / "m-read").is_file() and (mb / "new" / "m-unread").is_file(), "the mail stands")
+        self.assertEqual(self._rows_for("m-read"), ["sent", "exec"], "a read message stays read: no bounced row")
+        self.assertEqual(self._rows_for("m-unread"), ["sent"], "an unread message stays pending: no bounced row")
+        recs = {r["id"]: r for r in pm._sent_receipts(_SND)}
+        self.assertEqual([recs["m-read"]["bounced"], recs["m-unread"]["bounced"]], [None, None])
+        self.assertIn("read", pm.format_receipts([recs["m-read"]]))
+        self.assertIn("pending", pm.format_receipts([recs["m-unread"]]))
+        said = [m for m in self.logged if "removed at start" in m]
+        self.assertEqual(len(said), 2, "one line per temp")
+        self.assertTrue(all("reached the inbox" in m for m in said), "…each saying the message itself stands")
+        self.assertEqual(len(self._notices()), 1)
+        self.assertIn("2 unfinished mail write(s)", self._notices()[0])
+        self.assertIn("0 sender receipt(s) now read refused", self._notices()[0])
+        self.assertIn("2 of them the temp of a message that had reached the inbox", self._notices()[0])
+        self.assertEqual([m["id"] for m in pm.read_box(_RCP, consume=False)], ["m-unread"], "still delivered")
+
+    @unittest.skipIf(hasattr(os, "geteuid") and os.geteuid() == 0, "chmod cannot refuse root the unlink")
+    def test_a_temp_the_publish_could_not_remove_is_read_as_a_finished_publish(self):
+        # the real path, no mock on unlink: tmp/ is made read-only the instant link() has placed the
+        # message in new/, so _publish_new's tmp.unlink() meets a real EACCES and tolerates it (the
+        # message is out), the sent row lands, the recipient reads it, and the bus restarts.
+        import errno
+        tmpd = pm._mailbox(_RCP) / "tmp"
+        saved_link = os.link
+
+        def link_then_lock(src, dst, *a, **k):
+            saved_link(src, dst, *a, **k)
+            os.chmod(tmpd, 0o555)
+
+        os.link = link_then_lock
+        try:
+            mid = pm.deliver(_RCP, "web", _SND, "please review the schema", kind="question")
+        finally:
+            os.link = saved_link
+            os.chmod(tmpd, 0o755)
+        self.assertEqual([p.name for p in tmpd.iterdir()], [mid], "the temp lingered (its unlink was refused)")
+        lingered = [m for m in self.logged if "its temp could not be removed" in m]
+        self.assertEqual(len(lingered), 1)
+        self.assertIn(os.strerror(errno.EACCES), lingered[0])
+        self.assertEqual([m["id"] for m in pm.read_box(_RCP, consume=True)], [mid], "the recipient reads it")
+        pm._sweep_unfinished_writes()
+        self.assertEqual([p.name for p in tmpd.iterdir()], [], "the temp is gone")
+        self.assertTrue((pm.MAILROOT / _RCP / "cur" / mid).is_file(), "the read message stands in cur/")
+        self.assertEqual(self._rows_for(mid), ["sent", "exec"], "a finished publish is not closed as refused")
+        rec = pm._sent_receipts(_SND)[0]
+        self.assertEqual((rec["id"], rec["bounced"]), (mid, None))
+        self.assertTrue(rec["exec"], "the sender's receipt still reads read")
+        self.assertEqual(len(self._notices()), 1)
+        self.assertIn("0 sender receipt(s) now read refused", self._notices()[0])
+
+    def test_mail_in_new_with_no_sent_row_gets_its_row_at_start(self):
+        # the crash window between the publish and the row: the message stands in new/ (it WILL be
+        # delivered by the next read) and the ledger has never heard of it. The state is made by the
+        # writer itself with the row's append swallowed: a local question, a parked handoff and a
+        # relayed message, so every header deliver writes is recovered into the row.
+        saved = pm._tl_append
+        pm._tl_append = lambda f, o: True                         # the row "lands" nowhere: the crash window
+        try:
+            q = pm.deliver(_RCP, "web", _SND, "please review the schema", kind="question")
+            h = pm.deliver(_RCP, "web", _SND, "take over the api tests", park=True, kind="delegate")
+            r = pm.deliver(_RCP, "api", "33333333-4444-5555-6666-777777777777", "from afar", kind="coordinate",
+                           from_host="TESTHOST", relay_mid="px-far-1", relay_via="TESTHOST")
+        finally:
+            pm._tl_append = saved
+        ok = pm.deliver(_RCP, "web", _SND, "this one has its row")
+        self.assertEqual(self._rows_for(q) + self._rows_for(h) + self._rows_for(r), [], "the ledger knows none of the three")
+        pm._sweep_unfinished_writes()
+        rows = {r_["id"]: r_ for r_ in self._rows() if r_["ev"] == "sent"}
+        self.assertEqual(sorted(rows), sorted([q, h, r, ok]), "every message in new/ now has exactly one sent row")
+        self.assertEqual(len([r_ for r_ in self._rows() if r_["ev"] == "sent" and r_["id"] == ok]), 1,
+                         "a message with its row is not rowed again")
+        got = rows[q]
+        self.assertEqual((got["from"], got["from_id"], got["to_id"], got["body"], got["kind"], got["from_host"]),
+                         ("web", _SND, _RCP, "please review the schema", "question", ""))
+        self.assertTrue(got["recovered"], "the row says it was written at start, not by the send")
+        self.assertTrue(abs(got["t"] - int(time.time())) < 120, "t comes from the message's Date header")
+        self.assertTrue(rows[h]["park"] and rows[h]["kind"] == "delegate")
+        self.assertNotIn("park", rows[q])
+        self.assertEqual((rows[r]["from"], rows[r]["from_host"], rows[r]["originMid"], rows[r]["kind"]),
+                         ("api", "TESTHOST", "px-far-1", "coordinate"))
+        self.assertTrue(pm.peer_seen_check("px-far-1"),
+                        "the relayed one's origin mid is marked seen: the dialer's re-relay is acked as a duplicate")
+        self.assertNotIn("originMid", rows[q], "a local message has no origin mid")
+        recs = {r_["id"]: r_ for r_ in pm._sent_receipts(_SND)}
+        self.assertEqual(sorted(recs), sorted([q, h, ok]), "the sender's receipts now list them")
+        self.assertIn("pending", pm.format_receipts([recs[q]]))
+        self.assertEqual(len([m for m in self.logged if "no record" in m and "row written at start" in m]), 3,
+                         "one stderr line per recovered message")
+        self.assertEqual(len(self._notices()), 1, "one bell row for the sweep")
+        self.assertIn("3 delivered message(s)", self._notices()[0])
+        self.assertEqual(len(pm.read_box(_RCP, consume=False)), 4, "all four still stand for delivery")
+        pm._sweep_unfinished_writes()
+        self.assertEqual((len(self._rows()), len(self._notices())), (4, 1), "the next start finds nothing to do")
+
+    @unittest.skipIf(hasattr(os, "geteuid") and os.geteuid() == 0, "root reads through chmod 0")
+    def test_mail_in_new_with_no_sent_row_that_cannot_be_read_is_moved_aside(self):
+        # the unreadable branch: the file's fields cannot be recovered, so it goes the way read_box
+        # sends an unreadable inbox file (aside, once, with a terminal row and a bell row), and it
+        # counts as nothing recovered.
+        mb = pm._mailbox(_RCP)
+        bad = mb / "new" / "m-bad"
+        bad.write_text("From: alpha\n\nhi\n")
+        os.chmod(bad, 0o000)
+        good = pm.deliver(_RCP, "web", _SND, "fine")
+        pm._sweep_unfinished_writes()
+        self.assertEqual([p.name for p in (mb / "new").iterdir()], [good], "the unreadable file is out of new/")
+        aside = [p.name for p in mb.iterdir() if p.name.startswith("m-bad.corrupt-")]
+        self.assertEqual(len(aside), 1, "…moved aside beside new/, never deleted")
+        os.chmod(mb / aside[0], 0o644)
+        self.assertEqual(self._rows_for("m-bad"), ["bounced"])
+        self.assertEqual(self._rows_for(good), ["sent"])
+        self.assertEqual(len(self._notices()), 1, "the move-aside's bell row, and no recovery row to report")
+        self.assertIn("could not be read", self._notices()[0])
+        self.assertNotIn("delivered message(s)", self._notices()[0])
+
+    def test_a_row_that_cannot_be_written_at_start_leaves_the_mail_and_says_so(self):
+        # the log is faulted at start too: the message stays in new/ (it is still delivered), nothing
+        # claims a row was written, and the next start with a working log writes it.
+        saved = pm._tl_append
+        pm._tl_append = lambda f, o: True
+        try:
+            q = pm.deliver(_RCP, "web", _SND, "please review the schema", kind="question")
+        finally:
+            pm._tl_append = saved
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.addCleanup(lambda: os.unlink(path))
+        good_tl = pm.TLDIR
+        pm.TLDIR = type(pm.TLDIR)(path) / "timeline"                 # mkdir raises: the real _tl_append fails
+        try:
+            pm._sweep_unfinished_writes()
+        finally:
+            pm.TLDIR = good_tl
+        self.assertEqual(self._rows_for(q), [], "no row landed")
+        self.assertTrue((pm.MAILROOT / _RCP / "new" / q).is_file(), "the mail stands")
+        self.assertEqual(len([m for m in self.logged if q in m and "could not be written" in m]), 1)
+        self.assertEqual(self._notices(), [], "nothing claims a row was written")
+        pm._sweep_unfinished_writes()
+        self.assertEqual(self._rows_for(q), ["sent"], "the next start with a working log writes it")
+        self.assertEqual(len(self._notices()), 1)
 
     def test_temps_are_removed_ledgers_closed_and_said_once_and_sidecars_kept(self):
         for mid, to in (("m-tmp", _RCP), ("m-done", _RCP), ("px-tmp", "peer:srv")):

--- a/tests/test_postal_peers.py
+++ b/tests/test_postal_peers.py
@@ -455,6 +455,100 @@ class ExchangeRelaysAreBudgeted(_TwoBusHarness):
         self.assertEqual(len(box), 12, "every message arrived exactly once")
         self.assertEqual(sorted(len(m["body"]) for m in box), [100_000] * 12)
 
+    def test_a_name_collision_on_the_dialed_side_loses_no_message(self):
+        """The drain test above failed once on CI with 11 of 12 (2026-09-08, on a PR that touched no postal
+        code) and passed on either side of it. The dialed side names every message it lands by
+        _unique() — the second, the pid and five random digits, 100k names per second per process — and
+        deliver() published with rename(), which silently REPLACES a standing new/<name>. Two relays
+        landing in one second with the same draw became one file: the first sender's message gone, both
+        relays acked, both ledgers reading delivered (a drain of twelve loses one about once in 1500).
+        Drives that collision exactly, through the mint the drain reads: the second mint returns the
+        first's name. The standing message stays, the collided relay is refused rather than acked
+        (silence on the wire, so the sender's outbox keeps it), and it rides the next exchange under a
+        fresh name."""
+        for i in range(12):
+            pm.outbox_put("srv", {"mid": "big%02d" % i, "to": "beta", "frm": "alpha", "frm_id": "sid-a",
+                                  "body": ("%02d" % i).ljust(100_000, "R"), "kind": "coordinate", "t": i})
+        real, minted = pmb._unique, []
+
+        def collide_once():
+            name = real()
+            minted.append(name)
+            return minted[0] if len(minted) == 2 else name    # the drain's second mint repeats its first
+
+        pmb._unique = collide_once
+        acked = []
+        try:
+            rounds = 0
+            while pm.outbox_list("srv") and rounds < 10:
+                req = pm.build_exchange_request("srv", wait=False)
+                resp, status = pmb.peer_exchange_handle(req)
+                self.assertEqual(status, 200)
+                acked.append(resp["acks"])
+                pm.peer_exchange_apply("srv", req, resp)
+                rounds += 1
+        finally:
+            pmb._unique = real
+        self.assertEqual(pm.outbox_list("srv"), [], "the backlog drained")
+        box = pmb.read_box("sid-b", consume=True)
+        self.assertEqual(len(box), 12, "every message arrived exactly once")
+        self.assertEqual(sorted(m["body"][:2] for m in box), ["%02d" % i for i in range(12)],
+                         "the collided message included, under its own name")
+        self.assertEqual(len({m["id"] for m in box}), 12, "under twelve distinct names")
+        self.assertNotIn("big01", acked[0], "the relay that hit the collision was not acked")
+        self.assertIn("big01", acked[1], "it rode the next exchange and landed")
+        self.assertEqual(len(minted), 13, "one extra mint: the refused relay was named afresh on its next ride")
+
+    def test_a_refused_collision_leaves_the_standing_message_s_ledger_alone(self):
+        """The first cut of the collision refusal wrote the row before the publish, and under this same
+        forced collision it filed the refused message's `sent` row and then the refusal's `bounced` row
+        under the colliding name — the STANDING message's id — so the dialed side's ledger (its timeline,
+        its receipts, every reader that takes a bounced row on a sent id as terminal) showed a delivered
+        message as bounced. The publish is the claim on the name now and the row follows it: the refusal
+        writes nothing, the standing message keeps its one `sent` row, and the retry lands under a fresh
+        id with a row of its own."""
+        for i in range(3):
+            pm.outbox_put("srv", {"mid": "m%d" % i, "to": "beta", "frm": "alpha", "frm_id": "sid-a",
+                                  "body": "note %d" % i, "kind": "coordinate", "t": i})
+        ledger = pmb.TLDIR / "messages.jsonl"
+
+        def rows():
+            return [json.loads(l) for l in ledger.read_text().splitlines() if l] if ledger.exists() else []
+
+        before = len(rows())
+        real, minted = pmb._unique, []
+
+        def collide_once():
+            name = real()
+            minted.append(name)
+            return minted[0] if len(minted) == 2 else name    # the drain's second mint repeats its first
+
+        pmb._unique = collide_once
+        try:
+            rounds = 0
+            while pm.outbox_list("srv") and rounds < 10:
+                self._exchange()
+                rounds += 1
+        finally:
+            pmb._unique = real
+        self.assertEqual(pm.outbox_list("srv"), [], "the backlog drained")
+        self.assertEqual(len(minted), 4, "three lands, plus the refused relay's fresh name on its next ride")
+        standing, fresh = minted[0], minted[-1]
+        self.assertNotEqual(fresh, standing)
+        added = rows()[before:]
+        self.assertEqual([r["ev"] for r in added if r["id"] == standing], ["sent"],
+                         "the standing message has exactly one sent row and no bounced row")
+        self.assertEqual([r["ev"] for r in added], ["sent"] * 3, "three messages, three sent rows, nothing bounced")
+        by_id = {r["id"]: r for r in added}
+        self.assertEqual(len(by_id), 3, "three distinct ids: the refusal wrote no row under the standing id")
+        self.assertEqual(by_id[standing]["originMid"], "m0", "the standing message's one row is its own")
+        self.assertEqual(by_id[fresh]["originMid"], "m1", "the refused relay landed under a fresh id with its own row")
+        # the receipts reader on the dialed side: nothing about the standing message reads bounced
+        recs = {r["id"]: r for r in pmb._sent_receipts("sid-a")}
+        self.assertIsNone(recs[standing]["bounced"], "the standing message's receipt is not bounced")
+        self.assertIsNone(recs[fresh]["bounced"])
+        self.assertEqual(recs[standing]["to"], "beta")
+
     def test_the_budget_holds_through_the_dialed_bus_s_own_body_gate(self):
         # the HTTP layer in the path: the dialed bus's _body reads a request only up to _POST_MAX_BYTES,
         # and a 413 would raise out of _peer_http here
@@ -645,20 +739,45 @@ class LedgerBeforeTheDelete(unittest.TestCase):
         self.assertEqual([p.name for p in tmpd.iterdir()] if tmpd.is_dir() else [], [], "the temp is removed")
         self.assertFalse((pm.MAILPENDING / _RCP).exists(), "no pending marker for mail that never landed")
 
-    def test_the_sent_row_precedes_the_publish(self):
-        # the order pin, executed: a recording _tl_append sees new/ still EMPTY at the moment the
-        # sent row is written
+    def test_the_sent_row_follows_the_publish_it_names(self):
+        # the order pin, executed: a recording _tl_append sees the mail ALREADY in new/ under the very
+        # name the row carries. The publish is the claim on the name (link() refuses a standing one),
+        # so a row is never written for a name that is not this message's — the first cut wrote the
+        # row first and, under a collision, filed it under the standing message's id (the ledger pin
+        # is in ExchangeRelaysAreBudgeted). A row that then fails takes the mail back (pinned above).
         seen = []
         saved = pm._tl_append
         newd = pm.MAILROOT / _RCP / "new"
         pm._tl_append = lambda f, o: seen.append(
-            (o["ev"], sorted(p.name for p in newd.iterdir()) if newd.is_dir() else [])) or True
+            (o["ev"], o["id"], sorted(p.name for p in newd.iterdir()) if newd.is_dir() else [])) or True
         try:
             mid = pm.deliver(_RCP, "web", _SND, "hello")
         finally:
             pm._tl_append = saved
-        self.assertEqual(seen, [("sent", [])], "the row is written before the mail is visible in new/")
-        self.assertTrue((newd / mid).exists(), "…and the mail is published once the row landed")
+        self.assertEqual(seen, [("sent", mid, [mid])],
+                         "the row is written once the mail stands in new/, under the name the row carries")
+
+    def test_a_row_that_fails_after_a_reader_claimed_the_mail_answers_the_id(self):
+        # the one interleaving the take-back cannot undo: read_box moved the file into cur/ in the
+        # instant between the publish and the row. The message is in the recipient's hands, so the
+        # answer is the id, not a refusal that would have the sender deliver it twice — and the gap
+        # in the ledger is said out loud, by name.
+        claimed = []
+        saved = pm._tl_append
+
+        def claim_then_fail(f, o):
+            if o["ev"] == "sent":
+                claimed.extend(m["id"] for m in pm.read_box(_RCP, consume=True))   # the reader beat the row
+            return False
+
+        pm._tl_append = claim_then_fail
+        try:
+            mid = pm.deliver(_RCP, "web", _SND, "hello")
+        finally:
+            pm._tl_append = saved
+        self.assertEqual(claimed, [mid], "the reader took the message")
+        self.assertTrue((pm.MAILROOT / _RCP / "cur" / mid).is_file(), "…and holds it")
+        self.assertTrue(any(mid in m and "no record" in m for m in self.logged), "the missing row is said, by id")
 
     def test_bounce_apply_writes_the_terminal_row_and_the_note_before_the_delete(self):
         pm.outbox_put("srv", {"mid": "b1", "to": "beta", "frm": "alpha", "frm_id": _SND,

--- a/tests/test_postal_quarantine.py
+++ b/tests/test_postal_quarantine.py
@@ -347,6 +347,30 @@ class QuarantineDecide(unittest.TestCase):
         self.assertFalse(ok)
         self.assertIn("no held message", err)
 
+    def test_a_deny_whose_note_cannot_park_refuses_and_keeps_the_hold(self):
+        # mutant: outbox_put's False ignored (review find, 2026-09-08) → the hold is dropped, ok is
+        # answered, and the reviewer's note goes nowhere with nothing saying so
+        ps._relay_in("TESTHOST", _relay("q-deny-3", body="please rewrite the ingest job tonight"))
+        saved = ps.outbox_put
+        ps.outbox_put = lambda h, m: False                   # the outbox could not be written
+        try:
+            ok, err = ps.quarantine_decide("q-deny-3", "deny", feedback="not tonight, we freeze before the demo")
+        finally:
+            ps.outbox_put = saved
+        self.assertFalse(ok)
+        self.assertIn("the held message is untouched", err)
+        self.assertIn("deny without a note", err, "the way out is named")
+        self.assertIsNotNone(ps.quarantine_get("q-deny-3"), "the hold stands")
+        self.assertEqual(list((ps.OUTBOX / "TESTHOST").glob("*.json")) if (ps.OUTBOX / "TESTHOST").is_dir() else [],
+                         [], "nothing was parked")
+        ok, err = ps.quarantine_decide("q-deny-3", "deny", feedback="not tonight, we freeze before the demo")
+        self.assertTrue(ok, err)
+        self.assertIsNone(ps.quarantine_get("q-deny-3"), "the retry completes the deny")
+        rows = [json.loads(f.read_text()) for f in (ps.OUTBOX / "TESTHOST").glob("*.json")]
+        self.assertEqual(len(rows), 1, "and parks exactly one note")
+        for f in (ps.OUTBOX / "TESTHOST").glob("*.json"):
+            f.unlink()
+
 
 class PeerUpdateTrust(unittest.TestCase):
     def test_default_and_keep_last_known(self):

--- a/tests/test_postal_quarantine.py
+++ b/tests/test_postal_quarantine.py
@@ -319,6 +319,29 @@ class QuarantineDecide(unittest.TestCase):
         for f in (ps.OUTBOX / "TESTHOST").glob("*.json"):
             f.unlink()
 
+    def test_a_refused_approve_leaves_the_hold_in_place(self):
+        # mutant: no except → deliver's refusal propagates out of the approve (or, worse, quarantine_del
+        # runs) and the held message is gone with nothing in new/. Kept at the public-call level on
+        # purpose: another change edits this function's body.
+        ps._relay_in("TESTHOST", _relay("q-appr-refused", body="held text"))
+        self.assertIsNotNone(ps.quarantine_get("q-appr-refused"))
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        saved_tl = ps.TLDIR
+        ps.TLDIR = Path(path) / "timeline"                   # under a regular file: the REAL append fails
+        try:
+            ok, err = ps.quarantine_decide("q-appr-refused", "approve")
+        finally:
+            ps.TLDIR = saved_tl
+            ps._TL_FAULT[0] = False
+            os.unlink(path)
+        self.assertFalse(ok)
+        self.assertIn("the held message is untouched", err)
+        self.assertIn("not delivered", err)
+        self.assertIsNotNone(ps.quarantine_get("q-appr-refused"), "the hold stands")
+        box = ps.read_box("sess-web", consume=False)
+        self.assertFalse(any("held text" in (m.get("body") or "") for m in box), "nothing landed in new/")
+
     def test_decide_unknown_mid_errors(self):
         ok, err = ps.quarantine_decide("no-such-mid", "approve")
         self.assertFalse(ok)

--- a/tests/test_postal_read_receipts.py
+++ b/tests/test_postal_read_receipts.py
@@ -281,8 +281,7 @@ class RefusalReceipts(_Base):
         return r
 
     def test_a_refusal_bounce_promises_no_return_note(self):
-        for why in (ps.WHY_NOT_PUBLISHED + "a message with this id already stands in the recipient's inbox",
-                    ps.WHY_NOT_PARKED, ps.WHY_OUTBOX_UNREADABLE):
+        for why in (ps.WHY_STOPPED_BEFORE_PUBLISH, ps.WHY_NOT_PARKED, ps.WHY_OUTBOX_UNREADABLE):
             txt = ps.format_receipts([self._row(bounced=7, bouncedWhy=why)])
             self.assertIn("refused — " + why, txt)
             self.assertNotIn("returned to you", txt, why)

--- a/tests/test_postal_read_receipts.py
+++ b/tests/test_postal_read_receipts.py
@@ -269,5 +269,39 @@ class FormatHonesty(_Base):
         self.assertIn("parked for boxalias (unreachable) — delivers on reconnect", txt)
 
 
+class RefusalReceipts(_Base):
+    """A terminal bounced row that records a REFUSAL (nothing left this machine; no return note) must
+    not read as "undeliverable, returned to you" — no note is coming (2026-09-08). Mutant: the
+    refusal branch dropped → every bounce promises a note."""
+
+    def _row(self, **kw):
+        r = {"to": "boxalias:api", "id": "px-1.mail.peerbox", "sent": 1, "exec": None,
+             "recalled": None, "relayed": None, "bounced": None, "parked": None}
+        r.update(kw)
+        return r
+
+    def test_a_refusal_bounce_promises_no_return_note(self):
+        for why in (ps.WHY_NOT_PUBLISHED + "a message with this id already stands in the recipient's inbox",
+                    ps.WHY_NOT_PARKED, ps.WHY_OUTBOX_UNREADABLE):
+            txt = ps.format_receipts([self._row(bounced=7, bouncedWhy=why)])
+            self.assertIn("refused — " + why, txt)
+            self.assertNotIn("returned to you", txt, why)
+
+    def test_a_peers_refusal_still_reads_as_returned(self):
+        txt = ps.format_receipts([self._row(bounced=7, bouncedWhy="no live session named 'api' on boxalias")])
+        self.assertIn("undeliverable, returned to you", txt, "a peer's bounce did come back as a note")
+        txt = ps.format_receipts([self._row(bounced=7)])
+        self.assertIn("undeliverable, returned to you", txt, "an older row with no why keeps the old line")
+
+    def test_sent_receipts_carries_the_why(self):
+        ps._tl_append("messages.jsonl", {"t": 1, "ev": "sent", "id": "px-r", "from": "web", "from_id": "sid-w",
+                                         "to_id": "peer:boxalias", "toName": "boxalias:api", "body": "hi",
+                                         "kind": ""})
+        ps._tl_append("messages.jsonl", {"t": 2, "ev": "bounced", "id": "px-r", "host": "boxalias",
+                                         "why": ps.WHY_NOT_PARKED})
+        row = ps._sent_receipts("sid-w")[-1]
+        self.assertEqual((row["bounced"], row["bouncedWhy"]), (2, ps.WHY_NOT_PARKED))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_postal_read_receipts.py
+++ b/tests/test_postal_read_receipts.py
@@ -303,5 +303,73 @@ class RefusalReceipts(_Base):
         self.assertEqual((row["bounced"], row["bouncedWhy"]), (2, ps.WHY_NOT_PARKED))
 
 
+class ReceiptsNeverDropSilently(_Base):
+    """_read_arrived reports whether the receipt APPLIED, and both halves of the exchange keep an
+    unapplied one on the wire (review find, 2026-09-08): the dialed side names it in `readsKept`
+    (additive) so the dialer keeps its record for the next request, and the dialer withholds its
+    readAck so the dialed side re-sends. Before this readbox_put's new False was ignored: a
+    forwarded receipt the store could not take was acked and gone, where the base's raised OSError
+    had aborted the exchange and left it to retry. Mutants: the return ignored on either side."""
+
+    def _break_the_log(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        saved = ps.TLDIR
+        ps.TLDIR = Path(path) / "timeline"                 # under a regular file: the REAL append fails
+        self.addCleanup(lambda: (setattr(ps, "TLDIR", saved), ps._TL_FAULT.__setitem__(0, False), os.unlink(path)))
+        return saved
+
+    def test_a_forward_the_store_cannot_take_is_named_kept_and_the_dialer_keeps_it(self):
+        self._trusted_peer()
+        ps.peer_update({"host": "srchost", "port": 19998, "up": True, "trust": "trusted"})
+        mid = next(_MIDS)
+        saved = ps.readbox_put
+        ps.readbox_put = lambda h, r: False                # the readbox could not be written
+        try:
+            resp, status = ps.peer_exchange_handle(_req("boxalias", reads=[{"mid": mid, "t": 7, "origin": "srchost"}]))
+        finally:
+            ps.readbox_put = saved
+        self.assertEqual(status, 200)
+        self.assertEqual(resp["readsKept"], [{"mid": mid, "unread": False}], "named kept, not silently acked")
+        self.assertEqual(ps.readbox_list("srchost"), [], "nothing was parked for the hop")
+        # the dialer: its parked read, named kept by the response, survives for the next request
+        ps.readbox_put("boxalias", {"mid": mid, "t": 7})
+        req = ps.build_exchange_request("boxalias", wait=False)
+        self.assertEqual([r["mid"] for r in req["reads"]], [mid])
+        ps.peer_exchange_apply("boxalias", req, _resp("boxalias", readsKept=[{"mid": mid, "unread": False}]))
+        self.assertEqual([r["mid"] for r in ps.readbox_list("boxalias")], [mid], "kept for the next request")
+        ps.peer_exchange_apply("boxalias", req, _resp("boxalias"))
+        self.assertEqual(ps.readbox_list("boxalias"), [], "a response that kept nothing clears it as before")
+
+    def test_a_response_carried_read_that_cannot_apply_gets_no_readack(self):
+        self._trusted_peer()
+        mid = next(_MIDS)
+        ps._tl_append("messages.jsonl", {"t": 1, "ev": "sent", "id": mid, "from": "web", "from_id": "sess-web",
+                                         "to_id": "peer:boxalias", "toName": "boxalias:api", "body": "b",
+                                         "kind": "question"})
+        good = self._break_the_log()
+        ps.peer_exchange_apply("boxalias", _req("boxalias"), _resp("boxalias", reads=[{"mid": mid, "t": 7}]))
+        self.assertEqual(ps._pending("boxalias")["readAcks"], [], "no ack for a receipt whose row did not land")
+        ps.TLDIR = good                                    # the log writes again: the dialed side re-sent it
+        ps._TL_FAULT[0] = False
+        ps.peer_exchange_apply("boxalias", _req("boxalias"), _resp("boxalias", reads=[{"mid": mid, "t": 7}]))
+        self.assertEqual(ps._pending("boxalias")["readAcks"], [{"mid": mid, "unread": False}])
+        self.assertEqual(ps._sent_receipts("sess-web")[0]["exec"], 7)
+
+    def test_read_arrived_reports_the_outcome(self):
+        self._trusted_peer()
+        ps.peer_update({"host": "srchost", "port": 19998, "up": True, "trust": "trusted"})
+        mid = next(_MIDS)
+        self.assertTrue(ps._read_arrived("boxalias", {"mid": "../nope", "t": 1}), "unaddressable: nothing a retry could change")
+        self.assertTrue(ps._read_arrived("boxalias", {"mid": mid, "t": 1, "origin": "nosuch"}), "no peer owns it: dropped on purpose")
+        self.assertTrue(ps._read_arrived("boxalias", {"mid": mid, "t": 1, "origin": "srchost"}), "forwarded and parked")
+        self.assertEqual([r["mid"] for r in ps.readbox_list("srchost")], [mid])
+        ps._tl_append("messages.jsonl", {"t": 1, "ev": "sent", "id": mid, "from": "web", "from_id": "sess-web",
+                                         "to_id": "peer:boxalias", "toName": "boxalias:api", "body": "b", "kind": ""})
+        self.assertTrue(ps._read_arrived("boxalias", {"mid": mid, "t": 7}), "ours: the exec row landed")
+        self._break_the_log()
+        self.assertFalse(ps._read_arrived("boxalias", {"mid": mid, "t": 8}), "ours, but the row could not land")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_postal_relay_honesty.py
+++ b/tests/test_postal_relay_honesty.py
@@ -230,7 +230,7 @@ class IdShapedAddressingRoutes(_RelayBase):
         pm.PEER_STATE["spokec"] = {"presence": [{"id": GHOST, "name": "web2"}], "epoch": 1, "seenAt": 0}
         parked = []
         saved_put, saved_get = pm.outbox_put, pm.outbox_get
-        pm.outbox_put = lambda h, m: parked.append((h, m))
+        pm.outbox_put = lambda h, m: parked.append((h, m)) or True   # the park reports success as a bool
         pm.outbox_get = lambda h, mid: None
         self.addCleanup(lambda: (setattr(pm, "outbox_put", saved_put), setattr(pm, "outbox_get", saved_get),
                                  pm.PEER_STATE.clear(), os.environ.pop("ROMP_POSTAL_PEERS", None)))
@@ -249,7 +249,7 @@ class IdShapedAddressingRoutes(_RelayBase):
         pm.PEER_STATE["spokec"] = {"presence": [{"id": ALPHA, "name": "web"}], "epoch": 1, "seenAt": 0}
         parked = []
         saved_put, saved_get = pm.outbox_put, pm.outbox_get
-        pm.outbox_put = lambda h, m: parked.append((h, m))
+        pm.outbox_put = lambda h, m: parked.append((h, m)) or True   # the park reports success as a bool
         pm.outbox_get = lambda h, mid: None
         self.addCleanup(lambda: (setattr(pm, "outbox_put", saved_put), setattr(pm, "outbox_get", saved_get),
                                  pm.PEER_STATE.clear(), os.environ.pop("ROMP_POSTAL_PEERS", None)))
@@ -396,7 +396,7 @@ class RelayRowCarriesTheStableId(_RelayBase):
         pm.PEER_STATE["TESTHOST"] = {"presence": [{"id": GHOST, "name": "api"}], "epoch": 1, "seenAt": 0}
         parked = []                                           # … the recipient on TESTHOST
         saved_put = pm.outbox_put
-        pm.outbox_put = lambda h, m: parked.append((h, m))
+        pm.outbox_put = lambda h, m: parked.append((h, m)) or True   # the park reports success as a bool
         self.addCleanup(lambda: (setattr(pm, "outbox_put", saved_put), pm.PEER_STATE.clear(),
                                  os.environ.pop("ROMP_POSTAL_PEERS", None)))
         obj, code = self._post_send({"to": "api", "from": "web", "from_id": ALPHA,

--- a/tests/test_postal_self_host.py
+++ b/tests/test_postal_self_host.py
@@ -357,9 +357,8 @@ class MessageIdsNeverCollide(unittest.TestCase):
                              "the standing message is untouched; the collision was refused, not tiebroken")
             self.assertIn("refusing to replace", str(cm.exception))
             rows = [json.loads(l) for l in (pm.TLDIR / "messages.jsonl").read_text().splitlines() if l]
-            self.assertEqual([r["ev"] for r in rows], ["sent", "sent", "bounced"],
-                             "the ledger closes on the refused id — no 'sent' left pending forever")
-            self.assertIn("refusing to replace", rows[-1]["why"])
+            self.assertEqual([(r["ev"], r["id"]) for r in rows], [("sent", first)],
+                             "the refusal wrote no row: the id is the standing message's, never the impostor's")
             self.assertEqual([p.name for p in (pm.MAILROOT / self.RCP / "tmp").iterdir()], [],
                              "the temp is removed")
         finally:
@@ -414,21 +413,22 @@ class MessageIdsNeverCollide(unittest.TestCase):
                 self.assertIn("[Errno %d]" % code, fallback[0], "errno %d: the line names the errno" % code)
             for code in (errno.EIO, errno.ENOSPC):
                 os.link, os.rename = raising(code), raising(code)     # a REAL fault: the rename meets it too
-                before = box()
+                before, before_rows = box(), rows()
                 with self.assertRaises(pm.DeliveryNotRecorded):
                     pm.deliver(self.RCP, "web", self.SND, "never lands (%d)" % code)
                 self.assertEqual(box(), before, "errno %d: nothing new in the inbox" % code)
                 self.assertEqual(tmpd(), [], "errno %d: the temp is removed" % code)
-                self.assertEqual([r["ev"] for r in rows()[-2:]], ["sent", "bounced"],
-                                 "errno %d: the ledger closes on the refused id" % code)
-                self.assertTrue(rows()[-1]["why"].startswith(pm.WHY_NOT_PUBLISHED))
+                self.assertEqual(rows(), before_rows, "errno %d: a refused publish records nothing" % code)
+            self.assertEqual(len([m for m in logged if "refused, nothing recorded" in m]), 2,
+                             "each refusal is said on stderr, since no row says it")
             os.rename = saved_rename
             os.link = raising(errno.EEXIST)                          # EEXIST IS the collision: never a fallback
-            before = box()
+            before, before_rows = box(), rows()
             with self.assertRaises(pm.DeliveryNotRecorded) as cm:
                 pm.deliver(self.RCP, "web", self.SND, "a collision at the link")
             self.assertIn("refusing to replace", str(cm.exception))
-            self.assertEqual(box(), before)
+            self.assertEqual((box(), rows()), (before, before_rows), "a collision at the link writes no row either")
+            self.assertEqual(len([m for m in logged if "refused, nothing recorded" in m]), 3)
             # a forced collision under the fallback is refused too, and the first message stands
             os.link = raising(errno.EPERM)
             saved_unique = pm._unique

--- a/tests/test_postal_self_host.py
+++ b/tests/test_postal_self_host.py
@@ -172,7 +172,7 @@ class ExchangeUnkeyableHostGate(_HostnameSeams):
         super().setUp()
         self._peers, self._pstate = dict(pm.PEERS), dict(pm.PEER_STATE)
         self._agents = pm.local_agents
-        pm.local_agents = lambda: []          # presence enumeration is not under test; stay hermetic
+        pm.local_agents = lambda threads=False: []          # presence enumeration is not under test; stay hermetic
 
     def tearDown(self):
         pm.local_agents = self._agents
@@ -367,14 +367,18 @@ class MessageIdsNeverCollide(unittest.TestCase):
             shutil.rmtree(td, ignore_errors=True)
 
     def test_publish_without_hard_links_falls_back_once_and_real_faults_refuse(self):
-        # mutants: the fallback errno set widened to every OSError → EIO/ENOSPC would publish by rename
-        # over a real fault; narrowed to none → a link-less filesystem could never deliver at all
+        # Every link() refusal but a collision takes the checked rename (review find, 2026-09-08: the
+        # first cut named six errnos as "no hard links here" and re-raised the rest, so a mount that
+        # answers link() with EACCES or EINVAL refused EVERY send). A real fault fails the rename the
+        # same way, so it still refuses with the ledger closed. Mutants: the fallback narrowed back to
+        # a list (EACCES/EINVAL refuse); the rename's failure swallowed (a fault "delivers" nothing and
+        # leaves the sent row open); the collision folded into the fallback (a standing message replaced).
         import errno
         import json
         import shutil
         shutil.rmtree(pm.MAILROOT, ignore_errors=True)
         td = tempfile.mkdtemp()
-        saved_tl, saved_link, saved_log = pm.TLDIR, os.link, pm._log
+        saved_tl, saved_link, saved_rename, saved_log = pm.TLDIR, os.link, os.rename, pm._log
         pm.TLDIR = type(pm.TLDIR)(td)
         logged = []
         pm._log = lambda m: logged.append(m)
@@ -390,24 +394,26 @@ class MessageIdsNeverCollide(unittest.TestCase):
             t = pm.MAILROOT / self.RCP / "tmp"
             return [p.name for p in t.iterdir()] if t.is_dir() else []
 
-        def link_raising(code):
-            def _link(src, dst, *a, **k):
+        def raising(code):
+            def _f(*a, **k):
                 raise OSError(code, "staged by the test")
-            return _link
+            return _f
 
         try:
-            for code in (errno.EPERM, errno.EOPNOTSUPP, errno.ENOTSUP, errno.ENOSYS, errno.EMLINK, errno.EXDEV):
-                os.link = link_raising(code)
+            for code in (errno.EPERM, errno.EOPNOTSUPP, errno.ENOTSUP, errno.ENOSYS, errno.EMLINK, errno.EXDEV,
+                         errno.EACCES, errno.EINVAL):
+                os.link = raising(code)
                 pm._LINK_FALLBACK_SAID[0] = False
                 logged.clear()
                 mid = pm.deliver(self.RCP, "web", self.SND, "via rename (%d)" % code)
                 self.assertIn(mid, box(), "errno %d: delivered by the checked rename" % code)
                 self.assertEqual(tmpd(), [], "errno %d: no temp left" % code)
                 pm.deliver(self.RCP, "web", self.SND, "again (%d)" % code)
-                self.assertEqual(len([m for m in logged if "hard links unavailable" in m]), 1,
-                                 "errno %d: said once per bus run, not per send" % code)
-            for code in (errno.EACCES, errno.EIO, errno.ENOSPC, errno.EEXIST):
-                os.link = link_raising(code)
+                fallback = [m for m in logged if "hard links unavailable" in m]
+                self.assertEqual(len(fallback), 1, "errno %d: said once per bus run, not per send" % code)
+                self.assertIn("[Errno %d]" % code, fallback[0], "errno %d: the line names the errno" % code)
+            for code in (errno.EIO, errno.ENOSPC):
+                os.link, os.rename = raising(code), raising(code)     # a REAL fault: the rename meets it too
                 before = box()
                 with self.assertRaises(pm.DeliveryNotRecorded):
                     pm.deliver(self.RCP, "web", self.SND, "never lands (%d)" % code)
@@ -416,8 +422,15 @@ class MessageIdsNeverCollide(unittest.TestCase):
                 self.assertEqual([r["ev"] for r in rows()[-2:]], ["sent", "bounced"],
                                  "errno %d: the ledger closes on the refused id" % code)
                 self.assertTrue(rows()[-1]["why"].startswith(pm.WHY_NOT_PUBLISHED))
+            os.rename = saved_rename
+            os.link = raising(errno.EEXIST)                          # EEXIST IS the collision: never a fallback
+            before = box()
+            with self.assertRaises(pm.DeliveryNotRecorded) as cm:
+                pm.deliver(self.RCP, "web", self.SND, "a collision at the link")
+            self.assertIn("refusing to replace", str(cm.exception))
+            self.assertEqual(box(), before)
             # a forced collision under the fallback is refused too, and the first message stands
-            os.link = link_raising(errno.EPERM)
+            os.link = raising(errno.EPERM)
             saved_unique = pm._unique
             pm._unique = lambda: "1700000000.4242_c0ffee.TESTHOST"
             try:
@@ -430,7 +443,7 @@ class MessageIdsNeverCollide(unittest.TestCase):
             standing = [m["body"] for m in pm.read_box(self.RCP, consume=False) if m["id"] == first]
             self.assertEqual(standing, ["first under the fallback"])
         finally:
-            os.link, pm.TLDIR, pm._log = saved_link, saved_tl, saved_log
+            os.link, os.rename, pm.TLDIR, pm._log = saved_link, saved_rename, saved_tl, saved_log
             pm._LINK_FALLBACK_SAID[0] = False
             shutil.rmtree(td, ignore_errors=True)
 

--- a/tests/test_postal_self_host.py
+++ b/tests/test_postal_self_host.py
@@ -314,5 +314,126 @@ class SafeIdTwins(unittest.TestCase):
             getattr(pm, "_postal_host_env_warned", set()).clear()
 
 
+class MessageIdsNeverCollide(unittest.TestCase):
+    """_unique() carries 128 bits of randomness (2026-09-08) — random.randint(0, 99999) gave 100k
+    names per second per process — and deliver() refuses to publish over a standing new/<name>: a
+    collision, however unlikely, is detected loudly, never a silent replace of somebody's unread
+    mail (rename() overwrote; the publish is a link() now, which refuses an existing target)."""
+
+    RCP = "22222222-3333-4444-5555-666666666666"
+    SND = "11111111-2222-3333-4444-555555555555"
+
+    def setUp(self):
+        # set, never popped: other modules set ROMP_POSTAL_HOST at import time (see the module head)
+        self._prev = os.environ.get("ROMP_POSTAL_HOST")
+        os.environ["ROMP_POSTAL_HOST"] = "TESTHOST"
+
+    def tearDown(self):
+        if self._prev is None:
+            os.environ.pop("ROMP_POSTAL_HOST", None)
+        else:
+            os.environ["ROMP_POSTAL_HOST"] = self._prev
+
+    def test_the_id_carries_128_bits_of_randomness(self):
+        mid = pm._unique()
+        self.assertTrue(pm._safe_id(mid), "still a path component the outbox accepts")
+        self.assertRegex(mid, r"^\d+\.\d+_[0-9a-f]{32}\.TESTHOST$")
+        self.assertEqual(len({pm._unique() for _ in range(10000)}), 10000, "ten thousand mints, zero collisions")
+
+    def test_a_standing_message_is_never_replaced(self):
+        import json
+        import shutil
+        shutil.rmtree(pm.MAILROOT, ignore_errors=True)
+        td = tempfile.mkdtemp()
+        saved_tl, saved_unique = pm.TLDIR, pm._unique
+        pm.TLDIR = type(pm.TLDIR)(td)
+        pm._unique = lambda: "1700000000.4242_deadbeef.TESTHOST"       # a forced collision
+        try:
+            first = pm.deliver(self.RCP, "web", self.SND, "the first message")
+            with self.assertRaises(pm.DeliveryNotRecorded) as cm:
+                pm.deliver(self.RCP, "web", self.SND, "an impostor with the same id")
+            box = pm.read_box(self.RCP, consume=False)
+            self.assertEqual([(m["id"], m["body"]) for m in box], [(first, "the first message")],
+                             "the standing message is untouched; the collision was refused, not tiebroken")
+            self.assertIn("refusing to replace", str(cm.exception))
+            rows = [json.loads(l) for l in (pm.TLDIR / "messages.jsonl").read_text().splitlines() if l]
+            self.assertEqual([r["ev"] for r in rows], ["sent", "sent", "bounced"],
+                             "the ledger closes on the refused id — no 'sent' left pending forever")
+            self.assertIn("refusing to replace", rows[-1]["why"])
+            self.assertEqual([p.name for p in (pm.MAILROOT / self.RCP / "tmp").iterdir()], [],
+                             "the temp is removed")
+        finally:
+            pm.TLDIR, pm._unique = saved_tl, saved_unique
+            shutil.rmtree(td, ignore_errors=True)
+
+    def test_publish_without_hard_links_falls_back_once_and_real_faults_refuse(self):
+        # mutants: the fallback errno set widened to every OSError → EIO/ENOSPC would publish by rename
+        # over a real fault; narrowed to none → a link-less filesystem could never deliver at all
+        import errno
+        import json
+        import shutil
+        shutil.rmtree(pm.MAILROOT, ignore_errors=True)
+        td = tempfile.mkdtemp()
+        saved_tl, saved_link, saved_log = pm.TLDIR, os.link, pm._log
+        pm.TLDIR = type(pm.TLDIR)(td)
+        logged = []
+        pm._log = lambda m: logged.append(m)
+
+        def rows():
+            return [json.loads(l) for l in (pm.TLDIR / "messages.jsonl").read_text().splitlines() if l]
+
+        def box():
+            newd = pm.MAILROOT / self.RCP / "new"
+            return sorted(p.name for p in newd.iterdir()) if newd.is_dir() else []
+
+        def tmpd():
+            t = pm.MAILROOT / self.RCP / "tmp"
+            return [p.name for p in t.iterdir()] if t.is_dir() else []
+
+        def link_raising(code):
+            def _link(src, dst, *a, **k):
+                raise OSError(code, "staged by the test")
+            return _link
+
+        try:
+            for code in (errno.EPERM, errno.EOPNOTSUPP, errno.ENOTSUP, errno.ENOSYS, errno.EMLINK, errno.EXDEV):
+                os.link = link_raising(code)
+                pm._LINK_FALLBACK_SAID[0] = False
+                logged.clear()
+                mid = pm.deliver(self.RCP, "web", self.SND, "via rename (%d)" % code)
+                self.assertIn(mid, box(), "errno %d: delivered by the checked rename" % code)
+                self.assertEqual(tmpd(), [], "errno %d: no temp left" % code)
+                pm.deliver(self.RCP, "web", self.SND, "again (%d)" % code)
+                self.assertEqual(len([m for m in logged if "hard links unavailable" in m]), 1,
+                                 "errno %d: said once per bus run, not per send" % code)
+            for code in (errno.EACCES, errno.EIO, errno.ENOSPC, errno.EEXIST):
+                os.link = link_raising(code)
+                before = box()
+                with self.assertRaises(pm.DeliveryNotRecorded):
+                    pm.deliver(self.RCP, "web", self.SND, "never lands (%d)" % code)
+                self.assertEqual(box(), before, "errno %d: nothing new in the inbox" % code)
+                self.assertEqual(tmpd(), [], "errno %d: the temp is removed" % code)
+                self.assertEqual([r["ev"] for r in rows()[-2:]], ["sent", "bounced"],
+                                 "errno %d: the ledger closes on the refused id" % code)
+                self.assertTrue(rows()[-1]["why"].startswith(pm.WHY_NOT_PUBLISHED))
+            # a forced collision under the fallback is refused too, and the first message stands
+            os.link = link_raising(errno.EPERM)
+            saved_unique = pm._unique
+            pm._unique = lambda: "1700000000.4242_c0ffee.TESTHOST"
+            try:
+                first = pm.deliver(self.RCP, "web", self.SND, "first under the fallback")
+                with self.assertRaises(pm.DeliveryNotRecorded) as cm:
+                    pm.deliver(self.RCP, "web", self.SND, "an impostor under the fallback")
+            finally:
+                pm._unique = saved_unique
+            self.assertIn("refusing to replace", str(cm.exception))
+            standing = [m["body"] for m in pm.read_box(self.RCP, consume=False) if m["id"] == first]
+            self.assertEqual(standing, ["first under the fallback"])
+        finally:
+            os.link, pm.TLDIR, pm._log = saved_link, saved_tl, saved_log
+            pm._LINK_FALLBACK_SAID[0] = False
+            shutil.rmtree(td, ignore_errors=True)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_postal_token.py
+++ b/tests/test_postal_token.py
@@ -625,30 +625,58 @@ class _LiveBus(unittest.TestCase):
 class InboxSurvivesAnUnreadableFile(_LiveBus):
     """One unreadable file in new/ (EACCES here; EIO in the wild) used to raise out of read_box, and
     do_GET has no handler: socketserver printed the traceback and closed the socket with NO HTTP
-    answer — on every /inbox and /drain — so the session got no mail at all (2026-09-08). Now the
-    file is skipped and left in place, the rest of the box is served, and the fault is said once per
-    file per bus run."""
+    answer, on every /inbox and /drain, so the session got no mail at all (2026-09-08). The rest of
+    the box is served, and the file is moved ASIDE once (review find, 2026-09-08): to
+    `<mailbox>/<name>.corrupt-<stamp>`, beside new/ and out of every listing, never deleted; with one
+    log line, one bell row through the kernel, a terminal row that closes the sender's receipt as
+    refused, and the pending marker no longer latched. The first cut left the file in place, said
+    once: re-skipped every poll, the marker up forever, the receipt pending forever, and nothing the
+    user could see. Mutants: the move dropped (the file stays, the marker latches); the row dropped
+    (the receipt reads pending); the notice dropped (the log alone knows)."""
 
     @unittest.skipIf(os.geteuid() == 0, "root reads a mode-0 file; the fault cannot be staged")
-    def test_the_rest_of_the_box_is_served_and_the_fault_is_said_once(self):
+    def test_the_file_is_moved_aside_once_the_rest_is_served_and_the_sender_hears_refused(self):
         import errno
         import shutil
         shutil.rmtree(ps.MAILROOT / _RCP, ignore_errors=True)
+        shutil.rmtree(ps.MAILPENDING, ignore_errors=True)
+        td = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(td, ignore_errors=True))
+        ps.TLDIR = Path(td)
+        told, saved_post = [], ps._kernel_post
+        ps._kernel_post = lambda path, body, timeout=2: told.append((path, body)) or {"ok": True}
+        self.addCleanup(lambda: setattr(ps, "_kernel_post", saved_post))
         ps.deliver(_RCP, "web", _SND, "the readable one", kind="coordinate")
-        bad = ps.MAILROOT / _RCP / "new" / "0-unreadable.TESTHOST"    # sorts FIRST: the fault hits before any row
-        bad.write_text("From: web\nFrom-Id: %s\nDate: t\n\nnever readable\n" % _SND)
-        os.chmod(bad, 0)
-        self.addCleanup(lambda: (os.chmod(bad, 0o600), bad.unlink()))
+        bad = ps.deliver(_RCP, "web", _SND, "never readable", kind="question")   # a real send: its sent row stands
+        badf = ps.MAILROOT / _RCP / "new" / bad
+        os.chmod(badf, 0)
         status, body = _call(self.port, "/inbox?id=%s&peek=1" % _RCP)
         self.assertEqual(status, 200, "the inbox answers")
         self.assertEqual([m["body"] for m in body["messages"]], ["the readable one"],
                          "the rest of the box is served")
-        self.assertTrue(bad.exists(), "the unreadable file is left in place, never deleted")
+        self.assertFalse(badf.exists(), "the unreadable file leaves new/")
+        aside = [p.name for p in (ps.MAILROOT / _RCP).iterdir() if p.name.startswith(bad + ".corrupt-")]
+        self.assertEqual(len(aside), 1, "moved aside beside new/, kept as evidence")
         status, body = _call(self.port, "/inbox?id=%s&peek=1" % _RCP)
         self.assertEqual((status, [m["body"] for m in body["messages"]]), (200, ["the readable one"]))
-        said = [m for m in self.logged if "0-unreadable.TESTHOST" in m]
+        said = [m for m in self.logged if bad in m]
         self.assertEqual(len(said), 1, "said once across two polls, not per poll")
-        self.assertIn("errno %d" % errno.EACCES, said[0], "…naming the errno")
+        self.assertIn("errno %d" % errno.EACCES, said[0], "naming the errno")
+        self.assertIn(aside[0], said[0], "and where it went")
+        self.assertEqual([(p, "moved aside" in b.get("text", "")) for p, b in told], [("/postal-notice", True)],
+                         "one bell row through the kernel, not one per poll")
+        rows = [json.loads(l) for l in (Path(td) / "messages.jsonl").read_text().splitlines() if l]
+        self.assertEqual([r["ev"] for r in rows if r.get("id") == bad], ["sent", "bounced"],
+                         "the ledger closes on the id nobody can read")
+        rec = [r for r in ps._sent_receipts(_SND) if r["id"] == bad][0]
+        self.assertTrue(rec["bounced"])
+        self.assertTrue(rec["bouncedWhy"].startswith(ps.WHY_INBOX_UNREADABLE))
+        txt = ps.format_receipts([rec])
+        self.assertIn("refused", txt)
+        self.assertNotIn("returned to you", txt, "no return note exists for a refusal")
+        _call(self.port, "/inbox?id=%s" % _RCP)                        # the drain consumes the readable one
+        self.assertFalse((ps.MAILPENDING / _RCP).exists(),
+                         "the pending marker is not latched by a file nobody can read")
 
 
 class SendRefusesWhenTheRowCannotLand(_LiveBus):

--- a/tests/test_postal_token.py
+++ b/tests/test_postal_token.py
@@ -568,5 +568,164 @@ class PostalLockFailureIsFailClosed(_PostalTokenFile):
         self.assertEqual(self._temps(), [])
 
 
+def _call(port, path, method="GET", payload=None):
+    """(status, body) over the real Handler, token in hand — a refusal answers a JSON body too."""
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request("http://127.0.0.1:%d%s" % (port, path), data=data, method=method,
+                                 headers={"X-Romp-Token": TOK, "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=5) as r:
+            return r.status, json.loads(r.read().decode() or "{}")
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode() or "{}")
+
+
+_RCP = "22222222-3333-4444-5555-666666666666"
+_SND = "11111111-2222-3333-4444-555555555555"
+
+
+class _LiveBus(unittest.TestCase):
+    """A real ThreadingHTTPServer on ps.Handler: the routes below are pinned by their HTTP answers,
+    not by calling read_box / deliver directly — the defects were in what the socket saw."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), ps.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+        cls.srv.server_close()
+
+    def setUp(self):
+        self._saved = (ps.TLDIR, ps._log, ps.resolve_recipient)
+        self.logged = []
+        ps._log = lambda m: self.logged.append(m)
+        if hasattr(ps, "_TL_FAULT"):
+            ps._TL_FAULT[0] = False
+        getattr(ps, "_UNREADABLE_SAID", set()).clear()
+
+    def tearDown(self):
+        ps.TLDIR, ps._log, ps.resolve_recipient = self._saved
+        if hasattr(ps, "_TL_FAULT"):
+            ps._TL_FAULT[0] = False
+        ps.PEERS.pop("farhost", None)
+
+    def _break_the_log(self):
+        # TLDIR under a regular FILE: mkdir raises (ENOTDIR), so the REAL _tl_append fails the way a
+        # full or read-only disk fails it
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.addCleanup(lambda: os.unlink(path))
+        ps.TLDIR = Path(path) / "timeline"
+
+
+class InboxSurvivesAnUnreadableFile(_LiveBus):
+    """One unreadable file in new/ (EACCES here; EIO in the wild) used to raise out of read_box, and
+    do_GET has no handler: socketserver printed the traceback and closed the socket with NO HTTP
+    answer — on every /inbox and /drain — so the session got no mail at all (2026-09-08). Now the
+    file is skipped and left in place, the rest of the box is served, and the fault is said once per
+    file per bus run."""
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-0 file; the fault cannot be staged")
+    def test_the_rest_of_the_box_is_served_and_the_fault_is_said_once(self):
+        import errno
+        import shutil
+        shutil.rmtree(ps.MAILROOT / _RCP, ignore_errors=True)
+        ps.deliver(_RCP, "web", _SND, "the readable one", kind="coordinate")
+        bad = ps.MAILROOT / _RCP / "new" / "0-unreadable.TESTHOST"    # sorts FIRST: the fault hits before any row
+        bad.write_text("From: web\nFrom-Id: %s\nDate: t\n\nnever readable\n" % _SND)
+        os.chmod(bad, 0)
+        self.addCleanup(lambda: (os.chmod(bad, 0o600), bad.unlink()))
+        status, body = _call(self.port, "/inbox?id=%s&peek=1" % _RCP)
+        self.assertEqual(status, 200, "the inbox answers")
+        self.assertEqual([m["body"] for m in body["messages"]], ["the readable one"],
+                         "the rest of the box is served")
+        self.assertTrue(bad.exists(), "the unreadable file is left in place, never deleted")
+        status, body = _call(self.port, "/inbox?id=%s&peek=1" % _RCP)
+        self.assertEqual((status, [m["body"] for m in body["messages"]]), (200, ["the readable one"]))
+        said = [m for m in self.logged if "0-unreadable.TESTHOST" in m]
+        self.assertEqual(len(said), 1, "said once across two polls, not per poll")
+        self.assertIn("errno %d" % errno.EACCES, said[0], "…naming the errno")
+
+
+class SendRefusesWhenTheRowCannotLand(_LiveBus):
+    """The /send route answers ok:false — 503, so the tool and CLI clients, which raise only on a
+    non-2xx, surface it — when the sent row cannot be written, on BOTH legs: the relay park and the
+    local delivery. On origin/main both answered ok:true: the relay leg parked the message and
+    appended the row afterwards regardless, and deliver() published before its best-effort row."""
+
+    def _far(self):
+        ps.resolve_recipient = lambda to, frm_id="": {"kind": "relay", "host": "farhost",
+                                                       "agent": {"name": to, "id": _RCP}}
+        ps.PEERS["farhost"] = {"up": True, "port": 1}
+
+    def _send(self, kind="coordinate"):
+        return _call(self.port, "/send", "POST", {"to": "api", "from": "web", "from_id": _SND,
+                                                  "body": "the staging port?", "kind": kind})
+
+    def test_the_relay_leg_answers_ok_false_and_parks_nothing(self):
+        import shutil
+        shutil.rmtree(ps.OUTBOX / "farhost", ignore_errors=True)
+        self._far()
+        self._break_the_log()
+        status, body = self._send()
+        self.assertEqual(status, 503)
+        self.assertFalse(body.get("ok"))
+        self.assertIn("not recorded", body.get("error", ""))
+        self.assertIn("retry", body.get("error", ""))
+        self.assertEqual(ps.outbox_list("farhost"), [], "nothing parked without its row")
+
+    def test_the_relay_leg_still_answers_ok_when_the_row_lands(self):
+        import shutil
+        shutil.rmtree(ps.OUTBOX / "farhost", ignore_errors=True)
+        self._far()
+        td = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(td, ignore_errors=True))
+        ps.TLDIR = Path(td)
+        status, body = self._send()
+        self.assertEqual((status, body.get("ok")), (200, True))
+        self.assertEqual([m["mid"] for m in ps.outbox_list("farhost")], [body["id"]], "parked, with its row")
+        rows = [json.loads(l) for l in (Path(td) / "messages.jsonl").read_text().splitlines() if l]
+        self.assertEqual([(r["ev"], r["id"]) for r in rows], [("sent", body["id"])])
+
+    def test_the_local_leg_answers_ok_false_and_delivers_nothing(self):
+        import shutil
+        shutil.rmtree(ps.MAILROOT / _RCP, ignore_errors=True)
+        ps.resolve_recipient = lambda to, frm_id="": {"kind": "direct",
+                                                       "agent": {"name": to, "id": _RCP, "remote": False}}
+        self._break_the_log()
+        status, body = self._send(kind="question")
+        self.assertEqual(status, 503)
+        self.assertFalse(body.get("ok"))
+        self.assertIn("not delivered", body.get("error", ""))
+        newd = ps.MAILROOT / _RCP / "new"
+        self.assertEqual([p.name for p in newd.iterdir()] if newd.is_dir() else [], [], "no mail without its row")
+
+    def test_a_park_that_fails_after_the_row_closes_the_ledger_and_refuses(self):
+        # mutant: outbox_put's False ignored → 200 "relaying" with a sent row and nothing parked
+        import shutil
+        self._far()
+        td = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(td, ignore_errors=True))
+        ps.TLDIR = Path(td)
+        saved = ps.outbox_put
+        ps.outbox_put = lambda h, m: False                  # the record could not be written
+        try:
+            status, body = self._send()
+        finally:
+            ps.outbox_put = saved
+        self.assertEqual(status, 503)
+        self.assertFalse(body.get("ok"))
+        self.assertIn("could not be parked", body.get("error", ""))
+        rows = [json.loads(l) for l in (Path(td) / "messages.jsonl").read_text().splitlines() if l]
+        self.assertEqual([r["ev"] for r in rows], ["sent", "bounced"], "the ledger closes on the refused id")
+        self.assertEqual(rows[0]["id"], rows[1]["id"])
+        self.assertEqual(rows[1]["why"], ps.WHY_NOT_PARKED)
+
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_postal_undelivered.py
+++ b/tests/test_postal_undelivered.py
@@ -89,5 +89,114 @@ class StuckMailWarning(unittest.TestCase):
                          "the marker is pruned once the message left new/ so WARNED stays bounded")
 
 
+class RefusedNotesKeepTheMail(unittest.TestCase):
+    """deliver() can REFUSE now (2026-09-08: its sent row could not land). The orphan sweep and the
+    stuck-mail warning used to catch every deliver error and carry on — destroy the orphan, touch the
+    one-time marker — so a refused note lost the mail with no notice and no row, and the warning was
+    never retried. A refusal keeps the file and the marker untouched, is said once per episode, and
+    the next pass retries once the log writes again. Mutants killed: the generic `except Exception`
+    arm swallowing the refusal (the orphan is destroyed / the marker touched); the sweep's destroy
+    row written best-effort AFTER the unlink (the file goes with no row)."""
+
+    def setUp(self):
+        self._seamfile = os.path.join(tempfile.mkdtemp(), "sessions.json")
+        os.environ["ROMP_SESSIONS_FILE"] = self._seamfile
+        for d in (pm.MAILROOT, pm.WARNED, pm.MAILPENDING):
+            shutil.rmtree(d, ignore_errors=True)
+        self._tl, self._log = pm.TLDIR, pm._log
+        self.logged = []
+        pm._log = lambda m: self.logged.append(m)
+        try:
+            (pm.TLDIR / "messages.jsonl").unlink()
+        except OSError:
+            pass
+        pm._TL_FAULT[0] = False
+        pm._REFUSAL_SAID.clear()
+
+    def tearDown(self):
+        pm.TLDIR, pm._log = self._tl, self._log
+        pm._TL_FAULT[0] = False
+        pm._REFUSAL_SAID.clear()
+        os.environ.pop("ROMP_SESSIONS_FILE", None)
+
+    def _live(self, rows):
+        Path(self._seamfile).write_text(json.dumps(rows))
+
+    def _break_the_log(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.addCleanup(lambda: os.unlink(path))
+        pm.TLDIR = Path(path) / "timeline"          # under a regular file: the REAL append fails (ENOTDIR)
+
+    def _age(self, secs):
+        old = time.time() - secs
+        for f in (pm.MAILROOT / RECIP / "new").iterdir():
+            os.utime(f, (old, old))
+
+    def _rows(self):
+        p = self._tl / "messages.jsonl"
+        return [json.loads(l) for l in p.read_text().splitlines() if l] if p.exists() else []
+
+    def _said(self):
+        return len([m for m in self.logged if "kept for the next pass" in m])
+
+    def test_the_sweep_keeps_an_orphan_whose_bounce_note_was_refused(self):
+        self._live([{"id": SENDER, "name": "alice", "state": "idle"}])          # bob is dead → an orphan
+        mid = pm.deliver(RECIP, "alice", SENDER, "please review my PR")
+        self._age(pm.ORPHAN_GRACE + 60)
+        self._break_the_log()
+        pm._sweep_orphans()
+        self.assertTrue((pm.MAILROOT / RECIP / "new" / mid).exists(),
+                        "a refused bounce note destroys nothing: the orphan waits for the next sweep")
+        self.assertEqual(pm.read_box(SENDER, consume=False), [], "no note was published without its row")
+        pm._sweep_orphans()
+        self.assertTrue((pm.MAILROOT / RECIP / "new" / mid).exists())
+        self.assertEqual(self._said(), 1, "said once per episode, not per pass")
+        pm.TLDIR = self._tl                                                    # the log writes again
+        pm._sweep_orphans()
+        self.assertFalse((pm.MAILROOT / RECIP / "new" / mid).exists(), "the next pass completes the bounce")
+        notes = pm.read_box(SENDER, consume=False)
+        self.assertEqual(len(notes), 1)
+        self.assertIn("UNDELIVERED", notes[0]["body"])
+        self.assertEqual([r["ev"] for r in self._rows() if r.get("id") == mid], ["sent", "bounced"],
+                         "the destroy landed on the ledger")
+
+    def test_the_sweep_records_the_destroy_before_it_destroys(self):
+        # no live sender to bounce to (the sweep still runs: someone is live) → straight to the destroy
+        self._live([{"id": "33333333-4444-5555-6666-777777777777", "name": "carol", "state": "idle"}])
+        mid = pm.deliver(RECIP, "alice", SENDER, "please review my PR")
+        self._age(pm.ORPHAN_GRACE + 60)
+        self._break_the_log()
+        pm._sweep_orphans()
+        self.assertTrue((pm.MAILROOT / RECIP / "new" / mid).exists(),
+                        "a destroy that cannot be recorded does not happen")
+        pm.TLDIR = self._tl
+        pm._sweep_orphans()
+        self.assertFalse((pm.MAILROOT / RECIP / "new" / mid).exists())
+        self.assertEqual([r["ev"] for r in self._rows() if r.get("id") == mid], ["sent", "bounced"])
+
+    def test_the_stuck_warning_is_retried_once_its_note_lands(self):
+        self._live([{"id": SENDER, "name": "alice", "state": "idle"},
+                    {"id": RECIP, "name": "bob", "state": "idle"}])
+        mid = pm.deliver(RECIP, "alice", SENDER, "please review my PR")
+        self._age(pm.STUCK_GRACE + 60)
+        self._break_the_log()
+        pm._warn_stuck_mail()
+        self.assertFalse((pm.WARNED / mid).exists(), "a refused warning leaves the one-time marker untouched")
+        self.assertEqual(pm.read_box(SENDER, consume=False), [])
+        pm._warn_stuck_mail()
+        self.assertFalse((pm.WARNED / mid).exists())
+        self.assertEqual(self._said(), 1, "said once per episode")
+        pm.TLDIR = self._tl
+        pm._warn_stuck_mail()
+        warns = pm.read_box(SENDER, consume=False)
+        self.assertEqual(len(warns), 1, "the warning fires on the first pass whose note lands")
+        self.assertIn("STILL UNDELIVERED", warns[0]["body"])
+        self.assertTrue((pm.WARNED / mid).exists(), "…and only then is it marked one-time")
+        pm._warn_stuck_mail()
+        self.assertEqual(len(pm.read_box(SENDER, consume=False)), 1, "one-time still holds")
+        self.assertTrue((pm.MAILROOT / RECIP / "new" / mid).exists(), "the stuck message itself is left for delivery")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_postal_undelivered.py
+++ b/tests/test_postal_undelivered.py
@@ -198,5 +198,55 @@ class RefusedNotesKeepTheMail(unittest.TestCase):
         self.assertTrue((pm.MAILROOT / RECIP / "new" / mid).exists(), "the stuck message itself is left for delivery")
 
 
+class TheSweepMovesAnUnreadableFileAside(unittest.TestCase):
+    """A DEAD recipient's box has no drain to meet an unreadable file, so the orphan sweep moves it
+    aside the way read_box does (review find, 2026-09-08): before, the sweep skipped it on every pass
+    and the pending marker stayed latched for a session that will never read. The sidecar is
+    evidence: the tidy that removes an emptied box leaves a box holding one. Mutants: the sweep's
+    catch-all `except Exception: continue` kept for OSError (the file stays); the tidy guard removed
+    (the sidecar goes with the box)."""
+
+    def setUp(self):
+        self._seamfile = os.path.join(tempfile.mkdtemp(), "sessions.json")
+        os.environ["ROMP_SESSIONS_FILE"] = self._seamfile
+        for d in (pm.MAILROOT, pm.WARNED, pm.MAILPENDING):
+            shutil.rmtree(d, ignore_errors=True)
+        self._saved = (pm.TLDIR, pm._log, pm._kernel_post)
+        self.logged, self.told = [], []
+        pm._log = lambda m: self.logged.append(m)
+        pm._kernel_post = lambda path, body, timeout=2: self.told.append((path, body)) or {"ok": True}
+        try:
+            (pm.TLDIR / "messages.jsonl").unlink()
+        except OSError:
+            pass
+        pm._DASHBOARD_MISSED[0] = False
+
+    def tearDown(self):
+        pm.TLDIR, pm._log, pm._kernel_post = self._saved
+        pm._DASHBOARD_MISSED[0] = False
+        os.environ.pop("ROMP_SESSIONS_FILE", None)
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-0 file; the fault cannot be staged")
+    def test_the_file_is_moved_aside_the_marker_drops_and_the_box_keeps_its_evidence(self):
+        Path(self._seamfile).write_text(json.dumps([{"id": SENDER, "name": "alice", "state": "idle"}]))   # bob is dead
+        mid = pm.deliver(RECIP, "alice", SENDER, "please review my PR", kind="question")
+        f = pm.MAILROOT / RECIP / "new" / mid
+        os.chmod(f, 0)
+        self.assertTrue((pm.MAILPENDING / RECIP).exists())
+        pm._sweep_orphans()
+        self.assertFalse(f.exists(), "the unreadable file leaves new/")
+        aside = [p.name for p in (pm.MAILROOT / RECIP).iterdir() if p.name.startswith(mid + ".corrupt-")]
+        self.assertEqual(len(aside), 1, "moved aside beside new/, never deleted")
+        self.assertFalse((pm.MAILPENDING / RECIP).exists(), "the marker drops: nothing readable is pending")
+        rows = [json.loads(l) for l in (pm.TLDIR / "messages.jsonl").read_text().splitlines() if l]
+        self.assertEqual([r["ev"] for r in rows if r.get("id") == mid], ["sent", "bounced"])
+        self.assertTrue([r for r in rows if r.get("id") == mid][-1]["why"].startswith(pm.WHY_INBOX_UNREADABLE))
+        self.assertEqual(len([p for p, b in self.told if p == "/postal-notice"]), 1, "one bell row")
+        self.assertEqual(pm.read_box(SENDER, consume=False), [], "no bounce note: the sender's receipt carries it")
+        pm._sweep_orphans()
+        self.assertTrue((pm.MAILROOT / RECIP).is_dir(), "the emptied box is not tidied away while it holds evidence")
+        self.assertEqual(len([p for p, b in self.told if p == "/postal-notice"]), 1, "said once")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Four narrow silent-loss windows in the mail bus's file store, verified on `main`:

- **Receipts after deletes, publishes before the sent row.** `_tl_append` was best-effort with no return; `deliver` published the mail into the recipient's inbox and only then appended the sent row, so a failed row left delivered mail with no accounting; the relay leg parked the message and answered ok regardless of its row; the ack and bounce handlers deleted the outbox record before writing the receipt row or the return note, so a crash between them lost the accounting.
- **Non-atomic stores, torn records skipped forever.** The outbox and readbox wrote records with a plain write, and their listings skipped an unparseable record silently on every pass.
- **Low-entropy ids.** `_unique` had 100k names per second per process, and a colliding publish silently replaced a standing message.
- **One bad inbox file starved the inbox.** One unreadable file raised out of the inbox read with no HTTP answer, on every poll, so the session got no mail at all.

## What changes

**The row comes first.** `_tl_append` returns whether the row landed, saying a fault once per episode and once on recovery. `deliver` appends the sent row before publishing; if the row cannot land, the temp is removed and the send is refused as not recorded; if the publish fails after the row, a terminal bounced row corrects the record. The relay leg appends before it parks. The ack and bounce handlers write the receipt row or queue the return note before deleting the outbox record, and keep the record when the row fails. A refusal answers 503 with `ok: false` and the reason: a bare `ok: false` would read as delivered, because the client library raises only on a non-2xx status.

**Publishes are atomic and never replace.** `_publish_new` links the temp into place and refuses an existing target; a filesystem without hard links falls back to an exists check and rename, said once. Outbox and readbox records go through a temp, fsync and replace; a torn record is moved aside once to `<name>.corrupt-<stamp>`, with a stat fingerprint so a concurrent atomic rewrite is never moved, and the listing goes on.

**A refusal never destroys mail.** The orphan sweep and the stuck-mail warning, which send bounce notes through `deliver`, keep the file and leave the warning marker untouched when the note is refused, say so once, and retry on the next pass; before, they swallowed the refusal and deleted or marked anyway. A torn outbox record that the listing moves aside also gets a terminal row, so the sender's receipt says the record was unreadable instead of pending forever, and a receipt for a refused send reads as refused, not "returned to you".

**Ids carry 128 bits of randomness**, in the same shape `_safe_id` already accepts.

**One unreadable inbox file is skipped**, left in place, said once per file and errno; the rest of the inbox is served.

## Judgment calls

- A refused trusted relay delivery now answers "retry" rather than being acked and marked seen.
- The ack and bounce handlers with no readable record used to delete the file anyway; they now leave it, since the listing's quarantine is the evidence path.
- An unreadable file left in the inbox keeps the pending marker raised, so the retry loop re-pushes a no-op each interval. Harmless, noted.
- Residual, deferred: a refused send leaves a `sent` row and a terminal `bounced` row, and the kernel's and judge's wait readers ignore terminal rows, so a refused question reads as an open ask until the recipient sends anything back. Every real bounce already has that shape; a follow-up in those readers, which another open PR is reshaping, should close a pair on a terminal bounced row.

## Tests

`tests/test_postal_peers.py`: a failing row leaves no mail and answers a refusal; the relay leg answers `ok: false`; the bounce and ack handlers keep the record when the row fails and write the row before the delete, executed with recorders; outbox and readbox publish through replace; a torn record is moved aside once with a log line and the rest listed; the fingerprint guard. Also: the relay's refusal answers "retry" rather than acking and marking the message seen; the relay leg's park failing after the row writes the terminal row and answers 503; the bounce-arrived handler queues before it deletes; a refused approve leaves the held message in place; a bounce with no readable record deletes nothing; the recovery line fires exactly once when the log writes again; the no-hard-links fallback delivers by rename for its errnos and refuses the rest; the orphan sweep and stuck-mail warning keep refused mail. `tests/test_postal_self_host.py`: the id shape and a forced collision refused. `tests/test_postal_token.py`: over the real bus handler, an inbox with one unreadable file serves the others and says so once across two polls; a send whose row cannot land answers 503 on both legs, with a control that lands. Each fails on `main` with the first error the commit body names.

Module counts on this tree, one runner at a time: `tests/test_postal_peers.py` 49; `tests/test_postal_self_host.py` 12; `tests/test_postal_token.py` 23; `tests/test_kernel_deliver.py` 11; `tests/test_postal_undelivered.py` 7; `tests/test_postal_read_receipts.py` 19; `tests/test_postal_quarantine.py` 31; `tests/test_postal_delivery.py` 16; `tests/test_timeline_pending.py` 8; `tests/test_postal_relay_honesty.py` 30; `tests/test_postal_safe_id.py` 16 (28 subtests); `tests/test_postal_walked_ask.py` 7; `tests/test_postal_self_send.py` 28; `tests/test_postal_deferred_push_identity.py` 7; `tests/test_postal_isolation.py` 7; `tests/test_tracked_delegation.py` 13; `tests/test_relay_exec_dmid.py` 3; `tests/test_tunnel_demand_redial.py` 8; `bats tests/romp-postal.bats` 26 of 26. On `main` every new test fails with the first error the commit body names. Rebased over #1038's fold: its oversize bounce, when its note is refused, now puts the claimed message back and says so once; its note-then-row order in that one path is left as written and stated. Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## A CI flake that turned out to be this bug
A Python job on another PR failed once today with `11 != 12 : every message arrived exactly once` in the exchange-budget drain test, on a tree that had passed an hour earlier. The cause is the mail loss this PR fixes: on `main` a delivered message is named by a per-second random draw from a hundred thousand values and published with a rename that replaces a standing file, so two relays landing in one second collide about once in fifteen hundred drains of twelve, both are acknowledged, both ledgers say delivered, and one message is gone. This branch's 128-bit ids and link-based publish make the collision refuse instead of overwrite, and the sender re-relays under a fresh name. A deterministic test now forces the collision through a seam on the id mint and asserts all twelve arrive under twelve distinct names, with the refused relay acknowledged on the next exchange. Working through it also showed that a refused publish still wrote the refused message's rows under the standing message's name, so the recipient's ledger marked a delivered message as bounced; the recipient now publishes first and records only what landed, and a refused publish leaves no row. The test for that is red on the branch's previous head.


