### PR TITLE
A queued remote tag edit survives the extension's reconnect

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -23,7 +23,7 @@ import { execFile } from "child_process";
 import WebSocket from "ws";
 import { chatBody, FEED_BODY, FLEET_BODY, TIMELINE_BODY, ATTACH_TITLE_VSCODE } from "./page-skeleton";
 import { ensureThenAttach, parseHealthz, warnAfter } from "./kernel-attach";
-import { intentOp } from "./pipe-intent";
+import { intentOp, ReloadHold } from "./pipe-intent";
 import { routeViewMessage } from "./view-routing";
 import { deriveStatus, freshNeedsYou, renderStatusBar, statusTooltipLines, FleetStatus } from "./fleet-status";
 import { citeText, sessionsForWorkspace, SessionInfo } from "./workspace-sessions";
@@ -463,9 +463,10 @@ function askManagerEnsure(port: number): Promise<boolean> {
 class KernelPipe {
   private ws: WebSocket | null = null;
   private queue: { s: string; intent: boolean }[] = [];
+  private hold = new ReloadHold();   // refusals that arrived while the webview was reloading; see webviewReady
   private alive = true;
   private everConnected = false;
-  webviewReady = false;
+  private _webviewReady = false;
   constructor(
     private app: "chat" | "feed" | "timeline" | "fleet",
     private onDown: (m: any) => void,
@@ -480,6 +481,16 @@ class KernelPipe {
   }
   queuedIntents(): number {
     return this.queue.reduce((n, q) => n + (q.intent ? 1 : 0), 0);
+  }
+  // Set by the panel on its webview's "ready". The rising edge is the event a HELD frame waits for: a
+  // frame posted to a webview between its reload and its "ready" is gone, and the kernel's refusal of a
+  // replayed intent arrives in exactly that window: the reconnect below replays and then reloads in one
+  // tick. A remote-tag ADD replayed right after a kernel restart is refused (the home kernel's tunnel is
+  // not up yet, and an add never queues), and its tagEditFailed was never seen (review find, 2026-09-08).
+  get webviewReady(): boolean { return this._webviewReady; }
+  set webviewReady(v: boolean) {
+    this._webviewReady = v;
+    if (v) for (const m of this.hold.release()) this.onDown(m);
   }
   send(m: any) {
     const s = JSON.stringify(m);
@@ -529,6 +540,9 @@ class KernelPipe {
       // keepalive carries the kernel's dist build token — drift vs this bundle's stamp → one banner.
       // Panel pipes only: the passive status pipe observes and never toasts.
       if (m && m.type === "ka" && !this.passive) maybeBuildNotice(m.dv);
+      // a refusal for a webview that is mid-reload waits for its "ready" (webviewReady above); the passive
+      // status pipe has no webview and posts no intent, so nothing of its is ever held
+      if (!this.passive && !this.hold.offer(m, this._webviewReady)) return;
       this.onDown(m);
     });
     const reconnect = () => {
@@ -542,6 +556,7 @@ class KernelPipe {
   }
   dispose() {
     this.alive = false;
+    this.hold.release();   // the panel is gone; nothing is waiting for its ready any more
     try { this.ws?.close(); } catch { /* ignore */ }
     this.ws = null;
   }

--- a/vscode-extension/src/pipe-durability.test.ts
+++ b/vscode-extension/src/pipe-durability.test.ts
@@ -29,6 +29,15 @@ test("reconnect flushes intent ops before the webview reload instead of wiping t
   assert.ok(open.indexOf("const keep") < open.indexOf("this.queue = [];"), "keep must be captured before the wipe");
 });
 
+test("a refusal that arrives while the webview reloads is held for its ready, never posted into the reload", () => {
+  // the reconnect branch replays intent and rebuilds the html in the same tick; the kernel's refusal of a
+  // replayed op (a remote-tag ADD right after a kernel restart: the home kernel's tunnel is not up yet,
+  // and an add never queues) lands between the two, on a page that is gone (review find, 2026-09-08).
+  // Held at the pipe, so every panel gets it; delivered on the pipe's own ready edge, not in a panel's onDown.
+  assert.match(SRC, /if \(!this\.passive && !this\.hold\.offer\(m, this\._webviewReady\)\) return;\s*\n\s*this\.onDown\(m\);/);
+  assert.match(SRC, /set webviewReady\(v: boolean\) \{\s*\n\s*this\._webviewReady = v;\s*\n\s*if \(v\) for \(const m of this\.hold\.release\(\)\) this\.onDown\(m\);/);
+});
+
 test("the first-ever connect still flushes everything queued before the pipe was up", () => {
   assert.match(SRC, /this\.everConnected = true;\s*\n\s*for \(const q of this\.queue\) ws\.send\(q\.s\);/);
 });

--- a/vscode-extension/src/pipe-intent.test.ts
+++ b/vscode-extension/src/pipe-intent.test.ts
@@ -16,9 +16,16 @@ test("explicit state-changing picks are intent", () => {
   // 2026-09-05) — a tag renamed during a reconnect window must still land
   for (const t of ["setModel", "setEffort", "setMode", "setFast", "interrupt", "endSession",
     "nodeOverride", "askClear", "answerAsk", "submitAsk", "renameSession", "moveSession",
-    "setTimelineViews", "tagEdit"]) {
+    "setTimelineViews", "tagEdit", "editTag"]) {
     assert.ok(intentOp(t), `${t} must survive a reconnect`);
   }
+});
+
+test("a remote-tag edit is intent — its local half is already on screen when it is posted", () => {
+  // editTag is the federation op for a tag whose home is another kernel (render.ts's union add/remove,
+  // the timeline's __rompTimelineEditTag hook, 2026-08-24): the pane mirrors the edit locally right
+  // beside the post, so a post dropped on reconnect leaves a half-applied edit the user believes landed
+  assert.ok(intentOp("editTag"), "a queued editTag must be kept across the extension's reconnect");
 });
 
 test("view chatter is not intent — the reconnect reload resyncs it", () => {

--- a/vscode-extension/src/pipe-intent.test.ts
+++ b/vscode-extension/src/pipe-intent.test.ts
@@ -1,9 +1,11 @@
 // intentOp gates what survives a KernelPipe reconnect: user intent (typed text,
 // explicit picks) delivers after the socket returns; view chatter drops, because
 // the reconnect reloads the webview and resyncs it fresh (the user 2026-07-21).
+// heldAcrossReload / ReloadHold are the inbound half: the kernel's refusal of a
+// replayed op must outlive that same reload (review find, 2026-09-08).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { INTENT_OPS, intentOp } from "./pipe-intent";
+import { INTENT_OPS, intentOp, HELD_ACROSS_RELOAD, heldAcrossReload, ReloadHold } from "./pipe-intent";
 
 test("typed-text ops are intent — losing them loses the user's words", () => {
   for (const t of ["sendMessage", "askFollowUp", "askText", "addCustomAsk", "sendCommand", "rewindSend"]) {
@@ -21,11 +23,41 @@ test("explicit state-changing picks are intent", () => {
   }
 });
 
-test("a remote-tag edit is intent — its local half is already on screen when it is posted", () => {
+test("a remote-tag edit is intent: dropped on reconnect, it was simply lost", () => {
   // editTag is the federation op for a tag whose home is another kernel (render.ts's union add/remove,
-  // the timeline's __rompTimelineEditTag hook, 2026-08-24): the pane mirrors the edit locally right
-  // beside the post, so a post dropped on reconnect leaves a half-applied edit the user believes landed
+  // the timeline's __rompTimelineEditTag hook, 2026-08-24). The pane mirrors the edit locally beside
+  // the post, but the mirror never outlives the reconnect: every panel's onReconnect reloads its
+  // webview and the fresh "ready" resyncs from the kernel, where the edit never landed. So a post
+  // dropped with the view chatter left the tag unchanged, with nothing saying the gesture was lost
+  // (review find, 2026-09-08: the earlier wording had the mirror staying on screen, which it cannot)
   assert.ok(intentOp("editTag"), "a queued editTag must be kept across the extension's reconnect");
+});
+
+test("a refusal of a replayed intent is held across the webview's reload; state frames are not", () => {
+  // the reconnect replays intent and reloads the webview in one tick; the kernel's refusal of a replayed
+  // op (a remote-tag ADD right after a kernel restart: the home kernel's tunnel is not up yet, and an
+  // add never queues) then lands on a page that is gone (review find, 2026-09-08). A refusal addressed
+  // by name is one the fresh page can show; a state frame is resynced by its ready, and a per-page write
+  // ack names a write the fresh page never made
+  assert.ok(heldAcrossReload("tagEditFailed"), "the remote-tag refusal must reach the reloaded timeline");
+  assert.ok(HELD_ACROSS_RELOAD.has("tagEditFailed"));
+  for (const t of ["data", "bars", "caps", "ka", "pipeState", "models", "tagEditAck", "viewsAck"])
+    assert.ok(!heldAcrossReload(t), `${t} is resynced by the fresh ready, or names a write the fresh page never made`);
+  assert.ok(!heldAcrossReload(undefined));
+  assert.ok(!heldAcrossReload(42));
+});
+
+test("the hold parks a refusal only while the webview is not ready, and releases once, in arrival order", () => {
+  const h = new ReloadHold();
+  const refused = { type: "tagEditFailed", host: "TESTHOST-B", name: "team",
+    error: '"TESTHOST-B" is attached but not reachable right now', queued: false };
+  assert.equal(h.offer({ type: "data", data: {} }, false), true, "a state frame goes into the reload; the ready resyncs it");
+  assert.equal(h.offer(refused, false), false, "the refusal waits for the ready");
+  assert.equal(h.offer({ type: "tagEditFailed", host: "TESTHOST-B", name: "pool", error: "refused" }, false), false);
+  assert.deepEqual(h.release().map((m: any) => m.name), ["team", "pool"], "released in arrival order");
+  assert.deepEqual(h.release(), [], "…and only once");
+  assert.equal(h.offer(refused, true), true, "with the webview ready a refusal goes straight through");
+  assert.deepEqual(h.release(), [], "…and is not parked on the way");
 });
 
 test("view chatter is not intent — the reconnect reload resyncs it", () => {

--- a/vscode-extension/src/pipe-intent.ts
+++ b/vscode-extension/src/pipe-intent.ts
@@ -15,6 +15,7 @@ export const INTENT_OPS: ReadonlySet<string> = new Set([
   "nodeOverride", "askClear", "undoClear", "cardMove", "cardNotify", "redistill",
   "answerAsk", "submitAsk", "toggleAsk", "navAsk", "cancelAsk",
   "setSessionFlag", "setSessionColor", "setGlobalRetryPaused", "setTimelineViews", "tagEdit", "openTagsDialog",
+  "editTag",  // the REMOTE-tag edit: its optimistic local half is already on screen, so a drop half-applies the gesture
   "reorderTabs", "closeTab",
 ]);
 

--- a/vscode-extension/src/pipe-intent.ts
+++ b/vscode-extension/src/pipe-intent.ts
@@ -5,6 +5,8 @@
 // silently ate a card reply sent during a kernel-restart window (the user
 // 2026-07-21, roof). View chatter stays droppable — the reconnect reloads the
 // webview, and its fresh "ready" resyncs all view state from the kernel.
+// The inbound half (HELD_ACROSS_RELOAD, below): which kernel→webview frames must
+// outlive that same reload, because they answer a replayed op and come only once.
 export const INTENT_OPS: ReadonlySet<string> = new Set([
   // typed text — losing these loses the user's words
   "sendMessage", "askFollowUp", "askText", "addCustomAsk", "sendCommand", "rewindSend",
@@ -15,10 +17,42 @@ export const INTENT_OPS: ReadonlySet<string> = new Set([
   "nodeOverride", "askClear", "undoClear", "cardMove", "cardNotify", "redistill",
   "answerAsk", "submitAsk", "toggleAsk", "navAsk", "cancelAsk",
   "setSessionFlag", "setSessionColor", "setGlobalRetryPaused", "setTimelineViews", "tagEdit", "openTagsDialog",
-  "editTag",  // the REMOTE-tag edit: its optimistic local half is already on screen, so a drop half-applies the gesture
+  // the REMOTE-tag edit (a tag homed on another kernel). Dropped with the view chatter it was simply
+  // lost: the reconnect's reload wipes the pane's optimistic mirror too, and the resynced pane showed
+  // the tag unchanged with nothing saying so (review find, 2026-09-08: the mirror never outlives the reload)
+  "editTag",
   "reorderTabs", "closeTab",
 ]);
 
 export function intentOp(type: unknown): boolean {
   return typeof type === "string" && INTENT_OPS.has(type);
+}
+
+// The INBOUND half: a kernel→webview frame that must survive the panel's own webview RELOAD. The
+// reconnect path replays held intent and rebuilds the webview's html in the same tick, so the kernel's
+// answer to a replayed op lands on a page that is gone: a frame posted between the reload and the
+// fresh page's "ready" is dropped by the webview. State frames may go (the "ready" resyncs them), but a
+// REFUSAL comes once, and one addressed by NAME (host + tag, not a per-page write id) is one the fresh
+// page can still show. The case that found it (review find, 2026-09-08): a remote-tag ADD replayed
+// right after a KERNEL restart is refused (the restarted kernel marks every attached host down until
+// its tunnel supervisor dials it, and an add never queues), and the tagEditFailed frame hit the
+// reloading timeline. Per-page write acks (tagEditAck, viewsAck) stay out on purpose: the fresh page
+// tracks none of the old page's write ids and would drop them unread.
+export const HELD_ACROSS_RELOAD: ReadonlySet<string> = new Set(["tagEditFailed"]);
+
+export function heldAcrossReload(type: unknown): boolean {
+  return typeof type === "string" && HELD_ACROSS_RELOAD.has(type);
+}
+
+// The hold itself, pure so the node runner can drive it. `offer` takes a frame the pipe received and
+// says whether to deliver it now (false means it is parked); `release` hands back what was parked, in
+// arrival order, for the webview's "ready" edge to deliver (extension.ts KernelPipe.webviewReady).
+export class ReloadHold {
+  private held: unknown[] = [];
+  offer(m: any, webviewReady: boolean): boolean {
+    if (webviewReady || !heldAcrossReload(m?.type)) return true;
+    this.held.push(m);
+    return false;
+  }
+  release(): unknown[] { return this.held.splice(0); }
 }


### PR DESCRIPTION
Verified on `main`: the extension replays queued operations after a reconnect only when they carry user intent, and `INTENT_OPS` lists the local targeted tag edit but not `editTag`, the remote-tag federation op. Three client sites still post it, each after applying an optimistic local mirror, so a remote-tag edit made while the pipe was down was discarded on reconnect while its local half stayed on screen: a half-applied edit the user believed had landed.

## What changes

`editTag` joins `INTENT_OPS`, with a comment naming the op and why it is an intent.

## Tests

`vscode-extension/src/pipe-intent.test.ts`: `editTag` joins the explicit-picks list, and a dedicated test asserts a queued `editTag` is kept across the reconnect. Both fail on `main`.

`vscode-extension` `npm test`: 3291 passed, 0 failed (on b0ca406f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
