### PR TITLE
A check-in is refused when the declared host is not a hostname; nothing is recorded

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -46,7 +46,7 @@ These are for scripting and for agents rather than daily use:
 | `romp compact <session> [--wait] [--timeout <s>]` | Compact a session's context in place (Claude's `/compact`: summarize the history, keep the session's name, id, mailbox, and watches) — the alternative to ending and recreating a long-lived session, and the external hand a session needs since it cannot `/compact` itself mid-turn. Quiet session → compacts now; open turn → queued, fires alone the moment the turn ends (the same safe path the chat's compact button uses). `--wait` blocks until the compaction has started and cleared, polling the kernel's own `compacting` signal on the `/sessions` rows (also the field to point a `romp watch` predicate at for scripted recycling); exits 1 honestly on timeout. A remote session's compaction is requested on its own kernel — `--wait` can't follow it from here and says so |
 | `romp end <session>` | End a session |
 | `romp move <session> <dir>` | Move an SDK session's working directory to `<dir>` (the folder must already exist); the conversation, name, mail and history stay with the session. Quiet session → moves now; open turn → queued, fires when the turn ends. See [Moving a session to another folder](#moving-a-session-to-another-folder) |
-| `romp checkin <host>` / `romp checkout <host>` | Publish this machine to an attached hub, or withdraw it |
+| `romp checkin <host>` / `romp checkout <host>` | Publish this machine to an attached hub, or withdraw it. The hub files this machine under the name it declares only when that name is a machine name (letters, digits, dots, hyphens or underscores, starting with a letter or digit, at most 128 characters). Any other declared name is refused with a 400 that states the rule and echoes nothing, is recorded nowhere, and is said once on both machines: on the hub, one stderr line and one Log entry under the `refused` kind, naming the value as a clipped repr; on this machine, one stderr line, one dial-log record and one Log entry carrying the hub's reason, after which the same name is not re-sent until it, or the hub's kernel, changes. A hub's `POST /tunnels/trust` for a host it has never seen (the remembered-hosts entry that tiers relayed mail by origin) holds the wider rule that registry's writers share, a machine name or an ssh alias (letters, digits, dots, hyphens, underscores, at-signs, colons or square brackets, not starting with a hyphen, at most 255 characters), because a hub keys an attached peer by its ssh alias and carries that alias when you set trust between two of your machines; anything else is refused the same way, on the hub, with nothing recorded. `ROMP_HOST_NAME` (the kernel) and `ROMP_POSTAL_HOST` (the postal bus) override the declared name only when they clear the same rule; an unusable value (a space, an at-sign, a trailing newline) is set aside once, on stderr or in the bus log, and the derived name (the short hostname, else the platform's machine name, else a minted id) is used |
 | `romp default-dir [PATH]` | The default working directory for new sessions; no argument prints it, `""` clears it |
 | `romp debug [on\|off\|status]` | Judge debug mode, where rejection rows carry the full input and reply |
 | `romp resume <id> [--name <n>] [--detach]` | Resume one exact conversation by UUID |
@@ -1042,6 +1042,19 @@ read-only disk) is told to the gesture that asked, the gear's toast or the
 stop button's warning, and said once per fault episode in the error center;
 the automatic pass sends nothing whose record could not land, and the file
 keeps what it holds.
+
+The two host registries there, `remotes.json` (attached and checked-in
+machines, each row with that machine's serve token) and `remotes-known.json`
+(machines remembered for re-attach, with the mail tier you set for each), are
+read at boot under the rule their doors apply: a checked-in row's host must be
+a machine name, an attached row's an ssh alias, a remembered row's either. A
+row that fails (one filed before the doors applied the rule) is set aside,
+never loaded and never written back: the rows are moved to
+`<file>.refused-<UTC stamp>` beside the original (`-1`, `-2` when a second one
+lands in the same second; the `remotes.json` sidecar is 0600, since its rows
+carry tokens), the file is rewritten without them, and one stderr line plus one
+Log entry under the `refused` kind names each host as a clipped repr, never the
+raw string.
 
 ## Switches
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15126,8 +15126,11 @@ def _safe_ssh_host(host):
     metacharacters. The ssh argvs also carry a `--` guard (belt-and-suspenders); validating here turns a
     crafted host into a clean rejection instead of a confusing ssh failure. Real hosts — aliases and
     user@host / IPv6-literal forms — pass."""
+    # fullmatch, not match: the pattern's `$` also matches before ONE trailing newline, and _remotes_load
+    # now holds an ssh row on disk to this rule without stripping it first (review find, 2026-09-08, the
+    # same hole _safe_id had).
     return bool(host) and isinstance(host, str) and len(host) <= 255 \
-        and not host.startswith("-") and bool(_SSH_HOST_RE.match(host))
+        and not host.startswith("-") and bool(_SSH_HOST_RE.fullmatch(host))
 
 
 # ── what a PEER kernel's answer may say, field by field ──────────────────────────────────────────────────
@@ -15571,15 +15574,60 @@ def _bus_quarantine_act(body):
 # SAME file the bus uses (its STATE.parent == jd.STATE) — so this machine can never check in under
 # one name while its bus declares another.
 
-_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_SAFE_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 
 def _safe_id(s):
-    """True iff `s` is safe as a single path component (postal_service._safe_id, duplicated)."""
+    """True iff `s` is safe as a single path component (postal_service._safe_id, duplicated;
+    tests/test_postal_self_host.py pins the two copies identical). fullmatch, never match against
+    `^...$`: `$` also matches before ONE trailing newline, so "abc\\n" cleared the rule and the
+    override branches below returned it verbatim (review find, 2026-09-08)."""
     if not s or len(s) > 128:
         return False
     if "/" in s or "\\" in s or "\x00" in s or s.startswith("."):
         return False
-    return bool(_SAFE_ID_RE.match(s))
+    return bool(_SAFE_ID_RE.fullmatch(s))
+
+
+# What a door into the host registries says when it turns a declared name away. Two doors file a name
+# they have never seen (review find, 2026-09-08: the trust route took any string the serve token's holder
+# sent). The check-in handshake (checkin_apply) files what a mobile declares as its OWN name, so it holds
+# the machine-name rule, _safe_id. The trust route's origin-only branch (set_trust) files a name a hub
+# holds a peer under, and a hub keys an ATTACHED peer by its ssh alias (user@box, a bracketed address):
+# remote_trust carries that alias into a third machine's copy of this branch, and the relayed mail the
+# tier then judges is stamped with the same alias as its origin. So that door admits EITHER rule, the
+# union the remembered-hosts registry's two writers apply (attach: _safe_ssh_host; check-in and trust:
+# _safe_id), which is the union _known_load holds the registry's rows to. Neither sentence echoes the
+# refused string: it is the thing being refused.
+_HOST_RULE = ("host must be a machine name: letters, digits, dots, hyphens or underscores, starting with a "
+              "letter or digit, at most 128 characters")
+_HOST_OR_ALIAS_RULE = ("host must be a machine name or an ssh alias: letters, digits, dots, hyphens, underscores, "
+                       "at-signs, colons or square brackets, not starting with a hyphen, at most 255 characters")
+
+_host_refused_said = set()   # sha256 of each declared name already refused aloud: once per distinct value,
+#                              BOUNDED (cleared at 64, the _auto_push_tried idiom) because a peer chooses
+#                              these strings and could mint ten thousand distinct ones
+
+
+def _refuse_host_name(door, host, rule):
+    """A door turned a declared host away: say so ONCE per distinct value, on stderr and as a bell row of
+    kind refused (review find, 2026-09-08: the 400 with its reason went back to the peer, and no human on
+    this machine ever saw that a machine was being turned away). `rule` is the sentence the door answers
+    with, so the line names the rule that door holds. The value is shown as a CLIPPED repr, never raw: it
+    is the thing being refused, and it may carry a NUL, a newline or ten kilobytes. Never raises: the
+    refusal is answered whether or not it could be said."""
+    try:
+        key = hashlib.sha256(host.encode("utf-8", "surrogatepass")).hexdigest()
+        if key in _host_refused_said:
+            return
+        if len(_host_refused_said) >= 64:
+            _host_refused_said.clear()
+        _host_refused_said.add(key)
+        shown = repr(host[:40]) + (" (%d characters)" % len(host) if len(host) > 40 else "")
+        line = "%s refused the declared host %s: %s; nothing was recorded" % (door, shown, rule)
+        sys.stderr.write("romp-kernel: %s\n" % line)
+        _sync_notice(line, ok=False, kind="refused")
+    except Exception:
+        pass
 
 def _host_name_candidates():
     """Raw machine-name candidates for the self-host fallback, most meaningful first. macOS keeps
@@ -15686,6 +15734,7 @@ def checkin_set(host, on):
             r.setdefault("rk_port", _free_port())
             r.setdefault("rb_port", _free_port())
         r.pop("_handshook", None)
+        r.pop("_checkin_refused", None)    # a toggle is the user acting: a held refusal is re-tried
         proc = r.get("proc")
     if not on:
         _checkin_stop_hub(r)
@@ -15727,6 +15776,18 @@ def set_trust(host, level):
         if r is not None:
             r["trust"] = level
     if r is None:
+        # The ORIGIN-ONLY branch is the second door into the remembered-hosts registry (review find,
+        # 2026-09-08): a name with no tunnel here is filed and told to the bus on the word of any serve
+        # token holder (every checked-in mobile is one), and it took any string. The name is one a hub
+        # holds a peer under: the peer's own declared name (_safe_id), or the ssh alias the hub attached
+        # it by (user@box clears _safe_ssh_host, not _safe_id), which remote_trust carries here from the
+        # hub's popover and which stamps that peer's relayed mail as its origin. Either rule admits it, as
+        # at _known_load; a name clearing neither (a slash, whitespace, a NUL, a quote, ten kilobytes) is
+        # refused the way the check-in door refuses: nothing recorded, the string not echoed, said once
+        # with a clipped repr. The route maps this error to a 400.
+        if not (_safe_id(host) or _safe_ssh_host(host)):
+            _refuse_host_name("the trust route", host, _HOST_OR_ALIAS_RULE)
+            return None, _HOST_OR_ALIAS_RULE
         _known_note(host, level)           # the remembered entry IS the origin-trust store
         _notify_bus_origin_trust(host, level)   # best-effort now; the supervisor pass retries
         return {"host": host, "trust": level, "originOnly": True}, None
@@ -15980,18 +16041,54 @@ def _checkin_handshake(r):
     """Tell the hub (through our own -L to its kernel) where our reverse forwards landed and hand it
     our token — the PUSH that replaces the hub ever fetching credentials. Authorizes with the HUB's
     token (r["token"], fetched at attach — the hub requires it on every request, loopback included).
-    True on ack; the caller records success per tunnel incarnation and retries otherwise."""
+    True on ack; the caller records success per tunnel incarnation and retries otherwise.
+
+    A REFUSAL is read, said and held (review find, 2026-09-08: only the reply's status was read, so the
+    hub's reason reached nobody, and the same declared name went out again every supervisor pass,
+    forever). A non-200 is said once per distinct (status, reason): stderr, the dial log, a bell row of
+    kind refused. A 400, the hub's verdict on the very body we sent, is not re-sent while the
+    declared name and the hub's kernel incarnation are the ones it refused: the refusal is the event,
+    and a changed name (the operator fixed ROMP_HOST_NAME or the hostname), a hub restart (its /version
+    pid, the event _handshake_due keys on too), a check-in toggle, a port re-mint or a boot re-arms it.
+    A hub that answers nothing (mid-boot) is no refusal: no memo, no line, the next pass dials again."""
     import urllib.parse
+    payload = _checkin_payload(r)
+    memo = r.get("_checkin_refused") if isinstance(r.get("_checkin_refused"), dict) else {}
+    if memo.get("hold") and memo.get("host") == payload.get("host") and memo.get("hub") == r.get("hub_pid"):
+        return False                     # the hub already refused this very name, and nothing has changed
     try:
         conn = http.client.HTTPConnection("127.0.0.1", r["local_port"], timeout=4)
         p = "/checkin" + (("?token=" + urllib.parse.quote(r["token"])) if r.get("token") else "")
-        conn.request("POST", p, json.dumps(_checkin_payload(r)),
-                     {"Content-Type": "application/json"})
-        ok = conn.getresponse().status == 200
+        conn.request("POST", p, json.dumps(payload), {"Content-Type": "application/json"})
+        resp = conn.getresponse()
+        status, raw = resp.status, resp.read()
         conn.close()
-        return ok
     except Exception:
         return False
+    if status == 200:
+        with _remotes_lock:
+            r.pop("_checkin_refused", None)
+        return True
+    try:
+        why = str((json.loads(raw.decode() or "{}") or {}).get("error") or "")
+    except Exception:
+        why = ""
+    why = re.sub(r"[\x00-\x1f\x7f]+", " ", why)[:200]      # the hub's sentence, one line of it, bounded
+    with _remotes_lock:
+        r["_checkin_refused"] = {"status": status, "error": why, "host": payload.get("host"),
+                                 "hub": r.get("hub_pid"), "hold": status == 400}
+    if (memo.get("status"), memo.get("error")) != (status, why):    # each DISTINCT refusal once, not per pass
+        hub = r.get("host") or "?"
+        line = "check-in refused by %s (HTTP %d): %s%s" % (
+            hub, status, why or "no reason given",
+            "; not re-sent until this machine's name or that kernel changes" if status == 400 else "")
+        sys.stderr.write("romp-kernel: %s\n" % line)
+        _tunnel_log(hub, "checkin-refused", status=status, error=why)
+        try:
+            _sync_notice(line, ok=False, kind="refused")
+        except Exception:
+            pass
+    return False
 
 
 def _checkin_stop_hub(r):
@@ -16033,10 +16130,11 @@ def checkin_apply(body):
         # away only names no romp mobile produces, and a hostile or broken peer cannot file a slash, a
         # NUL, whitespace or ten kilobytes into any of it (2026-09-08). Checked BEFORE the same-token sweep
         # below, which would otherwise pop the mobile's good row on the way to refusing the junk one.
-        # The refused string is not echoed: it is the thing being refused.
-        return {"ok": False, "error": "host must be a machine name: letters, digits, dots, hyphens or "
-                                      "underscores, starting with a letter or digit, at most 128 "
-                                      "characters"}, 400
+        # The refused string is not echoed: it is the thing being refused. Said here too, once per
+        # distinct value, on stderr and the bell (review find, 2026-09-08: the reason went back to the
+        # peer and nobody on this machine saw a machine being turned away).
+        _refuse_host_name("the check-in handshake", host, _HOST_RULE)
+        return {"ok": False, "error": _HOST_RULE}, 400
     tok = str((body or {}).get("token") or "")
     with _remotes_lock:
         if tok:
@@ -16221,6 +16319,7 @@ def _remint_forward_ports(r):
     if r.get("checkin"):
         r["rk_port"], r["rb_port"] = fresh[2], fresh[3]
         r.pop("_handshook", None)        # the hub must be re-told the new ports
+        r.pop("_checkin_refused", None)  # …and a refusal of the old body no longer holds
     r["_peer_notified"] = None           # bus_port moved: the local bus is holding a stale endpoint
     new = {k: r.get(k) for k in ("local_port", "bus_port", "rk_port", "rb_port") if r.get(k)}
     _tunnel_log(r["host"], "ports-reminted", old=old, new=new)
@@ -16430,7 +16529,9 @@ _NOT_SAVED = ("proc",       # the live Popen
               #               _views_client serves every cached reading, status aside, so a down host's tags
               #               survive a kernel restart; the boot's first poll re-reads, the gate unstamped
               "misses",     # the poll run counters: they describe THIS connection, and a fresh boot
-              "ok_polls")   # dials from scratch, so carrying them across would judge a link that is gone
+              "ok_polls",   # dials from scratch, so carrying them across would judge a link that is gone
+              "_checkin_refused")   # the mobile's memo of a hub refusing the name it declared: a boot is
+#                                     an event that re-arms the send (review find, 2026-09-08)
 
 
 def _remotes_rows_for_save():
@@ -16475,6 +16576,39 @@ def _remotes_save_if_changed():
     return True
 
 
+def _registry_set_aside(path, rows, mode=None):
+    """Rows of a persisted host registry whose host is not a name this build would file (a check-in row
+    failing _safe_id, an ssh row failing _safe_ssh_host), moved ASIDE at load: never loaded, never written
+    back (review find, 2026-09-08: a row filed before the doors were guarded came back verbatim at every
+    boot, was told to the bus and rendered in the panel). The sidecar is `<name>.refused-<utc stamp>`
+    beside the file (a `-n` suffix within one second: the `.corrupt-` quarantines' shape, docs/reference.md
+    "Where things live"); `mode` 0o600 for remotes.json, whose rows carry that peer's serve token. Said once
+    on stderr with a CLIPPED repr of each host, never the raw string (it may carry a NUL or ten kilobytes),
+    and once as a bell row of kind refused. Returns the sidecar path, or None when it could not be written:
+    the rows are still not loaded, the caller's rewrite still drops them, and the line says so."""
+    shown = ", ".join(repr(str(r.get("host"))[:40]) for r in rows[:3])
+    if len(rows) > 3:
+        shown += " and %d more" % (len(rows) - 3)
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    aside, n = path.with_name("%s.refused-%s" % (path.name, stamp)), 0
+    while aside.exists():                                # a second set-aside in the same second
+        n += 1
+        aside = path.with_name("%s.refused-%s-%d" % (path.name, stamp, n))
+    try:
+        _atomic_write(aside, json.dumps(rows), mode=mode)
+        where = "moved aside to %s" % aside.name
+    except Exception as e:
+        aside, where = None, "and could not be moved aside (%s), so dropped" % _errno_text(e)
+    line = "%s: %d row%s whose host is not a machine name refused at load and %s: %s" % (
+        path.name, len(rows), "" if len(rows) == 1 else "s", where, shown)
+    sys.stderr.write("romp-kernel: %s\n" % line)
+    try:
+        _sync_notice(line, ok=False, kind="refused")
+    except Exception:
+        pass
+    return aside
+
+
 def _remotes_load():
     try:
         rows = json.loads(REMOTES_FILE.read_text())
@@ -16486,9 +16620,18 @@ def _remotes_load():
         pass
     if not isinstance(rows, list):
         return
+    aside = []
     with _remotes_lock:
         for row in rows:
             if not isinstance(row, dict) or not row.get("host"):
+                continue
+            h = row["host"]
+            if not isinstance(h, str) or not (_safe_id(h) if row.get("checkin_peer") else _safe_ssh_host(h)):
+                # The rule the row's own door applies, a check-in row _safe_id (checkin_apply), an ssh row
+                # _safe_ssh_host (attach_remote), re-applied to what the file says (review find,
+                # 2026-09-08): a row filed before the doors were guarded came back verbatim at every boot.
+                # Set aside below: never loaded, never written back.
+                aside.append(row)
                 continue
             r = dict(row)
             for k in _NOT_SAVED:    # a file an older build wrote carries keys this one does not save; they
@@ -16507,6 +16650,9 @@ def _remotes_load():
             r.setdefault("bus_port", _free_port())   # peer-bus mode's -L to the remote's bus (allocated
             #                                          unconditionally so a later flag flip needs no migration)
             _remotes[r["host"]] = r
+    if aside:
+        _registry_set_aside(REMOTES_FILE, aside, mode=0o600)   # 0600: the rows carry that peer's serve token
+        _remotes_save()                                          # the file heals now: the kept rows only
 
 
 def attach_remote(host, kernel_port=None):
@@ -16634,15 +16780,28 @@ def _known_load():
         return
     if not isinstance(rows, list):
         return
+    aside = []
     with _known_lock:
         for row in rows:
-            if isinstance(row, dict) and row.get("host"):
-                _known[row["host"]] = {"host": row["host"],
-                                       "lastAttachedAt": row.get("lastAttachedAt") or 0,
-                                       "trust": row.get("trust") or "directed",
-                                       "share": bool(row.get("share"))}
-                if row.get("attached"):               # set only when proven (absent = trust-only row)
-                    _known[row["host"]]["attached"] = True
+            if not (isinstance(row, dict) and row.get("host")):
+                continue
+            h = row["host"]
+            if not isinstance(h, str) or not (_safe_ssh_host(h) or _safe_id(h)):
+                # A remembered row does not record which door filed it, attach (the ssh rule: user@box
+                # passes) or a check-in / trust setting (_safe_id), so a host clearing EITHER stays, and
+                # one clearing neither (a slash, whitespace, a NUL, ten kilobytes) is set aside below:
+                # never loaded, never written back (review find, 2026-09-08).
+                aside.append(row)
+                continue
+            _known[h] = {"host": h,
+                         "lastAttachedAt": row.get("lastAttachedAt") or 0,
+                         "trust": row.get("trust") or "directed",
+                         "share": bool(row.get("share"))}
+            if row.get("attached"):               # set only when proven (absent = trust-only row)
+                _known[h]["attached"] = True
+    if aside:
+        _registry_set_aside(KNOWN_FILE, aside)
+        _known_save()                             # the file heals now: the kept rows only
 
 
 def _known_save():

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15633,28 +15633,43 @@ def _minted_host_id():
     return name
 
 _self_host_fb = None                         # resolved fallback identity, cached after the first (logged) resolve
+_host_name_env_warned = set()                # ROMP_HOST_NAME values already said to be unusable — once per value
 
 def _self_host():
     """This machine's name to peers (the check-in handshake, trust pushes, usage rows). Short
-    hostname; ROMP_HOST_NAME overrides (tests; unusual naming). The name MUST clear _safe_id — the
-    hub keys the mail it holds for us by it, as a path component — so an unsafe kernel hostname
-    falls back loudly, exactly like the bus's self_host(): the platform's user-set machine name,
-    else the minted id persisted in the SHARED file above (kernel and bus converge on one identity).
-    gethostname stays first and live — fixing the machine's hostname takes effect on the next call
-    with no restart."""
+    hostname; ROMP_HOST_NAME overrides (tests; unusual naming) WHEN it clears the same rule. The
+    name MUST clear _safe_id — the hub keys the mail it holds for us by it, as a path component,
+    and the hub's check-in door refuses anything else (checkin_apply) — so an unsafe kernel
+    hostname falls back loudly, exactly like the bus's self_host(): the platform's user-set machine
+    name, else the minted id persisted in the SHARED file above (kernel and bus converge on one
+    identity). An unsafe OVERRIDE is set aside the same way — said once on stderr, in plain words,
+    naming the name used instead — and the derived name goes out: the override used to come back
+    exactly as set, the one branch that dodged the rule (2026-09-08), so a mobile whose operator
+    set an odd ROMP_HOST_NAME landed on hubs while its own mail parked unreachable. gethostname
+    stays first and live — fixing the machine's hostname takes effect on the next call with no
+    restart."""
+    global _self_host_fb
     env = os.environ.get("ROMP_HOST_NAME")
-    if env:
+    if env and _safe_id(env):
         return env
     name = socket.gethostname().split(".")[0]
     if _safe_id(name):
-        return name
-    global _self_host_fb
-    if _self_host_fb is None:
-        _self_host_fb = next((s for s in map(_sanitize_host_name, _host_name_candidates()) if s),
-                             "") or _minted_host_id()
-        sys.stderr.write("self-host: kernel hostname %r fails path-safety; using %r for peering "
-                         "(fix the machine's hostname to control the name)\n" % (name, _self_host_fb))
-    return _self_host_fb
+        chosen = name
+    else:
+        if _self_host_fb is None:
+            _self_host_fb = next((s for s in map(_sanitize_host_name, _host_name_candidates()) if s),
+                                 "") or _minted_host_id()
+            sys.stderr.write("self-host: kernel hostname %r fails path-safety; using %r for peering "
+                             "(fix the machine's hostname to control the name)\n" % (name, _self_host_fb))
+        chosen = _self_host_fb
+    if env and env not in _host_name_env_warned:
+        _host_name_env_warned.add(env)
+        shown = env if len(env) <= 60 else env[:57] + "..."
+        sys.stderr.write("self-host: ROMP_HOST_NAME=%r is not usable as a machine name (letters, digits, dots, "
+                         "hyphens or underscores, starting with a letter or digit, at most 128 characters); "
+                         "using %r for peering instead. Fix or unset ROMP_HOST_NAME to control the name.\n"
+                         % (shown, chosen))
+    return chosen
 
 
 def checkin_set(host, on):
@@ -15999,13 +16014,29 @@ def checkin_apply(body):
     same federation row, same stage-1 bus notify — except we own NO ssh (proc None; the mobile
     supervises its tunnel; a dead forward reads down and the next handshake heals). An existing
     ssh-attached row by the same name is refused: the two ownership models must never mix silently."""
-    host = str((body or {}).get("host") or "").strip()
+    raw_host = (body or {}).get("host")
+    host = raw_host.strip() if isinstance(raw_host, str) else ""   # a number or list is no name: str() used
+    #                                                                 to coerce it into one ("1.5") and file it
     kp, bp = (body or {}).get("kernelPort"), (body or {}).get("busPort")
 
     def _bad(p):
         return not isinstance(p, int) or isinstance(p, bool) or not (0 < p < 65536)
     if not host or _bad(kp) or _bad(bp):
         return {"ok": False, "error": "host, kernelPort, busPort required"}, 400
+    if not _safe_id(host):
+        # The declared name used to be taken as it came, and it goes on to KEY everything: the registry
+        # and remotes.json, the remembered-hosts entry and remotes-known.json, the bus's peer table and
+        # the mail it holds for that peer (a path component there, gated by the bus's own _safe_id), the
+        # /remote/<host>/ routes, and every body/query lookup the row actions make. Every name a romp
+        # mobile can declare clears this rule: _self_host()'s derived names always did, for exactly that
+        # reason, and its ROMP_HOST_NAME override now does or is set aside aloud — so this door turns
+        # away only names no romp mobile produces, and a hostile or broken peer cannot file a slash, a
+        # NUL, whitespace or ten kilobytes into any of it (2026-09-08). Checked BEFORE the same-token sweep
+        # below, which would otherwise pop the mobile's good row on the way to refusing the junk one.
+        # The refused string is not echoed: it is the thing being refused.
+        return {"ok": False, "error": "host must be a machine name: letters, digits, dots, hyphens or "
+                                      "underscores, starting with a letter or digit, at most 128 "
+                                      "characters"}, 400
     tok = str((body or {}).get("token") or "")
     with _remotes_lock:
         if tok:

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -2298,30 +2298,42 @@ def _minted_host_id():
     return name
 
 _self_host_fb = None                         # resolved fallback identity, cached after the first (logged) resolve
+_postal_host_env_warned = set()              # ROMP_POSTAL_HOST values already said to be unusable — once per value
 
 def self_host():
     """This machine's postal identity: short hostname (each side keys the OTHER by its own name for
-    it, so exact agreement across machines is not required). ROMP_POSTAL_HOST overrides (tests).
-    The name MUST clear _safe_id: peers key the outbox that holds mail FOR us by it, as a path
-    component, so an unkeyable kernel hostname half-works — presence still crosses (PEER_STATE is a
-    dict), but outbox_put on the peer refuses every message back, parked "unreachable" forever with
-    the only trace a server-log line (2026-08-11, a kern.hostname stomped with control bytes). An
-    unsafe name falls back, loudly: the platform's user-set machine name, else a minted persisted
-    id. gethostname stays first and live, so fixing the machine's hostname takes effect on the next
-    call with no restart."""
+    it, so exact agreement across machines is not required). ROMP_POSTAL_HOST overrides (tests) WHEN
+    it clears the same rule. The name MUST clear _safe_id: peers key the outbox that holds mail FOR
+    us by it, as a path component, so an unkeyable kernel hostname half-works — presence still
+    crosses (PEER_STATE is a dict), but outbox_put on the peer refuses every message back, parked
+    "unreachable" forever with the only trace a server-log line (2026-08-11, a kern.hostname stomped
+    with control bytes). An unsafe name falls back, loudly: the platform's user-set machine name,
+    else a minted persisted id. An unsafe OVERRIDE is set aside the same way — said once, naming the
+    name used instead — and the derived name is declared: the override used to come back exactly as
+    set, the one branch that dodged the rule (2026-09-08; the kernel's _self_host had the same and
+    was fixed the same day). gethostname stays first and live, so fixing the machine's hostname
+    takes effect on the next call with no restart."""
+    global _self_host_fb
     env = os.environ.get("ROMP_POSTAL_HOST")
-    if env:
+    if env and _safe_id(env):
         return env
     name = socket.gethostname().split(".")[0]
     if _safe_id(name):
-        return name
-    global _self_host_fb
-    if _self_host_fb is None:
-        _self_host_fb = next((s for s in map(_sanitize_host_name, _host_name_candidates()) if s),
-                             "") or _minted_host_id()
-        _log("self_host: kernel hostname %r fails path-safety; declaring %r to peers instead "
-             "(fix the machine's hostname to control the name)" % (name, _self_host_fb))
-    return _self_host_fb
+        chosen = name
+    else:
+        if _self_host_fb is None:
+            _self_host_fb = next((s for s in map(_sanitize_host_name, _host_name_candidates()) if s),
+                                 "") or _minted_host_id()
+            _log("self_host: kernel hostname %r fails path-safety; declaring %r to peers instead "
+                 "(fix the machine's hostname to control the name)" % (name, _self_host_fb))
+        chosen = _self_host_fb
+    if env and env not in _postal_host_env_warned:
+        _postal_host_env_warned.add(env)
+        shown = env if len(env) <= 60 else env[:57] + "..."
+        _log("self_host: ROMP_POSTAL_HOST=%r is not usable as a machine name (letters, digits, dots, hyphens "
+             "or underscores, starting with a letter or digit, at most 128 characters); declaring %r to peers "
+             "instead. Fix or unset ROMP_POSTAL_HOST to control the name." % (shown, chosen))
+    return chosen
 
 def _peer_wake(host):
     with _peer_lock:

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -179,19 +179,23 @@ def my_name():
 def _iso_now():
     return datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S%z")
 
-_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_SAFE_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 
 def _safe_id(s):
     """True iff `s` is safe as a single path component under the mail/names roots.
     Blocks path traversal (`..`, `/`, `\\`, NUL, leading dot, absolute paths) in
     any id/name that arrives over the (unauthenticated) bus. Session ids are
     UUIDs and names are sanitized to [A-Za-z0-9_-] at creation, so both match;
-    anything else is a crafted reference (e.g. `../../../etc`) and is rejected."""
+    anything else is a crafted reference (e.g. `../../../etc`) and is rejected.
+    Duplicated in the kernel (its _safe_id; tests/test_postal_self_host.py pins
+    the two copies identical). fullmatch, never match against `^...$`: `$` also
+    matches before ONE trailing newline, so "abc\\n" cleared the rule and
+    self_host's override branch declared it verbatim (review find, 2026-09-08)."""
     if not s or len(s) > 128:
         return False
     if "/" in s or "\\" in s or "\x00" in s or s.startswith("."):
         return False
-    return bool(_SAFE_ID_RE.match(s))
+    return bool(_SAFE_ID_RE.fullmatch(s))
 
 # Every character str.splitlines() treats as a line break — \n \r \v \f \x1c \x1d \x1e
 # \x85 U+2028 U+2029 — plus the rest of the C0/C1 control range and NUL with them. Nothing

--- a/tests/test_checkin_trust_persists.py
+++ b/tests/test_checkin_trust_persists.py
@@ -20,10 +20,23 @@ now does or is set aside aloud (test_postal_self_host.py) — so the hub refuses
 door with a 400 that says what a name may look like, recording, saving, popping and waking nothing,
 and turns away only names no romp mobile produces.
 
+The review of that door (2026-09-08) found the rest of the claim undelivered, and these classes pin the
+fixes: TrustDoorHostChecked, the SECOND door into the remembered-hosts registry (POST /tunnels/trust on a
+name with no tunnel here filed any string and told the bus); RegistriesLoadChecked, rows already on disk
+from before the doors were guarded (read back verbatim at every boot, told to the bus, rendered: now set
+aside, never loaded, never written back); RefusalSaidOnBothMachines, the hub says a refusal once per
+distinct value with a clipped repr and a bell row, and the mobile reads the reason, says it once, and
+stops re-sending the same name until the name or the hub changes; and a trailing newline, which the
+rule's `$` anchor admitted, is not a hostname.
+
 Synthetic only — placeholder hosts/ports/tokens, hermetic temp STATE, no ssh.
 """
+import contextlib
+import io
 import json
 import os
+import socket as _socket
+import stat
 import tempfile
 import threading
 import unittest
@@ -31,6 +44,7 @@ import urllib.error
 import urllib.request
 from http.server import ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -103,8 +117,9 @@ class CheckinTrust(unittest.TestCase):
 
 
 # What the door must say when it refuses a name — the person's words, naming the shape a host may take.
-RULE = ("host must be a machine name: letters, digits, dots, hyphens or underscores, starting with a "
-        "letter or digit, at most 128 characters")
+# A KEY PHRASE, not the whole sentence (review find, 2026-09-08): ten tests pinned the full wording by
+# equality, so the sentence could never be improved without editing every one of them.
+RULE_KEY = "must be a machine name"
 
 # Names every consumer downstream would choke on, or silently mis-key. Each is a path/URL/JSON hazard a
 # hostile or merely broken peer could declare; none is anything _self_host() can produce.
@@ -160,7 +175,7 @@ class CheckinHostChecked(unittest.TestCase):
         payload, status = km.checkin_apply(dict(BODY, host=host))
         self.assertEqual(status, 400, why)
         self.assertIs(payload["ok"], False, why)
-        self.assertEqual(payload["error"], RULE, why)
+        self.assertIn(RULE_KEY, payload["error"], why)
         if len(host) > 3:
             self.assertNotIn(host, payload["error"], "the refused string is not echoed back (%s)" % why)
         self.assertEqual(km._remotes, {}, "nothing filed in the registry (%s)" % why)
@@ -213,7 +228,8 @@ class CheckinHostChecked(unittest.TestCase):
         self.saves.clear(), self.notes.clear()
         km._tunnel_wake.clear()
         payload, status = km.checkin_apply(dict(BODY, host=BAD_HOSTS["a slash with dot-dot"]))
-        self.assertEqual((status, payload["ok"], payload["error"]), (400, False, RULE))
+        self.assertEqual((status, payload["ok"]), (400, False))
+        self.assertIn(RULE_KEY, payload["error"])
         self.assertEqual(set(km._remotes), {"TESTHOST"}, "the good row is untouched")
         self.assertEqual(km._remotes["TESTHOST"]["token"], "peertok")
         self.assertEqual((self.saves, self.notes), ([], []))
@@ -232,22 +248,44 @@ class CheckinHostChecked(unittest.TestCase):
         self.assertTrue(km._tunnel_wake.is_set())
 
     def test_this_machines_own_declared_name_clears_the_rule(self):
-        # what a real mobile sends IS _self_host(); every shape it can produce must land. Read live, with
-        # the override out of the way, so this checks the box's real short hostname — never a literal.
-        saved = os.environ.pop("ROMP_HOST_NAME", None)
+        # what a real mobile sends IS _self_host(); every shape it can produce must land. The hostname
+        # source is STUBBED (review find, 2026-09-08: read live, this could not fail on a healthy box and
+        # ran scutil on macOS): a short name, a dotted one, and a junk one that sends _self_host to its
+        # fallbacks (no platform name here, so the minted id), with the override out of the way.
+        saved_env = os.environ.pop("ROMP_HOST_NAME", None)
+        saved = (_socket.gethostname, km._host_name_candidates, km._self_host_fb)
+        km._host_name_candidates = lambda: []
         try:
-            me = km._self_host()
+            for raw, expect in (("TESTHOST", "TESTHOST"), ("build-box-01.example.com", "build-box-01"),
+                                ("TEST\x04HOST", None)):
+                _socket.gethostname = lambda raw=raw: raw
+                km._self_host_fb = None
+                with contextlib.redirect_stderr(io.StringIO()):
+                    me = km._self_host()
+                if expect is not None:
+                    self.assertEqual(me, expect, repr(raw))
+                self.assertTrue(km._safe_id(me), "the rule IS the promise _self_host makes: %r" % raw)
+                payload, status = km.checkin_apply(dict(BODY, host=me, token="t-" + me))
+                self.assertEqual(status, 200, "a real machine's own name must never be refused: %r" % raw)
+                self.assertIn(me, km._remotes)
         finally:
-            if saved is not None:
-                os.environ["ROMP_HOST_NAME"] = saved
-        self.assertTrue(km._safe_id(me), "the rule IS the promise _self_host makes")
-        payload, status = km.checkin_apply(dict(BODY, host=me))
-        self.assertEqual(status, 200, "a real machine's own name must never be refused")
-        self.assertIn(me, km._remotes)
+            _socket.gethostname, km._host_name_candidates, km._self_host_fb = saved
+            if saved_env is not None:
+                os.environ["ROMP_HOST_NAME"] = saved_env
         # …and the two fallbacks _self_host reaches for when the kernel hostname fails path-safety
         for h in (km._sanitize_host_name("Some Body's Mac (2)"), "host-%08x" % 0xDEADBEEF):
             self.assertTrue(h and km._safe_id(h), h)
             self.assertEqual(km.checkin_apply(dict(BODY, host=h, token="t-" + h))[1], 200, h)
+
+    def test_a_trailing_newline_is_not_part_of_a_name(self):
+        # the rule's regex ended in `$`, which also matches before ONE trailing newline, so "TESTHOST\n"
+        # cleared _safe_id (review find, 2026-09-08). The door trims whitespace at the edges like every
+        # route, so the name lands as "TESTHOST": no key with a newline in it is ever filed
+        self.assertFalse(km._safe_id("TESTHOST\n"), "a trailing newline is not a hostname")
+        self.assertFalse(km._safe_id("TESTHOST\r\n"))
+        payload, status = km.checkin_apply(dict(BODY, host="TESTHOST\n"))
+        self.assertEqual((status, payload["host"]), (200, "TESTHOST"))
+        self.assertEqual(set(km._remotes), {"TESTHOST"})
 
 
 class CheckinRoute(unittest.TestCase):
@@ -294,13 +332,400 @@ class CheckinRoute(unittest.TestCase):
         for why in ("a slash with dot-dot", "whitespace inside", "a NUL", "ten kilobytes", "a leading dot"):
             st, r = self._post(dict(BODY, host=BAD_HOSTS[why]))
             self.assertEqual(st, 400, why)
-            self.assertEqual((r.get("ok"), r.get("error")), (False, RULE), why)
+            self.assertIs(r.get("ok"), False, why)
+            self.assertIn(RULE_KEY, r.get("error") or "", why)
         self.assertEqual((km._remotes, self.saves, self.notes), ({}, [], []), "nothing recorded over HTTP either")
         st, r = self._post(dict(BODY, host="build-box-01.example.com"))
         self.assertEqual(st, 200)
         self.assertEqual((r["ok"], r["host"]), (True, "build-box-01.example.com"))
         self.assertTrue(km._remotes["build-box-01.example.com"]["checkin_peer"])
         self.assertEqual((len(self.saves), len(self.notes)), (1, 1))
+
+
+def _serve(cls):
+    """A real Handler on a loopback port, the door a peer or a dashboard actually knocks on."""
+    cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+    cls.port = cls.srv.server_address[1]
+    threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+
+class TrustDoorHostChecked(unittest.TestCase):
+    """The SECOND door into the remembered-hosts registry (review find, 2026-09-08): POST /tunnels/trust on
+    a name with no tunnel here files it as an origin-only remembered entry and tells the bus, and it took
+    any string the serve token's holder sent; every checked-in mobile holds that token. The name must now
+    clear one of the two rules the registry's writers apply: the machine-name rule (a peer's own declared
+    name) or the ssh-alias rule (the alias a hub attached a peer by, which remote_trust carries here and
+    which stamps that peer's relayed mail as its origin), so a slash, whitespace, a NUL, a quote or ten
+    kilobytes is refused, nothing is recorded, and user@box still lands."""
+
+    @classmethod
+    def setUpClass(cls):
+        _serve(cls)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        km._remotes.clear()
+        with km._known_lock:
+            km._known.clear()
+        self.pushed, self.saves = [], []
+        self._saved = (km._notify_bus_origin_trust, km._known_save)
+        km._notify_bus_origin_trust = lambda h, t: self.pushed.append((h, t)) or True
+        km._known_save = lambda: self.saves.append(1)
+        km._host_refused_said.clear()
+        km._tunnel_wake.clear()
+
+    def tearDown(self):
+        km._notify_bus_origin_trust, km._known_save = self._saved
+        km._remotes.clear()
+        with km._known_lock:
+            km._known.clear()
+
+    def test_a_junk_name_is_refused_and_nothing_is_recorded(self):
+        # every shape NEITHER rule admits; "a leading dot", "an at-sign" and "a colon" are ssh-alias shapes
+        # (attach files them), so they are the landing cases below, not refusals here
+        seq0 = km._sync_notice_count()
+        err_out = io.StringIO()
+        with contextlib.redirect_stderr(err_out):
+            for why in ("a slash", "a slash with dot-dot", "whitespace inside", "a tab", "a newline", "a NUL",
+                        "a control char", "ten kilobytes", "a leading hyphen", "a quote", "a backslash",
+                        "a percent", "a query"):
+                host = BAD_HOSTS[why]
+                pub, err = km.set_trust(host, "trusted")
+                self.assertIsNone(pub, why)
+                self.assertIn(RULE_KEY, err or "", why)
+                self.assertIn("ssh alias", err, "this door's sentence names the wider rule it holds (%s)" % why)
+                if len(host) > 3:
+                    self.assertNotIn(host, err, "the refused string is not echoed back (%s)" % why)
+        with km._known_lock:
+            self.assertEqual(km._known, {}, "nothing remembered")
+        self.assertEqual((self.pushed, self.saves), ([], []), "the bus is not told, the file is not written")
+        self.assertFalse(km._tunnel_wake.is_set())
+        # said on this machine: one stderr line and one bell row per distinct value, naming the door
+        lines = [l for l in err_out.getvalue().splitlines() if "trust route refused" in l]
+        self.assertEqual(len(lines), 13, err_out.getvalue())
+        self.assertNotIn("b" * 10_000, err_out.getvalue(), "ten kilobytes never reach the log")
+        self.assertTrue(all("ssh alias" in l for l in lines))
+        rows = km._sync_notice_rows()[-(km._sync_notice_count() - seq0):]
+        self.assertEqual(len(rows), 13)
+        self.assertTrue(all((r["kind"], r["ok"]) == ("refused", False) for r in rows))
+
+    def test_a_good_unattached_name_still_files_an_origin_only_row(self):
+        pub, err = km.set_trust("FARBOX", "trusted")
+        self.assertIsNone(err)
+        self.assertEqual(pub, {"host": "FARBOX", "trust": "trusted", "originOnly": True})
+        self.assertEqual(km.known_trust("FARBOX"), "trusted")
+        self.assertEqual(self.pushed, [("FARBOX", "trusted")])
+
+    def test_an_ssh_alias_a_hub_holds_a_peer_under_lands_unremembered(self):
+        # the relay case: a hub attached a peer as user@box (the ssh rule admits it, _safe_id does not), its
+        # bus stamps that peer's relayed mail with that alias as origin, and remote_trust carries the alias
+        # to THIS machine's trust route the first time the user tiers the pair, so it must land here with
+        # nothing remembered beforehand; a bracketed address is the other alias shape attach admits
+        for alias in ("user@build-box", "[fe80::1]"):
+            pub, err = km.set_trust(alias, "isolated")
+            self.assertIsNone(err, alias)
+            self.assertEqual(pub, {"host": alias, "trust": "isolated", "originOnly": True})
+            self.assertEqual(km.known_trust(alias), "isolated")
+        self.assertEqual(self.pushed, [("user@build-box", "isolated"), ("[fe80::1]", "isolated")])
+        # ...and the same alias is what the popover re-tiers later, remembered now
+        pub, err = km.set_trust("user@build-box", "trusted")
+        self.assertEqual((err, pub["trust"], km.known_trust("user@build-box")), (None, "trusted", "trusted"))
+
+    def test_over_http_a_junk_name_is_a_400_that_echoes_nothing(self):
+        def post(body):
+            req = urllib.request.Request(
+                "http://127.0.0.1:%d/tunnels/trust" % self.port, data=json.dumps(body).encode(),
+                headers={"Content-Type": "application/json", "X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+            try:
+                with urllib.request.urlopen(req, timeout=10) as r:
+                    return r.status, json.loads(r.read().decode())
+            except urllib.error.HTTPError as e:
+                return e.code, json.loads(e.read().decode() or "{}")
+        with contextlib.redirect_stderr(io.StringIO()):
+            for why in ("a slash with dot-dot", "whitespace inside", "ten kilobytes"):
+                st, r = post({"host": BAD_HOSTS[why], "trust": "trusted"})
+                self.assertEqual(st, 400, why)
+                self.assertIs(r.get("ok"), False, why)
+                self.assertIn(RULE_KEY, r.get("error") or "", why)
+                self.assertNotIn(BAD_HOSTS[why], json.dumps(r), why)
+        with km._known_lock:
+            self.assertEqual(km._known, {})
+        self.assertEqual(self.pushed, [])
+        st, r = post({"host": "FARBOX", "trust": "isolated"})
+        self.assertEqual((st, r.get("ok")), (200, True))
+        self.assertEqual(self.pushed, [("FARBOX", "isolated")])
+
+
+class RegistriesLoadChecked(unittest.TestCase):
+    """Rows already on disk from before the doors were guarded (review find, 2026-09-08): _remotes_load and
+    _known_load restored any row with a truthy host, so a junk key filed by a pre-fix hub came back at every
+    boot, was told to the bus, and rendered in the panel. A row whose host fails the rule its own door
+    applies (check-in rows: _safe_id; ssh rows: _safe_ssh_host; remembered rows: either) is now set aside
+    to a sidecar beside the file, never loaded, never written back, said once with a clipped repr, and
+    filed as one bell row of kind refused."""
+
+    JUNK = "mobile/../hub name\x00"      # a path-traversal shape, with whitespace and a NUL
+
+    def setUp(self):
+        km._remotes.clear()
+        with km._known_lock:
+            km._known.clear()
+        km._origin_trust_pushed.clear()
+        km._host_refused_said.clear()
+        self.pushed = []
+        self._saved = (km._notify_bus_origin_trust, km.REMOTES_FILE, km.KNOWN_FILE)
+        km._notify_bus_origin_trust = lambda h, t: self.pushed.append((h, t)) or True
+        self.td = tempfile.TemporaryDirectory()
+        km.REMOTES_FILE = Path(self.td.name) / "remotes.json"
+        km.KNOWN_FILE = Path(self.td.name) / "remotes-known.json"
+
+    def tearDown(self):
+        km._notify_bus_origin_trust, km.REMOTES_FILE, km.KNOWN_FILE = self._saved
+        km._remotes.clear()
+        with km._known_lock:
+            km._known.clear()
+        self.td.cleanup()
+
+    @staticmethod
+    def _row(host, checkin=True, token="tok"):
+        return {"host": host, "checkin_peer": checkin, "kernel_port": 29855, "local_port": 29855,
+                "bus_port": 25302, "token": token, "trust": "directed", "sids": [], "status": "up"}
+
+    def _plant(self):
+        km.REMOTES_FILE.write_text(json.dumps([self._row(self.JUNK, token="junk-tok"), self._row("TESTHOST"),
+                                               self._row("user@build-box", checkin=False)]))
+        os.chmod(km.REMOTES_FILE, 0o600)
+        km.KNOWN_FILE.write_text(json.dumps([{"host": h, "lastAttachedAt": 1, "trust": "trusted", "share": False,
+                                              "attached": True} for h in (self.JUNK, "TESTHOST", "user@build-box")]))
+
+    def test_a_junk_row_is_set_aside_and_reaches_neither_registry_nor_bus_nor_panel(self):
+        self._plant()
+        seq0 = km._sync_notice_count()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            km._known_load()
+            km._remotes_load()
+        # the registries hold the rows their doors would have filed, and nothing else
+        self.assertEqual(set(km._remotes), {"TESTHOST", "user@build-box"})
+        with km._known_lock:
+            self.assertEqual(set(km._known), {"TESTHOST", "user@build-box"})
+        # rendered rows: what GET /tunnels and the popover show
+        hosts = [t["host"] for t in km.list_remotes()] + [k["host"] for k in km.list_known()]
+        self.assertNotIn(self.JUNK, hosts)
+        self.assertEqual(sorted(hosts), ["TESTHOST", "user@build-box"])
+        # the bus: the origin-trust push walks every remembered-but-unattached row; the junk one is not there
+        km._remotes.clear()
+        km._push_origin_trust_rows()
+        self.assertEqual(sorted(h for h, t in self.pushed), ["TESTHOST", "user@build-box"])
+        # disk: neither file carries the row any more (never written back)…
+        for f in (km.REMOTES_FILE, km.KNOWN_FILE):
+            self.assertNotIn("mobile/../hub", f.read_text(), f.name)
+        self.assertEqual({r["host"] for r in json.loads(km.REMOTES_FILE.read_text())}, {"TESTHOST", "user@build-box"})
+        self.assertEqual({r["host"] for r in json.loads(km.KNOWN_FILE.read_text())}, {"TESTHOST", "user@build-box"})
+        # …and each sits in a sidecar beside the file it came from, the remotes one 0600 (it carries a token)
+        aside = sorted(Path(self.td.name).glob("remotes.json.refused-*"))
+        self.assertEqual(len(aside), 1, aside)
+        self.assertEqual([r["host"] for r in json.loads(aside[0].read_text())], [self.JUNK])
+        self.assertEqual(json.loads(aside[0].read_text())[0]["token"], "junk-tok", "the evidence survives whole")
+        self.assertEqual(stat.S_IMODE(aside[0].stat().st_mode), 0o600)
+        kaside = sorted(Path(self.td.name).glob("remotes-known.json.refused-*"))
+        self.assertEqual(len(kaside), 1, kaside)
+        self.assertEqual([r["host"] for r in json.loads(kaside[0].read_text())], [self.JUNK])
+        # said once per file, with a clipped repr and never the raw string
+        lines = [l for l in err.getvalue().splitlines() if "refused" in l]
+        self.assertEqual(len(lines), 2, err.getvalue())
+        self.assertTrue(any("remotes.json" in l for l in lines) and any("remotes-known.json" in l for l in lines))
+        for l in lines:
+            self.assertNotIn(self.JUNK, l, "the raw string (a NUL in it) never reaches a log")
+            self.assertIn(repr(self.JUNK), l, "its repr does")
+            self.assertLess(len(l), 400)
+        # …and as bell rows of kind refused
+        rows = km._sync_notice_rows()[-(km._sync_notice_count() - seq0):]
+        self.assertEqual(len(rows), 2)
+        for r in rows:
+            self.assertEqual((r["kind"], r["ok"]), ("refused", False))
+            self.assertNotIn(self.JUNK, r["text"])
+        # a second boot finds clean files: nothing more to say
+        km._remotes.clear()
+        with km._known_lock:
+            km._known.clear()
+        err2 = io.StringIO()
+        with contextlib.redirect_stderr(err2):
+            km._known_load()
+            km._remotes_load()
+        self.assertEqual(err2.getvalue(), "")
+        self.assertEqual(km._sync_notice_count() - seq0, 2)
+        self.assertEqual(len(list(Path(self.td.name).glob("*.refused-*"))), 2, "no second sidecar")
+
+    def test_an_over_long_or_non_string_host_is_set_aside_too(self):
+        # ...and an ssh row whose alias ends in a newline: the ssh rule's `$` admitted it as _safe_id's did
+        # (review find, 2026-09-08), and nothing strips a row read from disk
+        self.assertFalse(km._safe_ssh_host("user@build-box\n"), "a trailing newline is not an ssh alias")
+        km.REMOTES_FILE.write_text(json.dumps([self._row("a" * 129), dict(self._row("x"), host=5),
+                                               self._row("-oProxyCommand=x", checkin=False),
+                                               self._row("user@build-box\n", checkin=False), self._row("TESTHOST")]))
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._remotes_load()
+        self.assertEqual(set(km._remotes), {"TESTHOST"})
+        self.assertEqual([r["host"] for r in json.loads(km.REMOTES_FILE.read_text())], ["TESTHOST"])
+        aside = sorted(Path(self.td.name).glob("remotes.json.refused-*"))
+        self.assertEqual(len(aside), 1)
+        self.assertEqual(len(json.loads(aside[0].read_text())), 4, "every refused row is in the sidecar")
+
+    def test_clean_files_load_as_before_and_are_not_rewritten(self):
+        km.REMOTES_FILE.write_text(json.dumps([self._row("TESTHOST"), self._row("user@build-box", checkin=False)]))
+        km.KNOWN_FILE.write_text(json.dumps([{"host": "TESTHOST", "lastAttachedAt": 1, "trust": "trusted"}]))
+        before = (km.REMOTES_FILE.read_bytes(), km.KNOWN_FILE.read_bytes())
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            km._known_load()
+            km._remotes_load()
+        self.assertEqual(set(km._remotes), {"TESTHOST", "user@build-box"})
+        self.assertEqual(km.known_trust("TESTHOST"), "trusted")
+        self.assertEqual((km.REMOTES_FILE.read_bytes(), km.KNOWN_FILE.read_bytes()), before)
+        self.assertEqual(err.getvalue(), "")
+        self.assertEqual(list(Path(self.td.name).glob("*.refused-*")), [])
+
+
+class RefusalSaidOnBothMachines(unittest.TestCase):
+    """A refused check-in was recorded nowhere (review find, 2026-09-08): the hub answered 400 with a reason
+    and logged nothing, and the mobile read only the status and re-sent the same name every supervisor pass
+    forever. Hub side: one stderr line per distinct offending value (a clipped repr, never the raw string)
+    and one bell row of kind refused. Mobile side: _checkin_handshake reads the reason, says it once per
+    distinct reason (stderr, the dial log, the bell), and does not re-send the same declared name until the
+    name or the hub's kernel incarnation changes; a hub that is simply unreachable keeps retrying quietly."""
+
+    @classmethod
+    def setUpClass(cls):
+        _serve(cls)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        km._remotes.clear()
+        with km._known_lock:
+            km._known.clear()
+        km._host_refused_said.clear()
+        self.td = tempfile.TemporaryDirectory()
+        self._saved = (km.TUNNEL_LOG, km._checkin_payload, km.checkin_apply, km._remotes_save, km._known_note)
+        km.TUNNEL_LOG = Path(self.td.name) / "tunnels.jsonl"
+        km._remotes_save = lambda: None
+        km._known_note = lambda *a, **k: None
+        self.asked = []
+        real = self._saved[2]
+        km.checkin_apply = lambda body: (self.asked.append(body.get("host")), real(body))[1]   # the Handler
+        #                                                                          resolves the name at call time
+
+    def tearDown(self):
+        km.TUNNEL_LOG, km._checkin_payload, km.checkin_apply, km._remotes_save, km._known_note = self._saved
+        km._remotes.clear()
+        with km._known_lock:
+            km._known.clear()
+        self.td.cleanup()
+
+    def _row(self, hub_pid=4242):
+        return {"host": "hub", "local_port": self.port, "token": os.environ["ROMP_SERVE_TOKEN"],
+                "rk_port": 29855, "rb_port": 25302, "hub_pid": hub_pid, "status": "up", "detail": ""}
+
+    def _dial_log(self):
+        if not km.TUNNEL_LOG.exists():
+            return []
+        return [json.loads(x) for x in km.TUNNEL_LOG.read_text().splitlines() if x.strip()]
+
+    def test_the_hub_says_a_refusal_once_per_value_with_a_clipped_repr(self):
+        big, nul = "b" * 10_000, "mobile/../hub name\x00"
+        seq0 = km._sync_notice_count()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            for h in (big, big, nul, big, nul):
+                self.assertEqual(km.checkin_apply(dict(BODY, host=h))[1], 400)
+        lines = [l for l in err.getvalue().splitlines() if "check-in" in l and "refused" in l]
+        self.assertEqual(len(lines), 2, "once per distinct value, not per attempt: %r" % err.getvalue())
+        self.assertNotIn(big, err.getvalue(), "ten kilobytes never reach the log")
+        self.assertNotIn(nul, err.getvalue(), "nor a raw NUL")
+        for l in lines:
+            self.assertLess(len(l), 400)
+            self.assertIn("machine name", l)
+        self.assertTrue(any(repr(nul) in l for l in lines), "the clipped repr names the value")
+        self.assertTrue(any("10000 characters" in l for l in lines), "the long one says how long it was")
+        rows = km._sync_notice_rows()[-(km._sync_notice_count() - seq0):]
+        self.assertEqual(len(rows), 2, "one bell row per distinct value")
+        for r in rows:
+            self.assertEqual((r["kind"], r["ok"]), ("refused", False))
+            self.assertNotIn(big, r["text"])
+            self.assertIn("machine name", r["text"])
+
+    def test_the_mobile_says_the_reason_once_and_stops_re_sending_that_name(self):
+        declared = ["mobile/../hub"]
+        km._checkin_payload = lambda r: dict(BODY, host=declared[0])
+        r = self._row()
+        seq0 = km._sync_notice_count()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            results = [km._checkin_handshake(r) for _ in range(3)]
+        self.assertEqual(results, [False, False, False])
+        self.assertEqual(self.asked, ["mobile/../hub"], "the hub was asked ONCE; the same name is not re-sent")
+        lines = [l for l in err.getvalue().splitlines() if "refused by" in l]      # the mobile's line
+        self.assertEqual(len(lines), 1, err.getvalue())
+        self.assertIn("hub", lines[0])
+        self.assertIn(RULE_KEY, lines[0], "the hub's reason, read at last")
+        recs = [x for x in self._dial_log() if x.get("event") == "checkin-refused"]
+        self.assertEqual(len(recs), 1, recs)
+        self.assertEqual((recs[0]["host"], recs[0]["status"]), ("hub", 400))
+        self.assertIn(RULE_KEY, recs[0]["error"])
+        rows = km._sync_notice_rows()[-(km._sync_notice_count() - seq0):]
+        mine = [x for x in rows if "refused by" in x["text"]]
+        self.assertEqual(len(mine), 1, rows)
+        self.assertEqual((mine[0]["kind"], mine[0]["ok"]), ("refused", False))
+        self.assertEqual(km._remotes, {}, "nothing landed on the hub")
+        # a changed name is the event that re-arms the send: it goes out, lands, and the memo clears
+        declared[0] = "mobile1"
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertTrue(km._checkin_handshake(r))
+        self.assertEqual(self.asked, ["mobile/../hub", "mobile1"])
+        self.assertNotIn("_checkin_refused", r)
+        self.assertIn("mobile1", km._remotes)
+
+    def test_a_hub_kernel_restart_re_arms_the_send(self):
+        km._checkin_payload = lambda r: dict(BODY, host="mobile/../hub")
+        r = self._row(hub_pid=4242)
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertFalse(km._checkin_handshake(r))
+            self.assertFalse(km._checkin_handshake(r))
+            r["hub_pid"] = 4243                    # the supervisor's /version poll saw a new incarnation
+            self.assertFalse(km._checkin_handshake(r))
+        self.assertEqual(len(self.asked), 2, "once per hub incarnation for an unchanged name")
+        recs = [x for x in self._dial_log() if x.get("event") == "checkin-refused"]
+        self.assertEqual(len(recs), 1, "the same reason is not said twice")
+
+    def test_an_unreachable_hub_keeps_retrying_quietly(self):
+        # a hub mid-boot answers nothing: that is not a refusal, so no memo, no line, and the next pass dials
+        km._checkin_payload = lambda r: dict(BODY, host="mobile1")
+        s = _socket.socket()
+        s.bind(("127.0.0.1", 0))
+        closed = s.getsockname()[1]
+        s.close()
+        r = dict(self._row(), local_port=closed)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual([km._checkin_handshake(r) for _ in range(2)], [False, False])
+        self.assertNotIn("_checkin_refused", r)
+        self.assertEqual(err.getvalue(), "")
+        self.assertEqual(self._dial_log(), [])
+
+    def test_the_memo_never_reaches_disk_or_the_panel(self):
+        # a boot is an event that re-arms the send, and the panel has no field for it
+        self.assertIn("_checkin_refused", km._NOT_SAVED)
+        r = dict(self._row(), _checkin_refused={"host": "x", "hub": 1, "status": 400, "error": "e", "hold": True},
+                 kernel_port=29855, trust="directed", sids=[], checkin=True, checkin_peer=False)
+        self.assertNotIn("_checkin_refused", km._remote_public(r))
+        km._remotes["hub"] = r
+        self.assertNotIn("_checkin_refused", json.dumps(km._remotes_rows_for_save()))
 
 
 if __name__ == "__main__":

--- a/tests/test_checkin_trust_persists.py
+++ b/tests/test_checkin_trust_persists.py
@@ -11,11 +11,25 @@ The mismatch is invisible from the sending end, which is why it read as a store 
 a peer DECLARES comes from its own row, so the sender kept displaying "they hold yours: trusted" while
 the receiver was quarantining. A re-check-in is the same relationship reconnecting, not a new one.
 
+CheckinHostChecked / CheckinRoute (2026-09-08): the same handshake took the peer's DECLARED name as it
+came — any length, any characters — and that string went on to key the registry, remotes.json, the
+remembered-hosts file, the bus's peer table (and the mail it holds for that peer, a path component
+there), the /remote/<host>/ routes and every row action's body lookup. Every name a romp mobile
+declares clears _safe_id — _self_host()'s derived names always did, and its ROMP_HOST_NAME override
+now does or is set aside aloud (test_postal_self_host.py) — so the hub refuses anything else at the
+door with a 400 that says what a name may look like, recording, saving, popping and waking nothing,
+and turns away only names no romp mobile produces.
+
 Synthetic only — placeholder hosts/ports/tokens, hermetic temp STATE, no ssh.
 """
+import json
 import os
 import tempfile
+import threading
 import unittest
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -86,6 +100,207 @@ class CheckinTrust(unittest.TestCase):
         self.assertEqual(status, 409)
         self.assertFalse(payload["ok"])
         self.assertEqual(km._remotes["TESTHOST"]["trust"], "trusted", "the ssh row is untouched")
+
+
+# What the door must say when it refuses a name — the person's words, naming the shape a host may take.
+RULE = ("host must be a machine name: letters, digits, dots, hyphens or underscores, starting with a "
+        "letter or digit, at most 128 characters")
+
+# Names every consumer downstream would choke on, or silently mis-key. Each is a path/URL/JSON hazard a
+# hostile or merely broken peer could declare; none is anything _self_host() can produce.
+BAD_HOSTS = {
+    "a slash": "mobile/hub", "a slash with dot-dot": "mobile/../hub",
+    "whitespace inside": "my host", "a tab": "host\tname", "a newline": "host\nname",
+    "a NUL": "host\x00name", "a control char": "host\x1bname",
+    "just over the limit": "a" * 129, "ten kilobytes": "b" * 10_000,
+    "a leading dot": ".hidden", "dot-dot": "..", "a lone dot": ".",
+    "a leading hyphen": "-oProxyCommand=x", "a quote": 'host"name', "a backslash": "host\\name",
+    "a colon": "host:22", "an at-sign": "user@host", "a percent": "host%2Fname", "a query": "host?x=1",
+}
+
+# Names machines really declare, and every fixture name the other check-in tests use. A dotted FQDN
+# with hyphens, an underscore (an ssh alias or a ROMP_HOST_NAME override may carry one), a minted
+# last-resort id, and single-character or digit-led labels all pass.
+GOOD_HOSTS = ("TESTHOST", "OTHERHOST", "mobile1", "hub", "laptop", "build-box-01.example.com",
+              "my_box", "host-1a2b3c4d", "a", "9box", "a" * 128)
+
+
+class CheckinHostChecked(unittest.TestCase):
+    """A check-in is refused when the declared host is not a hostname, and nothing is recorded."""
+
+    def setUp(self):
+        km._remotes.clear()
+        with km._known_lock:
+            km._known.clear()
+        self.saves, self.notes = [], []
+        self._saved = (km._remotes_save, km._known_note)
+        km._remotes_save = lambda: self.saves.append(1)
+        km._known_note = lambda *a, **k: self.notes.append((a, k))
+        km._tunnel_wake.clear()
+        self.disk = self._disk()
+
+    def tearDown(self):
+        km._remotes_save, km._known_note = self._saved
+        km._remotes.clear()
+        with km._known_lock:
+            km._known.clear()
+
+    @staticmethod
+    def _disk():
+        # the two persisted registries, as bytes (None = absent), so "nothing saved" is checked on disk too
+        out = []
+        for f in (km.REMOTES_FILE, km.KNOWN_FILE):
+            try:
+                out.append(f.read_bytes())
+            except OSError:
+                out.append(None)
+        return out
+
+    def _refused(self, why, host):
+        payload, status = km.checkin_apply(dict(BODY, host=host))
+        self.assertEqual(status, 400, why)
+        self.assertIs(payload["ok"], False, why)
+        self.assertEqual(payload["error"], RULE, why)
+        if len(host) > 3:
+            self.assertNotIn(host, payload["error"], "the refused string is not echoed back (%s)" % why)
+        self.assertEqual(km._remotes, {}, "nothing filed in the registry (%s)" % why)
+        with km._known_lock:
+            self.assertEqual(km._known, {}, "nothing remembered (%s)" % why)
+        self.assertEqual(self.saves, [], "remotes.json not written (%s)" % why)
+        self.assertEqual(self.notes, [], "no remembered-hosts entry (%s)" % why)
+        self.assertEqual(self._disk(), self.disk, "neither state file changed (%s)" % why)
+        self.assertFalse(km._tunnel_wake.is_set(), "the supervisor is not woken for nothing (%s)" % why)
+
+    def test_a_slash_is_refused_and_nothing_is_recorded(self):
+        for why in ("a slash", "a slash with dot-dot"):
+            self._refused(why, BAD_HOSTS[why])
+
+    def test_whitespace_inside_is_refused(self):
+        for why in ("whitespace inside", "a tab", "a newline"):
+            self._refused(why, BAD_HOSTS[why])
+
+    def test_a_control_char_or_nul_is_refused(self):
+        for why in ("a NUL", "a control char"):
+            self._refused(why, BAD_HOSTS[why])
+
+    def test_an_over_long_name_is_refused(self):
+        for why in ("just over the limit", "ten kilobytes"):
+            self._refused(why, BAD_HOSTS[why])
+
+    def test_a_leading_dot_or_dot_dot_is_refused(self):
+        for why in ("a leading dot", "dot-dot", "a lone dot"):
+            self._refused(why, BAD_HOSTS[why])
+
+    def test_every_other_hazard_is_refused_too(self):
+        for why, host in BAD_HOSTS.items():
+            self._refused(why, host)
+
+    def test_a_non_string_host_is_refused(self):
+        # str() used to coerce these into names — a JSON 1.5 became the host "1.5" and was filed
+        for host in (["mobile"], {"host": "mobile"}, 1.5, 5, True, None):
+            payload, status = km.checkin_apply(dict(BODY, host=host))
+            self.assertEqual(status, 400, repr(host))
+            self.assertIs(payload["ok"], False, repr(host))
+            self.assertEqual(payload["error"], "host, kernelPort, busPort required", repr(host))
+        self.assertEqual((km._remotes, self.saves, self.notes), ({}, [], []))
+        self.assertFalse(km._tunnel_wake.is_set())
+
+    def test_a_junk_name_with_a_known_token_pops_nothing(self):
+        # the same-token sweep ("this mobile re-checked in under a new name") ran BEFORE anything looked
+        # at the name, so a junk re-check-in would have dropped the mobile's good row on its way in
+        km.checkin_apply(dict(BODY))
+        self.assertEqual(set(km._remotes), {"TESTHOST"})
+        self.saves.clear(), self.notes.clear()
+        km._tunnel_wake.clear()
+        payload, status = km.checkin_apply(dict(BODY, host=BAD_HOSTS["a slash with dot-dot"]))
+        self.assertEqual((status, payload["ok"], payload["error"]), (400, False, RULE))
+        self.assertEqual(set(km._remotes), {"TESTHOST"}, "the good row is untouched")
+        self.assertEqual(km._remotes["TESTHOST"]["token"], "peertok")
+        self.assertEqual((self.saves, self.notes), ([], []))
+        self.assertFalse(km._tunnel_wake.is_set())
+
+    def test_the_names_machines_declare_still_land(self):
+        for h in GOOD_HOSTS:
+            payload, status = km.checkin_apply(dict(BODY, host=h, token="tok-" + h))
+            self.assertEqual(status, 200, h)
+            self.assertIs(payload["ok"], True, h)
+            self.assertEqual(payload["host"], h)
+            self.assertTrue(km._remotes[h]["checkin_peer"], h)
+            self.assertEqual(km._remotes[h]["host"], h)
+        self.assertEqual(len(self.saves), len(GOOD_HOSTS), "each landing is persisted, as before")
+        self.assertEqual([a[0] for a, k in self.notes], list(GOOD_HOSTS), "…and remembered, as before")
+        self.assertTrue(km._tunnel_wake.is_set())
+
+    def test_this_machines_own_declared_name_clears_the_rule(self):
+        # what a real mobile sends IS _self_host(); every shape it can produce must land. Read live, with
+        # the override out of the way, so this checks the box's real short hostname — never a literal.
+        saved = os.environ.pop("ROMP_HOST_NAME", None)
+        try:
+            me = km._self_host()
+        finally:
+            if saved is not None:
+                os.environ["ROMP_HOST_NAME"] = saved
+        self.assertTrue(km._safe_id(me), "the rule IS the promise _self_host makes")
+        payload, status = km.checkin_apply(dict(BODY, host=me))
+        self.assertEqual(status, 200, "a real machine's own name must never be refused")
+        self.assertIn(me, km._remotes)
+        # …and the two fallbacks _self_host reaches for when the kernel hostname fails path-safety
+        for h in (km._sanitize_host_name("Some Body's Mac (2)"), "host-%08x" % 0xDEADBEEF):
+            self.assertTrue(h and km._safe_id(h), h)
+            self.assertEqual(km.checkin_apply(dict(BODY, host=h, token="t-" + h))[1], 200, h)
+
+
+class CheckinRoute(unittest.TestCase):
+    """The same refusal through the door the mobile actually knocks on: POST /checkin on the real Handler
+    (the test_tag_route.py harness pattern)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        km._remotes.clear()
+        with km._known_lock:
+            km._known.clear()
+        self.saves, self.notes = [], []
+        self._saved = (km._remotes_save, km._known_note)
+        km._remotes_save = lambda: self.saves.append(1)
+        km._known_note = lambda *a, **k: self.notes.append((a, k))
+
+    def tearDown(self):
+        km._remotes_save, km._known_note = self._saved
+        km._remotes.clear()
+        with km._known_lock:
+            km._known.clear()
+
+    def _post(self, body):
+        req = urllib.request.Request(
+            "http://127.0.0.1:%d/checkin" % self.port, data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json",
+                     "X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return r.status, json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read().decode() or "{}")
+
+    def test_over_http_a_junk_name_is_a_400_and_a_real_one_lands(self):
+        for why in ("a slash with dot-dot", "whitespace inside", "a NUL", "ten kilobytes", "a leading dot"):
+            st, r = self._post(dict(BODY, host=BAD_HOSTS[why]))
+            self.assertEqual(st, 400, why)
+            self.assertEqual((r.get("ok"), r.get("error")), (False, RULE), why)
+        self.assertEqual((km._remotes, self.saves, self.notes), ({}, [], []), "nothing recorded over HTTP either")
+        st, r = self._post(dict(BODY, host="build-box-01.example.com"))
+        self.assertEqual(st, 200)
+        self.assertEqual((r["ok"], r["host"]), (True, "build-box-01.example.com"))
+        self.assertTrue(km._remotes["build-box-01.example.com"]["checkin_peer"])
+        self.assertEqual((len(self.saves), len(self.notes)), (1, 1))
 
 
 if __name__ == "__main__":

--- a/tests/test_postal_self_host.py
+++ b/tests/test_postal_self_host.py
@@ -11,9 +11,18 @@ under two names. peer_exchange_handle refuses an unkeyable declared name (guardi
 un-updated dialers) — but only AFTER _canon_peer_name, so the checked-in-alias fold keeps
 self-healing.
 
+The override tests (2026-09-08): the kernel's ROMP_HOST_NAME override and the bus's ROMP_POSTAL_HOST
+override were each the one branch that dodged the rule — returned exactly as set, directly under the
+docstring saying the name MUST clear _safe_id — so a mobile whose operator set one to an unusable name
+declared that name to every hub (which now refuses it at its check-in door, checkin_apply) while its
+own mail parked unreachable. An unusable override is now set aside aloud, once per process, and the
+derived name is used — on both daemons (KernelSelfHost and BusSelfHost).
+
 Synthetic only — invented hostnames (TESTHOST, a control-byte junk form), hermetic temp state dir,
 no real machine data.
 """
+import contextlib
+import io
 import os
 import socket as _socket
 import tempfile
@@ -48,6 +57,8 @@ class _HostnameSeams(unittest.TestCase):
         self._pc, self._kc = pm._host_name_candidates, km._host_name_candidates
         pm._host_name_candidates = km._host_name_candidates = lambda: []
         pm._self_host_fb = km._self_host_fb = None
+        getattr(km, "_host_name_env_warned", set()).clear()   # the once-per-process override warnings, re-armed
+        getattr(pm, "_postal_host_env_warned", set()).clear()
 
     def tearDown(self):
         for k, v in self._env.items():
@@ -58,6 +69,8 @@ class _HostnameSeams(unittest.TestCase):
         _socket.gethostname = self._gethostname
         pm._host_name_candidates, km._host_name_candidates = self._pc, self._kc
         pm._self_host_fb = km._self_host_fb = None
+        getattr(km, "_host_name_env_warned", set()).clear()
+        getattr(pm, "_postal_host_env_warned", set()).clear()
 
 
 class BusSelfHost(_HostnameSeams):
@@ -103,6 +116,42 @@ class BusSelfHost(_HostnameSeams):
         pm.outbox_put("TESTHOST", {"mid": mid, "body": "hi"})
         self.assertEqual((pm.outbox_get("TESTHOST", mid) or {}).get("body"), "hi")
         self.assertTrue(pm.outbox_del("TESTHOST", mid))
+
+    def test_a_valid_override_of_any_real_shape_is_returned_verbatim(self):
+        for name in ("TESTHOST", "build-box-01.example.com", "my_box", "host-1a2b3c4d"):
+            os.environ["ROMP_POSTAL_HOST"] = name
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(pm.self_host(), name)
+            self.assertEqual(err.getvalue(), "", "a usable override is taken quietly")
+
+    def test_a_junk_override_is_set_aside_aloud_once_and_the_derived_name_is_used(self):
+        # the bus's twin of the kernel gap: ROMP_POSTAL_HOST came back exactly as set, so a bus whose
+        # operator set it to an unusable name declared that name in every peer exchange (2026-09-08)
+        _socket.gethostname = lambda: "TESTHOST"
+        for junk in ("my box", "user@host", "a" * 129):
+            os.environ["ROMP_POSTAL_HOST"] = junk
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                first, second = pm.self_host(), pm.self_host()
+            self.assertEqual((first, second), ("TESTHOST", "TESTHOST"), repr(junk[:20]))
+            self.assertTrue(pm._safe_id(first))
+            lines = [l for l in err.getvalue().splitlines() if "ROMP_POSTAL_HOST" in l]
+            self.assertEqual(len(lines), 1, "said once per process, not per call: %r" % err.getvalue())
+            self.assertTrue(lines[0].startswith("[postal] self_host: "), "the bus's own log prefix")
+            self.assertIn("not usable as a machine name", lines[0])
+            self.assertIn("letters, digits, dots, hyphens or underscores", lines[0], "says what a name may look like")
+            self.assertIn("declaring 'TESTHOST' to peers instead", lines[0], "names the name used instead")
+            self.assertIn(repr(junk[:20])[:-1], lines[0], "and the name set aside (a long one is cut short)")
+
+    def test_a_junk_override_with_a_junk_hostname_still_converges_with_the_kernel(self):
+        os.environ["ROMP_POSTAL_HOST"] = "my box"
+        _socket.gethostname = lambda: JUNK
+        with contextlib.redirect_stderr(io.StringIO()):
+            b = pm.self_host()
+        self.assertTrue(pm._safe_id(b))
+        self.assertNotIn(" ", b)
+        self.assertEqual(b, km._self_host(), "bus and kernel still share the persisted identity")
 
 
 class ExchangeUnkeyableHostGate(_HostnameSeams):
@@ -158,6 +207,42 @@ class KernelSelfHost(_HostnameSeams):
         self.assertNotIn("\x04", k)
         self.assertEqual(k, pm.self_host(),
                          "kernel and bus share the persisted identity — one machine, one name")
+
+    def test_a_valid_override_of_any_real_shape_is_returned_verbatim(self):
+        # a dotted name with hyphens, an underscore, a minted-style id: what an operator might set
+        for name in ("TESTHOST", "build-box-01.example.com", "my_box", "host-1a2b3c4d"):
+            os.environ["ROMP_HOST_NAME"] = name
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(km._self_host(), name)
+            self.assertEqual(err.getvalue(), "", "a usable override is taken quietly")
+
+    def test_a_junk_override_is_set_aside_aloud_once_and_the_derived_name_is_used(self):
+        # the one branch that dodged the rule: the override came back exactly as set, so a mobile whose
+        # operator set ROMP_HOST_NAME to an unusable name declared it to every hub (2026-09-08)
+        _socket.gethostname = lambda: "TESTHOST"
+        for junk in ("my box", "user@host", "a" * 129):
+            os.environ["ROMP_HOST_NAME"] = junk
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                first, second = km._self_host(), km._self_host()
+            self.assertEqual((first, second), ("TESTHOST", "TESTHOST"), repr(junk[:20]))
+            self.assertTrue(km._safe_id(first))
+            lines = [l for l in err.getvalue().splitlines() if "ROMP_HOST_NAME" in l]
+            self.assertEqual(len(lines), 1, "said once per process, not per call: %r" % err.getvalue())
+            self.assertIn("not usable as a machine name", lines[0])
+            self.assertIn("letters, digits, dots, hyphens or underscores", lines[0], "says what a name may look like")
+            self.assertIn("using 'TESTHOST' for peering instead", lines[0], "names the name used instead")
+            self.assertIn(repr(junk[:20])[:-1], lines[0], "and the name set aside (a long one is cut short)")
+
+    def test_a_junk_override_with_a_junk_hostname_still_converges_with_the_bus(self):
+        os.environ["ROMP_HOST_NAME"] = "my box"
+        _socket.gethostname = lambda: JUNK
+        with contextlib.redirect_stderr(io.StringIO()):
+            k = km._self_host()
+        self.assertTrue(km._safe_id(k))
+        self.assertNotIn(" ", k)
+        self.assertEqual(k, pm.self_host(), "kernel and bus still share the persisted identity")
 
 
 if __name__ == "__main__":

--- a/tests/test_postal_self_host.py
+++ b/tests/test_postal_self_host.py
@@ -18,14 +18,23 @@ declared that name to every hub (which now refuses it at its check-in door, chec
 own mail parked unreachable. An unusable override is now set aside aloud, once per process, and the
 derived name is used — on both daemons (KernelSelfHost and BusSelfHost).
 
+SafeIdTwins (review find, 2026-09-08): the rule itself is duplicated in the two daemons, and its regex
+ended in `$`, which in Python also matches before ONE trailing newline, so "TESTHOST\n" cleared it, and
+the override branches on both daemons returned that name verbatim while every hub stripped it, leaving
+the machine believing in a name no peer keyed. Both copies now fullmatch, both must stay the same
+function, and a trailing newline is the one whitespace shape the junk-override cases now include.
+
 Synthetic only — invented hostnames (TESTHOST, a control-byte junk form), hermetic temp state dir,
 no real machine data.
 """
+import ast
 import contextlib
+import inspect
 import io
 import os
 import socket as _socket
 import tempfile
+import textwrap
 import unittest
 from importlib.machinery import SourceFileLoader
 
@@ -129,7 +138,7 @@ class BusSelfHost(_HostnameSeams):
         # the bus's twin of the kernel gap: ROMP_POSTAL_HOST came back exactly as set, so a bus whose
         # operator set it to an unusable name declared that name in every peer exchange (2026-09-08)
         _socket.gethostname = lambda: "TESTHOST"
-        for junk in ("my box", "user@host", "a" * 129):
+        for junk in ("my box", "user@host", "a" * 129, "TESTHOST2\n"):   # the trailing newline: review find, 2026-09-08
             os.environ["ROMP_POSTAL_HOST"] = junk
             err = io.StringIO()
             with contextlib.redirect_stderr(err):
@@ -221,7 +230,7 @@ class KernelSelfHost(_HostnameSeams):
         # the one branch that dodged the rule: the override came back exactly as set, so a mobile whose
         # operator set ROMP_HOST_NAME to an unusable name declared it to every hub (2026-09-08)
         _socket.gethostname = lambda: "TESTHOST"
-        for junk in ("my box", "user@host", "a" * 129):
+        for junk in ("my box", "user@host", "a" * 129, "TESTHOST2\n"):   # the trailing newline: review find, 2026-09-08
             os.environ["ROMP_HOST_NAME"] = junk
             err = io.StringIO()
             with contextlib.redirect_stderr(err):
@@ -243,6 +252,66 @@ class KernelSelfHost(_HostnameSeams):
         self.assertTrue(km._safe_id(k))
         self.assertNotIn(" ", k)
         self.assertEqual(k, pm.self_host(), "kernel and bus still share the persisted identity")
+
+
+class SafeIdTwins(unittest.TestCase):
+    """_safe_id lives in both daemons on purpose (each loads alone), so the two copies must stay ONE
+    function; and a trailing newline is not a name on either (review find, 2026-09-08: `$` matched
+    before it, and the override branches returned "TESTHOST\n" verbatim)."""
+
+    @staticmethod
+    def _body(fn):
+        # the function minus its docstring: the two copies explain themselves differently, and may
+        tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+        f = tree.body[0]
+        f.body = [n for n in f.body if not (isinstance(n, ast.Expr) and isinstance(n.value, ast.Constant)
+                                            and isinstance(n.value.value, str))]
+        return ast.dump(f)
+
+    def test_the_two_copies_are_the_same_function(self):
+        self.assertEqual(km._SAFE_ID_RE.pattern, pm._SAFE_ID_RE.pattern, "one regex on both daemons")
+        self.assertEqual(self._body(km._safe_id), self._body(pm._safe_id), "one rule on both daemons")
+
+    def test_a_trailing_newline_is_not_a_name_on_either_daemon(self):
+        for s in ("TESTHOST\n", "abc\n", "a\n", "TESTHOST\r\n", "TESTHOST\n\n"):
+            self.assertFalse(km._safe_id(s), repr(s))
+            self.assertFalse(pm._safe_id(s), repr(s))
+        for s in ("TESTHOST", "a", "A.B-c_2", "11111111-2222-3333-4444-555555555555", "a" * 128):
+            self.assertTrue(km._safe_id(s), repr(s))
+            self.assertTrue(pm._safe_id(s), repr(s))
+
+    def test_an_override_with_a_trailing_newline_is_set_aside_on_both_daemons(self):
+        # the ONE whitespace shape the rule admitted: returned verbatim by both override branches, then
+        # stripped by every hub, so the machine's own name and the name peers keyed it by differed by a
+        # newline, and the bus baked it into every message id
+        saved = {k: os.environ.pop(k, None) for k in ("ROMP_POSTAL_HOST", "ROMP_HOST_NAME")}
+        seams = (_socket.gethostname, pm._host_name_candidates, km._host_name_candidates,
+                 pm._self_host_fb, km._self_host_fb)
+        _socket.gethostname = lambda: "TESTHOST"
+        pm._host_name_candidates = km._host_name_candidates = lambda: []
+        pm._self_host_fb = km._self_host_fb = None
+        getattr(km, "_host_name_env_warned", set()).clear()
+        getattr(pm, "_postal_host_env_warned", set()).clear()
+        try:
+            os.environ["ROMP_HOST_NAME"] = os.environ["ROMP_POSTAL_HOST"] = "TESTHOST2\n"
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                k, b, mid = km._self_host(), pm.self_host(), pm._unique()
+            self.assertEqual((k, b), ("TESTHOST", "TESTHOST"), "the derived name, never the newline one")
+            self.assertNotIn("\n", mid, "no message id carries a newline")
+            self.assertTrue(pm._safe_id(mid))
+            self.assertEqual(len([l for l in err.getvalue().splitlines() if "ROMP_HOST_NAME" in l]), 1)
+            self.assertEqual(len([l for l in err.getvalue().splitlines() if "ROMP_POSTAL_HOST" in l]), 1)
+        finally:
+            for k_, v in saved.items():
+                if v is None:
+                    os.environ.pop(k_, None)
+                else:
+                    os.environ[k_] = v
+            (_socket.gethostname, pm._host_name_candidates, km._host_name_candidates,
+             pm._self_host_fb, km._self_host_fb) = seams
+            getattr(km, "_host_name_env_warned", set()).clear()
+            getattr(pm, "_postal_host_env_warned", set()).clear()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What was wrong
Verified on `main`: the check-in handshake's hub side (`checkin_apply`, behind `POST /checkin`) validates the two ports a mobile machine declares but takes its declared host name as-is beyond "not empty". That string then becomes the key of the remotes registry (persisted), the remembered-hosts entry (persisted), the bus's peer row and the directory it holds that peer's mail under, the rows the panel renders, a path segment in the per-remote websocket and file routes, and the name every trust and detach route looks up, including one that relays it into a third machine's registry. Any peer, hostile or merely misconfigured, could write an arbitrary string of any length, with whitespace, control characters, slashes or `..`, into two persisted registries and every consumer. The review of #1053 flagged this as a residual.

## What changes
`checkin_apply` refuses a declared host that is not a string or does not clear the kernel's existing path-safe identifier rule (`_safe_id`: letters, digits, dots, hyphens and underscores, no leading dot, at most 128 characters). That is the very rule the mobile's own host function already promises for every name it can produce, and the same rule the bus applies to the held-mail directory, so no third host rule is introduced. The guard sits before the same-token sweep, so a junk name never removes the mobile's existing good row on the way to being refused. A refusal answers 400 with a plain reason naming what a host may look like, does not echo the refused string, and records, saves, notes and wakes nothing. A non-string host used to coerce to a legal-looking label (a float became `"1.5"`); it now takes the existing required-fields 400.

Reused `_safe_id` rather than the ssh-alias rule, which admits `user@host`, bracketed addresses, colons and `..` because it guards an ssh command line, not a path or registry key.

## The other half: the name a machine declares
The review found the one legitimate client that could be refused: the mobile's own host function returned an operator's `ROMP_HOST_NAME` override verbatim, against its own docstring, so an override with a space or an at-sign used to land on the hub while the bus quietly parked that machine's mail, and would now be refused with nothing said anywhere. The override is now taken only when it clears the same rule; a junk value is set aside once per distinct value on stderr, naming the rule and the derived name used instead, and the machine still boots and checks in under a name every consumer accepts. The bus has the same knob, `ROMP_POSTAL_HOST`, with the same shape; it gets the same three-line fix and its own line through the bus log.

## Deliberately left out
No log line on a refused check-in: the mobile retries a failed handshake every supervisor pass, so a line would flood; the 400 with its reason is the loud failure, the same shape as the existing port refusal. The mobile side reads only the status of that reply today, so surfacing the reason there is a separate change. The routes that look a host up by name are not widened: their registry now only holds validated or ssh-validated keys.

## Tests
`tests/test_checkin_trust_persists.py` gains two classes: refusals for a slash, inner whitespace, a NUL, tab, newline, quote, backslash, colon, at-sign, percent, query, leading dot, leading hyphen, `..`, 129 characters and 10 kB, each asserting the 400, the plain reason and that the registry, the remembered hosts, both files on disk and the supervisor wake are untouched; a junk name carrying a known token leaves the existing row in place; every fixture name, a dotted name with hyphens, an underscore, a minted id, exactly 128 characters and this machine's live host function still land; and the same through the real handler over `POST /checkin`. On `main` the check-in module runs 9 failed / 8 passed, the nine being exactly the new refusals; `tests/test_postal_self_host.py` gains the override cases (a usable override of every real shape wins verbatim and quietly; a junk one is never returned, the derived name clears the rule, the line appears once across two calls), 2 failed / 10 passed on `main`. The bus twin has the same cases; on `main` that module runs 4 failed / 11 passed.

Module runs on this branch, one at a time: `test_checkin_trust_persists` 17, `test_postal_self_host` 15, `test_kernel_remote_identity` 7, `test_peer_reconnect` 9, `test_known_attached_flag` 4, `test_kernel` 468. Pin scans over the other test modules: nothing lost.

## Review
Reviewed by twelve read-only agents (two lenses, two skeptics per finding). Two findings confirmed, both about the override, folded as above. Three refuted as pre-existing and out of scope: the mobile reads only the status of the hub's reply, so any non-200 is silent there today; junk rows already on disk are re-keyed at boot; and "letters" for an ASCII class is the repo's own wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
