### PR TITLE
The views store is a proved read; a fault never erases the tags

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3046,8 +3046,8 @@ def _state_quarantine(p, st, reason):
 
 
 def _read_state_json(path, st=None, expect=None, _tries=3):
-    """The ONE strict reader for a small JSON state file (session-flags, session-order, notify-cards;
-    timeline-views follows in its own change). Distinguishes the outcomes the old `except Exception: {}` conflated:
+    """The ONE strict reader for a small JSON state file (session-flags, session-order, notify-cards,
+    timeline-views). Distinguishes the outcomes the old `except Exception: {}` conflated:
       - a MISSING file is legitimately empty            -> returns None (a fresh install has no files)
       - an UNREADABLE existing file (EIO/EACCES/...)     -> raises _StateUnreadable (never reads empty)
       - TORN or non-JSON bytes                           -> QUARANTINED aside (_state_quarantine: a move,
@@ -3166,7 +3166,8 @@ def _refuse_setting(client, exc, what, gesture, sid="", item_id="", flag="", val
     #1019, WRITTEN (_StateUnwritable: the publish itself failed): one stderr line, and the refusal answered
     on the DELIVERING socket as a `settingRefused` frame -- the same targeted _reply idiom the
     settingStale stand-down and the saveFile acks use, never a broadcast. The frame names the
-    `gesture` ("flag" / "bell" / "order"; "views" follows with its store, so a pane never infers it from which fields are
+    `gesture` ("flag" / "bell" / "order" -- the views store's doors answer on their own acks, _ack_views_write, and
+    never draw this frame -- so a pane never infers it from which fields are
     empty), the gesture's own address (sid / itemId / flag), and `value`: what the kernel's display
     path still paints for that flag or bell -- the value the next push carries -- so the pane
     repaints the refused toggle to it on THIS event rather than to a value it recorded at the click
@@ -3234,21 +3235,26 @@ _atomic_lock = threading.Lock()
 _atomic_seq = [0]
 
 
-def _write_state_json(path, text):
+def _write_state_json(path, text, note=True):
     """The ONE write door for the small JSON state files (session-flags, session-order, notify-cards,
-    and the views store once its path folds in): _atomic_write, with the publish's OSError turned into
+    timeline-views): _atomic_write, with the publish's OSError turned into
     _StateUnwritable and the fault filed ONCE per episode on the path's registry (_note_state_fault, the
     write faults' own table beside the read faults'); a landed write ends the episode. Left as an OSError, a publish that
     failed under a WS gesture escaped the arm's `except _StateUnreadable` to the receive loop, which
     re-raised it as a socket failure and dropped the client, and under an HTTP route reached do_POST's
     catch-all as a 500 traceback (the maintainer's fold on PR #1019: the write step is a fault boundary
-    too). Defined here, beside _atomic_write, because _write_session_order below is its first caller."""
+    too). Defined here, beside _atomic_write, because _write_session_order below is its first caller.
+    `note=False` raises the same _StateUnwritable but files NO notice and opens no write-fault episode:
+    for a write that is housekeeping rather than a gesture (the views reader's re-stamp on read), where
+    a failure is a log line the caller writes itself and the first GESTURE that fails is what the user
+    hears about (the views store's 2026-09-05 rule; the flags, order and bell stores never pass it)."""
     path = Path(path)
     try:
         _atomic_write(path, text)
     except OSError as e:
         exc = _StateUnwritable(path, "write failed: %s" % _errno_text(e))
-        _note_state_fault(exc)
+        if note:
+            _note_state_fault(exc)
         raise exc from e
     _state_write_fault_seen.pop(str(path), None)     # a landed write ends the write-fault episode
 
@@ -3396,6 +3402,16 @@ def _merge_session_order(incoming):
     return [s for s in merged if not (s in seen or seen.add(s))]
 
 
+# Forks whose views heal (_heal_timeline_views: a /clear or revive inherits its session's tag memberships)
+# could not run because the views store faulted -- new sid -> the sid whose memberships it inherits.
+# _ordered retries them on every later pass until the heal lands: the order publish that follows the
+# splice marks the fork KNOWN, so without this map a heal skipped over a transient EIO was never run
+# again and the /clear'd session fell out of its tag for good, with one stderr line as the whole record.
+# In-memory: a fork that is in the saved order when the kernel restarts is no longer new, so a heal
+# still pending across a restart is lost -- the stderr line the skip files says so.
+_views_heal_pending = {}
+
+
 def _ordered(sessions):
     """Order session dicts STRICTLY by the shared, persisted session order (session-order.json) — and by
     NOTHING else. A session already in the order keeps its saved slot; a session NEW to the order is
@@ -3437,6 +3453,16 @@ def _ordered(sessions):
     sess_name = {s["sid"]: (s.get("name") or "") for s in sessions}
     def _nm(sid):
         return sess_name.get(sid) or _name_of(sid) or ""
+    for fsid, osid in list(_views_heal_pending.items()):
+        # a heal deferred on an earlier pass (the views store faulted): retried until it lands. Quiet while
+        # the store still faults -- the skip said it once -- and one line when it lands.
+        try:
+            carried = _heal_timeline_views(osid, fsid)
+        except (_StateUnreadable, _StateUnwritable):
+            continue
+        _views_heal_pending.pop(fsid, None)
+        sys.stderr.write("romp-kernel: views heal for %s %s\n"
+                         % (fsid, "landed on retry" if carried else "retried: nothing to carry"))
     new = [s["sid"] for s in sessions if s["sid"] not in known]
     if new:
         name_at = [_nm(o) for o in order]                # each existing slot's stable name (resolved once)
@@ -3444,7 +3470,19 @@ def _ordered(sessions):
             a = _nm(sid)
             sib = [i for i, n in enumerate(name_at) if a and n == a]   # same-name entries already placed
             if sib:
-                _heal_timeline_views(order[sib[-1]], sid)   # the fork inherits hidden/tag state too
+                try:
+                    _heal_timeline_views(order[sib[-1]], sid)   # the fork inherits its tag state too
+                except (_StateUnreadable, _StateUnwritable) as e:
+                    # the views store faulted inside the heal (its PROVED read, or its publish): the slot
+                    # inheritance below still lands and the heal is deferred (_views_heal_pending), retried on
+                    # the next pass. Never a raise out of _ordered -- it runs inside every build (the push,
+                    # GET /feed.json, the WS clearAll arm) -- and never a fold: the heal read the display
+                    # reader before this change, which folded the fault to an empty store, so the heal
+                    # carried nothing and said nothing. Said once per fork, like the order publish below.
+                    if sid not in _views_heal_pending:
+                        sys.stderr.write("romp-kernel: views heal for %s skipped (%s) \u2014 deferred; the next pass "
+                                         "retries it (lost if the kernel restarts first)\n" % (sid, e))
+                    _views_heal_pending[sid] = order[sib[-1]]
                 order.insert(sib[-1] + 1, sid)           # a fork inherits its session's slot, not the END
                 name_at.insert(sib[-1] + 1, a)           # keep name_at aligned with order as we splice
             else:
@@ -3752,28 +3790,57 @@ def _views_lost_notice(note, members):
 
 
 def _timeline_views():
+    """The DISPLAY read of the views store, cached under the file's (mtime_ns, size) key. Never raises
+    into a build (build_feed / build_timeline / build_session run under _push's one outer try, so a
+    reader that raised would abort every client's push): a MISSING store is legitimately empty; a
+    store that EXISTS but cannot be read (a stat or read fault: EIO, EACCES) serves the last blob this
+    kernel served or wrote when the cache holds one, else the empty default -- UNPROVED either way,
+    NEVER CACHED, and loud once per episode (_note_state_fault). Until this change a fault was folded
+    to an empty store and CACHED under the file's real key, so after one EIO the store read as {} on
+    every call until the file's stat moved, and every read-modify-write door (which read here) then
+    persisted that emptiness plus its one edit over the user's whole tag set under an ok:true ack --
+    while every dashboard adopted the seq-less {} and its tag bar emptied with nothing said. Torn or
+    non-JSON bytes, or JSON of the wrong shape, are QUARANTINED aside by _read_state_json (a move,
+    never a delete; its own stderr line and dashboard notice) and the store then reads as empty: that
+    is the disk's state after a stated event, not a fold, and the cache entry is forgotten with it as
+    for a store read as missing. Writers never read here: they read _timeline_views_proved, which
+    raises, and refuse."""
     p = _views_path()
+    hit = _flags_cache.get(str(p))
     try:
         st = p.stat(); key = (st.st_mtime_ns, st.st_size)
-    except OSError:
+    except FileNotFoundError:
         # No store: nothing served before it describes this one. The cache entry is the last blob
         # this kernel served or wrote, and a file written outside the kernel after a delete or a
         # restore is judged against it (_views_restamp's third case) — forgetting it here is what
         # keeps a recreated store from being judged against a store that no longer exists. The seq
         # floor is kept (_VIEWS_SEQ_FLOOR): a recreated file is still ORDERED past what was served.
         _flags_cache.pop(str(p), None)
+        _clear_state_fault(p)
         return _norm_timeline_views({})
-    hit = _flags_cache.get(str(p))
+    except OSError as e:
+        # The store EXISTS but cannot be stat'ed (a state dir that cannot be searched): the last blob
+        # served, else the empty default -- unproved, uncached, the entry KEPT (the store is not gone);
+        # loud once per episode. Until this change this was the missing-store arm, so an EACCES forgot
+        # the entry and served {}.
+        _note_state_fault(_StateUnreadable(p, "stat failed: %s" % _errno_text(e)))
+        return hit[1] if hit is not None else _norm_timeline_views({})
     if hit is not None and hit[0] == key:
+        _clear_state_fault(p)
         return hit[1]
     try:
-        d = json.loads(p.read_text())
-        parsed = isinstance(d, dict)
-    except Exception:
-        d, parsed = {}, False
-    if not parsed:
-        d = {}
-    fix = _views_restamp(d, hit) if parsed else None
+        d = _read_state_json(p, st, expect=dict)
+    except _StateUnreadable as e:
+        _note_state_fault(e)
+        return hit[1] if hit is not None else _norm_timeline_views({})
+    _clear_state_fault(p)
+    if d is None:
+        # gone between the stat and the read, or quarantined aside just now: the store IS empty from
+        # here, and the entry is forgotten as for a missing store (a file that then appears is not
+        # judged against one that no longer exists)
+        _flags_cache.pop(str(p), None)
+        return _norm_timeline_views({})
+    fix = _views_restamp(d, hit)
     if fix is not None:
         # The file goes back through the write door BEFORE it is served (the cases in
         # _views_restamp), as ONE write: the setter is handed its diff base explicitly, because
@@ -3797,7 +3864,7 @@ def _timeline_views():
             try:
                 st2 = p.stat()
             except OSError:
-                return _norm_timeline_views({})
+                return _timeline_views()      # gone, or faulting, under the lock: the arms above say which
             if (st2.st_mtime_ns, st2.st_size) != key:
                 return _timeline_views()
             hit2 = _flags_cache.get(str(p))
@@ -3859,14 +3926,15 @@ def _timeline_views():
                                                              if m) or "no members")
                                     for g in raw)
             try:
-                _write_timeline_views(judged)
+                _write_timeline_views(judged, note=False)   # housekeeping: a failure is the log line below,
+                #                                              never a notice (the first GESTURE that fails is)
                 sys.stderr.write("romp-kernel: views store re-stamped on read: %s\n" % why)
                 if lost:
                     # the drop is permanent once the stamp is written
                     _views_lost_notice(_notice_list(
                         "%s %d tag%s dropped when it was re-stamped on read (%s)"
                         % (fact, len(lost), " was" if len(lost) == 1 else "s were", why), ": ", names), members)
-            except OSError as e:
+            except (_StateUnwritable, OSError) as e:
                 # The state dir is unwritable or full: a READ must still answer (every frame builds
                 # on it), so a blob is served and cached under the file's key — the next read is a
                 # hit, not another failing write — and the failure is logged once per distinct
@@ -3880,15 +3948,18 @@ def _timeline_views():
                 # past the floor that the file does not, which is the point: dashboards adopt it,
                 # and the next write that lands (a RMW built from this cache) persists it.
                 # the key is the error's kind, not its text: the atomic write's temp name differs
-                # per call, so the text would read as a new error every time
-                kind = "%s errno=%s" % (type(e).__name__, getattr(e, "errno", None))
+                # per call, so the text would read as a new error every time. The door raises
+                # _StateUnwritable around the publish's OSError now; the OSError underneath is what
+                # the kind and the line name, as before
+                oe = e.__cause__ if isinstance(e, _StateUnwritable) and isinstance(e.__cause__, OSError) else e
+                kind = "%s errno=%s" % (type(oe).__name__, getattr(oe, "errno", None))
                 if _VIEWS_RESTAMP_ERR[0] != kind:
                     _VIEWS_RESTAMP_ERR[0] = kind
                     sys.stderr.write("romp-kernel: views store could not be re-stamped on read (%s) — "
                                      "serving %s: %s: %s\n"
                                      % (why, "the judged blob, unwritten" if judge
                                         else "the file as read, under the cap, unstamped",
-                                        type(e).__name__, e))
+                                        type(oe).__name__, oe))
                 if lost:
                     # The file still holds the excess and the served blob does not, and the next
                     # write that lands (a RMW built from this cache) persists the served blob: the
@@ -3908,6 +3979,67 @@ def _timeline_views():
     d = _norm_timeline_views(d)
     _views_cache_put(p, key, d)
     return d
+
+
+def _timeline_views_proved():
+    """The MUTATION snapshot of the views store: a read fault RAISES (_StateUnreadable) instead of
+    folding to an empty store, so a read-modify-write writer (_edit_tag, _move_tag_member,
+    _heal_timeline_views, _inherit_tag_membership, and the judge's diff base) refuses rather than
+    publishing the emptiness back over the user's whole tag set, lenses and order under a success
+    ack. Only a missing store, or one just quarantined aside (_read_state_json moves torn bytes aside
+    BEFORE the store reads as empty), reads as empty; no last-known-good -- a writer acts on the real
+    store or not at all. Always a FRESH dict the caller may mutate.
+    The snapshot is what this kernel SERVES for the file state the read just proved: the display
+    cache's entry when its key is the file's current (mtime_ns, size) -- the file's own content, or
+    the JUDGED blob the reader served over an unwritable store, whose next write is meant to persist
+    it (the 2026-09-05 review) -- which is exactly what every RMW writer built on when it read the
+    display reader, now proved by a read rather than assumed from a key. Otherwise the file, with
+    what the reader's re-stamp would do to it replayed and not persisted -- the SAME snapshot the
+    display reader would serve for that file (_views_restamp, handed the same cache entry):
+    - the unjudged cases (the hidden->archived migration, the legacy per-tag mtimes) change the
+      CONTENT: the normalizer DROPS `hidden`, so a snapshot that skipped the migration would hand a
+      writer a blob without the legacy entries, and its write -- before the display reader's first
+      read after boot -- would lose every one of them;
+    - the JUDGED case -- a file written OUTSIDE the kernel (the timeline's Electron and Obsidian
+      branches write timeline-views.json themselves) whose seq fell behind the last served blob -- is
+      judged here against that blob exactly as the display reader judges it (the stale-writer guard,
+      `foreign`): a deleted tag the foreign copy still carries is not re-created, a member or a tag
+      added since is not lost, its refusals said by the judge. Replayed raw instead, in the window
+      before the pusher's next display read, every RMW door diffed its one edit against the foreign
+      copy (no refusal anywhere) and the judge stamped the result past everything served -- the stale
+      copy blessed on every dashboard (review find, 2026-09-08).
+    The writer's own write persists what the replay produced (the migrated tag, the judgment) through
+    the judge; a RMW that writes nothing leaves the file for the display reader's own re-stamp, whose
+    judge says the refusals once more. So the refusals can be said more than once for one outside
+    write: once per gesture that reads and then writes nothing while the stale copy stands, and once
+    more if the pusher's re-stamp lands between a gesture's read and its write -- notices only; the
+    content converges either way, and the persisted seq still orders past everything served."""
+    p = _views_path()
+    hit = _flags_cache.get(str(p))
+    try:
+        st = p.stat()
+    except FileNotFoundError:
+        return _norm_timeline_views({})
+    except OSError as e:
+        raise _StateUnreadable(p, "stat failed: %s" % _errno_text(e))
+    d = _read_state_json(p, st, expect=dict)
+    if d is None:
+        return _norm_timeline_views({})
+    if hit is not None and hit[0] == (st.st_mtime_ns, st.st_size):
+        return json.loads(json.dumps(hit[1]))
+    fix = _views_restamp(d, hit)
+    if fix is None:
+        return _norm_timeline_views(d)
+    why, d2, judge = fix
+    if not judge:
+        return _norm_timeline_views(d2)
+    try:
+        floor = int(hit[1].get("seq") or 0)
+    except (TypeError, ValueError):
+        floor = 0
+    judged, _rows = _judge_timeline_views(d2, base=hit[1], seq_floor=max(floor, _views_seq_floor(p)),
+                                          foreign="a stale write to the views file from outside the kernel")
+    return _norm_timeline_views(json.loads(json.dumps(judged)))
 
 
 def _views_stamp_legacy_tags(tags, d):
@@ -3963,6 +4095,8 @@ def _views_restamp(d, hit):
       file restored from an older copy would be served under its old seq and ignored by every
       dashboard holding a higher one. The seq floor outlives the entry (_VIEWS_SEQ_FLOOR), and the
       file is re-stamped past it, as written — ordered, not judged.
+    The proved reader (_timeline_views_proved) replays the unjudged cases on its snapshot without
+    persisting them, so a writer's blob carries what the file's re-stamp would have.
     Returns (why, dict-to-write, judge). The dict is a COPY: `d` is also the diff base the migration
     is stamped against, and mutating its tag dicts in place (an earlier aliasing bug) left the
     base already migrated — an existing "archived" tag gained its members with no fresh mtime, and
@@ -4025,19 +4159,29 @@ def _set_timeline_views(blob, base=None, seq_floor=0, edited=None, foreign=None)
     was written over by a blob judged against the pre-re-stamp store — the foreign write's lens
     change and its creates gone, under a seq no higher than the re-stamp's (both computed from the
     same base), with no refusal filed. The lock is re-entrant, and every caller holding _views_lock
-    takes it first, so the documented order stands."""
+    takes it first, so the documented order stands.
+    `base`: the store as the caller read it PROVED (_timeline_views_proved) -- every read-modify-write
+    door hands its own snapshot over, so the judge diffs against the very blob the caller edited and no
+    second read opens a fault window between the read and the write; with none (the WS whole-blob
+    door), the judge reads the store proved itself. A read fault RAISES _StateUnreadable and a failed
+    publish _StateUnwritable to the caller, which refuses the gesture; nothing is written either way."""
     with _views_file_lock:
         v, rows = _judge_timeline_views(blob, base=base, seq_floor=seq_floor, edited=edited, foreign=foreign)
         _write_timeline_views(v)
     return rows
 
 
-def _write_timeline_views(v):
+def _write_timeline_views(v, note=True):
     """Write a judged, stamped blob (from _judge_timeline_views) to the store and refresh the read
-    cache with it. Raises the OSError of an unwritable or full state dir to the caller."""
+    cache with it. Publishes through _write_state_json, the state files' one write door: an unwritable
+    or full state dir (ENOSPC, EROFS, EACCES) raises _StateUnwritable -- a plain Exception, filed once
+    per episode -- never the OSError, which do_POST answered as a 500 traceback (`romp tag` posts with
+    `curl -sf` and read that as an unreachable kernel) and the WS receive loop re-raises as a socket
+    failure should an arm let it through. `note=False` is the reader's re-stamp: housekeeping whose
+    failure is its own log line, not a notice."""
     text = json.dumps(v, sort_keys=True)
     with _views_file_lock:
-        _atomic_write(_views_path(), text)
+        _write_state_json(_views_path(), text, note=note)
         _views_cache_refresh(text)
     _VIEWS_RESTAMP_ERR[0] = None      # the store is writable again: a later failure logs afresh
 
@@ -4089,10 +4233,11 @@ def _judge_timeline_views(blob, base=None, seq_floor=0, edited=None, foreign=Non
     unread = _views_unread(blob, v["tags"])
     ed = set(x for x in edited if isinstance(x, str)) if isinstance(edited, list) else None
     if base is None:
-        try:
-            base = _timeline_views()
-        except Exception:
-            base = {}
+        # the PROVED store, never the display reader and never a fold: the guard's "previous truth"
+        # computed from a reader that folded a fault to {} refused nothing, and the write then landed
+        # the blob's tags -- or, on a lens write's empty `edited`, NO tags -- over the user's whole set
+        # under an ok:true ack. A fault here RAISES to the door, which refuses the write.
+        base = _timeline_views_proved()
     prev_blob = base
     prev = {t["id"]: t for t in (prev_blob.get("tags") or [])}
     now = int(time.time())
@@ -4727,14 +4872,19 @@ def _heal_timeline_views(old_sid, new_sid):
     """fsid churn (a /clear, relaunch or revive mints a new transcript fsid for the same logical
     session): carry the old sid's tag memberships to the new one, exactly like the order-slot
     inheritance that detects the churn. Without this a tagged session would silently fall out of
-    its tag on every /clear. (The hidden half retired with the set, 2026-08-24.)"""
+    its tag on every /clear. (The hidden half retired with the set, 2026-08-24.)
+    Reads the store PROVED, once: a fault RAISES (_StateUnreadable; a failed publish, _StateUnwritable)
+    to _ordered's boundary, which defers the heal and retries it, rather than carrying memberships off
+    a fabricated empty store; the snapshot is handed to the setter as its diff base, so no second read
+    opens a fault window inside a build. Returns True when memberships were carried, False when the old
+    sid held no tag (so _ordered's retry of a deferred heal can say which it was)."""
     def _has(t):
         return any(m["host"] == "" and m["sid"] == old_sid for m in t["members"])
     with _views_lock:   # RMW like _edit_tag: a write landing inside the read-to-write window is lost
-        v = _timeline_views()
-        if not any(_has(t) for t in v["tags"]):
-            return
-        v = json.loads(json.dumps(v))                    # deep copy: never mutate the cached blob
+        v0 = _timeline_views_proved()
+        if not any(_has(t) for t in v0["tags"]):
+            return False
+        v = json.loads(json.dumps(v0))                   # the working copy; v0 stays the pristine base
         # COPY, never move: stripping the old sid un-hid its DEAD lane, which lingers on the timeline for
         # hours — and when the old sid is still alive (a fork beside a living parent, or an unrelated new
         # session reusing a name), moving would steal the living session's state. A dead sid left in the
@@ -4742,7 +4892,8 @@ def _heal_timeline_views(old_sid, new_sid):
         for t in v["tags"]:
             if _has(t):
                 t["members"] = t["members"] + [{"host": "", "sid": new_sid}]   # normalizer dedups + re-sorts
-        _set_timeline_views(v)
+        _set_timeline_views(v, base=v0)
+    return True
 
 
 def _inherit_tag_membership(parent_sid, child_sid):
@@ -4754,22 +4905,26 @@ def _inherit_tag_membership(parent_sid, child_sid):
     where the parent is known instead of being detected later. COPY, never move — the parent keeps
     its tags. No-op when the parent holds none; idempotent (the normalizer dedups pairs). Local tags
     only in v1: a parent held only by a REMOTE-homed tag is not inherited here (its home kernel
-    would have to be asked — the accepted gap). Returns the inherited tag names."""
+    would have to be asked — the accepted gap). Returns the inherited tag names.
+    Reads the store PROVED: a fault RAISES (_StateUnreadable; a failed publish, _StateUnwritable) to
+    the caller -- the creation ack folds it into `tagError` (_tag_ack), the fork and thread-promotion
+    sites say what did not happen (_note_tags_not_inherited) -- rather than reading an empty parent
+    off a fabricated store and returning [] as if the parent held no tag."""
     parent_sid, child_sid = str(parent_sid or ""), str(child_sid or "")
     if not parent_sid or not child_sid or parent_sid == child_sid:
         return []
     with _views_lock:   # RMW like _edit_tag: two unlocked copies would both write the same pre-state
-        v = _timeline_views()
+        v0 = _timeline_views_proved()
         def _has(t):
             return any(m["host"] == "" and m["sid"] == parent_sid for m in t["members"])
-        names = [t["name"] for t in v["tags"] if _has(t)]
+        names = [t["name"] for t in v0["tags"] if _has(t)]
         if not names:
             return []
-        v = json.loads(json.dumps(v))                # deep copy: never mutate the cached blob
+        v = json.loads(json.dumps(v0))               # the working copy; v0 stays the pristine base
         for t in v["tags"]:
             if _has(t):
                 t["members"] = t["members"] + [{"host": "", "sid": child_sid}]
-        _set_timeline_views(v)
+        _set_timeline_views(v, base=v0)
     _mark_views_dirty()
     return names
 
@@ -4786,6 +4941,32 @@ def _b36(n):
 
 
 _TAG_GONE = "that tag no longer exists — it may have been deleted from another dashboard"
+
+
+def _views_fault_refusal(e):
+    """The refusal a gesture on the views store gets when the STORE itself faulted (_StateUnreadable /
+    _StateUnwritable out of a proved read or a publish) -- the tags dialog's tagEditAck, a lens write's
+    viewsAck, POST /tag's reply, the creation ack's `tagError`: the person's words, the fault's errno and
+    strerror, and what stands -- nothing changed, since a read that fails edits nothing and a publish
+    that fails never reached its replace. No file name: the once-per-episode notice names the file."""
+    return "the tag store could not be %s (%s); nothing was changed \u2014 retry" % (
+        "written" if isinstance(e, _StateUnwritable) else "read", e.fault)
+
+
+def _note_tags_not_inherited(parent_sid, child_name, e):
+    """A spawn (a fork, a promoted thread) whose parent's tag memberships could not be copied because the
+    views store faulted (_inherit_tag_membership raised): the session already exists, so the spawn stands
+    and what did NOT happen is said -- one stderr line, and one dashboard notice under the bell's `refused`
+    kind naming the child, since the store's own once-per-episode notice cannot say which session landed
+    outside its group. Tagging it again once the store reads puts it there."""
+    text = ('"%s" did not inherit the tags of "%s": the tag store could not be %s (%s) \u2014 tag it again once it can be'
+            % (child_name, _name_of(parent_sid) or parent_sid,
+               "written" if isinstance(e, _StateUnwritable) else "read", e.fault))
+    sys.stderr.write("romp-kernel: %s\n" % text)
+    try:
+        _sync_notice(text, ok=False, kind="refused")
+    except Exception:
+        pass
 
 
 def _default_tag_name(tags):
@@ -4824,7 +5005,12 @@ def _edit_tag(name=None, add=(), remove=(), color=None, delete=False, rename=Non
     # subsequent edit. A name that is empty after the strip is no name: a create takes the default.
     name = (str(name)[:_VIEWS_MAX_NAME].strip() or None) if name is not None else None
     with _views_lock:   # the server is threaded; two unlocked merges would both copy the same pre-state
-        v = json.loads(json.dumps(_timeline_views()))     # deep copy: never mutate the cached blob
+        v0 = _timeline_views_proved()   # PROVED: a read fault RAISES (_StateUnreadable; a failed publish
+        #                                below, _StateUnwritable) to the door, which refuses -- never an
+        #                                edit applied to a fabricated empty store and published over the
+        #                                user's real tags (a create landed a one-tag store; an edit by tid
+        #                                was refused as a deleted tag). v0 is the setter's diff base too.
+        v = json.loads(json.dumps(v0))                    # the working copy; v0 stays the pristine base
         if tid is not None:
             hits = [t for t in v["tags"] if t["id"] == tid]
             if not hits:
@@ -4841,7 +5027,7 @@ def _edit_tag(name=None, add=(), remove=(), color=None, delete=False, rename=Non
             if not hits:
                 return None, 'no tag named "%s"' % name
             v["tags"] = [t for t in v["tags"] if t["id"] != hits[0]["id"]]
-            _set_timeline_views(v)      # an active pointing at it falls back to "all" (the All view) in the normalizer
+            _set_timeline_views(v, base=v0)   # an active pointing at it falls back to "all" (the All view) in the normalizer
             return None, None
         if hits:
             t = hits[0]
@@ -4870,7 +5056,7 @@ def _edit_tag(name=None, add=(), remove=(), color=None, delete=False, rename=Non
         if color is not None:
             t["color"] = color
         v = _norm_timeline_views(v)
-        _set_timeline_views(v)
+        _set_timeline_views(v, base=v0)
         out = json.loads(json.dumps(next(t2 for t2 in v["tags"] if t2["id"] == t["id"])))
         out["members"] = [_member_str(m) for m in out["members"]]   # the route's reply speaks strings
         return out, None
@@ -4884,7 +5070,8 @@ def _move_tag_member(tid_from, tid_to, sids):
     viewer-relative id strings every client posts (_member_pair canonicalizes). Returns
     (tag-or-None, error-or-None) like _edit_tag; the tag is the destination's post-write row."""
     with _views_lock:
-        v = json.loads(json.dumps(_timeline_views()))     # deep copy: never mutate the cached blob
+        v0 = _timeline_views_proved()                     # PROVED, like _edit_tag: a fault raises to the door
+        v = json.loads(json.dumps(v0))                    # the working copy; v0 stays the pristine base
         by_id = {t["id"]: t for t in v["tags"]}
         src, dst = by_id.get(tid_from), by_id.get(tid_to)
         if src is None:
@@ -4897,7 +5084,7 @@ def _move_tag_member(tid_from, tid_to, sids):
         have = {(m["host"], m["sid"]) for m in dst["members"]}
         dst["members"] = list(dst["members"]) + [m for m in pairs if (m["host"], m["sid"]) not in have]
         v = _norm_timeline_views(v)
-        _set_timeline_views(v)
+        _set_timeline_views(v, base=v0)
         out = json.loads(json.dumps(next(t for t in v["tags"] if t["id"] == tid_to)))
         out["members"] = [_member_str(m) for m in out["members"]]
         return out, None
@@ -5115,15 +5302,30 @@ def _tag_ack(sid, parent_sid="", tags=()):
                       matches by position and says "applied as <name>" instead
       tagError      — the first refused tag edit's reason, when any
     The session exists by the time a tag edit can refuse (a same-named twin, the tag cap), so the
-    refusal rides beside the ack rather than undoing the spawn; the caller surfaces it."""
+    refusal rides beside the ack rather than undoing the spawn; the caller surfaces it. A views STORE
+    fault (the proved read raised; the publish failed) is a refusal of the same standing: nothing was
+    inherited or joined, every requested tag reads as not applied, and `tagError` carries the fault in
+    the person's words (_views_fault_refusal) -- before this change the inherit read an empty parent
+    off a fabricated store and the join created the tag anew, erasing the rest, under a clean ack."""
     sid = str(sid)
     tags = [str(t) for t in (tags or ())]
     err = None
     applied = []
     if parent_sid:
-        _inherit_tag_membership(parent_sid, sid)
+        try:
+            _inherit_tag_membership(parent_sid, sid)
+        except (_StateUnreadable, _StateUnwritable) as e:
+            sys.stderr.write("romp-kernel: %s did not inherit the tags of %s: %s\n" % (sid, parent_sid, e))
+            err = _views_fault_refusal(e)
     for name in tags:
-        row, e = _edit_tag(name.strip(), add=[sid])
+        try:
+            row, e = _edit_tag(name.strip(), add=[sid])
+        except (_StateUnreadable, _StateUnwritable) as ex:
+            # the same store for every name left: none joined, said once, positionally
+            sys.stderr.write("romp-kernel: %s joined no tag: %s\n" % (sid, ex))
+            applied.extend([None] * (len(tags) - len(applied)))
+            err = err or _views_fault_refusal(ex)
+            break
         applied.append(row["name"] if row else None)
         if e and not err:
             err = e
@@ -11907,7 +12109,10 @@ def _fork_session_inner(parent_sid, cut_msg_uuid, new_name, now=None, client=Non
     # the fork inherits the parent's TAGS too (tab groups on tags, the user 2026-09-04) — the same
     # "that conversation, continued elsewhere" contract be.fork applies to mode/effort/model/env —
     # before the direct push below, so the first frame already sections the new tab under its group
-    _inherit_tag_membership(parent_sid, sid)
+    try:
+        _inherit_tag_membership(parent_sid, sid)
+    except (_StateUnreadable, _StateUnwritable) as e:
+        _note_tags_not_inherited(parent_sid, nm, e)   # the fork stands; its group membership did not follow
     be.connect(sid)          # eager-connect: the CLI copies the conversation and the tab fills in
     if client is not None:   # the asker's window follows its fork; nobody else's chat moves
         _reveal_chat_for(client, {"type": "focus", "id": sid})
@@ -13167,7 +13372,10 @@ def _comment_promote_inner(parent_sid, tid, new_name, now=None, client=None):
     # the thread becomes a TAB now, so it inherits the parent's tags here (tab groups on tags, the
     # user 2026-09-04) — never at _comment_create, where it has no tab and a tagged hidden sid would
     # only inflate the member lists
-    _inherit_tag_membership(parent_sid, tsid)
+    try:
+        _inherit_tag_membership(parent_sid, tsid)
+    except (_StateUnreadable, _StateUnwritable) as e:
+        _note_tags_not_inherited(parent_sid, nm, e)   # the promotion stands; its group membership did not follow
     started = be.connect(tsid)
     if client is not None:   # the promoter's window follows the new session; nobody else's chat moves
         _reveal_chat_for(client, {"type": "focus", "id": tsid})
@@ -45029,10 +45237,22 @@ class Handler(BaseHTTPRequestHandler):
                         ", ".join('"%s"' % x for x in unknown)}), "application/json")
                 color = b.get("color")
                 rn = b.get("rename")
-                t, err = _edit_tag(name, add=ids["add"], remove=ids["remove"],
-                                   color=(str(color) if isinstance(color, str) else None),
-                                   delete=dele,
-                                   rename=(str(rn) if isinstance(rn, str) else None))
+                try:
+                    t, err = _edit_tag(name, add=ids["add"], remove=ids["remove"],
+                                       color=(str(color) if isinstance(color, str) else None),
+                                       delete=dele,
+                                       rename=(str(rn) if isinstance(rn, str) else None))
+                except (_StateUnreadable, _StateUnwritable) as e:
+                    # the views store could not be read, or its publish failed: the route's OWN refusal
+                    # shape -- 200, ok:false, retryable -- never a 5xx. `romp tag` posts with `curl -sf`,
+                    # which turns any 5xx into "kernel not reachable" (the wrong reason; until this change
+                    # a full disk drew exactly that, the OSError reaching do_POST's catch-all as a 500
+                    # traceback), and a federation forward treats every non-200 as a tunnel hiccup; both
+                    # read this body as the refusal it is. Nothing was written: a read that fails edits
+                    # nothing, a publish that fails never reached its replace.
+                    sys.stderr.write("romp-kernel: POST /tag refused: %s\n" % e)
+                    return self._send(200, json.dumps({"ok": False, "retryable": True,
+                                                       "error": _views_fault_refusal(e)}), "application/json")
                 if err:
                     return self._send(200, json.dumps({"ok": False, "error": err}), "application/json")
                 _mark_views_dirty()
@@ -45639,6 +45859,13 @@ class Handler(BaseHTTPRequestHandler):
                 else:
                     ok = not refused
                 err = None
+            except (_StateUnreadable, _StateUnwritable) as e:
+                # the views store could not be read (the judge's PROVED base raised -- until this change it
+                # folded the fault to {} and a lens write's empty `edited` then wrote `tags: []` over the
+                # user's whole set, acked ok) or its publish failed: refused on the poster's socket in the
+                # person's words, no traceback; the store is as it was
+                sys.stderr.write("romp-kernel: setTimelineViews refused: %s\n" % e)
+                refused, ok, err = [], False, _views_fault_refusal(e)
             except Exception as e:
                 sys.stderr.write("setTimelineViews: %s\n" % traceback.format_exc())
                 refused, ok, err = [], False, "the write failed on the kernel: %s" % (str(e) or type(e).__name__)
@@ -45657,6 +45884,12 @@ class Handler(BaseHTTPRequestHandler):
             # the recv loop's log: an unanswered write would pin the poster's optimistic copy.
             try:
                 ok, err, info = _apply_tag_edit(msg.get("edit"))
+            except (_StateUnreadable, _StateUnwritable) as e:
+                # the store faulted under the edit (a create until this change landed a one-tag store over
+                # the user's whole set, acked ok; an edit by tid was refused as a deleted tag): the fault,
+                # in the person's words, on the poster's socket; nothing was written
+                sys.stderr.write("romp-kernel: tagEdit refused: %s\n" % e)
+                ok, err, info = False, _views_fault_refusal(e), None
             except Exception as e:
                 sys.stderr.write("tagEdit: %s\n" % traceback.format_exc())
                 ok, err, info = False, "the edit failed on the kernel: %s" % (str(e) or type(e).__name__), None

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2887,9 +2887,10 @@ def _tab_order_frame(order, tabs, live):
     sessions of its own — every session attached from elsewhere — never learned it until the + picker was
     opened, and a remote card stamped with this kernel's name stayed plain text (review find, 2026-09-06).
     Every chat client receives a tabOrder frame, first of all on connect (tabs-first), so the name is known
-    before any card renders. Older clients ignore the extra fields."""
+    before any card renders. Older clients ignore the extra fields. Under a views read fault the blob is the last
+    one served, marked `viewsFault`, or absent with the marker alone (_views_payload)."""
     return {"type": "tabOrder", "order": list(order), "tabs": tabs, "selfHost": _self_host(),
-            "views": _views_client(), "live": sorted({str(x) for x in live})}
+            **_views_payload(), "live": sorted({str(x) for x in live})}
 
 
 def _alive_sessions(now, tmux):
@@ -3003,6 +3004,13 @@ _STATE_REPLACED = "replaced meanwhile; the new bytes get their own read"   # _st
 #                                        file is no longer the one whose bytes failed: the reader re-reads (bounded)
 
 
+# What a state file holds, for the quarantine notice: a quarantine resets the file to EMPTY, and the
+# notice says what starts over in the person's words. The views store holds the user's tags and lenses,
+# which are not settings (review find, 2026-09-08: its notice called them that); the flags, order and
+# bell stores are settings, the default.
+_STATE_FILE_HOLDS = {"timeline-views.json": "the tags and lenses"}
+
+
 def _state_quarantine(p, st, reason):
     """Move an unparseable state file ASIDE (never delete it) so the evidence survives the fresh
     start that follows: the sidecar keeps the original name plus `.corrupt-<utc stamp>` (a `-n`
@@ -3038,8 +3046,9 @@ def _state_quarantine(p, st, reason):
     # speaks exactly once. Guarded like _note_state_fault: a notice never turns a successful move
     # into a raise.
     try:
-        _sync_notice("%s could not be parsed and was moved aside to %s; the settings it held start over "
-                     "empty until you set them again" % (p.name, aside.name), ok=False, kind="refused")
+        _sync_notice("%s could not be parsed and was moved aside to %s; %s it held start over "
+                     "empty until you set them again"
+                     % (p.name, aside.name, _STATE_FILE_HOLDS.get(p.name, "the settings")), ok=False, kind="refused")
     except Exception:
         pass
     return None
@@ -3478,10 +3487,13 @@ def _ordered(sessions):
                     # the next pass. Never a raise out of _ordered -- it runs inside every build (the push,
                     # GET /feed.json, the WS clearAll arm) -- and never a fold: the heal read the display
                     # reader before this change, which folded the fault to an empty store, so the heal
-                    # carried nothing and said nothing. Said once per fork, like the order publish below.
+                    # carried nothing and said nothing. Said once per fork, like the order publish below:
+                    # the stderr line, and the bell row the fork and promotion sites file for the same
+                    # non-event (_note_views_heal_deferred; review find, 2026-09-08).
                     if sid not in _views_heal_pending:
                         sys.stderr.write("romp-kernel: views heal for %s skipped (%s) \u2014 deferred; the next pass "
                                          "retries it (lost if the kernel restarts first)\n" % (sid, e))
+                        _note_views_heal_deferred(a or sid, e)
                     _views_heal_pending[sid] = order[sib[-1]]
                 order.insert(sib[-1] + 1, sid)           # a fork inherits its session's slot, not the END
                 name_at.insert(sib[-1] + 1, a)           # keep name_at aligned with order as we splice
@@ -3790,12 +3802,28 @@ def _views_lost_notice(note, members):
 
 
 def _timeline_views():
-    """The DISPLAY read of the views store, cached under the file's (mtime_ns, size) key. Never raises
-    into a build (build_feed / build_timeline / build_session run under _push's one outer try, so a
-    reader that raised would abort every client's push): a MISSING store is legitimately empty; a
-    store that EXISTS but cannot be read (a stat or read fault: EIO, EACCES) serves the last blob this
-    kernel served or wrote when the cache holds one, else the empty default -- UNPROVED either way,
-    NEVER CACHED, and loud once per episode (_note_state_fault). Until this change a fault was folded
+    """The DISPLAY read of the views store as a blob every display caller can filter on: what
+    _timeline_views_display serves, with the empty default standing in when a fault left it nothing to
+    serve (a cold cache: a kernel that has never served the store). The display callers -- view
+    visibility, the tab sections, the union -- read here; a FRAME or an ACK reads _views_payload, which
+    carries the fault instead of that default (review find, 2026-09-08). Writers never read here: they
+    read _timeline_views_proved, which raises, and refuse."""
+    v, _fault = _timeline_views_display()
+    return v if v is not None else _norm_timeline_views({})
+
+
+def _timeline_views_display():
+    """The DISPLAY read of the views store, cached under the file's (mtime_ns, size) key, as (blob,
+    fault). Never raises into a build (build_feed / build_timeline / build_session run under _push's one
+    outer try, so a reader that raised would abort every client's push): a MISSING store is legitimately
+    empty; a store that EXISTS but cannot be read (a stat or read fault: EIO, EACCES) serves the last
+    blob this kernel served or wrote when the cache holds one, else None -- UNPROVED either way, NEVER
+    CACHED, loud once per episode (_note_state_fault), and NAMED: `fault` is the _StateUnreadable the
+    blob is served under, None after a read that proved the file state it served (a cache hit at the
+    file's key, a clean read, a missing store). The empty default is not served here (review find,
+    2026-09-08): carried on a frame it is a seq-less empty store that every dashboard adopts as the
+    store's word; _timeline_views stands it in for the filtering callers, and _views_payload carries the
+    fault instead. Until this change a fault was folded
     to an empty store and CACHED under the file's real key, so after one EIO the store read as {} on
     every call until the file's stat moved, and every read-modify-write door (which read here) then
     persisted that emptiness plus its one edit over the user's whole tag set under an ok:true ack --
@@ -3817,29 +3845,30 @@ def _timeline_views():
         # floor is kept (_VIEWS_SEQ_FLOOR): a recreated file is still ORDERED past what was served.
         _flags_cache.pop(str(p), None)
         _clear_state_fault(p)
-        return _norm_timeline_views({})
+        return _norm_timeline_views({}), None
     except OSError as e:
         # The store EXISTS but cannot be stat'ed (a state dir that cannot be searched): the last blob
-        # served, else the empty default -- unproved, uncached, the entry KEPT (the store is not gone);
-        # loud once per episode. Until this change this was the missing-store arm, so an EACCES forgot
-        # the entry and served {}.
-        _note_state_fault(_StateUnreadable(p, "stat failed: %s" % _errno_text(e)))
-        return hit[1] if hit is not None else _norm_timeline_views({})
+        # served, else nothing -- unproved, uncached, the entry KEPT (the store is not gone); loud once
+        # per episode, and the fault returned beside the blob. Until this change this was the
+        # missing-store arm, so an EACCES forgot the entry and served {}.
+        exc = _StateUnreadable(p, "stat failed: %s" % _errno_text(e))
+        _note_state_fault(exc)
+        return (hit[1] if hit is not None else None), exc
     if hit is not None and hit[0] == key:
         _clear_state_fault(p)
-        return hit[1]
+        return hit[1], None
     try:
         d = _read_state_json(p, st, expect=dict)
     except _StateUnreadable as e:
         _note_state_fault(e)
-        return hit[1] if hit is not None else _norm_timeline_views({})
+        return (hit[1] if hit is not None else None), e
     _clear_state_fault(p)
     if d is None:
         # gone between the stat and the read, or quarantined aside just now: the store IS empty from
         # here, and the entry is forgotten as for a missing store (a file that then appears is not
         # judged against one that no longer exists)
         _flags_cache.pop(str(p), None)
-        return _norm_timeline_views({})
+        return _norm_timeline_views({}), None
     fix = _views_restamp(d, hit)
     if fix is not None:
         # The file goes back through the write door BEFORE it is served (the cases in
@@ -3864,9 +3893,9 @@ def _timeline_views():
             try:
                 st2 = p.stat()
             except OSError:
-                return _timeline_views()      # gone, or faulting, under the lock: the arms above say which
+                return _timeline_views_display()      # gone, or faulting, under the lock: the arms above say which
             if (st2.st_mtime_ns, st2.st_size) != key:
-                return _timeline_views()
+                return _timeline_views_display()
             hit2 = _flags_cache.get(str(p))
             if hit2 is not None and hit2[0] == key:
                 # The same file state, served and cached by a reader that held the lock while this one
@@ -3876,7 +3905,7 @@ def _timeline_views():
                 # and two cold readers racing on a full disk each judged the file, each failed the
                 # write, and each filed the file-fact notice. The check the function opens with, run
                 # again under the lock; it serves nothing that check would not.
-                return hit2[1]
+                return hit2[1], None
             try:
                 floor = int(hit[1].get("seq") or 0) if hit is not None else 0
             except (TypeError, ValueError):
@@ -3974,11 +4003,11 @@ def _timeline_views():
                            "is" if len(lost) == 1 else "are"), ": ", names), members)
                 d = _norm_timeline_views(json.loads(json.dumps(judged)) if judge else d2)
                 _views_cache_put(p, key, d)
-                return d
-        return _timeline_views()          # the write refreshed the cache under the file's new key
+                return d, None
+        return _timeline_views_display()  # the write refreshed the cache under the file's new key
     d = _norm_timeline_views(d)
     _views_cache_put(p, key, d)
-    return d
+    return d, None
 
 
 def _timeline_views_proved():
@@ -4757,15 +4786,39 @@ def _row_op(row):
     return "delete" if row.get("delete") else ("rename" if row.get("rename") else "remove")
 
 
-def _views_client():
+def _views_payload():
+    """The views fields of a frame (the tabOrder frame, the feed, the timeline skeleton) and of a write's
+    ack (_ack_views_write), from ONE display read (_timeline_views_display): `views`, the rendered blob
+    (_views_client), and under a read fault `viewsFault`, the fault in the person's words
+    (_views_fault_text), which a pane can render as "tags unavailable: <reason>". With a last good blob
+    the frame carries it AND the marker: the blob is what this kernel last served or wrote, unproved by
+    this read and said so. With NONE (a cold cache: a kernel that has never served the store) the frame
+    carries no `views` at all -- every pane keeps what it holds on a frame without the blob (render.ts
+    captureViews, feed.ts, fleet.ts, the timeline's _takeViews) -- where the seq-less empty default it
+    carried until this change was adopted by every dashboard as the store's word: the tag bar emptied
+    with the fault said only on the bell, and the next lens click made it permanent (review find,
+    2026-09-08). A clean read adds no key, so a clean frame is byte-identical to before."""
+    v, fault = _timeline_views_display()
+    # a dict literal, not a subscript store of the views key: test_tag_federation_v2 counts that spelling across
+    # the module as a store of a REMOTE reading, which must go through _cache_remote_views; this is the local
+    # frame's own field
+    out = {"views": _views_client(v)} if v is not None else {}
+    if fault is not None:
+        out["viewsFault"] = _views_fault_text(fault)
+    return out
+
+
+def _views_client(v=None):
     """The views blob every client renders and matches against — the RENDERING of the canonical
     store (federation v0, the user 2026-08-24): local tags with members as viewer-relative strings
     (the pre-pairs contract, so no client re-learns anything), plus `remoteTags` — each ATTACHED
     kernel's own tags, read-only, host-stamped, members respelled for this viewer. Per-host maps
     joined at the viewer, never merged (the federation counter rule); same-name tags on two kernels
     stay two entries — the host disambiguates, nothing silently merges. Remote reads ride the
-    supervisor's cached /views poll; a kernel that is down simply contributes nothing this push."""
-    v = json.loads(json.dumps(_timeline_views()))
+    supervisor's cached /views poll; a kernel that is down simply contributes nothing this push.
+    `v`: the display blob to render, else the display read's own (_timeline_views); _views_payload hands
+    its read over, so a frame is built from ONE read and the fault it carries names that read."""
+    v = json.loads(json.dumps(_timeline_views() if v is None else v))
     for t in v["tags"]:
         t["members"] = [_member_str(m) for m in t["members"]]
     remote = []
@@ -4943,14 +4996,21 @@ def _b36(n):
 _TAG_GONE = "that tag no longer exists — it may have been deleted from another dashboard"
 
 
+def _views_fault_text(e):
+    """The views store's fault in the person's words: the store (never the file -- the once-per-episode
+    notice names it), the step that failed, and the errno and strerror. The head of every refusal
+    (_views_fault_refusal), the frame's marker of a blob it could not prove (_views_payload), and the
+    reason on the spawn sites' and the heal's bell rows."""
+    return "the tag store could not be %s (%s)" % ("written" if isinstance(e, _StateUnwritable) else "read", e.fault)
+
+
 def _views_fault_refusal(e):
     """The refusal a gesture on the views store gets when the STORE itself faulted (_StateUnreadable /
     _StateUnwritable out of a proved read or a publish) -- the tags dialog's tagEditAck, a lens write's
-    viewsAck, POST /tag's reply, the creation ack's `tagError`: the person's words, the fault's errno and
-    strerror, and what stands -- nothing changed, since a read that fails edits nothing and a publish
-    that fails never reached its replace. No file name: the once-per-episode notice names the file."""
-    return "the tag store could not be %s (%s); nothing was changed \u2014 retry" % (
-        "written" if isinstance(e, _StateUnwritable) else "read", e.fault)
+    viewsAck, POST /tag's reply, the creation ack's `tagError`: the fault (_views_fault_text) and what
+    stands -- nothing changed, since a read that fails edits nothing and a publish that fails never
+    reached its replace."""
+    return "%s; nothing was changed \u2014 retry" % _views_fault_text(e)
 
 
 def _note_tags_not_inherited(parent_sid, child_name, e):
@@ -4959,10 +5019,26 @@ def _note_tags_not_inherited(parent_sid, child_name, e):
     and what did NOT happen is said -- one stderr line, and one dashboard notice under the bell's `refused`
     kind naming the child, since the store's own once-per-episode notice cannot say which session landed
     outside its group. Tagging it again once the store reads puts it there."""
-    text = ('"%s" did not inherit the tags of "%s": the tag store could not be %s (%s) \u2014 tag it again once it can be'
-            % (child_name, _name_of(parent_sid) or parent_sid,
-               "written" if isinstance(e, _StateUnwritable) else "read", e.fault))
+    text = ('"%s" did not inherit the tags of "%s": %s \u2014 tag it again once it can be'
+            % (child_name, _name_of(parent_sid) or parent_sid, _views_fault_text(e)))
     sys.stderr.write("romp-kernel: %s\n" % text)
+    try:
+        _sync_notice(text, ok=False, kind="refused")
+    except Exception:
+        pass
+
+
+def _note_views_heal_deferred(name, e):
+    """A /clear or revive whose new session id could not inherit its session's tag memberships because
+    the views store faulted under the heal (_ordered's boundary deferred it, _views_heal_pending): the
+    dashboard hears it like the fork and promotion sites (_note_tags_not_inherited) -- one bell row under
+    the `refused` kind, once per deferral, beside the stderr line the boundary writes. Until this change
+    that line was the whole record, and it dies with the process while the session sits outside its tag
+    (review find, 2026-09-08). The row says what happens next: the heal is retried until it lands, and a
+    restart loses it, so tagging the session again is the remedy then. Guarded like the rest: a notice
+    never turns a placed fork into a raise out of a build."""
+    text = ('"%s" did not carry its tags across a /clear or revive: %s. Retried until it lands; '
+            'tag it again if the kernel restarts first' % (name, _views_fault_text(e)))
     try:
         _sync_notice(text, ok=False, kind="refused")
     except Exception:
@@ -5169,7 +5245,11 @@ def _ack_views_write(client, kind, write_id, ok, error=None, refused=None, info=
     kernel-minted `tid` and `name` here and opens its rename input on that id. `edited` is the
     write's own list (the whole-blob path): it orders the not-ok `error`, the poster's own refusals
     first. A dead socket is the client's problem, never the write's: the edit landed before this
-    runs."""
+    runs. Under a READ fault the store cannot be proved for the ack either (review find, 2026-09-08):
+    `views` is then the last blob this kernel served, marked by `viewsFault` (the fault in the person's
+    words), or absent with the marker alone when nothing was served yet -- so a poster reverting on the
+    refusal keeps what it holds instead of adopting a seq-less empty store as the base, and `seq` is
+    None. A publish fault's refusal read the store proved, so its ack carries the blob unmarked."""
     if not client or not callable(client.get("send")):
         return
     try:
@@ -5182,13 +5262,14 @@ def _views_write_ack(kind, write_id, ok, error=None, refused=None, info=None, ed
     """The ack document _ack_views_write sends, built without a socket: POST /views (the Obsidian
     panel's whole-blob write, _state_write_route) answers with this same document, so the panel feeds
     it to the viewsAck handler it already has and a refusal reads the same in every host."""
-    views = _views_client()
+    vp = _views_payload()
+    views = vp.get("views")
     ack = {"type": kind, "writeId": write_id if isinstance(write_id, str) else None,
-           "ok": bool(ok), "views": views,
+           "ok": bool(ok), **vp,
            # the store's write sequence after this write (the blob carries it too): the poster
            # orders this against the frames it receives — a frame with a lower seq predates the
-           # write and is ignored, whatever order the socket delivered them in
-           "seq": views.get("seq")}
+           # write and is ignored, whatever order the socket delivered them in; None with no blob
+           "seq": views.get("seq") if views is not None else None}
     for k in ("tid", "name"):
         if isinstance(info, dict) and info.get(k):
             ack[k] = info[k]
@@ -31751,7 +31832,7 @@ def build_feed(now, tmux=None):
     for _a in asks:
         _a["notify"] = True if _notify_card_effective(_ncards, _a["itemId"], str(_a.get("sid") or "")) else None
     return {"type": "feed", "asks": asks, "now": now,
-            "views": _views_client(),   # the rendered views blob — the outline + feed tag mounts read it (2026-08-25)
+            **_views_payload(),   # the rendered views blob — the outline + feed tag mounts read it (2026-08-25); under a read fault its marker rides too, or alone (2026-09-08)
             # usage-limit-down latch (judge-limit.json): analysis is paused because the account
             # cannot bill judge calls — the dashboard must SAY so, never fail quietly into retries
             # (the user 2026-08-18); self-expires at the window reset, cleared by the next success
@@ -34197,7 +34278,7 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
     # letting the bar slide through the map's hues as it compresses — mirroring the context battery fill.
     cmap_grad = [list(cm.ramp(v, ctx_stops)) for v in (0.12, 0.34, 0.56, 0.78, 1.0)]
     return {"type": "timeline", "now": now, "sessions": sessions, "turns": turns,
-            "views": _views_client(),
+            **_views_payload(),
             "palette": pal.colors(_palette_name()),   # tag color choices — the same set sessions draw identity colors from
             "messages": messages, "judging": judging,
             "cmapGrad": cmap_grad,

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -8,6 +8,8 @@ names/, skipped by live_sessions, skipped by discover), the opening message's fr
 the transcript→popover projection, the create/reply/resolve/promote ops, and promotion's seeding
 order. All fixtures SYNTHETIC: invented text, placeholder UUIDs.
 """
+import contextlib
+import errno
 import json
 import os
 import shutil
@@ -1107,6 +1109,29 @@ class FakeBackend:
         return True
 
 
+@contextlib.contextmanager
+def _views_reads_fault():
+    """Fail every byte read of the views store with an EIO for the duration of the block (its proved reader
+    reads bytes); everything else reads normally."""
+    real_rb, real_rt = Path.read_bytes, Path.read_text
+    tgt = str(jd.STATE / "timeline-views.json")
+
+    def rb(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EIO, "injected EIO")
+        return real_rb(self, *a, **k)
+
+    def rt(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EIO, "injected EIO")
+        return real_rt(self, *a, **k)
+    Path.read_bytes, Path.read_text = rb, rt
+    try:
+        yield
+    finally:
+        Path.read_bytes, Path.read_text = real_rb, real_rt
+
+
 class CommentOps(CommentBase):
     def setUp(self):
         super().setUp()
@@ -1398,6 +1423,36 @@ class CommentOps(CommentBase):
         self.assertEqual(self._tag_members("pool"), sorted([PARENT, tid]), "promoted = a tab now, in the parent's group")
         self.assertEqual(self._tag_members("other"), ["x"], "a tag the parent is not in is untouched")
         self.assertIn(tid, seen_at_connect[0], "membership landed before connect, ahead of the direct push")
+
+    def test_a_faulting_views_store_leaves_the_promotion_standing_and_says_it_did_not_inherit(self):
+        # the views store's proved read: a fault under the inherit RAISES (never an empty parent read off a
+        # fabricated store), and the promotion site's boundary keeps the spawn -- the thread is a session by
+        # then -- and says what did not happen: one refused-kind notice naming the child, nothing written
+        km._flags_cache.clear()
+        km._set_timeline_views({"active": "all", "tags": [{"id": "g1", "name": "pool", "members": [PARENT]}]})
+        km._flags_cache.clear()                      # a cold display cache: the fault must be met by the READ, not bypassed by a hit
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        self._promotable(tid)
+        p = jd.STATE / "timeline-views.json"
+        before = p.read_bytes()
+        connected = []
+        real_connect = self.be.connect
+        self.be.connect = lambda sid: (connected.append(sid), real_connect(sid))[1]
+        notices, saved = [], km._sync_notice
+        km._sync_notice = lambda text, ok=True, kind="sync": notices.append((text, ok, kind))
+        try:
+            with _views_reads_fault():
+                self.assertIsNone(km._comment_promote(PARENT, tid, "sidework"), "the promotion stands")
+        finally:
+            km._sync_notice = saved
+        self.assertEqual(connected, [tid], "the promoted session was connected as ever")
+        self.assertEqual(p.read_bytes(), before, "nothing was written to the store")
+        rows = [(t, k) for t, ok, k in notices if not ok and "did not inherit" in t]
+        self.assertEqual(len(rows), 1, "one notice for the one thing that did not happen")
+        self.assertIn('"sidework" did not inherit the tags of', rows[0][0])
+        self.assertIn("the tag store could not be read (read failed: [Errno 5]", rows[0][0])
+        self.assertEqual(rows[0][1], "refused")
+        self.assertEqual(self._tag_members("pool"), [PARENT], "the parent keeps its tag; the thread is not in it")
 
     def test_a_session_spawned_from_inside_a_thread_inherits_the_threads_parents_tags(self):
         # a thread's CLI carries the THREAD's sid as ROMP_SID, so `romp new` run from its shell names

--- a/tests/test_kernel_fork.py
+++ b/tests/test_kernel_fork.py
@@ -14,6 +14,8 @@ run_courier additionally grew its own episode-floor guard: a fork's copied histo
 that leaves OLD peer segments visible to it (a /clear's null-rooted head drops them from the parse).
 
 SYNTHETIC fixtures only (placeholder UUIDs, invented text)."""
+import contextlib
+import errno
 import json
 import os
 import re
@@ -122,6 +124,29 @@ class ForkStoreSeeding(unittest.TestCase):
         empty = os.path.join(self.td.name, "empty.jsonl")
         Path(empty).write_text("")
         self.assertIn("nothing to fork", km._seed_fork_stores(PARENT, NEWSID, empty, "") or "")
+
+
+@contextlib.contextmanager
+def _reads_fault(target):
+    """Fail every byte read of ONE path with an EIO for the duration of the block (the views store's proved
+    reader reads bytes); everything else reads normally."""
+    real_rb, real_rt = Path.read_bytes, Path.read_text
+    tgt = str(target)
+
+    def rb(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EIO, "injected EIO")
+        return real_rb(self, *a, **k)
+
+    def rt(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EIO, "injected EIO")
+        return real_rt(self, *a, **k)
+    Path.read_bytes, Path.read_text = rb, rt
+    try:
+        yield
+    finally:
+        Path.read_bytes, Path.read_text = real_rb, real_rt
 
 
 class _FakeForkBackend:
@@ -236,6 +261,35 @@ class ForkSessionOp(unittest.TestCase):
         self.assertIsNone(km._fork_session(PARENT, "", "api-fork"))
         fork_sid = next(e for e in self.be.events if e[0] == "fork")[4]
         self.assertNotIn(fork_sid, [m["sid"] for m in km._timeline_views()["tags"][0]["members"]])
+
+    def test_a_faulting_views_store_leaves_the_fork_standing_and_says_it_did_not_inherit(self):
+        # the views store's proved read: a fault under the inherit RAISES (never an empty parent read off a
+        # fabricated store), and the fork site's boundary keeps the spawn -- the session already exists -- and
+        # says what did not happen: one refused-kind notice naming the child, nothing written to the store
+        km._flags_cache.clear()
+        km._set_timeline_views({"active": "all", "tags": [{"id": "g1", "name": "pool", "members": [PARENT]}]})
+        km._flags_cache.clear()                      # a cold display cache: the fault must be met by the READ, not bypassed by a hit
+        p = jd.STATE / "timeline-views.json"
+        before = p.read_bytes()
+        notices, saved = [], km._sync_notice
+        km._sync_notice = lambda text, ok=True, kind="sync": notices.append((text, ok, kind))
+        try:
+            with _reads_fault(p):
+                self.assertIsNone(km._fork_session(PARENT, "", "api-fork"), "the fork stands")
+        finally:
+            km._sync_notice = saved
+        self.assertEqual([e[0] for e in self.be.events], ["seed", "fork", "connect"], "seeded, forked, connected as ever")
+        self.assertEqual(p.read_bytes(), before, "nothing was written to the store")
+        rows = [(t, k) for t, ok, k in notices if not ok]
+        self.assertEqual(len(rows), 1, "one notice for the one thing that did not happen")
+        self.assertIn('"api-fork" did not inherit the tags of', rows[0][0])
+        self.assertIn("the tag store could not be read (read failed: [Errno 5]", rows[0][0])
+        self.assertEqual(rows[0][1], "refused")
+        km._flags_cache.clear()
+        fork_sid = next(e for e in self.be.events if e[0] == "fork")[4]
+        self.assertEqual([m["sid"] for m in km._timeline_views()["tags"][0]["members"]], [PARENT],
+                         "the parent keeps its tag; the fork is not in it (tag it again once the store reads)")
+        self.assertNotEqual(fork_sid, PARENT)
 
 
 class CourierEpisodeFloor(unittest.TestCase):

--- a/tests/test_live_session_unresolved_transcript.py
+++ b/tests/test_live_session_unresolved_transcript.py
@@ -127,7 +127,7 @@ class _World(unittest.TestCase):
 
 class FrameCarriesLive(unittest.TestCase):
     def test_the_tab_order_frame_names_the_live_sids(self):
-        with mock.patch.object(km, "_views_client", lambda: {}):
+        with mock.patch.object(km, "_views_payload", lambda: {"views": {}}):   # the frame's one views carrier (2026-09-08)
             f = km._tab_order_frame(["a", "b"], [{"id": "a"}], {"a", "b", "c"})
         self.assertEqual(f["type"], "tabOrder")
         self.assertEqual(f["order"], ["a", "b"])

--- a/tests/test_tag_edit_ack.py
+++ b/tests/test_tag_edit_ack.py
@@ -791,9 +791,10 @@ class WriteSequence(_Wire):
         self.assertEqual(km._norm_timeline_views(json.loads(json.dumps(served)))["seq"], served["seq"],
                          "clients echo the blob wholesale — the stamp survives the round trip")
         src = open(os.path.join(BIN, "romp-kernel")).read()
-        self.assertGreaterEqual(src.count('"views": _views_client()'), 3,
+        self.assertGreaterEqual(src.count('**_views_payload()'), 3,
                                 "the timeline skeleton, the feed frame and the tabOrder frames all embed the "
-                                "rendered blob — one carrier, so the seq rides every one of them")
+                                "rendered blob — one carrier (_views_payload since 2026-09-08: the blob, marked "
+                                "under a read fault, or the marker alone), so the seq rides every one of them")
 
     def test_a_store_recreated_from_nothing_starts_past_what_a_connected_client_holds(self):
         """The seq is seeded from the clock, then +1 per write: a deleted views file (or a new

--- a/tests/test_tag_edit_ack.py
+++ b/tests/test_tag_edit_ack.py
@@ -283,7 +283,9 @@ class TargetedTagEdits(_Wire):
         self.seed()                                                        # web = gA holding SID1
         api = self.edit("w1", {"op": "create", "name": "api", "color": "#54B204"})["tid"]
         writes, real = [], km._set_timeline_views
-        km._set_timeline_views = lambda blob: (writes.append(1), real(blob))[1]
+        # the RMW doors hand the setter their proved snapshot as `base=` (one read per write), so the
+        # counting stub forwards the setter's keywords
+        km._set_timeline_views = lambda blob, **kw: (writes.append(1), real(blob, **kw))[1]
         try:
             a = self.edit("w2", {"op": "move", "tid_from": "gA", "tid_to": api, "sid": SID1})
         finally:
@@ -1122,16 +1124,27 @@ class LegacyStoreStampedOnce(_Wire):
         finally:
             restore()
 
-    def test_an_unreadable_file_is_served_empty_and_never_overwritten(self):
+    def test_a_torn_file_is_moved_aside_never_overwritten_and_the_store_reads_empty(self):
+        # MOVED PIN (the views store's proved read): this test asserted the torn file was left IN PLACE ("a corrupt
+        # file is left for a human"). The reader goes through _read_state_json now, which QUARANTINES torn bytes
+        # aside (<name>.corrupt-<stamp>: a move, never a delete -- the flags, order and bell stores' convention)
+        # so the evidence survives AND the store reads as empty only after it is preserved; left in place, the
+        # next writer's atomic replace overwrote it. The stamp still never replaces it with an empty store.
         p = km._views_path()
         p.write_text("{not json")
         n, restore = self._writes()
         try:
-            self.assertEqual(km._timeline_views()["tags"], [])
-            self.assertEqual(n[0], 0, "a corrupt file is left for a human — the stamp never replaces it with an empty store")
-            self.assertEqual(p.read_text(), "{not json")
+            with contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(km._timeline_views()["tags"], [])
+            self.assertEqual(n[0], 0, "a corrupt file is never replaced with an empty store by the stamp")
+            self.assertFalse(p.exists(), "the torn bytes were moved aside, not left for the next writer to overwrite")
+            aside = sorted(p.parent.glob("timeline-views.json.corrupt-*"))
+            self.assertEqual(len(aside), 1, "one quarantine file")
+            self.assertEqual(aside[0].read_text(), "{not json", "…holding the ORIGINAL bytes for forensics")
         finally:
             restore()
+            for q in p.parent.glob("timeline-views.json.corrupt-*"):
+                q.unlink()
 
 
 class LegacyTagsStampedOnFirstRead(_Wire):

--- a/tests/test_tag_route.py
+++ b/tests/test_tag_route.py
@@ -6,10 +6,14 @@ agent replaying a stale read would clobber the active view and every tag it neve
 /tag is a targeted merge on one NAMED tag (_edit_tag): live names resolve to sids, opaque
 ids (dead sids, host-prefixed remote ids) pass through verbatim, unknown names refuse loudly.
 Drives the REAL Handler over HTTP (the test_new_route_prefs.py pattern). Synthetic only."""
+import contextlib
+import errno
+import io
 import json
 import os
 import tempfile
 import threading
+import time
 import unittest
 import urllib.request
 from http.server import ThreadingHTTPServer
@@ -508,6 +512,733 @@ class HttpFlagsMustBeBooleans(TagRoute):
             self.assertEqual((st, r.get("ok"), r.get("error")), (200, False, "stubbed: no directory here"))
         finally:
             km._resolve_create_dir = saved
+# ── the views store under a FAULT (the state-readers audit: the flag, order and bell stores' twin) ──────
+# The reader used to fold ANY read fault (a transient EIO, an EACCES, torn bytes) to an empty blob and
+# CACHE it under the file's real (mtime, size) key, so after one fault the store read as {} on every
+# call until the file's stat moved; every read-modify-write door then wrote that emptiness plus its one
+# edit back -- the user's whole tag set, every lens and the order -- under an ok:true ack, while every
+# dashboard adopted the seq-less {} and its tag bar emptied with nothing said. Now the mutation path
+# reads PROVED (_timeline_views_proved raises), every door refuses in its own shape with the file
+# untouched, the display path serves its last-known-good uncached and files one notice per episode,
+# and torn bytes are moved aside. Synthetic sids and hosts only; a private temp state dir per test
+# (TagRoute.setUp), so no shared placeholder store is ever touched.
+
+
+@contextlib.contextmanager
+def _stat_fault(target):
+    """Fail every stat of ONE path with an EACCES for the duration of the block: every reader stats
+    BEFORE it reads (the display reader keys its cache on it), and a state dir that cannot be searched
+    faults exactly there. Everything else stats normally."""
+    real_stat = Path.stat
+    tgt = str(target)
+
+    def st(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EACCES, "injected EACCES")
+        return real_stat(self, *a, **k)
+    Path.stat = st
+    try:
+        yield
+    finally:
+        Path.stat = real_stat
+
+
+@contextlib.contextmanager
+def _stat_faults_after(target, n):
+    """Path.stat on ONE path succeeds for its first `n` calls, then fails with EACCES: the display
+    reader's in-lock re-stat (its second stat of the file, under _views_file_lock before a re-stamp) is
+    the arm no other injector reaches. Yields the call counter."""
+    real_stat = Path.stat
+    tgt, calls = str(target), [0]
+
+    def st(self, *a, **k):
+        if str(self) == tgt:
+            calls[0] += 1
+            if calls[0] > n:
+                raise OSError(errno.EACCES, "injected EACCES")
+        return real_stat(self, *a, **k)
+    Path.stat = st
+    try:
+        yield calls
+    finally:
+        Path.stat = real_stat
+
+
+@contextlib.contextmanager
+def _reads_fault(target):
+    """Fail every byte read of ONE path with an EIO (the proved reader's read_bytes and the pre-fix
+    reader's read_text alike) for the duration of the block; everything else reads normally."""
+    real_rb, real_rt = Path.read_bytes, Path.read_text
+    tgt = str(target)
+
+    def rb(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EIO, "injected EIO")
+        return real_rb(self, *a, **k)
+
+    def rt(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EIO, "injected EIO")
+        return real_rt(self, *a, **k)
+    Path.read_bytes, Path.read_text = rb, rt
+    try:
+        yield
+    finally:
+        Path.read_bytes, Path.read_text = real_rb, real_rt
+
+
+@contextlib.contextmanager
+def _writes_fault(target):
+    """Fail the PUBLISH of ONE state file with an ENOSPC for the duration of the block: _atomic_write
+    writes `<name>.tmp.<pid>.<tid>.<n>` beside the file and renames it over, so failing every write_text
+    of that shape is the disk refusing this file's publish while every other path, and every read, behaves."""
+    real = Path.write_text
+    prefix = Path(target).name + ".tmp."
+
+    def wt(self, *a, **k):
+        if self.name.startswith(prefix):
+            raise OSError(errno.ENOSPC, "No space left on device")
+        return real(self, *a, **k)
+    Path.write_text = wt
+    try:
+        yield
+    finally:
+        Path.write_text = real
+
+
+class _ViewsFaultMixin:
+    """The store-fault harness on top of TagRoute (a mixin, so it is not collected on its own): the fault
+    registries and the deferred-heal map start and end empty (process-wide state -- a fault filed here
+    must not silence a later test's), the notice ring is captured WITH the kind the fault machinery files
+    under (a two-argument stub raises on `kind=`, and the machinery's own try swallows the notice), and
+    helpers for a seeded store and a dashboard socket."""
+
+    def setUp(self):
+        super().setUp()
+        km._state_fault_seen.clear()
+        km._state_write_fault_seen.clear()
+        vars(km).get("_views_heal_pending", {}).clear()
+        km._VIEWS_RESTAMP_ERR[0] = None
+        self.notices = []
+        self._saved_notice = km._sync_notice
+        km._sync_notice = lambda text, ok=True, kind="sync": self.notices.append((text, ok, kind))
+
+    def tearDown(self):
+        km._sync_notice = self._saved_notice
+        km._state_fault_seen.clear()
+        km._state_write_fault_seen.clear()
+        vars(km).get("_views_heal_pending", {}).clear()
+        super().tearDown()
+
+    def _seed(self, *names):
+        """One tag per name, each holding "web" (SID), written through the route -- a real, stamped store;
+        returns the file's bytes for the untouched-store assertions. The cache is left as the writes primed it."""
+        for nm in names:
+            st, resp = self._post({"name": nm, "add": ["web"]})
+            self.assertTrue(resp.get("ok"), resp)
+        return self._bytes()
+
+    def _bytes(self):
+        return km._views_path().read_bytes()
+
+    def _client(self):
+        sent = []
+        return {"app": "timeline", "wid": "w1", "alive": True, "send": lambda raw: sent.append(json.loads(raw))}, sent
+
+    def _ws(self, msg, client):
+        km.Handler._dispatch_ws(object.__new__(km.Handler), msg, client)
+
+    def _faults(self, what="read"):
+        """The store's fault notices of one kind (read / written), as (text, bell kind) pairs. A quarantine's
+        "could not be parsed" notice is a different event and is not counted here."""
+        return [(t, k) for t, ok, k in self.notices if not ok and "timeline-views.json could not be %s" % what in t]
+
+
+class ViewsStoreUnreadableRefuses(_ViewsFaultMixin, TagRoute):
+    """A store that EXISTS but cannot be read. The mutation path refuses in its own shape and writes nothing;
+    the judge never folds; the display path serves what it last knew, caches nothing from the fault, and
+    says so once per episode."""
+
+    def test_a_tag_edit_is_refused_when_the_views_store_cannot_be_read(self):
+        # on main the cold display read folded the EIO to {} and cached it; _edit_tag found no "workers",
+        # CREATED one holding only api, and landed a ONE-tag store over the seeded two -- 200 ok:true
+        before = self._seed("workers", "reviewers")
+        km._flags_cache.clear()
+        with _reads_fault(km._views_path()):
+            status, resp = self._post({"name": "workers", "add": ["api"]})
+        self.assertEqual((status, resp.get("ok"), resp.get("retryable")), (200, False, True),
+                         "the route's OWN refusal shape: romp tag reads .error, and curl -sf turns a 5xx into 'not reachable'")
+        self.assertIn("the tag store could not be read (read failed: [Errno 5]", resp["error"])
+        self.assertIn("nothing was changed", resp["error"])
+        self.assertEqual(self._bytes(), before, "the views file is byte-for-byte unchanged: nothing was written over an empty")
+        self.assertEqual(self.dirty, [1, 1], "only the seeds marked the views dirty; the refusal pushed nothing")
+
+    def test_a_stat_fault_serves_the_last_good_blob_and_refuses_the_edit(self):
+        # the STAT arm: every reader stats before it reads, and a state dir that cannot be searched faults
+        # there. On main ANY stat OSError read as "no store": the cache entry was forgotten and {} served.
+        before = self._seed("workers")
+        km._flags_cache.clear()
+        self.assertEqual([t["name"] for t in km._timeline_views()["tags"]], ["workers"])   # the known-good, primed
+        with _stat_fault(km._views_path()):
+            served = km._timeline_views()
+            self.assertEqual([t["name"] for t in served["tags"]], ["workers"], "the last good blob, not {}")
+            self.assertIn(str(km._views_path()), km._flags_cache, "the entry is kept: the store is unreadable, not gone")
+            status, resp = self._post({"name": "workers", "add": ["api"]})
+        self.assertEqual((status, resp.get("ok"), resp.get("retryable")), (200, False, True))
+        self.assertIn("the tag store could not be read (stat failed: [Errno 13]", resp["error"])
+        self.assertEqual(self._bytes(), before)
+        self.assertEqual(len(self._faults()), 1, "one notice for the episode, from the display read")
+        self.assertIn("timeline-views.json could not be read (stat failed: [Errno 13]", self._faults()[0][0])
+        self.assertEqual(self._faults()[0][1], "refused", "filed under the bell's refused kind, not sync")
+
+    def test_the_judge_never_folds_a_read_fault_to_an_empty_base(self):
+        # the stale-writer guard's "previous truth" came from the display reader inside `except Exception:
+        # base = {}`; a lens write (`edited: []`) then kept prev.values() -- nothing -- and stored `tags: []`
+        self._seed("workers")
+        km._flags_cache.clear()
+        with _reads_fault(km._views_path()):
+            with self.assertRaises(km._StateUnreadable):
+                km._judge_timeline_views({"active": "all", "tags": []}, edited=[])
+
+    def test_a_torn_views_file_is_quarantined_aside_then_the_store_reads_empty(self):
+        torn = b'{"active": "all", "tags": [ THIS IS NOT JSON'
+        p = km._views_path()
+        p.write_bytes(torn)
+        km._flags_cache.clear()
+        with contextlib.redirect_stderr(io.StringIO()):
+            v = km._timeline_views_proved()
+        self.assertEqual(v["tags"], [], "the store starts empty ONLY after the bytes are preserved")
+        q = list(km.jd.STATE.glob("timeline-views.json.corrupt-*"))
+        self.assertEqual(len(q), 1, "the torn bytes were moved aside, not deleted")
+        self.assertEqual(q[0].read_bytes(), torn, "the quarantine holds the ORIGINAL bytes for forensics")
+        self.assertFalse(p.exists(), "the torn file was moved, not left in place for the next writer to overwrite")
+        self.assertEqual(len([t for t, ok, k in self.notices if "moved aside" in t and k == "refused"]), 1,
+                         "the dashboard hears the move once, under the refused kind")
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._timeline_views()["tags"], [], "the display reader agrees: empty now, not a fault")
+        self.assertEqual(self._faults(), [], "a quarantine is a stated event, not a read fault")
+
+    def test_enoent_views_reads_empty_with_no_quarantine_and_no_fault_filed(self):
+        try:
+            km._views_path().unlink()
+        except OSError:
+            pass
+        km._flags_cache.clear()
+        self.assertEqual(km._timeline_views()["tags"], [], "a missing store is legitimately empty")
+        self.assertEqual(km._timeline_views_proved()["tags"], [], "…and the mutation snapshot agrees")
+        self.assertEqual(list(km.jd.STATE.glob("timeline-views.json.corrupt-*")), [])
+        self.assertEqual(self.notices, [], "a missing file is not a fault: nothing is filed")
+        self.assertEqual(km._state_fault_seen, {})
+
+    def test_a_display_read_fault_never_raises_into_the_build_and_is_loud_once_per_episode(self):
+        # build_feed / build_timeline / build_session run under _push's ONE outer try, so a display reader
+        # that RAISED would abort every client's push. The display path serves the empty default here (a
+        # cold cache: nothing known-good yet), UNPROVED, and files exactly ONE notice per fault episode.
+        self._seed("workers")
+        km._flags_cache.clear()
+        with _reads_fault(km._views_path()):
+            feed1 = km.build_feed(int(time.time()))
+            self.assertEqual(feed1.get("type"), "feed", "build_feed still returns a payload: the board is not wedged")
+            self.assertIn("views", feed1)
+            self.assertEqual(feed1["views"]["tags"], [], "the unreadable store serves the empty default, not a crash")
+            self.assertEqual(len(self._faults()), 1, "exactly ONE notice the first time the fault is seen")
+            self.assertIn("timeline-views.json could not be read (read failed: [Errno 5]", self._faults()[0][0])
+            self.assertEqual(self._faults()[0][1], "refused")
+            km.build_feed(int(time.time()))                       # a second build in the SAME episode files nothing new
+            self.assertEqual(len(self._faults()), 1)
+        km._flags_cache.clear()
+        feed3 = km.build_feed(int(time.time()))
+        self.assertEqual([t["name"] for t in feed3["views"]["tags"]], ["workers"],
+                         "after the fault clears the real tag reads again: the reader never cached the empty")
+        self.assertNotIn(str(km._views_path()), km._state_fault_seen,
+                         "a clean read ends the episode, so a later fault speaks again (event-based)")
+
+    def test_the_display_reader_never_caches_a_value_that_came_from_a_fault(self):
+        # a reader that cached the fabricated empty under the file's (mtime, size) key kept serving it after
+        # the fault cleared (same key, and a cache HIT never reads): one EIO, then {} until the file moved
+        self._seed("workers")
+        km._flags_cache.clear()
+        with _reads_fault(km._views_path()):
+            self.assertEqual(km._timeline_views()["tags"], [], "a cold cache under a fault serves the empty default")
+            self.assertNotIn(str(km._views_path()), km._flags_cache, "…and the fabricated empty is NOT cached under the file's key")
+        self.assertEqual([t["name"] for t in km._timeline_views()["tags"]], ["workers"], "the next read is the real store")
+
+    def test_a_fault_serves_the_last_read_blob_and_caches_nothing_under_the_new_key(self):
+        # the primed-cache case: a HIT under the same stat key never reads, so the file is moved on first
+        # and the cache set back to what a reader that missed that write holds -- the faulted read is then a
+        # MISS that must serve the LAST blob read, and must not cache it (or {}) under the NEW key, or the
+        # recovered disk would never be read again
+        self._seed("workers")
+        km._flags_cache.clear()
+        first = km._timeline_views()
+        self.assertEqual([t["name"] for t in first["tags"]], ["workers"])
+        key1 = km._flags_cache[str(km._views_path())][0]
+        st, resp = self._post({"name": "reviewers", "add": ["api"]})   # the file moves on
+        self.assertTrue(resp.get("ok"), resp)
+        km._flags_cache[str(km._views_path())] = (key1, first)        # as held by a reader that missed the write
+        st2 = km._views_path().stat()
+        self.assertNotEqual(key1, (st2.st_mtime_ns, st2.st_size), "the edit must move the stat key, or this test reads nothing")
+        with _reads_fault(km._views_path()):
+            served = km._timeline_views()
+            self.assertEqual([t["name"] for t in served["tags"]], ["workers"], "the LAST blob read: not {} and not the unread file")
+            self.assertEqual(km._flags_cache[str(km._views_path())][0], key1, "nothing cached under the new key")
+        self.assertEqual(sorted(t["name"] for t in km._timeline_views()["tags"]), ["reviewers", "workers"],
+                         "the real, newer file reads once the fault clears")
+
+    def test_a_stat_fault_under_the_re_stamp_lock_serves_the_last_good_blob_and_is_said_once(self):
+        # the in-lock re-stat: the first stat (outside the lock) passes, the file reads, the re-stamp takes the
+        # lock and stats again -- and THAT one faults. Main folded it to {}; the arm re-enters the reader, whose
+        # stat arm serves the last good blob, files the fault once and caches nothing
+        self._seed("workers")
+        km._flags_cache.clear()
+        good = km._timeline_views()                                  # the last good blob
+        p = km._views_path()
+        legacy = {"active": "all", "tags": [{"id": "gL", "name": "legacy", "color": "",
+                                              "members": [{"host": "", "sid": SID}]}]}
+        p.write_text(json.dumps(legacy))                             # a seq-less file: the read wants to re-stamp it
+        km._flags_cache[str(p)] = (("stale", 0), good)               # an entry that misses (a reader that missed the write)
+        with _stat_faults_after(p, 1) as calls, contextlib.redirect_stderr(io.StringIO()):
+            served = km._timeline_views()
+        self.assertGreaterEqual(calls[0], 2, "the re-stamp's in-lock re-stat was reached")
+        self.assertEqual([t["name"] for t in served["tags"]], ["workers"], "the last good blob, not {}")
+        self.assertEqual(km._flags_cache[str(p)], (("stale", 0), good), "nothing cached from the fault")
+        self.assertEqual(len(self._faults()), 1, "said once")
+        self.assertIn("stat failed: [Errno 13]", self._faults()[0][0])
+        self.assertEqual(p.read_text(), json.dumps(legacy), "no re-stamp was written")
+
+
+class ViewsWsRefusal(_ViewsFaultMixin, TagRoute):
+    """The two dashboard doors under a store fault, through the real dispatcher: the poster is answered on
+    its own socket with the fault in the person's words, the file is untouched, the socket lives."""
+
+    LENS = {"active": "all", "tags": [], "actives": {"chat": {"none": True}}}   # a lens write's blob, as a dashboard posts it
+
+    def test_a_lens_write_under_a_read_fault_is_refused_on_the_socket_and_the_tags_stand(self):
+        # THE erasure on the whole-blob door: a lens or order write carries `edited: []`; the judge's lens_only
+        # arm kept prev.values() -- EMPTY off the poisoned base -- and stored `tags: []`, acked ok:true
+        before = self._seed("workers", "reviewers")
+        km._flags_cache.clear()
+        client, sent = self._client()
+        with _reads_fault(km._views_path()):
+            self._ws({"type": "setTimelineViews", "writeId": "w1", "edited": [], "views": dict(self.LENS)}, client)
+        self.assertEqual(len(sent), 1, "answered on the posting socket")
+        ack = sent[0]
+        self.assertEqual((ack["type"], ack["writeId"], ack["ok"]), ("viewsAck", "w1", False))
+        self.assertIn("the tag store could not be read (read failed: [Errno 5]", ack["error"])
+        self.assertIn("nothing was changed", ack["error"])
+        self.assertEqual(ack["refused"], [], "a store fault is not a stale-writer refusal: no rows")
+        self.assertEqual(self._bytes(), before, "the views file is byte-for-byte unchanged: `tags: []` did not land")
+        self.assertTrue(client["alive"])
+        km._flags_cache.clear()
+        self.assertEqual(sorted(t["name"] for t in km._timeline_views()["tags"]), ["reviewers", "workers"])
+
+    def test_a_tag_create_under_a_read_fault_is_refused_and_keeps_every_tag(self):
+        # on main _edit_tag read the poisoned {} and created the tag anew: a ONE-tag store landed, acked ok
+        before = self._seed("workers", "reviewers")
+        km._flags_cache.clear()
+        client, sent = self._client()
+        with _reads_fault(km._views_path()):
+            self._ws({"type": "tagEdit", "writeId": "w2", "edit": {"op": "create", "name": "api", "sids": [SID2]}}, client)
+        ack = sent[0]
+        self.assertEqual((ack["type"], ack["writeId"], ack["ok"]), ("tagEditAck", "w2", False))
+        self.assertIn("the tag store could not be read (read failed: [Errno 5]", ack["error"])
+        self.assertNotIn("tid", ack, "no tag was minted")
+        self.assertEqual(self._bytes(), before)
+
+    def test_a_rename_by_tid_under_a_read_fault_names_the_fault_not_a_deleted_tag(self):
+        # on main the poisoned {} held no such tid, so the rename was refused as "that tag no longer exists" --
+        # loud, and WRONG: the tag is right there in the file
+        st, resp = self._post({"name": "workers", "add": ["web"]})
+        tid = resp["tag"]["id"]
+        before = self._bytes()
+        km._flags_cache.clear()
+        client, sent = self._client()
+        with _reads_fault(km._views_path()):
+            self._ws({"type": "tagEdit", "writeId": "w3", "edit": {"op": "rename", "tid": tid, "newName": "crew"}}, client)
+        ack = sent[0]
+        self.assertFalse(ack["ok"])
+        self.assertNotIn("no longer exists", ack["error"], "the tag was not deleted; the store could not be read")
+        self.assertIn("the tag store could not be read", ack["error"])
+        self.assertEqual(self._bytes(), before)
+
+    def test_a_view_change_whose_publish_fails_is_refused_with_the_fault_named_and_the_socket_kept(self):
+        # the WRITE step (the maintainer's fold on PR #1019): the store reads, the judge passes, the publish hits
+        # ENOSPC. On main the arm caught the OSError as a generic failure ("the write failed on the kernel:
+        # [Errno 28] ... '<temp path>'") and filed nothing on the fault table; the door raises _StateUnwritable
+        # now, filed once per episode, and the ack carries the person's words
+        before = self._seed("workers")
+        client, sent = self._client()
+        p = km._views_path()
+        with _writes_fault(p):
+            self._ws({"type": "setTimelineViews", "writeId": "w4", "edited": [], "views": dict(self.LENS)}, client)
+            self._ws({"type": "setTimelineViews", "writeId": "w5", "edited": [], "views": dict(self.LENS)}, client)
+        self.assertTrue(client["alive"], "no OSError reached the receive loop")
+        self.assertEqual([(a["writeId"], a["ok"]) for a in sent], [("w4", False), ("w5", False)], "every attempt is answered")
+        self.assertIn("the tag store could not be written (write failed: [Errno 28] No space left on device)", sent[0]["error"])
+        self.assertIn("nothing was changed", sent[0]["error"])
+        self.assertNotIn(".tmp.", sent[0]["error"], "errno + strerror only, never the temp path")
+        self.assertEqual(self._bytes(), before, "the views file is byte-for-byte unchanged")
+        self.assertEqual(len(self._faults("written")), 1, "the fault is filed ONCE per episode, not per gesture")
+        self.assertIn(str(p), km._state_write_fault_seen)
+        self._ws({"type": "setTimelineViews", "writeId": "w6", "edited": [], "views": dict(self.LENS)}, client)   # the disk heals
+        self.assertTrue(sent[-1]["ok"], sent[-1])
+        self.assertNotIn(str(p), km._state_write_fault_seen, "a landed write ends the episode")
+        km._flags_cache.clear()
+        self.assertEqual([t["name"] for t in km._timeline_views()["tags"]], ["workers"], "a lens write changes no tag")
+
+    def test_a_move_under_a_read_fault_is_refused_with_the_fault_named_and_the_file_unchanged(self):
+        # the move door (_move_tag_member) reads proved like the rest: a door reading the display reader folds
+        # the fault to {} and refuses as "the tag to move out of no longer exists" -- its own text, and wrong
+        st, r1 = self._post({"name": "workers", "add": ["web"]})
+        st, r2 = self._post({"name": "reviewers", "add": ["api"]})
+        before = self._bytes()
+        km._flags_cache.clear()
+        client, sent = self._client()
+        with _reads_fault(km._views_path()):
+            self._ws({"type": "tagEdit", "writeId": "w7",
+                      "edit": {"op": "move", "tid_from": r1["tag"]["id"], "tid_to": r2["tag"]["id"], "sid": SID}}, client)
+        ack = sent[0]
+        self.assertEqual((ack["type"], ack["writeId"], ack["ok"]), ("tagEditAck", "w7", False))
+        self.assertIn("the tag store could not be read (read failed: [Errno 5]", ack["error"])
+        self.assertNotIn("no longer exists", ack["error"], "the tags are right there; the store could not be read")
+        self.assertEqual(self._bytes(), before)
+        km._flags_cache.clear()
+        self.assertEqual(sorted(t["name"] for t in km._timeline_views()["tags"]), ["reviewers", "workers"])
+
+
+class ViewsStoreUnwritableRefuses(_ViewsFaultMixin, TagRoute):
+    """The views store READS but its PUBLISH fails (ENOSPC, EROFS, EACCES): the write step is a fault
+    boundary too. On main the OSError out of _atomic_write escaped _edit_tag to do_POST's catch-all -- a
+    500 traceback, which `romp tag` (curl -sf) reports as an unreachable kernel and a federation forward
+    as a tunnel hiccup. Now the publish raises _StateUnwritable and the route answers its own shape."""
+
+    def test_a_tag_edit_whose_publish_fails_is_refused_in_the_route_shape(self):
+        before = self._seed("workers")
+        p = km._views_path()
+        with _writes_fault(p):
+            st, r = self._post({"name": "workers", "add": ["api"]})          # a 500 traceback on main
+            st2, r2 = self._post({"name": "workers", "add": ["api"]})        # and again, on the same full disk
+        self.assertEqual(st, 200, "a failed publish rides the route's own 200 shape, never a 500")
+        self.assertEqual((r["ok"], r["retryable"]), (False, True))
+        self.assertIn("the tag store could not be written (write failed: [Errno 28] No space left on device)", r["error"])
+        self.assertNotIn(".tmp.", r["error"], "errno + strerror only, never the temp path")
+        self.assertEqual((st2, r2["ok"]), (200, False), "every attempt is answered")
+        self.assertEqual(p.read_bytes(), before, "the views file is byte-for-byte unchanged")
+        self.assertEqual(len(self.dirty), 1, "only the seed marked the views dirty")
+        self.assertEqual(len(self._faults("written")), 1, "the fault is filed ONCE per episode, not per edit")
+        st, r = self._post({"name": "workers", "add": ["api"]})              # the disk heals
+        self.assertTrue(r.get("ok"), r)
+        self.assertEqual(sorted(r["tag"]["members"]), sorted([SID, SID2]), "the edit lands and ends the episode")
+        self.assertNotIn(str(p), km._state_write_fault_seen)
+
+    def test_the_setter_raises_the_plain_exception_never_the_os_error(self):
+        # the WS receive loop re-raises (BrokenPipeError, ConnectionResetError, OSError) as a dead socket; a
+        # plain Exception is one logged line. On main the setter raised the OSError itself.
+        with _writes_fault(km._views_path()):
+            with self.assertRaises(km._StateUnwritable) as cm:
+                km._set_timeline_views({"active": "all", "tags": []})
+        self.assertNotIsInstance(cm.exception, OSError)
+        self.assertFalse(issubclass(km._StateUnwritable, OSError))
+        self.assertEqual(str(cm.exception),
+                         "timeline-views.json could not be written (write failed: [Errno 28] No space left on device)")
+        self.assertFalse(km._views_path().exists(), "nothing was published")
+
+
+class HealHasABoundaryInTheBuild(_ViewsFaultMixin, TagRoute):
+    """_heal_timeline_views (a /clear or revive inherits its session's tag memberships) runs inside _ordered,
+    inside every build. It reads PROVED once and hands its snapshot to the setter; a fault raises to
+    _ordered's boundary, which places the fork, defers the heal and retries it on later passes -- the order
+    publish that follows the splice marks the fork known, so without the retry a heal skipped over a
+    transient fault never ran again. On main the heal read the display reader, folded to {}, and
+    silently carried nothing."""
+
+    FORK = "33333333-2222-3333-4444-555555555555"
+
+    def setUp(self):
+        super().setUp()
+        self._saved_heal = (km._session_order_proved, km._session_order, km._name_of, km._heal_timeline_views)
+        km._session_order_lkg[0] = None
+
+    def tearDown(self):
+        (km._session_order_proved, km._session_order, km._name_of, km._heal_timeline_views) = self._saved_heal
+        super().tearDown()
+
+    def _seed_tag_with(self, sid):
+        km._flags_cache.clear()
+        km._set_timeline_views({"active": "all", "tags": [{"id": "t1", "name": "workers", "color": "#123456",
+                                                            "members": [sid]}]})
+        km._flags_cache.clear()
+
+    def _stub_order(self, order):
+        km._session_order_proved = lambda: list(order)
+        km._session_order = lambda: list(order)
+        km._name_of = lambda sid: {SID: "web", SID2: "api", self.FORK: "web"}.get(sid, "")
+
+    def _sessions(self):
+        return [{"sid": SID2, "name": "api"}, {"sid": self.FORK, "name": "web"}, {"sid": SID, "name": "web"}]
+
+    def test_the_heal_writes_off_its_one_snapshot_even_when_a_second_read_would_fault(self):
+        # the fault begins AFTER the heal's read: a setter that re-read the store for its base would raise;
+        # the heal hands its snapshot over and the membership lands off ONE proved read
+        self._seed_tag_with(SID)
+        real = km._timeline_views_proved
+        calls = [0]
+
+        def once_then_fault():
+            calls[0] += 1
+            if calls[0] > 1:
+                raise km._StateUnreadable(km._views_path(), "read failed: [Errno 5] injected EIO")
+            return real()
+        km._timeline_views_proved = once_then_fault
+        try:
+            km._heal_timeline_views(SID, SID2)
+        finally:
+            km._timeline_views_proved = real
+        km._flags_cache.clear()
+        members = [t for t in real()["tags"] if t["name"] == "workers"][0]["members"]
+        self.assertEqual(sorted(m["sid"] for m in members), sorted([SID, SID2]), "the fork inherited the tag")
+        self.assertEqual(calls[0], 1, "exactly one proved read: the setter did not re-read")
+
+    def test_ordered_survives_a_heal_that_raises_and_still_places_the_fork(self):
+        self._stub_order([SID, SID2])
+
+        def boom(old, new):
+            raise km._StateUnreadable(km._views_path(), "read failed: [Errno 5] injected EIO")
+        km._heal_timeline_views = boom
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            out = [s["sid"] for s in km._ordered(self._sessions())]
+        self.assertEqual(out, [SID, self.FORK, SID2], "the fork slots after its same-name sibling despite the failed heal")
+        self.assertIn("views heal for %s skipped" % self.FORK, err.getvalue())
+        self.assertIn("could not be read", err.getvalue())
+        self.assertEqual(km._views_heal_pending, {self.FORK: SID}, "deferred, to be retried")
+
+    def test_ordered_survives_a_heal_whose_publish_fails_and_still_places_the_fork(self):
+        # the write-step twin, through the REAL heal: the store reads, the fork's membership is computed, the
+        # PUBLISH fails. On main that OSError left _ordered and reached every build that runs it.
+        self._seed_tag_with(SID)
+        self._stub_order([SID, SID2])
+        p = km._views_path()
+        before = p.read_bytes()
+        err = io.StringIO()
+        with _writes_fault(p), contextlib.redirect_stderr(err):
+            out = [s["sid"] for s in km._ordered(self._sessions())]
+        self.assertEqual(out, [SID, self.FORK, SID2])
+        self.assertIn("views heal for %s skipped" % self.FORK, err.getvalue())
+        self.assertIn("could not be written", err.getvalue())
+        self.assertEqual(p.read_bytes(), before, "the views file is untouched")
+
+    def test_a_deferred_heal_lands_on_a_later_pass_once_the_store_reads(self):
+        self._seed_tag_with(SID)
+        self._stub_order([SID, SID2])
+        p = km._views_path()
+        err = io.StringIO()
+        with _reads_fault(p), contextlib.redirect_stderr(err):
+            out1 = [s["sid"] for s in km._ordered(self._sessions())]
+        self.assertEqual(out1, [SID, self.FORK, SID2])
+        self.assertIn("views heal for %s skipped" % self.FORK, err.getvalue())
+        self.assertEqual(km._views_heal_pending, {self.FORK: SID})
+        self.assertIn(self.FORK, json.loads((km.jd.STATE / "session-order.json").read_text()),
+                      "the order persisted with the fork in it: without the retry the heal would never run again")
+        self._stub_order([SID, self.FORK, SID2])                          # the fork is known now; the store reads again
+        err2 = io.StringIO()
+        with contextlib.redirect_stderr(err2):
+            out2 = [s["sid"] for s in km._ordered(self._sessions())]
+        self.assertEqual(out2, [SID, self.FORK, SID2])
+        self.assertEqual(km._views_heal_pending, {}, "landed")
+        self.assertIn("views heal for %s landed on retry" % self.FORK, err2.getvalue())
+        km._flags_cache.clear()
+        members = [t for t in km._timeline_views_proved()["tags"] if t["name"] == "workers"][0]["members"]
+        self.assertIn(self.FORK, [m["sid"] for m in members], "the /clear'd session did not fall out of its tag")
+
+    def test_a_build_completes_when_the_store_faults_under_the_heal(self):
+        # end to end through the build: _ordered detects the same-name fork inside build_feed and runs the heal,
+        # whose proved read faults. The build returns a payload, the fault row is filed, the file is untouched.
+        self._seed_tag_with(SID)
+        self._stub_order([SID, SID2])
+        p = km._views_path()
+        before = p.read_bytes()
+        saved_alive = km._alive_sessions
+        km._alive_sessions = lambda now, tmux: [{"sid": SID2, "name": "api", "path": "/api", "mtime": now - 5},
+                                                {"sid": self.FORK, "name": "web", "path": "/web", "mtime": now - 1},
+                                                {"sid": SID, "name": "web", "path": "/web", "mtime": now - 9}]
+        err = io.StringIO()
+        try:
+            with _reads_fault(p), contextlib.redirect_stderr(err):
+                feed = km.build_feed(int(time.time()))
+        finally:
+            km._alive_sessions = saved_alive
+        self.assertEqual(feed.get("type"), "feed", "the build proceeded: nothing raised out of the heal")
+        self.assertIn("views heal for %s skipped" % self.FORK, err.getvalue())
+        self.assertEqual(p.read_bytes(), before)
+        # the belt behind the braces: were a store fault ever to escape a handler, the recv loop's socket-failure
+        # arm is (BrokenPipeError, ConnectionResetError, OSError) -- a plain Exception is logged, the socket kept
+        self.assertFalse(issubclass(km._StateUnreadable, OSError))
+
+
+class TagAckNamesTheFault(_ViewsFaultMixin, TagRoute):
+    """The creation event's tag half (`romp new --in`, the picker's Tags row, a fork, a promoted thread):
+    nothing is inherited or joined off a faulting store, and what did not happen is said -- in the ack's
+    `tagError`, or at the spawn sites in a notice naming the child."""
+
+    def test_romp_new_in_a_tag_under_a_read_fault_creates_nothing_and_names_the_fault(self):
+        # on main _edit_tag read the poisoned {} and CREATED "workers" anew holding only the new session -- a
+        # one-member tag over the user's set -- with tagsApplied ["workers", "reviewers"] and no tagError
+        before = self._seed("workers", "reviewers")
+        km._flags_cache.clear()
+        with _reads_fault(km._views_path()):
+            ack = km._tag_ack(DEAD, "", ["workers", "reviewers"])
+        self.assertEqual(ack["tagsRequested"], ["workers", "reviewers"])
+        self.assertEqual(ack["tagsApplied"], [None, None], "no tag was joined, positionally")
+        self.assertIn("the tag store could not be read (read failed: [Errno 5]", ack.get("tagError", ""))
+        self.assertEqual(self._bytes(), before)
+
+    def test_a_child_does_not_inherit_under_a_fault_and_the_ack_says_so(self):
+        self._seed("workers")                                    # holds "web" (SID), the parent
+        before = self._bytes()
+        km._flags_cache.clear()
+        with _reads_fault(km._views_path()):
+            ack = km._tag_ack(DEAD, SID, [])
+        self.assertIn("the tag store could not be read", ack.get("tagError", ""), "what did not happen is said")
+        self.assertEqual(ack["tags"], [])
+        self.assertEqual(self._bytes(), before)
+
+    def test_inherit_raises_under_a_fault_so_no_spawn_reads_an_empty_parent(self):
+        self._seed("workers")
+        km._flags_cache.clear()
+        with _reads_fault(km._views_path()):
+            with self.assertRaises(km._StateUnreadable):
+                km._inherit_tag_membership(SID, DEAD)
+        km._flags_cache.clear()
+        self.assertEqual(km._inherit_tag_membership(SID, DEAD), ["workers"], "…and lands once the store reads")
+
+    def test_a_spawn_site_says_what_did_not_happen(self):
+        # the fork and thread-promotion sites: the session exists by then, so the spawn stands and the child is
+        # named in one refused-kind notice (the store's own episode notice cannot say which session landed
+        # outside its group)
+        e = km._StateUnreadable(km._views_path(), "read failed: [Errno 5] Input/output error")
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            km._note_tags_not_inherited(SID, "web-2", e)
+        rows = [(t, k) for t, ok, k in self.notices if not ok]
+        self.assertEqual(len(rows), 1)
+        self.assertIn('"web-2" did not inherit the tags of', rows[0][0])
+        self.assertIn("the tag store could not be read (read failed: [Errno 5] Input/output error)", rows[0][0])
+        self.assertEqual(rows[0][1], "refused")
+        self.assertIn("did not inherit", err.getvalue())
+
+
+class LegacyHiddenEntriesSurviveAProvedRead(_ViewsFaultMixin, TagRoute):
+    """The display reader migrates a legacy blob's `hidden` entries into the archived tag on first read and
+    persists that; the normalizer DROPS `hidden`. A mutation snapshot that read the file raw would hand a
+    writer a blob without the legacy entries, and its write -- before the display reader's first read
+    after boot -- would lose every one of them. The proved reader replays the same idempotent migration
+    without persisting it; the writer's write carries it."""
+
+    LEGACY = {"active": "all", "tags": [{"id": "t1", "name": "workers", "color": "#123456", "members": [SID]}],
+              "hidden": ["44444444-2222-3333-4444-555555555555", "55555555-2222-3333-4444-555555555555"]}
+
+    def test_the_proved_snapshot_carries_the_hidden_entries_as_archived_members(self):
+        (km.jd.STATE / "timeline-views.json").write_text(json.dumps(self.LEGACY))
+        km._flags_cache.clear()
+        v = km._timeline_views_proved()
+        arch = [t for t in v["tags"] if t["name"] == "archived"]
+        self.assertEqual(len(arch), 1, "the migration is replayed on the mutation snapshot too")
+        self.assertEqual(sorted(m["sid"] for m in arch[0]["members"]), sorted(self.LEGACY["hidden"]))
+        self.assertNotIn("hidden", v)
+        self.assertEqual(json.loads((km.jd.STATE / "timeline-views.json").read_text()), self.LEGACY,
+                         "and it did NOT persist: the display reader owns that write")
+
+    def test_an_edit_before_the_first_display_read_keeps_the_legacy_entries(self):
+        # a guard (green on main too, where the display reader migrated and persisted before the edit): it pins
+        # the proved reader's replay, which a snapshot reading the file raw would fail
+        (km.jd.STATE / "timeline-views.json").write_text(json.dumps(self.LEGACY))
+        km._flags_cache.clear()
+        st, resp = self._post({"name": "workers", "add": ["api"]})   # an edit through the door, before any display read
+        self.assertTrue(resp.get("ok"), resp)
+        stored = json.loads((km.jd.STATE / "timeline-views.json").read_text())
+        arch = [t for t in stored["tags"] if t["name"] == "archived"]
+        self.assertEqual(len(arch), 1, "the edit's write carried the migrated archived tag")
+        self.assertEqual(sorted(m["sid"] for m in arch[0]["members"]), sorted(self.LEGACY["hidden"]),
+                         "the legacy hidden entries survived the edit (the normalizer would have dropped `hidden`)")
+        self.assertNotIn("hidden", stored)
+        self.assertTrue(all(t.get("mtime") for t in stored["tags"]), "every tag stamped, as the display reader's re-stamp would")
+        km._flags_cache.clear()
+        self.assertEqual(sorted(t["name"] for t in km._timeline_views()["tags"]), ["archived", "workers"])
+
+    def test_the_display_reader_still_persists_the_migration_once(self):
+        # a guard (green on main too): the display reader's write is unchanged by the proved reader
+        (km.jd.STATE / "timeline-views.json").write_text(json.dumps(self.LEGACY))
+        km._flags_cache.clear()
+        with contextlib.redirect_stderr(io.StringIO()):
+            v = km._timeline_views()
+        self.assertEqual(sorted(t["name"] for t in v["tags"]), ["archived", "workers"])
+        stored = json.loads((km.jd.STATE / "timeline-views.json").read_text())
+        self.assertNotIn("hidden", stored, "persisted: the next read has nothing to migrate")
+        self.assertEqual(sorted(t["name"] for t in stored["tags"]), ["archived", "workers"])
+
+
+class ReaderRestampIsHousekeeping(_ViewsFaultMixin, TagRoute):
+    """The reader's re-stamp on read writes through the state files' door with note=False: a publish that
+    fails there is the reader's own once-per-error log line, never a notice and never a write-fault
+    episode -- the first GESTURE that fails is what the user hears about. test_tag_edit_ack.py's
+    ReaderRestampUnwritable pins the log line; its `notices == []` cannot see a notice filed with a `kind`
+    (its stub takes none, and _note_state_fault swallows the TypeError), so this one observes the flag."""
+
+    def test_the_re_stamps_failed_publish_is_a_log_line_not_a_notice_and_the_first_gesture_is(self):
+        p = km._views_path()
+        legacy = {"active": "all", "tags": [{"id": "gL", "name": "legacy", "color": "",
+                                              "members": [{"host": "", "sid": SID}]}]}   # seq-less: the first read stamps it
+        p.write_text(json.dumps(legacy))
+        km._flags_cache.clear()
+        err = io.StringIO()
+        with _writes_fault(p), contextlib.redirect_stderr(err):
+            v = km._timeline_views()
+            self.assertEqual([t["name"] for t in v["tags"]], ["legacy"], "served as read, unstamped")
+            self.assertNotIn("seq", v)
+            lines = [ln for ln in err.getvalue().splitlines() if "could not be re-stamped" in ln]
+            self.assertEqual(len(lines), 1, "the reader's own once-per-error line")
+            self.assertIn("OSError", lines[0])
+            self.assertIn("[Errno 28]", lines[0])
+            self.assertEqual(self.notices, [], "housekeeping: no notice of any kind")
+            self.assertNotIn(str(p), km._state_write_fault_seen, "no write-fault episode opened by the re-stamp")
+            self.assertEqual(p.read_text(), json.dumps(legacy), "the file is untouched")
+            # the first GESTURE that fails on the same full disk IS the notice, and opens the episode
+            st, r = self._post({"name": "legacy", "add": ["api"]})
+            self.assertEqual((st, r["ok"], r["retryable"]), (200, False, True))
+            self.assertEqual(len(self._faults("written")), 1)
+            self.assertIn(str(p), km._state_write_fault_seen)
+
+
+class ForeignWriteBehindIsJudgedOnTheProvedRead(_ViewsFaultMixin, TagRoute):
+    """A file written OUTSIDE the kernel (the timeline's Electron/Obsidian branch writes
+    timeline-views.json itself) from an older copy, in the window before the pusher's next display read:
+    the display reader judges it against the last served blob and re-stamps it (ForeignWriteJudged in
+    test_tag_edit_ack.py). The proved reader must yield that SAME judged snapshot -- or every RMW door
+    diffs its one edit against the foreign copy, no refusal anywhere, and stamps it past everything
+    served, so every dashboard adopts the blessed stale copy."""
+
+    def test_an_edit_in_the_window_after_a_foreign_write_builds_on_the_judged_store_not_the_foreign_copy(self):
+        self._seed("workers")
+        km._flags_cache.clear()
+        older = json.loads(json.dumps(km._timeline_views()))          # a panel's copy: workers only, at T0, seq N1
+        time.sleep(1.1)                                                # tag mtimes are whole seconds
+        self._seed("reviewers")                                        # created since; the cache holds both at seq N2
+        served = km._timeline_views()
+        self.assertEqual(sorted(t["name"] for t in served["tags"]), ["reviewers", "workers"])
+        self.assertGreater(served["seq"], older["seq"])
+        p = km._views_path()
+        km._atomic_write(p, json.dumps(older))                         # the panel writes its older copy: seq behind, no cache clear
+        st, resp = self._post({"name": "workers", "color": "#123456"})   # ONE edit, no fault, inside the window
+        self.assertTrue(resp.get("ok"), resp)
+        stored = json.loads(p.read_text())
+        self.assertEqual(sorted(t["name"] for t in stored["tags"]), ["reviewers", "workers"],
+                         "the store carries the last-served content plus the one edit: the tag the foreign copy lacked is back")
+        self.assertEqual(next(t for t in stored["tags"] if t["name"] == "workers")["color"], "#123456", "the edit landed")
+        self.assertGreater(stored["seq"], served["seq"], "ordered past everything served")
+        self.assertTrue(any("outside the kernel" in t for t, ok, k in self.notices), "the foreign copy's refusal is said")
+        km._flags_cache.clear()
+        self.assertEqual(sorted(t["name"] for t in km._timeline_views()["tags"]), ["reviewers", "workers"])
 
 
 if __name__ == "__main__":

--- a/tests/test_tag_route.py
+++ b/tests/test_tag_route.py
@@ -39,7 +39,14 @@ DEAD = "33333333-4444-5555-6666-777777777777"                        # a sid no 
 REMOTE = "TESTHOST:11111111-2222-3333-4444-555555555555"             # a host-prefixed remote id
 
 
-class TagRoute(unittest.TestCase):
+class _TagRouteHarness(unittest.TestCase):
+    """The route harness alone -- the real Handler over HTTP, a private temp state dir per test, the
+    live-name stub and the HTTP helpers -- with NO tests of its own: a class that needs the harness for
+    cases of its own inherits this and runs only those. TagRoute below carries the route's fourteen cases;
+    the store-fault classes used to inherit TagRoute and re-ran them under eight more names, 112 runs that
+    told nothing new (review find, 2026-09-08). The door subclasses that predate them (HostForward and the
+    rest) still inherit TagRoute on purpose: each changes a door the fourteen exercise."""
+
     @classmethod
     def setUpClass(cls):
         cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
@@ -84,6 +91,10 @@ class TagRoute(unittest.TestCase):
             headers={"X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
         with urllib.request.urlopen(req, timeout=10) as r:
             return r.status, json.loads(r.read().decode())
+
+
+class TagRoute(_TagRouteHarness):
+    """GET /views + POST /tag through the harness: the fourteen cases every route door must pass."""
 
     def test_get_views_serves_the_normalized_default(self):
         st, v = self._views()
@@ -606,8 +617,37 @@ def _writes_fault(target):
         Path.write_text = real
 
 
+class _ClockAhead:
+    """The kernel's `time` module with time() moved `by` seconds ahead and everything else delegated. The
+    store's stamps (each tag's mtime, the blob's `at`) are whole seconds off the kernel's clock, so a case
+    that needs a later write to land in a LATER second moves the clock instead of sleeping across the
+    boundary (review find, 2026-09-08: 1.1 s of wall clock per run; the stamps live inside the blob, so a
+    file utime would not move them). Kernel-local: km.time is the name the kernel's code reads; this
+    module's `time` and the HTTP machinery's are untouched."""
+
+    def __init__(self, by):
+        self._by = by
+
+    def time(self):
+        return time.time() + self._by
+
+    def __getattr__(self, name):
+        return getattr(time, name)
+
+
+@contextlib.contextmanager
+def _clock_ahead(by):
+    saved = km.time
+    km.time = _ClockAhead(by)
+    try:
+        yield
+    finally:
+        km.time = saved
+
+
 class _ViewsFaultMixin:
-    """The store-fault harness on top of TagRoute (a mixin, so it is not collected on its own): the fault
+    """The store-fault harness on top of the route harness (_TagRouteHarness; a mixin, so it is not collected
+    on its own -- and the harness, not TagRoute, so its fourteen cases run once, review find 2026-09-08): the fault
     registries and the deferred-heal map start and end empty (process-wide state -- a fault filed here
     must not silence a later test's), the notice ring is captured WITH the kind the fault machinery files
     under (a two-argument stub raises on `kind=`, and the machinery's own try swallows the notice), and
@@ -654,7 +694,7 @@ class _ViewsFaultMixin:
         return [(t, k) for t, ok, k in self.notices if not ok and "timeline-views.json could not be %s" % what in t]
 
 
-class ViewsStoreUnreadableRefuses(_ViewsFaultMixin, TagRoute):
+class ViewsStoreUnreadableRefuses(_ViewsFaultMixin, _TagRouteHarness):
     """A store that EXISTS but cannot be read. The mutation path refuses in its own shape and writes nothing;
     the judge never folds; the display path serves what it last knew, caches nothing from the fault, and
     says so once per episode."""
@@ -718,6 +758,19 @@ class ViewsStoreUnreadableRefuses(_ViewsFaultMixin, TagRoute):
             self.assertEqual(km._timeline_views()["tags"], [], "the display reader agrees: empty now, not a fault")
         self.assertEqual(self._faults(), [], "a quarantine is a stated event, not a read fault")
 
+    def test_the_quarantine_notice_names_the_tags_and_lenses_it_held_not_settings(self):
+        # review find, 2026-09-08: the notice said "the settings it held start over", the words for the flags,
+        # order and bell stores; the views store holds the user's tags and lenses, and the notice says so
+        p = km._views_path()
+        p.write_bytes(b'{"active": "all", "tags": [ THIS IS NOT JSON')
+        km._flags_cache.clear()
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._timeline_views()
+        rows = [t for t, ok, k in self.notices if "moved aside" in t and k == "refused"]
+        self.assertEqual(len(rows), 1, rows)
+        self.assertIn("the tags and lenses it held start over empty until you set them again", rows[0])
+        self.assertNotIn("settings", rows[0])
+
     def test_enoent_views_reads_empty_with_no_quarantine_and_no_fault_filed(self):
         try:
             km._views_path().unlink()
@@ -732,15 +785,18 @@ class ViewsStoreUnreadableRefuses(_ViewsFaultMixin, TagRoute):
 
     def test_a_display_read_fault_never_raises_into_the_build_and_is_loud_once_per_episode(self):
         # build_feed / build_timeline / build_session run under _push's ONE outer try, so a display reader
-        # that RAISED would abort every client's push. The display path serves the empty default here (a
-        # cold cache: nothing known-good yet), UNPROVED, and files exactly ONE notice per fault episode.
+        # that RAISED would abort every client's push. The display path has nothing known-good here (a cold
+        # cache), so the feed carries the fault marker and NO blob (review find, 2026-09-08: the seq-less
+        # empty default it carried was adopted by every dashboard as the store's word), and files exactly
+        # ONE notice per fault episode.
         self._seed("workers")
         km._flags_cache.clear()
         with _reads_fault(km._views_path()):
             feed1 = km.build_feed(int(time.time()))
             self.assertEqual(feed1.get("type"), "feed", "build_feed still returns a payload: the board is not wedged")
-            self.assertIn("views", feed1)
-            self.assertEqual(feed1["views"]["tags"], [], "the unreadable store serves the empty default, not a crash")
+            self.assertNotIn("views", feed1, "nothing known-good: no blob, so no dashboard adopts an empty store")
+            self.assertIn("the tag store could not be read (read failed: [Errno 5]", feed1["viewsFault"],
+                          "the frame says why it carries no tags")
             self.assertEqual(len(self._faults()), 1, "exactly ONE notice the first time the fault is seen")
             self.assertIn("timeline-views.json could not be read (read failed: [Errno 5]", self._faults()[0][0])
             self.assertEqual(self._faults()[0][1], "refused")
@@ -807,7 +863,7 @@ class ViewsStoreUnreadableRefuses(_ViewsFaultMixin, TagRoute):
         self.assertEqual(p.read_text(), json.dumps(legacy), "no re-stamp was written")
 
 
-class ViewsWsRefusal(_ViewsFaultMixin, TagRoute):
+class ViewsWsRefusal(_ViewsFaultMixin, _TagRouteHarness):
     """The two dashboard doors under a store fault, through the real dispatcher: the poster is answered on
     its own socket with the fault in the person's words, the file is untouched, the socket lives."""
 
@@ -906,7 +962,7 @@ class ViewsWsRefusal(_ViewsFaultMixin, TagRoute):
         self.assertEqual(sorted(t["name"] for t in km._timeline_views()["tags"]), ["reviewers", "workers"])
 
 
-class ViewsStoreUnwritableRefuses(_ViewsFaultMixin, TagRoute):
+class ViewsStoreUnwritableRefuses(_ViewsFaultMixin, _TagRouteHarness):
     """The views store READS but its PUBLISH fails (ENOSPC, EROFS, EACCES): the write step is a fault
     boundary too. On main the OSError out of _atomic_write escaped _edit_tag to do_POST's catch-all -- a
     500 traceback, which `romp tag` (curl -sf) reports as an unreachable kernel and a federation forward
@@ -944,7 +1000,7 @@ class ViewsStoreUnwritableRefuses(_ViewsFaultMixin, TagRoute):
         self.assertFalse(km._views_path().exists(), "nothing was published")
 
 
-class HealHasABoundaryInTheBuild(_ViewsFaultMixin, TagRoute):
+class HealHasABoundaryInTheBuild(_ViewsFaultMixin, _TagRouteHarness):
     """_heal_timeline_views (a /clear or revive inherits its session's tag memberships) runs inside _ordered,
     inside every build. It reads PROVED once and hands its snapshot to the setter; a fault raises to
     _ordered's boundary, which places the fork, defers the heal and retries it on later passes -- the order
@@ -1075,8 +1131,60 @@ class HealHasABoundaryInTheBuild(_ViewsFaultMixin, TagRoute):
         # arm is (BrokenPipeError, ConnectionResetError, OSError) -- a plain Exception is logged, the socket kept
         self.assertFalse(issubclass(km._StateUnreadable, OSError))
 
+    def _heal_rows(self):
+        """The deferred heal's bell rows (text, kind): what the dashboard hears of a /clear'd session that sits
+        outside its tag while the store faults."""
+        return [(t, k) for t, ok, k in self.notices if not ok and "did not carry its tags" in t]
 
-class TagAckNamesTheFault(_ViewsFaultMixin, TagRoute):
+    def test_a_deferred_heal_rings_the_bell_once_and_the_retry_stays_quiet_while_the_store_still_faults(self):
+        # review find, 2026-09-08: the deferral was a stderr line alone, which dies with the process while the
+        # session sits outside its tag; the fork and promotion sites file a bell row for the same non-event. Now
+        # the boundary files one too, under the refused kind, naming the session -- ONCE: the two quiet arms of
+        # the retry (the fork re-detected as new while its heal is pending, as after a failed order publish; and
+        # the pending heal's retry while the store still faults) add no line and no row
+        self._seed_tag_with(SID)
+        self._stub_order([SID, SID2])
+        p = km._views_path()
+        before = p.read_bytes()
+        err = io.StringIO()
+        with _reads_fault(p), contextlib.redirect_stderr(err):
+            km._ordered(self._sessions())                                  # pass 1: deferred, said once
+            km._ordered(self._sessions())                                  # pass 2: the order still lacks the fork, heal pending
+            self._stub_order([SID, self.FORK, SID2])
+            km._ordered(self._sessions())                                  # pass 3: the retry, the store still faulting
+        self.assertEqual(err.getvalue().count("views heal for %s skipped" % self.FORK), 1, "the skip line once per deferral")
+        self.assertNotIn("landed", err.getvalue())
+        rows = self._heal_rows()
+        self.assertEqual([k for t, k in rows], ["refused"], "ONE bell row, under the refused kind, like the spawn sites: %r" % rows)
+        self.assertIn('"web" did not carry its tags across a /clear or revive: the tag store could not be read (read failed: [Errno 5]',
+                      rows[0][0])
+        self.assertIn("tag it again if the kernel restarts first", rows[0][0], "the row says what a restart costs")
+        self.assertEqual(km._views_heal_pending, {self.FORK: SID}, "still pending: the next pass retries it")
+        self.assertEqual(p.read_bytes(), before, "nothing written under the fault")
+
+    def test_a_retried_heal_with_nothing_to_carry_settles_and_says_which(self):
+        # the landing arm's other branch: the session held no tag, so the retry carries nothing and writes nothing,
+        # and the deferral is over -- the map entry is popped (without that the retry would run on every pass)
+        # and the bell keeps the deferral's one row
+        self._seed_tag_with(SID2)                                          # a store that exists; "web" is in no tag
+        self._stub_order([SID, SID2])
+        p = km._views_path()
+        with _reads_fault(p), contextlib.redirect_stderr(io.StringIO()):
+            km._ordered(self._sessions())
+        self.assertEqual(km._views_heal_pending, {self.FORK: SID})
+        self.assertEqual(len(self._heal_rows()), 1, "the deferral rang once")
+        before = p.read_bytes()
+        self._stub_order([SID, self.FORK, SID2])
+        err2 = io.StringIO()
+        with contextlib.redirect_stderr(err2):
+            km._ordered(self._sessions())
+        self.assertEqual(km._views_heal_pending, {}, "settled: nothing to carry is an answer, not a fault")
+        self.assertIn("views heal for %s retried: nothing to carry" % self.FORK, err2.getvalue())
+        self.assertEqual(p.read_bytes(), before, "no write: a heal with nothing to carry publishes nothing")
+        self.assertEqual(len(self._heal_rows()), 1, "the landing adds no row: the bell said what did not happen, once")
+
+
+class TagAckNamesTheFault(_ViewsFaultMixin, _TagRouteHarness):
     """The creation event's tag half (`romp new --in`, the picker's Tags row, a fork, a promoted thread):
     nothing is inherited or joined off a faulting store, and what did not happen is said -- in the ack's
     `tagError`, or at the spawn sites in a notice naming the child."""
@@ -1128,7 +1236,7 @@ class TagAckNamesTheFault(_ViewsFaultMixin, TagRoute):
         self.assertIn("did not inherit", err.getvalue())
 
 
-class LegacyHiddenEntriesSurviveAProvedRead(_ViewsFaultMixin, TagRoute):
+class LegacyHiddenEntriesSurviveAProvedRead(_ViewsFaultMixin, _TagRouteHarness):
     """The display reader migrates a legacy blob's `hidden` entries into the archived tag on first read and
     persists that; the normalizer DROPS `hidden`. A mutation snapshot that read the file raw would hand a
     writer a blob without the legacy entries, and its write -- before the display reader's first read
@@ -1178,7 +1286,7 @@ class LegacyHiddenEntriesSurviveAProvedRead(_ViewsFaultMixin, TagRoute):
         self.assertEqual(sorted(t["name"] for t in stored["tags"]), ["archived", "workers"])
 
 
-class ReaderRestampIsHousekeeping(_ViewsFaultMixin, TagRoute):
+class ReaderRestampIsHousekeeping(_ViewsFaultMixin, _TagRouteHarness):
     """The reader's re-stamp on read writes through the state files' door with note=False: a publish that
     fails there is the reader's own once-per-error log line, never a notice and never a write-fault
     episode -- the first GESTURE that fails is what the user hears about. test_tag_edit_ack.py's
@@ -1210,7 +1318,7 @@ class ReaderRestampIsHousekeeping(_ViewsFaultMixin, TagRoute):
             self.assertIn(str(p), km._state_write_fault_seen)
 
 
-class ForeignWriteBehindIsJudgedOnTheProvedRead(_ViewsFaultMixin, TagRoute):
+class ForeignWriteBehindIsJudgedOnTheProvedRead(_ViewsFaultMixin, _TagRouteHarness):
     """A file written OUTSIDE the kernel (the timeline's Electron/Obsidian branch writes
     timeline-views.json itself) from an older copy, in the window before the pusher's next display read:
     the display reader judges it against the last served blob and re-stamps it (ForeignWriteJudged in
@@ -1222,23 +1330,116 @@ class ForeignWriteBehindIsJudgedOnTheProvedRead(_ViewsFaultMixin, TagRoute):
         self._seed("workers")
         km._flags_cache.clear()
         older = json.loads(json.dumps(km._timeline_views()))          # a panel's copy: workers only, at T0, seq N1
-        time.sleep(1.1)                                                # tag mtimes are whole seconds
-        self._seed("reviewers")                                        # created since; the cache holds both at seq N2
-        served = km._timeline_views()
-        self.assertEqual(sorted(t["name"] for t in served["tags"]), ["reviewers", "workers"])
-        self.assertGreater(served["seq"], older["seq"])
+        with _clock_ahead(2):                                          # the stamps are whole seconds: what follows lands in a later second
+            self._seed("reviewers")                                    # created since; the cache holds both at seq N2
+            served = km._timeline_views()
+            self.assertEqual(sorted(t["name"] for t in served["tags"]), ["reviewers", "workers"])
+            self.assertGreater(served["seq"], older["seq"])
+            p = km._views_path()
+            km._atomic_write(p, json.dumps(older))                     # the panel writes its older copy: seq behind, no cache clear
+            st, resp = self._post({"name": "workers", "color": "#123456"})   # ONE edit, no fault, inside the window
+            self.assertTrue(resp.get("ok"), resp)
+            stored = json.loads(p.read_text())
+            self.assertEqual(sorted(t["name"] for t in stored["tags"]), ["reviewers", "workers"],
+                             "the store carries the last-served content plus the one edit: the tag the foreign copy lacked is back")
+            self.assertEqual(next(t for t in stored["tags"] if t["name"] == "workers")["color"], "#123456", "the edit landed")
+            self.assertGreater(stored["seq"], served["seq"], "ordered past everything served")
+            self.assertTrue(any("outside the kernel" in t for t, ok, k in self.notices), "the foreign copy's refusal is said")
+            km._flags_cache.clear()
+            self.assertEqual(sorted(t["name"] for t in km._timeline_views()["tags"]), ["reviewers", "workers"])
+
+
+class AFaultWithNothingGoodToShowSaysSo(_ViewsFaultMixin, _TagRouteHarness):
+    """The frames and the acks under a READ fault (review find, 2026-09-08). The display reader serves the
+    last blob this kernel served, UNPROVED, and every carrier -- the tabOrder frame, the feed, the timeline
+    skeleton, every write's ack -- embedded it as the store's word; with a COLD cache (a kernel that had never
+    served the store) they embedded the seq-less empty default, which every dashboard adopts: the tag bar
+    emptied with the fault said only on the bell, and a poster reverting on a refusal took that emptiness as
+    its base. Now _views_payload builds every carrier from ONE display read: a blob rides MARKED
+    (`viewsFault`, the fault in the person's words) when there is one, and with none the carrier holds the
+    marker alone and no `views` key, which every pane reads as "keep what you hold". A clean read adds no
+    key, so a clean frame and a clean ack are what they were."""
+
+    LENS = ViewsWsRefusal.LENS
+
+    def setUp(self):
+        super().setUp()
+        self._saved_alive = km._alive_sessions
+        km._alive_sessions = lambda now, tmux: []                          # build_feed with no sessions: the frame's views half is the subject
+
+    def tearDown(self):
+        km._alive_sessions = self._saved_alive
+        super().tearDown()
+
+    def test_a_cold_cache_fault_puts_the_marker_alone_on_every_frame_and_no_empty_store(self):
+        self._seed("workers", "reviewers")
+        km._flags_cache.clear()                                            # a kernel that never served the store
+        with _reads_fault(km._views_path()), contextlib.redirect_stderr(io.StringIO()):
+            frame = km._tab_order_frame([SID], [{"id": SID}], {SID})
+            feed = km.build_feed(int(time.time()))
+            payload = km._views_payload()
+        self.assertEqual((frame["type"], feed["type"]), ("tabOrder", "feed"), "the build proceeded")
+        for f in (frame, feed, payload):
+            self.assertNotIn("views", f, "no blob: a seq-less empty default here is adopted by every dashboard as the store's word")
+            self.assertIn("the tag store could not be read (read failed: [Errno 5]", f["viewsFault"])
+        self.assertEqual(frame["live"], [SID], "the rest of the frame is whole")
+        self.assertEqual(len(self._faults()), 1, "the once-per-episode notice still rides the bell")
+
+    def test_a_warm_cache_fault_carries_the_last_served_blob_and_marks_it(self):
+        self._seed("workers", "reviewers")                                  # the writes primed the cache
+        good = km._timeline_views()
         p = km._views_path()
-        km._atomic_write(p, json.dumps(older))                         # the panel writes its older copy: seq behind, no cache clear
-        st, resp = self._post({"name": "workers", "color": "#123456"})   # ONE edit, no fault, inside the window
-        self.assertTrue(resp.get("ok"), resp)
-        stored = json.loads(p.read_text())
-        self.assertEqual(sorted(t["name"] for t in stored["tags"]), ["reviewers", "workers"],
-                         "the store carries the last-served content plus the one edit: the tag the foreign copy lacked is back")
-        self.assertEqual(next(t for t in stored["tags"] if t["name"] == "workers")["color"], "#123456", "the edit landed")
-        self.assertGreater(stored["seq"], served["seq"], "ordered past everything served")
-        self.assertTrue(any("outside the kernel" in t for t, ok, k in self.notices), "the foreign copy's refusal is said")
+        p.write_bytes(p.read_bytes() + b"\n")                               # the file moved under the cache (a write outside the
+        #                                                                     kernel): the next display read must read it, and cannot
+        with _reads_fault(p), contextlib.redirect_stderr(io.StringIO()):
+            frame = km._tab_order_frame([SID], [{"id": SID}], {SID})
+        self.assertEqual(sorted(t["name"] for t in frame["views"]["tags"]), ["reviewers", "workers"])
+        self.assertEqual(frame["views"]["seq"], good["seq"], "the last blob served, at its seq: no dashboard moves")
+        self.assertIn("the tag store could not be read (read failed: [Errno 5]", frame["viewsFault"], "and it is said to be unproved")
+        with _stat_fault(p), contextlib.redirect_stderr(io.StringIO()):      # the stat-fault arm: the same answer
+            frame2 = km._tab_order_frame([SID], [{"id": SID}], {SID})
+        self.assertEqual(frame2["views"], frame["views"])
+        self.assertIn("the tag store could not be read (stat failed:", frame2["viewsFault"])
+
+    def test_a_clean_read_adds_no_marker_so_a_clean_frame_is_what_it_was(self):
+        self._seed("workers")
+        frame = km._tab_order_frame([SID], [{"id": SID}], {SID})
+        self.assertNotIn("viewsFault", frame)
+        self.assertEqual([t["name"] for t in frame["views"]["tags"]], ["workers"])
+        self.assertEqual(set(km._views_payload()), {"views"})
+
+    def test_a_refusal_ack_on_a_cold_cache_carries_the_marker_and_no_blob(self):
+        before = self._seed("workers", "reviewers")
         km._flags_cache.clear()
-        self.assertEqual(sorted(t["name"] for t in km._timeline_views()["tags"]), ["reviewers", "workers"])
+        client, sent = self._client()
+        with _reads_fault(km._views_path()), contextlib.redirect_stderr(io.StringIO()):
+            self._ws({"type": "setTimelineViews", "writeId": "w1", "edited": [], "views": dict(self.LENS)}, client)
+        ack = sent[0]
+        self.assertEqual((ack["type"], ack["ok"]), ("viewsAck", False))
+        self.assertNotIn("views", ack, "a poster reverting on this refusal keeps what it holds")
+        self.assertIsNone(ack["seq"])
+        self.assertIn("the tag store could not be read", ack["viewsFault"])
+        self.assertIn("nothing was changed", ack["error"])
+        self.assertEqual(self._bytes(), before)
+
+    def test_a_refusal_ack_on_a_warm_cache_carries_the_last_served_blob_marked_and_a_clean_ack_no_marker(self):
+        self._seed("workers", "reviewers")
+        good = km._timeline_views()
+        client, sent = self._client()
+        with _stat_fault(km._views_path()), contextlib.redirect_stderr(io.StringIO()):   # a warm cache: the file's key cannot be checked
+            self._ws({"type": "tagEdit", "writeId": "w2", "edit": {"op": "create", "name": "api", "sids": [SID2]}}, client)
+        ack = sent[0]
+        self.assertEqual((ack["type"], ack["ok"]), ("tagEditAck", False))
+        self.assertEqual(sorted(t["name"] for t in ack["views"]["tags"]), ["reviewers", "workers"])
+        self.assertEqual(ack["seq"], good["seq"], "the ack's seq is the blob's, the last one served")
+        self.assertIn("the tag store could not be read (stat failed:", ack["viewsFault"])
+        self.assertIn("nothing was changed", ack["error"])
+        client2, sent2 = self._client()
+        self._ws({"type": "setTimelineViews", "writeId": "w3", "edited": [], "views": dict(self.LENS)}, client2)
+        clean = sent2[0]
+        self.assertTrue(clean["ok"], clean)
+        self.assertNotIn("viewsFault", clean, "a proved read carries no marker")
+        self.assertEqual(clean["seq"], clean["views"]["seq"])
 
 
 if __name__ == "__main__":

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -260,13 +260,15 @@ class TimelineViews(unittest.TestCase):
 
     def test_payloads_echo_the_views_blob(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
-        self.assertIn('"views": _views_client(),', src, "the timeline payload carries the RENDERED shape")
+        self.assertIn('**_views_payload(),', src, "the timeline payload carries the RENDERED shape (through the one carrier, which marks "
+                      "a blob a read fault left unproved or sends the marker alone, 2026-09-08)")
         self.assertIn('"palette": pal.colors(_palette_name()),', src, "and the palette, for tag colors in every host")
         self.assertIn('_tab_order_frame(tab_order, tab_meta, tmux)', src, "tabOrder pushes carry it (the one frame builder, T258)")
-        # every tabOrder frame is built by ONE helper (2026-09-06: the frame also carries selfHost)
+        # every tabOrder frame is built by ONE helper (2026-09-06: the frame also carries selfHost; 2026-09-08: the
+        # views ride the one carrier, which marks a blob a read fault left unproved or sends the marker alone)
         self.assertIn('return {"type": "tabOrder", "order": list(order), "tabs": tabs, "selfHost": _self_host(),\n'
-                      '            "views": _views_client(), "live": sorted({str(x) for x in live})}', src, "tabOrder frames carry it")
-        self.assertIn('"views": _views_client(), "live":', src, "…which carries the blob")
+                      '            **_views_payload(), "live": sorted({str(x) for x in live})}', src, "tabOrder frames carry it")
+        self.assertIn('**_views_payload(), "live":', src, "…which carries the blob")
         self.assertIn('_frame = _tab_order_frame(_o, _tabs, _tm)', src, "the connect-time tabOrder carries it")
 
     def test_web_boot_exposes_the_set_views_hook(self):

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -786,7 +786,7 @@ class TagInheritance(unittest.TestCase):
         km._atomic_write(km._views_path(), json.dumps(served))
         km._flags_cache.clear()
         entered, release = threading.Event(), threading.Event()
-        real_read = km._timeline_views
+        real_read = km._timeline_views_proved   # the RMW doors' seam (a proved read)
         inheriting = []
         def stalled_read():
             v = real_read()
@@ -794,7 +794,7 @@ class TagInheritance(unittest.TestCase):
                 entered.set()             # parked INSIDE the locked window: after the read, before the write
                 release.wait(5)
             return v
-        km._timeline_views = stalled_read
+        km._timeline_views_proved = stalled_read
         got = []
         def inherit():
             inheriting.append(threading.current_thread())
@@ -816,7 +816,7 @@ class TagInheritance(unittest.TestCase):
             release.set()
             t1.join(5)
             t2.join(5)
-            km._timeline_views = real_read
+            km._timeline_views_proved = real_read
         self.assertEqual(got, [["pool"]])
         self.assertIn(self.C, self._members("pool"), "the inherit's write landed; the dashboard's stale copy could not strip it")
 
@@ -835,7 +835,7 @@ class TagInheritance(unittest.TestCase):
         km._atomic_write(km._views_path(), json.dumps(served))
         km._flags_cache.clear()
         entered, release = threading.Event(), threading.Event()
-        real_read = km._timeline_views
+        real_read = km._timeline_views_proved   # the RMW doors' seam (a proved read)
         healing = []
         def stalled_read():
             v = real_read()
@@ -843,7 +843,7 @@ class TagInheritance(unittest.TestCase):
                 entered.set()             # parked INSIDE the heal's window: after its read, before its write
                 release.wait(5)
             return v
-        km._timeline_views = stalled_read
+        km._timeline_views_proved = stalled_read
         def heal():
             healing.append(threading.current_thread())
             km._heal_timeline_views("old", "new")
@@ -861,7 +861,7 @@ class TagInheritance(unittest.TestCase):
             release.set()
             t1.join(5)
             t2.join(5)
-            km._timeline_views = real_read
+            km._timeline_views_proved = real_read
         self.assertEqual(sorted(self._members("pool")), ["new", "old", "other"], "both writers landed whole, in turn")
         self.assertEqual(len(edited), 1)
         self.assertIsNone(edited[0][1], "the edit was not refused")

--- a/ui/webview/feed-unscoped.test.ts
+++ b/ui/webview/feed-unscoped.test.ts
@@ -35,9 +35,9 @@ test("the coupling's artifacts are fully retired: cue, N-outside line, promoted 
 });
 
 test("the kernel's views blob serves the tabs/timeline; the feed payload carries it again for the tag mounts", () => {
-  assert.ok(KERNEL.includes('"views": _views_client(), "live": sorted({str(x) for x in live})}'), "tabOrder pushes keep the blob (tabs + timeline consume it; the one frame builder, T258)");
+  assert.ok(KERNEL.includes('**_views_payload(), "live": sorted({str(x) for x in live})}'), "tabOrder pushes keep the blob (tabs + timeline consume it; the one frame builder, T258; since 2026-09-08 through _views_payload, which marks a blob a read fault left unproved or sends the marker alone)");
   const fp = KERNEL.slice(KERNEL.indexOf('return {"type": "feed", "asks": asks'), KERNEL.indexOf('"clearNotices"'));
   // retired 2026-08-25 morning as unread; REVIVED the same day for the per-surface tag lenses —
   // the outline pane and the feed's own tag filter read the rendered blob off this payload
-  assert.ok(fp.includes('"views": _views_client()'), "the tag mounts' read");
+  assert.ok(fp.includes('**_views_payload()'), "the tag mounts' read");
 });

--- a/ui/webview/tag-mounts.test.ts
+++ b/ui/webview/tag-mounts.test.ts
@@ -72,7 +72,7 @@ test("the chat strip and the outline both mount the shared component (source pin
   assert.match(FLEET, /Object\.assign\(\{\}, v\.actives, \{ outline: l \}\)/);
   assert.match(FLEET, /if \(!lensVisible\(outlineLens, outlineUnions, s\.sid\)\) continue;/);
   assert.match(FLEET, /fleetViews = m\.views as SessionViews/, "the outline reads views off the feed payload");
-  assert.match(KERNEL, /"views": _views_client\(\),   # the rendered views blob — the outline \+ feed tag mounts read it/);
+  assert.match(KERNEL, /\*\*_views_payload\(\),   # the rendered views blob — the outline \+ feed tag mounts read it/);
 });
 
 test("the chat's menu carries the 'Group tabs by tag' switch at its foot; the phone mount does not (its strip is hidden)", () => {


### PR DESCRIPTION
Re-verified on `main` today: the timeline views store, which holds every tag and lens, folded a stat fault, a read fault or torn JSON into an empty store and cached it under the file's real key, so after one I/O error the store read as empty until the file's stat changed. Every writer then persisted that emptiness under a success acknowledgement: a tag create from the dashboard wrote a one-tag store over the user's whole tag set; a lens or order write from the dashboard carried an empty edit list, the judge's lens-only arm kept the empty base, and the store landed with no tags; the HTTP tag route did the same and answered ok; `romp new --in <tag>` created a fresh one-member tag and erased the rest. A rename, recolor or delete by id got a loud but wrong "that tag no longer exists". Worse, the display path served the empty store to every dashboard, and since the normalized empty carries no sequence the clients adopted it: the tag bar emptied with no notice, and the next lens click made it permanent. Nothing filed a fault, though the fault machinery from #1019 and #1020 exists and its docstrings said the views store would follow.

## What changes

**The display read never caches a fault and always says so.** `_timeline_views` reads through `_read_state_json`. A stat or read fault files one fault notice per episode and serves the last good cached blob, uncached; a missing file reads as empty and clears the fault; a torn file is quarantined aside once and then reads as empty.

**Every read-modify-write door reads a proved store.** `_timeline_views_proved` raises on a fault, never folds. The tag edit, the member move, the heal, the tag inheritance and the judge's base all read through it; the judge's own fold to empty is gone. `_write_timeline_views` publishes through `_write_state_json`.

**Every door has a boundary that says what did not happen.** The HTTP tag route answers its refusal shape with `retryable`; the two WebSocket arms acknowledge a fault in the person's words ahead of the generic arm; `romp new --in` reports the tag it could not join; the fork and promote paths report an inheritance that did not land; the heal inside the ordering pass is deferred and retried on every later pass until it lands, one line at the skip and one at the landing.

## Judgment calls

- Under a fault the display serves the last good blob rather than empty, because an empty board that looks current is the silent-staleness failure this repo forbids; a quarantined file reads as empty because the quarantine is a stated event.
- The re-stamp on the display path writes without a notice: two existing test classes pin "a log line, not a notice" for that arm, and they had been passing only by accident, since their harness stubs raise on a notice kind and `_note_state_fault` swallowed that.
- The deferred heal lives in memory; a restart loses a still-pending heal, and the skip line says so.
- Remaining gap, stated: a kernel that has never served the store has no last good blob, so under a fault it still serves a sequence-less empty that dashboards adopt. The write side is closed regardless, and the notice now says why the board is empty.
- One existing pin moved: a torn file used to be asserted left in place; it is now asserted moved aside, never overwritten, with the store reading empty.

## Tests

`tests/test_tag_route.py`: six fault classes over the tag-route harness with stat, read and write fault injectors. The route refuses instead of landing a one-tag store; the display serves the last good tags under a stat fault and caches nothing from it; the judge raises rather than folding; a torn file is quarantined; a missing file reads empty; the legacy hidden entries survive a proved read; a lens write and a create through the WebSocket are refused with the fault named, not acknowledged; a rename by id under a fault is refused as a fault, not as a vanished tag; a publish fault is refused in the person's words on both doors; the ordering pass survives a faulting heal and retries it until it lands; `romp new --in` reports the join it could not make. Each fails on `main` with the first error the commit body names; two guards are marked. `tests/test_tag_edit_ack.py` holds the moved pin; `tests/test_timeline_views.py`'s two lock-window tests stub the proved reader the doors now call.

Module runs on this branch, one at a time: `test_tag_route` 244, `test_tag_edit_ack` 94, `test_timeline_views` 44, `test_tag_federation_v2` 24, `test_fork_route` 8, `test_comment_threads` 108, `test_kernel_fork` 15, all green. On `main` the new cases are red: `test_tag_route` 27 failed / 217 passed (exactly the new fault cases; the two declared guards pass there), `test_kernel_fork` 1 / 14, `test_comment_threads` 1 / 107. Three mutants applied and run: the move door reading the display reader, the re-stamp writing with a notice, and the in-lock re-stat folding to empty, each fails its one target test.

## Review
Reviewed by twenty read-only agents (two lenses, two skeptics per finding). Five findings confirmed and folded: the first cut's proved reader replayed only the unjudged re-stamp cases on a cache-key mismatch, so a stale copy written outside the kernel would have become an edit's diff base and been stamped past everything served (main judged it first); it now replays the judged case with the last-served blob as base, unpersisted, and the edit's own write persists the judgment. The other four were coverage: a move under a fault, the quiet re-stamp flag observed by a kind-aware notice stub, the fork and promotion sites under a fault, and the in-lock re-stat re-entry. Four findings refuted as pre-existing or already pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
