### PR TITLE
T252c: the kernel's queued copies carry an identity, and the chat places by it

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21157,9 +21157,11 @@ def _pending_queued(path):
 
 def _pending_queued_meta(path):
     """_pending_queued's copies with what the CLI's ledger knows about each (T252c): the enqueue record's
-    stamp (`qts`, epoch ms) and an id digested from (stamp, text) (`qid`, stable across folds). The ledger
-    carries no ids and the kernel never sees the CLI take a copy, so nothing pairs a tmux landing with its
-    copy — the landed atom carries no qid on this route; the chat falls back to text there."""
+    stamp (`qts`, epoch ms) and NO id. The ledger carries none, the kernel's tmux echo is minted before the
+    CLI writes the enqueue record, and the kernel never sees the CLI take a copy — so nothing else in the
+    chain could share an id the ledger copy wore, and an id the chat latched from it would make it reject
+    the echo and the landing as another send's (the review of the first cut). The chat reads this route
+    by text; `qid` is None on every copy."""
     def step(pending, o):
         if o.get("type") != "queue-operation":
             return pending
@@ -21181,8 +21183,7 @@ def _pending_queued_meta(path):
             continue
         t = em.parse_z(ts) if isinstance(ts, str) else None
         qts = int(t * 1000) if isinstance(t, (int, float)) and t else None
-        qid = "tq:" + hashlib.sha1(("%s\n%s" % (qts, text.strip())).encode()).hexdigest()[:16]
-        out.append({"md": text.strip(), "qid": qid, "qts": qts})
+        out.append({"md": text.strip(), "qid": None, "qts": qts})
     return out
 
 
@@ -27744,13 +27745,18 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
                             # it FIFO per text, at or after the feed — so the chat retires and places its
                             # pending bubble by id, never by text. None on the tmux route or for a record
                             # from before this kernel's life; the chat falls back to text then.
-                            if hasattr(be, "qid_for_landing"):
+                            if hasattr(be, "qids_for_landing") and not a.get("_echo_text") and not str(a.get("uuid") or "").startswith("echo:"):
+                                # per text BLOCK: a record the CLI wrote from several queued sends is one landing per
+                                # block; the kernel's own echo atom is skipped — its uuid IS the copy's id
+                                _tblocks = [b.get("text", "") for b in (blocks or []) if b.get("type") == "text" and (b.get("text") or "").strip()] or [text]
                                 try:
-                                    _q = be.qid_for_landing(sid, a.get("uuid"), text, a.get("t"))
+                                    _qs = be.qids_for_landing(sid, a.get("uuid"), _tblocks, a.get("t"))
                                 except Exception:
-                                    _q = None
-                                if _q:
-                                    ev["qid"] = _q
+                                    _qs = []
+                                if len(_tblocks) > 1 and any(_qs):
+                                    ev["qids"] = list(_qs)
+                                elif len(_tblocks) == 1 and _qs and _qs[0]:
+                                    ev["qid"] = _qs[0]
                             if a.get("absorbed"):
                                 # A mid-turn splice (event_model._absorbed): the CLI queued this send
                                 # behind the running turn and took it at a later tool boundary, so the
@@ -28149,7 +28155,11 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
         if queued and hasattr(_cbe, "pending_queued_meta"):
             try:
                 _mm = _cbe.pending_queued_meta(sid)
-                if isinstance(_mm, list) and len(_mm) == len(queued):
+                # accepted only when each id sits beside ITS OWN text: the queue can move between the two reads
+                # this build makes (a pop and an append keep the length and shift every id by one), and a copy
+                # wearing another copy's id would be latched by the chat for good (review of the first cut)
+                if isinstance(_mm, list) and len(_mm) == len(queued) \
+                        and all(isinstance(x, dict) and (x.get("md") or "").strip() == (queued[i] or "").strip() for i, x in enumerate(_mm)):
                     _metas = _mm
             except Exception:
                 _metas = None

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -28175,9 +28175,10 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
                 continue
             goal, body, fu, ctx = _split_followup(t)
             m = {"md": body, "idx": i, "cancelable": cancelable, **_queued_romp_flags(t)}   # idx ↔ the backend's _pending position (cancelQueued)
-            if _metas and isinstance(_metas[i], dict) and _metas[i].get("qid"):
-                m["qid"] = _metas[i]["qid"]
-                if isinstance(_metas[i].get("qts"), int):
+            if _metas and isinstance(_metas[i], dict):          # the copy's identity and stamp: each rides on its own
+                if _metas[i].get("qid"):                          # (a tmux copy has a stamp and no id — third review)
+                    m["qid"] = _metas[i]["qid"]
+                if isinstance(_metas[i].get("qts"), int) and not isinstance(_metas[i].get("qts"), bool):
                     m["qts"] = _metas[i]["qts"]
             if fu:
                 m["followUp"] = True

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14892,6 +14892,10 @@ class TmuxBackend(sb.SessionBackend):
         p = _path_of(str(sid))
         return _pending_queued(p) if p else []
 
+    def pending_queued_meta(self, sid):
+        p = _path_of(str(sid))
+        return _pending_queued_meta(p) if p else []
+
     def live_atoms(self, sid):
         return _tmux_echo_atoms(str(sid))
 
@@ -21148,22 +21152,38 @@ def _pending_queued(path):
     (live corpus: one such remove in 305, and it is where a credited dequeue had already taken the entry)."""
     # A queue LEDGER: a dequeue resolves the OLDEST entry, which can predate any window, so this folds
     # append-incrementally over the whole record list (_fold_records) with the pending list carried.
+    return [m["md"] for m in _pending_queued_meta(path)]
+
+
+def _pending_queued_meta(path):
+    """_pending_queued's copies with what the CLI's ledger knows about each (T252c): the enqueue record's
+    stamp (`qts`, epoch ms) and an id digested from (stamp, text) (`qid`, stable across folds). The ledger
+    carries no ids and the kernel never sees the CLI take a copy, so nothing pairs a tmux landing with its
+    copy — the landed atom carries no qid on this route; the chat falls back to text there."""
     def step(pending, o):
         if o.get("type") != "queue-operation":
             return pending
         op = o.get("operation")
         content = o.get("content") if isinstance(o.get("content"), str) else None
         if op == "enqueue":
-            pending.append(content or "")
+            pending.append((content or "", o.get("timestamp")))
         elif op == "popAll":                                 # the whole queue recalled — nothing is left owed
             pending.clear()
-        elif op == "remove" and content is not None and content in pending:
-            pending.remove(content)                          # that entry only; the rest keep their places
+        elif op == "remove" and content is not None and any(c == content for c, _ts in pending):
+            pending.pop(next(i for i, (c, _ts) in enumerate(pending) if c == content))   # that entry only; the rest keep their places
         elif op in ("dequeue", "remove") and pending:
             del pending[0]                                   # anonymous resolution: the oldest is the one taken
         return pending
     pending = _fold_records(_queued_parse_cache, path, list, step)
-    return [t.strip() for t in pending if _genuine_queued(t)]
+    out = []
+    for text, ts in pending:
+        if not _genuine_queued(text):
+            continue
+        t = em.parse_z(ts) if isinstance(ts, str) else None
+        qts = int(t * 1000) if isinstance(t, (int, float)) and t else None
+        qid = "tq:" + hashlib.sha1(("%s\n%s" % (qts, text.strip())).encode()).hexdigest()[:16]
+        out.append({"md": text.strip(), "qid": qid, "qts": qts})
+    return out
 
 
 # ── Idle-queue drive: wake signals stuck in an idle SDK CLI's queue (the user 2026-08-18) ──
@@ -27720,6 +27740,17 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
                         if prompt or reminders or imgs:
                             ev = {"kind": "user", "md": prompt, "uuid": a.get("uuid"), "ts": ts,
                                   "human": author == "human" or bool(imgs), "reminders": reminders}
+                            # the identity of the queued copy this record lands (T252c): the fed ledger pairs
+                            # it FIFO per text, at or after the feed — so the chat retires and places its
+                            # pending bubble by id, never by text. None on the tmux route or for a record
+                            # from before this kernel's life; the chat falls back to text then.
+                            if hasattr(be, "qid_for_landing"):
+                                try:
+                                    _q = be.qid_for_landing(sid, a.get("uuid"), text, a.get("t"))
+                                except Exception:
+                                    _q = None
+                                if _q:
+                                    ev["qid"] = _q
                             if a.get("absorbed"):
                                 # A mid-turn splice (event_model._absorbed): the CLI queued this send
                                 # behind the running turn and took it at a later tool boundary, so the
@@ -28112,6 +28143,16 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
         # bubble stays (dashed, with a why-no-✕ tooltip client-side); only the false affordance goes.
         _cbe = Sessions.backend_for(sid)
         cancelable = hasattr(_cbe, "unqueue") and _queue_recallable(_cbe, sid)
+        # each copy's IDENTITY beside its text (T252c): the backend's per-copy id + enqueue stamp, when it
+        # keeps them (an SDK session that is running; a tmux ledger's stamps) — None for a restored queue
+        _metas = None
+        if queued and hasattr(_cbe, "pending_queued_meta"):
+            try:
+                _mm = _cbe.pending_queued_meta(sid)
+                if isinstance(_mm, list) and len(_mm) == len(queued):
+                    _metas = _mm
+            except Exception:
+                _metas = None
         qmsgs = []
         for i, t in enumerate(queued):
             if not _genuine_queued(t):
@@ -28124,6 +28165,10 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
                 continue
             goal, body, fu, ctx = _split_followup(t)
             m = {"md": body, "idx": i, "cancelable": cancelable, **_queued_romp_flags(t)}   # idx ↔ the backend's _pending position (cancelQueued)
+            if _metas and isinstance(_metas[i], dict) and _metas[i].get("qid"):
+                m["qid"] = _metas[i]["qid"]
+                if isinstance(_metas[i].get("qts"), int):
+                    m["qts"] = _metas[i]["qts"]
             if fu:
                 m["followUp"] = True
                 if goal:
@@ -28141,6 +28186,9 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
         # the ✕ handshake (_parked_md/_cancel_parked verify it so a shifted queue never drops the wrong op).
         for j, op in enumerate(pending_ops):
             m = {"md": _parked_md(op), "park": j, "cancelable": True, **(_queued_romp_flags(op[1]) if op[0] == "send" else {})}
+            # a PARKED copy carries no identity until it reaches the backend (T252c): the park's op is the
+            # three-field record the on-disk mirror and its readers pin, and the identity is minted where the
+            # copy enters the backend's queue (SdkBackend.send) — until then the chat reads this copy by text
             if op[0] == "send":
                 goal, _, fu, ctx = _split_followup(op[1])
                 if fu:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2653,31 +2653,48 @@ class SdkSession:
             return [{"md": t, "qid": (m or {}).get("qid"), "qts": (m or {}).get("qts")}
                     for t, m in zip(self._pending, self._pending_meta)]
 
-    def qid_for_landing(self, uuid_: str, text: str, t=None):
-        """The id of the fed copy a landed user record carries: the OLDEST fed entry with the same text
-        (echo_text_key), stamped at or before the record (a record stamped before the feed is an older
-        message's — 'ok', 'go ahead' repeat). Memoised per record uuid, so every rebuild answers the same and
-        each fed entry is spent once; None when nothing pairs (a record from before this kernel's life, a
-        copy the backend queued without an id)."""
-        if not uuid_:
-            return None
+    def qids_for_landing(self, uuid_: str, texts, t=None):
+        """The ids of the fed copies a landed user record carries, one per text block: for each block the
+        OLDEST fed entry with the same text (echo_text_key), stamped at or before the record (a record
+        stamped before the feed is an older message's — 'ok', 'go ahead' repeat), or None. A record the CLI
+        wrote from several back-to-back sends is as many landings as it has blocks, so each block spends its
+        own entry (asked with the blocks joined, no entry matched and the stale ones mis-paired a later
+        same-text landing — the review of the first cut). Memoised per record uuid, so every rebuild answers
+        the same. The kernel's own ECHO atom is refused outright (its uuid is the copy's id, minted at the
+        send): it is the visible copy between the feed and the CLI's record, and asked as a landing it took
+        the fed entry the real landing needed."""
+        if not uuid_ or str(uuid_).startswith("echo:"):
+            return [None] * len(texts)
         with self._lock:
             if uuid_ in self._landed_qid:
-                return self._landed_qid[uuid_]
-            key = echo_text_key(text)
-            hit = None
-            for i, f in enumerate(self._fed_meta):
-                if echo_text_key(f["text"]) != key:
-                    continue
-                if t is not None and float(t) < f["t"] - 2:
-                    continue                               # stamped before the feed: not this copy's landing
-                hit = self._fed_meta.pop(i)["qid"]
-                break
-            self._landed_qid[uuid_] = hit
+                return list(self._landed_qid[uuid_])
+            hits = []
+            for text in texts:
+                key = echo_text_key(text)
+                hit = None
+                for i, f in enumerate(self._fed_meta):
+                    if echo_text_key(f["text"]) != key:
+                        continue
+                    if t is not None and float(t) < f["t"] - 2:
+                        continue                           # stamped before the feed: not this copy's landing
+                    hit = self._fed_meta.pop(i)["qid"]
+                    break
+                hits.append(hit)
+            self._landed_qid[uuid_] = hits
             if len(self._landed_qid) > 512:
                 for k in list(self._landed_qid)[:-256]:
                     del self._landed_qid[k]
-            return hit
+            return list(hits)
+
+    def qid_for_landing(self, uuid_: str, text: str, t=None):
+        """qids_for_landing for a one-block record."""
+        return self.qids_for_landing(uuid_, [text], t)[0]
+
+    def forget_fed(self, qid: str):
+        """A fed copy the CLI dropped for good (its echo marked never delivered) leaves the fed ledger: its
+        landing will never come, and a later same-text landing must not be paired with it."""
+        with self._lock:
+            self._fed_meta = [f for f in self._fed_meta if f.get("qid") != qid]
 
     def enqueue(self, text: str, qid: str | None = None, qts: int | None = None):
         """Deliver a user turn (called from the kernel thread). Held in self._pending —
@@ -7433,10 +7450,23 @@ class SdkBackend:
         return s.pending_meta() if s else None
 
     def qid_for_landing(self, sid: str, uuid_: str, text: str, t=None):
-        """The id of the fed copy this landed user record carries, or None (see SdkSession.qid_for_landing)."""
+        """The id of the fed copy this landed user record carries, or None (see SdkSession.qids_for_landing)."""
         with self._lock:
             s = self.sessions.get(sid)
         return s.qid_for_landing(uuid_, text, t) if s else None
+
+    def qids_for_landing(self, sid: str, uuid_: str, texts, t=None):
+        """One id (or None) per text block of a landed record (see SdkSession.qids_for_landing)."""
+        with self._lock:
+            s = self.sessions.get(sid)
+        return s.qids_for_landing(uuid_, texts, t) if s else [None] * len(texts)
+
+    def forget_fed(self, sid: str, qid: str):
+        """A fed copy dropped for good leaves the session's fed ledger (see SdkSession.forget_fed)."""
+        with self._lock:
+            s = self.sessions.get(sid)
+        if s:
+            s.forget_fed(qid)
 
     def pending_queued(self, sid: str) -> list[str]:
         """Queued-but-not-yet-started user turns for an SDK session (oldest first), or [] if the
@@ -7637,6 +7667,7 @@ class SdkBackend:
                     atom["rompAuto"] = True
                 if e.get("dropped"):
                     atom["dropped"] = True
+                    self.forget_fed(reg["sid"], atom.get("uuid"))   # its landing will never come (T252c)
                 if isinstance(e.get("off"), int) and not isinstance(e.get("off"), bool):
                     atom["_echo_off"], atom["_echo_fsid"] = e["off"], str(e.get("fsid") or "")
                 if e.get("landed"):
@@ -7754,6 +7785,7 @@ class SdkBackend:
             if a["_echo_text"] in landed:
                 continue                                   # landed, un-pruned → the next build's prune_live
             a["dropped"] = True
+            self.forget_fed(sid, a.get("uuid"))   # its landing will never come (T252c)
             self._touch_live(sid)
             self._log("%s: a send never reached its CLI (the process died holding it) — kept in the chat "
                       "as never-delivered: %.80r" % (sid[:8], a["_echo_text"]), problem=True)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2306,6 +2306,40 @@ def _model_downgrade(frm, to):
     return a is not None and b is not None and b < a
 
 
+def _enqueue_with_id(s, text: str, uuid_, t):
+    """Re-queue `text` on session `s` under the echo's uuid as its id (T252c) — a stand-in session in tests takes
+    the text alone."""
+    qid = uuid_ if isinstance(uuid_, str) and uuid_.startswith("echo:") else None
+    try:
+        s.enqueue(text, qid=qid, qts=(int(t or 0) * 1000 or None) if qid else None)
+    except TypeError:
+        s.enqueue(text)
+
+
+def queue_meta_from_reg(reg: dict) -> list:
+    """The per-copy identities the registry mirror carries for reg['queue'], ALIGNED with it (one entry per text,
+    None for a copy without one). reg['queueMeta'] lists {"text", "qid", "qts"} for each identified copy in queue
+    order (_persist_queue); each queue text takes the first unused entry with its text, FIFO. Matching by text
+    rather than by position keeps the alignment through the reg-level edits that know texts only (a boot notice
+    prepended, a re-delivered send appended, the crash-resume nudge), and an older kernel's mirror, which has no
+    queueMeta, restores id-less copies the chat reads by text (second review: a chat that latched a copy's id
+    before the kernel died must find the same id on the restored copy, or fall back to text — never neither)."""
+    texts = [t for t in (reg.get("queue") or []) if isinstance(t, str) and t]
+    metas = [m for m in (reg.get("queueMeta") or [])
+             if isinstance(m, dict) and isinstance(m.get("qid"), str) and m["qid"] and isinstance(m.get("text"), str)]
+    used = [False] * len(metas)
+    out = []
+    for t in texts:
+        hit = None
+        for i, m in enumerate(metas):
+            if not used[i] and m["text"] == t:
+                used[i] = True
+                hit = {"qid": m["qid"], "qts": m.get("qts")}
+                break
+        out.append(hit)
+    return out
+
+
 class SdkSession:
     """One long-lived SDK client running in its own thread + asyncio loop."""
 
@@ -2572,7 +2606,7 @@ class SdkSession:
         # misattribute. The feed moves a copy's identity to _fed_meta, where qid_for_landing pairs it with
         # the record that lands the text (FIFO per text, at or after the feed) — the landed atom then carries
         # the same id the queued copy and the echo wore, and the chat places by identity, never by text.
-        self._pending_meta: list = [None] * len(self._pending)
+        self._pending_meta: list = queue_meta_from_reg(reg)   # the ids the mirror carries, aligned with _pending
         self._fed_meta: list = []
         self._landed_qid: dict = {}
         self._ping_feeding = False   # a rename ping was fed and its turn hasn't streamed yet: hold the
@@ -2625,9 +2659,26 @@ class SdkSession:
         self._pending.append(text)
         self._pending_meta.append(meta if isinstance(meta, dict) and meta.get("qid") else None)
 
-    def _q_prepend(self, texts):
-        self._pending[0:0] = list(texts)
-        self._pending_meta[0:0] = [None] * len(texts)
+    def _q_prepend(self, texts, metas=None):
+        texts = list(texts)
+        self._pending[0:0] = texts
+        metas = list(metas) if metas is not None and len(metas) == len(texts) else [None] * len(texts)
+        self._pending_meta[0:0] = [m if isinstance(m, dict) and m.get("qid") else None for m in metas]
+
+    def _unfeed_locked(self, texts):
+        """The fed entries for `texts` (FIFO per text), popped from the ledger: their identities go back to the queue
+        with the copies (the stranded re-head), so the same id rides the copy, its echo and the eventual landing —
+        and no stale entry is left to pair a later same-text landing. Under self._lock."""
+        metas = []
+        for t in texts:
+            k = echo_text_key(t)
+            hit = None
+            for j, f in enumerate(self._fed_meta):
+                if echo_text_key(f.get("text", "")) == k:
+                    hit = self._fed_meta.pop(j)
+                    break
+            metas.append({"qid": hit["qid"], "qts": hit.get("qts")} if hit else None)
+        return metas
 
     def _q_pop(self, idx: int):
         """(text, meta) at `idx`, both lists popped together — the one way a copy leaves the queue."""
@@ -2640,7 +2691,7 @@ class SdkSession:
         fed ledger, where the landing is paired with it. Returns (text, meta)."""
         text, meta = self._q_pop(0)
         if meta and meta.get("qid"):
-            self._fed_meta.append({"qid": meta["qid"], "text": text, "t": int(time.time())})
+            self._fed_meta.append({"qid": meta["qid"], "qts": meta.get("qts"), "text": text, "t": int(time.time())})
             del self._fed_meta[:-64]                       # bounded: a landing is paired within a turn or two
         return text, meta
 
@@ -2702,6 +2753,8 @@ class SdkSession:
         before the loop is ready too (the generator drains _pending on its first pass). `qid`/`qts`:
         the copy's identity (send() mints them; a caller without one queues an id-less copy)."""
         with self._lock:
+            if qid:
+                self._fed_meta = [f for f in self._fed_meta if f.get("qid") != qid]   # back in the queue: not fed (a re-delivery)
             self._q_append(text, {"qid": qid, "qts": qts} if qid else None)
             loop, wake = self.loop, self._input_wake
         self._persist_queue()
@@ -2766,8 +2819,11 @@ class SdkSession:
         transcript as a user atom, which is the cut-turn resume's territory, not replay's."""
         with self._lock:
             snap = list(self._pending)
+            metas = list(self._pending_meta)
+        qmeta = [{"text": t, "qid": m["qid"], "qts": m.get("qts")}
+                 for t, m in zip(snap, metas) if isinstance(m, dict) and m.get("qid")]   # identified copies only, in order
         try:
-            self.backend._update_reg(self.sid, queue=snap)
+            self.backend._update_reg(self.sid, queue=snap, queueMeta=qmeta)
         except Exception:
             self.backend._log("persist queue (%s): %s" % (self.name, traceback.format_exc()))
 
@@ -2954,7 +3010,7 @@ class SdkSession:
         self.backend.retire_live_work(self.sid)    # the abandoned turn's stream is gone with its client
         if stranded and not self.resume_sid:
             with self._lock:
-                self._q_prepend(stranded)
+                self._q_prepend(stranded, self._unfeed_locked(stranded))   # back at the head under their own ids
             self._persist_queue()                  # the fresh inputs() drains _pending on its first pass
         elif stranded:
             self.backend._mark_dropped_echoes(self.sid, self.pending(), refeed=False)
@@ -7441,13 +7497,18 @@ class SdkBackend:
         return self._ensure(sid) is not None
 
     def pending_queued_meta(self, sid: str):
-        """pending_queued's copies WITH their identities: [{"md", "qid", "qts"}] aligned with pending_queued,
-        or None when this session is not running (the persisted mirror carries texts only — a queue restored
-        after a kernel death has no ids, and the chat falls back to text for it) or the identities cannot be
-        trusted (T252c)."""
+        """pending_queued's copies WITH their identities: [{"md", "qid", "qts"}] aligned with pending_queued —
+        the live session's, or, when it is not running, the persisted mirror's (reg['queue'] + reg['queueMeta'],
+        the ids the copies carried when the kernel died; an older mirror carries none and the chat reads those
+        copies by text) — or None when the live identities cannot be trusted (T252c)."""
         with self._lock:
             s = self.sessions.get(sid)
-        return s.pending_meta() if s else None
+        if s:
+            return s.pending_meta()
+        reg = read_reg(self.state_dir, sid) or {}
+        texts = [t for t in (reg.get("queue") or []) if isinstance(t, str) and t]
+        return [{"md": t, "qid": (m or {}).get("qid"), "qts": (m or {}).get("qts")}
+                for t, m in zip(texts, queue_meta_from_reg(reg))]
 
     def qid_for_landing(self, sid: str, uuid_: str, text: str, t=None):
         """The id of the fed copy this landed user record carries, or None (see SdkSession.qids_for_landing)."""
@@ -7633,6 +7694,9 @@ class SdkBackend:
                     continue
                 e = {"t": a.get("t", 0), "text": a["_echo_text"], "author": a.get("author") or "human",
                      "rompAuto": bool(a.get("rompAuto")), "dropped": bool(a.get("dropped"))}
+                if isinstance(a.get("uuid"), str) and a["uuid"].startswith("echo:"):
+                    e["uuid"] = a["uuid"]          # the copy's identity (T252c): the reseed keeps it, so a chat that
+                    #                                latched it before the restart finds it on the reseeded echo
                 if a.get("_echo_off") is not None:
                     e["off"] = int(a["_echo_off"])                 # the send-time transcript mark (_transcript_mark)
                     e["fsid"] = str(a.get("_echo_fsid") or "")
@@ -7658,7 +7722,7 @@ class SdkBackend:
                 text = e.get("text")
                 if not isinstance(text, str) or not text:
                     continue
-                key = "echo:" + uuid.uuid4().hex
+                key = e["uuid"] if isinstance(e.get("uuid"), str) and e["uuid"].startswith("echo:") else "echo:" + uuid.uuid4().hex
                 atom = {"type": "user", "uuid": key, "session_id": reg["sid"],
                         "t": int(e.get("t") or 0) or int(time.time()), "parentUuid": None,
                         "author": e.get("author") or "human", "_echo_text": text,
@@ -7764,7 +7828,7 @@ class SdkBackend:
                         s._compacting = True               # same enqueue-time semantics as send()
                     if _is_clear_cmd(a["_echo_text"]):
                         s._clearing = True
-                    s.enqueue(a["_echo_text"])
+                    _enqueue_with_id(s, a["_echo_text"], a.get("uuid"), a.get("t"))   # under the echo's own id (T252c)
                     self._log("%s: re-delivering a typed send the dead CLI was holding: %.80r"
                               % (sid[:8], a["_echo_text"]))
             else:
@@ -7772,9 +7836,14 @@ class SdkBackend:
                     reg = read_reg(self.state_dir, sid)
                     if reg is not None:
                         have = [t for t in (reg.get("queue") or []) if isinstance(t, str) and t]
-                        add = [a["_echo_text"] for a in redeliver if a["_echo_text"] not in have]
+                        adds = [a for a in redeliver if a["_echo_text"] not in have]
+                        add = [a["_echo_text"] for a in adds]
                         if add:
                             reg["queue"] = have + add      # behind the surviving queue: original send order
+                            # each re-delivered copy keeps the echo's uuid as its id (T252c): the seed restores it
+                            reg["queueMeta"] = [m for m in (reg.get("queueMeta") or []) if isinstance(m, dict)] + [
+                                {"text": a["_echo_text"], "qid": a["uuid"], "qts": int(a.get("t") or 0) * 1000 or None}
+                                for a in adds if isinstance(a.get("uuid"), str) and a["uuid"].startswith("echo:")]
                             write_reg(self.state_dir, sid, reg)
                             for a in redeliver:
                                 self._log("%s: re-delivering a typed send the dead CLI was holding: %.80r"

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -7667,7 +7667,8 @@ class SdkBackend:
                     atom["rompAuto"] = True
                 if e.get("dropped"):
                     atom["dropped"] = True
-                    self.forget_fed(reg["sid"], atom.get("uuid"))   # its landing will never come (T252c)
+                    if hasattr(self, "forget_fed"):      # a stand-in backend in tests borrows this method without the ledger
+                        self.forget_fed(reg["sid"], atom.get("uuid"))   # its landing will never come (T252c)
                 if isinstance(e.get("off"), int) and not isinstance(e.get("off"), bool):
                     atom["_echo_off"], atom["_echo_fsid"] = e["off"], str(e.get("fsid") or "")
                 if e.get("landed"):
@@ -7785,7 +7786,8 @@ class SdkBackend:
             if a["_echo_text"] in landed:
                 continue                                   # landed, un-pruned → the next build's prune_live
             a["dropped"] = True
-            self.forget_fed(sid, a.get("uuid"))   # its landing will never come (T252c)
+            if hasattr(self, "forget_fed"):
+                self.forget_fed(sid, a.get("uuid"))   # its landing will never come (T252c)
             self._touch_live(sid)
             self._log("%s: a send never reached its CLI (the process died holding it) — kept in the chat "
                       "as never-delivered: %.80r" % (sid[:8], a["_echo_text"]), problem=True)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2565,6 +2565,16 @@ class SdkSession:
         # so a kernel death can DELAY queued messages but never lose them; the boot reconcile
         # resumes any session with a non-empty persisted queue and this seed delivers it.
         self._pending: list[str] = [t for t in (reg.get("queue") or []) if isinstance(t, str) and t]
+        # Per-copy IDENTITY beside each queued text (T252c): {"qid", "qts"} — the echo key send() minted for
+        # it and its enqueue stamp (epoch ms) — or None for a copy nobody stamped (a restored queue after a
+        # kernel death, a notice this backend queued itself). Kept ALIGNED with _pending by the _q_* helpers;
+        # pending_meta() refuses to answer when they disagree, so the chat falls back to text rather than
+        # misattribute. The feed moves a copy's identity to _fed_meta, where qid_for_landing pairs it with
+        # the record that lands the text (FIFO per text, at or after the feed) — the landed atom then carries
+        # the same id the queued copy and the echo wore, and the chat places by identity, never by text.
+        self._pending_meta: list = [None] * len(self._pending)
+        self._fed_meta: list = []
+        self._landed_qid: dict = {}
         self._ping_feeding = False   # a rename ping was fed and its turn hasn't streamed yet: hold the
         #                              queue so no message can share its pre-turn window (the CLI batches
         #                              everything pre-start into ONE record — the 2026-08-25 fold); cleared
@@ -2611,12 +2621,71 @@ class SdkSession:
             except Exception as e:
                 self.backend._log("boot-settled callback (%s) failed: %s" % (self.name, e))
 
-    def enqueue(self, text: str):
+    def _q_append(self, text: str, meta=None):
+        self._pending.append(text)
+        self._pending_meta.append(meta if isinstance(meta, dict) and meta.get("qid") else None)
+
+    def _q_prepend(self, texts):
+        self._pending[0:0] = list(texts)
+        self._pending_meta[0:0] = [None] * len(texts)
+
+    def _q_pop(self, idx: int):
+        """(text, meta) at `idx`, both lists popped together — the one way a copy leaves the queue."""
+        text = self._pending.pop(idx)
+        meta = self._pending_meta.pop(idx) if idx < len(self._pending_meta) else None
+        return text, meta
+
+    def _pop_for_feed_locked(self):
+        """The head copy leaves for the CLI (the input generator, under self._lock): its identity moves to the
+        fed ledger, where the landing is paired with it. Returns (text, meta)."""
+        text, meta = self._q_pop(0)
+        if meta and meta.get("qid"):
+            self._fed_meta.append({"qid": meta["qid"], "text": text, "t": int(time.time())})
+            del self._fed_meta[:-64]                       # bounded: a landing is paired within a turn or two
+        return text, meta
+
+    def pending_meta(self):
+        """[{"md", "qid", "qts"}] aligned with pending(), or None when the identities cannot be trusted (the
+        two lists disagree) — the chat then falls back to text for this queue rather than misattribute."""
+        with self._lock:
+            if len(self._pending_meta) != len(self._pending):
+                return None
+            return [{"md": t, "qid": (m or {}).get("qid"), "qts": (m or {}).get("qts")}
+                    for t, m in zip(self._pending, self._pending_meta)]
+
+    def qid_for_landing(self, uuid_: str, text: str, t=None):
+        """The id of the fed copy a landed user record carries: the OLDEST fed entry with the same text
+        (echo_text_key), stamped at or before the record (a record stamped before the feed is an older
+        message's — 'ok', 'go ahead' repeat). Memoised per record uuid, so every rebuild answers the same and
+        each fed entry is spent once; None when nothing pairs (a record from before this kernel's life, a
+        copy the backend queued without an id)."""
+        if not uuid_:
+            return None
+        with self._lock:
+            if uuid_ in self._landed_qid:
+                return self._landed_qid[uuid_]
+            key = echo_text_key(text)
+            hit = None
+            for i, f in enumerate(self._fed_meta):
+                if echo_text_key(f["text"]) != key:
+                    continue
+                if t is not None and float(t) < f["t"] - 2:
+                    continue                               # stamped before the feed: not this copy's landing
+                hit = self._fed_meta.pop(i)["qid"]
+                break
+            self._landed_qid[uuid_] = hit
+            if len(self._landed_qid) > 512:
+                for k in list(self._landed_qid)[:-256]:
+                    del self._landed_qid[k]
+            return hit
+
+    def enqueue(self, text: str, qid: str | None = None, qts: int | None = None):
         """Deliver a user turn (called from the kernel thread). Held in self._pending —
         VISIBLE to pending_queued — until the input generator releases it at turn end. Works
-        before the loop is ready too (the generator drains _pending on its first pass)."""
+        before the loop is ready too (the generator drains _pending on its first pass). `qid`/`qts`:
+        the copy's identity (send() mints them; a caller without one queues an id-less copy)."""
         with self._lock:
-            self._pending.append(text)
+            self._q_append(text, {"qid": qid, "qts": qts} if qid else None)
             loop, wake = self.loop, self._input_wake
         self._persist_queue()
         if loop is not None and wake is not None:
@@ -2632,7 +2701,7 @@ class SdkSession:
         with self._lock:
             if self._pending:
                 return False
-            self._pending.append(text)
+            self._q_append(text)
             loop, wake = self.loop, self._input_wake
         self._persist_queue()
         if loop is not None and wake is not None:
@@ -2666,7 +2735,7 @@ class SdkSession:
         with self._lock:
             if expect is not None and not (0 <= idx < len(self._pending) and self._pending[idx] == expect):
                 idx = next((i for i, q in enumerate(self._pending) if q == expect), -1)
-            item = self._pending.pop(idx) if 0 <= idx < len(self._pending) else None
+            item = self._q_pop(idx)[0] if 0 <= idx < len(self._pending) else None
         if item is not None:
             self._persist_queue()
         return item
@@ -2868,7 +2937,7 @@ class SdkSession:
         self.backend.retire_live_work(self.sid)    # the abandoned turn's stream is gone with its client
         if stranded and not self.resume_sid:
             with self._lock:
-                self._pending[0:0] = stranded
+                self._q_prepend(stranded)
             self._persist_queue()                  # the fresh inputs() drains _pending on its first pass
         elif stranded:
             self.backend._mark_dropped_echoes(self.sid, self.pending(), refeed=False)
@@ -3362,7 +3431,7 @@ class SdkSession:
                     # turn-end events. Mid-turn forwards keep flowing (inflight > 0), so the
                     # in-flight turn can still finish; the wedged/rewind holds above are untouched.
                     blocked = blocked or (self.inflight == 0 and self.backend.drain_holding())
-                    item = self._pending.pop(0) if (self._pending and not blocked) else None
+                    item, _meta = self._pop_for_feed_locked() if (self._pending and not blocked) else (None, None)
                     fresh = item is not None and self.inflight == 0     # starting from idle, not mid-turn
                     if item is not None:
                         # under the SAME lock as the pop: busy() reads inflight>0 or _pending, and the kernel's
@@ -3532,7 +3601,7 @@ class SdkSession:
         dropped = None
         if not bare:
             with self._lock:
-                dropped = self._pending.pop(0) if self._pending else None
+                dropped = self._q_pop(0)[0] if self._pending else None
             self._persist_queue()
         self._rewind_wait = False
         try:
@@ -4848,7 +4917,7 @@ class SdkSession:
             note = task_death_notice(died, cause=self._RECONNECT_CAUSE)
             with self._lock:
                 if note not in self._pending:      # a flapping reconnect must not stack the same notice
-                    self._pending.append(note)
+                    self._q_append(note)
             self._persist_queue()
             try:
                 self.backend._update_reg(self.sid, bgTasks=[])   # reported — never re-notify these deaths
@@ -7354,6 +7423,21 @@ class SdkBackend:
         a no-op if already running."""
         return self._ensure(sid) is not None
 
+    def pending_queued_meta(self, sid: str):
+        """pending_queued's copies WITH their identities: [{"md", "qid", "qts"}] aligned with pending_queued,
+        or None when this session is not running (the persisted mirror carries texts only — a queue restored
+        after a kernel death has no ids, and the chat falls back to text for it) or the identities cannot be
+        trusted (T252c)."""
+        with self._lock:
+            s = self.sessions.get(sid)
+        return s.pending_meta() if s else None
+
+    def qid_for_landing(self, sid: str, uuid_: str, text: str, t=None):
+        """The id of the fed copy this landed user record carries, or None (see SdkSession.qid_for_landing)."""
+        with self._lock:
+            s = self.sessions.get(sid)
+        return s.qid_for_landing(uuid_, text, t) if s else None
+
     def pending_queued(self, sid: str) -> list[str]:
         """Queued-but-not-yet-started user turns for an SDK session (oldest first), or [] if the
         session isn't SDK-backed / not running. The kernel calls this to build the chat's
@@ -7426,7 +7510,7 @@ class SdkBackend:
                         or getattr(s, "_ping_feeding", False)   # getattr: test doubles skip __init__
                         or (s._rewind_to and not getattr(s, "_rewind_armed", False)))
 
-    def send(self, sid: str, text: str) -> bool:
+    def send(self, sid: str, text: str, qid: str | None = None) -> bool:
         s = self._ensure(sid)
         if not s:
             return False
@@ -7445,11 +7529,17 @@ class SdkBackend:
         # 2026-09-06, is where _text_landed starts the scan for this echo — see _transcript_mark).
         sent_t = int(time.time())
         sent_off, sent_fsid = self._transcript_mark(sid)
-        s.enqueue(text)
+        # The copy's IDENTITY (T252c): the echo key, minted BEFORE the enqueue so the queued copy, the
+        # optimistic echo and — through the fed ledger — the landed atom share one id; a parked send hands
+        # in the id it minted at park time. Synthetic uuid; the echo is pruned by text once the transcript
+        # writes the real user atom.
+        key = qid or "echo:" + uuid.uuid4().hex
+        try:
+            s.enqueue(text, qid=key, qts=int(time.time() * 1000))
+        except TypeError:                                    # a stand-in session that takes the text alone: an id-less copy
+            s.enqueue(text)
         # optimistic input echo: show the user's own message INSTANTLY (neither the transcript nor the
-        # stream has it yet at send time — only we know the text). Synthetic uuid; pruned by text once the
-        # transcript writes the real user atom.
-        key = "echo:" + uuid.uuid4().hex
+        # stream has it yet at send time — only we know the text).
         # AUTHOR the echo from the romp markers, exactly as the event model authors the REAL atom — else a
         # romp-injected nudge/auto-nudge sent through send() echoed as a BLUE HUMAN bubble (a "Follow-up"),
         # not the GRAY "from romp" auto-nudge it is, until the transcript atom replaced it (the user

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2306,6 +2306,24 @@ def _model_downgrade(frm, to):
     return a is not None and b is not None and b < a
 
 
+def _echo_queued_in(a: dict, queued) -> bool:
+    """Whether echo atom `a` is in the surviving queue `queued` — its copies as {"md", "qid"} (a plain text is an
+    id-less copy) — by identity where it has one (T252c, third review): an echo whose uuid a queued copy wears is
+    queued; an echo whose text is queued only under OTHER ids is not (by text alone, the second of two identical
+    sends hid the loss of the first). A copy without an id (an older kernel's mirror, a notice the backend queued)
+    and an echo the reseed re-minted (an older mirror carried no uuid) keep the text reading, so an upgrade
+    mid-flight never re-delivers a copy that is in fact queued."""
+    metas = [m if isinstance(m, dict) else {"md": m, "qid": None} for m in (queued or [])]
+    qs = {m.get("md") for m in metas if isinstance(m.get("md"), str)}
+    ids = {m.get("qid") for m in metas if isinstance(m.get("qid"), str) and m.get("qid")}
+    idless = {m.get("md") for m in metas if isinstance(m.get("md"), str) and not m.get("qid")}
+    if a.get("uuid") in ids:
+        return True
+    if a.get("_echo_reminted") or not ids:
+        return a.get("_echo_text") in qs
+    return a.get("_echo_text") in idless
+
+
 def _enqueue_with_id(s, text: str, uuid_, t):
     """Re-queue `text` on session `s` under the echo's uuid as its id (T252c) — a stand-in session in tests takes
     the text alone."""
@@ -2319,22 +2337,38 @@ def _enqueue_with_id(s, text: str, uuid_, t):
 def queue_meta_from_reg(reg: dict) -> list:
     """The per-copy identities the registry mirror carries for reg['queue'], ALIGNED with it (one entry per text,
     None for a copy without one). reg['queueMeta'] lists {"text", "qid", "qts"} for each identified copy in queue
-    order (_persist_queue); each queue text takes the first unused entry with its text, FIFO. Matching by text
-    rather than by position keeps the alignment through the reg-level edits that know texts only (a boot notice
-    prepended, a re-delivered send appended, the crash-resume nudge), and an older kernel's mirror, which has no
-    queueMeta, restores id-less copies the chat reads by text (second review: a chat that latched a copy's id
+    order (_persist_queue), text alone for an id-less one. The run is aligned as one BLOCK of the queue, wherever
+    the reg-level edits that know texts only (a boot notice prepended, a re-delivered send appended, the
+    crash-resume nudge) have shifted it; only a run no block of the queue matches falls to first-in-first-out by
+    text over the identified entries. An older kernel's mirror, which has no queueMeta, restores id-less copies
+    the chat reads by text (second review: a chat that latched a copy's id
     before the kernel died must find the same id on the restored copy, or fall back to text — never neither)."""
     texts = [t for t in (reg.get("queue") or []) if isinstance(t, str) and t]
-    metas = [m for m in (reg.get("queueMeta") or [])
-             if isinstance(m, dict) and isinstance(m.get("qid"), str) and m["qid"] and isinstance(m.get("text"), str)]
-    used = [False] * len(metas)
+    raw = reg.get("queueMeta")
+    entries = [m for m in raw if isinstance(m, dict) and isinstance(m.get("text"), str)] if isinstance(raw, list) else []
+
+    def ident(m):
+        return {"qid": m["qid"], "qts": m.get("qts")} if isinstance(m.get("qid"), str) and m["qid"] else None
+
+    # the mirror lists EVERY position (text alone for an id-less copy): align the mirrored run as one block of the
+    # queue — the boot paths that edit reg['queue'] by text (a notice prepended, a re-delivered send appended)
+    # shift it whole — so a same-text pair keeps its ids where they were (third review)
+    n = len(entries)
+    if n and len(entries) == len(raw):
+        run = [m["text"] for m in entries]
+        for k in range(0, len(texts) - n + 1):
+            if texts[k:k + n] == run:
+                return [None] * k + [ident(m) for m in entries] + [None] * (len(texts) - k - n)
+    # no block matches (a copy removed by text): first in first out by text over the identified entries
+    idents = [m for m in entries if ident(m)]
+    used = [False] * len(idents)
     out = []
     for t in texts:
         hit = None
-        for i, m in enumerate(metas):
+        for i, m in enumerate(idents):
             if not used[i] and m["text"] == t:
                 used[i] = True
-                hit = {"qid": m["qid"], "qts": m.get("qts")}
+                hit = ident(m)
                 break
         out.append(hit)
     return out
@@ -2820,8 +2854,8 @@ class SdkSession:
         with self._lock:
             snap = list(self._pending)
             metas = list(self._pending_meta)
-        qmeta = [{"text": t, "qid": m["qid"], "qts": m.get("qts")}
-                 for t, m in zip(snap, metas) if isinstance(m, dict) and m.get("qid")]   # identified copies only, in order
+        qmeta = [{"text": t, "qid": m["qid"], "qts": m.get("qts")} if isinstance(m, dict) and m.get("qid") else {"text": t}
+                 for t, m in zip(snap, metas)]        # every position, so the restore aligns the run as a block
         try:
             self.backend._update_reg(self.sid, queue=snap, queueMeta=qmeta)
         except Exception:
@@ -3013,7 +3047,7 @@ class SdkSession:
                 self._q_prepend(stranded, self._unfeed_locked(stranded))   # back at the head under their own ids
             self._persist_queue()                  # the fresh inputs() drains _pending on its first pass
         elif stranded:
-            self.backend._mark_dropped_echoes(self.sid, self.pending(), refeed=False)
+            self.backend._mark_dropped_echoes(self.sid, self.pending_meta() or self.pending(), refeed=False)
         self.backend._poke()
 
     # ---- async internals (run inside the quarantined loop) ----
@@ -3437,7 +3471,7 @@ class SdkSession:
             # The SPAWN half of the dropped-echo marking (boot half: _reseed_echoes): a fresh CLI means
             # whatever held any earlier send is gone. An echo neither in self._pending (delivered to the
             # new CLI) nor landed has no holder left — flag it so the chat says "never delivered".
-            self.backend._mark_dropped_echoes(self.sid, self.pending())
+            self.backend._mark_dropped_echoes(self.sid, self.pending_meta() or self.pending())
             asyncio.run(self._amain())
         except Exception as e:                       # surfaced for debugging; never crash kernel
             # The TRACEBACK too, not just the type and message: a bare "KeyError: <uuid>" names no line,
@@ -7722,11 +7756,14 @@ class SdkBackend:
                 text = e.get("text")
                 if not isinstance(text, str) or not text:
                     continue
-                key = e["uuid"] if isinstance(e.get("uuid"), str) and e["uuid"].startswith("echo:") else "echo:" + uuid.uuid4().hex
+                kept = isinstance(e.get("uuid"), str) and e["uuid"].startswith("echo:")
+                key = e["uuid"] if kept else "echo:" + uuid.uuid4().hex
                 atom = {"type": "user", "uuid": key, "session_id": reg["sid"],
                         "t": int(e.get("t") or 0) or int(time.time()), "parentUuid": None,
                         "author": e.get("author") or "human", "_echo_text": text,
                         "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+                if not kept:
+                    atom["_echo_reminted"] = True    # an older mirror carried no uuid: this echo is judged by text
                 if e.get("rompAuto"):
                     atom["rompAuto"] = True
                 if e.get("dropped"):
@@ -7739,7 +7776,9 @@ class SdkBackend:
                     atom["_landed"] = True           # already adjudicated landed: never re-scanned, never flagged
                 self._stash_live(reg["sid"], key, atom)
             if self._live.get(reg["sid"]):
-                self._mark_dropped_echoes(reg["sid"], reg.get("queue") or [])
+                _texts = [t for t in (reg.get("queue") or []) if isinstance(t, str) and t]
+                self._mark_dropped_echoes(reg["sid"], [{"md": t, "qid": (m or {}).get("qid")}
+                                                       for t, m in zip(_texts, queue_meta_from_reg(reg))])
 
     def _mark_dropped_echoes(self, sid: str, queued_texts, refeed: bool = True) -> None:
         """A fresh CLI is spawning for this sid, or the kernel just booted: whatever process held any
@@ -7761,7 +7800,14 @@ class SdkBackend:
         exactly the duplicate that branch refuses by design. The loss still surfaces in full (the dropped
         flag); only the queue re-add is withheld. Boot and dead-spawn callers keep the default: no client
         survived there to be writing anything."""
-        qs = {q for q in queued_texts if isinstance(q, str)}
+        # The surviving queue, by identity where it has one (T252c, third review): `queued_texts` is the queue's
+        # copies as {"md", "qid"} (a caller with texts alone gives id-less copies). An echo whose uuid a queued
+        # copy wears is queued; an echo whose text is queued only under OTHER ids is not — by text alone, the
+        # second of two identical sends hid the loss of the first, which was neither re-delivered nor flagged.
+        # A copy without an id (an older kernel's mirror, a notice the backend queued) and an echo the reseed
+        # re-minted (an older mirror carried no uuid) keep the text reading, so an upgrade mid-flight never
+        # re-delivers a copy that is in fact queued.
+        _queued = lambda a: _echo_queued_in(a, queued_texts)
         # The selection is under the live-tail lock; everything after it (the transcript scan, the
         # queue re-add, the reg write) is not. This runs on the SESSION thread at spawn and at every
         # reconnect, outside the connect's try — while the kernel thread's send() stashes an echo into
@@ -7773,7 +7819,7 @@ class SdkBackend:
                 return
             newly = [a for a in list(d.values())
                      if a.get("_echo_text") and not a.get("command") and not a.get("dropped")
-                     and not a.get("_landed") and a["_echo_text"] not in qs]
+                     and not a.get("_landed") and not _queued(a)]
         if not newly:
             return
         # RE-DELIVER, don't just flag (the user 2026-08-23, their strongest point in the restart
@@ -7836,7 +7882,10 @@ class SdkBackend:
                     reg = read_reg(self.state_dir, sid)
                     if reg is not None:
                         have = [t for t in (reg.get("queue") or []) if isinstance(t, str) and t]
-                        adds = [a for a in redeliver if a["_echo_text"] not in have]
+                        # already queued, by the same identity reading as the selection above (by text alone, the
+                        # lost first of two identical sends was never re-added behind its queued twin)
+                        _have = [{"md": t, "qid": (m or {}).get("qid")} for t, m in zip(have, queue_meta_from_reg(reg))]
+                        adds = [a for a in redeliver if not _echo_queued_in(a, _have)]
                         add = [a["_echo_text"] for a in adds]
                         if add:
                             reg["queue"] = have + add      # behind the surviving queue: original send order

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2600,8 +2600,8 @@ class SdkSession:
         # resumes any session with a non-empty persisted queue and this seed delivers it.
         self._pending: list[str] = [t for t in (reg.get("queue") or []) if isinstance(t, str) and t]
         # Per-copy IDENTITY beside each queued text (T252c): {"qid", "qts"} — the echo key send() minted for
-        # it and its enqueue stamp (epoch ms) — or None for a copy nobody stamped (a restored queue after a
-        # kernel death, a notice this backend queued itself). Kept ALIGNED with _pending by the _q_* helpers;
+        # it and its enqueue stamp (epoch ms) — or None for a copy nobody stamped (a notice this backend queued
+        # itself; a copy restored from an older kernel's text-only mirror). Kept ALIGNED with _pending by the _q_* helpers;
         # pending_meta() refuses to answer when they disagree, so the chat falls back to text rather than
         # misattribute. The feed moves a copy's identity to _fed_meta, where qid_for_landing pairs it with
         # the record that lands the text (FIFO per text, at or after the feed) — the landed atom then carries

--- a/tests/test_queued_copy_identity.py
+++ b/tests/test_queued_copy_identity.py
@@ -318,6 +318,16 @@ class TheChatCarriesTheIds(unittest.TestCase):
         q = [e for e in m["events"] if e.get("kind") == "queued"]
         self.assertEqual([(x["md"], x.get("qid")) for x in q[0]["texts"]], [("A", None), ("B", None)])
 
+    def test_a_stamp_without_an_id_rides_the_queued_copy_too(self):
+        # the tmux route's copies carry an enqueue stamp and no id (TheTmuxQueueCarriesStamps): the group ships the
+        # stamp on its own — it rode only beside an id (third review)
+        self.w.write(RUNNING)
+        self.w.s.enqueue("stamped only")
+        self.w.be.pending_queued_meta = lambda sid: [{"md": "stamped only", "qid": None, "qts": 1_700_000_000_000}]
+        m = self.w.build()
+        q = [e for e in m["events"] if e.get("kind") == "queued"]
+        self.assertEqual([(t["md"], t.get("qid"), t.get("qts")) for t in q[0]["texts"]], [("stamped only", None, 1_700_000_000_000)])
+
     def test_a_parked_copy_carries_no_id_until_it_reaches_the_backend(self):
         # the park's op is the three-field record the on-disk mirror and its readers pin: no identity rides it; the
         # copy is identified where it enters the backend's queue (send()), and the chat reads a parked copy by text
@@ -409,6 +419,30 @@ class IdentitySurvivesTheKernelsDeath(unittest.TestCase):
                          "back in the queue under the echo's own uuid")
         self.assertEqual([(a["uuid"], bool(a.get("dropped"))) for a in be2.live_atoms(SID) if a.get("_echo_text")], [(qid, False)])
 
+    def test_a_re_delivered_copy_joins_a_surviving_identified_queue_with_both_ids_intact(self):
+        self.assertTrue(self.w.be.send(SID, "go on"))
+        self.assertTrue(self.w.be.send(SID, "keep this"))
+        [qid_go, qid_keep] = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
+        with self.w.s._lock:
+            self.w.s._pop_for_feed_locked()           # the CLI took the first…
+        self.w.s._persist_queue()                     # …so the mirror holds the second, and the first's unlanded echo
+        be2, s2 = self._restart()
+        self.assertEqual([(m["md"], m["qid"]) for m in be2.pending_queued_meta(SID)], [("keep this", qid_keep), ("go on", qid_go)],
+                         "the survivor first, the re-delivered copy behind it, each under its own id (third review)")
+
+    def test_the_lost_first_of_two_identical_sends_is_seen_lost_beside_the_queued_second(self):
+        self.assertTrue(self.w.be.send(SID, "ok"))
+        self.assertTrue(self.w.be.send(SID, "ok"))
+        [qa, qb] = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
+        with self.w.s._lock:
+            self.w.s._pop_for_feed_locked()           # the CLI took the first copy…
+        self.w.s._persist_queue()                     # …the mirror holds the second, and both echoes
+        be2, s2 = self._restart()                     # the first died with the CLI; by TEXT it looked queued (third review)
+        self.assertEqual([(m["md"], m["qid"]) for m in be2.pending_queued_meta(SID)], [("ok", qb), ("ok", qa)],
+                         "the survivor, then the lost copy re-delivered under its own id")
+        self.assertEqual(sorted((a["uuid"], bool(a.get("dropped"))) for a in be2.live_atoms(SID) if a.get("_echo_text")),
+                         sorted([(qa, False), (qb, False)]))
+
     def test_a_dead_spawns_re_delivery_into_a_live_session_carries_the_id_and_clears_the_stale_ledger_entry(self):
         self.assertTrue(self.w.be.send(SID, "go on"))
         [qid] = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
@@ -431,6 +465,25 @@ class IdentitySurvivesTheKernelsDeath(unittest.TestCase):
         self.assertEqual([(m["md"], m["qid"]) for m in s.pending_meta()], [("go on", qid), ("then this", later)],
                          "the fed copy is back at the head under its own id")
         self.assertEqual(s._fed_meta, [], "…and out of the fed ledger")
+
+
+class TheQueueMirrorAlignsByPosition(unittest.TestCase):
+    """The mirror lists every position (text alone for an id-less copy), so a restore aligns the mirrored run as one
+    block of the queue: the boot paths that edit reg['queue'] by text — a notice prepended, a re-delivered send
+    appended — shift it whole. Only when no block matches (a copy removed by text) does it fall to first-in-first-out
+    by text over the identified entries, and an older mirror restores nothing (third review)."""
+
+    def test_the_mirrored_run_aligns_as_a_block_after_text_only_edits_else_by_text(self):
+        meta = [{"text": "go"}, {"text": "go", "qid": "echo:b", "qts": 5}]
+        self.assertEqual(sb.queue_meta_from_reg({"queue": ["go", "go"], "queueMeta": meta}), [None, {"qid": "echo:b", "qts": 5}])
+        self.assertEqual(sb.queue_meta_from_reg({"queue": ["a notice", "go", "go", "later"],
+                                                 "queueMeta": meta + [{"text": "later", "qid": "echo:c", "qts": None}]}),
+                         [None, None, {"qid": "echo:b", "qts": 5}, {"qid": "echo:c", "qts": None}],
+                         "prepended and appended around the block: the id stays on the SECOND go")
+        self.assertEqual(sb.queue_meta_from_reg({"queue": ["go"], "queueMeta": meta}), [{"qid": "echo:b", "qts": 5}],
+                         "no block matches: the identified entry goes to the first copy of its text")
+        self.assertEqual(sb.queue_meta_from_reg({"queue": ["go"]}), [None], "an older mirror")
+        self.assertEqual(sb.queue_meta_from_reg({"queue": ["go"], "queueMeta": "junk"}), [None])
 
 
 if __name__ == "__main__":

--- a/tests/test_queued_copy_identity.py
+++ b/tests/test_queued_copy_identity.py
@@ -8,8 +8,10 @@ queue:
   SDK backend — send() mints the copy's id (the echo key it already minted for the optimistic echo) BEFORE the
   enqueue, so the queued copy, the echo atom and the landed atom share one id; the feed moves the id to a fed
   ledger, and the landed user record is paired with it FIFO per text, at or after the feed time (qid on the chat
-  event). A queue restored from the registry after a kernel death carries no ids (legacy: the chat falls back to
-  text), and so does a copy the backend itself queued (a death notice, the rename ping).
+  event). The registry mirrors carry the identity across a kernel death (second review): the queue mirror keeps
+  each identified copy's id and stamp, the echo mirror keeps the echo's uuid, and a fed copy the dead CLI was
+  holding goes back into the queue under its own id. An older kernel's mirror (texts only) restores id-less
+  copies, and a copy the backend itself queued (a death notice, the rename ping) carries none: text decides.
   Parked sends — a copy parked in the kernel's own FIFO (compaction, a usage-limit hold, a parked drive op) carries
   NO id until it reaches the backend: the park's op is the three-field record the on-disk mirror and a dozen
   readers pin, so the identity is minted where the copy enters the backend's queue. Stated as a gap.

--- a/tests/test_queued_copy_identity.py
+++ b/tests/test_queued_copy_identity.py
@@ -175,17 +175,22 @@ class TheSdkQueueCarriesIds(unittest.TestCase):
         self.assertEqual([m["md"] for m in after], ["a", "c"])
         self.assertEqual([m["qid"] for m in after], [before[0]["qid"], before[2]["qid"]])
 
-    def test_a_copy_the_backend_queued_itself_and_a_restored_queue_carry_no_id(self):
+    def test_a_copy_the_backend_queued_itself_carries_no_id_and_a_restored_queue_keeps_what_its_mirror_carries(self):
         self.w.be.send(SID, "typed")
         self.w.s.enqueue_if_empty("ping")           # the queue is not empty: refused, nothing changes
         self.w.s.enqueue("a backend-minted notice")  # no id: the chat falls back to text for it
         meta = self.w.be.pending_queued_meta(SID)
         self.assertEqual([m["md"] for m in meta], ["typed", "a backend-minted notice"])
         self.assertIsNotNone(meta[0]["qid"]); self.assertIsNone(meta[1]["qid"])
-        # a queue restored from the registry after a kernel death: texts only
+        # a queue restored from the registry after a kernel death: the mirror carries each identified copy's id
+        # (second review: a chat that latched the id before the death must find it in the new life)
         del self.w.be.sessions[SID]
         self.assertEqual(self.w.be.pending_queued(SID), ["typed", "a backend-minted notice"], "the persisted mirror")
-        self.assertIsNone(self.w.be.pending_queued_meta(SID), "…and it carries no ids (legacy)")
+        self.assertEqual([(m["md"], m["qid"]) for m in self.w.be.pending_queued_meta(SID)],
+                         [("typed", meta[0]["qid"]), ("a backend-minted notice", None)], "…with the ids it carried")
+        # an older kernel's mirror (texts only) restores id-less copies: legacy, text decides
+        reg = sb.read_reg(self.w.be.state_dir, SID); reg.pop("queueMeta", None); sb.write_reg(self.w.be.state_dir, SID, reg)
+        self.assertEqual([m["qid"] for m in self.w.be.pending_queued_meta(SID)], [None, None])
 
     def test_the_feed_moves_the_id_to_the_fed_ledger_and_the_landing_is_paired_fifo_per_text(self):
         self.w.be.send(SID, "ok"); self.w.be.send(SID, "other"); self.w.be.send(SID, "ok")
@@ -342,6 +347,88 @@ class TheTmuxQueueCarriesStamps(unittest.TestCase):
         # so an id only the ledger copy wore would make the chat reject the echo as another send's (review)
         self.assertIsNone(meta[0]["qid"])
         td.cleanup()
+
+
+class IdentitySurvivesTheKernelsDeath(unittest.TestCase):
+    """A kernel restart used to re-mint everything (second review): the queue mirror carried texts only, so the
+    restored copies were id-less; the echo mirror carried no uuid, so the reseeded echo wore a new one; and a fed
+    copy re-headed or re-delivered after the death lost its id on the way back into the queue. A chat that had
+    latched the copy's id before the death then found nothing in the frame wearing it. Both mirrors carry the
+    identity now, and the two ways back into the queue carry it too, so the restored copy, the reseeded echo and
+    the eventual landing still share one id."""
+
+    def setUp(self):
+        self.w = _World()
+        self.w.write(RUNNING, shift=self.w.now - T0)   # at the clock: a landing must follow the feed in time
+        self._parks = []
+
+    def tearDown(self):
+        for park in self._parks:
+            park.set()
+        self.w.close()
+
+    def _restart(self):
+        """The kernel dies and boots: a fresh backend over the same state root re-seeds the echo mirror (its
+        __init__), and the session is rebuilt from its registry record, the way the boot reconcile seeds it."""
+        import threading
+        self.w._park.set()
+        self.w.be.sessions.pop(SID, None)
+        be2 = sb.SdkBackend(self.w.be.state_dir, "/bin/true", lambda *a, **k: None)
+        s2 = sb.SdkSession(be2, dict(sb.read_reg(be2.state_dir, SID)))
+        park = threading.Event(); self._parks.append(park)
+        s2.thread = threading.Thread(target=park.wait, daemon=True); s2.thread.start()
+        be2.sessions[SID] = s2
+        km._sdk = lambda: be2
+        return be2, s2
+
+    def test_the_restored_queue_and_the_reseeded_echo_keep_the_copys_id_and_the_landing_pairs_with_it(self):
+        self.assertTrue(self.w.be.send(SID, "rename it"))
+        [qid] = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
+        be2, s2 = self._restart()
+        self.assertEqual([(m["md"], m["qid"]) for m in be2.pending_queued_meta(SID)], [("rename it", qid)],
+                         "the queue mirror carries the id across the death")
+        self.assertEqual([(a["uuid"], bool(a.get("dropped"))) for a in be2.live_atoms(SID) if a.get("_echo_text")], [(qid, False)],
+                         "the reseeded echo keeps its uuid, which IS the id")
+        with s2._lock:
+            s2._pop_for_feed_locked()
+        self.w.write(RUNNING + [uline(T0 + 55, "rename it", "u3", "tr1")], shift=self.w.now - T0)
+        m = self.w.build()
+        landed = [e for e in m["events"] if e.get("kind") == "user" and e.get("uuid") == "u3"]
+        self.assertEqual([e.get("qid") for e in landed], [qid], "the landing pairs with the same id in the new life")
+
+    def test_a_fed_copy_the_dead_cli_was_holding_is_re_delivered_under_its_own_id(self):
+        self.assertTrue(self.w.be.send(SID, "go on"))
+        [qid] = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
+        with self.w.s._lock:
+            self.w.s._pop_for_feed_locked()           # the CLI took it…
+        self.w.s._persist_queue()                     # …so the mirror holds an empty queue and the unlanded echo
+        be2, s2 = self._restart()                     # boot: the echo's text is in no queue and never landed: re-delivered
+        self.assertEqual([(m["md"], m["qid"]) for m in be2.pending_queued_meta(SID)], [("go on", qid)],
+                         "back in the queue under the echo's own uuid")
+        self.assertEqual([(a["uuid"], bool(a.get("dropped"))) for a in be2.live_atoms(SID) if a.get("_echo_text")], [(qid, False)])
+
+    def test_a_dead_spawns_re_delivery_into_a_live_session_carries_the_id_and_clears_the_stale_ledger_entry(self):
+        self.assertTrue(self.w.be.send(SID, "go on"))
+        [qid] = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
+        with self.w.s._lock:
+            self.w.s._pop_for_feed_locked()
+        self.assertEqual([f["qid"] for f in self.w.s._fed_meta], [qid])
+        self.w.be._mark_dropped_echoes(SID, self.w.s.pending())    # the dead-spawn caller: the live session re-queues it
+        self.assertEqual([(m["md"], m["qid"]) for m in self.w.s.pending_meta()], [("go on", qid)])
+        self.assertEqual(self.w.s._fed_meta, [], "a copy back in the queue is no longer fed: its stale entry cannot pair a later landing")
+
+    def test_a_stranded_fed_copy_re_heads_the_queue_with_its_id(self):
+        self.assertTrue(self.w.be.send(SID, "go on"))
+        self.assertTrue(self.w.be.send(SID, "then this"))
+        [qid, later] = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
+        s = self.w.s
+        with s._lock:
+            s._pop_for_feed_locked()
+        s._inflight_texts.append("go on"); s.inflight = 1; s.resume_sid = None   # fed to a client that is now gone
+        s._reconcile_stranded()
+        self.assertEqual([(m["md"], m["qid"]) for m in s.pending_meta()], [("go on", qid), ("then this", later)],
+                         "the fed copy is back at the head under its own id")
+        self.assertEqual(s._fed_meta, [], "…and out of the fed ledger")
 
 
 if __name__ == "__main__":

--- a/tests/test_queued_copy_identity.py
+++ b/tests/test_queued_copy_identity.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Every copy in the kernel's queued group carries an identity (T252c, the user via the manager 2026-09-08): the
+chat's pending bubble placed itself by TEXT and ORDINAL because the group carried texts and nothing else, and text
+cannot tell a press-time copy from a same-text copy another client queued later, nor pair two landings that arrive
+in one frame after a reconnect. Under the authoritative-source rule the identity comes from the store that owns the
+queue:
+
+  SDK backend — send() mints the copy's id (the echo key it already minted for the optimistic echo) BEFORE the
+  enqueue, so the queued copy, the echo atom and the landed atom share one id; the feed moves the id to a fed
+  ledger, and the landed user record is paired with it FIFO per text, at or after the feed time (qid on the chat
+  event). A queue restored from the registry after a kernel death carries no ids (legacy: the chat falls back to
+  text), and so does a copy the backend itself queued (a death notice, the rename ping).
+  Parked sends — a copy parked in the kernel's own FIFO (compaction, a usage-limit hold, a parked drive op) carries
+  NO id until it reaches the backend: the park's op is the three-field record the on-disk mirror and a dozen
+  readers pin, so the identity is minted where the copy enters the backend's queue. Stated as a gap.
+  tmux — the CLI's queue-operation records carry timestamps but no ids: each copy carries its enqueue stamp and a
+  digest of (stamp, text) as its id; nothing pairs the landed record (the kernel does not see the CLI take it).
+
+SYNTHETIC fixtures only: a private synthetic sid, the notes-api demo world, hostname-free.
+"""
+import json
+import os
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_qid", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_qid", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "5a6b7c8d-1e2f-4a3b-9c4d-5e6f7a8b9c0d"   # private synthetic sid (goal-store fixtures rule)
+T0 = 1_800_000_000
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+class _World:
+    """A real SdkBackend bound as the kernel's backend, owning SID, with a thread-less SdkSession, plus the
+    discovery a build_session needs (names/ + projects/<cdir>/<SID>.jsonl under a hermetic state root)."""
+
+    def __init__(self):
+        self.td = tempfile.TemporaryDirectory()
+        root = Path(self.td.name)
+        (root / "sdk").mkdir()
+        self.cwd = root / "proj"; self.cwd.mkdir()
+        os.environ["CLAUDE_CONFIG_DIR"] = str(root / "claude")
+        self.tpath = Path(sb.transcript_path(str(self.cwd), SID))
+        self.tpath.parent.mkdir(parents=True, exist_ok=True)
+        self.tpath.write_text("")
+        self.be = sb.SdkBackend(str(root), "/bin/true", lambda *a, **k: None)
+        reg = {"sid": SID, "name": "web", "mode": "acceptEdits", "alive": True, "cwd": str(self.cwd), "lastSid": SID}
+        sb.write_reg(self.be.state_dir, SID, reg)
+        self.s = sb.SdkSession(self.be, dict(reg))
+        # _ensure hands a send to THIS session only while its thread is alive (a dead one is respawned and
+        # the spawn dies on the stand-in binary): park a daemon thread in its place for the test's life
+        import threading
+        self._park = threading.Event()
+        self.s.thread = threading.Thread(target=self._park.wait, daemon=True)
+        self.s.thread.start()
+        self.be.sessions[SID] = self.s
+        self.saved_sdk = km._sdk
+        km._sdk = lambda: self.be
+        proj = root / "projects"
+        names = root / "names"; names.mkdir()
+        (names / SID).write_text("web\t%s\t#abcdef\n" % str(self.cwd))
+        self.saved = (km.jd.NAMES, km.jd.PROJECTS, km.jd.CAPDIR, km.jd.ARCHDIR, km.jd.GOALDIR, km.jd.STATE,
+                      km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD)
+        km.jd.NAMES, km.jd.PROJECTS = names, proj
+        km.jd.CAPDIR, km.jd.ARCHDIR, km.jd.GOALDIR = root / "captions", root / "archive", root / "goals"
+        km.jd.STATE = root
+        km.NAMES = names
+        km._GLOBAL_CLAUDE_MD = root / "no-global-claude.md"
+        self.now = int(time.time())
+        self.tm = {SID: {"state": "working", "since": self.now - 100, "model": "", "effort": "",
+                         "context": None, "compactPct": None, "color": None}}
+        km._tmux_sessions = lambda: self.tm
+        km._chat_fold.clear(); km._parse_cache.clear()
+        km._PATH_LINK_CACHE.clear(); km._SPACE_PATH_CACHE.clear()
+        km._postal_index_memo[0] = None
+        if isinstance(km.jd._discover_cache, dict):
+            km.jd._discover_cache.clear()
+        # the build_session transcript lives under the kernel's project dir for the cwd
+        self.kpath = proj / km.jd._proj_dir(str(self.cwd)).name / (SID + ".jsonl")
+        self.kpath.parent.mkdir(parents=True, exist_ok=True)
+
+    def close(self):
+        self._park.set()
+        (km.jd.NAMES, km.jd.PROJECTS, km.jd.CAPDIR, km.jd.ARCHDIR, km.jd.GOALDIR, km.jd.STATE,
+         km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD) = self.saved
+        km._sdk = self.saved_sdk
+        km._chat_fold.clear(); km._parse_cache.clear()
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+        import shutil
+        shutil.rmtree(self.td.name, ignore_errors=True)   # a backend writer (the echo mirror) may still be finishing
+
+    def write(self, recs, shift=None):
+        # discovery keys on the real clock: shift the fixture to "just now"; a landing that must pair with a
+        # feed made during the test is written AT the clock (shift=now-T0), since the CLI's enqueue stamp is
+        # never earlier than the feed that handed it the text
+        shift = (self.now - 600) - T0 if shift is None else shift
+        out = []
+        for r in recs:
+            r = dict(r)
+            r["timestamp"] = iso(datetime.strptime(r["timestamp"], "%Y-%m-%dT%H:%M:%S.000Z").replace(tzinfo=timezone.utc).timestamp() + shift)
+            out.append(r)
+        self.kpath.write_text("".join(json.dumps(r) + "\n" for r in out))
+        return shift
+
+    def build(self):
+        km._chat_fold.clear(); km._parse_cache.clear()
+        return km.build_session(SID, self.now, self.tm)
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "promptSource": "sdk",
+            "sessionId": SID, "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent, tools=(), stop="end_turn"):
+    content = [{"type": "text", "text": text}] if text else []
+    for i, n in enumerate(tools):
+        content.append({"type": "tool_use", "id": "tu_%s_%d" % (uuid, i), "name": n, "input": {"command": "true"}})
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "sessionId": SID,
+            "message": {"role": "assistant", "content": content, "stop_reason": stop}}
+
+
+def trline(t, tool_use_id, uuid, parent):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "sessionId": SID,
+            "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": tool_use_id, "content": "ok"}]}}
+
+
+def attline(t, prompt, uuid, parent):
+    return {"type": "attachment", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "isSidechain": False,
+            "sessionId": SID, "attachment": {"type": "queued_command", "prompt": prompt}}
+
+
+RUNNING = [uline(T0, "tighten the notes-api search", "u1"), aline(T0 + 10, "Done.", "a1", "u1"),
+           uline(T0 + 39, "drop the unused import", "u2", "a1"),
+           aline(T0 + 41, "Removing it.", "a2", "u2", tools=("Bash",), stop="tool_use"), trline(T0 + 50, "tu_a2_0", "tr1", "a2")]
+
+
+class TheSdkQueueCarriesIds(unittest.TestCase):
+    def setUp(self):
+        self.w = _World()
+
+    def tearDown(self):
+        self.w.close()
+
+    def test_send_mints_the_id_before_the_enqueue_and_the_echo_shares_it(self):
+        self.assertTrue(self.w.be.send(SID, "first"))
+        self.assertTrue(self.w.be.send(SID, "second"))
+        meta = self.w.be.pending_queued_meta(SID)
+        self.assertEqual(self.w.be.pending_queued(SID), ["first", "second"])
+        self.assertEqual([m["md"] for m in meta], ["first", "second"])
+        echoes = {a["uuid"] for a in self.w.be.live_atoms(SID) if a.get("_echo_text")}
+        self.assertEqual({m["qid"] for m in meta}, echoes, "the copy's id IS its echo's uuid")
+        self.assertTrue(all(isinstance(m["qts"], int) and m["qts"] > 1_700_000_000_000 for m in meta), "an epoch-ms enqueue stamp")
+
+    def test_unqueue_keeps_the_ids_aligned(self):
+        self.w.be.send(SID, "a"); self.w.be.send(SID, "b"); self.w.be.send(SID, "c")
+        before = self.w.be.pending_queued_meta(SID)
+        self.assertEqual(self.w.be.unqueue(SID, 1, expect="b"), "b")
+        after = self.w.be.pending_queued_meta(SID)
+        self.assertEqual([m["md"] for m in after], ["a", "c"])
+        self.assertEqual([m["qid"] for m in after], [before[0]["qid"], before[2]["qid"]])
+
+    def test_a_copy_the_backend_queued_itself_and_a_restored_queue_carry_no_id(self):
+        self.w.be.send(SID, "typed")
+        self.w.s.enqueue_if_empty("ping")           # the queue is not empty: refused, nothing changes
+        self.w.s.enqueue("a backend-minted notice")  # no id: the chat falls back to text for it
+        meta = self.w.be.pending_queued_meta(SID)
+        self.assertEqual([m["md"] for m in meta], ["typed", "a backend-minted notice"])
+        self.assertIsNotNone(meta[0]["qid"]); self.assertIsNone(meta[1]["qid"])
+        # a queue restored from the registry after a kernel death: texts only
+        del self.w.be.sessions[SID]
+        self.assertEqual(self.w.be.pending_queued(SID), ["typed", "a backend-minted notice"], "the persisted mirror")
+        self.assertIsNone(self.w.be.pending_queued_meta(SID), "…and it carries no ids (legacy)")
+
+    def test_the_feed_moves_the_id_to_the_fed_ledger_and_the_landing_is_paired_fifo_per_text(self):
+        self.w.be.send(SID, "ok"); self.w.be.send(SID, "other"); self.w.be.send(SID, "ok")
+        ids = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
+        with self.w.s._lock:
+            fed = [self.w.s._pop_for_feed_locked() for _ in range(3)]
+        self.assertEqual([f[0] for f in fed], ["ok", "other", "ok"])
+        self.assertEqual(self.w.be.pending_queued(SID), [])
+        now = int(time.time())
+        self.assertEqual(self.w.be.qid_for_landing(SID, "uA", "ok", now + 1), ids[0], "the first landing of 'ok' is the first fed 'ok'")
+        self.assertEqual(self.w.be.qid_for_landing(SID, "uA", "ok", now + 1), ids[0], "memoised per record")
+        self.assertEqual(self.w.be.qid_for_landing(SID, "uB", "ok", now + 2), ids[2], "the second landing is the second fed 'ok'")
+        self.assertIsNone(self.w.be.qid_for_landing(SID, "uC", "ok", now + 3), "no third fed copy: nothing to pair")
+        self.assertIsNone(self.w.be.qid_for_landing(SID, "uOld", "other", now - 3600), "a record stamped long before the feed is not this copy's landing")
+        self.assertEqual(self.w.be.qid_for_landing(SID, "uD", "other", now), ids[1])
+
+
+class TheChatCarriesTheIds(unittest.TestCase):
+    def setUp(self):
+        self.w = _World()
+
+    def tearDown(self):
+        self.w.close()
+        km._pending_ops.pop(SID, None)
+
+    def test_the_queued_group_and_the_landed_atom_share_the_copys_id(self):
+        live = self.w.now - T0            # this test's records sit at the clock: the landing follows the feed in time
+        self.w.write(RUNNING, shift=live)
+        fed_text = "and also update the docstring"
+        self.assertTrue(self.w.be.send(SID, fed_text))
+        self.assertTrue(self.w.be.send(SID, "later one"))
+        qid_fed, qid_later = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
+        m = self.w.build()
+        q = [e for e in m["events"] if e.get("kind") == "queued"]
+        self.assertEqual(len(q), 1, [e.get("kind") for e in m["events"]])
+        self.assertEqual([(t["md"], t.get("qid"), isinstance(t.get("qts"), int)) for t in q[0]["texts"]],
+                         [(fed_text, qid_fed, True), ("later one", qid_later, True)])
+        # the CLI takes the first copy at the boundary: the feed pops it, the splice record lands it
+        with self.w.s._lock:
+            self.w.s._pop_for_feed_locked()
+        recs = RUNNING + [attline(T0 + 55, fed_text, "att1", "tr1"), aline(T0 + 75, "Updated.", "a3", "att1", tools=("Bash",), stop="tool_use")]
+        self.w.write(recs, shift=live)
+        m = self.w.build()
+        landed = [e for e in m["events"] if e.get("kind") == "user" and e.get("md") == fed_text]
+        self.assertEqual(len(landed), 1)
+        self.assertTrue(landed[0].get("absorbed"))
+        self.assertEqual(landed[0].get("qid"), qid_fed, "the landed atom carries the copy's id")
+        q = [e for e in m["events"] if e.get("kind") == "queued"]
+        self.assertEqual([t.get("qid") for t in q[0]["texts"]], [qid_later], "the queue now holds the other copy only")
+
+    def test_a_parked_copy_carries_no_id_until_it_reaches_the_backend(self):
+        # the park's op is the three-field record the on-disk mirror and its readers pin: no identity rides it; the
+        # copy is identified where it enters the backend's queue (send()), and the chat reads a parked copy by text
+        self.w.write(RUNNING)
+        km._park_op(SID, ("send", "parked words", None))
+        m = self.w.build()
+        q = [e for e in m["events"] if e.get("kind") == "queued"]
+        self.assertEqual([(x["md"], x.get("qid"), x.get("qts")) for x in q[0]["texts"]], [("parked words", None, None)])
+        km._deliver_send_batch(self.w.be, SID, [km._pending_ops[SID][0]])
+        meta = self.w.be.pending_queued_meta(SID)
+        self.assertEqual(meta[0]["md"], "parked words")
+        self.assertTrue(meta[0]["qid"] and meta[0]["qid"].startswith("echo:"), "…and gains one the moment it enters the backend's queue")
+
+
+class TheTmuxQueueCarriesStamps(unittest.TestCase):
+    def test_each_copy_carries_its_enqueue_stamp_and_a_digest_id_and_nothing_pairs_the_landing(self):
+        td = tempfile.TemporaryDirectory()
+        p = Path(td.name) / "t.jsonl"
+        recs = [{"type": "queue-operation", "operation": "enqueue", "content": "one", "timestamp": iso(T0 + 5)},
+                {"type": "queue-operation", "operation": "enqueue", "content": "two", "timestamp": iso(T0 + 9)},
+                {"type": "queue-operation", "operation": "dequeue", "timestamp": iso(T0 + 12)}]
+        p.write_text("".join(json.dumps(r) + "\n" for r in recs))
+        km._queued_parse_cache.clear()
+        self.assertEqual(km._pending_queued(str(p)), ["two"])
+        meta = km._pending_queued_meta(str(p))
+        self.assertEqual([m["md"] for m in meta], ["two"])
+        self.assertEqual(meta[0]["qts"], (T0 + 9) * 1000)
+        self.assertTrue(meta[0]["qid"].startswith("tq:") and len(meta[0]["qid"]) > 6)
+        self.assertEqual(meta[0]["qid"], km._pending_queued_meta(str(p))[0]["qid"], "stable across folds")
+        td.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_queued_copy_identity.py
+++ b/tests/test_queued_copy_identity.py
@@ -13,8 +13,9 @@ queue:
   Parked sends — a copy parked in the kernel's own FIFO (compaction, a usage-limit hold, a parked drive op) carries
   NO id until it reaches the backend: the park's op is the three-field record the on-disk mirror and a dozen
   readers pin, so the identity is minted where the copy enters the backend's queue. Stated as a gap.
-  tmux — the CLI's queue-operation records carry timestamps but no ids: each copy carries its enqueue stamp and a
-  digest of (stamp, text) as its id; nothing pairs the landed record (the kernel does not see the CLI take it).
+  tmux — the CLI's queue-operation records carry timestamps but no ids: each copy carries its enqueue stamp and NO
+  id (an id only the ledger copy wore would make the chat reject the tmux echo as another send's); nothing pairs the
+  landed record (the kernel does not see the CLI take it), so the chat reads this route by text.
 
 SYNTHETIC fixtures only: a private synthetic sid, the notes-api demo world, hostname-free.
 """
@@ -201,6 +202,34 @@ class TheSdkQueueCarriesIds(unittest.TestCase):
         self.assertIsNone(self.w.be.qid_for_landing(SID, "uOld", "other", now - 3600), "a record stamped long before the feed is not this copy's landing")
         self.assertEqual(self.w.be.qid_for_landing(SID, "uD", "other", now), ids[1])
 
+    def test_the_kernels_own_echo_never_consumes_a_fed_entry(self):
+        # the echo atom is a user atom too, stamped at the send; between the feed and the CLI's record it is the
+        # visible copy — asked as a landing it took the fed entry and the real landing then carried no id (review)
+        self.w.be.send(SID, "hello there")
+        [qid] = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
+        with self.w.s._lock:
+            self.w.s._pop_for_feed_locked()
+        now = int(time.time())
+        self.assertIsNone(self.w.be.qid_for_landing(SID, qid, "hello there", now), "an echo uuid is refused")
+        self.assertEqual(self.w.be.qid_for_landing(SID, "uReal", "hello there", now + 1), qid, "…so the record still pairs")
+
+    def test_a_batched_record_pairs_every_block_and_a_dropped_copy_leaves_the_ledger(self):
+        self.w.be.send(SID, "ok"); self.w.be.send(SID, "ok"); self.w.be.send(SID, "ok")
+        ids = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
+        with self.w.s._lock:
+            for _ in range(3): self.w.s._pop_for_feed_locked()
+        now = int(time.time())
+        self.assertEqual(self.w.be.qids_for_landing(SID, "uJ", ["ok", "ok"], now), [ids[0], ids[1]], "two blocks, two copies, in order")
+        self.assertEqual(self.w.be.qids_for_landing(SID, "uJ", ["ok", "ok"], now), [ids[0], ids[1]], "memoised per record")
+        self.assertEqual(self.w.be.qid_for_landing(SID, "u3", "ok", now + 1), ids[2], "the third landing is the third copy's, not a stale first")
+        # a copy fed and then dropped for good leaves the ledger, so a later same-text landing is not paired with it
+        self.w.be.send(SID, "again"); self.w.be.send(SID, "again")
+        [d1, d2] = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
+        with self.w.s._lock:
+            for _ in range(2): self.w.s._pop_for_feed_locked()
+        self.w.be.forget_fed(SID, d1)          # what the never-delivered marking calls
+        self.assertEqual(self.w.be.qid_for_landing(SID, "uAg", "again", now + 2), d2)
+
 
 class TheChatCarriesTheIds(unittest.TestCase):
     def setUp(self):
@@ -235,6 +264,53 @@ class TheChatCarriesTheIds(unittest.TestCase):
         q = [e for e in m["events"] if e.get("kind") == "queued"]
         self.assertEqual([t.get("qid") for t in q[0]["texts"]], [qid_later], "the queue now holds the other copy only")
 
+    def test_an_intermediate_build_between_the_feed_and_the_landing_keeps_the_pairing(self):
+        live = self.w.now - T0
+        self.w.write(RUNNING, shift=live)
+        fed_text = "and also update the docstring"
+        self.w.be.send(SID, fed_text)
+        [qid] = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
+        with self.w.s._lock:
+            self.w.s._pop_for_feed_locked()
+        mid = self.w.build()                    # the echo is the visible copy now: a build here must not pair it
+        echoes = [e for e in mid["events"] if e.get("kind") == "user" and str(e.get("uuid", "")).startswith("echo:")]
+        self.assertEqual([e.get("qid") for e in echoes], [None] * len(echoes), "an echo event carries no landing id (its uuid IS the copy's id)")
+        self.w.write(RUNNING + [attline(T0 + 55, fed_text, "att1", "tr1"), aline(T0 + 75, "Updated.", "a3", "att1", tools=("Bash",), stop="tool_use")], shift=live)
+        m = self.w.build()
+        landed = [e for e in m["events"] if e.get("kind") == "user" and e.get("md") == fed_text and not str(e.get("uuid", "")).startswith("echo:")]
+        self.assertEqual([e.get("qid") for e in landed], [qid])
+
+    def test_a_two_block_record_carries_both_copies_ids(self):
+        live = self.w.now - T0
+        self.w.write(RUNNING, shift=live)
+        self.w.be.send(SID, "first of two"); self.w.be.send(SID, "second of two")
+        [q1, q2] = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
+        with self.w.s._lock:
+            for _ in range(2): self.w.s._pop_for_feed_locked()
+        batched = {"type": "user", "timestamp": iso(T0 + 90), "uuid": "u9", "parentUuid": "tr1", "promptSource": "sdk", "sessionId": SID,
+                   "message": {"role": "user", "content": [{"type": "text", "text": "first of two"}, {"type": "text", "text": "second of two"}]}}
+        self.w.write(RUNNING + [batched], shift=live)
+        m = self.w.build()
+        rec = [e for e in m["events"] if e.get("kind") == "user" and e.get("uuid") == "u9"]
+        self.assertEqual(len(rec), 1)
+        self.assertEqual(rec[0].get("blocks"), ["first of two", "second of two"])
+        self.assertEqual(rec[0].get("qids"), [q1, q2], "one id per block, in block order")
+        self.assertIsNone(rec[0].get("qid"), "no single id claims the whole record")
+
+    def test_ids_ride_only_when_each_one_sits_beside_its_own_text(self):
+        # the queue can move between the two reads a build makes (a pop and an append keep the length): an id set
+        # that does not match the texts one for one is not shipped, so no copy wears another copy's id
+        self.w.write(RUNNING)
+        self.w.be.send(SID, "A"); self.w.be.send(SID, "B")
+        real = self.w.be.pending_queued_meta
+        self.w.be.pending_queued_meta = lambda sid: [{"md": "B", "qid": "echo:b", "qts": 1}, {"md": "C", "qid": "echo:c", "qts": 2}]
+        try:
+            m = self.w.build()
+        finally:
+            self.w.be.pending_queued_meta = real
+        q = [e for e in m["events"] if e.get("kind") == "queued"]
+        self.assertEqual([(x["md"], x.get("qid")) for x in q[0]["texts"]], [("A", None), ("B", None)])
+
     def test_a_parked_copy_carries_no_id_until_it_reaches_the_backend(self):
         # the park's op is the three-field record the on-disk mirror and its readers pin: no identity rides it; the
         # copy is identified where it enters the backend's queue (send()), and the chat reads a parked copy by text
@@ -250,7 +326,7 @@ class TheChatCarriesTheIds(unittest.TestCase):
 
 
 class TheTmuxQueueCarriesStamps(unittest.TestCase):
-    def test_each_copy_carries_its_enqueue_stamp_and_a_digest_id_and_nothing_pairs_the_landing(self):
+    def test_each_copy_carries_its_enqueue_stamp_and_no_id_since_nothing_on_this_route_could_share_one(self):
         td = tempfile.TemporaryDirectory()
         p = Path(td.name) / "t.jsonl"
         recs = [{"type": "queue-operation", "operation": "enqueue", "content": "one", "timestamp": iso(T0 + 5)},
@@ -262,8 +338,9 @@ class TheTmuxQueueCarriesStamps(unittest.TestCase):
         meta = km._pending_queued_meta(str(p))
         self.assertEqual([m["md"] for m in meta], ["two"])
         self.assertEqual(meta[0]["qts"], (T0 + 9) * 1000)
-        self.assertTrue(meta[0]["qid"].startswith("tq:") and len(meta[0]["qid"]) > 6)
-        self.assertEqual(meta[0]["qid"], km._pending_queued_meta(str(p))[0]["qid"], "stable across folds")
+        # no id: the tmux echo is minted before the CLI writes its enqueue record and the landing carries nothing,
+        # so an id only the ledger copy wore would make the chat reject the echo as another send's (review)
+        self.assertIsNone(meta[0]["qid"])
         td.cleanup()
 
 

--- a/tests/test_sdk_rewind.py
+++ b/tests/test_sdk_rewind.py
@@ -189,7 +189,7 @@ class RollbackAndPendingCut(unittest.TestCase):
         # the head (a held postal delivery, say) must survive the failure
         self.assertIn("bare = self._rewind_bare", BACKEND_SRC)
         i_bare = BACKEND_SRC.index("bare = self._rewind_bare")
-        i_pop = BACKEND_SRC.index("dropped = self._pending.pop(0) if self._pending else None", i_bare)
+        i_pop = BACKEND_SRC.index("dropped = self._q_pop(0)[0] if self._pending else None", i_bare)   # T252c: the queue pops through its helper
         seg = BACKEND_SRC[i_bare:i_pop]
         self.assertIn("if not bare:", seg)
         self.assertIn("the rollback failed (the session's CLI refused it)", BACKEND_SRC)

--- a/tests/test_sdk_stream_survives_handler_errors.py
+++ b/tests/test_sdk_stream_survives_handler_errors.py
@@ -1138,7 +1138,7 @@ class TheDeferredReconnectTakesTheHeldQueueWithIt(unittest.TestCase):
     def test_the_hold_keys_on_the_armed_flag_by_source(self):
         src = inspect.getsource(sb.SdkSession._amain)
         i_inputs = src.index("async def inputs():")
-        i_pop = src.index("item = self._pending.pop(0)", i_inputs)
+        i_pop = src.index("item, _meta = self._pop_for_feed_locked()", i_inputs)   # T252c: the head leaves through the feed pop
         gate = src[i_inputs:i_pop]
         self.assertIn("blocked = blocked or self._reconnect\n", gate, "the armed flag is a hold in the gate")
         self.assertNotIn("_reconnect_when_idle", gate, "…and the deferred flag is not (mid-turn forwards flow)")

--- a/ui/webview/optimistic-send.test.ts
+++ b/ui/webview/optimistic-send.test.ts
@@ -162,7 +162,11 @@ test("EVERY ✕ stops our re-injection first; the optimistic one cancels by body
   // cancelResult, and the composer restore reverts (pendingCancelRestores).
   assert.match(RENDER, /if \(qmd\) \{/);
   // …by the bubble's OWN identity when it has one (data-qts) — send-pending.test.ts runs the lookup
-  assert.match(RENDER, /const qts = el\.dataset\.qts !== undefined \? Number\(el\.dataset\.qts\) : undefined;\s*\n\s*if \(dropPending\(list, qmd, qts\)\)/);
+  assert.match(RENDER, /const qts = el\.dataset\.qts !== undefined \? Number\(el\.dataset\.qts\) : undefined;\s*\n\s*const qid = el\.dataset\.qid \|\| undefined;\s*\n\s*if \(dropPending\(list, qmd, qts, qid\)\)/);
+  // …and the kernel's copies carry their own enqueue stamp under `qts` now (T252c): only OUR bubble's stamp is its identity
+  // for the ✕, while a kernel copy's ✕ names the copy's id, so it drops the send that owns it (third review)
+  assert.match(RENDER, /if \(t\.optimistic && t\.qts !== undefined\) x\.dataset\.qts = String\(t\.qts\);/);
+  assert.match(RENDER, /if \(t\.qid\) x\.dataset\.qid = t\.qid;/);
   assert.doesNotMatch(RENDER, /list\.findIndex\(\(p\) => p\.text === qmd\)/, "never 'the first entry with this text' for a bubble that names its entry");
   assert.match(RENDER, /echoShownSig\.delete\(sidQ\);/);
   assert.match(RENDER, /const msg: Record<string, unknown> = \{ type: "cancelQueued", id: sidQ, md: qmd \};/);

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -13,7 +13,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("a queued ChatEvent carries the pending messages (backend-agnostic, per-message md)", () => {
   // idx = backend-queue position (SDK); park = _pending_ops position (compaction/model parking, any backend)
   // `optimistic` (romp's own unconfirmed echo) rides along at the end — see optimistic-send.test.ts
-  assert.match(RENDER, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number; hiddenByPending\?: boolean \}\[\]/);   // imgPaths: the echo's dragged-image thumbnails (2026-08-25); romp flags: T243; lost + qts: the pending entry's connection-drop state and its identity for the ✕ (2026-09-06)
+  assert.match(RENDER, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number; qid\?: string; hiddenByPending\?: boolean \}\[\]/);   // imgPaths: the echo's dragged-image thumbnails (2026-08-25); romp flags: T243; lost + qts: the pending entry's connection-drop state and its identity for the ✕ (2026-09-06)
 });
 
 test("renderQueued draws a wireframe-hourglass header (singular/plural) + one markdown bubble per queued message", () => {
@@ -247,7 +247,7 @@ test("the kernel flags a romp-injected queued entry from the same markers as a l
 });
 
 test("what romp itself queued wears the LANDED romp grammar, split as landed: notice card vs gray romp bubble (T243)", () => {
-  assert.match(RENDER, /romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number; hiddenByPending\?: boolean \}\[\]/, "the queued text shape carries the flags");
+  assert.match(RENDER, /romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number; qid\?: string; hiddenByPending\?: boolean \}\[\]/, "the queued text shape carries the flags");
   const body = RENDER.split("function renderQueued(")[1].split("\nfunction ")[0];
   assert.match(body, /const bubble = el\("div", "queued-bubble md" \+ \(t\.cancelable \? " cancelable" : ""\)\s*\n\s*\+ \(t\.romp \? " queued-romp" : ""\) \+ \(t\.rompSystem \? " queued-sys" : ""\)\);/);
   // a SYSTEM notice → the landed card's own builder, nested; a one-line notice gets no body repeating its head

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -168,7 +168,7 @@ type ChatEvent = (
   // `held` DOES come from the kernel (_limit_hold): the queue is stuck on the ACCOUNT rather than on this
   // session — a usage limit or a monthly spend cap holds every send — so the head names what it is waiting
   // for, and how long is left when the API reported a reset (the user 2026-07-24).
-  | { kind: "queued"; texts: { md: string; followUp?: boolean; goal?: string; fuCtx?: string; idx?: number; park?: number; cancelable?: boolean; optimistic?: boolean; romp?: boolean; rompSystem?: boolean; rompAuto?: boolean; imgPaths?: string[]; lost?: string; qts?: number; hiddenByPending?: boolean }[]; ts?: string; uuid?: string; bare?: boolean; held?: { reason: string; resetsAt?: number | null; what: string; detail?: string } }   // imgPaths: an optimistic echo's dragged-image attachments → thumbnails, the landed form's own renderer (the user 2026-08-25); lost: client-only, the connection dropped after this unconfirmed send; qts: client-only, the pending entry's identity (its press time) so the ✕ removes ITS entry (send-pending.ts)
+  | { kind: "queued"; texts: { md: string; followUp?: boolean; goal?: string; fuCtx?: string; idx?: number; park?: number; cancelable?: boolean; optimistic?: boolean; romp?: boolean; rompSystem?: boolean; rompAuto?: boolean; imgPaths?: string[]; lost?: string; qts?: number; qid?: string; hiddenByPending?: boolean }[]; ts?: string; uuid?: string; bare?: boolean; held?: { reason: string; resetsAt?: number | null; what: string; detail?: string } }   // imgPaths: an optimistic echo's dragged-image attachments → thumbnails, the landed form's own renderer (the user 2026-08-25); lost: client-only, the connection dropped after this unconfirmed send; qts: on OUR optimistic copy the pending entry's identity (its press time) so the ✕ removes ITS entry, on a kernel copy its enqueue stamp (T252c); qid: a kernel copy's identity, the ✕ drops the send that owns it (send-pending.ts)
   // The turn stopped on an API error (event-based: transcript isApiErrorMessage). The session is BLOCKED
   // until retried — a red-dot card at the bottom with a Retry button (the user 2026-06-16).
   | { kind: "apiError"; text: string; status?: number; ts?: string; uuid?: string }
@@ -3965,7 +3965,8 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
       if (t.idx !== undefined) x.dataset.qidx = String(t.idx);
       if (t.park !== undefined) x.dataset.qpark = String(t.park);
       if (t.optimistic) x.dataset.qopt = "1";   // ✕ before confirmation → cancel-by-body (no park/idx yet)
-      if (t.qts !== undefined) x.dataset.qts = String(t.qts);   // OUR entry's identity: the ✕ removes this bubble's entry, not the first with its text
+      if (t.optimistic && t.qts !== undefined) x.dataset.qts = String(t.qts);   // OUR entry's identity: the ✕ removes this bubble's entry, not the first with its text
+      if (t.qid) x.dataset.qid = t.qid;   // the kernel's copy names its id (T252c): the ✕ drops the send that owns it (a kernel copy's own qts is its enqueue stamp, not an entry)
       if (isCmd) x.dataset.qcmd = "1";
       (x as any)._qmd = t.md;   // the bubble's body — the kernel's drift guard + the composer restore read it
       xHost.appendChild(x);
@@ -15245,7 +15246,8 @@ setupSettings();
         // drops the first pending send with the text — the one the kernel's first copy covers.
         const list = pendingSent.get(sidQ) || [];
         const qts = el.dataset.qts !== undefined ? Number(el.dataset.qts) : undefined;
-        if (dropPending(list, qmd, qts)) { if (list.length) pendingSent.set(sidQ, list); else pendingSent.delete(sidQ); }
+        const qid = el.dataset.qid || undefined;
+        if (dropPending(list, qmd, qts, qid)) { if (list.length) pendingSent.set(sidQ, list); else pendingSent.delete(sidQ); }
         echoShownSig.delete(sidQ);
       }
       // a PROVISIONAL tab's send has never left the client (T244): forget it from the queue adoption would

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -416,7 +416,7 @@ function hideQueuedCopy(s: Session, p: PendingSend): { held?: Extract<ChatEvent,
   const qi = tailQueuedIdx(s.events);
   if (qi < 0) return { held: undefined };            // nothing queued at the tail: nothing to hide, ours shows
   const q = s.events[qi] as Extract<ChatEvent, { kind: "queued" }>;
-  const k = queuedCopyToHide(q.texts, p.text);
+  const k = queuedCopyToHide(q.texts, p.text, p.qid);   // ours by identity first (T252c)
   if (k < 0) return null;                            // no copy to hide (or a non-cancelable one): the kernel's bubble stays
   const texts = q.texts.slice(); texts[k] = { ...texts[k], hiddenByPending: true };
   s.events[qi] = { ...q, texts };

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -1041,3 +1041,64 @@ test("two back-to-back sends the CLI took as ONE record retire both bubbles; a t
   assert.equal(provisionalIn({ kind: "user", md: "continue continue", uuid: "echo:1", blocks: ["continue", "continue"] }, list[0]), true,
     "…but were one ever shipped with blocks, its copies would be read the same way");
 });
+
+// ── (T252c, second review) identity decides where the frame SHOWS it; text decides where it does not ──────
+
+test("two identical identified sends the CLI took as one record both retire on that landing (T252c second review)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const [p1, p2] = press(tail, "ok", "ok");
+  reconcilePending([...tail, { kind: "queued", texts: [{ md: "ok", qid: "echo:q1", qts: 1 }, { md: "ok", qid: "echo:q2", qts: 2 }] }], [p1, p2]);
+  assert.deepEqual([p1.qid, p2.qid], ["echo:q1", "echo:q2"]);
+  const landing: TailEvent[] = [...tail, { kind: "user", md: "ok ok", uuid: "uXY", blocks: ["ok", "ok"], qids: ["echo:q1", "echo:q2"] }];
+  const r = reconcilePending(landing, [p1, p2]);
+  assert.deepEqual(r.landed.map((l) => [l.p, l.idx]), [[p1, 1], [p2, 1]], "each retires on its own block's id, whatever the other claimed of the text");
+  assert.deepEqual(r.keep, []);
+  // and the frames after: nothing lingers
+  assert.deepEqual(reconcilePending(landing, [p1, p2].filter((p) => !r.landed.some((l) => l.p === p))).keep, []);
+});
+
+test("an id the frame no longer carries leaves the decision to text: a restart that re-minted the mirrors, or an older kernel (T252c second review)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const latched = (text: string, ts: number): PendingSend => {
+    const p = newPending(text, undefined, ts);
+    reconcilePending(tail, [p]);
+    reconcilePending([...tail, { kind: "queued", texts: [{ md: text, qid: "echo:old" + ts, qts: 1 }] }], [p]);
+    assert.equal(p.qid, "echo:old" + ts);
+    return p;
+  };
+  // (1) the restored copy carries no id: it still covers ours, by text — ours drawn at its slot, that copy hidden
+  let p = latched("rename it", T0);
+  let r = reconcilePending([...tail, { kind: "queued", texts: [{ md: "rename it" }] }], [p]);
+  assert.deepEqual([r.unqueue, r.inject], [[p], [p]], "one bubble, never ours beside the kernel's copy");
+  // (2) an echo under a new uuid covers by text, and the first identity stays latched: nothing in the frame contradicts it
+  r = reconcilePending([...tail, { kind: "user", md: "rename it", uuid: "echo:new" }], [p]);
+  assert.deepEqual([r.inject, r.keep], [[], [p]], "the echo covers");
+  assert.equal(p.qid, "echo:old" + T0);
+  // (3) that echo flagged never-delivered is the verdict, by text
+  r = reconcilePending([...tail, { kind: "user", md: "rename it", uuid: "echo:new", undelivered: true }], [p]);
+  assert.deepEqual(r.lost, [p]);
+  // (4) a record the CLI wrote from the restored copy and a later identified send: our block carries no id, text lands it
+  p = latched("rename it", T0 + 1);
+  r = reconcilePending([...tail, { kind: "user", md: "rename it and go", uuid: "uB", blocks: ["rename it", "and go"], qids: [null, "echo:new2"] }], [p]);
+  assert.deepEqual(r.landed.map((l) => l.idx), [1]);
+});
+
+test("an id the frame still shows queued or echoed refuses a same-text landing that lacks it (T252c second review)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const [a, b] = press(tail, "ok", "ok");
+  reconcilePending([...tail, { kind: "queued", texts: [{ md: "ok", qid: "echo:q1", qts: 1 }, { md: "ok", qid: "echo:q2", qts: 2 }] }], [a, b]);
+  // the first copy lands unpaired (no id on the record) while the second is still queued under its id
+  let r = reconcilePending([...tail, { kind: "user", md: "ok", uuid: "u1" }, { kind: "queued", texts: [{ md: "ok", qid: "echo:q2", qts: 2 }] }], [a, b]);
+  assert.deepEqual(r.landed.map((l) => l.p), [a], "the id-less landing is the first send's, by text");
+  assert.deepEqual([r.keep, r.unqueue, r.inject], [[b], [b], [b]], "the second is still in the queue under its id: not that landing's");
+  // the same with the second copy fed: its echo shows the id — and the first send, landed, does not go on to claim
+  // that echo as its own cover on the way out
+  r = reconcilePending([...tail, { kind: "user", md: "ok", uuid: "u1" }, { kind: "user", md: "ok", uuid: "echo:q2" }], [a, b]);
+  assert.deepEqual([r.landed.map((l) => l.p), r.keep, r.inject], [[a], [b], []]);
+  // a send read by text (its id is nowhere in the frame) never takes an echo another send owns by id
+  const [c, d] = press(tail, "go", "go");
+  reconcilePending([...tail, { kind: "queued", texts: [{ md: "go", qid: "echo:c1", qts: 1 }, { md: "go", qid: "echo:d1", qts: 2 }] }], [c, d]);
+  assert.deepEqual([c.qid, d.qid], ["echo:c1", "echo:d1"]);
+  r = reconcilePending([...tail, { kind: "user", md: "go", uuid: "echo:d1" }], [c, d]);
+  assert.deepEqual([r.keep, r.inject], [[c, d], [c]], "the echo is the second send's cover; the first, unshown, is drawn by us");
+});

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -873,8 +873,8 @@ test("✕ on one of two identical bubbles removes that bubble's entry, never the
   assert.deepEqual(list2, []);
   // render.ts: the identity rides the bubble's ✕, and the handler removes by it
   assert.match(RENDER, /const mk = \(p: PendingSend\) => \(\{ md: p\.text, optimistic: true, cancelable: true, imgPaths: p\.imgPaths, lost: p\.lost, qts: p\.ts \}\);/);
-  assert.match(RENDER, /if \(t\.qts !== undefined\) x\.dataset\.qts = String\(t\.qts\);/);
-  assert.match(RENDER, /const qts = el\.dataset\.qts !== undefined \? Number\(el\.dataset\.qts\) : undefined;\s*\n\s*if \(dropPending\(list, qmd, qts\)\) \{ if \(list\.length\) pendingSent\.set\(sidQ, list\); else pendingSent\.delete\(sidQ\); \}/);
+  assert.match(RENDER, /if \(t\.optimistic && t\.qts !== undefined\) x\.dataset\.qts = String\(t\.qts\);/);
+  assert.match(RENDER, /const qts = el\.dataset\.qts !== undefined \? Number\(el\.dataset\.qts\) : undefined;\s*\n\s*const qid = el\.dataset\.qid \|\| undefined;\s*\n\s*if \(dropPending\(list, qmd, qts, qid\)\) \{ if \(list\.length\) pendingSent\.set\(sidQ, list\); else pendingSent\.delete\(sidQ\); \}/);
   assert.doesNotMatch(RENDER, /list\.findIndex\(\(p\) => p\.text === qmd\)/);
 });
 
@@ -1101,4 +1101,58 @@ test("an id the frame still shows queued or echoed refuses a same-text landing t
   assert.deepEqual([c.qid, d.qid], ["echo:c1", "echo:d1"]);
   r = reconcilePending([...tail, { kind: "user", md: "go", uuid: "echo:d1" }], [c, d]);
   assert.deepEqual([r.keep, r.inject], [[c, d], [c]], "the echo is the second send's cover; the first, unshown, is drawn by us");
+});
+
+test("a send covered by its identified copy holds that copy's position: a later same-text send never latches the same id, nor takes the copy (T252c third review)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const [p1, p2] = press(tail, "ok", "ok");
+  // the kernel shows the first copy alone: p1 takes it and latches its id; p2 has nothing yet
+  let r = reconcilePending([...tail, { kind: "queued", texts: [{ md: "ok", qid: "echo:q1", qts: 1 }] }], [p1, p2]);
+  assert.deepEqual([p1.qid, p2.qid, r.unqueue, r.inject], ["echo:q1", undefined, [p1], [p1, p2]]);
+  // both copies show: p1 is covered by id, and p2 takes the OTHER copy and its id
+  r = reconcilePending([...tail, { kind: "queued", texts: [{ md: "ok", qid: "echo:q1", qts: 1 }, { md: "ok", qid: "echo:q2", qts: 2 }] }], [p1, p2]);
+  assert.deepEqual([p1.qid, p2.qid], ["echo:q1", "echo:q2"], "two sends, two identities");
+  assert.deepEqual(r.unqueue, [p1, p2]);
+  // the first copy's landing retires p1 alone; p2 is still the queued second copy
+  r = reconcilePending([...tail, { kind: "user", md: "ok", uuid: "u1", qid: "echo:q1" }, { kind: "queued", texts: [{ md: "ok", qid: "echo:q2", qts: 2 }] }], [p1, p2]);
+  assert.deepEqual([r.landed.map((l) => l.p), r.keep, r.unqueue], [[p1], [p2], [p2]]);
+  // a send read by text never takes a queued copy another send owns by id, nor a landing wearing another send's id
+  const [c, d] = press(tail, "go", "go");
+  reconcilePending([...tail, { kind: "queued", texts: [{ md: "go", qid: "echo:d1", qts: 1 }] }], [d]);   // d alone saw its copy first
+  assert.equal(d.qid, "echo:d1");
+  r = reconcilePending([...tail, { kind: "queued", texts: [{ md: "go", qid: "echo:d1", qts: 1 }] }], [c, d]);
+  assert.deepEqual([c.qid, r.unqueue, r.inject], [undefined, [d], [c, d]], "the one copy is d's: c is drawn uncovered");
+  r = reconcilePending([...tail, { kind: "user", md: "go", uuid: "uD", qid: "echo:d1" }], [c, d]);
+  assert.deepEqual([r.landed.map((l) => l.p), r.keep], [[d], [c]], "the landing wearing d's id is d's, whatever the list order");
+});
+
+test("floors follow an earlier send's identity into a record of several sends, and an id-less press-time copy keeps its text floor beside an identified one (T252c third review)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const [x, y] = press(tail, "first", "second");
+  reconcilePending([...tail, { kind: "user", md: "first", uuid: "echo:x1" }], [x, y]);
+  assert.deepEqual(y.floors?.map((f) => f.qid), ["echo:x1"]);
+  dropPending([x, y], "first", x.ts);
+  // X's block lands inside a two-send record, behind an unrelated same-text message
+  const frame: TailEvent[] = [...tail, { kind: "user", md: "first", uuid: "uOther" }, { kind: "tool", uuid: "t1" },
+                              { kind: "user", md: "first and more", uuid: "uXZ", blocks: ["first", "and more"], qids: ["echo:x1", "echo:z1"] }, { kind: "tool", uuid: "t2" }];
+  assert.deepEqual(injectionGroups(frame, reconcilePending(frame, [y]).inject), [{ idx: 4, sends: [y] }], "below the record carrying X's id");
+  // a press against a group holding an identified F and an id-less F: the identified one lands by id while the other
+  // is still queued — the bubble stays below the group (the id-less copy's text floor), never above it
+  const queued: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "F", qid: "f1", qts: 1 }, { md: "F" }] }];
+  const mine = newPending("mine", undefined, T0 + 9);
+  reconcilePending(queued, [mine]);
+  const after: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1", qid: "f1" }, { kind: "tool", uuid: "t1" }, { kind: "queued", texts: [{ md: "F" }] }];
+  assert.deepEqual(injectionGroups(after, reconcilePending(after, [mine]).inject), [{ idx: 4, sends: [mine] }], "below the group while the id-less press-time copy is still queued");
+});
+
+test("the ✕ on the kernel's copy of an identified send drops THAT send's entry, by id (T252c third review)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const [p1, p2, p3] = press(tail, "ok", "ok", "ok");
+  reconcilePending([...tail, { kind: "queued", texts: [{ md: "ok", qid: "echo:q1", qts: 1 }, { md: "ok", qid: "echo:q2", qts: 2 }] }], [p1, p2, p3]);
+  assert.deepEqual([p1.qid, p2.qid, p3.qid], ["echo:q1", "echo:q2", undefined]);
+  const list = [p1, p2, p3];
+  assert.equal(dropPending(list, "ok", undefined, "echo:q2"), p2, "the second copy's ✕ removes the second send, not the first with the text");
+  assert.equal(dropPending(list, "ok", undefined, "echo:zz"), p3, "an id no entry latched falls to the first entry still WITHOUT an id — never one that owns another");
+  assert.equal(dropPending(list, "ok", undefined, "echo:zz"), undefined, "…and to nothing once every entry owns its id");
+  assert.deepEqual(list, [p1]);
 });

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -205,7 +205,7 @@ test("several pending sends: each after its own anchor, in send order; same anch
   const none = press([], "hello");
   assert.deepEqual(injectionGroups([], reconcilePending([], none).inject), [{ idx: 0, sends: [none[0]] }]);
   // an anchor that left the resident window: everything resident is later than the send, so the slot is the head
-  assert.equal(scanFrom([{ kind: "tool", uuid: "zz" }], { after: "gone", place: null, queuedForeign: [], queuedResident: {}, seen: [], queued: 0 }), 0);
+  assert.equal(scanFrom([{ kind: "tool", uuid: "zz" }], { after: "gone", place: null, queuedForeign: [], queuedForeignIds: [], queuedResident: {}, seen: [], queued: 0 }), 0);
 });
 
 test("a send pressed while an earlier send's echo is the newest event is placed BELOW that echo (review of the first cut)", () => {
@@ -508,6 +508,73 @@ test("a copy still shown in the group holds the bubble below it, and copies are 
   assert.deepEqual(injectionGroups(xTwice, r.inject), [{ idx: 2, sends: [y] }]);
 });
 
+// ── (T252c) identity from the kernel: qid on the queued copies and on the landed atom ─────────────
+
+test("the two limits fall with identities: a same-text copy queued later, and both landings in one frame (T252c)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  // (1) another client's F is queued (qid f1); we press; F lands (the atom carries qid f1); another client queues
+  // F AGAIN (qid f2) — by text the group still "shows F"; by identity the press-time copy has landed
+  const queued: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "F", qid: "f1", qts: 1 }] }];
+  const mine = newPending("mine", undefined, T0);
+  reconcilePending(queued, [mine]);
+  assert.deepEqual(mine.at?.queuedForeignIds, ["f1"], "the copies' ids are recorded at the press");
+  const again: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1", qid: "f1" }, { kind: "tool", uuid: "t1" },
+                              { kind: "queued", texts: [{ md: "mine", qid: "m1", qts: 2, hiddenByPending: true }, { md: "F", qid: "f2", qts: 3 }] }];
+  assert.deepEqual(injectionGroups(again, reconcilePending(again, [mine]).inject), [{ idx: 2, sends: [mine] }], "right after the press-time copy's landing, above the newer F");
+  const echoed: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1", qid: "f1" }, { kind: "tool", uuid: "t1" }, { kind: "user", md: "F", uuid: "echo:f2" }];
+  assert.deepEqual(injectionGroups(echoed, reconcilePending(echoed, [mine]).inject), [{ idx: 2, sends: [mine] }], "…and above the newer F's echo");
+  // (2) the reconnect: a fed same-text copy (no id we saw) and the press-time copy (qid f1) both land in ONE frame
+  const both: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF0", qid: "f0" }, { kind: "tool", uuid: "t1" }, { kind: "user", md: "F", uuid: "uF1", qid: "f1" }, { kind: "tool", uuid: "t2" }];
+  const late = newPending("mine", undefined, T0 + 1);
+  reconcilePending(queued, [late]);
+  assert.deepEqual(injectionGroups(both, reconcilePending(both, [late]).inject), [{ idx: 4, sends: [late] }], "below the copy we were queued behind, by its id, whatever landed first");
+  // without ids the same frames degrade to today's reading (the legacy path, an older kernel)
+  const strip = (evs: TailEvent[]): TailEvent[] => evs.map((e) => ({ ...e, qid: undefined, texts: e.texts?.map((t) => ({ ...t, qid: undefined })) }));
+  const legacy = newPending("mine", undefined, T0 + 2);
+  reconcilePending(strip(queued), [legacy]);
+  assert.deepEqual(legacy.at?.queuedForeignIds, []);
+  assert.deepEqual(injectionGroups(strip(again), reconcilePending(strip(again), [legacy]).inject), [{ idx: 4, sends: [legacy] }], "legacy: below the group while it shows a copy of F");
+  const legacy2 = newPending("mine", undefined, T0 + 3);
+  reconcilePending(strip(queued), [legacy2]);
+  assert.deepEqual(injectionGroups(strip(both), reconcilePending(strip(both), [legacy2]).inject), [{ idx: 2, sends: [legacy2] }], "legacy: the first landing is read as the copy's");
+});
+
+test("our own send's identity is latched from the kernel's first copy and then rules landing, cover and hiding (T252c)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const p = newPending("continue", undefined, T0);
+  reconcilePending(tail, [p]);
+  assert.equal(p.qid, undefined);
+  // the kernel lists our copy with its id: the copy covers us and we latch the id
+  let r = reconcilePending([...tail, { kind: "queued", texts: [{ md: "continue", qid: "c9", qts: 5 }] }], [p]);
+  assert.equal(p.qid, "c9");
+  assert.deepEqual(r.unqueue, [p]);
+  assert.equal(queuedCopyToHide([{ md: "continue", qid: "c8" }, { md: "continue", qid: "c9" }], "continue", "c9"), 1, "the copy to hide is OURS by id, not the newest by text");
+  // another client's same-text copy landing does NOT retire us: only the atom carrying our id does
+  r = reconcilePending([...tail, { kind: "user", md: "continue", uuid: "uX", qid: "c8" }, { kind: "queued", texts: [{ md: "continue", qid: "c9", qts: 5 }] }], [p]);
+  assert.deepEqual(r.keep, [p], "a same-text landing with another id is not ours");
+  r = reconcilePending([...tail, { kind: "user", md: "continue", uuid: "uX", qid: "c8" }, { kind: "user", md: "continue", uuid: "uMine", qid: "c9" }], [p]);
+  assert.deepEqual(r.landed.map((l) => [l.p, l.idx]), [[p, 2]], "our landing, by id, even behind a same-text one");
+  // the echo path latches too: the echo's uuid IS the copy's id
+  const q = newPending("go", undefined, T0 + 1);
+  reconcilePending(tail, [q]);
+  r = reconcilePending([...tail, { kind: "user", md: "go", uuid: "echo:g1" }], [q]);
+  assert.equal(q.qid, "echo:g1");
+  r = reconcilePending([...tail, { kind: "user", md: "go", uuid: "uG", qid: "echo:g1" }], [q]);
+  assert.deepEqual(r.landed.map((l) => l.idx), [1]);
+});
+
+test("floors carry the earlier send's identity and follow it through the echo → landed swap exactly (T252c)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const [x, y] = press(tail, "first", "second");
+  let r = reconcilePending([...tail, { kind: "user", md: "first", uuid: "echo:x1" }], [x, y]);
+  assert.equal(x.qid, "echo:x1");
+  assert.deepEqual(y.floors?.map((f) => [f.uuid, f.qid]), [["echo:x1", "echo:x1"]]);
+  dropPending([x, y], "first", x.ts);   // the ✕ the kernel could not honour
+  // X's atom lands under a new uuid but with X's id, behind an unrelated same-text message that has none of it
+  const frame: TailEvent[] = [...tail, { kind: "user", md: "first", uuid: "uOther" }, { kind: "tool", uuid: "t1" }, { kind: "user", md: "first", uuid: "uX", qid: "echo:x1" }, { kind: "tool", uuid: "t2" }];
+  assert.deepEqual(injectionGroups(frame, reconcilePending(frame, [y]).inject), [{ idx: 4, sends: [y] }], "below X's own atom, found by id, not the first same-text one");
+});
+
 test("a bubble that changes slot marks the view stale, so the incremental repaint never trusts a shifted prefix (second review)", () => {
   // chatTail lowers v.rendered to the kernel index and the normal-mode append path re-renders from there, assuming
   // the DOM prefix still matches s.events — which also requires the bubble's SLOT to be unchanged. The settle
@@ -528,7 +595,7 @@ test("queuedCopyToHide: the newest not-yet-hidden copy of the text, never a copy
   assert.equal(queuedCopyToHide(texts, "zzz"), -1);
   assert.equal(queuedCopyToHide([{ md: " a " }], "a"), 0, "trimmed match, like every other text test");
   // render.ts: a copy the helper refuses keeps covering our bubble (the send leaves `inject`)
-  assert.match(RENDER, /const k = queuedCopyToHide\(q\.texts, p\.text\);/);
+  assert.match(RENDER, /const k = queuedCopyToHide\(q\.texts, p\.text, p\.qid\);/);
   assert.match(RENDER, /if \(k < 0\) return null;\s*\/\/ no copy to hide/);
   assert.match(RENDER, /const hid = hideQueuedCopy\(s, p\);\s*\n\s*if \(hid === null\) covered\.add\(p\); else if \(hid\.held\) heldBy\.set\(p, hid\.held\);/);
   assert.match(RENDER, /const inject = r\.inject\.filter\(\(p\) => !covered\.has\(p\)\);/);
@@ -813,7 +880,7 @@ test("a send pressed against no frame (a placeholder tab): the first frame's cop
   // a first frame that predates the send entirely stamps exactly as a press-time stamp would
   list = [late()];
   reconcilePending([frame[0], frame[1]], list);
-  assert.deepEqual(list[0].at, { after: "a1", place: "u-old", placeText: TEXT, placeOrd: 0, queuedForeign: [], queuedResident: {}, seen: ["u-old"], queued: 0 });
+  assert.deepEqual(list[0].at, { after: "a1", place: "u-old", placeText: TEXT, placeOrd: 0, queuedForeign: [], queuedForeignIds: [], queuedResident: {}, seen: ["u-old"], queued: 0 });
   // a press-time stamp reads no stamp: its frame predates the press by construction, so an identical
   // message that landed within the press's own second is still background
   const prompt = press([frame[1], { kind: "user", md: TEXT, uuid: "u-same-second", ts: isoAt(Math.floor(T0 / 1000)) }], TEXT);
@@ -863,7 +930,7 @@ test("a late stamp presumes the first frame's newest queued copy of the text is 
   // follows covers it, exactly as at a press-time stamp
   const early = [late()];
   let r = reconcilePending([step], early);
-  assert.deepEqual(early[0].at, { after: "a1", place: null, placeText: undefined, placeOrd: 0, queuedForeign: [], queuedResident: {}, seen: [], queued: 0 });
+  assert.deepEqual(early[0].at, { after: "a1", place: null, placeText: undefined, placeOrd: 0, queuedForeign: [], queuedForeignIds: [], queuedResident: {}, seen: [], queued: 0 });
   assert.equal(r.inject.length, 1);
   r = reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }] }], early);
   assert.equal(r.inject.length, 1);

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -575,6 +575,36 @@ test("floors carry the earlier send's identity and follow it through the echo �
   assert.deepEqual(injectionGroups(frame, reconcilePending(frame, [y]).inject), [{ idx: 4, sends: [y] }], "below X's own atom, found by id, not the first same-text one");
 });
 
+test("identity edges: a copy without an id beside an echo, a landing carrying several ids, and an identified copy whose landing lost its id (T252c review)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  // the tmux route: the queued copy carries a stamp but no id, the echo a random uuid, the landing nothing — text decides
+  // throughout, and our bubble never doubles beside the kernel's copies
+  const p = newPending("go on", undefined, T0);
+  reconcilePending(tail, [p]);
+  let r = reconcilePending([...tail, { kind: "queued", texts: [{ md: "go on", qts: 5 }] }], [p]);
+  assert.equal(p.qid, undefined, "no id to latch");
+  assert.deepEqual(r.unqueue, [p]);
+  r = reconcilePending([...tail, { kind: "user", md: "go on", uuid: "echo:random" }], [p]);
+  assert.equal(r.inject.length, 0, "the echo covers by text");
+  r = reconcilePending([...tail, { kind: "user", md: "go on", uuid: "uL" }], [p]);
+  assert.deepEqual(r.landed.map((l) => l.idx), [1]);
+  // a record the CLI wrote from two sends lands with one id per block: ours retires on its own block's id
+  const [x, y] = press(tail, "one", "two");
+  reconcilePending([...tail, { kind: "queued", texts: [{ md: "one", qid: "q1", qts: 1 }, { md: "two", qid: "q2", qts: 2 }] }], [x, y]);
+  assert.deepEqual([x.qid, y.qid], ["q1", "q2"]);
+  r = reconcilePending([...tail, { kind: "user", md: "one two", uuid: "uXY", blocks: ["one", "two"], qids: ["q1", "q2"] }], [x, y]);
+  assert.deepEqual(r.landed.map((l) => [l.p.text, l.idx]), [["one", 1], ["two", 1]]);
+  // an identified press-time copy whose landing carries no id (a kernel restart between feed and landing): the text
+  // floor still holds — the bubble stays below that message, never jumps above it
+  const z = newPending("mine", undefined, T0 + 5);
+  reconcilePending([...tail, { kind: "queued", texts: [{ md: "F", qid: "f1", qts: 1 }] }], [z]);
+  const lostId: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF" }, { kind: "tool", uuid: "t1" }];
+  assert.deepEqual(injectionGroups(lostId, reconcilePending(lostId, [z]).inject), [{ idx: 2, sends: [z] }]);
+  // …while an identified copy whose landing DOES carry the id ignores the text path (the newer-copy case stays exact)
+  const withId: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF", qid: "f1" }, { kind: "tool", uuid: "t1" }, { kind: "queued", texts: [{ md: "F", qid: "f2", qts: 9 }] }];
+  assert.deepEqual(injectionGroups(withId, reconcilePending(withId, [z]).inject), [{ idx: 2, sends: [z] }]);
+});
+
 test("a bubble that changes slot marks the view stale, so the incremental repaint never trusts a shifted prefix (second review)", () => {
   // chatTail lowers v.rendered to the kernel index and the normal-mode append path re-renders from there, assuming
   // the DOM prefix still matches s.events — which also requires the bubble's SLOT to be unchanged. The settle

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -55,6 +55,12 @@ export type SendBase = {
                           //   (T252b). A LATE stamp leaves out the newest `own` copies of this send's text, the
                           //   ones the queued presumption reads as this press's. The group carries no uuid and is
                           //   no user event, so neither the anchor nor the floor ever saw it
+  queuedForeignIds: string[]; // the IDS of the copies the tail queue held at the press, when the kernel gave them one
+                          //   (T252c: qid on each queued copy, the same id its echo and its landed atom carry): the
+                          //   exact reading — a copy is still queued while the group shows its id, and has landed
+                          //   when a user event carries it — with no text or ordinal involved. Copies without an id
+                          //   (an older kernel, a queue restored after a kernel death) stay in queuedForeign and take
+                          //   the text path
   queuedResident?: Record<string, string[]>; // per foreign key: the uuids of user events after the anchor that
                           //   already carried the text AT THE PRESS (a never-delivered verdict for an earlier copy) —
                           //   not the queued copies' landings, so placement's ordinal counts them out while they are
@@ -68,7 +74,7 @@ export type SendBase = {
 
 /** A placement floor recorded from an earlier send's kernel event: found by uuid, else by the `ord`-th user
  *  event after the anchor carrying `text` (the echo → landed swap keeps the position, changes the uuid). */
-export type Floor = { uuid: string; text?: string; ord: number };
+export type Floor = { uuid: string; text?: string; ord: number; qid?: string };   // qid: the earlier send's identity, followed exactly through the echo → landed swap
 
 export type PendingSend = {
   text: string;        // the sent body, byte for byte — what the kernel echoes and the transcript lands
@@ -82,6 +88,11 @@ export type PendingSend = {
   imgPaths?: string[]; // dragged images → the bubble's thumbnails, and the image-aware landing match
   lost?: string;       // an event after the press that makes non-delivery LIKELY ("connection": the
                        //   socket dropped) — the bubble says "not confirmed" instead of "sending…"
+  qid?: string;        // this send's IDENTITY once the kernel has shown it (T252c): the queued copy's id or the echo's
+                       //   uuid, latched from the first copy attributed to this send by text and position — from then
+                       //   on the landing, the cover and the hidden copy are decided by id (an event that carries an id
+                       //   is ours only if it carries THIS one); an event without an id (an older kernel, tmux) keeps
+                       //   deciding by text
   floors?: Floor[];    // kernel user events that belong to EARLIER-registered pending sends — their covering
                        //   echoes and their landed atoms, recorded as they are claimed (T252b): an earlier send's
                        //   message sits above this one whatever its text, so its bubble is drawn below them. Each
@@ -98,11 +109,12 @@ export type TailEvent = {
   kind: string;
   md?: string;
   uuid?: string;
+  qid?: string;         // a landed user atom: the id of the queued copy it lands (T252c; the kernel pairs them)
   ts?: string;          // the kernel's stamp for the event, ISO-8601 UTC (kernel.py `iso(t)`, whole seconds)
   absorbed?: boolean;
   undelivered?: boolean;
   images?: unknown[];
-  texts?: { md?: string; hiddenByPending?: boolean }[];   // hiddenByPending: render.ts hid this copy for a send drawn in place
+  texts?: { md?: string; hiddenByPending?: boolean; qid?: string; qts?: number; cancelable?: boolean }[];   // qid/qts: the copy's identity (T252c); hiddenByPending: render.ts hid this copy for a send drawn in place
   blocks?: string[];    // a user record the CLI wrote from SEVERAL sends taken at one boundary: one text per
                         //   block (kernel.py build_session ships them when there are two or more); `md` is
                         //   the blocks joined, so each block is a copy of its own send
@@ -189,6 +201,7 @@ function textCopies(e: TailEvent, p: PendingSend): number {
  *  its quotes behind, so those are set aside on both sides). */
 export function landedCopies(e: TailEvent, p: PendingSend): number {
   if (e.kind !== "user" || typeof e.md !== "string" || isKernelEchoUuid(e.uuid)) return 0;
+  if (p.qid && e.qid) return e.qid === p.qid ? 1 : 0;   // identity decides (T252c): ours only if it carries THIS send's id
   const n = textCopies(e, p);
   if (n) return n;
   if (p.imgPaths && p.imgPaths.length && Array.isArray(e.images) && e.images.length > 0) {
@@ -212,14 +225,18 @@ function queuedCopies(e: TailEvent, p: PendingSend): number {
  *  VERDICT, not a provisional (lostIn), and never suppresses a bubble. */
 function provisionalCopies(e: TailEvent, p: PendingSend): number {
   if (e.kind === "queued") return queuedCopies(e, p);
-  return e.kind === "user" && isKernelEchoUuid(e.uuid) && !e.undelivered ? textCopies(e, p) : 0;
+  if (!(e.kind === "user" && isKernelEchoUuid(e.uuid) && !e.undelivered)) return 0;
+  if (p.qid) return e.uuid === p.qid ? 1 : 0;         // the echo's uuid IS the copy's id (T252c)
+  return textCopies(e, p);
 }
 export const provisionalIn = (e: TailEvent, p: PendingSend): boolean => provisionalCopies(e, p) > 0;
 
 /** The kernel's verdict that the send was LOST: its echo, flagged never-delivered (the CLI died holding
  *  it, or the session moved past it). That bubble carries the text and the resend/dismiss actions. */
 function lostCopies(e: TailEvent, p: PendingSend): number {
-  return e.kind === "user" && !!e.undelivered ? textCopies(e, p) : 0;
+  if (!(e.kind === "user" && !!e.undelivered)) return 0;
+  if (p.qid && isKernelEchoUuid(e.uuid)) return e.uuid === p.qid ? 1 : 0;   // the verdict is the echo, by id (T252c)
+  return textCopies(e, p);
 }
 export const lostIn = (e: TailEvent, p: PendingSend): boolean => lostCopies(e, p) > 0;
 
@@ -313,15 +330,18 @@ export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.l
   // queued presumption). Beside them, the carriers of each text already resident after the anchor: those
   // are not the queued copies' landings, so placement counts them out (second review).
   const queuedForeign: string[] = [];
+  const queuedForeignIds: string[] = [];
   const queuedResident: Record<string, string[]> = {};
   for (let i = events.length - 1; i >= 0; i--) {
     const e = events[i];
     if (e.kind !== "queued") continue;
     let skipOwn = p.late ? own : 0;
-    const copies = (e.texts || []).filter((t) => typeof t.md === "string" && !t.hiddenByPending).map((t) => t.md as string);
+    const copies = (e.texts || []).filter((t) => typeof t.md === "string" && !t.hiddenByPending);
     for (let k = copies.length - 1; k >= 0; k--) {
-      if (skipOwn > 0 && foreignKey(copies[k]) === foreignKey(p.text)) { skipOwn--; continue; }
-      queuedForeign.unshift(copies[k]);
+      const md = copies[k].md as string;
+      if (skipOwn > 0 && foreignKey(md) === foreignKey(p.text)) { skipOwn--; continue; }
+      if (copies[k].qid) queuedForeignIds.unshift(copies[k].qid!);   // an identified copy takes the id path (T252c)
+      else queuedForeign.unshift(md);                                //   an id-less one the text path
     }
     break;
   }
@@ -339,7 +359,7 @@ export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.l
   // the queued presumption (above): a late stamp's newest `own` copies are this press's, so the count of
   // background copies stops short of them — at zero when the frame lists fewer than presumed (the kernel
   // had not received every press yet; the copies still to come cover those entries in order)
-  return { after, place, placeText, placeOrd, queuedForeign, queuedResident, seen, queued: Math.max(0, queued - (p.late ? own : 0)) };
+  return { after, place, placeText, placeOrd, queuedForeign, queuedForeignIds, queuedResident, seen, queued: Math.max(0, queued - (p.late ? own : 0)) };
 }
 
 /** The first index AFTER the send's anchor — or 0 when there is no anchor, or when the anchor has left the
@@ -408,16 +428,21 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
       const text = owner.text;   // the earlier SEND's own text — a record of several sends carries it as a block, and its md is the blocks joined
       let ord = 0;
       if (q.at) for (let j = scanFrom(events, q.at); j <= at; j++) ord += carriedCopies(events[j], text);
-      q.floors.push({ uuid: u, text, ord });
+      q.floors.push({ uuid: u, text, ord, qid: owner.qid });
     }
   };
   for (const p of list) {
     const at = p.at!;
     const from = scanFrom(events, at);
-    let landedIdx = -1, lostIdx = -1, echoIdx = -1, copies = 0;
+    let landedIdx = -1, lostIdx = -1, echoIdx = -1, copies = 0, idCopy = -1;
     for (let i = from; i < events.length; i++) {
       const e = events[i];
-      if (e.kind === "queued") { copies += queuedCopies(e, p); continue; }
+      if (e.kind === "queued") {
+        copies += queuedCopies(e, p);
+        // the kernel's copy of THIS send, by id (T252c): the cover, wherever the copy sits in the group
+        if (p.qid && (e.texts || []).some((t) => t.qid === p.qid)) idCopy = i;
+        continue;
+      }
       // the copies of this event that are NOT this send's: background at the stamp, or claimed by an
       // entry retired since (`seen`); a landing an earlier entry took this push is counted in `claimed`
       const spoken = e.uuid ? spokenFor(at, e.uuid) : 0;
@@ -435,11 +460,26 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
       covered = true;
       const u = events[echoIdx].uuid;
       if (u) for (const q of list) if (q !== p && q.at && q.text === p.text && !q.at.seen.includes(u)) q.at.seen.push(u);
+      if (!p.qid && u) p.qid = u;                  // the echo's uuid is the copy's id: latched (T252c)
       floorFor(p, echoIdx);
-    } else if (copies > at.queued) {
+    } else if (p.qid && idCopy >= 0) {
+      covered = true; byQueued = true;              // our identified copy is in the queue: exact, whatever its position
+    } else if (!p.qid && copies > at.queued) {
       const taken = takenCopies.get(p.text) || new Set<number>();
       for (let k = at.queued; k < copies; k++) if (!taken.has(k)) { taken.add(k); covered = true; byQueued = true; break; }
       takenCopies.set(p.text, taken);
+      if (covered) {                                // latch the identity of the copy just attributed, when the kernel gave it one
+        let seen = 0;
+        outer: for (let i = from; i < events.length; i++) {
+          const e = events[i];
+          if (e.kind !== "queued") continue;
+          for (const t of e.texts || []) {
+            if (typeof t.md !== "string" || !sameText(t.md, p.text)) continue;
+            if (seen === [...taken].sort((a, b) => a - b).pop()) { if (t.qid) p.qid = t.qid; break outer; }
+            seen++;
+          }
+        }
+      }
     }
     if (covered) p.received = true;             // the kernel holds this send: proven once, latched
     if (p.received) p.lost = undefined;         // the drop is older news than the kernel's own copy
@@ -554,9 +594,22 @@ export function placementIndex(events: TailEvent[], p: PendingSend): number {
   // an earlier pending send's echo or landed atom: below it, whatever its text — by uuid, else by its text's ordinal
   for (const f of p.floors || []) {
     let found = -1;
-    for (let j = events.length - 1; j >= base; j--) if (events[j].uuid === f.uuid) { found = j + 1; break; }
+    if (f.qid) for (let j = events.length - 1; j >= base; j--) if (events[j].qid === f.qid || events[j].uuid === f.qid) { found = j + 1; break; }   // by identity (T252c)
+    if (found < 0) for (let j = events.length - 1; j >= base; j--) if (events[j].uuid === f.uuid) { found = j + 1; break; }
     if (found < 0 && f.text !== undefined && f.ord > 0) { const k = kthCarrier(f.text, f.ord); if (k.idx >= 0) found = k.idx + 1; }
     if (found > idx) idx = found;
+  }
+  // the identified copies the kernel's queue held at the press (T252c): a copy is still queued while the group shows
+  // its id, and has landed when a user event carries it — exact, no text, no count
+  if (at.queuedForeignIds && at.queuedForeignIds.length) {
+    let groupIdx = -1;
+    for (let j = events.length - 1; j >= base; j--) if (events[j].kind === "queued") { groupIdx = j; break; }
+    for (const id of at.queuedForeignIds) {
+      let floor = -1;
+      for (let j = events.length - 1; j >= base; j--) if (events[j].qid === id) { floor = j + 1; break; }
+      if (floor < 0 && groupIdx >= 0 && (events[groupIdx].texts || []).some((t) => t.qid === id && !t.hiddenByPending)) floor = groupIdx + 1;
+      if (floor > idx) idx = floor;
+    }
   }
   // the texts the kernel's queue held at the press, COUNTED per text: the press-time copies are the first k
   // landings of that text, so the floor is the k-th carrier (never a later copy another client sent), and the
@@ -598,7 +651,11 @@ export function placementIndex(events: TailEvent[], p: PendingSend): number {
  *  exists there: a tmux queue). That copy stays the one bubble shown, with its honest tooltip, and ours is
  *  suppressed as before: hidden behind our bubble's ✕ it offered a cancel the kernel would refuse (review of the
  *  first cut). */
-export function queuedCopyToHide(texts: { md?: string; cancelable?: boolean; hiddenByPending?: boolean; optimistic?: boolean }[], text: string): number {
+export function queuedCopyToHide(texts: { md?: string; cancelable?: boolean; hiddenByPending?: boolean; optimistic?: boolean; qid?: string }[], text: string, qid?: string): number {
+  if (qid) {   // OUR copy by identity (T252c): never the newest same-text one
+    const k = texts.findIndex((t) => t.qid === qid && !t.hiddenByPending && !t.optimistic);
+    if (k >= 0) return texts[k].cancelable === false ? -1 : k;
+  }
   for (let k = texts.length - 1; k >= 0; k--) {
     const t = texts[k];
     if (t.hiddenByPending || t.optimistic || typeof t.md !== "string" || !sameText(t.md, text)) continue;

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -110,6 +110,7 @@ export type TailEvent = {
   md?: string;
   uuid?: string;
   qid?: string;         // a landed user atom: the id of the queued copy it lands (T252c; the kernel pairs them)
+  qids?: string[];      // a record of SEVERAL sends: one id (or null) per text block, in block order
   ts?: string;          // the kernel's stamp for the event, ISO-8601 UTC (kernel.py `iso(t)`, whole seconds)
   absorbed?: boolean;
   undelivered?: boolean;
@@ -201,7 +202,8 @@ function textCopies(e: TailEvent, p: PendingSend): number {
  *  its quotes behind, so those are set aside on both sides). */
 export function landedCopies(e: TailEvent, p: PendingSend): number {
   if (e.kind !== "user" || typeof e.md !== "string" || isKernelEchoUuid(e.uuid)) return 0;
-  if (p.qid && e.qid) return e.qid === p.qid ? 1 : 0;   // identity decides (T252c): ours only if it carries THIS send's id
+  if (p.qid && (e.qid || (Array.isArray(e.qids) && e.qids.length)))   // identity decides (T252c): ours only if it carries THIS send's id
+    return e.qid === p.qid || (Array.isArray(e.qids) && e.qids.includes(p.qid)) ? 1 : 0;
   const n = textCopies(e, p);
   if (n) return n;
   if (p.imgPaths && p.imgPaths.length && Array.isArray(e.images) && e.images.length > 0) {
@@ -340,8 +342,8 @@ export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.l
     for (let k = copies.length - 1; k >= 0; k--) {
       const md = copies[k].md as string;
       if (skipOwn > 0 && foreignKey(md) === foreignKey(p.text)) { skipOwn--; continue; }
-      if (copies[k].qid) queuedForeignIds.unshift(copies[k].qid!);   // an identified copy takes the id path (T252c)
-      else queuedForeign.unshift(md);                                //   an id-less one the text path
+      if (copies[k].qid) queuedForeignIds.unshift(copies[k].qid!);   // an identified copy takes the id path first (T252c)…
+      queuedForeign.unshift(md);                                     //   …and every copy keeps the text path as its fallback
     }
     break;
   }
@@ -601,14 +603,24 @@ export function placementIndex(events: TailEvent[], p: PendingSend): number {
   }
   // the identified copies the kernel's queue held at the press (T252c): a copy is still queued while the group shows
   // its id, and has landed when a user event carries it — exact, no text, no count
+  // the keys whose identified copies RESOLVED by id this frame skip the text path below: the text path is the
+  // fallback for a copy whose landing lost its id (a kernel restart between feed and landing) or an older kernel
+  const resolvedKeys = new Set<string>();
   if (at.queuedForeignIds && at.queuedForeignIds.length) {
     let groupIdx = -1;
     for (let j = events.length - 1; j >= base; j--) if (events[j].kind === "queued") { groupIdx = j; break; }
     for (const id of at.queuedForeignIds) {
-      let floor = -1;
-      for (let j = events.length - 1; j >= base; j--) if (events[j].qid === id) { floor = j + 1; break; }
-      if (floor < 0 && groupIdx >= 0 && (events[groupIdx].texts || []).some((t) => t.qid === id && !t.hiddenByPending)) floor = groupIdx + 1;
+      let floor = -1, text: string | undefined;
+      for (let j = events.length - 1; j >= base; j--) {
+        const e = events[j];
+        if (e.qid === id || (Array.isArray(e.qids) && e.qids.includes(id))) { floor = j + 1; text = typeof e.md === "string" ? e.md : undefined; break; }
+      }
+      if (floor < 0 && groupIdx >= 0) {
+        const c = (events[groupIdx].texts || []).find((t) => t.qid === id && !t.hiddenByPending);
+        if (c) { floor = groupIdx + 1; text = c.md; }
+      }
       if (floor > idx) idx = floor;
+      if (floor >= 0 && text !== undefined) resolvedKeys.add(foreignKey(text));
     }
   }
   // the texts the kernel's queue held at the press, COUNTED per text: the press-time copies are the first k
@@ -621,6 +633,7 @@ export function placementIndex(events: TailEvent[], p: PendingSend): number {
     for (let j = events.length - 1; j >= base; j--) if (events[j].kind === "queued") { groupIdx = j; break; }
     for (const { text, n: copies } of counts.values()) {
       const key = foreignKey(text);
+      if (resolvedKeys.has(key)) continue;          // the identity path placed this key exactly
       const residents = (at.queuedResident ||= {})[key] ||= [];
       // The kernel's queued copies carry no identity, so which landing is the press-time copy's is read off the
       // GROUP (fourth review): while it still shows a copy of the key, the press-time copy has not landed, so every

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -395,13 +395,17 @@ export type Reconciled = {
  *   - the k-th kernel copy of the text after the anchor — an echo atom no earlier entry claimed, or a
  *     queued copy beyond the entry's press-time count — covers the k-th pending send with that text: it
  *     hides that send's bubble for this push and proves the kernel received THAT send (`received`). A
- *     claimed echo joins later same-text entries' `seen` for good; queued copies carry no identity, so
- *     they are handed out by position within a push (the copies an entry's press listed are its
- *     background). One echo used to mark every same-text entry received and clear every "not confirmed"
- *     (2026-09-06 review, round 3): with two identical sends in flight and one of them lost, the lost
- *     one read "sending…" for good, and nothing could ever mark it.
- *  Identical texts carry no identity of their own, so WHICH send a copy belongs to is attributed by
- *  order, exactly as landings are; the COUNT of confirmed sends is what the kernel's records support.
+ *     claimed echo joins later same-text entries' `seen` for good; a queued copy without an id is handed
+ *     out by position within a push (the copies an entry's press listed are its background). One echo
+ *     used to mark every same-text entry received and clear every "not confirmed" (2026-09-06 review,
+ *     round 3): with two identical sends in flight and one of them lost, the lost one read "sending…"
+ *     for good, and nothing could ever mark it.
+ *  Identity first (T252c): the kernel gives each copy an id — the queued copy's `qid`, the echo's uuid, the
+ *  landed atom's `qid`/`qids` — and a send latches the id of the first copy attributed to it; from then on
+ *  landing, cover and loss are decided by that id wherever the frame shows it. Text and order remain the
+ *  reading for copies the kernel gave no id (an older kernel, the tmux route, a notice it queued itself)
+ *  and for a push in which the frame carries a latched id nowhere; the COUNT of confirmed sends is then
+ *  what the kernel's records support.
  *  When the kernel hides a fed send's echo behind a same-text queued copy (its chat dedups by text), a
  *  received send can read "not confirmed" after a drop until a copy of its own shows; that clears on the
  *  next kernel copy, and the error is toward "not confirmed", never toward a false "sending…". */
@@ -435,8 +439,20 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
   for (const p of list) if (!p.at) p.at = stampBase(events, p, p.late ? lateOwn.get(p.text) || 1 : 0);
   const r: Reconciled = { keep: [], inject: [], unqueue: [], landed: [], lost: [] };
   const claimed = new Map<string, number>();           // "index\0text" → copies of that text in that landing taken by earlier entries THIS push
-  const owned = new Set<string>();                     // the identities pending sends have latched: an echo wearing one is that send's, never a text match
+  const owned = new Set<string>();                     // the identities pending sends have latched: an echo, a queued copy or a landing wearing one is that send's, never a text match
   for (const p of list) if (p.qid) owned.add(p.qid);
+  // a landing read by text (this send's id is nowhere in the frame): a record wearing another pending send's id is that
+  // send's, and in a record of several sends the same-text blocks wearing another send's id are not this one's (third review)
+  const landedForText = (e: TailEvent, pv: PendingSend, self?: string): number => {
+    if (e.qid && owned.has(e.qid) && e.qid !== self) return 0;
+    let n = landedCopies(e, pv);
+    if (n && Array.isArray(e.qids) && Array.isArray(e.blocks))
+      for (let k = 0; k < e.qids.length; k++) {
+        const q = e.qids[k], b = e.blocks[k];
+        if (q && owned.has(q) && q !== self && typeof b === "string" && sameText(b, pv.text)) n--;
+      }
+    return Math.max(0, n);
+  };
   const takenCopies = new Map<string, Set<number>>();  // text → queued-copy positions taken by an earlier entry THIS push
   // an earlier entry's covering echo / landed atom is a FLOOR for every entry registered after it (T252b),
   // recorded with its text and its ordinal among same-text user events after THAT entry's anchor, so the
@@ -457,7 +473,8 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
   for (const p of list) {
     const at = p.at!;
     const from = scanFrom(events, at);
-    let landedIdx = -1, lostIdx = -1, echoIdx = -1, copies = 0, idCopy = -1;
+    let landedIdx = -1, lostIdx = -1, echoIdx = -1, idCopy = -1;
+    const copyIds: (string | undefined)[] = [];   // the group's same-text copies in order, each with its id when the kernel gave one
     // identity decides where the frame shows it (T252c): the atom carrying our id is our landing, whatever the
     // text arithmetic says (an identical send retired on the same record this push claimed the text once);
     // while a queued copy or an echo wears it, no landing is ours; and an id the frame carries NOWHERE leaves
@@ -468,7 +485,7 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
     else for (let i = from; i < events.length; i++) {
       const e = events[i];
       if (e.kind === "queued") {
-        copies += queuedCopies(e, p);
+        for (const t of e.texts || []) if (typeof t.md === "string" && sameText(t.md, p.text)) copyIds.push(t.qid);
         // the kernel's copy of THIS send, by id (T252c): the cover, wherever the copy sits in the group
         if (p.qid && (e.texts || []).some((t) => t.qid === p.qid)) idCopy = i;
         continue;
@@ -480,7 +497,7 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
       const spoken = e.uuid ? spokenFor(at, e.uuid) : 0;
       // a send that landed needs no cover and no verdict: scanning on would claim a later echo (another send's
       // cover) as its own, and mark it spoken for that send (second review)
-      if (loc.where === "none" && landedIdx < 0 && landedCopies(e, pv) > spoken + (claimed.get(i + "\0" + p.text) || 0)) { landedIdx = i; break; }
+      if (loc.where === "none" && landedIdx < 0 && landedForText(e, pv, p.qid) > spoken + (claimed.get(i + "\0" + p.text) || 0)) { landedIdx = i; break; }
       if (lostIdx < 0 && lostCopies(e, pv) > spoken) { lostIdx = i; continue; }
       if (echoIdx < 0 && provisionalCopies(e, pv) > spoken) echoIdx = i;   // the first echo no earlier entry claimed (`seen`)
     }
@@ -498,21 +515,22 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
       floorFor(p, echoIdx);
     } else if (p.qid && idCopy >= 0) {
       covered = true; byQueued = true;              // our identified copy is in the queue: exact, whatever its position
-    } else if (!pv.qid && copies > at.queued) {
+      const k = copyIds.indexOf(p.qid);             // …and that position is spoken for on the text path this push: a later
+      if (k >= 0) {                                 // same-text send never takes it, nor its id (third review)
+        const taken = takenCopies.get(p.text) || new Set<number>();
+        taken.add(k); takenCopies.set(p.text, taken);
+      }
+    } else if (!pv.qid && copyIds.length > at.queued) {
       const taken = takenCopies.get(p.text) || new Set<number>();
-      for (let k = at.queued; k < copies; k++) if (!taken.has(k)) { taken.add(k); covered = true; byQueued = true; break; }
-      takenCopies.set(p.text, taken);
-      if (covered) {                                // latch the identity of the copy just attributed, when the kernel gave it one
-        let seen = 0;
-        outer: for (let i = from; i < events.length; i++) {
-          const e = events[i];
-          if (e.kind !== "queued") continue;
-          for (const t of e.texts || []) {
-            if (typeof t.md !== "string" || !sameText(t.md, p.text)) continue;
-            if (seen === [...taken].sort((a, b) => a - b).pop()) { if (t.qid && !p.qid) p.qid = t.qid; break outer; }
-            seen++;
-          }
-        }
+      let k = -1;
+      for (let j = at.queued; j < copyIds.length; j++) {
+        const id = copyIds[j];
+        if (taken.has(j) || (id && owned.has(id) && id !== p.qid)) continue;   // taken this push, or another send's by id
+        k = j; break;
+      }
+      if (k >= 0) {
+        taken.add(k); takenCopies.set(p.text, taken); covered = true; byQueued = true;
+        if (copyIds[k] && !p.qid) p.qid = copyIds[k];   // latch the identity of the copy just attributed, when the kernel gave it one
       }
     }
     if (covered) p.received = true;             // the kernel holds this send: proven once, latched
@@ -551,8 +569,13 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
  *  bubble back and the other was gone without a gesture (2026-09-06 review, round 3). Returns the removed
  *  entry; undefined when none matched — a bubble whose entry a push already retired removes nothing,
  *  never a neighbour with the same text. */
-export function dropPending(list: PendingSend[], text: string, ts?: number): PendingSend | undefined {
-  const i = ts !== undefined ? list.findIndex((p) => p.ts === ts && p.text === text) : list.findIndex((p) => p.text === text);
+export function dropPending(list: PendingSend[], text: string, ts?: number, qid?: string): PendingSend | undefined {
+  let i = -1;
+  if (ts !== undefined) i = list.findIndex((p) => p.ts === ts && p.text === text);
+  else if (qid) {   // the kernel's copy names its id (T252c): the send that owns it, else the first with the text that owns NO id yet
+    i = list.findIndex((p) => p.qid === qid);
+    if (i < 0) i = list.findIndex((p) => p.text === text && !p.qid);
+  } else i = list.findIndex((p) => p.text === text);
   return i >= 0 ? list.splice(i, 1)[0] : undefined;
 }
 
@@ -628,16 +651,19 @@ export function placementIndex(events: TailEvent[], p: PendingSend): number {
   // an earlier pending send's echo or landed atom: below it, whatever its text — by uuid, else by its text's ordinal
   for (const f of p.floors || []) {
     let found = -1;
-    if (f.qid) for (let j = events.length - 1; j >= base; j--) if (events[j].qid === f.qid || events[j].uuid === f.qid) { found = j + 1; break; }   // by identity (T252c)
+    if (f.qid) for (let j = events.length - 1; j >= base; j--) {   // by identity (T252c): the atom carrying it, alone or as one block of several
+      const e = events[j];
+      if (e.qid === f.qid || e.uuid === f.qid || (Array.isArray(e.qids) && e.qids.includes(f.qid))) { found = j + 1; break; }
+    }
     if (found < 0) for (let j = events.length - 1; j >= base; j--) if (events[j].uuid === f.uuid) { found = j + 1; break; }
     if (found < 0 && f.text !== undefined && f.ord > 0) { const k = kthCarrier(f.text, f.ord); if (k.idx >= 0) found = k.idx + 1; }
     if (found > idx) idx = found;
   }
   // the identified copies the kernel's queue held at the press (T252c): a copy is still queued while the group shows
   // its id, and has landed when a user event carries it — exact, no text, no count
-  // the keys whose identified copies RESOLVED by id this frame skip the text path below: the text path is the
-  // fallback for a copy whose landing lost its id (a kernel restart between feed and landing) or an older kernel
-  const resolvedKeys = new Set<string>();
+  // the copies that RESOLVED by id this frame leave the text path below to the rest: the text path is the fallback
+  // for an id-less copy beside them (a mixed group) or one whose landing lost its id (an older kernel's restart)
+  const resolvedCopies = new Map<string, number>();   // key → press-time copies of it the identity path placed
   if (at.queuedForeignIds && at.queuedForeignIds.length) {
     let groupIdx = -1;
     for (let j = events.length - 1; j >= base; j--) if (events[j].kind === "queued") { groupIdx = j; break; }
@@ -652,7 +678,7 @@ export function placementIndex(events: TailEvent[], p: PendingSend): number {
         if (c) { floor = groupIdx + 1; text = c.md; }
       }
       if (floor > idx) idx = floor;
-      if (floor >= 0 && text !== undefined) resolvedKeys.add(foreignKey(text));
+      if (floor >= 0 && text !== undefined) { const k = foreignKey(text); resolvedCopies.set(k, (resolvedCopies.get(k) || 0) + 1); }
     }
   }
   // the texts the kernel's queue held at the press, COUNTED per text: the press-time copies are the first k
@@ -663,9 +689,10 @@ export function placementIndex(events: TailEvent[], p: PendingSend): number {
     for (const f of at.queuedForeign) { const k = foreignKey(f); const c = counts.get(k); if (c) c.n++; else counts.set(k, { text: f, n: 1 }); }
     let groupIdx = -1;
     for (let j = events.length - 1; j >= base; j--) if (events[j].kind === "queued") { groupIdx = j; break; }
-    for (const { text, n: copies } of counts.values()) {
+    for (const { text, n: all } of counts.values()) {
       const key = foreignKey(text);
-      if (resolvedKeys.has(key)) continue;          // the identity path placed this key exactly
+      const copies = all - (resolvedCopies.get(key) || 0);   // the copies the identity path did not place: id-less ones, or one whose landing lost its id
+      if (copies <= 0) continue;
       const residents = (at.queuedResident ||= {})[key] ||= [];
       // The kernel's queued copies carry no identity, so which landing is the press-time copy's is read off the
       // GROUP (fourth review): while it still shows a copy of the key, the press-time copy has not landed, so every

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -110,7 +110,7 @@ export type TailEvent = {
   md?: string;
   uuid?: string;
   qid?: string;         // a landed user atom: the id of the queued copy it lands (T252c; the kernel pairs them)
-  qids?: string[];      // a record of SEVERAL sends: one id (or null) per text block, in block order
+  qids?: (string | null)[];   // a record of SEVERAL sends: one id (or null) per text block, in block order
   ts?: string;          // the kernel's stamp for the event, ISO-8601 UTC (kernel.py `iso(t)`, whole seconds)
   absorbed?: boolean;
   undelivered?: boolean;
@@ -202,8 +202,10 @@ function textCopies(e: TailEvent, p: PendingSend): number {
  *  its quotes behind, so those are set aside on both sides). */
 export function landedCopies(e: TailEvent, p: PendingSend): number {
   if (e.kind !== "user" || typeof e.md !== "string" || isKernelEchoUuid(e.uuid)) return 0;
-  if (p.qid && (e.qid || (Array.isArray(e.qids) && e.qids.length)))   // identity decides (T252c): ours only if it carries THIS send's id
-    return e.qid === p.qid || (Array.isArray(e.qids) && e.qids.includes(p.qid)) ? 1 : 0;
+  if (p.qid) {   // identity decides where the record carries it (T252c): ours if a block wears THIS send's id; not ours
+    if (e.qid === p.qid || (Array.isArray(e.qids) && e.qids.includes(p.qid))) return 1;   // when every block wears another's
+    if (e.qid || (Array.isArray(e.qids) && e.qids.length > 0 && e.qids.every((q) => !!q))) return 0;
+  }   // a block the kernel could not pair (null): text decides for it, below
   const n = textCopies(e, p);
   if (n) return n;
   if (p.imgPaths && p.imgPaths.length && Array.isArray(e.images) && e.images.length > 0) {
@@ -403,6 +405,23 @@ export type Reconciled = {
  *  When the kernel hides a fed send's echo behind a same-text queued copy (its chat dedups by text), a
  *  received send can read "not confirmed" after a drop until a copy of its own shows; that clears on the
  *  next kernel copy, and the error is toward "not confirmed", never toward a false "sending…". */
+/** Where the frame SHOWS a send's identity, from its anchor on: the landed atom that carries it, a queued copy or an
+ *  echo wearing it (the echo's uuid IS the id), or nowhere. Identity decides only where the frame shows it (second
+ *  review): a send whose id is nowhere in the frame — the kernel never showed it, an older kernel sends none, or a
+ *  restart re-minted the mirrors an older kernel kept text-only — is read by TEXT for that push, exactly as before
+ *  ids existed, rather than left with a bubble nothing can ever retire. */
+function locateId(events: TailEvent[], from: number, qid: string): { where: "landed"; idx: number } | { where: "provisional" | "none" } {
+  let provisional = false;
+  for (let i = from; i < events.length; i++) {
+    const e = events[i];
+    if (e.kind === "queued") { if ((e.texts || []).some((t) => t.qid === qid)) provisional = true; continue; }
+    if (e.kind !== "user") continue;
+    if (e.uuid === qid) { provisional = true; continue; }   // the echo, delivered or flagged
+    if (!isKernelEchoUuid(e.uuid) && (e.qid === qid || (Array.isArray(e.qids) && e.qids.includes(qid)))) return { where: "landed", idx: i };
+  }
+  return { where: provisional ? "provisional" : "none" };
+}
+
 export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reconciled {
   // First reconcile after the send: whatever the events ALREADY hold for this text is background — an
   // older identical message, an old echo, an undismissed never-delivered bubble — not this send. Only
@@ -416,6 +435,8 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
   for (const p of list) if (!p.at) p.at = stampBase(events, p, p.late ? lateOwn.get(p.text) || 1 : 0);
   const r: Reconciled = { keep: [], inject: [], unqueue: [], landed: [], lost: [] };
   const claimed = new Map<string, number>();           // "index\0text" → copies of that text in that landing taken by earlier entries THIS push
+  const owned = new Set<string>();                     // the identities pending sends have latched: an echo wearing one is that send's, never a text match
+  for (const p of list) if (p.qid) owned.add(p.qid);
   const takenCopies = new Map<string, Set<number>>();  // text → queued-copy positions taken by an earlier entry THIS push
   // an earlier entry's covering echo / landed atom is a FLOOR for every entry registered after it (T252b),
   // recorded with its text and its ordinal among same-text user events after THAT entry's anchor, so the
@@ -437,7 +458,14 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
     const at = p.at!;
     const from = scanFrom(events, at);
     let landedIdx = -1, lostIdx = -1, echoIdx = -1, copies = 0, idCopy = -1;
-    for (let i = from; i < events.length; i++) {
+    // identity decides where the frame shows it (T252c): the atom carrying our id is our landing, whatever the
+    // text arithmetic says (an identical send retired on the same record this push claimed the text once);
+    // while a queued copy or an echo wears it, no landing is ours; and an id the frame carries NOWHERE leaves
+    // this push to text, the reading every frame had before ids — `pv` is this send as text reads it
+    const loc = p.qid ? locateId(events, from, p.qid) : { where: "none" as const };
+    const pv: PendingSend = loc.where === "none" && p.qid ? { ...p, qid: undefined } : p;
+    if (loc.where === "landed") landedIdx = loc.idx;
+    else for (let i = from; i < events.length; i++) {
       const e = events[i];
       if (e.kind === "queued") {
         copies += queuedCopies(e, p);
@@ -445,12 +473,16 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
         if (p.qid && (e.texts || []).some((t) => t.qid === p.qid)) idCopy = i;
         continue;
       }
+      // an echo another pending send owns by id is not this one's, whatever its text says
+      if (!pv.qid && e.kind === "user" && isKernelEchoUuid(e.uuid) && owned.has(e.uuid!)) continue;
       // the copies of this event that are NOT this send's: background at the stamp, or claimed by an
       // entry retired since (`seen`); a landing an earlier entry took this push is counted in `claimed`
       const spoken = e.uuid ? spokenFor(at, e.uuid) : 0;
-      if (landedIdx < 0 && landedCopies(e, p) > spoken + (claimed.get(i + "\0" + p.text) || 0)) { landedIdx = i; continue; }
-      if (lostIdx < 0 && lostCopies(e, p) > spoken) { lostIdx = i; continue; }
-      if (echoIdx < 0 && provisionalCopies(e, p) > spoken) echoIdx = i;   // the first echo no earlier entry claimed (`seen`)
+      // a send that landed needs no cover and no verdict: scanning on would claim a later echo (another send's
+      // cover) as its own, and mark it spoken for that send (second review)
+      if (loc.where === "none" && landedIdx < 0 && landedCopies(e, pv) > spoken + (claimed.get(i + "\0" + p.text) || 0)) { landedIdx = i; break; }
+      if (lostIdx < 0 && lostCopies(e, pv) > spoken) { lostIdx = i; continue; }
+      if (echoIdx < 0 && provisionalCopies(e, pv) > spoken) echoIdx = i;   // the first echo no earlier entry claimed (`seen`)
     }
     // ONE kernel copy covers ONE send: an unclaimed echo atom first — its uuid is then background for
     // every later same-text entry, this push and every push after (the claim must outlive the claimant:
@@ -466,7 +498,7 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
       floorFor(p, echoIdx);
     } else if (p.qid && idCopy >= 0) {
       covered = true; byQueued = true;              // our identified copy is in the queue: exact, whatever its position
-    } else if (!p.qid && copies > at.queued) {
+    } else if (!pv.qid && copies > at.queued) {
       const taken = takenCopies.get(p.text) || new Set<number>();
       for (let k = at.queued; k < copies; k++) if (!taken.has(k)) { taken.add(k); covered = true; byQueued = true; break; }
       takenCopies.set(p.text, taken);
@@ -477,7 +509,7 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
           if (e.kind !== "queued") continue;
           for (const t of e.texts || []) {
             if (typeof t.md !== "string" || !sameText(t.md, p.text)) continue;
-            if (seen === [...taken].sort((a, b) => a - b).pop()) { if (t.qid) p.qid = t.qid; break outer; }
+            if (seen === [...taken].sort((a, b) => a - b).pop()) { if (t.qid && !p.qid) p.qid = t.qid; break outer; }
             seen++;
           }
         }

--- a/vscode-extension/src/followup-render.test.ts
+++ b/vscode-extension/src/followup-render.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("queued payload is per-message {md, followUp?, goal?, fuCtx?}, not raw strings", () => {
   // `optimistic` (romp's own unconfirmed echo) rides along at the end — see optimistic-send.test.ts
-  assert.match(SRC, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number; hiddenByPending\?: boolean \}\[\]/);
+  assert.match(SRC, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number; qid\?: string; hiddenByPending\?: boolean \}\[\]/);
 });
 
 test("renderQueued renders markdown (not raw text) + the follow-up header", () => {


### PR DESCRIPTION
Follow-up to #1067: the kernel's queued copies now carry an **identity**, and the chat places its pending bubble by it instead of by text and ordinal.

**Kernel**: the SDK backend's `send()` mints the copy's id (its existing echo key) before the enqueue, so the queued copy, the echo atom and the landed atom share one id; each queued text carries `{qid, qts}`; the feed moves the id to a fed ledger and `qid_for_landing` pairs the landed record with it (FIFO per text, at or after the feed); `build_session` ships `qid`/`qts` on queued copies and `qid` on the landed atom. A copy parked in the kernel's own FIFO carries no id until it reaches the backend (the park's op is the three-field record the on-disk mirror and a dozen readers pin; the id is minted where the copy enters the backend's queue) — stated as a gap. tmux copies carry their enqueue stamp and a digest id; nothing pairs a tmux landing (the kernel never sees the CLI take a copy), and a queue restored after a kernel death carries no ids — lossless legacy.

**Client**: a pending send latches its id from the first kernel copy attributed to it; landing, cover and hiding are then decided by id; floors and identified queued copies place exactly. Id-less copies keep today's text path unchanged (an older kernel, the tmux route, a restored queue).

**What came out of `send-pending.ts`**: nothing — the text path is the legacy fallback the lossless-legacy discipline requires, so it stays whole; the id path is added beside it and takes precedence when an identity is present.

**Tests (red before)**: `tests/test_queued_copy_identity.py` (kernel: minting, alignment, legacy copies, the fed ledger and pairing, the chat build, parks, tmux) and three new cases in `ui/webview/send-pending.test.ts` (the two stated limits with ids and their legacy degradation; identity latching; id-following floors).
