### PR TITLE
The Obsidian timeline writes flags, views and order through the kernel

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -67,6 +67,24 @@ and `false` apply, an absent field or an explicit `null` reads as the route's
 default, and anything else (the string `"false"`, `0`, `1`) is a 400 naming the
 field, with nothing acted on.
 
+Three routes exist for the Obsidian timeline panel, which has the state
+directory but no socket to the kernel: `POST /flag` (`{id, flag, value}`: one
+of the lane gear's toggles, `hideFromFeed`, `postalServiceOff` or `notify`,
+with a JSON boolean; here `value` is required, and an absent or `null` value is
+a 400, never a default, since a missing value must not read as "off"), `POST
+/views` (`{views, edited?, writeId?}`: the whole views blob, judged as the
+dashboards' write is and answered with the same `viewsAck` document, `ok`, the
+post-write `views` and `seq`, any `refused` tags and an `error` line), and
+`POST /order` (`{order: [sid, …]}`, merged into the saved order so lanes the
+drag did not carry keep their slots). Each lands through the setter its socket
+op uses; a store that cannot be read or written answers 200 with `ok:false` and
+the reason the dashboards see, and an unknown key or a wrong type is a 400
+naming it. The panel finds the kernel through the `serve-port` record the
+kernel writes beside `serve-token` in the state directory once its socket is
+bound; with no record, or nothing answering on it, the panel refuses the
+gesture and says the kernel is not running rather than writing a file the
+kernel cannot check.
+
 `--env` gives one session its own environment, so two sessions in the same
 directory can run with different toggles (a `FEATURE_FLAG=1`, a `CLAUDE_CODE_*`
 switch) without editing the directory's `.claude/settings*.json`, which reaches

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1270,6 +1270,23 @@ def _persist_repo_root():
 
 _persist_repo_root()
 
+
+def _persist_serve_port(port):
+    """The port this kernel serves on, written into state beside serve-token (state/romp/serve-port)
+    once the socket is BOUND (main): the AUTHORITATIVE answer for a same-user client that has the
+    state dir but no shell environment to read ROMP_KERNEL_PORT from -- the Obsidian timeline panel,
+    an Electron app launched from the dock, which posts its flag, views and order edits to the
+    routes below (_state_write_route) rather than writing the state files itself. A client that
+    finds no record, or a record nothing answers on, treats the kernel as not running and refuses the
+    gesture visibly, never guessing a port or falling back to a write the kernel cannot check. An
+    atomic publish (a reader never sees a torn number); best-effort, like the serve-token mint and
+    the repo-root record above."""
+    try:
+        _atomic_write(jd.STATE / "serve-port", "%d\n" % int(port))
+    except OSError:
+        pass
+
+
 def _ct_eq(a, b):
     """Constant-time string compare (no timing oracle on the serve token); never
     raises on odd input."""
@@ -3109,6 +3126,13 @@ def _clear_state_fault(path):
     _state_fault_seen.pop(str(path), None)
 
 
+def _setting_refusal_text(what, exc):
+    """The one sentence a refused gesture shows: what could not be saved, the store's fault or the
+    validator's complaint, and that a retry is the way on. Composed here so the WS door
+    (_refuse_setting) and the Obsidian panel's POST routes (_state_write_route) say the same thing."""
+    return "couldn't save %s \u2014 %s; try again" % (what, exc)
+
+
 def _refuse_setting(client, exc, what, gesture, sid="", item_id="", flag="", value=None, log=None):
     """A dashboard gesture (a lane/tab flag, a card bell, a drag, a view change) that this kernel
     REFUSED because the store it edits could not be read -- or, since the maintainer's fold on PR
@@ -3126,7 +3150,7 @@ def _refuse_setting(client, exc, what, gesture, sid="", item_id="", flag="", val
     the client's problem: the refusal already stands. `log`, when given, is what stderr gets INSTEAD of
     `text`: a flag refusal's text echoes the client's value for the client, and the log line names only
     the field and its type (_flag_type_note; review find, 2026-09-08)."""
-    text = "couldn't save %s \u2014 %s; try again" % (what, exc)
+    text = _setting_refusal_text(what, exc)
     sys.stderr.write("romp-kernel: %s\n" % (log or text))
     if not client or not callable(client.get("send")):
         return
@@ -4934,6 +4958,16 @@ def _ack_views_write(client, kind, write_id, ok, error=None, refused=None, info=
     runs."""
     if not client or not callable(client.get("send")):
         return
+    try:
+        client["send"](json.dumps(_views_write_ack(kind, write_id, ok, error=error, refused=refused, info=info, edited=edited)))
+    except Exception:
+        pass
+
+
+def _views_write_ack(kind, write_id, ok, error=None, refused=None, info=None, edited=None):
+    """The ack document _ack_views_write sends, built without a socket: POST /views (the Obsidian
+    panel's whole-blob write, _state_write_route) answers with this same document, so the panel feeds
+    it to the viewsAck handler it already has and a refusal reads the same in every host."""
     views = _views_client()
     ack = {"type": kind, "writeId": write_id if isinstance(write_id, str) else None,
            "ok": bool(ok), "views": views,
@@ -4967,10 +5001,7 @@ def _ack_views_write(client, kind, write_id, ok, error=None, refused=None, info=
                                           cap=_ACK_ERROR_CAP, joiner="; ") or "refused"
     if error:
         ack["error"] = str(error)
-    try:
-        client["send"](json.dumps(ack))
-    except Exception:
-        pass
+    return ack
 
 
 def _resolve_parent_sid(raw, live):
@@ -42607,6 +42638,121 @@ def _landing():
 _BOOT_ID = "%d.%d" % (os.getpid(), int(time.time()))
 
 
+_LANE_FLAGS = ("hideFromFeed", "postalServiceOff", "notify")   # the per-session toggles the lane gear offers
+#                                    (LANE_TOGGLES in ui/romp-timeline-view.js) and the tab menu's typed union
+#                                    (setSessionFlag in ui/webview/render.ts)
+
+
+def _unknown_keys_error(b, allowed):
+    """A typed body's refusal of keys the route does not read (the /restart helper's rule): a typo key
+    must never pass as "not asked" while the caller reads ok:true as its field applying."""
+    extra = sorted(set(b) - set(allowed))
+    if not extra:
+        return None
+    return "unknown key(s) %s \u2014 this route reads only %s" % (
+        ", ".join(repr(k[:60] + "\u2026" if len(k) > 60 else k) for k in extra[:8]),
+        ", ".join(repr(k) for k in allowed))
+
+
+def _state_write_route(path, b):
+    """POST /flag, /views and /order -> (status, payload): the Obsidian timeline panel's three state
+    writes as routes. The panel runs in Obsidian's Electron with Node's fs and the state dir and has
+    no socket to this kernel, so until these routes it wrote session-flags.json, timeline-views.json
+    and session-order.json ITSELF -- a second writer beside the kernel: its whole-blob views write
+    bypassed _set_timeline_views (the judge and the stale-writer guard never saw it, and a concurrent
+    dashboard edit could be rolled back), its flag write read-modify-wrote the flags with no lock
+    against _set_session_flag, and its order write skipped _merge_session_order (every lane the drag
+    did not carry lost its slot). Each route lands through the SAME setter the socket op calls
+    (setSessionFlag, setTimelineViews, reorderTabs in _dispatch_ws), with that op's validation, and
+    refuses the way it refuses; the panel writes none of the files any more (with no kernel to post
+    to, it refuses the gesture and says so). `b` is the typed body (_json_object_body, already a dict).
+
+    Contracts. /flag {id, flag, value}: `flag` one of _LANE_FLAGS, `value` a JSON boolean (_as_bool
+    -- bool("false") once undid a mute); a store fault answers 200 {ok:false, error, value} where
+    `value` is what the display path still paints (_painted_flag_value), the settingRefused frame's
+    field. /views {views, edited?, writeId?}: the setTimelineViews op as a POST -- under _views_lock,
+    through the judge, `edited` bounding what the write may change -- answered with the viewsAck
+    document the op sends (_views_write_ack: ok, the post-write views and seq, refused rows, an error
+    line), writeId echoed. /order {order: [sid, ...]}: _merge_session_order then _write_session_order,
+    exactly the reorderTabs arm; a store fault answers 200 {ok:false, error}. A wrong type, a missing
+    field or an unknown key is a 400 naming it (the #1038 body convention); a 200 with ok:false is
+    the kernel's own refusal, in the words the dashboards see."""
+    if path == "/flag":
+        err = _unknown_keys_error(b, ("id", "flag", "value"))
+        if err:
+            return 400, {"ok": False, "error": err}
+        sid = b.get("id")
+        if not isinstance(sid, str) or not sid.strip():
+            return 400, {"ok": False, "error": "id (the session's id) required"}
+        sid = sid.strip()
+        flag = b.get("flag")
+        if flag not in _LANE_FLAGS:
+            return 400, {"ok": False, "error": "flag must be one of %s, got %s"
+                         % (", ".join(_LANE_FLAGS), _clip_json(flag))}
+        if b.get("value") is None:
+            return 400, {"ok": False, "error": "value (true or false) required"}
+        value, ferr = _as_bool(b.get("value"), "value")
+        if ferr:
+            return 400, {"ok": False, "error": ferr}
+        try:
+            if flag == "notify":
+                _set_notify_session(sid, value)      # tri-state override on the master bell: its own setter
+            else:
+                _set_session_flag(sid, flag, value)
+        except (_StateUnreadable, _StateUnwritable) as e:
+            # the flags store could not be read, or its publish failed: the op's refusal, as a body --
+            # the text the lane gear shows, and the value it repaints the toggle to
+            text = _setting_refusal_text("that setting", e)
+            sys.stderr.write("romp-kernel: POST /flag refused: %s\n" % e)
+            return 200, {"ok": False, "error": text, "value": _painted_flag_value(sid, flag)}
+        _mark_views_dirty()
+        return 200, {"ok": True, "id": sid, "flag": flag, "value": value}
+    if path == "/views":
+        err = _unknown_keys_error(b, ("views", "edited", "writeId"))
+        if err:
+            return 400, {"ok": False, "error": err}
+        views = b.get("views")
+        if not isinstance(views, dict):
+            return 400, {"ok": False, "error": "views (an object) required, got %s" % _clip_json(views)}
+        edited = b.get("edited")
+        edited = [x for x in edited if isinstance(x, str)] if isinstance(edited, list) else None
+        write_id = b.get("writeId") if isinstance(b.get("writeId"), str) else None
+        try:
+            with _views_lock:
+                refused = _set_timeline_views(views, edited=edited)   # the setter files the notice by the same rule
+            if edited is not None:
+                ok = not any(_refusal_is_the_posters(r, edited) for r in refused)
+            else:
+                ok = not refused
+            err = None
+        except Exception as e:
+            # the setTimelineViews arm's refusal, word for word; once PR #1075's dedicated store-fault
+            # arm lands (_views_fault_refusal), this route and that arm should share it
+            sys.stderr.write("POST /views: %s\n" % traceback.format_exc())
+            refused, ok, err = [], False, "the write failed on the kernel: %s" % (str(e) or type(e).__name__)
+        _mark_views_dirty()
+        return 200, _views_write_ack("viewsAck", write_id, ok, error=err, refused=refused or [], edited=edited)
+    if path == "/order":
+        err = _unknown_keys_error(b, ("order",))
+        if err:
+            return 400, {"ok": False, "error": err}
+        order = b.get("order")
+        if not isinstance(order, list) or not all(isinstance(x, str) for x in order):
+            return 400, {"ok": False, "error": "order (a list of session ids) required, got %s" % _clip_json(order)}
+        try:
+            merged = _merge_session_order(order)
+            _write_session_order(merged)
+        except (_StateUnreadable, _StateUnwritable) as e:
+            # the order file could not be read, or its publish failed: the drag must not splice against a
+            # fabricated [] and persist discovery order over the saved one (the reorderTabs arm's rule)
+            text = _setting_refusal_text("the new order", e)
+            sys.stderr.write("romp-kernel: POST /order refused: %s\n" % e)
+            return 200, {"ok": False, "error": text}
+        _mark_views_dirty()
+        return 200, {"ok": True, "order": merged}
+    return 404, {"ok": False, "error": "no such route"}
+
+
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
@@ -44418,6 +44564,17 @@ class Handler(BaseHTTPRequestHandler):
                 if hint:
                     resp["hint"] = hint
                 return self._send(200, json.dumps(resp), "application/json")
+            if u.path in ("/flag", "/views", "/order"):
+                # The Obsidian timeline panel's state writes -- the setSessionFlag / setTimelineViews /
+                # reorderTabs socket ops for a client with no socket (_state_write_route has the why and
+                # the contracts). Same-user trust boundary as every client: the panel reads the 0600
+                # serve-token file and this kernel's serve-port record (_persist_serve_port) from the
+                # state dir and sends X-Romp-Token; _authorize above already ruled on it.
+                b, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
+                st, payload = _state_write_route(u.path, b)
+                return self._send(st, json.dumps(payload), "application/json")
             if u.path in ("/tag", "/group"):
                 # Headless tag edit (`romp tag`, the user 2026-08-23, the manager/worker workflow:
                 # the worker roster IS a session tag, so an agent needs to keep one current — and can
@@ -46444,6 +46601,8 @@ def main():
     threading.Thread(target=_ensure_postal_bus, daemon=True).start()   # a sessionless machine still needs its bus
     threading.Thread(target=_tunnel_supervisor, daemon=True).start()   # keep ssh tunnels alive + poll host↔sid map
     srv = ThreadingHTTPServer((BIND, PORT), Handler)
+    _persist_serve_port(srv.server_address[1])     # the port record the Obsidian panel posts to, written
+    #                                                once the bind SUCCEEDED (a failed bind leaves no lie)
     url = "http://127.0.0.1:%d" % PORT
     sys.stderr.write("romp-kernel: serving the ported UI at %s  (Ctrl-C to stop)\n" % url)
     sys.stderr.write("romp-kernel: records under %s ; bundles from %s\n" % (jd.STATE, DIST))

--- a/tests/test_kernel_session_flags.py
+++ b/tests/test_kernel_session_flags.py
@@ -675,49 +675,53 @@ class SyncNoticeRowsCarryAKind(unittest.TestCase):
 NODE = shutil.which("node")
 VIEW_JS = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "ui", "romp-timeline-view.js")
 
-# The timeline's Obsidian-desktop fallback writer of session-flags.json, executed in node with a stubbed
+# The timeline's Obsidian-desktop flag writer, executed in node against a stubbed _kernelPost and a stubbed
 # fs (the tests/test_timeline_touch.py harness shape). Synthetic sids; ROMP_STATE_DIR is a temp dir and fs
 # is stubbed besides, so no real file is ever touched.
 _WRITER_HARNESS = r"""
 const { TimelinePanel } = require(process.argv[1]);
-const fs = require('fs'), path = require('path');
+const fs = require('fs');
 process.env.ROMP_STATE_DIR = process.argv[2];
-const fp = path.join(process.argv[2], 'session-flags.json');
-const SID = '11111111-2222-3333-4444-555555555555', OTHER = '99999999-8888-7777-6666-555555555555';
-const real = { readFileSync: fs.readFileSync, writeFileSync: fs.writeFileSync, renameSync: fs.renameSync, mkdirSync: fs.mkdirSync };
-function run(readImpl) {
-  const writes = [], renames = [];
-  fs.readFileSync = function (p) { if (String(p) === fp) return readImpl(); return real.readFileSync.apply(fs, arguments); };
+const SID = '11111111-2222-3333-4444-555555555555';
+const real = { writeFileSync: fs.writeFileSync, renameSync: fs.renameSync, readFileSync: fs.readFileSync };
+function run(answer) {
+  const writes = [], renames = [], reads = [], posts = [];
   fs.writeFileSync = function (p, data) { writes.push([String(p), String(data)]); };
   fs.renameSync = function (a, b) { renames.push([String(a), String(b)]); };
-  fs.mkdirSync = function () {};
-  try {
-    const v = Object.create(TimelinePanel.prototype);
-    v._setSessionFlag({ id: SID }, 'hideFromFeed', true);
-  } finally { Object.assign(fs, real); }
-  return { writes, renames };
+  fs.readFileSync = function (p) { reads.push(String(p)); return real.readFileSync.apply(fs, arguments); };
+  const v = Object.create(TimelinePanel.prototype);
+  v.draw = () => {};
+  v.data = { sessions: [{ id: SID, hideFromFeed: true }] };            // the gear's optimistic click, already painted…
+  v._pendingFlags = { [SID]: { hideFromFeed: true } };                  // …and held sticky
+  v._laneRefusal = null; v._laneMenu = null; v._laneMenuBuild = null;
+  v._kernelPost = (route, body) => { posts.push([route, body]); return Promise.resolve(answer); };
+  try { v._setSessionFlag({ id: SID }, 'hideFromFeed', true); } finally { Object.assign(fs, real); }
+  return new Promise((res) => setImmediate(() => res({ writes, renames, reads, posts, refusal: v._laneRefusal,
+                                                          painted: v.data.sessions[0].hideFromFeed, pending: v._pendingFlags })));
 }
-const err = (code) => Object.assign(new Error(code), { code });
-const r = {};
-process.versions.electron = '1.0.0-test';                   // the Electron guard: the writer runs at all
-r.eio = run(() => { throw err('EIO'); });                   // a read fault
-r.torn = run(() => '{"' + OTHER + '": {"postalServiceOff": tr');   // torn bytes
-r.list = run(() => '["' + OTHER + '"]');                   // valid JSON of the wrong shape
-r.enoent = run(() => { throw err('ENOENT'); });             // a legitimately missing store
-r.clean = run(() => JSON.stringify({ [OTHER]: { postalServiceOff: true } }));
-delete process.versions.electron;
-r.noElectron = run(() => { throw err('ENOENT'); });         // a bare-node run: nothing at all
-process.stdout.write(JSON.stringify({ fp, ...r }));
+(async () => {
+  const r = {};
+  process.versions.electron = '1.0.0-test';                   // the Electron guard: the writer runs at all
+  r.ok = await run({ ok: true, body: { ok: true, id: SID, flag: 'hideFromFeed', value: true } });
+  r.refused = await run({ ok: false, refusal: true, body: { ok: false, value: false },
+                          error: "couldn't save that setting — session-flags.json could not be read (read failed: [Errno 5] injected EIO); try again" });
+  r.down = await run({ ok: false, unreachable: true, error: 'the kernel is not running; start romp and try again' });
+  delete process.versions.electron;
+  r.noElectron = await run({ ok: true, body: { ok: true } });   // a bare-node run: nothing at all
+  process.stdout.write(JSON.stringify(r));
+})();
 """
 
 
 @unittest.skipUnless(NODE, "node not available")
-class TimelineFallbackFlagWriter(unittest.TestCase):
-    """The timeline's Obsidian-desktop fallback writer of session-flags.json (review find, 2026-09-08)
-    had the exact shape the kernel dropped: any read fault or torn bytes became {} and was written over
-    EVERY session's flags, in place -- so the kernel's strict reader could observe 0 bytes mid-write
-    and quarantine the very file being written. It now refuses on anything but a missing file, and
-    publishes tmp + rename, like _persistOrder."""
+class TimelineFlagWriterPostsThroughTheKernel(unittest.TestCase):
+    """The timeline's Obsidian-desktop flag writer (2026-09-08). Until this change it read-modify-wrote
+    session-flags.json itself (PR #1020 had made that write honest: the Electron guard, the kernel's
+    state root, tmp + rename) -- a SECOND WRITER of the flags with no lock against the kernel's own
+    setter. It now posts the kernel's /flag, which lands through _set_session_flag with the socket op's
+    validation, and a refusal takes the settingRefused door the lane gear already renders from: the
+    optimistic state ends, the toggle repaints to what the kernel still paints, the reason shows. With
+    no kernel answering the gesture is refused and says so; the panel never writes the file."""
 
     @classmethod
     def setUpClass(cls):
@@ -732,26 +736,36 @@ class TimelineFallbackFlagWriter(unittest.TestCase):
     def tearDownClass(cls):
         cls.td.cleanup()
 
-    def test_a_read_fault_torn_bytes_or_the_wrong_shape_write_nothing(self):
-        for case in ("eio", "torn", "list"):
-            self.assertEqual(self.r[case]["writes"], [], "%s: never written over a store that could not be read" % case)
-            self.assertEqual(self.r[case]["renames"], [], case)
+    def test_the_toggle_is_one_post_through_the_kernel_and_never_a_file(self):
+        for case in ("ok", "refused", "down"):
+            self.assertEqual(self.r[case]["posts"], [["/flag", {"id": "11111111-2222-3333-4444-555555555555",
+                                                                 "flag": "hideFromFeed", "value": True}]], case)
+            self.assertEqual((self.r[case]["writes"], self.r[case]["renames"]), ([], []),
+                             "%s: the panel writes no state file of its own, kernel up or down" % case)
+            self.assertFalse(any(p.endswith("session-flags.json") for p in self.r[case]["reads"]),
+                             "%s: nor does it read one to modify" % case)
 
-    def test_a_missing_store_is_written_atomically(self):
-        fp = self.r["fp"]
-        writes, renames = self.r["enoent"]["writes"], self.r["enoent"]["renames"]
-        self.assertEqual(len(writes), 1)
-        self.assertEqual(writes[0][0], fp + ".tmp", "the bytes go to the temp, never the live file")
-        self.assertEqual(json.loads(writes[0][1]), {"11111111-2222-3333-4444-555555555555": {"hideFromFeed": True}})
-        self.assertEqual(renames, [[fp + ".tmp", fp]], "one atomic publish")
+    def test_an_accepted_write_holds_its_optimistic_state_until_the_poll_confirms_it(self):
+        ok = self.r["ok"]
+        self.assertEqual((ok["painted"], ok["pending"], ok["refusal"]),
+                         (True, {"11111111-2222-3333-4444-555555555555": {"hideFromFeed": True}}, None))
 
-    def test_a_clean_read_keeps_the_other_sessions_flags(self):
-        writes = self.r["clean"]["writes"]
-        self.assertEqual(json.loads(writes[0][1]), {"99999999-8888-7777-6666-555555555555": {"postalServiceOff": True},
-                                                    "11111111-2222-3333-4444-555555555555": {"hideFromFeed": True}})
+    def test_the_kernels_refusal_ends_the_optimistic_state_in_the_kernels_words(self):
+        rf = self.r["refused"]
+        self.assertEqual(rf["pending"], {}, "the sticky copy is released")
+        self.assertIs(rf["painted"], False, "the toggle repaints to what the kernel still paints (the value it sent)")
+        self.assertEqual(rf["refusal"], {"sid": "11111111-2222-3333-4444-555555555555", "flag": "hideFromFeed",
+                                         "text": "couldn't save that setting — session-flags.json could not be read (read failed: [Errno 5] injected EIO); try again"})
 
-    def test_without_electron_nothing_is_touched(self):
-        self.assertEqual((self.r["noElectron"]["writes"], self.r["noElectron"]["renames"]), ([], []))
+    def test_no_kernel_is_a_refusal_that_says_so_with_the_toggle_back_where_the_click_found_it(self):
+        dn = self.r["down"]
+        self.assertEqual(dn["pending"], {})
+        self.assertIs(dn["painted"], False)
+        self.assertEqual(dn["refusal"]["text"], "couldn't save that setting — the kernel is not running; start romp and try again")
+
+    def test_without_electron_nothing_is_posted_or_touched(self):
+        ne = self.r["noElectron"]
+        self.assertEqual((ne["posts"], ne["writes"], ne["renames"]), ([], [], []))
 
 
 if __name__ == "__main__":

--- a/tests/test_obsidian_state_routes.py
+++ b/tests/test_obsidian_state_routes.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""POST /flag, /views and /order (2026-09-08): the Obsidian timeline panel's three state writes as
+kernel routes. The panel runs in Obsidian's Electron with Node's fs and the state dir and has no
+socket to the kernel, so it used to write session-flags.json, timeline-views.json and
+session-order.json itself -- a second writer beside the kernel, bypassing the views judge and its
+stale-writer guard, the flags setter's lock, and the order merge. Each route lands through the SAME
+setter its socket op calls (setSessionFlag / setTimelineViews / reorderTabs in _dispatch_ws), with
+that op's validation, and refuses the way it refuses; the tests here drive the REAL Handler over
+HTTP (the test_tag_route.py pattern) and, where a refusal is claimed to match the socket op's, drive
+the socket op too and compare. Synthetic only."""
+import contextlib
+import errno
+import inspect
+import json
+import os
+import re
+import tempfile
+import threading
+import time
+import unittest
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads -- they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_osr", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+SID2 = "22222222-3333-4444-5555-666666666666"
+OTHER = "99999999-8888-7777-6666-555555555555"
+A, B, C, D = ("aaaaaaaa-1111-2222-3333-444444444444", "bbbbbbbb-1111-2222-3333-444444444444",
+              "cccccccc-1111-2222-3333-444444444444", "dddddddd-1111-2222-3333-444444444444")
+
+
+@contextlib.contextmanager
+def _reads_fault(target):
+    """Fail every byte read of ONE path with an EIO for the duration of the block (the
+    tests/test_kernel_session_flags.py injector); everything else reads normally."""
+    real_rb, real_rt = Path.read_bytes, Path.read_text
+    tgt = str(target)
+
+    def rb(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EIO, "injected EIO")
+        return real_rb(self, *a, **k)
+
+    def rt(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EIO, "injected EIO")
+        return real_rt(self, *a, **k)
+    Path.read_bytes, Path.read_text = rb, rt
+    try:
+        yield
+    finally:
+        Path.read_bytes, Path.read_text = real_rb, real_rt
+
+
+class _Routes(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._state = km.jd.STATE
+        km.jd.STATE = Path(self.td.name)
+        km._flags_cache.clear()
+        self._saved = (km._mark_views_dirty, km._sync_notice)
+        self.dirty, self.notices = [], []
+        km._mark_views_dirty = lambda: self.dirty.append(1)
+        km._sync_notice = lambda text, ok=True, **kw: self.notices.append((text, ok))
+
+    def tearDown(self):
+        km._mark_views_dirty, km._sync_notice = self._saved
+        km.jd.STATE = self._state
+        km._flags_cache.clear()
+        self.td.cleanup()
+
+    def _post(self, path, body=None, raw=None, token=os.environ["ROMP_SERVE_TOKEN"]):
+        headers = {"Content-Type": "application/json"}
+        if token is not None:
+            headers["X-Romp-Token"] = token
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, path),
+                                     data=(raw if raw is not None else json.dumps(body).encode()),
+                                     headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return r.status, json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            text = e.read().decode()
+            try:
+                return e.code, json.loads(text)
+            except ValueError:
+                return e.code, text
+
+    def _ws(self, msg):
+        """The socket op, through the real dispatcher; the frames it answered on the poster's socket."""
+        sent = []
+        client = {"app": "timeline", "wid": "w-obs", "alive": True,
+                  "send": lambda raw: sent.append(json.loads(raw))}
+        km.Handler._dispatch_ws(object.__new__(km.Handler), msg, client)
+        return sent
+
+
+class FlagRoute(_Routes):
+
+    def _flags_file(self):
+        p = km.jd.STATE / "session-flags.json"
+        return json.loads(p.read_text()) if p.exists() else None
+
+    def test_a_toggle_lands_through_the_setter_and_unsets_the_way_it_does(self):
+        st, r = self._post("/flag", {"id": SID, "flag": "hideFromFeed", "value": True})
+        self.assertEqual((st, r), (200, {"ok": True, "id": SID, "flag": "hideFromFeed", "value": True}))
+        self.assertEqual(self._flags_file(), {SID: {"hideFromFeed": True}}, "the store the kernel reads holds it")
+        self.assertTrue(km._session_flag(SID, "hideFromFeed"))
+        self.assertEqual(self.dirty, [1], "the views push is poked, as after the socket op")
+        st, r = self._post("/flag", {"id": SID, "flag": "hideFromFeed", "value": False})
+        self.assertEqual((st, r["ok"]), (200, True))
+        self.assertEqual(self._flags_file(), {}, "off drops the entry -- _set_session_flag's pop, not a stored false")
+
+    def test_the_bell_rides_its_own_tri_state_setter(self):
+        st, r = self._post("/flag", {"id": SID, "flag": "notify", "value": True})
+        self.assertEqual((st, r["ok"]), (200, True))
+        self.assertIs(km._session_flag_raw(SID, "notify"), True, "an override on the (off) master is stored")
+        st, r = self._post("/flag", {"id": SID, "flag": "notify", "value": False})
+        self.assertEqual((st, r["ok"]), (200, True))
+        self.assertIsNone(km._session_flag_raw(SID, "notify"), "back to the master's value: the override is dropped, not stored as false")
+
+    def test_a_non_boolean_or_missing_value_is_a_400_that_writes_nothing(self):
+        for value, needle in (("false", "'value' must be true or false"), (0, "'value' must be true or false"),
+                              (None, "value (true or false) required")):
+            body = {"id": SID, "flag": "hideFromFeed"}
+            if value is not None:
+                body["value"] = value
+            st, r = self._post("/flag", body)
+            self.assertEqual(st, 400, (value, r))
+            self.assertFalse(r["ok"])
+            self.assertIn(needle, r["error"])
+        st, r = self._post("/flag", {"id": SID, "flag": "hideFromFeed", "value": None})
+        self.assertEqual((st, r["error"]), (400, "value (true or false) required"), "an explicit null is not a value either")
+        self.assertIsNone(self._flags_file(), "bool('false') must never UNDO a mute -- nothing was written")
+        self.assertEqual(self.dirty, [])
+
+    def test_an_unknown_flag_key_or_a_missing_id_is_a_400_naming_it(self):
+        st, r = self._post("/flag", {"id": SID, "flag": "autoNudgeOff", "value": True})
+        self.assertEqual(st, 400)
+        self.assertEqual(r["error"], 'flag must be one of hideFromFeed, postalServiceOff, notify, got "autoNudgeOff"')
+        st, r = self._post("/flag", {"id": SID, "flag": "hideFromFeed", "value": True, "target": "web"})
+        self.assertEqual(st, 400)
+        self.assertEqual(r["error"], "unknown key(s) 'target' — this route reads only 'id', 'flag', 'value'")
+        st, r = self._post("/flag", {"flag": "hideFromFeed", "value": True})
+        self.assertEqual((st, r["error"]), (400, "id (the session's id) required"))
+        self.assertIsNone(self._flags_file())
+
+    def test_a_store_fault_answers_the_socket_ops_refusal_and_leaves_the_file_alone(self):
+        km._set_session_flag(OTHER, "postalServiceOff", True)     # a populated store: a safety boundary
+        km._flags_cache.clear()
+        p = km.jd.STATE / "session-flags.json"
+        before = p.read_bytes()
+        with _reads_fault(p):
+            st, r = self._post("/flag", {"id": SID, "flag": "hideFromFeed", "value": True})
+            ws = self._ws({"type": "setSessionFlag", "id": SID, "flag": "hideFromFeed", "value": True})
+        self.assertEqual(st, 200, "the kernel's own refusal is a 200 with ok:false, like every route's")
+        self.assertFalse(r["ok"])
+        self.assertIn("couldn't save that setting", r["error"])
+        self.assertIn("session-flags.json could not be read", r["error"])
+        self.assertIs(r["value"], False, "the value the display path still paints rides along (the settingRefused field)")
+        self.assertEqual(len(ws), 1)
+        self.assertEqual(ws[0]["type"], "settingRefused")
+        self.assertEqual(ws[0]["text"], r["error"], "word for word the socket op's refusal")
+        self.assertEqual(ws[0]["value"], r["value"])
+        self.assertEqual(p.read_bytes(), before, "the flags file is byte-for-byte unchanged")
+        self.assertEqual(self.dirty, [], "a refused write marks nothing dirty")
+
+
+class ViewsRoute(_Routes):
+
+    def setUp(self):
+        super().setUp()
+        try:
+            km._views_path().unlink()
+        except OSError:
+            pass
+
+    def _seed(self):
+        t, err = km._edit_tag("web", add=[SID])
+        self.assertIsNone(err)
+        self.dirty.clear()
+        return km._views_client()
+
+    def test_a_clean_write_lands_through_the_judge_and_answers_the_viewsack_document(self):
+        served = self._seed()
+        nv = json.loads(json.dumps(served))
+        nv["actives"] = {"timeline": {"tags": ["web"]}}                # a lens edit, built from the echo
+        st, r = self._post("/views", {"views": nv, "edited": [], "writeId": "w1"})
+        self.assertEqual(st, 200)
+        self.assertEqual((r["type"], r["writeId"], r["ok"], r["refused"]), ("viewsAck", "w1", True, []))
+        self.assertEqual(r["views"]["actives"]["timeline"], {"tags": ["web"]})
+        self.assertIsInstance(r["seq"], int)
+        self.assertNotIn("error", r)
+        stored = json.loads(km._views_path().read_text())
+        self.assertEqual(stored["seq"], r["seq"], "the store carries the judge's stamp -- the write went through the one door")
+        self.assertEqual(stored["actives"]["timeline"], {"tags": ["web"]})
+        self.assertEqual(self.dirty, [1])
+        self.assertEqual(self.notices, [])
+
+    def test_a_stale_copy_is_refused_exactly_as_the_socket_op_refuses_it(self):
+        served = self._seed()
+        tid = served["tags"][0]["id"]
+        stale = json.loads(json.dumps(served))                           # this panel's copy...
+        time.sleep(1.1)                                                  # int-second stamps: land in a later second
+        t, err = km._edit_tag("web", add=[SID2])                         # ...then another writer adds a member
+        self.assertIsNone(err)
+        stale["actives"] = {"timeline": {"tags": ["web"]}}               # the stale panel changes its lens...
+        stale["tags"][0]["members"] = []                                 # ...and its copy of web has no members
+        st, r = self._post("/views", {"views": stale, "edited": [tid], "writeId": "w2"})
+        self.assertEqual((st, r["type"], r["writeId"], r["ok"]), (200, "viewsAck", "w2", False))
+        self.assertEqual([x["name"] for x in r["refused"]], ["web"])
+        self.assertIn("predates", r["refused"][0]["reason"])
+        self.assertIn('"web"', r["error"], "one plain sentence the dialog shows as-is")
+        v = r["views"]
+        self.assertEqual(sorted(next(x for x in v["tags"] if x["id"] == tid)["members"]), sorted([SID, SID2]),
+                         "the store's newer members stand -- the guard judged this write")
+        self.assertEqual(v["actives"]["timeline"], {"tags": ["web"]}, "the rest of the write (the lens) landed")
+        # the SAME stale copy through the socket op: the same verdict, the same words, the same document
+        ws = self._ws({"type": "setTimelineViews", "writeId": "w3", "views": stale, "edited": [tid]})
+        self.assertEqual(len(ws), 1)
+        a = ws[0]
+        self.assertEqual((a["type"], a["ok"]), ("viewsAck", False))
+        self.assertEqual(a["error"], r["error"])
+        self.assertEqual([x["name"] for x in a["refused"]], [x["name"] for x in r["refused"]])
+        self.assertEqual(set(a) - {"writeId"}, set(r) - {"writeId"}, "one document, whichever door it came through")
+
+    def test_a_setter_exception_is_the_socket_arms_refusal_word_for_word(self):
+        self._seed()
+        real = km._set_timeline_views
+
+        def boom(blob, **kw):
+            raise RuntimeError("disk on fire")
+        km._set_timeline_views = boom
+        try:
+            st, r = self._post("/views", {"views": {"active": "all", "tags": []}, "writeId": "w1"})
+            ws = self._ws({"type": "setTimelineViews", "writeId": "w1", "views": {"active": "all", "tags": []}})
+        finally:
+            km._set_timeline_views = real
+        self.assertEqual((st, r["ok"], r["refused"]), (200, False, []))
+        self.assertEqual(r["error"], "the write failed on the kernel: disk on fire")
+        self.assertEqual(ws[0]["error"], r["error"])
+        self.assertIsInstance(r["views"], dict, "the store's blob rides the refusal, for the panel to revert to")
+
+    def test_a_non_object_views_field_or_an_unknown_key_is_a_400(self):
+        st, r = self._post("/views", {"views": "not-a-dict"})
+        self.assertEqual((st, r["error"]), (400, 'views (an object) required, got "not-a-dict"'))
+        st, r = self._post("/views", {"views": {"active": "all", "tags": []}, "target": "x"})
+        self.assertEqual(st, 400)
+        self.assertEqual(r["error"], "unknown key(s) 'target' — this route reads only 'views', 'edited', 'writeId'")
+        self.assertFalse(km._views_path().exists(), "nothing was written")
+        self.assertEqual(self.dirty, [])
+
+
+class OrderRoute(_Routes):
+
+    def _order_file(self):
+        return json.loads((km.jd.STATE / "session-order.json").read_text())
+
+    def test_the_merge_keeps_the_slots_of_lanes_the_drag_did_not_carry(self):
+        km._write_session_order([A, B, C])
+        st, r = self._post("/order", {"order": [C, A]})
+        self.assertEqual((st, r), (200, {"ok": True, "order": [C, B, A]}))
+        self.assertEqual(self._order_file(), [C, B, A], "B kept its slot -- the merge, never the whole-file overwrite")
+        self.assertEqual(self.dirty, [1])
+
+    def test_a_sid_the_store_does_not_know_lands_where_the_merge_puts_it(self):
+        km._write_session_order([A, B, C])
+        st, r = self._post("/order", {"order": [D, A]})
+        self.assertEqual((st, r["order"]), (200, [D, B, C, A]))
+        self.assertEqual(self._order_file(), [D, B, C, A], "the new sid takes the dragged slot; the displaced one appends")
+
+    def test_a_non_list_a_non_string_entry_or_an_unknown_key_is_a_400(self):
+        km._write_session_order([A, B, C])
+        self.dirty.clear()
+        st, r = self._post("/order", {"order": "abc"})
+        self.assertEqual((st, r["error"]), (400, 'order (a list of session ids) required, got "abc"'))
+        st, r = self._post("/order", {"order": [A, 7]})
+        self.assertEqual(st, 400)
+        self.assertIn("order (a list of session ids) required", r["error"])
+        st, r = self._post("/order", {"order": [A], "surface": "lanes"})
+        self.assertEqual((st, r["error"]), (400, "unknown key(s) 'surface' — this route reads only 'order'"))
+        self.assertEqual(self._order_file(), [A, B, C], "nothing was written")
+        self.assertEqual(self.dirty, [])
+
+    def test_a_store_fault_answers_the_socket_ops_refusal_and_leaves_the_file_alone(self):
+        km._write_session_order([A, B, C])
+        p = km.jd.STATE / "session-order.json"
+        before = p.read_bytes()
+        self.dirty.clear()
+        with _reads_fault(p):
+            st, r = self._post("/order", {"order": [C, A]})
+            ws = self._ws({"type": "reorderTabs", "order": [C, A]})
+        self.assertEqual((st, r["ok"]), (200, False))
+        self.assertIn("couldn't save the new order", r["error"])
+        self.assertIn("session-order.json could not be read", r["error"])
+        self.assertEqual(ws[0]["type"], "settingRefused")
+        self.assertEqual(ws[0]["text"], r["error"], "word for word the socket op's refusal")
+        self.assertEqual(p.read_bytes(), before, "never spliced against a fabricated [] and persisted")
+        self.assertEqual(self.dirty, [])
+
+
+class BodiesAndAuth(_Routes):
+
+    def test_a_non_object_body_is_the_typed_400_on_every_route(self):
+        for path in ("/flag", "/views", "/order"):
+            st, r = self._post(path, raw=b"[1]")
+            self.assertEqual((st, r), (400, {"ok": False, "error": "body must be a JSON object, got [1]"}), path)
+            st, r = self._post(path, raw=b"nope")
+            self.assertEqual((st, r), (400, {"ok": False, "error": "body is not JSON"}), path)
+
+    def test_a_missing_or_wrong_token_is_refused_before_the_body_is_read(self):
+        for path, body in (("/flag", {"id": SID, "flag": "hideFromFeed", "value": True}),
+                           ("/views", {"views": {"active": "all", "tags": []}}),
+                           ("/order", {"order": [A]})):
+            for tok in (None, "not-the-token"):
+                st, r = self._post(path, body, token=tok)
+                self.assertEqual(st, 403, (path, tok, r))
+                self.assertIn("forbidden", r)
+        self.assertFalse((km.jd.STATE / "session-flags.json").exists())
+        self.assertFalse(km._views_path().exists())
+        self.assertFalse((km.jd.STATE / "session-order.json").exists())
+
+
+class PortRecord(unittest.TestCase):
+    """The panel learns the kernel's port from the kernel's OWN record, written once the socket is
+    bound -- never from a guess (an Electron app launched from the dock sees no shell's
+    ROMP_KERNEL_PORT) -- and beside the serve-token file it already reads."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._state = km.jd.STATE
+        km.jd.STATE = Path(self.td.name)
+
+    def tearDown(self):
+        km.jd.STATE = self._state
+        self.td.cleanup()
+
+    def test_the_record_is_the_bound_port_one_line(self):
+        km._persist_serve_port(12345)
+        self.assertEqual((km.jd.STATE / "serve-port").read_text(), "12345\n")
+        km._persist_serve_port(29855)
+        self.assertEqual((km.jd.STATE / "serve-port").read_text(), "29855\n", "a restart on another port rewrites it")
+
+    def test_main_writes_it_right_after_the_bind_succeeds(self):
+        src = inspect.getsource(km.main)
+        bind = src.index("srv = ThreadingHTTPServer((BIND, PORT), Handler)")
+        rec = src.index("_persist_serve_port(srv.server_address[1])")
+        self.assertLess(bind, rec, "the record follows the bind")
+        between = src[bind:rec].split("\n")[1:]
+        self.assertTrue(all(not ln.strip() or ln.strip().startswith("#") for ln in between),
+                        "...immediately: a failed bind leaves no record that lies")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -162,6 +162,23 @@ function lensBlob(base, fields) {
   }
   return v;
 }
+// The keys a lens write is ABOUT are named by its caller (`own`, _setLens): value-diffing cannot name
+// them once a surface is held locally (a held surface differs from the store by construction, and the
+// click that re-posts a held filter to save it differs from nothing shown). lensSame / shownTagOrder
+// serve the hold-and-release bookkeeping (_holdLocalLens / _releaseLocalLens).
+function lensSame(a, b) { return JSON.stringify(a === undefined ? null : a) === JSON.stringify(b === undefined ? null : b); }
+function shownTagOrder(v) { return (v && v.tagOrder) || viewTagUnion(v).map((g) => g.name); }
+// The local lens OVER a blob (a copy), PER KEY: a held surface entry replaces only that surface's entry
+// in the store's map, a held `active` or `tagOrder` only itself — the store's other surfaces show and
+// post as the store has them (viewTagUnion orders by the blob's tagOrder, so the order needs no re-sort here).
+function overlayLensFields(v, fields) {
+  const nv = JSON.parse(JSON.stringify(v || { active: 'all', tags: [] }));
+  nv.tags = viewTags(nv).slice(); delete nv.groups;
+  if (fields.active !== undefined) nv.active = fields.active;
+  if (fields.actives) nv.actives = Object.assign({}, nv.actives || {}, JSON.parse(JSON.stringify(fields.actives)));
+  if (fields.tagOrder) nv.tagOrder = fields.tagOrder.slice();
+  return nv;
+}
 // A tag IS its NAME, everywhere (user ruling 2026-08-24: "if the UX requires understanding that
 // tags exist across different kernels, it is not good"): one name = one identity, membership the
 // UNION across every kernel defining that name, the LOCAL store's color winning the render. The
@@ -687,6 +704,14 @@ function readableRgb(rgb) {
 // The romp accent blue (same as the Fleet pill / focus accent) — the DARK theme's accent; the light
 // theme swaps in clay via PAL().accent / the ACCENT binding below.
 const ROMP_BLUE = '#9cd2ff';
+// what every refused write says when no kernel answers (_kernelPost): the panel never writes the state
+// files itself, so with romp down the gesture lands nowhere, and this is the whole of what happened
+const KERNEL_DOWN = 'the kernel is not running; start romp and try again';
+// ...and when the state dir holds no serve-port record at all, so the port was the CLI's default or
+// environment: a kernel older than this panel writes the token and no record (the live kernel lags
+// the checkout until `romp refresh`, and the plugin loads this file on its own), so "not running" alone
+// would be false against one that is
+const KERNEL_DOWN_NO_RECORD = 'the kernel is not running, or the one running predates this panel and left no port record; start or restart romp and try again';
 const PAL_DARK = {
   modelFg: '#9aa0a6',            // muted secondary text (MODEL_FG)
   metaHoverFg: '#e6edf3',        // hover-brightened text (META_HOVER_FG)
@@ -1008,6 +1033,7 @@ class TimelinePanel {
     this._caps = new Set();      // what the LOCAL kernel announced at `ready` ({type:"caps"}); 'tagEdit' = targeted ops, acks, seq (setCaps)
     this._pendingTagEdits = {};  // remote-tag edits held optimistically until the owner's poll echoes (federation v1): id → {tag: shape|null(=deleted), age}
     this._tagEditErr = null;     // the LOUD failure of the last tag edit ({host, name, error}), shown in the dialog until dismissed
+    this._localLens = null;      // {fields, reason}: a filter kept LOCAL because no kernel could save it (the Obsidian panel, kernel down): applied in _curViews, said in the Filter menu, cleared by the next lens write a kernel takes (_kernelViewsAnswer)
     this._viewsMenu = null;      // the Show-dropdown element, when open
     this._viewsDialog = null;    // the sessions/group dialog backdrop, when open
     this._viewsDialogKey = null; // its Escape hook {doc, fn}, removed on every close path
@@ -2316,9 +2342,10 @@ class TimelinePanel {
     this._suppressClick = true;
     const visOrder = this._dragOrder || d.order;
     this._dragOrder = null;
+    const prev = ((this.data && this.data.sessions) || []).map((s) => s.id);   // what a refused persist puts back
     const full = this._mergeVisibleOrder(visOrder);            // full SID list with only the visible lanes permuted
     this._applyOrderToData(full);                              // optimistic in-place reorder → no snap-back pre-poll
-    this._persistOrder(full);                                  // write the shared file (tabs watch it)
+    this._persistOrder(full, prev, d.sid);                     // the shared store (tabs follow it), through the kernel
     this.draw();
     ev.preventDefault();
   }
@@ -2335,25 +2362,29 @@ class TimelinePanel {
     const oidx = new Map(full.map((id, i) => [id, i]));
     this.data.sessions.sort((a, b) => ((oidx.has(a.id) ? oidx.get(a.id) : Infinity) - (oidx.has(b.id) ? oidx.get(b.id) : Infinity)));
   }
-  // Persist the full SID order to ~/.local/state/romp/session-order.json. VS Code webview has no Node →
-  // hand it to the extension host (which writes atomically); Obsidian desktop writes directly (tmp+rename).
-  _persistOrder(order) {
+  // Persist the full SID order. Web / VS Code: the host hook (→ the kernel's reorderTabs merge). Obsidian:
+  // the kernel's POST /order — the SAME merge, so lanes the drag did not carry keep their slots (the
+  // whole-file write this replaced dropped every one of them; _kernelPost has the rule). `prev` is the
+  // order before the drag and `sid` the lane it moved, both captured by the caller: a refusal puts the
+  // lanes back at once and names the reason in the dragged lane's gear (settingRefused) — the one
+  // place a lane has for a notice here, the web shell's notice bell having no Obsidian counterpart.
+  // Under PLAIN node with a window shim (the `node --test` runner) there is no romp UI at all, so
+  // nothing is written: the lane-drag test once landed in the old direct write and WIPED
+  // ~/.local/state/romp/session-order.json to its two fixture sids on every `npm test` — the "tabs keep
+  // reordering themselves" bug the order-audit log finally pinned (the user 2026-07-02). _kernelHost's
+  // Electron-or-nothing guard is that rule.
+  _persistOrder(order, prev, sid, from) {
     try {
       if (typeof window !== 'undefined' && typeof window.__rompTimelineWriteOrder === 'function') {
         window.__rompTimelineWriteOrder(order); return;
       }
-      // The direct write is the OBSIDIAN DESKTOP path — an Electron app. Under PLAIN node with a window
-      // shim (the `node --test` runner) there is no romp UI at all, so never touch the real state file:
-      // the lane-drag test used to land here and WIPE ~/.local/state/romp/session-order.json to its
-      // two fixture sids on every `npm test`, which is exactly the "tabs keep reordering themselves"
-      // bug the order-audit log finally pinned (the user 2026-07-02). Electron-or-nothing, no heuristic.
-      if (typeof process === 'undefined' || !process.versions || !process.versions.electron) return;
-      const fs = require('fs'), path = require('path'), os = require('os');
-      const base = process.env.XDG_STATE_HOME || path.join(os.homedir(), '.local', 'state');
-      const root = process.env.ROMP_STATE_DIR || path.join(base, 'romp');   // per-kernel state root (plans/multi-kernel.md)
-      const f = path.join(root, 'session-order.json'), tmp = f + '.tmp';
-      fs.writeFileSync(tmp, JSON.stringify(order));
-      fs.renameSync(tmp, f);
+      if (!this._kernelHost()) return;
+      return this._kernelPost('/order', { order }).then((r) => {   // the settle promise, for the tests that await it; callers ignore it
+        if (r.ok) return;                                        // the next poll shows the merged order
+        if (Array.isArray(prev)) this._applyOrderToData(prev);   // back to what stood before the drag
+        this.settingRefused({ gesture: 'order', sid: sid || '', from: from || '',
+                              text: r.refusal ? r.error : "couldn't save the new order — " + r.error });
+      });
     } catch (e) { /* no host hook + no Node → can't persist; the drag still reordered visually until next poll */ }
   }
 
@@ -3068,6 +3099,18 @@ class TimelinePanel {
   // timeline display toggles; the dialog holds the per-session checkboxes. All pointerdown-based
   // (the redraw-eats-click rule) and rebuilt per draw like the gear/lock.
   _curViews() {
+    // what the panel SHOWS: the write base, with the unsaved filter (a lens no kernel could take,
+    // _localLens) overlaid per key — this viewer's own surfaces over whatever the store says
+    const base = this._writeBase();
+    return this._localLens ? overlayLensFields(base, this._localLens.fields) : base;
+  }
+
+  // The blob a WRITE is built over: the pending copy or the store, the remote halves' pending edits
+  // overlaid — and never the local lens (review find, 2026-09-08: built from the shown blob, a tag
+  // create or a member edit on the Obsidian panel carried the unsaved filter to the kernel through an
+  // unrelated gesture, persisting a value the kernel never took while the not-saved note stayed). The
+  // local lens leaves this panel only through a LENS write of its own surface (_setLens).
+  _writeBase() {
     const base = this._pendingViews || this._views || { active: 'all', hidden: [], tags: [] };
     const ids = Object.keys(this._pendingTagEdits || {});
     if (!ids.length) return base;
@@ -3202,10 +3245,26 @@ class TimelinePanel {
       this._laneRefusal = { sid, flag, text };
       if (this._laneMenu && this._laneMenu._sid === sid && this._laneMenuBuild) this._laneMenuBuild();
     }
+    let shell = false;
     try {
-      if (typeof window !== 'undefined' && window.parent && window.parent !== window)
-        window.parent.postMessage({ romp: 'notify', kind: 'refused', text, sid }, '*');
+      shell = !!(typeof window !== 'undefined' && window.parent && window.parent !== window);
+      if (shell) window.parent.postMessage({ romp: 'notify', kind: 'refused', text, sid }, '*');
     } catch (e) { /* no parent frame (Obsidian, headless) */ }
+    if (!shell && m && m.gesture === 'order' && sid) {
+      if (m.from === 'dialog') {
+        // a row dragged INSIDE the tags dialog: the dialog's own row carries it, and only the dialog's —
+        // the gear is not where that gesture was made, and the same sentence in both slots rendered twice
+        // there (review find, 2026-09-08). `kind: 'order'`: the Filter menu, unrelated to a drag, skips it;
+        // the dialog's close clears it (_closeViewsDialog).
+        this._tagEditErr = { host: '', name: '', error: text, kind: 'order' };
+      } else {
+        // no shell bell to carry a refused lane drag (the Obsidian panel, _persistOrder): the dragged
+        // lane's gear shows it, the same dismissible row a refused toggle gets, until ✕ or a later refusal
+        this._laneRefusal = { sid, flag: '', text };
+        if (this._laneMenu && this._laneMenu._sid === sid && this._laneMenuBuild) this._laneMenuBuild();
+      }
+      this._repaintTagSurfaces();   // the dialog's rows, if it is open, back in the order that stands, with the reason
+    }
     this.draw();
   }
 
@@ -3235,8 +3294,9 @@ class TimelinePanel {
     if (g.pending) return;
     const meta = { name: g.name, tid: g.localId };
     // the local half's optimistic copy, taken BEFORE the remote fan-out: _curViews overlays the
-    // remote halves' pending copies, and those must not ride a local post
-    const localCopy = () => (g.localId ? JSON.parse(JSON.stringify(this._curViews())) : null);
+    // remote halves' pending copies, and those must not ride a local post — and taken from the WRITE
+    // base, never the shown blob: an unsaved filter (_localLens) must not ride a tag edit either
+    const localCopy = () => (g.localId ? JSON.parse(JSON.stringify(this._writeBase())) : null);
     // the fan-out to the remote halves a gesture reaches: every one is dispatched, and the local half
     // rides only if every one was taken. The refused halves make ONE notice naming each of them and
     // whether the local half was held back too (review find, 2026-09-08: each half's own notice
@@ -3383,7 +3443,7 @@ class TimelinePanel {
     });
     ni.addEventListener('keydown', (e) => {
       if (e.key !== 'Enter' || !ni.value.trim() || ni.disabled || this._createInFlight()) return;
-      const nv = JSON.parse(JSON.stringify(this._curViews()));
+      const nv = JSON.parse(JSON.stringify(this._writeBase()));   // the write base: an unsaved filter never rides a create
       const used = new Set(viewTags(nv).map((t) => t.color));
       const color = (this._palette || []).find((c) => !used.has(c)) || (this._palette || [])[0] || '#1EA1EB';
       // the optimistic row wears a PLACEHOLDER id: the kernel mints the tag's id, and the ack's blob
@@ -3484,6 +3544,7 @@ class TimelinePanel {
   _repaintTagSurfaces() {
     if (this._viewsDialog && this._viewsDialogBuild) this._viewsDialogBuild();
     if (this._laneMenu && typeof this._laneMenu._build === 'function') this._laneMenu._build();
+    if (this._viewsMenu && typeof this._viewsMenu._build === 'function') this._viewsMenu._build();   // the Filter menu (the display menu shares the slot and has no build)
   }
 
   // the kernel does not know an op this page posted (a dashboard newer than its kernel): the write is
@@ -3580,47 +3641,128 @@ class TimelinePanel {
     this.draw();
   }
 
-  // Persist the whole views blob — the lens and order edits, which have no targeted op. Web/VS
-  // Code: the host WS hook (→ kernel setTimelineViews, which normalizes + rebroadcasts, and answers
-  // viewsAck with the stale-writer guard's refusals, if any). Obsidian/headless fallback: write the
-  // same timeline-views.json the kernel reads (it re-normalizes on read) — the write IS the store
-  // write there, so the copy is adopted as the base on the spot. Optimistic, like the lane flags.
+  // Persist the whole views blob — the lens and order edits, which have no targeted op, and every tag
+  // edit of a panel with no targeted bridge (_postTagEdit). Web/VS Code: the host WS hook (→ kernel
+  // setTimelineViews, which normalizes + rebroadcasts, and answers viewsAck with the stale-writer
+  // guard's refusals, if any). Obsidian: the kernel's POST /views — the same op, the same judge, and
+  // the same viewsAck document back (_kernelViewsAck), so the copy clears or reverts on the ack
+  // exactly as it does on a socket; the panel no longer writes timeline-views.json itself (_kernelPost
+  // has the why). Optimistic, like the lane flags.
   // A LENS or ORDER write — {active?, actives?, tagOrder?}: the whole blob is built from the STORE's
   // blob (this._views, the last one adopted) plus these fields, never from the pending copy (the 2026-09-05 review: a copy carrying targeted edits still in flight posted them as this
   // dialog's claim on those tags, and a rename the kernel had refused as a duplicate landed through
   // the next lens toggle). The pending copy SHOWN is the current one with the same fields applied,
   // so in-flight edits stay visible; the in-flight record keeps the fields for rederiveViews.
-  _setLens(fields) {
-    this._setViews(lensBlob(this._views, fields), [], fields);
+  // `own` — what the gesture is ABOUT: {surfaces: [name…]} for the `actives` entries it changed (the
+  // Filter menu and the corner chips: the timeline's; the dialog's pane-filter rows: theirs), {tagOrder:
+  // true} for a pill drag, {active: true} for the legacy scalar. The rest of `fields` is the base the
+  // write was built over (_lensBaseActives) and nobody's change. A write no kernel takes keeps its own
+  // keys local (_holdLocalLens); a ruled write releases only them (_releaseLocalLens). Omitted, every
+  // key `fields` carries counts as the gesture's — right for a caller that posts only its own change.
+  _setLens(fields, own) {
+    own = own || { surfaces: Object.keys(fields.actives || {}), tagOrder: 'tagOrder' in fields, active: 'active' in fields };
+    this._setViews(lensBlob(this._views, fields), [], fields, own);
   }
 
-  _setViews(v, edited, lens) {
-    this._pendingViews = lens ? applyLensFields(this._curViews(), lens) : v; this._legacyViewsAge = 0;
+  // the map a lens gesture's `actives` is built over: the WRITE base's (the store's, or the pending
+  // copy's) — never the shown map, whose local entries would post an unsaved filter of another surface
+  // as this gesture's claim, and a chat lens the store has since moved past over the dashboard's
+  _lensBaseActives() { return Object.assign({}, this._writeBase().actives || {}); }
+
+  _setViews(v, edited, lens, own) {
+    // a lens write's pending copy is the WRITE base plus the gesture's own fields — never the shown blob:
+    // that copy is what _writeBase returns while the write is in flight, and built from the shown blob it
+    // carried every OTHER held key of the local lens into the next tag create or pane-filter write
+    // (review find, 2026-09-08). The local lens is overlaid at render only (_curViews).
+    this._pendingViews = lens ? applyLensFields(this._writeBase(), lens) : v; this._legacyViewsAge = 0;
+    // a lens gesture takes its keys over from any unsaved filter held for them, NOW: the pending copy is
+    // what shows (not the older local value under it) and its note goes; an answer no kernel gives holds
+    // the NEW value again, a ruled one leaves the kernel's blob standing (_kernelViewsAnswer)
+    if (lens && own) this._releaseLocalLens(own);
+    let settled = null;   // the kernel POST's settle promise (Obsidian), for the tests that await it; callers ignore it
     try {
-      if (typeof window !== 'undefined' && typeof window.__rompTimelineSetViews === 'function') {
+      const hook = typeof window !== 'undefined' && typeof window.__rompTimelineSetViews === 'function';
+      if (hook || this._kernelHost()) {
         const writeId = this._mintWriteId();
         // the record is what this write DID: its lens/order fields, else the blob IS its state (rederiveViews)
         this._viewsWrites.push(lens ? { id: writeId, name: '', lens } : { id: writeId, name: '', blob: v });
         // `edited`: the tag ids this write CHANGED — none for a lens or order edit — so the kernel acks a
         // refusal on a tag this dialog never touched (a stale copy of it) as ok, with the refusal listed:
         // the newer blob is adopted and no notice shows, since nothing the user did was refused
-        window.__rompTimelineSetViews(v, writeId, Array.isArray(edited) ? edited : []);
-      } else if (typeof process !== 'undefined' && process.versions && process.versions.electron) {
-        // Obsidian only — the Electron guard keeps a bare-node test run from ever touching the real
-        // file (the 2026-07-02 _persistOrder lesson). Resolve the state root the way the kernel does
-        // (ROMP_STATE_DIR, then XDG_STATE_HOME, then the default), write tmp+rename so a reader never
-        // sees a torn blob.
-        const fs = require('fs'), os = require('os'), path = require('path');
-        const root = process.env.ROMP_STATE_DIR
-          || path.join(process.env.XDG_STATE_HOME || path.join(os.homedir(), '.local', 'state'), 'romp');
-        fs.mkdirSync(root, { recursive: true });
-        const fp = path.join(root, 'timeline-views.json');
-        fs.writeFileSync(fp + '.tmp', JSON.stringify(v));
-        fs.renameSync(fp + '.tmp', fp);
-        this._views = v; this._pendingViews = null;   // the file IS the store: the write settled, no ack to wait for
+        const ed = Array.isArray(edited) ? edited : [];
+        if (hook) window.__rompTimelineSetViews(v, writeId, ed);
+        else settled = this._kernelPost('/views', { views: v, edited: ed, writeId }).then((r) => this._kernelViewsAnswer(r, writeId, lens, own));
       }
-    } catch (e) { /* no host hook + no Node fs → session-local only */ }
+    } catch (e) { /* no host hook + no Node → session-local only */ }
     this.draw();
+    return settled;
+  }
+
+  // The kernel's answer to a POST /views. A kernel that RULED (ok, or its own refusal — ok:false, a typed
+  // 400, a refused token) is fed to the viewsAck door as the very document the route returns, so the
+  // copy clears or reverts as it does on a socket. A LENS write that reached NO kernel (down, a foreign
+  // service on the recorded port, a kernel that predates the route) keeps the filter LOCAL instead
+  // (review find, 2026-09-08): the lens is the one write whose value is purely this viewer's own
+  // filter, so a snap-back would make filtering impossible without a kernel; the Filter menu says the
+  // filter is not saved and why (_localLens), and the next lens write a kernel takes clears it. Every
+  // other write that reached no kernel reverts, with the reason where the gesture was made.
+  _kernelViewsAnswer(r, writeId, lens, own) {
+    if (lens && r && r.unreachable) {
+      const i = this._viewsWrites.findIndex((w) => w.id === writeId);
+      if (i >= 0) this._viewsWrites.splice(i, 1);
+      this._pendingViews = this._viewsWrites.length ? rederiveViews(this._views, this._viewsWrites) : null;
+      this._holdLocalLens(lens, own || {}, r.error);
+      this._repaintTagSurfaces();
+      this.draw();
+      return;
+    }
+    const had = this._localLens;
+    if (lens && r && !r.unreachable) this._releaseLocalLens(own || {});   // a kernel ruled on these keys (released at post already; kept for a caller that posts without _setViews)
+    this.viewsAck(this._kernelViewsAck(r, writeId));
+    if (had !== this._localLens) this._repaintTagSurfaces();   // the note changed under an open menu
+  }
+
+  // The local lens is held PER KEY — `active`, each surface under `actives`, `tagOrder` — so a second
+  // gesture no kernel takes merges into what is held (a pill drag beside a filter), and a ruled write
+  // releases only the keys it carried (a tagOrder the kernel took leaves the viewer's timeline filter
+  // local, with its note). An entry equal to the store's is not held: a filter toggled back to what
+  // the store has is the store's, not unsaved.
+  _holdLocalLens(fields, own, reason) {
+    const store = this._views || {}, copy = (x) => JSON.parse(JSON.stringify(x));
+    const f = (this._localLens && this._localLens.fields) || {};
+    const held = { active: f.active, actives: Object.assign({}, f.actives || {}), tagOrder: f.tagOrder };
+    if (own.active) { if (fields.active === undefined || lensSame(fields.active, store.active)) delete held.active; else held.active = fields.active; }
+    for (const k of (own.surfaces || [])) {
+      const v = (fields.actives || {})[k];
+      if (v === undefined || lensSame(v, (store.actives || {})[k])) delete held.actives[k]; else held.actives[k] = copy(v);
+    }
+    if (own.tagOrder) { if (!fields.tagOrder || lensSame(fields.tagOrder, shownTagOrder(store))) delete held.tagOrder; else held.tagOrder = fields.tagOrder.slice(); }
+    this._localLens = this._heldLens(held, reason);
+  }
+  _releaseLocalLens(own) {
+    if (!this._localLens) return;
+    const f = this._localLens.fields;
+    const held = { active: f.active, actives: Object.assign({}, f.actives || {}), tagOrder: f.tagOrder };
+    if (own.active) delete held.active;
+    for (const k of (own.surfaces || [])) delete held.actives[k];
+    if (own.tagOrder) delete held.tagOrder;
+    this._localLens = this._heldLens(held, this._localLens.reason);
+  }
+  _heldLens(held, reason) {
+    const fields = {};
+    if (held.active !== undefined) fields.active = held.active;
+    if (Object.keys(held.actives).length) fields.actives = held.actives;
+    if (held.tagOrder) fields.tagOrder = held.tagOrder;
+    return Object.keys(fields).length ? { fields, reason } : null;
+  }
+
+  // the viewsAck frame for a POST /views answer: the route's own document when a kernel ruled; a
+  // refusal no kernel ruled on becomes an ack that is not ok, carrying the reason and no blob to adopt
+  _kernelViewsAck(r, writeId) {
+    const body = r && r.body && typeof r.body === 'object' ? r.body : {};
+    const ack = Object.assign({}, body, { type: 'viewsAck', writeId, ok: !!(r && r.ok) });
+    if (!ack.ok) ack.error = r && r.unreachable ? 'nothing was changed — ' + r.error : (r && r.error) || 'refused';
+    return ack;
   }
 
   // ── THE CORNER BAR — real HTML over the SVG strip (the user 2026-08-25, round three) ─────────
@@ -3716,7 +3858,7 @@ class TimelinePanel {
       x.title = 'remove \u201c' + c.label + '\u201d from this timeline\u2019s filter';
       x.addEventListener('pointerdown', (e) => {
         e.preventDefault(); e.stopPropagation();
-        this._setLens({ actives: Object.assign({}, v.actives, { timeline: lensToggle(lens, c.pick) }) });
+        this._setLens({ actives: Object.assign(this._lensBaseActives(), { timeline: lensToggle(lens, c.pick) }) }, { surfaces: ['timeline'] });
       });
       x.addEventListener('click', (e) => e.stopPropagation());
       chip.appendChild(x);
@@ -3740,6 +3882,7 @@ class TimelinePanel {
   _closeViewsDialog() {
     if (!this._viewsDialog) return;
     this._viewsDialog.remove(); this._viewsDialog = null; this._viewsDialogBuild = null;
+    this._tagEditErr = null;   // a notice the dialog showed was seen; it does not follow the user to the gear or the Filter menu
     this._tagNewDraft = null; this._tagNewInput = null;   // the join menu's draft dies with the dialog (_closeLaneMenu's rule)
     if (this._viewsDialogKey) {   // the Escape hook dies with the dialog on EVERY close path, not just Escape
       try { this._viewsDialogKey.doc.removeEventListener('keydown', this._viewsDialogKey.fn); } catch (e) {}
@@ -3793,7 +3936,7 @@ class TimelinePanel {
       const v = this._curViews();
       const lens = timelineLens(v);
       const apply = (nl, close) => {
-        this._setLens({ actives: Object.assign({}, v.actives, { timeline: nl }) });
+        this._setLens({ actives: Object.assign(this._lensBaseActives(), { timeline: nl }) }, { surfaces: ['timeline'] });
         if (close) this._closeViewsMenu(); else build();
       };
       item('All', { current: lensAll(lens) }).addEventListener('click', () => apply({ all: true }, true));
@@ -3807,8 +3950,31 @@ class TimelinePanel {
         this._closeViewsMenu();
         this._openViewsDialog(null);
       });
+      // a refused write shows HERE too (review find, 2026-09-08: a lens click's refusal showed only in
+      // the dialog and the lane gear, surfaces the click never opened, so the menu dead-ended — every
+      // toggle snapped back with no reason in sight): the dialog's notice in the menu's compact idiom,
+      // ✕ to dismiss; viewsAck / setCaps repaint the open menu (menu._build) as they repaint the dialog
+      const noticeStyle = 'display:flex;align-items:center;gap:6px;margin:2px 8px 4px;padding:3px 8px;'
+        + 'border:1px solid #F85B5A;border-radius:5px;color:#F85B5A;font-size:0.82em;';
+      if (this._tagEditErr && this._tagEditErr.kind !== 'order') {   // a lens or tag refusal; a dialog drag's is the dialog's
+        const er = menu.createDiv();
+        er.setAttribute('style', noticeStyle);
+        er.createSpan({ text: '⚠ ' + (this._tagEditErr.host ? this._tagEditErr.host + ': ' : '') + this._tagEditErr.error });
+        const ex = er.createSpan({ text: '✕' });
+        ex.setAttribute('style', 'margin-left:auto;cursor:pointer;opacity:0.7;');
+        ex.addEventListener('click', (e) => { e.stopPropagation(); this._tagEditErr = null; build(); });
+      }
+      // a filter kept LOCAL because no kernel could save it (_kernelViewsAnswer): the same row, no ✕ —
+      // the note stands as long as the filter is unsaved, and the next lens click a kernel takes clears
+      // both, so an unsaved filter is never shown as a saved one
+      if (this._localLens) {
+        const nr = menu.createDiv();
+        nr.setAttribute('style', noticeStyle);
+        nr.createSpan({ text: '⚠ this filter is not saved — ' + this._localLens.reason });
+      }
     };
     build();
+    menu._build = build;   // viewsAck / setCaps / _kernelViewsAnswer repaint the open menu with a refusal or the not-saved note
     const h = this._menuHost(anchorEl.getBoundingClientRect());
     h.doc.body.appendChild(menu);
     menu.style.left = Math.max(6, Math.min(Math.round(h.rect.left), (h.win.innerWidth || 9999) - 220)) + 'px';
@@ -4020,7 +4186,7 @@ class TimelinePanel {
                 // the union display order, remote-homed names included; the kernel orders the
                 // stored tags array by it (lensBlob's own re-sort matters on the Electron path,
                 // where the posted blob is the file)
-                this._setLens({ tagOrder: names });
+                this._setLens({ tagOrder: names }, { tagOrder: true });
                 build();
               };
               pillCell.addEventListener('pointermove', onMove);
@@ -4155,7 +4321,7 @@ class TimelinePanel {
           // name skips the ones in use rather than counting rows. The write names the new id as
           // edited: a kernel that reads `edited` takes an unnamed unknown tag for a stale copy
           // re-creating a deleted one.
-          const nv = JSON.parse(JSON.stringify(v));
+          const nv = JSON.parse(JSON.stringify(this._writeBase()));   // the write base, not the shown blob: an unsaved filter never rides a create
           const names = new Set(viewTags(nv).map((t) => t.name));
           let n = 1; while (names.has('tag ' + n)) n++;
           const tg = { id: 'g' + Date.now().toString(36), name: 'tag ' + n, color, members: [] };
@@ -4195,7 +4361,7 @@ class TimelinePanel {
           if (key === '*' || key !== 'feed') {
             const upd = key === '*' ? { chat: lens, timeline: lens, outline: lens } : {};
             if (key !== '*') upd[key] = lens;
-            this._setLens({ actives: Object.assign({}, this._curViews().actives, upd) });
+            this._setLens({ actives: Object.assign(this._lensBaseActives(), upd) }, { surfaces: Object.keys(upd) });
           }
           if (key === '*' || key === 'feed') {
             try { localStorage.setItem('romp:feedTags-set', JSON.stringify({ lens, t: Date.now() })); } catch (e) {}
@@ -4325,9 +4491,10 @@ class TimelinePanel {
               if (toIdx === fromIdx) return;
               const vis = cells.map((c) => c._sid);
               vis.splice(toIdx, 0, vis.splice(fromIdx, 1)[0]);
+              const prev = ((this.data && this.data.sessions) || []).map((s) => s.id);   // what a refused persist puts back
               const full = this._mergeVisibleOrder(vis);   // only the shown rows permute within the full order
               this._applyOrderToData(full);                // optimistic — no snap-back before the next poll
-              this._persistOrder(full);                    // the shared store: tabs + lanes follow
+              this._persistOrder(full, prev, vis[toIdx], 'dialog');   // the shared store: tabs + lanes follow
               renderRows();
             };
             nameCell.addEventListener('pointermove', onMove);
@@ -4517,37 +4684,150 @@ class TimelinePanel {
     if (this._dismissed.size) this.data.sessions = this.data.sessions.filter((s) => !this._dismissed.has(s.id));
   }
 
-  // Persist a per-session flag. Web dashboard: the host WS hook (→ kernel setSessionFlag → rebuild feed).
-  // Obsidian desktop fallback: write the same session-flags.json the kernel's build_feed reads, with the
-  // discipline the kernel's own writer has (review find, 2026-09-08). Before this it was the exact shape
-  // the kernel dropped: any read fault or torn bytes became {} and was written over EVERY session's flags
-  // (postal isolation included), and the write truncated the live file in place, so the kernel's strict
-  // reader could observe 0 bytes mid-write and quarantine the very file being written. Now it mirrors
-  // _persistOrder / _setViews: Electron-or-nothing (a bare-node test run must never touch the real file),
-  // the kernel's state root, a refusal on any read fault or non-object parse (only a MISSING file reads as
-  // empty; the kernel quarantines torn bytes on its own next read), and an atomic tmp + rename publish.
+  // Persist a per-session flag. Web dashboard: the host WS hook (→ kernel setSessionFlag → rebuild
+  // feed). Obsidian: the kernel's POST /flag — the same setter, the same JSON-boolean gate, and the same
+  // refusal, delivered to the settingRefused door this page already renders from (the lane gear ends its
+  // optimistic state and says why). Until 2026-09-08 this path read-modify-wrote session-flags.json
+  // itself, with no lock against the kernel's own setter; the panel writes none of the state files now
+  // (_kernelPost has the rule). Plain node (the runner) has neither a hook nor Electron and writes
+  // nothing — the guard every writer here wears.
   _setSessionFlag(s, flag, value) {
     try {
       if (typeof window !== 'undefined' && typeof window.__rompTimelineSetFlag === 'function') {
         window.__rompTimelineSetFlag(s.id, flag, value); return;
       }
-      if (typeof process === 'undefined' || !process.versions || !process.versions.electron) return;
+      if (!this._kernelHost()) return;
+      return this._kernelPost('/flag', { id: s.id, flag, value: !!value }).then((r) => {   // the settle promise, for the tests that await it
+        if (r.ok) return;                                          // the next data poll confirms it; _pendingFlags holds it sticky meanwhile
+        // the kernel's own refusal (200, ok:false) carries the value it still paints; a refusal it never
+        // ruled on (nothing answering, a 403, a typed 400) puts the toggle back where the click found it
+        const painted = r.body && typeof r.body.value === 'boolean' ? r.body.value : !value;
+        this.settingRefused({ gesture: 'flag', sid: s.id, flag, value: painted,
+                              text: r.refusal ? r.error : "couldn't save that setting — " + r.error });
+      });
+    } catch (e) { /* no host hook + no Node → can't persist */ }
+  }
+
+  // ── the Obsidian panel writes THROUGH the kernel (2026-09-08) ───────────────────────────────
+  // The panel runs inside Obsidian's Electron with Node's fs and the state dir, and no socket to the
+  // kernel — so it used to write session-flags.json, timeline-views.json and session-order.json ITSELF: a
+  // second writer beside the kernel, whose whole-blob views write skipped the judge and the stale-writer
+  // guard (a concurrent dashboard edit could be rolled back and the guard never saw the write), whose
+  // flag write raced the kernel's own setter with no lock, and whose order write skipped the merge that
+  // keeps untouched lanes' slots. Now every write is a POST to the kernel's /flag, /views and /order,
+  // which land through the same setters the dashboards' socket ops use, with the same validation and
+  // the same refusals. READS are unchanged: the host still builds the data from the files. With no
+  // kernel to post to — no serve-port record under the state dir, nothing answering on it, or a token
+  // it refuses — the gesture is REFUSED and the panel says so where the gesture was made (the lane
+  // gear, the tags dialog): an authority that cannot be reached is surfaced, never replaced by a write
+  // it cannot check, since this panel cannot tell "no kernel anywhere" from "a kernel it cannot see"
+  // (a stale record, another port, a token from another state dir), and the second case is exactly the
+  // race this removes. Same-user trust boundary as every kernel client: the serve token comes from the
+  // kernel's 0600 file and rides the X-Romp-Token header (never a URL), the port from the kernel's own
+  // record (never a guess). A panel reading SYNCED state on another machine finds a record no kernel of
+  // its own answers on and lands in the same refusal. Node's http, not fetch: a fetch from Obsidian's
+  // app:// origin with a custom header needs a CORS preflight, and a failed preflight reads exactly like
+  // a kernel that is down.
+  _kernelHost() {
+    // Electron (Obsidian) only: a bare-node run (the test runner) and a browser page (which has its host
+    // hooks) have no kernel to post to from here — the guard the file writers wore (the user 2026-07-02)
+    if (typeof process === 'undefined' || !process.versions || !process.versions.electron) return null;
+    // the requires sit INSIDE a try, like every Node require in this file (_tmuxPath, the shell-outs, the
+    // writers this replaced): this file is also bundled for the BROWSER (esbuild, platform browser, the
+    // webview's timeline-main.ts inlines it), and esbuild leaves an unresolvable require alone only when
+    // a try/catch wraps it — a bare one fails the build (PR #1078's first CI run). The guard above keeps
+    // the page from ever evaluating them.
+    try {
       const fs = require('fs'), os = require('os'), path = require('path');
-      const dir = process.env.ROMP_STATE_DIR
-        || path.join(process.env.XDG_STATE_HOME || path.join(os.homedir(), '.local', 'state'), 'romp');
-      const fp = path.join(dir, 'session-flags.json');
-      let cur = {};
-      try { cur = JSON.parse(fs.readFileSync(fp, 'utf8')); }
-      catch (e) { if (!e || e.code !== 'ENOENT') return; }   // unreadable or torn: never write over a store we could not read
-      if (!cur || typeof cur !== 'object' || Array.isArray(cur)) return;   // valid JSON of the wrong shape: not ours to overwrite
-      const f = (cur[s.id] && typeof cur[s.id] === 'object') ? cur[s.id] : {};
-      if (value) f[flag] = true; else delete f[flag];
-      if (Object.keys(f).length) cur[s.id] = f; else delete cur[s.id];
-      fs.mkdirSync(dir, { recursive: true });
-      const tmp = fp + '.tmp';
-      fs.writeFileSync(tmp, JSON.stringify(cur));
-      fs.renameSync(tmp, fp);
-    } catch (e) { /* no host hook + no Node fs → can't persist */ }
+      const base = process.env.XDG_STATE_HOME || path.join(os.homedir(), '.local', 'state');
+      const root = process.env.ROMP_STATE_DIR || path.join(base, 'romp');   // per-kernel state root (plans/multi-kernel.md; tests/test_state_dir_override.py pins this line)
+      return { fs, path, root };
+    } catch (e) { return null; }
+  }
+
+  // One POST to the kernel → a promise of {ok, status?, body?, error?, refusal?, unreachable?, foreign?};
+  // it never rejects. `error` is always a bare REASON the caller frames ("couldn't save that setting —
+  // …", "nothing was changed — …"). ok is true only for a 2xx whose body is a romp kernel's
+  // {ok:true, …}; ok:false carries the KERNEL'S words when a kernel ruled — a 200 with ok:false is its
+  // own refusal (`refusal`: the full sentence the dashboards see), a 4xx with ok:false its typed
+  // complaint, a 401/403 the token it would not take — and `unreachable` when NO romp kernel took the
+  // request: nothing answering (KERNEL_DOWN, or KERNEL_DOWN_NO_RECORD when the port was the CLI's
+  // default rather than the kernel's record), a record or token file this panel could not read, a
+  // kernel that predates the route (a 404), or some other local service that now owns the recorded
+  // port (`foreign`: a 2xx that is not a romp answer — read as accepted, that left the optimistic toggle
+  // re-applied on every push until a value that never comes, the silent divergence this change exists
+  // to remove). A body that stalls or a socket that drops after the headers settles too (res 'error' /
+  // 'aborted' / 'close' behind the done guard): unsettled, the optimistic state stood forever with no
+  // message, and the unhandled 'error' was an uncaught exception in the renderer.
+  _kernelPost(route, body) {
+    const h = this._kernelHost();
+    if (!h) return Promise.resolve({ ok: false, unreachable: true, error: KERNEL_DOWN });
+    const at = (name) => h.path.join(h.root, name);
+    const unreadable = (what, p, e) => Promise.resolve({ ok: false, unreachable: true,
+      error: "this panel could not read the kernel's " + what + ' ' + p + ' (' + ((e && e.code) || 'error') + ')' });
+    let tok = '';
+    try { tok = h.fs.readFileSync(at('serve-token'), 'utf8').trim(); }
+    catch (e) { if (!e || e.code !== 'ENOENT') return unreadable('token file', at('serve-token'), e); }
+    if (!tok) return Promise.resolve({ ok: false, unreachable: true, error: KERNEL_DOWN });   // never minted: no kernel has run against this state dir
+    let port = 0, recorded = true, envVar = '', envRaw = '';
+    try { port = parseInt(h.fs.readFileSync(at('serve-port'), 'utf8'), 10); }
+    catch (e) {
+      if (!e || e.code !== 'ENOENT') return unreadable('port record', at('serve-port'), e);
+      // no record: a kernel older than this panel writes the token and no port. Resolve the port the way
+      // the CLI does — the environment in cli/keyswap.py _kernel_urls' order (ROMP_KERNEL_PORT, then
+      // ROMP_SERVE_PORT; an empty value is unset), else bin/romp's default, ${ROMP_KERNEL_PORT:-29855}
+      // (keyswap alone goes on to probe two older ports; this panel does not) — and try it; only a
+      // refused connection then reads as down. An unusable override is refused, never silently replaced
+      // by the default (_kernel_urls' rule: that replacement hands the token to whatever answers there).
+      recorded = false;
+      const pick = (name) => String(process.env[name] || '').trim();
+      envVar = pick('ROMP_KERNEL_PORT') ? 'ROMP_KERNEL_PORT' : (pick('ROMP_SERVE_PORT') ? 'ROMP_SERVE_PORT' : '');
+      envRaw = envVar ? pick(envVar) : '29855';
+      port = /^\d+$/.test(envRaw) ? parseInt(envRaw, 10) : 0;
+    }
+    if (!(port > 0 && port < 65536))
+      return Promise.resolve({ ok: false, unreachable: true, error: recorded
+        ? "this panel could not read the kernel's port record " + at('serve-port') + ' (not a port number)'
+        : envVar + '=' + JSON.stringify(envRaw) + ' is not a port' });
+    const down = recorded ? KERNEL_DOWN : KERNEL_DOWN_NO_RECORD;
+    const where = '127.0.0.1:' + port;
+    return new Promise((resolve) => {
+      let done = false;
+      const finish = (r) => { if (!done) { done = true; resolve(r); } };
+      const dropped = () => finish({ ok: false, unreachable: true, error: down });
+      try {
+        const data = JSON.stringify(body);
+        const req = require('http').request({
+          host: '127.0.0.1', port, path: route, method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data), 'X-Romp-Token': tok },
+        }, (res) => {
+          let text = '';
+          res.setEncoding('utf8');
+          res.on('data', (c) => { text += c; });
+          res.on('error', dropped); res.on('aborted', dropped); res.on('close', dropped);   // a 'close' after a complete 'end' is a no-op behind the guard
+          res.on('end', () => {
+            const st = res.statusCode || 0;
+            let j = null;
+            try { j = JSON.parse(text); } catch (e) { j = null; }
+            if (!j || typeof j !== 'object' || Array.isArray(j)) j = null;
+            if (st === 401 || st === 403)
+              return finish({ ok: false, status: st, error: 'the kernel on ' + where + " refused this panel's token (HTTP " + st + ')' });
+            if (j && j.ok === false)             // a romp kernel's refusal: its own sentence on a 200, its typed complaint on a 4xx
+              return finish({ ok: false, status: st, body: j, refusal: st >= 200 && st < 300, error: j.error || 'refused' });
+            if (st >= 200 && st < 300 && j && j.ok === true)
+              return finish({ ok: true, status: st, body: j });
+            if (st >= 200 && st < 300)           // a 2xx that no romp kernel sent
+              return finish({ ok: false, status: st, unreachable: true, foreign: true, error: where + ' answered, but not as a romp kernel' });
+            if (st === 404)                      // a romp kernel from before these routes, found on the CLI's port
+              return finish({ ok: false, status: st, unreachable: true, error: 'the kernel on ' + where + ' predates this panel and has no ' + route + ' route; restart romp (`romp refresh`) and try again' });
+            return finish({ ok: false, status: st, error: 'the kernel on ' + where + ' answered HTTP ' + st });
+          });
+        });
+        req.on('error', dropped);
+        req.setTimeout(10000, () => req.destroy());
+        req.end(data);
+      } catch (e) { dropped(); }
+    });
   }
 
   // Clear a DEAD lane's leftover row from the timeline (the Clear pill on a struck-through lane). The kernel

--- a/ui/timeline-flags.test.ts
+++ b/ui/timeline-flags.test.ts
@@ -72,11 +72,33 @@ test("the icon drawers survive (they render inside the menu now): ON = romp blue
   assert.match(SRC, /t\.icon\(!on, 8\.5, 8\.5, on \? ACCENT : MODEL_FG\)/);   // ACCENT = ROMP_BLUE in dark; clay under body.theme-light
 });
 
-test("setSessionFlag still posts via the web host hook, with a Node-fs fallback for Obsidian", () => {
+test("setSessionFlag posts via the web host hook, and through the kernel's POST /flag in Obsidian", () => {
   assert.match(SRC, /_setSessionFlag\(s, flag, value\)/);
   assert.match(SRC, /window\.__rompTimelineSetFlag === 'function'/);
   assert.match(SRC, /window\.__rompTimelineSetFlag\(s\.id, flag, value\)/);
-  assert.match(SRC, /session-flags\.json/, "Obsidian/headless writes the same file the kernel reads");
+  assert.match(SRC, /this\._kernelPost\('\/flag', \{ id: s\.id, flag, value: !!value \}\)/, "Obsidian: the kernel's setter, through its route");
+  assert.doesNotMatch(SRC, /writeFileSync|renameSync/, "the panel writes none of the kernel's state files itself (2026-09-08)");
+});
+
+test("the Obsidian writer is the kernel's route, never a file of its own (2026-09-08; PR #1020's fallback superseded)", () => {
+  // Pinned on the writer's OWN slice. PR #1020 gave the old fallback writer the discipline of its two
+  // siblings (the Electron guard, the kernel's state root, tmp + rename); this change removes the
+  // fallback: the panel was a SECOND WRITER of session-flags.json with no lock against the kernel's own
+  // setter, and now posts through it, with the kernel's refusal landing in the settingRefused door the
+  // lane gear already renders from. Kernel down → the gesture is refused and says so, never written to a
+  // file the kernel cannot check. The writer is RUN from tests/test_kernel_session_flags.py
+  // (TimelineFlagWriterPostsThroughTheKernel) and ui/timeline-kernel-post.test.ts.
+  const w = SRC.slice(SRC.indexOf("_setSessionFlag(s, flag, value) {"), SRC.indexOf("_kernelHost() {"));
+  assert.ok(w.length > 0 && w.length < 4000, "the writer's slice");
+  assert.match(w, /if \(!this\._kernelHost\(\)\) return;/, "Electron-or-nothing, through the one shared guard");
+  assert.match(w, /this\._kernelPost\('\/flag'/);
+  assert.match(w, /this\.settingRefused\(\{ gesture: 'flag', sid: s\.id, flag, value: painted,/, "a refusal takes the door the socket op's refusal takes");
+  assert.doesNotMatch(w, /readFileSync|writeFileSync|renameSync|session-flags\.json'/, "no file of its own, read or written");
+  const h = SRC.slice(SRC.indexOf("_kernelHost() {"), SRC.indexOf("_kernelPost(route, body) {"));
+  assert.match(h, /if \(typeof process === 'undefined' \|\| !process\.versions \|\| !process\.versions\.electron\) return null;/,
+    "a bare-node run never posts");
+  assert.match(h, /const base = process\.env\.XDG_STATE_HOME \|\| path\.join\(os\.homedir\(\), '\.local', 'state'\);\s*\n\s*const root = process\.env\.ROMP_STATE_DIR \|\| path\.join\(base, 'romp'\);/,
+    "the kernel's state root, resolved as the kernel resolves it — where its serve-token and serve-port records are (the exact line tests/test_state_dir_override.py pins)");
 });
 
 test("the sticky-flag machinery survives: pendingFlags reconcile on every update (no flicker-back)", () => {

--- a/ui/timeline-kernel-post.test.ts
+++ b/ui/timeline-kernel-post.test.ts
@@ -1,0 +1,701 @@
+// The Obsidian timeline panel writes THROUGH the kernel (2026-09-08). The panel runs inside Obsidian's
+// Electron with Node's fs and the state dir, and no socket to the kernel — so it used to write
+// session-flags.json, timeline-views.json and session-order.json itself, a second writer beside the
+// kernel that bypassed the views judge and its stale-writer guard, the flags setter's proved read and
+// the order merge. Now every write is a POST to the kernel's /flag, /views and /order (_kernelPost);
+// when no kernel takes the write the gesture is REFUSED where it was made, never written to a file the
+// kernel cannot check — except the lens, this viewer's own filter, which stays applied LOCALLY and says
+// it is not saved. EXECUTED against real loopback servers standing in for the kernel (the transport,
+// the token, the port record, the answers no romp kernel would give) and against a stubbed _kernelPost
+// (the three writers' contracts, the Filter menu). Synthetic ids only; the state dir is a temp dir, the
+// CLI-default port is pinned to one nothing listens on, and no real file or kernel is ever touched.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as http from "node:http";
+import { createRequire } from "node:module";
+
+const requireCjs = createRequire(__filename);
+const VIEW_PATH = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
+const SRC = fs.readFileSync(VIEW_PATH, "utf8");
+const { TimelinePanel, timelineLens, viewTagUnion } = requireCjs(VIEW_PATH);
+
+const SID = "11111111-2222-3333-4444-555555555555";
+const SID2 = "22222222-3333-4444-5555-666666666666";
+const TOKEN = "test-token-DO-NOT-USE";
+const KERNEL_DOWN = "the kernel is not running; start romp and try again";
+const KERNEL_DOWN_NO_RECORD = "the kernel is not running, or the one running predates this panel and left no port record; start or restart romp and try again";
+
+function panel(): any {
+  const p: any = Object.create(TimelinePanel.prototype);
+  p.draw = () => {};
+  p.data = { sessions: [{ id: SID, name: "web", hideFromFeed: false }] };
+  p._pendingFlags = {}; p._laneRefusal = null; p._laneMenu = null; p._laneMenuBuild = null; p._metaMenu = null;
+  p._viewsWrites = []; p._pendingViews = null; p._pendingTagEdits = {}; p._tagEditErr = null; p._localLens = null;
+  p._views = null; p._rejectedViews = null; p._announcedViewsSeq = null; p._viewsWriteSeq = 0; p._legacyViewsAge = 0;
+  p._viewsDialog = null; p._viewsDialogBuild = null; p._viewsMenu = null; p._caps = new Set();
+  return p;
+}
+
+const tick = () => new Promise<void>((r) => setImmediate(r));
+
+// a loopback port nothing listens on (bound, then released)
+async function closedPort(): Promise<number> {
+  const srv = http.createServer();
+  await new Promise<void>((r) => srv.listen(0, "127.0.0.1", () => r()));
+  const port = (srv.address() as any).port;
+  await new Promise<void>((r) => srv.close(() => r()));
+  return port;
+}
+
+// an Obsidian-shaped process for the duration of fn: Electron on, the state dir a temp dir holding
+// whichever of the kernel's two records the test plants ("dir" plants an unreadable one), and the
+// CLI-default port the no-record fallback resolves (ROMP_KERNEL_PORT) pinned to `envPort` — a closed
+// port unless the test says — with ROMP_SERVE_PORT cleared, so no fallback here can reach a kernel
+// that happens to be running on this machine
+async function asObsidian(records: { port?: number | string; token?: string; envPort?: number }, fn: (root: string) => Promise<void>) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "romp-kernel-post-"));
+  if (records.port === "dir") fs.mkdirSync(path.join(root, "serve-port"));
+  else if (records.port !== undefined) fs.writeFileSync(path.join(root, "serve-port"), String(records.port) + "\n");
+  if (records.token === "dir") fs.mkdirSync(path.join(root, "serve-token"));
+  else if (records.token !== undefined) fs.writeFileSync(path.join(root, "serve-token"), records.token + "\n", { mode: 0o600 });
+  const saved = { root: process.env.ROMP_STATE_DIR, kport: process.env.ROMP_KERNEL_PORT, sport: process.env.ROMP_SERVE_PORT };
+  const versions: any = process.versions;
+  const hadElectron = versions.electron;
+  versions.electron = "1.0.0-test";
+  process.env.ROMP_STATE_DIR = root;
+  process.env.ROMP_KERNEL_PORT = String(records.envPort !== undefined ? records.envPort : await closedPort());
+  delete process.env.ROMP_SERVE_PORT;
+  try { await fn(root); } finally {
+    if (hadElectron === undefined) delete versions.electron; else versions.electron = hadElectron;
+    for (const [k, v] of [["ROMP_STATE_DIR", saved.root], ["ROMP_KERNEL_PORT", saved.kport], ["ROMP_SERVE_PORT", saved.sport]] as const)
+      if (v === undefined) delete process.env[k]; else process.env[k] = v;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+// a kernel stand-in on loopback: keeps every request, answers what the test says — a JSON body, or
+// `raw` text, or (`drop`) headers and a partial body followed by a destroyed socket
+type Seen = { method: string; url: string; headers: http.IncomingHttpHeaders; body: any };
+type Answer = { status: number; body?: any; raw?: string; drop?: boolean };
+function kernel(answer: (req: Seen) => Answer) {
+  return new Promise<{ port: number; seen: Seen[]; close: () => Promise<void> }>((resolve) => {
+    const seen: Seen[] = [];
+    const srv = http.createServer((req, res) => {
+      let text = "";
+      req.setEncoding("utf8");
+      req.on("data", (c) => { text += c; });
+      req.on("end", () => {
+        let body: any = null;
+        try { body = text ? JSON.parse(text) : null; } catch { body = text; }
+        const rec: Seen = { method: req.method || "", url: req.url || "", headers: req.headers, body };
+        seen.push(rec);
+        const a = answer(rec);
+        if (a.drop) { res.writeHead(a.status, { "Content-Type": "application/json", "Content-Length": "40" }); res.write('{"ok":'); setTimeout(() => res.destroy(), 5); return; }
+        res.writeHead(a.status, { "Content-Type": a.raw !== undefined ? "text/plain" : "application/json" });
+        res.end(a.raw !== undefined ? a.raw : JSON.stringify(a.body));
+      });
+    });
+    srv.listen(0, "127.0.0.1", () => resolve({
+      port: (srv.address() as any).port, seen,
+      close: () => new Promise<void>((r) => srv.close(() => r())),
+    }));
+  });
+}
+
+const gearClick = (p: any, s: any, next: boolean) => {   // the lane gear's toggle, as it runs: optimistic, sticky, then the writer (whose settle promise comes back)
+  s.hideFromFeed = next; (p._pendingFlags[s.id] = p._pendingFlags[s.id] || {}).hideFromFeed = next; return p._setSessionFlag(s, "hideFromFeed", next);
+};
+
+test("executed: the token rides the header from the kernel's 0600 file, the port comes from its record, and the URL carries neither", async () => {
+  const k = await kernel(() => ({ status: 200, body: { ok: true, id: SID, flag: "hideFromFeed", value: true } }));
+  try {
+    await asObsidian({ port: k.port, token: TOKEN }, async () => {
+      const r = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+      assert.equal(r.ok, true);
+      assert.equal(r.body.value, true, "the kernel's answer rides back whole");
+      assert.equal(k.seen.length, 1, "one request");
+      const q = k.seen[0];
+      assert.equal(q.method, "POST");
+      assert.equal(q.url, "/flag", "the route and nothing else — no token in the URL");
+      assert.equal(q.headers["x-romp-token"], TOKEN, "the token from the file, in the header every kernel client uses");
+      assert.equal(q.headers["content-type"], "application/json");
+      assert.deepEqual(q.body, { id: SID, flag: "hideFromFeed", value: true });
+    });
+  } finally { await k.close(); }
+  const kp = SRC.slice(SRC.indexOf("  _kernelPost(route, body) {"), SRC.indexOf("  _kernelPost(route, body) {") + 5000);
+  assert.doesNotMatch(kp, /token=/, "the token is never a query parameter");
+  assert.match(kp, /'X-Romp-Token': tok/);
+  assert.match(kp, /readFileSync\(at\('serve-port'\)/, "the port is the kernel's own record first…");
+  assert.match(kp, /e\.code !== 'ENOENT'\) return unreadable\('port record'/, "…an unreadable record is said, never read as 'not running'…");
+  assert.match(kp, /envVar = pick\('ROMP_KERNEL_PORT'\) \? 'ROMP_KERNEL_PORT' : \(pick\('ROMP_SERVE_PORT'\) \? 'ROMP_SERVE_PORT' : ''\);\s*\n\s*envRaw = envVar \? pick\(envVar\) : '29855';/,
+    "…and only a MISSING record falls to the CLI's resolution: the environment in _kernel_urls' order, else bin/romp's one default");
+  assert.match(kp, /bin\/romp's default, \$\{ROMP_KERNEL_PORT:-29855\}/, "the comment names the rule the panel actually mirrors (keyswap alone probes two more ports)");
+  assert.match(kp, /require\('http'\)\.request\(/, "Node's http, not fetch: no CORS preflight from Obsidian's app:// origin can read as a kernel that is down");
+});
+
+test("executed: a refusal comes back in the kernel's words — its own ok:false, a typed 400, a refused token — and the writer frames it", async () => {
+  const answers: Answer[] = [];
+  const k = await kernel(() => answers.shift() || { status: 500, body: {} });
+  try {
+    await asObsidian({ port: k.port, token: TOKEN }, async () => {
+      const p = panel();
+      const text = "couldn't save that setting — session-flags.json could not be read (read failed: [Errno 5] injected EIO); try again";
+      answers.push({ status: 200, body: { ok: false, error: text, value: true } });
+      let r = await p._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: false });
+      assert.deepEqual([r.ok, r.refusal, r.error, r.body.value], [false, true, text, true], "the kernel's own refusal: its full sentence, and the value it still paints");
+      answers.push({ status: 400, body: { ok: false, error: "'value' must be true or false, got \"false\"" } });
+      r = await p._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: "false" });
+      assert.deepEqual([r.ok, r.status, r.error, r.refusal, r.unreachable], [false, 400, "'value' must be true or false, got \"false\"", false, undefined], "a typed refusal, verbatim; not the kernel's own sentence, not 'not running'");
+      answers.push({ status: 403, body: {} });
+      r = await p._kernelPost("/order", { order: [SID] });
+      assert.equal(r.error, "the kernel on 127.0.0.1:" + k.port + " refused this panel's token (HTTP 403)");
+      assert.deepEqual([r.ok, r.unreachable], [false, undefined], "a kernel that answered is not 'not running'");
+      // the writer frames the bare reason
+      answers.push({ status: 403, body: {} });
+      const s = p.data.sessions[0];
+      await gearClick(p, s, true);
+      assert.equal(p._laneRefusal.text, "couldn't save that setting — the kernel on 127.0.0.1:" + k.port + " refused this panel's token (HTTP 403)");
+      assert.equal(s.hideFromFeed, false, "…and the toggle goes back where the click found it");
+    });
+  } finally { await k.close(); }
+});
+
+test("executed: a 2xx that is not a romp kernel's {ok:true} is NOT accepted — some other service owns that port — and the writer reverts (review find, 2026-09-08)", async () => {
+  const answers: Answer[] = [];
+  const k = await kernel(() => answers.shift() || { status: 500, body: {} });
+  try {
+    await asObsidian({ port: k.port, token: TOKEN }, async () => {
+      const p = panel();
+      const foreign = "127.0.0.1:" + k.port + " answered, but not as a romp kernel";
+      for (const a of [{ status: 200, body: {} }, { status: 200, body: { status: "ok" } }, { status: 200, body: { ok: "true" } },
+                       { status: 200, body: [1] }, { status: 200, raw: "OK" }, { status: 204, raw: "" }] as Answer[]) {
+        answers.push(a);
+        const r = await p._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+        assert.deepEqual([r.ok, r.unreachable, r.foreign, r.error], [false, true, true, foreign], JSON.stringify(a));
+      }
+      // …so the optimistic toggle is never left re-applying itself on every push until a value that never comes
+      const s = p.data.sessions[0];
+      answers.push({ status: 200, body: {} });
+      await gearClick(p, s, true);
+      assert.deepEqual([s.hideFromFeed, p._pendingFlags, p._laneRefusal.text],
+        [false, {}, "couldn't save that setting — " + foreign]);
+    });
+  } finally { await k.close(); }
+});
+
+test("executed: a socket that drops after the headers settles the promise (never a hung optimistic state, never an uncaught 'error')", async () => {
+  const k = await kernel(() => ({ status: 200, drop: true }));
+  try {
+    await asObsidian({ port: k.port, token: TOKEN }, async () => {
+      const t0 = Date.now();
+      const r = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+      assert.deepEqual([r.ok, r.unreachable, r.error], [false, true, KERNEL_DOWN]);
+      assert.ok(Date.now() - t0 < 5000, "settled by the drop itself, not the 10 s timeout");
+    });
+  } finally { await k.close(); }
+  const kp = SRC.slice(SRC.indexOf("  _kernelPost(route, body) {"), SRC.indexOf("  _kernelPost(route, body) {") + 5000);
+  assert.match(kp, /res\.on\('error', dropped\); res\.on\('aborted', dropped\); res\.on\('close', dropped\);/, "every way a response can die after its headers is handled, behind the done guard");
+});
+
+test("executed: no serve-port record → the CLI's port (env, else 29855) is tried; a kernel there takes the write, an old kernel there is named, nothing there is the combined down text (review find, 2026-09-08)", async () => {
+  // a running kernel that predates the record: the write lands through the CLI's port
+  const k = await kernel(() => ({ status: 200, body: { ok: true, id: SID, flag: "hideFromFeed", value: true } }));
+  try {
+    await asObsidian({ token: TOKEN, envPort: k.port }, async () => {
+      const r = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+      assert.equal(r.ok, true, "ROMP_KERNEL_PORT, as bin/romp resolves it");
+      assert.equal(k.seen.length, 1);
+      assert.equal(k.seen[0].headers["x-romp-token"], TOKEN);
+      delete process.env.ROMP_KERNEL_PORT; process.env.ROMP_SERVE_PORT = String(k.port);
+      const r2 = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+      assert.equal(r2.ok, true, "ROMP_SERVE_PORT too, as cli/keyswap.py resolves it");
+      assert.equal(k.seen.length, 2);
+    });
+  } finally { await k.close(); }
+  // a kernel there from before these routes: 404, named as such — not "not running"
+  const old = await kernel(() => ({ status: 404, raw: "not found" }));
+  try {
+    await asObsidian({ token: TOKEN, envPort: old.port }, async () => {
+      const r = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+      assert.deepEqual([r.ok, r.unreachable, r.status], [false, true, 404]);
+      assert.equal(r.error, "the kernel on 127.0.0.1:" + old.port + " predates this panel and has no /flag route; restart romp (`romp refresh`) and try again");
+    });
+  } finally { await old.close(); }
+  // an unusable override is refused as _kernel_urls refuses it — naming the variable actually read — never
+  // silently replaced by the default
+  await asObsidian({ token: TOKEN, envPort: k.port }, async () => {
+    process.env.ROMP_KERNEL_PORT = "29855x";
+    let r = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+    assert.deepEqual([r.ok, r.unreachable, r.error], [false, true, 'ROMP_KERNEL_PORT="29855x" is not a port']);
+    delete process.env.ROMP_KERNEL_PORT; process.env.ROMP_SERVE_PORT = " 7x ";
+    r = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+    assert.equal(r.error, 'ROMP_SERVE_PORT="7x" is not a port');
+    process.env.ROMP_KERNEL_PORT = ""; process.env.ROMP_SERVE_PORT = "70000";
+    r = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+    assert.equal(r.error, 'ROMP_SERVE_PORT="70000" is not a port', "an empty variable is unset, as the CLI reads it; the next one is the one read");
+  });
+  // nothing there: the down text that covers both readings
+  await asObsidian({ token: TOKEN }, async () => {
+    const r = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+    assert.deepEqual([r.ok, r.unreachable, r.error], [false, true, KERNEL_DOWN_NO_RECORD]);
+  });
+  // WITH a record and nothing there: plainly not running (the record is the kernel's own word on its port)
+  await asObsidian({ token: TOKEN, port: await closedPort() }, async () => {
+    const r = await panel()._kernelPost("/views", { views: { active: "all", tags: [] } });
+    assert.deepEqual([r.ok, r.unreachable, r.error], [false, true, KERNEL_DOWN]);
+  });
+  assert.match(SRC, /const KERNEL_DOWN = 'the kernel is not running; start romp and try again';/);
+  assert.match(SRC, /const KERNEL_DOWN_NO_RECORD = 'the kernel is not running, or the one running predates this panel and left no port record; start or restart romp and try again';/);
+});
+
+test("executed: a record or token file this panel cannot read is said as such — never 'not running' — and no token means no kernel ever ran here", async () => {
+  await asObsidian({ token: TOKEN, port: "dir" }, async (root) => {
+    const r = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+    assert.deepEqual([r.ok, r.unreachable], [false, true]);
+    assert.equal(r.error, "this panel could not read the kernel's port record " + path.join(root, "serve-port") + " (EISDIR)");
+  });
+  await asObsidian({ token: TOKEN, port: "not-a-port" }, async (root) => {
+    const r = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+    assert.equal(r.error, "this panel could not read the kernel's port record " + path.join(root, "serve-port") + " (not a port number)");
+  });
+  await asObsidian({ token: "dir", port: 1 }, async (root) => {
+    const r = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+    assert.equal(r.error, "this panel could not read the kernel's token file " + path.join(root, "serve-token") + " (EISDIR)");
+  });
+  // no token at all: the kernel mints it at its first boot, so none means no kernel has run against this state dir
+  const k = await kernel(() => ({ status: 200, body: { ok: true } }));
+  try {
+    await asObsidian({ port: k.port, envPort: k.port }, async () => {
+      const r = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+      assert.deepEqual([r.ok, r.unreachable, r.error], [false, true, KERNEL_DOWN]);
+      assert.equal(k.seen.length, 0, "nothing is posted without a token to present");
+    });
+  } finally { await k.close(); }
+  // plain node (the runner): no Electron, so no host to post from — and never a file
+  const r = await panel()._kernelPost("/order", { order: [SID] });
+  assert.deepEqual([r.ok, r.unreachable], [false, true]);
+  assert.doesNotMatch(SRC, /writeFileSync|renameSync/, "the panel writes none of the kernel's state files itself, kernel up or down");
+});
+
+test("executed: the three writers post first, and a refusal reverts the optimistic state and says why where the gesture was made", async () => {
+  await asObsidian({}, async () => {
+    const p = panel();
+    const posts: any[] = [];
+    const answers: any[] = [];
+    p._kernelPost = (route: string, body: any) => { posts.push([route, body]); return Promise.resolve(answers.shift()); };
+    const s = p.data.sessions[0];
+
+    // ── a lane flag, as the gear toggles it: optimistic + sticky, then the kernel ──
+    answers.push({ ok: true, body: { ok: true } });
+    gearClick(p, s, true); await tick();
+    assert.deepEqual(posts[0], ["/flag", { id: SID, flag: "hideFromFeed", value: true }]);
+    assert.deepEqual([s.hideFromFeed, p._pendingFlags[SID].hideFromFeed, p._laneRefusal], [true, true, null], "accepted: the copy holds sticky until the next poll confirms it");
+    const text = "couldn't save that setting — session-flags.json could not be read (read failed: [Errno 5] injected EIO); try again";
+    answers.push({ ok: false, refusal: true, error: text, body: { ok: false, error: text, value: false } });
+    gearClick(p, s, true); await tick();
+    assert.deepEqual(p._pendingFlags, {}, "the kernel's refusal ends the optimistic state…");
+    assert.equal(s.hideFromFeed, false, "…repaints the toggle to what the kernel still paints…");
+    assert.deepEqual(p._laneRefusal, { sid: SID, flag: "hideFromFeed", text }, "…and shows the kernel's words in the lane gear");
+    answers.push({ ok: false, unreachable: true, error: KERNEL_DOWN });
+    gearClick(p, s, true); await tick();
+    assert.equal(s.hideFromFeed, false, "no kernel: the toggle goes back where the click found it");
+    assert.equal(p._laneRefusal.text, "couldn't save that setting — " + KERNEL_DOWN);
+
+    // ── the views blob, as the tags dialog posts it (a tag edit: never kept locally) ──
+    p._views = { active: "all", actives: { timeline: { all: true } }, tags: [], seq: 3 };
+    const v = { active: "all", actives: { timeline: { all: true } }, tags: [{ id: "gA", name: "web", members: [SID] }] };
+    answers.push({ ok: true, body: { type: "viewsAck", ok: true, views: Object.assign({}, v, { seq: 4 }), seq: 4, refused: [] } });
+    p._setViews(v, ["gA"]);
+    assert.equal(p._pendingViews, v, "optimistic while the kernel judges");
+    assert.equal(posts[3][0], "/views");
+    assert.deepEqual([posts[3][1].views, posts[3][1].edited], [v, ["gA"]], "the blob and the tag ids this write changed, as the socket op posts them");
+    assert.match(posts[3][1].writeId, /^w/, "…and a writeId the ack echoes");
+    await tick();
+    assert.equal(p._pendingViews, null, "the ack settles the copy — an event, never a frame count");
+    assert.equal(p._views.seq, 4, "the kernel's post-write blob is the new base");
+    assert.equal(p._viewsWrites.length, 0);
+    const store = { active: "all", actives: { timeline: { all: true } }, tags: [{ id: "gA", name: "web", members: [SID, SID2] }], seq: 5 };
+    const err = '"web": it was edited after your copy was taken, so your copy predates the store\'s and was not applied';
+    answers.push({ ok: false, refusal: true, error: err, body: { type: "viewsAck", ok: false, views: store, seq: 5, refused: [{ tid: "gA", name: "web", reason: "predates" }], error: err } });
+    p._setViews(Object.assign({}, v, { tags: [{ id: "gA", name: "web", members: [] }] }), ["gA"]);
+    await tick();
+    assert.equal(p._pendingViews, null, "refused: the copy reverts at once");
+    assert.equal(p._views, store, "…to the blob the kernel serves");
+    assert.deepEqual([p._tagEditErr.error, p._tagEditErr.name], [err, "web"], "…with the kernel's words in the dialog");
+    p._tagEditErr = null;
+    answers.push({ ok: false, unreachable: true, error: KERNEL_DOWN });
+    p._setViews(v, ["gA"]);
+    await tick();
+    assert.equal(p._pendingViews, null, "a tag edit no kernel took reverts…");
+    assert.equal(p._tagEditErr.error, "nothing was changed — " + KERNEL_DOWN, "…and says so");
+    assert.equal(p._localLens, null, "a tag edit is never kept locally");
+    p._tagEditErr = null;
+
+    // ── the lens, as the Filter menu posts it: no kernel → kept LOCAL and said; a kernel's answer clears it ──
+    const lens = { actives: { timeline: { tags: ["web"] } } };
+    answers.push({ ok: false, unreachable: true, error: KERNEL_DOWN });
+    p._setLens(lens);
+    assert.deepEqual(p._pendingViews.actives.timeline, { tags: ["web"] }, "optimistic while it posts");
+    await tick();
+    assert.deepEqual(p._localLens, { fields: { actives: { timeline: { tags: ["web"] } } }, reason: KERNEL_DOWN }, "no kernel: the filter stays, marked unsaved, with the reason — only the surface the gesture changed");
+    assert.deepEqual([p._pendingViews, p._viewsWrites.length, p._tagEditErr], [null, 0, null], "nothing is in flight and nothing is called an error — the filter is the viewer's own");
+    assert.deepEqual(timelineLens(p._curViews()).tags, ["web"], "…and it applies to what the panel shows");
+    assert.equal(p._views.actives.timeline.all, true, "…while the store's blob is untouched");
+    answers.push({ ok: false, refusal: true, error: '"web": refused', body: { type: "viewsAck", ok: false, views: store, seq: 5, refused: [{ tid: "gA", name: "web", reason: "refused" }], error: '"web": refused' } });
+    p._setLens({ actives: { timeline: { all: true } } });
+    await tick();
+    assert.equal(p._localLens, null, "a kernel that RULED on a lens write (even refusing it) clears the local filter: its blob is what stands");
+    assert.equal(p._tagEditErr.error, '"web": refused');
+    p._tagEditErr = null;
+    answers.push({ ok: false, unreachable: true, error: KERNEL_DOWN });
+    p._setLens(lens); await tick();
+    assert.ok(p._localLens, "unsaved again");
+    const saved = Object.assign({}, store, { actives: { timeline: { tags: ["web"] } }, seq: 6 });
+    answers.push({ ok: true, body: { type: "viewsAck", ok: true, views: saved, seq: 6, refused: [] } });
+    p._setLens(lens); await tick();
+    assert.deepEqual([p._localLens, p._pendingViews, p._views.seq], [null, null, 6], "a later write the kernel takes clears the note; the kernel's blob carries the filter now");
+
+    // ── the lane order, as a drag persists it: prev + the moved lane ride along for the revert ──
+    p.data.sessions = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    p._applyOrderToData(["c", "b", "a"]);
+    answers.push({ ok: true, body: { ok: true, order: ["c", "b", "a"] } });
+    p._persistOrder(["c", "b", "a"], ["a", "b", "c"], "c");
+    await tick();
+    assert.deepEqual(posts[posts.length - 1], ["/order", { order: ["c", "b", "a"] }]);
+    assert.deepEqual(p.data.sessions.map((x: any) => x.id), ["c", "b", "a"], "accepted: the lanes stay");
+    answers.push({ ok: false, unreachable: true, error: KERNEL_DOWN });
+    p._persistOrder(["c", "b", "a"], ["a", "b", "c"], "c");
+    await tick();
+    assert.deepEqual(p.data.sessions.map((x: any) => x.id), ["a", "b", "c"], "refused: the lanes go back at once");
+    assert.deepEqual(p._laneRefusal, { sid: "c", flag: "", text: "couldn't save the new order — " + KERNEL_DOWN },
+      "…and the dragged lane's gear says why (no shell bell here)");
+    assert.equal(p._tagEditErr, null, "a lane drag's refusal is not the dialog's to show");
+    // a row dragged INSIDE the tags dialog: the dialog's own row carries the reason, and only the dialog's
+    p._laneRefusal = null;
+    answers.push({ ok: false, unreachable: true, error: KERNEL_DOWN });
+    p._persistOrder(["c", "b", "a"], ["a", "b", "c"], "c", "dialog");
+    await tick();
+    assert.deepEqual(p._tagEditErr, { host: "", name: "", error: "couldn't save the new order — " + KERNEL_DOWN, kind: "order" });
+    assert.equal(p._laneRefusal, null, "not the lane gear's slot too (it rendered both: the same sentence twice)");
+    p._viewsDialog = { remove() {} };
+    p._closeViewsDialog();
+    assert.equal(p._tagEditErr, null, "the dialog's close clears what the dialog showed");
+  });
+  // the two drag sites hand the writer the pre-drag order and the moved lane; the dialog's names itself
+  assert.match(SRC, /const prev = \(\(this\.data && this\.data\.sessions\) \|\| \[\]\)\.map\(\(s\) => s\.id\);[\s\S]{0,400}this\._persistOrder\(full, prev, d\.sid\);/, "the lane drag");
+  assert.match(SRC, /const prev = \(\(this\.data && this\.data\.sessions\) \|\| \[\]\)\.map\(\(s\) => s\.id\);[\s\S]{0,400}this\._persistOrder\(full, prev, vis\[toIdx\], 'dialog'\);/, "the dialog's row drag");
+});
+
+// ── the Filter menu and the tags dialog, executed over a fake DOM (the timeline-views-ack shape) ──────
+function makeNode(tag: string): any {
+  const n: any = {
+    tag, _attrs: {}, children: [] as any[], style: {}, dataset: {}, _text: "", parentNode: null, value: "", _listeners: {} as any,
+    get textContent() { return n._text + n.children.map((c: any) => c.textContent).join(""); },
+    set textContent(v: any) { n._text = v == null ? "" : String(v); for (const c of n.children) c.parentNode = null; n.children.length = 0; },
+    classList: { _s: new Set<string>(), add(...a: string[]) { a.forEach((c) => this._s.add(c)); }, remove(...a: string[]) { a.forEach((c) => this._s.delete(c)); },
+      toggle(c: string, f?: boolean) { f ? this._s.add(c) : this._s.delete(c); }, contains(c: string) { return this._s.has(c); } },
+    setAttribute(k: string, v: any) { n._attrs[k] = v; }, getAttribute(k: string) { return n._attrs[k]; },
+    setAttributeNS(_ns: any, k: string, v: any) { n._attrs[k] = v; }, removeAttribute(k: string) { delete n._attrs[k]; },
+    appendChild(c: any) { if (c.parentNode) c.parentNode.removeChild(c); c.parentNode = n; n.children.push(c); return c; },
+    insertBefore(c: any, ref: any) { c.parentNode = n; const i = n.children.indexOf(ref); i < 0 ? n.children.push(c) : n.children.splice(i, 0, c); return c; },
+    removeChild(c: any) { const i = n.children.indexOf(c); if (i >= 0) n.children.splice(i, 1); c.parentNode = null; return c; },
+    get firstChild() { return n.children[0] || null; },
+    remove() { if (n.parentNode) n.parentNode.removeChild(n); },
+    addEventListener(t: string, fn: any) { n._listeners[t] = fn; }, removeEventListener(t: string) { delete n._listeners[t]; },
+    setPointerCapture() {}, releasePointerCapture() {},
+    querySelector() { return null; }, querySelectorAll() { return []; }, closest() { return null; },
+    getBoundingClientRect() { return { width: 40, height: 20, left: 10, top: 700, right: 50, bottom: 720 }; },
+    focus() { const g: any = globalThis; if (g.document) g.document.activeElement = n; }, select() {}, setSelectionRange() {},
+    selectionStart: 0, selectionEnd: 0,
+    createEl(t: string, o: any) { const e = makeNode(t); if (o && o.cls) e.classList.add(o.cls); if (o && o.text) e.textContent = o.text; n.appendChild(e); return e; },
+    createDiv(o: any) { return n.createEl("div", o); }, createSpan(o: any) { return n.createEl("span", o); },
+  };
+  return n;
+}
+async function withDom(fn: () => Promise<void>) {
+  const g: any = globalThis;
+  const saved = { setTimeout: g.setTimeout };
+  g.document = {
+    body: makeNode("body"), documentElement: makeNode("html"), head: makeNode("head"), activeElement: null,
+    createElement(t: string) { return t === "canvas" ? { getContext() { return { font: "", measureText(s: string) { return { width: (s ? s.length : 0) * 6 }; } }; } } : makeNode(t); },
+    createElementNS(_ns: any, t: string) { return makeNode(t); },
+    createTextNode(text: string) { const t = makeNode("#text"); t._text = text; return t; },
+    getElementById() { return null; }, addEventListener() {}, removeEventListener() {},
+  };
+  g.window = g; g.innerWidth = 1400; g.innerHeight = 800;
+  g.localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} };
+  g.getComputedStyle = () => ({ backgroundColor: "rgb(30,30,30)", fontFamily: "sans-serif" });
+  g.requestAnimationFrame = () => 0;
+  g.matchMedia = () => ({ matches: false, addEventListener() {}, addListener() {} });
+  g.addEventListener = () => {}; g.removeEventListener = () => {};
+  // a real timer, its callback guarded: a dialog's deferred focus may fire after this DOM is gone
+  g.setTimeout = (fn: any, ms?: number) => saved.setTimeout(() => { try { fn(); } catch { /* a fake node after teardown */ } }, ms);
+  try { await fn(); } finally {
+    g.setTimeout = saved.setTimeout;
+    for (const k of ["document", "window", "innerWidth", "innerHeight", "localStorage", "getComputedStyle", "requestAnimationFrame", "matchMedia", "addEventListener", "removeEventListener"]) delete g[k];
+  }
+}
+const walk = (n: any): any[] => [n, ...(n && n.children ? n.children.flatMap(walk) : [])];
+const sess = (id: string, name: string, color: string) => ({
+  id, name, color, state: "working", live: true, model: "Opus", effort: "high",
+  context: 40, since: 1_781_000_000 - 60, awaiting: [], compacting: [], pendingMail: 0, compactions: [], faded: false, stale: false,
+});
+const rows = (menu: any) => menu.children.map((c: any) => c.textContent as string);
+const rowNamed = (menu: any, label: string) => menu.children.find((c: any) => c.textContent === label || c.textContent === label + "✓");
+
+test("executed: the Filter menu shows a refused lens write's reason, keeps an unsaved filter and says so, and clears the note once a kernel takes one (review find, 2026-09-08)", async () => {
+  await withDom(() => asObsidian({}, async () => {
+    const p = panel();
+    const posts: any[] = [];
+    const answers: any[] = [];
+    p._kernelPost = (route: string, body: any) => { posts.push([route, body]); return Promise.resolve(answers.shift()); };
+    const S = { active: "all", actives: { timeline: { all: true } }, seq: 3, tags: [{ id: "gA", name: "web", color: "#3b82f6", members: [SID] }] };
+    p._views = S;
+    const anchor = makeNode("button");
+    p._openViewsMenu(anchor);
+    const menu = p._viewsMenu;
+    assert.ok(menu && typeof menu._build === "function", "the menu takes a rebuild handle, like the lane gear");
+    assert.ok(rowNamed(menu, "web"), "the tag row is there: " + JSON.stringify(rows(menu)));
+    assert.ok(!rows(menu).some((t: string) => t.startsWith("⚠")), "nothing to say yet");
+
+    // a kernel REFUSES the lens write: the copy reverts and the reason shows in THIS menu, repainted in place
+    const err = '"web": it was edited after your copy was taken, so your copy predates the store\'s and was not applied';
+    answers.push({ ok: false, refusal: true, error: err, body: { type: "viewsAck", ok: false, views: S, seq: 3, refused: [{ tid: "gA", name: "web", reason: "predates" }], error: err } });
+    rowNamed(menu, "web")._listeners.click();
+    assert.equal(posts[0][0], "/views");
+    assert.deepEqual(posts[0][1].views.actives.timeline, { tags: ["web"] }, "the lens write, from the menu's toggle");
+    await tick();
+    assert.equal(p._viewsMenu, menu, "the menu stayed open (a settings panel, not a command)");
+    assert.ok(rows(menu).some((t: string) => t === "⚠ " + err + "✕"), "the refusal's reason, with ✕, in the menu: " + JSON.stringify(rows(menu)));
+    assert.deepEqual([p._pendingViews, p._localLens], [null, null], "refused: nothing kept");
+    assert.ok(rowNamed(menu, "web") && !rowNamed(menu, "web").textContent.endsWith("✓"), "the row reads unselected again");
+    p._tagEditErr = null; menu._build();
+
+    // NO kernel takes it: the filter stays applied, and the menu says it is not saved and why
+    answers.push({ ok: false, unreachable: true, error: KERNEL_DOWN });
+    rowNamed(menu, "web")._listeners.click();
+    await tick();
+    assert.ok(rowNamed(menu, "web").textContent.endsWith("✓"), "the filter is on: " + JSON.stringify(rows(menu)));
+    assert.deepEqual(timelineLens(p._curViews()).tags, ["web"], "…and applies to the lanes");
+    assert.ok(rows(menu).includes("⚠ this filter is not saved — " + KERNEL_DOWN), "the not-saved note, with the reason: " + JSON.stringify(rows(menu)));
+    assert.equal(p._tagEditErr, null, "not an error: the viewer's own filter, just unsaved");
+    assert.deepEqual(p._pendingViews, null);
+
+    // a later lens write a kernel takes: the note clears, the kernel's blob carries the filter
+    const saved = Object.assign({}, S, { actives: { timeline: { all: true } }, seq: 4 });
+    answers.push({ ok: true, body: { type: "viewsAck", ok: true, views: saved, seq: 4, refused: [] } });
+    rowNamed(menu, "All")._listeners.click();          // All closes the menu
+    assert.equal(p._viewsMenu, null);
+    await tick();
+    assert.deepEqual([p._localLens, p._pendingViews, p._views.seq], [null, null, 4]);
+    p._openViewsMenu(anchor);
+    assert.ok(!rows(p._viewsMenu).some((t: string) => t.startsWith("⚠")), "nothing left to say: " + JSON.stringify(rows(p._viewsMenu)));
+    assert.ok(rowNamed(p._viewsMenu, "All").textContent.endsWith("✓"));
+    p._closeViewsMenu();
+  }));
+  assert.match(SRC, /menu\._build = build;   \/\/ viewsAck \/ setCaps \/ _kernelViewsAnswer repaint the open menu/);
+  assert.match(SRC, /if \(this\._viewsMenu && typeof this\._viewsMenu\._build === 'function'\) this\._viewsMenu\._build\(\);/, "_repaintTagSurfaces reaches the Filter menu");
+});
+
+test("executed: the local lens is only the viewer's own surfaces and fields, overlaid on the store, never persisted by another gesture (review finds, 2026-09-08)", async () => {
+  await withDom(() => asObsidian({}, async () => {
+    const p = panel();
+    const posts: any[] = [];
+    const answers: any[] = [];
+    p._kernelPost = (route: string, body: any) => { posts.push([route, body]); return Promise.resolve(answers.shift()); };
+    const web = { id: "gA", name: "web", color: "#3b82f6", members: [SID] }, api = { id: "gB", name: "api", color: "#DD42FF", members: [SID2] };
+    const S = { active: "all", actives: { chat: { tags: ["api"] }, timeline: { all: true }, outline: { all: true } }, seq: 3, tags: [web, api] };
+    p._views = S;
+    p.data.sessions.push({ id: SID2, name: "api" });
+    const anchor = makeNode("button");
+    p._openViewsMenu(anchor);
+    const menu = p._viewsMenu;
+
+    // F0: kernel down, a timeline filter from the Filter menu — the whole map was posted (the store's chat
+    // and outline plus the gesture's timeline), but only TIMELINE is held
+    answers.push({ ok: false, unreachable: true, error: KERNEL_DOWN });
+    rowNamed(menu, "web")._listeners.click();
+    assert.deepEqual(posts[0][1].views.actives, { chat: { tags: ["api"] }, timeline: { tags: ["web"] }, outline: { all: true } }, "posted over the store's map");
+    await tick();
+    assert.deepEqual(p._localLens.fields, { actives: { timeline: { tags: ["web"] } } }, "held: the gesture's own surface, nothing else");
+    // the store moves under the panel (a dashboard changes the chat lens): the panel shows the STORE's chat…
+    const S2 = Object.assign({}, S, { actives: { chat: { tags: ["web"] }, timeline: { all: true }, outline: { none: true } }, seq: 4 });
+    p._takeViews(S2);
+    assert.deepEqual(p._curViews().actives, { chat: { tags: ["web"] }, timeline: { tags: ["web"] }, outline: { none: true } },
+      "overlaid PER KEY: the store's new chat and outline, the viewer's own timeline (the dialog's pane-filter rows read this map)");
+    // …and the next Filter-menu click posts the store's new chat with the gesture's timeline, never the snapshot's
+    answers.push({ ok: false, unreachable: true, error: KERNEL_DOWN });
+    rowNamed(menu, "api")._listeners.click();
+    assert.deepEqual(posts[1][1].views.actives, { chat: { tags: ["web"] }, timeline: { tags: ["web", "api"] }, outline: { none: true } },
+      "the store's chat as it is NOW, the gesture's timeline — the local snapshot's chat never flips the dashboard's filter back");
+    await tick();
+    assert.deepEqual(p._localLens.fields, { actives: { timeline: { tags: ["web", "api"] } } });
+
+    // F2: a second unreachable gesture of another kind MERGES (a pill drag's tagOrder beside the filter)
+    answers.push({ ok: false, unreachable: true, error: KERNEL_DOWN });
+    p._setLens({ tagOrder: ["api", "web"] });
+    await tick();
+    assert.deepEqual(p._localLens.fields, { actives: { timeline: { tags: ["web", "api"] } }, tagOrder: ["api", "web"] }, "both held");
+    assert.deepEqual(viewTagUnion(p._curViews()).map((g: any) => g.name), ["api", "web"], "the pills show the dragged order");
+    assert.ok(rows(menu).includes("⚠ this filter is not saved — " + KERNEL_DOWN), "one note: " + JSON.stringify(rows(menu)));
+
+    // F1: the kernel is back and a TAG edit lands (the Obsidian whole-blob path): its blob carries the
+    // STORE's timeline lens and tagOrder, not the local ones; the filter stays applied, the note stays
+    const g = viewTagUnion(p._curViews()).find((x: any) => x.name === "web");
+    const stored = Object.assign({}, S2, { tags: [web, Object.assign({}, api)], seq: 5 });
+    stored.tags[0] = Object.assign({}, web, { members: [SID, SID2] });
+    answers.push({ ok: true, body: { type: "viewsAck", ok: true, views: stored, seq: 5, refused: [] } });
+    p._editTagUnion(g, { add: [SID2] });
+    const tagPost = posts[posts.length - 1][1];
+    assert.deepEqual(tagPost.edited, ["gA"], "a tag edit, on the legacy whole-blob path");
+    assert.deepEqual(tagPost.views.actives.timeline, { all: true }, "the STORE's timeline lens rides the tag edit, never the unsaved one");
+    assert.equal(tagPost.views.tagOrder, undefined, "…and the store's (absent) tagOrder, never the unsaved drag");
+    assert.deepEqual(tagPost.views.tags[0].members, [SID, SID2], "the edit itself is there");
+    await tick();
+    assert.equal(p._views, stored, "the kernel's blob is the base");
+    assert.deepEqual(p._localLens.fields, { actives: { timeline: { tags: ["web", "api"] } }, tagOrder: ["api", "web"] }, "the local lens is untouched by a write that did not carry it");
+    assert.deepEqual(timelineLens(p._curViews()).tags, ["web", "api"], "…and still applies");
+    assert.ok(rows(menu).includes("⚠ this filter is not saved — " + KERNEL_DOWN), "…and the note still shows");
+
+    // F2: a ruled write of ONE kind releases only that kind — the kernel takes the pill order, the filter stays local
+    const ordered = Object.assign({}, stored, { tagOrder: ["api", "web"], seq: 6 });
+    answers.push({ ok: true, body: { type: "viewsAck", ok: true, views: ordered, seq: 6, refused: [] } });
+    p._setLens({ tagOrder: ["api", "web"] });
+    await tick();
+    assert.deepEqual(p._localLens.fields, { actives: { timeline: { tags: ["web", "api"] } } }, "tagOrder released, the filter still held");
+    assert.ok(rows(menu).includes("⚠ this filter is not saved — " + KERNEL_DOWN));
+    // …and a ruled write of the filter's own surface releases it: the note goes, the store carries the lens
+    const saved = Object.assign({}, ordered, { actives: Object.assign({}, ordered.actives, { timeline: { tags: ["web", "api", "x"] } }), seq: 7 });
+    answers.push({ ok: true, body: { type: "viewsAck", ok: true, views: saved, seq: 7, refused: [] } });
+    rowNamed(menu, "(no tags)")._listeners.click();
+    assert.deepEqual(posts[posts.length - 1][1].views.actives.chat, { tags: ["web"] }, "over the store's map");
+    await tick();
+    assert.deepEqual([p._localLens, p._pendingViews], [null, null], "nothing local is left");
+    assert.ok(!rows(menu).some((t: string) => t.startsWith("⚠")), "nothing to say: " + JSON.stringify(rows(menu)));
+
+    // a filter toggled back to what the store has, with no kernel, is the store's — not held as unsaved
+    p._views = S; p._localLens = null; menu._build();
+    answers.push({ ok: false, unreachable: true, error: KERNEL_DOWN });
+    rowNamed(menu, "web")._listeners.click(); await tick();
+    assert.ok(p._localLens, "on");
+    answers.push({ ok: false, unreachable: true, error: KERNEL_DOWN });
+    rowNamed(menu, "web")._listeners.click(); await tick();
+    assert.equal(p._localLens, null, "off again: equal to the store, so nothing is unsaved and no note shows");
+    assert.ok(!rows(menu).some((t: string) => t.startsWith("⚠")));
+
+    // F3: a dialog drag's refusal (kind 'order') is not the Filter menu's to show
+    p._tagEditErr = { host: "", name: "", error: "couldn't save the new order — " + KERNEL_DOWN, kind: "order" }; menu._build();
+    assert.ok(!rows(menu).some((t: string) => t.startsWith("⚠")), "an order refusal is the dialog's: " + JSON.stringify(rows(menu)));
+    p._tagEditErr = { host: "", name: "web", error: '"web": refused' }; menu._build();
+    assert.ok(rows(menu).some((t: string) => t.startsWith('⚠ "web": refused')), "a tag or lens refusal shows");
+    p._closeViewsMenu();
+  }));
+});
+
+test("executed: a lens write in flight never lends the local lens to another write — a tag edit and a chat pane-filter row post the STORE's timeline while a pill drag is pending (review finds, 2026-09-08)", async () => {
+  await withDom(() => asObsidian({}, async () => {
+    // a REAL panel (constructed, fed a frame), so the tags dialog builds as it does in Obsidian
+    const panel: any = new TimelinePanel(makeNode("div"));
+    const now = 1_781_000_000;
+    const web = { id: "gA", name: "web", color: "#3b82f6", members: [SID], mtime: 100 }, api = { id: "gB", name: "api", color: "#DD42FF", members: [SID2], mtime: 100 };
+    const S = { active: "all", actives: { chat: { all: true }, timeline: { all: true }, outline: { all: true } }, at: 100, seq: 1000, tags: [web, api] };
+    panel.update({ now, sessions: [sess(SID, "web", "#f7768e"), sess(SID2, "api", "#7aa2f7")], turns: {}, messages: [], judging: [], views: JSON.parse(JSON.stringify(S)), palette: ["#1EA1EB", "#54B204"] });
+    assert.deepEqual(panel._views.actives.timeline, { all: true });
+    const posts: any[] = [];
+    const answers: any[] = [];
+    // an answer may be a function of the posted body (a kernel echoing the write, stamped) or a promise the test settles
+    panel._kernelPost = (route: string, body: any) => { posts.push([route, body]); const a = answers.shift(); return Promise.resolve(typeof a === "function" ? a(body) : a); };
+    const echo = (seq: number) => (body: any) => ({ ok: true, body: { type: "viewsAck", ok: true, views: Object.assign({}, body.views, { seq }), seq, refused: [] } });
+
+    // kernel down: the viewer filters the timeline; the filter is held
+    answers.push({ ok: false, unreachable: true, error: KERNEL_DOWN });
+    panel._setLens({ actives: Object.assign(panel._lensBaseActives(), { timeline: { tags: ["web"] } }) }, { surfaces: ["timeline"] });
+    await tick();
+    assert.deepEqual(panel._localLens.fields, { actives: { timeline: { tags: ["web"] } } });
+
+    // the kernel is back; a pill drag goes out and stays IN FLIGHT
+    let settleDrag: (a: any) => void = () => {};
+    answers.push(new Promise((r) => { settleDrag = r; }));
+    panel._setLens({ tagOrder: ["api", "web"] }, { tagOrder: true });
+    assert.deepEqual(posts[1][1].views.tagOrder, ["api", "web"]);
+    assert.deepEqual(panel._pendingViews.actives.timeline, { all: true }, "the pending copy is the WRITE base plus the drag — the store's timeline, never the held one");
+    assert.deepEqual(panel._writeBase().actives.timeline, { all: true }, "…and that is what every write built during the flight starts from");
+    assert.deepEqual(timelineLens(panel._curViews()).tags, ["web"], "while the held filter still shows");
+    assert.deepEqual(viewTagUnion(panel._curViews()).map((g: any) => g.name), ["api", "web"], "…with the drag's order (the pending copy)");
+
+    // during the flight, a TAG EDIT (the Obsidian whole-blob path) posts the store's timeline lens
+    answers.push(echo(1002));
+    const g = viewTagUnion(panel._curViews()).find((x: any) => x.name === "web");
+    panel._editTagUnion(g, { add: [SID2] });
+    const tagPost = posts[2][1];
+    assert.deepEqual(tagPost.edited, ["gA"]);
+    assert.deepEqual(tagPost.views.actives.timeline, { all: true }, "the tag edit carries the STORE's timeline, not the unsaved filter");
+    assert.deepEqual(tagPost.views.tags.find((t: any) => t.id === "gA").members, [SID, SID2], "…and the edit itself");
+    await tick();
+    assert.deepEqual(panel._localLens.fields, { actives: { timeline: { tags: ["web"] } } }, "the held filter is untouched");
+
+    // …and a CHAT pane-filter row in the tags dialog posts chat's new value with the store's timeline (F2, trace c)
+    answers.push(echo(1003));
+    panel._openViewsDialog(null);
+    const chatLabel = walk(panel._viewsDialog).find((n) => n.tag === "span" && n.textContent === "Chat");
+    assert.ok(chatLabel, "the Chat pane-filter row");
+    const chatWeb = chatLabel.parentNode.children.find((n: any) => n.textContent === "web");
+    assert.ok(chatWeb && chatWeb._listeners.click, "its web pill");
+    chatWeb._listeners.click();
+    const chatPost = posts[3][1];
+    assert.deepEqual(chatPost.views.actives, { chat: { tags: ["web"] }, timeline: { all: true }, outline: { all: true } },
+      "chat's new value, the STORE's timeline and outline — never the held timeline");
+    await tick();
+    assert.deepEqual(panel._views.actives.chat, { tags: ["web"] }, "the kernel took chat");
+    assert.deepEqual(panel._localLens.fields, { actives: { timeline: { tags: ["web"] } } }, "the kernel's ok released only chat; the timeline filter survives");
+    assert.deepEqual(timelineLens(panel._curViews()).tags, ["web"], "…and still shows");
+    panel._closeViewsDialog();
+    panel._openViewsMenu(makeNode("button"));
+    assert.ok(rows(panel._viewsMenu).includes("⚠ this filter is not saved — " + KERNEL_DOWN), "…with its note: " + JSON.stringify(rows(panel._viewsMenu)));
+    panel._closeViewsMenu();
+
+    // the drag lands at last: only tagOrder was its own, so the filter and its note stay
+    settleDrag(echo(1004)(posts[1][1]));
+    await tick(); await tick();
+    assert.deepEqual(panel._views.tagOrder, ["api", "web"]);
+    assert.deepEqual(panel._localLens.fields, { actives: { timeline: { tags: ["web"] } } });
+    assert.equal(panel._pendingViews, null);
+  }));
+});
+
+test("every Node require the panel makes sits inside a try, so the browser bundle still builds (PR #1078's first CI run)", () => {
+  // esbuild bundles this file for the BROWSER too (ui/webview/timeline-main.ts inlines it; platform browser)
+  // and resolves every literal require at bundle time: an unresolvable one fails the build UNLESS a
+  // try/catch wraps it, which esbuild reads as run-time handled and leaves as-is. The Electron guard keeps
+  // the page from evaluating any of them. This pin fails on a bare require before `npm run build` would.
+  const fnOf = (at: number) => { const s = SRC.lastIndexOf("\n  _", at); return SRC.slice(s, SRC.indexOf("\n  }\n", at) + 4); };
+  let seen = 0;
+  for (const m of SRC.matchAll(/require\('(fs|os|path|http|child_process)'\)/g)) {
+    seen++;
+    const fn = fnOf(m.index!);
+    const inFn = m.index! - SRC.lastIndexOf("\n  _", m.index!);
+    assert.ok(fn.lastIndexOf("try {", inFn) >= 0 || fn.lastIndexOf("try { ", inFn) >= 0, "require('" + m[1] + "') at " + m.index + " sits inside a try: " + fn.slice(0, 60));
+  }
+  assert.ok(seen >= 6, "the requires were found: " + seen);
+  const host = SRC.slice(SRC.indexOf("  _kernelHost() {"), SRC.indexOf("  _kernelPost(route, body) {"));
+  assert.match(host, /return null;\s*\n(?:\s*\/\/[^\n]*\n)*\s*try \{\s*\n\s*const fs = require\('fs'\), os = require\('os'\), path = require\('path'\);/,
+    "_kernelHost: the Electron guard, then the requires inside a try");
+});
+
+test("plain node never posts: the writers do nothing without a host hook or Electron (the 2026-07-02 runner rule)", async () => {
+  const p = panel();
+  const posts: any[] = [];
+  p._kernelPost = (route: string, body: any) => { posts.push([route, body]); return Promise.resolve({ ok: true, body: { ok: true } }); };
+  assert.equal((process.versions as any).electron, undefined, "this runner is plain node");
+  p._setSessionFlag(p.data.sessions[0], "hideFromFeed", true);
+  p._setViews({ active: "all", tags: [] }, []);
+  p._persistOrder([SID], [SID], SID);
+  await tick();
+  assert.deepEqual(posts, [], "nothing to post from, nothing posted — and nothing written (no fs writer exists)");
+  assert.equal(p._viewsWrites.length, 0, "no write record was minted for a write that never left");
+  assert.match(SRC, /_kernelHost\(\) \{[\s\S]{0,500}if \(typeof process === 'undefined' \|\| !process\.versions \|\| !process\.versions\.electron\) return null;/,
+    "the one Electron-or-nothing guard every writer takes");
+});

--- a/ui/timeline-render.test.ts
+++ b/ui/timeline-render.test.ts
@@ -653,10 +653,16 @@ test("vertical click-drag reorders the lane (not pan), leaving the lock alone", 
   }
 });
 
-test("_persistOrder without a host hook refuses the direct file write outside Electron", () => {
+test("_persistOrder without a host hook posts through the kernel — inside Electron only, and never a file of its own", () => {
+  // The direct session-order.json write is gone (2026-09-08): Obsidian posts the kernel's /order, whose
+  // merge keeps the slots of lanes the drag did not carry. The Electron-or-nothing rule stands where it
+  // always did — plain node (the test runner) must never reach the real state, and now cannot: there is
+  // no fs writer to reach (ui/timeline-kernel-post.test.ts runs the writer both ways).
   const src = require("node:fs").readFileSync(viewPath, "utf8");
-  assert.match(src, /if \(typeof process === 'undefined' \|\| !process\.versions \|\| !process\.versions\.electron\) return;/,
-    "the direct session-order.json write is Electron-only (Obsidian desktop) — plain node (the test runner) must never touch the real state file");
+  assert.match(src, /if \(typeof process === 'undefined' \|\| !process\.versions \|\| !process\.versions\.electron\) return null;/,
+    "the one Electron guard (_kernelHost), which every writer takes");
+  assert.match(src, /_persistOrder\(order, prev, sid, from\) \{[\s\S]{0,600}if \(!this\._kernelHost\(\)\) return;\s*\n\s*return this\._kernelPost\('\/order', \{ order \}\)/);
+  assert.doesNotMatch(src, /writeFileSync|renameSync/, "no direct write of any state file remains");
 });
 
 // ── judging band (2026-06-17): a compact second timeline under the lanes, one row per summarizer

--- a/ui/timeline-views-ack.test.ts
+++ b/ui/timeline-views-ack.test.ts
@@ -1016,7 +1016,8 @@ test("pins: no frame count settles a stamped kernel's write; the legacy exact ec
   assert.equal((rec.match(/>= 3/g) || []).length, 1, "one legacy yield, nowhere else");
   assert.match(SRC, /_postTagEdit\(nv, edit, meta\) \{\s*\n\s*if \(!this\._tagEditsTargeted\(\)\) \{\s*\n\s*if \(!nv\) return;[\s\S]{0,1200}?const edited = \[edit\.tid, edit\.tid_from, edit\.tid_to\]\.filter\(Boolean\);[\s\S]{0,400}?this\._setViews\(nv, edited\);\s*\n\s*return;\s*\n\s*\}/,
     "a targeted op needs the capability AND a bridge; otherwise the whole-blob write, naming the tags it changed (a create's row included)");
-  assert.match(SRC, /window\.__rompTimelineSetViews\(v, writeId, Array\.isArray\(edited\) \? edited : \[\]\);/, "the whole-blob hook carries the writeId and the edited tag ids");
+  assert.match(SRC, /const ed = Array\.isArray\(edited\) \? edited : \[\];\s*\n\s*if \(hook\) window\.__rompTimelineSetViews\(v, writeId, ed\);/,
+    "the whole-blob hook carries the writeId and the edited tag ids (the same list rides the Obsidian panel's POST /views, 2026-09-08)");
   assert.match(SRC, /window\.__rompTimelineTagEdit\(writeId, edit\);/, "the targeted hook carries the writeId beside the NESTED op");
   assert.doesNotMatch(SRC, /op: '(?:rename|recolor|addMember|removeMember|delete)', name:/, "no op but create carries a name — every one addresses by tid");
 });
@@ -1055,10 +1056,13 @@ test("executed: a lens or order write is built from the STORE's blob — a renam
   assert.deepEqual(o.v.tagOrder, ["api", "web"]);
   assert.deepEqual(panel._curViews().tagOrder, ["api", "web"]);
   // every lens and order site goes through _setLens: the pane-filter row, the pill drag, the corner chip, the menu
-  assert.match(SRC, /this\._setLens\(\{ actives: Object\.assign\(\{\}, this\._curViews\(\)\.actives, upd\) \}\);/, "the dialog's pane filters");
-  assert.match(SRC, /this\._setLens\(\{ tagOrder: names \}\);/, "the pill drag");
+  // …each naming what it is ABOUT (`own`), the keys a write no kernel takes keeps local and a ruled one
+  // releases (the Obsidian panel's local lens, 2026-09-08); the map is built over the WRITE base's, never the shown one
+  assert.match(SRC, /this\._setLens\(\{ actives: Object\.assign\(this\._lensBaseActives\(\), upd\) \}, \{ surfaces: Object\.keys\(upd\) \}\);/, "the dialog's pane filters");
+  assert.match(SRC, /this\._setLens\(\{ tagOrder: names \}, \{ tagOrder: true \}\);/, "the pill drag");
   assert.equal((SRC.match(/this\._setViews\(nv\);/g) || []).length, 0, "no whole-blob write from a copy remains outside the legacy tag path");
-  assert.match(SRC, /_setLens\(fields\) \{\s*\n\s*this\._setViews\(lensBlob\(this\._views, fields\), \[\], fields\);/, "built from this._views, the store's blob");
+  assert.match(SRC, /_setLens\(fields, own\) \{\s*\n\s*own = own \|\| \{ surfaces: Object\.keys\(fields\.actives \|\| \{\}\), tagOrder: 'tagOrder' in fields, active: 'active' in fields \};\s*\n\s*this\._setViews\(lensBlob\(this\._views, fields\), \[\], fields, own\);/,
+    "built from this._views, the store's blob; `own` defaults to every key the fields carry");
 });
 
 test("executed: a tag whose create is in flight takes no gesture — the dialog row reads creating… with no actions, its chip has no ✕, the join menu does not offer it; the ack restores them", () => {

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -153,7 +153,7 @@ test("the trigger sits in the corner strip and opens on pointerdown, like every 
 test("an active tag is a REMOVABLE CHIP: outline only in its colour, a dim separate ✕, air below (the user 2026-08-24)", () => {
   // the chip's own pointerdown clears the filter without a menu trip; stopPropagation keeps the
   // text element's menu handler out of it (both are pointerdown — the redraw-eats-click rule)
-  assert.match(SRC, /this\._setLens\(\{ actives: Object\.assign\(\{\}, v\.actives, \{ timeline: lensToggle\(lens, c\.pick\) \}\) \}\);/,
+  assert.match(SRC, /this\._setLens\(\{ actives: Object\.assign\(this\._lensBaseActives\(\), \{ timeline: lensToggle\(lens, c\.pick\) \}\) \}, \{ surfaces: \['timeline'\] \}\);/,
     "each chip's ✕ unselects THAT pick (per-selection chips, the user 2026-08-25)");
   // OUTLINE only on the page's own ground (the tinted fill was too much — the user 2026-08-24),
   // and the ✕ is dim and SEPARATE, the composer context chip's read — never baked into the name
@@ -285,8 +285,8 @@ test("membership rows drag-reorder into the SHARED session order (the user 2026-
   assert.match(SRC, /nameCell\._sid = s\.id;/);
   assert.match(SRC, /cells\[toIdx\]\.style\[toIdx > fromIdx \? 'borderBottom' : 'borderTop'\] = '2px solid #9cd2ff';/,
     "the accent insertion cue rides the target cell's border — no mid-drag rebuild");
-  assert.match(SRC, /const full = this\._mergeVisibleOrder\(vis\);\s*\/\/ only the shown rows permute within the full order\n\s*this\._applyOrderToData\(full\);[\s\S]{0,200}this\._persistOrder\(full\);/,
-    "drop = merge, apply, persist — the lane-drag's exact sequence");
+  assert.match(SRC, /const full = this\._mergeVisibleOrder\(vis\);\s*\/\/ only the shown rows permute within the full order\n\s*this\._applyOrderToData\(full\);[\s\S]{0,200}this\._persistOrder\(full, prev, vis\[toIdx\], 'dialog'\);/,
+    "drop = merge, apply, persist — the lane-drag's exact sequence (the pre-drag order and the moved row ride along, for the revert a refused persist makes)");
   assert.match(SRC, /renderRows\(\);\n\s*\};\n\s*nameCell\.addEventListener\('pointermove', onMove\);/,
     "the rebuild happens on the drop, after the persist");
 });
@@ -344,17 +344,19 @@ test("the two display toggles write the host's own romp:settings — reachable i
   assert.match(SRC, /localStorage\.setItem\('romp:settings', JSON\.stringify\(s\)\);/);
 });
 
-test("_setViews posts through the host hook with a GUARDED, atomic Obsidian fallback", () => {
+test("_setViews posts through the host hook, or through the kernel's POST /views in Obsidian (2026-09-08)", () => {
   assert.match(SRC, /window\.__rompTimelineSetViews === 'function'/);
-  // Electron-gated (a bare-node test run must never touch the real file — the 2026-07-02 lesson),
-  // env-aware state root, tmp+rename so a reader never sees a torn blob
-  assert.match(SRC, /process\.versions && process\.versions\.electron/);
-  assert.match(SRC, /process\.env\.ROMP_STATE_DIR\n?\s*\|\| path\.join\(process\.env\.XDG_STATE_HOME \|\| path\.join\(os\.homedir\(\), '\.local', 'state'\), 'romp'\)/);
-  assert.match(SRC, /fs\.renameSync\(fp \+ '\.tmp', fp\);/);
-  // the file IS the store on that path: the write settles on the spot (no kernel ack to wait for)
-  assert.match(SRC, /fs\.renameSync\(fp \+ '\.tmp', fp\);\s*\n\s*this\._views = v; this\._pendingViews = null;/);
-  assert.match(SRC, /_setViews\(v, edited, lens\) \{\s*\n\s*this\._pendingViews = lens \? applyLensFields\(this\._curViews\(\), lens\) : v;/,
-    "a lens or order write shows the current copy with its fields applied; a whole-blob write shows the blob");
+  // Obsidian used to write timeline-views.json itself here — a whole-blob write the judge and the
+  // stale-writer guard never saw. Now it posts the kernel's /views (the setTimelineViews op as a route)
+  // and feeds the viewsAck document the route answers with to the door the socket's ack takes, so the
+  // copy clears or reverts on the ack in every host. Electron-gated through _kernelHost (a bare-node
+  // test run must never reach the real state — the 2026-07-02 lesson); executed in ui/timeline-kernel-post.test.ts.
+  assert.match(SRC, /const hook = typeof window !== 'undefined' && typeof window\.__rompTimelineSetViews === 'function';\s*\n\s*if \(hook \|\| this\._kernelHost\(\)\) \{/);
+  assert.match(SRC, /if \(hook\) window\.__rompTimelineSetViews\(v, writeId, ed\);\s*\n\s*else settled = this\._kernelPost\('\/views', \{ views: v, edited: ed, writeId \}\)\.then\(\(r\) => this\._kernelViewsAnswer\(r, writeId, lens, own\)\);/,
+    "…answered through _kernelViewsAnswer: a kernel's ruling feeds viewsAck; a lens no kernel took stays local and is said (ui/timeline-kernel-post.test.ts)");
+  assert.doesNotMatch(SRC, /renameSync|writeFileSync/, "no file write of its own remains");
+  assert.match(SRC, /_setViews\(v, edited, lens, own\) \{\s*\n(?:\s*\/\/[^\n]*\n){0,6}\s*this\._pendingViews = lens \? applyLensFields\(this\._writeBase\(\), lens\) : v;/,
+    "a lens or order write shows the WRITE base with its fields applied (never the shown blob, whose local lens must not ride the next write); a whole-blob write shows the blob");
   assert.match(SRC, /this\._reconcileViews\(\);\s*\/\/ \.\.\.and an optimistic view edit/);
 });
 
@@ -763,7 +765,7 @@ test("the corner grew two icon buttons and the menus split (the user 2026-08-25)
   assert.match(SRC, /apply\(lensToggle\(lens, \{ tag: g\.name \}\), false\)/,
     "tag rows TOGGLE and the menu stays open (repaint in place)");
   assert.match(SRC, /apply\(\{ all: true \}, true\)/, "All is a plain pick and closes");
-  assert.match(SRC, /this\._setLens\(\{ actives: Object\.assign\(\{\}, v\.actives, \{ timeline: nl \}\) \}\)/,
+  assert.match(SRC, /this\._setLens\(\{ actives: Object\.assign\(this\._lensBaseActives\(\), \{ timeline: nl \}\) \}, \{ surfaces: \['timeline'\] \}\)/,
     "writes land on THIS surface's lens only");
 });
 


### PR DESCRIPTION
Built on #1069, now merged: this change supersedes the fallback writers that #1069 made safe, and rewrites a test #1069 added. The new `serve-port` record beside `serve-token` is additive and is never removed at shutdown, so a dead port simply reads as a kernel that is down.

## What was wrong
Verified on `main`: the Obsidian timeline panel runs inside Obsidian's Electron with Node's file access and no WebSocket to the kernel, so it wrote three kernel-owned state files itself. It rewrote the views store whole, bypassing the kernel's setter, its judge and the stale-writer guard, so a concurrent dashboard edit could be rolled back unseen. It read, modified and wrote the session flags with no lock against the kernel's own flag setter. It overwrote the session order whole, bypassing the kernel's merge. #1069 made those writers safe as writers. This change makes the panel stop being a second writer at all.

## What changes
Three kernel routes, `POST /flag`, `POST /views` and `POST /order`, each landing through the same setter the dashboards' WebSocket arms use: the flag setter with the flag name closed to the three lane flags and the value a JSON boolean, the views setter under its lock and through the judge with the same bound on what an edit may touch, and the order merge. Bodies are parsed by the typed-body plumbing from #1038, so a non-object body or an unknown key is a 400 in the kernel's words. A state fault on the views route answers exactly as the WebSocket arm does on this tree; a one-line comment marks where it should share #1075's helper once that lands.

The panel gains one client that posts through those routes. It reads the serve token from the kernel's own 0600 token file and sends it in the header, never in a URL. It learns the port from a new kernel record, `serve-port`, written atomically right after the kernel binds, because nothing recorded the port before and a dock-launched Obsidian sees neither the environment nor the CLI default. It uses Node's HTTP client rather than the page's fetch, because a cross-origin preflight failure from Obsidian's own origin would read exactly like a kernel that is down.

## Design points
1. **One writer.** With a kernel running, the panel never writes the three files. Every Obsidian edit passes the judge, the stale-writer guard, the flag validation and the order merge, exactly as a dashboard edit does.
2. **No reachable kernel means a visible refusal, not a fallback write.** The old file writers are removed. The panel cannot tell "no kernel anywhere" from "a kernel it cannot see" through a stale record or a token from another state directory, and the second case is precisely the second-writer race this change exists to end. The repo's rule is to surface an unavailable authority rather than degrade past it. The panel shows, in the row or dialog the gesture came from, that nothing was saved and that the kernel is not running, and the optimistic change reverts at once. This removes a real, if never documented, behaviour: an Obsidian panel with no running kernel, or one reading a synced vault on another machine, could edit flags, views and order before and now refuses. Those direct writers entered as a test-isolation fallback and were hardened in passing; no doc ever described editing from Obsidian with romp down. Two independent design reviews upheld the removal. The one exception is the Filter lens, a purely personal view choice: with no reachable kernel the surfaces and fields the viewer changed stay applied locally, overlaid on the store's own values, and the menu says the filter is not saved. Each lens gesture names the surfaces it is about; only those keys are held, merged per key over the store, and released only when a kernel rules on a write carrying them. That local filter is never written by another gesture: every whole-blob write is built from the write base, never from the shown view.
3. **Refusals in the kernel's words.** A typed 400, a fault's ok:false, or a token the kernel refuses is shown where the gesture was made, and the local state reverts to what the kernel serves, through the same paths a dashboard uses for a refused setting or a refused views write.
4. **Reads are unchanged.** The panel still reads the state files directly. Only writes moved.
5. **A remote panel** on synced state finds a port record nothing answers on and lands in point 2.

## Left out on purpose
CLI clients keep their existing port resolution; the record is read by the panel only. No Obsidian-side toast: the panel has no host bridge for one.

## Tests
`tests/test_obsidian_state_routes.py` drives each route over HTTP through the real handler: each lands through its setter; a bad flag name, a non-boolean value, an unknown key and a non-object body are 400s; a wrong token is refused before routing; a state fault on the views route is compared word for word against the WebSocket arm driven in the same test; a stale writer is refused as the WebSocket arm refuses it; the port record is written after the bind. The flags module's fallback-writer class becomes a posts-through-the-kernel class. New `ui/timeline-kernel-post.test.ts` runs the real panel module against loopback servers: the header-only token, the port record and the CLI fallback when it is absent, an old kernel's 404, a refused token, a server that is not a romp kernel, a socket dropped mid-body, and the revert on each refusal. Executed fake-DOM tests cover the Filter menu's refusal row, the unsaved lens with its note, the note clearing after a later accepted write, a tag edit posting the store's lens while the local filter stays, a ruled pill-order write leaving a local filter in place, and, with a lens write left in flight, a tag edit and a chat pane-filter row both posting the store's timeline lens while the held one stays shown. On the base every route test is a 404 and the client test finds no client.

Module runs on this branch: `test_obsidian_state_routes` 17, `test_kernel_session_flags` 43; the whole extension test job as CI runs it, 3325 passed and 0 failed, with `tsc --noEmit` clean; `timeline-kernel-post` alone is 11 cases. On the base every route test is a 404, the flags class's new cases and every client test are red.

## Review
Reviewed by twenty-two read-only agents (two lenses, two skeptics per finding), then a narrow recheck of the folds. Confirmed and folded: the client accepted any 2xx body without an explicit refusal as a landed write; a dropped socket after the headers left the promise hanging; the Filter dropdown dead-ended on a refusal; a kernel older than this panel, which writes no port record, read as not running; a row drag inside the tags dialog showed its refusal only in a lane gear; a docs clause and a grammar nit. A read-only recheck of those folds then caught the local filter replacing every surface's lens rather than overlaying the one changed, a tag edit silently saving it, one slot for two gestures, a doubled refusal row, and a port text naming the wrong variable; all folded. Two independent design reviews upheld removing the fallback writers and judged the change a feature within the existing model. A first CI run then failed the extension build: the panel's node requires must sit inside a try block, as main's own do, for the browser bundle to leave them alone, and a Python source pin expects the panel's state-root shape; both are restored and pinned, and the whole extension job runs green as CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
