### PR TITLE
The usage modal covers every attached kernel's sessions, merged kernel-side by host

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -31771,14 +31771,42 @@ def _epoch_of_local_hour(key, off_min):
         return None
 
 
+def _peer_spend_call(row, timeout):
+    """GET /spend/detail?local=1 on an attached kernel — mirror_trust's transport (the tunnel's local
+    forward, THAT machine's serve token), asking for the peer's LOCAL half only: the route never fans out
+    when serving a peer, so a mutual attachment (the ordinary pairing: an ssh attach one way and the
+    check-in row the other) cannot recurse (review find: one modal open ping-ponged between two kernels
+    until the socket timeouts unwound it, hundreds of nested requests deep, and the healthy peer read as
+    timed out). Tolerant of a NON-JSON body: an older kernel's unknown-route answer is a plain-text 404,
+    which the shared transport reports as a parse error — here it is (404, None, None), so the caller can
+    say "older build" rather than "not reachable" (review find). Returns (status, json_or_None, err)."""
+    host = row.get("host") or "?"
+    port, tok = row.get("local_port") or 0, row.get("token") or ""
+    if not port or not tok:
+        return None, None, "no admin path to '%s' (missing forward or token)" % host
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", int(port), timeout=timeout)
+        conn.request("GET", "/spend/detail?local=1", None, {"X-Romp-Token": tok})
+        resp = conn.getresponse()
+        data = resp.read()
+        conn.close()
+        try:
+            j = json.loads(data.decode() or "null")
+        except Exception:
+            j = None
+        return resp.status, j, None
+    except Exception as e:
+        return None, None, "could not reach %s's kernel: %s" % (host, e)
+
+
 def _spend_detail(now=None):
     """GET /spend/detail — EVERY attached kernel's sessions, merged here (T247c, the user 2026-09-08:
     the per-session breakdown covered this machine only, and the federated kernels' sessions matter).
     Each kernel owns its spend.json and resolves its own names and colors, so a host's story comes
     from THAT host's kernel: for every attached host the hover's spend totals include (the same
     predicate as its rows — a remote reporting spend windows) this kernel calls its /spend/detail over
-    the tunnel with that machine's serve token (mirror_trust's transport), all in parallel under one
-    bounded timeout, and merges by host. A host that is down, that times out, that refuses the token,
+    the tunnel with that machine's serve token (mirror_trust's transport, asking for that kernel's LOCAL
+    half so nothing recurses), all in parallel under one bounded timeout, and merges by host. A host that is down, that times out, that refuses the token,
     or whose older build lacks the route is REPORTED in `hosts` by name and status — never omitted
     (fail loudly) — and the rest renders. Hours align by ABSOLUTE time (each host's epochs, or its
     offset for an older peer), never by the spelling of local-hour keys; days align by each machine's
@@ -31798,7 +31826,7 @@ def _spend_detail(now=None):
             continue
 
         def _ask(row=r):
-            results[row["host"]] = _remote_kernel_call(row, "GET", "/spend/detail", timeout=_PEER_SPEND_TIMEOUT_S)
+            results[row["host"]] = _peer_spend_call(row, _PEER_SPEND_TIMEOUT_S)
         t = threading.Thread(target=_ask, daemon=True)
         t.start()
         threads.append(t)
@@ -31832,10 +31860,17 @@ def _spend_detail(now=None):
 
 def _merge_spend_details(payloads, hosts, local):
     """Fold every host's /spend/detail into one payload on the LOCAL kernel's axes (see _spend_detail)."""
+    def _own(host, p, item):
+        """A peer's payload is its LOCAL half by request; should a build ever answer with a MERGED
+        payload anyway, only the rows it tagged as its own count here — a third host reachable both
+        ways would otherwise arrive twice under two names (review find)."""
+        tag = item.get("host") if isinstance(item, dict) else None
+        return not tag or tag == host or tag == p.get("host")
+
     sessions = []
     for host, p in payloads:
         for s in p.get("sessions") or []:
-            if isinstance(s, dict):
+            if isinstance(s, dict) and _own(host, p, s):
                 row = dict(s)
                 row["host"] = host
                 sessions.append(row)
@@ -31855,16 +31890,10 @@ def _merge_spend_details(payloads, hosts, local):
     def _merge_range(name):
         axis = local.get(name) or {}
         keys = list(axis.get("keys") or [])
-        n = len(keys)
-        if name == "hours":
-            pos = {e: i for i, e in enumerate(axis.get("epochs") or [])}
-        else:
-            pos = {k: i for i, k in enumerate(keys)}
-        per = {}           # (host, sid) -> [usd[], tok[]]
-        other = ([0.0] * n, [0] * n)
-        others = set()
-        una = ([0.0] * n, [0] * n)
-        una_hosts = {}
+        epochs = list(axis.get("epochs") or []) if name == "hours" else []
+        # each peer's axis in OUR terms: epochs for hours (its own, or through its offset for an older
+        # build that ships none), the date string for days
+        peer_axes = []
         for host, p in payloads:
             rng = p.get(name) if isinstance(p.get(name), dict) else {}
             pkeys = list(rng.get("keys") or [])
@@ -31873,25 +31902,59 @@ def _merge_spend_details(payloads, hosts, local):
                 if not (isinstance(peps, list) and len(peps) == len(pkeys)):
                     off = next((h.get("tzOffsetMin") for h in hosts if h["host"] == host), None) or 0
                     peps = [_epoch_of_local_hour(k, off) for k in pkeys]
-                idx = [pos.get(e) for e in peps]
+                peer_axes.append((host, p, rng, peps))
             else:
-                idx = [pos.get(k) for k in pkeys]
+                peer_axes.append((host, p, rng, pkeys))
+        # a peer's bucket BEYOND our newest — its current hour after ours ticked over, or its "today"
+        # east of our date line — extends the axis rather than vanishing (review find: the peer's
+        # freshest spend, the one most likely to hold money, was dropped without a trace); bounded
+        # so a wild clock cannot stretch the chart
+        last = (epochs[-1] if epochs else None) if name == "hours" else (keys[-1] if keys else None)
+        beyond = set()
+        for _h, _p, _r, ax in peer_axes:
+            for a in ax:
+                if a is not None and last is not None and a > last:
+                    beyond.add(a)
+        cap = 24 if name == "hours" else 7
+        for a in sorted(beyond)[:cap]:
+            if name == "hours":
+                epochs.append(a)
+                keys.append(time.strftime("%Y-%m-%dT%H", time.localtime(a * 3600)))
+            else:
+                keys.append(a)
+        n = len(keys)
+        pos = {e: i for i, e in enumerate(epochs)} if name == "hours" else {k: i for i, k in enumerate(keys)}
+        per = {}           # (host, sid) -> [usd[], tok[]]
+        other = ([0.0] * n, [0] * n)
+        other_count = 0    # "other (N sessions)" counts CONTRIBUTORS in this range only, like the local reader:
+        #                    each payload's own fold plus the top-N sessions of its own the merge folded
+        una = ([0.0] * n, [0] * n)
+        una_hosts = {}
+        for host, p, rng, ax in peer_axes:
+            idx = [pos.get(a) for a in ax]
             for s in rng.get("stacks") or []:
-                if not isinstance(s, dict):
+                if not isinstance(s, dict) or not _own(host, p, s):
                     continue
                 usd, tok = s.get("usd") or [], s.get("tok") or []
                 kind = s.get("kind")
                 if kind == "sid":
                     key = (host, str(s.get("sid") or ""))
-                    dst = per.setdefault(key, ([0.0] * n, [0] * n)) if key in top_set else other
-                    if key not in top_set and (any(usd) or any(tok)):
-                        others.add(key)
+                    if key in top_set:
+                        dst = per.setdefault(key, ([0.0] * n, [0] * n))
+                    else:
+                        dst = other
+                        if any(usd) or any(tok):
+                            other_count += 1
                 elif kind == "other":
                     dst = other
-                    # the peer's own fold already holds its non-top sessions: count them from the roster
+                    other_count += int(s.get("count") or 0)
                 elif kind == "unattributed":
                     dst = una
                     hu = una_hosts.setdefault(host, ([0.0] * n, [0] * n))
+                    # a merged-shaped answer breaks its unattributed stack down by host: take the peer's own share
+                    if isinstance(s.get("hosts"), dict) and isinstance(s["hosts"].get(p.get("host") or host), dict):
+                        own = s["hosts"][p.get("host") or host]
+                        usd, tok = own.get("usd") or [], own.get("tok") or []
                 else:
                     continue
                 for j, i in enumerate(idx):
@@ -31901,8 +31964,6 @@ def _merge_spend_details(payloads, hosts, local):
                     dst[0][i] += v; dst[1][i] += t
                     if kind == "unattributed":
                         hu[0][i] += v; hu[1][i] += t
-        # every non-top session across hosts is in "other", whichever fold it came through
-        others |= {(s["host"], s["sid"]) for s in sessions[top_n:]}
         stacks = []
         for key in top:
             arr = per.get(key)
@@ -31916,14 +31977,14 @@ def _merge_spend_details(payloads, hosts, local):
                            "live": bool(m.get("live")), "usd": u, "tok": arr[1]})
         ou = [round(v, 4) for v in other[0]]
         if any(ou) or any(other[1]):
-            stacks.append({"kind": "other", "name": "other", "count": len(others), "usd": ou, "tok": other[1]})
+            stacks.append({"kind": "other", "name": "other", "count": other_count, "usd": ou, "tok": other[1]})
         uu = [round(v, 4) for v in una[0]]
         if any(uu) or any(una[1]):
             stacks.append({"kind": "unattributed", "name": "unattributed", "usd": uu, "tok": una[1],
                            "hosts": {h: {"usd": [round(v, 4) for v in a[0]], "tok": a[1]} for h, a in una_hosts.items()}})
         out = {"keys": keys, "stacks": stacks}
         if name == "hours":
-            out["epochs"] = list(axis.get("epochs") or [])
+            out["epochs"] = epochs
         return out
 
     out = dict(local)
@@ -39630,7 +39691,8 @@ function spHosts(d){return ((d&&d.hosts)||[]).filter(function(h){return h.status
 function spMany(d){return spHosts(d).length>1;}
 function spLabel(s,many){return (many&&s.host?'<span class=host-prefix>'+esc(s.host)+':</span> ':'')+esc(spName(s));}
 function spColor(s){return (s.bg&&/^#[0-9a-fA-F]{3,8}$/.test(s.bg))?s.bg:SP_NONE;}
-function spHead(){return '<div class=rsp-top><span>'+(SP.data&&SP.data.scope==='computed'?'Spend (computed)':'API spend')+(SP.data&&SP.data.host?' \u00b7 '+esc(SP.data.host):'')+'</span>'
+function spHead(){var d=SP.data,ok=d?spHosts(d):[];return '<div class=rsp-top><span>'+(d&&d.scope==='computed'?'Spend (computed)':'API spend')
++(ok.length>1?' \u00b7 '+ok.length+' machines':(d&&d.host?' \u00b7 '+esc(d.host):''))+'</span>'
 +'<button class=rsp-x data-act=close aria-label=Close>\u00d7</button></div>';}
 var spPending=null;   // the in-flight detail fetch's controller: a close or a re-open aborts it
 function openSpend(){if(!spBack||!spPanel)return;SP.open=true;spBack.hidden=false;SP.data=null;SP.err='';SP.allRows=false;
@@ -42849,7 +42911,11 @@ class Handler(BaseHTTPRequestHandler):
                 # who spent what and spend over time stacked by session, read from the ledger's bySid
                 # maps with names + colors resolved kernel-side — the same read class as /usage, and
                 # the shell fetches it on open rather than scraping the hover's HTML. Every attached
-                # kernel's sessions ride along, asked over the tunnel and merged here (T247c).
+                # kernel's sessions ride along, asked over the tunnel and merged here (T247c) — and a
+                # PEER's ask (?local=1) gets this kernel's own half, never a fan-out: two kernels attached
+                # to each other would otherwise ask each other forever (review find).
+                if (q.get("local") or [""])[0]:
+                    return self._send(200, json.dumps(_spend_detail_local()), "application/json", cache="no-cache")
                 return self._send(200, json.dumps(_spend_detail()), "application/json", cache="no-cache")
             if p == "/mcp":                                   # the MCP panel's data (the user 2026-08-05): `/mcp`
                 # in a romp session hits the CLI's INTERACTIVE panel, which an SDK session can't render — it

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -31598,8 +31598,11 @@ def _spend_scope():
     #                     ledger's figures are computed costs nobody is billed — the modal says so (review find)
 
 
-def _spend_detail(now=None):
-    """GET /spend/detail — the usage modal's per-SESSION story (T247, the user 2026-09-07, who wanted
+_PEER_SPEND_TIMEOUT_S = 6.0   # one bounded wait for every attached kernel's /spend/detail, asked in parallel
+
+
+def _spend_detail_local(now=None):
+    """THIS kernel's half of GET /spend/detail — the usage modal's per-SESSION story (T247, the user 2026-09-07, who wanted
     to click the usage readout and see how much each session used, with a stacked histogram colored
     by session). Read from spend.json's bySid maps (T100's per-session attribution) — the ledger, never
     a transcript recount — with names and identity colors resolved HERE from the names registry
@@ -31738,25 +31741,195 @@ def _spend_detail(now=None):
         return {"keys": keys, "stacks": stacks}
 
     h0 = int(now // 3600) - (_SERIES_HOURS - 1)
-    hour_keys = []
+    hour_keys, epochs = [], []
     for i in range(_SERIES_HOURS):
         # the recorder keys by local hour, so a fall-back transition writes two epoch hours under ONE
-        # key: one slot for it here too, not a labeled empty twin (review find)
+        # key: one slot for it here too, not a labeled empty twin (review find). Each key also carries
+        # its ABSOLUTE hour (T247c): a peer in another zone merges by that, never by the key's spelling.
         k = time.strftime("%Y-%m-%dT%H", time.localtime((h0 + i) * 3600))
         if not hour_keys or hour_keys[-1] != k:
             hour_keys.append(k)
-    with _remotes_lock:
-        # the machines the hover's spend totals include: the same predicate as its rows — a remote
-        # that reports spend windows — never any remote with a usage payload (review find)
-        up = sum(1 for r in _remotes.values()
-                 if r.get("status") == "up" and isinstance((r.get("usage") or {}).get("spend"), dict))
+            epochs.append(h0 + i)
     lt = time.localtime(now)
-    return {"host": _self_host(), "hosts": 1 + up, "scope": scope,
+    hrs = _series(hours, hour_keys)
+    hrs["epochs"] = epochs
+    return {"host": _self_host(), "scope": scope,
             "tz": time.strftime("%Z", lt), "tzOffsetMin": int((getattr(lt, "tm_gmtoff", 0) or 0) // 60),
             "recordedAt": _spend_recorded_at(),
             "topN": _DETAIL_TOP_N, "sessions": sessions,
             "unattributed": {"usd": round(un[0], 4), "tok": un[1], "turns": un[2]},
-            "hours": _series(hours, hour_keys), "days": _series(days, day_keys)}
+            "hours": hrs, "days": _series(days, day_keys)}
+
+
+def _epoch_of_local_hour(key, off_min):
+    """The absolute epoch-hour of a peer's LOCAL hour key, given the offset (minutes east of UTC) that
+    peer reported — the fallback for a peer whose build ships keys without epochs."""
+    try:
+        import calendar
+        return int((calendar.timegm(time.strptime(key, "%Y-%m-%dT%H")) - int(off_min) * 60) // 3600)
+    except Exception:
+        return None
+
+
+def _spend_detail(now=None):
+    """GET /spend/detail — EVERY attached kernel's sessions, merged here (T247c, the user 2026-09-08:
+    the per-session breakdown covered this machine only, and the federated kernels' sessions matter).
+    Each kernel owns its spend.json and resolves its own names and colors, so a host's story comes
+    from THAT host's kernel: for every attached host the hover's spend totals include (the same
+    predicate as its rows — a remote reporting spend windows) this kernel calls its /spend/detail over
+    the tunnel with that machine's serve token (mirror_trust's transport), all in parallel under one
+    bounded timeout, and merges by host. A host that is down, that times out, that refuses the token,
+    or whose older build lacks the route is REPORTED in `hosts` by name and status — never omitted
+    (fail loudly) — and the rest renders. Hours align by ABSOLUTE time (each host's epochs, or its
+    offset for an older peer), never by the spelling of local-hour keys; days align by each machine's
+    own calendar date. Sessions and stacks carry their host; the top-N is taken across hosts; per-host
+    unattributed folds into one stack with a per-host breakdown for the tooltip."""
+    now = time.time() if now is None else now
+    local = _spend_detail_local(now)
+    me = local["host"]
+    with _remotes_lock:
+        peers = [dict(r) for r in _remotes.values()
+                 if isinstance((r.get("usage") or {}).get("spend"), dict)]
+    results = {}
+    threads = []
+    for r in peers:
+        if r.get("status") != "up":
+            results[r["host"]] = (None, None, "not connected")
+            continue
+
+        def _ask(row=r):
+            results[row["host"]] = _remote_kernel_call(row, "GET", "/spend/detail", timeout=_PEER_SPEND_TIMEOUT_S)
+        t = threading.Thread(target=_ask, daemon=True)
+        t.start()
+        threads.append(t)
+    deadline = time.time() + _PEER_SPEND_TIMEOUT_S + 0.5
+    for t in threads:
+        t.join(max(0.0, deadline - time.time()))
+    hosts = [{"host": me, "status": "ok", "scope": local["scope"], "tz": local["tz"], "tzOffsetMin": local["tzOffsetMin"]}]
+    payloads = [(me, local)]
+    for r in peers:
+        host = r["host"]
+        got = results.get(host)
+        if got is None:
+            hosts.append({"host": host, "status": "unreachable", "detail": "timed out after %d s" % int(_PEER_SPEND_TIMEOUT_S)})
+            continue
+        st, j, err = got
+        if err or st is None:
+            hosts.append({"host": host, "status": "unreachable", "detail": str(err or "no answer")})
+        elif st == 401 or st == 403:
+            hosts.append({"host": host, "status": "unreachable", "detail": "its kernel refused our token (HTTP %s)" % st})
+        elif st != 200 or not isinstance(j, dict) or "sessions" not in j:
+            hosts.append({"host": host, "status": "older", "detail": "HTTP %s" % st})   # the modal says what "older" means
+        else:
+            hosts.append({"host": host, "status": "ok", "scope": j.get("scope"), "tz": j.get("tz"), "tzOffsetMin": j.get("tzOffsetMin")})
+            payloads.append((host, j))
+    if len(payloads) == 1:
+        out = dict(local)
+        out["hosts"] = hosts
+        return out
+    return _merge_spend_details(payloads, hosts, local)
+
+
+def _merge_spend_details(payloads, hosts, local):
+    """Fold every host's /spend/detail into one payload on the LOCAL kernel's axes (see _spend_detail)."""
+    sessions = []
+    for host, p in payloads:
+        for s in p.get("sessions") or []:
+            if isinstance(s, dict):
+                row = dict(s)
+                row["host"] = host
+                sessions.append(row)
+    sessions.sort(key=lambda s: (-float(s.get("usd") or 0), -int(s.get("tok") or 0), str(s.get("name") or "")))
+    top_n = int(local.get("topN") or _DETAIL_TOP_N)
+    top = [(s["host"], s["sid"]) for s in sessions[:top_n]]
+    top_set = set(top)
+    meta = {(s["host"], s["sid"]): s for s in sessions}
+    un = {"usd": 0.0, "tok": 0, "turns": 0, "byHost": {}}
+    for host, p in payloads:
+        u = p.get("unattributed") if isinstance(p.get("unattributed"), dict) else {}
+        hu = {"usd": round(float(u.get("usd") or 0), 4), "tok": int(u.get("tok") or 0), "turns": int(u.get("turns") or 0)}
+        if hu["usd"] or hu["tok"] or hu["turns"]:
+            un["byHost"][host] = hu
+        un["usd"] = round(un["usd"] + hu["usd"], 4); un["tok"] += hu["tok"]; un["turns"] += hu["turns"]
+
+    def _merge_range(name):
+        axis = local.get(name) or {}
+        keys = list(axis.get("keys") or [])
+        n = len(keys)
+        if name == "hours":
+            pos = {e: i for i, e in enumerate(axis.get("epochs") or [])}
+        else:
+            pos = {k: i for i, k in enumerate(keys)}
+        per = {}           # (host, sid) -> [usd[], tok[]]
+        other = ([0.0] * n, [0] * n)
+        others = set()
+        una = ([0.0] * n, [0] * n)
+        una_hosts = {}
+        for host, p in payloads:
+            rng = p.get(name) if isinstance(p.get(name), dict) else {}
+            pkeys = list(rng.get("keys") or [])
+            if name == "hours":
+                peps = rng.get("epochs")
+                if not (isinstance(peps, list) and len(peps) == len(pkeys)):
+                    off = next((h.get("tzOffsetMin") for h in hosts if h["host"] == host), None) or 0
+                    peps = [_epoch_of_local_hour(k, off) for k in pkeys]
+                idx = [pos.get(e) for e in peps]
+            else:
+                idx = [pos.get(k) for k in pkeys]
+            for s in rng.get("stacks") or []:
+                if not isinstance(s, dict):
+                    continue
+                usd, tok = s.get("usd") or [], s.get("tok") or []
+                kind = s.get("kind")
+                if kind == "sid":
+                    key = (host, str(s.get("sid") or ""))
+                    dst = per.setdefault(key, ([0.0] * n, [0] * n)) if key in top_set else other
+                    if key not in top_set and (any(usd) or any(tok)):
+                        others.add(key)
+                elif kind == "other":
+                    dst = other
+                    # the peer's own fold already holds its non-top sessions: count them from the roster
+                elif kind == "unattributed":
+                    dst = una
+                    hu = una_hosts.setdefault(host, ([0.0] * n, [0] * n))
+                else:
+                    continue
+                for j, i in enumerate(idx):
+                    if i is None or j >= len(usd):
+                        continue
+                    v = float(usd[j] or 0); t = int((tok[j] if j < len(tok) else 0) or 0)
+                    dst[0][i] += v; dst[1][i] += t
+                    if kind == "unattributed":
+                        hu[0][i] += v; hu[1][i] += t
+        # every non-top session across hosts is in "other", whichever fold it came through
+        others |= {(s["host"], s["sid"]) for s in sessions[top_n:]}
+        stacks = []
+        for key in top:
+            arr = per.get(key)
+            if not arr:
+                continue
+            u = [round(v, 4) for v in arr[0]]
+            if not (any(u) or any(arr[1])):
+                continue
+            m = meta[key]
+            stacks.append({"kind": "sid", "host": key[0], "sid": key[1], "name": m.get("name") or "", "bg": m.get("bg") or "",
+                           "live": bool(m.get("live")), "usd": u, "tok": arr[1]})
+        ou = [round(v, 4) for v in other[0]]
+        if any(ou) or any(other[1]):
+            stacks.append({"kind": "other", "name": "other", "count": len(others), "usd": ou, "tok": other[1]})
+        uu = [round(v, 4) for v in una[0]]
+        if any(uu) or any(una[1]):
+            stacks.append({"kind": "unattributed", "name": "unattributed", "usd": uu, "tok": una[1],
+                           "hosts": {h: {"usd": [round(v, 4) for v in a[0]], "tok": a[1]} for h, a in una_hosts.items()}})
+        out = {"keys": keys, "stacks": stacks}
+        if name == "hours":
+            out["epochs"] = list(axis.get("epochs") or [])
+        return out
+
+    out = dict(local)
+    out.update({"hosts": hosts, "sessions": sessions, "unattributed": un,
+                "hours": _merge_range("hours"), "days": _merge_range("days")})
+    return out
 
 
 def _spend_windows(keyed_only=False):
@@ -39451,6 +39624,11 @@ var spBack=document.getElementById('rsp-back'),spPanel=document.getElementById('
 var SP={data:null,err:'',range:'hours',measure:'usd',open:false,allRows:false};
 var SP_OTHER='#4a5361',SP_NONE='#6b7a8c';   // "other" and a session with no identity color: neutrals, never a hue
 function spName(s){return s.name||('session '+String(s.sid||'').slice(0,8));}
+// T247c: when more than one machine contributes, a row or chip names its host the way a federated
+// session's tab does — the shared .host-prefix treatment (quiet, italic, a step smaller)
+function spHosts(d){return ((d&&d.hosts)||[]).filter(function(h){return h.status==='ok';});}
+function spMany(d){return spHosts(d).length>1;}
+function spLabel(s,many){return (many&&s.host?'<span class=host-prefix>'+esc(s.host)+':</span> ':'')+esc(spName(s));}
 function spColor(s){return (s.bg&&/^#[0-9a-fA-F]{3,8}$/.test(s.bg))?s.bg:SP_NONE;}
 function spHead(){return '<div class=rsp-top><span>'+(SP.data&&SP.data.scope==='computed'?'Spend (computed)':'API spend')+(SP.data&&SP.data.host?' \u00b7 '+esc(SP.data.host):'')+'</span>'
 +'<button class=rsp-x data-act=close aria-label=Close>\u00d7</button></div>';}
@@ -39501,9 +39679,9 @@ var h='<table class=rsp-tbl><thead><tr><th></th><th>session</th><th class=n>doll
 +'<th class=n>turns</th><th class=n>tokens</th></tr></thead><tbody>';
 // the table folds to the histogram's own top-N (progressive disclosure: the chart stays in view under
 // a long roster); one click shows every session
-var lim=(SP.allRows||ss.length<=(d.topN||10)+2)?ss.length:(d.topN||10),shown=ss.slice(0,lim);
+var lim=(SP.allRows||ss.length<=(d.topN||10)+2)?ss.length:(d.topN||10),shown=ss.slice(0,lim),many=spMany(d);
 shown.forEach(function(s){h+='<tr'+(s.live?'':' class=rsp-dead')+'><td><i class=rsp-sw style="background:'+spColor(s)+'"></i></td>'
-+'<td class=rsp-name>'+esc(spName(s))+(s.live?'':'<span class=ru-tip-reset> \u00b7 not running</span>')+'</td>'
++'<td class=rsp-name>'+spLabel(s,many)+(s.live?'':'<span class=ru-tip-reset> \u00b7 not running</span>')+'</td>'
 +'<td class=n>'+fmtUsd(s.usd)+'</td>'+(keyCol?'<td class=n>'+(s.key?fmtUsd(s.key.usd):'\u2014')+'</td>':'')
 +'<td class=n>'+(s.turns||0)+'</td><td class=n>'+fmtTok(s.tok||0)+'</td></tr>';});
 if(lim<ss.length){var rest=ss.slice(lim),ru=0,rt=0,rn=0;rest.forEach(function(s){ru+=s.usd||0;rt+=s.tok||0;rn+=s.turns||0;});
@@ -39529,11 +39707,16 @@ if(!d){h+='<div class=rsp-err>Couldn\u2019t load the spend detail'+(SP.err?': '+
 +'<button class=rsp-btn data-act=retry>Try again</button></div>';spPanel.innerHTML=h;return;}
 var computed=d.scope==='computed';
 h+='<div class=rsp-sec id=rsp-totals>'+totalsHTML(d)+'</div>';
-// 2. per session — THIS machine's ledger; when other machines join the totals above, say so
-var many=(d.hosts||1)>1;
-h+='<div class=rsp-sec><div class=ru-tip-name><span>By session'+(many?' \u00b7 this machine only':'')+'</span>'
-+'<span class=ru-tip-reset>'+(d.scope==='keyed'?'key-billed turns':computed?'computed cost, not billed':'all turns')+' \u00b7 last '+((d.days&&d.days.keys)?d.days.keys.length:90)+' days</span></div>';
-if(many)h+='<div class=rsp-note>Per-session detail covers '+esc(d.host||'this machine')+' only; the other '+(d.hosts-1)+' machine'+(d.hosts>2?'s':'')+' in the totals above do not share theirs yet.</div>';
+// 2. per session — EVERY attached kernel's sessions (T247c), each machine's own story merged here;
+// the billing rule is named when every contributing machine shares one, else each keeps its own
+var ok=spHosts(d),many=ok.length>1;
+var scopes={};ok.forEach(function(x){scopes[x.scope||d.scope]=1;});var sk=Object.keys(scopes);
+var rule=sk.length===1?(sk[0]==='keyed'?'key-billed turns':sk[0]==='computed'?'computed cost, not billed':'all turns'):'each machine\u2019s own billing rule';
+h+='<div class=rsp-sec><div class=ru-tip-name><span>By session'+(many?' \u00b7 '+ok.length+' machines':'')+'</span>'
++'<span class=ru-tip-reset>'+rule+' \u00b7 last '+((d.days&&d.days.keys)?d.days.keys.length:90)+' days</span></div>';
+// a machine that could not join is NAMED, never silently missing: down, timed out, refused, or too old
+((d.hosts)||[]).forEach(function(x){if(x.status==='ok')return;
+h+='<div class=rsp-note>'+esc(x.host)+': '+(x.status==='older'?'older build, no per-session data':'not reachable')+(x.detail?' \u2014 '+esc(x.detail):'')+'</div>';});
 h+='<div id=rsp-table>'+sessionTable(d)+'</div></div>';
 // 3. the histogram — the two ranges the ledger itself holds; dollars by default, tokens on a toggle
 h+='<div class=rsp-sec><div class=ru-tip-name><span>Spend over time</span></div>'
@@ -39549,6 +39732,12 @@ spPanel.innerHTML=h;renderChart();}
 function niceTop(mx){if(!(mx>0))return 1;var p=Math.pow(10,Math.floor(Math.log(mx)/Math.LN10)),f=mx/p;return (f<=1?1:f<=2?2:f<=5?5:10)*p;}
 function spFill(s){return s.kind==='unattributed'?'url(#rsp-hatch)':s.kind==='other'?SP_OTHER:spColor(s);}
 function spStackName(s){return s.kind==='other'?('other ('+(s.count||0)+' session'+(s.count===1?'':'s')+')'):s.kind==='unattributed'?'unattributed':spName(s);}
+// the plain-text form for the tooltip: host · name when more than one machine contributes; the
+// unattributed stack names each machine's share of the hovered bucket
+function spStackText(s,many,meas,i){if(s.kind==='sid')return (many&&s.host?s.host+' \u00b7 ':'')+spName(s);
+if(s.kind==='unattributed'&&many&&s.hosts){var parts=[];Object.keys(s.hosts).forEach(function(hn){var v=(s.hosts[hn][meas]||[])[i]||0;if(v>0)parts.push(hn+' '+(meas==='usd'?fmtUsd(v):fmtTok(Math.round(v))));});
+return 'unattributed'+(parts.length?' ('+parts.join(', ')+')':'');}
+return spStackName(s);}
 function spTipShow(x,y,name,val,sub){if(!spTip){spTip=document.createElement('div');spTip.id='rsp-tip';document.body.appendChild(spTip);}
 // values lead, labels follow; built with textContent — a session name is user data
 spTip.textContent='';var b=document.createElement('b');b.textContent=val;spTip.appendChild(b);
@@ -39603,17 +39792,21 @@ var xlab='';for(var i=0;i<n;i++){var k=ser.keys[i],m;
 if(SP.range==='hours'){m=/^(\\d{4})-(\\d\\d)-(\\d\\d)T00$/.exec(k);if(m){var dd=new Date(+m[1],+m[2]-1,+m[3]);
 xlab+='<span style="left:'+(((i+0.5)*slot)/W*100).toFixed(1)+'%">'+['S','M','T','W','T','F','S'][dd.getDay()]+'</span>';}}
 else{m=/^(\\d{4})-(\\d\\d)-(01|15)$/.exec(k);if(m)xlab+='<span style="left:'+(((i+0.5)*slot)/W*100).toFixed(1)+'%">'+Number(m[2])+'/'+Number(m[3])+'</span>';}}
+var many=spMany(d);
 var leg='<div class=rsp-leg>'+stacks.map(function(s){return '<span class="rsp-chip'+((s.kind==='sid'&&!s.live)||s.kind==='unattributed'?' rsp-dead':'')+'"><i class="rsp-sw'+(s.kind==='unattributed'?' rsp-hatch':'')+'"'
-+(s.kind==='unattributed'?'':' style="background:'+(s.kind==='other'?SP_OTHER:spColor(s))+'"')+'></i>'+esc(spStackName(s))+'</span>';}).join('')+'</div>';
++(s.kind==='unattributed'?'':' style="background:'+(s.kind==='other'?SP_OTHER:spColor(s))+'"')+'></i>'+(s.kind==='sid'?spLabel(s,many):esc(spStackName(s)))+'</span>';}).join('')+'</div>';
 var tzNote='';var mine=-(new Date().getTimezoneOffset());
-if(typeof d.tzOffsetMin==='number'&&d.tzOffsetMin!==mine)tzNote='<div class=rsp-note>Bucket times are '+esc(d.tz||'the kernel\u2019s clock')+' (the machine that recorded them), not your local time.</div>';
+if(typeof d.tzOffsetMin==='number'&&d.tzOffsetMin!==mine)tzNote+='<div class=rsp-note>Bucket times are '+esc(d.tz||'the kernel\u2019s clock')+' (the machine that recorded them), not your local time.</div>';
+// machines in different zones (T247c): the rule is stated, not left to be guessed
+var offs={};spHosts(d).forEach(function(x){offs[String(x.tzOffsetMin)]=1;});
+if(Object.keys(offs).length>1)tzNote+='<div class=rsp-note>Hourly buckets are aligned by clock time across machines; daily buckets follow each machine\u2019s own calendar day.</div>';
 box.innerHTML=svg+ylab+'<div class=ru-tip-gx>'+xlab+'</div>'+leg+tzNote;
 // the per-segment hover: session · value · bucket, the mark itself the hit target
 var svgEl=box.querySelector('svg');if(!svgEl)return;
 svgEl.onpointermove=function(e){var t=e.target;if(!t||!t.classList||!t.classList.contains('rsp-seg')){spTipHide();return;}
 var i=+t.getAttribute('data-i'),si=+t.getAttribute('data-s'),s=stacks[si];if(!s)return;
 var v=(s[meas]&&s[meas][i])||0,o=(s[meas==='usd'?'tok':'usd']&&s[meas==='usd'?'tok':'usd'][i])||0;
-spTipShow(e.clientX,e.clientY,spStackName(s),fmt(v),(meas==='usd'?fmtTok(Math.round(o))+' tok':fmtUsd(o))+' \u00b7 '+spBucketLabel(ser.keys[i],SP.range));};
+spTipShow(e.clientX,e.clientY,spStackText(s,many,meas,i),fmt(v),(meas==='usd'?fmtTok(Math.round(o))+' tok':fmtUsd(o))+' \u00b7 '+spBucketLabel(ser.keys[i],SP.range));};
 svgEl.onpointerleave=spTipHide;}
 window.addEventListener('resize',function(){if(SP.open&&SP.data)renderChart();});
 el.addEventListener('click',function(){pull(true);openSpend();});
@@ -42655,7 +42848,8 @@ class Handler(BaseHTTPRequestHandler):
             if p == "/spend/detail":                          # the usage MODAL's per-session breakdown (T247):
                 # who spent what and spend over time stacked by session, read from the ledger's bySid
                 # maps with names + colors resolved kernel-side — the same read class as /usage, and
-                # the shell fetches it on open rather than scraping the hover's HTML.
+                # the shell fetches it on open rather than scraping the hover's HTML. Every attached
+                # kernel's sessions ride along, asked over the tunnel and merged here (T247c).
                 return self._send(200, json.dumps(_spend_detail()), "application/json", cache="no-cache")
             if p == "/mcp":                                   # the MCP panel's data (the user 2026-08-05): `/mcp`
                 # in a romp session hits the CLI's INTERACTIVE panel, which an SDK session can't render — it

--- a/tests/spend_modal_headless.js
+++ b/tests/spend_modal_headless.js
@@ -29,6 +29,7 @@ const { chromium } = require('playwright');
     hatched: document.querySelectorAll('#rsp-chart .rsp-seg[fill="url(#rsp-hatch)"]').length,
     backdrop: getComputedStyle(document.getElementById('rsp-back')).backgroundColor,
     windows: Array.from(document.querySelectorAll('#rsp-panel .ru-tip-fleetspend .ru-tip-row .ru-tip-k')).map((e) => e.textContent),
+    notes: Array.from(document.querySelectorAll('#rsp-panel .rsp-note')).map((e) => e.textContent),
     xlabels: Array.from(document.querySelectorAll('#rsp-chart .ru-tip-gx span')).map((e) => e.textContent).join(''),
     ylabels: Array.from(document.querySelectorAll('#rsp-chart .ru-tip-gy')).map((e) => e.textContent),
     railOpacity: getComputedStyle(document.getElementById('rail-usage')).opacity,

--- a/tests/test_spend_detail.py
+++ b/tests/test_spend_detail.py
@@ -111,7 +111,7 @@ class SpendDetail(unittest.TestCase):
     def test_sessions_are_named_colored_sorted_and_flagged_live(self):
         d = km._spend_detail(now=NOW)
         self.assertEqual(d["host"], "TESTHOST")
-        self.assertEqual(d["hosts"], 1)
+        self.assertEqual([(h["host"], h["status"]) for h in d["hosts"]], [("TESTHOST", "ok")])
         self.assertEqual(d["scope"], "total")
         names = [s["name"] for s in d["sessions"]]
         self.assertEqual(names, ["web", "api", "tests"], "sorted by dollars, largest first")
@@ -191,14 +191,22 @@ class SpendDetail(unittest.TestCase):
         self.assertEqual(by2["web"]["key"], {"usd": 2.0, "tok": 20000, "turns": 2})
         self.assertNotIn("key", by2["api"])
 
-    def test_other_machines_are_counted_so_the_modal_can_say_this_machine_only(self):
-        # the hover's predicate exactly: a remote counts when it reports SPEND windows (review find: a
-        # login-only remote contributes bars, not spend, and must not be named as a machine "in the totals")
-        km._remotes["peer"] = {"host": "peer", "status": "up", "usage": {"apiKey": True, "spend": {"day": {"usd": 1}}}}
+    def test_the_hosts_asked_are_the_hovers_spend_hosts(self):
+        # the hover's predicate exactly: a remote joins when it reports SPEND windows (a login-only
+        # remote contributes bars, not spend, and is not asked); a down one is reported, never omitted
+        km._remotes["peer"] = {"host": "peer", "status": "up", "local_port": 1, "token": "t",
+                               "usage": {"apiKey": True, "spend": {"day": {"usd": 1}}}}
         km._remotes["bars"] = {"host": "bars", "status": "up", "usage": {"fiveHour": {"pct": 5}}}
         km._remotes["down"] = {"host": "down", "status": "down", "usage": {"apiKey": True, "spend": {"day": {"usd": 1}}}}
-        d = km._spend_detail(now=NOW)
-        self.assertEqual(d["hosts"], 2, "one live peer with spend joins the totals; its bySid does not reach us")
+        saved = km._PEER_SPEND_TIMEOUT_S
+        km._PEER_SPEND_TIMEOUT_S = 0.5
+        try:
+            d = km._spend_detail(now=NOW)
+        finally:
+            km._PEER_SPEND_TIMEOUT_S = saved
+        self.assertEqual([h["host"] for h in d["hosts"]], ["TESTHOST", "peer", "down"], "bars has no spend: not asked, not listed")
+        self.assertEqual(d["hosts"][1]["status"], "unreachable", "nothing answers on port 1")
+        self.assertEqual(d["hosts"][2]["status"], "unreachable")
 
     def test_a_login_without_a_key_is_the_computed_scope(self):
         # the rail's THIRD arm: windows present, no key → the rail shows no spend at all; the modal must
@@ -299,6 +307,126 @@ class SpendDetail(unittest.TestCase):
         self.assertEqual(d["unattributed"]["usd"], 0.0, "every key dollar is a session's: nothing unattributed")
         self.assertEqual([s["kind"] for s in d["days"]["stacks"]][-1], "other")
 
+    # ── T247c: every attached kernel's sessions, merged kernel-side ──────────────────────────────
+    def _peer_server(self, payload=None, status=200, token="peer-tok", hang=False):
+        """A stand-in peer kernel: /spend/detail behind the peer's own serve token (the transport
+        mirror_trust uses), answering `payload` — or 404 for an older build, or never (hang)."""
+        import threading
+        from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+        body = json.dumps(payload or {}).encode()
+
+        class H(BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):
+                if self.headers.get("X-Romp-Token") != token:
+                    self.send_response(401); self.end_headers(); return
+                if hang:
+                    time.sleep(5); return
+                if self.path.split("?")[0] != "/spend/detail":
+                    self.send_response(404); self.end_headers(); return
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        self.addCleanup(srv.shutdown)
+        return srv.server_address[1]
+
+    def _attach(self, host, port, token="peer-tok", status="up"):
+        km._remotes[host] = {"host": host, "status": status, "local_port": port, "token": token,
+                             "usage": {"apiKey": True, "spend": {"day": {"usd": 1}}}}
+
+    def _peer_payload(self, off_min, epochs=True):
+        """A peer's own /spend/detail, three hours east of us: the same absolute hours, LOCAL keys that
+        read three hours later, and one session of its own (plus a pre-attribution hour)."""
+        local = km._spend_detail_local(now=NOW)
+        keys, eps = local["hours"]["keys"], local["hours"]["epochs"]
+        pk = [time.strftime("%Y-%m-%dT%H", time.gmtime(e * 3600 + off_min * 60)) for e in eps]
+        n = len(keys)
+        usd = [0.0] * n; tok = [0] * n
+        i5 = n - 1 - 5
+        usd[i5] = 7.0; tok[i5] = 70000
+        una = [0.0] * n; una[n - 1 - 9] = 2.0
+        pd = {"host": "PEERHOST", "scope": "total", "tz": "PEER", "tzOffsetMin": off_min, "topN": 10,
+              "sessions": [{"sid": "22222222-3333-4444-5555-000000000001", "name": "worker", "bg": "#C2410C", "fg": "#fff",
+                            "live": True, "usd": 300.0, "tok": 3000000, "turns": 30}],
+              "unattributed": {"usd": 2.0, "tok": 0, "turns": 1},
+              "hours": {"keys": pk, "stacks": [
+                  {"kind": "sid", "sid": "22222222-3333-4444-5555-000000000001", "name": "worker", "bg": "#C2410C", "live": True, "usd": usd, "tok": tok},
+                  {"kind": "unattributed", "name": "unattributed", "usd": una, "tok": [0] * n}]},
+              "days": {"keys": local["days"]["keys"], "stacks": [
+                  {"kind": "sid", "sid": "22222222-3333-4444-5555-000000000001", "name": "worker", "bg": "#C2410C", "live": True,
+                   "usd": [0.0] * 89 + [300.0], "tok": [0] * 89 + [3000000]}]}}
+        if epochs:
+            pd["hours"]["epochs"] = eps
+        return pd
+
+    def test_a_peers_sessions_merge_in_with_their_host_and_hours_align_by_absolute_time(self):
+        off = int((time.localtime(NOW).tm_gmtoff or 0) // 60) + 180
+        self._attach("PEERHOST", self._peer_server(self._peer_payload(off)))
+        d = km._spend_detail(now=NOW)
+        self.assertEqual([h["host"] for h in d["hosts"]], ["TESTHOST", "PEERHOST"])
+        self.assertEqual([h["status"] for h in d["hosts"]], ["ok", "ok"])
+        names = [(s["host"], s["name"]) for s in d["sessions"]]
+        self.assertEqual(names[0], ("TESTHOST", "web"))
+        self.assertIn(("PEERHOST", "worker"), names, "the peer's session is a row, tagged with its host")
+        self.assertEqual(names[1], ("PEERHOST", "worker"), "sorted by dollars across hosts: 300 sits between web's 960 and api's 240")
+        hk = d["hours"]["keys"]
+        worker = [s for s in d["hours"]["stacks"] if s.get("name") == "worker"][0]
+        self.assertEqual(worker["host"], "PEERHOST")
+        self.assertAlmostEqual(worker["usd"][len(hk) - 1 - 5], 7.0, places=3,
+                               msg="the peer's hour lands on the same ABSOLUTE hour, though its local key reads three hours later")
+        self.assertEqual(sum(1 for v in worker["usd"] if v), 1)
+        una = [s for s in d["hours"]["stacks"] if s["kind"] == "unattributed"][0]
+        self.assertAlmostEqual(una["usd"][len(hk) - 1 - 9], 2.0, places=3, msg="the peer's pre-attribution hour joins the one unattributed stack")
+        self.assertAlmostEqual(una["hosts"]["PEERHOST"]["usd"][len(hk) - 1 - 9], 2.0, places=3, msg="…with its host named for the tooltip")
+        self.assertAlmostEqual(d["unattributed"]["byHost"]["PEERHOST"]["usd"], 2.0, places=3)
+        self.assertAlmostEqual(d["unattributed"]["usd"], 86.0 + 2.0, places=3)
+        dk = d["days"]["keys"]
+        wd = [s for s in d["days"]["stacks"] if s.get("name") == "worker"][0]
+        self.assertAlmostEqual(wd["usd"][len(dk) - 1], 300.0, places=3, msg="daily buckets align by each machine's own date")
+
+    def test_an_older_peer_without_epochs_still_aligns_through_its_offset(self):
+        off = int((time.localtime(NOW).tm_gmtoff or 0) // 60) + 180
+        self._attach("PEERHOST", self._peer_server(self._peer_payload(off, epochs=False)))
+        d = km._spend_detail(now=NOW)
+        hk = d["hours"]["keys"]
+        worker = [s for s in d["hours"]["stacks"] if s.get("name") == "worker"][0]
+        self.assertAlmostEqual(worker["usd"][len(hk) - 1 - 5], 7.0, places=3, msg="local keys converted with the peer's offset, never string-equal")
+
+    def test_a_down_an_older_and_a_hanging_peer_are_reported_by_name_never_omitted(self):
+        self._attach("DOWNHOST", 1, status="down")
+        self._attach("OLDHOST", self._peer_server(status=404))
+        self._attach("SLOWHOST", self._peer_server(hang=True))
+        self._attach("PEERHOST", self._peer_server(self._peer_payload(int((time.localtime(NOW).tm_gmtoff or 0) // 60))))
+        saved = km._PEER_SPEND_TIMEOUT_S
+        km._PEER_SPEND_TIMEOUT_S = 0.6
+        try:
+            t0 = time.time()
+            d = km._spend_detail(now=NOW)
+            took = time.time() - t0
+        finally:
+            km._PEER_SPEND_TIMEOUT_S = saved
+        by = {h["host"]: h for h in d["hosts"]}
+        self.assertEqual(by["DOWNHOST"]["status"], "unreachable")
+        self.assertEqual(by["OLDHOST"]["status"], "older", "no /spend/detail route: an older build, said so by name")
+        self.assertEqual(by["SLOWHOST"]["status"], "unreachable", "past the bounded timeout: reported, and the rest renders")
+        self.assertIn("timed out", by["SLOWHOST"]["detail"])
+        self.assertEqual(by["PEERHOST"]["status"], "ok", "a slow host holds nobody hostage")
+        self.assertIn(("PEERHOST", "worker"), [(s["host"], s["name"]) for s in d["sessions"]])
+        self.assertLess(took, 3.0, "the peer calls run in parallel under one bounded timeout")
+
+    def test_a_peer_that_rejects_our_token_is_unreachable_by_name(self):
+        self._attach("PEERHOST", self._peer_server(self._peer_payload(0)), token="wrong")
+        d = km._spend_detail(now=NOW)
+        by = {h["host"]: h for h in d["hosts"]}
+        self.assertEqual(by["PEERHOST"]["status"], "unreachable")
+
     def test_the_route_and_the_shell_are_wired(self):
         ksrc = inspect.getsource(km.Handler.do_GET) if hasattr(km.Handler, "do_GET") else open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
         self.assertIn('if p == "/spend/detail":', ksrc, "the kernel route exists")
@@ -315,7 +443,10 @@ class SpendDetail(unittest.TestCase):
         self.assertNotIn("__ROMP_LOADER__", html.split("_LANDING_JS")[0] if "_LANDING_JS" in html else html,
                          "the loader markup is spliced, not left as a placeholder")
         self.assertIn("rl-word", html)
-        self.assertIn("this machine only", html)
+        self.assertNotIn("this machine only", html, "T247c: every attached kernel's sessions are in — no such note")
+        self.assertIn("not reachable", html)
+        self.assertIn("older build", html)
+        self.assertIn("aligned by clock time across machines", html)
         self.assertIn("recorded before per-session tracking", html, "unattributed spend is named, never folded")
         self.assertIn("var rows=spendRowsHTML(LAST||[]);", html, "the modal's window numbers are the hover's own renderer")
         self.assertIn("function fleetSpendHTML(sets){", html, "…whose signature the other suites pin, untouched")

--- a/tests/test_spend_detail.py
+++ b/tests/test_spend_detail.py
@@ -308,9 +308,10 @@ class SpendDetail(unittest.TestCase):
         self.assertEqual([s["kind"] for s in d["days"]["stacks"]][-1], "other")
 
     # ── T247c: every attached kernel's sessions, merged kernel-side ──────────────────────────────
-    def _peer_server(self, payload=None, status=200, token="peer-tok", hang=False):
+    def _peer_server(self, payload=None, status=200, token="peer-tok", hang=False, seen=None):
         """A stand-in peer kernel: /spend/detail behind the peer's own serve token (the transport
-        mirror_trust uses), answering `payload` — or 404 for an older build, or never (hang)."""
+        mirror_trust uses), answering `payload` — or, for an older build, the real kernel's unknown-route
+        answer (a plain-text 404 "not found"), or never (hang). `seen` collects the paths it was asked."""
         import threading
         from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
         body = json.dumps(payload or {}).encode()
@@ -320,12 +321,20 @@ class SpendDetail(unittest.TestCase):
                 pass
 
             def do_GET(self):
+                if seen is not None:
+                    seen.append(self.path)
                 if self.headers.get("X-Romp-Token") != token:
                     self.send_response(401); self.end_headers(); return
                 if hang:
                     time.sleep(5); return
-                if self.path.split("?")[0] != "/spend/detail":
-                    self.send_response(404); self.end_headers(); return
+                if status == 404 or self.path.split("?")[0] != "/spend/detail":
+                    nf = b"not found"
+                    self.send_response(404)
+                    self.send_header("Content-Type", "text/plain")
+                    self.send_header("Content-Length", str(len(nf)))
+                    self.end_headers()
+                    self.wfile.write(nf)
+                    return
                 self.send_response(status)
                 self.send_header("Content-Type", "application/json")
                 self.send_header("Content-Length", str(len(body)))
@@ -390,6 +399,80 @@ class SpendDetail(unittest.TestCase):
         dk = d["days"]["keys"]
         wd = [s for s in d["days"]["stacks"] if s.get("name") == "worker"][0]
         self.assertAlmostEqual(wd["usd"][len(dk) - 1], 300.0, places=3, msg="daily buckets align by each machine's own date")
+
+    def test_a_peer_is_asked_for_its_local_half_only_and_the_route_serves_it(self):
+        # review find: the route served the MERGED payload to a peer too, so two kernels attached to each
+        # other asked each other back until the socket timeouts unwound hundreds of nested requests, and
+        # the healthy peer read as timed out. The ask carries ?local=1 and the route never fans out for it.
+        seen = []
+        self._attach("PEERHOST", self._peer_server(self._peer_payload(0), seen=seen))
+        km._spend_detail(now=NOW)
+        self.assertEqual(seen, ["/spend/detail?local=1"], "the peer is asked for its own half, nothing more")
+        ksrc = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        self.assertIn('if (q.get("local") or [""])[0]:\n                    return self._send(200, json.dumps(_spend_detail_local())', ksrc,
+                      "a peer's ask is served the local reader — the fan-out never runs on a peer's behalf")
+
+    def test_a_merged_shaped_answer_from_a_peer_counts_only_its_own_rows(self):
+        # review find: a peer answering with a MERGED payload (a third host it reaches, or us) had every
+        # row re-tagged as the peer's, doubling a host reachable both ways and our own sessions
+        pd = self._peer_payload(0)
+        pd["hosts"] = [{"host": "PEERHOST", "status": "ok"}, {"host": "TESTHOST", "status": "ok"}, {"host": "THIRDHOST", "status": "ok"}]
+        pd["sessions"][0]["host"] = "PEERHOST"
+        pd["sessions"] += [{"sid": WEB, "name": "web", "host": "TESTHOST", "bg": "#1EA1EB", "fg": "#fff", "live": True, "usd": 960.0, "tok": 1, "turns": 1},
+                           {"sid": "22222222-3333-4444-5555-000000000009", "name": "builder", "host": "THIRDHOST", "bg": "", "fg": "", "live": True, "usd": 50.0, "tok": 1, "turns": 1}]
+        for st in pd["hours"]["stacks"] + pd["days"]["stacks"]:
+            if st["kind"] == "sid":
+                st["host"] = "PEERHOST"
+        pd["days"]["stacks"].append({"kind": "sid", "sid": WEB, "name": "web", "host": "TESTHOST", "bg": "#1EA1EB", "live": True,
+                                     "usd": [0.0] * 89 + [960.0], "tok": [0] * 90})
+        self._attach("PEERHOST", self._peer_server(pd))
+        d = km._spend_detail(now=NOW)
+        rows = [(s["host"], s["name"]) for s in d["sessions"]]
+        self.assertEqual(rows.count(("TESTHOST", "web")), 1, "our own session arrives once, as ours")
+        self.assertNotIn(("PEERHOST", "web"), rows)
+        self.assertNotIn(("PEERHOST", "builder"), rows, "a third host's row is not the peer's")
+        self.assertEqual([s for s in d["days"]["stacks"] if s.get("name") == "web"][0]["host"], "TESTHOST")
+
+    def test_a_peers_bucket_beyond_our_axis_extends_it_instead_of_vanishing(self):
+        # review find: a peer east of us has a "today" our 90-day axis lacks, and a peer whose hour ticked
+        # over after ours ships an epoch beyond our newest — both were dropped without a trace
+        pd = self._peer_payload(0)
+        import datetime as _dt
+        tomorrow = (_dt.date.fromisoformat(pd["days"]["keys"][-1]) + _dt.timedelta(days=1)).isoformat()
+        pd["days"]["keys"] = pd["days"]["keys"][1:] + [tomorrow]
+        pd["days"]["stacks"][0]["usd"] = [0.0] * 89 + [300.0]
+        last_e = pd["hours"]["epochs"][-1]
+        pd["hours"]["epochs"] = pd["hours"]["epochs"][1:] + [last_e + 1]
+        pd["hours"]["keys"] = pd["hours"]["keys"][1:] + [time.strftime("%Y-%m-%dT%H", time.gmtime((last_e + 1) * 3600))]
+        n = len(pd["hours"]["keys"])
+        pd["hours"]["stacks"][0]["usd"] = [0.0] * (n - 1) + [7.0]
+        self._attach("PEERHOST", self._peer_server(pd))
+        d = km._spend_detail(now=NOW)
+        self.assertEqual(d["days"]["keys"][-1], tomorrow, "the peer's day joins the axis")
+        wd = [s for s in d["days"]["stacks"] if s.get("name") == "worker"][0]
+        self.assertAlmostEqual(wd["usd"][-1], 300.0, places=3)
+        self.assertEqual(d["hours"]["epochs"][-1], last_e + 1, "the peer's newest hour joins the axis")
+        wh = [s for s in d["hours"]["stacks"] if s.get("name") == "worker"][0]
+        self.assertAlmostEqual(wh["usd"][-1], 7.0, places=3)
+        self.assertEqual(len(d["hours"]["keys"]), len(d["hours"]["epochs"]))
+
+    def test_the_merged_other_count_names_contributors_in_that_range_only(self):
+        # review find: the merged "other (N sessions)" counted every non-top session from the roster,
+        # whatever it spent in the range — the single-host reader counts contributors only
+        write_ledger(km.jd.STATE, extra_sids=12)
+        led = json.loads((km.jd.STATE / "spend.json").read_text())
+        sid = "11111111-2222-3333-4444-000000000111"   # the last extra: outside the merged top ten
+        led["hours"][_hour(3)]["bySid"][sid] = {"usd": 0.2, "turns": 1, "tok": 200}
+        led["hours"][_hour(3)]["usd"] += 0.2
+        led["hours"][_hour(3)]["tokIn"] += 200
+        (km.jd.STATE / "spend.json").write_text(json.dumps(led))
+        self._attach("PEERHOST", self._peer_server(self._peer_payload(0)))
+        d = km._spend_detail(now=NOW)
+        other_h = [s for s in d["hours"]["stacks"] if s["kind"] == "other"]
+        self.assertEqual(len(other_h), 1)
+        self.assertEqual(other_h[0]["count"], 1, "one non-top session spent in the hourly range")
+        other_d = [s for s in d["days"]["stacks"] if s["kind"] == "other"][0]
+        self.assertEqual(other_d["count"], 16 - 10, "every non-top session spent in the daily range")
 
     def test_an_older_peer_without_epochs_still_aligns_through_its_offset(self):
         off = int((time.localtime(NOW).tm_gmtoff or 0) // 60) + 180

--- a/tests/test_spend_modal_headless.py
+++ b/tests/test_spend_modal_headless.py
@@ -9,6 +9,7 @@ not; this is the maintainer's screenshot harness too — pass ROMP_SHOTS=<path-p
 import json
 import os
 import subprocess
+import time
 import tempfile
 import threading
 import time
@@ -63,6 +64,16 @@ class SpendModalServed(unittest.TestCase):
         km._auth_key_present = lambda: True
         (state / "usage.json").write_text(json.dumps({"apiKey": True}))
         write_ledger(state, extra_sids=12)
+        # T247c: a two-host world — a peer kernel whose sessions merge in, and an older peer reported by name
+        self._saved_remotes = dict(km._remotes)
+        km._remotes.clear()
+        sd = _sd.SpendDetail("test_the_route_and_the_shell_are_wired")
+        off = int((time.localtime(_sd.NOW).tm_gmtoff or 0) // 60) + 180
+        peer_port = sd._peer_server.__func__(self, sd._peer_payload.__func__(self, off))
+        km._remotes["PEERHOST"] = {"host": "PEERHOST", "status": "up", "local_port": peer_port, "token": "peer-tok",
+                                   "usage": {"apiKey": True, "spend": {"day": {"usd": 1}}}}
+        km._remotes["OLDHOST"] = {"host": "OLDHOST", "status": "up", "local_port": sd._peer_server.__func__(self, status=404), "token": "peer-tok",
+                                  "usage": {"apiKey": True, "spend": {"day": {"usd": 1}}}}
         html = km._landing().encode()
         blank = b"<!doctype html><html><body style='margin:0;background:#1e1e1e'></body></html>"
 
@@ -92,6 +103,8 @@ class SpendModalServed(unittest.TestCase):
                     return self._out(200, json.dumps(km._usage() or {}).encode(), "application/json")
                 if p.startswith("/media/") or p.startswith("/dist/"):
                     f = os.path.join(ROOT, p.lstrip("/"))
+                    if p == "/dist/styles.css" and not os.path.isfile(f):
+                        f = os.path.join(ROOT, "ui", "webview", "styles.css")   # the source, when no build ran here
                     if os.path.isfile(f):
                         ct = "image/svg+xml" if f.endswith(".svg") else "application/javascript" if f.endswith(".js") else "application/octet-stream"
                         return self._out(200, open(f, "rb").read(), ct)
@@ -114,6 +127,8 @@ class SpendModalServed(unittest.TestCase):
         if hasattr(self, "_saved"):
             (km.jd.STATE, km.NAMES, km._live_names, km._tmux_sessions, km._self_host,
              km._claude_account, km._auth_key_present) = self._saved
+            km._remotes.clear()
+            km._remotes.update(getattr(self, "_saved_remotes", {}))
             self.td.cleanup()
 
     def test_click_opens_the_modal_with_table_and_stacked_histogram_and_escape_closes_it(self):
@@ -128,20 +143,24 @@ class SpendModalServed(unittest.TestCase):
         self.assertEqual(o["out"]["backdrop"], "rgba(0, 0, 0, 0.55)", "the panel rule's backdrop")
         self.assertEqual(o["out"]["head"], "API spend · TESTHOST")
         rows = o["out"]["rows"]
-        self.assertTrue(rows[0].startswith("web"), rows[0])
-        self.assertTrue(rows[1].startswith("api"), rows[1])
-        self.assertTrue(any(r.startswith("tests") and "not running" in r for r in rows), "a dead session keeps its name, dimmed")
-        self.assertTrue(o["out"]["rows"][2].startswith("tests"), "the top rows are the histogram's stacks, in order")
+        # T247c: two hosts contribute, so every row names its host in the tab strip's host-prefix voice
+        self.assertTrue(rows[0].startswith("TESTHOST:web") or rows[0].startswith("TESTHOST: web"), rows[0])
+        self.assertTrue(rows[1].startswith("PEERHOST:worker") or rows[1].startswith("PEERHOST: worker"), rows[1])
+        self.assertTrue(rows[2].startswith("TESTHOST:api") or rows[2].startswith("TESTHOST: api"), rows[2])
+        self.assertTrue(any("OLDHOST" in n and "older build" in n for n in o["out"]["notes"]), o["out"]["notes"])
+        self.assertFalse(any("this machine only" in n for n in o["out"]["notes"]))
+        self.assertTrue(any("aligned by clock time" in n for n in o["out"]["notes"]), "hosts in different zones: the timezone rule is stated")
+        self.assertTrue(any(c.startswith("PEERHOST") for c in o["out"]["legend"]), o["out"]["legend"])
+        self.assertTrue(any("tests" in r and "not running" in r for r in rows), "a dead session keeps its name, dimmed")
         self.assertTrue(any(r.startswith("unattributed") for r in rows), "pre-attribution spend is a row of its own")
         self.assertGreaterEqual(o["out"]["deadRows"], 2)
-        self.assertEqual(o["foldBefore"], 10 + 1 + 1, "the table folds to the top-N, a '5 more' row, and the unattributed row")
-        self.assertEqual(o["foldAfter"], 15 + 1, "show all: every session, plus the unattributed row")
-        self.assertTrue(any("5 more sessions" in r for r in rows), rows)
+        self.assertEqual(o["foldBefore"], 10 + 1 + 1, "the table folds to the top-N, a '6 more' row, and the unattributed row")
+        self.assertEqual(o["foldAfter"], 16 + 1, "show all: every session across both hosts, plus the unattributed row")
+        self.assertTrue(any("6 more sessions" in r for r in rows), rows)
         leg = o["out"]["legend"]
-        self.assertEqual(leg, ["web", "api", "tests", "unattributed"],
-                         "the hourly legend names only the stacks the hourly chart draws — no chip for a "
-                         "top-N session with nothing in this range, no empty 'other' (review find)")
-        self.assertIn("other (5 sessions)", o["days"]["legend"], "beyond the top-N the daily range folds them into one stack")
+        self.assertEqual([c.split(":")[-1].strip() for c in leg], ["web", "worker", "api", "tests", "unattributed"],
+                         "the hourly legend names only the stacks the hourly chart draws, across hosts, in dollar order")
+        self.assertIn("other (6 sessions)", o["days"]["legend"], "beyond the top-N the daily range folds them into one stack")
         self.assertEqual(o["days"]["legend"][-1], "unattributed")
         self.assertGreater(o["out"]["segs"], 60)
         self.assertGreaterEqual(o["out"]["hatched"], 1, "the unattributed stack wears the hatch, not a hue")
@@ -173,8 +192,9 @@ class SpendModalServed(unittest.TestCase):
         self.assertEqual(o["timeout"]["early"], {"err": False, "loader": True}, o["timeout"])
         # the unattributed chip dims like its row (review find: same class, two weights)
         self.assertIn("unattributed:0.55", o["out"]["chipOpacity"], o["out"]["chipOpacity"])
-        self.assertIn("web:1", o["out"]["chipOpacity"])
-        self.assertIn("tests:0.55", o["out"]["chipOpacity"])
+        self.assertIn("TESTHOST: web:1", o["out"]["chipOpacity"], "a live session's chip at full strength, host-prefixed (T247c)")
+        self.assertIn("TESTHOST: tests:0.55", o["out"]["chipOpacity"])
+        self.assertIn("PEERHOST: worker:1", o["out"]["chipOpacity"], "the peer's session wears its own host")
         # T247b: the phone's door is a real button — the hover's size, full opacity, not an annotation
         self.assertEqual(o["mobile"]["btn"]["font"], "11px", o["mobile"]["btn"])
         self.assertEqual(o["mobile"]["btn"]["opacity"], "1", o["mobile"]["btn"])

--- a/tests/test_spend_modal_headless.py
+++ b/tests/test_spend_modal_headless.py
@@ -9,7 +9,6 @@ not; this is the maintainer's screenshot harness too — pass ROMP_SHOTS=<path-p
 import json
 import os
 import subprocess
-import time
 import tempfile
 import threading
 import time
@@ -141,7 +140,7 @@ class SpendModalServed(unittest.TestCase):
         self.assertTrue(o["hiddenBefore"], "closed until the click")
         self.assertTrue(o["loaderSeen"], "the loader (or the content) is up the instant the modal opens")
         self.assertEqual(o["out"]["backdrop"], "rgba(0, 0, 0, 0.55)", "the panel rule's backdrop")
-        self.assertEqual(o["out"]["head"], "API spend · TESTHOST")
+        self.assertEqual(o["out"]["head"], "API spend · 2 machines", "the header names the machines when several contribute (review find)")
         rows = o["out"]["rows"]
         # T247c: two hosts contribute, so every row names its host in the tab strip's host-prefix voice
         self.assertTrue(rows[0].startswith("TESTHOST:web") or rows[0].startswith("TESTHOST: web"), rows[0])


### PR DESCRIPTION
**Feature (T247c).** The usage modal's per-session table and stacked histogram now include every attached kernel's sessions, not this machine's only. The user's ask (2026-09-08 morning PT): the API spend dashboard looks great but covers only the local sessions, and the federated kernels' sessions matter; the "do not share theirs yet" note was wrong in spirit.

**Design points**
- **Authoritative data, per host.** Each kernel owns its ledger and resolves its own names and colors, so a host's story comes from that host's kernel. `GET /spend/detail` aggregates kernel-side: for every attached host the hover's spend totals include (the same predicate as its rows), it calls that host's `/spend/detail` over the tunnel with the peer's serve token, the transport mirror_trust and the settings mirrors use, in parallel under one bounded timeout, and merges by host.
- **Fail loudly.** A host that is down, times out, refuses the token, or runs an older build without the route is reported in the payload by name and status and shown in the modal as a line ("HOST: not reachable", "HOST: older build, no per-session data"). Never silently omitted; a slow host holds nobody hostage past the timeout.
- **Alignment.** Hours align by absolute time: the local reader ships each key's epoch hour, and a peer's stacks map through its own epochs, or through the offset it reports when an older peer ships none. Never by the spelling of local-hour keys. Days align by each machine's own calendar date, and the footer states the rule when hosts sit in different zones.
- **Presentation.** Totals rows stay the summed windows the hover shows. The table lists sessions from all hosts sorted by dollars, with the host on each row in the tab strip's host-prefix voice when more than one machine contributes; identity colors stay per session. The histogram stacks sessions across hosts in their own colors; "other" counts every non-top contributor across hosts; per-host unattributed folds into one stack whose tooltip names each machine's share. The billing rule is named when every contributing machine shares one, else "each machine's own billing rule". The "this machine only" note is gone. The phone panel's door opens the same merged modal.
- **Top-N across hosts.** A session outside its own host's top-N has at least N host-mates above it, so it cannot enter the merged top-N; every merged stack therefore has its per-session series, and a peer's own "other" fold joins the merged one.

**Tests.** A hermetic two-kernel route test with a stand-in peer behind its serve token: merged rows tagged by host in dollar order, the peer's hour on the same absolute hour though its local key reads three hours later, per-host unattributed with the host named, daily alignment by date; an older peer without epochs aligning through its offset; a down, an older (404), a hanging and a token-refusing peer each reported by name inside one bounded wait; the asked set equals the hover's. The served test drives the two-host page: host prefixes on rows and chips, the older peer's status line, no "this machine only", the timezone footer. It doubles as the screenshot harness.

**Review folds (second commit).** Adversarial review, two lenses, ten findings, all confirmed hermetically and folded. Two were blocking: the route served the merged payload to a peer too, so two kernels attached to each other (the ordinary pairing) asked each other back until the socket timeouts unwound hundreds of nested requests, with the healthy peer reading as timed out; and a peer answering with a merged-shaped payload had every row re-tagged as the peer's, double counting a third host and our own sessions. The peer ask now carries `?local=1`, the route serves the local reader for it and never fans out, and only the rows a peer tags as its own count. Also folded: a tolerant peer call so a real older kernel's plain-text 404 reads as "older build" (the shared transport reported it as a parse error, so it read as "not reachable"); the axes extend, bounded, for a peer's day east of our date line or its hour after ours ticked over, which previously vanished without a trace; the merged "other" count names contributors in that range only; the header names the machine count when several contribute; a duplicate import removed. Each fold has a red-first test, including a stand-in peer that records the path it was asked and one that answers the real kernel's 404 shape.

**Left out.** Nothing from the dispatch. Remote hosts still answer with their own top-N and fold the rest into "other"; the merge is exact for the stacks it draws and for every table row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
