### PR TITLE
Chat scrollbar notches are links: click one to jump to its message (T260)

### DIFF
--- a/tests/test_scroll_marks_click.py
+++ b/tests/test_scroll_marks_click.py
@@ -2,12 +2,16 @@
 """T260 (the user 2026-09-08): the chat scrollbar's notches are links — the pointer turns into the link cursor
 over a notch, and a click jumps the transcript to that message.
 
-The served guard drives the real /chat page from a hermetic kernel (synthetic transcript: five user prompts,
-each answered by a long reply, so the first prompt sits far above the fold when the page opens at the tail).
-It checks, in the browser: the box stays pointer-events:none while each notch takes the pointer with the
-link cursor; hovering a notch shows the accent ring in BOTH themes (the painted 8×2 mark unchanged); and a
-click on the first prompt's notch lands the chat on that message — the turn carrying that uuid is in view and
-wears the deep-link flash, exactly as a comment tick's jump does (the pendingAnchor route, not a pixel jump).
+The served guard drives the real /chat page from a hermetic kernel (synthetic transcript: forty prompts,
+each answered by a long reply, so the first prompt sits far above the fold when the page opens at the tail;
+then two quick exchanges whose notches land a few pixels apart — the dense case). It checks, in the browser:
+the box stays pointer-events:none while each notch takes the pointer with the link cursor; hovering a notch
+shows the accent ring in BOTH themes (the painted 8×2 mark unchanged); the wheel over a notch still scrolls
+the transcript (review of the first cut: the box hangs off body, so the notch swallowed the wheel); a click on
+the first prompt's notch lands the chat on that message — the turn carrying that uuid is in view and wears the
+deep-link flash, exactly as a comment tick's jump does (the pendingAnchor route, not a pixel jump); and in the
+dense pair, the EARLIER notch's own paint answers for the earlier message (review of the first cut: a fixed hit
+pad reached over the neighbour and the later sibling won hover, tip and click).
 
 Skips LOUDLY without the extension deps or a Playwright browser (CI installs none); the CI-safe pins ride
 ui/webview/scroll-marks.test.ts. Pass NOTCH_CLICK_SHOTS=<path-prefix> for PNGs. All fixtures synthetic.
@@ -29,8 +33,9 @@ BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
 
 SID = "aaaaaaaa-1111-2222-3333-555555555555"
-PROMPTS = 5
-USER_UUID = "11111111-2222-3333-4444-%012d"       # % k → the k-th prompt's uuid
+PROMPTS = 40                                       # long exchanges — the scroller's world (all resident: well under the kernel's WIRE_TAIL)
+DENSE = 2                                          # quick exchanges at the tail — notches a few px apart
+USER_UUID = "11111111-2222-3333-4444-%012d"        # % k → the k-th prompt's uuid
 REPLY_UUID = "22222222-3333-4444-5555-%012d"
 
 
@@ -60,15 +65,10 @@ catch (e) {
     box: (document.querySelector(".scroll-marks") || {}).outerHTML || null, sh: document.getElementById("content")?.scrollHeight }));
   console.error("no notch painted: " + JSON.stringify(st)); process.exit(1);
 }
-await page.waitForTimeout(600);
+await page.waitForTimeout(800);
 const first = cfg.firstUuid;
-const sel = `.scroll-marks .scroll-mark[data-uuid="${first}"]`;
+const sel = (u) => `.scroll-marks .scroll-mark[data-uuid="${u}"]`;
 // what the page holds before any gesture: the notches' dress, the pointer contract, the target's position
-const inView = (turn, content) => {
-  if (!turn) return false;
-  const c = content.getBoundingClientRect(), r = turn.getBoundingClientRect();
-  return r.bottom > c.top && r.top < c.bottom;
-};
 const survey = () => page.evaluate((first) => {
   const content = document.getElementById("content");
   const box = document.querySelector(".scroll-marks");
@@ -81,10 +81,13 @@ const survey = () => page.evaluate((first) => {
   return {
     count: marks.length,
     acts: marks.map((m) => m.dataset.act), uuids: marks.map((m) => m.dataset.uuid), titles: marks.map((m) => m.title),
+    tops: marks.map((m) => parseFloat(m.style.top)),
+    pads: marks.map((m) => [m.style.getPropertyValue("--hit-t"), m.style.getPropertyValue("--hit-b")]),
     boxPointer: getComputedStyle(box).pointerEvents,
     notchPointer: cs && cs.pointerEvents, cursor: cs && cs.cursor,
     paint: m0 ? { w: m0.offsetWidth, h: m0.offsetHeight } : null,
     theme: document.body.className,
+    scrollTop: content.scrollTop,
     targetRendered: !!target,
     targetInView: !!target && r.bottom > c.top && r.top < c.bottom,
     flashed: Array.from(document.querySelectorAll(".turn.anchor-flash")).map((t) => t.dataset.uuid),
@@ -92,32 +95,36 @@ const survey = () => page.evaluate((first) => {
 }, first);
 const before = await survey();
 // HOVER (dark theme): the accent ring, the painted size unchanged
-await page.hover(sel);
+await page.hover(sel(first));
 await page.waitForTimeout(120);
-const hoverDark = await page.evaluate((sel) => { const m = document.querySelector(sel); const cs = getComputedStyle(m);
+const hoverStyle = (u) => page.evaluate((sel) => { const m = document.querySelector(sel); const cs = getComputedStyle(m);
   return { shadow: cs.boxShadow, opacity: cs.opacity, w: m.offsetWidth, h: m.offsetHeight, cursor: cs.cursor,
-           accent: getComputedStyle(document.body).getPropertyValue("--accent").trim() }; }, sel);
+           accent: getComputedStyle(document.body).getPropertyValue("--accent").trim(),
+           light: document.body.classList.contains("theme-light") }; }, sel(u));
+const hoverDark = await hoverStyle(first);
 if (cfg.shots) {
-  const b = await page.evaluate((sel) => { const r = document.querySelector(sel).getBoundingClientRect(); return { x: r.x, y: r.y }; }, sel);
+  const b = await page.evaluate((sel) => { const r = document.querySelector(sel).getBoundingClientRect(); return { x: r.x, y: r.y }; }, sel(first));
   await page.screenshot({ path: cfg.shots + "-hover-dark.png" });
   await page.screenshot({ path: cfg.shots + "-hover-dark-zoom.png",
     clip: { x: Math.max(0, b.x - 60), y: Math.max(0, b.y - 40), width: 80, height: 80 } });
 }
+// WHEEL over the hovered notch: the transcript scrolls (the box forwards the wheel to #content)
+const wheelBefore = await page.evaluate(() => document.getElementById("content").scrollTop);
+await page.mouse.wheel(0, -300);
+await page.waitForTimeout(300);
+const wheelAfter = await page.evaluate(() => document.getElementById("content").scrollTop);
 // HOVER (light theme): the same ring in the light accent
 await page.evaluate(() => document.body.classList.add("theme-light"));
 await page.mouse.move(5, 5);
-await page.hover(sel);
+await page.hover(sel(first));
 await page.waitForTimeout(120);
-const hoverLight = await page.evaluate((sel) => { const m = document.querySelector(sel); const cs = getComputedStyle(m);
-  return { shadow: cs.boxShadow, opacity: cs.opacity, w: m.offsetWidth, h: m.offsetHeight, cursor: cs.cursor,
-           accent: getComputedStyle(document.body).getPropertyValue("--accent").trim(),
-           light: document.body.classList.contains("theme-light") }; }, sel);
+const hoverLight = await hoverStyle(first);
 if (cfg.shots) await page.screenshot({ path: cfg.shots + "-hover-light.png" });
 await page.evaluate(() => document.body.classList.remove("theme-light"));
 await page.mouse.move(5, 5);
 await page.waitForTimeout(120);
 // CLICK the first prompt's notch: the chat lands on that message
-await page.click(sel);
+await page.click(sel(first));
 let landed = null;
 try {
   await page.waitForSelector(`.turn.anchor-flash[data-uuid="${first}"]`, { timeout: 8000 });
@@ -127,7 +134,28 @@ try {
   landed.error = "no flash landed on the clicked uuid: " + String(e).slice(0, 200);
 }
 if (cfg.shots) await page.screenshot({ path: cfg.shots + "-landed.png" });
-fs.writeSync(1, "RESULT:" + JSON.stringify({ before, hoverDark, hoverLight, landed }) + "\n");
+// THE DENSE PAIR: two notches a few px apart. The EARLIER notch's own paint (its top painted row) must
+// answer for the earlier message — hit test, tip and the click's landing alike.
+await page.waitForTimeout(1900);                     // the first landing's flash (1.7s) is gone
+const [d1, d2] = cfg.denseUuids;
+const geo = await page.evaluate(([s1, s2]) => {
+  const a = document.querySelector(s1).getBoundingClientRect(), b = document.querySelector(s2).getBoundingClientRect();
+  return { top1: a.top, top2: b.top, x: a.x + a.width / 2, gap: b.top - a.top };
+}, [sel(d1), sel(d2)]);
+const px = geo.x, py = geo.top1 + 0.5;               // the earlier notch's top painted row
+await page.mouse.move(px, py);
+await page.waitForTimeout(120);
+const under = await page.evaluate(([x, y]) => { const e = document.elementFromPoint(x, y); return { uuid: e && e.dataset ? e.dataset.uuid : null, title: e && e.title || null, cls: e && e.className || null }; }, [px, py]);
+await page.mouse.click(px, py);
+let dense = null;
+try {
+  await page.waitForSelector(`.turn.anchor-flash[data-uuid]`, { timeout: 8000 });
+  await page.waitForTimeout(150);
+  dense = await page.evaluate(() => Array.from(document.querySelectorAll(".turn.anchor-flash")).map((t) => t.dataset.uuid));
+} catch (e) { dense = ["no-flash: " + String(e).slice(0, 120)]; }
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-dense-landed.png" });
+fs.writeSync(1, "RESULT:" + JSON.stringify({ before, hoverDark, hoverLight, wheel: { before: wheelBefore, after: wheelAfter }, landed,
+                                              dense: { geo, under, flashed: dense } }) + "\n");
 await browser.close();
 process.exit(0);
 """
@@ -161,18 +189,20 @@ class ServedNotchClickJumps(unittest.TestCase):
         # realpath becomes '-' (jd._proj_dir)
         proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
         os.makedirs(proj, exist_ok=True)
-        # five prompts, each answered by a long reply: the page opens at the tail, so the FIRST prompt is far
-        # above the fold — the notch is the only way to reach it in one gesture
+        # forty prompts, each answered by a long reply: the page opens at the tail, so the FIRST prompt is far
+        # above the fold — the notch is the only way to reach it in one gesture. Then two quick exchanges (one-line
+        # replies): their notches land a few pixels apart on a 600px pane — the dense case.
         t0 = "2026-09-07T10:%02d:00.000Z"
         recs = []
         prev = None
-        for k in range(PROMPTS):
+        for k in range(PROMPTS + DENSE):
             u, a = USER_UUID % k, REPLY_UUID % k
             recs.append({"type": "user", "uuid": u, "parentUuid": prev, "timestamp": t0 % (2 * k), "sessionId": SID,
                          "message": {"role": "user", "content": "notes-api: prompt %d, please summarize the retry curve" % k}})
+            body = "Noted." if k >= PROMPTS else "\n\n".join("Paragraph %d of reply %d." % (i, k) for i in range(20))
             recs.append({"type": "assistant", "uuid": a, "parentUuid": u, "timestamp": t0 % (2 * k + 1), "sessionId": SID,
                          "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "end_turn",
-                                     "content": [{"type": "text", "text": "\n\n".join("Paragraph %d of reply %d." % (i, k) for i in range(14))}]}})
+                                     "content": [{"type": "text", "text": body}]}})
             prev = a
         Path(proj, SID + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
         cls.port = _free_port()
@@ -207,11 +237,12 @@ class ServedNotchClickJumps(unittest.TestCase):
         with open(cfg, "w") as f:
             json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
                        "firstUuid": USER_UUID % 0,
+                       "denseUuids": [USER_UUID % PROMPTS, USER_UUID % (PROMPTS + 1)],
                        "shots": os.environ.get("NOTCH_CLICK_SHOTS", "")}, f)
         driver = os.path.join(self.lab, name + ".mjs")
         with open(driver, "w") as f:
             f.write(script)
-        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
                            env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
         if p.returncode == 3:
             raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
@@ -222,20 +253,28 @@ class ServedNotchClickJumps(unittest.TestCase):
 
     def test_a_notch_is_a_link_that_lands_the_chat_on_its_message(self):
         r = self._drive(DRIVER, "click")
-        b, hd, hl, landed = r["before"], r["hoverDark"], r["hoverLight"], r["landed"]
+        b, hd, hl, landed, wheel, dense = r["before"], r["hoverDark"], r["hoverLight"], r["landed"], r["wheel"], r["dense"]
+        n = PROMPTS + DENSE
         # the dress: one notch per prompt, each a link to its message, with the rail's time on the tip
-        self.assertEqual(b["count"], PROMPTS, "one notch per prompt: %r" % b)
-        self.assertEqual(b["acts"], ["markjump"] * PROMPTS, "every notch routes the delegated click: %r" % b["acts"])
-        self.assertEqual(sorted(b["uuids"]), sorted(USER_UUID % k for k in range(PROMPTS)), "each notch names its message: %r" % b["uuids"])
+        self.assertEqual(b["count"], n, "one notch per prompt: %r" % b)
+        self.assertEqual(b["acts"], ["markjump"] * n, "every notch routes the delegated click: %r" % b["acts"])
+        self.assertEqual(sorted(b["uuids"]), sorted(USER_UUID % k for k in range(n)), "each notch names its message: %r" % b["uuids"])
         for t in b["titles"]:
-            self.assertRegex(t, r"\d\d:\d\d", "the tip carries the rail's HH:MM: %r" % t)
-            self.assertTrue(t.endswith("click to jump to your message"), "the tip says what a click does: %r" % t)
+            self.assertRegex(t, r"\d\d:\d\d · click to jump to your message$", "the tip: the rail's HH:MM, a middot, what a click does: %r" % t)
         # the pointer contract: the box passive over the native scrollbar, the notch a link with the link cursor
         self.assertEqual(b["boxPointer"], "none", "the box never intercepts the scrollbar: %r" % b)
         self.assertEqual(b["notchPointer"], "auto", "the notch takes the pointer: %r" % b)
         self.assertEqual(b["cursor"], "pointer", "the link cursor over a notch: %r" % b)
         self.assertEqual(b["paint"], {"w": 8, "h": 2}, "the painted mark is still 8×2 — the hit box is the pseudo: %r" % b)
         self.assertFalse(b["targetInView"], "the first prompt starts OFF-screen (the page opens at the tail), else the jump proves nothing: %r" % b)
+        # the hit pads: 2px where there is room, clamped to half the gap where notches crowd (never a neighbour's paint)
+        tops = b["tops"]
+        for k, (t, bt) in enumerate(b["pads"]):
+            up = int(t[:-2]); down = int(bt[:-2])
+            self.assertTrue(0 <= up <= 2 and 0 <= down <= 2, "pads within [0, 2]px: %r" % (b["pads"],))
+            if k > 0:
+                gap = tops[k] - tops[k - 1] - 2
+                self.assertLessEqual(int(b["pads"][k - 1][1][:-2]) + up, max(gap, 0), "no two pads meet over a neighbour's paint at %d: %r" % (k, b["pads"]))
         # hover, both themes: the accent ring (the theme's own accent), full opacity, size unchanged
         for name, h, accent in (("dark", hd, "#9cd2ff"), ("light", hl, "#C2410C")):
             self.assertEqual(h["accent"].lower(), accent.lower(), "%s theme accent token resolved: %r" % (name, h))
@@ -246,12 +285,23 @@ class ServedNotchClickJumps(unittest.TestCase):
             self.assertEqual((h["w"], h["h"]), (8, 2), "%s hover keeps the painted size: %r" % (name, h))
             self.assertEqual(h["cursor"], "pointer", "%s theme: link cursor: %r" % (name, h))
         self.assertTrue(hl["light"], "the light theme was on for the light hover: %r" % hl)
+        # the WHEEL over a notch scrolls the transcript (the box forwards it to #content)
+        self.assertLess(wheel["after"], wheel["before"] - 100, "wheel up over a notch scrolled the transcript up: %r" % wheel)
         # THE CLICK: the chat landed on the clicked message — rendered, in view, wearing the deep-link flash
         self.assertNotIn("error", landed, "landing: %r" % landed)
         self.assertTrue(landed["targetRendered"], "the target turn is rendered after the click: %r" % landed)
         self.assertTrue(landed["targetInView"], "…and in view: %r" % landed)
         self.assertIn(USER_UUID % 0, landed["flashed"], "the flash (one per navigation) sits on the clicked message: %r" % landed["flashed"])
-        self.assertEqual(landed["count"], PROMPTS, "the notches survived the landing paint: %r" % landed)
+        self.assertEqual(landed["count"], n, "the notches survived the landing paint: %r" % landed)
+        # THE DENSE PAIR: the fixture puts the two quick exchanges' notches within a few pixels (else this case
+        # proves nothing — the gap is reported so a drifted fixture fails loudly), and the EARLIER notch's own
+        # paint answers for the earlier message: under the pointer, in the tip, and in the landing
+        g = dense["geo"]
+        self.assertTrue(1 <= g["gap"] <= 4, "the dense pair sits 1–4px apart (fixture check): %r" % g)
+        d1 = USER_UUID % PROMPTS
+        self.assertEqual(dense["under"]["uuid"], d1, "the earlier notch's paint is hit-tested to itself, not to its later neighbour: %r" % dense["under"])
+        self.assertIn(d1, dense["flashed"], "the click on the earlier notch landed on the earlier message: %r" % dense)
+        self.assertNotIn(USER_UUID % (PROMPTS + 1), dense["flashed"], "…and not on the later one: %r" % dense)
 
 
 if __name__ == "__main__":

--- a/tests/test_scroll_marks_click.py
+++ b/tests/test_scroll_marks_click.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""T260 (the user 2026-09-08): the chat scrollbar's notches are links — the pointer turns into the link cursor
+over a notch, and a click jumps the transcript to that message.
+
+The served guard drives the real /chat page from a hermetic kernel (synthetic transcript: five user prompts,
+each answered by a long reply, so the first prompt sits far above the fold when the page opens at the tail).
+It checks, in the browser: the box stays pointer-events:none while each notch takes the pointer with the
+link cursor; hovering a notch shows the accent ring in BOTH themes (the painted 8×2 mark unchanged); and a
+click on the first prompt's notch lands the chat on that message — the turn carrying that uuid is in view and
+wears the deep-link flash, exactly as a comment tick's jump does (the pendingAnchor route, not a pixel jump).
+
+Skips LOUDLY without the extension deps or a Playwright browser (CI installs none); the CI-safe pins ride
+ui/webview/scroll-marks.test.ts. Pass NOTCH_CLICK_SHOTS=<path-prefix> for PNGs. All fixtures synthetic.
+"""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+
+SID = "aaaaaaaa-1111-2222-3333-555555555555"
+PROMPTS = 5
+USER_UUID = "11111111-2222-3333-4444-%012d"       # % k → the k-th prompt's uuid
+REPLY_UUID = "22222222-3333-4444-5555-%012d"
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1000, height: 600 }, deviceScaleFactor: 2 });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+try { await page.waitForSelector(".scroll-marks .scroll-mark", { timeout: 20000 }); }
+catch (e) {
+  const st = await page.evaluate(() => ({ turns: document.querySelectorAll(".turn[data-unit]").length,
+    box: (document.querySelector(".scroll-marks") || {}).outerHTML || null, sh: document.getElementById("content")?.scrollHeight }));
+  console.error("no notch painted: " + JSON.stringify(st)); process.exit(1);
+}
+await page.waitForTimeout(600);
+const first = cfg.firstUuid;
+const sel = `.scroll-marks .scroll-mark[data-uuid="${first}"]`;
+// what the page holds before any gesture: the notches' dress, the pointer contract, the target's position
+const inView = (turn, content) => {
+  if (!turn) return false;
+  const c = content.getBoundingClientRect(), r = turn.getBoundingClientRect();
+  return r.bottom > c.top && r.top < c.bottom;
+};
+const survey = () => page.evaluate((first) => {
+  const content = document.getElementById("content");
+  const box = document.querySelector(".scroll-marks");
+  const marks = Array.from(document.querySelectorAll(".scroll-marks .scroll-mark"));
+  const target = document.querySelector(`.turn[data-uuid="${first}"]`);
+  const m0 = marks.find((m) => m.dataset.uuid === first);
+  const cs = m0 ? getComputedStyle(m0) : null;
+  const c = content.getBoundingClientRect();
+  const r = target ? target.getBoundingClientRect() : null;
+  return {
+    count: marks.length,
+    acts: marks.map((m) => m.dataset.act), uuids: marks.map((m) => m.dataset.uuid), titles: marks.map((m) => m.title),
+    boxPointer: getComputedStyle(box).pointerEvents,
+    notchPointer: cs && cs.pointerEvents, cursor: cs && cs.cursor,
+    paint: m0 ? { w: m0.offsetWidth, h: m0.offsetHeight } : null,
+    theme: document.body.className,
+    targetRendered: !!target,
+    targetInView: !!target && r.bottom > c.top && r.top < c.bottom,
+    flashed: Array.from(document.querySelectorAll(".turn.anchor-flash")).map((t) => t.dataset.uuid),
+  };
+}, first);
+const before = await survey();
+// HOVER (dark theme): the accent ring, the painted size unchanged
+await page.hover(sel);
+await page.waitForTimeout(120);
+const hoverDark = await page.evaluate((sel) => { const m = document.querySelector(sel); const cs = getComputedStyle(m);
+  return { shadow: cs.boxShadow, opacity: cs.opacity, w: m.offsetWidth, h: m.offsetHeight, cursor: cs.cursor,
+           accent: getComputedStyle(document.body).getPropertyValue("--accent").trim() }; }, sel);
+if (cfg.shots) {
+  const b = await page.evaluate((sel) => { const r = document.querySelector(sel).getBoundingClientRect(); return { x: r.x, y: r.y }; }, sel);
+  await page.screenshot({ path: cfg.shots + "-hover-dark.png" });
+  await page.screenshot({ path: cfg.shots + "-hover-dark-zoom.png",
+    clip: { x: Math.max(0, b.x - 60), y: Math.max(0, b.y - 40), width: 80, height: 80 } });
+}
+// HOVER (light theme): the same ring in the light accent
+await page.evaluate(() => document.body.classList.add("theme-light"));
+await page.mouse.move(5, 5);
+await page.hover(sel);
+await page.waitForTimeout(120);
+const hoverLight = await page.evaluate((sel) => { const m = document.querySelector(sel); const cs = getComputedStyle(m);
+  return { shadow: cs.boxShadow, opacity: cs.opacity, w: m.offsetWidth, h: m.offsetHeight, cursor: cs.cursor,
+           accent: getComputedStyle(document.body).getPropertyValue("--accent").trim(),
+           light: document.body.classList.contains("theme-light") }; }, sel);
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-hover-light.png" });
+await page.evaluate(() => document.body.classList.remove("theme-light"));
+await page.mouse.move(5, 5);
+await page.waitForTimeout(120);
+// CLICK the first prompt's notch: the chat lands on that message
+await page.click(sel);
+let landed = null;
+try {
+  await page.waitForSelector(`.turn.anchor-flash[data-uuid="${first}"]`, { timeout: 8000 });
+  landed = await survey();
+} catch (e) {
+  landed = await survey();
+  landed.error = "no flash landed on the clicked uuid: " + String(e).slice(0, 200);
+}
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-landed.png" });
+fs.writeSync(1, "RESULT:" + JSON.stringify({ before, hoverDark, hoverLight, landed }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedNotchClickJumps(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        cls.lab = tempfile.mkdtemp(prefix="notch-click-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        shutil.copytree(os.path.join(EXT, "dist"), dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(cls.state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        Path(cls.state, "names", SID).write_text("web\t%s\t\t\n" % cwd)
+        Path(cls.state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high",
+             "lastSid": SID, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
+        Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 100}, "seven_day": {"pct": 10}}))
+        claude = os.path.join(cls.lab, "claude")
+        # the kernel finds a session's transcript under Claude's project dir: EVERY non-alphanumeric char of the
+        # realpath becomes '-' (jd._proj_dir)
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        # five prompts, each answered by a long reply: the page opens at the tail, so the FIRST prompt is far
+        # above the fold — the notch is the only way to reach it in one gesture
+        t0 = "2026-09-07T10:%02d:00.000Z"
+        recs = []
+        prev = None
+        for k in range(PROMPTS):
+            u, a = USER_UUID % k, REPLY_UUID % k
+            recs.append({"type": "user", "uuid": u, "parentUuid": prev, "timestamp": t0 % (2 * k), "sessionId": SID,
+                         "message": {"role": "user", "content": "notes-api: prompt %d, please summarize the retry curve" % k}})
+            recs.append({"type": "assistant", "uuid": a, "parentUuid": u, "timestamp": t0 % (2 * k + 1), "sessionId": SID,
+                         "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "end_turn",
+                                     "content": [{"type": "text", "text": "\n\n".join("Paragraph %d of reply %d." % (i, k) for i in range(14))}]}})
+            prev = a
+        Path(proj, SID + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+        cls.port = _free_port()
+        cls.token = "testtok-notchclick"
+        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
+                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
+        env.pop("ROMP_STATE_DIR", None)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def _drive(self, script, name):
+        cfg = os.path.join(self.lab, name + ".json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
+                       "firstUuid": USER_UUID % 0,
+                       "shots": os.environ.get("NOTCH_CLICK_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, name + ".mjs")
+        with open(driver, "w") as f:
+            f.write(script)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        return json.loads(line[len("RESULT:"):])
+
+    def test_a_notch_is_a_link_that_lands_the_chat_on_its_message(self):
+        r = self._drive(DRIVER, "click")
+        b, hd, hl, landed = r["before"], r["hoverDark"], r["hoverLight"], r["landed"]
+        # the dress: one notch per prompt, each a link to its message, with the rail's time on the tip
+        self.assertEqual(b["count"], PROMPTS, "one notch per prompt: %r" % b)
+        self.assertEqual(b["acts"], ["markjump"] * PROMPTS, "every notch routes the delegated click: %r" % b["acts"])
+        self.assertEqual(sorted(b["uuids"]), sorted(USER_UUID % k for k in range(PROMPTS)), "each notch names its message: %r" % b["uuids"])
+        for t in b["titles"]:
+            self.assertRegex(t, r"\d\d:\d\d", "the tip carries the rail's HH:MM: %r" % t)
+            self.assertTrue(t.endswith("click to jump to your message"), "the tip says what a click does: %r" % t)
+        # the pointer contract: the box passive over the native scrollbar, the notch a link with the link cursor
+        self.assertEqual(b["boxPointer"], "none", "the box never intercepts the scrollbar: %r" % b)
+        self.assertEqual(b["notchPointer"], "auto", "the notch takes the pointer: %r" % b)
+        self.assertEqual(b["cursor"], "pointer", "the link cursor over a notch: %r" % b)
+        self.assertEqual(b["paint"], {"w": 8, "h": 2}, "the painted mark is still 8×2 — the hit box is the pseudo: %r" % b)
+        self.assertFalse(b["targetInView"], "the first prompt starts OFF-screen (the page opens at the tail), else the jump proves nothing: %r" % b)
+        # hover, both themes: the accent ring (the theme's own accent), full opacity, size unchanged
+        for name, h, accent in (("dark", hd, "#9cd2ff"), ("light", hl, "#C2410C")):
+            self.assertEqual(h["accent"].lower(), accent.lower(), "%s theme accent token resolved: %r" % (name, h))
+            rgb = "rgb(%d, %d, %d)" % tuple(int(accent[i:i + 2], 16) for i in (1, 3, 5))
+            self.assertIn(rgb, h["shadow"], "%s hover ring is the accent: %r" % (name, h))
+            self.assertIn("1.5px", h["shadow"], "%s hover ring is a ring, not a fill: %r" % (name, h))
+            self.assertEqual(h["opacity"], "1", "%s hover lifts the notch to full opacity: %r" % (name, h))
+            self.assertEqual((h["w"], h["h"]), (8, 2), "%s hover keeps the painted size: %r" % (name, h))
+            self.assertEqual(h["cursor"], "pointer", "%s theme: link cursor: %r" % (name, h))
+        self.assertTrue(hl["light"], "the light theme was on for the light hover: %r" % hl)
+        # THE CLICK: the chat landed on the clicked message — rendered, in view, wearing the deep-link flash
+        self.assertNotIn("error", landed, "landing: %r" % landed)
+        self.assertTrue(landed["targetRendered"], "the target turn is rendered after the click: %r" % landed)
+        self.assertTrue(landed["targetInView"], "…and in view: %r" % landed)
+        self.assertIn(USER_UUID % 0, landed["flashed"], "the flash (one per navigation) sits on the clicked message: %r" % landed["flashed"])
+        self.assertEqual(landed["count"], PROMPTS, "the notches survived the landing paint: %r" % landed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -23,7 +23,7 @@ import { openTagMenu, tagMenuButton, syncTagFilter, tagChip } from "./tag-menu";
 import { syncSessionsFromTabMeta, applyMetaToSession, notePendingMeta, PendingTabMeta } from "./tab-meta";
 import { markerLabel, dayContext } from "./time-marker";
 import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
-import { senderKind } from "./sender-identity";
+import { senderKind, SenderKind } from "./sender-identity";
 import { loadSettings, onExternalSettingsChange, installSettingsSync, type RompSettings } from "./settings";
 import { delegate } from "./actions";
 import { awaitWord, awaitBreakdown, groupRows, GROUP_TITLE, workingFor, type AwaitRow } from "./spin-caption";
@@ -2353,9 +2353,15 @@ function ensureRailDay(): HTMLElement {
 // USER message — the conversation's shape at a glance, VS Code overview-ruler style. Positions are
 // proportional (turn offset over scroll height), so they are scroll-INVARIANT: the paint rides the
 // rail-sticky scheduler for free, but a signature check skips the DOM work on pure scrolls and only
-// rebuilds when the geometry or the set of user turns actually changed. Passive fixed chrome, like
-// the sticky: it never intercepts the native scrollbar underneath. The blue is the outgoing-bubble
-// blue — the color that already means "yours" — never the romp accent.
+// rebuilds when the geometry or the set of user turns actually changed. The BOX is passive fixed
+// chrome, like the sticky: it never intercepts the native scrollbar underneath. Each NOTCH, though,
+// is a link to its message (T260, the user 2026-09-08, who wanted to click a notch and land there):
+// it alone takes the pointer, carries the message's uuid, and a click rides the deep-link route
+// (scrollToAnchor → landOn: pointer-exact on the uuid, the one-per-navigation flash) exactly as a
+// comment tick does — never scrollTop arithmetic, which lands on a pixel and not on a message. The
+// notches are rebuilt on every paint, so the click is DELEGATED on the box (installed once, in
+// ensureScrollMarks) and keyed off data-act, per the click-safety rule. The blue is the
+// outgoing-bubble blue — the color that already means "yours" — never the romp accent.
 let scrollMarks: HTMLElement | null = null;
 let scrollMarksSig = "";
 // Measured unit heights, remembered once rendered (the user 2026-08-17, whose video showed notches
@@ -2450,7 +2456,27 @@ function ensureScrollMarks(): HTMLElement {
   scrollMarks = el("div", "scroll-marks");
   scrollMarks.style.display = "none";
   document.body.appendChild(scrollMarks);
+  // a notch: jump the chat to its message (fresh navigation → one flash), the comment tick's route
+  delegate(scrollMarks, {
+    markjump: (elx) => {
+      const uuid = elx.dataset.uuid;
+      if (!uuid || !activeId) return;
+      flashedAnchor = null;
+      scrollToAnchor(uuid);
+    },
+  });
   return scrollMarks;
+}
+
+// The notch's hover tip: the message's time in the rail's own HH:MM (a past day names the day too,
+// the way the rail's first stamp of that day does), and for a machine notch who sent it — romp, or
+// the ⚙ label the sender declared — so a gray notch never poses as your words even on hover.
+function scrollMarkTitle(ev: ChatEvent & { tag?: string }, kind: SenderKind): string {
+  const epoch = eventEpoch(ev);
+  const when = epoch != null ? markerLabel(epoch, null, Date.now()).text : "";
+  const who = kind === "user" ? "" : kind === "romp" ? "from romp" : "from " + (ev.tag || "a machine sender");
+  const head = [when, who].filter(Boolean).join(" · ");
+  return (head ? head + ": " : "") + (kind === "user" ? "click to jump to your message" : "click to jump to it");
 }
 
 function paintScrollMarks(): void {
@@ -2469,7 +2495,7 @@ function paintScrollMarks(): void {
   const frame = contentOffsetFrame(content, v, s);
   if (!frame) { box.style.display = "none"; scrollMarksSig = ""; return; }
   const sh = frame.sh;
-  const offs: Array<{ top: number; m: string }> = [];
+  const offs: Array<{ top: number; m: string; uuid: string; i: number; kind: SenderKind }> = [];
   const evUnit = eventUnitIndex(s);                       // marks anchor to EVENTS; the frame speaks UNITS
   for (let i = 0; i < s.events.length; i++) {
     const ev = s.events[i] as ChatEvent & { human?: boolean; romp?: boolean; rompAuto?: boolean; canned?: string; md?: string; tag?: string };
@@ -2488,11 +2514,13 @@ function paintScrollMarks(): void {
     if (u < 0) continue;                                  // not in the display stream (never for user events)
     const off = frame.offsetOf(u);
     if (off == null) continue;
-    offs.push({ top: off, m: kind === "user" ? "" : "machine" });
+    offs.push({ top: off, m: kind === "user" ? "" : "machine", uuid: ev.uuid || "", i, kind });
   }
-  const ys = offs.map((o) => ({ y: Math.round((o.top / sh) * (cRect.height - 4)), m: o.m }));
+  const ys = offs.map((o) => ({ y: Math.round((o.top / sh) * (cRect.height - 4)), m: o.m, uuid: o.uuid, i: o.i, kind: o.kind }));
+  // the uuid rides the signature too: a notch whose message changed identity under the same pixel
+  // (a provisional turn resolving to its real uuid) must re-point, not keep jumping to a ghost
   const sig = activeId + "|" + Math.round(cRect.top) + "," + Math.round(cRect.right) + ","
-    + Math.round(cRect.height) + "|" + ys.map((o) => o.y + (o.m ? "m" : "")).join(",");
+    + Math.round(cRect.height) + "|" + ys.map((o) => o.y + (o.m ? "m" : "") + o.uuid).join(",");
   if (sig !== scrollMarksSig) {
     scrollMarksSig = sig;
     // UPDATE IN PLACE when the notch count is unchanged (the user 2026-08-17: scrolling back streams
@@ -2501,13 +2529,22 @@ function paintScrollMarks(): void {
     // existing nodes lets the CSS transition carry them, so a history load reads as the map
     // rescaling rather than notches jumping to wrong places. Count changes (new messages, a fresh
     // tab) still rebuild outright — those are new marks, not moved ones.
+    // Every notch that knows its message is a link: data-act routes the delegated click, data-uuid
+    // says where, the title says when (and, for a machine notch, from whom). A notch without a uuid
+    // (nothing to land on) stays a plain mark — no act, no pointer cursor, no false affordance.
+    const dress = (m: HTMLElement, o: typeof ys[number]) => {
+      m.className = "scroll-mark" + (o.m ? " " + o.m : "");
+      if (o.uuid) { m.dataset.act = "markjump"; m.dataset.uuid = o.uuid; m.title = scrollMarkTitle(s.events[o.i] as ChatEvent & { tag?: string }, o.kind); }
+      else { delete m.dataset.act; delete m.dataset.uuid; m.removeAttribute("title"); }
+    };
     const kids = Array.from(box.children) as HTMLElement[];
     if (kids.length === ys.length) {
-      ys.forEach((o, i) => { kids[i].style.top = o.y + "px"; kids[i].className = "scroll-mark" + (o.m ? " " + o.m : ""); });
+      ys.forEach((o, i) => { kids[i].style.top = o.y + "px"; dress(kids[i], o); });
     } else {
       box.replaceChildren(...ys.map((o) => {
-        const m = el("div", "scroll-mark" + (o.m ? " " + o.m : ""));
+        const m = el("div", "");
         m.style.top = o.y + "px";
+        dress(m, o);
         return m;
       }));
     }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -2465,6 +2465,16 @@ function ensureScrollMarks(): HTMLElement {
       scrollToAnchor(uuid);
     },
   });
+  // The wheel over a notch scrolls the TRANSCRIPT (review of the first cut, 2026-09-08): the box hangs
+  // off body, not #content, so a notch that takes the pointer also took the wheel and its scroll chain
+  // ended at the page — the scrollbar under it stopped scrolling exactly where a notch sat. One passive
+  // listener on the stable box hands the delta to the scroller (lines and pages scaled to pixels).
+  scrollMarks.addEventListener("wheel", (e) => {
+    const c = document.getElementById("content");
+    if (!c) return;
+    const k = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? c.clientHeight : 1;
+    c.scrollBy({ top: e.deltaY * k, left: e.deltaX * k });
+  }, { passive: true });
   return scrollMarks;
 }
 
@@ -2476,7 +2486,7 @@ function scrollMarkTitle(ev: ChatEvent & { tag?: string }, kind: SenderKind): st
   const when = epoch != null ? markerLabel(epoch, null, Date.now()).text : "";
   const who = kind === "user" ? "" : kind === "romp" ? "from romp" : "from " + (ev.tag || "a machine sender");
   const head = [when, who].filter(Boolean).join(" · ");
-  return (head ? head + ": " : "") + (kind === "user" ? "click to jump to your message" : "click to jump to it");
+  return (head ? head + " · " : "") + (kind === "user" ? "click to jump to your message" : "click to jump to it");
 }
 
 function paintScrollMarks(): void {
@@ -2532,19 +2542,32 @@ function paintScrollMarks(): void {
     // Every notch that knows its message is a link: data-act routes the delegated click, data-uuid
     // says where, the title says when (and, for a machine notch, from whom). A notch without a uuid
     // (nothing to land on) stays a plain mark — no act, no pointer cursor, no false affordance.
-    const dress = (m: HTMLElement, o: typeof ys[number]) => {
+    // The HIT PAD above and below the 2px paint is clamped to half the gap to each neighbour (review
+    // of the first cut, 2026-09-08: a fixed pad reached over a neighbour's paint, and the later
+    // sibling won the hit test — hover, tip and click all answered for the message AFTER the one the
+    // user aimed at, wherever notches sat within about 5px). ys is in event order, hence ascending.
+    const PAD = 2;
+    const pad = (k: number): [number, number] => {
+      const up = k > 0 ? Math.floor((ys[k].y - ys[k - 1].y - 2) / 2) : PAD;
+      const down = k + 1 < ys.length ? Math.floor((ys[k + 1].y - ys[k].y - 2) / 2) : PAD;
+      return [Math.max(0, Math.min(PAD, up)), Math.max(0, Math.min(PAD, down))];
+    };
+    const dress = (m: HTMLElement, o: typeof ys[number], k: number) => {
       m.className = "scroll-mark" + (o.m ? " " + o.m : "");
+      const [up, down] = pad(k);
+      m.style.setProperty("--hit-t", up + "px");
+      m.style.setProperty("--hit-b", down + "px");
       if (o.uuid) { m.dataset.act = "markjump"; m.dataset.uuid = o.uuid; m.title = scrollMarkTitle(s.events[o.i] as ChatEvent & { tag?: string }, o.kind); }
       else { delete m.dataset.act; delete m.dataset.uuid; m.removeAttribute("title"); }
     };
     const kids = Array.from(box.children) as HTMLElement[];
     if (kids.length === ys.length) {
-      ys.forEach((o, i) => { kids[i].style.top = o.y + "px"; dress(kids[i], o); });
+      ys.forEach((o, i) => { kids[i].style.top = o.y + "px"; dress(kids[i], o, i); });
     } else {
-      box.replaceChildren(...ys.map((o) => {
+      box.replaceChildren(...ys.map((o, k) => {
         const m = el("div", "");
         m.style.top = o.y + "px";
-        dress(m, o);
+        dress(m, o, k);
         return m;
       }));
     }

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -50,9 +50,9 @@ test("a history load rescales the map smoothly — moved notches are carried, ne
   // the user 2026-08-17: scrolling back streams older history in; the scroller's world grows and
   // every proportional position compresses (the native thumb does the same). Rebuilt nodes can't
   // transition, so same-count updates move the EXISTING nodes and CSS carries them.
-  assert.match(RENDER, /if \(kids\.length === ys\.length\) \{\s*\n\s*ys\.forEach\(\(o, i\) => \{ kids\[i\]\.style\.top = o\.y \+ "px"; dress\(kids\[i\], o\); \}\);/,
-    "…and the dress (kind class, link target, tip) updates in place too — a machine notch stays gray through a rescale");
-  assert.match(RENDER, /const dress = \(m: HTMLElement, o: typeof ys\[number\]\) => \{\s*\n\s*m\.className = "scroll-mark" \+ \(o\.m \? " " \+ o\.m : ""\);/,
+  assert.match(RENDER, /if \(kids\.length === ys\.length\) \{\s*\n\s*ys\.forEach\(\(o, i\) => \{ kids\[i\]\.style\.top = o\.y \+ "px"; dress\(kids\[i\], o, i\); \}\);/,
+    "…and the dress (kind class, link target, tip, hit pads) updates in place too — a machine notch stays gray through a rescale");
+  assert.match(RENDER, /const dress = \(m: HTMLElement, o: typeof ys\[number\], k: number\) => \{\s*\n\s*m\.className = "scroll-mark" \+ \(o\.m \? " " \+ o\.m : ""\);/,
     "one dress for both DOM paths, so the moved notch and the rebuilt notch can never disagree");
   assert.match(CSS, /transition: top 180ms ease;/);
   assert.match(CSS, /prefers-reduced-motion: reduce\) \{ \.scroll-marks \.scroll-mark \{ transition: none; \} \}/);
@@ -119,7 +119,7 @@ test("every notch that knows its message carries the uuid and the action, on BOT
     "a notch with nothing to land on is a plain mark: no act, no pointer cursor, no false affordance");
   assert.match(PAINT, /offs\.push\(\{ top: off, m: kind === "user" \? "" : "machine", uuid: ev\.uuid \|\| "", i, kind \}\);/,
     "machine notches carry their uuid too — gray is clickable like blue");
-  assert.match(PAINT, /box\.replaceChildren\(\.\.\.ys\.map\(\(o\) => \{\s*\n\s*const m = el\("div", ""\);\s*\n\s*m\.style\.top = o\.y \+ "px";\s*\n\s*dress\(m, o\);/);
+  assert.match(PAINT, /box\.replaceChildren\(\.\.\.ys\.map\(\(o, k\) => \{\s*\n\s*const m = el\("div", ""\);\s*\n\s*m\.style\.top = o\.y \+ "px";\s*\n\s*dress\(m, o, k\);/);
   assert.match(PAINT, /ys\.map\(\(o\) => o\.y \+ \(o\.m \? "m" : ""\) \+ o\.uuid\)\.join\(","\)/,
     "the uuid rides the signature: a message changing identity under the same pixel re-points its notch");
 });
@@ -142,13 +142,35 @@ test("the tip is the rail's own time, and a machine notch names its sender (T260
   assert.match(TITLE, /kind === "romp" \? "from romp" : "from " \+ \(ev\.tag \|\| "a machine sender"\)/);
   assert.match(TITLE, /"click to jump to your message"/);
   assert.match(TITLE, /"click to jump to it"/);
+  assert.match(TITLE, /\(head \? head \+ " · " : ""\)/, "a middot before the verb phrase: a clock time followed by \": \" read as a doubled colon");
+});
+
+test("hit pads are clamped to half the gap to each neighbour, so a dense stretch never answers for the wrong message (T260 review)", () => {
+  // a fixed 3px pad reached over a neighbour's paint and the later sibling won the hit test: hover,
+  // tip and click all answered for the message AFTER the one under the pointer wherever notches sat
+  // within about 5px (verified in Chromium by two independent reviewers, 2026-09-08)
+  assert.match(PAINT, /const PAD = 2;/, "the pad is 2px each side — a 6px target for a 2px line, and less of the thumb's track than 3px took");
+  assert.match(PAINT, /const up = k > 0 \? Math\.floor\(\(ys\[k\]\.y - ys\[k - 1\]\.y - 2\) \/ 2\) : PAD;/);
+  assert.match(PAINT, /const down = k \+ 1 < ys\.length \? Math\.floor\(\(ys\[k \+ 1\]\.y - ys\[k\]\.y - 2\) \/ 2\) : PAD;/);
+  assert.match(PAINT, /return \[Math\.max\(0, Math\.min\(PAD, up\)\), Math\.max\(0, Math\.min\(PAD, down\)\)\];/, "half the gap, floored, never below 0 nor above the pad");
+  assert.match(PAINT, /m\.style\.setProperty\("--hit-t", up \+ "px"\);\s*\n\s*m\.style\.setProperty\("--hit-b", down \+ "px"\);/, "set in the one dress, so both DOM paths carry them");
+  assert.match(PAINT, /ys\.forEach\(\(o, i\) => \{ kids\[i\]\.style\.top = o\.y \+ "px"; dress\(kids\[i\], o, i\); \}\);/);
+  assert.match(PAINT, /box\.replaceChildren\(\.\.\.ys\.map\(\(o, k\) => \{/);
+});
+
+test("the wheel over a notch scrolls the transcript — the box forwards it (T260 review)", () => {
+  // the box hangs off body, not #content: a notch that takes the pointer took the wheel too, and its
+  // scroll chain ended at the page — the scrollbar stopped scrolling exactly where a notch sat
+  assert.match(ENSURE, /scrollMarks\.addEventListener\("wheel", \(e\) => \{/, "one listener on the stable box, never per notch");
+  assert.match(ENSURE, /const k = e\.deltaMode === 1 \? 16 : e\.deltaMode === 2 \? c\.clientHeight : 1;/, "lines and pages scaled to pixels");
+  assert.match(ENSURE, /c\.scrollBy\(\{ top: e\.deltaY \* k, left: e\.deltaX \* k \}\);\s*\n\s*\}, \{ passive: true \}\);/, "passive: the wheel is never blocked");
 });
 
 test("only the NOTCH takes the pointer — the box stays passive over the native scrollbar (T260)", () => {
   assert.match(CSS, /\.scroll-marks \{ position: fixed; z-index: 3; pointer-events: none; width: 12px; \}/, "the box: unchanged, passive");
   assert.match(CSS, /\.scroll-marks \.scroll-mark\[data-act\] \{ pointer-events: auto; cursor: pointer; \}/, "a linked notch: the link cursor");
-  assert.match(CSS, /\.scroll-marks \.scroll-mark\[data-act\]::before \{ content: ""; position: absolute; left: -2px; right: -2px; top: -3px; bottom: -3px; \}/,
-    "the hit box is padded past the 2px paint — the painted size never changes");
+  assert.match(CSS, /\.scroll-marks \.scroll-mark\[data-act\]::before \{ content: ""; position: absolute; left: -2px; right: -2px; top: calc\(-1 \* var\(--hit-t, 2px\)\); bottom: calc\(-1 \* var\(--hit-b, 2px\)\); \}/,
+    "the hit box is padded past the 2px paint by per-notch pads — the painted size never changes");
   const hover = (CSS.match(/\.scroll-marks \.scroll-mark\[data-act\]:hover \{[^}]*\}/) || [""])[0];
   assert.match(hover, /box-shadow: 0 0 0 1\.5px var\(--accent\)/, "the hover cue is the accent ring");
   assert.match(hover, /opacity: 1;/);

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -1,8 +1,9 @@
 // A thin blue notch on the chat's right scroll edge for every USER message (the user 2026-08-17) —
 // the conversation's shape at a glance, overview-ruler style. Proportional positions (scroll-
 // invariant), painted by the rail-sticky scheduler with a signature skip so pure scrolls do no DOM
-// work; passive fixed chrome that never blocks the native scrollbar; gestures (command rows, the
-// Continue row) draw no notch — those are doings, not words. Source pins.
+// work; the BOX is passive fixed chrome that never blocks the native scrollbar, while each NOTCH is a
+// link to its message (T260); gestures (command rows, the Continue row) draw no notch — those are
+// doings, not words. Source pins.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -49,8 +50,10 @@ test("a history load rescales the map smoothly — moved notches are carried, ne
   // the user 2026-08-17: scrolling back streams older history in; the scroller's world grows and
   // every proportional position compresses (the native thumb does the same). Rebuilt nodes can't
   // transition, so same-count updates move the EXISTING nodes and CSS carries them.
-  assert.match(RENDER, /if \(kids\.length === ys\.length\) \{\s*\n\s*ys\.forEach\(\(o, i\) => \{ kids\[i\]\.style\.top = o\.y \+ "px"; kids\[i\]\.className = "scroll-mark" \+ \(o\.m \? " " \+ o\.m : ""\); \}\);/,
-    "…and the kind class updates in place too (a machine notch stays gray through a rescale)");
+  assert.match(RENDER, /if \(kids\.length === ys\.length\) \{\s*\n\s*ys\.forEach\(\(o, i\) => \{ kids\[i\]\.style\.top = o\.y \+ "px"; dress\(kids\[i\], o\); \}\);/,
+    "…and the dress (kind class, link target, tip) updates in place too — a machine notch stays gray through a rescale");
+  assert.match(RENDER, /const dress = \(m: HTMLElement, o: typeof ys\[number\]\) => \{\s*\n\s*m\.className = "scroll-mark" \+ \(o\.m \? " " \+ o\.m : ""\);/,
+    "one dress for both DOM paths, so the moved notch and the rebuilt notch can never disagree");
   assert.match(CSS, /transition: top 180ms ease;/);
   assert.match(CSS, /prefers-reduced-motion: reduce\) \{ \.scroll-marks \.scroll-mark \{ transition: none; \} \}/);
 });
@@ -101,4 +104,59 @@ test("with every unit rendered the frame is the scrollbar's own truth: real midd
   assert.match(frameBody, /if \(exact\.size > 0 && exact\.size === unitTotal && !v\.el\.querySelector\("\.tx-spacer"\) && content\.scrollHeight > 0\) \{\s*\n\s*const shx = content\.scrollHeight;\s*\n\s*return \{ sh: shx, offsetOf: \(i: number\): number \| null => exact\.get\(i\) \?\? null \};/);
   // the virtual prefix-sum stays the fallback while spacers hide units
   assert.match(frameBody, /for \(let u = 0; u < unitTotal; u\+\+\) \{ t \+= uh\.get\(u\) \?\? avg; pre\.push\(t\); \}/);
+});
+
+// ── T260 (the user 2026-09-08): the notches are links — click one and the chat lands on that message ─────
+const PAINT = RENDER.slice(RENDER.indexOf("function paintScrollMarks(): void {"), RENDER.indexOf("function paintRailSticky(): void {"));
+const ENSURE = RENDER.slice(RENDER.indexOf("function ensureScrollMarks(): HTMLElement {"), RENDER.indexOf("function scrollMarkTitle("));
+const TITLE = RENDER.slice(RENDER.indexOf("function scrollMarkTitle("), RENDER.indexOf("function paintScrollMarks(): void {"));
+
+test("every notch that knows its message carries the uuid and the action, on BOTH DOM paths (T260)", () => {
+  // the click resolves to a MESSAGE (a uuid), never to a pixel — and the same dress runs on the in-place
+  // move and the rebuild, so a rescale re-points a moved notch rather than leaving it aimed at a ghost
+  assert.match(PAINT, /if \(o\.uuid\) \{ m\.dataset\.act = "markjump"; m\.dataset\.uuid = o\.uuid; m\.title = scrollMarkTitle\(/);
+  assert.match(PAINT, /else \{ delete m\.dataset\.act; delete m\.dataset\.uuid; m\.removeAttribute\("title"\); \}/,
+    "a notch with nothing to land on is a plain mark: no act, no pointer cursor, no false affordance");
+  assert.match(PAINT, /offs\.push\(\{ top: off, m: kind === "user" \? "" : "machine", uuid: ev\.uuid \|\| "", i, kind \}\);/,
+    "machine notches carry their uuid too — gray is clickable like blue");
+  assert.match(PAINT, /box\.replaceChildren\(\.\.\.ys\.map\(\(o\) => \{\s*\n\s*const m = el\("div", ""\);\s*\n\s*m\.style\.top = o\.y \+ "px";\s*\n\s*dress\(m, o\);/);
+  assert.match(PAINT, /ys\.map\(\(o\) => o\.y \+ \(o\.m \? "m" : ""\) \+ o\.uuid\)\.join\(","\)/,
+    "the uuid rides the signature: a message changing identity under the same pixel re-points its notch");
+});
+
+test("the click is DELEGATED on the stable box and rides the deep-link route, like a comment tick (T260)", () => {
+  // click-safety: the notches are rebuilt on every paint, so the listener lives on the box (created once)
+  // and keys off data-act; actions.ts's delegate() also gives the press pulse. The jump is scrollToAnchor —
+  // pointer-exact on the uuid, the one-per-navigation flash re-armed — never scrollTop arithmetic.
+  assert.match(ENSURE, /delegate\(scrollMarks, \{\s*\n\s*markjump: \(elx\) => \{\s*\n\s*const uuid = elx\.dataset\.uuid;\s*\n\s*if \(!uuid \|\| !activeId\) return;\s*\n\s*flashedAnchor = null;\s*\n\s*scrollToAnchor\(uuid\);/);
+  assert.doesNotMatch(PAINT, /addEventListener|onclick|scrollTop =/, "no per-notch listener, no pixel jump in the painter");
+  assert.equal((ENSURE.match(/delegate\(/g) || []).length, 1, "installed once, inside the create-once branch");
+  assert.ok(ENSURE.indexOf("delegate(scrollMarks") > ENSURE.indexOf("document.body.appendChild(scrollMarks);"), "…after the box is made");
+});
+
+test("the tip is the rail's own time, and a machine notch names its sender (T260)", () => {
+  // the same HH:MM the rail stamps (markerLabel, with a past day named the way the day's first stamp does);
+  // a gray notch says who sent it — romp, or the ⚙ label — so it never poses as your words even on hover
+  assert.match(TITLE, /const epoch = eventEpoch\(ev\);/);
+  assert.match(TITLE, /markerLabel\(epoch, null, Date\.now\(\)\)\.text/);
+  assert.match(TITLE, /kind === "romp" \? "from romp" : "from " \+ \(ev\.tag \|\| "a machine sender"\)/);
+  assert.match(TITLE, /"click to jump to your message"/);
+  assert.match(TITLE, /"click to jump to it"/);
+});
+
+test("only the NOTCH takes the pointer — the box stays passive over the native scrollbar (T260)", () => {
+  assert.match(CSS, /\.scroll-marks \{ position: fixed; z-index: 3; pointer-events: none; width: 12px; \}/, "the box: unchanged, passive");
+  assert.match(CSS, /\.scroll-marks \.scroll-mark\[data-act\] \{ pointer-events: auto; cursor: pointer; \}/, "a linked notch: the link cursor");
+  assert.match(CSS, /\.scroll-marks \.scroll-mark\[data-act\]::before \{ content: ""; position: absolute; left: -2px; right: -2px; top: -3px; bottom: -3px; \}/,
+    "the hit box is padded past the 2px paint — the painted size never changes");
+  const hover = (CSS.match(/\.scroll-marks \.scroll-mark\[data-act\]:hover \{[^}]*\}/) || [""])[0];
+  assert.match(hover, /box-shadow: 0 0 0 1\.5px var\(--accent\)/, "the hover cue is the accent ring");
+  assert.match(hover, /opacity: 1;/);
+  assert.doesNotMatch(hover, /--st-|--you|width|height|#[0-9a-fA-F]{3,6}/, "never a status colour, never a size change, never a hardcoded hex");
+  // both themes resolve the ring: the token exists in the dark root and in the light block
+  const light = CSS.split("body.theme-light {")[1].split("\n}")[0];
+  assert.match(CSS.split("body.theme-light {")[0], /--accent: #9cd2ff;/);
+  assert.match(light, /--accent: #C2410C;/);
+  // the hover rule outranks the machine notch's dimmer opacity by specificity (state rules must win the cascade)
+  assert.match(CSS, /\.scroll-marks \.scroll-mark\.machine \{ background: #8a8f98; opacity: 0\.55; \}/);
 });

--- a/ui/webview/sender-identity.test.ts
+++ b/ui/webview/sender-identity.test.ts
@@ -24,7 +24,7 @@ test("both consumers read the classifier — never a second hand-maintained pred
   assert.match(RENDER, /const kind = senderKind\(ev\);\s*\n\s*const romp = kind === "romp";\s*\n\s*const injected = kind === "injected";\s*\n\s*const tagged = kind === "tagged";/);
   // …and the notch painter reads the SAME function, coloring by it
   assert.match(RENDER, /const kind = senderKind\(ev\);\s*\n\s*if \(kind === "injected"\) continue;/);
-  assert.match(RENDER, /offs\.push\(\{ top: off, m: kind === "user" \? "" : "machine" \}\);/);
+  assert.match(RENDER, /offs\.push\(\{ top: off, m: kind === "user" \? "" : "machine", uuid: ev\.uuid \|\| "", i, kind \}\);/);
   // machine notches wear the light gray, never the blue that means "yours"
   assert.match(CSS, /\.scroll-marks \.scroll-mark\.machine \{ background: #8a8f98; opacity: 0\.55; \}/);
 });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1600,6 +1600,15 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
   border-radius: 1px; background: var(--you); opacity: 0.65;
   transition: top 180ms ease; }   /* history streaming in rescales the map — carried, not teleported */
 @media (prefers-reduced-motion: reduce) { .scroll-marks .scroll-mark { transition: none; } }
+/* a notch is a LINK to its message (T260, the user 2026-09-08): the box above stays pointer-events:none —
+   the native scrollbar under it keeps working wherever a notch is not — and only a notch that knows its
+   message (data-act) takes the pointer, with the link cursor. The painted mark stays 8×2; the HIT box is
+   the ::before, padded to 12×8 so a 2px line is actually clickable. Hover: full opacity plus an accent
+   ring (the focus family's colour; never a status colour, never a size change). The machine notch's
+   dimmer opacity (its rule below) yields to :hover by specificity, so a gray notch lights up the same. */
+.scroll-marks .scroll-mark[data-act] { pointer-events: auto; cursor: pointer; }
+.scroll-marks .scroll-mark[data-act]::before { content: ""; position: absolute; left: -2px; right: -2px; top: -3px; bottom: -3px; }
+.scroll-marks .scroll-mark[data-act]:hover { opacity: 1; box-shadow: 0 0 0 1.5px var(--accent); }
 .rail-day {
   position: fixed; z-index: 3; pointer-events: none; white-space: nowrap; line-height: 1;
   font-size: 0.66em; letter-spacing: 0.03em; color: var(--dim); opacity: 0.85;

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1592,9 +1592,11 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
    the pane's — "2 days ago" is wider than the 47px gutter, and the old gutter-pinned box clipped
    the leading digit at the pane edge (the user 2026-08-18, with a screenshot). Smaller than the
    stamp on purpose — context, not the time itself. */
-/* the user-message scroll notches (render.ts paintScrollMarks, the user 2026-08-17): passive fixed
-   chrome over the scroller's right edge, one 2px tick per user message at its proportional position.
-   The blue is the OUTGOING-BUBBLE blue (#2b6cef, "yours"), deliberately not the romp accent. */
+/* the scroll notches (render.ts paintScrollMarks, the user 2026-08-17): the BOX is passive fixed chrome
+   over the scroller's right edge (it never intercepts the native scrollbar); each notch is a 2px tick at
+   its message's proportional position and, since T260, a LINK to that message (the [data-act] rules
+   below). Blue = the OUTGOING-BUBBLE blue (#2b6cef, "yours"), deliberately not the romp accent; gray
+   (.machine, further down) = machine-sent. */
 .scroll-marks { position: fixed; z-index: 3; pointer-events: none; width: 12px; }
 .scroll-marks .scroll-mark { position: absolute; right: 1px; width: 8px; height: 2px;
   border-radius: 1px; background: var(--you); opacity: 0.65;
@@ -1603,11 +1605,16 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
 /* a notch is a LINK to its message (T260, the user 2026-09-08): the box above stays pointer-events:none —
    the native scrollbar under it keeps working wherever a notch is not — and only a notch that knows its
    message (data-act) takes the pointer, with the link cursor. The painted mark stays 8×2; the HIT box is
-   the ::before, padded to 12×8 so a 2px line is actually clickable. Hover: full opacity plus an accent
-   ring (the focus family's colour; never a status colour, never a size change). The machine notch's
-   dimmer opacity (its rule below) yields to :hover by specificity, so a gray notch lights up the same. */
+   the ::before, 12px wide and padded up to 2px above and below (a 6px target for a 2px line), each pad
+   CLAMPED per notch to half the gap to its neighbour (--hit-t / --hit-b, set by paintScrollMarks) so no
+   pad reaches a neighbour's paint: hover, tip and click always answer for the notch under the pointer.
+   The pads do sit over the scrollbar thumb's track: where notches are dense the thumb is grabbable only
+   in the gaps — the price of clickable notches ON the scrollbar, kept small on purpose; the wheel over a
+   notch still scrolls the transcript (the box forwards it). Hover: full opacity plus an accent ring
+   (the focus family's colour; never a status colour, never a size change). The machine notch's dimmer
+   opacity (its rule below) yields to :hover by specificity, so a gray notch lights up the same. */
 .scroll-marks .scroll-mark[data-act] { pointer-events: auto; cursor: pointer; }
-.scroll-marks .scroll-mark[data-act]::before { content: ""; position: absolute; left: -2px; right: -2px; top: -3px; bottom: -3px; }
+.scroll-marks .scroll-mark[data-act]::before { content: ""; position: absolute; left: -2px; right: -2px; top: calc(-1 * var(--hit-t, 2px)); bottom: calc(-1 * var(--hit-b, 2px)); }
 .scroll-marks .scroll-mark[data-act]:hover { opacity: 1; box-shadow: 0 0 0 1.5px var(--accent); }
 .rail-day {
   position: fixed; z-index: 3; pointer-events: none; white-space: nowrap; line-height: 1;


### PR DESCRIPTION
The blue user-message notches and the gray machine-message notches beside the chat scrollbar become clickable: the pointer turns into the link cursor over a notch, and a click jumps the transcript to that message (the user 2026-09-08, who wanted to click the little notches and land at that place in the chat).

## Design points

- **A click resolves to a message, not a pixel.** Every notch carries its event's uuid (`data-uuid`) and rides the deep-link route (`scrollToAnchor` → `landOn`): uuid-exact landing, the one-per-navigation flash re-armed, history fetched when the message is outside the resident window. Same route as the comment rail's ticks; never scrollTop arithmetic.
- **The box stays passive; only the notch takes the pointer.** `.scroll-marks` keeps `pointer-events: none`, so the native scrollbar under it keeps working wherever a notch is not. A notch that knows its message (`data-act`) gets `pointer-events: auto` and `cursor: pointer`. The hit box is a `::before` padded to 12×8 around the unchanged 8×2 paint.
- **Click-safe and acknowledged.** Notches are rebuilt on every paint, so the click is delegated once on the stable box (`actions.ts` `delegate`, installed in `ensureScrollMarks`), keyed off `data-act`, with the standard press pulse. The in-place move on rescale (count-unchanged path) is kept and re-dresses the moved notch (uuid, act, tip); the uuid also rides the paint signature so a message changing identity under the same pixel re-points its notch.
- **Hover cue in the accent, both themes.** `:hover` lifts to full opacity and draws a `1.5px var(--accent)` ring. Never a status colour, never a size change, no hardcoded hex; the hover rule outranks the machine notch's dimmer opacity by specificity.
- **Tooltip = the rail's own time, plus the sender for a machine notch.** `markerLabel` gives the HH:MM (a past day is named the way the day's first rail stamp does); a gray notch says `from romp` or `from <tag>` so it never poses as the user's words.
- **Machine (gray) notches are links too.** The dress is kind-agnostic.

## Tests

- `ui/webview/scroll-marks.test.ts`: four new pins (dress on both DOM paths, delegated click on the box + deep-link route, the tip, the CSS pointer contract in both themes) plus the in-place pin retargeted; `sender-identity.test.ts`'s sibling pin retargeted.
- `tests/test_scroll_marks_click.py`: a served browser test (hermetic kernel, Playwright; skips loudly without a browser) that checks the pointer contract, the accent hover ring in both themes with the painted size unchanged, and that clicking an off-screen prompt's notch lands the chat on that uuid with the flash.

Not touched: `kernel/`, `feed.ts`, the comment rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
