### PR TITLE
A rail dot never stands alone: a user record stripped to nothing renders no dot and no bubble

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -56,6 +56,7 @@ import { insertAtCaret } from "./composer-insert";
 import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
 import { followReader, keepPlaceAcrossShow } from "./scroll-keep";
 import { retainLiveOmitted } from "./tab-order";
+import { userTurnShows } from "./user-turn-content";
 import { keepResidentEvents } from "./frame-merge";
 import { activeTabToReannounce } from "./relay-active";
 import { dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
@@ -2688,6 +2689,15 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
     const romp = kind === "romp";
     const injected = kind === "injected";
     const tagged = kind === "tagged";
+    // A rail dot never stands alone (T261, the user 2026-09-08): a user record the kernel stripped to nothing
+    // (romp's own markers, an injected reminder) used to get its blue dot here and then no bubble below — a dot
+    // claiming a message nobody could see. Nothing to show renders nothing: a zero-height unit, like a queued
+    // group with nothing visible, so the scroll↔unit map still counts it. Decision in user-turn-content.ts.
+    if (!userTurnShows(ev)) {
+      const hid = el("div", "turn turn-user turn-user-empty");
+      hid.style.display = "none";
+      return hid;
+    }
     const turn = el("div", "turn turn-user" + (romp ? " romp" : injected ? " injected" : ""));
     // Unresolved postal ids ride the raw turn so a timeline message arc can still land on it. Without
     // this the arc pointed at a turn with nothing to match and the click died silently (the user

--- a/ui/webview/user-turn-content.ts
+++ b/ui/webview/user-turn-content.ts
@@ -1,0 +1,10 @@
+// Does a user-role event have anything to SHOW? (T261, the user 2026-09-08: a blue rail dot with no message beside
+// it.) The kernel strips romp's own markers and the harness's injected reminders out of a user record's text;
+// a record that was nothing but those arrives with an empty `md`, and the user branch of the event renderer
+// appended the rail dot BEFORE it checked for a bubble — so the dot stood alone on the rail, claiming a message
+// nobody could see. The rule: a rail dot never stands alone. An event with nothing to show renders nothing (a
+// zero-height unit, so the scroll↔unit map still counts it), and the dot is drawn only for a turn that draws
+// a bubble. Pure and DOM-free so node --test executes it.
+export function userTurnShows(ev: { md?: string | null; images?: readonly unknown[] | null }): boolean {
+  return !!(ev.md && ev.md.trim()) || !!(ev.images && ev.images.length);
+}

--- a/ui/webview/user-turn-empty.test.ts
+++ b/ui/webview/user-turn-empty.test.ts
@@ -1,0 +1,37 @@
+// T261 (the user 2026-09-08): a blue rail dot rendered with NO message beside it. The live chat frame for the
+// reported session carried user-kind events whose `md` was empty (records the kernel had stripped to nothing —
+// romp markers, injected reminders); the user branch of renderEventInner appended dot("user") before it checked
+// `ev.md || hasImgs`, so the dot stood alone. Rule: a rail dot never stands alone — an event with nothing to
+// show renders a zero-height unit and no dot. Executed decision + render.ts wiring pins, red on main. Synthetic
+// values only.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { userTurnShows } from "./user-turn-content";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("a user event shows only when it has text or images", () => {
+  assert.equal(userTurnShows({ md: "" }), false, "stripped to nothing → nothing to show");
+  assert.equal(userTurnShows({ md: "   \n " }), false, "whitespace is nothing");
+  assert.equal(userTurnShows({}), false);
+  assert.equal(userTurnShows({ md: null }), false);
+  assert.equal(userTurnShows({ md: "hello" }), true);
+  assert.equal(userTurnShows({ md: "", images: ["a.png"] }), true, "an image-only message shows its thumbnails");
+  assert.equal(userTurnShows({ md: "", images: [] }), false);
+});
+
+test("render.ts: the user branch returns a hidden zero-height unit BEFORE the rail dot when there is nothing to show", () => {
+  assert.match(RENDER, /import \{ userTurnShows \} from "\.\/user-turn-content";/);
+  const m = RENDER.match(/const kind = senderKind\(ev\);([\s\S]*?)turn\.appendChild\(dot\(romp \? "romp" : tagged \? "tag" : injected \? "ring" : "user"\)\);/);
+  assert.ok(m, "the user branch from the classifier to the rail dot");
+  const between = m![1];
+  assert.match(between, /if \(!userTurnShows\(ev\)\) \{\s*\n\s*const hid = el\("div", "turn turn-user turn-user-empty"\);\s*\n\s*hid\.style\.display = "none";\s*\n\s*return hid;\s*\n\s*\}/,
+               "nothing to show → a hidden unit, returned before any dot is appended");
+  // the guard precedes the turn element itself, so no dot, no follow-up header and no bubble are ever built for it
+  assert.ok(between.indexOf("if (!userTurnShows(ev))") < between.indexOf('const turn = el("div", "turn turn-user"'));
+  // the interrupt marker and the romp system notice keep their own marks (they return before this guard)
+  assert.match(RENDER, /if \(\(ev as any\)\.interruptMarker\) \{\s*\n\s*const turn = el\("div", "turn turn-interrupt"\);\s*\n\s*turn\.appendChild\(dot\("ring"\)\);/);
+  assert.match(RENDER, /if \(\(ev as any\)\.rompSystem && ev\.md\) \{/);
+});


### PR DESCRIPTION
## What

A blue user rail dot rendered with no message beside it (the user 2026-09-08). Read-only from the live chat frame for the reported session: between the kernel-restart notice and the next assistant text sits a user-kind event whose `md` is empty, and the same shape recurs later in the same transcript. Those are user records the kernel strips to nothing — romp's own markers, an injected reminder — and the user branch of `renderEventInner` appended `dot("user")` first and only then asked whether there was a bubble to draw (`if (ev.md || hasImgs)`). The dot went up; nothing followed.

**Fix.** A rail dot never stands alone. When a user event has neither text nor images, the branch returns a zero-height unit (the queued group's own idiom, so the scroll↔unit map still counts it) before any dot, header or bubble is built. The interrupt marker and the romp system notice return earlier with their own marks, unchanged. Decision in `ui/webview/user-turn-content.ts` so node executes it.

## Separate finding, not fixed here

The two gray cards below the restart notice in the report ("3 background tasks…", "Still watching…") are not the queued group and were not dropped or coalesced: the frame shows them as landed user events marked `absorbed` at the restart notice's second, i.e. they were delivered mid-turn as queued-command attachments (the transcript's `attachment` records; the queue's `remove` operations a minute later are those entries retiring). The later "1 background task" notice at 14:54 is a separate notice from a later cut, not a replacement.

## Tier

- [ ] tests-only
- [x] fix — a bug fix with a test that fails before it
- [ ] feature
- [ ] major-feature

## Tests

New `ui/webview/user-turn-empty.test.ts`: executes the decision (text or images show; empty or whitespace does not) and pins the guard's place between the sender classifier and the rail dot, plus the two earlier returns keeping their marks. The wiring pin is red on main. Suites: node 3402 passed (`npm test`, typecheck clean); the 28 Python modules that read the browser sources 886 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
