### PR TITLE
The usage hover says its click opens the full breakdown by session

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -40610,7 +40610,10 @@ return h;}
 // container's RIGHT edge, nowhere near a hover on the left end of a wide multi-account rail).
 function showTip(ev){var h=tipHTML();
 if(!h){tip.style.display='none';return;}
-tip.classList.remove('ru-modal');tip.innerHTML=h;
+// the compact level says there is more underneath (T247d, the user 2026-09-08): the click opens the
+// per-session breakdown — one footnote line in the hover's own footnote style; the phone panel has
+// its "By session" button instead (openIt), because a tap there opens nothing
+tip.classList.remove('ru-modal');tip.innerHTML=h+'<div class=ru-tip-hint>Click for the full breakdown by session.</div>';
 var r=el.getBoundingClientRect();tip.style.display='block';
 var x=(ev&&typeof ev.clientX==='number')?ev.clientX:(r.left+r.width/2);
 tip.style.left=Math.max(6,Math.min(window.innerWidth-tip.offsetWidth-6,x-tip.offsetWidth/2))+'px';
@@ -42690,6 +42693,7 @@ def _landing():
             # spend rows (no track span, the user 2026-08-08) read as one table.
             ".ru-tip-v{min-width:30px;text-align:right;font-variant-numeric:tabular-nums;margin-left:auto}"
             ".ru-tip-more{margin-top:8px;text-align:center}"   # the phone panel's door into the spend modal (T247b)
+            ".ru-tip-hint{margin-top:5px;opacity:.55;font-size:10px}"   # the hover's click affordance (T247d): the footnote's size and opacity, no rule line
             ".ru-tip-age{margin-top:7px;padding-top:5px;border-top:1px solid rgba(255,255,255,0.08);"
             "opacity:.55;font-size:10px}"
             # (The per-host .ru-set/.ru-host rail sets are gone, the user 2026-08-08: the collapsed rail

--- a/tests/spend_modal_headless.js
+++ b/tests/spend_modal_headless.js
@@ -13,6 +13,12 @@ const { chromium } = require('playwright');
   await pg.waitForSelector('#rail-usage', { timeout: 20000 });
   await pg.evaluate(() => { const bt = document.getElementById('romp-boot'); if (bt) bt.remove(); });
   await pg.waitForFunction(() => document.getElementById('rail-usage').children.length > 0, null, { timeout: 20000 });
+  // T247d: the desktop hover ends in the affordance line, and a screenshot of the tip
+  await pg.hover('#rail-usage');
+  await pg.waitForFunction(() => { const t = document.getElementById('ru-tip'); return t && t.style.display === 'block'; }, null, { timeout: 5000 });
+  const hoverHint = await pg.evaluate(() => { const t = document.getElementById('ru-tip'); const last = t.lastElementChild; return { text: last ? last.textContent : '', cls: last ? last.className : '', font: last ? getComputedStyle(last).fontSize : '', opacity: last ? getComputedStyle(last).opacity : '' }; });
+  if (shots) { const tipEl = await pg.$('#ru-tip'); if (tipEl) await tipEl.screenshot({ path: shots + '-hover.png' }); }
+  await pg.mouse.move(5, 400);
   const hiddenBefore = await pg.evaluate(() => document.getElementById('rsp-back').hidden);
   await pg.evaluate(() => document.getElementById('rail-usage').click());
   await pg.waitForFunction(() => !document.getElementById('rsp-back').hidden, null, { timeout: 5000 });
@@ -138,7 +144,8 @@ const { chromium } = require('playwright');
   await pg.waitForFunction(() => !document.getElementById('rsp-back').hidden && !document.getElementById('ru-back').classList.contains('on'), null, { timeout: 5000 });
   await pg.waitForSelector('#rsp-panel .rsp-tbl', { timeout: 10000 });
   if (shots) await pg.screenshot({ path: shots + '-phone.png' });
-  const mobile = { railHidden, panelOpened: true, modalOpened: true, btn };
-  console.log(JSON.stringify({ hiddenBefore, loaderSeen, out, days, tip, hiddenAfter, hiddenAfterTap, hiddenAfterDrag, lightErr, lightBtn, dim, timeout, mobile, foldBefore, foldAfter, errs }));
+  const panelHint = await pg.evaluate(() => document.getElementById('ru-tip').textContent.includes('Click for the full breakdown'));
+  const mobile = { railHidden, panelOpened: true, modalOpened: true, btn, panelHint };
+  console.log(JSON.stringify({ hoverHint, hiddenBefore, loaderSeen, out, days, tip, hiddenAfter, hiddenAfterTap, hiddenAfterDrag, lightErr, lightBtn, dim, timeout, mobile, foldBefore, foldAfter, errs }));
   await b.close();
 })().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/test_kernel_rail_usage.py
+++ b/tests/test_kernel_rail_usage.py
@@ -89,6 +89,21 @@ class RailUsage(unittest.TestCase):
         # and drops the old explanatory prose ("...rate-limit window") — no extra stuff
         self.assertNotIn("rate-limit window", self.html, "no explanatory prose, just the bars + %")
 
+    def test_the_desktop_hover_says_the_click_opens_the_full_breakdown(self):
+        # T247d (the user 2026-09-08): the readout's click opens the per-session spend modal, so the
+        # hover — the compact level — must say there is more underneath (progressive disclosure: never
+        # a dead end). One footnote line in the hover's own footnote style (.ru-tip-age size and
+        # opacity, no new font size), on the DESKTOP tip only: the phone panel has its "By session" button.
+        js = self.html.split('_LANDING_USAGE_JS')[0] if False else self.html
+        self.assertIn("Click for the full breakdown by session.", js)
+        self.assertIn("tip.classList.remove('ru-modal');tip.innerHTML=h+'<div class=ru-tip-hint>Click for the full breakdown by session.</div>';", js,
+                      "the desktop tip ends in the affordance line")
+        self.assertIn("tip.innerHTML=h+'<div class=ru-tip-more><button class=rsp-btn id=ru-bysession>", js,
+                      "the phone panel keeps its button and gets no click hint (a tap there opens nothing)")
+        self.assertEqual(js.count("Click for the full breakdown by session."), 1, "one place, the desktop tip")
+        self.assertIn(".ru-tip-hint{margin-top:5px;opacity:.55;font-size:10px}", js,
+                      "the footnote style: .ru-tip-age's size and opacity, without a second rule line")
+
     def test_the_spend_section_owns_its_age_and_never_speaks_for_rate_limits(self):
         # Pins from the 2026-08-24 spend-staleness screenshot — minus the telemetry note, which the
         # user later the same day had DELETED entirely (they know which machines are key-only; no

--- a/tests/test_spend_modal_headless.py
+++ b/tests/test_spend_modal_headless.py
@@ -124,6 +124,10 @@ class SpendModalServed(unittest.TestCase):
         self.assertEqual(r.returncode, 0, "the driver failed:\n" + r.stderr[-3000:])
         o = json.loads(r.stdout.strip().splitlines()[-1])
         self.assertTrue(o["hiddenBefore"], "closed until the click")
+        # T247d: the desktop hover ends in the affordance line, in the footnote style; the phone panel does not carry it
+        self.assertEqual(o["hoverHint"]["text"], "Click for the full breakdown by session.", o["hoverHint"])
+        self.assertEqual((o["hoverHint"]["cls"], o["hoverHint"]["font"], o["hoverHint"]["opacity"]), ("ru-tip-hint", "10px", "0.55"), o["hoverHint"])
+        self.assertIs(o["mobile"]["panelHint"], False, "the phone panel keeps its button and no click hint")
         self.assertTrue(o["loaderSeen"], "the loader (or the content) is up the instant the modal opens")
         self.assertEqual(o["out"]["backdrop"], "rgba(0, 0, 0, 0.55)", "the panel rule's backdrop")
         self.assertEqual(o["out"]["head"], "API spend · TESTHOST")


### PR DESCRIPTION
**Fix (T247d).** The usage readout's click opens the per-session spend modal, but the hover gave no sign there was more underneath. The user's ask (2026-09-08 morning PT): a little line at the bottom of the hover saying click for more.

- One footnote line on the desktop tip, in the hover's own footnote style (the age line's size and opacity, no new font size, no second rule line): "Click for the full breakdown by session."
- Desktop only: the phone panel keeps its "By session" button and gets no click hint, because a tap there opens nothing.
- Pinned in the landing-usage tests (the line, its one place, its style) and in the served test (the desktop tip's last child is the hint at 10px and 0.55 opacity; the phone panel carries none), which also screenshots the hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)