### PR TITLE
Every programmatic scroll write of the transcript is on the record: a client-diag breadcrumb per writer, and a marker for the user's own gestures

### DIFF
--- a/ui/webview/chat-older-restore.test.ts
+++ b/ui/webview/chat-older-restore.test.ts
@@ -69,7 +69,7 @@ test("scrollToAnchor restores a keep-offset instead of landing on it", () => {
   const branch = body.slice(at, body.indexOf('landTrail.push("pointer-exact")', at));   // the keep branch alone
   assert.match(branch, /landTrail\.push\("pointer-keep-offset"\)/,
     "the audit trail names the restore, so it is never mistaken for a click again");
-  assert.match(branch, /content\.scrollTop = yNow - keepY/,
+  assert.match(branch, /writeScroll\(content, yNow - keepY, "keep-offset"\)/,
     "the row comes back at its captured offset");
   assert.ok(!/landOn\(/.test(branch), "a restore must NOT top-align + flash the row like a jump");
   // …and the ordinary path still does land properly.

--- a/ui/webview/chat-windowing.test.ts
+++ b/ui/webview/chat-windowing.test.ts
@@ -65,7 +65,7 @@ test("scroll re-windows around the viewport (steady scroll OR jump) when near a 
   assert.match(RENDER, /const idx = unitAtScroll\(v, content\);/);
   assert.match(RENDER, /renderWindowItems\(v, s, items, Math\.max\(0, c - WINDOW_RADIUS\), Math\.min\(items\.length, c \+ WINDOW_RADIUS\), working\);/);
   // it re-anchors the focus unit so it doesn't jump, and shows a loading cue, coalesced to one frame
-  assert.match(RENDER, /content\.scrollTop = yNow - beforeY;/);
+  assert.match(RENDER, /writeScroll\(content, yNow - beforeY, "rewindow"\);/);   // (T262: every #content write rides writeScroll)
   assert.match(RENDER, /showLoadingPill\(\);/);
   assert.match(RENDER, /c\.addEventListener\("scroll", virtualizeToViewport, \{ passive: true \}\);/);
 });
@@ -102,7 +102,7 @@ test("a new message while scrolled UP keeps the viewport put (no backwards jump)
   // the view "backwards" when messages arrived (the user 2026-06-25).
   assert.match(RENDER, /const before = content\.scrollTop;/);
   assert.match(RENDER, /syncView\(activeId, stick\);/);
-  assert.match(RENDER, /else if \(!\(v && restoreScrollAnchor\(content, v, anchor\)\)\) content\.scrollTop = before;/);
+  assert.match(RENDER, /else if \(!\(v && restoreScrollAnchor\(content, v, anchor\)\)\) writeScroll\(content, before, "append-raw"\);/);
   // the compact branch keeps winStart on a scrolled-up append
   assert.match(RENDER, /const keepTop = wasAtTail && atBottom === false;/);
   assert.match(RENDER, /const ws = keepTop \? \(v\.winStart \?\? 0\)/);

--- a/ui/webview/jump-bottom.test.ts
+++ b/ui/webview/jump-bottom.test.ts
@@ -30,13 +30,13 @@ test("visibility reads the one nearBottom definition, off a passive scroll liste
 });
 
 test("click snaps to the bottom AND sets the view's stick — the explicit re-entry into follow mode", () => {
-  assert.match(RENDER, /c\.scrollTop = c\.scrollHeight;\s*\/\/ the snap IS the acknowledgment/);
+  assert.match(RENDER, /writeScroll\(c, c\.scrollHeight, "jump-button", true\);\s*\/\/ the snap IS the acknowledgment/);   // (T262: every #content write rides writeScroll)
   assert.match(RENDER, /if \(v\) \{ v\.stick = true; v\.scrollTop = c\.scrollTop; \}/);
 });
 
 test("the send gate stays byte-intact — the chip is the sanctioned mover, sends are not", () => {
   // T187's contract, cross-pinned from this feature so a regression here names both
-  assert.match(RENDER, /const wasAtBottom = !!content && nearBottom\(content\);\s*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) content\.scrollTop = content\.scrollHeight;/);
+  assert.match(RENDER, /const wasAtBottom = !!content && nearBottom\(content\);\s*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) writeScroll\(content, content\.scrollHeight, "optimistic-send", true\);/);
 });
 
 test("the chip wears the menu-card vocabulary and survives [hidden] against its own display:flex", () => {

--- a/ui/webview/optimistic-send.test.ts
+++ b/ui/webview/optimistic-send.test.ts
@@ -45,9 +45,9 @@ test("your OWN send reveals itself from the TAIL only — scrolled up, the viewp
   // is gated on a nearBottom read taken BEFORE appendActive lands the bubble (the append grows
   // scrollHeight, which would misread a tail-sitter as scrolled-up). Behavioral scenarios live in
   // send-scroll-preserve.test.ts.
-  assert.match(RENDER, /const wasAtBottom = !!content && nearBottom\(content\);\s*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) content\.scrollTop = content\.scrollHeight;/);
+  assert.match(RENDER, /const wasAtBottom = !!content && nearBottom\(content\);\s*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) writeScroll\(content, content\.scrollHeight, "optimistic-send", true\);/);
   // the unconditional form is retired everywhere — nothing snaps a scrolled-up reader on send
-  assert.doesNotMatch(RENDER, /if \(content\) content\.scrollTop = content\.scrollHeight;/);
+  assert.doesNotMatch(RENDER, /if \(content\) (?:content\.scrollTop = content\.scrollHeight|writeScroll\(content, content\.scrollHeight)/);
 });
 
 // The reconcile's two IN-PLACE tail mutations — merging into an existing queued group (a busy session

--- a/ui/webview/render-scroll.test.ts
+++ b/ui/webview/render-scroll.test.ts
@@ -67,7 +67,7 @@ test("appendActive snaps only when the user is already near the bottom of OVERFL
   // the slack rule (the user 2026-08-25): while nothing overflows, nearBottom is trivially true —
   // ungated, the very append crossing the overflow boundary yanked the view; now streaming into
   // slack writes in place and grows the scrollbar, and the stick engages only once overflowing
-  assert.match(RENDER, /const stick = content\.scrollHeight > content\.clientHeight \+ 2 && nearBottom\(content\);[\s\S]*?if \(stick\) content\.scrollTop = content\.scrollHeight/,
+  assert.match(RENDER, /const stick = content\.scrollHeight > content\.clientHeight \+ 2 && nearBottom\(content\);[\s\S]*?if \(stick\) writeScroll\(content, content\.scrollHeight, "append-stick", true\)/,
     "tail-append follows the live edge only if content overflows AND the reader was at the bottom");
   // the popover's thread list speaks the same rule
   assert.match(RENDER, /const overflowed = list\.scrollHeight > list\.clientHeight \+ 2;/);
@@ -83,13 +83,13 @@ test("a scrolled-up append restores by turn ANCHOR (data-uuid), raw scrollTop on
   const fn = RENDER.slice(RENDER.indexOf("function appendActive"), RENDER.indexOf("window.addEventListener(\"resize\", scheduleRestamp)"));
   assert.match(fn, /const anchor = !stick && v \? captureScrollAnchor\(content, v\) : null;/,
     "the anchor is captured BEFORE the rebuild, only when scrolled up");
-  assert.match(fn, /else if \(!\(v && restoreScrollAnchor\(content, v, anchor\)\)\) content\.scrollTop = before;/,
+  assert.match(fn, /else if \(!\(v && restoreScrollAnchor\(content, v, anchor\)\)\) writeScroll\(content, before, "append-raw"\);/,
     "anchor-relative restore first; the raw pixel offset only when the anchor was evicted");
   assert.match(RENDER, /function captureScrollAnchor\(content: HTMLElement, v: View\)/);
   assert.match(RENDER, /r\.bottom > cTop \+ 1/, "the anchor is the first turn still visible at the viewport top");
   assert.match(RENDER, /querySelector\(`\[data-uuid="\$\{cssEscape\(a\.uuid\)\}"\]`\)/,
     "the anchor re-resolves by its stable uuid after the rebuild");
-  assert.match(RENDER, /content\.scrollTop = yNow - a\.y;/, "the anchor turn keeps its exact on-screen offset");
+  assert.match(RENDER, /writeScroll\(content, yNow - a\.y, "anchor-restore"\);/, "the anchor turn keeps its exact on-screen offset");
 });
 
 // BY-ID landing only — NO time-based fallback anywhere (the user 2026-06-20, who wanted to shrink the 29%, then remove
@@ -199,7 +199,7 @@ test("ResizeObservers on #tabbar AND #ledger compensate #content.scrollTop by th
   // shift scrollTop by (new - old) box height — only when not stuck to bottom and the pane is visible
   assert.match(RENDER, /content\.clientHeight > 0 && !nearBottom\(content\)/,
     "skipped when stuck to the bottom or the pane is hidden");
-  assert.match(RENDER, /content\.scrollTop \+= h - lastH/, "compensates by the exact height delta");
+  assert.match(RENDER, /writeScroll\(content, content\.scrollTop \+ \(h - lastH\), "box-resize"\)/, "compensates by the exact height delta");
   assert.match(RENDER, /if \(v\) v\.scrollTop = content\.scrollTop/, "keeps the per-view saved scroll in sync");
 });
 
@@ -209,5 +209,5 @@ test("a focus with `live` lands on the live tail — a blocked card's picker/per
   // cover the ALREADY-ACTIVE case, where setActive early-returns (activeId === id, no anchor) → jump to
   // bottom ONE FRAME later (the user 2026-08-13): when this focus is what un-hid a closed pane, the
   // synchronous scroll ran at display:none (scrollHeight 0) and the jump read as a no-op
-  assert.match(RENDER, /if \(m\.live && activeId === m\.id\) \{[\s\S]{0,700}?window\.requestAnimationFrame\(\(\) => \{\s*\n\s*const c = document\.getElementById\("content"\); if \(c\) c\.scrollTop = c\.scrollHeight;/);
+  assert.match(RENDER, /if \(m\.live && activeId === m\.id\) \{[\s\S]{0,700}?window\.requestAnimationFrame\(\(\) => \{\s*\n\s*const c = document\.getElementById\("content"\); if \(c\) writeScroll\(c, c\.scrollHeight, "focus-live", true\);/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -57,6 +57,7 @@ import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDown
 import { followReader, keepPlaceAcrossShow } from "./scroll-keep";
 import { retainLiveOmitted } from "./tab-order";
 import { userTurnShows } from "./user-turn-content";
+import { ScrollDiagBudget, classifyScroll, scrollWriteRow } from "./scroll-write";
 import { keepResidentEvents } from "./frame-merge";
 import { activeTabToReannounce } from "./relay-active";
 import { dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
@@ -462,7 +463,7 @@ function registerOptimistic(id: string, text: string, imgPaths?: string[]): void
     const content = document.getElementById("content");
     const wasAtBottom = !!content && nearBottom(content);
     appendActive();
-    if (content && wasAtBottom) content.scrollTop = content.scrollHeight;
+    if (content && wasAtBottom) writeScroll(content, content.scrollHeight, "optimistic-send", true);
   }
 }
 
@@ -9166,6 +9167,31 @@ function nearBottom(c: HTMLElement): boolean {
   return c.scrollHeight - c.scrollTop - c.clientHeight < 80;
 }
 
+// EVERY programmatic write to #content.scrollTop goes through here (T262, the user 2026-09-08, whose view "jumps
+// up slightly on my scroll" on a page whose bundle state nobody could see): a write that moved the view files one
+// client-diag row naming its writer (before, after, delta, whether it was a follow-to-bottom), and the scroll
+// listener below files a "scrollgesture" row for every scroll these writes do not explain, so a recording's
+// timestamps match the laptop's client-diag.jsonl and the next occurrence is convictable. Capped per session per
+// minute per kind (scroll-write.ts), one "capped" row at the cap; no stack traces; a write that did not move the
+// view files nothing. The value written is applied exactly as before: this changes nothing about WHERE the view
+// lands, only that the landing is on the record.
+let lastScrollWriteAfter: number | null = null;
+const scrollDiag = new ScrollDiagBudget();
+function scrollDiagRow(kind: "scrollwrite" | "scrollgesture", data: any): void {
+  const v = scrollDiag.take(activeId || "", kind, Date.now());
+  if (v === "drop") return;
+  vscodeApi?.postMessage(v === "cap"
+    ? { type: "clientDiag", surface: "chat", what: kind + "-capped", data: { sid: activeId || "", perMinute: 40 } }
+    : { type: "clientDiag", surface: "chat", what: kind, data });
+}
+function writeScroll(content: HTMLElement, top: number, writer: string, stick = false): void {
+  const before = content.scrollTop;
+  content.scrollTop = top;
+  const after = content.scrollTop;
+  lastScrollWriteAfter = after;
+  if (after !== before) scrollDiagRow("scrollwrite", scrollWriteRow(activeId || "", writer, before, after, stick));
+}
+
 function cssEscape(s: string): string {
   return typeof (window as any).CSS?.escape === "function" ? CSS.escape(s) : s.replace(/["\\]/g, "\\$&");
 }
@@ -9270,7 +9296,7 @@ function scrollToAnchor(uuid: string): boolean {
     const content = document.getElementById("content");
     if (content) {
       const yNow = target.getBoundingClientRect().top - content.getBoundingClientRect().top + content.scrollTop;
-      content.scrollTop = yNow - keepY;
+      writeScroll(content, yNow - keepY, "keep-offset");
     }
     return true;
   }
@@ -9841,7 +9867,7 @@ function toggleToolGroup(key: string): void {
   // the expand/collapse changes the DOM without changing the event set, so mark the view stale to force
   // the compact rebuild past the cache guard (a plain tab switch leaves stale false → reuses the cache).
   if (activeId) { const v = views.get(activeId); if (v) v.stale = true; syncView(activeId); }
-  if (content) content.scrollTop = top;
+  if (content) writeScroll(content, top, "toolgroup-toggle");
   refillOpenCommentPop();   // the popover renders the same units — its copy of this run must flip too
   scheduleRailSticky();
 }
@@ -10229,8 +10255,8 @@ function landActive(content: HTMLElement | null, v: View): void {
     }
   }
   if (!scrolled) {
-    if (!v.shown || v.stick) content.scrollTop = content.scrollHeight;
-    else content.scrollTop = v.scrollTop;
+    if (!v.shown || v.stick) writeScroll(content, content.scrollHeight, "land-bottom", true);
+    else writeScroll(content, v.scrollTop, "land-saved");
   }
   v.shown = true;
   scheduleRailSticky();
@@ -10264,7 +10290,7 @@ function restoreScrollAnchor(content: HTMLElement, v: View, a: { uuid: string; y
   const el = v.el.querySelector(`[data-uuid="${cssEscape(a.uuid)}"]`) as HTMLElement | null;
   if (!el) return false;
   const yNow = el.getBoundingClientRect().top - content.getBoundingClientRect().top + content.scrollTop;
-  content.scrollTop = yNow - a.y;              // the anchor turn keeps its exact on-screen offset
+  writeScroll(content, yNow - a.y, "anchor-restore");   // the anchor turn keeps its exact on-screen offset
   return true;
 }
 
@@ -10311,8 +10337,8 @@ function appendActive() {
   syncView(activeId, stick);
   syncHostOfflineFoot();                 // before the scroll maths: it changes scrollHeight
   updateStatusline();
-  if (stick) content.scrollTop = content.scrollHeight;
-  else if (!(v && restoreScrollAnchor(content, v, anchor))) content.scrollTop = before;
+  if (stick) writeScroll(content, content.scrollHeight, "append-stick", true);
+  else if (!(v && restoreScrollAnchor(content, v, anchor))) writeScroll(content, before, "append-raw");
   scheduleRailSticky();
   updateJumpBtn();   // appends can cross the overflow boundary either way — re-read the chip's truth
 }
@@ -10364,7 +10390,7 @@ function updateJumpBtn(): void {
 jumpBtn.onclick = () => {
   const c = document.getElementById("content");
   if (!c) return;
-  c.scrollTop = c.scrollHeight;                       // the snap IS the acknowledgment
+  writeScroll(c, c.scrollHeight, "jump-button", true);   // the snap IS the acknowledgment
   const v = activeId ? views.get(activeId) : undefined;
   if (v) { v.stick = true; v.scrollTop = c.scrollTop; }   // the explicit re-entry into follow mode
   updateJumpBtn();                                    // at the bottom now — the chip hides itself
@@ -10398,6 +10424,10 @@ window.addEventListener("resize", updateJumpBtn);
   if (c) c.addEventListener("scroll", () => {
     if (c.clientHeight <= 0) return;
     followReader(activeId ? views.get(activeId) : null, c.scrollTop, nearBottom(c), pendingBuildRaf != null);
+    // the scroll nobody's code asked for is the user's (T262): filed so a recording lines up with the journal;
+    // a write's own echo (within a pixel of the value written) is consumed here and never read as a gesture
+    if (classifyScroll(c.scrollTop, lastScrollWriteAfter) === "write-echo") lastScrollWriteAfter = null;
+    else scrollDiagRow("scrollgesture", { sid: activeId || "", top: c.scrollTop, gesture: true });
   }, { passive: true });
 }
 // Boxes ABOVE the transcript grow/shrink → keep the chat text visually anchored (the user 2026-06-30 for
@@ -10417,7 +10447,7 @@ if (typeof ResizeObserver === "function") {
       const h = entries[0]?.contentRect?.height ?? 0;
       const content = document.getElementById("content");
       if (content && lastH >= 0 && h !== lastH && content.clientHeight > 0 && !nearBottom(content)) {
-        content.scrollTop += h - lastH;
+        writeScroll(content, content.scrollTop + (h - lastH), "box-resize");
         const v = activeId ? views.get(activeId) : null;
         if (v) v.scrollTop = content.scrollTop;               // keep the per-view saved position in sync
       }
@@ -10461,7 +10491,7 @@ if (typeof ResizeObserver === "function") {
       // growing the bar shrinks #content, which would push a tail-following view off the tail one
       // sub-threshold step at a time — if it was at the tail when the drag began, keep it there
       const content = document.getElementById("content");
-      if (stick && content) content.scrollTop = content.scrollHeight;
+      if (stick && content) writeScroll(content, content.scrollHeight, "tabbar-drag", true);
     };
     const onUp = () => {
       if (!dragging) return;
@@ -10554,7 +10584,7 @@ function virtualizeToViewport(): void {
       const anchor = v.el.querySelector(`[data-unit="${c}"]`) as HTMLElement | null;
       if (anchor) {
         const yNow = anchor.getBoundingClientRect().top - content.getBoundingClientRect().top + content.scrollTop;
-        content.scrollTop = yNow - beforeY;
+        writeScroll(content, yNow - beforeY, "rewindow");
       }
       if (activeId) applyCommentMarks(activeId);   // the re-window rebuilt turns — re-anchor highlights
       scheduleRailSticky();
@@ -11246,7 +11276,7 @@ function renderLiveAsk() {
   // Reveal the picker if the user is parked at the bottom — it's part of the scroll flow now, so new/taller
   // pickers would otherwise land below the fold. Never yank a user who has scrolled UP to read context.
   const v = activeId ? views.get(activeId) : undefined;
-  if (content && (!v || v.stick)) content.scrollTop = content.scrollHeight;
+  if (content && (!v || v.stick)) writeScroll(content, content.scrollHeight, "liveask-reveal", true);
 }
 
 // The focused option's side-by-side preview box, reproduced VERBATIM in a monospace block (the user
@@ -13237,7 +13267,7 @@ const navHist = new NavHistory({
     if (v) { v.scrollTop = spot.top; v.stick = false; }   // land on the remembered spot, never the live bottom
     setActive(spot.sid);
     const c = document.getElementById("content");
-    if (c) whenChatVisible(() => { if (activeId === spot.sid) c.scrollTop = spot.top; });
+    if (c) whenChatVisible(() => { if (activeId === spot.sid) writeScroll(c, spot.top, "nav-history"); });
   },
 });
 
@@ -13972,7 +14002,7 @@ window.addEventListener("message", perfFrameHandler("chat", (m) => vscodeApi?.po
       // pane was already visible the deferral is invisible. Anchored jumps need nothing: landOn's
       // ResizeObserver realign already re-lands them when the pane sizes in.
       window.requestAnimationFrame(() => {
-        const c = document.getElementById("content"); if (c) c.scrollTop = c.scrollHeight;
+        const c = document.getElementById("content"); if (c) writeScroll(c, c.scrollHeight, "focus-live", true);
       });
     } else {
       pendingAnchorQuote = typeof (m as { anchorQuote?: string }).anchorQuote === "string" ? (m as { anchorQuote?: string }).anchorQuote! : null;   // the supporting span (T218) — consumed by the landing

--- a/ui/webview/reveal-unhide.test.ts
+++ b/ui/webview/reveal-unhide.test.ts
@@ -12,6 +12,6 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 
 test("focus reveals the pane first, and the live-tail scroll waits one frame for real layout", () => {
   assert.match(RENDER, /revealSelfPane\(\);\s+\/\/ every focus is someone jumping HERE/);
-  assert.match(RENDER, /window\.requestAnimationFrame\(\(\) => \{\s*\n\s*const c = document\.getElementById\("content"\); if \(c\) c\.scrollTop = c\.scrollHeight;\s*\n\s*\}\);/,
+  assert.match(RENDER, /window\.requestAnimationFrame\(\(\) => \{\s*\n\s*const c = document\.getElementById\("content"\); if \(c\) writeScroll\(c, c\.scrollHeight, "focus-live", true\);\s*\n\s*\}\);/,
     "one frame later, not now — the un-hide lands a task after the postMessage");
 });

--- a/ui/webview/scroll-keep-on-show.test.ts
+++ b/ui/webview/scroll-keep-on-show.test.ts
@@ -79,9 +79,9 @@ test("render.ts: the reshow decision counts a live durable seek for the tab as n
 test("render.ts: the #content scroll listener keeps the active view's saved spot current (passive, no timer)", () => {
   assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow \} from "\.\/scroll-keep";/);
   // …and stands down while a deferred build is pending: the reveal's clamp fires a scroll event before the land
-  assert.match(RENDER, /c\.addEventListener\("scroll", \(\) => \{\n\s*if \(c\.clientHeight <= 0\) return;\n\s*followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, nearBottom\(c\), pendingBuildRaf != null\);\n\s*\}, \{ passive: true \}\);/);
+  assert.match(RENDER, /c\.addEventListener\("scroll", \(\) => \{\n\s*if \(c\.clientHeight <= 0\) return;\n\s*followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, nearBottom\(c\), pendingBuildRaf != null\);\n(?:.*\n){0,4}?\s*\}, \{ passive: true \}\);/);
   // landActive's landing rule itself is unchanged — its INPUT is what the fix repairs
-  assert.match(RENDER, /if \(!v\.shown \|\| v\.stick\) content\.scrollTop = content\.scrollHeight;\n\s*else content\.scrollTop = v\.scrollTop;/);
+  assert.match(RENDER, /if \(!v\.shown \|\| v\.stick\) writeScroll\(content, content\.scrollHeight, "land-bottom", true\);\n\s*else writeScroll\(content, v\.scrollTop, "land-saved"\);/);   // (T262: every #content write rides writeScroll)
 });
 
 test("render.ts: showActive keeps the reader's place across a re-show of the view already on screen, on both build paths", () => {

--- a/ui/webview/scroll-write.test.ts
+++ b/ui/webview/scroll-write.test.ts
@@ -1,0 +1,56 @@
+// T262 (the user 2026-09-08): a view that "jumps up slightly on my scroll", on a page whose bundle state nobody can
+// see. Every programmatic write to #content.scrollTop rides ONE helper (render.ts writeScroll) that files a
+// client-diag breadcrumb naming its writer, and the scroll listener files a gesture marker for every scroll the
+// writes do not explain — so the next occurrence is convictable from the laptop's client-diag.jsonl. Executed
+// budget + classifier + row shape; render.ts pins: the helper, every writer name, and NO raw write left. Red on main.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { ScrollDiagBudget, classifyScroll, scrollWriteRow, SCROLL_DIAG_CAP_PER_MINUTE } from "./scroll-write";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const SID = "TESTHOST:11111111-2222-4333-8444-000000000262";
+
+test("the budget sends up to the cap per session per minute, says 'cap' once, drops the rest, and rolls with the minute", () => {
+  const b = new ScrollDiagBudget(3);
+  const t0 = 1_700_000_000_000;
+  assert.deepEqual([b.take(SID, "scrollwrite", t0), b.take(SID, "scrollwrite", t0 + 10), b.take(SID, "scrollwrite", t0 + 20)], ["send", "send", "send"]);
+  assert.equal(b.take(SID, "scrollwrite", t0 + 30), "cap", "the (cap+1)th files one capped row");
+  assert.equal(b.take(SID, "scrollwrite", t0 + 40), "drop");
+  assert.equal(b.take(SID, "scrollgesture", t0 + 40), "send", "kinds are budgeted apart");
+  assert.equal(b.take("other", "scrollwrite", t0 + 40), "send", "sessions are budgeted apart");
+  assert.equal(b.take(SID, "scrollwrite", t0 + 60_000), "send", "the next minute starts fresh");
+  assert.equal(SCROLL_DIAG_CAP_PER_MINUTE, 40);
+});
+
+test("a scroll event within a pixel of the last programmatic write is its echo; anything else is a gesture", () => {
+  assert.equal(classifyScroll(1200, 1200), "write-echo");
+  assert.equal(classifyScroll(1200.5, 1200), "write-echo", "sub-pixel rounding");
+  assert.equal(classifyScroll(1230, 1200), "gesture");
+  assert.equal(classifyScroll(1200, null), "gesture", "no write pending: the user did it");
+});
+
+test("the row names the writer and carries before/after/delta/stick, gesture:false", () => {
+  assert.deepEqual(scrollWriteRow(SID, "append-stick", 100, 340, true),
+                   { sid: SID, writer: "append-stick", before: 100, after: 340, delta: 240, stick: true, gesture: false });
+});
+
+test("render.ts: one helper writes #content.scrollTop, files the row only when the view moved, and no raw write remains", () => {
+  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow \} from "\.\/scroll-write";/);
+  assert.match(RENDER, /function writeScroll\(content: HTMLElement, top: number, writer: string, stick = false\): void \{\s*\n\s*const before = content\.scrollTop;\s*\n\s*content\.scrollTop = top;\s*\n\s*const after = content\.scrollTop;\s*\n\s*lastScrollWriteAfter = after;\s*\n\s*if \(after !== before\) scrollDiagRow\("scrollwrite", scrollWriteRow\(activeId \|\| "", writer, before, after, stick\)\);/);
+  // the breadcrumb rides the existing clientDiag path, capped, with one capped row at the cap
+  assert.match(RENDER, /\{ type: "clientDiag", surface: "chat", what: kind \+ "-capped", data: \{ sid: activeId \|\| "", perMinute: 40 \} \}/);
+  assert.match(RENDER, /\{ type: "clientDiag", surface: "chat", what: kind, data \}/);
+  // every writer is named
+  for (const w of ["optimistic-send", "keep-offset", "toolgroup-toggle", "land-bottom", "land-saved", "anchor-restore",
+                   "append-stick", "append-raw", "jump-button", "box-resize", "tabbar-drag", "rewindow", "liveask-reveal",
+                   "nav-history", "focus-live"]) {
+    assert.match(RENDER, new RegExp('writeScroll\\((?:content|c), [^;]*"' + w + '"'), "writer " + w + " goes through the helper");
+  }
+  // no raw #content write outside the helper (menus, the editor box and the per-view bookkeeping are not the transcript)
+  const raw = RENDER.split("\n").filter((l) => /\b(content|c)\.scrollTop (=|\+=|-=) /.test(l) && !/writeScroll|const |let /.test(l));
+  assert.deepEqual(raw.map((l) => l.trim()), ["content.scrollTop = top;"], "the only assignment is the helper's own");
+  // the gesture marker: a write's echo is consumed, anything else files a gesture row
+  assert.match(RENDER, /if \(classifyScroll\(c\.scrollTop, lastScrollWriteAfter\) === "write-echo"\) lastScrollWriteAfter = null;\s*\n\s*else scrollDiagRow\("scrollgesture", \{ sid: activeId \|\| "", top: c\.scrollTop, gesture: true \}\);/);
+});

--- a/ui/webview/scroll-write.ts
+++ b/ui/webview/scroll-write.ts
@@ -1,0 +1,41 @@
+// Instrumenting every programmatic scroll write of the chat transcript (T262, the user 2026-09-08: the view
+// "jumps up slightly on my scroll in many, many sessions", on a page whose bundle state is unknown). A recording
+// alone cannot say WHICH writer moved the view; the laptop's client-diag journal can, once every write to
+// #content.scrollTop rides one helper that files a breadcrumb — {surface:"chat", what:"scrollwrite",
+// data:{sid, writer, before, after, delta, stick, gesture:false}} — and every scroll the writes do not explain
+// files a "scrollgesture" marker, so the recording's timestamps line up against the journal.
+//
+// Cheap by construction: no stack traces, one row per write that actually moved the view, a per-session
+// per-minute cap for each row kind (a following tail writes the bottom on every append; a wheel scroll fires
+// dozens of gesture events a second), with one "capped" row at the cap so a silence in the journal is never
+// mistaken for a quiet pane. The minute is the wall clock's minute bucket — a bound on volume, not a timer
+// that decides behaviour. Pure and DOM-free so node --test executes it.
+
+export const SCROLL_DIAG_CAP_PER_MINUTE = 40;
+
+/** One kind of row's budget for one session within the current minute: "send" while under the cap, "cap"
+ *  exactly once at the cap (the caller files a capped row), "drop" past it until the minute rolls. */
+export class ScrollDiagBudget {
+  private counts = new Map<string, { minute: number; n: number }>();
+  constructor(private cap = SCROLL_DIAG_CAP_PER_MINUTE) {}
+  take(sid: string, kind: string, nowMs: number): "send" | "cap" | "drop" {
+    const minute = Math.floor(nowMs / 60000);
+    const key = sid + " " + kind;
+    let e = this.counts.get(key);
+    if (!e || e.minute !== minute) { e = { minute, n: 0 }; this.counts.set(key, e); }
+    e.n += 1;
+    if (e.n <= this.cap) return "send";
+    return e.n === this.cap + 1 ? "cap" : "drop";
+  }
+}
+
+/** Is this #content scroll event the echo of the last programmatic write (its own scroll event, within a
+ *  pixel of the value written), or a gesture nobody's code asked for? */
+export function classifyScroll(scrollTop: number, lastWriteAfter: number | null): "write-echo" | "gesture" {
+  return lastWriteAfter != null && Math.abs(scrollTop - lastWriteAfter) <= 1 ? "write-echo" : "gesture";
+}
+
+/** The breadcrumb for one write that moved the view. */
+export function scrollWriteRow(sid: string, writer: string, before: number, after: number, stick: boolean) {
+  return { sid, writer, before, after, delta: after - before, stick, gesture: false as const };
+}

--- a/ui/webview/send-scroll-preserve.test.ts
+++ b/ui/webview/send-scroll-preserve.test.ts
@@ -65,7 +65,7 @@ test("a send that first overflows the pane still reveals itself — nearBottom i
 // ── source pins: the replica models the real code ─────────────────────────────────────────────────
 
 test("registerOptimistic gates the snap on a pre-append nearBottom read", () => {
-  assert.match(RENDER, /const wasAtBottom = !!content && nearBottom\(content\);\s*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) content\.scrollTop = content\.scrollHeight;/);
+  assert.match(RENDER, /const wasAtBottom = !!content && nearBottom\(content\);\s*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) writeScroll\(content, content\.scrollHeight, "optimistic-send", true\);/);
   // nearBottom's 80px threshold — the replica's constant
   assert.match(RENDER, /function nearBottom\(c: HTMLElement\): boolean \{\s*\n\s*return c\.scrollHeight - c\.scrollTop - c\.clientHeight < 80;/);
   // appendActive's stick rule — overflow gate + nearBottom, restore otherwise

--- a/ui/webview/tabbar-resize.test.ts
+++ b/ui/webview/tabbar-resize.test.ts
@@ -81,7 +81,7 @@ test("dragging moves the EFFECTIVE cap, guarded and captured, persists on releas
   assert.match(fn, /cap = clampTabbarH\(startH \+ \(e\.clientY - startY\), window\.innerHeight\);/,
     "drag DOWN grows — the cap follows the pointer");
   assert.match(fn, /stick = !!content && nearBottom\(content\);/, "a tail-following transcript is noted at drag start…");
-  assert.match(fn, /if \(stick && content\) content\.scrollTop = content\.scrollHeight;/,
+  assert.match(fn, /if \(stick && content\) writeScroll\(content, content\.scrollHeight, "tabbar-drag", true\);/,
     "…and held on the tail while the bar grows over it");
   assert.match(fn, /if \(cap != null\) localStorage\.setItem\(TABBAR_H_KEY, String\(cap\)\);/,
     "persisted on release, not per-move");

--- a/vscode-extension/src/picker-inline.test.ts
+++ b/vscode-extension/src/picker-inline.test.ts
@@ -27,7 +27,7 @@ test("renderLiveAsk keeps the picker last and reveals it when the user is parked
   assert.match(SRC, /if \(content && host\.parentNode === content && host !== content\.lastChild\) content\.appendChild\(host\)/);
   // scroll the transcript to the bottom to reveal the picker — only when stuck to the bottom (never yank a
   // user scrolled up reading context)
-  assert.match(SRC, /const v = activeId \? views\.get\(activeId\) : undefined;\s*\n\s*if \(content && \(!v \|\| v\.stick\)\) content\.scrollTop = content\.scrollHeight;/);
+  assert.match(SRC, /const v = activeId \? views\.get\(activeId\) : undefined;\s*\n\s*if \(content && \(!v \|\| v\.stick\)\) writeScroll\(content, content\.scrollHeight, "liveask-reveal", true\);/);
 });
 
 test("#live-ask is no longer a fixed 42vh mini-region — it flows in the scroll", () => {


### PR DESCRIPTION
## What

Instrumentation for the scroll snap the user still sees on the current bundle ("jumps up slightly on my scroll", 2026-09-08). A recording alone cannot say which writer moved the view; the laptop's client-diag journal can, once every programmatic write to the transcript's scroll position is on the record.

- **One helper for every write.** Every `#content.scrollTop` assignment in render.ts (fifteen sites: the land at the bottom and at the saved spot, the append's follow and raw fallback, the anchor restore, the keep-offset land, the re-window, the jump chip, the tabbar/ledger box compensation, the tabbar drag, the picker reveal, the optimistic send, the nav trail, the live focus, the tool-group toggle) now goes through `writeScroll(content, top, writer, stick)`. It applies the value exactly as before and, when the view actually moved, files `{type:"clientDiag", surface:"chat", what:"scrollwrite", data:{sid, writer, before, after, delta, stick, gesture:false}}` through the existing client-diag path.
- **A gesture marker.** The `#content` scroll listener classifies each scroll event: within a pixel of the last programmatic write it is that write's echo (consumed); anything else is the user's and files `{what:"scrollgesture", data:{sid, top, gesture:true}}`, so a recording's timestamps line up against the journal.
- **Cheap and bounded.** No stack traces. Each row kind is capped per session per minute (40), with one `-capped` row at the cap so a silent minute is never mistaken for a quiet pane. Pure bookkeeping in `ui/webview/scroll-write.ts`.

Nothing about where the view lands changes; this PR makes the next occurrence convictable from `client-diag.jsonl` (`what: scrollwrite` rows name the writer and the delta right before the user's `scrollgesture` rows).

## Tier

- [ ] tests-only
- [x] fix — a bug fix with a test that fails before it
- [ ] feature
- [ ] major-feature

## Tests

New `ui/webview/scroll-write.test.ts`: executes the per-minute budget (send, one cap row, drop, roll with the minute; kinds and sessions budgeted apart), the echo-versus-gesture classifier and the row shape; pins that render.ts imports the helper, that the helper writes and files only on a moved view, that every named writer goes through it, that NO raw `scrollTop` assignment on the transcript remains, and that the listener consumes echoes and files gestures. The render.ts pin is red on main. Fifteen existing pins on the old raw writes follow the helper. Suites: node 3414 passed (`npm test`, typecheck clean); the Python modules that read the browser sources are running and their result follows in a comment if anything differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
