### PR TITLE
romp tag repeats the kernel's refusal instead of calling it unreachable

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -1689,13 +1689,61 @@ if [[ "${1:-}" == "tag" || "${1:-}" == "group" ]]; then
         echo "romp tag: the kernel isn't running (no serve token). Start romp (the login service, or \`romp up\`) first." >&2
         exit 1
     fi
-    if [[ -z "$_gr_name" ]]; then
-        _resp="$(_romp_token_cfg | curl -sf -m 10 --config - "http://127.0.0.1:$_kport/views")" \
-            || { echo "romp tag: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
-        if $_gr_json; then
-            printf '%s\n' "$_resp"
-            exit 0
+    # One GET of the kernel's tag store: the body on stdout and 0 when the kernel answered 2xx.
+    # Never `curl -sf` here: -f folds EVERY non-2xx into the exit a dead kernel gets and throws the
+    # body away, so a kernel that ANSWERED — a 503 with {ok:false, retryable, error} while the store
+    # cannot be read (a polling peer needs the non-200 to keep its last reading), a 403 for a token
+    # it does not hold — read as "not reachable", and the person was told to restart a kernel that
+    # was up and explaining itself. The status rides -w and is read here, the way `romp perf` reads
+    # its own: a connection failure (curl's own nonzero exit, no status) keeps the "not reachable"
+    # line; a non-2xx whose JSON body carries `error` prints the kernel's words (plus "retry" when
+    # the body says the fault is retryable and the text does not already say so); a refused token
+    # is named as such; anything else prints the status and whatever came with it, never a guess.
+    # Exit 1 on every refusal, as the POST refusal below exits. With `json`, a JSON refusal body
+    # is printed as is on stdout — the same answer a script reads on a 2xx, now saying ok:false and
+    # why, so it needs no second parser — and only a non-JSON answer is said as prose on stderr.
+    _tag_views() {   # _tag_views [json]: GET /views; the 2xx body on stdout, or the failure said and 1
+        local _out _code _body _line _rc
+        _out="$(_romp_token_cfg | curl -s -m 10 --config - -w '\n%{http_code}' "http://127.0.0.1:$_kport/views")" \
+            || { echo "romp tag: kernel not reachable on :$_kport (is romp running?)" >&2; return 1; }
+        _code="${_out##*$'\n'}"
+        _body="${_out%$'\n'*}"
+        case "$_code" in
+            2??) if [[ "${1:-}" == json ]]; then printf '%s\n' "$_body"; else printf '%s' "$_body"; fi; return 0 ;;
+        esac
+        # exits 0 with the line to say for a JSON object carrying `error`; 3 for JSON without one; 1 for a body that is not JSON
+        _line="$(python3 -c '
+import json, sys
+try:
+    v = json.loads(sys.argv[1])
+except Exception:
+    sys.exit(1)
+e = v.get("error") if isinstance(v, dict) else None
+if not e:
+    sys.exit(3)
+e = str(e)
+if v.get("retryable") and "retry" not in e.lower():
+    e += " \u2014 retry"
+print(e)
+' "$_body" 2>/dev/null)" && _rc=0 || _rc=$?
+        if [[ "${1:-}" == json && ( $_rc -eq 0 || $_rc -eq 3 ) ]]; then
+            printf '%s\n' "$_body"; return 1
+        elif [[ $_rc -eq 0 ]]; then
+            echo "romp tag: $_line" >&2; return 1
         fi
+        case "$_code" in
+            401|403) echo "romp tag: the kernel on :$_kport refused the serve token (HTTP $_code); is ROMP_KERNEL_PORT pointing at another kernel?" >&2 ;;
+            *)       if [[ -n "$_body" ]]; then echo "romp tag: the kernel on :$_kport answered HTTP $_code: $_body" >&2
+                     else echo "romp tag: the kernel on :$_kport answered HTTP $_code with no explanation" >&2; fi ;;
+        esac
+        return 1
+    }
+    if [[ -z "$_gr_name" ]]; then
+        if $_gr_json; then
+            _tag_views json && exit 0
+            exit 1
+        fi
+        _resp="$(_tag_views)" || exit 1
         _rows="$(_romp_token_cfg | curl -sf -m 10 --config - "http://127.0.0.1:$_kport/sessions" 2>/dev/null)" || _rows='[]'
         python3 -c '
 import json, sys
@@ -1727,8 +1775,7 @@ for g in groups:
     if [[ $_gr_add_seen -eq 0 && $_gr_rm_seen -eq 0 && $_gr_cset -eq 0 && $_gr_del -eq 0 && -z "$_gr_rename" ]]; then
         # a bare name is a READ of that one group, never a write — POSTing here would CREATE a
         # missing group, so a typo'd "view" would mint a phantom and burn one of the 32 slots
-        _resp="$(_romp_token_cfg | curl -sf -m 10 --config - "http://127.0.0.1:$_kport/views")" \
-            || { echo "romp tag: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+        _resp="$(_tag_views)" || exit 1
         _rows="$(_romp_token_cfg | curl -sf -m 10 --config - "http://127.0.0.1:$_kport/sessions" 2>/dev/null)" || _rows='[]'
         if ! python3 -c '
 import json, sys

--- a/bin/romp
+++ b/bin/romp
@@ -1689,33 +1689,39 @@ if [[ "${1:-}" == "tag" || "${1:-}" == "group" ]]; then
         echo "romp tag: the kernel isn't running (no serve token). Start romp (the login service, or \`romp up\`) first." >&2
         exit 1
     fi
-    # One GET of the kernel's tag store: the body on stdout and 0 when the kernel answered 2xx.
-    # Never `curl -sf` here: -f folds EVERY non-2xx into the exit a dead kernel gets and throws the
-    # body away, so a kernel that ANSWERED — a 503 with {ok:false, retryable, error} while the store
-    # cannot be read (a polling peer needs the non-200 to keep its last reading), a 403 for a token
-    # it does not hold — read as "not reachable", and the person was told to restart a kernel that
-    # was up and explaining itself. The status rides -w and is read here, the way `romp perf` reads
-    # its own: a connection failure (curl's own nonzero exit, no status) keeps the "not reachable"
-    # line; a non-2xx whose JSON body carries `error` prints the kernel's words (plus "retry" when
-    # the body says the fault is retryable and the text does not already say so); a refused token
-    # is named as such; anything else prints the status and whatever came with it, never a guess.
-    # Exit 1 on every refusal, as the POST refusal below exits. With `json`, a JSON refusal body
-    # is printed as is on stdout — the same answer a script reads on a 2xx, now saying ok:false and
-    # why, so it needs no second parser — and only a non-JSON answer is said as prose on stderr.
-    _tag_views() {   # _tag_views [json]: GET /views; the 2xx body on stdout, or the failure said and 1
-        local _out _code _body _line _rc
-        _out="$(_romp_token_cfg | curl -s -m 10 --config - -w '\n%{http_code}' "http://127.0.0.1:$_kport/views")" \
+    # One kernel round trip for this verb, the GET of its tag store and the POST of an edit alike:
+    # the body on stdout and 0 when the kernel answered 2xx. Never `curl -sf` here: -f folds EVERY
+    # non-2xx into the exit a dead kernel gets and throws the body away, so a kernel that ANSWERED —
+    # a 503 with {ok:false, retryable, error} while the store cannot be read (a polling peer needs
+    # the non-200 to keep its last reading), a 400 with the reason it refused an edit, a 403 for a
+    # token it does not hold — read as "not reachable", and the person was told to restart a kernel
+    # that was up and explaining itself. The status rides -w and is read here, the way `romp perf`
+    # reads its own: a connection failure (curl's own nonzero exit, no status) keeps the "not
+    # reachable" line; a non-2xx whose JSON body carries `error` prints the kernel's words (plus
+    # "retry" when the body says the fault is retryable and the text does not already say so); a
+    # refused token is named as such; anything else prints the status and whatever came with it,
+    # never a guess. Exit 1 on every refusal, as the 200 ok:false refusal below exits. With `json`,
+    # a JSON refusal body is printed as is on stdout — the same answer a script reads on a 2xx, now
+    # saying ok:false and why, so it needs no second parser — and only a non-JSON answer is said as
+    # prose on stderr. The body reaches the parser on stdin, never argv: one argument is capped at
+    # 128 KB, so a larger answer would have defeated the parse and been echoed whole; and the prose
+    # echo shows the first 2 KB with a count of what was cut, since a terminal is not the place for
+    # a whole error page.
+    _tag_curl() {   # _tag_curl [json] <curl args…>: the 2xx body on stdout, or the failure said and 1
+        local _json=0 _out _code _body _line _rc _shown _more
+        if [[ "${1:-}" == json ]]; then _json=1; shift; fi
+        _out="$(_romp_token_cfg | curl -s --config - -w '\n%{http_code}' "$@")" \
             || { echo "romp tag: kernel not reachable on :$_kport (is romp running?)" >&2; return 1; }
         _code="${_out##*$'\n'}"
         _body="${_out%$'\n'*}"
         case "$_code" in
-            2??) if [[ "${1:-}" == json ]]; then printf '%s\n' "$_body"; else printf '%s' "$_body"; fi; return 0 ;;
+            2??) if [[ $_json -eq 1 ]]; then printf '%s\n' "$_body"; else printf '%s' "$_body"; fi; return 0 ;;
         esac
         # exits 0 with the line to say for a JSON object carrying `error`; 3 for JSON without one; 1 for a body that is not JSON
-        _line="$(python3 -c '
+        _line="$(printf '%s' "$_body" | python3 -c '
 import json, sys
 try:
-    v = json.loads(sys.argv[1])
+    v = json.load(sys.stdin)
 except Exception:
     sys.exit(1)
 e = v.get("error") if isinstance(v, dict) else None
@@ -1725,25 +1731,29 @@ e = str(e)
 if v.get("retryable") and "retry" not in e.lower():
     e += " \u2014 retry"
 print(e)
-' "$_body" 2>/dev/null)" && _rc=0 || _rc=$?
-        if [[ "${1:-}" == json && ( $_rc -eq 0 || $_rc -eq 3 ) ]]; then
+' 2>/dev/null)" && _rc=0 || _rc=$?
+        if [[ $_json -eq 1 && ( $_rc -eq 0 || $_rc -eq 3 ) ]]; then
             printf '%s\n' "$_body"; return 1
         elif [[ $_rc -eq 0 ]]; then
             echo "romp tag: $_line" >&2; return 1
         fi
         case "$_code" in
             401|403) echo "romp tag: the kernel on :$_kport refused the serve token (HTTP $_code); is ROMP_KERNEL_PORT pointing at another kernel?" >&2 ;;
-            *)       if [[ -n "$_body" ]]; then echo "romp tag: the kernel on :$_kport answered HTTP $_code: $_body" >&2
+            *)       if [[ -n "$_body" ]]; then
+                         _shown="$(printf '%s' "$_body" | head -c 2048)"
+                         _more=$(( $(printf '%s' "$_body" | wc -c) - 2048 ))
+                         [[ $_more -gt 0 ]] && _shown+=" ... ($_more more bytes)"
+                         echo "romp tag: the kernel on :$_kport answered HTTP $_code: $_shown" >&2
                      else echo "romp tag: the kernel on :$_kport answered HTTP $_code with no explanation" >&2; fi ;;
         esac
         return 1
     }
     if [[ -z "$_gr_name" ]]; then
         if $_gr_json; then
-            _tag_views json && exit 0
+            _tag_curl json -m 10 "http://127.0.0.1:$_kport/views" && exit 0
             exit 1
         fi
-        _resp="$(_tag_views)" || exit 1
+        _resp="$(_tag_curl -m 10 "http://127.0.0.1:$_kport/views")" || exit 1
         _rows="$(_romp_token_cfg | curl -sf -m 10 --config - "http://127.0.0.1:$_kport/sessions" 2>/dev/null)" || _rows='[]'
         python3 -c '
 import json, sys
@@ -1775,7 +1785,7 @@ for g in groups:
     if [[ $_gr_add_seen -eq 0 && $_gr_rm_seen -eq 0 && $_gr_cset -eq 0 && $_gr_del -eq 0 && -z "$_gr_rename" ]]; then
         # a bare name is a READ of that one group, never a write — POSTing here would CREATE a
         # missing group, so a typo'd "view" would mint a phantom and burn one of the 32 slots
-        _resp="$(_tag_views)" || exit 1
+        _resp="$(_tag_curl -m 10 "http://127.0.0.1:$_kport/views")" || exit 1
         _rows="$(_romp_token_cfg | curl -sf -m 10 --config - "http://127.0.0.1:$_kport/sessions" 2>/dev/null)" || _rows='[]'
         if ! python3 -c '
 import json, sys
@@ -1816,9 +1826,10 @@ if sys.argv[6]:
 print(json.dumps(body))
 ' "$_gr_name" "$_gr_cset" "$_gr_color" "$_gr_del" "$_gr_host" "$_gr_rename" "${#_gr_add[@]}" \
         "${_gr_add[@]+"${_gr_add[@]}"}" "${_gr_remove[@]+"${_gr_remove[@]}"}")"
-    _resp="$(_romp_token_cfg | curl -sf -m 15 --config - -X POST "http://127.0.0.1:$_kport/tag" \
-                  -H 'Content-Type: application/json' -d "$_payload")" \
-        || { echo "romp tag: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+    # the same status-reading call as the reads: a 400 with the kernel's reason for refusing the
+    # edit, or a 403, is said in its words, never as a kernel that is down
+    _resp="$(_tag_curl -m 15 -X POST "http://127.0.0.1:$_kport/tag" \
+                  -H 'Content-Type: application/json' -d "$_payload")" || exit 1
     if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
         _rows="$(_romp_token_cfg | curl -sf -m 10 --config - "http://127.0.0.1:$_kport/sessions" 2>/dev/null)" || _rows='[]'
         python3 -c '

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -119,6 +119,8 @@ teardown() {
     # Tests that launch a background romp-manager record its pid in MGR_PID so we
     # always reap it (and its child kernels), even if an assertion aborted the test.
     [[ -n "${MGR_PID:-}" ]] && kill "$MGR_PID" 2>/dev/null
+    # the stub kernel the `romp tag` read tests start (_stub_views_kernel) serves until reaped here
+    [[ -n "${VIEWS_KERNEL_PID:-}" ]] && kill "$VIEWS_KERNEL_PID" 2>/dev/null
     # The kill before the rm (a server the real tmux started must not outlive the test), and last, so
     # its failure is teardown's status: bats swallows a failing command mid-teardown.
     tmux_private_kill && rm -rf "$TEST_DIR"
@@ -171,7 +173,12 @@ if [[ -n "${MOCK_CURL_NEW_400:-}" && "$url" == */new ]]; then
   echo '{"ok": false, "error": "env: ROMP_SID is reserved — romp sets the session identity env itself"}'
   exit 0
 fi
-echo '{"ok": true}'
+# `romp tag`'s GET asks for the status as a trailer (-w '\n%{http_code}'), the way `romp perf`
+# does: append it as real curl would, so the read sees a 200 and not a body it must report as an
+# answer with no status
+_w=""; _prev=""
+for a in "$@"; do [[ "$_prev" == "-w" ]] && _w="$a"; _prev="$a"; done
+if [[ -n "$_w" ]]; then printf '{"ok": true}%b' "${_w//\%\{http_code\}/200}"; else echo '{"ok": true}'; fi
 MOCK
     chmod +x "$MOCK_DIR/curl"
 }
@@ -382,6 +389,7 @@ MOCK
     run run_romp tag workers
     grep -q '/views' "$MOCK_LOG"
     [ "$(grep -c '/tag' "$MOCK_LOG")" -eq 0 ]
+  [ "$status" -eq 1 ] && [[ "$output" == *"no tag named"* ]]   # the mock's -w trailer parsed: a good 200 body reaches the read (review pin)
 }
 
 @test "tag: --host rides the payload (an edit on an attached kernel's store)" {
@@ -450,6 +458,126 @@ MOCK
     run run_romp group workers --add exp-web
     [ "$status" -eq 0 ]
     grep '/tag' "$MOCK_LOG" | grep -q '"name": *"workers"'
+}
+
+# Helper — a stub kernel for `romp tag`'s READS, with REAL curl in front of it: answers GET /views
+# with the given HTTP status and body (GET /sessions with an empty list, so members print as ids) on
+# a free loopback port announced through a file written after the bind (the romp-headless.bats
+# pattern), and serves until teardown reaps it — a listing is two GETs. The curl mock above is the
+# wrong stand-in here: the subject is what the CLI makes of a status that `curl -sf` used to swallow,
+# and a mock that emulates -w would be testing its own emulation.
+_stub_views_kernel() {   # $1 = HTTP status for GET /views, $2 = its body
+    python3 - "$1" "$2" "$TEST_DIR/port" <<'PY' &
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+code, body, portfile = int(sys.argv[1]), sys.argv[2].encode(), sys.argv[3]
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        out, st = (body, code) if self.path.startswith("/views") else (b"[]", 200)
+        self.send_response(st); self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(out))); self.end_headers()
+        self.wfile.write(out)
+    def log_message(self, *a): pass
+srv = HTTPServer(("127.0.0.1", 0), H)
+with open(portfile, "w") as f:
+    f.write(str(srv.server_address[1]))
+srv.serve_forever()
+PY
+    VIEWS_KERNEL_PID=$!
+    until [ -s "$TEST_DIR/port" ]; do sleep 0.05; done
+    export ROMP_KERNEL_PORT="$(cat "$TEST_DIR/port")"
+}
+
+@test "tag: a kernel that answered 503 with its reason is repeated in its words, never called unreachable" {
+    # the tag store unreadable under a cold cache: the kernel answers GET /views with a 503 carrying
+    # {ok:false, retryable, error} (a polling peer needs the non-200 to keep its last reading).
+    # `curl -sf` threw that body away and told the person to restart a kernel that was up and
+    # explaining itself — and a restart cannot mend a disk fault
+    export ROMP_SERVE_TOKEN=testtok
+    _stub_views_kernel 503 '{"ok": false, "retryable": true, "error": "the tag store could not be read (read failed: [Errno 5] Input/output error) — retry"}'
+    run run_romp tag
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"romp tag: the tag store could not be read (read failed: [Errno 5] Input/output error) — retry"* ]]
+    [[ "$output" != *"retry — retry"* ]]      # a text that already says retry is not told twice
+    [[ "$output" != *"not reachable"* ]]
+    # the bare-name read is the same GET and says the same — not "no tag named"
+    run run_romp tag workers
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"the tag store could not be read"* ]]
+    [[ "$output" != *"not reachable"* ]]
+    [[ "$output" != *"no tag named"* ]]
+}
+
+@test "tag: a retryable refusal whose text does not say so gets 'retry' added" {
+    export ROMP_SERVE_TOKEN=testtok
+    _stub_views_kernel 503 '{"ok": false, "retryable": true, "error": "the tag store is being rebuilt"}'
+    run run_romp tag
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"romp tag: the tag store is being rebuilt — retry"* ]]
+}
+
+@test "tag: a 2xx answer still lists — the status-reading GET changes nothing on the good path" {
+    export ROMP_SERVE_TOKEN=testtok
+    _stub_views_kernel 200 '{"active": "all", "tags": [{"id": "t1", "name": "workers", "color": "#54B204", "members": ["11111111-2222-3333-4444-555555555555"]}]}'
+    run run_romp tag
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"active view: All"* ]]
+    [[ "$output" == *"workers  #54B204  1 member: 11111111-2222-3333-4444-555555555555"* ]]
+    run run_romp tag workers
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"workers  #54B204  1 member"* ]]
+    run run_romp tag --json
+    [ "$status" -eq 0 ]
+    [ "$output" = '{"active": "all", "tags": [{"id": "t1", "name": "workers", "color": "#54B204", "members": ["11111111-2222-3333-4444-555555555555"]}]}' ]
+}
+
+@test "tag: nothing listening on the port is still 'kernel not reachable'" {
+    export ROMP_SERVE_TOKEN=testtok
+    local port; free_port port
+    ROMP_KERNEL_PORT="$port" run run_romp tag
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"romp tag: kernel not reachable on :$port (is romp running?)"* ]]
+    ROMP_KERNEL_PORT="$port" run run_romp tag --json
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"kernel not reachable"* ]]
+}
+
+@test "tag --json: a non-2xx JSON answer is printed as is — a script reads ok:false and the reason — and exits 1" {
+    # --json hands a script the kernel's answer; a refusal is still that answer, and it already says
+    # ok:false and why, so the script needs no second parser. Only a non-JSON answer is said as prose.
+    export ROMP_SERVE_TOKEN=testtok
+    _stub_views_kernel 503 '{"ok": false, "retryable": true, "error": "the tag store could not be read (read failed: [Errno 5] Input/output error) — retry"}'
+    run run_romp tag --json
+    [ "$status" -eq 1 ]
+    [ "$output" = '{"ok": false, "retryable": true, "error": "the tag store could not be read (read failed: [Errno 5] Input/output error) — retry"}' ]
+}
+
+@test "tag: a 403 is a refused token, named as such (the kernel's plain-text answer is not JSON)" {
+    # what the kernel answers a GET /views carrying another kernel's token TODAY; -f read it as dead
+    export ROMP_SERVE_TOKEN=testtok
+    _stub_views_kernel 403 'forbidden: token required'
+    run run_romp tag
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"romp tag: the kernel on :$ROMP_KERNEL_PORT refused the serve token (HTTP 403)"* ]]
+    [[ "$output" != *"not reachable"* ]]
+    # --json has no JSON to print: the same prose line
+    run run_romp tag --json
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"refused the serve token (HTTP 403)"* ]]
+}
+
+@test "tag: a non-2xx with no JSON reason prints the status with what came with it, or says nothing came" {
+    export ROMP_SERVE_TOKEN=testtok
+    _stub_views_kernel 500 '<h1>Internal Server Error</h1>'
+    run run_romp tag
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"romp tag: the kernel on :$ROMP_KERNEL_PORT answered HTTP 500: <h1>Internal Server Error</h1>"* ]]
+    [[ "$output" != *"not reachable"* ]]
+    kill "$VIEWS_KERNEL_PID"; wait "$VIEWS_KERNEL_PID" 2>/dev/null || true; rm -f "$TEST_DIR/port"
+    _stub_views_kernel 502 ''
+    run run_romp tag
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"romp tag: the kernel on :$ROMP_KERNEL_PORT answered HTTP 502 with no explanation"* ]]
 }
 
 @test "color/tag: usage errors exit 2" {

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -119,8 +119,8 @@ teardown() {
     # Tests that launch a background romp-manager record its pid in MGR_PID so we
     # always reap it (and its child kernels), even if an assertion aborted the test.
     [[ -n "${MGR_PID:-}" ]] && kill "$MGR_PID" 2>/dev/null
-    # the stub kernel the `romp tag` read tests start (_stub_views_kernel) serves until reaped here
-    [[ -n "${VIEWS_KERNEL_PID:-}" ]] && kill "$VIEWS_KERNEL_PID" 2>/dev/null
+    # the stub kernel the `romp tag` tests start (_stub_tag_kernel) serves until reaped here
+    [[ -n "${TAG_KERNEL_PID:-}" ]] && kill "$TAG_KERNEL_PID" 2>/dev/null
     # The kill before the rm (a server the real tmux started must not outlive the test), and last, so
     # its failure is teardown's status: bats swallows a failing command mid-teardown.
     tmux_private_kill && rm -rf "$TEST_DIR"
@@ -460,30 +460,38 @@ MOCK
     grep '/tag' "$MOCK_LOG" | grep -q '"name": *"workers"'
 }
 
-# Helper — a stub kernel for `romp tag`'s READS, with REAL curl in front of it: answers GET /views
-# with the given HTTP status and body (GET /sessions with an empty list, so members print as ids) on
-# a free loopback port announced through a file written after the bind (the romp-headless.bats
-# pattern), and serves until teardown reaps it — a listing is two GETs. The curl mock above is the
-# wrong stand-in here: the subject is what the CLI makes of a status that `curl -sf` used to swallow,
-# and a mock that emulates -w would be testing its own emulation.
-_stub_views_kernel() {   # $1 = HTTP status for GET /views, $2 = its body
+# Helper — a stub kernel for `romp tag`, with REAL curl in front of it: answers GET /views and POST
+# /tag with the given HTTP status and body (GET /sessions with an empty list, so members print as
+# ids) on a free loopback port announced through a file written after the bind (the
+# romp-headless.bats pattern), and serves until teardown reaps it — a listing is two GETs. A body
+# argument starting with `@` names a file to serve, for a body too large to ride argv. The curl mock
+# above is the wrong stand-in here: the subject is what the CLI makes of a status that `curl -sf`
+# used to swallow, and a mock that emulates -w would be testing its own emulation.
+_stub_tag_kernel() {   # $1 = HTTP status for GET /views and POST /tag, $2 = its body (or @file)
     python3 - "$1" "$2" "$TEST_DIR/port" <<'PY' &
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
-code, body, portfile = int(sys.argv[1]), sys.argv[2].encode(), sys.argv[3]
+code, arg, portfile = int(sys.argv[1]), sys.argv[2], sys.argv[3]
+body = open(arg[1:], "rb").read() if arg.startswith("@") else arg.encode()
 class H(BaseHTTPRequestHandler):
-    def do_GET(self):
-        out, st = (body, code) if self.path.startswith("/views") else (b"[]", 200)
+    def _answer(self, out, st):
         self.send_response(st); self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(out))); self.end_headers()
         self.wfile.write(out)
+    def do_GET(self):
+        out, st = (body, code) if self.path.startswith("/views") else (b"[]", 200)
+        self._answer(out, st)
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length") or 0))   # drain, so curl's write lands
+        out, st = (body, code) if self.path.startswith("/tag") else (b"not found", 404)
+        self._answer(out, st)
     def log_message(self, *a): pass
 srv = HTTPServer(("127.0.0.1", 0), H)
 with open(portfile, "w") as f:
     f.write(str(srv.server_address[1]))
 srv.serve_forever()
 PY
-    VIEWS_KERNEL_PID=$!
+    TAG_KERNEL_PID=$!
     until [ -s "$TEST_DIR/port" ]; do sleep 0.05; done
     export ROMP_KERNEL_PORT="$(cat "$TEST_DIR/port")"
 }
@@ -494,7 +502,7 @@ PY
     # `curl -sf` threw that body away and told the person to restart a kernel that was up and
     # explaining itself — and a restart cannot mend a disk fault
     export ROMP_SERVE_TOKEN=testtok
-    _stub_views_kernel 503 '{"ok": false, "retryable": true, "error": "the tag store could not be read (read failed: [Errno 5] Input/output error) — retry"}'
+    _stub_tag_kernel 503 '{"ok": false, "retryable": true, "error": "the tag store could not be read (read failed: [Errno 5] Input/output error) — retry"}'
     run run_romp tag
     [ "$status" -eq 1 ]
     [[ "$output" == *"romp tag: the tag store could not be read (read failed: [Errno 5] Input/output error) — retry"* ]]
@@ -510,7 +518,7 @@ PY
 
 @test "tag: a retryable refusal whose text does not say so gets 'retry' added" {
     export ROMP_SERVE_TOKEN=testtok
-    _stub_views_kernel 503 '{"ok": false, "retryable": true, "error": "the tag store is being rebuilt"}'
+    _stub_tag_kernel 503 '{"ok": false, "retryable": true, "error": "the tag store is being rebuilt"}'
     run run_romp tag
     [ "$status" -eq 1 ]
     [[ "$output" == *"romp tag: the tag store is being rebuilt — retry"* ]]
@@ -518,7 +526,7 @@ PY
 
 @test "tag: a 2xx answer still lists — the status-reading GET changes nothing on the good path" {
     export ROMP_SERVE_TOKEN=testtok
-    _stub_views_kernel 200 '{"active": "all", "tags": [{"id": "t1", "name": "workers", "color": "#54B204", "members": ["11111111-2222-3333-4444-555555555555"]}]}'
+    _stub_tag_kernel 200 '{"active": "all", "tags": [{"id": "t1", "name": "workers", "color": "#54B204", "members": ["11111111-2222-3333-4444-555555555555"]}]}'
     run run_romp tag
     [ "$status" -eq 0 ]
     [[ "$output" == *"active view: All"* ]]
@@ -546,7 +554,7 @@ PY
     # --json hands a script the kernel's answer; a refusal is still that answer, and it already says
     # ok:false and why, so the script needs no second parser. Only a non-JSON answer is said as prose.
     export ROMP_SERVE_TOKEN=testtok
-    _stub_views_kernel 503 '{"ok": false, "retryable": true, "error": "the tag store could not be read (read failed: [Errno 5] Input/output error) — retry"}'
+    _stub_tag_kernel 503 '{"ok": false, "retryable": true, "error": "the tag store could not be read (read failed: [Errno 5] Input/output error) — retry"}'
     run run_romp tag --json
     [ "$status" -eq 1 ]
     [ "$output" = '{"ok": false, "retryable": true, "error": "the tag store could not be read (read failed: [Errno 5] Input/output error) — retry"}' ]
@@ -555,7 +563,7 @@ PY
 @test "tag: a 403 is a refused token, named as such (the kernel's plain-text answer is not JSON)" {
     # what the kernel answers a GET /views carrying another kernel's token TODAY; -f read it as dead
     export ROMP_SERVE_TOKEN=testtok
-    _stub_views_kernel 403 'forbidden: token required'
+    _stub_tag_kernel 403 'forbidden: token required'
     run run_romp tag
     [ "$status" -eq 1 ]
     [[ "$output" == *"romp tag: the kernel on :$ROMP_KERNEL_PORT refused the serve token (HTTP 403)"* ]]
@@ -568,16 +576,74 @@ PY
 
 @test "tag: a non-2xx with no JSON reason prints the status with what came with it, or says nothing came" {
     export ROMP_SERVE_TOKEN=testtok
-    _stub_views_kernel 500 '<h1>Internal Server Error</h1>'
+    _stub_tag_kernel 500 '<h1>Internal Server Error</h1>'
     run run_romp tag
     [ "$status" -eq 1 ]
     [[ "$output" == *"romp tag: the kernel on :$ROMP_KERNEL_PORT answered HTTP 500: <h1>Internal Server Error</h1>"* ]]
     [[ "$output" != *"not reachable"* ]]
-    kill "$VIEWS_KERNEL_PID"; wait "$VIEWS_KERNEL_PID" 2>/dev/null || true; rm -f "$TEST_DIR/port"
-    _stub_views_kernel 502 ''
+    kill "$TAG_KERNEL_PID"; wait "$TAG_KERNEL_PID" 2>/dev/null || true; rm -f "$TEST_DIR/port"
+    _stub_tag_kernel 502 ''
     run run_romp tag
     [ "$status" -eq 1 ]
     [[ "$output" == *"romp tag: the kernel on :$ROMP_KERNEL_PORT answered HTTP 502 with no explanation"* ]]
+}
+
+@test "tag write: a POST /tag the kernel answered 400 with its reason is repeated in its words, never called unreachable" {
+    # the kernel refuses a bad name or payload with a 400 and a JSON reason; on the write leg `curl -sf`
+    # still folded that into "not reachable" after the read leg had learned better (review fix)
+    export ROMP_SERVE_TOKEN=testtok
+    _stub_tag_kernel 400 '{"ok": false, "error": "a tag name is 1 to 40 characters"}'
+    run run_romp tag workers --add exp-web
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"romp tag: a tag name is 1 to 40 characters"* ]]
+    [[ "$output" != *"not reachable"* ]]
+    [[ "$output" != *testtok* ]]           # the serve token rides a header and is in no printed line
+    # every edit posts through the same call: --delete says the same
+    run run_romp tag workers --delete
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"romp tag: a tag name is 1 to 40 characters"* ]]
+    [[ "$output" != *"not reachable"* ]]
+    [[ "$output" != *testtok* ]]
+}
+
+@test "tag write: a 403 on POST /tag is a refused token, named as such" {
+    export ROMP_SERVE_TOKEN=testtok
+    _stub_tag_kernel 403 'forbidden: token required'
+    run run_romp tag workers --add exp-web
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"romp tag: the kernel on :$ROMP_KERNEL_PORT refused the serve token (HTTP 403)"* ]]
+    [[ "$output" != *"not reachable"* ]]
+    [[ "$output" != *testtok* ]]
+}
+
+@test "tag write: nothing listening on the port is still 'kernel not reachable'" {
+    export ROMP_SERVE_TOKEN=testtok
+    local port; free_port port
+    ROMP_KERNEL_PORT="$port" run run_romp tag workers --add exp-web
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"romp tag: kernel not reachable on :$port (is romp running?)"* ]]
+    [[ "$output" != *testtok* ]]
+}
+
+@test "tag: an oversized answer is echoed bounded when it is not JSON, and still read when it is" {
+    # a body over 128 KB cannot ride argv (E2BIG), so the JSON parse reads it from stdin; and the prose
+    # echo of a body that is not JSON shows the status plus its first 2 KB, then how much more there was
+    export ROMP_SERVE_TOKEN=testtok
+    python3 -c 'import sys; sys.stdout.write("<h1>Internal Server Error</h1>" + "x" * 200000)' > "$TEST_DIR/big"
+    _stub_tag_kernel 500 "@$TEST_DIR/big"
+    run run_romp tag
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"romp tag: the kernel on :$ROMP_KERNEL_PORT answered HTTP 500: <h1>Internal Server Error</h1>xxx"* ]]
+    [[ "$output" == *" ... (197982 more bytes)"* ]]
+    [ "${#output}" -lt 2300 ]
+    [[ "$output" != *"not reachable"* ]]
+    kill "$TAG_KERNEL_PID"; wait "$TAG_KERNEL_PID" 2>/dev/null || true; rm -f "$TEST_DIR/port"
+    python3 -c 'import json, sys; sys.stdout.write(json.dumps({"ok": False, "error": "the tag store could not be read", "detail": "y" * 200000}))' > "$TEST_DIR/bigjson"
+    _stub_tag_kernel 503 "@$TEST_DIR/bigjson"
+    run run_romp tag
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"romp tag: the tag store could not be read"* ]]
+    [ "${#output}" -lt 200 ]
 }
 
 @test "color/tag: usage errors exit 2" {


### PR DESCRIPTION
## What was wrong
Verified on `main`: `romp tag` fetches the kernel's views with a curl that fails on any non-2xx and discards the body, so on any failure it prints that the kernel is not reachable and asks whether romp is running. A kernel that answered, with a refusal in its own words, read as a dead kernel, and the person was pointed at a restart that could not help. The kernel's write route already answers a views-store fault as a 200-body refusal for exactly this reason, and a pending change makes the views route answer a retryable 503 under a store fault because a peer's poller needs a non-200 to keep its last reading; the CLI had to learn to read that answer.

## What changes
`romp tag` fetches the views the way `romp perf` already does, reading the status code beside the body. A connection failure keeps the exact old wording. A non-2xx with a JSON reason prints the kernel's words, adding "retry" only when the answer says so and the text does not, and exits as a refusal does today. A refused token says so. A non-2xx with no usable body prints the status and the body, or says the kernel gave no explanation. With `--json`, a non-2xx JSON body is printed as is, since a script reading that output already reads the kernel's answer, and a refusal is that answer. No `--fail-with-body`: the install docs require only a curl that runs the bootstrap line, and the status-write works on any curl.

## Deliberately left out
The tag write still posts with the failing curl, so a 400 with a JSON reason still reads as unreachable there; the best-effort session-name lookups inside `romp tag` fall back to ids by design; every other verb keeps its curl. The helper is local to the tag verb, so widening it later means lifting it beside the token helper.

## Tests
Seven new bats cases against a real stub kernel bound to a free loopback port and reaped in teardown, with real curl rather than a mock emulating the status write: a 503 with the kernel's reason prints that reason and exits non-zero; a retryable refusal whose text lacks "retry" gets it; `--json` prints a non-2xx JSON answer as is; a 403 is a refused token; a non-2xx with no JSON reason prints the status; a 2xx listing is unchanged; nothing listening still says not reachable. Five are red on `main`, the two guards green. The existing curl mock now carries the status trailer so the existing bare-read test keeps its meaning.

`tests/romp.bats` 119 passed on this branch; five of the seven new cases are red on `main`, the two guards green. Reviewed by read-only agents: no defects; one coverage nit, a pin on the curl mock's status trailer, folded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


