### PR TITLE
Follow-the-tail pins the bottom only when there is something new to follow, never on a frame that changed no content

### DIFF
--- a/ui/webview/follow-tail.test.ts
+++ b/ui/webview/follow-tail.test.ts
@@ -1,0 +1,36 @@
+// T262 (the user 2026-09-08, "jumped up slightly on my scroll in many, many sessions"): appendActive pinned a
+// reader within the 80 px follow threshold to the bottom on EVERY frame — a status-only chatTail included — so
+// wheeling up from the tail of a working session snapped back within the first 80 px, over and over. The
+// two-kernel harness reproduced it: a stop 60 px above the bottom moved 60 px to the bottom in a quiet window
+// with scrollHeight unchanged (compact mode), and both modes snapped on the next frame. Rule: follow the tail
+// only when there is something new to follow — the content's height changed — or when already at the very
+// bottom (a no-op pin). Executed decision + render.ts wiring pins, red on the previous render.ts.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { followTail } from "./scroll-keep";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("the harness case: 60 px above the bottom, a frame that adds nothing → no snap; new content → follow", () => {
+  assert.equal(followTail(60, 145219, 145219), false, "status-only tail: the reader stays 60 px up");
+  assert.equal(followTail(60, 145219, 145254), true, "35 px of new content: follow the tail (the designed threshold)");
+  assert.equal(followTail(60, 145219, 144945), true, "a height change either way is new information to follow");
+  assert.equal(followTail(0, 145219, 145219), true, "at the very bottom the pin is a no-op and keeps the tail visible");
+  assert.equal(followTail(2, 100, 100), true, "sub-pixel slack counts as at the bottom");
+  assert.equal(followTail(3, 100, 100), false, "three pixels up with nothing new: no write");
+});
+
+test("render.ts appendActive measures before the rebuild and pins only when followTail says so", () => {
+  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail \} from "\.\/scroll-keep";/);
+  const m = RENDER.match(/^function appendActive\(\) \{([\s\S]*?)\n\}/m);
+  assert.ok(m, "appendActive");
+  const body = m![1];
+  assert.match(body, /const heightBefore = content\.scrollHeight;\n\s*const distBefore = heightBefore - before - content\.clientHeight;/);
+  assert.ok(body.indexOf("const distBefore") < body.indexOf("syncView(activeId, stick);"), "measured BEFORE the rebuild");
+  assert.match(body, /if \(stick && followTail\(distBefore, heightBefore, content\.scrollHeight\)\) writeScroll\(content, content\.scrollHeight, "append-stick", true\);/);
+  assert.match(body, /else if \(stick\) \{ \/\* near the bottom, nothing new: the reader stays where they are \*\/ \}/);
+  // the scrolled-up path is untouched: anchor restore, raw fallback
+  assert.match(body, /else if \(!\(v && restoreScrollAnchor\(content, v, anchor\)\)\) writeScroll\(content, before, "append-raw"\);/);
+});

--- a/ui/webview/render-scroll.test.ts
+++ b/ui/webview/render-scroll.test.ts
@@ -67,7 +67,7 @@ test("appendActive snaps only when the user is already near the bottom of OVERFL
   // the slack rule (the user 2026-08-25): while nothing overflows, nearBottom is trivially true —
   // ungated, the very append crossing the overflow boundary yanked the view; now streaming into
   // slack writes in place and grows the scrollbar, and the stick engages only once overflowing
-  assert.match(RENDER, /const stick = content\.scrollHeight > content\.clientHeight \+ 2 && nearBottom\(content\);[\s\S]*?if \(stick\) writeScroll\(content, content\.scrollHeight, "append-stick", true\)/,
+  assert.match(RENDER, /const stick = content\.scrollHeight > content\.clientHeight \+ 2 && nearBottom\(content\);[\s\S]*?if \(stick && followTail\(distBefore, heightBefore, content\.scrollHeight\)\) writeScroll\(content, content\.scrollHeight, "append-stick", true\)/,   // …and only when there is new content to follow (T262 followTail)
     "tail-append follows the live edge only if content overflows AND the reader was at the bottom");
   // the popover's thread list speaks the same rule
   assert.match(RENDER, /const overflowed = list\.scrollHeight > list\.clientHeight \+ 2;/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -54,7 +54,7 @@ import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser
 import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
 import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
-import { followReader, keepPlaceAcrossShow } from "./scroll-keep";
+import { followReader, keepPlaceAcrossShow, followTail } from "./scroll-keep";
 import { retainLiveOmitted } from "./tab-order";
 import { userTurnShows } from "./user-turn-content";
 import { ScrollDiagBudget, classifyScroll, scrollWriteRow } from "./scroll-write";
@@ -10333,11 +10333,17 @@ function appendActive() {
   // bottom keeps the existing stick; scrolled-up keeps its never-yank rule.
   const stick = content.scrollHeight > content.clientHeight + 2 && nearBottom(content);
   const before = content.scrollTop;
+  const heightBefore = content.scrollHeight;
+  const distBefore = heightBefore - before - content.clientHeight;
   const anchor = !stick && v ? captureScrollAnchor(content, v) : null;
   syncView(activeId, stick);
   syncHostOfflineFoot();                 // before the scroll maths: it changes scrollHeight
   updateStatusline();
-  if (stick) writeScroll(content, content.scrollHeight, "append-stick", true);
+  // Follow-mode pins the bottom only when there is something new to follow (T262, the user 2026-09-08): a
+  // status-only tail changes no content, and pinning on it snapped a reader wheeling up from the tail of a
+  // busy session back down within the first 80 px, frame after frame. Decision in scroll-keep.ts followTail.
+  if (stick && followTail(distBefore, heightBefore, content.scrollHeight)) writeScroll(content, content.scrollHeight, "append-stick", true);
+  else if (stick) { /* near the bottom, nothing new: the reader stays where they are */ }
   else if (!(v && restoreScrollAnchor(content, v, anchor))) writeScroll(content, before, "append-raw");
   scheduleRailSticky();
   updateJumpBtn();   // appends can cross the overflow boundary either way — re-read the chip's truth

--- a/ui/webview/scroll-keep-on-show.test.ts
+++ b/ui/webview/scroll-keep-on-show.test.ts
@@ -77,7 +77,7 @@ test("render.ts: the reshow decision counts a live durable seek for the tab as n
 });
 
 test("render.ts: the #content scroll listener keeps the active view's saved spot current (passive, no timer)", () => {
-  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow \} from "\.\/scroll-keep";/);
+  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail \} from "\.\/scroll-keep";/);   // + followTail (T262: follow only on new content)
   // …and stands down while a deferred build is pending: the reveal's clamp fires a scroll event before the land
   assert.match(RENDER, /c\.addEventListener\("scroll", \(\) => \{\n\s*if \(c\.clientHeight <= 0\) return;\n\s*followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, nearBottom\(c\), pendingBuildRaf != null\);\n(?:.*\n){0,4}?\s*\}, \{ passive: true \}\);/);
   // landActive's landing rule itself is unchanged — its INPUT is what the fix repairs

--- a/ui/webview/scroll-keep.ts
+++ b/ui/webview/scroll-keep.ts
@@ -51,3 +51,16 @@ export function landSpot(v: KeepView): number | "bottom" {
 export function keepPlaceAcrossShow(v: KeepView, displayed: boolean, visible: boolean, navigating: boolean): boolean {
   return v.shown && displayed && visible && !navigating;
 }
+
+/** Follow-the-tail after an append, for a reader who was near the bottom (T262, the user 2026-09-08: "jumped up
+ *  slightly on my scroll" in busy sessions). A tab within the 80 px follow threshold used to be pinned to the
+ *  bottom on EVERY frame the pane received — including a status-only tail that changed no content — so a reader
+ *  wheeling up from the tail of a working session was snapped back within the first 80 px, again and again (the
+ *  harness reproduced it: a 60 px stop moved 60 px to the bottom in a quiet window with the content height
+ *  unchanged). The bottom is followed only when there is something new to follow: the content's height
+ *  changed, or the reader was already at the very bottom (where the pin is a no-op). Pure, so node executes it.
+ *  `distBefore` = scrollHeight − scrollTop − clientHeight before the rebuild. */
+export function followTail(distBefore: number, heightBefore: number, heightAfter: number): boolean {
+  if (distBefore <= 2) return true;
+  return heightAfter !== heightBefore;
+}


### PR DESCRIPTION
## What

A reader near the tail of a busy session was snapped back to the bottom within the first 80 px of wheeling up, frame after frame (the user 2026-09-08: "jumped up slightly on my scroll in many, many sessions").

**The writer, convicted on the two-kernel harness** (kernel B attached through A's relay, a 300-unit transcript, compact mode and normal, wheel-scrolled stop by stop): a stop 60 px above the bottom moved 60 px to the bottom during a quiet window with `scrollHeight` unchanged (compact), and both modes snapped on the next frame; stops at 300 px and at the very bottom never moved, and the continuous wheel scroll through the virtualization window (130 to 248 steps per pass) recorded no anchor-offset violations. `appendActive` treated "within the 80 px follow threshold" as follow mode and pinned the bottom on EVERY frame the pane received, a status-only `chatTail` with an empty suffix included, and a working or awaiting session sends those every pusher cycle. The snap is small (at most the threshold) and lands exactly while the reader scrolls away from the tail, which is what the report describes; the earlier scroll fixes (#1036, #1040, #1049, #1063) are about a different writer and stand.

**Fix.** Follow-mode pins the bottom only when there is something new to follow: the content's height changed across the rebuild, or the reader was already at the very bottom (a no-op pin that keeps the tail visible). A near-bottom reader on a frame that changed nothing stays exactly where they are. The scrolled-up path (anchor restore, raw fallback) and the threshold itself are untouched. Event-based: the content change is the event. Decision in `scroll-keep.ts` `followTail`, pure.

Composes with #1083: the remaining pin goes through the same `writeScroll` helper and stays on the client-diag record as `append-stick`.

## Tier

- [ ] tests-only
- [x] fix — a bug fix with a test that fails before it
- [ ] feature
- [ ] major-feature

## Tests

New `ui/webview/follow-tail.test.ts`: executes the harness case (60 px up, nothing new → no snap; 35 px of new content → follow; at the bottom → pin) and pins `appendActive` measuring before the rebuild and pinning only on `followTail`; the wiring pin is red on the previous render.ts. Suites: node typecheck clean, focused tests green; the full node and Python runs are in flight and CI gates the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
