### PR TITLE
Tab strip: every tag group starts on its own line (T264)

### DIFF
--- a/tests/test_tab_groups_rows.py
+++ b/tests/test_tab_groups_rows.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""T264 (the user 2026-09-08): in the tab strip's group-by-tag view every tag group starts on its own line —
+the tag chip at the left edge, its tabs after it (wrapping onto further rows as they need), the next group
+on a fresh line; the untagged trail opens its own line too, with no chip and no separator; a folded group
+is its header row alone.
+
+The served guard drives the real /chat page from a hermetic kernel: eight sessions under three tags of
+mixed sizes (one tag wide enough to wrap at the viewport) plus one untagged, one group folded by a header
+click. In the browser it reads the strip's geometry: every header is the first item of its row; the groups
+occupy disjoint row sets in strip order; a group's tabs share its header's row or a row below (its wrapped
+row starting at the left edge, never sharing a row with the next group); the folded header's row holds
+nothing else; the trail's tabs start their own row; no visible separator remains. Screenshots dark + light
+(the theme classes applyTheme sets) with NOTCH... no: TABROWS_SHOTS=<path-prefix>.
+
+Skips LOUDLY without the extension deps or a Playwright browser (CI installs none); the CI-safe pins ride
+ui/webview/tab-groups.test.ts and dragslot.test.ts. All fixtures synthetic (the notes-api demo world).
+"""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+
+# name → (sid, tag) ; the web tag is wide enough to wrap at a 640px viewport; "archived" folds by default
+SESSIONS = [
+    ("web-frontend", "aaaaaaaa-1111-2222-3333-000000000001", "web"),
+    ("web-backend", "aaaaaaaa-1111-2222-3333-000000000002", "web"),
+    ("web-gateway", "aaaaaaaa-1111-2222-3333-000000000003", "web"),
+    ("web-search", "aaaaaaaa-1111-2222-3333-000000000004", "web"),
+    ("web-billing", "aaaaaaaa-1111-2222-3333-000000000005", "web"),
+    ("infra-ci", "aaaaaaaa-1111-2222-3333-000000000006", "infra"),
+    ("infra-deploy", "aaaaaaaa-1111-2222-3333-000000000007", "infra"),
+    ("old-notes", "aaaaaaaa-1111-2222-3333-000000000008", "archived"),
+    ("scratch", "aaaaaaaa-1111-2222-3333-000000000009", None),
+]
+TAGS = [("t-web", "web", "#1EA1EB"), ("t-infra", "infra", "#54B204"), ("t-archived", "archived", "#4EA8A9")]
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 640, height: 480 }, deviceScaleFactor: 2 });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab[data-id]", { timeout: 20000 });
+try { await page.waitForSelector("#tabs .tab-group-head", { timeout: 20000 }); }
+catch (e) {
+  const st = await page.evaluate(() => ({ tabs: document.querySelectorAll("#tabs .tab").length, html: document.getElementById("tabs")?.innerHTML.slice(0, 800) }));
+  console.error("no section header rendered: " + JSON.stringify(st)); process.exit(1);
+}
+// wait for every VISIBLE session's tab (the archived group starts folded by default, so its member has none)
+try { await page.waitForFunction((n) => document.querySelectorAll("#tabs .tab[data-id]:not(.tab-placeholder)").length >= n
+                                        && document.querySelectorAll("#tabs .tab-group-head").length === 3, cfg.visible, { timeout: 30000 }); }
+catch (e) {
+  const st = await page.evaluate(() => ({ tabs: document.querySelectorAll("#tabs .tab[data-id]").length, placeholders: document.querySelectorAll("#tabs .tab-placeholder").length,
+    heads: Array.from(document.querySelectorAll("#tabs .tab-group-head")).map((h) => h.dataset.group) }));
+  console.error("strip never settled: " + JSON.stringify(st)); process.exit(1);
+}
+await page.waitForTimeout(500);
+const survey = () => page.evaluate(() => {
+  const bar = document.getElementById("tabs");
+  const kids = Array.from(bar.children);
+  const item = (e) => {
+    const r = e.getBoundingClientRect();
+    return { cls: e.className, group: e.dataset.group || null, id: e.dataset.id || null,
+             name: e.querySelector(".tab-label")?.textContent || e.querySelector(".tab-group-chip")?.textContent || null,
+             top: Math.round(e.offsetTop), left: Math.round(e.offsetLeft), w: Math.round(r.width), h: Math.round(r.height) };
+  };
+  return {
+    items: kids.map(item),
+    barLeft: 0, barW: bar.clientWidth,
+    theme: document.body.className,
+    seps: Array.from(document.querySelectorAll("#tabs .tab-group-sep")).map((e) => ({ w: e.getBoundingClientRect().width, h: e.getBoundingClientRect().height })),
+    breaks: document.querySelectorAll("#tabs .tab-group-break").length,
+    lines: Array.from(document.querySelectorAll("#tabs .tab-row-line")).map((l) => parseFloat(l.style.top)),
+    heads: Array.from(document.querySelectorAll("#tabs .tab-group-head")).map((h) => ({ group: h.dataset.group, act: h.dataset.act, folded: h.dataset.folded, count: h.querySelector(".tab-group-count")?.textContent })),
+  };
+});
+const open = await survey();
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-dark.png", clip: { x: 0, y: 0, width: 640, height: 130 } });
+// LIGHT theme: the classes applyTheme sets for the light theme
+await page.evaluate(() => document.body.classList.add("chat-theme-yatharth", "theme-light"));
+await page.waitForTimeout(300);
+const light = await survey();
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-light.png", clip: { x: 0, y: 0, width: 640, height: 130 } });
+fs.writeSync(1, "RESULT:" + JSON.stringify({ open, light }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedGroupsOnOwnLines(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        cls.lab = tempfile.mkdtemp(prefix="tabrows-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        shutil.copytree(os.path.join(EXT, "dist"), dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(cls.state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        claude = os.path.join(cls.lab, "claude")
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        for k, (name, sid, _tag) in enumerate(SESSIONS):
+            Path(cls.state, "names", sid).write_text("%s\t%s\t\t\n" % (name, cwd))
+            Path(cls.state, "sdk", sid + ".json").write_text(json.dumps(
+                {"sid": sid, "name": name, "cwd": cwd, "mode": "auto", "effort": "high",
+                 "lastSid": sid, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
+            u = "11111111-2222-3333-4444-%012d" % k
+            recs = [{"type": "user", "uuid": u, "parentUuid": None, "timestamp": "2026-09-07T10:%02d:00.000Z" % k, "sessionId": sid,
+                     "message": {"role": "user", "content": "notes-api: check the %s service" % name}}]
+            Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+        Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 100}, "seven_day": {"pct": 10}}))
+        # the kernel's session-views blob: three tags, members by sid (the legacy spelling it reads losslessly)
+        tags = [{"id": tid, "name": tname, "color": color, "members": [sid for (_n, sid, t) in SESSIONS if t == tname]}
+                for (tid, tname, color) in TAGS]
+        Path(cls.state, "timeline-views.json").write_text(json.dumps({"tags": tags, "tagOrder": [t[1] for t in TAGS]}))
+        cls.port = _free_port()
+        cls.token = "testtok-tabrows"
+        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
+                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
+        env.pop("ROMP_STATE_DIR", None)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def _drive(self, script, name):
+        cfg = os.path.join(self.lab, name + ".json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
+                       "visible": len([s for s in SESSIONS if s[2] != "archived"]),
+                       "shots": os.environ.get("TABROWS_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, name + ".mjs")
+        with open(driver, "w") as f:
+            f.write(script)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        return json.loads(line[len("RESULT:"):])
+
+    @staticmethod
+    def _sections(items):
+        """The strip in order, cut into sections: [(group or None, header item or None, [tab items])]."""
+        out = []
+        cur = None
+        for it in items:
+            cls = it["cls"].split()
+            if "tab-group-head" in cls:
+                cur = (it["group"], it, [])
+                out.append(cur)
+            elif "tab-group-break" in cls and "tab-group-sep" in cls:
+                cur = (None, None, [])
+                out.append(cur)
+            elif "tab" in cls and it["id"] and cur is not None:
+                cur[2].append(it)
+        return out
+
+    def _check_rows(self, s, label):
+        items = s["items"]
+        # the row's left edge: the leftmost TAB or HEADER (the T134 hairlines bleed 8px past the strip; breaks have no box)
+        strip = [it for it in items if it["w"] > 0 and it["h"] > 0 and ("tab-group-head" in it["cls"].split() or "tab" in it["cls"].split())]
+        left = min(it["left"] for it in strip)
+        secs = self._sections(items)
+        self.assertEqual([g for g, _h, _t in secs], ["web", "infra", "archived", None], "%s: three groups in tag order, then the untagged trail: %r" % (label, secs))
+        rows_of = lambda tabs: sorted({t["top"] for t in tabs})
+        prev_max = -1
+        for g, head, tabs in secs:
+            if head is not None:
+                self.assertEqual(head["left"], left, "%s: the %r chip sits at the row's left edge: %r" % (label, g, head))
+                self.assertGreater(head["top"], prev_max, "%s: the %r header opens a row below every earlier group's rows: %r" % (label, g, head))
+                first_row = head["top"]
+            else:
+                self.assertTrue(tabs, "%s: the untagged trail has its tab: %r" % (label, secs))
+                self.assertGreater(tabs[0]["top"], prev_max, "%s: the trail opens its own row: %r" % (label, tabs[0]))
+                self.assertEqual(tabs[0]["left"], left, "%s: the trail starts at the left edge, no separator ahead of it: %r" % (label, tabs[0]))
+                first_row = tabs[0]["top"]
+            rows = rows_of(tabs) or [first_row]
+            if tabs and head is not None:
+                self.assertEqual(tabs[0]["top"], head["top"], "%s: the %r group's first tab shares the chip's row: %r" % (label, g, tabs[0]))
+            for r in rows[1:]:   # a wrapped row of the same group starts at the left edge
+                first = min((t for t in tabs if t["top"] == r), key=lambda t: t["left"])
+                self.assertEqual(first["left"], left, "%s: %r wraps onto a row starting at the left edge: %r" % (label, g, first))
+            prev_max = max(rows)
+        return secs
+
+    def test_every_group_starts_on_its_own_line_and_a_fold_leaves_the_header_row_alone(self):
+        r = self._drive(DRIVER, "rows")
+        o, l = r["open"], r["light"]
+        # the world: eight visible tabs (the archived group starts folded, its one member hidden), three headers,
+        # no visible separator, one break per header after the first plus the trail's
+        visible = [s for s in SESSIONS if s[2] != "archived"]
+        self.assertEqual(len([i for i in o["items"] if i["id"]]), len(visible), "every visible session has its tab: %r" % [i["name"] for i in o["items"]])
+        self.assertEqual([h["group"] for h in o["heads"]], ["web", "infra", "archived"])
+        self.assertEqual(o["breaks"], 3, "a break before infra, before archived, and the trail's: %r" % o["breaks"])
+        for sp in o["seps"]:
+            self.assertEqual(sp["h"], 0, "the untagged boundary has no height — no separator is drawn: %r" % o["seps"])
+        secs = self._check_rows(o, "open")
+        web = next(t for g, _h, t in secs if g == "web")
+        self.assertGreater(len({t["top"] for t in web}), 1, "the web group wraps onto a further row at this width (the case under test): %r" % web)
+        # FOLDED (the archived group, folded by default): its header's row holds nothing else, and the trail
+        # below still opens its own line
+        arch = next(h for h in o["heads"] if h["group"] == "archived")
+        self.assertEqual((arch["folded"], arch["count"]), ("1", "1"), "archived is folded, its one member hidden: %r" % arch)
+        arch_head = next(h for g, h, _t in secs if g == "archived")
+        self.assertEqual(next(t for g, _h, t in secs if g == "archived"), [], "folded: no archived tab rendered")
+        same_row = [i for i in o["items"] if i["top"] == arch_head["top"] and i["w"] > 0 and i["id"]]
+        self.assertEqual(same_row, [], "folded: the header row alone: %r" % same_row)
+        # the per-row hairlines (T134, kept): one under every row but the last, none at the strip's top edge
+        self.assertNotIn(0.0, o["lines"], "no hairline at the top edge (a break is not a row): %r" % o["lines"])
+        self.assertTrue(o["lines"], "rows are still grounded by hairlines: %r" % o["lines"])
+        # LIGHT theme: the same geometry
+        self.assertIn("theme-light", l["theme"])
+        self._check_rows(l, "light")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/dragslot.test.ts
+++ b/ui/webview/dragslot.test.ts
@@ -43,3 +43,24 @@ test("degenerate inputs stay sane", () => {
   assert.equal(dragSlotIndex([], 300, 0, 30, 50, 50), 0);
   assert.equal(dragSlotIndex(boxes(400), 300, 0, 30, 10, -20), 0, "negative y clamps to row 0");
 });
+
+test("a `br` box opens a row even when it would have fit — the line-per-group strip's headers (T264)", () => {
+  // T264 (the user 2026-09-08): every tag group starts on its own line, so the real strip breaks
+  // before each header whatever the remaining width; the simulation must wrap at the same places or
+  // the pointer's slot would read against rows the strip does not have
+  const boxes = [{ id: "a", w: 50 }, { id: "b", w: 50 }, { id: "\0head:api", w: 40, br: true }, { id: "c", w: 50 }];
+  // row 0: a, b (100 of 400 used — b's row had room for the header, but the header opens row 1)
+  assert.equal(dragSlotIndex(boxes, 400, 0, 20, 10, 5), 0, "row 0, left of a");
+  assert.equal(dragSlotIndex(boxes, 400, 0, 20, 60, 5), 1, "row 0, between a and b");
+  assert.equal(dragSlotIndex(boxes, 400, 0, 20, 300, 5), 2, "row 0, past b: the header's slot (the end of row 0)");
+  assert.equal(dragSlotIndex(boxes, 400, 0, 20, 10, 25), 2, "row 1, left of the header: the same slot");
+  assert.equal(dragSlotIndex(boxes, 400, 0, 20, 60, 25), 3, "row 1, between the header and c");
+  assert.equal(dragSlotIndex(boxes, 400, 0, 20, 300, 25), 4, "row 1, past c: the end");
+  // a zero-width br box (the untagged trail's break) is a row opener too: the slot past the previous
+  // row's last tab and the slot before the trail's first tab stay two distinct slots
+  const trail = [{ id: "a", w: 50 }, { id: "\0sep", w: 0, br: true }, { id: "c", w: 50 }];
+  assert.equal(dragSlotIndex(trail, 400, 4, 20, 300, 5), 1, "past a: before the break (the end of a's row)");
+  assert.equal(dragSlotIndex(trail, 400, 4, 20, 10, 25), 2, "row 1, left of c's middle: the head of the trail");
+  // br on the FIRST box is a no-op (nothing to break from)
+  assert.equal(dragSlotIndex([{ id: "\0head:web", w: 40, br: true }, { id: "a", w: 50 }], 400, 0, 20, 100, 5), 2);
+});

--- a/ui/webview/dragslot.ts
+++ b/ui/webview/dragslot.ts
@@ -8,11 +8,17 @@
 // response to the insert they cause. Monotone pointer motion crosses each boundary once by
 // construction; no debounce, no heuristics.
 
-export interface SlotBox { id: string; w: number; }
+export interface SlotBox {
+  id: string; w: number;
+  /** T264: this box STARTS A ROW — the real strip breaks the line before it (a tag group's header, or
+   *  the untagged trail's boundary), so the simulation must too, even when the box would have fit. */
+  br?: boolean;
+}
 
 /** Simulate the strip's wrap layout (row fill left-to-right up to `containerW`, `gapX` between
- *  tabs, uniform `rowH`) over the non-dragged boxes, and return the insertion index for pointer
- *  (x, y) in the container's content space: 0..boxes.length, where boxes.length = the end. */
+ *  tabs, uniform `rowH`; a `br` box always opens a row) over the non-dragged boxes, and return the
+ *  insertion index for pointer (x, y) in the container's content space: 0..boxes.length, where
+ *  boxes.length = the end. */
 export function dragSlotIndex(boxes: readonly SlotBox[], containerW: number, gapX: number,
                               rowH: number, x: number, y: number): number {
   if (!boxes.length) return 0;
@@ -20,7 +26,7 @@ export function dragSlotIndex(boxes: readonly SlotBox[], containerW: number, gap
   const rows: { start: number; mids: number[] }[] = [];
   let cx = 0, row: { start: number; mids: number[] } | null = null;
   boxes.forEach((b, i) => {
-    const needsWrap = row !== null && cx + b.w > containerW && cx > 0;
+    const needsWrap = row !== null && cx > 0 && (b.br === true || cx + b.w > containerW);
     if (row === null || needsWrap) { row = { start: i, mids: [] }; rows.push(row); cx = 0; }
     row.mids.push(cx + b.w / 2);
     cx += b.w + gapX;

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5016,11 +5016,7 @@ function releaseTabStrip(): void {
 // unplanned; and the header holding the active tab is a labeled group, not a button — it takes no
 // action and no focus, and "button, expanded" promised both.
 function makeGroupHead(sec: TabSection, collapsed: boolean, holdsActive: boolean, hidden: readonly string[]): HTMLElement {
-  if (sec.name === null) {
-    const sep = el("div", "tab-group-sep");
-    sep.title = "sessions in no tag";
-    return sep;
-  }
+  if (sec.name === null) return makeRowBreak(true);
   const name = sec.name;
   const head = el("div", "tab-group-head" + (collapsed ? " collapsed" : "") + (holdsActive ? " holds-active" : ""));
   head.dataset.group = name;
@@ -5103,8 +5099,20 @@ function makeGroupHead(sec: TabSection, collapsed: boolean, holdsActive: boolean
   });
   return head;
 }
+/** A ROW BREAK (T264, the user 2026-09-08): a zero-height item spanning the strip, so whatever follows
+ *  opens a new line — every tag group starts on its own row (chip at the left edge, its tabs after
+ *  it, wrapping as they need) instead of the groups running on as one long concatenation. The
+ *  untagged trail's break also wears .tab-group-sep, the boundary sectionHeadOf reads (the trail
+ *  stays unlabeled by the user's ruling — its own line, with no chip, says "in no tag"). Breaks are
+ *  layout only: no drop, no hover, not a row for paintTabRowLines, and in the tab drag's virtual
+ *  layout the box AFTER a break starts a row (`br`) so the simulation wraps where the strip does. */
+function makeRowBreak(untagged: boolean): HTMLElement {
+  const brk = el("div", "tab-group-break" + (untagged ? " tab-group-sep" : ""));
+  brk.setAttribute("aria-hidden", "true");
+  return brk;
+}
 /** The section header a strip node belongs to: itself for a header, else the nearest header before
- *  it; null past the untagged separator or on a flat strip. */
+ *  it; null past the untagged boundary (the trail's row break) or on a flat strip. */
 function sectionHeadOf(node: HTMLElement): HTMLElement | null {
   let n: Element | null = node;
   while (n) {
@@ -5210,10 +5218,11 @@ function paintTabRowLines(bar: HTMLElement): void {
   for (const old of Array.from(bar.querySelectorAll(":scope > .tab-row-line"))) old.remove();
   const rows = new Map<number, number>();   // rowTop → rowBottom (max tab bottom in that row)
   for (const t of Array.from(bar.children) as HTMLElement[]) {
-    // tabs, and the section headers + untagged separator (tab groups): a wrapped row made only of
-    // folded headers is a row too — without a line under it the headers sat directly on the tabs
-    // below, reading as captions for tabs that are not theirs (the T134 floating look, back)
-    if (!(t.classList.contains("tab") || t.classList.contains("tab-group-head") || t.classList.contains("tab-group-sep"))) continue;
+    // tabs, and the section headers (tab groups): a wrapped row made only of folded headers is a
+    // row too — without a line under it the headers sat directly on the tabs below, reading as
+    // captions for tabs that are not theirs (the T134 floating look, back). The zero-height row
+    // BREAKS (T264) are not rows: one would draw a line at the strip's very top edge.
+    if (!(t.classList.contains("tab") || t.classList.contains("tab-group-head"))) continue;
     const top = t.offsetTop, bot = t.offsetTop + t.offsetHeight;
     rows.set(top, Math.max(rows.get(top) ?? 0, bot));
   }
@@ -5321,7 +5330,13 @@ function renderTabs() {
                          provisionalId ? { id: provisionalId, tags: provisionalTags } : null);
   collapsedTabIds = plan.folded;
   for (const item of plan.items) {
-    if ("head" in item) { bar.appendChild(makeGroupHead(item.head, item.folded, item.active, item.hidden)); continue; }
+    if ("head" in item) {
+      // every group on its own line (T264): a row break ahead of each header — except the strip's
+      // first item, which already opens the first row; the untagged trail's header IS a break
+      if (item.head.name !== null && bar.childElementCount) bar.appendChild(makeRowBreak(false));
+      bar.appendChild(makeGroupHead(item.head, item.folded, item.active, item.hidden));
+      continue;
+    }
     const id = item.id;
     const s = sessions.get(id);
     if (!s) { bar.appendChild(makePlaceholderTab(id)); continue; }
@@ -15562,17 +15577,27 @@ setupSettings();
     if (e.clientX >= dr.left && e.clientX <= dr.right && e.clientY >= dr.top && e.clientY <= dr.bottom) return;
     // the virtual layout: the OTHER tabs in current DOM order, widths from the dragstart snapshot —
     // boundaries that cannot move in response to the insert they cause (dragslot.ts owns the math)
-    // …plus the section headers and separator (tab groups): they take width in the real layout, so
-    // they join the virtual one as boxes — the simulated wrap then matches the strip's, and a slot
-    // just before a header is the end of the previous section. A drop changes no membership (the
-    // tab re-sections on the next render); "Move to" in the tab menu is the membership path.
+    // …plus the section headers (tab groups): they take width in the real layout, so they join the
+    // virtual one as boxes — the simulated wrap then matches the strip's. One group per line (T264):
+    // a header preceded by a row break OPENS a row in the simulation (`br`), as does the untagged
+    // trail's break itself — a zero-width row opener, so the slot past a group's last tab (the end
+    // of its row) and the slot before the trail's first tab (the head of the next row) stay two
+    // distinct slots, as they were when the trail stood behind a visible separator. A drop changes
+    // no membership (the tab re-sections on the next render); "Move to" in the tab menu is the
+    // membership path.
     const others = Array.from(tabs.querySelectorAll<HTMLElement>(".tab[data-id], .tab-group-head, .tab-group-sep")).filter((t) => t !== dragged);
+    const isBreak = (n: Element | null) => !!n && n.classList.contains("tab-group-break");
+    const before = (t: HTMLElement) => { let p = t.previousElementSibling; while (p && p === dragged) p = p.previousElementSibling; return p; };
     const boxes = others.map((t) => ({ id: t.dataset.id || " head:" + (t.dataset.group || ""),
-                                       w: (t.dataset.id ? dragGeom!.widths.get(t.dataset.id) : undefined) ?? t.getBoundingClientRect().width }));
+                                       w: isBreak(t) ? 0 : (t.dataset.id ? dragGeom!.widths.get(t.dataset.id) : undefined) ?? t.getBoundingClientRect().width,
+                                       br: isBreak(t) || isBreak(before(t)) }));
     const br = tabs.getBoundingClientRect();
     const idx = dragSlotIndex(boxes, dragGeom.containerW, dragGeom.gapX, dragGeom.rowH,
                               e.clientX - br.left, e.clientY - br.top);
-    const ref = idx < others.length ? others[idx] : dragged.parentElement === tabs ? tabs.querySelector(".tab-add") : null;
+    let ref = idx < others.length ? others[idx] : dragged.parentElement === tabs ? tabs.querySelector(".tab-add") : null;
+    // the slot before a header is the END OF THE PREVIOUS ROW: insert ahead of the header's break, never
+    // between the break and the chip (a tab there would sit left of the chip on the group's own line)
+    if (ref && ref.classList.contains("tab-group-head") && isBreak(before(ref as HTMLElement))) ref = before(ref as HTMLElement);
     if (ref !== dragged && dragged.nextElementSibling !== ref)
       flipTabs(() => tabs.insertBefore(dragged, ref));
   });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -401,11 +401,16 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 .tab-group-pip { flex: 0 0 auto; width: 6px; height: 6px; border-radius: 50%; background: var(--st-working-bg); }
 .tab-group-pip.blocked { background: var(--st-blocked-bg); }
 .tab-group-pip.retrying { background: #e67e22; }
-/* the separator's 6px gutters are PADDING, not margin, and the 1px line is the content box: its box
-   is then the full 13px it occupies in the row, so the tab drag's virtual layout (which measures
-   getBoundingClientRect widths) wraps where the real strip wraps, and paintTabRowLines reads its
-   offsetTop as the row's. */
-.tab-group-sep { flex: 0 0 auto; box-sizing: border-box; width: 13px; padding: 8px 6px; background: var(--box-border); background-clip: content-box; }
+/* ONE GROUP PER LINE (T264, the user 2026-09-08: the grouped strip read as one long concatenation).
+   A break is a zero-height flex item spanning the whole row, so the item after it — a group's header,
+   or the untagged trail's first tab — opens a new line: the chip sits at the left edge and its tabs
+   follow, wrapping onto further rows as they need. Zero height, so it adds no rhythm of its own
+   (the Yatharth seam is a column gap only); no pointer, so it can neither take a drop nor a hover.
+   The visible separator the untagged trail used to stand behind is gone — a line of its own, with
+   no chip, already says "in no tag" (the trail stays unlabeled by the user's ruling); the element
+   keeps the .tab-group-sep class as the boundary sectionHeadOf reads. The tab drag's virtual layout
+   (dragslot.ts) opens a row at the same places (`br`), so a drag wraps where the strip wraps. */
+.tab-group-break { flex: 0 0 100%; height: 0; margin: 0; padding: 0; pointer-events: none; }
 /* (the settings gear + modal live on the TIMELINE now — see ui/romp-timeline-view.js) */
 
 .tab {

--- a/ui/webview/tab-drag-live.test.ts
+++ b/ui/webview/tab-drag-live.test.ts
@@ -47,11 +47,14 @@ test("the slot comes from the VIRTUAL layout — boundaries that cannot move und
   // the boxes are measured by getBoundingClientRect, which excludes margins — so no strip member
   // may carry a horizontal margin, or the virtual row holds more than the real one and the slot
   // hops in a band at every wrap boundary (the separator's 6px gutters were margin: a 12px drift)
-  assert.match(body, /\?\? t\.getBoundingClientRect\(\)\.width \}\)\);/);
-  const sep = CSS.match(/^\.tab-group-sep \{[^}]*\}/m)![0];
-  assert.doesNotMatch(sep, /margin/, "the separator's gutters are padding inside a 13px box, so its rect IS its footprint");
-  assert.match(sep, /box-sizing: border-box; width: 13px; padding: 8px 6px;/);
-  assert.match(sep, /background-clip: content-box;/, "…and the 1px line is the content box");
+  assert.match(body, /\?\? t\.getBoundingClientRect\(\)\.width,\s*\n\s*br: isBreak\(t\) \|\| isBreak\(before\(t\)\) \}\)\);/);
+  // T264: the untagged trail's boundary is a zero-height ROW BREAK (the visible 13px separator is gone) —
+  // not a box in the real layout, so it joins the virtual one as a zero-width row opener (w: 0, br), and
+  // a header after a break opens a row too; the simulation then wraps exactly where the strip does
+  const brk = CSS.match(/^\.tab-group-break \{[^}]*\}/m)![0];
+  assert.match(brk, /flex: 0 0 100%; height: 0; margin: 0; padding: 0;/, "the break spans the row and has no box of its own");
+  assert.match(body, /w: isBreak\(t\) \? 0 : /, "…so it measures 0 in the virtual layout, never its full-row rect");
+  assert.doesNotMatch(CSS, /^\.tab-group-sep \{/m, "no separator rule remains to give the boundary a width");
   const head = CSS.match(/^\.tab-group-head \{[^}]*\}/m)![0];
   assert.doesNotMatch(head, /margin/, "headers carry no horizontal margin either");
   assert.match(body, /dragSlotIndex\(boxes, dragGeom\.containerW, dragGeom\.gapX, dragGeom\.rowH,/);

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -118,7 +118,8 @@ test("the strip renders sections when the switch is on and some tag holds a visi
   assert.match(RENDER, /const unions = viewTagUnion\(effViews\(\)\);\s*\n\s*const plan = planStrip\(visibleIds, unions, readTabGroups\(unions\), activeId, phoneLayout\(\),/,
     "the pure module owns the rule; the phone layout and the create in flight are its inputs");
   assert.match(RENDER, /collapsedTabIds = plan\.folded;/);
-  assert.match(RENDER, /if \("head" in item\) \{ bar\.appendChild\(makeGroupHead\(item\.head, item\.folded, item\.active, item\.hidden\)\); continue; \}/);
+  assert.match(RENDER, /if \("head" in item\) \{\s*\n(?:\s*\/\/[^\n]*\n)*\s*if \(item\.head\.name !== null && bar\.childElementCount\) bar\.appendChild\(makeRowBreak\(false\)\);\s*\n\s*bar\.appendChild\(makeGroupHead\(item\.head, item\.folded, item\.active, item\.hidden\)\);\s*\n\s*continue;\s*\n\s*\}/,
+    "a header paints from the plan (T264: on its own line — the break ahead of it)");
 });
 
 test("executed: planStrip — sections + folds; the flat strip when off or untagged; the ACTIVE tab's section never folds", () => {
@@ -256,7 +257,7 @@ test("a folded section renders its header alone with the folded-away count and o
   assert.ok(head.indexOf('el("span", "tab-group-count")') < head.indexOf("sectionPip("), "after the count");
   assert.ok(!head.includes("tabStateClass("), "the header itself wears no state class");
   assert.ok(!head.includes('"tab-dot"'), "never a .tab-dot — the kernel's mobile scrape keys on the tab pips' vocabulary");
-  assert.match(head, /const sep = el\("div", "tab-group-sep"\);/, "the untagged trail is UNLABELED (the ruling): a separator, not a header");
+  assert.match(head, /if \(sec\.name === null\) return makeRowBreak\(true\);/, "the untagged trail is UNLABELED (the ruling): its own row with no chip, not a header (T264)");
   // the tab's own class comes from the same function
   assert.match(RENDER, /const stateCls = tabStateClass\(s\.status\);\s*\n\s*if \(stateCls\) tab\.classList\.add\(stateCls\);/);
   assert.match(CSS, /\.tab-group-pip \{ flex: 0 0 auto; width: 6px; height: 6px; border-radius: 50%; background: var\(--st-working-bg\); \}/, "small: subordinate to the label");
@@ -264,12 +265,12 @@ test("a folded section renders its header alone with the folded-away count and o
   assert.match(CSS, /\.tab-group-pip\.retrying \{ background: #e67e22; \}/, "amber, the tab's .tab-retrying hue");
 });
 
-test("row hairlines count section headers and the separator as row members (T134's floating look must not return)", () => {
+test("row hairlines count section headers as row members (T134's floating look must not return), never the row breaks", () => {
   // a wrapped row made only of folded headers got no line: the painter grouped `.tab` children only
   const painter = RENDER.slice(RENDER.indexOf("function paintTabRowLines("), RENDER.indexOf("let tabRowObserver"));
-  assert.match(painter, /if \(!\(t\.classList\.contains\("tab"\) \|\| t\.classList\.contains\("tab-group-head"\) \|\| t\.classList\.contains\("tab-group-sep"\)\)\) continue;/);
-  // the separator's offsetTop is the row's: gutters are padding, not margin (see the drag-live pin)
-  assert.match(CSS, /\.tab-group-sep \{ flex: 0 0 auto; box-sizing: border-box; width: 13px; padding: 8px 6px; background: var\(--box-border\); background-clip: content-box; \}/);
+  assert.match(painter, /if \(!\(t\.classList\.contains\("tab"\) \|\| t\.classList\.contains\("tab-group-head"\)\)\) continue;/);
+  // the zero-height row breaks (T264) are not rows: counting one drew a hairline at the strip's top edge
+  assert.doesNotMatch(painter, /tab-group-sep|tab-group-break/);
 });
 
 test("the picker's Tags row is for SDK and Codex sessions: disabled behind a note on the tmux pick, and no `tags` ride a tmux create", () => {
@@ -357,8 +358,56 @@ test("the section chrome is a LABEL's (the user 2026-09-06): the surface's sub-l
   assert.doesNotMatch(CSS, /\.tab-group-dot/, "the dot is gone");
   const sizes = new Set(Array.from(CSS.matchAll(/\n\.tab-group-[^{\n]*\{[^}]*font-size: ([^;]+);/g)).map((m) => m[1]));
   assert.deepEqual([...sizes], ["0.82em"], "one font-size across every section rule");
-  assert.match(CSS, /\.tab-group-sep \{ flex: 0 0 auto; box-sizing: border-box; width: 13px; padding: 8px 6px;/, "a 1px line inside 6px gutters (padding, so its rect is its footprint)");
+  assert.doesNotMatch(CSS, /\.tab-group-sep \{/, "the visible separator is gone (T264): the untagged trail opens its own row instead");
 });
+
+// ── T264 (the user 2026-09-08): every tag group on its own line ──────────────────────────────────────────
+test("every group opens a new line: a zero-height full-width break ahead of each header, the trail's break doubling as the boundary (T264)", () => {
+  // the strip read as one long concatenation; now the chip sits at the left edge, its tabs follow it
+  // and wrap onto further rows as they need, and the next group starts a fresh line
+  const loop = RENDER.slice(RENDER.indexOf("collapsedTabIds = plan.folded;"), RENDER.indexOf("const id = item.id;"));
+  assert.match(loop, /if \(item\.head\.name !== null && bar\.childElementCount\) bar\.appendChild\(makeRowBreak\(false\)\);\s*\n\s*bar\.appendChild\(makeGroupHead\(item\.head, item\.folded, item\.active, item\.hidden\)\);/,
+    "a break before every header but the strip's first item (which already opens the first row)");
+  const brk = RENDER.slice(RENDER.indexOf("function makeRowBreak("), RENDER.indexOf("function sectionHeadOf("));
+  assert.match(brk, /el\("div", "tab-group-break" \+ \(untagged \? " tab-group-sep" : ""\)\)/,
+    "the untagged trail's break keeps the .tab-group-sep class — the boundary sectionHeadOf reads");
+  assert.match(brk, /brk\.setAttribute\("aria-hidden", "true"\);/, "layout only: nothing to read aloud");
+  assert.doesNotMatch(brk, /\.title = /, "no tooltip on a zero-height item");
+  assert.match(CSS, /\.tab-group-break \{ flex: 0 0 100%; height: 0; margin: 0; padding: 0; pointer-events: none; \}/,
+    "a full-row, zero-height item: the next item wraps; no rhythm of its own; takes no drop and no hover");
+  // sectionHeadOf still stops at the untagged boundary and walks past a plain break
+  const sh = RENDER.slice(RENDER.indexOf("function sectionHeadOf("), RENDER.indexOf("function makePlaceholderTab("));
+  assert.match(sh, /if \(h\.classList\.contains\("tab-group-sep"\)\) return null;/);
+  // the header's own rule is unchanged: flex-none, the chip first in its row
+  assert.match(CSS, /\.tab-group-head \{ display: flex; flex: 0 0 auto; align-items: center;/);
+});
+
+test("the tab drag's virtual layout wraps where the strip wraps: headers after a break and the trail's break open rows (T264)", () => {
+  const over = RENDER.slice(RENDER.indexOf('tabs.addEventListener("dragover"'), RENDER.indexOf('tabs.addEventListener("drop"'));
+  assert.match(over, /const isBreak = \(n: Element \| null\) => !!n && n\.classList\.contains\("tab-group-break"\);/);
+  assert.match(over, /const before = \(t: HTMLElement\) => \{ let p = t\.previousElementSibling; while \(p && p === dragged\) p = p\.previousElementSibling; return p; \};/,
+    "the box before, skipping the dragged tab (it is out of the virtual layout)");
+  assert.match(over, /w: isBreak\(t\) \? 0 : /, "the trail's break is a zero-width row opener, not a full-row box");
+  assert.match(over, /br: isBreak\(t\) \|\| isBreak\(before\(t\)\) \}\)\);/, "a header after a break, and the break itself, open a row");
+  assert.match(over, /if \(ref && ref\.classList\.contains\("tab-group-head"\) && isBreak\(before\(ref as HTMLElement\)\)\) ref = before\(ref as HTMLElement\);/,
+    "the slot before a header is the end of the previous row — never between the break and the chip");
+  const DS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "dragslot.ts"), "utf8");
+  assert.match(DS, /const needsWrap = row !== null && cx > 0 && \(b\.br === true \|\| cx \+ b\.w > containerW\);/, "dragslot honours br (executed in dragslot.test.ts)");
+});
+
+test("executed: a session under two tags is placed ONCE, under its home tag — the duplicate question stays the user's (T264)", () => {
+  // the manager's note (2026-09-08): sectionTabs homes each id under homeTag; the user has been asked
+  // whether a two-tag session should show under both. Until they rule, this pins today's behaviour so
+  // the line-per-group layout does not change it by accident.
+  const unions = viewTagUnion({ tags: [{ id: "t-infra", name: "infra", color: "#1EA1EB", members: ["web", "api"] },
+                                       { id: "t-qa", name: "qa", color: "#54B204", members: ["api", "tests"] }] });
+  const p = planStrip(["web", "api", "tests"], unions, parseTabGroups(null, unions), "web", false);
+  const tabs = p.items.filter((i) => "id" in i).map((i) => (i as { id: string }).id);
+  assert.deepEqual(tabs, ["web", "api", "tests"], "each session once");
+  const heads = p.items.map((i, k) => ("head" in i ? { name: i.head.name, ids: i.head.ids, at: k } : null)).filter(Boolean);
+  assert.deepEqual(heads.map((h) => [h!.name, h!.ids]), [["infra", ["web", "api"]], ["qa", ["tests"]]], "api sits under its home tag only");
+});
+
 
 test("the header's structure and gestures read as a label: chevron (flips with the fold) → color bar → name → count; a keyboard button; hover/focus say fold, never open; tokens only (the user 2026-09-06)", () => {
   const head = RENDER.slice(RENDER.indexOf("function makeGroupHead("), RENDER.indexOf("function sectionHeadOf("));


### PR DESCRIPTION
In the tab strip's group-by-tag view every tag group now starts on its own line (the user 2026-09-08: the strip read as one long concatenation). The tag chip sits at the row's left edge, its tabs follow it and wrap onto further rows as they need, and the next group starts a fresh line. Collapsing keeps working: a folded group is its header row alone, count and pip as before.

## Design points

- **A row break, not a wrapper.** A zero-height, full-width flex item (`.tab-group-break`) ahead of every header but the strip's first item forces the wrap; `#tabs` stays one flat wrapping flex row, so the drag-and-drop paths, the FLIP animation, keyboard order and the mobile scrape (all of which read `.tab`/`.tab-group-head` data attributes on direct children) are untouched.
- **The separators are gone.** The untagged trail opens its own line with no chip and no separator: a line of its own already says "in no tag" (the trail stays unlabeled per the user's earlier ruling). Its break also carries `.tab-group-sep`, the boundary `sectionHeadOf` reads, so group drag targeting is unchanged. Flat mode never used the separator.
- **The T134 per-row hairlines are KEPT.** With one group per line they ground each row exactly as before and now double as group dividers (classic theme; the light theme hides them as it always did). A break is not a row for the painter: counting one drew a hairline at the strip's top edge.
- **Drag-and-drop across the breaks.** The tab drag's virtual layout (`dragslot.ts`) wraps where the strip wraps: `SlotBox` gains `br` (this box opens a row) for a header after a break and for the trail's break itself, a zero-width row opener, so the slot at the end of a group's row and the slot at the head of the trail stay distinct. The slot before a header inserts ahead of its break, never between the break and the chip. The drop's neighbour rule and header reordering read data attributes, not positions.
- **Max-height cap and resize grip** apply as before: many groups scroll inside the strip.
- **Multi-tag sessions: unchanged.** `sectionTabs` places each session once, under its home tag; a session under two tags shows under the first in tag order only. The manager has put the once-versus-duplicate question to the user; nothing here prejudges it.

## Tests

- `ui/webview/dragslot.test.ts` executes `br`; `ui/webview/tab-groups.test.ts` pins the break ahead of each header, the break CSS, the retired separator, the painter excluding breaks, the drag boxes' `br`, and the once-per-session plan; `tab-drag-live.test.ts`'s separator pins retargeted.
- `tests/test_tab_groups_rows.py` drives the served `/chat` page in a real browser (skips loudly without one): three groups of mixed sizes, one wrapping onto a second row, one folded, and the trail, each header first on its row, in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
