### PR TITLE
Feed: each session header carries a Clear that clears every card of that session (grouped mode)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -46077,6 +46077,20 @@ class Handler(BaseHTTPRequestHandler):
             _gesture_store_refusal(client, "clear", _clear_ask(msg["itemId"]))
             _send_to_app("chat", {"type": "dropCitation", "itemId": str(msg["itemId"]), "itemIds": _gone})
             _mark_views_dirty()                # cleared.jsonl is invisible to the fleet sig → dirty-rebuild now
+        elif msg and msg.get("type") == "askClearMany" and isinstance(msg.get("itemIds"), list):
+            # ONE batch for a multi-card gesture (the feed's session Clear and the ask-group Clear): one
+            # cleared.jsonl stamp, so ONE UndoClear restores the whole gesture. N single askClear posts
+            # stamped N batches, and Undo brought back only the last-posted card while the client had
+            # optimistically restored all N: N-1 phantom cards the kernel had archived (the review of the
+            # session Clear, 2026-09-08). Same citation drop as askClear, over every card's subtree.
+            _ids = [str(i) for i in msg["itemIds"] if i]
+            _gone = []
+            for _i in _ids:
+                _gone.extend(x for x in _subtree_item_ids(_i) if x not in _gone)
+            _gesture_store_refusal(client, "clear", _clear_all(_ids))
+            if _ids:
+                _send_to_app("chat", {"type": "dropCitation", "itemId": _ids[0], "itemIds": _gone})
+            _mark_views_dirty()
         elif msg and msg.get("type") == "quarantineDecision" and msg.get("mid"):
             # Human verdict on a DIRECTED peer's held message (per-host trust): approve delivers it
             # (optionally with human-edited text), deny drops it. The bus owns delivery + the held-message

--- a/tests/test_clear_many.py
+++ b/tests/test_clear_many.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""askClearMany (2026-09-08): a multi-card clear gesture is ONE kernel batch, so one UndoClear restores it whole.
+
+The feed's session-header Clear and its ask-group Clear remove N cards in one click and cache them as one
+client-side Undo batch. Posted as N single askClear ops they became N kernel batches (_clear_all stamps one
+t per call, and _undo_clear restores only the ids at the newest stamp), so an Undo brought back only the
+last-posted card while the client had restored all N: N-1 phantom cards the kernel kept archived. The new
+op hands _clear_all the whole list.
+
+Synthetic sids (placeholder uuids) and node ids; hermetic state root; the socket client is a recording dict,
+the views-dirty hook a counter, the chat send a recorder."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_clear_many", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID_A = "11111111-2222-3333-4444-555555555555"
+IDS = [SID_A + ":g1", SID_A + ":g2", SID_A + ":g3"]
+
+
+class ClearMany(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._saved = (km.jd.STATE, km._mark_views_dirty, km._send_to_app)
+        km.jd.STATE = Path(self.td.name)
+        self.dirty, self.chat, self.sent = [], [], []
+        km._mark_views_dirty = lambda: self.dirty.append(1)
+        km._send_to_app = lambda app, m: self.chat.append((app, m))
+        self.client = {"app": "feed", "wid": "w1", "alive": True, "send": lambda raw: self.sent.append(json.loads(raw))}
+
+    def tearDown(self):
+        km.jd.STATE, km._mark_views_dirty, km._send_to_app = self._saved
+        self.td.cleanup()
+
+    def rows(self):
+        p = km.jd.STATE / "cleared.jsonl"
+        return [json.loads(l) for l in p.read_text().splitlines() if l.strip()] if p.exists() else []
+
+    def test_the_batch_is_one_stamp_and_one_undo_restores_it_whole(self):
+        km.Handler._dispatch_ws(None, {"type": "askClearMany", "itemIds": IDS, "sid": SID_A}, self.client)
+        clears = [r for r in self.rows() if r.get("op") == "clear"]
+        self.assertEqual(sorted(r["id"] for r in clears), sorted(IDS))
+        self.assertEqual(len({r["t"] for r in clears}), 1, "one batch, one stamp")
+        self.assertEqual(self.dirty, [1])
+        self.assertEqual(len(self.chat), 1, "one citation drop for the whole batch")
+        app, m = self.chat[0]
+        self.assertEqual((app, m["type"], m["itemId"]), ("chat", "dropCitation", IDS[0]))
+        self.assertEqual(sorted(m["itemIds"]), sorted(IDS), "every member's subtree (the id itself with no store)")
+        km._undo_clear()
+        self.assertEqual(len(km._cleared_ids()), 0, "the whole gesture comes back")
+
+    def test_n_single_clears_are_n_stamps_which_is_why_the_batch_op_exists(self):
+        for iid in IDS:
+            km.Handler._dispatch_ws(None, {"type": "askClear", "itemId": iid, "sid": SID_A}, self.client)
+        clears = [r for r in self.rows() if r.get("op") == "clear"]
+        self.assertEqual(len({r["t"] for r in clears}), 3, "three gestures, three stamps")
+        km._undo_clear()
+        self.assertEqual(len(km._cleared_ids()), 2, "one undo restores only the last-posted card")
+
+    def test_an_empty_or_junk_list_clears_nothing_and_says_nothing(self):
+        km.Handler._dispatch_ws(None, {"type": "askClearMany", "itemIds": [None, ""], "sid": SID_A}, self.client)
+        self.assertEqual(self.rows(), [])
+        self.assertEqual(self.chat, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -290,6 +290,8 @@ export function routeOutbound(msg: any, knownHosts?: ReadonlySet<string>): Route
   if (host !== LOCAL) {
     const out: any = { ...msg };
     for (const k of SCALAR_ID) if (typeof out[k] === "string") out[k] = bareId(out[k]);
+    // a batched clear (askClearMany) carries the session's card ids too — the remote kernel wants them bare
+    if (Array.isArray(out.itemIds)) out.itemIds = out.itemIds.map((x: any) => typeof x === "string" ? bareId(x) : x);
     return [{ host, msg: out }];
   }
 
@@ -1082,7 +1084,7 @@ export class FederationManager {
       return;
     }
     const routes = routeOutbound(m, new Set(this.hostSeq.filter((h) => h !== LOCAL)));
-    if (m && m.type === "askClear") this.lastClearHost = routes[0] ? routes[0].host : LOCAL;
+    if (m && (m.type === "askClear" || m.type === "askClearMany")) this.lastClearHost = routes[0] ? routes[0].host : LOCAL;
     for (const r of routes) {
       if (r.host === LOCAL) {
         const s = (window as any).__rompLocalSend;

--- a/ui/webview/feed-remote-actions.test.ts
+++ b/ui/webview/feed-remote-actions.test.ts
@@ -9,9 +9,11 @@ import * as path from "node:path";
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
 test("every askClear send carries the card's sid (routes a remote clear to its kernel)", () => {
-  const sends = FEED.match(/type: "askClear"[^}]*/g) || [];
-  assert.ok(sends.length >= 4, `found ${sends.length} askClear sends — expected the 4 known sites (standalone card removed 2026-07-07)`);
-  for (const s of sends) assert.match(s, /sid: (it|m|mem)\.sid/, `askClear send missing sid: ${s}`);
+  // single-card clears post askClear; the group card, the modal's group clear and the session header post
+  // ONE askClearMany for the batch (2026-09-08) — every one of them carries the session id
+  const sends = FEED.match(/type: "askClear(?:Many)?"[^}]*/g) || [];
+  assert.ok(sends.length >= 5, `found ${sends.length} clear sends — expected the 5 known sites`);
+  for (const s of sends) assert.match(s, /,\s*sid(: (it|m|mem|cur|grp)\.sid)?\s*$/, `clear send missing sid: ${s}`);   // explicit or shorthand property
 });
 
 test("every showAskPath send carries a sid (a remote card's hover highlight routes to its kernel)", () => {

--- a/ui/webview/feed-sess-clear.test.ts
+++ b/ui/webview/feed-sess-clear.test.ts
@@ -1,0 +1,60 @@
+// The session header's Clear (the user 2026-09-08): in grouped mode, each session header carries a Clear
+// on the far right of its row that clears every card of that session in the current view — every column,
+// folded ones included — as one motion and ONE Undo batch, through the same optimistic path the ask-group
+// clear takes. Only grouped mode renders headers, so the control exists only there. Source pins, in the
+// style of the other feed tests.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+
+test("the header carries a plain-worded Clear on the far right, hidden when the session has no cards", () => {
+  assert.match(FEED, /const clr = el\("button", "feed-sess-clear"\); clr\.textContent = "Clear";/);
+  assert.match(FEED, /clr\.title = "Clear every card for this session"; clr\.dataset\.act = "sess-clear";/);
+  // after the caret, count and service chip; before the full-width process list that wraps below
+  assert.match(FEED, /h\.append\(nm, fold, cnt, svc, clr, svcList\);/);
+  assert.match(FEED, /sclr\.dataset\.fsid = e\.sid;\s*\n\s*const ncards = sessionCards\(e\.sid\)\.length;\s*\n\s*sclr\.style\.display = ncards \? "" : "none";/);
+  // no romp nouns in the copy: not "board", "goal", "card"… the button says the one word every card's Clear says
+  const copy = FEED.match(/clr\.title = "([^"]+)"; clr\.dataset\.act = "sess-clear"/)![1];
+  for (const noun of ["board", "goal", "column", "dismiss", "nudge"]) assert.doesNotMatch(copy, new RegExp(noun, "i"));
+});
+
+test("grouped mode only: headers (and so the control) are emitted under the grouped guard", () => {
+  // the header entries are built inside `if (feedPrefs().grouped)`; flat mode never has a header to carry it
+  const guard = FEED.indexOf("if (feedPrefs().grouped) {\n    const rank = new Map(sessionOrder.map(");
+  assert.ok(guard > 0, "the grouped-mode header build lives under the grouped guard");
+  assert.match(FEED.slice(guard, guard + 2500), /head = \{ kind: "sess", t: e\.t, sid: s, name: src\.name/);
+  assert.match(FEED, /function dressHeaderIfLast\(card: HTMLElement, sid: string\): void \{\s*\n\s*if \(!feedPrefs\(\)\.grouped\) return;/);
+});
+
+test("the click is delegated on the stable columns root, never bound to the re-rendered header", () => {
+  assert.match(FEED, /import \{ delegate \} from "\.\/actions";/);
+  const at = FEED.indexOf('const cols = el("div", "feed-cols"); cols.id = "feed-cols";');
+  assert.ok(at > 0);
+  assert.match(FEED.slice(at, at + 900), /delegate\(cols, \{\s*\n\s*"sess-clear": \(b, ev\) => \{ ev\.stopPropagation\(\); const sid = b\.dataset\.fsid; if \(sid\) clearSessionCards\(sid\); \},/);
+  assert.doesNotMatch(FEED, /sclr\.onclick|clr\.onclick = \(ev\) => \{[^}]*clearSessionCards/, "no handler on the header's own node");
+});
+
+test("one click clears every card of the session in the current view, as one Undo batch, through the group-clear path", () => {
+  assert.match(FEED, /function sessionCards\(sid: string\): AskItem\[\] \{\s*\n\s*return viewFiltered\(asks\)\.filter\(\(a\) => a\.sid === sid\);/,
+    "the current view's cards for the session — every column; folded cards are in the view too");
+  const fn = FEED.slice(FEED.indexOf("function clearSessionCards(sid: string): void {"), FEED.indexOf("function reconcileCol("));
+  assert.match(fn, /clearedStack\.push\(members\.slice\(\)\);/, "ONE batch: one Undo restores the whole session");
+  assert.match(fn, /for \(const m of members\) \{ pendingCleared\.add\(m\.itemId\); vscodeApi\?\.postMessage\(\{ type: "askClear", itemId: m\.itemId, sid: m\.sid \}\); \}/,
+    "askClear per member, suppressed from incoming pushes until the kernel confirms");
+  assert.match(fn, /c\.dispatchEvent\(new MouseEvent\("mouseleave"\)\); c\.classList\.add\("dismissing"\);/, "flush the hover highlight, animate out");
+  assert.match(fn, /if \(head\.getAttribute\("data-fsid"\) === sid\) startSessHeadExit\(key, head\);/, "every column's header leaves with its run, one motion");
+  assert.match(fn, /setTimeout\(\(\) => \{[\s\S]*stillOurs\(\) && c\.classList\.contains\("dismissing"\)[\s\S]*dropDismissed\(ids\);\s*\n\s*\}, 180\);/,
+    "finalize after the 180ms exit, only what is still ours and still dismissing");
+  assert.doesNotMatch(fn, /confirm\(/, "no confirm dialog: Undo is the safety net");
+});
+
+test("the control wears the header's size and the caret's quiet monochrome treatment, pushed to the far right", () => {
+  assert.match(CSS, /\.feed-sess-clear \{ flex: none; margin-left: auto; padding: 0 5px; color: var\(--dim\); background: transparent;\s*\n\s*border: 0; font: inherit; font-weight: 400; line-height: 1; cursor: pointer;/);
+  assert.match(CSS, /\.feed-sess-clear:hover, \.feed-sess-clear:focus-visible \{ color: var\(--fg\); \}/);
+  assert.doesNotMatch(CSS, /\.feed-sess-clear[^\n]*font-size/, "no new font size on this surface");
+  assert.doesNotMatch(CSS, /\.feed-sess-clear[^\n]*(red|--st-|--accent)/, "monochrome: no status colour, no accent");
+});

--- a/ui/webview/feed-sess-clear.test.ts
+++ b/ui/webview/feed-sess-clear.test.ts
@@ -1,29 +1,31 @@
 // The session header's Clear (the user 2026-09-08): in grouped mode, each session header carries a Clear
-// on the far right of its row that clears every card of that session in the current view — every column,
-// folded ones included — as one motion and ONE Undo batch, through the same optimistic path the ask-group
-// clear takes. Only grouped mode renders headers, so the control exists only there. Source pins, in the
-// style of the other feed tests.
+// on the far right of its row that clears every clearable card of that session in the current view — every
+// column, folded ones included — as one motion and ONE Undo batch, on the client (clearedStack) AND on the
+// kernel (one askClearMany, one cleared.jsonl stamp). Only grouped mode renders headers, so the control
+// exists only there. Source pins, in the style of the other feed tests, plus the router's handling of the
+// batch message.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { routeOutbound } from "./federation";
 
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 
-test("the header carries a plain-worded Clear on the far right, hidden when the session has no cards", () => {
+test("the header carries a plain-worded Clear on the far right, hidden when the session has no clearable cards", () => {
   assert.match(FEED, /const clr = el\("button", "feed-sess-clear"\); clr\.textContent = "Clear";/);
-  assert.match(FEED, /clr\.title = "Clear every card for this session"; clr\.dataset\.act = "sess-clear";/);
+  // lowercase like every sibling tooltip on the header row (the caret's, the service chip's)
+  assert.match(FEED, /clr\.title = "clear every card for this session"; clr\.dataset\.act = "sess-clear";/);
+  assert.match(FEED, /sclr\.setAttribute\("aria-label", "clear every card for " \+ e\.name\);/);
   // after the caret, count and service chip; before the full-width process list that wraps below
   assert.match(FEED, /h\.append\(nm, fold, cnt, svc, clr, svcList\);/);
   assert.match(FEED, /sclr\.dataset\.fsid = e\.sid;\s*\n\s*const ncards = sessionCards\(e\.sid\)\.length;\s*\n\s*sclr\.style\.display = ncards \? "" : "none";/);
-  // no romp nouns in the copy: not "board", "goal", "card"… the button says the one word every card's Clear says
-  const copy = FEED.match(/clr\.title = "([^"]+)"; clr\.dataset\.act = "sess-clear"/)![1];
-  for (const noun of ["board", "goal", "column", "dismiss", "nudge"]) assert.doesNotMatch(copy, new RegExp(noun, "i"));
 });
 
 test("grouped mode only: headers (and so the control) are emitted under the grouped guard", () => {
-  // the header entries are built inside `if (feedPrefs().grouped)`; flat mode never has a header to carry it
   const guard = FEED.indexOf("if (feedPrefs().grouped) {\n    const rank = new Map(sessionOrder.map(");
   assert.ok(guard > 0, "the grouped-mode header build lives under the grouped guard");
   assert.match(FEED.slice(guard, guard + 2500), /head = \{ kind: "sess", t: e\.t, sid: s, name: src\.name/);
@@ -35,26 +37,56 @@ test("the click is delegated on the stable columns root, never bound to the re-r
   const at = FEED.indexOf('const cols = el("div", "feed-cols"); cols.id = "feed-cols";');
   assert.ok(at > 0);
   assert.match(FEED.slice(at, at + 900), /delegate\(cols, \{\s*\n\s*"sess-clear": \(b, ev\) => \{ ev\.stopPropagation\(\); const sid = b\.dataset\.fsid; if \(sid\) clearSessionCards\(sid\); \},/);
-  assert.doesNotMatch(FEED, /sclr\.onclick|clr\.onclick = \(ev\) => \{[^}]*clearSessionCards/, "no handler on the header's own node");
+  const head = FEED.slice(FEED.indexOf("function makeSessHead()"), FEED.indexOf("function updateSessHead("));
+  assert.doesNotMatch(head, /clr\.(onclick|addEventListener)/, "no handler on the header's own node");
 });
 
-test("one click clears every card of the session in the current view, as one Undo batch, through the group-clear path", () => {
-  assert.match(FEED, /function sessionCards\(sid: string\): AskItem\[\] \{\s*\n\s*return viewFiltered\(asks\)\.filter\(\(a\) => a\.sid === sid\);/,
+test("what it clears: the session's CLEARABLE cards in the current view — never a placeholder or a quarantine hold", () => {
+  assert.match(FEED, /function clearable\(it: AskItem\): boolean \{\s*\n\s*return !it\.provisional && it\.blocked\?\.state !== "quarantine";/);
+  assert.match(FEED, /function sessionCards\(sid: string\): AskItem\[\] \{\s*\n\s*return viewFiltered\(asks\)\.filter\(\(a\) => a\.sid === sid && clearable\(a\)\);/,
     "the current view's cards for the session — every column; folded cards are in the view too");
+});
+
+test("one click, one Undo batch on the client AND on the kernel, through the group-clear path", () => {
   const fn = FEED.slice(FEED.indexOf("function clearSessionCards(sid: string): void {"), FEED.indexOf("function reconcileCol("));
-  assert.match(fn, /clearedStack\.push\(members\.slice\(\)\);/, "ONE batch: one Undo restores the whole session");
-  assert.match(fn, /for \(const m of members\) \{ pendingCleared\.add\(m\.itemId\); vscodeApi\?\.postMessage\(\{ type: "askClear", itemId: m\.itemId, sid: m\.sid \}\); \}/,
-    "askClear per member, suppressed from incoming pushes until the kernel confirms");
+  assert.match(fn, /clearedStack\.push\(members\.slice\(\)\);/, "ONE client batch: one Undo restores the whole session");
+  assert.match(fn, /for \(const m of members\) pendingCleared\.add\(m\.itemId\);/, "suppressed from incoming pushes until the kernel confirms");
+  assert.match(fn, /vscodeApi\?\.postMessage\(\{ type: "askClearMany", itemIds: ids, sid \}\);/,
+    "ONE kernel batch: N askClear posts stamped N batches and the kernel's Undo restored only the last");
+  assert.doesNotMatch(fn, /type: "askClear",/, "no per-member posts");
   assert.match(fn, /c\.dispatchEvent\(new MouseEvent\("mouseleave"\)\); c\.classList\.add\("dismissing"\);/, "flush the hover highlight, animate out");
   assert.match(fn, /if \(head\.getAttribute\("data-fsid"\) === sid\) startSessHeadExit\(key, head\);/, "every column's header leaves with its run, one motion");
-  assert.match(fn, /setTimeout\(\(\) => \{[\s\S]*stillOurs\(\) && c\.classList\.contains\("dismissing"\)[\s\S]*dropDismissed\(ids\);\s*\n\s*\}, 180\);/,
-    "finalize after the 180ms exit, only what is still ours and still dismissing");
+  assert.match(fn, /setTimeout\(\(\) => \{[\s\S]*stillOurs\(\) && c\.classList\.contains\("dismissing"\)[\s\S]*dropDismissed\(ids\.filter\(\(id\) => pendingCleared\.has\(id\)\)\);\s*\n\s*\}, 180\);/,
+    "finalize after the 180ms exit only what is still ours and still dismissing; drop only ids still pending (an Undo inside the window keeps its cards)");
   assert.doesNotMatch(fn, /confirm\(/, "no confirm dialog: Undo is the safety net");
+  // the ask-group clear and the modal's group clear ride the same batch op — their Undo had the same hole
+  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "askClearMany", itemIds: cur\.members\.map\(\(m\) => m\.itemId\), sid: cur\.sid \}\);/);
+  assert.match(FEED, /type: "askClearMany", itemIds: grp\.members\.map\(\(mem\) => mem\.itemId\), sid: grp\.sid/);
+});
+
+test("the kernel takes the batch as one cleared.jsonl stamp and drops every member's citations", () => {
+  const op = KERNEL.slice(KERNEL.indexOf('msg.get("type") == "askClearMany"'), KERNEL.indexOf('msg.get("type") == "quarantineDecision"'));
+  assert.match(op, /_ids = \[str\(i\) for i in msg\["itemIds"\] if i\]/);
+  assert.match(op, /_gesture_store_refusal\(client, "clear", _clear_all\(_ids\)\)/, "one _clear_all call = one batch stamp");
+  assert.match(op, /_subtree_item_ids\(_i\)/, "the citation drop covers every member's subtree");
+  assert.match(op, /_send_to_app\("chat", \{"type": "dropCitation", "itemId": _ids\[0\], "itemIds": _gone\}\)/);
+  assert.match(op, /_mark_views_dirty\(\)/);
+});
+
+test("the router sends the batch to the session's kernel with bare ids, and Undo follows it there", () => {
+  const r = routeOutbound({ type: "askClearMany", sid: "box2:11111111-2222-3333-4444-555555555555", itemIds: ["box2:11111111-2222-3333-4444-555555555555:g1", "box2:11111111-2222-3333-4444-555555555555:g2"] }, new Set(["box2"]));
+  assert.equal(r.length, 1);
+  assert.equal(r[0].host, "box2");
+  assert.equal(r[0].msg.sid, "11111111-2222-3333-4444-555555555555");
+  assert.deepEqual(r[0].msg.itemIds, ["11111111-2222-3333-4444-555555555555:g1", "11111111-2222-3333-4444-555555555555:g2"]);
+  assert.match(FED, /if \(m && \(m\.type === "askClear" \|\| m\.type === "askClearMany"\)\) this\.lastClearHost = /,
+    "undoClear follows the LAST clear, batched or single, to the kernel that took it");
 });
 
 test("the control wears the header's size and the caret's quiet monochrome treatment, pushed to the far right", () => {
   assert.match(CSS, /\.feed-sess-clear \{ flex: none; margin-left: auto; padding: 0 5px; color: var\(--dim\); background: transparent;\s*\n\s*border: 0; font: inherit; font-weight: 400; line-height: 1; cursor: pointer;/);
   assert.match(CSS, /\.feed-sess-clear:hover, \.feed-sess-clear:focus-visible \{ color: var\(--fg\); \}/);
-  assert.doesNotMatch(CSS, /\.feed-sess-clear[^\n]*font-size/, "no new font size on this surface");
-  assert.doesNotMatch(CSS, /\.feed-sess-clear[^\n]*(red|--st-|--accent)/, "monochrome: no status colour, no accent");
+  // negatives scoped to the RULE BLOCK, not the selector's line (a second-line font-size or accent must fail)
+  assert.doesNotMatch(CSS, /\.feed-sess-clear \{[^}]*font-size/, "no new font size on this surface");
+  assert.doesNotMatch(CSS, /\.feed-sess-clear[^{]*\{[^}]*(red|--st-|--accent)/, "monochrome: no status colour, no accent");
 });

--- a/ui/webview/feed-thread-fold.test.ts
+++ b/ui/webview/feed-thread-fold.test.ts
@@ -17,7 +17,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("the caret sits to the RIGHT of the session name, where it was asked for", () => {
   assert.match(FEED, /const fold = el\("button", "feed-sess-fold"\);/);
-  assert.match(FEED, /h\.append\(nm, fold, cnt, svc, svcList\);/, "name, then caret — not a leading tree triangle");
+  assert.match(FEED, /h\.append\(nm, fold, cnt, svc, clr, svcList\);/, "name, then caret — not a leading tree triangle (the session-wide Clear sits after, at the far right; the user 2026-09-08)");
 });
 
 test("it is a caret, and it says which way it will go", () => {

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -430,6 +430,15 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 /* a folded header IS its whole group, so it takes the bottom margin the run of cards would have had —
    without it, consecutive folded threads jam into one unreadable stack of names. */
 .feed-sess-head.folded { margin-bottom: 7px; }
+/* the session-wide CLEAR (the user 2026-09-08): far right of the header row (margin-left:auto, before the
+   full-width process list that wraps below), the header's own size (font: inherit — no new size on this
+   surface) and the caret's quiet treatment — bare word, no chip box, dim at rest and full strength on
+   hover/focus, un-bolded from the header's 600 so the name stays the thing you read. Monochrome on
+   purpose: red is the card-level Clear's hover, and a whole run leaving is announced by the cards' own
+   exit, not by a coloured button on every header. The hit area is padded for a thumb. */
+.feed-sess-clear { flex: none; margin-left: auto; padding: 0 5px; color: var(--dim); background: transparent;
+  border: 0; font: inherit; font-weight: 400; line-height: 1; cursor: pointer; transition: color 0.12s ease; }
+.feed-sess-clear:hover, .feed-sess-clear:focus-visible { color: var(--fg); }
 /* the neutral background-process chip on the header (kernel bgServices): a process the session KEEPS
    (a dev server the judge classified as nobody-waits). Reuses the .fask-secbtn chip vocabulary — dim,
    0.74em, accent only while its list is open (a selected toggle, the accent's job) — and un-bolds from

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -8,6 +8,7 @@
 // when the fleet streams new deliverables in.
 import { distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote } from "./distiller-line";
 import { flipNeeded } from "./feed-flip";
+import { delegate } from "./actions";
 import { paintHeld, paintReleased } from "./paint-gate";
 import { linkifyPrRefs, setLinkedText, senderPrRepo, installPrLinkOpener } from "./pr-links";
 import { spinFor, waitedSuffix, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow } from "./spin-caption";
@@ -3429,9 +3430,17 @@ function makeSessHead(): HTMLElement {
   // most. The count beside it is what keeps the folded row from dead-ending — you can see what is under it.
   const fold = el("button", "feed-sess-fold");
   const cnt = el("span", "feed-sess-foldn"); cnt.style.display = "none";
-  h.append(nm, fold, cnt, svc, svcList);
+  // CLEAR for the whole session (the user 2026-09-08): far right of the header row, the header's own size,
+  // as quiet as the caret — one word, the same "Clear" every card wears. One click clears every card this
+  // session has in the current view (every column, folded ones included), with the same optimistic Undo
+  // the group clear uses instead of a confirm dialog. The action is DELEGATED on the stable columns root
+  // (data-act, installed once where the root is built) — never bound to this header node, which grouped
+  // mode re-homes and re-renders; the header only says which session it stands for (data-fsid).
+  const clr = el("button", "feed-sess-clear"); clr.textContent = "Clear";
+  clr.title = "Clear every card for this session"; clr.dataset.act = "sess-clear"; clr.style.display = "none";
+  h.append(nm, fold, cnt, svc, clr, svcList);
   (h as any)._name = nm; (h as any)._fold = fold; (h as any)._foldn = cnt;
-  (h as any)._svc = svc; (h as any)._svcList = svcList;
+  (h as any)._svc = svc; (h as any)._svcList = svcList; (h as any)._clear = clr;
   return h;
 }
 function updateSessHead(h: HTMLElement, e: Entry & { kind: "sess" }): void {
@@ -3459,6 +3468,13 @@ function updateSessHead(h: HTMLElement, e: Entry & { kind: "sess" }): void {
     if (collapsedThreads.has(e.sid)) collapsedThreads.delete(e.sid); else collapsedThreads.add(e.sid);
     render();
   };
+  // the session-wide Clear: which session, and only while it has cards in the current view (a header
+  // exists only for a run, so this is a guard against a stale header, not a common state)
+  const sclr = (h as any)._clear as HTMLElement;
+  sclr.dataset.fsid = e.sid;
+  const ncards = sessionCards(e.sid).length;
+  sclr.style.display = ncards ? "" : "none";
+  sclr.setAttribute("aria-label", "clear every card for " + e.name);
   const svc = (h as any)._svc as HTMLElement, svcList = (h as any)._svcList as HTMLElement;
   const procs = e.live ? bgServicesMap[e.name] || [] : [];
   const open = procs.length > 0 && openBgSvc.has(e.sid);
@@ -4091,6 +4107,12 @@ function ensureCols(list: HTMLElement) {
   if (!document.getElementById("feed-cols")) {
     list.innerHTML = "";
     const cols = el("div", "feed-cols"); cols.id = "feed-cols";
+    // Header actions ride the STABLE columns root (the click-safety rule): the header nodes under it are
+    // re-homed and re-rendered on every push, and a native click needs mousedown and mouseup on one element.
+    // delegate() also flashes the pressed control (.romp-acted), the instant acknowledgement.
+    delegate(cols, {
+      "sess-clear": (b, ev) => { ev.stopPropagation(); const sid = b.dataset.fsid; if (sid) clearSessionCards(sid); },
+    });
     // "Working" (the user's rename, 2026-06-11): every card is an ASK; the left
     // column holds the ones being worked — internal keys keep the old names
     // each header is a filled state chip reproducing the chat status chips
@@ -4173,6 +4195,42 @@ function dressHeaderIfLast(card: HTMLElement, sid: string): void {
   }
   const key = head.dataset.key || "";
   startSessHeadExit(key, head);
+}
+
+// Every card a session has in the CURRENT view (the same filters render reads: scope, lens, `#only=`),
+// across every column, folded-under-the-header ones included — the set the header's Clear removes.
+function sessionCards(sid: string): AskItem[] {
+  return viewFiltered(asks).filter((a) => a.sid === sid);
+}
+// The session header's Clear (the user 2026-09-08): one click, every card of that session in the current
+// view, as ONE motion and ONE Undo batch. The same optimistic path the ask-group clear takes, applied to
+// every card and turn-group of the session in every column: flush each card's cross-surface hover
+// highlight, mark it .dismissing, start every column's header for this session on its exit at the same
+// moment (the one-motion rule), cache the whole batch on clearedStack so Undo restores the session in one
+// click, suppress the ids from incoming pushes (pendingCleared) and post askClear per card. Finalize after
+// the 180ms exit only what is STILL ours and still dismissing — a render inside the window that revived a
+// card (re-render resets its class) or replaced its element must not be yanked by a stale timeout.
+function clearSessionCards(sid: string): void {
+  const members = sessionCards(sid);
+  if (!members.length) return;
+  const ids = members.map((m) => m.itemId);
+  const turns = new Set(members.map((m) => m.turnId).filter(Boolean));
+  const leaving: [HTMLElement, () => boolean, () => void][] = [];
+  for (const m of members) {
+    const c = askEls.get(m.itemId);
+    if (c) leaving.push([c, () => askEls.get(m.itemId) === c, () => askEls.delete(m.itemId)]);
+  }
+  for (const [tid, g] of Array.from(groupEls)) {
+    if (turns.has(tid) && ((g as any)._g as AskGroup | undefined)?.sid === sid) leaving.push([g, () => groupEls.get(tid) === g, () => groupEls.delete(tid)]);
+  }
+  for (const [c] of leaving) { c.dispatchEvent(new MouseEvent("mouseleave")); c.classList.add("dismissing"); }
+  for (const [key, head] of Array.from(sessHeadEls)) if (head.getAttribute("data-fsid") === sid) startSessHeadExit(key, head);
+  clearedStack.push(members.slice());   // one batch: one Undo brings the whole session back
+  for (const m of members) { pendingCleared.add(m.itemId); vscodeApi?.postMessage({ type: "askClear", itemId: m.itemId, sid: m.sid }); }
+  setTimeout(() => {
+    for (const [c, stillOurs, forget] of leaving) if (stillOurs() && c.classList.contains("dismissing")) { c.remove(); forget(); }
+    dropDismissed(ids);
+  }, 180);
 }
 
 function reconcileCol(listEl: HTMLElement, entries: Entry[], globalDesired: Set<string>) {

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -2494,7 +2494,10 @@ function makeGroupCard(g: AskGroup): HTMLElement {
     dressHeaderIfLast(card, cur.sid);   // a group is one session's turn — same one-motion rule (2026-08-24)
     card.classList.add("dismissing");
     clearedStack.push(cur.members.slice());   // cache the whole batch for an instant optimistic Undo
-    for (const m of cur.members) { pendingCleared.add(m.itemId); vscodeApi?.postMessage({ type: "askClear", itemId: m.itemId, sid: m.sid }); }   // clear every member
+    for (const m of cur.members) pendingCleared.add(m.itemId);
+    // ONE kernel batch for every member (askClearMany): the kernel's Undo restores a batch by its one
+    // stamp, so per-member posts left N-1 members archived after an Undo the client had shown whole
+    vscodeApi?.postMessage({ type: "askClearMany", itemIds: cur.members.map((m) => m.itemId), sid: cur.sid });
     // only finalize if a render in the 180ms window didn't revive (re-render clears
     // .dismissing) or replace this card — else a stale timeout yanks the wrong one
     setTimeout(() => { if (groupEls.get(cur.turnId) === card && card.classList.contains("dismissing")) { card.remove(); groupEls.delete(cur.turnId); dropDismissed(cur.members.map((m) => m.itemId)); } }, 180);
@@ -3311,7 +3314,7 @@ function renderModal() {
     ageEl.textContent = relAge(hostNow - grp.t);
     wireAgeTip(ageEl, () => provenanceGroupRows(grp.members.map(rootStart), grp.t, hostNow, PROV_FMT));
     ageEl.style.color = "rgb(" + grp.trgb.join(",") + ")";   // tint the age by recency (the time colour scheme)
-    clrEl.onclick = () => { for (const mem of grp.members) vscodeApi?.postMessage({ type: "askClear", itemId: mem.itemId, sid: mem.sid }); fullscreenAskId = null; renderModal(); };
+    clrEl.onclick = () => { vscodeApi?.postMessage({ type: "askClearMany", itemIds: grp.members.map((mem) => mem.itemId), sid: grp.sid }); fullscreenAskId = null; renderModal(); };   // one batch, one Undo
     // follow-up on a group goes to the session that took the typed prompt — one
     // message prefixed with the GROUP title, filed under the first member's ask
     wireFollowUp(fupEl, fuboxEl, fuinEl, fusendEl, (txt) => postFollowUp(txt, grp.members[0].itemId, grp.members[0].sid, grp.title));
@@ -3437,7 +3440,7 @@ function makeSessHead(): HTMLElement {
   // (data-act, installed once where the root is built) — never bound to this header node, which grouped
   // mode re-homes and re-renders; the header only says which session it stands for (data-fsid).
   const clr = el("button", "feed-sess-clear"); clr.textContent = "Clear";
-  clr.title = "Clear every card for this session"; clr.dataset.act = "sess-clear"; clr.style.display = "none";
+  clr.title = "clear every card for this session"; clr.dataset.act = "sess-clear"; clr.style.display = "none";
   h.append(nm, fold, cnt, svc, clr, svcList);
   (h as any)._name = nm; (h as any)._fold = fold; (h as any)._foldn = cnt;
   (h as any)._svc = svc; (h as any)._svcList = svcList; (h as any)._clear = clr;
@@ -4197,19 +4200,31 @@ function dressHeaderIfLast(card: HTMLElement, sid: string): void {
   startSessHeadExit(key, head);
 }
 
-// Every card a session has in the CURRENT view (the same filters render reads: scope, lens, `#only=`),
-// across every column, folded-under-the-header ones included — the set the header's Clear removes.
+// What a Clear may take: not a PLACEHOLDER (provisional / awaiting / blocked stand-ins carry no goal to
+// curate — the kernel keeps listing them, so a clear would only suppress them on this page until reload)
+// and not a QUARANTINE hold (a held peer message is approved or denied, never cleared — clearing would
+// hide its only surface while the held file stayed undelivered). The card-level Clear hides itself for
+// both; the session Clear must not reach around that (the review of the session Clear, 2026-09-08).
+function clearable(it: AskItem): boolean {
+  return !it.provisional && it.blocked?.state !== "quarantine";
+}
+// Every CLEARABLE card a session has in the CURRENT view (the same filters render reads: scope, lens,
+// `#only=`), across every column, folded-under-the-header ones included — the set the header's Clear removes.
 function sessionCards(sid: string): AskItem[] {
-  return viewFiltered(asks).filter((a) => a.sid === sid);
+  return viewFiltered(asks).filter((a) => a.sid === sid && clearable(a));
 }
 // The session header's Clear (the user 2026-09-08): one click, every card of that session in the current
 // view, as ONE motion and ONE Undo batch. The same optimistic path the ask-group clear takes, applied to
 // every card and turn-group of the session in every column: flush each card's cross-surface hover
 // highlight, mark it .dismissing, start every column's header for this session on its exit at the same
 // moment (the one-motion rule), cache the whole batch on clearedStack so Undo restores the session in one
-// click, suppress the ids from incoming pushes (pendingCleared) and post askClear per card. Finalize after
-// the 180ms exit only what is STILL ours and still dismissing — a render inside the window that revived a
-// card (re-render resets its class) or replaced its element must not be yanked by a stale timeout.
+// click, suppress the ids from incoming pushes (pendingCleared) and post ONE askClearMany — one kernel
+// batch, one cleared.jsonl stamp, so the kernel's UndoClear restores the whole gesture the way the client's
+// does (N single posts stamped N batches, and Undo brought back only the last-posted card while the
+// client restored all N: phantom cards). Finalize after the 180ms exit only what is STILL ours and still
+// dismissing — a render inside the window that revived a card (re-render resets its class) or replaced
+// its element must not be yanked by a stale timeout — and drop from the model only ids still pending
+// (an Undo inside the window deleted its ids from pendingCleared; a kernel-confirmed clear already left).
 function clearSessionCards(sid: string): void {
   const members = sessionCards(sid);
   if (!members.length) return;
@@ -4226,10 +4241,11 @@ function clearSessionCards(sid: string): void {
   for (const [c] of leaving) { c.dispatchEvent(new MouseEvent("mouseleave")); c.classList.add("dismissing"); }
   for (const [key, head] of Array.from(sessHeadEls)) if (head.getAttribute("data-fsid") === sid) startSessHeadExit(key, head);
   clearedStack.push(members.slice());   // one batch: one Undo brings the whole session back
-  for (const m of members) { pendingCleared.add(m.itemId); vscodeApi?.postMessage({ type: "askClear", itemId: m.itemId, sid: m.sid }); }
+  for (const m of members) pendingCleared.add(m.itemId);
+  vscodeApi?.postMessage({ type: "askClearMany", itemIds: ids, sid });   // ONE kernel batch (see above)
   setTimeout(() => {
     for (const [c, stillOurs, forget] of leaving) if (stillOurs() && c.classList.contains("dismissing")) { c.remove(); forget(); }
-    dropDismissed(ids);
+    dropDismissed(ids.filter((id) => pendingCleared.has(id)));
   }, 180);
 }
 


### PR DESCRIPTION
The user's ask (2026-09-08): in the feed's group-by-session mode, a Clear on the far right of the line that shows the session's name on the left, clearing every card of that session. Grouped mode only.

## What it does
- **The control.** Each grouped-mode session header row ends in a plain "Clear" (tooltip "clear every card for this session"), after the fold caret, count and background-process chip and before the process list that wraps below, in the header's own size and the caret's quiet monochrome treatment. Hidden when the session has nothing clearable in the view. Flat mode has no headers, so no button.
- **What one click clears.** Every **clearable** card the session has in the **current view** (the same scope, lens and `#only=` filters render reads), across all three columns, **folded** (collapsed-thread) cards included. Not cleared: cards hidden by the view's filters (they are not in the view), and cards whose own Clear hides itself: **placeholders** (provisional / awaiting / blocked stand-ins the kernel keeps listing, so a clear would only suppress them on this page) and **quarantine holds** (a held peer message is approved or denied, never cleared). `clearable()` names that rule once; the button's visibility follows it.
- **One motion, one Undo.** The same optimistic path the ask-group clear takes, applied to every card and turn-group of the session: hover highlight flushed, `.dismissing`, every column's header for the session starts its exit at the same moment, the batch cached on `clearedStack` so **one Undo restores the session**, `pendingCleared` per id, finalize after the 180 ms exit only what is still ours and still dismissing (and drop from the model only ids still pending, so an Undo inside the window keeps its cards). No confirm dialog: Undo is the safety net, and the click acknowledges at once (press pulse; the cards animate out).
- **Click-safe by construction.** The action is delegated on the stable columns root (`data-act`, installed once where the root is built), never bound to the header node grouped mode re-homes on every push.

## The kernel half (found by the review, fixes a pre-existing hole too)
The client cached N cards as one Undo batch but the wire had only single-card `askClear`, and the kernel stamps one `cleared.jsonl` batch per `_clear_all` call and restores only the newest stamp on `undoClear`: an Undo after a multi-card clear brought back the last-posted card on the kernel while the client had restored all N, leaving N-1 phantom cards until reload. The ask-group Clear had the same shape. New op **`askClearMany`** (`itemIds` + `sid`): one `_clear_all` call, one stamp, the same citation drop over every member's subtree. The session Clear, the ask-group Clear and the modal's group Clear post it; `routeOutbound` strips the ids' host prefixes for a remote kernel and `undoClear` follows the batch to the kernel that took it.

## Tests
- `ui/webview/feed-sess-clear.test.ts`: the control (copy, position, hidden at zero), grouped-only, the delegation, the clearable rule, the one-batch path on client and kernel, the router's handling of the batch (behavioural, via `routeOutbound`), the CSS (block-scoped negatives). `feed-thread-fold` and `feed-remote-actions` pins follow the new child order and the batched sends.
- `tests/test_clear_many.py`: through the real dispatcher, three ids in one op share one stamp and one undo restores all three; three single ops are three stamps and one undo restores one (why the op exists); an empty list clears nothing.
- Webview suite 3422 passed; typecheck clean; kernel tests for clears and the goal-store fault boundary pass.
- A two-lens adversarial review (UI correctness; tests and conventions) ran on the first commit; its critical (the Undo batch), major (placeholders and holds) and four minor findings are folded in the second commit.

## Screenshots
Taken from the served feed page with a synthetic notes-api world (web / api / tests): grouped feed with the header row in dark and light, and the board after clearing the web session with Undo in the footer. Sent to the manager with this PR's number.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)