### PR TITLE
Redact both pieces of a cut value when either piece is credential-shaped

### DIFF
--- a/tests/credential_patterns.py
+++ b/tests/credential_patterns.py
@@ -88,8 +88,9 @@ bound) is the JWT rule's, which takes the cut and its dotted tail the same way. 
 a cut token with more than JWT_HEADER_MAX characters between `eyJ` and the first dot or the cut,
 whichever comes first — a header past the bound with the cut anywhere after its first JWT_HEADER_MAX
 characters (a cut inside such a header within them is the cut rule's match: the bound is on the head,
-not the header): in a quoted repr the fragment rule takes its head and its tail as two matches, in a
-value position the generic rule takes the head and the tail shows, and in bare text the header shows
+not the header): in a quoted repr the fragment rule takes its head and its tail in one paired match (a
+marker on each side of the cut), in a value position the generic rule takes the head and the tail
+shows, and in bare text the header shows
 — whole, with the cut and the tail, when the cut is inside it; up to its dot when the cut is in the
 payload, where the payload's own `eyJ` (a JSON payload begins with one too) is the cut rule's match
 with the cut and the tail. No enumerated tool leaves a head of that width (pytest's widest default
@@ -105,7 +106,18 @@ camelCase or PascalCase name (`'SessionStart...'`, `'HookEndToEnd...'`), a cut I
 (`'python38...'`) are redacted. That is a readability cost in a cut repr, taken on purpose: a
 PascalCase name's letters are a shape a base64 tail without a digit takes for one 8-character
 fragment in 25 (one in 200 at 13), and a digit-bearing run is the shape of a hex tail, so an
-exclusion for either would pass fragments of a key.
+exclusion for either would pass fragments of a key. The two runs on the sides of one cut are pieces of
+ONE value (pytest cuts one operand's repr, unittest one element's), so when either qualifies the other
+is a piece of the same value whatever its alphabet, and the pair is taken in one match with the cut
+kept between two markers, as the two single matches rendered it: a hex tail of 13 characters is
+letters alone one time in 345,000 (an 8-character piece one in 2,560), and such a tail stood in the
+clear beside its redacted head on CI (2026-09-08). The floor is 8 on both sides, so a shorter piece
+beside a cut (unittest's 3 after `[88 chars]`) is what it always was, and a pair where neither run
+qualifies (`'test_a_long_...ithout_digits'`) stays, as one such run does. The pair has a readability
+cost of its own, taken for the same reason: the legible half of a cut identifier goes with its other
+half when that half qualifies, so a test or session name's head beside a digit-bearing tail
+(`'test_a_long_...1a2b3c4d5e6f7'`, `'romp-session...2026-09-08T1'`) and a Capitalised word before a
+hex tail (`'Connecting...1a2b3c4d5e6f7'`) are two markers where the qualifying half alone was one.
 
 Nothing here is a credential: the file holds prefixes and character classes only.
 """
@@ -170,7 +182,8 @@ _QUOTED_LINE = r"^(?P<pfxq>E[ \t]+['\"])" + _GENERIC + r"(?=['\"]$)"
 # of the cut; a known prefix against one, whatever follows; a JWT against one, its head and tail dotted;
 # and a fragment of an unknown-format value: a run of 8 or more token characters against an ellipsis, a
 # quote or another ellipsis on its far side, with a digit, or with a lower-case letter and an upper-case
-# one after its first, and the dotted rest of it.
+# one after its first, and the dotted rest of it; and the two runs on the sides of one cut as one match
+# when either is such a fragment (_PAIRED, below).
 #
 # CUT_HEAD_MAX bounds the head between a prefix and the cut. The widest head a tool leaves is pytest's
 # saferepr at its default 240: 118 characters of the repr, 117 of a quoted string; unittest's `[N chars]`
@@ -214,7 +227,22 @@ _JWT_ELLIPSIZED = (r"eyJ(?:" + _atomic_run("hj", r"{1,%d}" % JWT_HEADER_MAX) + r
                    + r"|" + _ELLIPSIS + _TOKEN_CHARS + r"+" + _DOTTED + r")")
 _FRAGMENT = (r"(?:(?=" + _TOKEN_CHARS + r"*\d)" + _TOKEN_CHARS + r"{8,}"
              r"|(?=" + _TOKEN_CHARS + r"*[a-z])(?=" + _TOKEN_CHARS + r"+[A-Z])" + _TOKEN_CHARS + r"{8,})" + _DOTTED)
-_ELLIPSIZED = (r"(?:(?<=['\"])" + _FRAGMENT + r"(?=" + _ELLIPSIS + r")"
+# The two runs on the sides of one cut are pieces of one value (pytest cuts one operand's repr, unittest
+# one element's): when either qualifies as a fragment, the other is a piece of the same value whatever
+# its alphabet. A hex tail of 13 characters is letters alone one time in 345,000, an 8-character piece
+# one in 2,560, and such a tail stood in the clear beside its redacted head (CI, 2026-09-08); a
+# letters-only head beside a qualifying tail showed the same way. Tried before the single-fragment forms;
+# the cut is captured (pcut, pcut2: a group name cannot repeat, so one per alternative) and scrub() keeps
+# it between two markers, the rendering the two single matches gave. The floor stays 8 on both sides. The
+# runs are greedy and disjoint from what follows them (a cut, a quote), so the pair costs one bounded scan
+# at each quote or cut, as the single forms do (ScrubCost times a hex head against a one-case tail).
+_RUN8 = _TOKEN_CHARS + r"{8,}" + _DOTTED
+_PAIRED = (r"(?:(?<=['\"])|(?<=\.\.\.)|(?<=chars\]))"
+           r"(?:" + _FRAGMENT + r"(?P<pcut>" + _ELLIPSIS + r")" + _RUN8
+           + r"|" + _RUN8 + r"(?P<pcut2>" + _ELLIPSIS + r")" + _FRAGMENT + r")"
+           r"(?=" + _ELLIPSIS + r"|['\"])")
+_ELLIPSIZED = (r"(?:" + _PAIRED
+               + r"|(?<=['\"])" + _FRAGMENT + r"(?=" + _ELLIPSIS + r")"
                r"|(?:(?<=\.\.\.)|(?<=chars\]))" + _FRAGMENT + r"(?=" + _ELLIPSIS + r"|['\"]))")
 # The last line of an explanation pytest truncated (over 8 lines or 640 characters: `...` is appended to
 # it, then `use '-vv' to show`). A diff line so cut ends in `...` instead of the token's end, which
@@ -268,7 +296,8 @@ def _is_model_id(tok):
 
 def scrub(text):
     """`text` with every match replaced by REDACTED (a diff line keeps its marker and sign, a quoted
-    element line its marker and quotes); anything that is not a str comes back as is."""
+    element line its marker and quotes, a pair of fragments the cut between two markers); anything that
+    is not a str comes back as is."""
     if not isinstance(text, str):
         return text
 
@@ -276,5 +305,8 @@ def scrub(text):
         pfx = m.group("pfx") or m.group("pfxq") or m.group("pfxc") or ""
         if _is_git_sha_in_context(text, m) or _is_model_id(m.group(0)[len(pfx):]):
             return m.group(0)
+        cut = m.group("pcut") or m.group("pcut2")
+        if cut:                                                 # a paired fragment: a marker on each side of its cut
+            return REDACTED + cut + REDACTED
         return pfx + REDACTED
     return TOKEN_RE.sub(one, text)

--- a/tests/credential_patterns.py
+++ b/tests/credential_patterns.py
@@ -119,6 +119,25 @@ half when that half qualifies, so a test or session name's head beside a digit-b
 (`'test_a_long_...1a2b3c4d5e6f7'`, `'romp-session...2026-09-08T1'`) and a Capitalised word before a
 hex tail (`'Connecting...1a2b3c4d5e6f7'`) are two markers where the qualifying half alone was one.
 
+pytest's diff of two compared strings skips what they share. At default verbosity, when the two agree
+on more than 42 leading characters it drops all but the last 10 of them and says so (`Skipping N
+identical leading characters in diff, use -v to show`), and the same for trailing characters when the
+two are of one length; the `- <a>` and `+ <a>` lines then show the rest of each operand. For two
+64-character secrets that agree on 51 or more that rest is 23 characters or fewer: too short for the
+generic rule, ending at the line's end rather than at a cut, so no rule above took it, and it stood in
+the clear under an assert line that showed both operands as markers (2026-09-08). A second pass over
+the scrubbed text closes that, keyed on the first pass's own verdict: a line under the `E` marker whose
+compared operand, the quoted string beside `==` or `!=`, came out of the first pass as markers and
+nothing else (`'<marker>'`, `'<marker>...<marker>'`) compared a credential, and the signed lines of the
+diff block under it are pieces of that operand, so each becomes its sign and the marker; the empty
+line, the `Skipping` lines and the `?` lines that point at the differing positions hold no character of
+either operand and stay. The pass cannot hide a plain string's diff: every rule takes runs of token
+characters, so a string with words and spaces keeps them beside any marker on its assert line
+(`'<marker>... string here'`), no verdict is reached, and its diff lines stay as they were. Its cost is
+the diff of a comparison in which either operand is a credential: after a skip every signed line begins
+with the 10 characters the two operands share, so the other operand's line goes too when it is a plain
+expected value (the assert line still shows that value, whole or cut).
+
 Nothing here is a credential: the file holds prefixes and character classes only.
 """
 import re
@@ -269,6 +288,55 @@ TOKEN_RE = re.compile(
     re.MULTILINE,
 )
 
+# The second pass (the module docstring measures the skip). pytest's diff of two compared strings drops
+# what they share past 42 leading (or trailing) characters but 10, so its `- <a>` and `+ <a>` lines can
+# show a rest of each operand too short for _DIFF_LINE's generic rule and ending at the line's end, which
+# is no cut: 22 characters of each of two 64-character secrets stood in the clear under an assert line
+# that showed both as markers (2026-09-08). Keyed on the first pass's own verdict, and on nothing else,
+# so that no plain string's diff is hidden: the trigger is a line under the E marker whose compared
+# operand, the quoted string beside `==` or `!=` with whitespace before its opening quote (a container's
+# element, `['<a>']`, is not one; pytest's diff of a container does not skip), came out of the first pass
+# as markers alone, and every rule of the first pass takes runs of token characters, so a string with
+# words and spaces keeps them beside any marker (`'<marker>... string here'`) and reaches no verdict. The
+# block under the trigger is the lines pytest's text diff emits and nothing else: the empty line, the
+# `Skipping N identical ... characters` lines and the `?` position lines (kept, since none holds a
+# character of either operand) and the signed lines, each of which becomes its sign and the marker; a
+# line of any other shape (`Full diff:`, `+  where '<a>' = f()`, a truncation notice, a location) ends
+# it. A signed line the first pass already took (a whole value under `-v`, unittest's whole-value diff)
+# is left as it is. The cost is the diff of a comparison in which either operand is a credential: after a
+# skip each signed line begins with the 10 shared characters, a piece of the credential whatever the
+# other operand is, so the other side's line goes too (the assert line still shows a plain expected
+# value, whole or cut). Either operand, not both: an operand sharing 43 or more characters with a
+# credential is one itself, and requiring both would leave the shared 10 in the clear.
+_MARKERS_ONLY = re.escape(REDACTED) + r"(?:" + _ELLIPSIS + re.escape(REDACTED) + r")*"
+_REDACTED_OPERAND_RE = re.compile(r"(?<=\s)['\"]" + _MARKERS_ONLY + r"['\"] [!=]= |[!=]= ['\"]" + _MARKERS_ONLY + r"['\"](?=\s|$)")
+_DIFF_BLOCK_LINE_RE = re.compile(
+    r"^(?P<signed>E[ \t]+[-+] )(?! (?:where|and) )(?P<piece>.*)$"
+    r"|^E(?:[ \t]*|[ \t]+\?.*|[ \t]+Skipping \d+ identical (?:leading|trailing) characters in diff, use -v to show)$")
+
+
+def _redact_skipped_diff(text):
+    """`text` with each signed line of a pytest text diff under a compared operand the first pass rendered
+    as markers alone replaced by its sign and the marker (the comment above says what and why)."""
+    lines = text.split("\n")
+    changed = False
+    i, n = 0, len(lines)
+    while i < n:
+        line = lines[i]
+        i += 1
+        if not (line.startswith("E") and line[1:2] in (" ", "\t") and _REDACTED_OPERAND_RE.search(line)):
+            continue
+        while i < n:
+            m = _DIFF_BLOCK_LINE_RE.match(lines[i])
+            if not m:
+                break
+            if m.group("signed") and m.group("piece") != REDACTED:
+                lines[i] = m.group("signed") + REDACTED
+                changed = True
+            i += 1
+    return "\n".join(lines) if changed else text
+
+
 # A git sha (40 lowercase hex) is no credential when the text says what it is: named as a commit
 # (`commit=<sha>`, `commit: <sha>`, `{'commit': '<sha>'}`), or sitting in a path or after an `@`. Under
 # today's value positions only the commit form can precede a match (a token after `/` or `@` is in no
@@ -296,8 +364,9 @@ def _is_model_id(tok):
 
 def scrub(text):
     """`text` with every match replaced by REDACTED (a diff line keeps its marker and sign, a quoted
-    element line its marker and quotes, a pair of fragments the cut between two markers); anything that
-    is not a str comes back as is."""
+    element line its marker and quotes, a pair of fragments the cut between two markers), and then the
+    signed lines of a pytest text diff under a compared operand so rendered replaced too (the second
+    pass, _redact_skipped_diff); anything that is not a str comes back as is."""
     if not isinstance(text, str):
         return text
 
@@ -309,4 +378,5 @@ def scrub(text):
         if cut:                                                 # a paired fragment: a marker on each side of its cut
             return REDACTED + cut + REDACTED
         return pfx + REDACTED
-    return TOKEN_RE.sub(one, text)
+    out = TOKEN_RE.sub(one, text)
+    return _redact_skipped_diff(out) if REDACTED in out else out   # the second pass needs a verdict of the first

--- a/tests/test_env_value_redaction.py
+++ b/tests/test_env_value_redaction.py
@@ -34,11 +34,16 @@ for the assertion nobody wrote that way. Pinned here:
     redacted, a Capitalised word or a single-case identifier is not); the two runs on the sides of one
     cut taken together when either qualifies, whatever the other's alphabet (a letters-only hex tail
     stood in the clear beside its redacted head on CI, 2026-09-08), with the floor on both sides and a
-    pair where neither qualifies left alone; and the two shapes the generic rule fires on but leaves
-    alone, a named git sha and a dated Anthropic model id.
+    pair where neither qualifies left alone; the signed lines of pytest's diff of two compared strings
+    after its identical-prefix (or -suffix) skip, which show a rest of each operand too short for any
+    rule (22 characters of each 64-character secret stood in the clear, 2026-09-08), redacted when the
+    assert line above rendered an operand as markers alone and left as they were under a plain string's
+    assert line; and the two shapes the generic rule fires on but leaves alone, a named git sha and a
+    dated Anthropic model id.
   ScrubCost: the scrub is linear: a 200 KB adversarial line (a run of repeated prefixes, of one case,
-    of digits, of dashes, of dots, a pair of runs around one cut) is scrubbed within a generous budget;
-    the first of them took 80 seconds before the cut-key rule's head was bounded.
+    of digits, of dashes, of dots, a pair of runs around one cut, a redacted compare over a 200 KB diff
+    line) is scrubbed within a generous budget; the first of them took 80 seconds before the cut-key
+    rule's head was bounded.
   ReportShapes: the hook's work on a report object of each outcome (a failure's longrepr, a skip's
     tuple, a passed test's sections); a changed failure keeps its crash location, its message scrubbed
     in pytest's E-marked rendering, through xdist's serialization round trip.
@@ -51,7 +56,11 @@ for the assertion nobody wrote that way. Pinned here:
     --showlocals (pytest's diff lines, its assert line and the locals all show the marker), and the
     where/and/in/not-found/Lists-differ/Tuples-differ renderings of two such tokens at default
     verbosity, and the ellipsized renderings of two keys and two 64-character tokens compared with
-    `==` (as strings, in a list, in a tuple, and through unittest's `[N chars]` shortening); a cut
+    `==` (as strings, in a list, in a tuple, and through unittest's `[N chars]` shortening); a
+    comparison of two 64-character values sharing 52 leading (or the first and 52 trailing) characters,
+    whose diff pytest skips down to 22 or 21 characters of each, shows the marker on both signed lines,
+    in the failure and in CI's repeat of the message; pytest's own cut onto a letters-only piece of a
+    hex value (a 13-letter tail, a 12-letter head) shows the marker on both pieces; a cut
     comparison of a 30-character environment value shows the marker for both of its pieces; and a
     comparison of a GitHub Actions variable, or of the conftest's own git identity, shows the value.
 
@@ -736,6 +745,80 @@ class CredentialPattern(_WithConftest):
                      "+ %s..." % a[:60]):
             self.assertEqual(red(text), text, text[:20])
 
+    def test_a_diff_after_pytests_identical_prefix_skip_shows_no_piece_of_a_redacted_operand(self):
+        # pytest's diff of two compared strings skips what they share: past 42 identical leading characters
+        # (or trailing, when the two are of one length) it keeps 10 and says so, and its `-` and `+` lines
+        # then show the rest of each operand, 22 characters of each 64-character value below: too short for
+        # the diff rule and ending at the line's end rather than a cut, so they stood in the clear under an
+        # assert line that showed both operands as markers (2026-09-08). Keyed on that verdict, the second
+        # pass makes each signed line its sign and the marker; the empty line, the Skipping line and the `?`
+        # lines stay. The shapes are pytest 9's, copied from a run; the `E   ` form is the crash message as
+        # the conftest scrubs it for CI's short summary
+        red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
+        a = _fixed_hex("prefix-skip")
+        b = a[:52] + _fixed_hex("prefix-skip-other")[52:]           # 52 shared: pytest keeps 10, shows 22 of each
+        c = _fixed_hex("suffix-skip")
+        d = c[0] + _fixed_hex("suffix-skip-other")[1:12] + c[12:]   # the first and the last 52 shared: shows 21
+        for piece in (a[:12], a[-13:], b[-13:], c[:12], c[-13:], d[:12]):
+            self.assertTrue(any(ch.isdigit() for ch in piece), piece)
+        skip_l = "Skipping 42 identical leading characters in diff, use -v to show"
+        skip_t = "Skipping 43 identical trailing characters in diff, use -v to show"
+
+        def no_piece(out, *values):
+            for v in values:
+                for i in range(0, len(v) - 8 + 1):
+                    self.assertFalse(v[i:i + 8] in out, "a piece of a compared value survived: " + out)
+        # the failure body: the assert line (the left operand is the `+` line, the right the `-` line)
+        body = ("E       AssertionError: assert '%s...%s' == '%s...%s'\nE         \nE         %s\nE         - %s\nE         + %s\n"
+                % (a[:12], a[-13:], b[:12], b[-13:], skip_l, b[42:], a[42:]))
+        out = red(body)
+        self.assertEqual(out, "E       AssertionError: assert '%s...%s' == '%s...%s'\nE         \nE         %s\nE         - %s\nE         + %s\n"
+                         % (R, R, R, R, skip_l, R, R))
+        no_piece(out, a, b)
+        # the trailing skip, with the `?` lines that point at the differing positions
+        body = ("E       AssertionError: assert '%s...%s' == '%s...%s'\nE         \nE         %s\nE         - %s\nE         ? ^^ ^  - ^^^^\n"
+                "E         + %s\nE         ? ^^^^ ^^   ^^\n" % (c[:12], c[-13:], d[:12], d[-13:], skip_t, d[:21], c[:21]))
+        out = red(body)
+        self.assertEqual(out, "E       AssertionError: assert '%s...%s' == '%s...%s'\nE         \nE         %s\nE         - %s\nE         ? ^^ ^  - ^^^^\n"
+                         "E         + %s\nE         ? ^^^^ ^^   ^^\n" % (R, R, R, R, skip_t, R, R))
+        no_piece(out, c, d)
+        # the crash message as _redact_crash_message marks it (every line under `E   `), and the same block
+        # after a location line and a second failure: the block ends where the E lines do
+        msg = "E   assert '%s...%s' == '%s...%s'\nE     \nE     %s\nE     - %s\nE     + %s" % (a[:12], a[-13:], b[:12], b[-13:], skip_l, b[42:], a[42:])
+        self.assertEqual(red(msg), "E   assert '%s...%s' == '%s...%s'\nE     \nE     %s\nE     - %s\nE     + %s" % (R, R, R, R, skip_l, R, R))
+        out = red(body + "\ntest_probe.py:7: AssertionError\n" + body)
+        no_piece(out, c, d)
+        self.assertEqual(out.count("- " + R), 2, out)
+        # a signed line the first pass took is left as it is: unittest's whole-value diff under its `!=` line,
+        # and pytest's under -v, where nothing is skipped
+        for line in ("E       AssertionError: '%s' != '%s'\nE       - %s\nE       ?    ^^\nE       + %s\n" % (a, b, b, a),
+                     "E       assert '%s' == '%s'\nE         \nE         - %s\nE         + %s\n" % (a, b, b, a)):
+            out = red(line)
+            self.assertEqual(out.count(R), 4, out)
+            self.assertFalse(R + R in out, "the second pass added nothing to a line already taken: " + out)
+        # the block is pytest's text diff and nothing else: a `where` line after the diff (where older pytests
+        # put it; pytest 9 renders none beside a diff) keeps its shape and ends the block, so a signed line
+        # past it is not the diff's; and `Full diff:` under a container's per-index line ends the block before
+        # the container's lines
+        out = red("E       assert '%s' == 'x'\nE         - x\nE         + %s\nE        +  where '%s' = f()\nE         - x\n" % (a, a, a))
+        self.assertEqual(out, "E       assert '%s' == 'x'\nE         - %s\nE         + %s\nE        +  where '%s' = f()\nE         - x\n" % (R, R, R, R))
+        out = red("E         At index 0 diff: '%s' != '%s'\nE         \nE         Full diff:\nE           [\nE         -     'x',\nE         +     'y',\nE           ]\n" % (a, b))
+        self.assertEqual(out, "E         At index 0 diff: '%s' != '%s'\nE         \nE         Full diff:\nE           [\nE         -     'x',\nE         +     'y',\nE           ]\n" % (R, R))
+        # what stays, exactly: a plain string's diff after the same skip (its assert line reaches no verdict);
+        # a string whose head is a token run but which is words beyond it; a container element beside the
+        # operator (pytest's diff of a container skips nothing); and the same block without the E marker
+        plain = ("E       AssertionError: assert 'the quick br...n running far' == 'the quick br...n running fat'\nE         \n"
+                 "E         Skipping 57 identical leading characters in diff, use -v to show\nE         - running fat\nE         ?           ^\n"
+                 "E         + running far\nE         ?           ^\n")
+        self.assertEqual(red(plain), plain)
+        words = "E       assert '%s...st of the text' == '%s...st of the test'\nE         \nE         Skipping 40 identical leading characters in diff, use -v to show\nE         - rest of the test\nE         + rest of the text\n" % (a[:12], a[:12])
+        self.assertEqual(red(words), words.replace(a[:12], R), "the heads go, the words and the diff stay")
+        listed = "E       assert ['%s'] == ['%s']\nE         \nE         - ['x']\nE         + ['y']\n" % (a, b)
+        self.assertEqual(red(listed), listed.replace(a, R).replace(b, R))
+        bare = "assert '%s...%s' == '%s...%s'\n  \n  %s\n  - %s\n  + %s\n" % (a[:12], a[-13:], b[:12], b[-13:], skip_l, b[42:], a[42:])
+        self.assertEqual(red(bare), "assert '%s...%s' == '%s...%s'\n  \n  %s\n  - %s\n  + %s\n" % (R, R, R, R, skip_l, b[42:], a[42:]),
+                         "without the E marker a signed line is a bullet in captured output, as the diff rule holds")
+
     def test_a_qualifying_token_takes_its_dotted_rest(self):
         # a dotted token in a value position was matched to its first dot; the `.<more>` segments ride along
         # once the first run qualifies. A dot with no token character after it (a sentence's, an ellipsis)
@@ -906,6 +989,9 @@ class ScrubCost(_WithConftest):
             # the two runs around one cut as a pair: a hex head and a one-case tail, closed by a quote and not
             "hex head, one-case tail": "'" + hexrun[:n // 2] + "..." + rep("a")[:n // 2] + "'",
             "hex head, one-case tail, unclosed": "'" + hexrun[:n // 2] + "..." + rep("a")[:n // 2] + " x",
+            # the second pass: a compared operand the first pass rendered as the marker, over a signed line the
+            # first pass leaves (the ` x` keeps it from the diff rule), so the pass itself does the replacing
+            "redacted compare over a 200 KB diff line": "E       assert '%s' == 'x'\nE         - %s x" % (self.cf.CREDENTIAL_REDACTED, hexrun),
         }
         for name, line in lines.items():
             t0 = time.perf_counter()
@@ -1255,6 +1341,79 @@ class HookEndToEnd(unittest.TestCase):
             # the keys' assert line (2) and diff (2); the tokens' four fragments and diff (6); the list's (6);
             # the tuple's (4); the three-element block (2 heads, 2 elements, 6 diff lines); the keys' block (8)
             self.assertGreaterEqual(out.count("[REDACTED-CREDENTIAL]"), 30, out[-2500:])
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def test_a_comparison_of_two_values_sharing_a_long_prefix_prints_the_marker_on_the_skipped_diff(self):
+        # pytest's diff of two compared strings skips what they share (past 42 identical leading characters,
+        # or trailing ones when the two are of one length, it keeps 10 and says so), and its `-` and `+`
+        # lines then show the rest of each operand: 22 and 21 characters of each 64-character value here,
+        # under an assert line that shows both operands as markers; they stood in the clear (2026-09-08).
+        # Two runs, as the JWT test below: the default rendering, and CI set, where the short summary
+        # repeats each failure's whole message, the diff lines included. No 8-character piece of either
+        # value survives on any line of either run. The values are fixed digests, so the skip is the same
+        # every run, and the Skipping lines are asserted so a change in pytest's threshold is seen
+        d = tempfile.mkdtemp()
+        try:
+            _copy_hook(d)
+            a, c = _fixed_hex("skip-leading"), _fixed_hex("skip-trailing")
+            probes = {"a": a, "b": a[:52] + _fixed_hex("skip-leading-other")[52:],              # 52 shared: skips 42, shows 22
+                      "c": c, "d": c[0] + _fixed_hex("skip-trailing-other")[1:12] + c[12:]}    # the first and the last 52: skips 43, shows 21
+            for piece in (a[:12], a[-13:], probes["b"][-13:], c[:12], c[-13:], probes["d"][:12]):
+                self.assertTrue(any(ch.isdigit() for ch in piece), piece)
+            with open(os.path.join(d, "probes.json"), "w") as fh:
+                json.dump(probes, fh)
+            with open(os.path.join(d, "test_probe_skip.py"), "w") as fh:
+                fh.write("import json, os\n"
+                         "P = json.load(open(os.path.join(os.path.dirname(__file__), 'probes.json')))\n\n"
+                         "def test_leading():\n    assert P['a'] == P['b']\n\n"
+                         "def test_trailing():\n    assert P['c'] == P['d']\n")
+            for env in ({}, {"CI": "1"}):
+                rc, out = self._run(d, "test_probe_skip.py", env=env)
+                self.assertNotEqual(rc, 0)
+                self.assertTrue("2 failed" in out, out[-600:])
+                self.assertTrue("Skipping 42 identical leading characters in diff" in out, "pytest skipped the shared prefix: " + out[-1500:])
+                self.assertTrue("Skipping 43 identical trailing characters in diff" in out, "and the shared suffix: " + out[-1500:])
+                for name, v in probes.items():
+                    for i in range(0, len(v) - 8 + 1):
+                        self.assertFalse(v[i:i + 8] in out, "a piece of %s reached the report (CI=%s)" % (name, env.get("CI")))
+                # each failure: the assert line (4) and its two signed lines; under CI the summary repeats them
+                self.assertGreaterEqual(out.count("- [REDACTED-CREDENTIAL]"), 2 if not env else 4, out[-1500:])
+                self.assertGreaterEqual(out.count("+ [REDACTED-CREDENTIAL]"), 2 if not env else 4, out[-1500:])
+                self.assertGreaterEqual(out.count("[REDACTED-CREDENTIAL]"), 12 if not env else 24, out[-2500:])
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def test_pytests_own_cut_onto_a_letters_only_piece_prints_the_marker_on_both_pieces(self):
+        # the CI shape at the reporter, not the scrub: pytest cuts each operand of a failed `==` to 12 and
+        # 13 characters around `...`, and one such piece of a 64-character hex value is letters alone (a-f)
+        # one draw in thousands, which the fragment rule's digit test cannot see; a tail so drawn stood in
+        # the clear beside its redacted head (2026-09-08). Forced here rather than drawn: a tail of 13 hex
+        # letters in one pair, a head of 12 in the other. The pair rule takes each with its qualifying
+        # other half, and the whole values on the diff lines are the diff rule's. No 8-character piece
+        # survives, and both assert lines show the four markers
+        d = tempfile.mkdtemp()
+        try:
+            _copy_hook(d)
+            probes = {"a": _fixed_hex("letters-tail")[:51] + _hex_letters(13), "b": _fixed_hex("letters-tail-other")[:51] + _hex_letters(13),
+                      "c": _hex_letters(12) + _fixed_hex("letters-head")[12:], "d": _hex_letters(12) + _fixed_hex("letters-head-other")[12:]}
+            for piece in (probes["a"][:12], probes["b"][:12], probes["c"][-13:], probes["d"][-13:]):
+                self.assertTrue(any(ch.isdigit() for ch in piece), piece)
+            with open(os.path.join(d, "probes.json"), "w") as fh:
+                json.dump(probes, fh)
+            with open(os.path.join(d, "test_probe_letters.py"), "w") as fh:
+                fh.write("import json, os\n"
+                         "P = json.load(open(os.path.join(os.path.dirname(__file__), 'probes.json')))\n\n"
+                         "def test_tail():\n    assert P['a'] == P['b']\n\n"
+                         "def test_head():\n    assert P['c'] == P['d']\n")
+            rc, out = self._run(d, "test_probe_letters.py")
+            self.assertNotEqual(rc, 0)
+            self.assertTrue("2 failed" in out, out[-600:])
+            for name, v in probes.items():
+                for i in range(0, len(v) - 8 + 1):
+                    self.assertFalse(v[i:i + 8] in out, "a piece of %s reached the report" % name)
+            R = "[REDACTED-CREDENTIAL]"
+            self.assertEqual(out.count("assert '%s...%s' == '%s...%s'" % (R, R, R, R)), 2, "both assert lines, both operands, both pieces: " + out[-1500:])
         finally:
             shutil.rmtree(d, ignore_errors=True)
 

--- a/tests/test_env_value_redaction.py
+++ b/tests/test_env_value_redaction.py
@@ -31,11 +31,14 @@ for the assertion nobody wrote that way. Pinned here:
     key bounded at the widest cut a tool makes, and a wider head taken with its cut and tail by the
     format rule, quoted or bare; the `hf_` and `rpa_` rules' letters-and-digits class and its cost;
     the fragment rule's documented costs (a camelCase name or a digit-bearing run against a cut is
-    redacted, a Capitalised word or a single-case identifier is not); and the two shapes the generic
-    rule fires on but leaves alone, a named git sha and a dated Anthropic model id.
+    redacted, a Capitalised word or a single-case identifier is not); the two runs on the sides of one
+    cut taken together when either qualifies, whatever the other's alphabet (a letters-only hex tail
+    stood in the clear beside its redacted head on CI, 2026-09-08), with the floor on both sides and a
+    pair where neither qualifies left alone; and the two shapes the generic rule fires on but leaves
+    alone, a named git sha and a dated Anthropic model id.
   ScrubCost: the scrub is linear: a 200 KB adversarial line (a run of repeated prefixes, of one case,
-    of digits, of dashes, of dots) is scrubbed within a generous budget; the first of them took 80
-    seconds before the cut-key rule's head was bounded.
+    of digits, of dashes, of dots, a pair of runs around one cut) is scrubbed within a generous budget;
+    the first of them took 80 seconds before the cut-key rule's head was bounded.
   ReportShapes: the hook's work on a report object of each outcome (a failure's longrepr, a skip's
     tuple, a passed test's sections); a changed failure keeps its crash location, its message scrubbed
     in pytest's E-marked rendering, through xdist's serialization round trip.
@@ -54,7 +57,11 @@ for the assertion nobody wrote that way. Pinned here:
 
 Every probe value is synthetic and assembled at run time ("romp-test-fixture-" + a uuid; a
 pattern-shaped probe is a public key prefix joined to uuids), so no literal in this file is a
-credential.
+credential. A case whose assertion depends on which characters a piece carries (the fragment rule
+wants a digit or mixed case) draws nothing: its value is the hex digest of a fixed tag, the same on
+every run, and a letters-only piece is the hex alphabet's six letters cycled. A uuid's 13-character
+piece lacks a digit one draw in 345,000 and an 8-character one in 2,560, and one such draw failed
+this module on CI (2026-09-08).
 """
 import base64
 import hashlib
@@ -132,6 +139,20 @@ def _letters(n):
     while len(out) < n:
         out += "".join(alphabet[b % 26] for b in uuid.uuid4().bytes)
     return out[:n]
+
+
+def _fixed_hex(tag):
+    """64 hex characters that are the same on every run: the sha256 digest of a fixed tag, assembled at
+    run time so no token-shaped literal sits in this file. For a case whose assertion depends on which
+    characters a piece carries: a uuid's 8-character piece lacks a digit one draw in 2,560 (0.375**8),
+    a 13-character one in 345,000, and one such draw failed this module on CI (2026-09-08)."""
+    return hashlib.sha256(b"romp-test-fixture-" + tag.encode()).hexdigest()
+
+
+def _hex_letters(n):
+    """`n` characters from the hex alphabet's letters alone (`abcdef`, cycled): the shape of a hex piece
+    with no digit, which the fragment rule's digit test cannot see."""
+    return ("abcdef" * (n // 6 + 1))[:n]
 
 
 def _copy_hook(d):
@@ -541,8 +562,12 @@ class CredentialPattern(_WithConftest):
         # of the value: a known prefix against the cut is a truncated key whatever follows it, and 8 or more
         # token characters against the cut are a fragment when they carry a digit or mixed case
         red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
-        k = patterned_probe()                                      # a public prefix and 64 hex
-        a = uuid.uuid4().hex + uuid.uuid4().hex                    # 64 hex, no known prefix
+        # the same values every run: a drawn piece lacks a digit one time in thousands, and a 13-character
+        # tail of letters alone stood in the clear on CI (2026-09-08). Every piece cut below carries a digit
+        k = "sk-ant-api03-" + _fixed_hex("ellipsized-key")        # a public prefix and 64 hex
+        a = _fixed_hex("ellipsized")                               # 64 hex, no known prefix
+        for piece in (a[:11], a[:12], a[:17], a[:41], a[-9:], a[-11:], a[-12:], a[-13:], a[-30:]):
+            self.assertTrue(any(c.isdigit() for c in piece), piece)
         # pytest's assert line for two keys: the prefix and 5 characters, the cut, 13 of the tail
         self.assertEqual(red("assert '%s...%s' == '%s...%s'" % (k[:12], k[-13:], k[:12], k[-13:])),
                          "assert '%s' == '%s'" % (R, R))
@@ -565,6 +590,28 @@ class CredentialPattern(_WithConftest):
         self.assertEqual(red("['sk-[13 chars]%s']" % a[-30:]), "['sk-[13 chars]%s']" % R)
         self.assertEqual(red("'[13 chars]%s[20 chars]%s'" % (a[:12], a[-9:])), "'[13 chars]%s[20 chars]%s'" % (R, R))
         self.assertEqual(red("['%s[101 chars]%s']" % (k[:54], k[-3:])), "['%s']" % R)
+        # the two runs on the sides of one cut are pieces of one value: when either carries a digit the other
+        # is taken with it whatever its alphabet, the cut kept between two markers. A 13-character hex tail of
+        # letters alone stood in the clear beside its redacted head (CI, 2026-09-08); a letters-only head
+        # beside a redacted tail showed the same way, and so did unittest's `[N chars]` pieces
+        t, h = _hex_letters(13), _hex_letters(12)
+        self.assertEqual(red("assert '%s...%s' == '%s...%s'" % (a[:12], t, a[:12], t)),
+                         "assert '%s...%s' == '%s...%s'" % (R, R, R, R), "a letters-only tail beside a redacted head")
+        self.assertEqual(red("assert '%s...%s' == '%s...%s'" % (h, a[-13:], h, a[-13:])),
+                         "assert '%s...%s' == '%s...%s'" % (R, R, R, R), "a letters-only head beside a redacted tail")
+        self.assertEqual(red("assert ['%s...%s'] == ['%s...%s']" % (a[:11], h, a[:11], h)),
+                         "assert ['%s...%s'] == ['%s...%s']" % (R, R, R, R))
+        self.assertEqual(red("FAILED test_x.py::test_y - AssertionError: assert '%s...%s..." % (a[:12], t)),
+                         "FAILED test_x.py::test_y - AssertionError: assert '%s...%s..." % (R, R), "the short summary's second cut")
+        self.assertEqual(red("'[13 chars]%s[20 chars]%s'" % (a[:12], _hex_letters(9))), "'[13 chars]%s[20 chars]%s'" % (R, R))
+        self.assertEqual(red("'[13 chars]%s[20 chars]%s'" % (h, a[-9:])), "'[13 chars]%s[20 chars]%s'" % (R, R))
+        self.assertEqual(red("Lists differ: ['%s[5 chars]%s'] != ['%s[5 chars]%s']" % (a[:12], t, h, a[-13:])),
+                         "Lists differ: ['%s[5 chars]%s'] != ['%s[5 chars]%s']" % (R, R, R, R))
+        # the floor holds on both sides: a piece under 8 beside a redacted one shows, as the 3-character tail
+        # above does; and a pair where neither run qualifies is outside the rule's promise, as one such run is
+        self.assertEqual(red("'%s...%s'" % (a[:12], _hex_letters(6))), "'%s...%s'" % (R, _hex_letters(6)))
+        for text in ("'%s...%s'" % (h, t), "'%s...'" % h, "'[13 chars]%s[20 chars]%s'" % (h, _hex_letters(9))):
+            self.assertEqual(red(text), text, text)
         # a mixed-case fragment without a digit qualifies when the upper-case letter is not its first
         self.assertEqual(red("'abcdEfghijk...'"), "'%s...'" % R)
         # what stays: a Capitalised word, a single-case identifier, words, a fragment under the floor, a bare
@@ -653,15 +700,22 @@ class CredentialPattern(_WithConftest):
         # the fragment rule cannot tell a camelCase or PascalCase name from a base64 tail without a digit
         # (one 8-character fragment in 25 has that shape), nor a cut date from a hex tail, so both are
         # redacted against a cut: a readability cost the module docstring names, pinned so it is a measured
-        # one. A Capitalised word and a single-case identifier stay, with or without dots
+        # one. The pair rule's cost is pinned the same way: the legible half of a cut identifier goes with its
+        # other half when that half qualifies. A Capitalised word and a single-case identifier stay, with or
+        # without dots, and so does a cut whose two halves are both legible
         red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
         for text in ("'SessionStart...'", "'HookEndToEnd...'", "'getUserById...'", "'python38...'", "'2026-09-06...'"):
             self.assertEqual(red(text), "'%s...'" % R, text)
         self.assertEqual(red("assert 'HookEndToEnd...rTheFirstTime' == 'HookEndToEnd...TheSecondTime'"),
                          "assert '%s...%s' == '%s...%s'" % (R, R, R, R), "a diff of two hook names loses both")
         self.assertEqual(red("'2026-09-06T1...6+00:00'"), "'%s...6+00:00'" % R, "the head is a fragment; the tail is under the floor")
+        tail = _fixed_hex("cut-identifier")[-13:]                  # a digit-bearing tail, the same every run
+        self.assertTrue(any(c.isdigit() for c in tail), tail)
+        for text in ("'test_a_long_...%s'" % tail, "'romp-session...2026-09-08T1'", "'HookEndToEnd...st_something'", "'Connecting...%s'" % tail):
+            self.assertEqual(red(text), "'%s...%s'" % (R, R), "the pair rule's cost: the legible half goes with the qualifying one: " + text)
         for text in ("'Connecting...'", "'Abcdefgh...'", "'test_a_long_...ithout_digits'", "'snake_case_id...'", "'deadbeef...'",
-                     "'ABCDEFGHIJKL...'", "'2.1.261...'", "'python3.12.3...'"):
+                     "'ABCDEFGHIJKL...'", "'2.1.261...'", "'python3.12.3...'", "'Connecting t...n port 8080'", "'the quick br...the lazy dog'",
+                     "'kernel.sdk_b...ckend.thing2'", "'https://exam...ple.com/a1b2c3d4'", "'v1.2.3-abcdef12...transcript'"):
             self.assertEqual(red(text), text, text)
 
     def test_a_diff_line_pytest_truncated_mid_token_is_a_fragment_position(self):
@@ -671,7 +725,8 @@ class CredentialPattern(_WithConftest):
         # and sign stay; the same floor and letter rules as any fragment apply; a `...` that does not end
         # the line is not pytest's cut
         red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
-        a = uuid.uuid4().hex + uuid.uuid4().hex
+        a = _fixed_hex("diff-line")                                # the same every run: a drawn 8-character piece lacks a digit one time in 2,560
+        self.assertTrue(any(c.isdigit() for c in a[:8]), a[:8])
         for pre in ("E         + ", "E         - ", "E       -  "):
             self.assertEqual(red("%s%s..." % (pre, a[:60])), "%s%s..." % (pre, R), pre)
             self.assertEqual(red("%s%s..." % (pre, a[:8])), "%s%s..." % (pre, R), "8 characters is the floor")
@@ -801,7 +856,7 @@ class CredentialPattern(_WithConftest):
         tok = "%s...%s" % (hdr, wide[-40:])                 # the whole header before the cut: a head past the bound
         self.assertEqual(red("x %s y" % tok), "x %s y" % tok, "bare: nothing takes it")
         self.assertEqual(red("log: %s" % tok), "log: %s...%s" % (R, wide[-40:]), "a value position: the head; the tail shows")
-        self.assertEqual(red("'%s'" % tok), "'%s...%s'" % (R, R), "quoted: the fragment rule, twice")
+        self.assertEqual(red("'%s'" % tok), "'%s...%s'" % (R, R), "quoted: the fragment rule, both sides in one paired match")
         self.assertTrue(pay.startswith("eyJ"), "a JSON payload begins with `eyJ` as the header does")
         tok = "%s...%s" % (wide[:M + 4 + 1 + 150], wide[-40:])   # the same header whole, a payload cut deep
         self.assertEqual(red("x %s y" % tok), "x %s.%s y" % (hdr, R), "bare: the header shows; the payload's `eyJ` starts the cut rule's match")
@@ -848,6 +903,9 @@ class ScrubCost(_WithConftest):
             "sk-ant- + 121 + ...": rep("sk-ant-" + "a" * 121 + "..."), "hf_ + 121 + [1 chars]": rep("hf_" + "a" * 121 + "[1 chars]"),
             "sk-ant- + 20 + ..": rep("sk-ant-" + "a" * 20 + ".."), "sk-ant- + 20 + [x chars]": rep("sk-ant-" + "a" * 20 + "[x chars]"),
             "eyJ + 300 + ...": rep("eyJ" + "a" * 300 + ".b" + "..."), "one huge cut key": "sk-ant-" + "a" * (n // 2) + "..." + "b" * (n // 2),
+            # the two runs around one cut as a pair: a hex head and a one-case tail, closed by a quote and not
+            "hex head, one-case tail": "'" + hexrun[:n // 2] + "..." + rep("a")[:n // 2] + "'",
+            "hex head, one-case tail, unclosed": "'" + hexrun[:n // 2] + "..." + rep("a")[:n // 2] + " x",
         }
         for name, line in lines.items():
             t0 = time.perf_counter()


### PR DESCRIPTION
## What was wrong
A test in the report-redaction module failed once on CI on a tree it had passed before: the right-hand piece of a cut value stood unredacted beside its redacted left-hand piece. The cause was real on both sides. When a failing assertion prints two long strings, pytest cuts each operand to a head and a tail around an ellipsis, and the scrubber recognised a piece as credential-shaped only when it carried a digit or mixed case, the rule that keeps ordinary words and test names readable. The test drew its value from random uuids, and one draw produced a thirteen-character tail of hex letters only, which the rule did not take. That draw is rare, but a real sixty-four-character hex secret's tail could reach a CI log the same way.

## What changes
The two pieces on either side of one cut belong to one value, so once one side is credential-shaped the other is a piece of the same credential whatever its alphabet. The pattern net gains a paired form, tried first: a qualifying fragment, the cut, and a run of eight or more token characters of any alphabet, in either order, with a quote or another cut on the far side. The scrubber keeps the cut between two markers, so every existing rendering is unchanged and every existing pin holds; a pair where neither side qualifies still stays readable. The test's value is now a fixed digest assembled at run time, so no token-shaped literal sits in the file, and the exact escaping shapes are pinned with cycled hex letters in both directions and both frameworks; a sibling test's random draw is fixed the same way, and the cost test gains the pair's adversarial shape.

## Deliberately left out
The generic rule in a value position still leaves a non-qualifying tail showing, as the module already documents for a wide-header token; the cuts that reach that rule keep far more characters, where a digit-free tail is not a realistic draw. The end-to-end subprocess test keeps its uuid draws, since a leak there would need both pieces of one operand to be letters only.

## Tests
On `main` the new module runs 1 failed / 1 passed for the exact shape CI printed. On the branch the module passes 47 cases, and thirty consecutive single-process runs were green.

Reviewed by read-only agents: correctness, blast radius and cost hold against twenty-four cut shapes and nineteen readability candidates compared with `main`'s module; one nit folded, the pair rule's own readability cost named with an example and pinned, with six readable controls pinned beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


