### PR TITLE
Tab strip: a session under several tags appears under every one of them (T264b)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -71,8 +71,8 @@ several. Right-click a tab and open **Tags** to add or remove them. Tags filter 
 surface (the tag button in the strip narrows the tabs to the tags you pick), and they group
 the tabs: as soon as any session carries a tag, the strip shows one section per tag, in your
 tag order, each with a header in the tag's color, and the untagged sessions after a divider
-at the end. A session with several tags sits under the first of them in your tag order; its
-other tags still filter. Each header shows a chevron, the tag's color, its name, and a
+at the end. A session with several tags appears under each of them; every copy is the same
+session (click either to open it, and closing either ends it). Each header shows a chevron, the tag's color, its name, and a
 member count. Click a header, or press Enter on it, to fold its section down to the header
 alone; the count then says how many tabs are folded away, and a small dot after it says when
 one of them is working or waiting on you (hover it for their names). To keep one tab visible
@@ -85,7 +85,7 @@ folds (its header says so, and a click there changes nothing), and the `archived
 starts folded. Drag a header to reorder the groups, which
 reorders the tags on every surface (the timeline's tag table shows the same order). To move
 a tab into another group, right-click it and pick **Move to <tag>** under **Tags**: one click
-adds that tag and drops the tab's current group tag, leaving its other tags alone. The row's
+adds that tag and drops the tag of the group you right-clicked it in, leaving its other tags alone. The row's
 **+** adds the tag without moving the tab. **Group tabs by tag**, at the foot of the tag
 button's menu, turns the sections off for this browser.
 

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -357,12 +357,12 @@ jobs:
 - **Filtering.** Each surface (chat tabs, timeline lanes, outline) keeps its own
   lens: every session, the untagged ones, or any set of tags.
 - **Grouping.** The chat tab strip sections by tag whenever a session carries
-  one: a header per tag in `tagOrder`, each tab under the first of its tags in
-  that order (its home tag), the untagged after a divider. Sections fold per
-  browser; dragging a header reorders `tagOrder` for every surface; **Move to
-  <tag>** in a tab's menu adds the target tag and drops the home tag in one
-  click. Groups are tags: there is no second store and no per-session group
-  field.
+  one: a header per tag in `tagOrder`, each tab under every tag it carries (a
+  session under two tags appears under both), the untagged on a line of their
+  own. Sections fold per browser; dragging a header reorders `tagOrder` for every
+  surface; **Move to <tag>** in a tab's menu adds the target tag and drops the
+  tag of the group that copy sits in, in one click. Groups are tags: there is no
+  second store and no per-session group field.
 - **Inheritance.** A session spawned from another joins the parent's tags at the
   creation event: a fork, a promoted comment thread, and `romp new` run inside a
   session (it sends its `ROMP_SID` as `parent`; `--no-inherit` withholds it and

--- a/tests/test_tab_groups_rows.py
+++ b/tests/test_tab_groups_rows.py
@@ -31,12 +31,13 @@ ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
 
-# name → (sid, tag) ; the web tag is wide enough to wrap at a 640px viewport; "archived" folds by default
+# name → (sid, tags) ; the web tag is wide enough to wrap at a 640px viewport; "archived" folds by default;
+# web-search carries TWO tags and appears under both (T264b: tags are equivalent, no home tag)
 SESSIONS = [
     ("web-frontend", "aaaaaaaa-1111-2222-3333-000000000001", "web"),
     ("web-backend", "aaaaaaaa-1111-2222-3333-000000000002", "web"),
     ("web-gateway", "aaaaaaaa-1111-2222-3333-000000000003", "web"),
-    ("web-search", "aaaaaaaa-1111-2222-3333-000000000004", "web"),
+    ("web-search", "aaaaaaaa-1111-2222-3333-000000000004", "web infra"),
     ("web-billing", "aaaaaaaa-1111-2222-3333-000000000005", "web"),
     ("infra-ci", "aaaaaaaa-1111-2222-3333-000000000006", "infra"),
     ("infra-deploy", "aaaaaaaa-1111-2222-3333-000000000007", "infra"),
@@ -91,6 +92,8 @@ const survey = () => page.evaluate(() => {
   };
   return {
     items: kids.map(item),
+    active: Array.from(document.querySelectorAll("#tabs .tab.active[data-id]")).map((t) => ({ id: t.dataset.id, copy: t.dataset.copy })),
+    dots: Array.from(document.querySelectorAll("#tabs .tab[data-id]")).map((t) => ({ id: t.dataset.id, copy: t.dataset.copy, dot: !!t.querySelector(".tab-dot"), close: t.querySelector(".tab-close")?.title || null })),
     barLeft: 0, barW: bar.clientWidth,
     theme: document.body.className,
     seps: Array.from(document.querySelectorAll("#tabs .tab-group-sep")).map((e) => ({ w: e.getBoundingClientRect().width, h: e.getBoundingClientRect().height })),
@@ -100,13 +103,20 @@ const survey = () => page.evaluate(() => {
   };
 });
 const open = await survey();
+// T264b: the two-tag session's copy under infra — click it, and the ONE session activates: both copies wear .active
+await page.click(`#tabs .tab[data-id="${cfg.twoTag}"][data-copy="infra"]`);
+await page.waitForFunction((id) => document.querySelectorAll(`#tabs .tab.active[data-id="${id}"]`).length === 2, cfg.twoTag, { timeout: 8000 });
+await page.waitForTimeout(400);
+const clicked = await survey();
+await page.mouse.move(320, 400);   // off the strip, so no hover tip rides the screenshots
+await page.waitForTimeout(200);
 if (cfg.shots) await page.screenshot({ path: cfg.shots + "-dark.png", clip: { x: 0, y: 0, width: 640, height: 130 } });
 // LIGHT theme: the classes applyTheme sets for the light theme
 await page.evaluate(() => document.body.classList.add("chat-theme-yatharth", "theme-light"));
 await page.waitForTimeout(300);
 const light = await survey();
 if (cfg.shots) await page.screenshot({ path: cfg.shots + "-light.png", clip: { x: 0, y: 0, width: 640, height: 130 } });
-fs.writeSync(1, "RESULT:" + JSON.stringify({ open, light }) + "\n");
+fs.writeSync(1, "RESULT:" + JSON.stringify({ open, clicked, light }) + "\n");
 await browser.close();
 process.exit(0);
 """
@@ -144,7 +154,7 @@ class ServedGroupsOnOwnLines(unittest.TestCase):
             Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
         Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 100}, "seven_day": {"pct": 10}}))
         # the kernel's session-views blob: three tags, members by sid (the legacy spelling it reads losslessly)
-        tags = [{"id": tid, "name": tname, "color": color, "members": [sid for (_n, sid, t) in SESSIONS if t == tname]}
+        tags = [{"id": tid, "name": tname, "color": color, "members": [sid for (_n, sid, t) in SESSIONS if tname in (t or "").split()]}
                 for (tid, tname, color) in TAGS]
         Path(cls.state, "timeline-views.json").write_text(json.dumps({"tags": tags, "tagOrder": [t[1] for t in TAGS]}))
         cls.port = _free_port()
@@ -178,7 +188,8 @@ class ServedGroupsOnOwnLines(unittest.TestCase):
         cfg = os.path.join(self.lab, name + ".json")
         with open(cfg, "w") as f:
             json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
-                       "visible": len([s for s in SESSIONS if s[2] != "archived"]),
+                       "visible": len([s for s in SESSIONS if s[2] != "archived"]) + 1,   # web-search has two copies
+                       "twoTag": next(sid for (n, sid, _t) in SESSIONS if n == "web-search"),
                        "shots": os.environ.get("TABROWS_SHOTS", "")}, f)
         driver = os.path.join(self.lab, name + ".mjs")
         with open(driver, "w") as f:
@@ -239,11 +250,11 @@ class ServedGroupsOnOwnLines(unittest.TestCase):
 
     def test_every_group_starts_on_its_own_line_and_a_fold_leaves_the_header_row_alone(self):
         r = self._drive(DRIVER, "rows")
-        o, l = r["open"], r["light"]
+        o, clicked, l = r["open"], r["clicked"], r["light"]
         # the world: eight visible tabs (the archived group starts folded, its one member hidden), three headers,
         # no visible separator, one break per header after the first plus the trail's
         visible = [s for s in SESSIONS if s[2] != "archived"]
-        self.assertEqual(len([i for i in o["items"] if i["id"]]), len(visible), "every visible session has its tab: %r" % [i["name"] for i in o["items"]])
+        self.assertEqual(len([i for i in o["items"] if i["id"]]), len(visible) + 1, "every visible session has its tab, the two-tag one twice: %r" % [i["name"] for i in o["items"]])
         self.assertEqual([h["group"] for h in o["heads"]], ["web", "infra", "archived"])
         self.assertEqual(o["breaks"], 3, "a break before infra, before archived, and the trail's: %r" % o["breaks"])
         for sp in o["seps"]:
@@ -262,6 +273,19 @@ class ServedGroupsOnOwnLines(unittest.TestCase):
         # the per-row hairlines (T134, kept): one under every row but the last, none at the strip's top edge
         self.assertNotIn(0.0, o["lines"], "no hairline at the top edge (a break is not a row): %r" % o["lines"])
         self.assertTrue(o["lines"], "rows are still grounded by hairlines: %r" % o["lines"])
+        # T264b: the two-tag session appears under BOTH its groups, each copy a full tab (same status dot, a ✕ that
+        # says it ends the one session); a click on the infra copy activates the ONE session — both copies highlight
+        two = next(sid for (n, sid, _t) in SESSIONS if n == "web-search")
+        copies = [d for d in o["dots"] if d["id"] == two]
+        self.assertEqual(sorted(c["copy"] for c in copies), ["infra", "web"], "one copy per tag it carries: %r" % copies)
+        self.assertEqual(len({c["dot"] for c in copies}), 1, "every copy wears the same state dot: %r" % copies)
+        for c in copies:
+            self.assertIn("one session", c["close"] or "", "the ✕ on a copy says it ends the one session: %r" % c)
+        self.assertEqual([c["copy"] for c in clicked["active"] if c["id"] == two], ["web", "infra"], "the active highlight sits on every copy: %r" % clicked["active"])
+        self.assertEqual(len(clicked["active"]), 2, "…and on nothing else: %r" % clicked["active"])
+        infra_tabs = next(t for g, _h, t in self._sections(clicked["items"]) if g == "infra")
+        self.assertIn(two, [t["id"] for t in infra_tabs], "the copy sits in the infra group: %r" % infra_tabs)
+        self._check_rows(clicked, "clicked")
         # LIGHT theme: the same geometry
         self.assertIn("theme-light", l["theme"])
         self._check_rows(l, "light")

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -847,8 +847,8 @@ function reachableHosts(): Set<string> { return reachableFrom((window as any).__
  *  only looks at `.on` needs none. */
 function tabGroups() { return readTabGroups(viewTagUnion(effViews())); }
 let draggedGroup: string | null = null;   // a section header mid-drag (reorders tagOrder) — never a tab
-// the tags a create in flight named (openProvisional): the provisional tab sections under its future
-// home from the first paint (planStrip's `pending`), instead of landing loose and jumping on the frame
+// the tags a create in flight named (openProvisional): the provisional tab sections under every tag it
+// named from the first paint (planStrip's `pending`), instead of landing loose and jumping on the frame
 let provisionalTags: string[] = [];
 function visibleOrder(): string[] { return order.filter((id) => tabInView(id) && !collapsedTabIds.has(id)); }
 // THE PHONE LAYOUT: the kernel's chat page swaps the tab strip for its own session list (#mhdr/#mlist,
@@ -5391,8 +5391,9 @@ function renderTabs() {
   }
   // TAB SECTIONS (the user 2026-09-04): groups are tags. With sectioning on (per browser — the
   // tag-lens menu's "Group tabs by tag") and some tag holding a visible tab, the strip renders one
-  // header per HOME tag in tagOrder — the rule revealIn already states, so a tab's section and its
-  // reveal agree — then that section's tabs, and the untagged trail behind a plain separator
+  // header per tag in tagOrder holding a visible tab, each tab under EVERY tag it carries (T264b, the
+  // user 2026-09-08: tags are equivalent — a session under N tags has a copy in N groups), then that
+  // section's tabs, and the untagged trail — the sessions in no tag — on its own line
   // (tab-groups.ts owns the rule). A folded section renders its header alone, with the count and
   // a pip when a member is working or blocked, so the gist survives the fold (progressive
   // disclosure). The ACTIVE tab's section never renders folded — keyboard focus must never land
@@ -5423,7 +5424,11 @@ function renderTabs() {
     }
     const id = item.id;
     const s = sessions.get(id);
-    if (!s) { bar.appendChild(makePlaceholderTab(id)); continue; }
+    if (!s) {
+      const ph = makePlaceholderTab(id);
+      if (copyGroup !== undefined) ph.dataset.copy = copyGroup ?? "";   // a placeholder copy per group too — flipTabs keys per copy (T264b)
+      bar.appendChild(ph); continue;
+    }
     const tab = el("div", "tab" + (id === activeId ? " active" : ""));
     tab.tabIndex = 0;            // focusable for keyboard nav
     tab.dataset.id = id;
@@ -5555,7 +5560,7 @@ function renderTabs() {
     // double-click a tab to show/hide the ledger overview — same as the strip's caret
     tab.addEventListener("dblclick", (e) => { e.preventDefault(); toggleLedgerCollapsed(); });
     // right-click → context menu; "Rename" edits the title in place (not for a viewer: nothing to rename/hide/end)
-    if (!s.sub) tab.addEventListener("contextmenu", (e) => { e.preventDefault(); e.stopPropagation(); showTabMenu(e, id); });
+    if (!s.sub) tab.addEventListener("contextmenu", (e) => { e.preventDefault(); e.stopPropagation(); showTabMenu(e, id, tab.dataset.copy); });   // the copy's group rides along (T264b)
     bar.appendChild(tab);
   }
   const add = el("div", "tab tab-add");
@@ -5762,7 +5767,7 @@ function ctxIcon(kind: "feed" | "mail" | "bell" | "bill" | "folder" | "tag" | "p
   return span;
 }
 
-function showTabMenu(e: MouseEvent, id: string) {
+function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: the group the right-clicked copy sits in (T264b), a plain string so the menu stays id-keyed
   dismissTabMenu();
   const menu = el("div", "ctx-menu");
   // Rename leads ONE top section with the session controls (the user 2026-08-24: it sat alone and
@@ -5779,7 +5784,7 @@ function showTabMenu(e: MouseEvent, id: string) {
     const l = el("span", "ctx-item-label"); l.textContent = "Rename"; bodyEl.appendChild(l);
     const sb = el("span", "ctx-item-sub"); sb.textContent = "the name is a label — mail, goals and history follow the session"; bodyEl.appendChild(sb);
     rename.appendChild(bodyEl);
-    rename.addEventListener("click", (ev) => { ev.stopPropagation(); dismissTabMenu(); startTabRename(id); });
+    rename.addEventListener("click", (ev) => { ev.stopPropagation(); dismissTabMenu(); startTabRename(id, copy); });
     menu.appendChild(rename);
   }
   // Move to folder… sits with Rename (the user 2026-09-01: a subproject became its own repo and the
@@ -6049,14 +6054,16 @@ function showTabMenu(e: MouseEvent, id: string) {
         }
         const others = unionFor().filter((g) => !g.members.includes(id) && !g.pending);   // a tag being created is not joinable yet
         if (holding().length && others.length) sub.appendChild(el("div", "ctx-sep"));
-        // ONE-CLICK MOVE (tab groups on tags, the user 2026-09-04): a session's section is its HOME
-        // tag — the first holder in tagOrder — so while the strip is sectioned and the session has
-        // one, each other tag's row reads "Move to <name>": one click adds that tag and drops the
-        // home tag, leaving any other tag alone (they filter, they do not section). The row's "+"
-        // adds without moving. With no home tag, "+ <name>" IS the move. A home tag whose create is
-        // still in flight cannot be moved out of (no id to address); the rows read "+ <name>" until
-        // the ack.
-        const home0 = readTabGroups().on ? holding()[0] : undefined;
+        // ONE-CLICK MOVE (tab groups on tags, the user 2026-09-04): while the strip is sectioned, each
+        // other tag's row reads "Move to <name>": one click adds that tag and drops THE GROUP THIS COPY
+        // SITS IN (T264b: a session under several tags has a copy in each group, and the menu opened
+        // from a copy speaks for that copy's group — the copy the user right-clicked is the one that
+        // moves; its other tags are left alone). No copy named (an older caller): the first holder in
+        // tagOrder. The row's "+" adds without moving. With no tag, "+ <name>" IS the move. A tag
+        // whose create is still in flight cannot be moved out of (no id to address); the rows read
+        // "+ <name>" until the ack. Whether "move" between equivalent tags is the right verb at all is
+        // the user's call (flagged with T264b); the mechanics are unchanged here.
+        const home0 = readTabGroups().on ? ((copy !== undefined ? holding().find((g) => g.name === copy) : undefined) ?? holding()[0]) : undefined;
         const home = home0 && !home0.pending ? home0 : undefined;
         for (const g of others) {
           const row = el("div", "ctx-item ctx-item-toggle");
@@ -6067,7 +6074,7 @@ function showTabMenu(e: MouseEvent, id: string) {
             lb.textContent = "Move to " + g.name; bodyE.appendChild(lb);
             row.appendChild(bodyE);
             const plus = el("button", "ctx-tag-x ctx-tag-plus") as HTMLButtonElement;
-            plus.type = "button"; plus.textContent = "+"; plus.title = "add this tag too — the session stays in its current group";
+            plus.type = "button"; plus.textContent = "+"; plus.title = "add this tag too — the session keeps its other tags";
             plus.addEventListener("click", (e2) => { e2.stopPropagation(); editUnion(g, { add: [id] }); build(); sb.textContent = subText(); });
             row.appendChild(plus);
             row.addEventListener("click", (e2) => { e2.stopPropagation(); moveUnion(home, g); build(); sb.textContent = subText(); });
@@ -6225,7 +6232,7 @@ window.addEventListener("blur", () => dismissTabMenu());
 // "Rename" (tab context menu): swap the tab's label for an inline input. Enter
 // or clicking away commits (the host renames the tmux session and confirms with
 // a "renamed" message — the label only changes once that lands), Esc cancels.
-function startTabRename(id: string) {
+function startTabRename(id: string, copy?: string) {   // `copy`: which copy of a multi-tag session to edit in place (T264b); the first one when it is gone
   const s = sessions.get(id);
   if (!s) return;
   // Resolve the tab NOW, by id. The old signature took the nodes captured at menu-open time, and a
@@ -6235,8 +6242,9 @@ function startTabRename(id: string) {
   // attempt always worked, and why committing it healed everything (the user 2026-08-08: "rename only
   // takes on the second try"). A vanished tab (session closed mid-menu) bails out BEFORE the flag.
   const bar = document.getElementById("tabs");
-  const tab = bar && Array.from(bar.children).find(
-    (t): t is HTMLElement => t instanceof HTMLElement && t.dataset.id === id);
+  const tab = bar && (Array.from(bar.children).find(
+    (t): t is HTMLElement => t instanceof HTMLElement && t.dataset.id === id && (copy === undefined || t.dataset.copy === copy))
+    ?? Array.from(bar.children).find((t): t is HTMLElement => t instanceof HTMLElement && t.dataset.id === id));   // the right-clicked copy (T264b), else the first
   const label = tab && tab.querySelector<HTMLElement>(".tab-label");
   if (!tab || !label || tab.querySelector(".tab-rename")) return;
   // A remote session displays as "host:name", where "host:" is METADATA this viewer added (see
@@ -6492,12 +6500,17 @@ window.addEventListener("keydown", (e) => {
 // Nearest tab in the row above (dir<0) or below (dir>0) the given tab, by column.
 function tabInAdjacentRow(id: string, dir: number): string | null {
   const bar = document.getElementById("tabs");
-  const cur = bar?.querySelector(`.tab[data-id="${id}"]`) as HTMLElement | null;
+  // a session under several tags has a tab in each group (T264b): the origin is the FOCUSED copy when
+  // it wears the id — the row the user is looking at — else the first copy
+  const focused = document.activeElement as HTMLElement | null;
+  const cur = focused && focused.classList.contains("tab") && focused.dataset.id === id && bar?.contains(focused)
+    ? focused : bar?.querySelector(`.tab[data-id="${id}"]`) as HTMLElement | null;
   if (!bar || !cur) return null;
   const cr = cur.getBoundingClientRect();
   const cx = cr.left + cr.width / 2;
   let best: { id: string; score: number } | null = null;
   for (const t of Array.from(bar.querySelectorAll(".tab[data-id]")) as HTMLElement[]) {
+    if (t.dataset.id === id) continue;   // never the session's own other copy: setActive would no-op and the key would read dead (T264b)
     const r = t.getBoundingClientRect();
     const vGap = dir < 0 ? cr.top - r.bottom : r.top - cr.bottom; // >0 only if on a row in that direction
     if (vGap < -1) continue;
@@ -6558,7 +6571,7 @@ function openProvisional(req: CreateReq): void {
   pendingNewSession = display;
   const id = mintProvisionalId(Date.now().toString(36) + Math.random().toString(36).slice(2));
   provisionalId = id;
-  provisionalTags = req.tags?.slice() ?? [];   // its future home: the strip sections it there from the first paint
+  provisionalTags = req.tags?.slice() ?? [];   // the strip sections it under each of these from the first paint
   // state "opening", NOT "working": updateStatusline renders the working chip with an elapsed timer off
   // sinceEpoch, and a provisional tab has no honest work clock — the seed showed "Working" + a giant
   // number for however long the first kernel payload took (the user 2026-08-10, who read it as "a random
@@ -15745,18 +15758,28 @@ setupSettings();
     e.preventDefault();
     const dragged = draggedEl && draggedEl.isConnected ? draggedEl : null;   // THIS copy, not the first tab wearing the id (T264b)
     if (!dragged) return;
-    // the neighbours are TABS: a section header or separator beside the dropped tab is skipped, so
-    // a drop at a section's edge still names the nearest tab and its side
-    // …and never the dragged SESSION's own copy in the group next door (T264b): reorderTo against itself
-    // would move nothing, so the neighbour beyond it names the slot instead
+    // the neighbours are TABS IN THE DRAGGED COPY'S OWN GROUP first (T264b): a drop at a group's head
+    // used to anchor on the group above's last tab — a tab whose place in the global order says
+    // nothing about the group dragged in — so the drop landed elsewhere and the session's other copy
+    // jumped. The walk stops at a header or a row break; only a group holding no other tab falls back
+    // to the nearest tab across groups (the flat strip has no edges, so it walks as it always did).
+    // Never the dragged SESSION's own copy: reorderTo against itself would move nothing.
     const own = (n: Element | null) => !!n && (n as HTMLElement).dataset?.id === draggedId;
-    const tabBefore = (n: Element | null) => { while (n && (!(n as HTMLElement).dataset?.id || own(n))) n = n.previousElementSibling; return n as HTMLElement | null; };
-    const tabAfter = (n: Element | null) => { while (n && (!(n as HTMLElement).dataset?.id || own(n))) n = n.nextElementSibling; return n as HTMLElement | null; };
-    const prev = tabBefore(dragged.previousElementSibling);
-    const next = tabAfter(dragged.nextElementSibling);
-    if (prev?.dataset?.id) reorderTo(draggedId, prev.dataset.id, true);
-    else if (next?.dataset?.id) reorderTo(draggedId, next.dataset.id, false);
-    tabDragCommitted = true;   // dragend must not treat this as a cancel (it fires next)
+    const edge = (n: Element) => n.classList.contains("tab-group-head") || n.classList.contains("tab-group-break");
+    const walk = (n: Element | null, step: (x: Element) => Element | null, inGroup: boolean): HTMLElement | null => {
+      while (n && (!(n as HTMLElement).dataset?.id || own(n))) { if (inGroup && edge(n)) return null; n = step(n); }
+      return n as HTMLElement | null;
+    };
+    const back = (x: Element) => x.previousElementSibling, fwd = (x: Element) => x.nextElementSibling;
+    const tabBefore = (n: Element | null) => walk(n, back, true);
+    const tabAfter = (n: Element | null) => walk(n, fwd, true);
+    const prevIn = tabBefore(dragged.previousElementSibling), nextIn = tabAfter(dragged.nextElementSibling);
+    const prev = prevIn ?? (nextIn ? null : walk(dragged.previousElementSibling, back, false));
+    const next = nextIn ?? (prevIn ? null : walk(dragged.nextElementSibling, fwd, false));
+    // committed only when a reorder actually ran: with no neighbour to name the slot (a group holding
+    // only this session's copies) dragend takes the cancel path and FLIPs the copy home
+    if (prev?.dataset?.id) { reorderTo(draggedId, prev.dataset.id, true); tabDragCommitted = true; }
+    else if (next?.dataset?.id) { reorderTo(draggedId, next.dataset.id, false); tabDragCommitted = true; }
   });
 })();
 // right-click a selection in the transcript → Reply (quote it) / Copy

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4865,6 +4865,7 @@ function auditTabOrder(ids: string[]) {
   lastTabIds = ids.slice();
 }
 let draggedId: string | null = null;
+let draggedEl: HTMLElement | null = null;   // the very tab being dragged: a session under several tags has a copy per group (T264b), so the id alone no longer names it
 let tabDragCommitted = false;   // set by the strip's drop handler; dragend without it = a cancel (Escape / dropped outside)
 // The drag hit-test's stable inputs (the drag-flap fix, 2026-08-28): every tab's outer width and
 // the strip's geometry, measured ONCE at dragstart. The pointer is then hit-tested against a
@@ -4901,12 +4902,15 @@ function dragImageBlank(): HTMLElement {
 function flipTabs(mutate: () => void): void {
   const bar = document.getElementById("tabs");
   if (!bar) { mutate(); return; }
+  // keyed per COPY — id plus the group it sits in (data-copy, T264b) — since a session under several
+  // tags has a tab in each group and one rect per id would animate every copy from the last one's place
+  const key = (t: HTMLElement) => t.dataset.id + "\0" + (t.dataset.copy ?? "");
   const before = new Map<string, DOMRect>();
-  bar.querySelectorAll<HTMLElement>(".tab[data-id]").forEach((t) => { if (t.dataset.id) before.set(t.dataset.id, t.getBoundingClientRect()); });
+  bar.querySelectorAll<HTMLElement>(".tab[data-id]").forEach((t) => { if (t.dataset.id) before.set(key(t), t.getBoundingClientRect()); });
   mutate();
   if (matchMedia("(prefers-reduced-motion: reduce)").matches) return;
   bar.querySelectorAll<HTMLElement>(".tab[data-id]").forEach((t) => {
-    const a = t.dataset.id ? before.get(t.dataset.id) : undefined;
+    const a = t.dataset.id ? before.get(key(t)) : undefined;
     if (!a) return;
     const b = t.getBoundingClientRect();
     const dx = a.left - b.left, dy = a.top - b.top;
@@ -5400,12 +5404,21 @@ function renderTabs() {
   const plan = planStrip(visibleIds, unions, readTabGroups(unions), activeId, phoneLayout(),
                          provisionalId ? { id: provisionalId, tags: provisionalTags } : null);
   collapsedTabIds = plan.folded;
+  // A session under several tags has a COPY in each group (T264b, the user 2026-09-08: tags are
+  // equivalent, none takes precedence). Every copy below is the full tab of the ONE session — same
+  // identity colour, same state class and dot, the active highlight on all of them (the loop reads
+  // activeId per item), the ✕ on all of them (ending the one session); a click on any copy selects
+  // the session (the #tabs delegate reads data-id). data-copy names the copy's group so a per-copy
+  // reader (flipTabs) can tell them apart; every by-id reader (focus, the menu, the tip) lands on the
+  // first copy, which is the same session.
+  let copyGroup: string | null | undefined;
   for (const item of plan.items) {
     if ("head" in item) {
       // every group on its own line (T264): a row break ahead of each header — except the strip's
       // first item, which already opens the first row; the untagged trail's header IS a break
       if (item.head.name !== null && bar.childElementCount) bar.appendChild(makeRowBreak(false));
       bar.appendChild(makeGroupHead(item.head, item.folded, item.active, item.hidden));
+      copyGroup = item.head.name;
       continue;
     }
     const id = item.id;
@@ -5414,6 +5427,7 @@ function renderTabs() {
     const tab = el("div", "tab" + (id === activeId ? " active" : ""));
     tab.tabIndex = 0;            // focusable for keyboard nav
     tab.dataset.id = id;
+    if (copyGroup !== undefined) tab.dataset.copy = copyGroup ?? "";   // sectioned strip: which group this copy sits in
     tab.dataset.act = "select";  // click → setActive, via the stable #tabs delegate (./actions), not a per-node handler
     tab.addEventListener("keydown", onTabKey);
     // drag-to-reorder (synced with the timeline via the shared session-order file). A subagent viewer
@@ -5426,7 +5440,7 @@ function renderTabs() {
     // visual, browser-style. dragImageBlank must be a rendered DOM node at dragstart (Chromium
     // snapshots it), hence the fixed off-viewport 1px div installed once below.
     tab.addEventListener("dragstart", (e) => {
-      draggedId = id; tabDragCommitted = false;
+      draggedId = id; draggedEl = tab; tabDragCommitted = false;
       if (e.dataTransfer) { e.dataTransfer.effectAllowed = "move"; e.dataTransfer.setDragImage(dragImageBlank(), 0, 0); }
       tab.classList.add("dragging");
       hideTabTip();                        // defect 2 (2026-08-28): the hover popover pinned open through the gesture
@@ -5440,7 +5454,7 @@ function renderTabs() {
     // already asked for its render; it ran deferred, so flush it.
     tab.addEventListener("dragend", () => {
       const cancelled = !tabDragCommitted;
-      draggedId = null; tabDragCommitted = false;
+      draggedId = null; draggedEl = null; tabDragCommitted = false;
       tab.classList.remove("dragging");
       tabPointerHeld = false;
       const pending = renderPendingWhilePressed;
@@ -5527,7 +5541,10 @@ function renderTabs() {
     // Close-tab / End-session confirm (closeSession → confirmClose). A subagent viewer likewise
     // just closes (the tabs delegate's close handler routes it by isSubId).
     const dead = st === "closed";
-    close.title = dead || s.sub ? "Close tab" : "End session";
+    // a session shown in several groups (T264b) has a ✕ on every copy, and any of them ends THE session —
+    // the tip says so, since a user may expect the ✕ to take the tab out of just this group
+    const copies = plan.items.reduce((n, it) => n + ("id" in it && it.id === id ? 1 : 0), 0);
+    close.title = dead || s.sub ? "Close tab" : copies > 1 ? "End session (it is the one session, shown in every group it is tagged with)" : "End session";
     // Click-safe (see ./actions): renderTabs() does `#tabs`.replaceChildren() on every kernel push, so a
     // handler hung on this ✕ is destroyed mid-click and the click is dropped (the "had to click End session
     // several times" bug). The action lives on the stable #tabs delegate instead; this node just declares it.
@@ -15674,7 +15691,7 @@ setupSettings();
     if (!draggedId || !dragGeom) return;
     e.preventDefault();   // the whole strip is a valid drop target
     if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
-    const dragged = tabs.querySelector<HTMLElement>(`.tab[data-id="${CSS.escape(draggedId)}"]`);
+    const dragged = draggedEl && draggedEl.isConnected ? draggedEl : null;   // THIS copy, not the first tab wearing the id (T264b)
     if (!dragged) return;
     // native feel: a pointer still inside the dragged tab's own box moves nothing (without this,
     // the virtual mapping — which removes the dragged tab — can read the untouched start position
@@ -15726,12 +15743,15 @@ setupSettings();
     }
     if (!draggedId) return;
     e.preventDefault();
-    const dragged = tabs.querySelector<HTMLElement>(`.tab[data-id="${CSS.escape(draggedId)}"]`);
+    const dragged = draggedEl && draggedEl.isConnected ? draggedEl : null;   // THIS copy, not the first tab wearing the id (T264b)
     if (!dragged) return;
     // the neighbours are TABS: a section header or separator beside the dropped tab is skipped, so
     // a drop at a section's edge still names the nearest tab and its side
-    const tabBefore = (n: Element | null) => { while (n && !(n as HTMLElement).dataset?.id) n = n.previousElementSibling; return n as HTMLElement | null; };
-    const tabAfter = (n: Element | null) => { while (n && !(n as HTMLElement).dataset?.id) n = n.nextElementSibling; return n as HTMLElement | null; };
+    // …and never the dragged SESSION's own copy in the group next door (T264b): reorderTo against itself
+    // would move nothing, so the neighbour beyond it names the slot instead
+    const own = (n: Element | null) => !!n && (n as HTMLElement).dataset?.id === draggedId;
+    const tabBefore = (n: Element | null) => { while (n && (!(n as HTMLElement).dataset?.id || own(n))) n = n.previousElementSibling; return n as HTMLElement | null; };
+    const tabAfter = (n: Element | null) => { while (n && (!(n as HTMLElement).dataset?.id || own(n))) n = n.nextElementSibling; return n as HTMLElement | null; };
     const prev = tabBefore(dragged.previousElementSibling);
     const next = tabAfter(dragged.nextElementSibling);
     if (prev?.dataset?.id) reorderTo(draggedId, prev.dataset.id, true);

--- a/ui/webview/subagent-view.test.ts
+++ b/ui/webview/subagent-view.test.ts
@@ -189,7 +189,7 @@ test("the viewer is READ-ONLY: the message box is hidden, send disabled, one dim
   // the tab: no drag (a reorder would post the id into the kernel's order), no rename menu, ✕ = Close tab
   assert.match(RENDER, /tab\.draggable = !s\.sub;/);
   assert.match(RENDER, /if \(!s\.sub\) tab\.addEventListener\("contextmenu"/);
-  assert.match(RENDER, /close\.title = dead \|\| s\.sub \? "Close tab" : "End session";/);
+  assert.match(RENDER, /close\.title = dead \|\| s\.sub \? "Close tab" : copies > 1 \? "End session \(it is the one session, shown in every group it is tagged with\)" : "End session";/);
   assert.match(RENDER, /if \(id && isSubId\(id\)\) \{ closeSubagentView\(id\); return; \}/);
 });
 

--- a/ui/webview/tab-drag-live.test.ts
+++ b/ui/webview/tab-drag-live.test.ts
@@ -82,12 +82,15 @@ test("the hover popover never survives a drag (defect 2, the user's recording)",
 
 test("drop commits through the SAME reorderTo — neighbor + side, hidden-view ids keep their places", () => {
   const body = between('tabs.addEventListener("drop"', "});");
-  assert.match(body, /if \(prev\?\.dataset\?\.id\) reorderTo\(draggedId, prev\.dataset\.id, true\);/);
-  assert.match(body, /else if \(next\?\.dataset\?\.id\) reorderTo\(draggedId, next\.dataset\.id, false\);/);
+  assert.match(body, /if \(prev\?\.dataset\?\.id\) \{ reorderTo\(draggedId, prev\.dataset\.id, true\); tabDragCommitted = true; \}/);
+  assert.match(body, /else if \(next\?\.dataset\?\.id\) \{ reorderTo\(draggedId, next\.dataset\.id, false\); tabDragCommitted = true; \}/,
+    "committed only when a reorder ran (T264b): no neighbour → dragend's cancel path FLIPs the copy home");
   // the neighbours are TABS (tab groups, 2026-09-04): a section header or separator beside the
   // dropped tab is skipped, so a drop at a section's edge still names the nearest tab and its side
-  assert.match(body, /const prev = tabBefore\(dragged\.previousElementSibling\);/);
-  assert.match(body, /const next = tabAfter\(dragged\.nextElementSibling\);/);
+  assert.match(body, /const prevIn = tabBefore\(dragged\.previousElementSibling\), nextIn = tabAfter\(dragged\.nextElementSibling\);/,
+    "the neighbours inside the dragged copy's own group first (T264b)");
+  assert.match(body, /const prev = prevIn \?\? \(nextIn \? null : walk\(dragged\.previousElementSibling, back, false\)\);/,
+    "…falling back across groups only when the group holds no other tab");
   // …and a drop changes no membership: a tab landing in another section re-sections on the next
   // render — the tab menu's "Move to" rows are the membership path (v1)
   assert.doesNotMatch(body, /editUnion|moveUnion|editTag/, "no tag write on a tab drop");

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -9,7 +9,8 @@ import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { viewTagUnion, type TagUnion } from "./session-views";
-import { sectionTabs, anySectioned, homeTag, parseTabGroups, readTabGroups, writeTabGroups, isSectionCollapsed,
+import * as TG_MOD from "./tab-groups";
+import { sectionTabs, anySectioned, parseTabGroups, readTabGroups, writeTabGroups, isSectionCollapsed,
          toggleSectionCollapsed, setSectionCollapsed, planStrip, reorderTagOrder, applyTagOrder, TABGROUPS_KEY,
          DEFAULT_COLLAPSED, sectionRef, isPinned, setPinned, togglePinned, prunePinned, reachableFrom, tagRenames, followTagRenames, followAdoption,
          sameTagNames, headWords, type TabSection, type SectionRef, type TabGroupsState } from "./tab-groups";
@@ -34,20 +35,24 @@ const V = {
   remoteTags: [{ id: "TESTHOST-A:r1", host: "TESTHOST-A", name: "remotepool", color: "#7aa2f7", members: ["TESTHOST-A:m1"] }],
 };
 
-test("executed: the home-tag rule — one section per tab, its FIRST holder in tagOrder; sections in union order; the untagged trail", () => {
+test("executed: the every-tag rule (T264b) — a section per tag holding EVERY visible member it carries; sections in union order; the untagged trail", () => {
+  // the user 2026-09-08: tags are equivalent, so a session under two tags appears under both — the
+  // home-tag rule (first holder in tagOrder) is retired
   const unions = viewTagUnion(V);
   const secs = sectionTabs(["web", "api", "loose", "tests"], unions);
   assert.deepEqual(secs.map((s) => [s.name, s.ids]),
-    [["qa", ["api", "tests"]], ["infra", ["web"]], [null, ["loose"]]],
-    "api holds qa AND infra — qa is first in the union order, so qa is its home; tabs keep strip order inside; the loose one trails");
+    [["qa", ["api", "tests"]], ["infra", ["web", "api"]], [null, ["loose"]]],
+    "api holds qa AND infra — it appears under both; tabs keep strip order inside; the loose one trails");
   assert.equal(secs[0].color, "#DD42FF", "the section wears its tag's colour");
-  assert.equal(homeTag("api", unions)!.name, "qa");
-  // the SAME rule revealIn keys on (session-views.ts) — the two must never disagree
+  assert.equal(typeof (TG_MOD as Record<string, unknown>).homeTag, "undefined", "homeTag is retired: nothing sections by a first holder any more");
+  // revealIn (session-views.ts) adds the session's FIRST holder to the lens — any holder reveals it now that every tag shows it
   assert.match(VIEWS, /const holder = unions\.find\(\(u\) => u\.members\.includes\(id\)\);/);
-  // reorder the tags and api moves home with them — this is why reordering is first-class
+  // reorder the tags and the sections follow — this is why reordering is first-class; api stays in both
   const flipped = viewTagUnion({ ...V, tagOrder: ["infra", "qa"] });
   assert.deepEqual(sectionTabs(["web", "api", "tests"], flipped).map((s) => [s.name, s.ids]),
-    [["infra", ["web", "api"]], ["qa", ["tests"]]]);
+    [["infra", ["web", "api"]], ["qa", ["api", "tests"]]]);
+  // the trail holds only ids in NO tag
+  assert.deepEqual(sectionTabs(["api", "loose"], unions).map((s) => [s.name, s.ids]), [["qa", ["api"]], ["infra", ["api"]], [null, ["loose"]]]);
   // a tag with no visible member yields no section; a remote-homed tag sections by NAME like any other
   assert.ok(!secs.some((s) => s.name === "empty"));
   assert.deepEqual(sectionTabs(["TESTHOST-A:m1"], unions).map((s) => s.name), ["remotepool"]);
@@ -118,8 +123,8 @@ test("the strip renders sections when the switch is on and some tag holds a visi
   assert.match(RENDER, /const unions = viewTagUnion\(effViews\(\)\);\s*\n\s*const plan = planStrip\(visibleIds, unions, readTabGroups\(unions\), activeId, phoneLayout\(\),/,
     "the pure module owns the rule; the phone layout and the create in flight are its inputs");
   assert.match(RENDER, /collapsedTabIds = plan\.folded;/);
-  assert.match(RENDER, /if \("head" in item\) \{\s*\n(?:\s*\/\/[^\n]*\n)*\s*if \(item\.head\.name !== null && bar\.childElementCount\) bar\.appendChild\(makeRowBreak\(false\)\);\s*\n\s*bar\.appendChild\(makeGroupHead\(item\.head, item\.folded, item\.active, item\.hidden\)\);\s*\n\s*continue;\s*\n\s*\}/,
-    "a header paints from the plan (T264: on its own line — the break ahead of it)");
+  assert.match(RENDER, /if \("head" in item\) \{\s*\n(?:\s*\/\/[^\n]*\n)*\s*if \(item\.head\.name !== null && bar\.childElementCount\) bar\.appendChild\(makeRowBreak\(false\)\);\s*\n\s*bar\.appendChild\(makeGroupHead\(item\.head, item\.folded, item\.active, item\.hidden\)\);\s*\n\s*copyGroup = item\.head\.name;\s*\n\s*continue;\s*\n\s*\}/,
+    "a header paints from the plan (T264: on its own line — the break ahead of it; T264b: it names the group the copies below sit in)");
 });
 
 test("executed: planStrip — sections + folds; the flat strip when off or untagged; the ACTIVE tab's section never folds", () => {
@@ -210,8 +215,8 @@ test("executed: a create in flight sections under the FIRST requested tag in tag
   const unions = viewTagUnion(V);
   const st = parseTabGroups(null);
   const p = planStrip(["web", "prov1", "loose"], unions, st, "prov1", false, { id: "prov1", tags: ["infra", "qa"] });
-  assert.deepEqual(p.items.map((i) => ("head" in i ? "#" + i.head.name : i.id)), ["#qa", "prov1", "#infra", "web", "#null", "loose"],
-    "qa is first in tagOrder of the requested tags → qa is its home (the kernel's own home-tag rule)");
+  assert.deepEqual(p.items.map((i) => ("head" in i ? "#" + i.head.name : i.id)), ["#qa", "prov1", "#infra", "web", "prov1", "#null", "loose"],
+    "the provisional tab appears under BOTH requested tags from the first paint (the every-tag rule, T264b)");
   const none = planStrip(["web", "prov1"], unions, st, "prov1", false, { id: "prov1", tags: [] });
   assert.deepEqual(none.items.map((i) => ("head" in i ? "#" + i.head.name : i.id)), ["#infra", "web", "#null", "prov1"], "no tags asked → the untagged trail");
   assert.deepEqual(V.tags.map((t) => t.members), [["tests", "api"], ["web", "api"], []], "the unions themselves are untouched");
@@ -395,17 +400,21 @@ test("the tab drag's virtual layout wraps where the strip wraps: headers after a
   assert.match(DS, /const needsWrap = row !== null && cx > 0 && \(b\.br === true \|\| cx \+ b\.w > containerW\);/, "dragslot honours br (executed in dragslot.test.ts)");
 });
 
-test("executed: a session under two tags is placed ONCE, under its home tag — the duplicate question stays the user's (T264)", () => {
-  // the manager's note (2026-09-08): sectionTabs homes each id under homeTag; the user has been asked
-  // whether a two-tag session should show under both. Until they rule, this pins today's behaviour so
-  // the line-per-group layout does not change it by accident.
+test("executed: a session under two tags is placed under BOTH — the user's ruling (T264b); folded away only when every copy is", () => {
+  // the user 2026-09-08: tags are equivalent; neither takes precedence, so the session appears under
+  // every tag it carries (the T264 once-per-session pin flipped to this rule)
   const unions = viewTagUnion({ tags: [{ id: "t-infra", name: "infra", color: "#1EA1EB", members: ["web", "api"] },
                                        { id: "t-qa", name: "qa", color: "#54B204", members: ["api", "tests"] }] });
-  const p = planStrip(["web", "api", "tests"], unions, parseTabGroups(null, unions), "web", false);
+  const st = parseTabGroups(null, unions);
+  const p = planStrip(["web", "api", "tests"], unions, st, "web", false);
   const tabs = p.items.filter((i) => "id" in i).map((i) => (i as { id: string }).id);
-  assert.deepEqual(tabs, ["web", "api", "tests"], "each session once");
-  const heads = p.items.map((i, k) => ("head" in i ? { name: i.head.name, ids: i.head.ids, at: k } : null)).filter(Boolean);
-  assert.deepEqual(heads.map((h) => [h!.name, h!.ids]), [["infra", ["web", "api"]], ["qa", ["tests"]]], "api sits under its home tag only");
+  assert.deepEqual(tabs, ["web", "api", "api", "tests"], "api has a copy in each of its groups");
+  const heads = p.items.map((i) => ("head" in i ? { name: i.head.name, ids: i.head.ids } : null)).filter(Boolean);
+  assert.deepEqual(heads.map((h) => [h!.name, h!.ids]), [["infra", ["web", "api"]], ["qa", ["api", "tests"]]], "counts per group count the group's own copies");
+  // fold qa: tests is folded away (its only copy), api is NOT (its infra copy is on screen) — the keyboard order keeps it
+  const folded = planStrip(["web", "api", "tests"], unions, setSectionCollapsed(st, "qa", true), "web", false);
+  assert.deepEqual([...folded.folded], ["tests"], "an id leaves the keyboard order only when every copy is folded");
+  assert.deepEqual(folded.items.filter((i) => "id" in i).map((i) => (i as { id: string }).id), ["web", "api"]);
 });
 
 
@@ -628,12 +637,12 @@ test("executed: SHARED — a member a local tag and a same-named remote tag both
   const st2 = followTagRenames(st, renames, ru);
   assert.deepEqual(st2.pinned, [{ sid: "web", name: "ops", id: "g7" }, { sid: "web", name: "infra" }], "the rewritten entry, and the old-name half");
   assert.equal(followTagRenames(st2, renames, ru), st2, "idempotent: a second pane adopting the same frame after the first has written finds nothing to change — the same object, no second write");
-  assert.deepEqual(strip(vis, ru, st2, "loose"), [["#ops(folded)", "web", "#null", "loose"], ["api"]], "web homes in ops and is pinned there; no member homes in infra, so it has no header");
+  assert.deepEqual(strip(vis, ru, st2, "loose"), [["#ops(folded)", "web", "#infra(folded)", "web", "#null", "loose"], ["api"]], "web shows under ops AND infra (every-tag rule, T264b), pinned in both");
   // the user had dragged infra into place before the rename: the kernel leaves tagOrder alone, so infra
   // keeps its slot and ops falls behind — web homes in the remote-only infra, and the kept half matches
   const infraFirst = viewTagUnion({ ...renamedV, tagOrder: ["infra"] });
   assert.deepEqual(infraFirst.map((u) => u.name), ["infra", "ops"]);
-  assert.deepEqual(strip(vis, infraFirst, st2, "loose"), [["#infra(folded)", "web", "#ops(folded)", "#null", "loose"], ["api"]], "web pinned under infra; api under ops");
+  assert.deepEqual(strip(vis, infraFirst, st2, "loose"), [["#infra(folded)", "web", "#ops(folded)", "web", "#null", "loose"], ["api"]], "web pinned under infra; api under ops");
   assert.equal(isPinned(st2, secOf(ru, "ops"), "web"), true, "the menu row reads on under ops…");
   assert.equal(isPinned(st2, secOf(infraFirst, "infra"), "web"), true, "…and under infra");
   // the prune keeps both halves while both hold web, and drops the infra half once the remote tag lets go
@@ -643,13 +652,13 @@ test("executed: SHARED — a member a local tag and a same-named remote tag both
   const letGo = viewTagUnion({ ...renamedV, remoteTags: [{ ...A, members: [] }] });
   assert.deepEqual(prunePinned(st2, letGo, known, HOSTS).pinned, [{ sid: "web", name: "ops", id: "g7" }], "no union named infra holds web: that half is dead");
   // the same rename with no client watching: the id half is found; the infra half is only the kept one
-  assert.deepEqual(strip(vis, ru, st, "loose"), [["#ops(folded)", "web", "#null", "loose"], ["api"]], "missed: the id finds ops");
-  assert.deepEqual(strip(vis, infraFirst, st, "loose"), [["#infra(folded)", "web", "#ops(folded)", "#null", "loose"], ["api"]], "missed, infra first: the stored name IS infra — the section the user pinned in");
+  assert.deepEqual(strip(vis, ru, st, "loose"), [["#ops(folded)", "web", "#infra(folded)", "web", "#null", "loose"], ["api"]], "missed: the id finds ops, the stored name finds infra — web shows under both");
+  assert.deepEqual(strip(vis, infraFirst, st, "loose"), [["#infra(folded)", "web", "#ops(folded)", "web", "#null", "loose"], ["api"]], "missed, infra first: the stored name IS infra — the section the user pinned in");
   // OFF IS PER SECTION: off under ops clears the ops entry alone; the infra pin is the infra row's to
   // clear, and the row there reads on
   const off = setPinned(st2, secOf(ru, "ops"), "web", false);
   assert.deepEqual(off.pinned, [{ sid: "web", name: "infra" }]);
-  assert.deepEqual(strip(vis, ru, off, "loose"), [["#ops(folded)", "#null", "loose"], ["web", "api"]], "web folded away under ops");
+  assert.deepEqual(strip(vis, ru, off, "loose"), [["#ops(folded)", "#infra(folded)", "web", "#null", "loose"], ["api"]], "web folded away under ops, shown under infra where its pin stands");
   assert.deepEqual(strip(vis, infraFirst, off, "loose"), [["#infra(folded)", "web", "#ops(folded)", "#null", "loose"], ["api"]], "infra dragged first: web shows through infra's fold — the pin set there stands until cleared there");
   assert.equal(isPinned(off, secOf(infraFirst, "infra"), "web"), true, "the row under infra reads on");
   assert.deepEqual(setPinned(off, secOf(infraFirst, "infra"), "web", false).pinned, [], "off under infra: cleared");
@@ -669,7 +678,7 @@ test("executed: a LOCAL-ONLY member of a MIXED union — the remote same-named t
   const renamedV = { active: "all", tags: [local("ops")], remoteTags: [A] };
   const st2 = followTagRenames(st, tagRenames(mixedV, renamedV), viewTagUnion(renamedV));
   assert.deepEqual(st2.pinned, [{ sid: "api", name: "ops", id: "g7" }], "no infra half: A's infra does not hold api");
-  assert.deepEqual(strip(["web", "api", "loose"], viewTagUnion(renamedV), st2, "loose"), [["#ops(folded)", "api", "#null", "loose"], ["web"]]);
+  assert.deepEqual(strip(["web", "api", "loose"], viewTagUnion(renamedV), st2, "loose"), [["#ops(folded)", "api", "#infra(folded)", "#null", "loose"], ["web"]]);
   assert.deepEqual(strip(["web", "api", "loose"], viewTagUnion({ ...renamedV, tagOrder: ["infra"] }), st2, "loose"), [["#infra(folded)", "#ops(folded)", "api", "#null", "loose"], ["web"]],
     "infra dragged first: web homes in the remote infra (unpinned there), api in ops, pinned");
 });
@@ -687,19 +696,19 @@ test("executed: TWO TAGS WITH DIFFERENT NAMES holding one tab — a pin under ea
   st = setPinned(st, secOf(aFirst, "a"), "web", true);   // 1. Show when folded under a
   assert.deepEqual(st.pinned, [{ sid: "web", name: "a", id: "gA" }]);
   assert.deepEqual(strip(vis, aFirst, st, "loose"), [["#a(folded)", "web", "#b(folded)", "#null", "loose"], ["x1", "x2"]]);
-  // 2. b dragged first: web's home is b, where nothing pins it (a move starts unpinned) — the row reads off
-  assert.deepEqual(strip(vis, bFirst, st, "loose"), [["#b(folded)", "#a(folded)", "#null", "loose"], ["web", "x2", "x1"]]);
+  // 2. b dragged first: web shows under b too (every-tag rule), where nothing pins it — hidden there, shown under a; the b row reads off
+  assert.deepEqual(strip(vis, bFirst, st, "loose"), [["#b(folded)", "#a(folded)", "web", "#null", "loose"], ["x2", "x1"]]);
   assert.equal(isPinned(st, secOf(bFirst, "b"), "web"), false);
   // 3. Show when folded under b: b's entry is added; a's stands
   st = setPinned(st, secOf(bFirst, "b"), "web", true);
   assert.deepEqual(st.pinned, [{ sid: "web", name: "a", id: "gA" }, { sid: "web", name: "b", id: "gB" }]);
-  assert.deepEqual(strip(vis, bFirst, st, "loose"), [["#b(folded)", "web", "#a(folded)", "#null", "loose"], ["x2", "x1"]]);
+  assert.deepEqual(strip(vis, bFirst, st, "loose"), [["#b(folded)", "web", "#a(folded)", "web", "#null", "loose"], ["x2", "x1"]]);
   // 4. a dragged first again: the pin set under a is still there
-  assert.deepEqual(strip(vis, aFirst, st, "loose"), [["#a(folded)", "web", "#b(folded)", "#null", "loose"], ["x1", "x2"]], "no gesture turned it off");
+  assert.deepEqual(strip(vis, aFirst, st, "loose"), [["#a(folded)", "web", "#b(folded)", "web", "#null", "loose"], ["x1", "x2"]], "no gesture turned it off");
   // off under a clears a's entry alone
   const off = setPinned(st, secOf(aFirst, "a"), "web", false);
   assert.deepEqual(off.pinned, [{ sid: "web", name: "b", id: "gB" }]);
-  assert.deepEqual(strip(vis, aFirst, off, "loose"), [["#a(folded)", "#b(folded)", "#null", "loose"], ["web", "x1", "x2"]], "folded away under a");
+  assert.deepEqual(strip(vis, aFirst, off, "loose"), [["#a(folded)", "#b(folded)", "web", "#null", "loose"], ["x1", "x2"]], "folded away under a, shown under b where its pin stands — so not skipped by the keyboard");
   assert.deepEqual(strip(vis, bFirst, off, "loose"), [["#b(folded)", "web", "#a(folded)", "#null", "loose"], ["x2", "x1"]], "still pinned under b");
   assert.equal(prunePinned(off, aFirst, new Set(vis), HOSTS), off, "both tags still hold web: nothing dead");
 });
@@ -725,8 +734,8 @@ test("executed: MIRROR A — pinned BEFORE the second holder: a remote host's sa
   const ru = viewTagUnion(renamedV);
   const st2 = followTagRenames(st, tagRenames(mixedV, renamedV), ru);
   assert.deepEqual(st2.pinned, [{ sid: "web", name: "ops", id: "g7" }, { sid: "web", name: "infra" }]);
-  assert.deepEqual(strip(vis, ru, st2, "loose"), [["#infra(folded)", "web", "#ops(folded)", "#null", "loose"], ["api"]], "pinned under infra, the home the drag order gives it");
-  assert.deepEqual(strip(vis, viewTagUnion({ ...renamedV, tagOrder: [] }), st2, "loose"), [["#ops(folded)", "web", "#null", "loose"], ["api"]], "and under ops, the default home");
+  assert.deepEqual(strip(vis, ru, st2, "loose"), [["#infra(folded)", "web", "#ops(folded)", "web", "#null", "loose"], ["api"]], "pinned under infra, the home the drag order gives it");
+  assert.deepEqual(strip(vis, viewTagUnion({ ...renamedV, tagOrder: [] }), st2, "loose"), [["#ops(folded)", "web", "#infra(folded)", "web", "#null", "loose"], ["api"]], "and under ops, the default home");
 });
 
 test("executed: MIRROR B — a remote pin, then a local same-name tag comes to hold the tab, then that tag's rename: the entry follows the local tag and gains its id, and the old-name half stays while the host's tag holds the tab", () => {
@@ -746,11 +755,11 @@ test("executed: MIRROR B — a remote pin, then a local same-name tag comes to h
   const st2 = followTagRenames(st, tagRenames(mixedV, renamedV), ru);
   assert.deepEqual(st2.pinned, [{ sid: "TESTHOST-A:m1", name: "ops", id: "g9" }, { sid: "TESTHOST-A:m1", name: "infra" }],
     "the renamed tag holds the tab, so the no-id entry follows it and gains the id; A's infra still holds the tab, so the infra half stays");
-  assert.deepEqual(strip(vis, ru, st2, "loose"), [["#ops(folded)", "TESTHOST-A:m1", "#null", "loose"], ["web"]], "default order: home ops, pinned");
-  assert.deepEqual(strip(vis, viewTagUnion({ ...renamedV, tagOrder: ["infra"] }), st2, "loose"), [["#infra(folded)", "TESTHOST-A:m1", "#ops(folded)", "#null", "loose"], ["web"]], "infra dragged first: home infra, pinned");
+  assert.deepEqual(strip(vis, ru, st2, "loose"), [["#ops(folded)", "TESTHOST-A:m1", "#infra(folded)", "TESTHOST-A:m1", "#null", "loose"], ["web"]], "default order: home ops, pinned");
+  assert.deepEqual(strip(vis, viewTagUnion({ ...renamedV, tagOrder: ["infra"] }), st2, "loose"), [["#infra(folded)", "TESTHOST-A:m1", "#ops(folded)", "TESTHOST-A:m1", "#null", "loose"], ["web"]], "infra dragged first: home infra, pinned");
   // the id it gained: a second rename, watched by no client, is found by id
   const againV = { ...renamedV, tags: [{ ...renamedV.tags[0], name: "platform" }] };
-  assert.deepEqual(strip(vis, viewTagUnion(againV), st2, "loose"), [["#platform(folded)", "TESTHOST-A:m1", "#null", "loose"], ["web"]]);
+  assert.deepEqual(strip(vis, viewTagUnion(againV), st2, "loose"), [["#platform(folded)", "TESTHOST-A:m1", "#infra(folded)", "TESTHOST-A:m1", "#null", "loose"], ["web"]]);
   // a same-named tag on another host holding another member is not this rename's to move
   const B = rt("TESTHOST-B", "t2", "infra", ["TESTHOST-B:m1"]);
   const other = setPinned(foldAll(parseTabGroups(null), "infra"), { name: "infra", localId: null }, "TESTHOST-B:m1", true);
@@ -780,7 +789,7 @@ test("executed: a rename is followed ONCE PER BROWSER — the store remembers, b
   assert.deepEqual(off.pinned, [{ sid: "web", name: "infra" }]);
   assert.deepEqual(off.followed, { g7: "ops" }, "the memory rides every write");
   assert.equal(followTagRenames(off, tagRenames(V0, V1), u1), off, "the late pane stands down: this browser already carried g7's pins to ops");
-  assert.deepEqual(strip(vis, u1, off, "loose"), [["#ops(folded)", "#null", "loose"], ["web", "api"]], "web stays folded away under ops, as the user left it");
+  assert.deepEqual(strip(vis, u1, off, "loose"), [["#ops(folded)", "#infra(folded)", "web", "#null", "loose"], ["api"]], "web stays folded away under ops, as the user left it — and shows under infra, where the kept pin stands");
   assert.equal(followTagRenames(off, tagRenames(V0, V2), u2), off, "…and a LATER frame adopted from the stale base — the same rename, coalesced — stands down too (a seq gate on the frame would have let it through)");
   // the id face: infra dragged first, the user turns the pin off under the kept infra half instead
   const offInfra = setPinned(st1, secOf(viewTagUnion({ ...V1, tagOrder: ["infra"] }), "infra"), "web", false);
@@ -863,7 +872,7 @@ test("executed: the follow's memory is pruned PER HOST — a detached host's tag
   // A reattaches. A background pane whose held blob predates A's rename adopts the frame and computes
   // infra → platform again — already followed, so it stands down, and web stays folded away under platform
   assert.equal(followTagRenames(away, tagRenames(V0, V4), viewTagUnion(V4)), away, "the stale pane stands down");
-  assert.deepEqual(strip(vis, viewTagUnion(V4), away, "loose"), [["#platform(folded)", "#infra(folded)", "#y(folded)", "#null", "loose"], ["web", "api", "tests"]]);
+  assert.deepEqual(strip(vis, viewTagUnion(V4), away, "loose"), [["#platform(folded)", "#infra(folded)", "web", "#y(folded)", "#null", "loose"], ["api", "tests"]]);
   assert.deepEqual(followTagRenames({ ...away, followed: { g8: "y" } }, tagRenames(V0, V4), viewTagUnion(V4)).pinned, [{ sid: "web", name: "infra", id: "g7" }, { sid: "web", name: "platform" }],
     "(without A's memory, the late pane re-applies the pin the user turned off)");
   // A DOWN instead of detached: the kernel keeps a down host's cached tags in the blob, so its ids are live and the memory stood already
@@ -1290,9 +1299,9 @@ test("executed: a REMOTE host's rename of a MIXED section — the entry carries 
   const ru = viewTagUnion(renamedV);
   const st2 = followTagRenames(st, tagRenames(mixedV, renamedV), ru);
   assert.deepEqual(st2.pinned, [{ sid: "TESTHOST-A:m1", name: "infra", id: "g9" }, { sid: "TESTHOST-A:m1", name: "ops" }], "the kept entry, and the remote half — no id: the tag is A's");
-  assert.deepEqual(strip(vis, ru, st2, "loose"), [["#infra(folded)", "TESTHOST-A:m1", "#null", "loose"], ["web"]], "default order: home infra, pinned; no member homes in ops, so it has no header");
+  assert.deepEqual(strip(vis, ru, st2, "loose"), [["#infra(folded)", "TESTHOST-A:m1", "#ops(folded)", "TESTHOST-A:m1", "#null", "loose"], ["web"]], "default order: shown under infra AND ops (every-tag rule), pinned in both");
   const opsFirst = viewTagUnion({ ...renamedV, tagOrder: ["ops"] });
-  assert.deepEqual(strip(vis, opsFirst, st2, "loose"), [["#ops(folded)", "TESTHOST-A:m1", "#infra(folded)", "#null", "loose"], ["web"]], "ops dragged first: home ops, pinned there too");
+  assert.deepEqual(strip(vis, opsFirst, st2, "loose"), [["#ops(folded)", "TESTHOST-A:m1", "#infra(folded)", "TESTHOST-A:m1", "#null", "loose"], ["web"]], "ops dragged first: home ops, pinned there too");
   assert.equal(isPinned(st2, secOf(opsFirst, "ops"), "TESTHOST-A:m1"), true);
   assert.equal(prunePinned(st2, opsFirst, new Set(vis), HOSTS), st2, "both halves hold the tab: both stand");
   // the same start with the LOCAL tag renamed instead — the mirror, as before
@@ -1308,7 +1317,7 @@ test("executed: a REMOTE host's rename of a MIXED section — the entry carries 
   assert.deepEqual(strip(vis2, viewTagUnion(beforeV), st, "loose"), [["#ops(folded)", "#infra(folded)", "TESTHOST-A:m1", "#null", "loose"], ["x", "web"]]);
   const st3 = followTagRenames(st, tagRenames(beforeV, afterV), au);
   assert.deepEqual(st3.pinned, [{ sid: "TESTHOST-A:m1", name: "infra", id: "g9" }, { sid: "TESTHOST-A:m1", name: "ops" }]);
-  assert.deepEqual(strip(vis2, au, st3, "loose"), [["#ops(folded)", "TESTHOST-A:m1", "#infra(folded)", "#null", "loose"], ["x", "web"]], "home ops now — the union g3 and A's tag make — and on the strip");
+  assert.deepEqual(strip(vis2, au, st3, "loose"), [["#ops(folded)", "TESTHOST-A:m1", "#infra(folded)", "TESTHOST-A:m1", "#null", "loose"], ["x", "web"]], "home ops now — the union g3 and A's tag make — and on the strip");
   assert.equal(isPinned(st3, secOf(au, "ops"), "TESTHOST-A:m1"), true, "the section's local id is g3, the entry's name is ops: matched by name");
 });
 
@@ -1330,8 +1339,8 @@ test("executed: TWO same-named tags both holding the tab, renamed in ONE frame �
   const twice = followTagRenames(followTagRenames(st, tagRenames(V0, V1), viewTagUnion(V1)), tagRenames(V1, V2), u2);
   assert.deepEqual(twice.pinned, once.pinned, "the same two renames a frame apart: the same entries");
   assert.deepEqual(once.followed, twice.followed);
-  assert.deepEqual(strip(vis, viewTagUnion({ ...V2, tagOrder: ["platform"] }), once, "loose"), [["#platform(folded)", "web", "#null", "api", "loose"], []], "platform first: pinned there");
-  assert.deepEqual(strip(vis, u2, once, "loose"), [["#ops(folded)", "web", "#null", "api", "loose"], []], "ops first: pinned there");
+  assert.deepEqual(strip(vis, viewTagUnion({ ...V2, tagOrder: ["platform"] }), once, "loose"), [["#platform(folded)", "web", "#ops(folded)", "web", "#null", "api", "loose"], []], "platform first: pinned there");
+  assert.deepEqual(strip(vis, u2, once, "loose"), [["#ops(folded)", "web", "#platform(folded)", "web", "#null", "api", "loose"], []], "ops first: pinned there");
   // the id face: local g7 infra and A's infra both hold web, both renamed in one frame
   const g7 = (name: string) => ({ id: "g7", name, color: "#4EC9B0", members: ["web", "api"] });
   const M0 = { active: "all", tags: [g7("infra")], remoteTags: [A] };
@@ -1342,7 +1351,7 @@ test("executed: TWO same-named tags both holding the tab, renamed in ONE frame �
   assert.deepEqual(onceM.pinned, [{ sid: "web", name: "ops", id: "g7" }, { sid: "web", name: "platform" }], "its own tag's rename by id, A's by the old name — one entry each; no infra half, nothing is named infra now");
   const M1 = { active: "all", tags: [g7("ops")], remoteTags: [A] };
   assert.deepEqual(followTagRenames(followTagRenames(pinned, tagRenames(M0, M1), viewTagUnion(M1)), tagRenames(M1, M2), m2).pinned, onceM.pinned, "a frame apart: the same");
-  assert.deepEqual(strip(vis, viewTagUnion({ ...M2, tagOrder: ["platform"] }), onceM, "loose"), [["#platform(folded)", "web", "#ops(folded)", "#null", "loose"], ["api"]]);
+  assert.deepEqual(strip(vis, viewTagUnion({ ...M2, tagOrder: ["platform"] }), onceM, "loose"), [["#platform(folded)", "web", "#ops(folded)", "web", "#null", "loose"], ["api"]]);
 });
 
 test("executed: tagRenames — a tag that keeps its id under a new name, local or a remote host's; a new tag, a deleted one, an unchanged name and a missing blob yield none; followTagRenames rewrites by id whatever the stored name, collapses duplicates, and returns the same state when no rename is new", () => {
@@ -1575,7 +1584,7 @@ test("executed: a folded section whose EVERY member is pinned stays folded — t
   const p = planStrip(["web", "api", "tests"], unions, st, "tests", false);
   const h = headsOf(p).find((x) => x.head.name === "infra")!;
   assert.deepEqual([h.folded, h.hidden], [true, []], "folded — the stored state the click acts on, so the header still opens it — with nothing hidden");
-  assert.deepEqual(p.items.map((i) => ("head" in i ? `#${i.head.name}${i.folded ? "(folded)" : ""}` : i.id)), ["#infra(folded)", "web", "api", "#qa", "tests"]);
+  assert.deepEqual(p.items.map((i) => ("head" in i ? `#${i.head.name}${i.folded ? "(folded)" : ""}` : i.id)), ["#infra(folded)", "web", "api", "#qa", "api", "tests"]);
   assert.deepEqual([...p.folded], [], "every tab reachable");
   // the words render.ts paints for that header
   assert.deepEqual(headWords("infra", 2, 0, true, false), {
@@ -1628,4 +1637,49 @@ test("the group header wears the SHARED tag chip — one vocabulary with the tag
   const head = RENDER.slice(RENDER.indexOf("function makeGroupHead("), RENDER.indexOf("function sectionHeadOf("));
   assert.match(head, /chip\.classList\.add\("tab-group-chip"\);/);
   assert.ok(!/font-size/.test(head), "the header sets no size of its own — the chip inherits the header's 0.82em (no nested em)");
+});
+
+// ── T264b (the user 2026-09-08): a session under several tags has a copy in every group ──────────────────
+test("every copy is the full tab of the ONE session, and the by-copy readers tell copies apart (T264b)", () => {
+  const loop = RENDER.slice(RENDER.indexOf("collapsedTabIds = plan.folded;"), RENDER.indexOf('const close = el("span", "tab-close");'));
+  // the active highlight, the state class and the dot come from the same per-item loop, so every copy wears them
+  assert.match(loop, /const tab = el\("div", "tab" \+ \(id === activeId \? " active" : ""\)\);/);
+  assert.match(loop, /if \(copyGroup !== undefined\) tab\.dataset\.copy = copyGroup \?\? "";/, "data-copy names the copy's group (sectioned strip only)");
+  assert.match(loop, /tab\.dataset\.act = "select";/, "a click on any copy selects the session through the #tabs delegate, by id");
+  // the ✕ on a copy ends THE session, and its tip says so
+  const close = RENDER.slice(RENDER.indexOf('const close = el("span", "tab-close");'), RENDER.indexOf('close.dataset.act = "close";'));
+  assert.match(close, /const copies = plan\.items\.reduce\(\(n, it\) => n \+ \("id" in it && it\.id === id \? 1 : 0\), 0\);/);
+  assert.match(close, /copies > 1 \? "End session \(it is the one session, shown in every group it is tagged with\)" : "End session"/);
+  // FLIP animates each copy from ITS rect: keyed per copy, not per id
+  const flip = RENDER.slice(RENDER.indexOf("function flipTabs("), RENDER.indexOf("function reorderTo("));
+  assert.match(flip, /const key = \(t: HTMLElement\) => t\.dataset\.id \+ "\\0" \+ \(t\.dataset\.copy \?\? ""\);/);
+  assert.match(flip, /before\.set\(key\(t\), t\.getBoundingClientRect\(\)\)/);
+  assert.match(flip, /before\.get\(key\(t\)\)/);
+});
+
+test("the tab drag moves THIS copy and reorders within its group's neighbours (T264b)", () => {
+  // the dragged element rides beside the id — the id alone names every copy
+  assert.match(RENDER, /let draggedEl: HTMLElement \| null = null;/);
+  assert.match(RENDER, /draggedId = id; draggedEl = tab; tabDragCommitted = false;/, "set at dragstart");
+  assert.match(RENDER, /draggedId = null; draggedEl = null; tabDragCommitted = false;/, "cleared at dragend");
+  assert.equal((RENDER.match(/const dragged = draggedEl && draggedEl\.isConnected \? draggedEl : null;/g) || []).length, 2, "dragover and drop both move the very copy under the pointer");
+  assert.doesNotMatch(RENDER, /tabs\.querySelector<HTMLElement>\(`\.tab\[data-id="\$\{CSS\.escape\(draggedId\)\}"\]`\)/, "never the first tab wearing the id");
+  // the drop's neighbours skip the session's own copy in the group next door — reorderTo against itself moves nothing
+  const drop = RENDER.slice(RENDER.indexOf('tabs.addEventListener("drop"'), RENDER.indexOf("tabDragCommitted = true;"));
+  assert.match(drop, /const own = \(n: Element \| null\) => !!n && \(n as HTMLElement\)\.dataset\?\.id === draggedId;/);
+  assert.match(drop, /const tabBefore = \(n: Element \| null\) => \{ while \(n && \(!\(n as HTMLElement\)\.dataset\?\.id \|\| own\(n\)\)\) n = n\.previousElementSibling;/);
+  assert.match(drop, /const tabAfter = \(n: Element \| null\) => \{ while \(n && \(!\(n as HTMLElement\)\.dataset\?\.id \|\| own\(n\)\)\) n = n\.nextElementSibling;/);
+  // a drop still changes no membership: a copy dragged into another group's row re-sections home on the next render
+  const over = RENDER.slice(RENDER.indexOf('tabs.addEventListener("dragover"'), RENDER.indexOf('tabs.addEventListener("drop"'));
+  assert.match(over, /A drop changes\s*\n?\s*\/\/ no membership/);
+});
+
+test("executed: the keyboard order keeps a session while any copy is on screen (T264b)", () => {
+  const unions = viewTagUnion({ tags: [{ id: "t-a", name: "alpha", color: "#1EA1EB", members: ["web", "api"] },
+                                       { id: "t-b", name: "beta", color: "#54B204", members: ["api"] }] });
+  const st = setSectionCollapsed(parseTabGroups(null, unions), "alpha", true);
+  const p = planStrip(["web", "api"], unions, st, null, false);
+  assert.deepEqual([...p.folded], ["web"], "web's only copy is folded; api's beta copy is on screen");
+  const both = planStrip(["web", "api"], unions, setSectionCollapsed(st, "beta", true), null, false);
+  assert.deepEqual([...both.folded].sort(), ["api", "web"], "every copy folded → skipped");
 });

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -1,5 +1,5 @@
-// TAB GROUPS ARE TAGS (the user 2026-09-04): the chat tab strip sections by HOME tag — the first
-// holder in tagOrder, the rule revealIn states — with the untagged trailing, per-browser on/off and
+// TAB GROUPS ARE TAGS (the user 2026-09-04): the chat tab strip sections by tag — every tag a
+// session carries (T264b, 2026-09-08; the home-tag rule is retired) — with the untagged trailing, per-browser on/off and
 // per-section fold state under romp:tabgroups, and the section headers draggable to reorder
 // tagOrder (the kernel-persisted union order the timeline's pill drag writes too). Executed tests on
 // the pure module + source pins on render.ts / tag-menu.ts / styles.css (the tab-order.ts pattern;
@@ -208,7 +208,7 @@ test("executed + pinned: the section holding the ACTIVE tab is unfoldable while 
   assert.match(CSS, /\.tab-group-head\.holds-active \{ cursor: default; \}/);
 });
 
-test("executed: a create in flight sections under the FIRST requested tag in tagOrder — its future home — from the first paint", () => {
+test("executed: a create in flight sections under EVERY requested tag from the first paint (T264b)", () => {
   // the kernel tags a new session before its first push so the tab never lands untagged and jumps;
   // the client's provisional tab used to land in the untagged trail (a client-minted id in no
   // union) and move into its group when the frame arrived — the very jump the kernel avoids
@@ -1645,6 +1645,7 @@ test("every copy is the full tab of the ONE session, and the by-copy readers tel
   // the active highlight, the state class and the dot come from the same per-item loop, so every copy wears them
   assert.match(loop, /const tab = el\("div", "tab" \+ \(id === activeId \? " active" : ""\)\);/);
   assert.match(loop, /if \(copyGroup !== undefined\) tab\.dataset\.copy = copyGroup \?\? "";/, "data-copy names the copy's group (sectioned strip only)");
+  assert.match(loop, /const ph = makePlaceholderTab\(id\);\s*\n\s*if \(copyGroup !== undefined\) ph\.dataset\.copy = copyGroup \?\? "";/, "…on a placeholder copy too (a create in flight under two tags), so flipTabs keys never collide");
   assert.match(loop, /tab\.dataset\.act = "select";/, "a click on any copy selects the session through the #tabs delegate, by id");
   // the ✕ on a copy ends THE session, and its tip says so
   const close = RENDER.slice(RENDER.indexOf('const close = el("span", "tab-close");'), RENDER.indexOf('close.dataset.act = "close";'));
@@ -1665,10 +1666,16 @@ test("the tab drag moves THIS copy and reorders within its group's neighbours (T
   assert.equal((RENDER.match(/const dragged = draggedEl && draggedEl\.isConnected \? draggedEl : null;/g) || []).length, 2, "dragover and drop both move the very copy under the pointer");
   assert.doesNotMatch(RENDER, /tabs\.querySelector<HTMLElement>\(`\.tab\[data-id="\$\{CSS\.escape\(draggedId\)\}"\]`\)/, "never the first tab wearing the id");
   // the drop's neighbours skip the session's own copy in the group next door — reorderTo against itself moves nothing
-  const drop = RENDER.slice(RENDER.indexOf('tabs.addEventListener("drop"'), RENDER.indexOf("tabDragCommitted = true;"));
+  const drop = RENDER.slice(RENDER.indexOf('tabs.addEventListener("drop"'), RENDER.indexOf("tabDragCommitted = true; }"));
   assert.match(drop, /const own = \(n: Element \| null\) => !!n && \(n as HTMLElement\)\.dataset\?\.id === draggedId;/);
-  assert.match(drop, /const tabBefore = \(n: Element \| null\) => \{ while \(n && \(!\(n as HTMLElement\)\.dataset\?\.id \|\| own\(n\)\)\) n = n\.previousElementSibling;/);
-  assert.match(drop, /const tabAfter = \(n: Element \| null\) => \{ while \(n && \(!\(n as HTMLElement\)\.dataset\?\.id \|\| own\(n\)\)\) n = n\.nextElementSibling;/);
+  // the neighbours come from the dragged copy's OWN group first: the walk stops at a header or a row break,
+  // and only a group holding no other tab falls back to the nearest tab across groups (a drop at a group's
+  // head used to anchor on the group above's last tab, so the session's other copy jumped)
+  assert.match(drop, /const edge = \(n: Element\) => n\.classList\.contains\("tab-group-head"\) \|\| n\.classList\.contains\("tab-group-break"\);/);
+  assert.match(drop, /while \(n && \(!\(n as HTMLElement\)\.dataset\?\.id \|\| own\(n\)\)\) \{ if \(inGroup && edge\(n\)\) return null; n = step\(n\); \}/);
+  assert.match(drop, /const prev = prevIn \?\? \(nextIn \? null : walk\(dragged\.previousElementSibling, back, false\)\);/);
+  assert.match(drop, /const next = nextIn \?\? \(prevIn \? null : walk\(dragged\.nextElementSibling, fwd, false\)\);/);
+  assert.doesNotMatch(drop, /\n\s*tabDragCommitted = true;\s*\/\//, "no unconditional commit: a drop that moved nothing takes dragend's cancel path");
   // a drop still changes no membership: a copy dragged into another group's row re-sections home on the next render
   const over = RENDER.slice(RENDER.indexOf('tabs.addEventListener("dragover"'), RENDER.indexOf('tabs.addEventListener("drop"'));
   assert.match(over, /A drop changes\s*\n?\s*\/\/ no membership/);
@@ -1682,4 +1689,50 @@ test("executed: the keyboard order keeps a session while any copy is on screen (
   assert.deepEqual([...p.folded], ["web"], "web's only copy is folded; api's beta copy is on screen");
   const both = planStrip(["web", "api"], unions, setSectionCollapsed(st, "beta", true), null, false);
   assert.deepEqual([...both.folded].sort(), ["api", "web"], "every copy folded → skipped");
+});
+
+test("↑/↓ measure from the focused copy and never land on the session's own other copy (T264b review)", () => {
+  const fn = RENDER.slice(RENDER.indexOf("function tabInAdjacentRow("), RENDER.indexOf("// ---- session picker overlay"));
+  assert.match(fn, /const focused = document\.activeElement as HTMLElement \| null;/);
+  assert.match(fn, /focused && focused\.classList\.contains\("tab"\) && focused\.dataset\.id === id && bar\?\.contains\(focused\)\s*\n\s*\? focused : bar\?\.querySelector/,
+    "the origin is the copy the user is on, else the first copy");
+  assert.match(fn, /if \(t\.dataset\.id === id\) continue;/, "the session's own other copy is never the answer (setActive would no-op: a dead key)");
+});
+
+test("the tab menu speaks for the right-clicked copy's group: Move to drops THAT tag, Show when folded pins THAT section, Rename edits THAT copy (T264b review)", () => {
+  assert.match(RENDER, /showTabMenu\(e, id, tab\.dataset\.copy\); \}\);/, "the copy's group rides the contextmenu call");
+  assert.match(RENDER, /function showTabMenu\(e: MouseEvent, id: string, copy\?: string\)/);
+  assert.match(RENDER, /const home0 = readTabGroups\(\)\.on \? \(\(copy !== undefined \? holding\(\)\.find\(\(g\) => g\.name === copy\) : undefined\) \?\? holding\(\)\[0\]\) : undefined;/,
+    "the copy's own group, else the first holder (the flat strip names no copy)");
+  assert.match(RENDER, /startTabRename\(id, copy\)/);
+  assert.match(RENDER, /function startTabRename\(id: string, copy\?: string\)/);
+  assert.match(RENDER, /t\.dataset\.id === id && \(copy === undefined \|\| t\.dataset\.copy === copy\)\)\s*\n\s*\?\? Array\.from\(bar\.children\)\.find\(\(t\): t is HTMLElement => t instanceof HTMLElement && t\.dataset\.id === id\)\);/,
+    "the right-clicked copy edits in place, the first copy when that one is gone");
+  assert.match(RENDER, /plus\.title = "add this tag too — the session keeps its other tags";/);
+});
+
+test("executed: activating a session under several tags springs no fold — only the open holders are active; all folded → the first opens (T264b review)", () => {
+  // web=[s1,s2], archived=[s2,s3,s4], archived folded by default: activating s2 (a live session also
+  // tagged archived to put it away later) must not spring the whole archived row open
+  const unions = viewTagUnion({ tags: [{ id: "t-web", name: "web", color: "#1EA1EB", members: ["s1", "s2"] },
+                                       { id: "t-arch", name: "archived", color: "#4EA8A9", members: ["s2", "s3", "s4"] }] });
+  const st = parseTabGroups(null, unions);
+  const marks = (active: string | null, state = st) => planStrip(["s1", "s2", "s3", "s4"], unions, state, active, false).items
+    .map((i) => ("head" in i ? `#${i.head.name}${i.active ? "(active)" : ""}${i.folded ? "(folded)" : ""}` : i.id));
+  assert.deepEqual(marks("s2"), ["#web(active)", "s1", "s2", "#archived(folded)"], "archived stays folded: s2 shows under web");
+  assert.deepEqual(marks("s1"), ["#web(active)", "s1", "s2", "#archived(folded)"]);
+  assert.deepEqual([...planStrip(["s1", "s2", "s3", "s4"], unions, st, "s2", false).folded], ["s3", "s4"], "s2 is on screen (under web): not skipped");
+  // both holders folded, nothing pinned: exactly one — the first in tagOrder — opens, as a single holder always did
+  const both = setSectionCollapsed(st, "web", true);
+  assert.deepEqual(marks("s2", both), ["#web(active)", "s1", "s2", "#archived(folded)"], "web forced open for the active tab; archived left as stored");
+  // a copy pinned through a fold counts as shown: no holder is forced open, the pinned copy carries focus
+  const pinned = setPinned(both, { name: "archived", localId: "t-arch" }, "s2", true);
+  assert.deepEqual(marks("s2", pinned), ["#web(folded)", "#archived(folded)", "s2"], "both folds stand; s2 shows through archived's fold");
+  // a single holder is unchanged: open and unfoldable whatever the store says
+  assert.deepEqual(marks("s3", both), ["#web(folded)", "#archived(active)", "s2", "s3", "s4"]);
+});
+
+test("the guide states the every-tag rule (T264b)", () => {
+  assert.match(GUIDE, /A session with several tags appears under each of them; every copy is the same\s+session/);
+  assert.doesNotMatch(GUIDE, /sits under the first of them in your tag order/, "the retired home-tag sentence is gone");
 });

--- a/ui/webview/tab-groups.ts
+++ b/ui/webview/tab-groups.ts
@@ -1,11 +1,11 @@
 // TAB GROUPS ARE TAGS (the user 2026-09-04). The chat tab strip renders one section per tag, in the
-// user's tag order, each tab under its HOME tag — the FIRST holder tag in tagOrder, the rule
-// revealIn already states ("a tagged session's home is its first holder tag"), so a tab's section
-// and its reveal agree. Sessions in no tag trail in an unlabeled section. No new store and no new
-// session field: the kernel's views blob (tags, members, tagOrder) is the whole model, the headers
-// are the very tags the Tags flyout edits, and reordering the groups IS reordering tagOrder — the
-// kernel-persisted union order the timeline's tag-pill drag writes too, so the two surfaces cannot
-// disagree. A session may hold other tags as well; they filter, they do not section.
+// user's tag order, each tab under EVERY tag it carries (T264b, the user 2026-09-08: tags are
+// equivalent, none takes precedence — a session under N tags has a copy in N sections; the earlier
+// "home tag" rule that placed it under its first holder alone is retired). Sessions in no tag trail
+// in an unlabeled section of their own. No new store and no new session field: the kernel's views
+// blob (tags, members, tagOrder) is the whole model, the headers are the very tags the Tags flyout
+// edits, and reordering the groups IS reordering tagOrder — the kernel-persisted union order the
+// timeline's tag-pill drag writes too, so the two surfaces cannot disagree.
 //
 // Per-browser state, this viewer's like romp:vieworder: whether the strip sections at all (ON by
 // default whenever some tag holds a visible tab; the chat tag-lens menu's "Group tabs by tag" turns
@@ -22,14 +22,14 @@ export const TABGROUPS_EVENT = "romp-tabgroups";
 /** sections that start folded until the user opens them (remembered per browser once toggled) */
 export const DEFAULT_COLLAPSED: ReadonlySet<string> = new Set(["archived"]);
 
-/** One strip section: a tag's name + color and the visible tabs homed in it, plus `localId` — the
+/** One strip section: a tag's name + color and the visible tabs it holds, plus `localId` — the
  *  local tag's stored id when the union has one, null for a union only remote hosts' tags make —
  *  which its pins are matched against beside its name (isPinned). name null = the trailing untagged
  *  section (unlabeled by the user's ruling — a separator, not a header; localId null). */
 export interface TabSection { name: string | null; localId: string | null; color: string; ids: string[] }
 
 /** A section as a pin is matched and written against it: its name and its local tag's id. The plan's
- *  TabSection is one; sectionRef builds one from a union (the menu row's home tag). */
+ *  TabSection is one; sectionRef builds one from a union (the menu row's tag). */
 export type SectionRef = Pick<TabSection, "name" | "localId">;
 
 /** A member kept visible under its folded section — the tab menu's "Show when folded" (the user
@@ -358,10 +358,10 @@ function storeSeqs(unions: readonly TagUnion[], views: SessionViews | null | und
  *  same-named tags' pins are not this tag's to move. EVERY matching rename is followed, one entry per:
  *  the new name, with the tag's id when the tag is local — so the next rename finds it by id even from
  *  a client with no previous blob. Where a rename SPLITS the section — a same-named tag on the other
- *  side still holds the tab, so the tab's home after the rename is whichever half tagOrder puts first
- *  (the kernel leaves tagOrder alone on a rename, so an old name once dragged into place keeps it and
- *  the renamed tag falls behind) — the half the tab did not move to keeps its entry beside the new
- *  one, whichever side renamed: a local rename keeps the old-name half while the remote tag holds the
+ *  side still holds the tab, so the tab shows under both halves, in tagOrder (the kernel leaves
+ *  tagOrder alone on a rename, so an old name once dragged into place keeps it and the renamed tag
+ *  falls behind) — the half the tab did not move to keeps its entry beside the new one, whichever
+ *  side renamed: a local rename keeps the old-name half while the remote tag holds the
  *  tab, a remote rename adds its new-name half while the local tag holds the tab under the old. The
  *  tab is pinned in both halves, and the prune drops the half that stops holding it. `unions` are the
  *  NEXT blob's. Exact duplicates collapse.
@@ -599,16 +599,20 @@ export interface StripPlan {
  *    every rendered tab; it has no header to unfold and no switch, so a folded section there made its
  *    sessions unreachable (`archived` starts folded). Sectioning is DESKTOP-ONLY: on the phone layout
  *    the plan is the flat strip, always — every visible id, nothing folded.
- *  - `pending`: a provisional tab (a create in flight) with the tags the request named. Its future
- *    home is the first of those in tagOrder — the kernel's own home-tag rule — so it renders there
- *    from the first paint instead of landing in the untagged trail and jumping when the frame arrives.
+ *  - `pending`: a provisional tab (a create in flight) with the tags the request named. It renders
+ *    under every one of them from the first paint — the way the kernel's frame will place it — instead
+ *    of landing in the untagged trail and jumping when the frame arrives.
  *  - A folded section hides its members EXCEPT the pinned ones (the tab menu's "Show when folded"),
  *    which keep their place under the header in strip order; the header stands in for `hidden` alone
  *    (its count reads those), and only those ids join the `folded` set.
- *  - The ACTIVE tab's section never renders folded: keyboard focus must never land on a hidden node.
- *    Its header is marked `active`, and render.ts gives that header no fold action: a fold stored
+ *  - The ACTIVE tab never renders hidden: keyboard focus must never land on a hidden node. Its
+ *    section's header is marked `active`, and render.ts gives that header no fold action: a fold stored
  *    there could not render (nothing changed on screen, on every click) and then bit when the user
- *    switched tabs. The section is unfoldable while it holds the active tab. */
+ *    switched tabs. The section is unfoldable while it holds the active tab. A session under several
+ *    tags (T264b) has a copy in each: while any copy is on screen under the stored folds (an open
+ *    section, or pinned through a fold) every fold stands and only the OPEN holders are marked active;
+ *    only when every copy would be hidden is exactly one holder — the first in tagOrder — forced open.
+ *    (Activating a live session also tagged `archived` must not spring the whole archived row open.) */
 export function planStrip(visibleIds: readonly string[], unions: readonly TagUnion[], st: TabGroupsState,
                           activeId: string | null, phone: boolean,
                           pending?: { id: string; tags: readonly string[] } | null): StripPlan {
@@ -624,8 +628,15 @@ export function planStrip(visibleIds: readonly string[], unions: readonly TagUni
     for (const id of visibleIds) items.push({ id });
     return { items, folded, sectioned };
   }
-  for (const sec of sectionTabs(visibleIds, u)) {
-    const active = activeId !== null && sec.ids.includes(activeId);
+  const secs = sectionTabs(visibleIds, u);
+  const open = (sec: TabSection) => sec.name === null || !isSectionCollapsed(st, sec.name);
+  const holders = activeId !== null ? secs.filter((sec) => sec.ids.includes(activeId)) : [];
+  const shownSomewhere = activeId !== null && holders.some((sec) => open(sec) || isPinned(st, sec, activeId));
+  for (const sec of secs) {
+    // one holder: open and unfoldable, as always. several (T264b): the open ones are active; a folded
+    // one stays folded (a pinned copy shows through it) unless NO copy shows anywhere — then the first
+    // holder in tagOrder opens
+    const active = holders.includes(sec) && (holders.length === 1 || open(sec) || (!shownSomewhere && sec === holders[0]));
     const f = sec.name !== null && !active && isSectionCollapsed(st, sec.name);
     const hidden = f ? sec.ids.filter((id) => !isPinned(st, sec, id)) : [];
     items.push({ head: sec, folded: f, active, hidden });

--- a/ui/webview/tab-groups.ts
+++ b/ui/webview/tab-groups.ts
@@ -69,26 +69,22 @@ export function sectionRef(u: TagUnion): SectionRef {
   return { name: u.name, localId: u.localId };
 }
 
-/** THE home-tag rule: the first union (they arrive in tagOrder) holding the id, or null. */
-export function homeTag(id: string, unions: readonly TagUnion[]): TagUnion | null {
-  return unions.find((u) => u.members.includes(id)) || null;
-}
-
-/** Section the visible ids: one section per home tag, sections in UNION order (tagOrder governs —
- *  which is why reordering tags is first-class), tabs inside keep their strip order, the untagged
- *  trail last. A tag holding no visible id yields no section. */
+/** Section the visible ids: one section per TAG, holding EVERY visible member it carries (T264b, the
+ *  user 2026-09-08: tags are equivalent — no tag takes precedence, so a session under N tags appears
+ *  in N groups; the "home tag" rule that placed it under its first holder is retired). Sections in
+ *  UNION order (tagOrder governs — which is why reordering tags is first-class), tabs inside keep
+ *  their strip order, the untagged trail — the ids in NO tag — last. A tag holding no visible id
+ *  yields no section. */
 export function sectionTabs(visibleIds: readonly string[], unions: readonly TagUnion[]): TabSection[] {
-  const byName = new Map<string, TabSection>();
-  const loose: string[] = [];
-  for (const id of visibleIds) {
-    const home = homeTag(id, unions);
-    if (!home) { loose.push(id); continue; }
-    let s = byName.get(home.name);
-    if (!s) { s = { name: home.name, localId: home.localId, color: home.color || "", ids: [] }; byName.set(home.name, s); }
-    s.ids.push(id);
-  }
   const out: TabSection[] = [];
-  for (const u of unions) { const s = byName.get(u.name); if (s && !out.includes(s)) out.push(s); }
+  const tagged = new Set<string>();
+  for (const u of unions) {
+    const ids = visibleIds.filter((id) => u.members.includes(id));
+    if (!ids.length) continue;
+    for (const id of ids) tagged.add(id);
+    out.push({ name: u.name, localId: u.localId, color: u.color || "", ids });
+  }
+  const loose = visibleIds.filter((id) => !tagged.has(id));
   if (loose.length) out.push({ name: null, localId: null, color: "", ids: loose });
   return out;
 }
@@ -96,7 +92,7 @@ export function sectionTabs(visibleIds: readonly string[], unions: readonly TagU
 /** Does any tag hold a visible tab? Sectioning is on by default exactly then — an untagged world
  *  renders the flat strip it always had. */
 export function anySectioned(visibleIds: readonly string[], unions: readonly TagUnion[]): boolean {
-  return visibleIds.some((id) => homeTag(id, unions) !== null);
+  return visibleIds.some((id) => unions.some((u) => u.members.includes(id)));
 }
 
 const fresh = (): TabGroupsState => ({ on: true, collapsed: [], expanded: [], pinned: [] });
@@ -589,7 +585,8 @@ export function headWords(name: string, total: number, hidden: number, folded: b
 
 /** One strip item: a section header (folded or open; `active` = it holds the active tab; `hidden` =
  *  the member ids a folded header stands in for — its members less the pinned ones, [] when open) or
- *  a tab. */
+ *  a tab. The same id may appear as a tab under several headers (T264b: a session under N tags has N
+ *  copies); render.ts paints each copy as a full tab of the one session. */
 export type StripItem = { head: TabSection; folded: boolean; active: boolean; hidden: string[] } | { id: string };
 export interface StripPlan {
   items: StripItem[];
@@ -634,6 +631,9 @@ export function planStrip(visibleIds: readonly string[], unions: readonly TagUni
     items.push({ head: sec, folded: f, active, hidden });
     for (const id of sec.ids) { if (hidden.includes(id)) folded.add(id); else items.push({ id }); }
   }
+  // a session under several tags (T264b) has a copy in each: it is folded away — skipped by the
+  // keyboard — only when EVERY copy is; one copy on screen keeps it in the order
+  for (const it of items) if ("id" in it) folded.delete(it.id);
   return { items, folded, sectioned };
 }
 

--- a/ui/webview/tab-rename-clicksafe.test.ts
+++ b/ui/webview/tab-rename-clicksafe.test.ts
@@ -19,13 +19,13 @@ const rename = RENDER.slice(RENDER.indexOf("function startTabRename"),
                             RENDER.indexOf("// Keyboard nav on a focused tab"));
 
 test("the menu's Rename hands over the id alone — no captured nodes", () => {
-  assert.match(RENDER, /dismissTabMenu\(\); startTabRename\(id\); \}\);/,
+  assert.match(RENDER, /dismissTabMenu\(\); startTabRename\(id, copy\); \}\);/,
                "the click resolves the tab itself; a node captured at menu-open time may be detached");
   assert.doesNotMatch(RENDER, /startTabRename\(tab, label, id\)/);
 });
 
 test("startTabRename resolves the live tab by data-id at call time", () => {
-  assert.match(rename, /function startTabRename\(id: string\)/);
+  assert.match(rename, /function startTabRename\(id: string, copy\?: string\)/, "the id, plus which copy of a multi-tag session to edit (T264b)");
   assert.match(rename, /dataset\.id === id/, "the strip is searched for the CURRENT node wearing this id");
   assert.match(rename, /querySelector<HTMLElement>\("\.tab-label"\)/, "…and its label is taken from that node");
 });

--- a/ui/webview/tab-tags.test.ts
+++ b/ui/webview/tab-tags.test.ts
@@ -84,11 +84,11 @@ test("presentation: one chip per NAME, identity dot, ✕ — and never a host pr
 
 test("one-click MOVE between groups (tab groups, 2026-09-04): 'Move to <name>' adds the target and drops the HOME tag on ONE blob; '+' adds without moving", () => {
   const fly = RENDER.slice(RENDER.indexOf('const sub = el("div", "ctx-menu ctx-sub ctx-sub-tags");'), RENDER.indexOf("// New tag… — an inline input"));
-  assert.match(fly, /const home0 = readTabGroups\(\)\.on \? holding\(\)\[0\] : undefined;\s*\n\s*const home = home0 && !home0\.pending \? home0 : undefined;/,
-    "the home tag is the FIRST holder in the union order — the same rule that sections the strip; only while the strip is sectioned, and never a home whose create is still in flight");
+  assert.match(fly, /const home0 = readTabGroups\(\)\.on \? \(\(copy !== undefined \? holding\(\)\.find\(\(g\) => g\.name === copy\) : undefined\) \?\? holding\(\)\[0\]\) : undefined;\s*\n\s*const home = home0 && !home0\.pending \? home0 : undefined;/,
+    "the group THIS COPY sits in (T264b: a session under several tags has a copy per group, and the menu speaks for the right-clicked copy's group), else the first holder; only while the strip is sectioned, and never a tag whose create is still in flight");
   assert.match(fly, /lb\.textContent = "Move to " \+ g\.name; bodyE\.appendChild\(lb\);/);
   assert.match(fly, /moveUnion\(home, g\); build\(\); sb\.textContent = subText\(\);/, "the row IS the move");
-  assert.match(fly, /plus\.title = "add this tag too — the session stays in its current group";/, "…and multi-tag stays one click away");
+  assert.match(fly, /plus\.title = "add this tag too — the session keeps its other tags";/, "…and multi-tag stays one click away");
   assert.match(fly, /lb\.textContent = "\+ " \+ g\.name; bodyE\.appendChild\(lb\);/, "with no home tag, + <name> is the move");
   const mv = RENDER.slice(RENDER.indexOf("const moveUnion = (from: TagUnion, to: TagUnion)"), RENDER.indexOf("// HOVER-INTENT open"));
   assert.match(mv, /const a = applyUnionEdit\(nv, to, \{ add: \[id\] \}\);\s*\n\s*const r = applyUnionEdit\(nv, from, \{ remove: \[id\] \}\);/,

--- a/vscode-extension/src/tabs-first.test.ts
+++ b/vscode-extension/src/tabs-first.test.ts
@@ -25,7 +25,8 @@ test("applyTabOrder REBUILDS tabMeta from the authoritative payload (closed tabs
 
 test("renderTabs renders the union of arrived sessions and tabMeta, placeholders for the rest", () => {
   assert.match(RENDER, /for \(const id of tabMeta\.keys\(\)\)/);
-  assert.match(RENDER, /if \(!s\) \{ bar\.appendChild\(makePlaceholderTab\(id\)\); continue; \}/);
+  assert.match(RENDER, /if \(!s\) \{\s*\n\s*const ph = makePlaceholderTab\(id\);\s*\n\s*if \(copyGroup !== undefined\) ph\.dataset\.copy = copyGroup \?\? "";[^\n]*\n\s*bar\.appendChild\(ph\); continue;\s*\n\s*\}/,
+    "a placeholder per plan item — one per group the session sits in (T264b), each keyed by its copy");
 });
 
 test("makePlaceholderTab draws name + identity color, and is CLICKABLE while loading", () => {


### PR DESCRIPTION
There is no home tag (the user 2026-09-08): tags are equivalent, so a session under two tags appears under both. Follows the one-group-per-line strip (#1087).

## Design points

- **The rule.** `sectionTabs` lists, per union, every visible member it holds: a session under N tags has N copies, sections in tag order, the untagged trail holds only sessions in no tag. `homeTag` is retired. The provisional tab (a create in flight) appears under every requested tag from the first paint.
- **Every copy is the full tab of the one session.** Same per-item loop, so each copy wears the identity colour, the state class and dot, and the active highlight; a click on any copy selects the session (the `#tabs` delegate reads `data-id`); the ✕ stays on every copy and ends the one session, its tooltip saying so. `data-copy` names the copy's group for the by-copy readers.
- **Keyboard order.** `planStrip` drops an id from the folded set only when every copy is folded away; one copy on screen keeps the session in ←/→ cycling. Focus, the tab menu and the hover tip land on the first copy (the same session).
- **Drag-and-drop.** The drag tracks the dragged element beside the id (the id alone named every copy, so the first copy moved while the user dragged another); the drop's neighbour rule skips the dragged session's own copy in the group next door (reordering against itself moves nothing). A drop still changes no membership: a copy dragged into another group's row reorders within the global order and re-sections home on the next render. Adding a tag stays with the tab menu's Tags rows.
- **Flagged, not changed here.** The tab menu's "Move to <tag>" row still swaps the session's first holder tag for another; under the equivalence ruling that row's meaning ("move" between equals) is the user's call.
- **Folds, counts and pips** count each group's own copies; a pinned copy shows through its own group's fold only.

## Tests

- `ui/webview/tab-groups.test.ts`: the every-tag rule and the untagged trail executed; the provisional tab under both requested tags; the folded-set rule; render pins (data-copy, ✕ tip, flipTabs per-copy keys, the dragged element in dragover and drop, the own-copy neighbour skip). The pinned-member expectations that encoded the home-tag rule are recomputed under the every-tag rule.
- `tests/test_tab_groups_rows.py`: a two-tag session shown under both groups in the served page, same state dot on both copies, the ✕ tip, a click on the second copy highlighting both; both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
