### PR TITLE
Usage modal second pass: chart first, every session its own stack and row, a scrolling list of tab titles, and an ordering control

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -32596,10 +32596,14 @@ def _spend_detail_local(now=None):
             "tz": time.strftime("%Z", lt), "tzOffsetMin": int((getattr(lt, "tm_gmtoff", 0) or 0) // 60),
             "recordedAt": _spend_recorded_at(),
             "sessions": sessions,
-            # the shared session order (session-order.json — what a tab drag or a lane drag writes): the
-            # modal's "your order" seed (T247f); the viewer's own arrangement is applied client-side, the
-            # way the strip and the lanes apply it (view-order.ts)
-            "order": _session_order(),
+            # the shared session order (session-order.json — what a tab drag or a lane drag writes),
+            # restricted to the sessions the TAB STRIP renders (live, or kept open): the modal's "your
+            # order" seed (T247f). The file keeps a recently dead session at its slot while its transcript
+            # is in the discover window; the strip does not show it, and the modal follows the strip, so
+            # every session no longer running trails in spend order (review find: shipped verbatim, a
+            # session dead an hour interleaved with live rows). The viewer's own arrangement is applied
+            # client-side, the way the strip and the lanes apply it (view-order.ts).
+            "order": [s for s in _session_order() if s in live or s in set(_kept_open)],
             "unattributed": {"usd": round(un[0], 4), "tok": un[1], "turns": un[2]},
             "hours": hrs, "days": _series(days, day_keys)}
 
@@ -40947,12 +40951,12 @@ spLoadPrefs();
 // module's applyViewOrder, twinned here because the landing page loads no webview bundle; a node test
 // (ui/webview/spend-order-twin.test.ts) holds the two together. Sessions the order does not know (dead,
 // archived, an older peer's) trail in their spend order.
-function spApplyViewOrder(seed,view){var clean=function(xs){var out=[],seen={};(xs||[]).forEach(function(x){if(typeof x==='string'&&!seen[x]){seen[x]=1;out.push(x);}});return out;};var s=clean(seed);if(!view||!view.length)return s;var want={},placed={},out=[];s.forEach(function(x){want[x]=1;});clean(view).forEach(function(id){if(want[id]){placed[id]=1;out.push(id);}});s.forEach(function(id){if(!placed[id])out.push(id);});return out;}
+function spApplyViewOrder(seed,view){var clean=function(xs){var out=[],seen=Object.create(null);(xs||[]).forEach(function(x){if(typeof x==='string'&&!seen[x]){seen[x]=1;out.push(x);}});return out;};var s=clean(seed);if(!view||!view.length)return s;var want=Object.create(null),placed=Object.create(null),out=[];s.forEach(function(x){want[x]=1;});clean(view).forEach(function(id){if(want[id]){placed[id]=1;out.push(id);}});s.forEach(function(id){if(!placed[id])out.push(id);});return out;}
 function spViewOrder(){try{var o=JSON.parse(localStorage.getItem('romp:vieworder')||'[]');return Array.isArray(o)?o:[];}catch(e){return [];}}
 function spKey(d,s){return (s.host&&s.host!==d.host)?(s.host+':'+s.sid):s.sid;}
 function spOrdered(d){var ss=(d.sessions||[]).slice();if(SP.order!=='yours')return ss;
 var seed=(d.order||[]).map(function(p){return (p[0]&&p[0]!==d.host)?(p[0]+':'+p[1]):p[1];});
-var fin=spApplyViewOrder(seed,spViewOrder()),rank={};fin.forEach(function(id,i){rank[id]=i;});
+var fin=spApplyViewOrder(seed,spViewOrder()),rank=Object.create(null);fin.forEach(function(id,i){rank[id]=i;});
 var known=[],rest=[];ss.forEach(function(s){if(rank[spKey(d,s)]!==undefined)known.push(s);else rest.push(s);});
 known.sort(function(a,b){return rank[spKey(d,a)]-rank[spKey(d,b)];});return known.concat(rest);}
 // the chart's stacks follow the list, bottom to top = top row to bottom row
@@ -41007,7 +41011,7 @@ if(a==='close'){closeSpend();return;}
 if(a==='retry'){openSpend();return;}
 var m=/^(range|measure|order):(\\w+)$/.exec(a);if(!m)return;
 SP[m[1]]=m[2];spSavePrefs();
-if(m[1]==='order'){var tb=document.getElementById('rsp-table');if(tb)tb.innerHTML=sessionTable(SP.data);}
+if(m[1]==='order'){var tb=document.getElementById('rsp-table');if(tb){tb.innerHTML=sessionTable(SP.data);tb.scrollTop=0;}}   // the new order's head rows, not a mid-list slice (review find)
 var sib=b.parentNode.querySelectorAll('[data-act^="'+m[1]+':"]');
 for(var i=0;i<sib.length;i++){if(sib[i]===b)sib[i].classList.add('on');else sib[i].classList.remove('on');}
 renderChart();});
@@ -42986,9 +42990,9 @@ def _landing():
             # unattributed spend wears a TEXTURE, not a hue: it is not a session, and texture is the
             # dataviz fallback for a class that must never be confused with one
             ".rsp-hatch{background:repeating-linear-gradient(45deg,rgba(138,151,166,0.9) 0 1.5px,rgba(138,151,166,0.18) 1.5px 5px)}"
-            ".rsp-ctl{display:flex;align-items:center;gap:4px;margin:6px 0 8px}.rsp-gap{flex:0 0 12px}"
+            ".rsp-ctl{display:flex;flex-wrap:wrap;align-items:center;gap:4px;margin:6px 0 8px}.rsp-gap{flex:0 0 12px}"   # three chip pairs flow onto a second row on a phone, whole (review find)
             ".rsp-btn{background:none;border:1px solid rgba(255,255,255,0.14);border-radius:5px;color:#cfd6dd;font:inherit;"
-            "padding:2px 8px;cursor:pointer}"
+            "padding:2px 8px;cursor:pointer;white-space:nowrap}"
             ".rsp-btn.on{background:var(--accent,#9cd2ff);color:var(--accent-fg,#0c1a2e);border-color:transparent}"
             "#rsp-chart{position:relative}.rsp-svg{display:block;width:100%;background:rgba(255,255,255,0.04);border-radius:3px}"
             ".rsp-grid{stroke:rgba(255,255,255,0.10);stroke-width:1}"

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -32389,7 +32389,8 @@ def _spend_recorded_at():
         return None
 
 
-_DETAIL_TOP_N = 10       # stacks the histogram names; every further session folds into ONE "other" stack
+# (T247e, the user 2026-09-08: EVERY session is its own stack in its own color and its own row in a
+# scrolling list — no top-N, no "other" fold, no legend; the list below the chart is the legend)
 _DETAIL_DAYS = 90        # the day ledger's own depth (the recorder prunes to 90 days)
 _SPEND_GRAIN = 5e-5      # a bucket's dollars minus its sids' dollars below this is rounding, not spend: the recorder
 #                          rounds the bucket sum and each sid's sum to 6 places INDEPENDENTLY, so a fully attributed
@@ -32502,16 +32503,28 @@ def _spend_detail_local(now=None):
     except Exception:
         live = set()
     sessions = []
+    swatches = pal.colors(pal.active_name(jd.STATE))
     for sid, (u, t, n) in totals.items():
         bg, fg = _identity_of(sid)
+        derived = False
+        if not bg:
+            # a session the registry never colored (a legacy or tmux one) still needs a color of its
+            # own for its stack and its row (T247e): a deterministic swatch of the active palette, by
+            # sid, so it reads the same on every open; flagged so a client can tell it from an identity
+            import zlib
+            bg = swatches[zlib.crc32(str(sid).encode()) % len(swatches)] if swatches else ""
+            fg = pal.fg_for(bg) if bg else ""
+            derived = True
         row = {"sid": sid, "name": _name_of(sid) or "", "bg": bg, "fg": fg, "live": sid in live,
                "usd": round(u, 4), "tok": t, "turns": n}
+        if derived:
+            row["bgDerived"] = True
         if sid in keyt:
             k = keyt[sid]
             row["key"] = {"usd": round(k[0], 4), "tok": k[1], "turns": k[2]}
         sessions.append(row)
     sessions.sort(key=lambda s: (-s["usd"], -s["tok"], s["name"]))
-    top = [s["sid"] for s in sessions[:_DETAIL_TOP_N]]
+    top = [s["sid"] for s in sessions]          # every session (T247e): the list IS the legend
     meta = {s["sid"]: s for s in sessions}
 
     def _series(buckets, keys):
@@ -32574,7 +32587,7 @@ def _spend_detail_local(now=None):
     return {"host": _self_host(), "scope": scope,
             "tz": time.strftime("%Z", lt), "tzOffsetMin": int((getattr(lt, "tm_gmtoff", 0) or 0) // 60),
             "recordedAt": _spend_recorded_at(),
-            "topN": _DETAIL_TOP_N, "sessions": sessions,
+            "sessions": sessions,
             "unattributed": {"usd": round(un[0], 4), "tok": un[1], "turns": un[2]},
             "hours": hrs, "days": _series(days, day_keys)}
 
@@ -32693,8 +32706,7 @@ def _merge_spend_details(payloads, hosts, local):
                 row["host"] = host
                 sessions.append(row)
     sessions.sort(key=lambda s: (-float(s.get("usd") or 0), -int(s.get("tok") or 0), str(s.get("name") or "")))
-    top_n = int(local.get("topN") or _DETAIL_TOP_N)
-    top = [(s["host"], s["sid"]) for s in sessions[:top_n]]
+    top = [(s["host"], s["sid"]) for s in sessions]   # every session is a stack (T247e)
     top_set = set(top)
     meta = {(s["host"], s["sid"]): s for s in sessions}
     un = {"usd": 0.0, "tok": 0, "turns": 0, "byHost": {}}
@@ -32743,9 +32755,9 @@ def _merge_spend_details(payloads, hosts, local):
         n = len(keys)
         pos = {e: i for i, e in enumerate(epochs)} if name == "hours" else {k: i for i, k in enumerate(keys)}
         per = {}           # (host, sid) -> [usd[], tok[]]
-        other = ([0.0] * n, [0] * n)
-        other_count = 0    # "other (N sessions)" counts CONTRIBUTORS in this range only, like the local reader:
-        #                    each payload's own fold plus the top-N sessions of its own the merge folded
+        others = {}        # host -> ([usd], [tok], count): an OLDER peer's own "other" fold (its build still
+        #                    folds beyond a top-N); kept as that host's stack so its dollars are not lost, and
+        #                    named with the host — a current build folds nothing (T247e)
         una = ([0.0] * n, [0] * n)
         una_hosts = {}
         for host, p, rng, ax in peer_axes:
@@ -32757,15 +32769,13 @@ def _merge_spend_details(payloads, hosts, local):
                 kind = s.get("kind")
                 if kind == "sid":
                     key = (host, str(s.get("sid") or ""))
-                    if key in top_set:
-                        dst = per.setdefault(key, ([0.0] * n, [0] * n))
-                    else:
-                        dst = other
-                        if any(usd) or any(tok):
-                            other_count += 1
+                    if key not in top_set:
+                        continue          # a stack for a session the roster does not know: nothing to draw it as
+                    dst = per.setdefault(key, ([0.0] * n, [0] * n))
                 elif kind == "other":
-                    dst = other
-                    other_count += int(s.get("count") or 0)
+                    o = others.setdefault(host, ([0.0] * n, [0] * n, [0]))
+                    o[2][0] += int(s.get("count") or 0)
+                    dst = o
                 elif kind == "unattributed":
                     dst = una
                     hu = una_hosts.setdefault(host, ([0.0] * n, [0] * n))
@@ -32792,10 +32802,11 @@ def _merge_spend_details(payloads, hosts, local):
                 continue
             m = meta[key]
             stacks.append({"kind": "sid", "host": key[0], "sid": key[1], "name": m.get("name") or "", "bg": m.get("bg") or "",
-                           "live": bool(m.get("live")), "usd": u, "tok": arr[1]})
-        ou = [round(v, 4) for v in other[0]]
-        if any(ou) or any(other[1]):
-            stacks.append({"kind": "other", "name": "other", "count": other_count, "usd": ou, "tok": other[1]})
+                           "live": bool(m.get("live")), "bgDerived": bool(m.get("bgDerived")), "usd": u, "tok": arr[1]})
+        for oh, o in others.items():
+            ou = [round(v, 4) for v in o[0]]
+            if any(ou) or any(o[1]):
+                stacks.append({"kind": "other", "host": oh, "name": "other", "count": o[2][0], "usd": ou, "tok": o[1]})
         uu = [round(v, 4) for v in una[0]]
         if any(uu) or any(una[1]):
             stacks.append({"kind": "unattributed", "name": "unattributed", "usd": uu, "tok": una[1],
@@ -40902,7 +40913,7 @@ pullFleet().then(done,function(){if(ROWS.length)renderRows(ROWS,SELF);done();});
 // kernel-side, the ledger's bySid series — fetched on open behind the romp loader, never scraped from
 // the hover's HTML. The click still kicks the hover's own refresh (pull), so both levels are fresh.
 var spBack=document.getElementById('rsp-back'),spPanel=document.getElementById('rsp-panel'),spTip=null;
-var SP={data:null,err:'',range:'hours',measure:'usd',open:false,allRows:false};
+var SP={data:null,err:'',range:'hours',measure:'usd',open:false};
 var SP_OTHER='#4a5361',SP_NONE='#6b7a8c';   // "other" and a session with no identity color: neutrals, never a hue
 function spName(s){return s.name||('session '+String(s.sid||'').slice(0,8));}
 // T247c: when more than one machine contributes, a row or chip names its host the way a federated
@@ -40910,12 +40921,16 @@ function spName(s){return s.name||('session '+String(s.sid||'').slice(0,8));}
 function spHosts(d){return ((d&&d.hosts)||[]).filter(function(h){return h.status==='ok';});}
 function spMany(d){return spHosts(d).length>1;}
 function spLabel(s,many){return (many&&s.host?'<span class=host-prefix>'+esc(s.host)+':</span> ':'')+esc(spName(s));}
+// a session row reads like its TAB TITLE (T247e, the user 2026-09-08): the tab strip's own classes —
+// .tab-label with the identity color as --chip-bg (styles.css keys the color and weight on the SAME
+// rule the strip uses, so the two cannot drift) and the quiet .host-prefix — no swatch
+function spTitle(s,many){return '<span class="tab-label colored" style="--chip-bg:'+spColor(s)+'">'+(many&&s.host?'<span class=host-prefix>'+esc(s.host)+':</span>':'')+esc(spName(s))+'</span>';}
 function spColor(s){return (s.bg&&/^#[0-9a-fA-F]{3,8}$/.test(s.bg))?s.bg:SP_NONE;}
 function spHead(){var d=SP.data,ok=d?spHosts(d):[];return '<div class=rsp-top><span>'+(d&&d.scope==='computed'?'Spend (computed)':'API spend')
 +(ok.length>1?' \u00b7 '+ok.length+' machines':(d&&d.host?' \u00b7 '+esc(d.host):''))+'</span>'
 +'<button class=rsp-x data-act=close aria-label=Close>\u00d7</button></div>';}
 var spPending=null;   // the in-flight detail fetch's controller: a close or a re-open aborts it
-function openSpend(){if(!spBack||!spPanel)return;SP.open=true;spBack.hidden=false;SP.data=null;SP.err='';SP.allRows=false;
+function openSpend(){if(!spBack||!spPanel)return;SP.open=true;spBack.hidden=false;SP.data=null;SP.err='';
 spPanel.innerHTML=spHead()+'<div class=rsp-load>'+__ROMP_LOADER__+'</div>';   // the loader FIRST (the loader rule)
 // the loader ends on the EVENT (the answer) — with a backstop that cannot trap (T247b review: a hung
 // socket spun the loader forever): a generous timer aborts the fetch onto the error + retry path
@@ -40946,7 +40961,6 @@ while(t&&t!==spPanel){if(t.getAttribute&&t.getAttribute('data-act')){b=t;break;}
 if(!b)return;var a=b.getAttribute('data-act');
 if(a==='close'){closeSpend();return;}
 if(a==='retry'){openSpend();return;}
-if(a==='table:all'){SP.allRows=true;var tb=document.getElementById('rsp-table');if(tb)tb.innerHTML=sessionTable(SP.data);return;}
 var m=/^(range|measure):(\\w+)$/.exec(a);if(!m)return;
 SP[m[1]]=m[2];
 var sib=b.parentNode.querySelectorAll('[data-act^="'+m[1]+':"]');
@@ -40957,22 +40971,20 @@ if(!ss.length&&!(un&&(un.usd>0||un.tok>0)))return '<div class=rsp-note>No per-se
 // the key-billed split shows where the hover would show it: the TOTAL scope on a mixed host, where a
 // session's key dollars differ from its computed total
 var keyCol=d.scope!=='keyed'&&ss.some(function(s){return s.key&&typeof s.key.usd==='number'&&Math.round(s.key.usd)!==Math.round(s.usd);});
-var h='<table class=rsp-tbl><thead><tr><th></th><th>session</th><th class=n>dollars</th>'+(keyCol?'<th class=n>key-billed</th>':'')
+// EVERY session, in a pane that scrolls under a sticky header (T247e): the list is the chart's legend,
+// each row its tab title in its identity color; no fold, no swatch
+var h='<table class=rsp-tbl><thead><tr><th>session</th><th class=n>dollars</th>'+(keyCol?'<th class=n>key-billed</th>':'')
 +'<th class=n>turns</th><th class=n>tokens</th></tr></thead><tbody>';
-// the table folds to the histogram's own top-N (progressive disclosure: the chart stays in view under
-// a long roster); one click shows every session
-var lim=(SP.allRows||ss.length<=(d.topN||10)+2)?ss.length:(d.topN||10),shown=ss.slice(0,lim),many=spMany(d);
-shown.forEach(function(s){h+='<tr'+(s.live?'':' class=rsp-dead')+'><td><i class=rsp-sw style="background:'+spColor(s)+'"></i></td>'
-+'<td class=rsp-name>'+spLabel(s,many)+(s.live?'':'<span class=ru-tip-reset> \u00b7 not running</span>')+'</td>'
+var many=spMany(d);
+ss.forEach(function(s){h+='<tr'+(s.live?'':' class=rsp-dead')+'>'
++'<td class=rsp-name>'+spTitle(s,many)+(s.live?'':'<span class=ru-tip-reset> \u00b7 not running</span>')+'</td>'
 +'<td class=n>'+fmtUsd(s.usd)+'</td>'+(keyCol?'<td class=n>'+(s.key?fmtUsd(s.key.usd):'\u2014')+'</td>':'')
 +'<td class=n>'+(s.turns||0)+'</td><td class=n>'+fmtTok(s.tok||0)+'</td></tr>';});
-if(lim<ss.length){var rest=ss.slice(lim),ru=0,rt=0,rn=0;rest.forEach(function(s){ru+=s.usd||0;rt+=s.tok||0;rn+=s.turns||0;});
-h+='<tr class=rsp-fold><td><i class=rsp-sw style="background:'+SP_OTHER+'"></i></td><td class=rsp-name><span class=rsp-muted>'+rest.length+' more session'+(rest.length===1?'':'s')
-+'</span> <button class=rsp-btn data-act=table:all>show all</button></td><td class=n>'+fmtUsd(ru)+'</td>'+(keyCol?'<td class=n></td>':'')+'<td class=n>'+rn+'</td><td class=n>'+fmtTok(rt)+'</td></tr>';}
 // spend recorded before per-session attribution existed (T100, 2026-08-24), or the part of a bucket no
-// session accounts for: shown as its own row, never dropped or folded into a session (fail loudly)
-if(un&&(un.usd>0||un.tok>0))h+='<tr class=rsp-dead><td><i class="rsp-sw rsp-hatch"></i></td>'
-+'<td class=rsp-name>unattributed<span class=ru-tip-reset> \u00b7 recorded before per-session tracking</span></td>'
+// session accounts for: shown as its own row, never dropped or folded into a session (fail loudly);
+// its hatch mark is the chart's hatched stack, not a session swatch
+if(un&&(un.usd>0||un.tok>0))h+='<tr class=rsp-dead>'
++'<td class=rsp-name><i class="rsp-sw rsp-hatch"></i> unattributed<span class=ru-tip-reset> \u00b7 recorded before per-session tracking</span></td>'
 +'<td class=n>'+fmtUsd(un.usd)+'</td>'+(keyCol?'<td class=n>\u2014</td>':'')+'<td class=n>'+(un.turns||0)+'</td><td class=n>'+fmtTok(un.tok||0)+'</td></tr>';
 return h+'</tbody></table>';}
 // 1. the SAME window numbers the hover shows — the sums across every machine, rows only (one renderer).
@@ -40989,7 +41001,17 @@ if(!d){h+='<div class=rsp-err>Couldn\u2019t load the spend detail'+(SP.err?': '+
 +'<button class=rsp-btn data-act=retry>Try again</button></div>';spPanel.innerHTML=h;return;}
 var computed=d.scope==='computed';
 h+='<div class=rsp-sec id=rsp-totals>'+totalsHTML(d)+'</div>';
-// 2. per session — EVERY attached kernel's sessions (T247c), each machine's own story merged here;
+// 2. the histogram FIRST (T247e, the user 2026-09-08): the two ranges the ledger itself holds; dollars
+// by default, tokens on a toggle; the session list below is its legend
+h+='<div class=rsp-sec><div class=ru-tip-name><span>Spend over time</span></div>'
++'<div class=rsp-ctl>'
++'<button class="rsp-btn'+(SP.range==='hours'?' on':'')+'" data-act=range:hours>8 days \u00b7 by hour</button>'
++'<button class="rsp-btn'+(SP.range==='days'?' on':'')+'" data-act=range:days>90 days \u00b7 by day</button>'
++'<span class=rsp-gap></span>'
++'<button class="rsp-btn'+(SP.measure==='usd'?' on':'')+'" data-act=measure:usd>dollars</button>'
++'<button class="rsp-btn'+(SP.measure==='tok'?' on':'')+'" data-act=measure:tok>tokens</button>'
++'</div><div id=rsp-chart></div></div>';
+// 3. per session — EVERY attached kernel's sessions (T247c), each machine's own story merged here;
 // the billing rule is named when every contributing machine shares one, else each keeps its own
 var ok=spHosts(d),many=ok.length>1;
 var scopes={};ok.forEach(function(x){scopes[x.scope||d.scope]=1;});var sk=Object.keys(scopes);
@@ -41000,20 +41022,11 @@ h+='<div class=rsp-sec><div class=ru-tip-name><span>By session'+(many?' \u00b7 '
 ((d.hosts)||[]).forEach(function(x){if(x.status==='ok')return;
 h+='<div class=rsp-note>'+esc(x.host)+': '+(x.status==='older'?'older build, no per-session data':'not reachable')+(x.detail?' \u2014 '+esc(x.detail):'')+'</div>';});
 h+='<div id=rsp-table>'+sessionTable(d)+'</div></div>';
-// 3. the histogram — the two ranges the ledger itself holds; dollars by default, tokens on a toggle
-h+='<div class=rsp-sec><div class=ru-tip-name><span>Spend over time</span></div>'
-+'<div class=rsp-ctl>'
-+'<button class="rsp-btn'+(SP.range==='hours'?' on':'')+'" data-act=range:hours>8 days \u00b7 by hour</button>'
-+'<button class="rsp-btn'+(SP.range==='days'?' on':'')+'" data-act=range:days>90 days \u00b7 by day</button>'
-+'<span class=rsp-gap></span>'
-+'<button class="rsp-btn'+(SP.measure==='usd'?' on':'')+'" data-act=measure:usd>dollars</button>'
-+'<button class="rsp-btn'+(SP.measure==='tok'?' on':'')+'" data-act=measure:tok>tokens</button>'
-+'</div><div id=rsp-chart></div></div>';
 spPanel.innerHTML=h;renderChart();}
 // 1-2-5 ceilings: the y-axis top is the nearest clean number above the tallest bucket
 function niceTop(mx){if(!(mx>0))return 1;var p=Math.pow(10,Math.floor(Math.log(mx)/Math.LN10)),f=mx/p;return (f<=1?1:f<=2?2:f<=5?5:10)*p;}
 function spFill(s){return s.kind==='unattributed'?'url(#rsp-hatch)':s.kind==='other'?SP_OTHER:spColor(s);}
-function spStackName(s){return s.kind==='other'?('other ('+(s.count||0)+' session'+(s.count===1?'':'s')+')'):s.kind==='unattributed'?'unattributed':spName(s);}
+function spStackName(s){return s.kind==='other'?('other ('+(s.count||0)+' session'+(s.count===1?'':'s')+(s.host?' on '+s.host:'')+')'):s.kind==='unattributed'?'unattributed':spName(s);}
 // the plain-text form for the tooltip: host · name when more than one machine contributes; the
 // unattributed stack names each machine's share of the hovered bucket
 function spStackText(s,many,meas,i){if(s.kind==='sid')return (many&&s.host?s.host+' \u00b7 ':'')+spName(s);
@@ -41075,14 +41088,13 @@ if(SP.range==='hours'){m=/^(\\d{4})-(\\d\\d)-(\\d\\d)T00$/.exec(k);if(m){var dd=
 xlab+='<span style="left:'+(((i+0.5)*slot)/W*100).toFixed(1)+'%">'+['S','M','T','W','T','F','S'][dd.getDay()]+'</span>';}}
 else{m=/^(\\d{4})-(\\d\\d)-(01|15)$/.exec(k);if(m)xlab+='<span style="left:'+(((i+0.5)*slot)/W*100).toFixed(1)+'%">'+Number(m[2])+'/'+Number(m[3])+'</span>';}}
 var many=spMany(d);
-var leg='<div class=rsp-leg>'+stacks.map(function(s){return '<span class="rsp-chip'+((s.kind==='sid'&&!s.live)||s.kind==='unattributed'?' rsp-dead':'')+'"><i class="rsp-sw'+(s.kind==='unattributed'?' rsp-hatch':'')+'"'
-+(s.kind==='unattributed'?'':' style="background:'+(s.kind==='other'?SP_OTHER:spColor(s))+'"')+'></i>'+(s.kind==='sid'?spLabel(s,many):esc(spStackName(s)))+'</span>';}).join('')+'</div>';
+// no legend (T247e): the session list under the chart is the legend, each row in its stack's color
 var tzNote='';var mine=-(new Date().getTimezoneOffset());
 if(typeof d.tzOffsetMin==='number'&&d.tzOffsetMin!==mine)tzNote+='<div class=rsp-note>Bucket times are '+esc(d.tz||'the kernel\u2019s clock')+' (the machine that recorded them), not your local time.</div>';
 // machines in different zones (T247c): the rule is stated, not left to be guessed
 var offs={};spHosts(d).forEach(function(x){offs[String(x.tzOffsetMin)]=1;});
 if(Object.keys(offs).length>1)tzNote+='<div class=rsp-note>Hourly buckets are aligned by clock time across machines; daily buckets follow each machine\u2019s own calendar day.</div>';
-box.innerHTML=svg+ylab+'<div class=ru-tip-gx>'+xlab+'</div>'+leg+tzNote;
+box.innerHTML=svg+ylab+'<div class=ru-tip-gx>'+xlab+'</div>'+tzNote;
 // the per-segment hover: session · value · bucket, the mark itself the hit target
 var svgEl=box.querySelector('svg');if(!svgEl)return;
 svgEl.onpointermove=function(e){var t=e.target;if(!t||!t.classList||!t.classList.contains('rsp-seg')){spTipHide();return;}
@@ -42892,7 +42904,20 @@ def _landing():
             ".rsp-note{opacity:.6;font-size:10px;margin:4px 0 6px}"
             ".rsp-err{color:#f2b8b5;margin:10px 0}"
             ".rsp-load{display:flex;justify-content:center;padding:40px 0}"
-            ".rsp-tbl{width:100%;border-collapse:collapse;margin-top:4px}"
+            # the session list is a SCROLL PANE under a sticky header (T247e): every session, the modal a
+            # centered card that keeps its size; the pane scrolls inside it
+            "#rsp-table{max-height:38vh;overflow-y:auto;margin-top:4px}"
+            ".rsp-tbl{width:100%;border-collapse:collapse}"
+            ".rsp-tbl thead th{position:sticky;top:0;background:#252526;z-index:1}"
+            # a row's title is its TAB TITLE, under the strip's own class names. The landing page loads no
+            # stylesheet (the panes do), so the two declarations are INLINED here as the strip's twin —
+            # `.tab.colored .tab-label` and `.host-prefix` from ui/webview/styles.css, byte for byte in
+            # their declarations — and tests/test_spend_detail.py pins the twin against the source, so the
+            # two cannot drift (the timeline's MENU_STYLE twin is the precedent). --dim is the strip's
+            # variable; a fallback carries the dark value where the landing defines none.
+            ".rsp-name .tab-label{font-size:inherit;line-height:inherit}"
+            ".rsp-name .tab-label.colored{color:var(--chip-bg);font-weight:600}"
+            ".rsp-name .host-prefix{color:var(--dim,#9aa0a6);font-weight:400;font-style:italic;font-size:0.86em}"
             ".rsp-tbl th{text-align:left;font-weight:400;opacity:.55;padding:2px 6px 4px 0;border-bottom:1px solid rgba(255,255,255,0.08)}"
             ".rsp-tbl td{padding:3px 6px 3px 0;border-bottom:1px solid rgba(255,255,255,0.05);white-space:nowrap}"
             ".rsp-tbl .n{text-align:right;font-variant-numeric:tabular-nums}"
@@ -42901,8 +42926,7 @@ def _landing():
             # cells carry the dimming, the annotation inside stays at the row's level (it used to compound
             # .55 × .6 to a 2.3:1 read), and a legend chip dims on its own; the fold row is a CONTROL row —
             # its count is muted, its "show all" is never dimmed (it read as disabled)
-            ".rsp-dead td{opacity:.55}.rsp-dead .ru-tip-reset{opacity:1}.rsp-chip.rsp-dead{opacity:.55}"
-            ".rsp-fold .rsp-muted{opacity:.55}"
+            ".rsp-dead td{opacity:.55}.rsp-dead .ru-tip-reset{opacity:1}"
             ".rsp-sw{display:inline-block;width:10px;height:10px;border-radius:3px;vertical-align:-1px;background:#6b7a8c}"
             # unattributed spend wears a TEXTURE, not a hue: it is not a session, and texture is the
             # dataviz fallback for a class that must never be confused with one
@@ -42914,7 +42938,6 @@ def _landing():
             "#rsp-chart{position:relative}.rsp-svg{display:block;width:100%;background:rgba(255,255,255,0.04);border-radius:3px}"
             ".rsp-grid{stroke:rgba(255,255,255,0.10);stroke-width:1}"
             ".rsp-seg{cursor:pointer}.rsp-seg:hover{filter:brightness(1.18)}"
-            ".rsp-leg{display:flex;flex-wrap:wrap;gap:4px 12px;margin-top:6px}.rsp-chip{display:inline-flex;align-items:center;gap:5px}"
             "#rsp-tip{position:fixed;z-index:310;pointer-events:none;display:none;background:#1e1e1e;border:1px solid #3a3a3a;"
             "border-radius:6px;padding:5px 8px;color:#cfd6dd;font:500 11px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;"
             "box-shadow:0 5px 18px rgba(0,0,0,0.45)}#rsp-tip b{color:#e8eef5;font-weight:700}"
@@ -43216,6 +43239,8 @@ def _landing():
             "body.theme-light .rsp-top{color:#1F1E1D;border-bottom-color:rgba(0,0,0,0.10)}"
             "body.theme-light .rsp-x{color:#5D574E}body.theme-light .rsp-x:hover{color:#1F1E1D}"
             "body.theme-light .rsp-tbl th{border-bottom-color:rgba(0,0,0,0.10)}body.theme-light .rsp-tbl td{border-bottom-color:rgba(0,0,0,0.06)}"
+            "body.theme-light .rsp-tbl thead th{background:#FFFFFF}"
+            "body.theme-light .rsp-name .host-prefix{color:var(--dim,#5D574E)}"
             "body.theme-light .rsp-btn{border-color:rgba(0,0,0,0.18);color:#1F1E1D}"
             # the PRESSED toggle's light step, written out (T247b review): `.rsp-btn.on` (0,2,0) lost to
             # `body.theme-light .rsp-btn` (0,2,1 — two classes and the body type) and painted dark text

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -32503,27 +32503,35 @@ def _spend_detail_local(now=None):
     except Exception:
         live = set()
     sessions = []
-    swatches = pal.colors(pal.active_name(jd.STATE))
     for sid, (u, t, n) in totals.items():
         bg, fg = _identity_of(sid)
-        derived = False
-        if not bg:
-            # a session the registry never colored (a legacy or tmux one) still needs a color of its
-            # own for its stack and its row (T247e): a deterministic swatch of the active palette, by
-            # sid, so it reads the same on every open; flagged so a client can tell it from an identity
-            import zlib
-            bg = swatches[zlib.crc32(str(sid).encode()) % len(swatches)] if swatches else ""
-            fg = pal.fg_for(bg) if bg else ""
-            derived = True
         row = {"sid": sid, "name": _name_of(sid) or "", "bg": bg, "fg": fg, "live": sid in live,
                "usd": round(u, 4), "tok": t, "turns": n}
-        if derived:
-            row["bgDerived"] = True
         if sid in keyt:
             k = keyt[sid]
             row["key"] = {"usd": round(k[0], 4), "tok": k[1], "turns": k[2]}
         sessions.append(row)
     sessions.sort(key=lambda s: (-s["usd"], -s["tok"], s["name"]))
+    # a session the registry never colored (a legacy or tmux one) still needs a color of its own for its
+    # stack and its row (T247e): a swatch of the active palette — the LEAST-USED one across this payload,
+    # so it never wears a color an identity-colored session here already has while a free one remains
+    # (the kernel's own picker's rule; review find: a plain hash gave a dead session web's blue), ties
+    # broken by the sid's hash so the pick is the same on every open; flagged so a client can tell it
+    import zlib
+    swatches = pal.colors(pal.active_name(jd.STATE))
+    used = {}
+    for s in sessions:
+        if s["bg"]:
+            used[s["bg"]] = used.get(s["bg"], 0) + 1
+    for s in sessions:
+        if s["bg"] or not swatches:
+            continue
+        h = zlib.crc32(str(s["sid"]).encode()) % len(swatches)
+        ranked = sorted(range(len(swatches)), key=lambda i: (used.get(swatches[i], 0), (i - h) % len(swatches)))
+        s["bg"] = swatches[ranked[0]]
+        s["fg"] = pal.fg_for(s["bg"])
+        s["bgDerived"] = True
+        used[s["bg"]] = used.get(s["bg"], 0) + 1
     top = [s["sid"] for s in sessions]          # every session (T247e): the list IS the legend
     meta = {s["sid"]: s for s in sessions}
 
@@ -32807,7 +32815,7 @@ def _merge_spend_details(payloads, hosts, local):
                 continue
             m = meta[key]
             stacks.append({"kind": "sid", "host": key[0], "sid": key[1], "name": m.get("name") or "", "bg": m.get("bg") or "",
-                           "live": bool(m.get("live")), "bgDerived": bool(m.get("bgDerived")), "usd": u, "tok": arr[1]})
+                           "live": bool(m.get("live")), "usd": u, "tok": arr[1]})
         for oh, o in others.items():
             ou = [round(v, 4) for v in o[0]]
             if any(ou) or any(o[1]):
@@ -40957,7 +40965,6 @@ function spName(s){return s.name||('session '+String(s.sid||'').slice(0,8));}
 // session's tab does — the shared .host-prefix treatment (quiet, italic, a step smaller)
 function spHosts(d){return ((d&&d.hosts)||[]).filter(function(h){return h.status==='ok';});}
 function spMany(d){return spHosts(d).length>1;}
-function spLabel(s,many){return (many&&s.host?'<span class=host-prefix>'+esc(s.host)+':</span> ':'')+esc(spName(s));}
 // a session row reads like its TAB TITLE (T247e, the user 2026-09-08): the tab strip's own classes —
 // .tab-label with the identity color as --chip-bg (styles.css keys the color and weight on the SAME
 // rule the strip uses, so the two cannot drift) and the quiet .host-prefix — no swatch
@@ -41063,7 +41070,14 @@ h+='<div class=rsp-sec><div class=ru-tip-name><span>By session'+(many?' \u00b7 '
 ((d.hosts)||[]).forEach(function(x){if(x.status==='ok')return;
 h+='<div class=rsp-note>'+esc(x.host)+': '+(x.status==='older'?'older build, no per-session data':'not reachable')+(x.detail?' \u2014 '+esc(x.detail):'')+'</div>';});
 h+='<div id=rsp-table>'+sessionTable(d)+'</div></div>';
-spPanel.innerHTML=h;renderChart();}
+spPanel.innerHTML=h;renderChart();spSizePane();}
+// the list pane takes exactly the room left under the chart (review find: a fixed 38vh cap left the card
+// itself scrolling at common viewport heights, a scroll region inside a scroll region); a floor keeps a
+// few rows visible on a very short screen, where the card then scrolls as the last resort
+function spSizePane(){var pane=document.getElementById('rsp-table');if(!pane||!spPanel)return;
+var cap=Math.floor(window.innerHeight*0.92),cs=getComputedStyle(spPanel),pad=parseFloat(cs.paddingTop)+parseFloat(cs.paddingBottom)+2;
+var above=pane.offsetTop-spPanel.offsetTop-spPanel.clientTop;   // everything rendered above the pane, inside the card
+var room=cap-pad-above-8;pane.style.maxHeight=Math.max(120,room)+'px';}
 // 1-2-5 ceilings: the y-axis top is the nearest clean number above the tallest bucket
 function niceTop(mx){if(!(mx>0))return 1;var p=Math.pow(10,Math.floor(Math.log(mx)/Math.LN10)),f=mx/p;return (f<=1?1:f<=2?2:f<=5?5:10)*p;}
 function spFill(s){return s.kind==='unattributed'?'url(#rsp-hatch)':s.kind==='other'?SP_OTHER:spColor(s);}
@@ -41094,7 +41108,7 @@ var tots=[],mx=0;for(var i=0;i<n;i++){var t=0;for(var s=0;s<stacks.length;s++){t
 if(!(mx>0)){box.innerHTML='<div class=rsp-note>Nothing recorded in this range.</div>';return;}
 var top=niceTop(mx),slot=W/n,gap=Math.min(2,slot*0.3),bw=Math.max(1,slot-gap),PADT=6;
 var Y=function(v){return H-Math.max(0,Math.min(1,v/top))*(H-PADT);};
-var fmt=function(v){return meas==='usd'?fmtUsd(v):fmtTok(Math.round(v));};
+var fmt=function(v){return meas==='usd'?(v>0&&v<0.5?'under $1':fmtUsd(v)):fmtTok(Math.round(v));};   // whole dollars, and a sliver says so rather than "$0"
 // axis labels wear whole dollars like every spend surface (no cents anywhere, the user 2026-08-09);
 // a half-line whose value is not a whole dollar (a $5 ceiling's $2.50) stays an unlabeled hairline
 // rather than rounding into a twin of another label
@@ -41109,8 +41123,8 @@ var svg='<svg class="rsp-svg" viewBox="0 0 '+W+' '+H+'" width="'+W+'" height="'+
 var ylab='';[top,top/2].forEach(function(g){var gy=Y(g);
 svg+='<line x1="0" y1="'+gy.toFixed(1)+'" x2="'+W+'" y2="'+gy.toFixed(1)+'" class="rsp-grid"></line>';
 var al=afmt(g);if(al)ylab+='<span class=ru-tip-gy style="top:'+(gy+1).toFixed(0)+'px">'+al+'</span>';});
-// one column per bucket, stacked bottom-up in stack order (top-N by dollars, then other, then
-// unattributed); a 2px surface gap between touching segments; the topmost segment's top corners
+// one column per bucket, stacked bottom-up in stack order (the session list's order — by dollars, or
+// the viewer's own — then unattributed); a 2px surface gap between touching segments; the topmost segment's top corners
 // rounded (4px data-end, square at the baseline) — the dataviz mark specs
 for(var i=0;i<n;i++){if(!(tots[i]>0))continue;var x=i*slot+gap/2,segs=[];
 for(var s=0;s<stacks.length;s++){var v=(stacks[s][meas]&&stacks[s][meas][i])||0;if(v>0)segs.push([s,v]);}
@@ -41143,7 +41157,9 @@ var i=+t.getAttribute('data-i'),si=+t.getAttribute('data-s'),s=stacks[si];if(!s)
 var v=(s[meas]&&s[meas][i])||0,o=(s[meas==='usd'?'tok':'usd']&&s[meas==='usd'?'tok':'usd'][i])||0;
 spTipShow(e.clientX,e.clientY,spStackText(s,many,meas,i),fmt(v),(meas==='usd'?fmtTok(Math.round(o))+' tok':fmtUsd(o))+' \u00b7 '+spBucketLabel(ser.keys[i],SP.range));};
 svgEl.onpointerleave=spTipHide;}
-window.addEventListener('resize',function(){if(SP.open&&SP.data)renderChart();});
+var spResizeRaf=0;
+window.addEventListener('resize',function(){if(!(SP.open&&SP.data)||spResizeRaf)return;
+spResizeRaf=requestAnimationFrame(function(){spResizeRaf=0;if(SP.open&&SP.data){renderChart();spSizePane();}});});
 el.addEventListener('click',function(){pull(true);openSpend();});
 setInterval(function(){pull(false);},60000);     // backup auto-refresh: re-read usage.json every 60s
 pull(false);                                     // fill on load, independent of the timeline-forward path
@@ -42947,7 +42963,7 @@ def _landing():
             ".rsp-load{display:flex;justify-content:center;padding:40px 0}"
             # the session list is a SCROLL PANE under a sticky header (T247e): every session, the modal a
             # centered card that keeps its size; the pane scrolls inside it
-            "#rsp-table{max-height:38vh;overflow-y:auto;margin-top:4px}"
+            "#rsp-table{max-height:38vh;overflow-y:auto;margin-top:4px}"   # the JS (spSizePane) refits it to the room under the chart
             ".rsp-tbl{width:100%;border-collapse:collapse}"
             ".rsp-tbl thead th{position:sticky;top:0;background:#252526;z-index:1}"
             # a row's title is its TAB TITLE, under the strip's own class names. The landing page loads no
@@ -42956,17 +42972,15 @@ def _landing():
             # their declarations — and tests/test_spend_detail.py pins the twin against the source, so the
             # two cannot drift (the timeline's MENU_STYLE twin is the precedent). --dim is the strip's
             # variable; a fallback carries the dark value where the landing defines none.
-            ".rsp-name .tab-label{font-size:inherit;line-height:inherit}"
             ".rsp-name .tab-label.colored{color:var(--chip-bg);font-weight:600}"
             ".rsp-name .host-prefix{color:var(--dim,#9aa0a6);font-weight:400;font-style:italic;font-size:0.86em}"
-            ".rsp-tbl th{text-align:left;font-weight:400;opacity:.55;padding:2px 6px 4px 0;border-bottom:1px solid rgba(255,255,255,0.08)}"
+            ".rsp-tbl th{text-align:left;font-weight:400;color:#8a97a6;padding:2px 6px 4px 0;border-bottom:1px solid rgba(255,255,255,0.08)}"   # muted by color, not opacity: the sticky header must occlude the rows scrolling under it (review find)
             ".rsp-tbl td{padding:3px 6px 3px 0;border-bottom:1px solid rgba(255,255,255,0.05);white-space:nowrap}"
             ".rsp-tbl .n{text-align:right;font-variant-numeric:tabular-nums}"
             ".rsp-tbl td.rsp-name{width:100%;max-width:0;overflow:hidden;text-overflow:ellipsis}"
             # a session no longer running keeps its last known name, dimmed ONCE (T247b review): the row's
             # cells carry the dimming, the annotation inside stays at the row's level (it used to compound
-            # .55 × .6 to a 2.3:1 read), and a legend chip dims on its own; the fold row is a CONTROL row —
-            # its count is muted, its "show all" is never dimmed (it read as disabled)
+            # .55 × .6 to a 2.3:1 read)
             ".rsp-dead td{opacity:.55}.rsp-dead .ru-tip-reset{opacity:1}"
             ".rsp-sw{display:inline-block;width:10px;height:10px;border-radius:3px;vertical-align:-1px;background:#6b7a8c}"
             # unattributed spend wears a TEXTURE, not a hue: it is not a session, and texture is the
@@ -43280,7 +43294,7 @@ def _landing():
             "body.theme-light .rsp-top{color:#1F1E1D;border-bottom-color:rgba(0,0,0,0.10)}"
             "body.theme-light .rsp-x{color:#5D574E}body.theme-light .rsp-x:hover{color:#1F1E1D}"
             "body.theme-light .rsp-tbl th{border-bottom-color:rgba(0,0,0,0.10)}body.theme-light .rsp-tbl td{border-bottom-color:rgba(0,0,0,0.06)}"
-            "body.theme-light .rsp-tbl thead th{background:#FFFFFF}"
+            "body.theme-light .rsp-tbl thead th{background:#FFFFFF}body.theme-light .rsp-tbl th{color:#5D574E}"
             "body.theme-light .rsp-name .host-prefix{color:var(--dim,#5D574E)}"
             "body.theme-light .rsp-btn{border-color:rgba(0,0,0,0.18);color:#1F1E1D}"
             # the PRESSED toggle's light step, written out (T247b review): `.rsp-btn.on` (0,2,0) lost to

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -32588,6 +32588,10 @@ def _spend_detail_local(now=None):
             "tz": time.strftime("%Z", lt), "tzOffsetMin": int((getattr(lt, "tm_gmtoff", 0) or 0) // 60),
             "recordedAt": _spend_recorded_at(),
             "sessions": sessions,
+            # the shared session order (session-order.json — what a tab drag or a lane drag writes): the
+            # modal's "your order" seed (T247f); the viewer's own arrangement is applied client-side, the
+            # way the strip and the lanes apply it (view-order.ts)
+            "order": _session_order(),
             "unattributed": {"usd": round(un[0], 4), "tok": un[1], "turns": un[2]},
             "hours": hrs, "days": _series(days, day_keys)}
 
@@ -32685,6 +32689,7 @@ def _spend_detail(now=None):
     if len(payloads) == 1:
         out = dict(local)
         out["hosts"] = hosts
+        out["order"] = [[me, s] for s in (local.get("order") or []) if isinstance(s, str)]
         return out
     return _merge_spend_details(payloads, hosts, local)
 
@@ -32816,8 +32821,16 @@ def _merge_spend_details(payloads, hosts, local):
             out["epochs"] = epochs
         return out
 
+    # the seed for "your order" (T247f): each host's own shared order, hosts local-first then in the
+    # remotes listing's order — the dashboard's host sequence (federation's hostSeq: local, then attach
+    # order); an older peer that ships no order contributes nothing and its sessions trail
+    order = []
+    for host, p in payloads:
+        for sid in (p.get("order") or []):
+            if isinstance(sid, str):
+                order.append([host, sid])
     out = dict(local)
-    out.update({"hosts": hosts, "sessions": sessions, "unattributed": un,
+    out.update({"hosts": hosts, "sessions": sessions, "unattributed": un, "order": order,
                 "hours": _merge_range("hours"), "days": _merge_range("days")})
     return out
 
@@ -40913,7 +40926,31 @@ pullFleet().then(done,function(){if(ROWS.length)renderRows(ROWS,SELF);done();});
 // kernel-side, the ledger's bySid series — fetched on open behind the romp loader, never scraped from
 // the hover's HTML. The click still kicks the hover's own refresh (pull), so both levels are fresh.
 var spBack=document.getElementById('rsp-back'),spPanel=document.getElementById('rsp-panel'),spTip=null;
-var SP={data:null,err:'',range:'hours',measure:'usd',open:false};
+var SP={data:null,err:'',range:'hours',measure:'usd',order:'spend',open:false};
+// the toggles persist across opens and reloads (T247f): range, measure, and the list's order
+var SP_PREFS_KEY='romp:spendModal';
+function spLoadPrefs(){try{var p=JSON.parse(localStorage.getItem(SP_PREFS_KEY)||'{}')||{};if(p.range==='days')SP.range='days';if(p.measure==='tok')SP.measure='tok';if(p.order==='yours')SP.order='yours';}catch(e){}}
+function spSavePrefs(){try{localStorage.setItem(SP_PREFS_KEY,JSON.stringify({range:SP.range,measure:SP.measure,order:SP.order}));}catch(e){}}
+spLoadPrefs();
+// "your order" (T247f, the user 2026-09-08): the order the tab strip and the timeline lanes show — the
+// kernel's shared seed per host (session-order.json; hosts local-first then attach order, remote ids
+// host-prefixed the way federation prefixes them) arranged by THIS viewer's own drag order, read from
+// the same localStorage key the strip reads (view-order.ts VIEW_ORDER_KEY). spApplyViewOrder is that
+// module's applyViewOrder, twinned here because the landing page loads no webview bundle; a node test
+// (ui/webview/spend-order-twin.test.ts) holds the two together. Sessions the order does not know (dead,
+// archived, an older peer's) trail in their spend order.
+function spApplyViewOrder(seed,view){var clean=function(xs){var out=[],seen={};(xs||[]).forEach(function(x){if(typeof x==='string'&&!seen[x]){seen[x]=1;out.push(x);}});return out;};var s=clean(seed);if(!view||!view.length)return s;var want={},placed={},out=[];s.forEach(function(x){want[x]=1;});clean(view).forEach(function(id){if(want[id]){placed[id]=1;out.push(id);}});s.forEach(function(id){if(!placed[id])out.push(id);});return out;}
+function spViewOrder(){try{var o=JSON.parse(localStorage.getItem('romp:vieworder')||'[]');return Array.isArray(o)?o:[];}catch(e){return [];}}
+function spKey(d,s){return (s.host&&s.host!==d.host)?(s.host+':'+s.sid):s.sid;}
+function spOrdered(d){var ss=(d.sessions||[]).slice();if(SP.order!=='yours')return ss;
+var seed=(d.order||[]).map(function(p){return (p[0]&&p[0]!==d.host)?(p[0]+':'+p[1]):p[1];});
+var fin=spApplyViewOrder(seed,spViewOrder()),rank={};fin.forEach(function(id,i){rank[id]=i;});
+var known=[],rest=[];ss.forEach(function(s){if(rank[spKey(d,s)]!==undefined)known.push(s);else rest.push(s);});
+known.sort(function(a,b){return rank[spKey(d,a)]-rank[spKey(d,b)];});return known.concat(rest);}
+// the chart's stacks follow the list, bottom to top = top row to bottom row
+function spStackOrder(d,stacks){if(SP.order!=='yours')return stacks;var rank={};spOrdered(d).forEach(function(s,i){rank[String(s.host)+'\t'+s.sid]=i;});
+var sids=stacks.filter(function(s){return s.kind==='sid';}),rest=stacks.filter(function(s){return s.kind!=='sid';});
+sids.sort(function(a,b){return (rank[String(a.host)+'\t'+a.sid]||0)-(rank[String(b.host)+'\t'+b.sid]||0);});return sids.concat(rest);}
 var SP_OTHER='#4a5361',SP_NONE='#6b7a8c';   // "other" and a session with no identity color: neutrals, never a hue
 function spName(s){return s.name||('session '+String(s.sid||'').slice(0,8));}
 // T247c: when more than one machine contributes, a row or chip names its host the way a federated
@@ -40961,8 +40998,9 @@ while(t&&t!==spPanel){if(t.getAttribute&&t.getAttribute('data-act')){b=t;break;}
 if(!b)return;var a=b.getAttribute('data-act');
 if(a==='close'){closeSpend();return;}
 if(a==='retry'){openSpend();return;}
-var m=/^(range|measure):(\\w+)$/.exec(a);if(!m)return;
-SP[m[1]]=m[2];
+var m=/^(range|measure|order):(\\w+)$/.exec(a);if(!m)return;
+SP[m[1]]=m[2];spSavePrefs();
+if(m[1]==='order'){var tb=document.getElementById('rsp-table');if(tb)tb.innerHTML=sessionTable(SP.data);}
 var sib=b.parentNode.querySelectorAll('[data-act^="'+m[1]+':"]');
 for(var i=0;i<sib.length;i++){if(sib[i]===b)sib[i].classList.add('on');else sib[i].classList.remove('on');}
 renderChart();});
@@ -40976,7 +41014,7 @@ var keyCol=d.scope!=='keyed'&&ss.some(function(s){return s.key&&typeof s.key.usd
 var h='<table class=rsp-tbl><thead><tr><th>session</th><th class=n>dollars</th>'+(keyCol?'<th class=n>key-billed</th>':'')
 +'<th class=n>turns</th><th class=n>tokens</th></tr></thead><tbody>';
 var many=spMany(d);
-ss.forEach(function(s){h+='<tr'+(s.live?'':' class=rsp-dead')+'>'
+spOrdered(d).forEach(function(s){h+='<tr data-sid="'+esc(s.sid||'')+'"'+(s.live?' class=rsp-live':' class=rsp-dead')+'>'
 +'<td class=rsp-name>'+spTitle(s,many)+(s.live?'':'<span class=ru-tip-reset> \u00b7 not running</span>')+'</td>'
 +'<td class=n>'+fmtUsd(s.usd)+'</td>'+(keyCol?'<td class=n>'+(s.key?fmtUsd(s.key.usd):'\u2014')+'</td>':'')
 +'<td class=n>'+(s.turns||0)+'</td><td class=n>'+fmtTok(s.tok||0)+'</td></tr>';});
@@ -41010,6 +41048,9 @@ h+='<div class=rsp-sec><div class=ru-tip-name><span>Spend over time</span></div>
 +'<span class=rsp-gap></span>'
 +'<button class="rsp-btn'+(SP.measure==='usd'?' on':'')+'" data-act=measure:usd>dollars</button>'
 +'<button class="rsp-btn'+(SP.measure==='tok'?' on':'')+'" data-act=measure:tok>tokens</button>'
++'<span class=rsp-gap></span>'
++'<button class="rsp-btn'+(SP.order==='spend'?' on':'')+'" data-act=order:spend>by spend</button>'
++'<button class="rsp-btn'+(SP.order==='yours'?' on':'')+'" data-act=order:yours>your order</button>'
 +'</div><div id=rsp-chart></div></div>';
 // 3. per session — EVERY attached kernel's sessions (T247c), each machine's own story merged here;
 // the billing rule is named when every contributing machine shares one, else each keeps its own
@@ -41048,7 +41089,7 @@ var n=/^(\\d{4})-(\\d\\d)-(\\d\\d)$/.exec(k);return n?(Number(n[2])+'/'+Number(n
 function renderChart(){var box=document.getElementById('rsp-chart');if(!box||!SP.data)return;
 var d=SP.data,ser=d[SP.range],meas=SP.measure;
 if(!ser||!ser.keys||!ser.keys.length){box.innerHTML='<div class=rsp-note>No history yet.</div>';return;}
-var stacks=ser.stacks||[],n=ser.keys.length,W=Math.max(320,box.clientWidth||600),H=200;
+var stacks=spStackOrder(d,ser.stacks||[]),n=ser.keys.length,W=Math.max(320,box.clientWidth||600),H=200;
 var tots=[],mx=0;for(var i=0;i<n;i++){var t=0;for(var s=0;s<stacks.length;s++){t+=(stacks[s][meas]&&stacks[s][meas][i])||0;}tots.push(t);if(t>mx)mx=t;}
 if(!(mx>0)){box.innerHTML='<div class=rsp-note>Nothing recorded in this range.</div>';return;}
 var top=niceTop(mx),slot=W/n,gap=Math.min(2,slot*0.3),bw=Math.max(1,slot-gap),PADT=6;

--- a/tests/spend_modal_headless.js
+++ b/tests/spend_modal_headless.js
@@ -31,7 +31,7 @@ const { chromium } = require('playwright');
     chartFirst: (() => { const secs = Array.from(document.querySelectorAll('#rsp-panel .rsp-sec')); const ci = secs.findIndex((s) => s.querySelector('#rsp-chart')); const ti = secs.findIndex((s) => s.querySelector('#rsp-table')); return ci >= 0 && ti > ci; })(),
     swatches: document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr .rsp-sw:not(.rsp-hatch)').length,
     title: (() => { const t = document.querySelector('#rsp-panel .rsp-tbl tbody tr .tab-label'); const cs = t ? getComputedStyle(t) : null; const hp = t ? t.querySelector('.host-prefix') : null; return { color: cs ? cs.color : null, weight: cs ? cs.fontWeight : null, prefix: hp ? hp.textContent : null }; })(),
-    pane: (() => { const p = document.getElementById('rsp-table'); const th = document.querySelector('#rsp-panel .rsp-tbl thead th'); return { scrolls: !!p && p.scrollHeight > p.clientHeight + 4, sticky: th ? getComputedStyle(th).position : null, h: p ? p.clientHeight : null }; })(),
+    pane: (() => { const p = document.getElementById('rsp-table'); const th = document.querySelector('#rsp-panel .rsp-tbl thead th'); const panel = document.getElementById('rsp-panel'); return { scrolls: !!p && p.scrollHeight > p.clientHeight + 4, sticky: th ? getComputedStyle(th).position : null, h: p ? p.clientHeight : null, thOpacity: th ? getComputedStyle(th).opacity : null, panelScrolls: panel.scrollHeight > panel.clientHeight + 2 }; })(),
     rows: Array.from(document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr')).map((tr) => tr.textContent),
     deadRows: document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr.rsp-dead').length,
     segs: document.querySelectorAll('#rsp-chart .rsp-seg').length,

--- a/tests/spend_modal_headless.js
+++ b/tests/spend_modal_headless.js
@@ -27,8 +27,11 @@ const { chromium } = require('playwright');
   await pg.waitForSelector('#rsp-chart .rsp-svg', { timeout: 15000 });
   const out = await pg.evaluate(() => ({
     head: document.querySelector('#rsp-panel .rsp-top span').textContent,
-    legend: Array.from(document.querySelectorAll('#rsp-chart .rsp-chip')).map((e) => e.textContent),
-    chipOpacity: Array.from(document.querySelectorAll('#rsp-chart .rsp-chip')).map((e) => e.textContent + ':' + getComputedStyle(e).opacity),
+    legendNodes: document.querySelectorAll('#rsp-chart .rsp-leg, #rsp-chart .rsp-chip').length,
+    chartFirst: (() => { const secs = Array.from(document.querySelectorAll('#rsp-panel .rsp-sec')); const ci = secs.findIndex((s) => s.querySelector('#rsp-chart')); const ti = secs.findIndex((s) => s.querySelector('#rsp-table')); return ci >= 0 && ti > ci; })(),
+    swatches: document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr .rsp-sw:not(.rsp-hatch)').length,
+    title: (() => { const t = document.querySelector('#rsp-panel .rsp-tbl tbody tr .tab-label'); const cs = t ? getComputedStyle(t) : null; const hp = t ? t.querySelector('.host-prefix') : null; return { color: cs ? cs.color : null, weight: cs ? cs.fontWeight : null, prefix: hp ? hp.textContent : null }; })(),
+    pane: (() => { const p = document.getElementById('rsp-table'); const th = document.querySelector('#rsp-panel .rsp-tbl thead th'); return { scrolls: !!p && p.scrollHeight > p.clientHeight + 4, sticky: th ? getComputedStyle(th).position : null, h: p ? p.clientHeight : null }; })(),
     rows: Array.from(document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr')).map((tr) => tr.textContent),
     deadRows: document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr.rsp-dead').length,
     segs: document.querySelectorAll('#rsp-chart .rsp-seg').length,
@@ -41,16 +44,11 @@ const { chromium } = require('playwright');
     railOpacity: getComputedStyle(document.getElementById('rail-usage')).opacity,
   }));
   if (shots) { await pg.screenshot({ path: shots + '-dark.png' }); const ch = await pg.$('#rsp-chart'); if (ch) await ch.screenshot({ path: shots + '-chart.png' }); }
-  const foldBefore = await pg.evaluate(() => document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr').length);
-  const foldBtn = await pg.$('#rsp-panel [data-act="table:all"]');
-  if (foldBtn) { await foldBtn.click(); await pg.waitForFunction((n) => document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr').length > n, foldBefore, { timeout: 5000 }); }
-  const foldAfter = await pg.evaluate(() => document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr').length);
   await pg.click('#rsp-panel [data-act="measure:tok"]');
   await pg.click('#rsp-panel [data-act="range:days"]');
   await pg.waitForFunction(() => document.querySelector('#rsp-panel [data-act="range:days"]').classList.contains('on')
     && document.querySelector('#rsp-panel [data-act="measure:tok"]').classList.contains('on'), null, { timeout: 5000 });
   const days = await pg.evaluate(() => ({
-    legend: Array.from(document.querySelectorAll('#rsp-chart .rsp-chip')).map((e) => e.textContent),
     segs: document.querySelectorAll('#rsp-chart .rsp-seg').length,
     ylabels: Array.from(document.querySelectorAll('#rsp-chart .ru-tip-gy')).map((e) => e.textContent),
     xlabels: Array.from(document.querySelectorAll('#rsp-chart .ru-tip-gx span')).map((e) => e.textContent),
@@ -104,9 +102,7 @@ const { chromium } = require('playwright');
   const dim = await pg.evaluate(() => {
     const dead = document.querySelector('#rsp-panel tr.rsp-dead td.rsp-name');
     const ann = dead && dead.querySelector('.ru-tip-reset');
-    const btn = document.querySelector('#rsp-panel [data-act="table:all"]');
-    return { row: dead ? getComputedStyle(dead).opacity : null, ann: ann ? getComputedStyle(ann).opacity : null,
-             btnRowDead: btn ? btn.closest('tr').classList.contains('rsp-dead') : null, btnOpacity: btn ? getComputedStyle(btn).opacity : null };
+    return { row: dead ? getComputedStyle(dead).opacity : null, ann: ann ? getComputedStyle(ann).opacity : null };
   });
   // the loader's backstop: a fetch that never answers ends on the error + retry path (T247b)
   const timeout = await pg.evaluate(async () => {
@@ -147,6 +143,6 @@ const { chromium } = require('playwright');
   if (shots) await pg.screenshot({ path: shots + '-phone.png' });
   const panelHint = await pg.evaluate(() => document.getElementById('ru-tip').textContent.includes('Click for the full breakdown'));
   const mobile = { railHidden, panelOpened: true, modalOpened: true, btn, panelHint };
-  console.log(JSON.stringify({ hoverHint, hiddenBefore, loaderSeen, out, days, tip, hiddenAfter, hiddenAfterTap, hiddenAfterDrag, lightErr, lightBtn, dim, timeout, mobile, foldBefore, foldAfter, errs }));
+  console.log(JSON.stringify({ hoverHint, hiddenBefore, loaderSeen, out, days, tip, hiddenAfter, hiddenAfterTap, hiddenAfterDrag, lightErr, lightBtn, dim, timeout, mobile, errs }));
   await b.close();
 })().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/spend_modal_headless.js
+++ b/tests/spend_modal_headless.js
@@ -58,13 +58,12 @@ const { chromium } = require('playwright');
   });
   if (shots) await pg.screenshot({ path: shots + '-yourorder.png' });
   // a viewer arrangement (the strip's key) puts web first
-  const webSid = await pg.evaluate(() => { const r = window.__rompSpendData && window.__rompSpendData(); return r; });
   await pg.evaluate(() => { const rows = Array.from(document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr')); const web = rows.find((tr) => tr.textContent.includes('TESTHOST:web')); const sid = web && web.getAttribute('data-sid'); localStorage.setItem('romp:vieworder', JSON.stringify(sid ? [sid] : [])); });
   await pg.click('#rsp-panel [data-act="order:spend"]'); await pg.click('#rsp-panel [data-act="order:yours"]');
   await pg.waitForFunction(() => document.querySelector('#rsp-panel [data-act="order:yours"]').classList.contains('on'), null, { timeout: 5000 });
   yourOrder.viewRows = await pg.evaluate(() => Array.from(document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr')).map((tr) => tr.textContent.trim()));
   await pg.evaluate(() => { localStorage.removeItem('romp:vieworder'); });
-  await pg.click('#rsp-panel [data-act="order:spend"]');
+  // leave "your order" pressed: the phone reload below must read it back (the chip pressed on open, the rows ordered)
   await pg.click('#rsp-panel [data-act="measure:tok"]');
   await pg.click('#rsp-panel [data-act="range:days"]');
   await pg.waitForFunction(() => document.querySelector('#rsp-panel [data-act="range:days"]').classList.contains('on')
@@ -163,7 +162,10 @@ const { chromium } = require('playwright');
   await pg.waitForSelector('#rsp-panel .rsp-tbl', { timeout: 10000 });
   if (shots) await pg.screenshot({ path: shots + '-phone.png' });
   const panelHint = await pg.evaluate(() => document.getElementById('ru-tip').textContent.includes('Click for the full breakdown'));
-  const mobile = { railHidden, panelOpened: true, modalOpened: true, btn, panelHint };
+  const persisted = await pg.evaluate(() => ({ pressed: document.querySelector('#rsp-panel [data-act="order:yours"]').classList.contains('on'),
+    first: (document.querySelector('#rsp-panel .rsp-tbl tbody tr') || {}).textContent || '' }));
+  await pg.click('#rsp-panel [data-act="order:spend"]');   // restore the default for whoever runs next
+  const mobile = { railHidden, panelOpened: true, modalOpened: true, btn, panelHint , persisted };
   console.log(JSON.stringify({ yourOrder, hoverHint, hiddenBefore, loaderSeen, out, days, tip, hiddenAfter, hiddenAfterTap, hiddenAfterDrag, lightErr, lightBtn, dim, timeout, mobile, errs }));
   await b.close();
 })().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/spend_modal_headless.js
+++ b/tests/spend_modal_headless.js
@@ -44,6 +44,27 @@ const { chromium } = require('playwright');
     railOpacity: getComputedStyle(document.getElementById('rail-usage')).opacity,
   }));
   if (shots) { await pg.screenshot({ path: shots + '-dark.png' }); const ch = await pg.$('#rsp-chart'); if (ch) await ch.screenshot({ path: shots + '-chart.png' }); }
+  // T247f: "your order"
+  await pg.click('#rsp-panel [data-act="order:yours"]');
+  await pg.waitForFunction(() => document.querySelector('#rsp-panel [data-act="order:yours"]').classList.contains('on'), null, { timeout: 5000 });
+  const yourOrder = await pg.evaluate(() => {
+    const rows = Array.from(document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr')).map((tr) => tr.textContent.trim());
+    // the bottom stack of the first bucket that has one: the path whose top edge is lowest among those sharing the first x
+    const segs = Array.from(document.querySelectorAll('#rsp-chart .rsp-seg'));
+    const byX = new Map(); segs.forEach((p) => { const x = p.getAttribute('d').split(/[ ,]/)[0].slice(1); if (!byX.has(x)) byX.set(x, []); byX.get(x).push(p); });
+    let bottomFill = null; for (const [, ps] of byX) { const withY = ps.map((p) => ({ p, y1: parseFloat(p.getAttribute('d').split(/[ ,]/)[1]) })); withY.sort((a, b) => b.y1 - a.y1); if (withY.length > 1) { bottomFill = withY[0].p.getAttribute('fill'); break; } }
+    const prefs = JSON.parse(localStorage.getItem('romp:spendModal') || '{}');
+    return { rows, bottomFill, prefs, pressed: document.querySelector('#rsp-panel [data-act="order:yours"]').classList.contains('on') };
+  });
+  if (shots) await pg.screenshot({ path: shots + '-yourorder.png' });
+  // a viewer arrangement (the strip's key) puts web first
+  const webSid = await pg.evaluate(() => { const r = window.__rompSpendData && window.__rompSpendData(); return r; });
+  await pg.evaluate(() => { const rows = Array.from(document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr')); const web = rows.find((tr) => tr.textContent.includes('TESTHOST:web')); const sid = web && web.getAttribute('data-sid'); localStorage.setItem('romp:vieworder', JSON.stringify(sid ? [sid] : [])); });
+  await pg.click('#rsp-panel [data-act="order:spend"]'); await pg.click('#rsp-panel [data-act="order:yours"]');
+  await pg.waitForFunction(() => document.querySelector('#rsp-panel [data-act="order:yours"]').classList.contains('on'), null, { timeout: 5000 });
+  yourOrder.viewRows = await pg.evaluate(() => Array.from(document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr')).map((tr) => tr.textContent.trim()));
+  await pg.evaluate(() => { localStorage.removeItem('romp:vieworder'); });
+  await pg.click('#rsp-panel [data-act="order:spend"]');
   await pg.click('#rsp-panel [data-act="measure:tok"]');
   await pg.click('#rsp-panel [data-act="range:days"]');
   await pg.waitForFunction(() => document.querySelector('#rsp-panel [data-act="range:days"]').classList.contains('on')
@@ -143,6 +164,6 @@ const { chromium } = require('playwright');
   if (shots) await pg.screenshot({ path: shots + '-phone.png' });
   const panelHint = await pg.evaluate(() => document.getElementById('ru-tip').textContent.includes('Click for the full breakdown'));
   const mobile = { railHidden, panelOpened: true, modalOpened: true, btn, panelHint };
-  console.log(JSON.stringify({ hoverHint, hiddenBefore, loaderSeen, out, days, tip, hiddenAfter, hiddenAfterTap, hiddenAfterDrag, lightErr, lightBtn, dim, timeout, mobile, errs }));
+  console.log(JSON.stringify({ yourOrder, hoverHint, hiddenBefore, loaderSeen, out, days, tip, hiddenAfter, hiddenAfterTap, hiddenAfterDrag, lightErr, lightBtn, dim, timeout, mobile, errs }));
   await b.close();
 })().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/test_spend_detail.py
+++ b/tests/test_spend_detail.py
@@ -117,12 +117,15 @@ class SpendDetail(unittest.TestCase):
         self.assertEqual(names, ["web", "api", "tests"], "sorted by dollars, largest first")
         web, api, tests = d["sessions"]
         self.assertEqual((web["bg"], web["fg"]), ("#1EA1EB", "#ffffff"), "identity color from the registry")
-        self.assertEqual(tests["bg"], "", "a session without an identity color says so (the client draws neutral)")
+        self.assertTrue(tests["bg"].startswith("#"), "a session without an identity color still gets one (see below)")
         self.assertTrue(web["live"] and api["live"] and not tests["live"], "a dead session keeps its name, flagged")
         self.assertAlmostEqual(web["usd"], 24.0 * 40, places=3)
         self.assertEqual(web["turns"], 48 * 40)
         self.assertEqual(api["tok"], 96000 * 40)
-        self.assertEqual(d["topN"], km._DETAIL_TOP_N)
+        self.assertNotIn("topN", d, "T247e: no top-N — every session is its own stack and row")
+        self.assertTrue(tests.get("bgDerived") and tests["bg"] in km.pal.colors(km.pal.active_name(km.jd.STATE)),
+                        "a session the registry never colored gets a deterministic swatch of the active palette")
+        self.assertEqual(tests["bg"], km._spend_detail(now=NOW)["sessions"][2]["bg"], "…the same one every open")
         self.assertNotIn("windows", d, "the modal's window rows are the hover's own (no second parse, no dead payload)")
         self.assertEqual(d["tzOffsetMin"], int((time.localtime(NOW).tm_gmtoff or 0) // 60))
 
@@ -152,17 +155,19 @@ class SpendDetail(unittest.TestCase):
         self.assertEqual(web["tok"][hk.index(_hour(5))], 20000)
         self.assertFalse(web["usd"][hk.index(_hour(100))], "an hour with nothing recorded is a true zero")
 
-    def test_beyond_the_top_n_sessions_fold_into_one_other_stack(self):
+    def test_every_session_is_its_own_stack_no_other_fold(self):
+        # T247e (the user 2026-09-08): no top-N, no "other (N sessions)" — the list is the legend
         write_ledger(km.jd.STATE, extra_sids=12)
         d = km._spend_detail(now=NOW)
         self.assertEqual(len(d["sessions"]), 15, "the table lists EVERY session")
         kinds = [s["kind"] for s in d["days"]["stacks"]]
-        self.assertEqual(kinds.count("sid"), km._DETAIL_TOP_N)
-        self.assertEqual(kinds[-2:], ["other", "unattributed"])
-        other = d["days"]["stacks"][-2]
-        self.assertEqual(other["count"], 15 - km._DETAIL_TOP_N)
+        self.assertEqual(kinds.count("sid"), 15, "one stack per session")
+        self.assertNotIn("other", kinds)
+        self.assertEqual(kinds[-1], "unattributed")
         keys = d["days"]["keys"]
-        self.assertAlmostEqual(other["usd"][keys.index(_day(1))], 0.1 * (15 - km._DETAIL_TOP_N), places=3)
+        small = [s for s in d["days"]["stacks"] if s.get("sid", "").endswith("0111")][0]
+        self.assertAlmostEqual(small["usd"][keys.index(_day(1))], 0.1, places=3, msg="a small session keeps its own series")
+        self.assertTrue(all(s["bg"].startswith("#") for s in d["days"]["stacks"] if s["kind"] == "sid"), "every stack has a color")
         self.assertEqual(d["hours"]["stacks"][0]["name"], "web", "stack order is the table's: top by dollars")
 
     def test_the_keyed_scope_reads_each_sids_key_split_like_the_rail(self):
@@ -302,10 +307,8 @@ class SpendDetail(unittest.TestCase):
         d = km._spend_detail(now=NOW)
         self.assertEqual(d["scope"], "keyed")
         self.assertEqual(len(d["sessions"]), 12, "the table lists the key-billed sessions only")
-        other = [s for s in d["days"]["stacks"] if s["kind"] == "other"][0]
-        self.assertEqual(other["count"], 2, "the legend's count is the table's fold: sessions that contributed")
+        self.assertEqual([s["kind"] for s in d["days"]["stacks"]], ["sid"] * 12, "twelve stacks, no fold (T247e)")
         self.assertEqual(d["unattributed"]["usd"], 0.0, "every key dollar is a session's: nothing unattributed")
-        self.assertEqual([s["kind"] for s in d["days"]["stacks"]][-1], "other")
 
     # ── T247c: every attached kernel's sessions, merged kernel-side ──────────────────────────────
     def _peer_server(self, payload=None, status=200, token="peer-tok", hang=False, seen=None):
@@ -456,9 +459,21 @@ class SpendDetail(unittest.TestCase):
         self.assertAlmostEqual(wh["usd"][-1], 7.0, places=3)
         self.assertEqual(len(d["hours"]["keys"]), len(d["hours"]["epochs"]))
 
-    def test_the_merged_other_count_names_contributors_in_that_range_only(self):
-        # review find: the merged "other (N sessions)" counted every non-top session from the roster,
-        # whatever it spent in the range — the single-host reader counts contributors only
+    def test_an_older_peers_other_fold_survives_as_that_hosts_own_stack(self):
+        # a peer on the previous build still folds beyond a top-N into "other"; its dollars are kept as a
+        # stack named with its host rather than dropped (T247e keeps nothing but sid stacks of its own)
+        pd = self._peer_payload(0)
+        n = len(pd["hours"]["keys"])
+        pd["hours"]["stacks"].append({"kind": "other", "name": "other", "count": 3, "usd": [0.0] * (n - 1) + [1.5], "tok": [0] * n})
+        self._attach("PEERHOST", self._peer_server(pd))
+        d = km._spend_detail(now=NOW)
+        oth = [s for s in d["hours"]["stacks"] if s["kind"] == "other"]
+        self.assertEqual(len(oth), 1)
+        self.assertEqual((oth[0]["host"], oth[0]["count"]), ("PEERHOST", 3))
+        self.assertAlmostEqual(oth[0]["usd"][-1], 1.5, places=3)
+
+    def test_a_small_session_keeps_its_own_hourly_stack_across_hosts(self):
+        # T247e: with no top-N there is no fold to count — a small session's hour is its own stack
         write_ledger(km.jd.STATE, extra_sids=12)
         led = json.loads((km.jd.STATE / "spend.json").read_text())
         sid = "11111111-2222-3333-4444-000000000111"   # the last extra: outside the merged top ten
@@ -468,11 +483,11 @@ class SpendDetail(unittest.TestCase):
         (km.jd.STATE / "spend.json").write_text(json.dumps(led))
         self._attach("PEERHOST", self._peer_server(self._peer_payload(0)))
         d = km._spend_detail(now=NOW)
-        other_h = [s for s in d["hours"]["stacks"] if s["kind"] == "other"]
-        self.assertEqual(len(other_h), 1)
-        self.assertEqual(other_h[0]["count"], 1, "one non-top session spent in the hourly range")
-        other_d = [s for s in d["days"]["stacks"] if s["kind"] == "other"][0]
-        self.assertEqual(other_d["count"], 16 - 10, "every non-top session spent in the daily range")
+        self.assertEqual([s["kind"] for s in d["hours"]["stacks"] if s["kind"] == "other"], [], "no fold anywhere")
+        small = [s for s in d["hours"]["stacks"] if s.get("sid", "").endswith("0111")]
+        self.assertEqual(len(small), 1, "the small session's hour is its own stack")
+        self.assertEqual(small[0]["host"], "TESTHOST")
+        self.assertEqual(len([s for s in d["days"]["stacks"] if s["kind"] == "sid"]), 16, "sixteen sessions across two hosts, sixteen stacks")
 
     def test_an_older_peer_without_epochs_still_aligns_through_its_offset(self):
         off = int((time.localtime(NOW).tm_gmtoff or 0) // 60) + 180
@@ -542,13 +557,33 @@ class SpendDetail(unittest.TestCase):
         self.assertIn("var spAbort=new AbortController()", html)
         self.assertIn("setTimeout(function(){spAbort.abort();}", html)
         self.assertIn("signal:spAbort.signal", html)
-        # T247b: dimmed rows dim ONCE — the annotation inside a dimmed row stays at the row's level, and
-        # the fold row's "show all" is a control, never dimmed
+        # T247b: dimmed rows dim ONCE — the annotation inside a dimmed row stays at the row's level
         self.assertIn(".rsp-dead td{opacity:.55}", html)
         self.assertIn(".rsp-dead .ru-tip-reset{opacity:1}", html)
-        self.assertNotIn("<tr class=rsp-dead><td><i class=rsp-sw style=\"background:'+SP_OTHER+'\"></i></td><td class=rsp-name>'+rest.length+' more session", html,
-                         "the fold row is not a dead row")
-        self.assertIn("<tr class=rsp-fold>", html)
+        # T247e: the chart precedes the list; the list is a scroll pane under a sticky header holding
+        # every session (no fold), each row its TAB TITLE (the strip's classes, the identity color as
+        # --chip-bg), no swatch, no legend
+        js = html
+        self.assertLess(js.index("<span>Spend over time</span>"), js.index("<span>By session"), "the chart comes first")
+        self.assertNotIn("more session", js, "no fold")
+        self.assertNotIn("rsp-leg", js, "no legend: the list is the legend")
+        self.assertIn("#rsp-table{max-height:38vh;overflow-y:auto", js)
+        self.assertIn(".rsp-tbl thead th{position:sticky;top:0;background:#252526;z-index:1}", js)
+        self.assertIn("body.theme-light .rsp-tbl thead th{background:#FFFFFF}", js)
+        self.assertIn('<span class="tab-label colored" style="--chip-bg:\'+spColor(s)+\'">', js, "a row's title wears the tab strip's classes")
+        # the landing page loads no stylesheet, so the strip's two rules are inlined as a TWIN; this pins the
+        # twin's declarations against the source so the two cannot drift
+        import re as _re
+        css = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "styles.css")).read()
+        def decls(sel):
+            m = _re.search(_re.escape(sel) + r"\s*\{([^}]*)\}", css)
+            self.assertIsNotNone(m, sel + " missing from styles.css")
+            return _re.sub(r"\s+", "", m.group(1)).rstrip(";")
+        self.assertIn(".rsp-name .tab-label.colored{" + decls(".tab.colored .tab-label") + "}", js,
+                      "the modal row's title declarations are the tab strip's, byte for byte")
+        hp = decls(".host-prefix").replace("var(--dim)", "var(--dim,#9aa0a6)")
+        self.assertIn(".rsp-name .host-prefix{" + hp + "}", js,
+                      "the host prefix declarations are the strip's (with the dark fallback the landing needs)")
         # T247b: the phone's door is its own row at the hover's button size, full opacity — not an
         # annotation inside .ru-tip-age (10px, .55)
         self.assertIn("<div class=ru-tip-more><button class=rsp-btn id=ru-bysession>", html)

--- a/tests/test_spend_detail.py
+++ b/tests/test_spend_detail.py
@@ -501,9 +501,11 @@ class SpendDetail(unittest.TestCase):
         # T247f: "your order" is the tab strip's and the lanes' order — the kernel's shared seed
         # (session-order.json) per host, hosts local-first then the remotes listing's order; an older peer
         # that ships no order contributes nothing (its sessions trail, client-side)
-        (km.jd.STATE / "session-order.json").write_text(json.dumps([API, WEB]))
+        (km.jd.STATE / "session-order.json").write_text(json.dumps([API, TESTS, WEB]))
         d = km._spend_detail(now=NOW)
-        self.assertEqual(d["order"], [["TESTHOST", API], ["TESTHOST", WEB]], "one host: its seed, host-tagged")
+        self.assertEqual(d["order"], [["TESTHOST", API], ["TESTHOST", WEB]],
+                         "one host: its seed, host-tagged — restricted to what the tab strip renders (tests is dead: the "
+                         "file keeps its slot while its transcript is in the window, the strip shows no such tab, so it trails)")
         self._attach("PEERHOST", self._peer_server(self._peer_payload(0)))
         d = km._spend_detail(now=NOW)
         self.assertEqual(d["order"], [["TESTHOST", API], ["TESTHOST", WEB], ["PEERHOST", "22222222-3333-4444-5555-000000000001"]])

--- a/tests/test_spend_detail.py
+++ b/tests/test_spend_detail.py
@@ -3,7 +3,7 @@
 spend breakdown and a stacked histogram of spend over time colored by session. The data is GET
 /spend/detail: the ledger's bySid maps (T100's per-session attribution) with names and identity colors
 resolved kernel-side, two ranges at the ledger's own granularity (192 hours, 90 days), the top-N sessions
-as stacks plus ONE "other" and ONE "unattributed" stack — spend recorded before attribution existed, or
+as stacks (every session its own, since T247e) plus ONE "unattributed" stack — spend recorded before attribution existed, or
 the part of a bucket no sid accounts for, is shown as such, never dropped (fail loudly). Hermetic state
 root, synthetic ledger, the notes-api demo sessions (web/api/tests), placeholder uuids, TESTHOST."""
 import inspect
@@ -168,6 +168,13 @@ class SpendDetail(unittest.TestCase):
         small = [s for s in d["days"]["stacks"] if s.get("sid", "").endswith("0111")][0]
         self.assertAlmostEqual(small["usd"][keys.index(_day(1))], 0.1, places=3, msg="a small session keeps its own series")
         self.assertTrue(all(s["bg"].startswith("#") for s in d["days"]["stacks"] if s["kind"] == "sid"), "every stack has a color")
+        # derived colors never take a swatch an identity-colored session here holds while a free one remains
+        # (review find: a plain hash gave a dead session web's blue)
+        ident = {s["bg"] for s in d["sessions"] if not s.get("bgDerived")}
+        derived = [s["bg"] for s in d["sessions"] if s.get("bgDerived")]
+        free = len(km.pal.colors(km.pal.active_name(km.jd.STATE))) - len(ident)
+        self.assertTrue(all(c not in ident for c in derived[:free]), "the free swatches go first")
+        self.assertEqual(len(set(derived[:free])), free, "…each once")
         self.assertEqual(d["hours"]["stacks"][0]["name"], "web", "stack order is the table's: top by dollars")
 
     def test_the_keyed_scope_reads_each_sids_key_split_like_the_rail(self):

--- a/tests/test_spend_detail.py
+++ b/tests/test_spend_detail.py
@@ -364,7 +364,8 @@ class SpendDetail(unittest.TestCase):
         i5 = n - 1 - 5
         usd[i5] = 7.0; tok[i5] = 70000
         una = [0.0] * n; una[n - 1 - 9] = 2.0
-        pd = {"host": "PEERHOST", "scope": "total", "tz": "PEER", "tzOffsetMin": off_min, "topN": 10,
+        pd = {"host": "PEERHOST", "scope": "total", "tz": "PEER", "tzOffsetMin": off_min,
+              "order": ["22222222-3333-4444-5555-000000000001"],
               "sessions": [{"sid": "22222222-3333-4444-5555-000000000001", "name": "worker", "bg": "#C2410C", "fg": "#fff",
                             "live": True, "usd": 300.0, "tok": 3000000, "turns": 30}],
               "unattributed": {"usd": 2.0, "tok": 0, "turns": 1},
@@ -489,6 +490,24 @@ class SpendDetail(unittest.TestCase):
         self.assertEqual(small[0]["host"], "TESTHOST")
         self.assertEqual(len([s for s in d["days"]["stacks"] if s["kind"] == "sid"]), 16, "sixteen sessions across two hosts, sixteen stacks")
 
+    def test_the_payload_carries_the_shared_session_order_by_host(self):
+        # T247f: "your order" is the tab strip's and the lanes' order — the kernel's shared seed
+        # (session-order.json) per host, hosts local-first then the remotes listing's order; an older peer
+        # that ships no order contributes nothing (its sessions trail, client-side)
+        (km.jd.STATE / "session-order.json").write_text(json.dumps([API, WEB]))
+        d = km._spend_detail(now=NOW)
+        self.assertEqual(d["order"], [["TESTHOST", API], ["TESTHOST", WEB]], "one host: its seed, host-tagged")
+        self._attach("PEERHOST", self._peer_server(self._peer_payload(0)))
+        d = km._spend_detail(now=NOW)
+        self.assertEqual(d["order"], [["TESTHOST", API], ["TESTHOST", WEB], ["PEERHOST", "22222222-3333-4444-5555-000000000001"]])
+        km._remotes.clear()
+        pd = self._peer_payload(0)
+        del pd["order"]
+        self._attach("OLDPEER", self._peer_server(pd))
+        d = km._spend_detail(now=NOW)
+        self.assertEqual(d["order"], [["TESTHOST", API], ["TESTHOST", WEB]], "no order from an older peer")
+        (km.jd.STATE / "session-order.json").unlink()
+
     def test_an_older_peer_without_epochs_still_aligns_through_its_offset(self):
         off = int((time.localtime(NOW).tm_gmtoff or 0) // 60) + 180
         self._attach("PEERHOST", self._peer_server(self._peer_payload(off, epochs=False)))
@@ -571,6 +590,11 @@ class SpendDetail(unittest.TestCase):
         self.assertIn(".rsp-tbl thead th{position:sticky;top:0;background:#252526;z-index:1}", js)
         self.assertIn("body.theme-light .rsp-tbl thead th{background:#FFFFFF}", js)
         self.assertIn('<span class="tab-label colored" style="--chip-bg:\'+spColor(s)+\'">', js, "a row's title wears the tab strip's classes")
+        # T247f: the order chips beside the measure chips; the choice persists with the other toggles
+        self.assertIn('data-act=order:spend>by spend</button>', js)
+        self.assertIn('data-act=order:yours>your order</button>', js)
+        self.assertIn("var SP_PREFS_KEY='romp:spendModal';", js)
+        self.assertIn("localStorage.getItem('romp:vieworder')", js, "the viewer's arrangement is the strip's own key")
         # the landing page loads no stylesheet, so the strip's two rules are inlined as a TWIN; this pins the
         # twin's declarations against the source so the two cannot drift
         import re as _re

--- a/tests/test_spend_modal_headless.py
+++ b/tests/test_spend_modal_headless.py
@@ -62,7 +62,7 @@ class SpendModalServed(unittest.TestCase):
         km._claude_account = lambda: ""
         km._auth_key_present = lambda: True
         (state / "usage.json").write_text(json.dumps({"apiKey": True}))
-        write_ledger(state, extra_sids=12)
+        write_ledger(state, extra_sids=20)     # enough sessions to scroll the pane (T247e)
         # T247c: a two-host world — a peer kernel whose sessions merge in, and an older peer reported by name
         self._saved_remotes = dict(km._remotes)
         km._remotes.clear()
@@ -147,24 +147,27 @@ class SpendModalServed(unittest.TestCase):
         self.assertEqual(o["out"]["head"], "API spend · 2 machines", "the header names the machines when several contribute (review find)")
         rows = o["out"]["rows"]
         # T247c: two hosts contribute, so every row names its host in the tab strip's host-prefix voice
-        self.assertTrue(rows[0].startswith("TESTHOST:web") or rows[0].startswith("TESTHOST: web"), rows[0])
-        self.assertTrue(rows[1].startswith("PEERHOST:worker") or rows[1].startswith("PEERHOST: worker"), rows[1])
-        self.assertTrue(rows[2].startswith("TESTHOST:api") or rows[2].startswith("TESTHOST: api"), rows[2])
+        self.assertTrue(rows[0].startswith("TESTHOST:web"), rows[0])
+        self.assertTrue(rows[1].startswith("PEERHOST:worker"), rows[1])
+        self.assertTrue(rows[2].startswith("TESTHOST:api"), rows[2])
         self.assertTrue(any("OLDHOST" in n and "older build" in n for n in o["out"]["notes"]), o["out"]["notes"])
         self.assertFalse(any("this machine only" in n for n in o["out"]["notes"]))
         self.assertTrue(any("aligned by clock time" in n for n in o["out"]["notes"]), "hosts in different zones: the timezone rule is stated")
-        self.assertTrue(any(c.startswith("PEERHOST") for c in o["out"]["legend"]), o["out"]["legend"])
+        # T247e: the chart comes first, has no legend; the list is a scroll pane of EVERY session under a
+        # sticky header, each row its tab title in its identity color, no swatch, no fold
+        self.assertTrue(o["out"]["chartFirst"], "the chart section precedes the session list")
+        self.assertEqual(o["out"]["legendNodes"], 0, "no legend")
+        self.assertEqual(o["out"]["swatches"], 0, "no swatch in a session row")
+        self.assertEqual(len(rows), 3 + 20 + 1 + 1, "every session across both hosts, plus the unattributed row")
+        self.assertEqual(o["out"]["title"]["color"], "rgb(30, 161, 235)", "web's title wears its identity color")
+        self.assertEqual(o["out"]["title"]["weight"], "600")
+        self.assertEqual(o["out"]["title"]["prefix"], "TESTHOST:")
+        self.assertTrue(o["out"]["pane"]["scrolls"], o["out"]["pane"])
+        self.assertEqual(o["out"]["pane"]["sticky"], "sticky")
         self.assertTrue(any("tests" in r and "not running" in r for r in rows), "a dead session keeps its name, dimmed")
-        self.assertTrue(any(r.startswith("unattributed") for r in rows), "pre-attribution spend is a row of its own")
+        self.assertTrue(any(r.strip().startswith("unattributed") for r in rows), "pre-attribution spend is a row of its own (its hatch mark leads)")
         self.assertGreaterEqual(o["out"]["deadRows"], 2)
-        self.assertEqual(o["foldBefore"], 10 + 1 + 1, "the table folds to the top-N, a '6 more' row, and the unattributed row")
-        self.assertEqual(o["foldAfter"], 16 + 1, "show all: every session across both hosts, plus the unattributed row")
-        self.assertTrue(any("6 more sessions" in r for r in rows), rows)
-        leg = o["out"]["legend"]
-        self.assertEqual([c.split(":")[-1].strip() for c in leg], ["web", "worker", "api", "tests", "unattributed"],
-                         "the hourly legend names only the stacks the hourly chart draws, across hosts, in dollar order")
-        self.assertIn("other (6 sessions)", o["days"]["legend"], "beyond the top-N the daily range folds them into one stack")
-        self.assertEqual(o["days"]["legend"][-1], "unattributed")
+        self.assertGreater(o["days"]["segs"], 24 * 30, "every session's daily bars, no fold")
         self.assertGreater(o["out"]["segs"], 60)
         self.assertGreaterEqual(o["out"]["hatched"], 1, "the unattributed stack wears the hatch, not a hue")
         self.assertIn("1 hour", o["out"]["windows"], "the same window rows the hover shows")
@@ -182,22 +185,15 @@ class SpendModalServed(unittest.TestCase):
         self.assertEqual(o["lightErr"], "rgb(154, 51, 36)", "the error line has a light-theme step")
         # T247b: the pressed toggle in the light theme wears the accent chip with --accent-fg text and no hairline
         self.assertEqual(o["lightBtn"], {"color": "rgb(255, 248, 242)", "border": "rgba(0, 0, 0, 0)", "bg": "rgb(194, 65, 12)"}, o["lightBtn"])
-        # T247b: dim once — the annotation inside a dead row is at the row's level; the fold row is a control row
+        # T247b: dim once — the annotation inside a dead row is at the row's level
         self.assertEqual(o["dim"]["row"], "0.55", o["dim"])
         self.assertEqual(o["dim"]["ann"], "1", "no second dimming inside a dimmed row")
-        self.assertIs(o["dim"]["btnRowDead"], False, "the 'show all' row is not dimmed")
-        self.assertEqual(o["dim"]["btnOpacity"], "1")
         # T247b: the loader's backstop lands on the error + retry path, and names the timeout (the AbortError
         # mapping is pinned, not just the shared prefix — review find); a re-open over a pending fetch keeps
         # the loader up: the superseded fetch's abort paints nothing (review find)
         self.assertTrue(o["timeout"]["err"] and "no answer from the kernel after 1 s" in o["timeout"]["err"], o["timeout"])
         self.assertTrue(o["timeout"]["retry"])
         self.assertEqual(o["timeout"]["early"], {"err": False, "loader": True}, o["timeout"])
-        # the unattributed chip dims like its row (review find: same class, two weights)
-        self.assertIn("unattributed:0.55", o["out"]["chipOpacity"], o["out"]["chipOpacity"])
-        self.assertIn("TESTHOST: web:1", o["out"]["chipOpacity"], "a live session's chip at full strength, host-prefixed (T247c)")
-        self.assertIn("TESTHOST: tests:0.55", o["out"]["chipOpacity"])
-        self.assertIn("PEERHOST: worker:1", o["out"]["chipOpacity"], "the peer's session wears its own host")
         # T247b: the phone's door is a real button — the hover's size, full opacity, not an annotation
         self.assertEqual(o["mobile"]["btn"]["font"], "11px", o["mobile"]["btn"])
         self.assertEqual(o["mobile"]["btn"]["opacity"], "1", o["mobile"]["btn"])

--- a/tests/test_spend_modal_headless.py
+++ b/tests/test_spend_modal_headless.py
@@ -178,6 +178,8 @@ class SpendModalServed(unittest.TestCase):
         self.assertTrue(yo["viewRows"][0].startswith("TESTHOST:web"), "the viewer's own arrangement wins over the seed: " + yo["viewRows"][0])
         self.assertEqual(yo["prefs"].get("order"), "yours")
         self.assertTrue(yo["pressed"])
+        self.assertTrue(o["mobile"]["persisted"]["pressed"], "the persisted choice is read back on a reload (review find: only the write was pinned)")
+        self.assertTrue(o["mobile"]["persisted"]["first"].strip().startswith("TESTHOST:api"), o["mobile"]["persisted"])
         self.assertTrue(any("tests" in r and "not running" in r for r in rows), "a dead session keeps its name, dimmed")
         self.assertTrue(any(r.strip().startswith("unattributed") for r in rows), "pre-attribution spend is a row of its own (its hatch mark leads)")
         self.assertGreaterEqual(o["out"]["deadRows"], 2)

--- a/tests/test_spend_modal_headless.py
+++ b/tests/test_spend_modal_headless.py
@@ -63,6 +63,7 @@ class SpendModalServed(unittest.TestCase):
         km._auth_key_present = lambda: True
         (state / "usage.json").write_text(json.dumps({"apiKey": True}))
         write_ledger(state, extra_sids=20)     # enough sessions to scroll the pane (T247e)
+        (state / "session-order.json").write_text(json.dumps([API, WEB]))   # the tab strip's order: api before web (T247f)
         # T247c: a two-host world — a peer kernel whose sessions merge in, and an older peer reported by name
         self._saved_remotes = dict(km._remotes)
         km._remotes.clear()
@@ -164,6 +165,17 @@ class SpendModalServed(unittest.TestCase):
         self.assertEqual(o["out"]["title"]["prefix"], "TESTHOST:")
         self.assertTrue(o["out"]["pane"]["scrolls"], o["out"]["pane"])
         self.assertEqual(o["out"]["pane"]["sticky"], "sticky")
+        # T247f: "your order" — the strip's order (api before web from session-order.json, then the peer's own
+        # order), unknown sessions trailing by spend; the chart's bottom stack follows; a viewer arrangement
+        # (the strip's localStorage key) reorders both; the choice persists with the other toggles
+        yo = o["yourOrder"]
+        self.assertTrue(yo["rows"][0].startswith("TESTHOST:api") and yo["rows"][1].startswith("TESTHOST:web"), yo["rows"][:3])
+        self.assertTrue(yo["rows"][2].startswith("PEERHOST:worker"), yo["rows"][:3])
+        self.assertTrue(yo["rows"][3].startswith("TESTHOST:tests"), "sessions the order does not know trail, by spend: " + yo["rows"][3])
+        self.assertEqual(yo["bottomFill"], "#54B204", "the chart's bottom stack is the first row (api)")
+        self.assertTrue(yo["viewRows"][0].startswith("TESTHOST:web"), "the viewer's own arrangement wins over the seed: " + yo["viewRows"][0])
+        self.assertEqual(yo["prefs"].get("order"), "yours")
+        self.assertTrue(yo["pressed"])
         self.assertTrue(any("tests" in r and "not running" in r for r in rows), "a dead session keeps its name, dimmed")
         self.assertTrue(any(r.strip().startswith("unattributed") for r in rows), "pre-attribution spend is a row of its own (its hatch mark leads)")
         self.assertGreaterEqual(o["out"]["deadRows"], 2)

--- a/tests/test_spend_modal_headless.py
+++ b/tests/test_spend_modal_headless.py
@@ -165,6 +165,8 @@ class SpendModalServed(unittest.TestCase):
         self.assertEqual(o["out"]["title"]["prefix"], "TESTHOST:")
         self.assertTrue(o["out"]["pane"]["scrolls"], o["out"]["pane"])
         self.assertEqual(o["out"]["pane"]["sticky"], "sticky")
+        self.assertEqual(o["out"]["pane"]["thOpacity"], "1", "the sticky header occludes: muted by color, not opacity (review find)")
+        self.assertFalse(o["out"]["pane"]["panelScrolls"], "the card itself does not scroll at 820px: the pane takes the room under the chart (review find)")
         # T247f: "your order" — the strip's order (api before web from session-order.json, then the peer's own
         # order), unknown sessions trailing by spend; the chart's bottom stack follows; a viewer arrangement
         # (the strip's localStorage key) reorders both; the choice persists with the other toggles

--- a/ui/webview/spend-order-twin.test.ts
+++ b/ui/webview/spend-order-twin.test.ts
@@ -1,0 +1,36 @@
+// The usage modal's "your order" (T247f) arranges the kernel's shared seed by the viewer's own drag order —
+// the SAME algorithm the tab strip and the timeline lanes apply (view-order.ts applyViewOrder). The landing
+// page loads no webview bundle, so the modal carries a twin inside kernel.py's _LANDING_USAGE_JS; this test
+// runs that twin against the module on the same inputs, so the two cannot drift.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { applyViewOrder } from "./view-order";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
+
+function twin(): (seed: readonly string[], view: readonly string[]) => string[] {
+  const usageJS = KERNEL.split('_LANDING_USAGE_JS = """')[1].split('"""')[0];
+  const line = usageJS.split("\n").find((l) => l.startsWith("function spApplyViewOrder(seed,view){"));
+  assert.ok(line, "the landing JS carries spApplyViewOrder on one line");
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  return new Function(line + "; return spApplyViewOrder;")();
+}
+
+test("the landing's spApplyViewOrder is view-order.ts applyViewOrder, input for input", () => {
+  const f = twin();
+  const cases: Array<[any[], any[]]> = [
+    [["a", "b", "c"], []],
+    [["a", "b", "c"], ["c", "a"]],
+    [["a", "b", "c"], ["zzz", "b"]],
+    [["a", "a", "b", 7 as any, null as any], ["b", "b", "a"]],
+    [["h1:x", "y", "h2:z"], ["h2:z", "y"]],
+    [[], ["a"]],
+    [["a"], [1 as any, undefined as any]],
+  ];
+  for (const [seed, view] of cases) {
+    assert.deepEqual(f(seed as any, view as any), applyViewOrder(seed as any, view as any), JSON.stringify([seed, view]));
+  }
+});

--- a/ui/webview/spend-order-twin.test.ts
+++ b/ui/webview/spend-order-twin.test.ts
@@ -29,6 +29,7 @@ test("the landing's spApplyViewOrder is view-order.ts applyViewOrder, input for 
     [["h1:x", "y", "h2:z"], ["h2:z", "y"]],
     [[], ["a"]],
     [["a"], [1 as any, undefined as any]],
+    [["constructor", "toString", "__proto__", "a"], ["a", "__proto__"]],   // ids that collide with Object.prototype keys
   ];
   for (const [seed, view] of cases) {
     assert.deepEqual(f(seed as any, view as any), applyViewOrder(seed as any, view as any), JSON.stringify([seed, view]));


### PR DESCRIPTION
**Feature (T247e).** The user's second pass on the usage modal (2026-09-08 morning PT): they like it and want these changes.

**Design points**
- **Order.** Totals, then the spend-over-time chart with its range and measure toggles, then the sessions.
- **Scroll pane.** The session list shows every session inside a capped pane with the header row (session / dollars / turns / tokens) sticky at its top; the modal stays a centered card (panel rule) and the list scrolls inside it. The "N more sessions · show all" fold is gone.
- **Every session its own stack.** No top-N and no "other" stack; each session stacks in its own color. A session the registry never colored gets a deterministic swatch of the active palette by sid (flagged `bgDerived`), so every stack and row has a color. Dead sessions keep their identity color; the hatched "unattributed" stack stays. An older peer that still folds beyond a top-N keeps its "other" as that host's own transitional stack, named with the host, so its dollars are not lost.
- **No legend.** The list below the chart is the legend.
- **Rows as tab titles.** No swatch. A row renders like the tab strip renders a tab title: the host prefix in quiet italic gray ("devbox:"), then the name bold in its identity color, under the strip's own class names (`.tab-label.colored` carrying `--chip-bg`, `.host-prefix`). The landing page loads no stylesheet (the panes do), so the two declarations are inlined as the strip's twin, and a test pins the twin against `ui/webview/styles.css` byte for byte so the two cannot drift, the timeline's menu twin being the precedent. Host prefix only when more than one machine contributes; dead sessions stay dimmed with their "not running" annotation.
- **Kept.** The footnote lines (timezone rule, per-host status), the phone door, the toggles' pressed styling and click safety, the residue grain.

**Tests.** Route tests follow the shape: no `topN`, no "other" stack, every session a stack with a color, the colorless session's deterministic swatch, an older peer's fold kept per host, the small session's own hourly stack across hosts, wiring pins for the scroll pane, sticky header and the twin's drift guard. The served test drives a twenty-session two-host world: chart before list, no legend, no swatches, every row present, the first row's title in its identity color at weight 600 with its host prefix, the pane scrolling under a sticky header, the drag-select and dim-once checks unchanged. Screenshots dark and light.

**Ordering control (second commit, T247f).** A third chip pair beside "dollars / tokens": "by spend" (default, descending dollars) and "your order". "Your order" is the order the tab strip and the timeline lanes show, from the one source they share: the kernel's shared seed per host (`session-order.json`, written by a tab drag or a lane drag), hosts local-first then in the remotes listing's order, arranged by this viewer's own drag order read from the strip's `localStorage` key and applied with `view-order.ts`'s own algorithm. Both layers are needed because the strip and the lanes are the seed arranged by the viewer (`mergeHostOrder` then `applyViewOrder`); the seed alone would not match what the user sees. The landing page loads no webview bundle, so the modal carries a twin of `applyViewOrder`, and a node test runs the twin against the module input for input. Sessions the order does not know (dead or archived, or an older peer's) trail in spend order, dimmed as today; the chart's stacks follow the same choice, bottom to top. The choice persists with the range and measure toggles, which persisted nowhere before; all three now ride one `localStorage` entry. Same delegated `data-act` door as the other chips. Tests: route pins for the host-tagged seed; the served pass presses "your order" against a saved order and a viewer arrangement, reads the rows, the chart's bottom stack and the persisted choice; a screenshot with "your order" pressed.

**Review folds (third commit).** Adversarial review of the second pass, twelve findings, ten real, folded: the sticky header was a 55 percent wash (opacity on the header cells composites the background too), so the muting is now the text color and the header occludes; the card itself still scrolled at common heights, so the pane's cap is computed from the room left under the chart; a derived color could be a swatch an identity-colored session in the same payload already wore, so the least-used swatch goes first with ties by the sid's hash; a segment under half a dollar tipped "$0" and now tips "under $1"; resize re-renders coalesce on one animation frame; dead code, a no-op rule, stale comments and an unread stack flag are gone. **Stated, not folded (design limits to weigh):** twelve swatches cannot keep more than twelve sessions apart, so past that the color maps stack to row only through the tooltip; with dozens of sessions active in one hour, per-session segments thin to sub-pixel hairlines; an older peer's transitional "other" stack is named only on hover; the payload is served uncompressed and grows with the session count.

**Review folds, ordering control (fourth commit).** Eight findings, seven real, folded: the seed shipped `session-order.json` verbatim, and the file keeps a recently dead session at its slot while its transcript is in the discover window, so "your order" interleaved a dead session the tab strip did not show; the seed is restricted to what the strip renders (live or kept open), so dead sessions trail as the contract says (this follows the strip, not the timeline lanes, which show recently dead sessions in place). The chip row wraps on a phone and a chip never breaks its label; an order toggle scrolls the pane back to its head rows; the apply-order twin keeps ids that collide with `Object.prototype` keys, as the module's sets do, with that case in the drift test; the persisted choice is read back across the phone reload in the served test; a dead scaffolding line in the driver is gone.

**Left out.** Nothing from the dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
