### PR TITLE
Chat pane: follow mode and the jump chip read the true bottom; the 80 px band is the send reveal's alone

### DIFF
--- a/ui/webview/at-bottom.test.ts
+++ b/ui/webview/at-bottom.test.ts
@@ -1,0 +1,101 @@
+// Follow mode and the go-to-bottom chip read the TRUE bottom; the 80 px band is the send reveal's alone
+// (T262c, the user 2026-09-08, who wheeled up from the tail of a working session, saw no chevron for a
+// stretch, and inside that stretch had the view snap back to the bottom; they expected the chevron the
+// moment they left the bottom). One 80 px band (render.ts's old nearBottom) drove BOTH follow mode and the
+// chip, so for the first 80 px of a deliberate scroll-up the reader still counted as at the bottom: no chip,
+// and every content-height change of a working session re-pinned them through followTail's height-changed
+// branch — a snapback with no predictable interval, because it fired whenever the session appended while
+// they were inside the band. Now: atBottom (2 px, the tolerance followTail already used) for every
+// follow-mode decision and the chip; nearBottomForSend (80 px) only where the user's own send reveals itself.
+// render.ts has import-time DOM side effects → the pure tolerance executes for real, the decisions run as a
+// replica pinned to source, and every call site is pinned to the helper its intent belongs to.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { atBottomDist, AT_BOTTOM_PX, followTail } from "./scroll-keep";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("the tolerance is 2 px: sub-pixel slack is the bottom, three pixels is not", () => {
+  assert.equal(AT_BOTTOM_PX, 2);
+  assert.equal(atBottomDist(0), true);
+  assert.equal(atBottomDist(2), true, "fractional scroll positions leave up to a pixel or two of slack");
+  assert.equal(atBottomDist(3), false);
+  assert.equal(atBottomDist(30), false, "30 px up is a reader who left the bottom");
+  assert.equal(atBottomDist(79), false, "…and so is the old band's edge");
+});
+
+// ── executed replica of appendActive's stick + the chip, pinned to source below ──────────────────
+type Box = { scrollHeight: number; clientHeight: number; scrollTop: number };
+const dist = (c: Box) => c.scrollHeight - c.scrollTop - c.clientHeight;
+const atBottom = (c: Box) => atBottomDist(dist(c));                       // render.ts atBottom
+const maxScroll = (c: Box) => Math.max(0, c.scrollHeight - c.clientHeight);
+const chipShown = (c: Box) => c.clientHeight > 0 && c.scrollHeight > c.clientHeight + 2 && !atBottom(c);   // updateJumpBtn
+function append(c: Box, growth: number): void {                           // appendActive
+  const stick = c.scrollHeight > c.clientHeight + 2 && atBottom(c);
+  const before = c.scrollTop, heightBefore = c.scrollHeight, distBefore = dist(c);
+  c.scrollHeight += growth;
+  if (stick && followTail(distBefore, heightBefore, c.scrollHeight)) c.scrollTop = maxScroll(c);
+  else c.scrollTop = before;
+}
+
+test("a reader 30 px above the bottom is NOT re-pinned when the content grows, and the chip is shown", () => {
+  const c: Box = { scrollHeight: 5000, clientHeight: 600, scrollTop: 5000 - 600 - 30 };
+  assert.equal(chipShown(c), true, "the chevron shows the moment they are more than 2 px off the bottom");
+  append(c, 40);                                                          // a streamed line lands
+  assert.equal(c.scrollTop, 5000 - 600 - 30, "the view did not move");
+  append(c, 300);                                                         // a whole card lands
+  assert.equal(c.scrollTop, 5000 - 600 - 30, "still not moved: only the true bottom follows");
+  assert.equal(chipShown(c), true);
+});
+
+test("a reader at the true bottom follows every append; scrolling 3 px up leaves follow mode at once", () => {
+  const c: Box = { scrollHeight: 5000, clientHeight: 600, scrollTop: 4400 };
+  assert.equal(chipShown(c), false);
+  append(c, 40);
+  assert.equal(c.scrollTop, 4440, "followed");
+  c.scrollTop -= 3;                                                       // the smallest deliberate wheel step
+  assert.equal(chipShown(c), true, "chevron up immediately");
+  append(c, 40);
+  assert.equal(c.scrollTop, 4437, "not re-pinned");
+  c.scrollTop = maxScroll(c);                                             // back to the true bottom (or the chip's click)
+  assert.equal(chipShown(c), false);
+  append(c, 40);
+  assert.equal(c.scrollTop, maxScroll(c), "follow mode re-engaged only by reaching the true bottom");
+});
+
+// ── source pins: two helpers, and every call site assigned to one by intent ─────────────────────
+test("render.ts defines atBottom on the shared tolerance and nearBottomForSend on the 80 px band; nearBottom is gone", () => {
+  assert.match(RENDER, /function atBottom\(c: HTMLElement\): boolean \{\s*\n\s*return atBottomDist\(c\.scrollHeight - c\.scrollTop - c\.clientHeight\);/);
+  assert.match(RENDER, /function nearBottomForSend\(c: HTMLElement\): boolean \{\s*\n\s*return c\.scrollHeight - c\.scrollTop - c\.clientHeight < 80;/);
+  assert.match(RENDER, /import \{[^}]*\batBottomDist\b[^}]*\} from "\.\/scroll-keep";/);
+  assert.doesNotMatch(RENDER, /\bnearBottom\(/, "the one-band helper must not come back under its old name");
+});
+
+test("follow mode and the chip read atBottom at every site", () => {
+  const follow = [
+    /const stick = content\.scrollHeight > content\.clientHeight \+ 2 && atBottom\(content\);/,          // appendActive
+    /const off = c\.scrollHeight > c\.clientHeight \+ 2 && !atBottom\(c\);/,                             // updateJumpBtn
+    /followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, atBottom\(c\), pendingBuildRaf != null\);/,   // the scroll record
+    /cur\.stick = atBottom\(content\);/,                                                                  // the leaving tab's save
+    /_wasNear = !_scrollContent \|\| !_v0 \|\| !_v0\.shown \|\| atBottom\(_scrollContent\);/,             // the rebuild branch
+    /content\.clientHeight > 0 && !atBottom\(content\) \? captureScrollAnchor\(content, av\) : null;/,      // rerenderAll's keep
+    /\(!atBottom\(content\) \? captureScrollAnchor\(content, v\) : null\)\) : null;/,                       // showActive's keep
+    /content\.clientHeight > 0 && !atBottom\(content\)\) \{\s*\n\s*writeScroll\(content, content\.scrollTop \+ \(h - lastH\), "box-resize"\);/,   // box-resize compensation
+    /stick = !!content && atBottom\(content\);/,                                                          // tab-strip drag
+  ];
+  for (const re of follow) assert.match(RENDER, re, String(re));
+  assert.equal((RENDER.match(/\batBottom\(/g) || []).length, 10, "nine call sites plus the definition");
+});
+
+test("only the user's own send reveal keeps the 80 px band", () => {
+  assert.match(RENDER, /const wasAtBottom = !!content && nearBottomForSend\(content\);[^\n]*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) writeScroll\(content, content\.scrollHeight, "optimistic-send", true\);/);
+  assert.equal((RENDER.match(/\bnearBottomForSend\(/g) || []).length, 2, "one call site plus the definition");
+});
+
+test("the tolerance is one constant: followTail reads it too", () => {
+  const KEEP = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "scroll-keep.ts"), "utf8");
+  assert.match(KEEP, /export const AT_BOTTOM_PX = 2;/);
+  assert.match(KEEP, /export function followTail\(distBefore: number, heightBefore: number, heightAfter: number\): boolean \{\s*\n\s*if \(atBottomDist\(distBefore\)\) return true;/);
+});

--- a/ui/webview/follow-tail.test.ts
+++ b/ui/webview/follow-tail.test.ts
@@ -1,5 +1,5 @@
 // T262 (the user 2026-09-08, "jumped up slightly on my scroll in many, many sessions"): appendActive pinned a
-// reader within the 80 px follow threshold to the bottom on EVERY frame — a status-only chatTail included — so
+// reader within the then 80 px follow threshold to the bottom on EVERY frame — a status-only chatTail included — so
 // wheeling up from the tail of a working session snapped back within the first 80 px, over and over. The
 // two-kernel harness reproduced it: a stop 60 px above the bottom moved 60 px to the bottom in a quiet window
 // with scrollHeight unchanged (compact mode), and both modes snapped on the next frame. Rule: follow the tail
@@ -23,7 +23,7 @@ test("the harness case: 60 px above the bottom, a frame that adds nothing → no
 });
 
 test("render.ts appendActive measures before the rebuild and pins only when followTail says so", () => {
-  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail \} from "\.\/scroll-keep";/);
+  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist \} from "\.\/scroll-keep";/);
   const m = RENDER.match(/^function appendActive\(\) \{([\s\S]*?)\n\}/m);
   assert.ok(m, "appendActive");
   const body = m![1];

--- a/ui/webview/jump-bottom.test.ts
+++ b/ui/webview/jump-bottom.test.ts
@@ -1,7 +1,9 @@
 // The jump-to-newest chip (the user 2026-08-31): scrolled-up reading leaves follow mode — and the
 // send gate keeps it that way — so a floating ↓ at the transcript's bottom-center is the deliberate
 // way back: click = snap to the bottom + re-engage follow (today's at-bottom behavior). Visibility
-// reads the SAME nearBottom threshold the stick rule and the send gate use — one definition.
+// reads the SAME atBottom read the stick rule uses — one definition, the TRUE bottom (T262c: the send
+// gate keeps its own wider 80 px band, nearBottomForSend, so the chevron appears the moment the reader
+// leaves the bottom rather than 80 px later).
 // render.ts has import-time DOM side effects → source pins + an executed replica of the decisions
 // (send-scroll-preserve.test.ts precedent).
 import { test } from "node:test";
@@ -19,8 +21,8 @@ test("the chip lives on BODY, never inside the re-rendered #content — click-sa
   assert.match(RENDER, /jumpBtn\.id = "jump-bottom";/);
 });
 
-test("visibility reads the one nearBottom definition, off a passive scroll listener — no polling", () => {
-  assert.match(RENDER, /const off = c\.scrollHeight > c\.clientHeight \+ 2 && !nearBottom\(c\);/);
+test("visibility reads the one atBottom definition, off a passive scroll listener — no polling", () => {
+  assert.match(RENDER, /const off = c\.scrollHeight > c\.clientHeight \+ 2 && !atBottom\(c\);/);
   assert.match(RENDER, /c\.addEventListener\("scroll", updateJumpBtn, \{ passive: true \}\);/);
   // a hidden pane measures 0 — the chip must not float over nothing
   assert.match(RENDER, /if \(!c \|\| c\.clientHeight <= 0\) \{ jumpBtn\.hidden = true; return; \}/);
@@ -36,7 +38,7 @@ test("click snaps to the bottom AND sets the view's stick — the explicit re-en
 
 test("the send gate stays byte-intact — the chip is the sanctioned mover, sends are not", () => {
   // T187's contract, cross-pinned from this feature so a regression here names both
-  assert.match(RENDER, /const wasAtBottom = !!content && nearBottom\(content\);\s*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) writeScroll\(content, content\.scrollHeight, "optimistic-send", true\);/);
+  assert.match(RENDER, /const wasAtBottom = !!content && nearBottomForSend\(content\);[^\n]*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) writeScroll\(content, content\.scrollHeight, "optimistic-send", true\);/);
 });
 
 test("the chip wears the menu-card vocabulary and survives [hidden] against its own display:flex", () => {
@@ -62,12 +64,12 @@ test("a short PILL with a stemless chevron — the circle + full arrow were the 
 
 // ── executed replica: visibility + click + follow ─────────────────────────────────────────────────
 type Box = { scrollHeight: number; clientHeight: number; scrollTop: number };
-const nearBottom = (c: Box) => c.scrollHeight - c.scrollTop - c.clientHeight < 80;   // render.ts nearBottom
+const atBottom = (c: Box) => c.scrollHeight - c.scrollTop - c.clientHeight <= 2;   // render.ts atBottom (T262c: the true bottom)
 const maxScroll = (c: Box) => Math.max(0, c.scrollHeight - c.clientHeight);
-const visible = (c: Box) => c.clientHeight > 0 && c.scrollHeight > c.clientHeight + 2 && !nearBottom(c);
+const visible = (c: Box) => c.clientHeight > 0 && c.scrollHeight > c.clientHeight + 2 && !atBottom(c);
 const clickJump = (c: Box, v: { stick: boolean }) => { c.scrollTop = maxScroll(c); v.stick = true; };
 const append = (c: Box, growth: number) => {          // appendActive's stick rule
-  const stick = c.scrollHeight > c.clientHeight + 2 && nearBottom(c);
+  const stick = c.scrollHeight > c.clientHeight + 2 && atBottom(c);
   const before = c.scrollTop;
   c.scrollHeight += growth;
   c.scrollTop = stick ? maxScroll(c) : before;
@@ -75,7 +77,8 @@ const append = (c: Box, growth: number) => {          // appendActive's stick ru
 
 test("replica: shown only when overflowing AND off the bottom", () => {
   assert.equal(visible({ scrollHeight: 5000, clientHeight: 600, scrollTop: 4400 }), false, "at bottom");
-  assert.equal(visible({ scrollHeight: 5000, clientHeight: 600, scrollTop: 4360 }), false, "inside the 80px band");
+  assert.equal(visible({ scrollHeight: 5000, clientHeight: 600, scrollTop: 4398 }), false, "2 px of sub-pixel slack is the bottom");
+  assert.equal(visible({ scrollHeight: 5000, clientHeight: 600, scrollTop: 4360 }), true, "40 px up: the old band hid the chip here (T262c), now it shows at once");
   assert.equal(visible({ scrollHeight: 5000, clientHeight: 600, scrollTop: 1000 }), true, "mid-history");
   assert.equal(visible({ scrollHeight: 500, clientHeight: 600, scrollTop: 0 }), false, "no overflow, no chip");
   assert.equal(visible({ scrollHeight: 5000, clientHeight: 0, scrollTop: 0 }), false, "hidden pane");

--- a/ui/webview/optimistic-send.test.ts
+++ b/ui/webview/optimistic-send.test.ts
@@ -35,17 +35,17 @@ test("the plain send registers an optimistic bubble; follow-up/quote sends keep 
   assert.match(RENDER, /function registerOptimistic\(id: string, text: string, imgPaths\?: string\[\]\): void/);   // + the dragged-image paths → echo thumbnails (2026-08-25)
   // the active-tab arm still paints via appendActive (the snap gate moved ahead of it, 2026-08-30)
   assert.match(RENDER, /if \(v\) v\.stale = true;\s*\n\s*if \(id === activeId\) \{/);
-  assert.match(RENDER, /const wasAtBottom = !!content && nearBottom\(content\);\s*\n\s*appendActive\(\);/);
+  assert.match(RENDER, /const wasAtBottom = !!content && nearBottomForSend\(content\);[^\n]*\s*\n\s*appendActive\(\);/);
 });
 
 test("your OWN send reveals itself from the TAIL only — scrolled up, the viewport stays put", () => {
   // The 2026-08-09 always-reveal snap (Enter = intent to see the message) survives where it belongs:
-  // at — or within the stick rule's 80px of — the bottom. Scrolled UP reading history, the user's
+  // at — or within nearBottomForSend's 80px of — the bottom (the send band; follow mode itself reads the true bottom since T262c). Scrolled UP reading history, the user's
   // 2026-08-30 ruling overrules it: the send must not move the scroll position at all, so the snap
-  // is gated on a nearBottom read taken BEFORE appendActive lands the bubble (the append grows
+  // is gated on a nearBottomForSend read taken BEFORE appendActive lands the bubble (the append grows
   // scrollHeight, which would misread a tail-sitter as scrolled-up). Behavioral scenarios live in
   // send-scroll-preserve.test.ts.
-  assert.match(RENDER, /const wasAtBottom = !!content && nearBottom\(content\);\s*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) writeScroll\(content, content\.scrollHeight, "optimistic-send", true\);/);
+  assert.match(RENDER, /const wasAtBottom = !!content && nearBottomForSend\(content\);[^\n]*\s*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) writeScroll\(content, content\.scrollHeight, "optimistic-send", true\);/);
   // the unconditional form is retired everywhere — nothing snaps a scrolled-up reader on send
   assert.doesNotMatch(RENDER, /if \(content\) (?:content\.scrollTop = content\.scrollHeight|writeScroll\(content, content\.scrollHeight)/);
 });

--- a/ui/webview/render-scroll.test.ts
+++ b/ui/webview/render-scroll.test.ts
@@ -41,9 +41,9 @@ test("a placeholder's first content-bearing build LANDS (bottom), it does not ap
 
 test("a rebuild NEVER snaps a scrolled-up reader to the bottom — it captures + restores their anchor", () => {
   // even a genuine rebuild (new tab / fork / slid tail-window) preserves position for a scrolled-up reader:
-  // capture nearBottom + the anchor BEFORE dropping the DOM, restore after (the user 2026-07-06). A true
+  // capture atBottom + the anchor BEFORE dropping the DOM, restore after (the user 2026-07-06). A true
   // fork's anchor uuid isn't in the new transcript, so restoreScrollAnchor no-ops → it stays at the bottom.
-  assert.match(RENDER, /_wasNear = !_scrollContent \|\| !_v0 \|\| !_v0\.shown \|\| nearBottom\(_scrollContent\);/);
+  assert.match(RENDER, /_wasNear = !_scrollContent \|\| !_v0 \|\| !_v0\.shown \|\| atBottom\(_scrollContent\);/);
   assert.match(RENDER, /_scrollAnchor = \(!_wasNear && _scrollContent && _v0\) \? captureScrollAnchor\(_scrollContent, _v0\) : null;/);
   assert.match(RENDER, /if \(!_wasNear && _scrollAnchor && _scrollContent\) \{[\s\S]*?restoreScrollAnchor\(_scrollContent, v1, _scrollAnchor\)/);
 });
@@ -64,10 +64,10 @@ test("sharesAnyUuid: a continuation shares a uuid, a wholesale fork shares none"
 });
 
 test("appendActive snaps only when the user is already near the bottom of OVERFLOWING content", () => {
-  // the slack rule (the user 2026-08-25): while nothing overflows, nearBottom is trivially true —
+  // the slack rule (the user 2026-08-25): while nothing overflows, atBottom is trivially true —
   // ungated, the very append crossing the overflow boundary yanked the view; now streaming into
   // slack writes in place and grows the scrollbar, and the stick engages only once overflowing
-  assert.match(RENDER, /const stick = content\.scrollHeight > content\.clientHeight \+ 2 && nearBottom\(content\);[\s\S]*?if \(stick && followTail\(distBefore, heightBefore, content\.scrollHeight\)\) writeScroll\(content, content\.scrollHeight, "append-stick", true\)/,   // …and only when there is new content to follow (T262 followTail)
+  assert.match(RENDER, /const stick = content\.scrollHeight > content\.clientHeight \+ 2 && atBottom\(content\);[\s\S]*?if \(stick && followTail\(distBefore, heightBefore, content\.scrollHeight\)\) writeScroll\(content, content\.scrollHeight, "append-stick", true\)/,   // …and only when there is new content to follow (T262 followTail)
     "tail-append follows the live edge only if content overflows AND the reader was at the bottom");
   // the popover's thread list speaks the same rule
   assert.match(RENDER, /const overflowed = list\.scrollHeight > list\.clientHeight \+ 2;/);
@@ -197,7 +197,7 @@ test("ResizeObservers on #tabbar AND #ledger compensate #content.scrollTop by th
   assert.match(RENDER, /for \(const boxId of \["tabbar", "ledger"\]\)/, "both boxes above the transcript are observed");
   assert.match(RENDER, /const tro = new ResizeObserver/, "via a dedicated per-box ResizeObserver");
   // shift scrollTop by (new - old) box height — only when not stuck to bottom and the pane is visible
-  assert.match(RENDER, /content\.clientHeight > 0 && !nearBottom\(content\)/,
+  assert.match(RENDER, /content\.clientHeight > 0 && !atBottom\(content\)/,
     "skipped when stuck to the bottom or the pane is hidden");
   assert.match(RENDER, /writeScroll\(content, content\.scrollTop \+ \(h - lastH\), "box-resize"\)/, "compensates by the exact height delta");
   assert.match(RENDER, /if \(v\) v\.scrollTop = content\.scrollTop/, "keeps the per-view saved scroll in sync");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -54,7 +54,7 @@ import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser
 import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
 import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
-import { followReader, keepPlaceAcrossShow, followTail } from "./scroll-keep";
+import { followReader, keepPlaceAcrossShow, followTail, atBottomDist } from "./scroll-keep";
 import { retainLiveOmitted } from "./tab-order";
 import { userTurnShows } from "./user-turn-content";
 import { ScrollDiagBudget, classifyScroll, scrollWriteRow } from "./scroll-write";
@@ -455,13 +455,14 @@ function registerOptimistic(id: string, text: string, imgPaths?: string[]): void
   if (v) v.stale = true;
   if (id === activeId) {
     // Your own send reveals itself only from the TAIL, measured BEFORE the bubble lands (the append
-    // grows scrollHeight, which would misread a tail-sitter as scrolled-up). At — or within the
-    // stick rule's 80px of — the bottom, hitting Enter scrolls to the new bubble, exactly once, at
-    // send time (the user 2026-08-09, whose send painted below the fold and looked lost). Scrolled
-    // UP reading history, the viewport stays exactly where it is and the bubble waits below (the
+    // grows scrollHeight, which would misread a tail-sitter as scrolled-up). At — or within
+    // nearBottomForSend's 80 px of — the bottom, hitting Enter scrolls to the new bubble, exactly once,
+    // at send time (the user 2026-08-09, whose send painted below the fold and looked lost). That band is
+    // deliberately wider than follow mode's true-bottom read (T262c): the send is the reader's own act.
+    // Scrolled UP reading history, the viewport stays exactly where it is and the bubble waits below (the
     // user 2026-08-30, yanked mid-read by the unconditional snap that used to live here).
     const content = document.getElementById("content");
-    const wasAtBottom = !!content && nearBottom(content);
+    const wasAtBottom = !!content && nearBottomForSend(content);   // the send band: the user's own send reveals itself
     appendActive();
     if (content && wasAtBottom) writeScroll(content, content.scrollHeight, "optimistic-send", true);
   }
@@ -9238,7 +9239,24 @@ function filterPicker(q: string) {
   setActiveRow(creating && q.trim() ? null : pickerRows()[0] ?? null);
 }
 
-function nearBottom(c: HTMLElement): boolean {
+// Two readings of "at the bottom", never one (T262c, the user 2026-09-08, who wheeled up from the tail of a
+// working session, saw no go-to-bottom chevron for a stretch, and within that stretch had the view snap back;
+// they expected the chevron the moment they left the bottom). One 80 px band used to drive BOTH follow mode
+// (appendActive's stick, followReader's record, the leaving-tab save, the rebuild's _wasNear, the resize
+// compensations) AND the jump chip, so for the first 80 px of a deliberate scroll-up the pane still counted the
+// reader as at the bottom: no chip, and every content-height change of a working session — streaming text, a
+// landed card — re-pinned them to the bottom through followTail's height-changed branch. That is the snapback
+// with no predictable interval: it fired whenever the session appended while they were inside the band.
+// Follow mode and the chip now read the TRUE bottom (atBottom: within the 2 px sub-pixel tolerance followTail
+// already used), so leaving the bottom by more than 2 px leaves follow mode and shows the chip at once, and the
+// only ways back are a scroll to the true bottom or the chip. The 80 px band survives ONLY as nearBottomForSend,
+// for the user's own send revealing itself (registerOptimistic; the user 2026-08-09, whose send painted below
+// the fold and looked lost): the question there is whether they meant to be at the tail, and a reader a few
+// lines up who hits Enter still gets to see their bubble. Two names so the two intents cannot be confused again.
+function atBottom(c: HTMLElement): boolean {
+  return atBottomDist(c.scrollHeight - c.scrollTop - c.clientHeight);
+}
+function nearBottomForSend(c: HTMLElement): boolean {
   return c.scrollHeight - c.scrollTop - c.clientHeight < 80;
 }
 
@@ -9953,11 +9971,11 @@ function rerenderAll(): void {
   cancelPrebuild(); // the queued plan is now stale (every view reset below) — re-warm after showActive
   // The reader's place, captured BEFORE the clear below empties the active view (T249 review find, 2026-09-08):
   // a settings change re-renders the transcript under a reader who may be scrolled up, and once the DOM is
-  // gone there is no anchor to capture and the box no longer overflows. Near the bottom → nothing to keep
+  // gone there is no anchor to capture and the box no longer overflows. At the bottom → nothing to keep
   // (follow mode lands there); a hidden pane has nothing to keep either. showActive restores it after the land.
   const content = document.getElementById("content");
   const av = activeId ? views.get(activeId) : null;
-  const keep = av && av.shown && content && content.clientHeight > 0 && !nearBottom(content) ? captureScrollAnchor(content, av) : null;
+  const keep = av && av.shown && content && content.clientHeight > 0 && !atBottom(content) ? captureScrollAnchor(content, av) : null;   // follow mode: only a true tail-sitter lands at the bottom
   for (const v of views.values()) { while (v.el.firstChild) v.el.removeChild(v.el.firstChild); v.rendered = 0; v.stale = false; v.winStart = 0; v.winEnd = 0; v.avgTurnH = undefined; v.spacerCount = undefined; v.spacerCountBot = undefined; v.unitTotal = undefined; }
   showActive(keep);
   schedulePrebuild(); // rebuild every off-screen view in idle under the new setting, so switches stay instant
@@ -10183,7 +10201,7 @@ function showActive(keep?: { uuid: string; y: number } | null) {
   // decision, and a restore over its landing would undo the jump the reader asked for (review find, 2026-09-08)
   const navigating = !!pendingAnchor || pendingAnchorT != null || (!!seek && seek.sid === activeId);
   const reshow = keepPlaceAcrossShow(v, v.el.style.display !== "none", content.clientHeight > 0, navigating);
-  const keepAnchor = reshow ? (keep !== undefined ? keep : (!nearBottom(content) ? captureScrollAnchor(content, v) : null)) : null;
+  const keepAnchor = reshow ? (keep !== undefined ? keep : (!atBottom(content) ? captureScrollAnchor(content, v) : null)) : null;   // follow mode: off the true bottom keeps its place
   // Bound the switch. A view the user scrolled to the top of has had its window expanded to the WHOLE
   // transcript (winStart crept to 0 via lazy-expand), and compact mode renders the whole folded stream —
   // either way, revealing thousands of nodes is the big-session switch lag (the user 2026-06-25: 4144 turns
@@ -10403,10 +10421,11 @@ function appendActive() {
   const v = views.get(activeId);
   // Follow-the-tail engages ONLY once content actually overflows (the user 2026-08-25: with slack
   // below, a streaming reply should write IN PLACE and grow a scrollbar, not jump the view to the
-  // bottom). nearBottom is trivially true while nothing overflows, so without this gate the very
+  // bottom). atBottom is trivially true while nothing overflows, so without this gate the very
   // append that crosses the overflow boundary yanked the view. Overflowing + genuinely at the
   // bottom keeps the existing stick; scrolled-up keeps its never-yank rule.
-  const stick = content.scrollHeight > content.clientHeight + 2 && nearBottom(content);
+  // follow mode: the TRUE bottom (T262c), never the send band
+  const stick = content.scrollHeight > content.clientHeight + 2 && atBottom(content);
   const before = content.scrollTop;
   const heightBefore = content.scrollHeight;
   const distBefore = heightBefore - before - content.clientHeight;
@@ -10445,8 +10464,9 @@ if (typeof ResizeObserver === "function") {
 // ── jump to newest (the user 2026-08-31) ─────────────────────────────────────────────────────────
 // Scrolled-up reading leaves follow mode, and the send gate keeps it that way — this chip is the
 // deliberate way BACK. Visible only while the transcript overflows AND the view is off the bottom,
-// read through the SAME nearBottom threshold appendActive's stick and the send gate use (one
-// definition, never a second). Click = snap to the bottom + set the view's stick: follow mode
+// read through the SAME atBottom read appendActive's stick uses (one definition, never a second; the
+// send gate keeps its own wider band, nearBottomForSend, on purpose — T262c). So the chevron appears
+// the moment the reader is more than 2 px off the bottom. Click = snap to the bottom + set the view's stick: follow mode
 // re-engaged exactly as today's at-bottom behavior — every subsequent append recomputes stick from
 // the at-bottom position and keeps descending until the user scrolls up, which re-shows the chip
 // from the same listener. It lives on BODY, never inside #content, so window re-renders cannot
@@ -10464,7 +10484,7 @@ jumpBtn.innerHTML = '<svg viewBox="0 0 24 24" width="16" height="16" fill="none"
 function updateJumpBtn(): void {
   const c = document.getElementById("content");
   if (!c || c.clientHeight <= 0) { jumpBtn.hidden = true; return; }   // hidden pane measures 0 — no chip
-  const off = c.scrollHeight > c.clientHeight + 2 && !nearBottom(c);
+  const off = c.scrollHeight > c.clientHeight + 2 && !atBottom(c);   // the chip: shown the moment the reader leaves the true bottom
   jumpBtn.hidden = !off;
   if (off) jumpBtn.style.bottom = (Math.max(0, window.innerHeight - c.getBoundingClientRect().bottom) + 8) + "px";
 }
@@ -10491,7 +10511,7 @@ window.addEventListener("resize", updateJumpBtn);
 // the reader's own scrolling. So the spot named where the tab was when last left, and a full show of a
 // shown tab (a fork/first-build frame, a settings rerender, a revive failure, a dismissal's fallback)
 // snapped the reader back there. Every scroll of the active view now records its position and its
-// follow-mode (the same nearBottom threshold appendActive and the jump chip read), passive, no timer.
+// follow-mode (the same atBottom read appendActive and the jump chip use), passive, no timer.
 // Programmatic scrolls (a land, an anchor restore) fire the same event, so the record is always the truth —
 // with ONE exception, the transient a DEFERRED build leaves (review find, 2026-09-08): showActive reveals
 // the entering view before its heavy build runs in the next frame, the browser clamps scrollTop to that
@@ -10504,7 +10524,7 @@ window.addEventListener("resize", updateJumpBtn);
   const c = document.getElementById("content");
   if (c) c.addEventListener("scroll", () => {
     if (c.clientHeight <= 0) return;
-    followReader(activeId ? views.get(activeId) : null, c.scrollTop, nearBottom(c), pendingBuildRaf != null);
+    followReader(activeId ? views.get(activeId) : null, c.scrollTop, atBottom(c), pendingBuildRaf != null);
     // the scroll nobody's code asked for is the user's (T262): filed so a recording lines up with the journal;
     // a write's own echo (within a pixel of the value written) is consumed here and never read as a gesture
     if (classifyScroll(c.scrollTop, lastScrollWriteAfter) === "write-echo") lastScrollWriteAfter = null;
@@ -10527,7 +10547,8 @@ if (typeof ResizeObserver === "function") {
     const tro = new ResizeObserver((entries) => {
       const h = entries[0]?.contentRect?.height ?? 0;
       const content = document.getElementById("content");
-      if (content && lastH >= 0 && h !== lastH && content.clientHeight > 0 && !nearBottom(content)) {
+      // follow mode: an off-bottom reader's line stays still
+      if (content && lastH >= 0 && h !== lastH && content.clientHeight > 0 && !atBottom(content)) {
         writeScroll(content, content.scrollTop + (h - lastH), "box-resize");
         const v = activeId ? views.get(activeId) : null;
         if (v) v.scrollTop = content.scrollTop;               // keep the per-view saved position in sync
@@ -10596,7 +10617,7 @@ if (typeof ResizeObserver === "function") {
       // weeks later with no visible cause.
       startH = cap != null ? clampTabbarH(cap, window.innerHeight) : TABBAR_H_DEFAULT;
       const content = document.getElementById("content");
-      stick = !!content && nearBottom(content);
+      stick = !!content && atBottom(content);   // follow mode at drag start: the true bottom
       pid = e.pointerId;
       // capture so the drag survives leaving the pane; a pointer already gone throws — the window
       // listeners below carry the drag either way, so a failed capture must not abort the setup
@@ -13378,7 +13399,7 @@ function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: s
   const content = document.getElementById("content");
   if (content && activeId && activeId !== id) {
     const cur = views.get(activeId);
-    if (cur) { cur.scrollTop = content.scrollTop; cur.stick = nearBottom(content); }
+    if (cur) { cur.scrollTop = content.scrollTop; cur.stick = atBottom(content); }   // the leaving tab's follow mode: the true bottom
   }
   // Stash the leaving tab's draft; show the entering tab's own (usually empty).
   const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
@@ -13516,7 +13537,7 @@ function upsert(msg: any) {
   if (msg.id === activeId && !(existed && !forked && !firstBuild)) {   // only the rebuild branch (appendActive preserves on its own)
     _scrollContent = document.getElementById("content");
     const _v0 = views.get(msg.id);
-    _wasNear = !_scrollContent || !_v0 || !_v0.shown || nearBottom(_scrollContent);
+    _wasNear = !_scrollContent || !_v0 || !_v0.shown || atBottom(_scrollContent);   // only a true tail-sitter follows a rebuild
     _scrollAnchor = (!_wasNear && _scrollContent && _v0) ? captureScrollAnchor(_scrollContent, _v0) : null;
   }
   if (forked) {

--- a/ui/webview/scroll-keep-on-show.test.ts
+++ b/ui/webview/scroll-keep-on-show.test.ts
@@ -65,7 +65,7 @@ test("keepPlaceAcrossShow: only a displayed, visible, already-shown view with no
 test("render.ts: the reshow decision counts a live durable seek for the tab as navigation, and rerenderAll hands showActive the anchor it captured BEFORE emptying the DOM", () => {
   assert.match(RENDER, /const navigating = !!pendingAnchor \|\| pendingAnchorT != null \|\| \(!!seek && seek\.sid === activeId\);/);
   assert.match(RENDER, /^function showActive\(keep\?: \{ uuid: string; y: number \} \| null\) \{/m);
-  assert.match(RENDER, /const keepAnchor = reshow \? \(keep !== undefined \? keep : \(!nearBottom\(content\) \? captureScrollAnchor\(content, v\) : null\)\) : null;/);
+  assert.match(RENDER, /const keepAnchor = reshow \? \(keep !== undefined \? keep : \(!atBottom\(content\) \? captureScrollAnchor\(content, v\) : null\)\) : null;[^\n]*/);
   const ra = RENDER.match(/^function rerenderAll\(\): void \{([\s\S]*?)\n\}/m);
   assert.ok(ra, "rerenderAll");
   const body = ra![1];
@@ -77,9 +77,9 @@ test("render.ts: the reshow decision counts a live durable seek for the tab as n
 });
 
 test("render.ts: the #content scroll listener keeps the active view's saved spot current (passive, no timer)", () => {
-  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail \} from "\.\/scroll-keep";/);   // + followTail (T262: follow only on new content)
+  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist \} from "\.\/scroll-keep";/);   // + followTail (T262: follow only on new content)
   // …and stands down while a deferred build is pending: the reveal's clamp fires a scroll event before the land
-  assert.match(RENDER, /c\.addEventListener\("scroll", \(\) => \{\n\s*if \(c\.clientHeight <= 0\) return;\n\s*followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, nearBottom\(c\), pendingBuildRaf != null\);\n(?:.*\n){0,4}?\s*\}, \{ passive: true \}\);/);
+  assert.match(RENDER, /c\.addEventListener\("scroll", \(\) => \{\n\s*if \(c\.clientHeight <= 0\) return;\n\s*followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, atBottom\(c\), pendingBuildRaf != null\);\n(?:.*\n){0,4}?\s*\}, \{ passive: true \}\);/);
   // landActive's landing rule itself is unchanged — its INPUT is what the fix repairs
   assert.match(RENDER, /if \(!v\.shown \|\| v\.stick\) writeScroll\(content, content\.scrollHeight, "land-bottom", true\);\n\s*else writeScroll\(content, v\.scrollTop, "land-saved"\);/);   // (T262: every #content write rides writeScroll)
 });
@@ -89,7 +89,7 @@ test("render.ts: showActive keeps the reader's place across a re-show of the vie
   assert.ok(m, "showActive");
   const body = m![1];
   assert.match(body, /const reshow = keepPlaceAcrossShow\(v, v\.el\.style\.display !== "none", content\.clientHeight > 0, navigating\);/);
-  assert.match(body, /const keepAnchor = reshow \? \(keep !== undefined \? keep : \(!nearBottom\(content\) \? captureScrollAnchor\(content, v\) : null\)\) : null;/, "captured BEFORE the rebuild, like appendActive — or handed in by a caller that had to empty the DOM first");
+  assert.match(body, /const keepAnchor = reshow \? \(keep !== undefined \? keep : \(!atBottom\(content\) \? captureScrollAnchor\(content, v\) : null\)\) : null;[^\n]*/, "captured BEFORE the rebuild, like appendActive — or handed in by a caller that had to empty the DOM first");
   const restores = body.match(/if \(keepAnchor(?: && cc)?\) restoreScrollAnchor\(/g) || [];
   assert.equal(restores.length, 2, "restored after landActive on the light path AND inside the deferred heavy build");
   // the big-view re-collapse to the tail is a SWITCH rule: a re-show of the view on screen must not snap it to the bottom

--- a/ui/webview/scroll-keep.ts
+++ b/ui/webview/scroll-keep.ts
@@ -52,15 +52,30 @@ export function keepPlaceAcrossShow(v: KeepView, displayed: boolean, visible: bo
   return v.shown && displayed && visible && !navigating;
 }
 
-/** Follow-the-tail after an append, for a reader who was near the bottom (T262, the user 2026-09-08: "jumped up
- *  slightly on my scroll" in busy sessions). A tab within the 80 px follow threshold used to be pinned to the
- *  bottom on EVERY frame the pane received — including a status-only tail that changed no content — so a reader
- *  wheeling up from the tail of a working session was snapped back within the first 80 px, again and again (the
- *  harness reproduced it: a 60 px stop moved 60 px to the bottom in a quiet window with the content height
- *  unchanged). The bottom is followed only when there is something new to follow: the content's height
- *  changed, or the reader was already at the very bottom (where the pin is a no-op). Pure, so node executes it.
- *  `distBefore` = scrollHeight − scrollTop − clientHeight before the rebuild. */
+/** The follow-mode tolerance (T262c, the user 2026-09-08): a reader within this many pixels of the bottom IS at
+ *  the bottom — fractional scroll positions on a scaled display leave up to a pixel of slack at the true end —
+ *  and one pixel further they have LEFT it: follow mode is off and the go-to-bottom chip shows. render.ts's
+ *  atBottom reads this for appendActive's stick, followReader's record, the leaving-tab save, the rebuild's
+ *  at-bottom capture, the resize compensations and the chip. The 80 px band that used to drive all of those
+ *  survives only for the user's own send revealing itself (render.ts nearBottomForSend). */
+export const AT_BOTTOM_PX = 2;
+export function atBottomDist(dist: number): boolean {
+  return dist <= AT_BOTTOM_PX;
+}
+
+/** Follow-the-tail after an append, for a reader whose view is in follow mode (T262, the user 2026-09-08: "jumped
+ *  up slightly on my scroll" in busy sessions). A tab within the old 80 px band used to be pinned to the bottom on
+ *  EVERY frame the pane received — including a status-only tail that changed no content — so a reader wheeling
+ *  up from the tail of a working session was snapped back within the first 80 px, again and again (the harness
+ *  reproduced it: a 60 px stop moved 60 px to the bottom in a quiet window with the content height unchanged).
+ *  The bottom is followed only when there is something new to follow: the content's height changed, or the
+ *  reader was already at the very bottom (where the pin is a no-op). T262c then found the height-changed branch
+ *  was the remaining snapback — a reader 30 px up in a streaming session was re-pinned by every append — and
+ *  moved follow mode itself onto the true bottom (atBottomDist), so a stick now implies `distBefore` within the
+ *  tolerance and this answers true for it; the height branch stays as the executable statement of the rule
+ *  should a wider stick ever return. Pure, so node executes it. `distBefore` = scrollHeight − scrollTop −
+ *  clientHeight before the rebuild. */
 export function followTail(distBefore: number, heightBefore: number, heightAfter: number): boolean {
-  if (distBefore <= 2) return true;
+  if (atBottomDist(distBefore)) return true;
   return heightAfter !== heightBefore;
 }

--- a/ui/webview/send-scroll-preserve.test.ts
+++ b/ui/webview/send-scroll-preserve.test.ts
@@ -1,8 +1,9 @@
 // Sending from the composer while scrolled UP must not move the scroll position at all: the message
 // sends, the optimistic bubble lands below the fold, and the reader stays exactly where they were
 // (the user 2026-08-30, yanked to the bottom mid-read by the old unconditional snap). Sending while
-// at — or within the stick rule's 80px of — the bottom keeps the old behavior: the view follows the
-// new bubble (the 2026-08-09 always-reveal rule, now scoped to the tail). The gate is a nearBottom
+// at — or within nearBottomForSend's 80px of — the bottom keeps the old behavior: the view follows the
+// new bubble (the 2026-08-09 always-reveal rule, now scoped to the tail). That band is the send's alone:
+// follow mode itself reads the true bottom (T262c, atBottom). The gate is a nearBottomForSend
 // read taken BEFORE appendActive lands the bubble, because the append grows scrollHeight and a
 // post-append read would misclassify a tail-sitter as scrolled-up.
 //
@@ -20,12 +21,13 @@ const RENDER = fs.readFileSync(
 // Mirrors registerOptimistic's active-tab arm + appendActive's stick rule, both pinned to source
 // below so the replica can't drift silently.
 type Box = { scrollHeight: number; clientHeight: number; scrollTop: number };
-const nearBottom = (c: Box) => c.scrollHeight - c.scrollTop - c.clientHeight < 80;   // render.ts nearBottom
+const nearBottomForSend = (c: Box) => c.scrollHeight - c.scrollTop - c.clientHeight < 80;   // render.ts nearBottomForSend (the send band)
+const atBottom = (c: Box) => c.scrollHeight - c.scrollTop - c.clientHeight <= 2;               // render.ts atBottom (follow mode, T262c)
 const maxScroll = (c: Box) => Math.max(0, c.scrollHeight - c.clientHeight);          // DOM clamps scrollTop
 function sendOwnMessage(c: Box, bubbleGrowth: number): void {
-  const wasAtBottom = nearBottom(c);                                   // measured BEFORE the append
-  // appendActive: stick only when overflowing AND near the bottom; otherwise restore the viewport
-  const stick = c.scrollHeight > c.clientHeight + 2 && nearBottom(c);
+  const wasAtBottom = nearBottomForSend(c);                            // measured BEFORE the append
+  // appendActive: stick only when overflowing AND at the true bottom; otherwise restore the viewport
+  const stick = c.scrollHeight > c.clientHeight + 2 && atBottom(c);
   const before = c.scrollTop;
   c.scrollHeight += bubbleGrowth;                                      // the bubble lands
   c.scrollTop = stick ? maxScroll(c) : before;                         // stick or anchor/before restore
@@ -50,13 +52,13 @@ test("at-bottom send still follows the new bubble", () => {
   assert.equal(c.scrollTop, 5200 - 600);
 });
 
-test("within-80px send still follows — the stick rule's near-bottom band is 'at the bottom'", () => {
+test("within-80px send still follows — the send band treats a reader a few lines up as meaning the tail", () => {
   const c: Box = { scrollHeight: 5000, clientHeight: 600, scrollTop: 5000 - 600 - 40 };    // 40px up
   sendOwnMessage(c, 200);
   assert.equal(c.scrollTop, 5200 - 600);
 });
 
-test("a send that first overflows the pane still reveals itself — nearBottom is trivially true", () => {
+test("a send that first overflows the pane still reveals itself — nearBottomForSend is trivially true", () => {
   const c: Box = { scrollHeight: 500, clientHeight: 600, scrollTop: 0 };
   sendOwnMessage(c, 400);   // 500 → 900: crosses the overflow boundary
   assert.equal(c.scrollTop, 900 - 600);
@@ -64,12 +66,12 @@ test("a send that first overflows the pane still reveals itself — nearBottom i
 
 // ── source pins: the replica models the real code ─────────────────────────────────────────────────
 
-test("registerOptimistic gates the snap on a pre-append nearBottom read", () => {
-  assert.match(RENDER, /const wasAtBottom = !!content && nearBottom\(content\);\s*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) writeScroll\(content, content\.scrollHeight, "optimistic-send", true\);/);
-  // nearBottom's 80px threshold — the replica's constant
-  assert.match(RENDER, /function nearBottom\(c: HTMLElement\): boolean \{\s*\n\s*return c\.scrollHeight - c\.scrollTop - c\.clientHeight < 80;/);
-  // appendActive's stick rule — overflow gate + nearBottom, restore otherwise
-  assert.match(RENDER, /const stick = content\.scrollHeight > content\.clientHeight \+ 2 && nearBottom\(content\);/);
+test("registerOptimistic gates the snap on a pre-append nearBottomForSend read", () => {
+  assert.match(RENDER, /const wasAtBottom = !!content && nearBottomForSend\(content\);[^\n]*\n\s*appendActive\(\);\s*\n\s*if \(content && wasAtBottom\) writeScroll\(content, content\.scrollHeight, "optimistic-send", true\);/);
+  // nearBottomForSend's 80px threshold — the replica's constant
+  assert.match(RENDER, /function nearBottomForSend\(c: HTMLElement\): boolean \{\s*\n\s*return c\.scrollHeight - c\.scrollTop - c\.clientHeight < 80;/);
+  // appendActive's stick rule — overflow gate + the TRUE bottom (T262c), restore otherwise
+  assert.match(RENDER, /const stick = content\.scrollHeight > content\.clientHeight \+ 2 && atBottom\(content\);/);
 });
 
 test("every composer-shaped send rides the same gate — staged flush and provisional adoption included", () => {

--- a/ui/webview/tabbar-resize.test.ts
+++ b/ui/webview/tabbar-resize.test.ts
@@ -80,7 +80,7 @@ test("dragging moves the EFFECTIVE cap, guarded and captured, persists on releas
     "anchored to the EFFECTIVE cap — anchoring to the rendered height silently collapsed a larger stored cap");
   assert.match(fn, /cap = clampTabbarH\(startH \+ \(e\.clientY - startY\), window\.innerHeight\);/,
     "drag DOWN grows — the cap follows the pointer");
-  assert.match(fn, /stick = !!content && nearBottom\(content\);/, "a tail-following transcript is noted at drag start…");
+  assert.match(fn, /stick = !!content && atBottom\(content\);[^\n]*/, "a tail-following transcript is noted at drag start…");
   assert.match(fn, /if \(stick && content\) writeScroll\(content, content\.scrollHeight, "tabbar-drag", true\);/,
     "…and held on the tail while the bar grows over it");
   assert.match(fn, /if \(cap != null\) localStorage\.setItem\(TABBAR_H_KEY, String\(cap\)\);/,


### PR DESCRIPTION
## Summary
The remaining scroll snapback in the chat pane: wheeling up from the tail of a working session, the go-to-bottom chevron did not appear for a stretch, and within that stretch the view snapped back to the bottom at no predictable interval (the user's report, 2026-09-08 11:00 AM PT).

**Cause.** One 80 px band (`nearBottom` in render.ts) drove BOTH follow mode and the jump chip. For the first 80 px of a deliberate scroll-up the pane still counted the reader as at the bottom: no chevron, and every content-height change of a working session (streamed text, a landed card) re-pinned them to the bottom through `followTail`'s height-changed branch. The snapback fired whenever the session appended while the reader was inside the band.

**Fix.** Two helpers, named for their intents:
- `atBottom(c)`: distance <= 2 px (`AT_BOTTOM_PX` in scroll-keep.ts, the tolerance `followTail` already used). Drives every follow-mode decision and the chip: `appendActive`'s stick, `followReader`'s record, the leaving-tab save, the rebuild branch's at-bottom capture, `rerenderAll`'s and `showActive`'s keep, the box-resize and tab-strip-drag compensations, and `updateJumpBtn`. The chevron shows the moment the reader is more than 2 px off the bottom; follow mode re-engages only by reaching the true bottom or clicking the chip.
- `nearBottomForSend(c)`: the 80 px band, kept ONLY for the user's own send revealing itself (`registerOptimistic`, the 2026-08-09 rule).

Every former call site is assigned to one helper with a one-line reason in the source (nine to `atBottom`, one to `nearBottomForSend`); `nearBottom` no longer exists and a test forbids its return.

## Evidence (two-kernel hermetic harness, headless Chromium, synthetic transcript)
Reader at the bottom of a working session, one real wheel gesture up, then 10 assistant records streamed ~1.5 s apart:

| tree | wheel | chevron visible after | samples where scrollTop moved | end distance from bottom |
|---|---|---|---|---|
| upstream/main (b896d722) | 30 px | never | 54 of 57 | 0 px (pulled back) |
| upstream/main (b896d722) | 60 px | never | 84 of 89 | 0 px (pulled back) |
| this branch | 30 px | 81 ms | 0 of 73 | 647 px |
| this branch | 60 px | 50 ms | 0 of 80 | 677 px |

Reader at the true bottom, 8 records streamed: distance from bottom stayed <= 2 px at every sample on both trees (follow mode intact).

## Tests
- New `ui/webview/at-bottom.test.ts`: executes the tolerance; a replica pinned to source shows a reader 30 px above the bottom is NOT re-pinned when the content grows and the chip is shown, the true bottom follows every append, and 3 px up leaves follow mode at once; pins both helpers, every call site's assignment, and that the old name is gone.
- Updated pins and replicas: follow-tail, jump-bottom, send-scroll-preserve, optimistic-send, render-scroll, scroll-keep-on-show, tabbar-resize.
- `npm test`: 3443 pass, 0 fail, 4 skipped; `npm run typecheck` clean. No Python changes.

## Notes
`followTail` keeps its height-changed branch as the executable statement of the rule; with the stick now read at the true bottom it answers true for every stick, and the doc says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
