### PR TITLE
A pending tag edit survives the host's transient store fault instead of being dropped as refused

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4447,6 +4447,9 @@ def _forward_tag_edit(host, body):
 # tag EDITED there after the ruling (the v2 mtime stamp) — is new information and survives, loudly.
 _PENDING_TAG_LOCK = threading.Lock()
 _PENDING_TAG_CACHE = {"rows": None}          # None = not loaded; kept in sync under the lock
+_pending_tag_faults = {}   # _pending_tag_row_key -> faulting passes so far, for each row whose host answered a retryable
+                           # store fault: the stderr line AND the dial record are written once per row per episode, and the
+                           # count rides the record that ends the episode (the apply prunes the map to the live rows)
 
 
 def _pending_tag_path():
@@ -4596,8 +4599,32 @@ def _apply_pending_tag_edits(r):
                         outcome="transport failed — retrying next pass")
             continue
         ok = bool(ans.get("ok"))
+        if not ok and ans.get("retryable"):
+            # The host ANSWERED, but did not rule: `retryable` on an ok:false body is the kernel's shape
+            # for a store fault (the /tag route's tag store unreadable or unwritable at that moment; the
+            # PR-watch route's save fault wears the same key) -- the disk's answer, not the host's. A
+            # refusal WITHOUT it is the host's own words (no such tag, a name already taken) and stays
+            # terminal below. Until this arm (review find, 2026-09-08) the fault retired the row as a
+            # refusal, and a pending delete or rename was lost to a transient disk fault on the host --
+            # the very case the journal exists to survive. Kept for the next pass, like a transport
+            # failure. Said ONCE per row per episode -- the stderr line and the dial record alike (a
+            # host whose disk stays bad would otherwise write a record every 15 s pass and rotate every
+            # host's dial history away within days); the passes are counted, and the count rides the
+            # record that ends the episode below.
+            fault = ans.get("error") or "?"
+            key = _pending_tag_row_key(row)
+            _pending_tag_faults[key] = _pending_tag_faults.get(key, 0) + 1
+            if _pending_tag_faults[key] == 1:
+                _tunnel_log(host, "pending-tag-edit", name=row.get("name"), op=_row_op(row),
+                            outcome="the host's tag store faulted: %s — kept; retried every pass, recorded once" % fault)
+                sys.stderr.write('pending-tag-edits: the %s of "%s" on %s stays queued \u2014 the host answered but '
+                                 'could not use its tag store just now (%s); retrying next pass\n'
+                                 % (_row_op(row), row.get("name"), host, fault))
+            continue
+        faults = _pending_tag_faults.pop(_pending_tag_row_key(row), 0)     # the episode ends with the host's answer
         _tunnel_log(host, "pending-tag-edit", name=row.get("name"), op=_row_op(row),
-                    outcome=("applied" if ok else "refused by the host: %s" % (ans.get("error") or "?")))
+                    outcome=("applied" if ok else "refused by the host: %s" % (ans.get("error") or "?"))
+                    + (" after %d faulting pass%s" % (faults, "" if faults == 1 else "es") if faults else ""))
         retired.append(row)                      # a refusal is the host's own answer — terminal
         applied += 1 if ok else 0
     if retired:
@@ -4605,7 +4632,19 @@ def _apply_pending_tag_edits(r):
         _save_pending_tag_rows(keep)
         r.pop("_views_at", None)                 # re-read the post-apply truth next pass
         _mark_views_dirty()
+    # a fault episode ends with its row: landed or retired here, or superseded by a later ruling
+    # (_queue_pending_tag_edit coalesces) -- a row queued afresh for the same tag is said afresh
+    live = {_pending_tag_row_key(x) for x in _pending_tag_rows()}
+    for k in [k for k in _pending_tag_faults if k not in live]:
+        del _pending_tag_faults[k]
     return applied
+
+
+def _pending_tag_row_key(row):
+    """One journaled row's identity for the once-per-episode fault line: host, name basis, op and the
+    ruling's moment (a re-ruling after a supersede is a new row, and a new episode; a same-op re-rule
+    within the same wall-clock second shares the key -- degenerate, and it only folds two lines into one)."""
+    return (row.get("host") or "", _tag_name_basis(row.get("name")), _row_op(row), row.get("ruledAt"))
 
 
 def _row_op(row):

--- a/tests/test_tag_federation_v2.py
+++ b/tests/test_tag_federation_v2.py
@@ -10,6 +10,8 @@ FRESH at apply time, a same-named tag CREATED there after the ruling survives (t
 creation ms), and the same tag EDITED there after the ruling makes the queued edit yield (the v2
 per-tag mtime, stamped at the store's one write door). ADD never queues. Synthetic hosts/sids only.
 """
+import contextlib
+import io
 import json
 import os
 import tempfile
@@ -41,6 +43,7 @@ def _fresh_journal():
         pass
     with km._PENDING_TAG_LOCK:
         km._PENDING_TAG_CACHE["rows"] = None
+    getattr(km, "_pending_tag_faults", {}).clear()   # the once-per-episode fault lines are module state too
 
 
 def _attach(views=None, status="up"):
@@ -191,6 +194,117 @@ class LateApply(unittest.TestCase):
         self.assertEqual(km._apply_pending_tag_edits(self.r), 0)
         self.assertEqual(self.forwarded, [])
         self.assertEqual(len(km._pending_tag_rows()), 1)
+
+    # the /tag route's STORE-FAULT refusal: 200 {ok:false, retryable:true, error} -- the disk's answer,
+    # not the host's ruling (the route's own shape; the PR-watch route wears the same key on a save fault)
+    _STORE_FAULT = {"ok": False, "retryable": True,
+                    "error": "the tag store could not be read (read failed: [Errno 5] Input/output error) \u2014 retry"}
+
+    def _pass(self, answer):
+        """One apply pass against a host whose /tag answers `answer`; returns (applied, stderr text)."""
+        km._remote_forward = lambda r, path, body: (self.forwarded.append((path, body)) or dict(answer))
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            n = km._apply_pending_tag_edits(self.r)
+        return n, err.getvalue()
+
+    def _dial_outcomes(self):
+        try:
+            recs = [json.loads(ln) for ln in km.TUNNEL_LOG.read_text().splitlines() if ln.strip()]
+        except OSError:
+            recs = []
+        return [x.get("outcome") for x in recs if x.get("event") == "pending-tag-edit"]
+
+    def test_a_retryable_store_fault_on_the_host_keeps_the_row_and_the_next_pass_lands_it(self):
+        """On main the host's store fault retired the row as "refused by the host": a pending delete was lost
+        to a transient disk fault on the host -- the case the journal exists to survive."""
+        self._rule({"delete": True})
+        self._host_answers([_remote_tag("g100", "web")])
+        n, err = self._pass(self._STORE_FAULT)
+        self.assertEqual(n, 0)
+        self.assertEqual(len(km._pending_tag_rows()), 1, "the disk's answer is not the host's ruling: the row stays")
+        lines = [ln for ln in err.splitlines() if "pending-tag-edits" in ln]
+        self.assertEqual(len(lines), 1, err)
+        for word in ('delete of "web"', HOST, "could not be read", "retrying next pass"):
+            self.assertIn(word, lines[0])
+        v = km._views_client()
+        self.assertEqual(v.get("pendingTagEdits"), [{"host": HOST, "name": "web", "op": "delete"}])
+        self.assertEqual(next(t for t in v["remoteTags"] if t["name"] == "web").get("pending"), "delete",
+                         "the badge stays while the edit is still owed")
+        self.assertIn("the host's tag store faulted: the tag store could not be read (read failed: [Errno 5] "
+                      "Input/output error) \u2014 retry \u2014 kept; retried every pass, recorded once", self._dial_outcomes())
+        # the next pass: the host's store is back, and the SAME row lands
+        n, err = self._pass({"ok": True, "deleted": True})
+        self.assertEqual(n, 1)
+        self.assertEqual([b for _, b in self.forwarded], [{"name": "web", "delete": True}] * 2)
+        self.assertEqual(km._pending_tag_rows(), [])
+        self.assertEqual(err, "", "landing is not a fault")
+        self.assertEqual(self._dial_outcomes()[-1], "applied after 1 faulting pass", "the landing record carries the count")
+        v = km._views_client()
+        self.assertNotIn("pendingTagEdits", v)
+        self.assertIsNone(next(t for t in v["remoteTags"] if t["name"] == "web").get("pending"), "the badge clears")
+        self.assertEqual(km._pending_tag_faults, {}, "the episode ended with its row")
+
+    def test_a_refusal_without_retryable_is_the_hosts_ruling_and_retires(self):
+        self._rule({"delete": True})
+        self._host_answers([_remote_tag("g100", "web")])
+        n, err = self._pass({"ok": False, "error": 'no tag named "web"'})
+        self.assertEqual(n, 0)
+        self.assertEqual(km._pending_tag_rows(), [], "the host's own words are terminal, as before")
+        self.assertEqual(err, "")
+        self.assertIn('refused by the host: no tag named "web"', self._dial_outcomes())
+
+    def test_a_host_that_keeps_faulting_is_said_once_and_a_fresh_ruling_afresh(self):
+        self._rule({"delete": True})
+        self._host_answers([_remote_tag("g100", "web")])
+        seen = len(self._dial_outcomes())          # the dial log is the module's shared state: count from here
+        said = []
+        for _ in range(3):
+            n, err = self._pass(self._STORE_FAULT)
+            self.assertEqual(n, 0)
+            self.assertEqual(len(km._pending_tag_rows()), 1, "still pending after every faulting pass")
+            said += [ln for ln in err.splitlines() if "pending-tag-edits" in ln]
+        self.assertEqual(len(said), 1, "one stderr line per row per episode, not one per pass")
+        self.assertEqual(len(self.forwarded), 3, "…while every pass still asks the host")
+        self.assertEqual(len(self._dial_outcomes()[seen:]), 1,
+                         "one dial record per episode too: a host whose disk stays bad must not rotate the dial log away")
+        self.assertTrue(self._dial_outcomes()[-1].startswith("the host's tag store faulted: "))
+        # the episode ends when the row retires -- here on the host's own ruling, which says how long it took
+        n, err = self._pass({"ok": False, "error": 'no tag named "web"'})
+        self.assertEqual((n, km._pending_tag_rows(), err), (0, [], ""))
+        self.assertEqual(self._dial_outcomes()[-1], 'refused by the host: no tag named "web" after 3 faulting passes')
+        self.assertEqual(km._pending_tag_faults, {})
+        # a NEW ruling on the same tag is a new row, and a fault on it is said afresh
+        self.r["views"] = {"tags": [_remote_tag("g100", "web")]}
+        self._rule({"rename": "site"})
+        n, err = self._pass(self._STORE_FAULT)
+        self.assertEqual(n, 0)
+        lines = [ln for ln in err.splitlines() if "pending-tag-edits" in ln]
+        self.assertEqual(len(lines), 1, err)
+        self.assertIn('rename of "web"', lines[0])
+        self.assertEqual(len(km._pending_tag_rows()), 1)
+
+    def test_a_supersede_mid_episode_is_a_new_row_and_is_said_afresh(self):
+        """_queue_pending_tag_edit coalesces: a delete ruled while a rename is still queued REPLACES the
+        rename's row (op and ruledAt change), so the prune drops the old key and the new row's fault is a
+        new episode -- said afresh. (A same-op re-rule within one wall-clock second shares its key: a
+        degenerate case that only folds two lines into one.)"""
+        self._rule({"rename": "site"})
+        self._host_answers([_remote_tag("g100", "web")])
+        n, err = self._pass(self._STORE_FAULT)
+        lines = [ln for ln in err.splitlines() if "pending-tag-edits" in ln]
+        self.assertEqual((n, len(lines)), (0, 1), err)
+        self.assertIn('rename of "web"', lines[0])
+        self._rule({"delete": True})                         # the supersede: one row, the delete's
+        rows = km._pending_tag_rows()
+        self.assertEqual([km._row_op(x) for x in rows], ["delete"])
+        n, err = self._pass(self._STORE_FAULT)
+        lines = [ln for ln in err.splitlines() if "pending-tag-edits" in ln]
+        self.assertEqual((n, len(lines)), (0, 1), "a second line: the delete is a new row, hence a new episode")
+        self.assertIn('delete of "web"', lines[0])
+        self.assertEqual(set(km._pending_tag_faults), {km._pending_tag_row_key(rows[0])},
+                         "after the prune the map holds only the live row's key")
+        self.assertEqual(len(self.forwarded), 2)
 
     def test_a_changed_reading_marks_the_views_dirty_with_nothing_retired(self):
         """The apply's fresh read stored the reading BARE, and _mark_views_dirty fired only when a row


### PR DESCRIPTION
## What was wrong
Verified on `main`: when a viewer edits a remote host's tag while that host is unreachable, the kernel journals a pending edit and applies it on a later pass. The apply reads the host's answer to its forwarded edit and treats every refusal as the host's ruling and retires the row. But a refusal can also be the host saying its own tag store could not be read or written at that moment, marked `retryable`, which is the marker the PR-watch route already uses for a disk fault and which #1075 adds to the tag route for exactly this case. Today a host's read fault is folded into "no tag named" and the pending delete or rename is lost to a transient disk fault, the very case the journal exists to survive.

## What changes
The apply honours the marker. A refusal carrying `retryable` is not the host's ruling: the row stays pending, and once per episode the dial log records the fault and one line on stderr says, in plain words, that the edit stays queued because the host could not use its tag store just now and will be retried. The line is said once per row per episode, keyed on the row's host, name, operation and ruling time, and the episode ends when the row lands, retires or is superseded by a newer ruling. A refusal without the marker still retires with the host's words, as before. With #1075 on the host side the new arm is reached in production; on today's `main` a stubbed answer drives it.

## Deliberately left out
The peer poller returns its kept reading on any non-200 from the views route, so the apply proceeds on that reading and forwards; that is the poller's own design. The host-side folding of a read fault into a wrong refusal is #1075's fix. The dial-log record is bounded to once per episode here, with the terminal record carrying how many faulting passes preceded the host's answer; the existing transport-failure arm still records every pass and is not this change's.

## Tests
Four cases in the federation module against the real apply, a real journal file and a stubbed host answer: a retryable fault keeps the row, the badge stays in the client payload, one stderr line is said, and the next pass lands the edit with the same forwarded body and clears the badge; a refusal without the marker retires, the existing behaviour; a host that keeps faulting for three passes keeps the row with the line said once, a real refusal then retires it, and a fresh ruling on the same tag is said afresh; a superseding ruling mid-episode, a delete over a rename, is a new row and is said afresh. On `main` the fault cases are red, since it never writes the line, and the guard is green.

The federation module runs 28 passed on this branch. Reviewed by read-only agents: the arms, the episode set and the main-side account hold; the supersede leg and the bounded dial record were their two folds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


