### PR TITLE
A message the sender withdrew or the bus returned is not the peer's word

### DIFF
--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -286,7 +286,16 @@ not a session); the recipient's stable id rides the additive `to_sid` key (rows 
 isn't in the log (legacy/rare).
 Two rules the wait readers apply to these rows: only a `question` or a `delegate` opens
 a wait, so the answered clock walks reply-requiring sends and a coordinate-only exchange
-neither opens nor reopens one (a reply of any kind still answers). A row without
+neither opens nor reopens one (a reply of any kind still answers). A `bounced` row
+naming a sent row's id is terminal (the send came back: the peer refused it, the
+recipient exited, it never left) and closes that ask for every reader that opens a
+wait from a sent row — the chip, the stamp clock, the closer's admit gate, the debt
+reminder's outcome, the courier's plant: the row is neither an ask nor an answer, so
+the sender is not waiting on a peer that never got it, a bounced reply answers
+nothing, and a stamp filed before the return is superseded by it as by a reply.
+A handoff tracker planted before the return arrived, and a `recall` row, are not read
+this way. The row is the event, keyed to the message it names, so a newer live ask
+keeps waiting whatever came back for an older one. A row without
 `to_sid` keys by whoever wore the name AT the row's send time, so a pre-2026-09-08 ask
 to a recreated same-named peer whose first sighting here is its own reply stays keyed
 to the prior wearer and reads open until the 6h wake: a known residual, legacy rows

--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -286,16 +286,27 @@ not a session); the recipient's stable id rides the additive `to_sid` key (rows 
 isn't in the log (legacy/rare).
 Two rules the wait readers apply to these rows: only a `question` or a `delegate` opens
 a wait, so the answered clock walks reply-requiring sends and a coordinate-only exchange
-neither opens nor reopens one (a reply of any kind still answers). A `bounced` row
-naming a sent row's id is terminal (the send came back: the peer refused it, the
-recipient exited, it never left) and closes that ask for every reader that opens a
-wait from a sent row — the chip, the stamp clock, the closer's admit gate, the debt
-reminder's outcome, the courier's plant: the row is neither an ask nor an answer, so
-the sender is not waiting on a peer that never got it, a bounced reply answers
-nothing, and a stamp filed before the return is superseded by it as by a reply.
-A handoff tracker planted before the return arrived, and a `recall` row, are not read
-this way. The row is the event, keyed to the message it names, so a newer live ask
-keeps waiting whatever came back for an older one. A row without
+neither opens nor reopens one (a reply of any kind still answers). Two rows are
+terminal for the sent row whose id they name: `bounced` (the send came back: the peer
+refused it, the recipient exited, it never left) and a maildir `recall` (the sender
+withdrew it before anyone read it: that arm unlinks the message unread from the
+recipient's new/). An outbox recall — its row names a relay mid, `px-…` — is NOT read
+as terminal: the outbox item outlives the carry until the end-to-end ack, so the far
+recipient may already hold the message; a recalled cross-host send stays an open ask
+(a bus follow-up: refuse to recall a carried item, or stamp the row with its box).
+Either terminal row closes that ask for every reader that opens a wait from a sent
+row — the chip, the stamp clock, the closer's admit gate, the debt reminder's outcome,
+the courier's plant: the row is neither an ask nor an answer, so the sender is not
+waiting on a peer that never got it, a reply that came back or was withdrawn unread
+answers nothing (the edge stands, the replier still owes, no tracker reads "reported
+back" on a report the asker never received), and a stamp filed before the return is
+superseded by it as by a reply. Cross-host that bites on the replier's own host for a
+refused relay, and on the asker's host when its own orphan sweep destroys the
+delivered copy unread — the two hosts then disagree, honestly, and the remote replier
+is not told (the sweep's note reaches local senders only). A handoff tracker planted
+before the return arrived is not closed this way. The row is the event, keyed to the
+message it names, so a newer live ask keeps waiting whatever came back for an older
+one. A row without
 `to_sid` keys by whoever wore the name AT the row's send time, so a pre-2026-09-08 ask
 to a recreated same-named peer whose first sighting here is its own reply stays keyed
 to the prior wearer and reads open until the 6h wake: a known residual, legacy rows

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10304,6 +10304,24 @@ def _learn_alias(alias, o):
         alias.setdefault(str(o["from_host"]) + ":" + str(o["from"]), []).append((at, str(o["from_id"])))
 
 
+def _learn_return(returned, o):
+    """Record one TERMINAL return from a `bounced` row: returned[mid] is the latest t the bus gave the
+    message back — a peer refused it, the recipient exited and its unread mail was destroyed, an inbox
+    file it could not read, a write a crash cut short, an oversize push. Every bounced row the bus writes
+    is terminal (a parked message awaiting relay has no row; that state is outbox residency), and the row
+    names the ORIGINAL message's id, so a sent row whose id is here is neither an ask nor an answer:
+    nothing will ever answer it, and nobody ever read it. The ONE shape all three scans share — the
+    judge's ask maps, the kernel's wait maps (which also need the time, for the return clock) and the
+    courier's cross-host plant (2026-09-08)."""
+    if o.get("ev") == "bounced" and o.get("id"):
+        try:
+            at = int(o.get("t") or 0)
+        except (TypeError, ValueError):
+            at = 0
+        mid = str(o["id"])
+        returned[mid] = max(returned.get(mid, 0), at)
+
+
 def _alias_settle(alias):
     """Order each name's sightings by t and collapse CONSECUTIVE sightings of one sid into one entry, so
     the history is per WEARER CHANGE, not per row (a chatty peer name otherwise carries thousands of
@@ -10347,7 +10365,9 @@ def _postal_ask_maps():
     carries it (relay rows since 2026-09-08), else the name alias AT the row's send time (_alias_at),
     else the raw "peer:<host>:<name>". `alias` is the time-ordered name→sid history the re-key used;
     consumers resolve a name through _alias_at with the time of the message they hold, never by a
-    bare lookup."""
+    bare lookup. A sent row whose id a terminal `bounced` row names (the send came back: refused,
+    recipient gone, never left) makes no entry at all — neither an ask nor an answer — read exactly as
+    the kernel's wait maps read it (2026-09-08, _learn_return, the shape both scans share)."""
     try:
         st = MESSAGES.stat()
         key = (st.st_mtime_ns, st.st_size)
@@ -10355,8 +10375,7 @@ def _postal_ask_maps():
         return {}, {}, {}
     if _PEER_ASK_CACHE[0] == key:
         return _PEER_ASK_CACHE[1]
-    last_any, last_ask, rows, alias = {}, {}, [], {}
-    ended = set()   # ids a terminal `bounced` row closed: mail that never reached anyone
+    last_any, last_ask, rows, alias, returned = {}, {}, [], {}, {}   # returned: mid -> t of its terminal bounced row
     try:
         for line in MESSAGES.read_text(errors="replace").splitlines():
             try:
@@ -10367,16 +10386,16 @@ def _postal_ask_maps():
                 continue
             rows.append(o)
             _learn_alias(alias, o)
-            if o.get("ev") == "bounced" and o.get("id"):
-                ended.add(str(o["id"]))
+            _learn_return(returned, o)
         _alias_settle(alias)
         for o in rows:
             f, t_, ts = o.get("from_id"), o.get("to_id"), o.get("t")
             if not (f and t_ and ts):
                 continue
-            if str(o.get("id") or "") in ended:
+            if str(o.get("id") or "") in returned:
                 continue   # refused or destroyed: never reached the recipient, so neither an ask nor an
                 #            answer (review find, 2026-09-08): the kernel's _postal_wait_maps rule, mirrored
+                #            (the return's time rides in `returned` for the kernel's clock; membership is the rule here)
             ts = int(ts)
             if isinstance(t_, str) and t_.startswith("peer:"):
                 if o.get("to_sid"):
@@ -14910,6 +14929,7 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
     # backfilled; idempotent by msgId, so one plant per message ever.
     placed = 0
     fleet_ids = {f for f, p, a, nm in fleet}
+    xback = {}   # mid -> t: delegates the bus gave BACK (terminal bounced rows) — these plant nothing
     try:
         xrows = []
         for line in MESSAGES.read_text(errors="replace").splitlines():
@@ -14917,6 +14937,7 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
                 o = json.loads(line)
             except Exception:
                 continue
+            _learn_return(xback, o)
             if (o.get("ev") == "sent" and o.get("kind") == "delegate" and o.get("id")
                     and o.get("from_id") in fleet_ids and o.get("toName")
                     and str(o.get("to_id") or "").startswith("peer:")
@@ -14924,6 +14945,12 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
                 xrows.append(o)
     except OSError:
         xrows = []
+    # A delegate that came back never reached the peer (2026-09-08): a tracker planted from it would
+    # wait on a report-back no event can bring, since the remote arm's ending is the peer's own reply
+    # at/after the send. The bounced row is terminal, so the skip is final, not a retry. (A tracker
+    # planted BEFORE the return arrived is not closed here: ending it needs a verdict that says the
+    # handoff came back, not "reported back" — a writer, outside this reader's scope.)
+    xrows = [o for o in xrows if str(o["id"]) not in xback]
     for o in xrows:
         try:
             sstore = load_goals(o["from_id"])

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10305,15 +10305,40 @@ def _learn_alias(alias, o):
 
 
 def _learn_return(returned, o):
-    """Record one TERMINAL return from a `bounced` row: returned[mid] is the latest t the bus gave the
-    message back — a peer refused it, the recipient exited and its unread mail was destroyed, an inbox
-    file it could not read, a write a crash cut short, an oversize push. Every bounced row the bus writes
-    is terminal (a parked message awaiting relay has no row; that state is outbox residency), and the row
-    names the ORIGINAL message's id, so a sent row whose id is here is neither an ask nor an answer:
-    nothing will ever answer it, and nobody ever read it. The ONE shape all three scans share — the
-    judge's ask maps, the kernel's wait maps (which also need the time, for the return clock) and the
-    courier's cross-host plant (2026-09-08)."""
-    if o.get("ev") == "bounced" and o.get("id"):
+    """Record one TERMINAL row naming a sent message: returned[mid] is the latest t the message was over
+    with nobody ever receiving it — so a sent row whose id is here is neither an ask nor an answer:
+    nothing will ever answer it, and nobody ever read it. Two kinds, joined by the id alone. `bounced`:
+    the bus gave it back — a peer refused it, the recipient exited and its unread mail was destroyed, an
+    inbox file it could not read, a write a crash cut short, an oversize push (every bounced row the bus
+    writes is terminal; a parked message awaiting relay has no row, that state is outbox residency). A
+    MAILDIR `recall`: the sender withdrew it before anyone read it — that arm's unlink from the
+    recipient's new/ is the atomic claim against read_box's rename to cur/, so the row is written only
+    for mail nobody read, and it names the maildir name deliver() logged as the sent id; exactly as
+    terminal as a bounce (2026-09-08; before, a recall was not read, and the sender wore "Awaiting
+    <peer>" for a question it had withdrawn).
+
+    NOT an OUTBOX recall (review find, 2026-09-08). That arm unlinks any outbox file of the sender's and
+    writes the same row, but an outbox item OUTLIVES THE CARRY: the exchange relays outbox_list on both
+    sides without removing anything; a SUCCESSFUL carry leaves the file until _ack_arrived removes it
+    on the END-TO-END ack (a bounce removes it too, but writes a bounced row the readers honour) —
+    one round trip normally, the whole outage when a response was lost and _peer_loop re-relays under
+    its 30 s-capped backoff. A recall inside that window names a message the far recipient already
+    holds (_relay_in delivered and pushed it) and may answer; reading it as terminal would close a LIVE
+    ask. The two arms are told apart by the id the row names: the relay send mints
+    `mid = "px-" + _unique()` and the outbox recall logs that stem, while a maildir name is a bare
+    _unique() — `<epoch>.<pid>_<rand>.<host>` — and never carries the prefix. So a recall naming a relay
+    mid is read as nothing here, and a recalled cross-host send stays an open ask (and a recalled
+    cross-host delegate still plants its tracker), exactly as before. The bus owns the fix: refuse to
+    recall a carried item, or stamp the recall row with the box it came from — a writer change for
+    another PR.
+
+    The ONE shape all three scans share — the judge's ask maps, the kernel's wait maps (which also need
+    the time, for the return clock) and the courier's cross-host plant: both map builders skip a sent
+    row whose id is here before last_any, so it is not its sender's WORD toward the recipient either,
+    and a reply that came back or was withdrawn unread answers nothing."""
+    if o.get("ev") == "recall" and str(o.get("id") or "").startswith("px-"):
+        return                                   # the outbox arm (a relay mid): not terminal, see above
+    if o.get("ev") in ("bounced", "recall") and o.get("id"):
         try:
             at = int(o.get("t") or 0)
         except (TypeError, ValueError):
@@ -10365,9 +10390,12 @@ def _postal_ask_maps():
     carries it (relay rows since 2026-09-08), else the name alias AT the row's send time (_alias_at),
     else the raw "peer:<host>:<name>". `alias` is the time-ordered name→sid history the re-key used;
     consumers resolve a name through _alias_at with the time of the message they hold, never by a
-    bare lookup. A sent row whose id a terminal `bounced` row names (the send came back: refused,
-    recipient gone, never left) makes no entry at all — neither an ask nor an answer — read exactly as
-    the kernel's wait maps read it (2026-09-08, _learn_return, the shape both scans share)."""
+    bare lookup. A sent row whose id a terminal row names (`bounced`: the send came back — refused,
+    recipient gone, never left; a maildir `recall`: the sender withdrew it unread — an outbox recall is
+    not terminal, see _learn_return) makes no entry at all — neither an ask nor an answer, so a returned
+    or withdrawn reply leaves the asker's question open — read exactly as the kernel's wait maps read it
+    (2026-09-08, _learn_return, the shape both scans share). The alias history still learns from it:
+    identity is not word."""
     try:
         st = MESSAGES.stat()
         key = (st.st_mtime_ns, st.st_size)
@@ -10393,8 +10421,8 @@ def _postal_ask_maps():
             if not (f and t_ and ts):
                 continue
             if str(o.get("id") or "") in returned:
-                continue   # refused or destroyed: never reached the recipient, so neither an ask nor an
-                #            answer (review find, 2026-09-08): the kernel's _postal_wait_maps rule, mirrored
+                continue   # refused, destroyed or withdrawn unread: never reached the recipient, so neither an
+                #            ask nor an answer (review find, 2026-09-08): the kernel's _postal_wait_maps rule, mirrored
                 #            (the return's time rides in `returned` for the kernel's clock; membership is the rule here)
             ts = int(ts)
             if isinstance(t_, str) and t_.startswith("peer:"):
@@ -14751,6 +14779,11 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
     # handoff's send time when the peer has spoken (it must have, to reply), else the raw relay
     # key. Anchored so a name a later session reused cannot make that stranger's mail the
     # report-back (2026-09-08).
+    # last_any carries no row that came back or was withdrawn unread (2026-09-08, _postal_ask_maps): a
+    # reply the asker never received is not a report-back, so neither arm below marks a tracker done
+    # on it. Cross-host it bites on the asker's host when its own orphan sweep destroys the delivered
+    # copy unread (a relayed reply is a local sent row here, and the sweep's bounce names its id); a
+    # relay the far host refused writes no sent row here at all.
     last_any, _la, alias = _postal_ask_maps()
     _rmemo = {}                                        # recipient sid -> merged nodes (per-pass, read-only)
 
@@ -14929,7 +14962,7 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
     # backfilled; idempotent by msgId, so one plant per message ever.
     placed = 0
     fleet_ids = {f for f, p, a, nm in fleet}
-    xback = {}   # mid -> t: delegates the bus gave BACK (terminal bounced rows) — these plant nothing
+    xback = {}   # mid -> t: delegates the bus gave BACK (terminal bounced rows, _learn_return) — these plant nothing
     try:
         xrows = []
         for line in MESSAGES.read_text(errors="replace").splitlines():
@@ -14947,7 +14980,9 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
         xrows = []
     # A delegate that came back never reached the peer (2026-09-08): a tracker planted from it would
     # wait on a report-back no event can bring, since the remote arm's ending is the peer's own reply
-    # at/after the send. The bounced row is terminal, so the skip is final, not a retry. (A tracker
+    # at/after the send. The bounced row is terminal, so the skip is final, not a retry. An OUTBOX
+    # recall of a cross-host delegate is NOT read as terminal (_learn_return: the item may already have
+    # been carried and delivered), so a recalled delegate still plants, as before. (A tracker
     # planted BEFORE the return arrived is not closed here: ending it needs a verdict that says the
     # handoff came back, not "reported back" — a writer, outside this reader's scope.)
     xrows = [o for o in xrows if str(o["id"]) not in xback]

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2672,7 +2672,11 @@ def _debt_reminder_outcomes(sid, lt, now):
     debtor's ENDED past the reminder's fire escalates to the asker's card and retires — the debtor had
     its chance and moved on without replying (the reminder's own response turn included: both honest
     exits it offered were postal replies, so a reply-less end IS the failure). A debtor that never turns
-    again is the backstop's case (_debt_backstop_tick)."""
+    again is the backstop's case (_debt_backstop_tick). An ask the bus RETURNED retires the record too and
+    never escalates (2026-09-08: the debtor exited before the reminder's turn read the ask; ORPHAN_GRACE
+    later the orphan sweep destroyed the mail and wrote the terminal bounced row; the asker got the bus
+    note; 6h on, the backstop flipped its card to blocked for an ask that had already come back) — the
+    debtor never had it, the return is the outcome, and the asker was told (_ask_returned)."""
     dn0 = _auto_nudge_data().get("debtNudged") or {}
     if not dn0:
         return
@@ -2686,6 +2690,9 @@ def _debt_reminder_outcomes(sid, lt, now):
         asker, _debtor, ts = parsed
         if last_any.get((sid, asker), 0) >= ts:        # answered → the reminder worked
             drop.append(key)
+            continue
+        if _ask_returned(asker, sid, ts):              # the ask came back: the debtor never had it, the
+            drop.append(key)                           # return is the outcome, the bus told the asker
             continue
         if isinstance(fire_t, (int, float)) and lt_end > fire_t:
             _debt_escalate(asker, sid, ts, now)        # moved on without replying → the user's turn
@@ -2717,6 +2724,9 @@ def _debt_backstop_tick(now):
             continue
         asker, debtor, ts = parsed
         if last_any.get((debtor, asker), 0) >= ts:
+            drop.append(key)
+            continue
+        if _ask_returned(asker, debtor, ts):           # came back → retired, never escalated (see above)
             drop.append(key)
             continue
         if isinstance(fire_t, (int, float)) and now - fire_t > NUDGE_DEFER_BACKSTOP_SECS:
@@ -30857,6 +30867,7 @@ def _blocked_placeholder(s, name, color, fsid, live, now, perm_state, since):
 _WAIT_Q_RE = re.compile(r"^\s*(?:QUESTION|ASK|Q)\b", re.I)
 _POSTAL_WAIT_CACHE = [None, None]   # (mtime_ns, size) , (last_any, last_ask, last_await) — one log scan per file change
 _POSTAL_PEER_NAMES = [None, {}]     # (mtime_ns, size) , {remote sid: "<host>:<name>"}: the same scan's display join
+_POSTAL_RETURNED = [None, {}]       # (mtime_ns, size) , {(from_id, peer key): {send t: return t}}: the same scan's returns — _postal_returned
 
 
 def _postal_wait_maps():
@@ -30890,17 +30901,35 @@ def _postal_wait_maps():
     host. The same scan therefore keeps the display join beside the maps, _POSTAL_PEER_NAMES, {remote
     sid: "<host>:<name>"} from every row that pairs the two (a relay row's to_sid + toName, a remote
     sender's from_id + from_host + from), newest sighting winning, and _peer_identity reads it
-    (_postal_peer_names) so the chip names the peer the row named."""
+    (_postal_peer_names) so the chip names the peer the row named.
+
+    A send that CAME BACK is neither an ask nor an answer (2026-09-08, two rules that agree). The bus
+    writes a terminal `bounced` row naming the message's id when a send is over with nothing ever coming
+    back — a peer refused it, the recipient exited and its unread mail was destroyed, an inbox file it
+    could not read, a write a crash cut short, an oversize push (every bounced row the bus writes is
+    terminal; a parked message awaiting relay has no row, its state is outbox residency). The scan used
+    to skip that row (it carries no from_id/to_id) and count the sent row, so the sender wore "Awaiting
+    <peer>" for a question the peer never received, its card parked as waiting on a peer while the
+    person may have needed to act, and a bounced reply read as answering the pair. A sent row whose id
+    a bounced row names now makes no entry at all — not last_any, not last_ask, not last_await (the
+    #1071 review's rule) — and a reply-requiring one records the return by pair and send time
+    (_POSTAL_RETURNED, read by _postal_returned) so the stamp readers' ending clock and the debt
+    reminder's outcome readers see it. The row is the closing EVENT: the card moves once, when it
+    lands. Keyed to the message it names, never the pair — a newer live ask keeps waiting whatever came
+    back for an older one."""
     try:
         st = jd.MESSAGES.stat()
         key = (st.st_mtime_ns, st.st_size)
     except OSError:
         _POSTAL_PEER_NAMES[:] = [None, {}]
+        _POSTAL_RETURNED[:] = [None, {}]
         return {}, {}, {}
     if _POSTAL_WAIT_CACHE[0] == key:
         return _POSTAL_WAIT_CACHE[1]
     last_any, last_ask, last_await = {}, {}, {}
     peer_names = {}   # remote sid -> (t, "<host>:<name>"): the display join, newest sighting wins
+    returned = {}     # mid -> t of its terminal `bounced` row: the sends that came back (jd._learn_return)
+    ended = {}        # (from_id, peer key) -> {send t: return t} for the pair's reply-requiring sends that came back
 
     def _saw(sid, at, hn):
         if sid and hn and at >= peer_names.get(sid, (-1, ""))[0]:
@@ -30908,14 +30937,12 @@ def _postal_wait_maps():
     try:
         rows = []
         alias = {}   # "host:name" -> [(t, sid), …], learned from every row a remote sender stamped
-        ended = set()   # ids a terminal `bounced` row closed: mail that never reached anyone
         for o in _messages_rows():                    # append-incremental rows (2026-09-03); the fold
             if not isinstance(o, dict):               # itself stays whole-log: aliases learned from LATER
                 continue                              # rows resolve EARLIER peer: rows
             rows.append(o)
             jd._learn_alias(alias, o)
-            if o.get("ev") == "bounced" and o.get("id"):
-                ended.add(str(o["id"]))
+            jd._learn_return(returned, o)
         jd._alias_settle(alias)
         for hn, hist in alias.items():                # the peer's own stamps, inverted: sid -> what it wore
             for at, sid in hist:
@@ -30923,16 +30950,6 @@ def _postal_wait_maps():
         for o in rows:
             f, t_, ts = o.get("from_id"), o.get("to_id"), o.get("t")
             if not (f and t_ and ts):
-                continue
-            if str(o.get("id") or "") in ended:
-                # A REFUSED or DESTROYED send is neither an ask nor an answer (review find,
-                # 2026-09-08): the bus closes a message it had to give up on — a peer's refusal, the
-                # orphan sweep's destroy, an inbox file it could not read, a write a crash cut short
-                # — with a terminal `bounced` row on the same id (a publish it refuses outright
-                # writes no row at all). The recipient never saw that message, so
-                # counting its row here made the asker wear an open ask (and the debt reminder
-                # count a debt) that no reply could ever close, and let a bounced reply read as
-                # answering the pair. The judge's _postal_ask_maps applies the same rule.
                 continue
             ts = int(ts)
             # a CROSS-HOST row is addressed to the RELAY ("peer:<host>"), not the recipient's sid —
@@ -30953,19 +30970,37 @@ def _postal_wait_maps():
                     # 29.6h-invisible ask eaten this way). The maps rebuild from the full log, so the
                     # moment the peer speaks the alias resolves and every row re-keys to the real sid.
                     t_ = jd._alias_at(alias, str(o["toName"]), ts) or "peer:" + str(o["toName"])
-            last_any[(f, t_)] = max(last_any.get((f, t_), 0), ts)
             k = o.get("kind")                            # the sender's DECLARED intent (schema field) wins
             is_ask = (k == "question") if k else bool(_WAIT_Q_RE.match(o.get("body") or ""))
+            is_await = (k in ("question", "delegate")) if k else is_ask   # reply-requiring; kindless rows by the ask prefix
+            mid = str(o.get("id") or "")
+            if mid and mid in returned:
+                # A REFUSED or DESTROYED send is neither an ask nor an answer (review find,
+                # 2026-09-08): the bus closes a message it had to give up on — a peer's refusal, the
+                # orphan sweep's destroy, an inbox file it could not read, a write a crash cut short
+                # — with a terminal `bounced` row on the same id (a publish it refuses outright
+                # writes no row at all). The recipient never saw that message, so counting its row
+                # here made the asker wear an open ask (and the debt reminder count a debt) that no
+                # reply could ever close, and let a bounced reply read as answering the pair. The
+                # judge's _postal_ask_maps applies the same rule. A reply-requiring one also records
+                # the RETURN on the pair, by send time: the stamp readers' other ending event beside
+                # the reply (_pair_wait_ended) and the debt outcome readers' join (_ask_returned). A
+                # coordinate opened no wait to end.
+                if is_await:
+                    pr = ended.setdefault((f, t_), {})
+                    pr[ts] = max(pr.get(ts, 0), returned[mid])
+                continue
+            last_any[(f, t_)] = max(last_any.get((f, t_), 0), ts)
             if is_ask and ts >= last_ask.get((f, t_), (0, ""))[0]:
                 # the ask's HEAD rides along (the user 2026-07-26): the debt reminder quotes the asker's
                 # own first words back at the debtor, so the reminder needs no second log scan
                 last_ask[(f, t_)] = (ts, k or "question", str(o.get("body") or "")[:300])
-            is_await = (k in ("question", "delegate")) if k else is_ask   # reply-requiring; kindless rows by the ask prefix
             if is_await:
                 last_await[(f, t_)] = max(last_await.get((f, t_), 0), ts)
     except OSError:
         pass
     _POSTAL_PEER_NAMES[:] = [key, {sid: hn for sid, (_at, hn) in peer_names.items()}]
+    _POSTAL_RETURNED[:] = [key, ended]
     _POSTAL_WAIT_CACHE[:] = [key, (last_any, last_ask, last_await)]
     return last_any, last_ask, last_await
 
@@ -30978,11 +31013,60 @@ def _postal_peer_names():
     return _POSTAL_PEER_NAMES[1]
 
 
+def _postal_returned():
+    """{(from_id, peer key): {send t: return t}}: per pair, each reply-requiring send of the sender's the
+    bus gave BACK — a terminal `bounced` row; the send is over and nothing will answer it (2026-09-08;
+    see _postal_wait_maps) — keyed by the send's own time. Kept by the same scan beside the maps, the
+    _postal_peer_names idiom, so the three-tuple every caller unpacks keeps its shape. The stamp readers'
+    ending clock reads the pair's newest return through _pair_wait_ended; the debt reminder's outcome
+    readers join a record's ask time to it through _ask_returned. Warms the scan when the log changed; a
+    stat per call otherwise."""
+    _postal_wait_maps()
+    return _POSTAL_RETURNED[1]
+
+
+def _pair_wait_ended(last_any, last_await, returned, f, t_):
+    """When the pair f → t_ stopped waiting, or 0 while it still does — THE ending clock both stamp
+    supersede readers (_peer_answered_at, _peer_answered) share. Two exact ending events, the newer
+    wins: the peer's reply at/after f's newest LIVE reply-requiring send (last_any[(t_, f)] at/after
+    last_await[(f, t_)]), and the bus returning such a send (returned[(f, t_)], the pair's returned sends
+    by send time: each a terminal `bounced` row — nothing will ever answer it, so the wait it opened is
+    over). A late reply after a return is not credited: with no live send there is nothing for it to
+    answer, so the pair's ending stays the return's t. A live send still unanswered
+    holds the pair open whatever came back for an older one: the return is keyed to the message it
+    names, never to the pair (2026-09-08)."""
+    sent = last_await.get((f, t_), 0)
+    reply = last_any.get((t_, f), 0)
+    if sent and reply < sent:
+        return 0                                     # a live reply-requiring send still waits
+    return max([reply if sent else 0] + list((returned.get((f, t_)) or {}).values()))
+
+
+def _ask_returned(asker, debtor, ask_ts):
+    """True when the ask `asker` sent `debtor` at `ask_ts` CAME BACK (a terminal bounced row named it) and
+    no live ask of theirs shares that second — the join the debt reminder's outcome readers
+    (_debt_reminder_outcomes, _debt_backstop_tick) make for a debtNudged record ("asker>debtor:ts", ts the
+    ask's own send time). The return is the outcome: the debtor never had the ask, so no reply is owed and
+    nothing escalates to the asker's card, and the bus's own note already told the asker the message came
+    back (2026-09-08). The reminder itself is injected through the session backend, never the bus, so only
+    the ask can be returned. The join is per SEND TIME, not per message: the record carries the ask's
+    second and the returns table keys a returned send by its second, so a live reply-expecting twin sent
+    in that same second keeps the record open — a returned m1 must not retire the reminder a live m2 still
+    owes. The twin check reads last_ask, the chip's own map and question-only like the record; a newer
+    live ask on the pair carries its own record, so the pair's newest live ask is the one that matters."""
+    ts = int(ask_ts)
+    if ts not in (_postal_returned().get((asker, debtor)) or {}):
+        return False
+    _any, last_ask, _aw = _postal_wait_maps()
+    return last_ask.get((asker, debtor), (0,))[0] != ts     # a live twin in the same second keeps the record
+
+
 def _wait_for_graph(now, alive_sids):
     """The fleet's WAIT-FOR graph from the postal log (the user 2026-06-22): a session X 'waits on' peer Y
     when X's latest REPLY-EXPECTING message to Y (a postal QUESTION, or a DELEGATE handoff whose result X
-    acts on — NOT a COORDINATE/FYI heads-up) has no answer back since (any later Y→X record answers it)
-    AND Y is ALIVE (a dead peer won't reply). Each X points to its single most-recent such Y (a functional
+    acts on — NOT a COORDINATE/FYI heads-up) has no answer back since (any later Y→X record answers it;
+    a send the bus RETURNED — a terminal bounced row — is neither an ask nor an answer, see
+    _postal_wait_maps) AND Y is ALIVE (a dead peer won't reply). Each X points to its single most-recent such Y (a functional
     graph), so following the edges detects CYCLES (X→Y→…→X = a mutual-wait deadlock). Returns
     {sid: {peerSid, name, color, inCycle, since, kind}} for every waiting session — the goal card's chip
     (kind picks its label: "Awaiting <peer>" vs "Handed off to <peer>") + the auto-nudge gate read it.
@@ -31014,8 +31098,9 @@ def _wait_for_graph(now, alive_sids):
 
 
 def _peer_answered_at(sid):
-    """The latest time a peer that `sid` had ASKED (question) or DELEGATED to REPLIED, over pairs with no
-    newer outstanding ask: max of last_any[(Y, sid)] where that reply is at/after sid's latest ask to Y.
+    """The latest time a peer that `sid` had ASKED (question) or DELEGATED to REPLIED — or the bus RETURNED
+    that send (a terminal bounced row, 2026-09-08) — over pairs with no newer outstanding ask: max of
+    last_any[(Y, sid)] where that reply is at/after sid's latest ask to Y, and of the pair's return.
     0 when nothing qualifies. The durable ⏳ awaiting-stamp readers treat a stamp OLDER than this as
     SUPERSEDED — the awaited answer arrived after the closer spoke, which is exactly the event the stamp
     was waiting for (the user 2026-07-25: a stamp filed at 13:12 kept a card on "Awaiting background
@@ -31024,6 +31109,7 @@ def _peer_answered_at(sid):
     stamp was really about non-peer work (subagents, a build), the LIVE sources that outrank it still
     carry the wait, and the closer's next pass can re-stamp with a fresh awaitingAt."""
     last_any, _ask, last_await = _postal_wait_maps()
+    returned = _postal_returned()
     best = 0
     # OUTBOUND rides last_await, not last_ask (2026-08-18 audit): the 2026-08-15 change that stopped
     # DELEGATES from making chip edges also emptied last_ask of them — which silently removed this
@@ -31033,17 +31119,19 @@ def _peer_answered_at(sid):
     # exact ending event for both; the chip edge stays question-only, exactly as #430 intended. Not
     # last_any (2026-09-08): a COORDINATE the asker sent after the answer landed ("thanks") counted as
     # a newer outbound awaiting a reply, so the answer read as stale and the stamp stood.
-    for (f, t_), sent in last_await.items():
+    # The bus RETURNING the send (2026-09-08, a terminal bounced row) is the pair's other ending event:
+    # the peer never got the ask and nothing will come back, so a stamp filed before the return is
+    # superseded by it exactly as by a reply (_pair_wait_ended, the clock _peer_answered shares).
+    for f, t_ in set(last_await) | set(returned):
         if f != sid:
             continue
-        r = last_any.get((t_, f), 0)
-        if r >= sent:                                    # the pair's newest reply-requiring send is answered
-            best = max(best, r)
+        best = max(best, _pair_wait_ended(last_any, last_await, returned, f, t_))
     return best
 
 
 def _peer_answered(sid):
-    """(answered_any, {peer_key: reply_t}) — _peer_answered_at with the PAIR kept (2026-08-24): the
+    """(answered_any, {peer_key: t the wait on that peer ENDED — its reply, or the bus returning the ask})
+    — _peer_answered_at with the PAIR kept (2026-08-24): the
     pair-blind scalar let ANY answered exchange supersede ANY peer stamp, so an unrelated coordinate
     from the same log hid a real wait (three stuck stamps, one ~14h). Stamps that record WHICH
     peer(s) they await (awaitingPeers, written by the closer's admit gate) are matched against their
@@ -31052,13 +31140,14 @@ def _peer_answered(sid):
     the admit gate derives them from, so the two sides can never disagree."""
     best = _peer_answered_at(sid)        # the scalar rides the existing name — the tests' stub seam
     last_any, _la, last_await = _postal_wait_maps()
+    returned = _postal_returned()
     per = {}
-    for (f, t_), sent in last_await.items():   # reply-requiring sends only — see _peer_answered_at
+    for f, t_ in set(last_await) | set(returned):   # reply-requiring sends only — see _peer_answered_at
         if f != sid:
             continue
-        r = last_any.get((t_, f), 0)
-        if r >= sent:
-            per[t_] = max(per.get(t_, 0), r)
+        ended = _pair_wait_ended(last_any, last_await, returned, f, t_)   # the reply, or the bus's return
+        if ended:
+            per[t_] = max(per.get(t_, 0), ended)
     return best, per
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2672,8 +2672,8 @@ def _debt_reminder_outcomes(sid, lt, now):
     debtor's ENDED past the reminder's fire escalates to the asker's card and retires — the debtor had
     its chance and moved on without replying (the reminder's own response turn included: both honest
     exits it offered were postal replies, so a reply-less end IS the failure). A debtor that never turns
-    again is the backstop's case (_debt_backstop_tick). An ask the bus RETURNED retires the record too and
-    never escalates (2026-09-08: the debtor exited before the reminder's turn read the ask; ORPHAN_GRACE
+    again is the backstop's case (_debt_backstop_tick). An ask returned or withdrawn (a terminal bounced or
+    maildir-recall row) retires the record too and never escalates (2026-09-08: the debtor exited before the reminder's turn read the ask; ORPHAN_GRACE
     later the orphan sweep destroyed the mail and wrote the terminal bounced row; the asker got the bus
     note; 6h on, the backstop flipped its card to blocked for an ask that had already come back) — the
     debtor never had it, the return is the outcome, and the asker was told (_ask_returned)."""
@@ -30903,20 +30903,36 @@ def _postal_wait_maps():
     sender's from_id + from_host + from), newest sighting winning, and _peer_identity reads it
     (_postal_peer_names) so the chip names the peer the row named.
 
-    A send that CAME BACK is neither an ask nor an answer (2026-09-08, two rules that agree). The bus
-    writes a terminal `bounced` row naming the message's id when a send is over with nothing ever coming
-    back — a peer refused it, the recipient exited and its unread mail was destroyed, an inbox file it
-    could not read, a write a crash cut short, an oversize push (every bounced row the bus writes is
-    terminal; a parked message awaiting relay has no row, its state is outbox residency). The scan used
-    to skip that row (it carries no from_id/to_id) and count the sent row, so the sender wore "Awaiting
-    <peer>" for a question the peer never received, its card parked as waiting on a peer while the
-    person may have needed to act, and a bounced reply read as answering the pair. A sent row whose id
-    a bounced row names now makes no entry at all — not last_any, not last_ask, not last_await (the
-    #1071 review's rule) — and a reply-requiring one records the return by pair and send time
-    (_POSTAL_RETURNED, read by _postal_returned) so the stamp readers' ending clock and the debt
-    reminder's outcome readers see it. The row is the closing EVENT: the card moves once, when it
-    lands. Keyed to the message it names, never the pair — a newer live ask keeps waiting whatever came
-    back for an older one."""
+    A send that CAME BACK, or that its sender WITHDREW unread, is neither an ask nor an answer
+    (2026-09-08, two rules that agree). The bus writes a terminal row naming the message's id when a
+    send is over with nobody ever receiving it: `bounced` — a peer refused it, the recipient exited and
+    its unread mail was destroyed, an inbox file it could not read, a write a crash cut short, an
+    oversize push (every bounced row the bus writes is terminal; a parked message awaiting relay has no
+    row, its state is outbox residency) — or a MAILDIR `recall`, written when the sender unlinks the
+    message unread from the recipient's new/ (jd._learn_return, the shared recognizer; it reads an
+    OUTBOX recall, a row naming a relay mid, as nothing: that item may already have been carried and
+    delivered, so a recalled cross-host send stays an open ask). The scan used to skip those rows (they
+    carry no from_id/to_id) and count the sent row, so the sender wore "Awaiting <peer>" for a question
+    the peer never received, or one it had itself withdrawn, its card parked as waiting on a peer while
+    the person may have needed to act, and a bounced reply read as answering the pair. A sent row whose
+    id such a row names now makes no entry at all — not last_any, not last_ask, not last_await (the
+    #1071 review's rule: one skip, before last_any) — and a reply-requiring one records the return by
+    pair and send time (_POSTAL_RETURNED, read by _postal_returned) so the stamp readers' ending clock
+    and the debt reminder's outcome readers see it. The row is the closing EVENT: the card moves once,
+    when it lands. Keyed to the message it names, never the pair — a newer live ask keeps waiting
+    whatever came back for an older one.
+
+    The no-last_any half is what makes a returned or withdrawn REPLY answer nothing: a reply of Y's that
+    the bus returned (the oversize push bounces it to Y without putting it back in X's box) or that Y
+    recalled before X read it was never received, so it must not clear X's chip edge, settle Y's debt,
+    end the pair for the stamp clock, or read as "reported back" to the courier's local arm; the judge's
+    _postal_ask_maps applies the same rule, so the twins keep agreeing. Cross-host it bites on the
+    replier's own host for a refused relay (the bounce lands in the replier's log; the asker's host never
+    held a row), and on the ASKER's host when its own orphan sweep destroys the delivered copy unread (a
+    relayed reply is a local sent row there, and the sweep's bounce names its id) — the two hosts then
+    disagree, honestly: the replier's host holds a `relayed` ack and reads the debt settled, and the
+    remote replier is not told (the sweep's note reaches local senders only). The peer-names display
+    join and the alias history still learn from the row — identity is not word."""
     try:
         st = jd.MESSAGES.stat()
         key = (st.st_mtime_ns, st.st_size)
@@ -30928,7 +30944,7 @@ def _postal_wait_maps():
         return _POSTAL_WAIT_CACHE[1]
     last_any, last_ask, last_await = {}, {}, {}
     peer_names = {}   # remote sid -> (t, "<host>:<name>"): the display join, newest sighting wins
-    returned = {}     # mid -> t of its terminal `bounced` row: the sends that came back (jd._learn_return)
+    returned = {}     # mid -> t of its terminal row (bounced, or a maildir recall): the sends that came back or were withdrawn (jd._learn_return)
     ended = {}        # (from_id, peer key) -> {send t: return t} for the pair's reply-requiring sends that came back
 
     def _saw(sid, at, hn):
@@ -30975,16 +30991,18 @@ def _postal_wait_maps():
             is_await = (k in ("question", "delegate")) if k else is_ask   # reply-requiring; kindless rows by the ask prefix
             mid = str(o.get("id") or "")
             if mid and mid in returned:
-                # A REFUSED or DESTROYED send is neither an ask nor an answer (review find,
+                # A REFUSED, DESTROYED or WITHDRAWN send is neither an ask nor an answer (review find,
                 # 2026-09-08): the bus closes a message it had to give up on — a peer's refusal, the
                 # orphan sweep's destroy, an inbox file it could not read, a write a crash cut short
                 # — with a terminal `bounced` row on the same id (a publish it refuses outright
-                # writes no row at all). The recipient never saw that message, so counting its row
-                # here made the asker wear an open ask (and the debt reminder count a debt) that no
-                # reply could ever close, and let a bounced reply read as answering the pair. The
-                # judge's _postal_ask_maps applies the same rule. A reply-requiring one also records
-                # the RETURN on the pair, by send time: the stamp readers' other ending event beside
-                # the reply (_pair_wait_ended) and the debt outcome readers' join (_ask_returned). A
+                # writes no row at all), and a sender's MAILDIR recall unlinks it unread with a
+                # `recall` row (an outbox recall is not terminal — jd._learn_return). The recipient
+                # never saw that message, so counting its row here made the asker wear an open ask
+                # (and the debt reminder count a debt) that no reply could ever close, and let a
+                # bounced or recalled reply read as answering the pair. The judge's _postal_ask_maps
+                # applies the same rule. A reply-requiring one also records the RETURN on the pair,
+                # by send time: the stamp readers' other ending event beside the reply
+                # (_pair_wait_ended) and the debt outcome readers' join (_ask_returned). A
                 # coordinate opened no wait to end.
                 if is_await:
                     pr = ended.setdefault((f, t_), {})
@@ -31014,8 +31032,9 @@ def _postal_peer_names():
 
 
 def _postal_returned():
-    """{(from_id, peer key): {send t: return t}}: per pair, each reply-requiring send of the sender's the
-    bus gave BACK — a terminal `bounced` row; the send is over and nothing will answer it (2026-09-08;
+    """{(from_id, peer key): {send t: return t}}: per pair, each reply-requiring send of the sender's that
+    was returned or withdrawn (a terminal bounced or maildir-recall row); the send is over and nothing will
+    answer it (2026-09-08;
     see _postal_wait_maps) — keyed by the send's own time. Kept by the same scan beside the maps, the
     _postal_peer_names idiom, so the three-tuple every caller unpacks keeps its shape. The stamp readers'
     ending clock reads the pair's newest return through _pair_wait_ended; the debt reminder's outcome
@@ -31029,9 +31048,10 @@ def _pair_wait_ended(last_any, last_await, returned, f, t_):
     """When the pair f → t_ stopped waiting, or 0 while it still does — THE ending clock both stamp
     supersede readers (_peer_answered_at, _peer_answered) share. Two exact ending events, the newer
     wins: the peer's reply at/after f's newest LIVE reply-requiring send (last_any[(t_, f)] at/after
-    last_await[(f, t_)]), and the bus returning such a send (returned[(f, t_)], the pair's returned sends
-    by send time: each a terminal `bounced` row — nothing will ever answer it, so the wait it opened is
-    over). A late reply after a return is not credited: with no live send there is nothing for it to
+    last_await[(f, t_)]), and such a send coming back (returned[(f, t_)], the pair's returned sends by
+    send time: each returned or withdrawn, a terminal bounced or maildir-recall row, jd._learn_return —
+    nothing will ever answer it,
+    so the wait it opened is over). A late reply after a return is not credited: with no live send there is nothing for it to
     answer, so the pair's ending stays the return's t. A live send still unanswered
     holds the pair open whatever came back for an older one: the return is keyed to the message it
     names, never to the pair (2026-09-08)."""
@@ -31043,7 +31063,8 @@ def _pair_wait_ended(last_any, last_await, returned, f, t_):
 
 
 def _ask_returned(asker, debtor, ask_ts):
-    """True when the ask `asker` sent `debtor` at `ask_ts` CAME BACK (a terminal bounced row named it) and
+    """True when the ask `asker` sent `debtor` at `ask_ts` was returned or withdrawn (a terminal bounced or
+    maildir-recall row named it) and
     no live ask of theirs shares that second — the join the debt reminder's outcome readers
     (_debt_reminder_outcomes, _debt_backstop_tick) make for a debtNudged record ("asker>debtor:ts", ts the
     ask's own send time). The return is the outcome: the debtor never had the ask, so no reply is owed and
@@ -31065,8 +31086,8 @@ def _wait_for_graph(now, alive_sids):
     """The fleet's WAIT-FOR graph from the postal log (the user 2026-06-22): a session X 'waits on' peer Y
     when X's latest REPLY-EXPECTING message to Y (a postal QUESTION, or a DELEGATE handoff whose result X
     acts on — NOT a COORDINATE/FYI heads-up) has no answer back since (any later Y→X record answers it;
-    a send the bus RETURNED — a terminal bounced row — is neither an ask nor an answer, see
-    _postal_wait_maps) AND Y is ALIVE (a dead peer won't reply). Each X points to its single most-recent such Y (a functional
+    a send that came back or was withdrawn unread — a terminal bounced or maildir-recall row — is
+    neither an ask nor an answer, see _postal_wait_maps) AND Y is ALIVE (a dead peer won't reply). Each X points to its single most-recent such Y (a functional
     graph), so following the edges detects CYCLES (X→Y→…→X = a mutual-wait deadlock). Returns
     {sid: {peerSid, name, color, inCycle, since, kind}} for every waiting session — the goal card's chip
     (kind picks its label: "Awaiting <peer>" vs "Handed off to <peer>") + the auto-nudge gate read it.
@@ -31098,8 +31119,9 @@ def _wait_for_graph(now, alive_sids):
 
 
 def _peer_answered_at(sid):
-    """The latest time a peer that `sid` had ASKED (question) or DELEGATED to REPLIED — or the bus RETURNED
-    that send (a terminal bounced row, 2026-09-08) — over pairs with no newer outstanding ask: max of
+    """The latest time a peer that `sid` had ASKED (question) or DELEGATED to REPLIED — or that send was
+    returned or withdrawn (a terminal bounced or maildir-recall row, 2026-09-08) — over pairs with no newer
+    outstanding ask: max of
     last_any[(Y, sid)] where that reply is at/after sid's latest ask to Y, and of the pair's return.
     0 when nothing qualifies. The durable ⏳ awaiting-stamp readers treat a stamp OLDER than this as
     SUPERSEDED — the awaited answer arrived after the closer spoke, which is exactly the event the stamp
@@ -31119,8 +31141,8 @@ def _peer_answered_at(sid):
     # exact ending event for both; the chip edge stays question-only, exactly as #430 intended. Not
     # last_any (2026-09-08): a COORDINATE the asker sent after the answer landed ("thanks") counted as
     # a newer outbound awaiting a reply, so the answer read as stale and the stamp stood.
-    # The bus RETURNING the send (2026-09-08, a terminal bounced row) is the pair's other ending event:
-    # the peer never got the ask and nothing will come back, so a stamp filed before the return is
+    # The send returned or withdrawn (2026-09-08, a terminal bounced or maildir-recall row) is the pair's
+    # other ending event: the peer never got the ask and nothing will come back, so a stamp filed before it is
     # superseded by it exactly as by a reply (_pair_wait_ended, the clock _peer_answered shares).
     for f, t_ in set(last_await) | set(returned):
         if f != sid:
@@ -31130,7 +31152,7 @@ def _peer_answered_at(sid):
 
 
 def _peer_answered(sid):
-    """(answered_any, {peer_key: t the wait on that peer ENDED — its reply, or the bus returning the ask})
+    """(answered_any, {peer_key: t the wait on that peer ENDED — its reply, or the ask returned or withdrawn})
     — _peer_answered_at with the PAIR kept (2026-08-24): the
     pair-blind scalar let ANY answered exchange supersede ANY peer stamp, so an unrelated coordinate
     from the same log hid a real wait (three stuck stamps, one ~14h). Stamps that record WHICH
@@ -31145,7 +31167,7 @@ def _peer_answered(sid):
     for f, t_ in set(last_await) | set(returned):   # reply-requiring sends only — see _peer_answered_at
         if f != sid:
             continue
-        ended = _pair_wait_ended(last_any, last_await, returned, f, t_)   # the reply, or the bus's return
+        ended = _pair_wait_ended(last_any, last_await, returned, f, t_)   # the reply, or the return / withdrawal
         if ended:
             per[t_] = max(per.get(t_, 0), ended)
     return best, per

--- a/tests/test_awaiting_peer_matrix.py
+++ b/tests/test_awaiting_peer_matrix.py
@@ -304,6 +304,24 @@ class TwinsKeyMailByStableId(_Base):
             jd._learn_alias(alias, o)
         self.assertEqual(alias, {"TESTHOST:api": [(0, self.X), (40, self.Y)]})
 
+    def test_a_row_that_came_back_still_teaches_the_alias(self):
+        # 2026-09-08: identity is not word — a remote sender's row names who wore the name even when the
+        # message itself came back or was recalled unread. The alias half is a guard on the exclusion's
+        # reach (green on the base by design); the last_any half is the fix (base: the row counted as
+        # X's word toward SID)
+        for terminal in ({"id": "m2", "ev": "bounced", "t": T0 + 60, "to": "web",
+                          "why": "recipient exited; unread mail destroyed by the orphan sweep"},
+                         {"id": "m2", "ev": "recall", "t": T0 + 60}):
+            self._log([self._row(i=2, **{"from": "api"}, from_id=self.X, to_id=SID, t=T0 + 50,
+                                 kind="coordinate", from_host="TESTHOST"),
+                       json.dumps(terminal)])
+            last_any, _ask, alias = jd._postal_ask_maps()
+            self.assertEqual(jd._alias_at(alias, "TESTHOST:api", T0 + 50), self.X, "the judge still learned the wearer")
+            self.assertNotIn((self.X, SID), last_any, "…while the row is not X's word: %s" % terminal["ev"])
+            k_any, _k_ask, _k_aw = km._postal_wait_maps()
+            self.assertEqual(km._postal_peer_names().get(self.X), "TESTHOST:api", "the kernel's display join too")
+            self.assertNotIn((self.X, SID), k_any)
+
 
 class MatrixPlannerGate(_Base):
     """The nudge planner's awaiting op: kind=peer demotes to kindless without an open ask (the op's
@@ -591,17 +609,44 @@ class CrossHostDelegation(_Base):
         self.assertEqual([nd["handoff"]["msgId"] for nd in self._handoffs()], ["px-2.mail.TESTHOST-A"],
                          "main: both planted — the returned delegate got a tracker no event could close")
 
+    def test_a_recalled_outbox_delegate_still_plants_the_tracker(self):
+        # review find, 2026-09-08: an OUTBOX recall names the relay mid ("px-…"), and the outbox item
+        # outlives the carry (the exchange relays it without removing it; only the end-to-end ack does),
+        # so the far host may already have delivered it and the peer may report back — NOT terminal,
+        # and the tracker is planted as before (green on the base by design, where no recall was read).
+        # The bus owns the follow-up: refuse to recall a carried item, or stamp the row with its box.
+        self._fleet_stub()
+        self._log([self._xrow(1, T0 + 10),
+                   json.dumps({"id": "px-1.mail.TESTHOST-A", "ev": "recall", "t": T0 + 50}),
+                   self._xrow(2, T0 + 20, body="own the importer work")])
+        jd.run_courier(now=T0 + 100)
+        self.assertEqual(sorted(nd["handoff"]["msgId"] for nd in self._handoffs()),
+                         ["px-1.mail.TESTHOST-A", "px-2.mail.TESTHOST-A"],
+                         "a recalled outbox delegate keeps its tracker: the recall is not read as terminal")
+
 
 class ReturnedAskTwins(_Base):
     """A send the bus RETURNED (a terminal `bounced` row naming its id) is a closed ask on both readers
     (2026-09-08): the closer's admit gate sees no open question to stamp a peer wait over, and the wait
     maps set no chip edge. Before, both twins skipped the row (no from_id/to_id) and the sender read as
-    waiting on a peer that never got the message — a card parked on a wait no event could end."""
+    waiting on a peer that never got the message — a card parked on a wait no event could end. The same
+    day's second fold: a maildir `recall` row (the sender withdrew the message unread) is the other
+    terminal kind, riding #1071's one skip before last_any — so a recalled reply, like a bounced one
+    (#1071's own test), leaves the asker's question open on both readers."""
 
     @staticmethod
     def _back(i, ts, host=""):
         return json.dumps({"id": "m%d" % i, "ev": "bounced", "t": ts, "to": "web", "host": host,
                            "why": "recipient exited; unread mail destroyed by the orphan sweep"})
+
+    @staticmethod
+    def _recall(i, ts):
+        return json.dumps({"id": "m%d" % i, "ev": "recall", "t": ts})    # the sender unsent it unread
+
+    @staticmethod
+    def _km_open(sid):
+        last_any, last_ask, _aw = km._postal_wait_maps()
+        return any(f == sid and last_any.get((p, sid), 0) < meta[0] for (f, p), meta in last_ask.items())
 
     def test_the_closer_does_not_stamp_a_peer_wait_over_a_returned_question(self):
         s, gid = self._store()
@@ -623,6 +668,53 @@ class ReturnedAskTwins(_Base):
             self._log(rows)
             self.assertEqual((jd._open_peer_asks(SID), km_open(SID)), (open_, open_),
                              "gate and wait-maps on: %s" % rows)
+
+    def test_the_closer_does_not_stamp_a_peer_wait_over_a_recalled_question(self):
+        # 2026-09-08: the worker withdrew its question before the manager read it — as over as a bounce
+        s, gid = self._store()
+        self._log([_msg(1, SID, MGR, T0 + 10, "question"), self._recall(1, T0 + 20)])
+        self._close_peer(s)
+        self.assertEqual((s["nodes"][gid].get("awaitingWhy"), s["nodes"][gid].get("awaitingKind")), (None, None),
+                         "base: the gate read the withdrawn question as open and admitted the peer stamp")
+        self.assertEqual(jd._open_ask_peers(SID), [], "no open ask: the worker unsent it")
+
+    def test_both_readers_agree_on_a_recalled_ask(self):
+        grid = [
+            ([_msg(1, SID, MGR, T0, "question"), self._recall(1, T0 + 5)], False),
+            ([_msg(1, SID, MGR, T0, "question"), _msg(2, SID, MGR, T0 + 5, "question"), self._recall(1, T0 + 9)], True),
+            # an OUTBOX recall (the row names the relay mid, "px-…") is not terminal: the item may already
+            # have been carried, so the cross-host ask stays open on both readers (review find, 2026-09-08)
+            ([json.dumps({"id": "px-1.mail.TESTHOST", "ev": "sent", "from": "web", "from_id": SID,
+                          "to_id": "peer:otherbox", "toName": "otherbox:web", "t": T0, "body": "x", "kind": "question"}),
+              json.dumps({"id": "px-1.mail.TESTHOST", "ev": "recall", "t": T0 + 5})], True),
+        ]
+        for rows, open_ in grid:
+            self._log(rows)
+            self.assertEqual((jd._open_peer_asks(SID), self._km_open(SID)), (open_, open_),
+                             "gate and wait-maps on: %s" % rows)
+
+    def test_both_readers_agree_a_recalled_reply_answers_nothing(self):
+        # the manager recalled its reply before the worker read it: the worker never received it, so its
+        # question is as open as before on both readers; the first row is the guard. (The BOUNCED reply
+        # is #1071's rule and test: test_a_refused_question_is_no_open_ask_for_either_reader's second half.)
+        grid = [
+            ([_msg(1, SID, MGR, T0, "question"), _msg(2, MGR, SID, T0 + 5, "coordinate")], False),
+            ([_msg(1, SID, MGR, T0, "question"), _msg(2, MGR, SID, T0 + 5, "coordinate"), self._recall(2, T0 + 9)], True),
+        ]
+        for rows, open_ in grid:
+            self._log(rows)
+            self.assertEqual((jd._open_peer_asks(SID), self._km_open(SID)), (open_, open_),
+                             "gate and wait-maps on: %s" % rows)
+
+    def test_the_closer_still_stamps_when_the_reply_was_recalled(self):
+        # the admit gate's other direction, at the closer's WRITE: the wait IS on when the only answer was
+        # withdrawn before it arrived (the bounced reply's gate predicate is #1071's test)
+        s, gid = self._store()
+        self._log([_msg(1, SID, MGR, T0 + 10, "question"), _msg(2, MGR, SID, T0 + 20, "coordinate"),
+                   self._recall(2, T0 + 30)])
+        self._close_peer(s)
+        self.assertEqual(s["nodes"][gid].get("awaitingKind"), "peer",
+                         "base: the recalled reply read as the answer and the gate dropped the stamp")
 
 
 if __name__ == "__main__":

--- a/tests/test_awaiting_peer_matrix.py
+++ b/tests/test_awaiting_peer_matrix.py
@@ -579,6 +579,51 @@ class CrossHostDelegation(_Base):
         self.assertTrue(nd.get("nodeComplete"))
         self.assertIn("reported back by TESTHOST-B:web", nd.get("doneWhy") or "")
 
+    def test_a_delegate_that_came_back_plants_no_tracker(self):
+        # 2026-09-08: the far host refused the handoff (a terminal bounced row names it) before the
+        # courier's pass — a tracker planted from it would wait on a report-back nothing can bring
+        self._fleet_stub()
+        self._log([self._xrow(1, T0 + 10),
+                   json.dumps({"id": "px-1.mail.TESTHOST-A", "ev": "bounced", "t": T0 + 50,
+                               "to": self.RNAME, "host": self.RHOST, "why": "refused"}),
+                   self._xrow(2, T0 + 20, body="own the importer work")])
+        jd.run_courier(now=T0 + 100)
+        self.assertEqual([nd["handoff"]["msgId"] for nd in self._handoffs()], ["px-2.mail.TESTHOST-A"],
+                         "main: both planted — the returned delegate got a tracker no event could close")
+
+
+class ReturnedAskTwins(_Base):
+    """A send the bus RETURNED (a terminal `bounced` row naming its id) is a closed ask on both readers
+    (2026-09-08): the closer's admit gate sees no open question to stamp a peer wait over, and the wait
+    maps set no chip edge. Before, both twins skipped the row (no from_id/to_id) and the sender read as
+    waiting on a peer that never got the message — a card parked on a wait no event could end."""
+
+    @staticmethod
+    def _back(i, ts, host=""):
+        return json.dumps({"id": "m%d" % i, "ev": "bounced", "t": ts, "to": "web", "host": host,
+                           "why": "recipient exited; unread mail destroyed by the orphan sweep"})
+
+    def test_the_closer_does_not_stamp_a_peer_wait_over_a_returned_question(self):
+        s, gid = self._store()
+        self._log([_msg(1, SID, MGR, T0 + 10, "question"), self._back(1, T0 + 20)])
+        self._close_peer(s)
+        self.assertEqual((s["nodes"][gid].get("awaitingWhy"), s["nodes"][gid].get("awaitingKind")), (None, None),
+                         "main: the gate read the returned question as open and admitted the peer stamp")
+        self.assertEqual(jd._open_ask_peers(SID), [], "no open ask: the message never reached the manager")
+
+    def test_both_readers_agree_on_a_returned_ask(self):
+        def km_open(sid):
+            last_any, last_ask, _aw = km._postal_wait_maps()
+            return any(f == sid and last_any.get((p, sid), 0) < meta[0] for (f, p), meta in last_ask.items())
+        grid = [   # the single returned question is test_a_refused_question_is_no_open_ask_for_either_reader's
+            ([_msg(1, SID, MGR, T0, "question"), _msg(2, SID, MGR, T0 + 5, "question"), self._back(1, T0 + 9)], True),
+            ([_msg(1, SID, "peer:otherbox", T0, "question"), self._back(1, T0 + 5, host="otherbox")], False),
+        ]
+        for rows, open_ in grid:
+            self._log(rows)
+            self.assertEqual((jd._open_peer_asks(SID), km_open(SID)), (open_, open_),
+                             "gate and wait-maps on: %s" % rows)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_chain_rooted_minting.py
+++ b/tests/test_chain_rooted_minting.py
@@ -1018,6 +1018,23 @@ class QuietReportBack(unittest.TestCase):
         self.assertFalse(jd.load_goals(MGR)["nodes"][MGR + ":t1"].get("nodeComplete"),
                          "a linked recipient goal exists — its completion is the event, not the reply")
 
+    def test_a_reply_that_came_back_completes_nothing(self):
+        # 2026-09-08: the worker's report was bounced back to it (the oversize push: the message is not
+        # put back in the manager's box) or recalled before the manager read it — a report the manager
+        # never received is not a report-back, so the tracker stays open. Guard:
+        # test_a_quiet_tracker_completes_on_the_reply (the same world, nothing naming the reply).
+        for name, terminal in (("bounced", {"t": T0 + 950, "ev": "bounced", "id": "r1", "to": "web", "host": "",
+                                            "why": "your message is 90000 bytes as delivered, over the limit"}),
+                               ("recalled", {"t": T0 + 950, "ev": "recall", "id": "r1"})):
+            self._world(quiet=True, reply_at=T0 + 900)
+            with jd.MESSAGES.open("a") as fh:
+                fh.write(json.dumps(terminal) + "\n")
+            jd._PEER_ASK_CACHE[:] = [None, ({}, {}, {})]
+            jd.run_propagate(now=NOW)
+            nd = jd.load_goals(MGR)["nodes"][MGR + ":t1"]
+            self.assertFalse(nd.get("nodeComplete"),
+                             "%s: base — marked done, reported back by a message the manager never got" % name)
+
 
 class NeedsYouStillSurfaces(unittest.TestCase):
     """THE CRITICAL PIN: quiet filing leaves zero goal nodes, and the needs-you surfaces are

--- a/tests/test_kernel_await_release.py
+++ b/tests/test_kernel_await_release.py
@@ -296,5 +296,106 @@ class RefusedSendsAreNoAsk(_AwaitBase):
         self.assertEqual(km._peer_answered_at(B), 0)
 
 
+class ReturnedSendEndsTheWait(_AwaitBase):
+    """The bus RETURNING a reply-requiring send is the pair's other ending event (2026-09-08). A
+    terminal `bounced` row names the message's id when the send is over with nothing ever coming back
+    (refused by the peer, recipient gone, never left). The answered clock walked replies only, so a
+    closer stamp awaiting that peer stood — the card parked on a wait no event could end — until the
+    6h backstop. Now the return supersedes a stamp filed before it, exactly as a reply does, and only
+    for the message it names."""
+
+    def _stamp(self, written_at):
+        return {"awaitingAt": written_at, "awaitingKind": "peer", "awaitingPeers": [B],
+                "awaitingWhy": "asked the api session which port", "log": [{"kind": "awaiting", "at": written_at}]}
+
+    @staticmethod
+    def _back(mid, t, **extra):
+        r = {"ev": "bounced", "id": mid, "t": t, "to": "api", "host": "",
+             "why": "recipient exited; unread mail destroyed by the orphan sweep"}
+        r.update(extra)
+        return r
+
+    def test_a_returned_question_ends_the_wait_at_the_return(self):
+        self._write([
+            {"id": "m1", "from_id": A, "to_id": B, "t": 100, "kind": "question", "body": "which port?"},
+            self._back("m1", 150),
+        ])
+        self.assertEqual(km._peer_answered_at(A), 150, "main: 0 — the pair read as still waiting")
+        self.assertEqual(km._peer_answered(A), (150, {B: 150}), "…pair-aware alike")
+        self.assertTrue(km._peer_stamp_superseded(self._stamp(120), km._peer_answered(A)),
+                        "a stamp written before the return is ended by it (main: stands)")
+        self.assertFalse(km._peer_stamp_superseded(self._stamp(160), km._peer_answered(A)),
+                         "a stamp written AFTER the return is fresher than it — it stands")
+
+    def test_a_returned_delegate_ends_the_handoff_wait_too(self):
+        self._write([
+            {"id": "m1", "from_id": A, "to_id": B, "t": 100, "kind": "delegate", "body": "own the exporter"},
+            self._back("m1", 150),
+        ])
+        self.assertEqual(km._peer_answered_at(A), 150, "a handoff that came back is over, like an answered one")
+
+    def test_the_return_ends_only_the_send_it_names(self):
+        # an older ask comes back after a newer one went out: the live ask holds the pair open
+        self._write([
+            {"id": "m1", "from_id": A, "to_id": B, "t": 100, "kind": "question", "body": "which port?"},
+            {"id": "m2", "from_id": A, "to_id": B, "t": 200, "kind": "question", "body": "and the host?"},
+            self._back("m1", 300),
+        ])
+        self.assertEqual(km._peer_answered_at(A), 0, "the newer ask still waits")
+        self.assertEqual(km._peer_answered(A), (0, {}))
+        self.assertFalse(km._peer_stamp_superseded(self._stamp(250), km._peer_answered(A)))
+
+    def test_a_reply_then_a_later_return_the_newer_ends_the_pair(self):
+        # m1 answered at 250; m2 (sent 200) came back at 300: the pair's last obligation ended at 300
+        self._write([
+            {"id": "m1", "from_id": A, "to_id": B, "t": 100, "kind": "question", "body": "which port?"},
+            {"id": "m2", "from_id": A, "to_id": B, "t": 200, "kind": "delegate", "body": "own the exporter"},
+            {"id": "r1", "from_id": B, "to_id": A, "t": 250, "kind": "coordinate", "body": "8080"},
+            self._back("m2", 300),
+        ])
+        self.assertEqual(km._peer_answered_at(A), 300)
+        self.assertTrue(km._peer_stamp_superseded(self._stamp(270), km._peer_answered(A)),
+                        "a stamp filed after the answer, about the handoff, ends when the handoff comes back")
+
+    def test_a_returned_coordinate_ends_nothing(self):
+        # a heads-up opened no wait; its return is not an ending event for the pair
+        self._write([
+            {"id": "m1", "from_id": A, "to_id": B, "t": 100, "kind": "coordinate", "body": "fyi"},
+            self._back("m1", 150),
+        ])
+        self.assertEqual(km._peer_answered_at(A), 0)
+        self.assertEqual(km._peer_answered(A), (0, {}))
+
+    def test_a_delivery_ack_is_not_an_ending(self):
+        self._write([
+            {"id": "m1", "from_id": A, "to_id": B, "t": 100, "kind": "question", "body": "which port?"},
+            {"ev": "relayed", "id": "m1", "t": 150, "host": "TESTHOST-B"},
+        ])
+        self.assertEqual(km._peer_answered_at(A), 0, "delivered is not answered, and not returned either")
+
+    def test_the_return_clock_is_keyed_like_the_maps(self):
+        # a cross-host ask keyed on to_sid: the return lands on the pair key the stamp recorded
+        rsid = "11111111-2222-3333-4444-000000000009"
+        self._write([
+            {"id": "m1", "from_id": A, "to_id": "peer:TESTHOST-B", "toName": "TESTHOST-B:api", "to_sid": rsid,
+             "t": 100, "kind": "question", "body": "which port?"},
+            self._back("m1", 150, host="TESTHOST-B", why="refused"),
+        ])
+        self.assertEqual(km._peer_answered(A), (150, {rsid: 150}))
+        self.assertEqual(km._postal_returned(), {(A, rsid): {100: 150}},
+                         "keyed by pair, then by the send's own time: the debt readers join a record's ask time to it")
+
+    def test_a_reply_after_the_return_is_not_credited(self):
+        # the return came first; a later B→A row finds no live reply-requiring send to answer, so the
+        # pair's ending stays the return's t (no live send, no reply credit — _pair_wait_ended's contract)
+        self._write([
+            {"id": "m1", "from_id": A, "to_id": B, "t": 100, "kind": "question", "body": "which port?"},
+            self._back("m1", 150),
+            {"id": "r1", "from_id": B, "to_id": A, "t": 200, "kind": "coordinate", "body": "8080"},
+        ])
+        self.assertEqual(km._peer_answered_at(A), 150)
+        self.assertEqual(km._peer_answered(A), (150, {B: 150}))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_kernel_await_release.py
+++ b/tests/test_kernel_await_release.py
@@ -296,17 +296,26 @@ class RefusedSendsAreNoAsk(_AwaitBase):
         self.assertEqual(km._peer_answered_at(B), 0)
 
 
+def _stamp(written_at):
+    return {"awaitingAt": written_at, "awaitingKind": "peer", "awaitingPeers": [B],
+            "awaitingWhy": "asked the api session which port", "log": [{"kind": "awaiting", "at": written_at}]}
+
+
 class ReturnedSendEndsTheWait(_AwaitBase):
     """The bus RETURNING a reply-requiring send is the pair's other ending event (2026-09-08). A
     terminal `bounced` row names the message's id when the send is over with nothing ever coming back
     (refused by the peer, recipient gone, never left). The answered clock walked replies only, so a
     closer stamp awaiting that peer stood — the card parked on a wait no event could end — until the
     6h backstop. Now the return supersedes a stamp filed before it, exactly as a reply does, and only
-    for the message it names."""
+    for the message it names. A `recall` row — the sender withdrew the message before anyone read it —
+    is the other terminal kind and ends the wait the same way (2026-09-08, the second fold)."""
 
     def _stamp(self, written_at):
-        return {"awaitingAt": written_at, "awaitingKind": "peer", "awaitingPeers": [B],
-                "awaitingWhy": "asked the api session which port", "log": [{"kind": "awaiting", "at": written_at}]}
+        return _stamp(written_at)
+
+    @staticmethod
+    def _recall(mid, t):
+        return {"ev": "recall", "id": mid, "t": t}     # the sender unsent it unread: the row's whole shape
 
     @staticmethod
     def _back(mid, t, **extra):
@@ -395,6 +404,87 @@ class ReturnedSendEndsTheWait(_AwaitBase):
         ])
         self.assertEqual(km._peer_answered_at(A), 150)
         self.assertEqual(km._peer_answered(A), (150, {B: 150}))
+
+    def test_a_recalled_question_ends_the_wait_at_the_recall(self):
+        # the asker withdrew its own question before the peer read it: the wait it opened is over at the
+        # recall's t, and a stamp filed before it is superseded exactly as by a bounce
+        self._write([
+            {"id": "m1", "from_id": A, "to_id": B, "t": 100, "kind": "question", "body": "which port?"},
+            self._recall("m1", 150),
+        ])
+        self.assertEqual(km._peer_answered_at(A), 150, "base: 0 — a recall was not read as terminal, the stamp stood")
+        self.assertEqual(km._peer_answered(A), (150, {B: 150}))
+        self.assertTrue(km._peer_stamp_superseded(self._stamp(120), km._peer_answered(A)))
+        self.assertFalse(km._peer_stamp_superseded(self._stamp(160), km._peer_answered(A)),
+                         "a stamp written AFTER the recall is fresher than it — it stands")
+
+    def test_a_recalled_delegate_ends_the_handoff_wait_too(self):
+        self._write([
+            {"id": "m1", "from_id": A, "to_id": B, "t": 100, "kind": "delegate", "body": "own the exporter"},
+            self._recall("m1", 150),
+        ])
+        self.assertEqual(km._peer_answered_at(A), 150, "a handoff its sender unsent is over, like one that came back")
+
+    def test_a_recalled_coordinate_ends_nothing(self):
+        # a heads-up opened no wait; withdrawing it ends none (a guard: green on the base by design)
+        self._write([
+            {"id": "m1", "from_id": A, "to_id": B, "t": 100, "kind": "coordinate", "body": "fyi"},
+            self._recall("m1", 150),
+        ])
+        self.assertEqual(km._peer_answered_at(A), 0)
+        self.assertEqual(km._peer_answered(A), (0, {}))
+        self.assertEqual(km._postal_returned(), {}, "no reply-requiring send was withdrawn → no return clock")
+
+    def test_a_recall_naming_a_relay_mid_ends_nothing(self):
+        # the OUTBOX arm (review find, 2026-09-08): the row names the relay mid ("px-…"), and the item may
+        # already have been carried and delivered, so its recall is not terminal — the wait stays open
+        # (as on the base, where no recall was read; the maildir recall above ends it)
+        rsid = "11111111-2222-3333-4444-000000000009"
+        self._write([
+            {"id": "px-1.mail.TESTHOST-A", "from_id": A, "to_id": "peer:TESTHOST-B", "toName": "TESTHOST-B:api",
+             "to_sid": rsid, "t": 100, "kind": "question", "body": "which port?"},
+            self._recall("px-1.mail.TESTHOST-A", 150),
+        ])
+        self.assertEqual(km._peer_answered_at(A), 0)
+        self.assertEqual(km._peer_answered(A), (0, {}))
+        self.assertEqual(km._postal_returned(), {})
+
+
+class ReturnedReplyDoesNotEndTheWait(_AwaitBase):
+    """A reply the replier recalled before the asker read it is not the peer's word (2026-09-08): the
+    ending clock read last_any[(B, A)] and credited B's sent row even after a terminal row named it — a
+    recall unlinks it from A's new/ unread — so A's stamp lifted on an answer A never received and the
+    card left a wait that was still on. The bounced reply is #1071's rule and its test
+    (RefusedSendsAreNoAsk.test_a_bounced_reply_answers_nothing holds _peer_answered_at at 0); the recall
+    rides the same skip through _learn_return. Guard: with nothing naming it the reply answers as ever
+    (test_the_reply_alone_answers; AwaitRelease.test_question_release_unchanged)."""
+
+    ROWS = [
+        {"id": "m1", "from_id": A, "to_id": B, "t": 100, "kind": "question", "body": "which port?"},
+        {"id": "r1", "from_id": B, "to_id": A, "t": 200, "kind": "coordinate", "body": "8080"},
+    ]
+
+    def test_the_reply_alone_answers(self):
+        self._write(self.ROWS)
+        self.assertEqual(km._peer_answered_at(A), 200)
+        self.assertTrue(km._peer_stamp_superseded(_stamp(150), km._peer_answered(A)))
+
+    def test_a_recalled_reply_answers_nothing(self):
+        self._write(self.ROWS + [ReturnedSendEndsTheWait._recall("r1", 250)])
+        self.assertEqual(km._peer_answered_at(A), 0, "base: 200 — the stamp lifted on a reply A never received")
+        self.assertEqual(km._peer_answered(A), (0, {}))
+        self.assertFalse(km._peer_stamp_superseded(_stamp(150), km._peer_answered(A)),
+                         "the stamp stands — A is still waiting on B")
+
+    def test_the_exclusion_is_per_message_not_per_second(self):
+        # B's live reply in the SAME second as the one that came back still answers: the join is the id,
+        # and last_any keys the pair by its newest live row exactly as before
+        self._write(self.ROWS + [
+            {"id": "r2", "from_id": B, "to_id": A, "t": 200, "kind": "coordinate", "body": "8080 (resent)"},
+            ReturnedSendEndsTheWait._recall("r1", 250),
+        ])
+        self.assertEqual(km._peer_answered_at(A), 200)
+        self.assertEqual(km._peer_answered(A), (200, {B: 200}))
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_debt_nudge.py
+++ b/tests/test_kernel_debt_nudge.py
@@ -10,6 +10,7 @@ import json
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
@@ -257,6 +258,87 @@ class ReminderOutcomes(DebtBase):
             self.assertEqual(self._esc, [(ASKER, DEBTOR, T_ASK)],
                              "%s: the live twin's reminder still escalates (the first fold retired it)" % path)
             self.assertEqual(self._d["debtNudged"], {})
+
+
+class TerminalRowsThroughTheRealMaps(unittest.TestCase):
+    """The debt readers against the REAL maps over a synthetic log (2026-09-08). The stub seam above hands
+    the readers their maps, so it cannot show what the maps make of a `recall` row or of a reply that came
+    back. (A) an ask its sender withdrew before the debtor read it is no debt, and its reminder retires
+    without escalating, exactly as a bounce; (B) a reply the bus returned (the oversize push bounces it to
+    the replier without putting it back in the asker's box), or that the replier recalled unread, is not
+    the replier's word: the debt stands, and a reminder the debtor moved on from escalates instead of
+    reading answered. Guard: the reply alone settles the debt (test_the_reply_alone_settles_the_debt)."""
+
+    ASK = {"ev": "sent", "id": "m1", "from_id": ASKER, "to_id": DEBTOR, "t": T_ASK, "kind": "question",
+           "body": "Which port should the staging server use?"}
+    REPLY = {"ev": "sent", "id": "r1", "from_id": DEBTOR, "to_id": ASKER, "t": T_ASK + 60,
+             "kind": "coordinate", "body": "8080"}
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._saved = (km.jd.MESSAGES, km._auto_nudge_data, km._write_auto_nudge, km._debt_escalate, km._name_of)
+        km.jd.MESSAGES = Path(self.td.name) / "messages.jsonl"
+        self._d = {"nudged": {}}
+        km._auto_nudge_data = lambda: self._d
+        km._write_auto_nudge = lambda d: self._d.update(d) or True
+        self._esc = []
+        km._debt_escalate = lambda asker, debtor, ts, now: (self._esc.append((asker, debtor, ts)) or True)
+        km._name_of = lambda sid: {ASKER: "web", DEBTOR: "tests"}.get(sid)
+        km._POSTAL_WAIT_CACHE[:] = [None, None]
+
+    def tearDown(self):
+        km.jd.MESSAGES, km._auto_nudge_data, km._write_auto_nudge, km._debt_escalate, km._name_of = self._saved
+        km._POSTAL_WAIT_CACHE[:] = [None, None]
+        self.td.cleanup()
+
+    def _log(self, rows):
+        km.jd.MESSAGES.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+        km._POSTAL_WAIT_CACHE[:] = [None, None]
+
+    def _armed(self, fire_t=NOW - 600):
+        self._d["debtNudged"] = {"%s>%s:%d" % (ASKER, DEBTOR, T_ASK): fire_t}
+
+    def test_a_recalled_ask_is_no_debt_and_its_reminder_retires(self):
+        self._log([self.ASK, {"ev": "recall", "id": "m1", "t": T_ASK + 30}])
+        self.assertEqual(km._debt_asks(DEBTOR, {ASKER}), [], "base: owed — for an ask the debtor never had")
+        self._armed()
+        km._debt_reminder_outcomes(DEBTOR, {"t": NOW - 300, "end": NOW - 200}, NOW)
+        self.assertEqual(self._esc, [], "base: escalated — a block on the asker's card for an ask it withdrew")
+        self.assertEqual(self._d["debtNudged"], {}, "the record retires, once-ever, like a bounced one")
+
+    def test_a_reply_that_came_back_settles_nothing(self):
+        for name, terminal in (("bounced", {"ev": "bounced", "id": "r1", "t": T_ASK + 90, "to": "web", "host": "",
+                                            "why": "your message is 90000 bytes as delivered, over the limit"}),
+                               ("recalled", {"ev": "recall", "id": "r1", "t": T_ASK + 90})):
+            self._esc.clear()
+            self._log([self.ASK, self.REPLY, terminal])
+            self.assertEqual([a[0] for a in km._debt_asks(DEBTOR, {ASKER})], [ASKER],
+                             "%s: base — no debt, on a reply the asker never received" % name)
+            self._armed(fire_t=NOW - 600)
+            km._debt_reminder_outcomes(DEBTOR, {"t": NOW - 300, "end": NOW - 200}, NOW)
+            self.assertEqual(self._esc, [(ASKER, DEBTOR, T_ASK)],
+                             "%s: base — retired as answered; the debtor moved on, so the wait is the user's" % name)
+            self.assertEqual(self._d["debtNudged"], {})
+
+    def test_a_recall_naming_a_relay_mid_leaves_the_debt_owed(self):
+        # the OUTBOX arm (review find, 2026-09-08): the relay mid ("px-…") marks a recall whose item may
+        # already have been carried and delivered — not terminal, so the debtor still owes and a reminder
+        # it moved on from escalates, exactly as before (green on the base by design)
+        ask = dict(self.ASK, id="px-1.mail.TESTHOST-A", to_id="peer:TESTHOST-B",
+                   toName="TESTHOST-B:tests", to_sid=DEBTOR)
+        self._log([ask, {"ev": "recall", "id": "px-1.mail.TESTHOST-A", "t": T_ASK + 30}])
+        self.assertEqual([a[0] for a in km._debt_asks(DEBTOR, {ASKER})], [ASKER], "still owed")
+        self._armed()
+        km._debt_reminder_outcomes(DEBTOR, {"t": NOW - 300, "end": NOW - 200}, NOW)
+        self.assertEqual(self._esc, [(ASKER, DEBTOR, T_ASK)], "the debtor moved on: the wait is the user's")
+        self.assertEqual(self._d["debtNudged"], {})
+
+    def test_the_reply_alone_settles_the_debt(self):
+        self._log([self.ASK, self.REPLY])
+        self.assertEqual(km._debt_asks(DEBTOR, {ASKER}), [])
+        self._armed()
+        km._debt_reminder_outcomes(DEBTOR, {"t": NOW - 300, "end": NOW - 200}, NOW)
+        self.assertEqual((self._esc, self._d["debtNudged"]), ([], {}), "the reminder worked; nothing escalates")
 
 
 class DebtEscalate(DebtBase):

--- a/tests/test_kernel_debt_nudge.py
+++ b/tests/test_kernel_debt_nudge.py
@@ -39,7 +39,8 @@ class _Recorder:
 class DebtBase(unittest.TestCase):
     def setUp(self):
         self._saved = (km._postal_wait_maps, km._name_of, km._auto_nudge_data,
-                       km._write_auto_nudge, km.Sessions.backend_for)
+                       km._write_auto_nudge, km.Sessions.backend_for,
+                       getattr(km, "_postal_returned", None))   # absent before 2026-09-08: the seam degrades
         self._d = {"nudged": {}}
         km._auto_nudge_data = lambda: self._d
         km._write_auto_nudge = lambda d: self._d.update(d) or True   # the writer's verdict: the reminder
@@ -49,17 +50,25 @@ class DebtBase(unittest.TestCase):
         km.Sessions.backend_for = lambda sid: self.rec
         self._maps = ({}, {}, {})   # (last_any, last_ask, last_await)
         km._postal_wait_maps = lambda: self._maps
+        self._returned = {}         # {(asker, debtor): {ask t: return t}} — the maps' returns, same seam
+        km._postal_returned = lambda: self._returned
 
     def tearDown(self):
         (km._postal_wait_maps, km._name_of, km._auto_nudge_data,
-         km._write_auto_nudge, km.Sessions.backend_for) = self._saved
+         km._write_auto_nudge, km.Sessions.backend_for, _ret) = self._saved
+        if _ret is None:
+            del km._postal_returned
+        else:
+            km._postal_returned = _ret
 
     def _ask(self, kind="question", head="Which port should the staging server use?",
-             ts=T_ASK, asker=ASKER, answered_at=None):
+             ts=T_ASK, asker=ASKER, answered_at=None, returned_at=None):
         last_any = {(asker, DEBTOR): ts}
         if answered_at is not None:
             last_any[(DEBTOR, asker)] = answered_at
-        last_ask = {(asker, DEBTOR): (ts, kind, head)}
+        # an ask the bus returned makes no last_ask entry and lands in the returns, as the real maps have it
+        last_ask = {} if returned_at is not None else {(asker, DEBTOR): (ts, kind, head)}
+        self._returned = {(asker, DEBTOR): {ts: returned_at}} if returned_at is not None else {}
         self._maps = (last_any, last_ask, {})
         km._postal_wait_maps = lambda: self._maps
 
@@ -200,6 +209,54 @@ class ReminderOutcomes(DebtBase):
         self._d["debtNudged"] = {"not-a-key": NOW - 600}
         km._debt_backstop_tick(NOW)
         self.assertEqual(self._d["debtNudged"], {}, "malformed records drop rather than loop forever")
+
+    def test_a_returned_ask_retires_the_reminder_without_escalating(self):
+        # 2026-09-08: the debtor exited before the reminder's turn read the ask; ORPHAN_GRACE later the
+        # sweep destroyed the mail and wrote the terminal bounced row, and the bus told the asker. The
+        # return IS the outcome. The guard — the same turn with no return escalates — is
+        # test_moving_on_without_replying_escalates_once above.
+        self._ask(returned_at=NOW - 400)
+        self._armed(fire_t=NOW - 600)
+        lt = {"t": NOW - 300, "end": NOW - 200}        # a turn ended after the fire, no reply
+        km._debt_reminder_outcomes(DEBTOR, lt, NOW)
+        self.assertEqual(self._esc, [], "main: escalated — a block on the asker's card for an ask that came back")
+        self.assertEqual(self._d["debtNudged"], {}, "the record retires, once-ever, like an answered one")
+
+    def test_the_backstop_retires_a_returned_ask_too(self):
+        # the debtor-never-returns path (its guard: test_the_backstop_escalates_a_debtor_that_never_returns)
+        self._ask(returned_at=NOW - 400)
+        self._armed(fire_t=NOW - km.NUDGE_DEFER_BACKSTOP_SECS - 60)
+        km._debt_backstop_tick(NOW)
+        self.assertEqual(self._esc, [], "main: the 6h backstop flipped the asker's card for a returned ask")
+        self.assertEqual(self._d["debtNudged"], {})
+
+    def test_a_return_of_a_different_ask_leaves_the_record_to_its_own_outcome(self):
+        # the join is the record's own ask time: a LATER ask on the same pair that came back says nothing
+        # about this one, which still escalates when the debtor moves on without replying
+        self._ask()
+        self._returned = {(ASKER, DEBTOR): {T_ASK + 300: NOW - 400}}
+        self._armed(fire_t=NOW - 600)
+        km._debt_reminder_outcomes(DEBTOR, {"t": NOW - 300, "end": NOW - 200}, NOW)
+        self.assertEqual(self._esc, [(ASKER, DEBTOR, T_ASK)])
+        self.assertEqual(self._d["debtNudged"], {})
+
+    def test_a_live_twin_in_the_same_second_keeps_the_record_open(self):
+        # the join is per send time: m1 and m2 both at T_ASK on the pair, m1 came back, m2 still waits —
+        # the record is m2's as much as m1's, so it stays and escalates on both paths exactly as before
+        # (main never retired on a return, so this guards the fold, not main)
+        for path in ("turn-end", "backstop"):
+            self._esc.clear()
+            self._ask()                                              # m2: live, last_ask at T_ASK
+            self._returned = {(ASKER, DEBTOR): {T_ASK: NOW - 400}}   # m1: the same second, returned
+            if path == "turn-end":
+                self._armed(fire_t=NOW - 600)
+                km._debt_reminder_outcomes(DEBTOR, {"t": NOW - 300, "end": NOW - 200}, NOW)
+            else:
+                self._armed(fire_t=NOW - km.NUDGE_DEFER_BACKSTOP_SECS - 60)
+                km._debt_backstop_tick(NOW)
+            self.assertEqual(self._esc, [(ASKER, DEBTOR, T_ASK)],
+                             "%s: the live twin's reminder still escalates (the first fold retired it)" % path)
+            self.assertEqual(self._d["debtNudged"], {})
 
 
 class DebtEscalate(DebtBase):

--- a/tests/test_kernel_waitfor.py
+++ b/tests/test_kernel_waitfor.py
@@ -99,9 +99,6 @@ class WaitFor(unittest.TestCase):
         self.assertEqual(g[X]["peerSid"], Z, "X's primary wait is its most-recent unanswered outbound")
 
 
-if __name__ == "__main__":
-    unittest.main()
-
 
 class DeclaredKindWins(unittest.TestCase):
     """The schema `kind` field is the designed intent source (send_message REQUIRES it); the body regex
@@ -140,3 +137,98 @@ class DeclaredKindWins(unittest.TestCase):
         self.assertEqual(km._wait_for_graph(0, {X, Y}).get(X, {}).get("peerSid"), Y)
         self._msgs([(X, Y, 100, "heads-up: landed the thing", "")])
         self.assertEqual(km._wait_for_graph(0, {X, Y}), {})
+
+
+class ReturnedSendClosesTheWait(unittest.TestCase):
+    """A send that came back is not an open ask (2026-09-08). The bus writes a terminal `bounced` row
+    naming the message's id when a send is over with nothing ever coming back — the peer refused it, the
+    recipient exited and its unread mail was destroyed, the send was refused before it left. The wait
+    reader skipped that row (no from_id/to_id), so the sender wore "Awaiting <peer>" for a question the
+    peer never received, and its card parked as waiting on a peer while the person may have needed to
+    act. The row is the closing EVENT, keyed to the message it names. The two guards this class leans on
+    live above: a sent question alone waits (test_unanswered_outbound_to_live_peer_is_a_wait) and a
+    reply of any kind answers it (test_a_reply_of_any_kind_answers_the_question)."""
+
+    RSID = "dddddddd-0000-0000-0000-000000000004"   # a remote recipient, keyed by the relay row's to_sid
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.MESSAGES
+        jd.MESSAGES = Path(self.td.name) / "messages.jsonl"
+        km._POSTAL_WAIT_CACHE[:] = [None, None]
+
+    def tearDown(self):
+        jd.MESSAGES = self.saved
+        km._POSTAL_WAIT_CACHE[:] = [None, None]
+        self.td.cleanup()
+
+    def _log(self, rows):
+        jd.MESSAGES.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+        km._POSTAL_WAIT_CACHE[:] = [None, None]
+
+    @staticmethod
+    def _ask(i, t, to=Y, **extra):
+        r = {"ev": "sent", "id": "m%d" % i, "from_id": X, "to_id": to, "t": t, "kind": "question",
+             "body": "which port should the api use?"}
+        r.update(extra)
+        return r
+
+    @staticmethod
+    def _back(i, t, why="recipient exited; unread mail destroyed by the orphan sweep", **extra):
+        # the bus's terminal return as the orphan sweep shapes it: the ORIGINAL id, a `to` name, a `why`
+        r = {"ev": "bounced", "id": "m%d" % i, "t": t, "to": "api", "host": "", "why": why}
+        r.update(extra)
+        return r
+
+    def test_a_returned_question_is_no_longer_a_wait(self):
+        self._log([self._ask(1, 100), self._back(1, 150)])
+        self.assertEqual(km._wait_for_graph(0, {X, Y}), {},
+                         "main: X wears Awaiting Y for a question Y never received")
+        last_any, last_ask, last_await = km._postal_wait_maps()
+        self.assertNotIn((X, Y), last_ask, "the ask is closed on the chip's map…")
+        self.assertNotIn((X, Y), last_await, "…and on the stamp clock's")
+        self.assertNotIn((X, Y), last_any, "…and it is no message either: neither an ask nor an answer (#1071's rule)")
+
+    def test_every_return_shape_the_bus_writes_closes_by_id_alone(self):
+        # the writers differ in their side fields (the orphan sweep: to/why; a peer's refusal: to/host/why;
+        # the oversize bounce: host ""; a failed publish: to_id/why; an unreadable outbox record:
+        # host/why) — the join is ev + id and nothing else
+        shapes = [
+            {"ev": "bounced", "id": "m1", "t": 150, "to": "api", "why": "recipient exited; unread mail destroyed by the orphan sweep"},
+            {"ev": "bounced", "id": "m1", "t": 150, "to": "api", "host": "TESTHOST-B", "why": "refused"},
+            {"ev": "bounced", "id": "m1", "t": 150, "to": "api", "host": "", "why": "your message is 90000 bytes as delivered, over the limit"},
+            {"ev": "bounced", "id": "m1", "t": 150, "to_id": Y, "why": "not published: a message with this id already stands"},
+            {"ev": "bounced", "id": "m1", "t": 150, "host": "TESTHOST-B", "why": "the outbox record was unreadable"},
+        ]
+        for row in shapes:
+            self._log([self._ask(1, 100), row])
+            self.assertEqual(km._wait_for_graph(0, {X, Y}), {}, "still waiting after: %s" % row)
+
+    def test_a_refused_cross_host_send_closes_the_same_way(self):
+        # the relay shape: the row is addressed to the relay and keyed on to_sid; the far host refused it
+        self._log([self._ask(1, 100, to="peer:TESTHOST-B", toName="TESTHOST-B:api", to_sid=self.RSID),
+                   self._back(1, 160, why="refused", host="TESTHOST-B")])
+        self.assertEqual(km._wait_for_graph(0, {X, self.RSID}), {},
+                         "main: the asker waits on a live peer whose kernel refused the message")
+
+    def test_the_return_closes_the_message_it_names_not_the_pair(self):
+        # an OLDER ask comes back after a newer one went out: the newer, live ask still waits
+        self._log([self._ask(1, 100), self._ask(2, 200), self._back(1, 300)])
+        g = km._wait_for_graph(0, {X, Y})
+        self.assertEqual(g.get(X, {}).get("peerSid"), Y, "the live ask is untouched by the older return")
+        self.assertEqual(g[X]["since"], 200, "…and the chip dates from it")
+
+    def test_a_delivery_ack_is_not_a_return(self):
+        # `relayed` says the far host took delivery; the ask is as open as before — only `bounced` closes
+        self._log([self._ask(1, 100), {"ev": "relayed", "id": "m1", "t": 150, "host": "TESTHOST-B"}])
+        self.assertEqual(km._wait_for_graph(0, {X, Y}).get(X, {}).get("peerSid"), Y)
+
+    def test_a_returned_coordinate_changes_nothing(self):
+        # a heads-up opened no wait, so its return has none to close — and must not invent one
+        self._log([self._ask(1, 100, kind="coordinate"), self._back(1, 150)])
+        self.assertEqual(km._wait_for_graph(0, {X, Y}), {})
+        self.assertEqual(km._postal_returned(), {}, "no reply-requiring send came back → no return clock")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_waitfor.py
+++ b/tests/test_kernel_waitfor.py
@@ -139,15 +139,9 @@ class DeclaredKindWins(unittest.TestCase):
         self.assertEqual(km._wait_for_graph(0, {X, Y}), {})
 
 
-class ReturnedSendClosesTheWait(unittest.TestCase):
-    """A send that came back is not an open ask (2026-09-08). The bus writes a terminal `bounced` row
-    naming the message's id when a send is over with nothing ever coming back — the peer refused it, the
-    recipient exited and its unread mail was destroyed, the send was refused before it left. The wait
-    reader skipped that row (no from_id/to_id), so the sender wore "Awaiting <peer>" for a question the
-    peer never received, and its card parked as waiting on a peer while the person may have needed to
-    act. The row is the closing EVENT, keyed to the message it names. The two guards this class leans on
-    live above: a sent question alone waits (test_unanswered_outbound_to_live_peer_is_a_wait) and a
-    reply of any kind answers it (test_a_reply_of_any_kind_answers_the_question)."""
+class _TerminalRowLog(unittest.TestCase):
+    """A synthetic postal log with the bus's terminal rows: `bounced` (the bus returned the message) and
+    `recall` (the sender withdrew it before anyone read it). Shared by the two classes below."""
 
     RSID = "dddddddd-0000-0000-0000-000000000004"   # a remote recipient, keyed by the relay row's to_sid
 
@@ -174,11 +168,37 @@ class ReturnedSendClosesTheWait(unittest.TestCase):
         return r
 
     @staticmethod
+    def _reply(i, t, kind="coordinate"):
+        return {"ev": "sent", "id": "m%d" % i, "from_id": Y, "to_id": X, "t": t, "kind": kind, "body": "8080"}
+
+    @staticmethod
     def _back(i, t, why="recipient exited; unread mail destroyed by the orphan sweep", **extra):
         # the bus's terminal return as the orphan sweep shapes it: the ORIGINAL id, a `to` name, a `why`
         r = {"ev": "bounced", "id": "m%d" % i, "t": t, "to": "api", "host": "", "why": why}
         r.update(extra)
         return r
+
+    @staticmethod
+    def _recall(i, t):
+        # the sender unsent it before anyone read it: {t, ev, id} is the row's whole shape, and the id is
+        # the sent row's own maildir name. (An OUTBOX recall names the relay mid, "px-…", and is not read
+        # as terminal — test_a_recall_naming_a_relay_mid_is_not_terminal.)
+        return {"ev": "recall", "id": "m%d" % i, "t": t}
+
+
+class ReturnedSendClosesTheWait(_TerminalRowLog):
+    """A send that came back is not an open ask (2026-09-08). The bus writes a terminal `bounced` row
+    naming the message's id when a send is over with nothing ever coming back — the peer refused it, the
+    recipient exited and its unread mail was destroyed, the send was refused before it left. The wait
+    reader skipped that row (no from_id/to_id), so the sender wore "Awaiting <peer>" for a question the
+    peer never received, and its card parked as waiting on a peer while the person may have needed to
+    act. The row is the closing EVENT, keyed to the message it names. The two guards this class leans on
+    live above: a sent question alone waits (test_unanswered_outbound_to_live_peer_is_a_wait) and a
+    reply of any kind answers it (test_a_reply_of_any_kind_answers_the_question). Since the same day a
+    maildir `recall` row (the sender withdrew the message before anyone read it) is read as the other
+    terminal kind through the same skip — #1071's rule, one skip before last_any, so neither row is its
+    sender's word toward the peer either — and ReturnedReplyIsNotTheAnswer below holds the recalled
+    reply's half (the bounced reply's is #1071's RefusedSendsAreNoAsk)."""
 
     def test_a_returned_question_is_no_longer_a_wait(self):
         self._log([self._ask(1, 100), self._back(1, 150)])
@@ -188,6 +208,34 @@ class ReturnedSendClosesTheWait(unittest.TestCase):
         self.assertNotIn((X, Y), last_ask, "the ask is closed on the chip's map…")
         self.assertNotIn((X, Y), last_await, "…and on the stamp clock's")
         self.assertNotIn((X, Y), last_any, "…and it is no message either: neither an ask nor an answer (#1071's rule)")
+
+    def test_a_recalled_question_is_no_longer_a_wait(self):
+        # the sender withdrew the question before the peer read it (unlinked unread from new/): as over
+        # as a bounce — the row went unread before, and X wore Awaiting Y for its own withdrawal
+        self._log([self._ask(1, 100), self._recall(1, 150)])
+        self.assertEqual(km._wait_for_graph(0, {X, Y}), {},
+                         "base: X wears Awaiting Y for a question X itself withdrew")
+        last_any, last_ask, last_await = km._postal_wait_maps()
+        self.assertNotIn((X, Y), last_ask, "the ask is closed on the chip's map…")
+        self.assertNotIn((X, Y), last_await, "…and on the stamp clock's")
+        self.assertNotIn((X, Y), last_any, "…and a withdrawn send is not X's word toward Y")
+
+    def test_a_recall_naming_a_relay_mid_is_not_terminal(self):
+        # the OUTBOX recall (review find, 2026-09-08): the row names the relay send's mid ("px-" +
+        # _unique()), and an outbox item outlives the carry — the exchange relays it without removing it;
+        # only the end-to-end ack does — so the far recipient may already hold the message and answer.
+        # Not terminal: the ask stays open, the send stays X's word, the debt stays owed, no return clock
+        # (as before — green on the base by design, where no recall was read). The maildir recall above
+        # still ends it.
+        self._log([self._ask(1, 100, id="px-1.mail.TESTHOST-A", to="peer:TESTHOST-B",
+                             toName="TESTHOST-B:api", to_sid=self.RSID),
+                   {"ev": "recall", "id": "px-1.mail.TESTHOST-A", "t": 160}])
+        self.assertEqual(km._wait_for_graph(0, {X, self.RSID}).get(X, {}).get("peerSid"), self.RSID)
+        last_any, last_ask, _aw = km._postal_wait_maps()
+        self.assertEqual(last_any.get((X, self.RSID)), 100)
+        self.assertIn((X, self.RSID), last_ask)
+        self.assertEqual([a[0] for a in km._debt_asks(self.RSID, {X})], [X])
+        self.assertEqual(km._postal_returned(), {})
 
     def test_every_return_shape_the_bus_writes_closes_by_id_alone(self):
         # the writers differ in their side fields (the orphan sweep: to/why; a peer's refusal: to/host/why;
@@ -228,6 +276,49 @@ class ReturnedSendClosesTheWait(unittest.TestCase):
         self._log([self._ask(1, 100, kind="coordinate"), self._back(1, 150)])
         self.assertEqual(km._wait_for_graph(0, {X, Y}), {})
         self.assertEqual(km._postal_returned(), {}, "no reply-requiring send came back → no return clock")
+
+
+class ReturnedReplyIsNotTheAnswer(_TerminalRowLog):
+    """A reply the replier recalled before the asker read it answers nothing (2026-09-08). last_any — any
+    later Y→X row answers X's ask — counted Y's sent row to X even after a terminal row named it: a recall
+    unlinks it from X's new/ unread (the bounced reply — the oversize push bounces it to Y WITHOUT putting
+    it back in X's box — is #1071's rule; its skip carries the recall through _learn_return). So X's chip
+    cleared, Y's debt read settled, and X's card left the wait on an answer nobody had received. The
+    exclusion is per MESSAGE (the id the row names), never per pair or per second: a live reply of Y's
+    answers as ever. Guards: the reply answers when nothing names it
+    (test_a_reply_of_any_kind_answers_the_question, and test_without_the_return_the_reply_answers)."""
+
+    def test_a_recalled_reply_leaves_the_ask_open(self):
+        self._log([self._ask(1, 100), self._reply(2, 200), self._recall(2, 250)])
+        self.assertEqual(km._wait_for_graph(0, {X, Y}).get(X, {}).get("peerSid"), Y,
+                         "base: X's edge cleared on a reply X never received")
+        last_any, _ask, _aw = km._postal_wait_maps()
+        self.assertNotIn((Y, X), last_any, "the withdrawn row is not Y's word toward X")
+        self.assertEqual([a[0] for a in km._debt_asks(Y, {X})], [X], "Y still owes X the answer (base: owed nothing)")
+
+    def test_a_bounced_reply_leaves_the_debt_owed(self):
+        # the bounced reply's edge and maps are #1071's rule and tests (RefusedSendsAreNoAsk, the twins'
+        # refused-question test); the debtor's own reader is what this pins (a guard on that rule)
+        self._log([self._ask(1, 100), self._reply(2, 200),
+                   self._back(2, 250, why="your message is 90000 bytes as delivered, over the limit")])
+        self.assertEqual([a[0] for a in km._debt_asks(Y, {X})], [X])
+
+    def test_without_the_return_the_reply_answers(self):
+        self._log([self._ask(1, 100), self._reply(2, 200)])
+        self.assertEqual(km._wait_for_graph(0, {X, Y}), {})
+        self.assertEqual(km._debt_asks(Y, {X}), [])
+
+    def test_a_live_reply_in_the_same_second_still_answers(self):
+        # per message, not per second: Y's second reply, sent the same second as the one that came back
+        # and read by X, answers — last_any keys the pair by its newest LIVE row exactly as before
+        self._log([self._ask(1, 100), self._reply(2, 200), self._reply(3, 200), self._recall(2, 250)])
+        self.assertEqual(km._wait_for_graph(0, {X, Y}), {})
+        self.assertEqual(km._postal_wait_maps()[0].get((Y, X)), 200)
+
+    def test_a_later_live_reply_still_answers(self):
+        self._log([self._ask(1, 100), self._reply(2, 200), self._recall(2, 250), self._reply(3, 300)])
+        self.assertEqual(km._wait_for_graph(0, {X, Y}), {})
+        self.assertEqual(km._postal_wait_maps()[0].get((Y, X)), 300)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Built on #1077, which made a returned send open no wait. This change completes that rule in two directions its review named.

## What was wrong
Verified on `main`: two states in the readers that turn a session's mail log into "waiting on a peer" or "answered by a peer". First, a recalled message, one the sender withdrew before anyone read it, was not recognised as terminal: after a recall the sender still wore "Awaiting" for a question it had withdrawn, the closer admitted a waiting stamp over it, the debt reminder woke the debtor over a question it could not see, and the courier planted a tracker for a withdrawn delegate. Second, the "any later word from the peer" map counted a peer's sent row even when that row's own id later came back, bounced on the local oversize push or recalled before the asker read it. The asker's chip cleared, the peer owed nothing, the pair read answered, and the propagation reader marked the asker's tracker reported back on a report the asker never received.

## What changes
The one recognizer that reads a returned message now reads a recall of a message still in the recipient's inbox the same way, by the message id the writer records, so every reader #1077 fixed for a bounce treats such a recall alike. A recall of a message parked for a relay is deliberately not read as terminal: the bus keeps a relayed item in its outbox until the far side's end-to-end acknowledgement, so a recall in that window can name a message the recipient already holds and may still answer; the relay's own id prefix tells the two apart, and the review that caught this asks the bus, in a change of its own, to refuse recalling a carried item. And a sent row whose id was returned or recalled is not the peer's word: it makes no entry in the "any later word" map in either reader. Identity is still learned from such a row, so names still resolve. Cross-host, a refused relay writes no sent row on the far host, so the second rule bites on the replier's own host for a refused relay, and on the asker's host when its own orphan sweep destroys a delivered reply unread; the two hosts then disagree, each honestly, and the remote replier is not told, since the sweep's note reaches local senders only. The docs say so.

## Deliberately left out
A handoff tracker planted before its return arrived stays open, as #1077 states. The writers, the sent receipts display and the bus's own note are untouched.

## Tests
Twenty-one new cases across the wait-for, await-release, awaiting-peer-matrix, debt-nudge and chain-rooted-minting modules, over a real synthetic mail log through the real readers, including a new debt class against the real maps: a recalled question makes no edge, ends the pair at the recall's time, admits no waiting stamp and retires its debt; a recalled question in the inbox plants no tracker, while a recalled relayed delegate still does, since the far side may hold it; a returned or recalled reply leaves the asker's edge standing, the pair unanswered, the debt owed and the tracker open; a recalled coordinate ends nothing; a reply alone still answers; a same-second live reply still answers; identity is still learned from a returned row. On its base the new cases run 14 failed across the five modules, with 12 guards passing there by design, among them the relayed-recall cases that keep main's behaviour.

Module runs on this branch, one at a time: wait-for 23, await-release 28, awaiting-peer-matrix 40, debt-nudge 25, chain-rooted-minting 54, `test_judge` 515, the `test_kernel` peer-wait subset 45, and eighteen neighbouring reader modules on the pre-fold shape. Base-side: wait-for 3 / 20, await-release 3 / 25, awaiting-peer-matrix 5 / 35, debt-nudge 2 / 23, chain-rooted-minting 1 / 53.

## Review
Reviewed by fourteen read-only agents (two lenses, two skeptics per finding), then a narrow recheck of the folds. Confirmed and folded: the outbox recall precondition the first cut assumed, since a relayed item outlives its carry until the far side's acknowledgement, so only the inbox recall is read as terminal; the cross-host sentence, which missed the asker-host sweep; six docstrings still naming bounces only; and a count slip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Narrowed after #1071
#1071 merged with the maintainer's rule that a refused or destroyed send is neither an ask nor an answer, which covers the bounced-reply half of this change. Rebased onto #1077's reconciled head, this PR now adds only what that rule lacks: a recall of a message still in the recipient's inbox is read as terminal too, with the relay-outbox exception, and the docs name the cross-host disagreement. The bounced-reply cases his tests already hold were dropped; the recall cases are red on #1077's head.
