### PR TITLE
Dashboard: reload itself on a kernel restart and on a newer served bundle, never mid-gesture, keeping the reader's place

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -34795,9 +34795,10 @@ WS_DEAD_S = float(os.environ.get("ROMP_WS_DEAD", "0")) or 3 * KEEPALIVE_S
 def _keepalive_all(now=None):
     # `dv` = the current dist build token (the same value baked into every page's ?v= urls). Riding the
     # keepalive makes build-drift detection EVENT-based on every surface with a live socket: a page whose
-    # LOADEDV is older raises the reload banner within one heartbeat of a rebuild — no per-page /version
-    # polling. The VS Code extension compares it against its bundled build stamp the same way (the user
-    # 2026-07-13: a stale tab sat silent through several rebuilds; drift must always show a banner).
+    # LOADEDV is older reloads itself within one heartbeat of a rebuild (T265, the user 2026-09-08; until then
+    # it raised the reload banner, the user 2026-07-13, whose stale tab sat silent through several rebuilds) —
+    # no per-page /version polling. The VS Code extension compares it against its bundled build stamp the same
+    # way and keeps its banner: a webview reload cannot fix bundled-code drift.
     s = json.dumps({"type": "ka", "dv": _dist_ver()})
     now = _ws_clock() if now is None else now
     with _clients_lock:
@@ -39345,12 +39346,99 @@ html,body{background:var(--vscode-editor-background);}
 body{font-family:var(--vscode-font-family);font-size:13px;color:var(--vscode-foreground);margin:0;padding:0;}"""
 
 # The WS bridge shim (ported verbatim from chat-view server.ts shimJs — same protocol).
+# ── the dashboard reloads ITSELF on a kernel restart and on a newer served bundle (T265) ──────────────────────
+# The user's ruling of 2026-09-08 (about 10:50 AM PT) supersedes their 2026-07-13 preference for a banner the
+# reader clicks: any restart of the kernel SERVING the page, and any bundle newer than the one the page loaded
+# with, reload the page by themselves. Two signals, both exact events, never a timer:
+#   (1) kernel restart — a socket REOPEN whose /version answers with a boot id other than the one baked into the
+#       page (checkBoot: the shell asks on its own socket's reopen; a standalone pane asks on its shim's
+#       reconnect); the 30 s /version poll the stale banner already ran is the backstop for a page whose socket
+#       never dropped (noteVersion, the same reading).
+#   (2) build drift — a `dv` on a keepalive, or /version's dist_ver, above the page's baked LOADEDV (noteDv).
+# Never mid-gesture: a pointer button held, a drag in flight, a text selection being made, or the composer
+# focused with text ARMS the reload, and the ending event (pointerup/pointercancel, dragend/drop,
+# selectionchange, input, focusout; a window blur releases every hold) fires it. The shell composes gesture state
+# across its same-origin panes, and a pane forwards its request to the shell when one is there, so ONE decision
+# reloads the top document; a standalone pane page decides for itself, and so does a pane under a foreign parent
+# (an iframe in another app can reload itself). Before reloading: every pane persists what a reload loses
+# (window.__rompPersistForReload — the chat pane's scroll position + follow mode; the draft and the active tab are
+# persisted already), the shell's lifted modals close (settings/picker), and a marker rides sessionStorage so the
+# fresh page leaves ONE notification-center line ("Reloaded onto build N — the kernel restarted / a newer romp
+# build was served"). If location.reload throws (a host that forbids it) the old banner is the fallback (the
+# `refused` hook). The VS Code webview never runs this: the extension loads its bundle from the installed VSIX
+# and a webview reload cannot fix bundled-code drift, so its own reload prompt stays (vscode-extension/src/
+# extension.ts). Federated relay: a REMOTE kernel's restart must not reload the page — and cannot: the core reads
+# only THIS page's own socket and /version (federation.ts drops remote `ka` frames, so they never reach the shim's
+# dv check, and the relay never forwards a remote kernel's boot id). tests/test_dashboard_auto_reload.py runs
+# this code in node with fakes and pins the wiring.
+_RELOAD_CORE_JS = r"""/*reload-core*/(function(){if(window.__rompReload)return;
+var LOADED=__LOADEDVER__,BOOT=__ROMP_BOOT__,ptr=0,drag=false,owed=null,fired=false;
+function shell(){try{var p=window.parent;if(p&&p!==window&&p.__rompReload)return p.__rompReload;}catch(e){}return null;}
+function busyHere(){if(ptr>0)return 'pointer';if(drag)return 'drag';
+try{var s=document.getSelection&&document.getSelection();if(s&&s.rangeCount&&!s.isCollapsed&&String(s).length)return 'selection';}catch(e){}
+try{var c=document.getElementById('composer-input');if(c&&document.activeElement===c&&(c.value||'').trim())return 'composer';}catch(e){}
+return '';}
+function panes(){var out=[],fs=document.querySelectorAll?document.querySelectorAll('iframe'):[];
+for(var i=0;i<fs.length;i++){try{var w=fs[i].contentWindow;if(w&&w.__rompReload)out.push(w);}catch(e){}}return out;}
+function busy(){var b=busyHere();if(b)return b;var ps=panes();for(var i=0;i<ps.length;i++){b=ps[i].__rompReload.busyHere();if(b)return b;}return '';}
+function persist(){try{if(window.__rompPersistForReload)window.__rompPersistForReload();}catch(e){}
+var ps=panes();for(var i=0;i<ps.length;i++){try{if(ps[i].__rompPersistForReload)ps[i].__rompPersistForReload();}catch(e){}}}
+function fire(){if(fired)return;fired=true;
+try{sessionStorage.setItem('romp:reloaded',JSON.stringify({reason:owed.reason,detail:owed.detail||'',from:LOADED,t:Date.now()}));}catch(e){}
+persist();
+try{document.body.classList.remove('settings-open','picker-open');}catch(e){}
+try{location.reload();}catch(e){fired=false;R.waiting='refused';if(R.refused)R.refused(owed);}}
+function tryFire(){if(!owed||fired)return;var b=busy();if(b){R.waiting=b;return;}R.waiting='';fire();}
+function request(reason,detail){var s=shell();if(s){s.request(reason,detail);return;}if(fired)return;
+if(!owed)owed={reason:reason,detail:detail||''};tryFire();}
+function noteDv(dv){if(LOADED&&dv&&dv>LOADED)request('build',String(dv));}
+function noteVersion(v){if(!v)return;if(v.boot&&BOOT&&v.boot!==BOOT)request('restart',String(v.boot));if(v.dist_ver)noteDv(v.dist_ver);}
+function checkBoot(){try{fetch('/version',{cache:'no-store'}).then(function(r){return r.json();}).then(noteVersion)['catch'](function(){});}catch(e){}}
+function announce(notify){var raw=null;try{raw=sessionStorage.getItem('romp:reloaded');if(raw)sessionStorage.removeItem('romp:reloaded');}catch(e){}
+if(!raw)return null;var d=null;try{d=JSON.parse(raw);}catch(e){return null;}if(!d)return null;
+var why=d.reason==='restart'?'the kernel restarted':'a newer romp build was served';
+var txt='Reloaded onto build '+LOADED+' — '+why+'.';try{if(notify)notify('reload',txt);}catch(e){}return txt;}
+document.addEventListener('pointerdown',function(){ptr++;},true);
+document.addEventListener('pointerup',function(){ptr=Math.max(0,ptr-1);},true);
+document.addEventListener('pointercancel',function(){ptr=Math.max(0,ptr-1);},true);
+document.addEventListener('dragstart',function(){drag=true;},true);
+document.addEventListener('dragend',function(){drag=false;},true);
+document.addEventListener('drop',function(){drag=false;},true);
+var END=['pointerup','pointercancel','dragend','drop','selectionchange','input','focusout'];
+function ended(){var s=shell();if(s)s.tryFire();else tryFire();}
+for(var k=0;k<END.length;k++)document.addEventListener(END[k],ended,true);
+window.addEventListener('blur',function(){ptr=0;drag=false;ended();});
+var R={request:request,tryFire:tryFire,busyHere:busyHere,busy:busy,noteDv:noteDv,noteVersion:noteVersion,checkBoot:checkBoot,announce:announce,
+inShell:function(){return !!shell();},owed:function(){return owed;},fired:function(){return fired;},refused:null,waiting:'',loaded:LOADED,boot:BOOT};
+window.__rompReload=R;})();/*end-reload-core*/"""
+
+
+def _reload_core(v=0):
+    """The reload core with this page's build token and this kernel's boot id baked in (see _RELOAD_CORE_JS).
+    Embedded by _shim (every pane page) and _stale_block (the dashboard landing)."""
+    return _RELOAD_CORE_JS.replace("__LOADEDVER__", str(int(v))).replace("__ROMP_BOOT__", json.dumps(_BOOT_ID))
+
+
+def _reload_core_js(v=0, boot=None):
+    """The reload core's IIFE alone — the code between its /*reload-core*/ anchors, baked for `v` and `boot` — so a
+    node test runs the REAL decision code with fakes for document, window, location, sessionStorage and fetch
+    (test_dashboard_auto_reload.py). Fails loudly if the anchors ever go missing."""
+    js = _RELOAD_CORE_JS.replace("__LOADEDVER__", str(int(v))).replace(
+        "__ROMP_BOOT__", json.dumps(_BOOT_ID if boot is None else boot))
+    a, b = "/*reload-core*/", "/*end-reload-core*/"
+    i, j = js.find(a), js.find(b)
+    if i < 0 or j < i:
+        raise RuntimeError("the reload-core anchors are missing from _RELOAD_CORE_JS")
+    return js[i + len(a):j]
+
+
 def _shim(app, v=0):
     # `v` = the dist build token this page was served with (its ?v= urls). The shim compares it against the
     # `dv` riding every keepalive and raises the build banner on drift — so EVERY kernel-served page gets the
     # "newer build" prompt, not just the dashboard landing's /version poll (the user 2026-07-13: a standalone
     # pane sat silent through rebuilds).
     return """
+%s
 (function(){/*shim-core*/var queue=[],ws=null,everConnected=false;
 var queuedDiag=0,DIAG_QUEUE_MAX=20;   // clientDiag rows waiting in `queue` for a reconnect, capped (an outage must not pile up breadcrumbs); other queued messages are untouched
 var failedConnects=0,firstFailT=0;   // handshakes that never OPENED since the last open: reported as ONE wsconnfail row on the next open, never one wsclose per redial
@@ -39376,7 +39464,10 @@ function netState(s){try{if(window.parent!==window)window.parent.postMessage({ro
 // "Re-judging" frame long after the kernel had moved on). PROMPT the user to reload rather than silently
 // auto-reloading (foisted, jarring) or leaving them staring at stale content. In the dashboard the pane rides
 // in an iframe, so hand it to the shell's ONE #rstale reload banner; a standalone page (feed/timeline opened
-// directly) has no shell, so self-inject a minimal top bar with the same Reload action.
+// directly) has no shell, so self-inject a minimal top bar with the same Reload action. Scope since T265 (the
+// user 2026-09-08): this prompt is for a reconnect to the SAME kernel process (a blip) — a reconnect against a
+// NEW process, and a newer bundle, reload the page by themselves (the reload core above); the "build" bar is
+// only the core's refused fallback.
 function selfBar(t,kind){try{if(document.getElementById("romp-stale-self"))return;
 var b=document.createElement("div");b.id="romp-stale-self";b.dataset.kind=kind||"conn";
 b.style.cssText="position:fixed;top:0;left:0;right:0;z-index:99999;display:flex;gap:12px;align-items:center;justify-content:center;background:#2b2d30;color:#e6e6e6;border-bottom:1px solid #4a4d51;padding:9px 14px;font:13px/1.4 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif";
@@ -39468,13 +39559,16 @@ if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale"},"*");}
 // path itself closes).
 var stalePending="",staleKa=0,pendingWhy="",openSock=null,openT=0;
 function armStale(why){stalePending=why;staleKa=0;}
-// BUILD drift (the user 2026-07-13): the keepalive carries the kernel's current dist token (dv); a page whose
-// baked LOADEDV is older is running outdated code against newer kernel state — prompt a reload (never auto).
-// In the dashboard the raise routes to the shell's #rstale banner (build:1 → its BUILDMSG); standalone pages
-// self-inject the same bar. Latched: one prompt per page life, cleared only by the reload it asks for.
+// BUILD drift: the keepalive carries the kernel's current dist token (dv); a page whose baked LOADEDV is older is
+// running outdated code against newer kernel state. The user 2026-07-13 wanted EVERY kernel-served page to notice
+// (a standalone pane sat silent through rebuilds); the user 2026-09-08 ruled the page RELOADS ITSELF, superseding
+// the 2026-07-13 "prompt, never auto" — the raise asks window.__rompReload (the reload core, embedded above this
+// shim on every kernel-served page), which forwards to the shell when this pane sits in one and otherwise reloads
+// this page in place, never mid-gesture. selfBar is only the refused fallback (a host that forbids location.reload).
+// Latched: one request per page life.
 var buildRaised=false,freshPending=false,restartAnnounced=0;   // freshPending: a reconnect is awaiting its resync frame; restartAnnounced: the kernel's dying frame (T217)
-function raiseBuild(){if(buildRaised)return;buildRaised=true;
-if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale",build:1},"*");}catch(e){}}
+function raiseBuild(){if(buildRaised)return;buildRaised=true;var R=window.__rompReload;
+if(R){R.refused=function(){selfBar("A newer romp build is available.","build");};R.request("build","");}
 else selfBar("A newer romp build is available.","build");}
 function connect(){if(ws&&(ws.readyState===0||ws.readyState===1))return;   // one live attempt at a time — a lost timer + the watchdog can both call in
 if(returnAt)returnRedialed=true;   // a dial inside a return window (whatever path led here) → the return-fresh row says so
@@ -39483,7 +39577,11 @@ var active="";try{var st0=JSON.parse(localStorage.getItem(SK)||"null");active=(s
 ws=new WebSocket(proto+location.host+"/ws?app=%s&delta=1&iid="+encodeURIComponent(IID)+(wid?"&wid="+encodeURIComponent(wid):"")+(active?"&active="+encodeURIComponent(active):""));
 // onopen: flush the queue; a RECONNECT (after a drop) also PROMPTS a reload — the fresh socket resyncs live via
 // the kernel's next push, and the banner offers a full reload for anything a live push doesn't cover. This
-// replaces the old silent location.reload() (the user: don't foist a reload; let me click — [[prefer-reload-banner-not-auto]]).
+// replaced the old silent location.reload() (the user 2026-07-05: don't foist a reload; let me click). Narrowed by
+// T265 (the user 2026-09-08, superseding that for restarts): when the reconnect is against a NEW kernel process
+// (its /version boot id differs from this page's) the page reloads itself via the reload core — a standalone page
+// asks here (checkBoot), a pane inside the shell leaves it to the shell's own socket; the prompt stays for a
+// same-process blip.
 // A RECONNECT also fires `romp:wsup`, the counterpart to the `romp:wsdown` below: whatever went up when the
 // socket dropped (the pane's romp loader) needs the socket's RETURN as its event to come back down. The
 // first connect deliberately doesn't fire it — nothing is waiting on it, and the loader must stay up until
@@ -39491,6 +39589,7 @@ ws=new WebSocket(proto+location.host+"/ws?app=%s&delta=1&iid="+encodeURIComponen
 ws.onopen=function(){lastRecv=Date.now();openT=lastRecv;openSock=this;netState("up");resumeProvisional=0;var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];queuedDiag=0;
 if(failedConnects){send({type:"clientDiag",surface:"pane-shim",what:"wsconnfail",data:{app:APP,attempts:failedConnects,firstFailMs:Date.now()-firstFailT}});failedConnects=0;firstFailT=0;}   // the redials that never opened since the last open, as ONE row: how many, and how long ago the first failed
 if(wasReconn){var ann=restartAnnounced&&Date.now()-restartAnnounced<30000;restartAnnounced=0;   // one-shot: spent here
+if(window.__rompReload&&!window.__rompReload.inShell())window.__rompReload.checkBoot();   // T265: a REOPEN is the restart signal — a standalone page asks /version whose kernel answered; inside the shell, the shell asks on its own socket
 if(!ann)armStale(pendingWhy||"reconnect");   // T217: an ANNOUNCED restart's reconnect skips the arm — the resync lands in a beat and the flash was pure noise; a restart that never comes back stays loud through the disconnected state itself, and a SECOND reconnect arms as always
 pendingWhy="";freshPending=true;try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}};
 ws.onmessage=function(ev){lastRecv=Date.now();resumeProvisional=0;if(returnAt)returnBytes+=(ev.data&&ev.data.length)||0;var msg;try{msg=JSON.parse(ev.data);}catch(e){return;}
@@ -39642,7 +39741,7 @@ pendingWhy="foreground";freshPending=true;   // the reconnect's arm reads "foreg
 if(ws&&ws.readyState===1)abandon();else{try{if(ws&&ws.readyState===0)ws.close();}catch(e){}}   // OPEN-but-quiet → abandoned + redialed below, now; stuck-CONNECTING → aborted, onclose retries
 if(!ws||ws.readyState===3)connect();
 returnDiag("return",row);});/*end-shim-core*/})();   // filed AFTER the redial so it queues for the new socket instead of vanishing into the dead one
-""" % (app, int(v), app, app)
+""" % (_reload_core(v), app, int(v), app, app)
 
 
 def _shim_core_js(app="test", v=0):
@@ -41896,13 +41995,16 @@ Array.prototype.forEach.call(bar.querySelectorAll('button[data-act]'),function(b
 b.addEventListener('click',function(){var f=A[b.getAttribute('data-act')];if(f)f();});});
 window.addEventListener('message',function(e){var m=e.data;if(!m)return;if(m.romp==='reveal'&&m.pane)reveal(m.pane);// the chat header's Fleet pill / the fleet's back-to-chat post toggleFleet — on mobile that IS a tab switch
 if(m.romp==='toggleFleet')show(m.to==='chat'?'chat':'fleet');});
+var shellOpened=false;   // T265: this socket's REOPEN is the kernel-restart signal — the shell asks /version whose kernel answered
 function shellWS(){try{var proto=location.protocol==='https:'?'wss://':'ws://';
 var ws=new WebSocket(proto+location.host+'/ws?app=shell');
 // ready → the kernel sends the current needs-you count, so a relaunched installed app trues up
 // its icon badge immediately instead of waiting for the next change (plans/ios-app.md proposal 3)
-ws.onopen=function(){try{ws.send(JSON.stringify({type:'ready'}));}catch(e){}};
+ws.onopen=function(){try{ws.send(JSON.stringify({type:'ready'}));}catch(e){}
+if(shellOpened&&window.__rompReload)window.__rompReload.checkBoot();shellOpened=true;};
 ws.onmessage=function(ev){var m;try{m=JSON.parse(ev.data);}catch(e){return;}
-if(m&&m.type==='reveal'&&m.pane)reveal(m.pane);
+if(m&&m.type==='ka'){if(m.dv&&window.__rompReload)window.__rompReload.noteDv(m.dv);}   // build drift on the shell's own keepalive (T265)
+else if(m&&m.type==='reveal'&&m.pane)reveal(m.pane);
 // the app-icon badge: setAppBadge only exists where badging works (installed apps) — everyone
 // else falls through silently, so this needs no capability gymnastics
 else if(m&&m.type==='badge'&&'setAppBadge' in navigator){
@@ -42145,24 +42247,33 @@ _STALE_JS = (
     "var BUILDMSG='A newer romp build is available.',"
     "CONNMSG='romp lost the live connection to the dashboard, so what you see may be stale.';"
     "function show(m){msg.textContent=m;box.classList.add('show');}"
+    # T265 (the user 2026-09-08): the reload core (window.__rompReload, _RELOAD_CORE_JS) owns build drift and
+    # kernel restarts — the page reloads itself, never mid-gesture. The BUILD banner survives only as the
+    # core's `refused` fallback (a host that forbids location.reload); the poll below hands the core every
+    # /version reading (a restart the socket never showed, a bundle newer than this page's).
+    "var RL=window.__rompReload;"
+    "if(RL){RL.refused=function(){buildStale=true;show(BUILDMSG);};"
+    "RL.announce(function(k,t){if(window.__rompNotify)window.__rompNotify(k,t);});}"
     "function check(){fetch('/version',{cache:'no-store'}).then(function(r){return r.json();}).then(function(v){"
     "if(v&&v.boot&&window.__rompUpdBoot)window.__rompUpdBoot(v.boot);"   # retire cross-boot update offers (2026-08-15)
     "served=v.dist_ver||0;"
-    "if(loaded&&served>loaded&&served!==dismissed)show(BUILDMSG);"
+    "if(RL)RL.noteVersion(v);"
+    "if(loaded&&served>loaded&&served!==dismissed){if(!RL)show(BUILDMSG);}"
     "else if(served<=loaded&&!connStale&&!buildStale)box.classList.remove('show');}).catch(function(){});}"
     # A pane whose WebSocket dropped-and-reconnected (or a foregrounded tab that found its socket dead) posts
     # {romp:'wsStale'} — the same shell-coalesced channel as the disconnect banner, but a RELOAD PROMPT rather
     # than a silent auto-reload (the user 2026-07-05: a stale feed card showed 'Re-judging' while the kernel had
     # long since moved on, with no cue the view was frozen). connStale latches so the /version poll can't clear
-    # the prompt out from under it; Dismiss (or a reload) clears it. A pane's BUILD-drift raise (the shim's
-    # keepalive dv check, the user 2026-07-13) rides the same channel with build:1 → the BUILDMSG wording;
-    # buildStale latches it identically so the poll (whose own token may be current) can't clear it.
+    # the prompt out from under it; Dismiss (or a reload) clears it. A pane's BUILD-drift raise used to ride the
+    # same channel with build:1 → the BUILDMSG wording (the user 2026-07-13); since T265 (the user 2026-09-08,
+    # superseding that) the shim asks the reload core directly and a build:1 that still arrives is handed to
+    # the core too — the banner shows for it only where the core is absent.
     # {romp:'wsFresh'} — the reconnected pane's resync LANDED (its first non-keepalive frame), so the
     # connection prompt is moot and retires itself; the user saw it on nearly every dashboard open, offering
     # a reload for a staleness that had already healed in the background. A latched BUILD prompt survives
     # (and re-asserts its wording): a resync delivers state, never new code, so only a reload answers it.
     "window.addEventListener('message',function(e){var m=e&&e.data;"
-    "if(m&&m.romp==='wsStale'){if(m.build){buildStale=true;show(BUILDMSG);}else{connStale=true;show(CONNMSG);}}"
+    "if(m&&m.romp==='wsStale'){if(m.build){if(RL)RL.request('build','');else{buildStale=true;show(BUILDMSG);}}else{connStale=true;show(CONNMSG);}}"
     "else if(m&&m.romp==='wsFresh'){connStale=false;if(buildStale)show(BUILDMSG);else box.classList.remove('show');}});"
     # T132 (the user 2026-08-27): the banner is DRAGGABLE — movable out of the way so it can STAY up
     # (it was covering a tab they needed before accepting the build). Moving never dismisses, mutes, or
@@ -42231,7 +42342,9 @@ _LANDING_COLLAPSE_JS = """
 
 
 def _stale_block(v):
+    # the reload core first: the banner script below registers as its refused fallback and announces a reload
     return ("<style>" + _STALE_CSS + "</style>" + _STALE_HTML
+            + "<script>" + _reload_core(v) + "</script>"
             + "<script>" + _STALE_JS.replace("__LOADEDVER__", str(int(v))) + "</script>")
 
 

--- a/tests/test_dashboard_auto_reload.py
+++ b/tests/test_dashboard_auto_reload.py
@@ -1,0 +1,303 @@
+"""The dashboard reloads ITSELF on a kernel restart and on a newer served bundle (T265).
+
+The user's ruling of 2026-09-08 supersedes their 2026-07-13 preference for a banner the reader clicks. The reload
+core (kernel.py _RELOAD_CORE_JS, window.__rompReload on every kernel-served page) runs here for REAL: node executes
+the IIFE between its anchors with fakes for document, window, location, sessionStorage and fetch, one process per
+scenario (the core installs once per window), and the scenario reads its state back by name. Pinned alongside:
+the wiring (the shim's raise, the shim's reconnect, the shell's socket, the stale banner's poll and fallback, the
+pages that embed the core) and the remote exclusion (federation drops remote keepalives, so a REMOTE kernel's
+restart or bundle never reaches the core). Synthetic values only."""
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_autoreload", os.path.join(BIN, "romp-kernel")).load_module()
+
+# The browser the core thinks it runs in. `var` at module scope shadows node's globals; the core's own
+# `document.addEventListener` calls land in LISTENERS so a scenario can emit the gesture events by name.
+HARNESS = r"""
+var LISTENERS = {}, STORE = {}, REMOVED = [], FETCHES = [], RELOADS = 0, REFUSE = false, PERSISTED = 0, WLISTENERS = {};
+var SEL = { rangeCount: 0, isCollapsed: true, toString: function () { return ""; } };
+var COMPOSER = { value: "" };
+var IFRAMES = [];
+var document = {
+  addEventListener: function (t, f) { (LISTENERS[t] = LISTENERS[t] || []).push(f); },
+  getSelection: function () { return SEL; },
+  getElementById: function (id) { return id === "composer-input" ? COMPOSER : null; },
+  activeElement: null,
+  body: { classList: { remove: function () { REMOVED.push(Array.prototype.slice.call(arguments)); } } },
+  querySelectorAll: function () { return IFRAMES; }
+};
+var window = { addEventListener: function (t, f) { (WLISTENERS[t] = WLISTENERS[t] || []).push(f); } };
+window.parent = window;
+window.__rompPersistForReload = function () { PERSISTED++; };
+var location = { reload: function () { RELOADS++; if (REFUSE) throw new Error("host forbids reload"); } };
+var sessionStorage = {
+  setItem: function (k, v) { STORE[k] = v; }, getItem: function (k) { return k in STORE ? STORE[k] : null; },
+  removeItem: function (k) { delete STORE[k]; }
+};
+var VERSION = null;
+function fetch(u) { FETCHES.push(u); return Promise.resolve({ json: function () { return Promise.resolve(VERSION); } }); }
+function emit(t) { (LISTENERS[t] || []).forEach(function (f) { f({}); }); }
+function wemit(t) { (WLISTENERS[t] || []).forEach(function (f) { f({}); }); }
+function tick() { return new Promise(function (r) { setTimeout(r, 0); }); }
+function state() {
+  var R = window.__rompReload;
+  return { reloads: RELOADS, fired: R.fired(), owed: R.owed(), waiting: R.waiting, persisted: PERSISTED, removed: REMOVED,
+           stored: STORE["romp:reloaded"] ? JSON.parse(STORE["romp:reloaded"]) : null, fetches: FETCHES.length };
+}
+function out(o) { process.stdout.write("RESULT:" + JSON.stringify(o) + "\n"); }
+"""
+
+
+def run_core(scenario, v=7, boot="1.1"):
+    node = shutil.which("node")
+    if not node:
+        raise unittest.SkipTest("node not installed")
+    d = tempfile.mkdtemp(prefix="reload-core-")
+    path = os.path.join(d, "core.js")
+    with open(path, "w") as f:
+        f.write(HARNESS + km._reload_core_js(v, boot) + "\n(async function(){\n" + scenario + "\n})();\n")
+    r = subprocess.run([node, path], capture_output=True, text=True, timeout=60)
+    shutil.rmtree(d, ignore_errors=True)
+    if r.returncode != 0:
+        raise AssertionError("node failed:\n" + r.stderr)
+    line = next((ln for ln in r.stdout.splitlines() if ln.startswith("RESULT:")), None)
+    assert line, "no RESULT line:\n" + r.stdout
+    return json.loads(line[len("RESULT:"):])
+
+
+class ReloadCoreExecuted(unittest.TestCase):
+    def test_a_newer_dv_reloads_at_once_when_idle_and_persists_first(self):
+        s = run_core("""
+var R = window.__rompReload;
+R.noteDv(7); var same = state();          // the page's own build
+R.noteDv(5); var older = state();         // an OLDER token (a rolled-back peer) is not drift
+R.noteDv(8);
+out({ same: same, older: older, after: state() });""")
+        self.assertEqual(s["same"]["reloads"], 0)
+        self.assertEqual(s["older"]["reloads"], 0)
+        a = s["after"]
+        self.assertEqual(a["reloads"], 1)
+        self.assertTrue(a["fired"])
+        self.assertEqual(a["stored"]["reason"], "build")
+        self.assertEqual(a["stored"]["detail"], "8")
+        self.assertEqual(a["stored"]["from"], 7)
+        self.assertEqual(a["persisted"], 1, "the pane's persist hook ran before the reload")
+        self.assertIn(["settings-open", "picker-open"], a["removed"], "the lifted modals close")
+
+    def test_a_restart_is_a_reopen_against_a_new_boot_id_never_a_blip(self):
+        s = run_core("""
+var R = window.__rompReload;
+VERSION = { boot: "1.1", dist_ver: 7 }; R.checkBoot(); await tick(); await tick(); var blip = state();
+VERSION = { boot: "2.2", dist_ver: 7 }; R.checkBoot(); await tick(); await tick();
+out({ blip: blip, after: state() });""")
+        self.assertEqual(s["blip"]["reloads"], 0, "the same kernel answered: a socket blip, not a restart")
+        self.assertEqual(s["blip"]["fetches"], 1)
+        self.assertEqual(s["after"]["reloads"], 1)
+        self.assertEqual(s["after"]["stored"]["reason"], "restart")
+        self.assertEqual(s["after"]["stored"]["detail"], "2.2")
+
+    def test_version_readings_feed_both_signals(self):
+        s = run_core("""
+var R = window.__rompReload;
+R.noteVersion({ boot: "1.1", dist_ver: 7 }); var quiet = state();
+R.noteVersion({ boot: "1.1", dist_ver: 9 });
+out({ quiet: quiet, after: state() });""")
+        self.assertEqual(s["quiet"]["reloads"], 0)
+        self.assertEqual(s["after"]["stored"]["reason"], "build")
+
+    def test_a_held_pointer_arms_and_the_pointerup_fires(self):
+        s = run_core("""
+var R = window.__rompReload;
+emit("pointerdown");
+R.noteDv(8); var held = state();
+emit("pointerup");
+out({ held: held, after: state() });""")
+        self.assertEqual(s["held"]["reloads"], 0)
+        self.assertEqual(s["held"]["waiting"], "pointer")
+        self.assertEqual(s["held"]["owed"]["reason"], "build", "armed, not dropped")
+        self.assertEqual(s["after"]["reloads"], 1)
+
+    def test_a_drag_in_flight_arms_and_dragend_fires(self):
+        s = run_core("""
+var R = window.__rompReload;
+emit("dragstart"); R.noteDv(8); var held = state(); emit("dragend");
+out({ held: held, after: state() });""")
+        self.assertEqual(s["held"]["waiting"], "drag")
+        self.assertEqual(s["held"]["reloads"], 0)
+        self.assertEqual(s["after"]["reloads"], 1)
+
+    def test_a_selection_being_made_arms_and_its_collapse_fires(self):
+        s = run_core("""
+var R = window.__rompReload;
+SEL = { rangeCount: 1, isCollapsed: false, toString: function () { return "some words"; } };
+R.noteDv(8); var held = state();
+SEL = { rangeCount: 1, isCollapsed: true, toString: function () { return ""; } }; emit("selectionchange");
+out({ held: held, after: state() });""")
+        self.assertEqual(s["held"]["waiting"], "selection")
+        self.assertEqual(s["held"]["reloads"], 0)
+        self.assertEqual(s["after"]["reloads"], 1)
+
+    def test_a_composer_with_text_and_focus_arms_and_emptying_or_blurring_fires(self):
+        s = run_core("""
+var R = window.__rompReload;
+document.activeElement = COMPOSER; COMPOSER.value = "half a thought";
+R.noteDv(8); var held = state();
+COMPOSER.value = "half a thought, more"; emit("input"); var typing = state();
+COMPOSER.value = ""; emit("input");
+out({ held: held, typing: typing, after: state() });""")
+        self.assertEqual(s["held"]["waiting"], "composer")
+        self.assertEqual(s["typing"]["reloads"], 0, "typing keeps the hold")
+        self.assertEqual(s["after"]["reloads"], 1, "an emptied composer releases it")
+        s2 = run_core("""
+var R = window.__rompReload;
+document.activeElement = COMPOSER; COMPOSER.value = "draft"; R.noteDv(8);
+document.activeElement = null; emit("focusout");
+out({ after: state() });""")
+        self.assertEqual(s2["after"]["reloads"], 1, "a blurred composer releases it (the draft is persisted already)")
+
+    def test_a_window_blur_releases_every_hold(self):
+        s = run_core("""
+var R = window.__rompReload;
+emit("pointerdown"); emit("dragstart"); R.noteDv(8); var held = state(); wemit("blur");
+out({ held: held, after: state() });""")
+        self.assertEqual(s["held"]["reloads"], 0)
+        self.assertEqual(s["after"]["reloads"], 1)
+
+    def test_a_refused_reload_falls_back_to_the_banner_hook(self):
+        s = run_core("""
+var R = window.__rompReload; var refused = [];
+R.refused = function (o) { refused.push(o); }; REFUSE = true;
+R.noteDv(8);
+out({ refused: refused, after: state() });""")
+        self.assertEqual(s["after"]["reloads"], 1, "the reload was attempted")
+        self.assertFalse(s["after"]["fired"], "…and stood down when the host threw")
+        self.assertEqual(s["after"]["waiting"], "refused")
+        self.assertEqual(s["refused"], [{"reason": "build", "detail": "8"}])
+
+    def test_the_fresh_page_announces_once_from_the_marker(self):
+        s = run_core("""
+var R = window.__rompReload; var notes = [];
+STORE["romp:reloaded"] = JSON.stringify({ reason: "restart", detail: "2.2", from: 6, t: 1 });
+var first = R.announce(function (k, t) { notes.push([k, t]); });
+var second = R.announce(function (k, t) { notes.push([k, t]); });
+out({ first: first, second: second, notes: notes, left: STORE["romp:reloaded"] || null });""")
+        self.assertEqual(s["first"], "Reloaded onto build 7 — the kernel restarted.")
+        self.assertEqual(s["notes"], [["reload", "Reloaded onto build 7 — the kernel restarted."]])
+        self.assertIsNone(s["second"], "one line per reload")
+        self.assertIsNone(s["left"], "the marker is consumed")
+        s2 = run_core("""
+var R = window.__rompReload;
+STORE["romp:reloaded"] = JSON.stringify({ reason: "build", detail: "9", from: 6, t: 1 });
+out({ first: R.announce(null) });""")
+        self.assertEqual(s2["first"], "Reloaded onto build 7 — a newer romp build was served.")
+
+    def test_the_shell_composes_gesture_state_across_its_panes_and_a_pane_forwards_its_request(self):
+        s = run_core("""
+var R = window.__rompReload;
+var paneBusy = "pointer";
+var pane = { __rompReload: { busyHere: function () { return paneBusy; } }, __rompPersistForReload: function () { PERSISTED += 10; } };
+IFRAMES = [{ contentWindow: pane }];
+R.request("build", "8"); var held = state();
+paneBusy = ""; R.tryFire();            // the pane's ending event calls the shell's tryFire
+out({ held: held, after: state() });""")
+        self.assertEqual(s["held"]["reloads"], 0)
+        self.assertEqual(s["held"]["waiting"], "pointer", "a pane's held pointer holds the shell's reload")
+        self.assertEqual(s["after"]["reloads"], 1)
+        self.assertEqual(s["after"]["persisted"], 11, "the shell and every pane persisted before the reload")
+        # a pane under a same-origin shell forwards: its own core never fires
+        s2 = run_core("""
+var shellReqs = [];
+window.parent = { __rompReload: { request: function (r, d) { shellReqs.push([r, d]); }, tryFire: function () { shellReqs.push(["tryFire"]); } } };
+var R = window.__rompReload;
+R.noteDv(8); emit("pointerup");
+out({ shellReqs: shellReqs, inShell: R.inShell(), after: state() });""")
+        self.assertTrue(s2["inShell"])
+        self.assertEqual(s2["shellReqs"], [["build", "8"], ["tryFire"]])
+        self.assertEqual(s2["after"]["reloads"], 0, "the top document reloads, never the pane alone")
+
+    def test_a_foreign_parent_leaves_the_pane_to_reload_itself(self):
+        s = run_core("""
+Object.defineProperty(window, "parent", { get: function () { throw new Error("cross-origin"); } });
+var R = window.__rompReload; R.noteDv(8);
+out({ inShell: R.inShell(), after: state() });""")
+        self.assertFalse(s["inShell"])
+        self.assertEqual(s["after"]["reloads"], 1, "an iframe in another app reloads itself")
+
+
+class ReloadWiringPinned(unittest.TestCase):
+    def test_every_kernel_served_page_embeds_the_core_with_its_build_and_boot(self):
+        shim = km._shim("feed", 123)
+        self.assertIn("/*reload-core*/", shim)
+        self.assertLess(shim.find("/*reload-core*/"), shim.find("/*shim-core*/"), "the core is defined before the shim asks it")
+        self.assertIn("var LOADED=123,BOOT=%s," % json.dumps(km._BOOT_ID), shim)
+        self.assertIn("/*reload-core*/", km._stale_block(123))
+        self.assertIn("var LOADED=123,BOOT=%s," % json.dumps(km._BOOT_ID), km._stale_block(123))
+        self.assertLess(km._stale_block(123).find("/*reload-core*/"), km._stale_block(123).find("var RL=window.__rompReload;"))
+        self.assertIn("var LOADED=0,", km._reload_core())
+        with self.assertRaises(RuntimeError):
+            km._RELOAD_CORE_JS = km._RELOAD_CORE_JS.replace("/*end-reload-core*/", "", 1)
+            try:
+                km._reload_core_js()
+            finally:
+                km._RELOAD_CORE_JS = km._RELOAD_CORE_JS.replace("window.__rompReload=R;})();", "window.__rompReload=R;})();/*end-reload-core*/", 1)
+
+    def test_the_shim_asks_the_core_on_build_drift_and_on_a_standalone_reconnect(self):
+        js = km._shim("chat", 5)
+        self.assertIn('function raiseBuild(){if(buildRaised)return;buildRaised=true;var R=window.__rompReload;\n'
+                      'if(R){R.refused=function(){selfBar("A newer romp build is available.","build");};R.request("build","");}\n'
+                      'else selfBar("A newer romp build is available.","build");}', js)
+        self.assertNotIn('postMessage({romp:"wsStale",build:1}', js, "the build:1 hand-off to the banner is gone")
+        self.assertIn('if(msg&&msg.type==="ka"){if(LOADEDV&&msg.dv&&msg.dv>LOADEDV)raiseBuild();', js, "the keepalive's dv is still the event")
+        self.assertIn("if(window.__rompReload&&!window.__rompReload.inShell())window.__rompReload.checkBoot();", js)
+        # …on the RECONNECT branch only: the first open is not a restart
+        i = js.find("if(wasReconn){")
+        self.assertGreater(i, 0)
+        self.assertLess(i, js.find("window.__rompReload.checkBoot();"))
+
+    def test_the_shell_asks_on_its_own_sockets_reopen_and_feeds_its_keepalive(self):
+        js = km._LANDING_MOBILE_JS
+        self.assertIn("var shellOpened=false;", js)
+        self.assertIn("if(shellOpened&&window.__rompReload)window.__rompReload.checkBoot();shellOpened=true;", js)
+        self.assertIn("if(m&&m.type==='ka'){if(m.dv&&window.__rompReload)window.__rompReload.noteDv(m.dv);}", js)
+
+    def test_the_banner_is_the_refused_fallback_and_the_poll_feeds_the_core(self):
+        js = km._STALE_JS
+        self.assertIn("if(RL){RL.refused=function(){buildStale=true;show(BUILDMSG);};", js)
+        self.assertIn("RL.announce(function(k,t){if(window.__rompNotify)window.__rompNotify(k,t);});}", js)
+        self.assertIn("if(RL)RL.noteVersion(v);", js)
+        self.assertIn("if(loaded&&served>loaded&&served!==dismissed){if(!RL)show(BUILDMSG);}", js)
+        self.assertIn("if(m.build){if(RL)RL.request('build','');else{buildStale=true;show(BUILDMSG);}}", js)
+        self.assertIn("if(m&&m.romp==='wsFresh'){connStale=false;if(buildStale)show(BUILDMSG);else box.classList.remove('show');}", js,
+                      "the CONNECTION prompt for a plain reconnect is untouched")
+
+    def test_a_remote_kernels_restart_or_bundle_never_reaches_the_core(self):
+        fed = open(os.path.join(ROOT, "ui", "webview", "federation.ts")).read()
+        self.assertIn('if (msg && msg.type === "ka") return;', fed, "federation drops a remote kernel's keepalive")
+        core = km._reload_core_js()
+        self.assertNotIn("__rompLocalSend", core)
+        self.assertNotIn("host", core, "the core knows no hosts: it reads THIS page's socket and /version only")
+        self.assertIn("fetch('/version'", core, "…and /version is the serving kernel's own")
+
+    def test_the_superseded_rule_is_recorded_with_both_dates(self):
+        src = open(os.path.join(ROOT, "kernel", "kernel.py")).read()
+        self.assertIn("The user's ruling of 2026-09-08 (about 10:50 AM PT) supersedes their 2026-07-13 preference", src)
+        self.assertIn('the user 2026-09-08 ruled the page RELOADS ITSELF, superseding\n// the 2026-07-13 "prompt, never auto"', src)
+        ext = open(os.path.join(ROOT, "vscode-extension", "src", "extension.ts")).read()
+        self.assertIn("2026-09-08", ext, "the VS Code exception names the ruling it stands beside")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dashboard_reload_served.py
+++ b/tests/test_dashboard_reload_served.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""T265, the served leg: the dashboard reloads ITSELF on a newer bundle and on a kernel restart, never
+mid-gesture, and the chat reader keeps their place (the user 2026-09-08, superseding their 2026-07-13
+preference for a banner the reader clicks).
+
+Executed against the REAL page: a hermetic kernel serves the dashboard from a private copy of dist; the
+driver opens it, scrolls the chat transcript to mid-history, and
+  1. holds a pointer button down over the chat pane, then bumps a dist bundle's mtime — the kernel's next
+     keepalive carries a higher `dv` (the authoritative drift signal) — and asserts the page did NOT reload
+     while the button was held (the reload is armed, waiting on the pointer);
+  2. releases the button and asserts the page reloaded, landed the chat tab on the reader's saved position
+     (not the bottom), and left one "Reloaded onto build …" line in the notification center;
+  3. kills the kernel and relaunches it on the same port — a socket reopen against a NEW boot id — and asserts
+     a second reload with the "kernel restarted" wording.
+Skips LOUDLY when the extension deps or a playwright browser are absent (CI installs none); the decision code
+itself runs in node in test_dashboard_auto_reload.py regardless. All fixtures synthetic."""
+import json
+import os
+import re
+import shutil
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+SID = "11111111-2222-4333-8444-000000000201"
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def _transcript(cwd, pairs):
+    """`pairs` closed user/assistant turns (an OPEN turn would invite the boot reconcile to resume it)."""
+    out, parent, t = [], None, 1_700_000_000
+    filler = ["The ranking pass reads its weights from the notes-api config now.",
+              "Tokenizer edge cases (hyphens, quotes) are covered by the new fixture set.",
+              "Index rebuild time is dominated by the stemmer; caching its table halves it.",
+              "The pagination cursor survives a re-sort because it encodes the sort key too."]
+    for i in range(pairs):
+        u = "11111111-2222-4333-8444-0000000a%04x" % i
+        a = "11111111-2222-4333-8444-0000000b%04x" % i
+        ts = lambda k: time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(t + i * 60 + k))
+        out.append({"type": "user", "uuid": u, "parentUuid": parent, "timestamp": ts(0), "sessionId": SID, "cwd": cwd,
+                    "message": {"role": "user", "content": "please keep going with the search module notes (part %d)" % (i + 1)}})
+        body = "\n\n".join(["Note %d." % (i + 1)] + [filler[(i + k) % len(filler)] for k in range(3)])
+        out.append({"type": "assistant", "uuid": a, "parentUuid": u, "timestamp": ts(5), "sessionId": SID, "cwd": cwd,
+                    "message": {"id": "msg_lab_%04d" % i, "type": "message", "role": "assistant", "model": "claude-sonnet-5",
+                                "content": [{"type": "text", "text": body}], "stop_reason": "end_turn"}})
+        parent = a
+    return "\n".join(json.dumps(r) for r in out) + "\n"
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import { spawn } from "node:child_process";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1400, height: 900 } });
+const out = {};
+const die = async (why) => {
+  fs.writeSync(1, "RESULT:" + JSON.stringify({ ...out, died: why }) + "\n");
+  await browser.close();
+  process.exit(0);
+};
+const chatFrame = () => page.frames().find((f) => f.url().split("?")[0].endsWith("/chat"));
+const waitChat = async () => {
+  await page.waitForFunction(() => Array.from(document.querySelectorAll("iframe")).some((f) => (f.getAttribute("src") || "").startsWith("/chat")), null, { timeout: 20000 });
+  let fr = null;
+  for (let i = 0; i < 200 && !fr; i++) { fr = chatFrame(); if (!fr) await page.waitForTimeout(100); }
+  if (!fr) await die("no /chat frame");
+  await fr.waitForFunction(() => {
+    const c = document.getElementById("content");
+    return !!c && c.querySelectorAll(".turn").length > 20 && c.scrollHeight > c.clientHeight + 500;
+  }, null, { timeout: 30000 }).catch(async () => { await die("chat never overflowed"); });
+  return fr;
+};
+const info = (fr) => fr.evaluate(() => {
+  const c = document.getElementById("content");
+  const cr = c.getBoundingClientRect();
+  const els = Array.from(c.querySelectorAll("[data-uuid]"));
+  let anchor = null;
+  for (const el of els) { const r = el.getBoundingClientRect(); if (r.bottom > cr.top) { anchor = { uuid: el.dataset.uuid, top: Math.round(r.top - cr.top) }; break; } }
+  return { scrollTop: c.scrollTop, scrollHeight: c.scrollHeight, clientHeight: c.clientHeight, anchor,
+           chipHidden: (document.getElementById("jump-bottom") || { hidden: true }).hidden };
+});
+const notices = () => page.evaluate(() => { try { return JSON.parse(localStorage.getItem("romp:notices") || "[]").filter((n) => n.kind === "reload").map((n) => n.text); } catch (e) { return []; } });
+const probeSet = () => page.evaluate(() => { window.__probe = 1; return 1; });
+const probeAlive = () => page.evaluate(() => window.__probe === 1).catch(() => false);
+const shellWaiting = () => page.evaluate(() => window.__rompReload ? { waiting: window.__rompReload.waiting, owed: window.__rompReload.owed(), fired: window.__rompReload.fired() } : null).catch(() => null);
+const bump = (n) => { const t = new Date(Date.now() + n * 60 * 1000); fs.utimesSync(cfg.bumpFile, t, t); };
+
+// ---- load, scroll to mid-history ----
+await page.goto(cfg.url);
+let fr = await waitChat();
+await page.waitForTimeout(800);
+await fr.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = Math.round(c.scrollHeight * 0.45); });
+await page.waitForTimeout(600);
+const before = await info(fr);
+out.before = before;
+await probeSet();
+out.noticesBefore = await notices();
+
+// ---- 1. hold the pointer over the chat pane, then bump the bundle: armed, not fired ----
+const box = await (await page.$('iframe[src^="/chat"]')).boundingBox();
+await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+await page.mouse.down();
+bump(1);
+// three keepalives (ROMP_WS_KEEPALIVE=2 in the lab env) — plenty for the higher dv to reach the page
+await page.waitForTimeout(6500);
+out.probeWhileHeld = await probeAlive();
+out.shellWhileHeld = await shellWaiting();
+// ---- 2. release: the reload fires; the chat tab lands where the reader was ----
+await page.mouse.up();
+const reloaded = await page.waitForFunction(() => window.__probe !== 1, null, { timeout: 15000 }).then(() => true).catch(() => false);
+out.reloadedOnRelease = reloaded;
+if (!reloaded) await die("no reload after the pointer was released");
+fr = await waitChat();
+// the land is a frame after the build; poll until the position settles off the bottom or 5 s pass
+let after = null;
+for (let i = 0; i < 25; i++) { after = await info(fr); if (after.scrollHeight - after.scrollTop - after.clientHeight > 2 && after.scrollTop > 0) break; await page.waitForTimeout(200); }
+out.after = after;
+out.noticesAfterBuild = await notices();
+await probeSet();
+// the fresh page must SETTLE: three more keepalives with no further reload (a page that reloaded onto the
+// current build must not read the same build as drift again)
+await page.waitForTimeout(7000);
+out.settledAfterBuild = await probeAlive();
+
+// ---- 3. a kernel restart: kill + relaunch on the same port → a reopen against a new boot id ----
+process.kill(cfg.kernelPid, "SIGKILL");
+await page.waitForTimeout(500);
+const k2 = spawn(cfg.relaunch.cmd, [], { env: cfg.relaunch.env, detached: true,
+  stdio: ["ignore", fs.openSync(cfg.relaunch.log, "a"), fs.openSync(cfg.relaunch.log, "a")] });
+k2.unref();
+fs.writeSync(1, "KPID:" + k2.pid + "\n");
+const reloaded2 = await page.waitForFunction(() => window.__probe !== 1, null, { timeout: 60000 }).then(() => true).catch(() => false);
+out.reloadedOnRestart = reloaded2;
+if (reloaded2) { await waitChat().catch(() => {}); await page.waitForTimeout(1500); }
+out.noticesAfterRestart = await notices();
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedAutoReload(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served leg needs them")
+        cls.lab = tempfile.mkdtemp(prefix="auto-reload-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        shutil.copytree(os.path.join(EXT, "dist"), dist)
+        cls.bump_file = os.path.join(dist, "render.js")
+        state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        os.makedirs(os.path.join(state, "names"), exist_ok=True)
+        os.makedirs(os.path.join(state, "sdk"), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        # one synthetic SDK session so the chat page has a tab (the test_ship_reship lab shape); its transcript
+        # holds only CLOSED turns, so the boot reconcile never tries to resume it and no CLI is ever spawned
+        Path(state, "names", SID).write_text("web\t%s\t\t\n" % cwd)
+        Path(state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": SID, "alive": True}))
+        Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 100}, "seven_day": {"pct": 10}}))   # park sends
+        claude = os.path.join(cls.lab, "claude")
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        Path(proj, SID + ".jsonl").write_text(_transcript(cwd, 60))   # long: overflows the pane several times over
+        cls.port = _free_port()
+        cls.token = "testtok-autoreload"
+        cls.env = dict(os.environ,
+                       XDG_STATE_HOME=os.path.join(cls.lab, "xdg"),
+                       CLAUDE_CONFIG_DIR=claude,
+                       ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1",
+                       ROMP_SERVE_TOKEN=cls.token, ROMP_KERNEL_PORT=str(cls.port),
+                       ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off",
+                       ROMP_WS_KEEPALIVE="2",                       # the dv rides the keepalive: keep the wait short
+                       ROMP_TMUX_SOCKET="romp-autoreload-%d" % cls.port)
+        cls.env.pop("ROMP_STATE_DIR", None)
+        cls.env.pop("ANTHROPIC_API_KEY", None)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=cls.env)
+        cls.kernel2_pid = None
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        for pid in [getattr(cls, "kernel", None) and cls.kernel.pid, getattr(cls, "kernel2_pid", None)]:
+            if pid:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except (ProcessLookupError, PermissionError):
+                    pass
+        if getattr(cls, "kernel", None):
+            cls.kernel.wait()
+        subprocess.run(["tmux", "-L", cls.env.get("ROMP_TMUX_SOCKET", ""), "kill-server"], capture_output=True)
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_build_drift_reloads_after_the_gesture_ends_and_a_restart_reloads_too(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"url": "http://127.0.0.1:%d/?token=%s" % (self.port, self.token),
+                       "kernelPid": self.kernel.pid, "bumpFile": self.bump_file,
+                       "relaunch": {"cmd": os.path.join(BIN, "romp-kernel"), "env": self.env, "log": self.klog}}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        try:
+            p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                               env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        except subprocess.TimeoutExpired as e:
+            so = e.stdout if isinstance(e.stdout, str) else (e.stdout or b"").decode()
+            kpid = next((ln for ln in so.splitlines() if ln.startswith("KPID:")), None)
+            if kpid:
+                type(self).kernel2_pid = int(kpid.split(":", 1)[1])
+            self.fail("driver timed out; partial output:\n%s" % so)
+        kpid = next((ln for ln in p.stdout.splitlines() if ln.startswith("KPID:")), None)
+        if kpid:
+            type(self).kernel2_pid = int(kpid.split(":", 1)[1])
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served leg needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        self.assertNotIn("died", r, "driver aborted early: %r" % r)
+        b, a = r["before"], r["after"]
+        self.assertGreater(b["scrollHeight"] - b["scrollTop"] - b["clientHeight"], 200, "the reader was scrolled up before: %r" % b)
+        # 1. armed, not fired, while the pointer was held
+        self.assertTrue(r["probeWhileHeld"], "the page must not reload mid-gesture: %r" % r)
+        self.assertEqual((r["shellWhileHeld"] or {}).get("waiting"), "pointer", "the reload is armed on the held pointer: %r" % r["shellWhileHeld"])
+        self.assertEqual(((r["shellWhileHeld"] or {}).get("owed") or {}).get("reason"), "build")
+        # 2. the release fires it, and the chat tab lands where the reader was
+        self.assertTrue(r["reloadedOnRelease"])
+        self.assertLessEqual(abs(a["scrollTop"] - b["scrollTop"]), 60, "the reader's position survives the reload: %r → %r" % (b, a))
+        self.assertGreater(a["scrollHeight"] - a["scrollTop"] - a["clientHeight"], 200, "…and is not the bottom: %r" % a)
+        self.assertFalse(a["chipHidden"], "off the bottom, the go-to-bottom chip shows")
+        self.assertEqual(len(r["noticesBefore"]), 0)
+        self.assertEqual(len(r["noticesAfterBuild"]), 1, "one notification-center line per reload: %r" % r["noticesAfterBuild"])
+        self.assertRegex(r["noticesAfterBuild"][0], r"^Reloaded onto build \d+ — a newer romp build was served\.$")
+        self.assertTrue(r["settledAfterBuild"], "one reload per drift — the fresh page must not reload again: %r" % r)
+        # 3. a kernel restart reloads too, with its own wording
+        self.assertTrue(r["reloadedOnRestart"], "a socket reopen against a new boot id reloads the page: %r" % r)
+        self.assertEqual(len(r["noticesAfterRestart"]), 2, r["noticesAfterRestart"])
+        self.assertRegex(r["noticesAfterRestart"][1], r"^Reloaded onto build \d+ — the kernel restarted\.$")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -155,7 +155,9 @@ class DisconnectBanner(unittest.TestCase):
         # a pane's build-drift raise rides the same wsStale channel tagged build:1 → the shell shows
         # BUILDMSG (not the connection wording), and latches it so its own /version poll — whose token
         # may be current — can't clear the prompt out from under the stale pane (the user 2026-07-13)
-        self.assertIn("if(m.build){buildStale=true;show(BUILDMSG);}else{connStale=true;show(CONNMSG);}", km._STALE_JS)
+        # T265 (the user 2026-09-08): a build:1 is handed to the reload core (the page reloads itself); the
+        # BUILDMSG wording shows only where the core is absent
+        self.assertIn("if(m.build){if(RL)RL.request('build','');else{buildStale=true;show(BUILDMSG);}}else{connStale=true;show(CONNMSG);}", km._STALE_JS)
         self.assertIn("!connStale&&!buildStale", km._STALE_JS, "the poll's clear respects both latches")
         self.assertIn("connStale=false;buildStale=false;", km._STALE_JS, "Dismiss clears both")
 

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -181,8 +181,10 @@ class LandingShell(unittest.TestCase):
         # Escape-closes-the-topmost-modal block 2026-08-09; + the release-update banner 2026-08-09).
         html = km._landing()
         # +1 2026-08-28: the theme reader right after <body>; +1 2026-09-06: the notification-tap landing
-        # script (_LANDING_REVEAL_JS) — its own script so a throw in the bell's cannot strand a tap
-        self.assertEqual(html.count("<script>"), 18)
+        # script (_LANDING_REVEAL_JS) — its own script so a throw in the bell's cannot strand a tap;
+        # +1 2026-09-08: the reload core (T265, _reload_core) ahead of the build-staleness banner script, which
+        # registers as its refused fallback — its own script so a banner throw cannot take the reload with it
+        self.assertEqual(html.count("<script>"), 19)
 
     def test_bottom_bar_is_text_only_and_compact(self):
         html = km._landing()

--- a/tests/test_kernel_ws_heartbeat.py
+++ b/tests/test_kernel_ws_heartbeat.py
@@ -129,12 +129,15 @@ class BuildDriftBanner(unittest.TestCase):
         # that doesn't know its build can never false-positive
         self.assertIn("var LOADEDV=0;", km._shim("feed"))
 
-    def test_shim_raises_the_build_banner_once_shell_or_self(self):
+    def test_shim_raises_build_drift_once_to_the_reload_core_with_the_bar_as_fallback(self):
+        # T265 (the user 2026-09-08): the raise asks the reload core (the page reloads itself, never mid-gesture);
+        # the self-injected bar is only the fallback for a host that refuses location.reload
         js = km._shim("chat", 7)
-        self.assertIn('window.parent.postMessage({romp:"wsStale",build:1}', js,
-                      "embedded pane routes build drift to the shell banner, tagged so it words it as a BUILD")
+        self.assertIn('if(R){R.refused=function(){selfBar("A newer romp build is available.","build");};R.request("build","");}', js,
+                      "build drift is a reload request to the core; the bar only if the reload is refused")
+        self.assertNotIn('postMessage({romp:"wsStale",build:1}', js, "the hand-off to the shell banner is gone")
         self.assertIn('selfBar("A newer romp build is available.","build")', js,
-                      "standalone page self-injects the same reload bar")
+                      "standalone page self-injects the bar when the core is absent or refused")
         self.assertIn("var buildRaised=false,freshPending=false,restartAnnounced=0;", js)   # latched: one prompt per page life (T217 added the announced-restart latch to the line)
         #                                    (freshPending rides along: the CONN prompt's self-retire, 2026-08-01)
 

--- a/ui/webview/pane-shim-stale.test.ts
+++ b/ui/webview/pane-shim-stale.test.ts
@@ -28,9 +28,11 @@ function shimJs(app: string): string {
   const def = KERNEL.indexOf("def _shim(app, v=0):");
   assert.ok(def > 0, "the shim renderer exists");
   const start = KERNEL.indexOf('return """', def) + 'return """'.length;
-  const end = KERNEL.indexOf('""" % (app, int(v), app, app)', start);
+  // the tuple's first slot is the reload core (T265, its own executed test in tests/test_dashboard_auto_reload.py);
+  // an empty core here leaves window.__rompReload undefined, so the shim's raise takes its fallback path
+  const end = KERNEL.indexOf('""" % (_reload_core(v), app, int(v), app, app)', start);
   assert.ok(end > start, "the template's format tuple is the one the test substitutes");
-  const args = [app, "5", app, app];
+  const args = ["", app, "5", app, app];
   let i = 0;
   return KERNEL.slice(start, end).replace(/%[sd]/g, () => args[i++]).replace(/%%/g, "%");
 }

--- a/ui/webview/reload-restore.test.ts
+++ b/ui/webview/reload-restore.test.ts
@@ -1,0 +1,62 @@
+// A page reload keeps the chat reader's place (T265, the user 2026-09-08: the dashboard reloads itself on a kernel
+// restart and on a newer served bundle, superseding their 2026-07-13 preference for a banner the reader clicks, so
+// the reload must not cost the reader their scroll position or follow mode). The decisions are pure and execute
+// here; render.ts has import-time DOM side effects, so its wiring — the synchronous persist hook the reload core
+// calls, the pagehide belt, the load-time take, landActive's one-shot consume — is pinned to source.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { reloadScrollRecord, takeReloadScroll, reloadLandTarget } from "./reload-restore";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const SID = "11111111-2222-4333-8444-000000000201";
+
+test("the record names the tab, the position, the follow mode and the anchor; no tab → nothing to keep", () => {
+  assert.deepEqual(reloadScrollRecord(SID, 1234, false, { uuid: "u1", y: 40 }), { id: SID, top: 1234, stick: false, anchor: { uuid: "u1", y: 40 } });
+  assert.deepEqual(reloadScrollRecord(SID, 5000, true, null), { id: SID, top: 5000, stick: true, anchor: null });
+  assert.equal(reloadScrollRecord(null, 10, false, null), null);
+  assert.equal(reloadScrollRecord("", 10, false, null), null);
+});
+
+test("the record applies to the tab it was saved for, once; another tab or a malformed record gets nothing", () => {
+  const rec = reloadScrollRecord(SID, 1234, false, null);
+  assert.equal(takeReloadScroll(rec, SID), rec);
+  assert.equal(takeReloadScroll(rec, "11111111-2222-4333-8444-000000000202"), null, "a different tab lands by the ordinary rule");
+  assert.equal(takeReloadScroll(rec, null), null);
+  assert.equal(takeReloadScroll(null, SID), null);
+  assert.equal(takeReloadScroll({ id: SID }, SID), null, "no position → no restore");
+  assert.equal(takeReloadScroll("junk", SID), null);
+});
+
+test("where the restored land goes: bottom for follow mode, the anchor when honoured, else the raw top", () => {
+  assert.equal(reloadLandTarget({ id: SID, top: 999, stick: true, anchor: { uuid: "u", y: 0 } }, true), "bottom");
+  assert.equal(reloadLandTarget({ id: SID, top: 999, stick: false, anchor: { uuid: "u", y: 0 } }, true), "anchor");
+  assert.equal(reloadLandTarget({ id: SID, top: 999, stick: false, anchor: { uuid: "u", y: 0 } }, false), 999, "the anchor turn is not in the rebuilt DOM: raw scrollTop");
+  assert.equal(reloadLandTarget({ id: SID, top: 999, stick: false, anchor: null }, false), 999);
+});
+
+test("render.ts persists SYNCHRONOUSLY for the reload core and on pagehide, into the persisted webview state", () => {
+  assert.match(RENDER, /import \{ reloadScrollRecord, takeReloadScroll, type ReloadScroll \} from "\.\/reload-restore";/);
+  assert.match(RENDER, /\(window as any\)\.__rompPersistForReload = persistScrollForReload;/);
+  assert.match(RENDER, /window\.addEventListener\("pagehide", persistScrollForReload\);/);
+  const m = RENDER.match(/^function persistScrollForReload\(\): void \{([\s\S]*?)\n\}/m);
+  assert.ok(m, "persistScrollForReload");
+  const body = m![1];
+  assert.match(body, /const stick = content\.scrollHeight - content\.scrollTop - content\.clientHeight <= 2;/, "follow mode is the true bottom");
+  assert.match(body, /reloadScrollRecord\(activeId, content\.scrollTop, stick, stick \? null : captureScrollAnchor\(content, v\)\)/);
+  assert.match(body, /vscodeApi\.setState\(\{ \.\.\.\(vscodeApi\.getState\(\) \|\| \{\}\), reloadScroll: rec \}\)/);
+  // nothing to keep for a hidden pane or a tab never shown
+  assert.match(body, /if \(!content \|\| !v \|\| !v\.shown \|\| content\.clientHeight <= 0\) return;/);
+});
+
+test("render.ts takes the record out of the state at load (one reload, one restore)", () => {
+  assert.match(RENDER, /let pendingReloadScroll: ReloadScroll \| null = \(\(\) => \{[\s\S]*?const r = st\.reloadScroll \|\| null;\s*\n\s*if \(r && vscodeApi\?\.setState\) vscodeApi\.setState\(\{ \.\.\.st, reloadScroll: undefined \}\);\s*\n\s*return r;/);
+});
+
+test("landActive's landing consumes the record for the active tab first, then falls to the ordinary rule", () => {
+  const m = RENDER.match(/^function landActive\(content: HTMLElement \| null, v: View\): void \{([\s\S]*?)\n\}/m);
+  assert.ok(m, "landActive");
+  const body = m![1];
+  assert.match(body, /const rs = takeReloadScroll\(pendingReloadScroll, activeId\);\s*\n\s*if \(rs\) \{\s*\n\s*pendingReloadScroll = null;\s*\n\s*v\.stick = rs\.stick;\s*\n\s*if \(rs\.stick\) writeScroll\(content, content\.scrollHeight, "reload-restore", true\);\s*\n\s*else if \(!\(rs\.anchor && restoreScrollAnchor\(content, v, rs\.anchor\)\)\) writeScroll\(content, rs\.top, "reload-restore"\);\s*\n\s*\}\s*\n\s*else if \(!v\.shown \|\| v\.stick\) writeScroll\(content, content\.scrollHeight, "land-bottom", true\);\s*\n\s*else writeScroll\(content, v\.scrollTop, "land-saved"\);/);
+});

--- a/ui/webview/reload-restore.ts
+++ b/ui/webview/reload-restore.ts
@@ -1,0 +1,38 @@
+// What a page reload costs the chat pane's reader, and how it comes back (T265, the user 2026-09-08: the dashboard
+// reloads itself on a kernel restart and on a newer served bundle — superseding their 2026-07-13 preference for a
+// banner the reader clicks — so the reload must not cost them their place). The draft and the active tab were
+// persisted already; the active tab's scroll position and follow mode were not, so every reload landed the reader
+// at the bottom of the transcript they were reading.
+//
+// Before the page goes down (the reload core calls window.__rompPersistForReload synchronously; `pagehide` is the
+// belt for any other navigation) render.ts records the active shown view's scrollTop, its follow mode (`stick`)
+// and its anchor turn (uuid + offset), keyed by the tab id, in the persisted webview state. On load the record is
+// taken out of the state at once (one reload, one restore) and landActive's first show of THAT tab consumes it:
+// a follow-mode reader lands at the bottom as before; anyone else lands on their anchor turn when the rebuilt DOM
+// has it, else on the raw scrollTop. Any other tab, or a second land, sees the ordinary rule. Pure, so node
+// executes the decisions; render.ts's wiring is pinned by reload-restore.test.ts.
+
+export interface ReloadScroll { id: string; top: number; stick: boolean; anchor: { uuid: string; y: number } | null; }
+
+/** The record to persist for the active shown view; null when there is nothing to keep (no active tab). */
+export function reloadScrollRecord(id: string | null | undefined, top: number, stick: boolean,
+                                   anchor: { uuid: string; y: number } | null | undefined): ReloadScroll | null {
+  if (!id) return null;
+  return { id, top, stick, anchor: anchor || null };
+}
+
+/** The saved record applies to exactly one land: the first show of the tab that was active when the page went
+ *  down. Anything else (a different tab, a malformed record) gets nothing. */
+export function takeReloadScroll(saved: unknown, id: string | null | undefined): ReloadScroll | null {
+  const s = saved as ReloadScroll | null | undefined;
+  if (!s || typeof s !== "object" || !id || s.id !== id || typeof s.top !== "number") return null;
+  return s;
+}
+
+/** Where the restored land goes: the bottom for a follow-mode reader, the anchor when the rebuilt DOM honoured it,
+ *  else the raw saved scrollTop. */
+export function reloadLandTarget(s: ReloadScroll, anchorRestored: boolean): "bottom" | "anchor" | number {
+  if (s.stick) return "bottom";
+  if (anchorRestored) return "anchor";
+  return s.top;
+}

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -58,6 +58,7 @@ import { followReader, keepPlaceAcrossShow, followTail } from "./scroll-keep";
 import { retainLiveOmitted } from "./tab-order";
 import { userTurnShows } from "./user-turn-content";
 import { ScrollDiagBudget, classifyScroll, scrollWriteRow } from "./scroll-write";
+import { reloadScrollRecord, takeReloadScroll, type ReloadScroll } from "./reload-restore";
 import { keepResidentEvents } from "./frame-merge";
 import { activeTabToReannounce } from "./relay-active";
 import { dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
@@ -10330,7 +10331,16 @@ function landActive(content: HTMLElement | null, v: View): void {
     }
   }
   if (!scrolled) {
-    if (!v.shown || v.stick) writeScroll(content, content.scrollHeight, "land-bottom", true);
+    // a page reload's one-shot restore (T265): the tab that was active when the page went down lands where its
+    // reader was — the bottom for a follow-mode reader, else their anchor turn, else the raw saved scrollTop
+    const rs = takeReloadScroll(pendingReloadScroll, activeId);
+    if (rs) {
+      pendingReloadScroll = null;
+      v.stick = rs.stick;
+      if (rs.stick) writeScroll(content, content.scrollHeight, "reload-restore", true);
+      else if (!(rs.anchor && restoreScrollAnchor(content, v, rs.anchor))) writeScroll(content, rs.top, "reload-restore");
+    }
+    else if (!v.shown || v.stick) writeScroll(content, content.scrollHeight, "land-bottom", true);
     else writeScroll(content, v.scrollTop, "land-saved");
   }
   v.shown = true;
@@ -10346,6 +10356,31 @@ function landActive(content: HTMLElement | null, v: View): void {
 // turn still visible at the viewport top, keyed by its STABLE data-uuid, and after the rebuild put THAT
 // element back at its exact offset — then content changing anywhere else, above or below, cannot move what
 // the user is reading. The raw scrollTop stays as the fallback for an anchor the render window evicted.
+// ── a page reload keeps the reader's place (T265, the user 2026-09-08) ───────────────────────────────────
+// The dashboard now reloads itself on a kernel restart and on a newer served bundle (the shell's reload core,
+// kernel.py _RELOAD_CORE_JS). The core calls window.__rompPersistForReload on every pane SYNCHRONOUSLY before
+// location.reload (a posted message could miss the unload); `pagehide` is the belt for any other navigation.
+// The record rides the persisted webview state beside the drafts and the active tab, is taken out of the state
+// the moment the page loads (one reload, one restore) and is consumed by landActive's first show of that tab.
+let pendingReloadScroll: ReloadScroll | null = (() => {
+  try {
+    const st = (vscodeApi?.getState?.() || {}) as any;
+    const r = st.reloadScroll || null;
+    if (r && vscodeApi?.setState) vscodeApi.setState({ ...st, reloadScroll: undefined });
+    return r;
+  } catch { return null; }
+})();
+function persistScrollForReload(): void {
+  const content = document.getElementById("content");
+  const v = activeId ? views.get(activeId) : null;
+  if (!content || !v || !v.shown || content.clientHeight <= 0) return;
+  const stick = content.scrollHeight - content.scrollTop - content.clientHeight <= 2;   // the true bottom
+  const rec = reloadScrollRecord(activeId, content.scrollTop, stick, stick ? null : captureScrollAnchor(content, v));
+  try { if (vscodeApi?.setState) vscodeApi.setState({ ...(vscodeApi.getState() || {}), reloadScroll: rec }); } catch { /* ignore */ }
+}
+(window as any).__rompPersistForReload = persistScrollForReload;
+window.addEventListener("pagehide", persistScrollForReload);
+
 function captureScrollAnchor(content: HTMLElement, v: View): { uuid: string; y: number } | null {
   const cTop = content.getBoundingClientRect().top;
   const turns = v.el.querySelectorAll("[data-uuid]");

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -114,7 +114,10 @@ function maybeBuildNotice(dv: unknown): void {
 // AUTH-EXEMPT route: anything answering on the kernel port could then choose the directory we ran a
 // shell command from, and drive the prompt that invites the click besides. When this copy isn't a
 // checkout it can't rebuild anything, so we say so and point at the terminal rather than running some
-// other install.sh. Reload stays a user click, never automatic (prefer-reload-banner-not-auto).
+// other install.sh. Reload stays a user click here, never automatic: the served dashboard reloads ITSELF on a
+// kernel restart or a newer bundle since 2026-09-08 (superseding the 2026-07-13 banner preference, T265), but a
+// VS Code webview reload cannot fix bundled-code drift — the bundle comes from the installed VSIX, so only a
+// reinstall plus the editor's own reload lands new code, and that is the user's click.
 let updating = false;
 async function updateExtension(): Promise<void> {
   if (updating) return;                                    // one run per host (double-click, or toast + palette)


### PR DESCRIPTION
## Summary
The dashboard reloads itself after a kernel restart and after a newer served bundle, never mid-gesture, and the chat reader keeps their place. The user's ruling of 2026-09-08 supersedes their 2026-07-13 preference for a banner the reader clicks; the comments that cited the old rule now say so with both dates.

## Design
**One reload core on every kernel-served page** (`_RELOAD_CORE_JS` in kernel.py, `window.__rompReload`), embedded by the shim on every pane page and by the landing ahead of the stale-banner script. Two signals, both exact events:
1. **Kernel restart**: a socket REOPEN whose `/version` answers with a boot id other than the one baked into the page (`checkBoot`). The shell asks on its own socket's reopen; a standalone pane asks on its shim's reconnect; a pane inside the shell leaves it to the shell. The banner's existing 30 s `/version` poll hands the core every reading as the backstop for a page whose socket never dropped.
2. **Build drift**: a `dv` on a keepalive above the page's baked `LOADEDV` (`noteDv`, from the shim's existing check and now the shell's own socket too), or `/version`'s `dist_ver`.

**Never mid-gesture.** A held pointer button, a drag in flight, a text selection being made, or the composer focused with text arms the reload; the ending event fires it (pointerup/pointercancel, dragend/drop, selectionchange, input, focusout; a window blur releases every hold). No timer. The shell composes gesture state across its same-origin panes and every pane forwards its request to the shell, so one decision reloads the top document. A pane under a foreign parent (an iframe in another app) decides for itself; an iframe can reload.

**Before reloading**: every pane's `window.__rompPersistForReload` runs synchronously (the chat pane records the active tab's scrollTop, follow mode and anchor turn beside the drafts and active tab it already persisted; `pagehide` is the belt), the shell's lifted modals close (settings/picker), and a marker rides sessionStorage. **After**: `landActive`'s first show of that tab lands a follow-mode reader at the bottom and anyone else on their anchor turn, else the raw scrollTop (`ui/webview/reload-restore.ts`), and the fresh page leaves one notification-center line: "Reloaded onto build N — the kernel restarted" or "— a newer romp build was served".

**The banner** stays only as the core's `refused` fallback (a host whose `location.reload` throws). The connection prompt for a same-process socket blip is untouched. **VS Code**: the webview never runs this code; its bundle comes from the installed VSIX and a webview reload cannot fix bundled-code drift, so its reload prompt stays a user click (comment updated in extension.ts to say why, beside the new ruling).

**Federated relay**: a remote kernel's restart cannot reload the page. The core reads only this page's own socket and `/version`; federation drops remote `ka` frames and the relay never forwards a remote boot id. Pinned.

## Tests
- `tests/test_dashboard_auto_reload.py`: node executes the real core (one process per scenario) with fakes: dv drift fires when idle and persists first; a reopen against the same boot is a blip, a new boot fires; `/version` readings feed both signals; held pointer, drag, selection and composer-with-text each arm and fire on their ending event; a window blur releases; a refused reload falls back to the banner hook; the fresh page announces once from the marker; the shell composes pane gesture state and a pane forwards its request; a foreign parent leaves the pane to reload itself. Plus wiring pins (shim raise and reconnect, shell socket, banner fallback and poll, every page embeds the core with its build and boot, remote exclusion, both dates recorded).
- `ui/webview/reload-restore.test.ts`: the pure restore decisions plus render.ts wiring pins (synchronous persist hook, pagehide, load-time take, landActive's one-shot consume).
- `tests/test_dashboard_reload_served.py`: the real page. Holds a pointer over the chat pane, bumps a dist bundle's mtime so the kernel's next keepalive carries a higher `dv`, asserts no reload while held (armed on the pointer), releases, asserts the reload, the restored scroll position and the notice; then kills and relaunches the kernel and asserts the restart reload with its wording. Skips loudly without node playwright (CI installs none); verified locally with the python playwright twin of the same steps:

| step | result (run 2 / run 3, headless Chromium) |
|---|---|
| reader scrolled to mid-history, then pointer held over the chat pane, dist bundle mtime bumped | no reload for 6.5 s (three keepalives); the shell reports the reload armed on the held pointer with reason `build` |
| pointer released | page reloaded; chat scrollTop 6281 → 6282 (anchor turn offset −40 → −41 px); go-to-bottom chip visible; one notice "Reloaded onto build N — a newer romp build was served." |
| fresh page left alone for three more keepalives | no second reload |
| kernel killed and relaunched on the same port | page reloaded once more; second notice "Reloaded onto build N — the kernel restarted." |

- Updated: `test_kernel_ws_heartbeat.py`, `test_kernel_disconnect_banner.py` pins moved to the core routing.
- Python suite: __PY__. `npm test`: __NPM__. `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
