### PR TITLE
Chat pane: a box below the transcript keeps an at-bottom reader at the bottom

### DIFF
--- a/ui/webview/box-below.test.ts
+++ b/ui/webview/box-below.test.ts
@@ -8,8 +8,9 @@
 // Fix: a ResizeObserver on #bg-tasks and #footer with the rule OPPOSITE to the boxes-above compensation: a reader
 // whose recorded follow mode is on (the view's `stick`, untouched by the growth since no scroll event fired) is
 // written to the new bottom (writer "box-below"); a scrolled-up reader is untouched (their top line never moved).
-// Pure rule executed here; render.ts wiring pinned. Also pinned: #content opts out of the browser's own scroll
-// anchoring, which was double-compensating the pane's own writers (see the comment beside the rule in styles.css).
+// Pure rule executed here; render.ts wiring pinned. Also pinned: the browser's scroll anchoring stays ON for #content
+// (a measured result, see the comment beside the rule in styles.css — the opt-out let the visible line drift
+// 194-246 px after a window slide, where the anchoring held it at 0).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -43,6 +44,7 @@ test("render.ts observes #bg-tasks and #footer and writes the new bottom through
   assert.match(RENDER, /writeScroll\(content, content\.scrollTop \+ \(h - lastH\), "box-resize"\);/);
 });
 
-test("#content opts out of the browser's scroll anchoring: the pane is the one compensator", () => {
-  assert.match(CSS, /#content \{[^}]*overflow-anchor: none;/);
+test("#content keeps the browser's scroll anchoring: measured, the opt-out made the line drift after a window slide", () => {
+  assert.doesNotMatch(CSS, /#content[^{]*\{[^}]*overflow-anchor/, "do not add overflow-anchor to #content");
+  assert.match(CSS, /The browser's scroll anchoring stays ON here \(measured 2026-09-08, T262e\)/);
 });

--- a/ui/webview/box-below.test.ts
+++ b/ui/webview/box-below.test.ts
@@ -1,0 +1,48 @@
+// A box BELOW the transcript growing must not drop an at-bottom reader out of follow mode (T262e, the user
+// 2026-09-08 11:30 AM PT: when the awaiting/background-task box appears between the transcript and the composer
+// and covers part of the text, a reader at the bottom must stay at the bottom — the pane scrolls by the box's
+// height — and today it does not). A box below the scroller changes the scroller's clientHeight and nothing else:
+// the browser keeps scrollTop, fires no scroll event, and the reader who was at the bottom is now the box's
+// height above it with the last lines covered; the next append reads atBottom false and leaves them there — the
+// pane has fallen into scrolled-up mode by itself. The composer auto-grows the same way while a message is typed.
+// Fix: a ResizeObserver on #bg-tasks and #footer with the rule OPPOSITE to the boxes-above compensation: a reader
+// whose recorded follow mode is on (the view's `stick`, untouched by the growth since no scroll event fired) is
+// written to the new bottom (writer "box-below"); a scrolled-up reader is untouched (their top line never moved).
+// Pure rule executed here; render.ts wiring pinned. Also pinned: #content opts out of the browser's own scroll
+// anchoring, which was double-compensating the pane's own writers (see the comment beside the rule in styles.css).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { followBoxBelow } from "./scroll-keep";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("a follow-mode reader follows the bottom when a box below grows or shrinks; a scrolled-up reader is untouched", () => {
+  assert.equal(followBoxBelow(true, 64), true, "the awaiting box appeared: pin to the new bottom");
+  assert.equal(followBoxBelow(true, -64), true, "it went away: the bottom is the bottom (the clamp already got there; the write is a no-op)");
+  assert.equal(followBoxBelow(true, 0), false, "no height change, no write");
+  assert.equal(followBoxBelow(false, 64), false, "reading history: the top line never moved, leave them");
+  assert.equal(followBoxBelow(false, -64), false);
+});
+
+test("render.ts observes #bg-tasks and #footer and writes the new bottom through the scroll-write helper", () => {
+  assert.match(RENDER, /import \{[^}]*\bfollowBoxBelow\b[^}]*\} from "\.\/scroll-keep";/);
+  assert.match(RENDER, /for \(const boxId of \["bg-tasks", "footer"\]\) \{/);
+  const m = RENDER.match(/for \(const boxId of \["bg-tasks", "footer"\]\) \{([\s\S]*?)\n\}/);
+  assert.ok(m, "the boxes-below observer block");
+  const body = m![1];
+  assert.match(body, /new ResizeObserver\(/);
+  assert.match(body, /followBoxBelow\(v\.stick, h - lastH\)/, "the recorded follow mode decides, never a post-growth atBottom read (the growth already moved the bottom away)");
+  assert.match(body, /writeScroll\(content, content\.scrollHeight, "box-below", true\);/);
+  assert.match(body, /v\.scrollTop = content\.scrollTop;/, "the per-view saved position follows");
+  assert.match(body, /content\.clientHeight > 0/, "a hidden pane measures 0: nothing to do");
+  // the boxes ABOVE keep their own (opposite) rule
+  assert.match(RENDER, /for \(const boxId of \["tabbar", "ledger"\]\) \{/);
+  assert.match(RENDER, /writeScroll\(content, content\.scrollTop \+ \(h - lastH\), "box-resize"\);/);
+});
+
+test("#content opts out of the browser's scroll anchoring: the pane is the one compensator", () => {
+  assert.match(CSS, /#content \{[^}]*overflow-anchor: none;/);
+});

--- a/ui/webview/follow-tail.test.ts
+++ b/ui/webview/follow-tail.test.ts
@@ -23,7 +23,7 @@ test("the harness case: 60 px above the bottom, a frame that adds nothing → no
 });
 
 test("render.ts appendActive measures before the rebuild and pins only when followTail says so", () => {
-  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist \} from "\.\/scroll-keep";/);
+  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow \} from "\.\/scroll-keep";/);
   const m = RENDER.match(/^function appendActive\(\) \{([\s\S]*?)\n\}/m);
   assert.ok(m, "appendActive");
   const body = m![1];

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -54,7 +54,7 @@ import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser
 import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
 import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
-import { followReader, keepPlaceAcrossShow, followTail, atBottomDist } from "./scroll-keep";
+import { followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow } from "./scroll-keep";
 import { retainLiveOmitted } from "./tab-order";
 import { userTurnShows } from "./user-turn-content";
 import { ScrollDiagBudget, classifyScroll, scrollWriteRow } from "./scroll-write";
@@ -10556,6 +10556,33 @@ if (typeof ResizeObserver === "function") {
       lastH = h;
     });
     tro.observe(box);
+  }
+}
+// Boxes BELOW the transcript — #bg-tasks (the awaiting/background-task box) and #footer (statusline + the
+// composer, which auto-grows as a message is typed) — grow/shrink → an at-bottom reader STAYS at the bottom
+// (T262e, the user 2026-09-08: the box appeared over the last lines and the pane fell into scrolled-up mode by
+// itself). A box below changes only #content's clientHeight: the browser keeps scrollTop and fires no scroll
+// event, so the reader who was at the bottom is now the box's height above it with the text covered, and the
+// next append reads atBottom false and leaves them there. The rule is the OPPOSITE of the boxes-above one: the
+// view's RECORDED follow mode (`stick` — still the pre-growth truth, nothing scrolled) decides (followBoxBelow),
+// and a follow-mode reader is written to the new bottom; a scrolled-up reader is untouched (their top line never
+// moved). Event-based (the observer), no timer.
+if (typeof ResizeObserver === "function") {
+  for (const boxId of ["bg-tasks", "footer"]) {
+    const box = document.getElementById(boxId);
+    if (!box) continue;
+    let lastH = -1;                                           // -1 = not yet measured (observe fires once on attach)
+    const bro = new ResizeObserver((entries) => {
+      const h = entries[0]?.contentRect?.height ?? 0;
+      const content = document.getElementById("content");
+      const v = activeId ? views.get(activeId) : null;
+      if (content && lastH >= 0 && content.clientHeight > 0 && v && v.shown && followBoxBelow(v.stick, h - lastH)) {
+        writeScroll(content, content.scrollHeight, "box-below", true);
+        v.scrollTop = content.scrollTop;                      // keep the per-view saved position in sync
+      }
+      lastH = h;
+    });
+    bro.observe(box);
   }
 }
 

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9282,7 +9282,7 @@ function writeScroll(content: HTMLElement, top: number, writer: string, stick = 
   content.scrollTop = top;
   const after = content.scrollTop;
   lastScrollWriteAfter = after;
-  if (after !== before) scrollDiagRow("scrollwrite", scrollWriteRow(activeId || "", writer, before, after, stick));
+  if (after !== before) scrollDiagRow("scrollwrite", scrollWriteRow(activeId || "", writer, before, after, stick, content.scrollHeight, content.clientHeight));
 }
 
 function cssEscape(s: string): string {
@@ -10528,7 +10528,7 @@ window.addEventListener("resize", updateJumpBtn);
     // the scroll nobody's code asked for is the user's (T262): filed so a recording lines up with the journal;
     // a write's own echo (within a pixel of the value written) is consumed here and never read as a gesture
     if (classifyScroll(c.scrollTop, lastScrollWriteAfter) === "write-echo") lastScrollWriteAfter = null;
-    else scrollDiagRow("scrollgesture", { sid: activeId || "", top: c.scrollTop, gesture: true });
+    else scrollDiagRow("scrollgesture", { sid: activeId || "", top: c.scrollTop, gesture: true, sh: c.scrollHeight, ch: c.clientHeight });   // sh/ch: a clamp reads top == sh - ch after sh dropped (T262e)
   }, { passive: true });
 }
 // Boxes ABOVE the transcript grow/shrink → keep the chat text visually anchored (the user 2026-06-30 for

--- a/ui/webview/scroll-keep-on-show.test.ts
+++ b/ui/webview/scroll-keep-on-show.test.ts
@@ -77,7 +77,7 @@ test("render.ts: the reshow decision counts a live durable seek for the tab as n
 });
 
 test("render.ts: the #content scroll listener keeps the active view's saved spot current (passive, no timer)", () => {
-  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist \} from "\.\/scroll-keep";/);   // + followTail (T262: follow only on new content)
+  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow \} from "\.\/scroll-keep";/);   // + followTail (T262: follow only on new content)
   // …and stands down while a deferred build is pending: the reveal's clamp fires a scroll event before the land
   assert.match(RENDER, /c\.addEventListener\("scroll", \(\) => \{\n\s*if \(c\.clientHeight <= 0\) return;\n\s*followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, atBottom\(c\), pendingBuildRaf != null\);\n(?:.*\n){0,4}?\s*\}, \{ passive: true \}\);/);
   // landActive's landing rule itself is unchanged — its INPUT is what the fix repairs

--- a/ui/webview/scroll-keep.ts
+++ b/ui/webview/scroll-keep.ts
@@ -63,6 +63,18 @@ export function atBottomDist(dist: number): boolean {
   return dist <= AT_BOTTOM_PX;
 }
 
+/** A box BELOW the transcript changed height (T262e, the user 2026-09-08: the awaiting/background-task box appeared
+ *  over the last lines and the pane fell into scrolled-up mode by itself; the composer auto-growing does the same).
+ *  A box below the scroller changes only the scroller's clientHeight: the browser keeps scrollTop and fires no
+ *  scroll event, so a reader at the bottom is silently the box's height above it, and the next append reads
+ *  atBottom false and leaves them there. The rule is the OPPOSITE of the boxes-above compensation: the reader's
+ *  RECORDED follow mode (`stick`, still the pre-growth truth because nothing scrolled) decides — on, and any
+ *  height change, they are written to the new bottom (a shrink is a no-op write: the clamp is already there);
+ *  off, nothing moves — their top line never did. Pure, so node executes it. */
+export function followBoxBelow(stick: boolean, dh: number): boolean {
+  return stick && dh !== 0;
+}
+
 /** Follow-the-tail after an append, for a reader whose view is in follow mode (T262, the user 2026-09-08: "jumped
  *  up slightly on my scroll" in busy sessions). A tab within the old 80 px band used to be pinned to the bottom on
  *  EVERY frame the pane received — including a status-only tail that changed no content — so a reader wheeling

--- a/ui/webview/scroll-write.test.ts
+++ b/ui/webview/scroll-write.test.ts
@@ -32,13 +32,16 @@ test("a scroll event within a pixel of the last programmatic write is its echo; 
 });
 
 test("the row names the writer and carries before/after/delta/stick, gesture:false", () => {
-  assert.deepEqual(scrollWriteRow(SID, "append-stick", 100, 340, true),
-                   { sid: SID, writer: "append-stick", before: 100, after: 340, delta: 240, stick: true, gesture: false });
+  assert.deepEqual(scrollWriteRow(SID, "append-stick", 100, 340, true, 5000, 600),
+                   { sid: SID, writer: "append-stick", before: 100, after: 340, delta: 240, stick: true, gesture: false, sh: 5000, ch: 600 });
+  // T262e: every row carries #content's scrollHeight/clientHeight, so an UNWRITTEN move in the journal can be told
+  // apart: a clamp after the tail shrank (sh dropped, top == sh - ch) vs the browser's anchoring (sh unchanged)
+  assert.deepEqual(scrollWriteRow(SID, "land-saved", 0, 10, false), { sid: SID, writer: "land-saved", before: 0, after: 10, delta: 10, stick: false, gesture: false, sh: 0, ch: 0 });
 });
 
 test("render.ts: one helper writes #content.scrollTop, files the row only when the view moved, and no raw write remains", () => {
   assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow \} from "\.\/scroll-write";/);
-  assert.match(RENDER, /function writeScroll\(content: HTMLElement, top: number, writer: string, stick = false\): void \{\s*\n\s*const before = content\.scrollTop;\s*\n\s*content\.scrollTop = top;\s*\n\s*const after = content\.scrollTop;\s*\n\s*lastScrollWriteAfter = after;\s*\n\s*if \(after !== before\) scrollDiagRow\("scrollwrite", scrollWriteRow\(activeId \|\| "", writer, before, after, stick\)\);/);
+  assert.match(RENDER, /function writeScroll\(content: HTMLElement, top: number, writer: string, stick = false\): void \{\s*\n\s*const before = content\.scrollTop;\s*\n\s*content\.scrollTop = top;\s*\n\s*const after = content\.scrollTop;\s*\n\s*lastScrollWriteAfter = after;\s*\n\s*if \(after !== before\) scrollDiagRow\("scrollwrite", scrollWriteRow\(activeId \|\| "", writer, before, after, stick, content\.scrollHeight, content\.clientHeight\)\);/);
   // the breadcrumb rides the existing clientDiag path, capped, with one capped row at the cap
   assert.match(RENDER, /\{ type: "clientDiag", surface: "chat", what: kind \+ "-capped", data: \{ sid: activeId \|\| "", perMinute: 40 \} \}/);
   assert.match(RENDER, /\{ type: "clientDiag", surface: "chat", what: kind, data \}/);
@@ -52,5 +55,5 @@ test("render.ts: one helper writes #content.scrollTop, files the row only when t
   const raw = RENDER.split("\n").filter((l) => /\b(content|c)\.scrollTop (=|\+=|-=) /.test(l) && !/writeScroll|const |let /.test(l));
   assert.deepEqual(raw.map((l) => l.trim()), ["content.scrollTop = top;"], "the only assignment is the helper's own");
   // the gesture marker: a write's echo is consumed, anything else files a gesture row
-  assert.match(RENDER, /if \(classifyScroll\(c\.scrollTop, lastScrollWriteAfter\) === "write-echo"\) lastScrollWriteAfter = null;\s*\n\s*else scrollDiagRow\("scrollgesture", \{ sid: activeId \|\| "", top: c\.scrollTop, gesture: true \}\);/);
+  assert.match(RENDER, /if \(classifyScroll\(c\.scrollTop, lastScrollWriteAfter\) === "write-echo"\) lastScrollWriteAfter = null;\s*\n\s*else scrollDiagRow\("scrollgesture", \{ sid: activeId \|\| "", top: c\.scrollTop, gesture: true, sh: c\.scrollHeight, ch: c\.clientHeight \}\);/);
 });

--- a/ui/webview/scroll-write.ts
+++ b/ui/webview/scroll-write.ts
@@ -35,7 +35,12 @@ export function classifyScroll(scrollTop: number, lastWriteAfter: number | null)
   return lastWriteAfter != null && Math.abs(scrollTop - lastWriteAfter) <= 1 ? "write-echo" : "gesture";
 }
 
-/** The breadcrumb for one write that moved the view. */
-export function scrollWriteRow(sid: string, writer: string, before: number, after: number, stick: boolean) {
-  return { sid, writer, before, after, delta: after - before, stick, gesture: false as const };
+/** The breadcrumb for one write that moved the view. `sh`/`ch` = #content's scrollHeight/clientHeight after the
+ *  write (T262e, the user 2026-09-08: their laptop's rows showed the view moving UP by the same 95 px on two
+ *  sessions with no write between the rows — an UNWRITTEN move, which the rows could not classify: a browser
+ *  CLAMP after the transcript's tail shrank (scrollHeight drops, the new top equals scrollHeight − clientHeight)
+ *  reads exactly like the browser's scroll anchoring absorbing a layout change above the viewport (scrollHeight
+ *  unchanged). With both numbers on every row the next log tells them apart in one pass.) */
+export function scrollWriteRow(sid: string, writer: string, before: number, after: number, stick: boolean, sh = 0, ch = 0) {
+  return { sid, writer, before, after, delta: after - before, stick, gesture: false as const, sh, ch };
 }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -716,12 +716,12 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
    (overflow-y:auto alone makes overflow-x compute to auto, which allowed it) */
 /* overflow-y: scroll (not auto) so the chat scrollbar + its gutter are ALWAYS shown and never
    auto-hide on the side — and the content doesn't shift when it would appear (the user 2026-06-16). */
-/* overflow-anchor: none (T262e, the user 2026-09-08, still "jumped up" at times): the pane is the ONE compensator
-   for layout changes inside the transcript — rewindow, anchor-restore, keep-offset, the append's anchor keep all
-   write the scrollTop that keeps the line being read still. Chrome's own scroll anchoring did the same job on top
-   of them for the same change, and the breadcrumbs showed the pair: a rewindow write of -106 px followed by a
-   browser move of +190 px nobody's code asked for, every window slide. Two compensators for one change is a jump. */
-#content { flex: 1 1 auto; overflow-y: scroll; overflow-x: hidden; padding: 8px 0 12px; overflow-anchor: none; }
+/* The browser's scroll anchoring stays ON here (measured 2026-09-08, T262e): after a scroll that slides the
+   virtualization window, the pane's rewindow write keeps the focus unit still and Chrome's anchoring then absorbs
+   the LATER layout changes the pane does not compensate (spacer re-measures, late-sizing rows). With
+   overflow-anchor: none the visible line drifted 194-246 px after every such scroll on a headless run; with it on,
+   0 px on every row. Do not add overflow-anchor: none to #content. */
+#content { flex: 1 1 auto; overflow-y: scroll; overflow-x: hidden; padding: 8px 0 12px; }
 /* a clearly-visible always-on thumb for the chat pane (brighter than the faint global thumb) */
 #content::-webkit-scrollbar-track { background: rgba(255, 255, 255, 0.04); }
 #content::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.24); border-radius: 5px; min-height: 36px; }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -716,7 +716,12 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
    (overflow-y:auto alone makes overflow-x compute to auto, which allowed it) */
 /* overflow-y: scroll (not auto) so the chat scrollbar + its gutter are ALWAYS shown and never
    auto-hide on the side — and the content doesn't shift when it would appear (the user 2026-06-16). */
-#content { flex: 1 1 auto; overflow-y: scroll; overflow-x: hidden; padding: 8px 0 12px; }
+/* overflow-anchor: none (T262e, the user 2026-09-08, still "jumped up" at times): the pane is the ONE compensator
+   for layout changes inside the transcript — rewindow, anchor-restore, keep-offset, the append's anchor keep all
+   write the scrollTop that keeps the line being read still. Chrome's own scroll anchoring did the same job on top
+   of them for the same change, and the breadcrumbs showed the pair: a rewindow write of -106 px followed by a
+   browser move of +190 px nobody's code asked for, every window slide. Two compensators for one change is a jump. */
+#content { flex: 1 1 auto; overflow-y: scroll; overflow-x: hidden; padding: 8px 0 12px; overflow-anchor: none; }
 /* a clearly-visible always-on thumb for the chat pane (brighter than the faint global thumb) */
 #content::-webkit-scrollbar-track { background: rgba(255, 255, 255, 0.04); }
 #content::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.24); border-radius: 5px; min-height: 36px; }


### PR DESCRIPTION
## Summary
Two scroll items from the user (2026-09-08 11:30 AM PT, running the true-bottom build): (b) when the awaiting/background-task box appears between the transcript and the composer and covers part of the text, a reader at the bottom must stay at the bottom, which did not happen; (a) the view still jumps up at times.

## (b) A box below the transcript keeps an at-bottom reader at the bottom
A box below the scroller (`#bg-tasks`; also `#footer`, since the composer auto-grows while a message is typed) changes only `#content`'s clientHeight. The browser keeps scrollTop and fires no scroll event, so a reader at the bottom was silently the box's height above it with the last lines covered, and the next append read `atBottom` false and left them there: the pane fell into scrolled-up mode by itself. Nothing observed those boxes; only the boxes ABOVE (`#tabbar`, `#ledger`) had a ResizeObserver, with the opposite rule.

Fix: a ResizeObserver on `#bg-tasks` and `#footer`. The view's RECORDED follow mode (`stick`, still the pre-growth truth because nothing scrolled) decides (`followBoxBelow` in scroll-keep.ts): on, and any height change, the reader is written to the new bottom through the scroll-write helper (writer `box-below`); off, nothing moves, since their top line never did. Event-based, no timer.

## (a) The browser's scroll anchoring stays ON (measured; the opt-out was tried and reverted on this branch)
The pane's writers (`rewindow`, `anchor-restore`, `keep-offset`, the append's anchor keep) compensate the layout change they cause synchronously, so the browser's anchoring never double-compensates them; what the anchoring does absorb is the LATER layout changes nobody in the pane writes for (spacer re-measures, late-sizing rows). A scroll-then-settle measurement on both trees: after a programmatic scroll that slides the virtualization window, the visible line held at 0 px on every row with the anchoring on (upstream/main) and drifted 194, 246 and 246 px with `overflow-anchor: none`. The CSS comment records the measurement and `box-below.test.ts` pins that `overflow-anchor` is not set on `#content`.

## Breadcrumbs carry scrollHeight and clientHeight
The user's laptop rows showed the view moving up by one fixed amount (~95 px) on two sessions with no write between the rows: an UNWRITTEN move. With only `top` recorded, two mechanisms read identically: a browser clamp after the transcript's tail shrank (scrollHeight drops and the new top equals scrollHeight − clientHeight; a reader near the bottom is yanked up by the shrink) and the browser's anchoring absorbing a layout change above the viewport (scrollHeight unchanged). Every `scrollwrite` and `scrollgesture` row now carries both numbers, so the next log tells them apart in one pass. The cap hid nothing: 154 writes in ~100 minutes, none capped (gestures capped once during a wheel burst), so the per-kind cap stays as it is.

## Scroll-writer review against "jumped up" (delta < 0 while off the bottom), on the true-bottom tree
| writer | can move an off-bottom reader up? | verdict |
|---|---|---|
| `rewindow`, `anchor-restore`, `keep-offset` | yes: they write "same line, new layout" compensation, positive or negative | correct alone; doubled by the browser's anchoring until this PR |
| `box-resize` (boxes above shrink) | yes, by the shrink | correct: the scroller itself moved, the browser does not anchor for that |
| `land-saved` | yes, if the saved spot is above | the saved spot follows the reader since the earlier scroll fix; a land is a show, not a push |
| `append-raw` | writes the pre-rebuild value | visually zero |
| `toolgroup-toggle`, `nav-history` | yes | the reader asked for it (a fold, a history jump) |
| `optimistic-send`, `land-bottom`, `append-stick`, `jump-button`, `tabbar-drag`, `liveask-reveal`, `focus-live` | no: bottom writes | not suspects |

Under the box-below scenario no writer fires at all on the true-bottom tree, and the browser does not anchor for a change outside the scroller: the reader is left the box's height above the bottom, which is (b), not a jump. The jumps come from in-scroller layout changes compensated twice, which is (a).

## Evidence (two-kernel hermetic harness, awaiting-box variant: the box is open and changes height on every watch add/cancel)
Reader at the bottom of a working session (pass A), 90 s of traffic: watch adds/cancels (12 box height changes), a queued-then-landed notice, a streamed reply.

| tree | worst distance from bottom | violating samples (50 ms) | violation runs | coincident with |
|---|---|---|---|---|
| upstream/main (76f325d0, the true-bottom build) | 1373 px | 3316 | 26 | the box's height changes; then every append while the reader was left off the bottom |
| this branch | 29 px | 1 | 1 | one sample between the box's layout change and the observer's write in the same frame (never painted) |

Reader scrolled to mid-history (pass B): anchor turn offset unchanged, scrollTop unchanged, on both trees (12 box height changes each).



## Tests
- New `ui/webview/box-below.test.ts`: executes the rule (a follow-mode reader follows growth and shrink; a scrolled-up reader is untouched) and pins the observer on both boxes, the `box-below` writer, the recorded follow mode as the input, the boxes-above rule unchanged, and that `overflow-anchor` is NOT set on `#content` (the measured result).
- `ui/webview/scroll-write.test.ts`: the rows' new scrollHeight/clientHeight fields, executed and pinned.
- The scroll-keep import pins in follow-tail and scroll-keep-on-show moved with the import.
- `npm test`: 3446 pass, 0 fail, 4 skipped; `npm run typecheck` clean. No Python changes.

Also ready for the user's laptop rows: a reader for the scroll breadcrumbs (client-diag `scrollwrite`/`scrollgesture` rows) that prints per-writer counts and total delta and the sequence around every gesture, kept outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
