### PR TITLE
T252d: a mid-turn send is shown where the model read it — atom at its landing time, bubble at the tail

### DIFF
--- a/docs/goal-state.md
+++ b/docs/goal-state.md
@@ -168,7 +168,7 @@ within a beat it reverts with a toast, never silently.
    only the new stretch (`deltaSince`).
 7. Identity: identical prompts in different turns are different work
    (twins); same-second identical bursts plan once; any seg-id-derivation
-   change ships a placements migration (`placementsV`, currently v2);
+   change ships a placements migration (`placementsV`, currently v12);
    `tests/test_placements_canary.py` pins the derivation.
 8. The auto-nudge fires once per genuine stall, never re-arms off romp's
    own turns, is suppressed while interrupted, and its failure becomes a

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -235,12 +235,19 @@ events, read from the events after the send (a landing of the text, the kernel's
 never-delivered verdict, or the user's ✕), and a record the CLI wrote from several
 back-to-back sends retires one bubble per text block (`blocks` on the user event).
 While the socket is down the bubble is labelled "not confirmed", until a kernel
-copy of the send clears the label. A send that landed mid-turn (`absorbed` and
-`landedAt` on the user chat event) is placed at its send time, and the chat's
-pending bubble is drawn at that same slot from the press — right after the last
-kernel event at the press, below an earlier send's echo or landing and below any
-texts the kernel already held queued — so the landing replaces it in place; there
-is no header and no cue (T252). The CLI extracts
+copy of the send clears the label. A send that landed mid-turn (`absorbed` on the
+user chat event) is placed where the model READ it: at its landing time, the
+moment the CLI took it off its queue, below the steps that ran while it waited
+(T252d, the user 2026-09-08). Their reasoning: the pane used to draw the message
+at its send position, above those steps, while the model read it only after them,
+so the order on screen contradicted the order the model saw; the read position is
+the one that matches. So the chat's pending bubble sits at the TAIL while pending,
+below every streaming step, and the landed atom appears in that same tail
+position, so nothing moves on landing; the send time rides along as `sentAt` for
+the bubble's hover ("sent at HH:MM", shown once landed when it differs from the
+landing by more than a minute). No header, no cue. This supersedes the
+in-place-at-send-position rule of T252/T252b; the kernel's per-copy identities
+(T252c) stay and decide landing, cover and hiding. The CLI extracts
 no image paths on the stream-json route (its only image-path test belongs to the
 interactive composer's paste handler), so an image path in an SDK send lands as
 typed and the echo's text matches. `_path_bearing` and the extension set it tests

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -1547,23 +1547,43 @@ class FileAdapter:
                               if v in ("broken", "eclipsed")}
 
     def _absorbed_atom(self, full, t, seq, auid, rompuuid, postal_index):
-        """One synthesized user atom for a mid-turn splice. The atom carries the FULL text — any
-        whitespace-collapsed form is for MATCHING only (the user 2026-07-08: collapsing ate the blank
-        line between a follow-up's quoted context and the typed reply, so markdown folded the reply
-        INTO the blockquote; and the kernel's optimistic echo could never text-prune against the
-        collapsed copy, so the message rendered TWICE)."""
+        """One synthesized user atom for a mid-turn splice, placed where the model READ it (T252d, the
+        user 2026-09-08): its `t` is the LANDING time — the moment the CLI took the message off its
+        queue, the file-order predecessor's stamp (_landing_t) — so the atom sits BELOW the steps that
+        ran while the message waited, and the order on screen is the order the model saw. The SEND time
+        stays on the atom as `sentAt` (the chat's bubble hover). Ordering rule: atoms sort by (t, _seq)
+        (parse_session), and the attachment's FILE ORDER is the authority — the atom sorts after every
+        record the CLI wrote before taking it (the witness's stamp, and a higher seq than the witness)
+        and before the assistant record that answers it (written after the attachment, stamped no
+        earlier); several sends the CLI took at one boundary share that boundary's stamp and keep
+        their send order, which is their file order. A send the CLI took AFTER a witness stamped
+        before the send clamps to the send time (no truthful landing precedes it); an attachment with
+        no predecessor in the read keeps its send time as the only truthful place. Before T252d the
+        atom sat at its send time, above those steps (the T252 in-place rule); the user's call was
+        that the read position is the one that matches what the model actually saw.
+
+        DEPLOY RULE: `t` is half of the segment id (fsid:t:texthash), so moving it changed placement
+        identity for every absorbed atom whose landing differs from its send — PLACEMENTS_V 12 (the
+        seal keeps dormant sessions from replaying the moved atoms as new goals);
+        tests/test_placements_canary.py pins the new derivation.
+
+        The atom carries the FULL text — any whitespace-collapsed form is for MATCHING only (the user
+        2026-07-08: collapsing ate the blank line between a follow-up's quoted context and the typed
+        reply, so markdown folded the reply INTO the blockquote; and the kernel's optimistic echo could
+        never text-prune against the collapsed copy, so the message rendered TWICE)."""
         blocks = [{"type": "text", "text": full}]
         atom = {
             "type": "user", "uuid": auid, "session_id": rompuuid,
-            "t": t, "fsid": self.fsid_of.get(auid),
+            "t": t, "sentAt": t, "fsid": self.fsid_of.get(auid),
             "parentUuid": (self.by_uuid.get(auid) or {}).get("parentUuid"),
             "message": {"role": "user", "content": blocks},
             "author": author_of(blocks, None, postal_index, getattr(self, "sdk_human", False)),
-            "absorbed": True,   # a mid-turn splice: the turn's FOLLOWING atoms are the interrupted
-            #                     ask's continuing work, not provably a reply to this — judges must
-            #                     not read them as one (jd._seg_spliced / _strip_unevidenced_dones).
-            #                     Metadata only: the atom set and seg ids are unchanged (no
-            #                     PLACEMENTS_V bump).
+            "absorbed": True,   # a mid-turn splice, placed where the model read it (T252d): the
+            #                     atoms that FOLLOW it are the model's work after reading it — its
+            #                     reply, as for any ask. (Until T252d the atom sat at its SEND time and
+            #                     the following atoms were the interrupted turn's work, which the judges
+            #                     had to refuse as evidence; that leg is gone with the placement.) The
+            #                     flag still tells the chat and the judges how the message arrived.
             "_seq": seq,
         }
         landed_t = self._landing_t(seq)
@@ -1581,7 +1601,7 @@ class FileAdapter:
                 # synthetic shape with no tool_result before the attachment.)
                 _ASM_STATS["landedT-clamp"] = _ASM_STATS.get("landedT-clamp", 0) + 1
                 landed_t = t
-            atom["landedT"] = landed_t   # when the CLI TOOK it (metadata, like `absorbed`; see _landing_t)
+            atom["t"] = landed_t         # placed where the model READ it (T252d); `sentAt` keeps the send
         if ROMP_AUTO_RE.search(full):   # an AUTO-nudge → flag it, mirroring the native user-record path
             atom["rompAuto"] = True
         return atom
@@ -1589,18 +1609,17 @@ class FileAdapter:
     def _landing_t(self, seq):
         """When the CLI TOOK a mid-turn prompt: the repaired stamp of the record written just BEFORE
         the queued_command attachment in file order. The attachment's own stamp is the ENQUEUE time
-        (the moment the user sent it — where the atom is placed, above the steps that ran while it
-        waited), but the CLI writes the record at the splice, right after the tool boundary it waited
-        for, so that boundary's own record — the file-order predecessor — is the landing moment to
-        within the boundary's latency. The chat's mid-turn cue reads it (kernel `landedAt`): "the
-        session took this at HH:MM" is a different fact from "sent at HH:MM", and the rail already
-        shows the latter. The PREDECESSOR, not the successor, on purpose: it is always ingested when
+        (the moment the user sent it — kept on the atom as `sentAt`), but the CLI writes the record at
+        the splice, right after the tool boundary it waited for, so that boundary's own record — the
+        file-order predecessor — is the landing moment to within the boundary's latency, and since
+        T252d it is where the atom is PLACED (its `t`): below the steps that ran while the message
+        waited, where the model read it. The PREDECESSOR, not the successor, on purpose: it is always ingested when
         the atom is emitted, so a fold that sees the attachment as the newest record still stamps
         it — a successor read would find nothing there, and no later fold re-emits the atom (the
         (ts, text) dedup). Attachment records are skipped as witnesses (a run of splices at one
         boundary all read that boundary). None only when nothing precedes the attachment in the
         read. The caller clamps the result to the atom's own send time (never earlier — see
-        _absorbed_atom). Metadata only: no atom-set or seg-id change, no PLACEMENTS_V bump."""
+        _absorbed_atom). Placement, not metadata, since T252d: it is half of the atom's segment id."""
         i = bisect.bisect_left(self._seq_ts, (seq,)) - 1
         return self._seq_ts[i][1] if i >= 0 else None
 
@@ -1610,7 +1629,8 @@ class FileAdapter:
         carrying the FULL prompt text and stamped with the ENQUEUE timestamp — and writes
         NONE for a dequeued prompt (that resurfaces as a native user line), a still-pending
         one, or a popAll (a recall: the queue is cleared, nothing spliced). So each
-        attachment becomes one user atom, at its own timestamp: the moment the user sent it.
+        attachment becomes one user atom, placed at its LANDING time (_absorbed_atom, T252d) with
+        the send time beside it; the (send ts, text) pair stays the dedup key below.
 
         The queue-operation ledger is deliberately NOT read at all: its dequeue/remove
         records are anonymous, and a CLI killed with items queued never writes their
@@ -2605,7 +2625,8 @@ def _asm_heal(entry, rompuuid, postal_index):
         for i, a in enumerate(entry["atoms"]):
             if not a.get("absorbed"):
                 continue
-            key = (a["t"], " ".join(_text_of(_content(a.get("message"))).split()))
+            key = (a.get("sentAt", a["t"]), " ".join(_text_of(_content(a.get("message"))).split()))   # the (send ts, text)
+            #                                                                                          key: `t` is the landing (T252d)
             if key not in st["postal_miss_att"]:
                 continue
             q = next((q for q in ad.qatts if q["ts"] == key[0]

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -422,7 +422,12 @@ JUDGE_FAIL_CAP = 3                       # the same rule for every other retryin
 #                                          consolidator / courier; the
 #                                          planner (PLAN_PARSE_RETRIES) and distiller/briefer (DISTILL_FAIL_CAP)
 #                                          already had their own.
-PLACEMENTS_V = 11                        # placements-identity schema version (plan P2, the user 2026-07-06).
+PLACEMENTS_V = 12                        # placements-identity schema version (plan P2, the user 2026-07-06).
+#                                          v12 (2026-09-08, T252d): an ABSORBED atom (a mid-turn send the CLI
+#                                          spliced in) is placed at its LANDING time, not its send time, so
+#                                          every absorbed segment whose landing differs from its send changes
+#                                          its id's t. Same seal: dormant sessions must not replay the moved
+#                                          atoms as new goals.
 #                                          v2 (2026-07-09): a 07-07/07-08 change to segment-text derivation
 #                                          stepped the text hash without this bump — dormant segments' old-hash
 #                                          placements stopped matching, and every restart/touch replayed them as
@@ -2530,7 +2535,8 @@ def tasks_for(fsid, leaf, files, now):
     cf = PCACHE / (fsid + ".json")
     try:
         o = json.loads(cf.read_text())
-        if o.get("key") == key and o.get("v") == 5:    # v5 = absorbed SDK-injection atoms carry real text (2026-07-06); older caches regenerate
+        if o.get("key") == key and o.get("v") == 6:    # v6 = absorbed atoms placed at their landing time, so their seg ids moved (T252d, 2026-09-08);
+            #                                             v5 = absorbed SDK-injection atoms carry real text (2026-07-06); older caches regenerate
             return o["tasks"]
     except Exception:
         pass
@@ -2549,7 +2555,7 @@ def tasks_for(fsid, leaf, files, now):
     try:
         PCACHE.mkdir(parents=True, exist_ok=True)
         tmp = cf.with_suffix(".tmp.%d" % os.getpid())
-        tmp.write_text(json.dumps({"key": key, "v": 5, "tasks": tasks}))
+        tmp.write_text(json.dumps({"key": key, "v": 6, "tasks": tasks}))
         tmp.rename(cf)
     except Exception:
         pass
@@ -5442,47 +5448,32 @@ def _strip_top_mints(ops):
     return out
 
 
-def _seg_spliced(seg):
-    """True when this segment's TRIGGER is an ABSORBED atom — a prompt the CLI spliced into a
-    RUNNING turn (a queued_command attachment; em._absorbed_atom marks the synthesized atom
-    `absorbed`). The atoms after such a trigger are the interrupted turn's CONTINUING work: by
-    wall-clock they follow the enqueue, but they answer the turn's ORIGINAL ask — deterministically
-    indistinguishable from a reply to the splice. So work in this segment is never proof that the
-    spliced ask, or any listed goal, was answered (see _strip_unevidenced_dones)."""
-    trig = (seg or {}).get("trigger")
-    if not trig:
-        return False
-    return any(a.get("uuid") == trig and a.get("absorbed") for a in seg.get("atoms") or [])
-
-
 def _strip_unevidenced_dones(ops, seg, fsid, seg_id):
-    """Drop planner DONE ops a segment cannot EVIDENCE — two shapes of one rule (a done needs the
-    reply's own post-ask work as proof):
-      - SPLICED trigger (_seg_spliced): a capable planner, handed 'USER ASKED: …' plus the
-        interrupted turn's unrelated tail work, answers the question from its OWN knowledge and
-        files done with a confabulated summary — a queued question completed as a card 30 seconds
-        after it was typed, before the assistant's first post-splice token, off a turn that then
-        crashed without ever replying (the user 2026-07-29).
-      - WORKLESS segment (no assistant work at all): the workless FOLLOW-UP unit (the user
-        2026-08-08, the beacon g10 card) judges the user's reply so the msg-reopen latch gets its
-        verdict — the reply is real evidence of the user's INTENT (pivot / continuation / block),
-        never of completion. Same failure family as the API-error confabulation (the user
-        2026-07-25), whose mint-only prompt-run op filter already enforces this for plain asks.
-    Mint/sub/block still apply — placing the ask and filing the work are right — and the goal stays
-    OPEN, which is the truth; the turn-level closer keeps done authority once the turn actually
-    ends. Logged (judge-errors, kinds 'spliced-done' / 'workless-done'), never silent."""
+    """Drop planner DONE ops a segment cannot EVIDENCE (a done needs the reply's own post-ask work as
+    proof): a WORKLESS segment (no assistant work at all). The workless FOLLOW-UP unit (the user
+    2026-08-08, the beacon g10 card) judges the user's reply so the msg-reopen latch gets its verdict —
+    the reply is real evidence of the user's INTENT (pivot / continuation / block), never of
+    completion. Same failure family as the API-error confabulation (the user 2026-07-25), whose
+    mint-only prompt-run op filter already enforces this for plain asks.
+
+    Until T252d (2026-09-08) a second leg refused dones off a SPLICED trigger — an absorbed mid-turn
+    send sat at its SEND time, so its segment held the interrupted turn's continuing work, never
+    provably a reply (the user 2026-07-29: a queued question completed as a card 30 seconds after it
+    was typed, off a turn that crashed without ever replying). The absorbed atom now sits where the
+    model READ it, so the atoms after it ARE its reply, like any ask's; and the 2026-07-29 shape — the
+    turn dying before its first post-splice token — is exactly a workless segment, which this leg
+    still refuses. Mint/sub/block still apply — placing the ask and filing the work are right — and
+    the goal stays OPEN, which is the truth; the turn-level closer keeps done authority once the
+    turn actually ends. Logged (judge-errors, kind 'workless-done'), never silent."""
     if not ops:
         return ops
-    spliced = _seg_spliced(seg)
-    workless = not _has_asst_work((seg or {}).get("atoms") or [])
-    if not (spliced or workless):
+    if _has_asst_work((seg or {}).get("atoms") or []):
         return ops
     kept = [o for o in ops if o.get("do") != "done"]
     if len(kept) != len(ops):
-        kind, shape = (("spliced-done", "spliced-trigger") if spliced else ("workless-done", "workless"))
-        _log_judge_error("planner", fsid, kind, seg=seg_id,
-                         note="dropped %d done op(s): a %s segment cannot evidence an answer"
-                              % (len(ops) - len(kept), shape))
+        _log_judge_error("planner", fsid, "workless-done", seg=seg_id,
+                         note="dropped %d done op(s): a workless segment cannot evidence an answer"
+                              % (len(ops) - len(kept)))
     return kept
 
 
@@ -9034,9 +9025,9 @@ def _plan_session(fsid, path, now):
             hist = _goal_work_text(store, seg_by_id, target, GOAL_HISTORY_CHARS)
             ops = _parse_plan(plan_llm(text, _menu_text(store, sub), human=False,
                                        goal_history=hist, goal_num=1), len(sub)) or []
-            ops = _strip_unevidenced_dones(ops, seg_by_id.get(seg_id), fsid, seg_id)   # a peer message spliced
-            #                                           mid-turn can't evidence an answer any more than a
-            #                                           spliced human ask can — the fallback sub still files
+            ops = _strip_unevidenced_dones(ops, seg_by_id.get(seg_id), fsid, seg_id)   # a peer message whose
+            #                                           segment holds no assistant work can't evidence an
+            #                                           answer — the fallback sub still files
             # Full expressivity, ROOTED under G: a delegation gets the same sub/done/block a human-minted top
             # does (over G's subtree), and a top-level MINT is re-rooted as a sub under G (#1) so a handoff is
             # never a competing top. Skips drop; an empty/skip-only reply falls back to one sub under G.
@@ -9124,9 +9115,9 @@ def _plan_session(fsid, path, now):
                 ops = [{"do": "sub", "under": 1, "text": o.get("text"), "why": o.get("why")}
                        if o["do"] == "mint" else o for o in ops if o["do"] != "skip"]
                 ops = _restrict_retitle(ops, 1)          # goal_num=1 above → retitle is only valid on #1
-                ops = _strip_unevidenced_dones(ops, _tseg, fsid, seg_id)   # a nudge spliced mid-turn reads the
-                #                                           interrupted turn's work as its reply — resolve
-                #                                           nothing; the goal stays open and re-nudgeable
+                ops = _strip_unevidenced_dones(ops, _tseg, fsid, seg_id)   # a nudge no work followed can't be
+                #                                           resolved off nothing — the goal stays open
+                #                                           and re-nudgeable
                 if apply_plan_guarded(fsid, path, store, seg_id, seg_t, ops, sub,
                                       place_key=_pkey, prompt_uuid=trig, quote=vq):
                     placed += 1
@@ -9161,8 +9152,8 @@ def _plan_session(fsid, path, now):
                                            goal_history=hist, goal_num=gi, followup=True,
                                            lifted_blocks=[(i, a) for i, (_n, a) in sorted(lifted_by_num.items())] or None),
                                   len(menu)) or []
-                ops = _strip_unevidenced_dones(ops, seg_by_id.get(seg_id), fsid, seg_id)   # a card reply spliced
-                #                                           mid-turn: strip BEFORE the pivot apply and before
+                ops = _strip_unevidenced_dones(ops, seg_by_id.get(seg_id), fsid, seg_id)   # a card reply no work
+                #                                           followed: strip BEFORE the pivot apply and before
                 #                                           the continuation lifts `res`, so a confabulated
                 #                                           done never re-completes the reopened target
                 if any(o["do"] == "mint" for o in ops):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -29069,16 +29069,15 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
                                     ev["qid"] = _qs[0]
                             if a.get("absorbed"):
                                 # A mid-turn splice (event_model._absorbed): the CLI queued this send
-                                # behind the running turn and took it at a later tool boundary, so the
-                                # atom sits at its SEND time, above the steps that ran while it waited.
-                                # The client marks it ("joined mid-turn") and, when the landing retires
-                                # a pending bubble that sat at the tail, leaves a cue where the bubble
-                                # was — the user 2026-09-05 watched a message vanish from the bottom
-                                # and reappear higher up with no explanation. `landedAt`: when the CLI
-                                # took it (the attachment's file-order predecessor; `ts` is the send).
+                                # behind the running turn and took it at a later tool boundary. The
+                                # atom sits at its LANDING time (`ts`), below the steps that ran while
+                                # it waited — where the model read it (T252d, the user 2026-09-08), and
+                                # where the chat's pending bubble already was (the tail), so nothing
+                                # moves when it lands. `sentAt`: when the user sent it, for the
+                                # bubble's hover when the two differ by more than a minute.
                                 ev["absorbed"] = True
-                                if a.get("landedT"):
-                                    ev["landedAt"] = int(a["landedT"])
+                                if a.get("sentAt"):
+                                    ev["sentAt"] = int(a["sentAt"])
                             # Several back-to-back sends the CLI took together land as ONE user record
                             # with a text block each — the shape _atom_user_texts prunes the kernel's
                             # echoes against. The chat's own pending bubbles end on an EXACT text match

--- a/tests/fixtures/event-model-golden/multi_input_absorbed.json
+++ b/tests/fixtures/event-model-golden/multi_input_absorbed.json
@@ -55,26 +55,6 @@
      "uuid": "a1"
     },
     {
-     "absorbed": true,
-     "author": "human",
-     "fsid": "11111111-2222-3333-4444-555555555555",
-     "landedT": 1781096455,
-     "message": {
-      "content": [
-       {
-        "text": "also rename the digest file",
-        "type": "text"
-       }
-      ],
-      "role": "user"
-     },
-     "parentUuid": "tr1",
-     "session_id": "11111111-2222-3333-4444-555555555555",
-     "t": 1781096440,
-     "type": "user",
-     "uuid": "att1"
-    },
-    {
      "fsid": "11111111-2222-3333-4444-555555555555",
      "message": {
       "content": [
@@ -91,6 +71,26 @@
      "t": 1781096455,
      "type": "user",
      "uuid": "tr1"
+    },
+    {
+     "absorbed": true,
+     "author": "human",
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "also rename the digest file",
+        "type": "text"
+       }
+      ],
+      "role": "user"
+     },
+     "parentUuid": "tr1",
+     "sentAt": 1781096440,
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096455,
+     "type": "user",
+     "uuid": "att1"
     },
     {
      "fsid": "11111111-2222-3333-4444-555555555555",

--- a/tests/fixtures/event-model-golden/popall.json
+++ b/tests/fixtures/event-model-golden/popall.json
@@ -55,46 +55,6 @@
      "uuid": "a1"
     },
     {
-     "absorbed": true,
-     "author": "human",
-     "fsid": "11111111-2222-3333-4444-555555555555",
-     "landedT": 1781096450,
-     "message": {
-      "content": [
-       {
-        "text": "first queued note",
-        "type": "text"
-       }
-      ],
-      "role": "user"
-     },
-     "parentUuid": "tr1",
-     "session_id": "11111111-2222-3333-4444-555555555555",
-     "t": 1781096430,
-     "type": "user",
-     "uuid": "att1"
-    },
-    {
-     "absorbed": true,
-     "author": "human",
-     "fsid": "11111111-2222-3333-4444-555555555555",
-     "landedT": 1781096450,
-     "message": {
-      "content": [
-       {
-        "text": "second queued note",
-        "type": "text"
-       }
-      ],
-      "role": "user"
-     },
-     "parentUuid": "att1",
-     "session_id": "11111111-2222-3333-4444-555555555555",
-     "t": 1781096440,
-     "type": "user",
-     "uuid": "att2"
-    },
-    {
      "fsid": "11111111-2222-3333-4444-555555555555",
      "message": {
       "content": [
@@ -111,6 +71,46 @@
      "t": 1781096450,
      "type": "user",
      "uuid": "tr1"
+    },
+    {
+     "absorbed": true,
+     "author": "human",
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "first queued note",
+        "type": "text"
+       }
+      ],
+      "role": "user"
+     },
+     "parentUuid": "tr1",
+     "sentAt": 1781096430,
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096450,
+     "type": "user",
+     "uuid": "att1"
+    },
+    {
+     "absorbed": true,
+     "author": "human",
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "text": "second queued note",
+        "type": "text"
+       }
+      ],
+      "role": "user"
+     },
+     "parentUuid": "att1",
+     "sentAt": 1781096440,
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096450,
+     "type": "user",
+     "uuid": "att2"
     },
     {
      "fsid": "11111111-2222-3333-4444-555555555555",

--- a/tests/test_event_model_golden.py
+++ b/tests/test_event_model_golden.py
@@ -1897,14 +1897,16 @@ class PopAll(unittest.TestCase):
 
 
 class AbsorbedLandingNeverPrecedesTheSend(unittest.TestCase):
-    """`landedT` — when the CLI took a mid-turn send — is read off the attachment's file-order
-    predecessor, whose stamp can precede the attachment's own (the ENQUEUE time) only by clock
-    granularity: the live corpus's worst case is -0.2 s, which whole-second stamps can turn into a 1 s
-    inversion. No truthful landing precedes the send, so the event model clamps landedT to the send
-    and counts the clamp in parse stats (`landedT-clamp`): the chat's cue can never read "delivered at"
-    a time before the bubble's own send. Pinned across every golden, because the two goldens that carry
-    absorbed atoms once pinned the inverted value (2026-09-06 review) from a scenario shape with no
-    tool_result before the attachment."""
+    """An absorbed atom's `t` is its LANDING — when the CLI took the mid-turn send, read off the
+    attachment's file-order predecessor — and `sentAt` is the send (T252d, 2026-09-08: placed where the
+    model read it, below the steps that ran while it waited). The predecessor's stamp can precede the
+    attachment's own (the ENQUEUE time) only by clock granularity: the live corpus's worst case is
+    -0.2 s, which whole-second stamps can turn into a 1 s inversion. No truthful landing precedes the
+    send, so the event model clamps the placement to the send and counts the clamp in parse stats
+    (`landedT-clamp`): the atom never sits before its own send. Pinned across every golden, because the
+    two goldens that carry absorbed atoms once pinned the inverted value (2026-09-06 review) from a
+    scenario shape with no tool_result before the attachment. The ORDER is pinned too: the atom sorts
+    after the record the CLI wrote before taking it and before the assistant record that answers it."""
 
     def _absorbed(self, out):
         return [a for t in out["turns"] for a in t["atoms"] if a.get("absorbed")]
@@ -1914,16 +1916,21 @@ class AbsorbedLandingNeverPrecedesTheSend(unittest.TestCase):
         for name in ALL_SCENARIOS:
             for a in self._absorbed(run_scenario(name)):
                 seen += 1
-                self.assertGreaterEqual(a["landedT"], a["t"], (name, a["uuid"]))
+                self.assertGreaterEqual(a["t"], a["sentAt"], (name, a["uuid"]))
         self.assertGreaterEqual(seen, 3, "multi_input_absorbed and popall carry the absorbed atoms this pins")
 
     def test_the_realistic_shape_lands_at_the_boundary_after_the_send(self):
-        a = self._absorbed(run_scenario("multi_input_absorbed"))
-        self.assertEqual([(x["t"], x["landedT"]) for x in a], [(T0 + 40, T0 + 55)],
-                         "placed at the enqueue, taken at the tool_result that followed it in file order")
-        a = self._absorbed(run_scenario("popall"))
-        self.assertEqual([(x["t"], x["landedT"]) for x in a], [(T0 + 30, T0 + 50), (T0 + 40, T0 + 50)],
-                         "two splices at one boundary both read that boundary")
+        out = run_scenario("multi_input_absorbed")
+        a = self._absorbed(out)
+        self.assertEqual([(x["sentAt"], x["t"]) for x in a], [(T0 + 40, T0 + 55)],
+                         "sent at the enqueue, placed at the tool_result that followed it in file order")
+        order = [x["uuid"] for t in out["turns"] for x in t["atoms"]]
+        self.assertLess(order.index("tr1"), order.index("att1"), "after the record the CLI wrote before taking it")
+        self.assertLess(order.index("att1"), order.index("a2"), "before the assistant record that answers it")
+        out = run_scenario("popall")
+        a = self._absorbed(out)
+        self.assertEqual([(x["uuid"], x["sentAt"], x["t"]) for x in a], [("att1", T0 + 30, T0 + 50), ("att2", T0 + 40, T0 + 50)],
+                         "two splices at one boundary both sit at that boundary, in send order")
 
     def test_an_inverted_witness_clamps_to_the_send_and_is_counted(self):
         # the tool_result stamped before the attachment's enqueue stamp: clock granularity at worst, an
@@ -1935,7 +1942,7 @@ class AbsorbedLandingNeverPrecedesTheSend(unittest.TestCase):
                 aline(T0 + 90, "Done.", "a2", "att1", stop="end_turn")]
         before = em._ASM_STATS.get("landedT-clamp", 0)
         a = self._absorbed(run_recs(recs))
-        self.assertEqual([(x["t"], x["landedT"]) for x in a], [(T0 + 40, T0 + 40)])
+        self.assertEqual([(x["sentAt"], x["t"]) for x in a], [(T0 + 40, T0 + 40)])
         self.assertEqual(em._ASM_STATS.get("landedT-clamp", 0), before + 1,
                          "counted in parse stats, beside ts-repair — a run of these is a CLI write-order change")
 
@@ -1947,7 +1954,7 @@ class AbsorbedLandingNeverPrecedesTheSend(unittest.TestCase):
                 aline(T0 + 90, "Done.", "a2", "att1", stop="end_turn")]
         before = em._ASM_STATS.get("landedT-clamp", 0)
         a = self._absorbed(run_recs(recs))
-        self.assertEqual([(x["t"], x["landedT"]) for x in a], [(T0 + 40, T0 + 40)])
+        self.assertEqual([(x["sentAt"], x["t"]) for x in a], [(T0 + 40, T0 + 40)])
         self.assertEqual(em._ASM_STATS.get("landedT-clamp", 0), before, "equal stamps are a landing, not an inversion")
 
 

--- a/tests/test_judge_spliced_done.py
+++ b/tests/test_judge_spliced_done.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
-"""A prompt QUEUED into a running turn must never complete off that turn's unrelated work (the user 2026-07-29).
+"""A prompt QUEUED into a running turn completes off the work that FOLLOWS it, and never off nothing.
 
-The incident: the user queued a question while the session was mid-turn on other work; the CLI
-spliced it in (a queued_command attachment, stamped with its ENQUEUE time), and the process died
-before any reply. The splice's segment absorbed the running turn's CONTINUING atoms — real assistant
-work, none of it a reply to the spliced ask — so the no-work guard from the API-error fix
-(_has_asst_work, the user 2026-07-25) passed, plan_units emitted a full work unit framed
-"USER ASKED: … ASSISTANT SAID: [other work]", and a capable planner answered the question from its
-own knowledge and filed done with a confabulated summary — 30 seconds after the ask was typed,
-before the assistant's first post-splice token. Now the event model marks the synthesized splice
-atom `absorbed`, and planner DONE ops filed off a spliced-trigger segment are stripped
-(_strip_unevidenced_dones, spliced leg): work in such a segment is never proof the spliced ask — or any listed goal —
-was answered. Mint/sub still apply (the ask gets its card, the tail work files), the goal stays
-open — the truth — and the turn-level closer keeps done authority. SYNTHETIC fixtures only."""
+The 2026-07-29 incident: the user queued a question while the session was mid-turn on other work; the
+CLI spliced it in (a queued_command attachment, stamped with its ENQUEUE time), and the process died
+before any reply. With the atom placed at its SEND time (the rule until T252d) the splice's segment
+absorbed the running turn's CONTINUING atoms — real assistant work, none of it a reply — and a
+done-happy planner completed the question from its own knowledge. A spliced leg of
+_strip_unevidenced_dones refused every done off such a segment.
+
+T252d (the user 2026-09-08) places the absorbed atom where the model READ it — at its landing time,
+below the steps that ran while it waited — so the atoms after it are the model's work after reading
+it: its reply, as for any ask. The spliced leg is gone with the placement, and the incident's shape
+(a turn that dies before its first post-splice token) is a WORKLESS segment, which the remaining leg
+still refuses. Mint/sub still apply, and the turn-level closer keeps done authority. SYNTHETIC
+fixtures only."""
 import json
 import tempfile
 import unittest
@@ -52,7 +53,8 @@ def aline(t, text, uuid, parent=None, stop="end_turn"):
 
 def qline(t, text, uuid, parent):
     """The CLI's mid-turn splice witness: a queued_command attachment, uuid-bearing, parent-chained,
-    stamped with the ENQUEUE time (earlier than its neighbours in file order — the real shape)."""
+    stamped with the ENQUEUE time (earlier than its neighbours in file order — the real shape). The
+    event model places its atom at the file-order predecessor's stamp, clamped never before the send."""
     return {"type": "attachment", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
             "attachment": {"type": "queued_command", "prompt": text}}
 
@@ -63,15 +65,26 @@ SKIP = '{"ops":[{"why":"nothing to file","do":"skip"}]}'
 
 
 def spliced_records():
-    """An in-flight labeling turn; the ask spliced into it at enqueue time; the turn's work
-    CONTINUES (chained through the attachment, as the CLI writes it) and never answers the ask;
-    a later unrelated turn ends things."""
+    """An in-flight labeling turn; the ask spliced into it; the model's work after reading it
+    (chained through the attachment, as the CLI writes it); a later unrelated turn ends things."""
     return [
         uline(T0, "Label the notes-api fixture batch", "u1"),
         aline(T0 + 10, "Working through the batch now.", "a1", "u1"),
         qline(T0 + 30, ASK, "q1", "a1"),
         aline(T0 + 60, "Sheet seven labeled; two to go.", "a2", "q1"),
         uline(T0 + 400, "unrelated: also bump the version", "u2", "a2"),
+        aline(T0 + 410, "Bumped.", "a3", "u2"),
+    ]
+
+
+def dead_splice_records():
+    """The 2026-07-29 shape: the ask spliced in, and the process dies before its first post-splice
+    token; a later unrelated turn ends things. The splice's segment holds no assistant work."""
+    return [
+        uline(T0, "Label the notes-api fixture batch", "u1"),
+        aline(T0 + 10, "Working through the batch now.", "a1", "u1"),
+        qline(T0 + 30, ASK, "q1", "a1"),
+        uline(T0 + 400, "unrelated: also bump the version", "u2", "q1"),
         aline(T0 + 410, "Bumped.", "a3", "u2"),
     ]
 
@@ -98,30 +111,25 @@ class SplicedDone(unittest.TestCase):
                 (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store) = saved
             return calls, store
 
-    def test_spliced_ask_places_but_cannot_complete(self):
+    def test_spliced_ask_completes_off_the_work_that_follows_it(self):
         calls, store = self._run(spliced_records(), DONE_HAPPY)
-        # the planner DID see the ambiguous frame (the unit still runs — the guard is at op level)
-        self.assertTrue(any(ASK[:40] in c for c in calls),
-                        "the spliced segment still gets its work unit — the tail work must still file")
+        self.assertTrue(any(ASK[:40] in c for c in calls), "the spliced segment gets its work unit")
+        asked = [nd for nd in store["nodes"].values()
+                 if "search endpoint" in (nd.get("text") or "").lower()]
+        self.assertTrue(asked, "the spliced ask gets a card — it is real")
+        self.assertTrue(asked[0].get("nodeComplete"),
+                        "the atoms after the splice are the model's work after reading it: a done-happy "
+                        "reply completes the ask, as for any ask (T252d)")
+
+    def test_a_splice_the_turn_never_answered_cannot_complete(self):
+        # the 2026-07-29 shape: the turn died before its first post-splice token — the splice's segment
+        # holds no assistant work, and the workless leg refuses the done; the ask still gets its card
+        calls, store = self._run(dead_splice_records(), DONE_HAPPY)
         asked = [nd for nd in store["nodes"].values()
                  if "search endpoint" in (nd.get("text") or "").lower()]
         self.assertTrue(asked, "the spliced ask still gets a card — it is real")
         self.assertFalse(asked[0].get("nodeComplete"),
-                         "a done-happy planner reply must not complete a goal off a spliced segment "
-                         "whose work belongs to the interrupted turn's own ask")
-
-    def test_spliced_done_cannot_complete_other_cards_either(self):
-        # a done aimed at a PRE-EXISTING card (the in-flight work's own card, coerce-placed by the
-        # earlier segment) is confabulation off the same unreliable frame — stripped too, and the
-        # ask itself still lands via the never-vanish floor
-        done_only = '{"ops":[{"why":"the batch is finished","do":"done","goal":1}]}'
-        calls, store = self._run(spliced_records(), done_only)
-        self.assertTrue(store["nodes"], "the earlier segment's ask was placed")
-        self.assertFalse(any(nd.get("nodeComplete") for nd in store["nodes"].values()),
-                         "no goal may complete off a spliced-trigger segment")
-        placed_texts = " | ".join((nd.get("quote") or nd.get("text") or "") for nd in store["nodes"].values())
-        self.assertIn(ASK[:30], placed_texts,
-                      "a stripped-to-empty reply still hard-places the spliced ask (never vanish)")
+                         "no work followed the splice: nothing evidences an answer")
 
     def test_typed_ask_with_real_answer_still_completes(self):
         # guard precision: an ordinary typed ask whose turn really answers it still dones
@@ -137,7 +145,7 @@ class SplicedDone(unittest.TestCase):
         self.assertTrue(asked and asked[0].get("nodeComplete"),
                         "a genuinely delivered answer still completes")
 
-    def test_absorbed_trigger_is_marked_and_detected(self):
+    def test_absorbed_trigger_is_marked_and_the_following_work_is_its_reply(self):
         with tempfile.TemporaryDirectory() as td:
             td = Path(td)
             tpath = td / (SID + ".jsonl")
@@ -150,11 +158,8 @@ class SplicedDone(unittest.TestCase):
         spliced = by_trig["q1"]
         self.assertTrue(any(a.get("uuid") == "q1" and a.get("absorbed") for a in spliced["atoms"]),
                         "the synthesized splice atom carries the absorbed marker")
-        self.assertTrue(jd._seg_spliced(spliced))
-        self.assertFalse(jd._seg_spliced(by_trig["u1"]),
-                         "an ordinary typed trigger is not spliced")
-        # and the running turn's continuation really does land inside the splice's segment —
-        # the ambiguity this whole guard exists for
+        self.assertFalse(hasattr(jd, "_seg_spliced"), "the spliced leg is gone with the send-time placement (T252d)")
+        # the work after the splice lands inside the splice's segment — its reply
         self.assertIn("a2", [a.get("uuid") for a in spliced["atoms"]])
 
 

--- a/tests/test_kernel_fed_echo_absorbed.py
+++ b/tests/test_kernel_fed_echo_absorbed.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python3
 """A send fed into a RUNNING turn is held by the CLI until its next tool boundary, then spliced in as a
-queued_command attachment stamped with the ENQUEUE time — so its atom lands ABOVE the tool calls that
-streamed while it waited. Until that splice the kernel's input echo is the message's only visible
-record, and two things must hold end to end:
+queued_command attachment stamped with the ENQUEUE time. Its atom is placed at the LANDING time — the
+boundary's own record, the attachment's file-order predecessor — so it lands BELOW the tool calls that
+streamed while it waited, where the model read it (T252d, the user 2026-09-08); the send time rides
+along as `sentAt`. Until that splice the kernel's input echo is the message's only visible record, and
+two things must hold end to end:
 
   1. the echo of a FED, unlanded text outlives its sibling's landing — no floor retires an SDK echo at
      all (sdk_backend.prune_live, 2026-09-06: the CLI's image-path extraction is a composer paste-hook
      behaviour that stream-json input never reaches) — and retires exactly when the absorbed atom's text
      lands: the kernel's _atom_user_texts reads the queued_command text off the parsed absorbed atom, so
      the by-text prune fires on it and the message never renders twice;
-  2. the chat event for that atom says so (`absorbed`, plus `landedAt`: when the CLI took it — the
-     file-order predecessor of the attachment record, since the attachment's own stamp is the send
-     time), so the client can mark it and leave a cue where the pending bubble was.
+  2. the chat event for that atom says so (`absorbed`, its `ts` the landing, plus `sentAt`: when the
+     user sent it), so the client's tail bubble is replaced in place and its hover can say when the
+     message was sent.
 
 The sdk_backend twin of the image-path predicate is pinned against the kernel's, and both against the
 CLI paste hook's extension set (ImagePathPredicateTwins names the source). The TEXT KEY the kernel's
@@ -207,8 +209,9 @@ class AbsorbedAtomCarriesItsLandingTime(unittest.TestCase):
         self.w.write(running_turn() + spliced_tail())
         a = self._absorbed(self.w.parse())
         self.assertEqual(len(a), 1)
-        self.assertEqual(a[0]["t"], T0 + 38, "placed at the SEND time, above the steps that ran meanwhile")
-        self.assertEqual(a[0]["landedT"], T0 + 50, "taken at the boundary before it in file order")
+        self.assertEqual(a[0]["t"], T0 + 50, "placed at the LANDING time — the boundary before it in file order — below the steps that ran meanwhile (T252d)")
+        self.assertEqual(a[0]["sentAt"], T0 + 38, "the send time rides along for the bubble's hover")
+        self.assertNotIn("landedT", a[0], "one time is the placement; the other is sentAt")
         self.assertNotIn("_seq", a[0], "the parse still strips its private ordering key")
 
     def test_the_fold_stamps_it_too(self):
@@ -226,7 +229,7 @@ class AbsorbedAtomCarriesItsLandingTime(unittest.TestCase):
                                postal_log=[], now=NOW, sdk_human=True, asm_mode_out=mode)
         self.assertEqual(mode, ["fold"], "the appended splice folds onto the cached parse")
         a = self._absorbed(out)
-        self.assertEqual([(x["t"], x["landedT"]) for x in a], [(T0 + 38, T0 + 50)])
+        self.assertEqual([(x["t"], x["sentAt"]) for x in a], [(T0 + 50, T0 + 38)])
 
     def test_two_splices_at_one_boundary_read_that_boundary(self):
         # the CLI drains its queue at a boundary: the second attachment's file-order neighbour is the
@@ -238,7 +241,8 @@ class AbsorbedAtomCarriesItsLandingTime(unittest.TestCase):
                                  aline(T0 + 75, "Both done.", "a3", "att2")]
         self.w.write(recs)
         a = self._absorbed(self.w.parse())
-        self.assertEqual([(x["uuid"], x["landedT"]) for x in a], [("att1", T0 + 50), ("att2", T0 + 50)])
+        self.assertEqual([(x["uuid"], x["t"], x["sentAt"]) for x in a], [("att1", T0 + 50, T0 + 38), ("att2", T0 + 50, T0 + 44)],
+                         "both placed at the boundary they waited for, in send order (the attachment's file order breaks the tie)")
 
     def test_a_witness_stamped_before_the_send_clamps_to_the_send(self):
         # whole-second stamps can invert a sub-second gap between the tool_result and the enqueue (the
@@ -249,19 +253,20 @@ class AbsorbedAtomCarriesItsLandingTime(unittest.TestCase):
                                       aline(T0 + 75, "Renamed.", "a3", "att1")]
         self.w.write(recs)
         a = self._absorbed(self.w.parse())
-        self.assertEqual([(x["t"], x["landedT"]) for x in a], [(T0 + 38, T0 + 38)])
+        self.assertEqual([(x["t"], x["sentAt"]) for x in a], [(T0 + 38, T0 + 38)])
 
     def test_an_attachment_with_no_predecessor_carries_no_stamp(self):
         # nothing before it in the read → nothing truthful to stamp; the field is simply absent
         self.w.write([attline(T0 + 38, FED, "att1", None), aline(T0 + 75, "ok", "a1", "att1")])
         a = self._absorbed(self.w.parse())
         self.assertEqual(len(a), 1)
-        self.assertNotIn("landedT", a[0])
+        self.assertEqual((a[0]["t"], a[0]["sentAt"]), (T0 + 38, T0 + 38), "no landing witness: the send time is the only truthful place")
 
 
 class ChatEventSaysAbsorbed(unittest.TestCase):
-    """build_session's kind:"user" event for the absorbed atom carries `absorbed` and `landedAt`, so
-    the client can mark the bubble and place the mid-turn cue. A synthetic session discovery can see
+    """build_session's kind:"user" event for the absorbed atom carries `absorbed`, its landing as `ts`
+    and the send as `sentAt`, so the client's tail bubble is replaced in place and its hover can say
+    when the message was sent. A synthetic session discovery can see
     (names/ + projects/<cdir>/<SID>.jsonl under a hermetic state root), the test_chat_fold shape."""
 
     def setUp(self):
@@ -315,8 +320,9 @@ class ChatEventSaysAbsorbed(unittest.TestCase):
         ab = [e for e in users if e.get("absorbed")]
         self.assertEqual([e["uuid"] for e in ab], ["att1"])
         self.assertEqual(ab[0]["md"], FED)
-        self.assertEqual(ab[0]["landedAt"], T0 + 50 + shift, "when the CLI took it, not when it was sent")
-        self.assertEqual(ab[0]["ts"][:19], iso(T0 + 38 + shift)[:19], "ts stays the send time — placement unchanged")
+        self.assertEqual(ab[0]["ts"][:19], iso(T0 + 50 + shift)[:19], "ts is the LANDING: the event sits below the steps that ran while the send waited (T252d)")
+        self.assertEqual(ab[0]["sentAt"], T0 + 38 + shift, "the send time rides along for the hover")
+        self.assertNotIn("landedAt", ab[0])
         self.assertTrue(all("absorbed" not in e for e in users if e["uuid"] != "att1"),
                         "a native user record never wears the flag")
 

--- a/tests/test_pending_at_tail.py
+++ b/tests/test_pending_at_tail.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""T252 (the user 2026-09-07): a message sent while the session is mid-turn appears where it was sent and
-stays there. The pending bubble is drawn at its SEND POSITION from the first paint — right after the last
-kernel event at the press — so the steps that stream in afterwards land below it, and the absorbed atom the
-kernel places at the send time replaces it in the same spot. No "joined mid-turn" header, no jump/✕ cue.
+"""T252d (the user 2026-09-08): a message sent while the session is mid-turn is shown where the model READ
+it — below the steps that ran while it waited. The pending bubble sits at the TAIL while pending, the steps
+that stream in land above it, and the absorbed atom the kernel places at the LANDING time (the moment the
+CLI took it) replaces the bubble in that same tail position, so nothing moves on landing and the order on
+screen is the order the model saw. No "joined mid-turn" header, no jump/✕ cue. The bubble's hover says when
+the message was SENT once it has landed, when the landing is more than a minute later. This supersedes the
+T252/T252b in-place-at-send-position rule (the user's call after seeing the pane draw the message above
+steps the model read it after).
 
 The executed guard drives the real /chat page against a hermetic kernel: the socket's outbound send is
 dropped in the page (the message never reaches the kernel, so nothing parks or echoes — the client's bubble
 is the only copy, which is the case under test), the composer sends, two tool steps are appended to the
-transcript, and then the CLI's own record of a mid-turn splice — a `queued_command` attachment stamped with
-the SEND time — lands the atom above those steps. Asserted: the bubble's position in scroll space never
-changes while steps stream in below it; a scrolled-up reader is not moved; the landed message takes the
-bubble's slot; no header and no cue exist at any point. Red on main: the bubble rode the tail, so it moved
-below the streamed steps and the landing appeared higher up with a header and a cue.
+transcript, a SECOND message is sent while the first is pending, and then the CLI's own record of the first
+splice — a `queued_command` attachment stamped with the SEND time, written after the steps — lands the atom
+below those steps. Asserted: the bubble is the last unit on the page while steps stream in above it; a
+scrolled-up reader is not moved; two pending sends sit at the tail in send order; the landed message takes
+the first bubble's slot and its hover names the send time; no header and no cue exist at any point. Red on
+the T252 pane: the bubble held its send slot above the steps and the landing appeared there.
 
 Skips LOUDLY without the extension deps or a Playwright browser (CI installs none). SYNTHETIC fixtures only.
 """
@@ -34,6 +39,7 @@ EXT = os.path.join(ROOT, "vscode-extension")
 
 SID = "aaaaaaaa-1111-2222-3333-444444444444"
 TEXT = "and also update the docstring"
+TEXT2 = "then run the formatter"
 
 
 def _free_port():
@@ -82,7 +88,8 @@ const measure = () => page.evaluate((text) => {
   const c = content.getBoundingClientRect();
   const yOf = (n) => Math.round(content.scrollTop + n.getBoundingClientRect().top - c.top);
   const turns = Array.from(document.querySelectorAll(".turn[data-unit]"));
-  const pending = document.querySelector(".turn-queued");
+  const groups = Array.from(document.querySelectorAll(".turn-queued"));
+  const pending = groups.length ? groups[groups.length - 1] : null;   // the tail group (one group under the rule; the last one when the old pane splits them)
   const landed = turns.find((t) => t.classList.contains("turn-user") && (t.textContent || "").includes(text)) || null;
   const tools = turns.filter((t) => t.classList.contains("turn-tool") || t.classList.contains("turn-toolgroup"));
   return {
@@ -91,7 +98,10 @@ const measure = () => page.evaluate((text) => {
     landed: landed ? { y: yOf(landed), unit: Number(landed.dataset.unit), idx: turns.indexOf(landed) } : null,
     toolIdx: tools.map((t) => turns.indexOf(t)),
     header: document.querySelectorAll(".absorbed-tag").length, cue: document.querySelectorAll(".turn-absorbed-cue").length,
-    dropped: window.__dropped,
+    dropped: window.__dropped, count: turns.length,
+    pendingTexts: groups.flatMap((g) => Array.from(g.querySelectorAll(".queued-text, .queued-msg, .md")).map((n) => (n.textContent || "").trim()).filter(Boolean)),
+    pendingGroups: groups.length,
+    landedTitle: landed ? ((landed.querySelector(".user-bubble") || landed).getAttribute("title") || "") : null,
   };
 }, cfg.text);
 await page.fill("#composer-input", cfg.text);
@@ -103,9 +113,8 @@ const pressed = await measure();
 await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = Math.max(0, c.scrollTop - 150); });
 await page.waitForTimeout(200);
 const scrolled = await measure();
-// two tool steps stream in while the CLI holds the send
-// the steps are on the page when the transcript's unit classes change (compact mode folds consecutive tools:
-// on main all three Bashes fold into one group; with the fix the bubble splits the run into a lone tool and a group)
+// two tool steps stream in while the CLI holds the send; they land ABOVE the bubble, which stays the last unit
+// (the steps are on the page when the transcript's unit classes change: compact mode folds consecutive tools)
 const classesOf = () => page.evaluate(() => JSON.stringify(Array.from(document.querySelectorAll(".turn[data-unit]")).map((t) => t.className)));
 const beforeSteps = await classesOf();
 fs.appendFileSync(cfg.transcript, cfg.steps.map((r) => JSON.stringify(r)).join("\n") + "\n");
@@ -115,26 +124,34 @@ const streamed = await measure();
 // shots show the tail (the reader's scroll position was already measured); the landing below does not read scrollTop
 const shot = async (name) => { if (!cfg.shots) return; await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = c.scrollHeight; }); await page.waitForTimeout(150); await page.screenshot({ path: cfg.shots + name }); };
 await shot("-pending.png");
-// the CLI takes it at the boundary: its attachment record carries the SEND time, so the atom lands above the steps
+// a SECOND send while the first is pending: both sit at the tail, in send order
+await page.fill("#composer-input", cfg.text2);
+await page.press("#composer-input", "Enter");
+await page.waitForFunction((t2) => Array.from(document.querySelectorAll(".turn-queued")).some((g) => (g.textContent || "").includes(t2)), cfg.text2, { timeout: 10000 });
+await page.waitForTimeout(300);
+const second = await measure();
+await shot("-second.png");
+// the CLI takes the first at the boundary after the steps: its attachment record carries the SEND time but is
+// written after the steps, so the kernel places the atom at the landing — the tail slot the bubble held
 fs.appendFileSync(cfg.transcript, JSON.stringify(cfg.landing) + "\n");
 await page.waitForFunction((text) => Array.from(document.querySelectorAll(".turn.turn-user")).some((t) => (t.textContent || "").includes(text)), cfg.text, { timeout: 20000 });
 await page.waitForTimeout(500);
 const landed = await measure();
 await shot("-landed.png");
-fs.writeSync(1, "RESULT:" + JSON.stringify({ pressed, scrolled, streamed, landed }) + "\n");
+fs.writeSync(1, "RESULT:" + JSON.stringify({ pressed, scrolled, streamed, second, landed }) + "\n");
 await browser.close();
 process.exit(0);
 """
 
 
-class ServedPendingInPlace(unittest.TestCase):
+class ServedPendingAtTail(unittest.TestCase):
     maxDiff = None
 
     @classmethod
     def setUpClass(cls):
         if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
             raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
-        cls.lab = tempfile.mkdtemp(prefix="pending-in-place-")
+        cls.lab = tempfile.mkdtemp(prefix="pending-at-tail-")
         b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
         if b.returncode != 0:
             raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
@@ -177,17 +194,19 @@ class ServedPendingInPlace(unittest.TestCase):
         Path(cls.transcript).write_text("".join(json.dumps(r) + "\n" for r in recs))
         # the steps the session runs while the send waits, and the splice the CLI writes when it takes it
         cls.steps = [
-            {"type": "assistant", "timestamp": iso(t0 + 60), "uuid": "a3", "parentUuid": "tr1", "sessionId": SID,
+            {"type": "assistant", "timestamp": iso(t0 + 120), "uuid": "a3", "parentUuid": "tr1", "sessionId": SID,
              "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "tool_use",
                          "content": [{"type": "tool_use", "id": "tu_a3_0", "name": "Bash", "input": {"command": "uv run pytest -q tests/test_search.py"}}]}},
-            {"type": "user", "timestamp": iso(t0 + 61), "uuid": "tr2", "parentUuid": "a3", "sessionId": SID,
+            {"type": "user", "timestamp": iso(t0 + 121), "uuid": "tr2", "parentUuid": "a3", "sessionId": SID,
              "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_a3_0", "content": "5 passed"}]}},
-            {"type": "assistant", "timestamp": iso(t0 + 62), "uuid": "a4", "parentUuid": "tr2", "sessionId": SID,
+            {"type": "assistant", "timestamp": iso(t0 + 122), "uuid": "a4", "parentUuid": "tr2", "sessionId": SID,
              "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "tool_use",
                          "content": [{"type": "tool_use", "id": "tu_a4_0", "name": "Bash", "input": {"command": "git diff --stat"}}]}},
-            {"type": "user", "timestamp": iso(t0 + 63), "uuid": "tr3", "parentUuid": "a4", "sessionId": SID,
+            {"type": "user", "timestamp": iso(t0 + 125), "uuid": "tr3", "parentUuid": "a4", "sessionId": SID,
              "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_a4_0", "content": "1 file changed"}]}},
         ]
+        # sent at t0+55, taken at the t0+125 boundary (tr3, its file-order predecessor): 70 s later, so the landed
+        # bubble's hover names the send time
         cls.landing = {"type": "attachment", "timestamp": iso(t0 + 55), "uuid": "att1", "parentUuid": "tr3", "isSidechain": False,
                        "sessionId": SID, "attachment": {"type": "queued_command", "prompt": TEXT}}
         cls.port = _free_port()
@@ -218,12 +237,12 @@ class ServedPendingInPlace(unittest.TestCase):
             cls.kernel.wait()
         shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
 
-    def test_the_pending_bubble_holds_its_send_position_and_the_landing_replaces_it_in_place(self):
+    def test_the_pending_bubble_sits_at_the_tail_and_the_landing_replaces_it_there(self):
         cfg = os.path.join(self.lab, "cfg.json")
         with open(cfg, "w") as f:
-            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "text": TEXT,
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "text": TEXT, "text2": TEXT2,
                        "transcript": self.transcript, "steps": self.steps, "landing": self.landing,
-                       "shots": os.environ.get("PENDING_IN_PLACE_SHOTS", "")}, f)
+                       "shots": os.environ.get("PENDING_AT_TAIL_SHOTS", "")}, f)
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
             f.write(DRIVER)
@@ -235,24 +254,37 @@ class ServedPendingInPlace(unittest.TestCase):
         line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
         self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
         r = json.loads(line[len("RESULT:"):])
-        pr, sc, st, ld = r["pressed"], r["scrolled"], r["streamed"], r["landed"]
+        pr, sc, st, sd, ld = r["pressed"], r["scrolled"], r["streamed"], r["second"], r["landed"]
         self.assertEqual(pr["dropped"], 1, "the send was dropped at the socket: the client's bubble is the only copy (%r)" % pr)
         self.assertIsNotNone(pr["pending"], "the press drew the pending bubble: %r" % pr)
         self.assertEqual(pr["header"] + pr["cue"] + st["header"] + st["cue"] + ld["header"] + ld["cue"], 0,
                          "no 'joined mid-turn' header and no cue at any point: %r" % r)
-        # THE RULE: the bubble keeps its slot while steps stream in below it
+        # THE RULE: the bubble is the LAST unit while steps stream in above it
+        self.assertEqual(pr["pending"]["idx"], pr["count"] - 1, "at the press the bubble is the tail: %r" % pr)
         self.assertIsNotNone(st["pending"], "still pending after the steps: %r" % st)
-        self.assertEqual(st["pending"]["y"], pr["pending"]["y"],
-                         "the bubble did not move in scroll space: pressed at %r, after the steps %r" % (pr["pending"], st["pending"]))
+        self.assertEqual(st["pending"]["idx"], st["count"] - 1, "the bubble is still the tail after the steps: %r" % st)
+        # (no assertion on the bubble's y: compact mode folds the new tools into the existing tool run, whose group head
+        # can be a few pixels shorter than the lone tool it replaces — the unit indices are the rule's measure)
         new_tools = [i for i in st["toolIdx"] if i not in pr["toolIdx"]] or st["toolIdx"][-1:]
-        self.assertTrue(all(i > st["pending"]["idx"] for i in new_tools), "the streamed steps sit BELOW the bubble: %r" % st)
+        self.assertTrue(all(i < st["pending"]["idx"] for i in new_tools), "the streamed steps sit ABOVE the bubble: %r" % st)
         self.assertEqual(st["scrollTop"], sc["scrollTop"], "a scrolled-up reader is not moved by the steps: %r → %r" % (sc["scrollTop"], st["scrollTop"]))
-        # the landing takes the bubble's slot
-        self.assertIsNone(ld["pending"], "the landing retired the bubble: %r" % ld)
+        # a second send while the first is pending: one tail group, both texts in send order
+        self.assertIsNotNone(sd["pending"], "the second send is pending too: %r" % sd)
+        self.assertEqual(sd["pendingGroups"], 1, "both sends in ONE tail group: %r" % sd)
+        self.assertEqual(sd["pending"]["idx"], sd["count"] - 1, "the pending group is still the tail: %r" % sd)
+        joined = " | ".join(sd["pendingTexts"])
+        self.assertLess(joined.find(TEXT), joined.find(TEXT2), "two pending sends in send order at the tail: %r" % sd["pendingTexts"])
+        self.assertEqual(sd["dropped"], 2, "both sends dropped at the socket")
+        # the landing takes the first bubble's slot; the second stays pending at the tail; the hover names the send time
         self.assertIsNotNone(ld["landed"], "the landed message is on the page: %r" % ld)
-        self.assertEqual(ld["landed"]["idx"], st["pending"]["idx"], "same slot in the transcript: bubble %r, landed %r" % (st["pending"], ld["landed"]))
-        self.assertLessEqual(abs(ld["landed"]["y"] - st["pending"]["y"]), 40,
-                             "same place on the page (the bare group's one-line head is the only difference): bubble y %r, landed y %r" % (st["pending"]["y"], ld["landed"]["y"]))
+        self.assertIsNotNone(ld["pending"], "the second send is still pending: %r" % ld)
+        self.assertEqual(ld["landed"]["idx"], sd["pending"]["idx"], "the landed message takes the slot the pending group held: group %r, landed %r" % (sd["pending"], ld["landed"]))
+        self.assertLessEqual(abs(ld["landed"]["y"] - sd["pending"]["y"]), 40,
+                             "same place on the page (the bare group's one-line head is the only difference): group y %r, landed y %r" % (sd["pending"]["y"], ld["landed"]["y"]))
+        self.assertEqual(ld["pending"]["idx"], ld["landed"]["idx"] + 1, "the second send's bubble sits right below the landed first")
+        self.assertNotIn(TEXT, " | ".join(ld["pendingTexts"]), "the first bubble retired; only the second is pending")
+        self.assertTrue((ld["landedTitle"] or "").startswith("sent at "),
+                        "the landed bubble's hover names the send time, more than a minute before the landing: %r" % ld["landedTitle"])
 
 
 if __name__ == "__main__":

--- a/tests/test_placements_canary.py
+++ b/tests/test_placements_canary.py
@@ -244,7 +244,7 @@ class MovedAtomsDoNotReplay(unittest.TestCase):
             jd.plan_llm = jd.opener_llm = lambda text, *a, **k: (calls.append(text) or '{"ops":[{"why":"x","do":"skip"}]}')
             jd._group_store = lambda *a, **k: None
             try:
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 store = jd.load_goals(SID)
                 store["placementsV"] = jd.PLACEMENTS_V - 1        # recorded under the previous derivation…
                 store["placements"] = {SID + ":1780000000:ca8d36fd#p": {"goal": 1}}   # …with history

--- a/tests/test_placements_canary.py
+++ b/tests/test_placements_canary.py
@@ -74,7 +74,14 @@ RECORDS = [
      "attachment": {"type": "queued_command", "commandMode": "prompt",
                     "prompt": [{"type": "text", "text": "also gzip the exported CSV"}]}},
     {"type": "queue-operation", "timestamp": iso(T0 + 335), "operation": "remove", "content": None},
-    aline(T0 + 360, "Renamed the columns, updated the importer tests, gzipped the export.", "a4", "att1"),
+    # a second splice whose LANDING differs from its send (T252d, 2026-09-08): sent at T0+340, taken at the
+    # T0+350 boundary (its file-order predecessor a3b). Its atom is placed at T0+350 — the read position —
+    # so its seg id's t is the landing, not the send; att1 above clamps (its witness a3 predates the send).
+    aline(T0 + 350, "Still renaming; one more file.", "a3b", "att1", stop=None),
+    {"type": "attachment", "timestamp": iso(T0 + 340), "uuid": "att2", "parentUuid": "a3b",
+     "attachment": {"type": "queued_command", "commandMode": "prompt",
+                    "prompt": [{"type": "text", "text": "and bump the export's version"}]}},
+    aline(T0 + 360, "Renamed the columns, updated the importer tests, gzipped the export.", "a4", "att2"),
     # a COMPACTION much later (2026-07-13): the boundary opens its OWN turn (the phantom pre-compaction
     # work-bar fix) — pinned here so the compact-turn split is part of placement identity too.
     {"type": "system", "subtype": "compact_boundary", "timestamp": iso(T0 + 4000), "uuid": "cb1",
@@ -109,6 +116,9 @@ RECORDS = [
     aline(T0 + 5560, "Renamed them again on the new export page.", "a7", "u7"),
 ]
 
+# v12 (2026-09-08, T252d): an absorbed atom is placed at its LANDING time, so a splice whose landing differs
+# from its send (att2 below, sent T0+340, taken T0+350) keys on the landing; att1's witness predates its send,
+# so it clamps and its id is unchanged. Both dimensions moved: att2 and its witness a3b join the atom set.
 # The pinned derivation, recorded under PLACEMENTS_V = 7 (2026-08-01; the derivation itself is unchanged
 # since v6 — v7 seals for a GROWN atom set, the replay-guard scoping. The LAST id of the first five — a
 # text-less segment — moved off the shared sha1('') hash da39a3ee onto its anchor atom's uuid, so text-less
@@ -122,6 +132,7 @@ EXPECTED_SEG_IDS = [
     SID + ":1780000120:f03c5f4f",
     SID + ":1780000240:686c9d66",
     SID + ":1780000330:f3320ed1",
+    SID + ":1780000350:26e8f145",   # att2: sent at T0+340, placed at its T0+350 landing (v12, T252d)
     SID + ":1780004000:d780b71b",
     SID + ":1780005000:d105998b",
     SID + ":1780005300:9b15c581",
@@ -133,7 +144,7 @@ EXPECTED_SEG_IDS = [
 # atom that changes segments without changing any id — the detached compact's stdout (so2) belongs to
 # the /compact COMMAND turn (cb2 sorts after it), and u7 must be in the set at all.
 EXPECTED_ATOM_UUIDS = [
-    "u1", "a1", "u2", "a2", "u3", "a3", "att1", "a4", "cb1", "a5",
+    "u1", "a1", "u2", "a2", "u3", "a3", "att1", "a3b", "att2", "a4", "cb1", "a5",
     "u6", "a6", "cw2", "so2", "cb2", "u7", "a7",
 ]
 
@@ -146,6 +157,7 @@ EXPECTED_UNITS = [
     (SID + ":1780000120:f03c5f4f", "nudge", False),
     (SID + ":1780000240:686c9d66", "work", True),
     (SID + ":1780000330:f3320ed1", "work", True),
+    (SID + ":1780000350:26e8f145", "work", True),
     (SID + ":1780004000:d780b71b", "work", False),
     (SID + ":1780005000:d105998b", "work", True),
     (SID + ":1780005500:686c9d66", "work", True),
@@ -208,8 +220,45 @@ class PlacementIdentityCanary(unittest.TestCase):
         # spur, so every pinned id is UNCHANGED — the bump seals transcripts whose eclipsed fork
         # held SIBLING chains (stub twins, error bursts, older attempts), whose atoms leave the
         # set again (tests/test_event_model_golden.py EclipsedChainSelection covers the pick).
-        self.assertEqual(jd.PLACEMENTS_V, 11, "EXPECTED_SEG_IDS was pinned under PLACEMENTS_V=11 — "
+        # v12 (2026-09-08, T252d): absorbed atoms placed at their landing time — att2's id and the atom set
+        # above re-pinned with the bump.
+        self.assertEqual(jd.PLACEMENTS_V, 12, "EXPECTED_SEG_IDS was pinned under PLACEMENTS_V=11 — "
                          "re-pin the ids and this version together, in the same commit")
+
+
+class MovedAtomsDoNotReplay(unittest.TestCase):
+    """The contract behind the bump (T252d): a store recorded under an older PLACEMENTS_V has untrustworthy
+    keys, so its currently-ready unplaced units are SEALED (placements[key] = None) at the next pass rather
+    than planned — a dormant session whose absorbed atoms moved to their landing time mints no new goals
+    for them. Proven here on the fixture: a v11 store with recorded history goes through _plan_session
+    under v12, the planner is never called, no node is minted, and every unit key is sealed."""
+
+    def test_a_dormant_older_store_seals_instead_of_replaying(self):
+        calls = []
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            tp = td / (SID + ".jsonl")
+            tp.write_text("\n".join(json.dumps(r) for r in RECORDS) + "\n")
+            saved = (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store)
+            jd.GOALDIR, jd.PCACHE = td / "goals", td / "pcache"
+            jd.plan_llm = jd.opener_llm = lambda text, *a, **k: (calls.append(text) or '{"ops":[{"why":"x","do":"skip"}]}')
+            jd._group_store = lambda *a, **k: None
+            try:
+                jd._PARSE_CACHE.clear()
+                store = jd.load_goals(SID)
+                store["placementsV"] = jd.PLACEMENTS_V - 1        # recorded under the previous derivation…
+                store["placements"] = {SID + ":1780000000:ca8d36fd#p": {"goal": 1}}   # …with history
+                jd.save_goals(SID, store)
+                jd._plan_session(SID, str(tp), T0 + 6000)
+                store = jd.load_goals(SID)
+            finally:
+                (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store) = saved
+        self.assertEqual(calls, [], "no unit of the moved history reached the planner")
+        self.assertEqual(store.get("nodes"), {}, "no goal minted for a moved atom")
+        self.assertEqual(store["placementsV"], jd.PLACEMENTS_V, "stamped current after the seal")
+        sealed = [k for k, v in store["placements"].items() if v is None]
+        self.assertTrue(any(k.startswith(SID + ":1780000350:") for k in sealed),
+                        "the moved splice's unit is sealed under its new key: %r" % sorted(store["placements"]))
 
 
 if __name__ == "__main__":

--- a/ui/webview/optimistic-send.test.ts
+++ b/ui/webview/optimistic-send.test.ts
@@ -95,13 +95,13 @@ test("retire needs a NEW landed atom (after the send's anchor); kernel provision
 // queued one are the same state, so they wear the same dashed bubble — and the look then only ever moves
 // provisional→settled. It first shipped as a 0.6-opacity SOLID bubble, which invented a third look and made a
 // queued send flip solid→dashed (backwards, as if it had un-landed).
-test("an optimistic echo is a kernel-invisible QUEUED event at its send slot — never a solid user bubble", () => {
+test("an optimistic echo is a kernel-invisible QUEUED event at the tail — never a solid user bubble", () => {
   const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
   const SP = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "send-pending.ts"), "utf8");
   assert.match(SP, /export const OPT_PREFIX = "optimistic:";/);
   assert.match(RENDER, /const isOptimistic = \(e: ChatEvent\): boolean => isOptimisticUuid\(e\.uuid\);/);
   assert.match(RENDER, /const mk = \(p: PendingSend\) => \(\{ md: p\.text, optimistic: true, cancelable: true, imgPaths: p\.imgPaths, lost: p\.lost, qts: p\.ts \}\);/);   // the echo carries its dragged-image paths (2026-08-25); cancelable from the press (2026-08-30); `lost` after a connection drop, `qts` its identity for the ✕ (2026-09-06)
-  // stale ones are stripped wherever they sit — since T252 a bubble is spliced at its send slot, not the tail
+  // stale ones are stripped wherever they sit (the strip is position-agnostic; T252d puts the group at the tail)
   assert.match(RENDER, /if \(isOptimistic\(e\)\) \{ s\.events\.splice\(i, 1\); continue; \}/);
   // the abandoned dim/pending idiom is FULLY gone: render, guard fields, and stylesheet — the last
   // leftovers (a `!e.pending` guard on a field no event carries, and a stylesheet paragraph describing
@@ -115,8 +115,8 @@ test("an optimistic echo is a kernel-invisible QUEUED event at its send slot —
 });
 
 test("nothing known-queued → a bare group wearing the honest 'sending…' header", () => {
-  assert.match(RENDER, /s\.events\.splice\(g\.idx, 0, \{ kind: "queued", bare: true, texts: g\.sends\.map\(mk\), uuid: OPT_PREFIX \+ g\.sends\[0\]\.ts,/,
-    "one bare group per send slot (T252: right after the send's anchor, never the tail)");
+  assert.match(RENDER, /s\.events\.push\(\{ kind: "queued", bare: true, texts: inject\.map\(mk\), uuid: OPT_PREFIX \+ inject\[0\]\.ts,/,
+    "ONE bare group at the tail, the sends in send order (T252d: where the model reads them)");
   // "N queued messages" stays unclaimable pre-confirmation — but NO label was the user's 2026-08-30
   // bug (a mid-compaction send sat unlabeled and uncuttable): the bare group now states exactly what
   // is known, and the reflow recounts it in the same vocabulary after a ✕
@@ -130,7 +130,7 @@ test("nothing known-queued → a bare group wearing the honest 'sending…' head
   assert.match(RENDER, /if \(!ev\.bare\) \{/, "the standard 'N queued' header still needs confirmation");
 });
 
-test("something IS queued → the kernel's copy of OUR text is hidden and ours stays at its slot (T252)", () => {
+test("something IS queued → the kernel's copy of OUR text is hidden and ours stays drawn below the group (T252)", () => {
   // one bubble per message: the kernel's queued group at the tail keeps its OTHER texts, our copy in it is
   // hidden (a client-only mark), and the hide is undone with every other injection before the counts run
   assert.match(RENDER, /function hideQueuedCopy\(s: Session, p: PendingSend\)/);
@@ -139,7 +139,7 @@ test("something IS queued → the kernel's copy of OUR text is hidden and ours s
   assert.match(RENDER, /const texts = ev\.texts\.filter\(\(t\) => !t\.hiddenByPending\);/, "the renderer draws the visible copies only");
   assert.match(RENDER, /map\(\(t\) => t\.hiddenByPending \? \{ \.\.\.t, hiddenByPending: undefined \} : t\)/, "the strip clears the marks");
   // a copy hidden out of a HELD group hands the hold's reason to our bubble
-  assert.match(RENDER, /held: g\.sends\.map\(\(p\) => heldBy\.get\(p\)\)\.find\(\(h\) => !!h\)/);
+  assert.match(RENDER, /held: inject\.map\(\(p\) => heldBy\.get\(p\)\)\.find\(\(h\) => !!h\)/);
 });
 
 test("an unconfirmed echo keeps its tooltip AND carries a ✕ from the press (the 2026-08-30 rule)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -38,7 +38,7 @@ import { titleWithKey, chordOf, effectiveChord, loadOverrides } from "./keybindi
 import { DEFAULT_CHORDS } from "./commands";
 import { NavHistory } from "./nav-history";
 import { StagedStack } from "./staged-messages";
-import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, newPending, reconcilePending, injectionGroups, queuedCopyToHide, dropPending, bareGroupLabel } from "./send-pending";
+import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, newPending, reconcilePending, queuedCopyToHide, dropPending, bareGroupLabel, sentAtLabel } from "./send-pending";
 import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional, focusResolvesProvisional } from "./provisional";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
@@ -99,7 +99,7 @@ type TaskOutputs = Record<string, { command: string; output: string }>;
 type ChatEvent = (
   // mid/mids: postal message ids the kernel could NOT resolve into cards, carried on the raw turn so a
   // timeline arc into it still lands (see _hydrate_postal's unresolved path)
-  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; canned?: string; tag?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[]; undelivered?: boolean; echoT?: number; spacePaths?: string[]; pathLinks?: Record<string, string>; pathPins?: Record<string, string> }
+  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; canned?: string; tag?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[]; undelivered?: boolean; echoT?: number; absorbed?: boolean; sentAt?: number; spacePaths?: string[]; pathLinks?: Record<string, string>; pathPins?: Record<string, string> }
   | { kind: "assistant"; md: string; uuid?: string; ts?: string; spacePaths?: string[]; pathLinks?: Record<string, string>; pathPins?: Record<string, string> }   // spacePaths: backticked filenames WITH spaces the kernel verified exist (build_session _space_paths) → whole-span links. pathLinks: path-shaped tokens the kernel verified against the filesystem, token → real open target (build_session _path_links) — the linkifier's gate
   | { kind: "thinking"; text: string; encrypted: boolean; uuid?: string; ts?: string }
   | {
@@ -301,12 +301,13 @@ const order: string[] = [];           // positional tab order (for cycling)
 // ── client-side optimistic echo (the user 2026-07-15) ── a composer send clears the box instantly, but the
 // message only reappears in the chat once the kernel round-trips it back (its own provisional). Sending to a
 // busy/slow thread, the kernel's provisional could briefly VANISH in the echo→landed gap — so a just-sent
-// message looked lost for a beat. We drop a local optimistic bubble the moment you hit Enter — AT ITS SEND
-// POSITION, right after the last kernel event at the press (T252, the user 2026-09-07), so the steps that
-// stream in while the CLI holds the send land below it and the absorbed atom the kernel places at the send
-// time replaces it in the same spot — and keep RE-injecting it on every push until the kernel's payload
-// demonstrably carries the message, then let it go — the immediacy is client-owned, independent of every
-// server-side timing subtlety.
+// message looked lost for a beat. We drop a local optimistic bubble the moment you hit Enter — at the TAIL,
+// below every event the kernel has shown, where the model will READ it (T252d, the user 2026-09-08: the
+// steps that stream in while the CLI holds the send land above it, and the absorbed atom the kernel places
+// at the LANDING time replaces it in that same tail position, so nothing moves on landing and the order on
+// screen is the order the model saw; T252 had drawn it at the send slot, above those steps) — and keep
+// RE-injecting it on every push until the kernel's payload demonstrably carries the message, then let it
+// go — the immediacy is client-owned, independent of every server-side timing subtlety.
 // It rides the QUEUED idiom (the user 2026-07-16): to the reader an unconfirmed send and a queued one are the
 // same state — sent, nothing's happened yet — so they wear the same dashed bubble. That also means the look
 // only ever moves provisional→settled: dashed→solid when it lands, dashed→dashed (invisible) when it really
@@ -329,11 +330,10 @@ const pendingSent = new Map<string, PendingSend[]>();
 const isOptimistic = (e: ChatEvent): boolean => isOptimisticUuid(e.uuid);
 
 // The kernel's own queued group, if one is at the tail. Since T252 ours is never merged into it: a copy of
-// OUR text in it is hidden (hideQueuedCopy — one bubble per message, ours at its send slot), and
-// a group holding OTHER texts is a floor — a send pressed while they were queued runs after them, so its
-// bubble is drawn below the group (send-pending.ts placementIndex, T252b; the user's 2026-07-16 rule that
-// a send queues behind what the session already holds, kept in placement rather than by merging).
-// Tail-scanned; a queued group only ever sits at the bottom.
+// OUR text in it is hidden (hideQueuedCopy — one bubble per message, ours in its own bare group right below
+// the kernel's), and a group holding OTHER texts simply sits above ours — a send pressed while they were
+// queued runs after them (the user's 2026-07-16 rule that a send queues behind what the session already
+// holds). Tail-scanned; a queued group only ever sits at the bottom.
 function tailQueuedIdx(evs: ChatEvent[]): number {
   for (let i = evs.length - 1, n = 0; i >= 0 && n < 10; i--, n++) if (evs[i].kind === "queued") return i;
   return -1;
@@ -371,8 +371,8 @@ function reconcileOptimistic(s: Session): void {
   // the text and the resend); its PROVISIONAL — echo atom or queued bubble — suppresses ours for this
   // push and nothing more, so if it blinks, ours steps straight back in, and proves the kernel has the
   // send (a "not confirmed" label is cleared). The kernel's QUEUED copy of a send is different (T252): it
-  // sits in the kernel's group at the tail while the bubble the user watches is ours, at its send slot —
-  // so that copy is hidden and ours stays, one bubble per message; the group keeps its other texts.
+  // sits in the kernel's group at the tail while the bubble the user watches is ours, right below it — so
+  // that copy is hidden and ours stays, one bubble per message; the group keeps its other texts.
   const r = reconcilePending(s.events as TailEvent[], list);
   if (r.keep.length) pendingSent.set(s.id, r.keep); else pendingSent.delete(s.id);
   const heldBy = new Map<PendingSend, NonNullable<Extract<ChatEvent, { kind: "queued" }>["held"]>>();
@@ -390,24 +390,22 @@ function reconcileOptimistic(s: Session): void {
   // `qts` is the entry's identity: the ✕ removes THAT entry, never the first with the same text (two
   // identical sends can sit in different states — one lost, one received).
   const mk = (p: PendingSend) => ({ md: p.text, optimistic: true, cancelable: true, imgPaths: p.imgPaths, lost: p.lost, qts: p.ts });
-  // A BARE dashed bubble at each send's slot — right after its anchor (send-pending.ts injectionGroups):
-  // no "N queued messages" header to claim what we can't back. Groups come highest slot first, so each
-  // splice leaves the lower slots valid. A copy hidden out of a HELD kernel group (a usage limit holds
-  // every send) hands its reason to our bubble, so the wait still says what it is waiting for.
-  const groups = injectionGroups(s.events as TailEvent[], inject);
-  for (const g of groups)
-    s.events.splice(g.idx, 0, { kind: "queued", bare: true, texts: g.sends.map(mk), uuid: OPT_PREFIX + g.sends[0].ts,
-                                held: g.sends.map((p) => heldBy.get(p)).find((h) => !!h) });
-  // the signature carries each group's SLOT beside its texts: chatTail repaints from the kernel index it was
-  // handed, trusting the DOM prefix — which also needs the bubble's slot unchanged. A slot that moves (a floor
-  // event arriving) marks the view stale, so the window is rebuilt (second review).
-  settle(groups.flatMap((g) => g.sends.map((p) => g.idx + ":" + p.text)));
+  // ONE BARE dashed group at the TAIL, the sends in send order (T252d): below every event the kernel has
+  // shown, where the model will read them; the landed atom, placed at its landing time, takes that same
+  // position. No "N queued messages" header to claim what we can't back. A copy hidden out of a HELD kernel
+  // group (a usage limit holds every send) hands its reason to our bubble, so the wait still says what it is
+  // waiting for.
+  s.events.push({ kind: "queued", bare: true, texts: inject.map(mk), uuid: OPT_PREFIX + inject[0].ts,
+                  held: inject.map((p) => heldBy.get(p)).find((h) => !!h) });
+  // the signature is the texts alone: the tail slot moves with every kernel push by design, and chatTail's
+  // incremental repaint strips our group before applying a kernel index, so the slot is never trusted
+  settle(inject.map((p) => p.text));
 }
 
-// Undo our own injections wherever they sit — the bare groups we spliced in (T252: at their send slots, no
-// longer only at the tail), the optimistic texts we once merged into a kernel group, and the hide marks on
-// the kernel's queued copies — so every reader below sees KERNEL truth only. Every ingest path that applies
-// a kernel INDEX (chatTail's `from`) strips first: a bubble sitting mid-array would shift that index.
+// Undo our own injections wherever they sit — the bare group at the tail (T252d; T252 had spliced groups at
+// their send slots mid-array, and the strip stays position-agnostic), the optimistic texts we once merged
+// into a kernel group, and the hide marks on the kernel's queued copies — so every reader below sees KERNEL
+// truth only. Every ingest path that applies a kernel INDEX (chatTail's `from`) strips first.
 function stripOptimistic(s: Session): void {
   for (let i = s.events.length - 1; i >= 0; i--) {
     const e = s.events[i];
@@ -418,8 +416,8 @@ function stripOptimistic(s: Session): void {
 }
 
 // Hide ONE copy of this send's text in the kernel's queued group (send-pending.ts queuedCopyToHide picks
-// it: the newest not-yet-hidden copy, never one the kernel marked non-cancelable): ours is drawn at its
-// slot, so the tail copy would be the same message twice. Returns the group's `held` so the bubble can
+// it: ours by id, else the newest not-yet-hidden copy, never one the kernel marked non-cancelable): ours is
+// drawn in its own bare group right below, so the kernel's copy would be the same message twice. Returns the group's `held` so the bubble can
 // carry the reason — or null when no copy is hidden, in which case the kernel's copy keeps covering ours.
 function hideQueuedCopy(s: Session, p: PendingSend): { held?: Extract<ChatEvent, { kind: "queued" }>["held"] } | null {
   const qi = tailQueuedIdx(s.events);
@@ -2795,6 +2793,10 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         turn.appendChild(tchip);
       }
       const bubble = el("div", (romp ? "romp-bubble" : tagged ? "romp-bubble tag-bubble" : injected ? "user-note" : "user-bubble") + " md");
+      // a mid-turn send sits where the model READ it (T252d): the hover says when it was SENT, once the two differ
+      // by more than a minute (both kernel stamps: the atom's landing `ts` and its `sentAt`)
+      const sentTip = sentAtLabel(ev.ts, ev.sentAt);
+      if (sentTip) bubble.title = sentTip;
       // A slash COMMAND you sent reads as a special keyword, not prose (the user 2026-06-29): render the leading
       // "/cmd" token as a monospace chip. Genuine human bubbles only (a romp/injected note is never a command).
       // paths this turn already renders as full in-bubble images (both the caption path and a
@@ -13652,10 +13654,10 @@ function chatTail(msg: any) {
   // Comparing `from` against the inflated length masked a genuine 1-event gap (the repair below never
   // fired, PR #107's desync class), and a delta starting exactly one past kernel truth landed BEYOND
   // the injected bubble, freezing it into the resident events as fake history the reconcile's strip
-  // loop could never pop (the user 2026-08-09). Since T252 a bubble sits at its send slot, mid-array,
-  // where it would also SHIFT every kernel index after it — so the gap check COUNTS kernel events here,
-  // and the strip itself waits until the delta is going to be applied: stripping ahead of the two early
-  // returns left s.events without the bubble while the DOM still showed it (review of the first cut).
+  // loop could never pop (the user 2026-08-09). The gap check COUNTS kernel events (our group at the tail
+  // is not one of them), and the strip itself waits until the delta is going to be applied: stripping
+  // ahead of the two early returns left s.events without the bubble while the DOM still showed it (review
+  // of the first cut).
   const kernelLen = s.events.reduce((n, e) => n + (isOptimistic(e) ? 0 : 1), 0);
   if (from > kernelLen) {
     // GAP: the delta starts PAST what we hold, so the events in between never reached us. Applying it would

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -21,7 +21,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { newPending, pendingBody, reconcilePending, dropPending, injectionGroups, scanFrom, queuedCopyToHide, foreignKey, landedIn, provisionalIn, bareGroupLabel, type TailEvent, type PendingSend } from "./send-pending";
+import { newPending, pendingBody, reconcilePending, dropPending, scanFrom, queuedCopyToHide, landedIn, provisionalIn, bareGroupLabel, sentAtLabel, type TailEvent, type PendingSend } from "./send-pending";
 
 const read = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
 const RENDER = read("render.ts");
@@ -169,375 +169,9 @@ test("what was already there at the press is background: an older identical mess
   assert.equal(r.inject.length, 1, "…and cover nothing: our bubble shows beside the older copies (two sends, two bubbles)");
 });
 
-// ── (5) the bubble sits at its send position: right after its anchor, from the first paint ────────
-
-test("the pending bubble is placed right after its anchor and stays there while steps stream in below (T252)", () => {
-  const tail: TailEvent[] = [{ kind: "user", md: "first", uuid: "u1" }, { kind: "assistant", md: "…", uuid: "a1" }];
-  const list = press(tail, TEXT);
-  assert.equal(list[0].at?.after, "a1", "anchored to the last stable kernel event at the press");
-  let r = reconcilePending(tail, list);
-  assert.deepEqual(injectionGroups(tail, r.inject), [{ idx: 2, sends: [list[0]] }], "at the press the slot IS the tail");
-  // two tool steps stream in while the CLI holds the send: they land below the bubble, the bubble does not move
-  const streaming: TailEvent[] = [...tail, { kind: "tool", uuid: "t1" }, { kind: "tool", uuid: "t2" }];
-  r = reconcilePending(streaming, list);
-  assert.equal(r.inject.length, 1, "still pending, still drawn");
-  assert.deepEqual(injectionGroups(streaming, r.inject), [{ idx: 2, sends: [list[0]] }], "same slot: after a1, above t1 and t2");
-  // the CLI takes it at the boundary: the kernel places the absorbed atom at its SEND time — the bubble's slot
-  const landed: TailEvent[] = [...tail, { kind: "user", md: TEXT, uuid: "att1", absorbed: true }, { kind: "tool", uuid: "t1" }, { kind: "tool", uuid: "t2" }];
-  r = reconcilePending(landed, list);
-  assert.deepEqual(r.landed.map((l) => l.idx), [2], "the landing replaces the bubble in place: same index");
-  assert.equal(r.keep.length, 0);
-});
-
-test("several pending sends: each after its own anchor, in send order; same anchor → one group in order", () => {
-  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
-  const list = press(tail, "one", "two");                 // pressed against the same frame
-  const later: TailEvent[] = [...tail, { kind: "tool", uuid: "t1" }];
-  const third = newPending("three", undefined, T0 + 9);
-  const all = [...list, third];
-  const r = reconcilePending(later, all);                  // the third is stamped now, after t1
-  assert.equal(third.at?.after, "t1");
-  assert.deepEqual(injectionGroups(later, r.inject), [
-    { idx: 2, sends: [third] },                            // highest slot first, so the caller can splice bottom-up
-    { idx: 1, sends: [list[0], list[1]] },                 // one bare group for the two that share an anchor, in send order
-  ]);
-  // no events at all: the only slot is the head, which is also the tail
-  const none = press([], "hello");
-  assert.deepEqual(injectionGroups([], reconcilePending([], none).inject), [{ idx: 0, sends: [none[0]] }]);
-  // an anchor that left the resident window: everything resident is later than the send, so the slot is the head
-  assert.equal(scanFrom([{ kind: "tool", uuid: "zz" }], { after: "gone", place: null, queuedForeign: [], queuedForeignIds: [], queuedResident: {}, seen: [], queued: 0 }), 0);
-});
-
-test("a send pressed while an earlier send's echo is the newest event is placed BELOW that echo (review of the first cut)", () => {
-  // the anchor skips the kernel's echo atoms (an echo is not a stable place to bound the landing scan), but as a
-  // PLACEMENT that inverted consecutive sends: the second message sat above the first until both landed. A user
-  // event the kernel stamped at or before the press — an echo, a never-delivered bubble, a landed atom — is
-  // older than this send, so the bubble goes below it, exactly where the absorbed atom will be placed by time.
-  const isoAt = (s: number) => new Date(s * 1000).toISOString();
-  const S = Math.floor(T0 / 1000);
-  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1", ts: isoAt(S - 30) }];
-  const first = press(tail, "first message");
-  const echoed: TailEvent[] = [...tail, { kind: "user", md: "first message", uuid: "echo:1", ts: isoAt(S - 2) }];
-  reconcilePending(echoed, first);                              // the kernel's echo covers the first send
-  const second = newPending("second message", undefined, T0);   // pressed with the echo as the newest event
-  const list = [...first, second];
-  const r = reconcilePending(echoed, list);
-  assert.equal(second.at?.after, "a1", "the scan anchor still skips the echo");
-  assert.deepEqual(r.inject, [second]);
-  assert.deepEqual(injectionGroups(echoed, r.inject), [{ idx: 2, sends: [second] }], "…but the bubble is placed below it");
-  // a never-delivered bubble from an earlier send: older than this press, so below it too
-  const lost: TailEvent[] = [...tail, { kind: "user", md: "older", uuid: "echo:9", undelivered: true, ts: isoAt(S - 5) }];
-  const p = press(lost, "newer");
-  assert.deepEqual(injectionGroups(lost, reconcilePending(lost, p).inject), [{ idx: 2, sends: [p[0]] }]);
-  // a user event that arrives AFTER the press is a later send: the bubble stays above it
-  const later: TailEvent[] = [...tail, { kind: "user", md: "someone else's later message", uuid: "u7", ts: isoAt(S + 30) }];
-  const q = newPending("mine", undefined, T0);
-  reconcilePending(tail, [q]);                                  // pressed against the tail before u7 arrived
-  assert.deepEqual(injectionGroups(later, reconcilePending(later, [q]).inject), [{ idx: 1, sends: [q] }]);
-});
-
-test("the placement floor is the last user event AT THE PRESS, by identity, never a clock (second review)", () => {
-  // a press-time frame already proves precedence: every event resident at the press is older than the send. Comparing
-  // the client's press second with the kernel host's stamps re-inverted the order whenever the kernel clock led by more
-  // than the gap between two presses (a phone, a remote browser), and misplaced a bubble below a later-received event
-  // when the client clock led. So the press records the last user event's uuid (an echo counts) as the floor.
-  const isoAt = (s: number) => new Date(s * 1000).toISOString();
-  const S = Math.floor(T0 / 1000);
-  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1", ts: isoAt(S - 30) }];
-  // kernel host 3 s AHEAD: the first send's echo is stamped after the second press's second
-  const echoed: TailEvent[] = [...tail, { kind: "user", md: "first", uuid: "echo:1", ts: isoAt(S + 3) }];
-  const second = newPending("second", undefined, T0);
-  let r = reconcilePending(echoed, [second]);
-  assert.equal(second.at?.place, "echo:1", "the floor is recorded at the press");
-  assert.deepEqual(injectionGroups(echoed, r.inject), [{ idx: 2, sends: [second] }], "below the echo, whatever the clocks say");
-  // the echo → landed swap: the floor's uuid is gone, the landed atom carries its text — still the floor
-  const landedFirst: TailEvent[] = [...tail, { kind: "user", md: "first", uuid: "u1", absorbed: true, ts: isoAt(S + 3) }, { kind: "tool", uuid: "t1" }];
-  r = reconcilePending(landedFirst, [second]);
-  assert.deepEqual(injectionGroups(landedFirst, r.inject), [{ idx: 2, sends: [second] }], "below the landed first message, above the later tool");
-  // client clock AHEAD: a peer's message the kernel receives after the press, stamped at or before the press second,
-  // was not resident at the press — the bubble stays above it
-  const peerLater: TailEvent[] = [...tail, { kind: "user", md: "a peer's message", uuid: "u9", ts: isoAt(S - 1) }];
-  const mine = newPending("mine", undefined, T0);
-  reconcilePending(tail, [mine]);
-  assert.deepEqual(injectionGroups(peerLater, reconcilePending(peerLater, [mine]).inject), [{ idx: 1, sends: [mine] }]);
-  // no user event at the press: no floor, the anchor rules
-  const bare = press(tail, "alone");
-  assert.equal(bare[0].at?.place, null);
-  assert.deepEqual(injectionGroups(tail, reconcilePending(tail, bare).inject), [{ idx: 1, sends: [bare[0]] }]);
-  // a LATE entry (pressed against no frame) reads the frame's own stamps for its floor, like its anchor
-  const lateFrame: TailEvent[] = [...tail, { kind: "user", md: "older", uuid: "echo:5", ts: isoAt(S - 2) }, { kind: "user", md: "newer", uuid: "echo:6", ts: isoAt(S + 2) }];
-  const late: PendingSend = { ...newPending("late one", undefined, T0), late: true };
-  reconcilePending(lateFrame, [late]);
-  assert.equal(late.at?.place, "echo:5", "the last user event the kernel stamped before the press");
-  assert.doesNotMatch(read("send-pending.ts").split("export function placementIndex(")[1].split("\n}")[0], /eventSecond|pressS|p\.ts/, "placement reads no clock");
-});
-
-test("the text fallback finds the floor by ORDINAL, so a later send of the same text never pulls the bubble down (third review)", () => {
-  // A = "ok" pressed and echoed; B = "next" pressed with echo:A the newest user event; A lands, two steps stream,
-  // then the user sends "ok" again. The fallback used to take the LAST same-text user event — the new send's echo —
-  // and B's bubble dropped to the tail under a message pressed after it, until B landed.
-  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
-  const echoedA: TailEvent[] = [...tail, { kind: "user", md: "ok", uuid: "echo:A" }];
-  const b = newPending("next", undefined, T0);
-  reconcilePending(echoedA, [b]);
-  assert.equal(b.at?.place, "echo:A");
-  assert.equal(b.at?.placeOrd, 1, "one same-text user event from the anchor through the floor");
-  const later: TailEvent[] = [...tail, { kind: "user", md: "ok", uuid: "uA", absorbed: true }, { kind: "tool", uuid: "t1" }, { kind: "tool", uuid: "t2" }, { kind: "user", md: "ok", uuid: "echo:C" }];
-  assert.deepEqual(injectionGroups(later, reconcilePending(later, [b]).inject), [{ idx: 2, sends: [b] }], "below uA, above t1 — not under the newer echo");
-  const laterLanded: TailEvent[] = [...later.slice(0, 4), { kind: "user", md: "ok", uuid: "uC" }];
-  assert.deepEqual(injectionGroups(laterLanded, reconcilePending(laterLanded, [b]).inject), [{ idx: 2, sends: [b] }], "…nor under its landed atom");
-  // two identical echoes as the tail: the floor is the SECOND, so after both land the bubble sits below the second
-  const twin: TailEvent[] = [...tail, { kind: "user", md: "ok", uuid: "echo:A1" }, { kind: "user", md: "ok", uuid: "echo:A2" }];
-  const c = newPending("next", undefined, T0 + 1);
-  reconcilePending(twin, [c]);
-  assert.equal(c.at?.placeOrd, 2);
-  const twinLanded: TailEvent[] = [...tail, { kind: "user", md: "ok", uuid: "uA1" }, { kind: "user", md: "ok", uuid: "uA2" }, { kind: "tool", uuid: "t1" }];
-  assert.deepEqual(injectionGroups(twinLanded, reconcilePending(twinLanded, [c]).inject), [{ idx: 3, sends: [c] }]);
-  // the floor sits ABOVE the anchor (steps followed the last message before the press): the anchor already covers
-  // it, and a later same-text send must not become a floor
-  const stepsAfter: TailEvent[] = [{ kind: "user", md: "ok", uuid: "u0" }, { kind: "tool", uuid: "t0" }, { kind: "assistant", md: "…", uuid: "a1" }];
-  const d = press(stepsAfter, "next")[0];
-  assert.equal(d.at?.placeOrd, 0, "no same-text event after the anchor: the floor is not in play");
-  const stepsAfterLater: TailEvent[] = [...stepsAfter, { kind: "tool", uuid: "t3" }, { kind: "user", md: "ok", uuid: "echo:D" }];
-  assert.deepEqual(injectionGroups(stepsAfterLater, reconcilePending(stepsAfterLater, [d]).inject), [{ idx: 3, sends: [d] }], "right after the anchor");
-});
-
-test("an earlier pending send's landing or echo is a floor for every later send, whatever its text (T252b)", () => {
-  // X then Y pressed against [a1], both with no floor; the kernel ships X's absorbed atom: Y's bubble must sit
-  // BELOW it. Landings were recorded into `seen` for same-text entries only and placement never read them, so Y
-  // was spliced before uX and read above the first message until it landed — the very move this work ends.
-  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
-  const [x, y] = press(tail, "first", "second");
-  assert.equal(y.at?.place, null);
-  let frame: TailEvent[] = [...tail, { kind: "user", md: "first", uuid: "uX", absorbed: true }, { kind: "tool", uuid: "t1" }];
-  let r = reconcilePending(frame, [x, y]);
-  assert.deepEqual(r.landed.map((l) => l.p), [x]);
-  assert.deepEqual(r.keep, [y]);
-  assert.deepEqual(y.floors?.map((f) => f.uuid), ["uX"], "X's landing is recorded as Y's floor");
-  assert.deepEqual(injectionGroups(frame, r.inject), [{ idx: 2, sends: [y] }], "below uX, above t1");
-  // the echo variant: X's echo arrives while both are pending — Y sits below it, and X is covered
-  const [x2, y2] = press(tail, "first", "second");
-  frame = [...tail, { kind: "user", md: "first", uuid: "echo:X" }];
-  r = reconcilePending(frame, [x2, y2]);
-  assert.deepEqual(r.inject, [y2]);
-  assert.deepEqual(y2.floors?.map((f) => f.uuid), ["echo:X"]);
-  assert.deepEqual(injectionGroups(frame, r.inject), [{ idx: 2, sends: [y2] }]);
-  // …and when that echo becomes the landed atom, the landing takes over as the floor
-  frame = [...tail, { kind: "user", md: "first", uuid: "uX2", absorbed: true }, { kind: "tool", uuid: "t1" }];
-  r = reconcilePending(frame, [x2, y2]);
-  assert.deepEqual(y2.floors?.map((f) => f.uuid), ["echo:X", "uX2"]);
-  assert.deepEqual(injectionGroups(frame, r.inject), [{ idx: 2, sends: [y2] }]);
-  // a LATER send never becomes a floor for an earlier one: Z pressed after Y, lands first (a different route)
-  const [y3, z3] = press(tail, "second", "third");
-  frame = [...tail, { kind: "user", md: "third", uuid: "uZ" }];
-  r = reconcilePending(frame, [y3, z3]);
-  assert.deepEqual(r.landed.map((l) => l.p), [z3]);
-  assert.equal(y3.floors, undefined, "z3 was registered after y3: its landing is not y3's floor");
-  assert.deepEqual(injectionGroups(frame, r.inject), [{ idx: 1, sends: [y3] }], "y3 stays above the later send's atom");
-});
-
-test("a send pressed while the kernel's queue holds OTHER texts is drawn below that queue, and below their atoms once they land (T252b)", () => {
-  // the kernel's queued group has no uuid and is no user event, so it was never the anchor nor the floor: a send
-  // pressed while it held a romp nudge, another client's message, or a queue predating a page reload was spliced
-  // ABOVE the queue although it runs after those texts, and dropped down when one of them landed
-  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
-  const queued: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "a nudge from elsewhere" }, { md: "mine" }] }];
-  const mine = newPending("mine", undefined, T0);
-  let r = reconcilePending(queued, [mine]);
-  assert.deepEqual(mine.at?.queuedForeign, ["a nudge from elsewhere", "mine"], "every copy the queue held at the press is ahead of the send — a same-text copy included: it predates the press, so it is an older send's (second review)");
-  assert.equal(mine.at?.queued, 1, "…and it is background for the landing scan as before");
-  assert.deepEqual(injectionGroups(queued, r.inject), [{ idx: 2, sends: [mine] }], "below the queue, not above it");
-  // our copy hidden (render.ts) leaves the foreign text visible: still below
-  const hidden: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "a nudge from elsewhere" }, { md: "mine", hiddenByPending: true }] }];
-  assert.deepEqual(injectionGroups(hidden, reconcilePending(hidden, [mine]).inject), [{ idx: 2, sends: [mine] }]);
-  // the foreign text lands and the queue drains: the bubble sits below its atom, above what streams after
-  const landed: TailEvent[] = [...tail, { kind: "user", md: "a nudge from elsewhere", uuid: "uN" }, { kind: "tool", uuid: "t1" }];
-  r = reconcilePending(landed, [mine]);
-  assert.deepEqual(injectionGroups(landed, r.inject), [{ idx: 2, sends: [mine] }]);
-  // OUR copy is the one the kernel lists AFTER the press: not in the frame at the press, hidden by render.ts
-  // when it appears — the in-place rule (right after the anchor) holds for it
-  const mine2 = newPending("mine", undefined, T0 + 1);
-  r = reconcilePending(tail, [mine2]);
-  assert.deepEqual(mine2.at?.queuedForeign, []);
-  const listed: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "mine" }] }];
-  r = reconcilePending(listed, [mine2]);
-  assert.deepEqual(r.unqueue, [mine2], "the copy that appears after the press is this send's: hidden, ours drawn");
-  assert.deepEqual(injectionGroups(listed, r.inject), [{ idx: 1, sends: [mine2] }]);
-  // a same-text copy PRESENT at the press is an older send's (another client, an earlier press): ahead, below the group
-  const older: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "mine" }] }];
-  const mine3 = newPending("mine", undefined, T0 + 2);
-  r = reconcilePending(older, [mine3]);
-  assert.deepEqual(mine3.at?.queuedForeign, ["mine"]);
-  assert.deepEqual(injectionGroups(older, r.inject), [{ idx: 2, sends: [mine3] }]);
-  // render.ts: the stale merge-into-the-group comment is gone; the tail group is described as a floor
-  assert.doesNotMatch(RENDER, /Ours merges INTO it when present/);
-  assert.match(RENDER, /a group holding OTHER texts is a floor/);
-});
-
-test("foreign and floor texts match the kernel's landed shapes: a nudge's quote and markers, a multi-block record, and by ordinal (T252b review)", () => {
-  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
-  // (1) a goal-marked romp nudge: the queued group ships the split BODY, the landed atom keeps the full text
-  const body = "where does this stand?";
-  const full = "> the goal's context line\n\n" + body + "\n\n<!-- romp-goal-id: g1 --><!-- romp-injected -->";
-  const x = newPending("mine", undefined, T0);
-  reconcilePending([...tail, { kind: "queued", texts: [{ md: body }, { md: "mine" }] }], [x]);
-  assert.deepEqual(x.at?.queuedForeign, [body, "mine"], "every copy present at the press is ahead (the same-text one is an older send's)");
-  const nudgeLanded: TailEvent[] = [...tail, { kind: "user", md: full, uuid: "uN" }, { kind: "assistant", md: "…", uuid: "a2" }, { kind: "queued", texts: [{ md: "mine", hiddenByPending: true }] }];
-  assert.deepEqual(injectionGroups(nudgeLanded, reconcilePending(nudgeLanded, [x]).inject), [{ idx: 2, sends: [x] }], "below the landed nudge, whatever wrapping the kernel kept");
-  // (2) a multi-block record: two foreign texts taken at one boundary land as ONE user record
-  const y = newPending("mine", undefined, T0 + 1);
-  reconcilePending([...tail, { kind: "queued", texts: [{ md: "F" }, { md: "G" }, { md: "mine" }] }], [y]);
-  const blocks: TailEvent[] = [...tail, { kind: "user", md: "F G", uuid: "uFG", blocks: ["F", "G"] }, { kind: "tool", uuid: "t1" }];
-  assert.deepEqual(injectionGroups(blocks, reconcilePending(blocks, [y]).inject), [{ idx: 2, sends: [y] }], "below the record that holds both");
-  // (3) by ordinal: one copy of F queued at the press; F lands; another client queues F AGAIN, and later echoes it —
-  // the press-time copy is the first landing, and the newer copies are later than this send
-  const z = newPending("mine", undefined, T0 + 2);
-  reconcilePending([...tail, { kind: "queued", texts: [{ md: "F" }, { md: "mine" }] }], [z]);
-  const again: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1" }, { kind: "tool", uuid: "t1" }, { kind: "queued", texts: [{ md: "mine", hiddenByPending: true }, { md: "F" }] }];
-  // the kernel's queued copies carry no identity, so a copy still shown in the group is read as the press-time one
-  // (fourth review): the group holds the bubble below it while it shows a copy of the key — the fed-copy case, where
-  // an identical text the kernel had already forwarded lands first, is the common one; a same-text copy re-queued by
-  // another client after the press-time one landed keeps ours below the group until ours lands — the known limit
-  assert.deepEqual(injectionGroups(again, reconcilePending(again, [z]).inject), [{ idx: 4, sends: [z] }], "below the group while it still shows a copy of F");
-  const echoed: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1" }, { kind: "tool", uuid: "t1" }, { kind: "user", md: "F", uuid: "echo:F2" }];
-  assert.deepEqual(injectionGroups(echoed, reconcilePending(echoed, [z]).inject), [{ idx: 4, sends: [z] }], "…and, uF1 having been learned as someone else's while the group showed F, below the newer F's echo until this send lands");
-  // two copies of F at the press: the second landing is the floor
-  const w = newPending("mine", undefined, T0 + 3);
-  reconcilePending([...tail, { kind: "queued", texts: [{ md: "F" }, { md: "F" }, { md: "mine" }] }], [w]);
-  const twoLanded: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1" }, { kind: "user", md: "F", uuid: "uF2" }, { kind: "tool", uuid: "t1" }];
-  assert.deepEqual(injectionGroups(twoLanded, reconcilePending(twoLanded, [w]).inject), [{ idx: 3, sends: [w] }]);
-  const oneLanded: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1" }, { kind: "queued", texts: [{ md: "F" }, { md: "mine", hiddenByPending: true }] }];
-  assert.deepEqual(injectionGroups(oneLanded, reconcilePending(oneLanded, [w]).inject), [{ idx: 3, sends: [w] }], "one press-time copy still queued: below the group");
-  // (4) an earlier send's ECHO floor survives the earlier send's ✕: when its atom lands under a new uuid the floor
-  // is followed by text and ordinal, with no entry left to record the landing
-  const [x4, y4] = press(tail, "first", "second");
-  reconcilePending([...tail, { kind: "user", md: "first", uuid: "echo:X" }], [x4, y4]);
-  assert.deepEqual(y4.floors?.map((f) => [f.uuid, f.text, f.ord]), [["echo:X", "first", 1]]);
-  dropPending([x4, y4], "first", x4.ts);   // the ✕ the kernel could not honour: the CLI had taken it
-  const afterX: TailEvent[] = [...tail, { kind: "user", md: "first", uuid: "uX", absorbed: true }, { kind: "tool", uuid: "t1" }];
-  assert.deepEqual(injectionGroups(afterX, reconcilePending(afterX, [y4]).inject), [{ idx: 2, sends: [y4] }], "below X's atom, under its new uuid");
-});
-
-test("the queue's copies count as they were at the press: a later press matching a queued text, resident carriers, and the key's gates (T252b second review)", () => {
-  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
-  // (1) another client's "y" queued; A presses "x", then B presses "y": both run after that y, and A before B
-  const foreignY: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "y" }] }];
-  const a = newPending("x", undefined, T0); reconcilePending(foreignY, [a]);
-  const b = newPending("y", undefined, T0 + 1); let r = reconcilePending(foreignY, [a, b]);
-  assert.deepEqual(b.at?.queuedForeign, ["y"], "the copy predates B's press: ahead of B, whatever its text");
-  assert.deepEqual(injectionGroups(foreignY, r.inject), [{ idx: 2, sends: [a, b] }], "both below the group, in send order");
-  // (2) a carrier of the text already resident at the press (a never-delivered verdict for an earlier F) is not
-  // the press-time copy's landing: the group holding F stays the floor
-  const resident: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "echo:F0", undelivered: true }, { kind: "queued", texts: [{ md: "F" }] }];
-  const c = newPending("mine", undefined, T0 + 2); r = reconcilePending(resident, [c]);
-  assert.deepEqual(injectionGroups(resident, r.inject), [{ idx: 3, sends: [c] }], "below the group, not at the group's own index");
-  const residentLanded: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "echo:F0", undelivered: true }, { kind: "user", md: "F", uuid: "uF" }, { kind: "tool", uuid: "t1" }];
-  assert.deepEqual(injectionGroups(residentLanded, reconcilePending(residentLanded, [c]).inject), [{ idx: 3, sends: [c] }], "…and below the copy's landing once it lands");
-  // (3) the key: a leading quote block is set aside only for a romp-marked text (the kernel's own gate); a
-  // user's blockquote is part of the text; image chips and image paths are set aside like the kernel strips them
-  assert.equal(foreignKey("> the goal\n\nbody\n\n<!-- romp-goal-id: g1 -->"), "body");
-  assert.notEqual(foreignKey("> hi\nok"), foreignKey("ok"), "a typed blockquote is not wrapping");
-  assert.equal(foreignKey("look /tmp/shot.png"), foreignKey("look"));
-  assert.equal(foreignKey("look [Image #1]"), foreignKey("look"));
-  // an image-bearing foreign message (tmux route): queued with the path, landed with the chips stripped
-  const imgQueued: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "look /tmp/shot.png" }] }];
-  const d = newPending("mine", undefined, T0 + 3); reconcilePending(imgQueued, [d]);
-  const imgLanded: TailEvent[] = [...tail, { kind: "user", md: "look", uuid: "uI", images: [{}] }, { kind: "tool", uuid: "t1" }];
-  assert.deepEqual(injectionGroups(imgLanded, reconcilePending(imgLanded, [d]).inject), [{ idx: 2, sends: [d] }]);
-  // a copy whose text is a user's blockquote plus ours: still a copy present at the press, still ahead
-  const quoted: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "> hi\nok" }] }];
-  const e = newPending("ok", undefined, T0 + 4); r = reconcilePending(quoted, [e]);
-  assert.deepEqual(injectionGroups(quoted, r.inject), [{ idx: 2, sends: [e] }]);
-});
-
-test("empty keys, retired verdicts, a verdict seen first, and the CLI's delimiters (T252b third review)", () => {
-  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }, { kind: "tool", uuid: "t1" }];
-  // (1) an image-only queued copy keys to nothing: a reminders-only user record (md "") that lands after the press
-  // is not its carrier — only an event that carries images can be
-  const imgQueued: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "/tmp/shot.png" }] }];
-  const b = newPending("typed after", undefined, T0); reconcilePending(imgQueued, [b]);
-  const notified: TailEvent[] = [...tail, { kind: "user", md: "", uuid: "uR" }, { kind: "tool", uuid: "t2" }, { kind: "queued", texts: [{ md: "/tmp/shot.png" }] }];
-  assert.deepEqual(injectionGroups(notified, reconcilePending(notified, [b]).inject), [{ idx: 5, sends: [b] }], "below the group, not after the notification");
-  const imgLanded: TailEvent[] = [...tail, { kind: "user", md: "", uuid: "uR" }, { kind: "tool", uuid: "t2" }, { kind: "user", md: "", uuid: "uImg", images: [{}] }, { kind: "tool", uuid: "t3" }];
-  assert.deepEqual(injectionGroups(imgLanded, reconcilePending(imgLanded, [b]).inject), [{ idx: 5, sends: [b] }], "below the image's atom once it lands");
-  // (2) a resident verdict counted at the press may be retired by the kernel: the group test must not then read a
-  // copy queued AFTER the press as a press-time one
-  const withVerdict: TailEvent[] = [tail[0], { kind: "user", md: "F", uuid: "echo:F0", undelivered: true }, { kind: "queued", texts: [{ md: "F" }] }];
-  const c = newPending("mine", undefined, T0 + 1); reconcilePending(withVerdict, [c]);
-  const verdictGone: TailEvent[] = [tail[0], { kind: "user", md: "F", uuid: "uF" }, { kind: "tool", uuid: "t1" }, { kind: "queued", texts: [{ md: "F" }] }];
-  // the group still shows a copy of F, so uF is read as someone else's landing and the bubble stays below the group
-  // (the known limit: the kernel's queued copies carry no identity — fourth review)
-  assert.deepEqual(injectionGroups(verdictGone, reconcilePending(verdictGone, [c]).inject), [{ idx: 4, sends: [c] }], "below the group while it shows a copy of F");
-  // (3) an earlier send's never-delivered verdict, seen already flagged (a reconnect): a floor for the later send
-  const [p3, b3] = press([tail[0]], "first", "second");
-  const lostFirst: TailEvent[] = [tail[0], { kind: "user", md: "first", uuid: "echo:P", undelivered: true }];
-  const r = reconcilePending(lostFirst, [p3, b3]);
-  assert.deepEqual(r.lost, [p3]);
-  assert.deepEqual(b3.floors?.map((f) => f.uuid), ["echo:P"]);
-  assert.deepEqual(injectionGroups(lostFirst, r.inject), [{ idx: 2, sends: [b3] }], "below the verdict bubble, exactly as below the unflagged echo");
-  // (4) the CLI replaces only the path and leaves the delimiters: both sides keep them
-  for (const [q, l] of [["look (/tmp/a.png)", "look ()"], ["look `/tmp/a.png`", "look ``"], ["look '/tmp/a.png'", "look ''"], ["look \"/tmp/a.png\"", "look \"\""], ["look /tmp/a.png,", "look ,"]])
-    assert.equal(foreignKey(q), foreignKey(l), q);
-  assert.notEqual(foreignKey("design.png.bak notes"), foreignKey("notes"), "not a path: an ordinary token stays");
-});
-
-test("a copy still shown in the group holds the bubble below it, and copies are counted per block (T252b fourth review)", () => {
-  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
-  // (1) an identical text the kernel had already FED lands first (its echo was hidden behind the queued copy): that
-  // landing is not the queued copy's — the group still shows the press-time F, so the bubble stays below the group,
-  // and below the queued copy's own atom once it lands
-  const fed: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "F" }] }];
-  const a = newPending("mine", undefined, T0); reconcilePending(fed, [a]);
-  const fedLanded: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1", absorbed: true }, { kind: "queued", texts: [{ md: "F" }, { md: "mine", hiddenByPending: true }] }];
-  assert.deepEqual(injectionGroups(fedLanded, reconcilePending(fedLanded, [a]).inject), [{ idx: 3, sends: [a] }], "still below the group");
-  const bothLanded: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1", absorbed: true }, { kind: "tool", uuid: "t1" }, { kind: "user", md: "F", uuid: "uF2" }, { kind: "tool", uuid: "t2" }];
-  assert.deepEqual(injectionGroups(bothLanded, reconcilePending(bothLanded, [a]).inject), [{ idx: 4, sends: [a] }], "below the second F once the group has drained");
-  // (2) two press-time copies of F land as ONE record with two blocks: that is two carriers, so a third F queued
-  // after the press is later than the send
-  const two: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "F" }, { md: "F" }] }];
-  const b = newPending("mine", undefined, T0 + 1); reconcilePending(two, [b]);
-  const oneRecord: TailEvent[] = [...tail, { kind: "user", md: "F F", uuid: "uFF", blocks: ["F", "F"] }, { kind: "tool", uuid: "t1" }];
-  assert.deepEqual(injectionGroups(oneRecord, reconcilePending(oneRecord, [b]).inject), [{ idx: 2, sends: [b] }], "after the record that holds both copies");
-  const thirdLanded: TailEvent[] = [...tail, { kind: "user", md: "F F", uuid: "uFF", blocks: ["F", "F"] }, { kind: "tool", uuid: "t1" }, { kind: "user", md: "F", uuid: "uF3" }, { kind: "tool", uuid: "t2" }];
-  assert.deepEqual(injectionGroups(thirdLanded, reconcilePending(thirdLanded, [b]).inject), [{ idx: 2, sends: [b] }], "…and above a third F queued after the send");
-  // a floor's ordinal counts blocks the same way: X's landing in a two-block record with an older same-text copy
-  const [x, y] = press(tail, "first", "second");
-  const xTwice: TailEvent[] = [...tail, { kind: "user", md: "first first", uuid: "uXX", blocks: ["first", "first"] }, { kind: "tool", uuid: "t1" }];
-  const r = reconcilePending(xTwice, [x, y]);
-  assert.deepEqual(y.floors?.map((f) => [f.uuid, f.ord]), [["uXX", 2]], "two copies in the record count as two");
-  assert.deepEqual(injectionGroups(xTwice, r.inject), [{ idx: 2, sends: [y] }]);
-});
+// ── (5) the bubble sits at the TAIL (T252d): render.ts appends one bare group after every kernel event ──
 
 // ── (T252c) identity from the kernel: qid on the queued copies and on the landed atom ─────────────
-
-test("the two limits fall with identities: a same-text copy queued later, and both landings in one frame (T252c)", () => {
-  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
-  // (1) another client's F is queued (qid f1); we press; F lands (the atom carries qid f1); another client queues
-  // F AGAIN (qid f2) — by text the group still "shows F"; by identity the press-time copy has landed
-  const queued: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "F", qid: "f1", qts: 1 }] }];
-  const mine = newPending("mine", undefined, T0);
-  reconcilePending(queued, [mine]);
-  assert.deepEqual(mine.at?.queuedForeignIds, ["f1"], "the copies' ids are recorded at the press");
-  const again: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1", qid: "f1" }, { kind: "tool", uuid: "t1" },
-                              { kind: "queued", texts: [{ md: "mine", qid: "m1", qts: 2, hiddenByPending: true }, { md: "F", qid: "f2", qts: 3 }] }];
-  assert.deepEqual(injectionGroups(again, reconcilePending(again, [mine]).inject), [{ idx: 2, sends: [mine] }], "right after the press-time copy's landing, above the newer F");
-  const echoed: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1", qid: "f1" }, { kind: "tool", uuid: "t1" }, { kind: "user", md: "F", uuid: "echo:f2" }];
-  assert.deepEqual(injectionGroups(echoed, reconcilePending(echoed, [mine]).inject), [{ idx: 2, sends: [mine] }], "…and above the newer F's echo");
-  // (2) the reconnect: a fed same-text copy (no id we saw) and the press-time copy (qid f1) both land in ONE frame
-  const both: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF0", qid: "f0" }, { kind: "tool", uuid: "t1" }, { kind: "user", md: "F", uuid: "uF1", qid: "f1" }, { kind: "tool", uuid: "t2" }];
-  const late = newPending("mine", undefined, T0 + 1);
-  reconcilePending(queued, [late]);
-  assert.deepEqual(injectionGroups(both, reconcilePending(both, [late]).inject), [{ idx: 4, sends: [late] }], "below the copy we were queued behind, by its id, whatever landed first");
-  // without ids the same frames degrade to today's reading (the legacy path, an older kernel)
-  const strip = (evs: TailEvent[]): TailEvent[] => evs.map((e) => ({ ...e, qid: undefined, texts: e.texts?.map((t) => ({ ...t, qid: undefined })) }));
-  const legacy = newPending("mine", undefined, T0 + 2);
-  reconcilePending(strip(queued), [legacy]);
-  assert.deepEqual(legacy.at?.queuedForeignIds, []);
-  assert.deepEqual(injectionGroups(strip(again), reconcilePending(strip(again), [legacy]).inject), [{ idx: 4, sends: [legacy] }], "legacy: below the group while it shows a copy of F");
-  const legacy2 = newPending("mine", undefined, T0 + 3);
-  reconcilePending(strip(queued), [legacy2]);
-  assert.deepEqual(injectionGroups(strip(both), reconcilePending(strip(both), [legacy2]).inject), [{ idx: 2, sends: [legacy2] }], "legacy: the first landing is read as the copy's");
-});
 
 test("our own send's identity is latched from the kernel's first copy and then rules landing, cover and hiding (T252c)", () => {
   const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
@@ -563,18 +197,6 @@ test("our own send's identity is latched from the kernel's first copy and then r
   assert.deepEqual(r.landed.map((l) => l.idx), [1]);
 });
 
-test("floors carry the earlier send's identity and follow it through the echo → landed swap exactly (T252c)", () => {
-  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
-  const [x, y] = press(tail, "first", "second");
-  let r = reconcilePending([...tail, { kind: "user", md: "first", uuid: "echo:x1" }], [x, y]);
-  assert.equal(x.qid, "echo:x1");
-  assert.deepEqual(y.floors?.map((f) => [f.uuid, f.qid]), [["echo:x1", "echo:x1"]]);
-  dropPending([x, y], "first", x.ts);   // the ✕ the kernel could not honour
-  // X's atom lands under a new uuid but with X's id, behind an unrelated same-text message that has none of it
-  const frame: TailEvent[] = [...tail, { kind: "user", md: "first", uuid: "uOther" }, { kind: "tool", uuid: "t1" }, { kind: "user", md: "first", uuid: "uX", qid: "echo:x1" }, { kind: "tool", uuid: "t2" }];
-  assert.deepEqual(injectionGroups(frame, reconcilePending(frame, [y]).inject), [{ idx: 4, sends: [y] }], "below X's own atom, found by id, not the first same-text one");
-});
-
 test("identity edges: a copy without an id beside an echo, a landing carrying several ids, and an identified copy whose landing lost its id (T252c review)", () => {
   const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
   // the tmux route: the queued copy carries a stamp but no id, the echo a random uuid, the landing nothing — text decides
@@ -594,24 +216,6 @@ test("identity edges: a copy without an id beside an echo, a landing carrying se
   assert.deepEqual([x.qid, y.qid], ["q1", "q2"]);
   r = reconcilePending([...tail, { kind: "user", md: "one two", uuid: "uXY", blocks: ["one", "two"], qids: ["q1", "q2"] }], [x, y]);
   assert.deepEqual(r.landed.map((l) => [l.p.text, l.idx]), [["one", 1], ["two", 1]]);
-  // an identified press-time copy whose landing carries no id (a kernel restart between feed and landing): the text
-  // floor still holds — the bubble stays below that message, never jumps above it
-  const z = newPending("mine", undefined, T0 + 5);
-  reconcilePending([...tail, { kind: "queued", texts: [{ md: "F", qid: "f1", qts: 1 }] }], [z]);
-  const lostId: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF" }, { kind: "tool", uuid: "t1" }];
-  assert.deepEqual(injectionGroups(lostId, reconcilePending(lostId, [z]).inject), [{ idx: 2, sends: [z] }]);
-  // …while an identified copy whose landing DOES carry the id ignores the text path (the newer-copy case stays exact)
-  const withId: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF", qid: "f1" }, { kind: "tool", uuid: "t1" }, { kind: "queued", texts: [{ md: "F", qid: "f2", qts: 9 }] }];
-  assert.deepEqual(injectionGroups(withId, reconcilePending(withId, [z]).inject), [{ idx: 2, sends: [z] }]);
-});
-
-test("a bubble that changes slot marks the view stale, so the incremental repaint never trusts a shifted prefix (second review)", () => {
-  // chatTail lowers v.rendered to the kernel index and the normal-mode append path re-renders from there, assuming
-  // the DOM prefix still matches s.events — which also requires the bubble's SLOT to be unchanged. The settle
-  // signature therefore carries each group's slot beside its texts.
-  const fn = RENDER.split("function reconcileOptimistic(")[1].split("\nfunction ")[0];
-  assert.match(fn, /settle\(groups\.flatMap\(\(g\) => g\.sends\.map\(\(p\) => g\.idx \+ ":" \+ p\.text\)\)\);/);
-  assert.match(fn, /const groups = injectionGroups\(s\.events as TailEvent\[\], inject\);/);
 });
 
 test("queuedCopyToHide: the newest not-yet-hidden copy of the text, never a copy the kernel marked non-cancelable", () => {
@@ -631,12 +235,12 @@ test("queuedCopyToHide: the newest not-yet-hidden copy of the text, never a copy
   assert.match(RENDER, /const inject = r\.inject\.filter\(\(p\) => !covered\.has\(p\)\);/);
 });
 
-test("the kernel's queued copy at the tail is hidden for a send drawn in place — one bubble per message (T252)", () => {
+test("the kernel's queued copy at the tail is hidden for a send drawn as our own bubble — one bubble per message (T252)", () => {
   const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
   const list = press(tail, TEXT);
   const r = reconcilePending([...tail, { kind: "tool", uuid: "t1" }, { kind: "queued", texts: [{ md: TEXT }] }], list);
   assert.equal(list[0].received, true, "the kernel's copy proves receipt");
-  assert.deepEqual(r.inject, [list[0]], "…but ours stays drawn, at its slot");
+  assert.deepEqual(r.inject, [list[0]], "…but ours stays drawn, at the tail");
   assert.deepEqual(r.unqueue, [list[0]], "and the caller drops the kernel's tail copy for it");
   // an ECHO atom covers ours as before: the kernel draws that atom itself, at the send time
   const r2 = reconcilePending([...tail, { kind: "user", md: TEXT, uuid: "echo:1" }], press(tail, TEXT));
@@ -644,10 +248,12 @@ test("the kernel's queued copy at the tail is hidden for a send drawn in place �
   assert.equal(r2.unqueue.length, 0);
 });
 
-test("render.ts draws the bubble at its slot, strips its own injections before applying kernel indices, and carries no header or cue", () => {
-  assert.match(RENDER, /const groups = injectionGroups\(s\.events as TailEvent\[\], inject\);\s*\n\s*for \(const g of groups\)\s*\n\s*s\.events\.splice\(g\.idx, 0, \{ kind: "queued", bare: true, texts: g\.sends\.map\(mk\), uuid: OPT_PREFIX \+ g\.sends\[0\]\.ts/,
-    "the bare group is spliced at the slot, never pushed at the tail");
-  assert.doesNotMatch(RENDER, /s\.events\.push\(\{ kind: "queued", bare: true/, "no tail push remains");
+test("render.ts appends the pending sends as ONE bare group at the tail, in send order; strips its own injections before applying kernel indices; carries no header or cue (T252d)", () => {
+  assert.match(RENDER, /s\.events\.push\(\{ kind: "queued", bare: true, texts: inject\.map\(mk\), uuid: OPT_PREFIX \+ inject\[0\]\.ts/,
+    "one bare group pushed at the tail, the sends in list (send) order");
+  assert.doesNotMatch(RENDER, /injectionGroups|placementIndex/, "the send-slot placement machinery is gone from render.ts");
+  const fn = RENDER.split("function reconcileOptimistic(")[1].split("\nfunction ")[0];
+  assert.match(fn, /settle\(inject\.map\(\(p\) => p\.text\)\);/, "the repaint signature is the texts alone: the tail slot moves with every push by design");
   assert.match(RENDER, /function stripOptimistic\(s: Session\): void \{/, "one strip, used by every ingest path");
   const tail = RENDER.slice(RENDER.indexOf("function chatTail(msg: any) {"), RENDER.indexOf("s.events.length = from;"));
   assert.match(tail, /stripOptimistic\(s\);/, "the delta's kernel index is applied to KERNEL events only — a mid-array bubble would shift it");
@@ -910,7 +516,7 @@ test("a send pressed against no frame (a placeholder tab): the first frame's cop
   // a first frame that predates the send entirely stamps exactly as a press-time stamp would
   list = [late()];
   reconcilePending([frame[0], frame[1]], list);
-  assert.deepEqual(list[0].at, { after: "a1", place: "u-old", placeText: TEXT, placeOrd: 0, queuedForeign: [], queuedForeignIds: [], queuedResident: {}, seen: ["u-old"], queued: 0 });
+  assert.deepEqual(list[0].at, { after: "a1", seen: ["u-old"], queued: 0 });
   // a press-time stamp reads no stamp: its frame predates the press by construction, so an identical
   // message that landed within the press's own second is still background
   const prompt = press([frame[1], { kind: "user", md: TEXT, uuid: "u-same-second", ts: isoAt(Math.floor(T0 / 1000)) }], TEXT);
@@ -960,7 +566,7 @@ test("a late stamp presumes the first frame's newest queued copy of the text is 
   // follows covers it, exactly as at a press-time stamp
   const early = [late()];
   let r = reconcilePending([step], early);
-  assert.deepEqual(early[0].at, { after: "a1", place: null, placeText: undefined, placeOrd: 0, queuedForeign: [], queuedForeignIds: [], queuedResident: {}, seen: [], queued: 0 });
+  assert.deepEqual(early[0].at, { after: "a1", seen: [], queued: 0 });
   assert.equal(r.inject.length, 1);
   r = reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }] }], early);
   assert.equal(r.inject.length, 1);
@@ -1126,25 +732,6 @@ test("a send covered by its identified copy holds that copy's position: a later 
   assert.deepEqual([r.landed.map((l) => l.p), r.keep], [[d], [c]], "the landing wearing d's id is d's, whatever the list order");
 });
 
-test("floors follow an earlier send's identity into a record of several sends, and an id-less press-time copy keeps its text floor beside an identified one (T252c third review)", () => {
-  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
-  const [x, y] = press(tail, "first", "second");
-  reconcilePending([...tail, { kind: "user", md: "first", uuid: "echo:x1" }], [x, y]);
-  assert.deepEqual(y.floors?.map((f) => f.qid), ["echo:x1"]);
-  dropPending([x, y], "first", x.ts);
-  // X's block lands inside a two-send record, behind an unrelated same-text message
-  const frame: TailEvent[] = [...tail, { kind: "user", md: "first", uuid: "uOther" }, { kind: "tool", uuid: "t1" },
-                              { kind: "user", md: "first and more", uuid: "uXZ", blocks: ["first", "and more"], qids: ["echo:x1", "echo:z1"] }, { kind: "tool", uuid: "t2" }];
-  assert.deepEqual(injectionGroups(frame, reconcilePending(frame, [y]).inject), [{ idx: 4, sends: [y] }], "below the record carrying X's id");
-  // a press against a group holding an identified F and an id-less F: the identified one lands by id while the other
-  // is still queued — the bubble stays below the group (the id-less copy's text floor), never above it
-  const queued: TailEvent[] = [...tail, { kind: "queued", texts: [{ md: "F", qid: "f1", qts: 1 }, { md: "F" }] }];
-  const mine = newPending("mine", undefined, T0 + 9);
-  reconcilePending(queued, [mine]);
-  const after: TailEvent[] = [...tail, { kind: "user", md: "F", uuid: "uF1", qid: "f1" }, { kind: "tool", uuid: "t1" }, { kind: "queued", texts: [{ md: "F" }] }];
-  assert.deepEqual(injectionGroups(after, reconcilePending(after, [mine]).inject), [{ idx: 4, sends: [mine] }], "below the group while the id-less press-time copy is still queued");
-});
-
 test("the ✕ on the kernel's copy of an identified send drops THAT send's entry, by id (T252c third review)", () => {
   const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
   const [p1, p2, p3] = press(tail, "ok", "ok", "ok");
@@ -1155,4 +742,19 @@ test("the ✕ on the kernel's copy of an identified send drops THAT send's entry
   assert.equal(dropPending(list, "ok", undefined, "echo:zz"), p3, "an id no entry latched falls to the first entry still WITHOUT an id — never one that owns another");
   assert.equal(dropPending(list, "ok", undefined, "echo:zz"), undefined, "…and to nothing once every entry owns its id");
   assert.deepEqual(list, [p1]);
+});
+
+// ── (T252d) the landed bubble's hover names the send time ─────────────────────────────────────────
+
+test("the landed bubble's hover says when the message was SENT, once the landing is more than a minute later (T252d)", () => {
+  const ts = "2026-09-08T10:05:30.000Z";
+  const at = Math.floor(Date.parse(ts) / 1000);
+  assert.equal(sentAtLabel(ts, at - 30), null, "half a minute apart: no hover");
+  assert.equal(sentAtLabel(ts, at - 60), null, "exactly a minute: no hover");
+  const label = sentAtLabel(ts, at - 61);
+  assert.ok(label && label.startsWith("sent at ") && /\d\d:\d\d$/.test(label), "more than a minute: 'sent at HH:MM' — " + label);
+  assert.equal(sentAtLabel(undefined, at), null);
+  assert.equal(sentAtLabel(ts, undefined), null);
+  // render.ts applies it to the landed user bubble's title, from the kernel's two stamps (never the client's clock)
+  assert.match(RENDER, /const sentTip = sentAtLabel\(ev\.ts, ev\.sentAt\);\s*\n\s*if \(sentTip\) bubble\.title = sentTip;/);
 });

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -1,4 +1,5 @@
 // The chat's client-side PENDING SEND (render.ts registerOptimistic / reconcileOptimistic): a composer
+import { markerLabel } from "./time-marker";
 // send shows its bubble the instant Enter is pressed and re-asserts it on every push until the kernel's
 // payload accounts for the message. The DECISIONS live here, pure, so send-pending.test.ts executes
 // them (the repo's extract-for-execution idiom); render.ts owns the DOM and the per-session maps.
@@ -17,8 +18,17 @@
 // guard in prune_live), but if it blinks, ours steps straight back in; a copy seen after the press also
 // proves the kernel RECEIVED that one send (`received`, attributed per send like a landing). Nothing here
 // reads a clock for a press-time entry: the frame resident at the press is older than the send by
-// construction, so its anchor AND its placement floor are recorded by identity; only a LATE stamp (stampBase)
-// compares stamps to order events.
+// construction, so its anchor is recorded by identity; only a LATE stamp (stampBase) compares stamps to
+// order events.
+//
+// WHERE THE BUBBLE IS DRAWN is not decided here (T252d, the user 2026-09-08): render.ts appends every
+// pending send as one bare group at the TAIL, below every event the kernel has shown, in send order — and
+// the kernel places the landed atom at its LANDING time, the moment the CLI took the message, which is that
+// same tail position, so nothing moves on landing and the order on screen is the order the model read.
+// (T252/T252b drew the bubble at its SEND slot, above the steps that ran while the CLI held it, with an
+// anchor, a placement floor and a foreign-queue reading to hold it there; the user's call was that the
+// message belongs where the model read it, so that machinery is gone.) The bubble's hover names the send
+// time once the atom has landed more than a minute later (sentAtLabel).
 //
 // THE ANCHOR (2026-09-06 review): every decision is read from the events AFTER the send, never from a
 // count of tail events. At the first reconcile after the press the entry records the uuid of the last
@@ -28,53 +38,20 @@
 // not in `seen`. ONE RECORD CAN CARRY SEVERAL SENDS (2026-09-07 review): the CLI takes back-to-back
 // sends at one boundary as one user record with a text block each, and the kernel ships those blocks
 // (`blocks`); such a record is as many copies as it has matching blocks, and `seen` lists its uuid once
-// per copy already spoken for. The old form read the last 30 events and assumed the landing was near the tail — but an
-// absorbed atom is placed at its SEND time, so after a gap in pushes (a sleep, a reconnect, a turn with
-// many thinking and tool events) it sat far above the tail and, with the lifetime gone, the bubble never
-// ended. When the anchor itself has left the resident window (the transcript grew past the wire tail),
-// everything resident is after it, so the scan starts at the head.
+// per copy already spoken for. The old form read the last 30 events and assumed the landing was near the
+// tail — and with the lifetime gone, a landing further up (a gap in pushes: a sleep, a reconnect, a turn
+// with many thinking and tool events) never ended the bubble. When the anchor itself has left the resident
+// window (the transcript grew past the wire tail), everything resident is after it, so the scan starts at
+// the head.
 
 export type SendBase = {
   after: string | null;   // uuid of the last stable kernel event at the press; null → nothing to anchor on, scan from the head
-  place: string | null;   // PLACEMENT FLOOR: uuid of the last USER event at the press, an echo included (T252 second
-                          //   review) — older than this send, so the bubble is drawn below it; the anchor skips echoes
-                          //   (not a stable place to bound the landing scan), but for placement an echo is exactly the
-                          //   earlier send the bubble must follow. null → no user event at the press, the anchor rules
-  placeText?: string;     // that event's text: when its uuid leaves (the echo → landed swap), the landed atom carrying
-                          //   the same text after the anchor is the floor…
-  placeOrd?: number;      //   …found by ORDINAL: how many same-text user events sit after the anchor through the floor
-                          //   at the press (the floor itself included). Events before the floor only ever swap echo →
-                          //   landed in place, so the k-th match stays the floor while a LATER send of the same text
-                          //   (its echo, its atom) lands beyond it and is never taken (third review). 0 → the floor sits
-                          //   at or above the anchor, which already covers it: no fallback
-  queuedForeign: string[]; // the texts of every visible copy the kernel's tail queue held at the press, one entry
-                          //   per copy (a queued romp nudge, another client's message, an earlier press of this
-                          //   client, a queue predating a page reload): at a press-time stamp every one of them
-                          //   predates the press, so the send runs after them all — its bubble is drawn below that
-                          //   group while a press-time copy is still queued and below their atoms once they land
-                          //   (T252b). A LATE stamp leaves out the newest `own` copies of this send's text, the
-                          //   ones the queued presumption reads as this press's. The group carries no uuid and is
-                          //   no user event, so neither the anchor nor the floor ever saw it
-  queuedForeignIds: string[]; // the IDS of the copies the tail queue held at the press, when the kernel gave them one
-                          //   (T252c: qid on each queued copy, the same id its echo and its landed atom carry): the
-                          //   exact reading — a copy is still queued while the group shows its id, and has landed
-                          //   when a user event carries it — with no text or ordinal involved. Copies without an id
-                          //   (an older kernel, a queue restored after a kernel death) stay in queuedForeign and take
-                          //   the text path
-  queuedResident?: Record<string, string[]>; // per foreign key: the uuids of user events after the anchor that
-                          //   already carried the text AT THE PRESS (a never-delivered verdict for an earlier copy) —
-                          //   not the queued copies' landings, so placement's ordinal counts them out while they are
-                          //   still present; the kernel retires a verdict once a same-text record lands, and a
-                          //   retired one must not keep the count unreachable (second and third reviews)
   seen: string[];         // uuids of the user events carrying the text that are background for this send: what
                           //   the press found, and what an earlier same-text entry claimed since — ONE ENTRY PER
                           //   COPY (a record of several sends lists its uuid once per spoken-for block)
   queued: number;         // copies of the text the kernel's queued bubble(s) already listed at the press
 };
 
-/** A placement floor recorded from an earlier send's kernel event: found by uuid, else by the `ord`-th user
- *  event after the anchor carrying `text` (the echo → landed swap keeps the position, changes the uuid). */
-export type Floor = { uuid: string; text?: string; ord: number; qid?: string };   // qid: the earlier send's identity, followed exactly through the echo → landed swap
 
 export type PendingSend = {
   text: string;        // the sent body, byte for byte — what the kernel echoes and the transcript lands
@@ -93,11 +70,6 @@ export type PendingSend = {
                        //   on the landing, the cover and the hidden copy are decided by id (an event that carries an id
                        //   is ours only if it carries THIS one); an event without an id (an older kernel, tmux) keeps
                        //   deciding by text
-  floors?: Floor[];    // kernel user events that belong to EARLIER-registered pending sends — their covering
-                       //   echoes and their landed atoms, recorded as they are claimed (T252b): an earlier send's
-                       //   message sits above this one whatever its text, so its bubble is drawn below them. Each
-                       //   carries the event's text and its ordinal among same-text user events after this send's
-                       //   anchor, so the echo → landed swap is followed even when the earlier entry is gone (its ✕)
   received?: boolean;  // the kernel has shown a copy of the text attributed to THIS send (an echo atom or
                        //   a queued copy after the press that no earlier same-text send claimed): the send
                        //   reached it, so a connection drop before or after cannot have lost it — `lost` is
@@ -112,59 +84,29 @@ export type TailEvent = {
   qid?: string;         // a landed user atom: the id of the queued copy it lands (T252c; the kernel pairs them)
   qids?: (string | null)[];   // a record of SEVERAL sends: one id (or null) per text block, in block order
   ts?: string;          // the kernel's stamp for the event, ISO-8601 UTC (kernel.py `iso(t)`, whole seconds)
-  absorbed?: boolean;
+  absorbed?: boolean;   // a mid-turn send the CLI spliced in: placed at its landing (T252d)
+  sentAt?: number;      // …with the send time beside it (epoch s), for the bubble's hover
   undelivered?: boolean;
   images?: unknown[];
-  texts?: { md?: string; hiddenByPending?: boolean; qid?: string; qts?: number; cancelable?: boolean }[];   // qid/qts: the copy's identity (T252c); hiddenByPending: render.ts hid this copy for a send drawn in place
+  texts?: { md?: string; hiddenByPending?: boolean; qid?: string; qts?: number; cancelable?: boolean }[];   // qid/qts: the copy's identity (T252c); hiddenByPending: render.ts hid this copy for a send drawn as our own bubble
   blocks?: string[];    // a user record the CLI wrote from SEVERAL sends taken at one boundary: one text per
                         //   block (kernel.py build_session ships them when there are two or more); `md` is
                         //   the blocks joined, so each block is a copy of its own send
 };
 
 export const OPT_PREFIX = "optimistic:";
+
+/** The landed bubble's hover (T252d): "sent at HH:MM" when the atom's landing (`ts`, where it is placed) is more
+ *  than a minute after the send (`sentAt`, both kernel stamps — never the client's clock); null otherwise. */
+export function sentAtLabel(ts: string | undefined, sentAt: number | undefined): string | null {
+  if (!ts || sentAt === undefined || sentAt === null) return null;
+  const landed = Date.parse(ts);
+  if (isNaN(landed) || Math.floor(landed / 1000) - sentAt <= 60) return null;
+  return "sent at " + markerLabel(sentAt, null, sentAt * 1000).hm;   // `hm` is the bare HH:MM: no clock read (the module reads none)
+}
 export const isOptimisticUuid = (u?: string): boolean => !!u && u.startsWith(OPT_PREFIX);
 export const isKernelEchoUuid = (u?: string): boolean => !!u && u.startsWith("echo:");
 const collapse = (s: string): string => s.replace(/\s+/g, " ").trim();
-/** The text a kernel event and a queued copy share once the kernel's wrapping is set aside (T252b review):
- *  - a romp-marked text (a nudge, a follow-up: `<!-- romp-… -->` in its tail) is queued as its split BODY but
- *    landed with the full text — a LEADING `> ` goal-quote block, the body, the marker comments (the kernel
- *    splits a landed record only for a human author). The comments go, and the leading quote block goes only
- *    when a romp marker is present — the kernel's own gate; a blockquote the user typed is part of their text;
- *  - the CLI's image chips (`[Image #N]`) and image paths go: an image-bearing message is queued with the path
- *    or the chip and landed with the chips stripped (kernel.py, images present), the same asymmetry
- *    landedCopies sets aside for this client's own sends. */
-export const foreignKey = (s: string): string => {
-  const marked = /<!--\s*romp-/.test(s);
-  let t = s.replace(/<!--[\s\S]*?-->/g, " ");
-  if (marked) {
-    const lines = t.split("\n");
-    let i = 0;
-    while (i < lines.length && (/^\s*>/.test(lines[i]) || (i > 0 && !lines[i].trim()))) i++;
-    if (i > 0 && lines.slice(0, i).some((l) => /^\s*>/.test(l))) t = lines.slice(i).join("\n");
-  }
-  // the CLI's own extraction (kernel _IMG_PATH_RE): a leading delimiter, a path from `/` or `~/`, the extension
-  // at a word boundary — only the PATH is replaced, so whatever delimiter wrapped it stays on both sides
-  t = t.replace(/\[Image #\d+\]/g, "").replace(/(^|[\s'"`(])((?:~\/|\/)[^\s'"`()]+\.(?:png|jpe?g|gif|webp))\b/gi, "$1");
-  return collapse(t.replace(/"/g, ""));   // a quoted path may leave its quotes behind: set aside on both sides (noq)
-};
-/** Whether a user event carries `text` (on the foreignKey) in its md or any of its blocks — a record the CLI
- *  wrote from several queued messages taken at one boundary lists each as a block (T252b review). */
-const carriesText = (e: TailEvent, text: string): boolean => carriedCopies(e, text) > 0;
-/** How many copies of `text` (on the foreignKey) a user event carries: one when its md IS the text, else one per
- *  matching block — a record the CLI wrote from several queued messages taken at one boundary is as many copies
- *  as it has matching blocks, the shape textCopies reads for this client's own sends (fourth review). */
-const carriedCopies = (e: TailEvent, text: string): number => {
-  if (e.kind !== "user" || isOptimisticUuid(e.uuid)) return 0;
-  const k = foreignKey(text);
-  // an image-only text keys to nothing: only an event that carries images can be its carrier — a reminders-only
-  // user record (a task notification landed mid-turn, md "") is not (the kernel's own by-text prune refuses an
-  // empty key the same way; third review)
-  if (!k) return Array.isArray(e.images) && e.images.length > 0 && (!e.md || !foreignKey(e.md)) ? 1 : 0;
-  if (typeof e.md === "string" && foreignKey(e.md) === k) return 1;
-  let n = 0;
-  if (Array.isArray(e.blocks)) for (const b of e.blocks) if (typeof b === "string" && foreignKey(b) === k) n++;
-  return n;
-};
 
 /** `text` with its shipped image paths removed (quoted or bare, however the composer joined them). */
 export function pendingBody(text: string, imgPaths?: string[]): string {
@@ -306,20 +248,6 @@ export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.l
   const beforeSend = (e: TailEvent): boolean => { const s = eventSecond(e); return s === null || s < pressS; };
   let after: string | null = null;
   for (let i = events.length - 1; i >= 0; i--) if (stableUuid(events[i]) && beforeSend(events[i])) { after = events[i].uuid!; break; }
-  let place: string | null = null, placeText: string | undefined, placeOrd = 0;
-  let floorIdx = -1;
-  for (let i = events.length - 1; i >= 0; i--) {
-    const e = events[i];
-    if (e.kind === "user" && e.uuid && !isOptimisticUuid(e.uuid) && beforeSend(e)) { place = e.uuid; placeText = typeof e.md === "string" ? e.md : undefined; floorIdx = i; break; }
-  }
-  if (floorIdx >= 0 && placeText !== undefined) {
-    let anchorIdx = -1;
-    if (after !== null) for (let i = events.length - 1; i >= 0; i--) if (events[i].uuid === after) { anchorIdx = i; break; }
-    for (let i = anchorIdx + 1; i <= floorIdx; i++) {
-      const e = events[i];
-      if (e.kind === "user" && !isOptimisticUuid(e.uuid) && typeof e.md === "string" && sameText(e.md, placeText)) placeOrd++;
-    }
-  }
   const seen: string[] = [];
   let queued = 0;
   for (const e of events) {
@@ -328,42 +256,10 @@ export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.l
     const n = copiesIn(e, p);
     for (let k = 0; k < n; k++) seen.push(e.uuid);   // once per COPY: a record of several sends is several
   }
-  // every visible copy the tail queue held at the press is ahead of this send (T252b): a press-time frame
-  // predates the press by construction, so none of them is this send's — a same-text copy is an older send's
-  // (another client, an earlier press). A late stamp leaves out the newest `own` copies of this text (the
-  // queued presumption). Beside them, the carriers of each text already resident after the anchor: those
-  // are not the queued copies' landings, so placement counts them out (second review).
-  const queuedForeign: string[] = [];
-  const queuedForeignIds: string[] = [];
-  const queuedResident: Record<string, string[]> = {};
-  for (let i = events.length - 1; i >= 0; i--) {
-    const e = events[i];
-    if (e.kind !== "queued") continue;
-    let skipOwn = p.late ? own : 0;
-    const copies = (e.texts || []).filter((t) => typeof t.md === "string" && !t.hiddenByPending);
-    for (let k = copies.length - 1; k >= 0; k--) {
-      const md = copies[k].md as string;
-      if (skipOwn > 0 && foreignKey(md) === foreignKey(p.text)) { skipOwn--; continue; }
-      if (copies[k].qid) queuedForeignIds.unshift(copies[k].qid!);   // an identified copy takes the id path first (T252c)…
-      queuedForeign.unshift(md);                                     //   …and every copy keeps the text path as its fallback
-    }
-    break;
-  }
-  if (queuedForeign.length) {
-    let anchorIdx = -1;
-    if (after !== null) for (let i = events.length - 1; i >= 0; i--) if (events[i].uuid === after) { anchorIdx = i; break; }
-    for (const f of queuedForeign) {
-      const k = foreignKey(f);
-      if (k in queuedResident) continue;
-      const us: string[] = [];
-      for (let i = anchorIdx + 1; i < events.length; i++) if (carriesText(events[i], f) && events[i].uuid) us.push(events[i].uuid!);
-      queuedResident[k] = us;
-    }
-  }
   // the queued presumption (above): a late stamp's newest `own` copies are this press's, so the count of
   // background copies stops short of them — at zero when the frame lists fewer than presumed (the kernel
   // had not received every press yet; the copies still to come cover those entries in order)
-  return { after, place, placeText, placeOrd, queuedForeign, queuedForeignIds, queuedResident, seen, queued: Math.max(0, queued - (p.late ? own : 0)) };
+  return { after, seen, queued: Math.max(0, queued - (p.late ? own : 0)) };
 }
 
 /** The first index AFTER the send's anchor — or 0 when there is no anchor, or when the anchor has left the
@@ -376,10 +272,10 @@ export function scanFrom(events: TailEvent[], at: SendBase): number {
 
 export type Reconciled = {
   keep: PendingSend[];                        // still pending after this push
-  inject: PendingSend[];                      // …and drawn by us: not covered by the kernel's echo atom (a queued
-                                              //   copy does not cover — ours stays in place and the copy is hidden, T252)
+  inject: PendingSend[];                      // …and drawn by us, at the tail: not covered by the kernel's echo atom (a
+                                              //   queued copy does not cover — ours stays drawn and the copy is hidden, T252)
   unqueue: PendingSend[];                     // …whose kernel cover is a QUEUED copy: the caller hides that copy
-  landed: { p: PendingSend; idx: number }[];  // retired by a landing; idx = the landed event's index — the slot the bubble held
+  landed: { p: PendingSend; idx: number }[];  // retired by a landing; idx = the landed event's index
   lost: PendingSend[];                        // retired by the kernel's never-delivered verdict
 };
 
@@ -454,22 +350,6 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
     return Math.max(0, n);
   };
   const takenCopies = new Map<string, Set<number>>();  // text → queued-copy positions taken by an earlier entry THIS push
-  // an earlier entry's covering echo / landed atom is a FLOOR for every entry registered after it (T252b),
-  // recorded with its text and its ordinal among same-text user events after THAT entry's anchor, so the
-  // echo → landed swap can be followed by text when the earlier entry is gone before its atom lands (its ✕)
-  const floorFor = (owner: PendingSend, at: number) => {
-    const u = events[at].uuid;
-    if (!u) return;
-    const i = list.indexOf(owner);
-    for (const q of list.slice(i + 1)) {
-      if (!q.floors) q.floors = [];
-      if (q.floors.some((f) => f.uuid === u)) continue;
-      const text = owner.text;   // the earlier SEND's own text — a record of several sends carries it as a block, and its md is the blocks joined
-      let ord = 0;
-      if (q.at) for (let j = scanFrom(events, q.at); j <= at; j++) ord += carriedCopies(events[j], text);
-      q.floors.push({ uuid: u, text, ord, qid: owner.qid });
-    }
-  };
   for (const p of list) {
     const at = p.at!;
     const from = scanFrom(events, at);
@@ -512,7 +392,6 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
       const u = events[echoIdx].uuid;
       if (u) for (const q of list) if (q !== p && q.at && q.text === p.text && !q.at.seen.includes(u)) q.at.seen.push(u);
       if (!p.qid && u) p.qid = u;                  // the echo's uuid is the copy's id: latched (T252c)
-      floorFor(p, echoIdx);
     } else if (p.qid && idCopy >= 0) {
       covered = true; byQueued = true;              // our identified copy is in the queue: exact, whatever its position
       const k = copyIds.indexOf(p.qid);             // …and that position is spoken for on the text path this push: a later
@@ -539,14 +418,13 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
       const ck = landedIdx + "\0" + p.text;             // per text: a record of two DIFFERENT sends is one landing for each
       claimed.set(ck, (claimed.get(ck) || 0) + 1);
       r.landed.push({ p, idx: landedIdx });
-      floorFor(p, landedIdx);
       continue;
     }
-    if (lostIdx >= 0) { r.lost.push(p); floorFor(p, lostIdx); continue; }   // the verdict IS the earlier send's echo: a floor for later sends
+    if (lostIdx >= 0) { r.lost.push(p); continue; }
     r.keep.push(p);
-    // The kernel's ECHO atom covers ours: the kernel draws that atom itself, at the send time. A QUEUED copy
-    // does not: it sits in the kernel's group at the tail, and the bubble the user watches is ours, at its
-    // send slot — so ours stays drawn and the caller hides that copy, one bubble per message (T252).
+    // The kernel's ECHO atom covers ours: the kernel draws that atom itself. A QUEUED copy does not: it sits
+    // in the kernel's group at the tail, and the bubble the user watches is ours, right below — so ours stays
+    // drawn and the caller hides that copy, one bubble per message (T252).
     if (!covered || byQueued) r.inject.push(p);
     if (covered && byQueued) r.unqueue.push(p);
   }
@@ -579,143 +457,6 @@ export function dropPending(list: PendingSend[], text: string, ts?: number, qid?
   return i >= 0 ? list.splice(i, 1)[0] : undefined;
 }
 
-/** Where the caller draws the pending bubbles: each at the index right AFTER its anchor — the last stable
- *  kernel event at the press — so the steps that stream in afterwards land below it and the absorbed atom,
- *  which the kernel places at the send time, replaces it in the same slot (T252, the user 2026-09-07: the
- *  bubble used to ride the tail and then vanish, its message reappearing higher up under a header and a
- *  cue). Sends that share an anchor form ONE group, in send order; groups come highest index first, so a
- *  caller splicing them into the events array bottom-up keeps every lower index valid. No anchor (nothing
- *  stable at the press) or an anchor that left the resident window puts the bubble at the head: everything
- *  resident is later than the send (scanFrom). */
-export type InjectionGroup = { idx: number; sends: PendingSend[] };
-export function injectionGroups(events: TailEvent[], inject: PendingSend[]): InjectionGroup[] {
-  const byIdx = new Map<number, PendingSend[]>();
-  for (const p of inject) {
-    const idx = p.at ? placementIndex(events, p) : events.length;
-    const g = byIdx.get(idx);
-    if (g) g.push(p); else byIdx.set(idx, [p]);
-  }
-  return [...byIdx.entries()].sort((x, y) => y[0] - x[0]).map(([idx, sends]) => ({ idx, sends }));
-}
-
-/** The slot for one send: after its scan anchor, and after its PLACEMENT FLOOR — the last user event at the
- *  press (an earlier send's echo atom, a never-delivered bubble, a landed atom), which the anchor rule skips
- *  (an echo is not a stable place to bound the LANDING scan, since the landed atom replaces it under a new
- *  uuid) but which is older than this send all the same. Without it a second message pressed while the
- *  first's echo was the newest event sat ABOVE it until both landed (review of the first cut). The floor is
- *  found by identity: its uuid, or — once the echo has become the landed atom — the k-th user event after
- *  the anchor carrying its text, k being how many such events sat through the floor at the press (a later
- *  send of the same text lands beyond the k-th and is never taken; the last match used to be, and pulled
- *  the bubble to the tail under a newer message — third review). A floor at or above the anchor is already
- *  covered by the anchor. Never by comparing the client's clock with the kernel's stamps: the frame
- *  resident at the press is older than the send by construction, and a clock comparison re-inverted the
- *  order whenever the kernel clock led the client by more than the gap between two presses (second
- *  review). A user event that arrives after the press is a later send and stays below the bubble — with two
- *  exceptions that are older than the send all the same (T252b): an EARLIER pending send's covering echo or
- *  landed atom (`floors`, recorded as reconcilePending claims them, whatever their text), and the texts the
- *  kernel's tail queue held at the press (`queuedForeign`: the bubble sits below that group while it holds
- *  them, and below their atoms once they land — the group carries no uuid and is no user event, so the
- *  anchor and the floor never saw it, and a send was drawn above texts it runs after). */
-export function placementIndex(events: TailEvent[], p: PendingSend): number {
-  const at = p.at!;
-  const base = scanFrom(events, at);
-  let idx = base;
-  if (at.place && at.placeOrd && at.placeOrd > 0) {
-    let found = -1;
-    for (let j = events.length - 1; j >= base; j--) if (events[j].uuid === at.place) { found = j + 1; break; }
-    if (found < 0 && at.placeText !== undefined) {
-      let n = 0, last = -1;
-      for (let j = base; j < events.length; j++) {
-        const e = events[j];
-        if (e.kind === "user" && !isOptimisticUuid(e.uuid) && typeof e.md === "string" && sameText(e.md, at.placeText)) {
-          n++; last = j;
-          if (n === at.placeOrd) { found = j + 1; break; }   // the floor, under its landed uuid
-        }
-      }
-      if (found < 0 && last >= 0) found = last + 1;         // fewer matches than at the press (a pruned echo): the newest stands in
-    }
-    if (found > idx) idx = found;
-  }
-  // the k-th user event after the anchor carrying `text` (md or a block) — the ordinal reading that never takes a
-  // LATER copy of the same words; -1 when fewer than k have landed
-  const kthCarrier = (text: string, k: number): { idx: number; count: number } => {
-    let n = 0, last = -1;
-    for (let j = base; j < events.length; j++) {
-      const c = carriedCopies(events[j], text);
-      if (!c) continue;
-      n += c; last = j;
-      if (n >= k) return { idx: j, count: n };
-    }
-    return { idx: last, count: n };
-  };
-  // an earlier pending send's echo or landed atom: below it, whatever its text — by uuid, else by its text's ordinal
-  for (const f of p.floors || []) {
-    let found = -1;
-    if (f.qid) for (let j = events.length - 1; j >= base; j--) {   // by identity (T252c): the atom carrying it, alone or as one block of several
-      const e = events[j];
-      if (e.qid === f.qid || e.uuid === f.qid || (Array.isArray(e.qids) && e.qids.includes(f.qid))) { found = j + 1; break; }
-    }
-    if (found < 0) for (let j = events.length - 1; j >= base; j--) if (events[j].uuid === f.uuid) { found = j + 1; break; }
-    if (found < 0 && f.text !== undefined && f.ord > 0) { const k = kthCarrier(f.text, f.ord); if (k.idx >= 0) found = k.idx + 1; }
-    if (found > idx) idx = found;
-  }
-  // the identified copies the kernel's queue held at the press (T252c): a copy is still queued while the group shows
-  // its id, and has landed when a user event carries it — exact, no text, no count
-  // the copies that RESOLVED by id this frame leave the text path below to the rest: the text path is the fallback
-  // for an id-less copy beside them (a mixed group) or one whose landing lost its id (an older kernel's restart)
-  const resolvedCopies = new Map<string, number>();   // key → press-time copies of it the identity path placed
-  if (at.queuedForeignIds && at.queuedForeignIds.length) {
-    let groupIdx = -1;
-    for (let j = events.length - 1; j >= base; j--) if (events[j].kind === "queued") { groupIdx = j; break; }
-    for (const id of at.queuedForeignIds) {
-      let floor = -1, text: string | undefined;
-      for (let j = events.length - 1; j >= base; j--) {
-        const e = events[j];
-        if (e.qid === id || (Array.isArray(e.qids) && e.qids.includes(id))) { floor = j + 1; text = typeof e.md === "string" ? e.md : undefined; break; }
-      }
-      if (floor < 0 && groupIdx >= 0) {
-        const c = (events[groupIdx].texts || []).find((t) => t.qid === id && !t.hiddenByPending);
-        if (c) { floor = groupIdx + 1; text = c.md; }
-      }
-      if (floor > idx) idx = floor;
-      if (floor >= 0 && text !== undefined) { const k = foreignKey(text); resolvedCopies.set(k, (resolvedCopies.get(k) || 0) + 1); }
-    }
-  }
-  // the texts the kernel's queue held at the press, COUNTED per text: the press-time copies are the first k
-  // landings of that text, so the floor is the k-th carrier (never a later copy another client sent), and the
-  // group is a floor only while a press-time copy is still queued (fewer than k have landed)
-  if (at.queuedForeign && at.queuedForeign.length) {
-    const counts = new Map<string, { text: string; n: number }>();
-    for (const f of at.queuedForeign) { const k = foreignKey(f); const c = counts.get(k); if (c) c.n++; else counts.set(k, { text: f, n: 1 }); }
-    let groupIdx = -1;
-    for (let j = events.length - 1; j >= base; j--) if (events[j].kind === "queued") { groupIdx = j; break; }
-    for (const { text, n: all } of counts.values()) {
-      const key = foreignKey(text);
-      const copies = all - (resolvedCopies.get(key) || 0);   // the copies the identity path did not place: id-less ones, or one whose landing lost its id
-      if (copies <= 0) continue;
-      const residents = (at.queuedResident ||= {})[key] ||= [];
-      // The kernel's queued copies carry no identity, so which landing is the press-time copy's is read off the
-      // GROUP (fourth review): while it still shows a copy of the key, the press-time copy has not landed, so every
-      // carrier landed so far was someone else's — an identical text the kernel had already forwarded (canned
-      // texts: the Continue button, a retry, a repeated nudge) — and is learned as a resident, so the count keeps
-      // looking past it. Two costs, stated: a same-text copy another client queues after the press-time one landed
-      // reads as the press-time one and keeps this bubble below it until this send lands; and the learning needs the
-      // frame in which the group still shows the key — a socket down from before the fed copy landed until after the
-      // press-time copy was taken (a laptop asleep for a whole turn) delivers both landings at once, nothing is
-      // learned, and the bubble sits between them until this send lands (fifth review). A stamp on each queued copy
-      // would make both readings exact.
-      const groupShows = groupIdx >= 0 && (events[groupIdx].texts || []).some((t) => typeof t.md === "string" && !t.hiddenByPending && foreignKey(t.md) === key);
-      if (groupShows) for (let j = base; j < events.length; j++) { const e = events[j]; if (e.uuid && carriedCopies(e, text) && !residents.includes(e.uuid)) residents.push(e.uuid); }
-      const resident = residents.reduce((acc, u) => { const e = events.find((x) => x.uuid === u); return acc + (e ? carriedCopies(e, text) : 0); }, 0);
-      const n = copies + resident;   // the carriers resident at the press, and those learned since, come first
-      const k = kthCarrier(text, n);
-      let floor = k.idx >= 0 ? k.idx + 1 : -1;
-      if (groupShows) floor = Math.max(floor, groupIdx + 1);
-      if (floor > idx) idx = floor;
-    }
-  }
-  return idx;
-}
 
 /** Which copy of `text` in a kernel queued group the caller hides for a send drawn at its own slot: the NEWEST
  *  copy not already hidden (the group lists the queue in order; ours is the latest press with that text), or -1


### PR DESCRIPTION
A message sent while the session is mid-turn is shown where the model READ it, not where it was sent (the user's decision, 2026-09-08). Supersedes the T252/T252b in-place-at-send-position rule; the T252c per-copy identities stay.

**Design points**
- **Kernel: an absorbed atom is placed at its landing time.** Its `t` is the moment the CLI took it off the queue (the `queued_command` attachment's file-order predecessor, clamped never before the send) and `sentAt` keeps the send time. The attachment's file order is the authority: the atom sorts after every record the CLI wrote before taking it and before the assistant record that answers it; several sends taken at one boundary share its stamp in send order. `landedT`/`landedAt` are gone; the chat event ships `sentAt`.
- **The `absorbed` flag stays, its hint flips:** the atoms after the atom are the model's work after reading it — its reply. The judges' spliced-done leg is removed with the placement that made it necessary; the workless leg still refuses a done off a turn that died before its first post-splice token.
- **PLACEMENTS_V 12.** `t` is half of the segment id, so absorbed segments whose landing differs from their send change id. The seal in `_migrate_placements` keeps dormant sessions from replaying the moved atoms as new goals; `tests/test_placements_canary.py` gains a splice whose landing differs from its send, re-pins ids/atoms/units, and proves the seal (a v11 store goes through a pass under v12: planner never called, every unit sealed, no node). Goldens with absorbed atoms regenerated (`multi_input_absorbed`, `popall`). The caption task memo version steps; the postal-author heal keys absorbed atoms on `sentAt`.
- **Client: the pending bubble is pinned at the tail** — one bare group, sends in send order, below every kernel event — and the landed atom appears in that same position, so nothing moves on landing. The T252/T252b send-slot machinery comes out of `send-pending.ts` (placement floor, foreign-queue reading, floors, `injectionGroups`, `placementIndex`, `foreignKey`, `carriedCopies`, the slot in the repaint signature). Kept: the anchor and `seen`, identity-first landing/cover/hiding, queued-copy hiding, not-confirmed marking, the ✕, one bubble per message. The landed bubble's hover reads "sent at HH:MM" when the landing is more than a minute after the send. No header, no cue.
- **Docs:** `docs/read-side.md` states the read-time rule with the user's reasoning.

**Tests (red first at both ends):** `tests/test_kernel_fed_echo_absorbed.py`, `tests/test_event_model_golden.py` (order pins), `tests/test_judge_spliced_done.py`, `tests/test_placements_canary.py` (new pins + no-replay proof), `tests/test_pending_at_tail.py` (served: bubble at the tail while two steps stream in, a second send joins in send order, the landing takes the slot, a scrolled-up reader does not move, the hover names the send time), `ui/webview/send-pending.test.ts`, `ui/webview/optimistic-send.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
