### PR TITLE
The auto converge moves the local main branch, not just a detached head

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7462,11 +7462,29 @@ def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV, target="
                 refuse("the checkout was left alone: the fetch did not bring %s, so it could not be "
                        "verified; the next check re-reads main" % target, anc)
                 return
-            r = subprocess.run(["git", "checkout", "--detach", target], cwd=str(ROOT),
-                               capture_output=True, text=True, timeout=30)
+            # The local `main` BRANCH moves too (the user 2026-09-08): the converge used to check the
+            # target out DETACHED and never touch `main`, so a later `git checkout main` landed on a
+            # months-old pointer and the user pulled "an enormous amount". When main is an ANCESTOR of the
+            # target (it has nothing the target lacks) it is moved onto the target and checked out — a
+            # fast-forward by construction, so nothing of the user's is rewritten. When main has commits
+            # the target does not (diverged), it is the user's to move: the target is checked out
+            # detached as before and the notice says main was left where it is. No main at all (a
+            # bootstrap install detached at a release tag): detached, as before.
+            mb = subprocess.run(["git", "merge-base", "--is-ancestor", "main", target], cwd=str(ROOT),
+                                capture_output=True, text=True, timeout=10)
+            if mb.returncode == 0:
+                r = subprocess.run(["git", "checkout", "-B", "main", target], cwd=str(ROOT),
+                                   capture_output=True, text=True, timeout=30)
+            else:
+                r = subprocess.run(["git", "checkout", "--detach", target], cwd=str(ROOT),
+                                   capture_output=True, text=True, timeout=30)
             if r.returncode != 0:
                 refuse("the checkout did not advance onto %s" % target, r)
                 return
+            if mb.returncode == 1:
+                _sync_notice("main moved at %s: the checkout is at %s, detached. Your local main branch has "
+                             "commits that are not on %s/main, so it was left where it is; merge or rebase it "
+                             "yourself when you want it on the new main." % (remote, target, remote), ok=True)
         except Exception as e:
             refuse("the pull step failed: %s" % e)
             return

--- a/tests/test_converge_main_branch.py
+++ b/tests/test_converge_main_branch.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""The auto converge moves the local `main` branch, never just a detached HEAD (the user 2026-09-08).
+
+_run_main_update("pull") used to `git checkout --detach <target>` and leave the local `main` branch where
+it was, so a maintainer's box sat detached at a fresh sha while `git checkout main` landed on a pointer
+months old. Now: when main is an ANCESTOR of the target it is moved onto the target and checked out (a
+fast-forward by construction); when main has commits the target lacks it is left alone, the target is
+checked out detached as before, and a sync notice says so; with no main branch at all the checkout stays
+detached, as before. Real temporary repositories, no network: a bare "remote", a clone as the shared
+checkout, a second clone to advance the remote's main.
+
+Hermetic state, synthetic content; the restart leg is stopped before the manager POST."""
+import os
+import subprocess
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest import mock
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+_STATE_TD = tempfile.TemporaryDirectory()
+_PREV_STATE_DIR = os.environ.get("ROMP_STATE_DIR")
+os.environ["ROMP_STATE_DIR"] = _STATE_TD.name
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+os.environ["ROMP_MANAGER_PORT"] = "1"
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_converge_main", os.path.join(BIN, "romp-kernel")).load_module()
+if _PREV_STATE_DIR is None:
+    os.environ.pop("ROMP_STATE_DIR", None)
+else:
+    os.environ["ROMP_STATE_DIR"] = _PREV_STATE_DIR
+
+
+def git(cwd, *args):
+    r = subprocess.run(["git", *args], cwd=str(cwd), capture_output=True, text=True, timeout=30)
+    if r.returncode != 0:
+        raise AssertionError("git %s failed: %s%s" % (" ".join(args), r.stdout, r.stderr))
+    return r.stdout.strip()
+
+
+def commit(cwd, name):
+    Path(cwd, name).write_text(name + "\n")
+    git(cwd, "add", name)
+    git(cwd, "commit", "-q", "-m", "add " + name)
+    return git(cwd, "rev-parse", "--short=8", "HEAD")
+
+
+class ConvergeMovesMain(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        root = Path(self.td.name)
+        self.remote = root / "remote.git"
+        seed = root / "seed"
+        seed.mkdir()
+        git(seed, "init", "-q", "-b", "main")
+        self.base = commit(seed, "one")
+        git(seed, "init", "-q", "--bare", "-b", "main", str(self.remote))   # HEAD -> main, so clones start on main
+        git(seed, "push", "-q", str(self.remote), "main")
+        self.checkout = root / "checkout"
+        git(root, "clone", "-q", str(self.remote), str(self.checkout))
+        # advance the remote's main from a second clone: the target the verdict advertises
+        other = root / "other"
+        git(root, "clone", "-q", str(self.remote), str(other))
+        commit(other, "two")
+        self.target = commit(other, "three")
+        git(other, "push", "-q", "origin", "main")
+        self.saved_state = jd.STATE
+        jd.STATE = root / "state"
+        jd.STATE.mkdir()
+        with km._SYNC_LOCK:
+            del km._SYNC_NOTICES[:]
+        km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
+
+    def tearDown(self):
+        jd.STATE = self.saved_state
+        self.td.cleanup()
+
+    def converge(self):
+        with mock.patch.object(km, "ROOT", self.checkout), \
+             mock.patch.object(km, "_release_remote", return_value="origin"), \
+             mock.patch.object(km, "_kernel_code_changed", return_value=False), \
+             mock.patch.object(km, "_in_place_converge", return_value=True):   # stop before the restart leg
+            km._run_main_update("pull", target=self.target)
+
+    def notices(self):
+        with km._SYNC_LOCK:
+            return list(km._SYNC_NOTICES)
+
+    def head_branch(self):
+        r = subprocess.run(["git", "symbolic-ref", "-q", "--short", "HEAD"], cwd=str(self.checkout),
+                           capture_output=True, text=True)
+        return r.stdout.strip()
+
+    def test_main_that_is_an_ancestor_is_fast_forwarded_and_checked_out(self):
+        # the maintainer's shape: an earlier converge left HEAD detached at an older sha; main sits
+        # further back still, at the clone's first commit
+        git(self.checkout, "checkout", "-q", "--detach", "HEAD")
+        self.converge()
+        self.assertEqual(self.head_branch(), "main", "on the branch, not a detached head")
+        self.assertEqual(git(self.checkout, "rev-parse", "--short=8", "main"), self.target)
+        self.assertEqual(git(self.checkout, "rev-parse", "--short=8", "HEAD"), self.target)
+        self.assertEqual([n for n in self.notices() if not n["ok"]], [], "no refusal")
+        self.assertEqual([n for n in self.notices() if "left where it is" in n["text"]], [])
+
+    def test_main_already_checked_out_and_behind_moves_on_the_branch(self):
+        self.assertEqual(self.head_branch(), "main")
+        self.converge()
+        self.assertEqual(self.head_branch(), "main")
+        self.assertEqual(git(self.checkout, "rev-parse", "--short=8", "HEAD"), self.target)
+
+    def test_main_with_local_commits_is_left_alone_and_the_notice_says_so(self):
+        # the branch has a commit the remote never saw, while HEAD sits detached at an earlier commit that
+        # IS an ancestor of the target (an earlier converge left it there): the checkout may advance, the
+        # branch may not
+        local = commit(self.checkout, "mine")
+        git(self.checkout, "checkout", "-q", "--detach", "main~1")
+        self.converge()
+        self.assertEqual(self.head_branch(), "", "detached at the target, as before")
+        self.assertEqual(git(self.checkout, "rev-parse", "--short=8", "HEAD"), self.target)
+        self.assertEqual(git(self.checkout, "rev-parse", "--short=8", "main"), local, "main untouched")
+        said = [n for n in self.notices() if "left where it is" in n["text"]]
+        self.assertEqual(len(said), 1, self.notices())
+        self.assertTrue(said[0]["ok"], "the converge itself succeeded: an informational row, not a refusal")
+        self.assertIn("origin/main", said[0]["text"])
+        self.assertIn(self.target, said[0]["text"])
+
+    def test_no_main_branch_stays_detached_as_before(self):
+        git(self.checkout, "checkout", "-q", "--detach", "HEAD")
+        git(self.checkout, "branch", "-q", "-D", "main")
+        self.converge()
+        self.assertEqual(self.head_branch(), "")
+        self.assertEqual(git(self.checkout, "rev-parse", "--short=8", "HEAD"), self.target)
+        self.assertEqual([n for n in self.notices() if "left where it is" in n["text"]], [])
+        self.assertEqual([n for n in self.notices() if not n["ok"]], [])
+
+    def test_a_diverged_checkout_still_refuses_before_any_branch_move(self):
+        # HEAD itself has a commit the target lacks: the existing refusal, and main is not touched either
+        local = commit(self.checkout, "mine")
+        git(self.checkout, "checkout", "-q", "--detach", "HEAD")
+        self.converge()
+        self.assertEqual(git(self.checkout, "rev-parse", "--short=8", "HEAD"), local)
+        self.assertEqual(git(self.checkout, "rev-parse", "--short=8", "main"), local)
+        self.assertTrue(any("not a fast-forward" in n["text"] and not n["ok"] for n in self.notices()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -793,15 +793,20 @@ class ConvergePullStep(unittest.TestCase):
 
     def test_the_happy_path_moves_onto_the_advertised_commit_and_restarts(self):
         steps = self._drive()
-        self.assertEqual(steps[:4], ["status", "fetch", "merge-base", "checkout"], steps)
-        self.assertEqual(set(steps[4:]), {"rev-parse"}, "after the move, only the checkout re-reads")
+        # two ancestry checks since 2026-09-08: HEAD against the target (the refusal gate) and the local
+        # main branch against it (moved and checked out when it is an ancestor; see the checkout step)
+        self.assertEqual(steps[:5], ["status", "fetch", "merge-base", "merge-base", "checkout"], steps)
+        self.assertEqual(set(steps[5:]), {"rev-parse"}, "after the move, only the checkout re-reads")
         fetch = next(a for s, a in self.calls if s == "fetch")
         self.assertEqual(fetch[-3:], ["fetch", "origin", "main"],
                          "main from the release remote (the scripted `git remote` lists none: a plain install's origin)")
         anc = next(a for s, a in self.calls if s == "merge-base")
         self.assertEqual(anc[-3:], ["--is-ancestor", "HEAD", self.TARGET], "a fast-forward from HEAD, proven")
         co = next(a for s, a in self.calls if s == "checkout")
-        self.assertEqual(co[-2:], ["--detach", self.TARGET], "the move lands on the sha the verdict named")
+        # the scripted git answers every ancestry check yes, so local main is an ancestor here: it is moved
+        # onto the sha the verdict named and checked out (2026-09-08); the diverged case detaches instead
+        # (tests/test_converge_main_branch.py, over real repositories)
+        self.assertEqual(co[-3:], ["-B", "main", self.TARGET], "the move lands on the sha the verdict named, on main")
         self.assertFalse(any(a.endswith("/main") for a in co), "never the ref: it can move, or sit stale")
         self.assertEqual(self.posts, [("POST", "/restart-all")])
         self.assertEqual(self.dials, [("127.0.0.1", 1)])


### PR DESCRIPTION
## Problem
`_run_main_update("pull")` checked the advertised commit out **detached** and never touched the local `main` branch, so an auto-converged box sat at a fresh sha while `git checkout main` landed on a pointer months old; the user then pulled an enormous amount by hand.

## Fix
After the existing gates (clean tree, fetch, HEAD an ancestor of the target):
- **main is an ancestor of the target** → `git checkout -B main <target>`: main moves onto the target and is checked out. A fast-forward by construction, so nothing of the user's is rewritten.
- **main has commits the target lacks** (diverged) → the target is checked out detached as before, main is left where it is, and an informational sync notice says so and names the remote. Moving it is the user's call.
- **no main branch** (a bootstrap install detached at a release tag) → detached, as before.

The refusal when HEAD itself has diverged is unchanged and runs first.

## Tests (red before)
`tests/test_converge_main_branch.py` drives the pull step over real temporary repositories (a bare remote, the checkout, a second clone advancing main): main behind and detached is fast-forwarded and checked out; main checked out and behind moves on the branch; main with a local commit is left alone with the notice while HEAD advances detached; no main stays detached; a diverged HEAD still refuses before any branch move. The scripted happy-path pin in `test_main_drift_notice.py` follows the second ancestry check and the branch checkout. Converge and update suites: 114 passed.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)