### PR TITLE
Chat pane: the transcript's bottom moving up under an at-bottom reader is the pane's own write

### DIFF
--- a/ui/webview/follow-tail.test.ts
+++ b/ui/webview/follow-tail.test.ts
@@ -23,7 +23,7 @@ test("the harness case: 60 px above the bottom, a frame that adds nothing → no
 });
 
 test("render.ts appendActive measures before the rebuild and pins only when followTail says so", () => {
-  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow, followTailShrink \} from "\.\/scroll-keep";/scroll-keep";/);
+  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow, followTailShrink \} from "\.\/scroll-keep";/);
   const m = RENDER.match(/^function appendActive\(\) \{([\s\S]*?)\n\}/m);
   assert.ok(m, "appendActive");
   const body = m![1];

--- a/ui/webview/follow-tail.test.ts
+++ b/ui/webview/follow-tail.test.ts
@@ -23,7 +23,7 @@ test("the harness case: 60 px above the bottom, a frame that adds nothing → no
 });
 
 test("render.ts appendActive measures before the rebuild and pins only when followTail says so", () => {
-  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow \} from "\.\/scroll-keep";/);
+  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow, followTailShrink \} from "\.\/scroll-keep";/scroll-keep";/);
   const m = RENDER.match(/^function appendActive\(\) \{([\s\S]*?)\n\}/m);
   assert.ok(m, "appendActive");
   const body = m![1];

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -54,7 +54,7 @@ import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser
 import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
 import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
-import { followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow } from "./scroll-keep";
+import { followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow, followTailShrink } from "./scroll-keep";
 import { retainLiveOmitted } from "./tab-order";
 import { userTurnShows } from "./user-turn-content";
 import { ScrollDiagBudget, classifyScroll, scrollWriteRow } from "./scroll-write";
@@ -9624,8 +9624,26 @@ function ensureView(id: string): View {
     // turn and the native thumb moved to the new truth while the notches kept the stale frame, and a notch
     // for a message on screen read as "below". The view element's box grows with any child, so one observer
     // per view re-runs the shared rAF paint exactly when the geometry changes. No timer, no per-image hook.
+    // …and the same observer carries the tail-shrink rule (T262f, the user 2026-09-08: the pane unreadable near
+    // the bottom): the ACTIVE view's element losing height — a queued group emptying, the offline foot going, a
+    // tail unit re-rendering shorter outside the append path — moves the transcript's bottom UP, and the browser
+    // clamps scrollTop to the new maximum on its own: an unwritten move the follow-mode latch never saw. When the
+    // view's RECORDED follow mode held (`stick`, the pre-change truth), the reader is written to the new bottom
+    // through writeScroll — where the clamp left them, so nothing moves twice, but the move is the pane's own,
+    // attributed in the journal, and the latch re-reads from a real scroll event. A scrolled-up reader is untouched.
     if (typeof ResizeObserver === "function") {
-      v.ro = new ResizeObserver(() => scheduleRailSticky());
+      let lastH = -1;                                        // -1 = not yet measured (observe fires once on attach)
+      const view = v;                                        // the closure's own binding (the outer `v` is a let)
+      v.ro = new ResizeObserver((entries) => {
+        scheduleRailSticky();
+        const h = entries[0]?.contentRect?.height ?? 0;
+        const content = document.getElementById("content");
+        if (content && lastH >= 0 && activeId === id && view.shown && content.clientHeight > 0 && followTailShrink(view.stick, h - lastH)) {
+          writeScroll(content, content.scrollHeight, "tail-shrink", true);
+          view.scrollTop = content.scrollTop;
+        }
+        lastH = h;
+      });
       v.ro.observe(elv);
     }
     views.set(id, v);
@@ -10595,6 +10613,25 @@ window.addEventListener("resize", updateJumpBtn);
     if (classifyScroll(c.scrollTop, lastScrollWriteAfter) === "write-echo") lastScrollWriteAfter = null;
     else scrollDiagRow("scrollgesture", { sid: activeId || "", top: c.scrollTop, gesture: true, sh: c.scrollHeight, ch: c.clientHeight });   // sh/ch: a clamp reads top == sh - ch after sh dropped (T262e)
   }, { passive: true });
+}
+// The live-ask host (#live-ask) sits INSIDE #content after the threads: the picker card is the transcript's tail
+// while it is up, and its clearing is a tail shrink under the reader (T262f) — the same rule as the view's own
+// observer above, with the active view's recorded follow mode deciding.
+if (typeof ResizeObserver === "function") {
+  const tailHost = document.getElementById("live-ask");
+  if (tailHost) {
+    let tailLastH = -1;
+    new ResizeObserver((entries) => {
+      const h = entries[0]?.contentRect?.height ?? 0;
+      const content = document.getElementById("content");
+      const v = activeId ? views.get(activeId) : null;
+      if (content && tailLastH >= 0 && v && v.shown && content.clientHeight > 0 && followTailShrink(v.stick, h - tailLastH)) {
+        writeScroll(content, content.scrollHeight, "tail-shrink", true);
+        v.scrollTop = content.scrollTop;
+      }
+      tailLastH = h;
+    }).observe(tailHost);
+  }
 }
 // Boxes ABOVE the transcript grow/shrink → keep the chat text visually anchored (the user 2026-06-30 for
 // #tabbar; extended to #ledger 2026-07-05). Both are `flex: 0 0 auto` directly above the `flex: 1 1 auto`

--- a/ui/webview/scroll-keep-on-show.test.ts
+++ b/ui/webview/scroll-keep-on-show.test.ts
@@ -77,7 +77,7 @@ test("render.ts: the reshow decision counts a live durable seek for the tab as n
 });
 
 test("render.ts: the #content scroll listener keeps the active view's saved spot current (passive, no timer)", () => {
-  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow \} from "\.\/scroll-keep";/);   // + followTail (T262: follow only on new content)
+  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow, followTailShrink \} from "\.\/scroll-keep";/scroll-keep";/);   // + followTail (T262: follow only on new content)
   // …and stands down while a deferred build is pending: the reveal's clamp fires a scroll event before the land
   assert.match(RENDER, /c\.addEventListener\("scroll", \(\) => \{\n\s*if \(c\.clientHeight <= 0\) return;\n\s*followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, atBottom\(c\), pendingBuildRaf != null\);\n(?:.*\n){0,4}?\s*\}, \{ passive: true \}\);/);
   // landActive's landing rule itself is unchanged — its INPUT is what the fix repairs

--- a/ui/webview/scroll-keep-on-show.test.ts
+++ b/ui/webview/scroll-keep-on-show.test.ts
@@ -77,7 +77,7 @@ test("render.ts: the reshow decision counts a live durable seek for the tab as n
 });
 
 test("render.ts: the #content scroll listener keeps the active view's saved spot current (passive, no timer)", () => {
-  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow, followTailShrink \} from "\.\/scroll-keep";/scroll-keep";/);   // + followTail (T262: follow only on new content)
+  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow, followTailShrink \} from "\.\/scroll-keep";/);   // + followTail (T262: follow only on new content)
   // …and stands down while a deferred build is pending: the reveal's clamp fires a scroll event before the land
   assert.match(RENDER, /c\.addEventListener\("scroll", \(\) => \{\n\s*if \(c\.clientHeight <= 0\) return;\n\s*followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, atBottom\(c\), pendingBuildRaf != null\);\n(?:.*\n){0,4}?\s*\}, \{ passive: true \}\);/);
   // landActive's landing rule itself is unchanged — its INPUT is what the fix repairs

--- a/ui/webview/scroll-keep.ts
+++ b/ui/webview/scroll-keep.ts
@@ -91,3 +91,16 @@ export function followTail(distBefore: number, heightBefore: number, heightAfter
   if (atBottomDist(distBefore)) return true;
   return heightAfter !== heightBefore;
 }
+
+/** The transcript's bottom moved UP under a follow-mode reader (T262f, the user 2026-09-08: the pane unreadable near
+ *  the bottom; their laptop's breadcrumbs showed the view moving up by one fixed amount with no pane write between
+ *  the rows). An element at the END of #content losing height — the live-ask card cleared, a queued group emptying,
+ *  the offline foot going — makes the browser clamp scrollTop to the new maximum: an unwritten move the follow-mode
+ *  latch never saw. The rule mirrors followBoxBelow: the view's RECORDED follow mode (`stick`, still the pre-change
+ *  truth) decides, and only a SHRINK qualifies — growth at the tail is the append path's (append-stick) or the
+ *  live-ask reveal's. On: the reader is written to the new bottom (where the clamp left them, so nothing moves
+ *  twice, but the move is the pane's own, attributed in the journal, and the latch re-reads from a real scroll
+ *  event). Off: nothing — the clamp cannot reach a reader more than the shrink above the bottom. Pure. */
+export function followTailShrink(stick: boolean, dh: number): boolean {
+  return stick && dh < 0;
+}

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -85,7 +85,8 @@ test("marks translate EVENT indices to DISPLAY UNITS before asking the frame", (
 // ── T245 (the user 2026-09-07): a notch sat below the thumb while its message was on screen ───────────────
 test("a rendered unit changing height re-runs the shared paint — the event the frame was missing (T245)", () => {
   const ev = RENDER.split("function ensureView(id: string): View {")[1].split("\n}")[0];
-  assert.match(ev, /v\.ro = new ResizeObserver\(\(\) => scheduleRailSticky\(\)\);\s*\n\s*v\.ro\.observe\(elv\);/,
+  // the observer's first statement is still the paint; the same callback carries the tail-shrink rule (T262f)
+  assert.match(ev, /v\.ro = new ResizeObserver\(\(entries\) => \{\s*\n\s*scheduleRailSticky\(\);[\s\S]*?\n\s*\}\);\s*\n\s*v\.ro\.observe\(elv\);/,
     "one observer per view element: a lazy figure sizing in or a fold toggling repaints notches AND rail ticks");
   assert.match(RENDER, /ro\?: ResizeObserver; \}/, "the View carries its observer");
   assert.equal((RENDER.match(/v\.ro\?\.disconnect\(\); v\.el\.remove\(\);/g) || []).length, 2, "both view-removal sites disconnect it");

--- a/ui/webview/tail-shrink.test.ts
+++ b/ui/webview/tail-shrink.test.ts
@@ -1,0 +1,40 @@
+// The transcript's bottom moving UP under an at-bottom reader keeps them at the bottom, through the pane's own
+// writer (T262f, the user 2026-09-08: the pane is unreadable near the bottom; their laptop's scroll breadcrumbs
+// showed the view moving up by one fixed amount with no pane write between the rows). When an element at the
+// END of #content loses height — the live-ask card cleared, a queued group emptying, the offline foot going —
+// the browser clamps scrollTop to the new maximum: an UNWRITTEN move the journal could only file as a gesture,
+// and one the follow-mode latch never saw. The rule is the same shape as the boxes-below one: the view's RECORDED
+// follow mode (`stick`, the pre-change truth) decides; on, and the tail shrank, the reader is written to the new
+// bottom through writeScroll (writer "tail-shrink") — the same place the clamp left them, so nothing visible moves
+// twice, but the move is now the pane's, attributed in the journal, and the latch is re-read from a real scroll
+// event; off, nothing (the clamp cannot reach a reader more than the shrink above the bottom, and the top line
+// they read never moved). Pure rule executed here; render.ts wiring pinned.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { followTailShrink } from "./scroll-keep";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("a follow-mode reader is written to the bottom when the tail shrinks; growth and a scrolled-up reader are left alone", () => {
+  assert.equal(followTailShrink(true, -95), true, "the card went: the bottom moved up by 95 px");
+  assert.equal(followTailShrink(true, -1), true, "any shrink");
+  assert.equal(followTailShrink(true, 0), false);
+  assert.equal(followTailShrink(true, 95), false, "growth is the append path's (append-stick) or the reveal's (liveask-reveal), not this rule's");
+  assert.equal(followTailShrink(false, -95), false, "reading history: untouched");
+});
+
+test("render.ts observes every view's element and #live-ask, and writes the bottom through the scroll-write helper", () => {
+  assert.match(RENDER, /import \{[^}]*\bfollowTailShrink\b[^}]*\} from "\.\/scroll-keep";/);
+  // the per-view ResizeObserver (it already re-lands the rail) carries the rule
+  const m = RENDER.match(/v\.ro = new ResizeObserver\(\(entries\) => \{([\s\S]*?)\n\s*\}\);/);
+  assert.ok(m, "the view's ResizeObserver");
+  assert.match(m![1], /followTailShrink\(view\.stick, h - lastH\)/, "the recorded follow mode decides, never a post-change atBottom read");
+  assert.match(m![1], /writeScroll\(content, content\.scrollHeight, "tail-shrink", true\);/);
+  assert.match(m![1], /activeId === id/, "only the ACTIVE view's element moves the reader");
+  // the live-ask host sits inside #content after the threads: its shrink is the card leaving
+  assert.match(RENDER, /const tailHost = document\.getElementById\("live-ask"\);/);
+  assert.match(RENDER, /followTailShrink\(v\.stick, h - tailLastH\)/);
+  assert.equal((RENDER.match(/"tail-shrink"/g) || []).length, 2, "two observers, one writer name");
+});


### PR DESCRIPTION
## Summary
Stopgap for the user's "unreadable near the bottom" (2026-09-08): when the transcript's bottom moves UP under an at-bottom reader, the pane writes them back to the bottom itself.

## Why
An element at the END of `#content` losing height (the live-ask card cleared, a queued group emptying, the offline foot going, a tail unit re-rendering shorter outside the append path) makes the browser clamp scrollTop to the new maximum on its own. That is an UNWRITTEN move: the scroll breadcrumbs could only file it as a gesture, and the follow-mode latch never saw it. The user's laptop rows showed exactly this shape, the view moving up by one fixed amount with no pane write between the rows.

## Rule
`followTailShrink(stick, dh)` in scroll-keep.ts, the mirror of the boxes-below rule: the view's RECORDED follow mode (`stick`, the pre-change truth) decides, and only a shrink qualifies (growth at the tail is the append path's `append-stick` or the live-ask `liveask-reveal`). Carried by the per-view ResizeObserver that already re-lands the rail (the ACTIVE view only) and by a new observer on `#live-ask`, whose card is the transcript's tail while it is up. On: `writeScroll(content, content.scrollHeight, "tail-shrink", true)`, the same place the clamp left them, so nothing visible moves twice, but the move is the pane's own, attributed in the journal, and the latch re-reads from a real scroll event. Off: nothing; the clamp cannot reach a reader more than the shrink above the bottom. Event-based, no timer.

## Tests
- New `ui/webview/tail-shrink.test.ts`: the executed rule (shrink under follow mode writes; growth and a scrolled-up reader do not) and pins for both observers and the one writer name.
- The scroll-keep import pins in follow-tail and scroll-keep-on-show moved with the import.
- `npm run typecheck` clean; the full extension suite runs on the branch (result in a comment if it finishes after this opens).

The kernel-side change gate for flapping `askLive`/`askLiveClear` frames follows as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
