### PR TITLE
Obsidian routes: the flag and order stores are written under a lock, the panel proves the kernel before it sends the token, and the port fallback is stated truthfully

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -82,9 +82,15 @@ op uses; a store that cannot be read or written answers 200 with `ok:false` and
 the reason the dashboards see, and an unknown key or a wrong type is a 400
 naming it. The panel finds the kernel through the `serve-port` record the
 kernel writes beside `serve-token` in the state directory once its socket is
-bound; with no record, or nothing answering on it, the panel refuses the
-gesture and says the kernel is not running rather than writing a file the
-kernel cannot check.
+bound; with a record nothing answers on, the panel refuses the gesture and says
+the kernel is not running rather than writing a file the kernel cannot check.
+With no record at all (a kernel older than the panel wrote the token and no
+port) it tries the port the command line resolves, `ROMP_KERNEL_PORT`, then
+`ROMP_SERVE_PORT`, else `29855`, and its refusal says so when nothing answers
+there. Record or fallback, the panel first asks the port to prove itself: a
+`GET /healthz` with no token, on `127.0.0.1` only, must answer `200 ok` with
+the kernel's `X-Romp-Boot` identity before the token is sent, and a port that
+answers as anything else is refused by name and never sees the token.
 
 `--env` gives one session its own environment, so two sessions in the same
 directory can run with different toggles (a `FEATURE_FLAG=1`, a `CLAUDE_CODE_*`

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1292,11 +1292,16 @@ def _persist_serve_port(port):
     once the socket is BOUND (main): the AUTHORITATIVE answer for a same-user client that has the
     state dir but no shell environment to read ROMP_KERNEL_PORT from -- the Obsidian timeline panel,
     an Electron app launched from the dock, which posts its flag, views and order edits to the
-    routes below (_state_write_route) rather than writing the state files itself. A client that
-    finds no record, or a record nothing answers on, treats the kernel as not running and refuses the
-    gesture visibly, never guessing a port or falling back to a write the kernel cannot check. An
-    atomic publish (a reader never sees a torn number); best-effort, like the serve-token mint and
-    the repo-root record above."""
+    routes below (_state_write_route) rather than writing the state files itself. With a record that
+    nothing answers on, the panel treats the kernel as not running and refuses the gesture visibly,
+    never falling back to a write the kernel cannot check. With NO record (a kernel older than this
+    one wrote the token and no port) the panel tries the port the CLI resolves -- ROMP_KERNEL_PORT,
+    then ROMP_SERVE_PORT, else 29855 -- and says so in its refusal when nothing answers there. Record
+    or fallback, the panel first asks the port to prove itself over GET /healthz (a 200 "ok" carrying
+    X-Romp-Boot, on 127.0.0.1 only) with no token, and sends its token only to a port that did; a
+    port that answers as anything else is refused by name and never sees the token (review find,
+    2026-09-08, on #1078). An atomic publish (a reader never sees a torn number); best-effort, like
+    the serve-token mint and the repo-root record above."""
     try:
         _atomic_write(jd.STATE / "serve-port", "%d\n" % int(port))
     except OSError:
@@ -3129,6 +3134,15 @@ def _read_state_json(path, st=None, expect=None, _tries=3):
 # Last-known-good session order (session-order.json has no mtime cache): served over a transient
 # fault instead of a fabricated [], and the order to render when the store cannot be re-read.
 _session_order_lkg = [None]
+# One writer of session-order.json at a time. Every writer of the order is a read-modify-write
+# (_merge_session_order + _write_session_order for a drag, _ordered's newcomer splice,
+# _gc_session_order's prune), and the kernel serves them from many threads: the WS receive loops,
+# the POST /order route's handler threads, the pusher. Two unlocked writers that read the same
+# store both publish, and the second publish silently drops the first one's change while both were
+# acked ok (review find, 2026-09-08, on #1078: 8 to 13 of 40 concurrent route writes survived).
+# Taken around the read AND the write, as one step; _views_lock nests INSIDE it (_ordered's
+# newcomer heal takes it), never the other way round -- nothing under _views_lock touches the order.
+_order_lock = threading.Lock()
 
 # One VISIBLE error per fault EPISODE, per state file (never a raise into the push/build path -- one
 # unreadable state file must not abort the whole push and wedge the board). str(path) -> the fault
@@ -3386,17 +3400,18 @@ def _gc_session_order(known):
     it so a closed / aged-out session falls out on its own). Everything still around keeps its EXACT slot —
     only truly-absent sids are removed, and since the discover window only slides FORWARD a pruned sid never
     flickers back to reclaim a slot. Writes only when something actually changed (no churn on the hot path)."""
-    try:
-        order = _session_order_proved()
-    except _StateUnreadable as e:
-        _note_state_fault(e)                         # loud once per episode, not per pass
-        return
-    kept = [sid for sid in order if sid in known]
-    if kept != order:
+    with _order_lock:                                # read and write as one step (the store's rule, above)
         try:
-            _write_session_order(kept)
-        except _StateUnwritable:
-            pass                                     # filed once per episode by the write door; the next pass retries
+            order = _session_order_proved()
+        except _StateUnreadable as e:
+            _note_state_fault(e)                     # loud once per episode, not per pass
+            return
+        kept = [sid for sid in order if sid in known]
+        if kept != order:
+            try:
+                _write_session_order(kept)
+            except _StateUnwritable:
+                pass                                 # filed once per episode by the write door; the next pass retries
 
 
 def _merge_session_order(incoming):
@@ -3427,6 +3442,20 @@ def _merge_session_order(incoming):
     return [s for s in merged if not (s in seen or seen.add(s))]
 
 
+def _reorder_session_order(incoming):
+    """A drag's write of the order, as the reorderTabs/writeOrder socket arm and POST /order both land
+    it: _merge_session_order then _write_session_order, under _order_lock so the read and the publish
+    are ONE step. Before the lock the two calls sat unlocked at each call site, and two writers -- the
+    Obsidian panel and a dashboard, or two dashboards -- that read the same store both published, the
+    later publish dropping the earlier one's drag while both were acked ok (review find, 2026-09-08,
+    on #1078). Raises _StateUnreadable / _StateUnwritable exactly as the two steps do; the callers'
+    refusals are unchanged. Returns the merged order that was published."""
+    with _order_lock:
+        merged = _merge_session_order(incoming)
+        _write_session_order(merged)
+    return merged
+
+
 # Forks whose views heal (_heal_timeline_views: a /clear or revive inherits its session's tag memberships)
 # could not run because the views store faulted -- new sid -> the sid whose memberships it inherits.
 # _ordered retries them on every later pass until the heal lands: the order publish that follows the
@@ -3451,76 +3480,80 @@ def _ordered(sessions):
     sibling already in the order. A genuinely-new session still appends at the end. Keyed off the anchor the
     sessions carry (default: the sid itself), so session-order.json + the client stay fsid-based — no
     migration (the user 2026-06-24: keep ONE slot across /clear / revive)."""
-    try:
-        order = _session_order_proved()   # a PROVED read: a transient fault must not fold to [] and then
-        #                                   mark every session "new", persisting discovery order over the
-        #                                   user's saved order under no gesture (the state-readers audit).
-    except _StateUnreadable as e:
-        # render the last-known order (or plain input order if we never read one) and persist NOTHING
-        # this pass; the next clean read re-appends any true newcomers. Loud once per episode.
-        _note_state_fault(e)
-        lkg = _session_order_lkg[0] or []
-        idx0 = {sid: i for i, sid in enumerate(lkg)}
-        return sorted(sessions, key=lambda s: idx0.get(s["sid"], len(idx0)))
-    _session_order_lkg[0] = list(order)   # a COPY of the clean read: `order` is spliced below and only
-    #                                       _write_session_order latches the spliced list, AFTER it lands
-    #                                       (review find, 2026-09-08: latched by reference, a publish that
-    #                                       failed left an unpersisted order as the known-good)
-    known = set(order)
-    # Slot inheritance keys on the STABLE session NAME (customTitle), NOT the fsid or discover's anchor: a
-    # /clear, relaunch, or revive mints a NEW transcript fsid for the SAME logical session, and it must
-    # inherit that session's existing slot rather than jump to the END. Keying on the name — resolved from
-    # the names registry, so even a DEAD order entry's name is known — is robust to fsid churn AND to
-    # discover occasionally SELF-anchoring a fork (a fork that has its own names entry, processed first in
-    # the lexical scan, anchors to itself instead of grouping under its session): that lexical-order accident
-    # was the silent, intermittent tab reorder the user kept hitting (2026-06-29). A genuinely-new session has
-    # a unique name → no sibling → appends at the end, then is frozen.
-    sess_name = {s["sid"]: (s.get("name") or "") for s in sessions}
-    def _nm(sid):
-        return sess_name.get(sid) or _name_of(sid) or ""
-    for fsid, osid in list(_views_heal_pending.items()):
-        # a heal deferred on an earlier pass (the views store faulted): retried until it lands. Quiet while
-        # the store still faults -- the skip said it once -- and one line when it lands.
+    # the read, the splice and the publish are ONE step under _order_lock: a drag landing between the
+    # read and the publish (POST /order, the socket arm) was overwritten by this splice, or overwrote it,
+    # with no gesture and no notice (review find, 2026-09-08, on #1078)
+    with _order_lock:
         try:
-            carried = _heal_timeline_views(osid, fsid)
-        except (_StateUnreadable, _StateUnwritable):
-            continue
-        _views_heal_pending.pop(fsid, None)
-        sys.stderr.write("romp-kernel: views heal for %s %s\n"
-                         % (fsid, "landed on retry" if carried else "retried: nothing to carry"))
-    new = [s["sid"] for s in sessions if s["sid"] not in known]
-    if new:
-        name_at = [_nm(o) for o in order]                # each existing slot's stable name (resolved once)
-        for sid in new:
-            a = _nm(sid)
-            sib = [i for i, n in enumerate(name_at) if a and n == a]   # same-name entries already placed
-            if sib:
-                try:
-                    _heal_timeline_views(order[sib[-1]], sid)   # the fork inherits its tag state too
-                except (_StateUnreadable, _StateUnwritable) as e:
-                    # the views store faulted inside the heal (its PROVED read, or its publish): the slot
-                    # inheritance below still lands and the heal is deferred (_views_heal_pending), retried on
-                    # the next pass. Never a raise out of _ordered -- it runs inside every build (the push,
-                    # GET /feed.json, the WS clearAll arm) -- and never a fold: the heal read the display
-                    # reader before this change, which folded the fault to an empty store, so the heal
-                    # carried nothing and said nothing. Said once per fork, like the order publish below:
-                    # the stderr line, and the bell row the fork and promotion sites file for the same
-                    # non-event (_note_views_heal_deferred; review find, 2026-09-08).
-                    if sid not in _views_heal_pending:
-                        sys.stderr.write("romp-kernel: views heal for %s skipped (%s) \u2014 deferred; the next pass "
-                                         "retries it (lost if the kernel restarts first)\n" % (sid, e))
-                        _note_views_heal_deferred(a or sid, e)
-                    _views_heal_pending[sid] = order[sib[-1]]
-                order.insert(sib[-1] + 1, sid)           # a fork inherits its session's slot, not the END
-                name_at.insert(sib[-1] + 1, a)           # keep name_at aligned with order as we splice
-            else:
-                order.append(sid)                        # a genuinely new session appends, then is frozen
-                name_at.append(a)
-        try:
-            _write_session_order(order)
-        except _StateUnwritable:
-            pass                                         # this build still sorts by the in-memory order; the publish
-            #                                              is filed once per episode and the next pass retries it
+            order = _session_order_proved()   # a PROVED read: a transient fault must not fold to [] and then
+            #                                   mark every session "new", persisting discovery order over the
+            #                                   user's saved order under no gesture (the state-readers audit).
+        except _StateUnreadable as e:
+            # render the last-known order (or plain input order if we never read one) and persist NOTHING
+            # this pass; the next clean read re-appends any true newcomers. Loud once per episode.
+            _note_state_fault(e)
+            lkg = _session_order_lkg[0] or []
+            idx0 = {sid: i for i, sid in enumerate(lkg)}
+            return sorted(sessions, key=lambda s: idx0.get(s["sid"], len(idx0)))
+        _session_order_lkg[0] = list(order)   # a COPY of the clean read: `order` is spliced below and only
+        #                                       _write_session_order latches the spliced list, AFTER it lands
+        #                                       (review find, 2026-09-08: latched by reference, a publish that
+        #                                       failed left an unpersisted order as the known-good)
+        known = set(order)
+        # Slot inheritance keys on the STABLE session NAME (customTitle), NOT the fsid or discover's anchor: a
+        # /clear, relaunch, or revive mints a NEW transcript fsid for the SAME logical session, and it must
+        # inherit that session's existing slot rather than jump to the END. Keying on the name — resolved from
+        # the names registry, so even a DEAD order entry's name is known — is robust to fsid churn AND to
+        # discover occasionally SELF-anchoring a fork (a fork that has its own names entry, processed first in
+        # the lexical scan, anchors to itself instead of grouping under its session): that lexical-order accident
+        # was the silent, intermittent tab reorder the user kept hitting (2026-06-29). A genuinely-new session has
+        # a unique name → no sibling → appends at the end, then is frozen.
+        sess_name = {s["sid"]: (s.get("name") or "") for s in sessions}
+        def _nm(sid):
+            return sess_name.get(sid) or _name_of(sid) or ""
+        for fsid, osid in list(_views_heal_pending.items()):
+            # a heal deferred on an earlier pass (the views store faulted): retried until it lands. Quiet while
+            # the store still faults -- the skip said it once -- and one line when it lands.
+            try:
+                carried = _heal_timeline_views(osid, fsid)
+            except (_StateUnreadable, _StateUnwritable):
+                continue
+            _views_heal_pending.pop(fsid, None)
+            sys.stderr.write("romp-kernel: views heal for %s %s\n"
+                             % (fsid, "landed on retry" if carried else "retried: nothing to carry"))
+        new = [s["sid"] for s in sessions if s["sid"] not in known]
+        if new:
+            name_at = [_nm(o) for o in order]                # each existing slot's stable name (resolved once)
+            for sid in new:
+                a = _nm(sid)
+                sib = [i for i, n in enumerate(name_at) if a and n == a]   # same-name entries already placed
+                if sib:
+                    try:
+                        _heal_timeline_views(order[sib[-1]], sid)   # the fork inherits its tag state too
+                    except (_StateUnreadable, _StateUnwritable) as e:
+                        # the views store faulted inside the heal (its PROVED read, or its publish): the slot
+                        # inheritance below still lands and the heal is deferred (_views_heal_pending), retried on
+                        # the next pass. Never a raise out of _ordered -- it runs inside every build (the push,
+                        # GET /feed.json, the WS clearAll arm) -- and never a fold: the heal read the display
+                        # reader before this change, which folded the fault to an empty store, so the heal
+                        # carried nothing and said nothing. Said once per fork, like the order publish below:
+                        # the stderr line, and the bell row the fork and promotion sites file for the same
+                        # non-event (_note_views_heal_deferred; review find, 2026-09-08).
+                        if sid not in _views_heal_pending:
+                            sys.stderr.write("romp-kernel: views heal for %s skipped (%s) \u2014 deferred; the next pass "
+                                             "retries it (lost if the kernel restarts first)\n" % (sid, e))
+                            _note_views_heal_deferred(a or sid, e)
+                        _views_heal_pending[sid] = order[sib[-1]]
+                    order.insert(sib[-1] + 1, sid)           # a fork inherits its session's slot, not the END
+                    name_at.insert(sib[-1] + 1, a)           # keep name_at aligned with order as we splice
+                else:
+                    order.append(sid)                        # a genuinely new session appends, then is frozen
+                    name_at.append(a)
+            try:
+                _write_session_order(order)
+            except _StateUnwritable:
+                pass                                         # this build still sorts by the in-memory order; the publish
+                #                                              is filed once per episode and the next pass retries it
     idx = {sid: i for i, sid in enumerate(order)}
     return sorted(sessions, key=lambda s: idx.get(s["sid"], len(idx)))   # stable sort: ties keep input order
 
@@ -5450,6 +5483,14 @@ def _tag_new_session(sid, parent_sid="", tags=()):
 # set from the timeline's lane controls; the session stays on the timeline. mtime-cached since
 # build_feed/build_timeline read it on every push.
 _flags_cache = {}   # str(path) -> ((mtime,size), dict)
+# One writer of session-flags.json at a time: _set_session_flag and _set_notify_session both
+# read-modify-write the whole file, and the kernel runs them from many threads (the WS receive loops
+# of every dashboard, the POST /flag route's handler threads). Two unlocked writers that read the same
+# store both publish, and the second publish drops the first one's toggle while both were acked ok
+# (review find, 2026-09-08, on #1078: 8 to 13 of 40 concurrent route writes survived). Taken around
+# the proved read and the publish as one step; the setters' side work (goal clearing, the planner
+# fast-forward) runs outside it, as it touches other stores.
+_flags_lock = threading.Lock()
 
 
 def _session_flags_proved():
@@ -5504,18 +5545,19 @@ def _session_flag_raw(sid, flag):
 
 
 def _set_session_flag(sid, flag, value):
-    cur = dict(_session_flags_proved())              # PROVED: a read fault refuses (raises) rather than
-    #                                                  overwriting every session's flags with a fabricated {}
-    f = dict(cur.get(sid)) if isinstance(cur.get(sid), dict) else {}
-    if value:
-        f[flag] = True
-    else:
-        f.pop(flag, None)
-    if f:
-        cur[sid] = f
-    else:
-        cur.pop(sid, None)
-    _write_state_json(jd.STATE / "session-flags.json", json.dumps(cur, sort_keys=True))
+    with _flags_lock:                                # read and publish as ONE step (the store's rule, above)
+        cur = dict(_session_flags_proved())          # PROVED: a read fault refuses (raises) rather than
+        #                                              overwriting every session's flags with a fabricated {}
+        f = dict(cur.get(sid)) if isinstance(cur.get(sid), dict) else {}
+        if value:
+            f[flag] = True
+        else:
+            f.pop(flag, None)
+        if f:
+            cur[sid] = f
+        else:
+            cur.pop(sid, None)
+        _write_state_json(jd.STATE / "session-flags.json", json.dumps(cur, sort_keys=True))
     if flag == "hideFromFeed" and value:
         # Muting takes the session OUT of task tracking → VIEW-CLEAR its current goals: seal them exactly like
         # crossing each card off the feed (cleared.jsonl + the durable node flag), NOT delete — they stay on
@@ -5685,22 +5727,23 @@ def _set_notify_session(sid, value):
     discipline as _set_notify_card, against the master. Not _set_session_flag: that setter's
     pop-on-false is right for the on/off view flags, but here False is a real value (muted while
     the master is on)."""
-    cur = dict(_session_flags_proved())              # PROVED: a read fault refuses rather than erasing flags
-    f = dict(cur.get(sid)) if isinstance(cur.get(sid), dict) else {}
-    # the master this click is judged against lives in the OTHER store and must be PROVED too: read
-    # through the display reader, a fault on notify-cards.json folded it to off, so a click matching
-    # that fabricated master popped the session's stored override -- a mute erased under the success
-    # path. A fault there refuses this write exactly like a fault on the flags file.
-    master = bool(_notify_cards_proved().get(NOTIFY_ALL_KEY))
-    if bool(value) == master:
-        f.pop("notify", None)
-    else:
-        f["notify"] = bool(value)
-    if f:
-        cur[sid] = f
-    else:
-        cur.pop(sid, None)
-    _write_state_json(jd.STATE / "session-flags.json", json.dumps(cur, sort_keys=True))
+    with _flags_lock:                                # read and publish as ONE step (the store's rule, above)
+        cur = dict(_session_flags_proved())          # PROVED: a read fault refuses rather than erasing flags
+        f = dict(cur.get(sid)) if isinstance(cur.get(sid), dict) else {}
+        # the master this click is judged against lives in the OTHER store and must be PROVED too: read
+        # through the display reader, a fault on notify-cards.json folded it to off, so a click matching
+        # that fabricated master popped the session's stored override -- a mute erased under the success
+        # path. A fault there refuses this write exactly like a fault on the flags file.
+        master = bool(_notify_cards_proved().get(NOTIFY_ALL_KEY))
+        if bool(value) == master:
+            f.pop("notify", None)
+        else:
+            f["notify"] = bool(value)
+        if f:
+            cur[sid] = f
+        else:
+            cur.pop(sid, None)
+        _write_state_json(jd.STATE / "session-flags.json", json.dumps(cur, sort_keys=True))
 
 
 def _prune_notify_cards(live_ids):
@@ -44178,8 +44221,7 @@ def _state_write_route(path, b):
         if not isinstance(order, list) or not all(isinstance(x, str) for x in order):
             return 400, {"ok": False, "error": "order (a list of session ids) required, got %s" % _clip_json(order)}
         try:
-            merged = _merge_session_order(order)
-            _write_session_order(merged)
+            merged = _reorder_session_order(order)   # merge + publish as one step under _order_lock (the arm's step too)
         except (_StateUnreadable, _StateUnwritable) as e:
             # the order file could not be read, or its publish failed: the drag must not splice against a
             # fabricated [] and persist discovery order over the saved one (the reorderTabs arm's rule)
@@ -47107,8 +47149,8 @@ class Handler(BaseHTTPRequestHandler):
             # tab-drag or lane-drag → reorder BOTH surfaces. MERGE the dragged surface's order into the
             # persisted one (don't overwrite): a chat-tab drag must not drop/reshuffle timeline-only lanes.
             try:
-                _merged = _merge_session_order(msg["order"])
-                _write_session_order(_merged)            # the publish too: a failed one is refused, never a
+                _reorder_session_order(msg["order"])     # merge + publish as ONE step under _order_lock (the
+                #                                          POST /order route's step too); a failed publish is refused, never a
             except (_StateUnreadable, _StateUnwritable) as e:   # dropped socket (the fold on PR #1019)
                 # the order file could not be read, or its publish failed; the drag must not splice against
                 # a fabricated [] and persist discovery order over the user's saved order. Refused on the

--- a/tests/test_obsidian_state_routes.py
+++ b/tests/test_obsidian_state_routes.py
@@ -67,10 +67,14 @@ def _reads_fault(target):
         Path.read_bytes, Path.read_text = real_rb, real_rt
 
 
+class _Server(ThreadingHTTPServer):
+    request_queue_size = 128   # socketserver's default backlog is 5; the concurrent-writer tests below open 32 at once
+
+
 class _Routes(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.srv = _Server(("127.0.0.1", 0), km.Handler)
         cls.port = cls.srv.server_address[1]
         threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
 
@@ -378,3 +382,156 @@ class PortRecord(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class _LockSpy:
+    """Stands in for one store's lock (_flags_lock / _order_lock) for the duration of a test and says,
+    without a timer, when a second writer is WAITING on it: the interleaving tests below release the
+    first writer on exactly that event (or on the second writer having landed, when there is no lock to
+    wait on). Delegates the lock itself."""
+
+    def __init__(self, lock, progressed):
+        self._lock, self._progressed = lock, progressed
+
+    def __enter__(self):
+        if self._lock.locked():
+            self._progressed.set()                   # a writer is queued behind the one holding the store
+        return self._lock.__enter__()
+
+    def __exit__(self, *a):
+        return self._lock.__exit__(*a)
+
+
+class ConcurrentWriters(_Routes):
+    """Two writers of one store, at once (review find, 2026-09-08, on #1078). The route and the socket
+    arm land through the same setters, and those setters are read-modify-writes of a whole JSON file:
+    unlocked, two writers that read the same store both publish, the later publish drops the earlier
+    one's change, and BOTH are acked ok:true -- the probe that found it kept 8 to 13 of 40 concurrent
+    route writes. The setters now hold a per-store lock across the read and the publish (_flags_lock,
+    _order_lock), so every writer's change survives and the acks stay truthful.
+
+    The interleaving tests force the lost-update ORDER rather than hoping for it: the first writer is
+    held after its proved read (the read patched to wait on an event), the second writer is started,
+    and the first is released only once the second has either LANDED (no lock: it read the same
+    snapshot and published) or is WAITING on the store's lock (_LockSpy) -- both events, no timers --
+    so without the lock the loss is certain, and with it the test never waits on a clock."""
+
+    def _interleave(self, lock_name, read_name, first, second):
+        """Run `first` up to and through its proved read, start `second`, wait for it to land or to
+        queue on the lock, release `first`, join both. Returns their results."""
+        read_done, go, progressed = threading.Event(), threading.Event(), threading.Event()
+        real_read = getattr(km, read_name)
+        real_lock = getattr(km, lock_name, None)      # absent on a kernel without the lock: nothing waits
+
+        def patched_read():
+            # the FIRST proved read is the first writer's (the second is not started until it has read);
+            # it runs on the server's handler thread for a route write, on the test's thread for a socket
+            # write, so the call order, not the thread, names it
+            r = real_read()
+            if not read_done.is_set():
+                read_done.set()
+                self.assertTrue(go.wait(20), "the first writer was never released")
+            return r
+
+        setattr(km, read_name, patched_read)
+        setattr(km, lock_name, _LockSpy(real_lock or threading.Lock(), progressed))
+        res = [None, None]
+        try:
+            t1 = threading.Thread(target=lambda: res.__setitem__(0, first()))
+            t1.start()
+            self.assertTrue(read_done.wait(20), "the first writer never read the store")
+
+            def run_second():
+                res[1] = second()
+                progressed.set()                     # landed (no lock) -- the other way to progress
+            t2 = threading.Thread(target=run_second)
+            t2.start()
+            self.assertTrue(progressed.wait(20), "the second writer neither landed nor queued on the lock")
+            go.set()
+            t1.join(20); t2.join(20)
+            self.assertFalse(t1.is_alive() or t2.is_alive(), "a writer hung")
+        finally:
+            setattr(km, read_name, real_read)
+            if real_lock is None:
+                delattr(km, lock_name)
+            else:
+                setattr(km, lock_name, real_lock)
+        return res
+
+    def _flags_file(self):
+        p = km.jd.STATE / "session-flags.json"
+        return json.loads(p.read_text()) if p.exists() else None
+
+    def _order_file(self):
+        return json.loads((km.jd.STATE / "session-order.json").read_text())
+
+    def test_n_concurrent_flag_posts_through_the_route_all_survive_and_every_ack_is_true(self):
+        n = 32
+        sids = ["%08x-1111-2222-3333-444444444444" % i for i in range(n)]
+        gate = threading.Barrier(n)
+        acks = [None] * n
+
+        def post(i):
+            gate.wait(20)                            # every request in flight together, then the handler threads race
+            try:
+                acks[i] = self._post("/flag", {"id": sids[i], "flag": "hideFromFeed", "value": True})
+            except Exception as e:                   # a transport failure is a finding too, said as such
+                acks[i] = ("EXC", repr(e))
+        ts = [threading.Thread(target=post, args=(i,)) for i in range(n)]
+        for t in ts:
+            t.start()
+        for t in ts:
+            t.join(60)
+        self.assertFalse(any(t.is_alive() for t in ts))
+        flags = self._flags_file() or {}
+        self.assertEqual(sorted(flags), sorted(sids),
+                         "%d of %d writes survive -- an ack must mean the toggle is in the store; acks: %s"
+                         % (len(flags), n, sorted(set(str(a[0]) for a in acks))))
+        self.assertTrue(all(flags[s] == {"hideFromFeed": True} for s in sids))
+        self.assertEqual([a[0] for a in acks], [200] * n, acks)
+        self.assertTrue(all(a[1].get("ok") is True for a in acks), "every writer was acked ok")
+
+    def test_a_route_write_and_a_socket_write_interleaved_both_survive(self):
+        r = self._interleave(
+            "_flags_lock", "_session_flags_proved",
+            lambda: self._post("/flag", {"id": SID, "flag": "hideFromFeed", "value": True}),
+            lambda: self._ws({"type": "setSessionFlag", "id": SID2, "flag": "postalServiceOff", "value": True}))
+        self.assertEqual(r[0], (200, {"ok": True, "id": SID, "flag": "hideFromFeed", "value": True}))
+        self.assertEqual(r[1], [], "the socket arm sent no refusal")
+        self.assertEqual(self._flags_file(), {SID: {"hideFromFeed": True}, SID2: {"postalServiceOff": True}},
+                         "both acked toggles are in the store; neither writer's publish dropped the other's")
+
+    def test_two_flag_posts_interleaved_both_survive(self):
+        r = self._interleave(
+            "_flags_lock", "_session_flags_proved",
+            lambda: self._post("/flag", {"id": SID, "flag": "notify", "value": True}),
+            lambda: self._post("/flag", {"id": SID2, "flag": "hideFromFeed", "value": True}))
+        self.assertTrue(r[0][1]["ok"] and r[1][1]["ok"])
+        self.assertEqual(self._flags_file(), {SID: {"notify": True}, SID2: {"hideFromFeed": True}})
+
+    def test_an_order_post_and_a_socket_drag_interleaved_both_survive(self):
+        (km.jd.STATE / "session-order.json").write_text(json.dumps([A, B, C, D]))
+        r = self._interleave(
+            "_order_lock", "_session_order_proved",
+            lambda: self._post("/order", {"order": [B, A]}),           # the Obsidian panel swaps the first two lanes
+            lambda: self._ws({"type": "reorderTabs", "order": [D, C]}))   # a dashboard swaps the last two tabs
+        self.assertEqual(r[0][1]["ok"], True)
+        self.assertEqual(r[1], [], "the socket arm sent no refusal")
+        self.assertEqual(self._order_file(), [B, A, D, C], "both drags are in the store, each in the slots it touched")
+        self.assertEqual(r[0][1]["order"], [B, A, C, D],
+                         "the route's ack is the order it published: its own swap on the store it read, the queued drag landing after")
+
+    def test_the_locks_are_per_store_and_taken_by_every_writer_of_the_store(self):
+        src = inspect.getsource(km)
+        self.assertIsInstance(km._flags_lock, type(threading.Lock()))
+        self.assertIsInstance(km._order_lock, type(threading.Lock()))
+        for fn in (km._set_session_flag, km._set_notify_session):
+            self.assertIn("with _flags_lock:", inspect.getsource(fn), fn.__name__)
+        for fn in (km._reorder_session_order, km._gc_session_order, km._ordered):
+            self.assertIn("with _order_lock:", inspect.getsource(fn), fn.__name__)
+        route = inspect.getsource(km._state_write_route)
+        self.assertIn("_reorder_session_order(order)", route, "the route lands the drag through the locked step")
+        self.assertNotIn("_write_session_order(merged)", route)
+        arm = src[src.index('msg.get("type") in ("reorderTabs", "writeOrder")'):][:1500]
+        self.assertIn('_reorder_session_order(msg["order"])', arm, "so does the socket arm")
+        self.assertNotIn("_write_session_order(_merged)", arm)

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3480,7 +3480,11 @@ class TimelinePanel {
   // spent on one of those missed the restored store the router adopted next (viewsAnnouncedAfter).
   _takeViews(v) {
     if (!v) return false;
-    if (viewsAdopts(this._views, v, this._announcedViewsSeq)) { this._announcedViewsSeq = viewsAnnouncedAfter(this._views, v, this._announcedViewsSeq); this._views = v; this._rejectedViews = null; return true; }
+    if (viewsAdopts(this._views, v, this._announcedViewsSeq)) {
+      this._announcedViewsSeq = viewsAnnouncedAfter(this._views, v, this._announcedViewsSeq); this._views = v; this._rejectedViews = null;
+      if (this._reconcileLocalLens()) this._repaintTagSurfaces();   // the store now carries a filter held as unsaved: its note goes
+      return true;
+    }
     this._rejectedViews = v;
     if (!this._staleViewsLogged) {
       this._staleViewsLogged = true;
@@ -3528,7 +3532,7 @@ class TimelinePanel {
     this._caps = new Set((m && Array.isArray(m.caps)) ? m.caps.filter((c) => typeof c === 'string') : []);
     const served = m ? m.viewsSeq : undefined;
     const adopted = viewsCapsAdopts(this._rejectedViews, served);
-    if (adopted) this._views = this._rejectedViews;
+    if (adopted) { this._views = this._rejectedViews; this._reconcileLocalLens(); }   // an adoption is a store read too; repainted below
     this._announcedViewsSeq = adopted ? null : viewsAnnouncedSeq(served);
     this._rejectedViews = null;
     if (this._viewsWrites.length) {
@@ -3754,6 +3758,24 @@ class TimelinePanel {
     if (Object.keys(held.actives).length) fields.actives = held.actives;
     if (held.tagOrder) fields.tagOrder = held.tagOrder;
     return Object.keys(fields).length ? { fields, reason } : null;
+  }
+  // The store read is the other event that settles an unsaved filter (review find, 2026-09-08, on
+  // #1078): a held key whose value the adopted store now carries, because a dashboard saved that same
+  // filter, or this panel's own write landed after an answer that read as unreachable, is released on
+  // the poll or ack that shows it (_takeViews), so the not-saved note never outlives the fact. A key the
+  // store carries with a DIFFERENT value stays held: that is still the viewer's own unsaved choice.
+  // Returns whether anything was released, for the caller's repaint.
+  _reconcileLocalLens() {
+    if (!this._localLens) return false;
+    const store = this._views || {}, f = this._localLens.fields;
+    const held = { active: f.active, actives: Object.assign({}, f.actives || {}), tagOrder: f.tagOrder };
+    if (held.active !== undefined && lensSame(held.active, store.active)) delete held.active;
+    for (const k of Object.keys(held.actives)) if (lensSame(held.actives[k], (store.actives || {})[k])) delete held.actives[k];
+    if (held.tagOrder && lensSame(held.tagOrder, shownTagOrder(store))) delete held.tagOrder;
+    const next = this._heldLens(held, this._localLens.reason);
+    if (lensSame(next && next.fields, this._localLens.fields)) return false;
+    this._localLens = next;
+    return true;
   }
 
   // the viewsAck frame for a POST /views answer: the route's own document when a kernel ruled; a
@@ -4723,11 +4745,17 @@ class TimelinePanel {
   // it cannot check, since this panel cannot tell "no kernel anywhere" from "a kernel it cannot see"
   // (a stale record, another port, a token from another state dir), and the second case is exactly the
   // race this removes. Same-user trust boundary as every kernel client: the serve token comes from the
-  // kernel's 0600 file and rides the X-Romp-Token header (never a URL), the port from the kernel's own
-  // record (never a guess). A panel reading SYNCED state on another machine finds a record no kernel of
-  // its own answers on and lands in the same refusal. Node's http, not fetch: a fetch from Obsidian's
-  // app:// origin with a custom header needs a CORS preflight, and a failed preflight reads exactly like
-  // a kernel that is down.
+  // kernel's 0600 file and rides the X-Romp-Token header (never a URL). The port is the kernel's own
+  // record (serve-port), or, with NO record (a kernel older than this panel wrote the token and no port),
+  // the port the CLI resolves: ROMP_KERNEL_PORT, then ROMP_SERVE_PORT, else 29855. Record or fallback,
+  // the port must first PROVE itself a romp kernel before any token leaves this panel (_kernelProve: GET
+  // /healthz with no token, on 127.0.0.1 only, answered 200 "ok" with the X-Romp-Boot identity), and the
+  // POST then rides the connection that proved itself; a port that answers as anything else, a stale
+  // record another local service now listens on, is refused by name and never sees the token (review
+  // find, 2026-09-08, on #1078). A panel reading SYNCED state on another machine finds a record no
+  // kernel of its own answers on and lands in the same refusal. Node's http, not fetch: a fetch from
+  // Obsidian's app:// origin with a custom header needs a CORS preflight, and a failed preflight reads
+  // exactly like a kernel that is down.
   _kernelHost() {
     // Electron (Obsidian) only: a bare-node run (the test runner) and a browser page (which has its host
     // hooks) have no kernel to post to from here — the guard the file writers wore (the user 2026-07-02)
@@ -4754,11 +4782,13 @@ class TimelinePanel {
   // request: nothing answering (KERNEL_DOWN, or KERNEL_DOWN_NO_RECORD when the port was the CLI's
   // default rather than the kernel's record), a record or token file this panel could not read, a
   // kernel that predates the route (a 404), or some other local service that now owns the recorded
-  // port (`foreign`: a 2xx that is not a romp answer — read as accepted, that left the optimistic toggle
-  // re-applied on every push until a value that never comes, the silent divergence this change exists
-  // to remove). A body that stalls or a socket that drops after the headers settles too (res 'error' /
-  // 'aborted' / 'close' behind the done guard): unsettled, the optimistic state stood forever with no
-  // message, and the unhandled 'error' was an uncaught exception in the renderer.
+  // port (`foreign`: a port that fails the identity check before the POST, or a 2xx that is not a romp
+  // answer; read as accepted, that left the optimistic toggle re-applied on every push until a value
+  // that never comes, the silent divergence this change exists to remove). The token leaves this panel
+  // only AFTER the port has proved itself (_kernelProve), and rides the connection that did. A body that
+  // stalls or a socket that drops after the headers settles too (res 'error' / 'aborted' / 'close'
+  // behind the done guard): unsettled, the optimistic state stood forever with no message, and the
+  // unhandled 'error' was an uncaught exception in the renderer.
   _kernelPost(route, body) {
     const h = this._kernelHost();
     if (!h) return Promise.resolve({ ok: false, unreachable: true, error: KERNEL_DOWN });
@@ -4791,14 +4821,22 @@ class TimelinePanel {
         : envVar + '=' + JSON.stringify(envRaw) + ' is not a port' });
     const down = recorded ? KERNEL_DOWN : KERNEL_DOWN_NO_RECORD;
     const where = '127.0.0.1:' + port;
-    return new Promise((resolve) => {
+    // one keep-alive connection for the proof and the write, so the token rides the very connection that
+    // answered as a romp kernel (best effort: a server that closes after the proof gets a fresh connection
+    // to the same port, the proof still immediately before it); torn down when the write settles
+    let agent = null;
+    try { agent = new (require('http').Agent)({ keepAlive: true, maxSockets: 1 }); } catch (e) { agent = null; }
+    const teardown = () => { try { if (agent) agent.destroy(); } catch (e) {} };
+    return this._kernelProve(port, agent, down).then((proof) => {
+      if (!proof.ok) { teardown(); return proof; }              // no token was sent; the refusal names the port
+      return new Promise((resolve) => {
       let done = false;
-      const finish = (r) => { if (!done) { done = true; resolve(r); } };
+      const finish = (r) => { if (!done) { done = true; teardown(); resolve(r); } };
       const dropped = () => finish({ ok: false, unreachable: true, error: down });
       try {
         const data = JSON.stringify(body);
         const req = require('http').request({
-          host: '127.0.0.1', port, path: route, method: 'POST',
+          host: '127.0.0.1', port, path: route, method: 'POST', agent: agent || undefined,
           headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data), 'X-Romp-Token': tok },
         }, (res) => {
           let text = '';
@@ -4826,6 +4864,42 @@ class TimelinePanel {
         req.on('error', dropped);
         req.setTimeout(10000, () => req.destroy());
         req.end(data);
+      } catch (e) { dropped(); }
+      });
+    });
+  }
+
+  // Before any token leaves this panel, the port must prove it is a romp kernel (review find, 2026-09-08,
+  // on #1078): GET /healthz, the kernel's auth-exempt liveness route, with NO token, on 127.0.0.1 only,
+  // answered 200 with the frozen body "ok" and the X-Romp-Boot kernel identity (<pid>.<epoch>, the header
+  // the restart flow keys on). Until this check the token was sent to whatever listened on the recorded
+  // port, so a stale serve-port record another local service had since bound received it. Anything else
+  // on the port is refused by name (`foreign`) and never sees the token; nothing answering is the caller's
+  // `down` text. Rides `agent`, the keep-alive connection the POST then reuses. Resolves {ok:true, boot}
+  // or the writer's refusal shape; never rejects.
+  _kernelProve(port, agent, down) {
+    const where = '127.0.0.1:' + port;
+    return new Promise((resolve) => {
+      let done = false;
+      const finish = (r) => { if (!done) { done = true; resolve(r); } };
+      const dropped = () => finish({ ok: false, unreachable: true, error: down });
+      const foreign = (why) => finish({ ok: false, unreachable: true, foreign: true,
+        error: where + ' answered, but not as a romp kernel (' + why + "); this panel's token was not sent to it" });
+      try {
+        const req = require('http').request({ host: '127.0.0.1', port, path: '/healthz', method: 'GET', agent: agent || undefined }, (res) => {
+          let text = '';
+          res.setEncoding('utf8');
+          res.on('data', (c) => { if (text.length < 4096) text += c; });
+          res.on('error', dropped); res.on('aborted', dropped); res.on('close', dropped);
+          res.on('end', () => {
+            const st = res.statusCode || 0, boot = String(res.headers['x-romp-boot'] || '');
+            if (st === 200 && text.trim() === 'ok' && /^\d+\.\d+$/.test(boot)) return finish({ ok: true, boot });
+            foreign('GET /healthz answered HTTP ' + st + (boot ? '' : ' with no kernel identity'));
+          });
+        });
+        req.on('error', dropped);
+        req.setTimeout(10000, () => req.destroy());
+        req.end();
       } catch (e) { dropped(); }
     });
   }

--- a/ui/timeline-kernel-post.test.ts
+++ b/ui/timeline-kernel-post.test.ts
@@ -76,11 +76,16 @@ async function asObsidian(records: { port?: number | string; token?: string; env
   }
 }
 
-// a kernel stand-in on loopback: keeps every request, answers what the test says — a JSON body, or
-// `raw` text, or (`drop`) headers and a partial body followed by a destroyed socket
-type Seen = { method: string; url: string; headers: http.IncomingHttpHeaders; body: any };
-type Answer = { status: number; body?: any; raw?: string; drop?: boolean };
-function kernel(answer: (req: Seen) => Answer) {
+// a kernel stand-in on loopback: keeps every request (with the client port it came in on), answers what
+// the test says: a JSON body, or `raw` text, or (`drop`) headers and a partial body followed by a
+// destroyed socket. GET /healthz, the identity the panel asks for before it sends a token, is answered
+// as a romp kernel answers it (200 "ok" with X-Romp-Boot) unless the test hands the stand-in another
+// answer (`healthz`: what a squatter on the port would say)
+type Seen = { method: string; url: string; headers: http.IncomingHttpHeaders; body: any; remotePort: number };
+type Answer = { status: number; body?: any; raw?: string; drop?: boolean; headers?: Record<string, string> };
+const HEALTHZ_KERNEL: Answer = { status: 200, raw: "ok", headers: { "X-Romp-Boot": "4242.1781000000" } };
+const posts = (k: { seen: Seen[] }) => k.seen.filter((q) => q.method === "POST");
+function kernel(answer: (req: Seen) => Answer, opts: { healthz?: Answer } = {}) {
   return new Promise<{ port: number; seen: Seen[]; close: () => Promise<void> }>((resolve) => {
     const seen: Seen[] = [];
     const srv = http.createServer((req, res) => {
@@ -90,11 +95,11 @@ function kernel(answer: (req: Seen) => Answer) {
       req.on("end", () => {
         let body: any = null;
         try { body = text ? JSON.parse(text) : null; } catch { body = text; }
-        const rec: Seen = { method: req.method || "", url: req.url || "", headers: req.headers, body };
+        const rec: Seen = { method: req.method || "", url: req.url || "", headers: req.headers, body, remotePort: req.socket.remotePort || 0 };
         seen.push(rec);
-        const a = answer(rec);
+        const a = (rec.method === "GET" && rec.url === "/healthz") ? (opts.healthz || HEALTHZ_KERNEL) : answer(rec);
         if (a.drop) { res.writeHead(a.status, { "Content-Type": "application/json", "Content-Length": "40" }); res.write('{"ok":'); setTimeout(() => res.destroy(), 5); return; }
-        res.writeHead(a.status, { "Content-Type": a.raw !== undefined ? "text/plain" : "application/json" });
+        res.writeHead(a.status, Object.assign({ "Content-Type": a.raw !== undefined ? "text/plain" : "application/json" }, a.headers || {}));
         res.end(a.raw !== undefined ? a.raw : JSON.stringify(a.body));
       });
     });
@@ -116,8 +121,10 @@ test("executed: the token rides the header from the kernel's 0600 file, the port
       const r = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
       assert.equal(r.ok, true);
       assert.equal(r.body.value, true, "the kernel's answer rides back whole");
-      assert.equal(k.seen.length, 1, "one request");
-      const q = k.seen[0];
+      assert.equal(k.seen.length, 2, "the proof, then the write");
+      assert.deepEqual([k.seen[0].method, k.seen[0].url, k.seen[0].headers["x-romp-token"]], ["GET", "/healthz", undefined], "the port proves itself first, with no token in that request");
+      assert.equal(k.seen[0].remotePort, k.seen[1].remotePort, "the write rides the connection that proved itself");
+      const q = k.seen[1];
       assert.equal(q.method, "POST");
       assert.equal(q.url, "/flag", "the route and nothing else — no token in the URL");
       assert.equal(q.headers["x-romp-token"], TOKEN, "the token from the file, in the header every kernel client uses");
@@ -207,12 +214,13 @@ test("executed: no serve-port record → the CLI's port (env, else 29855) is tri
     await asObsidian({ token: TOKEN, envPort: k.port }, async () => {
       const r = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
       assert.equal(r.ok, true, "ROMP_KERNEL_PORT, as bin/romp resolves it");
-      assert.equal(k.seen.length, 1);
-      assert.equal(k.seen[0].headers["x-romp-token"], TOKEN);
+      assert.equal(posts(k).length, 1);
+      assert.equal(posts(k)[0].headers["x-romp-token"], TOKEN);
+      assert.deepEqual([k.seen[0].method, k.seen[0].url], ["GET", "/healthz"], "the fallback port proves itself first, like the recorded one");
       delete process.env.ROMP_KERNEL_PORT; process.env.ROMP_SERVE_PORT = String(k.port);
       const r2 = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
       assert.equal(r2.ok, true, "ROMP_SERVE_PORT too, as cli/keyswap.py resolves it");
-      assert.equal(k.seen.length, 2);
+      assert.equal(posts(k).length, 2);
     });
   } finally { await k.close(); }
   // a kernel there from before these routes: 404, named as such — not "not running"
@@ -698,4 +706,139 @@ test("plain node never posts: the writers do nothing without a host hook or Elec
   assert.equal(p._viewsWrites.length, 0, "no write record was minted for a write that never left");
   assert.match(SRC, /_kernelHost\(\) \{[\s\S]{0,500}if \(typeof process === 'undefined' \|\| !process\.versions \|\| !process\.versions\.electron\) return null;/,
     "the one Electron-or-nothing guard every writer takes");
+});
+
+test("executed: before the token leaves this panel the port must prove itself over GET /healthz with no token; a port another service answers on receives nothing else and is refused by name (review find, 2026-09-08, on #1078)", async () => {
+  // a stale serve-port record that some other local service now listens on: every shape a squatter can
+  // answer the proof with. The stand-in would ACCEPT the POST if it ever arrived, so a token leaking
+  // through would read as ok:true here
+  const squatters: [string, Answer][] = [
+    ["a plain 200 OK", { status: 200, raw: "OK" }],
+    ["a JSON service", { status: 200, body: { ok: true } }],
+    ["a 404", { status: 404, raw: "not found" }],
+    ["the body without the kernel identity header", { status: 200, raw: "ok" }],
+    ["the header on the wrong body", { status: 200, raw: "ready", headers: { "X-Romp-Boot": "1.2" } }],
+  ];
+  for (const [label, hz] of squatters) {
+    const sq = await kernel(() => ({ status: 200, body: { ok: true, id: SID, flag: "hideFromFeed", value: true } }), { healthz: hz });
+    try {
+      await asObsidian({ port: sq.port, token: TOKEN }, async () => {
+        const p = panel();
+        const r = await p._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+        assert.deepEqual([r.ok, r.unreachable, r.foreign], [false, true, true], label);
+        assert.ok(r.error.startsWith("127.0.0.1:" + sq.port + " answered, but not as a romp kernel (GET /healthz answered HTTP " + hz.status), label + ": " + r.error);
+        assert.ok(r.error.endsWith("); this panel's token was not sent to it"), label + ": " + r.error);
+        assert.equal(sq.seen.length, 1, label + ": the proof and nothing after it");
+        assert.deepEqual([sq.seen[0].method, sq.seen[0].url], ["GET", "/healthz"], label);
+        // the writer, as the gear runs it: the toggle goes back where the click found it and the gear says why
+        const s = p.data.sessions[0];
+        await gearClick(p, s, true);
+        assert.deepEqual([s.hideFromFeed, p._pendingFlags], [false, {}], label);
+        assert.ok(p._laneRefusal.text.startsWith("couldn't save that setting — 127.0.0.1:" + sq.port + " answered, but not as a romp kernel"), label + ": " + p._laneRefusal.text);
+        for (const q of sq.seen) {
+          assert.equal(q.headers["x-romp-token"], undefined, label + ": no token ever reached the port");
+          assert.equal(q.headers["authorization"], undefined, label);
+          assert.equal(q.method + " " + q.url, "GET /healthz", label + ": nothing but token-less proofs");
+        }
+      });
+    } finally { await sq.close(); }
+  }
+  // the CLI-default fallback (no record) goes through the very same proof: a squatter there sees no token either
+  const sq2 = await kernel(() => ({ status: 200, body: { ok: true } }), { healthz: { status: 200, raw: "OK" } });
+  try {
+    await asObsidian({ token: TOKEN, envPort: sq2.port }, async () => {
+      const r = await panel()._kernelPost("/order", { order: [SID] });
+      assert.deepEqual([r.ok, r.unreachable, r.foreign], [false, true, true]);
+      assert.equal(sq2.seen.length, 1);
+      assert.ok(sq2.seen.every((q) => q.method === "GET" && q.url === "/healthz" && q.headers["x-romp-token"] === undefined), "the fallback port is asked to prove itself and the token stays home");
+    });
+  } finally { await sq2.close(); }
+  // a kernel that proves itself gets the write: the proof first, the token only on the POST, both on one connection
+  const k = await kernel(() => ({ status: 200, body: { ok: true, order: [SID] } }));
+  try {
+    await asObsidian({ port: k.port, token: TOKEN }, async () => {
+      const r = await panel()._kernelPost("/order", { order: [SID] });
+      assert.equal(r.ok, true);
+      assert.deepEqual(k.seen.map((q) => [q.method, q.url, q.headers["x-romp-token"]]), [["GET", "/healthz", undefined], ["POST", "/order", TOKEN]]);
+      assert.equal(k.seen[0].remotePort, k.seen[1].remotePort, "the token rides the connection that answered as a romp kernel");
+    });
+  } finally { await k.close(); }
+  // nothing answering on the proof is still plainly 'not running' (the record's word), never 'not a romp kernel'
+  await asObsidian({ token: TOKEN, port: await closedPort() }, async () => {
+    const r = await panel()._kernelPost("/flag", { id: SID, flag: "hideFromFeed", value: true });
+    assert.deepEqual([r.ok, r.unreachable, r.foreign, r.error], [false, true, undefined, KERNEL_DOWN]);
+  });
+  // the shape: the proof gates the POST, on loopback, the liveness route, no token in that request
+  const kp = SRC.slice(SRC.indexOf("  _kernelPost(route, body) {"), SRC.indexOf("  _kernelProve(port, agent, down) {"));
+  assert.ok(kp.length > 0 && kp.length < 9000, "the writer's slice");
+  assert.match(kp, /return this\._kernelProve\(port, agent, down\)\.then\(\(proof\) => \{\s*\n\s*if \(!proof\.ok\) \{ teardown\(\); return proof; \}/, "the proof gates the POST; a failed proof is the answer, and no request follows it");
+  assert.ok(kp.indexOf("this._kernelProve(") < kp.indexOf("'X-Romp-Token': tok"), "the proof is asked before the token is put in any header");
+  const pv = SRC.slice(SRC.indexOf("  _kernelProve(port, agent, down) {"), SRC.indexOf("  _kernelProve(port, agent, down) {") + 3500);
+  assert.match(pv, /host: '127\.0\.0\.1', port, path: '\/healthz', method: 'GET', agent: agent \|\| undefined \}/, "loopback only, the liveness route, no headers at all");
+  assert.doesNotMatch(pv, /X-Romp-Token|\btok\b/, "no token in the proof");
+  assert.ok(pv.includes("if (st === 200 && text.trim() === 'ok' && /^\\d+\\.\\d+$/.test(boot)) return finish({ ok: true, boot });"),
+    "the frozen liveness body and the kernel identity header (X-Romp-Boot: <pid>.<epoch>), both required");
+  // the fallback is STATED, in the panel, the kernel's record docstring and the reference, as what it is
+  assert.match(SRC, /the port the CLI resolves: ROMP_KERNEL_PORT, then ROMP_SERVE_PORT, else 29855\. Record or fallback,\s*\n\s*\/\/ the port must first PROVE itself a romp kernel/, "the panel's comment");
+  assert.doesNotMatch(SRC, /the port from the kernel's own\s*\n\s*\/\/ record \(never a guess\)/, "the sentence that was untrue is gone");
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(KERNEL, /the panel tries the port the CLI resolves -- ROMP_KERNEL_PORT,\s*\n\s*then ROMP_SERVE_PORT, else 29855/, "the serve-port record's docstring");
+  assert.match(KERNEL, /the panel first asks the port to prove itself over GET \/healthz/, "and it names the proof");
+  assert.doesNotMatch(KERNEL, /never guessing a port or falling back to a write the kernel cannot check/, "the record's untrue sentence is gone");
+  const DOCS = fs.readFileSync(path.resolve(process.cwd(), "..", "docs", "reference.md"), "utf8");
+  assert.match(DOCS, /it tries the port the command line resolves, `ROMP_KERNEL_PORT`, then\s*\n`ROMP_SERVE_PORT`, else `29855`/, "the reference");
+  assert.match(DOCS, /`GET \/healthz` with no token, on `127\.0\.0\.1` only, must answer `200 ok` with\s*\nthe kernel's `X-Romp-Boot` identity before the token is sent/);
+});
+
+test("executed: the not-saved note is reconciled on the store read: a poll that shows the store carrying the held filter releases it and repaints the Filter menu; a different store value or a stale frame leaves it (review find, 2026-09-08, on #1078)", async () => {
+  await withDom(() => asObsidian({}, async () => {
+    const p = panel();
+    const answers: any[] = [];
+    p._kernelPost = () => Promise.resolve(answers.shift());
+    const S = { active: "all", actives: { timeline: { all: true } }, seq: 3, tags: [{ id: "gA", name: "web", color: "#3b82f6", members: [SID] }] };
+    p._views = S;
+    p._openViewsMenu(makeNode("button"));
+    const menu = p._viewsMenu;
+    // no kernel takes the lens write: held locally, said in the menu
+    answers.push({ ok: false, unreachable: true, error: KERNEL_DOWN });
+    rowNamed(menu, "web")._listeners.click();
+    await tick();
+    assert.ok(rows(menu).includes("⚠ this filter is not saved — " + KERNEL_DOWN), "held, and said: " + JSON.stringify(rows(menu)));
+    assert.deepEqual(timelineLens(p._curViews()).tags, ["web"]);
+    // a poll whose store carries a DIFFERENT timeline filter (a dashboard picked another tag): the viewer's own
+    // unsaved choice still stands, note and all
+    const tags = S.tags.concat([{ id: "gB", name: "other", color: "#ef4444", members: [SID2] }]);
+    const other = Object.assign({}, S, { actives: { timeline: { tags: ["other"] }, chat: { all: true } }, seq: 4, tags });
+    assert.equal(p._takeViews(other), true, "adopted");
+    assert.deepEqual(timelineLens(p._curViews()).tags, ["web"], "the held filter still shows over the store's");
+    assert.ok(rows(menu).includes("⚠ this filter is not saved — " + KERNEL_DOWN), "still unsaved, still said");
+    // a stale frame (an older seq) adopts nothing and settles nothing
+    assert.equal(p._takeViews(Object.assign({}, other, { actives: { timeline: { tags: ["web"] } }, seq: 2 })), false);
+    assert.ok(p._localLens, "a frame the gate turned away is not the store");
+    assert.ok(rows(menu).includes("⚠ this filter is not saved — " + KERNEL_DOWN));
+    // the poll that shows the store carrying the very filter (a dashboard saved it, or this panel's own write landed
+    // after an answer that read as unreachable): released on that read, the note gone, the menu repainted in place
+    const saved = Object.assign({}, other, { actives: { timeline: { tags: ["web"] }, chat: { all: true } }, seq: 5 });
+    assert.equal(p._takeViews(saved), true);
+    assert.equal(p._localLens, null, "nothing held: the store has it");
+    assert.ok(!rows(menu).some((t: string) => t.startsWith("⚠")), "the note went with it: " + JSON.stringify(rows(menu)));
+    assert.ok(rowNamed(menu, "web").textContent.endsWith("✓"), "the filter shows, as the store's now");
+    assert.deepEqual(timelineLens(p._curViews()).tags, ["web"]);
+    p._closeViewsMenu();
+  }));
+  // per key: only the keys the store now carries are released; the rest stay held with the reason, and a
+  // second read with nothing new releases nothing (no repaint for nothing)
+  const p = panel();
+  p._views = { active: "all", actives: { timeline: { tags: ["web"] }, chat: { all: true } }, tagOrder: ["web", "api"], seq: 9,
+               tags: [{ id: "gA", name: "web", color: "#3b82f6", members: [] }, { id: "gB", name: "api", color: "#ef4444", members: [] }] };
+  p._localLens = { fields: { actives: { timeline: { tags: ["web"] }, chat: { tags: ["api"] } }, tagOrder: ["web", "api"] }, reason: KERNEL_DOWN };
+  assert.equal(p._reconcileLocalLens(), true);
+  assert.deepEqual(p._localLens, { fields: { actives: { chat: { tags: ["api"] } } }, reason: KERNEL_DOWN }, "the timeline filter and the pill order the store carries are released; the chat filter it does not is held");
+  assert.equal(p._reconcileLocalLens(), false, "nothing more to release");
+  p._localLens = null;
+  assert.equal(p._reconcileLocalLens(), false);
+  // the event: the store read, in _takeViews (the poll's update() and the ack's viewsAck both land there) and the caps adoption
+  assert.match(SRC, /if \(data\.views\) this\._takeViews\(data\.views\);/, "the poll adopts the store through _takeViews");
+  assert.match(SRC, /this\._views = v; this\._rejectedViews = null;\s*\n\s*if \(this\._reconcileLocalLens\(\)\) this\._repaintTagSurfaces\(\);/, "…which reconciles the held lens on adoption and repaints only when something was released");
+  assert.match(SRC, /if \(adopted\) \{ this\._views = this\._rejectedViews; this\._reconcileLocalLens\(\); \}/, "the caps frame's adoption too");
 });


### PR DESCRIPTION
Follow-up to #1078 from its review, which finished after that PR had merged. Three findings, each landing with a test that fails without the fix.

- **Lost writes on the flag and order stores.** `POST /flag` and `POST /order`, and the socket arms that share their setters, did unlocked read-modify-writes: a probe with 32 concurrent flag writes kept 7 to 13 of them while every writer was acked `ok:true`. Each store now has a lock around its proved read and its publish; the order store's newcomer splice and prune take it too. Lock order is one-directional, so no new deadlock path. Tests: 32 concurrent route writes all survive with truthful acks; a route write interleaved with a socket write; the order route interleaved with a drag; a source-shape pin that every writer of each store takes its lock.
- **The panel sent the serve token to an unproved port.** The Obsidian panel read the token from disk and sent it to whatever listened on the recorded port. It now issues `GET /healthz` with no headers first and requires the kernel's boot-id header on the exact body before any token leaves the panel; a squatter gets a named refusal in the lane and no token. The CLI-default port fallback stays, goes through the same proof, and the docs, the kernel docstring and the panel comment now say so instead of claiming the panel never guesses a port. Tests: five squatter shapes each receive one header-less request and no token; a kernel that proves itself gets the write on the same connection; a closed port still reads as kernel down.
- **The Filter lens's "not saved" note could outlive the store.** It is reconciled on every adopted store read, so the note leaves the moment the store carries the filter, keyed on the read rather than a timer.

Tests: full Python suite 9532 passed; extension suite 3442 passed, typecheck clean. With the fixes stashed, 5 Python tests and 4 extension tests fail.

Tier: fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
