### PR TITLE
Auto-reload review folds: queued sends hold the reload, touch pans and any editable count, the refusal latches, the record is per tab

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -39347,7 +39347,7 @@ body{font-family:var(--vscode-font-family);font-size:13px;color:var(--vscode-for
 
 # The WS bridge shim (ported verbatim from chat-view server.ts shimJs — same protocol).
 # ── the dashboard reloads ITSELF on a kernel restart and on a newer served bundle (T265) ──────────────────────
-# The user's ruling of 2026-09-08 (about 10:50 AM PT) supersedes their 2026-07-13 preference for a banner the
+# The user's ruling of 2026-09-08 supersedes their 2026-07-13 preference for a banner the
 # reader clicks: any restart of the kernel SERVING the page, and any bundle newer than the one the page loaded
 # with, reload the page by themselves. Two signals, both exact events, never a timer:
 #   (1) kernel restart — a socket REOPEN whose /version answers with a boot id other than the one baked into the
@@ -39355,61 +39355,79 @@ body{font-family:var(--vscode-font-family);font-size:13px;color:var(--vscode-for
 #       reconnect); the 30 s /version poll the stale banner already ran is the backstop for a page whose socket
 #       never dropped (noteVersion, the same reading).
 #   (2) build drift — a `dv` on a keepalive, or /version's dist_ver, above the page's baked LOADEDV (noteDv).
-# Never mid-gesture: a pointer button held, a drag in flight, a text selection being made, or the composer
-# focused with text ARMS the reload, and the ending event (pointerup/pointercancel, dragend/drop,
-# selectionchange, input, focusout; a window blur releases every hold) fires it. The shell composes gesture state
-# across its same-origin panes, and a pane forwards its request to the shell when one is there, so ONE decision
-# reloads the top document; a standalone pane page decides for itself, and so does a pane under a foreign parent
-# (an iframe in another app can reload itself). Before reloading: every pane persists what a reload loses
-# (window.__rompPersistForReload — the chat pane's scroll position + follow mode; the draft and the active tab are
-# persisted already), the shell's lifted modals close (settings/picker), and a marker rides sessionStorage so the
-# fresh page leaves ONE notification-center line ("Reloaded onto build N — the kernel restarted / a newer romp
-# build was served"). If location.reload throws (a host that forbids it) the old banner is the fallback (the
-# `refused` hook). The VS Code webview never runs this: the extension loads its bundle from the installed VSIX
+# Never mid-gesture: a pointer button held, a touch pan (pointercancel converts a held pointer into a pan hold
+# that touchend/touchcancel/scrollend release — the finger is still on the glass), a drag in flight, a text
+# selection being made in the FOCUSED document (a highlight left in another pane is not a gesture), any focused
+# editable with text (the composer, the picker's inputs, the feed modal's follow-up box — a generic "typing"
+# hold), or a pane's sends still queued for its socket's reopen (the shim's window.__rompPaneBusy: a prompt typed
+# while the kernel was down must flush before the page goes) ARMS the reload, and the ending event fires it —
+# pointerup, touchend/touchcancel/scrollend, dragend/drop, selectionchange, input, focusout, the pane's own flush;
+# a window blur releases every hold. The fire is deferred one tick past the ending event so the click the same
+# press produces lands on its control first. The shell composes gesture state across its same-origin panes, and a
+# pane forwards its request to the shell when one is there, so ONE decision reloads the top document; a standalone
+# pane page decides for itself, and so does a pane under a foreign parent (an iframe in another app can reload
+# itself). Before reloading: every pane persists what a reload loses (window.__rompPersistForReload — the chat
+# pane's scroll position + follow mode, per tab in sessionStorage; the draft and the active tab are persisted
+# already); once location.reload has been accepted the shell's lifted modals close (settings/picker) and a marker
+# rides sessionStorage, stamped with the page's path, so the fresh LANDING leaves ONE notification-center line
+# ("Reloaded onto build N — the kernel restarted / a newer romp build was served") and a standalone pane's marker
+# is consumed by nobody else. If location.reload throws (a host that forbids it) the old banner is the fallback
+# (the `refused` hook) and the refusal LATCHES for that build/boot: no re-attempt on every gesture end or poll,
+# only a strictly newer dv or boot re-arms. The VS Code webview never runs this: the extension loads its bundle from the installed VSIX
 # and a webview reload cannot fix bundled-code drift, so its own reload prompt stays (vscode-extension/src/
 # extension.ts). Federated relay: a REMOTE kernel's restart must not reload the page — and cannot: the core reads
 # only THIS page's own socket and /version (federation.ts drops remote `ka` frames, so they never reach the shim's
 # dv check, and the relay never forwards a remote kernel's boot id). tests/test_dashboard_auto_reload.py runs
 # this code in node with fakes and pins the wiring.
 _RELOAD_CORE_JS = r"""/*reload-core*/(function(){if(window.__rompReload)return;
-var LOADED=__LOADEDVER__,BOOT=__ROMP_BOOT__,ptr=0,drag=false,owed=null,fired=false;
+var LOADED=__LOADEDVER__,BOOT=__ROMP_BOOT__,ptr=0,pan=false,drag=false,owed=null,fired=false,refusedFor=null;
 function shell(){try{var p=window.parent;if(p&&p!==window&&p.__rompReload)return p.__rompReload;}catch(e){}return null;}
-function busyHere(){if(ptr>0)return 'pointer';if(drag)return 'drag';
-try{var s=document.getSelection&&document.getSelection();if(s&&s.rangeCount&&!s.isCollapsed&&String(s).length)return 'selection';}catch(e){}
-try{var c=document.getElementById('composer-input');if(c&&document.activeElement===c&&(c.value||'').trim())return 'composer';}catch(e){}
+function editing(){try{var a=document.activeElement;if(!a)return false;var tag=(a.tagName||'').toUpperCase();
+var textual=tag==='TEXTAREA'||(tag==='INPUT'&&/^(text|search|url|email|number|password|tel)$/i.test(a.type||'text'))||!!a.isContentEditable;
+if(!textual)return false;var val=(a.value!=null?a.value:(a.textContent||''));return !!String(val).trim();}catch(e){return false;}}
+function busyHere(){if(ptr>0)return 'pointer';if(pan)return 'pan';if(drag)return 'drag';
+try{var s=document.getSelection&&document.getSelection();var focused=!document.hasFocus||document.hasFocus();
+if(focused&&s&&s.rangeCount&&!s.isCollapsed&&String(s).length)return 'selection';}catch(e){}
+if(editing())return 'typing';
+try{if(window.__rompPaneBusy){var b=window.__rompPaneBusy();if(b)return String(b);}}catch(e){}
 return '';}
 function panes(){var out=[],fs=document.querySelectorAll?document.querySelectorAll('iframe'):[];
 for(var i=0;i<fs.length;i++){try{var w=fs[i].contentWindow;if(w&&w.__rompReload)out.push(w);}catch(e){}}return out;}
 function busy(){var b=busyHere();if(b)return b;var ps=panes();for(var i=0;i<ps.length;i++){b=ps[i].__rompReload.busyHere();if(b)return b;}return '';}
 function persist(){try{if(window.__rompPersistForReload)window.__rompPersistForReload();}catch(e){}
 var ps=panes();for(var i=0;i<ps.length;i++){try{if(ps[i].__rompPersistForReload)ps[i].__rompPersistForReload();}catch(e){}}}
-function fire(){if(fired)return;fired=true;
-try{sessionStorage.setItem('romp:reloaded',JSON.stringify({reason:owed.reason,detail:owed.detail||'',from:LOADED,t:Date.now()}));}catch(e){}
-persist();
-try{document.body.classList.remove('settings-open','picker-open');}catch(e){}
-try{location.reload();}catch(e){fired=false;R.waiting='refused';if(R.refused)R.refused(owed);}}
-function tryFire(){if(!owed||fired)return;var b=busy();if(b){R.waiting=b;return;}R.waiting='';fire();}
+function key(o){return o?o.reason+':'+(o.detail||''):'';}
+function fire(){if(fired)return;fired=true;persist();
+try{location.reload();}catch(e){fired=false;refusedFor=key(owed);R.waiting='refused';if(R.refused)R.refused(owed);return;}
+try{sessionStorage.setItem('romp:reloaded',JSON.stringify({reason:owed.reason,detail:owed.detail||'',from:LOADED,path:location.pathname,t:Date.now()}));}catch(e){}
+try{document.body.classList.remove('settings-open','picker-open');}catch(e){}}
+function tryFire(){if(!owed||fired)return;if(refusedFor!==null&&refusedFor===key(owed))return;var b=busy();if(b){R.waiting=b;return;}R.waiting='';fire();}
 function request(reason,detail){var s=shell();if(s){s.request(reason,detail);return;}if(fired)return;
-if(!owed)owed={reason:reason,detail:detail||''};tryFire();}
+var next={reason:reason,detail:detail||''};if(refusedFor!==null&&key(next)!==refusedFor){refusedFor=null;owed=next;}
+if(!owed)owed=next;tryFire();}
 function noteDv(dv){if(LOADED&&dv&&dv>LOADED)request('build',String(dv));}
 function noteVersion(v){if(!v)return;if(v.boot&&BOOT&&v.boot!==BOOT)request('restart',String(v.boot));if(v.dist_ver)noteDv(v.dist_ver);}
 function checkBoot(){try{fetch('/version',{cache:'no-store'}).then(function(r){return r.json();}).then(noteVersion)['catch'](function(){});}catch(e){}}
 function announce(notify){var raw=null;try{raw=sessionStorage.getItem('romp:reloaded');if(raw)sessionStorage.removeItem('romp:reloaded');}catch(e){}
 if(!raw)return null;var d=null;try{d=JSON.parse(raw);}catch(e){return null;}if(!d)return null;
+if(d.path&&d.path!==location.pathname)return null;
 var why=d.reason==='restart'?'the kernel restarted':'a newer romp build was served';
 var txt='Reloaded onto build '+LOADED+' — '+why+'.';try{if(notify)notify('reload',txt);}catch(e){}return txt;}
 document.addEventListener('pointerdown',function(){ptr++;},true);
 document.addEventListener('pointerup',function(){ptr=Math.max(0,ptr-1);},true);
-document.addEventListener('pointercancel',function(){ptr=Math.max(0,ptr-1);},true);
+document.addEventListener('pointercancel',function(){if(ptr>0){ptr=0;pan=true;}},true);
+document.addEventListener('touchend',function(){pan=false;},true);
+document.addEventListener('touchcancel',function(){pan=false;},true);
+document.addEventListener('scrollend',function(){pan=false;},true);
 document.addEventListener('dragstart',function(){drag=true;},true);
 document.addEventListener('dragend',function(){drag=false;},true);
 document.addEventListener('drop',function(){drag=false;},true);
-var END=['pointerup','pointercancel','dragend','drop','selectionchange','input','focusout'];
-function ended(){var s=shell();if(s)s.tryFire();else tryFire();}
+var END=['pointerup','touchend','touchcancel','scrollend','dragend','drop','selectionchange','input','focusout'];
+function ended(){setTimeout(function(){var s=shell();if(s)s.tryFire();else tryFire();},0);}
 for(var k=0;k<END.length;k++)document.addEventListener(END[k],ended,true);
-window.addEventListener('blur',function(){ptr=0;drag=false;ended();});
-var R={request:request,tryFire:tryFire,busyHere:busyHere,busy:busy,noteDv:noteDv,noteVersion:noteVersion,checkBoot:checkBoot,announce:announce,
-inShell:function(){return !!shell();},owed:function(){return owed;},fired:function(){return fired;},refused:null,waiting:'',loaded:LOADED,boot:BOOT};
+window.addEventListener('blur',function(){ptr=0;pan=false;drag=false;ended();});
+var R={request:request,tryFire:tryFire,ended:ended,busyHere:busyHere,busy:busy,noteDv:noteDv,noteVersion:noteVersion,checkBoot:checkBoot,announce:announce,
+inShell:function(){return !!shell();},owed:function(){return owed;},fired:function(){return fired;},refusedFor:function(){return refusedFor;},refused:null,waiting:'',loaded:LOADED,boot:BOOT};
 window.__rompReload=R;})();/*end-reload-core*/"""
 
 
@@ -39434,9 +39452,11 @@ def _reload_core_js(v=0, boot=None):
 
 def _shim(app, v=0):
     # `v` = the dist build token this page was served with (its ?v= urls). The shim compares it against the
-    # `dv` riding every keepalive and raises the build banner on drift — so EVERY kernel-served page gets the
-    # "newer build" prompt, not just the dashboard landing's /version poll (the user 2026-07-13: a standalone
-    # pane sat silent through rebuilds).
+    # `dv` riding every keepalive and, on drift, asks the reload core it embeds as the template's first slot
+    # (window.__rompReload, _RELOAD_CORE_JS) to reload the page — never mid-gesture (the user 2026-09-08,
+    # superseding the 2026-07-13 banner; the build bar is only the refused fallback). EVERY kernel-served page
+    # notices, not just the dashboard landing's /version poll (the user 2026-07-13: a standalone pane sat
+    # silent through rebuilds).
     return """
 %s
 (function(){/*shim-core*/var queue=[],ws=null,everConnected=false;
@@ -39567,6 +39587,12 @@ function armStale(why){stalePending=why;staleKa=0;}
 // this page in place, never mid-gesture. selfBar is only the refused fallback (a host that forbids location.reload).
 // Latched: one request per page life.
 var buildRaised=false,freshPending=false,restartAnnounced=0;   // freshPending: a reconnect is awaiting its resync frame; restartAnnounced: the kernel's dying frame (T217)
+// T265: the reload core asks every pane before firing; a pane whose socket is down with sends queued for its
+// reopen (a prompt typed during a kernel restart) holds the reload — the shell's socket may reopen first, and a
+// reload then would take the queue with it. Diag rows never hold. The flush in ws.onopen is the ending event.
+window.__rompPaneBusy=function(){return (everConnected&&queue.length>queuedDiag)?"sends":"";};
+// …and a standalone page (no same-origin shell) consumes its own reload marker: nobody else would
+try{if(window.__rompReload&&!window.__rompReload.inShell())window.__rompReload.announce(null);}catch(e){}
 function raiseBuild(){if(buildRaised)return;buildRaised=true;var R=window.__rompReload;
 if(R){R.refused=function(){selfBar("A newer romp build is available.","build");};R.request("build","");}
 else selfBar("A newer romp build is available.","build");}
@@ -39587,6 +39613,7 @@ ws=new WebSocket(proto+location.host+"/ws?app=%s&delta=1&iid="+encodeURIComponen
 // first connect deliberately doesn't fire it — nothing is waiting on it, and the loader must stay up until
 // real content lands.
 ws.onopen=function(){lastRecv=Date.now();openT=lastRecv;openSock=this;netState("up");resumeProvisional=0;var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];queuedDiag=0;
+try{if(window.__rompReload)window.__rompReload.ended();}catch(e){}   // T265: the flush is the ending event for the "sends" hold — a reload owed while a prompt sat in the queue goes now
 if(failedConnects){send({type:"clientDiag",surface:"pane-shim",what:"wsconnfail",data:{app:APP,attempts:failedConnects,firstFailMs:Date.now()-firstFailT}});failedConnects=0;firstFailT=0;}   // the redials that never opened since the last open, as ONE row: how many, and how long ago the first failed
 if(wasReconn){var ann=restartAnnounced&&Date.now()-restartAnnounced<30000;restartAnnounced=0;   // one-shot: spent here
 if(window.__rompReload&&!window.__rompReload.inShell())window.__rompReload.checkBoot();   // T265: a REOPEN is the restart signal — a standalone page asks /version whose kernel answered; inside the shell, the shell asks on its own socket

--- a/tests/test_dashboard_auto_reload.py
+++ b/tests/test_dashboard_auto_reload.py
@@ -29,11 +29,13 @@ km = SourceFileLoader("romp_kernel_autoreload", os.path.join(BIN, "romp-kernel")
 HARNESS = r"""
 var LISTENERS = {}, STORE = {}, REMOVED = [], FETCHES = [], RELOADS = 0, REFUSE = false, PERSISTED = 0, WLISTENERS = {};
 var SEL = { rangeCount: 0, isCollapsed: true, toString: function () { return ""; } };
-var COMPOSER = { value: "" };
+var COMPOSER = { tagName: "TEXTAREA", value: "" };              // the chat composer, one editable among any
+var FOCUSED = true;                                             // document.hasFocus()
 var IFRAMES = [];
 var document = {
   addEventListener: function (t, f) { (LISTENERS[t] = LISTENERS[t] || []).push(f); },
   getSelection: function () { return SEL; },
+  hasFocus: function () { return FOCUSED; },
   getElementById: function (id) { return id === "composer-input" ? COMPOSER : null; },
   activeElement: null,
   body: { classList: { remove: function () { REMOVED.push(Array.prototype.slice.call(arguments)); } } },
@@ -42,7 +44,7 @@ var document = {
 var window = { addEventListener: function (t, f) { (WLISTENERS[t] = WLISTENERS[t] || []).push(f); } };
 window.parent = window;
 window.__rompPersistForReload = function () { PERSISTED++; };
-var location = { reload: function () { RELOADS++; if (REFUSE) throw new Error("host forbids reload"); } };
+var location = { pathname: "/", reload: function () { RELOADS++; if (REFUSE) throw new Error("host forbids reload"); } };
 var sessionStorage = {
   setItem: function (k, v) { STORE[k] = v; }, getItem: function (k) { return k in STORE ? STORE[k] : null; },
   removeItem: function (k) { delete STORE[k]; }
@@ -54,7 +56,7 @@ function wemit(t) { (WLISTENERS[t] || []).forEach(function (f) { f({}); }); }
 function tick() { return new Promise(function (r) { setTimeout(r, 0); }); }
 function state() {
   var R = window.__rompReload;
-  return { reloads: RELOADS, fired: R.fired(), owed: R.owed(), waiting: R.waiting, persisted: PERSISTED, removed: REMOVED,
+  return { reloads: RELOADS, fired: R.fired(), owed: R.owed(), waiting: R.waiting, persisted: PERSISTED, removed: REMOVED, refusedFor: R.refusedFor(),
            stored: STORE["romp:reloaded"] ? JSON.parse(STORE["romp:reloaded"]) : null, fetches: FETCHES.length };
 }
 function out(o) { process.stdout.write("RESULT:" + JSON.stringify(o) + "\n"); }
@@ -94,6 +96,7 @@ out({ same: same, older: older, after: state() });""")
         self.assertEqual(a["stored"]["reason"], "build")
         self.assertEqual(a["stored"]["detail"], "8")
         self.assertEqual(a["stored"]["from"], 7)
+        self.assertEqual(a["stored"]["path"], "/", "the marker names the page that reloaded")
         self.assertEqual(a["persisted"], 1, "the pane's persist hook ran before the reload")
         self.assertIn(["settings-open", "picker-open"], a["removed"], "the lifted modals close")
 
@@ -123,17 +126,18 @@ out({ quiet: quiet, after: state() });""")
 var R = window.__rompReload;
 emit("pointerdown");
 R.noteDv(8); var held = state();
-emit("pointerup");
-out({ held: held, after: state() });""")
+emit("pointerup"); var atOnce = state(); await tick();
+out({ held: held, atOnce: atOnce, after: state() });""")
         self.assertEqual(s["held"]["reloads"], 0)
         self.assertEqual(s["held"]["waiting"], "pointer")
         self.assertEqual(s["held"]["owed"]["reason"], "build", "armed, not dropped")
+        self.assertEqual(s["atOnce"]["reloads"], 0, "the fire waits one tick so the click the same press produces lands on its control first")
         self.assertEqual(s["after"]["reloads"], 1)
 
     def test_a_drag_in_flight_arms_and_dragend_fires(self):
         s = run_core("""
 var R = window.__rompReload;
-emit("dragstart"); R.noteDv(8); var held = state(); emit("dragend");
+emit("dragstart"); R.noteDv(8); var held = state(); emit("dragend"); await tick();
 out({ held: held, after: state() });""")
         self.assertEqual(s["held"]["waiting"], "drag")
         self.assertEqual(s["held"]["reloads"], 0)
@@ -144,7 +148,7 @@ out({ held: held, after: state() });""")
 var R = window.__rompReload;
 SEL = { rangeCount: 1, isCollapsed: false, toString: function () { return "some words"; } };
 R.noteDv(8); var held = state();
-SEL = { rangeCount: 1, isCollapsed: true, toString: function () { return ""; } }; emit("selectionchange");
+SEL = { rangeCount: 1, isCollapsed: true, toString: function () { return ""; } }; emit("selectionchange"); await tick();
 out({ held: held, after: state() });""")
         self.assertEqual(s["held"]["waiting"], "selection")
         self.assertEqual(s["held"]["reloads"], 0)
@@ -155,23 +159,23 @@ out({ held: held, after: state() });""")
 var R = window.__rompReload;
 document.activeElement = COMPOSER; COMPOSER.value = "half a thought";
 R.noteDv(8); var held = state();
-COMPOSER.value = "half a thought, more"; emit("input"); var typing = state();
-COMPOSER.value = ""; emit("input");
+COMPOSER.value = "half a thought, more"; emit("input"); await tick(); var typing = state();
+COMPOSER.value = ""; emit("input"); await tick();
 out({ held: held, typing: typing, after: state() });""")
-        self.assertEqual(s["held"]["waiting"], "composer")
+        self.assertEqual(s["held"]["waiting"], "typing")
         self.assertEqual(s["typing"]["reloads"], 0, "typing keeps the hold")
         self.assertEqual(s["after"]["reloads"], 1, "an emptied composer releases it")
         s2 = run_core("""
 var R = window.__rompReload;
 document.activeElement = COMPOSER; COMPOSER.value = "draft"; R.noteDv(8);
-document.activeElement = null; emit("focusout");
+document.activeElement = null; emit("focusout"); await tick();
 out({ after: state() });""")
         self.assertEqual(s2["after"]["reloads"], 1, "a blurred composer releases it (the draft is persisted already)")
 
     def test_a_window_blur_releases_every_hold(self):
         s = run_core("""
 var R = window.__rompReload;
-emit("pointerdown"); emit("dragstart"); R.noteDv(8); var held = state(); wemit("blur");
+emit("pointerdown"); emit("dragstart"); R.noteDv(8); var held = state(); wemit("blur"); await tick();
 out({ held: held, after: state() });""")
         self.assertEqual(s["held"]["reloads"], 0)
         self.assertEqual(s["after"]["reloads"], 1)
@@ -180,12 +184,22 @@ out({ held: held, after: state() });""")
         s = run_core("""
 var R = window.__rompReload; var refused = [];
 R.refused = function (o) { refused.push(o); }; REFUSE = true;
-R.noteDv(8);
-out({ refused: refused, after: state() });""")
-        self.assertEqual(s["after"]["reloads"], 1, "the reload was attempted")
-        self.assertFalse(s["after"]["fired"], "…and stood down when the host threw")
-        self.assertEqual(s["after"]["waiting"], "refused")
-        self.assertEqual(s["refused"], [{"reason": "build", "detail": "8"}])
+R.noteDv(8); var first = state();
+emit("pointerup"); await tick(); emit("selectionchange"); await tick(); R.noteVersion({ boot: "1.1", dist_ver: 8 }); var again = state(); var shownAfterAgain = refused.length;
+R.noteDv(9); var newer = state();
+out({ refused: refused, first: first, again: again, shownAfterAgain: shownAfterAgain, newer: newer });""")
+        f = s["first"]
+        self.assertEqual(f["reloads"], 1, "the reload was attempted")
+        self.assertFalse(f["fired"], "…and stood down when the host threw")
+        self.assertEqual(f["waiting"], "refused")
+        self.assertEqual(f["refusedFor"], "build:8", "the refusal latches for this build")
+        self.assertEqual(f["stored"], None, "no marker and no un-lifted modal for a reload that never happened")
+        self.assertEqual(f["removed"], [])
+        self.assertEqual(s["refused"][0], {"reason": "build", "detail": "8"})
+        self.assertEqual(s["again"]["reloads"], 1, "gesture ends and the poll do not re-attempt the refused build")
+        self.assertEqual(s["shownAfterAgain"], 1, "the banner is shown once for that build")
+        self.assertEqual(s["newer"]["reloads"], 2, "a strictly newer build re-arms and tries again (and is refused again on this host)")
+        self.assertEqual(len(s["refused"]), 2)
 
     def test_the_fresh_page_announces_once_from_the_marker(self):
         s = run_core("""
@@ -203,6 +217,12 @@ var R = window.__rompReload;
 STORE["romp:reloaded"] = JSON.stringify({ reason: "build", detail: "9", from: 6, t: 1 });
 out({ first: R.announce(null) });""")
         self.assertEqual(s2["first"], "Reloaded onto build 7 — a newer romp build was served.")
+        s3 = run_core("""
+var R = window.__rompReload;
+STORE["romp:reloaded"] = JSON.stringify({ reason: "build", detail: "9", from: 6, path: "/feed", t: 1 });
+out({ first: R.announce(null), left: STORE["romp:reloaded"] || null });""")
+        self.assertIsNone(s3["first"], "a marker another page wrote (a standalone /feed reload) is not this page's to announce")
+        self.assertIsNone(s3["left"], "…but it is consumed, so it cannot be misattributed later")
 
     def test_the_shell_composes_gesture_state_across_its_panes_and_a_pane_forwards_its_request(self):
         s = run_core("""
@@ -222,11 +242,54 @@ out({ held: held, after: state() });""")
 var shellReqs = [];
 window.parent = { __rompReload: { request: function (r, d) { shellReqs.push([r, d]); }, tryFire: function () { shellReqs.push(["tryFire"]); } } };
 var R = window.__rompReload;
-R.noteDv(8); emit("pointerup");
+R.noteDv(8); emit("pointerup"); await tick();
 out({ shellReqs: shellReqs, inShell: R.inShell(), after: state() });""")
         self.assertTrue(s2["inShell"])
         self.assertEqual(s2["shellReqs"], [["build", "8"], ["tryFire"]])
         self.assertEqual(s2["after"]["reloads"], 0, "the top document reloads, never the pane alone")
+
+    def test_a_panes_queued_sends_hold_the_reload_until_its_flush(self):
+        s = run_core("""
+var R = window.__rompReload; var queued = 1;
+window.__rompPaneBusy = function () { return queued ? "sends" : ""; };   // the shim: everConnected && queue.length > queuedDiag
+R.noteVersion({ boot: "2.2" }); var held = state();
+queued = 0; R.ended(); await tick();                                    // the shim's ws.onopen flush
+out({ held: held, after: state() });""")
+        self.assertEqual(s["held"]["reloads"], 0, "a prompt typed during the outage sits in the pane's queue: the shell's earlier reopen must not take the page down")
+        self.assertEqual(s["held"]["waiting"], "sends")
+        self.assertEqual(s["after"]["reloads"], 1, "the flush is the ending event")
+
+    def test_a_touch_pan_holds_from_pointercancel_until_the_finger_lifts(self):
+        s = run_core("""
+var R = window.__rompReload;
+emit("pointerdown"); emit("pointercancel");       // the touch became a scroll: the browser cancels the pointer, the finger is still down
+R.noteDv(8); var panning = state();
+emit("pointerup"); await tick(); var stillPanning = state();   // no pointerup comes for a cancelled pointer, but even one must not release the pan
+emit("touchend"); await tick();
+out({ panning: panning, stillPanning: stillPanning, after: state() });""")
+        self.assertEqual(s["panning"]["reloads"], 0)
+        self.assertEqual(s["panning"]["waiting"], "pan")
+        self.assertEqual(s["stillPanning"]["reloads"], 0)
+        self.assertEqual(s["after"]["reloads"], 1, "touchend releases the pan")
+
+    def test_a_selection_counts_only_in_the_focused_document(self):
+        s = run_core("""
+var R = window.__rompReload;
+SEL = { rangeCount: 1, isCollapsed: false, toString: function () { return "an old highlight"; } };
+FOCUSED = false; R.noteDv(8);
+out({ after: state() });""")
+        self.assertEqual(s["after"]["reloads"], 1, "a highlight left in a pane the user is not in is not a gesture being made")
+
+    def test_typing_in_any_editable_holds_not_only_the_composer(self):
+        s = run_core("""
+var R = window.__rompReload;
+var pickerInput = { tagName: "INPUT", type: "text", value: "new-sess" };
+document.activeElement = pickerInput; R.noteDv(8); var held = state();
+var sel = { tagName: "SELECT", value: "x" }; document.activeElement = sel; emit("focusout"); await tick();
+out({ held: held, after: state() });""")
+        self.assertEqual(s["held"]["waiting"], "typing", "the new-session picker's name box holds like the composer")
+        self.assertEqual(s["held"]["reloads"], 0)
+        self.assertEqual(s["after"]["reloads"], 1, "a focused <select> is not text entry")
 
     def test_a_foreign_parent_leaves_the_pane_to_reload_itself(self):
         s = run_core("""
@@ -262,6 +325,11 @@ class ReloadWiringPinned(unittest.TestCase):
         self.assertNotIn('postMessage({romp:"wsStale",build:1}', js, "the build:1 hand-off to the banner is gone")
         self.assertIn('if(msg&&msg.type==="ka"){if(LOADEDV&&msg.dv&&msg.dv>LOADEDV)raiseBuild();', js, "the keepalive's dv is still the event")
         self.assertIn("if(window.__rompReload&&!window.__rompReload.inShell())window.__rompReload.checkBoot();", js)
+        # the pane's queued sends hold the reload, and the flush is the ending event (review find, 2026-09-08)
+        self.assertIn('window.__rompPaneBusy=function(){return (everConnected&&queue.length>queuedDiag)?"sends":"";};', js)
+        self.assertIn("queue=[];queuedDiag=0;\ntry{if(window.__rompReload)window.__rompReload.ended();}catch(e){}", js)
+        # a standalone page consumes its own marker; nobody else would
+        self.assertIn("try{if(window.__rompReload&&!window.__rompReload.inShell())window.__rompReload.announce(null);}catch(e){}", js)
         # …on the RECONNECT branch only: the first open is not a restart
         i = js.find("if(wasReconn){")
         self.assertGreater(i, 0)
@@ -293,8 +361,8 @@ class ReloadWiringPinned(unittest.TestCase):
 
     def test_the_superseded_rule_is_recorded_with_both_dates(self):
         src = open(os.path.join(ROOT, "kernel", "kernel.py")).read()
-        self.assertIn("The user's ruling of 2026-09-08 (about 10:50 AM PT) supersedes their 2026-07-13 preference", src)
-        self.assertIn('the user 2026-09-08 ruled the page RELOADS ITSELF, superseding\n// the 2026-07-13 "prompt, never auto"', src)
+        block = src[src.index("# ── the dashboard reloads ITSELF"):src.index("_RELOAD_CORE_JS = r")]
+        self.assertIn("2026-09-08", block); self.assertIn("2026-07-13", block); self.assertIn("supersedes", block)
         ext = open(os.path.join(ROOT, "vscode-extension", "src", "extension.ts")).read()
         self.assertIn("2026-09-08", ext, "the VS Code exception names the ruling it stands beside")
 

--- a/tests/test_kernel_ws_heartbeat.py
+++ b/tests/test_kernel_ws_heartbeat.py
@@ -108,11 +108,12 @@ class ShimWatchdogSourcePins(unittest.TestCase):
 
 
 class BuildDriftBanner(unittest.TestCase):
-    """Build drift always shows a banner (the user 2026-07-13): the keepalive carries the kernel's current
-    dist token (dv); every kernel-served page bakes its own load-time token (LOADEDV) into the shim and
-    raises the reload prompt when dv passes it — so a standalone pane (no dashboard shell, previously NO
-    check at all) prompts too, and within one heartbeat instead of a 30s poll. Reload stays the user's
-    click, never automatic ([[prefer-reload-banner-not-auto]])."""
+    """Build drift is noticed on every page (the user 2026-07-13): the keepalive carries the kernel's current
+    dist token (dv); every kernel-served page bakes its own load-time token (LOADEDV) into the shim and acts
+    when dv passes it — so a standalone pane (no dashboard shell, previously NO check at all) notices too,
+    and within one heartbeat instead of a 30s poll. What the raise DOES changed on 2026-09-08 (T265): it asks
+    the reload core to reload the page itself, never mid-gesture, superseding the 2026-07-13 "prompt, never
+    automatic" rule; the self-injected bar remains only as the fallback when the host refuses the reload."""
 
     def test_keepalive_frame_carries_the_dist_token(self):
         got = []

--- a/ui/webview/reload-restore.test.ts
+++ b/ui/webview/reload-restore.test.ts
@@ -36,7 +36,7 @@ test("where the restored land goes: bottom for follow mode, the anchor when hono
   assert.equal(reloadLandTarget({ id: SID, top: 999, stick: false, anchor: null }, false), 999);
 });
 
-test("render.ts persists SYNCHRONOUSLY for the reload core and on pagehide, into the persisted webview state", () => {
+test("render.ts persists SYNCHRONOUSLY for the reload core and on pagehide, into THIS tab's sessionStorage", () => {
   assert.match(RENDER, /import \{ reloadScrollRecord, takeReloadScroll, type ReloadScroll \} from "\.\/reload-restore";/);
   assert.match(RENDER, /\(window as any\)\.__rompPersistForReload = persistScrollForReload;/);
   assert.match(RENDER, /window\.addEventListener\("pagehide", persistScrollForReload\);/);
@@ -45,18 +45,22 @@ test("render.ts persists SYNCHRONOUSLY for the reload core and on pagehide, into
   const body = m![1];
   assert.match(body, /const stick = content\.scrollHeight - content\.scrollTop - content\.clientHeight <= 2;/, "follow mode is the true bottom");
   assert.match(body, /reloadScrollRecord\(activeId, content\.scrollTop, stick, stick \? null : captureScrollAnchor\(content, v\)\)/);
-  assert.match(body, /vscodeApi\.setState\(\{ \.\.\.\(vscodeApi\.getState\(\) \|\| \{\}\), reloadScroll: rec \}\)/);
+  assert.match(body, /sessionStorage\.setItem\(RELOAD_SCROLL_KEY, JSON\.stringify\(rec\)\)/, "per tab: the persisted webview state is localStorage on the served page, shared by every dashboard tab");
+  assert.match(RENDER, /const RELOAD_SCROLL_KEY = "romp:reloadScroll";/);
   // nothing to keep for a hidden pane or a tab never shown
   assert.match(body, /if \(!content \|\| !v \|\| !v\.shown \|\| content\.clientHeight <= 0\) return;/);
 });
 
-test("render.ts takes the record out of the state at load (one reload, one restore)", () => {
-  assert.match(RENDER, /let pendingReloadScroll: ReloadScroll \| null = \(\(\) => \{[\s\S]*?const r = st\.reloadScroll \|\| null;\s*\n\s*if \(r && vscodeApi\?\.setState\) vscodeApi\.setState\(\{ \.\.\.st, reloadScroll: undefined \}\);\s*\n\s*return r;/);
+test("render.ts takes the record out of sessionStorage at load (one reload, one restore)", () => {
+  assert.match(RENDER, /let pendingReloadScroll: ReloadScroll \| null = \(\(\) => \{[\s\S]*?const raw = sessionStorage\.getItem\(RELOAD_SCROLL_KEY\);\s*\n\s*if \(raw\) sessionStorage\.removeItem\(RELOAD_SCROLL_KEY\);/);
 });
 
 test("landActive's landing consumes the record for the active tab first, then falls to the ordinary rule", () => {
   const m = RENDER.match(/^function landActive\(content: HTMLElement \| null, v: View\): void \{([\s\S]*?)\n\}/m);
   assert.ok(m, "landActive");
   const body = m![1];
-  assert.match(body, /const rs = takeReloadScroll\(pendingReloadScroll, activeId\);\s*\n\s*if \(rs\) \{\s*\n\s*pendingReloadScroll = null;\s*\n\s*v\.stick = rs\.stick;\s*\n\s*if \(rs\.stick\) writeScroll\(content, content\.scrollHeight, "reload-restore", true\);\s*\n\s*else if \(!\(rs\.anchor && restoreScrollAnchor\(content, v, rs\.anchor\)\)\) writeScroll\(content, rs\.top, "reload-restore"\);\s*\n\s*\}\s*\n\s*else if \(!v\.shown \|\| v\.stick\) writeScroll\(content, content\.scrollHeight, "land-bottom", true\);\s*\n\s*else writeScroll\(content, v\.scrollTop, "land-saved"\);/);
+  assert.match(body, /const rs = takeReloadScroll\(pendingReloadScroll, activeId\);\s*\n\s*if \(rs\) \{\s*\n\s*pendingReloadScroll = null;\s*\n\s*v\.stick = rs\.stick;\s*\n\s*if \(rs\.stick\) writeScroll\(content, content\.scrollHeight, "reload-restore", true\);\s*\n\s*else if \(!\(rs\.anchor && restoreScrollAnchor\(content, v, rs\.anchor\)\)\) \{/);
+  // the anchor turn outside the fresh window: the raw top is the first guess and the deep-link land finishes it
+  assert.match(body, /writeScroll\(content, rs\.top, "reload-restore"\);\s*\n\s*if \(rs\.anchor\) \{ pendingAnchor = rs\.anchor\.uuid; pendingAnchorKeepY = rs\.anchor\.y; \}/);
+  assert.match(body, /else if \(!v\.shown \|\| v\.stick\) writeScroll\(content, content\.scrollHeight, "land-bottom", true\);\s*\n\s*else writeScroll\(content, v\.scrollTop, "land-saved"\);/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -10338,7 +10338,14 @@ function landActive(content: HTMLElement | null, v: View): void {
       pendingReloadScroll = null;
       v.stick = rs.stick;
       if (rs.stick) writeScroll(content, content.scrollHeight, "reload-restore", true);
-      else if (!(rs.anchor && restoreScrollAnchor(content, v, rs.anchor))) writeScroll(content, rs.top, "reload-restore");
+      else if (!(rs.anchor && restoreScrollAnchor(content, v, rs.anchor))) {
+        // the anchor turn is not in the fresh page's window (the reader was above the tail window): the raw
+        // scrollTop was measured in a differently windowed DOM, so land it now as the first guess and arm the
+        // deep-link land, whose window-around-unit and fetch-older paths bring the anchor turn back to its exact
+        // offset (review find, 2026-09-08)
+        writeScroll(content, rs.top, "reload-restore");
+        if (rs.anchor) { pendingAnchor = rs.anchor.uuid; pendingAnchorKeepY = rs.anchor.y; }
+      }
     }
     else if (!v.shown || v.stick) writeScroll(content, content.scrollHeight, "land-bottom", true);
     else writeScroll(content, v.scrollTop, "land-saved");
@@ -10360,14 +10367,16 @@ function landActive(content: HTMLElement | null, v: View): void {
 // The dashboard now reloads itself on a kernel restart and on a newer served bundle (the shell's reload core,
 // kernel.py _RELOAD_CORE_JS). The core calls window.__rompPersistForReload on every pane SYNCHRONOUSLY before
 // location.reload (a posted message could miss the unload); `pagehide` is the belt for any other navigation.
-// The record rides the persisted webview state beside the drafts and the active tab, is taken out of the state
-// the moment the page loads (one reload, one restore) and is consumed by landActive's first show of that tab.
+// The record rides sessionStorage — THIS tab's alone and it survives a reload (the persisted webview state is
+// localStorage on the served page, shared by every dashboard tab of the origin, so a record there could land
+// one tab on another's position; review find, 2026-09-08) — is taken out the moment the page loads (one reload,
+// one restore) and is consumed by landActive's first show of that tab.
+const RELOAD_SCROLL_KEY = "romp:reloadScroll";
 let pendingReloadScroll: ReloadScroll | null = (() => {
   try {
-    const st = (vscodeApi?.getState?.() || {}) as any;
-    const r = st.reloadScroll || null;
-    if (r && vscodeApi?.setState) vscodeApi.setState({ ...st, reloadScroll: undefined });
-    return r;
+    const raw = sessionStorage.getItem(RELOAD_SCROLL_KEY);
+    if (raw) sessionStorage.removeItem(RELOAD_SCROLL_KEY);
+    return raw ? (JSON.parse(raw) as ReloadScroll) : null;
   } catch { return null; }
 })();
 function persistScrollForReload(): void {
@@ -10376,7 +10385,7 @@ function persistScrollForReload(): void {
   if (!content || !v || !v.shown || content.clientHeight <= 0) return;
   const stick = content.scrollHeight - content.scrollTop - content.clientHeight <= 2;   // the true bottom
   const rec = reloadScrollRecord(activeId, content.scrollTop, stick, stick ? null : captureScrollAnchor(content, v));
-  try { if (vscodeApi?.setState) vscodeApi.setState({ ...(vscodeApi.getState() || {}), reloadScroll: rec }); } catch { /* ignore */ }
+  try { if (rec) sessionStorage.setItem(RELOAD_SCROLL_KEY, JSON.stringify(rec)); } catch { /* ignore */ }
 }
 (window as any).__rompPersistForReload = persistScrollForReload;
 window.addEventListener("pagehide", persistScrollForReload);


### PR DESCRIPTION
## Summary
Follow-up to the dashboard auto-reload (merged as PR 1097): the confirmed findings of an adversarial review of that branch (three lenses, two independent verifiers per finding), each fixed with an executed node scenario in `tests/test_dashboard_auto_reload.py`.

## Fixes
- **Queued sends hold the reload.** After an unannounced kernel restart the shell's socket can reopen before the chat pane's; a prompt typed during the outage sat in the pane shim's queue with nothing persisting it, and the shell-driven reload would have taken it. The shim now reports a `sends` hold (`window.__rompPaneBusy`: connected before and non-diag entries queued) that the core's busy check reads, and the shim's flush in `ws.onopen` is the ending event.
- **Touch pans.** `pointercancel` used to release the pointer hold and count as an ending event, so a reload fired the moment a touch became a scroll. It now converts the hold into a pan hold released by `touchend`/`touchcancel`/`scrollend`.
- **Selection only while focused.** A highlight left in another pane is not a gesture being made; the hold applies only when the document has focus.
- **Typing anywhere.** Any focused editable with text holds (textarea, text-like input, contenteditable), not only the chat composer: the new-session picker's inputs and the feed modal's follow-up box were reloaded out from under the typist.
- **Click first.** The fire waits one tick past its ending event so the click the same press produces lands on its control.
- **Refusal latches.** When `location.reload` throws, the refusal latches for that build/boot: no re-attempt on every gesture end or 30 s poll, the banner shows once, and only a strictly newer dv or boot re-arms. The marker write and the un-lifting of modals now happen only after the reload was accepted.
- **Marker scoped by page.** The sessionStorage marker carries the page's path; a standalone pane consumes its own and a landing never announces a marker another page wrote.
- **Per-tab scroll record.** The chat pane's reload record moved from the persisted webview state (localStorage on the served page, shared by every dashboard tab of the origin) to sessionStorage, this tab's alone. When the anchor turn is outside the fresh page's window, the raw scrollTop is the first guess and the deep-link land is armed to bring the turn back to its offset.
- **Comments.** The `_shim` header and the heartbeat test's class docstring no longer describe the banner as the mechanism; the prose pin on the design comment checks both dates rather than an exact sentence.

Refuted by both verifiers and left alone: the Enter-send "no ending event" claim (the composer's emptying fires `input`), the VS Code webview `pagehide` persist (the host has no reload core), user-initiated restarts racing the core (the restart flow's own reload wins), and a comment-quote claim (paraphrase).

`npm run typecheck` clean; the Python reload/banner/shim modules pass (133 tests); the full suites run on the branch before CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
