### PR TITLE
Feed: the session header's Clear is the card's Clear, built by one shared builder

### DIFF
--- a/ui/webview/feed-card-layout.test.ts
+++ b/ui/webview/feed-card-layout.test.ts
@@ -23,7 +23,7 @@ test("COMPACTNESS (the user 2026-07-07; action corner 2026-08-08): time trails t
   assert.match(FEED, /row1\.append\(btns\);/, "the corner floats from the END of row1's flow (title+time keep first claim)");
   assert.match(FEED, /row2\.append\(idwrap, retryBadge, apiBadge, apiRetry, apiLogin, capLine, capBtn, jauthBadge, blkBadge, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "ask card: the name row is identity + chips only");
   // its tooltip is plain-spoken (the user 2026-07-13): "clear this task", not the inbox-zero jargon
-  assert.match(FEED, /clr\.title = "clear this task";/);
+  assert.match(FEED, /const clr = clearButton\("clear this task"\);/, "the card's Clear comes from the one shared builder (2026-09-08)");
   assert.match(FEED, /btns\.append\(clr\);\s*\n\s*row1\.append\(btns\);\s*\n\s*row2\.append\(idwrap\);/, "group card: Clear in row1's action corner, name row is the name only");
   // the group card has no row3 anymore (its only content, the time, moved to row1)
   assert.match(FEED, /main\.append\(row1, row2, memberList\)/, "group card: no row3 (time moved to row1)");

--- a/ui/webview/feed-sess-clear.test.ts
+++ b/ui/webview/feed-sess-clear.test.ts
@@ -15,10 +15,16 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 
-test("the header carries a plain-worded Clear on the far right, hidden when the session has no clearable cards", () => {
-  assert.match(FEED, /const clr = el\("button", "feed-sess-clear"\); clr\.textContent = "Clear";/);
-  // lowercase like every sibling tooltip on the header row (the caret's, the service chip's)
-  assert.match(FEED, /clr\.title = "clear every card for this session"; clr\.dataset\.act = "sess-clear";/);
+test("the header's Clear IS the card's Clear: one builder, one class set, a layout-only position class", () => {
+  // the user 2026-09-08 (twice): same size, the outline, blue on hover — so the card, the turn-group and the
+  // header all build their Clear with clearButton(), which mints the .fdismiss button; the header adds only
+  // a positional class and its behaviour
+  assert.match(FEED, /function clearButton\(title: string\): HTMLElement \{\s*\n\s*const b = el\("button", "fdismiss"\);\s*\n\s*b\.textContent = "Clear";\s*\n\s*b\.title = title;/);
+  assert.match(FEED, /const clr = clearButton\("clear this task"\);/, "the card");
+  assert.match(FEED, /const clr = clearButton\("clear ALL sub-asks of this request \(inbox-zero\)"\);/, "the turn-group");
+  assert.match(FEED, /const clr = clearButton\("clear every card for this session"\);\s*\n\s*clr\.classList\.add\("feed-sess-clear"\); clr\.dataset\.act = "sess-clear";/, "the header");
+  assert.doesNotMatch(FEED, /el\("button", "feed-sess-clear"\)/, "no lookalike element");
+  // the tooltip keeps the sibling grammar: a lowercase verb phrase, like the card's "clear this task"
   assert.match(FEED, /sclr\.setAttribute\("aria-label", "clear every card for " \+ e\.name\);/);
   // after the caret, count and service chip; before the full-width process list that wraps below
   assert.match(FEED, /h\.append\(nm, fold, cnt, svc, clr, svcList\);/);
@@ -83,10 +89,14 @@ test("the router sends the batch to the session's kernel with bare ids, and Undo
     "undoClear follows the LAST clear, batched or single, to the kernel that took it");
 });
 
-test("the control wears the header's size and the caret's quiet monochrome treatment, pushed to the far right", () => {
-  assert.match(CSS, /\.feed-sess-clear \{ flex: none; margin-left: auto; padding: 0 5px; color: var\(--dim\); background: transparent;\s*\n\s*border: 0; font: inherit; font-weight: 400; line-height: 1; cursor: pointer;/);
-  assert.match(CSS, /\.feed-sess-clear:hover, \.feed-sess-clear:focus-visible \{ color: var\(--fg\); \}/);
-  // negatives scoped to the RULE BLOCK, not the selector's line (a second-line font-size or accent must fail)
-  assert.doesNotMatch(CSS, /\.feed-sess-clear \{[^}]*font-size/, "no new font size on this surface");
-  assert.doesNotMatch(CSS, /\.feed-sess-clear[^{]*\{[^}]*(red|--st-|--accent)/, "monochrome: no status colour, no accent");
+test("the header Clear's own class carries layout only; size, outline and the accent hover come from .fdismiss", () => {
+  assert.match(CSS, /\.feed-sess-clear \{ flex: none; margin-left: auto; \}/, "position only: far right of the row");
+  // nothing of the button's look may live on the positional class (block-scoped negatives)
+  assert.doesNotMatch(CSS, /\.feed-sess-clear[^{]*\{[^}]*(font|color|border|background|padding|line-height|opacity)/,
+    "a header-only size or colour would be a second button that drifts");
+  assert.doesNotMatch(CSS, /\.feed-sess-clear:hover|\.feed-sess-clear:focus/, "the hover is .fdismiss's accent hover, shared");
+  // the shared button: outlined, 0.72em, accent on hover — and its weight pinned, since the header renders at 600
+  assert.match(CSS, /\.fdismiss \{\s*\n\s*font: inherit; font-size: 0\.72em; font-weight: 400; cursor: pointer; white-space: nowrap;/);
+  assert.match(CSS, /border: 1px solid var\(--card-border\); border-radius: 6px;/);
+  assert.match(CSS, /\.fdismiss:hover \{ border-color: var\(--accent\); color: var\(--accent\); background: var\(--accent-wash\); \}/);
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -430,15 +430,11 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 /* a folded header IS its whole group, so it takes the bottom margin the run of cards would have had —
    without it, consecutive folded threads jam into one unreadable stack of names. */
 .feed-sess-head.folded { margin-bottom: 7px; }
-/* the session-wide CLEAR (the user 2026-09-08): far right of the header row (margin-left:auto, before the
-   full-width process list that wraps below), the header's own size (font: inherit — no new size on this
-   surface) and the caret's quiet treatment — bare word, no chip box, dim at rest and full strength on
-   hover/focus, un-bolded from the header's 600 so the name stays the thing you read. Monochrome on
-   purpose: red is the card-level Clear's hover, and a whole run leaving is announced by the cards' own
-   exit, not by a coloured button on every header. The hit area is padded for a thumb. */
-.feed-sess-clear { flex: none; margin-left: auto; padding: 0 5px; color: var(--dim); background: transparent;
-  border: 0; font: inherit; font-weight: 400; line-height: 1; cursor: pointer; transition: color 0.12s ease; }
-.feed-sess-clear:hover, .feed-sess-clear:focus-visible { color: var(--fg); }
+/* the session-wide CLEAR (the user 2026-09-08, twice): it IS the card's Clear (.fdismiss: the outline, the
+   0.72em size, the accent hover), built by the same builder; this class carries its POSITION only — far
+   right of the header row, before the full-width process list that wraps below. No size, colour, border
+   or hover of its own: any of those here would be a second button that drifts. */
+.feed-sess-clear { flex: none; margin-left: auto; }
 /* the neutral background-process chip on the header (kernel bgServices): a process the session KEEPS
    (a dev server the judge classified as nobody-waits). Reuses the .fask-secbtn chip vocabulary — dim,
    0.74em, accent only while its list is open (a selected toggle, the accent's job) — and un-bolds from
@@ -1075,7 +1071,9 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 }
 /* controls row — the "+" expand toggle (left, below the title) + Dismiss to its
    right; replaces the old right-rail button stack. */ .fdismiss {
-  font: inherit; font-size: 0.72em; cursor: pointer; white-space: nowrap;
+  font: inherit; font-size: 0.72em; font-weight: 400; cursor: pointer; white-space: nowrap;
+  /* ^ weight pinned, not inherited: the session header renders at 600 and its Clear is THIS button
+     (the user 2026-09-08: identical to the card's); cards already sat at 400, so nothing moves there */
   color: var(--dim); background: transparent;
   border: 1px solid var(--card-border); border-radius: 6px;
   transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease, transform 0.08s ease;

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -689,6 +689,16 @@ let canUndoClear = false;   // host: cleared.jsonl has rows → the UndoClear bu
 // from there instead of appearing from nowhere. Rebuilt every render.
 let prevItemKey = new Map<string, string>();
 
+// ONE builder for every Clear on the feed (the user 2026-09-08): the card's, the turn-group's and the
+// session header's wear the same element, class set, label and hover, so they cannot drift apart. Callers
+// add behaviour (an onclick, a data-act) and, for the header, a layout-only positional class.
+function clearButton(title: string): HTMLElement {
+  const b = el("button", "fdismiss");
+  b.textContent = "Clear";
+  b.title = title;
+  return b;
+}
+
 function el(tag: string, cls?: string): HTMLElement {
   const e = document.createElement(tag);
   if (cls) e.className = cls;
@@ -1080,7 +1090,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   // The header "awaiting" chip was REMOVED (the user 2026-07-04): it duplicated the "Awaiting background
   // agents" box in the card body, which says the same thing with room for the full "why" — so the chip was
   // pure redundancy. The awaiting state now reads only from that body box (see the awaitSpin block below).
-  const clr = el("button", "fdismiss"); clr.textContent = "Clear"; clr.title = "clear this task";   // plain-spoken (the user 2026-07-13, over the inbox-zero jargon)
+  const clr = clearButton("clear this task");   // plain-spoken (the user 2026-07-13, over the inbox-zero jargon)
   // "Continue" (the user 2026-08-08): the needs-you card's one-click "nothing needed from me, keep
   // going" — a REPLY with a kernel-canned body (askFollowUp cont:true), never a bare column move (the
   // removed cardMove is the cautionary tale: a move with no message adds no information). The card
@@ -2472,7 +2482,7 @@ function makeGroupCard(g: AskGroup): HTMLElement {
   const idwrap = el("div", "fask-id");
   const name = el("a", "fname"); name.title = "open this session";
   idwrap.append(name);   // no "· N parts" label — the member checklist below already shows the count
-  const clr = el("button", "fdismiss"); clr.textContent = "Clear"; clr.title = "clear ALL sub-asks of this request (inbox-zero)";
+  const clr = clearButton("clear ALL sub-asks of this request (inbox-zero)");
   // Clear rides row1's action corner in every mode (the user 2026-08-08) — matches the ask card. Same
   // fask-btns wrapper so the float/wrap CSS is shared; no Continue here (a group is a multi-ask turn —
   // its members carry their own).
@@ -3439,8 +3449,10 @@ function makeSessHead(): HTMLElement {
   // the group clear uses instead of a confirm dialog. The action is DELEGATED on the stable columns root
   // (data-act, installed once where the root is built) — never bound to this header node, which grouped
   // mode re-homes and re-renders; the header only says which session it stands for (data-fsid).
-  const clr = el("button", "feed-sess-clear"); clr.textContent = "Clear";
-  clr.title = "clear every card for this session"; clr.dataset.act = "sess-clear"; clr.style.display = "none";
+  // THE card's Clear, built by the same builder (the user 2026-09-08: same size, the outline, blue on hover),
+  // plus one positional class that carries layout only (far right of the row) — never a lookalike
+  const clr = clearButton("clear every card for this session");
+  clr.classList.add("feed-sess-clear"); clr.dataset.act = "sess-clear"; clr.style.display = "none";
   h.append(nm, fold, cnt, svc, clr, svcList);
   (h as any)._name = nm; (h as any)._fold = fold; (h as any)._foldn = cnt;
   (h as any)._svc = svc; (h as any)._svcList = svcList; (h as any)._clear = clr;


### PR DESCRIPTION
Follow-up to the per-session Clear (#1089). The user's ask: the header's Clear must look and behave exactly like the Clear on a single card: same size, with the outline, blue on hover.

## Change
- One builder (`clearButton(title)`) mints every Clear on the feed: the card's, the turn-group's and the session header's are the same `.fdismiss` button (outline, 0.72em, accent hover with the wash, press transform). Only the tooltip differs.
- The header adds its behaviour (`data-act`, the batched `askClearMany` and Undo it already had) and one positional class that carries **layout only** (`flex: none; margin-left: auto`): no size, colour, border or hover of its own.
- `.fdismiss` pins `font-weight: 400` explicitly: the header renders at 600 and the shared rule inherited its container's font; cards already sat at 400, so nothing moves there.

## Verified
On the served feed page with a synthetic notes-api payload: the header Clear and a card Clear report identical computed font-size, weight, border, radius, padding and colours; the header's sits flush right; hovered, it takes the accent border, text and wash in both themes. Screenshots (dark and light, one header Clear hovered beside card Clears) sent to the manager.

## Pins
`feed-sess-clear.test.ts`: the builder used at all three sites and no lookalike element; the positional class holds layout only (block-scoped negatives on font, colour, border, background, padding, line-height, opacity) and no hover of its own; the shared rule's outline, size, pinned weight and accent hover. `feed-card-layout.test.ts` follows the builder. Webview suite 3464 passed; typecheck clean.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)