### PR TITLE
Scroll breadcrumbs: the transcript's tail names itself when it changes height

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -57,7 +57,7 @@ import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDown
 import { followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow, followTailShrink } from "./scroll-keep";
 import { retainLiveOmitted } from "./tab-order";
 import { userTurnShows } from "./user-turn-content";
-import { ScrollDiagBudget, classifyScroll, scrollWriteRow } from "./scroll-write";
+import { ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel } from "./scroll-write";
 import { reloadScrollRecord, takeReloadScroll, type ReloadScroll } from "./reload-restore";
 import { keepResidentEvents } from "./frame-merge";
 import { activeTabToReannounce } from "./relay-active";
@@ -9301,7 +9301,7 @@ function nearBottomForSend(c: HTMLElement): boolean {
 // lands, only that the landing is on the record.
 let lastScrollWriteAfter: number | null = null;
 const scrollDiag = new ScrollDiagBudget();
-function scrollDiagRow(kind: "scrollwrite" | "scrollgesture", data: any): void {
+function scrollDiagRow(kind: "scrollwrite" | "scrollgesture" | "tailchange", data: any): void {
   const v = scrollDiag.take(activeId || "", kind, Date.now());
   if (v === "drop") return;
   vscodeApi?.postMessage(v === "cap"
@@ -9638,6 +9638,10 @@ function ensureView(id: string): View {
         scheduleRailSticky();
         const h = entries[0]?.contentRect?.height ?? 0;
         const content = document.getElementById("content");
+        // the tail's height change, named (T262f): which element grew or shrank under the reader — Chrome moves a
+        // bottom reader for both without a pane write, so the scroll rows alone cannot say which element flapped
+        if (content && lastH >= 0 && activeId === id && view.shown && h !== lastH)
+          scrollDiagRow("tailchange", tailChangeRow(id, h - lastH, tailLabel(view.el.children), view.stick, content.scrollHeight, content.clientHeight));
         if (content && lastH >= 0 && activeId === id && view.shown && content.clientHeight > 0 && followTailShrink(view.stick, h - lastH)) {
           writeScroll(content, content.scrollHeight, "tail-shrink", true);
           view.scrollTop = content.scrollTop;
@@ -10625,6 +10629,8 @@ if (typeof ResizeObserver === "function") {
       const h = entries[0]?.contentRect?.height ?? 0;
       const content = document.getElementById("content");
       const v = activeId ? views.get(activeId) : null;
+      if (content && tailLastH >= 0 && v && v.shown && h !== tailLastH)
+        scrollDiagRow("tailchange", tailChangeRow(activeId || "", h - tailLastH, "live-ask", v.stick, content.scrollHeight, content.clientHeight));
       if (content && tailLastH >= 0 && v && v.shown && content.clientHeight > 0 && followTailShrink(v.stick, h - tailLastH)) {
         writeScroll(content, content.scrollHeight, "tail-shrink", true);
         v.scrollTop = content.scrollTop;

--- a/ui/webview/scroll-write.test.ts
+++ b/ui/webview/scroll-write.test.ts
@@ -40,7 +40,7 @@ test("the row names the writer and carries before/after/delta/stick, gesture:fal
 });
 
 test("render.ts: one helper writes #content.scrollTop, files the row only when the view moved, and no raw write remains", () => {
-  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow \} from "\.\/scroll-write";/);
+  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel \} from "\.\/scroll-write";/);
   assert.match(RENDER, /function writeScroll\(content: HTMLElement, top: number, writer: string, stick = false\): void \{\s*\n\s*const before = content\.scrollTop;\s*\n\s*content\.scrollTop = top;\s*\n\s*const after = content\.scrollTop;\s*\n\s*lastScrollWriteAfter = after;\s*\n\s*if \(after !== before\) scrollDiagRow\("scrollwrite", scrollWriteRow\(activeId \|\| "", writer, before, after, stick, content\.scrollHeight, content\.clientHeight\)\);/);
   // the breadcrumb rides the existing clientDiag path, capped, with one capped row at the cap
   assert.match(RENDER, /\{ type: "clientDiag", surface: "chat", what: kind \+ "-capped", data: \{ sid: activeId \|\| "", perMinute: 40 \} \}/);

--- a/ui/webview/scroll-write.ts
+++ b/ui/webview/scroll-write.ts
@@ -35,6 +35,24 @@ export function classifyScroll(scrollTop: number, lastWriteAfter: number | null)
   return lastWriteAfter != null && Math.abs(scrollTop - lastWriteAfter) <= 1 ? "write-echo" : "gesture";
 }
 
+/** The breadcrumb for one height change of the transcript's TAIL outside the append path (T262f, the user
+ *  2026-09-08): the active view's element or the live-ask host grew or shrank, by `dh` px, with `last` naming the
+ *  tail element (its class list, or "live-ask"). Chrome moves a bottom reader down itself when the tail grows and
+ *  clamps them back when it shrinks — both unwritten, so the scroll rows alone cannot say WHICH element flapped;
+ *  this row, filed beside them, names it. `stick` = the view's recorded follow mode at the change. */
+export function tailChangeRow(sid: string, dh: number, last: string, stick: boolean, sh = 0, ch = 0) {
+  return { sid, dh, last: String(last || "").slice(0, 60), stick, sh, ch };
+}
+
+/** The class list of the tail element of a view: its last child that is not a virtualization spacer. */
+export function tailLabel(children: ArrayLike<{ className?: string }>): string {
+  for (let i = children.length - 1; i >= 0; i--) {
+    const c = String(children[i]?.className || "");
+    if (c.indexOf("tx-spacer") < 0) return c;
+  }
+  return "";
+}
+
 /** The breadcrumb for one write that moved the view. `sh`/`ch` = #content's scrollHeight/clientHeight after the
  *  write (T262e, the user 2026-09-08: their laptop's rows showed the view moving UP by the same 95 px on two
  *  sessions with no write between the rows — an UNWRITTEN move, which the rows could not classify: a browser

--- a/ui/webview/tail-change-row.test.ts
+++ b/ui/webview/tail-change-row.test.ts
@@ -1,0 +1,35 @@
+// The transcript's tail names itself when it changes height (T262f, the user 2026-09-08). Chrome keeps a bottom reader
+// at the bottom by itself when ANY element is appended at the end of #content and clamps them back when it is removed
+// (measured: a plain 95 px div, scrollTop +95/-95 with no pane write), so a tail element that toggles under a bottom
+// reader flaps the text by its height with no scrollwrite row at all — the shape of the user's laptop rows. The
+// scroll rows cannot say WHICH element flapped; this breadcrumb, filed by the active view's ResizeObserver and by
+// the live-ask host's, names it (class list or "live-ask") with the height delta and the recorded follow mode.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { tailChangeRow, tailLabel } from "./scroll-write";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const SID = "11111111-2222-4333-8444-000000000201";
+
+test("the row names the tail element, the delta and the follow mode; the label is bounded", () => {
+  assert.deepEqual(tailChangeRow(SID, -95, "turn turn-thinking", true, 5000, 600),
+                   { sid: SID, dh: -95, last: "turn turn-thinking", stick: true, sh: 5000, ch: 600 });
+  assert.equal(tailChangeRow(SID, 12, "x".repeat(200), false).last.length, 60);
+  assert.deepEqual(tailChangeRow(SID, 3, "live-ask", false), { sid: SID, dh: 3, last: "live-ask", stick: false, sh: 0, ch: 0 });
+});
+
+test("the tail label is the last child that is not a virtualization spacer", () => {
+  assert.equal(tailLabel([{ className: "turn turn-user" }, { className: "turn turn-assistant" }, { className: "tx-spacer tx-spacer-bot" }]), "turn turn-assistant");
+  assert.equal(tailLabel([{ className: "tx-spacer tx-spacer-top" }]), "");
+  assert.equal(tailLabel([]), "");
+});
+
+test("render.ts files the row from both tail observers, beside the tail-shrink rule, through the capped diag path", () => {
+  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel \} from "\.\/scroll-write";/);
+  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange", data: any\): void \{/);
+  assert.match(RENDER, /if \(content && lastH >= 0 && activeId === id && view\.shown && h !== lastH\)\s*\n\s*scrollDiagRow\("tailchange", tailChangeRow\(id, h - lastH, tailLabel\(view\.el\.children\), view\.stick, content\.scrollHeight, content\.clientHeight\)\);/);
+  assert.match(RENDER, /if \(content && tailLastH >= 0 && v && v\.shown && h !== tailLastH\)\s*\n\s*scrollDiagRow\("tailchange", tailChangeRow\(activeId \|\| "", h - tailLastH, "live-ask", v\.stick, content\.scrollHeight, content\.clientHeight\)\);/);
+  assert.equal((RENDER.match(/"tailchange"/g) || []).length, 3, "the kind in the router's union and the two filings");
+});


### PR DESCRIPTION
## Summary
Instrumentation for the remaining chat-pane snapback (the user's 2026-09-08 rows): the transcript's tail names itself when it changes height.

## Why
Measured on a hermetic kernel with headless Chromium: Chrome keeps a bottom reader at the bottom by itself when ANY element is appended at the end of `#content` and clamps them back when it is removed. A plain 95 px div moved scrollTop by +95 and −95 with no pane write; a live-ask card toggling every 1.2 s produced the same flips, both directions, with no `scrollwrite` row at all. That is exactly the shape of the user's laptop rows (the view moving up and down by one fixed amount with no write between the rows), and the scroll rows cannot say which element flapped.

## Change
A `tailchange` breadcrumb, filed by the active view's ResizeObserver (beside the tail-shrink rule that landed in PR 1102) and by the live-ask host's observer: the tail element's class list (or `live-ask`), the height delta, the view's recorded follow mode, and `#content`'s scrollHeight/clientHeight. It rides the same capped client-diag path as the scroll rows. The breadcrumb reader (outside the repo) correlates each unwritten move with the tail-change rows filed within two seconds of it, so the next pull of the user's rows convicts the element by name.

## Tests
- New `ui/webview/tail-change-row.test.ts`: the pure row builder and the tail-label helper executed; both filings and the router's kind union pinned.
- `ui/webview/scroll-write.test.ts`: import pin moved with the import.
- `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
