### PR TITLE
Tab strip: every tab carries its state-dot slot in every state, so the strip's row count cannot flap with a session's state

### DIFF
--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -31,7 +31,10 @@ test("the chat chip knows awaitingBg: its own await-green chip, label 'Awaiting'
 });
 
 test("the chat tab dot matches the chip: await-green for awaitingBg, yellow for working", () => {
-  assert.match(RENDER, /if \(st === "working"\) tab\.appendChild\(el\("span", "tab-dot"\)\);\s*\n\s*else if \(st === "awaitingBg"\) tab\.appendChild\(el\("span", "tab-dot await"\)\);/);
+  // the per-state dot is one rule now (tabDotClass, T262g): the slot is laid out in every state
+  const TS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "tab-state.ts"), "utf8");
+  assert.match(TS, /if \(st === "working"\) return "tab-dot";\s*\n\s*if \(st === "awaitingBg"\) return "tab-dot await";/);
+  assert.match(RENDER, /const dotCls = tabDotClass\(st\);\s*\n\s*if \(dotCls\) tab\.appendChild\(el\("span", dotCls\)\);/);
   assert.match(STYLES, /--st-awaitbg-bg: #54B204; --st-awaitbg-fg: #0c1a00;/);
   assert.match(STYLES, /\.chip-awaitingBg \{ background: var\(--st-awaitbg-bg\); color: var\(--st-awaitbg-fg\); \}/);
   assert.match(STYLES, /\.tab-dot\.await \{ background: var\(--st-awaitbg-bg\); \}/);

--- a/ui/webview/feed-status-pips.test.ts
+++ b/ui/webview/feed-status-pips.test.ts
@@ -54,7 +54,10 @@ test("the sessions pane speaks the same three-way language", () => {
 });
 
 test("the tab strip draws the gray ring for a missing state and nothing for idle", () => {
-  assert.match(RENDER, /else if \(!st\) tab\.appendChild\(el\("span", "tab-dot unknown"\)\);/);
+  // the unknown ring comes from the one dot rule (tabDotClass, T262g): a missing state → "tab-dot unknown"
+  const TS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "tab-state.ts"), "utf8");
+  assert.match(TS, /if \(!st\) return "tab-dot unknown";/);
+  assert.match(RENDER, /const dotCls = tabDotClass\(st\);/);
   // ready/idle reaches no branch at all — the ladder ends without appending
   assert.ok(!/tab-dot ready/.test(RENDER), "no ready pip on the strip");
 });

--- a/ui/webview/provisional.test.ts
+++ b/ui/webview/provisional.test.ts
@@ -99,7 +99,10 @@ test("creating a session opens the provisional tab instead of a modal", () => {
     "the chip says what this phase IS — the session is opening");
   assert.doesNotMatch(RENDER, /state: "working", sinceEpoch: Math\.floor/, "the broken-clock seed is gone");
   // …and the tab strip shows the accent loader dot for the opening state, so the starting tab has a cue
-  assert.match(RENDER, /else if \(st === "opening"\) tab\.appendChild\(el\("span", "tab-dot opening"\)\);/);
+  // the opening dot comes from the one dot rule (tabDotClass, T262g)
+  const TS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "tab-state.ts"), "utf8");
+  assert.match(TS, /if \(st === "opening"\) return "tab-dot opening";/);
+  assert.match(RENDER, /const dotCls = tabDotClass\(st\);/);
   assert.match(CSS, /\.tab-dot\.opening \{ background: var\(--accent\); animation: opening-line-pulse/);
   assert.match(RENDER, /order\.push\(id\);/, "the tab survives reconcileTabOrder as a not-yet-kernel-known extra");
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -33,7 +33,7 @@ import { reconcileTabOrder } from "./tab-order";
 import { writeViewOrder } from "./view-order";
 import { planStrip, readTabGroups, writeTabGroups, setSectionCollapsed, sectionRef, isPinned, setPinned, prunePinned, reachableFrom, headWords,
          followAdoption, reorderTagOrder, TABGROUPS_KEY, TABGROUPS_EVENT, type TabSection } from "./tab-groups";
-import { tabStateClass, sectionPip, sectionPipMembers, sectionPipTitle } from "./tab-state";
+import { tabStateClass, tabDotClass, sectionPip, sectionPipMembers, sectionPipTitle } from "./tab-state";
 import { titleWithKey, chordOf, effectiveChord, loadOverrides } from "./keybindings";
 import { DEFAULT_CHORDS } from "./commands";
 import { NavHistory } from "./nav-history";
@@ -5486,17 +5486,13 @@ function renderTabs() {
     if (s.status.faded) tab.classList.add("at-rest");
     // WORKING shows a yellow dot; AWAITING-BG the same dot in await-green — matching the chip's color, so the
     // tab reads the split at a glance (the user 2026-07-13); BLOCKED (API error) gets NO dot — the dashed
-    // red tab highlight instead (the user 2026-06-16).
-    if (st === "working") tab.appendChild(el("span", "tab-dot"));
-    else if (st === "awaitingBg") tab.appendChild(el("span", "tab-dot await"));
-    // MISSING state — the kernel listed this session but could not read what it is doing. An
-    // explicit gray ring, so a bare tab can only mean a state with its own tab treatment (dashed
-    // blocked ring, compacting bar, struck-through closed) or a healthy idle one, never a hole.
-    else if (!st) tab.appendChild(el("span", "tab-dot unknown"));
-    // OPENING (a provisional tab, or the kernel's own opening chip): the accent loader dot — the session
-    // is starting, and a tab with no cue at all read as dead (the user 2026-08-10). Same pulse as the
-    // statusline's opening dots; never the solid working yellow, which claims work that isn't happening.
-    else if (st === "opening") tab.appendChild(el("span", "tab-dot opening"));
+    // red tab highlight instead (the user 2026-06-16). MISSING state: an explicit gray ring, so a bare tab
+    // can only mean a state with its own treatment or a healthy idle one, never a hole. OPENING: the accent
+    // loader dot (the user 2026-08-10). The slot itself is there in EVERY state (T262g, the user 2026-09-08):
+    // a dot that came and went with the state changed the tab's width, and with the strip at a wrap boundary
+    // that added or removed a row and slid the transcript under the reader by a row's height (tabDotClass).
+    const dotCls = tabDotClass(st);
+    if (dotCls) tab.appendChild(el("span", dotCls));
     // compacting → a tiny animated compaction bar before the name (the tab gets no outline for this state,
     // so the bar IS the cue). A teal fill whose right edge slides left and loops — the same "compression"
     // motion as the statusline ctx-scan bar (.ctx-compress), miniaturised. Replaces the static ⇲ glyph the

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -478,6 +478,9 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 /* WORKING: a small yellow dot left of the name (replaces the old yellow outline). */
 .tab-dot { flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; background: var(--st-working-bg); }   /* solid — dot oscillation was distracting (the user 2026-06-16) */
 .tab-dot.await { background: var(--st-awaitbg-bg); }   /* awaiting-bg: the dot matches the await-green chip (the user 2026-07-13) */
+/* the slot with no dot to show (idle, blocked, closed…): laid out, invisible — a tab's width must not change with its
+   state, or the strip's row count flaps at a wrap boundary and the transcript slides under the reader (T262g, 2026-09-08) */
+.tab-dot.none { visibility: hidden; }
 /* state UNKNOWN: a hollow ring in the same "can't see it" gray the network strip paints a down host
    (the `#8a8a8a` in strip.ts's status-dot colour pick) — no-information rendered as itself, so a
    bare tab never has to carry that meaning. */

--- a/ui/webview/tab-dot-slot.test.ts
+++ b/ui/webview/tab-dot-slot.test.ts
@@ -1,0 +1,38 @@
+// A tab's width must not change with its state (T262g, the user 2026-09-08: the chat view slid up and down by one
+// tab row at times). renderTabs appended the working dot (.tab-dot, 7 px plus the 4 px gap) only while a session was
+// working or awaiting, so a tab grew and shrank with its state; with the strip filled to a wrap boundary, a dot
+// appearing or vanishing added or removed a ROW, and every row change moves #content's box under the reader: a
+// bottom reader's text slides by the row height (Chrome keeps the scroller at its maximum; on a wrap the pane's
+// box-resize compensation writes the same). Measured in a lab: wrap -31 px / un-wrap +31 px per flip, no browser
+// fault. Fix: every tab carries the dot's slot in every state — laid out, hidden when the state has no dot — so the
+// strip's row count changes only when tabs are added, removed or renamed. The compacting bar keeps its own wider
+// slot (a rare, deliberate state). Pure rule executed here; render.ts and the CSS pinned.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { tabDotClass } from "./tab-state";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("every state maps to a dot class; the ones without a visible dot get the hidden slot; compacting gets no dot (its bar)", () => {
+  assert.equal(tabDotClass("working"), "tab-dot");
+  assert.equal(tabDotClass("awaitingBg"), "tab-dot await");
+  assert.equal(tabDotClass(undefined), "tab-dot unknown");
+  assert.equal(tabDotClass(""), "tab-dot unknown");
+  assert.equal(tabDotClass("opening"), "tab-dot opening");
+  assert.equal(tabDotClass("compacting"), null);
+  for (const st of ["waiting", "idle", "blocked", "closed", "dead", "needsYou"]) assert.equal(tabDotClass(st), "tab-dot none", st);
+});
+
+test("render.ts appends the slot from the one rule; the compacting bar branch stays", () => {
+  assert.match(RENDER, /import \{[^}]*\btabDotClass\b[^}]*\} from "\.\/tab-state";/);
+  assert.match(RENDER, /const dotCls = tabDotClass\(st\);\s*\n\s*if \(dotCls\) tab\.appendChild\(el\("span", dotCls\)\);/);
+  assert.doesNotMatch(RENDER, /if \(st === "working"\) tab\.appendChild\(el\("span", "tab-dot"\)\);/, "the per-state appends are gone");
+  assert.match(RENDER, /const ci = el\("span", "tab-compacting-bar"\);/);
+});
+
+test("the hidden slot is laid out (visibility, never display:none), same box as the dot", () => {
+  assert.match(CSS, /\.tab-dot\.none \{ visibility: hidden; \}/);
+});

--- a/ui/webview/tab-state.ts
+++ b/ui/webview/tab-state.ts
@@ -81,3 +81,18 @@ export function sectionPipTitle(kind: SectionPip, names: readonly string[]): str
   const phrase = names.length === 1 ? SECTION_PIP_TITLE[kind] : SECTION_PIP_TITLE_MANY[kind](names.length);
   return `${phrase}: ${names.join(", ")}`;
 }
+
+/** The state dot every tab carries (T262g, the user 2026-09-08: the strip's row count flapped with a tab's state).
+ *  A tab's width must not depend on its state: the dot's slot is laid out in EVERY state and merely hidden when the
+ *  state has no dot ("tab-dot none"), so a session starting or finishing work cannot add or remove a row of the strip
+ *  and slide the transcript under the reader by a row's height. working → the solid dot; awaitingBg → the await-green
+ *  dot; a missing state → the gray ring; opening → the accent loader dot; compacting → null (its animated bar takes
+ *  the slot); everything else → the hidden slot. */
+export function tabDotClass(st: string | undefined | null): string | null {
+  if (st === "compacting") return null;
+  if (st === "working") return "tab-dot";
+  if (st === "awaitingBg") return "tab-dot await";
+  if (!st) return "tab-dot unknown";
+  if (st === "opening") return "tab-dot opening";
+  return "tab-dot none";
+}


### PR DESCRIPTION
## Summary
A tab's width no longer changes with its session's state, so the tab strip's row count cannot flap and slide the transcript under the reader by a row.

## What the user saw and why
On their rows (2026-09-08): the tab-strip compensation's `box-resize` write of +31.67 px immediately followed by an unwritten move of −31.67 px back. Reproduced in a lab (headless Chromium at device pixel ratios 1, 1.5 and 2; a strip filled to one row, then a tab added or removed, sampled every 50 ms next to the breadcrumb rows):

| case | what moved |
|---|---|
| wrap, bottom reader | clientHeight −31; one `box-resize` write +31; reader stays at the bottom; no browser undo |
| wrap or un-wrap, off-bottom reader | one `box-resize` write per change (±31); the visible line still; no undo |
| un-wrap, bottom reader | clientHeight +31; no pane write; Chrome clamps −31 (an unwritten row); the following re-wrap moves +31 with Chrome keeping the scroller at its new maximum before the observer runs |

So the compensation is neither redundant with a browser adjustment nor fighting a clamp. The user's pair of rows is a wrap immediately followed by an un-wrap: the strip's row count FLAPPED, and every flap slides a bottom reader's text by one row (31.67 px on their display) because `#content`'s box changes height under them.

The strip flapped because `renderTabs` appended the working dot (`.tab-dot`, 7 px plus the 4 px gap) only while a session was working or awaiting: a tab's width changed with its state (measured on the served page: 198 px idle, 209 px working), and with the strip at a wrap boundary a session starting or finishing work added or removed a row.

## Fix
`tabDotClass(st)` in `tab-state.ts` maps every state to the dot the tab carries: the solid working dot, the await-green dot, the gray ring for a missing state, the accent loader dot for opening, and for every other state `tab-dot none`, laid out but hidden (`visibility: hidden`, never `display: none`). A tab's width is now the same in every state (measured: 209 px idle and working). The compacting bar keeps its own wider slot (a rare, deliberate state; noted). The context gauge appears once when a session crosses 50%, a one-way change, left as is.

## Tests
- New `ui/webview/tab-dot-slot.test.ts`: the rule executed for every state, the single append in `renderTabs`, the compacting branch kept, the CSS pin (visibility, not display).
- `awaiting-state`, `feed-status-pips`, `provisional` tests: their pins on the per-state appends now pin the rule.
- `npm run typecheck` clean; the full extension suite runs on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
