### PR TITLE
Scroll journal: every mover of #content is a writeScroll, spacer re-sizes file a row, the cap is configurable

### DIFF
--- a/ui/webview/chat-windowing.test.ts
+++ b/ui/webview/chat-windowing.test.ts
@@ -44,8 +44,8 @@ test("renderWindowItems renders [unitStart, unitEnd) with a TOP and a BOTTOM spa
 
 test("sizeSpacers sizes BOTH spacers by hidden-unit count × avg, caching only a visible measurement", () => {
   assert.match(RENDER, /function sizeSpacers\(v: View\): void/);
-  assert.match(RENDER, /if \(top\) top\.style\.height = Math\.max\(0, Math\.round\(\(v\.spacerCount \?\? 0\) \* avg\)\)/);
-  assert.match(RENDER, /if \(bot\) bot\.style\.height = Math\.max\(0, Math\.round\(\(v\.spacerCountBot \?\? 0\) \* avg\)\)/);
+  assert.match(RENDER, /const topAfter = top \? Math\.max\(0, Math\.round\(\(v\.spacerCount \?\? 0\) \* avg\)\) : 0, botAfter = bot \? Math\.max\(0, Math\.round\(\(v\.spacerCountBot \?\? 0\) \* avg\)\) : 0;/);
+  assert.match(RENDER, /if \(top\) top\.style\.height = topAfter \+ "px";\s*\n\s*if \(bot\) bot\.style\.height = botAfter \+ "px";/);
   assert.match(RENDER, /if \(h > 0 && n > 0\) v\.avgTurnH = h \/ n;/);   // don't cache a display:none 0
 });
 

--- a/ui/webview/cite-span.test.ts
+++ b/ui/webview/cite-span.test.ts
@@ -34,7 +34,7 @@ test("the landing highlights with zero DOM surgery, and falls back honestly", ()
     "the CSS Custom Highlight API — the ever-re-rendering turn list is never mutated");
   assert.match(fn, /if \(!H \|\| typeof Highlight === "undefined"\) return;/, "no API → today's whole-message landing");
   assert.match(fn, /if \(!m\) return;\s*\/\/ unfindable in the rendered text → no highlight, no guess/);
-  assert.match(fn, /scrollIntoView\(\{ block: "center", behavior: "auto" \}\)/, "land ON the sentence, not the message top");
+  assert.match(fn, /scrollElInto\(content0, el0, "center", "land-on"\)/, "land ON the sentence, not the message top — through the write helper, attributed (T262j)");
   assert.match(CSS, /::highlight\(cite-span\) \{ background-color: color-mix\(in srgb, var\(--accent\) 30%, transparent\);/,
     "accent-tinted, never a status colour (via the token, so the light theme re-inks it)");
 });

--- a/ui/webview/hover-wiring.test.ts
+++ b/ui/webview/hover-wiring.test.ts
@@ -44,7 +44,7 @@ test("the feed modal title hover lights the originating chat message", () => {
 test("landOn top-aligns the target (block:'start'), never centers", () => {
   const landOn = RENDER.slice(RENDER.indexOf("function landOn("));
   const body = landOn.slice(0, landOn.indexOf("\n}\n"));
-  assert.match(body, /scrollIntoView\(\{ block: "start"/, "lands at the top");
+  assert.match(body, /scrollElInto\(c, target, "start", writer\)/, "lands at the top — through the write helper, attributed (T262j)");
   assert.doesNotMatch(body, /block: "center"/, "must not center the landing");
 });
 

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -57,7 +57,7 @@ import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDown
 import { followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow, followTailShrink } from "./scroll-keep";
 import { retainLiveOmitted } from "./tab-order";
 import { userTurnShows } from "./user-turn-content";
-import { ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel } from "./scroll-write";
+import { ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap } from "./scroll-write";
 import { reloadScrollRecord, takeReloadScroll, type ReloadScroll } from "./reload-restore";
 import { keepResidentEvents } from "./frame-merge";
 import { activeTabToReannounce } from "./relay-active";
@@ -2471,11 +2471,14 @@ function ensureScrollMarks(): HTMLElement {
   // off body, not #content, so a notch that takes the pointer also took the wheel and its scroll chain
   // ended at the page — the scrollbar under it stopped scrolling exactly where a notch sat. One passive
   // listener on the stable box hands the delta to the scroller (lines and pages scaled to pixels).
+  // …through the one write helper, as "wheel-scale" (T262j): a trackpad's momentum keeps delivering wheel
+  // events for a second or two after the fingers lift, and each one this box receives is a move of the
+  // transcript the journal must be able to name. #content never scrolls sideways (overflow-x hidden).
   scrollMarks.addEventListener("wheel", (e) => {
     const c = document.getElementById("content");
     if (!c) return;
     const k = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? c.clientHeight : 1;
-    c.scrollBy({ top: e.deltaY * k, left: e.deltaX * k });
+    scrollContentBy(c, e.deltaY * k, "wheel-scale");
   }, { passive: true });
   return scrollMarks;
 }
@@ -6375,7 +6378,7 @@ window.addEventListener("keydown", (e) => {
     const content = document.getElementById("content");
     if (!content) return;
     e.preventDefault();
-    content.scrollBy({ top: e.key === "ArrowDown" ? NAV_SCROLL_STEP : -NAV_SCROLL_STEP });
+    scrollContentBy(content, e.key === "ArrowDown" ? NAV_SCROLL_STEP : -NAV_SCROLL_STEP, "key-nav");   // attributed (T262j)
   } else if (e.key === "Enter") {
     // A live transcript selection outranks everything below (the user 2026-08-04): the selection already
     // seeded the reply chip (selectionchange), and Enter is the natural "now type the reply" — so drop
@@ -9302,12 +9305,14 @@ function nearBottomForSend(c: HTMLElement): boolean {
 // view files nothing. The value written is applied exactly as before: this changes nothing about WHERE the view
 // lands, only that the landing is on the record.
 let lastScrollWriteAfter: number | null = null;
-const scrollDiag = new ScrollDiagBudget();
-function scrollDiagRow(kind: "scrollwrite" | "scrollgesture" | "tailchange", data: any): void {
+// the cap is the default unless the page's localStorage says otherwise (a laptop capturing raises it; T262j)
+const scrollDiagCap = readScrollDiagCap((k) => { try { return localStorage.getItem(k); } catch { return null; } });
+const scrollDiag = new ScrollDiagBudget(scrollDiagCap);
+function scrollDiagRow(kind: "scrollwrite" | "scrollgesture" | "tailchange" | "spacer", data: any): void {
   const v = scrollDiag.take(activeId || "", kind, Date.now());
   if (v === "drop") return;
   vscodeApi?.postMessage(v === "cap"
-    ? { type: "clientDiag", surface: "chat", what: kind + "-capped", data: { sid: activeId || "", perMinute: 40 } }
+    ? { type: "clientDiag", surface: "chat", what: kind + "-capped", data: { sid: activeId || "", perMinute: scrollDiagCap } }
     : { type: "clientDiag", surface: "chat", what: kind, data });
 }
 function writeScroll(content: HTMLElement, top: number, writer: string, stick = false): void {
@@ -9316,6 +9321,23 @@ function writeScroll(content: HTMLElement, top: number, writer: string, stick = 
   const after = content.scrollTop;
   lastScrollWriteAfter = after;
   if (after !== before) scrollDiagRow("scrollwrite", scrollWriteRow(activeId || "", writer, before, after, stick, content.scrollHeight, content.clientHeight));
+}
+// EVERY mover of #content goes through writeScroll (T262j, the user 2026-09-08: an unwritten move the journal could
+// not name). scrollBy and scrollIntoView are scrollTop writes expressed differently, so they are expressed as such:
+/** scrollBy on #content, attributed. */
+function scrollContentBy(content: HTMLElement, dy: number, writer: string): void {
+  writeScroll(content, content.scrollTop + dy, writer);
+}
+/** scrollIntoView for a node inside #content, attributed: "start" puts its top at the viewport top, "center" centres
+ *  it, "nearest" writes only when it is off screen (the browser's own rule), else nothing. */
+function scrollElInto(content: HTMLElement, el: Element, block: "start" | "center" | "nearest", writer: string): void {
+  const cr = content.getBoundingClientRect();
+  const r = el.getBoundingClientRect();
+  const y = r.top - cr.top + content.scrollTop;                     // the node's top in scroll space
+  if (block === "start") writeScroll(content, y, writer);
+  else if (block === "center") writeScroll(content, y - (content.clientHeight - r.height) / 2, writer);
+  else if (r.top < cr.top) writeScroll(content, y, writer);
+  else if (r.bottom > cr.bottom) writeScroll(content, y - (content.clientHeight - r.height), writer);
 }
 
 function cssEscape(s: string): string {
@@ -9509,13 +9531,17 @@ function highlightCiteSpan(target: HTMLElement, quote: string): void {
     H.set("cite-span", new (Highlight as unknown as { new(...r: Range[]): unknown })(range));
     window.setTimeout(() => { try { H.delete("cite-span"); } catch { /* gone with a nav */ } }, 6000);
     const el0 = range.startContainer.parentElement;
-    if (el0) el0.scrollIntoView({ block: "center", behavior: "auto" });   // land ON the sentence, not the message top
+    const content0 = document.getElementById("content");
+    if (el0 && content0) scrollElInto(content0, el0, "center", "land-on");   // land ON the sentence, not the message top (attributed, T262j)
   } catch { /* highlight is chrome, never load-bearing */ }
 }
 
 function landOn(target: HTMLElement, flashKey?: string) {
-  const realign = () => target.scrollIntoView({ block: "start", behavior: "auto" });
-  realign();
+  // the land and its re-alignments are writes of #content like any other, attributed (T262j): "land-on" for the
+  // landing itself, "land-realign" for each re-land while the boxes above size in
+  const land = (writer: string) => { const c = document.getElementById("content"); if (c) scrollElInto(c, target, "start", writer); };
+  const realign = () => land("land-realign");
+  land("land-on");
   if (flashKey == null || flashKey !== flashedAnchor) {   // one flash per navigation (see flashedAnchor)
     if (flashKey != null) flashedAnchor = flashKey;
     target.classList.add("anchor-flash");
@@ -9916,8 +9942,16 @@ function sizeSpacers(v: View): void {
     if (h > 0 && n > 0) v.avgTurnH = h / n;
   }
   const avg = v.avgTurnH ?? 60;
-  if (top) top.style.height = Math.max(0, Math.round((v.spacerCount ?? 0) * avg)) + "px";
-  if (bot) bot.style.height = Math.max(0, Math.round((v.spacerCountBot ?? 0) * avg)) + "px";
+  const topBefore = top ? (parseFloat(top.style.height) || 0) : 0, botBefore = bot ? (parseFloat(bot.style.height) || 0) : 0;
+  const topAfter = top ? Math.max(0, Math.round((v.spacerCount ?? 0) * avg)) : 0, botAfter = bot ? Math.max(0, Math.round((v.spacerCountBot ?? 0) * avg)) : 0;
+  if (top) top.style.height = topAfter + "px";
+  if (bot) bot.style.height = botAfter + "px";
+  // a spacer re-size is a layout change above or below the reader that no pane write accompanies; the browser's
+  // anchoring answers it on its own, so the journal names it (T262j) — for the ACTIVE view only
+  if ((topAfter !== topBefore || botAfter !== botBefore) && activeId && views.get(activeId) === v) {
+    const content = document.getElementById("content");
+    scrollDiagRow("spacer", spacerRow(activeId, topBefore, topAfter, botBefore, botAfter, content ? content.scrollHeight : 0, content ? content.clientHeight : 0));
+  }
 }
 
 // Estimate the UNIT index at the viewport top: a spacer maps by avg height; a rendered row by its data-unit.

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -164,7 +164,7 @@ test("the wheel over a notch scrolls the transcript — the box forwards it (T26
   // scroll chain ended at the page — the scrollbar stopped scrolling exactly where a notch sat
   assert.match(ENSURE, /scrollMarks\.addEventListener\("wheel", \(e\) => \{/, "one listener on the stable box, never per notch");
   assert.match(ENSURE, /const k = e\.deltaMode === 1 \? 16 : e\.deltaMode === 2 \? c\.clientHeight : 1;/, "lines and pages scaled to pixels");
-  assert.match(ENSURE, /c\.scrollBy\(\{ top: e\.deltaY \* k, left: e\.deltaX \* k \}\);\s*\n\s*\}, \{ passive: true \}\);/, "passive: the wheel is never blocked");
+  assert.match(ENSURE, /scrollContentBy\(c, e\.deltaY \* k, "wheel-scale"\);\s*\n\s*\}, \{ passive: true \}\);/, "passive: the wheel is never blocked; the move rides the write helper as wheel-scale (T262j)");
 });
 
 test("only the NOTCH takes the pointer — the box stays passive over the native scrollbar (T260)", () => {

--- a/ui/webview/scroll-movers.test.ts
+++ b/ui/webview/scroll-movers.test.ts
@@ -1,0 +1,54 @@
+// The scroll journal is COMPLETE (T262j, the user 2026-09-08): an unwritten move of the chat transcript landed at a
+// fixed value per tab, 64 px above the bottom, with scrollHeight and clientHeight unchanged and no scrollwrite row,
+// and the journal could not name the mover because four movers still bypassed the one write helper: the wheel over a
+// scrollbar notch (scrollBy), the arrow keys (scrollBy), the deep-link land and its re-alignments (scrollIntoView), and
+// the sentence land (scrollIntoView). Every mover of #content now goes through writeScroll under its own writer name,
+// scrollBy and scrollIntoView expressed as the scrollTop writes they are; a virtualization spacer re-size files a
+// "spacer" row (a top re-estimate paired with a bottom one leaves scrollHeight unchanged yet moves everything under it,
+// and Chrome's anchoring answers with an unwritten move); and the per-minute cap is configurable from localStorage so a
+// laptop capturing does not lose the rest of the minute after a trackpad burst. Pure pieces executed; wiring pinned.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { readScrollDiagCap, spacerRow, SCROLL_DIAG_CAP_KEY, SCROLL_DIAG_CAP_PER_MINUTE } from "./scroll-write";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const SID = "11111111-2222-4333-8444-000000000201";
+
+test("the cap: the default, or a positive integer from localStorage; anything else is the default", () => {
+  assert.equal(SCROLL_DIAG_CAP_KEY, "romp:scrollDiagCap");
+  assert.equal(readScrollDiagCap(() => null), SCROLL_DIAG_CAP_PER_MINUTE);
+  assert.equal(readScrollDiagCap((k) => (k === SCROLL_DIAG_CAP_KEY ? "600" : null)), 600);
+  assert.equal(readScrollDiagCap(() => "0"), SCROLL_DIAG_CAP_PER_MINUTE);
+  assert.equal(readScrollDiagCap(() => "-5"), SCROLL_DIAG_CAP_PER_MINUTE);
+  assert.equal(readScrollDiagCap(() => "lots"), SCROLL_DIAG_CAP_PER_MINUTE);
+  assert.equal(readScrollDiagCap(() => "12.5"), SCROLL_DIAG_CAP_PER_MINUTE);
+  assert.equal(readScrollDiagCap(() => { throw new Error("no storage"); }), SCROLL_DIAG_CAP_PER_MINUTE, "a storage that throws is the default");
+});
+
+test("the spacer row carries both spacers' before/after and their deltas", () => {
+  assert.deepEqual(spacerRow(SID, 1000, 936, 0, 64, 9114, 902), { sid: SID, top: [1000, 936], bot: [0, 64], dTop: -64, dBot: 64, sh: 9114, ch: 902 });
+});
+
+test("render.ts: every mover of #content is a writeScroll — scrollBy and scrollIntoView on it are gone", () => {
+  assert.match(RENDER, /function scrollContentBy\(content: HTMLElement, dy: number, writer: string\): void \{\s*\n\s*writeScroll\(content, content\.scrollTop \+ dy, writer\);/);
+  assert.match(RENDER, /function scrollElInto\(content: HTMLElement, el: Element, block: "start" \| "center" \| "nearest", writer: string\): void \{/);
+  assert.doesNotMatch(RENDER, /\bc\.scrollBy\(|content\.scrollBy\(/, "no scrollBy on the transcript scroller");
+  // the movers, each under its name
+  assert.match(RENDER, /scrollContentBy\(c, e\.deltaY \* k, "wheel-scale"\);/, "the wheel over a scrollbar notch");
+  assert.match(RENDER, /scrollContentBy\(content, e\.key === "ArrowDown" \? NAV_SCROLL_STEP : -NAV_SCROLL_STEP, "key-nav"\);/, "the arrow keys");
+  assert.match(RENDER, /scrollElInto\(content0, el0, "center", "land-on"\);/, "the sentence land");
+  assert.match(RENDER, /const land = \(writer: string\) => \{ const c = document\.getElementById\("content"\); if \(c\) scrollElInto\(c, target, "start", writer\); \};\s*\n\s*const realign = \(\) => land\("land-realign"\);\s*\n\s*land\("land-on"\);/, "the deep-link land and its re-alignments");
+  // the scrollIntoView calls that remain are on OTHER scrollers (the tab strip, picker rows, the slash popup, the awaiting box)
+  const rest = RENDER.split("\n").filter((l) => /scrollIntoView\(/.test(l));
+  assert.equal(rest.length, 4, "four scrollIntoView calls remain, none on a #content child: " + rest.map((l) => l.trim().slice(0, 60)).join(" | "));
+  for (const l of rest) assert.doesNotMatch(l, /target|el0|realign/, l);
+});
+
+test("render.ts: a spacer re-size of the active view files a spacer row; the cap comes from localStorage", () => {
+  assert.match(RENDER, /if \(\(topAfter !== topBefore \|\| botAfter !== botBefore\) && activeId && views\.get\(activeId\) === v\) \{\s*\n\s*const content = document\.getElementById\("content"\);\s*\n\s*scrollDiagRow\("spacer", spacerRow\(activeId, topBefore, topAfter, botBefore, botAfter,/);
+  assert.match(RENDER, /const scrollDiagCap = readScrollDiagCap\(\(k\) => \{ try \{ return localStorage\.getItem\(k\); \} catch \{ return null; \} \}\);\s*\n\s*const scrollDiag = new ScrollDiagBudget\(scrollDiagCap\);/);
+  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer", data: any\): void \{/);
+  assert.match(RENDER, /data: \{ sid: activeId \|\| "", perMinute: scrollDiagCap \} \}/, "the capped row says which cap");
+});

--- a/ui/webview/scroll-write.test.ts
+++ b/ui/webview/scroll-write.test.ts
@@ -40,10 +40,10 @@ test("the row names the writer and carries before/after/delta/stick, gesture:fal
 });
 
 test("render.ts: one helper writes #content.scrollTop, files the row only when the view moved, and no raw write remains", () => {
-  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel \} from "\.\/scroll-write";/);
+  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap \} from "\.\/scroll-write";/);
   assert.match(RENDER, /function writeScroll\(content: HTMLElement, top: number, writer: string, stick = false\): void \{\s*\n\s*const before = content\.scrollTop;\s*\n\s*content\.scrollTop = top;\s*\n\s*const after = content\.scrollTop;\s*\n\s*lastScrollWriteAfter = after;\s*\n\s*if \(after !== before\) scrollDiagRow\("scrollwrite", scrollWriteRow\(activeId \|\| "", writer, before, after, stick, content\.scrollHeight, content\.clientHeight\)\);/);
   // the breadcrumb rides the existing clientDiag path, capped, with one capped row at the cap
-  assert.match(RENDER, /\{ type: "clientDiag", surface: "chat", what: kind \+ "-capped", data: \{ sid: activeId \|\| "", perMinute: 40 \} \}/);
+  assert.match(RENDER, /\{ type: "clientDiag", surface: "chat", what: kind \+ "-capped", data: \{ sid: activeId \|\| "", perMinute: scrollDiagCap \} \}/);   // the cap the page runs with (T262j: configurable)
   assert.match(RENDER, /\{ type: "clientDiag", surface: "chat", what: kind, data \}/);
   // every writer is named
   for (const w of ["optimistic-send", "keep-offset", "toolgroup-toggle", "land-bottom", "land-saved", "anchor-restore",

--- a/ui/webview/scroll-write.ts
+++ b/ui/webview/scroll-write.ts
@@ -13,6 +13,18 @@
 
 export const SCROLL_DIAG_CAP_PER_MINUTE = 40;
 
+/** The cap a page actually runs with: the default, or the positive integer in localStorage under
+ *  "romp:scrollDiagCap" (T262j, the user 2026-09-08: a capture on their laptop hit the 40/min gesture cap within
+ *  seconds of trackpad scrolling, and every unwritten move for the rest of the minute went unrecorded; a laptop
+ *  capturing sets the key, everyone else keeps the default). Anything that is not a positive integer → the default. */
+export const SCROLL_DIAG_CAP_KEY = "romp:scrollDiagCap";
+export function readScrollDiagCap(getItem: (key: string) => string | null): number {
+  let raw: string | null = null;
+  try { raw = getItem(SCROLL_DIAG_CAP_KEY); } catch { raw = null; }
+  const n = raw == null ? NaN : Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : SCROLL_DIAG_CAP_PER_MINUTE;
+}
+
 /** One kind of row's budget for one session within the current minute: "send" while under the cap, "cap"
  *  exactly once at the cap (the caller files a capped row), "drop" past it until the minute rolls. */
 export class ScrollDiagBudget {
@@ -33,6 +45,13 @@ export class ScrollDiagBudget {
  *  pixel of the value written), or a gesture nobody's code asked for? */
 export function classifyScroll(scrollTop: number, lastWriteAfter: number | null): "write-echo" | "gesture" {
   return lastWriteAfter != null && Math.abs(scrollTop - lastWriteAfter) <= 1 ? "write-echo" : "gesture";
+}
+
+/** The breadcrumb for one re-size of a view's virtualization spacers (T262j): a top spacer re-estimate paired with
+ *  a bottom one leaves scrollHeight unchanged yet moves everything under the top spacer, and Chrome's scroll
+ *  anchoring then moves the reader by the same amount with no pane write. `top`/`bot` = [before, after] heights. */
+export function spacerRow(sid: string, topBefore: number, topAfter: number, botBefore: number, botAfter: number, sh = 0, ch = 0) {
+  return { sid, top: [topBefore, topAfter], bot: [botBefore, botAfter], dTop: topAfter - topBefore, dBot: botAfter - botBefore, sh, ch };
 }
 
 /** The breadcrumb for one height change of the transcript's TAIL outside the append path (T262f, the user

--- a/ui/webview/tail-change-row.test.ts
+++ b/ui/webview/tail-change-row.test.ts
@@ -27,7 +27,7 @@ test("the tail label is the last child that is not a virtualization spacer", () 
 });
 
 test("render.ts files the row from both tail observers, beside the tail-shrink rule, through the capped diag path", () => {
-  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel \} from "\.\/scroll-write";/);
+  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap \} from "\.\/scroll-write";/);   // + spacerRow, readScrollDiagCap (T262j)
   assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer", data: any\): void \{/);   // + spacer (T262j)
   assert.match(RENDER, /if \(content && lastH >= 0 && activeId === id && view\.shown && h !== lastH\)\s*\n\s*scrollDiagRow\("tailchange", tailChangeRow\(id, h - lastH, tailLabel\(view\.el\.children\), view\.stick, content\.scrollHeight, content\.clientHeight\)\);/);
   assert.match(RENDER, /if \(content && tailLastH >= 0 && v && v\.shown && h !== tailLastH\)\s*\n\s*scrollDiagRow\("tailchange", tailChangeRow\(activeId \|\| "", h - tailLastH, "live-ask", v\.stick, content\.scrollHeight, content\.clientHeight\)\);/);

--- a/ui/webview/tail-change-row.test.ts
+++ b/ui/webview/tail-change-row.test.ts
@@ -28,7 +28,7 @@ test("the tail label is the last child that is not a virtualization spacer", () 
 
 test("render.ts files the row from both tail observers, beside the tail-shrink rule, through the capped diag path", () => {
   assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel \} from "\.\/scroll-write";/);
-  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange", data: any\): void \{/);
+  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer", data: any\): void \{/);   // + spacer (T262j)
   assert.match(RENDER, /if \(content && lastH >= 0 && activeId === id && view\.shown && h !== lastH\)\s*\n\s*scrollDiagRow\("tailchange", tailChangeRow\(id, h - lastH, tailLabel\(view\.el\.children\), view\.stick, content\.scrollHeight, content\.clientHeight\)\);/);
   assert.match(RENDER, /if \(content && tailLastH >= 0 && v && v\.shown && h !== tailLastH\)\s*\n\s*scrollDiagRow\("tailchange", tailChangeRow\(activeId \|\| "", h - tailLastH, "live-ask", v\.stick, content\.scrollHeight, content\.clientHeight\)\);/);
   assert.equal((RENDER.match(/"tailchange"/g) || []).length, 3, "the kind in the router's union and the two filings");


### PR DESCRIPTION
## Summary
Instrumentation for the remaining chat-pane snap: every mover of `#content` now goes through the one write helper under its own writer name, virtualization spacer re-sizes file a row, and the per-minute breadcrumb cap is configurable from local storage for a capture.

## Why
The user's laptop captures (2026-09-08) show an UNWRITTEN move landing at a fixed value per tab, 64 px above the bottom, with scrollHeight and clientHeight unchanged, no `scrollwrite` and no `tailchange` row, no kernel frame in three of five cases, 2.5 to 2.7 s after the reader reached the bottom. The journal could not name the mover: four movers still bypassed `writeScroll`.

## Change
- `scrollContentBy` and `scrollElInto`: `scrollBy` and `scrollIntoView` on the transcript are scrollTop writes expressed differently, so they are expressed as such and attributed: the wheel over a scrollbar notch (`wheel-scale`; a trackpad's momentum keeps delivering wheel events for a second or two after the fingers lift), the arrow keys (`key-nav`), the deep-link land and its re-alignments (`land-on`, `land-realign`), and the sentence land (`land-on`). The four `scrollIntoView` calls that remain are on other scrollers (tab strip, picker rows, slash popup, awaiting box).
- `sizeSpacers` files a `spacer` row when either spacer of the active view changes height (both spacers' before/after and deltas, scrollHeight, clientHeight). A top re-estimate paired with a bottom one leaves scrollHeight unchanged yet moves everything under it, and Chrome's anchoring answers with an unwritten move: the observed shape, now attributable.
- The cap: `localStorage["romp:scrollDiagCap"]` (a positive integer) overrides the default 40 per kind per minute; the capped row names the cap in force. The laptop sets the key for a capture; everyone else keeps the default.

## Tests
- New `ui/webview/scroll-movers.test.ts`: the cap reader and the spacer row executed; every routed mover, the absence of `scrollBy`/`scrollIntoView` on the transcript scroller, the spacer filing and the cap wiring pinned.
- Pins moved with the code in cite-span, hover-wiring, scroll-marks, scroll-write, chat-windowing and tail-change-row tests.
- `npm run typecheck` clean; the full extension suite runs on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
