### PR TITLE
T262h/T262i: the tail never loses height while a copy is in flight — the pending bubble keeps its node, a vanished queued copy is held until its atom lands

### DIFF
--- a/tests/test_pending_bubble_stable.py
+++ b/tests/test_pending_bubble_stable.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""T262h (the user 2026-09-08): the pending bubble's node must never leave the DOM between two paints while its
+entry is pending. The user's laptop rows showed the reader, sitting at the bottom with a send pending, moved UP by
+the bubble's height (64 px for a one-line bubble, 95 px for two) with no scroll write between the rows — the
+browser clamping scrollTop to a scrollHeight without the bubble — and then following no more: atBottom false,
+follow mode off, new content no longer pulling them down.
+
+The executed guard drives the real /chat page against a hermetic kernel with a bottom reader and a pending send
+(dropped at the socket, so the client's bubble is the only copy), then appends a transcript step every 0.5 s for
+T262H_SECONDS seconds (default 60) — one kernel push each — and after every push checks: the distance from the
+bottom is 0; the page filed no "scrollgesture" row (the page's own classification of a scroll no write explains:
+an UNWRITTEN move) and no "tail-shrink" write (the observer correcting a clamp that already happened); the
+`.turn-queued` node is the SAME element it was at the press (its harness mark survives) and no removal of a
+`.turn-queued` node was observed. Then the same with two sends and a ✕ on the first. SYNTHETIC fixtures only;
+skips loudly without the extension deps or a Playwright browser.
+"""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+TEXT = "and also update the docstring"
+TEXT2 = "then run the formatter"
+SECONDS = float(os.environ.get("T262H_SECONDS", "60"))
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1000, height: 600 } });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+await page.waitForSelector(".turn.turn-user", { timeout: 20000 });
+await page.waitForTimeout(600);
+// instrumentation: the page's own scroll rows (clientDiag frames on the socket), our sends dropped at the socket,
+// removals of any .turn-queued node, and a mark on the pending node to prove identity across pushes
+await page.evaluate(() => {
+  const orig = WebSocket.prototype.send;
+  window.__dropped = 0; window.__rows = []; window.__removals = 0; window.__frames = 0;
+  window.addEventListener("message", (e) => { const m = e.data; if (m && (m.type === "session" || m.type === "update" || m.type === "chatTail")) window.__frames++; });
+  WebSocket.prototype.send = function (d) {
+    try {
+      const m = JSON.parse(d);
+      if (m && m.type === "sendMessage") { window.__dropped++; return; }
+      if (m && m.type === "clientDiag" && m.surface === "chat" && /^scroll/.test(m.what || "")) window.__rows.push({ what: m.what, writer: m.data && m.data.writer, before: m.data && m.data.before, after: m.data && m.data.after, sh: m.data && m.data.sh, top: m.data && m.data.top });
+    } catch (e) {}
+    return orig.call(this, d);
+  };
+  const content = document.getElementById("content");
+  // a removal counts only when the node is NOT re-added within the same mutation batch (a same-task move keeps it on the
+  // page across the paint; a removal that survives the batch is a frame without the bubble)
+  const mo = new MutationObserver((muts) => {
+    const removed = new Set(); const added = new Set();
+    for (const m of muts) { for (const n of m.removedNodes) removed.add(n); for (const n of m.addedNodes) added.add(n); }
+    for (const n of removed) if (n instanceof HTMLElement && n.classList.contains("turn-queued") && !n.classList.contains("turn-queued-hidden") && !added.has(n) && !n.isConnected) window.__removals++;
+  });
+  mo.observe(content, { childList: true, subtree: true });
+});
+const measure = () => page.evaluate(() => {
+  const content = document.getElementById("content");
+  const g = document.querySelector(".turn-queued:not(.turn-queued-hidden)");
+  return {
+    dist: Math.round((content.scrollHeight - content.scrollTop - content.clientHeight) * 10) / 10,
+    marked: g ? g.dataset.h262 === "1" : null, texts: g ? Array.from(g.querySelectorAll(".queued-bubble")).length : 0,
+    units: document.querySelectorAll(".turn[data-unit]").length, removals: window.__removals,
+    gestures: window.__rows.filter((r) => r.what === "scrollgesture").length,
+    shrinks: window.__rows.filter((r) => r.what === "scrollwrite" && r.writer === "tail-shrink").length,
+    rows: window.__rows.length,
+  };
+});
+// a bottom reader
+await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = c.scrollHeight; });
+await page.waitForTimeout(300);
+await page.evaluate(() => { window.__rows = []; });
+await page.fill("#composer-input", cfg.text);
+await page.press("#composer-input", "Enter");
+await page.waitForSelector(".turn-queued", { timeout: 10000 });
+await page.evaluate(() => { const g = document.querySelector(".turn-queued:not(.turn-queued-hidden)"); if (g) g.dataset.h262 = "1"; });
+await page.waitForTimeout(300);
+const pressed = await measure();
+// pushes every 0.5 s: one transcript step each, alternating a tool call and its result
+const pushes = [];
+let n = 0; const t1 = Date.now(); let parent = cfg.parent; let t = cfg.t0 + 60;
+const step = (i) => {
+  if (i % 2 === 0) { const r = { type: "assistant", timestamp: cfg.iso(t + i), uuid: "s" + i, parentUuid: parent, sessionId: cfg.sid,
+      message: { role: "assistant", model: "claude-fable-5-1", stop_reason: "tool_use", content: [{ type: "tool_use", id: "tu_s" + i, name: "Bash", input: { command: "true # step " + i } }] } }; parent = "s" + i; return r; }
+  const r = { type: "user", timestamp: cfg.iso(t + i), uuid: "s" + i, parentUuid: parent, sessionId: cfg.sid,
+      message: { role: "user", content: [{ type: "tool_result", tool_use_id: "tu_s" + (i - 1), content: "ok" }] } }; parent = "s" + i; return r;
+};
+cfg.iso = (x) => new Date(x * 1000).toISOString().replace(/\.\d{3}Z$/, ".000Z");
+while (Date.now() - t1 < cfg.seconds * 1000) {
+  const before = await page.evaluate(() => window.__frames);
+  fs.appendFileSync(cfg.transcript, JSON.stringify(step(n)) + "\n");
+  n++;
+  try { await page.waitForFunction((b) => window.__frames > b, before, { timeout: 5000 }); } catch (e) { pushes.push({ i: n, timeout: true }); }
+  await page.waitForTimeout(500);
+  pushes.push({ i: n, ...(await measure()) });
+}
+const one = { pressed, pushes, n };
+// two sends and a ✕ on the first
+await page.fill("#composer-input", cfg.text2);
+await page.press("#composer-input", "Enter");
+await page.waitForFunction((t2) => Array.from(document.querySelectorAll(".turn-queued")).some((g) => (g.textContent || "").includes(t2)), cfg.text2, { timeout: 10000 });
+await page.waitForTimeout(300);
+const two = await measure();
+const twoPushes = [];
+for (let k = 0; k < 6; k++) {
+  const before = await page.evaluate(() => window.__frames);
+  fs.appendFileSync(cfg.transcript, JSON.stringify(step(n)) + "\n"); n++;
+  try { await page.waitForFunction((b) => window.__frames > b, before, { timeout: 5000 }); } catch (e) {}
+  await page.waitForTimeout(500);
+  twoPushes.push(await measure());
+}
+// the ✕ on the FIRST bubble
+await page.evaluate(() => { const xs = Array.from(document.querySelectorAll(".turn-queued:not(.turn-queued-hidden) .queued-x")); if (xs[0]) xs[0].click(); });
+await page.waitForTimeout(400);
+const afterX = await measure();
+for (let k = 0; k < 4; k++) {
+  const before = await page.evaluate(() => window.__frames);
+  fs.appendFileSync(cfg.transcript, JSON.stringify(step(n)) + "\n"); n++;
+  try { await page.waitForFunction((b) => window.__frames > b, before, { timeout: 5000 }); } catch (e) {}
+  await page.waitForTimeout(500);
+  twoPushes.push(await measure());
+}
+const rows = await page.evaluate(() => window.__rows);
+fs.writeSync(1, "RESULT:" + JSON.stringify({ one, two, twoPushes, afterX, rows: rows.slice(-40) }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedPendingBubbleStable(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        cls.lab = tempfile.mkdtemp(prefix="pending-stable-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        shutil.copytree(os.path.join(EXT, "dist"), dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(cls.state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        Path(cls.state, "names", SID).write_text("web\t%s\t\t\n" % cwd)
+        Path(cls.state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high",
+             "lastSid": SID, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
+        Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        claude = os.path.join(cls.lab, "claude")
+        # the kernel finds a session's transcript under Claude's project dir: EVERY non-alphanumeric char of the
+        # realpath becomes '-' (jd._proj_dir). A slashes-only munge missed the '_' pytest's temp root can carry,
+        # so the kernel found no transcript and drew an API-error turn instead (the batch-only flake, 2026-09-08).
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        # a running turn: the reply is tall enough to overflow the pane, then a tool call whose result is in
+        t0 = int(time.time()) - 900
+        cls.t0 = t0
+        recs = [
+            {"type": "user", "timestamp": iso(t0), "uuid": "u1", "parentUuid": None, "promptSource": "sdk", "sessionId": SID,
+             "message": {"role": "user", "content": "tighten the notes-api search"}},
+            {"type": "assistant", "timestamp": iso(t0 + 10), "uuid": "a1", "parentUuid": "u1", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "end_turn",
+                         "content": [{"type": "text", "text": "\n\n".join("Paragraph %d of the reply." % i for i in range(14))}]}},
+            {"type": "user", "timestamp": iso(t0 + 39), "uuid": "u2", "parentUuid": "a1", "promptSource": "sdk", "sessionId": SID,
+             "message": {"role": "user", "content": "drop the unused import"}},
+            {"type": "assistant", "timestamp": iso(t0 + 41), "uuid": "a2", "parentUuid": "u2", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "tool_use",
+                         "content": [{"type": "tool_use", "id": "tu_a2_0", "name": "Bash", "input": {"command": "uv run pytest -q"}}]}},
+            {"type": "user", "timestamp": iso(t0 + 50), "uuid": "tr1", "parentUuid": "a2", "sessionId": SID,
+             "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_a2_0", "content": "3 passed"}]}},
+        ]
+        cls.transcript = os.path.join(proj, SID + ".jsonl")
+        Path(cls.transcript).write_text("".join(json.dumps(r) + "\n" for r in recs))
+        # the steps the session runs while the send waits, and the splice the CLI writes when it takes it
+        cls.steps = [
+            {"type": "assistant", "timestamp": iso(t0 + 120), "uuid": "a3", "parentUuid": "tr1", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "tool_use",
+                         "content": [{"type": "tool_use", "id": "tu_a3_0", "name": "Bash", "input": {"command": "uv run pytest -q tests/test_search.py"}}]}},
+            {"type": "user", "timestamp": iso(t0 + 121), "uuid": "tr2", "parentUuid": "a3", "sessionId": SID,
+             "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_a3_0", "content": "5 passed"}]}},
+            {"type": "assistant", "timestamp": iso(t0 + 122), "uuid": "a4", "parentUuid": "tr2", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "tool_use",
+                         "content": [{"type": "tool_use", "id": "tu_a4_0", "name": "Bash", "input": {"command": "git diff --stat"}}]}},
+            {"type": "user", "timestamp": iso(t0 + 125), "uuid": "tr3", "parentUuid": "a4", "sessionId": SID,
+             "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_a4_0", "content": "1 file changed"}]}},
+        ]
+        # sent at t0+55, taken at the t0+125 boundary (tr3, its file-order predecessor): 70 s later, so the landed
+        # bubble's hover names the send time
+        cls.landing = {"type": "attachment", "timestamp": iso(t0 + 55), "uuid": "att1", "parentUuid": "tr3", "isSidechain": False,
+                       "sessionId": SID, "attachment": {"type": "queued_command", "prompt": TEXT}}
+        cls.port = _free_port()
+        cls.token = "testtok-pendingstable"
+        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
+                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
+        for k in ("ROMP_STATE_DIR", "ROMP_API_KEY_CMD", "ANTHROPIC_API_KEY"):
+            env.pop(k, None)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+
+    def test_the_pending_bubble_keeps_its_node_and_the_bottom_reader_stays_at_the_bottom(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "text": TEXT, "text2": TEXT2,
+                       "transcript": self.transcript, "sid": SID, "t0": self.t0, "parent": "tr1", "seconds": SECONDS}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=int(SECONDS) + 240,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(self.klog).read()[-1500:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        one, pushes = r["one"], r["one"]["pushes"]
+        print("T262H:", json.dumps({"pressed": one["pressed"], "dists": [p.get("dist") for p in pushes], "marked": [p.get("marked") for p in pushes],
+                                     "removals": pushes[-1].get("removals") if pushes else None, "gestures": pushes[-1].get("gestures") if pushes else None,
+                                     "shrinks": pushes[-1].get("shrinks") if pushes else None, "two": r["two"], "afterX": r["afterX"],
+                                     "twoDists": [p.get("dist") for p in r["twoPushes"]], "rows": r["rows"][-30:]}))
+        self.assertGreaterEqual(len(pushes), max(4, int(SECONDS // 4)), "enough pushes landed: %r" % len(pushes))
+        self.assertEqual([p["i"] for p in pushes if p.get("timeout")], [], "every push repainted: %r" % pushes[:3])
+        self.assertEqual(one["pressed"]["dist"], 0, "at the bottom with the bubble at the press: %r" % one["pressed"])
+        worst = max(p["dist"] for p in pushes)
+        self.assertLessEqual(worst, 2, "a bottom reader with a pending send stays at the bottom through every push (worst distance %r): %r" % (worst, [p["dist"] for p in pushes]))
+        self.assertEqual(pushes[-1]["gestures"], 0, "no unwritten move (no scroll the page could not attribute to a write): %r" % r["rows"][-12:])
+        self.assertEqual(pushes[-1]["shrinks"], 0, "no tail-shrink correction: nothing shrank the tail under the reader: %r" % r["rows"][-12:])
+        self.assertTrue(all(p["marked"] is True for p in pushes), "the pending bubble's node is the SAME element after every push: %r" % [p["marked"] for p in pushes])
+        self.assertEqual(pushes[-1]["removals"], 0, "no .turn-queued node was ever removed while pending")
+        # two sends and a ✕
+        two, tp, ax = r["two"], r["twoPushes"], r["afterX"]
+        self.assertEqual(two["texts"], 2, "two pending sends in the one group: %r" % two)
+        self.assertLessEqual(max(p["dist"] for p in tp), 2, "…and the reader stays at the bottom through pushes, before and after the ✕: %r" % [p["dist"] for p in tp])
+        self.assertEqual(ax["texts"], 1, "the ✕ removed one bubble: %r" % ax)
+        self.assertEqual(ax["dist"], 0, "the ✕ leaves the reader at the bottom: %r" % ax)
+        self.assertEqual(tp[-1]["gestures"], 0, "no unwritten move across the second send and the ✕: %r" % r["rows"][-12:])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_queued_copy_held.py
+++ b/tests/test_queued_copy_held.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""T262i (the user 2026-09-08): a queued copy of the kernel's — a romp mail card in the tail group (T243) — leaves the
+queue when the CLI takes it and LANDS as an absorbed atom (T252d), and those two facts reach the pane in different
+pushes: the queue state first, the transcript record later. Between the two the tail is SHORTER by the card, the
+browser clamps a reader within that height of the bottom, and the landed card then grows the tail back below them:
+the reader ends a card above the bottom, follow mode off, the jump chip shown — the flap the user saw on a session
+that receives mail all day, with no pending send of their own.
+
+The executed guard drives the real /chat page against a hermetic kernel and injects the two pushes as SEPARATE
+frames (the page's own frame listener, window.postMessage, with the kernel's real frame as the base): a queue frame
+adding the mail card, a queue frame without it (taken, not landed), then a transcript frame landing the atom that
+carries the card's id. Asserted for a bottom reader: the distance from the bottom is 0 after every frame, the page
+files no "scrollgesture" row (an unwritten move) and no "tail-shrink" write (a clamp corrected after the fact), the
+jump chip never shows, and the card's slot is continuous (a queued or landing card is on the page between the two
+frames). For an off-bottom reader: scrollTop never changes. Red on main at the queue-without-copy frame. Also the
+id-less copy (an older kernel, the tmux route): held for one push by text, then dropped. SYNTHETIC fixtures only;
+skips loudly without the extension deps or a Playwright browser.
+"""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+TEXT = "and also update the docstring"
+TEXT2 = "then run the formatter"
+MAIL = "<!-- romp-injected -->[romp mail from api] the fixtures batch is labeled; the export gzip is next <!-- romp-msg-id: 11111111.2222_33333.TESTHOST -->"
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1000, height: 600 } });
+// capture every kernel frame from the first byte (the FULL session frame arrives at load), and the page's scroll rows
+await page.addInitScript(() => {
+  window.__rows = []; window.__frames = [];
+  window.addEventListener("message", (e) => { const m = e.data; if (m && (m.type === "session" || m.type === "update" || m.type === "chatTail")) window.__frames.push(m); });
+  const orig = WebSocket.prototype.send;
+  WebSocket.prototype.send = function (d) {
+    try { const m = JSON.parse(d); if (m && m.type === "clientDiag" && m.surface === "chat" && /^scroll/.test(m.what || "")) window.__rows.push({ what: m.what, writer: m.data && m.data.writer, before: m.data && m.data.before, after: m.data && m.data.after, sh: m.data && m.data.sh }); } catch (e) {}
+    return orig.call(this, d);
+  };
+});
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+await page.waitForSelector(".turn.turn-user", { timeout: 20000 });
+await page.waitForTimeout(600);
+// the FULL session frame is the base for every synthetic push (a chatTail carries only a suffix)
+await page.waitForFunction(() => window.__frames.some((m) => m.type === "session" && Array.isArray(m.events) && m.events.length > 3), null, { timeout: 20000 });
+const base = await page.evaluate(() => { const fr = window.__frames.filter((m) => m.type === "session" && Array.isArray(m.events)); return fr[fr.length - 1]; });
+base.events = base.events.filter((e) => !(e.uuid || "").startsWith("optimistic:"));
+const measure = () => page.evaluate(() => {
+  const content = document.getElementById("content");
+  const chip = document.getElementById("jump-bottom");
+  const card = document.querySelector(".turn-queued:not(.turn-queued-hidden) .queued-bubble, .turn.turn-user .romp-bubble, .turn.turn-user .user-note");
+  return {
+    top: Math.round(content.scrollTop * 10) / 10, dist: Math.round((content.scrollHeight - content.scrollTop - content.clientHeight) * 10) / 10, sh: content.scrollHeight,
+    chip: !!chip && chip.offsetParent !== null && getComputedStyle(chip).display !== "none" && getComputedStyle(chip).visibility !== "hidden" && !chip.hidden,
+    queuedCards: document.querySelectorAll(".turn-queued:not(.turn-queued-hidden) .queued-bubble").length,
+    landing: document.querySelectorAll(".turn-queued .queued-bubble.landing, .queued-landing").length,
+    landedMail: Array.from(document.querySelectorAll(".turn.turn-user")).filter((t) => (t.textContent || "").includes("fixtures batch is labeled")).length,
+    gestures: window.__rows.filter((r) => r.what === "scrollgesture").length,
+    shrinks: window.__rows.filter((r) => r.what === "scrollwrite" && r.writer === "tail-shrink").length,
+  };
+});
+// frames: the queue with the mail card; the queue without it (taken, not landed); the transcript landing it
+const inject = (frame) => page.evaluate((f) => { window.postMessage(f, "*"); }, frame);
+const withCard = (b, qid) => ({ ...b, type: "update", events: [...b.events.filter((e) => e.kind !== "queued"), { kind: "queued", texts: [{ md: cfg.mail, romp: true, cancelable: true, idx: 0, ...(qid ? { qid, qts: Date.now() } : {}) }] }] });
+const without = (b) => ({ ...b, type: "update", events: b.events.filter((e) => e.kind !== "queued") });
+const landed = (b, qid, uuid) => ({ ...b, type: "update", events: [...b.events.filter((e) => e.kind !== "queued"), { kind: "user", md: cfg.mail, uuid, ts: new Date().toISOString(), romp: true, absorbed: true, sentAt: Math.floor(Date.now() / 1000) - 5, ...(qid ? { qid } : {}) }] });
+const run = async (label, qid, uuid) => {
+  const out = { label };
+  await inject(withCard(base, qid)); await page.waitForTimeout(400); out.card = await measure();
+  await inject(without(base)); await page.waitForTimeout(400); out.taken = await measure();
+  await inject(without(base)); await page.waitForTimeout(400); out.taken2 = await measure();   // another push carrying the (empty) queue
+  await inject(landed(base, qid, uuid)); await page.waitForTimeout(400); out.landed = await measure();
+  return out;
+};
+// a bottom reader
+await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = c.scrollHeight; window.__rows = []; });
+await page.waitForTimeout(300);
+const start = await measure();
+const idPath = await run("id", "echo:m1", "am1");
+// the landed atom stays in the base for the next rounds
+base.events = [...base.events.filter((e) => e.kind !== "queued"), { kind: "user", md: cfg.mail, uuid: "am1", ts: new Date().toISOString(), romp: true, absorbed: true, qid: "echo:m1" }];
+await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = c.scrollHeight; });
+await page.waitForTimeout(300);
+const textPath = await run("text", null, "am2");
+base.events = [...base.events, { kind: "user", md: cfg.mail, uuid: "am2", ts: new Date().toISOString(), romp: true, absorbed: true }];
+// an off-bottom reader: nothing may move
+await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = Math.max(0, c.scrollHeight - c.clientHeight - 300); });
+await page.waitForTimeout(300);
+const offStart = await measure();
+const off = await run("off", "echo:m3", "am3");
+const rows = await page.evaluate(() => window.__rows);
+fs.writeSync(1, "RESULT:" + JSON.stringify({ start, idPath, textPath, offStart, off, rows: rows.slice(-40), baseType: base.type, baseEvents: base.events.length }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedQueuedCopyHeld(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        cls.lab = tempfile.mkdtemp(prefix="queued-held-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        shutil.copytree(os.path.join(EXT, "dist"), dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(cls.state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        Path(cls.state, "names", SID).write_text("web\t%s\t\t\n" % cwd)
+        Path(cls.state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high",
+             "lastSid": SID, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
+        Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        claude = os.path.join(cls.lab, "claude")
+        # the kernel finds a session's transcript under Claude's project dir: EVERY non-alphanumeric char of the
+        # realpath becomes '-' (jd._proj_dir). A slashes-only munge missed the '_' pytest's temp root can carry,
+        # so the kernel found no transcript and drew an API-error turn instead (the batch-only flake, 2026-09-08).
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        # a running turn: the reply is tall enough to overflow the pane, then a tool call whose result is in
+        t0 = int(time.time()) - 900
+        cls.t0 = t0
+        recs = [
+            {"type": "user", "timestamp": iso(t0), "uuid": "u1", "parentUuid": None, "promptSource": "sdk", "sessionId": SID,
+             "message": {"role": "user", "content": "tighten the notes-api search"}},
+            {"type": "assistant", "timestamp": iso(t0 + 10), "uuid": "a1", "parentUuid": "u1", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "end_turn",
+                         "content": [{"type": "text", "text": "\n\n".join("Paragraph %d of the reply." % i for i in range(14))}]}},
+            {"type": "user", "timestamp": iso(t0 + 39), "uuid": "u2", "parentUuid": "a1", "promptSource": "sdk", "sessionId": SID,
+             "message": {"role": "user", "content": "drop the unused import"}},
+            {"type": "assistant", "timestamp": iso(t0 + 41), "uuid": "a2", "parentUuid": "u2", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "tool_use",
+                         "content": [{"type": "tool_use", "id": "tu_a2_0", "name": "Bash", "input": {"command": "uv run pytest -q"}}]}},
+            {"type": "user", "timestamp": iso(t0 + 50), "uuid": "tr1", "parentUuid": "a2", "sessionId": SID,
+             "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_a2_0", "content": "3 passed"}]}},
+        ]
+        cls.transcript = os.path.join(proj, SID + ".jsonl")
+        Path(cls.transcript).write_text("".join(json.dumps(r) + "\n" for r in recs))
+        # the steps the session runs while the send waits, and the splice the CLI writes when it takes it
+        cls.steps = [
+            {"type": "assistant", "timestamp": iso(t0 + 120), "uuid": "a3", "parentUuid": "tr1", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "tool_use",
+                         "content": [{"type": "tool_use", "id": "tu_a3_0", "name": "Bash", "input": {"command": "uv run pytest -q tests/test_search.py"}}]}},
+            {"type": "user", "timestamp": iso(t0 + 121), "uuid": "tr2", "parentUuid": "a3", "sessionId": SID,
+             "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_a3_0", "content": "5 passed"}]}},
+            {"type": "assistant", "timestamp": iso(t0 + 122), "uuid": "a4", "parentUuid": "tr2", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "tool_use",
+                         "content": [{"type": "tool_use", "id": "tu_a4_0", "name": "Bash", "input": {"command": "git diff --stat"}}]}},
+            {"type": "user", "timestamp": iso(t0 + 125), "uuid": "tr3", "parentUuid": "a4", "sessionId": SID,
+             "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_a4_0", "content": "1 file changed"}]}},
+        ]
+        # sent at t0+55, taken at the t0+125 boundary (tr3, its file-order predecessor): 70 s later, so the landed
+        # bubble's hover names the send time
+        cls.landing = {"type": "attachment", "timestamp": iso(t0 + 55), "uuid": "att1", "parentUuid": "tr3", "isSidechain": False,
+                       "sessionId": SID, "attachment": {"type": "queued_command", "prompt": TEXT}}
+        cls.port = _free_port()
+        cls.token = "testtok-queuedheld"
+        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
+                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
+        for k in ("ROMP_STATE_DIR", "ROMP_API_KEY_CMD", "ANTHROPIC_API_KEY"):
+            env.pop(k, None)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+
+
+    def test_a_taken_but_unlanded_copy_keeps_its_slot_so_the_reader_never_moves(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        step = {"type": "assistant", "timestamp": iso(self.t0 + 60), "uuid": "a3", "parentUuid": "tr1", "sessionId": SID,
+                "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "end_turn",
+                            "content": [{"type": "text", "text": "Removed the import."}]}}
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "transcript": self.transcript,
+                       "sid": SID, "step": step, "mail": MAIL}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(self.klog).read()[-1500:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        print("T262I:", json.dumps({k: r[k] for k in ("start", "idPath", "textPath", "offStart", "off", "baseType", "baseEvents")}), json.dumps(r["rows"][-20:]))
+        idp, txt, off = r["idPath"], r["textPath"], r["off"]
+        self.assertEqual(r["start"]["dist"], 0, "a bottom reader to begin with: %r" % r["start"])
+        # the identified copy: the card, then the queue without it, then the landing — the reader never moves
+        self.assertEqual(idp["card"]["queuedCards"], 1, "the mail card is queued at the tail: %r" % idp["card"])
+        for k in ("card", "taken", "taken2", "landed"):
+            self.assertEqual(idp[k]["dist"], 0, "at the bottom after the %s frame: %r" % (k, idp[k]))
+            self.assertFalse(idp[k]["chip"], "the jump chip never shows (%s): %r" % (k, idp[k]))
+        # the user's symptom: the tail shrinking under a bottom reader moves them UP (a clamp the page never wrote)
+        self.assertGreaterEqual(idp["taken"]["top"], idp["card"]["top"], "the tail never shrinks under the reader between the queue frame and the landing: %r → %r" % (idp["card"], idp["taken"]))
+        self.assertGreaterEqual(idp["taken"]["sh"], idp["card"]["sh"], "the transcript never loses the card's height while it is in flight: %r → %r" % (idp["card"], idp["taken"]))
+        self.assertEqual(idp["taken"]["queuedCards"] + idp["taken"]["landedMail"], 1,
+                         "between the queue frame and the transcript frame the card's slot is continuous: %r" % idp["taken"])
+        self.assertEqual(idp["taken"]["landing"], 1, "…the held card is marked landing: %r" % idp["taken"])
+        self.assertEqual(idp["landed"]["landedMail"], 1, "the landed atom took the slot: %r" % idp["landed"])
+        self.assertEqual(idp["landed"]["queuedCards"], 0, "…and the held copy is gone with it: %r" % idp["landed"])
+        self.assertEqual(idp["landed"]["gestures"], 0, "no unwritten move through the identified sequence: %r" % r["rows"][-12:])
+        self.assertEqual(idp["landed"]["shrinks"], 0, "no tail-shrink correction: nothing shrank under the reader: %r" % r["rows"][-12:])
+        # the id-less copy: held by text for one push, then dropped at the next queue frame (never a phantom)
+        self.assertEqual((txt["taken"]["queuedCards"], txt["taken"]["landing"]), (1, 1), "an id-less copy is held for the push it vanished on: %r" % txt["taken"])
+        self.assertGreaterEqual(txt["taken"]["top"], txt["card"]["top"], "an id-less copy in flight holds the tail too: %r → %r" % (txt["card"], txt["taken"]))
+        self.assertEqual(txt["taken2"]["queuedCards"], 0, "…and dropped at the next push that carries the queue: %r" % txt["taken2"])
+        self.assertEqual(txt["landed"]["landedMail"], 2, "its landing arrives on its own: %r" % txt["landed"])
+        self.assertEqual(txt["landed"]["gestures"], idp["landed"]["gestures"], "no unwritten move through the id-less sequence: %r" % r["rows"][-12:])
+        # an off-bottom reader: nothing moves at all
+        for k in ("card", "taken", "taken2", "landed"):
+            self.assertEqual(off[k]["top"], r["offStart"]["top"], "an off-bottom reader is never moved (%s): %r vs %r" % (k, off[k], r["offStart"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/at-bottom.test.ts
+++ b/ui/webview/at-bottom.test.ts
@@ -84,9 +84,10 @@ test("follow mode and the chip read atBottom at every site", () => {
     /\(!atBottom\(content\) \? captureScrollAnchor\(content, v\) : null\)\) : null;/,                       // showActive's keep
     /content\.clientHeight > 0 && !atBottom\(content\)\) \{\s*\n\s*writeScroll\(content, content\.scrollTop \+ \(h - lastH\), "box-resize"\);/,   // box-resize compensation
     /stick = !!content && atBottom\(content\);/,                                                          // tab-strip drag
+    /const wasAtBottom = !!contentX && contentX\.scrollHeight > contentX\.clientHeight \+ 2 && atBottom\(contentX\);/,   // the ✕ on a pending bubble (T262h)
   ];
   for (const re of follow) assert.match(RENDER, re, String(re));
-  assert.equal((RENDER.match(/\batBottom\(/g) || []).length, 10, "nine call sites plus the definition");
+  assert.equal((RENDER.match(/\batBottom\(/g) || []).length, 11, "ten call sites plus the definition");
 });
 
 test("only the user's own send reveal keeps the 80 px band", () => {

--- a/ui/webview/chat-delta-resync.test.ts
+++ b/ui/webview/chat-delta-resync.test.ts
@@ -21,7 +21,7 @@ test("a delta gap asks the kernel for a full session instead of freezing", () =>
   // coordinate space, and counting it masked a genuine 1-event gap (the user 2026-08-09)
   assert.match(RENDER, /if \(from > kernelLen\) \{/,
     "chatTail must treat a too-far-ahead delta as its own case, not fold it into the silent return");
-  assert.match(RENDER, /const kernelLen = s\.events\.reduce\(\(n, e\) => n \+ \(isOptimistic\(e\) \? 0 : 1\), 0\);/,
+  assert.match(RENDER, /const kernelLen = s\.events\.reduce\(\(n, e\) => n \+ \(isOptimistic\(e\) \|\| isHeldGroup\(e\) \? 0 : 1\), 0\);/,
     "…in kernel coordinates: our injections are counted out (since T252 a bubble sits at its send slot, mid-array) — and only counted here, the strip happens once the delta is applied");
   assert.match(RENDER, /requestFullSession\(msg\.id\);/, "…and request a re-base");
   assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "needFull", id \}\)/,

--- a/ui/webview/chat-exact-tail-exec.test.ts
+++ b/ui/webview/chat-exact-tail-exec.test.ts
@@ -40,6 +40,8 @@ function liftChatTail(): (hooks: TailHooks) => TailApi {
     const isOptimistic = (e) => !!e.opt;
     const stripOptimistic = (s) => { s.events = s.events.filter((e) => !e.opt); H.strips++; };
     const reconcileRewind = (s, bound) => { H.rewinds.push([s.id, bound]); };
+    const isHeldGroup = (e) => !!e.held;                 // a group the client made for held kernel copies (T262i): not kernel coordinates
+    const reconcileHeldCopies = () => {};                // the held-copy pass runs between the rewind and the pending sends (T262i)
     const reconcileOptimistic = () => { H.optRecs++; };
     const awaitKey = (st) => JSON.stringify((st && st.awaitingWhy) || "");
     const scheduleRenderTabs = () => { H.tabRenders++; };

--- a/ui/webview/optimistic-send.test.ts
+++ b/ui/webview/optimistic-send.test.ts
@@ -175,7 +175,7 @@ test("EVERY ✕ stops our re-injection first; the optimistic one cancels by body
 test("chatTail speaks the KERNEL's coordinates — the injected tail is not part of its space", () => {
   // counting the injected bubble in the gap check masked a genuine 1-event desync (the repair never
   // fired) and let a delta land PAST the bubble, freezing it into resident events as fake history
-  assert.match(RENDER, /const kernelLen = s\.events\.reduce\(\(n, e\) => n \+ \(isOptimistic\(e\) \? 0 : 1\), 0\);/);
+  assert.match(RENDER, /const kernelLen = s\.events\.reduce\(\(n, e\) => n \+ \(isOptimistic\(e\) \|\| isHeldGroup\(e\) \? 0 : 1\), 0\);/);
   assert.match(RENDER, /if \(from > kernelLen\) \{/);
 });
 
@@ -210,10 +210,13 @@ test("reconcile: inject on nothing, suppress on kernel provisionals, retire only
   assert.equal(r.keep.length, 1);
   assert.equal(r.inject.length, 1, "ours stays drawn at its slot (T252)…");
   assert.equal(r.unqueue.length, 1, "…and the kernel's copy is the one hidden: one bubble per message");
-  // …same for the kernel's unlanded echo atom (uuid keeps the backend's echo: prefix)
+  // the kernel's unlanded echo atom (uuid keeps the backend's echo: prefix) proves receipt but does not replace ours
+  // (T262h): the echo sits at its send time, above the steps that ran since, so swapping ours out for it shrank the
+  // tail under a bottom reader; ours stays, the echo is hidden
   r = reconcile([{ kind: "user", md: "continue", uuid: "echo:abc123" }], p);
   assert.equal(r.keep.length, 1);
-  assert.equal(r.inject.length, 0);
+  assert.equal(r.inject.length, 1, "ours stays drawn");
+  assert.deepEqual(r.echoHide, [0], "…and the caller hides the kernel's echo");
   // DEFECT B (the flash-out): the provisional blinks away in the echo→landed handoff — the entry
   // survived the suppression, so ours steps straight back in and the message never disappears
   r = reconcile([{ kind: "assistant", md: "…" }], p);
@@ -246,7 +249,7 @@ test("the landing SWAP repaints even when it replaces the echo 1:1 — no linger
   assert.match(RENDER, /const echoShownSig = new Map<string, string>\(\);/);
   assert.match(RENDER, /if \(\(echoShownSig\.get\(s\.id\) \|\| ""\) !== sig\) \{/);
   assert.match(RENDER, /if \(sig\) echoShownSig\.set\(s\.id, sig\); else echoShownSig\.delete\(s\.id\);/);
-  const fn = RENDER.split("function reconcileOptimistic(")[1].split("\nfunction ")[0];
+  const fn = RENDER.split("function reconcileOptimisticInner(")[1].split("\nfunction ")[0];   // the guarded body (T262h)
   const settles = (fn.match(/settle\(/g) || []).length;
   assert.ok(settles >= 3, "every exit settles the signature (early returns included), got " + settles);
 });

--- a/ui/webview/queued-held.test.ts
+++ b/ui/webview/queued-held.test.ts
@@ -1,0 +1,79 @@
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { reconcileHeld, heldAsQueued, landsCopy, type HeldCopy, type HeldEvent, type HeldQueued } from "./queued-held";
+
+// T262i: a kernel queued copy that left the queue frame before its landed record arrived is HELD in place, marked
+// landing, until the atom carrying its id arrives; an id-less copy is held by text for one push; never a phantom.
+
+const mail = "[romp mail from api] the fixtures batch is labeled";
+const base: HeldEvent[] = [{ kind: "user", uuid: "u1", md: "tighten the search" }, { kind: "assistant", uuid: "a1", md: "…" }];
+
+test("an identified copy that vanished from the queue is held until the atom with its id lands, then released", () => {
+  const prev: HeldQueued[] = [{ md: mail, qid: "echo:m1", qts: 5, romp: true }];
+  // push 1: the queue no longer lists it, nothing landed → held, anchored on the last kernel event
+  let r = reconcileHeld(prev, [], base, []);
+  assert.deepEqual(r.held.map((h) => [h.qid, h.since, h.pushes]), [["echo:m1", "a1", 0]]);
+  assert.deepEqual(heldAsQueued(r.held[0]), { md: mail, qid: "echo:m1", qts: 5, romp: true, rompSystem: undefined, rompAuto: undefined, followUp: undefined, goal: undefined, fuCtx: undefined, imgPaths: undefined, landing: true });
+  // push 2: still nothing → still held (an identified copy waits for its atom)
+  r = reconcileHeld(r.prev, r.held, base, []);
+  assert.deepEqual(r.held.map((h) => [h.qid, h.pushes]), [["echo:m1", 1]]);
+  // push 3: the atom with its id lands → released (the atom takes the slot)
+  r = reconcileHeld(r.prev, r.held, [...base, { kind: "user", uuid: "am1", md: mail, qid: "echo:m1" }], []);
+  assert.deepEqual(r.held, []);
+  // a record of several sends carrying the id among its qids releases it too
+  let r2 = reconcileHeld(prev, [], base, []);
+  r2 = reconcileHeld(r2.prev, r2.held, [...base, { kind: "user", uuid: "am9", md: "x y", blocks: [mail, "y"], qids: ["echo:m1", "q9"] }], []);
+  assert.deepEqual(r2.held, []);
+});
+
+test("a held identified copy is dropped once a LATER landing shows the CLI passed it, or once the queue lists it again", () => {
+  const prev: HeldQueued[] = [{ md: mail, qid: "echo:m1" }];
+  let r = reconcileHeld(prev, [], base, []);
+  // another message landed after the anchor without this copy's id: first-in-first-out says this copy is not coming
+  r = reconcileHeld(r.prev, r.held, [...base, { kind: "user", uuid: "u2", md: "something else" }], []);
+  assert.deepEqual(r.held, [], "a later landing drops the hold");
+  // the kernel's echo or an undelivered verdict is not a landing
+  let r2 = reconcileHeld(prev, [], base, []);
+  r2 = reconcileHeld(r2.prev, r2.held, [...base, { kind: "user", uuid: "echo:x", md: "something else" }, { kind: "user", uuid: "u3", md: "lost", undelivered: true }], []);
+  assert.deepEqual(r2.held.map((h) => h.qid), ["echo:m1"], "an echo or a verdict is not a later landing");
+  // the copy is listed again (the queue frame shows it): nothing to hold
+  let r3 = reconcileHeld(prev, [], base, []);
+  r3 = reconcileHeld(r3.prev, r3.held, base, [{ md: mail, qid: "echo:m1" }]);
+  assert.deepEqual(r3.held, []);
+  assert.deepEqual(r3.prev.map((p) => p.qid), ["echo:m1"], "…and it is the previous frame's copy again");
+  // the anchor left the resident window: the same reading as a later landing (never a phantom)
+  let r4 = reconcileHeld(prev, [], base, []);
+  r4 = reconcileHeld(r4.prev, r4.held, [{ kind: "assistant", uuid: "a7", md: "…" }], []);
+  assert.deepEqual(r4.held, []);
+});
+
+test("an id-less copy is held by text for the push it vanished on and dropped at the next, unless its text lands first", () => {
+  const prev: HeldQueued[] = [{ md: mail }];
+  let r = reconcileHeld(prev, [], base, []);
+  assert.deepEqual(r.held.map((h) => [h.qid, h.pushes]), [[undefined, 0]]);
+  const held1 = r.held;
+  r = reconcileHeld(r.prev, held1, base, []);
+  assert.deepEqual(r.held, [], "dropped at the next push that carries the queue");
+  // …but a landing of the text on that next push claims it (released, not dropped: the atom is there)
+  let r2 = reconcileHeld(prev, [], base, []);
+  r2 = reconcileHeld(r2.prev, r2.held, [...base, { kind: "user", uuid: "am2", md: mail }], []);
+  assert.deepEqual(r2.held, []);
+  // a same-text copy still queued: not vanished, nothing held
+  assert.deepEqual(reconcileHeld(prev, [], base, [{ md: mail }]).held, []);
+  // an OLDER record of the same text (before the anchor) is history, not this copy's landing: still held
+  const older: HeldEvent[] = [{ kind: "user", uuid: "am0", md: mail }, ...base];
+  let r3 = reconcileHeld(prev, [], older, []);
+  assert.deepEqual(r3.held.map((h) => [h.qid, h.since]), [[undefined, "a1"]], "held: the same-text record predates the vanish");
+  r3 = reconcileHeld(r3.prev, r3.held, [...older, { kind: "user", uuid: "am1", md: mail }], []);
+  assert.deepEqual(r3.held, [], "…and the record after the anchor claims it");
+});
+
+test("our own bubble and hidden copies never become held copies; a landing is a real record only", () => {
+  const prev: HeldQueued[] = [{ md: "mine", optimistic: true }, { md: "hidden", qid: "h1", hiddenByPending: true }, { md: mail, qid: "echo:m1" }];
+  const r = reconcileHeld(prev, [], base, []);
+  assert.deepEqual(r.held.map((h) => h.qid), ["echo:m1"]);
+  assert.equal(landsCopy({ kind: "user", uuid: "echo:m1", md: mail }, { md: mail, qid: "echo:m1" }), false, "the kernel's echo is not a landing");
+  assert.equal(landsCopy({ kind: "user", uuid: "optimistic:1", md: mail }, { md: mail }), false, "our bubble is not a landing");
+  assert.equal(landsCopy({ kind: "user", uuid: "u9", md: mail }, { md: mail, qid: "echo:m1" }), false, "an id-bearing copy needs its id, not its text");
+  assert.equal(landsCopy({ kind: "user", uuid: "u9", md: mail }, { md: mail }), true);
+});

--- a/ui/webview/queued-held.ts
+++ b/ui/webview/queued-held.ts
@@ -1,0 +1,95 @@
+// A kernel queued copy that LEFT the queue frame before its landed record arrived (T262i, the user 2026-09-08):
+// the CLI takes a copy off the queue (a romp mail card, a nudge, a follow-up — the T243 gray card in the tail
+// group) and later writes its record, and the two facts reach the pane in different pushes — the kernel's queue
+// state first, the transcript read later. Between them the tail is SHORTER by the card, the browser clamps a
+// reader within that height of the bottom, and the landed card then grows the tail back below them: a card above
+// the bottom, follow mode off, the jump chip shown. So a vanished copy is HELD in place, marked landing, until the
+// atom that carries its identity arrives (T252c: the queued copy's `qid` is the landed atom's `qid`, or one of its
+// `qids`), and the atom then takes the copy's slot in the same frame. A copy with no id (an older kernel, the tmux
+// route, a copy the backend queued itself) is held by TEXT for the one push it vanished on, and dropped at the
+// next push that carries the queue if nothing claimed it — never a phantom. A held identified copy is dropped the
+// moment a LATER landing shows the CLI has passed it (the queue is first-in-first-out: had the copy landed, its
+// record would precede that one), or when the kernel lists it queued again (it came back; nothing to hold).
+// Pure and DOM-free so node --test executes it; render.ts owns the per-session memory and the splice.
+
+export type HeldCopy = {
+  md: string;
+  qid?: string;
+  qts?: number;
+  romp?: boolean;
+  rompSystem?: boolean;
+  rompAuto?: boolean;
+  followUp?: boolean;
+  goal?: string;
+  fuCtx?: string;
+  imgPaths?: string[];
+  since: string | null;   // the uuid of the last kernel event on the push the copy vanished: a landing AFTER it that is
+                          //   not this copy's is a later landing (the CLI passed this copy: drop the hold)
+  pushes: number;         // pushes the copy has been held for (an id-less copy is dropped past the first)
+};
+
+export type HeldEvent = { kind: string; uuid?: string; md?: string; qid?: string; qids?: (string | null)[]; blocks?: string[]; undelivered?: boolean };
+export type HeldQueued = { md?: string; qid?: string; qts?: number; hiddenByPending?: boolean; optimistic?: boolean; landing?: boolean; romp?: boolean; rompSystem?: boolean; rompAuto?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; imgPaths?: string[] };
+
+const sameText = (a: string, b: string): boolean => a.trim() === b.trim();
+const isEcho = (u?: string): boolean => !!u && u.startsWith("echo:");
+const isOptimistic = (u?: string): boolean => !!u && u.startsWith("optimistic:");
+
+/** Whether a landed user event (a real record, never the kernel's echo nor our own bubble) carries this copy — by
+ *  identity when the copy has one, by text otherwise (its md, or one of its blocks). */
+export function landsCopy(e: HeldEvent, c: { md: string; qid?: string }): boolean {
+  if (e.kind !== "user" || isEcho(e.uuid) || isOptimistic(e.uuid)) return false;
+  if (c.qid) return e.qid === c.qid || (Array.isArray(e.qids) && e.qids.includes(c.qid));
+  if (typeof e.md === "string" && sameText(e.md, c.md)) return true;
+  return Array.isArray(e.blocks) && e.blocks.some((b) => typeof b === "string" && sameText(b, c.md));
+}
+
+/** Index of the last KERNEL event (not our own bubble), or -1. */
+function lastKernelIdx(events: HeldEvent[]): number {
+  for (let i = events.length - 1; i >= 0; i--) if (!isOptimistic(events[i].uuid) && events[i].kind !== "queued") return i;
+  return -1;
+}
+
+/** One push's decision. `prev` = the kernel's queued copies on the previous push (its tail group, our own bubble
+ *  and hidden copies excluded); `held` = the copies held so far; `events` = this push's KERNEL events (our
+ *  injections stripped); `cur` = this push's queued copies. Returns the copies to keep holding — each rendered
+ *  in the tail group marked `landing` — and the previous-copies memory for the next push. */
+export function reconcileHeld(prev: HeldQueued[], held: HeldCopy[], events: HeldEvent[], cur: HeldQueued[]): { held: HeldCopy[]; prev: HeldQueued[] } {
+  const kernelCopies = cur.filter((t) => typeof t.md === "string" && !t.optimistic && !t.landing);
+  const listed = (c: { md: string; qid?: string }): boolean =>
+    kernelCopies.some((t) => c.qid ? t.qid === c.qid : (!t.qid && sameText(t.md as string, c.md)));
+  const out: HeldCopy[] = [];
+  const consider = (c: HeldCopy) => {
+    if (listed(c)) return;                                              // queued again: nothing to hold
+    // only a landing AFTER the anchor (the last kernel event when the copy vanished) is the copy's — the way the
+    // pending path reads landings after the send: an older same-text record is history, not this copy (matters for
+    // the id-less text fallback; an id is unique wherever it sits)
+    const from = c.since === null ? -1 : events.findIndex((e) => e.uuid === c.since);
+    const after = c.since === null || from < 0 ? events : events.slice(from + 1);
+    if (after.some((e) => landsCopy(e, c))) return;                     // its atom is here: it takes the slot
+    if (!c.qid && c.pushes >= 1) return;                                // id-less: one push by text, then never a phantom
+    if (c.qid && c.since !== null) {                                    // a later landing means the CLI passed it
+      const later = after.some((e) => e.kind === "user" && !isEcho(e.uuid) && !isOptimistic(e.uuid) && !e.undelivered);
+      if (from < 0 || later) return;                                    // (its anchor left the window: the same reading)
+    }
+    out.push(c);
+  };
+  for (const h of held) consider({ ...h, pushes: h.pushes + 1 });
+  const anchor = events[lastKernelIdx(events)]?.uuid ?? null;
+  for (const p of prev) {
+    if (typeof p.md !== "string" || p.optimistic || p.landing || p.hiddenByPending) continue;
+    const pmd: string = p.md;
+    if (held.some((h) => h.qid ? h.qid === p.qid : (!p.qid && sameText(h.md, pmd)))) continue;   // already held
+    if (listed({ md: pmd, qid: p.qid })) continue;
+    consider({ md: pmd, qid: p.qid, qts: p.qts, romp: p.romp, rompSystem: p.rompSystem, rompAuto: p.rompAuto,
+               followUp: p.followUp, goal: p.goal, fuCtx: p.fuCtx, imgPaths: p.imgPaths, since: anchor, pushes: 0 });
+  }
+  return { held: out, prev: kernelCopies.map((t) => ({ ...t })) };
+}
+
+/** The queued copies a held copy renders as: the same card, marked `landing`, never cancelable (the kernel no
+ *  longer holds it — a ✕ would ask it to cancel a message it has already taken). */
+export function heldAsQueued(h: HeldCopy): HeldQueued {
+  const { since, pushes, ...copy } = h;
+  return { ...copy, landing: true };
+}

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -13,11 +13,11 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("a queued ChatEvent carries the pending messages (backend-agnostic, per-message md)", () => {
   // idx = backend-queue position (SDK); park = _pending_ops position (compaction/model parking, any backend)
   // `optimistic` (romp's own unconfirmed echo) rides along at the end — see optimistic-send.test.ts
-  assert.match(RENDER, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number; qid\?: string; hiddenByPending\?: boolean \}\[\]/);   // imgPaths: the echo's dragged-image thumbnails (2026-08-25); romp flags: T243; lost + qts: the pending entry's connection-drop state and its identity for the ✕ (2026-09-06)
+  assert.match(RENDER, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number; qid\?: string; hiddenByPending\?: boolean; landing\?: boolean \}\[\]/);   // imgPaths: the echo's dragged-image thumbnails (2026-08-25); romp flags: T243; lost + qts: the pending entry's connection-drop state and its identity for the ✕ (2026-09-06)
 });
 
 test("renderQueued draws a wireframe-hourglass header (singular/plural) + one markdown bubble per queued message", () => {
-  assert.match(RENDER, /ev\.kind === "queued"\) return renderQueued\(ev\)/);
+  assert.match(RENDER, /ev\.kind === "queued"\) return isOptimistic\(ev\) && ev\.bare \? renderPendingGroup\(ev\) : renderQueued\(ev\)/);   // OUR pending group keeps its node (T262h)
   assert.match(RENDER, /el\("div", "turn turn-queued"\)/);
   // header: a stroked accent-blue hourglass ICON (no ⌛ emoji) + "N queued message(s)" — pluralizes on count
   assert.doesNotMatch(RENDER, /⌛/, "no hourglass emoji — it clashes with the app's line-icon style");
@@ -247,7 +247,7 @@ test("the kernel flags a romp-injected queued entry from the same markers as a l
 });
 
 test("what romp itself queued wears the LANDED romp grammar, split as landed: notice card vs gray romp bubble (T243)", () => {
-  assert.match(RENDER, /romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number; qid\?: string; hiddenByPending\?: boolean \}\[\]/, "the queued text shape carries the flags");
+  assert.match(RENDER, /romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number; qid\?: string; hiddenByPending\?: boolean; landing\?: boolean \}\[\]/, "the queued text shape carries the flags");
   const body = RENDER.split("function renderQueued(")[1].split("\nfunction ")[0];
   assert.match(body, /const bubble = el\("div", "queued-bubble md" \+ \(t\.cancelable \? " cancelable" : ""\)\s*\n\s*\+ \(t\.romp \? " queued-romp" : ""\) \+ \(t\.rompSystem \? " queued-sys" : ""\)\);/);
   // a SYSTEM notice → the landed card's own builder, nested; a one-line notice gets no body repeating its head

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -39,6 +39,7 @@ import { DEFAULT_CHORDS } from "./commands";
 import { NavHistory } from "./nav-history";
 import { StagedStack } from "./staged-messages";
 import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, newPending, reconcilePending, queuedCopyToHide, dropPending, bareGroupLabel, sentAtLabel } from "./send-pending";
+import { reconcileHeld, heldAsQueued, type HeldCopy, type HeldQueued } from "./queued-held";
 import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional, focusResolvesProvisional } from "./provisional";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
@@ -104,7 +105,7 @@ type TaskOutputs = Record<string, { command: string; output: string }>;
 type ChatEvent = (
   // mid/mids: postal message ids the kernel could NOT resolve into cards, carried on the raw turn so a
   // timeline arc into it still lands (see _hydrate_postal's unresolved path)
-  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; canned?: string; tag?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[]; undelivered?: boolean; echoT?: number; absorbed?: boolean; sentAt?: number; spacePaths?: string[]; pathLinks?: Record<string, string>; pathPins?: Record<string, string> }
+  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; canned?: string; tag?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[]; undelivered?: boolean; echoT?: number; absorbed?: boolean; sentAt?: number; hiddenByPending?: boolean; spacePaths?: string[]; pathLinks?: Record<string, string>; pathPins?: Record<string, string> }
   | { kind: "assistant"; md: string; uuid?: string; ts?: string; spacePaths?: string[]; pathLinks?: Record<string, string>; pathPins?: Record<string, string> }   // spacePaths: backticked filenames WITH spaces the kernel verified exist (build_session _space_paths) → whole-span links. pathLinks: path-shaped tokens the kernel verified against the filesystem, token → real open target (build_session _path_links) — the linkifier's gate
   | { kind: "thinking"; text: string; encrypted: boolean; uuid?: string; ts?: string }
   | {
@@ -182,7 +183,7 @@ type ChatEvent = (
   // `held` DOES come from the kernel (_limit_hold): the queue is stuck on the ACCOUNT rather than on this
   // session — a usage limit or a monthly spend cap holds every send — so the head names what it is waiting
   // for, and how long is left when the API reported a reset (the user 2026-07-24).
-  | { kind: "queued"; texts: { md: string; followUp?: boolean; goal?: string; fuCtx?: string; idx?: number; park?: number; cancelable?: boolean; optimistic?: boolean; romp?: boolean; rompSystem?: boolean; rompAuto?: boolean; imgPaths?: string[]; lost?: string; qts?: number; qid?: string; hiddenByPending?: boolean }[]; ts?: string; uuid?: string; bare?: boolean; held?: { reason: string; resetsAt?: number | null; what: string; detail?: string } }   // imgPaths: an optimistic echo's dragged-image attachments → thumbnails, the landed form's own renderer (the user 2026-08-25); lost: client-only, the connection dropped after this unconfirmed send; qts: on OUR optimistic copy the pending entry's identity (its press time) so the ✕ removes ITS entry, on a kernel copy its enqueue stamp (T252c); qid: a kernel copy's identity, the ✕ drops the send that owns it (send-pending.ts)
+  | { kind: "queued"; texts: { md: string; followUp?: boolean; goal?: string; fuCtx?: string; idx?: number; park?: number; cancelable?: boolean; optimistic?: boolean; romp?: boolean; rompSystem?: boolean; rompAuto?: boolean; imgPaths?: string[]; lost?: string; qts?: number; qid?: string; hiddenByPending?: boolean; landing?: boolean }[]; ts?: string; uuid?: string; bare?: boolean; held?: { reason: string; resetsAt?: number | null; what: string; detail?: string } }   // imgPaths: an optimistic echo's dragged-image attachments → thumbnails, the landed form's own renderer (the user 2026-08-25); lost: client-only, the connection dropped after this unconfirmed send; qts: on OUR optimistic copy the pending entry's identity (its press time) so the ✕ removes ITS entry, on a kernel copy its enqueue stamp (T252c); qid: a kernel copy's identity, the ✕ drops the send that owns it (send-pending.ts)
   // The turn stopped on an API error (event-based: transcript isApiErrorMessage). The session is BLOCKED
   // until retried — a red-dot card at the bottom with a Retry button (the user 2026-06-16).
   | { kind: "apiError"; text: string; status?: number; ts?: string; uuid?: string }
@@ -357,6 +358,19 @@ function tailQueuedIdx(evs: ChatEvent[]): number {
 const echoShownSig = new Map<string, string>();
 
 function reconcileOptimistic(s: Session): void {
+  // The strip and the re-inject are ONE step: an exception between them would leave the events without our
+  // bubble until the next push, and the frame painted meanwhile would let the browser clamp a bottom reader by
+  // the bubble's height (T262h). So the group as it was is put back on any failure, and the failure is filed.
+  const prevGroup = s.events.filter((e) => isOptimistic(e));
+  try {
+    reconcileOptimisticInner(s);
+  } catch (err) {
+    if (!s.events.some((e) => isOptimistic(e))) s.events.push(...prevGroup);
+    vscodeApi?.postMessage({ type: "clientDiag", surface: "chat", what: "reconcile-optimistic-failed",
+                             data: { sid: s.id, error: String(err && (err as any).message || err).slice(0, 200) } });
+  }
+}
+function reconcileOptimisticInner(s: Session): void {
   const settle = (after: string[]) => {
     const sig = after.join("\u0000");
     if ((echoShownSig.get(s.id) || "") !== sig) {
@@ -365,7 +379,7 @@ function reconcileOptimistic(s: Session): void {
       if (v) v.stale = true;
     }
   };
-  stripOptimistic(s);   // kernel truth only below: our bubbles and our hide marks are re-derived from it
+  stripOptimistic(s, true);   // kernel truth (plus the held copies, T262i) below: our bubbles and our hide marks are re-derived from it
   const list = pendingSent.get(s.id);
   if (!list || !list.length) { settle([]); return; }
   // The decision reads KERNEL truth only (our injections are stripped above) — send-pending.ts: a
@@ -386,6 +400,9 @@ function reconcileOptimistic(s: Session): void {
     const hid = hideQueuedCopy(s, p);
     if (hid === null) covered.add(p); else if (hid.held) heldBy.set(p, hid.held);
   }
+  // the kernel's ECHO of a pending send is hidden the way its queued copy is (T262h): ours is the one bubble,
+  // at the tail, on the same node until the landing takes its place
+  for (const i of r.echoHide) { const e = s.events[i]; if (e && e.kind === "user" && !e.hiddenByPending) s.events[i] = { ...e, hiddenByPending: true }; }
   const inject = r.inject.filter((p) => !covered.has(p));
   if (!inject.length) { settle([]); return; }
   // cancelable from the PRESS (the user 2026-08-30, who sent mid-compaction and sat in an unlabeled,
@@ -411,12 +428,47 @@ function reconcileOptimistic(s: Session): void {
 // their send slots mid-array, and the strip stays position-agnostic), the optimistic texts we once merged
 // into a kernel group, and the hide marks on the kernel's queued copies — so every reader below sees KERNEL
 // truth only. Every ingest path that applies a kernel INDEX (chatTail's `from`) strips first.
-function stripOptimistic(s: Session): void {
+// `keepHeld`: the pending-send reconcile strips only ITS OWN marks (our bubbles, the hidden copies and echoes) and
+// leaves the held kernel copies (T262i) in place, which the ingest paths derive fresh from the kernel's frame first.
+function stripOptimistic(s: Session, keepHeld = false): void {
   for (let i = s.events.length - 1; i >= 0; i--) {
     const e = s.events[i];
     if (isOptimistic(e)) { s.events.splice(i, 1); continue; }
-    if (e.kind === "queued" && e.texts.some((t) => t.optimistic || t.hiddenByPending))
-      s.events[i] = { ...e, texts: e.texts.filter((t) => !t.optimistic).map((t) => t.hiddenByPending ? { ...t, hiddenByPending: undefined } : t) };
+    if (!keepHeld && isHeldGroup(e)) { s.events.splice(i, 1); continue; }   // a group we made for held copies alone
+    if (e.kind === "queued" && e.texts.some((t) => t.optimistic || t.hiddenByPending || (!keepHeld && t.landing))) {
+      const texts = e.texts.filter((t) => !t.optimistic && (keepHeld || !t.landing)).map((t) => t.hiddenByPending ? { ...t, hiddenByPending: undefined } : t);
+      s.events[i] = { ...e, texts };
+    }
+    if (e.kind === "user" && e.hiddenByPending) s.events[i] = { ...e, hiddenByPending: undefined };   // a hidden echo (T262h)
+  }
+}
+
+// ── held kernel copies (T262i, the user 2026-09-08) ──────────────────────────────────────────────────
+// A copy the kernel listed queued on the previous push and no longer lists, whose landed record is not in the
+// events yet, is HELD in the tail group — the same card, marked landing — so the tail never loses its height
+// between the queue frame and the transcript frame (the decisions: queued-held.ts). Per session: the previous
+// push's kernel copies and the copies held so far. Runs on every ingest path right after the strip, before the
+// pending sends are reconciled (a held copy of OUR text is then hidden for our bubble like any kernel copy).
+const HELD_PREFIX = "held:";
+const isHeldGroup = (e: ChatEvent): boolean => e.kind === "queued" && !!e.uuid && e.uuid.startsWith(HELD_PREFIX);
+const heldQueued = new Map<string, { prev: HeldQueued[]; held: HeldCopy[] }>();
+function reconcileHeldCopies(s: Session): void {
+  const mem = heldQueued.get(s.id) || { prev: [], held: [] };
+  const qi = tailQueuedIdx(s.events);
+  const cur = qi >= 0 ? ((s.events[qi] as Extract<ChatEvent, { kind: "queued" }>).texts as HeldQueued[]) : [];
+  const r = reconcileHeld(mem.prev, mem.held, s.events as any, cur);
+  heldQueued.set(s.id, r);
+  // the held set changed (a copy taken, a copy landed): the frame may keep its LENGTH while a held card gives way to
+  // the landed atom, and the repaint's no-op fast path reads length alone — so the view is marked stale here
+  const key = (h: HeldCopy[]) => h.map((c) => c.qid || c.md).join("\u0000");
+  if (key(mem.held) !== key(r.held)) { const v = views.get(s.id); if (v) v.stale = true; }
+  if (!r.held.length) return;
+  const add = r.held.map(heldAsQueued);
+  if (qi >= 0) {
+    const q = s.events[qi] as Extract<ChatEvent, { kind: "queued" }>;
+    s.events[qi] = { ...q, texts: [...q.texts, ...(add as any)] };
+  } else {
+    s.events.push({ kind: "queued", texts: add as any, uuid: HELD_PREFIX + s.id });   // the group the card sat in, kept for it
   }
 }
 
@@ -1820,6 +1872,9 @@ function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: 
 }
 
 function renderEvent(ev: ChatEvent, prevEpoch?: number | null, worked?: number | null): HTMLElement {
+  if (ev.kind === "user" && ev.hiddenByPending) {   // the kernel's echo of a send OUR bubble draws (T262h): the unit stays, invisible
+    const hid = el("div", "turn turn-user turn-echo-hidden"); hid.style.display = "none"; return hid;
+  }
   const turn = renderEventInner(ev);
   // pending-rewind overlay (reconcileRewind): this turn sits AFTER an edited message — it belongs to
   // the branch being abandoned, so it dims until the kernel's rewound payload replaces it
@@ -3057,7 +3112,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
   if (ev.kind === "postal-service") return renderPostalService(ev);
   if (ev.kind === "teammate") return renderTeammate(ev);
   if (ev.kind === "todo") return renderTodo(ev);
-  if (ev.kind === "queued") return renderQueued(ev);
+  if (ev.kind === "queued") return isOptimistic(ev) && ev.bare ? renderPendingGroup(ev) : renderQueued(ev);
   if (ev.kind === "apiError") return renderApiError(ev);
   if (ev.kind === "compacting") return renderCompacting();
   if (ev.kind === "clearing") return renderClearing();
@@ -3898,6 +3953,30 @@ function fillBareLabel(label: HTMLElement, nLost: number, nSending: number): voi
   label.title = title;
 }
 
+// OUR pending group keeps ONE DOM node for as long as it is pending (T262h, the user 2026-09-08): every kernel push
+// re-renders the tail window, and a group re-created from scratch left the DOM for the removal → re-add gap of
+// the repaint. The node is cached per session and reconciled IN PLACE — its children replaced from a fresh render
+// only when the group's content changed (a second send, a ✕, a "not confirmed" label, a held reason) — so the
+// element the scroll geometry rests on is the same element frame after frame; the caller re-appends it where the
+// group belongs (appendChild moves an attached node, one DOM operation, no frame without it).
+const pendingGroupNode = new Map<string, { sig: string; node: HTMLElement }>();
+function renderPendingGroup(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
+  const sid = renderingSid || activeId || "";
+  const sig = JSON.stringify(ev.texts.map((t) => [t.md, !!t.lost, t.qts, t.imgPaths || null])) + "|" + JSON.stringify(ev.held || null);
+  const fresh = renderQueued(ev);
+  const cached = pendingGroupNode.get(sid);
+  if (cached && cached.node.isConnected !== undefined) {
+    if (cached.sig !== sig) {
+      cached.node.className = fresh.className;
+      cached.node.replaceChildren(...Array.from(fresh.childNodes));
+      cached.sig = sig;
+    }
+    return cached.node;
+  }
+  pendingGroupNode.set(sid, { sig, node: fresh });
+  return fresh;
+}
+
 function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
   // a copy hidden for a send drawn at its own slot (T252 hideQueuedCopy) is not rendered here; a group left
   // with nothing visible renders as a zero-height unit (the unit still exists for the scroll↔unit map)
@@ -3974,6 +4053,7 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     // and is holding (the user 2026-07-16)
     if (t.optimistic && t.lost) bubble.title = "not confirmed — the connection dropped after this was sent; ✕ moves it back to the composer to send again";
     else if (t.optimistic) bubble.title = "sent just now — romp hasn't confirmed the session has it yet";
+    else if (t.landing) { bubble.classList.add("landing"); bubble.title = "the session has taken this — it joins the conversation as soon as its record lands"; }
     // a queued entry with NO ✕ (the user 2026-07-20): the queue lives inside the session's own CLI —
     // there is no recall — so instead of a cancel that would only ever say "too late", the tooltip says
     // where the message actually is. (SDK mid-turn forwards and every tmux queued message land here.)
@@ -13701,6 +13781,7 @@ function upsert(msg: any) {
   const tm = tabMeta.get(msg.id);
   if (tm) applyMetaToSession(s, tm, pendingTabMeta.get(msg.id));
   reconcileRewind(s);       // pending-rewind overlay + the editable-bubble set, from the fresh payload
+  reconcileHeldCopies(s);   // a queued copy the kernel no longer lists but has not landed keeps its slot (T262i)
   reconcileOptimistic(s);   // re-assert (or retire) any in-flight optimistic sends across the rebuild
   // The kernel re-sends the FULL "session" payload on every push. Distinguish an APPEND (more turns
   // on the SAME transcript — the common case) from a FORK (the tab re-pointed onto a NEW transcript,
@@ -13795,6 +13876,7 @@ function update(msg: any) {
   s.status = msg.status || s.status;
   if (msg.events) { const v0 = views.get(msg.id); if (v0) v0.stale = true; }   // events replaced wholesale: the window rebuilds (the tail path trusts v.rendered)
   reconcileRewind(s);                    // pending-rewind overlay + the editable-bubble set, from the fresh payload
+  reconcileHeldCopies(s);                // a queued copy the kernel no longer lists but has not landed keeps its slot (T262i)
   reconcileOptimistic(s);                // re-assert (or retire) any in-flight optimistic sends on this push
   renderTabs();                          // status/chip change only — repaint, never re-order (the user 2026-06-27)
   if (msg.id === activeId) {
@@ -13859,7 +13941,7 @@ function chatTail(msg: any) {
   // is not one of them), and the strip itself waits until the delta is going to be applied: stripping
   // ahead of the two early returns left s.events without the bubble while the DOM still showed it (review
   // of the first cut).
-  const kernelLen = s.events.reduce((n, e) => n + (isOptimistic(e) ? 0 : 1), 0);
+  const kernelLen = s.events.reduce((n, e) => n + (isOptimistic(e) || isHeldGroup(e) ? 0 : 1), 0);
   if (from > kernelLen) {
     // GAP: the delta starts PAST what we hold, so the events in between never reached us. Applying it would
     // fabricate a transcript that silently skips them. This used to just `return` and "wait for the next
@@ -13880,6 +13962,7 @@ function chatTail(msg: any) {
   s.events.length = from;                          // drop the (now superseded) tail...
   for (const e of (msg.events || [])) s.events.push(e);   // ...and append the freshly-changed suffix
   reconcileRewind(s, from);                        // pending-rewind overlay + the editable-bubble set, judged below the tail's start (see there)
+  reconcileHeldCopies(s);                          // a queued copy the kernel no longer lists but has not landed keeps its slot (T262i)
   reconcileOptimistic(s);                          // re-assert (or retire) any in-flight optimistic sends
   // A delta that SHRINKS the tail (an event retired with nothing replacing it — cancelling the last queued
   // message is the everyday case) lands on `from === new length`, so lowering v.rendered to `from` leaves it
@@ -15691,8 +15774,13 @@ setupSettings();
       // the bubble alone leaves its "1 queued message" header behind, still counting what just went.
       const bub = el.closest(".queued-bubble") as HTMLElement | null;
       const grp = bub?.closest(".turn-queued") as HTMLElement | null;
+      // a bubble leaving the tail shrinks it: a bottom reader is written to the new bottom in the same task, so the
+      // move is the pane's own (journaled), never a clamp the follow-mode latch never saw (T262h)
+      const contentX = document.getElementById("content");
+      const wasAtBottom = !!contentX && contentX.scrollHeight > contentX.clientHeight + 2 && atBottom(contentX);
       bub?.remove();
       if (grp) reflowQueuedGroup(grp);
+      if (contentX && wasAtBottom) writeScroll(contentX, contentX.scrollHeight, "queued-x", true);
     },
     // a comment highlight or its turn badge (the user 2026-08-13): open the thread's popover at the
     // click. Delegated — marks and badges are re-created on every transcript rebuild — and so is

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -66,7 +66,8 @@ test("it clears on the kernel's echo (suppressed) and ends on the landing (retir
   const list = press([{ kind: "assistant", md: "…", uuid: "a1" }], TEXT);
   let r = reconcilePending([{ kind: "assistant", md: "…", uuid: "a1" }, { kind: "user", md: TEXT, uuid: "echo:1" }], list);
   assert.equal(r.keep.length, 1, "the kernel's provisional never retires the entry");
-  assert.equal(r.inject.length, 0, "…but ours steps aside while it is visible");
+  assert.equal(r.inject.length, 1, "…and ours stays drawn: the echo is hidden for it, one bubble at the tail (T262h)");
+  assert.deepEqual(r.echoHide, [1], "the caller hides the kernel's echo");
   r = reconcilePending([
     { kind: "assistant", md: "…", uuid: "a1" },
     { kind: "user", md: TEXT, uuid: "att1", absorbed: true },
@@ -207,7 +208,7 @@ test("identity edges: a copy without an id beside an echo, a landing carrying se
   assert.equal(p.qid, undefined, "no id to latch");
   assert.deepEqual(r.unqueue, [p]);
   r = reconcilePending([...tail, { kind: "user", md: "go on", uuid: "echo:random" }], [p]);
-  assert.equal(r.inject.length, 0, "the echo covers by text");
+  assert.deepEqual([r.inject.length, r.echoHide], [1, [1]], "the echo is attributed by text: hidden, ours stays (T262h)");
   r = reconcilePending([...tail, { kind: "user", md: "go on", uuid: "uL" }], [p]);
   assert.deepEqual(r.landed.map((l) => l.idx), [1]);
   // a record the CLI wrote from two sends lands with one id per block: ours retires on its own block's id
@@ -242,19 +243,20 @@ test("the kernel's queued copy at the tail is hidden for a send drawn as our own
   assert.equal(list[0].received, true, "the kernel's copy proves receipt");
   assert.deepEqual(r.inject, [list[0]], "…but ours stays drawn, at the tail");
   assert.deepEqual(r.unqueue, [list[0]], "and the caller drops the kernel's tail copy for it");
-  // an ECHO atom covers ours as before: the kernel draws that atom itself, at the send time
+  // an ECHO atom proves receipt and is hidden in turn (T262h): ours is the one bubble, at the tail, until the landing
   const r2 = reconcilePending([...tail, { kind: "user", md: TEXT, uuid: "echo:1" }], press(tail, TEXT));
-  assert.equal(r2.inject.length, 0);
+  assert.equal(r2.inject.length, 1);
   assert.equal(r2.unqueue.length, 0);
+  assert.deepEqual(r2.echoHide, [1]);
 });
 
 test("render.ts appends the pending sends as ONE bare group at the tail, in send order; strips its own injections before applying kernel indices; carries no header or cue (T252d)", () => {
   assert.match(RENDER, /s\.events\.push\(\{ kind: "queued", bare: true, texts: inject\.map\(mk\), uuid: OPT_PREFIX \+ inject\[0\]\.ts/,
     "one bare group pushed at the tail, the sends in list (send) order");
   assert.doesNotMatch(RENDER, /injectionGroups|placementIndex/, "the send-slot placement machinery is gone from render.ts");
-  const fn = RENDER.split("function reconcileOptimistic(")[1].split("\nfunction ")[0];
+  const fn = RENDER.split("function reconcileOptimisticInner(")[1].split("\nfunction ")[0];   // the guarded body (T262h)
   assert.match(fn, /settle\(inject\.map\(\(p\) => p\.text\)\);/, "the repaint signature is the texts alone: the tail slot moves with every push by design");
-  assert.match(RENDER, /function stripOptimistic\(s: Session\): void \{/, "one strip, used by every ingest path");
+  assert.match(RENDER, /function stripOptimistic\(s: Session, keepHeld = false\): void \{/, "one strip, used by every ingest path (keepHeld: the pending reconcile leaves the held kernel copies in, T262i)");
   const tail = RENDER.slice(RENDER.indexOf("function chatTail(msg: any) {"), RENDER.indexOf("s.events.length = from;"));
   assert.match(tail, /stripOptimistic\(s\);/, "the delta's kernel index is applied to KERNEL events only — a mid-array bubble would shift it");
   // …but only once the delta is going to be applied: stripping before the gap/head early returns left s.events
@@ -262,7 +264,7 @@ test("render.ts appends the pending sends as ONE bare group at the tail, in send
   const afterReturns = tail.slice(tail.indexOf("if (from < 0) return;"));
   assert.match(afterReturns, /stripOptimistic\(s\);/, "the strip sits after both early returns");
   assert.doesNotMatch(tail.slice(0, tail.indexOf("if (from > kernelLen) {")), /stripOptimistic\(s\);/, "…and not before the gap check");
-  assert.match(tail, /const kernelLen = s\.events\.reduce\(\(n, e\) => n \+ \(isOptimistic\(e\) \? 0 : 1\), 0\);/, "the gap check counts kernel events without mutating");
+  assert.match(tail, /const kernelLen = s\.events\.reduce\(\(n, e\) => n \+ \(isOptimistic\(e\) \|\| isHeldGroup\(e\) \? 0 : 1\), 0\);/, "the gap check counts kernel events without mutating");
   for (const gone of ["absorbedHeader", "absorbedCues", "noteAbsorbedLanding", "renderAbsorbedCue", "appendAbsorbedCues", "dismissAbsorbedCue", "cueRendered", "abjump", "abdismiss", "absorbed-tag", "turn-absorbed-cue"])
     assert.ok(!RENDER.includes(gone), gone + " is gone from render.ts");
   for (const gone of [".absorbed-tag", ".turn-absorbed-cue", ".absorbed-cue-line", ".absorbed-cue-act"])
@@ -283,7 +285,7 @@ test("a resend of a never-delivered message is not retired by the old verdict �
   assert.equal(provisionalIn(tail[1], list[0]), false, "a never-delivered echo never suppresses");
   // the kernel's echo for the resend, then ITS verdict — that one ends the entry
   r = reconcilePending([...tail, { kind: "user", md: TEXT, uuid: "echo:new" }], list);
-  assert.equal(r.inject.length, 0);
+  assert.deepEqual([r.inject.length, r.echoHide], [1, [tail.length]], "ours stays, the echo is hidden (T262h)");
   r = reconcilePending([...tail, { kind: "user", md: TEXT, uuid: "echo:new", undelivered: true }], list);
   assert.equal(r.lost.length, 1);
   // a shorter send that the old never-delivered text merely contains is not its resend at all
@@ -393,7 +395,8 @@ test("two identical sends, one kernel echo: the first is received and covered; t
   const list = press(tail, "continue", "continue");
   let r = reconcilePending([...tail, { kind: "user", md: "continue", uuid: "echo:1" }], list);
   assert.deepEqual(list.map((p) => p.received), [true, undefined], "one echo is one send's receipt");
-  assert.deepEqual(r.inject, [list[1]], "the kernel's copy covers one bubble; ours shows for the other");
+  assert.deepEqual(r.inject, [list[0], list[1]], "both bubbles stay ours; the echo that proved the first's receipt is hidden (T262h)");
+  assert.deepEqual(r.echoHide, [1]);
   assert.deepEqual(list[1].at?.seen, ["echo:1"], "the claimed echo is background for the later send");
   // the drop (as render.ts markPendingLost writes it): only the unconfirmed send is marked
   for (const p of list) if (!p.lost && !p.received) p.lost = "connection";
@@ -504,7 +507,7 @@ test("a send pressed against no frame (a placeholder tab): the first frame's cop
   assert.equal(list[0].at?.after, "a1", "the anchor is the last stable event stamped BEFORE the press — not a2");
   assert.deepEqual(list[0].at?.seen, ["u-old"], "the old message is background; this send's echo is not");
   assert.equal(list[0].received, true);
-  assert.equal(r.inject.length, 0, "the kernel's echo covers our bubble: no double bubble");
+  assert.deepEqual([r.inject.length, r.echoHide], [1, [2]], "the kernel's echo is hidden for our bubble: no double bubble (T262h)");
   const landed: TailEvent[] = [frame[0], frame[1], { kind: "user", md: TEXT, uuid: "u1", ts: isoAt(S) }, frame[3]];
   r = reconcilePending(landed, list);
   assert.equal(r.keep.length, 0, "the echo→landed handoff retires it");
@@ -678,7 +681,7 @@ test("an id the frame no longer carries leaves the decision to text: a restart t
   assert.deepEqual([r.unqueue, r.inject], [[p], [p]], "one bubble, never ours beside the kernel's copy");
   // (2) an echo under a new uuid covers by text, and the first identity stays latched: nothing in the frame contradicts it
   r = reconcilePending([...tail, { kind: "user", md: "rename it", uuid: "echo:new" }], [p]);
-  assert.deepEqual([r.inject, r.keep], [[], [p]], "the echo covers");
+  assert.deepEqual([r.inject, r.keep, r.echoHide], [[p], [p], [1]], "the echo is attributed by text and hidden; ours stays");
   assert.equal(p.qid, "echo:old" + T0);
   // (3) that echo flagged never-delivered is the verdict, by text
   r = reconcilePending([...tail, { kind: "user", md: "rename it", uuid: "echo:new", undelivered: true }], [p]);
@@ -700,13 +703,14 @@ test("an id the frame still shows queued or echoed refuses a same-text landing t
   // the same with the second copy fed: its echo shows the id — and the first send, landed, does not go on to claim
   // that echo as its own cover on the way out
   r = reconcilePending([...tail, { kind: "user", md: "ok", uuid: "u1" }, { kind: "user", md: "ok", uuid: "echo:q2" }], [a, b]);
-  assert.deepEqual([r.landed.map((l) => l.p), r.keep, r.inject], [[a], [b], []]);
+  assert.deepEqual([r.landed.map((l) => l.p), r.keep, r.inject, r.echoHide], [[a], [b], [b], [2]]);
   // a send read by text (its id is nowhere in the frame) never takes an echo another send owns by id
   const [c, d] = press(tail, "go", "go");
   reconcilePending([...tail, { kind: "queued", texts: [{ md: "go", qid: "echo:c1", qts: 1 }, { md: "go", qid: "echo:d1", qts: 2 }] }], [c, d]);
   assert.deepEqual([c.qid, d.qid], ["echo:c1", "echo:d1"]);
   r = reconcilePending([...tail, { kind: "user", md: "go", uuid: "echo:d1" }], [c, d]);
-  assert.deepEqual([r.keep, r.inject], [[c, d], [c]], "the echo is the second send's cover; the first, unshown, is drawn by us");
+  assert.deepEqual([r.keep, r.inject, r.echoHide], [[c, d], [c, d], [1]], "the echo is the second send's, by id: hidden for it; both bubbles are ours, and the first never claimed it");
+  assert.deepEqual([c.received, d.received], [true, true], "both were received by their queued copies earlier; the echo added nothing to the first");
 });
 
 test("a send covered by its identified copy holds that copy's position: a later same-text send never latches the same id, nor takes the copy (T252c third review)", () => {

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -272,6 +272,10 @@ export function scanFrom(events: TailEvent[], at: SendBase): number {
 
 export type Reconciled = {
   keep: PendingSend[];                        // still pending after this push
+  echoHide: number[];                         // the kernel's ECHO atoms covering a kept send (T262h): the caller hides them and
+                                              //   draws ours — one bubble per message, OURS, at the tail, the same node until the
+                                              //   landing; an echo sits at its send time, above the steps that ran since, so
+                                              //   swapping ours for it shrank the tail under a bottom reader
   inject: PendingSend[];                      // …and drawn by us, at the tail: not covered by the kernel's echo atom (a
                                               //   queued copy does not cover — ours stays drawn and the copy is hidden, T252)
   unqueue: PendingSend[];                     // …whose kernel cover is a QUEUED copy: the caller hides that copy
@@ -333,7 +337,7 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
   const lateOwn = new Map<string, number>();
   for (const p of list) if (!p.at && p.late) lateOwn.set(p.text, (lateOwn.get(p.text) || 0) + 1);
   for (const p of list) if (!p.at) p.at = stampBase(events, p, p.late ? lateOwn.get(p.text) || 1 : 0);
-  const r: Reconciled = { keep: [], inject: [], unqueue: [], landed: [], lost: [] };
+  const r: Reconciled = { keep: [], inject: [], unqueue: [], landed: [], lost: [], echoHide: [] };
   const claimed = new Map<string, number>();           // "index\0text" → copies of that text in that landing taken by earlier entries THIS push
   const owned = new Set<string>();                     // the identities pending sends have latched: an echo, a queued copy or a landing wearing one is that send's, never a text match
   for (const p of list) if (p.qid) owned.add(p.qid);
@@ -386,9 +390,9 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
     // a ✕ on it must not hand its echo to the next entry; an echo is one text, so one entry in `seen` is
     // the whole of it) — else the first queued copy beyond this entry's press-time count that no
     // earlier entry took this push.
-    let covered = false, byQueued = false;
+    let covered = false, byQueued = false, byEcho = false;
     if (echoIdx >= 0) {
-      covered = true;
+      covered = true; byEcho = true;
       const u = events[echoIdx].uuid;
       if (u) for (const q of list) if (q !== p && q.at && q.text === p.text && !q.at.seen.includes(u)) q.at.seen.push(u);
       if (!p.qid && u) p.qid = u;                  // the echo's uuid is the copy's id: latched (T252c)
@@ -422,11 +426,14 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
     }
     if (lostIdx >= 0) { r.lost.push(p); continue; }
     r.keep.push(p);
-    // The kernel's ECHO atom covers ours: the kernel draws that atom itself. A QUEUED copy does not: it sits
-    // in the kernel's group at the tail, and the bubble the user watches is ours, right below — so ours stays
-    // drawn and the caller hides that copy, one bubble per message (T252).
-    if (!covered || byQueued) r.inject.push(p);
+    // The kernel's copy of a pending send never replaces OUR bubble (T252, T262h): a QUEUED copy sits in the
+    // kernel's group at the tail and the caller hides it; an ECHO atom sits at its SEND time, above the steps
+    // that ran since, and the caller hides it too — swapping ours (at the tail) for it shrank the tail under a
+    // bottom reader by the bubble's height, the clamp the user watched. Ours stays drawn, one node, until the
+    // landing takes its place; the kernel's copies only prove receipt (`received`).
+    r.inject.push(p);
     if (covered && byQueued) r.unqueue.push(p);
+    if (covered && byEcho && echoIdx >= 0 && !r.echoHide.includes(echoIdx)) r.echoHide.push(echoIdx);
   }
   // Every landing claimed this push is spoken for: one copy per claim becomes background for every
   // pending send with the same text that STAYS, on every push after (the retired entry's claim would

--- a/vscode-extension/src/followup-render.test.ts
+++ b/vscode-extension/src/followup-render.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("queued payload is per-message {md, followUp?, goal?, fuCtx?}, not raw strings", () => {
   // `optimistic` (romp's own unconfirmed echo) rides along at the end — see optimistic-send.test.ts
-  assert.match(SRC, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number; qid\?: string; hiddenByPending\?: boolean \}\[\]/);
+  assert.match(SRC, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number; qid\?: string; hiddenByPending\?: boolean; landing\?: boolean \}\[\]/);
 });
 
 test("renderQueued renders markdown (not raw text) + the follow-up header", () => {


### PR DESCRIPTION
A bottom reader moved up by exactly a bubble's height with no scroll write between the rows, then stopped following (the user's laptop, 2026-09-08). Two sources of one shape, both fixed at the source, event-based:

- **Our pending bubble (T262h):** the bare group was rebuilt from scratch on every push, and the kernel's echo (placed at the send time, above the steps that ran since) replaced our bubble at the tail, shrinking it. Now the pending group is one DOM node while pending (cached per session, reconciled in place), the echo is hidden like the queued copy (ours is the one bubble until the landing), the strip and re-inject are one guarded step, and a ✕ writes a bottom reader to the new bottom in the same task.
- **The kernel's queued copies (T262i):** a mail card leaves the queue frame before its landed record arrives. A vanished copy is held in the tail group, marked landing, until the atom with its id (T252c `qid`/`qids`) arrives and takes the slot in the same frame; an id-less copy is held by text for one push; a held copy is dropped once a later landing shows the CLI passed it, or the queue lists it again. Pure rules in `ui/webview/queued-held.ts`.

**Tests (red first):** `tests/test_pending_bubble_stable.py` (served, 60 s of pushes every 0.5 s: distance 0, no unwritten move, the same node, then two sends and a ✕), `tests/test_queued_copy_held.py` (served: the two frames driven separately for an identified and an id-less copy, a bottom and an off-bottom reader), `ui/webview/queued-held.test.ts`, and the flipped pins in `send-pending.test.ts` / `optimistic-send.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
