### PR TITLE
Feed: a session's group folds per column in group-by-session mode (T263c)

### DIFF
--- a/tests/test_feed_thread_fold_columns.py
+++ b/tests/test_feed_thread_fold_columns.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""T263c (the user 2026-09-08): in the feed's group-by-session mode, a session's run folds INDEPENDENTLY per
+column — collapse its Blocked (or Completed) cards while its Working cards stay open.
+
+The fold used to be keyed by session alone, so the caret on any column's header folded the session across the
+board. It is now keyed by (session, column). The served guard drives the real /feed page from a hermetic
+kernel and hands it a SYNTHETIC payload (one session, one card blocked on the user and one working) through
+the page's own frame path (a MessageEvent, exactly what the socket shim dispatches), then clicks the caret on
+the session's header in the Blocked column and reads the DOM: that header folds and shows its count, the same
+session's header in the Working column stays open with its card visible; a reload keeps the per-column fold.
+Red on main: the Working header folds too (one key per session).
+
+Screenshots with FEED_FOLD_SHOTS=<path-prefix> (dark + light). Skips LOUDLY without the extension deps or a
+Playwright browser (CI installs none); the CI-safe pins ride ui/webview/feed-thread-fold.test.ts and the
+executed key rules ui/webview/feed-view-state.test.ts. All fixtures synthetic (the notes-api demo world).
+"""
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+
+SID = "aaaaaaaa-1111-2222-3333-777777777777"
+BLOCKED = "cccccccc-1111-2222-3333-000000000001"
+WORKING = "cccccccc-1111-2222-3333-000000000002"
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 520 }, deviceScaleFactor: 2 });
+const errors = [];   // an exception mid-render aborts the view-state write: every page error is evidence
+page.on("pageerror", (e) => errors.push(String(e && e.stack || e).slice(0, 400)));
+page.on("console", (m) => { if (m.type() === "error") errors.push("console: " + m.text().slice(0, 300)); });
+await page.goto(cfg.feed);
+// the columns are built by the first render, which the first payload triggers: wait for the page's script, not the DOM
+await page.waitForFunction(() => document.readyState === "complete" && typeof window.acquireVsCodeApi === "function", null, { timeout: 20000 });
+await page.waitForTimeout(600);
+// the synthetic payload: ONE session with a card blocked on the user and a card working, grouped mode (the default)
+const now = Math.floor(Date.now() / 1000);
+const ask = (itemId, column, text, t) => ({ itemId, sid: cfg.sid, name: "web", color: { bg: "#1EA1EB", fg: "#ffffff" },
+  text, t, live: true, turnId: "turn-" + itemId.slice(-1), trgb: [30, 161, 235], column, tree: [] });   // tree: the card's (empty) sub-goal DAG — render iterates it
+const payload = { type: "feed", asks: [ask(cfg.blocked, "needs_input", "notes-api: pick the retry policy", now - 300),
+                                        ask(cfg.working, "working", "notes-api: draft the search index", now - 60)],
+                  sessions: [{ sid: cfg.sid, name: "web" }], order: [cfg.sid] };
+const deliver = (m) => page.evaluate((m) => { window.dispatchEvent(new MessageEvent("message", { data: m })); }, m);
+await deliver(payload);
+await page.waitForSelector(`[data-key="a:${cfg.blocked}"]`, { timeout: 10000 });
+await page.waitForSelector(`[data-key="a:${cfg.working}"]`, { timeout: 10000 });
+await page.waitForTimeout(300);
+// where each card sits: its column container and that container's header for the session
+const survey = () => page.evaluate((cfg) => {
+  const colOf = (el) => el ? el.closest(".feed-col") : null;
+  const headIn = (col) => col ? col.querySelector(`.feed-sess-head[data-fsid="${cfg.sid}"]`) : null;
+  const card = (id) => document.querySelector(`[data-key="a:${id}"]`);
+  const read = (col) => {
+    const h = headIn(col);
+    return { present: !!col, head: !!h, folded: !!h && h.classList.contains("folded"), caret: h ? h.querySelector(".feed-sess-fold")?.textContent : null,
+             count: h ? (h.querySelector(".feed-sess-foldn")?.style.display === "none" ? null : h.querySelector(".feed-sess-foldn")?.textContent) : null,
+             cards: col ? col.querySelectorAll("[data-key^='a:']").length : 0, id: col ? (col.querySelector(".feed-col-list")?.id || col.id) : null };
+  };
+  const heads = Array.from(document.querySelectorAll(".feed-sess-head")).map((h) => ({ col: h.closest(".feed-col")?.querySelector(".feed-col-list")?.id || null, folded: h.classList.contains("folded") }));
+  const cols = Array.from(document.querySelectorAll(".feed-col-list")).map((c) => c.id);
+  return { blocked: read(colOf(card(cfg.blocked)) || document.getElementById(cfg.blockedCol || "")), working: read(colOf(card(cfg.working)) || document.getElementById(cfg.workingCol || "")),
+           heads, cols, stored: localStorage.getItem("romp:feedview"), keys: Object.keys(localStorage),
+           probe: (() => { try { localStorage.setItem("romp:probe", "x"); const v = localStorage.getItem("romp:probe"); localStorage.removeItem("romp:probe"); return v; } catch (e) { return "ERR " + e; } })(),
+           hidden: document.hidden, empty: !!document.querySelector(".feed-empty"), listKids: document.querySelectorAll(".feed-col-list > *").length };
+}, cfg);
+const before = await survey();
+if (!before.blocked.present || !before.working.present) { console.error("cards did not land in two columns: " + JSON.stringify(before)); process.exit(1); }
+cfg.blockedCol = before.blocked.id; cfg.workingCol = before.working.id;   // remembered: a folded column hides its cards
+// CLICK the caret on the session's header in the BLOCKED column
+await page.click(`#${cfg.blockedCol} .feed-sess-head[data-fsid="${cfg.sid}"] .feed-sess-fold`);
+await page.waitForTimeout(400);
+const folded = await survey();
+await page.mouse.move(5, 500);
+await page.waitForTimeout(150);
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-dark.png" });
+// LIGHT theme: the classes the feed's theme switch sets
+await page.evaluate(() => document.body.classList.add("chat-theme-yatharth", "theme-light"));
+await page.waitForTimeout(250);
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-light.png" });
+await page.evaluate(() => document.body.classList.remove("chat-theme-yatharth", "theme-light"));
+// RELOAD: the per-column fold persists (the state is written at the end of every render)
+await page.reload();
+await page.waitForFunction(() => document.readyState === "complete" && typeof window.acquireVsCodeApi === "function", null, { timeout: 20000 });
+await page.waitForTimeout(600);
+await page.waitForTimeout(300);
+await deliver(payload);
+await page.waitForSelector(`[data-key="a:${cfg.working}"]`, { timeout: 10000 });
+await page.waitForTimeout(300);
+const reloaded = await survey();
+fs.writeSync(1, "RESULT:" + JSON.stringify({ before, folded, reloaded, errors }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedFoldIsPerColumn(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        cls.lab = tempfile.mkdtemp(prefix="feedfold-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        shutil.copytree(os.path.join(EXT, "dist"), dist)
+        state = os.path.join(cls.lab, "xdg", "romp")
+        os.makedirs(state, exist_ok=True)
+        cls.port = _free_port()
+        cls.token = "testtok-feedfold"
+        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=os.path.join(cls.lab, "claude"),
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
+                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
+        env.pop("ROMP_STATE_DIR", None)
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(os.path.join(cls.lab, "kernel.log"), "w"), stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_folding_a_session_in_one_column_leaves_its_other_column_open_and_persists(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"feed": "http://127.0.0.1:%d/feed?token=%s" % (self.port, self.token), "sid": SID,
+                       "blocked": BLOCKED, "working": WORKING, "shots": os.environ.get("FEED_FOLD_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        b, f_, rl = r["before"], r["folded"], r["reloaded"]
+        self.assertEqual(r.get("errors"), [], "the page threw nothing (an exception mid-render would skip the view-state write): %r" % r.get("errors"))
+        # the world: the two cards sit in different columns, each under a header for the one session
+        self.assertNotEqual(b["blocked"]["id"], b["working"]["id"], "two columns: %r" % b)
+        self.assertTrue(b["blocked"]["head"] and b["working"]["head"], "a session header heads each run: %r" % b)
+        self.assertFalse(b["blocked"]["folded"] or b["working"]["folded"], "nothing folded to start: %r" % b)
+        # THE FIX: the Blocked header folded (caret ▸, its one card counted onto it, no card rendered), the Working header
+        # untouched (caret ▾, its card still on screen) — red on main, where one key folded the session in every column
+        self.assertTrue(f_["blocked"]["folded"], "the clicked column folded: %r" % f_["blocked"])
+        self.assertEqual((f_["blocked"]["caret"], f_["blocked"]["count"], f_["blocked"]["cards"]), ("▸", "1", 0), "folded header stands in for its one card: %r" % f_["blocked"])
+        self.assertFalse(f_["working"]["folded"], "the other column stays open: %r" % f_["working"])
+        self.assertEqual((f_["working"]["caret"], f_["working"]["cards"]), ("▾", 1), "…its card still visible: %r" % f_["working"])
+        self.assertEqual(sorted(h["folded"] for h in f_["heads"]), [False, True], "exactly one of the session's two headers is folded: %r" % f_["heads"])
+        # after a reload the same column is folded and the other open
+        self.assertTrue(rl["blocked"]["folded"], "the fold survives a reload: %r (stored before reload: %r)" % (rl["blocked"], (f_["stored"] or "")[:300]))
+        self.assertFalse(rl["working"]["folded"], "…and stays per column: %r" % rl["working"])
+        # persisted per column: the stored key names the column, not the bare session
+        self.assertIn(SID + "\\u0000needsInput", rl["stored"] or "", "the stored fold is (session, column): %r" % (rl["stored"] or "")[:300])
+        self.assertNotIn('"%s"' % SID, rl["stored"] or "", "…never the bare sid")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/feed-group-mode.test.ts
+++ b/ui/webview/feed-group-mode.test.ts
@@ -34,9 +34,9 @@ test("session rank = the kernel's session-order list (tab/lane order); unknown s
 test("a name+dot header entry opens each session's run; only runs that exist get one", () => {
   // `folded` joined the header entry with collapsible threads (feed-thread-fold.test.ts, 2026-07-31):
   // it counts the cards a FOLDED header stands in for, and is 0 while the thread is open.
-  assert.match(FEED, /\{ kind: "sess"; t: number; sid: string; name: string; color: \{ bg: string; fg: string \} \| null; live: boolean; folded: number \}/);
+  assert.match(FEED, /\{ kind: "sess"; t: number; sid: string; col: Column; name: string; color: \{ bg: string; fg: string \} \| null; live: boolean; folded: number \}/, "the header entry names its column (T263c: the fold is per session per column)");
   assert.match(FEED, /if \(s !== cur\) \{/);
-  assert.match(FEED, /head = \{ kind: "sess", t: e\.t, sid: s, name: src\.name, color: src\.color \|\| null, live: !!src\.live, folded: 0 \};\s*\n\s*withHeads\.push\(head\);/);
+  assert.match(FEED, /head = \{ kind: "sess", t: e\.t, sid: s, col: k, name: src\.name, color: src\.color \|\| null, live: !!src\.live, folded: 0 \};\s*\n\s*withHeads\.push\(head\);/);
   // reconcile keys headers per (column, sid) — one session can head a run in EVERY column
   assert.match(FEED, /key = "s:" \+ listEl\.id \+ ":" \+ e\.sid;/);
   // the header carries the identity: colored name, host prefix treatment, the yellow working dot

--- a/ui/webview/feed-sess-clear.test.ts
+++ b/ui/webview/feed-sess-clear.test.ts
@@ -34,7 +34,7 @@ test("the header's Clear IS the card's Clear: one builder, one class set, a layo
 test("grouped mode only: headers (and so the control) are emitted under the grouped guard", () => {
   const guard = FEED.indexOf("if (feedPrefs().grouped) {\n    const rank = new Map(sessionOrder.map(");
   assert.ok(guard > 0, "the grouped-mode header build lives under the grouped guard");
-  assert.match(FEED.slice(guard, guard + 2500), /head = \{ kind: "sess", t: e\.t, sid: s, name: src\.name/);
+  assert.match(FEED.slice(guard, guard + 2500), /head = \{ kind: "sess", t: e\.t, sid: s, col: k, name: src\.name/);
   assert.match(FEED, /function dressHeaderIfLast\(card: HTMLElement, sid: string\): void \{\s*\n\s*if \(!feedPrefs\(\)\.grouped\) return;/);
 });
 

--- a/ui/webview/feed-thread-fold.test.ts
+++ b/ui/webview/feed-thread-fold.test.ts
@@ -1,9 +1,12 @@
 // COLLAPSIBLE THREADS in the grouped feed (the user 2026-07-31): a caret right of each session-header name
-// folds that thread away to its name alone, and it STAYS folded — including for cards that do not exist yet
+// folds that run away to its name alone, and it STAYS folded — including for cards that do not exist yet
 // — until you expand it again. Persisted with the rest of the feed's disclosure state.
 //
-// Keyed by SID rather than by column-run on purpose: a card's column is not knowable when you fold, so a
-// per-column fold could not honour "future cards stay folded" the moment a card moved columns.
+// Keyed by (SID, COLUMN) since T263c (the user 2026-09-08, who wanted to collapse a session's Blocked or
+// Completed cards independently of its Working ones): each column's header folds its own run, a card that
+// lands in that column later inherits that column's fold, and a card moving columns shows under the fold
+// state of the column it moves to. A pre-T263c bare-sid entry reads as every column (threadKeys), so an
+// older fold keeps folding until a column is opened.
 //
 // No jsdom for the feed renderer, so the render side is pinned at the source; the STATE side is executed in
 // feed-view-state.test.ts.
@@ -28,7 +31,8 @@ test("it is a caret, and it says which way it will go", () => {
 
 test("folding hides that thread's cards and counts them onto the header", () => {
   // the header stands in for the run: entries are counted, not rendered
-  assert.match(FEED, /if \(collapsedThreads\.has\(s\)\) \{ if \(head\) head\.folded \+= entryCards\(e\); continue; \}/);
+  assert.match(FEED, /if \(collapsedThreads\.has\(threadKey\(s, k\)\)\) \{ if \(head\) head\.folded \+= entryCards\(e\); continue; \}/,
+    "the check is per (session, column): `k` is the column being assembled");
   assert.match(FEED, /setText\(foldn, String\(e\.folded\)\);/, "bare number (the user 2026-08-26) — words on hover only");
   assert.match(FEED, /foldn\.style\.display = shut && e\.folded \? "" : "none";/);
 });
@@ -38,11 +42,19 @@ test("the column count reports the BOARD, not what you have open", () => {
   assert.match(FEED, /const nCards = \(es: Entry\[\]\) => es\.reduce\(\(n, e\) => n \+ entryCards\(e\), 0\);/);
 });
 
-test("the fold is per-SESSION, so a card that does not exist yet inherits it", () => {
+test("the fold is per (SESSION, COLUMN) — T263c — so a card that does not exist yet inherits its column's fold", () => {
   assert.match(FEED, /const collapsedThreads = new Set<string>\(\);/);
-  assert.match(FEED, /if \(collapsedThreads\.has\(e\.sid\)\) collapsedThreads\.delete\(e\.sid\); else collapsedThreads\.add\(e\.sid\);/);
-  // …and it survives a reload with the rest of the disclosure state
-  assert.match(FEED, /for \(const k of st\.threads\) collapsedThreads\.add\(k\);/);
+  // the header entry carries its column, and the caret reads and toggles THAT key
+  assert.match(FEED, /\| \{ kind: "sess"; t: number; sid: string; col: Column; name: string;/);
+  assert.match(FEED, /head = \{ kind: "sess", t: e\.t, sid: s, col: k, name: src\.name,/);
+  assert.match(FEED, /const tkey = threadKey\(e\.sid, e\.col\);\s*\n\s*const shut = collapsedThreads\.has\(tkey\);/);
+  assert.match(FEED, /if \(collapsedThreads\.has\(tkey\)\) collapsedThreads\.delete\(tkey\); else collapsedThreads\.add\(tkey\);/);
+  assert.doesNotMatch(FEED, /collapsedThreads\.(has|add|delete)\(e\.sid\)|collapsedThreads\.(has|add|delete)\(a\.sid\)|collapsedThreads\.has\(s\)/,
+    "no site keys the fold by the bare sid any more");
+  // the caret says which column it folds
+  assert.match(FEED, /fold\.title = shut \? "show this session's cards in this column" : "collapse this session's cards in this column to its name — new cards here stay folded too";/);
+  // …and it survives a reload with the rest of the disclosure state; a pre-T263c bare sid reads as every column
+  assert.match(FEED, /for \(const k of st\.threads\) for \(const key of threadKeys\(k\)\) collapsedThreads\.add\(key\);/);
   assert.match(FEED, /threads: \[\.\.\.collapsedThreads\]/);
 });
 
@@ -55,7 +67,8 @@ test("the click acknowledges immediately and cannot be lost to a re-render", () 
 
 test("a jump into a folded thread unfolds it instead of landing on nothing", () => {
   // revealCards scrolls to a DOM element; a folded card has none, so the navigation would silently no-op
-  assert.match(FEED, /if \(collapsedThreads\.has\(a\.sid\) && extHoverMatches\("a:" \+ a\.itemId, keys\)\) \{/);
+  assert.match(FEED, /const tkey = threadKey\(a\.sid, askColumn\(a\)\);[^\n]*\n\s*if \(collapsedThreads\.has\(tkey\) && extHoverMatches\("a:" \+ a\.itemId, keys\)\) \{/,
+    "the run the card sits in — its column's key — is what a jump unfolds");
   assert.match(FEED, /if \(opened\) render\(\);/);
 });
 

--- a/ui/webview/feed-view-state.test.ts
+++ b/ui/webview/feed-view-state.test.ts
@@ -7,8 +7,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import {
   emptyViewState, parseViewState, serializeViewState, pruneViewState, capViewState,
-  keyIsLive, viewStateSize, VIEW_STATE_KEY, VIEW_STATE_CAP, type FeedViewState,
-} from "./feed-view-state";
+  keyIsLive, viewStateSize, VIEW_STATE_KEY, VIEW_STATE_CAP, type FeedViewState, threadKey, threadKeys, FEED_COLUMNS } from "./feed-view-state";
 
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
@@ -191,4 +190,22 @@ test("stacked-column state persists, tolerates old blobs, and gates on the three
   const pruned = pruneViewState(sample(), new Set<string>([]));
   assert.deepEqual(pruned.cols, ["completed"], "layout state survives a full card prune");
   assert.deepEqual(pruned.order, ["asks", "completed", "needsInput"]);
+});
+
+// ── T263c (the user 2026-09-08): the fold key is (session, column) ─────────────────────────────────────────
+test("executed: threadKey names one session's run in one column; a stored bare sid reads as every column", () => {
+  const k = threadKey("sid-1", "needsInput");
+  assert.notEqual(k, "sid-1", "a (session, column) key is not the bare sid");
+  assert.ok(k.startsWith("sid-1"), "…but it carries the sid");
+  assert.notEqual(threadKey("sid-1", "asks"), threadKey("sid-1", "completed"), "one key per column");
+  assert.deepEqual(threadKeys(k), [k], "a keyed entry stands for itself");
+  // a fold saved before T263c covered the session everywhere: it keeps doing so until a column is opened
+  assert.deepEqual(threadKeys("sid-1"), FEED_COLUMNS.map((c) => threadKey("sid-1", c)));
+  assert.deepEqual(FEED_COLUMNS, ["asks", "needsInput", "completed"]);
+  // a remote sid spelled host:uuid is still one segment
+  assert.deepEqual(threadKeys("TESTHOST:sid-2"), FEED_COLUMNS.map((c) => threadKey("TESTHOST:sid-2", c)));
+  // the composite key round-trips through the persisted blob untouched
+  const st = { ...sample(), threads: [k, threadKey("sid-3", "asks")] };
+  assert.deepEqual(parseViewState(serializeViewState(st)).threads, [k, threadKey("sid-3", "asks")]);
+  assert.deepEqual(pruneViewState(st, new Set()).threads, [k, threadKey("sid-3", "asks")], "prune-exempt like before");
 });

--- a/ui/webview/feed-view-state.ts
+++ b/ui/webview/feed-view-state.ts
@@ -24,9 +24,11 @@ export interface FeedViewState {
   nodes: string[];               // "askId:nodeId" — COLLAPSED modal tree nodes (inverted sense, see feed.ts)
   logs: string[];                // "askId:nodeId" — expanded per-node log stories
   asks: string[];                // expanded ask itemIds
-  // COLLAPSED session sids (inverted sense, like `nodes`): in grouped mode the thread shows its header
-  // alone. Keyed by SESSION, not by card, because the point is that cards which do not exist yet inherit
-  // it — see the prune exemption below.
+  // COLLAPSED session runs (inverted sense, like `nodes`): in grouped mode the run shows its header alone.
+  // Keyed by (SESSION, COLUMN) — threadKey — never by card, because the point is that cards which do not
+  // exist yet inherit it (see the prune exemption below); per COLUMN (T263c, the user 2026-09-08) so a
+  // session's Blocked run folds while its Working run stays open. A bare sid is the pre-T263c spelling
+  // and reads as every column (threadKeys), so yesterday's folds survive the upgrade.
   threads: string[];
   // Stacked-layout COLUMN state (the user 2026-08-16): collapsed column keys ("asks"/"needsInput"/
   // "completed") and the user's dragged column order. Both describe the LAYOUT, not any card, so both
@@ -36,6 +38,19 @@ export interface FeedViewState {
 }
 
 export const VIEW_STATE_KEY = "romp:feedview";
+
+/** The feed's three columns, as the fold and layout state key them. */
+export const FEED_COLUMNS = ["asks", "needsInput", "completed"] as const;
+export type FeedColumn = typeof FEED_COLUMNS[number];
+const THREAD_SEP = "\u0000";   // a sid is a uuid (or host:uuid) and never carries a NUL
+/** The persisted key for one session's run in one column (T263c). */
+export function threadKey(sid: string, col: FeedColumn): string { return sid + THREAD_SEP + col; }
+/** The keys a STORED entry stands for: a (sid, column) key is itself; a bare sid — the pre-T263c spelling,
+ *  when a fold covered the session everywhere — is every column, so an old fold keeps folding until the
+ *  user opens a column. */
+export function threadKeys(stored: string): string[] {
+  return stored.includes(THREAD_SEP) ? [stored] : FEED_COLUMNS.map((c) => threadKey(stored, c));
+}
 // Backstop only. The live-set prune below bounds the real size to what is on screen; this exists so a bug in
 // that rule can never grow the entry unboundedly and wedge localStorage.
 export const VIEW_STATE_CAP = 4000;
@@ -100,8 +115,8 @@ export function keyIsLive(key: string, liveIds: Set<string>): boolean {
  *  everything the user just restored.
  *
  *  `threads` is EXEMPT, deliberately. Every other entry describes a card, so a card that is gone makes its
- *  entry meaningless; a collapsed thread describes a SESSION, and its whole purpose is to hold while that
- *  session has no cards on the board so the next one arrives collapsed too. Pruning it against the live set
+ *  entry meaningless; a collapsed thread describes a SESSION's run in a column, and its whole purpose is to
+ *  hold while that run has no cards on the board so the next one arrives collapsed too. Pruning it against the live set
  *  would silently re-expand a thread the moment its last card cleared — exactly the "collapse it and it
  *  stays collapsed" the feature is for. It is bounded by the cap instead. */
 export function pruneViewState(s: FeedViewState, liveIds: Set<string>): FeedViewState {

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -35,7 +35,7 @@ import { applyTheme } from "./theme";
 import { canPreview } from "./preview";
 import { initFileView, setFileViewIdentity, hostStub } from "./file-view";
 import { initFileBrowse, openFileBrowse } from "./file-browse";
-import { VIEW_STATE_KEY, parseViewState, serializeViewState, pruneViewState, capViewState, type FeedViewState } from "./feed-view-state";
+import { VIEW_STATE_KEY, parseViewState, serializeViewState, pruneViewState, capViewState, type FeedViewState, threadKey, threadKeys } from "./feed-view-state";
 import { wireTip, setTip, pruneTip } from "./tip";
 import { perfFrameHandler } from "./perf-telemetry";
 import { listenForFrames } from "./frame-listener";
@@ -1526,7 +1526,7 @@ let colOrder: string[] = [];                         // [] = each layout's own C
   for (const k of st.nodes) collapsedNodes.add(k);
   for (const k of st.logs) nodeLogOpen.add(k);
   for (const k of st.asks) expandedAsks.add(k);
-  for (const k of st.threads) collapsedThreads.add(k);
+  for (const k of st.threads) for (const key of threadKeys(k)) collapsedThreads.add(key);   // a pre-T263c bare sid = every column
   for (const k of st.cols) collapsedCols.add(k);
   colOrder = st.order.slice();
 })();
@@ -3512,7 +3512,8 @@ type Entry =
   // a SESSION HEADER row in grouped mode (the user 2026-07-13): the session's name + working dot on the
   // column backdrop, heading that session's run of cards. Only emitted for runs that exist.
   // `folded` = how many of this run's cards the header is standing in for (0 when the thread is expanded)
-  | { kind: "sess"; t: number; sid: string; name: string; color: { bg: string; fg: string } | null; live: boolean; folded: number };
+  // `col` = the column this header heads: the fold is per (session, column) — T263c, the user 2026-09-08
+  | { kind: "sess"; t: number; sid: string; col: Column; name: string; color: { bg: string; fg: string } | null; live: boolean; folded: number };
 
 // ONE counting rule (the user 2026-08-26): every number on the board counts CARDS, never rows — a
 // turn-group entry is worth its members, a folded session header is worth the cards it stands in for.
@@ -3572,10 +3573,13 @@ function updateSessHead(h: HTMLElement, e: Entry & { kind: "sess" }): void {
   setWorkDot(nm, dotFor(e.name));   // the working/awaiting dot rides the header, not the cards
   // the fold caret + the "n cards" stand-in for what it hides
   const fold = (h as any)._fold as HTMLElement, foldn = (h as any)._foldn as HTMLElement;
-  const shut = collapsedThreads.has(e.sid);
+  // per (session, COLUMN) — T263c, the user 2026-09-08: the same session folds in Blocked and stays open in
+  // Working; a card that lands in this column later inherits this column's fold
+  const tkey = threadKey(e.sid, e.col);
+  const shut = collapsedThreads.has(tkey);
   h.classList.toggle("folded", shut);
   setText(fold, shut ? "▸" : "▾");               // ▸ folded / ▾ open
-  fold.title = shut ? "show this session's cards" : "collapse this session to its name — new cards stay folded too";
+  fold.title = shut ? "show this session's cards in this column" : "collapse this session's cards in this column to its name — new cards here stay folded too";
   fold.setAttribute("aria-expanded", shut ? "false" : "true");
   fold.setAttribute("aria-label", (shut ? "expand " : "collapse ") + e.name);
   foldn.style.display = shut && e.folded ? "" : "none";
@@ -3584,7 +3588,7 @@ function updateSessHead(h: HTMLElement, e: Entry & { kind: "sess" }): void {
   foldn.title = e.folded === 1 ? "1 card folded under this session" : e.folded + " cards folded under this session";
   fold.onclick = (ev) => {
     ev.stopPropagation();   // the fold IS the acknowledgement: local state + an immediate re-render
-    if (collapsedThreads.has(e.sid)) collapsedThreads.delete(e.sid); else collapsedThreads.add(e.sid);
+    if (collapsedThreads.has(tkey)) collapsedThreads.delete(tkey); else collapsedThreads.add(tkey);
     render();
   };
   // the session-wide Clear: which session, and only while it has cards in the current view (a header
@@ -4889,13 +4893,13 @@ function render() {
         if (s !== cur) {
           cur = s;
           const src: any = e.kind === "ask" ? e.ask : e.kind === "group" ? e.group : e;
-          head = { kind: "sess", t: e.t, sid: s, name: src.name, color: src.color || null, live: !!src.live, folded: 0 };
+          head = { kind: "sess", t: e.t, sid: s, col: k, name: src.name, color: src.color || null, live: !!src.live, folded: 0 };
           withHeads.push(head);
         }
         // A COLLAPSED thread contributes its header and nothing else — the run's cards are counted onto the
         // header instead of rendered, so the folded row still says how much is under it. CARDS, not rows
         // (entryCards): a turn-group folds as its member count, the same rule the section chip reads.
-        if (collapsedThreads.has(s)) { if (head) head.folded += entryCards(e); continue; }
+        if (collapsedThreads.has(threadKey(s, k))) { if (head) head.folded += entryCards(e); continue; }
         withHeads.push(e);
       }
       buckets[k] = withHeads;
@@ -5851,8 +5855,9 @@ function unfoldThreadsFor(keys: Set<string>): void {
   if (!collapsedThreads.size) return;
   let opened = false;
   for (const a of asks) {
-    if (collapsedThreads.has(a.sid) && extHoverMatches("a:" + a.itemId, keys)) {
-      collapsedThreads.delete(a.sid); opened = true;
+    const tkey = threadKey(a.sid, askColumn(a));   // the run the card sits in — per (session, column), T263c
+    if (collapsedThreads.has(tkey) && extHoverMatches("a:" + a.itemId, keys)) {
+      collapsedThreads.delete(tkey); opened = true;
     }
   }
   if (opened) render();


### PR DESCRIPTION
When cards are grouped by session, folding a session's Blocked (or Completed) cards now leaves its Working cards open (the user 2026-09-08). The fold was keyed by session alone, so the caret on any column's header folded the session in every column.

- **Keying fix, no new control.** The fold key is `(session, column)` (`threadKey` in `feed-view-state.ts`, pure and executed in tests). The header entry carries its column; the caret reads and toggles that key and its tooltip says which column it folds. A card that lands in the column later inherits that column's fold; a card that moves columns shows under the fold state of the column it moves to; a jump into a folded card unfolds the run it sits in. The header count was already per run.
- **Persistence unchanged in shape.** The same `threads` list, prune-exempt as before. A stored bare sid (the earlier spelling, when a fold covered the session everywhere) reads as every column, so an older fold keeps folding until a column is opened.
- **Tests.** `feed-thread-fold.test.ts` pins the per-column key on every site and bans the bare-sid spelling; `feed-view-state.test.ts` executes the key helpers and the round trip; `tests/test_feed_thread_fold_columns.py` drives the served feed page in a browser with a synthetic payload (one session, blocked and working): the Blocked header folds with its count, the Working header stays open with its card, and the fold survives a reload. Red on main: the Working header folds too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
