### PR TITLE
Kernel: change-gate the pusher's idle path (comment threads, comments stores, the task-store join, state tails, working notes)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11299,11 +11299,22 @@ def _working_notes():
     # Read once per directory VERSION (2026-09-08): GET /sessions is polled about once a second by the
     # postal services of every live session, and each call re-read every note file; the key is every
     # entry's (name, mtime_ns, size, ino), so a rewritten or removed note misses exactly.
+    entries = []
     try:
         with os.scandir(WORKING_DIR) as it:
-            entries = sorted((e.name, e.path, e.stat().st_mtime_ns, e.stat().st_size, e.stat().st_ino) for e in it)
+            for e in it:
+                try:
+                    st = e.stat()
+                except OSError:
+                    continue        # unlinked between readdir and stat (a clear, an atomic write's temp renamed
+                    #                 away): that note is gone and the others still stand. One try around the whole
+                    #                 listing returned {} here instead, so for that call every live session read as
+                    #                 owning nothing, which the postal contract takes as free ownership (review
+                    #                 2026-09-08). The idiom is _task_store_fp's.
+                entries.append((e.name, e.path, st.st_mtime_ns, st.st_size, st.st_ino))
     except OSError:
         return {}
+    entries.sort()
     key = tuple((n, m, s, i) for n, _p, m, s, i in entries)
     hit = _working_notes_memo[0]
     if hit is not None and hit[0] == key:
@@ -12766,7 +12777,19 @@ def _thread_events(tsid, cut_uuid, now, tmux):
     try:
         base = _chat_build_sig(sess, tm)
         asig = _active_chat_sig(sess, tm, now, base=base) if base is not None else None
-        key = ("exact", asig) if asig is not None else (("stat", base) if base is not None else None)
+        sig = ("exact", asig) if asig is not None else (("stat", base) if base is not None else None)
+        if sig is not None:
+            # plus the thread's OWN state rows (review 2026-09-08): the backend writes states/<tsid>.jsonl under
+            # the romp sid, while the key above stats states/<fsid>.jsonl for the reg's lastSid (_sdk_sess hands
+            # over no anchor). The two are one file only until a resume mints a new fsid or a /clear moves
+            # lastSid; after that a states-only write (an interrupt settle's idle row, a retry marker, an
+            # orphan-reply salvage) changed the thread's events with no key change. None when absent.
+            try:
+                ss = os.stat(jd.STATESDIR / (tsid + ".jsonl"))
+                states = (ss.st_mtime_ns, ss.st_size, ss.st_ino)
+            except OSError:
+                states = None
+            key = sig + (states,)
     except Exception:
         key = None                              # an input we cannot key → build, never cache
     hit = _built_thread.get(tsid)
@@ -24688,8 +24711,9 @@ def _task_store_dir(fsid):
 
 
 _task_dir_hint = {}   # fsid → content-joined store dir NAME (see _task_store_resolve); reset per kernel run
-_task_join_miss = {}  # fsid → the fold pairs that failed to join — skip re-scanning until the pairs CHANGE
-#                       (event-based retry: new task activity reshapes the fold; a kernel restart clears both)
+_task_join_miss = {}  # fsid → (fold pairs, tasks-root listing) that failed to join: skip re-reading the stores
+#                       until EITHER changes (event-based retry: new task activity reshapes the fold, a store
+#                       appearing or gaining a file reshapes the root listing; a kernel restart clears both)
 
 
 def _task_store_known(fsid):
@@ -24723,7 +24747,10 @@ def _task_store_resolve(fsid, fold):
     the session's OWN record of creating the tasks: the transcript fold's (id, subject) pairs. A
     candidate store that contains them ALL is the session's store; no match or SEVERAL matches → None,
     and the caller stays loud (never guess). The join runs at most once per session per kernel run
-    (_task_dir_hint caches the winner)."""
+    (_task_dir_hint caches the winner). A MISS is remembered too (_task_join_miss), keyed on the pairs and
+    on the tasks root's listing (each store dir's name and mtime_ns): the root scan and a stat per dir run
+    on every call, cheap; the per-file reads are what the memo saves. A miss that a read fault produced (a
+    store listing that failed, a task file mid-rewrite) is never remembered, so the next call retries."""
     d = _task_store_known(fsid)
     if d is not None:
         return d
@@ -24731,23 +24758,38 @@ def _task_store_resolve(fsid, fold):
              if t.get("subject") and str(t["id"]).isdigit()}   # synthetic cN ids (no 'Task #N' result) can't join
     if not pairs:
         return None
-    if _task_join_miss.get(fsid) == pairs:
-        return None                                            # same fold already failed to join → no re-scan
     try:
         cands = [e for e in os.scandir(_task_store_dir(fsid).parent) if e.is_dir()]
     except OSError:
         return None
+    # The root's listing rides the memo's key beside the pairs (review 2026-09-08): a dir's mtime moves when a
+    # file is added or removed inside it, and the set of names moves when a store APPEARS, which Claude Code
+    # does a moment after the TaskCreate the fold already saw. Keyed on the pairs alone, the miss held until
+    # the next TaskCreate or a kernel restart (status updates never change the pairs), and the todo card
+    # showed the store as unreadable for the rest of the session.
+    root_key = []
+    for e in cands:
+        try:
+            root_key.append((e.name, e.stat().st_mtime_ns))
+        except OSError:
+            root_key.append((e.name, None))
+    root_key = tuple(sorted(root_key))
+    if _task_join_miss.get(fsid) == (pairs, root_key):
+        return None                                # the same fold under the same root already failed → no re-read
     hits = []
+    faulted = False                                # a store we could not read whole: the verdict is not evidence
     for e in cands:
         have = set()
         try:
             names = [n for n in os.listdir(e.path) if n.endswith(".json")]
         except OSError:
+            faulted = True
             continue
         for n in names:
             try:
                 t = json.loads((Path(e.path) / n).read_text())
             except (OSError, ValueError):
+                faulted = True                     # a task file mid-rewrite: its pair is missing from `have`
                 continue
             if isinstance(t, dict):
                 have.add((str(t.get("id") or n.rsplit(".", 1)[0]), str(t.get("subject") or "")))
@@ -24757,8 +24799,11 @@ def _task_store_resolve(fsid, fold):
         # the negative memo the gate above reads (2026-09-08): it was declared and consulted since the join
         # landed but never WRITTEN, so a session whose store cannot be joined re-read and re-decoded every
         # store under the tasks root on every build (39 dirs, 301 files here) — for every comment thread,
-        # every cycle. Same fold pairs → same verdict until the fold changes (the docstring's own rule).
-        _task_join_miss[fsid] = pairs
+        # every cycle. Same fold pairs under the same root listing → same verdict until either changes. A
+        # miss a read fault produced is TRANSIENT and is not remembered: remembered, it latched as a
+        # permanent miss until the fold next changed (review 2026-09-08).
+        if not faulted:
+            _task_join_miss[fsid] = (pairs, root_key)
         return None
     _task_join_miss.pop(fsid, None)
     _task_dir_hint[fsid] = hits[0]
@@ -38392,14 +38437,17 @@ def _push(targets, connect=False, tmux=None):
             # …and every fold entry for a sid no longer shown (loadOlder / connect-push builds) — EXCEPT the
             # comment THREADS the loop below is about to rebuild (2026-09-08): evicting their prefixes here
             # made every thread build a cold reshape of the fork's whole copied history, every cycle. The
-            # keep set is what last cycle's comments loop touched; a thread that stops being built (resolved,
-            # promoted, its parent closed) ages out of it after one cycle and is evicted as before.
+            # keep set is what LAST cycle's comments loop touched, swapped in here, BEFORE the eviction: with
+            # the swap after it the set consulted was two cycles old, so a thread first built in cycle N was
+            # evicted once more in N+1 and a stopped thread lingered a cycle longer (review 2026-09-08). A
+            # thread that stops being built (resolved, promoted, its parent closed) ages out of the set after
+            # one cycle and is evicted as before.
+            _thread_fold_keep[0], _thread_fold_keep[1] = _thread_fold_keep[1], set()
             keep = shown_sids | _thread_fold_keep[0]
             with _chat_fold_lock:
                 for sid in list(_chat_fold):
                     if sid not in keep:
                         _chat_fold.pop(sid, None)
-            _thread_fold_keep[0], _thread_fold_keep[1] = _thread_fold_keep[1], set()
             _retry_parked_creates()   # lag-parked comment creates ride every pusher cycle (T106)
             # COMMENT THREADS: one {type:"comments"} frame per session that has ever had one (its
             # comments/ store exists — an ~free stat for everyone else). Each frame rides its OWN

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -12807,7 +12807,10 @@ def _thread_events(tsid, cut_uuid, now, tmux):
     if cut_uuid:
         at = next((i for i, e in enumerate(evs)
                    if e.get("uuid") == cut_uuid or e.get("resultUuid") == cut_uuid), None)
-        evs = [] if at is None else evs[at + 1:]   # the cut isn't in this transcript — never the copy
+        if at is None:
+            evs = []                                 # the cut isn't in this transcript: never the copy
+        else:
+            evs = evs[at + 1:]                       # sliced to AFTER the branch point (the extension's source pin)
     else:
         floor = int((_comment_thread_row_created(tsid) or 0))
         evs = [e for e in evs if not e.get("ts") or int(em.parse_z(e.get("ts")) or 0) >= floor]

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11,6 +11,7 @@ zero protocol change at switchover. WS is hand-rolled on the stdlib socket (no d
 
 Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
+import copy
 import math
 import contextlib, json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip, collections, functools, fcntl
 from pathlib import Path
@@ -242,7 +243,7 @@ class _PerfStats:
     HTTP_PATHS = 256
     SLOTS = 32
     STAGES = ("jobs", "push", "push.chat", "push.feed", "push.timeline", "push.send")
-    BUILDS = ("chat", "feed", "timeline", "feedJson")
+    BUILDS = ("chat", "feed", "timeline", "feedJson", "thread")
     SEND_KINDS = ("full", "delta", "deduped")
 
     def __init__(self):
@@ -11295,18 +11296,31 @@ def _working_notes():
     """{sid: note} for every session with a NON-EMPTY published working-note, from the backend-agnostic store
     (working/<sid> files). The note is the set_working ownership claim the postal bus shows in list_agents;
     _session_rows attaches it per live sid. Empty/absent → omitted."""
-    out = {}
+    # Read once per directory VERSION (2026-09-08): GET /sessions is polled about once a second by the
+    # postal services of every live session, and each call re-read every note file; the key is every
+    # entry's (name, mtime_ns, size, ino), so a rewritten or removed note misses exactly.
     try:
-        for f in WORKING_DIR.iterdir():
-            try:
-                note = f.read_text().strip()
-            except OSError:
-                continue
-            if note:
-                out[f.name] = note
+        with os.scandir(WORKING_DIR) as it:
+            entries = sorted((e.name, e.path, e.stat().st_mtime_ns, e.stat().st_size, e.stat().st_ino) for e in it)
     except OSError:
-        pass
-    return out
+        return {}
+    key = tuple((n, m, s, i) for n, _p, m, s, i in entries)
+    hit = _working_notes_memo[0]
+    if hit is not None and hit[0] == key:
+        return dict(hit[1])
+    out = {}
+    for name, path, _m, _s, _i in entries:
+        try:
+            note = Path(path).read_text().strip()
+        except OSError:
+            continue
+        if note:
+            out[name] = note
+    _working_notes_memo[0] = (key, out)
+    return dict(out)
+
+
+_working_notes_memo = [None]      # ((name, mtime_ns, size, ino) per entry, {sid: note})
 
 
 def _set_working_note(sid, text):
@@ -12374,6 +12388,33 @@ def _load_comments(sid):
         return {"threads": []}
 
 
+_comments_memo = {}      # sid -> ((mtime_ns, size, ino), dict) — the store decoded once per file version
+
+
+def _load_comments_cached(sid):
+    """_load_comments for the READ-ONLY per-push callers (_comments_frame, _comment_markers), decoded once
+    per file version: the store is published by _save_comments through _atomic_write (a rename), so its
+    (mtime_ns, size, ino) is an exact key. Every caller gets its own deep copy — the memo's dict is never
+    handed out, so no reader can leak a write into the next reader. A missing or unreadable store reads
+    as {"threads": []} exactly as _load_comments does, and drops any memo (the file is gone).
+    Writers (_comment_thread and the handlers under _comments_lock) keep reading fresh through
+    _load_comments. Idle cost before this: twelve stores re-read and re-decoded on every pusher cycle."""
+    p = _comments_path(sid)
+    try:
+        st = os.stat(p)
+        key = (st.st_mtime_ns, st.st_size, st.st_ino)
+    except OSError:
+        _comments_memo.pop(sid, None)
+        return {"threads": []}
+    hit = _comments_memo.get(sid)
+    if hit is None or hit[0] != key:
+        if len(_comments_memo) > 512:
+            _comments_memo.clear()
+        hit = (key, _load_comments(sid))
+        _comments_memo[sid] = hit
+    return copy.deepcopy(hit[1])
+
+
 def _save_comments(sid, data):
     _atomic_write(_comments_path(sid), json.dumps(data))
 
@@ -12693,30 +12734,68 @@ def _thread_messages(tsid, cut_uuid, floor_t=0):
     return merged
 
 
+_built_thread = {}       # thread sid -> (key, cut_uuid, events, build_started_at): the popover's chat build,
+#                          served while the thread's exact change key stands (the active tab's own idiom)
+_thread_fold_keep = [set(), set()]   # [last cycle's thread sids, this cycle's]: _push's fold eviction keeps them
+
+
 def _thread_events(tsid, cut_uuid, now, tmux):
     """The thread rendered with the CHAT's own builder (the user 2026-08-17: the popover shows the
     same thing the chat shows), sliced to AFTER the branch point: build_session on the thread sid
     (reachable via _sdk_sess's reg fallback — no names/ entry), events after the cut record's, the
     head system card never included (it sits before the cut by construction). [] pre-fork, same
-    guard as the plain projection."""
+    guard as the plain projection.
+
+    SERVED, not rebuilt, while the thread's inputs stand (2026-09-08): this ran a full build_session
+    for every non-promoted thread on every pusher cycle — fifty-odd cold reshapes of forked
+    transcripts per cycle on an idle box, the single largest slice of the pusher's burn (py-spy: the
+    _comments_frame → _thread_events → build_session → _read_task_store chain). The key is the WATCHED
+    tab's own exact key, _active_chat_sig (transcript and states stats, judge generation, task store,
+    pending cut, the backend's live revision and queue, the snapshot row), falling back to the
+    file-stat _chat_build_sig when the exact one cannot be formed, and the serve yields to _views_dirty
+    like every other served build. A thread with no keyable input (no transcript yet) is built every
+    time, never cached."""
     reg = _thread_reg(tsid)
     if reg.get("forkOf"):
         return []
+    tmux = tmux if tmux is not None else {}
+    _thread_fold_keep[1].add(tsid)              # this cycle's thread: _push keeps its fold prefix
+    sess = _sdk_sess(tsid, now)
+    tm = tmux.get(tsid)
+    key = None
     try:
-        m = build_session(tsid, now, tmux if tmux is not None else {})
+        base = _chat_build_sig(sess, tm)
+        asig = _active_chat_sig(sess, tm, now, base=base) if base is not None else None
+        key = ("exact", asig) if asig is not None else (("stat", base) if base is not None else None)
+    except Exception:
+        key = None                              # an input we cannot key → build, never cache
+    hit = _built_thread.get(tsid)
+    if key is not None and hit is not None and hit[0] == key and hit[1] == cut_uuid and _views_dirty[0] <= hit[3]:
+        _PERF_STATS.build("thread", True)
+        return list(hit[2])
+    started = time.time()
+    _t0 = time.monotonic()
+    try:
+        m = build_session(tsid, now, tmux)
     except Exception:
         return []
+    _PERF_STATS.build("thread", False, time.monotonic() - _t0)
     evs = (m or {}).get("events") or []
     if cut_uuid:
         at = next((i for i, e in enumerate(evs)
                    if e.get("uuid") == cut_uuid or e.get("resultUuid") == cut_uuid), None)
-        if at is None:
-            return []                              # the cut isn't in this transcript — never the copy
-        evs = evs[at + 1:]
+        evs = [] if at is None else evs[at + 1:]   # the cut isn't in this transcript — never the copy
     else:
         floor = int((_comment_thread_row_created(tsid) or 0))
         evs = [e for e in evs if not e.get("ts") or int(em.parse_z(e.get("ts")) or 0) >= floor]
-    return evs[-80:]
+    evs = evs[-80:]
+    # an EMPTY result for these inputs is as settled as a full one and is served the same way; only a
+    # build that RAISED (above) stays uncached, so a transient read fault retries on the next cycle
+    if key is not None:
+        if len(_built_thread) > 256:               # bounded by the thread count; evict oldest-inserted, never clear
+            _built_thread.pop(next(iter(_built_thread)))
+        _built_thread[tsid] = (key, cut_uuid, evs, started)
+    return list(evs)
 
 
 _comment_created_memo = {}                          # tsid -> createdT, for the tip-fork event floor
@@ -12912,7 +12991,7 @@ def _comments_frame(sid, tmux=None):
     be = _sdk()
     now = int(time.time())
     threads = []
-    for th in _load_comments(sid).get("threads") or []:
+    for th in _load_comments_cached(sid).get("threads") or []:
         tsid = str(th.get("sid") or "")
         status = th.get("status") or "open"
         _comment_created_memo[tsid] = int(th.get("createdT") or 0)
@@ -13070,7 +13149,7 @@ def _comment_markers(sid):
     if not p.exists():
         return []
     out = []
-    for th in _load_comments(sid).get("threads") or []:
+    for th in _load_comments_cached(sid).get("threads") or []:
         if (th.get("status") or "open") not in ("open", "resolved"):
             continue
         out.append({"t": th.get("anchorT") or th.get("createdT") or 0,
@@ -24675,7 +24754,13 @@ def _task_store_resolve(fsid, fold):
         if pairs <= have:
             hits.append(e.name)
     if len(hits) != 1:
+        # the negative memo the gate above reads (2026-09-08): it was declared and consulted since the join
+        # landed but never WRITTEN, so a session whose store cannot be joined re-read and re-decoded every
+        # store under the tasks root on every build (39 dirs, 301 files here) — for every comment thread,
+        # every cycle. Same fold pairs → same verdict until the fold changes (the docstring's own rule).
+        _task_join_miss[fsid] = pairs
         return None
+    _task_join_miss.pop(fsid, None)
     _task_dir_hint[fsid] = hits[0]
     return _task_store_dir(hits[0])
 
@@ -38304,10 +38389,17 @@ def _push(targets, connect=False, tmux=None):
                     _built_chat.pop(sid, None)
                     _prev_chat_events.pop(sid, None)
                     _prev_chat_ledger.pop(sid, None)
-            with _chat_fold_lock:                        # …and every fold entry for a sid no longer shown,
-                for sid in list(_chat_fold):             # including ones _built_chat never held (thread sids,
-                    if sid not in shown_sids:            # loadOlder / connect-push builds)
+            # …and every fold entry for a sid no longer shown (loadOlder / connect-push builds) — EXCEPT the
+            # comment THREADS the loop below is about to rebuild (2026-09-08): evicting their prefixes here
+            # made every thread build a cold reshape of the fork's whole copied history, every cycle. The
+            # keep set is what last cycle's comments loop touched; a thread that stops being built (resolved,
+            # promoted, its parent closed) ages out of it after one cycle and is evicted as before.
+            keep = shown_sids | _thread_fold_keep[0]
+            with _chat_fold_lock:
+                for sid in list(_chat_fold):
+                    if sid not in keep:
                         _chat_fold.pop(sid, None)
+            _thread_fold_keep[0], _thread_fold_keep[1] = _thread_fold_keep[1], set()
             _retry_parked_creates()   # lag-parked comment creates ride every pusher cycle (T106)
             # COMMENT THREADS: one {type:"comments"} frame per session that has ever had one (its
             # comments/ store exists — an ~free stat for everyone else). Each frame rides its OWN

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1398,17 +1398,38 @@ def _lines_from_end(p: Path, block: int = 65536):
         yield rest.decode("utf-8", "replace")
 
 
+_LAST_STATE_MEMO: dict = {}     # states path -> ((mtime_ns, size, ino), record): the tail decoded once per file version
+
+
 def last_state(state_dir: Path, sid: str) -> dict:
     """The literal last line of states/<sid>.jsonl as a record ({} when absent, blank, or unparseable).
     Reads the file's tail only (2026-09-03): every caller wanted the newest record and paid a full
     forward walk of a log that only ever grows — megabytes per call for a long-lived session, on the
-    kernel's push path."""
+    kernel's push path. And only when the file MOVED (2026-09-08): live_sessions asks for every dormant
+    reg's state on every liveness read — every pusher cycle and every GET /sessions — so an unchanged
+    log now costs one stat, not a tail read and a decode. The key is the file's (mtime_ns, size, ino);
+    a missing file drops the memo and reads as {} exactly as before. Callers get their own copy."""
     p = Path(state_dir) / "states" / (sid + ".jsonl")
     try:
+        st = os.stat(p)
+    except OSError:
+        _LAST_STATE_MEMO.pop(str(p), None)
+        return {}
+    key = (st.st_mtime_ns, st.st_size, st.st_ino)
+    hit = _LAST_STATE_MEMO.get(str(p))
+    if hit is not None and hit[0] == key:
+        return dict(hit[1])
+    try:
         line = next(_lines_from_end(p), "")
-        return json.loads(line) if line.strip() else {}
+        rec = json.loads(line) if line.strip() else {}
     except (OSError, ValueError):
         return {}
+    if not isinstance(rec, dict):
+        rec = {}
+    if len(_LAST_STATE_MEMO) > 2048:
+        _LAST_STATE_MEMO.clear()
+    _LAST_STATE_MEMO[str(p)] = (key, rec)
+    return dict(rec)
 
 
 def last_state_value(state_dir: Path, sid: str) -> str:

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -349,6 +349,38 @@ class ThreadProjection(CommentBase):
              "exact": "exponential backoff", "status": "open",
              "createdT": self.now - 400, "lastSeenT": seen if seen is not None else self.now}]})
 
+    def test_the_thread_build_is_served_while_its_inputs_stand_and_rebuilt_when_they_move(self):
+        # 2026-09-08: the popover's build_session ran for every thread on every pusher cycle; it is now
+        # served on the thread's exact change key (the active tab's own) and rebuilt when an input moves
+        self._seed_thread()
+        km._built_thread.clear()
+        km._views_dirty[0] = 0.0
+        calls = []
+        real = km.build_session
+        km.build_session = lambda sid, now, tm=None, **kw: (calls.append(sid), real(sid, now, tm, **kw))[1]
+        try:
+            fr1 = km._comments_frame(PARENT)
+            n1 = len(calls)
+            self.assertGreaterEqual(n1, 1, "the first frame builds the thread")
+            fr2 = km._comments_frame(PARENT)
+            self.assertEqual(len(calls), n1, "unchanged inputs: served, not rebuilt")
+            self.assertEqual(fr1["threads"][0].get("unread"), fr2["threads"][0].get("unread"), "the same frame")
+            recs = self._thread_records()
+            recs.append(aline(self.now - 5, "one more thought on jitter", "a9", parent=recs[-1]["uuid"]))
+            self._write(THREAD, recs)                  # a moved input (the thread's transcript)
+            km._parse_cache.clear()
+            km._comments_frame(PARENT)
+            self.assertEqual(len(calls), n1 + 1, "a moved input rebuilds once")
+            km._comments_frame(PARENT)
+            self.assertEqual(len(calls), n1 + 1, "…and is served again afterwards")
+            km._views_dirty[0] = time.time() + 1       # a kernel-side optimistic mutation rebuilds too
+            km._comments_frame(PARENT)
+            self.assertEqual(len(calls), n1 + 2)
+        finally:
+            km.build_session = real
+            km._views_dirty[0] = 0.0
+            km._built_thread.clear()
+
     def test_projection_starts_after_the_cut_and_strips_the_frame(self):
         self._seed_thread()
         msgs = km._thread_messages(THREAD, "a1")

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -339,11 +339,13 @@ class ThreadProjection(CommentBase):
                 aline(t + 110, "Jitter prevents thundering herds.", "ca1", parent="cu1"),
                 aline(t + 111, "It also spreads retries across the window.", "ca2", parent="ca1")]
 
-    def _seed_thread(self, records=None, seen=None):
-        self._write(THREAD, records or self._thread_records())
+    def _seed_thread(self, records=None, seen=None, last_sid=None):
+        """`last_sid` names the transcript the reg points at when it is not the thread sid itself: what a
+        resume (a new fsid) or a /clear leaves behind. The default is the fresh fork, lastSid == sid."""
+        self._write(last_sid or THREAD, records or self._thread_records())
         (jd.SDKDIR / (THREAD + ".json")).write_text(json.dumps(
             {"sid": THREAD, "name": "thread-x", "cwd": self.cdir,
-             "lastSid": THREAD, "alive": True, "threadOf": PARENT}))
+             "lastSid": last_sid or THREAD, "alive": True, "threadOf": PARENT}))
         km._save_comments(PARENT, {"threads": [
             {"tid": THREAD, "sid": THREAD, "anchorUuid": "a1", "cutUuid": "a1",
              "exact": "exponential backoff", "status": "open",
@@ -376,6 +378,67 @@ class ThreadProjection(CommentBase):
             km._views_dirty[0] = time.time() + 1       # a kernel-side optimistic mutation rebuilds too
             km._comments_frame(PARENT)
             self.assertEqual(len(calls), n1 + 2)
+        finally:
+            km.build_session = real
+            km._views_dirty[0] = 0.0
+            km._built_thread.clear()
+
+    def test_a_build_that_raises_stores_nothing_and_the_next_frame_rebuilds(self):
+        # a transient read fault mid-build must not be served as the thread's (empty) events: nothing is stored
+        # for it, the next frame builds again, and that good build is what gets served (review 2026-09-08)
+        self._seed_thread()
+        km._built_thread.clear()
+        km._views_dirty[0] = 0.0
+        calls = []
+        real = km.build_session
+
+        def flaky(sid, now, tm=None, **kw):
+            calls.append(sid)
+            if calls.count(THREAD) == 1 and sid == THREAD:
+                raise OSError(errno.EIO, "a transient read fault")
+            return real(sid, now, tm, **kw)
+
+        km.build_session = flaky
+        try:
+            fr1 = km._comments_frame(PARENT)
+            self.assertEqual(calls.count(THREAD), 1, "premise: the first frame built the thread once, and it raised")
+            self.assertEqual(fr1["threads"][0]["events"], [], "the raised build reads as no events this frame")
+            self.assertNotIn(THREAD, km._built_thread, "a raised build stores nothing")
+            km._comments_frame(PARENT)
+            self.assertEqual(calls.count(THREAD), 2, "the next frame rebuilds")
+            self.assertIn(THREAD, km._built_thread, "the good build is cached")
+            km._comments_frame(PARENT)
+            self.assertEqual(calls.count(THREAD), 2, "and served from then on")
+        finally:
+            km.build_session = real
+            km._views_dirty[0] = 0.0
+            km._built_thread.clear()
+
+    def test_a_states_write_under_the_thread_sid_rebuilds_a_thread_whose_lastsid_moved(self):
+        # After a resume or a /clear the reg's lastSid names a NEW transcript while the backend keeps writing the
+        # thread's state rows under the romp sid; keyed on the transcript's fsid alone, a states-only write (an
+        # interrupt settle's idle row, a retry marker) changed the events with no key change (review 2026-09-08)
+        resumed = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
+        self._seed_thread(last_sid=resumed)
+        km._built_thread.clear()
+        km._views_dirty[0] = 0.0
+        calls = []
+        real = km.build_session
+        km.build_session = lambda sid, now, tm=None, **kw: (calls.append(sid), real(sid, now, tm, **kw))[1]
+        try:
+            km._comments_frame(PARENT)
+            n1 = calls.count(THREAD)
+            self.assertGreaterEqual(n1, 1, "premise: the first frame builds the thread from the resumed transcript")
+            km._comments_frame(PARENT)
+            self.assertEqual(calls.count(THREAD), n1, "premise: served while nothing moved")
+            states = jd.STATE / "states" / (THREAD + ".jsonl")
+            states.parent.mkdir(parents=True, exist_ok=True)
+            with open(states, "a") as fh:
+                fh.write(json.dumps({"t": self.now, "state": "idle"}) + "\n")
+            km._comments_frame(PARENT)
+            self.assertEqual(calls.count(THREAD), n1 + 1, "a states-only write under the thread's own sid rebuilds")
+            km._comments_frame(PARENT)
+            self.assertEqual(calls.count(THREAD), n1 + 1, "and is served again afterwards")
         finally:
             km.build_session = real
             km._views_dirty[0] = 0.0

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -108,7 +108,7 @@ class Collector(unittest.TestCase):
             self.assertEqual(p[k], 0.0, k)
         self.assertEqual(p["ring_n"], 0)
         self.assertEqual(set(snap["stages_ms"]), set(km._PerfStats.STAGES))
-        self.assertEqual(set(snap["builds"]), {"chat", "feed", "timeline", "feedJson"})
+        self.assertEqual(set(snap["builds"]), {"chat", "feed", "timeline", "feedJson", "thread"})   # thread: the comment popover's build (2026-09-08)
         self.assertEqual(set(snap["sends"]), {"full", "delta", "deduped"})
         self.assertEqual(snap["judge"]["ms_mean"], 0.0, "no passes: the mean is 0, not a division error")
         self.assertIn("cpu_ms_sum", snap["judge"])

--- a/tests/test_pusher_change_gates.py
+++ b/tests/test_pusher_change_gates.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Change gates on the pusher's idle path (2026-09-08): waiting must not cost CPU.
+
+A profile of an idle devbox kernel (py-spy plus the kernel's own /perf) put most of a core into work whose
+inputs had not changed: every comment thread's chat rebuilt per cycle (tests/test_comment_threads.py pins
+that gate), the fold prefixes of those threads evicted just before they were rebuilt, the comments stores
+re-decoded per cycle, the tasks root re-scanned per build for a session whose store never joins (a negative
+memo declared and read but never written), the dormant regs' state tails re-read on every liveness read,
+and the working notes re-read on every GET /sessions (polled about once a second by every session's postal
+service). Each gate is stat-keyed: an unchanged input costs a stat; a moved input misses exactly.
+Synthetic sids and paths; hermetic state."""
+import json
+import os
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest import mock
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["ROMP_SERVE_TOKEN"] = "testtok"
+jd = SourceFileLoader("romp_judge_gates", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_gates", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_gates", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class CommentsStoreMemo(unittest.TestCase):
+    def setUp(self):
+        km._comments_memo.clear()
+        (jd.STATE / "comments").mkdir(parents=True, exist_ok=True)
+
+    def test_decoded_once_per_file_version_and_never_shared(self):
+        km._save_comments(SID, {"threads": [{"tid": "t1", "sid": "s1", "status": "open"}]})
+        real = km._load_comments
+        calls = []
+        km._load_comments = lambda sid: (calls.append(sid), real(sid))[1]
+        try:
+            a = km._load_comments_cached(SID)
+            b = km._load_comments_cached(SID)
+            self.assertEqual(calls, [SID], "one decode for two reads of the same file version")
+            self.assertEqual(a, b)
+            a["threads"].append({"tid": "junk"})
+            self.assertEqual(len(km._load_comments_cached(SID)["threads"]), 1, "a reader's copy leaks nowhere")
+            km._save_comments(SID, {"threads": []})          # a rewrite (a rename) moves the key
+            self.assertEqual(km._load_comments_cached(SID)["threads"], [])
+            self.assertEqual(len(calls), 2)
+        finally:
+            km._load_comments = real
+
+    def test_a_missing_store_reads_empty_and_drops_the_memo(self):
+        km._save_comments(SID, {"threads": [{"tid": "t1"}]})
+        km._load_comments_cached(SID)
+        os.unlink(km._comments_path(SID))
+        self.assertEqual(km._load_comments_cached(SID), {"threads": []})
+        self.assertNotIn(SID, km._comments_memo)
+
+    def test_the_read_only_callers_use_the_memo_and_the_writers_do_not(self):
+        import inspect
+        self.assertIn("_load_comments_cached(sid)", inspect.getsource(km._comments_frame))
+        self.assertIn("_load_comments_cached(sid)", inspect.getsource(km._comment_markers))
+        self.assertNotIn("_load_comments_cached", inspect.getsource(km._comment_thread), "writers read fresh")
+
+
+class TaskJoinMiss(unittest.TestCase):
+    """The negative memo _task_store_resolve reads was never written: same fold pairs, the whole tasks root
+    re-read on every call. The tasks root sits under the CLAUDE_CONFIG_DIR floor here."""
+
+    def setUp(self):
+        km._task_join_miss.clear(); km._task_dir_hint.clear()
+        self.root = km._task_store_dir("x").parent
+        self.root.mkdir(parents=True, exist_ok=True)
+        for name, tasks in (("session-aaaaaaaa", [(1, "alpha")]), ("session-bbbbbbbb", [(2, "beta")])):
+            d = self.root / name; d.mkdir(exist_ok=True)
+            for i, subj in tasks:
+                (d / ("%d.json" % i)).write_text(json.dumps({"id": str(i), "subject": subj}))
+
+    def _root_scans(self, scans):
+        return len([s for s in scans if s == str(self.root)])
+
+    def test_a_failed_join_is_remembered_until_the_fold_changes(self):
+        fold = [{"id": "7", "subject": "gamma"}]            # in no store: the join fails
+        scans = []
+        real = os.scandir
+        with mock.patch.object(km.os, "scandir", side_effect=lambda p: (scans.append(str(p)), real(p))[1]):
+            self.assertIsNone(km._task_store_resolve(SID, fold))
+            self.assertEqual(self._root_scans(scans), 1, "the first miss scans the root once")
+            self.assertIsNone(km._task_store_resolve(SID, fold))
+            self.assertEqual(self._root_scans(scans), 1, "the same fold does not rescan")
+            fold2 = [{"id": "7", "subject": "gamma"}, {"id": "8", "subject": "delta"}]
+            self.assertIsNone(km._task_store_resolve(SID, fold2))
+            self.assertEqual(self._root_scans(scans), 2, "a changed fold rescans")
+
+    def test_a_successful_join_clears_the_miss_memo(self):
+        fold = [{"id": "1", "subject": "alpha"}]
+        km._task_join_miss[SID] = {("9", "nothing")}
+        d = km._task_store_resolve(SID, fold)
+        self.assertEqual(d.name, "session-aaaaaaaa")
+        self.assertNotIn(SID, km._task_join_miss)
+
+
+class LastStateMemo(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        (Path(self.td) / "states").mkdir()
+        self.p = Path(self.td) / "states" / (SID + ".jsonl")
+        sb._LAST_STATE_MEMO.clear()
+
+    def test_the_tail_is_read_once_per_file_version(self):
+        self.p.write_text('{"state": "working", "t": 1}\n{"state": "waiting", "t": 2}\n')
+        reads = []
+        real = sb._lines_from_end
+        sb._lines_from_end = lambda p, block=65536: (reads.append(str(p)), real(p, block))[1]
+        try:
+            a = sb.last_state(Path(self.td), SID)
+            b = sb.last_state(Path(self.td), SID)
+            self.assertEqual(a, {"state": "waiting", "t": 2}); self.assertEqual(a, b)
+            self.assertEqual(len(reads), 1, "the second read is a stat")
+            a["state"] = "mutated"
+            self.assertEqual(sb.last_state(Path(self.td), SID)["state"], "waiting", "callers get copies")
+            with open(self.p, "a") as fh:
+                fh.write('{"state": "working", "t": 3}\n')
+            self.assertEqual(sb.last_state(Path(self.td), SID)["t"], 3, "an appended record is read")
+            self.assertEqual(len(reads), 2)
+        finally:
+            sb._lines_from_end = real
+
+    def test_a_missing_file_reads_empty_and_forgets(self):
+        self.p.write_text('{"state": "waiting", "t": 2}\n')
+        sb.last_state(Path(self.td), SID)
+        self.p.unlink()
+        self.assertEqual(sb.last_state(Path(self.td), SID), {})
+        self.assertNotIn(str(self.p), sb._LAST_STATE_MEMO)
+
+
+class WorkingNotesMemo(unittest.TestCase):
+    def setUp(self):
+        km._working_notes_memo[0] = None
+        km.WORKING_DIR.mkdir(parents=True, exist_ok=True)
+        for f in km.WORKING_DIR.iterdir():
+            f.unlink()
+
+    def test_read_once_per_directory_version(self):
+        (km.WORKING_DIR / SID).write_text("editing the notes API\n")
+        real = Path.read_text
+        reads = []
+        with mock.patch.object(Path, "read_text", lambda self, *a, **k: (reads.append(str(self)), real(self, *a, **k))[1]):
+            a = km._working_notes(); b = km._working_notes()
+            self.assertEqual(a, {SID: "editing the notes API"}); self.assertEqual(a, b)
+            self.assertEqual(len(reads), 1)
+            (km.WORKING_DIR / SID).write_text("done, idle\n")
+            st = os.stat(km.WORKING_DIR / SID); os.utime(km.WORKING_DIR / SID, ns=(st.st_atime_ns, st.st_mtime_ns + 10_000_000))
+            self.assertEqual(km._working_notes()[SID], "done, idle")
+            (km.WORKING_DIR / SID).unlink()
+            self.assertEqual(km._working_notes(), {}, "a removed note is gone at once")
+
+
+class FoldEvictionKeepsThreads(unittest.TestCase):
+    def test_push_keeps_the_fold_prefixes_of_last_cycles_threads(self):
+        import inspect
+        src = inspect.getsource(km._push)
+        self.assertIn("keep = shown_sids | _thread_fold_keep[0]", src)
+        self.assertIn("_thread_fold_keep[0], _thread_fold_keep[1] = _thread_fold_keep[1], set()", src)
+        self.assertIn("_thread_fold_keep[1].add(tsid)", inspect.getsource(km._thread_events))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pusher_change_gates.py
+++ b/tests/test_pusher_change_gates.py
@@ -9,8 +9,10 @@ memo declared and read but never written), the dormant regs' state tails re-read
 and the working notes re-read on every GET /sessions (polled about once a second by every session's postal
 service). Each gate is stat-keyed: an unchanged input costs a stat; a moved input misses exactly.
 Synthetic sids and paths; hermetic state."""
+import contextlib
 import json
 import os
+import shutil
 import tempfile
 import time
 import unittest
@@ -22,6 +24,11 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)
+# The tasks root TaskJoinMiss writes under is $CLAUDE_CONFIG_DIR/tasks (default ~/.claude/tasks): floored here
+# like the state root, before the loads, so a bare `python` or `pytest --noconftest` run never writes its
+# synthetic stores into a developer's live ~/.claude (it did, review 2026-09-08). Under pytest, conftest's
+# per-test fixture re-asserts its own floor; either way the root is a temp dir.
+os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ["ROMP_SERVE_TOKEN"] = "testtok"
 jd = SourceFileLoader("romp_judge_gates", os.path.join(BIN, "romp-judge")).load_module()
@@ -48,8 +55,12 @@ class CommentsStoreMemo(unittest.TestCase):
             self.assertEqual(a, b)
             a["threads"].append({"tid": "junk"})
             self.assertEqual(len(km._load_comments_cached(SID)["threads"]), 1, "a reader's copy leaks nowhere")
+            st0 = os.stat(km._comments_path(SID))
             km._save_comments(SID, {"threads": []})          # a rewrite (a rename) moves the key
-            self.assertEqual(km._load_comments_cached(SID)["threads"], [])
+            # pinned back to the PREVIOUS mtime_ns: the size and the inode still differ, and they must carry the
+            # miss on their own (a same-tick rename-publish is exactly the case the three-part key exists for)
+            os.utime(km._comments_path(SID), ns=(st0.st_atime_ns, st0.st_mtime_ns))
+            self.assertEqual(km._load_comments_cached(SID)["threads"], [], "the new content is read on size and inode alone")
             self.assertEqual(len(calls), 2)
         finally:
             km._load_comments = real
@@ -70,32 +81,73 @@ class CommentsStoreMemo(unittest.TestCase):
 
 class TaskJoinMiss(unittest.TestCase):
     """The negative memo _task_store_resolve reads was never written: same fold pairs, the whole tasks root
-    re-read on every call. The tasks root sits under the CLAUDE_CONFIG_DIR floor here."""
+    re-read on every call. The tasks root is $CLAUDE_CONFIG_DIR/tasks, floored to a temp dir by this module's
+    preamble (and by conftest under pytest); tearDown removes the stores setUp and the tests wrote."""
 
     def setUp(self):
         km._task_join_miss.clear(); km._task_dir_hint.clear()
         self.root = km._task_store_dir("x").parent
+        self._root_was_there = self.root.exists()
         self.root.mkdir(parents=True, exist_ok=True)
-        for name, tasks in (("session-aaaaaaaa", [(1, "alpha")]), ("session-bbbbbbbb", [(2, "beta")])):
-            d = self.root / name; d.mkdir(exist_ok=True)
-            for i, subj in tasks:
-                (d / ("%d.json" % i)).write_text(json.dumps({"id": str(i), "subject": subj}))
+        self.made = []
+        self._store("session-aaaaaaaa", [(1, "alpha")])
+        self._store("session-bbbbbbbb", [(2, "beta")])
 
-    def _root_scans(self, scans):
-        return len([s for s in scans if s == str(self.root)])
+    def tearDown(self):
+        for d in self.made:
+            shutil.rmtree(d, ignore_errors=True)
+        if not self._root_was_there:
+            shutil.rmtree(self.root, ignore_errors=True)
+        km._task_join_miss.clear(); km._task_dir_hint.clear()
 
-    def test_a_failed_join_is_remembered_until_the_fold_changes(self):
+    def _store(self, name, tasks):
+        d = self.root / name; d.mkdir(exist_ok=True); self.made.append(d)
+        for i, subj in tasks:
+            (d / ("%d.json" % i)).write_text(json.dumps({"id": str(i), "subject": subj}))
+        return d
+
+    def test_a_failed_join_is_remembered_until_the_fold_or_the_root_changes(self):
+        # the root scan (a scandir plus a stat per store dir) runs on every call by design: it is the memo's
+        # second key; what the memo saves is listing and decoding every task file under every store
         fold = [{"id": "7", "subject": "gamma"}]            # in no store: the join fails
-        scans = []
-        real = os.scandir
-        with mock.patch.object(km.os, "scandir", side_effect=lambda p: (scans.append(str(p)), real(p))[1]):
+        listed = []
+        real = os.listdir
+        with mock.patch.object(km.os, "listdir", side_effect=lambda p: (listed.append(str(p)), real(p))[1]):
             self.assertIsNone(km._task_store_resolve(SID, fold))
-            self.assertEqual(self._root_scans(scans), 1, "the first miss scans the root once")
+            self.assertEqual(len(listed), 2, "the first miss reads every store once")
+            self.assertEqual(km._task_join_miss[SID][0], {("7", "gamma")}, "the memo carries the pairs...")
+            self.assertEqual(sorted(n for n, _m in km._task_join_miss[SID][1]), ["session-aaaaaaaa", "session-bbbbbbbb"],
+                             "...and the root's listing")
             self.assertIsNone(km._task_store_resolve(SID, fold))
-            self.assertEqual(self._root_scans(scans), 1, "the same fold does not rescan")
+            self.assertEqual(len(listed), 2, "the same fold under the same root does not re-read the stores")
             fold2 = [{"id": "7", "subject": "gamma"}, {"id": "8", "subject": "delta"}]
             self.assertIsNone(km._task_store_resolve(SID, fold2))
-            self.assertEqual(self._root_scans(scans), 2, "a changed fold rescans")
+            self.assertEqual(len(listed), 4, "a changed fold re-reads")
+
+    def test_a_miss_a_read_fault_produced_is_not_remembered(self):
+        # a task file mid-rewrite decodes as nothing, so its pair is missing and the join fails; remembered, that
+        # transient miss held until the fold next changed (status updates never change the pairs), and the todo
+        # card showed the store as unreadable for the rest of the session (review 2026-09-08)
+        fold = [{"id": "1", "subject": "alpha"}]
+        (self.root / "session-aaaaaaaa" / "1.json").write_text('{"id": "1", "sub')      # a partial write
+        self.assertIsNone(km._task_store_resolve(SID, fold))
+        self.assertNotIn(SID, km._task_join_miss, "a fault is not a verdict")
+        (self.root / "session-aaaaaaaa" / "1.json").write_text(json.dumps({"id": "1", "subject": "alpha"}))
+        d = km._task_store_resolve(SID, fold)
+        self.assertEqual(d.name, "session-aaaaaaaa", "the next call joins")
+        self.assertNotIn(SID, km._task_join_miss)
+
+    def test_a_store_that_appears_after_a_genuine_miss_joins_on_the_next_call(self):
+        # Claude Code writes the store a moment after the TaskCreate the fold saw: the pairs do not change, the
+        # root's listing does, and that is the memo's second key (review 2026-09-08)
+        fold = [{"id": "3", "subject": "gamma"}]
+        self.assertIsNone(km._task_store_resolve(SID, fold))
+        self.assertIn(SID, km._task_join_miss, "premise: a genuine miss is remembered")
+        self._store("session-cccccccc", [(3, "gamma")])
+        d = km._task_store_resolve(SID, fold)
+        self.assertIsNotNone(d, "the appeared store is found without the fold changing")
+        self.assertEqual(d.name, "session-cccccccc")
+        self.assertNotIn(SID, km._task_join_miss)
 
     def test_a_successful_join_clears_the_miss_memo(self):
         fold = [{"id": "1", "subject": "alpha"}]
@@ -122,8 +174,8 @@ class LastStateMemo(unittest.TestCase):
             b = sb.last_state(Path(self.td), SID)
             self.assertEqual(a, {"state": "waiting", "t": 2}); self.assertEqual(a, b)
             self.assertEqual(len(reads), 1, "the second read is a stat")
-            a["state"] = "mutated"
-            self.assertEqual(sb.last_state(Path(self.td), SID)["state"], "waiting", "callers get copies")
+            a["state"] = "mutated"; b["state"] = "mutated too"       # the build-path result AND the hit-path one
+            self.assertEqual(sb.last_state(Path(self.td), SID)["state"], "waiting", "callers get copies on both paths")
             with open(self.p, "a") as fh:
                 fh.write('{"state": "working", "t": 3}\n')
             self.assertEqual(sb.last_state(Path(self.td), SID)["t"], 3, "an appended record is read")
@@ -154,19 +206,108 @@ class WorkingNotesMemo(unittest.TestCase):
             a = km._working_notes(); b = km._working_notes()
             self.assertEqual(a, {SID: "editing the notes API"}); self.assertEqual(a, b)
             self.assertEqual(len(reads), 1)
+            a[SID] = "mutated"; b.pop(SID)                           # the build-path result AND the hit-path one
+            self.assertEqual(km._working_notes(), {SID: "editing the notes API"}, "callers get copies on both paths")
             (km.WORKING_DIR / SID).write_text("done, idle\n")
             st = os.stat(km.WORKING_DIR / SID); os.utime(km.WORKING_DIR / SID, ns=(st.st_atime_ns, st.st_mtime_ns + 10_000_000))
             self.assertEqual(km._working_notes()[SID], "done, idle")
             (km.WORKING_DIR / SID).unlink()
             self.assertEqual(km._working_notes(), {}, "a removed note is gone at once")
 
+    def test_a_note_that_vanishes_between_readdir_and_stat_costs_only_itself(self):
+        # one try around the whole listing returned {} for the call, and every live session read as owning
+        # nothing (which the postal contract takes as free ownership); the vanished entry alone is skipped
+        gone = "11111111-2222-3333-4444-666666666666"
+        (km.WORKING_DIR / SID).write_text("editing the notes API\n")
+        (km.WORKING_DIR / gone).write_text("unlinked by a clear before the stat\n")
+        real = os.scandir
+
+        class Vanished:
+            def __init__(self, e):
+                self.name, self.path = e.name, e.path
+
+            def stat(self, *a, **k):
+                raise FileNotFoundError(self.path)
+
+        @contextlib.contextmanager
+        def scan(p):
+            with real(p) as it:
+                yield (Vanished(e) if e.name == gone else e for e in it)
+
+        with mock.patch.object(km.os, "scandir", scan):
+            self.assertEqual(km._working_notes(), {SID: "editing the notes API"}, "the other note is still returned")
+
 
 class FoldEvictionKeepsThreads(unittest.TestCase):
+    """_push evicts every fold entry whose sid is not a shown tab, EXCEPT the comment threads the previous
+    cycle's comments loop built: evicting those made every thread build a cold reshape. Pinned at the source
+    and driven for real (the test_chat_empty_build_guard.py harness: one chat client, one tab, the builders
+    and the sends stubbed)."""
+
+    PSID = "11111111-2222-3333-4444-777777777777"           # the one shown tab
+    TSID = "66666666-7777-8888-9999-aaaaaaaaaaaa"           # a thread: never a tab
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.td.name, self.PSID + ".jsonl")
+        with open(self.path, "w") as f:
+            f.write("{}\n")                                 # stat-able: the build cache keys on it
+        self.sess = {"sid": self.PSID, "name": "web", "anchor": None, "path": self.path, "mtime": 0}
+        self.tmux = {self.PSID: {"state": "waiting", "color": "#888888", "since": 0, "model": "", "effort": "",
+                                 "context": None, "backend": "tmux"}}
+        self.client = {"app": "chat", "alive": True, "sent": {}, "send": lambda s: None}
+        self._saved_keep = [set(km._thread_fold_keep[0]), set(km._thread_fold_keep[1])]
+        km._thread_fold_keep[0], km._thread_fold_keep[1] = set(), set()
+        self._forget()
+
+    def tearDown(self):
+        km._thread_fold_keep[0], km._thread_fold_keep[1] = self._saved_keep
+        self._forget()
+        self.td.cleanup()
+
+    def _forget(self):
+        with km._chat_fold_lock:
+            km._chat_fold.pop(self.TSID, None)
+        for d in (km._built_chat, km._prev_chat_events, km._prev_chat_ledger):
+            d.pop(self.PSID, None)
+
+    def _cycle(self):
+        frame = {"type": "session", "id": self.PSID, "name": "web", "color": None, "status": {"state": "ready"},
+                 "ledger": None, "events": [{"kind": "assistant", "uuid": "11111111-2222-3333-4444-0000000000a1", "md": "hi"}]}
+        with mock.patch.object(km, "_alive_sessions", lambda now, tm: [dict(self.sess)]), \
+                mock.patch.object(km, "_chat_tab_sessions", lambda now, tm: [dict(self.sess)]), \
+                mock.patch.object(km, "_warm_fleet_bg", lambda now: None), \
+                mock.patch.object(km, "_tmux_sessions", lambda: dict(self.tmux)), \
+                mock.patch.object(km, "build_session", lambda sid, now, tmux=None, **kw: dict(frame)), \
+                mock.patch.object(km, "_cached_feed", lambda *a, **k: {"working": [], "awaiting": [], "asks": []}), \
+                mock.patch.object(km, "_send_client", lambda c, key, msg, pre=None, sig=None, kind="full": None):
+            km._push([self.client], tmux=self.tmux)
+
+    def _held(self):
+        with km._chat_fold_lock:
+            return self.TSID in km._chat_fold
+
+    def test_a_thread_built_last_cycle_keeps_its_fold_prefix_and_ages_out_after_one_idle_cycle(self):
+        km._chat_fold_put(self.TSID, {"probe": 1})
+        km._thread_fold_keep[1].add(self.TSID)              # what a thread build does inside a cycle's comments loop
+        self._cycle()
+        self.assertTrue(self._held(), "the thread the previous cycle built keeps its prefix")
+        km._thread_fold_keep[1].add(self.TSID)              # built again this cycle
+        self._cycle()
+        self.assertTrue(self._held(), "a thread built every cycle is never evicted")
+        self._cycle()                                       # nothing rebuilt it
+        self.assertFalse(self._held(), "a thread that stopped being built is evicted after one cycle")
+
     def test_push_keeps_the_fold_prefixes_of_last_cycles_threads(self):
         import inspect
         src = inspect.getsource(km._push)
-        self.assertIn("keep = shown_sids | _thread_fold_keep[0]", src)
-        self.assertIn("_thread_fold_keep[0], _thread_fold_keep[1] = _thread_fold_keep[1], set()", src)
+        swap = "_thread_fold_keep[0], _thread_fold_keep[1] = _thread_fold_keep[1], set()"
+        keep = "keep = shown_sids | _thread_fold_keep[0]"
+        self.assertIn(keep, src)
+        self.assertIn(swap, src)
+        self.assertIn("if sid not in keep:", src, "the eviction tests the keep set, not the shown tabs")
+        self.assertLess(src.index(swap), src.index(keep),
+                        "the swap runs BEFORE the eviction, so the keep set is last cycle's, not the one before")
         self.assertIn("_thread_fold_keep[1].add(tsid)", inspect.getsource(km._thread_events))
 
 


### PR DESCRIPTION
## What

The kernel at idle burned most of a core and grew past 5 GB resident on the maintainer's devbox. Measured before any change, from the kernel's `/perf` route and `/proc`:

| measure (13 min after boot) | before |
|---|---|
| kernel CPU | 752 s user + 95 s sys over 847 s wall (about 88% of a core) |
| pusher thread busy | 99% of cycles, cycle p50 6.6 s |
| timeline builds | 84 built, 0 served from cache |
| resident set | 4.4 GB, plus 1.4 GB swap |
| after a restart | 5.3 GB resident at 3 min, 5.7 GB at 6 min, CPU near a full core |

The profile put the idle cost in the pusher re-reading and re-deriving inputs that had not changed. This PR is the first of two batches and adds six change gates to the pusher's idle path, each keyed on the stat of the files it reads (mtime, size, inode) or on the chat build signature the kernel already keeps. Every pushed payload is byte-identical to what the ungated code produced whenever the inputs are unchanged, and any input change produces the fresh result in the same cycle it used to. Memos hand out copies, never their own objects.

- **Thread event slices** (`_thread_events`): served while the thread's chat build signature, its clip and the views-dirty mark stand. This was the largest single item: every comments frame rebuilt every thread's session every cycle.
- **Comments stores** (`_load_comments_cached`): the per-session comments file is parsed once per (mtime, size, inode); callers get a deep copy. Writers are unchanged and still publish by atomic rename.
- **Chat-fold eviction**: the thread sids the previous cycle's comments loop touched are kept, so their folds are not evicted and rebuilt every cycle.
- **Task-store join** (`_task_store_resolve`): a failed join is remembered against the fold pairs that produced it, so an unjoinable store is not re-scanned every cycle; a successful join clears the mark.
- **State tails** (`sdk_backend.last_state`): the states file tail is memoized on its stat, bounded.
- **Working notes** (`_working_notes`): memoized on every entry's stat.

The second batch (the timeline's dead-lane memo, which also drops dead sessions' parses from the parse cache, the resident-memory lever) follows as its own PR. After-numbers for CPU and resident set over an hour will be posted as a comment here once this lands and the devbox converges.

## Tier

`fix`: behaviour is unchanged by design; the work is the pusher doing less of it.

## Tests

- `tests/test_pusher_change_gates.py` (new): the comments-store memo (stat-keyed, copies out, missing file), the task-join miss mark, the state-tail memo, the working-notes memo, and the fold eviction keeping touched threads.
- `tests/test_comment_threads.py`: the thread build is served while its inputs stand and rebuilt when they move (counts session builds).
- `tests/test_perf_stats.py`: the `/perf` builds set includes the thread build kind.

Focused suites: 295 passed. Full suite on the two-batch branch: 9729 passed, 52 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
