### PR TITLE
Scroll journal: a tail element leaving the DOM, even within one frame, files a row

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -58,7 +58,7 @@ import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDown
 import { followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow, followTailShrink } from "./scroll-keep";
 import { retainLiveOmitted } from "./tab-order";
 import { userTurnShows } from "./user-turn-content";
-import { ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap } from "./scroll-write";
+import { ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap, summarizeTailMutations, tailMutRow } from "./scroll-write";
 import { reloadScrollRecord, takeReloadScroll, type ReloadScroll } from "./reload-restore";
 import { keepResidentEvents } from "./frame-merge";
 import { activeTabToReannounce } from "./relay-active";
@@ -1036,7 +1036,7 @@ let landTrail: string[] = [];
 // count is NOT len − winStart + spacer: a unit may own more than one node (the day
 // divider that opens a new day precedes its turn), so anything mapping DOM back to
 // units reads data-unit off the node rather than counting children.
-interface View { el: HTMLElement; rendered: number; scrollTop: number; stick: boolean; shown: boolean; stale: boolean; winStart: number; winEnd?: number; avgTurnH?: number; spacerCount?: number; spacerCountBot?: number; unitTotal?: number; working?: boolean; ro?: ResizeObserver; }   // working: the session's state at the last sync, the "worked …" footer's one non-event input (syncViewInner)
+interface View { el: HTMLElement; rendered: number; scrollTop: number; stick: boolean; shown: boolean; stale: boolean; winStart: number; winEnd?: number; avgTurnH?: number; spacerCount?: number; spacerCountBot?: number; unitTotal?: number; working?: boolean; ro?: ResizeObserver; mo?: MutationObserver; }   // working: the session's state at the last sync, the "worked …" footer's one non-event input (syncViewInner)
 const views = new Map<string, View>();
 
 // Pending pickers (AskUserQuestion / tool-permission) keyed by session id. These
@@ -9403,10 +9403,19 @@ function nearBottomForSend(c: HTMLElement): boolean {
 // view files nothing. The value written is applied exactly as before: this changes nothing about WHERE the view
 // lands, only that the landing is on the record.
 let lastScrollWriteAfter: number | null = null;
+let lastKnownSh = 0;   // the last scroll height the pane recorded (every write, every scroll event): the "before" a tail mutation row reports
+/** Reduce a MutationObserver batch on a tail container to the row's shape (scroll-write.ts summarizeTailMutations). */
+function tailMutations(records: MutationRecord[]): { removedTail: string[]; addedTail: string[]; reAdded: boolean } | null {
+  return summarizeTailMutations(records.map((r) => ({
+    removed: Array.from(r.removedNodes).map((n) => ({ cls: n instanceof Element ? n.className : n.nodeName, node: n })),
+    added: Array.from(r.addedNodes).map((n) => ({ cls: n instanceof Element ? n.className : n.nodeName, node: n })),
+    atEnd: r.nextSibling === null,
+  })).map((m) => ({ removed: m.removed, added: m.added, atEnd: m.atEnd })));
+}
 // the cap is the default unless the page's localStorage says otherwise (a laptop capturing raises it; T262j)
 const scrollDiagCap = readScrollDiagCap((k) => { try { return localStorage.getItem(k); } catch { return null; } });
 const scrollDiag = new ScrollDiagBudget(scrollDiagCap);
-function scrollDiagRow(kind: "scrollwrite" | "scrollgesture" | "tailchange" | "spacer", data: any): void {
+function scrollDiagRow(kind: "scrollwrite" | "scrollgesture" | "tailchange" | "spacer" | "tailmut", data: any): void {
   const v = scrollDiag.take(activeId || "", kind, Date.now());
   if (v === "drop") return;
   vscodeApi?.postMessage(v === "cap"
@@ -9418,6 +9427,7 @@ function writeScroll(content: HTMLElement, top: number, writer: string, stick = 
   content.scrollTop = top;
   const after = content.scrollTop;
   lastScrollWriteAfter = after;
+  lastKnownSh = content.scrollHeight;
   if (after !== before) scrollDiagRow("scrollwrite", scrollWriteRow(activeId || "", writer, before, after, stick, content.scrollHeight, content.clientHeight));
 }
 // EVERY mover of #content goes through writeScroll (T262j, the user 2026-09-08: an unwritten move the journal could
@@ -9769,6 +9779,20 @@ function ensureView(id: string): View {
         lastH = h;
       });
       v.ro.observe(elv);
+      // …and a MutationObserver (T262j): a tail node removed and re-appended within one task is invisible to the
+      // ResizeObserver (frame-end sizes only) yet clamps the reader if a layout is forced in between — the remaining
+      // snap's shape. Every removal at the END of the active view files a tailmut row: what left, whether it came
+      // back in the same task, the scroll height the pane last recorded and the one after.
+      const view2 = v;
+      v.mo = new MutationObserver((records) => {
+        if (activeId !== id || !view2.shown) return;
+        const m = tailMutations(records);
+        if (!m) return;
+        const content = document.getElementById("content");
+        if (!content) return;
+        scrollDiagRow("tailmut", tailMutRow(id, m, lastKnownSh, content.scrollHeight, content.scrollTop, content.clientHeight, "view"));
+      });
+      v.mo.observe(elv, { childList: true });
     }
     views.set(id, v);
   }
@@ -10783,7 +10807,8 @@ window.addEventListener("resize", updateJumpBtn);
     // the scroll nobody's code asked for is the user's (T262): filed so a recording lines up with the journal;
     // a write's own echo (within a pixel of the value written) is consumed here and never read as a gesture
     if (classifyScroll(c.scrollTop, lastScrollWriteAfter) === "write-echo") lastScrollWriteAfter = null;
-    else scrollDiagRow("scrollgesture", { sid: activeId || "", top: c.scrollTop, gesture: true, sh: c.scrollHeight, ch: c.clientHeight });   // sh/ch: a clamp reads top == sh - ch after sh dropped (T262e)
+    else scrollDiagRow("scrollgesture", { sid: activeId || "", top: c.scrollTop, gesture: true, sh: c.scrollHeight, ch: c.clientHeight });
+    lastKnownSh = c.scrollHeight;   // sh/ch: a clamp reads top == sh - ch after sh dropped (T262e)
   }, { passive: true });
 }
 // The live-ask host (#live-ask) sits INSIDE #content after the threads: the picker card is the transcript's tail
@@ -10792,6 +10817,14 @@ window.addEventListener("resize", updateJumpBtn);
 if (typeof ResizeObserver === "function") {
   const tailHost = document.getElementById("live-ask");
   if (tailHost) {
+    // the card leaving (even for part of a frame) is a tail removal like any other (T262j)
+    const tailMo = new MutationObserver((records) => {
+      const m = tailMutations(records);
+      const content = document.getElementById("content");
+      if (!m || !content || !activeId) return;
+      scrollDiagRow("tailmut", tailMutRow(activeId, m, lastKnownSh, content.scrollHeight, content.scrollTop, content.clientHeight, "live-ask"));
+    });
+    tailMo.observe(tailHost, { childList: true });
     let tailLastH = -1;
     new ResizeObserver((entries) => {
       const h = entries[0]?.contentRect?.height ?? 0;
@@ -13846,7 +13879,7 @@ function upsert(msg: any) {
   }
   if (forked) {
     const v = views.get(msg.id);
-    if (v) { v.ro?.disconnect(); v.el.remove(); views.delete(msg.id); }
+    if (v) { v.ro?.disconnect(); v.mo?.disconnect(); v.el.remove(); views.delete(msg.id); }
   } else if (existed && !kept) {
     // A full frame replaces every event object and can differ from what this view rendered ANYWHERE (it is
     // what the kernel sends a client it believes is behind): the tail path trusts v.rendered as the exact
@@ -14296,7 +14329,7 @@ function dismissSession(id: string, why: DismissWhy, doomed?: ReadonlySet<string
     persistDrafts();   // a host drop / omission KEEPS it all (see DismissWhy) — the stash above may have updated the copy
   }
   const v = views.get(id);
-  if (v) { v.ro?.disconnect(); v.el.remove(); views.delete(id); }
+  if (v) { v.ro?.disconnect(); v.mo?.disconnect(); v.el.remove(); views.delete(id); }
   const oi = order.indexOf(id); if (oi >= 0) order.splice(oi, 1);
   const mi = mru.indexOf(id); if (mi >= 0) mru.splice(mi, 1);   // before the fallback read below — never the dead id
   renderTabs();                          // tab removed from `order` above → repaint without it

--- a/ui/webview/scroll-keep-on-show.test.ts
+++ b/ui/webview/scroll-keep-on-show.test.ts
@@ -79,7 +79,7 @@ test("render.ts: the reshow decision counts a live durable seek for the tab as n
 test("render.ts: the #content scroll listener keeps the active view's saved spot current (passive, no timer)", () => {
   assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow, followTailShrink \} from "\.\/scroll-keep";/);   // + followTail (T262: follow only on new content)
   // …and stands down while a deferred build is pending: the reveal's clamp fires a scroll event before the land
-  assert.match(RENDER, /c\.addEventListener\("scroll", \(\) => \{\n\s*if \(c\.clientHeight <= 0\) return;\n\s*followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, atBottom\(c\), pendingBuildRaf != null\);\n(?:.*\n){0,4}?\s*\}, \{ passive: true \}\);/);
+  assert.match(RENDER, /c\.addEventListener\("scroll", \(\) => \{\n\s*if \(c\.clientHeight <= 0\) return;\n\s*followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, atBottom\(c\), pendingBuildRaf != null\);\n(?:.*\n){0,5}?\s*\}, \{ passive: true \}\);/);
   // landActive's landing rule itself is unchanged — its INPUT is what the fix repairs
   assert.match(RENDER, /if \(!v\.shown \|\| v\.stick\) writeScroll\(content, content\.scrollHeight, "land-bottom", true\);\n\s*else writeScroll\(content, v\.scrollTop, "land-saved"\);/);   // (T262: every #content write rides writeScroll)
 });

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -88,7 +88,7 @@ test("a rendered unit changing height re-runs the shared paint — the event the
   // the observer's first statement is still the paint; the same callback carries the tail-shrink rule (T262f)
   assert.match(ev, /v\.ro = new ResizeObserver\(\(entries\) => \{\s*\n\s*scheduleRailSticky\(\);[\s\S]*?\n\s*\}\);\s*\n\s*v\.ro\.observe\(elv\);/,
     "one observer per view element: a lazy figure sizing in or a fold toggling repaints notches AND rail ticks");
-  assert.match(RENDER, /ro\?: ResizeObserver; \}/, "the View carries its observer");
+  assert.match(RENDER, /ro\?: ResizeObserver; mo\?: MutationObserver; \}/, "the View carries its observers (the tail mutation one joined it, T262j)");
   assert.equal((RENDER.match(/v\.ro\?\.disconnect\(\); v\.el\.remove\(\);/g) || []).length, 2, "both view-removal sites disconnect it");
   assert.doesNotMatch(ev, /setTimeout|setInterval/, "no timer stands in for the event");
 });

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -89,7 +89,7 @@ test("a rendered unit changing height re-runs the shared paint — the event the
   assert.match(ev, /v\.ro = new ResizeObserver\(\(entries\) => \{\s*\n\s*scheduleRailSticky\(\);[\s\S]*?\n\s*\}\);\s*\n\s*v\.ro\.observe\(elv\);/,
     "one observer per view element: a lazy figure sizing in or a fold toggling repaints notches AND rail ticks");
   assert.match(RENDER, /ro\?: ResizeObserver; mo\?: MutationObserver; \}/, "the View carries its observers (the tail mutation one joined it, T262j)");
-  assert.equal((RENDER.match(/v\.ro\?\.disconnect\(\); v\.el\.remove\(\);/g) || []).length, 2, "both view-removal sites disconnect it");
+  assert.equal((RENDER.match(/v\.ro\?\.disconnect\(\); v\.mo\?\.disconnect\(\); v\.el\.remove\(\);/g) || []).length, 2, "both view-removal sites disconnect it (and the tail mutation observer beside it, T262j)");
   assert.doesNotMatch(ev, /setTimeout|setInterval/, "no timer stands in for the event");
 });
 

--- a/ui/webview/scroll-movers.test.ts
+++ b/ui/webview/scroll-movers.test.ts
@@ -49,6 +49,6 @@ test("render.ts: every mover of #content is a writeScroll — scrollBy and scrol
 test("render.ts: a spacer re-size of the active view files a spacer row; the cap comes from localStorage", () => {
   assert.match(RENDER, /if \(\(topAfter !== topBefore \|\| botAfter !== botBefore\) && activeId && views\.get\(activeId\) === v\) \{\s*\n\s*const content = document\.getElementById\("content"\);\s*\n\s*scrollDiagRow\("spacer", spacerRow\(activeId, topBefore, topAfter, botBefore, botAfter,/);
   assert.match(RENDER, /const scrollDiagCap = readScrollDiagCap\(\(k\) => \{ try \{ return localStorage\.getItem\(k\); \} catch \{ return null; \} \}\);\s*\n\s*const scrollDiag = new ScrollDiagBudget\(scrollDiagCap\);/);
-  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer", data: any\): void \{/);
+  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut", data: any\): void \{/);
   assert.match(RENDER, /data: \{ sid: activeId \|\| "", perMinute: scrollDiagCap \} \}/, "the capped row says which cap");
 });

--- a/ui/webview/scroll-write.test.ts
+++ b/ui/webview/scroll-write.test.ts
@@ -40,8 +40,8 @@ test("the row names the writer and carries before/after/delta/stick, gesture:fal
 });
 
 test("render.ts: one helper writes #content.scrollTop, files the row only when the view moved, and no raw write remains", () => {
-  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap \} from "\.\/scroll-write";/);
-  assert.match(RENDER, /function writeScroll\(content: HTMLElement, top: number, writer: string, stick = false\): void \{\s*\n\s*const before = content\.scrollTop;\s*\n\s*content\.scrollTop = top;\s*\n\s*const after = content\.scrollTop;\s*\n\s*lastScrollWriteAfter = after;\s*\n\s*if \(after !== before\) scrollDiagRow\("scrollwrite", scrollWriteRow\(activeId \|\| "", writer, before, after, stick, content\.scrollHeight, content\.clientHeight\)\);/);
+  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap, summarizeTailMutations, tailMutRow \} from "\.\/scroll-write";/);
+  assert.match(RENDER, /function writeScroll\(content: HTMLElement, top: number, writer: string, stick = false\): void \{\s*\n\s*const before = content\.scrollTop;\s*\n\s*content\.scrollTop = top;\s*\n\s*const after = content\.scrollTop;\s*\n\s*lastScrollWriteAfter = after;\s*\n\s*lastKnownSh = content\.scrollHeight;\s*\n\s*if \(after !== before\) scrollDiagRow\("scrollwrite", scrollWriteRow\(activeId \|\| "", writer, before, after, stick, content\.scrollHeight, content\.clientHeight\)\);/);
   // the breadcrumb rides the existing clientDiag path, capped, with one capped row at the cap
   assert.match(RENDER, /\{ type: "clientDiag", surface: "chat", what: kind \+ "-capped", data: \{ sid: activeId \|\| "", perMinute: scrollDiagCap \} \}/);   // the cap the page runs with (T262j: configurable)
   assert.match(RENDER, /\{ type: "clientDiag", surface: "chat", what: kind, data \}/);

--- a/ui/webview/scroll-write.ts
+++ b/ui/webview/scroll-write.ts
@@ -47,6 +47,29 @@ export function classifyScroll(scrollTop: number, lastWriteAfter: number | null)
   return lastWriteAfter != null && Math.abs(scrollTop - lastWriteAfter) <= 1 ? "write-echo" : "gesture";
 }
 
+/** One childList mutation of a tail container, reduced to what the row needs: the classes of the nodes removed at
+ *  the END, the classes of the nodes added at the end, and whether a removed node came back in the same task. */
+export interface TailMutation { removed: Array<{ cls: string }>; added: Array<{ cls: string }>; atEnd: boolean; }
+export function summarizeTailMutations(records: TailMutation[]): { removedTail: string[]; addedTail: string[]; reAdded: boolean } | null {
+  const removedTail: Array<{ cls: string }> = [], addedTail: Array<{ cls: string }> = [];
+  for (const r of records) {
+    if (!r.atEnd) continue;
+    removedTail.push(...r.removed); addedTail.push(...r.added);
+  }
+  if (!removedTail.length) return null;
+  const reAdded = removedTail.some((n) => addedTail.indexOf(n) >= 0);
+  return { removedTail: removedTail.map((n) => String(n.cls || "").slice(0, 40)), addedTail: addedTail.map((n) => String(n.cls || "").slice(0, 40)), reAdded };
+}
+
+/** The breadcrumb for a tail element leaving the DOM (T262j, the user 2026-09-08): the remaining snap is a clamp
+ *  against a transcript momentarily shorter WITHIN a frame — a tail node removed, a layout forced, the node back
+ *  before the frame ends — which no ResizeObserver can see. `shBefore` = the last scroll height the pane recorded,
+ *  `shAfter` = the height once the mutations settled; `reAdded` = the same node came back in the same task. */
+export function tailMutRow(sid: string, m: { removedTail: string[]; addedTail: string[]; reAdded: boolean }, shBefore: number, shAfter: number, st: number, ch: number, where: "view" | "live-ask") {
+  const clip = (a: string[]) => a.slice(0, 4).map((c) => String(c).slice(0, 40));
+  return { sid, where, removed: clip(m.removedTail), added: clip(m.addedTail), reAdded: m.reAdded, shBefore, shAfter, st, ch };
+}
+
 /** The breadcrumb for one re-size of a view's virtualization spacers (T262j): a top spacer re-estimate paired with
  *  a bottom one leaves scrollHeight unchanged yet moves everything under the top spacer, and Chrome's scroll
  *  anchoring then moves the reader by the same amount with no pane write. `top`/`bot` = [before, after] heights. */

--- a/ui/webview/tail-change-row.test.ts
+++ b/ui/webview/tail-change-row.test.ts
@@ -27,8 +27,8 @@ test("the tail label is the last child that is not a virtualization spacer", () 
 });
 
 test("render.ts files the row from both tail observers, beside the tail-shrink rule, through the capped diag path", () => {
-  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap \} from "\.\/scroll-write";/);   // + spacerRow, readScrollDiagCap (T262j)
-  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer", data: any\): void \{/);   // + spacer (T262j)
+  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap, summarizeTailMutations, tailMutRow \} from "\.\/scroll-write";/);   // + spacerRow, readScrollDiagCap (T262j)
+  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut", data: any\): void \{/);   // + spacer (T262j)
   assert.match(RENDER, /if \(content && lastH >= 0 && activeId === id && view\.shown && h !== lastH\)\s*\n\s*scrollDiagRow\("tailchange", tailChangeRow\(id, h - lastH, tailLabel\(view\.el\.children\), view\.stick, content\.scrollHeight, content\.clientHeight\)\);/);
   assert.match(RENDER, /if \(content && tailLastH >= 0 && v && v\.shown && h !== tailLastH\)\s*\n\s*scrollDiagRow\("tailchange", tailChangeRow\(activeId \|\| "", h - tailLastH, "live-ask", v\.stick, content\.scrollHeight, content\.clientHeight\)\);/);
   assert.equal((RENDER.match(/"tailchange"/g) || []).length, 3, "the kind in the router's union and the two filings");

--- a/ui/webview/tail-mutation.test.ts
+++ b/ui/webview/tail-mutation.test.ts
@@ -1,0 +1,52 @@
+// A tail element leaving the DOM — even for part of one frame — is on the record (T262j, the user 2026-09-08). The
+// remaining snap lands at scrollHeight − clientHeight − h, the bubble's height, from any position, 93 ms after a
+// land that took, with scrollHeight unchanged at the next read and NO tail-change row: a clamp against a transcript
+// momentarily h px shorter WITHIN a frame. A ResizeObserver reports frame-end sizes and cannot see that; a
+// MutationObserver on the active view's element (and on the live-ask host) sees every child removed at the tail,
+// including one re-appended in the same task, so a "tailmut" row names what left, whether it came back, and the
+// scroll height before (the last one the pane recorded) and after. Pure summary executed here; wiring pinned.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { summarizeTailMutations, tailMutRow } from "./scroll-write";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const SID = "11111111-2222-4333-8444-000000000201";
+const n = (cls: string) => ({ cls });
+
+test("a removal at the END of the container is a tail removal; a node removed and re-added in the same task is re-added", () => {
+  const bubble = n("turn turn-queued");
+  const s = summarizeTailMutations([
+    { removed: [bubble], added: [], atEnd: true },
+    { removed: [], added: [bubble], atEnd: true },
+  ]);
+  assert.deepEqual(s, { removedTail: ["turn turn-queued"], addedTail: ["turn turn-queued"], reAdded: true });
+});
+
+test("a removal in the MIDDLE is not a tail removal; a removal with a different node appended is not a re-add", () => {
+  const a = n("turn turn-assistant"), b = n("turn turn-tool");
+  assert.equal(summarizeTailMutations([{ removed: [a], added: [], atEnd: false }]), null, "nothing left the tail");
+  assert.deepEqual(summarizeTailMutations([{ removed: [a], added: [b], atEnd: true }]), { removedTail: ["turn turn-assistant"], addedTail: ["turn turn-tool"], reAdded: false });
+  assert.equal(summarizeTailMutations([{ removed: [], added: [b], atEnd: true }]), null, "an append alone is the append path's business");
+});
+
+test("the row carries what left, whether it came back, and the scroll height before and after", () => {
+  assert.deepEqual(tailMutRow(SID, { removedTail: ["turn turn-queued"], addedTail: ["turn turn-queued"], reAdded: true }, 9114, 9114, 8148.3, 902, "view"),
+                   { sid: SID, where: "view", removed: ["turn turn-queued"], added: ["turn turn-queued"], reAdded: true, shBefore: 9114, shAfter: 9114, st: 8148.3, ch: 902 });
+  assert.equal(tailMutRow(SID, { removedTail: ["x".repeat(80)], addedTail: [], reAdded: false }, 1, 2, 3, 4, "live-ask").removed[0].length, 40, "classes bounded");
+});
+
+test("render.ts observes the active view's children and the live-ask host's, and files the row through the capped diag path", () => {
+  assert.match(RENDER, /import \{[^}]*\bsummarizeTailMutations\b[^}]*\btailMutRow\b[^}]*\} from "\.\/scroll-write";/);
+  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut", data: any\): void \{/);
+  assert.match(RENDER, /mo\?: MutationObserver; \}/, "the View carries its mutation observer");
+  assert.match(RENDER, /v\.mo = new MutationObserver\(\(records\) => \{/);
+  assert.match(RENDER, /v\.mo\.observe\(elv, \{ childList: true \}\);/);
+  assert.equal((RENDER.match(/v\.ro\?\.disconnect\(\); v\.mo\?\.disconnect\(\); v\.el\.remove\(\);/g) || []).length, 2, "both view-removal sites disconnect it");
+  assert.match(RENDER, /const tailMo = new MutationObserver\(\(records\) => \{/, "the live-ask host too");
+  assert.equal((RENDER.match(/scrollDiagRow\("tailmut", tailMutRow\(/g) || []).length, 2);
+  // the "before" is the last scroll height the pane recorded, kept current by every write and every scroll event
+  assert.match(RENDER, /let lastKnownSh = 0;/);
+  assert.match(RENDER, /lastKnownSh = content\.scrollHeight;/);
+});


### PR DESCRIPTION
## Summary
Instrumentation: a tail element leaving the transcript's DOM, even for part of one frame, is on the record.

## Why
The user's laptop captures (2026-09-08) show the remaining snap landing at `scrollHeight − clientHeight − h` from any starting position (including mid-gesture), 93 ms after a `land-bottom` write that took, with scrollHeight unchanged at the next read, no `scrollwrite` and no `tailchange` row, and no frame delivered. That is a clamp against a transcript momentarily `h` px shorter WITHIN a frame: a tail node removed, a layout forced, the node back before the frame ends. `h` matches the pending bubble's height on each page (64 px on the devbox tabs, 128 px on the local tab), consistent with the bubble fix in PR 1111. A ResizeObserver reports frame-end sizes and cannot see such a removal.

## Change
A MutationObserver on the active view's element and on the `#live-ask` host files a `tailmut` row for every removal at the END of the container: the classes of the nodes that left, the classes of the nodes appended, whether the same node came back in the same task (`reAdded`), the scroll height the pane last recorded (kept current by every write and every scroll event) and the one after, the scroll position and the client height. It rides the same capped client-diag path as the other scroll rows. After PR 1111 is on the user's page, this row is also the proof the flap is gone: no `tailmut` with `reAdded: true` beside a snap.

## Tests
- New `ui/webview/tail-mutation.test.ts`: the pure reduction executed (a tail removal with the same node re-added; a middle removal is not a tail removal; a different node appended is not a re-add) and the row builder; the observers, the disconnects at both view-removal sites, the live-ask observer and the last-known-height tracking pinned.
- Pins moved with the code in scroll-write, scroll-movers, tail-change-row and scroll-marks tests.
- `npm run typecheck` clean; the full extension suite runs on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
