### PR TITLE
Scroll journal audit: the snap is recognizable from the rows, with tests

### DIFF
--- a/ui/webview/scroll-journal-audit.test.ts
+++ b/ui/webview/scroll-journal-audit.test.ts
@@ -1,0 +1,171 @@
+// The scroll journal's reader recognizes the snap (T262k, the user 2026-09-08): a single scroll event, after the reader
+// had stopped, landing on one fixed value per tab tens of pixels above the bottom, with no write, no tail change and
+// scrollHeight unchanged — and does NOT cry wolf at the reader's own bursts, a write's echo, a tail shrink's clamp or a
+// spacer re-size's anchoring. The rows are built with the pane's own row builders (scroll-write.ts), so a change to a
+// row's shape breaks this file before it breaks the reading. Synthetic values throughout.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { unwrittenMoves, repeatedLandings, journalRowFromDiagLine, type JournalRow } from "./scroll-journal-audit";
+import { scrollWriteRow, tailChangeRow, spacerRow } from "./scroll-write";
+
+const SID = "11111111-2222-4333-8444-000000000301";
+const SID2 = "devbox:11111111-2222-4333-8444-000000000302";
+const SH = 9000, CH = 900, BOTTOM = SH - CH;           // 8100
+
+const gesture = (t: number, top: number, sh = SH, ch = CH, sid = SID): JournalRow => ({ t, what: "scrollgesture", data: { sid, top, gesture: true, sh, ch } });
+const write = (t: number, writer: string, before: number, after: number, stick = false, sh = SH, ch = CH, sid = SID): JournalRow =>
+  ({ t, what: "scrollwrite", data: scrollWriteRow(sid, writer, before, after, stick, sh, ch) });
+const tail = (t: number, dh: number, last: string, stick: boolean, sh = SH, ch = CH, sid = SID): JournalRow =>
+  ({ t, what: "tailchange", data: tailChangeRow(sid, dh, last, stick, sh, ch) });
+const spacer = (t: number, topBefore: number, topAfter: number, botBefore: number, botAfter: number, sh = SH, ch = CH, sid = SID): JournalRow =>
+  ({ t, what: "spacer", data: spacerRow(sid, topBefore, topAfter, botBefore, botAfter, sh, ch) });
+
+/** A reader's trackpad burst: samples ~16 ms apart, accelerating then easing, from `from` to `to`. */
+function burst(t0: number, from: number, to: number, n = 12): JournalRow[] {
+  const rows: JournalRow[] = [];
+  for (let i = 1; i <= n; i++) {
+    const k = i / n, ease = k < 0.5 ? 2 * k * k : 1 - Math.pow(-2 * k + 2, 2) / 2;
+    rows.push(gesture(t0 + i * 16, Math.round((from + (to - from) * ease) * 10) / 10));
+  }
+  return rows;
+}
+
+test("the snap: one event after a pause, tens of pixels up, nothing wrote it — reported, with its distance above the bottom", () => {
+  const rows = [
+    write(1000, "land-bottom", 0, BOTTOM, true),
+    ...burst(1600, BOTTOM - 300, BOTTOM),                 // the reader scrolls down to the bottom
+    gesture(4400, BOTTOM - 64),                           // 2.6 s later: one event, 64 px up, sh unchanged
+    ...burst(9000, BOTTOM - 64, BOTTOM),                  // the reader scrolls back down
+    gesture(11900, BOTTOM - 64),                          // and it happens again
+  ];
+  const moves = unwrittenMoves(rows);
+  assert.equal(moves.length, 2, JSON.stringify(moves));
+  assert.deepEqual(moves.map((m) => [m.t, m.from, m.to, m.delta, m.distAfter, m.explained]),
+    [[4400, BOTTOM, BOTTOM - 64, -64, 64, "none"], [11900, BOTTOM, BOTTOM - 64, -64, 64, "none"]]);
+  assert.ok(moves[0].idleMs >= 2500, "the pause before it is on the record: " + moves[0].idleMs);
+  assert.deepEqual(repeatedLandings(moves), [{ to: BOTTOM - 64, count: 2, distAfter: 64 }], "one fixed landing, twice");
+});
+
+test("the snap right after a land: the write's after is the bottom, the next event 90 ms later already reads 128 px up", () => {
+  const rows = [
+    write(1000, "land-bottom", 3800, 13640.8, true, 14208, 567),
+    gesture(1093, 13512.9, 14208, 567),
+    ...burst(1700, 13514.6, 13640.8),
+  ];
+  // the write is the last recorded position; a 128 px move 93 ms later is not a burst sample (idle is measured from the write)
+  const moves = unwrittenMoves(rows, { idleMs: 80 });
+  assert.equal(moves.length, 1);
+  assert.equal(moves[0].from, 13640.8);
+  assert.equal(Math.round(moves[0].to * 10) / 10, 13512.9);
+  assert.equal(Math.round(moves[0].distAfter * 10) / 10, 128.1);
+  assert.equal(moves[0].explained, "none");
+  // at the default idle floor the same rows say nothing: the caller chooses how close to a write a move may sit
+  assert.equal(unwrittenMoves(rows).length, 0);
+});
+
+test("the reader's own bursts are not moves: samples 16 ms apart, small first steps, a continuing stream", () => {
+  const rows = [
+    write(1000, "land-bottom", 0, BOTTOM, true),
+    ...burst(1600, BOTTOM, BOTTOM - 420),                 // up
+    ...burst(4000, BOTTOM - 420, BOTTOM - 40),            // down, after a 2.4 s pause: the first step is small
+    ...burst(7000, BOTTOM - 40, BOTTOM),                  // to the bottom
+  ];
+  assert.deepEqual(unwrittenMoves(rows), []);
+});
+
+test("a fast flick after a pause is one big first step but a stream follows: not a move", () => {
+  const rows = [
+    write(1000, "land-bottom", 0, BOTTOM, true),
+    gesture(4000, BOTTOM - 90), gesture(4016, BOTTOM - 210), gesture(4033, BOTTOM - 300), gesture(4050, BOTTOM - 340),
+  ];
+  assert.deepEqual(unwrittenMoves(rows), []);
+  // …unless the settle window is set to zero, in which case the caller asked for every first step
+  assert.equal(unwrittenMoves(rows, { settleMs: 0 }).length, 1);
+});
+
+test("a write's echo and a write's own landing are not moves", () => {
+  const rows = [
+    ...burst(1000, BOTTOM - 500, BOTTOM - 300),
+    write(3000, "anchor-restore", BOTTOM - 300, 2438.3, false),
+    gesture(3020, 2438.3),                                // the echo (within a pixel)
+    write(6000, "box-resize", 2438.3, 2534.2, false, SH, CH - 96),
+    gesture(6016, 2534.5),                                // the echo, off by half a pixel
+  ];
+  assert.deepEqual(unwrittenMoves(rows), []);
+});
+
+test("a tail shrink under a bottom reader clamps them up by the shrink: reported, explained by the tailchange row", () => {
+  const rows = [
+    write(1000, "land-bottom", 0, BOTTOM, true),
+    tail(3000, -72, "turn turn-tool", true, SH - 72, CH),
+    gesture(3010, BOTTOM - 72, SH - 72, CH),
+  ];
+  const moves = unwrittenMoves(rows);
+  assert.equal(moves.length, 1);
+  assert.equal(moves[0].explained, "tail-change");
+  assert.equal(moves[0].by.dh, -72);
+  assert.equal(moves[0].distAfter, 0, "the reader is still at the (new) bottom");
+});
+
+test("a top spacer re-size under anchoring moves the reader by the opposite amount: reported, explained by the spacer row", () => {
+  const rows = [
+    write(1000, "land-saved", 0, 5000, false),
+    spacer(3000, 1000, 1064, 200, 136),                   // top grew 64, bottom shrank 64: scrollHeight unchanged
+    gesture(3010, 5064),                                  // anchoring carried the reader down with the content
+  ];
+  const moves = unwrittenMoves(rows);
+  assert.equal(moves.length, 1);
+  assert.equal(moves[0].explained, "spacer");
+  assert.deepEqual(moves[0].by.top, [1000, 1064]);
+});
+
+test("a tail change or spacer row of the WRONG size does not explain the move", () => {
+  const rows = [
+    write(1000, "land-bottom", 0, BOTTOM, true),
+    tail(2000, 30.8, "turn turn-tool", true, SH + 31, CH),   // the tail grew a little; unrelated
+    gesture(4400, BOTTOM - 64, SH, CH),
+  ];
+  const moves = unwrittenMoves(rows);
+  assert.equal(moves.length, 1);
+  assert.equal(moves[0].explained, "none");
+  assert.equal(moves[0].by, undefined);
+});
+
+test("rows of several tabs are audited per tab; `sid` picks one", () => {
+  const rows = [
+    write(1000, "land-bottom", 0, BOTTOM, true),
+    write(1000, "land-bottom", 0, 12000, true, 12900, 900, SID2),
+    gesture(4400, BOTTOM - 64),                           // tab 1 snaps
+    gesture(4500, 11936, 12900, 900, SID2),               // tab 2 snaps too
+    ...burst(5000, BOTTOM - 64, BOTTOM),
+  ];
+  const all = unwrittenMoves(rows);
+  assert.deepEqual(all.map((m) => [m.t, m.to]), [[4400, BOTTOM - 64], [4500, 11936]]);
+  assert.deepEqual(unwrittenMoves(rows, { sid: SID2 }).map((m) => m.to), [11936]);
+  // the positions of one tab never explain or seed the other's: tab 2's move is measured from ITS write
+  assert.equal(all[1].from, 12000);
+});
+
+test("repeatedLandings: the fixed value is the signature; a value seen once is not one", () => {
+  const moves = unwrittenMoves([
+    write(1000, "land-bottom", 0, BOTTOM, true),
+    gesture(4000, BOTTOM - 64), ...burst(5000, BOTTOM - 64, BOTTOM),
+    gesture(8000, BOTTOM - 64), ...burst(9000, BOTTOM - 64, BOTTOM),
+    gesture(12000, BOTTOM - 64), ...burst(13000, BOTTOM - 64, BOTTOM),
+    gesture(16000, BOTTOM - 233),                         // a lone flick
+  ]);
+  assert.equal(moves.length, 4);
+  assert.deepEqual(repeatedLandings(moves), [{ to: BOTTOM - 64, count: 3, distAfter: 64 }]);
+});
+
+test("client-diag lines: chat scroll rows parse with a millisecond clock (the arrival stamp when present), the rest are null", () => {
+  const base = { wid: "22222222-3333-4444-8555-000000000001", surface: "chat" };
+  const g = journalRowFromDiagLine(JSON.stringify({ ...base, t: 1700000000, what: "scrollgesture", data: { sid: SID, top: 10, gesture: true, sh: 100, ch: 50 } }));
+  assert.deepEqual(g, { t: 1700000000000, what: "scrollgesture", data: { sid: SID, top: 10, gesture: true, sh: 100, ch: 50 } });
+  const stamped = journalRowFromDiagLine(JSON.stringify({ ...base, t: 1700000000, ta: 1700000000.359, what: "scrollwrite", data: scrollWriteRow(SID, "land-bottom", 0, 10, true, 100, 50) }));
+  assert.equal(stamped!.t, 1700000000359);
+  assert.equal(journalRowFromDiagLine(JSON.stringify({ ...base, t: 1700000000, what: "send", data: { sid: SID } })), null, "not a scroll row");
+  assert.equal(journalRowFromDiagLine(JSON.stringify({ ...base, surface: "feed", t: 1700000000, what: "scrollgesture", data: {} })), null, "not the chat");
+  assert.equal(journalRowFromDiagLine("not json"), null);
+  assert.equal(journalRowFromDiagLine(JSON.stringify({ ...base, what: "scrollgesture", data: {} })), null, "no clock at all");
+});

--- a/ui/webview/scroll-journal-audit.test.ts
+++ b/ui/webview/scroll-journal-audit.test.ts
@@ -131,6 +131,21 @@ test("a tail change or spacer row of the WRONG size does not explain the move", 
   assert.equal(moves[0].by, undefined);
 });
 
+test("a read while the view has nothing to scroll (emptied for a rebuild, clamped to 0) is neither a move nor a position", () => {
+  const rows = [
+    write(1000, "land-bottom", 0, BOTTOM, true),
+    gesture(40000, 0, 800, 800),                          // the view is empty: scrollHeight == clientHeight, top clamps to 0
+    write(40100, "land-bottom", 0, BOTTOM, true),         // the rebuild lands
+    gesture(40200, BOTTOM),                               // its echo
+  ];
+  assert.deepEqual(unwrittenMoves(rows), []);
+  // …and it does not seed the next comparison either: a real snap after it is measured from the land, not from 0
+  const withSnap = [...rows, gesture(43000, BOTTOM - 64)];
+  const moves = unwrittenMoves(withSnap);
+  assert.equal(moves.length, 1);
+  assert.equal(moves[0].from, BOTTOM);
+});
+
 test("rows of several tabs are audited per tab; `sid` picks one", () => {
   const rows = [
     write(1000, "land-bottom", 0, BOTTOM, true),

--- a/ui/webview/scroll-journal-audit.ts
+++ b/ui/webview/scroll-journal-audit.ts
@@ -21,7 +21,9 @@
 //
 // Limits, stated so a quiet result is read correctly: a move inside a gesture (the snap landed mid-burst once) is not
 // separable from the burst by position alone and is not reported; a reader's single fast flick after a pause is
-// reported as a move with `explained: "none"` — repeatedLandings tells the two apart, since a flick lands anywhere.
+// reported as a move with `explained: "none"` — repeatedLandings tells the two apart, since a flick lands anywhere. A
+// scroll event read while the view has nothing to scroll (scrollHeight <= clientHeight: a view emptied for a rebuild
+// clamps to 0) is neither a move nor a position; the rebuild's own land is the next position.
 
 export type JournalRow = { t: number; what: string; data: any };
 
@@ -73,6 +75,8 @@ function auditOne(rows: JournalRow[], o: Required<Omit<AuditOptions, "sid">> & {
     if (r.what === "tailchange" || r.what === "spacer") { since.push(r); continue; }
     if (r.what !== "scrollgesture" || typeof d.top !== "number") continue;
     const top = d.top;
+    const sh0 = Number(d.sh) || 0, ch0 = Number(d.ch) || 0;
+    if (sh0 > 0 && ch0 > 0 && sh0 <= ch0) continue;                 // nothing to scroll: an emptied view mid-rebuild clamps to 0; not a move, not a position
     if (pos != null) {
       const delta = top - pos, idle = r.t - posT;
       const next = nextGesture(rows, i + 1);

--- a/ui/webview/scroll-journal-audit.ts
+++ b/ui/webview/scroll-journal-audit.ts
@@ -1,0 +1,131 @@
+// Reading the scroll journal for the move nobody wrote (T262k, the user 2026-09-08). For most of a day the chat
+// transcript snapped away from where the reader had put it: a single scroll event, 0.1–2.7 s after they reached the
+// bottom (or right after a land), read a scrollTop tens of pixels above the bottom — the same value every time for a
+// given tab — with no "scrollwrite" row, no "tailchange" row, and scrollHeight unchanged at the read. Six such moves in
+// five minutes of one capture; the go-to-bottom chip appeared after each. Every capture was read by hand.
+//
+// This module is that reading, as code, so the fingerprint is recognizable from the rows alone and a recurrence is a
+// function call away from any journal (the laptop's client-diag.jsonl, a kernel-side check, a test fixture). It is
+// pure and DOM-free; it consumes the rows the pane files through scroll-write.ts (scrollWriteRow, tailChangeRow,
+// spacerRow, and the scroll listener's gesture row) and answers two questions:
+//
+//   unwrittenMoves(rows)    — which scroll events moved the view without a write to explain them? A move is a
+//                             "scrollgesture" row whose top differs from the last recorded position by at least
+//                             `minPx`, arriving at least `idleMs` after that position was recorded (so it is not the
+//                             next sample of the reader's own burst) and with no further gesture within `settleMs`
+//                             after it (a reader's burst continues; the snap is one event). Each move says whether a
+//                             tail-height change or a spacer re-size filed since the last position accounts for its
+//                             size (Chrome clamps a bottom reader when the tail shrinks and carries them along when
+//                             a spacer above re-sizes — both legitimate, both unwritten) or nothing does.
+//   repeatedLandings(moves) — which landing values recur? The snap's signature was one fixed value per tab.
+//
+// Limits, stated so a quiet result is read correctly: a move inside a gesture (the snap landed mid-burst once) is not
+// separable from the burst by position alone and is not reported; a reader's single fast flick after a pause is
+// reported as a move with `explained: "none"` — repeatedLandings tells the two apart, since a flick lands anywhere.
+
+export type JournalRow = { t: number; what: string; data: any };
+
+export type UnwrittenMove = {
+  t: number;                   // when the move was read (ms, the row's clock)
+  from: number;                // the last recorded position before it
+  to: number;                  // the position the move landed on
+  delta: number;               // to - from
+  sh: number;                  // scrollHeight at the read
+  ch: number;                  // clientHeight at the read
+  distAfter: number;           // sh - to - ch: how far above the bottom the move left the reader
+  idleMs: number;              // how long the last position had stood
+  explained: "none" | "tail-change" | "spacer";
+  by?: any;                    // the tailchange or spacer row that explains it, when one does
+};
+
+export type AuditOptions = { minPx?: number; idleMs?: number; settleMs?: number; tolPx?: number; sid?: string };
+
+const DEFAULTS = { minPx: 24, idleMs: 400, settleMs: 150, tolPx: 2 };
+
+/** The moves no write explains, in row order. `rows` are one journal's chat rows (any sid mix; pass `sid` to pick
+ *  one, else rows are grouped by their data.sid). Rows need a millisecond `t`; the kernel's client-diag `t` is whole
+ *  seconds, so a caller reading that file should stamp arrival time and pass it as `t`. */
+export function unwrittenMoves(rows: JournalRow[], opts: AuditOptions = {}): UnwrittenMove[] {
+  const o = { ...DEFAULTS, ...opts };
+  const bySid = new Map<string, JournalRow[]>();
+  for (const r of rows) {
+    const sid = String(r?.data?.sid ?? "");
+    if (o.sid != null && sid !== o.sid) continue;
+    let list = bySid.get(sid);
+    if (!list) { list = []; bySid.set(sid, list); }
+    list.push(r);
+  }
+  const out: UnwrittenMove[] = [];
+  for (const list of bySid.values()) out.push(...auditOne(list, o));
+  return out.sort((a, b) => a.t - b.t);
+}
+
+function auditOne(rows: JournalRow[], o: Required<Omit<AuditOptions, "sid">> & { sid?: string }): UnwrittenMove[] {
+  const out: UnwrittenMove[] = [];
+  let pos: number | null = null, posT = 0;
+  let since: JournalRow[] = [];                                     // tailchange / spacer rows since `pos` was recorded
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i], d = r.data || {};
+    if (r.what === "scrollwrite") {
+      if (typeof d.after === "number") { pos = d.after; posT = r.t; since = []; }
+      continue;
+    }
+    if (r.what === "tailchange" || r.what === "spacer") { since.push(r); continue; }
+    if (r.what !== "scrollgesture" || typeof d.top !== "number") continue;
+    const top = d.top;
+    if (pos != null) {
+      const delta = top - pos, idle = r.t - posT;
+      const next = nextGesture(rows, i + 1);
+      const isolated = next == null || next.t - r.t >= o.settleMs;
+      if (Math.abs(delta) >= o.minPx && idle >= o.idleMs && isolated) {
+        const sh = Number(d.sh) || 0, ch = Number(d.ch) || 0;
+        const by = explain(since, delta, o.tolPx);
+        out.push({ t: r.t, from: pos, to: top, delta, sh, ch, distAfter: sh - top - ch, idleMs: idle,
+          explained: by ? (by.what === "spacer" ? "spacer" : "tail-change") : "none", ...(by ? { by: by.data } : {}) });
+      }
+    }
+    pos = top; posT = r.t; since = [];
+  }
+  return out;
+}
+
+function nextGesture(rows: JournalRow[], from: number): JournalRow | null {
+  for (let j = from; j < rows.length; j++) if (rows[j].what === "scrollgesture") return rows[j];
+  return null;
+}
+
+/** The tailchange or spacer row since the last position whose size accounts for `delta`: a tail that shrank by
+ *  |delta| clamps a bottom reader up by |delta| (dh == delta); a top spacer that grew by delta carries the content
+ *  under it down by delta and Chrome's anchoring carries the reader with it (dTop == delta). */
+function explain(since: JournalRow[], delta: number, tol: number): JournalRow | null {
+  for (const r of since) {
+    const d = r.data || {};
+    if (r.what === "tailchange" && typeof d.dh === "number" && Math.abs(d.dh - delta) <= tol) return r;
+    if (r.what === "spacer" && typeof d.dTop === "number" && Math.abs(d.dTop - delta) <= tol) return r;
+  }
+  return null;
+}
+
+/** Landing values that recur among the moves (rounded to a tenth of a pixel), most frequent first. The snap landed
+ *  on ONE value per tab, again and again; a reader's own flicks land anywhere. */
+export function repeatedLandings(moves: UnwrittenMove[]): { to: number; count: number; distAfter: number }[] {
+  const groups = new Map<number, { to: number; count: number; distAfter: number }>();
+  for (const m of moves) {
+    const key = Math.round(m.to * 10) / 10;
+    const g = groups.get(key);
+    if (g) g.count += 1; else groups.set(key, { to: key, count: 1, distAfter: Math.round(m.distAfter * 10) / 10 });
+  }
+  return [...groups.values()].filter((g) => g.count >= 2).sort((a, b) => b.count - a.count || a.to - b.to);
+}
+
+/** Parse one client-diag.jsonl line into a journal row, or null for anything that is not a chat scroll row. `t` is
+ *  the row's own whole-second clock unless the line carries a finer `ta` (an arrival stamp a capture added). */
+export function journalRowFromDiagLine(line: string): JournalRow | null {
+  let d: any;
+  try { d = JSON.parse(line); } catch { return null; }
+  if (!d || d.surface !== "chat" || typeof d.what !== "string") return null;
+  if (d.what !== "scrollgesture" && d.what !== "scrollwrite" && d.what !== "tailchange" && d.what !== "spacer") return null;
+  const t = typeof d.ta === "number" ? d.ta * 1000 : typeof d.t === "number" ? d.t * 1000 : NaN;
+  if (!Number.isFinite(t)) return null;
+  return { t, what: d.what, data: d.data || {} };
+}


### PR DESCRIPTION
## What

A pure reader for the chat pane's scroll journal (`ui/webview/scroll-journal-audit.ts`) and its tests. It consumes the rows `scroll-write.ts` already files (`scrollwrite`, `scrollgesture`, `tailchange`, `spacer`) and answers: which scroll events moved the transcript without a write to explain them, whether a tail change or spacer re-size since accounts for each one, and which landing values recur.

## Why

Today's snap (T262: one scroll event after the reader stopped, landing a fixed distance above the bottom, no write, no tail change, scrollHeight unchanged) was found and characterized by reading captures by hand, for hours. With this module the fingerprint is a function call over any journal: the laptop's `client-diag.jsonl`, a kernel-side check, a test fixture. Run over the day's captures it reports the 15 pre-fix moves (all landing 63 to 65 px above the bottom across eleven tabs) and the three at 128 px in a local tab, and nothing unexplained after PRs 1109, 1111 and 1108.

## Design points

- `unwrittenMoves(rows, {minPx, idleMs, settleMs, tolPx, sid})`: a move is an isolated gesture row (no further gesture within `settleMs`) at least `idleMs` after the last recorded position and at least `minPx` away from it. A reader's burst is a stream of small steps, so it never qualifies; the snap is one event.
- `explained`: `tail-change` when a `tailchange` row since the last position has `dh == delta` (a shrinking tail clamps a bottom reader), `spacer` when a `spacer` row has `dTop == delta` (anchoring carries the reader with the content), else `none`.
- `repeatedLandings(moves)`: the fixed value per tab was the snap's signature; a reader's flick lands anywhere.
- `journalRowFromDiagLine(line)`: reads a `client-diag.jsonl` line, taking a capture's `ta` arrival stamp when present because the kernel's `t` on those rows is whole seconds.
- No DOM, no wiring into the pane; nothing in `render.ts` changes. Test rows are built with the pane's own row builders so a shape change fails here first. All values synthetic.

## Not in this PR

A live hookup (a kernel-side check that flags a recurrence as it happens) is a natural next step; this PR keeps to the reader and its tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
