### PR TITLE
Chat pane: a re-render that re-windows the view keeps the reader's place through the deep-link land

### DIFF
--- a/ui/webview/keep-across-window.test.ts
+++ b/ui/webview/keep-across-window.test.ts
@@ -1,0 +1,31 @@
+// The reader's place across a rebuild that RE-WINDOWED the view (T262l, 2026-09-08, from a lab run). A settings
+// change re-renders every view from scratch; the fresh tail window of a long transcript rarely holds the anchor turn
+// of a reader scrolled up, so the direct restore (restoreScrollAnchor: query the uuid in the DOM, write its kept
+// offset) found nothing, the land put the reader on the raw saved scrollTop in a layout whose spacer estimate had
+// moved by thousands of pixels, and the anchor turn drifted about 200 px on screen (measured: -0.1 px → +198 px over
+// two re-renders, spacer rows dTop -10348 / dBot +4378). When the direct restore misses, the deep-link land takes over
+// with the kept offset: it renders a window AROUND the anchor's unit (or fetches older history and re-lands on
+// arrival) and writes "keep-offset", the anchor's exact on-screen position. Measured after: -0.14 px → -0.14 px, no
+// moves. render.ts wiring pinned (the machinery it reuses has its own executed tests).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("keepPlaceAcrossWindow: the direct restore first; on a miss, the deep-link land with the kept offset", () => {
+  const m = RENDER.match(/^function keepPlaceAcrossWindow\(content: HTMLElement, v: View, keep: \{ uuid: string; y: number \}\): boolean \{([\s\S]*?)\n\}/m);
+  assert.ok(m, "the helper");
+  const body = m![1];
+  assert.match(body, /if \(restoreScrollAnchor\(content, v, keep\)\) return true;/, "the cheap path when the turn is rendered");
+  assert.match(body, /pendingAnchor = keep\.uuid; pendingAnchorKeepY = keep\.y;/, "armed with the kept offset, so the land writes keep-offset, not a flashed top-of-viewport jump");
+  assert.match(body, /const landed = scrollToAnchor\(keep\.uuid\);/, "the window-around-unit land");
+  assert.match(body, /if \(!anchorPendingOlder\) \{ pendingAnchor = null; pendingAnchorKeepY = null; \}/, "disarmed unless an older-history fetch will re-land on arrival");
+});
+
+test("showActive keeps the place through the window-aware helper on both build paths", () => {
+  assert.match(RENDER, /syncView\(activeId!\); landActive\(content, v\);\n\s*if \(keepAnchor\) keepPlaceAcrossWindow\(content, v, keepAnchor\);/);
+  assert.match(RENDER, /landActive\(cc, vv\);\n\s*if \(keepAnchor && cc\) keepPlaceAcrossWindow\(cc, vv, keepAnchor\);/);
+  assert.equal((RENDER.match(/keepPlaceAcrossWindow\(/g) || []).length, 3, "two call sites and the definition");
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -10440,7 +10440,7 @@ function showActive(keep?: { uuid: string; y: number } | null) {
   const heavy = s.events.length > 0 && (v.el.childNodes.length === 0 || (settings.compact && (v.rendered !== s.events.length || v.stale)));
   if (!heavy) {
     syncView(activeId!); landActive(content, v);
-    if (keepAnchor) restoreScrollAnchor(content, v, keepAnchor);   // the line being read stays put across the rebuild (T249)
+    if (keepAnchor) keepPlaceAcrossWindow(content, v, keepAnchor);   // the line being read stays put across the rebuild (T249; T262l for a re-windowed view)
     return;
   }
   if (v.el.childNodes.length === 0) {   // truly empty → the ROMP LOADER holds the spot (the standing
@@ -10465,8 +10465,23 @@ function showActive(keep?: { uuid: string; y: number } | null) {
     const cc = document.getElementById("content");
     syncView(target);                   // the heavy build now (clears the loading hint)
     landActive(cc, vv);
-    if (keepAnchor && cc) restoreScrollAnchor(cc, vv, keepAnchor);   // same keep on the deferred path (T249)
+    if (keepAnchor && cc) keepPlaceAcrossWindow(cc, vv, keepAnchor);   // same keep on the deferred path (T249; T262l)
   });
+}
+
+// The reader's place across a rebuild that RE-WINDOWED the view (T262l, 2026-09-08, from a lab run: a settings
+// change re-renders every view from scratch; the fresh tail window of a long transcript rarely holds the anchor
+// turn of a reader scrolled up, so restoreScrollAnchor found nothing, the land put them on the raw saved scrollTop
+// in a layout whose spacer estimate had moved by thousands of pixels, and the anchor turn drifted ~200 px on
+// screen). When the direct restore misses, the deep-link land takes over with the kept offset: it renders a
+// window AROUND the anchor's unit (or fetches older history and re-lands on arrival) and writes "keep-offset",
+// the anchor's exact on-screen position — the same machinery a jump into folded history uses.
+function keepPlaceAcrossWindow(content: HTMLElement, v: View, keep: { uuid: string; y: number }): boolean {
+  if (restoreScrollAnchor(content, v, keep)) return true;
+  pendingAnchor = keep.uuid; pendingAnchorKeepY = keep.y;
+  const landed = scrollToAnchor(keep.uuid);
+  if (!anchorPendingOlder) { pendingAnchor = null; pendingAnchorKeepY = null; }   // an older-history fetch keeps them armed for chatHead's re-land
+  return landed;
 }
 
 // Scroll/anchor landing + deep-link diagnostics + restamp, AFTER the active view's DOM is up to date —

--- a/ui/webview/scroll-keep-on-show.test.ts
+++ b/ui/webview/scroll-keep-on-show.test.ts
@@ -90,8 +90,8 @@ test("render.ts: showActive keeps the reader's place across a re-show of the vie
   const body = m![1];
   assert.match(body, /const reshow = keepPlaceAcrossShow\(v, v\.el\.style\.display !== "none", content\.clientHeight > 0, navigating\);/);
   assert.match(body, /const keepAnchor = reshow \? \(keep !== undefined \? keep : \(!atBottom\(content\) \? captureScrollAnchor\(content, v\) : null\)\) : null;[^\n]*/, "captured BEFORE the rebuild, like appendActive — or handed in by a caller that had to empty the DOM first");
-  const restores = body.match(/if \(keepAnchor(?: && cc)?\) restoreScrollAnchor\(/g) || [];
-  assert.equal(restores.length, 2, "restored after landActive on the light path AND inside the deferred heavy build");
+  const restores = body.match(/if \(keepAnchor(?: && cc)?\) keepPlaceAcrossWindow\(/g) || [];
+  assert.equal(restores.length, 2, "restored after landActive on the light path AND inside the deferred heavy build (through the window-aware keep, T262l)");
   // the big-view re-collapse to the tail is a SWITCH rule: a re-show of the view on screen must not snap it to the bottom
   assert.match(body, /if \(!reshow && !pendingAnchor && pendingAnchorT == null\n\s*&& v\.el\.querySelectorAll\("\.turn"\)\.length > WINDOW_CAP\)/);
 });

--- a/ui/webview/tab-switch-defer.test.ts
+++ b/ui/webview/tab-switch-defer.test.ts
@@ -14,7 +14,7 @@ test("showActive renders a built view synchronously, defers an unbuilt/changed o
   // shows the "Loading transcript…" hint — it renders the empty placeholder synchronously (the user 2026-06-19)
   assert.match(RENDER, /const heavy = s\.events\.length > 0 && \(v\.el\.childNodes\.length === 0 \|\| \(settings\.compact && \(v\.rendered !== s\.events\.length \|\| v\.stale\)\)\);/);
   // cached/incremental → instant; since T249 the light path also restores the re-show anchor after the land
-  assert.match(RENDER, /if \(!heavy\) \{\s*\n\s*syncView\(activeId!\); landActive\(content, v\);\n\s*if \(keepAnchor\) restoreScrollAnchor\(content, v, keepAnchor\);[^\n]*\n\s*return;\n\s*\}/);
+  assert.match(RENDER, /if \(!heavy\) \{\s*\n\s*syncView\(activeId!\); landActive\(content, v\);\n\s*if \(keepAnchor\) keepPlaceAcrossWindow\(content, v, keepAnchor\);[^\n]*\n\s*return;\n\s*\}/);
 });
 
 test("the heavy build is deferred via rAF, replacing any in-flight one, and skipped if we switched away", () => {
@@ -27,5 +27,5 @@ test("the heavy build is deferred via rAF, replacing any in-flight one, and skip
 test("the landing (scroll/anchor/diagnostics) is factored so sync + deferred paths land identically", () => {
   assert.match(RENDER, /function landActive\(content: HTMLElement \| null, v: View\): void/);
   // called after the deferred build, on the #content read once for the land and the T249 re-show anchor restore
-  assert.match(RENDER, /const cc = document\.getElementById\("content"\);\n\s*syncView\(target\);[^\n]*\n\s*landActive\(cc, vv\);\n\s*if \(keepAnchor && cc\) restoreScrollAnchor\(cc, vv, keepAnchor\);/);
+  assert.match(RENDER, /const cc = document\.getElementById\("content"\);\n\s*syncView\(target\);[^\n]*\n\s*landActive\(cc, vv\);\n\s*if \(keepAnchor && cc\) keepPlaceAcrossWindow\(cc, vv, keepAnchor\);/);
 });


### PR DESCRIPTION
## Summary
A re-render that re-windows the chat view (a settings change, any `rerenderAll`) keeps a scrolled-up reader's place: when the direct anchor restore misses because the fresh window does not hold the anchor turn, the deep-link land takes over with the kept offset.

## Found on the harness (2026-09-08, while chasing the snap)
Two full re-renders under a reader at 55% of a 400-pair virtualized transcript (headless Chromium):

| tree | anchor turn offset on screen | moves | rows |
|---|---|---|---|
| main | −0.1 px → **+198 px** | 2 (−100, −99) | `spacer` dTop −10348 / dBot +4378, `land-saved`, `rewindow` ×2 |
| this branch | −0.14 px → −0.14 px | 0 | `land-saved`, `keep-offset` |

Under a bottom reader both trees land at the bottom (distance 0).

## Why it drifted
`rerenderAll` empties every view and resets the window and the average row height; `showActive(keep)` rebuilds the tail window and lands, then `restoreScrollAnchor` queries the anchor uuid in the DOM. For a reader far above the tail the uuid is not rendered, so the restore returned false and the reader stayed on the raw saved scrollTop in a layout whose spacer estimate had moved by thousands of pixels.

## Fix
`keepPlaceAcrossWindow(content, v, keep)`: the direct restore first; on a miss, `pendingAnchor` and `pendingAnchorKeepY` are armed and `scrollToAnchor` runs, which renders a window around the anchor's unit (or fetches older history and re-lands on arrival) and writes `keep-offset`, the anchor's exact on-screen position. Disarmed afterwards unless an older-history fetch will re-land. Both `showActive` build paths (immediate and deferred) use it.

## Tests
- New `ui/webview/keep-across-window.test.ts`: the helper's control flow and both call sites pinned (the machinery it reuses has its own executed tests).
- `scroll-keep-on-show` and `tab-switch-defer` pins moved to the helper.
- `npm run typecheck` clean; the full extension suite runs on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
