### PR TITLE
tab-strip-skip-exec: the lifted renderTabs needs tabDotClass in its sandbox

### DIFF
--- a/ui/webview/tab-strip-skip-exec.test.ts
+++ b/ui/webview/tab-strip-skip-exec.test.ts
@@ -12,7 +12,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { createRequire } from "node:module";
 import { planStrip, parseTabGroups, headWords } from "./tab-groups";
-import { tabStateClass, sectionPip, sectionPipMembers, sectionPipTitle } from "./tab-state";
+import { tabStateClass, tabDotClass, sectionPip, sectionPipMembers, sectionPipTitle } from "./tab-state";
 import type { TagUnion } from "./session-views";
 
 const requireCjs = createRequire(__filename);
@@ -62,7 +62,7 @@ type Hooks = {
   phone: boolean;             // the phone layout: the plan is the flat strip there
   heads: HeadCall[];          // every group header the paint minted, in order
   planStrip: typeof planStrip; parseTabGroups: typeof parseTabGroups; headWords: typeof headWords;
-  tabStateClass: typeof tabStateClass; sectionPip: typeof sectionPip; sectionPipMembers: typeof sectionPipMembers; sectionPipTitle: typeof sectionPipTitle;
+  tabStateClass: typeof tabStateClass; tabDotClass: typeof tabDotClass; sectionPip: typeof sectionPip; sectionPipMembers: typeof sectionPipMembers; sectionPipTitle: typeof sectionPipTitle;
 };
 type Api = {
   renderTabs: () => void; sig: () => string; folded: () => Set<string>;
@@ -97,7 +97,7 @@ function lift(): (hooks: Hooks) => Api {
     const readTabGroups = (u) => H.parseTabGroups(H.groupsRaw, u);
     const tabGroups = () => readTabGroups(H.unions); const writeTabGroups = () => {};
     const phoneLayout = () => H.phone;
-    const tabStateClass = H.tabStateClass, sectionPip = H.sectionPip, sectionPipMembers = H.sectionPipMembers, sectionPipTitle = H.sectionPipTitle;
+    const tabStateClass = H.tabStateClass, tabDotClass = H.tabDotClass, sectionPip = H.sectionPip, sectionPipMembers = H.sectionPipMembers, sectionPipTitle = H.sectionPipTitle;   // tabDotClass: the state-dot slot every tab carries (the tab-strip fix, 2026-09-08)
     function makeGroupHead(sec, folded, active, hidden) {
       const h = el("div", "tab-group-head" + (folded ? " collapsed" : ""));
       h.dataset.group = String(sec.name);
@@ -139,7 +139,7 @@ function world(): { H: Hooks; api: Api; sessions: Map<string, any>; tabMeta: Map
   const H: Hooks = { FakeEl, bar: new FakeEl("div"), mslot: null, only: "", hidden: new Set(), down: new Set(), notes: {},
                      keyHint: "Open a session (K)", lens: { all: true }, unions: [], tips: [], aftermaths: [], rowPaints: 0, tagSyncs: 0, placeholders: 0,
                      groupsRaw: null, phone: false, heads: [],
-                     planStrip, parseTabGroups, headWords, tabStateClass, sectionPip, sectionPipMembers, sectionPipTitle };
+                     planStrip, parseTabGroups, headWords, tabStateClass, tabDotClass, sectionPip, sectionPipMembers, sectionPipTitle };
   const api = lift()(H);
   const sessions = new Map<string, any>([["a", session("web", "ready")], ["b", session("api", "working")]]);
   const tabMeta = new Map<string, any>([["p", { name: "tests", color: { bg: "#112233", fg: "#ffffff" } }]]);

--- a/ui/webview/tab-strip-skip.test.ts
+++ b/ui/webview/tab-strip-skip.test.ts
@@ -57,7 +57,7 @@ test("every input the strip renders is in the signature", () => {
   // the state class the paint adds is the signature's own reading of the state: one rule for both — and for
   // the folded header's pip (tab-state.ts, the shared module)
   assert.match(fn, /const stateCls = tabStateClass\(s\.status\);\s*\n\s*if \(stateCls\) tab\.classList\.add\(stateCls\);/);
-  assert.match(RENDER, /^import \{ tabStateClass, sectionPip, sectionPipMembers, sectionPipTitle \} from "\.\/tab-state";/m);
+  assert.match(RENDER, /^import \{ tabStateClass, tabDotClass, sectionPip, sectionPipMembers, sectionPipTitle \} from "\.\/tab-state";/m);   // + tabDotClass: the dot slot every tab carries derives from st.state, already in the signature (the tab-strip fix, 2026-09-08)
 });
 
 test("a tab drag resets the signature (its live reorder changes the strip's DOM outside renderTabs), and the tooltip reads the session fresh", () => {


### PR DESCRIPTION
## Summary
Main's extension suite is red: ten tests in `ui/webview/tab-strip-skip-exec.test.ts` fail with `tabDotClass is not defined`.

## Why
Two merges crossed on 2026-09-08. The executed tab-strip test, which lifts `renderTabs` into a sandbox and hands it the tab-state helpers as hooks, landed with the T262h PR minutes before the tab-strip fix (PR 1108) auto-merged; that fix made `renderTabs` read the state dot's class from `tabDotClass` in tab-state.ts, and its check had run before the test existed. Every PR's merge check now fails on the ten tests.

## Change
`tabDotClass` joins the sandbox's hooks beside `tabStateClass`: imported, typed, destructured into the lifted code, passed. Test-only; the suite passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)