### PR TITLE
Held queued copies: judged against the previous push, released by their own landing, never a phantom after a cancel; the cached pending node is wired once

### DIFF
--- a/tests/test_queued_copy_held.py
+++ b/tests/test_queued_copy_held.py
@@ -65,6 +65,12 @@ const page = await browser.newPage({ viewport: { width: 1000, height: 600 } });
 await page.addInitScript(() => {
   window.__rows = []; window.__frames = [];
   window.addEventListener("message", (e) => { const m = e.data; if (m && (m.type === "session" || m.type === "update" || m.type === "chatTail")) window.__frames.push(m); });
+  // while the synthetic sequence runs, the kernel's own frames for this session are held back (a status-only tail
+  // would truncate the injected events): the shim's socket handler is wrapped at the prototype
+  window.__quiet = false;
+  const desc = Object.getOwnPropertyDescriptor(WebSocket.prototype, "onmessage");
+  Object.defineProperty(WebSocket.prototype, "onmessage", { configurable: true, get() { return desc.get.call(this); },
+    set(fn) { desc.set.call(this, (ev) => { if (window.__quiet) { try { const m = JSON.parse(ev.data); if (m && (m.type === "chatTail" || m.type === "update" || m.type === "session" || m.type === "status")) return; } catch (e) {} } return fn.call(this, ev); }); } });
   const orig = WebSocket.prototype.send;
   WebSocket.prototype.send = function (d) {
     try { const m = JSON.parse(d); if (m && m.type === "clientDiag" && m.surface === "chat" && /^scroll/.test(m.what || "")) window.__rows.push({ what: m.what, writer: m.data && m.data.writer, before: m.data && m.data.before, after: m.data && m.data.after, sh: m.data && m.data.sh }); } catch (e) {}
@@ -106,8 +112,8 @@ const run = async (label, qid, uuid) => {
   await inject(landed(base, qid, uuid)); await page.waitForTimeout(400); out.landed = await measure();
   return out;
 };
-// a bottom reader
-await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = c.scrollHeight; window.__rows = []; });
+// a bottom reader; from here on only the synthetic frames reach the page
+await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = c.scrollHeight; window.__rows = []; window.__quiet = true; });
 await page.waitForTimeout(300);
 const start = await measure();
 const idPath = await run("id", "echo:m1", "am1");

--- a/ui/webview/queued-held.test.ts
+++ b/ui/webview/queued-held.test.ts
@@ -1,79 +1,111 @@
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { reconcileHeld, heldAsQueued, landsCopy, type HeldCopy, type HeldEvent, type HeldQueued } from "./queued-held";
+import { reconcileHeld, heldAsQueued, landsCopy, lastKernelUuid, type HeldMemory, type HeldEvent, type HeldQueued } from "./queued-held";
 
 // T262i: a kernel queued copy that left the queue frame before its landed record arrived is HELD in place, marked
 // landing, until the atom carrying its id arrives; an id-less copy is held by text for one push; never a phantom.
+// The follow-up (the first review's reproductions): a copy judged against the PREVIOUS push's anchor, so one that
+// vanishes and lands in the same push is released; a landing that releases a sibling is not a "later" landing; a
+// copy the user cancelled here, or one that vanished on a settled session, is never held; copies count per text.
 
 const mail = "[romp mail from api] the fixtures batch is labeled";
 const base: HeldEvent[] = [{ kind: "user", uuid: "u1", md: "tighten the search" }, { kind: "assistant", uuid: "a1", md: "…" }];
+const fresh = (): HeldMemory => ({ prev: [], anchor: null, held: [] });
+const withCard = (qid?: string): HeldMemory => reconcileHeld(fresh(), base, [{ md: mail, ...(qid ? { qid, qts: 5 } : {}), romp: true }]);
 
 test("an identified copy that vanished from the queue is held until the atom with its id lands, then released", () => {
-  const prev: HeldQueued[] = [{ md: mail, qid: "echo:m1", qts: 5, romp: true }];
-  // push 1: the queue no longer lists it, nothing landed → held, anchored on the last kernel event
-  let r = reconcileHeld(prev, [], base, []);
-  assert.deepEqual(r.held.map((h) => [h.qid, h.since, h.pushes]), [["echo:m1", "a1", 0]]);
-  assert.deepEqual(heldAsQueued(r.held[0]), { md: mail, qid: "echo:m1", qts: 5, romp: true, rompSystem: undefined, rompAuto: undefined, followUp: undefined, goal: undefined, fuCtx: undefined, imgPaths: undefined, landing: true });
+  let m = withCard("echo:m1");
+  assert.deepEqual([m.prev.map((p) => p.qid), m.anchor, m.held], [["echo:m1"], "a1", []], "the memory: the copies listed, the push's anchor");
+  // push 1: the queue no longer lists it, nothing landed → held, judged against the previous push's anchor
+  m = reconcileHeld(m, base, []);
+  assert.deepEqual(m.held.map((h) => [h.qid, h.since, h.pushes]), [["echo:m1", "a1", 0]]);
+  assert.deepEqual(heldAsQueued(m.held[0]), { md: mail, qid: "echo:m1", qts: 5, romp: true, rompSystem: undefined, rompAuto: undefined, followUp: undefined, goal: undefined, fuCtx: undefined, imgPaths: undefined, landing: true });
   // push 2: still nothing → still held (an identified copy waits for its atom)
-  r = reconcileHeld(r.prev, r.held, base, []);
-  assert.deepEqual(r.held.map((h) => [h.qid, h.pushes]), [["echo:m1", 1]]);
+  m = reconcileHeld(m, base, []);
+  assert.deepEqual(m.held.map((h) => [h.qid, h.pushes]), [["echo:m1", 1]]);
   // push 3: the atom with its id lands → released (the atom takes the slot)
-  r = reconcileHeld(r.prev, r.held, [...base, { kind: "user", uuid: "am1", md: mail, qid: "echo:m1" }], []);
-  assert.deepEqual(r.held, []);
+  m = reconcileHeld(m, [...base, { kind: "user", uuid: "am1", md: mail, qid: "echo:m1" }], []);
+  assert.deepEqual(m.held, []);
   // a record of several sends carrying the id among its qids releases it too
-  let r2 = reconcileHeld(prev, [], base, []);
-  r2 = reconcileHeld(r2.prev, r2.held, [...base, { kind: "user", uuid: "am9", md: "x y", blocks: [mail, "y"], qids: ["echo:m1", "q9"] }], []);
-  assert.deepEqual(r2.held, []);
+  let m2 = reconcileHeld(withCard("echo:m1"), base, []);
+  m2 = reconcileHeld(m2, [...base, { kind: "user", uuid: "am9", md: "x y", blocks: [mail, "y"], qids: ["echo:m1", "q9"] }], []);
+  assert.deepEqual(m2.held, []);
 });
 
-test("a held identified copy is dropped once a LATER landing shows the CLI passed it, or once the queue lists it again", () => {
-  const prev: HeldQueued[] = [{ md: mail, qid: "echo:m1" }];
-  let r = reconcileHeld(prev, [], base, []);
-  // another message landed after the anchor without this copy's id: first-in-first-out says this copy is not coming
-  r = reconcileHeld(r.prev, r.held, [...base, { kind: "user", uuid: "u2", md: "something else" }], []);
-  assert.deepEqual(r.held, [], "a later landing drops the hold");
+test("a copy that vanishes and lands in the SAME push is released, never held (the anchor is the previous push's)", () => {
+  const m = reconcileHeld(withCard("echo:m1"), [...base, { kind: "user", uuid: "am1", md: mail, qid: "echo:m1" }], []);
+  assert.deepEqual(m.held, [], "its landing sits after the previous push's tail: released");
+  assert.equal(m.anchor, "am1", "…and the new anchor is that landing");
+  const t = reconcileHeld(withCard(), [...base, { kind: "user", uuid: "am1", md: mail }], []);
+  assert.deepEqual(t.held, [], "the id-less copy too, by text");
+});
+
+test("a held identified copy is dropped once a LATER landing shows the CLI passed it — but a landing that releases a sibling is not later", () => {
+  let m = reconcileHeld(withCard("echo:m1"), base, []);
+  m = reconcileHeld(m, [...base, { kind: "user", uuid: "u2", md: "something else" }], []);
+  assert.deepEqual(m.held, [], "a later landing drops the hold");
   // the kernel's echo or an undelivered verdict is not a landing
-  let r2 = reconcileHeld(prev, [], base, []);
-  r2 = reconcileHeld(r2.prev, r2.held, [...base, { kind: "user", uuid: "echo:x", md: "something else" }, { kind: "user", uuid: "u3", md: "lost", undelivered: true }], []);
-  assert.deepEqual(r2.held.map((h) => h.qid), ["echo:m1"], "an echo or a verdict is not a later landing");
+  let m2 = reconcileHeld(withCard("echo:m1"), base, []);
+  m2 = reconcileHeld(m2, [...base, { kind: "user", uuid: "echo:x", md: "something else" }, { kind: "user", uuid: "u3", md: "lost", undelivered: true }], []);
+  assert.deepEqual(m2.held.map((h) => h.qid), ["echo:m1"], "an echo or a verdict is not a later landing");
+  // two copies taken at one boundary: the first's record lands alone — the second stays held for its own
+  let m3 = reconcileHeld(fresh(), base, [{ md: "first mail", qid: "echo:a" }, { md: "second mail", qid: "echo:b" }]);
+  m3 = reconcileHeld(m3, base, []);
+  assert.deepEqual(m3.held.map((h) => h.qid), ["echo:a", "echo:b"]);
+  m3 = reconcileHeld(m3, [...base, { kind: "user", uuid: "aa", md: "first mail", qid: "echo:a" }], []);
+  assert.deepEqual(m3.held.map((h) => h.qid), ["echo:b"], "the first's landing releases the first and is not a later landing for the second");
+  m3 = reconcileHeld(m3, [...base, { kind: "user", uuid: "aa", md: "first mail", qid: "echo:a" }, { kind: "user", uuid: "ab", md: "second mail", qid: "echo:b" }], []);
+  assert.deepEqual(m3.held, []);
   // the copy is listed again (the queue frame shows it): nothing to hold
-  let r3 = reconcileHeld(prev, [], base, []);
-  r3 = reconcileHeld(r3.prev, r3.held, base, [{ md: mail, qid: "echo:m1" }]);
-  assert.deepEqual(r3.held, []);
-  assert.deepEqual(r3.prev.map((p) => p.qid), ["echo:m1"], "…and it is the previous frame's copy again");
+  let m4 = reconcileHeld(withCard("echo:m1"), base, []);
+  m4 = reconcileHeld(m4, base, [{ md: mail, qid: "echo:m1" }]);
+  assert.deepEqual([m4.held, m4.prev.map((p) => p.qid)], [[], ["echo:m1"]]);
   // the anchor left the resident window: the same reading as a later landing (never a phantom)
-  let r4 = reconcileHeld(prev, [], base, []);
-  r4 = reconcileHeld(r4.prev, r4.held, [{ kind: "assistant", uuid: "a7", md: "…" }], []);
-  assert.deepEqual(r4.held, []);
+  let m5 = reconcileHeld(withCard("echo:m1"), base, []);
+  m5 = reconcileHeld(m5, [{ kind: "assistant", uuid: "a7", md: "…" }], []);
+  assert.deepEqual(m5.held, []);
+});
+
+test("a copy the user cancelled here, or one that vanished on a SETTLED session, is never held", () => {
+  const cancelled = (c: { md: string; qid?: string }) => c.qid === "echo:m1";
+  const m = reconcileHeld(withCard("echo:m1"), base, [], { cancelled });
+  assert.deepEqual(m.held, [], "the ✕ said so: nothing will land");
+  const s = reconcileHeld(withCard("echo:m1"), base, [], { settled: true });
+  assert.deepEqual(s.held, [], "a settled session took nothing: cancelled or dropped");
+  let h = reconcileHeld(withCard("echo:m1"), base, []);
+  h = reconcileHeld(h, base, [], { settled: true });
+  assert.deepEqual(h.held, [], "…and a hold is dropped the push the session settles without a landing");
 });
 
 test("an id-less copy is held by text for the push it vanished on and dropped at the next, unless its text lands first", () => {
-  const prev: HeldQueued[] = [{ md: mail }];
-  let r = reconcileHeld(prev, [], base, []);
-  assert.deepEqual(r.held.map((h) => [h.qid, h.pushes]), [[undefined, 0]]);
-  const held1 = r.held;
-  r = reconcileHeld(r.prev, held1, base, []);
-  assert.deepEqual(r.held, [], "dropped at the next push that carries the queue");
-  // …but a landing of the text on that next push claims it (released, not dropped: the atom is there)
-  let r2 = reconcileHeld(prev, [], base, []);
-  r2 = reconcileHeld(r2.prev, r2.held, [...base, { kind: "user", uuid: "am2", md: mail }], []);
-  assert.deepEqual(r2.held, []);
+  let m = reconcileHeld(withCard(), base, []);
+  assert.deepEqual(m.held.map((h) => [h.qid, h.pushes]), [[undefined, 0]]);
+  m = reconcileHeld(m, base, []);
+  assert.deepEqual(m.held, [], "dropped at the next push that carries the queue");
+  let m2 = reconcileHeld(withCard(), base, []);
+  m2 = reconcileHeld(m2, [...base, { kind: "user", uuid: "am2", md: mail }], []);
+  assert.deepEqual(m2.held, []);
   // a same-text copy still queued: not vanished, nothing held
-  assert.deepEqual(reconcileHeld(prev, [], base, [{ md: mail }]).held, []);
+  assert.deepEqual(reconcileHeld(withCard(), base, [{ md: mail }]).held, []);
   // an OLDER record of the same text (before the anchor) is history, not this copy's landing: still held
   const older: HeldEvent[] = [{ kind: "user", uuid: "am0", md: mail }, ...base];
-  let r3 = reconcileHeld(prev, [], older, []);
-  assert.deepEqual(r3.held.map((h) => [h.qid, h.since]), [[undefined, "a1"]], "held: the same-text record predates the vanish");
-  r3 = reconcileHeld(r3.prev, r3.held, [...older, { kind: "user", uuid: "am1", md: mail }], []);
-  assert.deepEqual(r3.held, [], "…and the record after the anchor claims it");
+  let m3 = reconcileHeld(reconcileHeld(fresh(), older, [{ md: mail }]), older, []);
+  assert.deepEqual(m3.held.map((h) => [h.qid, h.since]), [[undefined, "a1"]], "held: the same-text record predates the vanish");
+  m3 = reconcileHeld(m3, [...older, { kind: "user", uuid: "am1", md: mail }], []);
+  assert.deepEqual(m3.held, [], "…and the record after the anchor claims it");
+  // two identical id-less copies, one taken: one is held (counted per text)
+  let m4 = reconcileHeld(fresh(), base, [{ md: mail }, { md: mail }]);
+  m4 = reconcileHeld(m4, base, [{ md: mail }]);
+  assert.deepEqual(m4.held.map((h) => h.md), [mail], "the copy that left is the one held");
 });
 
-test("our own bubble and hidden copies never become held copies; a landing is a real record only", () => {
+test("our own bubble and hidden copies never become held copies; a landing is a real record only; the anchor skips uuid-less markers", () => {
   const prev: HeldQueued[] = [{ md: "mine", optimistic: true }, { md: "hidden", qid: "h1", hiddenByPending: true }, { md: mail, qid: "echo:m1" }];
-  const r = reconcileHeld(prev, [], base, []);
-  assert.deepEqual(r.held.map((h) => h.qid), ["echo:m1"]);
+  const m = reconcileHeld(reconcileHeld(fresh(), base, prev), base, []);
+  assert.deepEqual(m.held.map((h) => h.qid), ["echo:m1"]);
   assert.equal(landsCopy({ kind: "user", uuid: "echo:m1", md: mail }, { md: mail, qid: "echo:m1" }), false, "the kernel's echo is not a landing");
   assert.equal(landsCopy({ kind: "user", uuid: "optimistic:1", md: mail }, { md: mail }), false, "our bubble is not a landing");
   assert.equal(landsCopy({ kind: "user", uuid: "u9", md: mail }, { md: mail, qid: "echo:m1" }), false, "an id-bearing copy needs its id, not its text");
   assert.equal(landsCopy({ kind: "user", uuid: "u9", md: mail }, { md: mail }), true);
+  assert.equal(lastKernelUuid([...base, { kind: "compacting" }, { kind: "queued" }]), "a1", "a uuid-less marker or a queued group is no anchor");
 });

--- a/ui/webview/queued-held.ts
+++ b/ui/webview/queued-held.ts
@@ -44,47 +44,77 @@ export function landsCopy(e: HeldEvent, c: { md: string; qid?: string }): boolea
   return Array.isArray(e.blocks) && e.blocks.some((b) => typeof b === "string" && sameText(b, c.md));
 }
 
-/** Index of the last KERNEL event (not our own bubble), or -1. */
-function lastKernelIdx(events: HeldEvent[]): number {
-  for (let i = events.length - 1; i >= 0; i--) if (!isOptimistic(events[i].uuid) && events[i].kind !== "queued") return i;
-  return -1;
+/** The uuid of the last KERNEL event that carries one (not our own bubble, not a queued group, not a uuid-less
+ *  compacting/clearing marker), or null: the anchor a hold is judged against. */
+export function lastKernelUuid(events: HeldEvent[]): string | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.kind === "queued" || !e.uuid || isOptimistic(e.uuid)) continue;
+    return e.uuid;
+  }
+  return null;
 }
+
+/** The per-session memory between pushes: the kernel's queued copies on the previous push and the anchor of
+ *  that push (its last kernel uuid) — a copy that vanished on THIS push is judged against landings after the
+ *  PREVIOUS push's tail, so a copy that vanishes and lands in one push is released, never held. */
+export type HeldMemory = { prev: HeldQueued[]; anchor: string | null; held: HeldCopy[] };
+
+/** What this push knows besides its events: the copies the user cancelled here (the ✕: the kernel will drop
+ *  them and nothing lands — never held), and whether the session has SETTLED (not working: a copy the queue no
+ *  longer lists on a settled session was cancelled or dropped, since a taken copy starts a turn). */
+export type HeldContext = { cancelled?: (c: { md: string; qid?: string }) => boolean; settled?: boolean };
 
 /** One push's decision. `prev` = the kernel's queued copies on the previous push (its tail group, our own bubble
  *  and hidden copies excluded); `held` = the copies held so far; `events` = this push's KERNEL events (our
  *  injections stripped); `cur` = this push's queued copies. Returns the copies to keep holding — each rendered
  *  in the tail group marked `landing` — and the previous-copies memory for the next push. */
-export function reconcileHeld(prev: HeldQueued[], held: HeldCopy[], events: HeldEvent[], cur: HeldQueued[]): { held: HeldCopy[]; prev: HeldQueued[] } {
+export function reconcileHeld(mem: HeldMemory, events: HeldEvent[], cur: HeldQueued[], ctx: HeldContext = {}): HeldMemory {
   const kernelCopies = cur.filter((t) => typeof t.md === "string" && !t.optimistic && !t.landing);
-  const listed = (c: { md: string; qid?: string }): boolean =>
-    kernelCopies.some((t) => c.qid ? t.qid === c.qid : (!t.qid && sameText(t.md as string, c.md)));
-  const out: HeldCopy[] = [];
-  const consider = (c: HeldCopy) => {
-    if (listed(c)) return;                                              // queued again: nothing to hold
-    // only a landing AFTER the anchor (the last kernel event when the copy vanished) is the copy's — the way the
-    // pending path reads landings after the send: an older same-text record is history, not this copy (matters for
-    // the id-less text fallback; an id is unique wherever it sits)
+  const prevCopies = mem.prev.filter((p) => typeof p.md === "string" && !p.optimistic && !p.landing && !p.hiddenByPending);
+  // copies are counted per identity, else per TEXT: two identical id-less copies with one taken leave one listed,
+  // and the one that left is the one to hold; a key listed MORE than on the previous push has a held copy back
+  const keyOf = (c: { md?: string; qid?: string }): string => c.qid || "text:" + (c.md as string).trim();
+  const countBy = (list: { md?: string; qid?: string }[]): Map<string, number> => {
+    const m = new Map<string, number>();
+    for (const c of list) m.set(keyOf(c), (m.get(keyOf(c)) || 0) + 1);
+    return m;
+  };
+  const prevN = countBy(prevCopies), curN = countBy(kernelCopies);
+  const candidates: HeldCopy[] = [];
+  const keys = new Set<string>([...prevN.keys(), ...mem.held.map(keyOf)]);
+  for (const k of keys) {
+    const carried = mem.held.filter((h) => keyOf(h) === k).map((h) => ({ ...h, pushes: h.pushes + 1 }));
+    const relisted = Math.max(0, (curN.get(k) || 0) - (prevN.get(k) || 0));   // came back to the queue: not held
+    candidates.push(...carried.slice(relisted));
+    const vanished = Math.max(0, (prevN.get(k) || 0) - (curN.get(k) || 0));
+    for (const p of prevCopies.filter((c) => keyOf(c) === k).slice(0, vanished))
+      candidates.push({ md: p.md as string, qid: p.qid, qts: p.qts, romp: p.romp, rompSystem: p.rompSystem, rompAuto: p.rompAuto,
+                        followUp: p.followUp, goal: p.goal, fuCtx: p.fuCtx, imgPaths: p.imgPaths, since: mem.anchor, pushes: 0 });
+  }
+  // the landings after each candidate's anchor; a landing that RELEASES a held copy is that copy's, not a "later"
+  // one for its siblings (two copies taken at one boundary land one record at a time)
+  const afterOf = (c: HeldCopy): HeldEvent[] => {
     const from = c.since === null ? -1 : events.findIndex((e) => e.uuid === c.since);
-    const after = c.since === null || from < 0 ? events : events.slice(from + 1);
-    if (after.some((e) => landsCopy(e, c))) return;                     // its atom is here: it takes the slot
-    if (!c.qid && c.pushes >= 1) return;                                // id-less: one push by text, then never a phantom
+    return c.since === null || from < 0 ? events : events.slice(from + 1);
+  };
+  const anchorGone = (c: HeldCopy): boolean => c.since !== null && !events.some((e) => e.uuid === c.since);
+  const releasing = new Set<HeldEvent>();
+  for (const c of candidates) { const hit = afterOf(c).find((e) => landsCopy(e, c)); if (hit) releasing.add(hit); }
+  const out: HeldCopy[] = [];
+  for (const c of candidates) {
+    if (ctx.cancelled && ctx.cancelled(c)) continue;                   // the user cancelled it here: nothing will land
+    const after = afterOf(c);
+    if (after.some((e) => landsCopy(e, c))) continue;                   // its atom is here: it takes the slot
+    if (!c.qid && c.pushes >= 1) continue;                              // id-less: one push by text, then never a phantom
+    if (ctx.settled) continue;                                          // a settled session took nothing: cancelled or dropped
     if (c.qid && c.since !== null) {                                    // a later landing means the CLI passed it
-      const later = after.some((e) => e.kind === "user" && !isEcho(e.uuid) && !isOptimistic(e.uuid) && !e.undelivered);
-      if (from < 0 || later) return;                                    // (its anchor left the window: the same reading)
+      const later = after.some((e) => e.kind === "user" && !isEcho(e.uuid) && !isOptimistic(e.uuid) && !e.undelivered && !releasing.has(e));
+      if (anchorGone(c) || later) continue;                             // (its anchor left the window: the same reading)
     }
     out.push(c);
-  };
-  for (const h of held) consider({ ...h, pushes: h.pushes + 1 });
-  const anchor = events[lastKernelIdx(events)]?.uuid ?? null;
-  for (const p of prev) {
-    if (typeof p.md !== "string" || p.optimistic || p.landing || p.hiddenByPending) continue;
-    const pmd: string = p.md;
-    if (held.some((h) => h.qid ? h.qid === p.qid : (!p.qid && sameText(h.md, pmd)))) continue;   // already held
-    if (listed({ md: pmd, qid: p.qid })) continue;
-    consider({ md: pmd, qid: p.qid, qts: p.qts, romp: p.romp, rompSystem: p.rompSystem, rompAuto: p.rompAuto,
-               followUp: p.followUp, goal: p.goal, fuCtx: p.fuCtx, imgPaths: p.imgPaths, since: anchor, pushes: 0 });
   }
-  return { held: out, prev: kernelCopies.map((t) => ({ ...t })) };
+  return { held: out, prev: kernelCopies.map((t) => ({ ...t })), anchor: lastKernelUuid(events) };
 }
 
 /** The queued copies a held copy renders as: the same card, marked `landing`, never cancelable (the kernel no

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -27,7 +27,7 @@ test("renderQueued draws a wireframe-hourglass header (singular/plural) + one ma
   // noun matches the content: all-commands → "command", all-prose → "message", mixed → "item" (the user 2026-07-01)
   assert.match(RENDER, /const noun = nCmd === n \? "command" : nSys === n \? "notice" : nNudge === n \? "nudge"\s*\n\s*: \(nCmd === 0 && nSys === 0 && nNudge === 0\) \? "message" : "item";/);   // romp's own entries: T243
   assert.match(RENDER, /return `\$\{n\} queued \$\{noun\}\$\{n === 1 \? "" : "s"\}`/);
-  assert.match(RENDER, /label\.textContent = queuedCountText\(n, nCmd, nSys, nNudge\) \+ why;/);
+  assert.match(RENDER, /label\.textContent = \(texts\.every\(\(t\) => t\.landing\) \? `\$\{n\} \$\{n === 1 \? "message" : "messages"\} landing…` : queuedCountText\(n, nCmd, nSys, nNudge\)\) \+ why;/);   // a held-only group says landing (T262i)
   assert.match(RENDER, /el\("div", "queued-head"\)/);
   // one faint "you" bubble per pending message, rendered as markdown (like a landed message — the
   // user-text renderer, newlines kept, so the queued→landed swap changes nothing on screen)

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -39,7 +39,7 @@ import { DEFAULT_CHORDS } from "./commands";
 import { NavHistory } from "./nav-history";
 import { StagedStack } from "./staged-messages";
 import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, newPending, reconcilePending, queuedCopyToHide, dropPending, bareGroupLabel, sentAtLabel } from "./send-pending";
-import { reconcileHeld, heldAsQueued, type HeldCopy, type HeldQueued } from "./queued-held";
+import { reconcileHeld, heldAsQueued, type HeldCopy, type HeldQueued, type HeldMemory } from "./queued-held";
 import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional, focusResolvesProvisional } from "./provisional";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
@@ -451,12 +451,38 @@ function stripOptimistic(s: Session, keepHeld = false): void {
 // pending sends are reconciled (a held copy of OUR text is then hidden for our bubble like any kernel copy).
 const HELD_PREFIX = "held:";
 const isHeldGroup = (e: ChatEvent): boolean => e.kind === "queued" && !!e.uuid && e.uuid.startsWith(HELD_PREFIX);
-const heldQueued = new Map<string, { prev: HeldQueued[]; held: HeldCopy[] }>();
+const heldQueued = new Map<string, HeldMemory>();
+// the copies the user cancelled with the ✕ on this client, per session (their qid, or their text when the kernel
+// gave none): the kernel drops them and nothing lands, so a vanished cancelled copy is never held; the entry is
+// forgotten once the queue no longer lists the copy (the cancel took effect) — event-based, no timer
+const cancelledQueued = new Map<string, { qid?: string; md: string }[]>();
+function noteCancelledQueued(sid: string, md: string, qid?: string): void {
+  const list = cancelledQueued.get(sid) || [];
+  list.push({ qid, md });
+  cancelledQueued.set(sid, list);
+}
 function reconcileHeldCopies(s: Session): void {
-  const mem = heldQueued.get(s.id) || { prev: [], held: [] };
+  // idempotent: a frame that kept the resident events (an empty full frame) still carries the previous pass's held
+  // marks and group — cleared first, so the pass recomputes from the kernel's copies alone
+  for (let i = s.events.length - 1; i >= 0; i--) {
+    const e = s.events[i];
+    if (isHeldGroup(e)) { s.events.splice(i, 1); continue; }
+    if (e.kind === "queued" && e.texts.some((t) => t.landing)) s.events[i] = { ...e, texts: e.texts.filter((t) => !t.landing) };
+  }
+  const mem = heldQueued.get(s.id) || { prev: [], anchor: null, held: [] };
   const qi = tailQueuedIdx(s.events);
   const cur = qi >= 0 ? ((s.events[qi] as Extract<ChatEvent, { kind: "queued" }>).texts as HeldQueued[]) : [];
-  const r = reconcileHeld(mem.prev, mem.held, s.events as any, cur);
+  const cancelled = cancelledQueued.get(s.id) || [];
+  const settled = !(s.status.state === "working" || s.status.state === "compacting");
+  const r = reconcileHeld(mem, s.events as any, cur, {
+    settled,
+    cancelled: (c) => cancelled.some((x) => x.qid && c.qid ? x.qid === c.qid : x.md.trim() === c.md.trim()),
+  });
+  // a cancel has taken effect once the kernel's queue no longer lists the copy: forget it
+  if (cancelled.length) {
+    const still = cancelled.filter((x) => cur.some((t) => x.qid && t.qid ? t.qid === x.qid : (typeof t.md === "string" && t.md.trim() === x.md.trim())));
+    if (still.length) cancelledQueued.set(s.id, still); else cancelledQueued.delete(s.id);
+  }
   heldQueued.set(s.id, r);
   // the held set changed (a copy taken, a copy landed): the frame may keep its LENGTH while a held card gives way to
   // the landed atom, and the repaint's no-op fast path reads length alone — so the view is marked stale here
@@ -1876,6 +1902,10 @@ function renderEvent(ev: ChatEvent, prevEpoch?: number | null, worked?: number |
     const hid = el("div", "turn turn-user turn-echo-hidden"); hid.style.display = "none"; return hid;
   }
   const turn = renderEventInner(ev);
+  // OUR cached pending group comes back as the SAME element on every push (renderPendingGroup): its anchors, hover
+  // wiring and rail chrome were attached the first time and must not accumulate (T262h follow-up)
+  if (turn.dataset.wired === "1") return turn;
+  if (ev.kind === "queued" && isOptimistic(ev) && ev.bare) turn.dataset.wired = "1";
   // pending-rewind overlay (reconcileRewind): this turn sits AFTER an edited message — it belongs to
   // the branch being abandoned, so it dims until the kernel's rewound payload replaces it
   if ((ev as any).rewound) turn.classList.add("rewound");
@@ -3965,7 +3995,8 @@ function fillBareLabel(label: HTMLElement, nLost: number, nSending: number): voi
 const pendingGroupNode = new Map<string, { sig: string; node: HTMLElement }>();
 function renderPendingGroup(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
   const sid = renderingSid || activeId || "";
-  const sig = JSON.stringify(ev.texts.map((t) => [t.md, !!t.lost, t.qts, t.imgPaths || null])) + "|" + JSON.stringify(ev.held || null);
+  const sig = JSON.stringify(ev.texts.map((t) => [t.md, !!t.lost, t.qts, t.imgPaths || null])) + "|" + JSON.stringify(ev.held || null)
+    + (ev.held && ev.held.resetsAt ? "|" + Math.floor(Date.now() / 60000) : "");   // a held countdown reads the minute: re-rendered as it ticks
   const fresh = renderQueued(ev);
   const cached = pendingGroupNode.get(sid);
   if (cached && cached.node.isConnected !== undefined) {
@@ -4033,7 +4064,8 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
       : askNote;
     const label = el("span", "queued-count");
     label.dataset.why = why;      // the ✕'s recount rewrites the count and keeps this suffix as-is
-    label.textContent = queuedCountText(n, nCmd, nSys, nNudge) + why;
+    // every copy taken but not landed (T262i): the head says so, so a held card never reads as a queued one
+    label.textContent = (texts.every((t) => t.landing) ? `${n} ${n === 1 ? "message" : "messages"} landing…` : queuedCountText(n, nCmd, nSys, nNudge)) + why;
     // `detail` is the CLI's OWN sentence about the limit (it carries the reset time as a wall clock, which
     // is why that flavor has no epoch to count down to). One level deeper on hover, per the compact-by-
     // default rule — the head keeps its one-line reason.
@@ -15834,6 +15866,7 @@ setupSettings();
       const provisional = isProvisionalId(sidQ);
       if (provisional && qmd) forgetProvisionalSend(qmd);
       const msg: Record<string, unknown> = { type: "cancelQueued", id: sidQ, md: qmd };
+      if (qmd && el.dataset.qopt !== "1") noteCancelledQueued(sidQ, qmd, el.dataset.qid || undefined);   // a kernel copy: never held once it vanishes (T262i)
       if (el.dataset.qidx !== undefined) msg.idx = Number(el.dataset.qidx);
       if (el.dataset.qpark !== undefined) msg.park = Number(el.dataset.qpark);
       if (!provisional) vscodeApi.postMessage(msg);


### PR DESCRIPTION
Follow-up to #1111 (the tail-height fix), from its review's reproductions: a held queued copy is now judged against the **previous** push's anchor (a copy that vanishes and lands in one push is released, not held forever); a landing that releases a held copy is not a "later landing" for its siblings; a copy the user cancelled with the ✕, or one that vanished on a settled session, is never held (no phantom "landing" card); copies count per text; the held pass is idempotent; our cached pending node is wired once instead of accumulating hover chrome on every push; a held-only group's header says "landing…".

**Tests:** `ui/webview/queued-held.test.ts` (red on the merged rules for the same-push landing, the sibling drop, the cancel, the settled session and the per-text count), the flipped pins, and both served harnesses green on this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
