### PR TITLE
T269: every deploy restart bounces at once; romp refresh --quiet is the only quiet-window door

### DIFF
--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -845,7 +845,7 @@ function startManager() {
       // SIGTERM respawns blinked every dashboard for an hour, and this handler — the one door every
       // programmatic restart walks through — recorded nothing. The immediate path used to be silent.
       log(`restart-all requested (${url.searchParams.get('when') === 'quiet' ? 'deferred to quiet window' : 'IMMEDIATE'}) from ${req.socket.remoteAddress || '?'}`);
-      if (url.searchParams.get('when') === 'quiet') {            // deploy path: land at the next quiet window
+      if (url.searchParams.get('when') === 'quiet') {            // `romp refresh --quiet`, the one quiet door (T269): land at the next quiet window
         return json(202, { ok: true, deferred: true, coalesced: queueQuietRestart('all') });
       }
       clearPendingQuiet();                                       // this bounce delivers any pending deploy too

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -21,7 +21,7 @@ update` starts a session called "update".
 | `romp resume` | Resume a past conversation, chosen from a full-screen picker |
 | `romp status` | Manager and kernel status |
 | `romp refresh` | Restart the postal bus and every kernel immediately, picking up new code (cut turns resume with their history) |
-| `romp update [host…]` | Push this machine's committed Romp to attached remotes and restart them |
+| `romp update [host…]` | Push this machine's committed Romp to attached remotes and restart them at once (every deploy restart is immediate; boot reconcile resumes the cut turns with their history) |
 | `romp up` | Run the kernel manager in the foreground; rare, since the login service runs it |
 | `romp version` | Version report across the moving parts |
 | `romp keyswap [<name>] [--cycle <session,…>\|--cycle-all]` | Switch the API key source without restarting the manager: selects a key command, a 1Password reference or a legacy key from `service.env.<name>`, and `--cycle` reconnects running sessions onto it. Bare, it reports the configured source and candidates without fetching secrets. See [Switching which API key the sessions bill](#switching-which-api-key-the-sessions-bill-romp-keyswap) |
@@ -51,7 +51,7 @@ These are for scripting and for agents rather than daily use:
 | `romp default-dir [PATH]` | The default working directory for new sessions; no argument prints it, `""` clears it |
 | `romp debug [on\|off\|status]` | Judge debug mode, where rejection rows carry the full input and reply |
 | `romp resume <id> [--name <n>] [--detach]` | Resume one exact conversation by UUID |
-| `romp refresh --quiet` | Refresh at the next quiet window instead — waits for sessions to finish their turns (15-min backstop) |
+| `romp refresh --quiet` | Refresh at the next quiet window instead — waits for sessions to finish their turns (15-min backstop). The ONLY door to the quiet window: a deploy (a peer's `romp update`, a release self-update, an automatic converge) restarts immediately, by the user's 2026-09-08 decision |
 
 Raw `POST` callers, anything that talks to the kernel's routes directly rather
 than through `romp`, follow one body contract, and the postal bus's own routes

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7328,9 +7328,6 @@ def _parked_quiet_deploy(checkout, now=None):
     """The `t` of a QUIET deploy request still pending for the code the checkout holds, else 0
     (T240d): the newest restart-requesting audit row is a p2p-update (a peer's apply, which advanced
     the checkout and asked the manager for a quiet restart) or a main-converge with when=quiet, its
-    — since T269 a new peer's apply asks for an IMMEDIATE bounce and writes no when=quiet, so it
-    parks nothing here (its restart lands within the manager's ack, inside one drift cadence); the
-    quiet rows this reads now come from older peers, a quiet converge and `romp refresh --quiet` —
     sha is the checkout's, no cut row has consumed it (auditT), and it is inside the window a quiet
     request stays pending — the far manager's backstop bound, exactly what _recent_restart_audit
     already gives such a row for cut attribution. So a park lost with its manager self-heals at that
@@ -7338,7 +7335,10 @@ def _parked_quiet_deploy(checkout, now=None):
     function's own. The p2p row's sha rides its reason ("from <host> to <sha>"); the converge row
     carries `sha` outright, and so does the CLI's `romp refresh --quiet` row, which names no action
     (bin/romp's caller-attribution row, review find: that door parked a quiet restart the check
-    pre-empted just the same); a quiet row naming no sha matches nothing (never guess)."""
+    pre-empted just the same); a quiet row naming no sha matches nothing (never guess). Since T269 a
+    peer's apply asks for an IMMEDIATE bounce and writes no when=quiet, so it parks nothing here (its
+    restart lands within the manager's ack, inside one drift cadence); the quiet rows this reads come
+    from peers still on older code, a quiet converge and `romp refresh --quiet`."""
     rec = _recent_restart_audit(now=now)
     if not isinstance(rec, dict) or rec.get("when") != "quiet" or not checkout:
         return 0

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19747,28 +19747,27 @@ def _update_remote(host, head=None):
         'if [ ! -x "$R/bin/romp-serve" ]; then echo "NOLAUNCH:$NEW$K"; exit 0; fi; '
         # NEVER AN ANONYMOUS SIGTERM (T238, the T121 rule): a restart-audit row lands BEFORE whichever
         # restart happens, so the far kernel's cut row carries WHO and WHY (the p2p update, from this
-        # machine, to this sha) — nine restarts in three hours had no reason on record. The QUIET row
-        # lands HERE, right after the reset and before the owner check (T240d): the far kernel's drift
-        # check stands down for a quiet deploy of the code its checkout holds by reading this row, and
-        # the owner check's manager status call was a window in which the checkout was already ahead
-        # with no row on disk. When no owning manager answers, the fallback below writes its own
-        # IMMEDIATE row, which is then the newest and supersedes this one for every reader. The
-        # restart goes THROUGH THE FAR MANAGER'S QUIET WINDOW (restart-all --quiet: no in-flight turn is cut,
-        # the 15-minute backstop still lands the deploy, a second apply arriving while one is pending
-        # coalesces into the same bounce) — but ONLY when that manager actually OWNS the kernel on the
-        # polled port (its /status lists it): a manager owning nothing, or a bare kernel beside a
-        # crash-looping managed one, answers 202 and restarts nothing, which would have turned this
-        # into a silent never-restart (review find). SYNCED:<sha>:QUIET = deferred; SYNCED:<sha>:FALLBACK
-        # = the immediate path below ran (no owning manager reachable — node absent, no manager, or
-        # the polled kernel is bare). The quiet audit row says when=quiet; the fallback writes its own
-        # row without it, so the cut row joins the right request with the right window.
+        # machine, to this sha) — nine restarts in three hours had no reason on record. The row lands
+        # HERE, right after the reset and before the owner check (T240d), so the far kernel's drift check
+        # reads the request the moment its checkout is ahead. When no owning manager answers, the
+        # fallback below writes its own row, which is then the newest and supersedes this one for every
+        # reader. The restart goes THROUGH THE FAR MANAGER and lands AT ONCE (T269, the user 2026-09-08:
+        # every deploy restart bounces immediately — the parked quiet window held the devbox unusable
+        # for the full 15-minute backstop on 26 of 32 restarts in a morning, and boot reconcile resumes
+        # the cut turns with their history either way, so an immediate bounce costs seconds; the quiet
+        # window survives only as the explicit `romp refresh --quiet`) — but ONLY when that manager
+        # actually OWNS the kernel on the polled port (its /status lists it): a manager owning nothing,
+        # or a bare kernel beside a crash-looping managed one, answers 202 and restarts nothing, which
+        # would have turned this into a silent never-restart (review find). SYNCED:<sha>:MANAGED = the
+        # manager bounced it; SYNCED:<sha>:FALLBACK = the kill path below ran (no owning manager
+        # reachable — node absent, no manager, or the polled kernel is bare).
         'python3 -c "import json,time;print(json.dumps({\'t\':int(time.time()),\'action\':\'p2p-update\','
-        '\'reason\':\'from %s to %s\',\'when\':\'quiet\'}))" >>"$LOGDIR/restart-audit.jsonl" 2>/dev/null || true; '
+        '\'reason\':\'from %s to %s\'}))" >>"$LOGDIR/restart-audit.jsonl" 2>/dev/null || true; '
         'OWNED=0; if command -v node >/dev/null 2>&1 && [ -x "$R/bin/romp-manager" ]; then '
         'OWNED="$("$R/bin/romp-manager" status 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); '
         'print(1 if any(int(k.get(\'port\') or 0)==%d for k in (d.get(\'kernels\') or [])) else 0)" 2>/dev/null || echo 0)"; fi; '
         'if [ "$OWNED" = 1 ]; then '
-        'if "$R/bin/romp-manager" restart-all --quiet >>"$LOGDIR/update.log" 2>&1; then echo "SYNCED:$NEW:QUIET$K"; exit 0; fi; fi; '
+        'if "$R/bin/romp-manager" restart-all >>"$LOGDIR/update.log" 2>&1; then echo "SYNCED:$NEW:MANAGED$K"; exit 0; fi; fi; '
         # LAST RESORT (no owning manager answering on this host): the immediate path below — audit row,
         # kill, then `ensure` upgrades the host to a supervised kernel.
         'python3 -c "import json,time;print(json.dumps({\'t\':int(time.time()),\'action\':\'p2p-update\','
@@ -19837,10 +19836,10 @@ def _update_remote(host, head=None):
         if tag == "SYNCED":
             short, _, mode = rest.partition(":")
             mode = mode.strip()
-            _expect(mode == "QUIET")
+            _expect(False)                    # every deploy restart is immediate (T269): the short expectation window
             short = short.strip() or lfull[:8]
-            if mode == "QUIET":
-                return True, "synced to %s — restarting at its next quiet window" % short
+            if mode == "MANAGED":
+                return True, "synced to %s + restarting now (through its manager)" % short
             if mode == "FALLBACK":
                 return True, ("synced to %s + restarting now (no manager owns that kernel there — an "
                               "immediate restart)" % short)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7328,6 +7328,9 @@ def _parked_quiet_deploy(checkout, now=None):
     """The `t` of a QUIET deploy request still pending for the code the checkout holds, else 0
     (T240d): the newest restart-requesting audit row is a p2p-update (a peer's apply, which advanced
     the checkout and asked the manager for a quiet restart) or a main-converge with when=quiet, its
+    — since T269 a new peer's apply asks for an IMMEDIATE bounce and writes no when=quiet, so it
+    parks nothing here (its restart lands within the manager's ack, inside one drift cadence); the
+    quiet rows this reads now come from older peers, a quiet converge and `romp refresh --quiet` —
     sha is the checkout's, no cut row has consumed it (auditT), and it is inside the window a quiet
     request stays pending — the far manager's backstop bound, exactly what _recent_restart_audit
     already gives such a row for cut attribution. So a park lost with its manager self-heals at that
@@ -7396,7 +7399,10 @@ def _main_drift_check():
         # restart from a peer resets it the same way (T240). Module memory still covers the seconds
         # before the ledger row exists.
         #
-        # A QUIET deploy already parked for the code on disk STANDS THIS CHECK DOWN (T240d): a peer's
+        # A QUIET deploy already parked for the code on disk STANDS THIS CHECK DOWN (T240d, when the
+        # p2p apply still asked for the quiet window; since T269 it asks for an immediate bounce and
+        # writes no quiet row, so a new peer's apply never parks — the park below now comes from older
+        # peers, a quiet converge, or `romp refresh --quiet`). The 2026-09 shape: a peer's
         # p2p apply advanced the checkout and asked the manager for a quiet restart, then this check
         # saw the checkout ahead of the kernel and posted an IMMEDIATE restart-all — 16:23Z quiet
         # park, 16:27Z converge/now, ten sessions cut, the quiet window the peer asked for never ran
@@ -19836,7 +19842,11 @@ def _update_remote(host, head=None):
         if tag == "SYNCED":
             short, _, mode = rest.partition(":")
             mode = mode.strip()
-            _expect(False)                    # every deploy restart is immediate (T269): the short expectation window
+            # every deploy restart is immediate (T269). `quiet` is RECORDED on the expectation, not read:
+            # the tunnel's reinterpretation keys on sha and t (RESTART_EXPECT_MAX_S caps a restart that
+            # never comes). The far kernel's own cut attribution takes the short window from the ROW,
+            # which no longer carries when=quiet (_recent_restart_audit).
+            _expect(False)
             short = short.strip() or lfull[:8]
             if mode == "MANAGED":
                 return True, "synced to %s + restarting now (through its manager)" % short

--- a/tests/test_kernel_remote_update.py
+++ b/tests/test_kernel_remote_update.py
@@ -141,7 +141,7 @@ class UpdateRemote(unittest.TestCase):
                         "pkill is the fallback AFTER the manager path, never the first move")
         exp = km._remotes["TESTHOST"].get("restartExpected")
         self.assertTrue(exp and exp.get("sha") == self.LFULL and exp.get("t") and exp.get("quiet") is False,
-                        "the dialing side expects the restart it just caused, on the immediate window")
+                        "the dialing side expects the restart it just caused; quiet is recorded, not read")
 
     def test_every_deploy_restart_is_immediate_and_only_refresh_quiet_defers(self):
         # T269, the three deploy callers: a peer's p2p update (the apply script above), a release

--- a/tests/test_kernel_remote_update.py
+++ b/tests/test_kernel_remote_update.py
@@ -116,27 +116,49 @@ class UpdateRemote(unittest.TestCase):
         self.assertIn(self.LFULL + ":refs/heads/" + km._P2P_REF, push,
                       "pushes the exact advertised sha to the scratch ref, not a HEAD that may move under it")
 
-    def test_the_apply_restarts_through_the_manager_quiet_window_with_an_audit_row(self):
+    def test_the_apply_restarts_through_the_manager_at_once_with_an_audit_row(self):
         # T238: the remote apply used to `pkill` the far kernel outright — an anonymous, immediate
-        # SIGTERM (no restart-audit row, no quiet window: nine in-flight-turn cuts in three hours on a
-        # merge day, each read by the dialing side as "unreachable"). The apply now writes the audit
-        # row first and asks the far MANAGER for a quiet-window restart; pkill survives only as the
-        # last-resort branch for a host with no manager.
-        calls = self._wire(apply_out="SYNCED:abcdef0:QUIET")
+        # SIGTERM (no restart-audit row: nine in-flight-turn cuts in three hours on a merge day, each
+        # read by the dialing side as "unreachable"). The apply writes the audit row first and asks the
+        # far MANAGER for the restart; pkill survives only as the last-resort branch for a host with no
+        # manager. T269 (the user 2026-09-08): the manager bounces AT ONCE — the parked quiet window
+        # held a box unusable for the full 15-minute backstop on 26 of 32 restarts in a morning, and
+        # boot reconcile resumes the cut turns either way; the quiet window is `romp refresh --quiet` only.
+        calls = self._wire(apply_out="SYNCED:abcdef0:MANAGED")
         km._remotes["TESTHOST"] = {"host": "TESTHOST"}
         self.addCleanup(km._remotes.pop, "TESTHOST", None)
         ok, detail = km._update_remote("TESTHOST")
         self.assertTrue(ok, detail)
-        self.assertIn("quiet window", detail)
+        self.assertIn("restarting now", detail)
+        self.assertNotIn("quiet", detail)
         apply = next(a[-1] for a in calls if isinstance(a[-1], str) and "reset --hard" in a[-1])
         self.assertIn("restart-audit.jsonl", apply, "the restart is never anonymous")
         self.assertIn("p2p-update", apply)
-        self.assertIn("restart-all --quiet", apply, "the manager's quiet-window gate, not a kill")
-        self.assertLess(apply.index("restart-all --quiet"), apply.index('pkill -f "bin/romp-kern[e]l"'),
+        self.assertIn('romp-manager" restart-all >>', apply, "the manager's IMMEDIATE restart, not a kill")
+        self.assertNotIn("restart-all --quiet", apply, "no deploy path asks for the quiet window (T269)")
+        self.assertNotIn("'when':'quiet'", apply, "the p2p row is an immediate request: no quiet marker")
+        self.assertLess(apply.index('restart-all >>'), apply.index('pkill -f "bin/romp-kern[e]l"'),
                         "pkill is the fallback AFTER the manager path, never the first move")
         exp = km._remotes["TESTHOST"].get("restartExpected")
-        self.assertTrue(exp and exp.get("sha") == self.LFULL and exp.get("t") and exp.get("quiet") is True,
-                        "the dialing side is told to expect the restart it just caused")
+        self.assertTrue(exp and exp.get("sha") == self.LFULL and exp.get("t") and exp.get("quiet") is False,
+                        "the dialing side expects the restart it just caused, on the immediate window")
+
+    def test_every_deploy_restart_is_immediate_and_only_refresh_quiet_defers(self):
+        # T269, the three deploy callers: a peer's p2p update (the apply script above), a release
+        # self-update (_run_update, immediate since T160) and the automatic converge (_run_main_update's
+        # default). The quiet window's one door is `romp refresh --quiet`: bin/romp forwards the flag,
+        # bin/romp-manager maps it to when=quiet, and nothing else sends it.
+        import os
+        root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        ksrc = open(os.path.join(root, "kernel", "kernel.py")).read()
+        i = ksrc.index("def _run_update(tag):"); j = ksrc.index("\ndef ", i + 10)
+        self.assertNotIn("when=quiet", ksrc[i:j], "the release self-update restarts at once")
+        self.assertIn("def _run_main_update(kind, immediate=True", ksrc, "the converge's default is immediate")
+        self.assertNotIn("restart-all --quiet", ksrc, "no kernel-generated script asks the manager for the quiet window")
+        cli = open(os.path.join(root, "bin", "romp")).read()
+        self.assertIn('restart-all "${2:-}"', cli, "romp refresh forwards --quiet, the one door")
+        mgr = open(os.path.join(root, "bin", "romp-manager")).read()
+        self.assertIn("process.argv[3] === '--quiet' ? { when: 'quiet' } : {}", mgr, "…which the manager maps to when=quiet")
 
     def test_a_host_with_no_owning_manager_restarts_the_old_way_and_says_so(self):
         calls = self._wire(apply_out="SYNCED:abcdef0:FALLBACK")
@@ -148,28 +170,28 @@ class UpdateRemote(unittest.TestCase):
         self.assertNotIn("quiet window", detail)
         self.assertIs(km._remotes["TESTHOST"]["restartExpected"]["quiet"], False)
 
-    def test_the_quiet_path_requires_the_manager_to_own_the_polled_kernel(self):
+    def test_the_managed_path_requires_the_manager_to_own_the_polled_kernel(self):
         # a manager owning nothing (or a bare kernel beside a crash-looping managed one) answers 202
         # and restarts nothing — trusting it turned the update into a silent never-restart (review)
-        calls = self._wire(apply_out="SYNCED:abcdef0:QUIET")
+        calls = self._wire(apply_out="SYNCED:abcdef0:MANAGED")
         km._update_remote("TESTHOST")
         apply = next(a[-1] for a in calls if isinstance(a[-1], str) and "reset --hard" in a[-1])
         self.assertIn('romp-manager" status', apply, "ownership is read from the manager's own registry")
-        self.assertLess(apply.index('romp-manager" status'), apply.index("restart-all --quiet"))
+        self.assertLess(apply.index('romp-manager" status'), apply.index('restart-all >>'))
         self.assertIn('if [ "$OWNED" = 1 ]', apply)
-        # per-branch audit rows: the quiet row precedes the quiet call; the fallback writes its own
-        # row (no when=quiet) right before pkill, so the cut row joins the request that happened
+        # per-branch audit rows: the request row precedes the manager call; the fallback writes its own
+        # row right before pkill, so the cut row joins the request that happened
         self.assertEqual(apply.count("restart-audit.jsonl"), 2)
-        self.assertLess(apply.index("p2p-update"), apply.index("restart-all --quiet"),
-                        "the quiet row lands before the quiet request")
-        self.assertLess(apply.index("restart-all --quiet"), apply.index("immediate: no owning manager"),
-                        "the fallback writes its own row after the quiet branch was skipped")
+        self.assertLess(apply.index("p2p-update"), apply.index('restart-all >>'),
+                        "the request row lands before the manager request")
+        self.assertLess(apply.index('restart-all >>'), apply.index("immediate: no owning manager"),
+                        "the fallback writes its own row after the managed branch was skipped")
         self.assertLess(apply.index("immediate: no owning manager"), apply.index('pkill -f "bin/romp-kern[e]l"'))
         self.assertIn('SYNCED:$NEW:FALLBACK', apply)
 
     def test_both_generated_apply_scripts_parse_as_bash(self):
         import shlex, subprocess as sp
-        calls = self._wire(apply_out="SYNCED:abcdef0:QUIET")
+        calls = self._wire(apply_out="SYNCED:abcdef0:MANAGED")
         km._update_remote("TESTHOST")
         wrapper = next(a[-1] for a in calls if isinstance(a[-1], str) and "reset --hard" in a[-1])
         inner = shlex.split(wrapper.split("; if command -v setsid")[0][len("APPLY="):])[0]
@@ -266,7 +288,7 @@ class UpdateRemote(unittest.TestCase):
         # having pushed nothing (and when it did push, the restart it told itself to expect named the old
         # sha). The transport reads the head the user actually has.
         stale, fresh = "3" * 40, "4" * 40
-        calls = self._wire(rhead=stale, apply_out="SYNCED:4444444:QUIET")   # the peer is on the OLD commit
+        calls = self._wire(rhead=stale, apply_out="SYNCED:4444444:MANAGED")   # the peer is on the OLD commit
         km._HEAD_CACHE.update(ts=9e18, full=stale, short=stale[:8])          # the cache still says so too
         km._remotes["TESTHOST"] = {"host": "TESTHOST"}
         self.addCleanup(km._remotes.pop, "TESTHOST", None)
@@ -337,7 +359,7 @@ class UpdateRemote(unittest.TestCase):
             if "for d in" in cmd:
                 return _R(out="DIR:/home/u/romp\nHEAD:%s\nDIRTY:" % remote)         # the peer never restarts
             if "merge-base" in cmd or "reset --hard" in cmd:
-                return _R(out="SYNCED:4444444:QUIET")
+                return _R(out="SYNCED:4444444:MANAGED")
             return _R()
         km.subprocess.run = fake
         km._behind_info = lambda sha, head=None: {"behind": 1, "ahead": 0, "date": ""}   # a straight fast-forward

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -282,7 +282,10 @@ class DriftWiring(unittest.TestCase):
             audit.unlink()
 
     def test_a_parked_quiet_deploy_for_the_checkouts_sha_stands_the_converge_down(self):
-        # T240d: a peer's p2p apply advanced the checkout and parked a QUIET restart at the manager;
+        # T240d: a peer's p2p apply advanced the checkout and parked a QUIET restart at the manager
+        # (the apply asked for the quiet window then; since T269 it asks for an immediate bounce and
+        # writes no quiet row, so this shape now comes from older peers, a quiet converge and
+        # `romp refresh --quiet` — the stand-down reads the row, not the writer);
         # the drift check then saw the checkout ahead of the kernel and posted an IMMEDIATE
         # restart-all — 16:23Z quiet park, 16:27Z converge/now, ten sessions cut — so the quiet
         # window the peer asked for never ran. The restart is already on its way: stand down, once,
@@ -343,7 +346,8 @@ class DriftWiring(unittest.TestCase):
                                          "reason": "from TESTHOST to 99999999", "when": "quiet"}) + "\n")
             check()
             self.assertEqual(ran, ["restart"], "a quiet deploy of other code is not this converge")
-            # an IMMEDIATE p2p row (the no-owning-manager fallback): nothing is parked — proceeds
+            # an IMMEDIATE p2p row (a peer's apply since T269, or the no-owning-manager fallback):
+            # nothing is parked — proceeds; the bounce it asked for lands within the manager's ack
             ran.clear()
             audit.write_text(json.dumps({"t": int(now - 240), "action": "p2p-update",
                                          "reason": "from TESTHOST to f3dc387a (immediate: no owning manager)"}) + "\n")
@@ -431,9 +435,10 @@ class DriftWiring(unittest.TestCase):
                 km.RESTART_CUTS_FILE.unlink()
 
     def test_the_quiet_deploy_rows_carry_what_the_stand_down_reads(self):
-        # T240d pins on the writers: the p2p apply's quiet audit row lands right after the reset that
-        # advances the checkout — BEFORE the owner check, whose manager status call is the window a
-        # drift pass could hit between "checkout ahead" and "row on disk" — and the local converge's
+        # T240d pins on the writers: the p2p apply's audit row (quiet then, immediate since T269) lands
+        # right after the reset that advances the checkout — BEFORE the owner check, whose manager
+        # status call is the window a drift pass could hit between "checkout ahead" and "row on disk",
+        # so a cut in that window still finds its request on disk — and the local converge's
         # row carries the sha it deploys, so a quiet `romp refresh` is matched, not guessed at
         ksrc = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
         reset = ksrc.index('reset --hard "$WANT" >/dev/null 2>&1 || {')


### PR DESCRIPTION
## What
Every deploy-triggered kernel restart bounces immediately. The quiet-window deferral survives only as the explicit `romp refresh --quiet`.

The user's decision (2026-09-08, ~2:05 PM PT): the parked quiet window held the box unusable for the full 15-minute backstop on 26 of the morning's 32 restarts, while boot reconcile resumes the cut turns with their history either way, so an immediate bounce costs seconds.

## Which cut, and why
**The caller.** Of the three deploy callers, two were already immediate (the release self-update since T160, and the automatic converge through `_run_main_update`'s default). Only the p2p apply script (a peer's `romp update`) still asked the far manager for `restart-all --quiet`. Changing that one caller leaves the manager's `?when=quiet` route, its 15-minute backstop and `bin/romp refresh --quiet` byte-for-byte as they were, so the explicit door keeps its tests without a special case in the kernel's gate. A gate-side cut (the manager ignoring `when=quiet` for deploy reasons) would have needed the manager to learn the reasons and would have left the audit rows claiming a window nobody honored.

In `kernel/kernel.py`:
- the apply script asks `romp-manager restart-all` (immediate) when the manager owns the polled kernel, writes its `p2p-update` audit row WITHOUT `when=quiet`, and reports `SYNCED:<sha>:MANAGED`; the fallback branch (no owning manager) is unchanged;
- the dialing side reads `MANAGED` as "synced to <sha> + restarting now (through its manager)" and arms `restartExpected` with `quiet: False`. That field is recorded, not read: the tunnel's reinterpretation of the far kernel's gap keys on the sha and the stamp only. The short window is the far kernel's own: its cut attribution (`_recent_restart_audit`) gives a row without `when=quiet` the 90-second window instead of the 20-minute quiet one, so the cut row names this request while it is fresh.

Interplay with T240d: the drift check stood down for a `p2p-update` row carrying `when=quiet`, because the parked restart could take up to 15 minutes and a drift pass inside that window posted a second, immediate restart. A new apply writes an immediate row, so the stand-down does not engage, and it does not need to: the drift check runs once per 300 seconds, and the gap between the far checkout's reset and the manager's bounce is the ownership check plus one POST, about a second. The row still lands before the ownership check exactly as before, so a cut inside that second finds its request on disk. Older peers, a quiet converge and `romp refresh --quiet` still write quiet rows, and the stand-down still reads them; the docstrings and comments now say so. Widening the stand-down to immediate rows was considered and left out: it would also have parked the drift check for 90 seconds behind the no-owning-manager fallback's row, and an existing T240d pin says an immediate request parks nothing.

## Tests
- `tests/test_kernel_remote_update.py`: the three managed-path tests move to the immediate spellings (`restart-all` without `--quiet`, the row has no quiet marker, `MANAGED` tag, `quiet is False`, detail says restarting now, no "quiet" wording; ordering pins kept). New `test_every_deploy_restart_is_immediate_and_only_refresh_quiet_defers` pins the self-update script text, the converge's default, the absence of `restart-all --quiet` anywhere in the kernel, and that `bin/romp refresh` forwards `--quiet` to the manager's `when=quiet` mapping.
- Kept green, unchanged: `tests/romp-refresh-audit.bats` (refresh `--quiet` reaches `restart-all --quiet`), `tests/manager-restart.test.js` (the explicit opt-in), `tests/romp-manager-ensure.bats` (the `?when=quiet` route), `tests/test_main_drift_notice.py` (converge default immediate; the T240d apply-order pin still holds), `tests/test_kernel_update.py` (self-update has no `when=quiet`), `tests/test_deploy_drain.py`.

## Docs
`docs/reference.md`: the `romp update` row says the remotes restart at once, and the `romp refresh --quiet` row names itself the only door to the quiet window.

## Evidence
Targeted modules green in the worktree: 208 tests across the remote-update, drift-notice, deploy-drain, kernel-update, restart-cuts and tunnel-truth modules; 80 manager node tests; 9 bats cases across the manager-ensure and refresh-audit files. Full pytest in the worktree on the first head: 9813 passed, 56 skipped, 0 failed. CI green on that head. The adversarial review (three lenses, two skeptics per finding) found only comment and docstring drift plus the inaccurate expectation comment; all folded in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
