### PR TITLE
Feed: a card's hover bolding is paint-only; the header's Clear reads "Clear all" (T270, T271)

### DIFF
--- a/tests/test_feed_hover_border_static.py
+++ b/tests/test_feed_hover_border_static.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""T270 (the user 2026-09-08): hovering a card in the feed's group-by-session view thickens its coloured
+border, and that must NOT move the card's text, nor the card below. Their recording showed the hovered
+card's text block shifting 1 px down and 1 px right and the card under it dropping 1 px.
+
+The served guard drives the real /feed page from a hermetic kernel with a synthetic payload (one session,
+two cards in the same column, grouped mode), hovers the first card, and compares the CONTENT boxes: the
+hovered card's text block and the second card must sit exactly where they sat at rest, while the border
+paint does thicken (the hover cue itself stays). Skips LOUDLY without the extension deps or a Playwright
+browser (CI installs none). FEED_HOVER_SHOTS=<path-prefix> writes rest + hover screenshots. All fixtures
+synthetic (the notes-api demo world).
+"""
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+
+SID = "aaaaaaaa-1111-2222-3333-888888888888"
+TOP = "dddddddd-1111-2222-3333-000000000001"
+BELOW = "dddddddd-1111-2222-3333-000000000002"
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 520 }, deviceScaleFactor: 2 });
+const errors = [];
+page.on("pageerror", (e) => errors.push(String(e && e.stack || e).slice(0, 400)));
+await page.goto(cfg.feed);
+await page.waitForFunction(() => document.readyState === "complete" && typeof window.acquireVsCodeApi === "function", null, { timeout: 20000 });
+await page.waitForTimeout(600);
+const now = Math.floor(Date.now() / 1000);
+const ask = (itemId, text, t) => ({ itemId, sid: cfg.sid, name: "web", color: { bg: "#54B204", fg: "#ffffff" },
+  text, t, live: true, turnId: "turn-" + itemId.slice(-1), trgb: [84, 178, 4], column: "working", tree: [] });
+const payload = { type: "feed", asks: [ask(cfg.top, "notes-api: draft the search index", now - 120), ask(cfg.below, "notes-api: tune the retry curve", now - 60)],
+                  sessions: [{ sid: cfg.sid, name: "web" }], order: [cfg.sid] };
+await page.evaluate((m) => { window.dispatchEvent(new MessageEvent("message", { data: m })); }, payload);
+await page.waitForSelector(`[data-key="a:${cfg.top}"]`, { timeout: 10000 });
+await page.waitForSelector(`[data-key="a:${cfg.below}"]`, { timeout: 10000 });
+await page.waitForTimeout(400);
+const measure = () => page.evaluate((cfg) => {
+  const rect = (el) => { if (!el) return null; const r = el.getBoundingClientRect(); return { x: Math.round(r.x * 100) / 100, y: Math.round(r.y * 100) / 100, w: Math.round(r.width * 100) / 100, h: Math.round(r.height * 100) / 100 }; };
+  const top = document.querySelector(`[data-key="a:${cfg.top}"]`), below = document.querySelector(`[data-key="a:${cfg.below}"]`);
+  const cs = getComputedStyle(top);
+  return { topCard: rect(top), topMain: rect(top.querySelector(".fitem-main")), topText: rect(top.querySelector(".fitem-main *")),
+           belowCard: rect(below), belowMain: rect(below.querySelector(".fitem-main")),
+           border: cs.borderTopWidth + " " + cs.borderLeftWidth, margin: cs.marginTop + " " + cs.marginLeft, padding: cs.paddingTop + " " + cs.paddingLeft,
+           color: cs.borderTopColor, boxShadow: cs.boxShadow, cls: top.className };
+}, cfg);
+await page.mouse.move(1000, 500);
+await page.waitForTimeout(250);
+const rest = await measure();
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-rest.png", clip: { x: 0, y: 0, width: 420, height: 320 } });
+await page.hover(`[data-key="a:${cfg.top}"] .fitem-main`);
+await page.waitForTimeout(350);   // the hover class lands on mouseenter; the transition is 0.12 s
+const hover = await measure();
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-hover.png", clip: { x: 0, y: 0, width: 420, height: 320 } });
+fs.writeSync(1, "RESULT:" + JSON.stringify({ rest, hover, errors }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedHoverKeepsTextStill(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        cls.lab = tempfile.mkdtemp(prefix="feedhover-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        shutil.copytree(os.path.join(EXT, "dist"), dist)
+        os.makedirs(os.path.join(cls.lab, "xdg", "romp"), exist_ok=True)
+        cls.port = _free_port()
+        cls.token = "testtok-feedhover"
+        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=os.path.join(cls.lab, "claude"),
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
+                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
+        env.pop("ROMP_STATE_DIR", None)
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(os.path.join(cls.lab, "kernel.log"), "w"), stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_hovering_a_card_thickens_its_border_without_moving_its_text_or_the_card_below(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"feed": "http://127.0.0.1:%d/feed?token=%s" % (self.port, self.token), "sid": SID,
+                       "top": TOP, "below": BELOW, "shots": os.environ.get("FEED_HOVER_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        rest, hover = r["rest"], r["hover"]
+        self.assertEqual(r.get("errors"), [], "the page threw nothing: %r" % r.get("errors"))
+        # the hover cue is on: the border colour bolds to full alpha and the shadow lifts — paint only
+        self.assertIn("focused", hover["cls"], "the hover class landed: %r" % hover["cls"])
+        self.assertNotEqual(rest["color"], hover["color"], "the hover bolds the border colour: rest %r hover %r" % (rest["color"], hover["color"]))
+        self.assertNotEqual(rest["boxShadow"], hover["boxShadow"], "…and lifts the shadow")
+        # THE FIX (T270): no LAYOUT property changes with the hover — red on main, where the border grew 2→3px with a
+        # compensating margin -1px and the rendered text still moved a device pixel on the user's display
+        self.assertEqual(rest["border"], hover["border"], "border width unchanged: rest %r hover %r" % (rest["border"], hover["border"]))
+        self.assertEqual(rest["margin"], hover["margin"], "margin unchanged: rest %r hover %r" % (rest["margin"], hover["margin"]))
+        self.assertEqual(rest["padding"], hover["padding"], "padding unchanged: rest %r hover %r" % (rest["padding"], hover["padding"]))
+        # …and so nothing inside or below moved — the text block and the card below keep their exact boxes
+        self.assertEqual(rest["topMain"], hover["topMain"], "the hovered card's content box did not move: rest %r hover %r" % (rest["topMain"], hover["topMain"]))
+        self.assertEqual(rest["topText"], hover["topText"], "…nor its first text block: rest %r hover %r" % (rest["topText"], hover["topText"]))
+        self.assertEqual(rest["belowCard"], hover["belowCard"], "the card below did not move: rest %r hover %r" % (rest["belowCard"], hover["belowCard"]))
+        self.assertEqual(rest["belowMain"], hover["belowMain"], "…nor its content: rest %r hover %r" % (rest["belowMain"], hover["belowMain"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/card-key.test.ts
+++ b/ui/webview/card-key.test.ts
@@ -106,11 +106,12 @@ test("a cross-pane hover bolds the card's own session colour, sharing the .focus
   const i = FEEDCSS.indexOf(".fitem.ask.focused, .fitem.ask.dot-hl");
   const rule = FEEDCSS.slice(i, FEEDCSS.indexOf("}", i));
   assert.match(rule, /border-color: rgb\(var\(--card-r/, "full-opacity session colour, as on mouse hover");
-  // T221: the extra 1px is the BORDER growing (one paint with the body — a box-shadow ring was a
-  // second paint whose contact with the border seamed on the user's renderer), with the negative
-  // margin keeping flow position and content box identical.
-  assert.match(rule, /border-width: 3px; margin: -1px;/, "the bolding is single-paint");
-  assert.doesNotMatch(rule, /box-shadow: 0 0 0 1px/, "…never a second ring paint laid against the border");
+  // T270 (the user 2026-09-08): the bolding is PAINT ONLY — colour and shadow. The T221 cut grew the
+  // border 2→3px with a compensating margin -1px, which kept the CSS boxes still but moved the RENDERED
+  // text a device pixel on the user's display; no layout property may change with the hover.
+  assert.doesNotMatch(rule, /border-width|margin|padding/, "no layout property changes with the hover");
+  assert.match(rule, /box-shadow: 0 2px 7px/, "the lift shadow is the other half of the bolding");
+  assert.doesNotMatch(rule, /box-shadow: 0 0 0 1px/, "…never a second ring paint laid against the border (T221's seam)");
 });
 
 test("the white outline no longer lands on a card, only on the modal rows that have no colour", () => {

--- a/ui/webview/feed-card-border.test.ts
+++ b/ui/webview/feed-card-border.test.ts
@@ -41,15 +41,15 @@ test("the border colour is CSS-driven from the channels: 0.5α at rest", () => {
   assert.match(CSS, /\.fitem\.ask, \.fitem\.fgroup \{ border-color: rgba\(var\(--card-r, 255\), var\(--card-g, 255\), var\(--card-b, 255\), 0\.5\); \}/);
 });
 
-test("the highlight BOLDS the same colour (no white ring): pinned 0.85α, focused full + a same-colour ring", () => {
+test("the highlight BOLDS the same colour (no white ring): pinned 0.85α, focused full alpha + the lift shadow, paint only", () => {
   assert.match(CSS, /\.fitem\.ask\.pinned  \{ border-color: rgba\(var\(--card-r, 255\), var\(--card-g, 255\), var\(--card-b, 255\), 0\.85\); \}/);
-  // focused = full-opacity border, one touch bolder as a SINGLE paint: the border grows 1px with a
-  // compensating negative margin (T221 — a box-shadow ring was a second paint whose contact with the
-  // border seamed on the user's renderer; flow position and content box stay identical). The
-  // selector also carries .dot-hl since 2026-07-23, so a hover from another pane looks like a mouse
-  // hover instead of the old neutral white outline — matched loosely so it survives further sharing.
+  // focused = full-opacity border at the SAME 2px width, plus the lift shadow — paint only (T270, the user
+  // 2026-09-08: the T221 border-grow-plus-negative-margin kept the CSS boxes still but moved the rendered
+  // text a device pixel on their display; a ring was T221's seam). The selector also carries .dot-hl since
+  // 2026-07-23, so a hover from another pane looks like a mouse hover instead of the old neutral white
+  // outline — matched loosely so it survives further sharing.
   assert.match(CSS, /\.fitem\.ask\.focused[^{]*\{[\s\S]*?border-color: rgb\(var\(--card-r, 255\), var\(--card-g, 255\), var\(--card-b, 255\)\);/);
-  assert.match(CSS, /\.fitem\.ask\.focused[^{]*\{[\s\S]*?border-width: 3px; margin: -1px;/);
+  assert.doesNotMatch(CSS, /\.fitem\.ask\.focused[^{]*\{[^}]*(border-width|margin|padding)/, "no layout property changes with the hover");
   assert.match(CSS, /\.fitem\.ask\.focused[^{]*\{[\s\S]*?box-shadow: 0 2px 7px/,
     "the lift shadow stays; the ring layer is gone");
   // no white ring anywhere in the highlight

--- a/ui/webview/feed-sess-clear.test.ts
+++ b/ui/webview/feed-sess-clear.test.ts
@@ -19,10 +19,11 @@ test("the header's Clear IS the card's Clear: one builder, one class set, a layo
   // the user 2026-09-08 (twice): same size, the outline, blue on hover — so the card, the turn-group and the
   // header all build their Clear with clearButton(), which mints the .fdismiss button; the header adds only
   // a positional class and its behaviour
-  assert.match(FEED, /function clearButton\(title: string\): HTMLElement \{\s*\n\s*const b = el\("button", "fdismiss"\);\s*\n\s*b\.textContent = "Clear";\s*\n\s*b\.title = title;/);
+  assert.match(FEED, /function clearButton\(title: string, label = "Clear"\): HTMLElement \{\s*\n\s*const b = el\("button", "fdismiss"\);\s*\n\s*b\.textContent = label;[^\n]*\n\s*b\.title = title;/,
+    "one builder; the label is the only knob (T271: the header's reads \"Clear all\")");
   assert.match(FEED, /const clr = clearButton\("clear this task"\);/, "the card");
   assert.match(FEED, /const clr = clearButton\("clear ALL sub-asks of this request \(inbox-zero\)"\);/, "the turn-group");
-  assert.match(FEED, /const clr = clearButton\("clear every card for this session"\);\s*\n\s*clr\.classList\.add\("feed-sess-clear"\); clr\.dataset\.act = "sess-clear";/, "the header");
+  assert.match(FEED, /const clr = clearButton\("clear every card for this session", "Clear all"\);[^\n]*\n\s*clr\.classList\.add\("feed-sess-clear"\); clr\.dataset\.act = "sess-clear";/, "the header");
   assert.doesNotMatch(FEED, /el\("button", "feed-sess-clear"\)/, "no lookalike element");
   // the tooltip keeps the sibling grammar: a lowercase verb phrase, like the card's "clear this task"
   assert.match(FEED, /sclr\.setAttribute\("aria-label", "clear every card for " \+ e\.name\);/);
@@ -99,4 +100,12 @@ test("the header Clear's own class carries layout only; size, outline and the ac
   assert.match(CSS, /\.fdismiss \{\s*\n\s*font: inherit; font-size: 0\.72em; font-weight: 400; cursor: pointer; white-space: nowrap;/);
   assert.match(CSS, /border: 1px solid var\(--card-border\); border-radius: 6px;/);
   assert.match(CSS, /\.fdismiss:hover \{ border-color: var\(--accent\); color: var\(--accent\); background: var\(--accent-wash\); \}/);
+});
+
+test("the header's button reads \"Clear all\" in the card Clear's exact chrome (T271, the user 2026-09-08)", () => {
+  // the card's own Clear keeps its one word; the session-wide one says what it clears — same builder, same
+  // .fdismiss class, the label the only difference
+  assert.match(FEED, /function clearButton\(title: string, label = "Clear"\): HTMLElement \{\s*\n\s*const b = el\("button", "fdismiss"\);\s*\n\s*b\.textContent = label;/);
+  assert.match(FEED, /clearButton\("clear every card for this session", "Clear all"\)/);
+  assert.doesNotMatch(FEED, /clearButton\([^)]*, "Clear"\)/, "no caller spells the default; a card's Clear is the bare builder");
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -431,7 +431,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    without it, consecutive folded threads jam into one unreadable stack of names. */
 .feed-sess-head.folded { margin-bottom: 7px; }
 /* the session-wide CLEAR (the user 2026-09-08, twice): it IS the card's Clear (.fdismiss: the outline, the
-   0.72em size, the accent hover), built by the same builder; this class carries its POSITION only — far
+   0.72em size, the accent hover), built by the same builder, reading "Clear all" (T271); this class carries its POSITION only — far
    right of the header row, before the full-width process list that wraps below. No size, colour, border
    or hover of its own: any of those here would be a second button that drifts. */
 .feed-sess-clear { flex: none; margin-left: auto; }
@@ -483,14 +483,15 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fitem.ask, .fitem.fgroup { border-color: rgba(var(--card-r, 255), var(--card-g, 255), var(--card-b, 255), 0.5); }
 .fitem.ask.pinned  { border-color: rgba(var(--card-r, 255), var(--card-g, 255), var(--card-b, 255), 0.85); }   /* pinned: bolded, persistent */
 /* effective focus: full-opacity same colour, thickened a touch — plus the hover lift (the user 2026-07-15).
-   The extra 1px is the BORDER growing with a compensating negative margin, ONE paint with the card body
-   (T221, the user 2026-09-01: the old 1px box-shadow ring was a second paint laid against the border, and
-   the contact between two adjacent paints is renderer- and zoom-dependent — their Mac browser opened a
-   1px dark seam between ring and border across the whole top edge; a single paint cannot seam at any
-   zoom or radius). Under the global border-box sizing with auto width/height, border 2→3px plus
-   margin -1px grows the OUTER edge by exactly the 1px the ring occupied while the flow position and the
-   content box stay byte-identical — verified by rect comparison, so no layout-shifting border change
-   (the original rule's own constraint, kept by construction).
+   The bolding is PAINT ONLY: the same 2px border at the identity colour's full alpha (rest is 0.5α), plus
+   the lifted shadow. No width change and no ring. History, so neither comes back: the first cut drew a 1px
+   box-shadow ring against the border, a second paint whose contact line is renderer- and zoom-dependent —
+   the user's Mac browser opened a dark seam between ring and border (T221, 2026-09-01); the second cut grew
+   the border 2→3px with a compensating margin -1px, which keeps the CSS content box byte-identical but not
+   the RENDERED text — on the user's display the hovered card's body text moved 1px right and down and the
+   card below dropped 1px (T270, 2026-09-08: a fractional border/margin pair snaps to device pixels
+   differently from the rest state). A colour change alone touches no layout property, so nothing inside or
+   below can move, at any zoom.
    A CROSS-PANE hover (a chat rail dot, a timeline bar) lands on this same rule rather than wearing a look
    of its own (the user 2026-07-23): it used to paint the neutral white .dot-hl outline, which read as a
    different kind of event from hovering the card with the mouse when it means exactly the same thing.
@@ -498,7 +499,6 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    specificity, so a pinned card still bolds to full when another pane hovers it. */
 .fitem.ask.focused, .fitem.ask.dot-hl, .fitem.fgroup.dot-hl {
   border-color: rgb(var(--card-r, 255), var(--card-g, 255), var(--card-b, 255));
-  border-width: 3px; margin: -1px;
   box-shadow: 0 2px 7px rgba(0, 0, 0, 0.30);
 }
 

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -738,9 +738,9 @@ let renderSeq = 0;
 // ONE builder for every Clear on the feed (the user 2026-09-08): the card's, the turn-group's and the
 // session header's wear the same element, class set, label and hover, so they cannot drift apart. Callers
 // add behaviour (an onclick, a data-act) and, for the header, a layout-only positional class.
-function clearButton(title: string): HTMLElement {
+function clearButton(title: string, label = "Clear"): HTMLElement {
   const b = el("button", "fdismiss");
-  b.textContent = "Clear";
+  b.textContent = label;   // "Clear" on a card; the session header's says "Clear all" (T271, the user 2026-09-08) — same chrome, same builder
   b.title = title;
   return b;
 }
@@ -3542,14 +3542,15 @@ function makeSessHead(): HTMLElement {
   const fold = el("button", "feed-sess-fold");
   const cnt = el("span", "feed-sess-foldn"); cnt.style.display = "none";
   // CLEAR for the whole session (the user 2026-09-08): far right of the header row, the header's own size,
-  // as quiet as the caret — one word, the same "Clear" every card wears. One click clears every card this
+  // as quiet as the caret — the card's Clear in the same chrome, reading "Clear all" (T271, the user 2026-09-08:
+  // it clears the whole session, so its label says so). One click clears every card this
   // session has in the current view (every column, folded ones included), with the same optimistic Undo
   // the group clear uses instead of a confirm dialog. The action is DELEGATED on the stable columns root
   // (data-act, installed once where the root is built) — never bound to this header node, which grouped
   // mode re-homes and re-renders; the header only says which session it stands for (data-fsid).
   // THE card's Clear, built by the same builder (the user 2026-09-08: same size, the outline, blue on hover),
   // plus one positional class that carries layout only (far right of the row) — never a lookalike
-  const clr = clearButton("clear every card for this session");
+  const clr = clearButton("clear every card for this session", "Clear all");   // "Clear all" (T271): it clears the whole session, the card's own says "Clear"
   clr.classList.add("feed-sess-clear"); clr.dataset.act = "sess-clear"; clr.style.display = "none";
   h.append(nm, fold, cnt, svc, clr, svcList);
   (h as any)._name = nm; (h as any)._fold = fold; (h as any)._foldn = cnt;


### PR DESCRIPTION
Two small feed asks from the user (2026-09-08), one PR.

**T270: hovering a card no longer moves its text.** In the group-by-session feed, hovering a card thickened its coloured border and the card's body text shifted a pixel right and down, with the card below dropping a pixel (their recording). The hover rule grew the border 2→3px with a compensating `margin: -1px`, which keeps the CSS content box byte-identical but not the rendered text: a fractional border/margin pair snaps to device pixels differently from the rest state. The bolding is now paint-only: the same 2px border at the identity colour's full alpha (rest is 0.5 alpha) plus the lifted shadow. No width change and no ring (the ring was T221's seam), so nothing inside or below can move at any zoom. The rule's comment keeps the history so neither earlier cut returns.

**T271: the session header's Clear reads "Clear all".** The card's own Clear keeps its one word. One builder mints both (the label is its only knob), so the header button keeps the card Clear's exact chrome and behaviour.

**Tests.** `tests/test_feed_hover_border_static.py` drives the served feed page in a browser (skips loudly without one) with two cards of one session, hovers the first, and pins the contract: the hover class lands, the border colour bolds and the shadow lifts, while border width, margin, padding, the card's content box, its text block and the card below stay byte-identical. Red on main: the border grew and the margin moved. `card-key.test.ts` and `feed-card-border.test.ts` pin that no layout property sits in the hover rule; `feed-sess-clear.test.ts` pins the builder's label knob and the header's "Clear all".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
