### PR TITLE
Auto-reload: a reload marker is consumed only by the page it names, and the chat pane holds the reload while an upload or a held send is in flight

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -40031,7 +40031,10 @@ body{font-family:var(--vscode-font-family);font-size:13px;color:var(--vscode-for
 # already); once location.reload has been accepted the shell's lifted modals close (settings/picker) and a marker
 # rides sessionStorage, stamped with the page's path, so the fresh LANDING leaves ONE notification-center line
 # ("Reloaded onto build N — the kernel restarted / a newer romp build was served") and a standalone pane's marker
-# is consumed by nobody else. If location.reload throws (a host that forbids it) the old banner is the fallback
+# is consumed by nobody else. The marker is removed only by the page whose path it names (T272, 2026-09-08):
+# sessionStorage is shared across the shell and its same-origin panes, and a pane's shim, running before the
+# shell's own core existed (it reads as standalone then), consumed the shell's marker while checking the path
+# only afterwards — the notification-center line was lost on every reload the pane won that race. If location.reload throws (a host that forbids it) the old banner is the fallback
 # (the `refused` hook) and the refusal LATCHES for that build/boot: no re-attempt on every gesture end or poll,
 # only a strictly newer dv or boot re-arms. The VS Code webview never runs this: the extension loads its bundle from the installed VSIX
 # and a webview reload cannot fix bundled-code drift, so its own reload prompt stays (vscode-extension/src/
@@ -40068,9 +40071,10 @@ if(!owed)owed=next;tryFire();}
 function noteDv(dv){if(LOADED&&dv&&dv>LOADED)request('build',String(dv));}
 function noteVersion(v){if(!v)return;if(v.boot&&BOOT&&v.boot!==BOOT)request('restart',String(v.boot));if(v.dist_ver)noteDv(v.dist_ver);}
 function checkBoot(){try{fetch('/version',{cache:'no-store'}).then(function(r){return r.json();}).then(noteVersion)['catch'](function(){});}catch(e){}}
-function announce(notify){var raw=null;try{raw=sessionStorage.getItem('romp:reloaded');if(raw)sessionStorage.removeItem('romp:reloaded');}catch(e){}
-if(!raw)return null;var d=null;try{d=JSON.parse(raw);}catch(e){return null;}if(!d)return null;
+function announce(notify){var raw=null;try{raw=sessionStorage.getItem('romp:reloaded');}catch(e){}
+if(!raw)return null;var d=null;try{d=JSON.parse(raw);}catch(e){try{sessionStorage.removeItem('romp:reloaded');}catch(e2){}return null;}if(!d)return null;
 if(d.path&&d.path!==location.pathname)return null;
+try{sessionStorage.removeItem('romp:reloaded');}catch(e){}
 var why=d.reason==='restart'?'the kernel restarted':'a newer romp build was served';
 var txt='Reloaded onto build '+LOADED+' — '+why+'.';try{if(notify)notify('reload',txt);}catch(e){}return txt;}
 document.addEventListener('pointerdown',function(){ptr++;},true);

--- a/tests/test_dashboard_auto_reload.py
+++ b/tests/test_dashboard_auto_reload.py
@@ -222,7 +222,21 @@ var R = window.__rompReload;
 STORE["romp:reloaded"] = JSON.stringify({ reason: "build", detail: "9", from: 6, path: "/feed", t: 1 });
 out({ first: R.announce(null), left: STORE["romp:reloaded"] || null });""")
         self.assertIsNone(s3["first"], "a marker another page wrote (a standalone /feed reload) is not this page's to announce")
-        self.assertIsNone(s3["left"], "…but it is consumed, so it cannot be misattributed later")
+        self.assertIsNotNone(s3["left"], "…and it is LEFT for the page it names (T272, 2026-09-08): sessionStorage is shared across the shell "
+                                         "and its same-origin panes, and a pane's shim that read as standalone for a beat consumed the "
+                                         "shell's marker before the path check — the shell then found nothing to announce, and the "
+                                         "notification-center line the served test waits for never appeared")
+        # the shell's marker (path "/") survives a pane's early announce and is announced by the shell itself, once
+        s4 = run_core("""
+var R = window.__rompReload; var notes = [];
+STORE["romp:reloaded"] = JSON.stringify({ reason: "restart", detail: "2.2", from: 6, path: "/", t: 1 });
+location.pathname = "/chat"; var pane = R.announce(null);
+location.pathname = "/"; var shell = R.announce(function (k, t) { notes.push([k, t]); }); var again = R.announce(null);
+out({ pane: pane, shell: shell, again: again, notes: notes, left: STORE["romp:reloaded"] || null });""")
+        self.assertIsNone(s4["pane"], "the chat pane leaves the shell's marker alone")
+        self.assertEqual(s4["shell"], "Reloaded onto build 7 — the kernel restarted.", "the shell announces its own reload")
+        self.assertEqual(s4["notes"], [["reload", "Reloaded onto build 7 — the kernel restarted."]])
+        self.assertIsNone(s4["again"], "one line per reload"); self.assertIsNone(s4["left"], "consumed by its own page")
 
     def test_the_shell_composes_gesture_state_across_its_panes_and_a_pane_forwards_its_request(self):
         s = run_core("""

--- a/tests/test_ship_reship.py
+++ b/tests/test_ship_reship.py
@@ -71,6 +71,15 @@ class SourcePins(unittest.TestCase):
         self.assertIn('ack["shipId"] = str(msg["shipId"])', KERNEL_SRC)
         self.assertIn("if (ackShip && !shipOwner(ackShip)) return;", RENDER)
 
+    def test_the_pane_holds_the_dashboards_reload_while_a_ship_or_a_held_send_is_in_flight(self):
+        # T272 (2026-09-08): the dashboard reloads itself on a kernel restart (T265), and a reload costs an upload in
+        # flight its bytes and a held send its release — the very wedge the reconnect re-ship heals in the same page.
+        # So the chat pane answers the reload core's busy ask while either is pending; the shim's own reasons first.
+        self.assertIn('(window as any).__rompPaneBusy = (): string => {', RENDER)
+        self.assertIn('if (pendingShips.size) return "upload";', RENDER)
+        self.assertIn('if (shipGateSid) return "held-send";', RENDER)
+        self.assertIn('const shimBusy = (window as any).__rompPaneBusy as (() => string) | undefined;', RENDER)
+
     def test_a_reload_loss_is_loud_never_a_silent_vanish(self):
         self.assertIn("shipsInFlight: [...pendingShips.values()].flat().map((p) => p.name)", RENDER)
         self.assertIn("still uploading when this page reloaded, so it was NOT attached", RENDER)
@@ -127,20 +136,45 @@ const k2 = spawn(cfg.relaunch.cmd, [], { env: cfg.relaunch.env, detached: true,
   stdio: ["ignore", fs.openSync(cfg.relaunch.log, "a"), fs.openSync(cfg.relaunch.log, "a")] });
 k2.unref();   // the kernel outlives this driver — an un-unref'd child held node open past RESULT
 fs.writeSync(1, "KPID:" + k2.pid + "\n");
+// T272: the restart's reload request normally rides the next keepalive (its cadence, not this test's); it is raised
+// HERE, while the ship is pending and the send held, so the hold is exercised on every run: on a pane without the
+// busy report the page reloads at once and the wait below dies (reloadedEarly), which is the failure this pins.
+await page.evaluate(() => { const R = window.__rompReload; if (R) R.request("restart", "forced-by-the-test"); }).catch(() => {});
 // today (pre-fix) this wait dies: the chip pulses forever and the held send never fires.
 // with the fix: romp:wsup re-ships, the ack retires the chip, and fireHeldSend sends the message.
-const healed = await page.waitForFunction((msg) => {
+// T272: the dashboard reloads itself on the restart (a new boot id, T265) — but only once this pane is no longer
+// busy: the pending ship and the held send hold the reload (render.ts __rompPaneBusy) until the ack lands and the
+// send fires, all on THIS page. A reload before that would take the upload's bytes with it (the loss toast) and
+// leave the send unfired: an early navigation here is the failure this test exists for, so it is recorded, never
+// swallowed.
+let reloadedEarly = false;
+// the heal is measured INSIDE the wait, on the page that healed: the reload the restart owes is let through the
+// instant the pane is idle again (the send's own composer events end the hold), so a measurement taken a poll
+// later may find a fresh page. The predicate also records that the reload was owed and WAITING while the pane was
+// busy (window.__rompReload.owed() && !fired() with the chip still pending) — the held reload this fix is for.
+const heal = await page.waitForFunction((msg) => {
+  const R = window.__rompReload;
   const input = document.getElementById("composer-input");
   const pending = document.querySelectorAll(".composer-file-pending").length;
   const content = document.getElementById("content");
-  return pending === 0 && input && input.value === "" &&
-         !!content && content.textContent.includes(msg);
-}, cfg.msg, { timeout: 45000 }).then(() => true).catch(() => false);
-out.wedge.healedAfterRestart = healed;
-out.wedge.pendingAfterRestart = await page.locator(".composer-file-pending").count();
-out.wedge.inputAfterRestart = await page.inputValue("#composer-input");
-out.wedge.contentHasMsg = await page.evaluate(
-  (msg) => (document.getElementById("content")?.textContent || "").includes(msg), cfg.msg);
+  if (R && R.owed() && !R.fired() && pending > 0) window.__t272HeldWhileBusy = String(R.waiting || "busy");
+  const ok = pending === 0 && !!input && input.value === "" && !!content && content.textContent.includes(msg);
+  return ok ? JSON.stringify({ pending, input: input.value, hasMsg: true, held: window.__t272HeldWhileBusy || null,
+                               owedNow: !!(R && R.owed()), firedNow: !!(R && R.fired()) }) : false;
+}, cfg.msg, { timeout: 45000 }).then(async (h) => JSON.parse(await h.jsonValue()))
+  .catch((e) => { if (/context was destroyed|navigation/i.test(String(e))) reloadedEarly = true; return null; });
+out.wedge.healedAfterRestart = !!heal;
+out.wedge.reloadedEarly = reloadedEarly;
+out.wedge.pendingAfterRestart = heal ? heal.pending : -1;
+out.wedge.inputAfterRestart = heal ? heal.input : null;
+out.wedge.contentHasMsg = heal ? heal.hasMsg : false;
+out.wedge.reloadHeldWhileBusy = heal ? heal.held : null;
+out.wedge.reloadOwedAfterHeal = heal ? heal.owedNow : null;
+// now the pane is idle: the owed reload goes through (its own ending events may already have fired it) — follow it
+await page.evaluate(() => { const R = window.__rompReload; if (R && R.owed() && !R.fired()) R.tryFire(); }).catch(() => {});
+await page.waitForLoadState("load").catch(() => {});
+await page.waitForSelector("#composer-input", { timeout: 20000 });
+await page.waitForTimeout(500);
 if (cfg.shots) await page.screenshot({ path: cfg.shots + "-wedge.png" });
 
 // ---- regression: a normal ship+send against the restarted kernel, untouched ----
@@ -310,10 +344,14 @@ class ServedWedge(_ShipLab):
                          "the held send keeps the composer text until the upload settles: %r" % w)
         self.assertEqual(w["chipStillPendingHeld"], 1, "the chip is honestly pending while held: %r" % w)
         # the heart of T215: after the restart the reconnect re-ships, the ack lands, the send fires
+        self.assertFalse(w.get("reloadedEarly"), "the dashboard's own reload on the restart must WAIT for the pending ship and the "
+                                                  "held send (T272): a reload first would lose the upload's bytes and leave the send unfired: %r" % w)
         self.assertTrue(w["healedAfterRestart"],
                         "the reconnect must re-ship and release the held send — pre-fix this pulses "
                         "forever and the send never fires: %r (kernel log tail: %s)"
                         % (w, Path(self.klog).read_text()[-500:]))
+        self.assertIn(w.get("reloadHeldWhileBusy"), ("upload", "held-send", "sends"),
+                      "the restart's reload was owed and WAITING on this pane while the ship and the held send were in flight: %r" % w)
         self.assertEqual(w["pendingAfterRestart"], 0, "no chip may pulse over an upload that settled: %r" % w)
         self.assertEqual(w["inputAfterRestart"], "", "the held send must have fired: %r" % w)
         self.assertTrue(w["contentHasMsg"], "the sent message must be in the transcript view: %r" % w)

--- a/tests/test_ship_reship.py
+++ b/tests/test_ship_reship.py
@@ -80,6 +80,17 @@ class SourcePins(unittest.TestCase):
         self.assertIn('if (shipGateSid) return "held-send";', RENDER)
         self.assertIn('const shimBusy = (window as any).__rompPaneBusy as (() => string) | undefined;', RENDER)
 
+    def test_the_chat_page_loads_the_shim_before_the_bundle_so_the_busy_report_wraps_the_shims(self):
+        # the wrapper above reads the shim's window.__rompPaneBusy first and replaces it; that only holds because the
+        # chat page emits the shim inline BEFORE <script src=/dist/render.js> — the other order would let the shim's
+        # own assignment overwrite the wrapper and drop the upload and held-send reasons with every pin above green
+        src = open(os.path.join(ROOT, "kernel", "kernel.py"), encoding="utf-8").read()
+        page = src[src.index("def _chat_page():"):src.index("\ndef ", src.index("def _chat_page():") + 10)]
+        self.assertLess(page.index("<script>%s</script>"), page.index("/dist/render.js"), "the shim's script precedes the bundle in the chat page")
+        self.assertIn('_shim("chat", v)', page)
+        self.assertIn('window.__rompPaneBusy=function(){return (everConnected&&queue.length>queuedDiag)?"sends":"";};', src,
+                      "the shim defines the hook the pane wraps")
+
     def test_a_reload_loss_is_loud_never_a_silent_vanish(self):
         self.assertIn("shipsInFlight: [...pendingShips.values()].flat().map((p) => p.name)", RENDER)
         self.assertIn("still uploading when this page reloaded, so it was NOT attached", RENDER)
@@ -138,8 +149,9 @@ k2.unref();   // the kernel outlives this driver — an un-unref'd child held no
 fs.writeSync(1, "KPID:" + k2.pid + "\n");
 // T272: the restart's reload request normally rides the next keepalive (its cadence, not this test's); it is raised
 // HERE, while the ship is pending and the send held, so the hold is exercised on every run: on a pane without the
-// busy report the page reloads at once and the wait below dies (reloadedEarly), which is the failure this pins.
-await page.evaluate(() => { const R = window.__rompReload; if (R) R.request("restart", "forced-by-the-test"); }).catch(() => {});
+// busy report the page reloads at once and the wait below dies (reloadedEarly), which is the failure this pins. The
+// probe marks THIS page: its disappearance is the reload firing on its own once the pane is idle again.
+await page.evaluate(() => { window.__probe = 1; const R = window.__rompReload; if (R) R.request("restart", "forced-by-the-test"); }).catch(() => {});
 // today (pre-fix) this wait dies: the chip pulses forever and the held send never fires.
 // with the fix: romp:wsup re-ships, the ack retires the chip, and fireHeldSend sends the message.
 // T272: the dashboard reloads itself on the restart (a new boot id, T265) — but only once this pane is no longer
@@ -149,9 +161,10 @@ await page.evaluate(() => { const R = window.__rompReload; if (R) R.request("res
 // swallowed.
 let reloadedEarly = false;
 // the heal is measured INSIDE the wait, on the page that healed: the reload the restart owes is let through the
-// instant the pane is idle again (the send's own composer events end the hold), so a measurement taken a poll
-// later may find a fresh page. The predicate also records that the reload was owed and WAITING while the pane was
-// busy (window.__rompReload.owed() && !fired() with the chip still pending) — the held reload this fix is for.
+// instant the pane is idle again (the last ack and the held send's release tell the core, endReloadHoldIfIdle), so a
+// measurement taken a poll later may find a fresh page. The predicate also records that the reload was owed and
+// WAITING while the pane was busy (window.__rompReload.owed() && !fired() with the chip still pending) — the held
+// reload this fix is for.
 const heal = await page.waitForFunction((msg) => {
   const R = window.__rompReload;
   const input = document.getElementById("composer-input");
@@ -170,8 +183,9 @@ out.wedge.inputAfterRestart = heal ? heal.input : null;
 out.wedge.contentHasMsg = heal ? heal.hasMsg : false;
 out.wedge.reloadHeldWhileBusy = heal ? heal.held : null;
 out.wedge.reloadOwedAfterHeal = heal ? heal.owedNow : null;
-// now the pane is idle: the owed reload goes through (its own ending events may already have fired it) — follow it
-await page.evaluate(() => { const R = window.__rompReload; if (R && R.owed() && !R.fired()) R.tryFire(); }).catch(() => {});
+// now the pane is idle: the owed reload fires ON ITS OWN (the ending event, never a nudge from this driver) — wait for
+// the page to go, then follow it
+out.wedge.reloadFiredAfterHeal = await page.waitForFunction(() => window.__probe !== 1, null, { timeout: 20000 }).then(() => true).catch(() => false);
 await page.waitForLoadState("load").catch(() => {});
 await page.waitForSelector("#composer-input", { timeout: 20000 });
 await page.waitForTimeout(500);
@@ -352,6 +366,8 @@ class ServedWedge(_ShipLab):
                         % (w, Path(self.klog).read_text()[-500:]))
         self.assertIn(w.get("reloadHeldWhileBusy"), ("upload", "held-send", "sends"),
                       "the restart's reload was owed and WAITING on this pane while the ship and the held send were in flight: %r" % w)
+        self.assertTrue(w.get("reloadFiredAfterHeal"), "…and fired on its own once the ack landed and the send left (the ending event, "
+                                                       "render.ts endReloadHoldIfIdle) — never waiting for the user's next click: %r" % w)
         self.assertEqual(w["pendingAfterRestart"], 0, "no chip may pulse over an upload that settled: %r" % w)
         self.assertEqual(w["inputAfterRestart"], "", "the held send must have fired: %r" % w)
         self.assertTrue(w["contentHasMsg"], "the sent message must be in the transcript view: %r" % w)

--- a/ui/webview/composer-ship-gate.test.ts
+++ b/ui/webview/composer-ship-gate.test.ts
@@ -44,7 +44,7 @@ test("the OPEN gate dialog resolves itself on the last ack: closes and sends, no
   assert.match(RENDER, /const gateOpen = shipGateSid === owner;/);
   assert.match(RENDER, /if \(gateOpen\) \{ shipGateSid = null; closeConfirm\(null\); \}/,
     "the dialog dismisses itself the moment the last ship lands, then the send fires");
-  assert.match(RENDER, /shipGateSid = null;\n\s*if \(v === "now"\)/,
+  assert.match(RENDER, /shipGateSid = null; endReloadHoldIfIdle\(\);\n\s*if \(v === "now"\)/,
     "any button (or cancel) un-registers the gate — the ack path can never resolve a closed dialog");
   // a FAILED save also moots the dialog — it closes, but never auto-sends without the file
   assert.match(RENDER, /const gateWasOpen = shipGateSid === owner;/);

--- a/ui/webview/pending-attach.test.ts
+++ b/ui/webview/pending-attach.test.ts
@@ -57,7 +57,7 @@ test("a failed kernel save is NACKED and surfaces loudly — never a silent stuc
   assert.match(KERNEL, /ack = \{"type": "dropSaveFailed", "name": str\(msg\["name"\]\)\}/);   // built then shipId-stamped (T215)
   // client: the nack retires the chip and says so in a toast
   assert.match(RENDER, /m\.type === "dropSaveFailed" && typeof m\.name === "string"/);
-  assert.match(RENDER, /retirePendingShip\(m\.name, nackShip\) \|\| activeId;[\s\S]{0,300}warnToast\(m\.name \+ " couldn't be saved on the kernel/);
+  assert.match(RENDER, /retirePendingShip\(m\.name, nackShip\) \|\| activeId;[\s\S]{0,400}warnToast\(m\.name \+ " couldn't be saved on the kernel/);   // the nack also ends the reload hold (T272)
   // a FileReader failure retires it too — an unreadable file must not pulse forever
   assert.match(RENDER, /reader\.onerror = \(\) => retirePendingShip\(name, shipId\);/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -13017,6 +13017,21 @@ let shipGateSid: string | null = null;
 // Assigned by setupComposer (sendComposer lives in its closure); the WS ack handler fires a held
 // send through it when the last pending ship lands.
 let fireHeldSend: () => void = () => {};
+// The reload core (kernel.py _RELOAD_CORE_JS) asks every pane before it reloads the page (T265). A page reload
+// costs an upload in flight its bytes (persistDrafts keeps only the names, for the loss toast) and a send held on
+// the upload gate its release — the T215 wedge the reconnect re-ship heals in the same page. So while a ship
+// awaits its ack, or a send is held on one, this pane reports itself busy and the core waits for the ending event
+// (the ack retires the chip, the held send fires) before it fires; the shim's own reasons come first (T272).
+{
+  const shimBusy = (window as any).__rompPaneBusy as (() => string) | undefined;
+  (window as any).__rompPaneBusy = (): string => {
+    const b = shimBusy ? shimBusy() : "";
+    if (b) return b;
+    if (pendingShips.size) return "upload";
+    if (shipGateSid) return "held-send";
+    return "";
+  };
+}
 
 // Persist drafts across a full RELOAD (the user 2026-06-25: a half-typed message must survive a refresh, not
 // only a tab switch). The Map is in-memory, so mirror it into the webview's persisted state — the same store

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -12950,6 +12950,7 @@ function retirePendingShip(key: string, shipId?: string): string | null {
     if (!list.length) pendingShips.delete(id);
     persistDrafts();
     if (id === activeId) renderComposerFiles(id);
+    endReloadHoldIfIdle();
     return id;
   }
   return null;
@@ -13031,6 +13032,14 @@ let fireHeldSend: () => void = () => {};
     if (shipGateSid) return "held-send";
     return "";
   };
+}
+// The ENDING event of those holds, told to the core the way the shim tells it its own (kernel.py ws.onopen →
+// __rompReload.ended()): the moment the last pending ship retires and no send is held, an owed reload may fire. The
+// core re-tries only on gesture ends, blur, a fresh request or the shell's poll, so without this a standalone page
+// stayed on the old build until the user's next unrelated click (the review of this change).
+function endReloadHoldIfIdle(): void {
+  if (pendingShips.size || shipGateSid) return;
+  try { (window as any).__rompReload?.ended?.(); } catch { /* a page without the core (the VS Code webview) */ }
 }
 
 // Persist drafts across a full RELOAD (the user 2026-06-25: a half-typed message must survive a refresh, not
@@ -13414,6 +13423,7 @@ function renderComposerFiles(id: string | null): void {
         if (gateWasOpen) { shipGateSid = null; closeConfirm(null); }
         if (held || gateWasOpen) warnToast("The pending upload was dismissed — your held message was NOT sent.");
       }
+      endReloadHoldIfIdle();   // after the settle above cleared the gate: the dismissed last chip ends the hold (T272)
       renderComposerFiles(id);
     });
     box.appendChild(x);
@@ -14732,6 +14742,7 @@ listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: M
       if (gateOpen) { shipGateSid = null; closeConfirm(null); }
       if (owner === activeId) fireHeldSend();
       else warnToast("attachments finished uploading on another tab — the held message was not sent; review it there.");
+      endReloadHoldIfIdle();   // the ending event follows the release: the held send has been posted
     }
   } else if (m.type === "dropSaveFailed" && typeof m.name === "string") {
     // the kernel could not SAVE the shipped bytes — clear the pending chip and say so loudly,
@@ -14743,6 +14754,7 @@ listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: M
     const held = !!owner && sendOnShip.delete(owner);    // a held send must not fire without the file it waited for
     const gateWasOpen = shipGateSid === owner;
     if (gateWasOpen) { shipGateSid = null; closeConfirm(null); }   // the question is moot — but a failed save never auto-sends
+    endReloadHoldIfIdle();
     warnToast(m.name + " couldn't be saved on the kernel, so it was not attached — try again."
               + (held || gateWasOpen ? " Your message was NOT sent." : ""));
     if (owner && owner === activeId) renderComposerFiles(owner);   // the held-send button state clears with the hold
@@ -14971,7 +14983,7 @@ function setupComposer() {
                   [{ label: "Wait for the upload", value: "wait" },
                    { label: "Send without " + them, value: "now", danger: true }],
                   (v) => {
-                    shipGateSid = null;
+                    shipGateSid = null; endReloadHoldIfIdle();
                     if (v === "now") sendComposer({ pastShipGate: true });
                     else if (v === "wait") { sendOnShip.add(sid); renderComposerFiles(sid); }
                   });


### PR DESCRIPTION
Two served tests failed on pristine main since the dashboard reloads itself (T265). Both exposed the reload, not only the drivers:

- **The reload notice was lost to a race.** The marker (`sessionStorage 'romp:reloaded'`, stamped with the reloading page's path) was removed before the path check; a pane's shim that read as standalone for a beat consumed the shell's marker, so the shell found nothing to announce. The marker is now removed only by the page whose path it names. Pinned in `tests/test_dashboard_auto_reload.py` (the previous assertion pinned the opposite).
- **A held send could be lost across the reload.** A reload takes an upload's bytes and a held send's release with it (the T215 wedge the same-page re-ship heals). The chat pane now answers the reload core's busy ask (`"upload"` / `"held-send"`) so the restart's reload waits for the ack and the send to fire. Pinned in `tests/test_ship_reship.py`; the served wedge test asserts the reload was held, then follows it.

**Drivers:** the ship test records an early navigation as a failure (never a dead driver) and follows the held reload before its regression half; the reload test needed no driver change.

**CI:** neither served test runs in CI (no browser installed; both skip loudly), which is why main's Python jobs stayed green while the devbox failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
