### PR TITLE
Our own send in the fed gap draws one bubble: the queued copy is attributed beside the echo cover

### DIFF
--- a/tests/test_queued_copy_held.py
+++ b/tests/test_queued_copy_held.py
@@ -272,5 +272,93 @@ class ServedQueuedCopyHeld(unittest.TestCase):
             self.assertEqual(off[k]["top"], r["offStart"]["top"], "an off-bottom reader is never moved (%s): %r vs %r" % (k, off[k], r["offStart"]))
 
 
+    def test_our_own_send_in_the_fed_gap_is_one_bubble(self):
+        # the tail fix's review: with our copy gone from the queue (held by the pane) and the kernel's echo showing, the
+        # echo cover skipped hiding the held copy — two bubbles for one message (three with the echo)
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "text": "and also update the docstring"}, f)
+        driver = os.path.join(self.lab, "driver-fed.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER_FED)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        print("T262M:", json.dumps(r))
+        self.assertEqual(r["dropped"], 1, "the send was dropped at the socket: the pane's bubble is the only copy of ours")
+        self.assertEqual((r["pressed"]["bubbles"], r["pressed"]["users"]), (1, 0), "our bubble at the press: %r" % r["pressed"])
+        self.assertEqual((r["queued"]["bubbles"], r["queued"]["users"]), (1, 0), "the kernel's queued copy hidden for ours: %r" % r["queued"])
+        self.assertEqual(r["fed"]["total"], 1, "the fed gap: the echo hidden, the held copy hidden, ours the one bubble: %r" % r["fed"])
+        self.assertEqual(r["fed2"]["total"], 1, "…and on the next push too: %r" % r["fed2"])
+        self.assertEqual((r["landed"]["bubbles"], r["landed"]["users"]), (0, 1), "the landing takes the slot: %r" % r["landed"])
+
+
+DRIVER_FED = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1000, height: 600 } });
+await page.addInitScript(() => {
+  window.__frames = []; window.__quiet = false; window.__dropped = 0;
+  window.addEventListener("message", (e) => { const m = e.data; if (m && (m.type === "session" || m.type === "update" || m.type === "chatTail")) window.__frames.push(m); });
+  const desc = Object.getOwnPropertyDescriptor(WebSocket.prototype, "onmessage");
+  Object.defineProperty(WebSocket.prototype, "onmessage", { configurable: true, get() { return desc.get.call(this); },
+    set(fn) { desc.set.call(this, (ev) => { if (window.__quiet) { try { const m = JSON.parse(ev.data); if (m && (m.type === "chatTail" || m.type === "update" || m.type === "session" || m.type === "status")) return; } catch (e) {} } return fn.call(this, ev); }); } });
+  const orig = WebSocket.prototype.send;
+  WebSocket.prototype.send = function (d) { try { const m = JSON.parse(d); if (m && m.type === "sendMessage") { window.__dropped++; return; } } catch (e) {} return orig.call(this, d); };
+});
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+await page.waitForSelector(".turn.turn-user", { timeout: 20000 });
+await page.waitForFunction(() => window.__frames.some((m) => m.type === "session" && Array.isArray(m.events) && m.events.length > 3), null, { timeout: 20000 });
+const base = await page.evaluate(() => { const fr = window.__frames.filter((m) => m.type === "session" && Array.isArray(m.events)); return fr[fr.length - 1]; });
+base.events = base.events.filter((e) => !(e.uuid || "").startsWith("optimistic:"));
+const measure = () => page.evaluate((text) => {
+  const vis = (n) => !!n && n.style.display !== "none" && !n.classList.contains("turn-echo-hidden") && !n.classList.contains("turn-queued-hidden");
+  const bubbles = Array.from(document.querySelectorAll(".turn-queued .queued-bubble")).filter((b) => vis(b.closest(".turn-queued")) && (b.textContent || "").includes(text));
+  const users = Array.from(document.querySelectorAll(".turn.turn-user")).filter((t) => vis(t) && (t.textContent || "").includes(text));
+  return { bubbles: bubbles.length, users: users.length, total: bubbles.length + users.length,
+           landingMarked: document.querySelectorAll(".turn-queued .queued-bubble.landing").length };
+}, cfg.text);
+const inject = (frame) => page.evaluate((f) => { window.postMessage(f, "*"); }, frame);
+// our send (dropped at the socket): its bubble
+await page.evaluate(() => { window.__quiet = true; });
+await page.fill("#composer-input", cfg.text);
+await page.press("#composer-input", "Enter");
+await page.waitForSelector(".turn-queued", { timeout: 10000 });
+await page.waitForTimeout(300);
+const pressed = await measure();
+// the kernel lists our copy with its id → ours stays, the kernel's copy hidden
+await inject({ ...base, type: "update", events: [...base.events, { kind: "queued", texts: [{ md: cfg.text, qid: "echo:m9", qts: Date.now(), cancelable: true, idx: 0 }] }] });
+await page.waitForTimeout(400);
+const queued = await measure();
+// the fed gap: the copy left the queue (held by the pane), the kernel's echo shows
+await inject({ ...base, type: "update", events: [...base.events, { kind: "user", md: cfg.text, uuid: "echo:m9", ts: new Date().toISOString() }] });
+await page.waitForTimeout(400);
+const fed = await measure();
+await inject({ ...base, type: "update", events: [...base.events, { kind: "user", md: cfg.text, uuid: "echo:m9", ts: new Date().toISOString() }] });
+await page.waitForTimeout(400);
+const fed2 = await measure();
+// the landing takes the slot
+await inject({ ...base, type: "update", events: [...base.events, { kind: "user", md: cfg.text, uuid: "am9", ts: new Date().toISOString(), qid: "echo:m9", human: true }] });
+await page.waitForTimeout(400);
+const landed = await measure();
+fs.writeSync(1, "RESULT:" + JSON.stringify({ pressed, queued, fed, fed2, landed, dropped: await page.evaluate(() => window.__dropped) }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -781,3 +781,19 @@ test("our own send in the fed gap: the kernel's echo visible AND its held copy i
   const r2 = reconcilePending(frame2, [q]);
   assert.deepEqual([r2.inject, r2.unqueue, r2.echoHide], [[q], [q], [1]]);
 });
+
+test("two identical presses, then one push with the first's echo AND the second's queued copy: each send takes its own kernel copy (fed-gap fix review)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const [p1, p2] = press(tail, "x", "x");
+  const frame: TailEvent[] = [...tail, { kind: "user", md: "x", uuid: "echo:x1" }, { kind: "queued", texts: [{ md: "x", qid: "echo:x2", qts: 2 }] }];
+  let r = reconcilePending(frame, [p1, p2]);
+  assert.deepEqual([p1.qid, p2.qid], ["echo:x1", "echo:x2"], "the echo is the first's, the queued copy the second's — never the first's by text");
+  assert.deepEqual([p1.received, p2.received], [true, true]);
+  assert.deepEqual([r.inject, r.unqueue, r.echoHide], [[p1, p2], [p2], [1]], "both drawn by us; the copy hidden for the second, the echo for the first");
+  r = reconcilePending(frame, [p1, p2]);
+  assert.deepEqual([r.inject, r.unqueue, r.echoHide], [[p1, p2], [p2], [1]], "…and the same on the next push: no third bubble");
+  // the first's landing retires the first, and only the first
+  const landed: TailEvent[] = [...tail, { kind: "user", md: "x", uuid: "ux1", qid: "echo:x1" }, { kind: "queued", texts: [{ md: "x", qid: "echo:x2", qts: 2 }] }];
+  r = reconcilePending(landed, [p1, p2]);
+  assert.deepEqual([r.landed.map((l) => l.p), r.keep, r.unqueue], [[p1], [p2], [p2]]);
+});

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -762,3 +762,22 @@ test("the landed bubble's hover says when the message was SENT, once the landing
   // render.ts applies it to the landed user bubble's title, from the kernel's two stamps (never the client's clock)
   assert.match(RENDER, /const sentTip = sentAtLabel\(ev\.ts, ev\.sentAt\);\s*\n\s*if \(sentTip\) bubble\.title = sentTip;/);
 });
+
+test("our own send in the fed gap: the kernel's echo visible AND its held copy in the group — ours is the one bubble, both kernel copies hidden (T262h review)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const p = newPending("hi there", undefined, T0);
+  reconcilePending(tail, [p]);
+  reconcilePending([...tail, { kind: "queued", texts: [{ md: "hi there", qid: "echo:q1", qts: 1 }] }], [p]);
+  assert.equal(p.qid, "echo:q1");
+  // the copy left the queue (fed) and is held by the caller, marked landing; the kernel's echo shows too
+  const frame: TailEvent[] = [...tail, { kind: "user", md: "hi there", uuid: "echo:q1" },
+                              { kind: "queued", texts: [{ md: "hi there", qid: "echo:q1", qts: 1, landing: true }], uuid: "held:s" }];
+  const r = reconcilePending(frame, [p]);
+  assert.deepEqual([r.inject, r.unqueue, r.echoHide], [[p], [p], [1]], "ours drawn; the held copy hidden; the echo hidden");
+  // an id-less send (an older kernel): the same by text
+  const q = newPending("go on", undefined, T0 + 1);
+  reconcilePending(tail, [q]);
+  const frame2: TailEvent[] = [...tail, { kind: "user", md: "go on", uuid: "echo:zz" }, { kind: "queued", texts: [{ md: "go on", landing: true }], uuid: "held:s" }];
+  const r2 = reconcilePending(frame2, [q]);
+  assert.deepEqual([r2.inject, r2.unqueue, r2.echoHide], [[q], [q], [1]]);
+});

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -391,36 +391,37 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
     // the whole of it) — else the first queued copy beyond this entry's press-time count that no
     // earlier entry took this push.
     let covered = false, byQueued = false, byEcho = false;
-    // The kernel's QUEUED copy of this send is attributed whether or not an echo also covers it: in the fed gap the
-    // caller holds the copy that left the queue (marked landing) while the kernel's echo shows, and both are this
-    // send's — ours is the one bubble, so the copy is hidden (`unqueue`) beside the hidden echo (T262h review: the
-    // echo cover used to skip the queued attribution, and the held card drew a second bubble).
-    if (p.qid && idCopy >= 0) {
-      covered = true; byQueued = true;              // our identified copy is in the queue: exact, whatever its position
-      const k = copyIds.indexOf(p.qid);             // …and that position is spoken for on the text path this push: a later
-      if (k >= 0) {                                 // same-text send never takes it, nor its id (third review)
-        const taken = takenCopies.get(p.text) || new Set<number>();
-        taken.add(k); takenCopies.set(p.text, taken);
-      }
-    } else if (!pv.qid && copyIds.length > at.queued) {
-      const taken = takenCopies.get(p.text) || new Set<number>();
-      let k = -1;
-      for (let j = at.queued; j < copyIds.length; j++) {
-        const id = copyIds[j];
-        if (taken.has(j) || (id && owned.has(id) && id !== p.qid)) continue;   // taken this push, or another send's by id
-        k = j; break;
-      }
-      if (k >= 0) {
-        taken.add(k); takenCopies.set(p.text, taken); covered = true; byQueued = true;
-        if (copyIds[k] && !p.qid) p.qid = copyIds[k];   // latch the identity of the copy just attributed, when the kernel gave it one
-      }
-    }
     if (echoIdx >= 0) {
       covered = true; byEcho = true;
       const u = events[echoIdx].uuid;
       if (u) for (const q of list) if (q !== p && q.at && q.text === p.text && !q.at.seen.includes(u)) q.at.seen.push(u);
       if (!p.qid && u) p.qid = u;                  // the echo's uuid is the copy's id: latched (T252c)
     }
+    // The kernel's QUEUED copy of this send, beside the echo or alone. By id first: our copy wherever it sits (an
+    // identified copy the caller HOLDS after it left the queue is ours by the same id — the fed gap, where the echo
+    // shows too and the held copy must hide with it, or the message draws twice). Else by text, for a copy the kernel
+    // gave no id: before any echo, the legacy reading (positions past the press-time count, untaken, not another
+    // send's by id); after an echo cover, ONLY an id-less copy — a copy wearing ANOTHER id is another send's, and
+    // taking it by text handed the second of two identical presses' copy to the first (the review of the fed-gap
+    // fix: three bubbles for two messages, the wrong entry retired on the landing).
+    const taken = takenCopies.get(p.text) || new Set<number>();
+    const idHit = p.qid ? copyIds.indexOf(p.qid) : -1;
+    if (idHit >= 0 && !taken.has(idHit)) {
+      taken.add(idHit); covered = true; byQueued = true;   // exact, whatever its position; spoken for on the text path this push
+    } else if (byEcho || (!pv.qid && copyIds.length > at.queued)) {
+      let k = -1;
+      for (let j = at.queued; j < copyIds.length; j++) {
+        const id = copyIds[j];
+        if (taken.has(j) || (id && owned.has(id) && id !== p.qid)) continue;   // taken this push, or another send's by id
+        if (byEcho && id) continue;                                            // after an echo: an id-less copy only
+        k = j; break;
+      }
+      if (k >= 0) {
+        taken.add(k); covered = true; byQueued = true;
+        if (copyIds[k] && !p.qid) p.qid = copyIds[k];   // latch the identity of the copy just attributed, when the kernel gave it one
+      }
+    }
+    takenCopies.set(p.text, taken);
     if (covered) p.received = true;             // the kernel holds this send: proven once, latched
     if (p.received) p.lost = undefined;         // the drop is older news than the kernel's own copy
     if (landedIdx >= 0) {

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -88,7 +88,7 @@ export type TailEvent = {
   sentAt?: number;      // …with the send time beside it (epoch s), for the bubble's hover
   undelivered?: boolean;
   images?: unknown[];
-  texts?: { md?: string; hiddenByPending?: boolean; qid?: string; qts?: number; cancelable?: boolean }[];   // qid/qts: the copy's identity (T252c); hiddenByPending: render.ts hid this copy for a send drawn as our own bubble
+  texts?: { md?: string; hiddenByPending?: boolean; qid?: string; qts?: number; cancelable?: boolean; landing?: boolean }[];   // landing: a copy the caller holds after it left the kernel's queue (T262i)   // qid/qts: the copy's identity (T252c); hiddenByPending: render.ts hid this copy for a send drawn as our own bubble
   blocks?: string[];    // a user record the CLI wrote from SEVERAL sends taken at one boundary: one text per
                         //   block (kernel.py build_session ships them when there are two or more); `md` is
                         //   the blocks joined, so each block is a copy of its own send
@@ -391,12 +391,11 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
     // the whole of it) — else the first queued copy beyond this entry's press-time count that no
     // earlier entry took this push.
     let covered = false, byQueued = false, byEcho = false;
-    if (echoIdx >= 0) {
-      covered = true; byEcho = true;
-      const u = events[echoIdx].uuid;
-      if (u) for (const q of list) if (q !== p && q.at && q.text === p.text && !q.at.seen.includes(u)) q.at.seen.push(u);
-      if (!p.qid && u) p.qid = u;                  // the echo's uuid is the copy's id: latched (T252c)
-    } else if (p.qid && idCopy >= 0) {
+    // The kernel's QUEUED copy of this send is attributed whether or not an echo also covers it: in the fed gap the
+    // caller holds the copy that left the queue (marked landing) while the kernel's echo shows, and both are this
+    // send's — ours is the one bubble, so the copy is hidden (`unqueue`) beside the hidden echo (T262h review: the
+    // echo cover used to skip the queued attribution, and the held card drew a second bubble).
+    if (p.qid && idCopy >= 0) {
       covered = true; byQueued = true;              // our identified copy is in the queue: exact, whatever its position
       const k = copyIds.indexOf(p.qid);             // …and that position is spoken for on the text path this push: a later
       if (k >= 0) {                                 // same-text send never takes it, nor its id (third review)
@@ -415,6 +414,12 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
         taken.add(k); takenCopies.set(p.text, taken); covered = true; byQueued = true;
         if (copyIds[k] && !p.qid) p.qid = copyIds[k];   // latch the identity of the copy just attributed, when the kernel gave it one
       }
+    }
+    if (echoIdx >= 0) {
+      covered = true; byEcho = true;
+      const u = events[echoIdx].uuid;
+      if (u) for (const q of list) if (q !== p && q.at && q.text === p.text && !q.at.seen.includes(u)) q.at.seen.push(u);
+      if (!p.qid && u) p.qid = u;                  // the echo's uuid is the copy's id: latched (T252c)
     }
     if (covered) p.received = true;             // the kernel holds this send: proven once, latched
     if (p.received) p.lost = undefined;         // the drop is older news than the kernel's own copy


### PR DESCRIPTION
Follow-up to #1111 (the tail-height fix), from its review's reproduction: in the **fed gap**, when a pending send's copy has left the kernel's queue and the pane holds it (marked landing) while the kernel's echo shows, the held copy stayed visible beside our bubble: two bubbles for one message.

The echo cover stays first (its uuid latches the send's id); the kernel's queued copy is then attributed **by id** (our held copy wears our id), else **by text only for a copy the kernel gave no id**. A copy wearing another id is another send's: the first cut of this PR attributed by text ahead of the echo and regressed two identical presses whose echo and same-text queued copy arrive together (the manager's review) — that case is now a pinned test, green on main and here.

**Tests:** `ui/webview/send-pending.test.ts` (the fed gap for an identified and an id-less send, red on main's module which leaves the held copy unhidden; two identical presses with an echo and a queued copy in one push), and a served fed-gap scenario with our own send in `tests/test_queued_copy_held.py` (one bubble through the queued frame, the fed gap and the landing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
