### PR TITLE
Feed: a jump into a folded turn-group member unfolds the run the group renders in (T263d)

### DIFF
--- a/tests/test_feed_thread_fold_columns.py
+++ b/tests/test_feed_thread_fold_columns.py
@@ -118,6 +118,63 @@ process.exit(0);
 """
 
 
+GROUP_DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 520 } });
+const errors = [];
+page.on("pageerror", (e) => errors.push(String(e && e.stack || e).slice(0, 400)));
+await page.goto(cfg.feed);
+await page.waitForFunction(() => document.readyState === "complete" && typeof window.acquireVsCodeApi === "function", null, { timeout: 20000 });
+await page.waitForTimeout(600);
+const now = Math.floor(Date.now() / 1000);
+const ask = (itemId, column, text, t, extra) => Object.assign({ itemId, sid: cfg.sid, name: "web", color: { bg: "#1EA1EB", fg: "#ffffff" },
+  text, t, live: true, turnId: "turn-solo-" + itemId.slice(-1), trgb: [30, 161, 235], column, tree: [] }, extra || {});
+// m1 + m2 share a typed turn (turnId + groupTitle) → one turn-group card, in Blocked (its worst member)
+const grp = { turnId: "turn-group-1", groupTitle: "notes-api: ship the search index" };
+const payload = { type: "feed", asks: [ask(cfg.m1, "needs_input", "notes-api: pick the index backend", now - 300, grp),
+                                        ask(cfg.m2, "completed", "notes-api: write the index schema", now - 240, grp),
+                                        ask(cfg.c3, "completed", "notes-api: tune the retry curve", now - 60)],
+                  sessions: [{ sid: cfg.sid, name: "web" }], order: [cfg.sid] };
+const deliver = (m) => page.evaluate((m) => { window.dispatchEvent(new MessageEvent("message", { data: m })); }, m);
+await deliver(payload);
+await page.waitForSelector(`[data-key="g:turn-group-1"]`, { timeout: 10000 });
+await page.waitForSelector(`[data-key="a:${cfg.c3}"]`, { timeout: 10000 });
+await page.waitForTimeout(300);
+const survey = () => page.evaluate((cfg) => {
+  const listOf = (el) => el ? el.closest(".feed-col")?.querySelector(".feed-col-list")?.id || null : null;
+  const heads = Array.from(document.querySelectorAll(".feed-sess-head")).map((h) => ({
+    col: h.closest(".feed-col")?.querySelector(".feed-col-list")?.id || null, folded: h.classList.contains("folded"),
+    count: h.querySelector(".feed-sess-foldn")?.style.display === "none" ? null : h.querySelector(".feed-sess-foldn")?.textContent }));
+  return { groupCol: listOf(document.querySelector('[data-key="g:turn-group-1"]')), soloCol: listOf(document.querySelector(`[data-key="a:${cfg.c3}"]`)),
+           groupShown: !!document.querySelector('[data-key="g:turn-group-1"]'), soloShown: !!document.querySelector(`[data-key="a:${cfg.c3}"]`),
+           heads, stored: localStorage.getItem("romp:feedview") };
+}, cfg);
+const before = await survey();
+if (!before.groupCol || !before.soloCol) { console.error("cards did not land: " + JSON.stringify(before)); process.exit(1); }
+// FOLD both runs (the group's Blocked run, the solo card's Completed run)
+for (const col of [before.groupCol, before.soloCol]) {
+  await page.click(`#${col} .feed-sess-head[data-fsid="${cfg.sid}"] .feed-sess-fold`);
+  await page.waitForTimeout(250);
+}
+const folded = await survey();
+// JUMP to the completed MEMBER of the group (a bell-entry click / notification tap): the run it RENDERS in — Blocked,
+// the group's column — must open; the Completed run, an unrelated fold, must stay folded
+await deliver({ romp: "revealCard", itemId: cfg.m2, sid: cfg.sid });
+await page.waitForTimeout(500);
+const jumped = await survey();
+fs.writeSync(1, "RESULT:" + JSON.stringify({ before, folded, jumped, groupCol: before.groupCol, soloCol: before.soloCol, errors }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
 class ServedFoldIsPerColumn(unittest.TestCase):
     maxDiff = None
 
@@ -158,6 +215,40 @@ class ServedFoldIsPerColumn(unittest.TestCase):
             cls.kernel.kill()
             cls.kernel.wait()
         shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_a_jump_into_a_folded_turn_group_member_opens_the_run_the_group_renders_in(self):
+        # T263d (review of T263c): a turn-group's members render in the GROUP's column (its worst member), so the
+        # jump must unfold that run — keying by the member's own column opened the unrelated Completed run and
+        # left the group's Blocked run shut (red on the first cut)
+        cfg = os.path.join(self.lab, "cfg-group.json")
+        with open(cfg, "w") as f:
+            json.dump({"feed": "http://127.0.0.1:%d/feed?token=%s" % (self.port, self.token), "sid": SID,
+                       "m1": "eeeeeeee-1111-2222-3333-000000000001", "m2": "eeeeeeee-1111-2222-3333-000000000002",
+                       "c3": "eeeeeeee-1111-2222-3333-000000000003"}, f)
+        driver = os.path.join(self.lab, "driver-group.mjs")
+        with open(driver, "w") as f:
+            f.write(GROUP_DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        self.assertEqual(r.get("errors"), [], "the page threw nothing: %r" % r.get("errors"))
+        gcol, scol = r["groupCol"], r["soloCol"]
+        self.assertEqual(gcol, "col-needsInput-list", "the mixed-state group renders in Blocked, its worst member's column: %r" % r["before"])
+        self.assertEqual(scol, "col-completed-list", "the solo completed card renders in Completed: %r" % r["before"])
+        f_ = r["folded"]
+        self.assertFalse(f_["groupShown"] or f_["soloShown"], "both runs folded: nothing rendered: %r" % f_)
+        self.assertEqual(sorted(h["folded"] for h in f_["heads"]), [True, True], "both headers folded: %r" % f_["heads"])
+        j = r["jumped"]
+        heads = {h["col"]: h for h in j["heads"]}
+        self.assertTrue(j["groupShown"], "the jump opened the run the member RENDERS in — the group is back on screen: %r" % j)
+        self.assertFalse(heads[gcol]["folded"], "the Blocked header (the group's run) is open: %r" % heads)
+        self.assertTrue(heads[scol]["folded"], "the Completed run — an unrelated fold — stays folded: %r" % heads)
+        self.assertFalse(j["soloShown"], "…its solo card still hidden: %r" % j)
 
     def test_folding_a_session_in_one_column_leaves_its_other_column_open_and_persists(self):
         cfg = os.path.join(self.lab, "cfg.json")

--- a/ui/webview/feed-thread-fold.test.ts
+++ b/ui/webview/feed-thread-fold.test.ts
@@ -67,8 +67,14 @@ test("the click acknowledges immediately and cannot be lost to a re-render", () 
 
 test("a jump into a folded thread unfolds it instead of landing on nothing", () => {
   // revealCards scrolls to a DOM element; a folded card has none, so the navigation would silently no-op
-  assert.match(FEED, /const tkey = threadKey\(a\.sid, askColumn\(a\)\);[^\n]*\n\s*if \(collapsedThreads\.has\(tkey\) && extHoverMatches\("a:" \+ a\.itemId, keys\)\) \{/,
-    "the run the card sits in — its column's key — is what a jump unfolds");
+  // the run the card RENDERS in (T263d): a turn-group member renders in the group's column (buildGroup's worst
+  // member), not its own — keying the unfold by askColumn(a) opened an unrelated run and left the group's shut
+  assert.match(FEED, /const tkey = threadKey\(a\.sid, renderedCol\.get\(a\.itemId\) \?\? askColumn\(a\)\);\s*\n\s*if \(collapsedThreads\.has\(tkey\) && extHoverMatches\("a:" \+ a\.itemId, keys\)\) \{/,
+    "the run the card renders in — its rendered column's key — is what a jump unfolds");
+  assert.match(FEED, /const renderedCol = new Map<string, Column>\(\);/);
+  assert.match(FEED, /if \(feedPrefs\(\)\.grouped\) \{\s*\n\s*const rank = new Map\(sessionOrder\.map\(\(s, i\) => \[s, i\] as const\)\);\s*\n\s*renderedCol\.clear\(\);/, "rebuilt on every grouped render");
+  assert.match(FEED, /if \(e\.kind === "ask"\) renderedCol\.set\(e\.ask\.itemId, k\);\s*\n\s*else if \(e\.kind === "group"\) for \(const m of e\.group\.members\) renderedCol\.set\(m\.itemId, k\);/,
+    "every card and every group member is recorded under the bucket column it renders in");
   assert.match(FEED, /if \(opened\) render\(\);/);
 });
 

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -680,6 +680,10 @@ const openBgSvc = new Set<string>();   // sids with the chip's process list expa
 // arrive collapsed too, and a card's column is not knowable when you fold the thread. Persisted across
 // reloads with the rest of the disclosure state, and deliberately NOT pruned when the cards go away.
 const collapsedThreads = new Set<string>();
+// itemId → the column its card RENDERS in this grouped render (T263d, review of T263c): a turn-group's
+// members render in the GROUP's column (buildGroup: the worst member's), not their own, so a jump into a
+// folded member must unfold the run that actually holds it. Rebuilt on every grouped render.
+const renderedCol = new Map<string, Column>();
 // names of sessions idle-but-AWAITING background work (the user 2026-07-13): the same dot in await-green —
 // matching the chat chip's Awaiting color — so a held session reads differently from a working one.
 let awaitingSet = new Set<string>();
@@ -4879,6 +4883,7 @@ function render() {
   // is stable, so per-session cards keep the column's newest/oldest order. Headers only where a run exists.
   if (feedPrefs().grouped) {
     const rank = new Map(sessionOrder.map((s, i) => [s, i] as const));
+    renderedCol.clear();   // rebuilt from this render's buckets (T263d)
     const eSid = (e: Entry) => e.kind === "ask" ? e.ask.sid : e.kind === "group" ? e.group.sid : e.sid;
     for (const k of Object.keys(buckets) as Column[]) {
       const extra = new Map<string, number>();   // sids the order list doesn't know → after it, first-seen order
@@ -4896,6 +4901,9 @@ function render() {
           head = { kind: "sess", t: e.t, sid: s, col: k, name: src.name, color: src.color || null, live: !!src.live, folded: 0 };
           withHeads.push(head);
         }
+        // where each card renders, for a jump into a folded run (unfoldThreadsFor): a group's members all sit in the group's column
+        if (e.kind === "ask") renderedCol.set(e.ask.itemId, k);
+        else if (e.kind === "group") for (const m of e.group.members) renderedCol.set(m.itemId, k);
         // A COLLAPSED thread contributes its header and nothing else — the run's cards are counted onto the
         // header instead of rendered, so the folded row still says how much is under it. CARDS, not rows
         // (entryCards): a turn-group folds as its member count, the same rule the section chip reads.
@@ -5855,7 +5863,9 @@ function unfoldThreadsFor(keys: Set<string>): void {
   if (!collapsedThreads.size) return;
   let opened = false;
   for (const a of asks) {
-    const tkey = threadKey(a.sid, askColumn(a));   // the run the card sits in — per (session, column), T263c
+    // the run the card RENDERS in — per (session, column), T263c; a turn-group member renders in the group's
+    // column, not its own (T263d), so the last grouped render's map wins over the card's own column
+    const tkey = threadKey(a.sid, renderedCol.get(a.itemId) ?? askColumn(a));
     if (collapsedThreads.has(tkey) && extHoverMatches("a:" + a.itemId, keys)) {
       collapsedThreads.delete(tkey); opened = true;
     }


### PR DESCRIPTION
Follow-up from the adversarial review of the per-column fold (#1112).

A turn-group's members render in the **group's** column, its worst member's, not their own. The jump-into-a-folded-card path (`unfoldThreadsFor`, used by bell-entry and notification jumps and by cross-pane reveals) keyed the unfold by the member's own column, so a jump to a completed member of a group sitting in Blocked opened the session's unrelated Completed run and left the group's Blocked run shut: a fold the user set was undone with no new information, and the jump still landed on nothing.

- **Fix.** The grouped render records, per card and per group member, the bucket column it renders in (`renderedCol`, rebuilt every grouped render); `unfoldThreadsFor` keys the unfold by that column, falling back to the card's own column when the map has no entry.
- **Tests.** `feed-thread-fold.test.ts` pins the map, its rebuild and the rendered-column key. `tests/test_feed_thread_fold_columns.py` gains a served case: a mixed-state turn-group in Blocked and a solo card in Completed, both runs folded; a jump to the completed member opens the Blocked run and shows the group while the Completed run stays folded. Red on the first cut (Completed opened, Blocked stayed shut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
