### PR TITLE
Chat split screen: the dashboard holds N chat columns, each a full chat on its own session

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -231,6 +231,18 @@ scrolling for the rest; the cap lifts while a row's details are open. Where the 
 it also shrinks the tabs and group headers; on a phone the session picker stands in for the strip, so
 there the setting tightens the panel alone. Like the other chat settings, it is per browser.
 
+**Several sessions at once.** The chat can be split into columns, so two or three sessions
+sit side by side instead of behind each other's tabs. Right-click a tab and pick **Open in
+new split**, and a new chat column opens to the right on that session; **⌘** / **Ctrl**
+with the backslash key, or **Split the chat** in the command palette, opens an empty one. Each column is a full chat, with its own tab strip,
+its own composer and its own place in each transcript; drag the gutter between two columns
+to resize them. A column remembers which session it was on, and its width, across reloads,
+and the set of open columns is remembered per browser. The **×** in a column's top-right
+corner closes it; **Close this chat split** in the palette closes the column you are in, or
+the last one when you are in the first. When a card in the feed or a notification jumps to
+a session, the jump lands in the column already showing it, else in the column you last
+worked in. Four columns at most; the phone shows one pane at a time and never splits.
+
 ### The feed
 
 The feed is Romp's task-management layer: a card for each task. Romp's

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -241,7 +241,11 @@ at its send position, above those steps, while the model read it only after them
 so the order on screen contradicted the order the model saw; the read position is
 the one that matches. So the chat's pending bubble sits at the TAIL while pending,
 below every streaming step, and the landed atom appears in that same tail
-position, so nothing moves on landing; the send time rides along as `sentAt` for
+position, so nothing moves on landing. Every other window of the session sees the
+kernel's echo of that send in the same place: the live merge orders an in-flight
+echo after everything the turn holds (a never-delivered one keeps its time), and
+the pane dresses it as the sender's bubble is dressed, so one session in two split
+columns agrees on what is pending (2026-09-11). The send time rides along as `sentAt` for
 the bubble's hover ("sent at HH:MM", shown once landed when it differs from the
 landing by more than a minute). No header, no cue. This supersedes the
 in-place-at-send-position rule of T252/T252b; the kernel's per-copy identities

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -31190,7 +31190,18 @@ def _merge_live_atoms(session, sid, shown_texts=()):
         turns = [{"id": "live", "trigger": None, "t": fresh[0]["t"], "end": fresh[-1]["t"],
                   "ended": not live_work, "atoms": []}]
     turns[-1] = dict(turns[-1])
-    turns[-1]["atoms"] = sorted(list(turns[-1]["atoms"]) + fresh, key=lambda a: (a.get("t", 0), a.get("_seq", 0)))
+    # An in-flight input ECHO — the kernel's copy of a send the model has not read yet — sorts AFTER every atom the
+    # turn holds, whatever its send time (T252d for every other window, 2026-09-11). The model reads a mid-turn
+    # send only at its next tool boundary, so the steps that streamed after the send ran BEFORE it was read; sorted
+    # by time the echo drew the message above them in every window but the sender's own, whose tail bubble hides
+    # the echo (render.ts hiddenByPending) — one session in two split columns read as one column behind the other
+    # (the user 2026-09-10). The landing (the queued_command attachment, event_model._absorbed) takes the
+    # boundary's own time, the same tail region, so nothing moves when it lands. A never-delivered echo (dropped)
+    # is a record of a loss and keeps its time, as does a landed-but-unpruned one and the CLI's command feedback.
+    def _order(a):
+        tail = 1 if (a.get("_echo_text") and not a.get("command") and not a.get("dropped") and not a.get("_landed")) else 0
+        return (tail, a.get("t", 0), a.get("_seq", 0))
+    turns[-1]["atoms"] = sorted(list(turns[-1]["atoms"]) + fresh, key=_order)
     # Extend the turn's window over the appended tail (the user 2026-07-02): segments() spans [turn.t,
     # turn.end], so a live atom past the disk turn's end (a /model invocation minutes after the last work)
     # otherwise falls OUTSIDE every segment — its timeline dot then appeared only retroactively, once the

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -39692,8 +39692,8 @@ def _note_ws_drop(c, why, frame_len, key=None):
     if key is None:
         key = c.get("curSlot")
     try:
-        sys.stderr.write("ws: dropping %s client — %s (wid=%s slot=%s queued=%dB frame=%dB)\n"
-                         % (c.get("app"), why, c.get("wid") or "-", _perf_slot(key) if key else "-",
+        sys.stderr.write("ws: dropping %s client — %s (wid=%s col=%s slot=%s queued=%dB frame=%dB)\n"
+                         % (c.get("app"), why, c.get("wid") or "-", c.get("col") or "-", _perf_slot(key) if key else "-",
                             int(c.get("qbytes") or 0), int(frame_len)))
         if "bytes behind" in str(why):
             _WS_DROP_SEQ[0] += 1
@@ -44912,7 +44912,16 @@ def _consume_pending_reveal(client, why="the pane's ready"):
     _PENDING_REVEAL[0] = None
     print("[reveal] sid=%s wid=%s: consumed — %s" % (str(p["sid"])[:8], str(p["wid"] or "")[:8], why), file=sys.stderr)
     try:
-        client["send"](json.dumps(_reveal_msg(p["sid"])))
+        m = _reveal_msg(p["sid"])
+        m["own"] = True   # addressed to THIS column (split screen, 2026-09-08): one chat client consumes the parked
+        #                   tap, so the pane's column arbitration (render.ts focusIsOurs) must not hand it elsewhere —
+        #                   a consumed park has ONE recipient, and a consumer that deferred to arbitration would lose
+        #                   the tap (a booting split whose second column's ready came first). Known residual
+        #                   (review find, 2026-09-11): a copy already delivered to unproven same-wid panes (`sent`,
+        #                   T312) can land in one column by arbitration and then, before its proof retires the park,
+        #                   in a redialing column too (its socket dead at the tap) — two columns on one session, a
+        #                   state the split allows on purpose, so the rare duplicate is accepted over a lost tap.
+        client["send"](json.dumps(m))
     except Exception:
         pass
 
@@ -45381,6 +45390,12 @@ var failedConnects=0,firstFailT=0;   // handshakes that never OPENED since the l
 // (a focus, a jump) at the dashboard that asked instead of at every one that is open (the user 2026-07-29).
 var wid=new URLSearchParams(location.search).get("wid")||"";
 try{if(!wid)wid=window.sessionStorage.getItem("romp:wid")||"";}catch(e){}
+// This pane's chat COLUMN (split screen, the user 2026-09-08): the shell serves every chat column past the
+// first as /chat?col=N. The column rides the persisted-state key (SK, below) so each column keeps its OWN
+// active tab, drafts and scroll — one blob per column, the first column on the unsuffixed key it always had —
+// and the WS connect, so the kernel can tell one dashboard's columns apart in its logs. "" for the first
+// column, a standalone page and every non-chat pane; the shim is shared, so absent means exactly today.
+var COL=new URLSearchParams(location.search).get("col")||"";if(COL==="1")COL="";
 // This PAGE's instance id — minted once per load, never stored: every connect of this page carries it, so the
 // kernel retires this page's previous socket on a reconnect, and never another page's (a duplicated tab copies
 // sessionStorage, and with it wid; it must not copy this).
@@ -45526,7 +45541,7 @@ function connect(){if(ws&&(ws.readyState===0||ws.readyState===1))return;   // on
 if(returnAt)returnRedialed=true;   // a dial inside a return window (whatever path led here) → the return-fresh row says so
 connT=Date.now();var proto=location.protocol==="https:"?"wss://":"ws://";
 var active="";try{var st0=JSON.parse(localStorage.getItem(SK)||"null");active=(st0&&st0.activeId)||"";}catch(e){}
-ws=new WebSocket(proto+location.host+"/ws?app=%s&delta=1&iid="+encodeURIComponent(IID)+(wid?"&wid="+encodeURIComponent(wid):"")+(active?"&active="+encodeURIComponent(active):"")+((everConnected&&bundleReady&&readyAcked&&!readyQueued)?"&reconnect=1":""));   // reconnect=1: this page has held a socket before AND its bundle has said ready AND the kernel's caps frame has answered that ready AND the ready is not still waiting in the queue for this open, so it holds the sessions the kernel served it; the kernel skeletons the tabs it is not looking at (2026-09-07). A socket that opened and died before the bundle said ready held nothing for the page, and neither did one whose bundle said ready only after it died (the ready queued, and flushes onto this socket as the bundle's own); a ready that left on an open socket the kernel never answered (the socket died before its caps frame came back) served the page nothing either: all three redials dial as a fresh page, the last for the page's life, since the bundle posts ready once and no later socket carries one for a caps frame to answer (2026-09-10)
+ws=new WebSocket(proto+location.host+"/ws?app=%s&delta=1&iid="+encodeURIComponent(IID)+(wid?"&wid="+encodeURIComponent(wid):"")+(active?"&active="+encodeURIComponent(active):"")+((everConnected&&bundleReady&&readyAcked&&!readyQueued)?"&reconnect=1":"")+(COL?"&col="+encodeURIComponent(COL):""));   // reconnect=1: this page has held a socket before AND its bundle has said ready AND the kernel's caps frame has answered that ready AND the ready is not still waiting in the queue for this open, so it holds the sessions the kernel served it; the kernel skeletons the tabs it is not looking at (2026-09-07). A socket that opened and died before the bundle said ready held nothing for the page, and neither did one whose bundle said ready only after it died (the ready queued, and flushes onto this socket as the bundle's own); a ready that left on an open socket the kernel never answered (the socket died before its caps frame came back) served the page nothing either: all three redials dial as a fresh page, the last for the page's life, since the bundle posts ready once and no later socket carries one for a caps frame to answer (2026-09-10)
 // onopen: flush the queue; a RECONNECT (after a drop) also PROMPTS a reload — the fresh socket resyncs live via
 // the kernel's next push, and the banner offers a full reload for anything a live push doesn't cover. This
 // replaced the old silent location.reload() (the user 2026-07-05: don't foist a reload; let me click). Narrowed by
@@ -45671,7 +45686,7 @@ var touched=kind.indexOf("dictlist:")===0?touchedLanes(c,map.order,order):null;
 last.maps[name]={order:order,items:items};m[name]=assemble(kind,last.maps[name],last.msg[name],touched);}
 last.rev=d.rev;last.msg=m;return m;}
 window.__rompLocalSend=send;window.__rompApp=APP;   // federation.ts (the multi-kernel manager) routes local sends + knows the app through these
-var SK="romp-vscode-state-%s";   // persist webview state to localStorage so UI prefs survive a refresh
+var SK="romp-vscode-state-%s"+(COL?":"+COL:"");   // persist webview state to localStorage so UI prefs survive a refresh — per chat column (split screen 2026-09-08)
 window.acquireVsCodeApi=function(){return{postMessage:function(m){if(window.__rompFed){window.__rompFed.outbound(m);}else{send(m);}},
 getState:function(){try{return JSON.parse(localStorage.getItem(SK)||"null");}catch(e){return null;}},
 setState:function(s){try{localStorage.setItem(SK,JSON.stringify(s));}catch(e){}}};};connect();
@@ -46309,14 +46324,24 @@ var GK='romp-pane-grow',grow={chat:60,fleet:34,feed:40,files:40};
 try{var g=JSON.parse(localStorage.getItem(GK)||'null');if(g)grow=Object.assign(grow,g);}catch(e){}
 function setGrow(k,v){grow[k]=v;row.style.setProperty('--g-'+k,v);}
 for(var k in grow)setGrow(k,grow[k]);
-function key(id){return id==='chat-pane'?'chat':id==='fleet-pane'?'fleet':id==='feed-pane'?'feed':'files';}
+// split chat columns (the user 2026-09-08) are made AFTER this runs: they register here so the grab's
+// normalisation and the fair-grow average see them, and gv-a/gv-b's left neighbour is the RIGHTMOST one.
+var KEYS={};
+window.__rompRegisterPane=function(id,k){KEYS[id]=k;if(PANES.indexOf(id)<0)PANES.splice(PANES.indexOf('fleet-pane'),0,id);};
+window.__rompUnregisterPane=function(id){var k=KEYS[id];delete KEYS[id];var i=PANES.indexOf(id);if(i>=0)PANES.splice(i,1);
+if(k){delete grow[k];row.style.removeProperty('--g-'+k);try{localStorage.setItem(GK,JSON.stringify(grow));}catch(e){}}};
+function lastChat(){return (window.__rompLastChatPane&&window.__rompLastChatPane())||'chat-pane';}
+function key(id){return KEYS[id]||(id==='chat-pane'?'chat':id==='fleet-pane'?'fleet':id==='feed-pane'?'feed':'files');}
 function shown(id){var p=document.getElementById(id);return p&&getComputedStyle(p).display!=='none';}
 // a pane re-shown from the rail gets a grow comparable to the panes already visible, so it never slots back
 // in as a sliver after the others were dragged to extreme widths (grows are stored as px). Timeline is the
 // bottom BAND now (fixed-height var, not a row grow), so it's excluded.
-window.__rompGrowFair=function(k){if(k==='timeline')return;var v=PANES.filter(shown).map(function(id){return grow[key(id)];});
+window.__rompGrowFair=function(k){if(k==='timeline')return;var v=PANES.filter(shown).map(function(id){return grow[key(id)];})
+.filter(function(g){return typeof g==='number'&&isFinite(g);});   // a pane with no grow yet (a split column being made) must not average in as NaN (review find 2026-09-08: the first split opened 0px wide)
 var avg=v.length?v.reduce(function(a,b){return a+b;},0)/v.length:50;setGrow(k,avg);
 try{localStorage.setItem(GK,JSON.stringify(grow));}catch(e){}};
+// a split column keeps the width it was dragged to across reloads: fair only when the store holds nothing for it
+window.__rompGrowFairIfNew=function(k){if(typeof grow[k]==='number'&&isFinite(grow[k])){setGrow(k,grow[k]);return;}window.__rompGrowFair(k);};
 // A drag moves a LANDING LINE and the panes take their widths ONCE, at release. A grow write re-lays out the row
 // and with it every same-origin pane document in that frame, so writing the pair on every mousemove cost one
 // relayout of every pane per pointer step, a cost that grows with what the panes hold (seconds a step once a pane
@@ -46328,7 +46353,11 @@ function gutter(gid,leftPick,rightId){var h=document.getElementById(gid);if(!h)r
 h.addEventListener('mousedown',function(e){e.preventDefault();
 var L=document.getElementById(leftPick()),R=document.getElementById(rightId);if(!L||!R)return;
 document.body.classList.add('drag','dragv');
-PANES.forEach(function(id){if(shown(id))setGrow(key(id),document.getElementById(id).offsetWidth);});
+// read EVERY shown pane's width first, then write: a setGrow re-flows the row, so a width read after it came back
+// at a mixed scale (the first pane in px, the rest still on their small default numbers) and the first drag in a
+// fresh browser ballooned the first column (served-test find, 2026-09-08; the split's fresh columns hit it every time)
+var px={};PANES.forEach(function(id){if(shown(id))px[id]=document.getElementById(id).offsetWidth;});
+Object.keys(px).forEach(function(id){setGrow(key(id),px[id]);});
 var wL=L.offsetWidth,wR=R.offsetWidth,sum=wL+wR,sx=e.clientX,mn=Math.min(120,sum*0.25),nL=wL,lx=L.getBoundingClientRect().left,rr=row.getBoundingClientRect();
 function show(){if(!ghost)return;ghost.style.top=rr.top+'px';ghost.style.height=rr.height+'px';ghost.style.left=(lx+nL)+'px';ghost.style.display='block';}
 function mv(ev){nL=Math.max(mn,Math.min(sum-mn,wL+(ev.clientX-sx)));show();}
@@ -46336,9 +46365,10 @@ function up(){document.body.classList.remove('drag','dragv');if(ghost)ghost.styl
 setGrow(key(L.id),nL);setGrow(key(R.id),sum-nL);try{localStorage.setItem(GK,JSON.stringify(grow));}catch(e){}
 window.removeEventListener('mousemove',mv);window.removeEventListener('mouseup',up);}
 show();window.addEventListener('mousemove',mv);window.addEventListener('mouseup',up);});}
-gutter('gv-a',function(){return 'chat-pane';},'fleet-pane');
-gutter('gv-b',function(){return document.body.classList.contains('po-fleet')?'fleet-pane':'chat-pane';},'feed-pane');
-gutter('gv-c',function(){var c=document.body.classList;return c.contains('po-feed')?'feed-pane':c.contains('po-fleet')?'fleet-pane':'chat-pane';},'files-pane');
+window.__rompGutter=gutter;   // the split's chat|chat gutters are wired through the same code
+gutter('gv-a',function(){return lastChat();},'fleet-pane');
+gutter('gv-b',function(){return document.body.classList.contains('po-fleet')?'fleet-pane':lastChat();},'feed-pane');
+gutter('gv-c',function(){var c=document.body.classList;return c.contains('po-feed')?'feed-pane':c.contains('po-fleet')?'fleet-pane':lastChat();},'files-pane');
 tf&&tf.addEventListener('load',function(){autosize();
 try{new ResizeObserver(autosize).observe(tf.contentDocument.body);}catch(e){}});
 window.addEventListener('resize',autosize);
@@ -46359,17 +46389,21 @@ var TL='f-timeline';                       // the timeline is a bottom BAND unde
 var curFocus='f-chat', lastCol='f-chat';   // for Shift-Up out of the timeline: return to the last column used
 // The active pane gets a focus RING (.pane-focused). Same-origin iframes, so the shell sets it directly on
 // pointerdown / focusin / window-focus — event-based, no polling. Exactly one pane is ringed at a time.
-function setFocus(id){var pid=PANE[id];if(!pid)return;curFocus=id;if(COLS.indexOf(id)>=0)lastCol=id;
-for(var k in PANE){var el=document.getElementById(PANE[k]);if(el)el.classList.toggle('pane-focused',PANE[k]===pid);}}
+var lastChat='f-chat';   // the chat column the user last worked in (split screen 2026-09-08): where shell relays land
+function paneOf(id){return PANE[id]||(window.__rompChatPaneOf?window.__rompChatPaneOf(id):null);}   // split columns are made after this map
+function allCols(){var c=window.__rompChatFrameIds?window.__rompChatFrameIds():['f-chat'];return c.concat(COLS.slice(1));}   // every chat column, then Outline, Feed
+function setFocus(id){var pid=paneOf(id);if(!pid)return;curFocus=id;if(allCols().indexOf(id)>=0)lastCol=id;if(pid.indexOf('chat-pane')===0)lastChat=id;
+Array.prototype.forEach.call(document.querySelectorAll('.pane'),function(el){el.classList.toggle('pane-focused',el.id===pid);});}
+window.__rompFocusedChatId=function(){return document.getElementById(lastChat)?lastChat:'f-chat';};
 // SPATIAL cross-pane keyboard nav (the user 2026-07-01): Alt(Option)+Arrow jumps focus between VISIBLE panes —
 // Alt-Left/Right along the columns (Chat <-> Outline <-> Feed, skipping hidden ones), Alt-Down into the
 // timeline band, Alt-Up back out. Alt (not Shift, which selects text; not Ctrl/Cmd, which macOS uses for
 // Spaces / browser back-forward) — the one modifier free outside a text field. Iframes can't focus each other,
 // but the shell (their parent) can; it then posts {romp:'paneFocus'} so the target pane can arm its own
 // intra-pane arrow nav (feed/outline cards). Configurable later; hardcoded for now (the user 2026-07-01).
-function paneVisible(id){var el=document.getElementById(PANE[id]);if(!el)return false;
+function paneVisible(id){var el=document.getElementById(paneOf(id));if(!el)return false;
 try{return getComputedStyle(el).display!=='none';}catch(e){return true;}}
-function visCols(){return COLS.filter(paneVisible);}
+function visCols(){return allCols().filter(paneVisible);}
 function focusPane(id,dir){var f=document.getElementById(id);if(!f)return;
 try{f.contentWindow.focus();}catch(e){}setFocus(id);
 try{f.contentWindow.postMessage({romp:'paneFocus',dir:dir||'',from:'shell'},'*');}catch(e){}}
@@ -46399,6 +46433,7 @@ f.contentWindow.addEventListener('focus',emit);
 d.addEventListener('keydown',onKey,true);}catch(e){}}   // capture Alt+Arrow before the pane's own handlers
 Object.keys(PANE).forEach(function(id){var f=document.getElementById(id);if(!f)return;
 f.addEventListener('load',function(){wire(f);});wire(f);});   // wire now (already-loaded) + on every (re)load
+window.__rompWireFocus=function(f){f.addEventListener('load',function(){wire(f);});wire(f);};   // a split column made later gets the same
 // ALSO claim Alt+Arrow at the TOP-LEVEL shell document (the user 2026-07-01): a keydown fires in whichever
 // document has focus and does NOT cross the iframe boundary, so the per-iframe handlers miss the case where
 // focus sits on the shell itself (right after load, or after clicking shell chrome) — there Alt+Left fell
@@ -46587,11 +46622,15 @@ window.__rompNotify(m.kind||'error',m.text,
 // loaded), so a blip on a pane you can't even see shouldn't cry wolf while the chat pane you interact
 // through is up. Gate on the pane-enabled body class the toggle sets (po-chat/po-feed/po-timeline/po-fleet).
 // Only the up->down TRANSITION logs an entry; the live red cue rides the state itself.
-var st={};
+var st={},stc={};   // stc: split chat columns (2026-09-08) by column, apart from the first column's `chat` key — one column's 'up' must never mask another's drop
 function shown(k){return document.body.classList.contains('po-'+k);}
-function liveDown(){for(var k in st){if(st[k]==='down'&&shown(k))return true;}return false;}
+function liveDown(){for(var k in st){if(st[k]==='down'&&shown(k))return true;}for(var c in stc){if(stc[c]==='down'&&shown('chat'))return true;}return false;}
+window.__rompColGone=function(c){delete stc[String(c)];paint();};   // a closed column takes its state with it
 var PN=""" + json.dumps(dict(_PANE_ORDER)) + """;   // key → rail label, from _PANE_ORDER (one list with the rail, the tabs and the drop row); timeline key stays internal — the pane outgrew the name (filter, tags, lane controls — the user 2026-08-24)
 window.addEventListener('message',function(e){var m=e&&e.data;if(!m||m.romp!=='wsState')return;
+var col=(m.app==='chat'&&window.__rompColOf)?window.__rompColOf(e.source):'';   // a split column reports under its own key (the sender frame says which)
+if(col){var sc=(m.state==='up')?'up':'down',pc=stc[col];stc[col]=sc;
+if(sc==='down'&&pc!=='down'&&shown('chat'))window.__rompNotify('conn','Kernel connection lost \\u2014 chat split '+col+' (reconnecting)');else paint();return;}
 var s=(m.state==='up')?'up':'down',prev=st[m.app];st[m.app]=s;
 if(s==='down'&&prev!=='down'&&shown(m.app))
 window.__rompNotify('conn','Kernel connection lost \\u2014 '+(PN[m.app]||m.app)+' pane (reconnecting)');
@@ -46650,6 +46689,8 @@ document.addEventListener('keydown',onEsc,true);
 ['f-chat','f-fleet','f-feed','f-files','f-timeline','f-settings'].forEach(function(id){var f=document.getElementById(id);if(!f)return;
 var wire=function(){try{if(f.contentDocument)f.contentDocument.addEventListener('keydown',onEsc,true);}catch(e){}};
 f.addEventListener('load',wire);wire();});
+window.__rompWireEsc=function(f){var wire=function(){try{if(f.contentDocument)f.contentDocument.addEventListener('keydown',onEsc,true);}catch(e){}};
+f.addEventListener('load',wire);wire();};   // a split chat column (2026-09-08) is wired as it is made
 })();
 """
 
@@ -47839,14 +47880,22 @@ open();};
 window.addEventListener('message',function(e){var m=e.data;if(!m)return;
 if(m.romp==='settings'){document.body.classList.toggle('settings-open',!!m.on);
 // closing hides the iframe that held the keyboard, which drops focus onto the shell body; put it back in the
-// chat (the dashboard's default focus, _LANDING_FOCUS_JS rings it) so the next keystroke lands in a pane
-if(!m.on){var fc=document.getElementById('f-chat');try{fc&&fc.contentWindow&&fc.contentWindow.focus();}catch(e){}}}
+// chat (the dashboard's default focus, _LANDING_FOCUS_JS rings it) so the next keystroke lands in a pane — the
+// split's column last worked in, else the first (2026-09-11: the close handed the keyboard to column 1 whatever
+// column the user was in, and that focus re-aimed every later shell relay at column 1 too)
+if(!m.on){var fid=(window.__rompFocusedChatId&&window.__rompFocusedChatId())||'f-chat';var fc=document.getElementById(fid)||document.getElementById('f-chat');try{fc&&fc.contentWindow&&fc.contentWindow.focus();}catch(e){}}}
 // a pane asking for the gear (the feed's login card, ui/webview/gear-host.ts openGear: the feed page hosts no gear)
 if(m.romp==='openSettings')window.__rompOpenSettings();
 // the gear's "Open log" (T290): the settings modal closes itself first, then asks the shell for the Log panel
 if(m.romp==='openLog'&&window.__rompOpenErrs)window.__rompOpenErrs();
 // the /chat iframe's new-session picker asks the shell to lift it full-window (see body.picker-open CSS)
-if(m.romp==='picker')document.body.classList.toggle('picker-open',!!m.on);
+if(m.romp==='picker'){
+  // the column that asked is the one lifted (split screen 2026-09-08): the sender frame wears .lifted (and its
+  // pane), the CSS lifts by that class; the first column when the sender cannot be told (no split script)
+  var lf=(window.__rompFrameOfWin&&window.__rompFrameOfWin(e.source))||document.getElementById('f-chat');
+  Array.prototype.forEach.call(document.querySelectorAll('.lifted'),function(el){el.classList.remove('lifted');});
+  if(m.on&&lf){lf.classList.add('lifted');if(lf.parentElement)lf.parentElement.classList.add('lifted');}
+  document.body.classList.toggle('picker-open',!!m.on);}
 // A file link clicked in the chat and routed to the FILES pane (ui/webview/file-route.ts fileLinkRoute,
 // decided at the click in render.ts openPath: the pane is on screen, or the gear's "File links open in"
 // names it) posts viewFile up with pane:'pane'. The shell brings that pane forward, the click being the
@@ -47909,6 +47958,7 @@ else if(m.romp==='browseFiles'){var bf=document.getElementById('f-feed');
 // opened for (m.sid beats the active tab there). The chat-hosted viewer posts to its own window and
 // never gets here.
 if(m.type==='editorSelection'&&typeof m.text==='string'){var fc=document.getElementById('f-chat');
+  fc=(window.__rompChatTarget&&window.__rompChatTarget(m.sid))||fc;   // the split column showing that session, else the one last used (2026-09-08)
   // the chat pane may be toggled OFF (hidden by CSS, iframe still loaded): the chip would seed a composer
   // nobody can see, a silent gesture (review find on #970, 2026-09-07). Bring the pane forward first, the
   // way the browseFiles arm does for the feed — desktop only; the phone's one-pane tab swap is untouched.
@@ -48879,7 +48929,8 @@ return (s?s.unsubscribe():Promise.resolve()).then(function(){return ep?post('/pu
 // files it as a client-diag row and the result line says no session was attached, never a silent probe.
 function diag(what,data){try{window.__rompShellDiag&&window.__rompShellDiag(what,data);}catch(e){}}
 function activeSession(){var t=null,why='',n=0;
-try{var f=document.getElementById('f-chat'),d=f&&f.contentDocument,tb=d&&d.querySelector('#tabs');
+try{var f=document.getElementById('f-chat');var fid=window.__rompFocusedChatId&&window.__rompFocusedChatId();   // the split column last worked in (2026-09-08)
+if(fid&&document.getElementById(fid))f=document.getElementById(fid);var d=f&&f.contentDocument,tb=d&&d.querySelector('#tabs');
 if(!f)why='no-frame';else if(!d)why='no-doc';else if(!tb)why='no-tabs';
 else{n=tb.querySelectorAll('.tab[data-id]').length;t=tb.querySelector('.tab.active[data-id]');if(!t)why='none-active';}}catch(e){why='threw';}
 var id=t?String(t.getAttribute('data-id')||''):'';var i=id.indexOf(':');
@@ -49309,6 +49360,85 @@ _LANDING_COLLAPSE_JS = """
 """
 
 
+# SPLIT SCREEN for the chat (the user 2026-09-08, who wanted several sessions open at once instead of tabbing
+# through them). Every chat column past the first is a client-made twin of #chat-pane — <div class="pane
+# chat-col"> around an iframe at /chat?col=N, inserted before gv-a with a .gv.gv-chat gutter ahead of it — so
+# the row reads chat | chat … | outline | feed. Each column is a FULL chat pane: its own tab strip, its own
+# persisted active tab, drafts and scroll (the shim keys its state blob by ?col=), its own socket (the kernel
+# already serves N chat clients per dashboard and builds every watched tab first), its own grow weight
+# (--g-chatN, in the gutters' store). The set of open columns persists per browser (romp-chat-cols); a
+# reopened column number finds its state where it left it. Desktop only: the phone shows one pane at a time.
+# A dashboard-aimed focus (a feed click, a kernel focus, a revive prompt) reaches EVERY column's socket, so the
+# columns ask the shell which of them it belongs to (__rompChatTarget: the column already showing the session,
+# else the one the user last worked in, else the first) and the others stand down — render.ts focusIsOurs.
+_LANDING_SPLIT_JS = """
+(function(){
+var CK='romp-chat-cols',MAX=4,cols=[];   // cols: the open column numbers in ROW order (2, 3, …); MAX counts the first column too
+var row=document.querySelector('.row'),gva=document.getElementById('gv-a');
+if(!row||!gva)return;
+function mobile(){var b=document.getElementById('mtabs');try{return !!b&&getComputedStyle(b).display!=='none';}catch(e){return false;}}
+function save(){try{localStorage.setItem(CK,JSON.stringify(cols));}catch(e){}}
+function paneId(n){return 'chat-pane-'+n;}function frameId(n){return 'f-chat-'+n;}
+function frames(){var out=[document.getElementById('f-chat')];cols.forEach(function(n){out.push(document.getElementById(frameId(n)));});return out.filter(Boolean);}
+function frameOfWin(win){if(!win)return null;var fs=frames();for(var i=0;i<fs.length;i++){try{if(fs[i].contentWindow===win)return fs[i];}catch(e){}}return null;}
+function colOf(win){var f=frameOfWin(win);return f?String(f.getAttribute('data-col')||''):'';}
+function lastPane(){return cols.length?paneId(cols[cols.length-1]):'chat-pane';}
+function activeIn(f){try{var t=f.contentDocument&&f.contentDocument.querySelector('#tabs .tab.active[data-id]');return t?String(t.getAttribute('data-id')||''):'';}catch(e){return '';}}
+function focused(){var id=(window.__rompFocusedChatId&&window.__rompFocusedChatId())||'f-chat';return document.getElementById(id)||document.getElementById('f-chat');}
+// Which column a session-focus belongs to: the column already showing that session, else the column the
+// user last worked in, else the first. The panes ask this before acting on a dashboard-aimed focus.
+function target(sid){var fs=frames();if(sid){for(var i=0;i<fs.length;i++){if(activeIn(fs[i])===sid)return fs[i];}}return focused()||fs[0]||null;}
+function make(n,sid){var have=document.getElementById(frameId(n));if(have)return have;
+var g=document.createElement('div');g.className='gv gv-chat';g.id='gv-chat-'+n;
+var p=document.createElement('div');p.className='pane chat-col';p.id=paneId(n);p.setAttribute('data-col',String(n));
+p.style.flex='var(--g-chat'+n+',60) 1 0';
+var f=document.createElement('iframe');f.id=frameId(n);f.className='chat-col';f.setAttribute('data-col',String(n));f.src='/chat?col='+n;
+var x=document.createElement('div');x.className='col-x';x.title='Close this split';x.setAttribute('role','button');x.textContent='×';
+x.addEventListener('click',function(ev){ev.stopPropagation();close(n);});
+p.appendChild(f);p.appendChild(x);
+row.insertBefore(g,gva);row.insertBefore(p,gva);
+if(window.__rompRegisterPane)window.__rompRegisterPane(p.id,'chat'+n);
+if(window.__rompGrowFairIfNew)window.__rompGrowFairIfNew('chat'+n);else if(window.__rompGrowFair)window.__rompGrowFair('chat'+n);   // a fair width, never a sliver — and a dragged width survives a reload
+if(window.__rompGutter)window.__rompGutter(g.id,function(){var i=cols.indexOf(n);return i>0?paneId(cols[i-1]):'chat-pane';},p.id);
+if(window.__rompWireFocus)window.__rompWireFocus(f);if(window.__rompWireEsc)window.__rompWireEsc(f);
+try{window.dispatchEvent(new CustomEvent('romp-chat-cols',{detail:{frame:f,col:n,open:true}}));}catch(e){}   // palette-main wires its keys
+// opened ON a session: the pane takes a focus before its frames land (render.ts latches it), so the new
+// column shows that session and not whatever its state blob last held. `own` says this focus is addressed
+// to THIS column — the pane's arbitration (focusIsOurs) would otherwise hand it to a column already
+// showing the session, which is exactly the case when a tab is opened in a new split.
+if(sid)f.addEventListener('load',function(){try{f.contentWindow.postMessage({type:'focus',id:sid,own:true},'*');}catch(e){}},{once:true});   // the opening only: a later reload of the frame keeps the tab its own state names
+return f;}
+function canSplit(){return !mobile()&&cols.length+1<MAX;}
+// a refused split says why (the click-acknowledgement rule): the cap, or the phone's one-pane layout
+function refuse(){var why=mobile()?'The phone shows one pane at a time — no split here.':'Four chat columns at most — close one to open another.';
+try{if(window.__rompNotify)window.__rompNotify('warn',why);}catch(e){}return null;}
+function open(sid){if(!canSplit())return refuse();
+try{if(!document.body.classList.contains('po-chat')&&window.__rompPaneToggle)window.__rompPaneToggle('chat',true);}catch(e){}   // a split of a hidden chat group brings the group forward first
+var n=2;while(cols.indexOf(n)>=0)n++;cols.push(n);save();
+var f=make(n,sid||'');try{f.contentWindow.focus();}catch(e){}return f;}
+function close(n){var i=cols.indexOf(n);if(i<0)return;cols.splice(i,1);save();
+var p=document.getElementById(paneId(n)),g=document.getElementById('gv-chat-'+n);
+if(window.__rompUnregisterPane)window.__rompUnregisterPane(paneId(n));
+if(p)p.remove();if(g)g.remove();
+if(window.__rompColGone)window.__rompColGone(String(n));
+try{window.dispatchEvent(new CustomEvent('romp-chat-cols',{detail:{col:n,open:false}}));}catch(e){}
+var pf=document.getElementById(i>0?frameId(cols[i-1]):'f-chat');   // the ring moves to the column before it
+try{pf&&pf.contentWindow.focus();}catch(e){}}
+function closeFocused(){var f=focused(),c=f?colOf(f.contentWindow):'';if(!c&&cols.length)c=String(cols[cols.length-1]);if(c)close(Number(c));}
+window.__rompSplitChat=function(sid){return open(typeof sid==='string'?sid:'');};window.__rompCanSplit=canSplit;
+window.__rompCloseSplit=function(n){if(n===undefined)closeFocused();else close(Number(n));};
+window.__rompChatFrames=frames;window.__rompChatFrameIds=function(){return frames().map(function(f){return f.id;});};
+window.__rompChatPaneOf=function(fid){return fid==='f-chat'?'chat-pane':(String(fid).indexOf('f-chat-')===0?paneId(String(fid).slice(7)):null);};
+window.__rompLastChatPane=lastPane;window.__rompColOf=colOf;window.__rompFrameOfWin=frameOfWin;window.__rompChatTarget=target;
+// a chat pane's tab menu asks for a split holding that session (render.ts "Open in new split")
+window.addEventListener('message',function(e){var m=e&&e.data;if(!m||m.romp!=='openSplit')return;open(typeof m.sid==='string'?m.sid:'');});
+// the columns this browser had open come back, each on its own state
+try{var saved=JSON.parse(localStorage.getItem(CK)||'null');
+if(Array.isArray(saved)&&!mobile())saved.forEach(function(n){n=Number(n);if(n>=2&&n<100&&cols.indexOf(n)<0&&cols.length+1<MAX){cols.push(n);make(n,'');}});}catch(e){}
+})();
+"""
+
+
 def _stale_block(v):
     # the reload core first: the banner script below registers as its refused fallback and announces a reload
     return ("<style>" + _STALE_CSS + "</style>" + _STALE_HTML
@@ -49698,13 +49828,15 @@ def _landing():
             # list. Same bridge as settings: render.ts posts {romp:'picker',on} and the shell lifts the chat
             # iframe over the whole window (body.picker-open) so the overlay fills the screen and the list gets
             # the full height to scroll. Restored on close.
-            "body.picker-open #chat-pane{display:block!important}"
+            # …by CLASS since the split (2026-09-08): the column whose picker is up wears .lifted (the shell marks
+            # the sender frame and its pane), so a picker opened in a later column lifts THAT column, never the first.
+            "body.picker-open .pane.lifted{display:block!important}"
             # Height = --app-h (the shell's live VISIBLE height, fed by the top-level visualViewport),
             # not inset:0: the layout viewport ignores the phone keyboard, so a bottom-anchored lift sat
             # half behind it — and, sized this way, the keyboard opening/closing reaches the iframe as
             # its own resize event, which is what render.ts keys the picker's short-window fold on
             # (the user 2026-08-10, Chrome on a phone).
-            "body.picker-open #f-chat{display:block;position:fixed;left:0;right:0;top:0;height:var(--app-h,100dvh);z-index:200;background:transparent}"   # same transparency as the settings lift above
+            "body.picker-open iframe.lifted{display:block;position:fixed;left:0;right:0;top:0;height:var(--app-h,100dvh);z-index:200;background:transparent}"   # same transparency as the settings lift above
             # ── pane rail (the user 2026-06-24; rotated to a BOTTOM BAR the user 2026-07-05): a thin toolbar with
             # Chat / Timeline / Outline / Feed toggles. It used to be a vertical strip on the far LEFT; it now runs
             # HORIZONTALLY across the bottom of .col, BELOW the timeline band (last child of .col). Each toggle is
@@ -50181,6 +50313,17 @@ def _landing():
             # off hides it AND the now-orphaned gutters. Fixed order: chat, outline, feed, files. Timeline is the band.
             "#chat-pane{flex:var(--g-chat,60) 1 0}#fleet-pane{flex:var(--g-fleet,34) 1 0}#feed-pane{flex:var(--g-feed,40) 1 0}#files-pane{flex:var(--g-files,40) 1 0}"
             "body:not(.po-chat) #chat-pane{display:none}body:not(.po-fleet) #fleet-pane{display:none}body:not(.po-feed) #feed-pane{display:none}body:not(.po-files) #files-pane{display:none}"
+            # split chat columns (the user 2026-09-08): every column past the first is a client-made .pane.chat-col
+            # (_LANDING_SPLIT_JS) with its own /chat?col=N iframe and its own grow var, set inline. They ride the
+            # chat group's toggle: off hides every column and the chat|chat gutters with it.
+            "body:not(.po-chat) .chat-col,body:not(.po-chat) .gv-chat{display:none}"
+            # a split column's close: a small × in its top-right corner, shown on hover and while the column is
+            # focused, above the iframe and the focus ring (z 6) — the pane rail's action dress, not a new one
+            ".chat-col>.col-x{position:absolute;top:4px;right:6px;z-index:7;width:20px;height:20px;border-radius:5px;"
+            "background:rgba(30,30,30,0.85);color:#8a8a8a;font:600 13px/20px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;"
+            "text-align:center;cursor:pointer;user-select:none;opacity:0;transition:opacity .12s,color .1s,background .1s}"
+            ".chat-col:hover>.col-x,.chat-col.pane-focused>.col-x{opacity:1}"
+            ".chat-col>.col-x:hover{color:#fff;background:rgba(255,255,255,0.12)}"
             ".row>.gv{flex:0 0 7px}"
             # gv-a sits chat|outline (only when both shown); gv-b sits (outline|chat)|feed, so it is the chat|feed gutter when
             # the outline is off; gv-c sits (feed|outline|chat)|files, hidden when files is off or no column is shown to its left.
@@ -50253,6 +50396,7 @@ def _landing():
             # the Outline (fleet) rides the tab bar like every other pane (the user 2026-07-11, who couldn't
             # access the outline view in the mobile UI — it was desktop-only before)
             "#chat-pane,#fleet-pane,#feed-pane,#files-pane,#tl-pane{display:contents!important}"
+            ".chat-col,.gv-chat{display:none!important}"   # one pane at a time here: split columns never show (nor are made, see _LANDING_SPLIT_JS)
             # reset the desktop iframe absolute-fill (the bare `iframe` reset below re-flows them as tab panes)
             ".pane>iframe{position:static;inset:auto;width:100%;height:100%}"
             "iframe{position:static;display:none;width:100%;height:100%;border:0}"
@@ -50403,6 +50547,8 @@ def _landing():
             # which silenced the bell's and the network glyph's on-state entirely in the light theme
             # (the user 2026-09-02) — restate `.on` at the winning specificity
             "body.theme-light .rail-act.on{color:var(--accent)}"
+            "body.theme-light .chat-col>.col-x{background:rgba(255,255,255,0.85);color:#5D574E}"
+            "body.theme-light .chat-col>.col-x:hover{color:#1F1E1D;background:rgba(0,0,0,0.06)}"
             "body.theme-light .gv{background:linear-gradient(90deg,transparent 3px,rgba(0,0,0,0.14) 3px,rgba(0,0,0,0.14) 4px,transparent 4px)}"
             "body.theme-light .gh{background:linear-gradient(180deg,transparent 3px,rgba(0,0,0,0.14) 3px,rgba(0,0,0,0.14) 4px,transparent 4px)}"
             "body.theme-light .gv::after,body.theme-light .gh::after{background:rgba(0,0,0,0.22)}"
@@ -50766,6 +50912,7 @@ def _landing():
             "<script>" + _LANDING_PUSH_JS + "</script>"
             "<script>" + _LANDING_REVEAL_JS + "</script>"
             "<script>" + _LANDING_COLLAPSE_JS + "</script>"
+            "<script>" + _LANDING_SPLIT_JS + "</script>"   # chat split columns (2026-09-08), after the controller it leans on
             # the command palette (Cmd/Ctrl+P) and the session quick-switcher hotkey (Cmd/Ctrl+O):
             # a dist bundle (ui/webview/palette-main.ts) like age-color-global above. Loaded last —
             # it reads the __romp* globals lazily, at command run time, so order is cosmetic.
@@ -54432,6 +54579,8 @@ class Handler(BaseHTTPRequestHandler):
         iid = (q.get("iid") or [""])[0]         # which page INSTANCE: a reconnect carrying it retires its old socket
         active = (q.get("active") or [""])[0]   # the tab this client is looking at → _push builds it FIRST
         reconnect = (q.get("reconnect") or [""])[0] == "1"   # the shim's own statement: this page opened a socket before and its bundle has said ready, with no ready waiting in its queue
+        col = (q.get("col") or [""])[0]         # which chat COLUMN of that dashboard (split screen, 2026-09-08) — for the logs;
+        #                                         the columns arbitrate a dashboard-aimed focus among themselves (render.ts focusIsOurs)
         self.send_response(101)
         self.send_header("Upgrade", "websocket")
         self.send_header("Connection", "Upgrade")
@@ -54467,6 +54616,8 @@ class Handler(BaseHTTPRequestHandler):
             # frame follows. Every redial of such a page is served whole, the cost before 2026-09-07, never a
             # false skeleton.
             client["reconnect"] = True
+        if col:
+            client["col"] = col
         _register_ws_client(client)
         if client.get("reconnect"):
             _pusher_wake.set()   # the reconnect is the event; without this it waited out the 0.5-3 s backstop

--- a/tests/test_chat_split.py
+++ b/tests/test_chat_split.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Split screen for the chat (the user 2026-09-08: several sessions open at once instead of tabbing through
+them). The dashboard shell can hold N chat COLUMNS: every column past the first is a client-made twin of
+#chat-pane around an iframe at /chat?col=N (_LANDING_SPLIT_JS), with its own tab strip, its own persisted
+active tab/drafts/scroll (the shim keys its state blob by the column), its own socket, and its own grow
+weight between the shared gutters. Two halves are checked here:
+
+  * SOURCE PINS against the served shell + shim: the column id reaches the state key and the connect query,
+    the shell's bridges (picker lift, editor selection, the bell's "session in front", the Log's connection
+    tracking, Alt+Arrow, Escape, the gutters) know about later columns, the rail carries the split action
+    without a data-pane (the rail/mobile parity test counts those), and the kernel stamps the column.
+  * EXECUTED: the real _LANDING_SPLIT_JS runs in node against a DOM stub (the test_error_center.py pattern)
+    and the whole story is driven — open on a session, DOM order, persistence, the hooks it wires, the
+    focus arbitration the panes ask for, close, the cap, restore from storage, and no columns on the phone.
+
+Synthetic only — invented sids, no network, no real DOM.
+"""
+import inspect
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = load_source("romp_kernel_split", os.path.join(BIN, "romp-kernel"))
+
+
+class SplitSourcePins(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = km._landing()
+        cls.shim = km._shim("chat", 1)
+
+    def test_the_split_script_is_served_after_the_pane_controller_it_leans_on(self):
+        self.assertIn("_LANDING_SPLIT_JS", vars(km), "a module-level _JS constant: test_inline_js_parses checks it parses")
+        self.assertIn("var CK='romp-chat-cols'", self.html)
+        self.assertGreater(self.html.index("var CK='romp-chat-cols'"), self.html.index("window.__rompPaneToggle=togglePane"),
+                           "the split runs after the controller: a restored column registers with the gutters and takes a fair "
+                           "grow at boot, and a split of a hidden chat group calls __rompPaneToggle")
+        self.assertIn("f.src='/chat?col='+n;", km._LANDING_SPLIT_JS, "every later column is /chat?col=N")
+
+    def test_the_shim_keys_each_column_s_state_and_names_it_on_the_connect(self):
+        # the column comes from the URL; the first column ("" or 1) keeps the unsuffixed key it always had, so no
+        # one's persisted active tab, drafts or scroll moves
+        self.assertIn('var COL=new URLSearchParams(location.search).get("col")||"";if(COL==="1")COL="";', self.shim)
+        self.assertIn('var SK="romp-vscode-state-chat"+(COL?":"+COL:"");', self.shim)
+        self.assertIn('(COL?"&col="+encodeURIComponent(COL):"")', self.shim, "the kernel can tell the columns apart in its logs")
+        # the ?active= connect hint reads the SAME key, so each column redials with ITS tab first
+        self.assertIn('var st0=JSON.parse(localStorage.getItem(SK)||"null");active=(st0&&st0.activeId)||"";', self.shim)
+
+    def test_the_kernel_stamps_the_column_on_the_client(self):
+        src = inspect.getsource(km.Handler)
+        self.assertIn('col = (q.get("col") or [""])[0]', src)
+        self.assertIn('if col:\n            client["col"] = col', src)
+        with open(os.path.join(BIN, "romp-kernel"), encoding="utf-8") as fh:
+            self.assertIn("(wid=%s col=%s slot=%s queued=%dB frame=%dB)", fh.read(), "the drop log names the column")
+
+    def test_the_rail_carries_no_split_button(self):
+        # the split opens from a tab's menu ("Open in new split") and the palette; a bottom-bar button for it
+        # read as clutter (the user 2026-09-08), so the rail and the mobile bar carry none
+        self.assertNotIn("rail-split", self.html)
+        self.assertNotIn("rail-split", km._LANDING_SPLIT_JS)
+        self.assertIn("m.romp!=='openSplit'", km._LANDING_SPLIT_JS, "the tab menu's ask is the door")
+
+    def test_the_css_hides_columns_with_the_chat_group_lifts_by_class_and_never_shows_them_on_the_phone(self):
+        self.assertIn("body:not(.po-chat) .chat-col,body:not(.po-chat) .gv-chat{display:none}", self.html)
+        self.assertIn("body.picker-open .pane.lifted{display:block!important}", self.html)
+        self.assertIn("body.picker-open iframe.lifted{display:block;position:fixed;left:0;right:0;top:0;height:var(--app-h,100dvh);z-index:200;background:transparent}", self.html)
+        self.assertNotIn("body.picker-open #f-chat{", self.html, "the lift is by class now — a later column's picker lifts THAT column")
+        self.assertIn(".chat-col>.col-x{position:absolute;top:4px;right:6px;z-index:7;", self.html)
+        mobile = self.html[self.html.index("@media (max-width:820px),(pointer:coarse) and (max-width:1024px){"):]
+        self.assertIn(".chat-col,.gv-chat{display:none!important}", mobile)
+
+    def test_the_shell_s_bridges_know_about_later_columns(self):
+        # the picker lift marks the ASKING frame (e.source) and its pane
+        js = km._LANDING_SETTINGS_JS
+        self.assertIn("var lf=(window.__rompFrameOfWin&&window.__rompFrameOfWin(e.source))||document.getElementById('f-chat');", js)
+        self.assertIn("Array.prototype.forEach.call(document.querySelectorAll('.lifted'),function(el){el.classList.remove('lifted');});", js)
+        self.assertIn("if(m.on&&lf){lf.classList.add('lifted');if(lf.parentElement)lf.parentElement.classList.add('lifted');}", js)
+        self.assertIn("document.body.classList.toggle('picker-open',!!m.on);}", js)
+        # a passage selected in the feed's viewer lands in the column showing that session, else the one last used
+        self.assertIn("fc=(window.__rompChatTarget&&window.__rompChatTarget(m.sid))||fc;", js)
+        # the gear's close hands the keyboard back to the column last worked in, else the first (2026-09-11)
+        self.assertIn("if(!m.on){var fid=(window.__rompFocusedChatId&&window.__rompFocusedChatId())||'f-chat';"
+                      "var fc=document.getElementById(fid)||document.getElementById('f-chat');", js)
+        # the bell's "session in front" reads the column last worked in
+        self.assertIn("var fid=window.__rompFocusedChatId&&window.__rompFocusedChatId();", km._LANDING_PUSH_JS)
+        # the Log tracks a split column's socket under its own key — never masking the first column's
+        errs = km._LANDING_ERRS_JS
+        self.assertIn("var st={},stc={};", errs)
+        self.assertIn("var col=(m.app==='chat'&&window.__rompColOf)?window.__rompColOf(e.source):'';", errs)
+        self.assertIn("if(col){var sc=(m.state==='up')?'up':'down',pc=stc[col];stc[col]=sc;", errs)
+        self.assertIn("for(var c in stc){if(stc[c]==='down'&&shown('chat'))return true;}", errs)
+        self.assertIn("window.__rompColGone=function(c){delete stc[String(c)];paint();};", errs)
+        # the first column's tracking is byte-for-byte what it was
+        self.assertIn("var s=(m.state==='up')?'up':'down',prev=st[m.app];st[m.app]=s;", errs)
+        # Alt+Arrow walks every chat column, the ring follows, later columns are wired as they are made
+        focus = km._LANDING_FOCUS_JS
+        self.assertIn("window.__rompFocusedChatId=function(){return document.getElementById(lastChat)?lastChat:'f-chat';};", focus)
+        self.assertIn("window.__rompWireFocus=function(f){f.addEventListener('load',function(){wire(f);});wire(f);};", focus)
+        self.assertIn("function paneOf(id){return PANE[id]||(window.__rompChatPaneOf?window.__rompChatPaneOf(id):null);}", focus)
+        self.assertIn("window.__rompWireEsc=function(f){", km._LANDING_ESC_JS)
+        # the gutters: later columns register, gv-a/gv-b's left neighbour is the rightmost chat column
+        gut = km._LANDING_JS
+        self.assertIn("window.__rompRegisterPane=function(id,k){KEYS[id]=k;if(PANES.indexOf(id)<0)PANES.splice(PANES.indexOf('fleet-pane'),0,id);};", gut)
+        self.assertIn("window.__rompUnregisterPane=function(id){", gut)
+        self.assertIn("function key(id){return KEYS[id]||(id==='chat-pane'?'chat':id==='fleet-pane'?'fleet':id==='feed-pane'?'feed':'files');}", gut)
+        self.assertIn("window.__rompGutter=gutter;", gut)
+        self.assertIn("gutter('gv-a',function(){return lastChat();},'fleet-pane');", gut)
+        # a pane with no grow yet never averages in as NaN (the first split opened 0px wide — review find 2026-09-08),
+        # and a column keeps the width it was dragged to across reloads
+        self.assertIn(".filter(function(g){return typeof g==='number'&&isFinite(g);});", gut)
+        self.assertIn("window.__rompGrowFairIfNew=function(k){if(typeof grow[k]==='number'&&isFinite(grow[k])){setGrow(k,grow[k]);return;}window.__rompGrowFair(k);};", gut)
+        split = km._LANDING_SPLIT_JS
+        self.assertIn("if(window.__rompGrowFairIfNew)window.__rompGrowFairIfNew('chat'+n);", split)
+        # a refused split says why (the acknowledgement rule), and the tab menu can ask first
+        self.assertIn("function canSplit(){return !mobile()&&cols.length+1<MAX;}", split)
+        self.assertIn("window.__rompCanSplit=canSplit;", split)
+        self.assertIn("Four chat columns at most", split)
+        self.assertIn("The phone shows one pane at a time", split)
+        # the hand-over is the opening's only: a later reload of the frame keeps the tab its own state names
+        self.assertIn("},{once:true});", split)
+
+    def test_the_parked_push_tap_reveal_is_addressed_to_the_column_that_consumes_it(self):
+        # one chat client consumes the parked tap (_consume_pending_reveal), so the pane's column arbitration
+        # must not hand that focus to another column: it rides `own`, the same mark the shell's hand-over wears
+        src = inspect.getsource(km._consume_pending_reveal)
+        self.assertIn('m["own"] = True', src)
+        self.assertIn("client[\"send\"](json.dumps(m))", src)
+
+
+# ── the split script, RUN ────────────────────────────────────────────────────────────────────────────
+HARNESS = r"""
+'use strict';
+let STORE = {};
+global.localStorage = { getItem: (k) => (k in STORE ? STORE[k] : null), setItem: (k, v) => { STORE[k] = String(v); }, removeItem: (k) => { delete STORE[k]; } };
+const CALLS = { register: [], unregister: [], growFair: [], gutter: [], wireFocus: [], wireEsc: [], colGone: [], events: [], posted: [], focus: [], notify: [], toggle: [] };
+let BODY_CLASSES = new Set(['po-chat', 'po-feed', 'po-timeline']);
+let FOCUSED = 'f-chat';   // what the shell's focus script would report as the column last worked in
+let MOBILE = false;       // whether #mtabs is displayed (the phone layout)
+let BYID = {};
+let WL = {};
+function mkEl(tag) {
+  const el = {
+    tagName: tag, className: '', title: '', textContent: '', src: '', parentElement: null, _id: '',
+    style: { flex: '', _props: {}, setProperty(k, v) { this._props[k] = v; }, removeProperty(k) { delete this._props[k]; } },
+    _attrs: {}, _ls: {}, children: [], _active: '',
+    setAttribute(k, v) { this._attrs[k] = String(v); },
+    getAttribute(k) { return k in this._attrs ? this._attrs[k] : null; },
+    appendChild(c) { c.parentElement = this; this.children.push(c); return c; },
+    insertBefore(c, ref) { c.parentElement = this; const i = this.children.indexOf(ref); if (i < 0) this.children.push(c); else this.children.splice(i, 0, c); return c; },
+    remove() { const p = this.parentElement; if (p) { const i = p.children.indexOf(this); if (i >= 0) p.children.splice(i, 1); }
+      const drop = (n) => { if (n._id) delete BYID[n._id]; n.children.forEach(drop); }; drop(this); this.parentElement = null; },
+    addEventListener(k, f, opts) { (this._ls[k] = this._ls[k] || []).push({ f, once: !!(opts && opts.once) }); },
+    fire(k, ev) { const ls = (this._ls[k] || []).slice(); this._ls[k] = ls.filter((l) => !l.once); ls.forEach((l) => l.f(ev || { stopPropagation() {} })); },
+  };
+  Object.defineProperty(el, 'id', { get() { return this._id; }, set(v) { if (this._id) delete BYID[this._id]; this._id = String(v); if (v) BYID[v] = this; } });
+  if (tag === 'iframe') {
+    el.contentWindow = { postMessage(m) { CALLS.posted.push({ id: el.id, m }); }, focus() { CALLS.focus.push(el.id); } };
+    el.contentDocument = { querySelector(sel) { return (sel === '#tabs .tab.active[data-id]' && el._active) ? { getAttribute: () => el._active } : null; } };
+  }
+  return el;
+}
+let ROW = null;
+global.document = {
+  body: { classList: { contains: (c) => BODY_CLASSES.has(c) } },
+  querySelector(sel) { return sel === '.row' ? ROW : null; },
+  getElementById(id) { return BYID[id] || null; },
+  createElement(tag) { return mkEl(tag); },
+};
+global.getComputedStyle = (el) => ({ display: el === BYID['mtabs'] ? (MOBILE ? 'flex' : 'none') : 'block' });
+global.window = global;
+global.addEventListener = (t, f) => { (WL[t] = WL[t] || []).push(f); };
+global.dispatchEvent = (ev) => { CALLS.events.push(ev); (WL[ev.type] || []).forEach((f) => f(ev)); return true; };
+global.CustomEvent = class { constructor(type, o) { this.type = type; this.detail = (o || {}).detail; } };
+global.__rompRegisterPane = (id, k) => CALLS.register.push([id, k]);
+global.__rompUnregisterPane = (id) => CALLS.unregister.push(id);
+global.__rompGrowFair = (k) => CALLS.growFair.push('fair:' + k);
+global.__rompGrowFairIfNew = (k) => CALLS.growFair.push(k);   // what the split calls: fair only when the store holds nothing
+global.__rompNotify = (kind, text) => CALLS.notify.push([kind, text]);
+global.__rompPaneToggle = (k, to) => CALLS.toggle.push([k, to]);
+global.__rompGutter = (gid, leftPick, rightId) => CALLS.gutter.push({ gid, leftPick, rightId });
+global.__rompWireFocus = (f) => CALLS.wireFocus.push(f.id);
+global.__rompWireEsc = (f) => CALLS.wireEsc.push(f.id);
+global.__rompColGone = (c) => CALLS.colGone.push(c);
+global.__rompFocusedChatId = () => FOCUSED;
+function boot(store, mobile) {
+  STORE = Object.assign({}, store || {}); MOBILE = !!mobile; BYID = {}; WL = {}; BODY_CLASSES = new Set(['po-chat', 'po-feed', 'po-timeline']);
+  for (const k in CALLS) CALLS[k] = [];
+  ROW = mkEl('div'); ROW.className = 'row';
+  const cp = mkEl('div'); cp.id = 'chat-pane'; const fc = mkEl('iframe'); fc.id = 'f-chat'; cp.appendChild(fc); ROW.appendChild(cp);
+  const gva = mkEl('div'); gva.id = 'gv-a'; ROW.appendChild(gva);
+  const fp = mkEl('div'); fp.id = 'fleet-pane'; ROW.appendChild(fp);
+  const gvb = mkEl('div'); gvb.id = 'gv-b'; ROW.appendChild(gvb);
+  const fd = mkEl('div'); fd.id = 'feed-pane'; ROW.appendChild(fd);
+  const mt = mkEl('nav'); mt.id = 'mtabs';
+  (0, eval)(SPLIT_JS);
+}
+const SPLIT_JS = __SPLIT_JS__;
+function order() { return ROW.children.map((c) => c.id); }
+"""
+
+DRIVER = r"""
+const out = {};
+// 1) a fresh desktop dashboard: one column, nothing made
+boot({}, false);
+out.fresh = { ids: window.__rompChatFrameIds(), order: order(), lastPane: window.__rompLastChatPane() };
+// 2) open a split ON a session (the tab menu's ask): a new column + its gutter before gv-a, persisted, wired
+const f2 = window.__rompSplitChat('11111111-2222-3333-4444-555555555501');
+f2.fire('load'); f2.fire('load');   // a later reload of the frame must not re-post the opening's hand-over
+out.opened = {
+  id: f2.id, src: f2.src, col: f2.getAttribute('data-col'), pane: f2.parentElement.id, paneCls: f2.parentElement.className,
+  flex: f2.parentElement.style.flex, order: order(), stored: STORE['romp-chat-cols'],
+  register: CALLS.register.slice(), growFair: CALLS.growFair.slice(), wireFocus: CALLS.wireFocus.slice(), wireEsc: CALLS.wireEsc.slice(),
+  gutter: CALLS.gutter.map((g) => ({ gid: g.gid, left: g.leftPick(), right: g.rightId })),
+  event: CALLS.events.filter((e) => e.type === 'romp-chat-cols').map((e) => ({ col: e.detail.col, open: e.detail.open, frame: e.detail.frame && e.detail.frame.id })),
+  posted: CALLS.posted.slice(), focused: CALLS.focus.slice(),
+  closeBtn: f2.parentElement.children.filter((c) => c.className === 'col-x').length,
+  ids: window.__rompChatFrameIds(), lastPane: window.__rompLastChatPane(), paneOf: window.__rompChatPaneOf('f-chat-2'),
+  colOf: window.__rompColOf(f2.contentWindow), frameOfWin: window.__rompFrameOfWin(f2.contentWindow) === f2,
+};
+// 3) the arbitration the panes ask before acting on a dashboard-aimed focus
+BYID['f-chat']._active = '11111111-2222-3333-4444-555555555500';
+f2._active = '11111111-2222-3333-4444-555555555501';
+FOCUSED = 'f-chat-2';
+out.target = {
+  showing1: window.__rompChatTarget('11111111-2222-3333-4444-555555555500').id,   // the column already showing it wins…
+  showing2: window.__rompChatTarget('11111111-2222-3333-4444-555555555501').id,
+  unknownFocused2: window.__rompChatTarget('11111111-2222-3333-4444-555555555599').id,   // …else the column last worked in
+};
+FOCUSED = 'f-chat';
+out.target.unknownFocused1 = window.__rompChatTarget('11111111-2222-3333-4444-555555555599').id;
+FOCUSED = 'f-chat-77';   // a stale id (its column is gone): the first column
+out.target.stale = window.__rompChatTarget('').id;
+FOCUSED = 'f-chat';
+// 4) more columns, up to the cap (four counting the first)
+const f3 = window.__rompSplitChat(); const f4 = window.__rompSplitChat(); const f5 = window.__rompSplitChat();
+out.cap = { ids: window.__rompChatFrameIds(), fifth: f5, stored: STORE['romp-chat-cols'], order: order(), notify: CALLS.notify.slice(), canSplit: window.__rompCanSplit(),
+            gutterLeft3: CALLS.gutter.filter((g) => g.gid === 'gv-chat-3')[0].leftPick(),
+            gutterLeft4: CALLS.gutter.filter((g) => g.gid === 'gv-chat-4')[0].leftPick(), lastPane: window.__rompLastChatPane() };
+// 5) close the middle one: its pane and gutter go, the store follows, the hooks hear it, the neighbour's gutter re-aims
+CALLS.focus = [];
+window.__rompCloseSplit(3);
+out.closed3 = { ids: window.__rompChatFrameIds(), order: order(), stored: STORE['romp-chat-cols'], unregister: CALLS.unregister.slice(), colGone: CALLS.colGone.slice(),
+                gutterLeft4: CALLS.gutter.filter((g) => g.gid === 'gv-chat-4')[0].leftPick(), focused: CALLS.focus.slice(),
+                closedEvent: CALLS.events.filter((e) => e.type === 'romp-chat-cols' && e.detail.open === false).map((e) => e.detail.col) };
+// 6) the palette's close with the FIRST column focused closes the last split; with a split focused, that one
+window.__rompCloseSplit();
+out.closedLast = { ids: window.__rompChatFrameIds(), stored: STORE['romp-chat-cols'] };
+FOCUSED = 'f-chat-2'; window.__rompCloseSplit();
+out.closedFocused = { ids: window.__rompChatFrameIds(), stored: STORE['romp-chat-cols'] };
+FOCUSED = 'f-chat';
+// 7) the tab menu's message from a pane, and the × on the column
+CALLS.posted = [];
+window.dispatchEvent({ type: 'message', data: { romp: 'openSplit', sid: '11111111-2222-3333-4444-555555555502' } });
+const f2b = BYID['f-chat-2']; f2b.fire('load');
+out.viaMessage = { ids: window.__rompChatFrameIds(), posted: CALLS.posted.slice(), src: f2b.src };
+f2b.parentElement.children.filter((c) => c.className === 'col-x')[0].fire('click', { stopPropagation() {} });
+out.viaX = { ids: window.__rompChatFrameIds(), stored: STORE['romp-chat-cols'] };
+// 8) the palette's split opens an empty column — and brings a hidden chat group forward first
+BODY_CLASSES.delete('po-chat'); CALLS.toggle = [];
+window.__rompSplitChat();
+out.viaRail = { ids: window.__rompChatFrameIds(), posted: CALLS.posted.length, toggle: CALLS.toggle.slice(), canSplit: window.__rompCanSplit() };
+BODY_CLASSES.add('po-chat');
+// 9) the columns a browser had open come back, each on its own state (no focus posted: the pane restores its tab)
+boot({ 'romp-chat-cols': '[2,5]' }, false);
+out.restored = { ids: window.__rompChatFrameIds(), order: order(), posted: CALLS.posted.slice(), srcs: [BYID['f-chat-2'].src, BYID['f-chat-5'].src],
+                 lastPane: window.__rompLastChatPane(), nextNumber: (window.__rompSplitChat() || {}).id };
+// 10) the phone: nothing is restored and nothing opens
+boot({ 'romp-chat-cols': '[2]' }, true);
+out.mobile = { ids: window.__rompChatFrameIds(), opened: window.__rompSplitChat('x'), order: order(), notify: CALLS.notify.slice(), canSplit: window.__rompCanSplit() };
+console.log(JSON.stringify(out));
+"""
+
+
+class SplitExecutes(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        script = HARNESS.replace("__SPLIT_JS__", json.dumps(km._LANDING_SPLIT_JS)) + DRIVER
+        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
+            f.write(script)
+            path = f.name
+        try:
+            r = subprocess.run(["node", path], capture_output=True, text=True, timeout=30)
+        finally:
+            os.unlink(path)
+        assert r.returncode == 0, "the split's JS threw: " + r.stderr[:1200]
+        cls.out = json.loads(r.stdout.strip().splitlines()[-1])
+
+    def test_a_fresh_dashboard_has_one_column(self):
+        o = self.out["fresh"]
+        self.assertEqual(o["ids"], ["f-chat"])
+        self.assertEqual(o["order"], ["chat-pane", "gv-a", "fleet-pane", "gv-b", "feed-pane"])
+        self.assertEqual(o["lastPane"], "chat-pane")
+
+    def test_opening_a_split_on_a_session_makes_a_wired_column_before_the_outline_gutter(self):
+        o = self.out["opened"]
+        self.assertEqual(o["id"], "f-chat-2")
+        self.assertEqual(o["src"], "/chat?col=2")               # its own state blob + connect param (the shim)
+        self.assertEqual(o["col"], "2")
+        self.assertEqual(o["pane"], "chat-pane-2")
+        self.assertEqual(o["paneCls"], "pane chat-col")
+        self.assertEqual(o["flex"], "var(--g-chat2,60) 1 0")    # its own grow var, the gutters' store
+        # chat | gv-chat-2 | chat 2 | gv-a | outline | gv-b | feed
+        self.assertEqual(o["order"], ["chat-pane", "gv-chat-2", "chat-pane-2", "gv-a", "fleet-pane", "gv-b", "feed-pane"])
+        self.assertEqual(json.loads(o["stored"]), [2])
+        self.assertEqual(o["register"], [["chat-pane-2", "chat2"]])
+        self.assertEqual(o["growFair"], ["chat2"], "a fair width, never a sliver — through the store-aware hook, so a dragged width survives a reload")
+        self.assertEqual(o["wireFocus"], ["f-chat-2"])
+        self.assertEqual(o["wireEsc"], ["f-chat-2"])
+        self.assertEqual(o["gutter"], [{"gid": "gv-chat-2", "left": "chat-pane", "right": "chat-pane-2"}])
+        self.assertEqual(o["event"], [{"col": 2, "open": True, "frame": "f-chat-2"}], "palette-main wires its chords on this")
+        # opened ON a session: the pane takes the focus on load, before its frames land
+        self.assertEqual(o["posted"], [{"id": "f-chat-2", "m": {"type": "focus", "id": "11111111-2222-3333-4444-555555555501", "own": True}}],
+                         "`own`: addressed to this column — the pane's arbitration must not hand it to a column already showing the "
+                         "session; and ONCE, though the frame's load fired twice")
+        self.assertEqual(o["focused"], ["f-chat-2"], "the new column takes the keyboard")
+        self.assertEqual(o["closeBtn"], 1)
+        self.assertEqual(o["ids"], ["f-chat", "f-chat-2"])
+        self.assertEqual(o["lastPane"], "chat-pane-2", "gv-a's left neighbour is now the split")
+        self.assertEqual(o["paneOf"], "chat-pane-2")
+        self.assertEqual(o["colOf"], "2")
+        self.assertTrue(o["frameOfWin"])
+
+    def test_a_focus_belongs_to_the_column_showing_the_session_else_the_one_last_worked_in(self):
+        t = self.out["target"]
+        self.assertEqual(t["showing1"], "f-chat")
+        self.assertEqual(t["showing2"], "f-chat-2")
+        self.assertEqual(t["unknownFocused2"], "f-chat-2")
+        self.assertEqual(t["unknownFocused1"], "f-chat")
+        self.assertEqual(t["stale"], "f-chat", "a stale focus id falls back to the first column")
+
+    def test_four_columns_at_most(self):
+        c = self.out["cap"]
+        self.assertEqual(c["ids"], ["f-chat", "f-chat-2", "f-chat-3", "f-chat-4"])
+        self.assertIsNone(c["fifth"])
+        self.assertEqual(c["notify"], [["warn", "Four chat columns at most — close one to open another."]], "a refused split says why")
+        self.assertFalse(c["canSplit"], "…and the tab menu can ask before offering the item")
+        self.assertEqual(json.loads(c["stored"]), [2, 3, 4])
+        self.assertEqual(c["order"][:7], ["chat-pane", "gv-chat-2", "chat-pane-2", "gv-chat-3", "chat-pane-3", "gv-chat-4", "chat-pane-4"])
+        self.assertEqual(c["gutterLeft3"], "chat-pane-2")
+        self.assertEqual(c["gutterLeft4"], "chat-pane-3")
+        self.assertEqual(c["lastPane"], "chat-pane-4")
+
+    def test_closing_a_column_removes_it_and_re_aims_its_neighbour_s_gutter(self):
+        c = self.out["closed3"]
+        self.assertEqual(c["ids"], ["f-chat", "f-chat-2", "f-chat-4"])
+        self.assertEqual(c["order"], ["chat-pane", "gv-chat-2", "chat-pane-2", "gv-chat-4", "chat-pane-4", "gv-a", "fleet-pane", "gv-b", "feed-pane"])
+        self.assertEqual(json.loads(c["stored"]), [2, 4])
+        self.assertEqual(c["unregister"], ["chat-pane-3"], "its grow weight leaves the store")
+        self.assertEqual(c["colGone"], ["3"], "the Log drops its connection state")
+        self.assertEqual(c["gutterLeft4"], "chat-pane-2", "the gutter picks its left neighbour LIVE")
+        self.assertEqual(c["focused"], ["f-chat-2"], "the ring moves to the column before it")
+        self.assertEqual(c["closedEvent"], [3])
+
+    def test_the_palette_s_close_takes_the_focused_split_else_the_last(self):
+        self.assertEqual(self.out["closedLast"]["ids"], ["f-chat", "f-chat-2"])
+        self.assertEqual(json.loads(self.out["closedLast"]["stored"]), [2])
+        self.assertEqual(self.out["closedFocused"]["ids"], ["f-chat"])
+        self.assertEqual(json.loads(self.out["closedFocused"]["stored"]), [])
+
+    def test_a_pane_s_ask_the_column_s_x_and_the_palette_all_drive_the_same_code(self):
+        m = self.out["viaMessage"]
+        self.assertEqual(m["ids"], ["f-chat", "f-chat-2"], "the lowest free number is reused")
+        self.assertEqual(m["src"], "/chat?col=2")
+        self.assertEqual(m["posted"], [{"id": "f-chat-2", "m": {"type": "focus", "id": "11111111-2222-3333-4444-555555555502", "own": True}}])
+        self.assertEqual(self.out["viaX"]["ids"], ["f-chat"])
+        self.assertEqual(json.loads(self.out["viaX"]["stored"]), [])
+        self.assertEqual(self.out["viaRail"]["ids"], ["f-chat", "f-chat-2"])
+        self.assertEqual(self.out["viaRail"]["posted"], 1, "an EMPTY column: no focus is handed over")
+        self.assertEqual(self.out["viaRail"]["toggle"], [["chat", True]], "a split of a hidden chat group brings the group forward")
+        self.assertTrue(self.out["viaRail"]["canSplit"])
+
+    def test_the_columns_a_browser_had_open_come_back_on_their_own_state(self):
+        r = self.out["restored"]
+        self.assertEqual(r["ids"], ["f-chat", "f-chat-2", "f-chat-5"])
+        self.assertEqual(r["srcs"], ["/chat?col=2", "/chat?col=5"])
+        self.assertEqual(r["posted"], [], "no focus: each column's own state blob names its tab")
+        self.assertEqual(r["order"][:5], ["chat-pane", "gv-chat-2", "chat-pane-2", "gv-chat-5", "chat-pane-5"])
+        self.assertEqual(r["lastPane"], "chat-pane-5")
+        self.assertEqual(r["nextNumber"], "f-chat-3", "a new column takes the lowest free number")
+
+    def test_the_phone_never_splits(self):
+        m = self.out["mobile"]
+        self.assertEqual(m["ids"], ["f-chat"])
+        self.assertIsNone(m["opened"])
+        self.assertEqual(m["notify"], [["warn", "The phone shows one pane at a time — no split here."]])
+        self.assertFalse(m["canSplit"])
+        self.assertEqual(m["order"], ["chat-pane", "gv-a", "fleet-pane", "gv-b", "feed-pane"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_chat_split_served.py
+++ b/tests/test_chat_split_served.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Chat split screen, the SERVED leg (the user 2026-09-08, who wanted several sessions open side by side
+instead of tabbing between them). The dashboard shell holds N chat columns: column 1 is #chat-pane / #f-chat,
+every later one a client-made twin (_LANDING_SPLIT_JS) around an iframe at /chat?col=N with its own tab
+strip, state blob, socket and grow weight, slotted before #gv-a behind a chat|chat gutter.
+
+The node-side test (tests/test_chat_split.py) drives the split script against a DOM stub; this one drives the
+REAL page: a hermetic kernel serves the dashboard with TWO synthetic sessions, a headless browser opens it
+once, and ONE driver run walks the whole story in order, each step landing in its own assertion here:
+  1. a split on session B opens a second column that is WIDE (the review find: the first split opened 0px
+     because the new column's missing grow averaged in as NaN), in the right row slot, with a finite
+     --g-chat2 and the column set persisted;
+  2. the new column shows B (the shell's hand-over focus), column 1 keeps its tab, and __rompChatTarget
+     routes a session-focus to the column showing it — or, for a session nobody shows, to the column the
+     user last clicked in;
+  3. a split opened ON a session column 1 already shows still takes it (own:true beats the "a column already
+     shows it" arbitration), and closing that column drops it from the persisted set;
+  4. dragging the chat|chat gutter moves width between the two columns and persists column 2's grow;
+  5. column 2's new-session picker lifts ITS iframe and pane (.lifted), never column 1's, and unlifts on
+     toggle;
+  6. a reload brings both columns back, column 2 on B again, at the width the drag left it;
+  7. closing column 2 leaves one column and an empty persisted set.
+Skips LOUDLY when the extension deps or a playwright browser are absent (CI installs none). Synthetic only:
+placeholder sids, invented notes-api prompt text, no real session data."""
+import json
+import os
+import re
+import shutil
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+# the kernel refuses to boot with a retired key variable or a 1Password name in its environment (kernel/credentials.py
+# check_boot_environment): the lab's kernel env is scrubbed by the kernel's own rule, read from the module itself
+from romp_load import load_source
+from tests.dist_copy import copy_dist
+_cred = load_source("romp_credentials_served", os.path.join(ROOT, "kernel", "credentials.py"))
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+
+SID_A = "11111111-2222-4333-8444-000000000301"   # "web": column 1's session
+SID_B = "11111111-2222-4333-8444-000000000302"   # "api": the session the split opens on
+SID_X = "11111111-2222-4333-8444-000000000999"   # a session no column shows
+DRAG_PX = 200
+SLACK_PX = 40
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def _transcript(sid, tag, cwd, pairs):
+    """`pairs` CLOSED user/assistant turns for `sid` (an OPEN turn would invite the boot reconcile to resume
+    it); `tag` keeps the two sessions' message uuids apart."""
+    out, parent, t = [], None, 1_700_000_000
+    filler = ["The ranking pass reads its weights from the notes-api config now.",
+              "Tokenizer edge cases (hyphens, quotes) are covered by the new fixture set.",
+              "Index rebuild time is dominated by the stemmer; caching its table halves it.",
+              "The pagination cursor survives a re-sort because it encodes the sort key too."]
+    for i in range(pairs):
+        u = "11111111-2222-4333-8444-%02x00000a%04x" % (tag, i)
+        a = "11111111-2222-4333-8444-%02x00000b%04x" % (tag, i)
+        ts = lambda k: time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(t + i * 60 + k))
+        out.append({"type": "user", "uuid": u, "parentUuid": parent, "timestamp": ts(0), "sessionId": sid, "cwd": cwd,
+                    "message": {"role": "user", "content": "please keep going with the search module notes (part %d)" % (i + 1)}})
+        body = "\n\n".join(["Note %d." % (i + 1)] + [filler[(i + k) % len(filler)] for k in range(3)])
+        out.append({"type": "assistant", "uuid": a, "parentUuid": u, "timestamp": ts(5), "sessionId": sid, "cwd": cwd,
+                    "message": {"id": "msg_lab_%d_%04d" % (tag, i), "type": "message", "role": "assistant", "model": "claude-sonnet-5",
+                                "content": [{"type": "text", "text": body}], "stop_reason": "end_turn"}})
+        parent = a
+    return "\n".join(json.dumps(r) for r in out) + "\n"
+
+
+# The chat iframes are SAME-ORIGIN with the shell, so every probe reads a column's document from the shell
+# context (document.getElementById(fid).contentDocument): no frame handles that a navigation could tear down.
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1400, height: 900 } });
+const out = { t0: Date.now() };
+const die = async (why) => {
+  out.ms = Date.now() - out.t0;
+  fs.writeSync(1, "RESULT:" + JSON.stringify({ ...out, died: why }) + "\n");
+  await browser.close();
+  process.exit(0);
+};
+const T = 15000;
+const waitFn = async (fn, arg, why) => page.waitForFunction(fn, arg, { timeout: T }).catch(async (e) => { await die(why + " (" + String(e).split("\n")[0] + ")"); });
+// a column's tab strip holds every one of `sids`
+const waitTabs = (fid, sids) => waitFn(([fid, sids]) => {
+  const f = document.getElementById(fid); const d = f && f.contentDocument; if (!d) return false;
+  const ids = Array.from(d.querySelectorAll("#tabs .tab[data-id]")).map((t) => t.dataset.id);
+  return sids.every((s) => ids.includes(s));
+}, [fid, sids], fid + " never showed tabs " + sids.join(","));
+// a column's ACTIVE tab is `sid`
+const waitActive = (fid, sid) => waitFn(([fid, sid]) => {
+  const f = document.getElementById(fid); const d = f && f.contentDocument;
+  const t = d && d.querySelector("#tabs .tab.active[data-id]"); return !!t && t.dataset.id === sid;
+}, [fid, sid], fid + " never activated " + sid);
+const waitBootGone = () => waitFn(() => !document.getElementById("romp-boot"), null, "boot splash never cleared");
+const waitFocused = (fid) => waitFn((fid) => window.__rompFocusedChatId && window.__rompFocusedChatId() === fid, fid, fid + " never took the focus ring");
+const activeIn = (fid) => page.evaluate((fid) => {
+  const f = document.getElementById(fid); const d = f && f.contentDocument;
+  const t = d && d.querySelector("#tabs .tab.active[data-id]"); return t ? t.dataset.id : null;
+}, fid);
+const targetOf = (sid) => page.evaluate((sid) => { const f = window.__rompChatTarget(sid); return f ? f.id : null; }, sid);
+const width = (id) => page.evaluate((id) => { const e = document.getElementById(id); return e ? e.getBoundingClientRect().width : null; }, id);
+const shell = () => page.evaluate(() => ({
+  frameIds: window.__rompChatFrameIds(), cols: localStorage.getItem("romp-chat-cols"),
+  rowKids: Array.from(document.querySelector(".row").children).map((e) => e.id || e.className),
+  grow: JSON.parse(localStorage.getItem("romp-pane-grow") || "null"),
+  lifted: Array.from(document.querySelectorAll(".lifted")).map((e) => e.id), pickerOpen: document.body.classList.contains("picker-open"),
+}));
+// the page rect of an element INSIDE a column, for page.mouse (the iframe's offset plus the element's own)
+const rectIn = (fid, sel) => page.evaluate(([fid, sel]) => {
+  const f = document.getElementById(fid); const fr = f.getBoundingClientRect(); const el = f.contentDocument.querySelector(sel);
+  const r = el.getBoundingClientRect(); return { x: fr.left + r.left, y: fr.top + r.top, w: r.width, h: r.height };
+}, [fid, sel]);
+const clickIn = async (fid, sel) => { const r = await rectIn(fid, sel); await page.mouse.click(r.x + r.w / 2, r.y + Math.min(r.h / 2, 120)); };
+
+// ---- load: both sessions are tabs in column 1; column 1 shows A ----
+await page.goto(cfg.url);
+await waitTabs("f-chat", [cfg.sidA, cfg.sidB]);
+await waitBootGone();
+if ((await activeIn("f-chat")) !== cfg.sidA) {
+  const fr = await (await page.$("#f-chat")).contentFrame();
+  await fr.locator('#tabs .tab[data-id="' + cfg.sidA + '"]').click();
+  await waitActive("f-chat", cfg.sidA);
+}
+out.col1Before = await activeIn("f-chat");
+
+// ---- 1. split on B: a second column, wide, before gv-a, persisted ----
+out.s1 = await page.evaluate((sidB) => {
+  const f = window.__rompSplitChat(sidB);
+  const row = document.querySelector(".row"), kids = Array.from(row.children).map((e) => e.id);
+  const w = (id) => { const e = document.getElementById(id); return e ? e.getBoundingClientRect().width : null; };
+  return { frameId: f && f.id, tag: f && f.tagName, src: f && f.getAttribute("src"), paneCol: (document.getElementById("chat-pane-2") || {}).getAttribute?.("data-col"),
+           order: kids, gIdx: kids.indexOf("gv-chat-2"), pIdx: kids.indexOf("chat-pane-2"), aIdx: kids.indexOf("gv-a"),
+           pane1W: w("chat-pane"), pane2W: w("chat-pane-2"), gChat2Inline: row.style.getPropertyValue("--g-chat2"),
+           gChat2: getComputedStyle(row).getPropertyValue("--g-chat2"), cols: localStorage.getItem("romp-chat-cols") };
+}, cfg.sidB);
+
+// ---- 2. the new column shows B; targets route by the column showing the session, else the last-clicked ----
+await waitTabs("f-chat-2", [cfg.sidA, cfg.sidB]);
+await waitActive("f-chat-2", cfg.sidB);
+out.s2 = { col2Active: await activeIn("f-chat-2"), col1After: await activeIn("f-chat"),
+           targetB: await targetOf(cfg.sidB), targetA: await targetOf(cfg.sidA) };
+await clickIn("f-chat-2", "#content");
+await waitFocused("f-chat-2");
+out.s2.unknownAfterCol2 = await targetOf(cfg.sidX);
+await clickIn("f-chat", "#content");
+await waitFocused("f-chat");
+out.s2.unknownAfterCol1 = await targetOf(cfg.sidX);
+out.s2.col1AfterClicks = await activeIn("f-chat");
+
+// ---- 3. a split ON the session column 1 shows: the third column takes it anyway; close it ----
+out.s3 = await page.evaluate((sidA) => { const f = window.__rompSplitChat(sidA); return { frameId: f && f.id, cols: localStorage.getItem("romp-chat-cols") }; }, cfg.sidA);
+await waitTabs("f-chat-3", [cfg.sidA, cfg.sidB]);
+await waitActive("f-chat-3", cfg.sidA);
+out.s3.col3Active = await activeIn("f-chat-3");
+out.s3.col1Still = await activeIn("f-chat");
+out.s3.targetAWithThree = await targetOf(cfg.sidA);   // column 1 shows A too and comes first in the row
+await page.evaluate(() => window.__rompCloseSplit(3));
+out.s3.after = await shell();
+out.s3.pane3Gone = await page.evaluate(() => !document.getElementById("chat-pane-3") && !document.getElementById("gv-chat-3") && !document.getElementById("f-chat-3"));
+
+// ---- 4. drag the chat|chat gutter right: column 1 grows, column 2 shrinks, the grow persists ----
+out.s4 = { before1: await width("chat-pane"), before2: await width("chat-pane-2") };
+const g = await (await page.$("#gv-chat-2")).boundingBox();
+await page.mouse.move(g.x + g.width / 2, g.y + g.height / 2);
+await page.mouse.down();
+out.s4.dragClass = await page.evaluate(() => document.body.classList.contains("drag"));
+// the grab normalises every shown pane's grow to its px width: what the store holds the instant after mousedown
+out.s4.growAtGrab = await page.evaluate(() => { const st = document.querySelector(".row").style; return { chat: parseFloat(st.getPropertyValue("--g-chat")), chat2: parseFloat(st.getPropertyValue("--g-chat2")), feed: parseFloat(st.getPropertyValue("--g-feed")) }; });
+await page.mouse.move(g.x + g.width / 2 + cfg.dragPx, g.y + g.height / 2, { steps: 10 });
+await page.mouse.up();
+out.s4.after1 = await width("chat-pane"); out.s4.after2 = await width("chat-pane-2");
+out.s4.dragClassAfter = await page.evaluate(() => document.body.classList.contains("drag"));
+out.s4.grow = (await shell()).grow;
+
+// ---- 5. the picker in column 2 lifts THAT column only; toggling it closed unlifts ----
+await page.evaluate(() => document.getElementById("f-chat-2").contentWindow.postMessage({ type: "openPicker" }, "*"));
+await waitFn(() => document.body.classList.contains("picker-open"), null, "the shell never lifted for column 2's picker");
+out.s5 = { open: await shell() };
+out.s5.open.pane2Lifted = await page.evaluate(() => document.getElementById("chat-pane-2").classList.contains("lifted"));
+out.s5.open.frame2Lifted = await page.evaluate(() => document.getElementById("f-chat-2").classList.contains("lifted"));
+out.s5.open.frame1Lifted = await page.evaluate(() => document.getElementById("f-chat").classList.contains("lifted"));
+out.s5.open.pickerShown = await page.evaluate(() => { const d = document.getElementById("f-chat-2").contentDocument; const p = d && d.getElementById("picker"); return !!p && p.style.display !== "none"; });
+await page.evaluate(() => document.getElementById("f-chat-2").contentWindow.postMessage({ type: "openPicker", toggle: true }, "*"));
+await waitFn(() => !document.body.classList.contains("picker-open"), null, "the shell never released the lift");
+out.s5.closed = await shell();
+
+// ---- 6. reload: both columns return, column 2 on B, at the dragged width ----
+await page.reload();
+await waitTabs("f-chat", [cfg.sidA, cfg.sidB]);
+await waitTabs("f-chat-2", [cfg.sidA, cfg.sidB]);
+await waitActive("f-chat-2", cfg.sidB);
+await waitBootGone();
+out.s6 = await shell();
+out.s6.col2Active = await activeIn("f-chat-2"); out.s6.col1Active = await activeIn("f-chat");
+out.s6.pane1W = await width("chat-pane"); out.s6.pane2W = await width("chat-pane-2");
+
+// ---- 7. close column 2: one column left, nothing persisted ----
+await page.evaluate(() => window.__rompCloseSplit(2));
+out.s7 = await shell();
+out.s7.pane2Gone = await page.evaluate(() => !document.getElementById("chat-pane-2") && !document.getElementById("gv-chat-2") && !document.getElementById("f-chat-2"));
+out.ms = Date.now() - out.t0;
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedChatSplit(unittest.TestCase):
+    """One kernel, one page, one driver run in setUpClass; each method asserts one step of the shared result."""
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served leg needs them")
+        cls.lab = tempfile.mkdtemp(prefix="chat-split-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(os.path.join(EXT, "dist"), dist)   # skips a concurrent build's staging files (tests/dist_copy.py)
+        state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        os.makedirs(os.path.join(state, "names"), exist_ok=True)
+        os.makedirs(os.path.join(state, "sdk"), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        claude = os.path.join(cls.lab, "claude")
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        # two synthetic SDK sessions so the chat page has two tabs (the test_dashboard_reload_served lab shape,
+        # doubled); their transcripts hold only CLOSED turns, so the boot reconcile never resumes either and no
+        # CLI is ever spawned
+        for sid, name, tag in ((SID_A, "web", 1), (SID_B, "api", 2)):
+            Path(state, "names", sid).write_text("%s\t%s\t\t\n" % (name, cwd))
+            Path(state, "sdk", sid + ".json").write_text(json.dumps(
+                {"sid": sid, "name": name, "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": sid, "alive": True}))
+            Path(proj, sid + ".jsonl").write_text(_transcript(sid, tag, cwd, 20))
+        Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 100}, "seven_day": {"pct": 10}}))   # park sends
+        cls.port = _free_port()
+        cls.token = "testtok-chatsplit"
+        cls.env = dict(os.environ,
+                       XDG_STATE_HOME=os.path.join(cls.lab, "xdg"),
+                       CLAUDE_CONFIG_DIR=claude,
+                       ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1",
+                       ROMP_SERVE_TOKEN=cls.token, ROMP_KERNEL_PORT=str(cls.port),
+                       ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off",
+                       ROMP_TMUX_SOCKET="romp-chatsplit-%d" % cls.port,
+                       # a postal bus of its own that is never started (the trio kernel_env gives every lab kernel):
+                       # the kernel's boot-time ensure must never take the machine's fixed bus port (tests/test_hermetic_kernel_postal.py)
+                       ROMP_POSTAL_PORT=str(_free_port()), ROMP_POSTAL_PEERS="0", ROMP_POSTAL_CLIENT_ONLY="1")
+        cls.env.pop("ROMP_STATE_DIR", None)
+        for k in [k for k in cls.env if k in _cred.RETIRED_VARS or _cred.is_op_env_name(k)]:   # the kernel's own boot rule (module top)
+            cls.env.pop(k, None)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=cls.env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+        cls.result, cls.driver_error = None, None
+        cls._drive()
+
+    @classmethod
+    def _drive(cls):
+        cfg = os.path.join(cls.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"url": "http://127.0.0.1:%d/?token=%s" % (cls.port, cls.token),
+                       "sidA": SID_A, "sidB": SID_B, "sidX": SID_X, "dragPx": DRAG_PX}, f)
+        driver = os.path.join(cls.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        t0 = time.monotonic()
+        try:
+            p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
+                               env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        except subprocess.TimeoutExpired as e:
+            so = e.stdout if isinstance(e.stdout, str) else (e.stdout or b"").decode()
+            cls.driver_error = "driver timed out; partial output:\n%s" % so
+            return
+        cls.driver_s = time.monotonic() - t0
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served leg needs one (CI installs none)")
+        if p.returncode != 0:
+            cls.driver_error = "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:]
+            return
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        if line is None:
+            cls.driver_error = "driver printed no result:\n" + p.stdout[-3000:] + p.stderr[-3000:]
+            return
+        r = json.loads(line[len("RESULT:"):])
+        if "died" in r:
+            cls.driver_error = "driver aborted early: %s\n%s" % (r["died"], json.dumps(r, indent=1)[-3000:])
+            return
+        cls.result = r
+
+    @classmethod
+    def tearDownClass(cls):
+        k = getattr(cls, "kernel", None)
+        if k:
+            try:
+                os.kill(k.pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+            k.wait()
+        subprocess.run(["tmux", "-L", getattr(cls, "env", {}).get("ROMP_TMUX_SOCKET", ""), "kill-server"], capture_output=True)
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def _r(self):
+        if self.driver_error:
+            tail = ""
+            try:
+                with open(self.klog) as fh:
+                    tail = "\nkernel log tail:\n" + fh.read()[-2000:]
+            except OSError:
+                pass
+            self.fail(self.driver_error + tail)
+        return self.result
+
+    def test_1_a_split_on_a_session_opens_a_wide_second_column_before_gv_a_and_persists(self):
+        s = self._r()["s1"]
+        self.assertEqual(s["tag"], "IFRAME", "__rompSplitChat returns the new column's iframe: %r" % s)
+        self.assertEqual(s["frameId"], "f-chat-2")
+        self.assertEqual(s["src"], "/chat?col=2", "every later column is /chat?col=N")
+        self.assertEqual(s["paneCol"], "2")
+        self.assertEqual(s["cols"], "[2]", "the open column set persists per browser")
+        # row order: … chat-pane, gv-chat-2, chat-pane-2, gv-a …
+        self.assertGreaterEqual(s["gIdx"], 0, s["order"])
+        self.assertEqual(s["pIdx"], s["gIdx"] + 1, "the gutter sits directly ahead of its column: %r" % s["order"])
+        self.assertLess(s["pIdx"], s["aIdx"], "the new column slots before gv-a: %r" % s["order"])
+        self.assertEqual(s["order"][s["gIdx"] - 1], "chat-pane", "…and right after the first column: %r" % s["order"])
+        # the review find (2026-09-08): the first split opened 0px wide because the new column's missing grow
+        # averaged in as NaN. Both columns must be real widths the moment the split opens.
+        self.assertGreater(s["pane1W"], 150, "column 1 keeps a real width: %r" % s)
+        self.assertGreater(s["pane2W"], 150, "the new column opens at a real width, never a sliver: %r" % s)
+        g = float(s["gChat2Inline"] or s["gChat2"] or "nan")
+        self.assertTrue(g == g and abs(g) != float("inf"), "--g-chat2 on .row is a finite number: %r" % s)
+        self.assertGreater(g, 0)
+
+    def test_2_the_new_column_shows_its_session_and_focus_targets_route_by_column(self):
+        r = self._r()
+        s = r["s2"]
+        self.assertEqual(r["col1Before"], SID_A, "the story starts with column 1 on A")
+        self.assertEqual(s["col2Active"], SID_B, "the shell's hand-over focus lands the new column on B: %r" % s)
+        self.assertEqual(s["col1After"], SID_A, "column 1's tab is untouched by the split: %r" % s)
+        self.assertEqual(s["targetB"], "f-chat-2", "a focus for B belongs to the column showing B: %r" % s)
+        self.assertEqual(s["targetA"], "f-chat", "a focus for A belongs to column 1: %r" % s)
+        # a session no column shows goes to the column the user last worked in (click-tracked by the shell)
+        self.assertEqual(s["unknownAfterCol2"], "f-chat-2", "after a click in column 2, an unshown session's focus goes there: %r" % s)
+        self.assertEqual(s["unknownAfterCol1"], "f-chat", "…and back to column 1 after a click there: %r" % s)
+        self.assertEqual(s["col1AfterClicks"], SID_A, "the focus clicks changed no tab")
+
+    def test_3_a_split_on_a_session_already_shown_takes_it_and_closing_it_drops_it_from_the_set(self):
+        s = self._r()["s3"]
+        self.assertEqual(s["frameId"], "f-chat-3")
+        self.assertEqual(s["cols"], "[2,3]")
+        # own:true: the arbitration would otherwise hand A's focus to column 1, which already shows A
+        self.assertEqual(s["col3Active"], SID_A, "the third column shows A even though column 1 does: %r" % s)
+        self.assertEqual(s["col1Still"], SID_A)
+        self.assertEqual(s["targetAWithThree"], "f-chat", "with two columns on A, the first in row order wins the target")
+        self.assertTrue(s["pane3Gone"], "__rompCloseSplit(3) removes the pane, its gutter and its iframe")
+        self.assertEqual(s["after"]["cols"], "[2]", "the persisted set is back to column 2 alone: %r" % s["after"])
+        self.assertEqual(s["after"]["frameIds"], ["f-chat", "f-chat-2"])
+        self.assertNotIn("chat3", s["after"]["grow"] or {}, "a closed column's grow leaves the store: %r" % s["after"]["grow"])
+
+    def test_4_dragging_the_chat_gutter_moves_width_between_the_columns_and_persists_it(self):
+        """FAILS on 2026-09-08 (a product bug the served leg exposed; left asserting the right behaviour): the
+        grab's normalisation writes each pane's grow and only THEN reads the next pane's offsetWidth, and the
+        write forces a reflow at a mixed scale (chat at its px width, the others still at their small default
+        numbers), so column 2 is recorded at about a fifth of its width and column 1 balloons before the pointer
+        moves. Pre-existing in _LANDING_JS for the chat|feed gutter, but every fresh browser's FIRST drag after a
+        split hits it, since the new column's fair grow sits next to the 60/40 defaults."""
+        s = self._r()["s4"]
+        self.assertTrue(s["dragClass"], "the grab arms the drag (body.drag makes the iframes let the pointer through)")
+        self.assertFalse(s["dragClassAfter"], "…and the release disarms it")
+        g0 = s["growAtGrab"]
+        self.assertLessEqual(abs(g0["chat"] - s["before1"]), 2, "the grab records column 1 at its real width: %r" % s)
+        self.assertLessEqual(abs(g0["chat2"] - s["before2"]), 2, "the grab records column 2 at its real width, not a half-relaid one: %r" % s)
+        d1, d2 = s["after1"] - s["before1"], s["after2"] - s["before2"]
+        self.assertLessEqual(abs(d1 - DRAG_PX), SLACK_PX, "column 1 grows by about the drag: %r" % s)
+        self.assertLessEqual(abs(d2 + DRAG_PX), SLACK_PX, "column 2 shrinks by about the drag: %r" % s)
+        g = (s["grow"] or {}).get("chat2")
+        self.assertIsInstance(g, (int, float), "romp-pane-grow carries column 2's weight: %r" % s["grow"])
+        self.assertTrue(g == g and abs(g) != float("inf"))
+        self.assertIsInstance((s["grow"] or {}).get("chat"), (int, float))
+
+    def test_5_the_picker_in_column_2_lifts_that_column_only_and_unlifts_on_toggle(self):
+        s = self._r()["s5"]
+        o = s["open"]
+        self.assertTrue(o["pickerOpen"], "body.picker-open while column 2's picker is up: %r" % o)
+        self.assertTrue(o["pickerShown"], "the picker overlay is visible in column 2")
+        self.assertTrue(o["frame2Lifted"], "the asking iframe wears .lifted: %r" % o)
+        self.assertTrue(o["pane2Lifted"], "…and its pane: %r" % o)
+        self.assertFalse(o["frame1Lifted"], "column 1 is NOT lifted: %r" % o)
+        self.assertEqual(sorted(o["lifted"]), ["chat-pane-2", "f-chat-2"], o["lifted"])
+        c = s["closed"]
+        self.assertFalse(c["pickerOpen"], "toggle closes the picker and releases the lift: %r" % c)
+        self.assertEqual(c["lifted"], [], "no .lifted remains: %r" % c)
+
+    def test_6_a_reload_brings_both_columns_back_on_their_sessions_at_the_dragged_width(self):
+        r = self._r()
+        s = r["s6"]
+        self.assertEqual(s["frameIds"], ["f-chat", "f-chat-2"], "both columns return after a reload: %r" % s)
+        self.assertEqual(s["cols"], "[2]")
+        self.assertEqual(s["col2Active"], SID_B, "column 2 finds its tab where it left it (its own state blob): %r" % s)
+        self.assertEqual(s["col1Active"], SID_A)
+        self.assertLessEqual(abs(s["pane2W"] - r["s4"]["after2"]), SLACK_PX,
+                             "column 2 comes back at the width the drag left it: %r vs %r" % (s["pane2W"], r["s4"]["after2"]))
+        self.assertLessEqual(abs(s["pane1W"] - r["s4"]["after1"]), SLACK_PX,
+                             "…and so does column 1: %r vs %r" % (s["pane1W"], r["s4"]["after1"]))
+        self.assertFalse(s["pickerOpen"]); self.assertEqual(s["lifted"], [])
+
+    def test_7_closing_the_last_split_leaves_one_column_and_an_empty_set(self):
+        s = self._r()["s7"]
+        self.assertTrue(s["pane2Gone"], "__rompCloseSplit(2) removes the pane, its gutter and its iframe")
+        self.assertEqual(s["frameIds"], ["f-chat"])
+        self.assertEqual(s["cols"], "[]")
+        self.assertNotIn("chat2", s["grow"] or {}, "the closed column's grow leaves the store: %r" % s["grow"])
+
+    def test_8_the_whole_story_runs_in_well_under_half_a_minute(self):
+        r = self._r()
+        self.assertLess(r["ms"], 25000, "the driver waits on conditions, never on fixed sleeps: %d ms" % r["ms"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_files_pane.py
+++ b/tests/test_files_pane.py
@@ -237,8 +237,9 @@ class Shell(unittest.TestCase):
         _has(self, "var PANES=['chat-pane','fleet-pane','feed-pane','files-pane'];", self.html)
         _has(self, "grow={chat:60,fleet:34,feed:40,files:40}", self.html)
         _has(self, "id==='feed-pane'?'feed':'files'", self.html)
+        # the chat side of gv-c is the RIGHTMOST chat column (the split, 2026-09-08: lastChat() is 'chat-pane' with no split)
         _has(self, "gutter('gv-c',function(){var c=document.body.classList;return c.contains('po-feed')?'feed-pane':"
-                      "c.contains('po-fleet')?'fleet-pane':'chat-pane';},'files-pane');", self.html)
+                      "c.contains('po-fleet')?'fleet-pane':lastChat();},'files-pane');", self.html)
 
     def test_the_files_controls_own_setting_hides_it_in_both_layouts(self):
         # T317 (the user 2026-09-10): the gear's "Files control in the dashboard bar" (romp:settings.showFilesControl,

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -7502,9 +7502,13 @@ class ServeSecurity(unittest.TestCase):
         # Height rides --app-h (the shell's live VISIBLE height): the layout viewport ignores the phone
         # keyboard, so an inset:0 lift sat half behind it, and the --app-h sizing is what delivers the
         # keyboard to the iframe as its own resize — the event the picker's fold keys on (2026-08-10).
-        self.assertIn("body.picker-open #f-chat{display:block;position:fixed;left:0;right:0;top:0;"
+        self.assertIn("body.picker-open iframe.lifted{display:block;position:fixed;left:0;right:0;top:0;"
                       "height:var(--app-h,100dvh);z-index:200;background:transparent}", html)
-        self.assertIn("body.picker-open #chat-pane{display:block!important}", html)         # un-hide it even if chat is toggled off
+        self.assertIn("body.picker-open .pane.lifted{display:block!important}", html)      # un-hide it even if chat is toggled off
+        # by CLASS since the split (2026-09-08): the shell marks the ASKING column .lifted, so a picker opened
+        # in a later column lifts that column and never the first
+        self.assertIn("var lf=(window.__rompFrameOfWin&&window.__rompFrameOfWin(e.source))||document.getElementById('f-chat');", html)
+        self.assertIn("if(m.on&&lf){lf.classList.add('lifted');if(lf.parentElement)lf.parentElement.classList.add('lifted');}", html)
         self.assertIn("m.romp==='picker'", html)                                            # the shell listens for the picker post
         self.assertIn("document.body.classList.toggle('picker-open',!!m.on)", html)
         # the settings bridge is untouched (both share the one message handler)

--- a/tests/test_kernel_fed_echo_absorbed.py
+++ b/tests/test_kernel_fed_echo_absorbed.py
@@ -137,6 +137,67 @@ class _World:
         return key
 
 
+def streamed_after_the_send():
+    """Tool steps the session ran after a send at T0+55 and before its splice: what the model did BEFORE reading it."""
+    return [
+        aline(T0 + 120, "", "a3", "tr1", tools=("Bash",), stop="tool_use"),
+        trline(T0 + 121, "tu_a3_0", "tr2", "a3"),
+        aline(T0 + 122, "", "a4", "tr2", tools=("Bash",), stop="tool_use"),
+    ]
+
+
+class TheEchoSitsAtTheTailForEveryViewer(unittest.TestCase):
+    """The kernel's echo of a fed, unlanded send is the message's only record until the splice, and every window but
+    the sender's draws it (the sender hides it behind its own tail bubble, T262h). The merge sorted the turn's atoms
+    by time alone, so the echo sat at its SEND time — above the tool steps that streamed after the send, which the
+    model ran before reading it — while the sender's bubble sat at the tail (T252d): one session in two split columns
+    read as one column behind the other (the user 2026-09-10). An in-flight echo now sorts after every atom the turn
+    holds; a never-delivered echo (a record of a loss) and the CLI's command feedback keep their time."""
+
+    def setUp(self):
+        self.w = _World()
+
+    def tearDown(self):
+        self.w.close()
+
+    def _atoms(self, merged):
+        return merged["turns"][-1]["atoms"]
+
+    def test_an_in_flight_echo_follows_the_steps_that_streamed_after_the_send(self):
+        self.w.write(running_turn() + streamed_after_the_send())
+        self.w.echo(FED, T0 + 55)                    # sent after tr1 (T0+50), before the steps
+        self.w.s.inflight = 1
+        self.w.s._inflight_texts.append(FED)
+        atoms = self._atoms(km._merge_live_atoms(self.w.parse(), SID))
+        self.assertEqual(atoms[-1].get("_echo_text"), FED, "the echo is the turn's last atom")
+        self.assertEqual([a["uuid"] for a in atoms[-4:-1]], ["a3", "tr2", "a4"], "…below the steps that ran while it waited")
+        by_time = sorted(atoms, key=lambda a: (a.get("t", 0), a.get("_seq", 0)))
+        self.assertEqual([a["uuid"] for a in by_time[-4:]], ["echo:fed", "a3", "tr2", "a4"],
+                         "time order alone drew the send above those steps: the old order, the other column's view")
+
+    def test_a_never_delivered_echo_and_command_feedback_keep_their_time(self):
+        self.w.write(running_turn() + streamed_after_the_send())
+        key = self.w.echo(FED, T0 + 55)
+        self.w.be._live[SID][key]["dropped"] = True   # never delivered: a record of a loss, at the time it was lost
+        self.w.be._live[SID]["cmd"] = {"type": "user", "uuid": "cmd", "session_id": SID, "t": T0 + 56, "parentUuid": None,
+                                       "author": "human", "command": "/model", "_echo_text": "/model opus",
+                                       "message": {"role": "user", "content": [{"type": "text", "text": "/model opus"}]}}
+        atoms = self._atoms(km._merge_live_atoms(self.w.parse(), SID))
+        self.assertEqual([a["uuid"] for a in atoms[-5:]], ["echo:fed", "cmd", "a3", "tr2", "a4"],
+                         "both keep their place in time, before the later steps")
+
+    def test_the_landing_replaces_the_tail_echo_in_place(self):
+        # the splice lands the text below the steps (T252d): the echo retires and the absorbed atom holds the tail
+        self.w.write(running_turn() + streamed_after_the_send() + [attline(T0 + 55, FED, "att1", "a4")])
+        self.w.echo(FED, T0 + 55)
+        self.w.s.inflight = 1
+        self.w.s._inflight_texts.append(FED)
+        atoms = self._atoms(km._merge_live_atoms(self.w.parse(), SID))
+        self.assertNotIn(SID, self.w.be._live, "the landing retires the echo")
+        self.assertEqual(atoms[-1]["uuid"], "att1", "the absorbed atom is the tail, where the echo was")
+        self.assertTrue(atoms[-1].get("absorbed"))
+
+
 class FedEchoSurvivesUntilTheSpliceLands(unittest.TestCase):
     def setUp(self):
         self.w = _World()

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -189,7 +189,8 @@ class LandingShell(unittest.TestCase):
         # +1 2026-09-08: the reload core (T265, _reload_core) ahead of the build-staleness banner script, which
         # registers as its refused fallback — its own script so a banner throw cannot take the reload with it
         # +1: the bottom bar's API health cell (_LANDING_APIH_JS), after the usage script whose backdrop it shares
-        self.assertEqual(html.count("<script>"), 20)
+        # +1 2026-09-08: the chat split columns (_LANDING_SPLIT_JS), after the pane controller it leans on
+        self.assertEqual(html.count("<script>"), 21)
 
     def test_bottom_bar_is_text_only_and_compact(self):
         html = km._landing()

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -119,10 +119,16 @@ class PaneRailTest(unittest.TestCase):
         self.assertIn("#chat-pane{flex:var(--g-chat,60) 1 0}#fleet-pane{flex:var(--g-fleet,34) 1 0}#feed-pane{flex:var(--g-feed,40) 1 0}#files-pane{flex:var(--g-files,40) 1 0}", self.html)
         self.assertNotIn("--g-timeline", self.html)              # timeline is the fixed-height band, not a row grow
         self.assertIn("var GK='romp-pane-grow'", self.html)
-        self.assertIn("setGrow(key(id),document.getElementById(id).offsetWidth)", self.html)
+        # two passes (2026-09-08): every shown width is READ before any grow is written — a write re-flows the row,
+        # and a read after it came back at a mixed scale, ballooning the first column on a fresh browser's first drag
+        self.assertIn("var px={};PANES.forEach(function(id){if(shown(id))px[id]=document.getElementById(id).offsetWidth;});", self.html)
+        self.assertIn("Object.keys(px).forEach(function(id){setGrow(key(id),px[id]);});", self.html)
         self.assertIn("localStorage.setItem(GK,JSON.stringify(grow))", self.html)
-        # gv-b picks its left neighbour live: fleet when shown, else chat (so it's the chat|feed gutter too)
-        self.assertIn("document.body.classList.contains('po-fleet')?'fleet-pane':'chat-pane'", self.html)
+        # gv-b picks its left neighbour live: the outline (fleet) when shown, else the RIGHTMOST chat column (so it's the
+        # chat|feed gutter too; lastChat() is the last split column, or #chat-pane when there is no split —
+        # split screen, the user 2026-09-08)
+        self.assertIn("document.body.classList.contains('po-fleet')?'fleet-pane':lastChat()", self.html)
+        self.assertIn("gutter('gv-a',function(){return lastChat();},'fleet-pane')", self.html)
 
     def test_the_shell_serves_the_landing_line_of_a_divider_drag(self):
         # a divider drag moves a line over the row and the panes take their widths once, at release (the drag

--- a/tests/test_kernel_panenav.py
+++ b/tests/test_kernel_panenav.py
@@ -36,7 +36,9 @@ class PaneNav(unittest.TestCase):
 
     def test_move_is_spatial_and_skips_hidden_panes(self):
         self.assertIn("function moveFocus(dir)", JS)
-        self.assertIn("function visCols(){return COLS.filter(paneVisible);}", JS, "only VISIBLE columns are traversed")
+        # every chat column (the split's, in row order) then the static Outline/Feed — only the VISIBLE ones
+        self.assertIn("function visCols(){return allCols().filter(paneVisible);}", JS, "only VISIBLE columns are traversed")
+        self.assertIn("function allCols(){var c=window.__rompChatFrameIds?window.__rompChatFrameIds():['f-chat'];return c.concat(COLS.slice(1));}", JS)
         self.assertIn("getComputedStyle(el).display!=='none'", JS, "hidden panes (display:none) are skipped")
         # left/right along columns, down into the timeline, up back out of it
         self.assertIn("if(dir==='left'){if(i>0)focusPane(cols[i-1],dir);}", JS)

--- a/tests/test_kernel_webpush.py
+++ b/tests/test_kernel_webpush.py
@@ -1305,7 +1305,8 @@ class RevealAiming(unittest.TestCase):
             # the aimed pane arrives → delivered once, latch cleared
             mine, mine_got = _fake_ws_client("chat", "W-phone")
             km._consume_pending_reveal(mine)
-            self.assertEqual(mine_got, [{"type": "focus", "id": "SID-live", "live": True}])
+            # `own` (split screen, 2026-09-08): ONE chat client consumes the parked tap, so the pane's column arbitration must not hand it elsewhere
+            self.assertEqual(mine_got, [{"type": "focus", "id": "SID-live", "live": True, "own": True}])
             self.assertIsNone(km._PENDING_REVEAL[0])
             km._consume_pending_reveal(mine)
             self.assertEqual(len(mine_got), 1, "consumed means consumed")
@@ -1348,7 +1349,7 @@ class RevealAiming(unittest.TestCase):
             # …then the ready handler stamps the client and consumes the park
             booting["ready"] = True
             km._consume_pending_reveal(booting)
-        self.assertEqual(heard, [{"type": "focus", "id": "SID-live", "live": True}])
+        self.assertEqual(heard, [{"type": "focus", "id": "SID-live", "live": True, "own": True}])   # own: a consumed reveal is the receiving column's to take (the split, 2026-09-08)
         self.assertIsNone(km._PENDING_REVEAL[0])
         # a live (non-boot) tap to that same not-yet-ready socket parks too: the sw / ack / vanish roads had the
         # same hole once the shell saw the socket up but before the bundle listened
@@ -1384,7 +1385,7 @@ class RevealAiming(unittest.TestCase):
             self.assertEqual((parked["sid"], parked["wid"], parked.get("sent")), ("S", "W-phone", [twin]), "…and the copy stays for the fresh pane")
             fresh, fresh_got = _fake_ws_client("chat", "W-phone")
             km._consume_pending_reveal(fresh)
-        self.assertEqual(fresh_got, [{"type": "focus", "id": "S", "live": True}])
+        self.assertEqual(fresh_got, [{"type": "focus", "id": "S", "live": True, "own": True}])
         self.assertIsNone(km._PENDING_REVEAL[0])
 
     def test_a_live_tap_to_an_unproven_socket_keeps_a_copy_until_the_pong_or_the_redial(self):
@@ -1418,7 +1419,7 @@ class RevealAiming(unittest.TestCase):
             km._reveal_request("S", "W1")
             fresh, fresh_got = _fake_ws_client("chat", "W1")
             km._consume_pending_reveal(fresh)
-        self.assertEqual(fresh_got, [{"type": "focus", "id": "S", "live": True}])
+        self.assertEqual(fresh_got, [{"type": "focus", "id": "S", "live": True, "own": True}])
         self.assertIsNone(km._PENDING_REVEAL[0])
 
     def test_a_redialed_pane_is_a_target_and_its_first_strip_consumes_the_park(self):
@@ -1769,7 +1770,12 @@ class LandingRevealPins(unittest.TestCase):
         self.assertIn("romp:wid", html)            # …at the shell's own per-window id
         self.assertIn("romp:'revealCard'", html)   # a card kind also scrolls the feed to the card…
         self.assertIn("m.romp==='ready'&&m.app==='feed'", html)   # …once the feed has its cards
-        self.assertNotIn("type:'focus',id:sid", html, "no focus posted straight into the chat iframe any more")
+        # the TAP's scripts post no focus straight into the chat iframe any more (the kernel aims it). The split
+        # script (_LANDING_SPLIT_JS, 2026-09-08) is the one deliberate exception and is not a tap path: it hands a
+        # column the shell has just MADE the session it was opened on, addressed to that column (`own`).
+        taps = km._LANDING_REVEAL_JS + km._LANDING_PUSH_JS + km._LANDING_MOBILE_JS
+        self.assertNotIn("type:'focus',id:sid", taps, "no focus posted straight into the chat iframe any more")
+        self.assertNotIn("type:'focus'", km._LANDING_REVEAL_JS)
         self.assertNotIn("setTimeout", km._LANDING_REVEAL_JS, "event-based: the feed's ready, never a timer")
 
     def test_the_link_is_read_at_boot_and_on_a_same_page_url_change(self):

--- a/tests/test_pane_gutters.py
+++ b/tests/test_pane_gutters.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""The shell's pane gutters must WORK with split chat columns in the row, not just parse (2026-09-08).
+
+The dashboard's chat|fleet|feed panes are sized by flex-grow weights the gutter script (_LANDING_JS in
+kernel.py) keeps in sync with `--g-<k>` vars on .row and persists in localStorage. Split screen (the user
+2026-09-08, who wanted several sessions side by side instead of tabbing through them) adds chat columns to
+that row AFTER the script has run, so the script grew a registry: a column registers its pane id and grow
+key, takes a fair grow (the average of what is already on screen) or the width it was dragged to before a
+reload, gets its own chat|chat gutter wired through the same drag code, and gv-a/gv-b treat the RIGHTMOST
+chat column as their left neighbour. The review of the first cut found the fair grow averaging the new
+column's own undefined grow in as NaN, so the first split opened 0px wide; that is the regression this
+file pins by running the code, since a source pin cannot tell NaN from 50.
+
+This EXECUTES the real _LANDING_JS in node against a DOM stub (the test_error_center.py pattern) and drives
+the whole story over one JSON result: the boot defaults; a fresh column's fair grow; the reload paths of
+__rompGrowFairIfNew (a stored width is kept, a missing one falls to the average) by re-running the blob
+against a re-seeded store; a drag on a chat|chat gutter moving only that pair; gv-a pairing the rightmost
+column with the outline (fleet) pane; unregistering a closed column; and the unregistered fallback keys. The stub records
+the `--g-*` vars the script sets on .row, because the script's `grow` object is a closure.
+
+Synthetic only: no network, no real DOM, invented widths.
+"""
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = load_source("romp_kernel_gutters", os.path.join(BIN, "romp-kernel"))
+
+# Everything _LANDING_JS touches, and nothing else: .col (the timeline band's --tl var, never driven here),
+# .row (records the --g-* vars), the gutters + panes by id, getComputedStyle(el).display for shown(),
+# body.classList (po-fleet / po-timeline reads, drag/dragv writes), localStorage, and the window's
+# mousemove/mouseup listeners a drag installs and removes. f-timeline is stubbed PRESENT (the served
+# shell always carries the iframe, kernel.py `<iframe id=f-timeline …>`), so the 'load' hookup runs; the
+# script also guards the null case (`tf&&…`, `tf?…:0`), so a stub without it would pass too.
+HARNESS = r"""
+'use strict';
+const STORE = {};
+global.localStorage = {
+  getItem: (k) => (k in STORE ? STORE[k] : null),
+  setItem: (k, v) => { STORE[k] = String(v); },
+  removeItem: (k) => { delete STORE[k]; },
+};
+const ROW = {};   // the --g-* vars the script sets on .row (its `grow` object is a closure)
+const rowEl = { style: { setProperty: (k, v) => { ROW[k] = v; }, removeProperty: (k) => { delete ROW[k]; } },
+                getBoundingClientRect: () => ({ top: 0, height: 800, left: 0, bottom: 800 }) };   // the landing line is placed by the row's rect (main, 2026-09)
+const colEl = { style: { setProperty() {} }, getBoundingClientRect: () => ({ bottom: 800 }) };
+function mkEl(id, w, display) {
+  return {
+    id: id, offsetWidth: w, _display: display, _ls: {},
+    getBoundingClientRect() { return { left: 0, top: 0, width: this.offsetWidth, height: 800, bottom: 800 }; },   // the drag's landing line reads the left pane's rect
+    addEventListener(k, f) { (this._ls[k] = this._ls[k] || []).push(f); },
+    fire(k, ev) { (this._ls[k] || []).slice().forEach((f) => f(ev)); },
+  };
+}
+let EL = {};
+let WL = {};
+// Fresh gutters, panes and window listeners for every boot of the blob: a re-run models a RELOAD, and the
+// previous instance's mousedown handlers must not linger on the same stub gutter (two closures dragging
+// one row would corrupt every width below).
+function resetDom() {
+  EL = {};
+  WL = {};
+  ['gh', 'gv-a', 'gv-b', 'gv-c', 'gv-chat-2', 'gv-chat-3', 'f-timeline'].forEach((id) => { EL[id] = mkEl(id, 0, 'flex'); });
+  EL['chat-pane'] = mkEl('chat-pane', 600, 'flex');
+  EL['fleet-pane'] = mkEl('fleet-pane', 300, 'none');   // hidden by default, like the real rail
+  EL['feed-pane'] = mkEl('feed-pane', 400, 'flex');
+  EL['files-pane'] = mkEl('files-pane', 400, 'none');   // the fourth top pane (main, 2026-09), hidden by default
+  EL['chat-pane-2'] = mkEl('chat-pane-2', 500, 'flex');   // the split's client-made column (shown once made)
+  EL['chat-pane-3'] = mkEl('chat-pane-3', 450, 'flex');
+  for (const k in ROW) delete ROW[k];
+}
+const BODY = new Set(['po-chat', 'po-feed']);
+global.window = {
+  innerHeight: 900,
+  addEventListener: (k, f) => { (WL[k] = WL[k] || []).push(f); },
+  removeEventListener: (k, f) => { WL[k] = (WL[k] || []).filter((g) => g !== f); },
+};
+global.getComputedStyle = (el) => ({ display: el._display });
+global.document = {
+  querySelector: (sel) => (sel === '.col' ? colEl : sel === '.row' ? rowEl : null),
+  getElementById: (id) => EL[id] || null,
+  body: { classList: {
+    contains: (c) => BODY.has(c),
+    add: (...cs) => cs.forEach((c) => BODY.add(c)),
+    remove: (...cs) => cs.forEach((c) => BODY.delete(c)),
+  } },
+};
+function showFleet(on) { EL['fleet-pane']._display = on ? 'flex' : 'none'; if (on) BODY.add('po-fleet'); else BODY.delete('po-fleet'); }
+function winFire(k, ev) { (WL[k] || []).slice().forEach((f) => f(ev)); }
+function grows() { return Object.assign({}, ROW); }
+function store() { return JSON.parse(STORE['romp-pane-grow'] || 'null'); }
+function drag(gid, x0, x1) {
+  const snap = {};
+  EL[gid].fire('mousedown', { preventDefault() {}, clientX: x0 });
+  snap.afterDown = grows();           // every shown pane normalised to its px width
+  snap.dragging = BODY.has('drag') && BODY.has('dragv');
+  snap.listeners = { move: (WL['mousemove'] || []).length, up: (WL['mouseup'] || []).length };
+  winFire('mousemove', { clientX: x1 });
+  snap.afterMove = grows();
+  winFire('mouseup', {});
+  snap.afterUp = grows();
+  snap.dragAfterUp = BODY.has('drag') || BODY.has('dragv');
+  snap.listenersAfterUp = { move: (WL['mousemove'] || []).length, up: (WL['mouseup'] || []).length };
+  snap.store = store();
+  return snap;
+}
+"""
+
+DRIVER = r"""
+const out = {};
+// 1) boot with an empty store: the defaults land on .row
+resetDom();
+BOOT();
+out.boot = { grows: grows(), store: store() };
+// 2) a split column registers, then asks for a fair grow while it has NO grow of its own yet: the average
+//    of the shown panes' finite grows (chat 60 + feed 40, the outline (fleet) pane hidden), never NaN (review find 2026-09-08)
+window.__rompRegisterPane('chat-pane-2', 'chat2');
+window.__rompGrowFair('chat2');
+out.fair = { grows: grows(), store: store(),
+  finite: typeof ROW['--g-chat2'] === 'number' && isFinite(ROW['--g-chat2']) };
+// 3a) a RELOAD with a stored width for the column: __rompGrowFairIfNew keeps it (no re-fair)
+resetDom();
+STORE['romp-pane-grow'] = JSON.stringify({ chat: 60, fleet: 34, feed: 40, chat2: 123 });
+BOOT();
+window.__rompRegisterPane('chat-pane-2', 'chat2');
+window.__rompGrowFairIfNew('chat2');
+out.ifNewKept = { grows: grows(), store: store() };
+// 3b) a RELOAD with nothing stored for the column: it falls through to the fair average
+resetDom();
+STORE['romp-pane-grow'] = JSON.stringify({ chat: 60, fleet: 34, feed: 40 });
+BOOT();
+window.__rompRegisterPane('chat-pane-2', 'chat2');
+window.__rompGrowFairIfNew('chat2');
+out.ifNewFair = { grows: grows(), store: store() };
+// 4) the column's own chat|chat gutter, wired the way the split script wires it (left = the previous
+//    column, here the first chat pane; right = the new column). Drag 100px to the right.
+window.__rompGutter('gv-chat-2', function () { return 'chat-pane'; }, 'chat-pane-2');
+out.dragChatChat = drag('gv-chat-2', 500, 600);
+// 5) gv-a's left neighbour is the RIGHTMOST chat column: with the outline (fleet) pane shown, a drag on gv-a moves chat2|fleet
+window.__rompLastChatPane = function () { return 'chat-pane-2'; };
+showFleet(true);
+out.dragGvA = drag('gv-a', 500, 560);
+showFleet(false);
+// 6) closing the column: its grow leaves the store and .row; a later fair grow (a new column made after
+//    the close) averages only what is still registered, though the closed pane's element is still there
+window.__rompUnregisterPane('chat-pane-2');
+out.unregister = { grows: grows(), store: store() };
+window.__rompRegisterPane('chat-pane-3', 'chat3');
+window.__rompGrowFair('chat3');
+out.fairAfterClose = { grows: grows(), store: store() };
+window.__rompUnregisterPane('chat-pane-3');
+// 7) no split at all: gv-b with fleet hidden pairs the first chat pane with feed, through the
+//    unregistered fallback keys (key('chat-pane') → chat, key('feed-pane') → feed)
+delete window.__rompLastChatPane;
+out.dragGvB = drag('gv-b', 500, 480);
+console.log(JSON.stringify(out));
+"""
+
+
+class PaneGuttersExecute(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # the blob is a self-invoking function; wrapping it as BOOT lets the driver re-run it against a
+        # re-seeded store, which is exactly what a reload of the shell does
+        script = HARNESS + "const BOOT = function () {" + km._LANDING_JS + "};\n" + DRIVER
+        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
+            f.write(script)
+            path = f.name
+        try:
+            r = subprocess.run(["node", path], capture_output=True, text=True, timeout=30)
+        finally:
+            os.unlink(path)
+        assert r.returncode == 0, "the gutter JS threw: " + r.stderr[:800]
+        cls.out = json.loads(r.stdout.strip().splitlines()[-1])
+
+    def test_1_boot_with_an_empty_store_sets_the_defaults_on_the_row(self):
+        a = self.out["boot"]
+        self.assertEqual(a["grows"], {"--g-chat": 60, "--g-fleet": 34, "--g-feed": 40, "--g-files": 40})
+        self.assertIsNone(a["store"], "booting alone writes nothing: the store fills on the first drag or fair grow")
+
+    def test_2_a_fresh_columns_fair_grow_averages_only_finite_grows(self):
+        # the zero-width regression: chat-pane-2 is shown and registered but has no grow yet, so the old
+        # average was (60 + undefined + 40) / 3 = NaN, which flex read as 0 and the column opened 0px wide
+        a = self.out["fair"]
+        self.assertTrue(a["finite"], "the new column's grow is a finite number, never NaN")
+        self.assertEqual(a["grows"]["--g-chat2"], 50, "the average of chat 60 and feed 40 (fleet is hidden)")
+        self.assertEqual(a["grows"]["--g-chat"], 60)
+        self.assertEqual(a["grows"]["--g-feed"], 40)
+        self.assertEqual(a["store"], {"chat": 60, "fleet": 34, "feed": 40, "files": 40, "chat2": 50}, "and it persists")
+
+    def test_3_grow_fair_if_new_keeps_a_stored_width_and_fairs_a_missing_one(self):
+        kept = self.out["ifNewKept"]
+        self.assertEqual(kept["grows"]["--g-chat2"], 123, "a dragged width survives the reload: setGrow applied, no re-fair")
+        self.assertEqual(kept["store"]["chat2"], 123)
+        fair = self.out["ifNewFair"]
+        self.assertEqual(fair["grows"]["--g-chat2"], 50, "nothing stored for it → the fair average")
+        self.assertEqual(fair["store"], {"chat": 60, "fleet": 34, "feed": 40, "files": 40, "chat2": 50})
+
+    def test_4_a_chat_chat_gutter_drag_moves_only_that_pair(self):
+        a = self.out["dragChatChat"]
+        # the grab normalises every SHOWN pane's grow to its px width; hidden fleet keeps its stored grow
+        self.assertEqual(a["afterDown"], {"--g-chat": 600, "--g-chat2": 500, "--g-feed": 400, "--g-fleet": 34, "--g-files": 40})
+        self.assertTrue(a["dragging"], "body.drag + body.dragv while the pointer is held")
+        self.assertEqual(a["listeners"], {"move": 1, "up": 1})
+        # a drag moves a LANDING LINE (main, 2026-09): the pointer's +100px writes nothing until the release…
+        self.assertEqual(a["afterMove"], a["afterDown"], "mousemove positions the ghost line; no pane re-lays out mid-drag")
+        # …then chat +100, chat2 -100, the others exactly where the grab left them
+        self.assertEqual(a["afterUp"]["--g-chat"], 700)
+        self.assertEqual(a["afterUp"]["--g-chat2"], 400)
+        self.assertEqual(a["afterUp"]["--g-feed"], a["afterDown"]["--g-feed"], "feed is untouched by the drag")
+        self.assertEqual(a["afterUp"]["--g-fleet"], a["afterDown"]["--g-fleet"], "fleet is untouched by the drag")
+        self.assertFalse(a["dragAfterUp"], "body.drag / body.dragv are removed on mouseup")
+        self.assertEqual(a["listenersAfterUp"], {"move": 0, "up": 0}, "the drag's window listeners are removed")
+        self.assertEqual(a["store"], {"chat": 700, "fleet": 34, "feed": 400, "files": 40, "chat2": 400}, "the store holds the dragged widths")
+
+    def test_5_gv_a_pairs_the_rightmost_chat_column_with_fleet(self):
+        a = self.out["dragGvA"]
+        # fleet is shown for this drag, so it normalises too; the previous drag's widths are the px the
+        # stubs report, so chat/chat2 re-normalise to 600/500 (a real pane's offsetWidth follows its grow)
+        self.assertEqual(a["afterDown"], {"--g-chat": 600, "--g-chat2": 500, "--g-fleet": 300, "--g-feed": 400, "--g-files": 40})
+        # +60px: the pair that moves is chat2|fleet, and the FIRST chat pane does not move
+        self.assertEqual(a["afterUp"]["--g-chat2"], 560)
+        self.assertEqual(a["afterUp"]["--g-fleet"], 240)
+        self.assertEqual(a["afterUp"]["--g-chat"], 600, "chat is not gv-a's left neighbour once a column sits to its right")
+        self.assertEqual(a["afterUp"]["--g-feed"], 400)
+        self.assertEqual(a["store"], {"chat": 600, "fleet": 240, "feed": 400, "files": 40, "chat2": 560})
+
+    def test_6_unregistering_a_closed_column_drops_it_everywhere(self):
+        a = self.out["unregister"]
+        self.assertNotIn("--g-chat2", a["grows"], "its --g-chat2 var leaves .row")
+        self.assertNotIn("chat2", a["store"], "and its grow leaves the store")
+        self.assertEqual(a["store"], {"chat": 600, "fleet": 240, "feed": 400, "files": 40})
+        # a column made after the close averages chat 600 + feed 400 (fleet hidden again) = 500; had the
+        # closed pane still counted (its element is still in the stub), the average would be 520
+        b = self.out["fairAfterClose"]
+        self.assertEqual(b["grows"]["--g-chat3"], 500)
+        self.assertNotIn("--g-chat2", b["grows"])
+        self.assertEqual(b["store"], {"chat": 600, "fleet": 240, "feed": 400, "files": 40, "chat3": 500})
+
+    def test_7_unregistered_ids_fall_back_to_the_fixed_keys(self):
+        # no split, fleet hidden: gv-b's left neighbour is the first chat pane (lastChat() with no
+        # __rompLastChatPane → 'chat-pane'), and key() resolves the fixed ids to chat / feed
+        a = self.out["dragGvB"]
+        self.assertEqual(a["afterDown"], {"--g-chat": 600, "--g-fleet": 240, "--g-feed": 400, "--g-files": 40},
+                         "only the fixed panes are registered; the closed columns are gone from the grab")
+        # -20px: chat -20, feed +20; fleet (hidden) untouched
+        self.assertEqual(a["afterUp"]["--g-chat"], 580)
+        self.assertEqual(a["afterUp"]["--g-feed"], 420)
+        self.assertEqual(a["afterUp"]["--g-fleet"], 240)
+        self.assertEqual(a["store"], {"chat": 580, "fleet": 240, "feed": 420, "files": 40})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pane_state_broadcast.py
+++ b/tests/test_pane_state_broadcast.py
@@ -895,7 +895,8 @@ class PaneEnabledReader(unittest.TestCase):
         self.assertEqual(html.count(HELPER), 1)
         self.assertLess(html.index(HELPER), html.index("<iframe"), "defined in the head, before the first iframe")
         self.assertLess(html.index(HELPER), html.index("<body"))
-        self.assertEqual(html.count("<script>"), 20, "the head's existing script carries it: no new script element")
+        self.assertEqual(html.count("<script>"), 21, "the head's existing script carries it: no new script element "
+                         "(main's 20 + the chat split's own script, tests/test_chat_split.py — 2026-09-11)")
         for js in (km._LANDING_ERRS_JS, km._LANDING_MOBILE_JS, km._LANDING_REVEAL_JS, km._LANDING_SETTINGS_JS):
             self.assertIn("window.__rompPaneEnabled&&!window.__rompPaneEnabled('feed')", js, "absent helper = every pane shown")
 

--- a/tests/test_shell_viewport_fit.py
+++ b/tests/test_shell_viewport_fit.py
@@ -63,7 +63,7 @@ class OneHeightBasis(unittest.TestCase):
         # left the picker's lower rows behind it — and the --app-h sizing is also what turns the keyboard
         # into an in-iframe resize event for the picker's short-window fold (the user 2026-08-10).
         # Horizontally it stays inset-sized (left:0;right:0), no 100vw.
-        self.assertIn("body.picker-open #f-chat{display:block;position:fixed;left:0;right:0;top:0;"
+        self.assertIn("body.picker-open iframe.lifted{display:block;position:fixed;left:0;right:0;top:0;"
                       "height:var(--app-h,100dvh);z-index:200;background:transparent}", self.html)
 
     def test_an_unpainted_pane_is_dark_not_white(self):

--- a/ui/webview/chat-split.test.ts
+++ b/ui/webview/chat-split.test.ts
@@ -1,0 +1,82 @@
+// Split screen for the chat (the user 2026-09-08: several sessions open at once instead of tabbing through
+// them). The shell owns the columns (kernel.py _LANDING_SPLIT_JS, executed in tests/test_chat_split.py); this
+// pins the PANE and PALETTE halves at source (no jsdom for the renderer — the repo convention):
+//   * render.ts stands down on a focus, a revive prompt or the feed's click echo that the shell says belongs
+//     to another column, asks for a split from the tab menu, and measures ITS OWN pane when lifted;
+//   * palette-main.ts aims every chat-directed command at the column last worked in, registers the split
+//     commands, and wires its chords on a column made later;
+//   * commands.ts binds the split to the editor convention.
+// Synthetic only — no session data.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const MAIN = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "palette-main.ts"), "utf8");
+const COMMANDS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "commands.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the pane asks the shell which column a session-focus belongs to, and acts only when it is its own", () => {
+  // the arbitration: the shell's __rompChatTarget names the frame; no shell (standalone, VS Code) → always ours
+  assert.match(RENDER, /function focusIsOurs\(sid: string\): boolean \{[\s\S]*?if \(!window\.parent \|\| window\.parent === window\) return true;[\s\S]*?const t = \(window\.parent as any\)\.__rompChatTarget;[\s\S]*?if \(typeof t !== "function"\) return true;[\s\S]*?return !f \|\| f === window\.frameElement;/);
+  // a kernel focus and a revive prompt aimed at another column are swallowed BEFORE the real branches
+  assert.match(RENDER, /else if \(m\.type === "focus" && !m\.own && !focusIsOurs\(m\.id\)\) \{[^}]*\}\n\s*else if \(m\.type === "focus"\) \{/);
+  // the shell's hand-over to a NEW column is addressed to it (`own`), so opening a tab in a new split works even
+  // when a column already shows that session
+  assert.ok(KERNEL.includes("f.contentWindow.postMessage({type:'focus',id:sid,own:true},'*')"));
+  assert.match(RENDER, /else if \(m\.type === "confirmRevive" && m\.id && !m\.own && !focusIsOurs\(m\.id\)\) \{[^}]*\}\n\s*else if \(m\.type === "confirmRevive" && m\.id\) \{/);
+  // …and the kernel marks the parked push-tap reveal it hands ONE column `own` (tests/test_chat_split.py pins the kernel side)
+  // the feed's click echo reaches every column's storage listener: the same gate, after the known-session check
+  assert.match(RENDER, /if \(e\.key !== "romp:focus-echo" \|\| !e\.newValue\) return;[\s\S]*?if \(!sid \|\| \(!sessions\.has\(sid\) && !tabMeta\.has\(sid\)\)\) return;\n\s*if \(!focusIsOurs\(sid\)\) return;/);
+});
+
+test("the tab menu offers Open in new split when a shell that can split hosts the pane", () => {
+  const i = RENDER.indexOf('l.textContent = "Open in new split"');
+  assert.ok(i > 0, "the item exists");
+  const block = RENDER.slice(RENDER.lastIndexOf("const shellCanSplit", i), RENDER.indexOf("menu.appendChild(split);", i));
+  // a shell with the split script, and one that can take another column right now (the cap, the phone)
+  assert.match(block, /inRompShell\(\) && typeof p\.__rompSplitChat === "function" && \(typeof p\.__rompCanSplit !== "function" \|\| !!p\.__rompCanSplit\(\)\)/);
+  assert.match(block, /if \(shellCanSplit\) \{/);
+  assert.match(block, /ctxIcon\("split", false\)/);
+  assert.match(block, /window\.parent\.postMessage\(\{ romp: "openSplit", sid: id \}, "\*"\)/);
+  // it sits with Rename and Move (where this session shows), ahead of the colour swatches
+  assert.ok(i > RENDER.indexOf('l.textContent = "Move to folder…"'), "after Move to folder…");
+  assert.ok(i < RENDER.indexOf("// Colors join Rename in the AESTHETIC section"), "before the colours");
+  // the icon: two columns side by side
+  assert.match(RENDER, /kind === "split"\n\s*\? '<rect x="2" y="3" width="5" height="10" rx="1"\/><rect x="9" y="3" width="5" height="10" rx="1"\/>'/);
+});
+
+test("a lifted column measures ITS OWN pane, never the first column's", () => {
+  assert.match(RENDER, /function liftPaneRect\(\): DOMRect \| null \{[\s\S]*?const own = window\.frameElement \? \(window\.frameElement as HTMLElement\)\.parentElement : null;\n\s*const p = own \|\| window\.parent\?\.document\?\.getElementById\("chat-pane"\);/);
+  // …and the shell lifts by class, marking the asking frame (the pinned CSS moved off #f-chat)
+  assert.ok(KERNEL.includes('"body.picker-open iframe.lifted{display:block;position:fixed;left:0;right:0;top:0;height:var(--app-h,100dvh);z-index:200;background:transparent}"'));
+  assert.ok(!KERNEL.includes('"body.picker-open #f-chat{'));
+});
+
+test("every chat-directed shell command lands in the column last worked in", () => {
+  assert.match(MAIN, /function chatPane\(\): HTMLIFrameElement \| null \{\n\s*try \{ const id = w\.__rompFocusedChatId && w\.__rompFocusedChatId\(\);[\s\S]*?return pane\("f-chat"\);\n\s*\}/);
+  assert.match(MAIN, /function chatPost\(msg: object\): void \{[\s\S]*?const f = chatPane\(\);/);
+  assert.match(MAIN, /\(chatPane\(\)\?\.contentWindow as any\)\?\.__rompSessionList/);
+  assert.match(MAIN, /\(chatPane\(\)\?\.contentWindow as any\)\?\.__rompMru/);
+  assert.match(MAIN, /chatPane\(\)!\.contentWindow!\.postMessage\(\{ romp: "chatNav", dir: -1 \}/);
+  assert.match(MAIN, /chatPane\(\)!\.contentWindow!\.postMessage\(\{ romp: "chatNav", dir: 1 \}/);
+  assert.match(MAIN, /onClose: \(\) => \{ try \{ chatPane\(\)!\.contentWindow!\.focus\(\); \}/);
+  assert.ok(!/pane\("f-chat"\)!/.test(MAIN), "no chat-directed command still hard-wires the first column");
+});
+
+test("the split commands exist, the split is bound to the editor convention, and a new column gets the chords", () => {
+  assert.match(MAIN, /registerCommand\(\{ id: "chat\.split", title: "Split the chat", run: \(\) => \{ if \(w\.__rompSplitChat\) w\.__rompSplitChat\(\); \} \}\);/);
+  assert.match(MAIN, /registerCommand\(\{ id: "chat\.closeSplit", title: "Close this chat split", run: \(\) => \{ if \(w\.__rompCloseSplit\) w\.__rompCloseSplit\(\); \} \}\);/);
+  assert.match(COMMANDS, /"chat\.split": "Mod\+\\\\",/);
+  assert.ok(!/"chat\.closeSplit":/.test(COMMANDS), "closing stays unbound by default — the palette owns it");
+  // the fixed four are wired as before, and a column the split makes later through the shell's event
+  assert.match(MAIN, /\["f-chat", "f-fleet", "f-feed", "f-files", "f-timeline", "f-settings"\]\.forEach\(\(id\) => wireKeys\(pane\(id\)\)\);/);   // + the Files pane and the settings iframe (main, 2026-09-10: the gear's document holds the keyboard while open)
+  assert.match(MAIN, /window\.addEventListener\("romp-chat-cols", \(e\) => wireKeys\(/);
+  // …and the columns restored before this module booted (the shell's split script runs ahead of it)
+  assert.match(MAIN, /\(\(w\.__rompChatFrameIds \? w\.__rompChatFrameIds\(\) : \[\]\) as string\[\]\)\.forEach\(\(id\) => \{ if \(id !== "f-chat"\) wireKeys\(pane\(id\)\); \}\);/);
+  // …which the shell dispatches with the frame when a column opens
+  assert.ok(KERNEL.includes("window.dispatchEvent(new CustomEvent('romp-chat-cols',{detail:{frame:f,col:n,open:true}}))"));
+  // no bottom-bar button for it (the user 2026-09-08): the tab menu and the palette are the doors
+  assert.ok(!KERNEL.includes("rail-split"));
+});

--- a/ui/webview/commands.ts
+++ b/ui/webview/commands.ts
@@ -27,6 +27,9 @@ export const DEFAULT_CHORDS: Record<string, string> = {
   // hotkeys.json, verified 2026-08-14), where "Ctrl" is the Control key on every platform.
   "chat.navBack": "Ctrl+M",
   "chat.navForward": "Ctrl+,",
+  // the editor convention for a split (VS Code's Cmd/Ctrl+\); closing a split stays unbound — Cmd+W is
+  // the browser's tab close, and a mis-aimed close of a column costs a re-split, so the palette owns it
+  "chat.split": "Mod+\\",
 };
 
 const commands = new Map<string, PaletteCommand>();

--- a/ui/webview/esc-close.test.ts
+++ b/ui/webview/esc-close.test.ts
@@ -60,6 +60,7 @@ test("the gear is the chain's last step: the shell asks the settings page's own 
   // gear.js: the hook closes the modal and says so, unless one of its own dialogs is up (they close one level at a time)
   assert.ok(GEAR.includes("window.__rompSettingsClose = function () { if (p.hidden || (lgM && !lgM.hidden) || openHousePick) return false; closeSettings(); return true; };"));
   assert.ok(GEAR.includes("if (e.key === 'Escape' && lgM && !lgM.hidden) lgModal(false);"), "the login card's own Escape stays");
-  // closing hides the iframe that held the keyboard: the shell's settings bridge puts focus back in the chat
-  assert.ok(KERNEL.includes("if(!m.on){var fc=document.getElementById('f-chat');try{fc&&fc.contentWindow&&fc.contentWindow.focus();}catch(e){}}}"));
+  // closing hides the iframe that held the keyboard: the shell's settings bridge puts focus back in the chat — the
+  // split's column last worked in, else the first (chat split, 2026-09-11)
+  assert.ok(KERNEL.includes("if(!m.on){var fid=(window.__rompFocusedChatId&&window.__rompFocusedChatId())||'f-chat';var fc=document.getElementById(fid)||document.getElementById('f-chat');try{fc&&fc.contentWindow&&fc.contentWindow.focus();}catch(e){}}}"));
 });

--- a/ui/webview/fork-session.test.ts
+++ b/ui/webview/fork-session.test.ts
@@ -77,7 +77,7 @@ test("the modal defaults to <session>-fork and posts forkSession {id, uuid, name
 
 test("the palette forks the ACTIVE session from the tip, via the chat pane", () => {
   assert.match(PALETTE, /id: "session\.fork", title: "Fork this session…"/);
-  assert.match(PALETTE, /pane\("f-chat"\)!\.contentWindow!\.postMessage\(\{ romp: "forkSession" \}, "\*"\)/);
+  assert.match(PALETTE, /chatPane\(\)!\.contentWindow!\.postMessage\(\{ romp: "forkSession" \}, "\*"\)/);   // the chat column last worked in (split screen 2026-09-08)
   assert.match(RENDER, /if \(m\.romp === "forkSession"\) \{/);
   assert.match(RENDER, /if \(activeId && !isProvisionalId\(activeId\) && sessions\.get\(activeId\)\) showForkPrompt\(activeId, ""\);/);
 });

--- a/ui/webview/palette-main.ts
+++ b/ui/webview/palette-main.ts
@@ -33,12 +33,19 @@ installMenuEcho();
   function pane(id: string): HTMLIFrameElement | null {
     return document.getElementById(id) as HTMLIFrameElement | null;
   }
+  // The chat column the user last worked in (split screen, the user 2026-09-08): every chat-directed
+  // command lands there — the shell's focus script tracks it (__rompFocusedChatId); the first column
+  // when there is no split, exactly as before.
+  function chatPane(): HTMLIFrameElement | null {
+    try { const id = w.__rompFocusedChatId && w.__rompFocusedChatId(); if (id) { const f = pane(id); if (f) return f; } } catch (e) { /* no split script */ }
+    return pane("f-chat");
+  }
   function chatPost(msg: object): void {
     // Reveal the chat pane if it's toggled off, focus it, and hand it the message. The
     // __romp* globals and the pane's message handlers are read lazily at RUN time, so boot
     // order across the shell's script tags doesn't matter.
     try { if (w.__rompPaneToggle) w.__rompPaneToggle("chat", true); } catch (e) { /* rail not booted yet */ }
-    const f = pane("f-chat");
+    const f = chatPane();
     try { f!.contentWindow!.focus(); f!.contentWindow!.postMessage(msg, "*"); }
     catch (e) { /* chat pane not loaded yet — nothing to talk to */ }
   }
@@ -56,12 +63,12 @@ installMenuEcho();
   type SwitchRow = { id: string; name: string; bg: string; dir: string };
   function chatSessions(): SwitchRow[] {
     try {
-      const ls = (pane("f-chat")?.contentWindow as any)?.__rompSessionList;
+      const ls = (chatPane()?.contentWindow as any)?.__rompSessionList;
       return ls ? ls().map((r: any) => ({ id: String(r.id), name: String(r.name), bg: String(r.bg || ""), dir: "" })) : [];
     } catch (e) { return []; }
   }
   function mruIds(): string[] {
-    try { return (pane("f-chat")?.contentWindow as any)?.__rompMru?.slice() || []; }
+    try { return (chatPane()?.contentWindow as any)?.__rompMru?.slice() || []; }
     catch (e) { return []; }
   }
   function sessionItems(locals: SessionRow[] | null): PickItem[] {
@@ -113,7 +120,7 @@ installMenuEcho();
     id: "session.fork", title: "Fork this session…",
     // the chat pane owns the modal (it knows the active session); from the palette the fork is
     // from-the-tip — the whole conversation (per-message forks live on the message's own hover row)
-    run: () => { try { pane("f-chat")!.contentWindow!.postMessage({ romp: "forkSession" }, "*"); } catch (e) { /* chat not loaded */ } },
+    run: () => { try { chatPane()!.contentWindow!.postMessage({ romp: "forkSession" }, "*"); } catch (e) { /* chat not loaded */ } },
   });
   registerCommand({
     id: "settings.open", title: "Open settings",
@@ -128,11 +135,11 @@ installMenuEcho();
   // (render.ts) reads the same bindings store, so a rebind moves both at once.
   registerCommand({
     id: "chat.navBack", title: "Navigate back in the chat",
-    run: () => { try { pane("f-chat")!.contentWindow!.postMessage({ romp: "chatNav", dir: -1 }, "*"); } catch (e) { /* chat not loaded */ } },
+    run: () => { try { chatPane()!.contentWindow!.postMessage({ romp: "chatNav", dir: -1 }, "*"); } catch (e) { /* chat not loaded */ } },
   });
   registerCommand({
     id: "chat.navForward", title: "Navigate forward in the chat",
-    run: () => { try { pane("f-chat")!.contentWindow!.postMessage({ romp: "chatNav", dir: 1 }, "*"); } catch (e) { /* chat not loaded */ } },
+    run: () => { try { chatPane()!.contentWindow!.postMessage({ romp: "chatNav", dir: 1 }, "*"); } catch (e) { /* chat not loaded */ } },
   });
   registerCommand({ id: "log.open", title: "Open the log", run: () => { if (w.__rompOpenErrs) w.__rompOpenErrs(); } });
   registerCommand({ id: "net.open", title: "Remote kernels", run: () => { if (w.__rompOpenNet) w.__rompOpenNet(); } });
@@ -159,12 +166,17 @@ installMenuEcho();
         : undefined,
     });
   }
+  // Split screen (the user 2026-09-08): another chat column beside the last one, and closing the one the
+  // user is in (the last one when the first column has the focus). The shell owns the columns
+  // (_LANDING_SPLIT_JS); the rail's split action runs the same code.
+  registerCommand({ id: "chat.split", title: "Split the chat", run: () => { if (w.__rompSplitChat) w.__rompSplitChat(); } });
+  registerCommand({ id: "chat.closeSplit", title: "Close this chat split", run: () => { if (w.__rompCloseSplit) w.__rompCloseSplit(); } });
 
   // Esc (or running an item) hands focus back to the chat pane, so "palette, Esc, type"
   // never strands the keyboard on the shell document. The palette's hotkey chips show each
   // command's EFFECTIVE binding (kbdFor), so a rebound command never advertises a stale default.
   const palette = initPalette({
-    onClose: () => { try { pane("f-chat")!.contentWindow!.focus(); } catch (e) { /* no chat pane */ } },
+    onClose: () => { try { chatPane()!.contentWindow!.focus(); } catch (e) { /* no chat pane */ } },
     kbdFor: (c) => { const ch = effectiveChord(c.id, c.chord, loadOverrides(), mac); return ch ? displayChord(ch, mac) : undefined; },
   });
   w.__rompPalette = palette;   // reachable by other shell scripts (e.g. a future mobile-bar button)
@@ -233,8 +245,7 @@ installMenuEcho();
   // (the /settings page, the gear's document since 2026-09-10) is wired with the panes: the gear
   // holds the keyboard while it is open, and the hotkey worked from inside it when it rode the feed.
   document.addEventListener("keydown", onKey, true);
-  ["f-chat", "f-fleet", "f-feed", "f-files", "f-timeline", "f-settings"].forEach((id) => {
-    const f = pane(id);
+  function wireKeys(f: HTMLIFrameElement | null): void {
     if (!f) return;
     const wire = () => {
       try { if (f.contentDocument) f.contentDocument.addEventListener("keydown", onKey, true); }
@@ -242,5 +253,11 @@ installMenuEcho();
     };
     f.addEventListener("load", wire);
     wire();
-  });
+  }
+  ["f-chat", "f-fleet", "f-feed", "f-files", "f-timeline", "f-settings"].forEach((id) => wireKeys(pane(id)));
+  // the split's chat columns too (the user 2026-09-08): the ones restored before this module booted (the
+  // shell's split script runs ahead of it, so their romp-chat-cols events fired into no listener), and any
+  // made later (the shell dispatches romp-chat-cols with the new frame) — so the chords work from every column
+  ((w.__rompChatFrameIds ? w.__rompChatFrameIds() : []) as string[]).forEach((id) => { if (id !== "f-chat") wireKeys(pane(id)); });
+  window.addEventListener("romp-chat-cols", (e) => wireKeys((((e as CustomEvent).detail || {}) as { frame?: HTMLIFrameElement }).frame || null));
 })();

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -306,3 +306,13 @@ test("queuedCountText: all notices → 'notice'; all nudges → 'nudge'; anythin
   assert.equal(countText(2, 0, 0, 0), "2 queued messages");
   assert.equal(countText(1, 1, 0, 0), "1 queued command");
 });
+
+test("the kernel's echo of a send another window made wears the sender's pending dress at the tail (the user 2026-09-10)", () => {
+  // one session in two split columns: the sender's column drew its dashed tail bubble, the other a solid user bubble at
+  // the send time above later steps — the kernel now orders the echo last (_merge_live_atoms) and the pane dresses it
+  assert.match(RENDER, /isKernelEchoUuid, newPending, mintQid/, "the one reader of the backend's echo prefix (send-pending.ts)");
+  assert.match(RENDER, /if \(!ev\.undelivered && !injected && isKernelEchoUuid\(ev\.uuid\)\) \{[^\n]*\n\s*turn\.classList\.add\("echo"\);\s*bubble\.classList\.add\("echo-bubble"\);/);
+  assert.match(RENDER, /note\.textContent = "sending…";/);
+  assert.match(CSS, /\.turn\.echo \.echo-bubble \{ border-style: dashed; border-color: color-mix\(in srgb, var\(--you\) 65%, transparent\); opacity: 0\.85; \}/);
+  assert.match(CSS, /\.echo-note \{ font-size: 0\.82em; color: var\(--dim\); letter-spacing: 0\.02em; text-align: right; \}/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6296,7 +6296,7 @@ function setSessionColor(id: string, bg: string) {
 
 // Small inline-SVG icon for the tab menu's toggle items (trusted constant markup; `off` slashes + dims it,
 // matching the timeline lane toggles). 16-unit viewBox; currentColor so .ctx-icon/.off set the tint.
-function ctxIcon(kind: "feed" | "mail" | "bell" | "bill" | "folder" | "tag" | "pencil", off: boolean): HTMLElement {
+function ctxIcon(kind: "feed" | "mail" | "bell" | "bill" | "folder" | "tag" | "pencil" | "split", off: boolean): HTMLElement {
   const span = el("span", "ctx-icon" + (off ? " off" : ""));
   const slash = off ? '<line x1="1.6" y1="14.4" x2="14.4" y2="1.6"/>' : "";
   const body = kind === "feed"
@@ -6309,6 +6309,8 @@ function ctxIcon(kind: "feed" | "mail" | "bell" | "bill" | "folder" | "tag" | "p
           ? '<path d="M2 4.5 A1.2 1.2 0 0 1 3.2 3.3 L6.2 3.3 L7.6 4.9 L12.8 4.9 A1.2 1.2 0 0 1 14 6.1 L14 11.5 A1.2 1.2 0 0 1 12.8 12.7 L3.2 12.7 A1.2 1.2 0 0 1 2 11.5 Z"/>'  // folder (browse files)
         : kind === "tag"
           ? '<path d="M2 3.4 A1.4 1.4 0 0 1 3.4 2 L7.6 2 A1.4 1.4 0 0 1 8.6 2.4 L13.6 7.4 A1.4 1.4 0 0 1 13.6 9.4 L9.4 13.6 A1.4 1.4 0 0 1 7.4 13.6 L2.4 8.6 A1.4 1.4 0 0 1 2 7.6 Z"/><circle cx="5.4" cy="5.4" r="1.1"/>'  // luggage tag (session tags)
+        : kind === "split"
+          ? '<rect x="2" y="3" width="5" height="10" rx="1"/><rect x="9" y="3" width="5" height="10" rx="1"/>'  // two columns side by side (open in a new split)
         : kind === "pencil"
           ? '<path d="M3 13 L3.6 10.4 L10.8 3.2 A1.3 1.3 0 0 1 12.8 5.2 L5.6 12.4 Z"/><line x1="9.8" y1="4.2" x2="11.8" y2="6.2"/>'  // pencil (rename)
           : '<path d="M8 2 C5.9 2.2 4.7 3.8 4.7 5.8 L4.7 8 L3.4 9.9 L12.6 9.9 L11.3 8 L11.3 5.8 C11.3 3.8 10.1 2.2 8 2 Z"/><path d="M6.6 11.6 A1.5 1.5 0 0 0 9.4 11.6"/>';  // bell (system notifications)
@@ -6352,6 +6354,27 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
     mv.appendChild(bodyEl);
     mv.addEventListener("click", (ev) => { ev.stopPropagation(); dismissTabMenu(); showMovePrompt(id); });
     menu.appendChild(mv);
+  }
+  // Open in new split (the user 2026-09-08, who wanted several sessions open at once instead of tabbing):
+  // another chat column beside the last one, opened on this session. The shell makes the column
+  // (_LANDING_SPLIT_JS) and hands it a focus; this pane only asks. Shell-hosted only — standalone and
+  // VS Code have no row to split — and only a shell that carries the split script.
+  const shellCanSplit = (() => {   // a shell with the split script, and one that can take another column right now (the cap, the phone)
+    try { const p = window.parent as any; return inRompShell() && typeof p.__rompSplitChat === "function" && (typeof p.__rompCanSplit !== "function" || !!p.__rompCanSplit()); }
+    catch (e) { return false; }
+  })();
+  if (shellCanSplit) {
+    const split = el("div", "ctx-item ctx-item-toggle");
+    split.appendChild(ctxIcon("split", false));
+    const bodyEl = el("span", "ctx-item-body");
+    const l = el("span", "ctx-item-label"); l.textContent = "Open in new split"; bodyEl.appendChild(l);
+    const sb = el("span", "ctx-item-sub"); sb.textContent = "another chat column beside this one, on this session"; bodyEl.appendChild(sb);
+    split.appendChild(bodyEl);
+    split.addEventListener("click", (ev) => {
+      ev.stopPropagation(); dismissTabMenu();
+      try { window.parent.postMessage({ romp: "openSplit", sid: id }, "*"); } catch (e) { /* no shell to ask */ }
+    });
+    menu.appendChild(split);
   }
   // Colors join Rename in the AESTHETIC section (the user 2026-08-24, the final by-kind grouping:
   // [Rename + colors] / [feed, mail, bell, billing, Tags] / [Browse]). The swatch row itself is
@@ -7305,6 +7328,20 @@ function revealSelfPane(): void {
     if (window.parent && window.parent !== window) window.parent.postMessage({ romp: "reveal", pane: "chat" }, "*");
   } catch (e) { /* standalone page — no shell to ask */ }
 }
+// Split screen (the user 2026-09-08): the kernel aims a focus at the DASHBOARD, so every chat column's socket
+// receives it, and the feed's click echo reaches every column's storage listener. The shell says which column
+// a session-focus belongs to (__rompChatTarget: the column already showing that session, else the one the
+// user last worked in, else the first) and the others stand down. Standalone and VS Code have no shell and
+// always act, exactly as before.
+function focusIsOurs(sid: string): boolean {
+  try {
+    if (!window.parent || window.parent === window) return true;
+    const t = (window.parent as any).__rompChatTarget;
+    if (typeof t !== "function") return true;   // a shell without the split script (an older page): one column
+    const f = t(sid);
+    return !f || f === window.frameElement;
+  } catch (e) { return true; }   // cross-origin parent (VS Code) — not the romp shell
+}
 
 // Full-screen bridge (the user 2026-07-05): the picker is rendered inside the /chat iframe, so its
 // position:fixed;inset:0 only covered the chat PANE — on a short pane the session list couldn't scroll.
@@ -7320,7 +7357,11 @@ function revealSelfPane(): void {
 // VS Code) falls back to that hiding via .pane-gone.
 function liftPaneRect(): DOMRect | null {
   try {
-    const p = window.parent?.document?.getElementById("chat-pane");
+    // THIS column's pane (split screen, the user 2026-09-08): a later column that measured #chat-pane pinned its
+    // transcript at the FIRST column's rect — the 2026-08-08/09 black-hole family in a new form. frameElement is
+    // the iframe the shell wrapped in a .pane; the id lookup stays as the fallback it always was.
+    const own = window.frameElement ? (window.frameElement as HTMLElement).parentElement : null;
+    const p = own || window.parent?.document?.getElementById("chat-pane");
     return p ? p.getBoundingClientRect() : null;
   } catch (e) { return null; }   // cross-origin parent (VS Code) — no shell pane to measure
 }
@@ -16364,6 +16405,7 @@ listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: M
   else if (m.type === "update") update(m);
   else if (m.type === "wsup") { onSocketUp(skeletonTabs); skeletonDiagArmed = true; reholdQueuedEditors(); }   // the shim's socket-flip marker, in FRAME order: the dead socket's frames may still be draining from the FIFO when onopen fires (review find 2026-09-07)
   else if (m.type === "status") statusOnly(m);
+  else if (m.type === "focus" && !m.own && !focusIsOurs(m.id)) { /* another chat column's (split screen): the shell named the column it belongs to; `own` is the shell's hand-over to THIS new column */ }
   else if (m.type === "focus") {
     revealSelfPane();   // every focus is someone jumping HERE — on mobile, come forward (incl. from a remote kernel)
     closingTabs.delete(m.id);   // an explicit reveal outranks a pending close-suppression: closing a tab and
@@ -16613,6 +16655,7 @@ listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: M
         closeTabLocally(m.id);   // same optimistic drop as the in-page ✕ — this path used to sit and wait
       });
   }
+  else if (m.type === "confirmRevive" && m.id && !m.own && !focusIsOurs(m.id)) { /* another chat column's prompt (split screen) — one dialog, not one per column; `own` is addressed to this column */ }
   else if (m.type === "confirmRevive" && m.id) {
     revealSelfPane();   // the dead-session prompt is drawn in THIS pane — useless if the pane isn't showing
     const nm = String(m.name || "");
@@ -18023,6 +18066,7 @@ window.addEventListener("storage", (e) => {
     const v = JSON.parse(e.newValue);
     const sid = typeof v.sid === "string" ? v.sid : "";
     if (!sid || (!sessions.has(sid) && !tabMeta.has(sid))) return;
+    if (!focusIsOurs(sid)) return;   // another chat column's (split screen): the echo reaches every column's listener
     revealSelfPane();
     closingTabs.delete(sid);
     assertPeekFor(sid);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -48,7 +48,7 @@ import { titleWithKey, chordOf, effectiveChord, loadOverrides } from "./keybindi
 import { DEFAULT_CHORDS } from "./commands";
 import { NavHistory } from "./nav-history";
 import { StagedStack, quoteReplyBody, stagedPosts } from "./staged-messages";
-import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, newPending, mintQid, reconcilePending, queuedCopyToHide, dropPending, bareGroupLabel, sentAtLabel, pendingBody } from "./send-pending";
+import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, isKernelEchoUuid, newPending, mintQid, reconcilePending, queuedCopyToHide, dropPending, bareGroupLabel, sentAtLabel, pendingBody } from "./send-pending";
 import { reconcileHeld, heldAsQueued, type HeldCopy, type HeldQueued, type HeldMemory } from "./queued-held";
 import { reloadHoldReason } from "./reload-hold";
 import { liveNotices, keepReloadNotices, takeReloadNotices } from "./reload-notices";
@@ -3314,6 +3314,20 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         turn.appendChild(notice({ src: "system", glyph: "system", gist, body: more ? bubble : null, nested: true,
                                   key: ev.uuid ? "hn:" + ev.uuid : undefined }));
       } else turn.appendChild(bubble);
+      // The kernel's ECHO of a send the model has not read yet, seen from a window that did not send it (the other
+      // column of a split, another browser): dressed as the sender's own tail bubble is — dashed, captioned
+      // "sending…" — so two views of one session agree on what is pending (the user 2026-09-10: one session in two
+      // columns, solid history in one and a pending bubble in the other). The kernel orders the echo at the turn's
+      // tail for the same reason (_merge_live_atoms); the sender's own window hides this event behind its bubble
+      // (hiddenByPending, above); a never-delivered echo takes the dress below instead.
+      if (!ev.undelivered && !injected && isKernelEchoUuid(ev.uuid)) {   // the backend's "echo:" prefix rides into the payload
+        turn.classList.add("echo");
+        bubble.classList.add("echo-bubble");
+        const note = el("div", "echo-note");
+        note.textContent = "sending…";
+        setTip(note, "On its way to the session. The window that sent it can still cancel it until the session takes it.");
+        turn.appendChild(note);
+      }
       // NEVER-DELIVERED send (kernel ev.undelivered, from the backend's dropped-echo marking): the
       // session's process died holding this message, so it was never seen — say so instead of letting
       // it pose as history (the user 2026-07-29: a two-day-old lost send kept resurfacing mid-chat as

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2035,6 +2035,11 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
   background: color-mix(in srgb, var(--you) 10%, transparent); border: 1px dashed color-mix(in srgb, var(--you) 65%, transparent);
   border-radius: 14px; padding: 7px 12px; color: var(--fg); opacity: 0.85;
 }
+/* the kernel's echo of a send ANOTHER window made, not yet read by the model: the sender's tail-bubble dress on the
+   user bubble it is drawn as — the same dashed border (its own 1px, so nothing shifts) and dim caption — so two views
+   of one session agree on what is pending (2026-09-10) */
+.turn.echo .echo-bubble { border-style: dashed; border-color: color-mix(in srgb, var(--you) 65%, transparent); opacity: 0.85; }
+.echo-note { font-size: 0.82em; color: var(--dim); letter-spacing: 0.02em; text-align: right; }
 .notice.queued-bubble, .notice.notice-slim.queued-bubble { max-width: none; display: block; }   /* the notice keeps its row
    width and flex head at either density; only the dress is the bubble's (the shared rule's specificities, later in the
    file). The boxed card too: it fills the column while provisional, so nothing snaps when the receipt lands. */

--- a/vscode-extension/src/tab-menu-flags.test.ts
+++ b/vscode-extension/src/tab-menu-flags.test.ts
@@ -28,7 +28,7 @@ test("the tab menu adds Feed + Mail toggle items with state-dependent labels", (
 });
 
 test("each toggle item carries an icon (slashed when off) and a sub-description", () => {
-  assert.match(SRC, /function ctxIcon\(kind: "feed" \| "mail" \| "bell" \| "bill" \| "folder" \| "tag" \| "pencil", off: boolean\)/);   // bill 2026-08-09; folder/tag/pencil 2026-08-24
+  assert.match(SRC, /function ctxIcon\(kind: "feed" \| "mail" \| "bell" \| "bill" \| "folder" \| "tag" \| "pencil" \| "split", off: boolean\)/);   // bill 2026-08-09; folder/tag/pencil 2026-08-24
   assert.match(SRC, /off \? '<line /);   // slash when the flag is off
   assert.match(SRC, /ctx-item-sub/);
   assert.match(CSS, /\.ctx-item-toggle \{ display: flex;/);


### PR DESCRIPTION
## What

The web dashboard's chat can be split into up to four columns, so several sessions sit side by side instead of behind each other's tabs. Every column is a full chat: its own tab strip, composer, active session, drafts and scroll place. Open one from a tab's right-click menu (**Open in new split**), or from the palette (**Split the chat**, `Mod+\`); close with the `×` in the column's corner or **Close this chat split**. The set of open columns and each column's width persist per browser. Phones never split.

## Design points

- **Shell-level columns, not a change to the chat pane's model.** Column 1 stays the served `#chat-pane` / `#f-chat`. Every later column is a client-made twin (`_LANDING_SPLIT_JS`) around an iframe at `/chat?col=N`, inserted before the outline gutter behind a `chat|chat` gutter of its own. `render.ts` keeps its single active tab; N columns are N chat clients, which the kernel already serves (each column's watched tab is built first, as today).
- **Per-column state without moving anyone's data.** The pane shim reads `?col=` and suffixes its persisted-state key (`romp-vscode-state-chat:N`) and its connect (`&col=`), so each column has its own active tab, drafts and scroll; column 1 keeps the unsuffixed key it always had. Browser-wide preferences (tags, view order, settings, keys) stay shared on purpose.
- **Focus arbitration is client-side and event-exact.** The kernel aims a focus, a revive prompt or a feed click at the dashboard, so every column receives it. The shell answers which column it belongs to (`__rompChatTarget`: the column already showing the session, else the one the user last worked in, else the first) and the others stand down (`focusIsOurs`). The shell's own hand-over to a new column, and the kernel's parked push-tap reveal (consumed by exactly one client), ride `own` and bypass the arbitration.
- **Existing shell services learn about later columns instead of assuming one.** The picker lift marks the asking frame (`.lifted`) rather than `#f-chat`; Alt+Arrow walks every column; the Log tracks each column's socket apart; the outline and feed gutters take the rightmost chat column as their neighbour; the palette's chat-directed commands land in the column last worked in; `activeSession()` reads it too.
- **A refused split says why** (the cap, the phone), and a split of a hidden chat group brings the group forward first.
- Found on the way, older than this change: the gutter grab normalised widths one pane at a time, so a read after a write came back at a mixed scale and a fresh browser's first drag ballooned the first column. The grab now reads every width before it writes.

## Tests

- `tests/test_chat_split.py`: source pins of the shell, shim and kernel, plus the split script executed in node against a DOM stub (open, order, persistence, arbitration, cap and its refusal, close, restore, phone).
- `tests/test_chat_split_served.py`: the served leg, a hermetic kernel with two synthetic sessions driven in headless Chromium (skips loudly without a browser, like the other served tests).
- `tests/test_pane_gutters.py`: the gutter script executed in node (fair grow never NaN, stored widths kept, registered columns, neighbours).
- `ui/webview/chat-split.test.ts`: the pane and palette halves at source.
- Pins that moved (lift selectors, gutter neighbour, visible columns, script count, icon kinds, the addressed reveal) are updated with their reasons. `docs/guide.md` gains a paragraph.

Not covered: the VS Code extension (a single chat panel there is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Creating a split:

<img width="1919" height="902" alt="Screenshot 2026-09-09 at 12 42 22 PM" src="https://github.com/user-attachments/assets/253f5932-73e4-4671-8d66-17698d402c23" />

What a split looks like:

<img width="1916" height="798" alt="Screenshot 2026-09-08 at 3 50 49 PM" src="https://github.com/user-attachments/assets/dff44917-c67c-46f0-bed8-070ad31b6e0c" />

Closing a split:

<img width="1919" height="878" alt="Screenshot 2026-09-09 at 12 42 37 PM" src="https://github.com/user-attachments/assets/9477bab9-b180-41e9-8e00-95591a3771ef" />
