### PR TITLE
Kernel: the timeline's dead lanes are derived once and served while their inputs stand; their parses are dropped

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -34477,7 +34477,7 @@ def _bind_message_execs(messages, turns):
 JUDGE_CAP_LIMIT = 80   # most-recent caption marks kept per session (the view merges adjacent marks anyway)
 
 
-def _derive_judging(sid, caps, goals, t0, out, seg_ends=None):
+def _derive_judging(sid, caps, goals, t0, out, seg_ends=None, stamp=False):
     """Append this session's JUDGE-activity marks to `out` — the second-timeline (data.judging) feed,
     read from the real artifacts the summarizer judges write (docs/judges.md):
       captioner ← captions/<sid>.jsonl   (one mark per segment/turn unit)
@@ -34495,11 +34495,19 @@ def _derive_judging(sid, caps, goals, t0, out, seg_ends=None):
     maps each segment's start t → its work-END t; a completion mark resolves through it to land just
     after the bar, where the work actually finished. CREATION marks (mint/sub) + captions stay at the
     start — a goal IS born when asked. Absent seg_ends (e.g. unit tests) → the old mt placement."""
+    # `stamp` (the dead-lane memo, 2026-09-08): every mark carries the value the horizon test compared
+    # under the private key "_h", so a lane cached once with t0 = 0 can be filtered later on exactly that
+    # value (the diary and distiller marks are COMPARED on their evidence time but EMITTED at the segment's
+    # work end, so a filter on the emitted `t` would not be the same set); _dead_lane_marks strips it.
+    def mark(h, m):
+        if stamp:
+            m["_h"] = h
+        out.append(m)
     endt = (lambda tt: seg_ends.get(tt, tt)) if seg_ends else (lambda tt: tt)   # completion → its segment's work-END
     caps_in = sorted((c for c in caps.values() if c.get("t") and c["t"] >= t0), key=lambda c: c["t"])
     for c in caps_in[-JUDGE_CAP_LIMIT:]:
-        out.append({"judge": "captioner", "sid": sid, "t": c["t"],
-                    "kind": c.get("grain", "segment"), "text": c.get("caption", "")})
+        mark(c["t"], {"judge": "captioner", "sid": sid, "t": c["t"],
+                      "kind": c.get("grain", "segment"), "text": c.get("caption", "")})
     for n in goals.get("nodes", {}).values():
         t = n.get("t")
         if not t:
@@ -34511,19 +34519,19 @@ def _derive_judging(sid, caps, goals, t0, out, seg_ends=None):
             # the grouper's surviving housekeeping (T103): merge/split/retitle append no diary
             # events by design, so the lane keys on the apply-time structure stamp — additive
             # beside the node's own mint/plant mark (a merged survivor is both)
-            out.append({"judge": "grouper", "sid": sid, "t": go["t"],
-                        "kind": go.get("kind") or "group", "text": text})
+            mark(go["t"], {"judge": "grouper", "sid": sid, "t": go["t"],
+                           "kind": go.get("kind") or "group", "text": text})
         if n.get("origin"):                                   # courier planted it from a peer's handoff
             if t >= t0:
-                out.append({"judge": "courier", "sid": sid, "t": t, "kind": "plant", "text": text})
+                mark(t, {"judge": "courier", "sid": sid, "t": t, "kind": "plant", "text": text})
         elif n.get("umbrella"):                               # ARCHIVED-history rendering only (T101
             # retired every umbrella mint; live containers dissolve each rollup) — an archived
             # pre-T101 container still shows the grouper mark it earned
             if mt >= t0:
-                out.append({"judge": "grouper", "sid": sid, "t": mt, "kind": "group", "text": text})
+                mark(mt, {"judge": "grouper", "sid": sid, "t": mt, "kind": "group", "text": text})
         elif t >= t0:                                         # planner placed it (top = mint, else a step)
-            out.append({"judge": "planner", "sid": sid, "t": t,
-                        "kind": ("mint" if not n.get("parentId") else "sub"), "text": text})
+            mark(t, {"judge": "planner", "sid": sid, "t": t,
+                     "kind": ("mint" if not n.get("parentId") else "sub"), "text": text})
         # done/block attribution reads the DIARY now (P3.4 2026-07-07): the event's src field IS the
         # provenance (negComplete/negBlock flags retired), each verdict gets its own mark at its own
         # evidence time, and reconstructed (synth) history never fakes a judging mark.
@@ -34531,33 +34539,75 @@ def _derive_judging(sid, caps, goals, t0, out, seg_ends=None):
             if _e.get("synth") or (_e.get("ev_t") or 0) < t0:
                 continue
             if _e.get("src") in ("planner", "closer") and _e.get("kind") in ("done", "block"):
-                out.append({"judge": _e["src"] if _e["src"] == "planner" else "closer", "sid": sid,
-                            "t": endt(_e["ev_t"]),
-                            "kind": ("done" if _e["src"] == "planner" else "close") if _e["kind"] == "done" else "block",
-                            "text": _e.get("why") or text})
+                mark(_e["ev_t"], {"judge": _e["src"] if _e["src"] == "planner" else "closer", "sid": sid,
+                                  "t": endt(_e["ev_t"]),
+                                  "kind": ("done" if _e["src"] == "planner" else "close") if _e["kind"] == "done" else "block",
+                                  "text": _e.get("why") or text})
         # distiller — key takeaway on a completed top goal. distilledMt == the goal's completion mt (the
         # completing segment's START); endt() lands the mark at that segment's work-END, just after the bar.
         # (The distiller LLM runs a pass later; the mark shows the work it summarizes, aligned to that work's
         # finish, not the judge's wall-clock run. A first sweep over the backlog still back-dates to old
         # completions, expected — the user 2026-06-17.)
         if n.get("distilledMt") and n["distilledMt"] >= t0:
-            out.append({"judge": "distiller", "sid": sid, "t": endt(n["distilledMt"]), "kind": "distill",
-                        "text": n.get("summary") or text})
+            mark(n["distilledMt"], {"judge": "distiller", "sid": sid, "t": endt(n["distilledMt"]), "kind": "distill",
+                                    "text": n.get("summary") or text})
         # block-distiller — the DECISION BRIEF on a BLOCKED top (briefedMt), the done-distiller's twin run
         # in the same pass. Same distiller row, a distinct kind ("brief"). Without this the brief popped up
         # on the card but left NO mark on the timeline, so the distiller row read as dead whenever the
         # recent work was blocks rather than completions (the user 2026-06-18). Lands at the block segment's
         # work-END via endt(), like the other completion marks.
         if n.get("briefedMt") and n["briefedMt"] >= t0:
-            out.append({"judge": "distiller", "sid": sid, "t": endt(n["briefedMt"]), "kind": "brief",
-                        "text": n.get("blockSummary") or text})
+            mark(n["briefedMt"], {"judge": "distiller", "sid": sid, "t": endt(n["briefedMt"]), "kind": "brief",
+                                  "text": n.get("blockSummary") or text})
     try:                                                      # archiver — the headline/abstract refresh
         arch = json.loads((jd.STATE / "archive" / (sid + ".json")).read_text(errors="replace"))
         if arch.get("t") and arch["t"] >= t0:
-            out.append({"judge": "archiver", "sid": sid, "t": arch["t"], "kind": "index",
-                        "text": arch.get("headline", "")})
+            mark(arch["t"], {"judge": "archiver", "sid": sid, "t": arch["t"], "kind": "index",
+                             "text": arch.get("headline", "")})
     except (OSError, ValueError):
         pass
+
+
+# ── the DEAD-LANE memo (2026-09-08): a timeline lane whose session is dead is re-derived only when an
+# input moves. The full build ran every cycle (the fleet signature's 5 s bucket turns over faster than a
+# 6 s cycle), and every rebuild parsed every lane's transcript and goals again — dead lanes included, the
+# majority within the 12 h window, none of which had changed. The memo holds the PARSE-DERIVED parts of a
+# dead lane (bars, compactions, the work end, and its judging marks stamped for the horizon filter) under a
+# key of every file they read; the clock-dependent parts (awaiting/compacting intervals, `since`) are
+# derived per build as before, so a cached lane's frame is byte-identical to a rebuilt one. Once a dead
+# lane is cached, its PARSE is dropped from _parse_cache: nothing else reads a dead session's parse per
+# cycle, and those parses were the bulk of a multi-GB resident set (a 166 MB transcript parses to ~220 MB).
+_dead_lane_memo = {}      # sid -> (key, {"bars", "compactions", "last_t", "marks"})
+_DEAD_LANE_MEMO_MAX = 512
+
+
+def _stat_key(p):
+    try:
+        st = os.stat(p)
+        return (st.st_mtime_ns, st.st_size, st.st_ino)
+    except OSError:
+        return None
+
+
+def _dead_lane_key(sid, path, branch):
+    """Every input the parse-derived parts of a dead lane read: the transcript and its states file (the
+    parse), the goals store (seams, judging), the captions and the archive (judging), the session flags
+    (the blocked state), and the branch clip. None when the transcript cannot be stat'd (never cache)."""
+    tk = _stat_key(path)
+    if tk is None:
+        return None
+    return (tk, _stat_key(jd.STATE / "states" / (sid + ".jsonl")), _stat_key(jd.GOALDIR / (sid + ".json")),
+            _stat_key(jd.STATE / "overrides" / (sid + ".jsonl")),   # the store's user-override journal, replayed on load
+            _stat_key(jd.CAPDIR / (sid + ".jsonl")),                # the file _captions(sid) reads
+            _stat_key(jd.STATE / "archive" / (sid + ".json")),
+            _stat_key(jd.STATE / "session-flags.json"),
+            (branch or {}).get("fromId"), (branch or {}).get("t"), (branch or {}).get("cut"))
+
+
+def _dead_lane_marks(marks, t0):
+    """The cached marks a build at horizon `t0` would have derived: filtered on the stamped compare value
+    and handed out without it, as fresh dicts (the frame is serialized and the memo's are shared)."""
+    return [{k: v for k, v in m.items() if k != "_h"} for m in marks if m.get("_h", 0) >= t0]
 
 
 _session_tok_cache = {}   # transcript path -> ((mtime, size), [(t, in, out, cache_w, cache_r, model), ...]): one
@@ -35167,7 +35217,17 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
         goals, gfault = jd.load_goals_shared_or_fault(sid)   # read-only view (seams + judging marks); a FAULT (row
         if gfault is not None:                       # filed) → None: this lane renders without goal-derived data
             _bars_complain(sid, "goals", gfault)     # (blocked state, seams, marks) and the frame ships for every other lane
-        if with_bars:
+        # a DEAD lane's parse-derived parts are served from the memo while every input they read stands
+        # (see _dead_lane_memo); a goals fault is never cached (the lane's marks are missing, loudly)
+        lane_key = _dead_lane_key(sid, s["path"], branch_of.get(sid)) if (with_bars and not live and gfault is None) else None
+        lane_hit = _dead_lane_memo.get(sid) if lane_key is not None else None
+        if lane_hit is not None and lane_hit[0] != lane_key:
+            lane_hit = None
+        if lane_hit is not None:
+            cached = lane_hit[1]
+            session = None; caps = {}; st_turns = []; open_now = False
+            _VIEW_STATS["laneServe"] = _VIEW_STATS.get("laneServe", 0) + 1
+        elif with_bars:
             try:
                 session = _parse(s["path"], sid, now)
             except Exception as e:
@@ -35236,6 +35296,8 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
             state = "needsInput" if blocked else "idle"   # muted → no awaiting/background-task badge on the lane
             aw_open = open_now                          # unused (awaitingBg is None for a dead lane) — kept defined
         bars, last_t, seg_ends = [], None, {}            # seg_ends: seg-start t → work-END t (for completion marks)
+        if lane_hit is not None:
+            bars, last_t = cached["bars"], cached["last_t"]
         for ti, turn in enumerate(st_turns):
             turn_open = (live and ti == len(st_turns) - 1 and not turn["ended"]
                          and not any(x["type"] == "idle" for x in turn["atoms"])
@@ -35295,17 +35357,40 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
                 last_t = os.stat(s["path"]).st_mtime     # lane `since` ≈ the transcript's last write (last activity), no parse
             except OSError:
                 pass
-        if with_bars:
+        _bft = (branch_of.get(sid) or {}).get("t")
+        if lane_hit is not None:
             turns[sid] = bars
+            semantic.extend(_dead_lane_marks(cached["marks"], now - TL_HORIZON))
+            compactions = cached["compactions"]
+        elif with_bars:
+            turns[sid] = bars
+            marks = []
             try:
                 if goals is not None:
-                    _derive_judging(sid, caps, goals, now - TL_HORIZON, semantic, seg_ends)
+                    # a dead lane's marks are derived ONCE at horizon 0 and stamped, so the memo can filter
+                    # them per build on exactly the value this call would have compared (_dead_lane_marks)
+                    if lane_key is not None:
+                        _derive_judging(sid, caps, goals, 0, marks, seg_ends, stamp=True)
+                        semantic.extend(_dead_lane_marks(marks, now - TL_HORIZON))
+                    else:
+                        _derive_judging(sid, caps, goals, now - TL_HORIZON, semantic, seg_ends)
             except Exception as e:
                 _bars_complain(sid, "judging-marks", e)   # this lane loses its marks, the frame ships
-        _bft = (branch_of.get(sid) or {}).get("t")
-        compactions = [{"t": a["t"]} for turn in st_turns for a in turn["atoms"]
-                       if a.get("type") == "system" and a.get("subtype") == "compact_boundary" and a.get("t")
-                       and not (_bft and a["t"] <= _bft)]           # copied boundaries stay on the parent's lane
+                lane_key = None                            # never cache a lane whose marks failed
+            compactions = [{"t": a["t"]} for turn in st_turns for a in turn["atoms"]
+                           if a.get("type") == "system" and a.get("subtype") == "compact_boundary" and a.get("t")
+                           and not (_bft and a["t"] <= _bft)]       # copied boundaries stay on the parent's lane
+            if lane_key is not None:
+                if len(_dead_lane_memo) > _DEAD_LANE_MEMO_MAX:      # bounded by the lane window; evict oldest-inserted
+                    _dead_lane_memo.pop(next(iter(_dead_lane_memo)))
+                _dead_lane_memo[sid] = (lane_key, {"bars": bars, "compactions": compactions, "last_t": last_t, "marks": marks})
+                # the parse has done its work for this dead lane: drop it (the RSS lever); a lane that moves
+                # re-parses once, and a session that revives is parsed by its chat build as before
+                _parse_cache.pop(s["path"], None)
+        else:
+            compactions = [{"t": a["t"]} for turn in st_turns for a in turn["atoms"]
+                           if a.get("type") == "system" and a.get("subtype") == "compact_boundary" and a.get("t")
+                           and not (_bft and a["t"] <= _bft)]       # copied boundaries stay on the parent's lane
         # Idle fade: the SAME rule the chat tab uses (ready + idle > 1h — see the `faded` beside the chat
         # chip), keyed on the DERIVED chip `state` computed above, not the raw tmux state. The old form read
         # tmux's vocabulary and counted "waiting" as active — but "waiting" IS the post-turn idle state, so
@@ -36302,13 +36387,23 @@ def _delta_key(kind, it, prefix=""):
     return _delta_keyer(kind)(it, prefix)
 
 
-def _delta_split(kind, value):
+_delta_entry_memo = {}   # (frame type, collection) -> {id(entry): (entry, json)} from the LAST split: an entry
+#                          object the builder reused (a memoized dead lane's bar dicts) is not encoded again
+
+
+def _delta_split(kind, value, memo_key=None):
     """Entries of one collection as {key: (object, json)} plus the key order, per the kind table above. A
     list item that cannot be keyed, or a duplicate key, takes a positional key ('#n') — exact, since the
-    shim rebuilds in key order, just less delta-friendly."""
+    shim rebuilds in key order, just less delta-friendly. With `memo_key`, an entry that is the SAME OBJECT
+    as one the previous split of that collection encoded takes its string from that split (the identity is
+    checked, never an id alone); the memo is rebuilt from this split's entries, so it never outgrows one
+    build (2026-09-08: the bars frame re-encoded every bar of every lane on every build, ~15 MB a cycle,
+    when only the live lanes' bars were new objects)."""
     ents, order = {}, []
     enc = json.JSONEncoder(default=_wire_default_in("_delta_split")).encode   # one encoder for the thousand entries, not one each
     key = _delta_keyer(kind)                            # …and the kind parsed once, not per item
+    prev = _delta_entry_memo.get(memo_key) if memo_key is not None else None
+    cur = {} if memo_key is not None else None
     def put(kk, v, pre=""):
         if kk is None or kk in ents:
             n = len(order)
@@ -36317,7 +36412,11 @@ def _delta_split(kind, value):
                 if kk not in ents:
                     break
                 n += 1
-        ents[kk] = (v, enc(v)); order.append(kk)
+        hit = prev.get(id(v)) if prev else None
+        js = hit[1] if (hit is not None and hit[0] is v) else enc(v)
+        if cur is not None:
+            cur[id(v)] = (v, js)
+        ents[kk] = (v, js); order.append(kk)
     if kind == "dict" and isinstance(value, dict):
         for kk, v in value.items():
             put(str(kk), v)
@@ -36340,6 +36439,8 @@ def _delta_split(kind, value):
         # something else, with no resync ever asked (review find, 2026-09-04). Unkeyable → the whole frame goes.
         raise ValueError("%s collection is a %s, not a %s" % (
             kind, type(value).__name__, "dict" if kind == "dict" or kind.startswith("dictlist:") else "list"))
+    if cur is not None:
+        _delta_entry_memo[memo_key] = cur
     return ents, order
 
 
@@ -36362,7 +36463,7 @@ def _delta_parts(ftype, payload):
                 continue
             _wire_bump("split_miss")
             try:
-                colls[name] = _delta_split(kind, value)
+                colls[name] = _delta_split(kind, value, memo_key=(ftype, name))
             except ValueError as e:
                 raise ValueError("%s: %s" % (name, e)) from None     # name the collection for the log line
             _delta_split_memo[(ftype, name)] = (value, colls[name])

--- a/tests/test_timeline_lane_memo.py
+++ b/tests/test_timeline_lane_memo.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""The timeline's DEAD-LANE memo (2026-09-08): a lane whose session is dead is re-derived only when an input moves.
+
+The full timeline build ran every pusher cycle (the fleet signature's 5 s bucket turns over faster than a 6 s
+cycle) and re-parsed every lane's transcript and goals each time, dead lanes included. Now a dead lane's
+parse-derived parts (bars, compactions, the work end, its judging marks) are served from a memo keyed on
+every file they read, its parse is dropped from _parse_cache once cached (the resident-memory lever), and the
+served frame is byte-identical to a rebuilt one: the judging marks are derived once at horizon zero, stamped
+with the value the horizon test compares, and filtered per build on exactly that. The bars encoder reuses the
+strings of entry objects it already encoded.
+
+Synthetic transcript, states and captions under a temp root; a placeholder sid; the lane is dead because the
+liveness snapshot is empty."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_lane_memo", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+NOW = 1_800_000_000
+T0 = NOW - 3600
+
+
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _rec(kind, t, uuid, parent, text):
+    if kind == "user":
+        return {"type": "user", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent, "promptSource": "typed",
+                "message": {"role": "user", "content": text}}
+    return {"type": "assistant", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}], "stop_reason": "end_turn"}}
+
+
+class DeadLaneMemo(unittest.TestCase):
+    def setUp(self):
+        km._downtime[:] = []
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        pdir = proj / km.jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        pdir.mkdir(parents=True)
+        self.recs = [_rec("user", T0, "u1", None, "run the long benchmark"),
+                     _rec("assistant", T0 + 10, "a1", "u1", "Launched it.")]
+        self.tpath = pdir / (SID + ".jsonl")
+        self._write(self.recs)
+        names = td / "names"; names.mkdir()
+        (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
+        self.saved = (km.jd.NAMES, km.jd.PROJECTS, km.jd.GOALDIR, km.jd.CAPDIR, km.jd.STATE, km.NAMES, km._tmux_sessions)
+        km.jd.NAMES, km.jd.PROJECTS, km.jd.GOALDIR, km.jd.CAPDIR = names, proj, td / "goals", td / "captions"
+        km.jd.STATE = td
+        km.NAMES = names
+        km._tmux_sessions = lambda: {}                 # NOBODY is live: the lane is a dead one within the window
+        (td / "states").mkdir(); (td / "captions").mkdir(); (td / "goals").mkdir()
+        (td / "goals" / (SID + ".json")).write_text(json.dumps({"nodes": {}, "status": {}}))   # the judging marks need a store
+        self.caps = td / "captions" / (SID + ".jsonl")
+        km._parse_cache.pop(str(self.tpath), None)
+        km._dead_lane_memo.clear()
+        km._delta_entry_memo.clear()
+
+    def tearDown(self):
+        (km.jd.NAMES, km.jd.PROJECTS, km.jd.GOALDIR, km.jd.CAPDIR, km.jd.STATE, km.NAMES, km._tmux_sessions) = self.saved
+        km._dead_lane_memo.clear()
+        self.td.cleanup()
+
+    def _write(self, recs):
+        self.tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        os.utime(self.tpath, (NOW - 30, NOW - 30))    # recently touched: a lane within the 12 h window
+
+    def _build(self, now=NOW):
+        return km.build_timeline(now, {}, with_bars=True)
+
+    def _lane(self, tl):
+        return next(s for s in tl["sessions"] if s["id"] == SID)
+
+    def test_the_second_build_serves_the_lane_without_a_parse_and_drops_the_parse(self):
+        parses = []
+        real = km._parse
+        km._parse = lambda path, sid, now: (parses.append(path), real(path, sid, now))[1]
+        try:
+            tl1 = self._build()
+            self.assertEqual(parses, [str(self.tpath)], "the first build parses the dead lane once")
+            self.assertNotIn(str(self.tpath), km._parse_cache, "and drops the parse once the lane is cached")
+            self.assertIn(SID, km._dead_lane_memo)
+            tl2 = self._build()
+            self.assertEqual(len(parses), 1, "the second build serves the lane: no parse")
+            self.assertEqual(tl1["turns"][SID], tl2["turns"][SID])
+            self.assertEqual(self._lane(tl1), self._lane(tl2), "a served lane is the rebuilt lane, byte for byte")
+            self.assertEqual([m for m in tl1["judging"] if m["sid"] == SID], [m for m in tl2["judging"] if m["sid"] == SID])
+            self.assertFalse(any("_h" in m for m in tl2["judging"]), "the horizon stamp never reaches the wire")
+        finally:
+            km._parse = real
+
+    def test_a_moved_transcript_re_derives_the_lane(self):
+        self._build()
+        recs = self.recs + [_rec("user", T0 + 600, "u2", "a1", "and the cap?"),
+                            _rec("assistant", T0 + 610, "a2", "u2", "Two minutes.")]
+        self._write(recs)
+        os.utime(self.tpath, (NOW - 20, NOW - 20))
+        tl = self._build()
+        self.assertEqual(len(tl["turns"][SID]), 2, "the new turn is drawn")
+        self.assertEqual(km._dead_lane_memo[SID][1]["bars"], tl["turns"][SID])
+
+    def test_the_memo_keeps_stamped_marks_and_the_wire_never_sees_the_stamp(self):
+        cap_t = NOW - km.TL_HORIZON + 30
+        self.caps.write_text(json.dumps({"id": "u1", "t": cap_t, "caption": "launched the benchmark",
+                                         "grain": "segment"}) + "\n")
+        tl = self._build(NOW)
+        marks = km._dead_lane_memo[SID][1]["marks"]
+        self.assertEqual([(m["judge"], m["_h"]) for m in marks], [("captioner", cap_t)], "derived once, stamped")
+        self.assertFalse(any("_h" in m for m in tl["judging"]), "the stamp never reaches the wire")
+
+    def test_a_live_lane_is_not_memoized(self):
+        km._tmux_sessions = lambda: {SID: {"state": "waiting", "since": NOW - 100, "model": "", "effort": "",
+                                           "context": None, "compactPct": None, "color": None, "mode": ""}}
+        km.build_timeline(NOW, km._tmux_sessions(), with_bars=True)
+        self.assertNotIn(SID, km._dead_lane_memo)
+
+
+class HorizonFilterIsExact(unittest.TestCase):
+    """The cached marks filtered on their stamped compare value are the marks a fresh derivation at that
+    horizon would append, mark for mark: the diary and distiller marks are compared on their EVIDENCE time
+    but emitted at the segment's work END, so a filter on the emitted time would admit a mark the fresh
+    derivation drops (evidence before the horizon, work end after it). Pure functions, synthetic inputs."""
+
+    def _inputs(self):
+        h = 1_700_000_000
+        caps = {"c%d" % i: {"id": "c%d" % i, "t": h - 100 + i * 50, "caption": "cap %d" % i, "grain": "segment"} for i in range(6)}
+        goals = {"nodes": {
+            "g1": {"t": h - 40, "mt": h + 10, "text": "old mint, done after the horizon",
+                   "log": [{"src": "closer", "kind": "done", "ev_t": h - 5, "why": "evidence just before the horizon"}]},
+            "g2": {"t": h + 20, "mt": h + 30, "text": "new mint", "distilledMt": h - 20, "briefedMt": h + 40},
+        }}
+        seg_ends = {h - 5: h + 300, h - 20: h + 400}      # completion marks land at the work END, after the horizon
+        return h, caps, goals, seg_ends
+
+    def test_filtered_stamped_marks_equal_a_fresh_derivation(self):
+        h, caps, goals, seg_ends = self._inputs()
+        for t0 in (h - 1000, h - 10, h, h + 15, h + 35, h + 1000):
+            fresh = []
+            km._derive_judging("s", caps, goals, t0, fresh, seg_ends)
+            stamped = []
+            km._derive_judging("s", caps, goals, 0, stamped, seg_ends, stamp=True)
+            self.assertEqual(km._dead_lane_marks(stamped, t0), fresh, "horizon %+d" % (t0 - h))
+        fresh = []
+        km._derive_judging("s", caps, goals, h, fresh, seg_ends)
+        self.assertFalse(any(m["judge"] == "closer" for m in fresh), "evidence before the horizon: dropped")
+        self.assertTrue(any(m["judge"] == "distiller" and m["kind"] == "brief" for m in fresh))
+
+    def test_the_stamp_is_private(self):
+        h, caps, goals, seg_ends = self._inputs()
+        stamped = []
+        km._derive_judging("s", caps, goals, 0, stamped, seg_ends, stamp=True)
+        self.assertTrue(stamped and all("_h" in m for m in stamped))
+        self.assertFalse(any("_h" in m for m in km._dead_lane_marks(stamped, 0)))
+
+
+class EntryEncodeMemo(unittest.TestCase):
+    def test_an_entry_object_seen_last_split_is_not_encoded_again(self):
+        km._delta_entry_memo.clear()
+        sep = km._DELTA_SEP
+        b1, b2 = {"id": "b1", "start": 1, "end": 2}, {"id": "b2", "start": 3, "end": 4}
+        ents1, _ = km._delta_split("dictlist:id", {"S": [b1, b2]}, memo_key=("bars", "turns"))
+        b3 = {"id": "b3", "start": 5, "end": 6}
+        ents2, _ = km._delta_split("dictlist:id", {"S": [b1, b3]}, memo_key=("bars", "turns"))
+        self.assertIs(ents2["S" + sep + "b1"][1], ents1["S" + sep + "b1"][1], "the same object: the same string, not re-encoded")
+        self.assertEqual(json.loads(ents2["S" + sep + "b3"][1]), b3)
+        self.assertNotIn(id(b2), km._delta_entry_memo[("bars", "turns")], "the memo is rebuilt from THIS split: no growth")
+        b1b = dict(b1)                                   # equal content, a NEW object: encoded afresh (identity, never equality)
+        ents3, _ = km._delta_split("dictlist:id", {"S": [b1b]}, memo_key=("bars", "turns"))
+        self.assertEqual(ents3["S" + sep + "b1"][1], ents1["S" + sep + "b1"][1])
+        self.assertIsNot(ents3["S" + sep + "b1"][1], ents1["S" + sep + "b1"][1])
+
+    def test_the_wire_fill_hands_the_collection_key_down(self):
+        import inspect
+        self.assertIn("_delta_split(kind, value, memo_key=(ftype, name))", inspect.getsource(km._delta_parts))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_timeline_lane_memo.py
+++ b/tests/test_timeline_lane_memo.py
@@ -123,6 +123,47 @@ class DeadLaneMemo(unittest.TestCase):
         self.assertEqual([(m["judge"], m["_h"]) for m in marks], [("captioner", cap_t)], "derived once, stamped")
         self.assertFalse(any("_h" in m for m in tl["judging"]), "the stamp never reaches the wire")
 
+    def test_every_keyed_input_re_derives_the_lane_when_it_moves(self):
+        """The key is every file the parse-derived parts read, not the transcript alone (the review of the
+        first batch found a key pinned on one component): touching each one changes the memo's key and the
+        lane is derived again."""
+        td = Path(self.td.name)
+        self._build()
+        key0 = km._dead_lane_memo[SID][0]
+        inputs = [td / "states" / (SID + ".jsonl"), td / "goals" / (SID + ".json"),
+                  td / "overrides" / (SID + ".jsonl"), td / "captions" / (SID + ".jsonl"),
+                  td / "archive" / (SID + ".json"), td / "session-flags.json"]
+        seen = {key0}
+        for i, p in enumerate(inputs):
+            p.parent.mkdir(parents=True, exist_ok=True)
+            if p.name == SID + ".json" and p.parent.name == "goals":
+                p.write_text(json.dumps({"nodes": {}, "status": {}, "touched": i}))
+            elif p.suffix == ".json":
+                p.write_text(json.dumps({"touched": i}))
+            else:
+                p.write_text("")
+            os.utime(p, (NOW - 10 + i, NOW - 10 + i))
+            self._build()
+            key = km._dead_lane_memo[SID][0]
+            self.assertNotIn(key, seen, "%s moved but the key did not" % p.name)
+            seen.add(key)
+        self._build()
+        self.assertEqual(km._dead_lane_memo[SID][0], key, "nothing moved: the key stands")
+
+    def test_a_lane_whose_goals_store_cannot_be_read_is_never_cached(self):
+        """A goals FAULT is a store that cannot be read (an OSError; malformed bytes are healed by the loader):
+        the lane renders without goal-derived data, complains, and is derived again on every build rather
+        than served from a memo that would silence the fault."""
+        store = Path(self.td.name) / "goals" / (SID + ".json")
+        store.chmod(0)
+        try:
+            self._build()
+            self.assertNotIn(SID, km._dead_lane_memo, "a faulted store stays loud on every build, never served stale")
+        finally:
+            store.chmod(0o600)
+        self._build()
+        self.assertIn(SID, km._dead_lane_memo, "readable again: cached like any other dead lane")
+
     def test_a_live_lane_is_not_memoized(self):
         km._tmux_sessions = lambda: {SID: {"state": "waiting", "since": NOW - 100, "model": "", "effort": "",
                                            "context": None, "compactPct": None, "color": None, "mode": ""}}

--- a/tests/test_wire_once_per_build.py
+++ b/tests/test_wire_once_per_build.py
@@ -135,7 +135,7 @@ class OneEncodePerBuild(unittest.TestCase):
         tl = _client("timeline")                                  # every timeline pane: slot deltas
         splits = collections.Counter()
         real_split = km._delta_split
-        with mock.patch.object(km, "_delta_split", side_effect=lambda kind, v: splits.update([kind]) or real_split(kind, v)):
+        with mock.patch.object(km, "_delta_split", side_effect=lambda kind, v, **kw: splits.update([kind]) or real_split(kind, v, **kw)):
             s0 = dict(km._wire_stats)
             km._push([dfeed, legacy, tl])
             self.assertEqual(sum(splits.values()), 4, "one per-entry pass per payload: the feed's one collection, the bars' three")
@@ -228,7 +228,7 @@ class ALedgersOnlyRefillEncodesNoCard(unittest.TestCase):
         first = dict(src, ledgers=[{"sid": SID, "name": "web", "status": "idle"}])
         refill = dict(src, ledgers=[{"sid": SID, "name": "web", "status": "working"}])   # the same asks list, another remainder
         splits = collections.Counter(); real_split = km._delta_split
-        with mock.patch.object(km, "_delta_split", side_effect=lambda kind, v: splits.update([kind]) or real_split(kind, v)):
+        with mock.patch.object(km, "_delta_split", side_effect=lambda kind, v, **kw: splits.update([kind]) or real_split(kind, v, **kw)):
             s0 = dict(km._wire_stats)
             p1 = km._delta_parts("feed", first)
             self.assertEqual(dict(splits), {"byid:itemId": 1}); self.assertEqual(_delta(km._wire_stats, s0), {"split_miss": 1})
@@ -255,7 +255,7 @@ class ALedgersOnlyRefillEncodesNoCard(unittest.TestCase):
         w = _World(self, feed=_feed())
         board, dfeed = _client("fleet"), _client("feed")
         splits = collections.Counter(); real_split = km._delta_split
-        with mock.patch.object(km, "_delta_split", side_effect=lambda kind, v: splits.update([kind]) or real_split(kind, v)):
+        with mock.patch.object(km, "_delta_split", side_effect=lambda kind, v, **kw: splits.update([kind]) or real_split(kind, v, **kw)):
             s0 = dict(km._wire_stats)
             km._push([board])                                     # an app="fleet" client: the cycle attaches ledgers to the copy
             self.assertEqual(dict(splits), {"byid:itemId": 1}); self.assertEqual(km._feed_wire[1], [])
@@ -278,7 +278,7 @@ class ALedgersOnlyRefillEncodesNoCard(unittest.TestCase):
         _World(self)
         tl = _timeline(nbars=3)
         splits = collections.Counter(); real_split = km._delta_split
-        with mock.patch.object(km, "_delta_split", side_effect=lambda kind, v: splits.update([kind]) or real_split(kind, v)):
+        with mock.patch.object(km, "_delta_split", side_effect=lambda kind, v, **kw: splits.update([kind]) or real_split(kind, v, **kw)):
             s0 = dict(km._wire_stats)
             p1 = km._delta_parts("bars", _bars_of(tl, warming=True))
             self.assertEqual(sum(splits.values()), 3); self.assertEqual(_delta(km._wire_stats, s0), {"split_miss": 3})


### PR DESCRIPTION
## What

The second batch of the idle-kernel work; the first (the pusher's change gates, #1113) halved the CPU and left the resident set where it was. This batch is the memory lever and the rest of the timeline's per-cycle cost.

`/perf` on the maintainer's devbox showed the timeline rebuilt on every pusher cycle with zero cache hits: the dashboard signature's 5 s bucket turns over faster than a 6 s cycle, and every rebuild re-parsed every lane's transcript and goals, dead lanes included (the majority within the 12 h window, none of which had changed), then re-encoded every bar of every lane into a 15 MB frame.

- **A dead lane is derived once and served while its inputs stand.** Its parse-derived parts (bars, compactions, the work end, its judging marks) are memoized per lane, keyed on the stat of every file they read: the transcript and its states file, the goals store and its user-override journal (replayed onto the store on every load, so an override moves the goals without moving the store file), the captions file the builder reads, the archive, the session flags, and the branch clip. The clock-dependent parts (awaiting and compacting intervals, `since`) are derived per build as before, so a served lane's frame is byte-identical to a rebuilt one. A goals fault or a marks failure is never cached. Live lanes are untouched.
- **Judging marks are derived once at horizon zero and stamped** with the value the horizon test compares, then filtered per build on exactly that and handed out without the stamp. The stamp matters: the diary and distiller marks are compared on their evidence time but emitted at the segment's work end, so a filter on the emitted time would admit marks a fresh derivation drops.
- **A cached dead lane's parse is dropped from the parse cache.** Nothing else reads a dead session's parse per cycle, and those parses were the bulk of a multi-GB resident set (a 166 MB transcript parses to about 220 MB; two caches held one each). A lane that moves re-parses once; a session that revives is parsed by its chat build as before.
- **The bars encoder reuses the JSON string** of an entry object it encoded in the previous split of the same collection (identity checked, never an id alone; the memo is rebuilt from each split, so it never outgrows one build).

## Before and after

| measure | before (13 min after boot) | after the first batch (12 min after boot) | after this batch |
|---|---|---|---|
| process CPU | about 88% of a core | about 40% of a core | to be posted here after it lands |
| timeline builds | 84 built, 0 served | 17 built, 0 served | |
| resident set | 4.4 GB + 1.4 GB swap | 4.3 GB + 1.1 GB swap | |

## Tier

`fix`: behaviour is unchanged by design (a served lane is byte-identical to a rebuilt one); the work is the timeline doing less of it.

## Tests

`tests/test_timeline_lane_memo.py` (new) builds a real dead lane from a synthetic transcript: the second build serves it with no parse and the parse is gone from the cache, the served lane and bars equal the rebuilt ones, a moved transcript re-derives, a live lane is never memoized, the stamp never reaches the wire; the stamped derivation filtered at six horizons equals a fresh derivation mark for mark, including the straddling closer mark; the entry memo reuses strings by identity and never grows. The wire test's splitter doubles pass the collection key through. Timeline, delta, wire, perf, isolation, change-gate and comment-thread suites: 306 passed on the rebased head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
