### PR TITLE
tests: the postal token fixture owns its state directory, so its cases pass alone

### DIFF
--- a/tests/test_postal_token.py
+++ b/tests/test_postal_token.py
@@ -335,6 +335,12 @@ class _PostalTokenFile(unittest.TestCase):
     def setUp(self):
         self.f = ps.STATE.parent / "serve-token"
         self.lock = self.f.with_name("serve-token.lock")
+        # The fixture owns its state directory (T274, 2026-09-08): the module's XDG_STATE_HOME is a fresh temp dir,
+        # and only the two minting cases (birth, the flock race) create STATE.parent through the loader. Run alone —
+        # a parallel worker scheduling one of the other six by itself — those wrote the token, the lock, or the
+        # symlink into a directory that did not exist yet and failed on the parent, then again in _restore. Serially
+        # they passed on a sibling's side effect, which is not a fixture.
+        self.f.parent.mkdir(parents=True, exist_ok=True)
         self._env = self._umask = None
         self.addCleanup(self._restore)      # registered FIRST: a failing _clear() must not leak a zeroed umask
         self._env = os.environ.pop("ROMP_SERVE_TOKEN", None)


### PR DESCRIPTION
## Summary
Six cases in `tests/test_postal_token.py` depended on a sibling test's side effect and failed when scheduled alone (as the parallel runner does). The fixture now creates its own state directory.

## Why
The module's `XDG_STATE_HOME` is a fresh temp dir, and only the two minting cases (the token's birth, the flock race) create `STATE.parent`, through the loader. Run alone, the other six (unreadable token, the two tighten cases, the symlink refusal, the empty-file mint, the lock-failure case) wrote the token, the lock or the symlink into a directory that did not exist yet and failed on the parent, then failed again in the fixture's own restore. Serially the file passed on the sibling's side effect, which is not a fixture.

## Proof
- Each of the six alone in a fresh `XDG_STATE_HOME` with `-p no:cacheprovider`: red before, green after.
- The whole file serially: 31 passed. Under `pytest -n 6`, three runs: 31 passed each.

Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)