### PR TITLE
Auto-reload: the upload hold counts only ships whose ack can still arrive, and a held reload wears a line

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -40356,7 +40356,10 @@ body{font-family:var(--vscode-font-family);font-size:13px;color:var(--vscode-for
 # shell's own core existed (it reads as standalone then), consumed the shell's marker while checking the path
 # only afterwards — the notification-center line was lost on every reload the pane won that race. If location.reload throws (a host that forbids it) the old banner is the fallback
 # (the `refused` hook) and the refusal LATCHES for that build/boot: no re-attempt on every gesture end or poll,
-# only a strictly newer dv or boot re-arms. The VS Code webview never runs this: the extension loads its bundle from the installed VSIX
+# only a strictly newer dv or boot re-arms. A reload HELD by a pane's reason wears a face (the `held` hook, fired once
+# per owed request and reason: the shell's notification center, a standalone pane's bar — T272 follow-up, the
+# manager's review 2026-09-08: nothing displayed `waiting`, and a hold could outlive the upload it protected),
+# The VS Code webview never runs this: the extension loads its bundle from the installed VSIX
 # and a webview reload cannot fix bundled-code drift, so its own reload prompt stays (vscode-extension/src/
 # extension.ts). Federated relay: a REMOTE kernel's restart must not reload the page — and cannot: the core reads
 # only THIS page's own socket and /version (federation.ts drops remote `ka` frames, so they never reach the shim's
@@ -40384,7 +40387,9 @@ function fire(){if(fired)return;fired=true;persist();
 try{location.reload();}catch(e){fired=false;refusedFor=key(owed);R.waiting='refused';if(R.refused)R.refused(owed);return;}
 try{sessionStorage.setItem('romp:reloaded',JSON.stringify({reason:owed.reason,detail:owed.detail||'',from:LOADED,path:location.pathname,t:Date.now()}));}catch(e){}
 try{document.body.classList.remove('settings-open','picker-open');}catch(e){}}
-function tryFire(){if(!owed||fired)return;if(refusedFor!==null&&refusedFor===key(owed))return;var b=busy();if(b){R.waiting=b;return;}R.waiting='';fire();}
+var heldFor=null;
+function tryFire(){if(!owed||fired)return;if(refusedFor!==null&&refusedFor===key(owed))return;var b=busy();
+if(b){R.waiting=b;var hk=key(owed)+'|'+b;if(hk!==heldFor){heldFor=hk;if(R.held)R.held(b,owed);}return;}R.waiting='';fire();}
 function request(reason,detail){var s=shell();if(s){s.request(reason,detail);return;}if(fired)return;
 var next={reason:reason,detail:detail||''};if(refusedFor!==null&&key(next)!==refusedFor){refusedFor=null;owed=next;}
 if(!owed)owed=next;tryFire();}
@@ -40411,7 +40416,7 @@ function ended(){setTimeout(function(){var s=shell();if(s)s.tryFire();else tryFi
 for(var k=0;k<END.length;k++)document.addEventListener(END[k],ended,true);
 window.addEventListener('blur',function(){ptr=0;pan=false;drag=false;ended();});
 var R={request:request,tryFire:tryFire,ended:ended,busyHere:busyHere,busy:busy,noteDv:noteDv,noteVersion:noteVersion,checkBoot:checkBoot,announce:announce,
-inShell:function(){return !!shell();},owed:function(){return owed;},fired:function(){return fired;},refusedFor:function(){return refusedFor;},refused:null,waiting:'',loaded:LOADED,boot:BOOT};
+inShell:function(){return !!shell();},owed:function(){return owed;},fired:function(){return fired;},refusedFor:function(){return refusedFor;},refused:null,held:null,waiting:'',loaded:LOADED,boot:BOOT};
 window.__rompReload=R;})();/*end-reload-core*/"""
 
 
@@ -40577,6 +40582,7 @@ var buildRaised=false,freshPending=false,restartAnnounced=0;   // freshPending: 
 window.__rompPaneBusy=function(){return (everConnected&&queue.length>queuedDiag)?"sends":"";};
 // …and a standalone page (no same-origin shell) consumes its own reload marker: nobody else would
 try{if(window.__rompReload&&!window.__rompReload.inShell())window.__rompReload.announce(null);}catch(e){}
+try{if(window.__rompReload&&!window.__rompReload.inShell()){window.__rompReload.held=function(b){var t=(b==='upload'?'The dashboard will reload once the upload in progress finishes.':b==='held-send'?'The dashboard will reload once the held message has been sent.':b==='sends'?'The dashboard will reload once the queued messages have left.':(b==='pointer'||b==='pan'||b==='drag'||b==='selection'||b==='typing'||!b)?null:'The dashboard will reload once the page is idle ('+b+').');if(t)selfBar(t,'held');};}}catch(e){}
 function raiseBuild(){if(buildRaised)return;buildRaised=true;var R=window.__rompReload;
 if(R){R.refused=function(){selfBar("A newer romp build is available.","build");};R.request("build","");}
 else selfBar("A newer romp build is available.","build");}
@@ -43354,6 +43360,9 @@ _STALE_JS = (
     # /version reading (a restart the socket never showed, a bundle newer than this page's).
     "var RL=window.__rompReload;"
     "if(RL){RL.refused=function(){buildStale=true;show(BUILDMSG);};"
+    # a reload HELD by a pane (an upload in flight, a held send, queued sends) says so, once per hold: the notification
+    # center line names what it waits for; momentary gesture holds (pointer, typing…) get no line (T272 follow-up)
+    "RL.held=function(b){var t=(b==='upload'?'The dashboard will reload once the upload in progress finishes.':b==='held-send'?'The dashboard will reload once the held message has been sent.':b==='sends'?'The dashboard will reload once the queued messages have left.':(b==='pointer'||b==='pan'||b==='drag'||b==='selection'||b==='typing'||!b)?null:'The dashboard will reload once the page is idle ('+b+').');if(t&&window.__rompNotify)window.__rompNotify('reload',t);};"
     "RL.announce(function(k,t){if(window.__rompNotify)window.__rompNotify(k,t);});}"
     "function check(){fetch('/version',{cache:'no-store'}).then(function(r){return r.json();}).then(function(v){"
     "if(v&&v.boot&&window.__rompUpdBoot)window.__rompUpdBoot(v.boot);"   # retire cross-boot update offers (2026-08-15)

--- a/tests/test_dashboard_auto_reload.py
+++ b/tests/test_dashboard_auto_reload.py
@@ -273,6 +273,31 @@ out({ held: held, after: state() });""")
         self.assertEqual(s["held"]["waiting"], "sends")
         self.assertEqual(s["after"]["reloads"], 1, "the flush is the ending event")
 
+    def test_a_held_reload_wears_a_face_once_per_hold_and_never_for_a_gesture(self):
+        # T272 follow-up (the manager's review): nothing displayed the core's `waiting`, so a reload held by a pane's
+        # reason (an upload in flight) sat invisible. The `held` hook fires once per owed request and reason — the shell
+        # files a notification-center line, a standalone pane raises its bar — and never for a momentary gesture hold.
+        s = run_core("""
+var R = window.__rompReload; var held = []; R.held = function (b, o) { held.push([b, o && o.reason]); };
+var busyReason = "upload";
+window.__rompPaneBusy = function () { return busyReason; };
+R.noteVersion({ boot: "2.2" });                       // owed, held on the pane's upload
+R.ended(); await tick(); R.ended(); await tick();     // re-asks while the same hold stands: no second line
+busyReason = "held-send"; R.ended(); await tick();    // the reason changed: one line for it
+busyReason = ""; R.ended(); await tick();             // idle: fires
+out({ held: held, reloads: RELOADS, waiting: R.waiting });""")
+        self.assertEqual(s["held"], [["upload", "restart"], ["held-send", "restart"]], "once per hold reason, with the owed request")
+        self.assertEqual(s["reloads"], 1)
+        s2 = run_core("""
+var R = window.__rompReload; var held = []; R.held = function (b) { held.push(b); };
+emit("pointerdown"); R.noteVersion({ boot: "2.2" });   // a held pointer: a gesture hold, no line
+var during = state();
+emit("pointerup"); await tick();
+out({ held: held, during: during, reloads: RELOADS });""")
+        self.assertEqual(s2["during"]["waiting"], "pointer")
+        self.assertEqual(s2["held"], ["pointer"], "the hook is told every hold; the shell's line filters gestures out (heldReloadText)")
+        self.assertEqual(s2["reloads"], 1)
+
     def test_a_touch_pan_holds_from_pointercancel_until_the_finger_lifts(self):
         s = run_core("""
 var R = window.__rompReload;
@@ -364,6 +389,17 @@ class ReloadWiringPinned(unittest.TestCase):
         self.assertIn("if(m.build){if(RL)RL.request('build','');else{buildStale=true;show(BUILDMSG);}}", js)
         self.assertIn("if(m&&m.romp==='wsFresh'){connStale=false;if(buildStale)show(BUILDMSG);else box.classList.remove('show');}", js,
                       "the CONNECTION prompt for a plain reconnect is untouched")
+
+    def test_a_held_reload_is_told_to_the_notification_center_and_to_a_standalone_panes_bar(self):
+        # the shell's stale script installs the `held` hook: the line names what the reload waits for (an upload, a held
+        # send, queued sends) and skips momentary gesture holds; a standalone pane (no shell) raises its own bar
+        js = km._STALE_JS
+        self.assertIn("RL.held=function(b){var t=(b==='upload'?'The dashboard will reload once the upload in progress finishes.'", js)
+        self.assertIn("if(t&&window.__rompNotify)window.__rompNotify('reload',t);", js)
+        shim = km._shim("chat", 7) if callable(getattr(km, "_shim", None)) else ""
+        self.assertIn("window.__rompReload.held=function(b){var t=(b==='upload'?", shim)
+        self.assertIn("if(t)selfBar(t,'held');", shim)
+        self.assertIn("!window.__rompReload.inShell()", shim, "only a standalone pane raises its own bar; in the shell the center speaks")
 
     def test_a_remote_kernels_restart_or_bundle_never_reaches_the_core(self):
         fed = open(os.path.join(ROOT, "ui", "webview", "federation.ts")).read()

--- a/tests/test_ship_reship.py
+++ b/tests/test_ship_reship.py
@@ -76,9 +76,11 @@ class SourcePins(unittest.TestCase):
         # flight its bytes and a held send its release — the very wedge the reconnect re-ship heals in the same page.
         # So the chat pane answers the reload core's busy ask while either is pending; the shim's own reasons first.
         self.assertIn('(window as any).__rompPaneBusy = (): string => {', RENDER)
-        self.assertIn('if (pendingShips.size) return "upload";', RENDER)
-        self.assertIn('if (shipGateSid) return "held-send";', RENDER)
         self.assertIn('const shimBusy = (window as any).__rompPaneBusy as (() => string) | undefined;', RENDER)
+        # …and only for ships whose ack can still arrive (reload-hold.ts, the review of the hold): a ship to a host whose
+        # relay is down, or to a host no longer attached, does not hold the dashboard's reload
+        self.assertIn('return reloadHoldReason([...pendingShips.keys()], shipGateSid, (window as any).__rompFed);', RENDER)
+        self.assertNotIn('if (pendingShips.size) return "upload";', RENDER)
 
     def test_the_chat_page_loads_the_shim_before_the_bundle_so_the_busy_report_wraps_the_shims(self):
         # the wrapper above reads the shim's window.__rompPaneBusy first and replaces it; that only holds because the

--- a/ui/webview/reload-hold.test.ts
+++ b/ui/webview/reload-hold.test.ts
@@ -1,0 +1,34 @@
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { shipHoldsReload, reloadHoldReason, heldReloadText } from "./reload-hold";
+
+// T272 follow-up: the upload hold on the dashboard's reload counts only ships whose ack can still arrive, and a held
+// reload wears a line.
+
+const fed = { hosts: () => ["web", "api"], down: () => ["api"] };
+
+test("a ship holds the reload only while its host is the local kernel or an attached, reachable host", () => {
+  assert.equal(shipHoldsReload("aaaaaaaa-1111-2222-3333-444444444444", fed), true, "local: the shim's own socket carries the ack");
+  assert.equal(shipHoldsReload("web:aaaaaaaa-1111-2222-3333-444444444444", fed), true, "an attached, reachable host");
+  assert.equal(shipHoldsReload("api:aaaaaaaa-1111-2222-3333-444444444444", fed), false, "its relay is down: no ack until it returns");
+  assert.equal(shipHoldsReload("gone:aaaaaaaa-1111-2222-3333-444444444444", fed), false, "a detached or removed host: no ack ever");
+  assert.equal(shipHoldsReload("api:aaaaaaaa-1111-2222-3333-444444444444", null), true, "no manager loaded (a single-kernel page): every ship holds");
+  assert.equal(shipHoldsReload("api:x", { hosts: () => { throw new Error("boom"); } }), true, "a manager that throws is read as reachable");
+});
+
+test("the pane's reason: upload for a live ship, held-send for a gate on a live ship, nothing for unreachable ones", () => {
+  assert.equal(reloadHoldReason(["s1"], null, fed), "upload");
+  assert.equal(reloadHoldReason(["api:s2"], null, fed), "", "a ship to a down host never holds");
+  assert.equal(reloadHoldReason(["api:s2", "web:s3"], null, fed), "upload", "…but a live one beside it does");
+  assert.equal(reloadHoldReason([], "s1", fed), "held-send");
+  assert.equal(reloadHoldReason([], "gone:s1", fed), "", "a send held on a gone host's upload does not hold");
+  assert.equal(reloadHoldReason([], null, fed), "");
+});
+
+test("a held reload's line names what it waits for; a momentary gesture hold gets none", () => {
+  assert.equal(heldReloadText("upload"), "The dashboard will reload once the upload in progress finishes.");
+  assert.equal(heldReloadText("held-send"), "The dashboard will reload once the held message has been sent.");
+  assert.equal(heldReloadText("sends"), "The dashboard will reload once the queued messages have left.");
+  for (const g of ["pointer", "pan", "drag", "selection", "typing", ""]) assert.equal(heldReloadText(g), null, g);
+  assert.match(heldReloadText("custom-reason")!, /^The dashboard will reload once the page is idle \(custom-reason\)\.$/);
+});

--- a/ui/webview/reload-hold.ts
+++ b/ui/webview/reload-hold.ts
@@ -1,0 +1,46 @@
+// The chat pane's hold on the dashboard's self-reload (T272 follow-up, the manager's review 2026-09-08): a reload takes
+// an upload in flight's bytes and a held send's release with it, so the pane reports itself busy while either is
+// pending — but ONLY while the ack can still arrive. A ship to a host whose relay is down, or to a host no longer
+// attached, has no ack coming until that host returns; holding every restart and build reload for it would stop the
+// dashboard from ever reloading, silently. So the hold counts ships whose host is the local kernel or an attached,
+// reachable host, and a held reload wears a face (heldReloadText) on the notification center or a standalone pane's
+// bar, since nothing displayed the core's `waiting` before. Pure and DOM-free so node --test executes it.
+
+export type FedView = { hosts?: () => string[]; down?: () => string[] } | null | undefined;
+
+/** The host prefix of a sid ("" for the local kernel). */
+const hostOfSid = (sid: string): string => { const i = sid.indexOf(":"); return i > 0 ? sid.slice(0, i) : ""; };
+
+/** Whether a pending ship for `sid` still has an ack coming: local, or a host the federation manager lists as
+ *  attached and not down. No manager loaded (a single-kernel page): every ship holds. */
+export function shipHoldsReload(sid: string, fed: FedView): boolean {
+  const host = hostOfSid(sid);
+  if (!host) return true;
+  if (!fed) return true;
+  try {
+    if (typeof fed.hosts === "function" && fed.hosts().indexOf(host) < 0) return false;   // detached or removed: gone
+    if (typeof fed.down === "function" && fed.down().indexOf(host) >= 0) return false;   // its relay is down
+  } catch { return true; }
+  return true;
+}
+
+/** The pane's busy reason for the reload core, from what is pending: "upload" while a ship whose ack can still
+ *  arrive awaits it, "held-send" while a send is held on such a ship; "" otherwise. */
+export function reloadHoldReason(shipSids: string[], gateSid: string | null, fed: FedView): string {
+  const live = shipSids.filter((sid) => shipHoldsReload(sid, fed));
+  if (live.length) return "upload";
+  if (gateSid && shipHoldsReload(gateSid, fed)) return "held-send";
+  return "";
+}
+
+/** The line a held reload wears, per the pane's reason; null for a momentary gesture hold (the core's own
+ *  pointer/pan/drag/selection/typing reasons), which needs no line. */
+export function heldReloadText(reason: string): string | null {
+  switch (reason) {
+    case "upload": return "The dashboard will reload once the upload in progress finishes.";
+    case "held-send": return "The dashboard will reload once the held message has been sent.";
+    case "sends": return "The dashboard will reload once the queued messages have left.";
+    case "pointer": case "pan": case "drag": case "selection": case "typing": case "": return null;
+    default: return "The dashboard will reload once the page is idle (" + reason + ").";
+  }
+}

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -40,6 +40,7 @@ import { NavHistory } from "./nav-history";
 import { StagedStack } from "./staged-messages";
 import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, newPending, reconcilePending, queuedCopyToHide, dropPending, bareGroupLabel, sentAtLabel } from "./send-pending";
 import { reconcileHeld, heldAsQueued, type HeldCopy, type HeldQueued, type HeldMemory } from "./queued-held";
+import { reloadHoldReason } from "./reload-hold";
 import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional, focusResolvesProvisional } from "./provisional";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
@@ -13060,9 +13061,9 @@ let fireHeldSend: () => void = () => {};
   (window as any).__rompPaneBusy = (): string => {
     const b = shimBusy ? shimBusy() : "";
     if (b) return b;
-    if (pendingShips.size) return "upload";
-    if (shipGateSid) return "held-send";
-    return "";
+    // only ships whose ack can still arrive hold (reload-hold.ts): a ship to a host whose relay is down, or to a host
+    // no longer attached, would otherwise hold every reload of this tab for good (the review of this hold)
+    return reloadHoldReason([...pendingShips.keys()], shipGateSid, (window as any).__rompFed);
   };
 }
 // The ENDING event of those holds, told to the core the way the shim tells it its own (kernel.py ws.onopen →


### PR DESCRIPTION
Follow-up to #1123, from its review: the chat pane held the dashboard's reload while **any** ship awaited its ack, with no host scoping, and nothing displayed that a reload was waiting. A ship to a host whose relay is down or that is no longer attached has no ack coming, so every reload of that tab was held for good, silently.

- **Scoped hold** (`ui/webview/reload-hold.ts`, pure): a ship holds the reload only while its host is the local kernel or an attached, reachable host (the federation manager's `hosts`/`down` sets); the pane's reason is `"upload"` for a live ship, `"held-send"` for a send held on one, nothing for unreachable ones.
- **A visible face:** the reload core gains a `held` hook, fired once per owed request and reason; the shell files a notification-center line naming what the reload waits for, a standalone pane raises its own bar, and momentary gesture holds get no line.

**Tests:** `ui/webview/reload-hold.test.ts`, `tests/test_dashboard_auto_reload.py` (node executes the core), `tests/test_ship_reship.py` (the pane's wrapper delegates to the scoped reason).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
