### PR TITLE
Docs: Claude Code's built-in ListAgents is not the postal service's list_agents

### DIFF
--- a/claude/skills/romp-postal/SKILL.md
+++ b/claude/skills/romp-postal/SKILL.md
@@ -12,6 +12,8 @@ Only applies inside a romp session (a tmux session tagged `@romp`, or an SDK-bac
 
 Message sibling sessions with the postal MCP tools (each tool's own description carries the specifics): `send_message(to, body, kind)`, `check_inbox()`, `list_agents()`, `set_working(text)`, `check_sent()`, `recall_message(to, id?)`. Inbox is also delivered automatically at each turn's end, so you rarely call `check_inbox` yourself.
 
+Not the same tools: romp peers are discovered only through the postal service's `list_agents`. Claude Code also ships its own `ListAgents` and `SendMessage` tools, which list the account's Anthropic cloud sessions and this session's own subagents: a different system, and a cloud session in that list is easy to mistake for a romp peer (the user 2026-09-08, who found one there that read like a session of theirs). The recommended setting is `"permissions": { "deny": ["ListAgents"] }` in the Claude Code settings, so the only list of agents a session sees is romp's; `SendMessage` must stay allowed, because continuing a subagent uses it.
+
 Addressing is live-only: you can message only currently-live sessions (see `list_agents`). Dead names error, with no parked mail or reviving. A session's stable id (the uuid `list_agents` shows) also works as the recipient — rename-proof, unique by construction, so it never hits the shared-name ambiguity refusal.
 
 Role-named recipients go stale: a role handed to a new session keeps the OLD name in your memory of it, and the retired name just bounces. Before sending to a role-style name (a router, a watcher, a manager), confirm it against `list_agents` and address whoever holds the role now.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -171,6 +171,8 @@ session by name, check the inbox, and see who is live. Each session also
 publishes a working note saying what it currently holds, so agents can see who
 to talk to instead of messaging each other to find out.
 
+Not the same tools: romp peers are discovered only through the postal service's `list_agents`. Claude Code also ships its own `ListAgents` and `SendMessage` tools, which list the account's Anthropic cloud sessions and this session's own subagents: a different system, and a cloud session in that list is easy to mistake for a romp peer (the user 2026-09-08, who found one there that read like a session of theirs). The recommended setting is `"permissions": { "deny": ["ListAgents"] }` in the Claude Code settings, so the only list of agents a session sees is romp's; `SendMessage` must stay allowed, because continuing a subagent uses it.
+
 The timeline draws an arc for each message. Hover one for its gist:
 
 <video src="../assets/guide/coordination.mp4" controls loop muted playsinline preload="none" data-romp-autoplay width="100%"></video>

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -198,6 +198,8 @@ romp mail remote                 # legacy singleton scheme only (ROMP_POSTAL_PEE
 | `check_sent()` | Whether your sent messages were read yet |
 | `recall_message(to, id?)` | Unsend a message the recipient hasn't read |
 
+Not the same tools: romp peers are discovered only through the postal service's `list_agents`. Claude Code also ships its own `ListAgents` and `SendMessage` tools, which list the account's Anthropic cloud sessions and this session's own subagents: a different system, and a cloud session in that list is easy to mistake for a romp peer (the user 2026-09-08, who found one there that read like a session of theirs). The recommended setting is `"permissions": { "deny": ["ListAgents"] }` in the Claude Code settings, so the only list of agents a session sees is romp's; `SendMessage` must stay allowed, because continuing a subagent uses it.
+
 ### When a send is refused
 
 A send whose record cannot be written, or that cannot be placed in the


### PR DESCRIPTION
## Summary
One shared note, in the three places where peers and messaging are introduced, that Claude Code's built-in `ListAgents` and `SendMessage` tools are a different system from the Romp Postal Service, with the recommended settings rule.

## Why
The user (2026-09-08) found an entry in a session list that read like a cloud session of theirs. It was Claude Code's own built-in `ListAgents` tool, which lists the account's Anthropic cloud sessions beside local ones, not a romp peer, and it is easy to confuse with the postal service's `list_agents`.

## The note (same wording in each place)
- romp peers are discovered only through the postal service's `list_agents`;
- Claude Code's `ListAgents` and `SendMessage` list the account's cloud sessions and this session's own subagents, and a cloud session there is easy to mistake for a romp peer;
- recommended: `"permissions": { "deny": ["ListAgents"] }` in the Claude Code settings, so the only list of agents a session sees is romp's; `SendMessage` stays allowed because continuing a subagent uses it.

## Where
- `docs/reference.md`: after the postal service's MCP tool table.
- `docs/guide.md`: in the inter-agent communication section, after the introduction.
- `claude/skills/romp-postal/SKILL.md`: after the Tools paragraph (the skill sessions read at start).

Docs only; the user is paraphrased, no names or hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)