### PR TITLE
A message the exchange already carried can no longer be recalled; every recall row says which box it left

### DIFF
--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -40,6 +40,7 @@ import errno
 import fcntl
 import hashlib
 import hmac
+import http.client
 import itertools
 import json
 import os
@@ -3361,11 +3362,12 @@ def _mark_carried(host, mid):
     refused connection during a restart), refusing a recall for bytes that never left. The
     events, per side: the DIALER marks when its dial returns a response (peer_exchange_apply,
     after the acks and bounces, so a record the ack just deleted is simply not there to mark) or
-    fails only AFTER the request went out — a read timeout, a dropped connection, an undecodable
-    body: the far bus may have taken the relays and answered into the void (_peer_exchange_once);
-    the DIALED side marks once its response write returned (the /peer-exchange route). A dial the
-    far bus refused with a status (any HTTP error precedes relay intake) or that never connected
-    (urllib.error.URLError) marks nothing. From the listing to that outcome the record is IN FLIGHT
+    fails only AFTER the request went out (a read timeout, an undecodable body): the far bus may
+    have taken the relays and answered into the void (_peer_exchange_once); the DIALED side marks
+    once its response write returned (the /peer-exchange route). A dial the far bus refused with a
+    status (any HTTP error precedes relay intake), that never connected (urllib.error.URLError), or
+    whose socket closed before any status line came back (through the ssh forward, a far bus not
+    listening; review find 2026-09-09) marks nothing. From the listing to that outcome the record is IN FLIGHT
     (_inflight), which the recall refuses as on its way — so no recall is granted for a record on
     the wire, and none is told "left" for one that never did.
 
@@ -4275,11 +4277,13 @@ def _peer_exchange_once(host, port, token):
     - 'ok': a response. peer_exchange_apply folds it in and marks the relays carried after the acks
       and bounces; if the fold itself fails the relays are marked here (the far bus answered, so it
       processed them) and the failure is said.
-    - 'lost': raised AFTER the request went out (a read timeout, a dropped connection, an undecodable
-      body — anything urllib does not wrap): the far bus may have taken the relays and answered into
-      the void, so they are marked carried; the re-relay next round is deduped over there.
+    - 'lost': raised AFTER the request went out (a read timeout, an undecodable body, anything else
+      urllib does not wrap): the far bus may have taken the relays and answered into the void, so
+      they are marked carried; the re-relay next round is deduped over there.
     - 'unsent': urllib.error.URLError — the connect or the send failed (refused, unresolved, a connect
-      timeout, a pipe broken mid-send): the request never arrived; nothing is marked.
+      timeout, a pipe broken mid-send): the request never arrived; nothing is marked. Also a socket
+      that closed before any status line came back (RemoteDisconnected, a reset): through the ssh
+      forward that is a far bus not listening, not an answer lost (the arm below has the shape).
     - 'drift': HTTP 409, the protocol handshake refused it before any relay was read; nothing marked.
     - 'refused': any other HTTP status — the token gate, the unsafe-host check, a bad body — all of
       which precede relay intake (a handler exception over there yields no response at all, not a
@@ -4313,6 +4317,19 @@ def _peer_exchange_once(host, port, token):
         return "refused"
     except urllib.error.URLError:
         _end(False)                                  # the request never arrived
+        return "unsent"
+    except (http.client.RemoteDisconnected, http.client.BadStatusLine, ConnectionResetError, BrokenPipeError):
+        # The socket closed before any status line came back. urllib wraps only the connect and the
+        # send (h.request) in URLError; a failure in getresponse propagates raw, and through the
+        # kernel's ssh -L forward that is the shape of a far bus that is not listening (its restart
+        # window, a crash): the LOCAL ssh listener accepts the TCP connection, the request goes out
+        # to it, ssh fails the channel and closes the socket, and no bus ever read a byte. The generic
+        # arm below took that for a lost answer and marked every record in the flight carried, a
+        # durable mark, so through every far-bus restart the sender was refused a recall for messages
+        # still in its own outbox (review find, 2026-09-09). A far handler that died AFTER delivering
+        # also closes without a status line, but the re-relay next round is deduped over there by id:
+        # re-sending is safe where a false carried mark is not, so nothing is marked.
+        _end(False)
         return "unsent"
     except Exception:
         _end(True)                                   # it went out; the answer was lost

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -40,6 +40,7 @@ import errno
 import fcntl
 import hashlib
 import hmac
+import itertools
 import json
 import os
 import random
@@ -962,7 +963,10 @@ def format_receipts(recs):
         elif r.get("parked"):                  # cross-host, still in the outbox awaiting relay
             # "(unreachable)" ONLY when the link is actually down (the user 2026-08-24): a healthy
             # queue is normal transit, not a failure. An older bus omits parkedUp — claim nothing.
-            if r.get("parkedUp"):
+            if r.get("carried"):               # it left with an exchange; the far side's ack is not back
+                st = "left for %s %s — awaiting delivery confirmation · id %s" % (
+                    r["parked"], _hhmm_epoch(r["carried"]), r.get("id", "?"))
+            elif r.get("parkedUp"):
                 st = "queued for relay to %s · id %s" % (r["parked"], r.get("id", "?"))
             elif "parkedUp" in r:
                 st = "parked for %s (unreachable) — delivers on reconnect · id %s" % (r["parked"], r.get("id", "?"))
@@ -1412,12 +1416,44 @@ def resolve_recipient(to, frm_id=""):
     return {"kind": "error", "status": 404, "error": "no live romp session named '%s'" % to}
 
 
-def _recall(from_id, to, mid):
+WHY_CARRIED = "already left for %s and can no longer be withdrawn"        # _recall: a carried outbox record
+WHY_IN_FLIGHT = "is on its way to %s right now (try again in a moment)"    # _recall: a record an exchange is carrying
+
+def _recall(from_id, to, mid, kept=None):
     """Unsend UNREAD mail: delete messages still sitting in a recipient's `new/`
     (queued or parked) that were sent BY from_id. With `to`, scope to that one
     recipient; with `mid` (and no `to`), find it across mailboxes; both narrows to
     one message. Only the original sender's own messages are touched. Already-read
-    mail has left `new/` and can't be recalled. Returns [{to, id, body}] removed."""
+    mail has left `new/` and can't be recalled. Returns [{to, id, body}] removed.
+
+    Cross-host mail parked in the OUTBOX is recallable only until an exchange CARRIES it
+    (2026-09-08). The record does not leave the outbox when it rides — it leaves on the
+    end-to-end ack, one round trip later at best and a whole outage later when a response was
+    lost — and the far bus delivers on arrival, so in that window the recipient already holds
+    the message and may be answering it. Unlinking the record then, as this arm used to, and
+    filing a terminal recall row for it, told the sender's receipts (and every reader that
+    treats a recall as final) that a read message had been withdrawn. Two states refuse here
+    now, both exact events of the exchange, and a refused record stays, no row is written, and
+    the refusal is appended to `kept` (a list the caller passes; None drops them) as {to, id,
+    host, carried, why, body} so the sender is told in plain words:
+    - CARRIED (`carried` on the record, durable): the exchange's OUTCOME said the record reached
+      the far bus — the dialer got a response, or its dial failed only after the request went
+      out; the dialed side's response write returned (_mark_carried has the event per side).
+      "already left for <host> and can no longer be withdrawn".
+    - IN FLIGHT (_inflight, in memory): an open exchange — any of them; two run at once for one
+      host — listed the record and its outcome is not in yet: the bytes are on the wire or about
+      to be, so a recall can neither be granted (the
+      recipient may already hold them) nor told they left (a refused dial means they never
+      will). "is on its way to <host> right now (try again in a moment)": the outcome, seconds
+      away, turns it into the carried refusal or frees the record for the recall.
+    The check and the unlink here share _outbox_lock with the listing that puts a record in
+    flight (_relays_for) and the outcome that marks or frees it (_flight_done), so a recall
+    either unlinks before the listing sees the record, or meets one of the two refusals; never
+    a granted recall for a record an exchange is carrying.
+
+    Every recall row names the box it came from — `box: 'new'` (a recipient's maildir) or
+    `box: 'outbox'` (a parked cross-host record, with `host`) — so a reader can tell the two
+    apart by an explicit field instead of an id's shape."""
     if not from_id:
         return []
     listing = []                                 # ONE listing per recall, at first need; every name lookup reads it
@@ -1466,33 +1502,44 @@ def _recall(from_id, to, mid):
             except Exception:
                 continue
             removed.append({"to": _name_for_id(rid, rows=_rows()), "id": f.name, "body": " ".join(body.split())[:120]})
-            _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "recall", "id": f.name})
+            _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "recall", "id": f.name, "box": "new"})
         _mark_pending(rid)         # recall may have emptied new/ -> reconcile the marker
     if peers_on() and OUTBOX.is_dir():
-        # A recall that beats the truck always wins: parked cross-host mail is still local, so the
-        # sender can unsend it right up until the exchange carries it. Forwarded mail (origin set)
-        # belongs to a sender on another host — never touched here.
+        # A recall that beats the truck wins: parked cross-host mail is still local, so the sender
+        # can unsend it right up until an exchange carries it — and not one moment after (the
+        # `carried` mark; see the docstring). Forwarded mail (origin set) belongs to a sender on
+        # another host — never touched here.
         for hostdir in OUTBOX.iterdir():
             if not hostdir.is_dir():
                 continue
             for f in list(hostdir.glob("*.json")):
                 if mid and f.stem != mid:
                     continue
-                try:
-                    msg = json.loads(f.read_text())
-                except Exception:
-                    continue
-                if msg.get("frm_id") != from_id or msg.get("origin"):
-                    continue
-                if to and (msg.get("to") or "") != to and "%s:%s" % (hostdir.name, msg.get("to") or "") != to:
-                    continue
-                try:
-                    f.unlink()
-                except Exception:
-                    continue
+                with _outbox_lock:                   # the listing, the mark and this unlink share it: no
+                    try:                             # unlink of a record an exchange is carrying right now
+                        msg = json.loads(f.read_text())
+                    except Exception:
+                        continue
+                    if msg.get("frm_id") != from_id or msg.get("origin"):
+                        continue
+                    if to and (msg.get("to") or "") != to and "%s:%s" % (hostdir.name, msg.get("to") or "") != to:
+                        continue
+                    riding = any(f.stem in mids for mids in (_inflight.get(hostdir.name) or {}).values())
+                    if msg.get("carried") or riding:
+                        if kept is not None:
+                            kept.append({"to": "%s:%s" % (hostdir.name, msg.get("to") or "?"), "id": f.stem,
+                                         "host": hostdir.name, "carried": msg.get("carried"),
+                                         "why": (WHY_CARRIED if msg.get("carried") else WHY_IN_FLIGHT) % hostdir.name,
+                                         "body": " ".join((msg.get("body") or "").split())[:120]})
+                        continue                     # it stays; no row: nothing about it changed
+                    try:
+                        f.unlink()
+                    except Exception:
+                        continue
                 removed.append({"to": "%s:%s" % (hostdir.name, msg.get("to") or "?"), "id": f.stem,
                                 "body": " ".join((msg.get("body") or "").split())[:120]})
-                _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "recall", "id": f.stem})
+                _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "recall", "id": f.stem,
+                                              "box": "outbox", "host": hostdir.name})
     return removed
 
 def _sent_receipts(mid):
@@ -1521,13 +1568,14 @@ def _sent_receipts(mid):
             bounced[e["id"]] = e["t"]
             bounced_why[e["id"]] = str(e.get("why") or "")   # a REFUSAL's why renders apart (format_receipts)
 
-    def _parked(i, e):                               # still in the outbox → honestly parked, not lost
-        tid = e.get("to_id", "")
+    def _parked(i, e):                               # still in the outbox → honestly parked, not lost:
+        tid = e.get("to_id", "")                     # (host, record) — the record carries the carry mark
         if tid.startswith("peer:") and not relays.get(i) and not bounced.get(i) and not recalls.get(i):
             h = tid[5:]
-            if outbox_get(h, i):
-                return h
-        return None
+            rec = outbox_get(h, i)
+            if rec:
+                return h, rec
+        return None, None
 
     listing = []                                 # one GET /sessions for every row without toName, at first need
 
@@ -1537,7 +1585,7 @@ def _sent_receipts(mid):
         return _name_for_id(sid, rows=listing[0])
 
     def _row(i, e):
-        h = _parked(i, e)
+        h, rec = _parked(i, e)
         r = {"to": e.get("toName") or _name(e.get("to_id", "")), "id": i, "sent": e["t"],
              "exec": execs.get(i), "recalled": recalls.get(i),
              "relayed": relays.get(i), "bounced": bounced.get(i), "parked": h}
@@ -1549,6 +1597,10 @@ def _sent_receipts(mid):
             # just in transit, and labeling it "(unreachable)" cried wolf on every normal relay.
             # PEERS is the authoritative dial state the send path already branches on.
             r["parkedUp"] = bool((PEERS.get(h) or {}).get("up"))
+            if rec.get("carried"):
+                # an exchange CARRIED it and the ack is not back (2026-09-08): the same fact the
+                # recall refuses on, so the two surfaces agree (additive: an older client ignores it)
+                r["carried"] = rec["carried"]
         return r
 
     out = [_row(i, e) for i, e in sent.items()]
@@ -2193,8 +2245,22 @@ class Handler(BaseHTTPRequestHandler):
             payload, status = peer_update(data)
             return self._send(payload, status)
         if u.path == "/peer-exchange":             # a peer bus dialing us through the kernel's -L forward
-            payload, status = peer_exchange_handle(data)
-            return self._send(payload, status)
+            flight = []                            # the ids of the flights the handler's listings registered
+            payload, status = peer_exchange_handle(data, flight=flight)
+            # The relays in a 200 leave with this write (2026-09-08): _send writes through the handler's
+            # unbuffered wfile (wbufsize 0 — sendall), so a return means the socket took the bytes and a
+            # dead socket raises here. Returned → the flight ends carried; raised → freed, nothing left,
+            # they ride the next exchange (a re-relay is deduped over there).
+            host = _exchange_peer_name(data)
+            try:
+                self._send(payload, status)
+            except Exception:
+                for fid in flight:
+                    _flight_done(host, fid, carried=False)
+                raise
+            for fid in flight:
+                _flight_done(host, fid, carried=(status == 200))
+            return
         if u.path == "/send":
             to = data.get("to", "")
             frm, frm_id = data.get("from", "unknown"), data.get("from_id", "")
@@ -2323,8 +2389,9 @@ class Handler(BaseHTTPRequestHandler):
             frm_id = data.get("from_id", "")
             if not frm_id:
                 return self._send({"error": "missing from_id"}, 400)
-            removed = _recall(frm_id, data.get("to", ""), data.get("id", ""))
-            return self._send({"ok": True, "removed": removed})
+            kept = []                                # carried outbox items the recall refused (additive:
+            removed = _recall(frm_id, data.get("to", ""), data.get("id", ""), kept=kept)   # an older client
+            return self._send({"ok": True, "removed": removed, "kept": kept})               # ignores the key)
         if u.path == "/wake":
             sid = data.get("id", "")
             if sid and _safe_id(sid):                         # force-deliver on revive once the prompt is live
@@ -2628,7 +2695,7 @@ def _sweep_unfinished_writes():
                 return True
         return False
 
-    removed, closed, standing, recovered = 0, 0, 0, 0
+    removed, closed, standing, recovered, standing_records = 0, 0, 0, 0, 0
     try:
         boxes = [b for b in MAILROOT.iterdir() if b.is_dir()] if MAILROOT.is_dir() else []
     except OSError:
@@ -2669,13 +2736,24 @@ def _sweep_unfinished_writes():
             except OSError:
                 continue
             for f in temps:
+                mid = f.name.split(".json.tmp-", 1)[0]
+                record_stands = (hostdir / (mid + ".json")).exists()
                 try:
                     f.unlink()
                 except OSError as e:
                     _log("unfinished %s record %s could not be removed (%s)" % (store.name, f.name, e))
                     continue
                 removed += 1
-                mid = f.name.split(".json.tmp-", 1)[0]
+                if record_stands:
+                    # the temp of a REWRITE of a standing record (_mark_carried publishes the carry mark
+                    # through the same temp-and-replace), cut short: the record itself stands and its
+                    # message is parked, so its ledger is left alone (2026-09-08). Closing it as never
+                    # parked — the reading when outbox_put was the only temp writer — read a parked
+                    # message as refused to its sender.
+                    standing_records += 1
+                    _log("unfinished %s record %s for %s removed at start; the record itself stands (the temp of "
+                         "a rewrite the stop cut short), its ledger left alone" % (store.name, f.name, hostdir.name))
+                    continue
                 if why:
                     closed += _close(mid, {"host": hostdir.name, "why": why})
                 _log("unfinished %s record %s for %s removed at start" % (store.name, f.name, hostdir.name))
@@ -2686,6 +2764,9 @@ def _sweep_unfinished_writes():
         if standing:
             parts.append("%d of them the temp of a message that had reached the inbox, its ledger left alone"
                          % standing)
+        if standing_records:
+            parts.append("%d of them the temp of a record that stands, its ledger left alone"
+                         % standing_records)
     if recovered:
         parts.append("%d delivered message(s) stood in an inbox with no sent row (the restart cut the delivery "
                      "after the publish); each has its row now" % recovered)
@@ -3004,6 +3085,14 @@ _peer_wakes = {}                           # host -> threading.Event (long-poll 
 _peer_threads = {}                         # host -> Thread (one dialer loop per up peer)
 _peer_pending = {}                         # host -> {"acks": [mid], "bounces": [{mid, why}]} for the NEXT request
 _peer_lock = threading.Lock()
+_outbox_lock = threading.Lock()            # serializes an outbox record's listing-into-flight, carry mark and
+#                                            unlink (recall, ack, bounce): none interleaves (_relays_for, _flight_done)
+_inflight = {}                             # host -> {flight id: {mid}}: the records each OPEN exchange is carrying, from
+#                                            its listing to its outcome; a recall meanwhile is "on its way" (_recall). Two
+#                                            exchanges for one host run at once by design (our dialer and their dial of
+#                                            us), so each listing is its own flight and ending one releases nothing another
+#                                            still holds. Memory only: a restart ends every exchange, so it empties itself
+_flight_seq = itertools.count(1)           # flight ids, minted under _outbox_lock (_relays_for)
 
 def _host_name_candidates():
     """Raw machine-name candidates for the self_host fallback, most meaningful first. macOS keeps
@@ -3252,11 +3341,99 @@ def outbox_get(host, mid):
 def outbox_del(host, mid):
     if not (_safe_id(host) and _safe_id(mid)):   # host/mid are path components — block traversal
         return False
-    try:
-        (OUTBOX / host / (mid + ".json")).unlink()
-        return True
-    except Exception:
+    with _outbox_lock:                           # never interleaved with a listing or a carry mark (_flight_done)
+        try:
+            (OUTBOX / host / (mid + ".json")).unlink()
+            return True
+        except Exception:
+            return False
+
+_CARRY_KEYS = ("carried", "carriedVia")        # the record's carry mark; never on the wire (_wire_form)
+
+def _mark_carried(host, mid):
+    """Record on outbox/<host>/<mid> that an exchange CARRIED it: `carried` (epoch of the first
+    departure) and `carriedVia` (the host it left for), published by the same atomic rewrite every
+    store record gets (_atomic_json_put), so the mark stands across a bus restart — the ack that
+    ends the record may arrive after one. True iff the record stands and is marked (2026-09-08).
+
+    The mark lands AFTER the departure, keyed on the exchange's outcome, never on the request
+    being built: a mark at build time survived every failed dial (protocol drift waits 60 s; a
+    refused connection during a restart), refusing a recall for bytes that never left. The
+    events, per side: the DIALER marks when its dial returns a response (peer_exchange_apply,
+    after the acks and bounces, so a record the ack just deleted is simply not there to mark) or
+    fails only AFTER the request went out — a read timeout, a dropped connection, an undecodable
+    body: the far bus may have taken the relays and answered into the void (_peer_exchange_once);
+    the DIALED side marks once its response write returned (the /peer-exchange route). A dial the
+    far bus refused with a status (any HTTP error precedes relay intake) or that never connected
+    (urllib.error.URLError) marks nothing. From the listing to that outcome the record is IN FLIGHT
+    (_inflight), which the recall refuses as on its way — so no recall is granted for a record on
+    the wire, and none is told "left" for one that never did.
+
+    Why an exact mark and not the outbox's residency: a record stays in the outbox until the
+    END-TO-END ack, one round trip normally and a whole outage when a response was lost — and the
+    far side delivers on arrival; nothing distinguished a carried record from a parked one, so a
+    recall in that window unlinked a message the recipient already held (_recall has the rest). A
+    re-relay after a lost response finds the mark and writes nothing: the first departure is the
+    fact. False when the record is gone (acked, bounced or recalled first) or when the mark could
+    not be written — then the record RODE and its departure is not recorded, so a recall can still
+    withdraw it (the behaviour before this mark); said in the log by id. Takes _outbox_lock; the
+    _locked form is for callers already holding it (_flight_done)."""
+    with _outbox_lock:
+        return _mark_carried_locked(host, mid)
+
+def _mark_carried_locked(host, mid):
+    if not (_safe_id(host) and _safe_id(mid)):
         return False
+    rec = outbox_get(host, mid)
+    if not rec:
+        return False
+    if rec.get("carried"):
+        return True
+    rec["carried"], rec["carriedVia"] = int(time.time()), host
+    try:
+        _atomic_json_put(OUTBOX / host / (mid + ".json"), rec)
+    except OSError as e:
+        _log("outbox %s/%s: it rode an exchange but its departure could not be recorded (%s); a recall "
+             "can still withdraw it" % (host, mid, e))
+        return False
+    return True
+
+def _wire_form(m):
+    """The record as it rides an exchange: the carry mark stays home. It is this bus's bookkeeping
+    (a forwarding hub would otherwise inherit a `carried` it never carried and re-mark it on its own
+    departure), and keeping it off the wire keeps a record's measured size under the relay budget
+    the same before and after its first departure."""
+    return {k: v for k, v in m.items() if k not in _CARRY_KEYS}
+
+def _flight_done(host, flight_id, carried):
+    """The OUTCOME of one exchange for the flight its listing registered (_relays_for): the flight is
+    popped, and when `carried` — the bytes reached the far bus (the events are in _mark_carried) —
+    each of its records takes the durable mark first, under the one lock, so no instant exists in
+    which a record is neither in flight nor marked. `carried` False frees the flight's records: the
+    request never arrived, and a recall wins again exactly as before the listing — unless another
+    OPEN flight for the host still holds the record (two exchanges for one host run at once by
+    design), in which case it stays on its way until that one ends. Ending one flight never
+    releases what another holds: the first cut kept one set per host, and the first outcome to
+    land released a record the other exchange was still carrying (review find, 2026-09-08). A
+    second call for the same flight, or an unknown id, is a no-op: the fold-then-exception path in
+    _peer_exchange_once relies on that."""
+    with _outbox_lock:
+        mids = (_inflight.get(host) or {}).pop(flight_id, None)
+        if not mids:
+            return
+        if carried:
+            for mid in mids:
+                _mark_carried_locked(host, mid)
+
+def _mark_relays_carried(host, relays):
+    """Mark wire `relays` (anything with a mid) carried, for a fold that runs without a flight to end
+    (peer_exchange_apply driven directly — the tests' build → handle → apply): a response still means
+    the relays reached the far bus."""
+    with _outbox_lock:
+        for m in relays or []:
+            mid = str((m or {}).get("mid") or "")
+            if mid:
+                _mark_carried_locked(host, mid)
 
 def readbox_put(host, rec):
     """Park one read receipt for `host` (readbox/<host>/<mid>.json) and poke its exchange. Keyed by
@@ -3815,6 +3992,7 @@ def _budget_relays(host, msgs, budget=None):
     budget = _RELAY_BUDGET_BYTES if budget is None else budget
     out, used = [], 0
     for m in msgs:
+        m = _wire_form(m)                            # measured and emitted as it rides: the carry mark stays home
         n = len(json.dumps(m).encode("utf-8"))
         if n > budget:
             _log("peer %s: relay %s is %d bytes, over the %d-byte exchange limit; bounced to its sender"
@@ -3828,10 +4006,51 @@ def _budget_relays(host, msgs, budget=None):
         used += n
     return out
 
+def _relays_for(host, flight=None):
+    """The relays ONE exchange carries for `host`, from either side of it: the outbox's budgeted prefix
+    (_budget_relays), in wire form, registered under _outbox_lock as ONE flight of this exchange's own
+    — a record a recall removed between the listing and here is left out, so nothing rides that the
+    ledger has closed, and from here to the exchange's outcome (_flight_done) a recall meets the
+    on-its-way refusal instead of unlinking a record whose bytes may already be delivered. `flight`
+    is a list the caller passes to receive the flight's id (an out-parameter, so the wire dict gains
+    nothing); the caller ends it at the outcome. A listing that finds nothing registers no flight, and
+    neither does one with no list to hand the id to: a listing with no flight to end is a read, not a
+    departure (the tests' direct build → handle → apply; the fold then marks by mid), and an entry
+    nobody can end must never be left in _inflight. A record another open flight already holds is
+    listed all the same: skipping it would hold a message
+    back for up to a dial timeout when only one direction of the link works. Nothing durable is
+    written here: the carry mark waits for the outcome (_mark_carried)."""
+    rel = _budget_relays(host, outbox_list(host))     # outside the lock: an oversize relay bounces from here
+    out, mids = [], set()
+    with _outbox_lock:
+        for m in rel:
+            mid = m.get("mid") or ""
+            if not mid or outbox_get(host, mid) is None:
+                continue                             # gone since the listing (recalled, acked, bounced)
+            mids.add(mid)
+            out.append(m)
+        if mids and flight is not None:
+            fid = next(_flight_seq)
+            _inflight.setdefault(host, {})[fid] = mids
+            flight.append(fid)
+    return out
 
-def peer_exchange_handle(data):
+
+def _exchange_peer_name(data):
+    """The name the dialed side files a dialer under: its declared host, canonicalized to the alias we
+    already peer with when its busId proves it is that bus (_canon_peer_name). ONE function for the
+    handler and for the route that marks the response's relays carried after the write (2026-09-08):
+    the handler's own canonicalization files the busId row this lookup reads, so the two agree."""
+    host = str((data or {}).get("host") or "").strip()
+    return _canon_peer_name(host, str((data or {}).get("busId") or ""))
+
+def peer_exchange_handle(data, flight=None):
     """The DIALED side of one exchange. Returns (payload, status). Relays ride under _RELAY_BUDGET_BYTES
-    (_budget_relays), the request side's bound mirrored, so the response is bounded the same way."""
+    (_budget_relays), the request side's bound mirrored, so the response is bounded the same way. The
+    relays it hands out are IN FLIGHT from the listing (_relays_for, which appends the flight's id to
+    `flight`, a list the route passes); the departure event is the response write, so the route ends
+    the flight carried once _send returned (2026-09-08), and freed when it raised — nothing here
+    touches the record or the wire form."""
     host = str((data or {}).get("host") or "").strip()
     if not host:
         return {"error": "host required"}, 400
@@ -3841,7 +4060,7 @@ def peer_exchange_handle(data):
     # Canonicalize BEFORE anything keys on the name: presence files under the alias (no duplicate
     # session rows), and the relays below are trust-judged under the alias the user actually tiered.
     bus_id = str((data or {}).get("busId") or "")
-    host = _canon_peer_name(host, bus_id)
+    host = _exchange_peer_name(data)
     if not _safe_id(host):
         # An unkeyable name would HALF-work: presence lands (PEER_STATE is a dict), but outbox_put
         # refuses it as a path component, so every reply parks "unreachable" with no error anywhere
@@ -3887,39 +4106,49 @@ def peer_exchange_handle(data):
 
     a2, b2 = _drain_backflow()
     acks, bounces = acks + a2, bounces + b2
-    rel, reads = _budget_relays(host, outbox_list(host)), readbox_list(host)
+    reads, rel = readbox_list(host), _relays_for(host, flight)   # the listing last: it puts records in flight
     if not rel and not reads and data.get("wait") and not acks and not bounces:
         # nothing to hand back → park on the wake so anything we accept mid-wait crosses instantly
         _peer_wake(host).clear()
         _peer_wake(host).wait(EXCHANGE_WAIT)
-        rel, reads = _budget_relays(host, outbox_list(host)), readbox_list(host)
+        reads, rel = readbox_list(host), _relays_for(host, flight)
         a2, b2 = _drain_backflow()
         acks, bounces = acks + a2, bounces + b2
     # `reads` stay parked until the dialer's NEXT request readAcks them — a response can vanish
     # after we send it, so the dialed side never clears on send. Re-applying a duplicate is a no-op.
-    return {"host": self_host(), "epoch": BUS_EPOCH, "proto": PEER_PROTO, "busId": BUS_ID,
-            "presence": fleet_presence(host), "holds": holds_payload(host),
-            "tier": my_tier_of(host),                # how WE hold the dialer's mail (display/mirror, never the gate)
-            "relays": rel, "acks": acks, "bounces": bounces, "reads": reads,
-            "readsKept": reads_kept}, 200            # see _read_arrived (2026-09-08)
+    try:
+        return {"host": self_host(), "epoch": BUS_EPOCH, "proto": PEER_PROTO, "busId": BUS_ID,
+                "presence": fleet_presence(host), "holds": holds_payload(host),
+                "tier": my_tier_of(host),            # how WE hold the dialer's mail (display/mirror, never the gate)
+                "relays": rel, "acks": acks, "bounces": bounces, "reads": reads,
+                "readsKept": reads_kept}, 200        # see _read_arrived (2026-09-08)
+    except Exception:
+        for fid in flight or []:
+            _flight_done(host, fid, carried=False)   # no response will carry them: freed, they ride next time
+        raise
 
-def build_exchange_request(host, wait=True):
+def build_exchange_request(host, wait=True, flight=None):
     """The DIALER's request for one exchange. The relays are the outbox's oldest-first prefix under
     _RELAY_BUDGET_BYTES (_budget_relays); the rest ride the next round, so a backlog drains over a few
     exchanges instead of being refused whole."""
     p = _pending(host)
     with _peer_lock:
         acks, bounces, read_acks = list(p["acks"]), list(p["bounces"]), list(p.get("readAcks") or [])
-    relays = _budget_relays(host, outbox_list(host))          # may bounce (a backward bounce joins the
-    #                                                           origin's pending queue): after the snapshot
-    return {"host": self_host(), "epoch": BUS_EPOCH, "proto": PEER_PROTO, "busId": BUS_ID,
-            "presence": fleet_presence(host), "holds": holds_payload(host),
-            "tier": my_tier_of(host),                # how WE hold the dialed host's mail
-            "relays": relays,
-            "acks": acks, "bounces": bounces,
-            "reads": readbox_list(host), "readAcks": read_acks, "wait": bool(wait)}
+    req = {"host": self_host(), "epoch": BUS_EPOCH, "proto": PEER_PROTO, "busId": BUS_ID,
+           "presence": fleet_presence(host), "holds": holds_payload(host),
+           "tier": my_tier_of(host),                 # how WE hold the dialed host's mail
+           "acks": acks, "bounces": bounces,
+           "reads": readbox_list(host), "readAcks": read_acks, "wait": bool(wait)}
+    req["relays"] = _relays_for(host, flight)    # may bounce (a backward bounce joins the origin's pending
+    #                                              queue): after the snapshot. Each relay is IN FLIGHT from
+    #                                              here (a recall is told it is on its way) until the dial's
+    #                                              outcome marks it carried or frees it (_peer_exchange_once,
+    #                                              through the flight id `flight` receives; the wire gains nothing).
+    #                                              The LAST step on purpose: nothing after it can raise and
+    #                                              leave a record in flight with no outcome to free it
+    return req
 
-def peer_exchange_apply(host, req_sent, resp):
+def peer_exchange_apply(host, req_sent, resp, flight=None):
     """The DIALER's half: fold one exchange response in. `req_sent` is the request that produced it —
     its included acks/bounces/readAcks are now delivered and leave the pending queue (kept on send
     failure), and its reads leave the readbox: a response means the dialed side processed the whole
@@ -3951,6 +4180,16 @@ def peer_exchange_apply(host, req_sent, resp):
         _ack_arrived(host, mid)
     for b in resp.get("bounces") or []:
         _bounce_arrived(host, b)
+    # A response means the dialed side processed the whole request: the relays it carried have
+    # LEFT (2026-09-08). Marked after the acks and bounces above, so a record they just closed is
+    # simply not there to mark, and no temp is ever written beside a record about to be deleted.
+    # `flight`: the ids the request's build registered (_peer_exchange_once passes them); a caller
+    # without one (build → handle → apply driven directly) still marks the relays it carried.
+    if flight:
+        for fid in flight:
+            _flight_done(host, fid, carried=True)
+    else:
+        _mark_relays_carried(host, req_sent.get("relays") or [])
     for r in resp.get("reads") or []:                # response-carried receipts: apply, ack on the NEXT dial
         if not _read_arrived(host, r):
             continue                                 # not applied → no readAck: the dialed side re-sends it
@@ -4030,50 +4269,83 @@ def _peer_http(port, payload, token=""):
     with urllib.request.urlopen(req, timeout=EXCHANGE_WAIT + 10) as r:
         return json.loads(r.read().decode() or "{}")
 
+def _peer_exchange_once(host, port, token):
+    """One exchange with `host`, from the request to the folded-in response. Returns the OUTCOME, which
+    is also the carry event for the request's relays (2026-09-08; _flight_done):
+    - 'ok': a response. peer_exchange_apply folds it in and marks the relays carried after the acks
+      and bounces; if the fold itself fails the relays are marked here (the far bus answered, so it
+      processed them) and the failure is said.
+    - 'lost': raised AFTER the request went out (a read timeout, a dropped connection, an undecodable
+      body — anything urllib does not wrap): the far bus may have taken the relays and answered into
+      the void, so they are marked carried; the re-relay next round is deduped over there.
+    - 'unsent': urllib.error.URLError — the connect or the send failed (refused, unresolved, a connect
+      timeout, a pipe broken mid-send): the request never arrived; nothing is marked.
+    - 'drift': HTTP 409, the protocol handshake refused it before any relay was read; nothing marked.
+    - 'refused': any other HTTP status — the token gate, the unsafe-host check, a bad body — all of
+      which precede relay intake (a handler exception over there yields no response at all, not a
+      status); nothing marked. Each distinct refusal is said once.
+    _peer_loop keys its waits on the return."""
+    flight = []                                  # the id of the flight the build registers (out-parameter)
+    req = build_exchange_request(host, wait=True, flight=flight)
+
+    def _end(carried):
+        for fid in flight:
+            _flight_done(host, fid, carried=carried)
+    try:
+        resp = _peer_http(port, req, token)
+    except urllib.error.HTTPError as e:
+        _end(False)                                  # answered before intake: nothing left
+        if e.code == 409:
+            st = PEER_STATE.setdefault(host, {})
+            if st.get("drift") != "proto":
+                st["drift"] = "proto"
+                _log("peer %s: protocol drift — update romp on one side" % host)
+            return "drift"
+        body = ""
+        try:
+            body = " ".join((e.read() or b"").decode("utf-8", "replace").split())[:200]
+        except Exception:
+            pass
+        st = PEER_STATE.setdefault(host, {})
+        if st.get("refused") != (e.code, body):      # each DISTINCT refusal once, not per retry —
+            st["refused"] = (e.code, body)           # a 4xx (e.g. the unsafe-host gate) otherwise
+            _log("peer %s: exchange refused (HTTP %s) %s" % (host, e.code, body))   # retries silently forever
+        return "refused"
+    except urllib.error.URLError:
+        _end(False)                                  # the request never arrived
+        return "unsent"
+    except Exception:
+        _end(True)                                   # it went out; the answer was lost
+        return "lost"
+    try:
+        peer_exchange_apply(host, req, resp, flight=flight)
+    except Exception as e:
+        _log("peer %s: apply failed: %s" % (host, e))
+        _end(True)                                   # the far bus answered: the relays reached it (a no-op
+        #                                              when the fold got as far as ending the flight itself)
+    return "ok"
+
 def _peer_loop(host):
     """One dialer per up peer: exchange, fold the response in, repeat — the dialed side's long-poll
     sets the pace, so a healthy loop is one parked request, not a poll. Exponential backoff (capped
-    30s) on connection errors only; exits when the kernel marks the peer down or the flag drops."""
+    30s) on connection errors only; exits when the kernel marks the peer down or the flag drops.
+    The body is _peer_exchange_once; this loop only paces it."""
     fails = 0
     while peers_on():
         p = PEERS.get(host)
         if not p or not p.get("up"):
             break
-        req = build_exchange_request(host, wait=True)
-        try:
-            resp = _peer_http(p["port"], req, p.get("token") or "")
-        except urllib.error.HTTPError as e:
-            if e.code == 409:
-                st = PEER_STATE.setdefault(host, {})
-                if st.get("drift") != "proto":
-                    st["drift"] = "proto"
-                    _log("peer %s: protocol drift — update romp on one side" % host)
-                _peer_wake(host).clear()
-                _peer_wake(host).wait(60)
-                continue
-            body = ""
-            try:
-                body = " ".join((e.read() or b"").decode("utf-8", "replace").split())[:200]
-            except Exception:
-                pass
-            st = PEER_STATE.setdefault(host, {})
-            if st.get("refused") != (e.code, body):      # each DISTINCT refusal once, not per retry —
-                st["refused"] = (e.code, body)           # a 4xx (e.g. the unsafe-host gate) otherwise
-                _log("peer %s: exchange refused (HTTP %s) %s" % (host, e.code, body))   # retries silently forever
-            fails += 1
-            _peer_wake(host).clear()
-            _peer_wake(host).wait(min(30, 2 ** min(fails, 5)))
+        outcome = _peer_exchange_once(host, p["port"], p.get("token") or "")
+        if outcome == "ok":
+            fails = 0
             continue
-        except Exception:
-            fails += 1
+        if outcome == "drift":
             _peer_wake(host).clear()
-            _peer_wake(host).wait(min(30, 2 ** min(fails, 5)))
+            _peer_wake(host).wait(60)
             continue
-        fails = 0
-        try:
-            peer_exchange_apply(host, req, resp)
-        except Exception as e:
-            _log("peer %s: apply failed: %s" % (host, e))
+        fails += 1
+        _peer_wake(host).clear()
+        _peer_wake(host).wait(min(30, 2 ** min(fails, 5)))
     with _peer_lock:
         _peer_threads.pop(host, None)
 
@@ -4309,7 +4581,7 @@ MCP_TOOLS = [
      "description": "See your recently sent messages and whether each was read/acted on by the recipient yet, or is still pending — instead of asking 'did you get it?'.",
      "inputSchema": {"type": "object", "properties": {}}},
     {"name": "recall_message",
-     "description": "Unsend a still-unread (queued) message when the ask went moot. Give 'to' to recall your unread message(s) to them, or add 'id' (from check_sent) for one. Only your own unread messages; anything already read is gone.",
+     "description": "Withdraw a message that is still here when the ask went moot: unread mail to a session on this machine, or mail to another machine that has not left for it yet (check_sent shows which). Give 'to' to withdraw your message(s) to them, or add 'id' (from check_sent) for one. Only your own; anything already read, or already on its way to another machine, is gone.",
      "inputSchema": {"type": "object",
                      "properties": {"to": {"type": "string", "description": "recipient session name (or UUID) whose queued message(s) from you to cancel"},
                                     "id": {"type": "string", "description": "optional specific message id (from check_sent) to recall just that one"}}}},
@@ -4402,13 +4674,23 @@ def _mcp_call(name, args):
             return "Give 'to' (the recipient) and/or 'id' to recall.", True
         if not mid:
             return "Not inside a romp session.", True
-        removed = _http("POST", "/recall", {"from_id": mid, "to": to, "id": rid}).get("removed", [])
-        if not removed:
+        res = _http("POST", "/recall", {"from_id": mid, "to": to, "id": rid})
+        removed, kept = res.get("removed", []), res.get("kept", [])
+        if not removed and not kept:
             return ("Nothing to recall — no unread message from you matched "
-                    "(it was already read, or nothing's queued there).", False)
-        lines = ["Recalled %d message(s) before they were read:" % len(removed)]
-        for r in removed:
-            lines.append("  ✕ to %s: %s" % (r["to"], r["body"]))
+                    "(it was already read or delivered, or nothing's queued there).", False)
+        lines = []
+        if removed:
+            lines.append("Recalled %d message(s) before they were read:" % len(removed))
+            for r in removed:
+                lines.append("  ✕ to %s: %s" % (r["to"], r["body"]))
+        for k in kept:                           # an outbox item the bus refused to withdraw (2026-09-08): carried
+            #                                      (it left; the tail says what that may mean) or in flight (try
+            #                                      again in a moment — never "too late" in the same breath)
+            why = k.get("why") or (WHY_CARRIED % k.get("host", "?"))
+            tail = "; they may already have read it" if k.get("carried") else ""
+            lines.append('  ✗ NOT recalled — to %s (id %s): it %s%s. "%s"'
+                         % (k.get("to", "?"), k.get("id", "?"), why, tail, k.get("body", "")))
         return "\n".join(lines), False
     return "Unknown tool: %s" % name, True
 
@@ -4577,13 +4859,18 @@ def cli_recall(argv):
     if not ensure():
         sys.stderr.write("[romp mail] %s\n" % _unreachable_hint()); return 1
     try:
-        removed = _http("POST", "/recall", {"from_id": my_id() or "", "to": to, "id": rid}).get("removed", [])
+        res = _http("POST", "/recall", {"from_id": my_id() or "", "to": to, "id": rid})
     except BusError as e:
         sys.stderr.write("[romp mail] %s\n" % e); return 1
-    if not removed:
-        print("[romp mail] nothing to recall (already read, or none queued to '%s')" % to)
-    else:
+    removed, kept = res.get("removed", []), res.get("kept", [])
+    for k in kept:                               # an outbox item the bus refused to withdraw (2026-09-08); the
+        why = k.get("why") or (WHY_CARRIED % k.get("host", "?"))   # "too late" tail only for one that has left
+        tail = "; they may already have read it" if k.get("carried") else ""
+        print("[romp mail] not recalled: the message to '%s' (id %s) %s%s" % (k.get("to", "?"), k.get("id", "?"), why, tail))
+    if removed:
         print("[romp mail] recalled %d message(s) to '%s' before they were read" % (len(removed), to))
+    elif not kept:
+        print("[romp mail] nothing to recall (already read or delivered, or none queued to '%s')" % to)
     return 0
 
 def cli_wake(argv):

--- a/tests/test_postal_peers.py
+++ b/tests/test_postal_peers.py
@@ -1747,6 +1747,41 @@ class RecallAfterTheCarry(_TwoBusHarness):
         self.assertIsNone(pm.outbox_get("srv", "c1").get("carried"))
         self.assertEqual([r["id"] for r in pm._recall("sid-a", "", "c1")], ["c1"], "still here, still the sender's")
 
+    def test_a_connection_closed_before_any_status_line_marks_nothing(self):
+        # through the kernel's ssh -L forward a far bus that is not listening (its restart window, a
+        # crash) looks like this: the local ssh listener accepts, the request goes out to it, ssh fails
+        # the channel and closes the socket, and getresponse raises RAW (urllib wraps only the connect
+        # and the send in URLError). The generic arm took it for a lost answer and marked the flight
+        # carried, so through every far-bus restart the sender was refused a recall for a message still
+        # in its own outbox (review find, 2026-09-09)
+        import http.client
+        self._park()
+
+        def closed(req):
+            raise http.client.RemoteDisconnected("Remote end closed connection without response")
+        outcome, req = self._dial(closed)
+        self.assertEqual(outcome, "unsent")
+        self.assertEqual([m["mid"] for m in req["relays"]], ["c1"], "the request listed it…")
+        self.assertIsNone(pm.outbox_get("srv", "c1").get("carried"), "…but no bus read it: no mark")
+        self.assertEqual(self._open(pm, "srv"), set(), "the flight is closed, not left open")
+        kept = []
+        self.assertEqual([r["id"] for r in pm._recall("sid-a", "", "c1", kept=kept)], ["c1"], "still here, still the sender's")
+        self.assertEqual(kept, [])
+        self.assertEqual(len(self._recall_rows()), 1)
+        self.assertEqual(pm.outbox_list("srv"), [])
+
+    def test_a_reset_connection_marks_nothing(self):
+        # the same shape when the tunnel's close arrives as a reset rather than a clean EOF
+        self._park()
+
+        def reset(req):
+            raise ConnectionResetError(104, "Connection reset by peer")
+        outcome, _ = self._dial(reset)
+        self.assertEqual(outcome, "unsent")
+        self.assertIsNone(pm.outbox_get("srv", "c1").get("carried"))
+        self.assertEqual(self._open(pm, "srv"), set())
+        self.assertEqual([r["id"] for r in pm._recall("sid-a", "", "c1")], ["c1"], "still here, still the sender's")
+
     def test_a_lost_response_marks_the_relays_carried(self):
         # a read timeout is raised after the request went out: the far bus may hold the message
         self._park()

--- a/tests/test_postal_peers.py
+++ b/tests/test_postal_peers.py
@@ -162,6 +162,9 @@ class _TwoBusHarness(unittest.TestCase):
             m.PEER_STATE.clear()
             m.PEERS.clear()
             m._peer_pending.clear()
+            getattr(m, "_inflight", {}).clear()      # no exchange is carrying anything at the start of a test
+            #                                          (getattr: the module also runs against a bus without the
+            #                                          flight table, to show each new test red for its own reason)
             m._seen_ids = None
         import shutil
         for m in (pm, pmb):
@@ -1566,3 +1569,663 @@ class BusStartSweepsUnfinishedWrites(_LoudBus):
         self.assertIn("_sweep_unfinished_writes()", src)
         self.assertLess(src.index("_sweep_unfinished_writes()"), src.index("ThreadingHTTPServer("),
                         "the sweep runs at start, before any writer of ours can run")
+
+
+class RecallAfterTheCarry(_TwoBusHarness):
+    """A recall reaches a parked cross-host record only until an exchange CARRIES it (2026-09-08). The
+    record stays in the outbox until the END-TO-END ack — one round trip normally, a whole outage when
+    a response was lost and the dialer re-relays under its backoff — and the far bus delivers on
+    arrival, so on origin/main a recall in that window unlinked a message the recipient already held
+    and filed a terminal recall row for it: the sender's receipts read withdrawn for a message that
+    was read, and any reader that treats a recall as final would close a live ask on it.
+
+    The carry is an exact mark on the record (`carried`, `carriedVia`), keyed on the exchange's
+    OUTCOME, never on the request being built (a first cut marked at build and so refused a recall
+    through every failed dial): the dialer marks on a response, or on a failure raised after the
+    request went out; a refused status or a failed connect marks nothing; the dialed side marks once
+    its response write returned. From the listing to that outcome the record is in flight, and a
+    recall is told it is on its way. A carried record is refused with the reason (`kept`), stays, and
+    writes no row; every recall row names its box (`new` / `outbox`); check_sent shows a carried
+    record as left, awaiting confirmation, the same fact the recall refuses on. Two exchanges for one
+    host run at once by design (our dialer, their dial of us): each listing is its own flight, and ending
+    one releases nothing another still holds."""
+
+    def setUp(self):
+        super().setUp()
+        for m in (pm, pmb):
+            try:
+                (m.TLDIR / "messages.jsonl").unlink()
+            except FileNotFoundError:
+                pass
+
+    @staticmethod
+    def _open(m, host):
+        """The mids every open flight for `host` holds on bus `m`."""
+        return set().union(*((m._inflight.get(host) or {}).values()))
+
+    def _rows(self, m=None):
+        log = (m or pm).TLDIR / "messages.jsonl"
+        return [json.loads(l) for l in log.read_text().splitlines()] if log.exists() else []
+
+    def _recall_rows(self, m=None):
+        return [r for r in self._rows(m) if r.get("ev") == "recall"]
+
+    def _park(self, mid="c1", body="please review the notes-api branch"):
+        pm.outbox_put("srv", {"mid": mid, "to": "beta", "frm": "alpha", "frm_id": "sid-a",
+                              "body": body, "kind": "question", "t": 1})
+
+    def _dial(self, fn):
+        """One exchange from A's dialer with the HTTP leg replaced by fn(req) — return a response, or
+        raise what urllib would. Returns (outcome, the request that went out)."""
+        seen, saved = [], pm._peer_http
+
+        def http(port, req, token=""):
+            seen.append(req)
+            return fn(req)
+        pm._peer_http = http
+        try:
+            return pm._peer_exchange_once("srv", 1, ""), seen[0]
+        finally:
+            pm._peer_http = saved
+
+    def _via_b(self, req):
+        resp, status = pmb.peer_exchange_handle(req)
+        self.assertEqual(status, 200)
+        return resp
+
+    @staticmethod
+    def _lost(req):
+        import socket
+        raise socket.timeout("timed out")             # raised by getresponse: AFTER the request went out
+
+    # ── the rows and the uncarried case ─────────────────────────────────────────────────────────
+
+    def test_an_uncarried_item_is_recalled_and_the_row_names_the_outbox(self):
+        self._park()
+        kept = []
+        removed = pm._recall("sid-a", "", "c1", kept=kept)
+        self.assertEqual([r["id"] for r in removed], ["c1"], "still parked here: the recall wins")
+        self.assertEqual(kept, [])
+        self.assertEqual(pm.outbox_list("srv"), [])
+        self.assertEqual([(r["id"], r["box"], r["host"]) for r in self._recall_rows()], [("c1", "outbox", "srv")],
+                         "the row says which box it left, by field")
+
+    def test_a_maildir_recall_row_names_the_new_box(self):
+        mid = pm.deliver(_RCP, "alpha", "sid-a", "a local ask", kind="question")
+        removed = pm._recall("sid-a", "", mid)
+        self.assertEqual([r["id"] for r in removed], [mid])
+        self.assertEqual([(r["id"], r["box"]) for r in self._recall_rows()], [(mid, "new")])
+
+    # ── the defect, end to end ──────────────────────────────────────────────────────────────────
+
+    def test_a_message_the_far_side_already_holds_is_not_withdrawn(self):
+        # the request carried it and B delivered on arrival; the end-to-end ack is not yet folded in on
+        # A. Main unlinked the record and filed a recall row here — the recipient reading a message its
+        # sender's receipts called withdrawn
+        self._park()
+        flight = []                                  # the dialer's shape: the build registers a flight it will end
+        req = pm.build_exchange_request("srv", wait=False, flight=flight)
+        resp, status = pmb.peer_exchange_handle(req)
+        self.assertEqual(status, 200)
+        self.assertEqual(len(pmb.read_box("sid-b", consume=False)), 1, "B holds it")
+        self.assertEqual(pm._recall("sid-a", "", "c1"), [], "a message the far side already holds is not withdrawn")
+        self.assertEqual(self._recall_rows(), [], "and no recall row says otherwise")
+        pm.peer_exchange_apply("srv", req, resp, flight=flight)
+        self.assertIsNone(pm.outbox_get("srv", "c1"), "the ack folds in: the record is gone")
+        self.assertEqual([r["ev"] for r in self._rows() if r.get("id") == "c1"], ["relayed"], "the ledger says delivered")
+        self.assertEqual(len(pmb.read_box("sid-b", consume=True)), 1)
+
+    def test_the_dialed_sides_copy_of_a_message_the_far_side_already_holds_cannot_be_withdrawn(self):
+        # The core defect through the real wire, in names main has: B's parked reply rides B's RESPONSE
+        # (a real server over B's Handler, A dialing it with the plain request shape), A delivers it to
+        # alpha, and the end-to-end ack is not back yet — B's copy is still in its outbox. On main B's
+        # recall then unlinked that copy and filed a recall row: withdrawn on the ledger, read on A.
+        pmb.outbox_put("hosta", {"mid": "r9", "to": "alpha", "frm": "beta", "frm_id": "sid-b",
+                                 "body": "the schema is frozen, ship it", "kind": "coordinate", "t": 1})
+        port = self._serve(pmb)
+        req = pm.build_exchange_request("srv", wait=False)
+        resp = pm._peer_http(port, req, token=pmb.SERVE_TOKEN)
+        self.assertEqual([m["mid"] for m in resp["relays"]], ["r9"], "B's response carried it")
+        pm.peer_exchange_apply("srv", req, resp)
+        held = pm.read_box("sid-a", consume=False)
+        self.assertEqual(len(held), 1, "alpha holds it on A")
+        self.assertEqual(pmb._recall("sid-b", "", "r9"), [], "the far side already holds it: B's copy is not withdrawn")
+        self.assertEqual(self._recall_rows(pmb), [], "and no recall row says otherwise")
+        self.assertIsNotNone(pmb.outbox_get("hosta", "r9"), "B's copy stays for A's ack")
+        self.assertIn("ship it", pm.read_box("sid-a", consume=True)[0]["body"], "alpha still has the message")
+
+    # ── the dialer: the dial's outcome is the event ─────────────────────────────────────────────
+
+    def test_building_the_request_marks_nothing_but_puts_the_record_in_flight(self):
+        # the mark keys on the outcome, never on the build: a request built is not a request delivered.
+        # Between the two the record is in flight, and a recall is told so instead of being granted —
+        # main granted it, for bytes the dial was about to put on the wire
+        self._park()
+        flight = []
+        req = pm.build_exchange_request("srv", wait=False, flight=flight)
+        self.assertEqual([m["mid"] for m in req["relays"]], ["c1"])
+        self.assertNotIn("carried", req["relays"][0], "the mark is this bus's bookkeeping, never on the wire")
+        self.assertIsNone(json.loads((pm.OUTBOX / "srv" / "c1.json").read_text()).get("carried"),
+                          "nothing durable is written at build")
+        self.assertEqual(len(flight), 1, "the build registered one flight and handed its id back")
+        self.assertEqual(self._open(pm, "srv"), {"c1"})
+        kept = []
+        self.assertEqual(pm._recall("sid-a", "", "c1", kept=kept), [], "in flight: not granted")
+        self.assertEqual([(k["id"], k["why"], k["carried"]) for k in kept], [("c1", pm.WHY_IN_FLIGHT % "srv", None)])
+        self.assertEqual(self._recall_rows(), [])
+        pm._flight_done("srv", flight[0], carried=False)   # the test stands in for a dial that never connected
+        self.assertEqual([r["id"] for r in pm._recall("sid-a", "", "c1")], ["c1"], "freed: the recall wins")
+
+    def test_a_protocol_drift_refusal_marks_nothing_and_the_recall_still_wins(self):
+        # the 409 arm waits 60 s between dials; a mark at build would have refused the recall throughout,
+        # for bytes the far bus refused before it read a relay
+        import io
+        import urllib.error
+        self._park()
+
+        def drift(req):
+            raise urllib.error.HTTPError("http://127.0.0.1:1/peer-exchange", 409, "drift", {},
+                                         io.BytesIO(b'{"error": "peer protocol drift"}'))
+        outcome, req = self._dial(drift)
+        self.assertEqual(outcome, "drift")
+        self.assertEqual([m["mid"] for m in req["relays"]], ["c1"], "the request carried it…")
+        self.assertIsNone(pm.outbox_get("srv", "c1").get("carried"), "…but nothing reached the far bus: no mark")
+        kept = []
+        self.assertEqual([r["id"] for r in pm._recall("sid-a", "", "c1", kept=kept)], ["c1"], "recalled, as on main")
+        self.assertEqual(kept, [])
+        self.assertEqual(len(self._recall_rows()), 1)
+
+    def test_a_refused_connection_marks_nothing(self):
+        # urllib wraps every connect/send failure in URLError: the request never arrived
+        import urllib.error
+        self._park()
+
+        def refused(req):
+            raise urllib.error.URLError(ConnectionRefusedError(111, "Connection refused"))
+        outcome, _ = self._dial(refused)
+        self.assertEqual(outcome, "unsent")
+        self.assertIsNone(pm.outbox_get("srv", "c1").get("carried"))
+        self.assertEqual([r["id"] for r in pm._recall("sid-a", "", "c1")], ["c1"], "still here, still the sender's")
+
+    def test_a_lost_response_marks_the_relays_carried(self):
+        # a read timeout is raised after the request went out: the far bus may hold the message
+        self._park()
+        outcome, req = self._dial(self._lost)
+        self.assertEqual(outcome, "lost")
+        self.assertNotIn("carried", req["relays"][0])
+        on_disk = json.loads((pm.OUTBOX / "srv" / "c1.json").read_text())   # from disk, not from memory
+        self.assertTrue(on_disk.get("carried"), "the departure is recorded on the record itself")
+        self.assertEqual(on_disk.get("carriedVia"), "srv")
+        kept = []
+        self.assertEqual(pm._recall("sid-a", "", "c1", kept=kept), [], "a carried item is not withdrawn")
+        self.assertEqual([(k["id"], k["to"], k["host"]) for k in kept], [("c1", "srv:beta", "srv")])
+        self.assertEqual(kept[0]["why"], "already left for srv and can no longer be withdrawn")
+        self.assertEqual(kept[0]["carried"], on_disk["carried"])
+        self.assertIn("notes-api", kept[0]["body"], "the sender can tell which message this was")
+        self.assertEqual([m["mid"] for m in pm.outbox_list("srv")], ["c1"], "it stays parked for its ack")
+        self.assertEqual(self._recall_rows(), [], "no recall row: nothing about the message changed")
+
+    def test_a_recall_by_recipient_name_meets_the_same_refusal(self):
+        # the `to` form the tool and `romp mail recall <to>` send; a caller passing no list still gets
+        # nothing removed, only without the reason
+        self._park()
+        self._dial(self._lost)
+        kept = []
+        self.assertEqual(pm._recall("sid-a", "srv:beta", "", kept=kept), [])
+        self.assertEqual([k["id"] for k in kept], ["c1"])
+        self.assertEqual(pm._recall("sid-a", "srv:beta", ""), [])
+        self.assertEqual(len(pm.outbox_list("srv")), 1)
+
+    def test_a_response_whose_ack_covers_the_relay_clears_the_record_with_no_stray_temp(self):
+        self._park()
+        outcome, req = self._dial(self._via_b)
+        self.assertEqual(outcome, "ok")
+        self.assertIsNone(pm.outbox_get("srv", "c1"), "acked end to end: the record is gone")
+        self.assertEqual([p.name for p in (pm.OUTBOX / "srv").iterdir()], [],
+                         "no temp beside it: the mark is written after the acks, so a closed record is never rewritten")
+        self.assertEqual([r["id"] for r in self._rows() if r.get("ev") == "relayed"], ["c1"])
+        self.assertEqual(len(pmb.read_box("sid-b", consume=True)), 1)
+        self.assertEqual(self._open(pm, "srv"), set(), "nothing left in flight")
+
+    def test_a_response_that_does_not_ack_the_relay_marks_it_carried(self):
+        # B's listing did not answer (its kernel mid-restart): _relay_in rules 'retry', silence on the
+        # wire — yet the relay reached B, and B re-processes the re-relay in full next round
+        self._park()
+        pmb.local_agents_checked = lambda threads=False: ([], False)
+        outcome, req = self._dial(self._via_b)
+        self.assertEqual(outcome, "ok")
+        rec = pm.outbox_get("srv", "c1")
+        self.assertTrue(rec.get("carried"), "no ack, no bounce: the record stays, marked as left")
+        self.assertEqual(rec.get("carriedVia"), "srv")
+        kept = []
+        self.assertEqual(pm._recall("sid-a", "", "c1", kept=kept), [])
+        self.assertEqual(kept[0]["why"], pm.WHY_CARRIED % "srv")
+        self.assertEqual(len(pm.outbox_list("srv")), 1)
+        self.assertEqual(self._recall_rows(), [])
+
+    def test_a_recall_during_the_dial_is_told_on_its_way_and_the_outcome_decides(self):
+        # between the listing and the outcome the bytes are on the wire or about to be: a recall then is
+        # neither granted (the recipient may already hold them) nor told they left (a refused dial means
+        # they never will) — it is told to try again in a moment, and the outcome decides
+        import urllib.error
+        during = []
+
+        def recall_now(mid):
+            kept = []
+            during.append((pm._recall("sid-a", "", mid, kept=kept), kept))
+
+        def refused_after_a_recall(req):
+            recall_now("c1")
+            raise urllib.error.URLError(ConnectionRefusedError(111, "Connection refused"))
+
+        def lost_after_a_recall(req):
+            recall_now("c2")
+            self._lost(req)
+        self._park("c1")
+        self._dial(refused_after_a_recall)
+        removed, kept = during[0]
+        self.assertEqual(removed, [])
+        self.assertEqual([(k["id"], k["why"], k["carried"]) for k in kept],
+                         [("c1", pm.WHY_IN_FLIGHT % "srv", None)], "in flight: on its way, not left")
+        self.assertEqual(self._recall_rows(), [], "no row was written for a refused recall")
+        self.assertEqual([r["id"] for r in pm._recall("sid-a", "", "c1")], ["c1"],
+                         "the dial failed to connect: the recall wins after all")
+        self._park("c2")
+        self._dial(lost_after_a_recall)
+        self.assertEqual(during[1][0], [])
+        self.assertEqual(during[1][1][0]["why"], pm.WHY_IN_FLIGHT % "srv")
+        kept = []
+        self.assertEqual(pm._recall("sid-a", "", "c2", kept=kept), [])
+        self.assertEqual(kept[0]["why"], pm.WHY_CARRIED % "srv", "the response was lost: it left for good")
+        self.assertEqual(self._open(pm, "srv"), set(), "every outcome empties the flight")
+
+    def test_a_recall_that_lands_between_the_listing_and_the_flight_keeps_the_message_off_the_wire(self):
+        # the exchange carries only what it put in flight: a record the recall removed after the listing
+        # read it never rides, so the recall it granted was honest
+        self._park()
+        saved = pm.outbox_list
+
+        def listed_then_recalled(host):
+            recs = saved(host)
+            self.assertEqual([r["id"] for r in pm._recall("sid-a", "", "c1")], ["c1"])
+            return recs
+        pm.outbox_list = listed_then_recalled
+        try:
+            req = pm.build_exchange_request("srv", wait=False)
+        finally:
+            pm.outbox_list = saved
+        self.assertEqual(req["relays"], [], "nothing rides that the ledger has closed")
+        self.assertEqual(len(self._recall_rows()), 1)
+        self.assertEqual(self._open(pm, "srv"), set(), "an empty listing registers no flight")
+
+    def test_a_re_relay_keeps_the_first_departure_and_the_ack_still_deletes(self):
+        self._park()
+        outcome, req1 = self._dial(self._lost)
+        first = pm.outbox_get("srv", "c1")["carried"]
+        writes, saved = [], pm._atomic_json_put
+        pm._atomic_json_put = lambda p, o: writes.append(p) or saved(p, o)
+        try:
+            outcome, req2 = self._dial(self._lost)   # the link is bad; it rides again and is lost again
+        finally:
+            pm._atomic_json_put = saved
+        self.assertEqual([m["mid"] for m in req2["relays"]], ["c1"], "it rides again")
+        self.assertEqual(writes, [], "already marked: nothing is rewritten")
+        self.assertEqual(pm.outbox_get("srv", "c1")["carried"], first, "the FIRST departure is the fact")
+        self.assertEqual(json.dumps(req1["relays"]), json.dumps(req2["relays"]),
+                         "the wire form is the same before and after the mark")
+        outcome, req3 = self._dial(self._via_b)      # the link heals: B takes it and acks
+        self.assertEqual(outcome, "ok")
+        self.assertIsNone(pm.outbox_get("srv", "c1"), "the end-to-end ack still clears the record")
+        self.assertEqual([r["id"] for r in self._rows() if r.get("ev") == "relayed"], ["c1"])
+        self.assertEqual(len(pmb.read_box("sid-b", consume=True)), 1, "delivered exactly once")
+        kept = []                                    # a recall that races the ack: the ack removed it first
+        self.assertEqual(pm._recall("sid-a", "", "c1", kept=kept), [])
+        self.assertEqual(kept, [])
+        self.assertEqual(self._recall_rows(), [], "nothing to recall and no row: it was delivered, not withdrawn")
+
+    def test_the_mark_survives_a_reload_of_the_bus(self):
+        # the mark lives on the record: a bus restarted between the carry and the ack (a fresh module
+        # instance over the same store) still refuses the recall
+        self._park()
+        self._dial(self._lost)
+        env = os.environ.get("XDG_STATE_HOME")
+        os.environ["XDG_STATE_HOME"] = str(pm.OUTBOX.parents[2])   # outbox → postal → romp → the XDG root
+        try:
+            fresh = SourceFileLoader("romp_postal_peers_fresh", os.path.join(BIN, "romp-postal-service")).load_module()
+        finally:
+            os.environ["XDG_STATE_HOME"] = env
+        self.assertEqual(fresh.OUTBOX, pm.OUTBOX, "the fresh bus reads the same store")
+        kept = []
+        self.assertEqual(fresh._recall("sid-a", "", "c1", kept=kept), [])
+        self.assertEqual([(k["id"], k["host"]) for k in kept], [("c1", "srv")])
+        self.assertEqual(len(pm.outbox_list("srv")), 1)
+
+    def test_a_mark_that_cannot_be_written_is_said_and_leaves_the_record_recallable(self):
+        # the record RODE; its departure could not be recorded, so a recall can still withdraw it — the
+        # behaviour before the mark — and the log says so by id
+        self._park()
+        logged, saved = [], (pm._atomic_json_put, pm._log)
+
+        def boom(p, o):
+            raise OSError(28, "No space left on device")
+        pm._atomic_json_put, pm._log = boom, lambda m: logged.append(m)
+        try:
+            outcome, _ = self._dial(self._lost)
+        finally:
+            pm._atomic_json_put, pm._log = saved
+        self.assertEqual(outcome, "lost")
+        self.assertIsNone(pm.outbox_get("srv", "c1").get("carried"))
+        said = [m for m in logged if "c1" in m and "departure could not be recorded" in m]
+        self.assertEqual(len(said), 1, logged)
+        self.assertIn("a recall can still withdraw it", said[0])
+        self.assertEqual(self._open(pm, "srv"), set(), "freed: no refusal outlives the outcome")
+        self.assertEqual([r["id"] for r in pm._recall("sid-a", "", "c1")], ["c1"])
+
+    # ── the dialed side: the response write is the event ───────────────────────────────────────
+
+    def _serve(self, m):
+        srv = ThreadingHTTPServer(("127.0.0.1", 0), m.Handler)
+        srv.handle_error = lambda *a: None           # a handler that raises is the point of one test below
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        self.addCleanup(srv.server_close)
+        self.addCleanup(srv.shutdown)
+        return srv.server_address[1]
+
+    def _outcome_event(self, m, want=None):
+        """m._flight_done wrapped to set an Event (on any outcome, or only on one whose `carried` is `want`):
+        the route records the outcome after the response is on the wire, so the client can hold the
+        response before the handler thread has recorded it. The wrapper keeps _flight_done's parameter
+        names: the route passes `carried=` by keyword."""
+        done, saved = threading.Event(), m._flight_done
+
+        def flight_done(host, flight_id, carried):
+            saved(host, flight_id, carried)
+            if want is None or carried == want:
+                done.set()
+        m._flight_done = flight_done
+        self.addCleanup(setattr, m, "_flight_done", saved)
+        return done
+
+    def _inbound_from_srv(self):
+        """A request as srv would dial A with: nothing to relay, so A's response carries A's outbox."""
+        return {"host": "srv", "proto": pm.PEER_PROTO, "busId": "bus-srv", "epoch": 1, "presence": [], "holds": [],
+                "relays": [], "acks": [], "bounces": [], "reads": [], "readAcks": [], "wait": False}
+
+    def test_the_dialed_side_marks_its_relays_after_the_response_is_written_not_before(self):
+        pmb.outbox_put("hosta", {"mid": "r1", "to": "alpha", "frm": "beta", "frm_id": "sid-b",
+                                 "body": "the port is 8080", "kind": "coordinate", "t": 1})
+        at_write, saved = [], pmb.Handler._send
+
+        def send_then_note(handler, obj, code=200, close=False):
+            if isinstance(obj, dict) and obj.get("relays"):
+                at_write.append((pmb.outbox_get("hosta", "r1") or {}).get("carried"))
+            return saved(handler, obj, code, close)
+        pmb.Handler._send = send_then_note
+        self.addCleanup(setattr, pmb.Handler, "_send", saved)
+        done = self._outcome_event(pmb)
+        port = self._serve(pmb)
+        req = pm.build_exchange_request("srv", wait=False)     # A's outbox is empty: no flight on A's side
+        resp = pm._peer_http(port, req, token=pmb.SERVE_TOKEN)
+        self.assertEqual([m["mid"] for m in resp["relays"]], ["r1"], "the dialed side handed it out")
+        self.assertNotIn("carried", resp["relays"][0])
+        self.assertEqual(at_write, [None], "unmarked while the response was being written")
+        self.assertTrue(done.wait(5), "the route recorded the outcome")
+        rec = pmb.outbox_get("hosta", "r1")
+        self.assertTrue(rec.get("carried"), "marked once the write returned")
+        self.assertEqual(rec.get("carriedVia"), "hosta")
+        kept = []
+        self.assertEqual(pmb._recall("sid-b", "", "r1", kept=kept), [])
+        self.assertEqual([(k["id"], k["host"], k["why"]) for k in kept], [("r1", "hosta", pmb.WHY_CARRIED % "hosta")])
+        self.assertEqual(len(pmb.outbox_list("hosta")), 1)
+        pm.peer_exchange_apply("srv", req, resp)
+        self.assertEqual(len(pm.read_box("sid-a", consume=True)), 1, "A folded it in: delivered")
+        self.assertEqual(self._open(pmb, "hosta"), set(), "the flight ended with the write")
+
+    def test_a_response_that_cannot_be_written_leaves_the_relays_unmarked_to_ride_again(self):
+        pmb.outbox_put("hosta", {"mid": "r2", "to": "alpha", "frm": "beta", "frm_id": "sid-b",
+                                 "body": "the port is 8080", "kind": "coordinate", "t": 1})
+        saved = pmb.Handler._send
+
+        def dead_socket(handler, obj, code=200, close=False):
+            if isinstance(obj, dict) and obj.get("relays"):
+                raise BrokenPipeError(32, "Broken pipe")
+            return saved(handler, obj, code, close)
+        pmb.Handler._send = dead_socket
+        self.addCleanup(setattr, pmb.Handler, "_send", saved)
+        done = self._outcome_event(pmb)
+        port = self._serve(pmb)
+        req = pm.build_exchange_request("srv", wait=False)
+        with self.assertRaises(Exception):           # the connection drops with no response
+            pm._peer_http(port, req, token=pmb.SERVE_TOKEN)
+        self.assertTrue(done.wait(5), "the route recorded the outcome")
+        self.assertIsNone(pmb.outbox_get("hosta", "r2").get("carried"), "nothing left: no mark")
+        self.assertEqual(self._open(pmb, "hosta"), set(), "freed to ride the next exchange")
+        self.assertEqual([r["id"] for r in pmb._recall("sid-b", "", "r2")], ["r2"], "and still the sender's to recall")
+
+    # ── two exchanges for one host at once ─────────────────────────────────────────────────────
+
+    def test_a_flight_that_ends_unsent_releases_nothing_another_open_flight_holds(self):
+        # srv dials A while A's own dialer is out: both list c1. The dialer's exchange never connects and
+        # ends first; srv's response is still being written. With one set per host the first outcome
+        # released c1 and a recall was granted for bytes on the wire (review find, 2026-09-08)
+        import urllib.error
+        self._park()
+        gate, listed = threading.Event(), threading.Event()
+        saved = pm.Handler._send
+
+        def hold_then_send(handler, obj, code=200, close=False):
+            if isinstance(obj, dict) and obj.get("relays"):
+                listed.set()
+                gate.wait(5)                         # the response to srv is mid-write while A's dialer runs
+            return saved(handler, obj, code, close)
+        pm.Handler._send = hold_then_send
+        self.addCleanup(setattr, pm.Handler, "_send", saved)
+        done = self._outcome_event(pm, want=True)
+        port = self._serve(pm)
+        got = []
+        t = threading.Thread(target=lambda: got.append(pmb._peer_http(port, self._inbound_from_srv(), token=pm.SERVE_TOKEN)),
+                             daemon=True)
+        t.start()
+        self.assertTrue(listed.wait(5), "srv's dial listed A's outbox into its flight")
+
+        def refused(req):
+            raise urllib.error.URLError(ConnectionRefusedError(111, "Connection refused"))
+        outcome, req = self._dial(refused)
+        self.assertEqual(outcome, "unsent")
+        self.assertEqual([m["mid"] for m in req["relays"]], ["c1"], "the second listing skips nothing another flight holds")
+        kept = []
+        self.assertEqual(pm._recall("sid-a", "", "c1", kept=kept), [], "srv's exchange still carries it: not granted")
+        self.assertEqual([(k["id"], k["why"]) for k in kept], [("c1", pm.WHY_IN_FLIGHT % "srv")])
+        gate.set()
+        t.join(5)
+        self.assertEqual([m["mid"] for m in got[0]["relays"]], ["c1"], "srv got it in the response")
+        self.assertTrue(done.wait(5), "the route recorded srv's outcome")
+        self.assertTrue(pm.outbox_get("srv", "c1").get("carried"), "the write returned: it left")
+        kept = []
+        self.assertEqual(pm._recall("sid-a", "", "c1", kept=kept), [])
+        self.assertEqual(kept[0]["why"], pm.WHY_CARRIED % "srv")
+        self.assertEqual(self._open(pm, "srv"), set())
+
+    def test_a_flight_that_ends_carried_leaves_the_mark_when_the_other_ends_unsent(self):
+        # the reverse order: srv's dial completes (carried) while A's dialer is out; A's dial then fails
+        # to connect and ends unsent — releasing nothing, since the record is marked
+        import urllib.error
+        self._park()
+        done = self._outcome_event(pm, want=True)
+        port = self._serve(pm)
+
+        def refused_after_srv_carried_it(req):
+            resp = pmb._peer_http(port, self._inbound_from_srv(), token=pm.SERVE_TOKEN)
+            self.assertEqual([m["mid"] for m in resp["relays"]], ["c1"])
+            self.assertTrue(done.wait(5))
+            raise urllib.error.URLError(ConnectionRefusedError(111, "Connection refused"))
+        outcome, req = self._dial(refused_after_srv_carried_it)
+        self.assertEqual(outcome, "unsent")
+        self.assertEqual([m["mid"] for m in req["relays"]], ["c1"])
+        self.assertTrue(pm.outbox_get("srv", "c1").get("carried"), "srv's write returned: it left")
+        kept = []
+        self.assertEqual(pm._recall("sid-a", "", "c1", kept=kept), [])
+        self.assertEqual(kept[0]["why"], pm.WHY_CARRIED % "srv", "the unsent outcome released no mark")
+        self.assertEqual(self._open(pm, "srv"), set())
+
+    def test_ending_a_flight_twice_is_a_no_op_and_a_failed_fold_still_ends_it_carried(self):
+        self._park()
+        pmb.local_agents_checked = lambda threads=False: ([], False)   # B rules 'retry': no ack, the record stays
+        flight = []
+        req = pm.build_exchange_request("srv", wait=False, flight=flight)
+        resp = self._via_b(req)
+        pm.peer_exchange_apply("srv", req, resp, flight=flight)
+        first = pm.outbox_get("srv", "c1")["carried"]
+        self.assertTrue(first)
+        self.assertEqual(self._open(pm, "srv"), set())
+        pm._flight_done("srv", flight[0], carried=True)          # the fold-then-exception path's second call
+        pm._flight_done("srv", flight[0], carried=False)
+        pm._flight_done("srv", 10 ** 9, carried=False)           # an id nobody registered
+        self.assertEqual(pm.outbox_get("srv", "c1")["carried"], first, "no-ops: the mark stands as written")
+        self.assertEqual(self._open(pm, "srv"), set())
+        # a fold that fails before it ends the flight: the dial answered, so the relays reached B
+        self._park("c2")
+        logged, saved = [], (pm._ack_arrived, pm._log)
+        pmb.local_agents_checked = lambda threads=False: (pmb.local_agents(), True)   # B acks c2 this time
+
+        def boom(host, mid):
+            raise RuntimeError("the fold broke")
+        pm._ack_arrived, pm._log = boom, lambda m: logged.append(m)
+        try:
+            outcome, req = self._dial(self._via_b)
+        finally:
+            pm._ack_arrived, pm._log = saved
+        self.assertEqual(outcome, "ok")
+        self.assertTrue(any("apply failed" in m and "the fold broke" in m for m in logged), logged)
+        self.assertTrue(pm.outbox_get("srv", "c2").get("carried"), "ended carried by the once-function")
+        self.assertEqual(self._open(pm, "srv"), set())
+
+    # ── the surfaces ───────────────────────────────────────────────────────────────────────────
+
+    def test_check_sent_shows_a_carried_record_as_left_awaiting_confirmation(self):
+        # the receipt and the recall read the same record: before this the receipt said "queued for
+        # relay" for the very id the recall refused as already left
+        self._park()
+        pm._tl_append("messages.jsonl", {"t": 10, "ev": "sent", "id": "c1", "from": "alpha", "from_id": "sid-a",
+                                         "to_id": "peer:srv", "toName": "srv:beta", "body": "hi", "kind": "question"})
+        row = pm._sent_receipts("sid-a")[-1]
+        self.assertNotIn("carried", row)
+        self.assertIn("queued for relay to srv", pm.format_receipts([row]), "parked, not yet left")
+        self._dial(self._lost)
+        row = pm._sent_receipts("sid-a")[-1]
+        self.assertEqual(row["carried"], pm.outbox_get("srv", "c1")["carried"])
+        line = pm.format_receipts([row])
+        self.assertIn("left for srv %s — awaiting delivery confirmation · id c1" % pm._hhmm_epoch(row["carried"]), line)
+        self.assertNotIn("queued for relay", line)
+        kept = []
+        pm._recall("sid-a", "", "c1", kept=kept)
+        self.assertEqual(kept[0]["why"], pm.WHY_CARRIED % "srv", "the two surfaces agree on the same id")
+
+    def test_the_route_answers_kept_beside_removed(self):
+        self._park("c3")
+        self._dial(self._lost)
+        srv = ThreadingHTTPServer(("127.0.0.1", 0), pm.Handler)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        try:
+            import urllib.request
+            req = urllib.request.Request("http://127.0.0.1:%d/recall" % srv.server_address[1],
+                                         data=json.dumps({"from_id": "sid-a", "id": "c3"}).encode(),
+                                         headers={"Content-Type": "application/json",
+                                                  "X-Romp-Token": pm.SERVE_TOKEN}, method="POST")
+            with urllib.request.urlopen(req, timeout=5) as r:
+                res = json.loads(r.read())
+        finally:
+            srv.shutdown()
+            srv.server_close()
+        self.assertEqual(res["removed"], [])
+        self.assertEqual([(k["id"], k["host"]) for k in res["kept"]], [("c3", "srv")])
+        self.assertEqual(res["kept"][0]["why"], pm.WHY_CARRIED % "srv")
+
+    def test_the_tool_and_the_cli_say_it_in_plain_words(self):
+        import contextlib
+        import io
+        kept = [{"to": "srv:beta", "id": "c1", "host": "srv", "carried": 5, "why": pm.WHY_CARRIED % "srv",
+                 "body": "please review the notes-api branch"}]
+        saved = (pm._http, pm._self_identity, pm._heartbeat, pm.ensure, pm.my_id)
+        pm._http = lambda method, path, payload=None: {"ok": True, "removed": [], "kept": kept}
+        pm._self_identity = lambda: ("sid-a", "alpha")
+        pm._heartbeat = lambda *a, **k: None
+        pm.ensure, pm.my_id = (lambda: True), (lambda: "sid-a")
+        try:
+            out, err = pm._mcp_call("recall_message", {"id": "c1"})
+            self.assertFalse(err)
+            self.assertIn('NOT recalled — to srv:beta (id c1): it already left for srv and can no longer be '
+                          'withdrawn; they may already have read it. "please review the notes-api branch"', out,
+                          "the gist is quoted: the sender's own imperative is not addressed to the reader")
+            self.assertNotIn("Nothing to recall", out, "a refusal is not 'nothing matched'")
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = pm.cli_recall(["srv:beta", "c1"])
+            self.assertEqual(rc, 0)
+            self.assertIn("[romp mail] not recalled: the message to 'srv:beta' (id c1) already left for srv and "
+                          "can no longer be withdrawn; they may already have read it", buf.getvalue())
+            self.assertNotIn("nothing to recall", buf.getvalue())
+            pm._http = lambda method, path, payload=None: {"ok": True, "kept": kept,
+                                                           "removed": [{"to": "srv:beta", "id": "c2", "body": "second"}]}
+            out, err = pm._mcp_call("recall_message", {"to": "srv:beta"})
+            self.assertIn("Recalled 1 message(s) before they were read:", out)
+            self.assertIn("✕ to srv:beta: second", out)
+            self.assertIn("NOT recalled — to srv:beta (id c1)", out, "one withdrawn, one refused: both are said")
+            riding = [{"to": "srv:beta", "id": "c4", "host": "srv", "carried": None, "why": pm.WHY_IN_FLIGHT % "srv",
+                       "body": "one more thing"}]
+            pm._http = lambda method, path, payload=None: {"ok": True, "removed": [], "kept": riding}
+            out, err = pm._mcp_call("recall_message", {"id": "c4"})
+            self.assertIn('NOT recalled — to srv:beta (id c4): it is on its way to srv right now (try again in a '
+                          'moment). "one more thing"', out, "in flight: try again — never 'too late' in the same breath")
+            self.assertNotIn("may already have read it", out)
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                pm.cli_recall(["srv:beta", "c4"])
+            self.assertIn("[romp mail] not recalled: the message to 'srv:beta' (id c4) is on its way to srv right now "
+                          "(try again in a moment)\n", buf.getvalue())
+            self.assertNotIn("may already have read it", buf.getvalue())
+            pm._http = lambda method, path, payload=None: {"ok": True, "removed": []}   # an older bus: no `kept`
+            out, err = pm._mcp_call("recall_message", {"to": "srv:beta"})
+            self.assertIn("Nothing to recall", out)
+            self.assertIn("already read or delivered", out, "delivered-and-unread on the far side is not 'read'")
+        finally:
+            (pm._http, pm._self_identity, pm._heartbeat, pm.ensure, pm.my_id) = saved
+        desc = [t for t in pm.MCP_TOOLS if t["name"] == "recall_message"][0]["description"]
+        self.assertIn("has not left for it yet", desc, "the tool says it withdraws mail still here")
+        self.assertIn("check_sent shows which", desc)
+
+
+class TheStartSweepLeavesAStandingOutboxRecordAlone(_LoudBus):
+    """_mark_carried rewrites a STANDING record through _atomic_json_put, whose temp is
+    <mid>.json.tmp-<pid>-<hex> beside it. A stop between the temp's open and its os.replace leaves that
+    temp beside a valid <mid>.json. The start sweep's outbox arm used to remove every temp and close its
+    id's ledger as never parked (WHY_STOPPED_BEFORE_PARK) — sound when outbox_put was the only temp
+    writer, and a parked message read as refused to its sender once a rewrite could leave one
+    (review find, 2026-09-08). The maildir arm's rule applies: a temp beside a record that stands is
+    removed, said, and its ledger is left alone."""
+
+    def test_a_temp_beside_a_standing_outbox_record_is_removed_and_its_ledger_left_alone(self):
+        pm._tl_append("messages.jsonl", {"t": 10, "ev": "sent", "id": "px-mark", "from": "alpha", "from_id": _SND,
+                                         "to_id": "peer:srv", "toName": "srv:beta", "body": "hi", "kind": "question"})
+        pm.outbox_put("srv", {"mid": "px-mark", "to": "beta", "frm": "alpha", "frm_id": _SND,
+                              "body": "hi", "kind": "question", "t": 1})
+        (pm.OUTBOX / "srv" / "px-mark.json.tmp-1-abcd").write_text('{"mid": "px-mark", "carried": 5')
+        pm._sweep_unfinished_writes()
+        self.assertEqual(sorted(p.name for p in (pm.OUTBOX / "srv").iterdir()), ["px-mark.json"],
+                         "the temp is gone, the record stands")
+        self.assertEqual([r["ev"] for r in self._rows() if r.get("id") == "px-mark"], ["sent"],
+                         "no bounced row: the message is parked and its ledger stays open")
+        said = [m for m in self.logged if "px-mark.json.tmp-1-abcd" in m]
+        self.assertEqual(len(said), 1, self.logged)
+        self.assertIn("the record itself stands", said[0])
+        self.assertIn("its ledger left alone", said[0])
+        self.assertEqual(len(self._notices()), 1)
+        self.assertIn("1 unfinished mail write(s)", self._notices()[0])
+        self.assertIn("0 sender receipt(s) now read refused", self._notices()[0])
+        self.assertIn("1 of them the temp of a record that stands", self._notices()[0],
+                      "both stores run the standing check (readbox_put rewrites too), so the row names neither")
+        rec = pm._sent_receipts(_SND)[0]
+        self.assertEqual((rec["parked"], rec["bounced"]), ("srv", None))
+        line = pm.format_receipts([rec])
+        self.assertIn("id px-mark", line)
+        self.assertNotIn("refused", line, "the receipt still reads parked, never refused")


### PR DESCRIPTION
## What was wrong
Verified on `main`: a sender could recall a message parked for a relay at any time until the far side's end-to-end acknowledgement removed it from the outbox. The exchange relays every parked item without marking or removing it, and the far side delivers and pushes on arrival, so a recall in the window between the carry and the acknowledgement, one round trip normally and a whole outage when a response was lost, unlinked a message the recipient already held and might answer, and wrote a terminal recall row for it. The sender's receipts then said "recalled" for a message that had been read, and any reader that treats a recall as terminal would close a live ask on a false record; #1095 had to route around this arm with an id-prefix guess. Nothing recorded that an item had been carried.

## What changes
The carry becomes an exact event, keyed on the exchange's outcome rather than on building the request. On the dialing side the exchange body is one function that returns what happened: a response marks the relays it carried (after the response's acknowledgements are applied, so an acknowledged record is simply gone); a lost response after the request went out marks them, because the far side may have processed it; a refusal of any status marks nothing, because the far bus answers before it reads a relay; a connection that never carried the request marks nothing. On the dialed side the relays ride in the response, so the route marks them only after the response was written, and frees them when the write failed. A record is marked on its own file, atomically and durably, with the moment it first left and the host it left for; a re-relay keeps the first departure; the mark is stripped from the wire so a forwarding hub never inherits it and the budgeted size is unchanged.

Between the listing and the outcome the record is in flight, per exchange, so two exchanges for one host that both carry a record keep it in flight until the last of them has its outcome; a recall then is neither granted nor told the message left: it is told the message is on its way right now and to try again in a moment. A recall after the mark is refused in plain words, on the tool and the CLI: the message already left for that host, can no longer be withdrawn, and may already have been read. A refused recall leaves the item where it is and writes no row; the route answers what it kept beside what it removed, so older clients are unaffected. The sender's receipts say the same thing the recall will enforce: a carried record reads as left for its host and awaiting delivery confirmation, not as queued. Every recall row names the box it left, the inbox or the outbox, so readers can tell the two apart by a field rather than a prefix.

The mark rewrites a standing record, so a crash mid-write can leave a temp file beside a valid one. The bus-start sweep used to take any such temp as proof the record was never written and closed the message's ledger as bounced; it now checks that the record stands and leaves its ledger alone.

## Deliberately left out
The kernel's and judge's readers keep their current recall handling; #1095 can switch from its id-prefix guard to the box field once this lands. The in-flight set lives in memory: a restart empties it, and the durable mark and the outcome events stand on their own.

## Tests
Against the real exchange builders, the real dialer body with a stubbed HTTP call, the real server route, the real recall and route over HTTP, and the real tool and CLI text: a message the far side already holds is not withdrawn, in both directions of the exchange, the response-carried one through the real server with no branch-only names so it runs on main and fails there on the behaviour; a recall that lands between the listing and the flight keeps the message off the wire; a flight that ends without sending releases nothing another open flight still holds, in both orders; each dialer outcome marks or does not mark as stated, and a recall during the dial is told the message is on its way while the outcome decides; the dialed side marks after the response is written and not before, and an unwritable response leaves the relays unmarked to ride again; a re-relay keeps the first mark and the acknowledgement still deletes, after which a recall is honestly empty; the mark survives a fresh load of the module over the same store; an unwritable mark is said and the recall can still withdraw; a temp beside a standing outbox record is removed and its ledger left alone; the receipt line, the tool and CLI wording, and the box stamp on both kinds of recall row. All of them are red on `main`: three on the behaviour itself (the message the far side holds is withdrawn, the listing race, the sweep's closed ledger), the rest on functions or keywords main does not have. The postal module passes 92 and the postal bats file 28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
