### PR TITLE
Kernel: a restart-cut turn's whole process tree dies before the resumed CLI launches (T276)

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2643,6 +2643,102 @@ def find_orphan_clis(ps_lines: list[str], lastsids: list[str], own_pid: int) -> 
     return out
 
 
+# ENDING A CUT TURN'S WHOLE TREE (T276, the user 2026-09-08). Reaping the orphaned CLI alone left its Bash
+# tool's processes alive: a stress harness's 32 busy loops and a benchmark's 11 (setsid'd from tool shells,
+# re-parented to the user manager once the shells died) burned cores for over an hour after restarts.
+# The CLI runs in a transient scope of its own when bin/romp-cli-scope is in use (`romp-session-<sid8>-
+# <pid>-<t>.scope`), and a scope holds EVERY process the CLI ever spawned — setsid changes the session,
+# not the cgroup — so stopping the unit ends the tree, dead intermediates included. Without a scope the
+# fallback walks the process tree from the CLI in the `ps` listing and signals each descendant's process
+# group (a tool shell's setsid child leads its own group), then the CLI; a descendant whose parent died
+# before the walk is out of reach there — the scope is what closes that gap, which is why it is tried
+# first. Nothing outside the CLI's own scope or tree is ever signaled: the walk is by ppid from the CLI,
+# and the scope list is filtered to OUR sessions' units whose pid is not a live child of this kernel.
+SESSION_SCOPE_PREFIX = "romp-session-"
+_SESSION_SCOPE_RE = re.compile(r"romp-session-([0-9a-fA-F]{1,8})-(\d+)-\d+\.scope\Z")
+SCOPE_LIST_ARGV = ["systemctl", "--user", "list-units", "--all", "--plain", "--no-legend", "--no-pager",
+                   SESSION_SCOPE_PREFIX + "*.scope"]
+SCOPE_STOP_TIMEOUT = 15.0     # systemd's own stop: SIGTERM to the cgroup, SIGKILL at its TimeoutStopSec
+TREE_KILL_GRACE = 1.0         # seconds for SIGTERM to land on the tree before SIGKILL
+
+
+def scope_unit_of(cgroup_text: str) -> str | None:
+    """The romp session scope a /proc/<pid>/cgroup listing places the process in (cgroup v2: one
+    `0::/user.slice/…/romp-session-<sid8>-<pid>-<t>.scope` line; the legacy hierarchy's lines carry the
+    same path per controller), or None when the process runs in no such scope."""
+    for ln in cgroup_text.splitlines():
+        path = ln.rsplit(":", 1)[-1]
+        for comp in path.split("/"):
+            if comp.startswith(SESSION_SCOPE_PREFIX) and comp.endswith(".scope"):
+                return comp
+    return None
+
+
+def scope_pid(unit: str) -> int | None:
+    """The pid a session scope's name carries — the pid its CLI ran as (bin/romp-cli-scope's naming)."""
+    m = _SESSION_SCOPE_RE.match(unit.strip())
+    return int(m.group(2)) if m else None
+
+
+def session_scope_units(list_lines: list[str], lastsids: list[str]) -> list[str]:
+    """The session scopes in a `systemctl --user list-units 'romp-session-*.scope' --plain --no-legend`
+    listing that belong to one of OUR sessions (the name's sid8 is the first 8 characters of a lastSid),
+    in listing order. Another kernel's sessions (other sids) never match. Pure."""
+    sid8 = {s[:8].lower() for s in lastsids if s}
+    out = []
+    for ln in list_lines:
+        head = ln.strip().split(None, 1)
+        if not head:
+            continue
+        m = _SESSION_SCOPE_RE.match(head[0])
+        if m and m.group(1).lower() in sid8:
+            out.append(head[0])
+    return out
+
+
+def descendants(ps_lines: list[str], root: int) -> list[int]:
+    """Every process under `root` in a PS_ARGV listing (`pid ppid command`), by the ppid chain, parents
+    before their children. A process whose parent died before the listing has re-parented away from
+    the tree and is NOT found here — the scope path covers those. Pure."""
+    kids: dict[int, list[int]] = {}
+    for ln in ps_lines:
+        parts = ln.strip().split(None, 2)
+        if len(parts) < 2 or not parts[0].isdigit() or not parts[1].isdigit():
+            continue
+        kids.setdefault(int(parts[1]), []).append(int(parts[0]))
+    out: list[int] = []
+    stack = [root]
+    seen = {root}
+    while stack:
+        p = stack.pop()
+        for c in kids.get(p, []):
+            if c in seen:
+                continue
+            seen.add(c)
+            out.append(c)
+            stack.append(c)
+    return out
+
+
+def _read_cgroup(pid: int) -> str:
+    """/proc/<pid>/cgroup, or "" where it cannot be read (no procfs, the pid gone)."""
+    try:
+        with open("/proc/%d/cgroup" % pid) as f:
+            return f.read()
+    except OSError:
+        return ""
+
+
+def _read_ppid(pid: int) -> int | None:
+    """The parent pid from /proc/<pid>/stat, or None where it cannot be read."""
+    try:
+        with open("/proc/%d/stat" % pid) as f:
+            tail = f.read().rsplit(")", 1)[1].split()   # the comm field may hold spaces and parens
+        return int(tail[1])
+    except (OSError, IndexError, ValueError):
+        return None
+
+
 def find_session_cli(ps_lines: list[str], sids: list[str], parent_pid: int) -> int | None:
     """The LIVE CLI pid holding one of `sids` as a child of `parent_pid` (this kernel), or None.
     The interrupt escalation's (and the drain reap's) target: same signature match as
@@ -7013,6 +7109,98 @@ class SdkBackend:
             self._log("session cli pid (%s): %s" % (session.name, e))
             return None
 
+    def _pid_alive(self, pid: int) -> bool:
+        """Does `pid` still exist? procfs where there is one (no signal sent, so a patched os.kill in
+        tests records only the real signals); `kill(pid, 0)` elsewhere."""
+        if os.path.isdir("/proc"):
+            return os.path.exists("/proc/%d" % pid)
+        try:
+            os.kill(pid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+
+    def _end_cli_tree(self, pid: int, ps_lines: list[str], kill=None, run=None, cgroup=None) -> dict:
+        """End an orphaned session CLI and EVERYTHING it left behind (T276): its scope unit when it runs
+        in one (systemd ends every process in the cgroup, a tool shell's setsid children and any
+        re-parented leftover included), and, always, the process tree the `ps` listing still shows
+        under it — each descendant's own process group where it leads one (a setsid child), else the
+        process; children before the CLI, SIGTERM first, SIGKILL after TREE_KILL_GRACE for whatever
+        stayed. Nothing outside the tree is signaled: this kernel's own group is never a target, and a
+        group is signaled only when a descendant of THIS CLI leads it. `kill`, `run` and `cgroup` are
+        the test seams, resolved at call time so a patched os.kill / subprocess.run is honoured. Returns
+        what happened, for the reconcile's log line."""
+        kill = kill or os.kill
+        run = run or subprocess.run
+        cgroup = cgroup or _read_cgroup
+        unit = scope_unit_of(cgroup(pid) or "")
+        stopped = False
+        if unit:
+            try:
+                run(["systemctl", "--user", "stop", unit], capture_output=True, text=True, timeout=SCOPE_STOP_TIMEOUT)
+                stopped = True
+            except Exception as e:
+                self._log("cut-turn reap: stopping %s failed (%s); falling back to the process tree" % (unit, e))
+        own_pg = None
+        try:
+            own_pg = os.getpgid(0)
+        except OSError:
+            pass
+        targets = [p for p in descendants(ps_lines, pid) if p != os.getpid()] + [pid]
+        def signal_all(sig, only_alive: bool) -> int:
+            n = 0
+            for p in targets:
+                if only_alive and not self._pid_alive(p):
+                    continue
+                try:
+                    pg = os.getpgid(p)
+                except OSError:
+                    pg = None
+                try:
+                    if pg is not None and pg == p and pg != own_pg:
+                        os.killpg(pg, sig)          # a setsid'd tool child leads its own group: take the group
+                    else:
+                        kill(p, sig)
+                    n += 1
+                except (ProcessLookupError, PermissionError):
+                    pass
+            return n
+        signaled = signal_all(signal.SIGTERM, False)   # unconditionally: the OS answers for a pid already gone
+        deadline = time.time() + TREE_KILL_GRACE
+        while time.time() < deadline and any(self._pid_alive(p) for p in targets):
+            time.sleep(0.05)
+        forced = signal_all(signal.SIGKILL, True) if any(self._pid_alive(p) for p in targets) else 0
+        return {"scope": unit if stopped else None, "signaled": signaled, "forced": forced, "tree": len(targets) - 1}
+
+    def _stop_leftover_scopes(self, lastsids: list[str], run=None) -> int:
+        """Stop the session scopes of OUR sessions whose CLI is not a live child of this kernel (T276):
+        a scope outlives its CLI when a tool's setsid children keep running — exactly the loops the
+        pid-only reap left behind once their shells had died and re-parented. Every process in the
+        scope belongs to that session by construction. A unit whose pid is this kernel's own child
+        (a session already started before this sweep) is left alone. No systemctl (macOS, a box without
+        the user manager) → nothing to sweep. `run` is the test seam, resolved at call time."""
+        run = run or subprocess.run
+        try:
+            listing = run(SCOPE_LIST_ARGV, capture_output=True, text=True, timeout=10).stdout or ""
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return 0
+        except Exception as e:
+            self._log("cut-turn reap: listing session scopes failed: %s" % e)
+            return 0
+        stopped = 0
+        for unit in session_scope_units(listing.splitlines(), lastsids):
+            sp = scope_pid(unit)
+            if sp is not None and (sp == os.getpid() or (self._pid_alive(sp) and _read_ppid(sp) == os.getpid())):
+                continue            # this kernel's live session
+            try:
+                run(["systemctl", "--user", "stop", unit], capture_output=True, text=True, timeout=SCOPE_STOP_TIMEOUT)
+                stopped += 1
+            except Exception as e:
+                self._log("cut-turn reap: stopping leftover %s failed: %s" % (unit, e))
+        return stopped
+
     def _boot_reconcile(self, regs: list[dict]) -> None:
         """The kernel just booted — reconcile what the previous kernel's death left behind. Event-keyed
         on the boot itself plus each session's state tail, never on ages or timers:
@@ -7039,18 +7227,23 @@ class SdkBackend:
         try:
             alive = [r for r in regs if r.get("alive") and r.get("sid")]
             reaped = 0
+            scopes_stopped = 0
             lastsids = [str(r.get("lastSid") or "") for r in alive if r.get("lastSid")]
             if lastsids:
                 try:
                     ps = subprocess.run(PS_ARGV, capture_output=True, text=True, timeout=10).stdout
-                    for pid in find_orphan_clis(ps.splitlines(), lastsids, os.getpid()):
+                    ps_lines = ps.splitlines()
+                    for pid in find_orphan_clis(ps_lines, lastsids, os.getpid()):
                         if pid == os.getpid():
                             continue
+                        # the CLI AND its tree (T276): its scope unit, then every process still under it
                         try:
-                            os.kill(pid, signal.SIGTERM)
+                            self._end_cli_tree(pid, ps_lines)
                             reaped += 1
                         except (ProcessLookupError, PermissionError):
                             pass
+                    # …and the scopes whose CLI already died but whose children live on
+                    scopes_stopped = self._stop_leftover_scopes(lastsids)
                 except Exception:
                     self._log("boot reconcile: orphan reap failed: %s" % traceback.format_exc())
             resumed, restored, notified = 0, 0, 0
@@ -7137,10 +7330,11 @@ class SdkBackend:
                 except Exception:
                     self._log("boot reconcile: session %s failed (sweep continues): %s"
                               % (r.get("sid"), traceback.format_exc()))
-            if reaped or resumed or restored or notified:
+            if reaped or resumed or restored or notified or scopes_stopped:
                 self._log("boot reconcile: resumed %d cut turn(s), restored %d queued message(s), "
-                          "notified %d session(s) of dead background tasks, reaped %d orphaned CLI(s)"
-                          % (resumed, restored, notified, reaped))
+                          "notified %d session(s) of dead background tasks, reaped %d orphaned CLI(s) with their "
+                          "process trees, stopped %d leftover session scope(s)"
+                          % (resumed, restored, notified, reaped, scopes_stopped))
                 self._poke()
             # STAGGERED spawn (see BOOT_RESUME_CONCURRENCY): every reg above is already fixed —
             # queues persisted, heals applied — so even a death mid-stagger loses nothing (the next

--- a/tests/test_cut_turn_tree_kill.py
+++ b/tests/test_cut_turn_tree_kill.py
@@ -46,6 +46,16 @@ sb = SourceFileLoader("romp_sdk_backend_treekill", os.path.join(BIN, "romp_sdk_b
 SID = "11111111-aaaa-0000-0000-00000000c276"
 OTHER = "22222222-bbbb-0000-0000-00000000c276"
 LINUX = sys.platform.startswith("linux") and shutil.which("ps") is not None and os.path.isdir("/proc")
+# Fake pids sit ABOVE pid_max, so no real process can ever wear one: the reaper's liveness poll (procfs) then
+# reads them as gone after the recorded SIGTERM, and never escalates to SIGKILL. A fake pid that happened to be a
+# live process on the box (4242 on a CI runner, 2026-09-09) made the recorded kills differ run to run.
+def _pid_max() -> int:
+    try:
+        return int(open("/proc/sys/kernel/pid_max").read().strip())
+    except (OSError, ValueError):
+        return 4194304
+P = _pid_max()
+CLI, TOOL, LOOP, BYSTANDER, MANAGER, KERNEL, TMUX, LIVE = (P + 42, P + 50, P + 60, P + 300, P + 901, P + 90210, P + 556, P + 557)
 
 
 def _backend(d=None):
@@ -105,27 +115,28 @@ class ScopePath(unittest.TestCase):
         runs, killed = [], []
         def run(argv, **kw):
             runs.append(list(argv)); return mock.Mock(stdout="", returncode=0)
-        cg = lambda pid: "0::/user.slice/user-1000.slice/user@1000.service/app.slice/romp-session-11111111-4242-1757374800.scope\n"
-        ps = ("  4242 901 /x/claude --input-format stream-json --resume %s\n"
-              "  4300 901 sleep 300\n") % SID
-        out = be._end_cli_tree(4242, ps.splitlines(), kill=lambda p, s: killed.append((p, s)), run=run, cgroup=cg)
-        self.assertEqual(runs, [["systemctl", "--user", "stop", "romp-session-11111111-4242-1757374800.scope"]],
+        unit = "romp-session-11111111-%d-1757374800.scope" % CLI
+        cg = lambda pid: "0::/user.slice/user-1000.slice/user@1000.service/app.slice/%s\n" % unit
+        ps = ("  %d %d /x/claude --input-format stream-json --resume %s\n"
+              "  %d %d sleep 300\n") % (CLI, MANAGER, SID, BYSTANDER, MANAGER)
+        out = be._end_cli_tree(CLI, ps.splitlines(), kill=lambda p, s: killed.append((p, s)), run=run, cgroup=cg)
+        self.assertEqual(runs, [["systemctl", "--user", "stop", unit]],
                          "the scope is stopped — systemd ends the cgroup, re-parented leftovers included")
-        self.assertEqual(killed, [(4242, signal.SIGTERM)], "the tree walk still signals the CLI (belt and braces), nothing else")
-        self.assertEqual(out["scope"], "romp-session-11111111-4242-1757374800.scope")
+        self.assertEqual(killed, [(CLI, signal.SIGTERM)], "the tree walk still signals the CLI (belt and braces), nothing else")
+        self.assertEqual(out["scope"], unit)
         self.assertEqual(out["tree"], 0)
 
     def test_a_cli_with_no_scope_falls_back_to_the_tree_children_first(self):
         be = _backend()
         runs, killed = [], []
-        ps = ("  4242 901 /x/claude --input-format stream-json --resume %s\n"
-              "  4250 4242 bash -c tool\n"
-              "  4260 4250 sleep 300\n"
-              "  4300 901 sleep 300\n") % SID
-        out = be._end_cli_tree(4242, ps.splitlines(), kill=lambda p, s: killed.append((p, s)),
+        ps = ("  %d %d /x/claude --input-format stream-json --resume %s\n"
+              "  %d %d bash -c tool\n"
+              "  %d %d sleep 300\n"
+              "  %d %d sleep 300\n") % (CLI, MANAGER, SID, TOOL, CLI, LOOP, TOOL, BYSTANDER, MANAGER)
+        out = be._end_cli_tree(CLI, ps.splitlines(), kill=lambda p, s: killed.append((p, s)),
                                run=lambda *a, **k: runs.append(a), cgroup=lambda pid: "0::/user.slice/user-1000.slice/user@1000.service/romp-manager.service\n")
         self.assertEqual(runs, [], "no scope → no systemctl")
-        self.assertEqual([p for p, _ in killed], [4250, 4260, 4242], "descendants (parents first) then the CLI; the bystander 4300 untouched")
+        self.assertEqual([p for p, _ in killed], [TOOL, LOOP, CLI], "descendants (parents first) then the CLI; the bystander untouched")
         self.assertTrue(all(s == signal.SIGTERM for _, s in killed), "fake pids are gone at once, so no SIGKILL escalation")
         self.assertIsNone(out["scope"])
         self.assertEqual(out["tree"], 2)
@@ -135,16 +146,16 @@ class ScopePath(unittest.TestCase):
         # a real child of THIS process stands in for "this kernel's live session": its unit is skipped
         child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         self.addCleanup(child.wait, timeout=10); self.addCleanup(child.kill)
-        listing = ("romp-session-11111111-424242-1757374800.scope loaded active running claude\n"     # our sid, CLI gone → stop
-                   "romp-session-11111111-%d-1757374801.scope loaded active running claude\n"           # our sid, our live child → keep
-                   "romp-session-22222222-424243-1757374802.scope loaded active running claude\n"      # another session → never ours
-                   ) % child.pid
+        listing = ("romp-session-11111111-%d-1757374800.scope loaded active running claude\n"          # our sid, CLI gone → stop
+                   "romp-session-11111111-%d-1757374801.scope loaded active running claude\n"          # our sid, our live child → keep
+                   "romp-session-22222222-%d-1757374802.scope loaded active running claude\n"          # another session → never ours
+                   ) % (CLI, child.pid, CLI + 1)
         runs = []
         def run(argv, **kw):
             runs.append(list(argv)); return mock.Mock(stdout=listing if argv == sb.SCOPE_LIST_ARGV else "", returncode=0)
         n = be._stop_leftover_scopes([SID], run=run)
         self.assertEqual(n, 1)
-        self.assertEqual(runs, [sb.SCOPE_LIST_ARGV, ["systemctl", "--user", "stop", "romp-session-11111111-424242-1757374800.scope"]])
+        self.assertEqual(runs, [sb.SCOPE_LIST_ARGV, ["systemctl", "--user", "stop", "romp-session-11111111-%d-1757374800.scope" % CLI]])
 
     def test_no_systemctl_means_nothing_to_sweep(self):
         be = _backend()
@@ -157,23 +168,24 @@ class BootReconcileEndsTheTree(unittest.TestCase):
         d = tempfile.mkdtemp(); be = _backend(d)
         _reg(d, SID)
         sb.append_state(Path(d), SID, "working")
-        ps = ("  555 1 /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
-              "  560 555 bash -c tool\n"
-              "  561 560 sleep 300\n"
-              "  556 1 claude --resume %s --name termsess\n"
-              "  90210 1 /usr/bin/python3 /x/romp/bin/romp-kernel\n"
-              "  557 90210 /x/claude --output-format stream-json --resume %s --input-format stream-json\n") % (SID, SID, SID)
-        listing = "romp-session-11111111-555-1757374800.scope loaded active running claude\n"
+        ps = ("  %d 1 /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
+              "  %d %d bash -c tool\n"
+              "  %d %d sleep 300\n"
+              "  %d 1 claude --resume %s --name termsess\n"
+              "  %d 1 /usr/bin/python3 /x/romp/bin/romp-kernel\n"
+              "  %d %d /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
+              ) % (CLI, SID, TOOL, CLI, LOOP, TOOL, TMUX, SID, KERNEL, LIVE, KERNEL, SID)
+        listing = "romp-session-11111111-%d-1757374800.scope loaded active running claude\n" % CLI
         killed, runs = [], []
         def run(argv, **kw):
             runs.append(list(argv)); return mock.Mock(stdout=ps if argv == sb.PS_ARGV else (listing if argv == sb.SCOPE_LIST_ARGV else ""), returncode=0)
         with mock.patch.object(sb.subprocess, "run", side_effect=run), \
              mock.patch.object(sb.os, "kill", side_effect=lambda p, s: killed.append((p, s))):
             be._boot_reconcile([sb.read_reg(Path(d), SID)])
-        self.assertEqual([p for p, _ in killed], [560, 561, 555], "the orphan's tree, children first, then the CLI; the tmux CLI and the live CLI untouched")
+        self.assertEqual([p for p, _ in killed], [TOOL, LOOP, CLI], "the orphan's tree, children first, then the CLI; the tmux CLI and the live CLI untouched")
         self.assertEqual(runs[0], sb.PS_ARGV, "the listing is read first, with PS_ARGV")
         self.assertIn(sb.SCOPE_LIST_ARGV, runs, "…then our sessions' scopes are listed")
-        self.assertIn(["systemctl", "--user", "stop", "romp-session-11111111-555-1757374800.scope"], runs,
+        self.assertIn(["systemctl", "--user", "stop", "romp-session-11111111-%d-1757374800.scope" % CLI], runs,
                       "the dead CLI's scope is stopped: its children live on in the cgroup even after the CLI is gone")
 
 

--- a/tests/test_cut_turn_tree_kill.py
+++ b/tests/test_cut_turn_tree_kill.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""T276 (the user 2026-09-08, from the devbox CPU hunt): when a kernel restart cuts a session's turn, that
+turn's Bash-tool processes must die with it. The boot reaper used to SIGTERM the orphaned CLI pid alone, so
+a tool shell's setsid children (a stress harness's 32 busy loops, a benchmark's 11) survived, re-parented
+to the user manager once their shells died, and burned cores for over an hour.
+
+Now the reaper ends the WHOLE tree before the resumed CLI launches:
+  * the session's transient scope unit when the CLI runs in one (bin/romp-cli-scope's
+    `romp-session-<sid8>-<pid>-<t>.scope`): systemd ends every process in the cgroup, setsid children and
+    re-parented leftovers included — read from the CLI's own /proc/<pid>/cgroup;
+  * always, the process tree the `ps` listing still shows under the CLI: each descendant's process group
+    where it leads one (a setsid child), else the process; children before the CLI, SIGTERM then SIGKILL;
+  * a sweep of OUR sessions' scopes whose CLI is not a live child of this kernel — a scope outlives its
+    CLI when the tool's children keep running, which is exactly the loops the pid-only reap left behind.
+Nothing outside the CLI's scope or tree is ever signaled: the walk is by ppid from the CLI, this kernel's
+own group is never a target, and the scope sweep is filtered to our sids and skips this kernel's live
+children.
+
+Deterministic where it can be (pure helpers; scripted `run`/`kill`/`cgroup` seams), plus REAL processes on
+Linux: a fake "CLI" whose child spawns a setsid'd sleep loop, and a bystander sleep outside the tree. The
+loops here sleep — no synthetic load — and every process this file starts is killed by it. Synthetic
+fixtures only.
+"""
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import uuid
+from pathlib import Path
+from unittest import mock
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # hermetic BEFORE the load
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_CLI_SCOPE"] = "0"
+sb = SourceFileLoader("romp_sdk_backend_treekill", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "11111111-aaaa-0000-0000-00000000c276"
+OTHER = "22222222-bbbb-0000-0000-00000000c276"
+LINUX = sys.platform.startswith("linux") and shutil.which("ps") is not None and os.path.isdir("/proc")
+
+
+def _backend(d=None):
+    return sb.SdkBackend(d or tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+
+
+def _reg(d, sid, **extra):
+    r = {"sid": sid, "name": "s-" + sid[:4], "cwd": "/tmp", "alive": True, "lastSid": sid}
+    r.update(extra)
+    sb.write_reg(Path(d), sid, r)
+    return r
+
+
+class PureRules(unittest.TestCase):
+    def test_scope_unit_of_reads_the_session_scope_from_a_cgroup_listing(self):
+        v2 = "0::/user.slice/user-1000.slice/user@1000.service/app.slice/romp-session-11111111-4242-1757374800.scope\n"
+        self.assertEqual(sb.scope_unit_of(v2), "romp-session-11111111-4242-1757374800.scope")
+        legacy = ("12:memory:/user.slice/romp-session-11111111-4242-1757374800.scope\n"
+                  "1:name=systemd:/user.slice/romp-session-11111111-4242-1757374800.scope\n")
+        self.assertEqual(sb.scope_unit_of(legacy), "romp-session-11111111-4242-1757374800.scope")
+        self.assertIsNone(sb.scope_unit_of("0::/user.slice/user-1000.slice/user@1000.service/romp-manager.service\n"),
+                          "the service cgroup is not a session scope — a CLI there has no unit of its own to stop")
+        self.assertIsNone(sb.scope_unit_of(""))
+
+    def test_scope_pid_and_our_sessions_units(self):
+        self.assertEqual(sb.scope_pid("romp-session-11111111-4242-1757374800.scope"), 4242)
+        self.assertIsNone(sb.scope_pid("romp-manager.service"))
+        self.assertIsNone(sb.scope_pid("romp-session-garbage.scope"))
+        listing = ("romp-session-11111111-4242-1757374800.scope loaded active running /x/claude\n"
+                   "romp-session-22222222-4343-1757374801.scope loaded active running /x/claude\n"
+                   "romp-session-11111111-4444-1757374802.scope loaded inactive dead /x/claude\n"
+                   "run-r9b2.scope loaded active running something else\n")
+        self.assertEqual(sb.session_scope_units(listing.splitlines(), [SID]),
+                         ["romp-session-11111111-4242-1757374800.scope", "romp-session-11111111-4444-1757374802.scope"],
+                         "our sid's units only, in listing order — another session's scope is never ours to stop")
+        self.assertEqual(sb.session_scope_units(listing.splitlines(), [OTHER]), ["romp-session-22222222-4343-1757374801.scope"])
+        self.assertEqual(sb.session_scope_units(listing.splitlines(), []), [])
+
+    def test_descendants_walk_the_ppid_chain_and_nothing_else(self):
+        ps = ("  100 1 /usr/lib/systemd/systemd --user\n"
+              "  200 100 /x/claude --input-format stream-json --resume %s\n"
+              "  201 200 bash -c tool\n"
+              "  202 201 bash -c 'while :; do sleep 1; done' loop\n"     # setsid'd: still a child by ppid
+              "  300 100 sleep 300\n"                                      # a bystander under the same manager
+              "  400 1 python3 unrelated\n") % SID
+        self.assertEqual(sorted(sb.descendants(ps.splitlines(), 200)), [201, 202])
+        self.assertEqual(sb.descendants(ps.splitlines(), 300), [])
+        self.assertEqual(sb.descendants(ps.splitlines(), 999), [], "an unknown root has no tree")
+        # a leftover whose shell died has re-parented (ppid 100) and is NOT in the CLI's tree — the scope covers it
+        ps2 = ps + "  203 100 bash -c 'while :; do sleep 1; done' orphaned-loop\n"
+        self.assertNotIn(203, sb.descendants(ps2.splitlines(), 200))
+
+
+class ScopePath(unittest.TestCase):
+    def test_a_cli_in_a_session_scope_has_its_unit_stopped_and_only_its_own_pid_signaled(self):
+        be = _backend()
+        runs, killed = [], []
+        def run(argv, **kw):
+            runs.append(list(argv)); return mock.Mock(stdout="", returncode=0)
+        cg = lambda pid: "0::/user.slice/user-1000.slice/user@1000.service/app.slice/romp-session-11111111-4242-1757374800.scope\n"
+        ps = ("  4242 901 /x/claude --input-format stream-json --resume %s\n"
+              "  4300 901 sleep 300\n") % SID
+        out = be._end_cli_tree(4242, ps.splitlines(), kill=lambda p, s: killed.append((p, s)), run=run, cgroup=cg)
+        self.assertEqual(runs, [["systemctl", "--user", "stop", "romp-session-11111111-4242-1757374800.scope"]],
+                         "the scope is stopped — systemd ends the cgroup, re-parented leftovers included")
+        self.assertEqual(killed, [(4242, signal.SIGTERM)], "the tree walk still signals the CLI (belt and braces), nothing else")
+        self.assertEqual(out["scope"], "romp-session-11111111-4242-1757374800.scope")
+        self.assertEqual(out["tree"], 0)
+
+    def test_a_cli_with_no_scope_falls_back_to_the_tree_children_first(self):
+        be = _backend()
+        runs, killed = [], []
+        ps = ("  4242 901 /x/claude --input-format stream-json --resume %s\n"
+              "  4250 4242 bash -c tool\n"
+              "  4260 4250 sleep 300\n"
+              "  4300 901 sleep 300\n") % SID
+        out = be._end_cli_tree(4242, ps.splitlines(), kill=lambda p, s: killed.append((p, s)),
+                               run=lambda *a, **k: runs.append(a), cgroup=lambda pid: "0::/user.slice/user-1000.slice/user@1000.service/romp-manager.service\n")
+        self.assertEqual(runs, [], "no scope → no systemctl")
+        self.assertEqual([p for p, _ in killed], [4250, 4260, 4242], "descendants (parents first) then the CLI; the bystander 4300 untouched")
+        self.assertTrue(all(s == signal.SIGTERM for _, s in killed), "fake pids are gone at once, so no SIGKILL escalation")
+        self.assertIsNone(out["scope"])
+        self.assertEqual(out["tree"], 2)
+
+    def test_the_leftover_scope_sweep_stops_our_dead_sessions_scopes_only(self):
+        be = _backend()
+        # a real child of THIS process stands in for "this kernel's live session": its unit is skipped
+        child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(child.wait, timeout=10); self.addCleanup(child.kill)
+        listing = ("romp-session-11111111-424242-1757374800.scope loaded active running claude\n"     # our sid, CLI gone → stop
+                   "romp-session-11111111-%d-1757374801.scope loaded active running claude\n"           # our sid, our live child → keep
+                   "romp-session-22222222-424243-1757374802.scope loaded active running claude\n"      # another session → never ours
+                   ) % child.pid
+        runs = []
+        def run(argv, **kw):
+            runs.append(list(argv)); return mock.Mock(stdout=listing if argv == sb.SCOPE_LIST_ARGV else "", returncode=0)
+        n = be._stop_leftover_scopes([SID], run=run)
+        self.assertEqual(n, 1)
+        self.assertEqual(runs, [sb.SCOPE_LIST_ARGV, ["systemctl", "--user", "stop", "romp-session-11111111-424242-1757374800.scope"]])
+
+    def test_no_systemctl_means_nothing_to_sweep(self):
+        be = _backend()
+        def run(argv, **kw): raise FileNotFoundError("systemctl")
+        self.assertEqual(be._stop_leftover_scopes([SID], run=run), 0)
+
+
+class BootReconcileEndsTheTree(unittest.TestCase):
+    def test_the_reap_signals_the_orphans_tree_and_sweeps_scopes_after_the_ps_read(self):
+        d = tempfile.mkdtemp(); be = _backend(d)
+        _reg(d, SID)
+        sb.append_state(Path(d), SID, "working")
+        ps = ("  555 1 /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
+              "  560 555 bash -c tool\n"
+              "  561 560 sleep 300\n"
+              "  556 1 claude --resume %s --name termsess\n"
+              "  90210 1 /usr/bin/python3 /x/romp/bin/romp-kernel\n"
+              "  557 90210 /x/claude --output-format stream-json --resume %s --input-format stream-json\n") % (SID, SID, SID)
+        listing = "romp-session-11111111-555-1757374800.scope loaded active running claude\n"
+        killed, runs = [], []
+        def run(argv, **kw):
+            runs.append(list(argv)); return mock.Mock(stdout=ps if argv == sb.PS_ARGV else (listing if argv == sb.SCOPE_LIST_ARGV else ""), returncode=0)
+        with mock.patch.object(sb.subprocess, "run", side_effect=run), \
+             mock.patch.object(sb.os, "kill", side_effect=lambda p, s: killed.append((p, s))):
+            be._boot_reconcile([sb.read_reg(Path(d), SID)])
+        self.assertEqual([p for p, _ in killed], [560, 561, 555], "the orphan's tree, children first, then the CLI; the tmux CLI and the live CLI untouched")
+        self.assertEqual(runs[0], sb.PS_ARGV, "the listing is read first, with PS_ARGV")
+        self.assertIn(sb.SCOPE_LIST_ARGV, runs, "…then our sessions' scopes are listed")
+        self.assertIn(["systemctl", "--user", "stop", "romp-session-11111111-555-1757374800.scope"], runs,
+                      "the dead CLI's scope is stopped: its children live on in the cgroup even after the CLI is gone")
+
+
+@unittest.skipUnless(LINUX, "real processes on Linux with procfs")
+class RealProcessTree(unittest.TestCase):
+    """The fixture the dispatch asked for: a 'session' (a fake CLI shell) whose child spawns a DETACHED sleep loop;
+    after the simulated cut — the reaper ending the orphaned CLI's tree — the loop is gone, and a bystander outside
+    the tree is untouched. No scope here (ROMP_CLI_SCOPE=0), so this is the process-group fallback."""
+
+    def _tree(self):
+        marker = "romp-t276-loop-" + uuid.uuid4().hex
+        # the "CLI": a shell that starts a setsid'd loop (its own session + process group, like a tool's nohup child)
+        # and then sits like a CLI mid-turn; the loop sleeps — no load
+        cli = subprocess.Popen(["bash", "-c", 'setsid bash -c "while :; do sleep 0.2; done" "$0" & wait', marker],
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
+        self.addCleanup(self._kill_marker, marker)
+        self.addCleanup(lambda: (cli.poll() is None) and os.killpg(cli.pid, signal.SIGKILL))
+        # a bystander outside the tree
+        by = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(by.wait, timeout=10); self.addCleanup(by.kill)
+        deadline = time.time() + 5
+        while time.time() < deadline and not self._marker_pids(marker):
+            time.sleep(0.05)
+        self.assertTrue(self._marker_pids(marker), "the detached loop is running before the cut")
+        return cli, by, marker
+
+    @staticmethod
+    def _marker_pids(marker):
+        out = subprocess.run(["pgrep", "-f", marker], capture_output=True, text=True).stdout.split()
+        return [int(x) for x in out if x.isdigit() and int(x) != os.getpid()]
+
+    def _kill_marker(self, marker):
+        for p in self._marker_pids(marker):
+            try: os.kill(p, signal.SIGKILL)
+            except ProcessLookupError: pass
+
+    def test_ending_the_cut_clis_tree_kills_the_detached_loop_and_spares_the_bystander(self):
+        cli, by, marker = self._tree()
+        be = _backend()
+        ps = subprocess.run(sb.PS_ARGV, capture_output=True, text=True, timeout=10).stdout.splitlines()
+        loop_pids = [p for p in self._marker_pids(marker) if p != cli.pid]   # the fake CLI's own argv carries the marker too
+        self.assertTrue(loop_pids and all(p in sb.descendants(ps, cli.pid) for p in loop_pids),
+                        "the setsid'd loop is still the CLI's descendant by ppid: %r vs %r" % (loop_pids, sb.descendants(ps, cli.pid)))
+        out = be._end_cli_tree(cli.pid, ps)
+        deadline = time.time() + 5
+        while time.time() < deadline and (self._marker_pids(marker) or cli.poll() is None):
+            time.sleep(0.05)
+        self.assertEqual(self._marker_pids(marker), [], "the detached loop died with the cut turn")
+        self.assertIsNotNone(cli.poll(), "the CLI is gone")
+        self.assertIsNone(by.poll(), "the bystander outside the tree was never signaled")
+        self.assertGreaterEqual(out["tree"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk_lifecycle_hardening.py
+++ b/tests/test_sdk_lifecycle_hardening.py
@@ -401,7 +401,9 @@ class BootReconcile(unittest.TestCase):
         sid = "11111111-aaaa-0000-0000-00000000000b"
         _reg(d, sid)
         sb.append_state(Path(d), sid, "working")
-        ps = ("  555 1 /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
+        # the orphan's fake pid sits above pid_max (T276): the tree kill polls procfs after its SIGTERM, and a live
+        # process wearing a small fake pid on the box would earn a SIGKILL the pin below does not expect
+        ps = ("  9999555 1 /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
               "  556 1 claude --resume %s --name termsess\n"
               "  90210 1 /usr/bin/python3 /x/romp/bin/romp-kernel\n"
               "  557 90210 /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
@@ -410,7 +412,7 @@ class BootReconcile(unittest.TestCase):
         with mock.patch.object(sb.subprocess, "run", return_value=mock.Mock(stdout=ps)) as run, \
              mock.patch.object(sb.os, "kill", side_effect=lambda p, s: killed.append((p, s))):
             be._boot_reconcile([sb.read_reg(Path(d), sid)])
-        self.assertEqual(killed, [(555, sb.signal.SIGTERM)],
+        self.assertEqual(killed, [(9999555, sb.signal.SIGTERM)],
                          "the SDK orphan is reaped; the tmux CLI and the live (parented) CLI "
                          "on the same sid are untouched")
         self.assertEqual(run.call_args_list[0][0][0], sb.PS_ARGV, "the listing is read with PS_ARGV")


### PR DESCRIPTION
When a kernel restart cuts a session's turn, the boot reaper used to SIGTERM the orphaned CLI pid alone, so the turn's Bash-tool processes lived on: a stress harness's 32 busy loops and a benchmark's 11, setsid'd from tool shells and re-parented to the user manager once those shells died, burned cores for over an hour (the user 2026-09-08).

## Design points

- **End the tree, not the pid, and before any cut turn resumes.** The reaper first stops the session's transient scope unit when the CLI runs in one (read from the CLI's own `/proc/<pid>/cgroup`; `bin/romp-cli-scope` names it `romp-session-<sid8>-<pid>-<t>.scope`): systemd ends every process in the cgroup, setsid children and re-parented leftovers included. Then, always, it walks the process tree the `ps` listing still shows under the CLI and signals each descendant's own process group where it leads one (a setsid child), else the process; children before the CLI; SIGTERM, then SIGKILL after a short grace.
- **Leftover scopes.** A scope outlives its CLI when a tool's children keep running, which is exactly the loops the pid-only reap left behind. The reaper lists `romp-session-*.scope`, keeps the units whose sid8 is one of our sessions', skips any whose pid is this kernel's live child, and stops the rest.
- **Nothing outside the session's scope or tree is signaled.** The walk is by ppid from the CLI; this kernel's own process group is never a target; the sweep is filtered to our sids. A descendant whose parent died before the walk is out of the tree's reach; the scope closes that gap, which is why it is tried first.
- **Seams resolve at call time** (`kill`, `run`, `cgroup`), so the existing reaper pins (patched `os.kill` / `subprocess.run`) hold unchanged.

## Tests

`tests/test_cut_turn_tree_kill.py`: pure rules (scope from a cgroup listing, our units from a list-units listing, the ppid walk and its exclusions); the scope path on scripted seams; the no-scope fallback (descendants first, CLI last, bystander untouched); the leftover sweep (our dead session's scope stopped, our live child's and another session's kept, no systemctl means nothing to sweep); the boot reconcile wiring; and real processes on Linux: a fake CLI whose child spawns a detached sleep loop dies with the cut while a bystander survives. The loops sleep (no synthetic load) and every process the tests start is killed by them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
