### PR TITLE
Judge concurrency is a knob: ROMP_JUDGE_CONCURRENCY at load, a live kernel setting beside the judge picks (T277)

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -459,6 +459,10 @@ permission/API-error floors: one interrupt at a time, the present event first.
 
 - Toggles: `CLOSER_ON`, `GROUPER_ON`, `DISTILLER_ON`, `CONSOLIDATE_ON`.
   Models: `STATE/judge-model` (triage), `STATE/index-model`.
+  Pool width: `STATE/judge-concurrency` (the gear's Judge concurrency, 1..16,
+  read fresh each pass; empty = `ROMP_JUDGE_CONCURRENCY` as read at load,
+  else 6). Every pool reads it at call time (`_conc`, or `_judge_concurrency()`
+  directly); `DEATH_DRAIN_PER_PASS` alone stays on the load-time value.
 - Logs: `STATE/judge-usage.jsonl` (per-call cost, one name per prompt),
   `STATE/judge-errors.jsonl` (the row contract above; kinds are parse,
   call, give-up, sweep-cut, cite-miss, rate-limited, task-store, history-unreadable,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -420,6 +420,19 @@ through to `install.sh`:
   falling back to `main` when none is published.
 - `ROMP_NO_PATH=1` leaves your shell rc alone.
 
+### Judge concurrency
+
+- `ROMP_JUDGE_CONCURRENCY=<1..16>` sets how many judge calls run at once,
+  across every tier; the default is 6. The judges read it once, when they
+  load, so set it where the kernel's service sees it (`service.env`, then a
+  restart). A value outside the range is applied at the nearer bound; a value
+  that is not an integer is ignored, with one line on the kernel's stderr. The
+  same knob is a kernel setting, **Judge concurrency**, the last row of the
+  gear's Judges section below the model and effort picks: a pick there
+  applies on the judges' next pass with no restart, wins over the variable,
+  and follows to every connected machine like the other judge settings; its
+  Default option clears the setting back to the variable, else 6.
+
 ### Ports
 
 - `ROMP_KERNEL_PORT=<port>` moves the kernel and its dashboard off the default

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -206,8 +206,8 @@ def _state_str(name, default=""):
     if not c or c["mt"] != mt:
         try:
             v = f.read_text().strip()
-        except OSError:
-            v = ""
+        except (OSError, ValueError):   # ValueError: an undecodable file (UnicodeDecodeError) reads as the
+            v = ""                      # default too, like a missing one — a hand edit must never fail a pass
         _state_cache[name] = c = {"val": v or default, "mt": mt}
     return c["val"]
 
@@ -550,7 +550,50 @@ CLOSE_RIDER_CAP = 6                      # RIDERS per closer call — the steps-
                                          # reply stamps them, so what is cut rides a later landed call. STATUS
                                          # riders are never cut — one-shot per status turn, they would be lost,
                                          # not deferred — and take their room off the cap first (why: _close_turn).
-CONCURRENCY = 6                          # concurrent claude -p calls
+CONCURRENCY_DEFAULT = 6                  # concurrent claude -p calls, unless configured (below)
+CONCURRENCY_MIN, CONCURRENCY_MAX = 1, 16   # the knob's range; the kernel's select offers exactly this
+
+
+def _concurrency_from_env(raw, default=CONCURRENCY_DEFAULT):
+    """ROMP_JUDGE_CONCURRENCY as read ONCE at module load (T277): an integer, clamped to
+    CONCURRENCY_MIN..CONCURRENCY_MAX (a value at either bound is applied at the bound, silently — it is a
+    value); unset or blank → `default`; anything that is not an integer is IGNORED with one stderr line,
+    never a crash — a typo in a service.env must not take the judges down with it."""
+    if raw is None or not raw.strip():
+        return default
+    try:
+        n = int(raw.strip())
+    except ValueError:
+        sys.stderr.write("romp-judge: ROMP_JUDGE_CONCURRENCY=%r is not an integer; using %d\n" % (raw, default))
+        return default
+    return max(CONCURRENCY_MIN, min(CONCURRENCY_MAX, n))
+
+
+CONCURRENCY = _concurrency_from_env(os.environ.get("ROMP_JUDGE_CONCURRENCY"))   # the variable's value, else 6
+
+
+def _judge_concurrency():
+    """The EFFECTIVE judge concurrency at this moment: the kernel setting `judge-concurrency` (the gear's
+    "Judge concurrency" select, validated to 1..16 by the kernel before it is written, read fresh each call
+    through the same mtime-cached STATE reader as the tier picks — so a change lands on the judges' NEXT
+    pass, no restart), else CONCURRENCY (the variable at module load, else 6). The setting wins over the
+    variable. An unparseable file (a hand edit) falls back rather than crashing a pass; the clamp here is
+    belt-and-braces — the kernel refuses anything outside the range."""
+    v = _state_str("judge-concurrency", "")
+    if v:
+        try:
+            return max(CONCURRENCY_MIN, min(CONCURRENCY_MAX, int(v)))
+        except ValueError:
+            pass
+    return CONCURRENCY
+
+
+def _conc(concurrency):
+    """A run_* function's `concurrency` argument, resolved: an explicit value stands (tests, the A/B tools);
+    None — every entry point's default — reads the setting at CALL time. A def-time default (the old
+    `=CONCURRENCY` in every signature) would have frozen the setting out of the long-lived kernel, which imports
+    this module once."""
+    return concurrency if concurrency is not None else _judge_concurrency()
 # The CLOSER: the turn-end completion backstop (judge.md HYBRID; named the "closer" 2026-06-16 — it
 # closes out goals whose outcome is delivered). SHIPPED as the default 2026-06-15 after the fleet A/B
 # (25→30 completed top-goals, zero false-positives — `romp-judge --ab-close` re-measures). Kept
@@ -6908,7 +6951,7 @@ def _archive_call(fsid, caps):
     return archive_llm("\n".join("- " + c for c in caps))
 
 
-def run_index(now=None, budget=BUDGET, fairness=FAIRNESS, concurrency=CONCURRENCY, verbose=False):
+def run_index(now=None, budget=BUDGET, fairness=FAIRNESS, concurrency=None, verbose=False):
     """One INDEX-TIER pass over the fleet: caption ready units, then refresh per-session archives whose
     turn set grew. Returns {"captions": n, "archives": m}. Frame-wrapped like run_triage: under the
     kernel producer it joins the producer's pass frame; standalone it owns one."""
@@ -6919,7 +6962,7 @@ def run_index(now=None, budget=BUDGET, fairness=FAIRNESS, concurrency=CONCURRENC
         end_pass_frame(own)
 
 
-def _run_index(now=None, budget=BUDGET, fairness=FAIRNESS, concurrency=CONCURRENCY, verbose=False):
+def _run_index(now=None, budget=BUDGET, fairness=FAIRNESS, concurrency=None, verbose=False):
     if now is None:
         now = int(time.time())
     fleet = discover(now)
@@ -6951,7 +6994,7 @@ def _run_index(now=None, budget=BUDGET, fairness=FAIRNESS, concurrency=CONCURREN
     captions = 0
     struck = set()                                        # one strike per unit per PASS (grains share ids)
     gave = {}                                             # fsid → units tombstoned this pass (one log row each)
-    with ThreadPoolExecutor(max_workers=concurrency) as ex:
+    with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         futs = {ex.submit(_caption_call, t): t for t in selected}
         for fut in as_completed(futs):
             task = futs[fut]
@@ -7002,7 +7045,7 @@ def _run_index(now=None, budget=BUDGET, fairness=FAIRNESS, concurrency=CONCURREN
     if verbose:
         sys.stderr.write("romp-judge: %d sessions need (re)archiving\n" % len(arch_tasks))
     archives = 0
-    with ThreadPoolExecutor(max_workers=concurrency) as ex:
+    with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         futs = {ex.submit(_archive_call, fsid, caps): (fsid, len(caps))
                 for fsid, caps in arch_tasks}
         for fut in as_completed(futs):
@@ -9272,7 +9315,7 @@ def _hidden_from_feed(fsid):
         return False
 
 
-def run_plan(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verbose=False):
+def run_plan(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=False):
     """One TRIAGE-TIER planner pass: advance each session's goal tree. Per-session sequential
     (the tree accretes); sessions concurrent. Returns total placements made. (Global cross-session
     time-order is the courier's need; the planner's tree is per-session.)"""
@@ -9280,7 +9323,7 @@ def run_plan(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verb
         now = int(time.time())
     fleet = [s for s in discover(now) if not _hidden_from_feed(s[0])][:sessions_cap]   # muted sessions are out of task tracking
     placed = 0
-    with ThreadPoolExecutor(max_workers=concurrency) as ex:
+    with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         futs = {ex.submit(_plan_session, fsid, str(path), now): fsid for fsid, path, anchor, name in fleet}
         for fut in as_completed(futs):
             try:
@@ -9915,7 +9958,7 @@ def _group_session(fsid, path, now):
     return relinks
 
 
-def run_group(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verbose=False):
+def run_group(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=False):
     """One GROUPER pass (triage tier), run after run_plan: nest each session's related open top goals into
     coherent trees. Event-gated per session (see _group_session) so it only calls the model when a
     session's open-top set changed. Per-session sequential, sessions concurrent. Returns total relinks."""
@@ -9923,7 +9966,7 @@ def run_group(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, ver
         now = int(time.time())
     fleet = discover(now)[:sessions_cap]
     n = 0
-    with ThreadPoolExecutor(max_workers=concurrency) as ex:
+    with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         futs = {ex.submit(_group_session, fsid, str(path), now): fsid
                 for fsid, path, anchor, name in fleet}
         for fut in as_completed(futs):
@@ -10009,7 +10052,7 @@ def _consolidate_session(fsid, path, now):
     return 1 if changed else 0
 
 
-def run_consolidate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verbose=False):
+def run_consolidate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=False):
     """One CONSOLIDATOR pass (triage tier), run after run_group / before run_distill so a card the
     housekeeping touched re-distills this same cycle. Event-gated per session. Returns the number
     of sessions whose completed column changed."""
@@ -10017,7 +10060,7 @@ def run_consolidate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENC
         now = int(time.time())
     fleet = discover(now)[:sessions_cap]
     n = 0
-    with ThreadPoolExecutor(max_workers=concurrency) as ex:
+    with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         futs = {ex.submit(_consolidate_session, fsid, str(path), now): fsid
                 for fsid, path, anchor, name in fleet}
         for fut in as_completed(futs):
@@ -11431,6 +11474,9 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
 
 
 DEATH_DRAIN_PER_PASS = CONCURRENCY   # a QUEUE-DRAIN bound on death-pending finalizes per closer pass —
+#   sized to the module-load concurrency (the variable, else 6), deliberately not the live setting: it
+#   spreads a one-time backfill, it is not a parallelism lever, and a bound that moved between passes
+#   would make the drain's progress unreadable. The pool that runs the finalizes follows the setting.
 #   NOT a fairness cap on live sessions (those were removed 2026-06-30 and stay removed): the pending
 #   set is a finite backlog that strictly shrinks (every drained marker gains endedAt, superseded ones
 #   retire), so the bound only spreads the one-time upgrade backfill over successive passes instead of
@@ -11556,7 +11602,7 @@ def _death_finalize(fsid, store, settled):
         append_episode_settle(fsid, "ended:%d" % mt, int(time.time()), open_tops)
 
 
-def run_close(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verbose=False):
+def run_close(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=False):
     """One CLOSER pass (the turn-end completion backstop), triage tier, run after run_plan.
     Per-session sequential (the tree accretes), sessions concurrent. Returns nodes completed.
     The fleet is the discover set PLUS a bounded drain of death-pending sids (markers without
@@ -11583,7 +11629,7 @@ def run_close(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, ver
                     m["noTranscript"] = True
                     _write_death_marker(sid, m)
     n = 0
-    with ThreadPoolExecutor(max_workers=concurrency) as ex:
+    with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         futs = {ex.submit(_close_session, fsid, str(path), now): fsid
                 for fsid, path, anchor, name in fleet}
         for fut in as_completed(futs):
@@ -11853,14 +11899,14 @@ def _unblock_session(fsid, path, now):
     return lifted
 
 
-def run_unblock(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verbose=False):
+def run_unblock(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=False):
     """One UNBLOCKER pass (stale sub-block re-examination), triage tier, run after run_close.
     Per-session sequential (one call covers all its due blocks), sessions concurrent."""
     if now is None:
         now = int(time.time())
     fleet = [s for s in discover(now) if not _hidden_from_feed(s[0])][:sessions_cap]
     n = 0
-    with ThreadPoolExecutor(max_workers=concurrency) as ex:
+    with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         futs = {ex.submit(_unblock_session, fsid, str(path), now): fsid
                 for fsid, path, anchor, name in fleet}
         for fut in as_completed(futs):
@@ -11908,7 +11954,7 @@ def _ab_close(sessions_cap=PLAN_SESSIONS):
     tot_a = tot_b = 0
     all_new, all_samples = [], []
     # Parallel ACROSS sessions (each session sweeps its own turns sequentially for clean attribution).
-    with ThreadPoolExecutor(max_workers=min(len(fleet) or 1, 2 * CONCURRENCY)) as ex:
+    with ThreadPoolExecutor(max_workers=min(len(fleet) or 1, 2 * _judge_concurrency())) as ex:
         futs = {ex.submit(_ab_close_session, fsid, str(path), now): (name or fsid[:8])
                 for fsid, path, anchor, name in fleet}
         for fut in as_completed(futs):
@@ -11959,7 +12005,7 @@ def _latest_subtree_segment(nid, nodes, children, seg_by_id):
     return max(segs, key=lambda s: s["t"]) if segs else None
 
 
-def _ab_classify(sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY):
+def _ab_classify(sessions_cap=PLAN_SESSIONS, concurrency=None):
     """Measure-only: re-run the planner's BLOCKED/WORKING verdict on the current uncleared top-goals
     (working + blocked) under 3 arms — sonnet / sonnet+effort medium / opus+effort medium — and diff vs
     the live status, WITHOUT mutating goal state. The question: do the soft blocks hold under
@@ -11997,7 +12043,7 @@ def _ab_classify(sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY):
             ops = _parse_plan(plan_llm(job["text"], job["menu_text"], model=model, effort=effort), job["menu_len"])
             v[arm] = ("blocked" if any(o["do"] == "block" for o in ops) else "working") if ops else "?"
         return dict(job, v=v)
-    with ThreadPoolExecutor(max_workers=concurrency) as ex:
+    with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         rows = list(ex.map(classify, jobs))
 
     armnames = [a[0] for a in CLASSIFY_ARMS]
@@ -13567,7 +13613,7 @@ def _drain_undiscovered(now, fleet_sids):
     return n
 
 
-def run_distill(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verbose=False):
+def run_distill(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=False):
     """One DISTILLER pass (triage tier), run after the closer/grouper: store a key-takeaway summary on each
     newly-(re)completed top goal's card. Event-gated per goal. Also drains stores the fleet walk
     can't reach (_drain_undiscovered) and logs a session pass that dies instead of swallowing it —
@@ -13577,7 +13623,7 @@ def run_distill(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
         now = int(time.time())
     fleet = discover(now)[:sessions_cap]
     n = 0
-    with ThreadPoolExecutor(max_workers=concurrency) as ex:
+    with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         futs = {ex.submit(_distill_session, fsid, str(path), now): fsid for fsid, path, anchor, name in fleet}
         for fut in as_completed(futs):
             try:
@@ -13590,7 +13636,7 @@ def run_distill(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
     return n
 
 
-def run_triage(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verbose=False):
+def run_triage(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=False):
     """The TRIAGE-tier sequence as ONE unit, so the kernel can run it in PARALLEL with the always-on INDEX
     tier (run_index) — they share no store and triage never reads the captioner's output, so the only cost
     of overlap is each tier parsing a transcript instead of sharing one parse. Order matters: the planner
@@ -14523,7 +14569,7 @@ def _presumed_closed(sid, now):
     return sid not in remote
 
 
-def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verbose=False):
+def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=False):
     """DETERMINISTIC delegation completion link-back (the user 2026-06-22). When a courier-planted goal G
     (origin.peer + origin.goalId) is COMPLETE on the recipient B's tree, mark the SENDER's tracking node
     origin.goalId DONE too — so a '↪ delegated to B' item checks off the instant B finishes and reports. NO
@@ -14790,7 +14836,7 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
     return n
 
 
-def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verbose=False):
+def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=False):
     """One TRIAGE-TIER courier pass: place peer-message (postal) segments as delegations, GLOBAL
     oldest-first across sessions. Idempotent (msgId + seg_id). COORDINATING segments are marked processed
     without a goal-edit; a declared coordinate/question files that way outright, no model call (demote-
@@ -15143,7 +15189,7 @@ def _test(path):
     tasks.sort(key=lambda t: max(w["t"] for w in t["writes"]), reverse=True)
     tasks = tasks[:TEST_UNITS]
     print("transcript %s — %d recent caption tasks (newest first)\n" % (fsid[:8], len(tasks)))
-    with ThreadPoolExecutor(max_workers=CONCURRENCY) as ex:
+    with ThreadPoolExecutor(max_workers=_judge_concurrency()) as ex:   # the live setting, like every pass pool
         caps = list(ex.map(lambda t: caption_llm(t["text"]), tasks))
     from datetime import datetime
     for t, cap in zip(tasks, caps):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1003,6 +1003,7 @@ def _version_info():
             "updateAvail": _UPDATE_AVAIL[0],   # newer release the boot check found ("" = none/unknown)
             "judgeModel": jd._triage_model(), "indexModel": jd._index_model(),      # current per-tier judge models → the gear dropdowns
             "judgeEffort": jd._triage_effort(), "indexEffort": jd._index_effort(),  # current per-tier judge efforts ("" = default/none)
+            "judgeConcurrency": jd._state_str("judge-concurrency", ""),   # RAW ("" = ROMP_JUDGE_CONCURRENCY, else 6) → the gear select (T277)
             "distillModel": jd._state_str("distill-model", "triage"),   # RAW ("triage" = follow the triage pick) — the gear shows the choice, not the resolution
             "distillEffort": jd._state_str("distill-effort", "triage"),
             # the default-comment trio, RAW too ("session" = same as the session) — the gear shows
@@ -1023,6 +1024,7 @@ def _version_info():
                          "fileEditing": _mv["fileEditing"],
                          "judgeModel": jd._triage_model(), "judgeEffort": jd._triage_effort(),
                          "indexModel": jd._index_model(), "indexEffort": jd._index_effort(),
+                         "judgeConcurrency": jd._state_str("judge-concurrency", ""),
                          "distillModel": jd._state_str("distill-model", "triage"),
                          "distillEffort": jd._state_str("distill-effort", "triage"),
                          "commentModel": jd._state_str("comment-model", "session"),
@@ -37004,6 +37006,13 @@ def _set_judge_model(v, gt=None):  return _set_judge_state("judge-model", v, _ju
 def _set_index_model(v, gt=None):  return _set_judge_state("index-model", v, _judge_model_values(), gt=gt)
 def _set_judge_effort(v, gt=None): return _set_judge_state("judge-effort", v, _EFFORT_VALUES, allow_empty=True, gt=gt)
 def _set_index_effort(v, gt=None): return _set_judge_state("index-effort", v, _EFFORT_VALUES, allow_empty=True, gt=gt)
+# Judge concurrency (T277): how many judge calls run at once, every tier. The select offers exactly the
+# judge's range (1..16, jd.CONCURRENCY_MIN/MAX), so anything else is a bad client and is refused unwritten —
+# the judge trusts the file. The EMPTY value is the gear's Default: it clears the setting, and the judge
+# falls back to ROMP_JUDGE_CONCURRENCY as read at its load, else 6 (jd._judge_concurrency). Read fresh on
+# every pass, so a pick lands on the judges' next pass with no restart; the setting wins over the variable.
+_CONCURRENCY_VALUES = {str(n) for n in range(jd.CONCURRENCY_MIN, jd.CONCURRENCY_MAX + 1)}
+def _set_judge_concurrency(v, gt=None): return _set_judge_state("judge-concurrency", v, _CONCURRENCY_VALUES, allow_empty=True, gt=gt)
 # The distilling pair accepts extra sentinels (resolved by jd._distill_model/_distill_effort at call
 # time): "triage" (the default) means FOLLOW the triage pick live — exactly what the distiller/briefer/
 # staller did before the split (the user 2026-08-14) — and effort's "none" pins no-flag. "none" exists
@@ -37038,6 +37047,7 @@ def _set_comment_fast(v, gt=None):   return _set_judge_state("comment-fast", v, 
 
 _JUDGE_SETTING_FIELDS = (("judgeModel", _set_judge_model), ("indexModel", _set_index_model),
                          ("judgeEffort", _set_judge_effort), ("indexEffort", _set_index_effort),
+                         ("judgeConcurrency", _set_judge_concurrency),   # T277: one width for every tier's pool
                          ("distillModel", _set_distill_model), ("distillEffort", _set_distill_effort),
                          # the comment-thread defaults ride the same cross-kernel door: kernel-side
                          # settings follow to every machine (the 2026-08-14 gear rule), and
@@ -37089,6 +37099,7 @@ def _apply_judge_settings(body):
         _push_soon()   # ack-fast (the 2026-08-30 wedge: inline fleet builds piled 53 POST handlers; the pusher coalesces)
     return {"ok": True, "judgeModel": jd._triage_model(), "indexModel": jd._index_model(),
             "judgeEffort": jd._triage_effort(), "indexEffort": jd._index_effort(),
+            "judgeConcurrency": jd._state_str("judge-concurrency", ""),   # RAW: "" = the variable, else 6
             "distillModel": jd._state_str("distill-model", "triage"),
             "distillEffort": jd._state_str("distill-effort", "triage"),
             "commentModel": jd._state_str("comment-model", "session"),
@@ -37302,7 +37313,7 @@ def _adopt_peer_settings(host, rver):
 # Every gt-gated store, by the name _setting_stale is called with — the vocabulary the settingStale
 # frame and the gear's STALE_LABELS already share, so /version's settingsGt speaks the same one.
 _GT_STORES = ("auto-nudge", "compact-suggest", "file-editing", "update-mode", "thinking-summaries",
-              "judge-model", "index-model", "judge-effort", "index-effort",
+              "judge-model", "index-model", "judge-effort", "index-effort", "judge-concurrency",
               "distill-model", "distill-effort", "comment-model", "comment-effort", "comment-fast")
 
 
@@ -48189,6 +48200,13 @@ class Handler(BaseHTTPRequestHandler):
             if _jgt is not None:
                 threading.Thread(target=_propagate_judge_settings,
                                  args=({"indexEffort": str(msg.get("effort") or ""), "gt": _jgt},), daemon=True).start()
+            else:
+                _tell_stale_gesture(client, msg)
+        elif msg and msg.get("type") == "setJudgeConcurrency":
+            _jgt = _set_judge_concurrency(str(msg.get("value") or ""), gt=_gesture_ms(msg))   # gear "Judge concurrency" ("" = Default: the variable, else 6)
+            if _jgt is not None:
+                threading.Thread(target=_propagate_judge_settings,
+                                 args=({"judgeConcurrency": str(msg.get("value") or ""), "gt": _jgt},), daemon=True).start()
             else:
                 _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setDistillModel" and msg.get("model"):

--- a/tests/test_gear_select_matrix.py
+++ b/tests/test_gear_select_matrix.py
@@ -52,6 +52,13 @@ GEAR = open(os.path.join(ROOT, "ui", "webview", "gear.js")).read()
 
 
 class SourcePins(unittest.TestCase):
+    def test_the_concurrency_options_span_exactly_the_kernels_range(self):
+        # the kernel refuses anything outside jd.CONCURRENCY_MIN..MAX (its _CONCURRENCY_VALUES); the gear's
+        # loop must paint exactly that range, or a stored value could be off the list (T277). The served
+        # matrix below proves it end to end where a browser exists; this pin runs everywhere.
+        self.assertIn("for (var ci = %d; ci <= %d; ci++)" % (km.jd.CONCURRENCY_MIN, km.jd.CONCURRENCY_MAX), GEAR,
+                      "the gear's concurrency options span exactly the kernel's range")
+
     def test_every_facade_joins_the_one_repaint_registry(self):
         # the versionMenu label sync must repaint on fill()'s silent writes exactly like the
         # selectPick facades do — one registry, flushed at the end of fill()
@@ -63,7 +70,7 @@ class SourcePins(unittest.TestCase):
         self.assertIn("function setShow(sel, val)", GEAR)
         # a stored value with no option INJECTS a marked one — honest, never the default lie
         self.assertIn("not in this kernel's list", GEAR)
-        for sel in ("jm", "im", "dm", "cmm", "je", "ie", "de", "cme", "upm"):
+        for sel in ("jm", "im", "dm", "cmm", "je", "ie", "jc", "de", "cme", "upm"):
             self.assertIn("setShow(%s, v." % sel, GEAR, sel + " must render through setShow")
 
 
@@ -86,6 +93,7 @@ MATRIX = {
     "rs-cmtmodel":      ("comment-model", ["session", "default"] + MODELS_ALL),
     "rs-judgeeffort":   ("judge-effort", EFFORTS),
     "rs-indexeffort":   ("index-effort", EFFORTS),
+    "rs-judgeconc":     ("judge-concurrency", [str(n) for n in range(km.jd.CONCURRENCY_MIN, km.jd.CONCURRENCY_MAX + 1)]),
     "rs-distilleffort": ("distill-effort", ["triage", "none"] + EFFORTS),
     "rs-cmteffort":     ("comment-effort", ["session"] + EFFORTS),
 }

--- a/tests/test_judge_concurrency.py
+++ b/tests/test_judge_concurrency.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Judge concurrency is a knob (T277). The judges' worker-pool width was a bare constant (6 concurrent
+`claude -p` calls). It stays 6 by default and now reads from two places, the setting winning:
+
+- `ROMP_JUDGE_CONCURRENCY`, read ONCE at judge module load: an integer clamped to 1..16; a value that is
+  not an integer is ignored with one stderr line and the default stands.
+- the kernel setting `judge-concurrency` (the gear's "Judge concurrency" select, alongside the triage
+  model/effort picks): validated by the kernel before it is written, read fresh on every pass through
+  the same mtime-cached STATE reader the tier picks use, so a change lands on the judges' NEXT pass with
+  no restart. An empty setting clears back to the variable (else the default).
+
+Every run_* entry point's `concurrency` argument defaults to None and resolves at CALL time (`_conc`),
+because a def-time default (`=CONCURRENCY`) would have frozen the setting out of the long-lived kernel.
+Hermetic: the judge module is loaded against a temp XDG state dir; no live state is touched.
+"""
+import contextlib
+import inspect
+import io
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)   # a live kernel's export outranks the XDG floor
+os.environ.pop("ROMP_JUDGE_CONCURRENCY", None)   # the default case below must see NO variable
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_conc", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+
+def _load_judge_with_env(value, name):
+    """A FRESH judge module loaded with ROMP_JUDGE_CONCURRENCY=value (None = unset), plus what it
+    wrote to stderr while loading — the module-load read is the thing under test."""
+    saved = os.environ.get("ROMP_JUDGE_CONCURRENCY")
+    if value is None:
+        os.environ.pop("ROMP_JUDGE_CONCURRENCY", None)
+    else:
+        os.environ["ROMP_JUDGE_CONCURRENCY"] = value
+    err = io.StringIO()
+    try:
+        with contextlib.redirect_stderr(err):
+            mod = SourceFileLoader(name, os.path.join(BIN, "romp-judge")).load_module()
+    finally:
+        if saved is None:
+            os.environ.pop("ROMP_JUDGE_CONCURRENCY", None)
+        else:
+            os.environ["ROMP_JUDGE_CONCURRENCY"] = saved
+    return mod, err.getvalue()
+
+
+class _Sandbox(unittest.TestCase):
+    """STATE sandboxed per test: km and jd share the module object, so steering jd.STATE steers both
+    the kernel's setters and the judge's readers (the test_kernel_judge_model idiom)."""
+    def setUp(self):
+        self._saved_state = jd.STATE
+        self._td = tempfile.mkdtemp()
+        jd.STATE = Path(self._td)
+        jd._state_cache.clear()
+
+    def tearDown(self):
+        jd.STATE = self._saved_state
+        jd._state_cache.clear()
+        shutil.rmtree(self._td, ignore_errors=True)
+
+
+class Default(_Sandbox):
+    def test_default_is_six_with_no_variable_and_no_setting(self):
+        self.assertEqual(jd.CONCURRENCY_DEFAULT, 6)
+        self.assertEqual(jd.CONCURRENCY, 6, "no ROMP_JUDGE_CONCURRENCY in this process → the constant stays 6")
+        self.assertEqual(jd._judge_concurrency(), 6, "no setting file → the module-load value")
+        self.assertEqual(jd._conc(None), 6)
+        self.assertEqual(jd._conc(2), 2, "an explicit argument always stands")
+
+    def test_every_pass_entry_point_resolves_concurrency_at_call_time(self):
+        # a def-time default (=CONCURRENCY) is exactly the bug this knob must not have: the kernel
+        # imports the judge once and would run the setting-less value forever
+        for fn in (jd.run_index, jd._run_index, jd.run_plan, jd.run_group, jd.run_consolidate, jd.run_close,
+                   jd.run_unblock, jd.run_distill, jd.run_triage, jd.run_propagate, jd.run_courier,
+                   jd._ab_classify):
+            p = inspect.signature(fn).parameters["concurrency"]
+            self.assertIsNone(p.default, "%s must default concurrency to None (resolved per call)" % fn.__name__)
+
+
+def _recording_pool(seen):
+    """A ThreadPoolExecutor stand-in that records max_workers and runs nothing: the tests below patch it in
+    to read what width a real entry point asked for."""
+    class Pool:
+        def __init__(self, max_workers=None):
+            seen.append(max_workers)
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def submit(self, *a, **k):
+            raise AssertionError("nothing to submit — the session list is empty")
+        def map(self, fn, it):
+            return [fn(x) for x in it]
+    return Pool
+
+
+class Variable(_Sandbox):
+    def test_variable_is_read_at_module_load(self):
+        mod, err = _load_judge_with_env("10", "romp_judge_conc_ten")
+        mod.STATE = jd.STATE   # the fresh module resolved STATE from the process env at load; under a full run that
+        mod._state_cache.clear()   # is another module's store, which a peer test may have written a setting into
+        self.assertEqual(mod.CONCURRENCY, 10)
+        self.assertEqual(mod._judge_concurrency(), 10, "no setting → the variable's value")
+        self.assertEqual(err, "", "a valid integer says nothing")
+
+    def test_parser_defaults_clamps_and_ignores_garbage_with_one_line(self):
+        parse = jd._concurrency_from_env
+        self.assertEqual(parse(None), 6)
+        self.assertEqual(parse(""), 6)
+        self.assertEqual(parse("  "), 6)
+        self.assertEqual(parse(" 4 "), 4)
+        self.assertEqual(parse("0"), 1, "clamped to the floor")
+        self.assertEqual(parse("-3"), 1)
+        self.assertEqual(parse("99"), 16, "clamped to the ceiling")
+        self.assertEqual(parse("16"), 16)
+        for bad in ("six", "6.5", "1e1", "0x6"):
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(parse(bad), 6, "%r is ignored" % bad)
+            lines = err.getvalue().splitlines()
+            self.assertEqual(len(lines), 1, "exactly one stderr line for %r: %r" % (bad, lines))
+            self.assertIn("ROMP_JUDGE_CONCURRENCY", lines[0])
+            self.assertIn(bad, lines[0])
+
+    def test_clamp_applies_at_module_load_too(self):
+        mod, err = _load_judge_with_env("99", "romp_judge_conc_clamp")
+        self.assertEqual(mod.CONCURRENCY, 16)
+        self.assertEqual(err, "", "a clamped integer says nothing — it is a value, applied at the bound")
+        mod, err = _load_judge_with_env("lots", "romp_judge_conc_bad")
+        self.assertEqual(mod.CONCURRENCY, 6, "garbage → the default")
+        self.assertEqual(len(err.splitlines()), 1, "…and one stderr line: %r" % err)
+
+
+class Setting(_Sandbox):
+    def test_setting_is_validated_written_and_read_fresh(self):
+        self.assertIsNotNone(km._set_judge_concurrency("3"))
+        self.assertEqual((jd.STATE / "judge-concurrency").read_text(), "3")
+        self.assertEqual(jd._judge_concurrency(), 3)
+        self.assertEqual(jd._conc(None), 3, "the run_* default resolves to the setting")
+        # a later change lands on the next read (mtime-cached, like the tier picks); the mtime bump
+        # stands in for the seconds between two real gestures
+        self.assertIsNotNone(km._set_judge_concurrency("5"))
+        f = jd.STATE / "judge-concurrency"
+        st = f.stat()
+        os.utime(f, (st.st_atime + 2, st.st_mtime + 2))
+        self.assertEqual(jd._judge_concurrency(), 5)
+
+    def test_out_of_range_and_garbage_are_refused_not_clamped(self):
+        # the kernel validates before writing (the judge trusts the file): a select can only offer
+        # 1..16, so anything else is a bad client, refused with nothing written
+        self.assertIsNotNone(km._set_judge_concurrency("2"))
+        for bad in ("0", "17", "40", "-1", "six", "6.0", " 6"):
+            self.assertIsNone(km._set_judge_concurrency(bad), "%r must be refused" % bad)
+        self.assertEqual((jd.STATE / "judge-concurrency").read_text(), "2", "the refused values wrote nothing")
+        self.assertEqual(jd._judge_concurrency(), 2)
+
+    def test_empty_setting_clears_back_to_the_variable_or_default(self):
+        self.assertIsNotNone(km._set_judge_concurrency("9"))
+        self.assertEqual(jd._judge_concurrency(), 9)
+        self.assertIsNotNone(km._set_judge_concurrency(""), "the empty pick is the gear's Default option")
+        f = jd.STATE / "judge-concurrency"
+        st = f.stat()
+        os.utime(f, (st.st_atime + 2, st.st_mtime + 2))
+        self.assertEqual(jd._judge_concurrency(), jd.CONCURRENCY, "cleared → the module-load value")
+
+    def test_setting_wins_over_the_variable(self):
+        mod, _ = _load_judge_with_env("12", "romp_judge_conc_twelve")
+        saved = mod.STATE
+        mod.STATE = jd.STATE   # the sandboxed store the kernel writes
+        mod._state_cache.clear()
+        try:
+            self.assertEqual(mod._judge_concurrency(), 12, "no setting → the variable")
+            self.assertIsNotNone(km._set_judge_concurrency("2"))
+            self.assertEqual(mod._judge_concurrency(), 2, "a setting outranks the variable")
+        finally:
+            mod.STATE = saved
+            mod._state_cache.clear()
+
+    def test_a_pass_sizes_its_pool_from_the_live_setting(self):
+        # end to end through a real entry point: run_distill with nothing to distill still builds its
+        # pool, and the pool's width is the setting at call time
+        seen = []
+        with unittest.mock.patch.object(jd, "ThreadPoolExecutor", _recording_pool(seen)), \
+             unittest.mock.patch.object(jd, "discover", lambda now, **k: []), \
+             unittest.mock.patch.object(jd, "_drain_undiscovered", lambda *a, **k: 0):
+            jd.run_distill(now=1)
+            self.assertEqual(seen, [6], "no setting → the default pool")
+            self.assertIsNotNone(km._set_judge_concurrency("4"))
+            jd.run_distill(now=1)
+            self.assertEqual(seen, [6, 4], "the next pass reads the setting — no restart")
+            jd.run_distill(now=1, concurrency=2)
+            self.assertEqual(seen, [6, 4, 2], "an explicit argument still stands")
+
+    def test_the_eyeballing_cli_pool_follows_the_setting_too(self):
+        # `romp-judge --test <transcript>` (jd._test) opens its own caption pool: the one pool outside the
+        # pass entry points, and the review found it still on the load-time constant. Nothing to caption
+        # here (a synthetic path, no tasks), so only the requested width is observed.
+        seen = []
+        self.assertIsNotNone(km._set_judge_concurrency("2"))
+        with unittest.mock.patch.object(jd, "ThreadPoolExecutor", _recording_pool(seen)), \
+             unittest.mock.patch.object(jd, "tasks_for", lambda *a, **k: []), \
+             unittest.mock.patch.object(jd, "caption_llm", lambda text: ""), \
+             contextlib.redirect_stdout(io.StringIO()):
+            jd._test("/tmp/11111111-2222-4333-8444-555555555555.jsonl")
+        self.assertEqual(seen, [2])
+
+    def test_an_undecodable_setting_file_reads_as_the_default(self):
+        # a hand edit saved in another encoding: the STATE reader caught OSError only, and read_text's
+        # UnicodeDecodeError (a ValueError) escaped through _conc BEFORE any pool opened, failing the whole
+        # tier every cycle (the review's find). It reads as the default now, like a missing file.
+        (jd.STATE / "judge-concurrency").write_bytes(b"\xff\xfe6")
+        self.assertEqual(jd._state_str("judge-concurrency", ""), "")
+        self.assertEqual(jd._judge_concurrency(), jd.CONCURRENCY)
+        self.assertEqual(jd._conc(None), jd.CONCURRENCY, "the pass opens its pool at the default width")
+
+    def test_kernel_surfaces_carry_the_field(self):
+        # /judge-settings applies it through the same validated door and answers RAW ("" = following
+        # the variable/default), like the distill and comment fields; the stamp store list and the
+        # settings-field table both name it, so it propagates and orders like every other judge knob
+        self.assertIn("judgeConcurrency", dict(km._JUDGE_SETTING_FIELDS))
+        self.assertIn("judge-concurrency", km._GT_STORES)
+        res = km._apply_judge_settings({})
+        self.assertEqual(res["judgeConcurrency"], "")
+        res = km._apply_judge_settings({"judgeConcurrency": "7"})
+        self.assertEqual(res["judgeConcurrency"], "7")
+        self.assertEqual(jd._judge_concurrency(), 7)
+        res = km._apply_judge_settings({"judgeConcurrency": "70"})
+        self.assertEqual(res["judgeConcurrency"], "7", "an invalid value is ignored and the ack shows what stands")
+        # /version reports it beside the other judge knobs, top level AND in the cross-machine `settings`
+        # dict (the mixed marks compare that one), RAW like the distill and comment fields
+        v = km._version_info()
+        self.assertEqual(v["judgeConcurrency"], "7")
+        self.assertEqual(v["settings"]["judgeConcurrency"], "7")
+        self.assertIn("judge-concurrency", v["settingsGt"], "its gesture stamp rides with the other stores'")
+
+
+import unittest.mock  # noqa: E402  (after the module loads above, like the other kernel tests)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge_settings_sync.py
+++ b/tests/test_judge_settings_sync.py
@@ -220,13 +220,14 @@ class OneHopNeverALoop(unittest.TestCase):
                      'args=({"indexModel": str(msg["model"]), "gt": _jgt},)',
                      'args=({"judgeEffort": str(msg.get("effort") or ""), "gt": _jgt},)',
                      'args=({"indexEffort": str(msg.get("effort") or ""), "gt": _jgt},)',
+                     'args=({"judgeConcurrency": str(msg.get("value") or ""), "gt": _jgt},)',   # T277
                      'args=({"distillModel": str(msg["model"]), "gt": _jgt},)',
                      'args=({"distillEffort": str(msg["effort"]), "gt": _jgt},)',
                      'args=({"commentModel": str(msg["model"]), "gt": _jgt},)',
                      'args=({"commentEffort": str(msg["effort"]), "gt": _jgt},)',
                      'args=({"commentFast": str(msg["fast"]), "gt": _jgt},)'):
             self.assertIn(frag, self.src, frag)
-        self.assertGreaterEqual(self.src.count("if _jgt is not None:"), 9,
+        self.assertGreaterEqual(self.src.count("if _jgt is not None:"), 10,
                                 "every judge-tier fan-out is gated on the pick actually applying")
 
     def test_the_gear_copy_says_the_pick_follows(self):

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -77,15 +77,16 @@ class SettingsSectionsTest(unittest.TestCase):
         self.assertNotIn("headless", h)
 
     def test_judge_rows_are_one_line_label_plus_picker(self):
-        # label + picker share the line (the user 2026-07-12): eight .rs-jrow rows — six judge rows
-        # since the distilling tier split out of triage (the user 2026-08-14), plus the default-comment
+        # label + picker share the line (the user 2026-07-12): nine .rs-jrow rows — six judge rows
+        # since the distilling tier split out of triage (the user 2026-08-14), the judge concurrency
+        # select (T277), plus the default-comment
         # model/effort pair (the user 2026-08-29), which reuses the same one-line layout — the select
         # right after the hover sub, no full-width select stacked under the label; the flex CSS
         # carries the layout. Each label carries the hidden mixed-state marker (the settings-sync work).
         h = _gear_src()
-        self.assertEqual(h.count("rs-jrow"), 8)
+        self.assertEqual(h.count("rs-jrow"), 9)
         for sel in ("rs-judgemodel", "rs-judgeeffort", "rs-distillmodel", "rs-distilleffort",
-                    "rs-indexmodel", "rs-indexeffort"):
+                    "rs-indexmodel", "rs-indexeffort", "rs-judgeconc"):
             self.assertRegex(h, r"rs-jrow'><b>[^<]+<span class=rs-mixed hidden></span></b>"
                                 r"<span class=rs-sub>[^<]*</span><select id=" + sel)
         self.assertIn("#rsettings .rs-jrow select {", _gear_css_src())

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -795,7 +795,7 @@ class VersionReportsEveryStoredStamp(_Base):
     def test_a_fresh_install_reports_every_store_at_zero(self):
         gts = km._version_info()["settingsGt"]
         self.assertEqual(set(gts), set(km._GT_STORES), "one key per gt-gated store, no more, no less")
-        self.assertEqual(len(km._GT_STORES), 14, "five toggles/modes + nine judge-tier stores")
+        self.assertEqual(len(km._GT_STORES), 15, "five toggles/modes + ten judge-tier stores (judge-concurrency since T277)")
         self.assertEqual(set(gts.values()), {0}, "nothing applied yet reads 0 — nothing to outrank")
         self.assertEqual(json.loads(json.dumps(gts)), gts, "plain JSON — ints, no paths, nothing to redact")
 
@@ -833,14 +833,16 @@ class VersionReportsEveryStoredStamp(_Base):
                  {"type": "setFileEditing", "enabled": True}, {"type": "setUpdateMode", "mode": "auto"},
                  {"type": "setThinkingSummaries", "enabled": True}, {"type": "setJudgeModel", "model": "fable"},
                  {"type": "setIndexModel", "model": "fable"}, {"type": "setJudgeEffort", "effort": "high"},
-                 {"type": "setIndexEffort", "effort": "high"}, {"type": "setDistillModel", "model": "haiku"},
+                 {"type": "setIndexEffort", "effort": "high"}, {"type": "setJudgeConcurrency", "value": "4"},
+                 {"type": "setDistillModel", "model": "haiku"},
                  {"type": "setDistillEffort", "effort": "high"}, {"type": "setCommentModel", "model": "haiku"},
                  {"type": "setCommentEffort", "effort": "high"}, {"type": "setCommentFast", "fast": "on"}]
         older = [{"type": "setAutoNudge", "enabled": True}, {"type": "setCompactSuggest", "enabled": False},
                  {"type": "setFileEditing", "enabled": False}, {"type": "setUpdateMode", "mode": "off"},
                  {"type": "setThinkingSummaries", "enabled": False}, {"type": "setJudgeModel", "model": "opus"},
                  {"type": "setIndexModel", "model": "opus"}, {"type": "setJudgeEffort", "effort": "low"},
-                 {"type": "setIndexEffort", "effort": "low"}, {"type": "setDistillModel", "model": "triage"},
+                 {"type": "setIndexEffort", "effort": "low"}, {"type": "setJudgeConcurrency", "value": "2"},
+                 {"type": "setDistillModel", "model": "triage"},
                  {"type": "setDistillEffort", "effort": "low"}, {"type": "setCommentModel", "model": "session"},
                  {"type": "setCommentEffort", "effort": "session"}, {"type": "setCommentFast", "fast": "session"}]
         with contextlib.redirect_stderr(io.StringIO()):
@@ -849,7 +851,7 @@ class VersionReportsEveryStoredStamp(_Base):
                 km.Handler._dispatch_ws(types.SimpleNamespace(), dict(o, gt=T_OLD), client)
         named = {m["setting"] for m in sent if m.get("type") == "settingStale"}
         self.assertEqual(named, set(km._version_info()["settingsGt"]), "frames and the report share one vocabulary")
-        self.assertEqual(len(named), 14)
+        self.assertEqual(len(named), 15)   # ten judge-tier stores since T277
 
 
 class ASkewedClockCannotLockTheStore(_Base):

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -75,6 +75,7 @@ const OBJ_ID = ["tabs"]; //                       an array of objects keyed by `
 // them).
 const KERNEL_SETTING = new Set(["setAutoNudge", "setJudgeModel", "setIndexModel",
                                 "setJudgeEffort", "setIndexEffort", "setUpdateMode",
+                                "setJudgeConcurrency",   // T277: the judges' pool width, one value across machines
                                 "setDistillModel", "setDistillEffort", "setFileEditing",
                                 "setCompactSuggest",
                                 "setCommentModel", "setCommentEffort", "setCommentFast"]);

--- a/ui/webview/gear-models-frame.test.ts
+++ b/ui/webview/gear-models-frame.test.ts
@@ -33,10 +33,10 @@ function sel(): Sel {
 }
 // the one document call the block makes: setShow's injected <option>
 const DOC = { createElement: (tag: string): Opt => { assert.equal(tag, "option"); return { value: "", textContent: "" }; } };
-const SELECTS = ["jm", "im", "je", "ie", "dm", "de", "cmm", "cme"] as const;
+const SELECTS = ["jm", "im", "je", "ie", "jc", "dm", "de", "cmm", "cme"] as const;   // jc: the judge concurrency select (T277)
 
 // The block, evaluated with the closure variables it reads passed in: `window` (the listener's target),
-// `document` (the injected option), `fetch`/`ku` (the read), and the eight <select>s — real stand-ins by
+// `document` (the injected option), `fetch`/`ku` (the read), and the nine <select>s — real stand-ins by
 // default, or null (the guards).
 function lift(withSelects = true) {
   const start = GEAR.indexOf("  var choices = null");
@@ -137,6 +137,7 @@ test("executed: when the frame's re-read overtakes the page-load fill, every pic
   for (const k of SELECTS) assert.ok(S[k]!.innerHTML.length > 0, `${k} is painted`);
   assert.deepEqual(S.jm!.values, ["fable", "claude-fable-5"], "family + version options, from the list that won");
   assert.deepEqual(S.je!.values, ["", "high"]);
+  assert.deepEqual(S.jc!.values, ["", ...Array.from({ length: 16 }, (_, i) => String(i + 1))], "Default, then the kernel's whole 1..16 range (T277)");
   assert.deepEqual(S.dm!.values, ["triage", "fable", "claude-fable-5"], "the distilling sentinel leads");
   assert.deepEqual(S.de!.values, ["triage", "none", "high"]);
   assert.deepEqual(S.cmm!.values, ["session", "default", "fable", "claude-fable-5"], "the comment sentinels lead");

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -155,6 +155,7 @@ var GEAR_HTML =
   "<div class='rs-row rs-jrow'><b>Distilling effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the distilling judges. Follow triage (the default) rides the triage effort; Default pins no effort flag. Follows to every connected machine's kernel.</span><select id=rs-distilleffort></select></div>" +
   "<div class='rs-row rs-jrow'><b>Indexing model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model the indexing judges use — captioner + archiver (high-volume, low-stakes summarization). Haiku by default for cost. Follows to every connected machine's kernel.</span><select id=rs-indexmodel></select></div>" +
   "<div class='rs-row rs-jrow'><b>Indexing effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the indexing judges. Default keeps this high-volume work cheap: effort low on models with adaptive thinking (Fable, Opus 4.6 and later, Sonnet 4.6 and later); Haiku, Sonnet 4.5 and Opus 4.5 have none, so they run with thinking off and no flag. Follows to every connected machine's kernel.</span><select id=rs-indexeffort></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Judge concurrency <span class=rs-mixed hidden></span></b><span class=rs-sub>How many judge calls run at once, across every tier. Default is 6, or the ROMP_JUDGE_CONCURRENCY the kernel's service environment sets. Applies on the judges' next pass; no restart. Follows to every connected machine's kernel.</span><select id=rs-judgeconc></select></div>" +
   '<div class=rs-sec>Updates & debug</div>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Automatic updates <span class=rs-mixed hidden></span></b>" +
   '<span class=rs-sub>romp watches for new tagged releases (every 6 hours) AND new commits on main (origin polled every few minutes, plus a restart offer when updated code sits on disk unbooted) — one banner covers both, and acting on it converges every attached machine. Check and ask (the default) offers the banner with an Update button; Install automatically converges by itself, restarting at the next quiet moment; Off never checks. Kernel-side setting.</span>' +
@@ -227,6 +228,7 @@ function initGear(post) {
     jm = document.getElementById('rs-judgemodel'),
     im = document.getElementById('rs-indexmodel'), je = document.getElementById('rs-judgeeffort'),
     ie = document.getElementById('rs-indexeffort'), upm = document.getElementById('rs-updates'),
+    jc = document.getElementById('rs-judgeconc'),
     dm = document.getElementById('rs-distillmodel'), de = document.getElementById('rs-distilleffort'),
     cmm = document.getElementById('rs-cmtmodel'), cme = document.getElementById('rs-cmteffort'),
     cmf = document.getElementById('rs-cmtfast'),
@@ -431,6 +433,7 @@ function initGear(post) {
   selectPick(bk, 'margin-top:5px');
   selectPick(je, 'flex:0 0 auto;width:45%');
   selectPick(ie, 'flex:0 0 auto;width:45%');
+  selectPick(jc, 'flex:0 0 auto;width:45%');   // T277: the concurrency select wears the same facade as the effort picks
   selectPick(de, 'flex:0 0 auto;width:45%');
   selectPick(cme, 'flex:0 0 auto;width:45%');
   jix.addEventListener('change', function () { var s = load(); s.showIndexJudges = jix.checked; save(s); });
@@ -700,6 +703,7 @@ function initGear(post) {
   if (im) im.addEventListener('change', function () { post({ type: 'setIndexModel', model: im.value, gt: gclock.stamp('index-model') }); });
   if (je) je.addEventListener('change', function () { post({ type: 'setJudgeEffort', effort: je.value, gt: gclock.stamp('judge-effort') }); });
   if (ie) ie.addEventListener('change', function () { post({ type: 'setIndexEffort', effort: ie.value, gt: gclock.stamp('index-effort') }); });
+  if (jc) jc.addEventListener('change', function () { post({ type: 'setJudgeConcurrency', value: jc.value, gt: gclock.stamp('judge-concurrency') }); });
   if (dm) dm.addEventListener('change', function () { post({ type: 'setDistillModel', model: dm.value, gt: gclock.stamp('distill-model') }); });
   if (de) de.addEventListener('change', function () { post({ type: 'setDistillEffort', effort: de.value, gt: gclock.stamp('distill-effort') }); });
   // Fast is an Opus-only research preview (render.ts fastAvailable, the same rule): a pinned
@@ -780,7 +784,7 @@ function initGear(post) {
   var STALE_LABELS = { 'auto-nudge': 'Auto Nudge', 'compact-suggest': 'Suggest /compact',
     'file-editing': 'File editing',
     'update-mode': 'Automatic updates', 'judge-model': 'Triage model', 'judge-effort': 'Triage effort',
-    'index-model': 'Indexing model', 'index-effort': 'Indexing effort',
+    'index-model': 'Indexing model', 'index-effort': 'Indexing effort', 'judge-concurrency': 'Judge concurrency',
     'distill-model': 'Distilling model', 'distill-effort': 'Distilling effort',
     'comment-model': 'Comment model', 'comment-effort': 'Comment effort',
     'comment-fast': 'Fast comment threads', 'thinking-summaries': 'Thinking summaries' };
@@ -790,7 +794,7 @@ function initGear(post) {
   var STALE_TYPE = { 'auto-nudge': 'setAutoNudge', 'compact-suggest': 'setCompactSuggest',
     'file-editing': 'setFileEditing', 'update-mode': 'setUpdateMode', 'thinking-summaries': 'setThinkingSummaries',
     'judge-model': 'setJudgeModel', 'judge-effort': 'setJudgeEffort',
-    'index-model': 'setIndexModel', 'index-effort': 'setIndexEffort',
+    'index-model': 'setIndexModel', 'index-effort': 'setIndexEffort', 'judge-concurrency': 'setJudgeConcurrency',
     'distill-model': 'setDistillModel', 'distill-effort': 'setDistillEffort',
     'comment-model': 'setCommentModel', 'comment-effort': 'setCommentEffort', 'comment-fast': 'setCommentFast' };
   // store name → the words its select shows for the sentinel options whose value is not the word. The
@@ -798,7 +802,7 @@ function initGear(post) {
   // refused Default pick drew the value-less copy and a plain Apply anyway — in the frozen-tab case, the
   // one pick the user most needs to see named (#967 review). Kept in step with paintChoices' option
   // lists: setting-stale.test.ts pins every literal sentinel there against this map.
-  var STALE_WORDS = { 'judge-effort': { '': 'Default' }, 'index-effort': { '': 'Default' },
+  var STALE_WORDS = { 'judge-effort': { '': 'Default' }, 'index-effort': { '': 'Default' }, 'judge-concurrency': { '': 'Default' },
     'distill-model': { 'triage': 'Follow triage' }, 'distill-effort': { 'triage': 'Follow triage', 'none': 'Default' },
     'comment-model': { 'session': 'Same as the session', 'default': 'Default' }, 'comment-effort': { 'session': 'Same as the session' } };
   // Dismissal is the warn-toast FAMILY treatment (the user 2026-08-25: a notice with no visible
@@ -973,6 +977,10 @@ function initGear(post) {
     }).join('');
     var eff = (choices.efforts || []).map(function (m) { return '<option value="' + m.value + '">' + m.label + '</option>'; }).join('');
     var eo = '<option value="">Default</option>' + eff;
+    // judge concurrency: the kernel's exact range (1..16, its _CONCURRENCY_VALUES) behind the same Default
+    // sentinel — the empty value clears the setting back to the variable, else 6 (T277)
+    var co = '<option value="">Default</option>';
+    for (var ci = 1; ci <= 16; ci++) co += '<option value="' + ci + '">' + ci + '</option>';
     function put(sel, html) {
       if (!sel) return;
       var held = sel.value;
@@ -981,6 +989,7 @@ function initGear(post) {
     }
     put(jm, mo); put(im, mo);
     put(je, eo); put(ie, eo);
+    put(jc, co);
     // the distilling pair leads with the follow-triage sentinel — its default, so a fresh kernel
     // shows "Follow triage" rather than a model nobody picked. Its Default (no effort flag) is the
     // stored sentinel "none", never "" — an empty state file reads back as the default ("follow").
@@ -1059,7 +1068,7 @@ function initGear(post) {
   function fillMixedMarks(v, rows) {
     var mine = (v && v.settings) || null;
     [['updateMode', upm], ['judgeModel', jm], ['judgeEffort', je], ['indexModel', im],
-     ['indexEffort', ie], ['distillModel', dm], ['distillEffort', de], ['fileEditing', fe],
+     ['indexEffort', ie], ['judgeConcurrency', jc], ['distillModel', dm], ['distillEffort', de], ['fileEditing', fe],
      ['compactSuggest', csg],
      ['commentModel', cmm], ['commentEffort', cme], ['commentFast', cmf]].forEach(function (pair) {
       var key = pair[0], el = pair[1];
@@ -1100,6 +1109,7 @@ function initGear(post) {
     if (typeof v.indexModel === 'string') setShow(im, v.indexModel);
     if (typeof v.judgeEffort === 'string') setShow(je, v.judgeEffort);
     if (typeof v.indexEffort === 'string') setShow(ie, v.indexEffort);
+    if (typeof v.judgeConcurrency === 'string') setShow(jc, v.judgeConcurrency);   // RAW: "" selects Default (the variable, else 6)
     if (typeof v.distillModel === 'string') setShow(dm, v.distillModel);   // RAW: "triage" selects the Follow-triage option
     if (typeof v.distillEffort === 'string') setShow(de, v.distillEffort);
     if (typeof v.commentModel === 'string') setShow(cmm, v.commentModel);   // RAW: "session" selects Same as the session

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -44,7 +44,7 @@ test("every gear fetch routes through the kernel base + token (VS Code's webview
 
 test("the gear posts kernel ops through ONE shared channel (never re-acquires the VS Code API)", () => {
   assert.ok(!GEAR.includes("acquireVsCodeApi"), "a second acquire throws in a real webview");
-  for (const op of ["setAutoNudge", "setJudgeModel", "setIndexModel", "setJudgeEffort", "setIndexEffort",
+  for (const op of ["setAutoNudge", "setJudgeModel", "setIndexModel", "setJudgeEffort", "setIndexEffort", "setJudgeConcurrency",
     "setDistillModel", "setDistillEffort", "setCommentModel", "setCommentEffort", "setCommentFast",
     "setFileEditing", "setColormap", "setPalette", "setDefaultDir", "browseDir"])
     assert.ok(GEAR.includes(`'${op}'`), `gear must post ${op}`);


### PR DESCRIPTION
The judges' worker-pool width was a bare constant: six concurrent `claude -p` calls, the same on every machine. It is now a knob, with the default unchanged at 6.

**Environment variable.** `ROMP_JUDGE_CONCURRENCY` is read once, when the judge module loads: an integer clamped to 1..16 (a value past a bound is applied at the bound, silently, since it is a value); unset or blank leaves the default; anything that is not an integer is ignored with exactly one stderr line, never a crash, so a typo in `service.env` cannot take the judges down.

**Kernel setting.** The same value rides alongside the other judge knobs as `STATE/judge-concurrency`: the gear's Judges section gains a **Judge concurrency** select (Default plus 1..16), `/version` reports it top level and in the cross-machine `settings` dict, `/judge-settings` applies and acks it, the WebSocket op `setJudgeConcurrency` sets it with a gesture stamp, and the store sits in the stamp list, so it orders and propagates exactly like the triage model and effort picks. The kernel validates before writing (the select's exact range; anything else is refused unwritten), and the judge reads the file fresh on every pass through the same mtime-cached reader the tier picks use, so a change lands on the judges' next pass with no restart. The setting wins over the variable; the Default option clears the setting back to the variable, else 6.

**Design points.**
- Every `run_*` entry point's `concurrency` argument now defaults to `None` and resolves at call time (`_conc`). The old def-time default (`=CONCURRENCY`) would have frozen the setting out of the long-lived kernel, which imports the judge once. An explicit argument still stands, for tests and the A/B tools.
- The setting follows to every connected machine, like the other judge settings (the 2026-08-14 gear rule: kernel-side settings are one value across machines). The variable stays per machine, which is what a service environment is for.
- `DEATH_DRAIN_PER_PASS` alone stays on the load-time value: it spreads a one-time backfill of dead-session finalizes across passes and is not a parallelism lever; a bound that moved between passes would make the drain's progress unreadable. The pool that runs those finalizes follows the setting.
- Nothing about the devbox's value changes: no variable is set anywhere, and no setting file is written by this change.

**Tests** (`tests/test_judge_concurrency.py`, 13 cases): the default is 6 with no variable and no setting; every entry point defaults `concurrency` to `None`; the variable is read at module load (a fresh module load under `ROMP_JUDGE_CONCURRENCY=10`); the parser defaults, clamps and ignores garbage with one stderr line, at load too; the setting is validated, written and read fresh; out-of-range and garbage are refused, not clamped; the empty pick clears; the setting wins over the variable; a real pass (`run_distill`) sizes its pool from the live setting between two calls with no reload; the kernel surfaces (`_JUDGE_SETTING_FIELDS`, `_GT_STORES`, the `/judge-settings` ack, `/version`) carry the field; the `romp-judge --test` caption pool follows the setting too; an undecodable setting file (a hand edit in another encoding) reads as the default instead of failing the tier, which the shared state reader now guarantees for every judge setting. The served gear matrix test gains the new select, so every acceptable stored value is shown end to end through a real kernel.

**Docs.** `docs/reference.md` gains a "Judge concurrency" subsection under Configuration (the variable, the setting, the range, when each applies); `docs/judges.md`'s "Ops and knobs" names the state file beside the model files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
