### PR TITLE
Kernel: the auto-nudge walk derives its placement gate once per (parse, store) and reads the store through the shared view

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -884,15 +884,19 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   loader (`load_goals`) and `save_goals`; the pusher's read-only loads go
   through the shared store cache and show under `memos.shared`, not here. A
   save that would rewrite identical bytes is a save without a write.
-- `memos`: the three identity memos on the goal-store path. `pass` is the
+- `memos`: the identity memos on the goal-store path. `pass` is the
   judge pass's stat-keyed store memo (`hit`, `miss`, `fail`, `evict`, `punch`,
   and its occupancy `entries`, `bytes`); `shared` is the pusher's shared
   read-only store cache (`hit`, `miss`, `compare_miss`, `refuse`, `dup`,
   `absent`, `corrupt`, `unreadable_journal`, `evict`, `fallback`, `poisoned`,
   with `entries`, `bytes` and `off`); `chain` is the write-moment chain memo
-  (`hit`, `miss`, `populate`, `bypass`). The compaction sweep after each judge
-  pass evicts from `pass` and `shared` the entries of stores no session in the
-  discover window owns, so both stay bounded by the live board.
+  (`hit`, `miss`, `populate`, `bypass`); `nudgeGate` is the auto-nudge walk's
+  planner-placement gate, derived once per (parse, store) and served while
+  both stand (`served`, `derived`; a healthy quiet box serves almost every
+  cycle). The compaction sweep after each judge pass evicts from `pass` and
+  `shared` the entries of stores no session in the discover window owns, so
+  both stay bounded by the live board; the gate memo is bounded by the session
+  count.
 - `judge`: `passes`, `ms_sum`, `ms_last`, `ms_mean` (wall time; a pass waits
   on model calls), `cpu_ms_sum` (CPU time of the judge tier threads and every
   per-session worker they run; the workers' share is `cpu_ms_workers`).

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -381,6 +381,7 @@ class _PerfStats:
                 memos[key] = read()
             except Exception:
                 memos[key] = {}
+        memos["nudgeGate"] = dict(_NUDGE_GATE_STATS)   # the nudge walk's placement gate: served vs re-derived (2026-09-09)
         now = time.time()
         return {"now": now, "since": since, "uptime_s": now - _STARTED, "log": _PERF,
                 "process": _process_stats(), "pusher": pusher, "stages_ms": stages,
@@ -8407,7 +8408,7 @@ def _intr_block_stands(sid, gid):
     once the file read again."""
     if not gid:
         return False
-    store, fault = jd.load_goals_or_fault(sid)
+    store, fault = jd.load_goals_shared_or_fault(sid)   # a pure read: the shared view, one parse per file version (2026-09-09)
     if fault is not None:
         return True
     nd = store.get("nodes", {}).get(gid)
@@ -10714,6 +10715,53 @@ def _nudge_response_ready(turns, store, rec, gid, now):
     return True, resp
 
 
+_nudge_gate_memo = {}            # sid -> (parse key, store key, unplanned): the placement gate's answer while its inputs stand
+_NUDGE_GATE_STATS = {"served": 0, "derived": 0}   # /perf memos.nudgeGate: how often the walk re-derived the gate
+_NUDGE_GATE_MEMO_MAX = 512
+
+
+def _nudge_placement_gate(sid, turns, store):
+    """The planner-placement gate's answer (is any unit of this parse still unplaced?), DERIVED ONCE per
+    (parse, store) and served while both stand (2026-09-09). The derivation re-segments every turn, applies
+    the seams, builds the plan units and normalizes every recorded placement key; on the maintainer's box it
+    was 70% of the kernel's CPU, run for every idle session on every pusher cycle with nothing changed
+    (py-spy: _seg_key, _placed_key, _segment_id, _mint_quote under _auto_nudge_session). Its inputs are
+    exactly two: the parse (parsed_session's own cache key: the transcript's and the states file's stat, and
+    the pending cut) and the store's bytes (the store file's and its override journal's stat, the same key
+    the shared loader and the timeline's dead-lane memo use), so a key built from those is exact: a new
+    turn, an idle atom, a placement landing, a user override each move it, and nothing else changes the
+    answer, except one: _placed_key scopes its fuzzy match by the session's episode floor, which is the
+    clears log (EPIDIR/<sid>.jsonl), so that file's stat rides the key too (found by the same check the
+    dead-lane memo went through). A parse the cache does not hold (a fresh parse the caller made outside
+    parsed_session) is derived every time, never cached. The exception path is unchanged: a gate that cannot
+    be computed waves nothing through silently."""
+    pk = jd._PARSE_CACHE.get(sid)
+    parse_key = pk[0] if (pk is not None and pk[1] is not None and pk[1].get("turns") is turns) else None
+    key = None
+    if parse_key is not None:
+        key = (parse_key, _stat_key(jd.GOALDIR / (sid + ".json")), _stat_key(jd.STATE / "overrides" / (sid + ".jsonl")),
+               _stat_key(jd.EPIDIR / (sid + ".jsonl")))
+        hit = _nudge_gate_memo.get(sid)
+        if hit is not None and hit[0] == key:
+            _NUDGE_GATE_STATS["served"] += 1
+            return hit[1]
+    try:
+        _live = {sg["id"] for tn in turns for sg in jd._segs(tn, store)}
+        unplanned = any(not jd._placed_key(store.get("placements") or {}, jd._unit_key(u[0], u[1]), _live)
+                        for u in jd.plan_units({"turns": turns}, store))
+    except Exception:
+        unplanned = False                        # minimal/legacy turn shapes → the closer gate stands alone,
+        sys.stderr.write("auto-nudge placement gate (session %s): %s\n"   # but never SILENTLY (the user
+                         % (sid, traceback.format_exc()))                 #  2026-07-21: a mute gate error
+        return unplanned                         #  would wave nudges through); a failed derivation is not cached
+    _NUDGE_GATE_STATS["derived"] += 1
+    if key is not None:
+        if len(_nudge_gate_memo) > _NUDGE_GATE_MEMO_MAX:      # bounded by the session count; evict oldest-inserted
+            _nudge_gate_memo.pop(next(iter(_nudge_gate_memo)))
+        _nudge_gate_memo[sid] = (key, unplanned)
+    return unplanned
+
+
 def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None, wake_only=False):
     """One session's slice of the auto-nudge tick: the session-level gates, then the fire/stamp
     walk over its still-'working' top goals. Split from _auto_nudge_tick so the tick isolates
@@ -10800,7 +10848,12 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None, wake_only
     # deliberately NOT the arm: a romp-injected turn can never become the arm, so a verdict about one is
     # newer than the arm FOREVER (see _nudge_fire_list's deadlock note).
     seen = next((tn for tn in reversed(turns) if tn.get("ended")), None)
-    store, fault = jd.load_goals_or_fault(sid)
+    # The walk's READ of the store (2026-09-09): the shared read-only view every pusher builder reads, one
+    # parse per file version instead of a fresh load per idle session per cycle (66 loads a cycle on the
+    # maintainer's box, most of them this line). Every writer downstream reloads at its write moment
+    # (_wake_goal's _fresh, _nudge_fire_list's and the fire path's jd.load_goals), and a write through the
+    # view raises FrozenStoreError rather than landing, so a future writer that forgets fails loudly.
+    store, fault = jd.load_goals_shared_or_fault(sid)
     if fault is not None:
         return None                                  # its row is filed; nothing fires or stamps on a store we cannot read
     # Don't nudge until the CLOSER has classified this turn AT ITS CURRENT SIZE (session-level gate). A turn
@@ -10818,15 +10871,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None, wake_only
     # the unit's PLACEMENT (a skip records one too — key presence marks the phase processed), the same
     # event the nudge-failed stamp below already waits on; require the queue empty before ANY fire.
     # Event-based: the placement's landing opens the gate on the next tick.
-    try:
-        _live = {sg["id"] for tn in turns for sg in jd._segs(tn, store)}
-        _unplanned = any(not jd._placed_key(store.get("placements") or {}, jd._unit_key(u[0], u[1]), _live)
-                         for u in jd.plan_units({"turns": turns}, store))
-    except Exception:
-        _unplanned = False                       # minimal/legacy turn shapes → the closer gate stands alone,
-        sys.stderr.write("auto-nudge placement gate (session %s): %s\n"   # but never SILENTLY (the user
-                         % (sid, traceback.format_exc()))                 #  2026-07-21: a mute gate error
-        #                                                                    would wave nudges through)
+    _unplanned = _nudge_placement_gate(sid, turns, store)
     if _unplanned:
         return "planner-queue"
     nodes, status = store.get("nodes", {}), store.get("status", {})

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10715,7 +10715,7 @@ def _nudge_response_ready(turns, store, rec, gid, now):
     return True, resp
 
 
-_nudge_gate_memo = {}            # sid -> (parse key, store key, unplanned): the placement gate's answer while its inputs stand
+_nudge_gate_memo = {}            # sid -> (parse key, the shared view object, clears-log stat, unplanned): the gate's answer while its inputs stand
 _NUDGE_GATE_STATS = {"served": 0, "derived": 0}   # /perf memos.nudgeGate: how often the walk re-derived the gate
 _NUDGE_GATE_MEMO_MAX = 512
 
@@ -10725,26 +10725,26 @@ def _nudge_placement_gate(sid, turns, store):
     (parse, store) and served while both stand (2026-09-09). The derivation re-segments every turn, applies
     the seams, builds the plan units and normalizes every recorded placement key; on the maintainer's box it
     was 70% of the kernel's CPU, run for every idle session on every pusher cycle with nothing changed
-    (py-spy: _seg_key, _placed_key, _segment_id, _mint_quote under _auto_nudge_session). Its inputs are
-    exactly two: the parse (parsed_session's own cache key: the transcript's and the states file's stat, and
-    the pending cut) and the store's bytes (the store file's and its override journal's stat, the same key
-    the shared loader and the timeline's dead-lane memo use), so a key built from those is exact: a new
-    turn, an idle atom, a placement landing, a user override each move it, and nothing else changes the
-    answer, except one: _placed_key scopes its fuzzy match by the session's episode floor, which is the
-    clears log (EPIDIR/<sid>.jsonl), so that file's stat rides the key too (found by the same check the
-    dead-lane memo went through). A parse the cache does not hold (a fresh parse the caller made outside
-    parsed_session) is derived every time, never cached. The exception path is unchanged: a gate that cannot
-    be computed waves nothing through silently."""
+    (py-spy: _seg_key, _placed_key, _segment_id, _mint_quote under _auto_nudge_session). Its inputs: the
+    parse, the store's bytes, and the clears log (_placed_key scopes its fuzzy match by the episode floor).
+
+    Both halves are IDENTITY-bound, never stat'd after the read (review 2026-09-09: the first cut stat'd the
+    store file after the walk had read the view, so a placement a judge published in between was keyed under
+    the NEW file with the OLD bytes' answer and served until the store next moved). The parse half is
+    parsed_session's cached object; the store half is the shared read-only view object itself, which the
+    shared loader replaces whenever the store, its override journal or the archive moves, and the answer is
+    cached only when that view is STILL the current one after the derivation. The clears log's stat is taken
+    BEFORE the derivation, so a boundary appended during it leaves a key the next cycle's stat cannot match.
+    A parse the cache does not hold, or a store that is not the current shared view, is derived every time
+    and never cached. The exception path is unchanged: a gate that cannot be computed waves nothing through
+    silently, and is never cached."""
     pk = jd._PARSE_CACHE.get(sid)
     parse_key = pk[0] if (pk is not None and pk[1] is not None and pk[1].get("turns") is turns) else None
-    key = None
-    if parse_key is not None:
-        key = (parse_key, _stat_key(jd.GOALDIR / (sid + ".json")), _stat_key(jd.STATE / "overrides" / (sid + ".jsonl")),
-               _stat_key(jd.EPIDIR / (sid + ".jsonl")))
-        hit = _nudge_gate_memo.get(sid)
-        if hit is not None and hit[0] == key:
-            _NUDGE_GATE_STATS["served"] += 1
-            return hit[1]
+    epi = _stat_key(jd.EPIDIR / (sid + ".jsonl")) if parse_key is not None else None
+    hit = _nudge_gate_memo.get(sid) if parse_key is not None else None
+    if hit is not None and hit[0] == parse_key and hit[1] is store and hit[2] == epi:
+        _NUDGE_GATE_STATS["served"] += 1
+        return hit[3]
     try:
         _live = {sg["id"] for tn in turns for sg in jd._segs(tn, store)}
         unplanned = any(not jd._placed_key(store.get("placements") or {}, jd._unit_key(u[0], u[1]), _live)
@@ -10755,10 +10755,15 @@ def _nudge_placement_gate(sid, turns, store):
                          % (sid, traceback.format_exc()))                 #  2026-07-21: a mute gate error
         return unplanned                         #  would wave nudges through); a failed derivation is not cached
     _NUDGE_GATE_STATS["derived"] += 1
-    if key is not None:
-        if len(_nudge_gate_memo) > _NUDGE_GATE_MEMO_MAX:      # bounded by the session count; evict oldest-inserted
-            _nudge_gate_memo.pop(next(iter(_nudge_gate_memo)))
-        _nudge_gate_memo[sid] = (key, unplanned)
+    if parse_key is not None:
+        try:
+            current, _f = jd.load_goals_shared_or_fault(sid)   # a stat and a compare on the shared loader's key
+        except Exception:
+            current = None
+        if current is store:                     # the view we derived from is still the store's current one
+            if len(_nudge_gate_memo) > _NUDGE_GATE_MEMO_MAX:      # bounded by the session count; evict oldest-inserted
+                _nudge_gate_memo.pop(next(iter(_nudge_gate_memo)))
+            _nudge_gate_memo[sid] = (parse_key, store, epi, unplanned)
     return unplanned
 
 

--- a/tests/test_nudge_bundle.py
+++ b/tests/test_nudge_bundle.py
@@ -259,7 +259,8 @@ class AutoNudgeBundlesSameTick(unittest.TestCase):
             "_interrupt_suppresses_nudge", "_backend_queued", "_backend_rewind_pending",
             "_last_state", "_session_awaiting", "_turn_romp_injected", "_closer_settled",
             "_revivers_pending", "_pending_ops")}
-        self._orig_jd = {n: getattr(jd, n) for n in ("parsed_session", "load_goals", "_segs", "plan_units")}
+        self._orig_jd = {n: getattr(jd, n) for n in ("parsed_session", "load_goals", "load_goals_shared_or_fault",
+                                                     "_segs", "plan_units")}
         self._orig_backend = km.Sessions.backend_for
         km._session_flag = lambda sid, flag: False
         km._compacting_now = lambda sid: False
@@ -280,7 +281,12 @@ class AutoNudgeBundlesSameTick(unittest.TestCase):
         jd.parsed_session = lambda sid, paths, now: {"turns": self.turns}
         self.store = _store({G1: _node(G1, "Ship the auth refactor"),
                              G2: _node(G2, "Write the migration guide")})
+        # The walk's SNAPSHOT is the shared read-only view (2026-09-09); its writers and the fire list reload
+        # fresh through load_goals. Both are stubbed: with only load_goals stubbed, the shared read found no
+        # store file in a fresh process (and delegated to the stub), but under the parallel runner it read a
+        # store an earlier module had left at the shared placeholder sid, and nothing was due.
         jd.load_goals = lambda sid: self.store
+        jd.load_goals_shared_or_fault = lambda sid: (self.store, None)
         self.sent = []
         test = self
 
@@ -336,12 +342,8 @@ class AutoNudgeBundlesSameTick(unittest.TestCase):
         done = _store({G1: _node(G1, "Ship the auth refactor"),
                        G2: _node(G2, "Write the migration guide", nodeComplete=True)},
                       status={G1: "working", G2: "completed"})
-        calls = {"n": 0}
-
-        def load(sid):
-            calls["n"] += 1
-            return snap if calls["n"] == 1 else done
-        jd.load_goals = load
+        jd.load_goals_shared_or_fault = lambda sid: (snap, None)   # the tick's snapshot
+        jd.load_goals = lambda sid: done                            # the send-moment re-read
         self._tick()
         self.assertEqual(len(self.sent), 1)
         self.assertIn("<!-- romp-goal-id: %s -->" % G1, self.sent[0])
@@ -358,12 +360,8 @@ class AutoNudgeBundlesSameTick(unittest.TestCase):
         snap = self.store
         fresh = _store({G1: _node(G1, "Ship the auth refactor, retitled by the planner"),
                         G2: _node(G2, "Write the migration guide")})
-        calls = {"n": 0}
-
-        def load(sid):
-            calls["n"] += 1
-            return snap if calls["n"] == 1 else fresh
-        jd.load_goals = load
+        jd.load_goals_shared_or_fault = lambda sid: (snap, None)   # the tick's snapshot
+        jd.load_goals = lambda sid: fresh                           # the send-moment re-read
         self._tick()
         self.assertEqual(len(self.sent), 1)
         self.assertIn("retitled by the planner", self.sent[0],

--- a/tests/test_nudge_fresh_guard.py
+++ b/tests/test_nudge_fresh_guard.py
@@ -60,7 +60,7 @@ class FreshGuard(unittest.TestCase):
             "_interrupt_suppresses_nudge", "_backend_queued", "_backend_rewind_pending",
             "_last_state", "_session_awaiting", "_closer_settled", "_revivers_pending",
             "_pending_ops", "_last_assistant_report", "_all_outstanding_delegated")}
-        self._orig_jd = {n: getattr(jd, n) for n in ("parsed_session", "load_goals", "_segs",
+        self._orig_jd = {n: getattr(jd, n) for n in ("parsed_session", "load_goals", "load_goals_shared_or_fault", "_segs",
                                                      "plan_units", "nudge_redundant")}
         self._orig_backend = km.Sessions.backend_for
         km._session_flag = lambda sid, flag: False
@@ -85,6 +85,7 @@ class FreshGuard(unittest.TestCase):
         jd.parsed_session = lambda sid, paths, now: {"turns": self.turns}
         self.store = _store()
         jd.load_goals = lambda sid: self.store
+        jd.load_goals_shared_or_fault = lambda sid: (self.store, None)   # the walk reads the shared view; the fresh re-read stays on load_goals
         self.sent = []
         # the tail reads the gate makes, in order: [snapshot, fire-time freshness re-read]
         self.reports = [("working through the queue", ARM_T + 50),
@@ -260,6 +261,7 @@ class FreshGuard(unittest.TestCase):
         working, resolved = self.store, _store()
         resolved["status"][G1] = "completed"
         jd.load_goals = lambda sid: resolved if test.judge_calls else working
+        jd.load_goals_shared_or_fault = lambda sid: (working, None)
         self.judge_replies = [False]
         self._tick()
         self.assertEqual(self.sent, [], "nothing survives → nothing sends")
@@ -272,6 +274,7 @@ class FreshGuard(unittest.TestCase):
         working, blocked = self.store, _store()
         blocked["status"][G1] = "blocked"
         jd.load_goals = lambda sid: blocked if test.judge_calls else working
+        jd.load_goals_shared_or_fault = lambda sid: (working, None)
         self.judge_replies = [False]
         self._tick()
         self.assertEqual(self.sent, [])

--- a/tests/test_nudge_gate_memo.py
+++ b/tests/test_nudge_gate_memo.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""The nudge walk's planner-placement gate is derived once per (parse, store) and served while both stand
+(2026-09-09), and the walk reads the store through the shared read-only view.
+
+Measured on the maintainer's box (py-spy over the live kernel, 90 s): the pusher's jobs stage was 77% of the
+kernel's samples, _auto_nudge_tick 91% of that, and the gate's derivation (re-segmenting every turn, applying
+the seams, building the plan units, normalizing every recorded placement key) the bulk of it, run for every
+idle session on every cycle with nothing changed; the walk's fresh goal-store load per session per cycle was
+most of the 66 loads a cycle. Pins: the gate is served on the second call and re-derived when the parse or the
+store moves, its answer equals the direct derivation, a failed derivation is never cached, a parse the cache
+does not hold is derived every time, the memo is bounded, the walk reads through the shared view and never a
+fresh load, and the counters ride /perf.
+
+Synthetic transcript, states and store under a temp root; a private synthetic sid (the goal-store fixture
+rule); the closer is off so the walk reaches the gate without judge marks."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest.mock import patch
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_nudge_gate", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-888888888801"
+NOW = 1_800_000_000
+T0 = NOW - 3600
+
+
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent, stop="end_turn"):
+    return {"type": "assistant", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}], "stop_reason": stop}}
+
+
+class _Gate(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        pdir = proj / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        pdir.mkdir(parents=True)
+        self.tpath = pdir / (SID + ".jsonl")
+        names = td / "names"; names.mkdir()
+        (names / SID).write_text("api\t%s\t#abcdef\n" % str(cdir))
+        self.saved = (jd.STATE, jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATESDIR, km.NAMES, jd.CLOSER_ON)
+        jd._rebind_state(td)
+        jd.NAMES, jd.PROJECTS = names, proj
+        km.NAMES = names
+        jd.CLOSER_ON = False
+        jd.GOALDIR.mkdir(parents=True)
+        (td / "states").mkdir()
+        self.recs = [uline(T0, "wire up the reconnect banner", "u1"),
+                     aline(T0 + 20, "done, the banner reconnects", "a1", "u1")]
+        self._write(self.recs)
+        g = {"id": SID + ":g1", "text": "Ship the reconnect banner", "parentId": None, "nodeComplete": False,
+             "blocked": False, "cleared": False, "trail": [], "t": T0}
+        self.store = {"rompUuid": SID, "seq": 1, "lastNode": g["id"], "closedTurns": [], "nodes": {g["id"]: g},
+                      "placements": {}, "status": {g["id"]: "working"}}
+        self._save_store()
+        self._reset()
+
+    def _write(self, recs):
+        self.tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+
+    def _save_store(self):
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(self.store))
+
+    def _reset(self):
+        km._parse_cache.clear()
+        km._nudge_gate_memo.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+        for k in km._NUDGE_GATE_STATS:
+            km._NUDGE_GATE_STATS[k] = 0
+
+    def tearDown(self):
+        jd._rebind_state(self.saved[0])
+        (jd.STATE, jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATESDIR, km.NAMES, jd.CLOSER_ON) = self.saved
+        self._reset()
+        self.td.cleanup()
+
+    def _turns(self, now=NOW):
+        return jd.parsed_session(SID, [str(self.tpath)], now)["turns"]
+
+    def _view(self):
+        store, fault = jd.load_goals_shared_or_fault(SID)
+        self.assertIsNone(fault)
+        return store
+
+    def _direct(self, turns, store):
+        live = {sg["id"] for tn in turns for sg in jd._segs(tn, store)}
+        return any(not jd._placed_key(store.get("placements") or {}, jd._unit_key(u[0], u[1]), live)
+                   for u in jd.plan_units({"turns": turns}, store))
+
+
+class GateMemo(_Gate):
+    def test_derived_once_then_served_while_the_parse_and_the_store_stand(self):
+        turns, store = self._turns(), self._view()
+        with patch.object(jd, "plan_units", wraps=jd.plan_units) as pu:
+            a = km._nudge_placement_gate(SID, turns, store)
+            b = km._nudge_placement_gate(SID, turns, store)
+            c = km._nudge_placement_gate(SID, self._turns(), self._view())   # the same cached parse and view
+        self.assertEqual((a, b, c), (True, True, True), "an unplaced ended segment: the planner queue is not empty")
+        self.assertEqual(pu.call_count, 1, "derived once; the two later calls were served")
+        self.assertEqual(km._NUDGE_GATE_STATS, {"served": 2, "derived": 1})
+
+    def test_the_answer_is_the_direct_derivation_before_and_after_the_placement_lands(self):
+        turns, store = self._turns(), self._view()
+        self.assertEqual(km._nudge_placement_gate(SID, turns, store), self._direct(turns, store))
+        # the planner places the segment's work unit: the store moves, the gate re-derives and now reads clear
+        seg_id = next(u[0] for u in jd.plan_units({"turns": turns}, store) if u[1] == "work")
+        self.store["placements"] = {seg_id: SID + ":g1"}
+        self.store["seq"] = 2
+        self._save_store()
+        turns2, store2 = self._turns(), self._view()
+        self.assertIsNot(store2, store, "a moved store is a new shared view")
+        with patch.object(jd, "plan_units", wraps=jd.plan_units) as pu:
+            got = km._nudge_placement_gate(SID, turns2, store2)
+        self.assertEqual(pu.call_count, 1, "the store's stat moved: derived again")
+        self.assertEqual(got, self._direct(turns2, store2))
+        self.assertFalse(got, "every unit placed: the queue is empty")
+
+    def test_a_transcript_append_re_derives(self):
+        km._nudge_placement_gate(SID, self._turns(), self._view())
+        self._write(self.recs + [uline(T0 + 600, "and the cap?", "u2", "a1"),
+                                 aline(T0 + 610, "two minutes", "a2", "u2")])
+        os.utime(self.tpath, (NOW - 20, NOW - 20))
+        with patch.object(jd, "plan_units", wraps=jd.plan_units) as pu:
+            km._nudge_placement_gate(SID, self._turns(), self._view())
+        self.assertEqual(pu.call_count, 1, "a new parse: derived again")
+        self.assertEqual(km._NUDGE_GATE_STATS["derived"], 2)
+
+    def test_an_override_journal_write_re_derives(self):
+        km._nudge_placement_gate(SID, self._turns(), self._view())
+        (jd.STATE / "overrides").mkdir(exist_ok=True)
+        (jd.STATE / "overrides" / (SID + ".jsonl")).write_text(json.dumps({"t": NOW, "op": "noop"}) + "\n")
+        with patch.object(jd, "plan_units", wraps=jd.plan_units) as pu:
+            km._nudge_placement_gate(SID, self._turns(), self._view())
+        self.assertEqual(pu.call_count, 1, "the journal is a store input: the key moved")
+
+    def test_a_clear_boundary_re_derives(self):
+        """_placed_key scopes its fuzzy match by the episode floor, read from the clears log: a boundary row
+        appended there changes the gate's answer with neither the parse nor the store moving, so the log's
+        stat is part of the key."""
+        km._nudge_placement_gate(SID, self._turns(), self._view())
+        jd.EPIDIR.mkdir(parents=True, exist_ok=True)
+        (jd.EPIDIR / (SID + ".jsonl")).write_text(json.dumps({"head": "u1", "fsid": SID, "t": T0}) + "\n"
+                                                  + json.dumps({"head": "u9", "fsid": SID, "t": NOW - 60}) + "\n")
+        with patch.object(jd, "plan_units", wraps=jd.plan_units) as pu:
+            km._nudge_placement_gate(SID, self._turns(), self._view())
+        self.assertEqual(pu.call_count, 1, "the clears log is a gate input: the key moved")
+
+    def test_a_failed_derivation_is_never_cached_and_waves_nothing_through(self):
+        turns, store = self._turns(), self._view()
+        import io
+        from contextlib import redirect_stderr
+        err = io.StringIO()
+        with patch.object(jd, "_segs", side_effect=RuntimeError("synthetic gate fault")), redirect_stderr(err):
+            self.assertFalse(km._nudge_placement_gate(SID, turns, store))
+            self.assertFalse(km._nudge_placement_gate(SID, turns, store))
+        self.assertNotIn(SID, km._nudge_gate_memo, "a failed derivation is not an answer to serve")
+        self.assertEqual(err.getvalue().count("auto-nudge placement gate"), 2, "loud every time, never silent")
+        self.assertTrue(km._nudge_placement_gate(SID, turns, store), "the next good derivation answers")
+
+    def test_a_parse_the_cache_does_not_hold_is_derived_every_time(self):
+        turns, store = self._turns(), self._view()
+        copied = list(turns)                              # not the cached object: no key to serve on
+        with patch.object(jd, "plan_units", wraps=jd.plan_units) as pu:
+            km._nudge_placement_gate(SID, copied, store)
+            km._nudge_placement_gate(SID, copied, store)
+        self.assertEqual(pu.call_count, 2)
+        self.assertNotIn(SID, km._nudge_gate_memo)
+
+    def test_the_memo_is_bounded(self):
+        turns, store = self._turns(), self._view()
+        km._nudge_gate_memo.clear()
+        for i in range(km._NUDGE_GATE_MEMO_MAX + 1):
+            km._nudge_gate_memo["11111111-2222-3333-4444-%012d" % i] = (("k",), False)
+        oldest = next(iter(km._nudge_gate_memo))
+        before = len(km._nudge_gate_memo)
+        km._nudge_placement_gate(SID, turns, store)    # a store past the bound evicts the oldest entry first
+        self.assertEqual(len(km._nudge_gate_memo), before, "one out, one in: the memo never grows past its bound")
+        self.assertNotIn(oldest, km._nudge_gate_memo)
+        self.assertIn(SID, km._nudge_gate_memo)
+
+    def test_the_counters_ride_the_perf_snapshot(self):
+        km._nudge_placement_gate(SID, self._turns(), self._view())
+        km._nudge_placement_gate(SID, self._turns(), self._view())
+        snap = km._PERF_STATS.snapshot()
+        self.assertEqual(snap["memos"]["nudgeGate"], {"served": 1, "derived": 1})
+
+
+class WalkReadsTheSharedView(_Gate):
+    def test_the_walk_reads_through_the_shared_view_and_never_a_fresh_load(self):
+        """The walk's own read is the shared view; every writer downstream reloads at its write moment
+        (_wake_goal's fresh load, the fire list's, the fire path's), so a fresh load per idle session per cycle
+        bought nothing. A write through the view raises FrozenStoreError, so a future writer that forgets the
+        reload fails loudly instead of landing."""
+        import inspect
+        src = inspect.getsource(km._auto_nudge_session)
+        self.assertIn("store, fault = jd.load_goals_shared_or_fault(sid)", src)
+        self.assertNotIn("jd.load_goals_or_fault(sid)", src, "no fresh load for the walk's own read")
+        self.assertIn("_nudge_placement_gate(sid, turns, store)", src, "the gate is the memoized one")
+        self.assertIn("jd.load_goals(sid)", inspect.getsource(km._wake_goal), "the wake reloads fresh before it writes")
+        self.assertIn("_nudge_fire_list(jd.load_goals(sid)", src, "the fire list judges a FRESH store, never the view")
+        self.assertIn("_nodes = jd.load_goals(sid)", src, "the fire path re-reads fresh too")
+
+    def test_the_interrupt_block_stand_check_reads_the_shared_view(self):
+        import inspect
+        src = inspect.getsource(km._intr_block_stands)
+        self.assertIn("jd.load_goals_shared_or_fault(sid)", src, "a pure read")
+        self.assertNotIn("jd.load_goals_or_fault(", src)
+        for writer in ("_record_interrupt_block", "_lift_interrupt_block"):
+            self.assertIn("jd.load_goals_or_fault(sid)", inspect.getsource(getattr(km, writer)),
+                          "%s writes, so it loads fresh" % writer)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nudge_gate_memo.py
+++ b/tests/test_nudge_gate_memo.py
@@ -168,6 +168,36 @@ class GateMemo(_Gate):
             km._nudge_placement_gate(SID, self._turns(), self._view())
         self.assertEqual(pu.call_count, 1, "the clears log is a gate input: the key moved")
 
+    def test_a_placement_landing_between_the_read_and_the_derivation_is_never_pinned(self):
+        """The maintainers' review of the first cut (2026-09-09): cycle N read the view, a judge published a
+        placement, the gate stat'd the NEW file and cached the OLD bytes' answer under it, and cycle N+1 served
+        'planner-queue' until the store next moved. The store half of the key is the view object itself now,
+        and the answer is cached only while that view is still the current one."""
+        turns, view_old = self._turns(), self._view()
+        seg_id = next(u[0] for u in jd.plan_units({"turns": turns}, view_old) if u[1] == "work")
+        self.store["placements"] = {seg_id: SID + ":g1"}
+        self.store["seq"] = 2
+        self._save_store()                                   # the judge's publish lands between the read and the gate
+        self.assertTrue(km._nudge_placement_gate(SID, turns, view_old), "derived from the old bytes: still unplanned")
+        self.assertNotIn(SID, km._nudge_gate_memo, "not cached: the view it derived from is no longer current")
+        view_new = self._view()
+        self.assertIsNot(view_new, view_old)
+        with patch.object(jd, "plan_units", wraps=jd.plan_units) as pu:
+            got = km._nudge_placement_gate(SID, self._turns(), view_new)
+        self.assertEqual(pu.call_count, 1, "re-derived against the current view")
+        self.assertFalse(got, "the placement landed: the queue is empty")
+        self.assertEqual(km._NUDGE_GATE_STATS, {"served": 0, "derived": 2})
+        self.assertIs(km._nudge_gate_memo[SID][1], view_new)
+
+    def test_a_store_that_is_not_the_shared_view_is_derived_every_time(self):
+        turns = self._turns()
+        fresh = jd.load_goals(SID)                           # a writer's mutable store, not the view
+        with patch.object(jd, "plan_units", wraps=jd.plan_units) as pu:
+            km._nudge_placement_gate(SID, turns, fresh)
+            km._nudge_placement_gate(SID, turns, fresh)
+        self.assertEqual(pu.call_count, 2)
+        self.assertNotIn(SID, km._nudge_gate_memo)
+
     def test_a_failed_derivation_is_never_cached_and_waves_nothing_through(self):
         turns, store = self._turns(), self._view()
         import io
@@ -193,7 +223,7 @@ class GateMemo(_Gate):
         turns, store = self._turns(), self._view()
         km._nudge_gate_memo.clear()
         for i in range(km._NUDGE_GATE_MEMO_MAX + 1):
-            km._nudge_gate_memo["11111111-2222-3333-4444-%012d" % i] = (("k",), False)
+            km._nudge_gate_memo["11111111-2222-3333-4444-%012d" % i] = (("k",), None, None, False)
         oldest = next(iter(km._nudge_gate_memo))
         before = len(km._nudge_gate_memo)
         km._nudge_placement_gate(SID, turns, store)    # a store past the bound evicts the oldest entry first

--- a/tests/test_nudge_injected_turn_arm.py
+++ b/tests/test_nudge_injected_turn_arm.py
@@ -141,7 +141,7 @@ class InjectedTurnDeadlockEndToEnd(unittest.TestCase):
             "_interrupt_suppresses_nudge", "_backend_queued", "_backend_rewind_pending",
             "_last_state", "_session_awaiting", "_closer_settled", "_revivers_pending",
             "_pending_ops")}
-        self._orig_jd = {n: getattr(jd, n) for n in ("parsed_session", "load_goals", "_segs", "plan_units")}
+        self._orig_jd = {n: getattr(jd, n) for n in ("parsed_session", "load_goals", "load_goals_shared_or_fault", "_segs", "plan_units")}
         self._orig_backend = km.Sessions.backend_for
         km._session_flag = lambda sid, flag: False
         km._compacting_now = lambda sid: False
@@ -163,6 +163,7 @@ class InjectedTurnDeadlockEndToEnd(unittest.TestCase):
         jd.parsed_session = lambda sid, paths, now: {"turns": self.turns}
         self.store = _store({G1: _node(G1, "Ship the reconnect banner", log=_incident_log())})
         jd.load_goals = lambda sid: self.store
+        jd.load_goals_shared_or_fault = lambda sid: (self.store, None)   # the walk reads the shared view; the fresh re-read stays on load_goals
         self.sent = []
         test = self
 

--- a/tests/test_nudge_memo_deadlock.py
+++ b/tests/test_nudge_memo_deadlock.py
@@ -58,7 +58,7 @@ class MemoDeadlock(unittest.TestCase):
             "_interrupt_suppresses_nudge", "_backend_queued", "_backend_rewind_pending",
             "_last_state", "_session_awaiting", "_closer_settled", "_revivers_pending",
             "_pending_ops", "_last_assistant_report", "_all_outstanding_delegated")}
-        self._orig_jd = {n: getattr(jd, n) for n in ("parsed_session", "load_goals", "_segs",
+        self._orig_jd = {n: getattr(jd, n) for n in ("parsed_session", "load_goals", "load_goals_shared_or_fault", "_segs",
                                                      "plan_units", "nudge_redundant")}
         self._orig_backend = km.Sessions.backend_for
         km._session_flag = lambda sid, flag: False
@@ -83,6 +83,7 @@ class MemoDeadlock(unittest.TestCase):
         jd.parsed_session = lambda sid, paths, now: {"turns": self.turns}
         self.store = _store()
         jd.load_goals = lambda sid: self.store
+        jd.load_goals_shared_or_fault = lambda sid: (self.store, None)   # the walk reads the shared view; the fresh re-read stays on load_goals
         self.sent = []
         self.reports = [("working through the queue", ARM_T + 50),
                         ("working through the queue", ARM_T + 50)]

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -115,7 +115,9 @@ class Collector(unittest.TestCase):
         self.assertIn("cpu_ms_workers", snap["judge"])
         self.assertEqual(set(snap["goals"]), {"loads", "saves", "writes"}, "read through jd.goal_io_stats")
         # the three identity memos' readers land here (review find, 2026-09-08: they had no consumer)
-        self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain"})
+        self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate"})
+        self.assertEqual(snap["memos"]["nudgeGate"], {"served": 0, "derived": 0},
+                         "the nudge walk's placement gate: served vs re-derived (2026-09-09)")
         self.assertEqual(snap["memos"]["pass"], km._goals_memo_report())
         self.assertEqual(snap["memos"]["shared"], km.jd.shared_store_stats())
         self.assertEqual(snap["memos"]["chain"], km.jd.chain_memo_stats())


### PR DESCRIPTION
## What

The third idle-kernel batch. After the two push-stage batches, the pusher's cycle push cost about 0.2 s, but the kernel still burned most of a core: the pusher's **jobs** stage (the ticks that run every cycle beside the push) held the time. Measured on the maintainer's devbox, live kernel, no browser connected:

| measure | before |
|---|---|
| jobs stage share of wall time | 78% to 79% (three and six minutes after boot) |
| goal-store loads per pusher cycle | 55 to 66 |
| process CPU | about 90% of a core |
| py-spy, 90 s, 3905 samples | 77% in the jobs stage; 91% of that in the auto-nudge tick; within it the planner-placement gate's derivation (segment keys, seams, plan units, placement-key normalization) and the per-session store load |

The auto-nudge walk ran, for every idle session on every cycle, with nothing changed since the previous cycle:

- the **planner-placement gate**: re-segment every turn, apply the seams, build the plan units, normalize every recorded placement key;
- a **fresh goal-store load**, most of the cycle's loads.

## The change

- **The gate is derived once per (parse, store) and served while both stand.** Its answer is a pure function of the parse (the parser's own cache key: the transcript's and the states file's stat, the pending cut) and the store's bytes (the store file's, its override journal's and the clears log's stat; the placement-key function scopes its fuzzy match by the episode floor, which the clears log holds). A parse outside the cache is derived every time and never cached; a failed derivation stays loud and is never cached. Bounded by the session count. Counted on `/perf` under `memos.nudgeGate` (`served`, `derived`).
- **The walk's read of the store is the shared read-only view**, one parse per file version, shared with every pusher builder. Every writer downstream reloads at its write moment (the wake's fresh load, the fire list's, the fire path's), and a write through the view raises rather than landing, so a writer that forgets fails loudly.
- **The interrupt-block tick's stand check** (a pure read per marked session per cycle) reads the shared view too; its two writers keep their fresh loads.

No card-move rule changes: the gate answers the same question from the same inputs, and the writers write the same stores at the same moments.

**Not folded here, and why.** The awaiting-lift tick loads fresh per session per cycle because it writes on the same object (2% of the jobs stage in the profile); splitting its read from its write is its own change. The interrupt tick's per-session re-parse is the live-session parse cost the parked memory lever owns.

## Tier

`fix`: performance, behaviour unchanged.

## After-numbers

To be posted here after this lands and the devbox converges, read at the same uptime after a deploy restart: loads per cycle, the jobs stage's share of wall time, process CPU, and the gate's served-to-derived ratio.

## Tests

`tests/test_nudge_gate_memo.py` (new): the gate is derived once and served on the second call; re-derived when the parse, the store, the override journal or the clears log moves; its answer equals the direct derivation before and after a placement lands; a failed derivation is never cached and stays loud; a parse outside the cache is derived every time; the memo is bounded; the counters ride the perf snapshot; source pins for the shared-view reads and the writers' fresh loads. The nudge bundle fixture stubs the shared read beside the fresh loader (it modelled the walk's snapshot through the fresh loader alone, which under the parallel runner read a store another module left at the shared placeholder sid). The nudge suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
