### PR TITLE
A failed names write after a Codex thread start leaves the file as the atomic writer left it: the in-place restore that truncated it under the very ENOSPC it existed for is gone

### DIFF
--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -1173,34 +1173,27 @@ class CodexBackend:
                 s.norm = None
             self._ensure_norm(s)
             self.transcript_path(s.sid).touch()
-            nf = self.state / "names" / s.sid
-            try:
-                old_line = nf.read_bytes()
-            except OSError:
-                old_line = None
             try:
                 self._write_name(s)
             except (OSError, UnicodeDecodeError) as e:
                 # the thread is HEALTHY — failing the turn over a cosmetic identity write would
                 # be worse (a decode failure from crash residue sailed through an OSError-only
-                # catch and DID fail the turn, unhealed forever — the r31 verification) — but
-                # the write must not leave residue either. Restore the old line, or remove the
-                # partial file.
-                try:
-                    if old_line is not None:
-                        nf.write_bytes(old_line)
-                        self.log("codex: names/%s write failed after thread start (%s) — the "
-                                 "identity file was restored; it refreshes on the next rename"
-                                 % (s.sid, e))
-                    else:
-                        nf.unlink(missing_ok=True)
-                        self.log("codex: names/%s could not be published after thread start "
-                                 "(%s) — the session runs UNNAMED on shared surfaces until a "
-                                 "rename lands; a same-name create may collide meanwhile"
-                                 % (s.sid, e))
-                except OSError:
-                    self.log("codex: names/%s left in an unknown state by a failed write (%s)"
-                             % (s.sid, e))
+                # catch and DID fail the turn, unhealed forever — the r31 verification). No
+                # restore write for the names file: _write_name is tmp + os.replace and removes
+                # its own temp (the r32 shape), so a raise leaves names/<sid> exactly as it was —
+                # and creates nothing when there was no file. The in-place nf.write_bytes(old_line)
+                # this branch carried predates that: it was the one non-atomic write on this path,
+                # an mtime bump for no content change, and under the very ENOSPC it existed for it
+                # truncated a good file to nothing, then blamed "a failed write" (#1138 dropped the
+                # same shape from rename; this is its twin, 2026-09-09). The log still says which
+                # of the two states the file is in — READ after the fact, never rewritten.
+                if (self.state / "names" / s.sid).is_file():
+                    self.log("codex: names/%s write failed after thread start (%s) — the identity "
+                             "file kept its old line; it refreshes on the next rename" % (s.sid, e))
+                else:
+                    self.log("codex: names/%s could not be published after thread start (%s) — "
+                             "the session runs UNNAMED on shared surfaces until a rename lands; "
+                             "a same-name create may collide meanwhile" % (s.sid, e))
             self.push()
             return True
         c.thread_resume(tid, {"cwd": cwd, **_approval_params(s.mode),

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -1313,29 +1313,39 @@ class RaisingRegistryTransactions(unittest.TestCase):
                              "neither the file nor its temp exists: a failed rename publishes nothing")
             self.assertEqual(be._session(sid).name, "webby")
 
-    def test_a_names_write_failure_after_thread_start_is_restored_not_fatal(self):
-        # the r30 verification: _prepare_thread's unguarded names write truncated the identity
-        # file permanently — no later path rewrites it (resume skips the create branch)
+    def test_a_failed_names_write_after_thread_start_leaves_the_file_untouched(self):
+        # the r30 verification, rewritten to the truth (2026-09-09, the twin of #1138's rename
+        # rewrite): the old form mocked _write_name with a fake that truncated the file IN PLACE —
+        # something the real tmp+os.replace writer cannot do — and pinned an in-place RESTORE that,
+        # under the very ENOSPC it existed for, truncated a good file to nothing and then blamed "a
+        # failed write". _disk_full drives the REAL writer with the fault beneath it and models
+        # ENOSPC for any in-place write aimed at the file; on origin/main the restore itself
+        # empties the file. No later path rewrites it (resume skips the create branch)
         import tempfile
         with tempfile.TemporaryDirectory() as td:
             fake = FakeClient()
-            be = cb.CodexBackend(td, client_factory=lambda: fake)
+            logs = []
+            be = cb.CodexBackend(td, client_factory=lambda: fake, log=logs.append)
             sid = be.spawn("webby", "/tmp")
             s = be._session(sid)
-            nf = os.path.join(td, "names", sid)
-            old_line = open(nf).read()
+            nf = Path(td) / "names" / sid
+            old_line = nf.read_bytes()
+            old_mtime = nf.stat().st_mtime_ns
             s.tid = "pending-%s" % sid[:8]         # force the create path
             s.loaded = False
-
-            def truncating_write(s2, bg="", fg=""):
-                open(nf, "w").close()
-                raise OSError(28, "No space left on device")
-            with mock.patch.object(be, "_write_name", side_effect=truncating_write):
+            with _disk_full(nf):
                 ok = be._prepare_thread(s, fake)
             self.assertTrue(ok, "the thread is healthy — the turn proceeds")
-            self.assertEqual(open(nf).read(), old_line,
-                             "the truncation cannot outlive the failure")
             self.assertTrue(s.loaded)
+            self.assertEqual(nf.read_bytes(), old_line,
+                             "byte-identical: the atomic writer left it, and nothing rewrote it in place")
+            self.assertEqual(nf.stat().st_mtime_ns, old_mtime,
+                             "no rewrite for no content change — the names producers watch the mtime")
+            self.assertEqual(sorted(p.name for p in nf.parent.iterdir()), [sid], "no staging file left behind")
+            said = [m for m in logs if "after thread start" in m]
+            self.assertEqual(len(said), 1, logs)
+            self.assertIn("[Errno 28]", said[0], "the log names the errno")
+            self.assertNotIn("restored", said[0], "nothing was restored, so the log does not say so")
 
     def test_a_corrupt_names_file_is_healed_by_the_next_write(self):
         # the r31 verification: non-UTF-8 names bytes sailed through _write_name's OSError-only
@@ -1394,25 +1404,27 @@ class RaisingRegistryTransactions(unittest.TestCase):
     def test_an_unpublishable_name_after_thread_start_says_so(self):
         # the r31 verification: the no-prior-file leg logged "was restored" when the partial
         # file was actually unlinked — and the state it leaves (live row, no published name) is
-        # the duplicate-name hole, which the log must NAME
+        # the duplicate-name hole, which the log must NAME. Since 2026-09-09 the REAL writer runs
+        # under _disk_full (green on origin/main as well — its unlink branch was a no-op there);
+        # kept as the pin for the absent-entry shape: a failed first publish creates nothing
         import tempfile
         with tempfile.TemporaryDirectory() as td:
             fake = FakeClient()
-            be = cb.CodexBackend(td, client_factory=lambda: fake)
+            logs = []
+            be = cb.CodexBackend(td, client_factory=lambda: fake, log=logs.append)
             sid = be.spawn("webby", "/tmp")
             s = be._session(sid)
-            nf = os.path.join(td, "names", sid)
-            os.unlink(nf)                          # no prior file to restore
+            nf = Path(td) / "names" / sid
+            os.unlink(nf)                          # a legacy row predating the names write
             s.tid = "pending-%s" % sid[:8]
             s.loaded = False
-            logs = []
-            with mock.patch.object(be, "log", side_effect=lambda m: logs.append(m)):
-                with mock.patch.object(be, "_write_name",
-                                       side_effect=OSError(28, "No space left on device")):
-                    ok = be._prepare_thread(s, fake)
+            with _disk_full(nf):
+                ok = be._prepare_thread(s, fake)
             self.assertTrue(ok, "the healthy turn still proceeds")
-            self.assertTrue(any("could not be published" in m for m in logs), logs)
-            self.assertFalse(any("was restored" in m for m in logs),
+            self.assertEqual(sorted(p.name for p in nf.parent.iterdir()), [],
+                             "neither the file nor its temp exists: a failed publish leaves nothing")
+            self.assertTrue(any("could not be published" in m and "[Errno 28]" in m for m in logs), logs)
+            self.assertFalse(any("restored" in m for m in logs),
                              "the log must not claim a restore that never happened")
 
     def test_resume_never_overwrites_a_fresher_registry_name(self):


### PR DESCRIPTION
Tier: fix

## What was wrong
Verified on `main`: the Codex backend's thread-start names write kept a compensation written for an earlier in-place writer. It read the old line, called the writer, and on failure wrote the old bytes back in place, or removed the file if there had been none. The writer itself is atomic, a temp file and a rename under the names lock with the temp removed on failure, so on any failure the names file is untouched by construction. The compensation was therefore the only non-atomic write on the path: it rewrote an intact file in place, moved its modification time for no change in content, and under the very disk-full condition it existed for it truncated the good file to nothing and then hoped the rewrite would land. #1138 removed the same shape from both backends' rename and named this site as the sibling left for its own change.

## What changes
The snapshot, the in-place restore and the removal branch are gone. A failed write still does not stop the thread from starting, and the log still says what happened with the error: an existing file kept its old line, because the writer left it, or there was no file, so the session runs unnamed until a rename. That distinction is now made by reading the file after the fact, never by writing.

## Deliberately left out
Nothing else in the file writes a names entry in place; the rename twin was fixed in #1138.

## Tests
The existing fake-driven test that pinned the restore is rewritten to drive the real writer with the fault injected beneath it, using the disk-full model #1138 added, which also makes an in-place write truncate before it fails. It asserts the names file is byte-identical, its modification time unchanged, no temp sibling left, the thread start still completing, and one log line naming the error and not a restore. On `main` it is red because main's own restore truncated the file to nothing. The absent-file case also moves to the real writer and asserts nothing is created, green on both sides as its comment says. The Codex backend module passes 64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
