### PR TITLE
Scroll journal: a unit above the tail, or a box of the scroller outside the thread, names itself when it changes height (T262n)

### DIFF
--- a/ui/webview/at-bottom.test.ts
+++ b/ui/webview/at-bottom.test.ts
@@ -85,9 +85,11 @@ test("follow mode and the chip read atBottom at every site", () => {
     /content\.clientHeight > 0 && !atBottom\(content\)\) \{\s*\n\s*writeScroll\(content, content\.scrollTop \+ \(h - lastH\), "box-resize"\);/,   // box-resize compensation
     /stick = !!content && atBottom\(content\);/,                                                          // tab-strip drag
     /const wasAtBottom = !!contentX && contentX\.scrollHeight > contentX\.clientHeight \+ 2 && atBottom\(contentX\);/,   // the ✕ on a pending bubble (T262h)
+    /unitChangeRow\(id, c\.dh, c\.cls, c\.fromTail, view3\.stick, atBottom\(content\), content\.scrollHeight, content\.clientHeight\)/,   // the unit-change row's measured bottom (T262n)
+    /unitChangeRow\(activeId \|\| "", dh, cls, BOX_FROM_TAIL, v\.stick, atBottom\(c\), c\.scrollHeight, c\.clientHeight\)/,   // the scroller's boxes outside the thread (T262n follow-up)
   ];
   for (const re of follow) assert.match(RENDER, re, String(re));
-  assert.equal((RENDER.match(/\batBottom\(/g) || []).length, 11, "ten call sites plus the definition");
+  assert.equal((RENDER.match(/\batBottom\(/g) || []).length, 13, "twelve call sites plus the definition");
 });
 
 test("only the user's own send reveal keeps the 80 px band", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -59,7 +59,7 @@ import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDown
 import { followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow, followTailShrink } from "./scroll-keep";
 import { retainLiveOmitted } from "./tab-order";
 import { userTurnShows } from "./user-turn-content";
-import { ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap, summarizeTailMutations, tailMutRow } from "./scroll-write";
+import { ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap, summarizeTailMutations, tailMutRow, unitChangeRow, unitChanges, boxChanges, boxLabel, BOX_FROM_TAIL } from "./scroll-write";
 import { reloadScrollRecord, takeReloadScroll, type ReloadScroll } from "./reload-restore";
 import { keepResidentEvents } from "./frame-merge";
 import { activeTabToReannounce } from "./relay-active";
@@ -1063,7 +1063,7 @@ let landTrail: string[] = [];
 // count is NOT len − winStart + spacer: a unit may own more than one node (the day
 // divider that opens a new day precedes its turn), so anything mapping DOM back to
 // units reads data-unit off the node rather than counting children.
-interface View { el: HTMLElement; rendered: number; scrollTop: number; stick: boolean; shown: boolean; stale: boolean; winStart: number; winEnd?: number; avgTurnH?: number; spacerCount?: number; spacerCountBot?: number; unitTotal?: number; working?: boolean; ro?: ResizeObserver; mo?: MutationObserver; }   // working: the session's state at the last sync, the "worked …" footer's one non-event input (syncViewInner)
+interface View { el: HTMLElement; rendered: number; scrollTop: number; stick: boolean; shown: boolean; stale: boolean; winStart: number; winEnd?: number; avgTurnH?: number; spacerCount?: number; spacerCountBot?: number; unitTotal?: number; working?: boolean; uo?: ResizeObserver; uh?: WeakMap<Element, number>; ro?: ResizeObserver; mo?: MutationObserver; }   // working: the session's state at the last sync, the "worked …" footer's one non-event input (syncViewInner)
 const views = new Map<string, View>();
 
 // Pending pickers (AskUserQuestion / tool-permission) keyed by session id. These
@@ -9448,7 +9448,7 @@ function tailMutations(records: MutationRecord[]): { removedTail: string[]; adde
 // the cap is the default unless the page's localStorage says otherwise (a laptop capturing raises it; T262j)
 const scrollDiagCap = readScrollDiagCap((k) => { try { return localStorage.getItem(k); } catch { return null; } });
 const scrollDiag = new ScrollDiagBudget(scrollDiagCap);
-function scrollDiagRow(kind: "scrollwrite" | "scrollgesture" | "tailchange" | "spacer" | "tailmut", data: any): void {
+function scrollDiagRow(kind: "scrollwrite" | "scrollgesture" | "tailchange" | "spacer" | "tailmut" | "unitchange", data: any): void {
   const v = scrollDiag.take(activeId || "", kind, Date.now());
   if (v === "drop") return;
   vscodeApi?.postMessage(v === "cap"
@@ -9816,8 +9816,42 @@ function ensureView(id: string): View {
       // ResizeObserver (frame-end sizes only) yet clamps the reader if a layout is forced in between — the remaining
       // snap's shape. Every removal at the END of the active view files a tailmut row: what left, whether it came
       // back in the same task, the scroll height the pane last recorded and the one after.
+      // …and a ResizeObserver over EVERY unit in the rendered window (T262n, the user 2026-09-08: an eleven-minute
+      // laptop capture held one unwritten move, a 24 px shrink with the reader at the bottom, and no row named what
+      // shrank). The rail above says the view changed height and names the TAIL; a unit above the tail changing height
+      // in place (a tool head folding, a figure sizing in, a status line going) moves the view by the same amount and
+      // the rail's row can only name the tail. This one names the unit: its class, how many units above the tail it
+      // sits, the view's recorded follow mode and the measured bottom at the read. A row only: no write, no rule. The
+      // tail unit is left to the rail's row (unitChanges skips it), spacers to their spacer rows. Units join and leave
+      // this observer through the mutation observer below (a window slide replaces them all), and a unit's first
+      // observation is its baseline, never a row. Same per-kind, per-minute cap as every other row.
+      const view3 = v;
+      const unitHeights = new WeakMap<Element, number>();
+      v.uh = unitHeights;
+      let unitW = -1;   // the view's width at the last observation: a change means every unit reflowed, not a unit that changed
+      const unitOf = (n: Element) => { const u = (n as HTMLElement).dataset?.unit; return u != null && u !== "" ? Number(u) : undefined; };
+      v.uo = new ResizeObserver((entries) => {
+        // A hidden view's units have no box: the observer reports each at 0x0 on hide and at its full height on
+        // re-show, neither a change in the unit (the review's find: one switch back would have filed a row per unit
+        // and burnt the minute's cap). The hide forgets the reported baselines and files nothing; the re-show
+        // observation records fresh ones, like a first show. Covers the tab switch and stripAftermath's blank.
+        if (view3.el.style.display === "none") { for (const e of entries) unitHeights.delete(e.target); return; }
+        // …and a width change reflows every unit at once (a resize, a scrollbar appearing): the new heights become
+        // the baselines and nothing is filed — a hundred honest rows would say nothing about any one unit.
+        const w = view3.el.clientWidth;
+        if (w !== unitW) { unitW = w; for (const e of entries) unitHeights.set(e.target, e.contentRect?.height ?? 0); return; }
+        const changes = unitChanges(entries.map((e) => ({ target: e.target, height: e.contentRect?.height ?? 0 })), view3.el.children, unitHeights, unitOf);
+        const content = document.getElementById("content");
+        if (!content || activeId !== id || !view3.shown) return;   // baselines are recorded above regardless; an inactive view files nothing
+        for (const c of changes)
+          scrollDiagRow("unitchange", unitChangeRow(id, c.dh, c.cls, c.fromTail, view3.stick, atBottom(content), content.scrollHeight, content.clientHeight));
+      });
       const view2 = v;
       v.mo = new MutationObserver((records) => {
+        for (const rec of records) {   // units entering the window are observed, units leaving are dropped (T262n)
+          rec.addedNodes.forEach((n) => { if (n instanceof Element) view2.uo?.observe(n); });
+          rec.removedNodes.forEach((n) => { if (n instanceof Element) { view2.uo?.unobserve(n); unitHeights.delete(n); } });
+        }
         if (activeId !== id || !view2.shown) return;
         const m = tailMutations(records);
         if (!m) return;
@@ -10886,6 +10920,39 @@ if (typeof ResizeObserver === "function") {
       }
       tailLastH = h;
     }).observe(tailHost);
+  }
+}
+// …and the scroller's boxes OUTSIDE the thread (the T262n follow-up, the user's 2026-09-08 laptop capture: its one
+// unwritten move, a 24 px shrink with the reader at the bottom, had no tailchange row, so it came from outside the
+// thread element, on a remote-host tab, where the one such box is the host-offline foot). #content's direct children
+// that are not a thread and not the live-ask host — the foot, #sub-head, the build placeholders — file the unit row
+// with fromTail BOX_FROM_TAIL, named by id else class: on appearing (their height, read once), on changing in place
+// (the observer) and on leaving (the height they had). A box removed under a bottom reader is exactly a clamp to the
+// bottom by its height, and the browser writes nothing; the row is attribution only, nothing moves for it.
+if (typeof ResizeObserver === "function") {
+  const c = document.getElementById("content");
+  if (c) {
+    const boxHeights = new WeakMap<Element, number>();
+    const isBox = (n: Node): n is HTMLElement => n instanceof HTMLElement && !n.classList.contains("thread") && n.id !== "live-ask";
+    const fileBox = (dh: number, cls: string) => {
+      const v = activeId ? views.get(activeId) : null;
+      if (!dh || !v || !v.shown || c.clientHeight <= 0) return;
+      scrollDiagRow("unitchange", unitChangeRow(activeId || "", dh, cls, BOX_FROM_TAIL, v.stick, atBottom(c), c.scrollHeight, c.clientHeight));
+    };
+    const boxRo = new ResizeObserver((entries) => {   // offsetHeight both here and at the baseline: one measure, no false first row
+      // the whole pane hidden measures every box at 0: forget those baselines and file nothing; the re-show
+      // observation is a fresh baseline (the same rule as the unit observer's hide)
+      if (c.clientHeight <= 0) { for (const e of entries) boxHeights.delete(e.target); return; }
+      for (const b of boxChanges(entries.map((e) => ({ target: e.target as HTMLElement, height: (e.target as HTMLElement).offsetHeight })), boxHeights)) fileBox(b.dh, b.cls);
+    });
+    const watchBox = (n: HTMLElement): number => { const h = n.offsetHeight; boxHeights.set(n, h); boxRo.observe(n); return h; };
+    for (const n of Array.from(c.children)) if (isBox(n)) watchBox(n);   // what is there now is the baseline, no row
+    new MutationObserver((records) => {
+      for (const rec of records) {
+        rec.removedNodes.forEach((n) => { if (isBox(n)) { const h = boxHeights.get(n) || 0; boxRo.unobserve(n); boxHeights.delete(n); fileBox(-h, boxLabel(n)); } });
+        rec.addedNodes.forEach((n) => { if (isBox(n)) fileBox(watchBox(n), boxLabel(n)); });
+      }
+    }).observe(c, { childList: true });
   }
 }
 // Boxes ABOVE the transcript grow/shrink → keep the chat text visually anchored (the user 2026-06-30 for
@@ -13952,7 +14019,7 @@ function upsert(msg: any) {
   }
   if (forked) {
     const v = views.get(msg.id);
-    if (v) { v.ro?.disconnect(); v.mo?.disconnect(); v.el.remove(); views.delete(msg.id); }
+    if (v) { v.uo?.disconnect(); v.ro?.disconnect(); v.mo?.disconnect(); v.el.remove(); views.delete(msg.id); }
   } else if (existed && !kept) {
     // A full frame replaces every event object and can differ from what this view rendered ANYWHERE (it is
     // what the kernel sends a client it believes is behind): the tail path trusts v.rendered as the exact
@@ -14402,7 +14469,7 @@ function dismissSession(id: string, why: DismissWhy, doomed?: ReadonlySet<string
     persistDrafts();   // a host drop / omission KEEPS it all (see DismissWhy) — the stash above may have updated the copy
   }
   const v = views.get(id);
-  if (v) { v.ro?.disconnect(); v.mo?.disconnect(); v.el.remove(); views.delete(id); }
+  if (v) { v.uo?.disconnect(); v.ro?.disconnect(); v.mo?.disconnect(); v.el.remove(); views.delete(id); }
   const oi = order.indexOf(id); if (oi >= 0) order.splice(oi, 1);
   const mi = mru.indexOf(id); if (mi >= 0) mru.splice(mi, 1);   // before the fallback read below — never the dead id
   renderTabs();                          // tab removed from `order` above → repaint without it

--- a/ui/webview/scroll-movers.test.ts
+++ b/ui/webview/scroll-movers.test.ts
@@ -49,6 +49,6 @@ test("render.ts: every mover of #content is a writeScroll — scrollBy and scrol
 test("render.ts: a spacer re-size of the active view files a spacer row; the cap comes from localStorage", () => {
   assert.match(RENDER, /if \(\(topAfter !== topBefore \|\| botAfter !== botBefore\) && activeId && views\.get\(activeId\) === v\) \{\s*\n\s*const content = document\.getElementById\("content"\);\s*\n\s*scrollDiagRow\("spacer", spacerRow\(activeId, topBefore, topAfter, botBefore, botAfter,/);
   assert.match(RENDER, /const scrollDiagCap = readScrollDiagCap\(\(k\) => \{ try \{ return localStorage\.getItem\(k\); \} catch \{ return null; \} \}\);\s*\n\s*const scrollDiag = new ScrollDiagBudget\(scrollDiagCap\);/);
-  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut", data: any\): void \{/);
+  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut" \| "unitchange", data: any\): void \{/);
   assert.match(RENDER, /data: \{ sid: activeId \|\| "", perMinute: scrollDiagCap \} \}/, "the capped row says which cap");
 });

--- a/ui/webview/scroll-write.test.ts
+++ b/ui/webview/scroll-write.test.ts
@@ -40,7 +40,7 @@ test("the row names the writer and carries before/after/delta/stick, gesture:fal
 });
 
 test("render.ts: one helper writes #content.scrollTop, files the row only when the view moved, and no raw write remains", () => {
-  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap, summarizeTailMutations, tailMutRow \} from "\.\/scroll-write";/);
+  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap, summarizeTailMutations, tailMutRow, unitChangeRow, unitChanges, boxChanges, boxLabel, BOX_FROM_TAIL \} from "\.\/scroll-write";/);
   assert.match(RENDER, /function writeScroll\(content: HTMLElement, top: number, writer: string, stick = false\): void \{\s*\n\s*const before = content\.scrollTop;\s*\n\s*content\.scrollTop = top;\s*\n\s*const after = content\.scrollTop;\s*\n\s*lastScrollWriteAfter = after;\s*\n\s*lastKnownSh = content\.scrollHeight;\s*\n\s*if \(after !== before\) scrollDiagRow\("scrollwrite", scrollWriteRow\(activeId \|\| "", writer, before, after, stick, content\.scrollHeight, content\.clientHeight\)\);/);
   // the breadcrumb rides the existing clientDiag path, capped, with one capped row at the cap
   assert.match(RENDER, /\{ type: "clientDiag", surface: "chat", what: kind \+ "-capped", data: \{ sid: activeId \|\| "", perMinute: scrollDiagCap \} \}/);   // the cap the page runs with (T262j: configurable)

--- a/ui/webview/scroll-write.ts
+++ b/ui/webview/scroll-write.ts
@@ -95,6 +95,70 @@ export function tailLabel(children: ArrayLike<{ className?: string }>): string {
   return "";
 }
 
+/** The breadcrumb for one height change of a unit that is NOT the tail (T262n, the user's 2026-09-08 laptop capture:
+ *  one unwritten move in eleven minutes, a 24 px shrink of the transcript with the reader at the bottom, and no row
+ *  named what shrank). The view rail's row says the transcript changed height and names the TAIL; when a unit above
+ *  the tail changes height in place, that row still names the tail. This one names the unit: `cls` its class list,
+ *  `fromTail` how many units above the tail it sits (1 = the unit just above it), `stick` the view's recorded follow
+ *  mode and `atBottom` the measured bottom at the read. A row only: nothing is written or decided from it. */
+export function unitChangeRow(sid: string, dh: number, cls: string, fromTail: number, stick: boolean, atBottom: boolean, sh = 0, ch = 0) {
+  return { sid, dh, cls: String(cls || "").slice(0, 60), fromTail, stick, atBottom, sh, ch };
+}
+
+export interface UnitHeights<T> { get(t: T): number | undefined; set(t: T, h: number): unknown; }
+
+/** Boxes of the scroller OUTSIDE the thread (the T262n follow-up): #content's direct children that are not a
+ *  thread and not the live-ask host (which has its own rows): the host-offline foot, #sub-head, the build
+ *  placeholders. The laptop capture's one unwritten move had no tailchange row, so its 24 px came from one of
+ *  these, on a remote-host tab, where the foot is the one such box. A box has no place in the thread, so its
+ *  unit row carries fromTail BOX_FROM_TAIL and names the box by id (#host-offline-foot) else by class. */
+export const BOX_FROM_TAIL = -1;
+export function boxLabel(box: { id?: string; className?: string }): string {
+  return box.id ? "#" + box.id : String(box.className || "");
+}
+/** Fold one ResizeObserver callback over the scroller's boxes into the in-place changes to file: the first
+ *  observation is the baseline (the pane records it when the box appears), an unchanged height files nothing. */
+export function boxChanges<T extends { id?: string; className?: string }>(entries: Array<{ target: T; height: number }>,
+                                                                        heights: UnitHeights<T>): Array<{ target: T; dh: number; cls: string }> {
+  const out: Array<{ target: T; dh: number; cls: string }> = [];
+  for (const e of entries) {
+    const prev = heights.get(e.target);
+    heights.set(e.target, e.height);
+    if (prev === undefined || e.height === prev) continue;
+    out.push({ target: e.target, dh: e.height - prev, cls: boxLabel(e.target) });
+  }
+  return out;
+}
+/** Fold one ResizeObserver callback over a view's units into the non-tail changes to file. `entries` are the
+ *  observed units with their new heights, `children` the view's children in order, `heights` the last height seen
+ *  per unit (a WeakMap in the pane). The first observation of a unit is its baseline and files nothing (observe()
+ *  reports once on attach); an unchanged height files nothing; a virtualization spacer never files (its spacer rows
+ *  say what it did); the TAIL unit (the last child that is not a spacer, tailLabel's rule) never files here, because
+ *  the view rail's row already carries its change; a unit no longer in the window files nothing. `fromTail` counts
+ *  UNITS when `unitOf` can say which unit a child belongs to (the pane's data-unit: a day divider is a child of its
+ *  own carrying the unit it opens, so counting children would read one turn plus a divider as two turns); it falls
+ *  back to child distance where no unit index exists. */
+export function unitChanges<T extends { className?: string }>(entries: Array<{ target: T; height: number }>, children: ArrayLike<T>,
+                                                                heights: UnitHeights<T>, unitOf?: (t: T) => number | undefined): Array<{ target: T; dh: number; cls: string; fromTail: number }> {
+  let tail = -1;
+  for (let i = children.length - 1; i >= 0; i--) if (String(children[i]?.className || "").indexOf("tx-spacer") < 0) { tail = i; break; }
+  const out: Array<{ target: T; dh: number; cls: string; fromTail: number }> = [];
+  for (const e of entries) {
+    const prev = heights.get(e.target);
+    heights.set(e.target, e.height);
+    if (prev === undefined || e.height === prev) continue;
+    const cls = String(e.target?.className || "");
+    if (cls.indexOf("tx-spacer") >= 0) continue;
+    let idx = -1;
+    for (let i = 0; i < children.length; i++) if (children[i] === e.target) { idx = i; break; }
+    if (idx < 0 || idx === tail) continue;
+    const ut = unitOf ? unitOf(children[tail]) : undefined, uu = unitOf ? unitOf(e.target) : undefined;
+    const byUnit = typeof ut === "number" && typeof uu === "number" && !Number.isNaN(ut) && !Number.isNaN(uu);
+    out.push({ target: e.target, dh: e.height - prev, cls, fromTail: byUnit ? ut - uu : tail - idx });
+  }
+  return out;
+}
+
 /** The breadcrumb for one write that moved the view. `sh`/`ch` = #content's scrollHeight/clientHeight after the
  *  write (T262e, the user 2026-09-08: their laptop's rows showed the view moving UP by the same 95 px on two
  *  sessions with no write between the rows — an UNWRITTEN move, which the rows could not classify: a browser

--- a/ui/webview/tail-change-row.test.ts
+++ b/ui/webview/tail-change-row.test.ts
@@ -27,8 +27,8 @@ test("the tail label is the last child that is not a virtualization spacer", () 
 });
 
 test("render.ts files the row from both tail observers, beside the tail-shrink rule, through the capped diag path", () => {
-  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap, summarizeTailMutations, tailMutRow \} from "\.\/scroll-write";/);   // + spacerRow, readScrollDiagCap (T262j)
-  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut", data: any\): void \{/);   // + spacer (T262j)
+  assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap, summarizeTailMutations, tailMutRow, unitChangeRow, unitChanges, boxChanges, boxLabel, BOX_FROM_TAIL \} from "\.\/scroll-write";/);   // + spacerRow, readScrollDiagCap (T262j)
+  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut" \| "unitchange", data: any\): void \{/);   // + spacer (T262j)
   assert.match(RENDER, /if \(content && lastH >= 0 && activeId === id && view\.shown && h !== lastH\)\s*\n\s*scrollDiagRow\("tailchange", tailChangeRow\(id, h - lastH, tailLabel\(view\.el\.children\), view\.stick, content\.scrollHeight, content\.clientHeight\)\);/);
   assert.match(RENDER, /if \(content && tailLastH >= 0 && v && v\.shown && h !== tailLastH\)\s*\n\s*scrollDiagRow\("tailchange", tailChangeRow\(activeId \|\| "", h - tailLastH, "live-ask", v\.stick, content\.scrollHeight, content\.clientHeight\)\);/);
   assert.equal((RENDER.match(/"tailchange"/g) || []).length, 3, "the kind in the router's union and the two filings");

--- a/ui/webview/tail-mutation.test.ts
+++ b/ui/webview/tail-mutation.test.ts
@@ -39,7 +39,7 @@ test("the row carries what left, whether it came back, and the scroll height bef
 
 test("render.ts observes the active view's children and the live-ask host's, and files the row through the capped diag path", () => {
   assert.match(RENDER, /import \{[^}]*\bsummarizeTailMutations\b[^}]*\btailMutRow\b[^}]*\} from "\.\/scroll-write";/);
-  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut", data: any\): void \{/);
+  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut" \| "unitchange", data: any\): void \{/);
   assert.match(RENDER, /mo\?: MutationObserver; \}/, "the View carries its mutation observer");
   assert.match(RENDER, /v\.mo = new MutationObserver\(\(records\) => \{/);
   assert.match(RENDER, /v\.mo\.observe\(elv, \{ childList: true \}\);/);

--- a/ui/webview/unit-change-row.test.ts
+++ b/ui/webview/unit-change-row.test.ts
@@ -1,0 +1,135 @@
+// A unit above the tail names itself when it changes height (T262n, the user's 2026-09-08 laptop capture). The merged
+// audit reader found one unwritten move in eleven minutes of real use: the transcript shrank 24 px with the reader at
+// the bottom and the browser carried them down, still at the bottom, and no row said what shrank. The view rail's row
+// names the TAIL whenever the view's height changes, so a unit above the tail changing height in place is a row that
+// names the wrong element. This instrument observes every unit in the rendered window and files, for a NON-tail unit's
+// height change, the unit's class, its distance above the tail, the recorded follow mode and the measured bottom. A
+// row only: nothing is written or decided from it. The tail unit's own change stays the rail's tailchange row.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { unitChangeRow, unitChanges, tailChangeRow, tailLabel, boxChanges, boxLabel, BOX_FROM_TAIL } from "./scroll-write";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const SID = "11111111-2222-4333-8444-000000000262";
+
+type U = { className: string; unit?: number };
+const unitOf = (u: U) => u.unit;   // the pane's data-unit: a day divider carries the unit it opens
+function window() {
+  const top: U = { className: "tx-spacer tx-spacer-top" };
+  const a: U = { className: "turn turn-user", unit: 5 };
+  const b: U = { className: "turn turn-assistant", unit: 6 };
+  const c: U = { className: "turn turn-tool", unit: 7 };            // the tail: the last child that is not a spacer
+  const bot: U = { className: "tx-spacer tx-spacer-bot" };
+  const children = [top, a, b, c, bot];
+  const heights = new Map<U, number>();
+  // observe() reports once on attach: the first observation of every unit is its baseline, never a row
+  assert.deepEqual(unitChanges(children.map((u, i) => ({ target: u, height: [20, 100, 200, 300, 40][i] })), children, heights, unitOf), []);
+  return { top, a, b, c, bot, children, heights };
+}
+
+test("a non-tail unit growing by N files exactly one row with dh N, naming the unit and its distance above the tail", () => {
+  const w = window();
+  const changes = unitChanges([{ target: w.b, height: 237 }], w.children, w.heights, unitOf);
+  assert.equal(changes.length, 1, "one change, one row");
+  assert.deepEqual({ dh: changes[0].dh, cls: changes[0].cls, fromTail: changes[0].fromTail }, { dh: 37, cls: "turn turn-assistant", fromTail: 1 });
+  assert.deepEqual(unitChangeRow(SID, changes[0].dh, changes[0].cls, changes[0].fromTail, true, true, 23690, 869),
+                   { sid: SID, dh: 37, cls: "turn turn-assistant", fromTail: 1, stick: true, atBottom: true, sh: 23690, ch: 869 });
+  // the same height again is no change; a shrink reads negative; a unit two above the tail says so
+  assert.deepEqual(unitChanges([{ target: w.b, height: 237 }], w.children, w.heights, unitOf), []);
+  const two = unitChanges([{ target: w.a, height: 76 }], w.children, w.heights, unitOf);
+  assert.deepEqual(two.map((x) => [x.dh, x.fromTail]), [[-24, 2]]);
+  assert.equal(unitChangeRow(SID, 1, "x".repeat(200), 1, false, false).cls.length, 60, "the class list is bounded like the rail's label");
+});
+
+test("fromTail counts units, not children: a day divider between the unit and the tail is not a turn", () => {
+  const w = window();
+  const divider: U = { className: "day-divider", unit: 7 };   // opens the tail's day: a child of its own, the tail's unit
+  const children = [w.top, w.a, w.b, divider, w.c, w.bot];
+  w.heights.set(divider, 18);
+  const byUnit = unitChanges([{ target: w.b, height: 260 }], children, w.heights, unitOf);
+  assert.deepEqual(byUnit.map((x) => [x.dh, x.fromTail]), [[60, 1]], "one turn above the tail, whatever sits between");
+  const byChild = unitChanges([{ target: w.b, height: 290 }], children, w.heights);
+  assert.deepEqual(byChild.map((x) => [x.dh, x.fromTail]), [[30, 2]], "with no unit index the child distance is all there is");
+  const dividerGrew = unitChanges([{ target: divider, height: 40 }], children, w.heights, unitOf);
+  assert.deepEqual(dividerGrew.map((x) => [x.cls, x.dh, x.fromTail]), [["day-divider", 22, 0]], "the divider itself is named, at the tail's own unit");
+});
+
+test("the tail unit's own change files the existing tailchange row and not this one", () => {
+  const w = window();
+  assert.deepEqual(unitChanges([{ target: w.c, height: 350 }], w.children, w.heights, unitOf), [], "the tail is the rail's");
+  // …and the rail's row is what it always was: the view grew by the same 50 px, named by the tail's class
+  assert.deepEqual(tailChangeRow(SID, 350 - 300, tailLabel(w.children), true, 23740, 869),
+                   { sid: SID, dh: 50, last: "turn turn-tool", stick: true, sh: 23740, ch: 869 });
+  // a batch mixing the tail and a unit above it files the unit alone
+  const mixed = unitChanges([{ target: w.c, height: 360 }, { target: w.b, height: 210 }], w.children, w.heights, unitOf);
+  assert.deepEqual(mixed.map((x) => [x.cls, x.dh, x.fromTail]), [["turn turn-assistant", 10, 1]]);
+});
+
+test("spacers, units that left the window and a window with no tail file nothing", () => {
+  const w = window();
+  assert.deepEqual(unitChanges([{ target: w.top, height: 4483 }], w.children, w.heights), [], "a spacer re-estimate has its own spacer row");
+  const gone: U = { className: "turn turn-user" };
+  w.heights.set(gone, 90);
+  assert.deepEqual(unitChanges([{ target: gone, height: 120 }], w.children, w.heights), [], "a unit the window slide removed files nothing");
+  const spacersOnly = [w.top, w.bot];
+  const h2 = new Map<U, number>([[w.top, 10], [w.bot, 10]]);
+  assert.deepEqual(unitChanges([{ target: w.top, height: 30 }], spacersOnly, h2), []);
+});
+
+test("a box of the scroller outside the thread files the same row, named by id else class, with fromTail -1", () => {
+  // the laptop capture's one unwritten move had NO tailchange row: the 24 px came from outside the thread element,
+  // on a remote-host tab, where the one such box is the host-offline foot (T262n follow-up)
+  assert.equal(BOX_FROM_TAIL, -1, "units sit 1 or more above the tail; a box has no place in the thread");
+  assert.equal(boxLabel({ id: "host-offline-foot", className: "tx-hostoff" }), "#host-offline-foot");
+  assert.equal(boxLabel({ className: "tx-loading" }), "tx-loading");
+  const foot = { id: "host-offline-foot", className: "tx-hostoff" }, sub = { id: "sub-head", className: "sub-head" };
+  const heights = new Map<object, number>();
+  assert.deepEqual(boxChanges([{ target: foot, height: 58 }, { target: sub, height: 26 }], heights), [], "first observations are baselines");
+  assert.deepEqual(boxChanges([{ target: foot, height: 58 }], heights), [], "unchanged files nothing");
+  assert.deepEqual(boxChanges([{ target: sub, height: 50 }], heights).map((b) => [b.cls, b.dh]), [["#sub-head", 24]]);
+  assert.deepEqual(unitChangeRow(SID, -58, "#host-offline-foot", BOX_FROM_TAIL, true, true, 23666, 869),
+                   { sid: SID, dh: -58, cls: "#host-offline-foot", fromTail: -1, stick: true, atBottom: true, sh: 23666, ch: 869 });
+});
+
+test("render.ts watches #content's non-thread boxes: appear, change in place and leave all file; nothing is written", () => {
+  const blk = RENDER.split("// …and the scroller's boxes OUTSIDE the thread")[1].split("\n}\n")[0];
+  assert.match(blk, /const isBox = \(n: Node\): n is HTMLElement => n instanceof HTMLElement && !n\.classList\.contains\("thread"\) && n\.id !== "live-ask";/,
+    "threads have their own observers, the live-ask host its own rows");
+  assert.match(blk, /scrollDiagRow\("unitchange", unitChangeRow\(activeId \|\| "", dh, cls, BOX_FROM_TAIL, v\.stick, atBottom\(c\), c\.scrollHeight, c\.clientHeight\)\)/);
+  assert.match(blk, /for \(const n of Array\.from\(c\.children\)\) if \(isBox\(n\)\) watchBox\(n\);/, "what is there at load is the baseline");
+  assert.match(blk, /rec\.removedNodes\.forEach\(\(n\) => \{ if \(isBox\(n\)\) \{ const h = boxHeights\.get\(n\) \|\| 0; boxRo\.unobserve\(n\); boxHeights\.delete\(n\); fileBox\(-h, boxLabel\(n\)\); \} \}\);/,
+    "a box leaving files the height it had, negative: the clamp's size");
+  assert.match(blk, /rec\.addedNodes\.forEach\(\(n\) => \{ if \(isBox\(n\)\) fileBox\(watchBox\(n\), boxLabel\(n\)\); \}\);/, "a box appearing files its height");
+  assert.match(blk, /\.observe\(c, \{ childList: true \}\);/);
+  assert.match(blk, /height: \(e\.target as HTMLElement\)\.offsetHeight/, "one measure at the baseline and in the observer: no false first row");
+  assert.match(blk, /if \(c\.clientHeight <= 0\) \{ for \(const e of entries\) boxHeights\.delete\(e\.target\); return; \}/, "the whole pane hidden forgets the box baselines, like the unit observer's hide");
+  assert.doesNotMatch(blk, /writeScroll|scrollTop =/, "attribution only");
+});
+
+test("render.ts wires one observer per view over every unit, through the mutation observer, into the capped diag path", () => {
+  const ev = RENDER.split("function ensureView(id: string): View {")[1].split("\n}")[0];
+  assert.match(RENDER, /import \{[^}]*\bunitChangeRow\b[^}]*\bunitChanges\b[^}]*\} from "\.\/scroll-write";/);
+  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut" \| "unitchange", data: any\): void \{/);
+  assert.match(RENDER, /uo\?: ResizeObserver; uh\?: WeakMap<Element, number>; ro\?: ResizeObserver; mo\?: MutationObserver; \}/, "the View carries the unit observer and its heights");
+  // a hidden view's units measure 0x0 on hide and their full height on re-show: neither is a change (the review's
+  // find: one switch back would have filed a row per unit and burnt the minute's cap). The hide forgets baselines
+  // and files nothing; a width change (every unit reflows) refreshes them and files nothing; then the fold, BEFORE
+  // the active gate, so an inactive view's baselines stay current
+  const uo = ev.split("v.uo = new ResizeObserver((entries) => {")[1].split("\n      });")[0];
+  assert.match(uo, /^[\s\S]*?if \(view3\.el\.style\.display === "none"\) \{ for \(const e of entries\) unitHeights\.delete\(e\.target\); return; \}/, "the hide guard is the first statement");
+  assert.match(uo, /const w = view3\.el\.clientWidth;\s*\n\s*if \(w !== unitW\) \{ unitW = w; for \(const e of entries\) unitHeights\.set\(e\.target, e\.contentRect\?\.height \?\? 0\); return; \}/, "a reflow refreshes baselines and files nothing");
+  assert.ok(uo.indexOf('display === "none"') < uo.indexOf("w !== unitW") && uo.indexOf("w !== unitW") < uo.indexOf("const changes = unitChanges("), "hide, then reflow, then the fold");
+  assert.match(uo, /const changes = unitChanges\(entries\.map\(\(e\) => \(\{ target: e\.target, height: e\.contentRect\?\.height \?\? 0 \}\)\), view3\.el\.children, unitHeights, unitOf\);\s*\n\s*const content = document\.getElementById\("content"\);\s*\n\s*if \(!content \|\| activeId !== id \|\| !view3\.shown\) return;/,
+    "the fold runs BEFORE the active/shown gate, so an inactive view's baselines stay current");
+  assert.match(ev, /const unitOf = \(n: Element\) => \{ const u = \(n as HTMLElement\)\.dataset\?\.unit; return u != null && u !== "" \? Number\(u\) : undefined; \};/, "fromTail counts the pane's data-unit");
+  assert.match(ev, /scrollDiagRow\("unitchange", unitChangeRow\(id, c\.dh, c\.cls, c\.fromTail, view3\.stick, atBottom\(content\), content\.scrollHeight, content\.clientHeight\)\)/);
+  assert.match(ev, /rec\.addedNodes\.forEach\(\(n\) => \{ if \(n instanceof Element\) view2\.uo\?\.observe\(n\); \}\);/, "units entering the window are observed");
+  assert.match(ev, /rec\.removedNodes\.forEach\(\(n\) => \{ if \(n instanceof Element\) \{ view2\.uo\?\.unobserve\(n\); unitHeights\.delete\(n\); \} \}\);/, "units leaving are dropped");
+  // the rail's own filing is untouched: the tail's change still files tailchange from the view observer
+  assert.match(ev, /if \(content && lastH >= 0 && activeId === id && view\.shown && h !== lastH\)\s*\n\s*scrollDiagRow\("tailchange", tailChangeRow\(id, h - lastH, tailLabel\(view\.el\.children\)/);
+  assert.equal((RENDER.match(/v\.uo\?\.disconnect\(\); v\.ro\?\.disconnect\(\); v\.mo\?\.disconnect\(\); v\.el\.remove\(\);/g) || []).length, 2, "both view-removal sites disconnect it");
+  assert.equal((RENDER.match(/"unitchange"/g) || []).length, 3, "the kind in the router's union, the unit filing and the box filing");
+  assert.doesNotMatch(ev.split("v.uo = new ResizeObserver")[1].split("v.mo = new MutationObserver")[0], /writeScroll|scrollTop =/, "a row only: the unit observer never writes");
+});


### PR DESCRIPTION
An instrument, not a behaviour change: a unit above the transcript's tail now names itself when it changes height.

**Why.** The laptop capture read with the merged audit reader (T262k) held one unwritten move in eleven minutes of real use: the transcript shrank 24 px with the reader at the bottom and the browser carried them down, still at the bottom. No row named what shrank. The view rail's `tailchange` row fires whenever the view element's height changes and labels the change with the TAIL unit's class, so a unit above the tail changing height in place (a tool head folding, a figure sizing in, a status line going) is a row that names the wrong element, and the next unattributed `scrollHeight` change would have stayed unnamed.

**What.** Every unit in the rendered window is observed by one `ResizeObserver` per view. A non-tail unit's height change files a `unitchange` row: `{sid, dh, cls, fromTail, stick, atBottom, sh, ch}`, with `cls` the unit's class list, `fromTail` how many units above the tail it sits (1 = the unit just above), `stick` the view's recorded follow mode and `atBottom` the measured bottom at the read. Units join and leave the observer through the existing per-view `MutationObserver` (a window slide replaces them all); a unit's first observation is its baseline, never a row. The tail unit's own change stays the rail's `tailchange` row (the fold skips it); spacers keep their `spacer` rows. Same per-kind, per-minute cap as every other row. Nothing is written or decided from the row.

**Pinned** (`ui/webview/unit-change-row.test.ts`, executed): a non-tail unit growing by N files exactly one row with `dh` N naming the unit and its distance above the tail; the tail unit's own change files nothing here while the rail's `tailChangeRow` still carries it; a batch mixing both files the unit alone; spacers, units that left the window and a spacerless window file nothing; and render.ts wires the fold before the active/shown gate (baselines for hidden views too), observes added nodes and drops removed ones, files through the capped path, disconnects at both view-removal sites, and never writes from this observer. The four existing pins naming the row union and the import line are updated.

**The scroller's boxes outside the thread file the same row** (the manager's follow-up, folded in). The rail observes the thread element, so a height change INSIDE the thread always files a `tailchange` row (possibly mislabeled) and now a `unitchange` row too. The 7:38 PM move had NO `tailchange` row, so its 24 px came from outside the thread element, and that tab showed a session on a remote host, where the one box the dashboard adds under the thread is the host-offline foot (`#host-offline-foot`). `#content`'s direct children that are not a thread and not the live-ask host (the foot, `#sub-head`, the build placeholders) are now watched too: a box appearing files its height, a box changing in place files the delta, and a box leaving files the height it had, negative, since its removal under a bottom reader is exactly a clamp to the bottom by that height. These rows carry `fromTail: -1` and name the box by id else class. Baseline and observer both read `offsetHeight`, so the first observation never fakes a row. Pinned: `boxChanges`/`boxLabel` executed; the render wiring (exclusions, appear, leave, no writes) by source.

**Two guards from the adversarial review, so the rows stay about units.** A hidden view's units measure 0x0 on hide and their full height on re-show, and neither is a change: without a guard one switch back would have filed a row per unit and burnt the minute's cap, dropping the very row the instrument exists for. The hide now forgets the reported baselines and files nothing, and the re-show observation records fresh ones, like a first show (the same rule covers the whole pane hidden, for the boxes). A width change reflows every unit at once (a resize, a scrollbar appearing): the new heights become the baselines and nothing is filed. And `fromTail` counts units through the pane's `data-unit`, not children, so a day divider between a unit and the tail is not read as a turn. All three are pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
