### PR TITLE
T278: the socket budget bounds the backlog behind the frame in flight, so a first frame larger than the budget is delivered

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4424,8 +4424,10 @@ def _judge_timeline_views(blob, base=None, seq_floor=0, edited=None, foreign=Non
         # blob missing its own creates. Rows only, never stored — the bound stands.
         # ROWS ARE BOUNDED to `bound` of them (the 2026-09-05 review): the rows, the loud
         # notice and the ack's `error` were O(N) in the posted array, so a 100k-entry post (a client
-        # bug, or any page holding the socket) drew a ~22 MB ack that overran WS_QUEUE_BYTES and
-        # dropped the poster's own socket before the ack was queued. Every unread store tag is still
+        # bug, or any page holding the socket) drew a ~22 MB ack, which under the budget rule of the
+        # time (queued bytes plus the frame against WS_QUEUE_BYTES) dropped the poster's own socket
+        # before the ack was queued; since T278 a lone big frame is delivered, and the bound stands
+        # for the pane's sake, a 22 MB ack being nothing a client should have to parse. Every unread store tag is still
         # kept, however far past the bound its copy sat (at most the store's 32); past the first
         # `bound` unread entries the rest are ONE summary row carrying their count and how many of
         # them `edited` names (`moreEdited`), which the door's ok rule reads — a client whose own

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -35542,6 +35542,15 @@ def _ws_accept(key):
 # stall being fixed here (caught by test_ws_send_bounded, which overran a 32-frame cap with 40 keepalives
 # a healthy client would have drained fine). Bytes track the thing that actually matters: a client behind
 # by 16 MB of view payloads has stopped reading, while any burst of ~40-byte keepalives is noise.
+# "Behind" is the bytes queued BEHIND the frame at the head of the queue, the one in flight or about to be
+# (T278, 2026-09-08): the budget bounds a peer that has stopped draining, not a frame that is simply big.
+# The devbox's timeline-bars frame grew to 17.7 MB against this budget, so every fresh timeline connection
+# was dropped on its FIRST frame ("0 bytes behind"), reconnected, and was dropped again — 299 drops in one
+# evening, a 17 MB frame rebuilt and serialized several times a minute for nothing, and a laptop that never
+# saw this machine's bars. An empty queue accepts any frame; a healthy peer drains the head at wire speed
+# while the small deltas queue behind it; a wedged peer's stuck head lets the backlog behind it grow past
+# the budget, which is the drop. The head is tracked as a size deque beside the queue (qsizes): one sender
+# thread, one queue, so completions are FIFO and the head of the deque is the head of the queue.
 WS_QUEUE_BYTES = int(os.environ.get("ROMP_WS_QUEUE_BYTES", str(16 * 1024 * 1024)))
 
 
@@ -35594,15 +35603,23 @@ def _ws_sender(q, sock, lock, client):
         finally:
             with client["qlock"]:              # released whether the frame landed or the socket died
                 client["qbytes"] -= len(s)
+                sizes = client.get("qsizes")
+                if sizes:
+                    sizes.popleft()            # this frame was the head; the next queued frame is now in flight
 
 
 def _mk_ws_send(q, sock, client):
-    """The client's `send`: enqueue, never block. Past WS_QUEUE_BYTES the peer has stopped draining, so the
-    client is dropped and its socket shut down — which also unblocks its sender thread, parked in a write
-    that will now fail, instead of leaking it for the life of the kernel."""
+    """The client's `send`: enqueue, never block. With more than WS_QUEUE_BYTES queued BEHIND the frame at the
+    head of the queue the peer has stopped draining (T278: a frame that is merely big is delivered; see the
+    budget's comment), so the client is dropped and its socket shut down — which also unblocks its sender
+    thread, parked in a write that will now fail, instead of leaking it for the life of the kernel."""
     def send(s):
         with client["qlock"]:
-            if client["qbytes"] + len(s) > WS_QUEUE_BYTES:
+            sizes = client.get("qsizes")
+            if sizes is None:
+                sizes = client["qsizes"] = collections.deque()
+            behind = client["qbytes"] - (sizes[0] if sizes else 0)
+            if behind > WS_QUEUE_BYTES:
                 client["alive"] = False
                 try:
                     sock.shutdown(socket.SHUT_RDWR)
@@ -35610,11 +35627,12 @@ def _mk_ws_send(q, sock, client):
                     pass
                 # Raise: every caller already treats an exception from send as "mark this client dead".
                 # Logged HERE, once per client (_note_ws_drop): the drop is loud whichever caller's frame
-                # tipped the budget — the ~60 direct client["send"] replies as much as the push paths.
-                why = "%d bytes behind" % client["qbytes"]
+                # found the backlog past the budget — the ~60 direct client["send"] replies as much as the push paths.
+                why = "%d bytes behind" % behind
                 _note_ws_drop(client, why, len(s))
                 raise OSError("ws client %s is %s — dropping" % (client.get("app"), why))
             client["qbytes"] += len(s)
+            sizes.append(len(s))
         q.put(s)                               # unbounded; the byte budget above is the real bound
     return send
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -35544,15 +35544,19 @@ def _ws_accept(key):
 # stall being fixed here (caught by test_ws_send_bounded, which overran a 32-frame cap with 40 keepalives
 # a healthy client would have drained fine). Bytes track the thing that actually matters: a client behind
 # by 16 MB of view payloads has stopped reading, while any burst of ~40-byte keepalives is noise.
-# "Behind" is the bytes queued BEHIND the frame at the head of the queue, the one in flight or about to be
-# (T278, 2026-09-08): the budget bounds a peer that has stopped draining, not a frame that is simply big.
+# "Behind" is the bytes queued beyond the LARGEST frame in the queue (T278, 2026-09-08): one frame may be
+# arbitrarily big and is not the peer's fault; everything else waiting is the backlog, and the budget bounds a
+# peer that has stopped draining, not a frame that is simply big. The largest, not the head: a connect push
+# enqueues the small lanes skeleton, then the 17 MB bars, then two small frames within microseconds, and
+# whether the skeleton has left the queue by the time the small frames arrive is a scheduling accident.
 # The devbox's timeline-bars frame grew to 17.7 MB against this budget, so every fresh timeline connection
 # was dropped on its FIRST frame ("0 bytes behind"), reconnected, and was dropped again — 299 drops in one
 # evening, a 17 MB frame rebuilt and serialized several times a minute for nothing, and a laptop that never
 # saw this machine's bars. An empty queue accepts any frame; a healthy peer drains the head at wire speed
 # while the small deltas queue behind it; a wedged peer's stuck head lets the backlog behind it grow past
-# the budget, which is the drop. The head is tracked as a size deque beside the queue (qsizes): one sender
-# thread, one queue, so completions are FIFO and the head of the deque is the head of the queue.
+# the budget, which is the drop. Frame sizes ride a deque beside the queue (qsizes), appended and enqueued
+# as ONE step under the client's queue lock and popped as each frame completes: one sender thread, one
+# queue, so completions are FIFO and the deque mirrors the queue exactly.
 WS_QUEUE_BYTES = int(os.environ.get("ROMP_WS_QUEUE_BYTES", str(16 * 1024 * 1024)))
 
 
@@ -35607,20 +35611,22 @@ def _ws_sender(q, sock, lock, client):
                 client["qbytes"] -= len(s)
                 sizes = client.get("qsizes")
                 if sizes:
-                    sizes.popleft()            # this frame was the head; the next queued frame is now in flight
+                    sizes.popleft()            # this frame was the head of both; the next queued frame is now in flight
 
 
 def _mk_ws_send(q, sock, client):
-    """The client's `send`: enqueue, never block. With more than WS_QUEUE_BYTES queued BEHIND the frame at the
-    head of the queue the peer has stopped draining (T278: a frame that is merely big is delivered; see the
-    budget's comment), so the client is dropped and its socket shut down — which also unblocks its sender
-    thread, parked in a write that will now fail, instead of leaking it for the life of the kernel."""
+    """The client's `send`: enqueue, never block. With more than WS_QUEUE_BYTES queued beyond the largest queued
+    frame the peer has stopped draining (T278: a frame that is merely big is delivered; see the budget's
+    comment), so the client is dropped and its socket shut down — which also unblocks its sender thread,
+    parked in a write that will now fail, instead of leaking it for the life of the kernel. The size append and
+    the enqueue are one step under the queue lock: two producers (the pusher and the heartbeat, or a handler's
+    direct reply) interleaving between them would leave the deque in a different order from the queue."""
     def send(s):
         with client["qlock"]:
             sizes = client.get("qsizes")
             if sizes is None:
                 sizes = client["qsizes"] = collections.deque()
-            behind = client["qbytes"] - (sizes[0] if sizes else 0)
+            behind = client["qbytes"] - (max(sizes) if sizes else 0)
             if behind > WS_QUEUE_BYTES:
                 client["alive"] = False
                 try:
@@ -35635,7 +35641,7 @@ def _mk_ws_send(q, sock, client):
                 raise OSError("ws client %s is %s — dropping" % (client.get("app"), why))
             client["qbytes"] += len(s)
             sizes.append(len(s))
-        q.put(s)                               # unbounded; the byte budget above is the real bound
+            q.put(s)                           # unbounded, never blocks; the byte budget above is the real bound
     return send
 
 

--- a/tests/test_ws_drop_loud.py
+++ b/tests/test_ws_drop_loud.py
@@ -49,10 +49,11 @@ class _Sock:
         pass
 
 
-def _budgeted(app, wid, behind=10):
-    """A client with the kernel's OWN send (_mk_ws_send), `behind` bytes under the drop budget: the next
-    frame that size or larger tips it."""
-    client = {"app": app, "wid": wid, "alive": True, "qbytes": km.WS_QUEUE_BYTES - behind,
+def _budgeted(app, wid, over=10):
+    """A client with the kernel's OWN send (_mk_ws_send), already `over` bytes PAST the drop budget with
+    nothing in flight (T278: "behind" is the backlog behind the head frame, and a backlog past the budget
+    drops the client on its next frame, whatever that frame's size)."""
+    client = {"app": app, "wid": wid, "alive": True, "qbytes": km.WS_QUEUE_BYTES + over,
               "qlock": threading.Lock()}
     client["send"] = km._mk_ws_send(queue.Queue(), _Sock(), client)
     return client
@@ -160,7 +161,9 @@ class DroppedClientsAreLoud(unittest.TestCase):
         pre = json.dumps(first)
         km._send_slot(client, "feed", first, pre, km._dedup_sig(first, pre))
         self.assertIn("feed", client.get("dstate", {}), "the keyed full went, and the client is held as its base")
-        client["qbytes"] = km.WS_QUEUE_BYTES - 10                    # the next frame — a small delta — tips it
+        # the backlog BEHIND the held full (the head of the queue, in flight) is past the budget: the next
+        # frame — a small delta — drops it (T278: the head itself never counts as "behind")
+        client["qbytes"] = client["qsizes"][0] + km.WS_QUEUE_BYTES + 10
         second = feed("Wire the notes-api health route, then its test")
         pre2 = json.dumps(second)
         err, old = io.StringIO(), sys.stderr

--- a/tests/test_ws_send_bounded.py
+++ b/tests/test_ws_send_bounded.py
@@ -307,8 +307,9 @@ class WedgedClientCannotStallTheSendLoop(unittest.TestCase):
                 why = str(e)
                 break
         self.assertFalse(c["alive"], "the backlog behind the stuck head did pass the budget")
-        self.assertGreaterEqual(accepted, 8, "the frames that fit behind the head were accepted (%d)" % accepted)
-        self.assertLessEqual(accepted, 10)
+        # exact and deterministic: before the k-th small frame the backlog is (k-1) x 8 KiB, and the drop comes
+        # when it passes 64 KiB, at k = 10, so nine small frames were accepted behind the head
+        self.assertEqual(accepted, 9, "the frames that fit behind the head were accepted (%d)" % accepted)
         self.assertIn("bytes behind", why)
         behind = int(why.split(" is ")[1].split(" bytes")[0])
         self.assertLess(behind, len(head), "the count names the backlog, not the frame in flight")

--- a/tests/test_ws_send_bounded.py
+++ b/tests/test_ws_send_bounded.py
@@ -216,10 +216,10 @@ class WedgedClientCannotStallTheSendLoop(unittest.TestCase):
     # big. The devbox's timeline-bars frame grew to 17.7 MB against the 16 MiB budget, so every fresh
     # connection was dropped on its FIRST frame ("0 bytes behind"), reconnected, and was dropped again: 299
     # drops in one evening, a 17 MB frame rebuilt and serialized several times a minute for nothing, and a
-    # laptop that never saw this machine's bars. "Behind" is the bytes queued BEHIND the frame at the head
-    # of the queue (in flight, or about to be): an empty queue accepts any frame, a healthy peer drains the
-    # head at wire speed while small frames queue behind it, and a wedged peer's stuck head lets the
-    # backlog behind it grow past the budget, which is the drop.
+    # laptop that never saw this machine's bars. "Behind" is the bytes queued beyond the LARGEST frame in the
+    # queue (one frame may be arbitrarily big; the rest is the backlog): an empty queue accepts any frame, a
+    # healthy peer drains the big frame at wire speed while small frames queue behind it, and a wedged
+    # peer's stuck head lets the backlog behind it grow past the budget, which is the drop.
     def _budget(self, n):
         old = km.WS_QUEUE_BYTES
         km.WS_QUEUE_BYTES = n
@@ -287,11 +287,46 @@ class WedgedClientCannotStallTheSendLoop(unittest.TestCase):
             self.fail("an empty queue accepts any frame, got: %s" % e)
         self.assertTrue(c["alive"])
         self.assertEqual(c["qbytes"], len(big))
-        self.assertEqual(c["qsizes"][0], len(big), "the head of the queue is the frame in flight")
+        self.assertEqual(c["qsizes"][0], len(big), "the size deque mirrors the queue")
 
-    def test_bytes_behind_exclude_the_frame_being_written(self):
+    def test_a_small_frame_ahead_of_the_big_one_does_not_make_the_big_one_backlog(self):
+        """The connect push's shape: a small skeleton first, the big bars frame behind it, then two small
+        frames, all enqueued before the sender thread has necessarily written the skeleton. The big frame is
+        never the backlog whatever its position: the largest queued frame is the one that is merely big."""
+        self._budget(64 * 1024)
+        sock, _peer_never_reads = self._tcp_pair()
+        c, _q, _t = self._wire(sock)
+        c["send"]("s" * 4096)                                  # the skeleton, possibly still at the head
+        c["send"]("b" * (200 * 1024))                          # the bars, three times the budget
+        try:
+            c["send"]("t" * 512)                               # tabOrder
+            c["send"]("k" * 512)                               # caps
+        except OSError as e:
+            self.fail("the frames around a big one on a fresh connection must not be dropped, got: %s" % e)
+        self.assertTrue(c["alive"])
+
+    def test_the_size_append_and_the_enqueue_are_one_step_under_the_queue_lock(self):
+        """Two producers (the pusher and the heartbeat, or a handler's direct reply) interleaving between the
+        size append and the queue put would leave the size deque in a different order from the queue, and the
+        sender's positional pop would then credit the wrong frame. The put happens under the lock."""
+        test = self
+
+        class LockedPutQueue(queue.Queue):
+            def put(self, item, block=True, timeout=None):
+                test.assertTrue(c["qlock"].locked(), "q.put must run while the client's queue lock is held")
+                super().put(item, block, timeout)
+
+        q = LockedPutQueue()
+        c = {"app": "feed", "alive": True, "qbytes": 0, "qlock": threading.Lock()}
+        c["send"] = km._mk_ws_send(q, object(), c)             # no sender thread: the items stay queued
+        c["send"]("one")
+        c["send"]("two")
+        self.assertEqual(list(c["qsizes"]), [3, 3])
+        self.assertEqual([q.get_nowait(), q.get_nowait()], ["one", "two"])
+
+    def test_bytes_behind_exclude_the_largest_queued_frame(self):
         """A wedged peer with a big frame stuck at the head: the small frames queued BEHIND it are the
-        backlog, and the drop comes when that backlog, not the head, passes the budget."""
+        backlog, and the drop comes when that backlog, not the big frame, passes the budget."""
         self._budget(64 * 1024)
         sock, _peer_never_reads = self._tcp_pair()
         c, _q, _t = self._wire(sock)

--- a/tests/test_ws_send_bounded.py
+++ b/tests/test_ws_send_bounded.py
@@ -22,6 +22,7 @@ The fix is structural: each client owns a queue and a sender thread, and shared 
 Real TCP loopback throughout, matching the kernel's actual transport (AF_UNIX socketpairs behave
 differently again and would not represent it). Synthetic only: no session data.
 """
+import json
 import os
 import queue
 import socket
@@ -210,6 +211,108 @@ class WedgedClientCannotStallTheSendLoop(unittest.TestCase):
         self.assertEqual(got[0], 0x81)
         self.assertEqual(got[1], 127, "70000 bytes uses the 64-bit length form")
         self.assertEqual(bytes(got[10:70010]), body.encode(), "payload must arrive byte-exact")
+
+    # T278 (2026-09-08): the budget bounds a client that has STOPPED DRAINING, not a frame that is simply
+    # big. The devbox's timeline-bars frame grew to 17.7 MB against the 16 MiB budget, so every fresh
+    # connection was dropped on its FIRST frame ("0 bytes behind"), reconnected, and was dropped again: 299
+    # drops in one evening, a 17 MB frame rebuilt and serialized several times a minute for nothing, and a
+    # laptop that never saw this machine's bars. "Behind" is the bytes queued BEHIND the frame at the head
+    # of the queue (in flight, or about to be): an empty queue accepts any frame, a healthy peer drains the
+    # head at wire speed while small frames queue behind it, and a wedged peer's stuck head lets the
+    # backlog behind it grow past the budget, which is the drop.
+    def _budget(self, n):
+        old = km.WS_QUEUE_BYTES
+        km.WS_QUEUE_BYTES = n
+        self.addCleanup(setattr, km, "WS_QUEUE_BYTES", old)
+
+    @staticmethod
+    def _bars_payload(target_bytes):
+        """A synthetic {type:"bars"} frame, invented prompts under a placeholder sid, at least target_bytes long."""
+        sid = "11111111-2222-3333-4444-555555555555"
+        bars, i = [], 0
+        while len(json.dumps({"turns": {sid: bars}})) < target_bytes:
+            bars.append({"id": "t%d" % i, "promptId": "p%d" % i, "workId": "w%d" % i, "start": 1000 + 10 * i,
+                         "end": 1005 + 10 * i, "open": False, "cont": False, "prompt": "invented prompt %d" % i,
+                         "summary": "invented work caption %d" % i, "msgCaption": "gist %d" % i, "src": "typed",
+                         "mids": [], "pending": False, "tid": sid, "uuid": "u%d" % i, "nudgeAuto": False,
+                         "romp": False, "workUuid": "w%d" % i, "replyUuid": "r%d" % i})
+            i += 1
+        return {"type": "bars", "turns": {sid: bars}, "judging": [], "messages": [], "now": 2000, "warming": False}
+
+    def test_a_first_frame_larger_than_the_budget_is_delivered_whole(self):
+        """A fresh connection, an empty queue, a bars frame three times the budget: delivered byte-exact."""
+        self._budget(64 * 1024)
+        payload = self._bars_payload(3 * 64 * 1024)
+        body = json.dumps(payload)
+        self.assertGreater(len(body), km.WS_QUEUE_BYTES, "the fixture is bigger than the budget, as the devbox's frame is")
+        sock, peer = self._tcp_pair(sndbuf=1 << 20)
+        c, _q, _t = self._wire(sock)
+        got = bytearray()
+        want = len(body) + 10
+
+        def drain():
+            peer.settimeout(5)
+            while len(got) < want:
+                try:
+                    b = peer.recv(65536)
+                except OSError:
+                    return
+                if not b:
+                    return
+                got.extend(b)
+
+        t = threading.Thread(target=drain, daemon=True)
+        t.start()
+        try:
+            c["send"](body)
+        except OSError as e:
+            self.fail("a first frame on an empty queue must never be dropped, got: %s" % e)
+        t.join(10)
+        self.assertTrue(c["alive"])
+        self.assertEqual(got[0], 0x81)
+        self.assertEqual(got[1], 127, "the 64-bit length form")
+        n = int.from_bytes(bytes(got[2:10]), "big")
+        self.assertEqual(n, len(body))
+        self.assertEqual(json.loads(bytes(got[10:10 + n]).decode()), payload, "the whole frame, reassembled by the peer")
+
+    def test_a_fresh_connection_is_never_dropped_on_its_first_frame_even_to_a_wedged_peer(self):
+        """The budget is not a frame-size cap: with nothing queued, a frame five times the budget is accepted."""
+        self._budget(64 * 1024)
+        sock, _peer_never_reads = self._tcp_pair()
+        c, _q, _t = self._wire(sock)
+        big = "x" * (5 * 64 * 1024)
+        try:
+            c["send"](big)
+        except OSError as e:
+            self.fail("an empty queue accepts any frame, got: %s" % e)
+        self.assertTrue(c["alive"])
+        self.assertEqual(c["qbytes"], len(big))
+        self.assertEqual(c["qsizes"][0], len(big), "the head of the queue is the frame in flight")
+
+    def test_bytes_behind_exclude_the_frame_being_written(self):
+        """A wedged peer with a big frame stuck at the head: the small frames queued BEHIND it are the
+        backlog, and the drop comes when that backlog, not the head, passes the budget."""
+        self._budget(64 * 1024)
+        sock, _peer_never_reads = self._tcp_pair()
+        c, _q, _t = self._wire(sock)
+        head = "x" * (200 * 1024)
+        c["send"](head)
+        small = "y" * (8 * 1024)
+        accepted, why = 0, ""
+        for _ in range(40):
+            try:
+                c["send"](small)
+                accepted += 1
+            except OSError as e:
+                why = str(e)
+                break
+        self.assertFalse(c["alive"], "the backlog behind the stuck head did pass the budget")
+        self.assertGreaterEqual(accepted, 8, "the frames that fit behind the head were accepted (%d)" % accepted)
+        self.assertLessEqual(accepted, 10)
+        self.assertIn("bytes behind", why)
+        behind = int(why.split(" is ")[1].split(" bytes")[0])
+        self.assertLess(behind, len(head), "the count names the backlog, not the frame in flight")
+        self.assertGreater(behind, km.WS_QUEUE_BYTES)
 
     def test_the_sender_thread_ends_on_the_teardown_sentinel(self):
         """The handler's finally puts None so a closed pane does not leak its thread."""


### PR DESCRIPTION
The socket queue budget bounds the backlog behind the frame in flight, so a first frame larger than the budget is delivered instead of dropped.

Tier: fix

## Why
Between 7:30 and 8:00 PM PT on 2026-09-08 the devbox kernel dropped the laptop's timeline-bars socket hundreds of times (299 drop lines in the journal for the evening, 6 to 12 a minute, one window id), each with reason "0 bytes behind": `_mk_ws_send` dropped a client when queued bytes plus the frame exceeded `WS_QUEUE_BYTES`, and this machine's bars frame is 17.65 to 17.74 MB against a 16 MiB budget. Every reconnect was dropped on its first frame and reconnected, forever. The laptop's timeline pane never showed this machine's bars, and the kernel rebuilt and serialized a 17 MB frame several times a minute for nothing.

## What changed
`kernel/kernel.py`, `_mk_ws_send` and `_ws_sender`: "behind" is the bytes queued beyond the LARGEST frame in the client's queue: one frame may be arbitrarily big and is not the peer's fault, everything else waiting is the backlog. Frame sizes ride a deque beside the queue (`qsizes`), appended and enqueued as one step under the client's queue lock and popped as each frame completes; one sender thread and one queue make completions FIFO, so the deque mirrors the queue. The drop fires when the backlog exceeds the budget. Consequences:
- An empty queue accepts any frame, so a fresh connection is never dropped on its first frame, whatever its size.
- A healthy peer drains a big head at wire speed while the small deltas that follow queue behind it, well under the budget.
- A wedged peer's head never completes, the backlog behind it grows with every push and keepalive, and the client is dropped when that backlog passes the budget, as before. The liveness pings still catch a peer that answers nothing.
- The drop message names the backlog, not the big frame.
- The largest frame, not the head: a connect push enqueues the small lanes skeleton, then the 17 MB bars, then two small frames within microseconds, and whether the skeleton has left the queue by then is a scheduling accident. Measured against the largest queued frame, the small frames around a big one on a fresh connection can never read as backlog.

Chosen over sending the bars in parts: parts enqueued together add up to the same queued total, so the next frame would still have tripped a total-based budget; the budget itself was measuring the wrong thing. Shrinking the frame is left for a follow-up with a measured field breakdown (see Evidence).

## Tests
`tests/test_ws_send_bounded.py`, real loopback pairs like the rest of the file, with the budget patched to 64 KiB: a synthetic bars frame three times the budget (invented prompts under a placeholder sid) is delivered whole and byte-exact to a draining peer; a fresh connection is never dropped on its first frame even when the peer never reads; with a big frame stuck at the head, exactly nine 8 KiB frames are accepted behind it before the backlog passes the 64 KiB budget, and the drop names a count smaller than the big frame; the connect push's shape (small, big, small, small) is never dropped; a queue whose put asserts the client's lock pins that the size append and the enqueue are one step. `tests/test_ws_drop_loud.py`: the fixtures that sat 10 bytes under the budget now sit past it, and the delta-path case puts the backlog behind its held full past the budget, the rule those tests pin. The wedged-client, keepalive-burst, walk-starvation and byte-exact tests are unchanged and green.

## Evidence
Before, from the devbox journal (read-only): 299 `dropping timeline client` lines between 02:00 and 04:00 UTC on 2026-09-09, every one `0 bytes behind`, `queued=0B`, frame 17,649,511 to 17,740,614 bytes. The frame size is unchanged by this fix; what changes is that it is delivered once per connection and then followed by deltas, so the rebuild-and-drop loop ends. A measuring client cannot be attached to the running kernel, since it drops that client on the same first frame; the after-deploy measurement and a field breakdown for a shrink follow-up come in the report once this lands.

## Review (three lenses, two skeptics per finding)
Confirmed and folded: the queue put ran outside the client's queue lock, so two producers could interleave between the size append and the put and the sender's positional pop would credit the wrong frame (four skeptic confirmations); the accepted-count assertion was a window where the exact value is nine; a comment on the tag-edit acknowledgement still described a lone big reply as a budget drop. Refuted as pre-existing or timing-bound: a peer wedged mid-frame is judged by the ping path only once the ping reaches the socket (unchanged by this fix), the bell row's figure includes the big frame (true as stated), and the connect-time scenario above, which the largest-frame rule now rules out by construction rather than by loopback timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
