### PR TITLE
Kernel: the cut-turn reaper stops only the CLI's own scope, never one it inherited (T276 review fold)

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2729,6 +2729,17 @@ def _read_cgroup(pid: int) -> str:
         return ""
 
 
+def _read_starttime(pid: int) -> int | None:
+    """The process start time (clock ticks since boot, /proc/<pid>/stat field 22) — a pid's identity across a
+    reuse; None where it cannot be read (no procfs, the pid gone)."""
+    try:
+        with open("/proc/%d/stat" % pid) as f:
+            tail = f.read().rsplit(")", 1)[1].split()
+        return int(tail[19])
+    except (OSError, IndexError, ValueError):
+        return None
+
+
 def _read_ppid(pid: int) -> int | None:
     """The parent pid from /proc/<pid>/stat, or None where it cannot be read."""
     try:
@@ -7136,11 +7147,23 @@ class SdkBackend:
         run = run or subprocess.run
         cgroup = cgroup or _read_cgroup
         unit = scope_unit_of(cgroup(pid) or "")
+        # The scope must be the CLI's OWN: bin/romp-cli-scope names the unit with the pid the CLI runs as
+        # (`romp-session-<sid8>-$$-$t`, then execs into it), so a CLI in its own scope always carries its pid
+        # in the name. A CLI whose cgroup names a scope with ANOTHER pid merely INHERITED it — a kernel launched
+        # from inside a romp session's tool shell spawns CLIs inside that session's scope — and stopping that
+        # unit would end the launching session, not the orphan (the lean review of T276, 2026-09-09: the
+        # real-process test did exactly that to the session running it). Such a CLI is treated as unscoped.
+        if unit and scope_pid(unit) != pid:
+            self._log("cut-turn reap: pid %d sits in %s, a scope it did not start (inherited) — tree walk only" % (pid, unit))
+            unit = None
         stopped = False
         if unit:
             try:
-                run(["systemctl", "--user", "stop", unit], capture_output=True, text=True, timeout=SCOPE_STOP_TIMEOUT)
-                stopped = True
+                res = run(["systemctl", "--user", "stop", unit], capture_output=True, text=True, timeout=SCOPE_STOP_TIMEOUT)
+                stopped = (getattr(res, "returncode", 0) == 0)
+                if not stopped:
+                    err = ((getattr(res, "stderr", "") or "").strip().splitlines() or ["(no stderr)"])[0]
+                    self._log("cut-turn reap: systemctl stop %s exited %s: %s; the tree walk still runs" % (unit, getattr(res, "returncode", "?"), err))
             except Exception as e:
                 self._log("cut-turn reap: stopping %s failed (%s); falling back to the process tree" % (unit, e))
         own_pg = None
@@ -7149,11 +7172,19 @@ class SdkBackend:
         except OSError:
             pass
         targets = [p for p in descendants(ps_lines, pid) if p != os.getpid()] + [pid]
+        # a pid reused by an unrelated process between the ps snapshot and a signal must not be hit: remember
+        # each target's start time (procfs) and skip any whose identity changed; no procfs → no such check
+        born = {p: _read_starttime(p) for p in targets}
+        def same(p) -> bool:
+            b = born.get(p)
+            return b is None or _read_starttime(p) == b
         def signal_all(sig, only_alive: bool) -> int:
             n = 0
             for p in targets:
                 if only_alive and not self._pid_alive(p):
                     continue
+                if not same(p):
+                    continue          # the pid now names another process
                 try:
                     pg = os.getpgid(p)
                 except OSError:

--- a/tests/test_cut_turn_tree_kill.py
+++ b/tests/test_cut_turn_tree_kill.py
@@ -126,6 +126,30 @@ class ScopePath(unittest.TestCase):
         self.assertEqual(out["scope"], unit)
         self.assertEqual(out["tree"], 0)
 
+    def test_an_inherited_scope_is_never_stopped_only_the_clis_own(self):
+        # the lean review of T276 (2026-09-09): the real-process test's fake CLI sat in the cgroup of the romp
+        # session running the tests, and the reaper stopped THAT session's scope. A scope is the CLI's own
+        # only when the unit name carries the CLI's pid (bin/romp-cli-scope names it so and execs into it).
+        be = _backend()
+        runs, killed = [], []
+        inherited = "romp-session-49985d8b-%d-1757374700.scope" % (CLI + 7)   # another pid: not this CLI's scope
+        cg = lambda pid: "0::/user.slice/user-1000.slice/user@1000.service/app.slice/%s\n" % inherited
+        ps = "  %d %d /x/claude --input-format stream-json --resume %s\n" % (CLI, MANAGER, SID)
+        out = be._end_cli_tree(CLI, ps.splitlines(), kill=lambda p, s: killed.append((p, s)),
+                               run=lambda *a, **k: runs.append(list(a[0])), cgroup=cg)
+        self.assertEqual(runs, [], "no systemctl: the unit is not this CLI's, so stopping it would end someone else's session")
+        self.assertEqual(killed, [(CLI, signal.SIGTERM)], "the tree walk alone")
+        self.assertIsNone(out["scope"])
+
+    def test_a_failed_stop_is_not_reported_as_stopped(self):
+        be = _backend()
+        unit = "romp-session-11111111-%d-1757374800.scope" % CLI
+        cg = lambda pid: "0::/user.slice/user-1000.slice/user@1000.service/app.slice/%s\n" % unit
+        run = lambda argv, **kw: mock.Mock(stdout="", stderr="Failed to stop: Unit not loaded.", returncode=5)
+        out = be._end_cli_tree(CLI, ("  %d 1 /x/claude --input-format stream-json --resume %s\n" % (CLI, SID)).splitlines(),
+                               kill=lambda p, s: None, run=run, cgroup=cg)
+        self.assertIsNone(out["scope"], "a nonzero systemctl is not a stopped scope; the tree walk still ran")
+
     def test_a_cli_with_no_scope_falls_back_to_the_tree_children_first(self):
         be = _backend()
         runs, killed = [], []
@@ -180,7 +204,8 @@ class BootReconcileEndsTheTree(unittest.TestCase):
         def run(argv, **kw):
             runs.append(list(argv)); return mock.Mock(stdout=ps if argv == sb.PS_ARGV else (listing if argv == sb.SCOPE_LIST_ARGV else ""), returncode=0)
         with mock.patch.object(sb.subprocess, "run", side_effect=run), \
-             mock.patch.object(sb.os, "kill", side_effect=lambda p, s: killed.append((p, s))):
+             mock.patch.object(sb.os, "kill", side_effect=lambda p, s: killed.append((p, s))), \
+             mock.patch.object(sb.SdkBackend, "_pid_alive", lambda self, p: False):   # fake pids read as gone on every platform (no /proc on macOS → os.kill(pid, 0) would be this mock)
             be._boot_reconcile([sb.read_reg(Path(d), SID)])
         self.assertEqual([p for p, _ in killed], [TOOL, LOOP, CLI], "the orphan's tree, children first, then the CLI; the tmux CLI and the live CLI untouched")
         self.assertEqual(runs[0], sb.PS_ARGV, "the listing is read first, with PS_ARGV")
@@ -193,7 +218,10 @@ class BootReconcileEndsTheTree(unittest.TestCase):
 class RealProcessTree(unittest.TestCase):
     """The fixture the dispatch asked for: a 'session' (a fake CLI shell) whose child spawns a DETACHED sleep loop;
     after the simulated cut — the reaper ending the orphaned CLI's tree — the loop is gone, and a bystander outside
-    the tree is untouched. No scope here (ROMP_CLI_SCOPE=0), so this is the process-group fallback."""
+    the tree is untouched. The cgroup seam is pinned EMPTY: the fake CLI inherits the cgroup of whatever runs
+    the tests (a romp session's own scope, when run from one — ROMP_CLI_SCOPE=0 only governs spawned CLIs), and
+    the reaper's own pid check would already refuse that unit, but this class is about the process-group
+    fallback, so it never consults the real cgroup at all."""
 
     def _tree(self):
         marker = "romp-t276-loop-" + uuid.uuid4().hex
@@ -229,7 +257,7 @@ class RealProcessTree(unittest.TestCase):
         loop_pids = [p for p in self._marker_pids(marker) if p != cli.pid]   # the fake CLI's own argv carries the marker too
         self.assertTrue(loop_pids and all(p in sb.descendants(ps, cli.pid) for p in loop_pids),
                         "the setsid'd loop is still the CLI's descendant by ppid: %r vs %r" % (loop_pids, sb.descendants(ps, cli.pid)))
-        out = be._end_cli_tree(cli.pid, ps)
+        out = be._end_cli_tree(cli.pid, ps, cgroup=lambda p: "")
         deadline = time.time() + 5
         while time.time() < deadline and (self._marker_pids(marker) or cli.poll() is None):
             time.sleep(0.05)


### PR DESCRIPTION
Follow-up from the adversarial review of #1139, which found a blocker.

`_end_cli_tree` read the CLI's `/proc/<pid>/cgroup` and stopped whatever `romp-session-*` scope it named. A CLI in its own scope always carries its pid in the unit name (`bin/romp-cli-scope` names the unit `romp-session-<sid8>-$$-$t` and execs into it); a CLI whose cgroup names a scope with another pid merely **inherited** it, as every process does that a romp session's tool shell starts, a kernel launched there and its CLIs included. Stopping that unit ended the launching session, not the orphan. The branch's own real-process test did exactly that to the session running the suite.

- **Fix.** The reaper requires the CLI's own pid in the unit name and otherwise treats the CLI as unscoped (tree walk only), logging the inherited unit. Red-first: an inherited scope is never stopped and only the CLI is signaled.
- **Also from the review.** A nonzero `systemctl stop` is no longer reported as a stopped scope (return code read, stderr's first line logged). Each target's start time is captured at the `ps` snapshot and a pid whose identity changed during the grace is skipped. The real-process test pins the cgroup seam empty (its docstring no longer claims `ROMP_CLI_SCOPE=0` removes the inherited cgroup), and the reconcile-level test pins fake pids as gone on every platform.
- **Tests.** `tests/test_cut_turn_tree_kill.py` gains the inherited-scope and failed-stop cases; the existing tree-kill, reaper and scope pins hold (134 passed together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
