### PR TITLE
Kernel: a safeguards refusal the CLI retried on a fallback model is filed and shown, not logged as unhandled

### DIFF
--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -140,11 +140,16 @@ interface Trigger {
 interface Atom {
   // Parity with the streaming API:
   type: "assistant" | "user" | "system" | "result" | "idle";   // "idle" is ours
-  subtype?: "compact_boundary" | "status" | "task_notification"; // when type==="system"
+  subtype?: "compact_boundary" | "status" | "task_notification"
+          | "model_refusal_fallback";                          // when type==="system"
   uuid: string;             // message id (same value in stream and transcript)
   session_id: string;       // = rompUuid
   message?: ApiMessage;     // assistant/user: the Anthropic message object (below)
   compact_metadata?: { trigger: "auto" | "manual"; pre_tokens: number }; // system:compact_boundary
+  content?: string; fallback_from?: string; fallback_to?: string;   // system:model_refusal_fallback — the CLI's
+  refusal_category?: string; refusal_explanation?: string;          //   line, the swap, the refusal's category and
+  scope?: "session" | "local";                                      //   the API's explanation ("" when the record
+                                                                    //   carried none), the scope (absent = session)
   result?: {                // type==="result"
     subtype: "success" | "error_during_execution" | "error_max_turns" | string;
     num_turns: number; stop_reason: string | null;

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -2148,6 +2148,13 @@ class FileAdapter:
                        "content": r.get("content") or "",          # the CLI's full explanation
                        "fallback_from": r.get("originalModel") or "",
                        "fallback_to": r.get("fallbackModel") or "",
+                       # T279: the refusal category (an open string; null when neither lane carried one),
+                       # the API's explanation (display-only prose; null on server-lane banners) and the
+                       # scope ('session' = the session model is swapped; 'local' = a subagent's or a
+                       # side question's reply only; absent on older CLIs = session)
+                       "refusal_category": r.get("apiRefusalCategory") or "",
+                       "refusal_explanation": r.get("apiRefusalExplanation") or "",
+                       "scope": r.get("scope") or "session",
                        "_seq": seq}
             # other system subtypes (turn_duration, stop_hook_summary, local_command,
             # away_summary) are harness bookkeeping, not conversational messages -> skipped.

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -12301,6 +12301,13 @@ def mint_fallback_card(sid, from_model, to_model, ev_t=None):
                     and prev.get("text") == text and not prev.get("cleared") \
                     and prev.get("id") not in vc:
                 return None
+            # T279: the same swap is already on the board WITH its cause — a safeguards refusal the CLI
+            # retried on the fallback (a CLI that streams that notice ahead of the reply); the capacity
+            # reading of the down-tier transition stands down rather than filing a second card.
+            if prev.get("why") == REFUSAL_FALLBACK_WHY and not prev.get("cleared") \
+                    and prev.get("id") not in vc \
+                    and prev.get("swap") == {"from": from_model or "?", "to": to_model or "?"}:
+                return None
         n = store.get("seq", 0) + 1
         store["seq"] = n
         gid = "%s:g%d" % (sid, n)
@@ -12309,7 +12316,7 @@ def mint_fallback_card(sid, from_model, to_model, ev_t=None):
                "capacity fallback, not a pick. Work continued on the fallback; switch back from the "
                "statusline if that isn't what you want."
                % (from_model or "the pinned model", to_model))
-        nd = GuardedNode({"id": gid, "text": text,
+        nd = GuardedNode({"id": gid, "text": text, "swap": {"from": from_model or "?", "to": to_model or "?"},
                           "parentId": None, "nodeComplete": False, "blocked": False, "cleared": False,
                           "trail": [], "promptUuid": "", "quote": "", "t": t, "mt": t,
                           "why": "kernel-observed API model fallback", "log": []})
@@ -12322,6 +12329,151 @@ def mint_fallback_card(sid, from_model, to_model, ev_t=None):
         sys.stderr.write("fallback-card mint (%s): %r\n" % (sid[:8], e))
         return None
 
+
+REFUSAL_FALLBACK_WHY = "kernel-observed safeguards refusal fallback"     # the refusal card's why key (T279)
+CAPACITY_FALLBACK_WHY = "kernel-observed API model fallback"            # mint_fallback_card's, as it spells it
+
+
+def _refusal_fallback_texts(from_model, to_model, category, explanation, scope):
+    """The refusal card's title and done-why. The title carries the swap and the category (the head the
+    chat notice shows); the why carries the cause, the API's explanation when it sent one (the notice's
+    fold), and what to do about it. 'local' scope: only that reply came from the fallback model."""
+    to = to_model or "a fallback model"
+    cat = (category or "").strip()
+    expl = (explanation or "").strip()
+    local = (scope or "session") == "local"
+    cat_part = (" (%s)" % cat) if cat else ""
+    if local:
+        text = "A reply came from %s after a safeguards refusal%s" % (to, cat_part)
+    else:                                    # the swap LAST: mint_fallback_card's stand-down matches on it
+        text = "Model changed after a safeguards refusal%s: %s → %s" % (cat_part, from_model or "?", to)
+    why = ("The model's safeguards flagged a message%s and the request was retried on %s: a refusal "
+           "fallback, not a pick." % ((" (category: %s)" % cat) if cat else "", to))
+    if expl:
+        why += " The API's explanation: %s%s" % (expl, "" if expl.endswith((".", "!", "?")) else ".")
+    if local:
+        why += (" Only that reply (a subagent's or a side question's) came from %s; the session's model "
+                "is unchanged." % to)
+    else:
+        why += " Work continued on %s; switch back from the statusline if that isn't what you want." % to
+    return text, why
+
+
+def _swap_of(nd):
+    """(from, to) of a fallback card: the `swap` field, or, for a capacity card minted before the field
+    existed, the two names its title spells ("Model changed automatically: A → B")."""
+    sw = nd.get("swap")
+    if isinstance(sw, dict) and sw.get("from") and sw.get("to"):
+        return str(sw["from"]), str(sw["to"])
+    text = str(nd.get("text") or "")
+    if ": " in text and " → " in text:
+        a, _, b = text.split(": ", 1)[1].partition(" → ")
+        if a and b:
+            return a.strip(), b.strip()
+    return None
+
+
+def _chain_cards(cards, origin, target):
+    """The fallback cards that lie on a path origin → … → target through `cards` (each a (from, to)
+    pair keyed by id): a card is on the chain when its `from` is reachable from the origin and the
+    target is reachable from its `to`. A multi-hop refusal (the first fallback refused too) learned a
+    card per hop; a card off the path (another swap this turn) is never claimed."""
+    fwd = {origin}
+    changed = True
+    while changed:
+        changed = False
+        for a, b in cards.values():
+            if a in fwd and b not in fwd:
+                fwd.add(b); changed = True
+    bwd = {target}
+    changed = True
+    while changed:
+        changed = False
+        for a, b in cards.values():
+            if b in bwd and a not in bwd:
+                bwd.add(a); changed = True
+    return [cid for cid, (a, b) in cards.items() if a in fwd and b in bwd]
+
+
+def _claimable(store, nd, vc):
+    """A fallback card the bookkeeping may fold: uncleared, and untouched by the user (no follow-up in
+    flight, no user stamp) — the user's gesture outranks the bookkeeping."""
+    return not nd.get("cleared") and nd.get("id") not in vc \
+        and not _floor_of(store, nd) and not nd.get("followupPending")
+
+
+def mint_refusal_fallback_card(sid, from_model, to_model, category=None, explanation=None,
+                               scope="session", ev_t=None, capacity_gids=None, episode=None):
+    """A COMPLETED card recording a SAFEGUARDS refusal the CLI retried on a fallback model (T279): the
+    model's classifier declined the request (the API's stop_reason "refusal") and the CLI re-ran the
+    call on the configured fallback, so the reply that followed came from a different model, for a
+    reason the user should see: the refusal category, and the API's explanation when it sent one.
+    Same shape as mint_fallback_card (kernel-authored bookkeeping, minted done, never a question;
+    existence-keyed dedupe while an identical uncleared card is on the board), with its own why key,
+    the swap as data (`swap`, for both mints' dedupes), the episode key (`episode`: the refused prompt's
+    uuid) and prose that names the refusal, never "capacity".
+
+    ONE card per swap. The fallback model's own reply streams BEFORE the CLI's end-of-turn refusal
+    notice, and its model learn has already filed the swap as a capacity fallback (a down-tier
+    transition nobody asked for is all _learn_model can see). The backend names the cards its own
+    learn minted THIS turn (`capacity_gids`; never an older card that reads the same), and those that
+    lie on the chain from the refused model to the answering one (_chain_cards: a multi-hop refusal
+    learned a card per hop) are FOLDED into the fresh refusal card with the store's merge
+    (_merge_nodes): the refusal node is new, so a concurrent writer's save adopts it wholesale, and
+    each folded card's deletion is a durable tombstone (mergedFrom) the rebase honors from either
+    side — no field of an existing node is rewritten, so no stale snapshot can half-revert it. The
+    same fold retires an earlier refusal card of the SAME episode (a CLI that files an intermediate
+    hop unmarked): the final frame's card is the record. The user's gesture outranks the bookkeeping:
+    a card the user cleared, followed up on, or otherwise stamped (_claimable) is left exactly as they
+    left it and the refusal files fresh beside it. `scope` per the CLI's schema: 'session' (the
+    session's model is swapped) or 'local' (a subagent's or a side question's reply only; the
+    session's model is unchanged; absent on older CLIs = session); a 'local' refusal claims no
+    capacity card. The rollup runs with session_closed=False: the card completes on its own (it is
+    never the session's focus), and a swap's information must not force the settle of the focus
+    card."""
+    try:
+        store = load_goals(sid)
+        nodes = store.setdefault("nodes", {})
+        text, why = _refusal_fallback_texts(from_model, to_model, category, explanation, scope)
+        swap = {"from": from_model or "?", "to": to_model or "?"}
+        local = (scope or "session") == "local"
+        vc = _view_cleared()
+        for prev in nodes.values():
+            if prev.get("why") == REFUSAL_FALLBACK_WHY and prev.get("text") == text \
+                    and not prev.get("cleared") and prev.get("id") not in vc:
+                return None                          # the board already says exactly this
+        t = int(ev_t or time.time())
+        n = store.get("seq", 0) + 1
+        store["seq"] = n
+        gid = "%s:g%d" % (sid, n)
+        nd = GuardedNode({"id": gid, "text": text, "swap": swap, "episode": episode or "",
+                          "parentId": None, "nodeComplete": False, "blocked": False, "cleared": False,
+                          "trail": [], "promptUuid": "", "quote": "", "t": t, "mt": t,
+                          "why": REFUSAL_FALLBACK_WHY, "log": []})
+        nodes[gid] = nd
+        record_verdict(store, nd, "romp", "done", t, why=why)
+        fold = []
+        if not local:
+            cands = {}
+            for cid in (capacity_gids or []):
+                cap = nodes.get(cid)
+                sw = _swap_of(cap) if cap is not None else None
+                if sw and cap.get("why") == CAPACITY_FALLBACK_WHY and _claimable(store, cap, vc):
+                    cands[cid] = sw
+            fold += _chain_cards(cands, swap["from"], swap["to"])
+        if episode:
+            fold += [pid for pid, prev in list(nodes.items())
+                     if pid != gid and prev.get("why") == REFUSAL_FALLBACK_WHY
+                     and prev.get("episode") == episode and _claimable(store, prev, vc)]
+        for did in fold:
+            _merge_nodes(store, did, gid, t, "the same swap, filed with its cause: a safeguards refusal "
+                                             "the CLI retried on the fallback model")
+        rollup_status(store, False)                # the fold materializes nodeComplete/doneWhy from the diary
+        save_goals(sid, store)
+        return gid
+    except Exception as e:
+        sys.stderr.write("refusal-fallback card mint (%s): %r\n" % (sid[:8], e))
+        return None
 
 NUDGE_REDUNDANT_SYS = (
     "You answer one question about a working session, from its own latest message. The user message "

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14000,6 +14000,14 @@ def _sdk_locked():
             # observes the transition; the judge store owns the card; the kernel wires the two
             type(_sdk_backend).on_model_fallback = staticmethod(
                 lambda sid, frm, to: (jd.mint_fallback_card(sid, frm, to), _push_soon()))
+            # a SAFEGUARDS refusal the CLI retried on a fallback model (T279): the same wiring shape —
+            # the backend observes the frame (and names the capacity card this turn's learn minted for
+            # the swap), the judge store files the refusal and folds that card into it, the kernel
+            # wires the two
+            type(_sdk_backend).on_model_refusal_fallback = staticmethod(
+                lambda sid, frm, to, cat, expl, scope, caps, ep: (
+                    jd.mint_refusal_fallback_card(sid, frm, to, cat, expl, scope, capacity_gids=caps, episode=ep),
+                    _push_soon()))
             # a version the CLI REFUSED must leave the pick memory too: the backend rules on the CLI's
             # answer, the kernel owns model-picks.json — the same wiring shape
             type(_sdk_backend).on_model_refused = staticmethod(_model_pick_refused)
@@ -29712,10 +29720,15 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
             elif a["type"] == "system" and a.get("subtype") == "model_refusal_fallback":
                 # Safeguards flagged the prompt and the CLI retried the turn on a fallback model — the
                 # reply that follows came from a DIFFERENT model, and the swap must be visible in the
-                # chat, never silent (the user 2026-08-03). Raw model ids; the client prettifies.
+                # chat, never silent (the user 2026-08-03). Raw model ids; the client prettifies. The
+                # refusal's category (the notice's head) and the API's explanation (its fold) ride along,
+                # with the scope: 'session' = the session model is swapped, 'local' = one reply (T279).
                 events.append({"kind": "modelFallback", "uuid": a.get("uuid"), "ts": ts,
                                "from": a.get("fallback_from") or "", "to": a.get("fallback_to") or "",
-                               "md": a.get("content") or ""})
+                               "md": a.get("content") or "",
+                               "category": a.get("refusal_category") or "",
+                               "explanation": a.get("refusal_explanation") or "",
+                               "scope": a.get("scope") or "session"})
     # Agent/Task cards: the agent join, the running preview, the landed report (plans/subagent-transcripts.md).
     # Tail events only in fold mode — the sealed prefix's cards are gated by _chat_agents_moved and held
     # open by _chat_agent_open_at below.

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3662,6 +3662,7 @@ class SdkSession:
         # BEFORE the ResultMessage that carries api_error_status, so the settle pairs the two.
         self.auth_label = "unknown"
         self._ah_turn = 0
+        self._swap_cards = []        # (pretty from, pretty to, card gid) per capacity fallback learned this turn (T279)
         self._ah_gaveup = None
         self._interrupted = False                    # user interrupted the in-flight turn → snapshot reads 'waiting' (display only; inflight stays event-driven)
         self._intr_level = 0                         # interrupt escalation rung this episode (interrupt_action); reset on settle / fresh turn
@@ -4954,7 +4955,19 @@ class SdkSession:
             fb = getattr(type(self.backend), "on_model_fallback", None)
             if fb:
                 try:
-                    fb(self.sid, self.model, pm)
+                    ret = fb(self.sid, self.model, pm)
+                    # T279: keep the swap and the card it minted until the turn settles. A safeguards
+                    # refusal the CLI retried on the fallback model looks exactly like this from here
+                    # (the retried leg streams on the fallback model), and its cause arrives only in the
+                    # CLI's END-OF-TURN model_refusal_fallback notice — whose filing then folds exactly
+                    # this card, by id, into the refusal card (one swap, one card). The kernel's hook
+                    # returns (gid, ...); a test double may return None.
+                    gid = ret[0] if isinstance(ret, tuple) and ret else (ret if isinstance(ret, str) else None)
+                    if gid:
+                        cards = getattr(self, "_swap_cards", None)     # (__new__-built doubles skip __init__)
+                        if cards is None:
+                            cards = self._swap_cards = []
+                        cards.append((self.model, pm, gid))
                 except Exception as e:
                     self.backend._log("model-fallback card (%s): %s" % (self.name, e), problem=True)
         self.model = pm
@@ -4967,6 +4980,46 @@ class SdkSession:
         except Exception as e:
             self.backend._log("model learn (%s): registry write failed: %s" % (self.name, e))
         self.backend._poke()
+
+    def _on_refusal_fallback(self, d: dict):
+        """File a streamed model_refusal_fallback frame through the kernel-wired hook (the branch in
+        _on_message). PRETTY names, like the capacity path's learn (self.model / pm), so the swap the
+        notice names is the swap the learn recorded. A null category / explanation becomes "" (the
+        schema: null is normal, not an error); an absent scope is 'session'. The frame carries every
+        capacity card this turn's learn minted (_swap_cards) and the episode key (the refused prompt's
+        uuid), so the store can fold the cards that belong to this swap. Loud where the frame or the
+        wiring is broken: a frame without model ids (the schema marks both required) is a logged problem
+        and files nothing rather than a card reading "? → a fallback model"; an unwired hook is said once
+        per kernel life, never a silent drop. A `provisional` frame (an intermediate hop of a multi-hop
+        chain: the first fallback refused too) files like any other: on the CLI's chain path no final
+        frame need follow it, so skipping it would drop the filing, and a later hop of the same episode
+        folds its card in the store. A failing hook is a logged problem, never a raise into the stream
+        loop."""
+        if not isinstance(d, dict) or not d.get("original_model") or not d.get("fallback_model"):
+            self.backend._log("sdk: model_refusal_fallback frame without model ids — keys=%r; nothing filed"
+                              % (sorted(d)[:20] if isinstance(d, dict) else type(d).__name__,), problem=True)
+            return
+        frm = pretty_model(str(d.get("original_model") or ""))
+        to = pretty_model(str(d.get("fallback_model") or ""))
+        cat = str(d.get("api_refusal_category") or "").strip()
+        expl = str(d.get("api_refusal_explanation") or "").strip()
+        scope = str(d.get("scope") or "session")
+        episode = str(d.get("refused_user_message_uuid") or "")
+        # A 'local' refusal (a subagent's or a side question's reply) never swapped the session's model,
+        # so none of this turn's cards is its own.
+        caps = [] if scope == "local" else [c[2] for c in (getattr(self, "_swap_cards", None) or []) if c[2]]
+        hook = getattr(type(self.backend), "on_model_refusal_fallback", None)
+        if not hook:
+            memo = "model_refusal_fallback:no-hook"
+            if memo not in SdkSession._sys_subtypes_seen:
+                SdkSession._sys_subtypes_seen.add(memo)
+                self.backend._log("sdk: a model_refusal_fallback frame arrived but no on_model_refusal_fallback "
+                                  "hook is wired — the refusal is not filed (first seen this kernel life)")
+            return
+        try:
+            hook(self.sid, frm, to, cat, expl, scope, caps, episode)
+        except Exception as e:
+            self.backend._log("refusal-fallback card (%s): %s" % (self.name, e), problem=True)
 
     def _resolve_model_pending(self, pm) -> bool:
         """If a /model switch is pending and the observed live name `pm` now reflects the chosen alias,
@@ -5426,6 +5479,18 @@ class SdkSession:
             # off subtype+data (the typed subclasses need a newer SDK; the raw payload is identical).
             # Terminal statuses clear from EITHER message kind — a TaskStop can suppress the notification.
             self._on_task_event(msg.subtype, msg.data if isinstance(msg.data, dict) else {})
+        elif isinstance(msg, SystemMessage) and msg.subtype == "model_refusal_fallback":
+            # The CLI's structured record of a SAFEGUARDS refusal it retried on a fallback model (T279):
+            # the model's classifier declined the request and the turn re-ran on the configured fallback,
+            # so the reply that follows came from a different model, for a reason the user should see.
+            # Fields per the CLI's stream-json schema (bundled CLI 2.1.259): original_model /
+            # fallback_model; api_refusal_category (an open string; new categories ship ahead of schema
+            # updates; null when neither lane carried one, which is normal); api_refusal_explanation
+            # (display-only prose; null on server-lane banners); scope ('session': the session model is
+            # swapped; 'local': a subagent / side reply only; absent on older CLIs, read as session).
+            # Filed for the judges through the kernel-wired hook, the on_model_fallback way. The chat
+            # notice itself comes from the transcript record (event_model -> build_session modelFallback).
+            self._on_refusal_fallback(msg.data if isinstance(getattr(msg, "data", None), dict) else {})
         elif isinstance(msg, SystemMessage):
             # A subtype no branch above handles. Logged ONCE per subtype per kernel life (keys only, no
             # values): the CLI's stream-json allowlist decides what reaches us, and a frame kind it
@@ -5586,6 +5651,8 @@ class SdkSession:
                 # the CLI, its next streamed atom re-asserts 'working' via _forward — the stream is the truth.
                 self.inflight = 0
                 self._inflight_texts.clear()           # the CLI processed everything fed — same settle semantics
+                self._swap_cards = []                  # T279: a capacity card learned this turn is claimable only by
+                #                                        this turn's refusal notice — the settle is the deciding event
                 # A /compact that found NOTHING to compact emits no boundary — the turn just settles here. Clear
                 # the authoritative flag so parked ops proceed immediately, instead of waiting out a 180s cap.
                 self._compacting = False

--- a/tests/test_model_fallback_notice.py
+++ b/tests/test_model_fallback_notice.py
@@ -34,6 +34,8 @@ T0 = NOW - 3600
 
 NOTICE = ("The model's safeguards flagged this message. Switched to a fallback model. "
           "Send feedback with /feedback.")
+CATEGORY = "synthetic-category"
+EXPLANATION = "a synthetic explanation of the refusal"
 
 
 def iso(t):
@@ -58,7 +60,10 @@ def refusal_turn_records():
         {"type": "system", "subtype": "model_refusal_fallback", "timestamp": iso(T0 + 5),
          "uuid": "sfb", "parentUuid": "a1", "direction": "retry", "trigger": "refusal",
          "level": "warning", "content": NOTICE,
-         "originalModel": "claude-fable-5", "fallbackModel": "claude-opus-5"},
+         "originalModel": "claude-fable-5", "fallbackModel": "claude-opus-5",
+         # T279: the refusal's category (an open string; null when neither lane carried one) and the
+         # API's explanation (display-only prose; null on server-lane banners), plus the scope
+         "scope": "session", "apiRefusalCategory": CATEGORY, "apiRefusalExplanation": EXPLANATION},
     ]
 
 
@@ -77,6 +82,15 @@ class ParseEmitsTheFallbackAtom(unittest.TestCase):
         self.assertEqual(fb[0]["fallback_from"], "claude-fable-5")
         self.assertEqual(fb[0]["fallback_to"], "claude-opus-5")
         self.assertEqual(fb[0]["content"], NOTICE)
+
+    def test_the_atom_carries_the_refusal_category_explanation_and_scope(self):
+        # T279: the head and fold of the chat notice, and the card's cause — dropped at the parse before
+        parsed = self._parse()
+        atoms = [a for t in parsed["turns"] for a in t["atoms"]]
+        fb = [a for a in atoms if a.get("subtype") == "model_refusal_fallback"][0]
+        self.assertEqual(fb["refusal_category"], CATEGORY)
+        self.assertEqual(fb["refusal_explanation"], EXPLANATION)
+        self.assertEqual(fb["scope"], "session")
 
     def test_the_notice_sorts_before_the_fallback_models_reply(self):
         # its timestamp is the retry START, so the atom order reads: flagged -> switched -> the reply
@@ -141,6 +155,24 @@ class BuildSessionEmitsTheNoticeEvent(unittest.TestCase):
                        if "README covers install" in (e.get("md") or ""))
         self.assertLess(kinds.index("modelFallback"), i_reply,
                         "the notice reads before the fallback model's reply")
+
+    def test_the_event_carries_the_category_explanation_and_scope(self):
+        # T279: the client renders the category in the head and the explanation in the fold
+        m = km.build_session(SID, NOW)
+        ev = next(e for e in m["events"] if e.get("kind") == "modelFallback")
+        self.assertEqual(ev["category"], CATEGORY)
+        self.assertEqual(ev["explanation"], EXPLANATION)
+        self.assertEqual(ev["scope"], "session")
+
+    def test_the_notice_is_never_the_users_bubble(self):
+        # a STANDING guard on the routing, green before T279 too (the system atom is never a user
+        # event): the record's user-facing text belongs to the notice, never to a user bubble
+        m = km.build_session(SID, NOW)
+        for e in m["events"]:
+            if e.get("kind") == "user":
+                self.assertNotIn(NOTICE, e.get("md") or "")
+                self.assertNotIn(EXPLANATION, e.get("md") or "")
+        self.assertEqual([e.get("kind") for e in m["events"]].count("modelFallback"), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_refusal_fallback_notice.py
+++ b/tests/test_refusal_fallback_notice.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""A safeguards refusal the CLI retried on a fallback model is filed, not logged as unhandled (T279).
+
+The CLI streams a system/model_refusal_fallback frame when the model's classifier declined the request
+and the turn was re-run on the configured fallback model. The SDK backend had no branch for it, so the
+frame fell to the once-per-life "unhandled SystemMessage subtype" log line and nothing was filed: the
+judges' only record of the swap was the capacity-fallback card the fallback reply's own model learn
+minted — with the wrong cause. Now the frame files the refusal through a kernel-wired hook (the
+on_model_fallback idiom) into a completed card naming the refusal category and the API's explanation,
+and the capacity card the same turn's model learn minted for the swap is FOLDED into it with the store's
+merge machinery (claimed by exact id, only while the user has not acted on it), so one swap is one card. Field names follow the CLI's stream-json schema (bundled CLI 2.1.259): original_model,
+fallback_model, api_refusal_category (open string, nullable), api_refusal_explanation (display-only
+prose, nullable), scope ('session' | 'local'; absent on older CLIs = session). SYNTHETIC only."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+sb = SourceFileLoader("romp_sdk_backend",
+                      os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).load_module()
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+CATEGORY = "synthetic-category"
+EXPLANATION = "a synthetic explanation of the refusal"
+
+
+def wire_frame(**over):
+    """The stream frame, snake_case per the CLI's schema; every value invented."""
+    d = {"type": "system", "subtype": "model_refusal_fallback", "direction": "retry",
+         "trigger": "refusal", "scope": "session",
+         "original_model": "claude-fable-5", "fallback_model": "claude-opus-5",
+         "request_id": "req_synthetic", "api_refusal_category": CATEGORY,
+         "api_refusal_explanation": EXPLANATION,
+         "retracted_message_uuids": ["aaaaaaaa-1111-2222-3333-444444444401"],
+         "refused_user_message_uuid": "aaaaaaaa-1111-2222-3333-444444444400",
+         "content": "The model's safeguards flagged this message. Switched to a fallback model.",
+         "uuid": "aaaaaaaa-1111-2222-3333-444444444402", "session_id": SID}
+    d.update(over)
+    return d
+
+
+class StreamBranchFilesTheRefusal(unittest.TestCase):
+    """_on_message takes the SDK message classes as PARAMETERS (the lazy-import seam), so the branch
+    runs hermetically with stand-in classes — the SidechainNeverLearns idiom."""
+
+    class _SM:
+        def __init__(self, subtype, data):
+            self.subtype, self.data = subtype, data
+            self.parent_tool_use_id = None
+
+    class _AM:                       # AssistantMessage stand-in (the learn path)
+        def __init__(self, model, ptid=None):
+            self.model = model
+            self.parent_tool_use_id = ptid
+            self.error = None
+            self.content = []
+
+    class _RM:
+        pass
+
+    def setUp(self):
+        sb.SdkSession._sys_subtypes_seen = set()
+
+    def tearDown(self):
+        sb.SdkSession._sys_subtypes_seen = set()
+
+    def _session(self, hook_raises=False):
+        calls = {"refusal": [], "fallback": [], "log": []}
+
+        class Backend:
+            state_dir = None
+
+            def on_model_refusal_fallback(sid, frm, to, category, explanation, scope, capacity_gids, episode):
+                if hook_raises:                          # looked up on the CLASS, called unbound —
+                    raise RuntimeError("synthetic hook failure")   # exactly how the kernel wires it
+                calls["refusal"].append((sid, frm, to, category, explanation, scope, capacity_gids, episode))
+
+            def on_model_fallback(sid, frm, to):
+                calls["fallback"].append((frm, to))
+                return (SID + ":g7", None)               # the kernel's lambda returns (gid, _push_soon())
+
+            def _update_reg(self, sid, **kw):
+                pass
+
+            def _poke(self):
+                pass
+
+            def _forward(self, sess, msg):
+                pass
+
+            def _log(self, line, *a, **k):
+                calls["log"].append((line, bool(k.get("problem"))))
+
+        s = object.__new__(sb.SdkSession)
+        s.backend = Backend()
+        s.sid = SID
+        s.name = "web"
+        s.model = "Fable 5"
+        s._model_id = "claude-fable-5"
+        s._model_pending = ""
+        s.retrying = False
+        s.retry_count = 0
+        s.retry_info = None
+        return s, calls
+
+    def _feed(self, s, data):
+        s._on_message(self._SM("model_refusal_fallback", data), self._AM, self._RM, self._SM)
+
+    def test_the_frame_files_the_refusal_through_the_hook_with_pretty_names(self):
+        s, calls = self._session()
+        self._feed(s, wire_frame())
+        self.assertEqual(calls["refusal"],
+                         [(SID, "Fable 5", "Opus 5", CATEGORY, EXPLANATION, "session", [],
+                           "aaaaaaaa-1111-2222-3333-444444444400")],
+                         "the same pretty names the capacity path files; no capacity card was learned this turn")
+        self.assertEqual(calls["fallback"], [], "the branch files a refusal, never a capacity swap")
+
+    def test_the_frame_is_no_longer_logged_as_unhandled(self):
+        s, calls = self._session()
+        self._feed(s, wire_frame())
+        self.assertFalse(any("unhandled SystemMessage" in line for line, _ in calls["log"]), calls["log"])
+        self.assertNotIn("model_refusal_fallback", sb.SdkSession._sys_subtypes_seen)
+
+    def test_null_fields_and_an_absent_scope_normalise(self):
+        # the schema: category/explanation null when the response carried none (normal, not an error);
+        # scope absent on older CLIs = the session model was swapped
+        s, calls = self._session()
+        d = wire_frame(api_refusal_category=None, api_refusal_explanation=None)
+        del d["scope"]
+        self._feed(s, d)
+        self.assertEqual(calls["refusal"][0][:7], (SID, "Fable 5", "Opus 5", "", "", "session", []))
+
+    def test_a_local_scope_rides_through_and_claims_no_capacity_card(self):
+        # 'local': a subagent / side question fell back — only that reply came from the fallback model;
+        # the session's own model never changed, so no capacity card of this turn is the swap's
+        s, calls = self._session()
+        s._swap_cards = [("Fable 5", "Opus 5", SID + ":g7")]
+        self._feed(s, wire_frame(scope="local"))
+        self.assertEqual(calls["refusal"][0][5:7], ("local", []))
+
+    def test_the_learn_captures_the_capacity_card_the_fallback_reply_minted(self):
+        # the fallback model's reply streams first: its learn mints the capacity card; the branch keeps
+        # the swap and the card's id so the end-of-turn notice can name exactly that card
+        s, calls = self._session()
+        s._on_message(self._AM("claude-opus-5"), self._AM, self._RM, self._SM)
+        self.assertEqual(calls["fallback"], [("Fable 5", "Opus 5")])
+        self.assertEqual(s._swap_cards, [("Fable 5", "Opus 5", SID + ":g7")])
+        self._feed(s, wire_frame())
+        self.assertEqual(calls["refusal"][0][6], [SID + ":g7"], "the notice names the card the learn minted")
+
+    def test_every_card_learned_this_turn_rides_the_hook_for_the_store_to_judge(self):
+        # a multi-hop chain learns a card per hop (origin -> hop 1, hop 1 -> hop 2); the store decides
+        # which of them the episode's final frame folds, so all of this turn's cards ride along
+        s, calls = self._session()
+        s._swap_cards = [("Fable 5", "Opus 5", SID + ":g7"), ("Opus 5", "Sonnet 5", SID + ":g8")]
+        self._feed(s, wire_frame(fallback_model="claude-sonnet-5"))
+        self.assertEqual(calls["refusal"][0][6], [SID + ":g7", SID + ":g8"])
+
+    def test_a_provisional_frame_files_too(self):
+        # an intermediate hop of a multi-hop chain (the first fallback refused too) may arrive marked
+        # provisional, and on the CLI's chain path no final frame need follow it — so it files like any
+        # other frame; a later hop of the same episode folds its card (the store's episode fold). Skipping
+        # it would drop the refusal's filing entirely (review, 2026-09-09).
+        s, calls = self._session()
+        self._feed(s, wire_frame(provisional=True))
+        self.assertEqual(len(calls["refusal"]), 1)
+        self.assertEqual(calls["refusal"][0][7], "aaaaaaaa-1111-2222-3333-444444444400", "the episode key rides")
+        self.assertFalse(any("unhandled SystemMessage" in line for line, _ in calls["log"]), calls["log"])
+
+    def test_the_settle_forgets_the_captured_swap(self):
+        # the turn's end is the deciding event: a card learned in an earlier turn is never claimed later
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read()
+        i = src.index("        elif isinstance(msg, ResultMessage):" + chr(10) + "            try:")
+        j = src.index('        elif getattr(msg, "rate_limit_info", None) is not None:', i)
+        self.assertIn("self._swap_cards = []", src[i:j], "the settle branch clears the captured swaps")
+
+    def test_a_failing_hook_is_logged_as_a_problem_and_never_raises(self):
+        s, calls = self._session(hook_raises=True)
+        self._feed(s, wire_frame())
+        probs = [line for line, problem in calls["log"] if problem]
+        self.assertEqual(len(probs), 1, calls["log"])
+        self.assertIn("refusal-fallback card", probs[0])
+        self.assertIn("synthetic hook failure", probs[0])
+
+    def test_the_branch_sits_between_the_task_tuple_and_the_unhandled_memo(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read()
+        i_tasks = src.index('"task_started", "task_progress", "task_updated", "task_notification"')
+        i_branch = src.index('msg.subtype == "model_refusal_fallback"')
+        i_trail = src.index("elif isinstance(msg, SystemMessage):", i_branch)   # the bare catch-all after it
+        self.assertLess(i_tasks, i_branch)
+        self.assertLess(i_branch, i_trail, "handled before the memo, so the memo never names it")
+        self.assertIn("_sys_subtypes_seen", src[i_trail:i_trail + 1200], "that bare elif IS the memo")
+
+    def test_an_unwired_hook_is_said_once_never_swallowed(self):
+        # a backend without the kernel wiring must not turn the frame into a silent drop now that the
+        # unhandled memo no longer names it: one line per kernel life says so
+        s, calls = self._session()
+        del type(s.backend).on_model_refusal_fallback
+        self._feed(s, wire_frame())
+        self._feed(s, wire_frame())
+        hits = [line for line, _ in calls["log"] if "no on_model_refusal_fallback hook" in line]
+        self.assertEqual(len(hits), 1, calls["log"])
+        self.assertEqual(calls["refusal"], [])
+
+    def test_a_frame_without_model_ids_is_a_logged_problem_not_a_card(self):
+        # the schema marks both model fields required: a frame without them is a broken frame, and a
+        # card reading "? → a fallback model" would hide the breakage behind a plausible card
+        s, calls = self._session()
+        d = wire_frame()
+        del d["original_model"]; del d["fallback_model"]
+        self._feed(s, d)
+        self.assertEqual(calls["refusal"], [], "no card from a frame with no models")
+        probs = [line for line, problem in calls["log"] if problem]
+        self.assertEqual(len(probs), 1, calls["log"])
+        self.assertIn("model_refusal_fallback", probs[0])
+        self.assertIn("keys=", probs[0], "keys only, never the values")
+        self.assertNotIn(EXPLANATION, probs[0])
+
+    def test_the_episode_key_rides_the_hook(self):
+        # the refused prompt's uuid keys the episode: a multi-hop refusal (the first fallback refused too)
+        # streams a frame per hop, and the filing folds the earlier hop's card into the final one by it
+        s, calls = self._session()
+        self._feed(s, wire_frame())
+        self.assertEqual(calls["refusal"][0][7], "aaaaaaaa-1111-2222-3333-444444444400")
+        s2, calls2 = self._session()
+        d = wire_frame(); d["refused_user_message_uuid"] = None
+        self._feed(s2, d)
+        self.assertEqual(calls2["refusal"][0][7], "", "a null key is no key")
+
+
+class RefusalCard(unittest.TestCase):
+    """OWN sid, like test_model_fallback_card's FallbackCard and for the same reason: load_goals replays
+    the per-sid user-override journal, other modules journal gestures against the shared placeholder
+    sid, and a fresh store's first node id collides."""
+
+    RSID = "7b7b7b7b-8c8c-9d9d-0e0e-1f1f1f1f1f1f"
+    T = 1_787_500_000
+
+    def tearDown(self):
+        for f in jd.GOALDIR.glob("*"):
+            f.unlink()
+        try:
+            (jd._overrides_dir() / (self.RSID + ".jsonl")).unlink()
+        except OSError:
+            pass
+
+    EPISODE = "aaaaaaaa-1111-2222-3333-444444444400"
+
+    def _mint(self, to="Opus 5", **over):
+        kw = dict(category=CATEGORY, explanation=EXPLANATION, scope="session", ev_t=self.T, episode=self.EPISODE)
+        kw.update(over)
+        return jd.mint_refusal_fallback_card(self.RSID, "Fable 5", to, **kw)
+
+    def test_a_later_hop_of_the_same_episode_folds_the_earlier_hops_card(self):
+        # a multi-hop refusal: the first fallback model refused too, so the CLI streams a frame per hop
+        # (origin -> hop 1, then origin -> hop 2); the final hop's card is the record, the earlier one
+        # folds into it — same episode key, different swap — instead of two cards for one episode
+        g1 = self._mint(to="Opus 5")
+        g2 = self._mint(to="Sonnet 5", ev_t=self.T + 3)
+        self.assertTrue(g1 and g2 and g1 != g2)
+        store = jd.load_goals(self.RSID)
+        self.assertEqual(list(store["nodes"]), [g2])
+        nd = store["nodes"][g2]
+        self.assertIn("Fable 5 → Sonnet 5", nd["text"])
+        self.assertEqual([m["id"] for m in nd["mergedFrom"]], [g1])
+        self.assertEqual(nd["episode"], self.EPISODE)
+
+    def test_another_episodes_card_is_never_folded(self):
+        g1 = self._mint(to="Opus 5")
+        g2 = self._mint(to="Sonnet 5", ev_t=self.T + 3, episode="aaaaaaaa-1111-2222-3333-444444444499")
+        self.assertEqual(sorted(jd.load_goals(self.RSID)["nodes"]), sorted([g1, g2]))
+
+    def test_no_episode_key_folds_nothing(self):
+        g1 = self._mint(to="Opus 5", episode="")
+        g2 = self._mint(to="Sonnet 5", ev_t=self.T + 3, episode="")
+        self.assertEqual(sorted(jd.load_goals(self.RSID)["nodes"]), sorted([g1, g2]))
+
+    def _capacity(self, t=None):
+        gid = jd.mint_fallback_card(self.RSID, "Fable 5", "Opus 5", ev_t=t or self.T)
+        self.assertTrue(gid)
+        return gid
+
+    def test_mints_a_completed_card_naming_the_refusal_category_and_explanation(self):
+        gid = self._mint()
+        self.assertTrue(gid)
+        store = jd.load_goals(self.RSID)
+        nd = store["nodes"][gid]
+        self.assertEqual(nd["text"], "Model changed after a safeguards refusal (%s): Fable 5 → Opus 5" % CATEGORY)
+        self.assertTrue(nd["nodeComplete"])
+        self.assertEqual(store["status"].get(gid), "completed", "pops straight into Completed")
+        self.assertIn(CATEGORY, nd["doneWhy"], "the head: the category")
+        self.assertIn(EXPLANATION, nd["doneWhy"], "the fold: the API's explanation")
+        self.assertIn("Opus 5", nd["doneWhy"])
+        self.assertNotIn("capacity", nd["doneWhy"].lower(), "a refusal is never filed as a capacity fallback")
+        self.assertEqual(nd["why"], jd.REFUSAL_FALLBACK_WHY)
+        self.assertEqual(nd["swap"], {"from": "Fable 5", "to": "Opus 5"}, "the swap as data, for the dedupes")
+        dones = [e for e in nd["log"] if e.get("kind") == "done"]
+        self.assertEqual(len(dones), 1)
+        self.assertEqual(dones[0]["src"], "romp", "kernel-authored bookkeeping, never a question")
+
+    def test_null_category_and_explanation_still_mint_cleanly(self):
+        gid = self._mint(category=None, explanation=None)
+        nd = jd.load_goals(self.RSID)["nodes"][gid]
+        self.assertEqual(nd["text"], "Model changed after a safeguards refusal: Fable 5 → Opus 5")
+        self.assertNotIn("None", nd["doneWhy"])
+        self.assertNotIn("()", nd["doneWhy"])
+        self.assertIn("safeguards", nd["doneWhy"])
+
+    def test_a_local_scope_names_only_the_reply_and_leaves_the_session_model_alone(self):
+        gid = self._mint(scope="local")
+        nd = jd.load_goals(self.RSID)["nodes"][gid]
+        self.assertTrue(nd["text"].startswith("A reply came from Opus 5 after a safeguards refusal"))
+        self.assertIn("unchanged", nd["doneWhy"], "the session's model is unchanged")
+        self.assertNotIn("switch back", nd["doneWhy"].lower())
+
+    def test_an_identical_uncleared_card_dedupes_the_mint(self):
+        self.assertTrue(self._mint())
+        self.assertIsNone(self._mint(ev_t=self.T + 5))
+        self.assertEqual(len(jd.load_goals(self.RSID)["nodes"]), 1)
+
+    def test_folds_the_capacity_card_the_fallback_reply_minted_into_the_refusal_card(self):
+        # the fallback model's reply streams BEFORE the CLI's end-of-turn notice, and its model learn
+        # files the swap as a capacity fallback; the notice names that card by id and the store's
+        # merge folds it into the refusal card — a fresh node any concurrent save adopts wholesale,
+        # and a durable tombstone for the capacity card
+        gid_cap = self._capacity()
+        gid = self._mint(capacity_gids=[gid_cap], ev_t=self.T + 1)
+        self.assertTrue(gid)
+        self.assertNotEqual(gid, gid_cap, "the refusal card is its own node")
+        store = jd.load_goals(self.RSID)
+        self.assertEqual(list(store["nodes"]), [gid], "one swap, one card")
+        nd = store["nodes"][gid]
+        self.assertEqual(nd["text"], "Model changed after a safeguards refusal (%s): Fable 5 → Opus 5" % CATEGORY)
+        self.assertEqual(nd["why"], jd.REFUSAL_FALLBACK_WHY)
+        self.assertIn(CATEGORY, nd["doneWhy"])
+        self.assertNotIn("capacity", nd["doneWhy"].lower())
+        self.assertEqual([m["id"] for m in nd["mergedFrom"]], [gid_cap], "the capacity card's tombstone")
+        self.assertTrue(nd["nodeComplete"])
+        self.assertEqual(store["status"].get(gid), "completed")
+        self.assertNotIn(gid_cap, store["status"])
+
+    def test_a_capacity_card_the_user_followed_up_on_is_left_alone(self):
+        # the user acted on the card mid-turn: their gesture outranks the bookkeeping — the refusal
+        # files fresh and the capacity card keeps its state (two cards, no move on the user's card)
+        gid_cap = self._capacity()
+        store = jd.load_goals(self.RSID)
+        nd = store["nodes"][gid_cap]
+        jd.record_verdict(store, nd, "user", "reopen", self.T + 1, msg=True)
+        jd.rollup_status(store, True)
+        jd.save_goals(self.RSID, store)
+        gid = self._mint(capacity_gids=[gid_cap], ev_t=self.T + 2)
+        self.assertTrue(gid)
+        store = jd.load_goals(self.RSID)
+        self.assertEqual(sorted(store["nodes"]), sorted([gid_cap, gid]))
+        self.assertEqual(store["nodes"][gid_cap]["text"], "Model changed automatically: Fable 5 → Opus 5")
+        self.assertNotEqual(store["status"].get(gid_cap), "completed", "the user's reopen still stands")
+
+    def test_an_unknown_capacity_id_files_the_refusal_fresh(self):
+        gid = self._mint(capacity_gids=[self.RSID + ":g99"])
+        self.assertTrue(gid)
+        self.assertEqual(list(jd.load_goals(self.RSID)["nodes"]), [gid])
+
+    def test_a_multi_hop_chain_folds_every_hops_capacity_card(self):
+        # origin -> hop 1 -> hop 2: the learn minted a card per hop; the final frame (origin -> hop 2)
+        # folds the cards that chain between its two models, and only those
+        g1 = jd.mint_fallback_card(self.RSID, "Fable 5", "Opus 5", ev_t=self.T)
+        g2 = jd.mint_fallback_card(self.RSID, "Opus 5", "Sonnet 5", ev_t=self.T + 1)
+        g_other = jd.mint_fallback_card(self.RSID, "Opus 5", "Haiku 4.5", ev_t=self.T + 1)   # not in the chain
+        gid = self._mint(to="Sonnet 5", capacity_gids=[g1, g2, g_other], ev_t=self.T + 2)
+        store = jd.load_goals(self.RSID)
+        self.assertEqual(sorted(store["nodes"]), sorted([gid, g_other]))
+        self.assertEqual(sorted(m["id"] for m in store["nodes"][gid]["mergedFrom"]), sorted([g1, g2]))
+
+    def test_a_capacity_mint_after_the_refusal_card_stands_down(self):
+        # the other order (a CLI that streams the notice first): the swap is already filed with its cause
+        self.assertTrue(self._mint())
+        self.assertIsNone(jd.mint_fallback_card(self.RSID, "Fable 5", "Opus 5", ev_t=self.T + 1))
+        self.assertEqual(len(jd.load_goals(self.RSID)["nodes"]), 1)
+
+    def test_a_cleared_capacity_card_is_left_alone(self):
+        # the user crossed the capacity card off; the refusal is filed fresh, never folded onto it
+        gid_cap = self._capacity()
+        store = jd.load_goals(self.RSID)
+        nd = store["nodes"][gid_cap]
+        jd.record_verdict(store, nd, "user", "clear", self.T + 1)
+        jd.rollup_status(store, True)
+        jd.save_goals(self.RSID, store)
+        gid = self._mint(capacity_gids=[gid_cap], ev_t=self.T + 2)
+        self.assertTrue(gid)
+        self.assertNotEqual(gid, gid_cap)
+        self.assertIn(gid_cap, jd.load_goals(self.RSID)["nodes"], "the cleared card stays as the user left it")
+
+
+class KernelWiring(unittest.TestCase):
+    def test_the_kernel_wires_the_hook_to_the_judge_store_at_boot(self):
+        ksrc = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("type(_sdk_backend).on_model_refusal_fallback = staticmethod(", ksrc)
+        i = ksrc.index("on_model_refusal_fallback = staticmethod(")
+        j = ksrc.index("jd.mint_refusal_fallback_card(", i)
+        self.assertLess(i, j, "the hook's body is the judge mint")
+        self.assertIn("capacity_gids=", ksrc[j:j + 200], "this turn's capacity cards flow through")
+        self.assertIn("episode=", ksrc[j:j + 200], "and the episode key")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_refusal_notice_served.py
+++ b/tests/test_refusal_notice_served.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""T279: a safeguards refusal the CLI retried on a fallback model renders in the served chat pane as a
+SOURCED notice in the shared notice-card grammar, never as the user's bubble.
+
+The executed guard drives the real /chat page against a hermetic kernel whose one session's transcript
+carries the refusal turn as the CLI writes it (the refused call's assistant record with a fallback block,
+the fallback model's reply, the system/model_refusal_fallback record with the category, the API's
+explanation and the scope). Asserted on the page: one notice card in the refusal variant with the
+"safeguards" chip; a head naming both models (prettified) and the category; the fold collapsed by default,
+holding the API's explanation and the CLI's own line, opening on a head click; the notice's own rail dot;
+the notice placed before the fallback model's reply; and the notice text in NO user bubble. Screenshots
+when T279_SHOTS names a directory. Skips LOUDLY without the extension deps or a Playwright browser (CI
+installs none). SYNTHETIC fixtures only."""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+NOTICE = ("The model's safeguards flagged this message. Switched to a fallback model. "
+          "Send feedback with /feedback.")
+CATEGORY = "synthetic-category"
+EXPLANATION = "a synthetic explanation of the refusal"
+REPLY = "The README covers install and usage."
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1000, height: 700 } });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+try { await page.waitForSelector(".turn.turn-user", { timeout: 20000 }); }
+catch (e) {
+  const st = await page.evaluate(() => ({ turns: Array.from(document.querySelectorAll(".turn")).map((t) => t.className.slice(5, 40)),
+    text: (document.body.innerText || "").replace(/\s+/g, " ").slice(0, 200) }));
+  console.error("no user turn rendered: " + JSON.stringify(st)); process.exit(1);
+}
+try { await page.waitForSelector(".notice-card-refusal", { timeout: 20000 }); }
+catch (e) {
+  const st = await page.evaluate(() => ({ turns: Array.from(document.querySelectorAll(".turn")).map((t) => t.className.slice(5, 60)),
+    text: (document.body.innerText || "").replace(/\s+/g, " ").slice(0, 400) }));
+  console.error("no refusal notice card rendered: " + JSON.stringify(st)); process.exit(1);
+}
+await page.waitForTimeout(400);
+const measure = () => page.evaluate((reply) => {
+  const cards = Array.from(document.querySelectorAll(".notice-card-refusal"));
+  const card = cards[0];
+  const turn = card.closest(".turn");
+  const turns = Array.from(document.querySelectorAll(".turn"));
+  const replyTurn = turns.find((t) => !t.classList.contains("turn-user") && (t.textContent || "").includes(reply)) || null;
+  return {
+    cards: cards.length,
+    chip: ((card.querySelector(".notice-chip") || {}).textContent || "").trim(),
+    head: ((card.querySelector(".notice-head-text") || {}).textContent || "").trim(),
+    open: card.classList.contains("notice-open"),
+    collapsible: card.classList.contains("notice-collapsible"),
+    body: ((card.querySelector(".notice-body") || {}).textContent || "").replace(/\s+/g, " ").trim(),
+    bodyVisible: (() => { const b = card.querySelector(".notice-body"); return b ? b.getBoundingClientRect().height > 0 : false; })(),
+    dot: !!turn.querySelector(".notice-dot-refusal"),
+    turnClasses: turn.className,
+    idxNotice: turns.indexOf(turn), idxReply: replyTurn ? turns.indexOf(replyTurn) : -1,
+    userTexts: Array.from(document.querySelectorAll(".turn.turn-user")).map((t) => (t.textContent || "").replace(/\s+/g, " ").trim()),
+    slimLines: document.querySelectorAll(".modelswap-line, .turn-modelswap").length,
+  };
+}, cfg.reply);
+const closed = await measure();
+const shot = async (name) => { if (!cfg.shots) return; fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/t279-refusal-notice" + name, fullPage: false }); };
+await shot(".png");
+await page.click(".notice-card-refusal .notice-head");
+await page.waitForTimeout(300);
+const opened = await measure();
+await shot("-open.png");
+fs.writeSync(1, "RESULT:" + JSON.stringify({ closed, opened }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+def refusal_turn_records(t0):
+    """The refusal-turn shape as the CLI writes it (camelCase on disk): the refused call leaves an
+    assistant record whose only content is a fallback block, the fallback model replies, and the system
+    record, stamped with the retry start and parented onto the reply, carries the category, the API's
+    explanation and the scope."""
+    return [
+        {"type": "user", "timestamp": iso(t0), "uuid": "u1", "parentUuid": None, "promptSource": "typed",
+         "sessionId": SID, "message": {"role": "user", "content": "summarize the notes-api README"}},
+        {"type": "assistant", "timestamp": iso(t0 + 5), "uuid": "afb", "parentUuid": "u1", "sessionId": SID,
+         "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
+                     "content": [{"type": "fallback", "from": {"model": "claude-fable-5"},
+                                  "to": {"model": "claude-opus-5"}}]}},
+        {"type": "assistant", "timestamp": iso(t0 + 45), "uuid": "a1", "parentUuid": "afb", "sessionId": SID,
+         "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
+                     "content": [{"type": "text", "text": REPLY}]}},
+        {"type": "system", "subtype": "model_refusal_fallback", "timestamp": iso(t0 + 5), "uuid": "sfb",
+         "parentUuid": "a1", "sessionId": SID, "direction": "retry", "trigger": "refusal", "level": "warning",
+         "scope": "session", "content": NOTICE, "originalModel": "claude-fable-5", "fallbackModel": "claude-opus-5",
+         "requestId": "req_synthetic", "apiRefusalCategory": CATEGORY, "apiRefusalExplanation": EXPLANATION,
+         "retractedMessageUuids": [], "refusedUserMessageUuid": "u1"},
+    ]
+
+
+class ServedRefusalNotice(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        # a cheap browser probe BEFORE the bundle and the kernel: a box with the deps but no browser (CI's
+        # shape) skips here instead of paying a build and a boot to learn it at the driver
+        probe = subprocess.run(["node", "-e", "const p=require(process.argv[1]);process.stdout.write(p.chromium.executablePath())",
+                                os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
+        if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        cls.lab = tempfile.mkdtemp(prefix="refusal-notice-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        shutil.copytree(os.path.join(EXT, "dist"), dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(cls.state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        Path(cls.state, "names", SID).write_text("web\t%s\t\t\n" % cwd)
+        Path(cls.state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high",
+             "lastSid": SID, "alive": True, "model": "claude-fable-5", "liveModel": "Fable 5"}))
+        Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        claude = os.path.join(cls.lab, "claude")
+        # the kernel finds a session's transcript under Claude's project dir: EVERY non-alphanumeric char of the
+        # realpath becomes '-' (jd._proj_dir)
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        t0 = int(time.time()) - 900
+        cls.transcript = os.path.join(proj, SID + ".jsonl")
+        Path(cls.transcript).write_text("".join(json.dumps(r) + "\n" for r in refusal_turn_records(t0)))
+        cls.port = _free_port()
+        cls.token = "testtok-refusalnotice"
+        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
+                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
+        for k in ("ROMP_STATE_DIR", "ROMP_API_KEY_CMD", "ANTHROPIC_API_KEY"):
+            env.pop(k, None)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            cls.kernel.wait()
+            shutil.rmtree(cls.lab, ignore_errors=True)
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_the_refusal_renders_as_a_sourced_notice_card_and_never_as_the_users_bubble(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "reply": REPLY,
+                       "shots": os.environ.get("T279_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:]
+                         + "\nkernel:\n" + open(self.klog).read()[-1500:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        c, o = r["closed"], r["opened"]
+        self.assertEqual(c["cards"], 1, "one notice card for the one record: %r" % c)
+        self.assertEqual(c["chip"], "safeguards", "the chip is the source: %r" % c)
+        for part in ("Fable 5", "Opus 5", "(%s)" % CATEGORY, "safeguards"):
+            self.assertIn(part, c["head"], "the head: both models prettified and the category: %r" % c)
+        self.assertNotIn("this reply came from", c["head"], "session scope: the session's model was swapped")
+        self.assertTrue(c["collapsible"] and not c["open"], "collapsed by default: %r" % c)
+        self.assertFalse(c["bodyVisible"], "the fold is hidden until the head is clicked: %r" % c)
+        self.assertIn("Fable 5 → Opus 5", c["body"], "the fold restates the swap, so a truncated head is recoverable: %r" % c)
+        self.assertIn(EXPLANATION, c["body"], "the fold holds the API's explanation: %r" % c)
+        self.assertIn(NOTICE, c["body"], "and the CLI's own line, verbatim: %r" % c)
+        self.assertTrue(c["dot"], "the notice's own rail dot, in the refusal variant: %r" % c)
+        self.assertIn("turn-notice", c["turnClasses"])
+        self.assertEqual(c["slimLines"], 0, "the retired slim rail line is gone")
+        self.assertGreaterEqual(c["idxReply"], 0, "the fallback model's reply is on the page: %r" % c)
+        self.assertLess(c["idxNotice"], c["idxReply"], "the notice reads BEFORE the fallback model's reply: %r" % c)
+        for ut in c["userTexts"]:
+            self.assertNotIn(NOTICE, ut, "the notice is never the user's bubble: %r" % c["userTexts"])
+            self.assertNotIn(EXPLANATION, ut, "the explanation is never the user's bubble: %r" % c["userTexts"])
+        self.assertEqual(len(c["userTexts"]), 1, "one user bubble: the prompt, once: %r" % c["userTexts"])
+        self.assertTrue(o["open"] and o["bodyVisible"], "a head click opens the fold: %r" % o)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/model-fallback.test.ts
+++ b/ui/webview/model-fallback.test.ts
@@ -1,9 +1,11 @@
 // A mid-turn safeguards model swap must be visible in the chat, never silent (the user 2026-08-03:
 // fable's safeguards flagged a message, the CLI silently retried on opus, and nothing in the chat said
 // so). The kernel emits {kind:"modelFallback"} from the transcript's system/model_refusal_fallback
-// record; render.ts wears it as the retried note's slim rail line in the warning voice, with the CLI's
-// full explanation one click away. render.ts has import-time DOM side effects → source pins
-// (rewind-delete.test.ts precedent).
+// record. T279: render.ts wears it as a SOURCED notice in the shared notice-card grammar — the
+// "safeguards" chip, a one-line head naming the models and the refusal category, and the API's
+// explanation (plus the CLI's own line) folded one click away — never as the user's bubble and never in
+// the red API-error dress. render.ts has import-time DOM side effects → source pins (rewind-delete.test.ts
+// precedent).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -14,34 +16,60 @@ const RENDER = fs.readFileSync(
 const CSS = fs.readFileSync(
   path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
+function renderer(): string {
+  const fn = RENDER.slice(RENDER.indexOf("function renderModelFallback"));
+  return fn.slice(0, fn.indexOf("\n}"));
+}
+
 test("the modelFallback kind is dispatched to its renderer", () => {
   assert.match(RENDER, /if \(ev\.kind === "modelFallback"\) return renderModelFallback\(ev\);/);
-  // and the union carries the payload the kernel sends (raw ids + the CLI's explanation)
-  assert.match(RENDER, /kind: "modelFallback"; from\?: string; to\?: string; md\?: string/);
+  // the union carries the payload the kernel sends: raw ids, the CLI's line, the refusal's category,
+  // the API's explanation and the scope (session model swapped vs. one local reply)
+  for (const field of ["category", "explanation", "scope"]) {
+    assert.match(RENDER, new RegExp('kind: "modelFallback";[^}]*' + field + '\\?: string'), field + " is typed on the event");
+  }
 });
 
-test("the head line names both models via prettyModel, in the warning voice", () => {
-  const fn = RENDER.slice(RENDER.indexOf("function renderModelFallback"));
-  const body = fn.slice(0, fn.indexOf("\n}"));
+test("the notice is a sourced notice card: the safeguards chip, in the warning voice", () => {
+  const body = renderer();
+  assert.match(body, /noticeCard\(\{ variant: "refusal", chip: "safeguards"/);
+  assert.match(RENDER, /type NoticeVariant = [^;]*"refusal"/, "the grammar's variant union admits it");
+  // never a red/blocked dress: a swap is a warning about provenance, not a failure of the turn
+  assert.doesNotMatch(body, /apierror|gaveup/);
+  assert.doesNotMatch(RENDER, /"modelswap-(line|text|body)"|turn-modelswap/, "the old slim rail line's classes are gone");
+});
+
+test("the head names both models via prettyModel and the refusal category", () => {
+  const body = renderer();
   assert.match(body, /prettyModel\(ev\.from\)/);
   assert.match(body, /prettyModel\(ev\.to\)/);
   assert.match(body, /safeguards flagged this message/);
-  assert.match(body, /"retried-text modelswap-text"/, "warning-voice class on the head text");
-  // never a red/blocked dress: a swap is a warning about provenance, not a failure of the turn
-  assert.doesNotMatch(body, /apierror|gaveup/);
+  assert.match(body, /ev\.category/);
+  // 'local' scope: only that reply came from the fallback model — the session's model is unchanged
+  assert.match(body, /ev\.scope === "local"/);
+  assert.match(body, /switched to/);
 });
 
-test("the full CLI notice is one click away and the fold survives re-renders", () => {
-  const fn = RENDER.slice(RENDER.indexOf("function renderModelFallback"));
-  const body = fn.slice(0, fn.indexOf("\n}"));
-  assert.match(body, /body\.textContent = ev\.md;/, "verbatim notice — never paraphrased chrome");
-  assert.match(body, /applyFold\(body, "expanded", key\)/);
-  assert.match(body, /rememberFold\(body, "expanded", key\)/);
+test("the API's explanation and the CLI's own line fold under the head, keyed by the record's uuid", () => {
+  const body = renderer();
+  assert.match(body, /ev\.explanation/);
+  assert.match(body, /ev\.md/, "the CLI's verbatim line still rides along — never paraphrased chrome");
   assert.match(body, /"mswap:" \+ ev\.uuid/, "fold keyed by the record's uuid");
 });
 
-test("the body is hidden until expanded, styled in the note family", () => {
-  assert.match(CSS, /\.modelswap-body \{ display: none;/);
-  assert.match(CSS, /\.modelswap-body\.expanded \{ display: block; \}/);
-  assert.match(CSS, /\.modelswap-text \{ color: var\(--warn/);
+test("a truncated head is recoverable: the full head is the hover, and the fold restates the swap", () => {
+  // progressive disclosure never dead-ends: a narrow pane ellipsizes the head from the right, which cuts
+  // exactly the swap and the category the card exists to surface (review, 2026-09-09)
+  const body = renderer();
+  assert.match(body, /querySelector\("\.notice-head-text"\)\?\.setAttribute\("title", head\)/);
+  assert.match(body, /el\("div", "refusal-swap"\)/);
+  assert.match(CSS, /\.refusal-swap \{/);
+  assert.doesNotMatch(RENDER, /Slim rail line in the warning voice/, "the retired treatment's comment is gone too");
+});
+
+test("the refusal variant wears the heads-up amber, like the other notice variants wear theirs", () => {
+  assert.match(CSS, /\.notice-card-refusal \{ border-left-color: var\(--warn/);
+  assert.match(CSS, /\.notice-chip-refusal \{ color: var\(--warn/);
+  assert.match(CSS, /\.notice-dot-refusal \{ border-color: var\(--warn/);
+  assert.doesNotMatch(CSS, /\.modelswap-(line|text|body)/, "the retired line's rules are gone");
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -252,7 +252,7 @@ type ChatEvent = (
   // transcript's system/model_refusal_fallback record). The reply that follows came from a DIFFERENT
   // model — conversation state that must be apparent in the chat, never silent (the user 2026-08-03).
   // from/to are raw model ids; md is the CLI's full explanation, one click away.
-  | { kind: "modelFallback"; from?: string; to?: string; md?: string; ts?: string; uuid?: string }
+  | { kind: "modelFallback"; from?: string; to?: string; md?: string; category?: string; explanation?: string; scope?: string; ts?: string; uuid?: string }
   // Pinned, collapsed "system context" card at the top of the transcript (the user 2026-06-19): the
   // CLAUDE.md instructions in effect + session config. NOT the verbatim harness prompt — it's never
   // recorded, so it can't be shown (renderSystem says so). No ts/uuid → off the rail (no dot/hover).
@@ -1457,7 +1457,8 @@ function foldable(label: string, content: HTMLElement, key?: string): HTMLElemen
 // detached from the timeline. Nested → return the bare card; it sits in the parent turn's rail column under
 // its single dot (connected, like any in-turn card). A standalone notice (romp system) IS its own top-level
 // turn, so it keeps the .turn wrapper + dot.
-function noticeCard(o: { variant: "agent" | "romp" | "reminder" | "compact" | "clear" | "peer"; chip: string; logo?: boolean;
+type NoticeVariant = "agent" | "romp" | "reminder" | "compact" | "clear" | "peer" | "refusal";
+function noticeCard(o: { variant: NoticeVariant; chip: string; logo?: boolean;
                         head: string; body: HTMLElement; collapsible?: boolean; key?: string;
                         nested?: boolean }): HTMLElement {
   const card = el("div", "notice-card notice-card-" + o.variant + (o.nested ? " notice-nested" : ""));
@@ -3876,30 +3877,32 @@ function renderCmdGesture(ev: Extract<ChatEvent, { kind: "cmdGesture" }>): HTMLE
   return turn;
 }
 
-// The durable "safeguards flagged → switched model" note (the user 2026-08-03: a mid-turn model swap
-// must be apparent in the chat, never silent). Slim rail line in the warning voice, placed where the
-// retry started — i.e. just above the fallback model's reply. The CLI's full explanation (why the
-// safeguards fired, the /feedback pointer) expands on click; fold state survives re-renders via the
-// record's uuid key.
 function renderModelFallback(ev: Extract<ChatEvent, { kind: "modelFallback" }>): HTMLElement {
-  const turn = el("div", "turn turn-retried turn-modelswap");
-  turn.appendChild(dot("ring"));
-  const line = el("div", "retried-line modelswap-line");
-  const txt = el("span", "retried-text modelswap-text");
+  // A safeguards refusal the CLI retried on a fallback model: the swap must be visible where it happened
+  // (the user 2026-08-03), as a SOURCED notice in the shared notice-card grammar (T279). The head is the
+  // gist: whose safeguards flagged the message, the refusal category when the API named one, and which
+  // model answered instead. The fold holds the API's explanation (when it sent one) and the CLI's own
+  // line, verbatim. 'local' scope: only that reply (a subagent's or a side question's) came from the
+  // fallback model and the session's model is unchanged, so the head says so instead of "switched".
   const from = ev.from ? prettyModel(ev.from) : "";
   const to = ev.to ? prettyModel(ev.to) : "a fallback model";
-  txt.textContent = `${from || "The model"}'s safeguards flagged this message · switched to ${to}`;
-  line.appendChild(txt);
-  turn.appendChild(line);
-  if (ev.md) {
-    const body = el("div", "modelswap-body");
-    body.textContent = ev.md;
-    const key = ev.uuid ? "mswap:" + ev.uuid : undefined;
-    applyFold(body, "expanded", key);
-    line.title = "click for the full notice";
-    line.addEventListener("click", () => rememberFold(body, "expanded", key));
-    turn.appendChild(body);
-  }
+  const cat = (ev.category || "").trim();
+  const local = ev.scope === "local";
+  const head = `${from || "The model"}'s safeguards flagged this message${cat ? ` (${cat})` : ""} · ` +
+    (local ? `this reply came from ${to}` : `switched to ${to}`);
+  const body = el("div", "refusal-notice");
+  // the fold's first line restates the swap and the category: a narrow pane ellipsizes the head from the
+  // right, which cuts exactly these two facts, and a compact view must never dead-end (the full head is
+  // the hover too)
+  const swapLine = el("div", "refusal-swap");
+  swapLine.textContent = `${from || "the model"} → ${to}${cat ? " · " + cat : ""}`;
+  body.appendChild(swapLine);
+  const expl = (ev.explanation || "").trim();
+  if (expl) { const p = el("div", "refusal-explanation"); p.textContent = expl; body.appendChild(p); }
+  if (ev.md) { const p = el("div", "refusal-cli-line"); p.textContent = ev.md; body.appendChild(p); }
+  const turn = noticeCard({ variant: "refusal", chip: "safeguards", head, body,
+                            collapsible: body.childNodes.length > 0, key: ev.uuid ? "mswap:" + ev.uuid : undefined });
+  turn.querySelector(".notice-head-text")?.setAttribute("title", head);
   return turn;
 }
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1528,14 +1528,7 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
    so a storm that produced nothing never reads like a recovery (the user 2026-07-25) */
 .gaveup-text { color: var(--st-blocked-bg); font-weight: 600; }
 /* the durable "safeguards flagged → switched model" note (the user 2026-08-03: a mid-turn model swap
-   must be apparent in the chat, never silent) — the retried note's slim rail treatment in the warning
-   voice; the CLI's full explanation expands below the line on click */
-.modelswap-text { color: var(--warn, #d7a23a); font-weight: 600; }
-.modelswap-line { cursor: pointer; }
-.modelswap-line:hover .modelswap-text { filter: brightness(1.15); }
-.modelswap-body { display: none; color: var(--dim); font-size: 0.92em; margin: 4px 0 2px;
-  white-space: pre-wrap; max-width: 72ch; }
-.modelswap-body.expanded { display: block; }
+   must be apparent in the chat, never silent) is a notice card since T279: see .notice-card-refusal */
 /* the durable record of a died turn — the live card's chrome without its buttons; slightly dimmer body
    so history reads calmer than the ACTIVE blocked card while staying unmistakably an error */
 .apierror-note .apierror-body { color: var(--dim); }
@@ -2383,6 +2376,15 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
 .notice-card-clear { border-left-color: var(--dim); }
 .notice-chip-clear { color: var(--dim); border-color: var(--dim); }
 .notice-dot-clear { border-color: var(--dim); }
+/* a safeguards refusal the CLI retried on a fallback model (T279): the heads-up amber — attention, not an
+   error. The fold: the API's explanation, then the CLI's own line, dimmed. */
+.notice-card-refusal { border-left-color: var(--warn, #d7a23a); }
+.notice-chip-refusal { color: var(--warn, #d7a23a); border-color: var(--warn, #d7a23a); }
+.notice-dot-refusal { border-color: var(--warn, #d7a23a); }
+.refusal-swap { font-weight: 600; }
+.refusal-cli-line { color: var(--dim); }
+.refusal-swap + .refusal-explanation, .refusal-swap + .refusal-cli-line,
+.refusal-explanation + .refusal-cli-line { margin-top: 6px; }
 .clear-loading { display: inline-flex; align-items: center; gap: 8px; }
 .clear-truncated { color: var(--dim); padding: 4px 0 6px; }
 


### PR DESCRIPTION
## What

A new Claude Code system event, `model_refusal_fallback` (the model's safeguards declined the request and the CLI retried the turn on the configured fallback model), reached the SDK backend and fell to the once-per-life "unhandled SystemMessage subtype" log line. Nothing was filed for the judges: their only record of the swap was the capacity-fallback card the fallback reply's own model learn minted, with the wrong cause ("an API-side capacity fallback"). The chat notice (from the transcript record) dropped the refusal category and the API's explanation.

Now the frame is handled at every hop:

- **Stream (kernel/sdk_backend.py):** a branch for the subtype, placed before the unhandled memo, files the frame through a kernel-wired class-level hook (the `on_model_fallback` idiom) with pretty model names, the refusal category, the API's explanation and the scope. The unhandled line no longer fires for it. A failing hook is a logged problem, never a raise into the stream loop.
- **Judges (kernel/judge.py):** `mint_refusal_fallback_card` files a completed card naming the refusal: the category in the title, the explanation in the rationale, with its own why key and the swap as data. The fallback model's reply streams before the CLI's end-of-turn notice, and its model learn has already filed the swap as a capacity fallback, so the backend keeps the ids of the capacity cards its learn minted this turn (forgotten at the settle) and the filing folds the ones on the chain from the refused model to the answering one into the fresh refusal card with the store's existing merge (`_merge_nodes`): one swap, one card, and no field of an existing node is rewritten, so a concurrent store writer cannot half-revert it (the refusal node is adopted wholesale by a rebase; each folded card's deletion is a durable tombstone). An earlier hop's refusal card of the same episode (keyed by the refused prompt's uuid) folds the same way; a `provisional` frame (an intermediate hop of a multi-hop chain) files like any other, since on the CLI's chain path no final frame need follow it; the next hop's frame folds its card by episode. A card the user cleared, followed up on, or otherwise stamped is left alone and the refusal files fresh beside it. `mint_fallback_card` stands down when a refusal card for the swap is already on the board. The rollup runs with `session_closed=False`, so the filing never forces the settle of the session's focus card. A frame without model ids is a logged problem, not a card; an unwired hook is said once per kernel life.
- **Transcript → chat event (kernel/event_model.py, kernel/kernel.py):** the atom and the `modelFallback` event carry `category`, `explanation` and `scope`; the kernel wires the hook at boot.
- **Pane (ui/webview/render.ts, styles.css):** the notice is a sourced notice card in the shared notice-card grammar: a "safeguards" chip in the heads-up amber, a head naming whose safeguards flagged the message, the category, and which model answered ("switched to X", or "this reply came from X" for a local scope), and a keyed fold holding the API's explanation and the CLI's own line verbatim. Never the user's bubble. The old slim rail line and its private CSS are gone.

## Field names: the CLI's own schema, not one sample

The public SDK docs do not yet document this subtype. The field list comes from the stream-json schema embedded in the installed CLI (bundled CLI 2.1.259, matching the system CLI 2.1.257): `original_model`, `fallback_model`, `request_id`, `api_refusal_category` (open string; null when neither lane carried one, described as normal), `api_refusal_explanation` (display-only prose; null on server-lane banners), `scope` (`session` | `local`; absent on older CLIs, to be read as `session`), `retracted_message_uuids`, `refused_user_message_uuid`, `direction`, `trigger`, `content`. The transcript record carries the same fields in camelCase (`apiRefusalCategory`, `apiRefusalExplanation`, `originalModel`, `fallbackModel`, `scope`). The sibling `model_refusal_no_fallback` is left as-is: it is the blocked API-error path, already surfaced by the error classification.

## Tests (red first)

- `tests/test_refusal_fallback_notice.py`: the stream branch calls the hook with the normalised fields (null → "", absent scope → session, local rides through and claims no card), the learn captures the capacity card's id and the settle forgets it, every card of the turn rides the hook, a provisional frame files too (the episode fold collapses hops), the unhandled line no longer fires, an unwired hook is said once, a frame without model ids is a logged problem, a failing hook is a logged problem, the branch order is pinned; the card mints completed with the category and explanation, dedupes, folds the same turn's capacity card (and a multi-hop chain of them, and an earlier hop of the same episode), leaves a followed-up or cleared capacity card alone, files fresh on an unknown id, stands the capacity mint down after a refusal card; the kernel wiring is pinned.
- `tests/test_model_fallback_notice.py`: the atom and the chat event carry the new fields; the notice text is never a user event.
- `tests/test_refusal_notice_served.py`: the served chat page against a hermetic kernel renders one refusal notice card with the safeguards chip, a head naming both models and the category (the full head as the hover), the collapsed fold restating the swap and holding the explanation and the CLI line, the notice's rail dot, before the fallback model's reply, and no user bubble carrying the text; a head click opens the fold.
- `ui/webview/model-fallback.test.ts`: the notice-card pins (variant, chip, head fields, fold keys, CSS variant; the slim line gone).

Synthetic fixtures only (placeholder ids, an invented category and explanation, the notes-api demo world).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
