### PR TITLE
T276c: the two process tests answer the same on every runner (fake pids above pid_max, seams, exact signal sequence)

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -7216,7 +7216,8 @@ class SdkBackend:
         except PermissionError:
             return True
 
-    def _end_cli_tree(self, pid: int, ps_lines: list[str], kill=None, run=None, cgroup=None) -> dict:
+    def _end_cli_tree(self, pid: int, ps_lines: list[str], kill=None, run=None, cgroup=None,
+                      killpg=None, alive=None, sleep=None, now=None) -> dict:
         """End an orphaned session CLI and EVERYTHING it left behind (T276): its scope unit when it runs
         in one (systemd ends every process in the cgroup, a tool shell's setsid children and any
         re-parented leftover included), and, always, the process tree the `ps` listing still shows
@@ -7229,6 +7230,12 @@ class SdkBackend:
         kill = kill or os.kill
         run = run or subprocess.run
         cgroup = cgroup or _read_cgroup
+        # the process-group kill, the liveness poll and the grace clock are seams too (T276c): a test then
+        # pins the exact signal sequence with no real process, pid or second behind it
+        killpg = killpg or os.killpg
+        alive = alive or self._pid_alive
+        sleep = sleep or time.sleep
+        now = now or time.time
         unit = scope_unit_of(cgroup(pid) or "")
         # The scope must be the CLI's OWN: bin/romp-cli-scope names the unit with the pid the CLI runs as
         # (`romp-session-<sid8>-$$-$t`, then execs into it), so a CLI in its own scope always carries its pid
@@ -7264,7 +7271,7 @@ class SdkBackend:
         def signal_all(sig, only_alive: bool) -> int:
             n = 0
             for p in targets:
-                if only_alive and not self._pid_alive(p):
+                if only_alive and not alive(p):
                     continue
                 if not same(p):
                     continue          # the pid now names another process
@@ -7274,7 +7281,7 @@ class SdkBackend:
                     pg = None
                 try:
                     if pg is not None and pg == p and pg != own_pg:
-                        os.killpg(pg, sig)          # a setsid'd tool child leads its own group: take the group
+                        killpg(pg, sig)             # a setsid'd tool child leads its own group: take the group
                     else:
                         kill(p, sig)
                     n += 1
@@ -7282,10 +7289,10 @@ class SdkBackend:
                     pass
             return n
         signaled = signal_all(signal.SIGTERM, False)   # unconditionally: the OS answers for a pid already gone
-        deadline = time.time() + TREE_KILL_GRACE
-        while time.time() < deadline and any(self._pid_alive(p) for p in targets):
-            time.sleep(0.05)
-        forced = signal_all(signal.SIGKILL, True) if any(self._pid_alive(p) for p in targets) else 0
+        deadline = now() + TREE_KILL_GRACE
+        while now() < deadline and any(alive(p) for p in targets):
+            sleep(0.05)
+        forced = signal_all(signal.SIGKILL, True) if any(alive(p) for p in targets) else 0
         return {"scope": unit if stopped else None, "signaled": signaled, "forced": forced, "tree": len(targets) - 1}
 
     def _stop_leftover_scopes(self, lastsids: list[str], run=None) -> int:

--- a/tests/test_cut_turn_tree_kill.py
+++ b/tests/test_cut_turn_tree_kill.py
@@ -165,6 +165,29 @@ class ScopePath(unittest.TestCase):
         self.assertIsNone(out["scope"])
         self.assertEqual(out["tree"], 2)
 
+    def test_a_survivor_of_the_grace_gets_sigkill_on_a_fake_clock(self):
+        # The escalation, pinned with no real process, pid or second behind it (T276c): the liveness poll,
+        # the grace sleep and the clock are seams. The loop ignores its SIGTERM; the clock steps past the
+        # grace in recorded sleeps; exactly the survivor is SIGKILLed, once, after every SIGTERM.
+        be = _backend()
+        killed, slept, clock = [], [], [0.0]
+        ps = ("  %d %d /x/claude --input-format stream-json --resume %s\n"
+              "  %d %d bash -c tool\n"
+              "  %d %d sleep 300\n") % (CLI, MANAGER, SID, TOOL, CLI, LOOP, TOOL)
+        def alive(p):                    # the loop outlives its SIGTERM until its SIGKILL is recorded
+            return p == LOOP and (LOOP, signal.SIGKILL) not in killed
+        def sleep(s):
+            slept.append(s); clock[0] += s
+        out = be._end_cli_tree(CLI, ps.splitlines(), kill=lambda p, s: killed.append((p, s)),
+                               run=lambda *a, **k: None, cgroup=lambda pid: "",
+                               alive=alive, sleep=sleep, now=lambda: clock[0])
+        self.assertEqual(killed, [(TOOL, signal.SIGTERM), (LOOP, signal.SIGTERM), (CLI, signal.SIGTERM),
+                                  (LOOP, signal.SIGKILL)],
+                         "SIGTERM to the tree children-first then the CLI; SIGKILL to the one survivor only")
+        self.assertTrue(slept and all(s == 0.05 for s in slept), "the grace waits in short recorded sleeps")
+        self.assertGreaterEqual(clock[0], sb.TREE_KILL_GRACE, "…until the fake clock passes the grace")
+        self.assertEqual((out["signaled"], out["forced"], out["tree"]), (3, 1, 2))
+
     def test_the_leftover_scope_sweep_stops_our_dead_sessions_scopes_only(self):
         be = _backend()
         # a real child of THIS process stands in for "this kernel's live session": its unit is skipped

--- a/tests/test_cut_turn_tree_kill.py
+++ b/tests/test_cut_turn_tree_kill.py
@@ -179,6 +179,7 @@ class ScopePath(unittest.TestCase):
         def sleep(s):
             slept.append(s); clock[0] += s
         out = be._end_cli_tree(CLI, ps.splitlines(), kill=lambda p, s: killed.append((p, s)),
+                               killpg=lambda g, s: killed.append(("pg", g, s)),   # a group kill would show up, not fire
                                run=lambda *a, **k: None, cgroup=lambda pid: "",
                                alive=alive, sleep=sleep, now=lambda: clock[0])
         self.assertEqual(killed, [(TOOL, signal.SIGTERM), (LOOP, signal.SIGTERM), (CLI, signal.SIGTERM),

--- a/tests/test_file_github.py
+++ b/tests/test_file_github.py
@@ -19,6 +19,7 @@ import threading
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
+from unittest import mock
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -418,25 +419,32 @@ class BranchOnOrigin(_WithOrigin):
     def test_the_cut_kills_the_ssh_git_spawned_not_git_alone(self):
         # subprocess.run's timeout kill reached git alone; the ssh it had spawned sat in its TCP connect
         # for minutes after the viewer was told "could not check" (reproduced 2026-09-05). The query
-        # runs in its own session now and the deadline kills the whole group.
-        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
-        pidfile = os.path.join(self.root, "stuck-ssh.pid")
-        os.environ["GIT_SSH_COMMAND"] = _script(self.root, "stuck-ssh",
-                                                "echo $$ > '%s'\nexec sleep 30\n" % pidfile)
-        real = km.GH_LS_REMOTE_S
-        km.GH_LS_REMOTE_S = 0.3
-        try:
-            self.assertEqual(km._file_github_link(self.fp, None),
-                             (self.URL % "wip", "could not check whether branch wip is on origin"))
-        finally:
-            km.GH_LS_REMOTE_S = real
-        self.assertTrue(os.path.exists(pidfile), "the stand-in ssh ran before the cut")
-        pid = int(open(pidfile).read())
-        self.addCleanup(_kill_quiet, pid)
-        deadline = time.time() + 3
-        while _alive(pid) and time.time() < deadline:
-            time.sleep(0.02)
-        self.assertFalse(_alive(pid), "the ssh git spawned outlived the cut")
+        # runs in its own session now and the deadline kills the whole group. Pinned on the MECHANISM
+        # (T276c): the earlier version raced a real git against a 0.3 s deadline and a stand-in ssh's
+        # pidfile — on a slow runner git had not reached ssh by the cut, and the test flaked. Here a fake
+        # Popen stands in for git: its first communicate times out, and the query must (1) have started
+        # git in its own session (start_new_session, so the pid IS the group) and (2) kill THE GROUP by
+        # that pid with SIGKILL, then reap — the two facts that reach the ssh under git.
+        calls = {"popen": [], "killpg": [], "communicate": 0}
+        class FakeGit:
+            pid = 7_654_321                      # above pid_max: never a live process on the box
+            def communicate(self, timeout=None):
+                calls["communicate"] += 1
+                if calls["communicate"] == 1:
+                    raise subprocess.TimeoutExpired(cmd="git", timeout=timeout)
+                return ("", "")
+            def kill(self):
+                calls.setdefault("kill", 0); calls["kill"] += 1
+        def fake_popen(argv, **kw):
+            calls["popen"].append((list(argv), kw)); return FakeGit()
+        with mock.patch.object(km.subprocess, "Popen", side_effect=fake_popen), \
+             mock.patch.object(km.os, "killpg", side_effect=lambda g, s: calls["killpg"].append((g, s))):
+            out = km._git_net_out(["ls-remote", "--exit-code", "--heads", "origin", "wip"], self.tmp, 0.3, dict(os.environ))
+        self.assertIsNone(out, "a timed-out query has no answer")
+        self.assertEqual(len(calls["popen"]), 1)
+        self.assertTrue(calls["popen"][0][1].get("start_new_session"), "git starts in its own session, so its pid names the whole group")
+        self.assertEqual(calls["killpg"], [(FakeGit.pid, km.signal.SIGKILL)], "the deadline kills the GROUP under git's pid — the ssh with it")
+        self.assertEqual(calls["communicate"], 2, "…and the dead group is reaped")
 
     def test_a_detached_sha_is_never_checked(self):
         sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=self.tmp,

--- a/tests/test_file_github.py
+++ b/tests/test_file_github.py
@@ -93,27 +93,6 @@ def _git_version():
     return tuple(int(x) for x in out.split()[2].split(".")[:2])
 
 
-def _alive(pid):
-    """Whether `pid` is still a running process. A zombie counts as gone: it has been killed and only
-    awaits its reaper (init, once its parent died with it)."""
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    try:
-        with open("/proc/%d/stat" % pid) as f:
-            return f.read().rsplit(")", 1)[-1].split()[0] != "Z"
-    except OSError:
-        return True
-
-
-def _kill_quiet(pid):
-    try:
-        os.kill(pid, 9)
-    except OSError:
-        pass
-
-
 class _Repo(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.mkdtemp()

--- a/tests/test_sdk_lifecycle_hardening.py
+++ b/tests/test_sdk_lifecycle_hardening.py
@@ -48,6 +48,18 @@ def _backend(d=None):
     return sb.SdkBackend(d or tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
 
 
+def _pid_max() -> int:
+    """Fake pids above this can never be a live process on the box (T276c) — the reaper's liveness poll and
+    os.getpgid then answer deterministically for them on every runner."""
+    try:
+        return int(open("/proc/sys/kernel/pid_max").read().strip())
+    except (OSError, ValueError):
+        return 4194304
+
+
+_P = _pid_max()
+
+
 def _reg(d, sid, **extra):
     r = {"sid": sid, "name": "s-" + sid[:4], "cwd": "/tmp", "alive": True, "lastSid": sid}
     r.update(extra)
@@ -427,18 +439,24 @@ class BootReconcile(unittest.TestCase):
         _reg(d, sid)
         sb.append_state(Path(d), sid, "working")
         me = os.getpid()
-        ps = ("  901 1 /usr/lib/systemd/systemd --user\n"
-              "  %d 901 python3 ./kernel.py\n"
-              "  558 %d /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
-              "  559 901 /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
-              ) % (me, me, sid, sid)
+        # fake pids above pid_max (T276c): a live runner process wearing a small fake pid made the tree kill
+        # take a REAL process group (os.getpgid succeeded, killpg went unrecorded — an empty list on one
+        # interpreter) or escalate to SIGKILL (the liveness poll saw it alive — an extra signal on another)
+        MANAGER, OURS, ORPHAN = _P + 901, _P + 558, _P + 559
+        ps = ("  %d 1 /usr/lib/systemd/systemd --user\n"
+              "  %d %d python3 ./kernel.py\n"
+              "  %d %d /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
+              "  %d %d /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
+              ) % (MANAGER, me, MANAGER, OURS, me, sid, ORPHAN, MANAGER, sid)
         killed = []
         with mock.patch.object(sb.subprocess, "run", return_value=mock.Mock(stdout=ps)), \
-             mock.patch.object(sb.os, "kill", side_effect=lambda p, s: killed.append((p, s))):
+             mock.patch.object(sb.os, "kill", side_effect=lambda p, s: killed.append((p, s))), \
+             mock.patch.object(sb.os, "killpg", side_effect=lambda g, s: killed.append(("pg", g, s))), \
+             mock.patch.object(sb.SdkBackend, "_pid_alive", lambda self, p: False):   # nothing is alive after its SIGTERM: no grace, no SIGKILL
             be._boot_reconcile([sb.read_reg(Path(d), sid)])
-        self.assertEqual(killed, [(559, sb.signal.SIGTERM)],
+        self.assertEqual(killed, [(ORPHAN, sb.signal.SIGTERM)],
                          "a child this kernel already spawned is left alone whatever ps calls the kernel; "
-                         "the orphan under the user manager is still reaped")
+                         "the orphan under the user manager is reaped with exactly one SIGTERM — no group kill, no escalation")
 
     def test_reconcile_is_opt_in(self):
         # Constructing the backend plain (tests, ad-hoc) must NOT spawn a reconcile thread; the


### PR DESCRIPTION
Two CI-only flakes made deterministic; no behaviour change in the kernel beyond four call-time seams.

**Reaper shield test** (`tests/test_sdk_lifecycle_hardening.py`): the fixture's fake pids (558/559/901) could name a live process on a runner. Then `os.getpgid` succeeded and the tree kill took a real process group through `os.killpg`, which the test did not record (empty list on 3.12), or the liveness poll saw the pid alive and escalated (extra SIGKILL on 3.10). Fake pids now sit above `pid_max`, `os.killpg` is recorded, the liveness poll is pinned dead, and the assertion pins the exact sequence.

**Git cut test** (`tests/test_file_github.py`): it raced a real git against a 0.3 s deadline and a stand-in ssh's pidfile. On a slow runner git had not reached ssh by the cut. It now pins the mechanism on seams: fake `Popen` whose first `communicate` times out; the query must start git in its own session, `killpg(pid, SIGKILL)`, then reap.

**Seams** (`kernel/sdk_backend.py::_end_cli_tree`): `killpg`, `alive`, `sleep`, `now`, resolved at call time like the existing ones. A new test in `tests/test_cut_turn_tree_kill.py` drives the SIGKILL escalation on a fake clock with recorded sleeps.

Before/after loop counts (20 sequential runs each, own transient scope, no load) are in the task report; both tests were already 20/20 on the devbox, which is why the fix targets the mechanism rather than a timing constant.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
