### PR TITLE
Jobs stage: the clear set is parsed once per file state, and the wake sweep reads the shared view

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -908,7 +908,9 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   (`hit`, `miss`, `populate`, `bypass`); `nudgeGate` is the auto-nudge walk's
   planner-placement gate, derived once per (parse, store) and served while
   both stand (`served`, `derived`; a healthy quiet box serves almost every
-  cycle). The compaction sweep after each judge pass evicts from `pass` and
+  cycle); `cleared` is the feed's clear set, parsed once per state of
+  `cleared.jsonl` (its stat, taken before the read) and served while the file
+  stands (`served`, `derived`). The compaction sweep after each judge pass evicts from `pass` and
   `shared` the entries of stores no session in the discover window owns, so
   both stay bounded by the live board; the gate memo is bounded by the session
   count.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9166,7 +9166,9 @@ def _auto_nudge_pass(now, tmux, run_dead_wait):
     alive_ids = {s["sid"] for s in alive}
     waitfor = _wait_for_graph(now, alive_ids)             # {sid:{peerSid,name,inCycle}} — the peer-wait gate
     fired = False
-    cleared = _cleared_ids()                              # one parsed clear set for every session this pass walks (2026-09-09)
+    cleared = _cleared_ids()                              # one parsed clear set for every session this pass walks (2026-09-09):
+    #                                                       a clear landing mid-pass reaches the later sessions next pass; the
+    #                                                       node's own cleared flag, written in the same gesture, covers the gap
     for s in alive:
         # PER-SESSION ISOLATION (2026-07-16): one session's failure — a bad backend snapshot, a
         # malformed store — must not abort the whole tick and silence nudging fleet-wide. A
@@ -30559,7 +30561,8 @@ def build_episode(sid, now):
 
 # ───────────────────────── feed clear / undo (inbox-zero) ─────────────────────────
 _CLEARED_MEMO = {"slot": None}     # (key, parsed set) or None: the clear log's stat taken BEFORE the read, and the set read under it
-_CLEARED_STATS = {"served": 0, "derived": 0}
+_CLEARED_STATS = {"served": 0, "derived": 0}   # bumped from the pusher AND socket threads (undo, connect-time builds) with
+#                                                no lock: a lost count under a race is tolerated, these are diagnostics only
 
 
 def _cleared_ids():
@@ -30599,7 +30602,7 @@ def _cleared_ids():
                 cur[iid] = o.get("t", 0)
     except OSError:
         _CLEARED_STATS["derived"] += 1
-        return cur                                       # vanished between the stat and the read: empty, uncached
+        return cur                                       # absent, vanished after the stat, or unreadable: empty, uncached
     _CLEARED_STATS["derived"] += 1
     if key is not None:
         _CLEARED_MEMO["slot"] = (key, cur)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -382,6 +382,7 @@ class _PerfStats:
             except Exception:
                 memos[key] = {}
         memos["nudgeGate"] = dict(_NUDGE_GATE_STATS)   # the nudge walk's placement gate: served vs re-derived (2026-09-09)
+        memos["cleared"] = dict(_CLEARED_STATS)       # the clear set: parsed once per file state, served while it stands (2026-09-09)
         now = time.time()
         return {"now": now, "since": since, "uptime_s": now - _STARTED, "log": _PERF,
                 "process": _process_stats(), "pusher": pusher, "stages_ms": stages,
@@ -9165,6 +9166,7 @@ def _auto_nudge_pass(now, tmux, run_dead_wait):
     alive_ids = {s["sid"] for s in alive}
     waitfor = _wait_for_graph(now, alive_ids)             # {sid:{peerSid,name,inCycle}} — the peer-wait gate
     fired = False
+    cleared = _cleared_ids()                              # one parsed clear set for every session this pass walks (2026-09-09)
     for s in alive:
         # PER-SESSION ISOLATION (2026-07-16): one session's failure — a bad backend snapshot, a
         # malformed store — must not abort the whole tick and silence nudging fleet-wide. A
@@ -9172,7 +9174,7 @@ def _auto_nudge_pass(now, tmux, run_dead_wait):
         # ticks over two days before anyone noticed; every session after the bad one in the
         # iteration lost its nudges. The failure still logs loudly, per session.
         try:
-            r = _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids, wake_only=not on)
+            r = _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids, wake_only=not on, cleared=cleared)
             fired = (r is True) or fired
             # the walk->sweep handoff journal (the user 2026-08-24): a session gate names itself as
             # the return value; the sweep owns gate-held records by the GATE'S CLASS, never by age
@@ -10255,7 +10257,8 @@ def _awaiting_wake_outcomes(now, walked=None):
             if (walked is not None and sid in walked) and _gate not in WALK_GATES_WEDGE:
                 continue                             # the walk owns it: no gate, or one whose ending
                 #                                      event re-runs the walk (transient/judge-owned)
-            store = jd.load_goals(sid)
+            store = jd.load_goals_shared(sid)         # the read-only view: nodes, status, confirming, placements (a fresh
+            #                                              writer load per record was the pusher's remaining goal loads, 2026-09-09)
             nd = store.get("nodes", {}).get(gid)
             if (nd is None or store.get("status", {}).get(gid, "working") != "working"
                     or gid in set(store.get("confirming") or ())):
@@ -10270,7 +10273,8 @@ def _awaiting_wake_outcomes(now, walked=None):
                 # answered and ruled — re-arm from the answer, exactly as the walk's eval would have (the
                 # walk never got to: its session gates held, e.g. an api-error AFTER the judged response)
                 _put_nudged(gid, dict(rec, answeredAt=(resp.get("t") or int(now))))
-                _file_wake_answer(store, sid, gid, now)   # …and the answer files, same as the walk's leg
+                _file_wake_answer(jd.load_goals(sid), sid, gid, now)   # …and the answer files, same as the walk's leg: the
+                #                                              filing saves, so it takes a writer load; the view is frozen
                 continue
             if resp is not None:
                 continue                             # visible but not ruled yet — the judges own it
@@ -10819,7 +10823,7 @@ def _nudge_placement_gate(sid, turns, store):
     return unplanned
 
 
-def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None, wake_only=False):
+def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None, wake_only=False, cleared=None):
     """One session's slice of the auto-nudge tick: the session-level gates, then the fire/stamp
     walk over its still-'working' top goals. Split from _auto_nudge_tick so the tick isolates
     failures per session (see the tick's loop). Mutates `nudged` (the tick's in-memory mirror);
@@ -10932,7 +10936,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None, wake_only
     if _unplanned:
         return "planner-queue"
     nodes, status = store.get("nodes", {}), store.get("status", {})
-    cleared = _cleared_ids()
+    cleared = _cleared_ids() if cleared is None else cleared   # the pass hands every session the one parsed set
     _kids = {}                                       # child map for the FORK-stalled check below
     for _nid, _nd in nodes.items():
         _kids.setdefault(_nd.get("parentId"), []).append(_nid)
@@ -30554,13 +30558,34 @@ def build_episode(sid, now):
 
 
 # ───────────────────────── feed clear / undo (inbox-zero) ─────────────────────────
+_CLEARED_MEMO = {"slot": None}     # (key, parsed set) or None: the clear log's stat taken BEFORE the read, and the set read under it
+_CLEARED_STATS = {"served": 0, "derived": 0}
+
+
 def _cleared_ids():
     """The set of currently-cleared feed itemIds (asks + stream), replayed from the append-only
     cleared.jsonl: a 'clear' row adds an id, an 'undo' row removes it (newest-wins). Mirrors the old
-    kernel's shared cleared.jsonl so one Clear hides both an ask card and its stream deliverable."""
+    kernel's shared cleared.jsonl so one Clear hides both an ask card and its stream deliverable.
+
+    Parsed once per file state and served while the file stands (2026-09-09): the nudge walk read it for
+    every session on every pusher cycle, and once the placement gate was memoized this replay of the whole
+    log (two thousand rows on the maintainer's box) was 60% of the nudge tick. The key is the file's path
+    and stat (mtime_ns, size, inode), taken BEFORE the read (the chain-memo rule): a row appended during the
+    read moves the stat the next call takes, so a set parsed mid-write is served no further than that call;
+    every writer appends, so a same-second append moves the size (the kernel's file clock is coarse, so
+    mtime alone would not see it); a rebound state root is a different path. An absent or unreadable file
+    is the empty set, never cached. One slot, replaced whole, so two threads deriving at once can never pair
+    one's key with the other's set. Callers read the returned dict and never mutate it."""
+    path = jd.STATE / "cleared.jsonl"
+    st = _stat_key(path)
+    key = (str(path),) + st if st is not None else None
+    slot = _CLEARED_MEMO["slot"]
+    if key is not None and slot is not None and slot[0] == key:
+        _CLEARED_STATS["served"] += 1
+        return slot[1]
     cur = {}
     try:
-        for line in (jd.STATE / "cleared.jsonl").read_text().splitlines():
+        for line in path.read_text().splitlines():
             try:
                 o = json.loads(line)
             except Exception:
@@ -30573,7 +30598,11 @@ def _cleared_ids():
             else:
                 cur[iid] = o.get("t", 0)
     except OSError:
-        pass
+        _CLEARED_STATS["derived"] += 1
+        return cur                                       # vanished between the stat and the read: empty, uncached
+    _CLEARED_STATS["derived"] += 1
+    if key is not None:
+        _CLEARED_MEMO["slot"] = (key, cur)
     return cur
 
 

--- a/tests/test_cleared_set_memo.py
+++ b/tests/test_cleared_set_memo.py
@@ -157,17 +157,52 @@ class ClearSetMemo(_Memo):
         self.assertEqual(km._cleared_ids(), {G1: NOW - 100, G2: NOW})
 
 
-class PassHoist(unittest.TestCase):
-    def test_the_pass_parses_once_and_hands_every_session_the_set(self):
-        src = inspect.getsource(km._auto_nudge_pass)
-        self.assertIn("cleared = _cleared_ids()", src, "hoisted before the alive loop")
-        self.assertIn("cleared=cleared", src, "and handed to every session")
+class PassHoist(_Memo):
+    def test_the_pass_parses_once_and_hands_every_session_the_same_set(self):
+        # BEHAVIOURAL, not a source pin: two alive sessions, the real pass, the walk a recorder. The clear
+        # log is parsed once for the pass and both walks receive the very same dict.
+        self._append(self._clear(G1, NOW - 100))
+        A, B = SID, "11111111-2222-3333-4444-888888888803"
+        seen, calls = [], []
+        real = km._cleared_ids
+
+        def counting():
+            calls.append(1)
+            return real()
+
+        def walk(s, now, tmux, nudged, waitfor, alive_ids=None, wake_only=False, cleared=None):
+            seen.append(cleared)
+            return False
+        saved = {n: getattr(km, n) for n in
+                 ("_cleared_ids", "_alive_sessions", "_wait_for_graph", "_auto_nudge_session", "_compact_suggest_tick",
+                  "_debt_backstop_tick", "_dead_wait_sweep", "_awaiting_wake_outcomes", "_push_soon",
+                  "_pop_walk_gate", "_put_walk_gate")}
+        km._cleared_ids = counting
+        km._alive_sessions = lambda now, tmux: [{"sid": A, "path": "/nonexistent-a.jsonl"},
+                                                {"sid": B, "path": "/nonexistent-b.jsonl"}]
+        km._wait_for_graph = lambda now, alive_ids: {}
+        km._auto_nudge_session = walk
+        km._compact_suggest_tick = lambda sid, tm, now: False
+        km._debt_backstop_tick = lambda now: None
+        km._dead_wait_sweep = lambda alive_ids, nudged, now: None
+        km._awaiting_wake_outcomes = lambda now, alive_ids: False
+        km._push_soon = lambda: None
+        km._pop_walk_gate = lambda sid: None
+        km._put_walk_gate = lambda sid, gate, now: None
+        try:
+            km._auto_nudge_pass(NOW, {}, run_dead_wait=False)
+        finally:
+            for n, v in saved.items():
+                setattr(km, n, v)
+        self.assertEqual(len(seen), 2, "both sessions walked")
+        self.assertEqual(calls, [1], "the clear log parsed once for the pass")
+        self.assertIs(seen[0], seen[1], "one set, handed to every session")
+        self.assertEqual(seen[0], {G1: NOW - 100})
+
+    def test_a_walk_without_the_set_derives_it_as_before(self):
         params = inspect.signature(km._auto_nudge_session).parameters
         self.assertIn("cleared", params)
-        self.assertIsNone(params["cleared"].default, "a caller without the set (the tests' direct calls) still works")
-        walk = inspect.getsource(km._auto_nudge_session)
-        self.assertIn("_cleared_ids() if cleared is None else cleared", walk)
-        self.assertEqual(walk.count("_cleared_ids("), 1, "the walk's only read is the fallback")
+        self.assertIsNone(params["cleared"].default)
 
     def test_the_counters_ride_the_perf_snapshot(self):
         snap = km._PERF_STATS.snapshot()

--- a/tests/test_cleared_set_memo.py
+++ b/tests/test_cleared_set_memo.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""The feed's clear set is parsed once per state of cleared.jsonl and served while the file stands
+(2026-09-09), and the nudge pass hands every session it walks the one parsed set.
+
+Measured on the maintainer's box (py-spy over the live kernel, 60 s, after the placement gate was memoized):
+the nudge tick was 73% of the pusher's jobs stage and _cleared_ids() 60% of the tick, a replay of the whole
+append-only log (two thousand rows) for every session on every cycle. Pins: parsed once then served; an
+append re-derives, including one the file clock cannot see (same mtime, larger size); an undo row removes;
+a set read before a write is served no further than that call (the key is the stat taken before the read);
+an absent file is empty and never cached; the key carries the path, so a rebound state root is a new key;
+the pass hoists one set and the walk takes it; the counters ride /perf.
+
+Synthetic ids under a private synthetic sid; a temp state root; nothing real is read."""
+import inspect
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest.mock import patch
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_cleared_memo", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-888888888802"
+G1, G2, G3 = SID + ":g1", SID + ":g2", SID + ":g3"
+NOW = 1_800_000_000
+
+
+class _Memo(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_root = jd.STATE
+        jd._rebind_state(Path(self.td.name))
+        self.path = jd.STATE / "cleared.jsonl"
+        self._reset()
+
+    def tearDown(self):
+        jd._rebind_state(self.saved_root)
+        self._reset()
+        self.td.cleanup()
+
+    def _reset(self):
+        km._CLEARED_MEMO["slot"] = None
+        for k in km._CLEARED_STATS:
+            km._CLEARED_STATS[k] = 0
+
+    def _append(self, *rows):
+        with self.path.open("a") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+
+    @staticmethod
+    def _clear(iid, t):
+        return {"id": iid, "t": t}
+
+    @staticmethod
+    def _undo(iid, t):
+        return {"id": iid, "op": "undo", "t": t}
+
+
+class ClearSetMemo(_Memo):
+    def test_parsed_once_then_served_while_the_file_stands(self):
+        self._append(self._clear(G1, NOW - 100), self._clear(G2, NOW - 50))
+        with patch.object(Path, "read_text", wraps=Path.read_text, autospec=True) as rt:
+            a = km._cleared_ids()
+            b = km._cleared_ids()
+            c = km._cleared_ids()
+        self.assertEqual(a, {G1: NOW - 100, G2: NOW - 50})
+        self.assertIs(b, a); self.assertIs(c, a)
+        self.assertEqual(rt.call_count, 1, "one read of the log over three calls")
+        self.assertEqual(km._CLEARED_STATS, {"served": 2, "derived": 1})
+
+    def test_an_append_re_derives_even_when_the_file_clock_does_not_move(self):
+        self._append(self._clear(G1, NOW - 100))
+        self.assertEqual(km._cleared_ids(), {G1: NOW - 100})
+        before = os.stat(self.path)
+        self._append(self._clear(G2, NOW - 50))
+        os.utime(self.path, ns=(before.st_atime_ns, before.st_mtime_ns))   # the kernel's coarse file clock: same tick
+        self.assertEqual(os.stat(self.path).st_mtime_ns, before.st_mtime_ns)
+        self.assertEqual(km._cleared_ids(), {G1: NOW - 100, G2: NOW - 50}, "the size moved: derived again")
+        self.assertEqual(km._CLEARED_STATS, {"served": 0, "derived": 2})
+
+    def test_an_undo_row_removes_the_id(self):
+        self._append(self._clear(G1, NOW - 100), self._clear(G2, NOW - 100))
+        self.assertEqual(set(km._cleared_ids()), {G1, G2})
+        self._append(self._undo(G2, NOW))
+        self.assertEqual(km._cleared_ids(), {G1: NOW - 100})
+        self.assertEqual(km._CLEARED_STATS["derived"], 2)
+
+    def test_a_set_read_before_a_write_is_served_no_further_than_that_call(self):
+        # INTERLEAVED WRITE: a row lands while the log is being read. The key was taken before the read,
+        # so the set the first call returns (without the row) is cached under a stat the file no longer
+        # has; the next call's stat differs and derives again, with the row.
+        self._append(self._clear(G1, NOW - 100))
+        real = Path.read_text
+        landed = []
+
+        def read_then_write(p, *a, **k):
+            data = real(p, *a, **k)
+            if p == self.path and not landed:
+                landed.append(True)
+                with p.open("a") as f:
+                    f.write(json.dumps(self._clear(G2, NOW)) + "\n")
+            return data
+        with patch.object(Path, "read_text", read_then_write):
+            first = km._cleared_ids()
+        self.assertEqual(first, {G1: NOW - 100}, "what the read saw")
+        self.assertTrue(landed)
+        second = km._cleared_ids()
+        self.assertEqual(second, {G1: NOW - 100, G2: NOW}, "the write moved the stat the second call took")
+        self.assertEqual(km._CLEARED_STATS, {"served": 0, "derived": 2})
+        self.assertIs(km._cleared_ids(), second, "and the newer set is what serves from here")
+
+    def test_an_absent_file_is_empty_and_never_cached(self):
+        self.assertFalse(self.path.exists())
+        self.assertEqual(km._cleared_ids(), {})
+        self.assertEqual(km._cleared_ids(), {})
+        self.assertEqual(km._CLEARED_STATS, {"served": 0, "derived": 2})
+        self.assertIsNone(km._CLEARED_MEMO["slot"])
+        self._append(self._clear(G3, NOW))
+        self.assertEqual(km._cleared_ids(), {G3: NOW}, "the first row is seen at once")
+
+    def test_the_key_carries_the_path_so_a_rebound_root_is_a_new_key(self):
+        self._append(self._clear(G1, NOW - 100))
+        km._cleared_ids()
+        key = km._CLEARED_MEMO["slot"][0]
+        self.assertEqual(key[0], str(self.path))
+        self.assertEqual(len(key), 4, "path, then the stat's mtime_ns, size and inode")
+        other = tempfile.TemporaryDirectory()
+        try:
+            jd._rebind_state(Path(other.name))
+            (jd.STATE / "cleared.jsonl").write_text(json.dumps(self._clear(G2, NOW)) + "\n")
+            self.assertEqual(km._cleared_ids(), {G2: NOW}, "the other root's log, not the cached set")
+        finally:
+            jd._rebind_state(Path(self.td.name))
+            other.cleanup()
+
+    def test_a_malformed_row_is_skipped_as_before(self):
+        self._append(self._clear(G1, NOW - 100))
+        with self.path.open("a") as f:
+            f.write("{not json\n")
+        self._append({"t": NOW}, self._clear(G2, NOW))
+        self.assertEqual(km._cleared_ids(), {G1: NOW - 100, G2: NOW})
+
+
+class PassHoist(unittest.TestCase):
+    def test_the_pass_parses_once_and_hands_every_session_the_set(self):
+        src = inspect.getsource(km._auto_nudge_pass)
+        self.assertIn("cleared = _cleared_ids()", src, "hoisted before the alive loop")
+        self.assertIn("cleared=cleared", src, "and handed to every session")
+        params = inspect.signature(km._auto_nudge_session).parameters
+        self.assertIn("cleared", params)
+        self.assertIsNone(params["cleared"].default, "a caller without the set (the tests' direct calls) still works")
+        walk = inspect.getsource(km._auto_nudge_session)
+        self.assertIn("_cleared_ids() if cleared is None else cleared", walk)
+        self.assertEqual(walk.count("_cleared_ids("), 1, "the walk's only read is the fallback")
+
+    def test_the_counters_ride_the_perf_snapshot(self):
+        snap = km._PERF_STATS.snapshot()
+        self.assertEqual(set(snap["memos"]["cleared"]), {"served", "derived"})
+        self.assertEqual(snap["memos"]["cleared"], dict(km._CLEARED_STATS))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cleared_set_memo.py
+++ b/tests/test_cleared_set_memo.py
@@ -69,13 +69,19 @@ class _Memo(unittest.TestCase):
 class ClearSetMemo(_Memo):
     def test_parsed_once_then_served_while_the_file_stands(self):
         self._append(self._clear(G1, NOW - 100), self._clear(G2, NOW - 50))
-        with patch.object(Path, "read_text", wraps=Path.read_text, autospec=True) as rt:
+        real, reads = Path.read_text, []                 # a plain wrapper: an autospec'd wrap does not call through on 3.10
+
+        def counting(p, *a, **k):
+            if p == self.path:
+                reads.append(p)
+            return real(p, *a, **k)
+        with patch.object(Path, "read_text", counting):
             a = km._cleared_ids()
             b = km._cleared_ids()
             c = km._cleared_ids()
         self.assertEqual(a, {G1: NOW - 100, G2: NOW - 50})
         self.assertIs(b, a); self.assertIs(c, a)
-        self.assertEqual(rt.call_count, 1, "one read of the log over three calls")
+        self.assertEqual(len(reads), 1, "one read of the log over three calls")
         self.assertEqual(km._CLEARED_STATS, {"served": 2, "derived": 1})
 
     def test_an_append_re_derives_even_when_the_file_clock_does_not_move(self):

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -789,25 +789,31 @@ class AwaitingWakeOutcomeSweep(unittest.TestCase):
         self.assertFalse(km.jd.load_goals(SID)["nodes"][self.gid]["blocked"])
 
 
-    def test_sweep_decides_through_the_shared_view_and_never_asks_the_writer_for_an_inert_record(self):
+    def test_sweep_escalates_through_the_view_and_the_writer_loads_only_to_stamp(self):
         # T267d (2026-09-09): the sweep's per-record store read takes the shared read-only view
         # (kernel/judge.py load_goals_shared); a fresh writer load per record was the pusher's remaining
-        # goal loads once the walk's own read moved. Decisions unchanged: a walked, ungated record is the
-        # walk's, and the writer's loader is never asked for it.
+        # goal loads once the walk's own read moved. Decision unchanged: a silent due wake the walk cannot
+        # reach still escalates; the view is read once for the record, and the writer's loader is asked
+        # exactly once, by the stamp itself (_mark_nudge_failed), never to decide.
         now = 1_000_000
         self._seed_goal(at=now - 20 * 3600)
-        self._seed_rec({"wake": True, "anchor": now - 20 * 3600, "count": 1, "lastTurnId": "t1",
-                        "armAtoms": 0, "at": now - 3600})
+        self._seed_rec({"wake": True, "anchor": now - 20 * 3600, "count": 1, "lastTurnId": "t0",
+                        "armAtoms": 0, "at": now - 7 * 3600})
         km.jd._shared_clear()
-        private, o_load = [], km.jd.load_goals
-        km.jd.load_goals = lambda fsid: (private.append(fsid), o_load(fsid))[1]
-        stats0 = km.jd.shared_store_stats()
+        reads, o_load, o_view = [], km.jd.load_goals, km.jd.load_goals_shared
+        km.jd.load_goals = lambda fsid: (reads.append("writer"), o_load(fsid))[1]
+        km.jd.load_goals_shared = lambda fsid: (reads.append("view"), o_view(fsid))[1]
         try:
-            self.assertFalse(km._awaiting_wake_outcomes(now, walked={SID}))
+            self.assertTrue(km._awaiting_wake_outcomes(now))
         finally:
-            km.jd.load_goals = o_load
-        self.assertEqual(private, [], "the writer's loader is never asked to decide")
-        self.assertFalse(km.jd.load_goals(SID)["nodes"][self.gid]["blocked"])
+            km.jd.load_goals, km.jd.load_goals_shared = o_load, o_view
+        self.assertEqual(reads[0], "view", "the decision reads the view")
+        self.assertEqual(reads.count("view"), 1, "once, for the record")
+        self.assertTrue(len(reads) > 1 and all(r == "writer" for r in reads[1:]),
+                        "every writer load belongs to the stamp, after the decision: %r" % reads)
+        store = km.jd.load_goals(SID)
+        self.assertTrue(store["nodes"][self.gid]["blocked"], "the same escalation as before")
+        self.assertEqual(store["nodes"][self.gid].get("blockWhy"), km.jd.WAKE_BLOCK_WHY)
 
     def test_sweep_leaves_a_cleared_card_alone_through_the_view(self):
         # a due wake whose card the user cleared: the record is inert (not 'working'), no block, no writer load

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -789,6 +789,69 @@ class AwaitingWakeOutcomeSweep(unittest.TestCase):
         self.assertFalse(km.jd.load_goals(SID)["nodes"][self.gid]["blocked"])
 
 
+    def test_sweep_decides_through_the_shared_view_and_never_asks_the_writer_for_an_inert_record(self):
+        # T267d (2026-09-09): the sweep's per-record store read takes the shared read-only view
+        # (kernel/judge.py load_goals_shared); a fresh writer load per record was the pusher's remaining
+        # goal loads once the walk's own read moved. Decisions unchanged: a walked, ungated record is the
+        # walk's, and the writer's loader is never asked for it.
+        now = 1_000_000
+        self._seed_goal(at=now - 20 * 3600)
+        self._seed_rec({"wake": True, "anchor": now - 20 * 3600, "count": 1, "lastTurnId": "t1",
+                        "armAtoms": 0, "at": now - 3600})
+        km.jd._shared_clear()
+        private, o_load = [], km.jd.load_goals
+        km.jd.load_goals = lambda fsid: (private.append(fsid), o_load(fsid))[1]
+        stats0 = km.jd.shared_store_stats()
+        try:
+            self.assertFalse(km._awaiting_wake_outcomes(now, walked={SID}))
+        finally:
+            km.jd.load_goals = o_load
+        self.assertEqual(private, [], "the writer's loader is never asked to decide")
+        self.assertFalse(km.jd.load_goals(SID)["nodes"][self.gid]["blocked"])
+
+    def test_sweep_leaves_a_cleared_card_alone_through_the_view(self):
+        # a due wake whose card the user cleared: the record is inert (not 'working'), no block, no writer load
+        now = 1_000_000
+        self._seed_goal(at=now - 20 * 3600)
+        d = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())
+        d["status"][self.gid] = "cleared"
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(d))
+        self._seed_rec({"wake": True, "anchor": now - 20 * 3600, "count": 1, "lastTurnId": "t0",
+                        "armAtoms": 0, "at": now - 7 * 3600})
+        km.jd._shared_clear()
+        private, o_load = [], km.jd.load_goals
+        km.jd.load_goals = lambda fsid: (private.append(fsid), o_load(fsid))[1]
+        stats0 = km.jd.shared_store_stats()
+        try:
+            self.assertFalse(km._awaiting_wake_outcomes(now))
+        finally:
+            km.jd.load_goals = o_load
+        self.assertEqual(private, [])
+        self.assertEqual(km.jd.shared_store_stats()["miss"] - stats0["miss"], 1, "one view read for the record")
+        self.assertFalse(km.jd.load_goals(SID)["nodes"][self.gid].get("blocked"))
+
+    def test_sweep_files_an_answer_through_one_writer_load(self):
+        # the answered leg SAVES (record_verdict + save_goals), so it alone takes a writer load, exactly one
+        now = 1_000_000
+        self._seed_goal(at=now - 20 * 3600)
+        self._seed_rec({"wake": True, "anchor": now - 20 * 3600, "count": 1, "lastTurnId": "t1",
+                        "armAtoms": 0, "at": now - 7 * 3600})
+        km.jd._shared_clear()
+        saved = km._nudge_response_ready
+        km._nudge_response_ready = lambda *a, **k: (True, {"id": "s9", "t": now - 6 * 3600})
+        private, o_load = [], km.jd.load_goals
+        km.jd.load_goals = lambda fsid: (private.append(fsid), o_load(fsid))[1]
+        try:
+            self.assertFalse(km._awaiting_wake_outcomes(now))
+        finally:
+            km._nudge_response_ready = saved
+            km.jd.load_goals = o_load
+        self.assertEqual(private, [SID], "one writer load, for the filing")
+        self.assertEqual(km._auto_nudge_data()["nudged"][self.gid].get("answeredAt"), now - 6 * 3600)
+        self.assertFalse(km.jd.load_goals(SID)["nodes"][self.gid]["blocked"])
+        self.assertEqual(km.jd.shared_store_stats()["off"], 0, "no write ever reached the frozen view")
+
+
 class WakeBodyKeepsItsCopy(unittest.TestCase):
     """_followup_body(wake=True): the wake's ask survives the hierarchical enumeration branch. The generic
     status ask invites an answer from memory — the audited session twice reassured from memory that its

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -115,9 +115,11 @@ class Collector(unittest.TestCase):
         self.assertIn("cpu_ms_workers", snap["judge"])
         self.assertEqual(set(snap["goals"]), {"loads", "saves", "writes"}, "read through jd.goal_io_stats")
         # the three identity memos' readers land here (review find, 2026-09-08: they had no consumer)
-        self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate"})
+        self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate", "cleared"})
         self.assertEqual(snap["memos"]["nudgeGate"], {"served": 0, "derived": 0},
                          "the nudge walk's placement gate: served vs re-derived (2026-09-09)")
+        self.assertEqual(set(snap["memos"]["cleared"]), {"served", "derived"},
+                         "the clear set: parsed once per file state, served while it stands (2026-09-09)")
         self.assertEqual(snap["memos"]["pass"], km._goals_memo_report())
         self.assertEqual(snap["memos"]["shared"], km.jd.shared_store_stats())
         self.assertEqual(snap["memos"]["chain"], km.jd.chain_memo_stats())

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -1082,7 +1082,7 @@ class AutoNudgeTickIsSingleFlight(_Base):
             setattr(km, n, v)
         super().tearDown()
 
-    def _walk(self, s, now, tmux, nudged, waitfor, alive_ids=None, wake_only=False):   # #936 adds the kwarg (toggle off → wake-only walk)
+    def _walk(self, s, now, tmux, nudged, waitfor, alive_ids=None, wake_only=False, cleared=None):   # #936 adds the kwarg (toggle off → wake-only walk); T267d hands the pass's clear set
         """The per-session walk standing in for the SEND: the first pass to reach it holds here,
         mid-send, until the test releases it; every later pass records and returns at once."""
         self.sends.append(now)


### PR DESCRIPTION
Tier: fix

## What

The jobs stage, second round (T267d; follows the placement-gate memo and the walk's shared-view read). Two hot spots the after-profile of that round named:

1. **The feed's clear set is parsed once per file state.** `_cleared_ids()` replayed the whole append-only `cleared.jsonl` (two thousand rows on the maintainer's box) for every session on every pusher cycle, from inside the nudge walk; once the placement gate was memoized it was 60% of the nudge tick and 44% of the jobs stage. It now keys a one-slot memo on the file's path and stat (`mtime_ns`, size, inode) taken **before** the read (the chain-memo rule), so a row appended during the read moves the stat the next call takes and a set parsed mid-write is served no further than that call. Every writer appends, so a same-second append moves the size (the kernel's file clock is coarse; mtime alone would miss it). An absent or unreadable file is the empty set, never cached. The slot is replaced whole, so two threads deriving at once can never pair one's key with the other's set. The nudge pass hoists one parsed set and hands it to every session it walks (`cleared=`); a caller without it derives as before.

2. **The awaiting-wake sweep reads through the shared view.** `_awaiting_wake_outcomes` took a fresh writer `jd.load_goals` per wake record per pass; that was the pusher's remaining goal loads after the walk's read moved. It reads the read-only view now (nodes, status, confirming, placements). The answered leg saves, so it alone takes a writer load, at the filing moment.

No card-move rule changes: the same inputs decide the same things; only the reads are cheaper.

## Tests

`tests/test_cleared_set_memo.py` (new): parsed once then served (one read over three calls); an append re-derives even when the file clock does not move (same `mtime_ns`, larger size); an undo row removes; a set read before an interleaved write is served no further than that call (the T267c interleaved-write pattern); an absent file is empty and never cached; the key carries the path so a rebound state root is a new key; a malformed row is skipped as before; the real pass over two alive sessions parses once and hands both the same dict; the counters ride `/perf` (`memos.cleared`).

`tests/test_kernel_awaiting_stamp.py` (three new tests in the sweep class): a silent due wake the walk cannot reach still escalates, decided through the view first with every writer load after it, inside the stamp; a due wake whose card was cleared is inert, one view read, no writer load; an answered wake files through exactly one writer load and the frozen view is never written.

`tests/test_perf_stats.py`: the memos key set and the new counter's shape. `docs/reference.md`: the memos passage. `tests/test_setting_gesture_order.py`: the walk stub accepts the new keyword.

## Measurement (before, on the merged first round; the shared box, no synthetic load)

Two `/perf` readings 120 s apart during an active hour, plus a 60 s py-spy sample (3066 samples):

| | |
|---|---|
| pusher cycles | 102 in 120 s (0.85/s); the loop's wait ended by the 0.5 s backstop 74 times, by an event 28 |
| cycle wall | 785 ms mean, p50 487 ms, p90 1428 ms; cycles cover 67% of wall |
| pusher thread CPU | 198 ms per cycle, 17% of a core |
| jobs stage | 49% of wall |
| process CPU | 94% of a core |
| judge tier | 10 passes in 120 s, 11 s each (93% of wall), 73% of a core |
| goal loads | 1172 per judge pass; 115 per pusher cycle |

**What drives the cycle rate.** The loop is `_pusher_cycle()` then `_pusher_wake.wait(0.5)`: it re-enters after at most half a second whether or not anything changed, so the rate is 1 / (cycle wall + 0.5 s), and a cheaper cycle means more cycles, not less pusher time per second. Three waits in four end on the backstop, not an event. The backstop exists for tmux sessions mid-turn, which have no per-message event (the loop's comment, 2026-06-22).

**What an idle cycle costs.** Not separable from the ring yet (it keeps p50, p90 and max); the p50 of 487 ms wall and 198 ms mean thread CPU bound it from above during this window. An idle-cycle counter (a cycle that sent nothing and changed nothing, with its own wall and CPU sums) is the instrumentation to add before touching the cadence.

**Where the process's CPU is.** The pusher thread is 15% of the sample. The judge tier thread (`_run_tier`) is 61%, and 83% of that is `run_triage > run_courier > load_goals`: the courier loads every session's goal store with the writer's loader on every triage pass, plus one per pending row and per sender. The planner worker is 22%. So the number the user watches, the process's CPU share, is set by the judge tier, not the pusher.

**Proposed, not done here.** (a) The pusher waits on its event, with the 0.5 s backstop only while a tmux session is mid-turn, else the earliest due time among the time-based ticks. (b) The courier's per-session scan reads through the shared view and skips a session whose parse and store stat have not moved since its last pass, the same shape as the placement gate; its writes keep the writer's loader. Both are separate rounds.

## After-numbers

Posted below after the deploy restart at matched uptimes (3, 6, 20 min), with loads per cycle and the jobs-stage share.
