### PR TITLE
Courier: skip a session whose inputs have not moved, read the shared view; the pusher counts idle cycles

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -887,9 +887,12 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   `cycle_ms_sum`, `cycle_ms_max` (since start), `cycle_ms_last`,
   `cycle_cpu_ms_sum` (the pusher thread's own CPU time), `cycle_ms_p50`,
   `cycle_ms_p90`, `cycle_ms_ring_max`, `ring_n` from the last 256 cycles,
-  `sends` (every client payload), and `idle_cycles`, `idle_ms_sum`,
-  `idle_cpu_ms_sum` (cycles that set no wake, sent no payload and saved no
-  goal store: what a longer wait between cycles would have skipped).
+  `sends` (every payload that went to a client; a deduped frame the client
+  already holds is not one), and `idle_cycles`, `idle_ms_sum`, `idle_cpu_ms_sum`
+  (cycles that set no wake, sent no payload and saved no goal store: what a
+  longer wait between cycles would have skipped; a conservative undercount,
+  since a wake set by another thread or a periodic repost of an unchanged
+  frame marks a cycle busy).
 - `stages_ms`: `jobs` (the cycle's tick jobs outside the push), `push`, and
   inside it `push.chat`, `push.feed`, `push.timeline`, `push.send`. The
   `push.*` stages count every push, including the one a connecting page gets,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -885,8 +885,11 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
 - `pusher`: `cycles`, `wakes` (every wake call; a burst of wakes runs one
   cycle), `wakes_event` and `wakes_backstop` (how the loop's wait ended),
   `cycle_ms_sum`, `cycle_ms_max` (since start), `cycle_ms_last`,
-  `cycle_cpu_ms_sum` (the pusher thread's own CPU time), and `cycle_ms_p50`,
-  `cycle_ms_p90`, `cycle_ms_ring_max`, `ring_n` from the last 256 cycles.
+  `cycle_cpu_ms_sum` (the pusher thread's own CPU time), `cycle_ms_p50`,
+  `cycle_ms_p90`, `cycle_ms_ring_max`, `ring_n` from the last 256 cycles,
+  `sends` (every client payload), and `idle_cycles`, `idle_ms_sum`,
+  `idle_cpu_ms_sum` (cycles that set no wake, sent no payload and saved no
+  goal store: what a longer wait between cycles would have skipped).
 - `stages_ms`: `jobs` (the cycle's tick jobs outside the push), `push`, and
   inside it `push.chat`, `push.feed`, `push.timeline`, `push.send`. The
   `push.*` stages count every push, including the one a connecting page gets,
@@ -910,7 +913,10 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   both stand (`served`, `derived`; a healthy quiet box serves almost every
   cycle); `cleared` is the feed's clear set, parsed once per state of
   `cleared.jsonl` (its stat, taken before the read) and served while the file
-  stands (`served`, `derived`). The compaction sweep after each judge pass evicts from `pass` and
+  stands (`served`, `derived`); `courierSkip` is the courier's change gate
+  (`skipped`, `scanned`, `recorded`: a session whose parse, store, journal,
+  archive and episode log have not moved since a scan that found nothing to
+  place is skipped whole). The compaction sweep after each judge pass evicts from `pass` and
   `shared` the entries of stores no session in the discover window owns, so
   both stay bounded by the live board; the gate memo is bounded by the session
   count.

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -164,6 +164,7 @@ def _rebind_state(path):
     _lastsid_memo.clear()   # sdk-registry reads are mtime-memoized per sid — a rebind must not serve the old root's values
     _STORE_FAULTS.clear()   # unreadable-store episodes belong to the old root's files
     _CHAIN_MEMO.clear()     # the write-moment chain memo keys on paths under STATESDIR; a new root is a new world
+    _COURIER_SEEN.clear()   # the courier gate keys on the old root's files
     _episode_memo.clear()   # ...and so are the episode-log reads
     _head_memo.clear()      # transcript heads are immutable per path, but a rebind swaps the whole world of paths
     _namefp_memo.clear()    # names-entry content is memoized per SID against same-second mtimes — across a
@@ -2158,6 +2159,37 @@ def _fileset_key(files):
 
 
 _PARSE_CACHE = {}          # fsid -> (fileset_key, parsed_session)
+
+# ── the courier's change gate (2026-09-09) ──
+# run_courier scanned every session's transcript and goal store on every triage pass, loading the store
+# with the writer's loader: 1172 goal loads a pass across 18 sessions on the maintainer's box, 83% of
+# the judge tier thread's samples, most of the process's CPU. A session whose inputs have not moved since
+# a scan that found nothing to place has no new information for the courier by construction, so it is
+# skipped whole. The key is every input the per-session scan reads, taken BEFORE the store read (the
+# chain-memo rule): the parse cache's fileset key bound to the session object the scan holds, the store
+# file's key and its journal's and archive's (the shared view's inputs), the episode log's key (the
+# floor) and the transcript path. A session is recorded only when its scan added nothing pending; one
+# with rows to place is scanned again next pass however its inputs stand (its placements move the store
+# anyway). A parse the cache does not hold (a stubbed one) is never keyed, so never skipped. Pruned to
+# the pass's fleet, so bounded by it; a rebound state root clears it.
+_COURIER_SEEN = {}         # fsid -> the scan key of its last pass that found nothing to place
+_COURIER_STATS = {"skipped": 0, "scanned": 0, "recorded": 0}
+
+
+def courier_skip_stats():
+    """A copy of the courier gate's counters for /perf (memos.courierSkip)."""
+    return dict(_COURIER_STATS)
+
+
+def _courier_scan_key(fsid, path, session):
+    """Every input run_courier's per-session scan reads, or None when the parse is not the cache's own
+    (never skip what cannot be keyed). Taken before the store read, so a write landing during the scan
+    moves the key the next pass takes."""
+    pk = _PARSE_CACHE.get(fsid)
+    if pk is None or pk[1] is not session:
+        return None
+    return (str(path), pk[0], _file_key(str(GOALDIR / (fsid + ".json"))), _journal_key(fsid), _archive_key(fsid),
+            _file_key(str(EPIDIR / (fsid + ".jsonl"))))
 
 # ── the write-moment chain memo ──
 # _rewound_away builds a FRESH FileAdapter on every call by design (the pass frame pins a stale
@@ -14272,24 +14304,38 @@ def _attach_courier_link(store, seg_id, mid):
     planner-first placement orphaned the sender's handoff forever. The link rides `links[]` — never
     `origin`, which means "this goal was BORN from that delegation" and stays truthful — and
     run_propagate completes the sender's tracking node from either. Idempotent by msgId; a store
-    already carrying the msgId anywhere (origin or links) is left alone. Saves only on change."""
+    already carrying the msgId anywhere (origin or links) is left alone. Saves only on change.
+    `store` is a writer's load: the courier's scan asks _courier_link_wanted on its read-only view first
+    and loads for the write only when the link is missing (2026-09-09), so a pass over placed delegates
+    with their links in place loads nothing."""
+    wanted = _courier_link_wanted(store, seg_id, mid)
+    if wanted is None:
+        return False
+    top, peer_sid, peer_gid = wanted
+    store["nodes"][top].setdefault("links", []).append({"peer": peer_sid, "goalId": peer_gid, "msgId": mid})
+    save_goals(store["rompUuid"], store)
+    return True
+
+
+def _courier_link_wanted(store, seg_id, mid):
+    """Read-only: (top, peer_sid, peer_gid) when `mid`'s courier link is missing from the store and has a
+    placed top to attach to, else None. The idempotency half of _attach_courier_link, split out so the
+    scan can ask it of the shared view."""
     nodes = store.get("nodes", {})
     for nd in nodes.values():
         o = nd.get("origin")
         if isinstance(o, dict) and o.get("msgId") == mid:
-            return False
+            return None
         if any(isinstance(l, dict) and l.get("msgId") == mid for l in (nd.get("links") or [])):
-            return False
+            return None
     tgt = store.get("placements", {}).get(seg_id)
     if not tgt or tgt not in nodes:
-        return False
+        return None
     top = _top_ancestor(nodes, tgt)
     peer_sid, peer_gid = _handoff_backref(mid)
     if not (peer_sid and peer_gid):
-        return False
-    nodes[top].setdefault("links", []).append({"peer": peer_sid, "goalId": peer_gid, "msgId": mid})
-    save_goals(store["rompUuid"], store)
-    return True
+        return None
+    return (top, peer_sid, peer_gid)
 
 
 def _serving_dispatch(session, store, fsid, upto_seg_id):
@@ -15006,14 +15052,21 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=
         except Exception as e:                         # a poisoned transcript must not skip silently (T111)
             _log_judge_error("courier", fsid, "pass-crash", note="parse: %r" % e)
             continue
+        skey = _courier_scan_key(fsid, path, session)   # BEFORE the store read (the chain-memo rule)
+        if skey is not None and _COURIER_SEEN.get(fsid) == skey:
+            _COURIER_STATS["skipped"] += 1             # nothing moved since a scan that found nothing: no new information
+            continue
+        _COURIER_STATS["scanned"] += 1
         try:
-            cstore = load_goals(fsid)
+            cstore = load_goals_shared(fsid)           # the read-only view: the scan reads placements and seams; its one
+            #                                            writer (the link repair below) takes its own load at the write
         except Exception as e:                         # an unreadable store: this session's row, the next session's turn
             _log_judge_error("courier", fsid, "pass-crash", note="store: %r" % e)
             continue
         closed[fsid] = _session_settled(fsid, str(path), session, cstore)
         placed_ids = cstore["placements"]
         floor = episode_floor(fsid)
+        n_pending0 = len(pending)
         for turn in session["turns"]:
             for seg in _segs(turn, cstore):
                 if seg["id"] in placed_ids:
@@ -15025,8 +15078,10 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=
                     # that goal lands. No model call; idempotent by msgId.
                     try:
                         pm0 = _seg_peer(seg)
-                        if pm0 and pm0[0] and pm0[1] and _seg_peer_kind(seg) == "delegate":
-                            _attach_courier_link(cstore, seg["id"], pm0[1])
+                        if (pm0 and pm0[0] and pm0[1] and _seg_peer_kind(seg) == "delegate"
+                                and _courier_link_wanted(cstore, seg["id"], pm0[1]) is not None):
+                            _attach_courier_link(load_goals(fsid), seg["id"], pm0[1])   # a writer: its own load,
+                            #                                                              only when the view says the link is missing
                     except Exception as e:             # bookkeeping, but its failure is not nothing (T111)
                         _log_judge_error("courier", fsid, "pass-crash", note="link-attach: %r" % e)
                     continue
@@ -15048,6 +15103,14 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=
                     continue
                 pending.append((seg["t"], fsid, seg["id"], _unit_text(seg["atoms"]), pm[1], pm[0],
                                 _seg_peer_kind(seg), _seg_anchor(seg), str(path)))
+        if skey is not None:
+            if len(pending) == n_pending0:
+                _COURIER_SEEN[fsid] = skey             # nothing to place: the next pass skips it until an input moves
+                _COURIER_STATS["recorded"] += 1
+            else:
+                _COURIER_SEEN.pop(fsid, None)          # rows to place: scanned again next pass whatever the key says
+    for _gone in [f for f in _COURIER_SEEN if f not in {f for f, p, a, nm in fleet}]:
+        _COURIER_SEEN.pop(_gone, None)                 # bounded by the pass's fleet
     # CROSS-HOST delegates plant the SENDER-side tracking node here too (the user 2026-08-24, the
     # paused-cards investigation): the recipient lives on a remote kernel, so no inbound segment
     # ever reaches this courier and _plant_handoff_track never ran — the sender's goal waited on a

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -14321,17 +14321,28 @@ def _courier_link_wanted(store, seg_id, mid):
     """Read-only: (top, peer_sid, peer_gid) when `mid`'s courier link is missing from the store and has a
     placed top to attach to, else None. The idempotency half of _attach_courier_link, split out so the
     scan can ask it of the shared view."""
+    top = _courier_link_target(store, seg_id, mid)
+    if top is None:
+        return None
+    peer_sid, peer_gid = _handoff_backref(mid)
+    if not (peer_sid and peer_gid):
+        return None
+    return (top, peer_sid, peer_gid)
+
+
+def _courier_link_target(store, seg_id, mid):
+    """Read-only, and reading this store alone: the TOP a missing courier link for `mid` would attach to, or
+    None when the store already carries the msgId or the segment's placement is not a live node (filed
+    "fyi", retired, or a target since compacted away: nothing to attach to, so nothing to repair). The
+    scan's change gate asks this to tell an open repair, which depends on the sender's store as well,
+    from a placement with no repair possible, which it may record and skip."""
     if _courier_link_present(store, mid):
         return None
     nodes = store.get("nodes", {})
     tgt = store.get("placements", {}).get(seg_id)
     if not tgt or tgt not in nodes:
         return None
-    top = _top_ancestor(nodes, tgt)
-    peer_sid, peer_gid = _handoff_backref(mid)
-    if not (peer_sid and peer_gid):
-        return None
-    return (top, peer_sid, peer_gid)
+    return _top_ancestor(nodes, tgt)
 
 
 def _courier_link_present(store, mid):
@@ -15088,10 +15099,12 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=
                     try:
                         pm0 = _seg_peer(seg)
                         if (pm0 and pm0[0] and pm0[1] and _seg_peer_kind(seg) == "delegate"
-                                and not _courier_link_present(cstore, pm0[1])):
-                            repair_open = True     # the link is missing; whether it can attach depends on the
-                            #                        SENDER's store (_handoff_backref), outside this session's key,
-                            #                        so the session is scanned again next pass, as before
+                                and _courier_link_target(cstore, seg["id"], pm0[1]) is not None):
+                            repair_open = True     # a missing link with a live node to attach to: whether it CAN
+                            #                        attach depends on the SENDER's store (_handoff_backref), outside
+                            #                        this session's key, so the session is scanned again next pass, as
+                            #                        before. A placement with no node (filed fyi, retired) has no
+                            #                        repair to wait for and records like any settled session.
                             if _courier_link_wanted(cstore, seg["id"], pm0[1]) is not None:
                                 _attach_courier_link(load_goals(fsid), seg["id"], pm0[1])   # a writer: its own load
                     except Exception as e:             # bookkeeping, but its failure is not nothing (T111)

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -14321,13 +14321,9 @@ def _courier_link_wanted(store, seg_id, mid):
     """Read-only: (top, peer_sid, peer_gid) when `mid`'s courier link is missing from the store and has a
     placed top to attach to, else None. The idempotency half of _attach_courier_link, split out so the
     scan can ask it of the shared view."""
+    if _courier_link_present(store, mid):
+        return None
     nodes = store.get("nodes", {})
-    for nd in nodes.values():
-        o = nd.get("origin")
-        if isinstance(o, dict) and o.get("msgId") == mid:
-            return None
-        if any(isinstance(l, dict) and l.get("msgId") == mid for l in (nd.get("links") or [])):
-            return None
     tgt = store.get("placements", {}).get(seg_id)
     if not tgt or tgt not in nodes:
         return None
@@ -14336,6 +14332,19 @@ def _courier_link_wanted(store, seg_id, mid):
     if not (peer_sid and peer_gid):
         return None
     return (top, peer_sid, peer_gid)
+
+
+def _courier_link_present(store, mid):
+    """Read-only: does the store already carry `mid` anywhere, as a node's origin or a link? The scan's
+    change gate keeps a session unrecorded while a placed delegate lacks its link: the repair's other input
+    is the SENDER's store (_handoff_backref), outside the session's own key."""
+    for nd in store.get("nodes", {}).values():
+        o = nd.get("origin")
+        if isinstance(o, dict) and o.get("msgId") == mid:
+            return True
+        if any(isinstance(l, dict) and l.get("msgId") == mid for l in (nd.get("links") or [])):
+            return True
+    return False
 
 
 def _serving_dispatch(session, store, fsid, upto_seg_id):
@@ -15066,7 +15075,7 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=
         closed[fsid] = _session_settled(fsid, str(path), session, cstore)
         placed_ids = cstore["placements"]
         floor = episode_floor(fsid)
-        n_pending0 = len(pending)
+        n_pending0, repair_open = len(pending), False
         for turn in session["turns"]:
             for seg in _segs(turn, cstore):
                 if seg["id"] in placed_ids:
@@ -15079,9 +15088,12 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=
                     try:
                         pm0 = _seg_peer(seg)
                         if (pm0 and pm0[0] and pm0[1] and _seg_peer_kind(seg) == "delegate"
-                                and _courier_link_wanted(cstore, seg["id"], pm0[1]) is not None):
-                            _attach_courier_link(load_goals(fsid), seg["id"], pm0[1])   # a writer: its own load,
-                            #                                                              only when the view says the link is missing
+                                and not _courier_link_present(cstore, pm0[1])):
+                            repair_open = True     # the link is missing; whether it can attach depends on the
+                            #                        SENDER's store (_handoff_backref), outside this session's key,
+                            #                        so the session is scanned again next pass, as before
+                            if _courier_link_wanted(cstore, seg["id"], pm0[1]) is not None:
+                                _attach_courier_link(load_goals(fsid), seg["id"], pm0[1])   # a writer: its own load
                     except Exception as e:             # bookkeeping, but its failure is not nothing (T111)
                         _log_judge_error("courier", fsid, "pass-crash", note="link-attach: %r" % e)
                     continue
@@ -15104,8 +15116,8 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=
                 pending.append((seg["t"], fsid, seg["id"], _unit_text(seg["atoms"]), pm[1], pm[0],
                                 _seg_peer_kind(seg), _seg_anchor(seg), str(path)))
         if skey is not None:
-            if len(pending) == n_pending0:
-                _COURIER_SEEN[fsid] = skey             # nothing to place: the next pass skips it until an input moves
+            if len(pending) == n_pending0 and not repair_open:
+                _COURIER_SEEN[fsid] = skey             # nothing to place, no link to repair: skipped until an input moves
                 _COURIER_STATS["recorded"] += 1
             else:
                 _COURIER_SEEN.pop(fsid, None)          # rows to place: scanned again next pass whatever the key says

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -196,7 +196,9 @@ class _PerfStats:
                                    cycle_ms_last, cycle_cpu_ms_sum (the pusher thread's own CPU,
                                    time.thread_time, so a forked tmux read is excluded), and
                                    cycle_ms_p50 / cycle_ms_p90 / cycle_ms_ring_max / ring_n from a
-                                   ring of the last RING cycle durations
+                                   ring of the last RING cycle durations; sends (every client payload);
+                                   idle_cycles / idle_ms_sum / idle_cpu_ms_sum (cycles that set no wake,
+                                   sent no payload and saved no store: what a longer wait would skip)
       stages_ms                    jobs: the cycle's tick jobs outside _push_all; push: _push_all as
                                    the cycle calls it; push.chat (the tab strip, the build_session
                                    loop and the chat sends), push.feed (the view signature,
@@ -255,7 +257,8 @@ class _PerfStats:
             self.since = time.time()
             self.pusher = {"cycles": 0, "wakes": 0, "wakes_event": 0, "wakes_backstop": 0,
                            "cycle_ms_sum": 0.0, "cycle_ms_max": 0.0, "cycle_ms_last": 0.0,
-                           "cycle_cpu_ms_sum": 0.0}
+                           "cycle_cpu_ms_sum": 0.0, "sends": 0,
+                           "idle_cycles": 0, "idle_ms_sum": 0.0, "idle_cpu_ms_sum": 0.0}
             self.ring = collections.deque(maxlen=self.RING)
             self.stages = {k: 0.0 for k in self.STAGES}
             self.builds = {k: {"cached": 0, "built": 0, "ms": 0.0} for k in self.BUILDS}
@@ -272,8 +275,16 @@ class _PerfStats:
         with self.lock:
             self.pusher["wakes_event" if by_event else "wakes_backstop"] += 1
 
-    def cycle(self, dt, cpu_dt=0.0):
-        """dt: the cycle's wall seconds; cpu_dt: the pusher thread's own CPU seconds over it."""
+    def marks(self):
+        """(wakes, sends) so far: the cycle compares the pair before and after itself to tell an idle cycle."""
+        with self.lock:
+            return (self.pusher["wakes"], self.pusher["sends"])
+
+    def cycle(self, dt, cpu_dt=0.0, idle=False):
+        """dt: the cycle's wall seconds; cpu_dt: the pusher thread's own CPU seconds over it; idle: the cycle
+        sent nothing and changed nothing (no wake set, no client payload, no goal-store save or write over
+        it), so its wall and CPU also go to the idle sums (2026-09-09: the loop re-enters after a fixed 0.5 s
+        backstop, and the idle share is what a cadence change would be judged on)."""
         ms = dt * 1000.0
         with self.lock:
             p = self.pusher
@@ -281,6 +292,10 @@ class _PerfStats:
             p["cycle_ms_sum"] += ms
             p["cycle_ms_last"] = ms
             p["cycle_cpu_ms_sum"] += cpu_dt * 1000.0
+            if idle:
+                p["idle_cycles"] += 1
+                p["idle_ms_sum"] += ms
+                p["idle_cpu_ms_sum"] += cpu_dt * 1000.0
             if ms > p["cycle_ms_max"]:
                 p["cycle_ms_max"] = ms
             self.ring.append(ms)
@@ -301,6 +316,7 @@ class _PerfStats:
     def send(self, key, kind, nbytes):
         slot = key[0] if isinstance(key, tuple) else key
         with self.lock:
+            self.pusher["sends"] += 1
             d = self.sends[kind]
             e = d.get(slot)
             if e is None:
@@ -376,7 +392,7 @@ class _PerfStats:
         # chain memo. `goals.loads` is the writer's loader alone; the pusher's loads show under memos.shared.
         memos = {}
         for key, read in (("pass", _goals_memo_report), ("shared", jd.shared_store_stats),
-                          ("chain", jd.chain_memo_stats)):
+                          ("chain", jd.chain_memo_stats), ("courierSkip", jd.courier_skip_stats)):
             try:
                 memos[key] = read()
             except Exception:
@@ -40899,6 +40915,7 @@ def _pusher_cycle():
     ran before them."""
     _t_cycle = time.monotonic()
     _c_cycle = time.thread_time()           # this thread's CPU: the wall above includes the tmux fork and lock waits
+    _m_cycle = (_PERF_STATS.marks(), jd._GOAL_IO["saves"], jd._GOAL_IO["writes"])   # idle-cycle marks: see cycle()
     with _clients_lock:
         any_client = bool(_clients)
     now = int(time.time())
@@ -40923,7 +40940,8 @@ def _pusher_cycle():
         _live_scope.names = None
         _live_scope.paths = None
         _live_scope.sessions = None
-        _PERF_STATS.cycle(time.monotonic() - _t_cycle, time.thread_time() - _c_cycle)
+        _PERF_STATS.cycle(time.monotonic() - _t_cycle, time.thread_time() - _c_cycle,
+                          idle=(_PERF_STATS.marks(), jd._GOAL_IO["saves"], jd._GOAL_IO["writes"]) == _m_cycle)
 
 
 def _pusher_cycle_jobs(now, tmux, any_client):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -284,7 +284,9 @@ class _PerfStats:
         """dt: the cycle's wall seconds; cpu_dt: the pusher thread's own CPU seconds over it; idle: the cycle
         sent nothing and changed nothing (no wake set, no client payload, no goal-store save or write over
         it), so its wall and CPU also go to the idle sums (2026-09-09: the loop re-enters after a fixed 0.5 s
-        backstop, and the idle share is what a cadence change would be judged on)."""
+        backstop, and the idle share is what a cadence change would be judged on). A conservative undercount:
+        a wake another thread sets during the cycle, or the periodic repost of an unchanged frame past the
+        dedup window, marks that cycle busy though the cycle itself changed nothing."""
         ms = dt * 1000.0
         with self.lock:
             p = self.pusher
@@ -316,7 +318,10 @@ class _PerfStats:
     def send(self, key, kind, nbytes):
         slot = key[0] if isinstance(key, tuple) else key
         with self.lock:
-            self.pusher["sends"] += 1
+            if kind != "deduped":
+                self.pusher["sends"] += 1             # a payload that went to a client; a deduped frame (built,
+                #                                       compared, already held byte for byte) is not one, or the
+                #                                       per-cycle chat frames would mark every cycle busy
             d = self.sends[kind]
             e = d.get(slot)
             if e is None:

--- a/tests/test_courier_link.py
+++ b/tests/test_courier_link.py
@@ -125,7 +125,9 @@ class CourierLinkRepair(unittest.TestCase):
 
     def test_courier_scan_carries_the_repair_branch(self):
         src = open(os.path.join(BIN, "romp-judge")).read()
-        self.assertIn("_attach_courier_link(cstore, seg[\"id\"], pm0[1])", src)
+        # the scan asks the read-only view whether the link is missing and loads for the write only then (2026-09-09)
+        self.assertIn("_courier_link_wanted(cstore, seg[\"id\"], pm0[1]) is not None", src)
+        self.assertIn("_attach_courier_link(load_goals(fsid), seg[\"id\"], pm0[1])", src)
         self.assertIn('_seg_peer_kind(seg) == "delegate"', src)
 
 

--- a/tests/test_courier_skip.py
+++ b/tests/test_courier_skip.py
@@ -86,6 +86,7 @@ class _World(unittest.TestCase):
         jd.ERRORS = td / "judge-errors.jsonl"
         jd.MESSAGES.write_text("")
         self.recs = {sid: [] for sid in self.SIDS}
+        self.mid_of = {sid: [] for sid in self.SIDS}   # the message ids delivered to each session, in order
         self.mids = 0
         self._reset_memos()
         jd._COURIER_SEEN.clear()
@@ -118,6 +119,7 @@ class _World(unittest.TestCase):
         """One peer message (a declared delegate) lands in `sid`'s transcript, with its postal row."""
         self.mids += 1
         mid = "%d.%05d_%05d.TESTHOST" % (T0, self.mids, self.mids)
+        self.mid_of[sid].append(mid)
         with jd.MESSAGES.open("a") as f:
             f.write(json.dumps({"t": t - 5, "ev": "sent", "id": mid, "from": "sender", "from_id": SENDER,
                                 "to_id": sid, "kind": "delegate",
@@ -247,7 +249,7 @@ class CourierSkip(_World):
         # outside A's key, so A is never recorded while the link is missing; once the sender's tracking node
         # exists, the next pass attaches the link through a writer load, and only then does A settle.
         path = self.proj_dir / (A + ".jsonl")
-        mid_a = self.recs[A][0]["message"]["content"].split("romp-msg-id: ")[1].split(" ")[0]
+        mid_a = self.mid_of[A][0]
         session = jd.parsed_session(A, [str(path)], T0 + 200)
         fresh = jd.load_goals(A)
         seg = next(sg for tn in session["turns"] for sg in jd._segs(tn, fresh) if (jd._seg_peer(sg) or ("",))[0])

--- a/tests/test_courier_skip.py
+++ b/tests/test_courier_skip.py
@@ -56,14 +56,14 @@ class _World(unittest.TestCase):
     def setUp(self):
         self._rooted_saved = jd._delegate_user_rooted
         jd._delegate_user_rooted = lambda *a, **k: True       # chain-rooted minting is orthogonal here
-        self.saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.PCACHE,
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.GOALARCHDIR, jd.PCACHE,
                       jd.MESSAGES, jd.ERRORS, jd.courier_llm)
         jd.courier_llm = lambda *a, **k: DELEGATING
         self._make_world()
 
     def tearDown(self):
         self._drop_world()
-        (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.PCACHE,
+        (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.GOALARCHDIR, jd.PCACHE,
          jd.MESSAGES, jd.ERRORS, jd.courier_llm) = self.saved
         jd._delegate_user_rooted = self._rooted_saved
 
@@ -82,6 +82,7 @@ class _World(unittest.TestCase):
         jd.NAMES, jd.PROJECTS = names, proj
         jd.GOALDIR = td / "goals"
         jd.CAPDIR, jd.ARCHDIR, jd.PCACHE = td / "captions", td / "archive", td / "pcache"
+        jd.GOALARCHDIR = td / "goals-archive"           # the goal archive, one of the skip key's inputs, under this root too
         jd.MESSAGES = tl / "messages.jsonl"
         jd.ERRORS = td / "judge-errors.jsonl"
         jd.MESSAGES.write_text("")
@@ -288,6 +289,19 @@ class CourierSkip(_World):
         self.assertEqual(self.run_pass(), (1, 3, 1), "A's store moved with the link: scanned once more and recorded; "
                                                      "B, C and the sender skipped")
         self.assertEqual(self.run_pass(), (0, 4, 0), "and now every session is settled")
+
+    def test_a_delegate_filed_quiet_has_no_repair_to_wait_for_and_is_recorded(self):
+        # An UNROOTED dispatch files "fyi" (the recipient gets no standalone top): the placement is not a
+        # node, so no courier link can ever attach and there is no repair to keep the session scanned.
+        # Exactly the worker sessions that receive team dispatches; they must settle and skip like any other.
+        jd._delegate_user_rooted = lambda *a, **k: False
+        self.assertEqual(self.run_pass(), (3, 0, 0), "first pass: every delegate filed quiet")
+        for sid in self.SIDS:
+            st = jd.load_goals(sid)
+            self.assertIn("fyi", set(st["placements"].values()), "the placement is the fyi mark, not a node")
+            self.assertFalse(any(isinstance(nd.get("origin"), dict) for nd in st["nodes"].values()), "no top planted")
+        self.assertEqual(self.run_pass(), (3, 0, 3), "second pass: nothing to place, no repair open, all recorded")
+        self.assertEqual(self.run_pass(), (0, 3, 0), "third pass: all skipped")
 
     def test_a_parse_the_cache_does_not_hold_is_never_skipped(self):
         real = jd.parsed_session

--- a/tests/test_courier_skip.py
+++ b/tests/test_courier_skip.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""The courier skips a session whose inputs have not moved since a scan that found nothing to place, and
+reads the ones it scans through the shared read-only view (2026-09-09).
+
+Measured on the maintainer's box: run_courier loaded every session's goal store with the writer's loader on
+every triage pass, 1172 goal loads a pass across 18 sessions, 83% of the judge tier thread's samples. The
+skip key is every input the per-session scan reads, taken before the store read (the chain-memo rule): the
+parse cache's key bound to the session object, the store file's key with its journal's and archive's, the
+episode log's key and the transcript path. Pins: unchanged inputs skip after a scan that placed nothing; a
+moved store, a fresh parse or an episode boundary un-skips that session alone; a write landing during the
+scan is seen next pass; three sessions with one moved place exactly what the ungated pass places; a parse
+the cache does not hold is never skipped; the scan asks the writer's loader for nothing; the counters.
+
+Synthetic fixtures only: placeholder sids, invented text, hostname TESTHOST; a temp root per test."""
+import json
+import os
+import re
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_courier_skip", os.path.join(BIN, "romp-judge")).load_module()
+
+A = "11111111-2222-3333-4444-777777777701"
+B = "11111111-2222-3333-4444-777777777702"
+C = "11111111-2222-3333-4444-777777777703"
+SENDER = "aaaaaaaa-bbbb-cccc-dddd-777777777700"
+T0 = 1781100000
+DELEGATING = '{"verdict": "delegating", "goal": 0, "text": "check the subnet layout"}'
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "user", "content": text}, "promptSource": "typed"}
+
+
+def aline(t, text, uuid, parent):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+class _World(unittest.TestCase):
+    SIDS = (A, B, C)
+
+    def setUp(self):
+        self._rooted_saved = jd._delegate_user_rooted
+        jd._delegate_user_rooted = lambda *a, **k: True       # chain-rooted minting is orthogonal here
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.PCACHE,
+                      jd.MESSAGES, jd.ERRORS, jd.courier_llm)
+        jd.courier_llm = lambda *a, **k: DELEGATING
+        self._make_world()
+
+    def tearDown(self):
+        self._drop_world()
+        (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.PCACHE,
+         jd.MESSAGES, jd.ERRORS, jd.courier_llm) = self.saved
+        jd._delegate_user_rooted = self._rooted_saved
+
+    def _make_world(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        munged = re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        self.proj_dir = proj / munged
+        self.proj_dir.mkdir(parents=True)
+        names = td / "names"; names.mkdir()
+        for i, sid in enumerate(self.SIDS):
+            (names / sid).write_text("worker%d\t%s\t#abcdef\n" % (i, str(cdir)))
+        tl = td / "timeline"; tl.mkdir()
+        jd.NAMES, jd.PROJECTS = names, proj
+        jd.GOALDIR = td / "goals"
+        jd.CAPDIR, jd.ARCHDIR, jd.PCACHE = td / "captions", td / "archive", td / "pcache"
+        jd.MESSAGES = tl / "messages.jsonl"
+        jd.ERRORS = td / "judge-errors.jsonl"
+        jd.MESSAGES.write_text("")
+        self.recs = {sid: [] for sid in self.SIDS}
+        self.mids = 0
+        self._reset_memos()
+        jd._COURIER_SEEN.clear()
+        for k in jd._COURIER_STATS:
+            jd._COURIER_STATS[k] = 0
+        for sid in self.SIDS:
+            self.deliver(sid, T0 + 10 * self.SIDS.index(sid))
+
+    def _drop_world(self):
+        for sid in self.SIDS:
+            try:
+                (jd.EPIDIR / (sid + ".jsonl")).unlink()
+            except OSError:
+                pass
+            try:
+                (jd._overrides_dir() / (sid + ".jsonl")).unlink()
+            except OSError:
+                pass
+        jd._COURIER_SEEN.clear()
+        self._reset_memos()
+        self.td.cleanup()
+
+    @staticmethod
+    def _reset_memos():
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+        jd._episode_memo.clear()
+        jd._shared_clear()
+
+    def deliver(self, sid, t):
+        """One peer message (a declared delegate) lands in `sid`'s transcript, with its postal row."""
+        self.mids += 1
+        mid = "%d.%05d_%05d.TESTHOST" % (T0, self.mids, self.mids)
+        with jd.MESSAGES.open("a") as f:
+            f.write(json.dumps({"t": t - 5, "ev": "sent", "id": mid, "from": "sender", "from_id": SENDER,
+                                "to_id": sid, "kind": "delegate",
+                                "body": "check the subnet layout for box %d" % self.mids}) + "\n")
+        n = len(self.recs[sid]) // 2 + 1
+        parent = self.recs[sid][-1]["uuid"] if self.recs[sid] else None
+        self.recs[sid] += [uline(t, "check the subnet layout for box %d\n<!-- romp-msg-id: %s -->\n"
+                                    "<!-- romp-msg-kind: delegate -->" % (self.mids, mid), "u%d" % n, parent),
+                           aline(t + 30, "Looking at box %d now." % self.mids, "a%d" % n, "u%d" % n)]
+        p = self.proj_dir / (sid + ".jsonl")
+        p.write_text("\n".join(json.dumps(r) for r in self.recs[sid]) + "\n")
+        os.utime(p, (t + 60, t + 60))                       # a distinct mtime per write: the parse key moves
+        jd._discover_cache["fp"] = None
+        jd._discover_cache["result"] = None
+        return mid
+
+    def run_pass(self, now=T0 + 200):
+        """One courier pass; returns the gate counters' deltas (scanned, skipped, recorded)."""
+        before = jd.courier_skip_stats()
+        jd._discover_cache["fp"] = None
+        jd._discover_cache["result"] = None
+        jd._postal_from_memo["key"] = None
+        jd.run_courier(now=now)
+        after = jd.courier_skip_stats()
+        return tuple(after[k] - before[k] for k in ("scanned", "skipped", "recorded"))
+
+    def stores(self):
+        return {sid: json.loads((jd.GOALDIR / (sid + ".json")).read_text()) for sid in self.SIDS}
+
+    @staticmethod
+    def shape(store):
+        """The decisions a pass makes for a session: its placements and its planted peer nodes."""
+        planted = sorted((nd.get("text"), (nd.get("origin") or {}).get("msgId"))
+                         for nd in store["nodes"].values() if isinstance(nd.get("origin"), dict))
+        return (store["placements"], planted)
+
+
+class CourierSkip(_World):
+    def test_unchanged_inputs_skip_after_a_scan_that_placed_nothing(self):
+        self.assertEqual(self.run_pass(), (3, 0, 0), "first pass: every session scanned, rows to place, none recorded")
+        placed = self.stores()
+        self.assertTrue(all(any(isinstance(nd.get("origin"), dict) for nd in st["nodes"].values())
+                            for st in placed.values()), "a recipient top planted in each session")
+        self.assertEqual(self.run_pass(), (3, 0, 3), "second pass: scanned, nothing to place, all three recorded")
+        self.assertEqual(self.run_pass(), (0, 3, 0), "third pass: nothing moved, all three skipped")
+        self.assertEqual(self.run_pass(), (0, 3, 0))
+        self.assertEqual(self.stores(), placed, "a skipped pass writes nothing")
+
+    def _settled(self):
+        self.run_pass(); self.run_pass()
+        self.assertEqual(self.run_pass(), (0, 3, 0))
+
+    def test_a_moved_store_un_skips_that_session_only(self):
+        self._settled()
+        p = jd.GOALDIR / (A + ".json")
+        d = json.loads(p.read_text()); d["seq"] = d.get("seq", 0) + 1
+        p.write_text(json.dumps(d))
+        self.assertEqual(self.run_pass(), (1, 2, 1), "A's store moved: A scanned and re-recorded, B and C skipped")
+
+    def test_a_journal_write_un_skips(self):
+        self._settled()
+        jd._overrides_dir().mkdir(parents=True, exist_ok=True)
+        with (jd._overrides_dir() / (B + ".jsonl")).open("a") as f:
+            f.write(json.dumps({"op": "resolve", "id": B + ":gX", "t": T0 + 150}) + "\n")
+        self.assertEqual(self.run_pass(), (1, 2, 1), "B's override journal moved: B alone scanned")
+
+    def test_a_fresh_parse_un_skips(self):
+        self._settled()
+        p = self.proj_dir / (C + ".jsonl")
+        recs = self.recs[C] + [uline(T0 + 120, "and the gateway?", "u9", self.recs[C][-1]["uuid"]),
+                               aline(T0 + 130, "10.0.0.1", "a9", "u9")]
+        p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        os.utime(p, (T0 + 190, T0 + 190))
+        self.assertEqual(self.run_pass(), (1, 2, 1), "C's transcript grew: C alone scanned")
+
+    def test_an_episode_boundary_un_skips(self):
+        self._settled()
+        jd.EPIDIR.mkdir(parents=True, exist_ok=True)
+        (jd.EPIDIR / (A + ".jsonl")).write_text(json.dumps({"t": T0 - 100, "kind": "seed"}) + "\n"
+                                                + json.dumps({"t": T0 + 150, "kind": "clear"}) + "\n")
+        self.assertEqual(self.run_pass(), (1, 2, 1), "A's episode log moved: A alone scanned")
+
+    def test_a_write_landing_during_the_scan_is_seen_next_pass(self):
+        # INTERLEAVED WRITE: the key is taken before the store read. A row appended to A's journal while the
+        # scan reads A's store leaves the recorded key behind the file, so the next pass scans A again.
+        self.run_pass()                                   # places
+        real = jd.load_goals_shared
+        landed = []
+
+        def read_then_write(fsid):
+            store = real(fsid)
+            if fsid == A and not landed:
+                landed.append(True)
+                jd._overrides_dir().mkdir(parents=True, exist_ok=True)
+                with (jd._overrides_dir() / (A + ".jsonl")).open("a") as f:
+                    f.write(json.dumps({"op": "resolve", "id": A + ":gX", "t": T0 + 160}) + "\n")
+            return store
+        jd.load_goals_shared = read_then_write
+        try:
+            self.assertEqual(self.run_pass(), (3, 0, 3), "the recording pass, with A's write landing mid-scan")
+        finally:
+            jd.load_goals_shared = real
+        self.assertTrue(landed)
+        self.assertEqual(self.run_pass(), (1, 2, 1), "A is scanned again: its recorded key predates the write")
+        self.assertEqual(self.run_pass(), (0, 3, 0))
+
+    def test_three_sessions_one_moved_place_exactly_what_the_ungated_pass_places(self):
+        def scenario(gated):
+            self.run_pass()                               # places the first three
+            self.run_pass()                               # records all three
+            self.deliver(B, T0 + 150)                     # B moves: a second message
+            if not gated:
+                jd._COURIER_SEEN.clear()                  # the ungated pass scans every session
+            counts = self.run_pass(now=T0 + 300)
+            return counts, {sid: self.shape(st) for sid, st in self.stores().items()}
+        gated_counts, gated = scenario(True)
+        self._drop_world(); self._make_world()
+        ungated_counts, ungated = scenario(False)
+        self.assertEqual(gated_counts, (1, 2, 0), "gated: B scanned with rows to place, A and C skipped")
+        self.assertEqual(ungated_counts, (3, 0, 2), "ungated: all scanned, A and C recorded")
+        self.assertEqual(gated, ungated, "the same placements and planted nodes either way")
+        self.assertEqual(len(gated[B][1]), 2, "B's second delegate planted")
+
+    def test_a_parse_the_cache_does_not_hold_is_never_skipped(self):
+        real = jd.parsed_session
+        jd.parsed_session = lambda fsid, paths, now: dict(real(fsid, paths, now))   # a copy: not the cache's object
+        try:
+            self.run_pass(); self.run_pass()
+            self.assertEqual(self.run_pass(), (3, 0, 0), "unkeyed: scanned every pass, never recorded")
+        finally:
+            jd.parsed_session = real
+
+    def test_the_scan_asks_the_writers_loader_for_nothing(self):
+        self.run_pass()                                   # places (writers, legitimately)
+        private, o_load = [], jd.load_goals
+        jd.load_goals = lambda fsid: (private.append(fsid), o_load(fsid))[1]
+        try:
+            self.assertEqual(self.run_pass(), (3, 0, 3))
+        finally:
+            jd.load_goals = o_load
+        self.assertEqual(private, [], "a scan with nothing to place reads only the view")
+
+    def test_the_counters(self):
+        self.assertEqual(set(jd.courier_skip_stats()), {"skipped", "scanned", "recorded"})
+        s = jd.courier_skip_stats(); s["skipped"] = 99
+        self.assertNotEqual(jd.courier_skip_stats()["skipped"], 99, "a copy")
+
+    def test_a_rebound_root_forgets_the_seen_keys(self):
+        self._settled()
+        self.assertTrue(jd._COURIER_SEEN)
+        saved = jd.STATE
+        other = tempfile.TemporaryDirectory()
+        try:
+            jd._rebind_state(Path(other.name))
+            self.assertEqual(jd._COURIER_SEEN, {})
+        finally:
+            jd._rebind_state(saved)
+            other.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_courier_skip.py
+++ b/tests/test_courier_skip.py
@@ -241,6 +241,52 @@ class CourierSkip(_World):
         self.assertEqual(gated, ungated, "the same placements and planted nodes either way")
         self.assertEqual(len(gated[B][1]), 2, "B's second delegate planted")
 
+    def test_a_placed_delegate_without_its_link_keeps_the_session_scanned_until_the_repair_lands(self):
+        # PLANNER-FIRST PLACEMENT: A's delegate segment sits under a plain top with no courier link, and no
+        # sender tracks the message yet. The repair's other input is the SENDER's store (_handoff_backref),
+        # outside A's key, so A is never recorded while the link is missing; once the sender's tracking node
+        # exists, the next pass attaches the link through a writer load, and only then does A settle.
+        path = self.proj_dir / (A + ".jsonl")
+        mid_a = self.recs[A][0]["message"]["content"].split("romp-msg-id: ")[1].split(" ")[0]
+        session = jd.parsed_session(A, [str(path)], T0 + 200)
+        fresh = jd.load_goals(A)
+        seg = next(sg for tn in session["turns"] for sg in jd._segs(tn, fresh) if (jd._seg_peer(sg) or ("",))[0])
+        top = {"id": A + ":g1", "text": "Look after the subnet", "parentId": None, "nodeComplete": False,
+               "blocked": False, "cleared": False, "trail": [], "t": T0}
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        (jd.GOALDIR / (A + ".json")).write_text(json.dumps(
+            {"rompUuid": A, "seq": 1, "lastNode": top["id"], "closedTurns": [], "nodes": {top["id"]: top},
+             "placements": {seg["id"]: top["id"]}, "status": {top["id"]: "working"}}))
+        self._reset_memos()
+        self.run_pass()                                   # B and C place; A has nothing pending but an open repair
+        self.assertEqual(self.run_pass(), (3, 0, 2), "B and C recorded; A stays scanned: its link is missing")
+        self.assertEqual(self.run_pass(), (1, 2, 0), "A alone, every pass, while no sender tracks the message")
+        self.assertNotIn("links", jd.load_goals(A)["nodes"][top["id"]])
+        # the sender's tracking node appears (a names entry and a transcript make the sender discoverable, the way
+        # _handoff_backref finds sender boards; its store carries the handoff)
+        (jd.NAMES / SENDER).write_text("sender\t%s\t#abcdef\n" % str(Path(self.td.name) / "launchdir"))
+        (self.proj_dir / (SENDER + ".jsonl")).write_text(json.dumps(uline(T0 - 100, "hand the subnet check to worker0", "s1"))
+                                                         + "\n" + json.dumps(aline(T0 - 90, "Delegated.", "s2", "s1")) + "\n")
+        snd = jd.load_goals(SENDER)
+        snd["nodes"][SENDER + ":g1"] = {"id": SENDER + ":g1", "text": "delegated to worker0", "parentId": None,
+                                        "nodeComplete": False, "blocked": False, "cleared": False, "trail": [],
+                                        "t": T0, "handoff": {"peer": A, "msgId": mid_a}}
+        snd["status"][SENDER + ":g1"] = "working"
+        jd.save_goals(SENDER, snd)
+        private, o_load = [], jd.load_goals
+        jd.load_goals = lambda fsid: (private.append(fsid), o_load(fsid))[1]
+        try:
+            self.assertEqual(self.run_pass(), (2, 2, 1), "A and the now-discoverable sender scanned, B and C skipped; "
+                                                         "the sender records, A does not yet (its store just moved)")
+        finally:
+            jd.load_goals = o_load
+        self.assertIn(A, private, "the repair took a writer load for A")
+        links = jd.load_goals(A)["nodes"][top["id"]].get("links") or []
+        self.assertEqual([l.get("msgId") for l in links], [mid_a], "the link attached")
+        self.assertEqual(self.run_pass(), (1, 3, 1), "A's store moved with the link: scanned once more and recorded; "
+                                                     "B, C and the sender skipped")
+        self.assertEqual(self.run_pass(), (0, 4, 0), "and now every session is settled")
+
     def test_a_parse_the_cache_does_not_hold_is_never_skipped(self):
         real = jd.parsed_session
         jd.parsed_session = lambda fsid, paths, now: dict(real(fsid, paths, now))   # a copy: not the cache's object

--- a/tests/test_goal_store_fault_boundary.py
+++ b/tests/test_goal_store_fault_boundary.py
@@ -446,7 +446,9 @@ class TriagePassBoundary(_World):
         return sorted((r["fsid"], r["note"].split(":")[0]) for r in self._rows("pass-crash") if r["judge"] == judge)
 
     def test_run_courier_continues_past_a_faulting_session(self):
-        with _fault_on(self.a_file):
+        o_view = jd.load_goals_shared                 # the courier's scan reads the shared view (2026-09-09): record
+        view = lambda fsid: (self.seen.append(fsid), o_view(fsid))[1]   # its reads beside the writer's
+        with _fault_on(self.a_file), mock.patch.object(jd, "load_goals_shared", view):
             jd.run_courier(now=NOW)
         self.assertIn(B, self.seen, "the pass reached the healthy session after the fault")
         rows = self._rows("pass-crash")
@@ -472,7 +474,8 @@ class TriagePassBoundary(_World):
             if fsid == P or (fsid == A and calls[fsid] >= 2):
                 raise OSError(errno.EIO, "Input/output error", str(jd.GOALDIR / (fsid + ".json")))
             return orig(fsid)
-        with mock.patch.object(jd, "load_goals", faulting):
+        with mock.patch.object(jd, "load_goals", faulting), \
+                mock.patch.object(jd, "load_goals_shared", faulting):
             jd.run_courier(now=NOW)
         self.assertEqual(self._crashes("courier"),
                          sorted([(P, "store"), (P, "sender store"), (A, "store"), (B, "sender %s store" % P[:8])]),
@@ -498,7 +501,8 @@ class TriagePassBoundary(_World):
             return orig(fsid)
         with mock.patch.object(jd, "courier_llm",
                                lambda text, menu, declared=None: '{"verdict": "delegating", "goal": 1, "text": "the first piece"}'), \
-                mock.patch.object(jd, "load_goals", faulting):
+                mock.patch.object(jd, "load_goals", faulting), \
+                mock.patch.object(jd, "load_goals_shared", faulting):
             jd.run_courier(now=NOW)
         self.assertEqual(self._crashes("courier"), [(B, "root walk")], "the one arm that tripped, attributed to the recipient")
         self.assertGreaterEqual(calls.get(P, 0), 2, "premise: the walk did hop to the peer")

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -115,11 +115,13 @@ class Collector(unittest.TestCase):
         self.assertIn("cpu_ms_workers", snap["judge"])
         self.assertEqual(set(snap["goals"]), {"loads", "saves", "writes"}, "read through jd.goal_io_stats")
         # the three identity memos' readers land here (review find, 2026-09-08: they had no consumer)
-        self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate", "cleared"})
+        self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate", "cleared", "courierSkip"})
         self.assertEqual(snap["memos"]["nudgeGate"], {"served": 0, "derived": 0},
                          "the nudge walk's placement gate: served vs re-derived (2026-09-09)")
         self.assertEqual(set(snap["memos"]["cleared"]), {"served", "derived"},
                          "the clear set: parsed once per file state, served while it stands (2026-09-09)")
+        self.assertEqual(snap["memos"]["courierSkip"], km.jd.courier_skip_stats(),
+                         "the courier gate: sessions skipped, scanned, recorded (2026-09-09)")
         self.assertEqual(snap["memos"]["pass"], km._goals_memo_report())
         self.assertEqual(snap["memos"]["shared"], km.jd.shared_store_stats())
         self.assertEqual(snap["memos"]["chain"], km.jd.chain_memo_stats())
@@ -486,6 +488,43 @@ class PusherRecords(unittest.TestCase):
 
     def _pusher(self):
         return km._PERF_STATS.snapshot()["pusher"]
+
+    def test_an_idle_cycle_is_one_that_set_no_wake_sent_nothing_and_saved_nothing(self):
+        # IDLE CYCLES (2026-09-09): the loop re-enters after a fixed 0.5 s backstop whether or not anything
+        # changed; the idle share is what a cadence change is judged on. A cycle whose jobs set no wake,
+        # sent no client payload and saved no goal store counts as idle, with its wall and CPU.
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: time.sleep(0.003)
+        before = self._pusher()
+        km._pusher_cycle()
+        after = self._pusher()
+        self.assertEqual(after["idle_cycles"], before["idle_cycles"] + 1)
+        self.assertGreaterEqual(after["idle_ms_sum"] - before["idle_ms_sum"], 3.0)
+        self.assertGreaterEqual(after["idle_cpu_ms_sum"], before["idle_cpu_ms_sum"])
+        self.assertEqual(after["cycles"], before["cycles"] + 1, "an idle cycle is still a cycle")
+
+    def test_a_cycle_that_sends_a_payload_is_not_idle(self):
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: km._PERF_STATS.send(("chat", "s1"), "full", 10)
+        before = self._pusher()
+        km._pusher_cycle()
+        after = self._pusher()
+        self.assertEqual(after["idle_cycles"], before["idle_cycles"])
+        self.assertEqual(after["sends"], before["sends"] + 1)
+
+    def test_a_cycle_that_sets_the_wake_is_not_idle(self):
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: km._pusher_wake.set()
+        before = self._pusher()
+        km._pusher_cycle()
+        km._pusher_wake.clear()
+        self.assertEqual(self._pusher()["idle_cycles"], before["idle_cycles"])
+
+    def test_a_cycle_that_saves_a_goal_store_is_not_idle(self):
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: km.jd._goal_io_bump("saves")
+        before = self._pusher()
+        km._pusher_cycle()
+        self.assertEqual(self._pusher()["idle_cycles"], before["idle_cycles"])
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: km.jd._goal_io_bump("writes")
+        km._pusher_cycle()
+        self.assertEqual(self._pusher()["idle_cycles"], before["idle_cycles"])
 
     def test_a_cycle_is_counted_and_timed(self):
         km._pusher_cycle_jobs = lambda now, tmux, any_client: time.sleep(0.005)

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -510,6 +510,16 @@ class PusherRecords(unittest.TestCase):
         self.assertEqual(after["idle_cycles"], before["idle_cycles"])
         self.assertEqual(after["sends"], before["sends"] + 1)
 
+    def test_a_deduped_frame_does_not_break_an_idle_cycle(self):
+        # with a dashboard connected the push builds and compares the per-cycle chat frames every cycle; a
+        # frame the client already holds is reported as "deduped" and is not a payload that went out
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: km._PERF_STATS.send(("chat", "taborder"), "deduped", 10)
+        before = self._pusher()
+        km._pusher_cycle()
+        after = self._pusher()
+        self.assertEqual(after["idle_cycles"], before["idle_cycles"] + 1, "still idle")
+        self.assertEqual(after["sends"], before["sends"], "a deduped frame is not a send")
+
     def test_a_cycle_that_sets_the_wake_is_not_idle(self):
         km._pusher_cycle_jobs = lambda now, tmux, any_client: km._pusher_wake.set()
         before = self._pusher()


### PR DESCRIPTION
Tier: fix

## What

The judge tier's courier, and the pusher's idle-cycle counter (T267e; follows the jobs-stage rounds).

1. **The courier skips a session whose inputs have not moved since a scan that found nothing to place.** `run_courier` scanned every session's transcript and goal store on every triage pass, loading the store with the writer's loader: on the maintainer's box, 1172 goal loads a pass across 18 sessions, a pass every 12 s, 83% of the judge tier thread's samples, which is where most of the process's CPU went (the judge thread at 73% of a core against the pusher's 17%). The skip key is every input the per-session scan reads, taken **before** the store read (the chain-memo rule): the parse cache's fileset key bound to the session object the scan holds, the store file's key with its journal's and archive's (the shared view's inputs), the episode log's key (the floor), and the transcript path. A session is recorded as seen only when its scan added nothing pending and no placed delegate with a live node lacks its courier link (the link repair's other input is the sender's store, outside the session's key); a delegate filed fyi or retired has no node to attach to and no repair to wait for, so it records like any settled session. One with rows to place or a link to repair is scanned again next pass whatever the key says. A parse the cache does not hold (a stubbed one) is never keyed, so never skipped. The table is pruned to the pass's fleet and cleared with the state root. Counters ride `/perf` as `memos.courierSkip` (`skipped`, `scanned`, `recorded`).

2. **The scan reads the shared read-only view.** Its one writer, the planner-first link repair, asks the view whether the link is missing (`_courier_link_wanted`, the idempotency half split out of `_attach_courier_link`) and takes a writer load only then. The placement loop and the cross-host arm keep the writer's loader: they write.

Follow-up named, not done: `_handoff_backref` walks every discovered session's store with the writer's loader on each call; it runs only when a link is missing, as before, and a per-pass memo of the backref map would remove the walk.

3. **The pusher counts idle cycles.** A cycle that set no wake, sent no client payload and saved no goal store is idle; its wall and CPU go to `pusher.idle_cycles`, `idle_ms_sum`, `idle_cpu_ms_sum` (`pusher.sends` counts payloads that went to a client; a deduped frame the client already holds is not one, or the per-cycle chat frames would mark every cycle busy with a dashboard connected). A conservative undercount: a wake another thread sets during the cycle, or a periodic repost of an unchanged frame past the dedup window, marks that cycle busy. The loop re-enters after a fixed 0.5 s backstop whether or not anything changed (three waits in four end on it), and the idle share is what a cadence change would be judged on. No cadence change here.

No card-move rule changes: a skipped session has no new information by construction, and a moved session decides exactly as before.

## Tests

`tests/test_courier_skip.py` (new; three recipient sessions, one sender, a stubbed courier model): unchanged inputs skip after a scan that placed nothing, and a skipped pass writes nothing; a moved store, an override-journal write, a fresh parse or an episode boundary un-skips that session alone; a write landing during the scan (the interleaved-write pattern) is seen next pass because the recorded key predates it; three sessions with one moved place exactly what the ungated pass places (placements and planted nodes equal, run in two fresh worlds); a delegate filed quiet (an unrooted dispatch) has no repair to wait for and records and skips; a planner-first placement whose link is missing keeps its session scanned every pass until the sender's tracking node appears, then the link attaches through one writer load and the session settles (the review's finding); a parse the cache does not hold is never skipped; a scan with nothing to place asks the writer's loader for nothing; the counters are a copy; a rebound state root forgets the keys.

`tests/test_perf_stats.py`: an idle cycle is counted with its wall and CPU; a cycle that sends a payload, sets the wake, or saves or writes a goal store is not idle; a deduped frame does not break an idle cycle; the memos key set and the courier gate's shape. `tests/test_courier_link.py`: the repair-branch pin follows the split. `tests/test_goal_store_fault_boundary.py`: the three courier fault tests fault the shared loader beside the writer's, or record the view's reads, since the scan's read moved. `docs/reference.md`: the pusher and memos passages.

## Before (the merged jobs-stage rounds; the shared box, no synthetic load)

Two `/perf` readings 120 s apart in an active hour plus a 60 s py-spy sample (3066 samples): judge tier 10 passes in 120 s at 11 s each (93% of wall), judge thread CPU 73% of a core, 1172 goal loads per triage pass; `_run_tier > run_triage > run_courier > load_goals` 83% of the tier thread's samples; pusher thread 17% of a core, 102 cycles in 120 s with 74 waits ended by the backstop.

## After

Posted below after the deploy restart at matched uptimes: judge-thread CPU share and goal loads per triage pass, and the idle-cycle numbers once they have an hour.
