### PR TITLE
T281: the feed dedup test builds over its own state root, and the modules that left stores, journals and a session order at the run-wide root keep them under their own

### DIFF
--- a/tests/test_kernel_resolve_node.py
+++ b/tests/test_kernel_resolve_node.py
@@ -9,6 +9,7 @@ import tempfile
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -25,6 +26,31 @@ NOW = int(time.time())
 
 
 class ResolveNode(unittest.TestCase):
+    def setUp(self):
+        # kern.jd is one module object shared by every test module in the process; the store this test saves and
+        # the resolve it journals at the import-bound root outlived the module and were replayed onto every later
+        # module's feed for the placeholder sid (T281). A private root for the duration.
+        self._td = tempfile.TemporaryDirectory()
+        self._state = jd.STATE
+        jd._rebind_state(Path(self._td.name))
+
+    def tearDown(self):
+        jd._rebind_state(self._state)
+        self._td.cleanup()
+
+    def test_the_store_and_the_journal_do_not_outlive_the_module(self):
+        # The residue pin (T281): after the resolve, this test's store and journal live under its own root; the
+        # run-wide root (what every later module's feed reads) is exactly as it was.
+        shared = [Path(self._state) / "goals" / (SID + ".json"), Path(self._state) / "overrides" / (SID + ".jsonl")]
+        before = [(p.exists(), p.stat().st_size if p.exists() else None) for p in shared]
+        jd.save_goals(SID, {"rompUuid": SID, "seq": 1, "placements": {}, "status": {},
+                            "nodes": {GID: {"id": GID, "text": "Ship the widget", "parentId": None, "nodeComplete": False,
+                                            "blocked": False, "cleared": False, "trail": [], "t": NOW - 600, "mt": NOW - 300}}})
+        self.assertTrue(kern._resolve_node(SID, GID))
+        self.assertTrue((Path(self._td.name) / "goals" / (SID + ".json")).exists(), "the store lives under this test's root")
+        self.assertEqual([(p.exists(), p.stat().st_size if p.exists() else None) for p in shared], before,
+                         "the run-wide store and journal for the placeholder sid are untouched by this module")
+
     def test_user_resolve_is_evented_and_survives_the_rollup(self):
         store = {"rompUuid": SID, "seq": 1, "placements": {}, "status": {},
                  "nodes": {GID: {"id": GID, "text": "Ship the widget", "parentId": None,

--- a/tests/test_kernel_session_flags.py
+++ b/tests/test_kernel_session_flags.py
@@ -18,6 +18,9 @@ SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 km = SourceFileLoader("romp_kernel_sf", os.path.join(BIN, "romp-kernel")).load_module()
 # the kernel's helpers read/write jd.STATE; sandbox THAT module's STATE (the one the kernel actually uses)
+# ...with _rebind_state, never STATE alone: GOALDIR and every derived dir stay at the import-bound root otherwise,
+# and that module is ONE object shared by every test module in the process, so a goal store saved there outlived
+# this module and reached every later module's feed for the placeholder sid (T281).
 jd = km.jd
 
 
@@ -25,11 +28,11 @@ class SessionFlags(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         self.saved = jd.STATE
-        jd.STATE = Path(self.td.name)
+        jd._rebind_state(Path(self.td.name))
         km._flags_cache.clear()
 
     def tearDown(self):
-        jd.STATE = self.saved
+        jd._rebind_state(self.saved)
         self.td.cleanup()
 
     def test_default_is_empty(self):
@@ -78,7 +81,7 @@ class AutoNudgeWiring(unittest.TestCase):
     def test_version_reports_autonudge_state_for_the_checkbox(self):
         saved = jd.STATE
         td = tempfile.TemporaryDirectory()
-        jd.STATE = Path(td.name)
+        jd._rebind_state(Path(td.name))
         km._autonudge_cache.clear()
         try:
             self.assertTrue(km._version_info()["autoNudge"], "on by default (no state file)")
@@ -87,19 +90,19 @@ class AutoNudgeWiring(unittest.TestCase):
             km._set_auto_nudge(True)
             self.assertTrue(km._version_info()["autoNudge"], "the gear reads the kernel's authoritative state")
         finally:
-            jd.STATE = saved
+            jd._rebind_state(saved)
             td.cleanup()
 
     def test_default_on_even_when_state_file_lacks_the_key(self):
         saved = jd.STATE
         td = tempfile.TemporaryDirectory()
-        jd.STATE = Path(td.name)
+        jd._rebind_state(Path(td.name))
         km._autonudge_cache.clear()
         try:
             (Path(td.name) / "auto-nudge.json").write_text('{"nudged": {}}')  # present, no "enabled" key
             self.assertTrue(km._auto_nudge_on(), "a state file missing the enabled key still defaults on")
         finally:
-            jd.STATE = saved
+            jd._rebind_state(saved)
             td.cleanup()
 
 
@@ -115,11 +118,11 @@ class FlagsStoreUnreadableRefuses(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         self.saved = jd.STATE
-        jd.STATE = Path(self.td.name)
+        jd._rebind_state(Path(self.td.name))
         km._flags_cache.clear()
 
     def tearDown(self):
-        jd.STATE = self.saved
+        jd._rebind_state(self.saved)
         km._flags_cache.clear()
         self.td.cleanup()
 
@@ -279,7 +282,7 @@ class FlagsDisplayReaderServesUnproved(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         self.saved = jd.STATE
-        jd.STATE = Path(self.td.name)
+        jd._rebind_state(Path(self.td.name))
         km._flags_cache.clear()
         km._state_fault_seen.clear()
         self.notices = []
@@ -288,7 +291,7 @@ class FlagsDisplayReaderServesUnproved(unittest.TestCase):
 
     def tearDown(self):
         km._sync_notice = self._notice
-        jd.STATE = self.saved
+        jd._rebind_state(self.saved)
         km._flags_cache.clear()
         km._state_fault_seen.clear()
         self.td.cleanup()
@@ -423,13 +426,14 @@ class FlagsWsRefusal(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         self.saved = (jd.STATE, km._mark_views_dirty)
-        jd.STATE = Path(self.td.name)
+        jd._rebind_state(Path(self.td.name))
         km._flags_cache.clear()
         self.dirty = []
         km._mark_views_dirty = lambda: self.dirty.append(1)
 
     def tearDown(self):
-        jd.STATE, km._mark_views_dirty = self.saved
+        jd._rebind_state(self.saved[0])
+        km._mark_views_dirty = self.saved[1]
         km._flags_cache.clear()
         self.td.cleanup()
 
@@ -499,13 +503,14 @@ class SessionBellJudgedAgainstAProvedMaster(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         self.saved = (jd.STATE, km._mark_views_dirty)
-        jd.STATE = Path(self.td.name)
+        jd._rebind_state(Path(self.td.name))
         km._flags_cache.clear(); km._notify_cards_cache.clear()
         self.dirty = []
         km._mark_views_dirty = lambda: self.dirty.append(1)
 
     def tearDown(self):
-        jd.STATE, km._mark_views_dirty = self.saved
+        jd._rebind_state(self.saved[0])
+        km._mark_views_dirty = self.saved[1]
         km._flags_cache.clear(); km._notify_cards_cache.clear()
         self.td.cleanup()
 
@@ -558,7 +563,7 @@ class FlagsWsWriteFailure(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         self.saved = (jd.STATE, km._mark_views_dirty, km._sync_notice)
-        jd.STATE = Path(self.td.name)
+        jd._rebind_state(Path(self.td.name))
         km._flags_cache.clear(); km._notify_cards_cache.clear(); km._state_fault_seen.clear()
         vars(km).get("_state_write_fault_seen", {}).clear()
         self.dirty, self.notices = [], []
@@ -566,7 +571,8 @@ class FlagsWsWriteFailure(unittest.TestCase):
         km._sync_notice = lambda text, ok=True, kind="sync": self.notices.append((text, ok))
 
     def tearDown(self):
-        jd.STATE, km._mark_views_dirty, km._sync_notice = self.saved
+        jd._rebind_state(self.saved[0])
+        km._mark_views_dirty, km._sync_notice = self.saved[1:]
         km._flags_cache.clear(); km._notify_cards_cache.clear(); km._state_fault_seen.clear()
         vars(km).get("_state_write_fault_seen", {}).clear()
         self.td.cleanup()
@@ -801,14 +807,15 @@ class WsFlagsMustBeBooleans(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         self.saved = (jd.STATE, km._mark_views_dirty, km._push_soon, km._ws_act_now_tick)
-        jd.STATE = Path(self.td.name)
+        jd._rebind_state(Path(self.td.name))
         km._flags_cache.clear()
         km._mark_views_dirty = lambda: None
         km._push_soon = lambda: None
         km._ws_act_now_tick = lambda: None           # turn-on acts at once in service; not under test here
 
     def tearDown(self):
-        jd.STATE, km._mark_views_dirty, km._push_soon, km._ws_act_now_tick = self.saved
+        jd._rebind_state(self.saved[0])
+        km._mark_views_dirty, km._push_soon, km._ws_act_now_tick = self.saved[1:]
         km._flags_cache.clear()
         self.td.cleanup()
 

--- a/tests/test_kernel_undo_restore_completed.py
+++ b/tests/test_kernel_undo_restore_completed.py
@@ -8,6 +8,7 @@ import os
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -37,16 +38,34 @@ def _run_undo(archive):
     jd.save_goal_archive = lambda sid, a: None
     jd.load_goals = lambda sid: live
     jd.save_goals = lambda sid, s: None
+    # The stores are in memory, but the undo pair still JOURNALS: the override rows and cleared.jsonl land under
+    # the kernel's judge, one module object shared by every test module in the process, so at its import-bound
+    # root they outlived this module and were replayed onto every later module's feed for the placeholder sid
+    # (T281). A private root for the duration.
+    saved_state = jd.STATE
+    jd._rebind_state(Path(tempfile.mkdtemp()))
     try:
         km._restore_goal_archive([IID])
         km._mark_nodes_cleared([IID], False)
     finally:
         for n, fn in orig.items():
             setattr(jd, n, fn)
+        jd._rebind_state(saved_state)
     return live
 
 
 class UndoRestoreCompleted(unittest.TestCase):
+    def test_the_undo_journal_does_not_outlive_the_module(self):
+        # The residue pin (T281): the rows the undo pair journals stay under the private root; the run-wide root's
+        # override journal and cleared.jsonl for the placeholder sid are exactly as they were.
+        jd = km.jd
+        shared = [jd.STATE / "overrides" / (SID + ".jsonl"), jd.STATE / "cleared.jsonl"]
+        before = [(p.exists(), p.stat().st_size if p.exists() else None) for p in shared]
+        _run_undo({"nodes": {IID: {"id": IID, "parentId": None, "nodeComplete": True, "cleared": True,
+                                   "text": "x", "t": NOW - 900, "mt": NOW - 600}}, "status": {IID: "completed"}})
+        self.assertEqual([(p.exists(), p.stat().st_size if p.exists() else None) for p in shared], before,
+                         "the run-wide journal and cleared log are untouched by this module")
+
     def test_completed_top_comes_back_with_sticky_settledDone(self):
         # a roll-down-completed top that LACKS settledDone (the ≈5% gap) — the case that used to flicker:
         # the top's own nodeComplete is False; its rolled-up done child carries the completion bottom-up

--- a/tests/test_live_session_unresolved_transcript.py
+++ b/tests/test_live_session_unresolved_transcript.py
@@ -61,13 +61,13 @@ class _World(unittest.TestCase):
     def tearDown(self):
         self._proj_patch.stop()
         self._names_patch.stop()
-        jd._rebind_state(self._state)
         if hasattr(km, "_UNRESOLVED_LIVE_NOTED"):
             km._UNRESOLVED_LIVE_NOTED.discard(SID)
         for f in (jd.NAMES / SID,):
             try: f.unlink()
             except OSError: pass
         self.td.cleanup()
+        jd._rebind_state(self._state)   # last: everything above cleans under THIS test's root
 
     def _alive_sids(self):
         jd._discover_cache.clear()

--- a/tests/test_live_session_unresolved_transcript.py
+++ b/tests/test_live_session_unresolved_transcript.py
@@ -31,6 +31,11 @@ class _World(unittest.TestCase):
         self.td = tempfile.TemporaryDirectory()
         root = Path(self.td.name)
         self.cwd = root / "work"; self.cwd.mkdir()
+        # The kernel's judge is one module object shared by every test module in the process, so a names entry
+        # and the session order this world writes at its import-bound root outlived the module and were read by
+        # every later module's feed (T281). The world lives under this test's root for the duration.
+        self._state = jd.STATE
+        jd._rebind_state(root / "state")
         # names registry entry: name \t cwd \t #bg  (written at launch for both backends). The kernel binds
         # NAMES at import while the ONE romp_judge module is re-executed by every later kernel load in the
         # suite, so km.NAMES and jd.NAMES can name different roots under the full run — align them.
@@ -56,6 +61,7 @@ class _World(unittest.TestCase):
     def tearDown(self):
         self._proj_patch.stop()
         self._names_patch.stop()
+        jd._rebind_state(self._state)
         if hasattr(km, "_UNRESOLVED_LIVE_NOTED"):
             km._UNRESOLVED_LIVE_NOTED.discard(SID)
         for f in (jd.NAMES / SID,):

--- a/tests/test_new_session_dir.py
+++ b/tests/test_new_session_dir.py
@@ -262,6 +262,12 @@ class CreateSessionTags(_Wire):
                                  setattr(km, "_spawn_session", saved[2]),
                                  setattr(km, "_create_codex_session", saved[3]),
                                  setattr(km, "_codex_ready", saved[4])))
+        # A private state root for the duration: the kernel's judge is one module object shared by every test
+        # module in the process, and the names entry, goal store and cleared rows the create flow writes at its
+        # import-bound root outlived this module and reached every later module's feed (T281).
+        self._saved_state = km.jd.STATE
+        km.jd._rebind_state(Path(tempfile.mkdtemp()))
+        self.addCleanup(lambda: km.jd._rebind_state(self._saved_state))
         (km.jd.STATE / "names").mkdir(parents=True, exist_ok=True)
         (km.jd.STATE / "names" / self.PARENT).write_text("web\t/tmp\t#123456\twhite\n")
 
@@ -341,10 +347,11 @@ class CreateSessionTags(_Wire):
         km._live_names = lambda *_: {"api": self.LIVE}
         km._reveal_chat_for = lambda client, m: focused.append(m)
         km._mark_views_dirty = lambda: None
-        km.jd.STATE = Path(tempfile.mkdtemp())
+        km.jd._rebind_state(Path(tempfile.mkdtemp()))   # every derived dir moves with STATE (T281), not STATE alone
         km._flags_cache.clear()
         def restore():
-            km._live_names, km._reveal_chat_for, km._mark_views_dirty, km.jd.STATE = saved
+            km._live_names, km._reveal_chat_for, km._mark_views_dirty = saved[:3]
+            km.jd._rebind_state(saved[3])
             km._flags_cache.clear()
         self.addCleanup(restore)
         km._set_timeline_views({"active": "all", "tags": [{"id": "g1", "name": "pool", "members": [self.PARENT]}]})

--- a/tests/test_node_override_ack.py
+++ b/tests/test_node_override_ack.py
@@ -48,6 +48,8 @@ class NodeOverrideAck(unittest.TestCase):
         # the handler under test reads the same module, so it still sees the store.
         self._td = tempfile.TemporaryDirectory()
         self._state = jd.STATE
+        shared = Path(self._state) / "goals" / (SID + ".json")     # the run-wide store, as it is BEFORE this test writes
+        self._shared_before = (shared.exists(), shared.stat().st_mtime_ns if shared.exists() else None)
         jd._rebind_state(Path(self._td.name))
         store = {"nodes": {
             TOP: {"id": TOP, "text": "ship the notes API", "parentId": None, "t": 1, "mt": 1},
@@ -65,8 +67,8 @@ class NodeOverrideAck(unittest.TestCase):
         # every later module's feed reads) carries nothing this module wrote.
         self.assertTrue((Path(self._td.name) / "goals" / (SID + ".json")).exists())
         shared = Path(self._state) / "goals" / (SID + ".json")
-        self.assertFalse(shared.exists() and json.loads(shared.read_text()).get("nodes", {}).get(TOP),
-                         "the run-wide goals directory holds no store from this module")
+        self.assertEqual((shared.exists(), shared.stat().st_mtime_ns if shared.exists() else None), self._shared_before,
+                         "the run-wide goals directory is exactly as it was before this module's save")
 
     def _resolve(self, node_id):
         km.Handler._dispatch_ws(None, {"type": "nodeOverride", "sid": SID, "nodeId": node_id,

--- a/tests/test_node_override_ack.py
+++ b/tests/test_node_override_ack.py
@@ -16,6 +16,7 @@ import os
 import tempfile
 import unittest
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -41,6 +42,13 @@ class NodeOverrideAck(unittest.TestCase):
         self.sent = []
         self._real_send = km._send_to_app
         km._send_to_app = lambda app, msg: self.sent.append((app, msg))
+        # The store below is saved through the kernel's judge, which is one module object shared by every test
+        # module in the process: at its import-bound GOALDIR the store outlived this module and became part of
+        # every later module's feed for the placeholder sid (T281). Rebind to a private root for the duration;
+        # the handler under test reads the same module, so it still sees the store.
+        self._td = tempfile.TemporaryDirectory()
+        self._state = jd.STATE
+        jd._rebind_state(Path(self._td.name))
         store = {"nodes": {
             TOP: {"id": TOP, "text": "ship the notes API", "parentId": None, "t": 1, "mt": 1},
             SUB: {"id": SUB, "text": "decide the auth story", "parentId": TOP, "t": 1, "mt": 1},
@@ -49,6 +57,16 @@ class NodeOverrideAck(unittest.TestCase):
 
     def tearDown(self):
         km._send_to_app = self._real_send
+        jd._rebind_state(self._state)
+        self._td.cleanup()
+
+    def test_the_fixture_store_does_not_outlive_the_module(self):
+        # The residue pin (T281): setUp's store lives under this test's root; the run-wide goals directory (what
+        # every later module's feed reads) carries nothing this module wrote.
+        self.assertTrue((Path(self._td.name) / "goals" / (SID + ".json")).exists())
+        shared = Path(self._state) / "goals" / (SID + ".json")
+        self.assertFalse(shared.exists() and json.loads(shared.read_text()).get("nodes", {}).get(TOP),
+                         "the run-wide goals directory holds no store from this module")
 
     def _resolve(self, node_id):
         km.Handler._dispatch_ws(None, {"type": "nodeOverride", "sid": SID, "nodeId": node_id,

--- a/tests/test_obsidian_state_routes.py
+++ b/tests/test_obsidian_state_routes.py
@@ -85,7 +85,9 @@ class _Routes(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         self._state = km.jd.STATE
-        km.jd.STATE = Path(self.td.name)
+        # _rebind_state, not STATE alone: the kernel's judge is one module object shared by every test module in the process (each kernel load re-executes bin/romp-judge into the same sys.modules entry); a store written at its import-bound GOALDIR is read by every later module's feed (T281). Assigning STATE left GOALDIR at the run-wide root, so every
+        # goal store these routes saved for the placeholder sid outlived this module.
+        km.jd._rebind_state(Path(self.td.name))
         km._flags_cache.clear()
         self._saved = (km._mark_views_dirty, km._sync_notice)
         self.dirty, self.notices = [], []
@@ -94,9 +96,19 @@ class _Routes(unittest.TestCase):
 
     def tearDown(self):
         km._mark_views_dirty, km._sync_notice = self._saved
-        km.jd.STATE = self._state
+        km.jd._rebind_state(self._state)
         km._flags_cache.clear()
         self.td.cleanup()
+
+    def test_the_stores_these_routes_write_do_not_outlive_the_module(self):
+        # The residue pin (T281): a store saved through the kernel's judge lands under THIS test's root, and the
+        # run-wide root (what every later module's feed reads) is left exactly as it was.
+        shared = Path(self._state) / "goals" / (SID + ".json")
+        before = (shared.exists(), shared.stat().st_mtime_ns if shared.exists() else None)
+        km.jd.save_goals(SID, {"nodes": {SID + ":t281": {"id": SID + ":t281", "text": "a note", "parentId": None, "t": 1, "mt": 1}}})
+        self.assertTrue((Path(self.td.name) / "goals" / (SID + ".json")).exists(), "the store lives under this module's root")
+        self.assertEqual((shared.exists(), shared.stat().st_mtime_ns if shared.exists() else None), before,
+                         "the run-wide goals directory is untouched by this module")
 
     def _post(self, path, body=None, raw=None, token=os.environ["ROMP_SERVE_TOKEN"]):
         headers = {"Content-Type": "application/json"}

--- a/tests/test_payload_dedup_invariant.py
+++ b/tests/test_payload_dedup_invariant.py
@@ -194,13 +194,26 @@ class BuiltFeedIsClockInvariantApartFromTheClockItself(unittest.TestCase):
         module left for the placeholder sid at the run-wide GOALDIR used to be part of THIS feed (T281). A
         store planted there now changes nothing here: the feed reads this fixture's goals directory."""
         foreign = Path(self.saved_kernel_state) / "goals"
-        foreign.mkdir(parents=True, exist_ok=True)
         planted = foreign / (SID + ".json")
-        existed = planted.exists()
-        if not existed:
-            planted.write_text(json.dumps({"nodes": {"t281-foreign": {"id": "t281-foreign", "title": "a card another module left",
-                                                                      "parentId": None, "status": "open"}}, "status": {}}))
-            self.addCleanup(lambda: planted.exists() and planted.unlink())
+        original = planted.read_bytes() if planted.exists() else None     # another module's store, if one is there
+        made_dir = not foreign.exists()
+        foreign.mkdir(parents=True, exist_ok=True)
+        store = json.loads(original) if original else {"nodes": {}, "status": {}}
+        store.setdefault("nodes", {})["t281-foreign"] = {"id": "t281-foreign", "title": "a card another module left",
+                                                          "parentId": None, "status": "open"}
+        planted.write_text(json.dumps(store))                              # always planted, so the assertion has teeth
+
+        def restore():
+            if original is not None:
+                planted.write_bytes(original)
+            else:
+                planted.unlink(missing_ok=True)
+                if made_dir:
+                    try:
+                        os.rmdir(foreign)
+                    except OSError:
+                        pass
+        self.addCleanup(restore)
         self.assertNotIn("t281-foreign", json.dumps(km.build_feed(NOW, self.tmux), default=str),
                          "a store at the run-wide goals directory is not this feed's input")
         self.assertEqual(km.jd.GOALDIR, Path(self.td.name) / "goals", "the kernel's judge reads this fixture's goals")

--- a/tests/test_payload_dedup_invariant.py
+++ b/tests/test_payload_dedup_invariant.py
@@ -135,6 +135,7 @@ class BuiltFeedIsClockInvariantApartFromTheClockItself(unittest.TestCase):
 
         self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
                       km.NAMES, km._GLOBAL_CLAUDE_MD, km.jd.NAMES, km.jd.PROJECTS)
+        self.saved_kernel_state = km.jd.STATE
         jd.NAMES, jd.PROJECTS = names, proj
         jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
         jd.STATE = td
@@ -143,6 +144,14 @@ class BuiltFeedIsClockInvariantApartFromTheClockItself(unittest.TestCase):
         # SourceFileLoader load), so discover() — which the kernel runs through km.jd — never saw this
         # fixture's names/ or transcript: the session was invisible and the invariant held hollowly. Reach
         # the kernel's copy too, so the fixture's transcript is the one the feed builds from (T258).
+        # And the kernel's judge is ONE module object for every test module in the process (each kernel
+        # load re-executes bin/romp-judge into the same sys.modules entry), so its STATE — goals, the
+        # override journals, cleared.jsonl, session-order.json — is a directory the whole run shares.
+        # Built over it, this feed carried whatever store an earlier module left for the placeholder sid,
+        # and a writer of that world between the two builds re-sent the feed (T281, CI 2026-09-09). The
+        # feed builds over THIS fixture's state root and nothing else: _rebind_state moves GOALDIR and
+        # every derived dir with it (assigning STATE alone would not).
+        km.jd._rebind_state(td)
         km.jd.NAMES, km.jd.PROJECTS = names, proj
         km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
         # Fixed so the stub itself contributes nothing clock-derived (mirrors the chat invariant test).
@@ -155,6 +164,7 @@ class BuiltFeedIsClockInvariantApartFromTheClockItself(unittest.TestCase):
         km.build_feed(NOW - 1, self.tmux)
 
     def tearDown(self):
+        km.jd._rebind_state(self.saved_kernel_state)
         (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
          km.NAMES, km._GLOBAL_CLAUDE_MD, km.jd.NAMES, km.jd.PROJECTS) = self.saved
         self.td.cleanup()
@@ -178,6 +188,22 @@ class BuiltFeedIsClockInvariantApartFromTheClockItself(unittest.TestCase):
         km._send_client(client, ("feed",), km.build_feed(NOW + 600, self.tmux))
         self.assertEqual(len(sent), 1,
                          "an unchanging fleet must not re-send the feed just because time passed")
+
+    def test_the_feed_is_built_over_this_fixtures_world_not_the_runs_shared_one(self):
+        """The kernel's judge module is shared by every test module in the process, so a goal store another
+        module left for the placeholder sid at the run-wide GOALDIR used to be part of THIS feed (T281). A
+        store planted there now changes nothing here: the feed reads this fixture's goals directory."""
+        foreign = Path(self.saved_kernel_state) / "goals"
+        foreign.mkdir(parents=True, exist_ok=True)
+        planted = foreign / (SID + ".json")
+        existed = planted.exists()
+        if not existed:
+            planted.write_text(json.dumps({"nodes": {"t281-foreign": {"id": "t281-foreign", "title": "a card another module left",
+                                                                      "parentId": None, "status": "open"}}, "status": {}}))
+            self.addCleanup(lambda: planted.exists() and planted.unlink())
+        self.assertNotIn("t281-foreign", json.dumps(km.build_feed(NOW, self.tmux), default=str),
+                         "a store at the run-wide goals directory is not this feed's input")
+        self.assertEqual(km.jd.GOALDIR, Path(self.td.name) / "goals", "the kernel's judge reads this fixture's goals")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
One CI-only flake (the dedup invariant test sending twice on 3.11) traced to suite-order residue, fixed at its sources, with the target made hermetic.

**Cause.** Every test module loads `bin/romp-judge` via `SourceFileLoader` under the fixed name `romp_judge`, so `km.jd` is one shared module object for the whole pytest process, and its `STATE`/`GOALDIR`/override journals/`cleared.jsonl`/`session-order.json` are one directory for the run. The dedup test rebound only `NAMES`/`PROJECTS` on it, so its feed was built over a goal store another module saved for the placeholder sid, the override journal others appended for it (replayed on every load), and a session order another module wrote, which the build itself rewrites (`_chat_tab_sessions` gc). Two builds over that shared, writable world are not guaranteed identical.

**Target.** `tests/test_payload_dedup_invariant.py` rebinds the kernel's judge to its fixture root for the test (`_rebind_state`, so GOALDIR and every derived dir move with it) and restores it in tearDown. A pin plants a store for the placeholder sid at the run-wide goals directory and asserts the feed does not carry it (red without the rebind).

**Sources.** A tracer over the run-wide root at every module boundary in CI order named the writers whose files were present at the dedup test. Each now keeps its state under a private root, with a pin that the store/journal/order does not outlive the module: `test_obsidian_state_routes.py`, `test_kernel_session_flags.py`, `test_new_session_dir.py` (assigned `STATE` alone, which leaves GOALDIR at the run-wide root), `test_node_override_ack.py`, `test_kernel_resolve_node.py`, `test_kernel_undo_restore_completed.py`, `test_live_session_unresolved_transcript.py`.

**Evidence.** Two CI-order runs of the 411 preceding modules on 3.11, a 20x pair loop and 200 amplified build pairs at the target did not reproduce the flake on the devbox (the foreign store was present throughout), so the fix removes the coupling rather than tuning a timing constant. Counts are in the task report.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
