### PR TITLE
An answered wake files its diary row from its own writer load of the goal store

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10029,7 +10029,7 @@ def _dead_wait_block(sid, gid, at, why, nudged, now, blk_why=None):
     return False
 
 
-def _file_wake_answer(store, sid, gid, now):
+def _file_wake_answer(sid, gid, now):
     """The answered wake's outcome becomes a FILED event (the user 2026-08-25, closing the awaiting
     audit's last live mechanism): the answer IS new information, and new information that files no
     diary row is invisible to every reader that matters — the response segment was often placed
@@ -10039,8 +10039,15 @@ def _file_wake_answer(store, sid, gid, now):
     and patience never churn) — the row's arrival moves _newest_filed past closerLookT, so the
     closer re-audits WITH the answer in view and rules it — done, lift, block, or keep — from real
     evidence. Runs once per answer by construction (the answered leg itself runs once per record).
-    Returns True when the row landed."""
+    Returns True when the row landed.
+    Takes no store from its callers: both hold read-only views (the walk's, _awaiting_wake_outcomes'),
+    and everything here is bound to the one object that gets saved (the node filed on must belong to
+    the store record_verdict appends to and save_goals publishes), so the helper loads its own writer
+    copy (jd.load_goals) at the write moment. A write through the shared view would raise
+    FrozenStoreError into the catch below, landing no row and switching the shared cache off for the
+    process; loading here rules that out by construction."""
     try:
+        store = jd.load_goals(sid)
         nodes = store.get("nodes", {})
         kids = {}
         for x, n in nodes.items():
@@ -10086,7 +10093,8 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux, wake_only=F
                 the stamp still stands → the wait was re-affirmed; keep the record with answeredAt so the
                 NEXT wake measures from the answer — NOT the anchor, which a same-why re-assert
                 deliberately freezes (judge apply_close's coalesce rule; keying episodes on the anchor is
-                what made the one-shot design terminal).
+                what made the one-shot design terminal), and file the answer into the diary
+                (_file_wake_answer, on its own writer load: `store` here is the walk's read-only view).
       silent    no response within the same window (from the FIRE, rec["at"]) → _mark_nudge_failed(wake=True):
                 the block rides the normal ladder to Needs-you. A failed/moot record re-arms only on a
                 genuinely NEW stamp episode (anchor newer than the one that failed).
@@ -10130,7 +10138,7 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux, wake_only=F
             # the judges ruled on the answer and the stamp still stands → the wait was re-affirmed
             nudged[gid] = dict(rec, answeredAt=(resp.get("t") or int(now)))
             _put_nudged(gid, nudged[gid])
-            _file_wake_answer(store, sid, gid, now)   # the answer becomes a FILED event → the closer
+            _file_wake_answer(sid, gid, now)         # the answer becomes a FILED event → the closer
             return False                              #   re-audits with it in view (see the helper)
         _sdefer = _revivers_pending(sid, store, turns, gid)
         if _sdefer and not _nudge_deferred_ok(gid, _sdefer, now, sid):
@@ -10275,8 +10283,8 @@ def _awaiting_wake_outcomes(now, walked=None):
                 # answered and ruled — re-arm from the answer, exactly as the walk's eval would have (the
                 # walk never got to: its session gates held, e.g. an api-error AFTER the judged response)
                 _put_nudged(gid, dict(rec, answeredAt=(resp.get("t") or int(now))))
-                _file_wake_answer(jd.load_goals(sid), sid, gid, now)   # …and the answer files, same as the walk's leg: the
-                #                                              filing saves, so it takes a writer load; the view is frozen
+                _file_wake_answer(sid, gid, now)     # …and the answer files, same as the walk's leg (the filing
+                #                                      saves, so the helper takes its own writer load; the view is frozen)
                 continue
             if resp is not None:
                 continue                             # visible but not ruled yet — the judges own it
@@ -10914,8 +10922,10 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None, wake_only
     # The walk's READ of the store (2026-09-09): the shared read-only view every pusher builder reads, one
     # parse per file version instead of a fresh load per idle session per cycle (66 loads a cycle on the
     # maintainer's box, most of them this line). Every writer downstream reloads at its write moment
-    # (_wake_goal's _fresh, _nudge_fire_list's and the fire path's jd.load_goals), and a write through the
-    # view raises FrozenStoreError rather than landing, so a future writer that forgets fails loudly.
+    # (_wake_goal's _fresh, _file_wake_answer's own load, _nudge_fire_list's and the fire path's
+    # jd.load_goals), and a write through the view raises FrozenStoreError rather than landing, files a
+    # frozen-store-write row and switches the cache off for the process, so a writer that forgets is refused
+    # and recorded rather than landing a write.
     store, fault = jd.load_goals_shared_or_fault(sid)
     if fault is not None:
         return None                                  # its row is filed; nothing fires or stamps on a store we cannot read

--- a/tests/test_nudge_gate_memo.py
+++ b/tests/test_nudge_gate_memo.py
@@ -241,15 +241,17 @@ class GateMemo(_Gate):
 class WalkReadsTheSharedView(_Gate):
     def test_the_walk_reads_through_the_shared_view_and_never_a_fresh_load(self):
         """The walk's own read is the shared view; every writer downstream reloads at its write moment
-        (_wake_goal's fresh load, the fire list's, the fire path's), so a fresh load per idle session per cycle
-        bought nothing. A write through the view raises FrozenStoreError, so a future writer that forgets the
-        reload fails loudly instead of landing."""
+        (_wake_goal's fresh load, _file_wake_answer's own load, the fire list's, the fire path's), so a fresh
+        load per idle session per cycle bought nothing. A write through the view raises FrozenStoreError, files
+        a frozen-store-write row and switches the cache off, so a writer that forgets the reload is refused
+        and recorded instead of landing. The answered wake's filing is pinned by behaviour, not by source text,
+        in tests/test_wake_answer_files_under_shared_view.py: a text pin on _wake_goal's load matched the due
+        leg's reload and stayed green while the answered leg wrote through the view."""
         import inspect
         src = inspect.getsource(km._auto_nudge_session)
         self.assertIn("store, fault = jd.load_goals_shared_or_fault(sid)", src)
         self.assertNotIn("jd.load_goals_or_fault(sid)", src, "no fresh load for the walk's own read")
         self.assertIn("_nudge_placement_gate(sid, turns, store)", src, "the gate is the memoized one")
-        self.assertIn("jd.load_goals(sid)", inspect.getsource(km._wake_goal), "the wake reloads fresh before it writes")
         self.assertIn("_nudge_fire_list(jd.load_goals(sid)", src, "the fire list judges a FRESH store, never the view")
         self.assertIn("_nodes = jd.load_goals(sid)", src, "the fire path re-reads fresh too")
 

--- a/tests/test_wake_answer_files_under_shared_view.py
+++ b/tests/test_wake_answer_files_under_shared_view.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""An answered wake files its outcome row whatever store its caller holds (2026-09-09).
+
+The nudge walk (_auto_nudge_session) reads a session's goal store through the shared read-only view
+(kernel/judge.py load_goals_shared_or_fault) and hands that view to _wake_goal. When the judges have
+ruled on a wake's answer, the answered leg records answeredAt and files the answer into the goal's
+diary (_file_wake_answer): that row is the event the closer's filed-since gate reads, so it re-audits
+with the answer in view. The filing writes (record_verdict, rollup_status, save_goals), so it must take
+its own writer load of the store: a write through the frozen view raises FrozenStoreError inside the
+helper's own catch, and the caller sees only a False return. Before the fix, the first answered wake
+per kernel process filed no row and never retried, a frozen-store-write judge-errors row was filed,
+and the shared cache switched itself off until the next restart (regression:
+https://github.com/romp-on/romp/pull/1141; the other caller, _awaiting_wake_outcomes, already loaded
+a writer copy and was unaffected).
+
+The tests here drive the real path: a file-backed store under a private synthetic sid, read by the
+REAL shared loader (never stubbed), the walk's own store binding, and the answered leg with the
+response judgment stubbed to "answered and ruled" (the response gates are pinned elsewhere; the
+mechanism under test is the write moment). SYNTHETIC fixtures only."""
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads: they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_wakeans", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd                                        # the kernel's OWN judge instance: the cache, its off
+#                                                   switch and the error log live there
+
+SID = "7e7e7e7e-1111-4222-8333-0000000000a7"     # private to this module (synthetic)
+GID = SID + ":g1"
+NOW = 1_790_000_000
+ANCHOR = NOW - 20 * 3600                          # the closer's stamp: a wait older than the dead-man
+FIRE = NOW - 7 * 3600                             # the wake went out
+ANSWER = NOW - 6 * 3600                           # the response the judges ruled on
+WHY = "the build it dispatched; reports when it returns"
+
+
+class _FakeBackend:
+    def __init__(self):
+        self.sent = []
+
+    def send(self, sid, body):
+        self.sent.append((sid, body))
+
+
+def _stamped_node():
+    return {"id": GID, "text": "a goal", "parentId": None, "nodeComplete": False,
+            "blocked": False, "cleared": False, "trail": [], "t": 100, "mt": 100,
+            "awaitingWhy": WHY, "awaitingAt": ANCHOR,
+            "log": [{"ev_t": ANCHOR, "src": "closer", "kind": "awaiting", "why": WHY, "at": 1}]}
+
+
+def _wake_in_flight():
+    return {"wake": True, "anchor": ANCHOR, "count": 1, "lastTurnId": "t1", "armAtoms": 0, "at": FIRE}
+
+
+class AnsweredWakeFilesWhenItsCallerHoldsTheSharedView(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self.saved_state = jd.STATE
+        jd._rebind_state(td)                      # every state path, the shared cache cleared, its off switch lifted
+        jd.GOALDIR.mkdir(parents=True)
+        km._SESSION_STAMP_CACHE.clear(); km._autonudge_cache.clear()
+        self.saved = {k: getattr(km, k) for k in (
+            "_session_flag", "_compacting_now", "_api_error", "_session_working",
+            "_interrupt_suppresses_nudge", "_backend_queued", "_backend_rewind_pending", "_last_state",
+            "_session_awaiting", "_closer_settled", "_revivers_pending", "_pending_ops",
+            "_all_outstanding_delegated", "_peer_answered_at", "_nudge_response_ready")}
+        self.saved_jd = {k: getattr(jd, k) for k in ("parsed_session", "_segs", "plan_units")}
+        self.saved_backend = km.Sessions.backend_for
+        # the session-level gates read idle-and-settled, so the walk reaches the goal loop
+        km._session_flag = lambda sid, flag: False
+        km._compacting_now = lambda sid: False
+        km._api_error = lambda path: None
+        km._session_working = lambda turns: False
+        km._interrupt_suppresses_nudge = lambda turns, sid="", **k: False
+        km._backend_queued = lambda sid: False
+        km._backend_rewind_pending = lambda sid: False
+        km._last_state = lambda sid: ("", 0)
+        km._session_awaiting = lambda *a, **k: None
+        km._closer_settled = lambda *a: True
+        km._revivers_pending = lambda *a, **k: ""
+        km._pending_ops = {}
+        km._all_outstanding_delegated = lambda nodes, gid: False
+        km._peer_answered_at = lambda sid: 0
+        # the judges ruled on the wake's response: the answered leg is the one under test
+        km._nudge_response_ready = lambda *a, **k: (True, {"id": "s9", "t": ANSWER})
+        jd._segs = lambda tn, store: []
+        jd.plan_units = lambda session, store: []
+        self.turns = [{"id": "t1", "ended": True, "end": 100, "t": 90, "atoms": []}]
+        jd.parsed_session = lambda sid, paths, now: {"turns": self.turns}
+        self.fb = _FakeBackend()
+        km.Sessions.backend_for = lambda sid: self.fb
+        self.tmux = {SID: {"state": ""}}
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "placements": {}, "status": {GID: "working"},
+            "nodes": {GID: _stamped_node()}}))
+        (td / "auto-nudge.json").write_text(json.dumps({"enabled": True, "nudged": {GID: _wake_in_flight()}}))
+        self.stats0 = jd.shared_store_stats()
+
+    def tearDown(self):
+        for k, v in self.saved.items():
+            setattr(km, k, v)
+        for k, v in self.saved_jd.items():
+            setattr(jd, k, v)
+        km.Sessions.backend_for = self.saved_backend
+        journal = jd._overrides_dir() / (SID + ".jsonl")   # this sid's override journal goes with the class
+        if journal.exists():
+            journal.unlink()
+        jd._rebind_state(self.saved_state)      # also clears the cache and lifts an off switch this class tripped
+        km._SESSION_STAMP_CACHE.clear(); km._autonudge_cache.clear()
+        self.td.cleanup()
+
+    def _delta(self, key):
+        return jd.shared_store_stats()[key] - self.stats0[key]
+
+    def _frozen_write_rows(self):
+        try:
+            rows = [json.loads(l) for l in jd.ERRORS.read_text().splitlines() if l.strip()]
+        except FileNotFoundError:
+            return []
+        return [r for r in rows if r.get("err") == "frozen-store-write"]
+
+    def _filed_answers(self):
+        nd = jd.load_goals(SID)["nodes"][GID]
+        return nd, [e for e in nd["log"] if e.get("src") == "nudge" and e.get("kind") == "awaiting"
+                    and not e.get("lift")]
+
+    def _assert_answer_filed_cleanly(self, stderr):
+        rec = km._auto_nudge_data()["nudged"][GID]
+        self.assertEqual(rec.get("answeredAt"), ANSWER, "the answered leg ran: the record re-arms from the answer")
+        nd, filed = self._filed_answers()
+        st = jd.shared_store_stats()
+        self.assertEqual(len(filed), 1, "the answer is a FILED event in the goal's diary (shared cache off=%d, "
+                         "poisoned=%d, frozen-store-write rows=%d); helper stderr: %r"
+                         % (st["off"], st["poisoned"] - self.stats0["poisoned"], len(self._frozen_write_rows()), stderr))
+        self.assertEqual(filed[0].get("ev_t"), ANCHOR, "filed at the stamp's own anchor (the coalesce rule)")
+        self.assertEqual(filed[0].get("why"), WHY)
+        self.assertEqual(nd.get("awaitingAt"), ANCHOR, "the anchor never moves")
+        look = {"closerLookT": nd["log"][0]["at"]}    # the closer last looked when the stamp was filed
+        self.assertTrue(jd._filed_since({GID: dict(nd, **look)}, {None: [GID]}, GID,
+                                        jd._look_stamp(dict(nd, **look))),
+                        "the row re-nominates the closer: its filed-since gate opens on the answer")
+        self.assertEqual(jd.shared_store_stats()["off"], 0, "no write reached the shared read-only view")
+        self.assertEqual(self._delta("poisoned"), 0)
+        self.assertEqual(self._frozen_write_rows(), [], "no frozen-store-write row was filed")
+        self.assertEqual(self.fb.sent, [], "an answered wake sends nothing")
+
+    def test_the_walk_files_the_answer_it_read_through_the_shared_view(self):
+        nudged = dict(km._auto_nudge_data().get("nudged", {}))
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            out = km._auto_nudge_session({"sid": SID, "path": "/nonexistent.jsonl"}, NOW, self.tmux, nudged, {})
+        self.assertNotIsInstance(out, str, "a session gate held the walk before the goal loop: %r" % (out,))
+        self.assertGreaterEqual(self._delta("miss") + self._delta("hit"), 1,
+                                "fixture: the walk's store read went through the shared loader")
+        self._assert_answer_filed_cleanly(err.getvalue())
+
+    def test_the_answered_leg_files_when_handed_the_view_itself(self):
+        # the walk's binding, taken here by hand: the shared read-only view object is what _wake_goal holds
+        store, fault = jd.load_goals_shared_or_fault(SID)
+        self.assertIsNone(fault)
+        self.assertIsInstance(store, jd.FrozenStore, "fixture: the store is the shared view, not a writer copy")
+        stamp = km._goal_awaiting_stamp_full(store.get("nodes", {}), GID)
+        self.assertIsNotNone(stamp, "fixture: the goal is stamped")
+        nudged = dict(km._auto_nudge_data().get("nudged", {}))
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            fired = km._wake_goal(SID, GID, stamp, nudged, self.turns, store, NOW, self.turns[-1], self.tmux)
+        self.assertFalse(fired, "an answered wake never escalates")
+        self._assert_answer_filed_cleanly(err.getvalue())
+        self.assertEqual(len(store["nodes"][GID]["log"]), 1, "the view object itself is untouched")
+
+    def test_a_second_answered_wake_in_the_same_process_files_too(self):
+        # the failure mode was per process: the first answered wake tripped the cache off, and every later
+        # one was served a private copy and filed. Two answers in one process must both land, and the
+        # cache must still be on after both.
+        for n in (1, 2):
+            (Path(self.td.name) / "auto-nudge.json").write_text(json.dumps(
+                {"enabled": True, "nudged": {GID: _wake_in_flight()}}))
+            km._autonudge_cache.clear()
+            nudged = dict(km._auto_nudge_data().get("nudged", {}))
+            before = jd.shared_store_stats()
+            with contextlib.redirect_stderr(io.StringIO()):
+                km._auto_nudge_session({"sid": SID, "path": "/nonexistent.jsonl"}, NOW, self.tmux, nudged, {})
+            after = jd.shared_store_stats()
+            self.assertGreaterEqual((after["miss"] + after["hit"]) - (before["miss"] + before["hit"]), 1,
+                                    "fixture: walk %d read the store through the shared loader" % n)
+            nd, filed = self._filed_answers()
+            self.assertEqual(len(filed), n, "answer %d filed its row" % n)
+            self.assertEqual(after["off"], 0, "the shared cache is still on after answer %d" % n)
+            self.assertEqual(after["poisoned"], before["poisoned"], "answer %d wrote nothing through the view" % n)
+        self.assertEqual(self._frozen_write_rows(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

**Symptom.** Since the nudge walk started reading the goal store through the shared read-only view, the first answered wake in a kernel process filed no diary row and never retried. That row drives the closer's re-audit: a goal whose judged wait passed the dead-man window takes a wake; when the session answers and the judges rule on the answer, the walk records the answer and files a same-why re-assert into the goal's diary, and the closer's filed-since gate reads it and re-audits with the answer in view. Without the row the closer never saw the answer, so the wait stood without a re-audit; a `frozen-store-write` judge-errors row was filed, and the shared store cache switched itself off for the rest of the process (`jd.shared_store_stats()` reads `off=1`, `poisoned=1`).

**Cause.** `kernel/kernel.py`: `_auto_nudge_session` binds `store` to the view from `jd.load_goals_shared_or_fault` and hands it to `_wake_goal`; `_wake_goal`'s answered leg passed that view to `_file_wake_answer`. The helper writes (`jd.record_verdict`, `jd.rollup_status`, `jd.save_goals`), so the first write (`nd.setdefault("log", [])` inside `record_verdict`) raised `FrozenStoreError` into the helper's own `except`, which logs to stderr and returns False; the poison side effect had already run. The other caller, `_awaiting_wake_outcomes`, passed `jd.load_goals(sid)` and was unaffected.

**Fix.** `_file_wake_answer(sid, gid, now)` takes no store from its callers and loads its own writer copy with `jd.load_goals` at the write moment. Every use of the store inside the helper is bound to the object that gets saved (the node it files on must belong to the store `record_verdict` appends to and `save_goals` publishes), so a caller-supplied store had no read-only role left, and dropping the parameter makes a write through a frozen view impossible at this site. Both callers change; `_awaiting_wake_outcomes` still costs exactly one writer load per filing. The walk's comment on which writers reload, and `_wake_goal`'s docstring, name the helper's own load, and the comment now says what a write through the view does (raises, files a `frozen-store-write` row, switches the cache off for the process) rather than that it fails loudly. No card-move rule changes.

## Tests

`tests/test_wake_answer_files_under_shared_view.py` (new) drives the real path on a file-backed store under a private synthetic sid, with the shared loader never stubbed: the walk itself (`_auto_nudge_session`, its store read through the shared cache, asserted by the cache counters), the answered leg handed the `FrozenStore` view directly (the view object stays untouched), and two answers in one process (each pass asserts the shared read, the row, and the cache still on). Each asserts that the row lands at the stamp's anchor with its why, that the anchor never moves, that the closer's filed-since gate opens on it, that `jd.shared_store_stats()['off']` is 0 with no poison count, and that no `frozen-store-write` row was filed. Without the change all three fail: no row, `off=1`, `poisoned=1`, one `frozen-store-write` row, and the helper's stderr carries the `FrozenStoreError` traceback.

`tests/test_nudge_gate_memo.py` drops its source-text pin on `_wake_goal`'s load: the pin matched the due leg's reload and stayed green with this regression present, so the behavioural module above replaces it, and the test's docstring now lists the helper's own load among the writers that reload. `tests/test_kernel_awaiting_stamp.py::AwaitingWakeOutcomeSweep::test_sweep_files_an_answer_through_one_writer_load`, which pins one writer load per filing for `_awaiting_wake_outcomes`, still passes.

Regression from https://github.com/romp-on/romp/pull/1141.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)