### PR TITLE
Courier scan: a peer segment placed under a drifted key is not queued

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -15118,6 +15118,12 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=
                     # fired before). Defense in depth beside the fork's sealed-placements seed.
                     continue
                 pm = _seg_peer(seg)
+                if pm and pm[0] and _placed_key(placed_ids, seg["id"]):
+                    continue                           # placed under a DRIFTED key (the parse's t shifted after the
+                    #                                    placement was recorded): the placement loop's own _placed_key
+                    #                                    check dropped the row unwritten every pass, at a writer load per
+                    #                                    row per pass, and the row kept its session from ever recording
+                    #                                    in the change gate (2026-09-09). The same rule, applied here.
                 if not pm or not pm[0]:                # peer-triggered with a KNOWN sender only. This filter
                     #                                    is one half of a partition contract with plan_units:
                     #                                    the courier places exactly the peer segments it can

--- a/tests/test_courier_skip.py
+++ b/tests/test_courier_skip.py
@@ -303,6 +303,39 @@ class CourierSkip(_World):
         self.assertEqual(self.run_pass(), (3, 0, 3), "second pass: nothing to place, no repair open, all recorded")
         self.assertEqual(self.run_pass(), (0, 3, 0), "third pass: all skipped")
 
+    def test_a_segment_placed_under_a_shifted_key_is_not_queued_and_the_session_records(self):
+        # DRIFT (measured live, 2026-09-09): a peer segment whose parse t shifted after its placement was
+        # recorded is no exact member of placements, so the scan queued it every pass; the placement loop
+        # then loaded the store (a writer load per row per pass) and dropped the row through _placed_key
+        # unwritten. Every such session stayed unrecorded, and the courier's loads per pass did not fall.
+        # The scan applies the same drift-tolerant rule: no row, no load, the session records and skips.
+        path = self.proj_dir / (A + ".jsonl")
+        session = jd.parsed_session(A, [str(path)], T0 + 200)
+        fresh = jd.load_goals(A)
+        seg = next(sg for tn in session["turns"] for sg in jd._segs(tn, fresh) if (jd._seg_peer(sg) or ("",))[0])
+        sid, t, texthash = seg["id"].rsplit(":", 2)
+        shifted = "%s:%d:%s" % (sid, int(t) + 7, texthash)          # the same segment, recorded seven seconds later
+        self.assertTrue(jd._placed_key({shifted: "x"}, seg["id"]), "premise: the drift-tolerant rule matches")
+        top = {"id": A + ":g1", "text": "Look after the subnet", "parentId": None, "nodeComplete": False,
+               "blocked": False, "cleared": False, "trail": [], "t": T0,
+               "origin": {"peer": SENDER, "goalId": SENDER + ":g1", "msgId": self.mid_of[A][0]}}
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        (jd.GOALDIR / (A + ".json")).write_text(json.dumps(
+            {"rompUuid": A, "seq": 1, "lastNode": top["id"], "closedTurns": [], "nodes": {top["id"]: top},
+             "placements": {shifted: top["id"]}, "status": {top["id"]: "working"}}))
+        self._reset_memos()
+        private, o_load = [], jd.load_goals
+        jd.load_goals = lambda fsid: (private.append(fsid), o_load(fsid))[1]
+        try:
+            self.assertEqual(self.run_pass(), (3, 0, 1), "A records at once: nothing queued; B and C place")
+        finally:
+            jd.load_goals = o_load
+        self.assertNotIn(A, private, "no writer load for A: its segment never reached the placement loop")
+        self.assertEqual(self.run_pass(), (2, 1, 2), "A skipped; B and C record")
+        self.assertEqual(self.run_pass(), (0, 3, 0))
+        self.assertEqual(json.loads((jd.GOALDIR / (A + ".json")).read_text())["placements"], {shifted: top["id"]},
+                         "A's store untouched: the drifted placement stands as recorded")
+
     def test_a_parse_the_cache_does_not_hold_is_never_skipped(self):
         real = jd.parsed_session
         jd.parsed_session = lambda fsid, paths, now: dict(real(fsid, paths, now))   # a copy: not the cache's object


### PR DESCRIPTION
Tier: fix

## What

The courier's scan applies the placement loop's drift-tolerant placed check before it queues a peer segment. Completes the courier change gate's criterion that goal loads per triage pass fall.

**Measured on the merged gate's first readings** (3.5 and 6.5 min uptime on the shared box, no synthetic load): goal loads per triage pass did not fall (1103 and 1058 against 1062 to 1217 before), the judge thread stayed at 58% to 61% of a core, and the gate barely recorded (scanned 677, skipped 135, recorded 5 over 27 passes). A 60 s py-spy sample put 100% of the courier's remaining writer loads on one line: the placement loop's per-row `store = load_goals(fsid)`. The judge error log had no courier rows, so nothing was deferred or failing.

**Cause.** The scan tests placement by exact segment id (`seg["id"] in placed_ids`); the placement loop tests it with `_placed_key`, the timestamp-invariant rule (a segment whose parse t drifted after its placement was recorded still counts as placed). A peer segment placed under a drifted key therefore passed the scan as unplaced, was queued, cost a writer load in the placement loop, and was dropped there unwritten by `_placed_key`, every pass. Its session had "rows to place" every pass, so the change gate never recorded it: the win was absent for exactly the sessions with drifted placements, which on this box is most of them.

**Fix.** A peer segment with a known sender that `_placed_key(placed_ids, seg["id"])` reports as placed is skipped in the scan (the same call the placement loop makes, without `live`, on the same store content). No row, no writer load, and the session records like any settled one. The exact check stays first (the common case, a set lookup), so `_placed_key` runs only for peer segments the exact check missed, which the placement loop paid for anyway.

No card-move rule changes: those rows were dropped unwritten every pass already; the outcome for every segment is identical, minus the load.

## Review (by hand; the change is five lines)

Cost: `_placed_key` now runs in the scan only for peer segments with a known sender that the exact check missed, the rows that reached the placement loop's `_placed_key` before, so no new cost. Same rule: the two-argument form the placement loop uses, on the same store content (the view; a write landing between the two reads moves the gate's key for the next pass). Repair: a drifted-placed segment never had a repair path (the repair branch is the exact-hit branch, and `_courier_link_target` looks the placement up by exact id), so none is lost. Twins: without `live`, `_placed_key` treats a byte-identical prompt in another turn as a drifted twin, exactly as the placement loop already did for these rows; the planner's own dedup (which passes `live`) is untouched.

## Tests

`tests/test_courier_skip.py`: a segment placed under a shifted key (the same segment recorded seven seconds later) is not queued, takes no writer load, and its session records on the first pass and skips on the second, with the store untouched. Red without the fix (the session had a row to place and never recorded), green with it.

## After

Posted below after the deploy restart: goal loads per triage pass, judge-thread CPU share and the gate's counters at matched uptime, against the readings above.
