### PR TITLE
Codex backend: prune_live takes the kernel's four arguments, and its echo atoms carry the input-echo marker

### DIFF
--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -40,6 +40,14 @@ from pathlib import Path
 HERE = Path(os.path.dirname(os.path.realpath(__file__)))
 _events = SourceFileLoader("romp_codex_events", str(HERE / "codex_events.py")).load_module()
 _runtime = SourceFileLoader("romp_codex_runtime", str(HERE / "codex_runtime.py")).load_module()
+# The by-text KEY RULE (session_backend.echo_text_key): the one normalization under which an input echo's
+# text is compared with a transcript record's, shared with the kernel's _atom_user_texts and
+# SdkBackend.prune_live, so an echo whose text carries a trailing newline still lands. The kernel's own
+# copy of that module when it is loaded (kernel.py loads it as romp_session_backend, and TmuxBackend
+# subclasses that copy's ABC); otherwise the file is loaded under its OWN module name, as sdk_backend
+# does, so re-executing the source never rebinds the ABC out from under a subclass.
+echo_text_key = (sys.modules.get("romp_session_backend") or SourceFileLoader(
+    "romp_session_backend_keys", str(HERE / "session_backend.py")).load_module()).echo_text_key
 
 SDK_PIN = "openai-codex==0.144.4"     # bin/romp-codex-setup installs exactly this into codexvenv
 SETUP_HINT = ("Session not created: the Codex backend isn't installed. "
@@ -769,7 +777,12 @@ class CodexBackend:
         with s.lock:
             if s.dead:
                 return False
-            s.echoes.append({"text": text.strip(), "t": time.time(),
+            # WHOLE seconds, as the SDK and tmux echoes stamp theirs: record times are parse_z's int
+            # seconds and prune_live lands an echo by text only through a record at or after its send,
+            # so a float stamp would keep an echo whose record was written later in the same second. The
+            # text is stored under the shared key rule (echo_text_key), the key prune_live compares
+            # against; for a str that is the stripped text _append matches.
+            s.echoes.append({"text": echo_text_key(text), "t": int(time.time()),
                              "uuid": "echo-%s" % uuidlib.uuid4().hex[:8]})
             turn_id = s.turn_id
             tid = s.tid
@@ -1425,20 +1438,58 @@ class CodexBackend:
         if not s:
             return []
         with s.lock:
+            # `_echo_text` marks the atom as an INPUT ECHO to the kernel, as SdkBackend's echo atoms do:
+            # _merge_live_atoms hides it behind its queued bubble (shown_texts) and never counts it as
+            # live work (an echo-only merge keeps the turn's real ended state), and build_session's
+            # queued-bubble pass enlists it while the session is busy. Without the marker an echo paints
+            # as a solid user atom beside its own queued bubble and forces the last turn open: a false
+            # "working" chip for a session whose only live item is a pending send.
             return [{"type": "user", "uuid": e["uuid"], "session_id": sid, "fsid": s.tid,
-                     "t": e["t"], "parentUuid": None, "author": "human",
+                     "t": e["t"], "parentUuid": None, "author": "human", "_echo_text": e["text"],
                      "message": {"role": "user",
                                  "content": [{"type": "text", "text": e["text"]}]}}
                     for e in s.echoes]
 
-    def prune_live(self, sid, tx_uuids, tx_user_texts=()):
+    def prune_live(self, sid, tx_uuids, tx_user_texts=(), human_floor=0):
+        """Drop the optimistic input echoes the transcript has caught up on, in the SessionBackend
+        contract's full call shape (the kernel's _merge_live_atoms passes sid, tx_uuids, tx_text_t and
+        human_floor positionally; tests/test_backend_call_parity.py pins the shape against every backend).
+
+        An echo retires on the events SdkBackend.prune_live names: its uuid is on disk, or its text
+        LANDED. `tx_user_texts` as a MAPPING (text -> the newest record time carrying it) lands the echo
+        only through a record written at or after its own send: this prune sees the whole transcript, and
+        without that floor a repeated text ("ok" twice) would retire the second echo the moment it was
+        sent (the SDK's T237b case); a plain set (an older caller) keeps the unfloored match. Texts are
+        compared under echo_text_key on BOTH sides. Record times are parse_z's whole seconds, so send()
+        stamps the echo with int(time.time()) as the SDK and tmux echoes do: a float stamp would keep an
+        echo whose record was written later in the same second. The backend's own _append retire is the
+        other exit; it sees only the records it just wrote.
+
+        `human_floor` (the newest genuine-human record's time) is accepted and retires nothing here. No
+        floor retires a plain input echo on any backend: a send the app-server never records must stay
+        visible. The SDK uses the floor to retire its streamed slash-command feedback, atoms carrying
+        `command`, and no Codex echo carries that flag: send() mints plain echoes only."""
         s = self._session(sid)
         if not s:
             return
-        texts = {t.strip() for t in tx_user_texts or ()}
+        uuids = tx_uuids or ()
+        text_t = tx_user_texts if isinstance(tx_user_texts, dict) else None
+        keys = None if text_t is not None else {echo_text_key(t) for t in (tx_user_texts or ())} - {""}
+
+        def _landed(e):
+            if e.get("uuid") in uuids:
+                return True
+            key = echo_text_key(e.get("text"))
+            if not key:
+                return False
+            if text_t is None:
+                return key in keys
+            return key in text_t and float(text_t[key] or 0) >= float(e.get("t") or 0)
+
         with s.lock:
-            s.echoes = [e for e in s.echoes
-                        if e["uuid"] not in (tx_uuids or ()) and e["text"] not in texts]
+            kept = [e for e in s.echoes if not _landed(e)]
+            if len(kept) != len(s.echoes):
+                s.echoes = kept
 
     # ── ask picker (no Codex equivalent in phase 1) ─────────────────────────────────────────────
     def on_ask(self, sid, kind, payload=None):

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -34,7 +34,7 @@ def echo_text_key(text) -> str:
     outer whitespace stripped, nothing else. Every reader shares it and must agree: the kernel's
     _atom_user_text(s) (the keys of the `tx_user_texts` mapping prune_live receives, and the sets the
     queued fold, _merge_live_atoms, _comments_frame and _tmux_echo_prune compare against),
-    SdkBackend.prune_live's by-text retire (the echo side of that comparison), and SdkBackend._text_landed
+    the SDK and Codex prune_live by-text retire (the echo side of that comparison), and SdkBackend._text_landed
     / _landed_texts (the transcript scan behind the boot and dead-spawn duplicate guard). Until 2026-09-06
     the scan collapsed internal whitespace while the prune compared the raw echo text against stripped
     keys, so a send whose text carried a trailing newline (`romp send` passes its argument verbatim) was
@@ -286,8 +286,19 @@ class SessionBackend(ABC):
         stream), [] if none. Merged before the on-disk parse so a just-sent message shows instantly."""
 
     @abstractmethod
-    def prune_live(self, sid: str, tx_uuids, tx_user_texts=()) -> None:
-        """Drop live atoms the transcript now carries (by uuid or echo text), so they don't double-show."""
+    def prune_live(self, sid: str, tx_uuids, tx_user_texts=(), human_floor: int = 0) -> None:
+        """Drop live atoms the transcript now carries (by uuid or echo text), so they don't double-show.
+        THE KERNEL'S CALL SHAPE, which every backend must accept (kernel._merge_live_atoms passes all four
+        positionally; tests/test_backend_call_parity.py pins the shape against each backend): `tx_uuids` is
+        the set of record uuids on disk; `tx_user_texts` maps each landed user text (keyed by echo_text_key)
+        to the NEWEST record time carrying it, so an echo lands by text only through a record written at or
+        after its own send (T237b: "ok" twice must not retire the second before its record), while a plain
+        set from an older caller keeps the unfloored match; `human_floor` is the newest genuine-human
+        record's time, the event that says the transcript has moved past anything typed before it. No floor
+        retires a plain input echo on any backend: the SDK uses it to retire stale COMMAND feedback atoms,
+        the tmux backend to SETTLE an overtaken echo as dropped, and the Codex backend accepts it and retires
+        nothing by it. A backend that declares a narrower signature than this raises TypeError on every live
+        merge of one of its sessions that holds a live atom."""
 
     # ── ask picker ───────────────────────────────────────────────────────────────────────────────
     @abstractmethod

--- a/tests/test_backend_call_parity.py
+++ b/tests/test_backend_call_parity.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""The kernel's call shape on a session backend equals every backend's signature.
+CodexBackend.prune_live took three positional arguments while the kernel's _merge_live_atoms passed four,
+so every live merge of a Codex session holding an input echo raised TypeError: the chat build and the
+feed's merge of that session failed until the echo landed, and the timeline bars logged a live-merge
+failure. Nothing pinned the shape: the backends duck-type the SessionBackend ABC (only TmuxBackend
+subclasses it), so the ABC's own signature, which also lagged, was never enforced, and the conformance
+test checked that each method EXISTS, not what it accepts.
+Two checks, both static (AST over the sources, no kernel import, so a bare run touches no state):
+  1. every call kernel.py makes on a backend bound as `be = Sessions.backend_for(...)` binds against each
+     backend class that defines the method (positional count and keyword names), so a caller that grows an
+     argument fails here until every backend takes it (outside the scan: chained
+     `Sessions.backend_for(x).method(...)` calls and functions that take `be` as a parameter);
+  2. every method the SessionBackend ABC declares is accepted with at least the ABC's positional shape by
+     each backend that defines it, so the ABC stays the contract it claims to be.
+Synthetic fixtures only; the scan reads this repo's own sources.
+"""
+import ast
+import os
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+KERNEL = os.path.join(os.path.dirname(HERE), "kernel")
+SESSION_BACKEND = os.path.join(KERNEL, "session_backend.py")
+BACKENDS = {   # class -> the source file defining it
+    "SdkBackend": os.path.join(KERNEL, "sdk_backend.py"),
+    "CodexBackend": os.path.join(KERNEL, "codex_backend.py"),
+    "TmuxBackend": os.path.join(KERNEL, "kernel.py"),
+}
+
+
+def _parse(path):
+    with open(path, encoding="utf-8") as f:
+        return ast.parse(f.read(), filename=path)
+
+
+def _is_static(fn):
+    return any(isinstance(d, ast.Name) and d.id == "staticmethod" for d in fn.decorator_list)
+
+
+def _class_signatures(tree, cls):
+    """{method: (min_positional, max_positional, has_varargs, keyword_names, has_varkw)} for `cls`, the
+    receiver (self, or cls) excluded; a staticmethod has none. max_positional is None with *args."""
+    out = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == cls:
+            for item in node.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    a = item.args
+                    positional = [x.arg for x in a.posonlyargs + a.args]
+                    if not _is_static(item):
+                        positional = positional[1:]                       # drop the receiver
+                    required = len(positional) - len(a.defaults)
+                    names = set(positional) | {k.arg for k in a.kwonlyargs}
+                    out[item.name] = (required, None if a.vararg else len(positional),
+                                      a.vararg is not None, names, a.kwarg is not None)
+            return out
+    raise AssertionError("class %s not found" % cls)
+
+
+def _binds(sig, npos, kws):
+    """Would a call with `npos` positional arguments and the keyword names `kws` bind to `sig`?"""
+    required, maxpos, varargs, names, varkw = sig
+    if maxpos is not None and npos > maxpos:
+        return False
+    if any(k not in names and not varkw for k in kws):
+        return False
+    return npos + len(kws) >= required
+
+
+def _backend_for_calls(tree):
+    """Every `be.<method>(...)` call in a kernel function whose every `be` binding is
+    Sessions.backend_for(...): [(method, lineno, npos, keyword names)]. Calls with *args are skipped
+    (their count is dynamic)."""
+    found = []
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        binds = []
+        for n in ast.walk(fn):
+            if isinstance(n, ast.Assign) and any(isinstance(t, ast.Name) and t.id == "be" for t in n.targets):
+                binds.append(n.value)
+        if not binds or not all(isinstance(v, ast.Call) and isinstance(v.func, ast.Attribute)
+                                and v.func.attr == "backend_for" for v in binds):
+            continue
+        if "be" in [a.arg for a in fn.args.args]:
+            continue                                     # a parameter: its binding is the caller's
+        for n in ast.walk(fn):
+            if (isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                    and isinstance(n.func.value, ast.Name) and n.func.value.id == "be"
+                    and not any(isinstance(a, ast.Starred) for a in n.args)):
+                found.append((n.func.attr, n.lineno, len(n.args), [k.arg for k in n.keywords if k.arg]))
+    return found
+
+
+class CallShapeParity(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        trees = {path: _parse(path) for path in set(BACKENDS.values()) | {SESSION_BACKEND}}   # each file once
+        cls.calls = _backend_for_calls(trees[BACKENDS["TmuxBackend"]])                     # kernel.py
+        cls.sigs = {name: _class_signatures(trees[path], name) for name, path in BACKENDS.items()}
+        cls.abc = _class_signatures(trees[SESSION_BACKEND], "SessionBackend")
+
+    def test_the_live_merge_calls_prune_live_with_four_arguments_every_backend_takes(self):
+        # the exact drift: pinned by name so a rename of the caller cannot pass this vacuously
+        calls = [c for c in self.calls if c[0] == "prune_live"]
+        self.assertTrue(calls, "kernel.py no longer calls be.prune_live on a backend_for backend; re-anchor")
+        for _, lineno, npos, kws in calls:
+            self.assertEqual((npos, kws), (4, []), "kernel.py:%d prune_live call shape" % lineno)
+            for name, sigs in self.sigs.items():
+                self.assertIn("prune_live", sigs, name)
+                self.assertTrue(_binds(sigs["prune_live"], 4, []),
+                                "%s.prune_live does not take the kernel's four arguments" % name)
+
+    def test_every_backend_for_call_binds_on_every_backend_that_defines_the_method(self):
+        bad = []
+        for method, lineno, npos, kws in self.calls:
+            for name, sigs in self.sigs.items():
+                if method in sigs and not _binds(sigs[method], npos, kws):
+                    bad.append("kernel.py:%d be.%s(%d positional%s) does not bind on %s.%s"
+                               % (lineno, method, npos, (", kw=" + ",".join(kws)) if kws else "", name, method))
+        self.assertEqual(bad, [], "\n".join(bad))
+
+    def test_every_backend_accepts_at_least_the_abcs_shape_for_each_method_it_defines(self):
+        bad = []
+        for method, (req, maxpos, _, names, _) in self.abc.items():
+            if method.startswith("__"):
+                continue
+            fullest = maxpos if maxpos is not None else req      # a *args method's fullest FIXED call
+            for name, sigs in self.sigs.items():
+                sig = sigs.get(method)
+                if sig is None:
+                    continue
+                # the ABC's fullest positional call must bind, and its required count must not be raised
+                if not _binds(sig, fullest, []) or sig[0] > req:
+                    bad.append("%s.%s accepts %d..%s but SessionBackend.%s declares %d..%s positional"
+                               % (name, method, sig[0], sig[1], method, req, maxpos))
+        self.assertEqual(bad, [], "\n".join(bad))
+
+    def test_the_abc_declares_prune_lives_floor(self):
+        self.assertEqual(self.abc["prune_live"][1], 4, "SessionBackend.prune_live: sid, tx_uuids, tx_user_texts, human_floor")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -1139,6 +1139,122 @@ for i in range(20):
         self.assertTrue(be.kill(sid))   # kill's held-final drain notifies too — same reentry
 
 
+class _Clock:
+    """A clock the backend module reads through its `time` global: time() answers `now`, everything
+    else (monotonic, sleep) is the real module's. Patched onto the backend MODULE for one send() call,
+    never onto the time module, so nothing outside the backend sees it."""
+
+    def __init__(self, now):
+        self.now = now
+
+    def time(self):
+        return self.now
+
+    def __getattr__(self, name):
+        return getattr(time, name)
+
+
+class PruneLive(unittest.TestCase):
+    """The kernel's _merge_live_atoms calls be.prune_live(sid, tx_uuids, tx_text_t, human_floor), four
+    positional arguments, and CodexBackend.prune_live took three: every live merge of a Codex session
+    holding an echo raised TypeError (the chat build and the feed's merge failed outright; the timeline
+    bars logged a live-merge failure). The call shape is pinned across every backend in
+    tests/test_backend_call_parity.py; this class covers the behaviour in the kernel's REAL shapes:
+    record times are parse_z's whole seconds (the mapping's values are floats of them), and the echo's
+    own stamp is int(time.time()), as the SDK and tmux echoes stamp theirs."""
+
+    def _with_echo(self, text="ship it", t=1000):
+        be, fake, _ = build()
+        sid = be.spawn("web", "/TESTDIR")
+        s = be._session(sid)
+        with s.lock:
+            s.echoes.append({"text": text, "t": t, "uuid": "echo-11111111"})
+        return be, sid
+
+    def _sent(self, be, sid, text, now):
+        """An echo through send() itself, on the steer path (an open turn: nothing queues, no worker
+        thread runs), with the backend's clock reading `now`."""
+        s = be._session(sid)
+        with s.lock:
+            s.turn_id = "t-live"
+        with mock.patch.object(cb, "time", _Clock(now)):
+            self.assertTrue(be.send(sid, text))
+
+    def test_accepts_the_kernels_four_positional_arguments_and_no_floor_retires_a_plain_echo(self):
+        be, sid = self._with_echo()
+        be.prune_live(sid, frozenset(), {}, 2000)          # the exact caller shape: a set, a mapping, a floor
+        self.assertEqual(len(be.live_atoms(sid)), 1,
+                         "no floor retires a plain echo: a send the app-server never records must stay visible")
+
+    def test_text_lands_only_through_a_record_at_or_after_the_send(self):
+        # "ok" sent twice: the first record predates the second echo, so it must not retire it; a record
+        # stamped at or after the send does. Whole-second record times, as the kernel derives them.
+        be, sid = self._with_echo("ok", t=1000)
+        be.prune_live(sid, frozenset(), {"ok": 999.0}, 0)
+        self.assertEqual(len(be.live_atoms(sid)), 1, "an older record with the same text is not this send")
+        be.prune_live(sid, frozenset(), {"ok": 1000.0}, 0)
+        self.assertEqual(be.live_atoms(sid), [], "a record at the send's second lands it")
+
+    def test_a_record_later_in_the_sends_own_second_lands_the_echo(self):
+        # The echo is stamped in WHOLE seconds like the SDK's and the tmux echo's. A float stamp (1000.3)
+        # would keep an echo whose record was written at 1000.7: parse_z reads that record as 1000, and
+        # 1000 >= 1000.3 is false, the same-second case the SDK retires.
+        be, fake, _ = build()
+        sid = be.spawn("web", "/TESTDIR")
+        self._sent(be, sid, "ok", 1000.3)
+        atom, = be.live_atoms(sid)
+        self.assertIsInstance(atom["t"], int)
+        self.assertEqual(atom["t"], 1000)
+        be.prune_live(sid, frozenset(), {"ok": 999.0}, 0)
+        self.assertEqual(len(be.live_atoms(sid)), 1, "the second before the send is not this send")
+        be.prune_live(sid, frozenset(), {"ok": 1000.0}, 0)
+        self.assertEqual(be.live_atoms(sid), [], "a record later in the send's own second lands it")
+
+    def test_text_compares_under_the_shared_key_rule_on_both_sides(self):
+        # The ECHO side: an echo whose stored text carries outer whitespace (injected directly, past
+        # send()'s own keying) still lands against the kernel's stripped key.
+        be, sid = self._with_echo("  ship it\n", t=1000)
+        be.prune_live(sid, frozenset(), {"ship it": 1001.0}, 0)
+        self.assertEqual(be.live_atoms(sid), [], "the echo's text is keyed before the comparison")
+        # The SET side: an older caller's plain set, unstripped, keyed the same way and unfloored.
+        be2, sid2 = self._with_echo("ship it", t=1000)
+        be2.prune_live(sid2, frozenset(), {"  ship it\n"}, 0)
+        self.assertEqual(be2.live_atoms(sid2), [], "a plain set keeps the unfloored match, keyed the same way")
+
+    def test_uuid_retires(self):
+        be, sid = self._with_echo("ship it", t=1000)
+        s = be._session(sid)
+        with s.lock:
+            s.echoes.append({"text": "and the tests", "t": 1000, "uuid": "echo-22222222"})
+        be.prune_live(sid, frozenset({"echo-11111111"}), {}, 0)
+        self.assertEqual([a["uuid"] for a in be.live_atoms(sid)], ["echo-22222222"], "by uuid, that echo only")
+
+    def test_unknown_sid_is_a_no_op(self):
+        be, _, _ = build()
+        be.prune_live("7c1d2e3f-4a5b-4c6d-8e7f-9a0b1c2d3e4f", frozenset(), {}, 0)
+
+
+class EchoAtoms(unittest.TestCase):
+    """What the kernel reads off a Codex echo. `_echo_text` is the marker every kernel reader of an input
+    echo keys on (SdkBackend's echo atoms carry it): _merge_live_atoms hides the echo behind its queued
+    bubble and never counts it as live work, and build_session's queued-bubble pass enlists it while the
+    session is busy. Without it a Codex echo would paint as a solid user atom beside its own queued bubble
+    and force the last turn open (the merge itself is pinned in tests/test_codex_echo_merge.py)."""
+
+    def test_the_echo_atom_is_marked_as_an_input_echo(self):
+        be, fake, _ = build()
+        sid = be.spawn("web", "/TESTDIR")
+        s = be._session(sid)
+        with s.lock:
+            s.turn_id = "t-live"                           # an open turn: send() steers, nothing queues
+        self.assertTrue(be.send(sid, "  ship it\n"))
+        atom, = be.live_atoms(sid)
+        self.assertEqual(atom["_echo_text"], "ship it", "the sent text, under the shared key rule")
+        self.assertEqual(atom["message"]["content"][0]["text"], "ship it")
+        self.assertEqual(atom["author"], "human")
+        self.assertNotIn("command", atom, "a plain echo carries no command flag")
+
+
 class LaunchErrorNames(unittest.TestCase):
     """A LIVE launch-error row without a shared name let a retry mint a duplicate live session
     under the same name (the v1.3.12 audit's P2) — both failure branches now write names/."""

--- a/tests/test_codex_echo_merge.py
+++ b/tests/test_codex_echo_merge.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""A Codex input echo is an ECHO to the kernel's live merge. CodexBackend.live_atoms emitted its echo
+atoms without `_echo_text`, the marker every kernel reader of an input echo keys on, so with prune_live
+taking the kernel's four arguments (tests/test_codex_backend.py PruneLive) and nothing else changed, the
+merge would paint a Codex echo as a solid user atom beside its own queued bubble, paint it once more
+beside its landed record, and count an echo-only merge as live ASSISTANT work, forcing the last turn
+open: a false "working" chip for a session whose only live item is a pending send. The atoms carry
+`_echo_text` now, and this module runs the REAL kernel merge (_merge_live_atoms) over the REAL backend (a
+scripted fake app-server client: no SDK, no network, no turn ever streams) to pin the consequences. The
+kernel is loaded the way tests/test_kernel_fed_echo_absorbed.py loads it. Synthetic fixtures only (the
+notes-api demo domain).
+"""
+import os
+import tempfile
+import threading
+import unittest
+from importlib.machinery import SourceFileLoader
+from types import SimpleNamespace
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+# Hermetic state BEFORE the loads: they resolve their state root at import time, and only pytest runs
+# conftest's floor (a bare unittest or script run otherwise writes REAL state, and a kernel module that
+# can reach a live manager port restarts the live kernel).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["ROMP_MANAGER_PORT"] = "1"             # a dead port, never an inherited live one
+os.environ["ROMP_MODEL_CATALOG"] = "off"          # never the Models API from a test
+km = SourceFileLoader("romp_kernel_codex_echo_merge", os.path.join(BIN, "romp-kernel")).load_module()
+cb = SourceFileLoader("romp_codex_backend_echo_merge",
+                      os.path.join(ROOT, "kernel", "codex_backend.py")).load_module()
+
+T0 = 1781100000
+
+
+class FakeClient:
+    """The slice of the app-server client that spawn and a mid-turn send (a steer) touch. Nothing
+    streams: no turn is ever started, so no worker thread writes the transcript under the test, and
+    next_notification parks the backend's global pump (a daemon thread) for the process."""
+
+    def __init__(self):
+        self.steers = []
+        self._park = threading.Event()
+
+    def account_read(self, *a, **k):
+        return SimpleNamespace(requires_openai_auth=False, account={"ok": True})
+
+    def thread_start(self, params=None):
+        return SimpleNamespace(thread=SimpleNamespace(id="T-1"), model="gpt-5-test")
+
+    def thread_set_name(self, tid, name):
+        pass
+
+    def turn_steer(self, tid, expected_turn_id, input_items):
+        self.steers.append((tid, expected_turn_id, input_items))
+
+    def next_notification(self):
+        self._park.wait()
+
+
+class CodexEchoMerge(unittest.TestCase):
+    def setUp(self):
+        self.fake = FakeClient()
+        self.be = cb.CodexBackend(tempfile.mkdtemp(), client_factory=lambda: self.fake, log=lambda m: None)
+        self.sid = self.be.spawn("web", "/TESTDIR")
+        s = self.be._session(self.sid)
+        with s.lock:
+            s.turn_id = "t-live"          # an open turn: send() steers (nothing queues, no worker thread)
+        self._saved_backend_for = km.Sessions.__dict__["backend_for"]
+        be = self.be
+        km.Sessions.backend_for = staticmethod(lambda sid: be)
+
+    def tearDown(self):
+        km.Sessions.backend_for = self._saved_backend_for
+
+    @staticmethod
+    def _user(text, uid, t):
+        return {"type": "user", "uuid": uid, "t": t, "author": "human",
+                "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+
+    @staticmethod
+    def _assistant(uid, t, text):
+        return {"type": "assistant", "uuid": uid, "t": t,
+                "message": {"role": "assistant", "content": [{"type": "text", "text": text}]}}
+
+    def _session(self, *extra):
+        """One ENDED turn on disk, plus whatever `extra` atoms the case lands in it."""
+        return {"turns": [{"id": "t1", "trigger": "u1", "t": T0, "end": T0 + 10, "ended": True,
+                           "atoms": [self._user("tighten the notes-api search", "u1", T0),
+                                     self._assistant("a1", T0 + 10, "Done."), *extra]}]}
+
+    def test_an_echo_shown_as_queued_adds_no_atom_and_leaves_the_turn_ended(self):
+        # build_session's exact call: shown_texts = the queued bubbles already painted; the echo behind
+        # one is hidden, not pruned (its record has not landed), and it is not live work
+        self.assertTrue(self.be.send(self.sid, "and the tests"))
+        self.assertEqual(len(self.fake.steers), 1, "a mid-turn send steers")
+        sess = self._session()
+        merged = km._merge_live_atoms(sess, self.sid, shown_texts=["and the tests"])
+        self.assertIs(merged, sess, "hidden behind its queued bubble: nothing to merge, the turn stays as parsed")
+        self.assertTrue(sess["turns"][-1]["ended"])
+        self.assertEqual(len(self.be.live_atoms(self.sid)), 1, "hidden, not pruned: the record has not landed")
+
+    def test_an_echo_alone_paints_once_and_never_forces_the_turn_open(self):
+        self.assertTrue(self.be.send(self.sid, "and the tests"))
+        merged = km._merge_live_atoms(self._session(), self.sid)
+        echoes = [a for a in merged["turns"][-1]["atoms"] if a.get("_echo_text")]
+        self.assertEqual([a["_echo_text"] for a in echoes], ["and the tests"], "the pending send is visible, once")
+        self.assertTrue(merged["turns"][-1]["ended"], "an echo-only merge keeps the turn's real ended state")
+        self.assertFalse(km._session_working(merged["turns"]), "no false working chip")
+
+    def test_a_record_in_the_sends_second_retires_the_echo_and_the_text_paints_once(self):
+        self.assertTrue(self.be.send(self.sid, "and the tests"))
+        t_echo = self.be.live_atoms(self.sid)[0]["t"]
+        self.assertIsInstance(t_echo, int, "the echo is stamped in whole seconds, as the record will be")
+        sess = self._session(self._user("and the tests", "u2", t_echo))      # lands within the send's second
+        merged = km._merge_live_atoms(sess, self.sid)
+        self.assertEqual(self.be.live_atoms(self.sid), [], "prune_live retired the echo by text")
+        self.assertIs(merged, sess, "and the merge painted nothing beside the record")
+        texts = [t for a in sess["turns"][-1]["atoms"] for t in km._atom_user_texts(a)]
+        self.assertEqual(texts.count("and the tests"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Symptom.** Any live merge of a Codex session holding an input echo (a send queued behind a busy turn, a steer in flight, a send the app-server never recorded) raises `TypeError: CodexBackend.prune_live() takes from 3 to 4 positional arguments but 5 were given`. The chat build of that session fails (`build_session`), the feed build fails for every session while the echo exists and that session's parse is cached (`build_feed` merges inside its loop), and the timeline bars log a live-merge failure and fall back to disk-only bars. The failure lasts as long as the echo does.

**Cause.** `_merge_live_atoms` calls `be.prune_live(sid, tx_uuids, tx_text_t, human_floor)`. `SdkBackend.prune_live` and the tmux backend's take the fourth argument; `CodexBackend.prune_live` and the `SessionBackend` ABC declare three. Nothing checked the shape: the backends duck-type the ABC, and the conformance test checks that methods exist, not what they accept.

Once the call binds, a second problem shows. `CodexBackend.live_atoms` emitted its echo atoms without `_echo_text`, the key the merge uses to recognise an input echo: it hides an echo behind its queued bubble or its landed record only when the key is present, and counts an atom without it as live assistant work, forcing the last turn open. So a queued Codex send would paint twice, and a session whose only live item is a pending send would show a working chip.

**Fix.**
- `CodexBackend.prune_live(sid, tx_uuids, tx_user_texts=(), human_floor=0)`, and the ABC declares the same four with the kernel's call shape in its docstring. An echo retires by uuid, or by text under `echo_text_key` on both sides; when the caller passes the kernel's text-to-newest-record-time mapping, only through a record written at or after the echo's send (the rule the SDK backend applies: a repeated "ok" must not retire the newer echo before its record); a plain set keeps the unfloored match. `human_floor` is accepted and retires nothing here: no Codex echo carries the `command` flag the SDK's floor is for, and no floor retires a plain echo.
- `send()` stamps the echo in whole seconds like the SDK and tmux echoes: record times are whole seconds, and a float stamp would keep an echo whose record was written later in the same second. The text is stored under `echo_text_key`, imported the way `sdk_backend.py` imports it (the kernel's copy of `session_backend` when it is loaded, else the file under its own module name).
- `live_atoms` marks each echo with `_echo_text`.

**Visible change.** A mid-turn steer now reads as a pending bubble until the app-server records it, because `build_session`'s queued-bubble pass takes every unlanded echo of a backend without `unqueue` while the session is busy. A queued send is already shown from the queue and is not doubled.

**Tests, each failing before the change.**
- `tests/test_backend_call_parity.py` (new, static: an AST walk over the sources, no kernel import): every call the kernel makes on a `Sessions.backend_for` backend binds on every backend that defines the method; the `prune_live` call is four positional arguments and binds on all three backends; every backend accepts at least the ABC's shape; the ABC declares the floor. On main three of four fail: `kernel.py:28854 be.prune_live(4 positional) does not bind on CodexBackend.prune_live`, and `SessionBackend.prune_live` declares 3, not 4.
- `tests/test_codex_backend.py`: `PruneLive` (the four-argument call with no floor retiring a plain echo; a text landing only through a record at or after the send; a record later in the send's own second; the key rule on both sides, mapping and plain set; retire by uuid; unknown sid) and `EchoAtoms` (the marker). On main every four-argument call raises `TypeError`. With only the two `def` lines changed, four stay red: the mapping-floor test (a 999.0 record retires a t=1000 echo), the same-second test (the float stamp), the both-sides key test (the raw echo text compared against a stripped key), and the marker test (`KeyError: '_echo_text'`).
- `tests/test_codex_echo_merge.py` (new): the real `_merge_live_atoms` over the real `CodexBackend` with a scripted app-server client. An echo behind its queued bubble adds no atom and leaves the turn ended; an echo alone paints once and never forces the turn open; a record in the send's second retires the echo and the text paints once. On main all three fail (two on the `TypeError`, the third on the float stamp before it reaches the merge). Without the marker all three fail; without the whole-second stamp the third does.

**Not in this PR.** Several sends queued before a turn starts go out as one turn, and the normalizer joins them into one text block, so none of their echoes retires; that is a separate fix with its own test, filed next. The Codex model picker opening blank (an empty catalog cached for the process, no reason on `/models`, no models frame when the first Codex session opens the list, no reason row in the picker) is separate work in the kernel and the picker. This PR touches no `kernel.py`, no UI and no docs.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)