### PR TITLE
T282: every module ends the threads it starts, and no module writes the placeholder sid at the run-wide root

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36361,8 +36361,9 @@ def _heartbeat():
     ~40-byte frame is schedulable on time no matter how pegged the CPU-bound threads are, so the
     watchdog now measures the SOCKET's health, not the kernel's load. Frame-safety: _ws_send holds the
     per-client write lock, so beating concurrently with the pusher can't interleave frames."""
-    while True:
-        time.sleep(KEEPALIVE_S)
+    while not _LOOPS_STOP.is_set():
+        if _LOOPS_STOP.wait(KEEPALIVE_S):      # the sleep, ended early only by the stop seam (T282)
+            return
         try:
             _keepalive_all()
         except Exception:
@@ -39569,6 +39570,10 @@ _last_producer_sig = [None]
 # Event-driven wake: POST /tick (poked by the Stop / UserPromptSubmit hooks the instant a turn ends or a
 # prompt lands) sets this so the producer runs a judge pass NOW instead of waiting out the 20s backstop.
 _producer_wake = threading.Event()
+# The three long-lived loops (_producer, _pusher, _heartbeat) run for the kernel's lifetime; this event is the
+# ONE way to end them, for a test that starts a real loop and must not leave it running past its module
+# (T282). Never set in production: the kernel's loops end with the process.
+_LOOPS_STOP = threading.Event()
 # Same idea for the CHAT PUSHER: the SDK live-tail (and any caller) sets this to push the chat NOW
 # instead of waiting out the 4s poll — the SDK stream leads the transcript on disk, so an immediate push
 # of the in-memory live atoms makes messages appear instantly. 4s stays as the backstop.
@@ -40823,7 +40828,7 @@ def _run_tier(fn):
 
 def _producer():
     _prev_wall = _prev_mono = None
-    while True:
+    while not _LOOPS_STOP.is_set():
         _nw, _nm = time.time(), time.monotonic()        # detect a host suspension (laptop slept) since the
         _iv = _detect_suspend(_prev_wall, _prev_mono, _nw, _nm)   # last tick: wall jumped past monotonic
         if _iv:
@@ -41036,7 +41041,7 @@ def _pusher_cycle_jobs(now, tmux, any_client):
 
 
 def _pusher():
-    while True:
+    while not _LOOPS_STOP.is_set():
         _pusher_cycle()
         # Event-driven (woken by the SDK live-tail and by /tick on hook events) with a SHORT 0.5s backstop
         # poll, so tmux sessions — which have no per-message event for mid-turn streaming — still refresh

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -610,3 +610,39 @@ def pytest_collectreport(report):
     Redacted BEFORE the other implementations see it: the terminal reporter files it from here."""
     _redact_report(report)
     yield
+
+
+# ── thread census (T282) ──────────────────────────────────────────────────────────────────────────────
+# A test that starts a real kernel loop, a backend pump or a fake server must end it before its module ends: a
+# daemon thread that outlives its module runs against whatever the shared modules (the judge, the event model)
+# are bound to by then. These two helpers are the pin every such module carries, and the module-boundary
+# tracer reads the same census, so a leak is named by the module that made it.
+def thread_census():
+    """The live non-main threads as stable descriptors: the target's qualified name when the thread has one,
+    else its name; pytest-timeout's own watchdog thread excluded. Sorted, so two censuses compare directly."""
+    import threading
+    out = []
+    for t in threading.enumerate():
+        if t is threading.main_thread():
+            continue
+        target = getattr(t, "_target", None)
+        mod = (getattr(target, "__module__", "") or "") if target is not None else ""
+        if t.name.startswith("pytest_timeout") or mod.startswith("pytest_timeout"):
+            continue
+        out.append("%s.%s" % (mod, getattr(target, "__qualname__", None) or repr(target)) if target is not None else t.name)
+    return sorted(out)
+
+
+def wait_for_census(before, timeout=5.0):
+    """The threads alive now that were NOT in `before`, once that set is empty or at the deadline: a module's pin is
+    "nothing this module started outlives it", so a thread from an EARLIER module that happens to end during this one
+    cannot fail it, and a thread this module started has a moment (20 ms polls, up to `timeout`) to reach its exit
+    after join(timeout) returned. Returns the sorted leftovers; a clean module gets []."""
+    import time
+    deadline = time.monotonic() + timeout
+    base = set(before)
+    while True:
+        extra = sorted(set(thread_census()) - base)
+        if not extra or time.monotonic() >= deadline:
+            return extra
+        time.sleep(0.02)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -638,11 +638,12 @@ def wait_for_census(before, timeout=5.0):
     "nothing this module started outlives it", so a thread from an EARLIER module that happens to end during this one
     cannot fail it, and a thread this module started has a moment (20 ms polls, up to `timeout`) to reach its exit
     after join(timeout) returned. Returns the sorted leftovers; a clean module gets []."""
+    import collections
     import time
     deadline = time.monotonic() + timeout
-    base = set(before)
+    base = collections.Counter(before)
     while True:
-        extra = sorted(set(thread_census()) - base)
-        if not extra or time.monotonic() >= deadline:
+        extra = sorted((collections.Counter(thread_census()) - base).elements())   # by COUNT: a second thread of a
+        if not extra or time.monotonic() >= deadline:                              # kind already present is a leftover
             return extra
         time.sleep(0.02)

--- a/tests/test_clear_chat_view.py
+++ b/tests/test_clear_chat_view.py
@@ -65,7 +65,8 @@ def _write_jsonl(path, rows):
 
 class ClearChatViewTest(unittest.TestCase):
     def setUp(self):
-        self._td = tempfile.mkdtemp()
+        self._saved_state = jd.STATE       # restored in tearDown: the judge is one module shared by every test module
+        self._td = tempfile.mkdtemp()      # in the process, and it was left aimed at this tmp after rmtree (T282)
         jd._rebind_state(Path(self._td))
         jd.PROJECTS = Path(self._td) / "projects"
         jd._discover_cache["fp"] = None
@@ -100,6 +101,7 @@ class ClearChatViewTest(unittest.TestCase):
         ])
 
     def tearDown(self):
+        jd._rebind_state(self._saved_state)
         shutil.rmtree(self._td, ignore_errors=True)
 
     def _events(self):
@@ -233,7 +235,8 @@ class PreClearNotesStayInTheirEpisode(unittest.TestCase):
     card's fold, with the rest of the pre-clear conversation). Synthetic data only."""
 
     def setUp(self):
-        self._td = tempfile.mkdtemp()
+        self._saved_state = jd.STATE       # restored in tearDown: the judge is one module shared by every test module
+        self._td = tempfile.mkdtemp()      # in the process, and it was left aimed at this tmp after rmtree (T282)
         jd._rebind_state(Path(self._td))
         jd.PROJECTS = Path(self._td) / "projects"
         jd._discover_cache["fp"] = None
@@ -269,6 +272,7 @@ class PreClearNotesStayInTheirEpisode(unittest.TestCase):
         ])
 
     def tearDown(self):
+        jd._rebind_state(self._saved_state)
         shutil.rmtree(self._td, ignore_errors=True)
 
     def test_live_render_shows_only_the_current_episodes_notes(self):

--- a/tests/test_clear_wrap.py
+++ b/tests/test_clear_wrap.py
@@ -39,6 +39,29 @@ class SentNothing:
 
 
 class ClearIsSilent(unittest.TestCase):
+    def setUp(self):
+        # the kernel's judge is one module object shared by every test module in the process, so a store saved at its import-bound GOALDIR outlives the module and reaches every later module's feed for the placeholder sid (T281/T282); a private root for the duration.
+        self._td = tempfile.TemporaryDirectory()
+        self._state = jd.STATE
+        jd._rebind_state(Path(self._td.name))
+
+    def tearDown(self):
+        jd._rebind_state(self._state)
+        self._td.cleanup()
+
+    def test_the_store_this_module_saves_does_not_outlive_it(self):
+        # The residue pin (T281/T282): a store saved through the shared judge lands under this test's root and
+        # the run-wide root (what every later module's feed reads) is exactly as it was.
+        shared = Path(self._state) / "goals" / (SID + ".json")
+        before = (shared.exists(), shared.stat().st_mtime_ns if shared.exists() else None)
+        st = jd.load_goals(SID)
+        st["nodes"][SID + ":t282"] = jd.GuardedNode({"id": SID + ":t282", "text": "a note", "parentId": None, "nodeComplete": False,
+                                                        "blocked": False, "cleared": False, "trail": [], "t": 1, "mt": 1, "log": []})
+        jd.save_goals(SID, st)
+        self.assertTrue((Path(self._td.name) / "goals" / (SID + ".json")).exists(), "the store lives under this module's root")
+        self.assertEqual((shared.exists(), shared.stat().st_mtime_ns if shared.exists() else None), before,
+                         "the run-wide goals directory is untouched by this module")
+
     def test_clearing_an_open_card_sends_the_session_nothing(self):
         store = jd.load_goals(SID)
         store["nodes"][G_OPEN] = jd.GuardedNode({"id": G_OPEN, "text": "build the exporter",

--- a/tests/test_client_diag_rotation.py
+++ b/tests/test_client_diag_rotation.py
@@ -36,6 +36,12 @@ WID = "11111111-2222-3333-4444-555555555555"
 
 class ClientDiagRotationTest(unittest.TestCase):
     def setUp(self):
+        # A private state root (T282): km.jd is the judge module every test module shares, and its STATE is whatever
+        # the last module left, once a directory another module had already removed; the writer under test then
+        # had nowhere to write and these tests read a file that was never made.
+        self._saved_state = km.jd.STATE
+        self._td = tempfile.TemporaryDirectory()
+        km.jd._rebind_state(pathlib.Path(self._td.name))
         self.fp = km.jd.STATE / "client-diag.jsonl"
         self.fp1 = km.jd.STATE / "client-diag.jsonl.1"
         for f in (self.fp, self.fp1):
@@ -50,6 +56,8 @@ class ClientDiagRotationTest(unittest.TestCase):
         for f in (self.fp, self.fp1):
             if f.exists():
                 f.unlink()
+        km.jd._rebind_state(self._saved_state)
+        self._td.cleanup()
 
     def post(self, i):
         """One breadcrumb through the real dispatch: what the shim sends for a pane's minute row."""

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -19,6 +19,8 @@ import time
 import unittest
 from unittest import mock
 from importlib.machinery import SourceFileLoader
+
+from tests.conftest import thread_census, wait_for_census
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -84,6 +86,41 @@ def note(method, params):
     return SimpleNamespace(method=method, payload=_Payload(params))
 
 
+_CLIENTS = []                    # every FakeClient made by this module
+_BACKENDS = []                   # every CodexBackend made by this module
+_CENSUS0 = []
+_ORIG_INIT = []
+
+
+def setUpModule():
+    # Residue hygiene (T282): each backend this module builds starts a global pump per client and a worker per
+    # session, daemon threads that parked on the fake client forever and outlived the module (64 of them under
+    # the full suite). Every backend and client is recorded here and ended in tearDownModule, which then pins
+    # the thread census back to what it was when the module started.
+    _CENSUS0[:] = [thread_census()]
+    orig = cb.CodexBackend.__init__
+
+    def recording_init(self, *a, **k):
+        orig(self, *a, **k)
+        _BACKENDS.append(self)
+    _ORIG_INIT[:] = [orig]
+    cb.CodexBackend.__init__ = recording_init
+
+
+def tearDownModule():
+    cb.CodexBackend.__init__ = _ORIG_INIT[0]
+    for be in _BACKENDS:
+        for _, sess in be._session_items():          # a worker returns when it wakes to a dead session
+            with sess.lock:
+                sess.dead = True
+            sess.kick.set()
+    for c in _CLIENTS:
+        c.close()                                    # a pump returns when its client reads as closed
+    _BACKENDS.clear(); _CLIENTS.clear()
+    left = wait_for_census(_CENSUS0[0], timeout=10)
+    assert left == [], "threads outlived this module: %r" % left
+
+
 class FakeClient:
     """Scripted app-server: turn_start opens a queue and streams either the injected script or a
     default echo turn (userMessage + agentMessage + tokenUsage + completed)."""
@@ -95,6 +132,8 @@ class FakeClient:
         self.hold_open = False      # script the turn to stay open (steer/interrupt tests)
         self._n = 0
         self._global = queue.Queue()
+        self._closed = False
+        _CLIENTS.append(self)       # every client ever made is closed when the module ends (T282)
 
     # bookkeeping helpers ------------------------------------------------------------------
     def _rec(self, name, *a):
@@ -113,6 +152,8 @@ class FakeClient:
 
     def close(self):
         self._rec("close")
+        self._closed = True
+        self._global.put(None)      # wakes the backend's global pump, which reads the close and stops (T282)
 
     def thread_start(self, params=None):
         self._rec("thread_start", params)
@@ -186,7 +227,10 @@ class FakeClient:
                                                      "status": "interrupted"}}))
 
     def next_notification(self):
-        return self._global.get()   # blocks forever — the global pump just parks in tests
+        n = self._global.get()      # parks the backend's global pump until a notification or the close
+        if n is None or self._closed:
+            raise RuntimeError("client closed")   # the pump logs "global pump stopped" and returns
+        return n
 
 
 def build(tmp=None, factory=None):

--- a/tests/test_courier_link.py
+++ b/tests/test_courier_link.py
@@ -11,6 +11,7 @@ import os
 import tempfile
 import unittest
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -52,6 +53,10 @@ def _seed_recipient(placed_under_existing=True):
 
 class CourierLinkRepair(unittest.TestCase):
     def setUp(self):
+        # the kernel's judge is one module object shared by every test module in the process, so a store saved at its import-bound GOALDIR outlives the module and reaches every later module's feed for the placeholder sid (T281/T282); a private root for the duration.
+        self._td = tempfile.TemporaryDirectory()
+        self._state = jd.STATE
+        jd._rebind_state(Path(self._td.name))
         self._saved = jd.discover
         jd.discover = lambda now, window=None, forks=True: [
             (SENDER, "/dev/null", None, "web"), (RECIP, "/dev/null", None, "api")]
@@ -60,8 +65,21 @@ class CourierLinkRepair(unittest.TestCase):
 
     def tearDown(self):
         jd.discover = self._saved
-        for f in jd.GOALDIR.glob("*"):
-            f.unlink()
+        jd._rebind_state(self._state)
+        self._td.cleanup()
+
+    def test_the_store_this_module_saves_does_not_outlive_it(self):
+        # The residue pin (T281/T282): a store saved through the shared judge lands under this test's root and
+        # the run-wide root (what every later module's feed reads) is exactly as it was.
+        shared = Path(self._state) / "goals" / (SENDER + ".json")
+        before = (shared.exists(), shared.stat().st_mtime_ns if shared.exists() else None)
+        st = jd.load_goals(SENDER)
+        st["nodes"][SENDER + ":t282"] = jd.GuardedNode({"id": SENDER + ":t282", "text": "a note", "parentId": None, "nodeComplete": False,
+                                                        "blocked": False, "cleared": False, "trail": [], "t": 1, "mt": 1, "log": []})
+        jd.save_goals(SENDER, st)
+        self.assertTrue((Path(self._td.name) / "goals" / (SENDER + ".json")).exists(), "the store lives under this module's root")
+        self.assertEqual((shared.exists(), shared.stat().st_mtime_ns if shared.exists() else None), before,
+                         "the run-wide goals directory is untouched by this module")
 
     def test_link_attaches_to_the_placed_top_and_is_idempotent(self):
         st = jd.load_goals(RECIP)
@@ -133,6 +151,9 @@ class CourierLinkRepair(unittest.TestCase):
 
 class DormantHandoffConverts(unittest.TestCase):
     def setUp(self):
+        self._td = tempfile.TemporaryDirectory()      # a private root: see CourierLinkRepair.setUp
+        self._state = jd.STATE
+        jd._rebind_state(Path(self._td.name))
         _seed_sender()
         d = jd.STATE / "states"
         d.mkdir(parents=True, exist_ok=True)
@@ -153,11 +174,8 @@ class DormantHandoffConverts(unittest.TestCase):
     def tearDown(self):
         for nm in ("available", "alive_sids"):
             km._TMUX.__dict__.pop(nm, None)   # instance attrs shadow the class methods; drop them
-        for f in jd.GOALDIR.glob("*"):
-            f.unlink()
-        for f in (jd.STATE / "states").glob("*"):
-            f.unlink()
-        (jd.NAMES / SENDER).unlink(missing_ok=True)
+        jd._rebind_state(self._state)                # the private root goes with the tempdir
+        self._td.cleanup()
 
     def test_dormant_sender_handoff_blocks_with_the_dead_wait_why(self):
         km._dead_wait_sweep(set(), self.nudged, T + 900)

--- a/tests/test_goal_status_ux.py
+++ b/tests/test_goal_status_ux.py
@@ -19,6 +19,7 @@ import tempfile
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -129,6 +130,29 @@ class NodeLogRows(unittest.TestCase):
 
 
 class SubNodeDrop(unittest.TestCase):
+    def setUp(self):
+        # the kernel's judge is one module object shared by every test module in the process, so a store saved at its import-bound GOALDIR outlives the module and reaches every later module's feed for the placeholder sid (T281/T282); a private root for the duration.
+        self._td = tempfile.TemporaryDirectory()
+        self._state = jd.STATE
+        jd._rebind_state(Path(self._td.name))
+
+    def tearDown(self):
+        jd._rebind_state(self._state)
+        self._td.cleanup()
+
+    def test_the_store_this_module_saves_does_not_outlive_it(self):
+        # The residue pin (T281/T282): a store saved through the shared judge lands under this test's root and
+        # the run-wide root (what every later module's feed reads) is exactly as it was.
+        shared = Path(self._state) / "goals" / (SID + ".json")
+        before = (shared.exists(), shared.stat().st_mtime_ns if shared.exists() else None)
+        st = jd.load_goals(SID)
+        st["nodes"][SID + ":t282"] = jd.GuardedNode({"id": SID + ":t282", "text": "a note", "parentId": None, "nodeComplete": False,
+                                                        "blocked": False, "cleared": False, "trail": [], "t": 1, "mt": 1, "log": []})
+        jd.save_goals(SID, st)
+        self.assertTrue((Path(self._td.name) / "goals" / (SID + ".json")).exists(), "the store lives under this module's root")
+        self.assertEqual((shared.exists(), shared.stat().st_mtime_ns if shared.exists() else None), before,
+                         "the run-wide goals directory is untouched by this module")
+
     """The item-level "Drop" (nodeOverride op:clear): the same user-authority clear seam as a card
     Clear, scoped to ONE sub — checks it off as no-longer-needed without claiming completion."""
 

--- a/tests/test_goal_status_ux.py
+++ b/tests/test_goal_status_ux.py
@@ -130,6 +130,9 @@ class NodeLogRows(unittest.TestCase):
 
 
 class SubNodeDrop(unittest.TestCase):
+    """The item-level "Drop" (nodeOverride op:clear): the same user-authority clear seam as a card
+    Clear, scoped to ONE sub — checks it off as no-longer-needed without claiming completion."""
+
     def setUp(self):
         # the kernel's judge is one module object shared by every test module in the process, so a store saved at its import-bound GOALDIR outlives the module and reaches every later module's feed for the placeholder sid (T281/T282); a private root for the duration.
         self._td = tempfile.TemporaryDirectory()
@@ -153,8 +156,6 @@ class SubNodeDrop(unittest.TestCase):
         self.assertEqual((shared.exists(), shared.stat().st_mtime_ns if shared.exists() else None), before,
                          "the run-wide goals directory is untouched by this module")
 
-    """The item-level "Drop" (nodeOverride op:clear): the same user-authority clear seam as a card
-    Clear, scoped to ONE sub — checks it off as no-longer-needed without claiming completion."""
 
     TOP = SID + ":g10"
     SUB = SID + ":g11"

--- a/tests/test_heartbeat_thread.py
+++ b/tests/test_heartbeat_thread.py
@@ -14,6 +14,8 @@ import unittest
 from importlib.machinery import SourceFileLoader
 import tempfile
 
+from tests.conftest import thread_census, wait_for_census
+
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
@@ -26,15 +28,39 @@ km = SourceFileLoader("romp_kernel_hb", os.path.join(BIN, "romp-kernel")).load_m
 
 class WsHeartbeat(unittest.TestCase):
     def setUp(self):
+        self.census0 = thread_census()
         self.saved_ka = km.KEEPALIVE_S
+        self.saved_push_all = km._push_all
+        self.threads = []                              # every loop this test starts; tearDown ends them
+        self.wedge = None
         with km._clients_lock:
             self.saved_clients = list(km._clients)
             km._clients[:] = []
 
     def tearDown(self):
+        # End what this test started (T282): the stop seam ends every loop at its next turn of the wheel; the
+        # wedge is released only AFTER the stop is set, so the pusher's one in-flight cycle returns and the
+        # loop exits without another cycle against this module's kernel. The census then must read as it did
+        # before the test: a loop that outlived its module would run against whatever the shared judge module
+        # is bound to by then.
+        km._LOOPS_STOP.set()
+        if self.wedge is not None:
+            self.wedge.set()
+        km._push_all = self.saved_push_all
+        km._pusher_wake.set()
+        for t in self.threads:
+            t.join(5)
+        km._LOOPS_STOP.clear()
         km.KEEPALIVE_S = self.saved_ka
         with km._clients_lock:
             km._clients[:] = self.saved_clients
+        self.assertEqual(wait_for_census(self.census0), [], "no thread of this test outlives it")
+
+    def _start(self, target):
+        t = threading.Thread(target=target, daemon=True)
+        self.threads.append(t)
+        t.start()
+        return t
 
     def _fake_client(self):
         frames = []
@@ -48,7 +74,7 @@ class WsHeartbeat(unittest.TestCase):
         # proof the beat no longer depends on pusher loop iterations.
         frames = self._fake_client()
         km.KEEPALIVE_S = 0.05
-        threading.Thread(target=km._heartbeat, daemon=True).start()
+        self._start(km._heartbeat)
         deadline = time.time() + 3.0
         while time.time() < deadline and len(frames) < 3:
             time.sleep(0.02)
@@ -58,14 +84,14 @@ class WsHeartbeat(unittest.TestCase):
     def test_beat_survives_a_wedged_push(self):
         # The failure mode behind the false banner, end to end: the REAL _pusher loop enters a push
         # that never finishes (stand-in for a heavy fleet build under GIL contention). The beat must
-        # keep flowing anyway. _push_all stays wedged for the process lifetime on purpose — restoring
-        # it would let the leaked daemon pusher run real tick jobs against live tmux mid-test-run.
+        # keep flowing anyway. The push stays wedged for the TEST's lifetime; tearDown sets the stop seam
+        # first and releases the wedge second, so the pusher returns from its one cycle and ends (T282).
         frames = self._fake_client()
         km.KEEPALIVE_S = 0.05
-        wedge = threading.Event()                       # never set → the push never returns
-        km._push_all = lambda *a, **k: wedge.wait()   # accepts the cycle's snapshot kwarg
-        threading.Thread(target=km._pusher, daemon=True).start()
-        threading.Thread(target=km._heartbeat, daemon=True).start()
+        self.wedge = threading.Event()                  # not set while the test runs → the push never returns
+        km._push_all = lambda *a, **k: self.wedge.wait()   # accepts the cycle's snapshot kwarg
+        self._start(km._pusher)
+        self._start(km._heartbeat)
         deadline = time.time() + 3.0
         while time.time() < deadline and len(frames) < 3:
             time.sleep(0.02)
@@ -86,8 +112,24 @@ class WsHeartbeat(unittest.TestCase):
         frames = self._fake_client()   # healthy client AFTER the bad one → send order hits bad first
         km._keepalive_all()
         self.assertFalse(bad["alive"], "a failing send must flag the client dead")
-        # >= 1, not == 1: leaked heartbeat threads from earlier tests may land a stray (identical) beat
-        self.assertGreaterEqual(len(frames), 1, "a bad client must not block the beat to healthy ones")
+        # exactly one: no heartbeat thread from an earlier test is alive to land a stray beat (T282)
+        self.assertEqual(len(frames), 1, "a bad client must not block the beat to healthy ones")
+
+    def test_the_stop_seam_ends_a_running_pusher_and_heartbeat(self):
+        # The seam this module's hygiene rests on (T282): a real _pusher and a real _heartbeat end within a
+        # bounded join once _LOOPS_STOP is set and the pusher is woken, and the census is back to before.
+        km.KEEPALIVE_S = 0.05
+        pusher, beat = self._start(km._pusher), self._start(km._heartbeat)
+        deadline = time.time() + 3.0
+        while time.time() < deadline and not (pusher.is_alive() and beat.is_alive()):
+            time.sleep(0.01)
+        self.assertTrue(pusher.is_alive() and beat.is_alive(), "both loops are running")
+        km._LOOPS_STOP.set()
+        km._pusher_wake.set()
+        pusher.join(5); beat.join(5)
+        km._LOOPS_STOP.clear()
+        self.assertFalse(pusher.is_alive() or beat.is_alive(), "both loops ended on the stop seam")
+        self.assertEqual(wait_for_census(self.census0), [])
 
     @staticmethod
     def _boom(_s):

--- a/tests/test_heartbeat_thread.py
+++ b/tests/test_heartbeat_thread.py
@@ -31,6 +31,13 @@ class WsHeartbeat(unittest.TestCase):
         self.census0 = thread_census()
         self.saved_ka = km.KEEPALIVE_S
         self.saved_push_all = km._push_all
+        # A real _pusher cycle runs the tick jobs before its push; on a module-fresh kernel the usage poll fires on
+        # the FIRST cycle and builds a real SdkBackend (re-executing sdk_backend.py into the shared module and
+        # touching the shared judge's latches). These tests are about the beat, so the cycle's jobs and the
+        # backend are stubbed for the class; each test still chooses its own _push_all.
+        self.saved_jobs = (km._pusher_cycle_jobs, km._sdk)
+        km._pusher_cycle_jobs = lambda *a, **k: None
+        km._sdk = lambda: None
         self.threads = []                              # every loop this test starts; tearDown ends them
         self.wedge = None
         with km._clients_lock:
@@ -50,7 +57,11 @@ class WsHeartbeat(unittest.TestCase):
         km._pusher_wake.set()
         for t in self.threads:
             t.join(5)
-        km._LOOPS_STOP.clear()
+        if not any(t.is_alive() for t in self.threads):
+            km._LOOPS_STOP.clear()                     # every loop ended: the seam is free for the next test
+        # (a loop still alive keeps the stop set, so it exits at its next check instead of running on; the
+        #  census assertion below then reports it)
+        km._pusher_cycle_jobs, km._sdk = self.saved_jobs
         km.KEEPALIVE_S = self.saved_ka
         with km._clients_lock:
             km._clients[:] = self.saved_clients
@@ -127,8 +138,8 @@ class WsHeartbeat(unittest.TestCase):
         km._LOOPS_STOP.set()
         km._pusher_wake.set()
         pusher.join(5); beat.join(5)
-        km._LOOPS_STOP.clear()
         self.assertFalse(pusher.is_alive() or beat.is_alive(), "both loops ended on the stop seam")
+        km._LOOPS_STOP.clear()
         self.assertEqual(wait_for_census(self.census0), [])
 
     @staticmethod

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -7894,8 +7894,9 @@ class FailureContract(unittest.TestCase):
     event (the turn gaining atoms / the top set changing)."""
 
     def setUp(self):
+        self._saved_state = jd.STATE
         self._td = tempfile.mkdtemp()
-        jd._rebind_state(Path(self._td))
+        jd._rebind_state(Path(self._td))   # GOALDIR and every derived dir move too (T282)
         # the model-health latch is process-global, keyed by model: the failing calls below push "model-x"
         # and "gpt-5-test" past the degraded cap, so snapshot it here and restore it after — a later test
         # must not inherit a degraded model (review nit, 2026-09-03)
@@ -7904,6 +7905,7 @@ class FailureContract(unittest.TestCase):
                             {m: dict(st) for m, st in jd._CALL_HEALTH["stats"].items()})
 
     def tearDown(self):
+        jd._rebind_state(self._saved_state)   # the shared judge goes back to the run-wide root (T282)
         shutil.rmtree(self._td, ignore_errors=True)
         with jd._health_lock:
             jd._CALL_HEALTH["degraded"].clear()

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -7194,6 +7194,7 @@ class LivePickerBrief(unittest.TestCase):
 
     def tearDown(self):
         (jd.GOALDIR, jd.STATESDIR, jd.STATE, jd.brief_llm, jd.distill_llm) = self._saved
+        jd._rebind_state(jd.STATE)   # the tuple restores STATE; every derived dir follows it (T282)
         shutil.rmtree(self._td, ignore_errors=True)
 
     _RECORDS = [uline(T0, "wire the picker", "u1", ps="typed"),
@@ -7603,6 +7604,7 @@ class LiveReplan(unittest.TestCase):
     def tearDown(self):
         (jd.GOALDIR, jd.GOALARCHDIR, jd.PCACHE, jd.STATE,
          jd.plan_llm, jd.opener_llm, jd._group_store) = self.saved
+        jd._rebind_state(jd.STATE)   # the tuple restores STATE; every derived dir follows it (T282)
         self.td.cleanup()
 
     @staticmethod

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -1310,6 +1310,7 @@ class ClearedSeal(unittest.TestCase):
 
     def tearDown(self):
         jd._rebind_state(self._saved_state)
+        shutil.rmtree(self._td, ignore_errors=True)
 
     def test_the_stores_this_class_saves_do_not_outlive_it(self):
         # The residue pin (T282): a store saved through this module's judge (the object every kernel shares) lands
@@ -1323,7 +1324,6 @@ class ClearedSeal(unittest.TestCase):
         self.assertTrue((Path(self._td) / "goals" / (SID + ".json")).exists(), "the store lives under the sandbox root")
         self.assertEqual((shared.exists(), shared.stat().st_mtime_ns if shared.exists() else None), before,
                          "the run-wide goals directory is untouched by this class")
-        shutil.rmtree(self._td, ignore_errors=True)
 
     def _view_clear(self, *ids):
         with (jd.STATE / "cleared.jsonl").open("a") as f:
@@ -5004,6 +5004,7 @@ class DistillAtDone(unittest.TestCase):
 
     def tearDown(self):
         jd.STATE, jd.STATESDIR, jd.distill_llm = self._saved
+        jd._rebind_state(jd.STATE)   # the tuple restores STATE; every derived dir follows it (T282)
         shutil.rmtree(self._td, ignore_errors=True)
 
     def _write(self, status="working", confirming=True, log=None, **nd_extra):
@@ -7592,6 +7593,7 @@ class LiveReplan(unittest.TestCase):
         self.saved = (jd.GOALDIR, jd.GOALARCHDIR, jd.PCACHE, jd.STATE,
                       jd.plan_llm, jd.opener_llm, jd._group_store)
         jd.GOALDIR, jd.GOALARCHDIR = td / "goals", td / "goals-archive"
+        jd._rebind_state(Path(td))   # every derived dir moves too; the explicit ones below still win (T282)
         jd.PCACHE, jd.STATE = td / "pcache", td
         jd.GOALDIR.mkdir()
         jd._group_store = lambda *a, **k: None           # never fire the real grouper model
@@ -8405,6 +8407,7 @@ class OrphanedHistory(unittest.TestCase):
 
     def tearDown(self):
         jd.STATE, jd.ERRORS = self._saved_state, self._saved_errors
+        jd._rebind_state(jd.STATE)   # the tuple restores STATE; every derived dir follows it (T282)
         jd.distill_llm = self._saved_distill
         shutil.rmtree(self._td, ignore_errors=True)
 

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -1306,10 +1306,23 @@ class ClearedSeal(unittest.TestCase):
     def setUp(self):
         self._saved_state = jd.STATE
         self._td = tempfile.mkdtemp()
-        jd.STATE = Path(self._td)
+        jd._rebind_state(Path(self._td))
 
     def tearDown(self):
-        jd.STATE = self._saved_state
+        jd._rebind_state(self._saved_state)
+
+    def test_the_stores_this_class_saves_do_not_outlive_it(self):
+        # The residue pin (T282): a store saved through this module's judge (the object every kernel shares) lands
+        # under the sandbox root, and the run-wide root is exactly as it was.
+        shared = Path(self._saved_state) / "goals" / (SID + ".json")
+        before = (shared.exists(), shared.stat().st_mtime_ns if shared.exists() else None)
+        st = jd.load_goals(SID)
+        st["nodes"][SID + ":t282"] = jd.GuardedNode({"id": SID + ":t282", "text": "a note", "parentId": None, "nodeComplete": False,
+                                                    "blocked": False, "cleared": False, "trail": [], "t": 1, "mt": 1, "log": []})
+        jd.save_goals(SID, st)
+        self.assertTrue((Path(self._td) / "goals" / (SID + ".json")).exists(), "the store lives under the sandbox root")
+        self.assertEqual((shared.exists(), shared.stat().st_mtime_ns if shared.exists() else None), before,
+                         "the run-wide goals directory is untouched by this class")
         shutil.rmtree(self._td, ignore_errors=True)
 
     def _view_clear(self, *ids):
@@ -1438,7 +1451,7 @@ class Grouper(unittest.TestCase):
         # empty dir so every grouper test is hermetic (no real cleared.jsonl bleeds in).
         self._saved_state = jd.STATE
         self._state_td = tempfile.mkdtemp()
-        jd.STATE = Path(self._state_td)
+        jd._rebind_state(Path(self._state_td))
 
     def _two_tops(self):
         s = _store()
@@ -1589,10 +1602,10 @@ class Grouper(unittest.TestCase):
         return str(pdir / (SID + ".jsonl"))
 
     def tearDown(self):
-        jd.STATE = self._saved_state
-        shutil.rmtree(self._state_td, ignore_errors=True)
         if hasattr(self, "_saved"):
-            (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.group_llm) = self._saved
+            (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.group_llm) = self._saved   # _setup's own dirs, off first
+        jd._rebind_state(self._saved_state)   # ...then the import-time root and every derived dir
+        shutil.rmtree(self._state_td, ignore_errors=True)
 
     def test_view_cleared_top_is_excluded_from_grouping(self):
         # The reappearance bug (the user 2026-06-18): the user CLEARS a top from the feed (a row in
@@ -1713,13 +1726,13 @@ class Consolidator(unittest.TestCase):
     def setUp(self):
         self._saved_state = jd.STATE
         self._state_td = tempfile.mkdtemp()
-        jd.STATE = Path(self._state_td)
+        jd._rebind_state(Path(self._state_td))
 
     def tearDown(self):
-        jd.STATE = self._saved_state
-        shutil.rmtree(self._state_td, ignore_errors=True)
         if hasattr(self, "_saved"):
-            (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.group_llm) = self._saved
+            (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.group_llm) = self._saved   # _setup's own dirs, off first
+        jd._rebind_state(self._saved_state)   # ...then the import-time root and every derived dir
+        shutil.rmtree(self._state_td, ignore_errors=True)
 
     def _completed_store(self, specs):
         # specs: [(gid_suffix, text, [trail segs])] → a store of completed top goals (rolled up to "completed")
@@ -4295,11 +4308,11 @@ class ModelTiers(unittest.TestCase):
         # read nor deleted). The tier split must hold on the DEFAULT aliases.
         self._saved_state = jd.STATE
         self._td = tempfile.mkdtemp()
-        jd.STATE = Path(self._td)
+        jd._rebind_state(Path(self._td))
         jd._state_cache.clear()
 
     def tearDown(self):
-        jd.STATE = self._saved_state
+        jd._rebind_state(self._saved_state)
         jd._state_cache.clear()
         shutil.rmtree(self._td, ignore_errors=True)
 
@@ -4776,10 +4789,10 @@ class DeltaScopedDistill(unittest.TestCase):
         self._saved_state = jd.STATE
         self._saved_distill = jd.distill_llm
         self._td = tempfile.mkdtemp()
-        jd.STATE = Path(self._td)
+        jd._rebind_state(Path(self._td))
 
     def tearDown(self):
-        jd.STATE = self._saved_state
+        jd._rebind_state(self._saved_state)
         jd.distill_llm = self._saved_distill
         shutil.rmtree(self._td, ignore_errors=True)
 
@@ -4986,7 +4999,7 @@ class DistillAtDone(unittest.TestCase):
     def setUp(self):
         self._saved = (jd.STATE, jd.STATESDIR, jd.distill_llm)
         self._td = tempfile.mkdtemp()
-        jd.STATE = Path(self._td)
+        jd._rebind_state(Path(self._td))
         jd.STATESDIR = Path(self._td) / "states"
 
     def tearDown(self):
@@ -5168,10 +5181,10 @@ class ProceduralBlockStillSpeaks(unittest.TestCase):
         self._saved_stall = jd.stall_llm
         self._saved_brief = jd.brief_llm
         self._td = tempfile.mkdtemp()
-        jd.STATE = Path(self._td)
+        jd._rebind_state(Path(self._td))
 
     def tearDown(self):
-        jd.STATE = self._saved_state
+        jd._rebind_state(self._saved_state)
         jd.stall_llm = self._saved_stall
         jd.brief_llm = self._saved_brief
         shutil.rmtree(self._td, ignore_errors=True)
@@ -7107,10 +7120,10 @@ class OrphanRollup(unittest.TestCase):
     def setUp(self):
         self._saved_state = jd.STATE
         self._td = tempfile.mkdtemp()
-        jd.STATE = Path(self._td)                        # hermetic: _reopen's _view_cleared reads STATE
+        jd._rebind_state(Path(self._td))                        # hermetic: _reopen's _view_cleared reads STATE
 
     def tearDown(self):
-        jd.STATE = self._saved_state
+        jd._rebind_state(self._saved_state)
         shutil.rmtree(self._td, ignore_errors=True)
 
     def test_completed_top_rolls_its_open_children_done(self):
@@ -7174,7 +7187,7 @@ class LivePickerBrief(unittest.TestCase):
         self._saved = (jd.GOALDIR, jd.STATESDIR, jd.STATE, jd.brief_llm, jd.distill_llm)
         self._td = Path(tempfile.mkdtemp())
         jd.GOALDIR = self._td / "goals"
-        jd.STATE = self._td
+        jd._rebind_state(Path(self._td))
         jd.STATESDIR = self._td / "states"
         jd.STATESDIR.mkdir(parents=True, exist_ok=True)
 
@@ -8387,7 +8400,7 @@ class OrphanedHistory(unittest.TestCase):
         self._saved_state, self._saved_errors = jd.STATE, jd.ERRORS
         self._saved_distill = jd.distill_llm
         self._td = tempfile.mkdtemp()
-        jd.STATE = Path(self._td)
+        jd._rebind_state(Path(self._td))
         jd.ERRORS = jd.STATE / "judge-errors.jsonl"   # module-level twin of STATE — captured at import
 
     def tearDown(self):

--- a/tests/test_kernel_deliver.py
+++ b/tests/test_kernel_deliver.py
@@ -137,10 +137,14 @@ class Chrome(unittest.TestCase):
         km._identity_of = lambda sid: ("#abc", "#fff")
 
     def tearDown(self):
+        # The expiry thread reads BADGE_TTL and the stubbed show_var on ITS first instructions; wait for it to end
+        # while both are still in place (restoring first would let a late-scheduled thread read the 300 s constant
+        # and the real tmux client), then put the class back as it was.
+        left = wait_for_census(self._census0)
         (self.T.set_var, self.T.fire, self.T.display, self.T.show_var, self.T.refresh_client,
          km._name_of, km._identity_of) = self.saved
         self.T.__dict__.pop("BADGE_TTL", None)                  # back to the class constant
-        self.assertEqual(wait_for_census(self._census0), [], "no badge-expiry thread outlives the test (T282)")
+        self.assertEqual(left, [], "no badge-expiry thread outlives the test (T282)")
 
     def test_mail_badge_paints_the_recipient(self):
         km._name_of = lambda sid: "recip" if sid == "r" else None

--- a/tests/test_kernel_deliver.py
+++ b/tests/test_kernel_deliver.py
@@ -10,6 +10,8 @@ import tempfile
 import unittest
 from importlib.machinery import SourceFileLoader
 
+from tests.conftest import thread_census, wait_for_census
+
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
@@ -118,7 +120,12 @@ class Chrome(unittest.TestCase):
     no-op for a session with no tmux name (an SDK session skips)."""
 
     def setUp(self):
+        self._census0 = thread_census()
         self.T = km._TMUX
+        # A painted badge starts an expiry thread that sleeps BADGE_TTL (300 s) before it looks again; under the
+        # full suite that thread outlived this module by minutes (T282). Zero TTL here: the thread wakes at once,
+        # reads the stubbed token ("" ≠ the badge's) and ends without clearing anything.
+        self.T.BADGE_TTL = 0
         self.saved = (self.T.set_var, self.T.fire, self.T.display, self.T.show_var, self.T.refresh_client,
                       km._name_of, km._identity_of)
         self.sets, self.fires = [], []
@@ -132,6 +139,8 @@ class Chrome(unittest.TestCase):
     def tearDown(self):
         (self.T.set_var, self.T.fire, self.T.display, self.T.show_var, self.T.refresh_client,
          km._name_of, km._identity_of) = self.saved
+        self.T.__dict__.pop("BADGE_TTL", None)                  # back to the class constant
+        self.assertEqual(wait_for_census(self._census0), [], "no badge-expiry thread outlives the test (T282)")
 
     def test_mail_badge_paints_the_recipient(self):
         km._name_of = lambda sid: "recip" if sid == "r" else None

--- a/tests/test_kernel_parked_ops_liveness.py
+++ b/tests/test_kernel_parked_ops_liveness.py
@@ -25,6 +25,8 @@ from datetime import datetime, timezone
 from unittest import mock
 from importlib.machinery import SourceFileLoader
 
+from tests.conftest import thread_census, wait_for_census
+
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
@@ -87,6 +89,7 @@ def _tmux_row(state):
 
 class DeliveryRidesTheSettle(unittest.TestCase):
     def setUp(self):
+        self._census0 = thread_census()
         self.be = _FakeBackend()
         self._patches = [
             mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: self.be)),
@@ -112,6 +115,8 @@ class DeliveryRidesTheSettle(unittest.TestCase):
         km._moving.clear()
         km._drain_hold.clear()
         km._refresh_parse_failures.clear()
+        km._LOOPS_STOP.clear()
+        self.assertEqual(wait_for_census(self._census0), [], "no thread of this test outlives it (T282)")
 
     def test_parked_op_delivers_on_settle_while_a_judge_pass_is_stuck(self):
         gate = threading.Event()             # the judge tiers block here: a closer sweep that never returns
@@ -122,9 +127,9 @@ class DeliveryRidesTheSettle(unittest.TestCase):
             ran_on.append(threading.current_thread().name)
             return real_apply()
 
-        # The stuck pass stays stuck: a real _producer has no exit, and ending its thread by exception
-        # trips pytest's thread-exception hook — so the gate is never set and the three daemon threads
-        # (producer + two tiers) stay parked, touching nothing, until the process ends.
+        # The pass stays stuck for the whole test; at its end the stop seam is set FIRST and the gate released
+        # SECOND, so the tiers return, the pass completes under these same stubs, and the producer ends at its
+        # next turn of the wheel instead of outliving the module (T282).
         with mock.patch.object(km, "_run_tier", lambda fn: gate.wait()), \
              mock.patch.object(km, "_retry_paused_on", lambda: False), \
              mock.patch.object(km, "_episode_boundary_tick", lambda now: None), \
@@ -163,6 +168,11 @@ class DeliveryRidesTheSettle(unittest.TestCase):
             self.assertNotIn(SID, km._pending_ops)
             self.assertEqual(ran_on, [threading.current_thread().name],
                              "the drain ran on this cycle and never on the producer")
+            km._LOOPS_STOP.set()                     # the loop ends at its next turn of the wheel...
+            gate.set()                               # ...which comes once the stuck tiers return and the pass completes
+            km._producer_wake.set()
+            producer.join(5)
+            self.assertFalse(producer.is_alive(), "the producer ended on the stop seam once its pass finished")
 
     def test_two_parks_drain_one_per_settle_in_park_order(self):
         self.assertTrue(km._send_or_park(self.be, SID, "one", echo="human"))   # tmux-shaped: a send parks mid-turn

--- a/tests/test_kernel_remote_ws_proxy.py
+++ b/tests/test_kernel_remote_ws_proxy.py
@@ -93,8 +93,16 @@ class _FakeRemoteKernel:
             self.done.set()
 
     def close(self):
-        # End the serve thread (T282): a listening socket closed from another thread does not wake accept()
-        # on Linux; shutdown() does. Then wait for the thread's exit, bounded.
+        # End the serve thread (T282). A fake nobody dialed is parked in accept(): closing the listening socket
+        # from another thread does not wake it (on Linux shutdown() does, on macOS/BSD neither does), so a
+        # throwaway dial that ends at once wakes it portably: accept() returns, recv() sees the EOF, the thread
+        # ends. Then shut down and close the listener and wait for the thread's exit, bounded.
+        if not self.done.is_set():
+            try:
+                with socket.create_connection(("127.0.0.1", self.port), timeout=1):
+                    pass
+            except OSError:
+                pass
         for op in (lambda: self.srv.shutdown(socket.SHUT_RDWR), self.srv.close):
             try:
                 op()

--- a/tests/test_kernel_remote_ws_proxy.py
+++ b/tests/test_kernel_remote_ws_proxy.py
@@ -21,6 +21,8 @@ import threading
 import unittest
 from http.server import ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
+
+from tests.conftest import thread_census, wait_for_census
 import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -91,14 +93,21 @@ class _FakeRemoteKernel:
             self.done.set()
 
     def close(self):
-        try:
-            self.srv.close()
-        except OSError:
-            pass
+        # End the serve thread (T282): a listening socket closed from another thread does not wake accept()
+        # on Linux; shutdown() does. Then wait for the thread's exit, bounded.
+        for op in (lambda: self.srv.shutdown(socket.SHUT_RDWR), self.srv.close):
+            try:
+                op()
+            except OSError:
+                pass
+        self.done.wait(5)
 
 
 class RemoteWsProxy(unittest.TestCase):
     def setUp(self):
+        self._census0 = thread_census()
+        self.addCleanup(lambda: self.assertEqual(wait_for_census(self._census0), [],
+                                                 "no thread of this test outlives it (T282)"))   # runs LAST
         self.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
         self.port = self.srv.server_address[1]
         threading.Thread(target=self.srv.serve_forever, daemon=True).start()
@@ -141,6 +150,7 @@ class RemoteWsProxy(unittest.TestCase):
 
     def test_splices_both_directions_and_rewrites_the_token(self):
         fake = _FakeRemoteKernel()
+        self.addCleanup(fake.close)
         self._register("gpu1", fake.port)
         try:
             s, status, head, tail, key = self._upgrade("/remote/gpu1/ws?app=chat&token=whatever-the-browser-sent")
@@ -178,6 +188,7 @@ class RemoteWsProxy(unittest.TestCase):
         """Dial the relay for `host` with `browser_path` and return the query the FAR side received, parsed."""
         from urllib.parse import parse_qs, urlsplit
         fake = _FakeRemoteKernel()
+        self.addCleanup(fake.close)
         try:
             self._register(host, fake.port, token=km._remotes[host]["token"] if host in km._remotes else REMOTE_TOKEN)
             s, status, _, _, _ = self._upgrade(browser_path)
@@ -214,6 +225,7 @@ class RemoteWsProxy(unittest.TestCase):
 
     def test_unauthorized_403s_before_any_dial(self):
         fake = _FakeRemoteKernel()
+        self.addCleanup(fake.close)
         self._register("gpu1", fake.port)
         try:
             s, status, _, _, _ = self._upgrade("/remote/gpu1/ws", token=False)
@@ -236,6 +248,7 @@ class RemoteWsProxy(unittest.TestCase):
 
     def test_non_websocket_request_400s(self):
         fake = _FakeRemoteKernel()
+        self.addCleanup(fake.close)
         self._register("gpu1", fake.port)
         try:
             s, status, _, _, _ = self._upgrade("/remote/gpu1/ws", ws_headers=False)


### PR DESCRIPTION
Follow-up to the dedup-flake fix: the thread census behind it found daemon threads that outlive their test module, and four more modules that wrote the placeholder sid's goal store at the run-wide judge root.

**Threads.** Each module now ends what it starts and pins that the thread census at its end equals the census at its start, via two small helpers in `tests/conftest.py` (`thread_census`, `wait_for_census`) that the module-boundary tracer reads too. The pin is "nothing this module started outlives it" (threads beyond the start census must be none), so an earlier module's straggler ending mid-module cannot fail it.
- One kernel seam, `_LOOPS_STOP`, honoured by `_producer`, `_pusher` and `_heartbeat`: the three loops had no exit at all, so a test that started a real one could not end it. The heartbeat's sleep becomes a stop-aware wait. Never set in production.
- `test_heartbeat_thread.py`: stop first, release the wedge second, join; a new test pins the seam. `test_kernel_parked_ops_liveness.py`: the stuck producer ends the same way inside the test's stubs. `test_kernel_remote_ws_proxy.py`: the fake remote kernel shuts its listening socket down (close alone does not wake `accept()` on Linux) and waits for its thread. `test_codex_backend.py`: every fake client and backend is recorded and ended at module end (close wakes the pump; dead sessions end their workers); 64 parked threads before. `test_kernel_deliver.py`: the mail-badge expiry thread (a 300 s sleep) runs with a zero TTL in the chrome tests, so it ends at once.

**Shared root left deleted.** `test_clear_chat_view.py` rebound the shared judge to a tmp it then removed and never restored; `test_client_diag_rotation.py` read its files under that deleted root and passed only because another module's writes used to recreate it. The first now restores the root, the second runs under its own.

**Placeholder sid.** `test_clear_wrap.py`, `test_courier_link.py`, `test_goal_status_ux.py` and `test_judge.py` keep their state under a private root via `jd._rebind_state`, each with the residue pin from the previous PR.

Verification: a CI-order run of the preceding modules with a census+residue tracer shows no thread leak and no placeholder-sid file at the run-wide root reaching the dedup test; counts in the task report.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
