### PR TITLE
T276d: the real-process reaper test waits for the loop itself, before and after the cut

### DIFF
--- a/tests/test_cut_turn_tree_kill.py
+++ b/tests/test_cut_turn_tree_kill.py
@@ -258,16 +258,25 @@ class RealProcessTree(unittest.TestCase):
         # a bystander outside the tree
         by = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         self.addCleanup(by.wait, timeout=10); self.addCleanup(by.kill)
+        # Wait for the LOOP itself, not for any process wearing the marker: the fake CLI's own argv carries it too,
+        # so a poll on _marker_pids alone was satisfied the instant the shell existed, before its setsid'd child
+        # had started; on a slow runner the descendant check below then found no loop (T276d, CI 3.13 once).
         deadline = time.time() + 5
-        while time.time() < deadline and not self._marker_pids(marker):
+        while time.time() < deadline and not self._loop_pids(marker, cli.pid):
             time.sleep(0.05)
-        self.assertTrue(self._marker_pids(marker), "the detached loop is running before the cut")
+        self.assertTrue(self._loop_pids(marker, cli.pid), "the detached loop itself is running before the cut")
         return cli, by, marker
 
     @staticmethod
     def _marker_pids(marker):
         out = subprocess.run(["pgrep", "-f", marker], capture_output=True, text=True).stdout.split()
         return [int(x) for x in out if x.isdigit() and int(x) != os.getpid()]
+
+    def _loop_pids(self, marker, cli_pid):
+        """The setsid'd loop's pid(s): every process wearing the marker except the fake CLI shell (whose argv carries
+        it too). pgrep reads /proc/<pid>/cmdline, which a killed-but-unreaped process no longer has, so a pid listed
+        here is a live loop, never a zombie."""
+        return [p for p in self._marker_pids(marker) if p != cli_pid]
 
     def _kill_marker(self, marker):
         for p in self._marker_pids(marker):
@@ -278,14 +287,17 @@ class RealProcessTree(unittest.TestCase):
         cli, by, marker = self._tree()
         be = _backend()
         ps = subprocess.run(sb.PS_ARGV, capture_output=True, text=True, timeout=10).stdout.splitlines()
-        loop_pids = [p for p in self._marker_pids(marker) if p != cli.pid]   # the fake CLI's own argv carries the marker too
+        loop_pids = self._loop_pids(marker, cli.pid)
         self.assertTrue(loop_pids and all(p in sb.descendants(ps, cli.pid) for p in loop_pids),
                         "the setsid'd loop is still the CLI's descendant by ppid: %r vs %r" % (loop_pids, sb.descendants(ps, cli.pid)))
         out = be._end_cli_tree(cli.pid, ps, cgroup=lambda p: "")
+        # Bounded poll for the loop to be GONE (the reaper's own poll shape: liveness, up to a few seconds): the
+        # SIGKILL has been sent when _end_cli_tree returns, but a slow runner may not have taken the process off
+        # the table yet. The bystander check stays immediate and strict.
         deadline = time.time() + 5
-        while time.time() < deadline and (self._marker_pids(marker) or cli.poll() is None):
+        while time.time() < deadline and (self._loop_pids(marker, cli.pid) or cli.poll() is None):
             time.sleep(0.05)
-        self.assertEqual(self._marker_pids(marker), [], "the detached loop died with the cut turn")
+        self.assertEqual(self._loop_pids(marker, cli.pid), [], "the detached loop died with the cut turn")
         self.assertIsNotNone(cli.poll(), "the CLI is gone")
         self.assertIsNone(by.poll(), "the bystander outside the tree was never signaled")
         self.assertGreaterEqual(out["tree"], 1)


### PR DESCRIPTION
The readiness poll in the real-process reaper test was satisfied by any process wearing the marker, and the fake CLI shell's own argv carries it, so on a slow runner the test went on before the setsid'd loop had started and the descendant check found no loop (CI 3.13, once). Both the readiness poll and the gone-poll after the cut now key on the loop's own pid (the CLI excluded), bounded at 5 s as before; the bystander assertion stays immediate and strict; cleanups kill everything the test starts on any exit path.

Ran the module three times on 3.13 in its own transient scope: 12 passed each time, no leftover processes.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)