### PR TITLE
Codex backend: several queued sends land one text block each, and each retire takes back one echo per send

### DIFF
--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -705,19 +705,43 @@ class CodexBackend:
         with open(path, "a", encoding="utf-8") as f:
             for r in recs:
                 f.write(json.dumps(r, ensure_ascii=False) + "\n")
-        # a landed user record replaces its optimistic echo (uuid-independent: match by text)
-        landed = {self._rec_text(r) for r in recs if r.get("type") == "user"}
+        # A landed user record replaces its optimistic echoes (uuid-independent: match by text, under
+        # echo_text_key on both sides). ONE echo per landed text BLOCK, the OLDEST carrying the text. A
+        # block is one send: the worker starts a turn from its whole queue, one input per queued send, and
+        # the normalizer writes the app-server's one userMessage item as one record with a block per input
+        # (codex_events._user_input_texts), so a turn started from two queued sends lands both echoes here;
+        # a one-send record is one block. One per key, not every echo carrying it: a second identical
+        # STEER (delivered mid-turn, never queued) keeps its echo when the first one's record lands, and a
+        # second send dropped after that (the client dying mid-queue) stays visible. The kernel's
+        # prune_live is the other retire, floored by record time; this one sees only the records it just
+        # wrote.
+        landed = [t for r in recs if r.get("type") == "user" for t in self._rec_texts(r)]
         if landed:
             with s.lock:
-                s.echoes = [e for e in s.echoes if e["text"] not in landed]
+                kept = list(s.echoes)
+                for text in landed:
+                    for i, e in enumerate(kept):
+                        if echo_text_key(e.get("text")) == text:
+                            del kept[i]
+                            break
+                if len(kept) != len(s.echoes):
+                    s.echoes = kept
 
     @staticmethod
-    def _rec_text(rec):
+    def _rec_texts(rec):
+        """A user record's texts under the shared key rule (echo_text_key: outer whitespace stripped,
+        nothing else), the key send() stores on the echo and _append and prune_live compare: one entry per
+        text BLOCK (a string content is one entry), empty ones dropped. Per block and never the blocks
+        joined: each block of a Codex user record is one send (see _append), and this retire takes exactly
+        one echo per send. The kernel's prune_live also matches the record's space-joined text
+        (_atom_user_texts yields the joined text and each block), floored by record time; that match is
+        not repeated here."""
         c = (rec.get("message") or {}).get("content")
         if isinstance(c, list):
-            return " ".join(b.get("text", "") for b in c
-                            if isinstance(b, dict) and b.get("type") == "text").strip()
-        return (c or "").strip() if isinstance(c, str) else ""
+            keys = [echo_text_key(b.get("text")) for b in c if isinstance(b, dict) and b.get("type") == "text"]
+        else:
+            keys = [echo_text_key(c)]
+        return [k for k in keys if k]
 
     # ── liveness / identity ──────────────────────────────────────────────────────────────────────
     def end_marker(self, sid):
@@ -780,10 +804,10 @@ class CodexBackend:
             # WHOLE seconds, as the SDK and tmux echoes stamp theirs: record times are parse_z's int
             # seconds and prune_live lands an echo by text only through a record at or after its send,
             # so a float stamp would keep an echo whose record was written later in the same second. The
-            # text is stored under the shared key rule (echo_text_key), the key prune_live compares
-            # against; for a str that is the stripped text _append matches.
-            s.echoes.append({"text": echo_text_key(text), "t": int(time.time()),
-                             "uuid": "echo-%s" % uuidlib.uuid4().hex[:8]})
+            # text is stored under the shared key rule (echo_text_key), the key prune_live and _append
+            # compare against. The uuid is kept: it names THIS send's echo on the dead path below.
+            echo_uuid = "echo-%s" % uuidlib.uuid4().hex[:8]
+            s.echoes.append({"text": echo_text_key(text), "t": int(time.time()), "uuid": echo_uuid})
             turn_id = s.turn_id
             tid = s.tid
         if c is not None and turn_id:
@@ -796,7 +820,11 @@ class CodexBackend:
                 pass
         with s.lock:
             if s.dead:
-                s.echoes = [e for e in s.echoes if e["text"] != text.strip()]
+                # The session died during the steer RPC: take back THIS send's echo, by the uuid minted
+                # above, and no other. Retiring by text would take an earlier same-text send the
+                # app-server never recorded with it. prune_live's rule applies here too: a send the
+                # app-server never records stays visible, and no other send's failure retires it.
+                s.echoes = [e for e in s.echoes if e["uuid"] != echo_uuid]
                 return False
             entry_id = "q-%s" % uuidlib.uuid4().hex
             s.queue.append(text)
@@ -1463,7 +1491,10 @@ class CodexBackend:
         compared under echo_text_key on BOTH sides. Record times are parse_z's whole seconds, so send()
         stamps the echo with int(time.time()) as the SDK and tmux echoes do: a float stamp would keep an
         echo whose record was written later in the same second. The backend's own _append retire is the
-        other exit; it sees only the records it just wrote.
+        other exit; it sees only the records it just wrote and takes one echo per landed text block, the
+        oldest carrying the text (a turn started from several queued sends lands as one record with a
+        block per send; _atom_user_texts yields each block, so this prune lands every echo of such a turn
+        too).
 
         `human_floor` (the newest genuine-human record's time) is accepted and retires nothing here. No
         floor retires a plain input echo on any backend: a send the app-server never records must stay

--- a/kernel/codex_events.py
+++ b/kernel/codex_events.py
@@ -49,9 +49,18 @@ def _iso(ms, clock):
     return dt.strftime("%Y-%m-%dT%H:%M:%S.") + ("%03dZ" % (ms % 1000))
 
 
-def _user_input_text(content):
-    """The prompt text of a userMessage item's UserInput list. Non-text inputs keep a readable
-    placeholder (the Claude CLI does the same for pasted images)."""
+def _user_input_texts(content):
+    """The prompt texts of a userMessage item's UserInput list, ONE ENTRY PER INPUT, each stripped of
+    outer whitespace, an empty one dropped. Non-text inputs keep a readable placeholder (the Claude CLI
+    does the same for pasted images), an entry of its own. Per input, never one joined text: the backend
+    starts a turn from its WHOLE queue, one input per queued send, and the app-server answers with one
+    userMessage item carrying them all. Joined, the record for two queued sends reads
+    "first send\nsecond send", which matches neither send's echo (the backend's _append and the kernel's
+    prune_live both key an echo by its text), so both echoes stay live for good and paint as user bubbles
+    beside the record in every later build. A user record with several text blocks is a shape the kernel
+    already reads per block (kernel._atom_user_texts, behind the echo prune and the pending-bubble pass;
+    sdk_backend._landed_texts): romp bundles its own injected messages as several blocks in one record.
+    So a block per input needs no kernel change."""
     parts = []
     for c in content or []:
         t = (c or {}).get("type")
@@ -61,7 +70,7 @@ def _user_input_text(content):
             parts.append("[Image: %s]" % (c.get("path") or c.get("url") or "pasted"))
         elif t in ("skill", "mention") and c.get("name"):
             parts.append(c["name"])
-    return "\n".join(p for p in parts if p).strip()
+    return [p.strip() for p in parts if p and p.strip()]
 
 
 def _mcp_text(item):
@@ -246,11 +255,14 @@ class ThreadNormalizer:
             if iid in self._seen_user:
                 return []
             self._seen_user.add(iid)
-            text = _user_input_text(item.get("content"))
-            if not text:
+            texts = _user_input_texts(item.get("content"))
+            if not texts:
                 return []
-            # a user item mid-turn is a steer — close any held text first, then the prompt record
-            return self._flush() + [self._user(iid, ts_ms, [{"type": "text", "text": text}])]
+            # a user item mid-turn is a steer: close any held text first, then the prompt record, one
+            # text block per input (see _user_input_texts), so a turn started from several queued sends
+            # lands each send's text as its own block
+            return self._flush() + [self._user(iid, ts_ms,
+                                               [{"type": "text", "text": t} for t in texts])]
         if started:
             # calls whose INVOCATION should show the moment it starts (long commands stay visible
             # while they run, like a Claude tool_use does); results land at completed.

--- a/plans/codex-backend.md
+++ b/plans/codex-backend.md
@@ -119,7 +119,7 @@ machinery on such boxes without it.
 
 | Codex event | Transcript record |
 |---|---|
-| `item/*` userMessage | `user` record, `promptSource:"sdk"` (human on a programmatic session, same as the SDK backend) |
+| `item/*` userMessage | `user` record, one text block per input (a turn started from several queued sends lands each of them), `promptSource:"sdk"` (human on a programmatic session, same as the SDK backend) |
 | `item/completed` agentMessage | assistant text — HELD, flushed with `stop_reason:null` when more items follow, `"end_turn"` at `turn/completed` (records are append-only; the turn's last message must land already-stamped) |
 | `item/completed` reasoning | assistant `thinking` block |
 | `item/started` commandExecution | assistant `tool_use` (name `Bash`, input {command}) |

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -183,10 +183,12 @@ class FakeClient:
         ms = 1781100000000 + self._n * 100000
         text = " ".join(i.get("text", "") for i in input_items)
         if script is None:
+            # the app-server's shape: ONE userMessage item carrying the turn's input list, an entry per
+            # input (the worker sends one input per queued send), never the inputs joined into one text
             script = [
                 ("item/completed", {"threadId": tid, "turnId": turn_id, "completedAtMs": ms,
                                     "item": {"type": "userMessage", "id": "u-%d" % self._n,
-                                             "content": [{"type": "text", "text": text}]}}),
+                                             "content": list(input_items)}}),
                 ("item/completed", {"threadId": tid, "turnId": turn_id, "completedAtMs": ms + 1000,
                                     "item": {"type": "agentMessage", "id": "a-%d" % self._n,
                                              "text": "ack: " + text}}),
@@ -420,6 +422,36 @@ class Lifecycle(unittest.TestCase):
         self.assertEqual(params["permissions"], "romp_workspace")
         self.assertEqual(params["runtimeWorkspaceRoots"], ["/TESTDIR"])
         self.assertNotIn("sandboxPolicy", params)
+
+    def test_two_sends_queued_before_the_turn_land_as_two_blocks_and_retire_both_echoes(self):
+        # Two sends queued before the worker starts a turn (an idle session sent twice quickly, sends
+        # while the client is down or backing off, a resume after a kernel restart) go out as ONE
+        # turn_start with an input per send; the app-server answers one userMessage item carrying both,
+        # and the normalizer lands it as one record with a text block per input. Joined into one block
+        # the record matches neither echo, and both echoes stay live for good, painted beside the record
+        # in every later build.
+        be, fake, _ = build()
+        sid = be.spawn("web", "/TESTDIR")
+        be._ensure_worker = lambda s: None             # hold the worker so both sends queue
+        self.assertTrue(be.send(sid, "first send"))
+        self.assertTrue(be.send(sid, "second send"))
+        del be._ensure_worker                          # the class method is back in place
+        self.assertEqual([a["_echo_text"] for a in be.live_atoms(sid)], ["first send", "second send"])
+        self.assertTrue(be.wake(sid))
+        self.assertTrue(until(lambda: not be.busy(sid) and not be.pending_queued(sid)))
+        starts = fake.called("turn_start")
+        self.assertEqual(len(starts), 1, "one turn for the whole queue")
+        self.assertEqual([i["text"] for i in starts[0][2]], ["first send", "second send"])
+        recs = [json.loads(l) for l in Path(be.transcript_path(sid)).read_text().splitlines()]
+        users = [r for r in recs if r["type"] == "user"]
+        self.assertEqual(len(users), 1, "one user record for the one item")
+        self.assertEqual(users[0]["message"]["content"],
+                         [{"type": "text", "text": "first send"}, {"type": "text", "text": "second send"}],
+                         "a text block per send, never the sends joined")
+        self.assertTrue(until(lambda: be.live_atoms(sid) == []), "both echoes retired, one per block")
+        s = be._session(sid)
+        with s.lock:
+            self.assertEqual(s.echoes, [])
 
     def test_send_during_open_turn_steers(self):
         be, fake, _ = build()
@@ -1279,11 +1311,14 @@ class PruneLive(unittest.TestCase):
 
 
 class EchoAtoms(unittest.TestCase):
-    """What the kernel reads off a Codex echo. `_echo_text` is the marker every kernel reader of an input
-    echo keys on (SdkBackend's echo atoms carry it): _merge_live_atoms hides the echo behind its queued
-    bubble and never counts it as live work, and build_session's queued-bubble pass enlists it while the
-    session is busy. Without it a Codex echo would paint as a solid user atom beside its own queued bubble
-    and force the last turn open (the merge itself is pinned in tests/test_codex_echo_merge.py)."""
+    """What the kernel reads off a Codex echo, and how the backend's own retire takes echoes back.
+    `_echo_text` is the marker every kernel reader of an input echo keys on (SdkBackend's echo atoms carry
+    it): _merge_live_atoms hides the echo behind its queued bubble and never counts it as live work, and
+    build_session's queued-bubble pass enlists it while the session is busy. Without it a Codex echo would
+    paint as a solid user atom beside its own queued bubble and force the last turn open (the merge itself
+    is pinned in tests/test_codex_echo_merge.py). Each echo is ONE send: _append takes one echo per landed
+    text BLOCK (a turn started from several queued sends lands as one record with a block per send), the
+    oldest carrying the text, and send()'s dead path takes back only the echo it minted."""
 
     def test_the_echo_atom_is_marked_as_an_input_echo(self):
         be, fake, _ = build()
@@ -1297,6 +1332,111 @@ class EchoAtoms(unittest.TestCase):
         self.assertEqual(atom["message"]["content"][0]["text"], "ship it")
         self.assertEqual(atom["author"], "human")
         self.assertNotIn("command", atom, "a plain echo carries no command flag")
+
+    @staticmethod
+    def _rec(kind, uid, text):
+        return {"type": kind, "uuid": uid, "message": {"role": kind, "content": [{"type": "text", "text": text}]}}
+
+    def test_a_landed_record_retires_one_echo_the_oldest_carrying_its_text(self):
+        # One block is one send (each record here has one). Dropping EVERY echo carrying the landed text
+        # loses the second echo of a text sent twice when the first record lands, and a second send dropped
+        # after that (the client dying mid-queue) leaves nothing visible. The kernel's prune_live, floored
+        # by record time, is the other retire; this one sees only the records it just wrote.
+        be, fake, _ = build()
+        sid = be.spawn("web", "/TESTDIR")
+        s = be._session(sid)
+        with s.lock:
+            s.echoes.extend([{"text": "ok", "t": 1000, "uuid": "echo-11111111"},
+                             {"text": "ok", "t": 1001, "uuid": "echo-22222222"},
+                             {"text": "ship it", "t": 1002, "uuid": "echo-33333333"}])
+        with s.norm_lock:                                  # _append's contract: the caller holds it
+            be._append(s, [self._rec("user", "u-1", "  ok \n")])   # the record side is keyed the same way
+        self.assertEqual([a["uuid"] for a in be.live_atoms(sid)], ["echo-22222222", "echo-33333333"],
+                         "one record, one echo: the oldest carrying its text")
+        with s.norm_lock:
+            be._append(s, [self._rec("user", "u-2", "ok"), self._rec("assistant", "a-1", "ship it")])
+        self.assertEqual([a["uuid"] for a in be.live_atoms(sid)], ["echo-33333333"],
+                         "the second record takes the second echo; an assistant record takes none")
+        with s.norm_lock:
+            be._append(s, [self._rec("user", "u-3", "ok")])
+        self.assertEqual([a["uuid"] for a in be.live_atoms(sid)], ["echo-33333333"],
+                         "a record with no echo left to take retires nothing else")
+
+    @staticmethod
+    def _two_block_record(uid="u-1"):
+        """Shaped like the record the normalizer writes for a turn started from two queued sends (the
+        app-server's one userMessage item, a block per input; codex_events._user_input_texts), with one
+        block left padded so the key rule on the record side is exercised."""
+        return {"type": "user", "uuid": uid,
+                "message": {"role": "user", "content": [{"type": "text", "text": "first send"},
+                                                         {"type": "text", "text": "  second send\n"}]}}
+
+    def test_a_two_block_record_retires_one_echo_per_block(self):
+        # A turn started from two queued sends lands one record with a block per send. One echo per block,
+        # the oldest carrying the text: a joined reading of the record ("first send second send") matches
+        # neither echo and both stay live for good, and taking every echo carrying a landed text would take
+        # a later repeat of the first send with it.
+        be, fake, _ = build()
+        sid = be.spawn("web", "/TESTDIR")
+        s = be._session(sid)
+        with s.lock:
+            s.echoes.extend([{"text": "first send", "t": 1000, "uuid": "echo-11111111"},
+                             {"text": "second send", "t": 1000, "uuid": "echo-22222222"},
+                             {"text": "third send", "t": 1001, "uuid": "echo-33333333"},
+                             {"text": "first send", "t": 1002, "uuid": "echo-44444444"}])   # sent again, later
+        with s.norm_lock:
+            be._append(s, [self._two_block_record()])
+        self.assertEqual([a["uuid"] for a in be.live_atoms(sid)], ["echo-33333333", "echo-44444444"],
+                         "one record with two blocks retires two echoes, one per block, the oldest of each")
+
+    def test_a_joined_text_echo_does_not_match_a_two_block_record(self):
+        # Per block, never the blocks joined: an echo spelling both texts in ONE message is a third send
+        # the app-server has not recorded, and a joined key (space- or newline-joined) would retire it
+        # against the two-send record. (The kernel's prune_live does match the joined text, floored by
+        # record time; this pins the backend's own retire.) The record is spelled unpadded so a space-join
+        # of its blocks is exactly the first echo's text: a padded block would join to three spaces, match
+        # nothing, and pass for the wrong reason.
+        be, fake, _ = build()
+        sid = be.spawn("web", "/TESTDIR")
+        s = be._session(sid)
+        with s.lock:
+            s.echoes.extend([{"text": "first send second send", "t": 1000, "uuid": "echo-11111111"},
+                             {"text": "first send\nsecond send", "t": 1000, "uuid": "echo-22222222"}])
+        rec = {"type": "user", "uuid": "u-1",
+               "message": {"role": "user", "content": [{"type": "text", "text": "first send"},
+                                                        {"type": "text", "text": "second send"}]}}
+        with s.norm_lock:
+            be._append(s, [rec])
+        self.assertEqual([a["uuid"] for a in be.live_atoms(sid)], ["echo-11111111", "echo-22222222"],
+                         "neither joined spelling is a block of the record")
+        self.assertEqual(be._rec_texts(self._two_block_record()), ["first send", "second send"],
+                         "one key per block, stripped")
+        self.assertEqual(be._rec_texts({"type": "user", "message": {"role": "user", "content": "  plain \n"}}),
+                         ["plain"], "a string content is one entry")
+        self.assertEqual(be._rec_texts({"type": "user", "message": {"role": "user", "content": [
+            {"type": "text", "text": "   "}, {"type": "image", "source": {}}]}}), [],
+            "blank and non-text blocks key nothing")
+
+    def test_a_send_that_finds_the_session_dead_takes_back_only_its_own_echo(self):
+        # send() minted an echo, steered, and found the session dead under its second lock (it died during
+        # the steer RPC). It takes back the echo it minted, by uuid, and no other: an earlier same-text
+        # send the app-server never recorded must stay visible, the rule prune_live states.
+        be, fake, _ = build()
+        sid = be.spawn("web", "/TESTDIR")
+        s = be._session(sid)
+        with s.lock:
+            s.turn_id = "t-live"                           # an open turn: send() steers
+            s.echoes.append({"text": "ok", "t": 1000, "uuid": "echo-11111111"})   # an earlier, unrecorded send
+
+        def dies_mid_steer(tid, expected_turn_id, input_items):
+            with s.lock:
+                s.dead = True
+            raise RuntimeError("synthetic: the app-server went away during the steer")
+
+        fake.turn_steer = dies_mid_steer
+        self.assertFalse(be.send(sid, "ok"))
+        self.assertEqual([a["uuid"] for a in be.live_atoms(sid)], ["echo-11111111"],
+                         "the earlier echo survives; only the failed send's own echo is taken back")
 
 
 class LaunchErrorNames(unittest.TestCase):

--- a/tests/test_codex_echo_merge.py
+++ b/tests/test_codex_echo_merge.py
@@ -6,9 +6,10 @@ merge would paint a Codex echo as a solid user atom beside its own queued bubble
 beside its landed record, and count an echo-only merge as live ASSISTANT work, forcing the last turn
 open: a false "working" chip for a session whose only live item is a pending send. The atoms carry
 `_echo_text` now, and this module runs the REAL kernel merge (_merge_live_atoms) over the REAL backend (a
-scripted fake app-server client: no SDK, no network, no turn ever streams) to pin the consequences. The
-kernel is loaded the way tests/test_kernel_fed_echo_absorbed.py loads it. Synthetic fixtures only (the
-notes-api demo domain).
+scripted fake app-server client: no SDK, no network, no turn ever streams) to pin the consequences, and
+the case of a turn started from two queued sends: the real normalizer lands it as one record with a text
+block per send, and the merge retires both echoes. The kernel is loaded the way
+tests/test_kernel_fed_echo_absorbed.py loads it. Synthetic fixtures only (the notes-api demo domain).
 """
 import os
 import tempfile
@@ -121,6 +122,33 @@ class CodexEchoMerge(unittest.TestCase):
         self.assertIs(merged, sess, "and the merge painted nothing beside the record")
         texts = [t for a in sess["turns"][-1]["atoms"] for t in km._atom_user_texts(a)]
         self.assertEqual(texts.count("and the tests"), 1)
+
+    def test_a_two_block_record_in_the_sends_second_retires_both_echoes_and_paints_each_text_once(self):
+        # Two sends queued before a turn starts go out as ONE turn (an input per send) and the app-server
+        # answers one userMessage item carrying both; the REAL normalizer writes it as one user record with
+        # a text block per input (codex_events._user_input_texts), the kernel's _atom_user_texts yields each
+        # block, and prune_live lands both echoes. Joined into one block the record matches neither echo:
+        # both stay live for good and paint as user bubbles beside the record in every later build.
+        self.assertTrue(self.be.send(self.sid, "first send"))
+        self.assertTrue(self.be.send(self.sid, "second send"))
+        self.assertEqual([a["_echo_text"] for a in self.be.live_atoms(self.sid)], ["first send", "second send"])
+        t_echo = max(a["t"] for a in self.be.live_atoms(self.sid))
+        norm = cb._events.ThreadNormalizer("T-1", cwd="/TESTDIR", model="gpt-5-test", version="codex",
+                                           clock=lambda: t_echo)
+        rec, = norm.handle("item/completed", {
+            "threadId": "T-1", "turnId": "t-live", "completedAtMs": t_echo * 1000,
+            "item": {"type": "userMessage", "id": "u2",
+                     "content": [{"type": "text", "text": "first send"},
+                                 {"type": "text", "text": "second send"}]}})
+        self.assertEqual(rec["type"], "user")
+        atom = {"type": "user", "uuid": rec["uuid"], "t": t_echo, "author": "human", "message": rec["message"]}
+        sess = self._session(atom)                                           # lands within the sends' second
+        merged = km._merge_live_atoms(sess, self.sid)
+        self.assertEqual(self.be.live_atoms(self.sid), [], "prune_live retired both echoes, one per block")
+        self.assertIs(merged, sess, "and the merge painted nothing beside the record")
+        texts = [t for a in sess["turns"][-1]["atoms"] for t in km._atom_user_texts(a)]
+        self.assertEqual(texts.count("first send"), 1)
+        self.assertEqual(texts.count("second send"), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_codex_events_golden.py
+++ b/tests/test_codex_events_golden.py
@@ -210,6 +210,37 @@ class Chain(unittest.TestCase):
                     item_completed(user_item("hello", "u1")))
         self.assertEqual(len(recs), 1)
 
+    def test_several_inputs_land_as_one_text_block_each(self):
+        # The backend starts a turn from its WHOLE queue, one input per queued send, and the app-server
+        # answers one userMessage item carrying them all. Each input is its own text block: a user record
+        # with several text blocks is a shape the kernel already reads per block (_atom_user_texts, behind
+        # the echo prune and the pending-bubble pass; romp bundles its own injected messages that way).
+        # Joined into one block ("first send\nsecond send") the record matches no send's echo, and the
+        # echoes of a turn started from several sends never retire. A placeholder for a non-text input is
+        # a block of its own.
+        n = norm()
+        two = {"type": "userMessage", "id": "u1",
+               "content": [{"type": "text", "text": "first send"},
+                           {"type": "text", "text": "  second send\n"}]}
+        recs = feed(n, turn_started(), item_completed(two))
+        self.assertEqual([r["type"] for r in recs], ["user"], "one record for the one item")
+        self.assertEqual(recs[0]["message"]["content"],
+                         [{"type": "text", "text": "first send"}, {"type": "text", "text": "second send"}],
+                         "a block per input, each stripped of outer whitespace")
+        mixed = {"type": "userMessage", "id": "u2",
+                 "content": [{"type": "text", "text": "   "},
+                             {"type": "localImage", "path": "/TESTDIR/shot.png"},
+                             {"type": "skill", "name": "review"},
+                             {"type": "text", "text": "and the tests"}]}
+        recs = feed(n, item_completed(mixed))
+        self.assertEqual([b["text"] for b in recs[0]["message"]["content"]],
+                         ["[Image: /TESTDIR/shot.png]", "review", "and the tests"],
+                         "a blank input is dropped; placeholders keep their own block")
+        # one text input writes exactly what it wrote before: one block, outer whitespace stripped
+        recs = feed(n, item_completed(user_item("  fix the flaky test\n", "u3")))
+        self.assertEqual(recs[0]["message"]["content"], [{"type": "text", "text": "fix the flaky test"}])
+        self.assertEqual(feed(n, item_completed(user_item("  ", "u4"))), [], "every input blank: no record")
+
     def test_compaction_stitch(self):
         n = norm()
         recs = feed(n,


### PR DESCRIPTION
**Symptom.** Two sends queued before a Codex turn starts (an idle session sent twice quickly, sends while the app-server client is down or backing off, a queue resumed after a kernel restart) go out as one turn, and their input echoes never retire. They stay live for as long as the session does: pending sends while the session is busy, user atoms beside the landed record when it is idle, in every later build. Two related over-retires: a send that finds its session dead during a steer takes back every echo carrying its text, so an earlier same-text send the app-server never recorded, which must stay visible, vanishes with it; and the backend's own retire on a landed record drops every echo carrying the record's text, so a text sent twice loses both echoes when the first record lands.

**Cause.** `CodexBackend._run_turn_in_mode` (kernel/codex_backend.py) starts one turn from the whole queue, one input per queued send, and the app-server answers with one userMessage item carrying them all. `_user_input_text` (kernel/codex_events.py) newline-joined those inputs and `ThreadNormalizer._item` wrote them as one text block, `"first send\nsecond send"`, which matches neither send's echo: `CodexBackend._append` keyed the record by its space-joined text, and the kernel's `prune_live` receives the keys `_atom_user_texts` yields (the joined text and each block), where the only block was the joined one. `send()`'s dead path retired by text.

**Fix.**
- `codex_events._user_input_texts` returns one stripped entry per input (blanks dropped; an image or skill placeholder is an entry of its own), and `_item` writes one text block per entry. A user record with several text blocks is a shape the kernel already reads per block (`_atom_user_texts`, behind the echo prune and the pending-bubble pass; `sdk_backend._landed_texts`): romp bundles its own injected messages as several blocks in one record, so no kernel change is needed.
- `CodexBackend._rec_texts` keys each text block of a user record under `echo_text_key` (a string content is one entry, blanks dropped), and `_append` retires one echo per landed block, the oldest carrying the text, so a second identical steer keeps its echo when the first one's record lands and a second send dropped after that stays visible. The kernel's `prune_live`, floored by record time, is the other retire; it also matches the record's joined text, which `_append` does not repeat.
- `send()` keeps the uuid it mints and, when the session died during the steer RPC, takes back that echo alone.
- `plans/codex-backend.md`'s event table says one text block per input. The test fake client's default turn answers a userMessage carrying the input list, the app-server's shape.

**Tests, each failing before the change.**
- `tests/test_codex_events_golden.py` `test_several_inputs_land_as_one_text_block_each`: two inputs land as two stripped blocks, a blank input is dropped, placeholders are blocks of their own, one input writes one block as before, all-blank inputs write no record. Before: one block, `"first send\n  second send"`.
- `tests/test_codex_backend.py` `Lifecycle.test_two_sends_queued_before_the_turn_land_as_two_blocks_and_retire_both_echoes`, through the real worker: one `turn_start` with two inputs, one user record with two blocks, both echoes retired. Before: one joined block, both echoes live.
- `tests/test_codex_backend.py` `EchoAtoms`: a landed record retires one echo, the oldest carrying its text (before: both `"ok"` echoes went on one record); a two-block record retires one echo per block, the oldest of each, and a later repeat of the first text stays (before: the space-joined key matched no echo and every echo stayed); a joined-text echo does not match a two-block record (before: the space-joined key retired the echo spelling both texts in one message); a send that finds the session dead takes back only its own echo (before: the earlier same-text echo went with it).
- `tests/test_codex_echo_merge.py` `test_a_two_block_record_in_the_sends_second_retires_both_echoes_and_paints_each_text_once`: the real normalizer and the real `_merge_live_atoms` over the real backend. Before: both echoes live after the merge.

Follows https://github.com/romp-on/romp/pull/1162 (merged), which this change builds on: the key rule `send()` stores on an echo and `prune_live` compares, and the `_echo_text` marker the tests read, come from that PR.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)