### PR TITLE
GET /models names why the Codex model list is empty; the backend caches only a non-empty catalog

### DIFF
--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -929,8 +929,12 @@ class CodexBackend:
     def model_catalog_error(self):
         """Why the last model_catalog() answered [] (one sentence for a picker to show), or None when
         a catalog is held or none has been asked for yet. The kernel's /models reads it after an empty
-        answer; the failure is the app-server's or the client's, so the sentence names that side."""
-        return self._catalog_err
+        answer; the failure is the app-server's or the client's, so the sentence names that side.
+        Read under _catalog_lock like every writer of the reason, so a concurrent read that is mid-way
+        through storing a list or recording its own reason cannot hand this caller a half-updated value
+        (review find, 2026-09-09)."""
+        with self._catalog_lock:
+            return self._catalog_err
 
     def set_mode(self, sid, mode):
         s = self._session(sid)

--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -285,7 +285,9 @@ class CodexBackend:
         self._client_retry_at = 0.0
         self._client_failures = 0
         self._client_generation = 0   # successful app-server client installations
-        self._catalog = None          # model_catalog() cache — fetched once per process
+        self._catalog = None          # model_catalog() cache: a NON-EMPTY list, fetched once per process
+        self._catalog_err = None      # why the last model_catalog() answered [] (str), or None
+        self._catalog_lock = threading.Lock()   # one model_catalog() read at a time (see its docstring)
         self._client_lock = threading.Lock()
         self._sessions = {}           # sid → _Session
         self._sessions_lock = threading.RLock()
@@ -880,24 +882,55 @@ class CodexBackend:
 
     def model_catalog(self):
         """[{value,label}] for the UI's model picker — the app-server's own model list (the ONE
-        authoritative source), fetched once per process and cached. [] when the client is
-        unavailable (the picker then shows nothing rather than another vendor's list). A plan
-        account may still refuse some listed models per turn — that failure surfaces loudly as
-        the turn's error card, and switching back is one click."""
-        if self._catalog is not None:
-            return self._catalog
-        c = self._get_client()
-        if c is None:
-            return []
-        try:
-            ms = c.model_list()
-            self._catalog = [{"value": m.id, "label": getattr(m, "display_name", None) or m.id}
-                             for m in (getattr(ms, "data", None) or [])
-                             if not getattr(m, "hidden", False)]
-        except Exception as e:
-            self.log("model_list failed: %s" % e)
-            return []
-        return self._catalog
+        authoritative source), fetched once per process and cached. [] when the list cannot be had,
+        and then model_catalog_error() says WHY (the picker shows nothing rather than another vendor's
+        list, and the kernel's /models hands the reason on). Three ways to [], each recorded: the
+        client is unavailable (_get_client() None: the factory failed, or the client sits in its retry
+        backoff), model_list raised, or the app-server answered an EMPTY page. Only a NON-EMPTY list is
+        cached: an empty page `is not None`, and caching it would hold the empty catalog for the life of
+        the process, a blank menu on every later picker open after the app-server has models to list.
+        Each failure is logged once per DISTINCT reason, not once per call: the kernel
+        re-reads the catalog on every picker open and every models frame, and a per-call line repeats
+        for as long as the fault lasts. The read runs under _catalog_lock: /models is served from handler
+        threads, and two readers racing the same first read would otherwise both log the same reason, or
+        one that found no client would record its reason after the other had stored the list and cleared
+        it, a stale reason beside a held catalog. A plan account may still refuse some listed models per
+        turn — that failure surfaces loudly as the turn's error card, and switching back is one click."""
+        with self._catalog_lock:
+            if self._catalog:
+                return self._catalog
+            c = self._get_client()
+            if c is None:
+                self._note_catalog_error("the Codex app-server client is unavailable: %s"
+                                         % (self._client_err or "not started yet"))
+                return []
+            try:
+                ms = c.model_list()
+                rows = [{"value": m.id, "label": getattr(m, "display_name", None) or m.id}
+                        for m in (getattr(ms, "data", None) or [])
+                        if not getattr(m, "hidden", False)]
+            except Exception as e:
+                self._note_catalog_error("model_list failed: %s" % (str(e) or e.__class__.__name__))
+                return []
+            if not rows:
+                self._note_catalog_error("the Codex app-server listed no models")
+                return []
+            self._catalog = rows
+            self._catalog_err = None
+            return rows
+
+    def _note_catalog_error(self, why):
+        """Record why model_catalog() answered [] and log it once per distinct reason (see model_catalog).
+        Caller owns _catalog_lock."""
+        if why != self._catalog_err:
+            self.log(why)
+        self._catalog_err = why
+
+    def model_catalog_error(self):
+        """Why the last model_catalog() answered [] (one sentence for a picker to show), or None when
+        a catalog is held or none has been asked for yet. The kernel's /models reads it after an empty
+        answer; the failure is the app-server's or the client's, so the sentence names that side."""
+        return self._catalog_err
 
     def set_mode(self, sid, mode):
         s = self._session(sid)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14142,6 +14142,7 @@ CODEX_SETUP_HINT = ("Session not created: the Codex backend isn't installed. "
 
 _codex_backend = None   # None = not built yet, False = module unavailable, else the CodexBackend
 _codex_lock = threading.Lock()
+_codex_catalog_fault = [None]   # the last /models catalog raise logged (str), or None: see _note_codex_catalog_fault
 
 
 def _codex():
@@ -14169,6 +14170,19 @@ def _codex():
                 sys.stderr.write("codex-backend unavailable: %s\n" % traceback.format_exc())
                 _codex_backend = False
         return _codex_backend or None
+
+
+def _note_codex_catalog_fault(why):
+    """Log a raise out of the Codex backend's catalog read (model_catalog or model_catalog_error) ONCE per
+    distinct reason, from GET /models. Every picker open and every models frame re-reads the route, so a
+    line per read would repeat for as long as the fault lasts; the backend logs its own recorded reasons
+    (an empty page, a failed model_list, a client in backoff) the same way. `why` None clears the latch
+    (the read returned without raising), so the same fault after a recovery is a new line. The line
+    carries the backend's own `codex-backend:` prefix so every Codex line in the kernel log greps together."""
+    if why != _codex_catalog_fault[0]:
+        _codex_catalog_fault[0] = why
+        if why:
+            sys.stderr.write("codex-backend: %s\n" % why)
 
 
 def _codex_ready():
@@ -46522,18 +46536,34 @@ class Handler(BaseHTTPRequestHandler):
                 # (docs/codex.md) — models from the app-server's own list via the backend (the
                 # authoritative source; [] until the backend runs, so no picker ever shows another
                 # vendor's models); efforts are the four Codex accepts — max/ultracode are Claude-only.
+                # The section's `error` field names WHY `models` is empty: null beside a non-empty list,
+                # else one sentence for the picker to show (a string, never an object or a code).
+                # Without it the picker opens on a blank menu with no word of why: the backend's
+                # model_catalog() answers [] when its client is in retry backoff, when model_list
+                # raised or when the app-server listed no models (CodexBackend.model_catalog_error
+                # names which), a raise out of it would land here as the same empty list, and the
+                # closed gate below and an absent backend serve the same [] too. The last two name
+                # themselves so an empty list is never read as the app-server's answer.
                 cx = _codex()
-                cx_models = []
+                cx_models, cx_err = [], None
                 # Codex is consulted ONLY where this machine opted in — the Codex default backend, the
                 # Codex judge engine, or a live Codex session. model_catalog() builds the client, which
                 # SPAWNS `codex app-server`; unconditional, every dashboard load spawned (or repeatedly
                 # failed to spawn) it on every install, the opposite of off-by-default (PR #885 review).
                 if cx and (_default_backend() == "codex" or _judge_engine_name() == "codex"
                            or bool(cx.live_sessions())):
+                    fault = None
                     try:
                         cx_models = cx.model_catalog()
-                    except Exception:
-                        pass
+                        if not cx_models:
+                            cx_err = cx.model_catalog_error() or "the Codex app-server sent no model list"
+                    except Exception as e:
+                        fault = cx_err = "model catalog: %s" % (str(e) or e.__class__.__name__)
+                    _note_codex_catalog_fault(fault)   # a raise is logged once per distinct reason; None clears
+                elif cx:
+                    cx_err = "no live Codex session; the list is read once one runs"
+                else:
+                    cx_err = "the Codex backend is unavailable (see the kernel log)"
                 return self._send(200, json.dumps(
                     # `rev` is the pick memory's revision — the models frame's counter (_models_changed),
                     # read here BEFORE the picks so a payload never carries a rev newer than its list: a
@@ -46548,7 +46578,7 @@ class Handler(BaseHTTPRequestHandler):
                                 for c in MODEL_CHOICES],
                      "efforts": [dict(c, color=_effort_color(c["value"], _stops), tone=_effort_tone(c["value"]))
                                  for c in EFFORT_CHOICES],
-                     "codex": {"models": cx_models,
+                     "codex": {"models": cx_models, "error": cx_err,
                                "efforts": [{"value": v, "label": v}
                                            for v in ("low", "medium", "high", "xhigh")]},
                      # the create dialog's pre-read (the user 2026-08-29): what a new comment thread

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -1187,6 +1187,72 @@ for i in range(20):
         self.assertEqual(cat, [{"value": "gpt-5-test", "label": "GPT-5 Test"}])
         be.model_catalog()
         self.assertEqual(len(fake.called("model_list")), 1, "catalog is fetched once, then cached")
+        self.assertIsNone(be.model_catalog_error(), "a held catalog carries no error")
+
+    def test_model_catalog_empty_answer_is_not_cached_and_is_named(self):
+        # The picker opened on a blank menu and stayed blank for the life of the kernel: the app-server's
+        # first answer was an empty page, and `[] is not None`, so the empty list was cached as the catalog.
+        # Only a non-empty list is held; an empty answer is named and the next read asks again.
+        be, fake, _ = build()
+        logged = []
+        be.log = logged.append
+        real = fake.model_list
+        pages, asked = [SimpleNamespace(data=[])], []
+
+        def paged(*a, **k):
+            asked.append(1)
+            return pages.pop() if pages else real(*a, **k)
+        fake.model_list = paged
+        self.assertEqual(be.model_catalog(), [])
+        self.assertEqual(be.model_catalog(), [{"value": "gpt-5-test", "label": "GPT-5 Test"}],
+                         "an empty answer is not the catalog: the next read asks the app-server again")
+        self.assertEqual(len(asked), 2)
+        self.assertEqual(logged.count("the Codex app-server listed no models"), 1, "the empty answer is named, once")
+        self.assertIsNone(be.model_catalog_error(), "the held list clears the reason")
+        be.model_catalog()
+        self.assertEqual(len(asked), 2, "the non-empty list is the one that is cached")
+
+    def test_model_catalog_failure_is_named_and_logged_once_per_reason(self):
+        # model_list raised: the backend answered [] and logged a line per call, and the caller had no way to
+        # read why. The reason is readable (model_catalog_error) and logged once per DISTINCT reason: the
+        # kernel re-reads the catalog on every picker open, so a per-call line repeats for as long as the
+        # fault lasts. A later good answer clears the reason.
+        be, fake, _ = build()
+        logged = []
+        be.log = logged.append
+        real = fake.model_list
+        faults = [RuntimeError("app-server not ready"), RuntimeError("app-server not ready"), RuntimeError("pump died")]
+
+        def flaky(*a, **k):
+            if faults:
+                raise faults.pop(0)
+            return real(*a, **k)
+        fake.model_list = flaky
+        named = lambda: [l for l in logged if l.startswith("model_list failed")]
+        self.assertEqual(be.model_catalog(), [])
+        self.assertEqual(be.model_catalog_error(), "model_list failed: app-server not ready")
+        self.assertEqual(be.model_catalog(), [], "the same fault again")
+        self.assertEqual(named(), ["model_list failed: app-server not ready"], "one line for one reason, however many reads")
+        self.assertEqual(be.model_catalog(), [])
+        self.assertEqual(be.model_catalog_error(), "model_list failed: pump died")
+        self.assertEqual(named(), ["model_list failed: app-server not ready", "model_list failed: pump died"],
+                         "a different reason is a new line")
+        self.assertEqual(be.model_catalog(), [{"value": "gpt-5-test", "label": "GPT-5 Test"}],
+                         "the next read retries instead of serving the failed answer")
+        self.assertIsNone(be.model_catalog_error())
+
+    def test_model_catalog_without_a_client_names_the_client_failure(self):
+        # _get_client() None (the factory failed; the client sits in its retry backoff) answered [] with
+        # nothing logged and nothing for the caller to show. The reason carries the client's own failure text.
+        be, _, _ = build(factory=lambda: (_ for _ in ()).throw(RuntimeError("codex login missing")))
+        logged = []
+        be.log = logged.append
+        self.assertEqual(be.model_catalog(), [])
+        want = "the Codex app-server client is unavailable: codex login missing"
+        self.assertEqual(logged.count(want), 1, logged)
+        self.assertEqual(be.model_catalog_error(), want)
+        self.assertEqual(be.model_catalog(), [])
+        self.assertEqual(logged.count(want), 1, "the same reason is logged once, not once per read")
 
     def test_deliver_and_wake_reach_the_agent(self):
         be, fake, _ = build()

--- a/tests/test_codex_models_route.py
+++ b/tests/test_codex_models_route.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""GET /models' Codex section says WHY it is empty. A Codex session's model picker opened on a blank menu
+with no word of what was wrong: the route carried `codex: {models: []}` whenever the backend's
+model_catalog() answered [] (the app-server client in its retry backoff, a model_list that raised, an
+empty page) or raised (the handler swallowed the exception into the same empty list), and it carried the
+same empty list on a dashboard where the Codex consult is gated off (no live Codex session, Codex neither
+the default backend nor the judge engine) or where the backend module failed to load. The section now
+carries `error`: null beside a non-empty list, else one sentence naming the reason, read from the
+backend after an empty answer (model_catalog_error) or built from the raise (out of either call), and the
+closed gate and an absent backend name themselves so an empty list is never read as the app-server's
+answer. A raising catalog is logged once per distinct reason, and again when the same fault recurs after
+the catalog answered: every picker open and every models frame re-reads the route.
+The handler runs in-process on a loopback ThreadingHTTPServer (the test_kernel_cors idiom) over a FAKE
+backend holding the slice the handler reads, and once over the REAL clientless backend so the sentence the
+route serves is the backend's own. Synthetic fixtures only.
+"""
+import http.client
+import io
+import json
+import os
+import sys
+import tempfile
+import threading
+import unittest
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+from unittest import mock
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+# Hermetic state BEFORE the loads: they resolve their state root at import time, and only pytest runs
+# conftest's floor (a bare unittest or script run otherwise writes REAL state, and a kernel module that
+# can reach a live manager port restarts the live kernel).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["ROMP_MANAGER_PORT"] = "1"             # a dead port, never an inherited live one
+os.environ["ROMP_MODEL_CATALOG"] = "off"          # never the Models API from a test
+km = SourceFileLoader("romp_kernel_codex_models", os.path.join(BIN, "romp-kernel")).load_module()
+cb = SourceFileLoader("romp_codex_backend_codex_models",
+                      os.path.join(ROOT, "kernel", "codex_backend.py")).load_module()
+
+SID = "11111111-2222-4333-8444-555555555555"
+MODELS = [{"value": "gpt-5-test", "label": "GPT-5 Test"}]
+
+
+class FakeCodex:
+    """The slice of CodexBackend the /models handler reads: the gate's row walk, the catalog, its reason."""
+
+    def __init__(self, models=None, error=None, live=None, raise_catalog=None, raise_error=None):
+        self.models, self.error, self.live = list(models or []), error, dict(live or {})
+        self.raise_catalog, self.raise_error = raise_catalog, raise_error
+        self.catalog_calls = 0
+
+    def live_sessions(self):
+        return self.live
+
+    def model_catalog(self):
+        self.catalog_calls += 1
+        if self.raise_catalog:
+            raise self.raise_catalog
+        return list(self.models)
+
+    def model_catalog_error(self):
+        if self.raise_error:
+            raise self.raise_error
+        return self.error
+
+
+class ModelsRoute(unittest.TestCase):
+    def setUp(self):
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        self.port = self.srv.server_address[1]
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+        self._saved = km._codex_backend
+        km._codex_backend = False        # every test picks its backend; none builds the real one by accident
+        self._saved_fault = km._codex_catalog_fault[0]
+        km._codex_catalog_fault[0] = None   # the once-per-reason latch starts clear whatever ran before
+
+    def tearDown(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+        km._codex_backend = self._saved
+        km._codex_catalog_fault[0] = self._saved_fault
+        try:
+            os.unlink(km.jd.STATE / "default-backend")
+        except OSError:
+            pass
+
+    def _models(self):
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=5)
+        try:
+            conn.request("GET", "/models", headers={"X-Romp-Token": km.TOKEN})
+            r = conn.getresponse()
+            self.assertEqual(r.status, 200)
+            return json.loads(r.read())
+        finally:
+            conn.close()
+
+    def _codex(self):
+        d = self._models()
+        self.assertIn("error", d["codex"], "the section always carries the field; null when the list is served")
+        return d["codex"]
+
+    def test_a_live_codex_session_gets_the_backends_list_and_no_error(self):
+        km._codex_backend = FakeCodex(models=MODELS, live={SID: {"backend": "codex"}})
+        cx = self._codex()
+        self.assertEqual((cx["models"], cx["error"]), (MODELS, None))
+        self.assertEqual([e["value"] for e in cx["efforts"]], ["low", "medium", "high", "xhigh"])
+
+    def test_an_empty_list_carries_the_backends_reason(self):
+        km._codex_backend = FakeCodex(models=[], error="model_list failed: app-server not ready",
+                                      live={SID: {"backend": "codex"}})
+        cx = self._codex()
+        self.assertEqual((cx["models"], cx["error"]), ([], "model_list failed: app-server not ready"))
+
+    def test_an_empty_list_with_no_recorded_reason_still_says_so(self):
+        km._codex_backend = FakeCodex(models=[], error=None, live={SID: {"backend": "codex"}})
+        cx = self._codex()
+        self.assertEqual((cx["models"], cx["error"]), ([], "the Codex app-server sent no model list"))
+
+    def test_a_raising_catalog_is_reported_not_swallowed(self):
+        km._codex_backend = FakeCodex(raise_catalog=RuntimeError("pump died"), live={SID: {"backend": "codex"}})
+        cx = self._codex()
+        self.assertEqual((cx["models"], cx["error"]), ([], "model catalog: pump died"))
+
+    def test_a_raise_out_of_the_reason_read_is_reported_too(self):
+        # An empty list sends the handler to model_catalog_error(); a raise there is the same kind of
+        # fault as a raise out of model_catalog() and takes the same sentence, never a swallowed None.
+        km._codex_backend = FakeCodex(models=[], raise_error=RuntimeError("reason lost"),
+                                      live={SID: {"backend": "codex"}})
+        cx = self._codex()
+        self.assertEqual((cx["models"], cx["error"]), ([], "model catalog: reason lost"))
+
+    def test_a_raising_catalog_is_logged_once_per_distinct_reason(self):
+        # The route is re-read on every picker open and every models frame, so a line per read repeats for
+        # as long as the fault lasts: one line per distinct reason, and the SAME fault recurring after the
+        # catalog answered in between is a new line (the answer clears the latch). A raise out of the
+        # reason read is logged the same way.
+        fake = FakeCodex(raise_catalog=RuntimeError("pump died"), live={SID: {"backend": "codex"}})
+        km._codex_backend = fake
+        err = io.StringIO()
+        with mock.patch.object(sys, "stderr", err):
+            self._codex()
+            self._codex()
+            fake.raise_catalog = RuntimeError("app-server not ready")
+            self._codex()
+            self._codex()
+            fake.raise_catalog = None
+            fake.models = list(MODELS)
+            self.assertEqual(self._codex()["error"], None)
+            fake.raise_catalog = RuntimeError("app-server not ready")
+            self._codex()
+            fake.raise_catalog, fake.models = None, []
+            fake.raise_error = RuntimeError("reason lost")
+            self._codex()
+            self._codex()
+        lines = [l for l in err.getvalue().splitlines() if "model catalog" in l]
+        self.assertEqual(lines, ["codex-backend: model catalog: pump died",
+                                 "codex-backend: model catalog: app-server not ready",
+                                 "codex-backend: model catalog: app-server not ready",
+                                 "codex-backend: model catalog: reason lost"])
+
+    def test_the_closed_gate_consults_nothing_and_names_itself(self):
+        # No live Codex session, Codex neither the default backend nor the judge engine: the backend is not
+        # asked (asking would spawn the app-server on every dashboard load), and the reason says so rather
+        # than leaving an empty list that reads as the app-server's answer.
+        fake = FakeCodex(models=MODELS)
+        km._codex_backend = fake
+        cx = self._codex()
+        self.assertEqual((cx["models"], cx["error"], fake.catalog_calls),
+                         ([], "no live Codex session; the list is read once one runs", 0))
+
+    def test_the_codex_default_backend_opens_the_gate_without_a_live_session(self):
+        fake = FakeCodex(models=MODELS)
+        km._codex_backend = fake
+        km.jd.STATE.mkdir(parents=True, exist_ok=True)
+        (km.jd.STATE / "default-backend").write_text("codex\n")
+        cx = self._codex()
+        self.assertEqual((cx["models"], cx["error"], fake.catalog_calls), (MODELS, None, 1))
+
+    def test_an_unavailable_backend_names_itself(self):
+        km._codex_backend = False        # _codex(): the module failed to load, so every caller gets None
+        cx = self._codex()
+        self.assertEqual((cx["models"], cx["error"]), ([], "the Codex backend is unavailable (see the kernel log)"))
+
+    def test_the_real_backends_reason_rides_the_route(self):
+        # The real backend, clientless: the client factory fails as a missing `codex login` does, so
+        # model_catalog() answers [] with the client's failure as the reason, and the route serves that
+        # sentence, not the fallback. The gate is opened by the machine default rather than a live row.
+        be = cb.CodexBackend(tempfile.mkdtemp(), log=lambda m: None,
+                             client_factory=lambda: (_ for _ in ()).throw(RuntimeError("codex login missing")))
+        km._codex_backend = be
+        km.jd.STATE.mkdir(parents=True, exist_ok=True)
+        (km.jd.STATE / "default-backend").write_text("codex\n")
+        cx = self._codex()
+        self.assertEqual((cx["models"], cx["error"]),
+                         ([], "the Codex app-server client is unavailable: codex login missing"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Symptom.** A Codex session's model picker opens on a blank menu with no word of why, and stays blank for the life of the kernel. `GET /models` carries `codex: {models: []}` in every empty state, and the picker has nothing else to read.

**Cause.** `CodexBackend.model_catalog()` caches whatever its first fetch produces. An empty page `is not None`, so a first answer of `[]` holds the empty catalog for the process, and later picker opens show the blank menu after the app-server has models to list. Two other paths to `[]` are silent to the caller: a client in its retry backoff (nothing recorded, nothing logged) and a `model_list` that raised (logged on every read, unreadable by the caller). The `/models` handler swallows a raise out of `model_catalog()` into the same empty list, and it serves the same `[]` where the Codex consult is gated off (no live Codex session, Codex neither the default backend nor the judge engine) and where the backend module failed to load.

**Fix.** `model_catalog()` caches only a non-empty list. It records why it answered `[]` (the client's failure text, `model_list`'s error, or an empty page) and logs each reason once per distinct reason, since the route is re-read on every picker open and every models frame. The read runs under a lock: `/models` is served from handler threads, and without it two readers racing the same first read could both log the reason, or one that found no client could record its reason after the other had stored the list and cleared it. `model_catalog_error()` returns the recorded reason, `None` while a catalog is held or before one was asked for.

The handler's `codex` section gains `error`, always present: `null` beside a non-empty list, else one sentence (a string, never an object or a code) naming the reason:
- after an empty answer, the backend's recorded reason, or `the Codex app-server sent no model list` when none was recorded;
- when the catalog read raised (`model_catalog` or `model_catalog_error`), `model catalog: <error>`, logged to the kernel log once per distinct reason under the backend's `codex-backend:` prefix, and again when the same fault recurs after the read answered;
- the closed gate: `no live Codex session; the list is read once one runs`;
- an absent backend: `the Codex backend is unavailable (see the kernel log)`.

The last two name themselves so an empty list is never read as the app-server's answer. The gate itself is unchanged.

**Tests** (each red before the change).
- `tests/test_codex_backend.py`: an empty first page is not cached and is named (before: the second read serves the cached `[]`); a `model_list` fault is readable through `model_catalog_error` and logged once per distinct reason (before: the method does not exist, and the fault logs on every read); a failed client factory names the client failure (before: nothing recorded or logged by `model_catalog`); the held-catalog test also asserts a null reason.
- `tests/test_codex_models_route.py` (new): the handler in-process on a loopback server over a fake backend, and once over the real clientless `CodexBackend`: a live session gets the list and a null `error`; the backend's reason, the fallback sentence, a raise out of the catalog, a raise out of the reason read, the closed gate, the default-backend gate and an absent backend each carry their sentence; a raising catalog logs once per distinct reason and the same fault again after a recovery (before: the section has no `error` field, and every test fails on it). The module resets the kernel's log latch around each test, so no test depends on the order the others ran in.

Full suite: 10034 passed, 61 skipped.

**Not in this PR.** The models frame when the first Codex session opens the gate (so an already-open dashboard re-reads the list) and the picker's reason row in the UI are separate work; this PR's `error` field is the value that row will read.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)