### PR TITLE
Tab strip: one tag group per row becomes a gear setting, on by default

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -85,8 +85,8 @@ instead; a PDF too large to show offers a download in its place.
 several. Right-click a tab and open **Tags** to add or remove them. Tags filter every
 surface (the tag button in the strip narrows the tabs to the tags you pick), and they group
 the tabs: as soon as any session carries a tag, the strip shows one section per tag, in your
-tag order, each with a header in the tag's color, and the untagged sessions after a divider
-at the end. A session with several tags appears under each of them; every copy is the same
+tag order, each with a header in the tag's color, and the untagged sessions on a row of their
+own at the end. A session with several tags appears under each of them; every copy is the same
 session (click either to open it, and closing either ends it). Each header shows a chevron, the tag's color, its name, and a
 member count. Click a header, or press Enter on it, to fold its section down to the header
 alone; the count then says how many tabs are folded away, and a small dot after it says when
@@ -102,7 +102,10 @@ reorders the tags on every surface (the timeline's tag table shows the same orde
 a tab into another group, right-click it and pick **Move to <tag>** under **Tags**: one click
 adds that tag and drops the tag of the group you right-clicked it in, leaving its other tags alone. The row's
 **+** adds the tag without moving the tab. **Group tabs by tag**, at the foot of the tag
-button's menu, turns the sections off for this browser.
+button's menu, turns the sections off for this browser. Every group starts on its own row; turning off
+the gear's **One tag group per row in the tab strip** lets the groups follow one another across the
+strip and wrap as they need, with the untagged sessions behind a thin divider, so a strip with many
+tags stays short.
 
 **Coming back after a dropped connection.** When the dashboard's link to the kernel
 drops and comes back (a laptop lid closed and opened, a network change, a phone that

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -46,7 +46,7 @@ class SettingsSectionsTest(unittest.TestCase):
                     "id=rs-conserve", "id=rs-thinksum", "id=rs-fileedit"):
             self.assertTrue(h.index(">Sessions<") < h.index(rid) < h.index(">Chat<"), rid)
         # Chat: transcript prefs AND the comment defaults (comments are part of the chat)
-        for rid in ("id=rs-compact", "id=rs-branch", "id=rs-cmtmodel", "id=rs-cmtfast"):
+        for rid in ("id=rs-compact", "id=rs-branch", "id=rs-striprows", "id=rs-cmtmodel", "id=rs-cmtfast"):
             self.assertTrue(h.index(">Chat<") < h.index(rid) < h.index(">Sessions pane<"), rid)
         # Sessions pane, then Feed, then Colors
         self.assertTrue(h.index(">Sessions pane<") < h.index("id=rs-collapsegaps") < h.index(">Feed<"))
@@ -114,6 +114,16 @@ class SettingsSectionsTest(unittest.TestCase):
         self.assertIn("activeOnly: true", _gear_src())
         self.assertIn("s.activeOnly = ao.checked", _gear_src())
         self.assertIn("ao.checked = s.activeOnly !== false", _gear_src())
+
+    def test_one_group_per_row_is_wired_to_the_shared_stripGroupRows_setting(self):
+        # "One tag group per row in the tab strip": a Chat-section checkbox, default ON, persisted as
+        # romp:settings.stripGroupRows. render.ts is the reader: the strip's row breaks and the trail's
+        # boundary read it, and it rides the strip's rebuild signature so a flip repaints at once.
+        self.assertIn("id=rs-striprows checked", _gear_src())
+        self.assertIn("One tag group per row in the tab strip", _gear_src())
+        self.assertEqual(_gear_src().count("stripGroupRows: true"), 2, "on in both of load()'s default literals")
+        self.assertIn("s.stripGroupRows = sr.checked", _gear_src())
+        self.assertIn("sr.checked = s.stripGroupRows !== false", _gear_src())
 
     def test_section_header_styling_exists(self):
         self.assertIn("#rsettings .rs-sec {", _gear_css_src())

--- a/tests/test_tab_groups_rows.py
+++ b/tests/test_tab_groups_rows.py
@@ -4,6 +4,11 @@ the tag chip at the left edge, its tabs after it (wrapping onto further rows as 
 on a fresh line; the untagged trail opens its own line too, with no chip and no separator; a folded group
 is its header row alone.
 
+That layout is the gear's "One tag group per row in the tab strip" (`stripGroupRows`, on by default). The first
+test drives the page as shipped (nothing written to the settings store) and checks T264's geometry; the second
+writes the setting off before the page loads and checks the inline layout: no break element at all, each
+group's header followed by its tabs with nothing between, and the untagged trail behind a visible 13px divider.
+
 The served guard drives the real /chat page from a hermetic kernel: eight sessions under three tags of
 mixed sizes (one tag wide enough to wrap at the viewport) plus one untagged, one group folded by a header
 click. In the browser it reads the strip's geometry: every header is the first item of its row; the groups
@@ -65,6 +70,9 @@ let browser;
 try { browser = await chromium.launch(); }
 catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
 const page = await browser.newPage({ viewport: { width: 640, height: 480 }, deviceScaleFactor: 2 });
+// the inline drive turns the one-group-per-row setting off before any page script runs, so the first paint reads
+// it; the default drive writes nothing and exercises the shipped default
+if (cfg.rows === false) await page.addInitScript(() => { try { localStorage.setItem("romp:settings", JSON.stringify({ stripGroupRows: false })); } catch (e) {} });
 await page.goto(cfg.chat);
 await page.waitForSelector("#tabs .tab[data-id]", { timeout: 20000 });
 try { await page.waitForSelector("#tabs .tab-group-head", { timeout: 20000 }); }
@@ -185,10 +193,12 @@ class ServedGroupsOnOwnLines(unittest.TestCase):
             cls.kernel.wait()
         shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
 
-    def _drive(self, script, name):
+    def _drive(self, script, name, rows=True):
+        """rows: True drives the shipped default (nothing written to the settings store); False writes the
+        one-group-per-row setting off before the page loads."""
         cfg = os.path.join(self.lab, name + ".json")
         with open(cfg, "w") as f:
-            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "rows": rows,
                        "visible": len([s for s in SESSIONS if s[2] != "archived"]) + 1,   # web-search has two copies
                        "twoTag": next(sid for (n, sid, _t) in SESSIONS if n == "web-search"),
                        "shots": os.environ.get("TABROWS_SHOTS", "")}, f)
@@ -214,7 +224,7 @@ class ServedGroupsOnOwnLines(unittest.TestCase):
             if "tab-group-head" in cls:
                 cur = (it["group"], it, [])
                 out.append(cur)
-            elif "tab-group-break" in cls and "tab-group-sep" in cls:
+            elif "tab-group-sep" in cls:   # the trail's boundary: the break under the setting, the divider with it off
                 cur = (None, None, [])
                 out.append(cur)
             elif "tab" in cls and it["id"] and cur is not None:
@@ -250,6 +260,7 @@ class ServedGroupsOnOwnLines(unittest.TestCase):
         return secs
 
     def test_every_group_starts_on_its_own_line_and_a_fold_leaves_the_header_row_alone(self):
+        # the shipped default: nothing written to the settings store, so this is what a fresh browser shows
         r = self._drive(DRIVER, "rows")
         o, clicked, l = r["open"], r["clicked"], r["light"]
         # the world: eight visible tabs (the archived group starts folded, its one member hidden), three headers,
@@ -296,6 +307,29 @@ class ServedGroupsOnOwnLines(unittest.TestCase):
         # LIGHT theme: the same geometry
         self.assertIn("theme-light", l["theme"])
         self._check_rows(l, "light")
+
+    def test_with_the_setting_off_the_strip_flows_inline_no_breaks_and_the_trail_behind_its_divider(self):
+        # the gear's "One tag group per row in the tab strip" turned off (written to the settings store before the
+        # page loads): the strip emits no row break, a group's header is followed by its tabs with nothing between,
+        # and the untagged trail stands behind a visible 13px divider
+        o = self._drive(DRIVER, "inline", rows=False)["open"]
+        self.assertEqual(o["breaks"], 0, "no row break with the setting off: %r" % [i["cls"] for i in o["items"]])
+        self.assertEqual(len(o["seps"]), 1, "one trail boundary: %r" % o["seps"])
+        self.assertEqual(round(o["seps"][0]["w"]), 13, "the divider is a 13px box: %r" % o["seps"])
+        self.assertGreater(o["seps"][0]["h"], 0, "…and visible: %r" % o["seps"])
+        secs = self._sections(o["items"])
+        self.assertEqual([g for g, _h, _t in secs], ["web", "infra", "archived", None], "three groups in tag order, then the trail: %r" % secs)
+        by_name = {n: sid for (n, sid, _t) in SESSIONS}
+        want = {"web": ["web-frontend", "web-backend", "web-gateway", "web-search", "web-billing"],
+                "infra": ["web-search", "infra-ci", "infra-deploy"], "archived": [], None: ["scratch"]}
+        for g, _h, tabs in secs:
+            # membership, not order: within a group the strip orders tabs by the user's order and recency, and
+            # _sections already proves contiguity (every tab between this header and the next belongs here)
+            self.assertCountEqual([t["id"] for t in tabs], [by_name[n] for n in want[g]], "%r: its tabs, contiguous after its header, nothing else between: %r" % (g, tabs))
+        # nothing of zero height sits in the strip besides the T134 hairlines (a break spans the row at zero height):
+        # every item is a header, a tab or the divider
+        zero = [i for i in o["items"] if i["h"] == 0 and "tab-row-line" not in i["cls"].split()]
+        self.assertEqual(zero, [], "no zero-height item (a break) with the setting off: %r" % zero)
 
 
 if __name__ == "__main__":

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -104,6 +104,10 @@ var GEAR_HTML =
   '<span><b>Show git branch</b>' +
   "<span class=rs-sub>Show the session's git branch (when it's in a repo) in the chat bottom bar, beside the directory.</span>" +
   '</span></label>' +
+  '<label class=rs-row><input type=checkbox id=rs-striprows checked>' +
+  '<span><b>One tag group per row in the tab strip</b>' +
+  '<span class=rs-sub>With the tabs grouped by tag, each group starts on its own row with its tag at the left edge. Off, the groups follow one another across the strip and wrap as they need, so many tags do not mean many rows.</span>' +
+  '</span></label>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto;min-width:0'><b>Context gauge in tabs</b>" +
   "<span class=rs-sub>A slim vertical bar beside each session's name in the tab strip, filling as its context fills — the same colors as the context battery, no number. By default it appears only once a session is half full, so quiet tabs stay clean.</span>" +
   "<select id=rs-tabctx style='display:none'>" +
@@ -227,6 +231,7 @@ function initGear(post) {
     csg = document.getElementById('rs-suggestcompact'),
     dd = document.getElementById('rs-defaultdir'), gb = document.getElementById('rs-branch'),
     tc = document.getElementById('rs-tabctx'),
+    sr = document.getElementById('rs-striprows'),
     cs = document.getElementById('rs-chatscheme'),
     tt = document.getElementById('rs-theme'),
     cg = document.getElementById('rs-collapsegaps'), ao = document.getElementById('rs-activeonly'),
@@ -242,7 +247,7 @@ function initGear(post) {
     fe = document.getElementById('rs-fileedit'),
     ths = document.getElementById('rs-thinksum'),
     ans = document.getElementById('rs-autonudge-split'), asub = document.getElementById('rs-autonudge-sub');
-  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true, activeOnly: true }; } }
+  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', stripGroupRows: true, collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', stripGroupRows: true, collapseGaps: true, activeOnly: true }; } }
   // mirrors settings.ts tabCtxMode (this file can't import the TS module): the gauge shipped for a
   // few hours as a boolean toggle — false was an explicit hide, true the default nobody chose.
   function tabCtxMode(v) { return (v === 'always' || v === 'never') ? v : (v === false ? 'never' : 'over50'); }
@@ -261,6 +266,8 @@ function initGear(post) {
   }
   cc.addEventListener('change', function () { var s = load(); s.compact = cc.checked; save(s); });
   if (gb) gb.addEventListener('change', function () { var s = load(); s.showBranch = gb.checked; save(s); });
+  // one tag group per row in the tab strip (on by default); render.ts repaints the strip on the save
+  if (sr) sr.addEventListener('change', function () { var s = load(); s.stripGroupRows = sr.checked; save(s); });
   if (tc) tc.addEventListener('change', function () { var s = load(); s.tabCtx = tc.value; save(s); });
   // ── the settings' value-picker DROPDOWNS (T117, the user 2026-08-27, screenshot: the Chat
   // tabs and Text scheme pickers rendered every option always-expanded, and the description spans
@@ -1189,7 +1196,7 @@ function initGear(post) {
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
     try { if (window.parent !== window) window.parent.postMessage({ romp: 'logUnseenQuery' }, '*'); } catch (e) { /* no shell to ask */ }   // T290: the Open log count
-    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); paintBackendOffer(tb ? tb.checked : false); if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (sr) sr.checked = s.stripGroupRows !== false; if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); paintBackendOffer(tb ? tb.checked : false); if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   // The shortcuts row: the web shell (same-origin parent) gets the customize link — it opens the

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5349,7 +5349,9 @@ function releaseTabStrip(): void {
 // unplanned; and the header holding the active tab is a labeled group, not a button — it takes no
 // action and no focus, and "button, expanded" promised both.
 function makeGroupHead(sec: TabSection, collapsed: boolean, holdsActive: boolean, hidden: readonly string[]): HTMLElement {
-  if (sec.name === null) return makeRowBreak(true);
+  // the untagged trail (unlabeled by the user's ruling): a row of its own under the one-group-per-row
+  // setting, else behind a divider
+  if (sec.name === null) return settings.stripGroupRows ? makeRowBreak(true) : makeTrailSep();
   const name = sec.name;
   const head = el("div", "tab-group-head" + (collapsed ? " collapsed" : "") + (holdsActive ? " holds-active" : ""));
   head.dataset.group = name;
@@ -5445,14 +5447,26 @@ function makeGroupHead(sec: TabSection, collapsed: boolean, holdsActive: boolean
  *  untagged trail's break also wears .tab-group-sep, the boundary sectionHeadOf reads (the trail
  *  stays unlabeled by the user's ruling — its own line, with no chip, says "in no tag"). Breaks are
  *  layout only: no drop, no hover, not a row for paintTabRowLines, and in the tab drag's virtual
- *  layout the box AFTER a break starts a row (`br`) so the simulation wraps where the strip does. */
+ *  layout the box AFTER a break starts a row (`br`) so the simulation wraps where the strip does.
+ *  Breaks are emitted only under the `stripGroupRows` setting (the gear's "One tag group per row in
+ *  the tab strip", on by default): with it off the groups follow one another and wrap as they need,
+ *  and the trail stands behind makeTrailSep's divider. */
 function makeRowBreak(untagged: boolean): HTMLElement {
   const brk = el("div", "tab-group-break" + (untagged ? " tab-group-sep" : ""));
   brk.setAttribute("aria-hidden", "true");
   return brk;
 }
+/** The untagged trail's DIVIDER with the one-group-per-row setting off: a visible 13px item, a 1px line
+ *  between 6px gutters, so the last group's tabs and the loose ones never read as one run. It wears
+ *  .tab-group-sep (the boundary sectionHeadOf reads, and the drop's group edge) and takes its width
+ *  in the layout (padding, not margin), so the tab drag's virtual layout measures it. */
+function makeTrailSep(): HTMLElement {
+  const sep = el("div", "tab-group-sep");
+  sep.title = "sessions in no tag";
+  return sep;
+}
 /** The section header a strip node belongs to: itself for a header, else the nearest header before
- *  it; null past the untagged boundary (the trail's row break) or on a flat strip. */
+ *  it; null past the untagged boundary (the trail's row break, or its divider) or on a flat strip. */
 function sectionHeadOf(node: HTMLElement): HTMLElement | null {
   let n: Element | null = node;
   while (n) {
@@ -5790,14 +5804,15 @@ function renderTabs() {
   // tag-lens menu's "Group tabs by tag") and some tag holding a visible tab, the strip renders one
   // header per tag in tagOrder holding a visible tab, each tab under EVERY tag it carries (T264b, the
   // user 2026-09-08: tags are equivalent — a session under N tags has a copy in N groups), then that
-  // section's tabs, and the untagged trail — the sessions in no tag — on its own line
-  // (tab-groups.ts owns the rule). A folded section renders its header alone, with the count and
-  // a pip when a member is working or blocked, so the gist survives the fold (progressive
-  // disclosure). The ACTIVE tab's section never renders folded — keyboard focus must never land
-  // on a hidden node — and visibleOrder() drops the folded ids so ←/→ skip them. DESKTOP ONLY: on
-  // the phone layout (phoneLayout — the kernel page's own media rule) the plan is the flat strip,
-  // since the phone's session list is scraped from every rendered tab and has no header to unfold.
-  // A create in flight (the provisional tab) sections under the tags its request named.
+  // section's tabs, and the untagged trail (the sessions in no tag) on its own line, or behind a
+  // divider with the one-group-per-row setting off (tab-groups.ts owns the rule). A folded section
+  // renders its header alone, with the count and a pip when a member is working or blocked, so the
+  // gist survives the fold (progressive disclosure). The ACTIVE tab's section never renders folded —
+  // keyboard focus must never land on a hidden node — and visibleOrder() drops the folded ids so ←/→
+  // skip them. DESKTOP ONLY: on the phone layout (phoneLayout — the kernel page's own media rule) the
+  // plan is the flat strip, since the phone's session list is scraped from every rendered tab and has
+  // no header to unfold. A create in flight (the provisional tab) sections under the tags its request
+  // named.
   const unions = viewTagUnion(effViews());
   const plan = planStrip(visibleIds, unions, readTabGroups(unions), activeId, phoneLayout(),
                          provisionalId ? { id: provisionalId, tags: provisionalTags } : null);
@@ -5808,7 +5823,8 @@ function renderTabs() {
   // it is folded or holds the active tab, and the members its folded header stands in for (the header's
   // chip, count and pip read those; the pip's state and names come from the per-id records) — and per
   // visible id either a placeholder's meta or the session's name, color, state and its tab class, faded,
-  // context and its tint, viewer flag, host-down mark and note; plus the context-gauge setting, the theme
+  // context and its tint, viewer flag, host-down mark and note; plus the context-gauge setting, the
+  // one-group-per-row setting (the row breaks and the trail's boundary read it), the theme
   // and the colormap (the gauge's tone and fallback read the theme — pickTone, ctxFallbackColor — and the
   // compacting sweep's gradient the colormap, so a settings change repaints through this signature), the +
   // tab's key hint, and the tag lens and unions the filter chips render. Equal string, same DOM: the guards
@@ -5821,7 +5837,7 @@ function renderTabs() {
   // input missing here is a repaint that never happens.
   const stripSig = JSON.stringify([
     activeId, peekId, ids, visibleIds, activeId ? tabInView(activeId) : null, plan.items,
-    settings.tabCtx, settings.theme, settings.colormap, titleWithKey("Open a session", "session.new"),
+    settings.tabCtx, settings.stripGroupRows, settings.theme, settings.colormap, titleWithKey("Open a session", "session.new"),
     surfaceLens(effViews(), "chat"), unions,
     visibleIds.map((id) => {
       const s = sessions.get(id), down = hostIsDown(id), note = down ? hostDownNote(id) : "";
@@ -5861,9 +5877,11 @@ function renderTabs() {
   let copyGroup: string | null | undefined;
   for (const item of plan.items) {
     if ("head" in item) {
-      // every group on its own line (T264): a row break ahead of each header — except the strip's
-      // first item, which already opens the first row; the untagged trail's header IS a break
-      if (item.head.name !== null && bar.childElementCount) bar.appendChild(makeRowBreak(false));
+      // every group on its own line (T264), under the one-group-per-row setting: a row break ahead of
+      // each header except the strip's first item, which already opens the first row; the untagged
+      // trail's header IS a break. With the setting off, heads and tabs follow one another and wrap
+      // as they need, and the trail stands behind its divider (makeGroupHead).
+      if (settings.stripGroupRows && item.head.name !== null && bar.childElementCount) bar.appendChild(makeRowBreak(false));
       bar.appendChild(makeGroupHead(item.head, item.folded, item.active, item.hidden));
       copyGroup = item.head.name;
       continue;
@@ -16588,11 +16606,13 @@ setupSettings();
     // the virtual layout: the OTHER tabs in current DOM order, widths from the dragstart snapshot —
     // boundaries that cannot move in response to the insert they cause (dragslot.ts owns the math)
     // …plus the section headers (tab groups): they take width in the real layout, so they join the
-    // virtual one as boxes — the simulated wrap then matches the strip's. One group per line (T264):
-    // a header preceded by a row break OPENS a row in the simulation (`br`), as does the untagged
-    // trail's break itself — a zero-width row opener, so the slot past a group's last tab (the end
-    // of its row) and the slot before the trail's first tab (the head of the next row) stay two
-    // distinct slots, as they were when the trail stood behind a visible separator. A drop changes
+    // virtual one as boxes — the simulated wrap then matches the strip's. One group per line (T264,
+    // under the one-group-per-row setting): a header preceded by a row break OPENS a row in the
+    // simulation (`br`), as does the untagged trail's break itself, a zero-width row opener, so the
+    // slot past a group's last tab (the end of its row) and the slot before the trail's first tab
+    // (the head of the next row) stay two distinct slots, as they were when the trail stood behind a
+    // visible separator. With the setting off the trail's divider is a real 13px box and no break
+    // exists, so the boxes below measure it as they did before T264. A drop changes
     // no membership (the tab re-sections on the next render); "Move to" in the tab menu is the
     // membership path.
     const others = Array.from(tabs.querySelectorAll<HTMLElement>(".tab[data-id], .tab-group-head, .tab-group-sep")).filter((t) => t !== dragged);
@@ -16635,11 +16655,12 @@ setupSettings();
     // the neighbours are TABS IN THE DRAGGED COPY'S OWN GROUP first (T264b): a drop at a group's head
     // used to anchor on the group above's last tab — a tab whose place in the global order says
     // nothing about the group dragged in — so the drop landed elsewhere and the session's other copy
-    // jumped. The walk stops at a header or a row break; only a group holding no other tab falls back
+    // jumped. The walk stops at a header, a row break or the trail's divider (.tab-group-sep, its
+    // boundary with the one-group-per-row setting off); only a group holding no other tab falls back
     // to the nearest tab across groups (the flat strip has no edges, so it walks as it always did).
     // Never the dragged SESSION's own copy: reorderTo against itself would move nothing.
     const own = (n: Element | null) => !!n && (n as HTMLElement).dataset?.id === draggedId;
-    const edge = (n: Element) => n.classList.contains("tab-group-head") || n.classList.contains("tab-group-break");
+    const edge = (n: Element) => n.classList.contains("tab-group-head") || n.classList.contains("tab-group-break") || n.classList.contains("tab-group-sep");
     const walk = (n: Element | null, step: (x: Element) => Element | null, inGroup: boolean): HTMLElement | null => {
       while (n && (!(n as HTMLElement).dataset?.id || own(n))) { if (inGroup && edge(n)) return null; n = step(n); }
       return n as HTMLElement | null;

--- a/ui/webview/settings.test.ts
+++ b/ui/webview/settings.test.ts
@@ -33,6 +33,17 @@ test("Compact transcript defaults ON (the user 2026-07-14): fresh installs read 
   assert.equal(DEFAULT_SETTINGS.compact, true);
 });
 
+// The tab strip's one-group-per-row layout (T264) is the default and a per-device pick: an explicit false
+// lets the groups follow one another across the strip and wrap as they need (render.ts renderTabs).
+test("stripGroupRows defaults ON: every tag group on its own row; an explicit false round-trips, and a store from before the key reads as on", () => {
+  assert.equal(DEFAULT_SETTINGS.stripGroupRows, true);
+  store["romp:settings"] = JSON.stringify({ stripGroupRows: false });
+  assert.equal(loadSettings().stripGroupRows, false, "the opt-out round-trips");
+  store["romp:settings"] = JSON.stringify({});
+  assert.equal(loadSettings().stripGroupRows, true, "a store from before the key reads as on");
+  delete store["romp:settings"];
+});
+
 // The settings change signal must cover every way a change can happen: another
 // same-origin tab (storage event), THIS document (the gear now lives in the same
 // page — same-document writes never fire storage), and another VS Code webview

--- a/ui/webview/settings.ts
+++ b/ui/webview/settings.ts
@@ -17,6 +17,7 @@ export interface RompSettings {
   defaultDir: string;        // default working directory PREFILLED in the new-session field (the user 2026-06-22). A session starts there; the tab menu's "Move to folder…" can change it later. Empty → the kernel's serve dir. ~ / $VAR expanded server-side.
   showBranch: boolean;       // chat bottom-bar: show the session's git branch (if any) beside the dir (the user 2026-06-23). OFF by default (the user 2026-08-10, trimming the statusline for narrow panes; an explicit stored true keeps showing it).
   tabCtx: TabCtxMode;        // chat tabs: WHEN the context gauge shows beside each session name (the user 2026-08-08) — "over50" (default: only once half full, so quiet tabs stay clean), "always", or "never".
+  stripGroupRows: boolean;   // chat tabs, grouped by tag: start EVERY tag group on its own row (T264, the row breaks in render.ts). ON by default; off, the groups follow one another across the strip and wrap as they need, the untagged trail behind its divider. Per browser profile, like every setting here. Read by renderTabs and part of the strip's rebuild signature, so a gear flip repaints at once.
   chatScheme: ChatScheme;    // chat TEXT scheme (the user 2026-08-24): raises body-text contrast without collapsing the tool-dimmer-than-prose hierarchy. A scheme = a text-tier variable set (styles.css body.scheme-*); "default" applies nothing — today's values exactly.
   chatTabTheme: ChatTabTheme;   // LEGACY, derived (2026-08-28): the chat TAB STRIP's appearance (T113). Now computed from `theme` on every load/save ("classic" -> classic strip, anything else -> the yatharth strip) so older panes/extension builds keep working; never set it directly.
   theme: Theme;   // the OVERALL dashboard theme (the user 2026-08-27, promoting the tab-strip setting): "classic" = the pre-720 dark look; "yatharth" = dark + the contributed strip aesthetic (what chatTabTheme:"yatharth" was); "yatharth-light" = the warm light theme (body.theme-light + the yatharth strip). Migration: a store written before `theme` existed seeds it from chatTabTheme.
@@ -50,7 +51,7 @@ export function tabCtxMode(v: unknown): TabCtxMode {
 // hand-written "why" as their line; they show the distiller's summary instead (the why demotes to a hover).
 // compact defaults ON (the user 2026-07-14): a fresh install reads the tidy transcript
 // (thinking hidden, tool runs folded); the gear opts back into the full stream.
-export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, tabCtx: "over50", chatScheme: "default", chatTabTheme: "classic", theme: "classic" };
+export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, tabCtx: "over50", stripGroupRows: true, chatScheme: "default", chatTabTheme: "classic", theme: "classic" };
 const KEY = "romp:settings";
 
 export function loadSettings(): RompSettings {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -407,11 +407,19 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
    or the untagged trail's first tab — opens a new line: the chip sits at the left edge and its tabs
    follow, wrapping onto further rows as they need. Zero height, so it adds no rhythm of its own
    (the Yatharth seam is a column gap only); no pointer, so it can neither take a drop nor a hover.
-   The visible separator the untagged trail used to stand behind is gone — a line of its own, with
-   no chip, already says "in no tag" (the trail stays unlabeled by the user's ruling); the element
-   keeps the .tab-group-sep class as the boundary sectionHeadOf reads. The tab drag's virtual layout
+   The breaks are emitted only while the gear's "One tag group per row in the tab strip" is on
+   (stripGroupRows, the default; render.ts renderTabs). Under it the untagged trail stands behind no
+   visible divider: a line of its own, with no chip, already says "in no tag" (the trail stays
+   unlabeled by the user's ruling); the element keeps the .tab-group-sep class as the boundary
+   sectionHeadOf reads. With the setting off the divider below returns. The tab drag's virtual layout
    (dragslot.ts) opens a row at the same places (`br`), so a drag wraps where the strip wraps. */
 .tab-group-break { flex: 0 0 100%; height: 0; margin: 0; padding: 0; pointer-events: none; }
+/* THE UNTAGGED TRAIL'S DIVIDER with the one-group-per-row setting off (render.ts makeTrailSep): a 1px
+   line between 6px gutters. The gutters are PADDING, not margin, and the line is the content box, so
+   its box is the full 13px it occupies in the row and the tab drag's virtual layout (which measures
+   getBoundingClientRect widths) wraps where the real strip wraps. Scoped off the row break above,
+   which wears .tab-group-sep too (the boundary sectionHeadOf reads) and must keep no box. */
+.tab-group-sep:not(.tab-group-break) { flex: 0 0 auto; box-sizing: border-box; width: 13px; padding: 8px 6px; background: var(--box-border); background-clip: content-box; }
 /* (the settings gear + modal live on the TIMELINE now — see ui/romp-timeline-view.js) */
 
 .tab {

--- a/ui/webview/tab-drag-live.test.ts
+++ b/ui/webview/tab-drag-live.test.ts
@@ -48,13 +48,20 @@ test("the slot comes from the VIRTUAL layout — boundaries that cannot move und
   // may carry a horizontal margin, or the virtual row holds more than the real one and the slot
   // hops in a band at every wrap boundary (the separator's 6px gutters were margin: a 12px drift)
   assert.match(body, /\?\? t\.getBoundingClientRect\(\)\.width,\s*\n\s*br: isBreak\(t\) \|\| isBreak\(before\(t\)\) \}\)\);/);
-  // T264: the untagged trail's boundary is a zero-height ROW BREAK (the visible 13px separator is gone) —
-  // not a box in the real layout, so it joins the virtual one as a zero-width row opener (w: 0, br), and
-  // a header after a break opens a row too; the simulation then wraps exactly where the strip does
+  // T264 (under the one-group-per-row setting, on by default): the untagged trail's boundary is a zero-height
+  // ROW BREAK, not a box in the real layout, so it joins the virtual one as a zero-width row opener (w: 0, br),
+  // and a header after a break opens a row too; the simulation then wraps exactly where the strip does
   const brk = CSS.match(/^\.tab-group-break \{[^}]*\}/m)![0];
   assert.match(brk, /flex: 0 0 100%; height: 0; margin: 0; padding: 0;/, "the break spans the row and has no box of its own");
   assert.match(body, /w: isBreak\(t\) \? 0 : /, "…so it measures 0 in the virtual layout, never its full-row rect");
-  assert.doesNotMatch(CSS, /^\.tab-group-sep \{/m, "no separator rule remains to give the boundary a width");
+  // with the setting off the trail's boundary is the 13px divider, a real box the virtual layout measures by its
+  // rect, whose gutters are padding (a margin would drift the simulated row); its rule is scoped off the break
+  assert.doesNotMatch(CSS, /^\.tab-group-sep \{/m, "no unscoped separator rule: the break's boundary class gives it no box");
+  const sepM = CSS.match(/^\.tab-group-sep:not\(\.tab-group-break\) \{[^}]*\}/m);
+  assert.ok(sepM, "the divider's rule exists, scoped off the break");
+  const sep = sepM[0];
+  assert.match(sep, /width: 13px; padding: 8px 6px;/, "the divider's footprint is its box");
+  assert.doesNotMatch(sep, /margin/, "no margin on the divider: the virtual row holds what the real one holds");
   const head = CSS.match(/^\.tab-group-head \{[^}]*\}/m)![0];
   assert.doesNotMatch(head, /margin/, "headers carry no horizontal margin either");
   assert.match(body, /dragSlotIndex\(boxes, dragGeom\.containerW, dragGeom\.gapX, dragGeom\.rowH,/);

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -15,10 +15,13 @@ import { sectionTabs, anySectioned, parseTabGroups, readTabGroups, writeTabGroup
          DEFAULT_COLLAPSED, sectionRef, isPinned, setPinned, togglePinned, prunePinned, reachableFrom, tagRenames, followTagRenames, followAdoption,
          sameTagNames, headWords, type TabSection, type SectionRef, type TabGroupsState } from "./tab-groups";
 import { sectionPipTitle } from "./tab-state";
+import { DEFAULT_SETTINGS } from "./settings";
 
 const ui = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", ...p), "utf8");
 const RENDER = ui("webview", "render.ts");
 const CSS = ui("webview", "styles.css");
+const GEAR = ui("webview", "gear.js");
+const SETTINGS = ui("webview", "settings.ts");
 const MENU = ui("webview", "tag-menu.ts");
 const VIEWS = ui("webview", "session-views.ts");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
@@ -123,8 +126,9 @@ test("the strip renders sections when the switch is on and some tag holds a visi
   assert.match(RENDER, /const unions = viewTagUnion\(effViews\(\)\);\s*\n\s*const plan = planStrip\(visibleIds, unions, readTabGroups\(unions\), activeId, phoneLayout\(\),/,
     "the pure module owns the rule; the phone layout and the create in flight are its inputs");
   assert.match(RENDER, /collapsedTabIds = plan\.folded;/);
-  assert.match(RENDER, /if \("head" in item\) \{\s*\n(?:\s*\/\/[^\n]*\n)*\s*if \(item\.head\.name !== null && bar\.childElementCount\) bar\.appendChild\(makeRowBreak\(false\)\);\s*\n\s*bar\.appendChild\(makeGroupHead\(item\.head, item\.folded, item\.active, item\.hidden\)\);\s*\n\s*copyGroup = item\.head\.name;\s*\n\s*continue;\s*\n\s*\}/,
-    "a header paints from the plan (T264: on its own line — the break ahead of it; T264b: it names the group the copies below sit in)");
+  // the break ahead of a header is emitted under the one-group-per-row setting (stripGroupRows, on by default)
+  assert.match(RENDER, /if \("head" in item\) \{\s*\n(?:\s*\/\/[^\n]*\n)*\s*if \(settings\.stripGroupRows && item\.head\.name !== null && bar\.childElementCount\) bar\.appendChild\(makeRowBreak\(false\)\);\s*\n\s*bar\.appendChild\(makeGroupHead\(item\.head, item\.folded, item\.active, item\.hidden\)\);\s*\n\s*copyGroup = item\.head\.name;\s*\n\s*continue;\s*\n\s*\}/,
+    "a header paints from the plan (T264: on its own line under the setting, opened by the break ahead of it; T264b: it names the group the copies below sit in)");
 });
 
 test("executed: planStrip — sections + folds; the flat strip when off or untagged; the ACTIVE tab's section never folds", () => {
@@ -262,7 +266,10 @@ test("a folded section renders its header alone with the folded-away count and o
   assert.ok(head.indexOf('el("span", "tab-group-count")') < head.indexOf("sectionPip("), "after the count (the row's last child when folded, T284)");
   assert.ok(!head.includes("tabStateClass("), "the header itself wears no state class");
   assert.ok(!head.includes('"tab-dot"'), "never a .tab-dot — the kernel's mobile scrape keys on the tab pips' vocabulary");
-  assert.match(head, /if \(sec\.name === null\) return makeRowBreak\(true\);/, "the untagged trail is UNLABELED (the ruling): its own row with no chip, not a header (T264)");
+  // the trail is never a header: its own row with no chip under the one-group-per-row setting (T264), a 13px
+  // divider with the setting off
+  assert.match(head, /if \(sec\.name === null\) return settings\.stripGroupRows \? makeRowBreak\(true\) : makeTrailSep\(\);/,
+    "the untagged trail is UNLABELED (the ruling): never a header; its own row with no chip under stripGroupRows (T264), the divider otherwise");
   // the tab's own class comes from the same function
   assert.match(RENDER, /const stateCls = tabStateClass\(s\.status\);\s*\n\s*if \(stateCls\) tab\.classList\.add\(stateCls\);/);
   assert.match(CSS, /\.tab-group-pip \{ flex: 0 0 auto; width: 6px; height: 6px; border-radius: 50%; background: var\(--st-working-bg\); \}/, "small: subordinate to the label");
@@ -363,17 +370,22 @@ test("the section chrome is a LABEL's (the user 2026-09-06): the surface's sub-l
   assert.doesNotMatch(CSS, /\.tab-group-dot/, "the dot is gone");
   const sizes = new Set(Array.from(CSS.matchAll(/\n\.tab-group-[^{\n]*\{[^}]*font-size: ([^;]+);/g)).map((m) => m[1]));
   assert.deepEqual([...sizes], ["0.82em"], "one font-size across every section rule");
-  assert.doesNotMatch(CSS, /\.tab-group-sep \{/, "the visible separator is gone (T264): the untagged trail opens its own row instead");
+  // the divider the trail stands behind with the one-group-per-row setting off is scoped off the row break,
+  // which wears .tab-group-sep too (the boundary sectionHeadOf reads) and must keep no box
+  assert.doesNotMatch(CSS, /\.tab-group-sep \{/, "no unscoped separator rule: the break's boundary class must not give it a box");
+  assert.match(CSS, /\.tab-group-sep:not\(\.tab-group-break\) \{ flex: 0 0 auto; box-sizing: border-box; width: 13px; padding: 8px 6px; background: var\(--box-border\); background-clip: content-box; \}/,
+    "the divider's rule: a 13px box whose gutters are padding");
 });
 
-// ── T264 (the user 2026-09-08): every tag group on its own line ──────────────────────────────────────────
-test("every group opens a new line: a zero-height full-width break ahead of each header, the trail's break doubling as the boundary (T264)", () => {
+// ── T264 (the user 2026-09-08): every tag group on its own line, under the stripGroupRows setting (on by default) ──
+test("under the setting (on by default), every group opens a new line: a zero-height full-width break ahead of each header, the trail's break doubling as the boundary (T264)", () => {
   // the strip read as one long concatenation; now the chip sits at the left edge, its tabs follow it
-  // and wrap onto further rows as they need, and the next group starts a fresh line
+  // and wrap onto further rows as they need, and the next group starts a fresh line. The breaks are
+  // emitted under the one-group-per-row setting (the next test runs the gate at both values)
   const loop = RENDER.slice(RENDER.indexOf("collapsedTabIds = plan.folded;"), RENDER.indexOf("const id = item.id;"));
-  assert.match(loop, /if \(item\.head\.name !== null && bar\.childElementCount\) bar\.appendChild\(makeRowBreak\(false\)\);\s*\n\s*bar\.appendChild\(makeGroupHead\(item\.head, item\.folded, item\.active, item\.hidden\)\);/,
-    "a break before every header but the strip's first item (which already opens the first row)");
-  const brk = RENDER.slice(RENDER.indexOf("function makeRowBreak("), RENDER.indexOf("function sectionHeadOf("));
+  assert.match(loop, /if \(settings\.stripGroupRows && item\.head\.name !== null && bar\.childElementCount\) bar\.appendChild\(makeRowBreak\(false\)\);\s*\n\s*bar\.appendChild\(makeGroupHead\(item\.head, item\.folded, item\.active, item\.hidden\)\);/,
+    "under the setting, a break before every header but the strip's first item (which already opens the first row)");
+  const brk = RENDER.slice(RENDER.indexOf("function makeRowBreak("), RENDER.indexOf("function makeTrailSep("));
   assert.match(brk, /el\("div", "tab-group-break" \+ \(untagged \? " tab-group-sep" : ""\)\)/,
     "the untagged trail's break keeps the .tab-group-sep class — the boundary sectionHeadOf reads");
   assert.match(brk, /brk\.setAttribute\("aria-hidden", "true"\);/, "layout only: nothing to read aloud");
@@ -385,6 +397,81 @@ test("every group opens a new line: a zero-height full-width break ahead of each
   assert.match(sh, /if \(h\.classList\.contains\("tab-group-sep"\)\) return null;/);
   // the header's own rule is unchanged: flex-none, the chip first in its row
   assert.match(CSS, /\.tab-group-head \{ display: flex; flex: 0 0 auto; align-items: center;/);
+});
+
+// ── the one-group-per-row setting (stripGroupRows, on by default): off, the groups follow one another across the strip ──
+test("executed + pinned: the one-group-per-row setting is on by default; off, the strip emits NO break, a group's head and tabs stay contiguous and the trail stands behind a divider; the gear's row", () => {
+  // the setting and its default (executed: the real defaults object)
+  assert.equal(DEFAULT_SETTINGS.stripGroupRows, true, "on by default: every tag group on its own row");
+  assert.match(SETTINGS, /stripGroupRows: boolean;/);
+  // the loop's head branch appends the break and the header, nothing else, and the break is the ONE gated append;
+  // the gate itself is executed here off the source text: on, every head but the first gets a break; off, none
+  const loop = RENDER.slice(RENDER.indexOf("for (const item of plan.items) {"), RENDER.indexOf("const id = item.id;"));
+  assert.equal((loop.match(/makeRowBreak\(/g) ?? []).length, 1, "one break site in the loop");
+  assert.equal((loop.match(/bar\.appendChild\(/g) ?? []).length, 2, "the head branch appends the break (gated) and the header; nothing else sits between a head and its tabs");
+  const gate = loop.match(/if \((settings\.stripGroupRows && item\.head\.name !== null && bar\.childElementCount)\) bar\.appendChild\(makeRowBreak\(false\)\);/);
+  assert.ok(gate, "the break is gated on the setting");
+  const breaks = new Function("settings", "item", "bar", "return !!(" + gate![1] + ");") as (s: unknown, it: unknown, b: unknown) => boolean;
+  const heads = [{ head: { name: "web" } }, { head: { name: "api" } }, { head: { name: null } }];
+  assert.deepEqual(heads.map((it, i) => breaks({ stripGroupRows: true }, it, { childElementCount: i })), [false, true, false], "on: a break ahead of every header but the strip's first item; the trail's header is itself the break");
+  assert.deepEqual(heads.map((it, i) => breaks({ stripGroupRows: false }, it, { childElementCount: i })), [false, false, false], "off: no break ahead of any header, first or later, nor the trail's");
+  // the plan's items are contiguous per group (executed on the pure module): a head, then its tabs, then the next
+  // head; with no break appended the DOM is the plan in order, so the groups follow one another and wrap
+  const unions = viewTagUnion({ tags: [{ id: "t-infra", name: "infra", color: "#1EA1EB", members: ["web", "api"] },
+                                       { id: "t-qa", name: "qa", color: "#54B204", members: ["tests"] }] });
+  const plan = planStrip(["web", "api", "tests", "loose"], unions, parseTabGroups(null, unions), "web", false);
+  assert.deepEqual(plan.items.map((it) => ("head" in it ? "#" + (it.head.name ?? "null") : it.id)), ["#infra", "web", "api", "#qa", "tests", "#null", "loose"],
+    "each group's head is followed by its tabs and then the next head; the trail's head last");
+  // with the setting off the trail's boundary is a divider: a real 13px box wearing .tab-group-sep (the boundary
+  // sectionHeadOf reads and the drop's group edge), titled, no aria noise
+  const sep = RENDER.slice(RENDER.indexOf("function makeTrailSep("), RENDER.indexOf("function sectionHeadOf("));
+  assert.match(sep, /const sep = el\("div", "tab-group-sep"\);\s*\n\s*sep\.title = "sessions in no tag";\s*\n\s*return sep;/);
+  const drop = RENDER.slice(RENDER.indexOf('tabs.addEventListener("drop"'), RENDER.indexOf("tabDragCommitted = true; }"));
+  assert.match(drop, /const edge = \(n: Element\) => n\.classList\.contains\("tab-group-head"\) \|\| n\.classList\.contains\("tab-group-break"\) \|\| n\.classList\.contains\("tab-group-sep"\);/,
+    "the divider bounds the trail for the drop's in-group neighbour walk, as the break does under the setting");
+  // a gear flip repaints at once: the setting rides the strip's rebuild signature, and the settings listener calls renderTabs
+  assert.match(RENDER, /settings\.tabCtx, settings\.stripGroupRows, settings\.theme, settings\.colormap,/, "in the strip's signature");
+  assert.match(RENDER, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\); renderTabs\(\);/);
+  // the gear's row: a checkbox like Show git branch's, checked by default, saved through the same save() and filled at open
+  assert.match(GEAR, /<label class=rs-row><input type=checkbox id=rs-striprows checked>' \+\s*\n\s*'<span><b>One tag group per row in the tab strip<\/b>/);
+  assert.match(GEAR, /sr\.addEventListener\('change', function \(\) \{ var s = load\(\); s\.stripGroupRows = sr\.checked; save\(s\); \}\);/);
+  assert.match(GEAR, /if \(sr\) sr\.checked = s\.stripGroupRows !== false;/, "the default-ON fill: only an explicit false unchecks");
+  assert.equal((GEAR.match(/stripGroupRows: true/g) ?? []).length, 2, "the gear's defaults mirror agrees: on, in both of load()'s literals");
+  // the guide says so in one sentence (matched across its line wraps)
+  const sentence = "Every group starts on its own row; turning off the gear's **One tag group per row in the tab strip** lets the groups follow one another across the strip and wrap as they need, with the untagged sessions behind a thin divider, so a strip with many tags stays short.";
+  assert.match(GUIDE, new RegExp(sentence.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/ /g, "\\s+")));
+  assert.match(GUIDE, /the untagged sessions on a row of their\s+own at the end\./, "the paragraph's opening describes the default layout");
+});
+
+test("executed: the drop's in-group neighbour walk stops at the trail's divider, as it stops at a break or a header", () => {
+  // the walk's own source, lifted from the drop handler and run over a fake sibling chain; the replaces strip the
+  // body's TypeScript annotations, leaving plain JS for new Function
+  const drop = RENDER.slice(RENDER.indexOf('tabs.addEventListener("drop"'), RENDER.indexOf("tabDragCommitted = true; }"));
+  const src = drop.slice(drop.indexOf("const own = "), drop.indexOf("// committed only when"))
+    .replace(/: \(x: Element\) => Element \| null/g, "").replace(/\): HTMLElement \| null =>/g, ") =>")
+    .replace(/ as HTMLElement \| null/g, "").replace(/\(n as HTMLElement\)/g, "n")
+    .replace(/: Element \| null/g, "").replace(/: Element\)/g, ")").replace(/: boolean\)/g, ")");
+  assert.match(src, /const edge = /); assert.match(src, /const next = /);
+  const neighbours = new Function("dragged", "draggedId", src + "\nreturn { prev: prev?.dataset?.id ?? null, next: next?.dataset?.id ?? null };") as
+    (dragged: unknown, draggedId: string) => { prev: string | null; next: string | null };
+  type Fake = { classList: { contains(c: string): boolean }; dataset: { id?: string }; previousElementSibling: Fake | null; nextElementSibling: Fake | null };
+  const strip = (specs: { cls: string; id?: string }[]): Fake[] => {
+    const els = specs.map((s): Fake => ({ classList: { contains: (c) => s.cls.split(" ").includes(c) }, dataset: s.id ? { id: s.id } : {},
+                                          previousElementSibling: null, nextElementSibling: null }));
+    els.forEach((e, i) => { e.previousElementSibling = els[i - 1] ?? null; e.nextElementSibling = els[i + 1] ?? null; });
+    return els;
+  };
+  // the strip with the setting off: [#infra] a b | loose1 loose2 [+]; loose1 dropped where it stands, at the trail's head
+  const inline = [{ cls: "tab-group-head" }, { cls: "tab", id: "a" }, { cls: "tab", id: "b" }, { cls: "tab-group-sep" },
+                  { cls: "tab", id: "loose1" }, { cls: "tab", id: "loose2" }, { cls: "tab tab-add" }];
+  const bar = strip(inline);
+  assert.deepEqual(neighbours(bar[4], "loose1"), { prev: null, next: "loose2" },
+    "the divider bounds the trail: the drop anchors before the trail's next tab, never after the tagged group's last");
+  // under the setting the same boundary is the break, wearing both classes: the same edge
+  const rows = strip(inline.map((s) => (s.cls === "tab-group-sep" ? { cls: "tab-group-break tab-group-sep" } : s)));
+  assert.deepEqual(neighbours(rows[4], "loose1"), { prev: null, next: "loose2" }, "the trail's break is the edge under the setting");
+  // inside a group the walk names the tab before, and the group's end bounds the tab after
+  assert.deepEqual(neighbours(bar[2], "b"), { prev: "a", next: null }, "b sits after a; the divider ends its group");
 });
 
 test("the tab drag's virtual layout wraps where the strip wraps: headers after a break and the trail's break open rows (T264)", () => {
@@ -1679,10 +1766,11 @@ test("the tab drag moves THIS copy and reorders within its group's neighbours (T
   // the drop's neighbours skip the session's own copy in the group next door — reorderTo against itself moves nothing
   const drop = RENDER.slice(RENDER.indexOf('tabs.addEventListener("drop"'), RENDER.indexOf("tabDragCommitted = true; }"));
   assert.match(drop, /const own = \(n: Element \| null\) => !!n && \(n as HTMLElement\)\.dataset\?\.id === draggedId;/);
-  // the neighbours come from the dragged copy's OWN group first: the walk stops at a header or a row break,
-  // and only a group holding no other tab falls back to the nearest tab across groups (a drop at a group's
-  // head used to anchor on the group above's last tab, so the session's other copy jumped)
-  assert.match(drop, /const edge = \(n: Element\) => n\.classList\.contains\("tab-group-head"\) \|\| n\.classList\.contains\("tab-group-break"\);/);
+  // the neighbours come from the dragged copy's OWN group first: the walk stops at a header, a row break or
+  // the trail's divider (its boundary with the one-group-per-row setting off), and only a group holding no
+  // other tab falls back to the nearest tab across groups (a drop at a group's head used to anchor on the
+  // group above's last tab, so the session's other copy jumped)
+  assert.match(drop, /const edge = \(n: Element\) => n\.classList\.contains\("tab-group-head"\) \|\| n\.classList\.contains\("tab-group-break"\) \|\| n\.classList\.contains\("tab-group-sep"\);/);
   assert.match(drop, /while \(n && \(!\(n as HTMLElement\)\.dataset\?\.id \|\| own\(n\)\)\) \{ if \(inGroup && edge\(n\)\) return null; n = step\(n\); \}/);
   assert.match(drop, /const prev = prevIn \?\? \(nextIn \? null : walk\(dragged\.previousElementSibling, back, false\)\);/);
   assert.match(drop, /const next = nextIn \?\? \(prevIn \? null : walk\(dragged\.nextElementSibling, fwd, false\)\);/);

--- a/ui/webview/tab-strip-skip-exec.test.ts
+++ b/ui/webview/tab-strip-skip-exec.test.ts
@@ -88,7 +88,10 @@ function lift(): (hooks: Hooks) => Api {
     let tabStripSig = "", activeId = null, peekId = null, allHiddenBlanked = false, draggedId = null, draggedEl = null, tabDragCommitted = false;
     let order = [], closingTabs = new Set(), tabMeta = new Map(), sessions = new Map(), views = new Map();
     let collapsedTabIds = new Set(), draggedGroup = null, provisionalId = null, provisionalTags = [];
-    let settings = { tabCtx: "over50", theme: "classic", colormap: "aurora" };
+    // stripGroupRows mirrors the default. Its break site is never reached here: FakeEl has no childElementCount,
+    // so the gate's last operand is undefined whatever the setting, hence no makeRowBreak stub. Give FakeEl a
+    // childElementCount and this prelude needs one.
+    let settings = { tabCtx: "over50", stripGroupRows: true, theme: "classic", colormap: "aurora" };
     const H = HOOKS;
     const el = (tag, cls) => new H.FakeEl(tag, cls);
     const document = { activeElement: null,
@@ -154,7 +157,7 @@ function world(): { H: Hooks; api: Api; sessions: Map<string, any>; tabMeta: Map
   const api = lift()(H);
   const sessions = new Map<string, any>([["a", session("web", "ready")], ["b", session("api", "working")]]);
   const tabMeta = new Map<string, any>([["p", { name: "tests", color: { bg: "#112233", fg: "#ffffff" } }]]);
-  const settings = { tabCtx: "over50", theme: "classic", colormap: "aurora" };
+  const settings = { tabCtx: "over50", stripGroupRows: true, theme: "classic", colormap: "aurora" };
   api.set({ order: ["a", "b", "p"], sessions, tabMeta, settings, activeId: "a" });
   return { H, api, sessions, tabMeta, settings };
 }
@@ -217,6 +220,7 @@ test("every input the strip paints repaints it, once, when it changes", () => {
     ["the order", () => { api.set({ order: ["b", "a", "p"] }); }],
     ["a tab hidden by the views filter", () => { H.hidden.add("p"); }],
     ["the context-gauge setting", () => { settings.tabCtx = "always"; }],
+    ["the one-group-per-row setting", () => { settings.stripGroupRows = false; }],
     ["the theme", () => { settings.theme = "yatharth"; }],
     ["the colormap", () => { settings.colormap = "hawaii"; }],
     ["the + tab's key hint", () => { H.keyHint = "Open a session (J)"; }],

--- a/ui/webview/tab-strip-skip.test.ts
+++ b/ui/webview/tab-strip-skip.test.ts
@@ -45,7 +45,7 @@ test("every input the strip renders is in the signature", () => {
   // `unions` is the tag unions the filter chips render (the same viewTagUnion(effViews()) the plan read).
   for (const needle of [
     "activeId", "peekId", "ids", "visibleIds", "tabInView(activeId)", "plan.items",
-    "settings.tabCtx", "settings.theme", "settings.colormap", 'titleWithKey("Open a session", "session.new")',
+    "settings.tabCtx", "settings.stripGroupRows", "settings.theme", "settings.colormap", 'titleWithKey("Open a session", "session.new")',
     'surfaceLens(effViews(), "chat")', "unions",
     "m?.name", "m?.color?.bg", "m?.color?.fg",
     "s.name", "s.color?.bg", "s.color?.fg", "st.state", "tabStateClass(st)", "!!st.faded",


### PR DESCRIPTION
With the tabs grouped by tag, every tag group still starts on its own row (#1087). A new gear checkbox, on by default, lets a user turn that off so the groups follow one another across the strip and wrap as they need.

## Why: the many-groups case, in the strip's own numbers

- One group per row means at least one row per tag plus one for the untagged trail. The strip's cap is 150px, about four rows (`TABBAR_H_DEFAULT` in tabbar-resize.ts; a row measured 31.67px in #1108). Four rows fill it; whatever comes fifth, another tag or the untagged trail, sits below the cap, reachable only by scrolling the strip or dragging the grip, whose ceiling is 60% of the window.
- A dozen tags is thirteen rows, roughly 410px: nearly three times the cap, and a large share of a laptop window even at the grip's ceiling. Folding does not shorten it, because a folded group is still its header row alone (a #1087 design point): twelve folded tags are twelve rows of one chip each, where inline they share a row or two at desktop width. A session under several tags (#1091) has a copy in every group and adds wrap rows to each.
- The strip is the switcher the user glances at, and groups below the cap are groups they cannot see. #1087 noted that many groups scroll inside the cap; this PR is for the strips where scrolling the switcher is the problem. The per-row layout stays the default because it reads best at a handful of tags.

## Design points

- Default kept: `stripGroupRows` defaults to true. A settings store written before the key reads true (loadSettings spreads the defaults); no migration, no kernel involvement.
- Where it lives: RompSettings in settings.ts and the browser-side `romp:settings` store, like every gear row (per browser profile; synced to same-origin tabs by the storage event and to sibling VS Code panes by the existing settingsSync post). The row sits in the gear's Chat section, after Show git branch and before Context gauge in tabs, so the two strip rows sit together. It is not in the tag menu's foot: the Group tabs by tag row there switches sectioning itself, is stored in the romp:tabgroups blob, and rides a menu shared with mounts that have no strip.
- Off is the strip as it was before #1087. The row breaks are emitted only under the setting, and the untagged trail stands behind the 13px divider again (`makeTrailSep`, the pre-#1087 element and its rule), scoped `.tab-group-sep:not(.tab-group-break)` so the trail's break keeps no box. The divider returns only in this layout, because there the trail has no row of its own to say "in no tag". Its gutters are padding, so the drag's virtual layout measures its footprint (the dragover already selects `.tab-group-sep` and measures a non-break box live); it is a group edge for the drop's in-group neighbour walk (#1091) and the boundary `sectionHeadOf` reads, as it was.
- The row hairlines (T134) are unchanged: `#tabs` is `align-items: stretch` and the trail's boundary exists only when loose tabs do, so the divider always shares a row with a tab and never forms a row alone; the painter's tabs-and-headers rule and its pin stand. If you would rather count the divider as the pre-#1087 painter did, it is one clause in the painter's filter plus the pin.
- A flip repaints at once: the setting rides the strip's rebuild signature (tab-strip-skip pins it; the executed harness drives it), and the existing settings listener already calls renderTabs.
- Unchanged in both states: keyboard order and focus, ARIA (the break stays aria-hidden; the divider carries a title only; neither is focusable), the phone layout (flat strip), the mobile scrape (`.tab` only), the copies of a multi-tag session, the resize grip and cap, and the Group tabs by tag switch.
- Deliberately left out: no automatic switch by group count (a threshold would decide for the user; the checkbox is their call). The opt-out layout keeps its pre-#1087 wrap, in which a header can end a row while its tabs start the next; a keep-with-next break is a natural follow-up if that bothers anyone. docs/reference.md is unchanged (it documents kernel-side configuration). The guide's tab-groups paragraph now describes both layouts: its opening still said the untagged sessions sit after a divider, which #1087 had retired, so it now says they take a row of their own, and the sentence about the setting names the divider for the inline layout. The kernel is untouched.

## Tier

Tier: feature

## Tests

- `ui/webview/tab-groups.test.ts` runs the head loop's break gate at both values (on: a break ahead of every header but the strip's first item and never the trail's; off: none), runs the drop's in-group neighbour walk, lifted from the handler, over a fake strip (a tab dropped at the trail's head anchors on its trail neighbour and never on the tagged group's last tab, with the divider as the edge and with the break), and pins the trail branch, the divider builder, the scoped divider rule, the signature entry, the settings listener, the gear row and its wiring, and the guide's two sentences.
- `ui/webview/settings.test.ts` pins the default and the round trip of an explicit false and of a store from before the key.
- `ui/webview/tab-strip-skip.test.ts` lists the new signature input; `ui/webview/tab-strip-skip-exec.test.ts` executes the flip as exactly one repaint.
- `ui/webview/tab-drag-live.test.ts` pins the divider's footprint (width and padding, no margin) and the absence of an unscoped rule.
- `tests/test_kernel_settings_sections.py` places the row under Chat and pins the gear's default in both of load()'s literals, its listener and its fill.
- `tests/test_tab_groups_rows.py` drives the served /chat page in both layouts: the default with nothing written to the settings store, and the inline layout with the setting written off before load (no break, one visible 13px divider, each group's tabs contiguous after its header, no zero-height item besides the hairlines). It skips loudly without a browser, so the local run is recorded here: both drives green, `2 passed in 6.50s`. Before the change the inline drive found three breaks.
- Ran locally: `cd vscode-extension && npm run typecheck && npm test` (typecheck clean; 3651 tests, 3651 pass); `python3 -m pytest -q tests/test_kernel_settings_sections.py tests/test_tab_groups_rows.py` (9 passed; 2 passed); the rest of the Python suite with `-n 8`, the served guard run separately: 10054 passed, 40 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)