### PR TITLE
Codex: a session going live sends the models frame, so an open dashboard learns the model list without a reload

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1567,8 +1567,8 @@ _learned_announced = set()   # ids already announced on stderr as outside the ca
 # file both parse it and store equal tuples, and holding _catalog_lock around file I/O would stall the
 # catalog refresh thread.
 _learned_reg_cache = {}   # str(path) -> ((mtime_ns, size, ino), liveModelId or "") — see _reported_model_ids
-# Bumps on every pick-memory change and every catalog growth; rides the models frame (_models_changed) AND
-# the /models payload, so a picker can drop a response older than one it has applied. Seeded from the clock
+# Bumps on every pick-memory change, catalog growth and Codex landing; rides the models frame (_models_changed)
+# AND the /models payload, so a picker can drop a response older than one it has applied. Seeded from the clock
 # rather than 0: the counter is per process, and a kernel restart must never hand a page that kept its
 # high-water mark a LOWER rev, or that page would ignore every re-read until the count caught up — a silent
 # stale list. Milliseconds leave room for one bump per ms across a restart.
@@ -2042,7 +2042,14 @@ def _models_changed():
     itself, never a poll. A counter rides it so a client can tell frames apart, and the same counter stamps
     the /models payload so a late response never overwrites a newer one. (Without it, after Latest
     un-pinned a family on the kernel the same tab's next family click sent the STALE pinned id and silently
-    re-pinned; a second dashboard's pick moved the default without the first tab knowing.) The FEED app is
+    re-pinned; a second dashboard's pick moved the default without the first tab knowing.) Also sent when a
+    Codex session lands (the create door's spawn returned a sid; the revive door's resume answered True, as it
+    does for a dead row made live again and for a row already live): a live Codex row opens GET /models's
+    Codex consult for every dashboard, so every open picker's cached `codex.models` just went from [] to the
+    list. Sent per landing, not only on the closed-to-open flip: a door cannot observe the flip without the
+    backend counting closings (two first creates can both land before either checks; a kill between a door's
+    check and its landing hides a close-and-reopen), and a repeated frame costs one GET /models per open
+    picker, which the payload's rev reconciles. The FEED app is
     on the list because the settings gear lives in the feed bundle (feed.ts requires gear.js; the shell's
     rail gear and VS Code's settings command both open it in the feed pane). The feed shim and the VS Code
     pipe hand every non-keepalive frame to the window as a message; feed.ts's own listener ignores a type
@@ -12454,6 +12461,9 @@ def _create_codex_session_inner(nm, cwd, client=None, parent="", tags=()):
     kernel. Returns (sid, echo)."""
     bg, fg = _pick_identity_color()
     sid = _codex().spawn(nm, cwd, bg, fg)
+    # the row is live, so GET /models's Codex consult (gated on a live Codex session) is open; every open
+    # picker re-reads the list on this frame. Sent on every landing, not only the first: see _models_changed
+    _models_changed()
     extra = {}
     if parent or tags:
         extra.update(_tag_ack(sid, parent, tags))
@@ -15569,6 +15579,10 @@ def _revive_session_inner(sid, client=None):
             else:
                 ok = bool(cx.resume(name, sid, cwd=_cwd_of(sid)))
                 detail = "" if ok else "the Codex backend could not resume it (see the kernel log)"
+                if ok:
+                    # the row is live (a dead one made live again, or one already live: resume answers True for
+                    # any known sid), which opens the same /models consult as the create door's spawn
+                    _models_changed()
         else:
             cwd = _cwd_of(sid)
             workdir = cwd if cwd and os.path.isdir(cwd) else os.path.expanduser("~")

--- a/tests/test_codex_models_frame.py
+++ b/tests/test_codex_models_frame.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""A Codex session going live sends the models frame. GET /models consults the Codex catalog only where
+this machine opted in (Codex as the default backend or the judge engine, or a live Codex session), and
+every picker re-reads the route only on the kernel's models frame, so a dashboard loaded before the
+first Codex session held `codex: {models: []}` until a reload: the two doors that make a Codex row live,
+the create's spawn and the revive's resume, sent nothing. Both doors now call _models_changed() once the
+backend has landed the row, on every landing: a door cannot see the closed-to-open flip by itself, so
+sending each time never misses, and the cost is one GET /models per open picker, which the payload's rev
+reconciles.
+The real doors run here over a fake backend (spawn, resume, the live and dead sets, a barrier for the
+race) and one fake WS client per app that hosts a picker. Each client's send records whether the fake's
+live set was non-empty at that moment, so a frame sent before the row landed fails the test that reads
+it. Synthetic fixtures only.
+"""
+import contextlib
+import json
+import os
+import tempfile
+import threading
+import unittest
+from importlib.machinery import SourceFileLoader
+from unittest import mock
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+# Hermetic state BEFORE the loads: they resolve their state root at import time, and only pytest runs
+# conftest's floor (a bare unittest or script run otherwise writes REAL state, and a kernel module that
+# can reach a live manager port restarts the live kernel).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["ROMP_MANAGER_PORT"] = "1"             # a dead port, never an inherited live one
+os.environ["ROMP_MODEL_CATALOG"] = "off"          # never the Models API from a test
+km = SourceFileLoader("romp_kernel_codex_models_frame", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "33333333-4444-4555-8666-777777777777"
+SID2 = "44444444-5555-4666-8777-888888888888"
+APPS = ("chat", "timeline", "feed")               # the apps _models_changed addresses: each hosts a picker
+
+
+class FakeCodex:
+    """The slice of CodexBackend the two doors and their neighbours read: the row walk (the /models gate,
+    the identity-colour pick), the registry lookup the revive arm makes, spawn and resume. `sids` are what
+    successive spawns mint. `barrier`, when set, is waited on by spawn and by a landing resume AFTER the row
+    is live, so two doors can be held with both rows landed and neither returned. `refuse` makes resume
+    answer False without landing; `spawn_error` makes spawn raise it before any row exists. Like the real
+    backend's, resume answers True for any known sid: a dead one lands, a live one is left as it is."""
+
+    def __init__(self, sids=(SID,), live=None, dead=(), barrier=None, refuse=False, spawn_error=None):
+        self.live = dict(live or {})        # sid -> row, what live_sessions() answers
+        self.dead = set(dead)               # sids the registry knows that are not running
+        self._sids = list(sids)
+        self._lock = threading.Lock()
+        self.barrier = barrier
+        self.refuse = refuse
+        self.spawn_error = spawn_error
+        self._client_err = None
+
+    def live_sessions(self):
+        with self._lock:
+            return dict(self.live)
+
+    def _session(self, sid):
+        return object() if (sid in self.live or sid in self.dead) else None
+
+    def spawn(self, nm, cwd, bg="", fg="", *a, **kw):
+        if self.spawn_error is not None:
+            raise self.spawn_error
+        with self._lock:
+            sid = self._sids.pop(0)
+            self.live[sid] = {"backend": "codex", "state": "waiting"}
+        if self.barrier is not None:
+            self.barrier.wait()
+        return sid
+
+    def resume(self, name, sid, cwd=None):
+        if self.refuse:
+            return False
+        if sid in self.dead:
+            with self._lock:
+                self.dead.discard(sid)
+                self.live[sid] = {"backend": "codex", "state": "waiting"}
+            if self.barrier is not None:
+                self.barrier.wait()
+            return True
+        return sid in self.live
+
+
+class ModelsFrameOnLanding(unittest.TestCase):
+    """The fake is installed as the kernel's Codex singleton, and one fake WS client per picker app sits in
+    the kernel's client list. A client's send appends (app, frame, live) where `live` is whether the fake's
+    live set was non-empty when the send ran."""
+
+    def setUp(self):
+        self.fake = None
+        self.frames = []
+        self._saved_backend = km._codex_backend
+        self.clients = []
+        for app in APPS:
+            c = {"app": app, "wid": "w-" + app, "alive": True}
+            c["send"] = lambda s, app=app: self.frames.append((app, json.loads(s), bool(self.fake.live)))
+            self.clients.append(c)
+        with km._clients_lock:
+            km._clients.extend(self.clients)
+
+    def tearDown(self):
+        with km._clients_lock:
+            km._clients[:] = [c for c in km._clients if not any(c is mine for mine in self.clients)]
+        km._codex_backend = self._saved_backend
+
+    def _backend(self, fake):
+        self.fake = fake
+        km._codex_backend = fake
+        return fake
+
+    @contextlib.contextmanager
+    def _door_quiet(self):
+        """The create door's tail (a dirty mark and a direct push) stubbed: neither is under test, and
+        the push would build a session view over a fake backend."""
+        with mock.patch.object(km, "_push_session_now"), mock.patch.object(km, "_mark_views_dirty"):
+            yield
+
+    def _create(self, nm):
+        with self._door_quiet():
+            return km._create_codex_session_inner(nm, "/TESTDIR")
+
+    def _revive(self, sid, ready=True):
+        """Run the real revive door with its neighbours stubbed the way the Codex revive tests do; the
+        asker is a chat client with wid w-chat. Returns (focused, sent): the focus messages the asker's
+        chat received and the (app, msg) pairs aimed at the asker's dashboard."""
+        focused, sent = [], []
+        with mock.patch.multiple(km, _sdk=lambda: None, _codex_ready=lambda: ready,
+                                 _name_of=lambda s: "web", _cwd_of=lambda s: "/TESTDIR",
+                                 _commands_for_cwd=lambda cwd: None, _push_soon=lambda: None,
+                                 _reveal_chat_for=lambda client, msg: focused.append(msg),
+                                 _send_to_view=lambda app, msg, wid: sent.append((app, msg))):
+            km._revive_session_inner(sid, {"wid": "w-chat"})
+        return focused, sent
+
+    def _assert_one_frame_per_app(self, rev0):
+        self.assertEqual(sorted(app for app, _, _ in self.frames), sorted(APPS),
+                         "one models frame to each picker app: %r" % (self.frames,))
+        for app, frame, live in self.frames:
+            self.assertEqual(frame.get("type"), "models", "the %s client got %r" % (app, frame))
+            self.assertGreater(frame.get("rev", 0), rev0, "the %s frame's rev did not move" % app)
+            self.assertTrue(live, "the %s frame went out before the row was live" % app)
+
+    def _race(self, run, names):
+        """One thread per name, all joined; a thread's exception is re-raised here and a thread still alive
+        after the join fails the test."""
+        errors = []
+
+        def body(nm):
+            try:
+                run(nm)
+            except BaseException as e:      # noqa: BLE001 - re-raised on the test thread below
+                errors.append(e)
+
+        threads = [threading.Thread(target=body, args=(nm,), name="door-" + nm) for nm in names]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15)
+        self.assertEqual([t.name for t in threads if t.is_alive()], [], "a door never returned")
+        if errors:
+            raise errors[0]
+
+    def test_the_first_codex_spawn_sends_the_models_frame_to_every_picker_app(self):
+        fake = self._backend(FakeCodex(sids=(SID,)))
+        rev0 = km._models_rev[0]
+        sid, extra = self._create("web")
+        self.assertEqual((sid, extra), (SID, {}))
+        self.assertEqual(set(fake.live), {SID})
+        self._assert_one_frame_per_app(rev0)
+
+    def test_a_second_spawn_beside_a_live_session_sends_the_frame_again(self):
+        """The rule is every landing, not only the one that opens the consult. A door cannot see the
+        closed-to-open flip by itself: two first creates can both land before either checks, and a kill
+        between a door's check and its landing hides a close-and-reopen; seeing it would need the backend to
+        count closings at every live-to-dead write. The cost of sending each time is one GET /models per
+        open picker per landing, which the payload's rev reconciles."""
+        fake = self._backend(FakeCodex(sids=(SID, SID2)))
+        self._create("web")
+        rev1 = km._models_rev[0]            # the counter after the first landing: its frames carry this rev
+        del self.frames[:]
+        sid, _ = self._create("api")
+        self.assertEqual(sid, SID2)
+        self.assertEqual(set(fake.live), {SID, SID2})
+        self._assert_one_frame_per_app(rev1)
+
+    def test_reviving_a_dead_codex_session_sends_the_frame_and_focuses_the_asker(self):
+        fake = self._backend(FakeCodex(dead=(SID,)))
+        rev0 = km._models_rev[0]
+        focused, sent = self._revive(SID)
+        self.assertEqual((set(fake.live), fake.dead), ({SID}, set()))
+        self._assert_one_frame_per_app(rev0)
+        self.assertEqual([(m["type"], m["id"]) for m in focused], [("focus", SID)])
+        self.assertEqual(sent, [], "no reviveFailed for a resume that answered True")
+
+    def test_reviving_an_already_live_codex_session_sends_the_frame_too(self):
+        """The backend's resume answers True for a live row as well, and the arm fires on that answer: a
+        Revive click on a row that is already live costs one re-read per picker, the same as a landing."""
+        fake = self._backend(FakeCodex(live={SID: {"backend": "codex", "state": "waiting"}}))
+        rev0 = km._models_rev[0]
+        focused, sent = self._revive(SID)
+        self.assertEqual((set(fake.live), fake.dead), ({SID}, set()))
+        self._assert_one_frame_per_app(rev0)
+        self.assertEqual([(m["type"], m["id"]) for m in focused], [("focus", SID)])
+        self.assertEqual(sent, [])
+
+    def test_a_resume_the_backend_refuses_sends_no_frame_and_files_revive_failed(self):
+        fake = self._backend(FakeCodex(dead=(SID,), refuse=True))
+        focused, sent = self._revive(SID)
+        self.assertEqual((fake.live, fake.dead), ({}, {SID}))
+        self.assertEqual(self.frames, [], "nothing landed, so no picker re-reads")
+        self.assertEqual([(app, m["type"]) for app, m in sent],
+                         [("chat", "reviveFailed"), ("feed", "reviveFailed")])
+        self.assertEqual(len({m["text"] for _, m in sent}), 1, "the same text to both panes")
+        self.assertEqual(focused, [])
+
+    def test_a_revive_refused_by_the_readiness_check_sends_no_frame(self):
+        fake = self._backend(FakeCodex(dead=(SID,)))
+        fake._client_err = "codex login missing"
+        focused, sent = self._revive(SID, ready=False)
+        self.assertEqual((fake.live, fake.dead), ({}, {SID}), "nothing resumed without the app server")
+        self.assertEqual(self.frames, [])
+        self.assertEqual([(app, m["type"], m["text"]) for app, m in sent],
+                         [("chat", "reviveFailed", "codex login missing"),
+                          ("feed", "reviveFailed", "codex login missing")])
+        self.assertEqual(focused, [])
+
+    def test_a_spawn_that_raises_sends_no_frame_and_the_raise_propagates(self):
+        fake = self._backend(FakeCodex(spawn_error=RuntimeError("thread start refused")))
+        with self.assertRaises(RuntimeError) as cm:
+            self._create("web")
+        self.assertEqual(str(cm.exception), "thread start refused")
+        self.assertEqual((fake.live, self.frames), ({}, []))
+
+    def test_two_first_creates_landing_together_still_reach_every_app(self):
+        fake = self._backend(FakeCodex(sids=(SID, SID2), barrier=threading.Barrier(2, timeout=10)))
+        rev0 = km._models_rev[0]
+        with self._door_quiet():
+            self._race(lambda nm: km._create_codex_session_inner(nm, "/TESTDIR"), ("web", "api"))
+        self.assertEqual(set(fake.live), {SID, SID2})
+        # two frames per app is the designed outcome of sending on every landing; zero is the bug
+        self.assertEqual({app for app, _, _ in self.frames}, set(APPS),
+                         "every picker app hears at least one frame: %r" % (self.frames,))
+        for app, frame, live in self.frames:
+            self.assertEqual(frame.get("type"), "models")
+            self.assertGreater(frame.get("rev", 0), rev0)
+            self.assertTrue(live, "the %s frame went out before its row was live" % app)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Symptom.** `GET /models` consults the Codex catalog only where this machine opted in: Codex as the default backend or the judge engine, or a live Codex session. A dashboard loaded before the first Codex session read `codex: {models: []}` (with #1167, the reason `no live Codex session; the list is read once one runs`) and was never told the list existed: the models frame that makes every picker re-read `/models` fires from the pick memory and the catalog fetch, not from the session that opens the consult. The chat's Codex model menu and the timeline lane's stayed empty until a reload; the same after a kernel restart that found every Codex session dead and a revive that made one live again.

**Cause.** `_create_codex_session_inner` and `_revive_session_inner`'s Codex arm return without `_models_changed()`. Those are the only kernel call sites of `CodexBackend.spawn` and `resume`.

**Fix.** Both doors call `_models_changed()` once the backend has landed the row: the spawn returned its sid; the resume answered True. Every landing sends the frame, not only the one that opens the consult: the flip is the exact event, but a door cannot see it without the backend counting closings at every live-to-dead write (two first creates can both land before either checks; a kill between a door's check and its landing hides a close-and-reopen). Sending on every landing never misses. The cost is one `GET /models` per open picker (chat, timeline, the feed's gear) per Codex create or successful revive, and the payload's `rev` already makes a repeated or late read harmless; the catalog is cached after its first non-empty answer. A spawn that returns a launch-error row (client unavailable) opens the consult too and sends the frame, so the re-read carries the client's reason in `error`. A revive of an already-live row also sends one (the backend's resume answers True for any known session). Nothing fires on a spawn that raised, a resume that answered False, or a revive the readiness check refused. `_models_changed`'s docstring and the `_models_rev` comment name the third cause. The calls are bare, like the two pick-memory callers: `_models_changed` cannot raise (the WS send path catches every exception and marks the client dead). A flip-only rule (the backend counting closings under its lock, the doors snapshotting before landing) is available if preferred; this PR sends one cheap re-read instead.

**Tests** (`tests/test_codex_models_frame.py`, new; the real doors over a fake backend and fake WS clients for the three apps; each send records whether the fake's live set was non-empty at that moment, and each frame assertion fails before the change because neither door reached `_models_changed`). The first Codex spawn sends one frame to chat, timeline and feed, each rev above the last, after the row is live. A second spawn beside a live one sends one: the rule is every landing. A revive of a dead Codex session sends one and focuses the asker's chat; a revive of a row already live sends one too; a resume the backend refuses sends none and files `reviveFailed` to the asker's chat and feed as before; a revive refused by the readiness check sends none. A spawn that raises sends none and the raise propagates. Two first creates racing, both landing before either continues, still reach every app. Removing the create door's call fails the two spawn tests and the race; moving it before the spawn fails the first on a frame sent while nothing was live; removing the revive arm's call fails both revive-landing tests, gating it on the row having been dead before the resume fails the already-live one, and dropping its `ok` guard fails the refused-resume test. The existing door tests (create ack, names, revive, command cache, discovery's source pin) run unchanged; their fakes need nothing new.

**Not in this PR.** The exact flip (a closings counter in the backend) if wanted. A frame when the last Codex session dies (a picker on a dead session cannot open). The consult opened by a settings change (default backend or judge engine set to Codex) with no live session. The chat picker's own row for an empty Codex list (an empty-state row that shows the route's reason) is a separate PR; the `/models` `error` field is #1167.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)