### PR TITLE
Courier link repair: the sender-board walk is built once per state of its inputs

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -940,7 +940,9 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   stands (`served`, `derived`); `courierSkip` is the courier's change gate
   (`skipped`, `scanned`, `recorded`: a session whose parse, store, journal,
   archive and episode log have not moved since a scan that found nothing to
-  place is skipped whole). The compaction sweep after each judge pass evicts from `pass` and
+  place is skipped whole); `backref` is the sender-board walk behind the
+  courier's link repair, built once per state of the sender stores and served
+  while they stand (`served`, `built`). The compaction sweep after each judge pass evicts from `pass` and
   `shared` the entries of stores no session in the discover window owns, so
   both stay bounded by the live board; the gate memo is bounded by the session
   count.

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -165,6 +165,7 @@ def _rebind_state(path):
     _STORE_FAULTS.clear()   # unreadable-store episodes belong to the old root's files
     _CHAIN_MEMO.clear()     # the write-moment chain memo keys on paths under STATESDIR; a new root is a new world
     _COURIER_SEEN.clear()   # the courier gate keys on the old root's files
+    _BACKREF_MEMO["slot"] = None   # ...and so does the sender-board walk's map
     _episode_memo.clear()   # ...and so are the episode-log reads
     _head_memo.clear()      # transcript heads are immutable per path, but a rebind swaps the whole world of paths
     _namefp_memo.clear()    # names-entry content is memoized per SID against same-second mtimes — across a
@@ -14407,17 +14408,51 @@ def _serving_ref(serving):
     return ref
 
 
+_BACKREF_MEMO = {"slot": None}     # (key, {msgId: (sender sid, node id)}) or None: the sender-board walk, keyed on its inputs
+_BACKREF_STATS = {"served": 0, "built": 0}
+
+
+def backref_memo_stats():
+    """A copy of the backref memo's counters for /perf (memos.backref)."""
+    return dict(_BACKREF_STATS)
+
+
+def _backref_key(fleet):
+    """Every input the sender-board walk reads, taken BEFORE the reads (the chain-memo rule): the discover
+    order and, per session, the store file's key with its journal's and archive's (the shared view's inputs;
+    a journal replay can complete a handoff node, which drops it from the map)."""
+    return tuple((fsid, _file_key(str(GOALDIR / (fsid + ".json"))), _journal_key(fsid), _archive_key(fsid))
+                 for fsid, path, anchor, name in fleet)
+
+
 def _handoff_backref(mid):
     """(sender sid, sender tracking-node id) for a delegate message id — read from the SENDER boards'
     own handoff nodes (the durable record _plant_handoff_track wrote at send time). '' pair when no
-    sender tracks this message (a delegate from a non-romp source, or the sender's store is gone)."""
-    for fsid, path, anchor, name in discover(int(time.time())):
-        st = load_goals(fsid)
+    sender tracks this message (a delegate from a non-romp source, or the sender's store is gone).
+
+    Built once per state of its inputs and served while they stand (2026-09-09): every call walked every
+    discovered session's store with the writer's loader, and the courier asked it for each placed
+    delegate whose link was missing, on every triage pass. The map answers every message id from one
+    walk over the read-only view; its key is _backref_key, taken before the reads, so a store written
+    during the walk moves the key the next call takes (a set read mid-write is served no further than
+    that call). The first sender in discover order wins, as the walk answered; a completed handoff node
+    is no backref. A store that raises leaves nothing cached (the caller's own boundary logs it)."""
+    fleet = discover(int(time.time()))
+    key = _backref_key(fleet)
+    slot = _BACKREF_MEMO["slot"]
+    if slot is not None and slot[0] == key:
+        _BACKREF_STATS["served"] += 1
+        return slot[1].get(mid, ("", ""))
+    mp = {}
+    for fsid, path, anchor, name in fleet:
+        st = load_goals_shared(fsid)
         for nid, nd in st.get("nodes", {}).items():
             h = nd.get("handoff")
-            if isinstance(h, dict) and h.get("msgId") == mid and not nd.get("nodeComplete"):
-                return fsid, nid
-    return "", ""
+            if isinstance(h, dict) and h.get("msgId") is not None and not nd.get("nodeComplete"):
+                mp.setdefault(h["msgId"], (fsid, nid))
+    _BACKREF_STATS["built"] += 1
+    _BACKREF_MEMO["slot"] = (key, mp)
+    return mp.get(mid, ("", ""))
 
 
 def _plant_handoff_track(store, parent_id, text, peer_sid, peer_name, t, mid, tracked=False, to_sid=None):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -397,7 +397,8 @@ class _PerfStats:
         # chain memo. `goals.loads` is the writer's loader alone; the pusher's loads show under memos.shared.
         memos = {}
         for key, read in (("pass", _goals_memo_report), ("shared", jd.shared_store_stats),
-                          ("chain", jd.chain_memo_stats), ("courierSkip", jd.courier_skip_stats)):
+                          ("chain", jd.chain_memo_stats), ("courierSkip", jd.courier_skip_stats),
+                          ("backref", jd.backref_memo_stats)):
             try:
                 memos[key] = read()
             except Exception:

--- a/tests/test_backref_memo.py
+++ b/tests/test_backref_memo.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""The sender-board walk behind the courier's link repair (_handoff_backref) is built once per state of its
+inputs and served while they stand (2026-09-09).
+
+Every call walked every discovered session's goal store with the writer's loader, and the courier asked it
+for each placed delegate whose link was missing, on every triage pass. The map now answers every message id
+from one walk over the read-only view, keyed on the discover order and each sender store's file key with
+its journal's and archive's, taken before the reads. Pins: built once then served; a sender store write
+re-derives, including one the file clock cannot see; a journal row re-derives; a fleet change re-derives;
+a write landing during the build is seen next call; the first sender in discover order wins; a completed
+handoff is no backref; a store that raises leaves nothing cached; a rebound root forgets; the counters.
+
+Synthetic sids and stores under a temp root; discover is a stub, so no transcripts are needed."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_backref_memo", os.path.join(BIN, "romp-judge")).load_module()
+
+S1 = "11111111-2222-3333-4444-999999999901"
+S2 = "11111111-2222-3333-4444-999999999902"
+S3 = "11111111-2222-3333-4444-999999999903"
+M1, M2, M3 = "1781100000.00001_00001.TESTHOST", "1781100000.00002_00002.TESTHOST", "1781100000.00003_00003.TESTHOST"
+T0 = 1781100000
+
+
+def _node(nid, text, mid=None, complete=False):
+    nd = {"id": nid, "text": text, "parentId": None, "nodeComplete": complete, "blocked": False, "cleared": False,
+          "trail": [], "t": T0}
+    if mid:
+        nd["handoff"] = {"peer": "peer", "msgId": mid}
+    return nd
+
+
+class _Memo(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_root, self.saved_discover = jd.STATE, jd.discover
+        jd._rebind_state(Path(self.td.name))
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        self.fleet = [(S1, "/nonexistent/s1.jsonl", None, "s1"), (S2, "/nonexistent/s2.jsonl", None, "s2")]
+        jd.discover = lambda now: list(self.fleet)
+        self.write(S1, {S1 + ":g1": _node(S1 + ":g1", "delegated to worker0", M1)})
+        self.write(S2, {S2 + ":g1": _node(S2 + ":g1", "delegated to worker1", M2)})
+        self._reset()
+
+    def tearDown(self):
+        jd.discover = self.saved_discover
+        jd._rebind_state(self.saved_root)
+        self._reset()
+        self.td.cleanup()
+
+    @staticmethod
+    def _reset():
+        jd._BACKREF_MEMO["slot"] = None
+        for k in jd._BACKREF_STATS:
+            jd._BACKREF_STATS[k] = 0
+        jd._shared_clear()
+
+    def write(self, sid, nodes, mtime=None):
+        p = jd.GOALDIR / (sid + ".json")
+        p.write_text(json.dumps({"rompUuid": sid, "seq": 1, "lastNode": None, "closedTurns": [], "nodes": nodes,
+                                 "placements": {}, "status": {k: "working" for k in nodes}}))
+        if mtime is not None:
+            os.utime(p, (mtime, mtime))
+
+    def counting(self):
+        """Wrap the view's loader; returns the list of sids read."""
+        reads, real = [], jd.load_goals_shared
+        jd.load_goals_shared = lambda fsid: (reads.append(fsid), real(fsid))[1]
+        self.addCleanup(lambda: setattr(jd, "load_goals_shared", real))
+        return reads
+
+
+class BackrefMemo(_Memo):
+    def test_built_once_then_served_while_the_inputs_stand(self):
+        reads = self.counting()
+        self.assertEqual(jd._handoff_backref(M1), (S1, S1 + ":g1"))
+        self.assertEqual(jd._handoff_backref(M2), (S2, S2 + ":g1"))
+        self.assertEqual(jd._handoff_backref("1781100000.00009_00009.TESTHOST"), ("", ""), "an untracked message")
+        self.assertEqual(sorted(reads), sorted([S1, S2]), "one walk: each sender store read once")
+        self.assertEqual(jd._BACKREF_STATS, {"served": 2, "built": 1})
+
+    def test_a_sender_store_write_re_derives_even_when_the_file_clock_does_not_move(self):
+        jd._handoff_backref(M1)
+        before = os.stat(jd.GOALDIR / (S2 + ".json"))
+        self.write(S2, {S2 + ":g1": _node(S2 + ":g1", "delegated to worker1", M2),
+                        S2 + ":g2": _node(S2 + ":g2", "delegated to worker2", M3)}, mtime=before.st_mtime)
+        self.assertEqual(os.stat(jd.GOALDIR / (S2 + ".json")).st_mtime, before.st_mtime)
+        self.assertEqual(jd._handoff_backref(M3), (S2, S2 + ":g2"), "the size moved: built again, the new handoff seen")
+        self.assertEqual(jd._BACKREF_STATS["built"], 2)
+
+    def test_a_journal_row_re_derives(self):
+        jd._handoff_backref(M1)
+        jd._overrides_dir().mkdir(parents=True, exist_ok=True)
+        with (jd._overrides_dir() / (S1 + ".jsonl")).open("a") as f:
+            f.write(json.dumps({"op": "resolve", "id": S1 + ":g1", "t": T0 + 10}) + "\n")
+        jd._shared_clear()
+        jd._handoff_backref(M1)
+        self.assertEqual(jd._BACKREF_STATS["built"], 2, "the journal is a keyed input")
+
+    def test_a_fleet_change_re_derives(self):
+        jd._handoff_backref(M1)
+        self.write(S3, {S3 + ":g1": _node(S3 + ":g1", "delegated to worker3", M3)})
+        self.fleet.append((S3, "/nonexistent/s3.jsonl", None, "s3"))
+        self.assertEqual(jd._handoff_backref(M3), (S3, S3 + ":g1"))
+        self.assertEqual(jd._BACKREF_STATS["built"], 2)
+
+    def test_a_write_landing_during_the_build_is_seen_next_call(self):
+        # INTERLEAVED WRITE: the key is taken before the reads. S2 gains a handoff while the walk reads S1, so
+        # the map the first call builds is cached under a key the store no longer has; the next call rebuilds.
+        real = jd.load_goals_shared
+        landed = []
+
+        def read_then_write(fsid):
+            st = real(fsid)
+            if fsid == S1 and not landed:
+                landed.append(True)
+                self.write(S2, {S2 + ":g1": _node(S2 + ":g1", "delegated to worker1", M2),
+                                S2 + ":g2": _node(S2 + ":g2", "delegated to worker2", M3)})
+            return st
+        jd.load_goals_shared = read_then_write
+        try:
+            first = jd._handoff_backref(M3)
+        finally:
+            jd.load_goals_shared = real
+        self.assertTrue(landed)
+        self.assertEqual(jd._BACKREF_STATS["built"], 1)
+        second = jd._handoff_backref(M3)
+        self.assertEqual(jd._BACKREF_STATS, {"served": 0, "built": 2}, "the write moved the key the second call took")
+        self.assertEqual(second, (S2, S2 + ":g2"))
+        self.assertIn(first, ((S2, S2 + ":g2"), ("", "")), "what the first walk saw, depending on the read order")
+
+    def test_the_first_sender_in_discover_order_wins(self):
+        self.write(S2, {S2 + ":g1": _node(S2 + ":g1", "delegated to worker1", M1)})   # both track M1
+        self.assertEqual(jd._handoff_backref(M1), (S1, S1 + ":g1"))
+        self.fleet.reverse()
+        self.assertEqual(jd._handoff_backref(M1), (S2, S2 + ":g1"), "the order is part of the key and the answer")
+
+    def test_a_completed_handoff_is_no_backref(self):
+        self.write(S1, {S1 + ":g1": _node(S1 + ":g1", "delegated to worker0", M1, complete=True)})
+        self.assertEqual(jd._handoff_backref(M1), ("", ""))
+
+    def test_a_store_that_raises_leaves_nothing_cached(self):
+        real = jd.load_goals_shared
+
+        def faulting(fsid):
+            if fsid == S2:
+                raise OSError(5, "Input/output error")
+            return real(fsid)
+        jd.load_goals_shared = faulting
+        try:
+            with self.assertRaises(OSError):
+                jd._handoff_backref(M1)
+        finally:
+            jd.load_goals_shared = real
+        self.assertIsNone(jd._BACKREF_MEMO["slot"])
+        self.assertEqual(jd._BACKREF_STATS, {"served": 0, "built": 0})
+        self.assertEqual(jd._handoff_backref(M1), (S1, S1 + ":g1"), "healed: built")
+
+    def test_a_rebound_root_forgets_the_map(self):
+        jd._handoff_backref(M1)
+        self.assertIsNotNone(jd._BACKREF_MEMO["slot"])
+        other = tempfile.TemporaryDirectory()
+        try:
+            jd._rebind_state(Path(other.name))
+            self.assertIsNone(jd._BACKREF_MEMO["slot"])
+        finally:
+            jd._rebind_state(Path(self.td.name))
+            other.cleanup()
+
+    def test_the_counters_are_a_copy(self):
+        s = jd.backref_memo_stats()
+        self.assertEqual(set(s), {"served", "built"})
+        s["built"] = 99
+        self.assertNotEqual(jd.backref_memo_stats()["built"], 99)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -115,7 +115,9 @@ class Collector(unittest.TestCase):
         self.assertIn("cpu_ms_workers", snap["judge"])
         self.assertEqual(set(snap["goals"]), {"loads", "saves", "writes"}, "read through jd.goal_io_stats")
         # the three identity memos' readers land here (review find, 2026-09-08: they had no consumer)
-        self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate", "cleared", "courierSkip"})
+        self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate", "cleared", "courierSkip", "backref"})
+        self.assertEqual(set(snap["memos"]["backref"]), {"served", "built"},
+                         "the sender-board walk behind the courier link repair: built once per input state (2026-09-09)")
         self.assertEqual(snap["memos"]["nudgeGate"], {"served": 0, "derived": 0},
                          "the nudge walk's placement gate: served vs re-derived (2026-09-09)")
         self.assertEqual(set(snap["memos"]["cleared"]), {"served", "derived"},


### PR DESCRIPTION
Tier: fix

## What

The sender-board walk behind the courier's link repair (`_handoff_backref`) is built once per state of its inputs and served while they stand. Every call walked every discovered session's goal store with the writer's loader, and the courier asked it for each placed delegate whose link was missing, on every triage pass. The map now answers every message id from one walk over the read-only view, keyed the same way as the courier gate: the discover order and, per session, the store file's key with its journal's and archive's (the shared view's inputs; a journal replay can complete a handoff node), taken **before** the reads, so a store written during the walk moves the key the next call takes and a map read mid-write is served no further than that call. The first sender in discover order wins, as the walk answered; a completed handoff is no backref; a store that raises leaves nothing cached and the caller's own boundary logs it, as before. Counters ride `/perf` as `memos.backref` (`served`, `built`); a rebound state root clears the map. No card-move rule changes: the repair attaches exactly what the walk would have found.

## Review (by hand)

Key completeness: the walk read `nodes[*].handoff.msgId` and `nodeComplete` of every discovered store; both come from the store file with the journal replayed (the journal's resolve can set `nodeComplete`) and the archive is the view's third input, so the three keys plus the discover order cover every input; discover itself is cached by its own fingerprint. Faults: `_file_key` returns a fresh sentinel on a stat error, so the key never matches and the map rebuilds; a raising store propagates before the slot is written. Thread safety: one slot replaced whole; the only caller is the courier on the judge tier thread. Semantics: `setdefault` in discover order reproduces the walk's first hit; `mp.get(mid)` keeps the walk's equality on the raw msgId. Cost: one view read per discovered session per input state instead of one writer load per session per placed unlinked delegate per pass.

## Tests

`tests/test_backref_memo.py` (new): built once then served (one view read per sender); a sender store write re-derives even when the file clock does not move (same mtime, larger size); a journal row re-derives; a fleet change re-derives; a write landing during the build is seen next call (the interleaved-write pattern); the first sender in discover order wins; a completed handoff is no backref; a store that raises leaves nothing cached and a healed read builds; a rebound root forgets; the counters are a copy. `tests/test_perf_stats.py`: the memos key set and the counter's shape. `docs/reference.md`: the memos passage.

## Measurement for the judge thread (the dispatch's second half; nothing changed for it here)

A 60 s py-spy sample of the deployed kernel at 63 min uptime (1931 samples), the courier gate live (18585 scans skipped against 62 performed), 231 goal loads per triage pass, judge thread 45% of a core, planner workers 35%, process 57%.

**The judge tier thread is 18% of the process's samples; the planner worker pool is 37%.** Within the tier thread, `run_index` is 54%, the rewind reconcile 19%, propagate 14%, the courier 9%.

Top three romp lines by CPU, with what they read:

| where | line | share of its thread | reads, per session per pass | in the courier's skip key? |
|---|---|---|---|---|
| index tier | `tasks_for` (judge.py:2527) | 14% | `pcache/<sid>.json`, read and JSON-decoded every pass although its content is keyed on the transcript's fileset | no (the pcache file); its key input, the transcript, yes |
| triage tier | `load_goal_archive` (judge.py:4503) | 11% | `goals-archive/<sid>.json`, read and decoded per call (the live re-plan's recently-cleared context) | yes (`_archive_key`), but it is read fresh every call |
| index tier | `captioned_ids` + `_live_natoms` + `session_turn_captions` (judge.py:2563 to 2736) | 19% together | `captions/<sid>.jsonl`, the whole file JSON-decoded line by line, three times per session per pass | no |

Planner worker: `_seg_key` (judge.py:8585 to 8586, 12%), `_segment_id` (event_model.py:2434, 7%), `_placed_key` (judge.py:8640, 5%), `task_store_plan` (event_model.py:3028, 5%), `_mint_quote` (judge.py:7473, 5%). `_plan_session` calls `plan_units(session, store)` twice per session per pass and re-derives every session's segmentation and placements every pass; its inputs are the parse, the store with journal and archive, the episode log (all in the courier's skip key), plus Claude's task store for the session and the session's reg (not in it).

**Proposed next cuts, with the numbers above.** (a) The captions file parsed once per stat and the three readers derived from that one parse: about 19% of the tier thread. (b) `load_goal_archive` through a stat-keyed memo (or the shared-view idiom): 11% of the tier thread. (c) The planner's per-session change gate, the courier gate's construction with the task-store and reg keys added to the key, and `plan_units` computed once per `_plan_session`: the planner pool is 35% of a core and the courier gate's skip ratio (300 to 1) says most sessions would skip most passes. (c) is the largest; it touches the planner's mint path, so it wants the same red-first fixture discipline as the courier gate (three sessions, one moved, identical placements).
