### PR TITLE
Judge readers: the captions file parsed once per file state, the goal archive loaded once for readers

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -942,7 +942,10 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   archive and episode log have not moved since a scan that found nothing to
   place is skipped whole); `backref` is the sender-board walk behind the
   courier's link repair, built once per state of the sender stores and served
-  while they stand (`served`, `built`). The compaction sweep after each judge pass evicts from `pass` and
+  while they stand (`served`, `built`); `captions` and `goalArchive` are the
+  per-file read memos behind the index tier's caption readers and the re-plan's
+  cleared context, each parsed once per file state (`served`, `parsed` or
+  `loaded`). The compaction sweep after each judge pass evicts from `pass` and
   `shared` the entries of stores no session in the discover window owns, so
   both stay bounded by the live board; the gate memo is bounded by the session
   count.

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -166,6 +166,7 @@ def _rebind_state(path):
     _CHAIN_MEMO.clear()     # the write-moment chain memo keys on paths under STATESDIR; a new root is a new world
     _COURIER_SEEN.clear()   # the courier gate keys on the old root's files
     _BACKREF_MEMO["slot"] = None   # ...and so does the sender-board walk's map
+    _CAPTIONS_MEMO.clear(); _GOALARCH_MEMO.clear()   # ...and the per-file read memos
     _episode_memo.clear()   # ...and so are the episode-log reads
     _head_memo.clear()      # transcript heads are immutable per path, but a rebind swaps the whole world of paths
     _namefp_memo.clear()    # names-entry content is memoized per SID against same-second mtimes — across a
@@ -2554,23 +2555,74 @@ def tasks_for(fsid, leaf, files, now):
 
 
 # ───────────────────────── the caption store ─────────────────────────
-def captioned_ids(fsid):
-    """The set of unit ids already captioned for this transcript (id-keyed dedup, no window). LIVE
-    in-progress captions (the open segment's provisional work caption, the user 2026-06-21 via link_audit)
-    are SKIPPED: they're not 'done', so run_index keeps re-captioning the open segment until it closes and
-    writes the final non-live record — which then dedups normally and supersedes (the reader is last-wins)."""
-    done = set()
+# ── per-file read memos for the index tier and the re-plan's context (2026-09-09) ──
+# Measured on the maintainer's box (py-spy, the judge tier thread): captioned_ids, _live_natoms and
+# session_turn_captions each read and JSON-decoded the whole captions/<sid>.jsonl for every session on
+# every index pass (19% of the thread), and load_goal_archive decoded goals-archive/<sid>.json per call
+# (11%). Each file is now parsed once per file state: the key is _file_key (inode, mtime_ns, size) taken
+# BEFORE the read (the chain-memo rule), so a row appended during the read moves the key the next call
+# takes and content read mid-write is served no further than that call; an absent or unreadable file is
+# never cached; a stat error (a fresh sentinel key) never matches. Bounded at _FILE_MEMO_MAX entries,
+# oldest-inserted out; a rebound state root clears both. The captions memo serves the three readers from
+# one parse; the archive memo serves READERS only (load_goal_archive_shared): every archiver keeps
+# load_goal_archive, a fresh private object it mutates and saves.
+_CAPTIONS_MEMO = {}        # fsid -> (file key taken before the read, the parsed rows)
+_CAPTIONS_STATS = {"served": 0, "parsed": 0}
+_GOALARCH_MEMO = {}        # fsid -> (file key taken before the read, the guarded archive store: read-only)
+_GOALARCH_STATS = {"served": 0, "loaded": 0}
+_FILE_MEMO_MAX = 256
+
+
+def captions_memo_stats():
+    return dict(_CAPTIONS_STATS)
+
+
+def goal_archive_memo_stats():
+    return dict(_GOALARCH_STATS)
+
+
+def _memo_put(memo, fsid, key, val):
+    if fsid not in memo and len(memo) >= _FILE_MEMO_MAX:
+        memo.pop(next(iter(memo)))                        # oldest-inserted out: bounded by construction
+    memo[fsid] = (key, val)
+
+
+def _captions_rows(fsid):
+    """The parsed rows of captions/<fsid>.jsonl (dict rows only; a malformed or non-object line is skipped, as
+    the readers skipped it), once per file state and served while the file stands. The key is the file's stat
+    taken before the read; an absent or unreadable file is [] and never cached."""
+    p = CAPDIR / (fsid + ".jsonl")
+    key = _file_key(str(p))
+    if key is None:
+        return []
+    ent = _CAPTIONS_MEMO.get(fsid)
+    if ent is not None and isinstance(key, tuple) and ent[0] == key:
+        _CAPTIONS_STATS["served"] += 1
+        return ent[1]
+    rows = []
     try:
-        for line in (CAPDIR / (fsid + ".jsonl")).read_text(errors="replace").splitlines():
+        for line in p.read_text(errors="replace").splitlines():
             try:
                 o = json.loads(line)
             except Exception:
                 continue
-            if o.get("id") and not o.get("live"):
-                done.add(o["id"])
+            if isinstance(o, dict):
+                rows.append(o)
     except OSError:
-        pass
-    return done
+        return []
+    _CAPTIONS_STATS["parsed"] += 1
+    if isinstance(key, tuple):
+        _memo_put(_CAPTIONS_MEMO, fsid, key, rows)
+    return rows
+
+
+def captioned_ids(fsid):
+    """The set of unit ids already captioned for this transcript (id-keyed dedup, no window). LIVE
+    in-progress captions (the open segment's provisional work caption, the user 2026-06-21 via link_audit)
+    are SKIPPED: they're not 'done', so run_index keeps re-captioning the open segment until it closes and
+    writes the final non-live record — which then dedups normally and supersedes (the reader is last-wins).
+    Derived from the one parse _captions_rows holds per file state (2026-09-09)."""
+    return {o["id"] for o in _captions_rows(fsid) if o.get("id") and not o.get("live")}
 
 
 LIVE_CAPTION_ATOM_CHUNK = 8   # re-caption an OPEN segment's live work caption only every ~8 NEW atoms (a
@@ -2581,18 +2633,12 @@ LIVE_CAPTION_ATOM_CHUNK = 8   # re-caption an OPEN segment's live work caption o
 def _live_natoms(fsid):
     """{id: natoms} for the LIVE in-progress captions — the atom count each was built from. run_index
     re-captions an open segment only once its atoms grow by a full LIVE_CAPTION_ATOM_CHUNK past this (event-
-    based cadence, no timer), so a busy segment re-captions once per chunk of work, not per atom."""
+    based cadence, no timer), so a busy segment re-captions once per chunk of work, not per atom. Derived
+    from the one parse _captions_rows holds per file state (2026-09-09)."""
     out = {}
-    try:
-        for line in (CAPDIR / (fsid + ".jsonl")).read_text(errors="replace").splitlines():
-            try:
-                o = json.loads(line)
-            except Exception:
-                continue
-            if o.get("live") and o.get("id"):
-                out[o["id"]] = o.get("natoms", 0)         # last-wins: the latest live caption's size
-    except OSError:
-        pass
+    for o in _captions_rows(fsid):
+        if o.get("live") and o.get("id"):
+            out[o["id"]] = o.get("natoms", 0)             # last-wins: the latest live caption's size
     return out
 
 
@@ -2729,18 +2775,9 @@ def archive_llm(session_log):
 
 
 def session_turn_captions(fsid):
-    """The session's TURN captions, oldest first — the archiver's input."""
-    caps = []
-    try:
-        for line in (CAPDIR / (fsid + ".jsonl")).read_text(errors="replace").splitlines():
-            try:
-                o = json.loads(line)
-            except Exception:
-                continue
-            if o.get("grain") == "turn" and o.get("caption"):
-                caps.append((o.get("t", 0), o["caption"]))
-    except OSError:
-        pass
+    """The session's TURN captions, oldest first — the archiver's input. Derived from the one parse
+    _captions_rows holds per file state (2026-09-09)."""
+    caps = [(o.get("t", 0), o["caption"]) for o in _captions_rows(fsid) if o.get("grain") == "turn" and o.get("caption")]
     caps.sort()
     return [c for _, c in caps]
 
@@ -3670,7 +3707,7 @@ def _replay_overrides(fsid, store, lines=None):
         op, t = ev.get("op"), int(ev.get("t") or 0)
         if op == "restore":
             if arch_nodes is None:
-                arch_nodes = (load_goal_archive(fsid) or {}).get("nodes", {})
+                arch_nodes = (load_goal_archive_shared(fsid) or {}).get("nodes", {})   # read-only: membership
             for nid, nddata in (ev.get("nodes") or {}).items():
                 if nid in store.get("nodes", {}) or nid in arch_nodes:
                     continue                           # alive, or re-cleared into the archive → nothing lost
@@ -4504,6 +4541,24 @@ def load_goal_archive(fsid):
         return _guard_nodes(json.loads((GOALARCHDIR / (fsid + ".json")).read_text()))
     except Exception:
         return {"rompUuid": fsid, "nodes": {}, "status": {}}
+
+
+def load_goal_archive_shared(fsid):
+    """load_goal_archive for READERS: the guarded archive store, loaded once per file state and served while
+    the file stands (2026-09-09), the key its stat taken before the read. The object is shared and read-only
+    by contract; every archiver (a compaction, a rewind sweep, an undo restore) keeps load_goal_archive, a
+    fresh private object it mutates and saves under the archive lock."""
+    p = GOALARCHDIR / (fsid + ".json")
+    key = _file_key(str(p))
+    ent = _GOALARCH_MEMO.get(fsid)
+    if ent is not None and isinstance(key, tuple) and ent[0] == key:
+        _GOALARCH_STATS["served"] += 1
+        return ent[1]
+    store = load_goal_archive(fsid)
+    _GOALARCH_STATS["loaded"] += 1
+    if isinstance(key, tuple):
+        _memo_put(_GOALARCH_MEMO, fsid, key, store)
+    return store
 
 
 def save_goal_archive(fsid, store):
@@ -7776,7 +7831,7 @@ def _cleared_context(fsid, store, cap=6):
     mine = [iid for iid in times if iid.startswith(fsid + ":")]
     if not mine:
         return ""
-    arch = load_goal_archive(fsid).get("nodes", {})
+    arch = load_goal_archive_shared(fsid).get("nodes", {})   # read-only context: the re-plan's <recently-cleared> block
     nodes = store.get("nodes", {})
     out = []
     for iid in sorted(mine, key=lambda i: times[i], reverse=True)[:cap]:
@@ -10849,7 +10904,7 @@ def _deleg_report_lines(store, nid):
             sub = ""                                   # the bare pre-fix form carries none
         if not sub and ":" not in str(h.get("peer") or ""):
             try:                                       # read-only recipient join (local peers only)
-                r_nodes = dict(load_goal_archive(h["peer"]).get("nodes") or {})
+                r_nodes = dict(load_goal_archive_shared(h["peer"]).get("nodes") or {})   # a copy of the map; the nodes are read
                 r_nodes.update(load_goals(h["peer"]).get("nodes") or {})
                 for rn in r_nodes.values():
                     o = rn.get("origin")
@@ -12916,7 +12971,7 @@ def _deleg_frame(store, nid):
     parts = [str(nd["frame"])]
     if o.get("goalId") and not o.get("peerHost"):
         try:
-            snodes = dict(load_goal_archive(o["peer"]).get("nodes") or {})
+            snodes = dict(load_goal_archive_shared(o["peer"]).get("nodes") or {})   # a copy of the map; the nodes are read
             snodes.update(load_goals(o["peer"]).get("nodes") or {})
             tr = snodes.get(o["goalId"]) or {}
             ask = (snodes.get(tr.get("parentId") or "") or {}).get("text") or ""
@@ -14868,7 +14923,7 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbos
     def _arch(sid):
         a = archives.get(sid)
         if a is None:
-            a = archives[sid] = load_goal_archive(sid)
+            a = archives[sid] = load_goal_archive_shared(sid)   # read-only: the pass never saves an archive
         return a
 
     def _publish(sid):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -398,7 +398,8 @@ class _PerfStats:
         memos = {}
         for key, read in (("pass", _goals_memo_report), ("shared", jd.shared_store_stats),
                           ("chain", jd.chain_memo_stats), ("courierSkip", jd.courier_skip_stats),
-                          ("backref", jd.backref_memo_stats)):
+                          ("backref", jd.backref_memo_stats), ("captions", jd.captions_memo_stats),
+                          ("goalArchive", jd.goal_archive_memo_stats)):
             try:
                 memos[key] = read()
             except Exception:

--- a/tests/test_file_read_memos.py
+++ b/tests/test_file_read_memos.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""The index tier's caption readers and the re-plan's cleared context read their files once per file state
+(2026-09-09): captions/<sid>.jsonl is parsed once and captioned_ids, _live_natoms and session_turn_captions
+derive from that parse; goals-archive/<sid>.json is loaded once for readers (load_goal_archive_shared) while
+every archiver keeps the fresh loader.
+
+Measured on the maintainer's box (py-spy, the judge tier thread): the three caption readers decoded the whole
+file three times per session per index pass (19% of the thread), the archive loader decoded per call (11%).
+Pins: parsed once then served; the derived readers equal the direct derivations; an append re-derives, including
+one the file clock cannot see; a write landing during the read is served no further than that call; an absent
+file is empty and never cached; a malformed line is skipped; the memos are bounded; the archive's writers get a
+fresh object; the switched callers; a rebound root forgets; the counters.
+
+Synthetic ids under a private synthetic sid; a temp state root."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest.mock import patch
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_file_memos", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "11111111-2222-3333-4444-666666666601"
+T0 = 1781100000
+
+
+class _Memo(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_root = jd.STATE
+        jd._rebind_state(Path(self.td.name))
+        jd.CAPDIR.mkdir(parents=True, exist_ok=True)
+        jd.GOALARCHDIR.mkdir(parents=True, exist_ok=True)
+        self.cap = jd.CAPDIR / (SID + ".jsonl")
+        self.arch = jd.GOALARCHDIR / (SID + ".json")
+        self._reset()
+
+    def tearDown(self):
+        jd._rebind_state(self.saved_root)
+        self._reset()
+        self.td.cleanup()
+
+    @staticmethod
+    def _reset():
+        jd._CAPTIONS_MEMO.clear(); jd._GOALARCH_MEMO.clear()
+        for d in (jd._CAPTIONS_STATS, jd._GOALARCH_STATS):
+            for k in d:
+                d[k] = 0
+
+    def append(self, *rows, mtime=None):
+        with self.cap.open("a") as f:
+            for r in rows:
+                f.write((json.dumps(r) if isinstance(r, dict) else r) + "\n")
+        if mtime is not None:
+            os.utime(self.cap, (mtime, mtime))
+
+    def direct(self):
+        """The three answers computed the way the readers used to: three passes over the file."""
+        rows = []
+        for line in self.cap.read_text(errors="replace").splitlines():
+            try:
+                rows.append(json.loads(line))
+            except Exception:
+                pass
+        done = {o["id"] for o in rows if o.get("id") and not o.get("live")}
+        live = {}
+        for o in rows:
+            if o.get("live") and o.get("id"):
+                live[o["id"]] = o.get("natoms", 0)
+        caps = sorted((o.get("t", 0), o["caption"]) for o in rows if o.get("grain") == "turn" and o.get("caption"))
+        return done, live, [c for _, c in caps]
+
+    def counting(self):
+        reads, real = [], Path.read_text
+
+        def spy(p, *a, **k):
+            if p in (self.cap, self.arch):
+                reads.append(p.name)
+            return real(p, *a, **k)
+        patcher = patch.object(Path, "read_text", spy)
+        patcher.start(); self.addCleanup(patcher.stop)
+        return reads
+
+
+class CaptionsMemo(_Memo):
+    ROWS = [{"id": SID + ":s1", "grain": "work", "t": T0, "caption": "wired the banner"},
+            {"id": SID + ":t1", "grain": "turn", "t": T0 + 5, "caption": "The banner reconnects."},
+            {"id": SID + ":s2", "grain": "work", "t": T0 + 20, "caption": "checking the cap", "live": True, "natoms": 8},
+            {"id": SID + ":t0", "grain": "turn", "t": T0 - 100, "caption": "An earlier turn."}]
+
+    def test_parsed_once_and_the_three_readers_equal_the_direct_derivations(self):
+        self.append(*self.ROWS)
+        expected = self.direct()                          # three passes over the file, the way the readers used to
+        reads = self.counting()
+        got = (jd.captioned_ids(SID), jd._live_natoms(SID), jd.session_turn_captions(SID))
+        self.assertEqual(got, expected)
+        self.assertEqual(got[0], {SID + ":s1", SID + ":t1", SID + ":t0"}, "live rows are not done")
+        self.assertEqual(got[1], {SID + ":s2": 8})
+        self.assertEqual(got[2], ["An earlier turn.", "The banner reconnects."], "oldest first")
+        self.assertEqual(reads, [SID + ".jsonl"], "one read of the file for three readers")
+        self.assertEqual(jd._CAPTIONS_STATS, {"served": 2, "parsed": 1})
+
+    def test_an_append_re_derives_even_when_the_file_clock_does_not_move(self):
+        self.append(*self.ROWS[:2])
+        self.assertEqual(jd.captioned_ids(SID), {SID + ":s1", SID + ":t1"})
+        before = os.stat(self.cap)
+        self.append({"id": SID + ":s2", "grain": "work", "t": T0 + 20, "caption": "checking the cap"}, mtime=before.st_mtime)
+        self.assertEqual(os.stat(self.cap).st_mtime, before.st_mtime)
+        self.assertIn(SID + ":s2", jd.captioned_ids(SID), "the size moved: parsed again")
+        self.assertEqual(jd._CAPTIONS_STATS["parsed"], 2)
+
+    def test_a_live_row_superseded_by_its_final_leaves_the_live_map(self):
+        self.append({"id": SID + ":s2", "grain": "work", "t": T0, "caption": "working", "live": True, "natoms": 8})
+        self.assertEqual((jd.captioned_ids(SID), jd._live_natoms(SID)), (set(), {SID + ":s2": 8}))
+        jd.append_caption(SID, SID + ":s2", "work", T0 + 30, "checked the cap")      # the writer everyone uses
+        self.assertEqual(jd.captioned_ids(SID), {SID + ":s2"}, "the final record is seen at once")
+        self.assertEqual(jd._live_natoms(SID), {SID + ":s2": 8}, "the live row stays until the file says otherwise")
+
+    def test_a_write_landing_during_the_read_is_served_no_further_than_that_call(self):
+        # INTERLEAVED WRITE: a row appended while the file is being read. The key was taken before the read,
+        # so whatever the first call saw is cached under a stat the file no longer has; the next call re-parses.
+        self.append(*self.ROWS[:1])
+        real = Path.read_text
+        landed = []
+
+        def read_then_write(p, *a, **k):
+            data = real(p, *a, **k)
+            if p == self.cap and not landed:
+                landed.append(True)
+                with p.open("a") as f:
+                    f.write(json.dumps(self.ROWS[1]) + "\n")
+            return data
+        with patch.object(Path, "read_text", read_then_write):
+            first = jd.captioned_ids(SID)
+        self.assertEqual(first, {SID + ":s1"}, "what the read saw")
+        self.assertTrue(landed)
+        self.assertEqual(jd.captioned_ids(SID), {SID + ":s1", SID + ":t1"}, "the write moved the stat the second call took")
+        self.assertEqual(jd._CAPTIONS_STATS, {"served": 0, "parsed": 2})
+
+    def test_an_absent_file_is_empty_and_never_cached(self):
+        self.assertEqual((jd.captioned_ids(SID), jd._live_natoms(SID), jd.session_turn_captions(SID)), (set(), {}, []))
+        self.assertEqual(jd._CAPTIONS_STATS, {"served": 0, "parsed": 0})
+        self.assertNotIn(SID, jd._CAPTIONS_MEMO)
+        self.append(*self.ROWS[:1])
+        self.assertEqual(jd.captioned_ids(SID), {SID + ":s1"}, "the first row is seen at once")
+
+    def test_a_malformed_or_non_object_line_is_skipped(self):
+        self.append(self.ROWS[0], "{not json", "[1, 2]", "42", self.ROWS[1])
+        self.assertEqual(jd.captioned_ids(SID), {SID + ":s1", SID + ":t1"})
+
+    def test_the_memo_is_bounded(self):
+        saved = jd._FILE_MEMO_MAX
+        jd._FILE_MEMO_MAX = 3
+        try:
+            for i in range(5):
+                sid = "11111111-2222-3333-4444-6666666666%02d" % (10 + i)
+                (jd.CAPDIR / (sid + ".jsonl")).write_text(json.dumps({"id": sid + ":s1", "grain": "work", "t": T0, "caption": "x"}) + "\n")
+                jd.captioned_ids(sid)
+            self.assertEqual(len(jd._CAPTIONS_MEMO), 3, "oldest-inserted out at the cap")
+            self.assertNotIn("11111111-2222-3333-4444-666666666610", jd._CAPTIONS_MEMO)
+        finally:
+            jd._FILE_MEMO_MAX = saved
+
+
+class GoalArchiveMemo(_Memo):
+    def _write(self, nodes, mtime=None):
+        self.arch.write_text(json.dumps({"rompUuid": SID, "nodes": nodes, "status": {k: "cleared" for k in nodes}}))
+        if mtime is not None:
+            os.utime(self.arch, (mtime, mtime))
+
+    @staticmethod
+    def _node(nid, text):
+        return {"id": nid, "text": text, "parentId": None, "nodeComplete": False, "blocked": False,
+                "cleared": True, "trail": [], "t": T0}
+
+    def test_loaded_once_then_served_and_the_writers_get_a_fresh_object(self):
+        self._write({SID + ":g1": self._node(SID + ":g1", "Ship the banner")})
+        reads = self.counting()
+        a = jd.load_goal_archive_shared(SID)
+        b = jd.load_goal_archive_shared(SID)
+        self.assertIs(a, b, "one object, served")
+        self.assertEqual(reads, [SID + ".json"])
+        self.assertEqual(set(a["nodes"]), {SID + ":g1"})
+        self.assertEqual(jd._GOALARCH_STATS, {"served": 1, "loaded": 1})
+        w1, w2 = jd.load_goal_archive(SID), jd.load_goal_archive(SID)
+        self.assertIsNot(w1, w2); self.assertIsNot(w1, a)
+        self.assertEqual(reads.count(SID + ".json"), 3, "an archiver's loader reads fresh every time, as before")
+
+    def test_a_write_re_derives_even_when_the_file_clock_does_not_move(self):
+        self._write({SID + ":g1": self._node(SID + ":g1", "Ship the banner")})
+        jd.load_goal_archive_shared(SID)
+        before = os.stat(self.arch)
+        self._write({SID + ":g1": self._node(SID + ":g1", "Ship the banner"),
+                     SID + ":g2": self._node(SID + ":g2", "Retire the cap")}, mtime=before.st_mtime)
+        self.assertEqual(set(jd.load_goal_archive_shared(SID)["nodes"]), {SID + ":g1", SID + ":g2"})
+        self.assertEqual(jd._GOALARCH_STATS["loaded"], 2)
+
+    def test_a_write_landing_during_the_read_is_served_no_further_than_that_call(self):
+        self._write({SID + ":g1": self._node(SID + ":g1", "Ship the banner")})
+        real = Path.read_text
+        landed = []
+
+        def read_then_write(p, *a, **k):
+            data = real(p, *a, **k)
+            if p == self.arch and not landed:
+                landed.append(True)
+                self._write({SID + ":g1": self._node(SID + ":g1", "Ship the banner"),
+                             SID + ":g2": self._node(SID + ":g2", "Retire the cap")})
+            return data
+        with patch.object(Path, "read_text", read_then_write):
+            first = jd.load_goal_archive_shared(SID)
+        self.assertEqual(set(first["nodes"]), {SID + ":g1"})
+        self.assertTrue(landed)
+        self.assertEqual(set(jd.load_goal_archive_shared(SID)["nodes"]), {SID + ":g1", SID + ":g2"})
+        self.assertEqual(jd._GOALARCH_STATS, {"served": 0, "loaded": 2})
+
+    def test_an_absent_archive_is_the_empty_shape_and_never_cached(self):
+        a = jd.load_goal_archive_shared(SID)
+        self.assertEqual((a["nodes"], a["status"]), ({}, {}))
+        self.assertNotIn(SID, jd._GOALARCH_MEMO)
+        self.assertEqual(jd._GOALARCH_STATS, {"served": 0, "loaded": 1})
+
+    def test_the_readers_take_the_shared_loader_and_the_archivers_keep_the_fresh_one(self):
+        src = open(os.path.join(BIN, "romp-judge")).read()
+        self.assertIn('arch = load_goal_archive_shared(fsid).get("nodes", {})', src, "the re-plan's cleared context")
+        self.assertIn('arch_nodes = (load_goal_archive_shared(fsid) or {}).get("nodes", {})', src, "the override replay's restore membership")
+        self.assertIn('r_nodes = dict(load_goal_archive_shared(h["peer"]).get("nodes") or {})', src)
+        self.assertIn('snodes = dict(load_goal_archive_shared(o["peer"]).get("nodes") or {})', src)
+        self.assertIn('a = archives[sid] = load_goal_archive_shared(sid)', src, "the propagate pass's per-pass archive map reads")
+        for writer in ('        arch = load_goal_archive(fsid)\n        a_nodes = arch.setdefault("nodes", {})',
+                       '            arch = load_goal_archive(fsid)\n            for nid in back:'):
+            self.assertIn(writer, src, "an archiver loads fresh")
+
+    def test_a_rebound_root_forgets_both_memos(self):
+        self.append({"id": SID + ":s1", "grain": "work", "t": T0, "caption": "x"})
+        self._write({SID + ":g1": self._node(SID + ":g1", "Ship the banner")})
+        jd.captioned_ids(SID); jd.load_goal_archive_shared(SID)
+        self.assertTrue(jd._CAPTIONS_MEMO and jd._GOALARCH_MEMO)
+        other = tempfile.TemporaryDirectory()
+        try:
+            jd._rebind_state(Path(other.name))
+            self.assertEqual((jd._CAPTIONS_MEMO, jd._GOALARCH_MEMO), ({}, {}))
+        finally:
+            jd._rebind_state(Path(self.td.name))
+            other.cleanup()
+
+    def test_the_counters_are_copies(self):
+        for fn in (jd.captions_memo_stats, jd.goal_archive_memo_stats):
+            s = fn(); k = next(iter(s)); s[k] = 99
+            self.assertNotEqual(fn()[k], 99)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -115,7 +115,9 @@ class Collector(unittest.TestCase):
         self.assertIn("cpu_ms_workers", snap["judge"])
         self.assertEqual(set(snap["goals"]), {"loads", "saves", "writes"}, "read through jd.goal_io_stats")
         # the three identity memos' readers land here (review find, 2026-09-08: they had no consumer)
-        self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate", "cleared", "courierSkip", "backref"})
+        self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate", "cleared", "courierSkip", "backref", "captions", "goalArchive"})
+        self.assertEqual(set(snap["memos"]["captions"]), {"served", "parsed"})
+        self.assertEqual(set(snap["memos"]["goalArchive"]), {"served", "loaded"})
         self.assertEqual(set(snap["memos"]["backref"]), {"served", "built"},
                          "the sender-board walk behind the courier link repair: built once per input state (2026-09-09)")
         self.assertEqual(snap["memos"]["nudgeGate"], {"served": 0, "derived": 0},


### PR DESCRIPTION
Tier: fix

## What

Two per-file read memos on the judge side, keyed the same way (the file's stat, inode, mtime_ns and size, taken **before** the read; served only while the key stands):

1. **The captions file is parsed once per file state.** `captioned_ids`, `_live_natoms` and `session_turn_captions` each read and JSON-decoded the whole `captions/<sid>.jsonl` for every session on every index pass, 19% of the judge tier thread's samples. One parse (`_captions_rows`) now serves the three readers, each derived from the rows exactly as before. The file is append-only (`append_caption`), so a same-second append moves the size. An absent or unreadable file is empty and never cached; a malformed line is skipped as before, and a well-formed line that is not an object is skipped too (the old readers would have raised on it).

2. **The goal archive is loaded once per file state for readers.** `load_goal_archive` decoded `goals-archive/<sid>.json` per call, 11% of the tier thread; most calls were the re-plan's cleared context, the override replay's restore membership, two peer-node joins and the propagate pass's per-pass map, none of which write. Those take `load_goal_archive_shared`, the memo, whose object is shared and read-only by contract; every archiver (the compaction, the rewind sweep, the undo restore, the ledger merge in the kernel) keeps `load_goal_archive`, a fresh private object it mutates and saves under the archive lock.

Both memos are bounded (256 entries, oldest-inserted out) and cleared with the state root; counters ride `/perf` as `memos.captions` (`served`, `parsed`) and `memos.goalArchive` (`served`, `loaded`). No card-move rule changes: the readers' answers are the same functions of the same file content.

## Review (by hand)

Key rule: each key is the file's stat taken before the read, so a write during the read leaves the cache under a key the file no longer has and the next call re-derives (the interleaved-write tests pin it for both files); a stat error yields a fresh sentinel that never matches. Writers: every `save_goal_archive` site loads through `load_goal_archive` (the fresh loader), pinned by source; `load_goal_archive_shared` is only reached from readers, and the shared object is never handed to a saver. The captions memo's rows are shared across the three derivations, none of which mutate a row. Bounds: the eviction pops the oldest-inserted entry, so a box with more sessions than the cap re-parses the oldest rather than growing. Threads: the index tier and the planner workers both read captions; a race between two fills writes the same content under the same key, and a slot is replaced whole.

## Tests

`tests/test_file_read_memos.py` (new): parsed once and the three readers equal the direct three-pass derivations; an append re-derives even when the file clock does not move; a live row superseded by its final through `append_caption` is seen at once; a write landing during the read is served no further than that call; an absent file is empty and never cached; a malformed or non-object line is skipped; the memo is bounded; the archive is loaded once then served while every writer's load is fresh; an archive write re-derives; the interleaved write; an absent archive is the empty shape and never cached; the switched readers and the kept writers are pinned by source; a rebound root forgets both; the counters are copies. `tests/test_perf_stats.py`: the memos key set and the two shapes. `docs/reference.md`: the memos passage.

## After

Posted below after the deploy restart at matched uptime: judge tier thread, planner pool and process CPU shares, with the two memos' counters.
