### PR TITLE
Timeline: the dead-lane memo's key carries each file's ctime and the host's recorded suspensions

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -30701,12 +30701,12 @@ def _cleared_ids():
     Parsed once per file state and served while the file stands (2026-09-09): the nudge walk read it for
     every session on every pusher cycle, and once the placement gate was memoized this replay of the whole
     log (two thousand rows on the maintainer's box) was 60% of the nudge tick. The key is the file's path
-    and stat (mtime_ns, size, inode), taken BEFORE the read (the chain-memo rule): a row appended during the
-    read moves the stat the next call takes, so a set parsed mid-write is served no further than that call;
-    every writer appends, so a same-second append moves the size (the kernel's file clock is coarse, so
-    mtime alone would not see it); a rebound state root is a different path. An absent or unreadable file
-    is the empty set, never cached. One slot, replaced whole, so two threads deriving at once can never pair
-    one's key with the other's set. Callers read the returned dict and never mutate it."""
+    and stat (mtime_ns, size, inode, ctime_ns), taken BEFORE the read (the chain-memo rule): a row appended
+    during the read moves the stat the next call takes, so a set parsed mid-write is served no further than
+    that call; every writer appends, so a same-second append moves the size (the kernel's file clock is
+    coarse, so mtime alone would not see it); a rebound state root is a different path. An absent or
+    unreadable file is the empty set, never cached. One slot, replaced whole, so two threads deriving at
+    once can never pair one's key with the other's set. Callers read the returned dict and never mutate it."""
     path = jd.STATE / "cleared.jsonl"
     st = _stat_key(path)
     key = (str(path),) + st if st is not None else None
@@ -35122,18 +35122,27 @@ def _derive_judging(sid, caps, goals, t0, out, seg_ends=None, stamp=False):
 # 6 s cycle), and every rebuild parsed every lane's transcript and goals again — dead lanes included, the
 # majority within the 12 h window, none of which had changed. The memo holds the PARSE-DERIVED parts of a
 # dead lane (bars, compactions, the work end, and its judging marks stamped for the horizon filter) under a
-# key of every file they read; the clock-dependent parts (awaiting/compacting intervals, `since`) are
-# derived per build as before, so a cached lane's frame is byte-identical to a rebuilt one. Once a dead
-# lane is cached, its PARSE is dropped from _parse_cache: nothing else reads a dead session's parse per
-# cycle, and those parses were the bulk of a multi-GB resident set (a 166 MB transcript parses to ~220 MB).
+# key of every file they read and of the host's recorded suspensions (the in-memory list _awake_spans reads;
+# its jsonl mirror is appended best-effort, so the list, not the file, is the input). A transcript that
+# cannot be read parses as the empty lane (the read layer returns no records on an OSError) and a parse that
+# raises is stored the same way; either is parsed again when the transcript's stat moves, which a chmod or
+# chown that repairs the read does through the ctime in _stat_key. The clock-dependent parts
+# (awaiting/compacting intervals, `since`) are derived per build as before, so a cached lane's frame is
+# byte-identical to a rebuilt one. Once a dead lane is cached, its PARSE is dropped from _parse_cache:
+# nothing else reads a dead session's parse per cycle, and those parses were the bulk of a multi-GB
+# resident set (a 166 MB transcript parses to ~220 MB).
 _dead_lane_memo = {}      # sid -> (key, {"bars", "compactions", "last_t", "marks"})
 _DEAD_LANE_MEMO_MAX = 512
 
 
 def _stat_key(p):
+    """A file's identity for the memos keyed on it: mtime_ns, size, inode and ctime_ns. The ctime is there
+    because a chmod, chown or rename moves it while mtime, size and inode stand, and the dead-lane memo
+    caches a lane whose transcript could not be read as the empty lane, so a permission fix must move its
+    key. None when the file cannot be stat'd."""
     try:
         st = os.stat(p)
-        return (st.st_mtime_ns, st.st_size, st.st_ino)
+        return (st.st_mtime_ns, st.st_size, st.st_ino, st.st_ctime_ns)
     except OSError:
         return None
 
@@ -35141,7 +35150,10 @@ def _stat_key(p):
 def _dead_lane_key(sid, path, branch):
     """Every input the parse-derived parts of a dead lane read: the transcript and its states file (the
     parse), the goals store (seams, judging), the captions and the archive (judging), the session flags
-    (the blocked state), and the branch clip. None when the transcript cannot be stat'd (never cache)."""
+    (the blocked state), the branch clip, and the host's recorded suspensions (tuple(_downtime)), which
+    _awake_spans excises from every bar; a suspension recorded after the lane was cached would otherwise
+    leave the un-excised bar served until a keyed file moved, which a dead transcript never does. None when
+    the transcript cannot be stat'd (never cache)."""
     tk = _stat_key(path)
     if tk is None:
         return None
@@ -35150,7 +35162,8 @@ def _dead_lane_key(sid, path, branch):
             _stat_key(jd.CAPDIR / (sid + ".jsonl")),                # the file _captions(sid) reads
             _stat_key(jd.STATE / "archive" / (sid + ".json")),
             _stat_key(jd.STATE / "session-flags.json"),
-            (branch or {}).get("fromId"), (branch or {}).get("t"), (branch or {}).get("cut"))
+            (branch or {}).get("fromId"), (branch or {}).get("t"), (branch or {}).get("cut"),
+            tuple(_downtime))
 
 
 def _dead_lane_marks(marks, t0):

--- a/tests/test_cleared_set_memo.py
+++ b/tests/test_cleared_set_memo.py
@@ -8,13 +8,15 @@ append-only log (two thousand rows) for every session on every cycle. Pins: pars
 append re-derives, including one the file clock cannot see (same mtime, larger size); an undo row removes;
 a set read before a write is served no further than that call (the key is the stat taken before the read);
 an absent file is empty and never cached; the key carries the path, so a rebound state root is a new key;
-the pass hoists one set and the walk takes it; the counters ride /perf.
+a chmod of the log re-derives once (the shared stat key carries ctime_ns); the pass hoists one set and the
+walk takes it; the counters ride /perf.
 
 Synthetic ids under a private synthetic sid; a temp state root; nothing real is read."""
 import inspect
 import json
 import os
 import tempfile
+import time
 import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
@@ -32,6 +34,21 @@ jd = km.jd
 SID = "11111111-2222-3333-4444-888888888802"
 G1, G2, G3 = SID + ":g1", SID + ":g2", SID + ":g3"
 NOW = 1_800_000_000
+
+
+def _move_ctime(path):
+    """Move a file's ctime and nothing else: flip its mode between 0o600 and 0o644, checking the stat after
+    each chmod, until the ctime differs (a coarse filesystem clock can hand two chmods one timestamp). mtime,
+    size and inode stand. Bounded at 5 s: a filesystem that never ticks ctime under chmod fails the test
+    loudly rather than passing it."""
+    before = cur = os.stat(path)
+    deadline = time.monotonic() + 5
+    while cur.st_ctime_ns == before.st_ctime_ns:
+        if time.monotonic() > deadline:
+            raise AssertionError("ctime did not move under chmod within 5 s")
+        os.chmod(path, 0o644 if (cur.st_mode & 0o777) == 0o600 else 0o600)
+        cur = os.stat(path)
+    return cur
 
 
 class _Memo(unittest.TestCase):
@@ -139,7 +156,7 @@ class ClearSetMemo(_Memo):
         km._cleared_ids()
         key = km._CLEARED_MEMO["slot"][0]
         self.assertEqual(key[0], str(self.path))
-        self.assertEqual(len(key), 4, "path, then the stat's mtime_ns, size and inode")
+        self.assertEqual(len(key), 5, "path, then the stat's mtime_ns, size, inode and ctime_ns")
         other = tempfile.TemporaryDirectory()
         try:
             jd._rebind_state(Path(other.name))
@@ -148,6 +165,31 @@ class ClearSetMemo(_Memo):
         finally:
             jd._rebind_state(Path(self.td.name))
             other.cleanup()
+
+    def test_a_chmod_of_the_log_re_derives_the_set_once(self):
+        """_stat_key is shared with the dead-lane memo and carries ctime_ns, which a chmod or chown moves while
+        mtime, size and inode stand: the set is derived again once and then served as before. No kernel path
+        changes this log's metadata without appending, so that one read is the whole cost of the member."""
+        self._append(self._clear(G1, NOW - 100))
+        real, reads = Path.read_text, []
+
+        def counting(p, *a, **k):
+            if p == self.path:
+                reads.append(p)
+            return real(p, *a, **k)
+        with patch.object(Path, "read_text", counting):
+            a = km._cleared_ids()
+            self.assertIs(km._cleared_ids(), a)
+            key0 = km._CLEARED_MEMO["slot"][0]
+            _move_ctime(self.path)
+            b = km._cleared_ids()
+            self.assertIs(km._cleared_ids(), b, "served again once re-derived")
+        self.assertEqual(b, a, "the same rows")
+        self.assertEqual(len(reads), 2, "one extra read: the chmod moved the ctime")
+        key1 = km._CLEARED_MEMO["slot"][0]
+        self.assertEqual(key1[:4], key0[:4], "path, mtime_ns, size and inode stood")
+        self.assertNotEqual(key1[4], key0[4], "ctime_ns moved")
+        self.assertEqual(km._CLEARED_STATS, {"served": 2, "derived": 2})
 
     def test_a_malformed_row_is_skipped_as_before(self):
         self._append(self._clear(G1, NOW - 100))

--- a/tests/test_timeline_lane_memo.py
+++ b/tests/test_timeline_lane_memo.py
@@ -4,17 +4,20 @@
 The full timeline build ran every pusher cycle (the fleet signature's 5 s bucket turns over faster than a 6 s
 cycle) and re-parsed every lane's transcript and goals each time, dead lanes included. Now a dead lane's
 parse-derived parts (bars, compactions, the work end, its judging marks) are served from a memo keyed on
-every file they read, its parse is dropped from _parse_cache once cached (the resident-memory lever), and the
-served frame is byte-identical to a rebuilt one: the judging marks are derived once at horizon zero, stamped
-with the value the horizon test compares, and filtered per build on exactly that. The bars encoder reuses the
-strings of entry objects it already encoded.
+every file they read and the host's recorded suspensions, its parse is dropped from _parse_cache once cached
+(the resident-memory lever), and the served frame is byte-identical to a rebuilt one: the judging marks are
+derived once at horizon zero, stamped with the value the horizon test compares, and filtered per build on
+exactly that. The bars encoder reuses the strings of entry objects it already encoded.
 
 Synthetic transcript, states and captions under a temp root; a placeholder sid; the lane is dead because the
 liveness snapshot is empty."""
+import io
 import json
 import os
 import tempfile
+import time
 import unittest
+from contextlib import redirect_stderr
 from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
@@ -42,6 +45,21 @@ def _rec(kind, t, uuid, parent, text):
                 "message": {"role": "user", "content": text}}
     return {"type": "assistant", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
             "message": {"role": "assistant", "content": [{"type": "text", "text": text}], "stop_reason": "end_turn"}}
+
+
+def move_ctime(path):
+    """Move a file's ctime and nothing else: flip its mode between 0o600 and 0o644, checking the stat after
+    each chmod, until the ctime differs (a coarse filesystem clock can hand two chmods one timestamp). mtime,
+    size and inode stand. Bounded at 5 s: a filesystem that never ticks ctime under chmod fails the test
+    loudly rather than passing it."""
+    before = cur = os.stat(path)
+    deadline = time.monotonic() + 5
+    while cur.st_ctime_ns == before.st_ctime_ns:
+        if time.monotonic() > deadline:
+            raise AssertionError("ctime did not move under chmod within 5 s")
+        os.chmod(path, 0o644 if (cur.st_mode & 0o777) == 0o600 else 0o600)
+        cur = os.stat(path)
+    return cur
 
 
 class DeadLaneMemo(unittest.TestCase):
@@ -74,6 +92,7 @@ class DeadLaneMemo(unittest.TestCase):
     def tearDown(self):
         (km.jd.NAMES, km.jd.PROJECTS, km.jd.GOALDIR, km.jd.CAPDIR, km.jd.STATE, km.NAMES, km._tmux_sessions) = self.saved
         km._dead_lane_memo.clear()
+        km._downtime[:] = []
         self.td.cleanup()
 
     def _write(self, recs):
@@ -169,6 +188,93 @@ class DeadLaneMemo(unittest.TestCase):
                                            "context": None, "compactPct": None, "color": None, "mode": ""}}
         km.build_timeline(NOW, km._tmux_sessions(), with_bars=True)
         self.assertNotIn(SID, km._dead_lane_memo)
+
+    def test_a_chmod_alone_moves_the_transcripts_stat_key(self):
+        """A chmod, chown or rename moves a file's ctime while its mtime, size and inode stand, so the stat
+        key carries st_ctime_ns as its fourth member: the repair of a read the memo cached as the empty lane is
+        visible to the key."""
+        p = str(self.tpath)
+        k0 = km._stat_key(p)
+        move_ctime(p)
+        k1 = km._stat_key(p)
+        self.assertNotEqual(k0, k1, "ctime is in the key: a chmod or a rename moves it")
+        self.assertEqual(k0[:3], k1[:3], "mtime, size and inode stood")
+        self.assertIsNone(km._stat_key(p + ".absent"))
+
+    def test_a_failed_parse_is_served_once_cached_and_re_attempted_when_the_transcripts_stat_moves(self):
+        """A transcript that cannot be read parses as the empty lane (the read layer returns no records on an
+        OSError, silently) and a parse that raises leaves the same empty lane plus one stderr line; either is
+        cached like any other lane (a dead transcript has no writer, so the result would repeat). The lane is
+        derived again only when a keyed file moves, and a chmod or chown that repairs the read moves neither
+        mtime, size nor inode: the ctime in the key is what makes the repair visible. The vehicle here is a
+        raising stub, the path with an observable complaint; the chmod only moves the ctime."""
+        parses, failing = [], [True]
+        real = km._parse
+
+        def parse(path, sid, now):
+            parses.append(path)
+            if failing[0]:
+                raise OSError("unreadable")
+            return real(path, sid, now)
+        km._parse = parse
+        km._BARS_COMPLAINED.pop((SID, "parse"), None)   # the complaint latch: one line per distinct cause
+        err = io.StringIO()
+        try:
+            with redirect_stderr(err):
+                tl1 = self._build()
+                tl2 = self._build()
+            self.assertEqual(len(parses), 1, "parsed once: the failed parse is cached as the empty lane")
+            self.assertEqual(tl1["turns"][SID], [])
+            self.assertEqual(tl2["turns"][SID], [], "served as the empty lane it drew")
+            self.assertEqual(err.getvalue().count("timeline bars:"), 1, "one stderr line, none when served")
+            self.assertIn(SID, km._dead_lane_memo)
+            failing[0] = False
+            move_ctime(self.tpath)
+            tl3 = self._build()
+            self.assertEqual(len(parses), 2, "the transcript's stat moved: the parse is attempted again")
+            self.assertEqual(len(tl3["turns"][SID]), 1, "readable again: the bar is drawn")
+            self._build()
+            self.assertEqual(len(parses), 2, "and the repaired lane is served like any other")
+        finally:
+            km._parse = real
+
+    def test_a_suspension_recorded_after_the_lane_was_cached_re_derives_it(self):
+        """_awake_spans excises every recorded suspension from each segment's span, reading the in-memory list
+        (its jsonl mirror is appended best-effort, so the list, not the file, is the input), and the list
+        grows at run time when the producer's tick detects a sleep, on a thread other than the build's. The
+        key carries the list: a nap inside a cached segment splits its bar on the very next build; a
+        different nap of the same count is a different key; a nap outside every segment re-derives to equal
+        bars; the same list rebound is served."""
+        parses = []
+        real = km._parse
+        km._parse = lambda path, sid, now: (parses.append(path), real(path, sid, now))[1]
+        try:
+            self._build()
+            key0 = km._dead_lane_memo[SID][0]
+            self.assertEqual(len(parses), 1)
+            km._downtime[:] = [(T0 + 3, T0 + 7)]            # a nap inside the one segment, an atom on each side
+            tl = self._build()
+            self.assertEqual(len(tl["turns"][SID]), 2, "the bar is cut at the nap on the very next build")
+            self.assertEqual(len(parses), 2, "derived again, not served")
+            key1 = km._dead_lane_memo[SID][0]
+            self.assertNotEqual(key1, key0, "the suspensions are in the key")
+            km._downtime[:] = [(T0 + 2, T0 + 8)]            # a different nap, the same count
+            tl2 = self._build()
+            self.assertNotEqual(tl2["turns"][SID], tl["turns"][SID], "a different nap cuts the bar elsewhere")
+            key2 = km._dead_lane_memo[SID][0]
+            self.assertNotEqual(key2, key1, "a nap of the same count is a different key")
+            km._downtime.append((NOW - 20000, NOW - 19000))  # a sleep outside every segment: equal bars, a new key
+            tl3 = self._build()
+            key3 = km._dead_lane_memo[SID][0]
+            self.assertNotEqual(key3, key2)
+            self.assertEqual(tl3["turns"][SID], tl2["turns"][SID], "a nap outside every segment: the same bars")
+            self.assertEqual(len(parses), 4)
+            km._downtime[:] = list(km._downtime)            # the same content, rebound
+            self._build()
+            self.assertEqual(km._dead_lane_memo[SID][0], key3, "the same suspensions: the same key")
+            self.assertEqual(len(parses), 4, "served")
+        finally:
+            km._parse = real
 
 
 class HorizonFilterIsExact(unittest.TestCase):


### PR DESCRIPTION
## Symptom
A dead lane whose transcript cannot be read stays empty until a restart or an eviction, even after a chmod or chown repairs the read. An unreadable transcript parses as an empty session with no complaint (the read layer returns no records on an OSError); a parser fault draws the same empty lane and says so once on stderr; either way the empty lane is cached and served. Separately, a host suspension recorded after a dead lane was cached is never cut out of that lane's bars.

## Cause
The dead-lane memo (#1131) serves a lane while every file its derivation reads stands, keyed on each file's (mtime_ns, size, inode) plus the branch clip. Two inputs the derivation reads are not in that key.

- **The transcript's ctime.** An empty lane is cached like any other (the populate runs; a parser fault's complaint dedups). That is right for a dead transcript with no writer, but the lane is derived again only when a keyed file moves, and a chmod or chown that repairs the read moves neither mtime, size nor inode.
- **The host's recorded suspensions.** `_awake_spans` excises every interval in `_downtime` from each segment's span. It reads the in-memory list (`_record_suspend` appends the jsonl mirror best-effort, so the list, not the file, is the input); the list grows when the producer's tick detects a sleep, and the timeline builds on the pusher thread. A lane derived after a resume but before that tick (a session that died across the sleep) draws one bar across the sleep and caches it; the interval recorded seconds later moves no file.

## Fix
`_stat_key` now carries `st_ctime_ns` as its fourth member: the repair moves the key and the parse is attempted once more. `_stat_key` is shared: it also keys the cleared-set memo and the nudge-gate memo's episodes file. The cleared-set memo re-derives once on a chmod of cleared.jsonl, one extra read (a new test pins it, and the docstring names the fourth member); the nudge-gate memo compares the episodes file's key by equality, so the same follows there. If a dead-lane-only stat is preferred: a second stat helper carrying ctime, called by `_dead_lane_key` alone, with `_stat_key`, the other two memos and their tests unchanged.

`_dead_lane_key` now ends in `tuple(_downtime)`, so the next build re-cuts the bars. The cost: a recorded suspension re-derives every cached dead lane once on the next build (a parse per lane, from the assembly cache while it holds the leaf and from disk once it does not, then re-segmentation and the judging marks), about 18 times a night under macOS dark-wake by the figure in `_awake_spans`. Clearing the memo from `_record_suspend` would cost the same; the key form keeps every input in one place and is what the tests pin. A later change could store each lane's cached span and re-derive only the lanes a new nap overlaps. The tuple is a copy of the append-only list, built per dead lane per build, and each cached lane holds one; a hoist per build would share one object if that matters.

No change to what is cached or when; a served lane stays byte-identical to a rebuilt one; the memo's header comment names both inputs.

## Tests
`tests/test_timeline_lane_memo.py`, three cases in `DeadLaneMemo`, each red on main:
- a chmod alone moves the transcript's stat key while mtime, size and inode stand (red: the two keys are equal);
- a parse that raises is cached as the empty lane and served once, with one stderr line across the two builds, then attempted again after the transcript's ctime moves and draws its bar (red: the parse count stays at 1 and the lane stays empty);
- a suspension set inside a cached segment splits the bar on the very next build and moves the key, a different nap of the same count re-derives again, one outside every segment re-derives to equal bars, and the same list rebound is served (red: the single bar is served).

The ctime is moved by chmod in a bounded loop, checked by stat after each attempt, that fails loudly if the filesystem never ticks it. The vehicle for the empty lane is a raising stub, the path with an observable complaint; an unreadable file parses as empty silently and is cached the same way. `tests/test_cleared_set_memo.py`: a new case pins that a chmod of cleared.jsonl re-derives the set once (red on main: the set is served), and the key-length pin reads 5. Module counts: 10 to 13 and 10 to 11.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)