### PR TITLE
Tests: restore the shared judge's roots and the sessions-file seam after every test, and fail the test that does not

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -318,6 +318,95 @@ def _stub_place_llm(monkeypatch):
     yield
 
 
+# No test may leave the shared judge or a call-time environment seam changed (2026-09-09). kernel.py
+# loads the judge as SourceFileLoader("romp_judge", ...).load_module(), and load_module re-executes
+# into the module object already in sys.modules under that name, so every kernel-loading test
+# module's km.jd is ONE process-wide object. A test that rebinds jd.STATE to a temp dir and removes
+# that dir in tearDown without restoring the prior value leaves every later STATE reader in the
+# process pointing at a removed directory: a FileNotFoundError on restart-audit.jsonl or
+# timeline-views.json, or a silent empty read where the writer swallows OSError. The postal
+# sessions-file seam has the same shape: postal_service reads ROMP_SESSIONS_FILE from os.environ at
+# call time, so a tearDown that pops it instead of restoring the prior value leaves a later module,
+# which set the seam once at import, resolving no local sessions. Neither shows when the victim runs
+# alone, and the serial order of the whole suite passes only because a test that loads a kernel
+# between the cause and the victim re-executes judge.py and rebinds the roots; any other order (a
+# subset, another scheduler) fails a module that did nothing wrong. This fixture names the cause
+# instead: it snapshots the shared judge's STATE and PROJECTS and the watched environment names
+# before each test and fails the test that changed one and did not restore it, or left a path that
+# was a directory pointing at nothing. Transition-based on purpose: a module-level preamble runs at
+# collection, before any snapshot, and is not seen; a test that changes and restores is quiet; and a
+# test that merely runs under another test's leftover is not blamed for it. A test that loads a
+# kernel (or the judge itself) re-executes judge.py into the shared module, which rebinds every root
+# from the environment as it stands at that moment: that is the loader's reset, made from values
+# other modules' import-time writes decide, not a directory the test made and removed, so the path
+# check compares no values for that test (the re-execution recreates every function object, which is
+# how it is told apart from an assignment). Only the values: judge.py creates STATE at import, so a
+# STATE that is not a directory after a reload is the test's own doing and is still named, and the
+# environment names are still checked. Values of the environment names are never printed (one of
+# them is a credential), only the kind of change.
+_SHARED_JUDGE_PATHS = ("STATE", "PROJECTS")
+_SEAM_ENV_NAMES = ("ROMP_SESSIONS_FILE", "ROMP_SERVE_TOKEN")
+
+
+def _shared_judge_paths():
+    """({name: (path text or None, is a directory)}, marker) for the shared judge's watched globals,
+    the marker being a function object judge.py defines (a re-execution replaces it); ({}, None) when
+    no module has loaded the judge under its shared name yet."""
+    jd = sys.modules.get("romp_judge")
+    if jd is None:
+        return {}, None
+    out = {}
+    for name in _SHARED_JUDGE_PATHS:
+        p = getattr(jd, name, None)
+        text = None if p is None else str(p)
+        out[name] = (text, text is not None and os.path.isdir(text))
+    return out, vars(jd).get("_rebind_state")
+
+
+@pytest.fixture(autouse=True)
+def _shared_state_restored(request):
+    paths_before, marker_before = _shared_judge_paths()
+    env_before = {name: os.environ.get(name) for name in _SEAM_ENV_NAMES}
+    yield
+    paths_after, marker_after = _shared_judge_paths()
+    left = []
+    if marker_after is marker_before:      # not re-executed: whatever differs, this test assigned
+        for name, (text0, isdir0) in paths_before.items():
+            text1, isdir1 = paths_after.get(name, (None, False))
+            if text1 != text0:
+                left.append("romp_judge.%s changed from %s to %s" % (name, text0, text1))
+            elif isdir0 and not isdir1:
+                left.append("romp_judge.%s %s was a directory and is gone" % (name, text0))
+    else:                                  # re-executed: the loader bound the roots, and created STATE
+        text1, isdir1 = paths_after.get("STATE", (None, False))
+        if text1 is not None and not isdir1:
+            left.append("romp_judge.STATE %s is not a directory after the test reloaded the judge" % text1)
+    for name in _SEAM_ENV_NAMES:
+        v0, v1 = env_before[name], os.environ.get(name)
+        if v0 == v1:
+            continue
+        if v1 is None:
+            left.append("%s was set and is now unset" % name)
+        elif v0 is None:
+            left.append("%s was unset and is now set" % name)
+        else:
+            left.append("%s was changed" % name)
+    if left:
+        pytest.fail("%s left shared state changed after its teardown: %s. Save the prior value before "
+                    "changing it and put it back at the end of the test; for a path, before removing the "
+                    "directory it named." % (request.node.nodeid, "; ".join(left)), pytrace=False)
+
+
+def restore_env(name, prior):
+    """Put the environment name back the way a test found it: `prior` is the os.environ.get(name) taken before
+    the test changed it, None meaning unset. A tearDown that pops the name instead leaves a later module in the
+    process without the value its own import set; this is the restore the fixture above expects."""
+    if prior is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = prior
+
+
 # No test report may carry a process-environment VALUE, or a credential-shaped token (2026-09-05). A
 # test that renders an env mapping in an assertion (assertNotIn on os.environ, on a _judge_env() copy
 # of it, on a launch env) prints the whole mapping when it fails, and on a developer's box that

--- a/tests/test_chat_delta_resync.py
+++ b/tests/test_chat_delta_resync.py
@@ -22,6 +22,8 @@ import re
 from importlib.machinery import SourceFileLoader
 import tempfile
 
+import pytest
+
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
 # Hermetic state BEFORE the loads — they resolve their state root at import time, and only
 # pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
@@ -139,12 +141,21 @@ def test_chat_diff_append_starts_at_the_previous_total():
 
 # ───────────────────────── (2) the fork-lane states key ─────────────────────────
 
-def test_build_sig_folds_in_the_anchor_states_file(tmp_path):
+@pytest.fixture
+def state_root(tmp_path):
+    """The judge rebound to a private state root for one test, and back afterwards: the judge module is
+    shared by every test module in the process, so a root left behind is what the next module reads."""
+    saved = jd.STATE
+    jd._rebind_state(tmp_path)
+    yield tmp_path
+    jd._rebind_state(saved)
+
+
+def test_build_sig_folds_in_the_anchor_states_file(state_root):
     """A forked lane is keyed by a new fsid but keeps writing states/<anchor>.jsonl. The signature must
     stat the anchor's file too, or a settle (which touches ONLY states/) never busts the cached payload
     and the lane latches on 'working'."""
-    jd._rebind_state(tmp_path)
-    km.jd = jd
+    tmp_path = state_root
     (tmp_path / "states").mkdir(parents=True, exist_ok=True)
     tx = tmp_path / "fork.jsonl"
     tx.write_text('{"type":"user"}\n')
@@ -164,10 +175,9 @@ def test_build_sig_folds_in_the_anchor_states_file(tmp_path):
     assert before != after, "a settle under the ANCHOR sid must bust the fork lane's chat cache"
 
 
-def test_build_sig_still_tracks_the_fsid_states_file(tmp_path):
+def test_build_sig_still_tracks_the_fsid_states_file(state_root):
     """The common case (sid == fsid, no fork) must keep working."""
-    jd._rebind_state(tmp_path)
-    km.jd = jd
+    tmp_path = state_root
     (tmp_path / "states").mkdir(parents=True, exist_ok=True)
     sid = "11111111-2222-3333-4444-555555555555"
     tx = tmp_path / (sid + ".jsonl")
@@ -181,11 +191,10 @@ def test_build_sig_still_tracks_the_fsid_states_file(tmp_path):
     assert before != km._chat_build_sig(sess)
 
 
-def test_build_sig_keys_the_rows_context_percentage(tmp_path):
+def test_build_sig_keys_the_rows_context_percentage(state_root):
     """The snapshot row's context-% is `context`, the key the merged liveness row writes; the sig read `ctx`,
     which no row carries, so a background tab's context change never busted its chat cache."""
-    jd._rebind_state(tmp_path)
-    km.jd = jd
+    tmp_path = state_root
     sid = "11111111-2222-3333-4444-555555555555"
     tx = tmp_path / (sid + ".jsonl")
     tx.write_text('{"type":"user"}\n')

--- a/tests/test_clear_chat_view.py
+++ b/tests/test_clear_chat_view.py
@@ -65,8 +65,10 @@ def _write_jsonl(path, rows):
 
 class ClearChatViewTest(unittest.TestCase):
     def setUp(self):
-        self._saved_state = jd.STATE       # restored in tearDown: the judge is one module shared by every test module
-        self._td = tempfile.mkdtemp()      # in the process, and it was left aimed at this tmp after rmtree (T282)
+        # both restored in tearDown: the judge is one module shared by every test module in the process, and
+        # it was left aimed at this tmp after rmtree (T282)
+        self._saved_state, self._saved_projects = jd.STATE, jd.PROJECTS
+        self._td = tempfile.mkdtemp()
         jd._rebind_state(Path(self._td))
         jd.PROJECTS = Path(self._td) / "projects"
         jd._discover_cache["fp"] = None
@@ -102,6 +104,7 @@ class ClearChatViewTest(unittest.TestCase):
 
     def tearDown(self):
         jd._rebind_state(self._saved_state)
+        jd.PROJECTS = self._saved_projects
         shutil.rmtree(self._td, ignore_errors=True)
 
     def _events(self):
@@ -235,8 +238,10 @@ class PreClearNotesStayInTheirEpisode(unittest.TestCase):
     card's fold, with the rest of the pre-clear conversation). Synthetic data only."""
 
     def setUp(self):
-        self._saved_state = jd.STATE       # restored in tearDown: the judge is one module shared by every test module
-        self._td = tempfile.mkdtemp()      # in the process, and it was left aimed at this tmp after rmtree (T282)
+        # both restored in tearDown: the judge is one module shared by every test module in the process, and
+        # it was left aimed at this tmp after rmtree (T282)
+        self._saved_state, self._saved_projects = jd.STATE, jd.PROJECTS
+        self._td = tempfile.mkdtemp()
         jd._rebind_state(Path(self._td))
         jd.PROJECTS = Path(self._td) / "projects"
         jd._discover_cache["fp"] = None
@@ -273,6 +278,7 @@ class PreClearNotesStayInTheirEpisode(unittest.TestCase):
 
     def tearDown(self):
         jd._rebind_state(self._saved_state)
+        jd.PROJECTS = self._saved_projects
         shutil.rmtree(self._td, ignore_errors=True)
 
     def test_live_render_shows_only_the_current_episodes_notes(self):

--- a/tests/test_episode_boundary.py
+++ b/tests/test_episode_boundary.py
@@ -53,6 +53,7 @@ def _node(nid, parent, **kw):
 
 class EpisodeBoundaryTest(unittest.TestCase):
     def setUp(self):
+        self._saved_state = jd.STATE
         self._td = tempfile.mkdtemp()
         jd._rebind_state(Path(self._td))
         self.proj = Path(self._td) / "proj"
@@ -60,6 +61,7 @@ class EpisodeBoundaryTest(unittest.TestCase):
         self.g = lambda n: "%s:%s" % (SID, n)
 
     def tearDown(self):
+        jd._rebind_state(self._saved_state)   # the judge module is shared process-wide: never leave it on a removed dir
         shutil.rmtree(self._td, ignore_errors=True)
 
     def _store(self):

--- a/tests/test_judge_auth_billing.py
+++ b/tests/test_judge_auth_billing.py
@@ -491,11 +491,25 @@ class KeylessKeyBilledCalls(_JudgeAuthBase):
         jd._LOGIN_AUTH_ENV_FN = lambda: {"CLAUDE_CODE_OAUTH_TOKEN": "synthetic-login-token"}
         jd._judge_ctx.fsid = SID
         seen = {}
+        # the fake envelope carries the modelUsage map a current CLI reports, naming the version the bare
+        # alias resolved to (the one the alias table assumes, so nothing drifts); without the map the judge
+        # says once per process that the served version cannot be checked, and whether this test saw that
+        # line depended on which class in the module had already spent the notice
+        served_id = "claude-sonnet-%d-%d" % jd._ALIAS_HEAD["sonnet"]
+        prior_served = jd._ALIAS_SERVED.get("sonnet")     # the answered call records the served version per process
+
+        def put_back():
+            if prior_served is None:
+                jd._ALIAS_SERVED.pop("sonnet", None)
+            else:
+                jd._ALIAS_SERVED["sonnet"] = prior_served
+        self.addCleanup(put_back)
 
         def fake_run(cmd, input=None, env=None, **kw):
             seen["cmd"] = list(cmd)
             seen["env"] = env
-            return SimpleNamespace(stdout=json.dumps({"result": "ok", "usage": {}, "duration_ms": 3}),
+            return SimpleNamespace(stdout=json.dumps({"result": "ok", "usage": {}, "duration_ms": 3,
+                                                      "modelUsage": {served_id: {"outputTokens": 4}}}),
                                    stderr="", returncode=0)
         with patch.object(jd, "_judge_engine", return_value="claude"), \
                 patch.object(jd.subprocess, "run", side_effect=fake_run):

--- a/tests/test_judge_rate_limit_gate.py
+++ b/tests/test_judge_rate_limit_gate.py
@@ -19,6 +19,8 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 import os
 
+from tests.conftest import restore_env
+
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 # Hermetic state BEFORE the loads — they resolve their state root at import time, and only
@@ -194,6 +196,12 @@ class SegKeyUnified(unittest.TestCase):
     def test_kernel_delegates_to_the_judge_seg_key(self):
         # the two copies had to never drift; since 2026-07-07 the kernel's is a delegation, so they cannot.
         import inspect
+        prior = {name: os.environ.get(name) for name in ("ROMP_KERNEL_NO_OPEN", "ROMP_SERVE_TOKEN")}
+
+        def put_back():
+            for name, value in prior.items():
+                restore_env(name, value)
+        self.addCleanup(put_back)      # the kernel's import needs both set; this process keeps neither
         os.environ.setdefault("ROMP_KERNEL_NO_OPEN", "1")
         os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
         km = SourceFileLoader("romp_kernel_segkey", os.path.join(BIN, "romp-kernel")).load_module()

--- a/tests/test_kernel_goal_compaction.py
+++ b/tests/test_kernel_goal_compaction.py
@@ -40,6 +40,7 @@ def _node(nid, parent, **kw):
 
 class GoalCompactionTest(unittest.TestCase):
     def setUp(self):
+        self._saved_state = jd.STATE
         self._td = tempfile.mkdtemp()
         jd._rebind_state(Path(self._td))
         km._compact_seen.clear()
@@ -66,6 +67,7 @@ class GoalCompactionTest(unittest.TestCase):
         self.g = g
 
     def tearDown(self):
+        jd._rebind_state(self._saved_state)   # the judge module is shared process-wide: never leave it on a removed dir
         shutil.rmtree(self._td, ignore_errors=True)
 
     def test_a_cleared_root_and_subtree_leave_the_live_store_for_the_archive(self):

--- a/tests/test_postal_live_only.py
+++ b/tests/test_postal_live_only.py
@@ -11,6 +11,8 @@ import tempfile
 import unittest
 from importlib.machinery import SourceFileLoader
 
+from tests.conftest import restore_env
+
 HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
@@ -39,8 +41,11 @@ def _set_live(rows):
 
 
 class LiveOnlyAddressing(unittest.TestCase):
+    def setUp(self):
+        self._prior_seam = os.environ.get("ROMP_SESSIONS_FILE")
+
     def tearDown(self):
-        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        restore_env("ROMP_SESSIONS_FILE", self._prior_seam)
         pm.HEARTBEATS.clear()
 
     def test_live_name_resolves(self):
@@ -82,10 +87,11 @@ class RecallReachesParkedMailForTheDead(unittest.TestCase):
     two dead boxes wearing one name is not a guess the sender authorized."""
 
     def setUp(self):
+        self._prior_seam = os.environ.get("ROMP_SESSIONS_FILE")
         _set_live([{"id": ALPHA, "name": "alpha"}])
 
     def tearDown(self):
-        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        restore_env("ROMP_SESSIONS_FILE", self._prior_seam)
         for rid in (GHOST, "99999999-8888-7777-6666-555555555556", PEER):
             box = pm.MAILROOT / rid / "new"
             if box.is_dir():
@@ -154,13 +160,13 @@ class KernelSilenceIsNotDeadness(unittest.TestCase):
     resolve_recipient now probes the source once on the refusal path and answers 503-honestly."""
 
     def setUp(self):
-        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        self._prior_seam = os.environ.pop("ROMP_SESSIONS_FILE", None)   # no seam: the source is the kernel
         self._base = pm.KERNEL_BASE
         pm.KERNEL_BASE = "http://127.0.0.1:9"      # nothing listens: every fetch fails fast
 
     def tearDown(self):
         pm.KERNEL_BASE = self._base
-        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        restore_env("ROMP_SESSIONS_FILE", self._prior_seam)
         pm.HEARTBEATS.clear()
 
     def test_unanswered_source_refuses_without_claiming_death(self):
@@ -187,13 +193,14 @@ class AnsweredButAbsentIsNotDeadness(unittest.TestCase):
     GHOST_SID = "99999999-8888-7777-6666-000000000001"
 
     def setUp(self):
+        self._prior_seam = os.environ.get("ROMP_SESSIONS_FILE")
         _set_live([{"id": ALPHA, "name": "alpha"}])     # answered listing, target absent
         self._sdk = pm.STATE.parent / "sdk"
         self._sdk.mkdir(parents=True, exist_ok=True)
         pm.NAMES_DIR.mkdir(parents=True, exist_ok=True)
 
     def tearDown(self):
-        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        restore_env("ROMP_SESSIONS_FILE", self._prior_seam)
         pm.HEARTBEATS.clear()
         for f in list(self._sdk.iterdir()) + list(pm.NAMES_DIR.iterdir()):
             f.unlink()

--- a/tests/test_postal_quarantine.py
+++ b/tests/test_postal_quarantine.py
@@ -13,6 +13,8 @@ import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
+from tests.conftest import restore_env
+
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
@@ -35,6 +37,7 @@ def _relay(mid, body="ship it", frm="api", origin=None):
 
 class InboundTrustGate(unittest.TestCase):
     def setUp(self):
+        self._prior_seam = os.environ.get("ROMP_SESSIONS_FILE")
         os.environ["ROMP_SESSIONS_FILE"] = _SESS   # pin OUR sessions seam (read live; a later-collected postal test clobbers it)
         # fresh peer table + empty stores each test
         ps.PEERS.clear()
@@ -44,6 +47,9 @@ class InboundTrustGate(unittest.TestCase):
                     f.unlink()
             except OSError:
                 pass
+
+    def tearDown(self):
+        restore_env("ROMP_SESSIONS_FILE", self._prior_seam)
 
     def _set_trust(self, host, level, up=True):
         ps.peer_update({"host": host, "port": 47101, "up": up, "trust": level})
@@ -171,6 +177,7 @@ class TokenProvenDialerGate(InboundTrustGate):
 
     def tearDown(self):
         ps._relay_in = self._orig_relay_in
+        super().tearDown()
 
     def test_unknown_origin_defaults_to_directed(self):
         # OVERRIDES the inherited default-hold test: with the dialer token-proven, unknown-origin
@@ -204,6 +211,7 @@ class ExchangeHandleIsTokenProven(unittest.TestCase):
     gate — so an attached machine's own relays deliver instead of quarantining on the dialed side."""
 
     def setUp(self):
+        self._prior_seam = os.environ.get("ROMP_SESSIONS_FILE")
         os.environ["ROMP_SESSIONS_FILE"] = _SESS
         os.environ["ROMP_POSTAL_PEERS"] = "1"
         ps.PEERS.clear()
@@ -222,6 +230,7 @@ class ExchangeHandleIsTokenProven(unittest.TestCase):
 
     def tearDown(self):
         os.environ.pop("ROMP_POSTAL_PEERS", None)
+        restore_env("ROMP_SESSIONS_FILE", self._prior_seam)
 
     def test_handle_delivers_unknown_dialers_direct_relay(self):
         req = {"host": "MYSTERY", "epoch": 1, "proto": ps.PEER_PROTO, "presence": [], "holds": [],
@@ -260,6 +269,7 @@ class ExchangeHandleIsTokenProven(unittest.TestCase):
 
 class QuarantineDecide(unittest.TestCase):
     def setUp(self):
+        self._prior_seam = os.environ.get("ROMP_SESSIONS_FILE")
         os.environ["ROMP_SESSIONS_FILE"] = _SESS   # pin OUR sessions seam (see InboundTrustGate.setUp)
         ps.PEERS.clear()
         ps.peer_update({"host": "TESTHOST", "port": 47101, "up": True, "trust": "directed"})
@@ -269,6 +279,9 @@ class QuarantineDecide(unittest.TestCase):
                     f.unlink()
             except OSError:
                 pass
+
+    def tearDown(self):
+        restore_env("ROMP_SESSIONS_FILE", self._prior_seam)
 
     def test_approve_delivers_and_clears(self):
         ps._relay_in("TESTHOST", _relay("q-appr-1", body="original text"))

--- a/tests/test_postal_read_receipts.py
+++ b/tests/test_postal_read_receipts.py
@@ -15,6 +15,8 @@ import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
+from tests.conftest import restore_env
+
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
@@ -53,6 +55,10 @@ def _resp(host, **kw):
 
 class _Base(unittest.TestCase):
     def setUp(self):
+        # the sessions-file seam is read per call, so the import-time assignment above holds only until
+        # another module's test changes it: bind this module's file for the duration of each test
+        self._prior_seam = os.environ.get("ROMP_SESSIONS_FILE")
+        os.environ["ROMP_SESSIONS_FILE"] = _SESS
         os.environ["ROMP_POSTAL_PEERS"] = "1"
         ps.PEERS.clear()
         ps.PEER_STATE.clear()
@@ -66,6 +72,7 @@ class _Base(unittest.TestCase):
 
     def tearDown(self):
         os.environ.pop("ROMP_POSTAL_PEERS", None)
+        restore_env("ROMP_SESSIONS_FILE", self._prior_seam)
 
     def _trusted_peer(self, host="boxalias"):
         ps.peer_update({"host": host, "port": 19999, "up": True, "trust": "trusted"})

--- a/tests/test_postal_relay_honesty.py
+++ b/tests/test_postal_relay_honesty.py
@@ -22,6 +22,8 @@ import uuid
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
+from tests.conftest import restore_env
+
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
@@ -46,10 +48,13 @@ def _fresh_mid():
 
 class _RelayBase(unittest.TestCase):
     def setUp(self):
-        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        # no seam unless a test sets one: the source under test is the kernel listing. The prior value
+        # goes back at cleanup, because the bus reads the seam from os.environ at call time and a later
+        # module in the same process may have set it once at import.
+        self._prior_seam = os.environ.pop("ROMP_SESSIONS_FILE", None)
         self._base = pm.KERNEL_BASE
         self.addCleanup(lambda: (setattr(pm, "KERNEL_BASE", self._base),
-                                 os.environ.pop("ROMP_SESSIONS_FILE", None),
+                                 restore_env("ROMP_SESSIONS_FILE", self._prior_seam),
                                  pm.HEARTBEATS.clear()))
 
     def _msg(self, to):

--- a/tests/test_postal_self_identity.py
+++ b/tests/test_postal_self_identity.py
@@ -15,6 +15,8 @@ import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
+from tests.conftest import restore_env
+
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
@@ -33,6 +35,7 @@ ps = SourceFileLoader("romp_postal_selfid", os.path.join(BIN, "romp-postal-servi
 
 class ForkedSelfIdentity(unittest.TestCase):
     def setUp(self):
+        self._prior_seam = os.environ.get("ROMP_SESSIONS_FILE")
         os.environ["ROMP_SESSIONS_FILE"] = _SESS
         self._env = os.environ.get("CLAUDE_CODE_SESSION_ID")
 
@@ -41,6 +44,7 @@ class ForkedSelfIdentity(unittest.TestCase):
             os.environ.pop("CLAUDE_CODE_SESSION_ID", None)
         else:
             os.environ["CLAUDE_CODE_SESSION_ID"] = self._env
+        restore_env("ROMP_SESSIONS_FILE", self._prior_seam)
 
     def test_exact_id_match_resolves_directly(self):
         os.environ["CLAUDE_CODE_SESSION_ID"] = STABLE

--- a/tests/test_postal_undelivered.py
+++ b/tests/test_postal_undelivered.py
@@ -15,6 +15,8 @@ import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
+from tests.conftest import restore_env
+
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
@@ -29,12 +31,13 @@ RECIP = "22222222-2222-2222-2222-222222222222"
 class StuckMailWarning(unittest.TestCase):
     def setUp(self):
         self._seamfile = os.path.join(tempfile.mkdtemp(), "sessions.json")
+        self._prior_seam = os.environ.get("ROMP_SESSIONS_FILE")
         os.environ["ROMP_SESSIONS_FILE"] = self._seamfile      # local_agents() reads this instead of a live kernel
         for d in (pm.MAILROOT, pm.WARNED, pm.MAILPENDING):     # isolate each test
             shutil.rmtree(d, ignore_errors=True)
 
     def tearDown(self):
-        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        restore_env("ROMP_SESSIONS_FILE", self._prior_seam)
 
     def _set_recip_state(self, state):
         Path(self._seamfile).write_text(json.dumps(
@@ -100,6 +103,7 @@ class RefusedNotesKeepTheMail(unittest.TestCase):
 
     def setUp(self):
         self._seamfile = os.path.join(tempfile.mkdtemp(), "sessions.json")
+        self._prior_seam = os.environ.get("ROMP_SESSIONS_FILE")
         os.environ["ROMP_SESSIONS_FILE"] = self._seamfile
         for d in (pm.MAILROOT, pm.WARNED, pm.MAILPENDING):
             shutil.rmtree(d, ignore_errors=True)
@@ -117,7 +121,7 @@ class RefusedNotesKeepTheMail(unittest.TestCase):
         pm.TLDIR, pm._log = self._tl, self._log
         pm._TL_FAULT[0] = False
         pm._REFUSAL_SAID.clear()
-        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        restore_env("ROMP_SESSIONS_FILE", self._prior_seam)
 
     def _live(self, rows):
         Path(self._seamfile).write_text(json.dumps(rows))
@@ -208,6 +212,7 @@ class TheSweepMovesAnUnreadableFileAside(unittest.TestCase):
 
     def setUp(self):
         self._seamfile = os.path.join(tempfile.mkdtemp(), "sessions.json")
+        self._prior_seam = os.environ.get("ROMP_SESSIONS_FILE")
         os.environ["ROMP_SESSIONS_FILE"] = self._seamfile
         for d in (pm.MAILROOT, pm.WARNED, pm.MAILPENDING):
             shutil.rmtree(d, ignore_errors=True)
@@ -224,7 +229,7 @@ class TheSweepMovesAnUnreadableFileAside(unittest.TestCase):
     def tearDown(self):
         pm.TLDIR, pm._log, pm._kernel_post = self._saved
         pm._DASHBOARD_MISSED[0] = False
-        os.environ.pop("ROMP_SESSIONS_FILE", None)
+        restore_env("ROMP_SESSIONS_FILE", self._prior_seam)
 
     @unittest.skipIf(os.geteuid() == 0, "root reads a mode-0 file; the fault cannot be staged")
     def test_the_file_is_moved_aside_the_marker_drops_and_the_box_keeps_its_evidence(self):

--- a/tests/test_session_retry_suppress.py
+++ b/tests/test_session_retry_suppress.py
@@ -41,6 +41,7 @@ class SessionRetrySuppress(unittest.TestCase):
         self.dir = Path(self.td.name)
         self._orig = {k: getattr(km, k) for k in
                       ("_alive_sessions", "_parse_cached", "_session_chip", "_mark_views_dirty")}
+        self._saved_state = km.jd.STATE
         km.jd.STATE = self.dir                          # retry-suppressed.json lives under jd.STATE
         km._retry_suppress_cache.clear()                # the file cache is process-global — reset per test
         km._mark_views_dirty = lambda *a, **k: None     # no clients in the test
@@ -48,6 +49,7 @@ class SessionRetrySuppress(unittest.TestCase):
     def tearDown(self):
         for k, v in self._orig.items():
             setattr(km, k, v)
+        km.jd.STATE = self._saved_state                 # km.jd is the shared judge module, whatever name the kernel loaded under
         self.td.cleanup()
 
     # --- arming ---

--- a/tests/test_subagent_transcripts.py
+++ b/tests/test_subagent_transcripts.py
@@ -96,6 +96,7 @@ class World(unittest.TestCase):
     FOREGROUND agent (its tool_result is the report), each with its own file under subagents/."""
 
     def setUp(self):
+        self._saved_state, self._saved_projects = jd.STATE, jd.PROJECTS
         self._td = tempfile.mkdtemp()
         jd._rebind_state(Path(self._td))
         jd.PROJECTS = Path(self._td) / "projects"
@@ -162,6 +163,11 @@ class World(unittest.TestCase):
             cache.clear()
 
     def tearDown(self):
+        # the judge module is shared process-wide: rebind STATE and PROJECTS to what they were, and drop the
+        # discover results computed under this test's roots, before the roots are removed
+        jd._rebind_state(self._saved_state)
+        jd.PROJECTS = self._saved_projects
+        jd._discover_cache.clear()
         shutil.rmtree(self._td, ignore_errors=True)
 
     def _agent_records(self, aid, t, calls, closing="All four tests pass now; one flaky case was re-run."):


### PR DESCRIPTION
## What

**Symptom.** Under xdist with `--dist loadfile` or `--dist loadscope`, unrelated test modules went red together on one worker in about half the runs, and every failing test passed when its module ran alone. Three default-scheduler runs (`-n 8`) were clean; the default scheduler rarely puts the cause and the victim on the same worker. CI's serial run passes only because a test that loads a kernel between them (`tests/test_kernel_redistill.py`) re-executes `judge.py` and rebinds the roots from the environment. The victims:

- `tests/test_restart_cuts.py::CutRow` (3 tests): FileNotFoundError writing `restart-audit.jsonl`
- `tests/test_tag_edit_ack.py::LegacyStoreStampedOnce` (2): FileNotFoundError on `timeline-views.json`
- `tests/test_kernel_tunnel_truth.py::ExpectedRestart` (1): an empty restart reason, because `_audit_restart_request` swallows the write error
- `tests/test_dead_wait_block.py::DeadWaitBlock` (4): `_dead_wait_sweep` globs `STATE / "goals"` under `except OSError` and finds nothing
- `tests/test_postal_read_receipts.py::RecipientQueuesReceipt` (5): relays refused with no live session named `web`
- `tests/test_judge_auth_billing.py::KeylessKeyBilledCalls` (1): a stderr line the test did not expect

**Mechanism.** Two process-wide objects carry state from one test module to the next: the judge module and the process environment.

The judge module is one object per process. `kernel.py` loads it as `SourceFileLoader("romp_judge", ...).load_module()`, and `load_module` re-executes into the module already in `sys.modules` under that name, so every kernel-loading test module's `km.jd` is the same object. A fixture that rebinds `jd.STATE` to a per-test temp dir and removes the dir in tearDown without putting the prior root back leaves every later STATE reader on that worker pointing at a removed directory. Four fixtures did that (`test_episode_boundary`, `test_kernel_goal_compaction`, `test_session_retry_suppress::SessionRetrySuppress`, `test_subagent_transcripts`, the last also leaving `jd.PROJECTS` in the removed dir); `test_session_retry_suppress` rebinds STATE alone, so `GOALDIR` stayed valid while `_dead_wait_sweep` read `STATE / "goals"`, which is why it alone breaks `test_dead_wait_block`. Two more left a root changed without breaking anything yet: `test_chat_delta_resync` rebinds STATE to `tmp_path` in three tests and leaves it there; `test_clear_chat_view` restores STATE but leaves PROJECTS in its removed dir.

The sessions-file seam is read per call: the postal service reads `ROMP_SESSIONS_FILE` from `os.environ` each time it lists the live sessions. Three modules popped it in tearDown or a cleanup instead of restoring what they found (`test_postal_undelivered`, `test_postal_live_only`, `test_postal_relay_honesty`), so `test_postal_read_receipts`, which set the seam once at import, resolved no local sessions after any of them. Two modules pinned their own file in setUp without restoring it (`test_postal_quarantine`, four classes, and `test_postal_self_identity`); in a full run the value they set differs from the one the last-collected module left, so the guard names their first test. The new pin in `test_postal_read_receipts` restores for the same reason.

The billing case is a class-order dependency inside one module: the judge says once per process that a bare-alias envelope carries no `modelUsage` map, the test's fake envelope had none, and the test passed only after a sibling class had spent the notice.

**Fixes (tests only).**

- `tests/test_episode_boundary.py`: setUp saves `jd.STATE`; tearDown rebinds it before the rmtree.
- `tests/test_kernel_goal_compaction.py`: the same.
- `tests/test_session_retry_suppress.py` (`SessionRetrySuppress`): saves `km.jd.STATE` and restores it before `td.cleanup()`, as the module's second class already did.
- `tests/test_subagent_transcripts.py`: saves and restores `jd.STATE` and `jd.PROJECTS`, and clears `jd._discover_cache` so no discover result built under its roots is served afterwards.
- `tests/test_chat_delta_resync.py`: the three rebinding tests use a `state_root` fixture that rebinds and rebinds back.
- `tests/test_clear_chat_view.py`: both classes restore `jd.PROJECTS` alongside STATE.
- `tests/test_postal_undelivered.py`: the three tearDown pops restore the prior value.
- `tests/test_postal_live_only.py`: the four tearDown pops restore the prior value; the setUp pop in `KernelSilenceIsNotDeadness`, which tests the no-seam path, stays and now records what it popped.
- `tests/test_postal_relay_honesty.py`: `_RelayBase`'s cleanup restores the prior value; its setUp pop and the three in-test pops that exercise the no-seam fallback are unchanged.
- `tests/test_postal_read_receipts.py`: `_Base.setUp` pins the module's own file per test and tearDown restores the prior value, so the module no longer depends on what the last-collected module left in the environment.
- `tests/test_postal_quarantine.py`, `tests/test_postal_self_identity.py`: the existing setUp pins gain a tearDown restore (`TokenProvenDialerGate.tearDown` now calls `super().tearDown()`).
- `tests/test_judge_rate_limit_gate.py`: the seg-key test restores `ROMP_SERVE_TOKEN` and `ROMP_KERNEL_NO_OPEN` after the kernel import that needed them set.
- `tests/test_judge_auth_billing.py` (`KeylessKeyBilledCalls`): the fake envelope carries the `modelUsage` map a current CLI reports, naming the version `_ALIAS_HEAD` assumes for `sonnet`, so the test's own fixture satisfies the premise it asserts (nothing missing, nothing announced); the served record is put back to what it was afterwards.

The STATE restores follow `tests/test_judge.py::ClearedSeal` and `tests/test_kernel_resolve_node.py`. The environment restores call one helper, `restore_env(name, prior)` in `tests/conftest.py`, imported the way `thread_census` is; `prior` is the `os.environ.get` taken before the change, `None` meaning unset.

**Guard.** `tests/conftest.py` gains an autouse, function-scoped fixture, `_shared_state_restored`. Before each test it snapshots the shared judge's `STATE` and `PROJECTS` (when `romp_judge` is loaded) and the environment names `ROMP_SESSIONS_FILE` and `ROMP_SERVE_TOKEN`; after the test it fails the test that changed one of them and did not restore it, or left a path that was a directory pointing at nothing. The failure names the test and what it left behind (for the environment names only the kind of change, never the value; one of them is a credential). It reports as an ERROR at teardown, which is still red.

It is transition-based: a module-level preamble runs at collection, before any snapshot, and is not seen; a test that changes and restores is quiet; a test that runs under another test's leftover is not blamed for it. A test that loads a kernel re-executes `judge.py` into the shared module, which rebinds every root from the environment as it stands at that moment (other modules' import-time `XDG_STATE_HOME` and `CLAUDE_CONFIG_DIR` writes decide those values, and the per-test `CLAUDE_CONFIG_DIR` floor differs from the collection-time one). That reset is the loader's, so for such a test (told apart by the function objects `judge.py` redefines) the guard compares no values. Two things are still checked for it: `judge.py` creates `STATE` at import, so a `STATE` that is not a directory afterwards is the test's own doing and is named; and the environment names.

With the guard in place, a green run no longer depends on the kernel-loading test running between a cause and its victim.

**Not here.** `tests/test_kernel_webpush.py::LandingRevealOffers::test_no_offer_for_the_session_already_in_front` asserts a clock-derived `ageS` of 5 and saw 6 twice under load across many runs; it passes alone (9/9, module 86/86) and is timing, not shared state. Goal-store tests that mint goals under the shared placeholder sid can be re-flagged by another module's journaled override on the same worker; that is a separate class with a separate fix (a private sid per module), and nothing here touches it.

## Tests

Commands run from the repo root as `pytest -q <targets>`. Red counts were taken with the guard in place and the named module at its previous version; green counts at this commit.

STATE and PROJECTS polluters, alone under the guard (the guard errors at every test of the polluting class; nothing else in the process):

- `tests/test_episode_boundary.py`: 17 errors before, 17 passed after
- `tests/test_kernel_goal_compaction.py`: 8 errors before, 8 passed after
- `tests/test_session_retry_suppress.py`: 6 errors before (the second class was quiet), 24 passed after
- `tests/test_subagent_transcripts.py`: 27 errors before (STATE and PROJECTS both named), 27 passed after
- `tests/test_chat_delta_resync.py`: 3 errors before, 12 passed after
- `tests/test_clear_chat_view.py`: 14 errors before (PROJECTS), 14 passed after
- `tests/test_judge_rate_limit_gate.py`: 1 error before (ROMP_SERVE_TOKEN was unset and is now set), 20 passed after

The victims paired with their polluter, whole modules in this order (before: the base tree; after: this commit):

- `tests/test_episode_boundary.py tests/test_restart_cuts.py`: 3 CutRow failures before, 25 passed after
- `tests/test_kernel_goal_compaction.py tests/test_restart_cuts.py`: 3 before, 16 passed after
- `tests/test_session_retry_suppress.py tests/test_dead_wait_block.py`: 4 DeadWaitBlock failures before, 47 passed after
- `tests/test_subagent_transcripts.py tests/test_restart_cuts.py`: 3 before, 35 passed after
- `tests/test_episode_boundary.py tests/test_kernel_tunnel_truth.py`: 1 before, 39 passed after

Seam poppers with the victim, whole modules. Before the fix, popper first: 5 RecipientQueuesReceipt failures plus 1 guard error on the popper's first test, since the victim's import had set the seam. After: green in both orders.

- `tests/test_postal_undelivered.py tests/test_postal_read_receipts.py`: 30 passed, and 30 reversed
- `tests/test_postal_live_only.py tests/test_postal_read_receipts.py`: 48 and 48
- `tests/test_postal_relay_honesty.py tests/test_postal_read_receipts.py`: 59 and 59
- `tests/test_postal_live_only.py tests/test_postal_self_identity.py`: 2 guard errors before (the pop, then the pin), 30 passed after
- `tests/test_postal_live_only.py tests/test_postal_quarantine.py`: 58 passed. The quarantine pins have no pair line: before their restore, a full run's guard named the pins' first tests, since the file they set differs from the one the last-collected module left.

Billing: `tests/test_judge_auth_billing.py::KeylessKeyBilledCalls` alone: 1 failed before, 1 passed after; the module: 40 passed.

Reload exemption: `tests/test_session_auth.py tests/test_kernel_redistill.py`: 78 passed (without the exemption the guard named the redistill test for a change the loader made). A scratch test that reloaded the judge and then rebound `STATE` to a temp dir it removed errors under the guard; a reload that leaves `STATE` standing is quiet.

The pairs are not a subprocess meta-test: the guard already fails a popper's first test in any run that collected a seam-setting module in the same process, which every full run does (several postal modules set the seam at import), so CI catches the class in-process without a nested pytest run. The pair commands are for a reader who wants to see the victim fail without the guard.

Full suite, `-n 8`, on this commit:

- default scheduling: 10104 passed, 61 skipped, 1671 subtests passed in 78 s
- `--dist loadfile`: 10104 passed, 61 skipped, 1671 subtests passed in 97 s
- `--dist loadscope`: 10104 passed, 61 skipped, 1671 subtests passed in 66 s

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)