### PR TITLE
Courier link repair: an unreadable sender store is skipped for that sender, not for every recipient

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -947,8 +947,10 @@ def _log_judge_error(judge, fsid, err, note=None, goal=None, seg=None):
              behind and the shape of the menu that died), "store-quarantined" (a goals store that
              could not be parsed was moved aside to <file>.corrupt-<stamp> and the session started fresh),
              "store-unreadable" (a goals store that cannot be READ — EACCES, EIO — filed once per fault
-             episode by load_goals_or_fault; inside a judge pass the raise instead reaches the pass
-             wrapper's "pass-crash" row), "store-unwritable" (a goals store that read but whose publish
+             episode by load_goals_or_fault and the readers that share its boundary, run_propagate's
+             recipient read and the courier's sender-board walk among them; a reader inside a judge pass
+             that loads a store strictly instead raises into the pass wrapper's "pass-crash" row),
+             "store-unwritable" (a goals store that read but whose publish
              then failed under a user gesture, the save path's own strict read or the write itself; filed
              once per fault episode by save_goals_or_fault, and the gesture is answered on its socket)
       note   the evidence — reply tail, error message, exception name, or the give-up scope + re-arm
@@ -14554,22 +14556,42 @@ def _handoff_backref(mid):
     walk over the read-only view; its key is _backref_key, taken before the reads, so a store written
     during the walk moves the key the next call takes (a set read mid-write is served no further than
     that call). The first sender in discover order wins, as the walk answered; a completed handoff node
-    is no backref. A store that raises leaves nothing cached (the caller's own boundary logs it)."""
+    is no backref.
+
+    A sender store that cannot be read (EACCES, EIO, a directory at the path) is SKIPPED for this call
+    through the per-session boundary (load_goals_shared_or_fault: one store-unreadable row per fault
+    episode, as every other reader of a goal store files it), and the other senders answer. The fault is
+    one sender's; left to raise it failed the lookup for every message id and every recipient, so the
+    courier filed a link-attach pass-crash row per placed unlinked delegate per pass and landed no link
+    anywhere (the walk the memo replaced had answered every sender before the fault). The map is then
+    NOT published: a fault moves no file key (a permission fix changes neither inode, mtime nor size),
+    so a cached map missing a sender would be served after the store reads again. While the fault lasts,
+    a call whose key no longer matches the published map walks the read-only views again, which the shared
+    store cache serves (a map published before the fault keeps serving while its key stands: the content it
+    describes has not changed); a recipient whose sender is the faulted store gets the '' pair, attaches
+    nothing, and the courier gate keeps it scanned until the sender reads again, the wait it already models
+    for a sender that does not yet track the message. The boundary catches OSError only, as every reader
+    boundary does: any other raise out of a sender's read leaves the walk as before, cached nowhere and
+    filed by the courier's own catch."""
     fleet = discover(int(time.time()))
     key = _backref_key(fleet)
     slot = _BACKREF_MEMO["slot"]
     if slot is not None and slot[0] == key:
         _BACKREF_STATS["served"] += 1
         return slot[1].get(mid, ("", ""))
-    mp = {}
+    mp, partial = {}, False
     for fsid, path, anchor, name in fleet:
-        st = load_goals_shared(fsid)
+        st, fault = load_goals_shared_or_fault(fsid)
+        if fault is not None:
+            partial = True                           # this sender's row is filed; the others still answer
+            continue
         for nid, nd in st.get("nodes", {}).items():
             h = nd.get("handoff")
             if isinstance(h, dict) and h.get("msgId") is not None and not nd.get("nodeComplete"):
                 mp.setdefault(h["msgId"], (fsid, nid))
     _BACKREF_STATS["built"] += 1
-    _BACKREF_MEMO["slot"] = (key, mp)
+    if not partial:
+        _BACKREF_MEMO["slot"] = (key, mp)            # a map missing a sender is not published (see above)
     return mp.get(mid, ("", ""))
 
 

--- a/tests/test_backref_memo.py
+++ b/tests/test_backref_memo.py
@@ -8,7 +8,10 @@ from one walk over the read-only view, keyed on the discover order and each send
 its journal's and archive's, taken before the reads. Pins: built once then served; a sender store write
 re-derives, including one the file clock cannot see; a journal row re-derives; a fleet change re-derives;
 a write landing during the build is seen next call; the first sender in discover order wins; a completed
-handoff is no backref; a store that raises leaves nothing cached; a rebound root forgets; the counters.
+handoff is no backref; a sender store that cannot be read is skipped for that call through the per-session
+boundary (one store-unreadable row per fault episode, the other senders answer, the map is not published
+while a sender is missing from it) and any other raise out of a sender's read stays loud; a rebound root
+forgets; the counters.
 
 Synthetic sids and stores under a temp root; discover is a stub, so no transcripts are needed."""
 import json
@@ -27,7 +30,11 @@ jd = SourceFileLoader("romp_judge_backref_memo", os.path.join(BIN, "romp-judge")
 S1 = "11111111-2222-3333-4444-999999999901"
 S2 = "11111111-2222-3333-4444-999999999902"
 S3 = "11111111-2222-3333-4444-999999999903"
+S4 = "11111111-2222-3333-4444-999999999904"
+R1 = "11111111-2222-3333-4444-999999999911"   # recipients: their stores hold the placements the courier repairs
+R2 = "11111111-2222-3333-4444-999999999912"
 M1, M2, M3 = "1781100000.00001_00001.TESTHOST", "1781100000.00002_00002.TESTHOST", "1781100000.00003_00003.TESTHOST"
+M4 = "1781100000.00004_00004.TESTHOST"
 T0 = 1781100000
 
 
@@ -45,10 +52,13 @@ class _Memo(unittest.TestCase):
         self.saved_root, self.saved_discover = jd.STATE, jd.discover
         jd._rebind_state(Path(self.td.name))
         jd.GOALDIR.mkdir(parents=True, exist_ok=True)
-        self.fleet = [(S1, "/nonexistent/s1.jsonl", None, "s1"), (S2, "/nonexistent/s2.jsonl", None, "s2")]
+        # three senders in discover order, so a sender AFTER a faulted one is covered by the fault tests
+        self.fleet = [(S1, "/nonexistent/s1.jsonl", None, "s1"), (S2, "/nonexistent/s2.jsonl", None, "s2"),
+                      (S3, "/nonexistent/s3.jsonl", None, "s3")]
         jd.discover = lambda now: list(self.fleet)
         self.write(S1, {S1 + ":g1": _node(S1 + ":g1", "delegated to worker0", M1)})
         self.write(S2, {S2 + ":g1": _node(S2 + ":g1", "delegated to worker1", M2)})
+        self.write(S3, {S3 + ":g1": _node(S3 + ":g1", "delegated to worker3", M3)})
         self._reset()
 
     def tearDown(self):
@@ -64,10 +74,10 @@ class _Memo(unittest.TestCase):
             jd._BACKREF_STATS[k] = 0
         jd._shared_clear()
 
-    def write(self, sid, nodes, mtime=None):
+    def write(self, sid, nodes, mtime=None, placements=None):
         p = jd.GOALDIR / (sid + ".json")
         p.write_text(json.dumps({"rompUuid": sid, "seq": 1, "lastNode": None, "closedTurns": [], "nodes": nodes,
-                                 "placements": {}, "status": {k: "working" for k in nodes}}))
+                                 "placements": placements or {}, "status": {k: "working" for k in nodes}}))
         if mtime is not None:
             os.utime(p, (mtime, mtime))
 
@@ -78,6 +88,27 @@ class _Memo(unittest.TestCase):
         self.addCleanup(lambda: setattr(jd, "load_goals_shared", real))
         return reads
 
+    def faulting(self, sid, exc):
+        """Wrap the view's loader so `sid`'s read raises `exc` and every other read is real. The boundary
+        resolves the loader's name at call time, so the patch is what it reads. The store FILE is untouched:
+        its inode, mtime and size stand, so the walk's key does not move between the fault and the heal."""
+        real = jd.load_goals_shared
+
+        def loader(fsid):
+            if fsid == sid:
+                raise exc
+            return real(fsid)
+        jd.load_goals_shared = loader
+        self.addCleanup(lambda: setattr(jd, "load_goals_shared", real))
+        return lambda: setattr(jd, "load_goals_shared", real)
+
+    @staticmethod
+    def rows():
+        """(fsid, err) of every judge-errors row filed under the temp root."""
+        if not jd.ERRORS.exists():
+            return []
+        return [(r["fsid"], r["err"]) for r in (json.loads(l) for l in jd.ERRORS.read_text().splitlines() if l.strip())]
+
 
 class BackrefMemo(_Memo):
     def test_built_once_then_served_while_the_inputs_stand(self):
@@ -85,7 +116,7 @@ class BackrefMemo(_Memo):
         self.assertEqual(jd._handoff_backref(M1), (S1, S1 + ":g1"))
         self.assertEqual(jd._handoff_backref(M2), (S2, S2 + ":g1"))
         self.assertEqual(jd._handoff_backref("1781100000.00009_00009.TESTHOST"), ("", ""), "an untracked message")
-        self.assertEqual(sorted(reads), sorted([S1, S2]), "one walk: each sender store read once")
+        self.assertEqual(sorted(reads), sorted([S1, S2, S3]), "one walk: each sender store read once")
         self.assertEqual(jd._BACKREF_STATS, {"served": 2, "built": 1})
 
     def test_a_sender_store_write_re_derives_even_when_the_file_clock_does_not_move(self):
@@ -108,9 +139,9 @@ class BackrefMemo(_Memo):
 
     def test_a_fleet_change_re_derives(self):
         jd._handoff_backref(M1)
-        self.write(S3, {S3 + ":g1": _node(S3 + ":g1", "delegated to worker3", M3)})
-        self.fleet.append((S3, "/nonexistent/s3.jsonl", None, "s3"))
-        self.assertEqual(jd._handoff_backref(M3), (S3, S3 + ":g1"))
+        self.write(S4, {S4 + ":g1": _node(S4 + ":g1", "delegated to worker4", M4)})
+        self.fleet.append((S4, "/nonexistent/s4.jsonl", None, "s4"))
+        self.assertEqual(jd._handoff_backref(M4), (S4, S4 + ":g1"))
         self.assertEqual(jd._BACKREF_STATS["built"], 2)
 
     def test_a_write_landing_during_the_build_is_seen_next_call(self):
@@ -136,7 +167,7 @@ class BackrefMemo(_Memo):
         second = jd._handoff_backref(M3)
         self.assertEqual(jd._BACKREF_STATS, {"served": 0, "built": 2}, "the write moved the key the second call took")
         self.assertEqual(second, (S2, S2 + ":g2"))
-        self.assertIn(first, ((S2, S2 + ":g2"), ("", "")), "what the first walk saw, depending on the read order")
+        self.assertIn(first, ((S2, S2 + ":g2"), (S3, S3 + ":g1")), "what the first walk saw, depending on the read order")
 
     def test_the_first_sender_in_discover_order_wins(self):
         self.write(S2, {S2 + ":g1": _node(S2 + ":g1", "delegated to worker1", M1)})   # both track M1
@@ -148,22 +179,88 @@ class BackrefMemo(_Memo):
         self.write(S1, {S1 + ":g1": _node(S1 + ":g1", "delegated to worker0", M1, complete=True)})
         self.assertEqual(jd._handoff_backref(M1), ("", ""))
 
-    def test_a_store_that_raises_leaves_nothing_cached(self):
-        real = jd.load_goals_shared
+    def test_one_unreadable_sender_store_skips_that_sender_and_the_others_answer(self):
+        """A sender store that exists and cannot be read is that SENDER's fault, contained to it: the senders
+        before and after it in discover order answer, its own message is unanswered for this call, and the
+        boundary files one store-unreadable row for the episode, however many lookups meet it.
 
-        def faulting(fsid):
-            if fsid == S2:
-                raise OSError(5, "Input/output error")
-            return real(fsid)
-        jd.load_goals_shared = faulting
-        try:
-            with self.assertRaises(OSError):
-                jd._handoff_backref(M1)
-        finally:
-            jd.load_goals_shared = real
+        This test replaces the one that pinned the raise (the memo's first shape): one raising store failed the
+        lookup for every message id and every recipient, so the courier filed a link-attach pass-crash row per
+        placed unlinked delegate per pass and no link landed anywhere, while the walk the memo replaced had
+        answered every sender before the fault. The per-session boundary (load_goals_shared_or_fault) is how
+        every other reader of a goal store contains a fault; the walk reads through it now.
+
+        The map is NOT published while a sender is missing from it: a fault moves no file key (a permission
+        fix changes neither inode, mtime nor size), so a cached partial map would be served after the store
+        reads again. The heal below restores the loader WITHOUT touching the file, so the key stands; only a
+        withheld slot lets the healed sender answer."""
+        restore = self.faulting(S2, OSError(13, "Permission denied"))
+        self.assertEqual(jd._handoff_backref(M1), (S1, S1 + ":g1"), "the sender before the fault answers")
+        self.assertEqual(jd._handoff_backref(M3), (S3, S3 + ":g1"), "the sender after the fault answers")
+        self.assertEqual(jd._handoff_backref(M2), ("", ""), "the faulted sender's own message waits")
+        self.assertIsNone(jd._BACKREF_MEMO["slot"], "a map missing a sender is not published")
+        self.assertEqual(jd._BACKREF_STATS, {"served": 0, "built": 3}, "walked again per call while the fault lasts")
+        self.assertEqual(self.rows(), [(S2, "store-unreadable")], "one row for the episode, not one per lookup")
+        restore()
+        self.assertEqual(jd._handoff_backref(M2), (S2, S2 + ":g1"), "healed with the key unmoved: the sender answers")
+        self.assertIsNotNone(jd._BACKREF_MEMO["slot"], "a complete walk is published")
+        self.assertEqual(jd._BACKREF_STATS, {"served": 0, "built": 4})
+        self.assertEqual(jd._handoff_backref(M1), (S1, S1 + ":g1"))
+        self.assertEqual(jd._BACKREF_STATS, {"served": 1, "built": 4}, "and served from then on")
+        self.assertEqual(self.rows(), [(S2, "store-unreadable")], "the heal files nothing")
+
+    def test_a_directory_at_a_sender_store_path_faults_that_sender_only(self):
+        """The same rule under a REAL read fault, no loader patched: a directory at the store path opens and
+        then raises on the read inside load_goals_shared, an OSError the boundary contains. Here the key does
+        move on the heal (no regular file, then one), so this test pins the skip and the row; the patched-loader
+        test above pins the withheld slot."""
+        p = jd.GOALDIR / (S2 + ".json")
+        os.remove(p)
+        os.mkdir(p)
+        self.assertEqual(jd._handoff_backref(M1), (S1, S1 + ":g1"))
+        self.assertEqual(jd._handoff_backref(M3), (S3, S3 + ":g1"))
+        self.assertEqual(jd._handoff_backref(M2), ("", ""))
         self.assertIsNone(jd._BACKREF_MEMO["slot"])
-        self.assertEqual(jd._BACKREF_STATS, {"served": 0, "built": 0})
-        self.assertEqual(jd._handoff_backref(M1), (S1, S1 + ":g1"), "healed: built")
+        self.assertEqual(self.rows(), [(S2, "store-unreadable")])
+        os.rmdir(p)
+        self.write(S2, {S2 + ":g1": _node(S2 + ":g1", "delegated to worker1", M2)})
+        self.assertEqual(jd._handoff_backref(M2), (S2, S2 + ":g1"), "the file is back: the sender answers")
+        self.assertIsNotNone(jd._BACKREF_MEMO["slot"])
+        self.assertEqual(self.rows(), [(S2, "store-unreadable")], "the heal files nothing")
+
+    def test_the_courier_gate_attaches_the_readable_senders_link_beside_a_faulted_sender(self):
+        """The consequence for run_courier's link repair, through the functions it calls: two recipients each
+        hold a planner-placed delegate with no courier link, one from S1 and one from S2, and S2's store is a
+        directory. Before the boundary the walk raised out of _courier_link_wanted for BOTH recipients, so the
+        courier filed a link-attach pass-crash row for each every pass and no link landed. Now S1's link lands
+        on its recipient; S2's recipient is answered None (no attach, no raise: the courier gate keeps it
+        scanned, the wait it already models for a sender that does not yet track the message); and the fault
+        is one store-unreadable row for S2 across both recipients' lookups."""
+        self.write(R1, {R1 + ":g1": _node(R1 + ":g1", "check the subnet")}, placements={"seg-1": R1 + ":g1"})
+        self.write(R2, {R2 + ":g1": _node(R2 + ":g1", "rotate the logs")}, placements={"seg-2": R2 + ":g1"})
+        p = jd.GOALDIR / (S2 + ".json")
+        os.remove(p)
+        os.mkdir(p)
+        r1 = jd.load_goals(R1)
+        self.assertEqual(jd._courier_link_wanted(r1, "seg-1", M1), (R1 + ":g1", S1, S1 + ":g1"))
+        self.assertTrue(jd._attach_courier_link(r1, "seg-1", M1))
+        self.assertEqual(jd.load_goals(R1)["nodes"][R1 + ":g1"]["links"],
+                         [{"peer": S1, "goalId": S1 + ":g1", "msgId": M1}], "the readable sender's link landed")
+        self.assertIsNone(jd._courier_link_wanted(jd.load_goals(R2), "seg-2", M2),
+                          "the faulted sender's recipient waits: answered None where the walk raised before")
+        self.assertEqual(self.rows(), [(S2, "store-unreadable")], "one row for the sender, none per recipient")
+
+    def test_a_raise_that_is_not_a_read_fault_stays_loud(self):
+        """The boundary contains OSError only, as every reader boundary does. Any other raise out of a sender's
+        read (a journal row that parses as JSON but is not an event, a bug in a loader) is not a read fault: it
+        leaves the walk as before, caches nothing, files no store-unreadable row, and reaches the courier's own
+        catch instead of passing as a skipped sender."""
+        self.faulting(S2, ValueError("a journal row that is not an event"))
+        with self.assertRaises(ValueError):
+            jd._handoff_backref(M1)
+        self.assertIsNone(jd._BACKREF_MEMO["slot"], "nothing cached")
+        self.assertEqual(self.rows(), [], "not a read fault: no row")
+        self.assertEqual(jd._BACKREF_STATS, {"served": 0, "built": 0}, "the walk did not complete")
 
     def test_a_rebound_root_forgets_the_map(self):
         jd._handoff_backref(M1)


### PR DESCRIPTION
## What

#1170 built the sender-board walk behind the courier's link repair (`_handoff_backref`) once per state of its inputs, reading every discovered store through the read-only view. That loader raises for a store that exists and cannot be read (EACCES, EIO, a directory at the path), and the walk had no per-sender boundary and wrote its memo slot only after the loop, so one such store failed the lookup for every message id and every recipient: a link-attach pass-crash row per placed unlinked delegate per pass for as long as the fault lasted, and no repair landed anywhere. The walk it replaced returned at the first hit in discover order, so a fault reached only the lookups past it. The review record on #1170 names this as the follow-up.

Each sender is now read through the per-session boundary (`load_goals_shared_or_fault`): a faulted store is skipped for this call and files its one store-unreadable row per fault episode, as every other reader of a goal store files it; the other senders answer, and the first in discover order still wins. The map is not published when a sender was skipped, because a permission fix moves no file key (neither inode, mtime nor size) and a cached map missing a sender would be served after the store reads again. While the fault lasts, a call whose key no longer matches the published map walks the shared views again (a map published before the fault keeps serving while its key stands, since the content it describes has not changed); a recipient whose sender is faulty gets the empty pair, attaches nothing, stays unrecorded by the courier gate and is scanned again next pass, the wait the gate already models for a sender that does not yet track the message.

## Review (by hand)

The boundary catches OSError only, as every reader boundary does: a raise that is not a read fault (a journal row that parses as JSON but is not an event, a bug in a loader) leaves the walk as before and reaches the courier's own catch; a row `json.loads` rejects is skipped by the replay and raises nothing. The counters keep their shape (`{served, built}`); the slot is written only for a complete walk; the first sender in discover order still wins. `_handoff_backref` is the only code changed. One docstring outside it moves: `_log_judge_error`'s row contract said a store-unreadable fault inside a judge pass reaches the pass-crash row, which held only for a strict load (run_propagate's recipient read already filed the row through the same boundary); it now names the readers that file it from inside a pass and keeps the pass-crash clause for a strict load.

## Tests

`tests/test_backref_memo.py`. The raising-store test becomes the per-sender rule. It had pinned the all-or-nothing raise, which was the memo's first shape; the walk the memo replaced answered every sender before a fault, and the per-session boundary is how every other reader of a goal store contains one, so the test's docstring records the change of contract. The fixture gains a third sender after the second in discover order, so a sender past the fault is covered. Three tests red at 1566f7ae with the OSError out of their first lookup, and one that pins a contract that already held:

- a patched read fault on the second sender with its file untouched: the first and third senders answer, the second's message is unanswered, the slot is withheld, one store-unreadable row stands across three lookups; the loader is restored without touching the file, so the key does not move, and the sender answers and the slot is published (this heal is what tells a withheld slot from a cached partial map);
- a directory at the second sender's store path, a real fault with no patching: the same skip, row and withheld slot, and the sender answers once the file is back;
- the courier gate itself (`_courier_link_wanted`, `_attach_courier_link`) with two recipients holding planner-placed unlinked delegates, one from each sender: the readable sender's link lands on its recipient, the faulted sender's recipient is answered None where the walk raised before, and one store-unreadable row covers both recipients;
- a ValueError out of a sender's read propagates, caches nothing and files no row: the boundary is OSError-only, and a wider catch around it fails this test.

Publishing the map despite a skip fails the withheld-slot assertion and the key-stable heal; `break` for `continue` leaves the third sender unanswered; a bare catch around the loader files no row. Full suite: 10126 passed, 61 skipped.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)