### PR TITLE
Judge read memos: the eviction at the cap runs under a lock

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2611,16 +2611,27 @@ def tasks_for(fsid, leaf, files, now):
 # every index pass (19% of the thread), and load_goal_archive decoded goals-archive/<sid>.json per call
 # (11%). Each file is now parsed once per file state: the key is _file_key (inode, mtime_ns, size) taken
 # BEFORE the read (the chain-memo rule), so a row appended during the read moves the key the next call
-# takes and content read mid-write is served no further than that call; an absent or unreadable file is
-# never cached; a stat error (a fresh sentinel key) never matches. Bounded at _FILE_MEMO_MAX entries,
-# oldest-inserted out; a rebound state root clears both. The captions memo serves the three readers from
-# one parse; the archive memo serves READERS only (load_goal_archive_shared): every archiver keeps
-# load_goal_archive, a fresh private object it mutates and saves.
+# takes and content read mid-write is served no further than that call; an absent file is never cached
+# (its key is None); a stat error (a fresh sentinel key) never matches. An existing file that cannot be
+# read is [] and never cached by the captions memo; the archive memo caches load_goal_archive's answer
+# for it, the empty shape, the same answer the fresh loader gives every archiver for that file. Bounded
+# at _FILE_MEMO_MAX entries, oldest-inserted out, the eviction and the insert under _FILE_MEMO_LOCK; a
+# rebound state root clears both. The captions memo serves the three readers from one parse; the archive
+# memo serves READERS only (load_goal_archive_shared): every archiver keeps load_goal_archive, a fresh
+# private object it mutates and saves.
 _CAPTIONS_MEMO = {}        # fsid -> (file key taken before the read, the parsed rows)
 _CAPTIONS_STATS = {"served": 0, "parsed": 0}
 _GOALARCH_MEMO = {}        # fsid -> (file key taken before the read, the guarded archive store: read-only)
 _GOALARCH_STATS = {"served": 0, "loaded": 0}
 _FILE_MEMO_MAX = 256
+_FILE_MEMO_LOCK = threading.Lock()   # the two memos are filled from the index tier, the planner workers and
+#                                      every load_goals caller (a journaled restore row): the eviction's
+#                                      iterate-and-pop and the insert of a new key run under it. Reads do not:
+#                                      a served entry is one dict read of a whole tuple, and a stale or missing
+#                                      read re-derives (the chain memo's two-misses-both-build rule). A LEAF
+#                                      lock: nothing inside _memo_put takes another, so reaching it under
+#                                      _GOAL_ARCH_LOCK (an archiver whose load_goals replays a restore row) is
+#                                      safe; keep it that way.
 
 
 def captions_memo_stats():
@@ -2632,9 +2643,18 @@ def goal_archive_memo_stats():
 
 
 def _memo_put(memo, fsid, key, val):
-    if fsid not in memo and len(memo) >= _FILE_MEMO_MAX:
-        memo.pop(next(iter(memo)))                        # oldest-inserted out: bounded by construction
-    memo[fsid] = (key, val)
+    """Memoize `val` under `fsid` at `key`, evicting the oldest-inserted entry when a NEW key arrives at the
+    cap. The whole step holds _FILE_MEMO_LOCK: unlocked, two fills for new sids at the cap chose the same
+    oldest key (the second pop raised KeyError) or one changed the size under the other's iteration
+    (RuntimeError); the raise passed _or_fault (OSError only) into every load_goals caller, and in the index
+    tier's serial caption loop, which has no per-session guard, it ended the pass for every session (review
+    find on #1171, 2026-09-09). With every size change under the lock a single eviction per fill suffices, so
+    the `if` stays. The counters and the served checks in the two readers stay outside it on purpose: the
+    served read is one dict read, and a lost `+= 1` under-counts a diagnostic and raises nothing."""
+    with _FILE_MEMO_LOCK:
+        if fsid not in memo and len(memo) >= _FILE_MEMO_MAX:
+            memo.pop(next(iter(memo)))                    # oldest-inserted out: bounded by construction
+        memo[fsid] = (key, val)
 
 
 def _captions_rows(fsid):
@@ -4582,11 +4602,15 @@ def save_goals(fsid, store):
 
 
 def load_goal_archive(fsid):
-    """The CLEARED-goal archive for a session (goals-archive/<fsid>.json) — dismissed top goals + their
-    subtrees moved out of the live store by the kernel's compaction sweep. Same shape as the live store
-    (nodes/status). The judge reads this ONLY as read-only context (_cleared_context, for the live re-plan's
-    <recently-cleared> block) — its placements dedup + view-cleared sealing keep it from ever re-minting an
-    archived node; the kernel's undo-clear restore and the ledger merge are the mutating readers."""
+    """The CLEARED-goal archive for a session (goals-archive/<fsid>.json): dismissed top goals and their
+    subtrees moved out of the live store, in the live store's shape (nodes/status). This is the FRESH loader,
+    a private object per call: the archivers (archive_goal_nodes here, for the rewind take and the dead-branch
+    reconciliation; the kernel's store compaction and undo restore) load through it and save under
+    _GOAL_ARCH_LOCK. The judge's readers (_cleared_context for the live re-plan's <recently-cleared> block,
+    the override replay, the peer-node joins, the propagate pass) take load_goal_archive_shared, its twin,
+    which serves one loaded object per file state; the re-plan's placements dedup and view-cleared sealing
+    keep it from ever re-minting an archived node. Any failure to read or decode an existing file answers the
+    empty shape, and the shared twin memoizes that answer for the file as it stands."""
     try:
         return _guard_nodes(json.loads((GOALARCHDIR / (fsid + ".json")).read_text()))
     except Exception:

--- a/tests/test_file_read_memos.py
+++ b/tests/test_file_read_memos.py
@@ -9,12 +9,14 @@ file three times per session per index pass (19% of the thread), the archive loa
 Pins: parsed once then served; the derived readers equal the direct derivations; an append re-derives, including
 one the file clock cannot see; a write landing during the read is served no further than that call; an absent
 file is empty and never cached; a malformed line is skipped; the memos are bounded; the archive's writers get a
-fresh object; the switched callers; a rebound root forgets; the counters.
+fresh object; the switched callers; a rebound root forgets; the counters; two fills at the cap on two
+threads neither raise nor overflow it.
 
 Synthetic ids under a private synthetic sid; a temp state root."""
 import json
 import os
 import tempfile
+import threading
 import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
@@ -254,6 +256,145 @@ class GoalArchiveMemo(_Memo):
         for fn in (jd.captions_memo_stats, jd.goal_archive_memo_stats):
             s = fn(); k = next(iter(s)); s[k] = 99
             self.assertNotEqual(fn()[k], 99)
+
+
+class _HookedMemo(dict):
+    """A dict with an optional hook before dict.pop and one before dict.__setitem__; every other operation
+    (len, in, get, iter, clear) is the plain dict's, and so are these two when no hook is set. The eviction
+    tests rebind the module's archive memo to one so a thread can be held at a chosen point inside _memo_put:
+    about to pop its chosen victim, or about to insert after its eviction."""
+    before_pop = None
+    before_set = None
+
+    def pop(self, key, *default):
+        if self.before_pop is not None:
+            self.before_pop(key)
+        return dict.pop(self, key, *default)
+
+    def __setitem__(self, key, val):
+        if self.before_set is not None:
+            self.before_set(key)
+        dict.__setitem__(self, key, val)
+
+
+class MemoEviction(_Memo):
+    """The eviction at the cap is filled from many threads (every load_goals that replays a restore row, the
+    index tier, the planner workers). Two fills for new sids at the cap must neither raise nor overflow the
+    cap. Both tests run real fills through load_goal_archive_shared with the cap patched to 4, and make the
+    interleaving deterministic with hooks on the memo: the first holds both threads at the point where both
+    have chosen the same victim (before the pop), the second holds one thread between its pop and its insert
+    (before the insert). Without a lock around the eviction and the insert, the first raises KeyError out of
+    the fill (both pop the same key) and the second leaves five entries; a lock around the pop alone still
+    fails the second, since the other thread measures the size in the gap. Each hold is bounded by a timeout
+    (about one second on the green path, where the lock keeps the other thread out until the hold expires)
+    and every thread is joined under a wall-clock cap that fails loudly. Only the red side depends on timing:
+    without the lock the second thread must reach its hold within the first's one-second wait, so a heavily
+    loaded machine can let an unlocked judge pass; the green path holds under any load."""
+    CAP = 4
+    JOIN_S = 10.0
+    HOLD_S = 1.0
+    OLD = ["11111111-2222-3333-4444-6666666666%02d" % (20 + i) for i in range(4)]
+    NEW1 = "11111111-2222-3333-4444-666666666631"
+    NEW2 = "11111111-2222-3333-4444-666666666632"
+
+    def setUp(self):
+        super().setUp()
+        self.memo = _HookedMemo()
+        for sid in self.OLD:
+            self.memo[sid] = ((1, 2, 3), {})            # placeholder entries: the memo is at the cap
+        for sid in (self.NEW1, self.NEW2):              # real files, so _file_key is a tuple and _memo_put is reached
+            (jd.GOALARCHDIR / (sid + ".json")).write_text(
+                json.dumps({"rompUuid": sid, "nodes": {}, "status": {}}))
+        self.saved = (jd._GOALARCH_MEMO, jd._FILE_MEMO_MAX)
+        jd._GOALARCH_MEMO, jd._FILE_MEMO_MAX = self.memo, self.CAP
+
+    def tearDown(self):
+        jd._GOALARCH_MEMO, jd._FILE_MEMO_MAX = self.saved   # the module's own dict back before the rebind clears it
+        super().tearDown()
+
+    def _run(self, *targets):
+        """Run each target on its own thread; the exceptions they raised, in the order the threads were started.
+        A thread still alive at the cap is a failure, not a hang: the threads are daemons, so a fill that
+        deadlocks fails the check below without then holding the process open at exit."""
+        errors = [[] for _ in targets]
+
+        def wrap(i, fn):
+            def go():
+                try:
+                    fn()
+                except BaseException as e:      # noqa: BLE001 - the test reports what the fill raised
+                    errors[i].append(e)
+            return go
+        threads = [threading.Thread(target=wrap(i, fn), name="fill-%d" % i, daemon=True)
+                   for i, fn in enumerate(targets)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=self.JOIN_S)
+        self.assertFalse([t.name for t in threads if t.is_alive()], "a fill did not finish within the cap")
+        return [e for es in errors for e in es]
+
+    def _check_shape(self):
+        self.assertEqual(len(self.memo), self.CAP, "the cap holds")
+        self.assertIn(self.NEW1, self.memo); self.assertIn(self.NEW2, self.memo)
+        for ent in self.memo.values():
+            self.assertIsInstance(ent, tuple); self.assertEqual(len(ent), 2)
+        self.assertEqual(jd._GOALARCH_STATS["served"], 0, "both calls were fills")   # never incremented here, so
+        #                                                   race-free. `loaded` is unlocked by design (a lost
+        #                                                   increment under-counts a diagnostic) and is pinned
+        #                                                   only where the two increments are ordered.
+
+    def test_two_fills_at_the_cap_that_chose_the_same_victim_evict_without_raising(self):
+        # Both threads compute next(iter(memo)) before either pops: the hook before dict.pop parks each at a
+        # two-party barrier. Without the lock both arrive (the dict is unchanged while the first waits), the
+        # barrier releases both, and the second dict.pop of the same key raises KeyError out of the fill. With
+        # the lock the first holds it through the barrier's timeout, pops and inserts; the second then chooses
+        # the next oldest key, its barrier call raises BrokenBarrierError at once (swallowed), and it evicts
+        # and inserts in turn.
+        barrier = threading.Barrier(2)
+
+        def hold(_key):
+            try:
+                barrier.wait(timeout=self.HOLD_S)
+            except threading.BrokenBarrierError:
+                pass
+        self.memo.before_pop = hold
+        errors = self._run(lambda: jd.load_goal_archive_shared(self.NEW1),
+                           lambda: jd.load_goal_archive_shared(self.NEW2))
+        self.assertEqual(errors, [], "a fill raised out of the eviction: %r" % errors)
+        self._check_shape()
+
+    def test_a_fill_landing_between_another_fills_eviction_and_insert_does_not_overflow_the_cap(self):
+        # The first thread is held after its pop and before its insert (the hook before dict.__setitem__, on
+        # that thread only); the second fills while it waits. Without the lock the second sees three entries,
+        # skips the eviction and inserts, and the first's insert then makes five. With the lock the second
+        # blocks until the first's hold expires and it inserts, then evicts one itself. A lock around the pop
+        # alone leaves the gap open and fails here too: the hold sits at the insert, outside such a lock.
+        first = []
+        evicted, other_done = threading.Event(), threading.Event()
+
+        def gap(_key):
+            if first and threading.get_ident() == first[0]:
+                evicted.set()
+                other_done.wait(timeout=self.HOLD_S)
+        self.memo.before_set = gap
+
+        def fill_first():
+            first.append(threading.get_ident())
+            jd.load_goal_archive_shared(self.NEW1)
+
+        def fill_second():
+            self.assertTrue(evicted.wait(timeout=self.JOIN_S), "the first fill never reached its insert")
+            try:
+                jd.load_goal_archive_shared(self.NEW2)
+            finally:
+                other_done.set()
+        errors = self._run(fill_first, fill_second)
+        self.assertEqual(errors, [], "a fill raised: %r" % errors)
+        self.assertTrue(evicted.is_set(), "the first fill evicted and reached its insert")
+        self._check_shape()
+        self.assertEqual(jd._GOALARCH_STATS["loaded"], 2)   # exact here: the second fill starts after the first's
+        #                                                     increment, so the unlocked counter is ordered
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Symptom. #1171 bounded the captions and goal-archive read memos at 256 entries with an oldest-out eviction in `_memo_put`, which iterates and pops the dict with no lock. The archive memo is filled from every thread that loads a goal store (a journaled restore row reaches it inside `load_goals`), the captions memo from the index tier and the planner workers. At the cap, two concurrent fills for new sids can both pick the same oldest key (the second pop raises KeyError) or one can change the dict's size during the other's iteration (RuntimeError). The per-session boundary (`_or_fault`) catches OSError only, so the raise reaches the feed builders, the tick jobs and a planner pass-crash row, and the index tier's serial caption loop, which has no per-session guard, ends its pass for every session. Narrow (it needs the cap) and self-healing, but a raise on a read path; reproduced by the review record on #1171 with a stress script.

Cause. `_memo_put` evicts with `memo.pop(next(iter(memo)))` and inserts under no lock.

Fix. One leaf lock, `_FILE_MEMO_LOCK`, around the eviction and the insert. The served path is unchanged (one dict read of an immutable tuple; a stale or missing read re-derives, the chain memo's rule), and the counters stay unlocked: a lost increment under-counts a diagnostic and raises nothing. The chain memo already evicts under its own lock. Nothing inside `_memo_put` takes another lock, so the archiver path that reaches it under `_GOAL_ARCH_LOCK` (an undo restore whose `load_goals` replays a restore row) stays safe; the note beside the lock says so. Comment corrections from the same record: the archive memo does cache the fresh loader's empty answer for an existing unreadable or corrupt file (an absent file is never cached), and `load_goal_archive`'s docstring now names the archivers as they are (the rewind take and the dead-branch reconciliation in the judge, the kernel's store compaction and undo restore, all saving under `_GOAL_ARCH_LOCK`) and `load_goal_archive_shared` as the readers' twin. Not here: freezing the memoized archive store (the record's first item), a separate change.

Tests. Two in `tests/test_file_read_memos.py` (class `MemoEviction`), both through `load_goal_archive_shared` with real archive files and the cap patched to 4, made deterministic by hooks on the memo's `pop` and `__setitem__`: two fills that chose the same victim, and a fill landing between another's eviction and insert. Red on main before the change (ab144390): KeyError out of the fill, 20 of 20 runs; 5 entries against a cap of 4, 20 of 20 runs. Green with the lock, 20 of 20 runs. The second test also fails a lock around the pop alone. Each hold is bounded by a one-second timeout, so the class adds about two seconds; the threads are daemons joined under a wall-clock cap that fails loudly. The unlocked `loaded` counter is pinned only where the two increments are ordered; both tests pin `served == 0`, which never races. Full suite: 10125 passed, 61 skipped.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)