### PR TITLE
Planner gate: the key carries the leaf's task store, the captions file and each running launch's deadline crossing

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -947,11 +947,12 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   cleared context, each parsed once per file state (`served`, `parsed` or
   `loaded`); `plannerSkip` is the planner's change gate (`skipped`, `planned`,
   `recorded`: a session whose parse, store, journal, archive, episode log,
-  task store and reg have not moved since a pass that had nothing to do is
-  not planned again). The compaction sweep after each judge pass evicts from `pass` and
-  `shared` the entries of stores no session in the discover window owns, so
-  both stay bounded by the live board; the gate memo is bounded by the session
-  count.
+  its leaf's task store, captions file and reg have not moved since a pass
+  that had nothing to do, and none of whose running background launches has
+  crossed its deadline, is not planned again). The compaction sweep after
+  each judge pass evicts from `pass` and `shared` the entries of stores no
+  session in the discover window owns, so both stay bounded by the live
+  board; the gate memo is bounded by the session count.
 - `judge`: `passes`, `ms_sum`, `ms_last`, `ms_mean` (wall time; a pass waits
   on model calls), `cpu_ms_sum` (CPU time of the judge tier threads and every
   per-session worker they run; the workers' share is `cpu_ms_workers`).

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2184,11 +2184,15 @@ _COURIER_SEEN = {}         # fsid -> the scan key of its last pass that found no
 # store where it was has no new information for the planner by construction, so the pass returns at once.
 # The key is every input the pass reads, taken BEFORE the store read (the chain-memo rule): the parse
 # cache's fileset key bound to the session object, the store file's key with its journal's and archive's,
-# the episode log's key, the session's task-store files (each name with its key: the declared-plan sync
-# reads them), the reg file's key, and the transcript path. Recorded only when the pass did nothing and the
-# store's key after the pass equals the one before it (a heal, a mint, a retirement or a rollup change
-# moves it); a pass with units, placements or a moved store is planned again next pass whatever the key
-# says. A parse the cache does not hold is never keyed. Pruned to the pass's fleet; a rebound root clears.
+# the episode log's key, the LEAF's task-store files (each name with its key: the declared-plan sync reads
+# the leaf fsid's directory, which a /clear forks away from an SDK session's sid), the reg file's key, the
+# captions file's key (the floor-title heal reads it), each running background launch with whether it has
+# crossed its deadline under the pass clock (the settle's one input no file records; see _bg_expiry_key),
+# and the transcript path. Recorded only when the pass did nothing and the store's key after the pass
+# equals the one before it (a heal, a mint, a retirement or a rollup change moves it); a pass with units,
+# placements or a moved store is planned again next pass whatever the key says. A parse the cache does not
+# hold is never keyed, nor is an expiry view that cannot be computed. Pruned to the sessions the pass
+# discovered; a rebound root clears.
 _PLANNER_SEEN = {}         # fsid -> the plan key of its last pass that had nothing to do
 _PLANNER_STATS = {"skipped": 0, "planned": 0, "recorded": 0}
 
@@ -2199,9 +2203,11 @@ def planner_skip_stats():
 
 
 def _task_store_key(fsid):
-    """The session's Claude task store (<config>/tasks/<fsid>/*.json, what em.task_store_plan reads) as a key:
-    each file's name with its stat, or None when the directory is absent; a listing error is a fresh sentinel
-    (never equal), so a store that cannot be read is never skipped over."""
+    """A Claude task store (<config>/tasks/<fsid>/*.json) as a key: each file's name with its stat, or None when
+    the directory is absent; a listing error is a fresh sentinel (never equal), so a store that cannot be read
+    is never skipped over. The planner hands in the LEAF fsid, the directory em.task_store_plan reads for the
+    declared-plan sync: an SDK session's /clear forks its transcript to a new fsid under the same romp sid, and
+    the agent's to-dos live under the fsid it is running as, not the sid."""
     d = Path(os.environ.get("CLAUDE_CONFIG_DIR") or str(em.HOME / ".claude")) / "tasks" / fsid
     try:
         names = sorted(n for n in os.listdir(d) if n.endswith(".json"))
@@ -2212,14 +2218,20 @@ def _task_store_key(fsid):
     return tuple((n, _file_key(str(d / n))) for n in names)
 
 
-def _plan_key(fsid, path, session):
+def _plan_key(fsid, path, session, now):
     """Every input _plan_session reads, or None when the parse is not the cache's own (never skip what cannot
-    be keyed). Taken before the store read."""
+    be keyed). Taken before the store read. Index 2 is the store key: the record rule compares it after the
+    pass, so new terms go after the existing ones. Three terms beyond the files the pass opens by sid: the
+    LEAF's task store (the directory the declared-plan sync reads, which differs from the sid's for every SDK
+    session after a /clear), the captions file (the floor-title heal reads it), and each running background
+    launch with whether it has crossed its deadline under the pass clock `now` (_bg_expiry_key: the settle
+    reads that crossing and no file records it)."""
     pk = _PARSE_CACHE.get(fsid)
     if pk is None or pk[1] is not session:
         return None
     return (str(path), pk[0], _store_key(fsid), _file_key(str(EPIDIR / (fsid + ".jsonl"))),
-            _task_store_key(fsid), _file_key(str(SDKDIR / (fsid + ".json"))))
+            _task_store_key(session.get("leafFsid") or fsid), _file_key(str(SDKDIR / (fsid + ".json"))),
+            _file_key(str(CAPDIR / (fsid + ".jsonl"))), _bg_expiry_key(path, now))
 
 
 def _store_key(fsid):
@@ -7235,16 +7247,39 @@ def _session_closed(session):
 _BG_SCAN_CACHE = {}                       # path -> em.fold_records entry (running tasks) — mirrors the kernel's _bg_scan_cached
 
 
-def _bg_unresolved(path):
+def _bg_unresolved(path, now=None):
     """The transcript's still-RUNNING background launches (em._scan_bg_tasks pairing), folded append-incrementally.
     The DURABLE awaited-work source: the pairing lives in the transcript, so unlike any live backend
-    snapshot it survives a kernel restart and covers tmux CLIs whose tasks outlive the kernel."""
+    snapshot it survives a kernel restart and covers tmux CLIs whose tasks outlive the kernel.
+    `now`: the pass's clock when the planner hands it in (one clock for its key's expiry term and the
+    settle that term gates, so the two cannot disagree at the crossing); the wall clock otherwise."""
     # folds append-incrementally since 2026-09-03: a changed transcript steps only its appended records
     tasks = em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)
     # expiry is applied OUTSIDE the cache with a fresh now: a monitor whose CLI died mid-watch has no
     # terminal record, and an idle transcript never busts the mtime key — a cached verdict would say
     # "running" forever (see em._bg_expired)
-    return [t for t in tasks if not em._bg_expired(t, time.time())]
+    if now is None:
+        now = time.time()
+    return [t for t in tasks if not em._bg_expired(t, now)]
+
+
+def _bg_expiry_key(path, now):
+    """The settle's one input no file records, as a term of the planner gate's key: each running background
+    launch the transcript pairs (the judge's running-only fold, the set _awaiting_bg_hold filters) with
+    WHETHER its recorded deadline has passed under `now`, sorted. A clock fact keyed as the boolean it
+    resolves to, the shape of the kernel's awaiting-lift gate (_lift_spent_awaiting): the term moves once,
+    at the crossing, and the crossing itself re-plans the session, so a done focus top that a watch whose
+    CLI died mid-watch held at 'working' completes when the watch can no longer return. A launch with no
+    recorded ceiling (a backgrounded Bash, a dev server) is a stable False and never re-plans an idle
+    session; a ghost launch (before the live CLI's epoch) is a superset entry that costs one re-plan at a
+    crossing that cannot change the verdict, as the kernel's gate accepts. A scan that raises answers a
+    fresh sentinel (never equal, _task_store_key's listing-error rule), so a session whose view cannot be
+    computed is planned every pass; the settle's own call then raises as it does today."""
+    try:
+        return tuple(sorted((str(t.get("id") or ""), bool(em._bg_expired(t, now)))
+                            for t in em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)))
+    except Exception:
+        return object()
 
 
 def _death_marker(sid):
@@ -7281,7 +7316,7 @@ def _cli_epoch(sid):
     return max(sp or 0, mt or 0)
 
 
-def _awaiting_bg_hold(fsid, path, session, store):
+def _awaiting_bg_hold(fsid, path, session, store, now=None):
     """True while the session is awaiting its own dispatched background work — the settle must hold.
 
     A turn that ends with a live awaited task has NOT handed back the floor: the harness re-invokes the
@@ -7300,8 +7335,8 @@ def _awaiting_bg_hold(fsid, path, session, store):
         same placed-unstamped-is-a-service rule as the kernel's _bg_split, translated to judge-native
         events. A live awaitingWhy stamp re-affirms the hold past that audit; its lift releases it.
     Pre-verdict the hold is conservative (a launch whose turn nothing has swept always holds), matching
-    _bg_split's PENDING→awaited prior."""
-    tasks = _bg_unresolved(path)
+    _bg_split's PENDING→awaited prior. `now`: the pass's clock for the expiry view (see _bg_unresolved)."""
+    tasks = _bg_unresolved(path, now)
     if not tasks:
         return False
     sp = _cli_epoch(fsid)
@@ -7327,11 +7362,11 @@ def _awaiting_bg_hold(fsid, path, session, store):
     return any(launch_turn.get(t["id"]) not in swept for t in tasks)
 
 
-def _session_settled(fsid, path, session, store):
+def _session_settled(fsid, path, session, store, now=None):
     """The rollup's settled gate: the turn ended AND nothing the session dispatched is still awaited.
     _session_closed alone read the 'ended' proxy; this keys the settle on the event it was
     approximating — the session actually handing back the floor."""
-    return _session_closed(session) and not _awaiting_bg_hold(fsid, path, session, store)
+    return _session_closed(session) and not _awaiting_bg_hold(fsid, path, session, store, now)
 
 
 def _prompt_anchor_uuid(seg):
@@ -8959,7 +8994,7 @@ def _plan_session(fsid, path, now):
     re-examinable — until the courier plants a real goal). Returns placements made."""
     _judge_ctx.fsid = fsid                            # usage logging: attribute this session's judge calls
     session = parsed_session(fsid, [path], now)
-    pkey = _plan_key(fsid, path, session)             # BEFORE the store read (the chain-memo rule)
+    pkey = _plan_key(fsid, path, session, now)        # BEFORE the store read (the chain-memo rule)
     if pkey is not None and _PLANNER_SEEN.get(fsid) == pkey:
         _PLANNER_STATS["skipped"] += 1               # nothing moved since a pass that had nothing to do
         return 0
@@ -9440,7 +9475,7 @@ def _plan_session(fsid, path, now):
     _latch_ask_anchors(fsid, session, store)          # durable ask-unit anchor verdicts — no LLM,
     #                                                   idempotent (latched nodes skip), persisted
     #                                                   by the save just below
-    rollup_status(store, _session_settled(fsid, path, session, store))
+    rollup_status(store, _session_settled(fsid, path, session, store, now))
     save_goals(fsid, store)
     if pkey is not None:
         if placed == 0 and not units and not retired and _store_key(fsid) == pkey[2]:
@@ -9472,7 +9507,7 @@ def run_plan(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=Fal
         now = int(time.time())
     fleet = [s for s in discover(now) if not _hidden_from_feed(s[0])][:sessions_cap]   # muted sessions are out of task tracking
     for _gone in [f for f in _PLANNER_SEEN if f not in {s[0] for s in fleet}]:
-        _PLANNER_SEEN.pop(_gone, None)                # the planner gate, bounded by the pass's fleet
+        _PLANNER_SEEN.pop(_gone, None)                # the planner gate, bounded by the sessions this pass discovered
     placed = 0
     with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         futs = {ex.submit(_plan_session, fsid, str(path), now): fsid for fsid, path, anchor, name in fleet}

--- a/tests/test_bg_scan_monitor.py
+++ b/tests/test_bg_scan_monitor.py
@@ -158,8 +158,11 @@ class ConsumersApplyExpiry(unittest.TestCase):
                       "the awaiting-stamp lift must not wait forever on a dead monitor")
         self.assertIn("em._bg_expired(tk, time.time())", kernel,
                       "source 0.75's normalized rows must drop expired monitors")
-        self.assertIn("em._bg_expired(t, time.time())", judge,
-                      "the judge's settled gate must apply expiry with a fresh now, not the cached one")
+        body = judge.split("def _bg_unresolved(", 1)[1].split("\ndef ", 1)[0]
+        self.assertIn("em._bg_expired(t, now)", body,
+                      "the judge's settled gate must apply expiry outside the cache, with the caller's now")
+        self.assertIn("now = time.time()", body,
+                      "...a fresh wall clock when no pass clock is handed in, not the cached one")
 
 
 if __name__ == "__main__":

--- a/tests/test_planner_skip.py
+++ b/tests/test_planner_skip.py
@@ -4,12 +4,17 @@
 Measured on the maintainer's box: the planner worker pool was 37% of the process's samples, re-deriving every
 session's segmentation, plan units and placement normalization on every pass. The gate keys each session on
 every input the pass reads, taken before the store read: the parse cache's key bound to the session object,
-the store with its journal and archive, the episode log, the session's task-store files, the reg file and the
-transcript path; it records only when the pass placed nothing, collected no unit and left the store's key
-unchanged. Pins: unchanged inputs skip after a pass that had nothing to do; a moved store, a fresh parse, a
-task-store change alone and a reg change alone each un-skip that session; a write landing during the pass is
-seen next pass; three sessions with one moved leave placements and nodes byte-identical to the ungated passes
-(two fresh worlds); a parse the cache does not hold is never skipped; a rebound root forgets; the counters.
+the store with its journal and archive, the episode log, the leaf's task-store files, the reg file and the
+transcript path, the captions file and each running background launch's expiry under the pass clock; it records
+only when the pass placed nothing, collected no unit and left the store's key unchanged. Pins: unchanged inputs
+skip after a pass that had nothing to do; a moved store, a fresh parse, a task-store change alone (under the
+session's own sid, and under its forked leaf's), a reg change alone, a prompt caption landing (which heals a
+floor title) and a running launch crossing its deadline (which completes a done focus top) each un-skip that
+session; the expiry term holds while a launch is inside its ceiling, and for a launch with no recorded ceiling
+however far the clock runs; the settle reads the wall clock when no pass clock is handed in; a write landing
+during the pass is seen next pass; three sessions with one moved leave placements and nodes byte-identical to
+the ungated passes (two fresh worlds); a parse the cache does not hold is never skipped, nor is an expiry view
+that cannot be computed; a rebound root forgets; the counters.
 
 Synthetic sids and text; a temp state root, a temp Claude config root for the task store; the planner's model
 calls are stubs, deterministic, so two worlds agree byte for byte."""
@@ -31,6 +36,7 @@ jd = SourceFileLoader("romp_judge_planner_skip", os.path.join(BIN, "romp-judge")
 A = "11111111-2222-3333-4444-555555555501"
 B = "11111111-2222-3333-4444-555555555502"
 C = "11111111-2222-3333-4444-555555555503"
+LEAF = "11111111-2222-3333-4444-555555555511"     # the transcript A's /clear forks to (its reg's lastSid)
 NOW = 1781100000
 T0 = NOW - 3600
 
@@ -98,7 +104,7 @@ class _World(unittest.TestCase):
     @staticmethod
     def _reset():
         jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear(); jd._episode_memo.clear(); jd._shared_clear()
-        jd._PLANNER_SEEN.clear()
+        jd._PLANNER_SEEN.clear(); jd._lastsid_memo.clear(); jd._BG_SCAN_CACHE.clear()
         for k in jd._PLANNER_STATS:
             jd._PLANNER_STATS[k] = 0
         jd._discover_cache["fp"] = None
@@ -261,6 +267,140 @@ class PlannerSkip(_World):
         self.assertEqual(set(jd.planner_skip_stats()), {"skipped", "planned", "recorded"})
         s = jd.planner_skip_stats(); s["skipped"] = 99
         self.assertNotEqual(jd.planner_skip_stats()["skipped"], 99)
+
+    def test_a_task_store_change_under_the_forked_leaf_un_skips(self):
+        # A is an SDK session that /cleared: its reg names LEAF as the current transcript, so discover hands the
+        # planner the leaf file under A's stable sid and the declared-plan sync reads tasks/<LEAF>/, never
+        # tasks/<A>/. A's anchor transcript stays a parse candidate; the fork's null-rooted head drops it.
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        (jd.SDKDIR / (A + ".json")).write_text(json.dumps(
+            {"sid": A, "name": "worker0", "cwd": str(Path(self.td.name) / "launchdir"), "lastSid": LEAF}))
+        leaf = self.proj_dir / (LEAF + ".jsonl")
+        recs = [uline(T0 + 100, "wire up the reconnect banner after the clear", "f1"),
+                aline(T0 + 130, "Done: the banner reconnects.", "f2", "f1")]
+        leaf.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        os.utime(leaf, (T0 + 160, T0 + 160))
+        self.assertEqual(self.run_pass()[0:2], (3, 0))
+        self.assertEqual(jd._PARSE_CACHE[A][1]["leafFsid"], LEAF, "A parses its forked leaf")
+        self.assertTrue(any(n.get("parentId") is None for n in self.stores()[A]["nodes"].values()), "A's ask minted")
+        self.settle()
+        d = self.cfg / "tasks" / LEAF
+        d.mkdir(parents=True)
+        (d / "1.json").write_text(json.dumps({"id": "1", "subject": "check the width on iOS", "status": "pending"}))
+        self.assertEqual(self.run_pass()[0:2], (1, 2), "the leaf's task store appeared: A alone planned")
+        self.assertTrue(any((n.get("agentTask") or {}).get("key") == "1" for n in self.stores()[A]["nodes"].values()),
+                        "the to-do is mirrored from the leaf's store")
+
+    def test_a_prompt_caption_landing_heals_a_floor_title_on_a_recorded_session(self):
+        # The planner answers C's work-run with a lone skip: a human message never vanishes, so the hard guard
+        # places it on the coerce floor wearing the verbatim head (no caption exists yet to title it from).
+        # The prompt caption the index tier appends later is the ONLY input that moves; the heal must see it.
+        stub = jd.plan_llm
+        jd.plan_llm = (lambda text, *a, **kw:
+                       '{"ops":[{"do":"skip","why":"nothing to file"}]}' if self.PROMPTS[C] in text else stub(text, *a, **kw))
+        self.settle()
+        floor = [n for n in self.stores()[C]["nodes"].values() if n.get("why") == jd._COERCE_WHY]
+        self.assertEqual(len(floor), 1, "C's prompt landed on the coerce floor")
+        nd = floor[0]
+        self.assertEqual(nd["text"], jd._seg_label(nd["quote"]), "precondition: the floor node wears the verbatim head")
+        seg = nd["trail"][0]
+        jd.append_caption(C, seg + "#p", "prompt", NOW, "Fix the mobile tab width")
+        self.assertEqual(self.run_pass()[0:2], (1, 2), "C's captions file appeared: C alone planned")
+        self.assertEqual(self.stores()[C]["nodes"][nd["id"]]["text"], "Fix the mobile tab width", "retitled from the caption")
+        self.settle()
+
+    def _launch_transcript(self, sid, tid, name, inp, ack):
+        """`sid`'s turn dispatches one background launch (tool_use `tid`: `name` with `inp`), the harness acks it
+        with plain text (no <task-notification>, so em._bg_step keeps it running) and the turn ends."""
+        recs = [uline(T0, self.PROMPTS[sid], "u1"),
+                {"type": "assistant", "timestamp": iso(T0 + 20), "uuid": "m1", "parentUuid": "u1",
+                 "message": {"role": "assistant", "stop_reason": None, "content": [
+                     {"type": "tool_use", "id": tid, "name": name, "input": inp}]}},
+                {"type": "user", "timestamp": iso(T0 + 21), "uuid": "r1", "parentUuid": "m1",
+                 "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": tid, "content": ack}]}},
+                aline(T0 + 30, "Done: it is running.", "a1", "r1")]
+        p = self.proj_dir / (sid + ".jsonl")
+        p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        os.utime(p, (T0 + 90, T0 + 90))
+
+    def _monitor_transcript(self, sid):
+        """A Monitor: its timeout_ms is a recorded ceiling. em._bg_step registers the deadline at T0 + 20 + 3600
+        and em._bg_expired reads the crossing 120 s later, at NOW + 140."""
+        self._launch_transcript(sid, "toolu_mon1", "Monitor",
+                                {"timeout_ms": 3600000, "persistent": False, "description": "watch the build"},
+                                "monitoring started")
+
+    def _bash_transcript(self, sid):
+        """A backgrounded Bash: no recorded ceiling, so em._bg_expired never expires it."""
+        self._launch_transcript(sid, "toolu_bash1", "Bash", {"command": "./serve-dev.sh", "run_in_background": True},
+                                "Command running in background")
+
+    def test_a_running_launch_crossing_its_deadline_re_plans_the_session_and_its_done_top_completes(self):
+        self._monitor_transcript(A)
+        self.assertEqual(self.run_pass()[0:2], (3, 0))
+        top = next(nid for nid, n in self.stores()[A]["nodes"].items() if n.get("parentId") is None)
+        sp = jd.GOALDIR / (A + ".json")                     # the done verdict, filed as a closer files it
+        d = json.loads(sp.read_text())
+        d["nodes"][top]["nodeComplete"] = True
+        d["nodes"][top].setdefault("log", []).append({"ev_t": T0 + 40, "src": "closer", "kind": "done",
+                                                      "why": "shipped", "at": T0 + 40})
+        d["lastNode"] = top
+        sp.write_text(json.dumps(d))
+        self.settle()
+        self.assertEqual(self.stores()[A]["status"][top], "working",
+                         "precondition: complete and in focus, held by the running watch under the pass clock")
+        self.assertEqual(self.run_pass(now=NOW + 100), (0, 3, 0), "the clock moved, no launch crossed: all skipped")
+        self.assertEqual(self.run_pass(now=NOW + 200)[0:2], (1, 2), "the watch crossed its deadline: A alone planned")
+        self.assertEqual(self.stores()[A]["status"][top], "completed", "the hold released and the top settled")
+
+    def test_a_launch_with_no_ceiling_leaves_a_recorded_session_skipped(self):
+        # The alternative to a key term, "never record while a launch runs", would plan this session on every
+        # pass: a backgrounded Bash has no recorded ceiling, so its expiry is a stable False and the term never
+        # moves, however far the clock runs.
+        self._bash_transcript(A)
+        self.assertEqual(self.run_pass()[0:2], (3, 0))
+        self.settle()
+        path = str(self.proj_dir / (A + ".jsonl"))
+        self.assertEqual(jd._bg_expiry_key(path, NOW), (("toolu_bash1", False),), "running, no ceiling")
+        self.assertEqual(jd._bg_expiry_key(path, NOW + 86400), jd._bg_expiry_key(path, NOW), "a day later: unchanged")
+        self.assertEqual(self.run_pass(now=NOW + 200), (0, 3, 0), "the clock moved, nothing crossed: all skipped")
+        self.assertEqual(self.run_pass(now=NOW + 86400), (0, 3, 0), "a day later: still skipped")
+
+    def test_the_settle_reads_the_wall_clock_when_no_pass_clock_is_handed_in(self):
+        # Every caller but the planner asks with no clock (the closer, the unblocker, the A/B path): the default
+        # is the wall clock, read per call outside the scan cache. The clock is frozen, never slept.
+        self._monitor_transcript(A)
+        path = str(self.proj_dir / (A + ".jsonl"))
+        saved = jd.time.time
+        try:
+            jd.time.time = lambda: NOW + 200
+            self.assertEqual(jd._bg_unresolved(path), [], "past the ceiling under the wall clock: expired")
+            self.assertEqual([t["id"] for t in jd._bg_unresolved(path, T0 + 25)], ["toolu_mon1"],
+                             "a clock handed in outranks the wall clock")
+            jd.time.time = lambda: NOW
+            self.assertEqual([t["id"] for t in jd._bg_unresolved(path)], ["toolu_mon1"],
+                             "inside the ceiling under the wall clock: still running")
+        finally:
+            jd.time.time = saved
+
+    def test_an_expiry_view_that_cannot_be_computed_is_never_skipped(self):
+        self.settle()
+        real = jd.em.scan_bg_tasks_cached
+        a_path = str(self.proj_dir / (A + ".jsonl"))
+
+        def raising(path, cache, want_all=False):
+            if str(path) == a_path:
+                raise OSError("the transcript cannot be read")
+            return real(path, cache, want_all)
+        self.assertEqual(jd._bg_expiry_key(a_path, NOW), jd._bg_expiry_key(a_path, NOW), "a readable view is stable")
+        jd.em.scan_bg_tasks_cached = raising
+        try:
+            self.assertNotEqual(jd._bg_expiry_key(a_path, NOW), jd._bg_expiry_key(a_path, NOW),
+                                "a view that cannot be computed never equals a recorded one")
+            for _ in range(3):
+                self.assertEqual(self.run_pass()[0:2], (1, 2), "A planned every pass, never skipped")
+        finally:
+            jd.em.scan_bg_tasks_cached = real
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Three inputs the planner reads are outside its change gate's key (#1173: a pass that had nothing to do records the session, and it is skipped while the key stands), so a recorded session is not planned again when only they move:

- After a `/clear`, an SDK session's to-do change alone does not re-plan it. Today the backend's TaskCreate/TaskUpdate hook rewrites the reg on the same call and the reg is keyed, so the card still moves; the gate's own contract does not hold there, and when the hook finds the reg unreadable it writes nothing, so no keyed input moves.
- A coerce-floor title on an idle session never heals when its prompt caption lands. Nothing masks this one; it needs a judge outage at mint time to arise.
- A done focus top held at `working` by a launch whose CLI died mid-watch completes only when another input moves. At the default the closer's own settle at the end of each triage pass covers it; `run_plan` alone does not.

The review record on #1173 lists the three.

Cause: `_plan_key` keys the task store under the romp sid while `_sync_declared_plan` reads it under the leaf fsid (the two differ for every SDK session after a `/clear`); `_heal_floor_titles` reads `captions/<sid>.jsonl`, which no term carries; `_awaiting_bg_hold` applies `em._bg_expired` to every running launch with the clock, and no file records the crossing.

Fix: the key stats `tasks/<leaf fsid>/` (the directory the sync reads, replacing the sid's) and the captions file, and carries each running launch's expiry boolean under the pass clock, appended after the existing terms so the record rule's compare of the store key (`pkey[2]`) is unchanged. `_bg_unresolved`, `_awaiting_bg_hold` and `_session_settled` take the pass clock from the planner (a default keeps the wall clock for every other caller), so the key and the verdict read one clock. The source pin on the settled gate's expiry moves with it and still asserts a fresh clock outside the scan cache.

Why a key term and not "never record while a launch runs": a launch with no recorded ceiling (a backgrounded Bash, a dev server) never expires, so that alternative would plan the idle sessions the gate is meant to skip, on every pass. The boolean is the value the derivation reads, keyed the way the awaiting lift's gate in `kernel.py` (`_lift_spent_awaiting`) keys the same crossing, so the key moves once, at the crossing, and not before. Threading the clock moves the planner's expiry view from the wall clock to the pass's start second; a launch whose expiry falls during the pass is judged one pass later, the tolerance the kernel's lift gate accepts.

Overlap with #1062, which is open: it threads the same clock through the same three helpers and rewrites the same source pin. Its code lines (the three signatures, the `now = time.time()` default, the rollup call in `_plan_session`) and its `tests/test_bg_scan_monitor.py` hunk are identical to this PR's, so its rebase meets the same change there; the `_bg_unresolved` docstring differs by a sentence, and #1062 also documents `now` on `_session_settled`, which this PR leaves as it is. Its `_plan_session` tail and `run_plan` loop need a manual resolve. Its evidence signature (`_sig_inputs`) already carries the captions file and the leaf's task store, with a not-before clock in place of the boolean, so on that rebase its gate supersedes the terms added here.

## Review (by hand)

The store key stays at index 2. A key that cannot be computed is a fresh sentinel and the session is planned (the rule `_task_store_key` already applies to a listing error). The death marker needs no term: the kernel writes a states row with it and the states file is in the parse key. The awaiting hold reads the transcript's pairing, the goal store's awaiting stamps and audited turns, the parsed turns, the reg, the death marker and the clock, not the task store (a correction to #1173's body). One extra `em.scan_bg_tasks_cached` call per session per pass in the key: a cache hit on an unchanged transcript.

## Tests

`tests/test_planner_skip.py`, in the module's own fixture. Three are red at 42db9cc5 with the counts stated: a forked leaf's task-store change alone un-skips and mints the mirror (red: `(0, 3)`, no mirror node); a prompt caption landing heals a floor title on a recorded session (red: `(0, 3)`, the verbatim head stays); a launch crossing its deadline re-plans the session and its done focus top completes (red for two reasons: no expiry term, and the wall-clock settle completes the top before the crossing, so the `working` precondition fails first). The same test checks that a pass 100 s later, the launch still inside its ceiling, skips every session, which a term keyed on the raw clock instead of the boolean fails. Three more pin the design: a backgrounded Bash on a recorded session leaves it skipped 200 s later and a day later (the term is a stable False); the settle reads the wall clock when no pass clock is handed in (a frozen clock, no sleeping: past the ceiling the launch is expired, inside it running, and a clock handed in outranks the wall clock); an expiry view that cannot be computed never equals a recorded one. `tests/test_bg_scan_monitor.py`: the source pin now looks inside `_bg_unresolved` for `em._bg_expired(t, now)` and `now = time.time()`. Docs: the `plannerSkip` sentence in `reference.md` names the two files and the crossing. Two comments rephrased for the vocabulary rule.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)