### PR TITLE
Meta commands: the route no longer evaluates the drive-op gate itself; each setter already decides

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -27868,10 +27868,13 @@ def _route_meta_command(be, sid, text, client=None, floating=False, state=None):
     command, a bare "/model" (the CLI's own picker), plain text that merely contains one — is the
     caller's to send verbatim: the CLI owns what executes. A refused fast toggle is told to
     the client (fail loudly): a dormant SDK session has no live CLI to apply it, and the typed text
-    used to at least draw the CLI's own refusal. `state`, when given, receives {"queued": bool} — whether
-    the change PARKED: the effort/fast setters park under _ops_gate (read here), the model setter returns
-    its own verdict (_set_model_or_park) — so POST /send answers `queued` for a meta command exactly as for
-    a text send (2026-09-03: a parked /model read as plain 'ok')."""
+    used to at least draw the CLI's own refusal. `state`, when given, receives {"queued": bool}: whether
+    the change PARKED, taken from each setter's own return, so POST /send answers `queued` for a meta
+    command exactly as for a text send (2026-09-03: a parked /model read as plain 'ok'). The effort/fast
+    setters report whether they parked under _gate_or_park (the one _ops_gate evaluation those two pay),
+    the model setter has its own rule (_set_model_or_park), and this route never evaluates _ops_gate
+    itself: a read here cost every command a tmux fork, discover pass and usage read for a value nothing
+    used (#986, the review of #954, removed it; the #923 merge restored it)."""
     head, _, rest = (text or "").strip().partition(" ")
     value = rest.strip()
     # ONE token, and one the kernel can vouch for: the setters PERSIST their value — set_model's lands
@@ -27880,11 +27883,10 @@ def _route_meta_command(be, sid, text, client=None, floating=False, state=None):
     # ours to swallow: it stays the CLI's, verbatim, and the user sees the CLI's own error.
     if not value or len(value.split()) != 1:
         return False
-    gate = _ops_gate(sid)                  # the effort/fast setters park under exactly this gate; read here so `state` can say so
     if head == "/model" and _vouched_model(value):
         # the model setter has its OWN rule (an open turn fires it live only on a backend that declares
         # model_switches_live — none shipped does yet, so the SDK still parks; #923), so its verdict is
-        # read, not inferred from the gate — which would say `queued` for a pick that had already applied
+        # read, not inferred from _ops_gate, which would say `queued` for a pick that had already applied
         parked = _set_model_or_park(be, sid, value, floating=floating)
     elif head == "/effort" and value in _EFFORT_VALUES:
         parked = _set_effort_or_park(be, sid, value)    # mid-compaction → parked as a queued command

--- a/tests/test_kernel_meta_command_gate.py
+++ b/tests/test_kernel_meta_command_gate.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""_route_meta_command evaluates the drive-op gate (_ops_gate) exactly as often as the setter it calls
+does, and never on its own account. /effort and /fast take _gate_or_park: ONE evaluation, outside the
+queue lock, then the locked queue-presence check. /model takes _set_model_or_park's own rule, which
+never calls _ops_gate. Each setter returns whether it parked, and that return is what POST /send
+answers as `queued`.
+
+The route used to evaluate _ops_gate once more itself, to answer `queued`, and then took the setter's
+return anyway: a tmux fork, a discover pass, the usage file and the backend's busy() on the handler
+thread, per command, for a value nothing read. The review of #954 (#986) removed that read on
+2026-09-07; the #923 merge the same day brought it back. tests/test_model_live_midturn pins the value
+of `queued`; this pins its cost. The gate is patched to a counter, so the counts are the gate's own
+evaluations and nothing underneath it runs. Synthetic only: a placeholder sid, invented values."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from unittest import mock
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the load: the kernel resolves its state root at import time, and only pytest
+# runs conftest's floor (a bare unittest run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["ROMP_MANAGER_PORT"] = "1"             # a dead port, never an inherited live one
+km = SourceFileLoader("romp_kernel_meta_gate", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-4333-8444-0a0a0a0a0a0a"      # private to this module: parked ops are keyed by sid
+
+
+class _Backend:
+    """A backend that takes every setter; records what fired. Only the three setters' calls: neither the
+    route nor a setter reaches any other method on the paths driven here."""
+    def __init__(self): self.calls = []
+    def set_model(self, sid, v): self.calls.append(("model", v))
+    def set_effort(self, sid, v): self.calls.append(("effort", v))
+    def set_fast(self, sid, v): self.calls.append(("fast", v)); return True
+
+
+def _forget_queue():
+    """Drop the sid's parked ops from memory AND the disk mirror: a park writes pending-ops.json under this
+    module's state dir, and a kernel loaded later in the same process would restore the queue from it."""
+    km._pending_ops.pop(SID, None)
+    km._save_pending_ops()
+
+
+class MetaCommandGateCost(unittest.TestCase):
+    def setUp(self):
+        self.be = _Backend()
+        self.gate_calls = []
+        self.verdict = False
+        _forget_queue()
+        km._moving.discard(SID)
+        stubs = {
+            "_ops_gate": lambda sid: (self.gate_calls.append(str(sid)), self.verdict)[1],
+            "_compacting_now": lambda sid, **k: False,   # the model setter's own gates, quiet here
+            "_working_now": lambda sid: False,
+            "_limit_hold": lambda sid: None,             # the account gate is its own axis
+            "_mark_model_pending": lambda *a, **k: None,
+            "_note_model_pick": lambda *a, **k: None,
+        }
+        for name, stub in stubs.items():
+            p = mock.patch.object(km, name, stub)
+            p.start()
+            self.addCleanup(p.stop)
+        self.addCleanup(_forget_queue)
+
+    def _route(self, text):
+        self.gate_calls.clear()
+        state = {}
+        self.assertTrue(km._route_meta_command(self.be, SID, text, state=state), text)
+        return len(self.gate_calls), state.get("queued")
+
+    def test_effort_and_fast_evaluate_the_gate_once_and_model_never_when_they_fire(self):
+        self.assertEqual(self._route("/effort high"), (1, False))
+        self.assertEqual(self._route("/fast on"), (1, False))
+        self.assertEqual(self._route("/model opus"), (0, False), "the model setter has its own rule; no _ops_gate")
+        self.assertEqual(self.be.calls, [("effort", "high"), ("fast", "on"), ("model", "opus")], "each fired once")
+        self.assertNotIn(SID, km._pending_ops)
+
+    def test_the_counts_are_the_same_when_the_gate_parks(self):
+        # `queued` comes from the setter's own return, so a park costs the same single evaluation
+        self.verdict = True
+        self.assertEqual(self._route("/effort high"), (1, True))
+        self.assertEqual(self._route("/fast on"), (1, True))
+        with mock.patch.object(km, "_compacting_now", lambda sid, **k: True):   # the model setter's own park
+            self.assertEqual(self._route("/model opus"), (0, True))
+        self.assertEqual(self.be.calls, [], "nothing fired: every op parked")
+        self.assertEqual([op[0] for op in km._pending_ops[SID]], ["effort", "fast", "model"], "parked in press order")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Symptom. `/effort` and `/fast` typed into the composer, picked from the timeline lane menu or sent through POST /send paid the drive-op gate twice on the handler thread, and `/model` paid it once, for a value nothing read. `_ops_gate` is the expensive gate: a tmux fork, a discover pass, a read of the usage file and the backend's `busy()`. `_route_meta_command` evaluated it before dispatching, and the effort and fast setters evaluated it again.

Cause. `_route_meta_command` assigned `gate = _ops_gate(sid)` and never read it. Every branch takes `queued` from its setter's return: `_set_effort_or_park` and `_set_fast_or_park` decide under `_gate_or_park`, which runs `_ops_gate` itself, and `_set_model_or_park` has its own rule and never calls `_ops_gate`. The review of #954 (#986) removed this read on 2026-09-07; the #923 branch, rebased past that removal, re-added it in place of the comment that explained it, and the #923 merge the same day carried it to main. The line's comment said `state` reads it, which was not so; ruff reports the line as F841.

Fix. In `kernel/kernel.py`, `_route_meta_command`: the assignment is removed. The docstring's `state` clause and the `/model` branch comment now say that `queued` is each setter's own return and that the route evaluates nothing itself. The parked-or-fired outcome and the `queued` answer are unchanged.

Tests. `tests/test_kernel_meta_command_gate.py` patches `_ops_gate` with a counting stub and drives the three commands through `_route_meta_command`. `/effort` and `/fast` evaluate the gate once and `/model` never, both when the setters fire (each backend call recorded once, no queue created) and when they park (nothing fired, the three ops queued in press order), with `queued` read correctly in both. Before the change both cases fail at their first assertion, two evaluations for `/effort` instead of one. The full pytest suite passes.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)