### PR TITLE
Reference: the Billing row's four readings, as render.ts renders them, pinned

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -317,7 +317,7 @@ a remembered key pick on a helper-less machine already fell to the login, and
 the fall is said once per process as a problem row. An explicit pick that
 names the missing side (a session picked "login" on a box that later lost its
 login) launches on the other side when one exists and says so once per session
-start, on the card's Billing sub-line as `⚠ login unavailable, billing API key`
+start, on the tab menu's Billing sub-line as `⚠ login unavailable, billing API key`
 and in the log; the fall itself rides the status as `authPickFell`, so the hover
 and the sub-line never infer one. A pick with nothing to fall to (a box with
 neither side) launches as picked and the CLI decides; the sub-line then says
@@ -350,13 +350,23 @@ covered by the picker: their CLI lives in the tmux server's environment, which
 the kernel does not control, and resolves its credential the way any `claude`
 in a terminal does.
 
-Each chat tab's hover tooltip carries the same fact as a `Billing` row,
-`API key`, or `Login (name@example.com)`, whenever the session's backend
-reports it, one-auth machines included; only tmux sessions, whose billing romp
-cannot know, show no row. When the CLI's own report disagrees with what the
-session was launched for (a login pick whose CLI reports a key, a key pick
-whose CLI landed on the login), the row carries both: `Login (CLI reports API
-key)`.
+An SDK session's chat tab carries the same fact as a `Billing` row in its hover
+tooltip, one-auth machines included; tmux sessions, whose billing romp cannot
+know, and Codex sessions, which bill no Claude account, show no row. The row
+has four readings. Unless one of the three cases below applies, it reads
+`API key` or `Login (name@example.com)` (`Login` alone when the account name is
+unknown). While a switch is still reconnecting the session, the row appends
+`(applying — not confirmed yet)` to the side: `Login (applying — not confirmed
+yet)`. A pick naming a side this machine cannot bill leads with the warning,
+the reason, and the side the launch fell to: `⚠ Login picked, but no Claude
+login signed in on this machine — this session bills the API key`; with
+nothing to fall to, the tail says the launch went out as picked. A pick the
+CLI's own report contradicts (a login pick whose CLI reports a key, a key pick
+whose CLI landed on the login) leads with the warning too: `⚠ Login picked, but
+the CLI reports the API key — this session bills that`, and, for a key pick,
+the same with the sides swapped. The tab menu's Billing sub-line says the same
+in fewer words: `API key` or `Login (name@example.com)`, `applying…`, `⚠ login
+unavailable, billing API key`, and `⚠ CLI reports API key`.
 
 Failures are loud rather than silent: a session that lands on the other auth
 than it was launched for is flagged in the Log panel, and a dead credential

--- a/tests/test_reference_billing_label.py
+++ b/tests/test_reference_billing_label.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""docs/reference.md's Billing-row paragraph quotes what ui/webview/render.ts renders.
+
+The tab hover's `Billing` row and the tab menu's Billing sub-line each have four readings: the plain side,
+a pick still applying, a pick this machine cannot bill, and a pick the CLI's own report contradicts. The
+reference describes them by quoting the rendered text, and nothing else ties the two files together, so
+these pins hold the doc to the code: the copy render.ts builds each reading from is asserted there, and
+the doc is asserted to quote the readings assembled from that same copy. A wording change in render.ts
+reddens here before the reference goes stale, and a retired reading cannot linger in the doc.
+
+The render.ts pins are the rendered text, not the expressions around it: a rename, a reshuffle or an
+extraction into a helper that leaves every rendered word as it was stays green here, since the doc is
+not stale then. Where a fragment is a common word (`unavailable`) or the warning glyph, the template
+quote beside it is included, so the pin names the row's own copy and not a comment or another control's.
+
+Text only: labels, never key material.
+"""
+import os
+import re
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+
+
+def _read(*parts):
+    with open(os.path.join(ROOT, *parts), encoding="utf-8") as f:
+        return f.read()
+
+
+def _flat(text):
+    """Collapse hard wraps so a quote that spans a line break in the doc still compares."""
+    return re.sub(r"\s+", " ", text)
+
+
+REFERENCE = _flat(_read("docs", "reference.md"))
+RENDER = _read("ui", "webview", "render.ts")
+CREDENTIALS = _read("kernel", "credentials.py")
+
+# The hover row's readings, as render.ts assembles them: the side word first, then these fragments
+# around an interpolated reason or side.
+WARN = "⚠ "
+PENDING = " (applying — not confirmed yet)"
+UNAVAILABLE_HEAD = " picked, but "
+FELL_TAIL = " — this session bills "
+NO_FALL_TAIL = " — nothing to fall to, so the launch went out as picked"
+CONTRADICTED_HEAD = " picked, but the CLI reports "
+CONTRADICTED_TAIL = " — this session bills that"
+# The side words the row starts each reading with, and the ones it names a fall or a report with.
+HOVER_SIDES = ('"API key"', '"Login"', '"the API key"', '"the login"')
+ACCOUNT_FORM = "Login (${"   # the login side with its account name: `Login (name@example.com)` in the doc
+# The tab menu's shorter mirror of each reading.
+MENU_PENDING = '"applying…"'
+MENU_UNAVAILABLE = " unavailable"
+MENU_FELL = ", billing "
+MENU_CONTRADICTED = "⚠ CLI reports "
+MENU_SIDES = ('"API key"', '"login"')
+# The kernel's reason for a login pick on a machine with no login, which the hover row interpolates.
+WHY_NO_LOGIN = "no Claude login signed in on this machine"
+
+
+class _Pins(unittest.TestCase):
+    def assertQuoted(self, needle, haystack, where, msg=""):
+        # a bare assertIn would print the whole file on a miss; name the missing text and the file instead
+        self.assertTrue(needle in haystack, "%s does not carry %r%s" % (where, needle, (": " + msg) if msg else ""))
+
+    def assertNotQuoted(self, needle, haystack, where, msg=""):
+        self.assertFalse(needle in haystack, "%s still carries %r%s" % (where, needle, (": " + msg) if msg else ""))
+
+
+class RenderTsRendersThePinnedCopy(_Pins):
+    SRC = "ui/webview/render.ts"
+
+    def test_the_hover_row(self):
+        self.assertQuoted('"%s"' % PENDING, RENDER, self.SRC)
+        self.assertQuoted("`" + WARN, RENDER, self.SRC, "the warning glyph opens the warning readings")
+        self.assertQuoted(UNAVAILABLE_HEAD, RENDER, self.SRC)
+        self.assertQuoted(FELL_TAIL, RENDER, self.SRC)
+        self.assertQuoted('"%s"' % NO_FALL_TAIL, RENDER, self.SRC)
+        self.assertQuoted(CONTRADICTED_HEAD, RENDER, self.SRC)
+        self.assertQuoted(CONTRADICTED_TAIL, RENDER, self.SRC)
+        for side in HOVER_SIDES:
+            self.assertQuoted(side, RENDER, self.SRC, "the key is 'API key', never any key material")
+        self.assertQuoted(ACCOUNT_FORM, RENDER, self.SRC)
+
+    def test_the_tab_menu_sub_line(self):
+        self.assertQuoted(MENU_PENDING, RENDER, self.SRC)
+        self.assertQuoted(MENU_UNAVAILABLE + "`", RENDER, self.SRC, "the word ends the sub-line's template piece")
+        self.assertQuoted(MENU_FELL, RENDER, self.SRC)
+        self.assertQuoted(MENU_CONTRADICTED, RENDER, self.SRC)
+        for side in MENU_SIDES:
+            self.assertQuoted(side, RENDER, self.SRC)
+
+    def test_the_kernel_reason_the_unavailable_reading_interpolates(self):
+        self.assertQuoted('WHY_NO_LOGIN = "%s"' % WHY_NO_LOGIN, CREDENTIALS, "kernel/credentials.py")
+
+
+class TheReferenceQuotesEachReading(_Pins):
+    DOC = "docs/reference.md"
+
+    def test_the_plain_readings(self):
+        self.assertQuoted("`API key` or `Login (name@example.com)`", REFERENCE, self.DOC)
+
+    def test_the_applying_reading(self):
+        self.assertQuoted("`Login%s`" % PENDING, REFERENCE, self.DOC)
+        self.assertQuoted("`applying…`", REFERENCE, self.DOC, "the tab menu's sub-line while the switch applies")
+
+    def test_the_unavailable_pick_reading(self):
+        self.assertQuoted("`%sLogin%s%s%sthe API key`" % (WARN, UNAVAILABLE_HEAD, WHY_NO_LOGIN, FELL_TAIL),
+                          REFERENCE, self.DOC)
+        self.assertQuoted("`%slogin%s%sAPI key`" % (WARN, MENU_UNAVAILABLE, MENU_FELL), REFERENCE, self.DOC,
+                          "the tab menu's sub-line")
+
+    def test_the_contradicted_pick_reading(self):
+        self.assertQuoted("`%sLogin%sthe API key%s`" % (WARN, CONTRADICTED_HEAD, CONTRADICTED_TAIL), REFERENCE, self.DOC)
+        self.assertQuoted("`%sAPI key`" % MENU_CONTRADICTED, REFERENCE, self.DOC, "the tab menu's sub-line")
+
+    def test_no_retired_reading_lingers(self):
+        # the CLI's report is not a parenthetical after the side: the row leads with the warning
+        # (render.ts's contradicted reading)
+        self.assertNotQuoted("(CLI reports", REFERENCE, self.DOC)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
docs/reference.md described the tab hover's Billing row, when the CLI's report disagrees with the pick, as `Login (CLI reports API key)`. ui/webview/render.ts renders no such text.

The hover row (the `Billing` entry among the tab tooltip's rows, `ui/webview/render.ts` line 5145) has four readings:

- The default, when none of the three below applies: `API key`, or `Login (name@example.com)` (`Login` alone when the account name is unknown). The code needs no report from the CLI for this reading; an empty `authLive` (no init landed yet) renders it too.
- A switch is still reconnecting the session (`authPending`): `Login (applying — not confirmed yet)`, or the same after `API key`.
- The pick names a side this machine cannot bill (`authPickUnavailable`): `⚠ Login picked, but no Claude login signed in on this machine — this session bills the API key`, the reason being the kernel's (`kernel/credentials.py`, `WHY_NO_LOGIN`); with neither side, the tail reads `— nothing to fall to, so the launch went out as picked`.
- The CLI's own report contradicts the pick (`authLive`): `⚠ Login picked, but the CLI reports the API key — this session bills that`, and the same with the sides swapped for a key pick.

The tab menu's Billing sub-line (`ui/webview/render.ts` line 6105) mirrors them in fewer words: `API key` or `Login (name@example.com)`, `applying…`, `⚠ login unavailable, billing API key`, and `⚠ CLI reports API key`.

The row is an SDK session's. A tmux session's billing romp cannot know, and a Codex session bills no Claude account; `Sessions.live()` forwards no `auth` for either, and the row renders only under `if (s.status.auth)`, so neither tab carries one.

Change:

- `docs/reference.md`: the hover-row paragraph now names each reading with the text the code renders, and the sub-line's mirror of each. The paragraph reads:

  > An SDK session's chat tab carries the same fact as a `Billing` row in its hover tooltip, one-auth machines included; tmux sessions, whose billing romp cannot know, and Codex sessions, which bill no Claude account, show no row. The row has four readings. Unless one of the three cases below applies, it reads `API key` or `Login (name@example.com)` (`Login` alone when the account name is unknown). While a switch is still reconnecting the session, the row appends `(applying — not confirmed yet)` to the side: `Login (applying — not confirmed yet)`. A pick naming a side this machine cannot bill leads with the warning, the reason, and the side the launch fell to: `⚠ Login picked, but no Claude login signed in on this machine — this session bills the API key`; with nothing to fall to, the tail says the launch went out as picked. A pick the CLI's own report contradicts (a login pick whose CLI reports a key, a key pick whose CLI landed on the login) leads with the warning too: `⚠ Login picked, but the CLI reports the API key — this session bills that`, and, for a key pick, the same with the sides swapped. The tab menu's Billing sub-line says the same in fewer words: `API key` or `Login (name@example.com)`, `applying…`, `⚠ login unavailable, billing API key`, and `⚠ CLI reports API key`.

  One word in the paragraph above it changes too: the sentence on an explicit pick of the missing side said the fall shows "on the card's Billing sub-line"; the sub-line lives in the tab's right-click menu (`showTabMenu`), so it now says "the tab menu's Billing sub-line", the name the new paragraph uses.

- `tests/test_reference_billing_label.py` (new): pins the copy `render.ts` renders each reading from (` (applying — not confirmed yet)`, ` picked, but the CLI reports `, ` — this session bills that`, `⚠ CLI reports `, `, billing `, the side words, and the rest) and the kernel's reason string the unavailable reading interpolates, then asserts that `docs/reference.md` quotes the readings assembled from those same fragments and no longer carries `(CLI reports`. The pins are the rendered text, not the TypeScript around it: a rename or a reshuffle of the row's code that leaves every rendered word as it was stays green (checked by renaming `s.status.` to `st.` throughout the hover row: 8 passed), and a wording change turns the module red before the reference goes stale (checked twice, rewording `applying — not confirmed yet` and the sub-line's `unavailable`: one code pin red each, every doc pin green). Against the previous paragraph the five doc pins fail and the three code pins pass. The fix for a red run after a wording change is to change the paragraph and the pinned fragment together.

No kernel, backend, judge or webview code changes.

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)