### PR TITLE
Courier: a raise in one session's scan is that session's pass-crash row, not the tier's

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2175,7 +2175,8 @@ _PARSE_CACHE = {}          # fsid -> (fileset_key, parsed_session)
 # file's key and its journal's and archive's (the shared view's inputs), the episode log's key (the
 # floor) and the transcript path. A session is recorded only when its scan added nothing pending; one
 # with rows to place is scanned again next pass however its inputs stand (its placements move the store
-# anyway). A parse the cache does not hold (a stubbed one) is never keyed, so never skipped. Pruned to
+# anyway), and so is one whose scan raised (its pass-crash row is filed, the rows it queued are dropped).
+# A parse the cache does not hold (a stubbed one) is never keyed, so never skipped. Pruned to
 # the pass's fleet, so bounded by it; a rebound state root clears it.
 _COURIER_SEEN = {}         # fsid -> the scan key of its last pass that found nothing to place
 
@@ -15317,57 +15318,71 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=
         except Exception as e:                         # an unreadable store: this session's row, the next session's turn
             _log_judge_error("courier", fsid, "pass-crash", note="store: %r" % e)
             continue
-        closed[fsid] = _session_settled(fsid, str(path), session, cstore)
-        placed_ids = cstore["placements"]
-        floor = episode_floor(fsid)
-        n_pending0, repair_open = len(pending), False
-        for turn in session["turns"]:
-            for seg in _segs(turn, cstore):
-                if seg["id"] in placed_ids:
-                    # LINK-ONLY repair (the user 2026-08-23): the planner placed this peer segment
-                    # before the courier saw it, so no courier goal was minted and the SENDER's
-                    # handoff waits on a completion event that can never fire (12 live handoffs, up
-                    # to 240h old). A placed DELEGATE with no courier link gets the link attached to
-                    # the placement's TOP — run_propagate completes the sender's tracking node when
-                    # that goal lands. No model call; idempotent by msgId.
-                    try:
-                        pm0 = _seg_peer(seg)
-                        if (pm0 and pm0[0] and pm0[1] and _seg_peer_kind(seg) == "delegate"
-                                and _courier_link_target(cstore, seg["id"], pm0[1]) is not None):
-                            repair_open = True     # a missing link with a live node to attach to: whether it CAN
-                            #                        attach depends on the SENDER's store (_handoff_backref), outside
-                            #                        this session's key, so the session is scanned again next pass, as
-                            #                        before. A placement with no node (filed fyi, retired) has no
-                            #                        repair to wait for and records like any settled session.
-                            if _courier_link_wanted(cstore, seg["id"], pm0[1]) is not None:
-                                _attach_courier_link(load_goals(fsid), seg["id"], pm0[1])   # a writer: its own load
-                    except Exception as e:             # bookkeeping, but its failure is not nothing (T111)
-                        _log_judge_error("courier", fsid, "pass-crash", note="link-attach: %r" % e)
-                    continue
-                if floor and seg["t"] < floor:
-                    # pre-episode: conversation the agent can no longer see. The planner retires these
-                    # before any model call; the courier needs its own guard because a FORK's copied
-                    # history is the first shape that leaves OLD peer segments visible here (a /clear's
-                    # null-rooted head drops pre-clear history from the parse for free, so this never
-                    # fired before). Defense in depth beside the fork's sealed-placements seed.
-                    continue
-                pm = _seg_peer(seg)
-                if pm and pm[0] and _placed_key(placed_ids, seg["id"]):
-                    continue                           # placed under a DRIFTED key (the parse's t shifted after the
-                    #                                    placement was recorded): the placement loop's own _placed_key
-                    #                                    check dropped the row unwritten every pass, at a writer load per
-                    #                                    row per pass, and the row kept its session from ever recording
-                    #                                    in the change gate (2026-09-09). The same rule, applied here.
-                if not pm or not pm[0]:                # peer-triggered with a KNOWN sender only. This filter
-                    #                                    is one half of a partition contract with plan_units:
-                    #                                    the courier places exactly the peer segments it can
-                    #                                    file under a sender's goal, and plan_units yields a
-                    #                                    '#d' unit for exactly those (a sender-less one gets a
-                    #                                    plain work unit there instead — a '#d' nothing places
-                    #                                    wedges auto-nudge's placement gate, 2026-08-16).
-                    continue
-                pending.append((seg["t"], fsid, seg["id"], _unit_text(seg["atoms"]), pm[1], pm[0],
-                                _seg_peer_kind(seg), _seg_anchor(seg), str(path)))
+        n_pending0 = len(pending)                      # before the walk: the boundary below drops what it queued
+        try:
+            closed[fsid] = _session_settled(fsid, str(path), session, cstore)
+            placed_ids = cstore["placements"]
+            floor = episode_floor(fsid)
+            repair_open = False
+            for turn in session["turns"]:
+                for seg in _segs(turn, cstore):
+                    if seg["id"] in placed_ids:
+                        # LINK-ONLY repair (the user 2026-08-23): the planner placed this peer segment
+                        # before the courier saw it, so no courier goal was minted and the SENDER's
+                        # handoff waits on a completion event that can never fire (12 live handoffs, up
+                        # to 240h old). A placed DELEGATE with no courier link gets the link attached to
+                        # the placement's TOP — run_propagate completes the sender's tracking node when
+                        # that goal lands. No model call; idempotent by msgId.
+                        try:
+                            pm0 = _seg_peer(seg)
+                            if (pm0 and pm0[0] and pm0[1] and _seg_peer_kind(seg) == "delegate"
+                                    and _courier_link_target(cstore, seg["id"], pm0[1]) is not None):
+                                repair_open = True     # a missing link with a live node to attach to: whether it CAN
+                                #                        attach depends on the SENDER's store (_handoff_backref), outside
+                                #                        this session's key, so the session is scanned again next pass, as
+                                #                        before. A placement with no node (filed fyi, retired) has no
+                                #                        repair to wait for and records like any settled session.
+                                if _courier_link_wanted(cstore, seg["id"], pm0[1]) is not None:
+                                    _attach_courier_link(load_goals(fsid), seg["id"], pm0[1])   # a writer: its own load
+                        except Exception as e:             # bookkeeping, but its failure is not nothing (T111)
+                            _log_judge_error("courier", fsid, "pass-crash", note="link-attach: %r" % e)
+                        continue
+                    if floor and seg["t"] < floor:
+                        # pre-episode: conversation the agent can no longer see. The planner retires these
+                        # before any model call; the courier needs its own guard because a FORK's copied
+                        # history is the first shape that leaves OLD peer segments visible here (a /clear's
+                        # null-rooted head drops pre-clear history from the parse for free, so this never
+                        # fired before). Defense in depth beside the fork's sealed-placements seed.
+                        continue
+                    pm = _seg_peer(seg)
+                    if pm and pm[0] and _placed_key(placed_ids, seg["id"]):
+                        continue                           # placed under a DRIFTED key (the parse's t shifted after the
+                        #                                    placement was recorded): the placement loop's own _placed_key
+                        #                                    check dropped the row unwritten every pass, at a writer load per
+                        #                                    row per pass, and the row kept its session from ever recording
+                        #                                    in the change gate (2026-09-09). The same rule, applied here.
+                    if not pm or not pm[0]:                # peer-triggered with a KNOWN sender only. This filter
+                        #                                    is one half of a partition contract with plan_units:
+                        #                                    the courier places exactly the peer segments it can
+                        #                                    file under a sender's goal, and plan_units yields a
+                        #                                    '#d' unit for exactly those (a sender-less one gets a
+                        #                                    plain work unit there instead — a '#d' nothing places
+                        #                                    wedges auto-nudge's placement gate, 2026-08-16).
+                        continue
+                    pending.append((seg["t"], fsid, seg["id"], _unit_text(seg["atoms"]), pm[1], pm[0],
+                                    _seg_peer_kind(seg), _seg_anchor(seg), str(path)))
+        except Exception as e:                         # the settle, the floor or the walk raised: this session's row,
+            #                                            never the tier's. Outside this boundary one session's raise
+            #                                            left run_courier before its write loop (no session placed)
+            #                                            and run_triage before the propagate, group, consolidate and
+            #                                            distill passes, with a stderr traceback for the whole tier.
+            _log_judge_error("courier", fsid, "pass-crash", note="scan: %r" % e)
+            del pending[n_pending0:]                   # the rows an unfinished walk queued place nothing
+            _COURIER_SEEN.pop(fsid, None)              # a record from an earlier scan is dropped, as the rows-to-place
+            #                                            arm below drops it: the memo holds only a completed scan that
+            #                                            found nothing. The continue skips the record step, so the
+            #                                            session is scanned again next pass.
+            continue
         if skey is not None:
             if len(pending) == n_pending0 and not repair_open:
                 _COURIER_SEEN[fsid] = skey             # nothing to place, no link to repair: skipped until an input moves

--- a/tests/test_courier_skip.py
+++ b/tests/test_courier_skip.py
@@ -9,7 +9,9 @@ parse cache's key bound to the session object, the store file's key with its jou
 episode log's key and the transcript path. Pins: unchanged inputs skip after a scan that placed nothing; a
 moved store, a fresh parse or an episode boundary un-skips that session alone; a write landing during the
 scan is seen next pass; three sessions with one moved place exactly what the ungated pass places; a parse
-the cache does not hold is never skipped; the scan asks the writer's loader for nothing; the counters.
+the cache does not hold is never skipped; the scan asks the writer's loader for nothing; the counters. A raise
+inside one session's scan is that session's pass-crash row: the other sessions place, the rows its unfinished scan
+queued are dropped and theirs are kept, it is not recorded, and the tiers after the courier run (CourierScanCrash).
 
 Synthetic fixtures only: placeholder sids, invented text, hostname TESTHOST; a temp root per test."""
 import json
@@ -371,6 +373,157 @@ class CourierSkip(_World):
         finally:
             jd._rebind_state(saved)
             other.cleanup()
+
+
+
+class CourierScanCrash(_World):
+    """A raise inside ONE session's scan is that session's pass-crash row, not the tier's (2026-09-09). The
+    per-session boundary in run_courier covered the parse, the store read and the link attach; the settle, the
+    episode floor and the segment walk ran outside it, so one poisoned session left run_courier before the
+    write loop (no other session placed), left run_triage before the propagate, group, consolidate and distill
+    passes, and left only a stderr traceback. Pins: the other sessions place in the crashing pass; one row for
+    the crashed session with the scan note; the rows its half-walked scan queued are dropped, and only those;
+    it is not recorded (scanned again next pass, placed once the poison lifts), and a record from an earlier
+    scan is dropped; the tiers after the courier run.
+
+    The poisoned session is C: discover walks the names directory sorted, so A's and B's scans run first and
+    their rows are on the pending list when C's scan raises. Each poison records the order it saw and the
+    assertions check that premise. With the FIRST session poisoned, dropping the crashed session's rows and
+    dropping every session's rows are indistinguishable, and the second is the fault this boundary removes."""
+
+    def _crash_rows(self):
+        text = jd.ERRORS.read_text() if jd.ERRORS.exists() else ""
+        return [r for r in (json.loads(l) for l in text.splitlines() if l.strip()) if r.get("err") == "pass-crash"]
+
+    @staticmethod
+    def _planted(store):
+        return [nd for nd in store["nodes"].values() if isinstance(nd.get("origin"), dict)]
+
+    def _poisoned_pass(self, attr, poison, now=T0 + 200):
+        """One pass with jd.<attr> replaced by `poison`; restored whatever the pass does."""
+        real = getattr(jd, attr)
+        setattr(jd, attr, poison)
+        try:
+            return self.run_pass(now=now)
+        finally:
+            setattr(jd, attr, real)
+
+    def _assert_c_scanned_after_a_and_b(self, order):
+        self.assertEqual(list(dict.fromkeys(order)), [A, B, C],
+                         "premise: C's scan follows A's and B's, so their rows are queued when it raises")
+
+    def _assert_row_and_recovery(self, counts, order, planted_c):
+        self._assert_c_scanned_after_a_and_b(order)
+        self.assertEqual(counts, (3, 0, 0), "every session scanned; A and B have rows to place, C's scan died")
+        self.assertTrue(self._planted(jd.load_goals(A)) and self._planted(jd.load_goals(B)),
+                        "A and B placed in the pass whose scan of C raised: only C's queued rows went with the crash")
+        self.assertEqual(self._planted(jd.load_goals(C)), [], "nothing placed from C's unfinished scan")
+        rows = self._crash_rows()
+        self.assertEqual([(r["judge"], r["fsid"]) for r in rows], [("courier", C)], "one row, C's")
+        self.assertTrue(rows[0]["note"].startswith("scan: RuntimeError("), rows[0]["note"])
+        self.assertNotIn(C, jd._COURIER_SEEN, "a scan that raised is not recorded: C is scanned again next pass")
+        # the poison lifted: C places on the next pass and settles like the others
+        self.assertEqual(self.run_pass(), (3, 0, 2), "C scanned with rows to place, A and B recorded")
+        self.assertEqual(len(self._planted(jd.load_goals(C))), planted_c, "C's delegates planted once its scan completes")
+        self.assertEqual(self.run_pass(), (1, 2, 1))
+        self.assertEqual(self.run_pass(), (0, 3, 0))
+        self.assertEqual(len(self._crash_rows()), 1, "no further rows once the scan completes")
+
+    def test_a_raise_in_the_segment_walk_is_that_sessions_row_and_the_others_place(self):
+        # C has TWO delegates and the walk raises on the second turn: the row the first turn queued must go
+        # with the crash (or the write loop places from a walk that never finished, and C, never recorded,
+        # re-attempts the rest every pass while the poison lasts), and A's and B's rows must stay.
+        self.deliver(C, T0 + 100)
+        real, order = jd._segs, []
+
+        def poison(turn, store):
+            order.append(store.get("rompUuid"))
+            if order.count(C) == 2:
+                raise RuntimeError("seam walk failed")
+            return real(turn, store)
+        counts = self._poisoned_pass("_segs", poison)
+        self.assertEqual(order.count(C), 2, "premise: C's first turn walked, the second raised")
+        self._assert_row_and_recovery(counts, order, planted_c=2)
+
+    def test_a_raise_in_the_episode_floor_is_that_sessions_row_and_the_others_place(self):
+        real, order = jd.episode_floor, []
+
+        def poison(sid):
+            order.append(sid)
+            if sid == C:
+                raise RuntimeError("episode log unreadable")
+            return real(sid)
+        self._assert_row_and_recovery(self._poisoned_pass("episode_floor", poison), order, planted_c=1)
+
+    def test_a_raise_in_the_settle_is_that_sessions_row_and_the_others_place(self):
+        # The settle reads the background-hold state (_awaiting_bg_hold, _bg_unresolved) and a raise there
+        # propagates by design (_bg_expiry_key's docstring). The planner files it as the session's row; so
+        # does the courier now.
+        real, order = jd._session_settled, []
+
+        def poison(fsid, path, session, store, now=None):
+            order.append(fsid)
+            if fsid == C:
+                raise RuntimeError("background hold unreadable")
+            return real(fsid, path, session, store, now)
+        self._assert_row_and_recovery(self._poisoned_pass("_session_settled", poison), order, planted_c=1)
+
+    def test_a_recorded_session_whose_rescan_raised_holds_no_stale_record(self):
+        # C is recorded, a delivery moves its inputs, and the rescan raises. The record says C's last scan
+        # found nothing to place, which is no longer so: it is dropped, as the rows-to-place arm drops it,
+        # rather than kept under a key a later pass could match.
+        self.run_pass(); self.run_pass()
+        self.assertEqual(self.run_pass(), (0, 3, 0), "premise: all three recorded")
+        self.assertIn(C, jd._COURIER_SEEN)
+        self.deliver(C, T0 + 150)
+        real = jd.episode_floor
+
+        def poison(sid):
+            if sid == C:
+                raise RuntimeError("episode log unreadable")
+            return real(sid)
+        self.assertEqual(self._poisoned_pass("episode_floor", poison, now=T0 + 300), (1, 2, 0),
+                         "C alone scanned (its inputs moved), and its scan died")
+        self.assertNotIn(C, jd._COURIER_SEEN, "the earlier record is dropped, not kept under its stale key")
+        self.assertEqual([(r["judge"], r["fsid"]) for r in self._crash_rows()], [("courier", C)])
+        self.assertEqual(self.run_pass(now=T0 + 300), (1, 2, 0), "the poison lifted: C places its second delegate")
+        self.assertEqual(len(self._planted(jd.load_goals(C))), 2)
+        self.assertEqual(self.run_pass(now=T0 + 300), (1, 2, 1))
+        self.assertEqual(self.run_pass(now=T0 + 300), (0, 3, 0))
+
+    def test_the_tiers_after_the_courier_run_in_the_crashing_pass(self):
+        # run_triage is one try/finally around the tier sequence: a raise leaving run_courier skipped the
+        # propagate, group, consolidate and distill passes for every session until the poison lifted.
+        ran, tiers = [], ("run_rewound_reconcile", "run_plan", "run_close", "run_unblock", "run_propagate",
+                          "run_group", "run_consolidate", "run_distill")
+        saved = {t: getattr(jd, t) for t in tiers}
+        for t in tiers:
+            setattr(jd, t, (lambda name: lambda *a, **k: ran.append(name))(t))
+        real, order = jd._segs, []
+
+        def poison(turn, store):
+            order.append(store.get("rompUuid"))
+            if order[-1] == C:
+                raise RuntimeError("seam walk failed")
+            return real(turn, store)
+        jd._segs = poison
+        try:
+            jd._discover_cache["fp"] = None
+            jd._discover_cache["result"] = None
+            jd._postal_from_memo["key"] = None
+            jd.run_triage(now=T0 + 200)
+        finally:
+            jd._segs = real
+            for t, fn in saved.items():
+                setattr(jd, t, fn)
+        self._assert_c_scanned_after_a_and_b(order)
+        self.assertIn("run_propagate", ran, "the tier after the courier ran in the crashing pass")
+        after = (["run_propagate"] + (["run_group"] if jd.GROUPER_ON else []) + (["run_consolidate"] if jd.CONSOLIDATE_ON else [])
+                 + (["run_distill"] if jd.DISTILLER_ON else []))
+        self.assertEqual(ran[ran.index("run_propagate"):], after, "every tier after the courier ran, in order")
+        self.assertTrue(self._planted(jd.load_goals(A)) and self._planted(jd.load_goals(B)), "A and B placed")
+        self.assertEqual([(r["judge"], r["fsid"]) for r in self._crash_rows()], [("courier", C)])
+        self.assertNotIn(C, jd._COURIER_SEEN)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

A raise inside one session's courier scan files that session's pass-crash row and the pass goes on. Before, it left the tier: `run_courier` exited before its write loop (no session's delegate placed that pass), and `run_triage`, one try/finally around the tier sequence, skipped the propagate, group, consolidate and distill passes too. `_run_tier` wrote a stderr traceback and no judge-errors row, so the fault surfaced nowhere but the kernel's stderr, and the pass repeated the same way while the fault lasted.

**Cause.** `run_courier`'s per-session try covered the parse (note `parse:`), the store read (`store:`) and the link attach (`link-attach:`) and nothing else. `_session_settled` (through `_awaiting_bg_hold` and `_bg_unresolved`), `episode_floor`, `_segs`, `_seg_peer`, `_placed_key`, `_unit_text` and `_seg_anchor` ran outside it. `_bg_expiry_key`'s docstring notes that a settle that raises still raises; in the planner that raise lands in a per-session future and `run_plan` files it as that session's row, in the courier it left the tier.

**Fix.** `kernel/judge.py`, `run_courier`: the scan from the settle to the end of the turn walk runs under the same per-session boundary as the parse and the store read. On a raise the session files one `pass-crash` row with note `scan: <repr>`; the rows its unfinished walk queued this pass are dropped, and only those (a scan that raised places nothing, as one whose parse or store read raised places nothing, and the next completed scan queues them again); a record from an earlier scan is dropped, as the rows-to-place arm drops it, so the session is scanned again next pass and placed once the fault lifts; the loop moves to the next session. Unchanged: the write loop, the cross-host plant, the scan key, the record rule and the link-attach catch. The gate's header comment names the new case. The judge.py hunk is mostly a re-indent of the walk under the new try; `git diff -w` shows the lines that changed.

No card-move rule changes: a session whose scan raised placed nothing before (the tier left) and places nothing now; the other sessions place what the pass places when no scan raises.

## Tests

`tests/test_courier_skip.py`, `CourierScanCrash` on the module's fixture (three sessions, a declared delegate delivered to each, `courier_llm` stubbed). The poisoned session is C, which `discover` scans after A and B (the names directory, sorted), so A's and B's rows are queued when C's scan raises; each poison records the order it saw and the assertions check that premise. All five red at 67773fb2: the `RuntimeError` leaves `run_courier`, and in the last case `run_triage`.

- The segment walk raises on the second turn of C, which holds two delegates: A and B place in that pass; one row (`courier`, C, note starting `scan: RuntimeError(`) is filed; the row C's first turn queued is not placed; C is absent from `_COURIER_SEEN`. With the poison lifted, the next pass plants both of C's delegates and C records and skips like the others, with no further row.
- The same with `episode_floor` raising for C, and with `_session_settled` raising for C.
- C recorded, a delivery moves its inputs, the rescan raises: C alone is scanned, its record is dropped rather than kept under the stale key, and it places on the next pass.
- `run_triage` with the other tiers stubbed and the walk raising for C: every tier after the courier runs, in order, and A and B place.

Each line of the boundary has a case that fails without it: the settle moved above the try (the settle case), `del pending[:]` in place of `del pending[n_pending0:]` (the four cases with A's and B's rows queued), the `del` removed (the segment-walk case), the `pop` removed (the stale-record case). With the whole try reverted, all five fail.

Full suite locally: 10142 passed, 61 skipped, and one browser-clock case in `tests/test_kernel_webpush.py::LandingRevealOffers` (`ageS` 6 for 5) that passes alone and reads nothing this change touches.

The courier's change gate (`_COURIER_SEEN`, `_courier_scan_key`, `repair_open`, the drifted-key rule) is untouched; the change widens the crash boundary around the scan the gate keys.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
