### PR TITLE
Tab strip: a tag group's fold caret and count sit right after its chip, the feed's grouped-header order (T284)

### DIFF
--- a/tests/test_tab_groups_rows.py
+++ b/tests/test_tab_groups_rows.py
@@ -99,7 +99,8 @@ const survey = () => page.evaluate(() => {
     seps: Array.from(document.querySelectorAll("#tabs .tab-group-sep")).map((e) => ({ w: e.getBoundingClientRect().width, h: e.getBoundingClientRect().height })),
     breaks: document.querySelectorAll("#tabs .tab-group-break").length,
     lines: Array.from(document.querySelectorAll("#tabs .tab-row-line")).map((l) => parseFloat(l.style.top)),
-    heads: Array.from(document.querySelectorAll("#tabs .tab-group-head")).map((h) => ({ group: h.dataset.group, act: h.dataset.act, folded: h.dataset.folded, count: h.querySelector(".tab-group-count")?.textContent })),
+    heads: Array.from(document.querySelectorAll("#tabs .tab-group-head")).map((h) => ({ group: h.dataset.group, act: h.dataset.act, folded: h.dataset.folded, count: h.querySelector(".tab-group-count")?.textContent,
+      kids: Array.from(h.children).map((c) => Array.from(c.classList).find((k) => k.startsWith("tab-group-")) || c.className) })),   // T284: the child order
   };
 });
 const open = await survey();
@@ -270,6 +271,12 @@ class ServedGroupsOnOwnLines(unittest.TestCase):
         self.assertEqual(next(t for g, _h, t in secs if g == "archived"), [], "folded: no archived tab rendered")
         same_row = [i for i in o["items"] if i["top"] == arch_head["top"] and i["w"] > 0 and i["id"]]
         self.assertEqual(same_row, [], "folded: the header row alone: %r" % same_row)
+        # T284 (the user 2026-09-09): every header opens chip, caret, count, the feed's grouped headers' order
+        # (name at the left, caret and count together at the right); the folded header's member pip comes
+        # last, so the folded and the open row share one shape and the caret is always the chip's neighbour
+        for h in o["heads"]:
+            self.assertEqual(h["kids"][:3], ["tab-group-chip", "tab-group-caret", "tab-group-count"], "%r: chip, caret, count: %r" % (h["group"], h["kids"]))
+        self.assertEqual(arch["kids"], ["tab-group-chip", "tab-group-caret", "tab-group-count", "tab-group-pip"], "folded: the pip after the count")
         # the per-row hairlines (T134, kept): one under every row but the last, none at the strip's top edge
         self.assertNotIn(0.0, o["lines"], "no hairline at the top edge (a break is not a row): %r" % o["lines"])
         self.assertTrue(o["lines"], "rows are still grounded by hairlines: %r" % o["lines"])

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5303,18 +5303,25 @@ function makeGroupHead(sec: TabSection, collapsed: boolean, holdsActive: boolean
       if (e.key === "Enter" || e.key === " ") { e.preventDefault(); head.click(); }
     });
   }
+  // The header's order mirrors the feed's grouped headers (T284, the user 2026-09-09: the caret sat
+  // beside the chip at the left; the feed's Working / Blocked / Completed headers and its session
+  // headers put the name at the left and the caret with its count together at the RIGHT): the tag's
+  // chip first, then the caret and the count right after it, then (folded) the gist's pip last — so
+  // the folded and the open row share one shape and the caret is always the chip's neighbour. The
+  // whole row stays the fold's click target, the keyboard and aria paths above are unchanged, and the
+  // fold state key (the tag's name) is unchanged.
+  // The tag as THE CHIP it wears everywhere (T251, the user 2026-09-07: the swatch+name pair read as a
+  // plain label; the chip says "this is the tag" the way the tags bar and the feed say it, so which
+  // tabs belong to which group reads at a glance). The shared builder from tag-menu.ts — one
+  // vocabulary, never a lookalike — inheriting the header's own sub-line size (no nested em).
+  const chip = tagChip(name, sec.color, { inheritSize: true });
+  chip.classList.add("tab-group-chip");
+  head.appendChild(chip);
+  // the caret and the count, right after the chip (the feed's order: name, caret, then count)
   const caret = el("span", "tab-group-caret");
   caret.textContent = "▸";                       // turned down by CSS while open (.tab-group-head:not(.collapsed))
   caret.setAttribute("aria-hidden", "true");
   head.appendChild(caret);
-  // the tag as THE CHIP it wears everywhere (T251, the user 2026-09-07: the swatch+name pair read as a
-  // plain label; the chip says "this is the tag" the way the tags bar and the feed say it, so which
-  // tabs belong to which group reads at a glance). The shared builder from tag-menu.ts — one
-  // vocabulary, never a lookalike — inheriting the header's own sub-line size (no nested em). The
-  // count rides right after it in the same row.
-  const chip = tagChip(name, sec.color, { inheritSize: true });
-  chip.classList.add("tab-group-chip");
-  head.appendChild(chip);
   const n = el("span", "tab-group-count");
   n.textContent = words.count;   // folded: the hidden members — a pinned one shows itself; all pinned: the total (headWords)
   head.appendChild(n);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -386,7 +386,8 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 .tab-group-head.dragging { opacity: 0.45; }
 .tab-group-head.drop-target { box-shadow: inset 2px 0 0 var(--accent); }
 /* the disclosure chevron: ▸ folded, turned down while open — the fold-caret idiom (a CSS transition on
-   the flip, no timer) */
+   the flip, no timer). Right after the chip with the count after it (T284), the feed's grouped headers'
+   order; the header is content-sized, so the DOM order alone places them. */
 .tab-group-caret { display: inline-block; flex: 0 0 auto; width: 0.9em; text-align: center; transition: transform 0.12s ease; }
 .tab-group-head:not(.collapsed) .tab-group-caret { transform: rotate(90deg); }
 /* the tag's color as a short bar, not a dot: a dot beside a name is a session pip */

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -259,7 +259,7 @@ test("a folded section renders its header alone with the folded-away count and o
   assert.match(head, /const kind = sectionPip\(hidden\.map\(\(id\) => sessions\.get\(id\)\?\.status\)\);/,
     "one summary pip, classified by tab-state.ts — the same rule the tab itself wears (tab-state.test)");
   assert.match(head, /pip\.title = sectionPipTitle\(kind, sectionPipMembers\(kind, hidden\.map\(\(id\) => sessions\.get\(id\)\)\)\);/, "the tooltip names the sessions");
-  assert.ok(head.indexOf('el("span", "tab-group-count")') < head.indexOf("sectionPip("), "after the count");
+  assert.ok(head.indexOf('el("span", "tab-group-count")') < head.indexOf("sectionPip("), "after the count (the row's last child when folded, T284)");
   assert.ok(!head.includes("tabStateClass("), "the header itself wears no state class");
   assert.ok(!head.includes('"tab-dot"'), "never a .tab-dot — the kernel's mobile scrape keys on the tab pips' vocabulary");
   assert.match(head, /if \(sec\.name === null\) return makeRowBreak\(true\);/, "the untagged trail is UNLABELED (the ruling): its own row with no chip, not a header (T264)");
@@ -418,11 +418,22 @@ test("executed: a session under two tags is placed under BOTH — the user's rul
 });
 
 
-test("the header's structure and gestures read as a label: chevron (flips with the fold) → color bar → name → count; a keyboard button; hover/focus say fold, never open; tokens only (the user 2026-09-06)", () => {
+test("the header's structure and gestures read as a label: the tag's chip, then the chevron (flips with the fold) and the count at the right; a keyboard button; hover/focus say fold, never open; tokens only (the user 2026-09-06)", () => {
   const head = RENDER.slice(RENDER.indexOf("function makeGroupHead("), RENDER.indexOf("function sectionHeadOf("));
   const at = (t: string) => { const i = head.indexOf(t); assert.ok(i >= 0, "present: " + t); return i; };
-  assert.ok(at('el("span", "tab-group-caret")') < at('tagChip(name, sec.color, { inheritSize: true })')
-    && at('tagChip(name, sec.color, { inheritSize: true })') < at('el("span", "tab-group-count")'), "chevron, the tag's CHIP, count");
+  assert.ok(at('tagChip(name, sec.color, { inheritSize: true })') < at('el("span", "tab-group-caret")')
+    && at('el("span", "tab-group-caret")') < at('el("span", "tab-group-count")'), "the tag's CHIP, then chevron and count at the right (T284)");
+  // T284 (the user 2026-09-09): the chip, then the caret and the count right after it, the feed's grouped
+  // headers' order (name at the left, caret and count together at the right); the folded gist's pip comes
+  // last, so the folded and the open row share one shape and the caret is always the chip's neighbour.
+  // Read from the builder's appends (the only way a child joins the head).
+  const appends = [...head.matchAll(/head\.appendChild\((\w+)\)/g)].map((m) => m[1]);
+  assert.deepEqual(appends, ["chip", "caret", "n", "pip"], "chip, caret, count, then the folded pip: " + appends.join(","));
+  // the pin reads named appendChild calls, so every other way a child could join the head is ruled out (the
+  // review's find: an inline appendChild(el(...)), a prepend or an insertBefore would have slipped past it)
+  assert.equal((head.match(/head\.appendChild\(/g) || []).length, appends.length, "every appendChild passes one of the named children");
+  assert.ok(!/head\.(append|prepend|insertBefore|insertAdjacentElement|insertAdjacentHTML|replaceChildren)\(/.test(head),
+    "children join one at a time through appendChild, which the pin above reads");
   assert.match(head, /caret\.textContent = "▸";/);
   assert.match(CSS, /\.tab-group-head:not\(\.collapsed\) \.tab-group-caret \{ transform: rotate\(90deg\); \}/,
     "the fold state flips it — the sheet's fold-caret idiom, a CSS transition, no timer");


### PR DESCRIPTION
In the chat tab strip's group-by-tag layout, each tag's section header now puts the fold caret at the RIGHT end of the header with the member count beside it, mirroring the feed's grouped headers (the Working / Blocked / Completed headers and the session headers: name at the left, caret and count together at the right). The caret used to sit beside the chip at the left (the user, 2026-09-09).

**Design points.**
- DOM order only: the tag's chip first, then the caret and the count right after it, then (folded) the gist's member pip last, so the folded and the open row share one shape and the caret is always the chip's neighbour. The header is content-sized (`flex: 0 0 auto`), so the order alone places them; no new CSS rule.
- The caret keeps its glyph and its CSS rotation for folded/open (the sheet's fold-caret idiom), and the count keeps the header's one font size. Same glyph and count scale as before; only the side changed.
- The whole header row stays the fold's click target through the stable `#tabs` delegate; the keyboard path (Enter or Space), the aria label and role, and the fold state key (the tag's name under `romp:tabgroups`) are unchanged. A header holding the active tab stays unfoldable, as before.

**Order, as ruled.** The dispatch first asked for the caret and count as the header's last children; the manager's follow-up after seeing the screenshots moved the folded gist's pip after the count instead ("infra ▸ 2 ●"), so the folded and the open row share one shape and the caret is always the chip's neighbour. The pins assert that ruled order.

**Pins.** `ui/webview/tab-groups.test.ts`: the builder's appends read chip, caret, count, then the folded pip (the order pins that named the old left-side caret are updated). `tests/test_tab_groups_rows.py` (served, hermetic kernel, real DOM) reads every header's child order and asserts chip, caret, count open each row, with the folded header's pip last.

**Screenshots** (dark and light, two tags, infra folded) are in the maintainer's `~/romp-shots/t284/` as before-dark, before-light, after-dark, after-light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
