### PR TITLE
T283: the tag-lens menu's tags are the tag chips themselves, acting as toggles

### DIFF
--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1650,6 +1650,9 @@ a.fileview-gh-note { border-style: dashed; }
 .ctx-item-toggle .ctx-icon.off { color: var(--dim); }
 .ctx-item-body { display: flex; flex-direction: column; line-height: 1.25; }
 .ctx-item-sub { font-size: 0.82em; opacity: 0.6; }
+/* a tag chip standing for an UNSELECTED toggle (the tag-lens menu, T283): faded, its colour kept —
+   the state class; tag-menu.ts paints the same opacity inline for a sheet-less host (TAG_CHIP_OFF_OPACITY) */
+.tag-chip-off { opacity: 0.45; }
 /* the bell BUTTON (the user 2026-07-28, round 4): inline in row1's metadata cluster, right after the
    timestamp — shown only once the card is hovered or it's armed. Off = slashed dim bell; armed (.on) =
    accent bell, always visible. Accent = mechanics chrome, never a status colour.

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -629,6 +629,9 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 /* the tab menu's Tags flyout (the user 2026-08-24): identity dot per union tag, ✕ = remove-
    everywhere, an inline New tag… input — all in the menu vocabulary, no new font sizes */
 .ctx-tag-dot { flex: 0 0 auto; width: 9px; height: 9px; border-radius: 50%; }
+/* a tag chip standing for an UNSELECTED toggle (the tag-lens menu, T283): faded, its colour kept —
+   the state class; tag-menu.ts paints the same opacity inline for a sheet-less host (TAG_CHIP_OFF_OPACITY) */
+.tag-chip-off { opacity: 0.45; }
 .ctx-tag-x { flex: 0 0 auto; background: none; border: none; color: var(--dim); cursor: pointer; font: inherit; padding: 0 2px; }
 .ctx-tag-x:hover { color: var(--fg); }
 .ctx-item-newtag { cursor: default; }

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -1630,7 +1630,7 @@ test("assistive tech hears a label: decoration is aria-hidden, the header's name
 
 test("the group header wears the SHARED tag chip — one vocabulary with the tags bar and the feed (T251)", () => {
   const MENU = ui("webview", "tag-menu.ts");
-  assert.match(MENU, /export function tagChip\(label: string, color\?: string \| null, opts\?: \{ inheritSize\?: boolean \}\): HTMLElement \{/,
+  assert.match(MENU, /export function tagChip\(label: string, color\?: string \| null, opts\?: \{ inheritSize\?: boolean; off\?: boolean \}\): HTMLElement \{/,
     "the chip is a named builder, not a lookalike");
   assert.match(MENU, /const chip = tagChip\(c\.label, c\.color\);/, "the tags bar builds its chips through it");
   assert.match(MENU, /\("var\(--dim, " \+ TAG_BTN_GRAY \+ "\)"\)/, "the uncoloured fallback is a THEME TOKEN — the light theme is never handed a dark gray");

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -332,7 +332,7 @@ test("dragging a header reorders tagOrder through the views path — the store t
 
 test("the switch lives at the foot of the chat tag-lens menu beside Configure tags…, desktop mount only", () => {
   assert.match(MENU, /groupToggle\?: \{ label: string; on: \(\) => boolean; toggle: \(\) => void \};/);
-  assert.match(MENU, /if \(opts\.groupToggle\)\s*\n\s*row\(opts\.groupToggle\.label, opts\.groupToggle\.on\(\), null, true\)\.addEventListener\("click", \(\) => \{ opts\.groupToggle!\.toggle\(\); build\(\); \}\);/,
+  assert.match(MENU, /if \(opts\.groupToggle\)\s*\n\s*row\(opts\.groupToggle\.label, opts\.groupToggle\.on\(\), true\)\.addEventListener\("click", \(\) => \{ opts\.groupToggle!\.toggle\(\); build\(\); \}\);/,
     "✓-marked when on; flips and repaints in place like the tag rows");
   assert.ok(MENU.indexOf("if (opts.groupToggle)") < MENU.indexOf('row("Configure tags…"'), "beside — above — Configure tags…");
   assert.match(RENDER, /groupToggle: \{ label: "Group tabs by tag", on: \(\) => readTabGroups\(\)\.on,/);

--- a/ui/webview/tag-menu-chips.test.ts
+++ b/ui/webview/tag-menu-chips.test.ts
@@ -1,0 +1,120 @@
+// THE TAG-LENS MENU'S TAGS ARE CHIPS (the user 2026-09-09, T283): each union tag renders as the shared
+// tag chip and acts as a toggle button — selected = full colour, unselected = faded (its colour kept),
+// aria-pressed on the chip, one tag per line with the chip at the left, the menu staying open across
+// toggles. All and (no tags) keep the row grammar (All the exclusive pick), the group switch row is
+// unchanged. Executed against a stub document (the tab-groups pattern: no jsdom) plus source pins on
+// tag-menu.ts and the two sheets. Synthetic tags only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ui = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", ...p), "utf8");
+const MENU = ui("webview", "tag-menu.ts");
+const CSS = ui("webview", "styles.css");
+const FEED_CSS = ui("webview", "feed.css");
+const OPEN = MENU.slice(MENU.indexOf("export function openTagMenu"), MENU.indexOf("export function tagMenuButton"));
+const LOOP = OPEN.slice(OPEN.indexOf("for (const u of opts.unions())"), OPEN.indexOf("if (opts.groupToggle || opts.onConfigure)"));
+
+type Node = { tag: string; attrs: Record<string, string>; kids: Node[]; text?: string; style: Record<string, string>;
+              handlers: Record<string, () => void>; setAttribute(k: string, v: string): void; getAttribute(k: string): string | null;
+              appendChild(c: Node): void; addEventListener(k: string, fn: () => void): void; remove(): void;
+              getBoundingClientRect(): { left: number; right: number; top: number; bottom: number };
+              offsetWidth: number; offsetHeight: number; textContent: string; dataset: Record<string, string> };
+
+/** The real openTagMenu against a stub document; returns the menu's rows and the recorded applies. */
+function open(lens: { all?: boolean; none?: boolean; tags?: string[] }, unions: { name: string; color: string }[]) {
+  const created: Node[] = [];
+  const mk = (tag: string): Node => {
+    const n: Node = { tag, attrs: {}, kids: [], style: {}, handlers: {}, offsetWidth: 200, offsetHeight: 100, dataset: {},
+      get textContent() { return this.kids.map((k) => k.tag === "#text" ? k.text || "" : k.textContent).join(""); },
+      set textContent(v: string) { this.kids = v ? [{ tag: "#text", text: v } as Node] : []; },
+      setAttribute(k, v) { this.attrs[k] = v; }, getAttribute(k) { return k in this.attrs ? this.attrs[k] : null; },
+      appendChild(c) { this.kids.push(c); }, addEventListener(k, fn) { this.handlers[k] = fn; }, remove() { /* detached */ },
+      getBoundingClientRect() { return { left: 10, right: 40, top: 10, bottom: 30 }; } };
+    created.push(n); return n;
+  };
+  const g = globalThis as any;
+  const saved = { document: g.document, window: g.window, localStorage: g.localStorage };
+  const body = mk("body");
+  g.document = { createElement: mk, createTextNode: (t: string) => ({ tag: "#text", text: t }), body, addEventListener() { /* closers */ } };
+  g.window = { addEventListener() { /* storage */ }, innerWidth: 1200, innerHeight: 800 };
+  g.localStorage = { setItem() { /* echo */ } };
+  const applies: { lens: unknown; done: boolean }[] = [];
+  let current = lens;
+  // the stub document stays installed until close(): the rows' click handlers rebuild the menu through it
+  const restore = () => { g.document = saved.document; g.window = saved.window; g.localStorage = saved.localStorage; };
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const mod = require("./tag-menu");
+    mod.closeTagMenu();
+    mod.openTagMenu(mk("button"), {
+      lens: () => current,
+      unions: () => unions.map((u) => ({ ...u, members: [], ids: [], localId: null, locals: [], remotes: [] })),
+      onApply: (l: unknown, done: boolean) => { applies.push({ lens: l, done }); current = l as typeof lens; },
+    });
+    const menu = body.kids[body.kids.length - 1];
+    return { menu, applies, rows: () => menu.kids, created, close: () => { mod.closeTagMenu(); restore(); } };
+  } catch (e) { restore(); throw e; }
+}
+
+const label = (n: Node) => n.kids.map((k) => k.tag === "#text" ? k.text : label(k)).join("");
+const chipOf = (row: Node) => row.kids.find((k) => k.tag === "span" && "aria-pressed" in k.attrs) as Node | undefined;
+
+test("each union tag is its own chip acting as a toggle: selected full colour + aria-pressed=true, unselected faded + the off class", () => {
+  const m = open({ tags: ["infra"] }, [{ name: "infra", color: "#54B204" }, { name: "qa", color: "#3355aa" }]);
+  const rows = m.rows();
+  assert.equal(label(rows[0]), "All"); assert.equal(label(rows[1]), "(no tags)");
+  const infra = chipOf(rows[2])!, qa = chipOf(rows[3])!;
+  assert.ok(infra && qa, "the two tags render as chips, one per row, after All and (no tags)");
+  assert.equal(infra.attrs["aria-pressed"], "true");
+  assert.equal(infra.attrs["role"], "button");
+  assert.doesNotMatch(infra.attrs.style, /opacity/, "a selected chip stands at full opacity");
+  assert.equal(infra.attrs["class"], undefined, "…and wears no off class");
+  assert.match(infra.attrs.style, /border:1px solid #54B204;color:#54B204;/, "the chip keeps the tag's own colour");
+  assert.equal(qa.attrs["aria-pressed"], "false");
+  assert.equal(qa.attrs["class"], "tag-chip-off", "an unselected chip wears the faded class");
+  assert.match(qa.attrs.style, /opacity:0\.45;/, "…and paints the same fade inline for a sheet-less host");
+  assert.match(qa.attrs.style, /border:1px solid #3355aa;color:#3355aa;/, "faded, not recoloured");
+  assert.equal(label(rows[2]), "infra"); assert.equal(label(rows[3]), "qa");
+  for (const r of [rows[2], rows[3]]) assert.ok(!label(r).includes("✓"), "the tag rows carry no ✓: the chip's state IS the mark");
+  m.close();
+});
+
+test("clicking a chip's row toggles that tag and the menu stays open and repaints", () => {
+  const m = open({ tags: ["infra"] }, [{ name: "infra", color: "#54B204" }, { name: "qa", color: "#3355aa" }]);
+  const before = m.rows().length;
+  m.rows()[3].handlers.click();   // qa: off → on
+  assert.deepEqual(m.applies, [{ lens: { none: undefined, tags: ["infra", "qa"] }, done: false }], "the toggle applies without closing (done=false)");
+  const rows = m.rows();
+  assert.equal(rows.length, before, "repainted in place: the same rows");
+  assert.equal(chipOf(rows[3])!.attrs["aria-pressed"], "true", "the chip now reads selected");
+  assert.equal(chipOf(rows[3])!.attrs["class"], undefined);
+  rows[2].handlers.click();       // infra: on → off
+  assert.equal(chipOf(m.rows()[2])!.attrs["aria-pressed"], "false");
+  assert.equal(chipOf(m.rows()[2])!.attrs["class"], "tag-chip-off");
+  m.close();
+});
+
+test("All and (no tags) keep the row grammar: All is the exclusive pick that closes the menu, (no tags) toggles with the ✓", () => {
+  const m = open({ none: true, tags: ["infra"] }, [{ name: "infra", color: "#54B204" }]);
+  const rows = m.rows();
+  assert.ok(rows[1].kids.some((k) => k.tag === "span" && label(k) === "✓"), "(no tags) selected → its ✓");
+  assert.ok(!rows[0].kids.some((k) => k.tag === "span" && label(k) === "✓"), "All not selected → no ✓");
+  rows[0].handlers.click();
+  assert.deepEqual(m.applies.at(-1), { lens: { all: true }, done: true }, "All applies as the exclusive pick and closes");
+  m.close();
+});
+
+test("source pins: the tag rows build through the shared tagChip, the state is a class the two sheets define at the same opacity", () => {
+  assert.match(LOOP, /const chip = tagChip\(u\.name, u\.color \|\| null, \{ off: !on \}\);/, "the pill every surface wears, faded when off");
+  assert.match(LOOP, /chip\.setAttribute\("aria-pressed", on \? "true" : "false"\);/);
+  assert.doesNotMatch(LOOP, /✓|--check-bg|border-radius:50%/, "no dot, no ✓ on the tag rows");
+  assert.match(MENU, /export const TAG_CHIP_OFF_CLASS = "tag-chip-off";/);
+  assert.match(MENU, /export const TAG_CHIP_OFF_OPACITY = "0\.45";/);
+  for (const [name, sheet] of [["styles.css", CSS], ["feed.css", FEED_CSS]] as const)
+    assert.match(sheet, /\n\.tag-chip-off \{ opacity: 0\.45; \}\n/, name + " defines the faded class at the inline value");
+  // the ✓ grammar survives for All / (no tags) / the group switch: the row helper still paints it from the token
+  assert.match(OPEN, /background:var\(--check-bg, #1EA1EB\)/);
+  assert.match(OPEN, /row\("All", lensAll\(lens\)\)/); assert.match(OPEN, /row\("\(no tags\)", !lensAll\(lens\) && !!lens\.none\)/);
+});

--- a/ui/webview/tag-menu-chips.test.ts
+++ b/ui/webview/tag-menu-chips.test.ts
@@ -58,7 +58,7 @@ function open(lens: { all?: boolean; none?: boolean; tags?: string[] }, unions: 
   } catch (e) { restore(); throw e; }
 }
 
-const label = (n: Node) => n.kids.map((k) => k.tag === "#text" ? k.text : label(k)).join("");
+const label = (n: Node): string => n.kids.map((k) => k.tag === "#text" ? (k.text || "") : label(k)).join("");   // recursive: the return type is stated (tsc strict)
 const chipOf = (row: Node) => row.kids.find((k) => k.tag === "span" && "aria-pressed" in k.attrs) as Node | undefined;
 
 test("each union tag is its own chip acting as a toggle: selected full colour + aria-pressed=true, unselected faded + the off class", () => {

--- a/ui/webview/tag-menu.ts
+++ b/ui/webview/tag-menu.ts
@@ -1,9 +1,14 @@
 // The SHARED tag-lens menu (the user 2026-08-25): one component every webview surface mounts —
-// the outline pane, the chat tab strip, the feed's local filter. (The timeline inlines the same
-// behavior in MENU_STYLE: it may live in Obsidian's document and loads no modules.) The menu is
-// multi-select toggles on ONE surface's lens: All a plain exclusive pick, (no tags) and every
-// name-keyed union tag toggling with the ✓ per selected row, the menu staying open across toggles
-// (a settings panel, not a command). A CAPTIONED DIVIDER says which surface the selection governs
+// the outline pane, the chat tab strip, the feed's local filter. (The timeline inlines its OWN copy
+// of this menu in MENU_STYLE, since it may live in Obsidian's document and loads no modules; that
+// copy still draws each tag as a colour-dot row with a ✓, not as the chips below — T283 changed the
+// shared component only, the timeline's mirror is its own follow-up.) The menu is
+// multi-select toggles on ONE surface's lens: All a plain exclusive pick, (no tags) toggling with
+// the ✓ when selected, and every name-keyed union tag as ITS OWN CHIP acting as a toggle button
+// (the user 2026-09-09, T283: the pill every surface already wears, one tag per line with the chip
+// at the left as the group-by-tag strip settled it; selected = full colour, unselected = faded, no
+// colour change, aria-pressed on the chip) — the menu staying open across toggles (a settings
+// panel, not a command). A CAPTIONED DIVIDER says which surface the selection governs
 // ("filters these tabs") — the shared idiom, sub-line scale. One management entry, "Configure
 // tags…", when the surface offers a route to the dialog.
 //
@@ -116,9 +121,22 @@ export function openTagMenu(anchor: HTMLElement, opts: TagMenuOpts): void {
     row("All", lensAll(lens)).addEventListener("click", () => opts.onApply({ all: true }, true));
     row("(no tags)", !lensAll(lens) && !!lens.none)
       .addEventListener("click", () => { opts.onApply(toggleLens(lens, "none"), false); build(); });
-    for (const u of opts.unions())
-      row(u.name, !lensAll(lens) && (lens.tags || []).includes(u.name), u.color || "#9aa0a6")
-        .addEventListener("click", () => { opts.onApply(toggleLens(lens, { tag: u.name }), false); build(); });
+    for (const u of opts.unions()) {
+      // one tag per line, the chip at the left: the chip IS the toggle (aria-pressed), full colour when
+      // selected, faded when not — the same pill tagChip builds for every other surface
+      const on = !lensAll(lens) && (lens.tags || []).includes(u.name);
+      const r = document.createElement("div");
+      r.setAttribute("style", "padding:3px 8px;border-radius:4px;cursor:pointer;white-space:nowrap;display:flex;align-items:center;");
+      const chip = tagChip(u.name, u.color || null, { off: !on });
+      chip.setAttribute("role", "button");
+      chip.setAttribute("aria-pressed", on ? "true" : "false");
+      chip.setAttribute("title", on ? "selected — click to drop it from the filter" : "click to add it to the filter");
+      r.appendChild(chip);
+      r.addEventListener("mouseenter", () => { r.style.background = "var(--menu-hover, rgba(255,255,255,0.09))"; });
+      r.addEventListener("mouseleave", () => { r.style.background = "transparent"; });
+      r.addEventListener("click", () => { opts.onApply(toggleLens(lens, { tag: u.name }), false); build(); });
+      menu.appendChild(r);
+    }
     if (opts.groupToggle || opts.onConfigure) {
       const s = document.createElement("div");
       s.setAttribute("style", "height:1px;margin:4px 6px;background:var(--menu-border, rgba(255,255,255,0.12));");
@@ -173,13 +191,20 @@ export const TAG_BTN_WASH = "rgba(156,210,255,0.12)";     // the feed .on's fain
  *  tags bar and the feed's tag chips wear. `inheritSize` drops the pill's own 0.82em for a host that
  *  already sits at the surface's sub-line size (the group header), so no em nests inside an em (the
  *  fonts rule). The uncoloured fallback is the theme's --dim (a token, so the light theme is never
- *  handed a dark gray), with the constant as the file:// fallback. */
-export function tagChip(label: string, color?: string | null, opts?: { inheritSize?: boolean }): HTMLElement {
+ *  handed a dark gray), with the constant as the file:// fallback.
+ *  `off` is the FADED state (T283): a chip standing for an unselected toggle keeps its colour and fades
+ *  to TAG_CHIP_OFF_OPACITY — the class names the state for the sheets and the pins, the inline opacity
+ *  paints it on a sheet-less host, the two equal by construction. */
+export const TAG_CHIP_OFF_CLASS = "tag-chip-off";
+export const TAG_CHIP_OFF_OPACITY = "0.45";   // pinned equal to .tag-chip-off in styles.css / feed.css
+export function tagChip(label: string, color?: string | null, opts?: { inheritSize?: boolean; off?: boolean }): HTMLElement {
   const col = color || ("var(--dim, " + TAG_BTN_GRAY + ")");
   const chip = document.createElement("span");
   chip.setAttribute("style", "display:inline-flex;align-items:center;gap:5px;padding:2px 7px;"
     + "border-radius:9px;" + (opts && opts.inheritSize ? "" : "font-size:0.82em;")
-    + "border:1px solid " + col + ";color:" + col + ";background:transparent;white-space:nowrap;");
+    + "border:1px solid " + col + ";color:" + col + ";background:transparent;white-space:nowrap;"
+    + (opts && opts.off ? "opacity:" + TAG_CHIP_OFF_OPACITY + ";" : ""));
+  if (opts && opts.off) chip.setAttribute("class", TAG_CHIP_OFF_CLASS);
   chip.appendChild(document.createTextNode(label));
   return chip;
 }

--- a/ui/webview/tag-menu.ts
+++ b/ui/webview/tag-menu.ts
@@ -95,15 +95,12 @@ export function openTagMenu(anchor: HTMLElement, opts: TagMenuOpts): void {
     const lens = opts.lens();
     // (the scope caption retired 2026-08-25 — the user: the button tooltip already names the
     // surface, so it is the ONE scope carrier and the menu opens straight onto its rows)
-    const row = (label: string, current: boolean, dot?: string | null, dim?: boolean) => {
+    // a plain row (All, (no tags), the group switch, Configure tags…): the label, the ✓ when current; the
+    // tags are not rows any more but chips (below), so the colour dot the tag rows wore is gone (T283)
+    const row = (label: string, current: boolean, dim?: boolean) => {
       const r = document.createElement("div");
       r.setAttribute("style", "padding:4px 22px 4px 8px;border-radius:4px;cursor:pointer;position:relative;white-space:nowrap;"
         + (dim ? "opacity:0.85;" : ""));
-      if (dot) {
-        const d = document.createElement("span");
-        d.setAttribute("style", "display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:7px;background:" + dot + ";");
-        r.appendChild(d);
-      }
       r.appendChild(document.createTextNode(label));
       if (current) {
         const c = document.createElement("span");
@@ -143,9 +140,9 @@ export function openTagMenu(anchor: HTMLElement, opts: TagMenuOpts): void {
       menu.appendChild(s);
     }
     if (opts.groupToggle)
-      row(opts.groupToggle.label, opts.groupToggle.on(), null, true).addEventListener("click", () => { opts.groupToggle!.toggle(); build(); });
+      row(opts.groupToggle.label, opts.groupToggle.on(), true).addEventListener("click", () => { opts.groupToggle!.toggle(); build(); });
     if (opts.onConfigure)
-      row("Configure tags…", false, null, true).addEventListener("click", () => { closeTagMenu(); opts.onConfigure!(); });
+      row("Configure tags…", false, true).addEventListener("click", () => { closeTagMenu(); opts.onConfigure!(); });
   };
   build();
   document.body.appendChild(menu);


### PR DESCRIPTION
In the shared tag-lens menu (`ui/webview/tag-menu.ts`, mounted by the feed's footer, the chat's tab strip and phone header, and the outline pane) each union tag was a row with a colour dot and a ✓ when selected. The user asked for the tags to appear as the tag chips every surface already wears and to act as toggle buttons, the inactive ones faded.

**Design points**
- Each tag renders through the shared `tagChip` builder, one tag per line with the chip at the left (the group-by-tag strip's earlier ruling), and the chip is the toggle: selected = full colour, `aria-pressed="true"`; unselected = the same colour faded (class `tag-chip-off` plus the inline opacity for a sheet-less host, both 0.45), `aria-pressed="false"`. The row keeps the hover wash; a click toggles that tag and the menu stays open, as before.
- "All" and "(no tags)" keep the row grammar with the ✓ (All the exclusive pick); the group switch row and Configure tags… are unchanged. The ctx-menu skin and tokens stand; no raw colour added.
- One component, so the feed, the chat and the outline change together; both mounts the dispatch named were verified by screenshot (dark and light).

**Tests.** `ui/webview/tag-menu-chips.test.ts` drives the real `openTagMenu` against a stub document and pins the chips' `aria-pressed`, the faded class and opacity, the colour kept, the toggle without close, and the All/(no tags) rows; the tab-groups pin follows `tagChip`'s new signature. Node suite and full Python suite green in transient scopes; lean adversarial review run before auto-merge was armed.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
