### PR TITLE
Cleared cards stay cleared across a restart: the ledger is authoritative at every read, and a clear is journaled

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3710,6 +3710,21 @@ def append_override(fsid, node_id, op, t):
         f.write(json.dumps({"node": node_id, "op": op, "t": int(t)}) + "\n")
 
 
+def append_clear(fsid, node_id, src, why, t):
+    """Journal the user's cross-off (or a romp-authored clear: the episode boundary, a mute) BEFORE the
+    caller's store save, so a clobbered clear re-applies on the very next load (2026-09-09). Until now a
+    clear lived in two places only, the cleared.jsonl ledger and the store's own node verdict and flag: a
+    triage pass that loaded the store before the clear and saved after it erased the verdict and the flag,
+    the ledger kept hiding the live card so nothing showed, and the compaction then archived the node with
+    cleared false, where the archive projections trusted the flag alone and the card came back completed
+    and uncleared after a restart. The row carries its author and why, so the replay re-records the same
+    verdict the live write made."""
+    d = _overrides_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    with (d / (fsid + ".jsonl")).open("a") as f:
+        f.write(json.dumps({"node": node_id, "op": "clear", "src": src, "why": why, "t": int(t)}) + "\n")
+
+
 def append_block(fsid, node_id, src, why, t):
     """Journal a KERNEL-side block verdict (src "nudge"/"interrupt") — the same clobber protection
     append_override gives user clicks, for the blocks the kernel stamps BETWEEN judge passes. These are
@@ -3874,6 +3889,20 @@ def _replay_overrides(fsid, store, lines=None):
                 applied = True
                 if was_done and not nd.get("settledDone"):
                     record_verdict(store, nd, "romp", "settle", t)
+        elif op == "clear":
+            # The cross-off (_mark_nodes_cleared value=True, append_clear), replayed so a store a racing pass
+            # save clobbered re-seals exactly as the live one did (2026-09-09; the unclear arm's mirror).
+            # Voided by a LATER undo: a strictly-later user reopen (the undo-clear's own verdict, or its
+            # replayed "unclear" row) outranks this entry; the twin check keeps the survived write as is.
+            if nd.get("cleared") or _twin("clear") or any(e.get("kind") == "reopen"
+                                                          and int(e.get("ev_t") or 0) >= t for e in uev):
+                continue                               # sealed already, survived, or undone at or after it (an undo in
+                #                                        the clear's own second is the later gesture: the ledger's undo
+                #                                        row follows its clear row, so at-or-after voids, unlike the
+                #                                        unclear arm, where a later clear is the only voider)
+            if record_verdict(store, nd, ev.get("src") or "user", "clear", t,
+                              why=ev.get("why") or "cleared from the feed"):
+                applied = True
         elif op == "block":
             # A kernel-side block (append_block). The answer guard keeps AT-OR-AFTER (>= via later|eq):
             # a user reply in the same second as the nudge stamp genuinely answered it, so replaying

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -29067,7 +29067,7 @@ def _fleet_archived_tops(sid, cap=20):
         return []                                    # no archive → nothing to surface
     hit = _arch_tops_cache.get(str(p))
     if hit and hit[0] == mt:
-        return hit[1]
+        return _ledger_cleared_overlay(hit[1])
     arch = jd.load_goal_archive(sid)
     nodes, status = arch.get("nodes", {}), arch.get("status", {})
     kids = {}
@@ -29117,6 +29117,25 @@ def _fleet_archived_tops(sid, cap=20):
     if len(_arch_tops_cache) > 256:
         _arch_tops_cache.clear()
     _arch_tops_cache[str(p)] = (mt, out)
+    return _ledger_cleared_overlay(out)
+
+
+def _ledger_cleared_overlay(rows):
+    """The archive projection with cleared.jsonl applied over the node flags (2026-09-09): an archived top the
+    ledger clears reads cleared whatever its copied flag says (a racing pass save could have erased it), and
+    its subtree follows, the roll-down the live tree's top-only cross-off has. Applied AFTER the mtime cache,
+    so a clear that lands later than the archive's last write shows on the next build."""
+    vc = _cleared_ids()
+    if not vc:
+        return rows
+    out, root_cleared = [], False
+    for n in rows:
+        if n.get("depth") == 0:
+            root_cleared = bool(n.get("cleared")) or n.get("id") in vc
+            out.append(dict(n, cleared=root_cleared) if root_cleared != bool(n.get("cleared")) else n)
+        else:
+            c = bool(n.get("cleared")) or n.get("id") in vc or root_cleared
+            out.append(dict(n, cleared=c) if c != bool(n.get("cleared")) else n)
     return out
 
 
@@ -30780,6 +30799,13 @@ def _mark_nodes_cleared(item_ids, value, src="user", why=None):
                                             "clear" if value else "reopen", now,
                                             why=(why or "cleared from the feed") if value else "undo clear",
                                             undo=not value)   # an undo-restore asserts nothing about doneness
+                if value and applied:
+                    # Journal the CLEAR too (2026-09-09): a triage pass holding this store across a model call
+                    # saved after the cross-off and erased the verdict and the flag; the ledger kept hiding
+                    # the live card, and the compaction archived the node unflagged, where the archive
+                    # projections trusted the flag and the card came back after a restart. Journal-first,
+                    # like the unclear row: this precedes the save below.
+                    jd.append_clear(sid, iid, src, why or "cleared from the feed", now)
                 if not value and applied:
                     # Journal the UN-CLEAR (the user 2026-07-23, the restore-then-reply flicker): the
                     # restore journal row carries only the ARCHIVED node payload — still flag-cleared —
@@ -31116,9 +31142,17 @@ def _compact_goal_store(fsid):
         nd = nodes.get(nid) or {}
         return bool(nd.get("cleared")) or nid in cleared or status.get(nid) == "cleared"
 
-    move = []
+    move, resealed = [], False
     for r in children.get(None, []):                   # ROOTS only
         if _cleared_root(r):
+            if r in cleared and not nodes[r].get("cleared"):
+                # the ledger is authoritative (2026-09-09): a root the user cleared whose verdict and flag a racing
+                # pass save erased is re-sealed through the diary (the flag is diary-owned, derived by the rollup
+                # below) at the ledger row's own time before the copy, so no archive reader takes it for an
+                # uncleared card. Since the same day every clear also journals an override row, so a load heals
+                # it first; this covers a ledger row with no journal row (history, another writer of the ledger).
+                resealed = jd.record_verdict(store, nodes[r], "user", "clear", int(cleared[r] or time.time()),
+                                             why="cleared from the feed (re-applied from the ledger at compaction)") or resealed
             stack = [r]
             while stack:                               # the whole subtree
                 x = stack.pop()
@@ -31126,6 +31160,14 @@ def _compact_goal_store(fsid):
                 stack.extend(children.get(x, []))
     if not move:
         return 0
+    if resealed:
+        try:                                           # the flags are the rollup's (history to flags), and the settled
+            now = int(time.time())                     # gate wants the session's honest closed state, as the clear path reads it
+            path = next((sd["path"] for sd in _sessions(now) if sd["sid"] == fsid), None)
+            closed = jd._session_closed(_parse(path, fsid, now)) if path else False
+        except Exception:
+            closed = False
+        jd.rollup_status(store, closed)
     with jd._GOAL_ARCH_LOCK:                            # the archive is a blind RMW — see the lock's note
         arch = jd.load_goal_archive(fsid)
         a_nodes = arch.setdefault("nodes", {})

--- a/tests/test_kernel_goal_compaction.py
+++ b/tests/test_kernel_goal_compaction.py
@@ -167,5 +167,130 @@ class GoalCompactionTest(unittest.TestCase):
                         body.index("_mark_nodes_cleared(restored, False)"))
 
 
+
+
+class ClearedLedgerIsAuthoritativeAcrossTheCompaction(unittest.TestCase):
+    """The user (2026-09-09): after a restart, a batch of cards they had cleared came back. A clear lived in the
+    ledger (cleared.jsonl) and in the store's node verdict and flag; a triage pass that loaded the store before the
+    clear and saved after it erased the verdict and the flag, the ledger kept hiding the live card so nothing
+    showed, the boot compaction archived the node with cleared false, and the archive projection trusted the flag
+    alone, so the card rendered completed and uncleared. Three fixes, each pinned: the clear is journaled and a
+    clobbered clear heals on the next load; the compaction stamps the ledger's flag on the root it moves; the
+    projection reads the ledger over the copied flag, after its cache, with the roll-down to the subtree."""
+
+    def setUp(self):
+        self._saved_state = jd.STATE
+        self._td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self._td))
+        km._compact_seen.clear()
+        km._arch_tops_cache.clear()
+        km._CLEARED_MEMO["slot"] = None
+        jd._GOALARCH_MEMO.clear()
+        self.g = lambda n: "%s:%s" % (SID, n)
+        (jd.STATE).mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "cleared.jsonl").write_text("")
+
+    def tearDown(self):
+        jd._rebind_state(self._saved_state)
+        km._arch_tops_cache.clear()
+        km._CLEARED_MEMO["slot"] = None
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _completed_top(self, n, with_child=False):
+        """A completed top the way a real one is: its completion is a done verdict in its log (rollup derives
+        nodeComplete from the log, so a bare flag would not survive a load)."""
+        nodes = {self.g(n): _node(self.g(n), None, t=100, mt=100)}
+        if with_child:
+            nodes[self.g(n + "a")] = _node(self.g(n + "a"), self.g(n), t=100, mt=100)
+        store = jd._guard_nodes({"rompUuid": SID, "seq": 1, "lastNode": self.g(n), "nodes": nodes,
+                                 "status": {}, "placements": {self.g(n) + "seg": self.g(n)}})
+        for nid in list(nodes):
+            jd.record_verdict(store, store["nodes"][nid], "closer", "done", 100, why="shipped")
+        jd.rollup_status(store, True)
+        jd.save_goals(SID, store)
+        self.assertEqual(jd.load_goals(SID)["status"].get(self.g(n)), "completed", "premise: a completed top")
+        return store
+
+    def _fresh_process(self):
+        """Every in-process memo the archive projection could serve from, dropped: what a restart drops."""
+        km._arch_tops_cache.clear()
+        km._CLEARED_MEMO["slot"] = None
+        jd._GOALARCH_MEMO.clear()
+        jd._shared_clear()
+
+    def _clobber_with(self, snapshot):
+        """A pass save from a pre-clear snapshot: the store file loses the verdict and the flag."""
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(snapshot))
+        jd._shared_clear()
+
+    def test_the_users_sequence_clear_clobber_compact_restart_the_card_stays_cleared(self):
+        self._completed_top("g3", with_child=True)
+        snapshot = json.loads((jd.GOALDIR / (SID + ".json")).read_text())   # a pass holds this across its model call
+        km._clear_all([self.g("g3")])                                       # the user's cross-off
+        raw = json.loads((jd.GOALDIR / (SID + ".json")).read_text())
+        self.assertTrue(raw["nodes"][self.g("g3")]["cleared"], "premise: the live write landed the flag")
+        self._clobber_with(snapshot)                                        # ...and the pass's save erased it
+        raw = json.loads((jd.GOALDIR / (SID + ".json")).read_text())
+        self.assertFalse(raw["nodes"][self.g("g3")].get("cleared"), "premise: the flag is gone from the file")
+        moved = km._compact_goal_store(SID)
+        self.assertEqual(moved, 2, "the ledger-cleared root and its child leave the live store")
+        arch = json.loads((jd.GOALARCHDIR / (SID + ".json")).read_text())
+        self.assertTrue(arch["nodes"][self.g("g3")]["cleared"], "the archived copy carries the flag")
+        self.assertTrue(any(e.get("kind") == "clear" for e in arch["nodes"][self.g("g3")].get("log") or []),
+                        "...as a verdict in its log, not a bare flag")
+        self._fresh_process()
+        by_id = {n["id"]: n for n in km._fleet_archived_tops(SID)}
+        for nid in (self.g("g3"), self.g("g3a")):
+            n = by_id.get(nid)
+            self.assertTrue(n is None or n["cleared"],
+                            "after the restart the card is gone from Show completed (a cleared top is no longer a "
+                            "completed one) or reads cleared; it never comes back as completed and uncleared")
+
+    def test_a_clobbered_clear_heals_on_the_next_load_and_an_undo_still_wins(self):
+        self._completed_top("g6")
+        snapshot = json.loads((jd.GOALDIR / (SID + ".json")).read_text())
+        km._clear_all([self.g("g6")])
+        rows = [json.loads(l) for l in (jd._overrides_dir() / (SID + ".jsonl")).read_text().splitlines()]
+        self.assertEqual([r["op"] for r in rows], ["clear"], "the clear is journaled, journal-first")
+        self.assertEqual((rows[0]["node"], rows[0]["src"]), (self.g("g6"), "user"))
+        self._clobber_with(snapshot)
+        st = jd.load_goals(SID)
+        self.assertTrue(st["nodes"][self.g("g6")].get("cleared"), "the replay re-seals the clobbered clear")
+        self.assertTrue(any(e.get("kind") == "clear" for e in st["nodes"][self.g("g6")].get("log") or []))
+        # the user undoes: the reopen at or after the clear outranks the replayed row from then on
+        km._undo_clear()
+        st = jd.load_goals(SID)
+        self.assertFalse(st["nodes"][self.g("g6")].get("cleared"), "undone")
+        jd._shared_clear()
+        self.assertFalse(jd.load_goals(SID)["nodes"][self.g("g6")].get("cleared"), "...and it stays undone on a reload")
+
+    def test_the_compaction_stamps_a_root_only_the_ledger_clears(self):
+        self._completed_top("g4")
+        with (jd.STATE / "cleared.jsonl").open("a") as f:                  # the ledger alone: no flag, no journal
+            f.write(json.dumps({"id": self.g("g4"), "t": 200, "op": "clear"}) + "\n")   # after its completion, as a cross-off is
+        km._CLEARED_MEMO["slot"] = None
+        self.assertEqual(km._compact_goal_store(SID), 1)
+        arch = json.loads((jd.GOALARCHDIR / (SID + ".json")).read_text())
+        self.assertTrue(arch["nodes"][self.g("g4")]["cleared"], "stamped before the copy")
+        self.assertEqual(arch["status"][self.g("g4")], "completed", "the status is history, untouched")
+
+    def test_the_projection_reads_the_ledger_over_the_copied_flag_after_its_cache(self):
+        jd.GOALARCHDIR.mkdir(parents=True, exist_ok=True)
+        (jd.GOALARCHDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID,
+            "nodes": {self.g("g5"): _node(self.g("g5"), None, nodeComplete=True, t=100, mt=100),
+                      self.g("g5a"): _node(self.g("g5a"), self.g("g5"), nodeComplete=True, t=100, mt=100)},
+            "status": {self.g("g5"): "completed"}}))
+        first = {n["id"]: n for n in km._fleet_archived_tops(SID)}
+        self.assertFalse(first[self.g("g5")]["cleared"], "no ledger row: the flag stands")
+        with (jd.STATE / "cleared.jsonl").open("a") as f:                  # a clear lands after the archive's write
+            f.write(json.dumps({"id": self.g("g5"), "t": 200, "op": "clear"}) + "\n")
+        km._CLEARED_MEMO["slot"] = None
+        second = {n["id"]: n for n in km._fleet_archived_tops(SID)}
+        self.assertTrue(second[self.g("g5")]["cleared"], "the ledger applies over the cached projection")
+        self.assertTrue(second[self.g("g5a")]["cleared"], "and rolls down to the subtree")
+        self.assertFalse(first[self.g("g5")]["cleared"], "the cached rows themselves are not mutated")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Tier: fix

## What

After a restart, a batch of cards the user had cleared came back, rendered completed and uncleared (the user, 2026-09-09 morning). The clear ledger (`cleared.jsonl`) is now authoritative at every read, and a clear is journaled so a clobbered one heals.

**Mechanism** (verified on the maintainer's box: 33 archived tops carry the signature back to 08-28, so it predates the recent jobs-stage and judge-side rounds; on the second machine the three cards came back exactly this way two minutes before its restart):

1. A clear lived in two places: the ledger row (`_clear_all`) and the store's node verdict and flag (`_mark_nodes_cleared`, a `clear` verdict whose flag the rollup derives). It was not journaled in the override journal, whose ops were restore, resolve, followup, move, unclear, block, redistill. A triage pass that loaded the store before the clear and saved after it erased the verdict and the flag; the ledger kept hiding the live card, so the loss was invisible.
2. The compaction (`_compact_goal_store`) treats a root as cleared by flag or ledger or status, so it moved the ledger-only-cleared top into the archive with the node copied as is: `cleared` false, status completed.
3. The archive projection the Fleet's "Show completed" reads (`_fleet_archived_tops`, attached as `ledger.archivedTops`) set `cleared` from the copied flag alone and never consulted the ledger, so the archived top rendered as completed and not cleared: the card came back. The boot compaction is when hidden live cards become archive-projected ones, which is why a restart shows it; any compaction does the same.

**Fix, three parts.**

- **The clear is journaled, journal-first.** `_mark_nodes_cleared` appends a `clear` override row (`append_clear`, carrying its author and why, so a romp-authored clear replays as one) before the save a racing pass could clobber, and the replay gains a `clear` arm mirroring `unclear`: it re-records the verdict unless the node is sealed, the write survived (the twin check), or a user reopen at or after the row's time undid it (the undo's own row follows the clear's in the ledger, so at-or-after voids, unlike the unclear arm where only a later clear voids).
- **The compaction re-seals a root the ledger clears** whose flag a pass erased: a `clear` verdict at the ledger row's time through the diary, then the rollup with the session's honest closed state (the clear path's own reading), before the copy. Only when a re-seal happened.
- **The archive projection reads the ledger over the copied flag**, applied after the mtime cache (a clear landing after the archive's last write shows on the next build), with the roll-down to the subtree the live tree's top-only cross-off has. The tab-hover Recent lists tops regardless of clearing, so it needed nothing.

Note what the fix does to a cleared completed top in "Show completed": its rollup turns its status to cleared and drops its completion flag, so it leaves the completed projection altogether, which is the live tree's behavior and the state the user expects. No card-move rule changes: a clear's outcome is the same as the live write's; only the reads that trusted a copied flag now trust the ledger.

## Review (lean, by hand; the restart cadence kills review agents)

The replay arm: a romp-authored clear row (the episode boundary, a mute) has no user event for the twin check, but a survived write leaves the flag set, so the sealed check skips it; a clear outranked by a later done in the fold (a clear before a completion, which no user path writes) is found by the twin check and not re-recorded; a user reopen at or after the row's time voids it, and the reopen's own `unclear` row replays after it in journal order. The compaction's re-seal runs the rollup only when a verdict was recorded, with the closed state read the way `_mark_nodes_cleared` reads it, so an unrelated in-focus completed top is treated exactly as the clear path treats it. The overlay builds new rows and leaves the cached ones alone; the ledger set is the kernel's per-file-state memo, so the overlay costs a set lookup per row. The `_cleared_root` rule of the compaction is unchanged, so what moves is what moved before; only the copy's flag is honest now.

## Tests

`tests/test_kernel_goal_compaction.py`, new class: the user's exact sequence (a completed top with a child, the cross-off, a pass save from a pre-clear snapshot that erases the verdict and flag, the compaction, every in-process memo dropped as a restart drops them, the projection read: the archived copy carries the flag as a verdict in its log, and the card is gone from Show completed or reads cleared, never completed and uncleared); a clobbered clear heals on the next load through the journal and an undo still wins and stays undone on a reload; the compaction re-seals a root only the ledger clears; the projection reads the ledger over the copied flag after its cache, rolling down to the subtree, without mutating the cached rows.
