### PR TITLE
T285: a session header row holds the feed's hover-freeze gate like a card does

### DIFF
--- a/ui/webview/feed-freeze.test.ts
+++ b/ui/webview/feed-freeze.test.ts
@@ -166,7 +166,8 @@ test("badges wear the header conventions: accent adds, block-red removes, the co
   // painted on the build-once column heads and the data-fsid-stamped session headers; cleared when quiet
   assert.match(FEED, /put\(document\.querySelector\("\.feed-col\.col-" \+ key \+ " \.feed-col-head"\), d\.cols\[key\]\);/);
   assert.match(FEED, /h\.setAttribute\("data-fsid", e\.sid\);/);
-  assert.match(FEED, /put\(h, groupedNow \? d\.sess\[h\.getAttribute\("data-fsid"\) \|\| ""\] : undefined\);/);
+  assert.match(FEED, /const c = groupedNow \? d\.sess\[sid\] : undefined;\s*if \(sid !== hoveredSid\) \{ put\(h, c\); return; \}/,
+    "every header but the hovered one carries its in-row badge (the hovered one's floats — T285)");
   assert.match(FEED, /document\.querySelectorAll\("\.freeze-badge"\)\.forEach\(\(n\) => n\.remove\(\)\);/,
     "nothing pending → every badge comes off");
   // local renders while frozen re-sync the hints, so a rebuilt board never strands a stale count
@@ -195,7 +196,14 @@ test("a session header row holds the same gate a card holds: a push while it is 
   const heal = FEED.slice(FEED.indexOf("// Stale-freeze heal (hover-freeze)"), FEED.indexOf("paintFreezeBadges();   // hover-freeze: local renders"));
   assert.match(heal, /querySelector<HTMLElement>\("\.feed-cols \.fitem:hover, \.feed-sess-head:hover"\)/, "a hovered header keeps the freeze live across a local render");
   assert.match(heal, /hov\.classList\.contains\("feed-sess-head"\) \? sessFreezeKey\(hov\) : kbHoverId\(hov\)/);
-  // the badge painter already hints the deferred churn beside each header — the same pending indicator
-  assert.match(FEED, /document\.querySelectorAll<HTMLElement>\("\.feed-sess-head"\)\.forEach\(\(h\) => \{\s*put\(h, groupedNow \? d\.sess\[h\.getAttribute\("data-fsid"\) \|\| ""\] : undefined\);/);
+  // the same pending indicator beside each header — but NEVER inside the hovered row (review find): an in-row
+  // badge lands after the auto-margin Clear all and slides it out from under the pointer, the very click loss
+  // this hold prevents. The hovered header's badge floats: body-mounted, pointer-inert, its row's rect untouched.
+  const paint = FEED.slice(FEED.indexOf("function paintFreezeBadges(): void {"), FEED.indexOf("// ── CARD KEYBOARD SCOPE"));
+  assert.match(paint, /const hoveredSid = freezeKey && freezeKey\.startsWith\("h:"\) \? freezeKey\.slice\(2\) : null;/);
+  assert.match(paint, /if \(sid !== hoveredSid\) \{ put\(h, c\); return; \}\s*put\(h, undefined\);/, "every other header keeps its in-row badge; the hovered one carries none");
+  assert.match(paint, /headNote\.id = "freeze-headnote"; document\.body\.appendChild\(headNote\);/, "…its hint is body-mounted");
+  assert.match(paint, /headNote\.style\.top = Math\.round\(r\.bottom \+ 2\) \+ "px";/, "…placed just under the row, right-aligned");
+  assert.match(CSS, /#freeze-headnote \{ position: fixed; z-index: 6; pointer-events: none;/, "pointer-inert, like the card's self-note");
 });
 

--- a/ui/webview/feed-freeze.test.ts
+++ b/ui/webview/feed-freeze.test.ts
@@ -72,9 +72,10 @@ test("a local render that detaches or re-keys the hovered element heals the free
   // found in review 2026-08-24: a removed element never fires mouseleave — typing in search can
   // filter the hovered card out, and toggling Group swaps it for a group card in place with no
   // enter/leave events. The render tail checks live pointer truth per render — event-based.
-  assert.match(FEED, /const hov = document\.querySelector<HTMLElement>\("\.feed-cols \.fitem:hover"\);/);
+  assert.match(FEED, /const hov = document\.querySelector<HTMLElement>\("\.feed-cols \.fitem:hover, \.feed-sess-head:hover"\);/,
+    "a card or a session header under the pointer is pointer truth (T285 added the header)");
   assert.match(FEED, /if \(!hov\) \{ freezeKey = null; flushFreeze\(\); \}/);
-  assert.match(FEED, /else \{ const k = kbHoverId\(hov\); if \(k && k !== freezeKey\) freezeKey = k; \}/,
+  assert.match(FEED, /else \{ const k = hov\.classList\.contains\("feed-sess-head"\) \? sessFreezeKey\(hov\) : kbHoverId\(hov\); if \(k && k !== freezeKey\) freezeKey = k; \}/,
     "a re-keyed card under a stationary pointer re-arms to the element actually hovered");
 });
 
@@ -171,3 +172,30 @@ test("badges wear the header conventions: accent adds, block-red removes, the co
   // local renders while frozen re-sync the hints, so a rebuilt board never strands a stale count
   assert.match(FEED, /paintFreezeBadges\(\);   \/\/ hover-freeze: local renders while frozen re-sync/);
 });
+
+test("a session header row holds the same gate a card holds: a push while it is hovered is queued, never rebuilt under the pointer; leaving releases (T285)", () => {
+  const head = FEED.slice(FEED.indexOf("function makeSessHead()"), FEED.indexOf("function updateSessHead("));
+  // the row (name, caret, Clear all inside it) enters and leaves the freeze by the session it stands for
+  assert.match(head, /h\.addEventListener\("mouseenter", \(\) => freezeEnter\(sessFreezeKey\(h\)\)\);/, "hovering the header row arms the gate");
+  assert.match(head, /h\.addEventListener\("mouseleave", \(\) => freezeLeave\(sessFreezeKey\(h\)\)\);/, "leaving it releases (the flush follows)");
+  assert.match(FEED, /function sessFreezeKey\(h: HTMLElement\): string \{ return "h:" \+ \(h\.getAttribute\("data-fsid"\) \|\| ""\); \}/,
+    "keyed by the data-fsid stamp read at event time — the row's identity across re-homing renders");
+  // the payload path is ONE gate for both holders: while any freeze key is set, the payload is queued and
+  // NOTHING renders — so updateSessHead never runs and the hovered row (its Clear all included) stands
+  const gate = FEED.slice(FEED.indexOf('if (m.type === "feed") {'), FEED.indexOf('} else if (m.type === "hoverCards") {'));
+  assert.match(gate, /if \(freezeKey \|\| tabScopeKey\) \{ pendingFeedPayload = m; paintFreezeBadges\(\); return; \}/,
+    "a push during header hover is held: queued, badges painted, no render");
+  assert.match(gate, /applyFeedPayload\(m\);/, "…and applies only when nothing holds the gate");
+  // the release re-renders: mouseleave → freezeLeave → flushFreeze → applyFeedPayload of the newest payload
+  const leave = FEED.slice(FEED.indexOf("function freezeLeave(key: string): void {"), FEED.indexOf("let flushQueued = false;"));
+  assert.match(leave, /if \(freezeKey !== key\) return;\s*freezeKey = null;\s*flushFreeze\(\);/);
+  const flush = FEED.slice(FEED.indexOf("function flushFreeze(): void {"), FEED.indexOf('window.addEventListener("blur", () => { releaseTabScope();'));
+  assert.match(flush, /if \(m\) applyFeedPayload\(m\);/, "the queued payload renders on release");
+  // the stale-freeze heal reads a hovered header as pointer truth, keyed the same way
+  const heal = FEED.slice(FEED.indexOf("// Stale-freeze heal (hover-freeze)"), FEED.indexOf("paintFreezeBadges();   // hover-freeze: local renders"));
+  assert.match(heal, /querySelector<HTMLElement>\("\.feed-cols \.fitem:hover, \.feed-sess-head:hover"\)/, "a hovered header keeps the freeze live across a local render");
+  assert.match(heal, /hov\.classList\.contains\("feed-sess-head"\) \? sessFreezeKey\(hov\) : kbHoverId\(hov\)/);
+  // the badge painter already hints the deferred churn beside each header — the same pending indicator
+  assert.match(FEED, /document\.querySelectorAll<HTMLElement>\("\.feed-sess-head"\)\.forEach\(\(h\) => \{\s*put\(h, groupedNow \? d\.sess\[h\.getAttribute\("data-fsid"\) \|\| ""\] : undefined\);/);
+});
+

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -327,6 +327,10 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 #freeze-selfnote { position: fixed; z-index: 6; pointer-events: none; color: var(--accent);
   font-size: 10.5px; font-weight: 600; background: rgba(30, 30, 30, 0.85);
   border-radius: 4px; padding: 1px 6px; }
+/* the HOVERED session header's churn badge (T285): the self-note's body-mounted, pointer-inert dress, so the
+   row the pointer rests on keeps its shape — an in-row badge slid Clear all out from under the pointer */
+#freeze-headnote { position: fixed; z-index: 6; pointer-events: none; background: rgba(30, 30, 30, 0.85);
+  border-radius: 4px; padding: 1px 6px; margin-left: 0; }
 /* margin-top, NOT header padding: the liveness rings are outlines drawn ~2.5px
    OUTSIDE the first card's top edge, and the sticky header paints its padding as
    opaque background over them — only unpainted margin space lets them show */

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -5342,7 +5342,7 @@ function pendingSelfChanged(key: string): boolean {
 }
 function paintFreezeBadges(): void {
   if (!pendingFeedPayload) {
-    document.querySelectorAll(".freeze-badge").forEach((n) => n.remove());
+    document.querySelectorAll(".freeze-badge").forEach((n) => n.remove());   // the floating header note is one too
     document.getElementById("freeze-selfnote")?.remove();
     return;
   }
@@ -5359,9 +5359,27 @@ function paintFreezeBadges(): void {
     put(document.querySelector(".feed-col.col-" + key + " .feed-col-head"), d.cols[key]);
   }
   const groupedNow = feedPrefs().grouped;
+  // The HOVERED header row must not change shape (T285 review): a badge appended inside it lands after the
+  // auto-margin Clear all and slides that button out from under the pointer — the click loss the header
+  // hold exists to prevent, caused by the hold's own hint. That row's badge floats instead: body-mounted,
+  // pointer-inert, right-aligned just under the row (the self-note idiom), so the row's rect stands.
+  const hoveredSid = freezeKey && freezeKey.startsWith("h:") ? freezeKey.slice(2) : null;
+  let headNote = document.getElementById("freeze-headnote") as HTMLElement | null;
+  let floated = false;
   document.querySelectorAll<HTMLElement>(".feed-sess-head").forEach((h) => {
-    put(h, groupedNow ? d.sess[h.getAttribute("data-fsid") || ""] : undefined);
+    const sid = h.getAttribute("data-fsid") || "";
+    const c = groupedNow ? d.sess[sid] : undefined;
+    if (sid !== hoveredSid) { put(h, c); return; }
+    put(h, undefined);                                   // never inside the hovered row
+    if (!c || (!c.add && !c.del)) return;
+    if (!headNote) { headNote = el("div", "freeze-badge"); headNote.id = "freeze-headnote"; document.body.appendChild(headNote); }
+    paintFreezeParts(headNote, c);
+    const r = h.getBoundingClientRect();
+    headNote.style.top = Math.round(r.bottom + 2) + "px";
+    headNote.style.right = Math.max(0, Math.round(window.innerWidth - r.right)) + "px";
+    floated = true;
   });
+  if (!floated) headNote?.remove();
   // the hovered/keyed card's OWN pending update — its own line, independent of the churn badges
   // (both show when both are true). Body-mounted and pointer-inert: it must never affect hover,
   // and the frozen card's rect is stable by construction (that is the freeze's whole contract).

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3568,8 +3568,18 @@ function makeSessHead(): HTMLElement {
   h.append(nm, fold, cnt, svc, clr, svcList);
   (h as any)._name = nm; (h as any)._fold = fold; (h as any)._foldn = cnt;
   (h as any)._svc = svc; (h as any)._svcList = svcList; (h as any)._clear = clr;
+  // HOVER-FREEZE for the header row too (the user 2026-09-09, T285): a push while the pointer rests on the
+  // row — its name, its caret, its Clear all — must not rebuild the row under the pointer (the click-safety
+  // rule; a rebuilt Clear all lost the click). The row holds the same payload gate a card holds, keyed by
+  // the session it stands for, and releases it on mouseleave exactly like a card; entering the row's own
+  // buttons is entering the row (mouseenter/leave do not fire between a row and its children).
+  h.addEventListener("mouseenter", () => freezeEnter(sessFreezeKey(h)));
+  h.addEventListener("mouseleave", () => freezeLeave(sessFreezeKey(h)));
   return h;
 }
+/** The hover-freeze key a session header holds: "h:<sid>", read from the data-fsid stamp at event time (grouped
+ *  mode re-homes and re-stamps headers across renders; the stamp is the row's identity). */
+function sessFreezeKey(h: HTMLElement): string { return "h:" + (h.getAttribute("data-fsid") || ""); }
 function updateSessHead(h: HTMLElement, e: Entry & { kind: "sess" }): void {
   // the hover-freeze badge painter finds headers by sid; compare first, like the labels below — the DOM's
   // change-an-attribute steps queue a mutation record for a same-value write too
@@ -5022,9 +5032,10 @@ function render() {
   // is stale, clear it and flush the queue; a DIFFERENT card under the pointer (re-keyed in place,
   // so no enter event ever fired) → re-arm to the element actually being hovered.
   if (freezeKey) {
-    const hov = document.querySelector<HTMLElement>(".feed-cols .fitem:hover");
+    // a card OR a session header under the pointer (T285): both hold the gate
+    const hov = document.querySelector<HTMLElement>(".feed-cols .fitem:hover, .feed-sess-head:hover");
     if (!hov) { freezeKey = null; flushFreeze(); }
-    else { const k = kbHoverId(hov); if (k && k !== freezeKey) freezeKey = k; }
+    else { const k = hov.classList.contains("feed-sess-head") ? sessFreezeKey(hov) : kbHoverId(hov); if (k && k !== freezeKey) freezeKey = k; }
   }
   paintFreezeBadges();   // hover-freeze: local renders while frozen re-sync the +N/-N hints (no-op unfrozen)
   // stale-ring heal: releaseTabScope sweeps the DOCUMENT, but a card DETACHED at release (filtered
@@ -5240,10 +5251,10 @@ function mirrorBadges(items: AskItem[], clears: ClearNoticeRow[], sdk: SdkNotice
 }
 
 // ── HOVER-FREEZE (the user 2026-08-24) ──────────────────────────────────────────────────────────
-// While the pointer rests on a card, the board must not move under it: incoming feed payloads QUEUE
-// (newest wins — intermediate states were never on screen, so nothing owes them an animation)
-// instead of rendering, and the deferred churn shows as a subtle +N/-N beside the column pills and,
-// in grouped mode, the session headers. Only the PAYLOAD path defers: the hovered card's own
+// While the pointer rests on a card — or on a session header row and its buttons (T285) — the board
+// must not move under it: incoming feed payloads QUEUE (newest wins — intermediate states were never
+// on screen, so nothing owes them an animation) instead of rendering, and the deferred churn shows
+// as a subtle +N/-N beside the column pills and, in grouped mode, the session headers. Only the PAYLOAD path defers: the hovered card's own
 // controls and every local gesture still render live from the displayed model. Flush is event-based
 // (repo rule, no timers): the hovered card's mouseleave applies everything at once — a card CLEARED
 // under the pointer flushes too, via its synthetic mouseleave — and window blur is the backstop.


### PR DESCRIPTION
While the pointer rests on a card, the feed queues incoming payloads instead of moving the board under it (hover-freeze, the click-safety rule). The grouped session header row, with its name, fold caret and Clear all, had no such hold: a push while hovering Clear all rebuilt the row under the pointer and the click landed on the wrong thing or nothing.

The header row now enters and leaves the same gate a card holds, keyed by the session it stands for (read from its `data-fsid` stamp at event time, since grouped mode re-homes and re-stamps headers across renders); entering its buttons is entering the row. The stale-freeze heal reads a hovered header as pointer truth too. The payload path is unchanged: while any key holds the gate the payload is queued and the existing +N/-N badges beside the headers say so; mouseleave flushes and renders the newest payload.

Pinned in `ui/webview/feed-freeze.test.ts`: the header wiring, the single gate (a push during header hover is queued, so the row is never rebuilt), the release path (mouseleave → flush → apply), and the heal selector. Node suite green; full Python suite in a transient scope.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
