### PR TITLE
T283b: the timeline's inlined views menu renders each tag as its chip acting as a toggle

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -382,6 +382,15 @@ const menuCheckStyleFor = (p) => 'position:absolute;right:6px;top:50%;transform:
   + 'background:' + p.accentSolid + ';color:#fff;border-radius:50%;width:13px;height:13px;font-size:9px;'
   + 'font-weight:900;display:inline-flex;align-items:center;justify-content:center;line-height:1;';
 let MENU_STYLE = null, MENU_CHECK_STYLE = null;   // set by applyPal() below (dark by default)
+// THE TAG CHIP in the views menu (T283b, the user 2026-09-09: menus wear one vocabulary): the shared tag-lens
+// menu renders each tag as the tag chip itself acting as a toggle (ui/webview/tag-menu.ts tagChip + T283's
+// loop); this pane inlines the RESOLVED twin, since it may live in a foreign document that loads no module.
+// TAG_CHIP_STYLE is tagChip's pill byte for byte up to the colour (a drift test compares); the fade is the
+// shared TAG_CHIP_OFF_OPACITY, and the class names the state for a host that does load the sheets.
+const TAG_CHIP_STYLE = 'display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;font-size:0.82em;border:1px solid ';
+const TAG_CHIP_OFF_OPACITY = '0.45';
+const TAG_CHIP_OFF_CLASS = 'tag-chip-off';
+const TAG_CHIP_ROW_STYLE = 'padding:3px 8px;border-radius:4px;cursor:pointer;white-space:nowrap;display:flex;align-items:center;';
 // Judging band: a compact second timeline UNDER the session lanes, on the SAME axis — one row per
 // summarizer judge (docs/judges.md). Each mark is FILLED with the colour of the SESSION it acted on and
 // OUTLINED in the judge's OWN colour (so a bar reads as "judge X on session Y"). Fed by
@@ -3969,19 +3978,35 @@ class TimelinePanel {
     menu.setAttribute('style', 'position:fixed;z-index:1001;min-width:200px;' + MENU_STYLE);
     menu.dataset.rompMenu = '1';   // the echo writers skip in-menu presses (T213)
     menu.addEventListener('click', (e) => e.stopPropagation());
+    // a plain row (All, (no tags), Configure tags…): the label, the ✓ when current. The tags are not rows any
+    // more but CHIPS (tagRow below, T283b), so the colour dot the tag rows wore is gone, as in the shared menu
     const item = (label, opts) => {
       const row = menu.createDiv();
       row.setAttribute('style', 'padding:4px 22px 4px 8px;border-radius:4px;cursor:pointer;position:relative;white-space:nowrap;'
         + (opts && opts.dim ? 'opacity:0.85;' : ''));
-      if (opts && opts.dot) {
-        const d = row.createSpan();
-        d.setAttribute('style', 'display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:7px;background:' + opts.dot + ';');
-      }
       row.appendChild(document.createTextNode(label));
       if (opts && opts.current) {
         const c = row.createSpan({ text: '✓' });
         c.setAttribute('style', MENU_CHECK_STYLE);
       }
+      row.addEventListener('mouseenter', () => { row.style.background = HOVER_BG; });
+      row.addEventListener('mouseleave', () => { row.style.background = 'transparent'; });
+      return row;
+    };
+    // one tag per line, the chip at the left: the chip IS the toggle (aria-pressed), full colour when selected,
+    // faded when not, its colour kept — the pill tagChip builds for every other surface, resolved here (T283b).
+    // The uncoloured fallback is the palette's muted text, the theme token's resolved value (MODEL_FG).
+    const tagRow = (name, color, on) => {
+      const row = menu.createDiv();
+      row.setAttribute('style', TAG_CHIP_ROW_STYLE);
+      const col = color || MODEL_FG;
+      const chip = row.createSpan({ text: name });
+      chip.setAttribute('style', TAG_CHIP_STYLE + col + ';color:' + col + ';background:transparent;white-space:nowrap;'
+        + (on ? '' : 'opacity:' + TAG_CHIP_OFF_OPACITY + ';'));
+      if (!on) chip.classList.add(TAG_CHIP_OFF_CLASS);
+      chip.setAttribute('role', 'button');
+      chip.setAttribute('aria-pressed', on ? 'true' : 'false');
+      chip.setAttribute('title', on ? 'selected \u2014 click to drop it from the filter' : 'click to add it to the filter');
       row.addEventListener('mouseenter', () => { row.style.background = HOVER_BG; });
       row.addEventListener('mouseleave', () => { row.style.background = 'transparent'; });
       return row;
@@ -4014,7 +4039,7 @@ class TimelinePanel {
       item('(no tags)', { current: !lensAll(lens) && !!lens.none })
         .addEventListener('click', () => apply(lensToggle(lens, 'none'), false));
       for (const g of viewTagUnion(v))
-        item(g.name, { dot: g.color || MODEL_FG, current: !lensAll(lens) && (lens.tags || []).indexOf(g.name) >= 0 })
+        tagRow(g.name, g.color, !lensAll(lens) && (lens.tags || []).indexOf(g.name) >= 0)
           .addEventListener('click', () => apply(lensToggle(lens, { tag: g.name }), false));
       sep();
       item('Configure tags…', { dim: true }).addEventListener('click', () => {

--- a/ui/timeline-kernel-post.test.ts
+++ b/ui/timeline-kernel-post.test.ts
@@ -451,8 +451,12 @@ const sess = (id: string, name: string, color: string) => ({
   id, name, color, state: "working", live: true, model: "Opus", effort: "high",
   context: 40, since: 1_781_000_000 - 60, awaiting: [], compacting: [], pendingMail: 0, compactions: [], faded: false, stale: false,
 });
+// the harness's textContent already walks a node's children, so a tag row reads as its CHIP's text (since
+// T283b the text lives on the chip span, the shared menu's shape); a tag row's selected state is the chip's
+// aria-pressed, a plain row's the trailing ✓
 const rows = (menu: any) => menu.children.map((c: any) => c.textContent as string);
 const rowNamed = (menu: any, label: string) => menu.children.find((c: any) => c.textContent === label || c.textContent === label + "✓");
+const selected = (row: any) => !!row && ((row.children || []).some((c: any) => c._attrs && c._attrs["aria-pressed"] === "true") || String(row.textContent).endsWith("✓"));
 
 test("executed: the Filter menu shows a refused lens write's reason, keeps an unsaved filter and says so, and clears the note once a kernel takes one (review find, 2026-09-08)", async () => {
   await withDom(() => asObsidian({}, async () => {
@@ -479,14 +483,14 @@ test("executed: the Filter menu shows a refused lens write's reason, keeps an un
     assert.equal(p._viewsMenu, menu, "the menu stayed open (a settings panel, not a command)");
     assert.ok(rows(menu).some((t: string) => t === "⚠ " + err + "✕"), "the refusal's reason, with ✕, in the menu: " + JSON.stringify(rows(menu)));
     assert.deepEqual([p._pendingViews, p._localLens], [null, null], "refused: nothing kept");
-    assert.ok(rowNamed(menu, "web") && !rowNamed(menu, "web").textContent.endsWith("✓"), "the row reads unselected again");
+    assert.ok(rowNamed(menu, "web") && !selected(rowNamed(menu, "web")), "the row reads unselected again");
     p._tagEditErr = null; menu._build();
 
     // NO kernel takes it: the filter stays applied, and the menu says it is not saved and why
     answers.push({ ok: false, unreachable: true, error: KERNEL_DOWN });
     rowNamed(menu, "web")._listeners.click();
     await tick();
-    assert.ok(rowNamed(menu, "web").textContent.endsWith("✓"), "the filter is on: " + JSON.stringify(rows(menu)));
+    assert.ok(selected(rowNamed(menu, "web")), "the filter is on: " + JSON.stringify(rows(menu)));
     assert.deepEqual(timelineLens(p._curViews()).tags, ["web"], "…and applies to the lanes");
     assert.ok(rows(menu).includes("⚠ this filter is not saved — " + KERNEL_DOWN), "the not-saved note, with the reason: " + JSON.stringify(rows(menu)));
     assert.equal(p._tagEditErr, null, "not an error: the viewer's own filter, just unsaved");
@@ -822,7 +826,7 @@ test("executed: the not-saved note is reconciled on the store read: a poll that 
     assert.equal(p._takeViews(saved), true);
     assert.equal(p._localLens, null, "nothing held: the store has it");
     assert.ok(!rows(menu).some((t: string) => t.startsWith("⚠")), "the note went with it: " + JSON.stringify(rows(menu)));
-    assert.ok(rowNamed(menu, "web").textContent.endsWith("✓"), "the filter shows, as the store's now");
+    assert.ok(selected(rowNamed(menu, "web")), "the filter shows, as the store's now");
     assert.deepEqual(timelineLens(p._curViews()).tags, ["web"]);
     p._closeViewsMenu();
   }));

--- a/ui/timeline-tag-chips.test.ts
+++ b/ui/timeline-tag-chips.test.ts
@@ -1,0 +1,146 @@
+// THE TIMELINE'S VIEWS MENU RENDERS EACH TAG AS ITS CHIP ACTING AS A TOGGLE (T283b, the user 2026-09-09: menus wear
+// one vocabulary): the shared tag-lens menu (ui/webview/tag-menu.ts, T283) made each union tag the tag chip itself,
+// aria-pressed on the chip, selected = full colour, unselected = faded at 0.45 with its colour kept, one tag per line
+// with the chip at the left, All and (no tags) keeping the ✓ row grammar. This pane inlines its own copy of that
+// menu (it may live in Obsidian's document and loads no module), so the copy mirrors the chips with the RESOLVED
+// palette values it already carries. Executed over the house three-helper host (the tagbtn-click harness), plus
+// drift pins between the two menus' chip and row shapes. Synthetic sessions and tags only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+function makeNode(tag: string): any {
+  const n: any = {
+    tag, _attrs: {}, children: [] as any[], style: {}, dataset: {}, textContent: "", parentNode: null,
+    classList: { _s: new Set<string>(), add(...a: string[]) { a.forEach((c) => this._s.add(c)); },
+      remove(...a: string[]) { a.forEach((c) => this._s.delete(c)); },
+      toggle(c: string, f?: boolean) { f ? this._s.add(c) : this._s.delete(c); }, contains(c: string) { return this._s.has(c); } },
+    setAttribute(k: string, v: any) { this._attrs[k] = v; }, getAttribute(k: string) { return k in this._attrs ? this._attrs[k] : null; },
+    setAttributeNS(_n: any, k: string, v: any) { this._attrs[k] = v; }, removeAttribute(k: string) { delete this._attrs[k]; },
+    appendChild(c: any) { if (c.parentNode) { const i = c.parentNode.children.indexOf(c); if (i >= 0) c.parentNode.children.splice(i, 1); } c.parentNode = n; this.children.push(c); return c; },
+    insertBefore(c: any, ref: any) { c.parentNode = n; const i = this.children.indexOf(ref); i < 0 ? this.children.push(c) : this.children.splice(i, 0, c); return c; },
+    removeChild(c: any) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); return c; },
+    get firstChild() { return this.children[0] || null; },
+    remove() { if (n.parentNode) n.parentNode.removeChild(n); },
+    _listeners: {} as any,
+    addEventListener(t: string, fn: any) { n._listeners[t] = fn; }, removeEventListener() {},
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    getBoundingClientRect() { return { width: 32, height: 18, left: 8, top: 400, right: 40, bottom: 418 }; },
+    closest() { return null; }, focus() {},
+    createEl(t: string, o: any) { const e = makeNode(t); if (o && o.cls) e.classList.add(o.cls); if (o && o.text) e.textContent = o.text; this.appendChild(e); return e; },
+    createDiv(o: any) { return this.createEl("div", o); }, createSpan(o: any) { return this.createEl("span", o); },
+  };
+  return n;
+}
+const g: any = global;
+g.document = {
+  createElement(t: string) { return t === "canvas" ? { getContext() { return { font: "", measureText(s: string) { return { width: (s ? s.length : 0) * 6 }; } }; } } : makeNode(t); },
+  createElementNS(_n: any, t: string) { return makeNode(t); },
+  createTextNode(text: string) { const n = makeNode("#text"); n.textContent = text; return n; },
+  body: makeNode("body"), documentElement: makeNode("html"), head: makeNode("head"),
+  getElementById() { return null; }, addEventListener() {}, removeEventListener() {},
+};
+g.localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} };
+g.getComputedStyle = () => ({ backgroundColor: "rgb(30,30,30)" });
+g.requestAnimationFrame = () => 0;
+g.addEventListener = () => {}; g.removeEventListener = () => {};
+g.matchMedia = () => ({ matches: false, addEventListener() {}, addListener() {} });
+g.window = g; g.innerWidth = 1400; g.innerHeight = 800;
+
+const viewPath = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
+const { TimelinePanel } = createRequire(__filename)(viewPath);
+const SRC = fs.readFileSync(viewPath, "utf8");
+const MENU = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "tag-menu.ts"), "utf8");
+
+const TAGS = [{ id: "g1", name: "infra", color: "#DD42FF", members: ["s2"] }, { id: "g2", name: "qa", color: "#3355aa", members: ["s1"] }];
+function panelWith(lens: any): any {
+  const now = 1_781_000_000;
+  const sess = (id: string, name: string, color: string) => ({ id, name, color, state: "working", live: true, model: "Opus", effort: "high",
+    context: 40, since: now - 60, awaiting: [], compacting: [], pendingMail: 0, compactions: [], faded: false, stale: false });
+  const panel = new TimelinePanel(makeNode("div"));
+  panel.update({ now, sessions: [sess("s1", "web", "#f7768e"), sess("s2", "api", "#7aa2f7")],
+    turns: { s1: [{ id: "t1", start: now - 400, end: now - 100, prompt: "do the thing", mids: [] }] }, messages: [], judging: {},
+    views: { active: "all", tags: TAGS, actives: { timeline: lens } } });
+  return panel;
+}
+const openMenu = (panel: any) => { panel._openViewsMenu(makeNode("button")); return panel._viewsMenu; };
+const rows = (menu: any) => menu.children.filter((c: any) => c.tag === "div");
+const text = (n: any): string => (n.tag === "#text" ? n.textContent : (n.textContent || "")) + (n.children || []).map(text).join("");
+const chipOf = (row: any) => (row.children || []).find((c: any) => c.tag === "span" && "aria-pressed" in c._attrs);
+const hasCheck = (row: any) => (row.children || []).some((c: any) => c.tag === "span" && c.textContent === "✓");
+
+test("executed: each tag is its own chip acting as a toggle, the selected one full colour, the other faded with its colour kept", () => {
+  const panel = panelWith({ tags: ["infra"] });
+  const menu = openMenu(panel);
+  const r = rows(menu);
+  assert.equal(text(r[0]), "All"); assert.equal(text(r[1]), "(no tags)");
+  const infra = chipOf(r[2]), qa = chipOf(r[3]);
+  assert.ok(infra && qa, "the two tags render as chips, one per row, after All and (no tags)");
+  assert.equal(infra.textContent, "infra"); assert.equal(qa.textContent, "qa");
+  assert.equal(infra._attrs["aria-pressed"], "true"); assert.equal(infra._attrs.role, "button");
+  assert.doesNotMatch(infra._attrs.style, /opacity/, "a selected chip stands at full opacity");
+  assert.equal(infra.classList.contains("tag-chip-off"), false);
+  assert.match(infra._attrs.style, /border:1px solid #DD42FF;color:#DD42FF;/, "the chip keeps the tag's own colour");
+  assert.equal(qa._attrs["aria-pressed"], "false");
+  assert.equal(qa.classList.contains("tag-chip-off"), true, "an unselected chip wears the faded class");
+  assert.match(qa._attrs.style, /opacity:0\.45;/, "…and paints the same fade inline: this host loads no sheet");
+  assert.match(qa._attrs.style, /border:1px solid #3355aa;color:#3355aa;/, "faded, not recoloured");
+  for (const row of [r[2], r[3]]) assert.equal(hasCheck(row), false, "the tag rows carry no ✓: the chip's state IS the mark");
+  assert.match(r[2]._attrs.style, /^padding:3px 8px;border-radius:4px;cursor:pointer;white-space:nowrap;display:flex;align-items:center;$/, "the chip row's shape");
+  panel._closeViewsMenu();
+});
+
+test("executed: All and (no tags) keep the row grammar with the ✓; an uncoloured tag falls back to the palette's muted text", () => {
+  const panel = panelWith({ none: true, tags: ["infra"] });
+  panel.update(Object.assign({}, panel.data, { views: { active: "all", tags: TAGS.concat([{ id: "g3", name: "plain", color: null, members: [] }]),
+    actives: { timeline: { none: true, tags: ["infra"] } } } }));
+  const menu = openMenu(panel);
+  const r = rows(menu);
+  assert.equal(hasCheck(r[1]), true, "(no tags) selected → its ✓");
+  assert.equal(hasCheck(r[0]), false, "All not selected → no ✓");
+  const plain = chipOf(r[4]);
+  assert.ok(plain, "the uncoloured tag is a chip too");
+  assert.match(plain._attrs.style, /border:1px solid #9aa0a6;color:#9aa0a6;/, "the dark palette's muted text, resolved (no var() in this host)");
+  panel._closeViewsMenu();
+});
+
+test("executed: clicking a chip's row toggles that tag, the menu stays open and repaints in place", () => {
+  const panel = panelWith({ tags: ["infra"] });
+  const applied: any[] = [];
+  panel._setLens = (blob: any) => { applied.push(blob); panel.data.views.actives = blob.actives; };
+  const menu = openMenu(panel);
+  const before = rows(menu).length;
+  rows(menu)[3]._listeners.click();          // qa: off → on
+  assert.deepEqual(applied[0].actives.timeline.tags, ["infra", "qa"]); assert.ok(!applied[0].actives.timeline.none);
+  assert.equal(panel._viewsMenu, menu, "the menu stayed open");
+  assert.equal(rows(menu).length, before, "repainted in place: the same rows");
+  assert.equal(chipOf(rows(menu)[3])._attrs["aria-pressed"], "true", "the chip now reads selected");
+  assert.equal(chipOf(rows(menu)[3]).classList.contains("tag-chip-off"), false);
+  rows(menu)[2]._listeners.click();          // infra: on → off
+  assert.equal(chipOf(rows(menu)[2])._attrs["aria-pressed"], "false");
+  assert.equal(chipOf(rows(menu)[2]).classList.contains("tag-chip-off"), true);
+  panel._closeViewsMenu();
+});
+
+test("drift pins: the inlined chip is the shared tagChip's pill up to the colour, and the fade and row shape match the shared menu", () => {
+  const chipStyle = /const TAG_CHIP_STYLE = '([^']+)';/.exec(SRC)![1];
+  const shared = /chip\.setAttribute\("style", "([^"]+)"\s*\n\s*\+ "border-radius:9px;" \+ \(opts && opts\.inheritSize \? "" : "font-size:0\.82em;"\)\s*\n\s*\+ "border:1px solid "/.exec(MENU);
+  assert.ok(shared, "the shared tagChip's style is where the pin expects it");
+  assert.equal(chipStyle, shared![1] + "border-radius:9px;font-size:0.82em;border:1px solid ", "the pill, byte for byte up to the colour");
+  assert.match(SRC, /const TAG_CHIP_OFF_OPACITY = '0\.45';/);
+  assert.match(SRC, /const TAG_CHIP_OFF_CLASS = 'tag-chip-off';/);
+  // the shared menu's own constants and chip row, once its T283 change is on this branch (it lands separately);
+  // until then the values above are pinned to the numbers T283 chose
+  const off = /export const TAG_CHIP_OFF_OPACITY = "([^"]+)";/.exec(MENU);
+  if (off) assert.equal(off[1], "0.45", "the shared fade");
+  const cls = /export const TAG_CHIP_OFF_CLASS = "([^"]+)";/.exec(MENU);
+  if (cls) assert.equal(cls[1], "tag-chip-off", "the shared state class");
+  const row = /r\.setAttribute\("style", "(padding:3px 8px;[^"]+)"\);\s*\n\s*const chip = tagChip\(u\.name/.exec(MENU);
+  if (row) assert.equal(/const TAG_CHIP_ROW_STYLE = '([^']+)';/.exec(SRC)![1], row[1], "the chip row's shape");
+  // the shared tag rows never carried a dot after T283; this copy's plain rows carry none either
+  const views = SRC.slice(SRC.indexOf("  _openViewsMenu(anchorEl) {"), SRC.indexOf("  _openDisplayMenu(anchorEl) {"));
+  assert.doesNotMatch(views, /border-radius:50%/, "no colour dot in the views menu");
+  assert.match(views, /c\.setAttribute\('style', MENU_CHECK_STYLE\);/, "the ✓-in-circle stays for All and (no tags)");
+});

--- a/ui/timeline-tag-chips.test.ts
+++ b/ui/timeline-tag-chips.test.ts
@@ -131,14 +131,17 @@ test("drift pins: the inlined chip is the shared tagChip's pill up to the colour
   assert.equal(chipStyle, shared![1] + "border-radius:9px;font-size:0.82em;border:1px solid ", "the pill, byte for byte up to the colour");
   assert.match(SRC, /const TAG_CHIP_OFF_OPACITY = '0\.45';/);
   assert.match(SRC, /const TAG_CHIP_OFF_CLASS = 'tag-chip-off';/);
-  // the shared menu's own constants and chip row, once its T283 change is on this branch (it lands separately);
-  // until then the values above are pinned to the numbers T283 chose
+  // the shared menu's own constants and chip row (T283, on main): each pin fails LOUDLY when its anchor moves,
+  // never skips, so a reformat of the shared loop cannot leave a later padding or radius change uncaught
   const off = /export const TAG_CHIP_OFF_OPACITY = "([^"]+)";/.exec(MENU);
-  if (off) assert.equal(off[1], "0.45", "the shared fade");
+  assert.ok(off, "the shared fade constant is where the pin expects it");
+  assert.equal(off![1], "0.45", "the shared fade");
   const cls = /export const TAG_CHIP_OFF_CLASS = "([^"]+)";/.exec(MENU);
-  if (cls) assert.equal(cls[1], "tag-chip-off", "the shared state class");
-  const row = /r\.setAttribute\("style", "(padding:3px 8px;[^"]+)"\);\s*\n\s*const chip = tagChip\(u\.name/.exec(MENU);
-  if (row) assert.equal(/const TAG_CHIP_ROW_STYLE = '([^']+)';/.exec(SRC)![1], row[1], "the chip row's shape");
+  assert.ok(cls, "the shared state class is where the pin expects it");
+  assert.equal(cls![1], "tag-chip-off", "the shared state class");
+  const row = /r\.setAttribute\("style", "([^"]+)"\);\s*\n\s*const chip = tagChip\(u\.name/.exec(MENU);
+  assert.ok(row, "the shared chip row is where the pin expects it");
+  assert.equal(/const TAG_CHIP_ROW_STYLE = '([^']+)';/.exec(SRC)![1], row![1], "the chip row's shape");
   // the shared tag rows never carried a dot after T283; this copy's plain rows carry none either
   const views = SRC.slice(SRC.indexOf("  _openViewsMenu(anchorEl) {"), SRC.indexOf("  _openDisplayMenu(anchorEl) {"));
   assert.doesNotMatch(views, /border-radius:50%/, "no colour dot in the views menu");

--- a/ui/timeline-tag-chips.test.ts
+++ b/ui/timeline-tag-chips.test.ts
@@ -54,7 +54,7 @@ const { TimelinePanel } = createRequire(__filename)(viewPath);
 const SRC = fs.readFileSync(viewPath, "utf8");
 const MENU = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "tag-menu.ts"), "utf8");
 
-const TAGS = [{ id: "g1", name: "infra", color: "#DD42FF", members: ["s2"] }, { id: "g2", name: "qa", color: "#3355aa", members: ["s1"] }];
+const TAGS: any[] = [{ id: "g1", name: "infra", color: "#DD42FF", members: ["s2"] }, { id: "g2", name: "qa", color: "#3355aa", members: ["s1"] }];
 function panelWith(lens: any): any {
   const now = 1_781_000_000;
   const sess = (id: string, name: string, color: string) => ({ id, name, color, state: "working", live: true, model: "Opus", effort: "high",

--- a/ui/webview/tag-menu.ts
+++ b/ui/webview/tag-menu.ts
@@ -1,8 +1,8 @@
 // The SHARED tag-lens menu (the user 2026-08-25): one component every webview surface mounts —
 // the outline pane, the chat tab strip, the feed's local filter. (The timeline inlines its OWN copy
-// of this menu in MENU_STYLE, since it may live in Obsidian's document and loads no modules; that
-// copy still draws each tag as a colour-dot row with a ✓, not as the chips below — T283 changed the
-// shared component only, the timeline's mirror is its own follow-up.) The menu is
+// of this menu in MENU_STYLE, since it may live in Obsidian's document and loads no modules; since
+// T283b that copy builds the same chip rows from its palette's RESOLVED values — tagRow / TAG_CHIP_STYLE in
+// ui/romp-timeline-view.js — and ui/timeline-tag-chips.test.ts pins the drift between the two.) The menu is
 // multi-select toggles on ONE surface's lens: All a plain exclusive pick, (no tags) toggling with
 // the ✓ when selected, and every name-keyed union tag as ITS OWN CHIP acting as a toggle button
 // (the user 2026-09-09, T283: the pill every surface already wears, one tag per line with the chip


### PR DESCRIPTION
The timeline's inlined views menu renders each tag as its chip acting as a toggle, mirroring the shared tag-lens menu.

Tier: feature

## Why
The shared tag-lens menu (feed, chat, outline) made each union tag the tag chip itself acting as a toggle: selected at full colour with `aria-pressed="true"`, unselected faded at 0.45 with its colour kept, one tag per line with the chip at the left, All and "(no tags)" keeping the ✓ row grammar, the group switch and "Configure tags…" unchanged. The timeline pane inlines its own copy of that menu, because it may live in Obsidian's document and loads no module, and that copy still drew colour-dot rows with a ✓, so the menus no longer wore one vocabulary (the user's rule).

## What changed
`ui/romp-timeline-view.js`, `_openViewsMenu`:
- A `tagRow` builds each tag as a chip span with the shared `tagChip` pill's resolved styles, byte for byte up to the colour (`TAG_CHIP_STYLE`: inline-flex, gap 5px, padding 2px 7px, radius 9px, font-size 0.82em, a 1px border and text in the tag's colour, transparent background), `role="button"`, `aria-pressed`, a title saying what a click does. Unselected: `opacity:0.45` inline (this host loads no sheet) and the `tag-chip-off` class (for a host that does). The uncoloured fallback is the palette's muted text, the theme token's resolved value (`MODEL_FG`), so no `var()` is read. The row wears the shared chip row's shape (padding 3px 8px, flex, centred) and the menu's hover wash; the menu stays open across toggles and repaints in place, as before.
- The plain row helper (All, "(no tags)", "Configure tags…") lost its colour-dot option; the ✓-in-circle mark from `MENU_CHECK_STYLE` stays for those rows. `MENU_STYLE`, `PAL_DARK` and `PAL_LIGHT` are untouched; the menu card already declares its font family, which the chips inherit.

## Tests
- `ui/timeline-tag-chips.test.ts` (new): executes `_openViewsMenu` under the three-helper host the tag-button test uses. The two tags render as chips after All and "(no tags)"; the selected one carries `aria-pressed="true"`, `role="button"`, full opacity and its colour; the other carries `aria-pressed="false"`, the off class and `opacity:0.45` with its colour kept; no ✓ on tag rows; an uncoloured tag falls back to the palette's muted text; clicking a chip's row toggles it, the menu stays open and repaints in place. Drift pins: the inlined pill equals the shared `tagChip`'s style up to the colour; the fade, the class and the chip row equal the shared menu's constants (the shared T283 change merged while this was open; the branch carries upstream main, and each pin fails loudly when its anchor moves rather than skipping).
- `ui/timeline-kernel-post.test.ts`: a tag row's selected state reads from the chip's pressed attribute rather than a trailing ✓.
- Extension suite: 3663 passed with upstream main merged in; typecheck clean. Python untouched.
- `ui/webview/tag-menu.ts`: its header no longer calls the timeline's mirror a follow-up.

## Screenshots
`~/romp-shots/t283b/`: `views-menu-dark.png` (all tags unselected), `views-menu-dark-selected.png` (one chip pressed on its hover-washed row), `views-menu-light.png` (the cream card, dark text, one chip pressed). Taken against the kernel-served timeline page with this branch's view swapped into the page response; the kernel and the live filter were not touched (the pressed state came from a lens write the capture answered with a refusal).

## Review (two lenses, two skeptics per finding)
Confirmed and folded: the drift pins were conditional on the shared change being present and would have gone silently dead once it merged (they are loud now, with the row anchor capturing the whole style); the shared menu's header still described the timeline copy as dot rows and a follow-up (rewritten). Refuted as pre-existing: a theme flip followed by opening the menu before the next repaint uses the previous palette for the card and the uncoloured fallback alike, a window the kernel-served page closes through its storage listener and this change did not widen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
