### PR TITLE
Cleared ledger follow-ups: journal-order replay for same-second rows, and the viewer's ledger over remote rows

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3799,6 +3799,14 @@ def _replay_overrides(fsid, store, lines=None):
             return False
     applied = False                                    # any write → load_goals re-runs rollup (one truth)
     arch_nodes = None                                  # the archive is read once, only if a restore entry needs it
+    last_seal = {}                                     # node -> the LAST clear/unclear row's op, in journal order: a
+    for ln in lines:                                   # clear, undo and clear inside one second are settled by the rows'
+        try:                                           # order, not by their integer seconds (review find, 2026-09-09)
+            ev0 = json.loads(ln)
+        except ValueError:
+            continue
+        if ev0.get("op") in ("clear", "unclear") and ev0.get("node"):
+            last_seal[ev0["node"]] = ev0["op"]
     for ln in lines:
         try:
             ev = json.loads(ln)
@@ -3880,9 +3888,9 @@ def _replay_overrides(fsid, store, lines=None):
             # reopen (e.g. the card reply seconds after the restore) must NOT eat it, so `later` is
             # deliberately not consulted. was_done mirrors _mark_nodes_cleared: re-settle a completed
             # top so the restored card returns to Completed, not Working.
-            if _twin("reopen", undo=True) or any(e.get("kind") == "clear"
-                                                 and int(e.get("ev_t") or 0) > t for e in uev):
-                continue                               # survived, or re-dismissed since
+            if _twin("reopen", undo=True) or last_seal.get(ev.get("node")) == "clear" or any(
+                    e.get("kind") == "clear" and int(e.get("ev_t") or 0) > t for e in uev):
+                continue                               # survived, re-dismissed by a LATER row (journal order, 2026-09-09), or since
             was_done = nd.get("parentId") is None and (
                 store.get("status", {}).get(ev.get("node")) == "completed" or nd.get("nodeComplete"))
             if record_verdict(store, nd, "user", "reopen", t, why="undo clear", undo=True):
@@ -3894,12 +3902,11 @@ def _replay_overrides(fsid, store, lines=None):
             # save clobbered re-seals exactly as the live one did (2026-09-09; the unclear arm's mirror).
             # Voided by a LATER undo: a strictly-later user reopen (the undo-clear's own verdict, or its
             # replayed "unclear" row) outranks this entry; the twin check keeps the survived write as is.
-            if nd.get("cleared") or _twin("clear") or any(e.get("kind") == "reopen"
-                                                          and int(e.get("ev_t") or 0) >= t for e in uev):
-                continue                               # sealed already, survived, or undone at or after it (an undo in
-                #                                        the clear's own second is the later gesture: the ledger's undo
-                #                                        row follows its clear row, so at-or-after voids, unlike the
-                #                                        unclear arm, where a later clear is the only voider)
+            if nd.get("cleared") or _twin("clear") or last_seal.get(ev.get("node")) != "clear" \
+                    or any(e.get("kind") == "reopen" and int(e.get("ev_t") or 0) > t for e in uev):
+                continue                               # sealed already, survived, undone by a LATER row (the undo's
+                #                                        unclear row follows its clear row in the journal, whatever the
+                #                                        seconds say), or reopened strictly later by another gesture
             if record_verdict(store, nd, ev.get("src") or "user", "clear", t,
                               why=ev.get("why") or "cleared from the feed"):
                 applied = True

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -30714,6 +30714,23 @@ _CLEARED_STATS = {"served": 0, "derived": 0}   # bumped from the pusher AND sock
 #                                                no lock: a lost count under a race is tolerated, these are diagnostics only
 
 
+def _cleared_foreign(cleared):
+    """The ledger's ids that belong to no local session: no goal store and no archive here for the id's sid. A
+    merged board routes a card's gestures to the owning kernel by id, but a viewer's ledger can still hold a
+    remote card's clear (a gesture taken while the owner was unreachable, a ledger copied between machines,
+    an older client), and the owning kernel's archive projection reads only its own ledger; so the viewer's
+    feed payload carries these for the client to apply over remote rows (federation.ts mergeHostFeeds).
+    Small in practice (a viewer clears few foreign cards); capped so a stray ledger cannot swell the frame.
+    One directory listing per build for the local sid set, the same cost class as the ledger read."""
+    local = set()
+    for d in (jd.GOALDIR, jd.GOALARCHDIR):
+        try:
+            local.update(n[:-5] for n in os.listdir(d) if n.endswith(".json"))
+        except OSError:
+            pass
+    return sorted(i for i in cleared if i.rsplit(":", 1)[0] not in local)[:500]
+
+
 def _cleared_ids():
     """The set of currently-cleared feed itemIds (asks + stream), replayed from the append-only
     cleared.jsonl: a 'clear' row adds an id, an 'undo' row removes it (newest-wins). Mirrors the old
@@ -33099,6 +33116,10 @@ def build_feed(now, tmux=None):
             # _bg_split) → the grouped-mode session header's neutral chip, never a waiting state (2026-07-24)
             "bgServices": bg_services,
             "dismissedCount": len(cleared), "showDismissed": False,
+            # the ledger's ids that belong to no session of THIS kernel (review find, 2026-09-09): clears this
+            # kernel took for cards another kernel owns; the merged board applies them over that host's rows
+            # (federation.ts mergeHostFeeds), since a remote kernel's projection reads only its own ledger
+            "clearedForeign": _cleared_foreign(cleared),
             # the shared session order (session-order.json — the tab/lane order): grouped mode sorts each
             # column's session runs by it (the user 2026-07-13); federation prefixes + concatenates per host
             "order": _session_order(),

--- a/tests/test_kernel_goal_compaction.py
+++ b/tests/test_kernel_goal_compaction.py
@@ -264,6 +264,45 @@ class ClearedLedgerIsAuthoritativeAcrossTheCompaction(unittest.TestCase):
         jd._shared_clear()
         self.assertFalse(jd.load_goals(SID)["nodes"][self.g("g6")].get("cleared"), "...and it stays undone on a reload")
 
+    def test_clear_undo_clear_inside_one_second_replays_to_the_last_row(self):
+        # the review find (2026-09-09): the arms compared integer seconds, so three gestures in one second
+        # left the LAST clear skipped on replay; the journal's row order decides now
+        self._completed_top("g7")
+        snapshot = json.loads((jd.GOALDIR / (SID + ".json")).read_text())
+        km._clear_all([self.g("g7")])
+        km._undo_clear()
+        km._clear_all([self.g("g7")])
+        rows = [json.loads(l)["op"] for l in (jd._overrides_dir() / (SID + ".jsonl")).read_text().splitlines()]
+        self.assertEqual([r for r in rows if r in ("clear", "unclear")], ["clear", "unclear", "clear"])
+        self._clobber_with(snapshot)
+        self.assertTrue(jd.load_goals(SID)["nodes"][self.g("g7")].get("cleared"), "the last row, a clear, wins")
+        # and the mirror: clear then undo in the same second ends unsealed
+        self._completed_top("g8")
+        snapshot = json.loads((jd.GOALDIR / (SID + ".json")).read_text())
+        km._clear_all([self.g("g8")])
+        km._undo_clear()
+        self._clobber_with(snapshot)
+        self.assertFalse(jd.load_goals(SID)["nodes"][self.g("g8")].get("cleared"), "the last row, an undo, wins")
+
+    def test_the_feed_payload_carries_the_ledgers_foreign_ids_for_the_merged_board(self):
+        # the viewer's ledger over remote rows (review find, 2026-09-09): ids the local ledger clears whose
+        # session has no store and no archive here ride the payload, bare, for the client merge to apply
+        # over that host's rows; local ids stay off it (the local kernel applied them itself); capped
+        self._completed_top("g4")
+        foreign_sid = "11111111-2222-3333-4444-999999999909"
+        with (jd.STATE / "cleared.jsonl").open("a") as f:
+            f.write(json.dumps({"id": self.g("g4"), "t": 200, "op": "clear"}) + "\n")
+            f.write(json.dumps({"id": foreign_sid + ":g1", "t": 201, "op": "clear"}) + "\n")
+            f.write(json.dumps({"id": foreign_sid + ":g2", "t": 202, "op": "clear"}) + "\n")
+            f.write(json.dumps({"id": foreign_sid + ":g2", "t": 203, "op": "undo"}) + "\n")
+        km._CLEARED_MEMO["slot"] = None
+        self.assertEqual(km._cleared_foreign(km._cleared_ids()), [foreign_sid + ":g1"],
+                         "the foreign clear rides; the local one and the undone one do not")
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn('"clearedForeign": _cleared_foreign(cleared),', src, "on the feed payload beside dismissedCount")
+        many = {"%s:g%d" % (foreign_sid, i): i for i in range(700)}
+        self.assertEqual(len(km._cleared_foreign(many)), 500, "capped")
+
     def test_the_compaction_stamps_a_root_only_the_ledger_clears(self):
         self._completed_top("g4")
         with (jd.STATE / "cleared.jsonl").open("a") as f:                  # the ledger alone: no flag, no journal

--- a/ui/webview/federation-cleared-overlay.test.ts
+++ b/ui/webview/federation-cleared-overlay.test.ts
@@ -1,0 +1,56 @@
+// The viewer's ledger over remote rows (review find, 2026-09-09): a remote kernel's feed and archive projection read
+// only their own cleared.jsonl, so an id the LOCAL ledger clears for a remote card (clearedForeign on the local
+// payload, bare) must drop that remote ask/item and read that remote archived top cleared, subtree with it, while
+// local rows and untouched remote rows pass through exactly as before. Same harness as feed-clock-anchor.test.ts.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { mergeHostFeeds, applyViewerClears } from "./federation";
+
+const SID = "11111111-2222-3333-4444-555555555555";
+const A = "HOSTA:" + SID;
+
+function remoteFeed() {
+  return {
+    type: "feed", now: 100,
+    asks: [{ itemId: A + ":g1", sid: A }, { itemId: A + ":g2", sid: A }],
+    items: [{ itemId: A + ":g9", sid: A }],
+    ledgers: [{ sid: A, name: "HOSTA:api", ledger: { tree: [], archivedTops: [
+      { id: A + ":g1", depth: 0, cleared: false, done: true },
+      { id: A + ":g1a", depth: 1, cleared: false, done: true },
+      { id: A + ":g3", depth: 0, cleared: false, done: true },
+      { id: A + ":g3a", depth: 1, cleared: false, done: true },
+    ] } }],
+  };
+}
+
+test("a foreign clear on the local payload drops the remote ask and reads the remote archived top cleared, subtree with it", () => {
+  const local = { type: "feed", now: 7, asks: [{ itemId: SID + ":g1", sid: SID }], ledgers: [], clearedForeign: [SID + ":g1", SID + ":g9"] };
+  const remote = remoteFeed();
+  const merged = mergeHostFeeds({ "": local, HOSTA: remote }, ["", "HOSTA"]);
+  assert.deepEqual(merged.asks.map((a: any) => a.itemId), [SID + ":g1", A + ":g2"], "the remote g1 ask is gone; the LOCAL g1 stays (the local kernel already applied its ledger)");
+  assert.deepEqual(merged.items.map((c: any) => c.itemId), [], "the remote item is gone");
+  const tops = merged.ledgers.find((l: any) => l.sid === A).ledger.archivedTops;
+  assert.deepEqual(tops.map((n: any) => [n.id.split(":").pop(), n.cleared]),
+    [["g1", true], ["g1a", true], ["g3", false], ["g3a", false]], "g1 and its child read cleared; g3 untouched");
+  assert.equal(remote.ledgers[0].ledger.archivedTops[0].cleared, false, "the host payload's own rows are not mutated");
+  assert.equal(remote.asks.length, 2);
+});
+
+test("without foreign ids nothing changes, and a remote host with none named passes through", () => {
+  const remote = remoteFeed();
+  const merged = mergeHostFeeds({ "": { type: "feed", now: 7, asks: [], ledgers: [] }, HOSTA: remote }, ["", "HOSTA"]);
+  assert.equal(merged.asks.length, 2);
+  assert.deepEqual(merged.ledgers[0].ledger.archivedTops.map((n: any) => n.cleared), [false, false, false, false]);
+  const other = { type: "feed", now: 7, asks: [], ledgers: [], clearedForeign: [SID + ":zz"] };
+  const merged2 = mergeHostFeeds({ "": other, HOSTA: remoteFeed() }, ["", "HOSTA"]);
+  assert.equal(merged2.asks.length, 2, "an id that names nothing drops nothing");
+});
+
+test("the overlay is pure over the rows it is given and ignores junk ids", () => {
+  const merged: any = { asks: [{ itemId: A + ":g1" }], items: [] };
+  const ledgers = [{ sid: A, ledger: { tree: [], archivedTops: [{ id: A + ":g1", depth: 0, cleared: false }] } }];
+  applyViewerClears(merged, ledgers, [SID + ":g1", 42, null]);
+  assert.equal(merged.asks.length, 0);
+  assert.equal(ledgers[0].ledger.archivedTops[0].cleared, true);
+  applyViewerClears(merged, ledgers, undefined);   // no ids: a no-op
+});

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -375,6 +375,33 @@ export function mergeHostOrder(perHost: Record<string, readonly string[]>, hostS
  *  had been quiet. The pair comes from the LOCAL host's frame; with no local frame yet, from the newest
  *  remote arrival that carries a clock — the same host for both halves, so they always describe one frame.
  *  Absent `arrivedAt` (a caller with no wire), no `nowAt` is set and the pane anchors on its own arrival. */
+/** Apply the viewer's foreign cleared ids (bare, from the local payload) over REMOTE rows of a merged feed:
+ *  remote asks/items they name are dropped; remote archived tops they name read cleared, rolled down to the
+ *  subtree (the live tree's top-only cross-off). Rewrites `merged.asks`/`merged.items` and each remote ledger
+ *  entry's archivedTops with fresh row objects; the host payloads' own rows are not mutated. No-op without ids. */
+export function applyViewerClears(merged: any, ledgers: any[], clearedForeign: any): void {
+  const foreign = new Set<string>(Array.isArray(clearedForeign) ? clearedForeign.filter((x: any) => typeof x === "string") : []);
+  if (!foreign.size) return;
+  const hit = (id: any) => typeof id === "string" && hostOf(id) !== LOCAL && foreign.has(bareId(id));
+  merged.asks = merged.asks.filter((a: any) => !hit(a?.itemId));
+  merged.items = merged.items.filter((c: any) => !hit(c?.itemId));
+  ledgers.forEach((l: any, i: number) => {
+    if (!l || typeof l.sid !== "string" || hostOf(l.sid) === LOCAL) return;
+    const tops = l.ledger?.archivedTops;
+    if (!Array.isArray(tops) || !tops.length) return;
+    let rootCleared = false, changed = false;
+    const out = tops.map((n: any) => {
+      if (n?.depth === 0) rootCleared = !!n.cleared || hit(n.id);
+      const c = !!n?.cleared || hit(n?.id) || (n?.depth !== 0 && rootCleared);
+      if (c === !!n?.cleared) return n;
+      changed = true;
+      return { ...n, cleared: c };
+    });
+    // a fresh ENTRY too, never the host payload's own object: the merge pushed those by reference
+    if (changed) ledgers[i] = { ...l, ledger: { ...l.ledger, archivedTops: out } };
+  });
+}
+
 export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly string[],
                                view: readonly string[] = [], deadHosts: readonly string[] = [],
                                arrivedAt: Record<string, number> = {}): any {
@@ -440,6 +467,14 @@ export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly s
   // the grouped feed ranks its session runs off `order`, so it takes the viewer's arrangement like the tab
   // strip does — the two surfaces have to agree or the feed's groups and the tabs read in different orders.
   merged.order = applyViewOrder(merged.order, view);
+  // The VIEWER's ledger over remote rows (review find, 2026-09-09): a remote kernel's feed and its archive
+  // projection read only their own cleared.jsonl, and the local ledger can hold a remote card's clear (a
+  // gesture taken while the owner was unreachable, a ledger copied between machines, an older client). The
+  // local payload carries those ids (kernel: clearedForeign, bare); a remote ask or item they name is
+  // dropped, and a remote archived top they name reads cleared, its subtree with it, exactly as the owning
+  // kernel's own overlay would have read them. Local rows are untouched: the local kernel already applied
+  // its ledger to them.
+  applyViewerClears(merged, ledgers, local.clearedForeign);
   if (anyLedgers) merged.ledgers = ledgers;
   else delete merged.ledgers;
   if (anyDismissed) merged.dismissedCount = dismissed;


### PR DESCRIPTION
Tier: fix

## What

Two follow-ups from the review of the returned-cards fix.

1. **Same-second clear and undo rows replay in journal order.** The replay's clear and unclear arms compared integer seconds, so a clear, an undo and a clear inside one second left the last clear skipped on replay. A pre-scan of the override journal now records, per node, the last clear or unclear row in row order, and each arm defers to it: a clear row is void when a later unclear row exists for the node, an unclear row when a later clear row does; the strictly-later user-reopen guard on the clear arm stays as a second line. Pinned with the three-rows-in-one-second case in both directions.

2. **The viewer's ledger over remote rows.** A remote kernel's feed and its archive projection read only their own `cleared.jsonl`; the merged board's gestures route to the owning kernel by id, but a viewer's ledger can still hold a remote card's clear (a gesture taken while the owner was unreachable, a ledger copied between machines, an older client), and until now nothing applied it to that host's rows. The local feed payload carries `clearedForeign`: the ledger's ids whose session has no goal store and no archive on this kernel, bare, capped at 500; the client's `mergeHostFeeds` drops a remote ask or item they name and reads a remote archived top they name cleared, its subtree with it, exactly as the owning kernel's own overlay reads them. Local rows are untouched (the local kernel already applied its ledger).

**How the merged feed treated remote archived tops before:** they came straight from the remote kernel's projection with that kernel's ledger overlaid (since the returned-cards fix) and nothing else; a single-card clear is routed to the owning kernel, so that path was already whole. A related gap this does not touch, reported separately: Clear-all carries no session id and routes to the local kernel only, so a merged board's Clear-all clears the local cards alone.

No card-move rule changes: a replayed clear or undo now lands as the last row the user wrote; a remote row the viewer's ledger clears reads as the viewer already saw its local twin read.

## Review (lean, by hand)

The pre-scan tolerates malformed rows (skipped, as the loop skips them) and costs one extra pass over the journal per load. The clear arm keeps `nd.get("cleared")` and the twin check first, so a survived write is never re-recorded; the unclear arm's new skip only adds a reason to stand down, never a reason to act. `_cleared_foreign` lists the goal and archive directories once per build, the same cost class as the ledger read, and never carries a local id. The client helper filters remote rows only (`hostOf(id) !== LOCAL`), builds fresh row objects, and is a no-op without ids, so single-kernel merges are byte-identical.

## Tests

`tests/test_kernel_goal_compaction.py`: clear, undo, clear inside one second replays to the last row (sealed), and clear then undo to the undo (unsealed); the payload's foreign id list carries a foreign clear, not a local one nor an undone one, is pinned on the payload beside `dismissedCount`, and is capped. `ui/webview/federation-cleared-overlay.test.ts` (new): a foreign clear on the local payload drops the remote ask and item and reads the remote archived top cleared with its subtree while the local twin and an untouched remote top pass through and the host payload's own rows are not mutated; no ids means no change; the helper is pure and ignores junk ids.
