### PR TITLE
Merged board: the footer's Clear all reaches every attached kernel, and Undo follows it to each

### DIFF
--- a/tests/test_clear_many.py
+++ b/tests/test_clear_many.py
@@ -73,5 +73,50 @@ class ClearMany(unittest.TestCase):
         self.assertEqual(self.chat, [])
 
 
+
+
+class TwoKernelsClearAllEachTheirOwn(unittest.TestCase):
+    """The board-wide Clear all reaches every attached kernel (T286): the client broadcasts it (federation.ts, pinned
+    in ui/webview/feed-clear-all-broadcast.test.ts) and each kernel clears ITS OWN feed's cards and appends ITS OWN
+    ledger rows, so an Undo on each side restores that side whole. Two state roots stand in for two kernels."""
+
+    SID_B = "11111111-2222-3333-4444-666666666666"
+
+    def setUp(self):
+        self.roots = [tempfile.TemporaryDirectory(), tempfile.TemporaryDirectory()]
+        self._saved = (km.jd.STATE, km._mark_views_dirty, km._send_to_app)
+        km._mark_views_dirty = lambda: None
+        km._send_to_app = lambda app, m: None
+
+    def tearDown(self):
+        km.jd.STATE, km._mark_views_dirty, km._send_to_app = self._saved
+        for r in self.roots:
+            r.cleanup()
+
+    def _on(self, i):
+        km.jd.STATE = Path(self.roots[i].name)
+        km._CLEARED_MEMO["slot"] = None
+
+    def _ledger(self, i):
+        p = Path(self.roots[i].name) / "cleared.jsonl"
+        return [json.loads(l) for l in p.read_text().splitlines() if l.strip()] if p.exists() else []
+
+    def test_each_kernel_clears_its_own_cards_writes_its_own_rows_and_undoes_its_own_batch(self):
+        a_ids, b_ids = IDS, [self.SID_B + ":g1", self.SID_B + ":g2"]
+        self._on(0); km._clear_all(a_ids)                 # the broadcast lands on kernel A: its cards
+        self._on(1); km._clear_all(b_ids)                 # ...and on kernel B: its cards
+        self.assertEqual([r["id"] for r in self._ledger(0)], a_ids, "A's ledger carries A's rows only")
+        self.assertEqual([r["id"] for r in self._ledger(1)], b_ids, "B's ledger carries B's rows only")
+        self._on(0); self.assertEqual(set(km._cleared_ids()), set(a_ids), "the board on A shows none of A's cards")
+        self._on(1); self.assertEqual(set(km._cleared_ids()), set(b_ids))
+        # Undo, sent to both kernels by the client: each restores its own batch whole
+        self._on(0); km._undo_clear()
+        self._on(1); km._undo_clear()
+        self._on(0); self.assertEqual(km._cleared_ids(), {}, "A restored")
+        self._on(1); self.assertEqual(km._cleared_ids(), {}, "B restored")
+        self.assertEqual([r.get("op") for r in self._ledger(0)][-3:], ["undo"] * 3, "A's undo rows name A's batch")
+        self.assertNotIn(self.SID_B, "".join(r["id"] for r in self._ledger(0)), "A never learned of B's cards")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/ui/webview/federation-send-queue.test.ts
+++ b/ui/webview/federation-send-queue.test.ts
@@ -165,7 +165,7 @@ test("a NON-setting drop stays a drop — but leaves a client-diag breadcrumb an
 test("the undoClear send site drops loudly too: diag + warn on a down socket", () => {
   withFed((fm, winEvents, localSends) => {
     attach(fm, "TESTHOSTA"); // still CONNECTING
-    fm.lastClearHost = "TESTHOSTA";
+    fm.lastClearHosts = ["TESTHOSTA"];   // T286: the hosts the last clear reached (one here)
     fm.outbound({ type: "undoClear" });
     const dg = diags(localSends, "senddrop");
     assert.equal(dg.length, 1);
@@ -358,8 +358,10 @@ test("the queue and the flush never mint a timestamp — gt is stamped at the ge
 
 test("both outbound remote send sites route through sendRemote — no raw inline drop path remains", () => {
   const outb = FED.slice(FED.indexOf("outbound(m: any): void {"), FED.indexOf("private dropWarn"));
-  assert.match(outb, /this\.sendRemote\(this\.lastClearHost, m\);/);
-  assert.match(outb, /this\.sendRemote\(r\.host, r\.msg\);/);
+  // T286: both sites go through the one sendTo helper, whose remote arm is sendRemote
+  assert.match(outb, /for \(const h of hosts\) this\.sendTo\(h, m\);/);
+  assert.match(outb, /for \(const r of routes\) this\.sendTo\(r\.host, r\.msg\);/);
+  assert.match(outb, /private sendTo\(host: string, msg: any\): void \{[\s\S]*?this\.sendRemote\(host, msg\);/);
   assert.doesNotMatch(outb, /readyState === 1\) c\.ws\.send/,
     "the old drop-if-not-open inline sends must not come back");
 });

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -300,6 +300,15 @@ export function routeOutbound(msg: any, knownHosts?: ReadonlySet<string>): Route
   // with nothing on screen to say so). Broadcast, like the hover clear above.
   if (KERNEL_SETTING.has(msg.type)) return [LOCAL, ...(knownHosts || [])].map((h) => ({ host: h, msg }));
 
+  // The BOARD-WIDE Clear all (the feed footer's, T286; the session header's Clear all is askClearMany, routed
+  // by its session id below) carries no session id, so it fell through to the local kernel alone and a merged
+  // board's Clear all left every remote card standing. Broadcast, local first: each kernel clears its own
+  // feed's cards and appends its own ledger rows, so each side's Undo stays whole (FederationManager.outbound
+  // remembers the hosts and sends undoClear to the same ones). Deliberately NOT a KERNEL_SETTING: a setting
+  // queues on a down socket and replays on reconnect, and a Clear all replayed minutes later would clear
+  // cards the user never saw; a kernel that is down at the click misses it and its cards stay.
+  if (msg.type === "clearAll") return [LOCAL, ...(knownHosts || [])].map((h) => ({ host: h, msg }));
+
   // openFolder ALWAYS stays LOCAL, `id` UNSTRIPPED (the user 2026-07-03): unlike every other id-bearing
   // message, this one means "open a window on the machine the BROWSER is running on" — routing it to a
   // remote kernel would open a folder/terminal on that headless machine's own (unwatched) screen. The
@@ -1165,26 +1174,35 @@ export class FederationManager {
     if (next.length !== cur.length || next.some((id, i) => id !== cur[i])) writeViewOrder(next);
   }
 
-  private lastClearHost = LOCAL; // where the most recent askClear routed — undoClear follows it
+  private lastClearHosts: string[] = [LOCAL]; // where the most recent clear routed (one kernel for a card or a
+  //                                             session's batch, every attached kernel for the board-wide Clear
+  //                                             all, T286) — undoClear follows it to each of them
 
   // browser → kernel: route each message to the owning kernel, prefix stripped.
   outbound(m: any): void {
-    // undoClear undoes the LAST clear, which may have gone to a remote kernel — follow it there.
-    // (The kernel keeps its own cleared.jsonl; only the kernel that took the clear can undo it.)
-    if (m && m.type === "undoClear" && this.lastClearHost !== LOCAL) {
-      this.sendRemote(this.lastClearHost, m);
-      this.lastClearHost = LOCAL;
+    // undoClear undoes the LAST clear on every kernel that took it: a remote card's clear went to that kernel
+    // alone, the board-wide Clear all went to all of them. (Each kernel keeps its own cleared.jsonl; only the
+    // kernel that took a clear can undo it, and it undoes its own newest batch.)
+    if (m && m.type === "undoClear") {
+      const hosts = this.lastClearHosts.length ? this.lastClearHosts : [LOCAL];
+      this.lastClearHosts = [LOCAL];
+      for (const h of hosts) this.sendTo(h, m);
       return;
     }
     const routes = routeOutbound(m, new Set(this.hostSeq.filter((h) => h !== LOCAL)));
-    if (m && (m.type === "askClear" || m.type === "askClearMany")) this.lastClearHost = routes[0] ? routes[0].host : LOCAL;
-    for (const r of routes) {
-      if (r.host === LOCAL) {
-        const s = (window as any).__rompLocalSend;
-        if (typeof s === "function") s(r.msg);
-      } else {
-        this.sendRemote(r.host, r.msg);
-      }
+    if (m && (m.type === "askClear" || m.type === "askClearMany" || m.type === "clearAll")) {
+      this.lastClearHosts = routes.length ? routes.map((r) => r.host) : [LOCAL];
+    }
+    for (const r of routes) this.sendTo(r.host, r.msg);
+  }
+
+  /** One send to one kernel: the local one through the page's own socket, a remote one through its conn. */
+  private sendTo(host: string, msg: any): void {
+    if (host === LOCAL) {
+      const s = (window as any).__rompLocalSend;
+      if (typeof s === "function") s(msg);
+    } else {
+      this.sendRemote(host, msg);
     }
   }
 

--- a/ui/webview/feed-clear-all-broadcast.test.ts
+++ b/ui/webview/feed-clear-all-broadcast.test.ts
@@ -1,0 +1,75 @@
+// The board-wide Clear all reaches every attached kernel (T286, the user 2026-09-09): the feed footer's Clear all
+// carries no session id and used to fall through to the local kernel alone, so a merged board's Clear all left every
+// remote card standing. The router broadcasts it, local first; each kernel clears its own feed's cards and appends its
+// own ledger rows; Undo follows the last clear to every kernel it reached. The session header's Clear all
+// (askClearMany, routed by its session id) is unchanged. A kernel whose socket is down at the click misses it (the
+// message is deliberately not a queued kernel setting) and its cards stay.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { routeOutbound, FederationManager } from "./federation";
+
+const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+const SID = "11111111-2222-3333-4444-555555555555";
+
+function withManager(fn: (fm: FederationManager, localSent: any[], remoteSent: [string, any][]) => void): void {
+  const localSent: any[] = [], remoteSent: [string, any][] = [];
+  const g: any = globalThis;
+  const hadWindow = "window" in g, prevWindow = g.window;
+  const hadLS = "localStorage" in g, prevLS = g.localStorage;
+  g.window = { dispatchEvent: () => {}, __rompLocalSend: (m: any) => localSent.push(m) };
+  g.localStorage = { getItem: () => null, setItem: () => {} };
+  try {
+    const fm = new FederationManager();
+    (fm as any).sendRemote = (h: string, m: any) => remoteSent.push([h, m]);
+    (fm as any).hostSeq = ["", "box2", "box3"];       // a board with two attached kernels' cards on it
+    fn(fm, localSent, remoteSent);
+  } finally {
+    if (hadWindow) g.window = prevWindow; else delete g.window;
+    if (hadLS) g.localStorage = prevLS; else delete g.localStorage;
+  }
+}
+
+test("the router broadcasts the board-wide Clear all to every attached kernel, local first, the message untouched", () => {
+  const r = routeOutbound({ type: "clearAll" }, new Set(["box2", "box3"]));
+  assert.deepEqual(r.map((x) => x.host), ["", "box2", "box3"]);
+  assert.ok(r.every((x) => x.msg.type === "clearAll" && Object.keys(x.msg).length === 1));
+  assert.deepEqual(routeOutbound({ type: "clearAll" }).map((x) => x.host), [""], "a single-kernel board: the local kernel alone, as before");
+});
+
+test("a Clear all on a merged board reaches both kernels and Undo restores both sides", () => {
+  withManager((fm, localSent, remoteSent) => {
+    fm.outbound({ type: "clearAll" });
+    assert.deepEqual(localSent.map((m) => m.type), ["clearAll"], "the local kernel does its part first");
+    assert.deepEqual(remoteSent.map(([h, m]) => [h, m.type]), [["box2", "clearAll"], ["box3", "clearAll"]]);
+    fm.outbound({ type: "undoClear" });
+    assert.deepEqual(localSent.map((m) => m.type), ["clearAll", "undoClear"]);
+    assert.deepEqual(remoteSent.map(([h, m]) => [h, m.type]),
+      [["box2", "clearAll"], ["box3", "clearAll"], ["box2", "undoClear"], ["box3", "undoClear"]], "each kernel undoes its own batch");
+    fm.outbound({ type: "undoClear" });
+    assert.equal(remoteSent.length, 4, "a second Undo has no clear to follow to a remote kernel: local alone");
+    assert.deepEqual(localSent.map((m) => m.type), ["clearAll", "undoClear", "undoClear"]);
+  });
+});
+
+test("the session header's Clear all still goes to that session's kernel alone, and Undo follows it there alone", () => {
+  withManager((fm, localSent, remoteSent) => {
+    fm.outbound({ type: "askClearMany", sid: "box2:" + SID, itemIds: ["box2:" + SID + ":g1", "box2:" + SID + ":g2"] });
+    assert.equal(localSent.length, 0);
+    assert.deepEqual(remoteSent.map(([h, m]) => [h, m.type, m.sid]), [["box2", "askClearMany", SID]], "routed by id, bare");
+    fm.outbound({ type: "undoClear" });
+    assert.equal(localSent.length, 0, "the local kernel took no clear: nothing to undo there");
+    assert.deepEqual(remoteSent.map(([h, m]) => [h, m.type]), [["box2", "askClearMany"], ["box2", "undoClear"]]);
+    fm.outbound({ type: "askClear", sid: SID, itemId: SID + ":g5" });   // the feed's shape: routed by the session id
+    fm.outbound({ type: "undoClear" });
+    assert.deepEqual(localSent.map((m) => m.type), ["askClear", "undoClear"], "a local clear's Undo stays local");
+    assert.equal(remoteSent.length, 2);
+  });
+});
+
+test("Clear all is not a queued kernel setting: a kernel that is down at the click misses it and its cards stay", () => {
+  assert.doesNotMatch(FED.slice(FED.indexOf("const KERNEL_SETTING"), FED.indexOf("]);", FED.indexOf("const KERNEL_SETTING"))), /clearAll/);
+  assert.match(FED, /if \(msg\.type === "clearAll"\) return \[LOCAL, \.\.\.\(knownHosts \|\| \[\]\)\]\.map\(\(h\) => \(\{ host: h, msg \}\)\);/);
+  assert.match(FED, /this\.diag\("senddrop", \{ host, msgType: \(msg && msg\.type\) \|\| "" \}\);\s*\n\s*this\.dropWarn\(host, msg\);/, "a non-setting on a down socket is dropped and warned, never queued");
+});

--- a/ui/webview/feed-sess-clear.test.ts
+++ b/ui/webview/feed-sess-clear.test.ts
@@ -86,8 +86,8 @@ test("the router sends the batch to the session's kernel with bare ids, and Undo
   assert.equal(r[0].host, "box2");
   assert.equal(r[0].msg.sid, "11111111-2222-3333-4444-555555555555");
   assert.deepEqual(r[0].msg.itemIds, ["11111111-2222-3333-4444-555555555555:g1", "11111111-2222-3333-4444-555555555555:g2"]);
-  assert.match(FED, /if \(m && \(m\.type === "askClear" \|\| m\.type === "askClearMany"\)\) this\.lastClearHost = /,
-    "undoClear follows the LAST clear, batched or single, to the kernel that took it");
+  assert.match(FED, /if \(m && \(m\.type === "askClear" \|\| m\.type === "askClearMany" \|\| m\.type === "clearAll"\)\) \{\s*\n\s*this\.lastClearHosts = routes\.length \? routes\.map\(\(r\) => r\.host\) : \[LOCAL\];/,
+    "undoClear follows the LAST clear, batched or single, to the kernel that took it (T286: the board-wide Clear all to every kernel it reached)");
 });
 
 test("the header Clear's own class carries layout only; size, outline and the accent hover come from .fdismiss", () => {


### PR DESCRIPTION
Tier: fix

## What

The board-wide Clear all (the feed footer's) reaches every attached kernel. It carries no session id, so the client router fell through to the local kernel alone, and on a merged board Clear all left every remote card standing. The router now broadcasts it the way kernel settings propagate, local first; each kernel clears its own feed's cards and appends its own ledger rows, so each side's Undo stays whole. The manager's Undo routing, which already followed the last clear to the one kernel that took it, now remembers every kernel the last clear reached: a board-wide Clear all's Undo goes to all of them, a card's or a session's clear keeps its Undo where it landed. The button's acknowledgement is unchanged (the client's optimistic clear and the kernel's push reconcile as before), and the session header's Clear all (a batch routed by its session id) is unchanged and pinned.

**A kernel that is down at the click misses it, and its cards stay.** The message is deliberately not a queued kernel setting: a setting rides the next socket open, and a Clear all replayed minutes later would clear cards the user never saw. A non-setting on a down socket is dropped with the existing warning; there is no retry queue.

No card-move rule changes: each kernel clears exactly what its own Clear all handler cleared before, on the user's gesture.

## Review (lean, by hand)

The broadcast branch sits after the kernel-setting branch and before the id routing, so a message with a session id never reaches it, and a single-kernel board routes as before (the local kernel alone). The manager keeps the hosts the last clear routed to as a list; Undo sends to each and resets to the local kernel, so a second Undo with nothing left to follow stays local, as today. One private send helper serves both the routing loop and the Undo loop (the local socket through the page's own sender, a remote one through its conn), so no send path changed. The kernel's Clear all and Undo handlers are untouched.

## Tests

`ui/webview/feed-clear-all-broadcast.test.ts` (new): the router broadcasts Clear all to every attached kernel, local first, the message untouched, and a single-kernel board stays local; a merged board with two attached kernels: Clear all reaches both, Undo goes to both, a second Undo stays local; the session header's Clear all still goes to its session's kernel alone with bare ids and its Undo follows it there alone, and a local clear's Undo stays local; Clear all is not a kernel setting and a non-setting on a down socket is dropped and warned, never queued. `ui/webview/feed-sess-clear.test.ts`: the Undo-follows pin reads the new list. `tests/test_clear_many.py` (new class): two state roots as two kernels, each clears its own cards and writes its own ledger rows, each Undo restores its own side whole, and neither ledger ever names the other's cards.
