### PR TITLE
Spend: a paid result with no modelUsage map is said once in the error center

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -411,7 +411,10 @@ output, cache writes, and cache reads. Cache reads are most of it: every API
 call within a turn (one per tool step) re-reads the whole context from the
 cache, so a long session's single turn can read tens of millions of tokens at
 a tenth of the input price. The hover splits each window's count by kind, so
-the size of the number carries its explanation.
+the size of the number carries its explanation. A result that carries no
+per-model usage map is counted from the main loop alone, and the error center
+says so once: once per session when the CLI left the map out, once per kernel
+run when the Agent SDK the kernel imported has no field for it.
 
 ### Self-scheduled work wakes an idle session
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2477,6 +2477,37 @@ def sdk_importable() -> bool:
         return False
 
 
+def usage_fallback_is_sdk(msg) -> bool:
+    """A paid result carried no modelUsage map (SdkSession._turn_usage read the flat `usage` dict instead): is
+    that the imported SDK's doing? The current claude-agent-sdk declares `model_usage` as a field of
+    ResultMessage, None when the CLI sends no map, so a result with no such ATTRIBUTE at all came from
+    an older copy of the SDK, whichever one the kernel's interpreter imported: a copy found on sys.path
+    ahead of the dedicated venv's (kernel._ensure_sdk_on_path takes an importable copy first), or the
+    venv's own, as old as its last bin/romp-sdk-setup run. That is a fact about the host, the same for
+    every session this kernel runs; a field that is there but empty is this session's CLI's doing on
+    this result."""
+    return not hasattr(msg, "model_usage")
+
+
+def usage_fallback_notice(name, msg) -> str:
+    """The problem line for a paid result with no modelUsage map, by the cause usage_fallback_is_sdk
+    tells apart. The SDK cause names no session (it holds for all of them) and names the copy the
+    kernel imported, so the remedy is a path and not a search; the CLI cause names the session. Either
+    way the reader learns what the token columns now count and that the dollars are unaffected: the
+    flat dict is the main loop's own per-turn total, so what subagents and sidechains spent is not in
+    it, while total_cost_usd stays the process total."""
+    if usage_fallback_is_sdk(msg):
+        where = getattr(sys.modules.get("claude_agent_sdk"), "__file__", None) or "an unknown path"
+        return ("spend: every session's token columns count the main loop alone from here on (no subagent or "
+                "sidechain tokens; the dollars are unaffected). Cause: the claude-agent-sdk the kernel imported "
+                "(%s) has no model_usage field on ResultMessage, so the CLI's modelUsage map never reaches the "
+                "kernel. Run bin/romp-sdk-setup to install a current one, or remove a copy that shadows the "
+                "venv's, then restart romp." % where)
+    return ("spend (%s): a paid turn's tokens were recorded from the main loop alone (no subagent or sidechain "
+            "tokens; the dollars are unaffected): the CLI emitted no modelUsage on the result. Said once per "
+            "session." % name)
+
+
 # What the SDK puts on ProcessError.stderr when NOBODY registered an options.stderr callback: it does
 # not pipe the child's stderr at all, and substitutes this literal (subprocess_cli.py). Surfacing it is
 # worse than useless — it tells the user to go read an output romp never captured, and it outranked the
@@ -3775,6 +3806,9 @@ class SdkSession:
         #   total when the deltas were written (`usage: this.totalUsage`) and is the TURN's own total
         #   on the current CLI — diffing it under-counted every turn but the first (the user
         #   2026-09-06). Which counter is which, and the measurement: _turn_usage.
+        self._usage_fallback_noted = False  # the once-per-session line for a paid result whose modelUsage map
+        #   is there but empty (usage_fallback_notice, the CLI cause); the SDK cause is said once per
+        #   backend on its flag, _usage_fallback_sdk_noted (see _note_usage_fallback)
         # Pending conversation REWIND (the chat's edit-message branch): the target record uuid +
         # the transcript leaf recorded at request time (the one-shot guard — see rewind_disposition).
         # Seeded from the reg so a kernel death mid-rewind re-applies it iff nothing landed since.
@@ -5120,7 +5154,8 @@ class SdkSession:
           of every turn — roughly half a day's tokens went missing, and five sessions' recorded
           totals matched that subtraction to the token (the user 2026-09-06, who did not believe
           the count and was right, in the other direction). So the flat dict is never diffed: when
-          the map is absent (an older CLI) it folds WHOLE.
+          the map is absent it folds WHOLE, and the fallback is said once (_note_usage_fallback): it
+          is the main loop's count alone, and a reader of the token columns has to know that.
         Cache reads dominate either way — every API call of a turn re-reads the whole context — and
         the hover breaks the count down by kind so the size of the number has its explanation."""
         mu = getattr(msg, "model_usage", None)
@@ -5140,7 +5175,38 @@ class SdkSession:
             return out
         u = getattr(msg, "usage", None)
         u = u if isinstance(u, dict) else {}
-        return {k: (int(u[k]) if isinstance(u.get(k), (int, float)) else 0) for k, _ in self._USAGE_KEYS}
+        out = {k: (int(u[k]) if isinstance(u.get(k), (int, float)) else 0) for k, _ in self._USAGE_KEYS}
+        self._note_usage_fallback(msg)   # after the count: a count that raises is the containment's one report
+        return out
+
+    def _note_usage_fallback(self, msg):
+        """_turn_usage read the flat `usage` dict because the paid result carried no modelUsage map:
+        this turn's token columns are the main loop's count alone. Recorded silently before, so a kernel
+        on an old SDK under-counted every session with nothing in the error center naming why. Said as a
+        problem the user can act on (usage_fallback_notice), by the cause the message tells apart
+        (usage_fallback_is_sdk): the SDK cause is the host's, one for every session this kernel runs, so
+        it is said ONCE PER BACKEND on the backend's flag (per session it would be one near-identical
+        card per live session, and another per dormant revive, for a single remedy), checked and set
+        under the backend's lock because sessions settle on their own threads and a bare check-then-set
+        lets two first paid results both say it; the CLI cause is this session's, so once per session on
+        its own flag, which only this session's thread touches. The line is not worth the count: this
+        runs inside the token count, ahead of the spend write and after the cost watermark moved, so a
+        log callback that raises here would lose the turn's dollars and tokens for the sake of a line.
+        The raise is swallowed instead (the flag is set first, and the ring row lands before the callback
+        runs, so nothing is said twice). The `total > 0` gate in the settle keeps zero-cost results out."""
+        if usage_fallback_is_sdk(msg):
+            with self.backend._lock:
+                if self.backend._usage_fallback_sdk_noted:
+                    return
+                self.backend._usage_fallback_sdk_noted = True
+        else:
+            if self._usage_fallback_noted:
+                return
+            self._usage_fallback_noted = True
+        try:
+            self.backend._log(usage_fallback_notice(self.name, msg), problem=True)
+        except Exception:
+            pass    # a raising log callback: the count proceeds (the docstring's rule)
 
     async def _drain(self, client, AssistantMessage, ResultMessage, SystemMessage):
         """The receive loop. Every streamed message goes through _handle_stream_message, which keeps
@@ -7028,6 +7094,8 @@ class SdkBackend:
         self.append_prompt_path = append_prompt_path
         self._log_cb = log
         self._thinking_override_logged = False   # thinking_override_note said once per backend (see _options)
+        self._usage_fallback_sdk_noted = False   # usage_fallback_notice's SDK cause said once per backend: the
+        #   imported SDK is one fact for every session (SdkSession._note_usage_fallback)
         self.sessions: dict[str, SdkSession] = {}
         self._lock = threading.Lock()
         self._turn_seq: dict = {}                 # sid -> turns ended this kernel life (turn_seq; under _lock)

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -2976,10 +2976,9 @@ class SpendRecord(unittest.TestCase):
         self.assertIn('"spend": _spend_windows()', ksrc)
         self.assertIn("def _spend_windows(keyed_only=False):", ksrc)   # keyed_only: the mixed-host API sum (test_session_auth)
 
-    def _spend_session(self):
+    def _spend_session(self, sid="11111111-2222-3333-4444-bbbbbbbbbbbb", name="n"):
         import asyncio
-        sid = "11111111-2222-3333-4444-bbbbbbbbbbbb"
-        s = sb.SdkSession(self.be, {"sid": sid, "name": "n", "cwd": "/tmp"})
+        s = sb.SdkSession(self.be, {"sid": sid, "name": name, "cwd": "/tmp"})
         self.be._forward = lambda sess, msg: None
         self.be._turn_completed = lambda sid: None
         async def _noop(): pass
@@ -3091,6 +3090,118 @@ class SpendRecord(unittest.TestCase):
         self.assertEqual(day()["tokIn"], 300, "a turn smaller than the last folds whole too — there is no watermark on a per-turn figure")
         self.assertAlmostEqual(day()["usd"], 3.0, msg="the dollars stay a delta of their running total")
         self.assertEqual(s._last_usage_totals, {}, "the per-turn dict leaves the modelUsage watermarks untouched")
+
+    def test_a_paid_result_without_model_usage_says_so_once_per_session(self):
+        """The fallback above was SILENT: a paid result with no modelUsage map recorded the flat dict and
+        the day's token columns became main-loop-only figures with nothing in the error center saying
+        so. The field is present here (None, then an empty map), so the SDK has it and the CLI sent
+        nothing on this result: that is THIS session's CLI's doing, so the line names the session and
+        is said once per session, not once per turn. The count itself is unchanged."""
+        s, run, day = self._spend_session(name="web")
+        def _result(total, turn_in, mu):
+            r = _ResultMessage()
+            r.total_cost_usd = total
+            r.usage = {"input_tokens": turn_in, "output_tokens": 20}
+            r.model_usage = mu                    # the attribute exists: a current SDK, a CLI that sent no map
+            return r
+        run(_result(1.0, 100, None))
+        run(_result(2.0, 140, {}))
+        self.assertEqual(day()["tokIn"], 240, "each per-turn figure still lands whole")
+        self.assertAlmostEqual(day()["usd"], 2.0)
+        probs = [p["text"] for p in self.be.problems()]
+        self.assertEqual(len(probs), 1, "one line per session, not one per turn: %r" % probs)
+        self.assertIn("no modelUsage", probs[0])
+        self.assertIn("spend (web)", probs[0], "the CLI cause is this session's, so the line names it")
+        self.assertNotIn("model_usage field", probs[0], "the SDK remedy is not given for a CLI omission")
+        self.assertTrue(s._usage_fallback_noted)
+        self.assertFalse(self.be._usage_fallback_sdk_noted, "the CLI cause never spends the SDK cause's flag")
+        run(_result(3.0, 50, self._model_map(5000)))     # the map is back: the count diffs it, nothing new to say
+        self.assertEqual(day()["tokIn"], 5240)
+        self.assertEqual(len(self.be.problems()), 1)
+        # the scope is the session, not the backend: another session's CLI omission is said for that session
+        api, run_api, _ = self._spend_session("11111111-2222-3333-4444-aaaaaaaaaaaa", name="api")
+        run_api(_result(1.0, 10, None))
+        probs = [p["text"] for p in self.be.problems()]
+        self.assertEqual(len(probs), 2, "a second session says it once for itself: %r" % probs)
+        self.assertIn("spend (api)", probs[1])
+        self.assertTrue(api._usage_fallback_noted)
+        self.assertEqual(day()["tokIn"], 5250)
+
+    def test_a_log_callback_that_raises_on_the_notice_never_costs_the_turn_its_count(self):
+        """The notice is said from inside the token count, ahead of the spend write and after the cost
+        watermark moved: a log callback that raised there would propagate out of _turn_usage and the
+        turn's dollars and tokens would go unrecorded for the sake of a line. The line is not worth the
+        count. The ring row has landed by the time the callback runs, so the raise is swallowed and the
+        count proceeds; the settle's own containment never has to hear of it."""
+        s, run, day = self._spend_session(name="web")
+        def badlog(m):
+            if "no modelUsage" in str(m):
+                raise OSError(32, "Broken pipe")
+        self.be._log_cb = badlog                  # armed after construction (construction logs too)
+        r = _ResultMessage()
+        r.total_cost_usd = 1.0
+        r.usage = {"input_tokens": 100, "output_tokens": 20}
+        r.model_usage = None
+        run(r)
+        self.assertEqual(day()["tokIn"], 100, "the count landed although the notice's callback raised")
+        self.assertAlmostEqual(day()["usd"], 1.0)
+        probs = [p["text"] for p in self.be.problems()]
+        self.assertEqual(len(probs), 1, "the ring row landed before the callback raised: %r" % probs)
+        self.assertIn("spend (web)", probs[0])
+        self.assertTrue(s._usage_fallback_noted)
+
+    def test_an_sdk_whose_result_message_lacks_the_field_is_said_once_per_kernel_life(self):
+        """A ResultMessage with no model_usage ATTRIBUTE at all is the imported SDK's doing: the current
+        claude-agent-sdk declares the field (None when the CLI sends nothing), so a result without it
+        means the kernel imported an older copy found on sys.path ahead of the dedicated venv's. One
+        fact for every session this kernel runs, so the line names no session, names the remedy, and is
+        said once per backend: two sessions and three paid turns produce one line, and a fresh
+        SdkSession for a sid already seen (a dormant revive) adds nothing. The line names the copy by
+        path (the remedy is then a path, not a search), read off the imported module: a stand-in module
+        supplies one here, since this test interpreter has no SDK of its own."""
+        import sys
+        import types
+        fake = types.ModuleType("claude_agent_sdk")
+        fake.__file__ = "/synthetic/site-packages/claude_agent_sdk/__init__.py"
+        saved = sys.modules.get("claude_agent_sdk")
+        sys.modules["claude_agent_sdk"] = fake
+        def restore():
+            if saved is None:
+                sys.modules.pop("claude_agent_sdk", None)
+            else:
+                sys.modules["claude_agent_sdk"] = saved
+        self.addCleanup(restore)
+        web, run_web, day = self._spend_session("11111111-2222-3333-4444-aaaaaaaaaaaa", name="web")
+        api, run_api, _ = self._spend_session("11111111-2222-3333-4444-bbbbbbbbbbbb", name="api")
+        def _result(total):
+            r = _ResultMessage()                  # no model_usage attribute at all
+            r.total_cost_usd = total
+            r.usage = {"input_tokens": 100, "output_tokens": 20}
+            return r
+        r0 = _result(0)                           # a zero-cost result never reaches the token count (total > 0)
+        run_web(r0)
+        self.assertEqual(self.be.problems(), [])
+        run_web(_result(1.0))
+        run_api(_result(1.0))
+        run_web(_result(2.0))
+        self.assertEqual(day()["tokIn"], 300, "every turn's tokens still land, counted whole")
+        probs = [p["text"] for p in self.be.problems()]
+        self.assertEqual(len(probs), 1, "one line for one host-level remedy: %r" % probs)
+        self.assertIn("model_usage field", probs[0])
+        self.assertIn("romp-sdk-setup", probs[0], "the remedy names the venv the kernel should be importing from")
+        self.assertIn(fake.__file__, probs[0], "the line names the copy the kernel imported, by path")
+        self.assertTrue(probs[0].startswith("spend: "), "a host-level line names no session: %r" % probs[0])
+        self.assertNotIn("spend (web)", probs[0])
+        self.assertNotIn("spend (api)", probs[0])
+        self.assertTrue(self.be._usage_fallback_sdk_noted)
+        self.assertFalse(web._usage_fallback_noted, "the per-session flag is the CLI cause's, untouched")
+        self.assertFalse(api._usage_fallback_noted)
+        again, run_again, _ = self._spend_session("11111111-2222-3333-4444-aaaaaaaaaaaa", name="web")
+        run_again(_result(1.0))
+        self.assertEqual(len(self.be.problems()), 1, "a revive of a seen sid adds nothing")
+        self.assertEqual(day()["tokIn"], 400)
+        sys.modules.pop("claude_agent_sdk")       # no SDK loaded at all: the line still reads, and says so
+        self.assertIn("(an unknown path)", sb.usage_fallback_notice("web", _result(1.0)))
 
     def test_the_keyed_sub_count_carries_the_by_kind_split(self):
         # the hover splits each window's tokens by kind; a mixed host's API readout sums ONLY the keyed

--- a/tests/test_sdk_stream_survives_handler_errors.py
+++ b/tests/test_sdk_stream_survives_handler_errors.py
@@ -777,7 +777,11 @@ class TheSettleRunsWhateverTheResultsBookkeepingDid(unittest.TestCase):
         def bad_spend(*a, **k):
             raise OSError(28, "No space left on device")
         be._record_spend = bad_spend
-        out = self._settle(be, s, ok_expected=False, msg=_result(total_cost_usd=0.5, usage={"input_tokens": 10}))
+        # the map is on the double so the ring holds the containment's line alone: a paid result WITHOUT
+        # modelUsage is itself reported once (SdkSession._note_usage_fallback), which is not this test
+        out = self._settle(be, s, ok_expected=False,
+                           msg=_result(total_cost_usd=0.5, usage={"input_tokens": 10},
+                                       model_usage={"claude-x": {"inputTokens": 10}}))
         self._assert_settled(s, out)
         probs = _problems(be)
         self.assertEqual(len(probs), 1)
@@ -816,14 +820,18 @@ class TheSettleRunsWhateverTheResultsBookkeepingDid(unittest.TestCase):
                 resolved = []
                 be.rewind_resolved_cb = lambda sid, outcome: resolved.append(outcome)
                 be._stash_live(SID, "w1", _work("w1", 1))    # a work atom of the turn, never landed
+                fields = {}
                 if trigger == "a NaN usage field":
                     usage = json.loads('{"input_tokens": NaN, "output_tokens": 5}')
                 else:
                     usage = {"input_tokens": 10}
+                    # with the map the token count succeeds silently and the stubbed write is the one report: a
+                    # paid result WITHOUT modelUsage is itself reported once (_note_usage_fallback)
+                    fields["model_usage"] = {"claude-x": {"inputTokens": 10}}
                     def bad_spend(*a, **k):
                         raise OSError(28, "No space left on device")
                     be._record_spend = bad_spend
-                out = self._settle(be, s, ok_expected=False, msg=_result(total_cost_usd=0.5, usage=usage))
+                out = self._settle(be, s, ok_expected=False, msg=_result(total_cost_usd=0.5, usage=usage, **fields))
                 self._assert_settled(s, out)
                 self.assertEqual(s._rewind_to, "", "the rewind flag was consumed before the spend step failed")
                 self.assertFalse(s._rewind_armed)


### PR DESCRIPTION
## Symptom

The token count beside the dollars can be the main loop's count alone with nothing saying so. A paid result that carries no modelUsage map is recorded from the flat `usage` dict (the fallback #956 kept for a CLI without the map), so subagent and sidechain tokens are missing from every token column it feeds while the dollars stay right. Two causes reach that branch and both were silent: the kernel importing a claude-agent-sdk whose ResultMessage has no `model_usage` field (a copy found on sys.path ahead of the venv bin/romp-sdk-setup builds, since `_ensure_sdk_on_path` prefers an already-importable copy, or a venv built before the field existed and never rebuilt), which takes the fallback on every turn of every session; and a CLI that emits no modelUsage on a paid result, which does it for that session. The first happened on one installation on 2026-09-06: about twenty resumed sessions under-counting, fresh launches dying on a TypeError from the same old SDK, and no line in the error center naming why.

## Cause

`SdkSession._turn_usage`'s fallback branch reads the flat dict and returns; nothing reports that the fallback ran. The judge has a once-per-process line for the same missing map (#967); the kernel's spend path had none, against the rule that a lossy source is announced rather than quietly used.

## Fix

`kernel/sdk_backend.py`: two module-level helpers, `usage_fallback_is_sdk(msg)` (no `model_usage` attribute at all: the imported SDK's doing; a field that is there but empty: this session's CLI's doing on this result) and `usage_fallback_notice(name, msg)` (the two texts), and `SdkSession._note_usage_fallback`, called from the fallback branch after the count so a count that raises (a NaN field) stays the containment's one report. The SDK cause is one fact for every session this kernel runs, so its line names no session, names the imported copy's path (`sys.modules["claude_agent_sdk"].__file__`, "an unknown path" with none loaded) and the bin/romp-sdk-setup remedy, and is said once per backend (`SdkBackend._usage_fallback_sdk_noted`, checked and set under the backend's `_lock` because sessions settle on their own threads); the CLI cause is this session's, so its line names the session and is said once per session (`SdkSession._usage_fallback_noted`). The notice runs inside the token count after the cost watermark moved, so a log callback that raises there is swallowed and the turn's dollars and tokens are still recorded (the ring row lands before the callback runs). `_turn_usage`'s count, `_USAGE_KEYS` and the watermark rule are unchanged; the `total > 0` gate in the settle keeps zero-cost results out. `docs/reference.md`: one sentence in the token paragraph.

## Tests

- `tests/test_sdk_backend.py::SpendRecord::test_a_paid_result_without_model_usage_says_so_once_per_session`: two paid results with `model_usage` None, then `{}`; the count still lands 240, the ring holds one line reading `spend (web)` and "no modelUsage" and not the SDK remedy, the session flag is set and the backend flag is not; a third result with a map adds nothing; a second session's omission adds one line reading `spend (api)`. Before the change: `AssertionError: 0 != 1` (the ring is empty).
- `tests/test_sdk_backend.py::SpendRecord::test_an_sdk_whose_result_message_lacks_the_field_is_said_once_per_kernel_life`: a stand-in module installed as `claude_agent_sdk` with a synthetic `__file__` (the prior entry restored by addCleanup); results with no `model_usage` attribute fed to two sessions on one backend (a zero-cost one first, then three paid turns); every turn's tokens land, the ring holds one line that starts with `spend: `, names the remedy and the stand-in's path and neither session, the backend flag is set and neither session flag is, a fresh SdkSession for an already seen sid adds nothing, and with the module removed the text reads "an unknown path". Before the change: `AssertionError: 0 != 1`.
- `tests/test_sdk_backend.py::SpendRecord::test_a_log_callback_that_raises_on_the_notice_never_costs_the_turn_its_count`: a log callback that raises on the notice; the turn's tokens and dollars are recorded and the ring holds the line. Before the change: `AssertionError: 0 != 1` (no line); with the guard removed, the raise propagates out of the count and the spend file is never written.
- `tests/test_sdk_stream_survives_handler_errors.py`: the two costed doubles whose count succeeds and then hit a stubbed `_record_spend` carry a modelUsage map, so the ring still holds the containment's line alone (a paid result without the map is now itself reported once, which is not what those tests observe). The NaN doubles are untouched: their count raises inside `_turn_usage` before the report, as the frame pin there requires.
- `SpendRecord._spend_session()` takes a sid and a name so two sessions can share one backend; defaults unchanged.
- Full suite at this head, `pytest -n 8 tests/`: 10160 passed, 61 skipped, 1671 subtests passed, 0 failed.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)