### PR TITLE
Staged messages release as one message, and the strip shows four and scrolls the rest

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -24,15 +24,16 @@ complementary views of what the agents are doing:
 **Reviewing a document.** Select any passage in the file viewer and it lands in the
 composer as a quote chip, labeled with the file and the line the passage lives on. Type
 what should change and press **⌘⏎** to set the note aside; keep reading, select the next
-passage, and repeat — each staged note remembers its quote and its place. **⏎** sends
-everything you staged along with whatever is in the box, so the session applies the lot
-in one pass, and you never copy a line out of the document by hand. The line in each
-label is checked against the file at the moment you select, so numbers that moved under
-you are caught rather than quietly carried. When several sessions work in the same
-repository, or in worktrees of it, the viewer's title bar says which one you opened the
-file from: a chip with the session's name, in the same color as its tab. The title bar's
-**GitHub ↗** button opens the file on GitHub. While the check runs, the button waits dimmed
-with pulsing dots beside it.
+passage, and repeat — each staged note remembers its quote and its place. The list above
+the composer shows about four staged notes and scrolls for the rest; its caret collapses
+it to the count. **⏎** sends everything you staged along with whatever is in the box as
+one message, so the session applies the lot in one pass, and you never copy a line out of
+the document by hand. The line in each label is checked against the file at the moment
+you select, so numbers that moved under you are caught rather than quietly carried. When
+several sessions work in the same repository, or in worktrees of it, the viewer's title
+bar says which one you opened the file from: a chip with the session's name, in the same
+color as its tab. The title bar's **GitHub ↗** button opens the file on GitHub. While the
+check runs, the button waits dimmed with pulsing dots beside it.
 When there is nothing to open, the button stays in place, dimmed, and a caption beside it
 says why (the file is not in a git repository or not committed — untracked, staged but in no
 commit, or on a branch with no commits yet — the repository has no origin remote, its origin

--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -10,6 +10,7 @@ import * as path from "node:path";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const STAGED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "staged-messages.ts"), "utf8");   // quoteReplyBody lives here
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 const SKELETON = fs.readFileSync(path.resolve(process.cwd(), "src", "page-skeleton.ts"), "utf8");
 
@@ -55,9 +56,10 @@ test("Backspace at the start of the box deletes the citation like a character", 
 
 test("sending with a GOAL citation routes as an askFollowUp (reopen) and consumes the chip", () => {
   // the three routing branches live in routeUserMessage since the staged flush (2026-08-15) — ONE
-  // owner for the live send and the staged release; deliver feeds it activeId as the sid
+  // owner for the live send and the staged release; deliver hands the typed message to flushStaged, which
+  // routes every post of the release through it with sid (the active session) as the sid
   assert.match(RENDER, /const cites = composerCitations\.get\(activeId\);/);
-  assert.match(RENDER, /routeUserMessage\(activeId, text, cites, attached\.filter\(\(p\) => previewKind\(p\) === "img"\)\);/);   // + the echo's thumbnail paths (2026-08-25)
+  assert.match(RENDER, /flushStaged\(sid, \{ text, cites, imgPaths: attached\.filter\(\(p\) => previewKind\(p\) === "img"\) \}\);/);   // + the echo's thumbnail paths (2026-08-25)
   assert.match(RENDER, /if \(goalCite\?\.itemId\) \{ vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\); registerOptimistic\(sid, text, imgPaths\); \}/);
   assert.match(RENDER, /else \{ vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text \}\); registerOptimistic\(sid, text, imgPaths\); \}/);
   assert.match(RENDER, /if \(cites\) \{ composerCitations\.delete\(activeId\); renderComposerChips\(activeId\); \}/);
@@ -72,7 +74,8 @@ test("a citation follow-up carries its SID, so a reply to a REMOTE card reaches 
   // still flashed to Working (the kernel's cardPredict fires before any of that) and snapped back on the
   // ok:false ack, so the only visible trace was a bounce.
   assert.match(RENDER, /if \(goalCite\?\.itemId\) \{ vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\); registerOptimistic\(sid, text, imgPaths\); \}/);
-  assert.match(RENDER, /routeUserMessage\(activeId, text, cites, attached\.filter\(\(p\) => previewKind\(p\) === "img"\)\);/);   // deliver's sid IS the active session
+  assert.match(RENDER, /const sid = activeId;   \/\/ the session this send \(and any confirm below\) was armed for/);   // deliver's sid IS the active session
+  assert.match(RENDER, /flushStaged\(sid, \{ text, cites, imgPaths: attached\.filter\(\(p\) => previewKind\(p\) === "img"\) \}\);/);
   // every OTHER card-addressed op already routes this way — the citation follow-up was the lone omission
   assert.match(FEED, /type: "askClear", itemId: it\.itemId, sid: it\.sid/);
   assert.match(FEED, /type: "askFollowUp", itemId: tgt \? tgt\.itemId : fbId, title: tgt \? tgt\.title : fbTitle, text: txt, sid: fbSid/);
@@ -211,8 +214,9 @@ test("quote chips send a plain message wrapped by quoteReplyBody — never askFo
   assert.match(RENDER, /else if \(quoteCites\.length\) \{ const body = quoteReplyBody\(quoteCites, text\); vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text: body \}\); registerOptimistic\(sid, body, imgPaths\); \}/);
   // the wrap: one section per stacked chip (lead-in + the highlighted text as a markdown quote block), in
   // strip order, then the typed message — a single chip composes byte-identically to the pre-stack form
-  // a context-only body (staged with an empty box) carries no dangling blank tail
-  assert.match(RENDER, /return text \? sections\.join\("\\n\\n"\) \+ "\\n\\n" \+ text : sections\.join\("\\n\\n"\);/);
+  // a context-only body (staged with an empty box) carries no dangling blank tail. The function lives in
+  // staged-messages.ts now (the staged release composes from it too) and its test executes it.
+  assert.match(STAGED, /return quoted && text \? quoted \+ "\\n\\n" \+ text : quoted \|\| text;/);
   // the chip's audit preview shows the SAME composed body — the whole outgoing message, every stacked
   // quote, whichever chip was clicked — client-side (no /followup-preview fetch)
   assert.match(RENDER, /body\.textContent = quoteReplyBody\(cites\.filter\(\(c\) => c\.quote\), draft \|\| "\(your message\)"\);/);
@@ -267,7 +271,7 @@ test("a VS Code EDITOR highlight seeds the same chip, labeled + wrapped with its
   assert.match(RENDER, /const i = list\.findIndex\(\(c\) => !!c\.src\);\s*\n\s*if \(i >= 0\) list\[i\] = chip; else list\.push\(chip\);/);
   // the chip title leads with the origin; the wrap lead-in points at the code, not the conversation
   assert.match(RENDER, /const title = \(src \? src \+ " — " \+ snip : snip\)\.slice\(0, 140\);/);
-  assert.match(RENDER, /const lead = c\.src \? "Replying to this highlighted code \(" \+ c\.src \+ "\):" : "Replying to this part of the conversation:";/);
+  assert.match(STAGED, /const lead = c\.src \? "Replying to this highlighted code \(" \+ c\.src \+ "\):" : "Replying to this part of the conversation:";/);
 });
 
 test("deselecting in the editor (editorSelectionCleared) drops the editor chip, scoped + focus-safe (the user 2026-07-14)", () => {

--- a/ui/webview/composer-send.test.ts
+++ b/ui/webview/composer-send.test.ts
@@ -98,7 +98,7 @@ test("a staged chip clips IN BOUNDS with an ellipsis and expands on click (the u
   // the flex label could never shrink (no min-width:0), so long texts ran off the pane edge with no
   // ellipsis; expanded, the same label wraps to the full text — the context-fold idiom
   assert.match(STYLES, /\.staged-chip \.composer-chip-label \{ flex: 1 1 auto; max-width: 100%; min-width: 0; \}/);
-  assert.match(STYLES, /\.staged-chip\.open \.staged-row \.composer-chip-label \{ white-space: pre-wrap; overflow: visible; \}/);
+  assert.match(STYLES, /\.staged-chip\.open \.staged-row \.composer-chip-label \{ white-space: pre-wrap; overflow: visible; overflow-wrap: anywhere; \}/);
   // the affordance is visibly CHROME, not message text: dim, parenthesized, at the line's end
   assert.match(STYLES, /\.staged-expand \{ flex: 0 0 auto; color: var\(--dim\); font-size: 0\.86em; \}/);
   assert.match(RENDER, /hint\.textContent = open \? "\(collapse\)" : "\(click to expand\)";/);   // the tail names the gesture (the user 2026-08-16)
@@ -113,6 +113,6 @@ test("a staged chip clips IN BOUNDS with an ellipsis and expands on click (the u
   assert.match(RENDER, /el\("div", "composer-chip staged-cite"/);
   assert.match(STYLES, /\.staged-cite \{ min-width: 0; max-width: 100%; cursor: pointer; \}/);
   assert.match(RENDER, /cite\.addEventListener\("click", \(ev\) => \{\s*\n\s*ev\.stopPropagation\(\);/);
-  assert.match(STYLES, /\.staged-cite\.open \.composer-chip-label \{ white-space: pre-wrap; overflow: visible; \}/);
+  assert.match(STYLES, /\.staged-cite\.open \.composer-chip-label \{ white-space: pre-wrap; overflow: visible; overflow-wrap: anywhere; \}/);
 });
 

--- a/ui/webview/optimistic-send.test.ts
+++ b/ui/webview/optimistic-send.test.ts
@@ -235,7 +235,8 @@ test("the echo renders dragged-image THUMBNAILS — composer → provisional →
   // bytes and the reconcile swap never re-fetches or flickers.
   assert.match(RENDER, /if \(t\.imgPaths && t\.imgPaths\.length\) \{\s*\n\s*for \(const ip of t\.imgPaths\) bubble\.appendChild\(userImage\(\{ src: "path:" \+ ip, path: ip \}, true\)\);/);
   // the paths ride the send at every register site (deliver, staged flush, the provisional hold)
-  assert.match(RENDER, /routeUserMessage\(activeId, text, cites, attached\.filter\(\(p\) => previewKind\(p\) === "img"\)\);/);
+  assert.match(RENDER, /flushStaged\(sid, \{ text, cites, imgPaths: attached\.filter\(\(p\) => previewKind\(p\) === "img"\) \}\);/);
+  assert.match(RENDER, /routeUserMessage\(sid, p\.text, [^\n]*p\.imgPaths\);/);   // each post of the release carries its images (staged-list-cap.test.ts executes the loop)
   // …and ONLY image-kind attachments mint thumbs — a dropped .csv stays the path text it always was
   assert.doesNotMatch(RENDER, /registerOptimistic\(sid, text, attached\)/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -37,7 +37,7 @@ import { tabStateClass, tabDotClass, sectionPip, sectionPipMembers, sectionPipTi
 import { titleWithKey, chordOf, effectiveChord, loadOverrides } from "./keybindings";
 import { DEFAULT_CHORDS } from "./commands";
 import { NavHistory } from "./nav-history";
-import { StagedStack } from "./staged-messages";
+import { StagedStack, quoteReplyBody, stagedPosts } from "./staged-messages";
 import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, newPending, reconcilePending, queuedCopyToHide, dropPending, bareGroupLabel, sentAtLabel } from "./send-pending";
 import { reconcileHeld, heldAsQueued, type HeldCopy, type HeldQueued, type HeldMemory } from "./queued-held";
 import { reloadHoldReason } from "./reload-hold";
@@ -13319,21 +13319,33 @@ try {
 // strip shows an "Editing message" pill whose ✕ (or Esc in the box) cancels back to normal sending.
 const composerEdits = new Map<string, { uuid: string; orig: string }>();
 
-// STAGED messages (the user 2026-08-15): compose against a highlight, ⌘/Ctrl+⏎ to HOLD it — citation
-// chips and all — clear the box and keep reading; repeat. Nothing sends until the next plain send
-// (the stack flushes first, in stage order, the typed message last) or the strip's Send now.
-// Deliberately NOT the queue and never called "queued": queued is romp's injection-side wait (sent,
-// pending injection); staged is user-side — unsent by choice, each message keeping the context it was
-// written against so the batch reads as quote → comment, quote → comment. Per-tab, persisted with the
-// drafts (a reload or tab switch never drops a stack). The pure stack rules live in staged-messages.ts,
-// executed by its test; this file owns the strip DOM and the send routing.
+// STAGED messages (the user 2026-08-15): compose against a highlight, ⌘/Ctrl+⏎ to HOLD it, citation
+// chips and all, clear the composer and keep reading; repeat. Nothing sends until the next plain send
+// or the strip's Send now, and the release is ONE message: the staged items in stage order, each as the
+// quote it was written against and then its comment, the typed message last, so the run reads
+// quote, comment, quote, comment, wrap-up, and the agent takes it in one turn (stagedPosts in
+// staged-messages.ts says which items still go on their own). Deliberately NOT the queue and never
+// called "queued": queued is romp's injection-side wait (sent, pending injection); staged is user-side,
+// unsent by choice. Per-tab, persisted with the drafts (a reload or tab switch never drops a stack).
+// The pure stack rules and the body live in staged-messages.ts, executed by its test; this file owns
+// the strip DOM and the send routing.
 const stagedMsgs = new StagedStack();
 const stagedOpen = new Set<string>();   // sid:index of staged chips expanded to their full text
+// The strip collapsed to its head line: a page-lifetime Set of session ids, empty (list shown) at load,
+// written by the head's caret or label click and cleared when the stack empties, so a collapse is the
+// user's and belongs to the stack they collapsed (the next stack starts shown, its first item in view),
+// and a reload shows the list again. The head keeps the count and Send now either way.
+const stagedCollapsed = new Set<string>();
+// The list's kept scroll offset, PER TAB: the strip holds one tab's list at a time, so the offset is
+// stored under the sid that built the list the strip holds (strip.dataset.sid) and reused only for
+// that sid. Read off whatever list was in the strip, it would carry the leaving tab's offset onto the
+// entering tab's list on a switch and hide that tab's first items.
+const stagedScroll = new Map<string, number>();
 try { stagedMsgs.restore(((vscodeApi?.getState?.() || {}) as any).staged); } catch { /* ignore */ }
 
-// One routing owner for a user message (the deliver path and the staged flush both speak it): a goal
-// chip rides askFollowUp, quote chips wrap client-side, a bare message is a plain send with the
-// optimistic bubble (chip sends have their own kernel-side echo).
+// One routing owner for a user message (deliver speaks it through flushStaged, once per post of the
+// release): a goal chip rides askFollowUp, quote chips wrap client-side, a bare message is a plain send
+// with the optimistic bubble (chip sends have their own kernel-side echo).
 function routeUserMessage(sid: string, text: string, cites: Citation[] | undefined, imgPaths?: string[]): void {
   if (!vscodeApi) return;
   const goalCite = cites?.find((c) => c.itemId);
@@ -13354,27 +13366,63 @@ function routeUserMessage(sid: string, text: string, cites: Citation[] | undefin
     data: { sid, ts: Date.now(), len: text.length, route: goalCite?.itemId ? "followup" : quoteCites.length ? "quote" : "plain" } });
 }
 
-/** Release the tab's staged stack (deliver's guards — host down, provisional — run before this in the
- *  send path; Send now re-checks reachability itself). Returns how many went. */
-function flushStaged(sid: string): number {
-  const batch = stagedMsgs.takeAll(sid);
-  for (const s of batch) routeUserMessage(sid, s.text, s.cites as Citation[]);
-  if (batch.length) { persistDrafts(); renderStagedStrip(sid); }
-  return batch.length;
+/** Release the tab's staged stack as ONE message: stagedPosts (staged-messages.ts, executed by its test)
+ *  composes the staged items in stage order and then the typed message, when the send carries one, into
+ *  a single body, so one post makes one bubble and one turn. Two kinds of item still go on their own, at
+ *  their place in stage order: an item citing a GOAL (the kernel wraps one goal per message, askFollowUp;
+ *  a typed goal follow-up carries the run inside its text and the goal wraps the lot) and a SLASH
+ *  COMMAND, staged or typed (the kernel fires a command only at the head of its own text: after another
+ *  section a typed /clear would be prose the agent read, and ahead of one a staged /compact would take
+ *  the comments after it as its argument). With nothing staged the typed message routes exactly as
+ *  before. Deliver's guards (host down, provisional) run before this in the send path; Send now
+ *  re-checks reachability itself. Returns how many staged items went. */
+function flushStaged(sid: string, typed?: { text: string; cites?: Citation[]; imgPaths?: string[] }): number {
+  const run = stagedMsgs.takeAll(sid);
+  for (const p of stagedPosts(run, typed)) routeUserMessage(sid, p.text, p.cites as Citation[] | undefined, p.imgPaths);
+  if (run.length) { persistDrafts(); renderStagedStrip(sid); }
+  return run.length;
 }
 
-function renderStagedStrip(id: string | null): void {
+function renderStagedStrip(id: string | null, opts?: { reveal?: "last" }): void {
   const strip = document.getElementById("composer-staged");
   if (!strip) return;
+  // the list's scroll position survives the rebuild: expanding or discarding an item re-renders the
+  // strip, and a fresh list would start at the top, away from the item just clicked. The offset is kept
+  // under the tab that built the list it is read from (stagedScroll), so a switch never carries one tab's
+  // place onto another's list and a tab comes back to its own; an emptied list forgets it. The STAGE path
+  // passes reveal: "last" instead and the new item scrolls into view: with only the kept offset, every
+  // item staged past the fourth would land below the list's edge, out of sight.
+  const prev = strip.querySelector(".staged-list");
+  if (prev && strip.dataset.sid) stagedScroll.set(strip.dataset.sid, prev.scrollTop);
   strip.replaceChildren();
-  const list = id ? stagedMsgs.list(id) : [];
-  if (!id || !list.length) { strip.style.display = "none"; return; }
+  const items = id ? stagedMsgs.list(id) : [];
+  if (!id || !items.length) { if (id) { stagedScroll.delete(id); stagedCollapsed.delete(id); } delete strip.dataset.sid; strip.style.display = "none"; return; }
+  strip.dataset.sid = id;
   strip.style.display = "flex";
+  const collapsed = stagedCollapsed.has(id);
   const head = el("div", "staged-head");
-  const lbl = el("span");
-  lbl.textContent = list.length + " staged — sends with your next message";
+  // the caret: the head line alone when collapsed, the count still on it; a real button so the keyboard
+  // reaches it, and its state is spoken (aria-expanded) as well as drawn
+  const caret = el("button", "staged-caret") as HTMLButtonElement;
+  caret.textContent = collapsed ? "▸" : "▾";
+  caret.setAttribute("aria-expanded", collapsed ? "false" : "true");
+  caret.setAttribute("aria-label", collapsed ? "Show the staged messages" : "Hide the staged messages");
+  const lbl = el("span", "staged-lbl");
+  lbl.textContent = items.length + " staged — sends with your next message";
   lbl.title = "⌘⏎ (or Ctrl+⏎) stages what you've typed, quote chips and all, without sending. "
-    + "A plain send releases them in order with your new message last — or Send now releases them alone.";
+    + "A plain send releases them as one message, in order, with your new message last; a card follow-up or a slash command goes on its own, in its place. "
+    + "Send now releases them alone.";
+  const toggleCollapse = (ev: Event) => {
+    ev.stopPropagation();
+    if (stagedCollapsed.has(id)) stagedCollapsed.delete(id); else stagedCollapsed.add(id);
+    // the rebuild destroys the caret that had focus, so the keyboard user stays on the new one (dropped
+    // to body, the next Enter would be the bare-area Enter that focuses the composer)
+    const had = document.activeElement === caret;
+    renderStagedStrip(id);
+    if (had) (strip.querySelector(".staged-caret") as HTMLElement | null)?.focus();
+  };
+  caret.addEventListener("click", toggleCollapse);
+  lbl.addEventListener("click", toggleCollapse);
   const go = el("button", "staged-go");
   go.textContent = "Send now";
   go.addEventListener("click", () => {
@@ -13385,9 +13433,14 @@ function renderStagedStrip(id: string | null): void {
     }
     flushStaged(id);
   });
-  head.append(lbl, go);
+  head.append(caret, lbl, go);
   strip.appendChild(head);
-  list.forEach((s, i) => {
+  if (collapsed) return;
+  // the items sit in their own scrolling list UNDER the head: about four items show and the rest scroll
+  // (.staged-list in styles.css), the head with its count and Send now stays outside the scroll, and the
+  // composer below keeps its place. An expanded item grows inside the scroll.
+  const list = el("div", "staged-list");
+  items.forEach((s, i) => {
     const chip = el("div", "staged-chip");
     // each staged reply keeps the CONTEXT it was written against visible inside its own dotted box
     // (the user 2026-08-15): one small context chip per quote, independently expandable — clicking
@@ -13435,8 +13488,10 @@ function renderStagedStrip(id: string | null): void {
     x.addEventListener("click", (ev) => { ev.stopPropagation(); stagedMsgs.removeAt(id, i); persistDrafts(); renderStagedStrip(id); });
     row.append(mark, label, hint, x);
     chip.appendChild(row);
-    strip.appendChild(chip);
+    list.appendChild(chip);
   });
+  strip.appendChild(list);
+  list.scrollTop = opts?.reveal === "last" ? list.scrollHeight : (stagedScroll.get(id) || 0);
 }
 
 function beginComposerEdit(sid: string, uuid: string, orig: string): void {
@@ -13729,20 +13784,8 @@ function setCitation(id: string, cite: Citation): void {
   if (id === activeId) { renderComposerChips(id); focusComposer(); }
 }
 
-// The outgoing body for QUOTE citations (the user 2026-07-13): the highlighted text rides ahead of the
-// typed message as a markdown quote block, so the agent knows exactly which part is being replied to.
-// Also what the chip's audit preview shows — one function, no drift. Stacked chips (the user 2026-08-04)
-// become one section each, in the order they sit in the strip. `src` (the VS Code editor flavor,
-// 2026-07-13) names where a highlight came from — a workspace-relative file:lines — so that section's
-// lead-in points the agent at the code, not the conversation.
-function quoteReplyBody(cites: { quote?: string; src?: string | null }[], text: string): string {
-  const sections = cites.map((c) => {
-    const q = (c.quote || "").split("\n").map((l) => "> " + l).join("\n");
-    const lead = c.src ? "Replying to this highlighted code (" + c.src + "):" : "Replying to this part of the conversation:";
-    return lead + "\n" + q;
-  });
-  return text ? sections.join("\n\n") + "\n\n" + text : sections.join("\n\n");
-}
+// quoteReplyBody, the outgoing body for QUOTE citations, lives in staged-messages.ts: the live send, the
+// staged release and the chip's audit preview compose from that one function, and its test executes it.
 
 // HIGHLIGHT-TO-REPLY (the user 2026-07-13): selecting text in the chat transcript seeds the composer chip
 // as reply context, exactly like a distilled-summary click — but quote-flavored. Event-based on
@@ -15162,7 +15205,7 @@ function setupComposer() {
     drafts.delete(activeId); draftStartedAt.delete(activeId);
     ta.value = ""; composerManualH = null; ta.style.height = "";
     persistDrafts();
-    renderStagedStrip(activeId);
+    renderStagedStrip(activeId, { reveal: "last" });   // the new item is the one event that moves the list: show it
   };
   const sendComposer = (opts?: { pastShipGate?: boolean }) => {
     const typed = ta.value.trim();
@@ -15272,17 +15315,18 @@ function setupComposer() {
         return;
       }
       lastSent.set(activeId, text);   // remembered for a possible Ctrl+C restore
-      // STAGED first (the user 2026-08-15): the held run releases in stage order, each message with the
-      // context it was written against, and the message being typed right now lands LAST — the reading
-      // the user composed: quote → comment, quote → comment, then the wrap-up. The guards above (host
-      // down, provisional) have already passed, so nothing staged can be half-lost here.
-      flushStaged(sid);
+      // The STAGED run and this message go together (the user 2026-08-15): the held items in stage order,
+      // each with the context it was written against, and the message being typed right now last, the
+      // reading the user composed: quote, comment, quote, comment, then the wrap-up. flushStaged composes
+      // them into one message (stagedPosts says which items still go alone) and routes every post through
+      // routeUserMessage; with nothing staged that is this message as itself. The guards above (host down,
+      // provisional) have already passed, so nothing staged can be half-lost here.
       // A pending citation chip → send as a FOLLOW-UP on that goal (the user 2026-07-01): askFollowUp wraps the
       // text with the goal's context + the romp-goal-id marker (kernel side), so the goal reopens (done→working,
       // unless cleared) and the chat renders the ↩ Follow-up header — the same path the Follow-up button uses,
       // just seeded by the click. A QUOTE chip (highlighted transcript text, the user 2026-07-13) has no goal:
       // it wraps client-side (quoteReplyBody) into a plain message. No chip → plain sendMessage. The three
-      // branches live in routeUserMessage — ONE routing owner, shared with the staged flush above.
+      // branches live in routeUserMessage, the ONE routing owner.
       // Inside it, `sid` is what ROUTES this to the owning kernel in a federated dashboard (the user
       // 2026-07-29): federation keys routing off `id`/`sid` only, and an `itemId` ("‹sid›:‹goal›") can't
       // be one — its own colon would read the session uuid as a host. Without the sid a follow-up on a
@@ -15290,7 +15334,7 @@ function setupComposer() {
       // uuid — nothing sent, no error, the card flashing to Working and back. The kernel keeps deriving
       // its sid from itemId, so this is inert locally; every other card op carries the sid the same way.
       const cites = composerCitations.get(activeId);
-      routeUserMessage(activeId, text, cites, attached.filter((p) => previewKind(p) === "img"));
+      flushStaged(sid, { text, cites, imgPaths: attached.filter((p) => previewKind(p) === "img") });
       // (a citation follow-up/quote has its own kernel-side echo path; the optimistic bubble covers the plain send)
       if (cites) { composerCitations.delete(activeId); renderComposerChips(activeId); }   // consumed on send
       sendOnShip.delete(sid);                       // a send happened — any held one is superseded

--- a/ui/webview/rewind-edit.test.ts
+++ b/ui/webview/rewind-edit.test.ts
@@ -34,7 +34,7 @@ test("sending in edit mode posts rewindSend and never a plain sendMessage", () =
   // fall through into a plain send (the routing itself now lives in routeUserMessage, defined earlier
   // in the file, so a source-index race against it would be meaningless)
   const editBranch = RENDER.indexOf('type: "rewindSend"');
-  const stagedFlush = RENDER.indexOf("flushStaged(sid);");
+  const stagedFlush = RENDER.indexOf("flushStaged(sid, {");
   assert.ok(editBranch > 0 && stagedFlush > 0 && editBranch < stagedFlush,
     "edit branch precedes deliver's first send action");
 });

--- a/ui/webview/send-scroll-preserve.test.ts
+++ b/ui/webview/send-scroll-preserve.test.ts
@@ -75,8 +75,8 @@ test("registerOptimistic gates the snap on a pre-append nearBottomForSend read",
 });
 
 test("every composer-shaped send rides the same gate — staged flush and provisional adoption included", () => {
-  // the staged flush releases each message through routeUserMessage…
-  assert.match(RENDER, /function flushStaged\(sid: string\): number \{\s*\n\s*const batch = stagedMsgs\.takeAll\(sid\);\s*\n\s*for \(const s of batch\) routeUserMessage\(sid, s\.text, s\.cites as Citation\[\]\);/);
+  // the staged flush releases each post of the run (one message, plus any item that goes alone) through routeUserMessage…
+  assert.match(RENDER, /function flushStaged\(sid: string, typed\?: \{ text: string; cites\?: Citation\[\]; imgPaths\?: string\[\] \}\): number \{\s*\n\s*const run = stagedMsgs\.takeAll\(sid\);\s*\n\s*for \(const p of stagedPosts\(run, typed\)\) routeUserMessage\(sid, p\.text, p\.cites as Citation\[\] \| undefined, p\.imgPaths\);/);
   // …whose every branch registers the optimistic bubble (2026-08-23), so the gate covers them all
   assert.match(RENDER, /if \(goalCite\?\.itemId\) \{ [^\n]*registerOptimistic\(sid, text, imgPaths\); \}/);
   assert.match(RENDER, /else if \(quoteCites\.length\) \{ [^\n]*registerOptimistic\(sid, body, imgPaths\); \}/);

--- a/ui/webview/staged-list-cap.test.ts
+++ b/ui/webview/staged-list-cap.test.ts
@@ -1,0 +1,376 @@
+// The staged strip above the composer: the items sit in their own list under the head, about four items
+// tall, and the rest scroll; the head with the count and Send now stays outside the scroll; a caret on
+// the head collapses the strip to that one line. And the run releases as ONE message: flushStaged routes
+// the posts stagedPosts composes from the staged items and the typed message.
+//
+// The strip's behaviour is EXECUTED: routeUserMessage, flushStaged and renderStagedStrip are lifted out
+// of render.ts, transpiled at run time and driven over a minimal fake DOM (the tab-strip-skip-exec.test.ts
+// idiom), with the real StagedStack and the module's real composition under them, so a change that keeps
+// the pinned lines but breaks the logic around them fails here. What a fake DOM cannot see is pinned at
+// the source: the CSS (the cap's px and its geometry inputs, the wrap rules) and the call sites inside
+// the composer closure, which nothing lifts (deliver's send, the stage path's reveal). The cap's geometry
+// is measured in a real browser by staged-list-layout.test.ts where one is installed.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import { StagedStack, quoteReplyBody, stagedRunBody, stagedPosts } from "./staged-messages";
+
+const requireCjs = createRequire(__filename);
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const FLUSH = RENDER.split("function flushStaged(")[1].split("\nfunction ")[0];
+const LIST = (CSS.match(/\.staged-list \{[^}]*\}/) || [""])[0];
+
+/** Enough of Element for the strip's paint: children, classList, dataset, style, attributes, listeners
+ *  (fired by hand), a class-selector querySelector, a scroll offset with a synthetic scrollHeight (50 per
+ *  child, so a reveal to the end reads as a different number from the top), and focus, which the fake
+ *  document records. */
+class FakeEl {
+  static doc: { activeElement: FakeEl | null } = { activeElement: null };
+  tag: string; className: string; children: FakeEl[] = []; parent: FakeEl | null = null;
+  dataset: Record<string, string> = {}; attrs: Record<string, string> = {}; listeners: Record<string, Function[]> = {};
+  textContent = ""; title = ""; scrollTop = 0;
+  style: { display: string } = { display: "" };
+  classList: { add(...c: string[]): void; remove(...c: string[]): void; contains(c: string): boolean };
+  constructor(tag: string, cls = "") {
+    this.tag = tag; this.className = cls;
+    const self = this;
+    this.classList = {
+      add(...c: string[]) { for (const x of c) if (!self.has(x)) self.className = (self.className + " " + x).trim(); },
+      remove(...c: string[]) { for (const x of c) self.className = self.className.split(/\s+/).filter((y) => y !== x).join(" "); },
+      contains(x: string) { return self.has(x); },
+    };
+  }
+  has(x: string): boolean { return this.className.split(/\s+/).includes(x); }
+  get scrollHeight(): number { return this.children.length * 50; }
+  appendChild(c: FakeEl): FakeEl { c.parent = this; this.children.push(c); return c; }
+  append(...cs: FakeEl[]): void { for (const c of cs) this.appendChild(c); }
+  replaceChildren(...cs: FakeEl[]): void { this.children = []; this.append(...cs); }
+  setAttribute(k: string, v: string): void { this.attrs[k] = v; }
+  addEventListener(t: string, f: Function): void { (this.listeners[t] ??= []).push(f); }
+  fire(t: string, ev: { stopPropagation?: () => void } = {}): void { for (const f of this.listeners[t] ?? []) f({ stopPropagation() { /* the default: nothing to stop */ }, ...ev }); }
+  focus(): void { FakeEl.doc.activeElement = this; }
+  /** ".class" selectors only, the first matching descendant in document order (what the paint asks for). */
+  querySelector(sel: string): FakeEl | null {
+    const cls = sel.replace(/^\./, "");
+    for (const c of this.children) { if (c.has(cls)) return c; const d = c.querySelector(sel); if (d) return d; }
+    return null;
+  }
+}
+
+type Posted = { type: string; [k: string]: unknown };
+type FakeDocument = { activeElement: FakeEl | null; getElementById: (id: string) => FakeEl | null };
+type Hooks = {
+  FakeEl: typeof FakeEl; document: FakeDocument;
+  StagedStack: typeof StagedStack; quoteReplyBody: typeof quoteReplyBody; stagedPosts: typeof stagedPosts;
+  posted: Posted[];                                                   // every vscodeApi.postMessage frame, in order
+  optimistic: { sid: string; text: string; imgPaths?: string[] }[];   // every registerOptimistic call
+  persists: number; down: Set<string>; provisional: Set<string>; toasts: string[];
+};
+type Api = {
+  routeUserMessage: (sid: string, text: string, cites: unknown[] | undefined, imgPaths?: string[]) => void;
+  flushStaged: (sid: string, typed?: { text: string; cites?: unknown[]; imgPaths?: string[] }) => number;
+  renderStagedStrip: (id: string | null, opts?: { reveal?: "last" }) => void;
+  stagedMsgs: StagedStack; stagedOpen: Set<string>; stagedCollapsed: Set<string>; stagedScroll: Map<string, number>;
+};
+
+// routeUserMessage, flushStaged and renderStagedStrip, transpiled (TS to JS) with esbuild at run time and
+// required dynamically so the test bundle does not try to bundle esbuild itself (the models-rev.test.ts
+// pattern). The module-level state they close over is minted fresh per world.
+function lift(): (hooks: Hooks) => Api {
+  const a = RENDER.indexOf("function routeUserMessage("), b = RENDER.indexOf("\nfunction beginComposerEdit(");
+  assert.ok(a > 0 && b > a, "anchors not found: routeUserMessage or beginComposerEdit moved; re-anchor");
+  const js = requireCjs("esbuild").transformSync(RENDER.slice(a, b), { loader: "ts" }).code;
+  const prelude = `
+    const H = HOOKS;
+    const el = (tag, cls) => new H.FakeEl(tag, cls);
+    const document = H.document;
+    const stagedMsgs = new H.StagedStack();
+    const stagedOpen = new Set(), stagedCollapsed = new Set(), stagedScroll = new Map();
+    const quoteReplyBody = H.quoteReplyBody, stagedPosts = H.stagedPosts;
+    const vscodeApi = { postMessage: (m) => { H.posted.push(m); } };
+    const registerOptimistic = (sid, text, imgPaths) => { H.optimistic.push({ sid, text, imgPaths }); };
+    const persistDrafts = () => { H.persists++; };
+    const hostIsDown = (id) => H.down.has(id); const isProvisionalId = (id) => H.provisional.has(id);
+    const warnToast = (msg) => { H.toasts.push(msg); };
+  `;
+  const epilogue = `return { routeUserMessage, flushStaged, renderStagedStrip, stagedMsgs, stagedOpen, stagedCollapsed, stagedScroll };`;
+  return new Function("HOOKS", prelude + js + epilogue) as (hooks: Hooks) => Api;
+}
+
+// synthetic session ids, private to this file
+const A = "5b1e7c2a-4d3f-4a6b-9c8d-0e1f2a3b4c5d", B = "8c2d9e4f-1a5b-4c7d-8e9f-0a1b2c3d4e5f";
+const Q1 = { quote: "const a = 1;", src: "src/a.ts:12-12", title: "t" };
+const Q2 = { quote: "first line\nsecond line", title: "t" };
+const G = { itemId: A + ":g1", title: "t" };   // a goal citation: the card the words follow up on
+const send = (m: Posted) => m.type !== "clientDiag";   // the frames the kernel acts on (the breadcrumb aside)
+
+/** The strip (#composer-staged) in an otherwise empty page, and the lifted functions over fresh state. */
+function world(): { H: Hooks; api: Api; strip: FakeEl; document: FakeDocument } {
+  const strip = new FakeEl("div");
+  const document: FakeDocument = { activeElement: null, getElementById: (id) => id === "composer-staged" ? strip : null };
+  FakeEl.doc = document;
+  const H: Hooks = { FakeEl, document, StagedStack, quoteReplyBody, stagedPosts, posted: [], optimistic: [], persists: 0, down: new Set(), provisional: new Set(), toasts: [] };
+  return { H, api: lift()(H), strip, document };
+}
+const listOf = (strip: FakeEl): FakeEl => { const l = strip.querySelector(".staged-list"); assert.ok(l, "the strip holds a .staged-list"); return l; };
+
+test("the head is the strip's first child, with the caret, the count and Send now; every chip sits in .staged-list under it", () => {
+  const { api, strip } = world();
+  api.renderStagedStrip(A);
+  assert.equal(strip.style.display, "none", "nothing staged: hidden");
+  api.stagedMsgs.push(A, { text: "rename it", cites: [Q1] });
+  api.stagedMsgs.push(A, { text: "a bare note", cites: [] });
+  api.renderStagedStrip(A);
+  assert.equal(strip.style.display, "flex");
+  assert.equal(strip.dataset.sid, A, "the strip says whose list it holds");
+  assert.deepEqual(strip.children.map((c) => c.className), ["staged-head", "staged-list"], "the head, then the list; no chip lands on the strip itself");
+  const [head, list] = strip.children;
+  assert.deepEqual(head.children.map((c) => c.tag + "." + c.className), ["button.staged-caret", "span.staged-lbl", "button.staged-go"]);
+  const [caret, lbl, go] = head.children;
+  assert.equal(caret.attrs["aria-expanded"], "true");
+  assert.equal(caret.attrs["aria-label"], "Hide the staged messages");
+  assert.ok(lbl.textContent.startsWith("2 staged"), lbl.textContent);
+  // the tooltip says what a send does, the two exceptions included
+  assert.ok(lbl.title.includes("releases them as one message, in order, with your new message last"), lbl.title);
+  assert.ok(lbl.title.includes("a card follow-up or a slash command goes on its own, in its place"), lbl.title);
+  assert.ok(lbl.title.includes("Send now releases them alone."), lbl.title);
+  assert.equal(go.textContent, "Send now");
+  assert.equal(list.children.length, 2);
+  assert.ok(list.children.every((c) => c.has("staged-chip")));
+  // an item's anatomy is unchanged: its quote as the composer's blue pill, then the row with the words, the
+  // hint and the discard ✕; and no drag and drop on any of it
+  const [quoted, bare] = list.children;
+  assert.deepEqual(quoted.children.map((c) => c.className), ["composer-chip staged-cite", "staged-row"]);
+  assert.deepEqual(quoted.children[1].children.map((c) => c.tag + "." + c.className), ["span.composer-chip-mark", "span.composer-chip-label", "span.staged-expand", "button.composer-chip-x"]);
+  assert.equal(quoted.children[1].children[1].textContent, "rename it");
+  assert.deepEqual(bare.children.map((c) => c.className), ["staged-row"]);
+  assert.equal(bare.querySelector(".staged-expand")!.textContent, "(click to expand)");
+  for (const c of list.children) assert.ok(!c.listeners.dragstart && !c.listeners.dragover && !c.listeners.drop, "no drag and drop on a staged item");
+});
+
+test("the list's place is kept per tab across the rebuild an expand, a discard or a switch triggers; staging reveals the end; an emptied list forgets", () => {
+  const { api, strip } = world();
+  for (let i = 0; i < 6; i++) api.stagedMsgs.push(A, { text: "note " + i, cites: i % 2 ? [Q1] : [] });
+  api.renderStagedStrip(A, { reveal: "last" });
+  let list = listOf(strip);
+  assert.equal(list.children.length, 6);
+  assert.ok(list.scrollTop > 0 && list.scrollTop === list.scrollHeight, "the stage path reveals the new item: the list is scrolled to its end");
+  list.scrollTop = 40;                              // the user scrolls
+  api.renderStagedStrip(A);
+  list = listOf(strip);
+  assert.equal(list.scrollTop, 40, "a plain rebuild keeps the place");
+  assert.equal(api.stagedScroll.get(A), 40);
+  // expand an item: the strip rebuilds with the item open, at the same place
+  list.children[2].fire("click");
+  list = listOf(strip);
+  assert.ok(list.children[2].has("open"), "the expand is keyed and survives the rebuild");
+  assert.equal(list.children[2].querySelector(".staged-expand")!.textContent, "(collapse)");
+  assert.equal(list.scrollTop, 40);
+  // the quote pill has its own expand, and its click never toggles the row's
+  list.children[1].querySelector(".staged-cite")!.fire("click");
+  list = listOf(strip);
+  assert.ok(list.children[1].querySelector(".staged-cite")!.has("open") && !list.children[1].has("open"));
+  assert.equal(list.scrollTop, 40);
+  // discard an item: gone from the stack and the list, the place kept, and the ✕'s click stops at itself
+  let stopped = 0;
+  list.children[0].querySelector(".composer-chip-x")!.fire("click", { stopPropagation: () => { stopped++; } });
+  assert.equal(stopped, 1, "the ✕ never toggles the item it discards");
+  list = listOf(strip);
+  assert.equal(list.children.length, 5);
+  assert.deepEqual(api.stagedMsgs.list(A).map((m) => m.text), ["note 1", "note 2", "note 3", "note 4", "note 5"]);
+  assert.equal(list.scrollTop, 40);
+  // a switch: the entering tab's list starts at its own place (none yet); the leaving tab's is remembered
+  api.stagedMsgs.push(B, { text: "for b", cites: [] });
+  api.renderStagedStrip(B);
+  list = listOf(strip);
+  assert.equal(strip.dataset.sid, B);
+  assert.equal(list.scrollTop, 0, "B's list at B's place, not A's offset");
+  assert.equal(api.stagedScroll.get(A), 40);
+  list.scrollTop = 10;
+  api.renderStagedStrip(A);
+  assert.equal(listOf(strip).scrollTop, 40, "A comes back to its own place");
+  assert.equal(api.stagedScroll.get(B), 10, "and B's is kept for its return");
+  // emptied: hidden, its place forgotten with it; the other tab's stands
+  api.stagedMsgs.takeAll(A);
+  api.renderStagedStrip(A);
+  assert.equal(strip.style.display, "none");
+  assert.equal(strip.dataset.sid, undefined);
+  assert.equal(api.stagedScroll.has(A), false);
+  assert.equal(api.stagedScroll.get(B), 10);
+  api.renderStagedStrip(null);
+  assert.equal(strip.style.display, "none");
+});
+
+test("the caret and the label collapse the strip to the head line and back, per tab; the mark is the click's, and it ends with the stack", () => {
+  const { api, strip } = world();
+  for (let i = 0; i < 3; i++) api.stagedMsgs.push(A, { text: "note " + i, cites: [] });
+  api.renderStagedStrip(A);
+  assert.equal(strip.children.length, 2, "a fresh page shows the list");
+  strip.querySelector(".staged-caret")!.fire("click");
+  assert.deepEqual(strip.children.map((c) => c.className), ["staged-head"], "collapsed: the head line alone");
+  const [caret, lbl, go] = strip.children[0].children;
+  assert.equal(caret.textContent, "▸");
+  assert.equal(caret.attrs["aria-expanded"], "false");
+  assert.equal(caret.attrs["aria-label"], "Show the staged messages");
+  assert.ok(lbl.textContent.startsWith("3 staged"), "the count stays on the head");
+  assert.equal(go.textContent, "Send now", "and so does Send now");
+  assert.ok(api.stagedCollapsed.has(A));
+  api.renderStagedStrip(A);
+  assert.equal(strip.children.length, 1, "any rebuild keeps the collapse: the state is the Set's, not the paint's");
+  strip.children[0].children[1].fire("click");
+  assert.equal(strip.children.length, 2, "the label opens it again");
+  assert.equal(strip.children[0].children[0].textContent, "▾");
+  assert.equal(strip.children[0].children[0].attrs["aria-expanded"], "true");
+  assert.ok(!api.stagedCollapsed.has(A));
+  // per tab: A collapsed, B shown, A still collapsed on its return
+  strip.children[0].children[1].fire("click");
+  api.stagedMsgs.push(B, { text: "for b", cites: [] });
+  api.renderStagedStrip(B);
+  assert.equal(strip.children.length, 2, "B's list shows: the collapse is A's");
+  api.renderStagedStrip(A);
+  assert.equal(strip.children.length, 1);
+  // the stack empties (a release): the mark goes with it, so the next stack starts shown with its item in view
+  api.stagedMsgs.takeAll(A);
+  api.renderStagedStrip(A);
+  assert.ok(!api.stagedCollapsed.has(A), "an emptied stack takes its collapse with it");
+  api.stagedMsgs.push(A, { text: "a new run", cites: [] });
+  api.renderStagedStrip(A, { reveal: "last" });
+  assert.equal(strip.children.length, 2, "the new stack is shown, not hidden behind the old collapse");
+  assert.equal(listOf(strip).scrollTop, listOf(strip).scrollHeight);
+});
+
+test("the keyboard user stays on the caret across the rebuild its click causes; a click from elsewhere moves no focus", () => {
+  const { api, strip, document } = world();
+  api.stagedMsgs.push(A, { text: "note", cites: [] });
+  api.renderStagedStrip(A);
+  const caret = strip.querySelector(".staged-caret")!;
+  document.activeElement = caret;                  // reached by Tab
+  caret.fire("click");
+  const next = strip.querySelector(".staged-caret")!;
+  assert.notEqual(next, caret, "the rebuild minted a new caret");
+  assert.equal(document.activeElement, next, "and focus followed it");
+  document.activeElement = null;                   // a pointer click, focus elsewhere
+  next.fire("click");
+  assert.equal(document.activeElement, null, "no focus taken");
+});
+
+test("flushStaged routes the posts stagedPosts composes, one routeUserMessage call each; what the kernel receives is the composed body", () => {
+  const { H, api, strip } = world();
+  const items = [{ text: "rename it", cites: [Q1] }, { text: "a bare note", cites: [] }];
+  for (const it of items) api.stagedMsgs.push(A, it);
+  api.renderStagedStrip(A);
+  const typed = { text: "that is all", cites: [Q2], imgPaths: ["a.png"] };
+  assert.equal(api.flushStaged(A, typed), 2, "two staged items went");
+  assert.deepEqual(H.posted.filter(send), [{ type: "sendMessage", id: A, text: stagedRunBody(items, typed) }],
+    "ONE message: the run in stage order, each quote with its comment, the typed message last");
+  assert.deepEqual(H.optimistic, [{ sid: A, text: stagedRunBody(items, typed), imgPaths: ["a.png"] }], "one bubble, the typed images on it");
+  assert.equal(H.posted.filter((m) => !send(m)).length, 1, "one breadcrumb per post");
+  assert.equal(api.stagedMsgs.count(A), 0, "the release is one-shot");
+  assert.equal(H.persists, 1);
+  assert.equal(strip.style.display, "none", "the strip emptied with the stack");
+  // nothing staged: the typed message as itself (here a goal follow-up), nothing persisted or repainted
+  H.posted.length = 0; H.optimistic.length = 0;
+  assert.equal(api.flushStaged(A, { text: "hi", cites: [G] }), 0);
+  assert.deepEqual(H.posted.filter(send), [{ type: "askFollowUp", itemId: G.itemId, text: "hi", sid: A }]);
+  assert.equal(H.persists, 1);
+  // the two kinds of item that go alone, at their place: the frames leave in stage order
+  H.posted.length = 0;
+  const Gm = { text: "on the card", cites: [G] }, C = { text: "/compact", cites: [] }, Bn = { text: "why two?", cites: [Q2] };
+  for (const it of [items[0], Gm, C, Bn]) api.stagedMsgs.push(A, it);
+  api.flushStaged(A, { text: "done", cites: [] });
+  assert.deepEqual(H.posted.filter(send), [
+    { type: "sendMessage", id: A, text: stagedRunBody([items[0]]) },
+    { type: "askFollowUp", itemId: G.itemId, text: "on the card", sid: A },
+    { type: "sendMessage", id: A, text: "/compact" },
+    { type: "sendMessage", id: A, text: stagedRunBody([Bn], { text: "done" }) },
+  ]);
+  // a command staged with a quote chip goes alone with its chip, and the chip wraps it as any quoted
+  // message: the CLI reads that as prose, exactly as it did when every item was its own message
+  H.posted.length = 0;
+  api.stagedMsgs.push(A, { text: "/compact", cites: [Q1] });
+  api.flushStaged(A);
+  assert.deepEqual(H.posted.filter(send), [{ type: "sendMessage", id: A, text: quoteReplyBody([Q1], "/compact") }]);
+});
+
+test("Send now releases the stack alone, and a session that is not reachable keeps it, with a word to the user", () => {
+  const { H, api, strip } = world();
+  const items = [{ text: "rename it", cites: [Q1] }, { text: "a bare note", cites: [] }];
+  for (const it of items) api.stagedMsgs.push(A, it);
+  api.renderStagedStrip(A);
+  H.down.add(A);
+  strip.querySelector(".staged-go")!.fire("click");
+  assert.equal(H.toasts.length, 1);
+  assert.equal(api.stagedMsgs.count(A), 2, "still staged");
+  assert.equal(H.posted.length, 0);
+  H.down.delete(A); H.provisional.add(A);
+  strip.querySelector(".staged-go")!.fire("click");
+  assert.equal(H.toasts.length, 2, "a provisional tab is not reachable either");
+  assert.equal(api.stagedMsgs.count(A), 2);
+  H.provisional.delete(A);
+  strip.querySelector(".staged-go")!.fire("click");
+  assert.deepEqual(H.posted.filter(send), [{ type: "sendMessage", id: A, text: stagedRunBody(items) }], "the run alone, as one message");
+  assert.equal(api.stagedMsgs.count(A), 0);
+  assert.equal(strip.style.display, "none");
+});
+
+// What the fake DOM cannot see, pinned at the source.
+
+test("CSS: the staged items live in .staged-list, capped at about four items (209px) with its own scroll; the cap's inputs are pinned", () => {
+  assert.match(LIST, /max-height: 209px;/, "four items of 50px (a quote pill and a comment row each) plus three 3px gaps");
+  assert.match(LIST, /overflow-y: auto;/, "the scroll is the list's own");
+  assert.match(LIST, /overflow-x: hidden;/, "never sideways: the pane's rule for every scroll container");
+  assert.match(LIST, /overscroll-behavior: contain;/, "a wheel at the end never scrolls the page");
+  assert.match(LIST, /display: flex; flex-direction: column; gap: 3px;/, "the chips keep the strip's column and gap");
+  // the cap is on the LIST, never on the strip or the head: the head must stay visible above the scroll.
+  // [^{}]* spans a selector list, so a rule whose selectors name the strip or the head anywhere trips it
+  assert.doesNotMatch(CSS, /#composer-staged[^{}]*\{[^}]*max-height/);
+  assert.doesNotMatch(CSS, /\.staged-head[^{}]*\{[^}]*max-height/);
+  // the arithmetic's inputs, so a geometry change here fails loudly instead of quietly showing three or five
+  // (staged-list-layout.test.ts measures the result where a browser is installed)
+  assert.match(CSS, /\.staged-chip \{[^}]*border: 1px dashed[^}]*padding: 2px 6px; font-size: 12px;/);
+  assert.match(CSS, /\.staged-chip \{[^}]*gap: 2px;/);
+  assert.match(CSS, /\.composer-chip \{[^}]*padding: 2px 4px 2px 8px; font-size: 12px; line-height: 1\.4;/);
+  assert.match(CSS, /\.composer-chip-x \{[^}]*font-size: 11px; line-height: 1; padding: 2px 4px;/, "the row's tallest control stays under the row's line");
+  assert.match(CSS, /\.staged-expand \{[^}]*font-size: 0\.86em;/);
+  assert.match(CSS, /html, body \{[^}]*line-height: 1\.6;/);
+  assert.match(CSS, /#composer-staged \{ flex-direction: column; gap: 3px;/);
+  assert.doesNotMatch(LIST, /:has\(/, "no cap lift: an expanded item scrolls inside the list");
+});
+
+test("CSS: an expanded label wraps an unbroken token inside the list; the caret and the label are click targets in the head's own dress", () => {
+  // an expanded item grows inside the scroll, and a long unbroken token in it (a digest, a query string)
+  // wraps instead of widening the list: the list's overflow-x is hidden, so unwrapped it was unreadable
+  assert.match(CSS, /\.staged-chip\.open \.staged-row \.composer-chip-label \{ white-space: pre-wrap; overflow: visible; overflow-wrap: anywhere; \}/);
+  assert.match(CSS, /\.staged-cite\.open \.composer-chip-label \{ white-space: pre-wrap; overflow: visible; overflow-wrap: anywhere; \}/);
+  // the caret: no new font size or colour (the head's own, --dim like the label), and the chip ✕'s padding
+  // so its hit target is that of the strip's other small control rather than the glyph's own width
+  assert.match(CSS, /\.staged-head \.staged-caret \{[^}]*padding: 2px 4px; color: var\(--dim\); font: inherit;[^}]*cursor: pointer;/);
+  assert.match(CSS, /\.staged-head \.staged-lbl \{ cursor: pointer; \}/);
+});
+
+test("the composer closure's call sites: deliver sends only through flushStaged with the typed message, the stage path is the one reveal, and nothing collapses a list on its own", () => {
+  // deliver lives inside setupComposer's closure, which nothing lifts: the typed message rides the flush
+  // as the run's last item, and no second send follows it
+  assert.match(RENDER, /const cites = composerCitations\.get\(activeId\);\s*\n\s*flushStaged\(sid, \{ text, cites, imgPaths: attached\.filter\(\(p\) => previewKind\(p\) === "img"\) \}\);/);
+  const deliverBody = RENDER.split("const deliver = () => {")[1].split("setComposerAskMode();")[0];
+  assert.doesNotMatch(deliverBody, /routeUserMessage\(/, "deliver sends only through flushStaged");
+  assert.equal((deliverBody.match(/flushStaged\(/g) || []).length, 1);
+  // the empty send (nothing typed, nothing attached, something staged) releases the stack alone
+  assert.match(RENDER, /if \(!typed && !\(composerFiles\.get\(activeId\) \|\| \[\]\)\.length && stagedMsgs\.count\(activeId\)\) \{[\s\S]*?flushStaged\(activeId\);\s*\n\s*return;/);
+  // the STAGE path is the one caller with the reveal intent: the new item is the event that justifies the
+  // move, and every other rebuild keeps the place (executed above)
+  assert.match(RENDER, /stagedMsgs\.push\(activeId, \{ text: typed, cites: \(composerCitations\.get\(activeId\) \|\| \[\]\)\.slice\(\) \}\);[\s\S]*?renderStagedStrip\(activeId, \{ reveal: "last" \}\);/);
+  assert.equal((RENDER.match(/renderStagedStrip\(\w+, \{ reveal/g) || []).length, 1, "only the stage path reveals");
+  // the collapse has exactly three writers, all in the strip: the click's toggle (two) and the empty stack's clear
+  assert.equal((RENDER.match(/stagedCollapsed\.(add|delete|clear)\(/g) || []).length, 3, "the renderer never collapses or expands a list on its own");
+  // one routing loop over the module's post list; the composition and its exceptions are decided there,
+  // and quoteReplyBody lives there too (one function for the send, the release and the chip preview)
+  assert.match(RENDER, /import \{ StagedStack, quoteReplyBody, stagedPosts \} from "\.\/staged-messages";/);
+  assert.match(FLUSH, /for \(const p of stagedPosts\(run, typed\)\) routeUserMessage\(sid, p\.text, p\.cites as Citation\[\] \| undefined, p\.imgPaths\);/);
+  assert.equal((FLUSH.match(/routeUserMessage\(/g) || []).length, 1, "no send outside the post list");
+  assert.doesNotMatch(FLUSH, /stagedRunBody|itemId|isSlashCommand/, "not re-derived here");
+  assert.doesNotMatch(RENDER, /^function quoteReplyBody\(/m);
+});

--- a/ui/webview/staged-list-layout.test.ts
+++ b/ui/webview/staged-list-layout.test.ts
@@ -1,0 +1,137 @@
+// The staged list's geometry, measured in a real browser against the real stylesheet: a staged item with
+// one quote is 50px, so the list's 209px cap shows four whole items and a fifth starts the scroll; fewer
+// than four and the list is its content's height; the head sits above the list, outside the scroll; an
+// expanded label wraps an unbroken token instead of widening the list; the caret's hit target is the
+// chip ✕'s, not the glyph's. Runs only where a Playwright browser exists (CI installs none) and SKIPS LOUDLY
+// there; the CI-safe pins on the cap's inputs live in staged-list-cap.test.ts, which also executes the
+// renderer whose markup this page mirrors (the last test here checks the mirror).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const CSS_PATH = path.resolve(process.cwd(), "..", "ui", "webview", "styles.css");
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+const TOKEN = "a".repeat(400);   // one unbroken token wider than the list (a digest, a query string)
+// one staged item as renderStagedStrip builds it: the quote as the composer's blue pill, then the row with
+// the words, the hint and the discard ✕
+const chip = (i: number, o: { quote?: boolean; open?: boolean; text?: string } = {}) =>
+  `<div class="staged-chip${o.open ? " open" : ""}">` +
+  (o.quote === false ? "" : `<div class="composer-chip staged-cite"><span class="composer-chip-mark">“</span><span class="composer-chip-label">quoted line ${i}</span><span class="staged-expand">(expand)</span></div>`) +
+  `<div class="staged-row"><span class="composer-chip-mark">•</span><span class="composer-chip-label">${o.text ?? "comment " + i}</span>` +
+  `<span class="staged-expand">${o.open ? "(collapse)" : "(click to expand)"}</span><button class="composer-chip-x" aria-label="Discard staged message">✕</button></div></div>`;
+// six items: four with one quote each, a bare note, and an expanded item holding the token
+const chips = [0, 1, 2, 3].map((i) => chip(i)).join("") + chip(4, { quote: false }) + chip(5, { open: true, text: TOKEN });
+const html = `<body style="margin:0;width:700px">
+<div id="composer-staged" style="display:flex" data-sid="x">
+  <div class="staged-head"><button class="staged-caret" aria-expanded="true" aria-label="Hide the staged messages">▾</button><span class="staged-lbl">6 staged — sends with your next message</span><button class="staged-go">Send now</button></div>
+  <div class="staged-list">${chips}</div>
+</div>
+</body>`;
+
+type Box = { l: number; r: number; t: number; b: number; w: number; h: number };
+type Measured = {
+  chips: number[]; listClient: number; listScroll: number; listClientW: number; listScrollW: number;
+  wholeVisible: number; head: Box; list: Box; caret: Box; x: Box; openLabelH: number;
+  four: { client: number; scroll: number }; three: { client: number; scroll: number };
+};
+
+// The measurement runs in a standalone driver process (the T225 served-test pattern): the test bundle is
+// CommonJS without top-level await, and esbuild must never try to bundle playwright itself.
+const DRIVER = `
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+let chromium;
+try { chromium = require("playwright").chromium; } catch (e) { process.exit(3); }
+let browser;
+try { browser = await chromium.launch(); } catch (e) { process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 900, height: 1100 } });
+await page.setContent(fs.readFileSync(process.env.HTML_PATH, "utf8"));
+await page.addStyleTag({ path: process.env.CSS_PATH });
+const out = await page.evaluate(() => {
+  const r = (el) => { const b = el.getBoundingClientRect(); return { l: b.left, r: b.right, t: b.top, b: b.bottom, w: b.width, h: b.height }; };
+  const list = document.querySelector(".staged-list");
+  const all = [...document.querySelectorAll(".staged-chip")];
+  const listTop = list.getBoundingClientRect().top;
+  const res = {
+    chips: all.map((c) => c.getBoundingClientRect().height),
+    listClient: list.clientHeight, listScroll: list.scrollHeight, listClientW: list.clientWidth, listScrollW: list.scrollWidth,
+    wholeVisible: all.filter((c) => c.getBoundingClientRect().bottom <= listTop + list.clientHeight + 0.01).length,
+    head: r(document.querySelector(".staged-head")), list: r(list),
+    caret: r(document.querySelector(".staged-caret")), x: r(document.querySelector(".composer-chip-x")),
+    openLabelH: document.querySelector(".staged-chip.open .staged-row .composer-chip-label").getBoundingClientRect().height,
+  };
+  list.removeChild(all[5]); list.removeChild(all[4]);
+  res.four = { client: list.clientHeight, scroll: list.scrollHeight };
+  list.removeChild(all[3]);
+  res.three = { client: list.clientHeight, scroll: list.scrollHeight };
+  return res;
+});
+if (process.env.SHOT) await page.screenshot({ path: process.env.SHOT, fullPage: true });
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\\n");
+await browser.close();
+process.exit(0);
+`;
+
+function measure(): Measured | null {
+  const os = require("node:os");
+  const cp = require("node:child_process");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "staged-layout-"));
+  const driver = path.join(dir, "driver.mjs"); fs.writeFileSync(driver, DRIVER);
+  const htmlPath = path.join(dir, "page.html"); fs.writeFileSync(htmlPath, html);
+  try {
+    const p = cp.spawnSync(process.execPath, [driver], { encoding: "utf8", timeout: 120000,   // the running node, never PATH
+      env: { ...process.env, EXT_PKG: path.resolve(process.cwd(), "package.json"), HTML_PATH: htmlPath, CSS_PATH: CSS_PATH,
+             SHOT: process.env.STAGED_LAYOUT_SHOT || "" } });
+    if (p.status === 3) return null;                                  // no playwright / no browser here
+    if (p.status !== 0) throw new Error("layout driver failed: " + String(p.stderr || p.stdout || p.error || "").slice(-800));
+    const line = (p.stdout || "").split("\n").find((l: string) => l.startsWith("RESULT:"));
+    if (!line) throw new Error("layout driver printed no result: " + (p.stdout || "").slice(-400));
+    return JSON.parse(line.slice("RESULT:".length));
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+const m = measure();
+const skip = m ? false : "no Playwright browser here (CI installs none); the CI-safe pins on the cap's inputs live in staged-list-cap.test.ts";
+
+test("a staged item with one quote is 50px, a bare note about half that, and the list's 209px cap shows exactly four whole items with the rest scrolling", { skip }, () => {
+  for (const h of m!.chips.slice(0, 4)) assert.ok(Math.abs(h - 50) < 0.5, `a one-quote item is 50px (the arithmetic behind the cap), measured ${h}`);
+  assert.ok(m!.chips[4] > 24 && m!.chips[4] < 27, `a bare note is the row alone, about 25px, measured ${m!.chips[4]}`);
+  assert.equal(m!.listClient, 209, "the list's box is the cap");
+  assert.ok(m!.listScroll > m!.listClient, `six items overflow the cap and scroll (${m!.listScroll} in ${m!.listClient})`);
+  assert.equal(m!.wholeVisible, 4, "four whole items in view, the fifth cut at the edge");
+});
+
+test("under four items the list is its content's height: the cap is a ceiling, not a fixed height", { skip }, () => {
+  assert.equal(m!.four.client, 209, "four one-quote items fill the cap exactly");
+  assert.equal(m!.four.scroll, 209, "and nothing to scroll");
+  assert.equal(m!.three.client, m!.three.scroll, "three items: no scroll either");
+  assert.ok(m!.three.client < 209 && Math.abs(m!.three.client - 156) < 1, `three items and two gaps are 156px, measured ${m!.three.client}`);
+});
+
+test("the head with the count and Send now sits above the list, outside the scroll", { skip }, () => {
+  assert.ok(m!.head.b <= m!.list.t + 0.01, `head bottom ${m!.head.b} above list top ${m!.list.t}`);
+  assert.ok(m!.head.h < 30, `the head is one line, measured ${m!.head.h}`);
+});
+
+test("an expanded label wraps an unbroken token inside the list instead of widening it", { skip }, () => {
+  assert.ok(m!.listScrollW <= m!.listClientW, `no sideways overflow (${m!.listScrollW} in ${m!.listClientW})`);
+  assert.ok(m!.openLabelH > 40, `the 400-character token wrapped to several lines, measured ${m!.openLabelH}`);
+});
+
+test("the caret's hit target is the chip ✕'s, not the glyph's", { skip }, () => {
+  assert.ok(m!.caret.h >= m!.x.h - 1, `caret ${m!.caret.h}px tall against the ✕'s ${m!.x.h}`);
+  assert.ok(m!.caret.w >= 13, `caret ${m!.caret.w}px wide: the glyph plus the ✕'s side padding`);
+});
+
+test("the page mirrors the renderer's anatomy (CI-safe pin)", () => {
+  const strip = RENDER.split("function renderStagedStrip(")[1].split("\nfunction ")[0];
+  for (const mint of [`el("div", "staged-head")`, `el("button", "staged-caret")`, `el("span", "staged-lbl")`, `el("button", "staged-go")`, `el("div", "staged-list")`,
+                      `el("div", "staged-chip")`, `el("div", "composer-chip staged-cite"`, `el("span", "composer-chip-mark")`, `el("span", "composer-chip-label")`,
+                      `el("span", "staged-expand")`, `el("div", "staged-row")`, `el("button", "composer-chip-x")`])
+    assert.ok(strip.includes(mint), "the renderer builds " + mint);
+  assert.ok(strip.includes(`chip.classList.add("open")`), "an expanded item wears .open");
+  assert.ok(strip.includes(`strip.style.display = "flex"`), "the strip shows as a flex column");
+});

--- a/ui/webview/staged-messages.test.ts
+++ b/ui/webview/staged-messages.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { StagedStack } from "./staged-messages";
+import { StagedStack, quoteReplyBody, stagedRunBody, stagedPosts, isSlashCommand } from "./staged-messages";
 
 test("stage order is release order, and a flush is one-shot", () => {
   const s = new StagedStack();
@@ -60,4 +60,162 @@ test("a staged line stays inside the pane: shrinkable strips, ellipsis, click-to
     "the one-line ellipsis that the shrinkable strip finally lets engage");
   assert.match(RENDER, /hint\.textContent = open \? "\(collapse\)" : "\(click to expand\)";/,
     "the tail names the gesture");
+});
+
+// The one-message release: a plain send posts the staged run and the typed message as ONE body, and the
+// body is this module's return value, so these tests run the composition instead of reading render.ts.
+
+const Q1 = { quote: "const a = 1;", src: "src/a.ts:12-12", title: "t" };
+const Q2 = { quote: "first line\nsecond line", title: "t" };
+// a goal citation names the card the words follow up on; a synthetic session id, private to this file
+const G = { itemId: "7a1c3e5f-0b2d-4c6e-8f90-a1b2c3d4e5f6:g1", title: "t" };
+const J = (v: unknown) => JSON.parse(JSON.stringify(v));   // drops undefined-valued keys, so shapes compare by content
+
+test("quoteReplyBody: one section per quote in strip order, then the text; a file highlight names its source; no quote is the text alone", () => {
+  assert.equal(quoteReplyBody([Q1], "rename it"),
+    "Replying to this highlighted code (src/a.ts:12-12):\n> const a = 1;\n\nrename it");
+  assert.equal(quoteReplyBody([Q2], "why two?"),
+    "Replying to this part of the conversation:\n> first line\n> second line\n\nwhy two?");
+  assert.equal(quoteReplyBody([Q1, Q2], "both"),
+    quoteReplyBody([Q1], "") + "\n\n" + quoteReplyBody([Q2], "") + "\n\nboth", "stacked quotes, strip order, text last");
+  assert.equal(quoteReplyBody([Q1], ""), "Replying to this highlighted code (src/a.ts:12-12):\n> const a = 1;",
+    "context only: no dangling blank tail");
+  assert.equal(quoteReplyBody([], "bare"), "bare", "no quote at all is the text alone, no leading blank lines");
+  assert.equal(quoteReplyBody([], ""), "");
+});
+
+test("stagedRunBody: N items become ONE body in stage order, each as its quote block(s) then its comment, blank-line separated", () => {
+  const items = [
+    { text: "rename it", cites: [Q1] },
+    { text: "why two?", cites: [Q2] },
+    { text: "and a bare note", cites: [] },
+  ];
+  const body = stagedRunBody(items);
+  assert.equal(body, [
+    "Replying to this highlighted code (src/a.ts:12-12):\n> const a = 1;\n\nrename it",
+    "Replying to this part of the conversation:\n> first line\n> second line\n\nwhy two?",
+    "and a bare note",
+  ].join("\n\n"));
+  // each section is byte for byte what the item sent on its own before the release was one message
+  for (const it of items) assert.ok(body.includes(quoteReplyBody(it.cites as any, it.text)), "the item's own body is a section");
+  assert.ok(body.indexOf("rename it") < body.indexOf("why two?") && body.indexOf("why two?") < body.indexOf("and a bare note"), "stage order");
+});
+
+test("stagedRunBody: the typed message closes the body; alone, one item composes exactly what it sent before", () => {
+  const items = [{ text: "rename it", cites: [Q1] }];
+  assert.equal(stagedRunBody(items, { text: "that is all", cites: [] }),
+    quoteReplyBody([Q1], "rename it") + "\n\nthat is all");
+  // a typed message with its own quote chips keeps its quote block ahead of its words, after the staged run
+  assert.equal(stagedRunBody(items, { text: "and this", cites: [Q2] }),
+    quoteReplyBody([Q1], "rename it") + "\n\n" + quoteReplyBody([Q2], "and this"));
+  // Send now: nothing typed, one item, the body it always sent
+  assert.equal(stagedRunBody(items), quoteReplyBody([Q1], "rename it"));
+  // a goal citation is not a quote and adds no section: the kernel wraps a goal follow-up itself
+  assert.equal(stagedRunBody(items, { text: "follow-up words", cites: [G] }),
+    quoteReplyBody([Q1], "rename it") + "\n\nfollow-up words");
+});
+
+test("stagedRunBody: an empty item adds nothing, no stray separators, and nothing at all is the empty string", () => {
+  assert.equal(stagedRunBody([]), "");
+  assert.equal(stagedRunBody([], { text: "just typed", cites: [] }), "just typed");
+  assert.equal(stagedRunBody([{ text: "", cites: [] }], { text: "typed", cites: [] }), "typed", "an item with nothing to say is skipped");
+  assert.equal(stagedRunBody([{ text: "", cites: [Q1] }]), quoteReplyBody([Q1], ""), "context only stages as its quote block");
+  assert.equal(stagedRunBody([{ text: "t", cites: [{ quote: "" }] }]), "t", "an empty quote is not a quote: no lead-in, no empty block");
+  assert.doesNotMatch(stagedRunBody([{ text: "a", cites: [] }, { text: "b", cites: [] }]), /^\n|\n$|\n\n\n/, "no leading, trailing or tripled blank lines");
+});
+
+// The release's post list: a goal follow-up and a slash command each go on their own, at their place in
+// stage order, and the items between them share one body. render.ts routes exactly these posts, one
+// routeUserMessage call each.
+
+test("isSlashCommand mirrors the kernel's shape test: a slash, a name, then whitespace or the end, at the head of the trimmed text", () => {
+  // the name's first character is ASCII on both sides; its tail is Unicode letters and digits, as the
+  // kernel's word class is, so "/résumé" is a command and "/é" is not
+  for (const t of ["/clear", "/clear ", " /compact", "/model opus", "/fast on", "/effort high\nmore lines", "/mcp:x", "/9lives", "/re-run now", "/clear\nfile.png", "/résumé", "/café now", "/a٣"])
+    assert.ok(isSlashCommand(t), JSON.stringify(t));
+  for (const t of ["", "a /clear", "/", "/ clear", "//", "/Users/x", "/a/b", "/-x", "/clear,now", "not a command", "see /clear", "/é", "/é x"])
+    assert.ok(!isSlashCommand(t), JSON.stringify(t));
+});
+
+test("stagedPosts: the plain shapes are one post (Send now) or one post with the typed message last; nothing staged posts the typed message as itself", () => {
+  const items = [{ text: "rename it", cites: [Q1] }, { text: "and a bare note", cites: [] }];
+  assert.deepEqual(J(stagedPosts(items)), [{ text: stagedRunBody(items) }]);
+  const typed = { text: "that is all", cites: [Q2], imgPaths: ["a.png"] };
+  assert.deepEqual(J(stagedPosts(items, typed)), [{ text: stagedRunBody(items, typed), imgPaths: ["a.png"] }], "the typed images ride the run they close");
+  // a typed goal citation wraps the run: the one post carries exactly that citation and the goal wraps the lot
+  assert.deepEqual(J(stagedPosts(items, { text: "follow-up words", cites: [G] })), [{ text: stagedRunBody(items) + "\n\nfollow-up words", cites: [G] }]);
+  // nothing staged: the typed message, citations and images intact, exactly as a send with no stack
+  assert.deepEqual(J(stagedPosts([], typed)), [typed]);
+  assert.deepEqual(J(stagedPosts([], { text: "/clear" })), [{ text: "/clear" }], "a typed command with nothing staged is the typed message");
+  assert.deepEqual(stagedPosts([]), []);
+});
+
+test("stagedPosts: a typed slash command goes last on its own, never as the tail of the shared body (there, a /clear was prose the agent read)", () => {
+  const items = [{ text: "rename it", cites: [Q1] }, { text: "why two?", cites: [Q2] }];
+  for (const cmd of ["/clear", "/model opus", "/compact", "/fast on", "/clear\nshot.png"]) {
+    const posts = stagedPosts(items, { text: cmd, cites: [], imgPaths: ["shot.png"] });
+    assert.equal(posts.length, 2, cmd);
+    assert.equal(posts[0].text, stagedRunBody(items), "the run goes without the command, and without the typed images");
+    assert.equal(posts[0].imgPaths, undefined);
+    assert.deepEqual(J(posts[1]), { text: cmd, cites: [], imgPaths: ["shot.png"] }, "the command is the whole text of its own post, its images with it");
+  }
+  // a typed command with a goal chip still goes alone, the chip on it
+  assert.deepEqual(J(stagedPosts(items, { text: "/clear", cites: [G] })), [{ text: stagedRunBody(items) }, { text: "/clear", cites: [G] }]);
+});
+
+test("stagedPosts: a staged slash command goes alone at its place; a leading one never heads a shared body (the comments after it were its argument)", () => {
+  const A = { text: "rename it", cites: [Q1] }, B = { text: "why two?", cites: [Q2] }, C = { text: "/compact", cites: [] };
+  assert.deepEqual(stagedPosts([C, A, B], { text: "done", cites: [] }).map((p) => p.text),
+    ["/compact", stagedRunBody([A, B], { text: "done" })]);
+  assert.deepEqual(stagedPosts([A, C, B]).map((p) => p.text),
+    [stagedRunBody([A]), "/compact", stagedRunBody([B])]);
+  assert.deepEqual(stagedPosts([A, B, C], { text: "done", cites: [] }).map((p) => p.text),
+    [stagedRunBody([A, B]), "/compact", "done"], "a run closed by a command: the typed message follows on its own");
+  // the command goes exactly as it went before: its own citations with it. A quote chip on a command means
+  // routeUserMessage wraps it as any quoted message (staged-list-cap.test.ts executes that post) and the
+  // CLI reads it as prose, as it did when every item was its own message; only a bare command fires
+  const Cq = { text: "/compact", cites: [Q1] };
+  assert.deepEqual(J(stagedPosts([Cq, A])), [{ text: "/compact", cites: [Q1] }, { text: stagedRunBody([A]) }]);
+});
+
+test("stagedPosts: a goal follow-up goes alone at its place in stage order and the runs around it share a body each", () => {
+  const A = { text: "rename it", cites: [Q1] }, Gm = { text: "on the card", cites: [G] }, B = { text: "why two?", cites: [Q2] };
+  const typed = { text: "done", cites: [Q2], imgPaths: ["a.png"] };
+  assert.deepEqual(J(stagedPosts([A, Gm, B], typed)), [
+    { text: stagedRunBody([A]) },
+    { text: "on the card", cites: [G] },
+    { text: stagedRunBody([B], typed), imgPaths: ["a.png"] },
+  ]);
+  // a goal item last: the typed message goes on its own after it, its own citations with it
+  assert.deepEqual(J(stagedPosts([A, Gm], { text: "done", cites: [G] })),
+    [{ text: stagedRunBody([A]) }, { text: "on the card", cites: [G] }, { text: "done", cites: [G] }]);
+  // a goal-only stage with nothing typed: the follow-up alone, no empty post
+  assert.deepEqual(J(stagedPosts([Gm])), [{ text: "on the card", cites: [G] }]);
+});
+
+test("stagedPosts invariants over every shape: stage order across the posts, each item once, and no shared body carries a command section", () => {
+  const cmd = { text: "/clear", cites: [] }, note = { text: "a note", cites: [Q1] }, bare = { text: "bare words", cites: [] }, goal = { text: "on the card", cites: [G] };
+  const stages = [[cmd], [note, cmd], [cmd, note], [note, cmd, bare], [goal, cmd], [cmd, goal, note], [note, goal, bare, cmd, note], [note, bare]];
+  const typeds = [undefined, { text: "/model x", cites: [] }, { text: "typed words", cites: [] }, { text: "typed words", cites: [G] }];
+  for (const items of stages) for (const typed of typeds) {
+    const posts = stagedPosts(items, typed);
+    const all = posts.map((p) => p.text).join("\n\n");
+    const seq = typed ? [...items, typed] : items;
+    let at = -1;
+    for (const it of seq) {
+      const i = all.indexOf(it.text, at + 1);
+      assert.ok(i > at, "in stage order: " + it.text + " in " + JSON.stringify(all));
+      at = i;
+    }
+    // and each item's words exactly as many times as they were staged (the order walk above skips past a
+    // doubled section without noticing it)
+    for (const text of new Set(seq.map((it) => it.text)))
+      assert.equal(all.split(text).length - 1, seq.filter((it) => it.text === text).length, "once per staging: " + text + " in " + JSON.stringify(all));
+    for (const p of posts) {
+      if (isSlashCommand(p.text)) { assert.equal(p.text.split("\n\n").length, 1, "a command is the whole post"); continue; }
+      for (const s of p.text.split("\n\n")) assert.ok(!isSlashCommand(s), "no command inside a shared body: " + JSON.stringify(p.text));
+    }
+    // a goal citation rides at most one post, and only a post whose text ends with the words it was typed with
+    for (const p of posts) if ((p.cites || []).some((c: any) => c && c.itemId)) assert.ok(p.text.endsWith("on the card") || p.text.endsWith("typed words"), JSON.stringify(p));
+  }
 });

--- a/ui/webview/staged-messages.ts
+++ b/ui/webview/staged-messages.ts
@@ -1,15 +1,98 @@
-// STAGED messages (the user 2026-08-15): compose against a highlight, hold it, keep reading — then
-// release the whole run together. ⌘/Ctrl+⏎ stages the composer's text WITH its citation chips; a
-// plain send flushes the stack in stage order with the typed message last; the strip's Send now
+// STAGED messages (the user 2026-08-15): compose against a highlight, hold it, keep reading, then release
+// the whole run together. ⌘/Ctrl+⏎ stages the composer's text WITH its citation chips; a plain send
+// releases the stack in stage order as one message with the typed message last; the strip's Send now
 // releases the stack alone. Deliberately NOT "queued": queued is romp's injection-side wait (sent,
-// pending injection into the session); staged is user-side — not sent at all, just held where it
-// was written so each message keeps the context it was written against.
+// pending injection into the session); staged is user-side, not sent at all, just held where it was
+// written so each message keeps the context it was written against.
 //
-// This is the PURE stack — per-tab isolation, order, flush-clears, discard, persistence round-trip —
-// so staged-messages.test.ts EXECUTES the rules instead of regexing render.ts (the repo's
+// This is the PURE stack (per-tab isolation, order, flush-clears, discard, persistence round-trip), the
+// outgoing BODY (quoteReplyBody, stagedRunBody) and the release's post list (stagedPosts), so
+// staged-messages.test.ts EXECUTES the rules instead of regexing render.ts (the repo's
 // extract-for-execution idiom). The DOM strip and the send routing live in render.ts.
 
 export interface StagedMsg { text: string; cites: unknown[] }
+
+/** The outgoing body for QUOTE citations (the user 2026-07-13): the highlighted text rides ahead of the
+ *  typed message as a markdown quote block, so the agent knows exactly which part is being replied to.
+ *  Also what the chip's audit preview shows: one function, no drift. Stacked chips (the user 2026-08-04)
+ *  become one section each, in the order they sit in the strip. `src` (the VS Code editor flavor,
+ *  2026-07-13) names where a highlight came from, a workspace-relative file:lines, so that section's
+ *  lead-in points the agent at the code, not the conversation. No quote at all is the text alone. */
+export function quoteReplyBody(cites: { quote?: string; src?: string | null }[], text: string): string {
+  const sections = cites.map((c) => {
+    const q = (c.quote || "").split("\n").map((l) => "> " + l).join("\n");
+    const lead = c.src ? "Replying to this highlighted code (" + c.src + "):" : "Replying to this part of the conversation:";
+    return lead + "\n" + q;
+  });
+  const quoted = sections.join("\n\n");
+  return quoted && text ? quoted + "\n\n" + text : quoted || text;
+}
+
+/** ONE body for a staged run: each item in stage order as its own section, the quote block(s) it was
+ *  written against and then its comment, byte for byte what the item sent when each item was its own
+ *  message; sections separated by a blank line; the typed message, when the send carries one, last. An
+ *  item with nothing to say (no quote, no text) adds nothing; no items and nothing typed is "". A goal
+ *  citation is not a quote and plays no part here: the kernel wraps a goal follow-up itself (render.ts
+ *  routes those). */
+export function stagedRunBody(items: readonly StagedMsg[], typed?: { text: string; cites?: unknown[] } | null): string {
+  const parts: string[] = [];
+  for (const it of typed ? [...items, typed] : items) {
+    const quotes = (it.cites || []).filter((c): c is { quote: string; src?: string | null } =>
+      !!c && typeof (c as { quote?: unknown }).quote === "string" && !!(c as { quote?: string }).quote);
+    const s = quoteReplyBody(quotes, it.text || "");
+    if (s) parts.push(s);
+  }
+  return parts.join("\n\n");
+}
+
+/** What one send posts: the words, the citation chips they ride with (a goal chip makes the post a
+ *  follow-up on that card; quote chips wrap client-side) and the image paths the echo renders as
+ *  thumbnails. The typed message a release carries has this shape, and so does each post stagedPosts
+ *  returns. */
+export interface Post { text: string; cites?: unknown[]; imgPaths?: string[] }
+
+// a goal citation names the card the words follow up on; the kernel wraps one goal per message
+const isGoalCite = (c: unknown): boolean =>
+  !!c && typeof (c as { itemId?: unknown }).itemId === "string" && !!(c as { itemId?: string }).itemId;
+
+/** The kernel's own shape test for a slash command, mirrored (kernel/kernel.py _SLASH_CMD_RE: a slash, a
+ *  name, then whitespace or the end, at the head of the trimmed text). Shape-matched, not checked against
+ *  a command list, as there: the CLI owns what executes; this only decides that the text must reach it
+ *  alone. The name's tail is Unicode letters and digits, underscore, colon and hyphen, because Python's
+ *  \w is Unicode where JavaScript's is ASCII, and a user-defined command may carry an accented letter. */
+const SLASH_COMMAND_RE = /^\/[A-Za-z0-9][\p{L}\p{N}_:-]*(\s|$)/u;
+export function isSlashCommand(text: string): boolean { return SLASH_COMMAND_RE.test((text || "").trim()); }
+
+/** The posts a release makes, in order (render.ts routes each through routeUserMessage). The rule is ONE
+ *  message for the run, with two kinds of item that go on their own, at their place in stage order, so
+ *  nothing arrives out of the order it was staged in: a GOAL follow-up (the kernel wraps one goal per
+ *  message, askFollowUp) and a SLASH COMMAND (the kernel fires a command only at the head of its own
+ *  text: after another section it is prose the agent reads; ahead of one it takes the sections after it as
+ *  its argument). Each goes exactly as it went when every item was its own message, its own cites with
+ *  it: a bare command reaches the CLI as itself and fires; a command staged with a quote chip is wrapped
+ *  by routeUserMessage as any quoted message is, and one with a goal chip by the kernel's follow-up
+ *  wrapper, so either reads as prose, exactly as it did before, and going alone costs it nothing. The
+ *  items between them share one body. The typed message closes the last run (a typed goal cite
+ *  wraps that run; the typed images ride it) unless it is itself a command, which goes last on its own;
+ *  with no run to close, the typed message posts as itself, cites and images intact, exactly as a send
+ *  with nothing staged. Nothing staged and nothing typed posts nothing. */
+export function stagedPosts(items: readonly StagedMsg[], typed?: Post | null): Post[] {
+  const posts: Post[] = [];
+  let run: StagedMsg[] = [];
+  const close = (last?: Post | null) => {
+    if (!run.length) return;
+    const goal = last ? (last.cites || []).find(isGoalCite) : undefined;
+    posts.push({ text: stagedRunBody(run, last), cites: goal ? [goal] : undefined, imgPaths: last?.imgPaths });
+    run = [];
+  };
+  for (const it of items) {
+    if ((it.cites || []).some(isGoalCite) || isSlashCommand(it.text)) { close(); posts.push({ text: it.text, cites: it.cites }); }
+    else run.push(it);
+  }
+  if (typed && run.length && !isSlashCommand(typed.text)) close(typed);
+  else { close(); if (typed) posts.push({ text: typed.text, cites: typed.cites, imgPaths: typed.imgPaths }); }
+  return posts;
+}
 
 export class StagedStack {
   private m = new Map<string, StagedMsg[]>();

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1051,6 +1051,23 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .staged-head .staged-go { margin-left: auto; background: none; border: 1px solid var(--accent); color: var(--accent);
   border-radius: 5px; font: inherit; padding: 1px 8px; cursor: pointer; }
 .staged-head .staged-go:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }   /* the feed word-button hover (2026-08-25) */
+/* the head's caret and label: a click collapses the strip to the head line alone, count and Send now
+   still on it; the caret is a real button so the keyboard reaches it. It wears --dim like the label and
+   the chip ✕'s padding (2px 4px), so its hit target is that of the strip's other small control (about
+   13 by 15px) rather than the glyph's own 9px: the one control the keyboard and a finger reach */
+.staged-head .staged-caret { flex: 0 0 auto; background: none; border: 0; padding: 2px 4px; color: var(--dim); font: inherit; line-height: 1; cursor: pointer; }
+.staged-head .staged-lbl { cursor: pointer; }
+/* the items in their own scrolling list UNDER the head, about four items tall: a dozen staged comments
+   otherwise fill the page below the strip and push the transcript out of view. A staged item with one
+   quote is 50px (the quote pill 22.8px = 12px text at the pill's 1.4 line height plus 2px padding and
+   1px border top and bottom; the comment row 19.2px = 12px text at the page's 1.6 line height; the 2px
+   gap between them; the item's 2px padding and 1px border top and bottom), so four items and the three
+   3px gaps between them are 209px. The head with the count and Send now sits outside the scroll; an
+   expanded item grows inside it. overflow-x hidden, as on every scroll container in the pane: a
+   scrolling list computes overflow-x to auto on its own, and an expanded item holding one unbroken
+   token (a digest, a query string) wider than the list would give the pane a sideways scroll; the open
+   labels below wrap such a token so it stays readable. */
+.staged-list { display: flex; flex-direction: column; gap: 3px; min-height: 0; max-height: 209px; overflow-x: hidden; overflow-y: auto; overscroll-behavior: contain; }
 /* the chips strip's Stage button (the user 2026-08-23; moved 2026-08-24): it FOLLOWS the blue
    context chips in the strip's column — immediately after what it acts on, where its meaning reads;
    right-justified it floated detached. Exists exactly while context is held (the strip renders it,
@@ -1075,12 +1092,12 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    one-line-ellipsis-then-expand read as everything else here. min-width:0 + max-width guard the
    pane against sideways growth at every level. */
 .staged-cite { min-width: 0; max-width: 100%; cursor: pointer; }
-.staged-cite.open .composer-chip-label { white-space: pre-wrap; overflow: visible; }
+.staged-cite.open .composer-chip-label { white-space: pre-wrap; overflow: visible; overflow-wrap: anywhere; }
 .staged-cite.open { align-items: flex-start; }
 /* min-width:0 lets the flex label actually SHRINK — without it the line ran off the pane edge with no
    ellipsis (the user 2026-08-15); expanded, the same label wraps to the full text */
 .staged-chip .composer-chip-label { flex: 1 1 auto; max-width: 100%; min-width: 0; }
-.staged-chip.open .staged-row .composer-chip-label { white-space: pre-wrap; overflow: visible; }
+.staged-chip.open .staged-row .composer-chip-label { white-space: pre-wrap; overflow: visible; overflow-wrap: anywhere; }
 .staged-chip.open .staged-row { align-items: flex-start; }
 .staged-expand { flex: 0 0 auto; color: var(--dim); font-size: 0.86em; }   /* chrome, not message text */
 .composer-chip-x {


### PR DESCRIPTION
A release of the staged run goes out as one message, and the strip above the composer shows about four items and scrolls the rest.

## Tier

Tier: feature

## Design

**One message per release.** `stagedPosts` and `stagedRunBody` (ui/webview/staged-messages.ts) compose the staged items in stage order, each as its quote block(s) and then its comment, byte for byte what the item sent on its own, separated by a blank line, with the typed message last; `flushStaged` routes the result through the existing `routeUserMessage`, one call per post. One post, one bubble, one turn. Send now and the next-message path share the composition, and with nothing staged the typed message routes exactly as before.

**What e35381e3 set, and what changes.** That commit released a run as a series of messages, each keeping its quote, so the run read quote, comment, quote, comment. The property survives: the one body keeps every quote with its comment in stage order, so the agent reads the same sequence. What changes is how the run arrives. A series lands in pieces. The first note starts a turn on its own, and the rest reach the agent only at its next tool boundary, or after the turn when it has none; the agent begins its answer before it has read the whole run, and the chat shows a bubble per note. One message is one turn over the whole run, read in full before it is answered. If the series is preferred as a choice, a setting (one message or a series) is the fallback: the composition is a pure function, so the setting would select between `stagedPosts` and a per-item loop.

**Two kinds of item still go alone, at their place in stage order.** A goal follow-up: the kernel wraps one goal per message through askFollowUp, so a staged item citing a goal posts on its own, and a typed goal citation wraps the run before it as that follow-up's text. A slash command, staged or typed: the kernel fires a command only at the head of its own text, so after another section a typed `/clear` would be prose the agent read, and ahead of one a staged `/compact` would take the comments after it as its argument. `isSlashCommand` mirrors the kernel's `_SLASH_CMD_RE` shape (a slash, a name, then whitespace or the end, at the head of the trimmed text), with a Unicode letter and digit class for the name's tail because Python's `\w` is Unicode where JavaScript's is ASCII. A command staged with a quote chip goes with its chip, and `routeUserMessage` wraps it as it wraps any quoted message, so the CLI reads it as prose; that is what it did when every item was its own message, and going alone costs it nothing. Several goals in one message would need a multi-goal askFollowUp and is out of scope; the kernel is unchanged.

**`quoteReplyBody` moves into the module.** The live send, the release and the chip's audit preview compose from one function, and the test executes it. Its no-quote case returns the text alone; render.ts only ever called it with at least one quote, so existing sends are byte-identical.

**The strip.** The items sit in a `.staged-list` under the head with `max-height: 209px`, derived from the existing chip geometry (a one-quote item is 50px: the 22.8px quote pill, the 19.2px comment row, the 2px gap between them, 2px padding and 1px border top and bottom; four items plus three 3px gaps), its own vertical scroll, `overflow-x: hidden` (the pane never scrolls sideways; an expanded label holding an unbroken token wraps with `overflow-wrap: anywhere`) and `overscroll-behavior: contain`. The head with the count and Send now stays outside the scroll; an expanded item grows inside it. The scroll offset is kept per tab under the sid that built the list (`strip.dataset.sid`), read once before the rebuild, so an expand or a discard keeps the place and a tab switch never carries one tab's offset onto another; an emptied list forgets it. Staging is the one caller that reveals the new item, since the new item is the event that justifies the move.

**The caret.** A button on the head (aria-expanded, aria-label, keyboard-reachable, focus kept across the rebuild) and the label collapse the strip to the head line; the count and Send now stay on it. The caret takes the chip ✕'s padding, so its hit target is that of the strip's other small control (about 13 by 15px) rather than the glyph's own 9px. The state is a page-lifetime Set written by the click and cleared when the stack empties, so the collapse belongs to the stack the user collapsed (the next stack starts shown, its first item in view) and a reload shows the list again. No new font sizes or colors: the caret wears `--dim` like the label. The tooltip on the count names the one-message release and its two exceptions; docs/guide.md gains a sentence on the list and says "as one message".

**Left out.** No kernel change. Persisted staged items keep their `{text, cites}` shape, so nothing staged before this lands is lost or migrated. The cap is in px at the pinned 12px chip text; a zoomed pane shows more or fewer than four, and the input pins hold the geometry so a change there fails a test rather than quietly showing three or five. The client's slash-command test mirrors the kernel regex by hand; a Python-side pin of the regex text would tie the two together.

## Tests

- `ui/webview/staged-messages.test.ts`: ten new executed cases over `quoteReplyBody`, `stagedRunBody`, `isSlashCommand` and `stagedPosts` (plain shapes, a typed command last and alone, a staged command alone at its place, a goal follow-up alone with the runs around it, an empty quote adding no section, and an invariant check over every shape: stage order across posts, each item exactly as often as it was staged, no shared body carries a command section). Before the change the module has none of the four exports, so the test bundle is refused with four "no matching export" errors.
- `ui/webview/staged-list-cap.test.ts` (new): `routeUserMessage`, `flushStaged` and `renderStagedStrip` lifted out of render.ts, transpiled at run time and executed over a fake DOM with the real `StagedStack` and the module's composition under them (the tab-strip-skip-exec.test.ts idiom). Six executed cases: the head first and every chip in the list, with the tooltip and no drag; the scroll offset kept across an expand, a discard and a switch, per tab, the reveal on stage and the forgetting on empty; the caret and the label collapsing the strip and back, per tab, the mark ending with the stack; focus kept on the rebuilt caret; the frames the kernel receives from a release (one `sendMessage` for the shared body, `askFollowUp` and a bare command at their place, a quoted command wrapped as prose); Send now alone, and held with a toast while the session is unreachable. All six fail against render.ts before the change (no `.staged-list`, no caret, a series of sends). Three pin cases cover what a fake DOM cannot see: the CSS cap with its geometry inputs and never on the strip or the head, the wrap rules and the caret's dress, and the composer closure's call sites (deliver's single `flushStaged`, the stage path as the one reveal, exactly three writers of the collapse Set, the one routing loop).
- `ui/webview/staged-list-layout.test.ts` (new): the cap measured in a real browser against the stylesheet, in the queued-romp-layout.test.ts shape, skipping loudly where no Playwright browser is installed (CI installs none): a one-quote item is 50px and a bare note about 25px, the list's client height is 209px with exactly four whole items in view of six, four items fill the cap with no scroll and three are 156px, the head sits above the list, a 400-character token in an expanded label wraps without sideways overflow, the caret's hit target is at least the chip ✕'s. Against the stylesheet before the change four of the five measured cases fail; one CI-safe pin checks that the page mirrors the renderer's markup.
- Re-aimed pins: `composer-citation.test.ts` (deliver's single `flushStaged` call, the wrap and the lead-in read from the module), `send-scroll-preserve.test.ts` (flushStaged's signature and loop), `rewind-edit.test.ts` (the edit branch precedes `flushStaged(sid, {`), `optimistic-send.test.ts` (image paths ride each post), `composer-send.test.ts` (the two open-label rules gain `overflow-wrap: anywhere`).
- Run: `npm run typecheck` clean; `npm test` 3687 passed, 0 failed, 0 skipped (the layout suite ran against a local Chromium; on a runner without one its five measured cases skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)