### PR TITLE
Remote clears keep their session: a route strips only its own host prefix, and the viewer's-ledger overlay reads the row's sid

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -30728,7 +30728,11 @@ def _cleared_foreign(cleared):
             local.update(n[:-5] for n in os.listdir(d) if n.endswith(".json"))
         except OSError:
             pass
-    return sorted(i for i in cleared if i.rsplit(":", 1)[0] not in local)[:500]
+    # newest first under the cap (T287: a cut by id text dropped yesterday's clears on a long ledger), and only
+    # ids that name a session (a bare node id a mis-stripped route once recorded matches no card anywhere)
+    foreign = [i for i in cleared if ":" in i and i.rsplit(":", 1)[0] not in local]
+    foreign.sort(key=lambda i: (-(cleared.get(i) or 0), i))
+    return foreign[:500]
 
 
 def _cleared_ids():

--- a/tests/test_kernel_goal_compaction.py
+++ b/tests/test_kernel_goal_compaction.py
@@ -300,8 +300,13 @@ class ClearedLedgerIsAuthoritativeAcrossTheCompaction(unittest.TestCase):
                          "the foreign clear rides; the local one and the undone one do not")
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn('"clearedForeign": _cleared_foreign(cleared),', src, "on the feed payload beside dismissedCount")
-        many = {"%s:g%d" % (foreign_sid, i): i for i in range(700)}
-        self.assertEqual(len(km._cleared_foreign(many)), 500, "capped")
+        many = {"%s:g%d" % (foreign_sid, i): 1_000_000 + i for i in range(700)}
+        got = km._cleared_foreign(many)
+        self.assertEqual(len(got), 500, "capped")
+        self.assertEqual(got[0], "%s:g699" % foreign_sid, "newest first under the cap (T287: yesterday's clears must ride)")
+        self.assertNotIn("%s:g0" % foreign_sid, got, "the oldest fall off, not the newest")
+        junk = {"g448": 5, "g7": 6, foreign_sid + ":g1": 7}
+        self.assertEqual(km._cleared_foreign(junk), [foreign_sid + ":g1"], "a bare node id with no session rides nowhere")
 
     def test_the_compaction_stamps_a_root_only_the_ledger_clears(self):
         self._completed_top("g4")

--- a/ui/webview/federation-cleared-overlay.test.ts
+++ b/ui/webview/federation-cleared-overlay.test.ts
@@ -12,13 +12,13 @@ const A = "HOSTA:" + SID;
 function remoteFeed() {
   return {
     type: "feed", now: 100,
-    asks: [{ itemId: A + ":g1", sid: A }, { itemId: A + ":g2", sid: A }],
-    items: [{ itemId: A + ":g9", sid: A }],
+    asks: [{ itemId: SID + ":g1", sid: A }, { itemId: SID + ":g2", sid: A }],
+    items: [{ itemId: SID + ":g9", sid: A }],
     ledgers: [{ sid: A, name: "HOSTA:api", ledger: { tree: [], archivedTops: [
-      { id: A + ":g1", depth: 0, cleared: false, done: true },
-      { id: A + ":g1a", depth: 1, cleared: false, done: true },
-      { id: A + ":g3", depth: 0, cleared: false, done: true },
-      { id: A + ":g3a", depth: 1, cleared: false, done: true },
+      { id: SID + ":g1", depth: 0, cleared: false, done: true },
+      { id: SID + ":g1a", depth: 1, cleared: false, done: true },
+      { id: SID + ":g3", depth: 0, cleared: false, done: true },
+      { id: SID + ":g3a", depth: 1, cleared: false, done: true },
     ] } }],
   };
 }
@@ -27,7 +27,7 @@ test("a foreign clear on the local payload drops the remote ask and reads the re
   const local = { type: "feed", now: 7, asks: [{ itemId: SID + ":g1", sid: SID }], ledgers: [], clearedForeign: [SID + ":g1", SID + ":g9"] };
   const remote = remoteFeed();
   const merged = mergeHostFeeds({ "": local, HOSTA: remote }, ["", "HOSTA"]);
-  assert.deepEqual(merged.asks.map((a: any) => a.itemId), [SID + ":g1", A + ":g2"], "the remote g1 ask is gone; the LOCAL g1 stays (the local kernel already applied its ledger)");
+  assert.deepEqual(merged.asks.map((a: any) => [a.sid, a.itemId]), [[SID, SID + ":g1"], [A, SID + ":g2"]], "the remote g1 ask is gone; the LOCAL g1 stays (the local kernel already applied its ledger)");
   assert.deepEqual(merged.items.map((c: any) => c.itemId), [], "the remote item is gone");
   const tops = merged.ledgers.find((l: any) => l.sid === A).ledger.archivedTops;
   assert.deepEqual(tops.map((n: any) => [n.id.split(":").pop(), n.cleared]),
@@ -47,8 +47,8 @@ test("without foreign ids nothing changes, and a remote host with none named pas
 });
 
 test("the overlay is pure over the rows it is given and ignores junk ids", () => {
-  const merged: any = { asks: [{ itemId: A + ":g1" }], items: [] };
-  const ledgers = [{ sid: A, ledger: { tree: [], archivedTops: [{ id: A + ":g1", depth: 0, cleared: false }] } }];
+  const merged: any = { asks: [{ itemId: SID + ":g1", sid: A }], items: [] };
+  const ledgers = [{ sid: A, ledger: { tree: [], archivedTops: [{ id: SID + ":g1", depth: 0, cleared: false }] } }];
   applyViewerClears(merged, ledgers, [SID + ":g1", 42, null]);
   assert.equal(merged.asks.length, 0);
   assert.equal(ledgers[0].ledger.archivedTops[0].cleared, true);

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -260,6 +260,13 @@ export interface Route {
  *  name, which inbound prefixing made `host:name`) route to a KNOWN host only — a local name that happens
  *  to contain ":" must never misroute — and messages with no sid that mean the same thing on every kernel
  *  (a hover CLEAR, the gear's kernel-side settings) fan out to all of them. */
+/** `id` without `host`'s own prefix when it carries it ("host:rest" → "rest"), else unchanged: the strip a remote
+ *  route applies to what it sends, so an id that never had the prefix (a card id "sid:gN") keeps every part. The
+ *  first-colon cut (bareId) is right only for ids KNOWN to be prefixed, and an outbound message mixes both. */
+export function stripHost(host: string, id: string): string {
+  return host && typeof id === "string" && id.startsWith(host + ":") ? id.slice(host.length + 1) : id;
+}
+
 export function routeOutbound(msg: any, knownHosts?: ReadonlySet<string>): Route[] {
   if (!msg || typeof msg !== "object") return [{ host: LOCAL, msg }];
 
@@ -326,9 +333,13 @@ export function routeOutbound(msg: any, knownHosts?: ReadonlySet<string>): Route
   }
   if (host !== LOCAL) {
     const out: any = { ...msg };
-    for (const k of SCALAR_ID) if (typeof out[k] === "string") out[k] = bareId(out[k]);
-    // a batched clear (askClearMany) carries the session's card ids too — the remote kernel wants them bare
-    if (Array.isArray(out.itemIds)) out.itemIds = out.itemIds.map((x: any) => typeof x === "string" ? bareId(x) : x);
+    for (const k of SCALAR_ID) if (typeof out[k] === "string") out[k] = stripHost(host, out[k]);
+    // a batched clear (askClearMany) carries the session's card ids too — the remote kernel wants them without
+    // the host prefix. ONLY the host prefix (T287, the user 2026-09-09): a card id is "sid:gN" and prefixInbound
+    // prefixes the ask's sid, not its item ids, so the first-colon cut bareId makes turned "sid:g448" into
+    // "g448"; the owning kernel then recorded a node id with no session, cleared nothing, and the cards the
+    // laptop's session-header Clear all had crossed off came back with the next payload and every restart.
+    if (Array.isArray(out.itemIds)) out.itemIds = out.itemIds.map((x: any) => typeof x === "string" ? stripHost(host, x) : x);
     return [{ host, msg: out }];
   }
 
@@ -391,17 +402,21 @@ export function mergeHostOrder(perHost: Record<string, readonly string[]>, hostS
 export function applyViewerClears(merged: any, ledgers: any[], clearedForeign: any): void {
   const foreign = new Set<string>(Array.isArray(clearedForeign) ? clearedForeign.filter((x: any) => typeof x === "string") : []);
   if (!foreign.size) return;
-  const hit = (id: any) => typeof id === "string" && hostOf(id) !== LOCAL && foreign.has(bareId(id));
-  merged.asks = merged.asks.filter((a: any) => !hit(a?.itemId));
-  merged.items = merged.items.filter((c: any) => !hit(c?.itemId));
+  // Remoteness is the ROW's sid (prefixInbound prefixes it: "host:sid"); the item and node ids are unprefixed
+  // ("sid:gN") and compare as they are against the bare foreign ids (T287: reading the id's own first colon as
+  // a host took the uuid for a host and compared "gN", so nothing ever matched).
+  const remote = (sid: any) => typeof sid === "string" && hostOf(sid) !== LOCAL;
+  const hit = (sid: any, id: any) => remote(sid) && typeof id === "string" && foreign.has(id);
+  merged.asks = merged.asks.filter((a: any) => !hit(a?.sid, a?.itemId));
+  merged.items = merged.items.filter((c: any) => !hit(c?.sid, c?.itemId));
   ledgers.forEach((l: any, i: number) => {
-    if (!l || typeof l.sid !== "string" || hostOf(l.sid) === LOCAL) return;
+    if (!l || !remote(l.sid)) return;
     const tops = l.ledger?.archivedTops;
     if (!Array.isArray(tops) || !tops.length) return;
     let rootCleared = false, changed = false;
     const out = tops.map((n: any) => {
-      if (n?.depth === 0) rootCleared = !!n.cleared || hit(n.id);
-      const c = !!n?.cleared || hit(n?.id) || (n?.depth !== 0 && rootCleared);
+      if (n?.depth === 0) rootCleared = !!n.cleared || (typeof n.id === "string" && foreign.has(n.id));
+      const c = !!n?.cleared || (typeof n?.id === "string" && foreign.has(n.id)) || (n?.depth !== 0 && rootCleared);
       if (c === !!n?.cleared) return n;
       changed = true;
       return { ...n, cleared: c };

--- a/ui/webview/routing-clear-ids.test.ts
+++ b/ui/webview/routing-clear-ids.test.ts
@@ -1,0 +1,44 @@
+// A remote route strips only its own host's prefix (T287, the user 2026-09-09): the session header's Clear all
+// reached the owning kernel with every item id cut at its first colon ("sid:g448" → "g448"), so the owner recorded a
+// node id with no session, cleared nothing, and the cards came back with the next payload and every restart. The
+// same first-colon reading kept the viewer's-ledger overlay from ever matching a remote row.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { routeOutbound, stripHost, mergeHostFeeds } from "./federation";
+
+const SID = "11111111-2222-3333-4444-555555555555";
+
+test("stripHost removes exactly the route's own host prefix and nothing else", () => {
+  assert.equal(stripHost("box2", "box2:" + SID), SID);
+  assert.equal(stripHost("box2", "box2:" + SID + ":g1"), SID + ":g1");
+  assert.equal(stripHost("box2", SID + ":g448"), SID + ":g448", "an unprefixed card id keeps its session");
+  assert.equal(stripHost("box2", "box3:" + SID), "box3:" + SID, "another host's prefix is not ours to strip");
+  assert.equal(stripHost("", SID + ":g1"), SID + ":g1");
+});
+
+test("a session header's Clear all routed to a remote kernel keeps every item id whole", () => {
+  const r = routeOutbound({ type: "askClearMany", sid: "box2:" + SID, itemIds: [SID + ":g448", SID + ":g449", "box2:" + SID + ":g450"] });
+  assert.equal(r.length, 1);
+  assert.equal(r[0].host, "box2");
+  assert.equal(r[0].msg.sid, SID, "the sid loses its host prefix");
+  assert.deepEqual(r[0].msg.itemIds, [SID + ":g448", SID + ":g449", SID + ":g450"],
+    "the owner receives session-qualified card ids, whether or not one arrived prefixed");
+  const single = routeOutbound({ type: "askClear", sid: "box2:" + SID, itemId: SID + ":g5" });
+  assert.deepEqual([single[0].host, single[0].msg.sid, single[0].msg.itemId], ["box2", SID, SID + ":g5"]);
+  const local = routeOutbound({ type: "askClearMany", sid: SID, itemIds: [SID + ":g1"] });
+  assert.deepEqual([local[0].host, local[0].msg.itemIds], ["", [SID + ":g1"]], "a local route touches nothing");
+});
+
+test("the viewer's-ledger overlay matches a remote row by its prefixed sid and its unprefixed item id", () => {
+  const A = "box2:" + SID;
+  const remote = { type: "feed", now: 1, asks: [{ itemId: SID + ":g1", sid: A }, { itemId: SID + ":g2", sid: A }], items: [],
+                   ledgers: [{ sid: A, name: "box2:api", ledger: { tree: [], archivedTops: [
+                     { id: SID + ":g1", depth: 0, cleared: false, done: true }, { id: SID + ":g1a", depth: 1, cleared: false, done: true },
+                     { id: SID + ":g3", depth: 0, cleared: false, done: true }] } }] };
+  const local = { type: "feed", now: 7, asks: [{ itemId: SID + ":g1", sid: SID }], ledgers: [], clearedForeign: [SID + ":g1"] };
+  const merged = mergeHostFeeds({ "": local, box2: remote }, ["", "box2"]);
+  assert.deepEqual(merged.asks.map((a: any) => [a.sid, a.itemId.split(":").pop()]), [[SID, "g1"], [A, "g2"]],
+    "the remote g1 is dropped, the local twin stays");
+  const tops = merged.ledgers.find((l: any) => l.sid === A).ledger.archivedTops;
+  assert.deepEqual(tops.map((n: any) => [n.id.split(":").pop(), n.cleared]), [["g1", true], ["g1a", true], ["g3", false]]);
+});


### PR DESCRIPTION
Tier: fix

## What

Cleared cards owned by another kernel came back on every restart (the user, 2026-09-09; the session-header Clear all from the laptop over devbox cards). Two defects, one cause: the client took an id's first colon for a host prefix.

**Root cause, verified on the owning kernel's ledger.** It holds 127 cleared ids that are bare node ids with no session at all ("g20", "g1609", …), the newest written minutes after the user's gesture; every other row is "sid:gN". The session header's Clear all (`askClearMany`) is routed to the owning kernel by the ask's host-prefixed sid, but the route stripped every id with `bareId`, which cuts everything before the first colon, and `prefixInbound` prefixes an ask's sid, not its item ids, so an unprefixed "sid:g448" became "g448". The owner recorded a node id with no session, cleared nothing, and the viewer's optimistic clear painted the cards gone until the next remote payload or restart brought them back. The single-card clear was unaffected (its `itemId` is not among the stripped fields), which is why some clears held and others did not.

**The same reading kept the viewer's-ledger overlay (#1190) from ever matching**: it read a remote ask's unprefixed item id, took the uuid for a host and compared "gN" against bare "sid:gN" ids; archived tops' ids are unprefixed too. And the overlay's foreign-id list was cut at 500 by id text, so on a long ledger yesterday's clears could fall off.

**Fix.**
- A remote route strips exactly its own host prefix (`stripHost`: "host:rest" to "rest", else unchanged) from the sid fields and the item ids, never a first-colon cut. A remote session-header Clear all now arrives at the owner with "sid:gN" ids and clears them.
- The overlay takes remoteness from the row's host-prefixed sid and compares item and node ids as they are, so the bare devbox ids already in a viewer's ledger apply over that host's rows: the safety net for the rows already recorded.
- The payload's foreign-id list rides newest first under its cap and skips ids that name no session (the junk rows a mis-stripped route recorded match no card anywhere).

Both kernels need this build: the viewer's, which serves the dashboard bundle, for the routing and the overlay; the owner's for nothing new, its clear handler was always right once the ids arrive whole. The junk rows already in the owner's ledger stay inert.

**Declined, stated:** a one-time forward on boot of a kernel's foreign ledger ids to their owners. The kernel cannot map an arbitrary bare sid to its owner (only currently attached hosts' sids are known), the overlay already makes the viewer's ledger authoritative for display, and today's rows show how a wrong id shape propagates between kernels; a separate round with an idempotent cross-kernel clear route would be the place.

No card-move rule changes: a clear lands where it always meant to, with the id it always meant.

## Review (lean, by hand)

`stripHost` is a prefix test, so an id carrying another host's prefix or none passes through, and the local route is untouched (it never stripped). The overlay's remoteness test moved from the id to the row's sid, the field `prefixInbound` actually prefixes; a row without a sid is left alone. The Python cap orders by the ledger's own time, ties by id, deterministic. The kernel's clear handlers are unchanged.

## Tests

`ui/webview/routing-clear-ids.test.ts` (new): `stripHost` removes exactly the route's own prefix; a remote session-header Clear all keeps every item id whole whether or not one arrived prefixed, the sid loses its host, a single-card clear likewise, a local route touches nothing (red before this change: the ids arrived as "gN"); the overlay matches a remote row by its prefixed sid and unprefixed item id and marks archived tops. `ui/webview/federation-cleared-overlay.test.ts`: its rows now carry the real shape (prefixed sid, unprefixed item ids). `tests/test_kernel_goal_compaction.py`: the foreign list is newest first under the cap and skips a bare node id.
