### PR TITLE
Markdown: a file's own <style> or <form> can no longer blank the viewer or navigate the page

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,6 +63,20 @@ UID can read.
 - **Output sanitization:** model output and message content rendered in the
   dashboard/webview pass through DOMPurify; the VS Code webview runs under a
   strict nonce CSP with `localResourceRoots` limited to the extension's assets.
+  The profile is modelled on the rules GitHub applies to a README
+  (`ui/webview/md-sanitize.ts`, shared by the chat and the file viewer): no
+  `<style>`, no form controls, no image map, ids and names prefixed
+  `user-content-`, an inline `style` reduced to its color declarations, no
+  `background` attribute; unlike GitHub it keeps that color-only inline `style`
+  and inline SVG. One renderer writes
+  into that sanitized DOM after DOMPurify has run: KaTeX. The sanitizer keeps
+  only color in an inline `style`, and KaTeX's layout is inline style, so a
+  formula's TeX passes through DOMPurify as the text of an inert placeholder
+  and KaTeX renders it there afterwards, under `trust: false` (KaTeX's own
+  safety model: no TeX command writes a link, an image, or an HTML attribute of
+  the author's choosing). That boundary is checked against the code by
+  `ui/webview/md-sanitize-postpass-browser.test.ts`; the profile, as the browser
+  lays a file out, by `ui/webview/md-sanitize-browser.test.ts`.
 - **No unsafe deserialization:** no `pickle`, `eval`, `exec`, or non-safe YAML on
   untrusted data.
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -58,6 +58,21 @@ beside it shows, and a link to a sibling document opens in the same viewer. Link
 on other sites open in a new tab, as before — and a ctrl- or ⌘-click still opens the file in
 a tab.
 
+**A file's own HTML.** The Rendered view keeps the HTML a markdown file carries, under rules
+modelled on those GitHub applies to a README, so nothing in a file can move, hide or cover the
+viewer's own controls. A `<style>` block is dropped whole. A form, its controls and a
+`<dialog>` are dropped but their text stays as prose. A task-list checkbox stays but cannot be
+ticked. An inline `style` keeps only its `color` and `background-color`, and only when the
+value is a color name, a hex code, or `rgb()`, `rgba()`, `hsl()` or `hsla()`; a span colored
+with any other function, such as `var()`, loses its color. A `background=` attribute is
+dropped, since it would load a remote image the moment the file opens. An inline `svg`, a
+`canvas` or a `video` shrinks to the column, as a picture does, and a table wider than the
+column scrolls sideways on its own. An element's `id` or `name` is prefixed `user-content-`,
+as on GitHub; the viewer's own heading ids are not, so a link to a heading in the file still
+lands on it. An image map (`<map>`, `usemap`) is dropped. The same rules apply to the HTML in
+a chat message, where a link to an element's own `id` or `<a name>` lands on it under the
+prefix.
+
 **Opening a PDF.** A PDF the session mentions, or one you click in the file browser, opens
 inside the dashboard like an image: the chat's PDF card opens it full-view, a path or a
 file-browser row opens it in the file viewer. Cmd-click it instead (Ctrl on Windows and

--- a/ui/webview/chat-md.test.ts
+++ b/ui/webview/chat-md.test.ts
@@ -53,12 +53,15 @@ test("the chat grammar rides along: ~~double~~ strikes, a lone ~ stays literal",
   assert.match(lone, /~21/);
 });
 
-test("the chat grammar rides along: $x$ still renders KaTeX, and a price stays a price", () => {
+test("the chat grammar rides along: $x$ still becomes math, and a price stays a price", () => {
+  // math.ts emits an inert placeholder carrying the TeX; KaTeX is rendered into it after the sanitizer, by
+  // renderMathPlaceholders as a sanitizeMd post-pass this module registers at load (render.ts's userMd() calls
+  // sanitizeMd and nothing of its own), so marked's own output holds the placeholder, never KaTeX's markup
   const out = userMdHtml("Euler: $e^{i\\pi}+1=0$\nnext line");
-  assert.ok(out.includes('class="katex"'), "inline math renders");
+  assert.ok(out.includes('<span class="md-math-inline">e^{i\\pi}+1=0</span>'), "inline math becomes the placeholder: " + out);
   assert.match(out, /<br>\s*next line/, "…and the newline after it is still kept");
   const price = userMdHtml("costs $5 and $10 today");
-  assert.ok(!price.includes('class="katex"'));
+  assert.ok(!price.includes("md-math"));
   assert.match(price, /\$5/);
 });
 
@@ -77,14 +80,21 @@ test("the singleton stays breaks:false — assistant rendering is unchanged", ()
   assert.match(RENDER, /marked\.use\(\.\.\.chatMdExtensions\);/, "…and takes the same grammar the user instance does");
 });
 
-test("userMd() renders through the breaks:true instance and the SAME DOMPurify profile as md()", () => {
-  // (both signatures grew an optional repo parameter for PR links — pr-links.ts — so match them loosely)
+test("userMd() renders through the breaks:true instance and the SAME sanitizer as md()", () => {
+  // both renderers take the sanitized DOM back to link PR references before serializing (pr-links.ts); the
+  // sanitizer is sanitizeMd (md-sanitize.ts), one call shared with the file viewer, which returns the sanitized
+  // <body>; the profile is spelled there and nowhere in render.ts. Both signatures carry an optional repo
+  // parameter for the PR links, so the match on them is loose.
   const fn = RENDER.match(/function userMd\(src: string[^\n]*?\): string \{[\s\S]*?\n\}/)?.[0] || "";
   assert.ok(fn, "userMd() must exist");
-  assert.match(fn, /DOMPurify\.sanitize\(userMdHtml\(src\), \{ \.\.\.MD_PURIFY, RETURN_DOM: true \}\)/);
+  assert.match(fn, /const clean = sanitizeMd\(userMdHtml\(src\)\);/);
   const mdFn = RENDER.match(/function md\(src: string[^\n]*?\): string \{[\s\S]*?\n\}/)?.[0] || "";
-  assert.match(mdFn, /DOMPurify\.sanitize\(dirty, \{ \.\.\.MD_PURIFY, RETURN_DOM: true \}\)/, "md() sanitizes with the same shared profile");
-  assert.match(RENDER, /const MD_PURIFY: Config = \{ USE_PROFILES: \{ html: true, svg: true \}, ADD_DATA_URI_TAGS: \["img"\], ALLOW_DATA_ATTR: false \};/);
+  assert.match(mdFn, /const clean = sanitizeMd\(dirty\);/, "md() sanitizes through the same shared call");
+  assert.match(RENDER, /import \{[^}]*\bsanitizeMd\b[^}]*\} from "\.\/md-sanitize";/);
+  assert.doesNotMatch(RENDER, /from "dompurify"|DOMPurify\.sanitize|MD_PURIFY/, "render.ts holds no sanitizer of its own");
+  const SAN = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "md-sanitize.ts"), "utf8");
+  assert.match(SAN, /USE_PROFILES: \{ html: true, svg: true \},\n\s*ADD_DATA_URI_TAGS: \["img"\],\n\s*ALLOW_DATA_ATTR: false,/);
+  assert.doesNotMatch(fn + mdFn, /USE_PROFILES|ALLOW_DATA_ATTR/, "neither renderer spells its own profile: every option comes through md-sanitize.ts");
 });
 
 test("the user bubble renders the user's OWN words with userMd, harness notes and everything else with md", () => {

--- a/ui/webview/chat-md.ts
+++ b/ui/webview/chat-md.ts
@@ -11,9 +11,12 @@
 // Both take the SAME extensions from `chatMdExtensions`, so a user message with math or strikethrough
 // renders exactly as it did before — only its newlines are kept. Pure (no DOM): the executed tests import
 // it directly, the way render-math.test.ts exercises math.ts. Sanitizing is the caller's job: render.ts's
-// userMd() runs the output through the same DOMPurify profile md() uses before it ever reaches innerHTML.
+// userMd() runs the output through the same sanitizer md() uses (sanitizeMd, md-sanitize.ts) before it ever
+// reaches innerHTML; the math fill rides that sanitize as a registered post-pass (below), so no caller
+// renders it by hand.
 import { Marked, type MarkedExtension } from "marked";
-import { mathBlock, mathInline } from "./math";
+import { mathBlock, mathInline, renderMathPlaceholders } from "./math";
+import { registerMdPostPass } from "./md-sanitize";
 
 // Strikethrough requires DOUBLE tildes (the user 2026-06-26). marked's built-in GFM `del` tokenizer also
 // fires on a SINGLE tilde, so prose like "near the ~21 Wh/day budget … gives ~1.5–2 days" renders as one big
@@ -30,16 +33,24 @@ export const delDoubleTilde = {
 } as MarkedExtension;
 
 // TeX math ($..$, $$..$$, \(..\), \[..\]) rendered via KaTeX. All delimiter heuristics (the
-// $-vs-shell/price disambiguation) live in math.ts; the output is plain spans + inline styles
-// (output: "html"), which DOMPurify's html profile in md() passes through unchanged.
+// $-vs-shell/price disambiguation) live in math.ts. The extensions emit an inert placeholder (the TeX as
+// text under md-math-inline / md-math-display), and KaTeX is rendered into it AFTER the sanitizer (math.ts
+// renderMathPlaceholders), because sanitizeMd keeps only colour in an inline style and KaTeX's layout is all
+// inline style. The fill is registered here, once, as a sanitizeMd post-pass: the grammar and its fill travel
+// together, so every sanitizeMd call in a bundle that parses with this grammar renders math (the chat's md()
+// and userMd(); the viewer's mdBlock when it runs inside the chat page, whose marked singleton render.ts
+// arms with these extensions), and a bundle that never imports this module (feed.js) has neither the
+// grammar nor KaTeX.
 export const chatMdExtensions: MarkedExtension[] = [delDoubleTilde, { extensions: [mathBlock, mathInline] }];
+registerMdPostPass(renderMathPlaceholders);
 
 // The user-text instance: the chat grammar with hard line breaks. Its own `Marked` so the singleton's
 // `breaks: false` — every assistant message — is untouched.
 export const userMarked = new Marked({ gfm: true, breaks: true }, ...chatMdExtensions);
 
 /** marked's HTML for the user's own typed text: newlines kept as <br>, otherwise the chat grammar.
- *  UNSANITIZED — render.ts's userMd() is the only caller that reaches innerHTML, and it purifies first. */
+ *  UNSANITIZED: render.ts's userMd() is the only caller that reaches innerHTML; it purifies first, and the
+ *  sanitize renders the math placeholders (the post-pass registered above) on the sanitized DOM. */
 export function userMdHtml(src: string): string {
   return userMarked.parse(src) as string;
 }

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1509,7 +1509,14 @@ a.fileview-gh-note { border-style: dashed; }
    sheets — the .romp-acted precedent); font sizes reuse what this surface already wears (the page base,
    12px mono, the err-hint's 0.92em). Vars the feed sheet does not define carry the chat's literals as
    fallbacks (feed-css-vars.test.ts holds that line). */
-.fileview-md { padding: 14px 18px; max-width: 860px; overflow-wrap: anywhere; font-family: var(--font-prose); }
+/* contain: layout makes .fileview-md the containing block for any fixed or absolutely positioned descendant: an
+   element in a file that reaches `position: fixed` (a class of the page's it happens to wear; the sanitizer drops
+   an inline one) stays inside the note instead of covering the viewer's chrome. Layout only, not paint: the
+   body's vertical scroll is untouched. Content wider than .fileview-md becomes ink overflow the body cannot
+   scroll to, so the media rules below cap an <svg>, <canvas> or <video> at the column as `.fileview-md img`
+   already does, and the table rule below gives a table wider than the column a horizontal scroll of its own.
+   Pinned byte-equal in both sheets (fileview-parity.test.ts). */
+.fileview-md { padding: 14px 18px; max-width: 860px; overflow-wrap: anywhere; font-family: var(--font-prose); contain: layout; }
 .fileview-md > :first-child { margin-top: 0; }
 .fileview-md > :last-child { margin-bottom: 0; }
 .fileview-md p { margin: 0.5em 0; }
@@ -1547,10 +1554,22 @@ a.fileview-gh-note { border-style: dashed; }
   font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
   color: var(--code-fg, #e1c08d); white-space: pre-wrap; overflow-wrap: anywhere;
 }
-.fileview-md table { border-collapse: collapse; margin: 0.6em 0; }
+/* A table wider than the column (a `nowrap` cell, many columns) scrolls sideways on its own, as on GitHub: a block
+   box shrink-wrapped to its content (width: max-content) and capped at the column, with the overflow scrollable.
+   Under contain: layout the body cannot scroll to what a table lets run past the column, so the table has to.
+   border-collapse is inherited by the anonymous table box the block wraps, so the cell borders still collapse. */
+.fileview-md table { border-collapse: collapse; margin: 0.6em 0; display: block; width: max-content; max-width: 100%; overflow-x: auto; }
 .fileview-md th, .fileview-md td { border: 1px solid var(--box-border); padding: 4px 10px; text-align: left; }
 .fileview-md th { background: var(--box-bg, rgba(255, 255, 255, 0.03)); }
 .fileview-md img { max-width: 100%; }
+/* Media a file draws itself (an inline <svg> diagram, a <canvas>, a <video>) fits the column the way an <img> does:
+   under contain: layout anything wider than .fileview-md is clipped at the body's edge and unreachable. :where() keeps
+   the selectors at element specificity, so KaTeX's own rules for the <svg> glyphs it draws inside a formula
+   (`.katex svg`, sized by its sheet) still outrank them. height: auto keeps a pixel-sized svg's or canvas's own
+   ratio (its viewBox, or its width and height) as the cap shrinks it; a percentage-width element is never shrunk by
+   the cap and keeps the author's height. */
+:where(.fileview-md) svg, :where(.fileview-md) canvas, :where(.fileview-md) video { max-width: 100%; }
+:where(.fileview-md :is(svg, canvas)[width]:not([width$="%"])) { height: auto; }
 
 /* ── the viewer's image + PDF bodies (a .png used to open as line-numbered mojibake). The <img>
    wears the lightbox image's own treatment (.romp-lightbox-img: capped, object-fit contain, the

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -256,17 +256,18 @@ test("format prefs: rendered is the markdown default, and a corrupt entry reads 
 });
 
 // B: the toggle itself — markdown only, and the rendered path is sanitized. These are arbitrary bytes
-// off a disk and marked emits raw HTML verbatim, so DOMPurify sits between it and .innerHTML with the
-// same profile the chat's md() uses (render.ts).
+// off a disk and marked emits raw HTML verbatim, so DOMPurify sits between it and the DOM, through the
+// ONE sanitizer the chat's md() uses too (sanitizeMd, md-sanitize.ts); what it does to a file's own HTML
+// is executed in headless Chromium by md-sanitize-browser.test.ts.
 test("Raw ⇄ Rendered exists for markdown ONLY, and nothing reaches innerHTML unsanitized", () => {
   assert.match(VIEW, /const isMd = langFor\(path\) === "markdown";/);
   // the two buttons are built inside the isMd gate — a .py file shows no Rendered/Raw toggle
   assert.match(VIEW, /if \(isMd\) \{\s*\n\s*for \(const mode of \["rendered", "raw"\] as const\)/);
   assert.match(VIEW, /const rendered = isMd && fmt\.md === "rendered";/, "non-md never renders as prose");
-  assert.match(VIEW, /import DOMPurify from "dompurify";/);
-  // html + svg, in lockstep with the chat's md(): KaTeX draws stretchy glyphs as inline <svg>
-  // …and data-* never rides in from a document's raw HTML: the page's delegates key actions off data-act
-  assert.match(VIEW, /box\.innerHTML = DOMPurify\.sanitize\(dirty, \{ USE_PROFILES: \{ html: true, svg: true \}, ADD_DATA_URI_TAGS: \["img"\], ALLOW_DATA_ATTR: false \}\);/);
+  assert.match(VIEW, /import \{ sanitizeMd \} from "\.\/md-sanitize";/);
+  assert.doesNotMatch(VIEW, /from "dompurify"/, "the viewer spells no profile of its own: every option comes through md-sanitize.ts");
+  // the sanitized <body>'s children are adopted as they are (no re-parse of a serialized string)
+  assert.match(VIEW, /box\.replaceChildren\(\.\.\.Array\.from\(sanitizeMd\(dirty\)\.childNodes\)\);/);
   // a README's links open a NEW tab rather than navigating the hosting pane's document away
   assert.match(VIEW, /target = "_blank"/);
   assert.match(VIEW, /rel = "noopener"/);

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -17,7 +17,7 @@
 // whichever bundle imports it gets the identical modal.
 import hljs from "highlight.js/lib/core";
 import { marked } from "marked";
-import DOMPurify from "dompurify";
+import { sanitizeMd } from "./md-sanitize";
 import { hostOf, bareId, hostNameNodes } from "./host-prefix";
 import { fileUrl } from "./preview";
 import { openPdfTab, wantsOwnTab } from "./preview";   // a PDF's own tab, and the gesture that asks for it
@@ -564,6 +564,11 @@ export function openFileView(path: string, sid?: string | null, frag?: string | 
     // an in-document `[top](#evidence)` lands on its heading (mdBlock minted the ids) — never a tab
     "fv-anchor": (a, ev) => { ev.preventDefault(); scrollToFragment(body, a.getAttribute("href") || ""); },
   });
+  // A submit inside the body never navigates the pane's document. The sanitizer drops <form> and every
+  // form control (md-sanitize.ts), so this is the backstop: a note's `<form action=...><button>` used to
+  // take the pane's document to the action URL. One listener per open on the stable body, like the click
+  // delegate above, so it survives every Rendered ⇄ Raw swap of the body's children.
+  body.addEventListener("submit", (ev) => { ev.preventDefault(); });
   // Per the loading-state rule the first thing up is the romp loader, not a blank pane — a file coming
   // over an ssh tunnel to a phone is a real wait.
   const load = el("div", "fileview-load");
@@ -997,6 +1002,7 @@ export function openUrlView(href: string): void {
   delegate(body, {
     "fv-anchor": (a, ev) => { ev.preventDefault(); scrollToFragment(body, a.getAttribute("href") || ""); },
   });
+  body.addEventListener("submit", (ev) => { ev.preventDefault(); });   // the local viewer's backstop (openFileView), same reason
   body.appendChild(loaderEl());                        // loader first; the fetch below replaces it
   box.appendChild(bar); box.appendChild(body);
   wrap.appendChild(box);
@@ -1194,21 +1200,22 @@ function scrollToFragment(box: HTMLElement, fragment: string): boolean {
 type MdDocLoc = { kind: "url"; href: string } | { kind: "file"; path: string; sid: string | null };
 
 // Markdown rendered as the prose it means (the user 2026-08-09: Rendered is the default, Raw one click
-// away). The file is arbitrary bytes off a disk and marked emits raw HTML verbatim, so — exactly like the
-// chat's md() in render.ts — the output goes through DOMPurify before it ever reaches .innerHTML: an
-// <img onerror> or a javascript: href in a README must never run in the dashboard.
+// away). The file is arbitrary bytes off a disk and marked emits raw HTML verbatim, so, exactly like the
+// chat's md() in render.ts, the output goes through the shared sanitizer (sanitizeMd, md-sanitize.ts)
+// before it ever reaches the DOM: an <img onerror> or a javascript: href in a README must never run in
+// the dashboard, and a README's <style>, form or fixed-positioned div must never reach the viewer's chrome.
 function mdBlock(text: string, doc?: MdDocLoc): HTMLElement {
   const box = el("div", "fileview-md");
   try {
     const dirty = marked.parse(text) as string;
-    // html + svg, in lockstep with the chat's md(): KaTeX draws stretchy glyphs (\sqrt radicals,
-    // wide accents) as inline <svg> even in html output, and the html-only profile ate them.
-    // ALLOW_DATA_ATTR: false — a document's raw HTML must not carry data-* into the page: the viewer's
-    // body delegate lets an act it does not own bubble to render.ts's document-level delegate, so a
-    // `<span data-act="stopRetrying">` in a published report would interrupt the active session on a
-    // click (review find on #958, 2026-09-07). The viewer's own fv-open / fv-anchor stamps are set
-    // AFTER this sanitize, so they are unaffected.
-    box.innerHTML = DOMPurify.sanitize(dirty, { USE_PROFILES: { html: true, svg: true }, ADD_DATA_URI_TAGS: ["img"], ALLOW_DATA_ATTR: false });
+    // The one sanitizer the chat's md() uses too (md-sanitize.ts): html + svg (a note's own inline SVG), no
+    // data-* (a document's `<span data-act="stopRetrying">` would otherwise bubble to render.ts's
+    // document-level delegate and interrupt the active session; review find on #958, 2026-09-07), and
+    // rules modelled on GitHub's for a note's own HTML: no <style>, no form controls, ids and names prefixed
+    // user-content-, inline style reduced to its colours, no background attribute. The sanitized <body>'s
+    // children are adopted as they are, no re-parse. The viewer's own stamps (heading ids, fv-open,
+    // fv-anchor) are set AFTER this sanitize, so they are unaffected and never prefixed.
+    box.replaceChildren(...Array.from(sanitizeMd(dirty).childNodes));
   } catch {
     box.textContent = text;                            // a marked bug must never cost the content
   }

--- a/ui/webview/fileview-parity.test.ts
+++ b/ui/webview/fileview-parity.test.ts
@@ -3,7 +3,12 @@
 // (the .romp-acted / filebrowse precedent). The copies had already drifted once (feed.css lacked the
 // a.fileview-btn anchor rules, so the GitHub link rendered hrefless-underlined there, 2026-08-26).
 // This pins the shared chrome byte-equal so it cannot drift again. Rules that are deliberately
-// pane-specific (the md body, wrap mode, load cue) are not pinned.
+// pane-specific (wrap mode, load cue, the md body's typography where the feed sheet carries a
+// fallback) are not pinned. The md body's own rule IS: its `contain: layout` is what keeps a
+// file's fixed-positioned element inside the note, and it has to hold in both documents, as do
+// the width caps on the media a file draws itself (svg, canvas, video), which under containment
+// would otherwise be clipped and unreachable, and the table rule that gives a wide table a
+// horizontal scroll of its own for the same reason.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -18,7 +23,10 @@ const RULES = [
   ".fileview-dir {", ".fileview-base {", ".fileview-sess {", ".fileview-sess .host-prefix {", ".fileview-acts {", ".fileview-btn {", ".fileview-btn:hover {",
   "a.fileview-btn {", ".fileview-gh {", ".fileview-gh-why {", ".fileview-gh-dots {",
   ".fileview-gh .fileview-btn:disabled {", ".fileview-gh .fileview-btn:disabled:hover {",
-  ".fileview-gh .fileview-btn:disabled:active {", "a.fileview-gh-note {", ".fileview-body {",
+  ".fileview-gh .fileview-btn:disabled:active {", "a.fileview-gh-note {", ".fileview-body {", ".fileview-md {",
+  ":where(.fileview-md) svg, :where(.fileview-md) canvas, :where(.fileview-md) video {",
+  ':where(.fileview-md :is(svg, canvas)[width]:not([width$="%"])) {',
+  ".fileview-md table {",
   ".fileview-cm {", ".fileview-cm .cm-editor {", ".fileview-editor {", ".fileview > .fileview-err {",
   ".fileview-dir-link {", ".fileview-dir-link:hover {",
   ".fileview-imgbox {", ".fileview-img {", ".fileview-frame {",

--- a/ui/webview/math.ts
+++ b/ui/webview/math.ts
@@ -1,9 +1,23 @@
 // TeX math for chat markdown: inline \( .. \) and $ .. $, display \[ .. \] and $$ .. $$
 // (the user 2026-08-03). marked has no math syntax, so without this every formula an agent
-// writes reaches the transcript as raw TeX source. KaTeX renders with output: "html" ONLY,
-// no MathML twin, so the result passes md()'s DOMPurify html profile untouched and the
-// sanitizer never widens for math. The KaTeX layout CSS ships via styles.css
-// (@import "katex/dist/katex.min.css"; fonts emitted to dist/fonts/ by esbuild).
+// writes reaches the transcript as raw TeX source.
+//
+// Rendering happens AFTER the sanitizer, not inside marked. KaTeX carries every piece of vertical
+// layout in inline `style` (a strut's height and vertical-align, a vlist row's top, a fraction line's
+// border width, a radical's padding), and the shared sanitizer (md-sanitize.ts) keeps only colour
+// declarations in a `style` attribute, so KaTeX's output passed through sanitizeMd would come back
+// flat: numerator and denominator on one line, a superscript at the baseline. The extensions therefore
+// emit an INERT placeholder (class md-math-inline or md-math-display, a span inside a paragraph or a
+// div for a display paragraph of its own, the TeX as its text, HTML-escaped) that the sanitizer treats
+// as any element with text, and renderMathPlaceholders below renders KaTeX into each placeholder on
+// the sanitized DOM, so its styles never meet DOMPurify. Nothing an author writes gains by hand-writing
+// the placeholder markup: KaTeX renders only what TeX says, under `trust: false` (no \href, \url,
+// \includegraphics, \htmlClass, \htmlStyle, \htmlData), which is KaTeX's own safety model. KaTeX
+// renders with output: "html" ONLY, no MathML twin. The KaTeX layout CSS ships via styles.css
+// (@import "katex/dist/katex.min.css"; fonts emitted to dist/fonts/ by esbuild). chat-md.ts registers
+// the post-pass with the sanitizer (md-sanitize.ts registerMdPostPass), so every sanitizeMd call in the
+// chat bundle renders math, the file viewer's mdBlock included when it runs in the chat page; a bundle
+// without the grammar (feed.js) has neither the placeholders nor KaTeX.
 //
 // The delimiter problem: `$` is everywhere in chat text that is NOT math (shell variables,
 // prices), and a naive $..$ tokenizer strikes a formula through half a sentence the way the
@@ -26,6 +40,12 @@ import type { TokenizerAndRendererExtension, Tokens } from "marked";
 
 type MathToken = Tokens.Generic & { text: string; display: boolean };
 
+/** The placeholder classes: inline math, and display math (KaTeX's displayMode). The class is the whole
+ *  contract between the extensions and renderMathPlaceholders; the tag (span in a paragraph, div for a
+ *  display paragraph of its own) only keeps an unrendered placeholder in the flow it came from. */
+export const MATH_INLINE_CLASS = "md-math-inline";
+export const MATH_DISPLAY_CLASS = "md-math-display";
+
 // Closing punctuation allowed right after the closing $ (plus whitespace / end-of-text).
 // Includes markdown emphasis/strike markers so **$O(n)$** works, and the common CJK stops.
 const AFTER_CLOSE = "[\\s.,;:!?)\\]}\"'*_~\\-、。，；：！？）】」]";
@@ -43,16 +63,16 @@ const INLINE_DOLLAR = new RegExp(
 const BLOCK_DOLLARS = /^ {0,3}\$\$([\s\S]+?)\$\$ *(?:\n+|$)/;
 const BLOCK_BRACKET = /^ {0,3}\\\[([\s\S]+?)\\\] *(?:\n+|$)/;
 
-function renderTex(tex: string, display: boolean): string {
-  // throwOnError: false renders bad TeX as visibly-flagged source instead of throwing; the
-  // catch is a belt for the residual throws (wrong option types, internal errors), falling
-  // back to the escaped literal so a formula can never blank a message.
-  try {
-    return katex.renderToString(tex, { displayMode: display, throwOnError: false, output: "html" });
-  } catch {
-    const esc = tex.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-    return display ? `<pre><code>${esc}</code></pre>` : `<code>${esc}</code>`;
-  }
+function escapeText(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** The placeholder marked emits for a formula: the TeX as escaped text under the class that names the
+ *  mode. `block` picks the tag, a div for a display paragraph of its own, a span inside a paragraph. */
+export function mathPlaceholder(tex: string, display: boolean, block: boolean): string {
+  const cls = display ? MATH_DISPLAY_CLASS : MATH_INLINE_CLASS;
+  const tag = block ? "div" : "span";
+  return `<${tag} class="${cls}">${escapeText(tex)}</${tag}>`;
 }
 
 export const mathBlock: TokenizerAndRendererExtension = {
@@ -68,7 +88,7 @@ export const mathBlock: TokenizerAndRendererExtension = {
     return { type: "mathBlock", raw: m[0], text: m[1].trim(), display: true } as MathToken;
   },
   renderer(token) {
-    return renderTex((token as MathToken).text, true);
+    return mathPlaceholder((token as MathToken).text, true, true);
   },
 };
 
@@ -89,6 +109,47 @@ export const mathInline: TokenizerAndRendererExtension = {
   },
   renderer(token) {
     const t = token as MathToken;
-    return renderTex(t.text, t.display);
+    return mathPlaceholder(t.text, t.display, false);
   },
 };
+
+/** The belt under the fill: the TeX as text in a code element where the placeholder stood, so a formula
+ *  can never blank a message and the reader still sees what was written. A block placeholder (the div a
+ *  display paragraph of its own becomes) turns into a code block; a span, display mode or not, into a code
+ *  span, so the paragraph it sits in survives the serialization to innerHTML (a <pre> inside a <p> splits
+ *  the paragraph when the HTML is parsed again). */
+function showSource(el: HTMLElement, tex: string): void {
+  const doc = el.ownerDocument;
+  const code = doc.createElement("code");
+  code.textContent = tex;
+  if (el.tagName === "DIV") { const pre = doc.createElement("pre"); pre.appendChild(code); el.replaceWith(pre); }
+  else el.replaceWith(code);
+}
+
+/** Render KaTeX into every math placeholder under `root`, the SANITIZED DOM (sanitizeMd's body), and
+ *  unwrap each so the rendered `.katex` (or `.katex-display`) root stands where the placeholder stood,
+ *  exactly where marked's own KaTeX output used to. The selector reaches a placeholder an author typed by
+ *  hand as well (no class name is special-cased): it renders under the same options, so it gains nothing.
+ *  throwOnError: false paints bad TeX as KaTeX's flagged source instead of throwing; the catch is a belt for
+ *  the residual throws (an internal error), showing the TeX as text (showSource) with a word on the console
+ *  once per call, so a formula can never blank a message. A second run over the same root is a no-op: no
+ *  placeholder survives the first. Plain and exported: chat-md.ts registers it as sanitizeMd's post-pass,
+ *  and the tests call it directly. */
+export function renderMathPlaceholders(root: ParentNode): void {
+  let reported = false;      // the belt's console report, once per call
+  root.querySelectorAll("." + MATH_INLINE_CLASS + ", ." + MATH_DISPLAY_CLASS).forEach((node) => {
+    const el = node as HTMLElement;
+    const display = el.classList.contains(MATH_DISPLAY_CLASS);
+    const tex = el.textContent || "";
+    if (!tex.trim()) { el.replaceWith(...Array.from(el.childNodes)); return; }
+    try {
+      // trust: false is KaTeX's own default, spelled out so that enabling trust is a visible edit (render-math.test.ts
+      // pins the option): under it no TeX command mints a link, an image or an HTML attribute of the author's choosing
+      katex.render(tex, el, { displayMode: display, throwOnError: false, output: "html", trust: false });
+      el.replaceWith(...Array.from(el.childNodes));
+    } catch (e) {
+      if (!reported) { reported = true; console.error("math: KaTeX could not lay out a formula; its source is shown instead", e); }
+      showSource(el, tex);
+    }
+  });
+}

--- a/ui/webview/md-sanitize-browser.test.ts
+++ b/ui/webview/md-sanitize-browser.test.ts
@@ -1,0 +1,393 @@
+// A file's own HTML in the rendered file view, over the REAL viewer module (file-view.ts) in headless Chromium.
+// A markdown file is arbitrary bytes off a disk, and DOMPurify's default html profile keeps <style>, <form>,
+// <button>, <dialog>, inline `style`, `id`, `name` and the `background` attribute. Four things followed, each
+// a test below: a `<style>` block hid the whole viewer and a `position: fixed` div covered its close button; a
+// `<form action=...><button>` navigated the pane's document to the action URL; an author's `id` shadowed the
+// page's own ids, an inline style set any property, `<td background=URL>` fetched the URL on render, and a text
+// input or a select was a live control; and an element that reached `position: fixed` escaped the note. The
+// sanitizer (md-sanitize.ts), the body's submit backstop (file-view.ts) and `contain: layout` on .fileview-md
+// (both sheets) close them together, as the browser lays them out. Each test opens the viewer on a synthetic
+// note through openFileView and reads the rendered DOM: styles resolved, boxes measured, elementFromPoint at the
+// close button's centre. Content wider than the column is measured too: under containment the body cannot scroll
+// to it, so an inline svg, canvas or video is capped at the column and a table scrolls sideways on its own. Skips
+// with a stated reason when no playwright browser is installed (CI installs none; tests/test_spend_modal_headless.py
+// is the precedent, skipping without a playwright install). Synthetic values only: an invented note under a
+// TESTHOST path, a placeholder sid.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+const EXT = process.cwd();                                        // npm test runs in vscode-extension
+// resolve playwright and esbuild from the extension, not from wherever this bundle was written
+const requireCjs = createRequire(path.join(EXT, "package.json"));
+const UI = path.resolve(EXT, "..", "ui", "webview");
+// the chat's sheet, its one @import dropped (KaTeX's sheet is not what is measured here, and a bare specifier
+// fetched from the test origin resolves to nothing)
+const STYLES = fs.readFileSync(path.join(UI, "styles.css"), "utf8").replace(/^@import [^\n]*\n/m, "");
+
+const SID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const NOTE_PATH = "/tmp/TESTHOST/notes-api/report.md";
+const NOTE_URL = "http://romp.test/docs/report.md";           // the same note as a same-origin document (openUrlView)
+const FILLER = Array.from({ length: 120 }, (_, i) => "Paragraph " + (i + 1) + " of the long tail, so the body has to scroll.").join("\n\n");
+
+// the viewer alone: the module every hosting page imports, opened the way a path click opens it (openFileView) or
+// a same-origin .md link does (openUrlView)
+const ENTRY = `
+import { openFileView, openUrlView } from "./file-view";
+(window as any).__openNote = (p: string, sid: string) => { openFileView(p, sid); };
+(window as any).__openUrl = (href: string) => { openUrlView(href); };
+`;
+
+function bundle(): string {
+  const esbuild = requireCjs("esbuild");
+  const r = esbuild.buildSync({
+    stdin: { contents: ENTRY, resolveDir: UI, loader: "ts", sourcefile: "md-sanitize-viewer-entry.ts" },
+    bundle: true, write: false, format: "iife", platform: "browser", target: "es2020",
+    nodePaths: [path.join(EXT, "node_modules")], external: ["*.png", "*.svg", "*.woff", "*.ttf", "../media/*.woff2"], logLevel: "silent",
+  });
+  return r.outputFiles[0].text;
+}
+
+const PAGE_HTML = `<!DOCTYPE html><html><head><meta charset=utf-8><style>${STYLES}</style></head><body>
+<script>window.acquireVsCodeApi=function(){return{postMessage:function(){}}};</script>
+<script src=/dist/viewer.js></script></body></html>`;
+
+let pw: any = null;
+try { pw = requireCjs("playwright"); } catch { pw = null; }
+
+// What the page's own events say happened over a test: every main-frame navigation (the load is one), and every
+// request whose host is not the page's (a submitted `<form action=https://example.invalid/go>` would be one)
+type Seen = { navigations: string[]; foreignRequests: string[] };
+
+async function withNote(t: any, note: string, body: (page: any, errors: string[], seen: Seen) => Promise<void>, via: "file" | "url" = "file"): Promise<void> {
+  if (!pw) { t.skip("playwright is not installed under vscode-extension; the browser leg needs it (CI installs no browsers)"); return; }
+  let browser: any;
+  try { browser = await pw.chromium.launch(); }
+  catch (e) { t.skip("no playwright browser on this machine; the browser leg needs one (CI installs none): " + String((e as Error).message).split("\n")[0]); return; }
+  const errors: string[] = [];
+  const seen: Seen = { navigations: [], foreignRequests: [] };
+  try {
+    const js = bundle();
+    const page = await browser.newPage({ viewport: { width: 900, height: 600 } });
+    page.on("pageerror", (e: Error) => { errors.push(e.message); });
+    page.on("framenavigated", (f: any) => { if (f === page.mainFrame()) seen.navigations.push(f.url()); });
+    page.on("request", (r: any) => { const u = new URL(r.url()); if (u.protocol !== "data:" && u.host !== "romp.test") seen.foreignRequests.push(r.url()); });
+    await page.route("**/*", (route: any) => {
+      const u = new URL(route.request().url());
+      // the action's host answers, so a navigation that does happen commits and is seen
+      if (u.hostname === "example.invalid") return route.fulfill({ status: 200, contentType: "text/html", body: "<title>elsewhere</title>elsewhere" });
+      if (u.hostname !== "romp.test") return route.fulfill({ status: 404, body: "" });
+      if (u.pathname === "/viewer") return route.fulfill({ status: 200, contentType: "text/html; charset=utf-8", body: PAGE_HTML });
+      if (u.pathname === "/dist/viewer.js") return route.fulfill({ status: 200, contentType: "application/javascript", body: js });
+      if (u.pathname === "/file" && u.searchParams.get("path") === NOTE_PATH) {
+        return route.fulfill({ status: 200, contentType: "text/plain; charset=utf-8", headers: { "X-Romp-Mtime-Ns": "1", "X-Romp-Text-Utf8": "1" }, body: note });
+      }
+      if (u.href === NOTE_URL) return route.fulfill({ status: 200, contentType: "text/markdown; charset=utf-8", body: note });
+      return route.fulfill({ status: 404, body: "" });
+    });
+    await page.goto("http://romp.test/viewer");
+    await page.waitForFunction(() => typeof (window as any).__openNote === "function", null, { timeout: 10000 });
+    if (via === "url") await page.evaluate((href: string) => { (window as any).__openUrl(href); }, NOTE_URL);
+    else await page.evaluate(([p, sid]: [string, string]) => { (window as any).__openNote(p, sid); }, [NOTE_PATH, SID] as [string, string]);
+    // attached, not visible: a note whose <style> hides the viewer is one of the cases under test
+    await page.waitForSelector("#romp-fileview .fileview-body .fileview-md", { state: "attached", timeout: 10000 });
+    await body(page, errors, seen);
+  } finally {
+    await browser.close();
+  }
+}
+
+type Rect = { left: number; top: number; right: number; bottom: number; width: number; height: number };
+const near = (a: number, b: number, msg: string, tol = 1) => assert.ok(Math.abs(a - b) <= tol, msg + ": " + a + " vs " + b);
+
+test("a file's <style> block and a position: fixed div neither hide the viewer nor cover its close button", { timeout: 60000 }, async (t) => {
+  const note = [
+    "# Report", "",
+    "<style>.fileview, #romp-fileview { display: none !important; } body { background: red; }</style>", "",
+    '<div class="fx-fixed" style="position:fixed;inset:0;background:red">cover</div>', "",
+    "Prose after.", "",
+  ].join("\n");
+  await withNote(t, note, async (page, errors) => {
+    const facts = await page.evaluate(() => {
+      const md = document.querySelector("#romp-fileview .fileview-md") as HTMLElement;
+      const card = document.querySelector("#romp-fileview .fileview") as HTMLElement;
+      const close = document.querySelector("#romp-fileview .fileview-close") as HTMLElement;
+      const fixed = md.querySelector(".fx-fixed") as HTMLElement;
+      const r = close.getBoundingClientRect();
+      const at = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+      return {
+        styleElements: document.querySelectorAll("#romp-fileview style").length,
+        cardDisplay: getComputedStyle(card).display,
+        bodyBackground: getComputedStyle(document.body).backgroundColor,
+        closeArea: r.width * r.height,
+        atCloseCentre: at === close ? "close" : (at ? at.tagName + "." + at.className : "nothing"),
+        fixedStyleAttr: fixed.getAttribute("style"),
+        fixedPosition: getComputedStyle(fixed).position,
+        fixedText: fixed.textContent,
+      };
+    });
+    assert.equal(facts.styleElements, 0, "the note's <style> is gone");
+    assert.notEqual(facts.cardDisplay, "none", "the note's <style> did not blank the viewer");
+    assert.notEqual(facts.bodyBackground, "rgb(255, 0, 0)", "nor restyle the page");
+    assert.ok(facts.closeArea > 0, "the close button has a box");
+    assert.equal(facts.atCloseCentre, "close", "the element at the close button's centre is the close button, not the note's div");
+    assert.equal(facts.fixedStyleAttr, null, "position/inset/background all dropped: the attribute goes");
+    assert.equal(facts.fixedPosition, "static");
+    assert.equal(facts.fixedText, "cover", "the div's text stays as prose");
+    assert.deepEqual(errors, [], "no page errors");
+  });
+});
+
+test("a form in a file is prose, and a submit inside the body never navigates the pane's document", { timeout: 60000 }, async (t) => {
+  const note = [
+    "# Report", "",
+    '<form action="https://example.invalid/go"><button>Go</button></form>', "",
+    "Prose after.", "",
+  ].join("\n");
+  await withNote(t, note, async (page, errors, seen) => {
+    const before = page.url();
+    // 1. no form and no control in the rendered note; the button's text landed as prose, and the point where it landed
+    //    is prose (elementFromPoint names no control above it)
+    const goAt = await page.evaluate(() => {
+      const md = document.querySelector("#romp-fileview .fileview-md") as HTMLElement;
+      const controls = md.querySelectorAll("form, button, input, select, textarea").length;
+      const walker = document.createTreeWalker(md, NodeFilter.SHOW_TEXT);
+      let node: Node | null;
+      while ((node = walker.nextNode())) {
+        if ((node.textContent || "").trim() === "Go") {
+          const range = document.createRange(); range.selectNodeContents(node);
+          const r = range.getBoundingClientRect();
+          const x = r.left + r.width / 2, y = r.top + r.height / 2;
+          const e = document.elementFromPoint(x, y);
+          return { controls, x, y, w: r.width, h: r.height, hit: e ? e.tagName + "." + e.className : "nothing", inControl: !!(e && e.closest("form, button, input, select, textarea")) };
+        }
+      }
+      return { controls, x: 0, y: 0, w: 0, h: 0, hit: "no Go text", inControl: false };
+    });
+    assert.equal(goAt.controls, 0, "no form, button, input, select or textarea in the rendered note");
+    assert.ok(goAt.w > 0 && goAt.h > 0, "the form's text is laid out in the note as prose: " + JSON.stringify(goAt));
+    assert.equal(goAt.inControl, false, "the point to click is prose: " + goAt.hit);
+    await page.mouse.click(goAt.x, goAt.y);
+    assert.equal(await page.evaluate(() => location.href), before, "location.href is unchanged after clicking where the button was");
+    // 2. the submit backstop itself: a REAL form put into the note after render (the sanitizer never lets one through, so
+    //    this is the only way to exercise the listener) submits nowhere, and the event reaches the document defaultPrevented
+    const submit = await page.evaluate(() => {
+      const md = document.querySelector("#romp-fileview .fileview-md") as HTMLElement;
+      const form = document.createElement("form"); form.action = "https://example.invalid/go";
+      const btn = document.createElement("button"); btn.type = "submit"; btn.textContent = "Submit"; form.appendChild(btn);
+      md.insertBefore(form, md.firstChild);
+      let prevented: boolean | null = null;
+      document.addEventListener("submit", (ev) => { prevented = ev.defaultPrevented; }, { once: true });
+      btn.click();
+      form.remove();
+      return { prevented, href: location.href };
+    });
+    assert.equal(submit.prevented, true, "the body's submit listener called preventDefault before the event reached the document");
+    assert.equal(submit.href, before);
+    // 3. over the whole test, from the page's own events: the document navigated once (its load), and no request left its host
+    assert.deepEqual(seen.navigations, [before], "the document navigated exactly once, at its load");
+    assert.deepEqual(seen.foreignRequests, [], "no request left romp.test (a submitted form would have asked example.invalid)");
+    assert.deepEqual(errors, [], "no page errors");
+  });
+});
+
+test("an author's id and name are prefixed, an inline style keeps only its colour, a background attribute fetches nothing, an image map is dropped, and the task checkbox is the one control left", { timeout: 60000 }, async (t) => {
+  const note = [
+    "# Report", "",
+    'A <span class="fx-span" style="color: rgb(200, 0, 0); font-size: 80px">x</span> in prose.', "",
+    'A <span class="fx-tagged" data-act="stopRetrying" data-fx="1">tagged</span> span.', "",
+    '<p id="top">Top paragraph.</p>', "",
+    '<a name="install"></a>', "",
+    "- [x] done", "- [ ] later", "",
+    '<input type="text" value="typed">', "",
+    '<input type="checkbox" class="fx-hand">', "",
+    "<select><option>a</option></select>", "",
+    "<dialog open>hi</dialog>", "",
+    "<textarea>notes</textarea>", "",
+    "| Left | Centre | Right |", "|:-----|:------:|------:|", "| a    |   b    |     c |", "",
+    '<table><tr><td class="fx-bg" background="https://example.invalid/px.gif">cell</td></tr></table>', "",
+    '<img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" width=120 height=40 alt="dot">', "",
+    '<map name="nav"><area shape="rect" coords="0,0,10,10" href="https://example.invalid/a" alt="a"></map>', "",
+    '<img class="fx-mapped" usemap="#nav" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" width=100 height=30 alt="mapped">', "",
+  ].join("\n");
+  await withNote(t, note, async (page, errors, seen) => {
+    const facts = await page.evaluate(() => {
+      const md = document.querySelector("#romp-fileview .fileview-md") as HTMLElement;
+      const count = (sel: string) => md.querySelectorAll(sel).length;
+      const span = md.querySelector(".fx-span") as HTMLElement;
+      const cell = md.querySelector(".fx-bg") as HTMLElement;
+      const hand = md.querySelector(".fx-hand") as HTMLInputElement | null;
+      if (hand) hand.click();
+      return {
+        forbidden: count("style, form, button, select, option, dialog, textarea"),
+        spanStyleAttr: span.getAttribute("style"),
+        spanColor: getComputedStyle(span).color,
+        spanFontSize: getComputedStyle(span).fontSize,
+        proseFontSize: getComputedStyle(span.parentElement as HTMLElement).fontSize,
+        taggedSpans: count(".fx-tagged"),
+        authorDataAttrs: count("[data-fx], .fx-tagged[data-act]"),
+        userContentTop: count("p#user-content-top"),
+        rawTop: count("#top"),
+        userContentInstall: count('a[name="user-content-install"]'),
+        rawInstall: count('a[name="install"]'),
+        heading: count("h1#md-report"),
+        prefixedHeadings: count('h1[id^="user-content-"], h2[id^="user-content-"]'),
+        checkboxes: count('input[type="checkbox"][disabled]'),
+        checked: count('input[type="checkbox"]:checked'),
+        otherInputs: count('input:not([type="checkbox"])'),
+        handDisabled: hand ? hand.disabled : null,
+        handChecked: hand ? hand.checked : null,
+        alignedCells: count('td[align="center"]'),
+        cellBackgroundAttr: cell.getAttribute("background"),
+        cellBackgroundImage: getComputedStyle(cell).backgroundImage,
+        cellText: cell.textContent,
+        sizedImg: count('img[width="120"][height="40"]'),
+        dialogText: (md.textContent || "").includes("hi"),
+        imageMap: count("map, area, [usemap]"),
+        mappedImg: count("img.fx-mapped"),
+      };
+    });
+    assert.equal(facts.forbidden, 0, "no style, form, button, select, option, dialog or textarea in the rendered note");
+    assert.equal(facts.spanStyleAttr, "color: rgb(200, 0, 0)", "the span keeps only its colour declaration");
+    assert.equal(facts.spanColor, "rgb(200, 0, 0)");
+    assert.equal(facts.spanFontSize, facts.proseFontSize, "font-size: 80px was dropped: the span reads at the prose size");
+    assert.equal(facts.taggedSpans, 1, "the span that wore data-* is still there");
+    assert.equal(facts.authorDataAttrs, 0, "an author's data-* never rides in: the page's delegates key off data-act");
+    assert.equal(facts.userContentTop, 1, "an author's id is prefixed user-content-");
+    assert.equal(facts.rawTop, 0);
+    assert.equal(facts.userContentInstall, 1, "and so is an author's name");
+    assert.equal(facts.rawInstall, 0);
+    assert.equal(facts.heading, 1, "the viewer's own heading ids are minted after the sanitize and never prefixed");
+    assert.equal(facts.prefixedHeadings, 0);
+    assert.equal(facts.checkboxes, 3, "the two task checkboxes and the hand-written one all survive, disabled");
+    assert.equal(facts.checked, 1, "the ticked task item is still ticked");
+    assert.equal(facts.handDisabled, true, "a checkbox written by hand is forced disabled");
+    assert.equal(facts.handChecked, false, "and a click leaves it unchecked");
+    assert.equal(facts.otherInputs, 0, "no other input survives");
+    assert.equal(facts.alignedCells, 1, "table alignment (the align attribute) survives");
+    assert.equal(facts.cellBackgroundAttr, null, "the background attribute is gone");
+    assert.equal(facts.cellBackgroundImage, "none", "so the cell resolves to no background image");
+    assert.equal(facts.cellText, "cell", "the cell's text stays");
+    assert.equal(facts.sizedImg, 1, "an image's width/height survive");
+    assert.ok(facts.dialogText, "the dialog's text stays as prose");
+    assert.equal(facts.imageMap, 0, "no image map: <map>, <area> and the usemap attribute are all gone");
+    assert.equal(facts.mappedImg, 1, "the picture the map was bound to stays");
+    assert.deepEqual(seen.foreignRequests, [], "no request left romp.test: the background URL was never fetched");
+    assert.deepEqual(errors, [], "no page errors");
+  });
+});
+
+test("layout containment: a fixed box inside the note spans the note, not the viewport, and the body still scrolls to the end", { timeout: 60000 }, async (t) => {
+  const note = ["# Report", "", FILLER, "", "Last line.", ""].join("\n");
+  await withNote(t, note, async (page, errors) => {
+    // a `position: fixed; inset: 0` box injected after render (a style no author can write past the hook) is contained
+    // by the note: it spans the note's box, and the close button stays the element at its own centre, scrolled or not
+    const contained = await page.evaluate(() => {
+      const md = document.querySelector("#romp-fileview .fileview-md") as HTMLElement;
+      const body = document.querySelector("#romp-fileview .fileview-body") as HTMLElement;
+      const close = document.querySelector("#romp-fileview .fileview-close") as HTMLElement;
+      const rect = (e: Element) => { const b = e.getBoundingClientRect(); return { left: b.left, top: b.top, right: b.right, bottom: b.bottom, width: b.width, height: b.height }; };
+      const hitClose = () => { const c = rect(close); const e = document.elementFromPoint(c.left + c.width / 2, c.top + c.height / 2); return e === close ? "close" : (e ? e.tagName + "." + e.className : "nothing"); };
+      body.scrollTop = 0;
+      const mdAt0 = rect(md);
+      const inject = document.createElement("div"); inject.style.cssText = "position:fixed;inset:0;z-index:2147483647;background:red;";
+      (md.querySelector("p") as HTMLElement).appendChild(inject);
+      const injectAt0 = rect(inject);
+      const hitAt0 = hitClose();
+      body.scrollTop = 300;
+      const scrolled = body.scrollTop;
+      const hitScrolled = hitClose();
+      inject.remove();
+      body.scrollTop = 0;
+      return { mdContain: getComputedStyle(md).contain, mdAt0, injectAt0, hitAt0, scrolled, hitScrolled };
+    });
+    assert.equal(contained.mdContain, "layout", ".fileview-md is layout-contained under the real sheet");
+    for (const k of ["left", "top", "right", "bottom"] as const) near((contained.injectAt0 as Rect)[k], (contained.mdAt0 as Rect)[k], "an injected inset:0 fixed box spans exactly the note's box (" + k + ")");
+    assert.equal(contained.hitAt0, "close", "elementFromPoint at the close button's centre is the close button, with a full-inset fixed box in the note");
+    assert.ok(contained.scrolled >= 299, "the body scrolled: " + contained.scrolled);
+    assert.equal(contained.hitScrolled, "close", "and still after the body scrolled under it");
+    // the body still scrolls to the end of a long note: layout containment does not eat vertical overflow
+    const scroll = await page.evaluate(() => {
+      const body = document.querySelector("#romp-fileview .fileview-body") as HTMLElement;
+      const md = document.querySelector("#romp-fileview .fileview-md") as HTMLElement;
+      const last = Array.from(md.querySelectorAll("p")).pop() as HTMLElement;
+      body.scrollTop = body.scrollHeight;
+      const b = body.getBoundingClientRect(), l = last.getBoundingClientRect();
+      return { scrollable: body.scrollHeight > body.clientHeight + 50, atEnd: body.scrollTop + body.clientHeight >= body.scrollHeight - 1,
+               lastVisible: l.bottom <= b.bottom + 1 && l.top >= b.top - 1, lastText: last.textContent };
+    });
+    assert.ok(scroll.scrollable, "the fixture is longer than the body");
+    assert.ok(scroll.atEnd, "the body scrolled to its end");
+    assert.ok(scroll.lastVisible, "the last paragraph is in view at the end");
+    assert.equal(scroll.lastText, "Last line.");
+    assert.deepEqual(errors, [], "no page errors");
+  });
+});
+
+test("content wider than the column: an inline svg, canvas or video shrinks to the column with its shape kept, a table scrolls sideways on its own, and the body has nothing to scroll to", { timeout: 60000 }, async (t) => {
+  const words = Array.from({ length: 40 }, (_, i) => "word" + (i + 1)).join(" ");
+  const note = [
+    "# Report", "",
+    '<svg class="fx-svg" width="3000" height="300" viewBox="0 0 3000 300"><rect width="3000" height="300" fill="teal"/></svg>', "",
+    '<canvas class="fx-canvas" width="2500" height="100"></canvas>', "",
+    '<video class="fx-video" width="2400" height="200"></video>', "",
+    '<table class="fx-table"><tr><td nowrap>' + words + "</td></tr></table>", "",
+    "Prose after.", "",
+  ].join("\n");
+  await withNote(t, note, async (page, errors) => {
+    const facts = await page.evaluate(() => {
+      const md = document.querySelector("#romp-fileview .fileview-md") as HTMLElement;
+      const body = document.querySelector("#romp-fileview .fileview-body") as HTMLElement;
+      const cs = getComputedStyle(md);
+      const column = md.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
+      const box = (sel: string) => { const r = (md.querySelector(sel) as HTMLElement).getBoundingClientRect(); return { width: r.width, height: r.height }; };
+      const table = md.querySelector(".fx-table") as HTMLElement;
+      table.scrollLeft = 200;
+      return {
+        column, svg: box(".fx-svg"), canvas: box(".fx-canvas"), video: box(".fx-video"),
+        tableClient: table.clientWidth, tableScroll: table.scrollWidth, tableOverflowX: getComputedStyle(table).overflowX, tableScrolled: table.scrollLeft,
+        cellBorders: getComputedStyle(md.querySelector(".fx-table td") as HTMLElement).borderLeftWidth,
+        bodyClient: body.clientWidth, bodyScroll: body.scrollWidth,
+      };
+    });
+    assert.ok(facts.column > 100 && facts.column < 3000, "the column is narrower than the fixtures: " + facts.column);
+    assert.ok(facts.svg.width <= facts.column + 0.5 && facts.svg.width > facts.column - 2, "the svg fills the column, no wider: " + JSON.stringify(facts.svg));
+    near(facts.svg.height, facts.svg.width * 300 / 3000, "the svg keeps its viewBox ratio as it shrinks", 1.5);
+    assert.ok(facts.canvas.width <= facts.column + 0.5 && facts.canvas.width > facts.column - 2, "the canvas fills the column, no wider: " + JSON.stringify(facts.canvas));
+    near(facts.canvas.height, facts.canvas.width * 100 / 2500, "the canvas keeps its own ratio", 1.5);
+    assert.ok(facts.video.width <= facts.column + 0.5, "the video is no wider than the column: " + JSON.stringify(facts.video));
+    assert.ok(facts.tableClient <= facts.column + 0.5, "the table's box is no wider than the column: " + facts.tableClient);
+    assert.ok(facts.tableScroll > facts.tableClient + 100, "the table's content runs past its box: " + facts.tableScroll + " vs " + facts.tableClient);
+    assert.equal(facts.tableOverflowX, "auto", "and the table scrolls it");
+    assert.ok(facts.tableScrolled > 0, "the table did scroll: " + facts.tableScrolled);
+    assert.equal(facts.cellBorders, "1px", "the cell borders still collapse to the sheet's 1px");
+    assert.ok(facts.bodyScroll <= facts.bodyClient, "the body has no horizontal overflow of its own: nothing is clipped out of reach");
+    assert.deepEqual(errors, [], "no page errors");
+  });
+});
+
+test("the URL viewer's body carries the same submit backstop: a form put into a rendered document submits nowhere", { timeout: 60000 }, async (t) => {
+  const note = ["# Report", "", "Prose.", ""].join("\n");
+  await withNote(t, note, async (page, errors, seen) => {
+    const before = page.url();
+    const facts = await page.evaluate(() => {
+      const md = document.querySelector("#romp-fileview .fileview-md") as HTMLElement;
+      const form = document.createElement("form"); form.action = "https://example.invalid/go";
+      const btn = document.createElement("button"); btn.type = "submit"; btn.textContent = "Submit"; form.appendChild(btn);
+      md.insertBefore(form, md.firstChild);
+      let prevented: boolean | null = null;
+      document.addEventListener("submit", (ev) => { prevented = ev.defaultPrevented; }, { once: true });
+      btn.click();
+      form.remove();
+      return { rendered: md.querySelectorAll("h1#md-report").length, prevented, href: location.href };
+    });
+    assert.equal(facts.rendered, 1, "the document rendered through mdBlock in the URL viewer");
+    assert.equal(facts.prevented, true, "the URL viewer's body cancelled the submit before it reached the document");
+    assert.equal(facts.href, before);
+    assert.deepEqual(seen.navigations, [before], "the document navigated exactly once, at its load");
+    assert.deepEqual(seen.foreignRequests, [], "no request left romp.test");
+    assert.deepEqual(errors, [], "no page errors");
+  }, "url");
+});

--- a/ui/webview/md-sanitize-chat-fragment-browser.test.ts
+++ b/ui/webview/md-sanitize-chat-fragment-browser.test.ts
@@ -1,0 +1,252 @@
+// A message's own `#fragment` link over the REAL chat bundle (render.ts) in headless Chromium, at an http: origin.
+// The sanitizer prefixes every author id and name user-content- (md-sanitize.ts, GitHub's rule) and leaves the
+// href as written, so the browser's default lookup, which reads the bare name, finds nothing: a footnote's back
+// link or a `[section](#install)` over the reply's own `<a name>` would die. The chat's click delegate resolves the
+// fragment itself (render.ts; md-sanitize.ts userContentTarget): the message's own rendered body first, then the
+// document; found, the target is revealed (a closed <details> above it opened) and scrolled into view and the
+// default action cancelled, so the page's hash stays as it was; not found, the click is left to the browser.
+// The first test states the delegate's contract over the markup the sanitizer produces; the second runs the
+// chat's own pipeline (marked + sanitizeMd, as md() runs them) on a message with a `#` link and clicks it; the
+// third posts a session frame so render.ts's own md() renders the reply, and clicks there. Skips with a stated
+// reason when no playwright browser is installed (CI installs none; tests/test_spend_modal_headless.py is the
+// precedent, skipping without a playwright install). Synthetic values only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import { chatBody, ATTACH_TITLE_WEB } from "../../vscode-extension/src/page-skeleton";
+
+const EXT = process.cwd();                                        // npm test runs in vscode-extension
+// resolve playwright and esbuild from the extension, not from wherever this bundle was written
+const requireCjs = createRequire(path.join(EXT, "package.json"));
+const UI = path.resolve(EXT, "..", "ui", "webview");
+const STYLES = fs.readFileSync(path.join(UI, "styles.css"), "utf8").replace(/^@import [^\n]*\n/m, "");
+
+const BUILD = { bundle: true, write: false, format: "iife", platform: "browser", target: "es2020",
+  nodePaths: [path.join(EXT, "node_modules")], external: ["*.png", "*.svg", "*.woff", "*.ttf", "../media/*.woff2"], logLevel: "silent" };
+function bundle(entry: string): string {
+  const r = requireCjs("esbuild").buildSync({ ...BUILD, entryPoints: [path.join(UI, entry)] });
+  return r.outputFiles[0].text;
+}
+// md() as render.ts runs it, minus the PR-reference walk: marked with the chat's options and grammar, then sanitizeMd
+function probeBundle(): string {
+  const contents = [
+    'import { marked } from "marked";',
+    'import { sanitizeMd } from "./md-sanitize";',
+    'import { chatMdExtensions } from "./chat-md";',
+    "marked.setOptions({ gfm: true, breaks: false });",
+    "marked.use(...chatMdExtensions);",
+    "(window as any).__mdProbe = (s: string) => sanitizeMd(marked.parse(s) as string).innerHTML;",
+  ].join("\n");
+  const r = requireCjs("esbuild").buildSync({ ...BUILD, stdin: { contents, resolveDir: UI, sourcefile: "md-probe.ts", loader: "ts" } });
+  return r.outputFiles[0].text;
+}
+
+// the chat page as the web dashboard serves it: the shared skeleton, the chat's sheet, a fake acquireVsCodeApi (the
+// kernel's shim's role), then the chat bundle and, when a test asks for it, the probe
+const chatHtml = (probe: boolean) => `<!DOCTYPE html><html lang=en><head><meta charset=utf-8><style>${STYLES}</style></head><body>
+${chatBody(ATTACH_TITLE_WEB)}
+<script>window.acquireVsCodeApi=function(){return{postMessage:function(){}}};</script>
+<script src=/dist/render.js></script>${probe ? "\n<script src=/dist/probe.js></script>" : ""}</body></html>`;
+
+let pw: any = null;
+try { pw = requireCjs("playwright"); } catch { pw = null; }
+
+async function inChat(t: any, probe: boolean, body: (page: any, errors: string[]) => Promise<void>): Promise<void> {
+  if (!pw) { t.skip("playwright is not installed under vscode-extension; the browser leg needs it (CI installs no browsers)"); return; }
+  let browser: any;
+  try { browser = await pw.chromium.launch(); }
+  catch (e) { t.skip("no playwright browser on this machine; the browser leg needs one (CI installs none): " + String((e as Error).message).split("\n")[0]); return; }
+  const errors: string[] = [];
+  try {
+    const renderJs = bundle("render.ts");
+    const probeJs = probe ? probeBundle() : "";
+    const page = await browser.newPage({ viewport: { width: 900, height: 600 } });
+    page.on("pageerror", (e: Error) => { errors.push(e.message); });
+    await page.route("**/*", (route: any) => {
+      const u = new URL(route.request().url());
+      if (u.hostname !== "romp.test") return route.fulfill({ status: 404, body: "" });
+      if (u.pathname === "/chat") return route.fulfill({ status: 200, contentType: "text/html; charset=utf-8", body: chatHtml(probe) });
+      if (u.pathname === "/dist/render.js") return route.fulfill({ status: 200, contentType: "application/javascript", body: renderJs });
+      if (u.pathname === "/dist/probe.js") return route.fulfill({ status: 200, contentType: "application/javascript", body: probeJs });
+      return route.fulfill({ status: 404, body: "" });
+    });
+    await page.goto("http://romp.test/chat");
+    if (probe) await page.waitForFunction(() => typeof (window as any).__mdProbe === "function", null, { timeout: 10000 });
+    await body(page, errors);
+  } finally {
+    await browser.close();
+  }
+}
+
+const FILLER = Array.from({ length: 80 }, (_, i) => "<p>Filler paragraph " + (i + 1) + " so the transcript scrolls.</p>").join("\n");
+
+// fill a message body the way render.ts does (body.innerHTML = md(text)), alone in the transcript: `html` is either
+// the markup the sanitizer produces (the delegate's contract) or, through the probe, a message's markdown
+async function show(page: any, html: string, throughMd: boolean): Promise<string> {
+  return page.evaluate(([h, viaMd]: [string, boolean]) => {
+    document.querySelectorAll(".fx-turn").forEach((n) => n.remove());
+    const content = document.getElementById("content") as HTMLElement;
+    const turn = document.createElement("div"); turn.className = "turn turn-assistant fx-turn";
+    const body = document.createElement("div"); body.className = "assistant md fx-body";
+    body.innerHTML = viaMd ? (window as any).__mdProbe(h) : h;
+    turn.appendChild(body); content.appendChild(turn);
+    content.scrollTop = 0;
+    history.replaceState(null, "", location.pathname);
+    return body.innerHTML;
+  }, [html, throughMd] as [string, boolean]);
+}
+type Landed = { hash: string; inView: boolean; prevented: boolean | null; detailsOpen: boolean | null };
+// one real click at the link's centre; then where the target stands relative to the transcript's viewport, the page's
+// hash, whether the click's default action was cancelled, and whether a <details> above the target is open. The
+// window listener runs after the document's delegate, so what it reads is the delegate's verdict; for a click with a
+// modifier held it then cancels the default itself, so the browser opens no window of its own over the test.
+async function clickLink(page: any, linkSel: string, targetSel: string, modifier?: "Shift"): Promise<Landed> {
+  const link = page.locator(linkSel).first();
+  await link.scrollIntoViewIfNeeded();                              // an earlier click may have scrolled it out of the transcript's viewport
+  const box = await link.boundingBox();
+  assert.ok(box, linkSel + " has a box");
+  await page.evaluate((mod: boolean) => { (window as any).__lastClick = null; window.addEventListener("click", (e) => { (window as any).__lastClick = e.defaultPrevented; if (mod) e.preventDefault(); }, { once: true }); }, !!modifier);
+  if (modifier) await page.keyboard.down(modifier);
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+  if (modifier) await page.keyboard.up(modifier);
+  return page.evaluate((sel: string) => {
+    const content = document.getElementById("content") as HTMLElement;
+    const target = document.querySelector(sel) as HTMLElement | null;
+    const c = content.getBoundingClientRect();
+    const r = target ? target.getBoundingClientRect() : null;
+    const details = target ? target.closest("details") : null;
+    return { hash: location.hash, inView: !!r && r.top >= c.top - 1 && r.bottom <= c.bottom + 1,
+             prevented: (window as any).__lastClick as boolean | null, detailsOpen: details ? details.hasAttribute("open") : null };
+  }, targetSel);
+}
+
+test("the delegate lands a message's `#` link on its prefixed target, revealing a closed <details>, with the hash untouched; a fragment with no target is left to the browser", { timeout: 60000 }, async (t) => {
+  await inChat(t, false, async (page, errors) => {
+    // the markup the sanitizer produces for a reply with a footnote, a section anchor and a folded note
+    await show(page, [
+      '<p>Claim.<sup id="user-content-fn1"><a href="#fnref1" class="fx-fwd">1</a></sup> <a href="#install" class="fx-install">install</a>',
+      ' <a href="#note" class="fx-note">the note</a> <a href="#found" class="fx-found">the searchable</a> <a href="#nowhere" class="fx-none">missing</a></p>',
+      FILLER,
+      '<a name="user-content-install" class="fx-install-anchor"></a><p class="fx-install-p">Install section.</p>',
+      '<p id="user-content-fnref1">1. a note <a href="#fn1" class="fx-back">back</a>.</p>',
+      FILLER,
+      '<details class="fx-details"><summary>notes</summary><p id="user-content-note">the folded note</p></details>',
+      FILLER,
+      '<div hidden="until-found" class="fx-until"><p id="user-content-found">shown when found</p></div>',
+    ].join("\n"), false);
+    const before = await page.evaluate(() => ({ inView: (() => { const c = document.getElementById("content")!.getBoundingClientRect(); const r = document.querySelector("#user-content-fnref1")!.getBoundingClientRect(); return r.top >= c.top && r.bottom <= c.bottom; })(), hash: location.hash }));
+    assert.equal(before.inView, false, "precondition: the footnote starts out of view");
+    assert.equal(before.hash, "");
+
+    const fwd = await clickLink(page, ".fx-fwd", "#user-content-fnref1");
+    assert.equal(fwd.prevented, true, "the delegate cancelled the click's default action");
+    assert.equal(fwd.inView, true, "the footnote is in view: resolved under the prefix");
+    assert.equal(fwd.hash, "", "the page's hash is untouched");
+
+    const back = await clickLink(page, ".fx-back", "#user-content-fn1");
+    assert.equal(back.prevented, true);
+    assert.equal(back.inView, true, "the back link lands on the prefixed sup");
+    assert.equal(back.hash, "");
+
+    const install = await clickLink(page, ".fx-install", ".fx-install-p");
+    assert.equal(install.prevented, true);
+    assert.equal(install.inView, true, "a link over the reply's own <a name> lands on it under the prefix");
+    assert.equal(install.hash, "");
+
+    const note = await clickLink(page, ".fx-note", "#user-content-note");
+    assert.equal(note.prevented, true);
+    assert.equal(note.detailsOpen, true, "the closed <details> above the target was opened, as the browser's fragment navigation would");
+    assert.equal(note.inView, true, "and the folded note is in view");
+    assert.equal(note.hash, "");
+
+    await page.evaluate(() => { (document.getElementById("content") as HTMLElement).scrollTop = 0; });
+    const none = await clickLink(page, ".fx-none", "#user-content-nowhere");
+    assert.equal(none.prevented, false, "a fragment that names nothing is left to the browser");
+    assert.equal(none.hash, "#nowhere", "whose default action sets the hash, as before");
+
+    // a target under hidden="until-found" is revealed the way the browser's fragment navigation reveals it
+    await page.evaluate(() => { history.replaceState(null, "", location.pathname); (document.getElementById("content") as HTMLElement).scrollTop = 0; });
+    const found = await clickLink(page, ".fx-found", "#user-content-found");
+    assert.equal(found.prevented, true);
+    assert.equal(await page.evaluate(() => (document.querySelector(".fx-until") as HTMLElement).hasAttribute("hidden")), false, "hidden=until-found was removed from the target's ancestor");
+    assert.equal(found.inView, true, "and the target is in view");
+    assert.equal(found.hash, "");
+
+    // a click with a modifier held asked the browser for a window of its own: the delegate leaves it alone
+    await page.evaluate(() => { (document.getElementById("content") as HTMLElement).scrollTop = 0; });
+    const shifted = await clickLink(page, ".fx-fwd", "#user-content-fnref1", "Shift");
+    assert.equal(shifted.prevented, false, "the delegate did not cancel a shift-click");
+    assert.equal(shifted.inView, false, "and did not scroll to the target");
+    assert.deepEqual(errors, [], "no page errors");
+  });
+});
+
+test("through the chat's own pipeline: a reply's `<p id>` is prefixed and its `[link](#id)` still lands on it, in the reply's body before an older message's", { timeout: 60000 }, async (t) => {
+  await inChat(t, true, async (page, errors) => {
+    // an OLDER message carrying the same id: the click in the newer one must land in its own body, not there
+    const html = await page.evaluate(([older, newer]: [string, string]) => {
+      document.querySelectorAll(".fx-turn").forEach((n) => n.remove());
+      const content = document.getElementById("content") as HTMLElement;
+      const out: string[] = [];
+      for (const [cls, src] of [["fx-older", older], ["fx-newer", newer]] as const) {
+        const turn = document.createElement("div"); turn.className = "turn turn-assistant fx-turn";
+        const body = document.createElement("div"); body.className = "assistant md " + cls;
+        body.innerHTML = (window as any).__mdProbe(src);
+        turn.appendChild(body); content.appendChild(turn);
+        out.push(body.innerHTML);
+      }
+      content.scrollTop = 0;
+      history.replaceState(null, "", location.pathname);
+      return out;
+    }, ['<p id="dup" class="fx-dup-older">the older dup</p>\n\nolder text',
+        ['[go to top](#top) and [dup](#dup)', '', FILLER.replace(/<\/?p>/g, "").split("\n").join("\n\n"), '', '<p id="top" class="fx-top">Top paragraph.</p>', '', '<p id="dup" class="fx-dup-here">this message\'s dup</p>'].join("\n")] as [string, string]);
+    // DOMPurify re-adds the attributes it keeps, so their order is its own: match the two whatever the order
+    assert.match(html[1], /<p (?=[^>]*\bid="user-content-top")(?=[^>]*\bclass="fx-top")[^>]*>/, "the reply's id is prefixed by the sanitizer");
+    assert.match(html[1], /href="#top"/, "and its href is left as written");
+    assert.doesNotMatch(html[1], /id="top"/);
+
+    const top = await clickLink(page, ".fx-newer a[href='#top']", ".fx-top");
+    assert.equal(top.prevented, true, "the delegate cancelled the click");
+    assert.equal(top.inView, true, "the reply's own paragraph is in view");
+    assert.equal(top.hash, "", "the hash is untouched");
+
+    await page.evaluate(() => { (document.getElementById("content") as HTMLElement).scrollTop = 0; });
+    const dup = await clickLink(page, ".fx-newer a[href='#dup']", ".fx-dup-here");
+    assert.equal(dup.prevented, true);
+    assert.equal(dup.inView, true, "a duplicated id resolves in the reply's own body first");
+    const olderInView = await page.evaluate(() => { const c = document.getElementById("content")!.getBoundingClientRect(); const r = document.querySelector(".fx-dup-older")!.getBoundingClientRect(); return r.top >= c.top && r.bottom <= c.bottom; });
+    assert.equal(olderInView, false, "not in the older message's");
+    assert.deepEqual(errors, [], "no page errors");
+  });
+});
+
+test("through render.ts's own md(): a session frame's reply renders with its ids prefixed and its `#` link lands", { timeout: 60000 }, async (t) => {
+  await inChat(t, false, async (page, errors) => {
+    // the kernel's session frame, as the pane's frame listener receives it: the one session is adopted as the active
+    // tab and its events are rendered by render.ts (renderEventInner: body.innerHTML = md(ev.md))
+    const SID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    const reply = ["[go to top](#top)", "", FILLER.replace(/<\/?p>/g, "").split("\n").join("\n\n"), "", '<p id="top" class="fx-top">Top paragraph.</p>'].join("\n");
+    await page.evaluate(([sid, md]: [string, string]) => {
+      window.postMessage({ type: "session", id: sid, name: "web", cwd: "/tmp/TESTHOST/notes-api", status: { state: "idle", sinceEpoch: null },
+                           events: [{ kind: "assistant", md, uuid: "11111111-2222-4333-8444-555555555555" }] }, "*");
+    }, [SID, reply] as [string, string]);
+    await page.waitForSelector("#content .turn-assistant .md .fx-top", { state: "attached", timeout: 10000 });
+    const facts = await page.evaluate(() => {
+      const body = document.querySelector("#content .turn-assistant .md") as HTMLElement;
+      history.replaceState(null, "", location.pathname);
+      (document.getElementById("content") as HTMLElement).scrollTop = 0;
+      return { prefixed: body.querySelectorAll("p#user-content-top.fx-top").length, raw: body.querySelectorAll("#top").length,
+               href: (body.querySelector("a") as HTMLAnchorElement).getAttribute("href") };
+    });
+    assert.equal(facts.prefixed, 1, "render.ts's md() prefixed the reply's id");
+    assert.equal(facts.raw, 0);
+    assert.equal(facts.href, "#top", "and left the href as written");
+    const top = await clickLink(page, "#content .turn-assistant .md a[href='#top']", ".fx-top");
+    assert.equal(top.prevented, true, "the delegate cancelled the click");
+    assert.equal(top.inView, true, "the reply's own paragraph is in view");
+    assert.equal(top.hash, "", "the hash is untouched");
+    assert.deepEqual(errors, [], "no page errors");
+  });
+});

--- a/ui/webview/md-sanitize-postpass-browser.test.ts
+++ b/ui/webview/md-sanitize-postpass-browser.test.ts
@@ -1,0 +1,277 @@
+// The chat's markdown pipeline in headless Chromium over the real modules: marked with the chat grammar (chat-md.ts,
+// math.ts), then sanitizeMd (md-sanitize.ts), which runs renderMathPlaceholders as the post-pass chat-md.ts registers
+// at load; userMd the same over the breaks:true instance. This is md() and userMd() as render.ts composes them,
+// minus the PR-reference walk (render-math.test.ts and chat-md.test.ts pin render.ts to that order).
+// What a source pin cannot see, and this leg measures:
+//   • Math keeps its layout. KaTeX positions everything with inline style (a strut's height, a vlist row's top, a
+//     radical's padding), and sanitizeMd keeps only colour in a `style` attribute, so KaTeX markup emitted by marked
+//     and then sanitized would come back flat. The extensions emit an inert placeholder instead and KaTeX renders
+//     into it after the sanitize: a fraction stacks, a superscript is raised, the radical has height, a display sum
+//     stands at block level, and the rendered root is katex.render's own output byte for byte, so nothing of it
+//     passed through DOMPurify. An author's own `style` beside the math still loses everything but its colour.
+//   • A hand-written placeholder gets only what KaTeX renders under the fill's options: no link from \href, no image
+//     (trust: false, KaTeX's own default, spelled out in math.ts and pinned by render-math.test.ts).
+//   • An author's <style>, <form> and <button> in a message are gone, an author's id is prefixed, a checkbox written
+//     by hand is forced disabled and a click leaves it unchecked.
+//   • The registry: a pass registered twice runs once per sanitize; a second run of the fill is a no-op.
+// Skips with a stated reason when no playwright browser is installed (CI installs none; tests/test_spend_modal_headless.py
+// is the precedent, skipping without a playwright install). Synthetic values only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+const EXT = process.cwd();                                        // npm test runs in vscode-extension
+// resolve playwright and esbuild from the extension, not from wherever this bundle was written
+const requireCjs = createRequire(path.join(EXT, "package.json"));
+const UI = path.resolve(EXT, "..", "ui", "webview");
+const KATEX_DIST = path.join(EXT, "node_modules", "katex", "dist");
+const KATEX_CSS = fs.readFileSync(path.join(KATEX_DIST, "katex.min.css"), "utf8");
+
+const ENTRY = `
+import { marked } from "marked";
+import katex from "katex";
+import { chatMdExtensions, userMdHtml } from "./chat-md";
+import { sanitizeMd, registerMdPostPass } from "./md-sanitize";
+import { renderMathPlaceholders } from "./math";
+marked.setOptions({ gfm: true, breaks: false });
+marked.use(...chatMdExtensions);
+function md(src: string): string { return sanitizeMd(marked.parse(src) as string).innerHTML; }
+function userMd(src: string): string { return sanitizeMd(userMdHtml(src)).innerHTML; }
+function markedOnly(src: string): string { return marked.parse(src) as string; }
+// KaTeX's own output for the same TeX by the same DOM path (katex.render into a fresh element, the browser serializing),
+// under the options the fill uses
+function direct(tex: string, display: boolean): string {
+  const el = document.createElement("div"); katex.render(tex, el, { displayMode: display, throwOnError: false, output: "html", trust: false }); return el.innerHTML;
+}
+function twice(src: string): { once: string; again: string } {
+  const clean = sanitizeMd(marked.parse(src) as string); const once = clean.innerHTML;
+  renderMathPlaceholders(clean); return { once, again: clean.innerHTML };
+}
+// the registry: a pass registered twice runs once per sanitize; a second pass runs too, after the fill
+function registry(): { runs: number; other: number; sawKatex: boolean } {
+  let runs = 0, other = 0, sawKatex = false;
+  const counting = (root: ParentNode) => { runs++; sawKatex = sawKatex || root.querySelectorAll(".katex").length > 0; };
+  const second = () => { other++; };
+  registerMdPostPass(counting); registerMdPostPass(counting); registerMdPostPass(second);
+  sanitizeMd(marked.parse("one $x$ formula") as string);
+  return { runs, other, sawKatex };
+}
+(window as any).__pipe = { md, userMd, markedOnly, direct, twice, registry };
+`;
+
+function bundle(): string {
+  const esbuild = requireCjs("esbuild");
+  const r = esbuild.buildSync({
+    stdin: { contents: ENTRY, resolveDir: UI, loader: "ts", sourcefile: "md-sanitize-postpass-entry.ts" },
+    bundle: true, write: false, format: "iife", platform: "browser", target: "es2020",
+    nodePaths: [path.join(EXT, "node_modules")], external: ["*.png", "*.svg", "*.woff", "*.ttf", "../media/*.woff2"], logLevel: "silent",
+  });
+  return r.outputFiles[0].text;
+}
+
+// a standards-mode page (KaTeX refuses quirks mode) with KaTeX's own sheet, its fonts served from the package
+const PAGE_HTML = `<!DOCTYPE html><html><head><meta charset=utf-8><style>${KATEX_CSS}\nbody{font-size:16px}</style></head><body>
+<div id=out></div>
+<script src=/dist/postpass.js></script></body></html>`;
+
+let pw: any = null;
+try { pw = requireCjs("playwright"); } catch { pw = null; }
+
+async function inBrowser(t: any, body: (page: any, errors: string[]) => Promise<void>): Promise<void> {
+  if (!pw) { t.skip("playwright is not installed under vscode-extension; the browser leg needs it (CI installs no browsers)"); return; }
+  let browser: any;
+  try { browser = await pw.chromium.launch(); }
+  catch (e) { t.skip("no playwright browser on this machine; the browser leg needs one (CI installs none): " + String((e as Error).message).split("\n")[0]); return; }
+  const errors: string[] = [];
+  try {
+    const js = bundle();
+    const page = await browser.newPage({ viewport: { width: 900, height: 600 } });
+    page.on("pageerror", (e: Error) => { errors.push(e.message); });
+    await page.route("http://romp.test/**", (route: any) => {
+      const u = new URL(route.request().url());
+      if (u.pathname === "/page") return route.fulfill({ status: 200, contentType: "text/html; charset=utf-8", body: PAGE_HTML });
+      if (u.pathname === "/dist/postpass.js") return route.fulfill({ status: 200, contentType: "application/javascript", body: js });
+      if (u.pathname.startsWith("/fonts/")) {
+        const f = path.join(KATEX_DIST, "fonts", path.basename(u.pathname));
+        if (fs.existsSync(f)) return route.fulfill({ status: 200, contentType: "font/woff2", body: fs.readFileSync(f) });
+      }
+      return route.fulfill({ status: 404, body: "" });
+    });
+    await page.goto("http://romp.test/page");
+    await page.waitForFunction(() => typeof (window as any).__pipe === "object", null, { timeout: 10000 });
+    await page.evaluate(() => (document as any).fonts.ready);
+    await body(page, errors);
+  } finally {
+    await browser.close();
+  }
+}
+
+type Box = { top: number; bottom: number; height: number; width: number };
+
+test("math keeps its KaTeX layout when rendered after the sanitizer, and is KaTeX's own output byte for byte; an author's style beside it keeps only its colour", { timeout: 60000 }, async (t) => {
+  await inBrowser(t, async (page, errors) => {
+    const MSG = [
+      "The ratio is $\\frac{a}{b}$ and $x^2$ and $\\sqrt{d}$ and $a<b$ here.",
+      "",
+      "$$\\sum_{i=0}^{n} i^2$$",
+      "",
+      'A <span class="fx-red" style="color: rgb(200, 0, 0); position: fixed; top: 0; font-size: 80px">red</span> word.',
+      "",
+    ].join("\n");
+    // 1. what reaches the sanitizer is the placeholder, not KaTeX: no style attribute for the colour rule to strip
+    const before = await page.evaluate((src: string) => {
+      const marked = (window as any).__pipe.markedOnly(src) as string;
+      return { markedHasKatex: /class="katex/.test(marked), markedStyles: (marked.match(/ style="/g) || []).length,
+        placeholders: (marked.match(/md-math-(inline|display)/g) || []).length };
+    }, MSG);
+    assert.equal(before.markedHasKatex, false, "marked emits placeholders, never KaTeX markup");
+    assert.equal(before.markedStyles, 1, "the one inline style in marked's output is the author's span; the math placeholders carry none");
+    assert.equal(before.placeholders, 5, "five placeholders (4 inline + 1 display)");
+
+    // 2. the full pipeline: render, then measure
+    const facts = await page.evaluate((src: string) => {
+      const P = (window as any).__pipe;
+      const out = document.getElementById("out") as HTMLElement;
+      out.innerHTML = P.md(src);
+      const box = (e: Element | null): Box | null => { if (!e) return null; const r = e.getBoundingClientRect(); return { top: r.top, bottom: r.bottom, height: r.height, width: r.width }; };
+      const katex = Array.from(out.querySelectorAll(".katex")) as HTMLElement[];
+      const frac = out.querySelector(".mfrac") as HTMLElement | null;
+      const fracGlyphs = frac ? Array.from(frac.querySelectorAll(".mord.mathnormal")) as HTMLElement[] : [];
+      const fracA = fracGlyphs.find((g) => g.textContent === "a") || null;
+      const fracB = fracGlyphs.find((g) => g.textContent === "b") || null;
+      const sup = katex[1] || null;
+      const supBase = sup ? sup.querySelector(".mord.mathnormal") : null;
+      const supScript = sup ? sup.querySelector(".msupsub .mord") : null;
+      const sqrt = katex[2] || null;
+      const svg = sqrt ? sqrt.querySelector("svg") : null;
+      const display = out.querySelector(".katex-display") as HTMLElement | null;
+      const red = out.querySelector(".fx-red") as HTMLElement | null;
+      const line = red ? red.parentElement as HTMLElement : null;
+      return {
+        placeholdersLeft: out.querySelectorAll(".md-math-inline, .md-math-display").length,
+        katexCount: katex.length,
+        katexStyled: out.querySelectorAll(".katex [style]").length,
+        inlineParent: katex[0] ? katex[0].parentElement?.tagName : null,
+        fracA: box(fracA), fracB: box(fracB),
+        supBase: box(supBase), supScript: box(supScript),
+        svg: box(svg),
+        display: box(display), displayParentId: display ? display.parentElement?.id : null, displayInParagraph: display ? !!display.closest("p") : null,
+        exactFrac: katex[0] ? katex[0].outerHTML === P.direct("\\frac{a}{b}", false) : false,
+        exactDisplay: display ? display.outerHTML === P.direct("\\sum_{i=0}^{n} i^2", true) : false,
+        redStyle: red ? red.getAttribute("style") : null,
+        redPosition: red ? getComputedStyle(red).position : null,
+        redFontSize: red ? getComputedStyle(red).fontSize : null,
+        lineFontSize: line ? getComputedStyle(line).fontSize : null,
+        ltEscaped: (out.textContent || "").includes("a<b"),
+      };
+    }, MSG);
+    assert.equal(facts.placeholdersLeft, 0, "every placeholder was rendered and unwrapped");
+    assert.equal(facts.katexCount, 5, "five formulas rendered");
+    assert.ok(facts.katexStyled >= 10, "KaTeX's inline layout styles are all there: " + facts.katexStyled);
+    assert.equal(facts.inlineParent, "P", "an inline formula's .katex root stands in the paragraph where the placeholder stood");
+    assert.ok(facts.fracA && facts.fracB && facts.fracA.bottom <= facts.fracB.top + 1, "the fraction stacks: the numerator sits above the denominator: " + JSON.stringify([facts.fracA, facts.fracB]));
+    assert.ok(facts.supBase && facts.supScript && facts.supScript.top < facts.supBase.top, "the superscript is raised above its base: " + JSON.stringify([facts.supBase, facts.supScript]));
+    assert.ok(facts.svg && facts.svg.height > 5 && facts.svg.width > 5, "the radical's stretchy glyph has a box: " + JSON.stringify(facts.svg));
+    assert.ok(facts.display && facts.display.height > 20, "the display sum is taller than a line: " + JSON.stringify(facts.display));
+    assert.equal(facts.displayParentId, "out", "the display formula stands at block level, unwrapped");
+    assert.equal(facts.displayInParagraph, false);
+    assert.ok(facts.exactFrac, "the inline formula is katex.render's own output byte for byte: nothing of it passed through DOMPurify");
+    assert.ok(facts.exactDisplay, "and so is the display one");
+    assert.equal(facts.redStyle, "color: rgb(200, 0, 0)", "the author's span keeps only its colour declaration");
+    assert.equal(facts.redPosition, "static");
+    assert.equal(facts.redFontSize, facts.lineFontSize, "font-size: 80px was dropped");
+    assert.ok(facts.ltEscaped, "a formula's `<` is text, never markup");
+    assert.deepEqual(errors, [], "no page errors");
+  });
+});
+
+test("a hand-written placeholder renders under the fill's options (no link from \\href), an empty one is unwrapped, and the user's own words take the same path", { timeout: 60000 }, async (t) => {
+  await inBrowser(t, async (page, errors) => {
+    const facts = await page.evaluate(() => {
+      const P = (window as any).__pipe;
+      const out = document.getElementById("out") as HTMLElement;
+      out.innerHTML = P.md('hand <span class="md-math-inline">\\href{javascript:alert(1)}{x}</span> and <span class="md-math-inline"> </span> empty\n\n<div class="md-math-display">\\int_0^1 f</div>');
+      const hand = { katex: out.querySelectorAll(".katex").length, anchors: out.querySelectorAll("a").length, hasJs: out.innerHTML.includes("javascript:"),
+        placeholders: out.querySelectorAll(".md-math-inline, .md-math-display").length, display: out.querySelectorAll(".katex-display").length,
+        text: out.textContent };
+      out.innerHTML = P.userMd("Euler: $e^{i\\pi}+1=0$\nnext line");
+      const user = { katex: out.querySelectorAll(".katex").length, br: out.querySelectorAll("br").length, placeholders: out.querySelectorAll(".md-math-inline").length };
+      const t = P.twice("a $x^2$ b");
+      return { hand, user, twiceSame: t.once === t.again, twiceKatex: (t.once.match(/class="katex"/g) || []).length };
+    });
+    assert.equal(facts.hand.katex, 2, "the two non-empty hand-written placeholders rendered (KaTeX flags the untrusted command in red)");
+    assert.equal(facts.hand.anchors, 0, "\\href mints no link under the fill's options (trust: false, which is also KaTeX's default)");
+    assert.equal(facts.hand.hasJs, false, "and the URL is nowhere in the markup");
+    assert.equal(facts.hand.placeholders, 0, "no placeholder is left, the empty one included");
+    assert.equal(facts.hand.display, 1, "the hand-written display placeholder renders in display mode");
+    assert.ok((facts.hand.text || "").includes("empty"), "the empty placeholder's neighbours are intact");
+    assert.equal(facts.user.katex, 1, "the user's own words render math through the same fill");
+    assert.equal(facts.user.br, 1, "and keep their line break");
+    assert.equal(facts.user.placeholders, 0);
+    assert.ok(facts.twiceSame, "a second run of the fill over the same body is a no-op");
+    assert.equal(facts.twiceKatex, 1);
+    assert.deepEqual(errors, [], "no page errors");
+  });
+});
+
+test("a message's own <style>, form and controls are gone, its ids are prefixed, and a hand-written checkbox is inert", { timeout: 60000 }, async (t) => {
+  await inBrowser(t, async (page, errors) => {
+    const facts = await page.evaluate(() => {
+      const P = (window as any).__pipe;
+      const out = document.getElementById("out") as HTMLElement;
+      // the <style> comes AFTER a block: a document that OPENS with <style> has it hoisted into <head> by the HTML
+      // parser, and DOMPurify hands back the <body>, so the case would pass with style allowed; here the sanitizer
+      // is what removes it
+      const src = [
+        '<p id="top">top</p>',
+        "",
+        "<style>#out { display: none }</style>",
+        "",
+        '<form action="https://example.invalid/go"><button>Go</button></form>',
+        "",
+        "- [x] done",
+        "",
+        '<input type="checkbox" class="fx-hand"> <input type="text" class="fx-text">',
+      ].join("\n");
+      const dirty = P.markedOnly(src) as string;
+      out.innerHTML = P.md(src);
+      const hand = out.querySelector(".fx-hand") as HTMLInputElement | null;
+      if (hand) hand.click();
+      return {
+        dirtyHasStyle: /<style>#out \{ display: none \}<\/style>/.test(dirty) && dirty.indexOf("<style>") > dirty.indexOf("<p id=\"top\">"),
+        forbidden: out.querySelectorAll("style, form, button").length,
+        outDisplay: getComputedStyle(out).display,
+        goText: (out.textContent || "").includes("Go"),
+        prefixed: out.querySelectorAll("p#user-content-top").length,
+        raw: out.querySelectorAll("#top").length,
+        task: out.querySelectorAll('li input[type="checkbox"][disabled]:checked').length,
+        handDisabled: hand ? hand.disabled : null,
+        handChecked: hand ? hand.checked : null,
+        textInputs: out.querySelectorAll(".fx-text, input[type=text]").length,
+      };
+    });
+    assert.ok(facts.dirtyHasStyle, "precondition: marked hands the sanitizer the <style>, after the paragraph");
+    assert.equal(facts.forbidden, 0, "no style, form or button in the rendered message");
+    assert.notEqual(facts.outDisplay, "none", "the message's <style> did not hide the transcript");
+    assert.ok(facts.goText, "the button's text stays as prose");
+    assert.equal(facts.prefixed, 1, "the author's id is prefixed user-content-");
+    assert.equal(facts.raw, 0);
+    assert.equal(facts.task, 1, "marked's task checkbox survives, disabled and ticked");
+    assert.equal(facts.handDisabled, true, "a checkbox written by hand is forced disabled");
+    assert.equal(facts.handChecked, false, "and a click leaves it unchecked");
+    assert.equal(facts.textInputs, 0, "a text input does not survive");
+    assert.deepEqual(errors, [], "no page errors");
+  });
+});
+
+test("the post-pass registry: a pass registered twice runs once per sanitize, after the math fill", { timeout: 60000 }, async (t) => {
+  await inBrowser(t, async (page, errors) => {
+    const r = await page.evaluate(() => (window as any).__pipe.registry());
+    assert.equal(r.runs, 1, "the counting pass ran once for one sanitize, though registered twice");
+    assert.equal(r.other, 1, "the second pass ran too");
+    assert.equal(r.sawKatex, true, "and by then the math fill had run: the passes see rendered math");
+    assert.deepEqual(errors, [], "no page errors");
+  });
+});

--- a/ui/webview/md-sanitize.test.ts
+++ b/ui/webview/md-sanitize.test.ts
@@ -1,0 +1,216 @@
+// The shared markdown sanitizer's pure parts, in node. DOMPurify itself needs a window, so the sanitize call and
+// the DOM post-passes are proven in headless Chromium: md-sanitize-browser.test.ts opens a note in the real file
+// viewer, md-sanitize-postpass-browser.test.ts runs the chat's pipeline, md-sanitize-chat-fragment-browser.test.ts
+// clicks a message's own `#` link over the real chat bundle. Here: the colour grammar an inline `style` is held to,
+// the profile's forbidden tags and attributes, the hook body, the hook's install guard, and the source pins that
+// make md-sanitize.ts the ONE sanitizer the dashboard has (the chat's md() and userMd(), the viewer's mdBlock).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import { MD_FORBID_TAGS, MD_FORBID_ATTR, MD_PURIFY, USER_CONTENT_PREFIX, colorOnlyStyle, isLiteralColor, styleAttributeHook, installMdSanitizeHooks } from "./md-sanitize";
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const read = (f: string) => fs.readFileSync(path.join(UI, f), "utf8");
+const ROOT = path.resolve(UI, "..", "..");
+
+// ── the colour grammar ──────────────────────────────────────────────────────────────────────────────
+
+test("a literal colour: a keyword, #hex of 3 to 8 digits, or rgb/rgba/hsl/hsla over plain numeric arguments", () => {
+  for (const v of ["red", "Red", "transparent", "currentcolor", "inherit", "#abc", "#abcd", "#aabbcc", "#AABBCCDD",
+                   "rgb(200, 0, 0)", "rgb(200 0 0)", "rgb(200 0 0 / 50%)", "rgba(1,2,3,.5)", "rgba(1, 2, 3, 0.5)",
+                   "hsl(120, 50%, 50%)", "hsl(120deg 50% 50%)", "hsla(120 50% 50% / 0.4)", "hsl(none 50% 50%)", "rgb(+10 -0 0.5)"]) {
+    assert.ok(isLiteralColor(v), "accepted: " + v);
+  }
+});
+
+test("not a literal colour: other functions, nested parentheses, escapes, quotes, !important, wrong arity", () => {
+  for (const v of ["url(x)", "url(javascript:alert(1))", "var(--x)", "expression(alert(1))", "calc(1px)", "rgb(var(--x))",
+                   "rgb(1,2)", "rgb(1,2,3,4,5)", "rgb()", "red !important", "red\"", "'red'", "#ab", "#abcdefabc", "#ggg",
+                   "rgb(1,2,3)) ;", "red;color:blue", "rgb(1,2,3/**/)", "r\\65d", "rgb(1 2 3) x", "rgb(1px 2 3)", "red blue", "", " "]) {
+    assert.ok(!isLiteralColor(v), "rejected: " + JSON.stringify(v));
+  }
+});
+
+test("colorOnlyStyle keeps color and background-color with literal values, in order, and nothing else", () => {
+  assert.equal(colorOnlyStyle("color: rgb(200, 0, 0); font-size: 80px"), "color: rgb(200, 0, 0)");
+  assert.equal(colorOnlyStyle("position:fixed;inset:0;background:red"), "", "`background` is not `background-color`: the shorthand takes images and positions");
+  assert.equal(colorOnlyStyle("COLOR: Red; Background-Color: #abc"), "color: Red; background-color: #abc", "property names case-folded, values as written");
+  assert.equal(colorOnlyStyle("color: red !important"), "");
+  assert.equal(colorOnlyStyle("color: url(javascript:alert(1))"), "");
+  assert.equal(colorOnlyStyle("color: red; color: blue"), "color: red; color: blue", "a repeated property is two valid declarations");
+  assert.equal(colorOnlyStyle("color"), "");
+  assert.equal(colorOnlyStyle("color:"), "");
+  assert.equal(colorOnlyStyle(""), "");
+  assert.equal(colorOnlyStyle("background-color: rgb(0 0 0 / 50%)"), "background-color: rgb(0 0 0 / 50%)");
+  assert.equal(colorOnlyStyle("color: red; background: url(x); background-color: var(--y); display: none"), "color: red");
+  assert.equal(colorOnlyStyle("color: red; }; .fileview { display: none"), "color: red", "a declaration that tries to close the block is an invalid declaration");
+  assert.equal(colorOnlyStyle("color: rgb(1,2,3); font-family: x; color: hsl(1 2% 3%)"), "color: rgb(1,2,3); color: hsl(1 2% 3%)");
+});
+
+// ── the hook ────────────────────────────────────────────────────────────────────────────────────────
+
+test("the style hook rewrites a style attribute to its colours, drops it when none remain, and leaves other attributes to DOMPurify", () => {
+  const kept = { attrName: "style", attrValue: "color: red; position: fixed; inset: 0", keepAttr: true };
+  styleAttributeHook(kept);
+  assert.deepEqual(kept, { attrName: "style", attrValue: "color: red", keepAttr: true });
+  const dropped = { attrName: "style", attrValue: "position:fixed;inset:0;background:red", keepAttr: true };
+  styleAttributeHook(dropped);
+  assert.equal(dropped.keepAttr, false, "nothing survived: the attribute goes");
+  const other = { attrName: "href", attrValue: "position:fixed", keepAttr: true };
+  styleAttributeHook(other);
+  assert.deepEqual(other, { attrName: "href", attrValue: "position:fixed", keepAttr: true }, "not a style attribute: untouched (DOMPurify's own URI rules apply)");
+  const upper = { attrName: "style", attrValue: "COLOR: #fff", keepAttr: true };
+  styleAttributeHook(upper);
+  assert.equal(upper.attrValue, "color: #fff");
+});
+
+test("installMdSanitizeHooks registers ONE uponSanitizeAttribute hook however often it is called, and that hook is the style rewrite", () => {
+  // The guard is module-global and never reset, so this test must be the module's FIRST installer: node runs a
+  // file's tests in order, and nothing above calls installMdSanitizeHooks or sanitizeMd (which would need a window).
+  const calls: { name: string; fn: Function }[] = [];
+  const fake = { addHook: (name: string, fn: Function) => { calls.push({ name, fn }); } } as unknown as Parameters<typeof installMdSanitizeHooks>[0];
+  installMdSanitizeHooks(fake);
+  installMdSanitizeHooks(fake);
+  installMdSanitizeHooks(fake);
+  assert.equal(calls.length, 1, "idempotent: a second registration would run the rewrite twice per attribute");
+  assert.equal(calls[0].name, "uponSanitizeAttribute");
+  const ev = { attrName: "style", attrValue: "font-size: 80px; color: rgb(200, 0, 0)", keepAttr: true, allowedAttributes: {}, forceKeepAttr: undefined };
+  calls[0].fn.call(fake, {} as Element, ev, {});
+  assert.equal(ev.attrValue, "color: rgb(200, 0, 0)");
+  assert.equal(ev.keepAttr, true);
+});
+
+// ── the profile ─────────────────────────────────────────────────────────────────────────────────────
+
+test("the profile: html + svg, data: on img, no data-*, the forbidden tags, prefixed ids and names; input stays for the task checkbox", () => {
+  assert.deepEqual(MD_PURIFY.USE_PROFILES, { html: true, svg: true });
+  assert.deepEqual(MD_PURIFY.ADD_DATA_URI_TAGS, ["img"]);
+  assert.equal(MD_PURIFY.ALLOW_DATA_ATTR, false);
+  assert.equal(MD_PURIFY.SANITIZE_NAMED_PROPS, true, "an author's id and name are prefixed user-content- (GitHub's rule), never dropped");
+  assert.equal(USER_CONTENT_PREFIX, "user-content-", "the prefix DOMPurify writes; the lookups compare against it");
+  assert.deepEqual(MD_PURIFY.FORBID_TAGS, [...MD_FORBID_TAGS]);
+  for (const tag of ["style", "dialog", "form", "button", "select", "option", "optgroup", "textarea", "fieldset", "legend", "label", "datalist", "output", "meter", "progress", "map", "area"]) {
+    assert.ok(MD_FORBID_TAGS.includes(tag), tag + " is forbidden");
+  }
+  assert.ok(!MD_FORBID_TAGS.includes("input"), "input is allowed by the profile; sanitizeMd's post-pass keeps only a disabled checkbox");
+  assert.ok(!MD_FORBID_TAGS.includes("details") && !MD_FORBID_TAGS.includes("summary"), "details/summary are prose structure GitHub keeps");
+  assert.deepEqual(MD_PURIFY.FORBID_ATTR, [...MD_FORBID_ATTR]);
+  assert.deepEqual([...MD_FORBID_ATTR], ["background", "usemap"], "two forbidden attributes: a background image fetches on render with no click; usemap binds an image map, which is dropped");
+});
+
+// ── source pins: one sanitizer ──────────────────────────────────────────────────────────────────────
+
+test("md-sanitize.ts holds the dashboard's ONLY DOMPurify.sanitize call; render.ts and file-view.ts import sanitizeMd and no dompurify of their own", () => {
+  const sources = fs.readdirSync(UI).filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts") && !f.endsWith(".d.ts"));
+  const callers = sources.filter((f) => /DOMPurify\.sanitize\(/.test(read(f)));
+  assert.deepEqual(callers, ["md-sanitize.ts"], "every other module goes through sanitizeMd");
+  const SAN = read("md-sanitize.ts");
+  assert.equal((SAN.match(/DOMPurify\.sanitize\(/g) || []).length, 1);
+  assert.match(SAN, /export function sanitizeMd\(dirty: string\): HTMLElement \{\n\s*installMdSanitizeHooks\(\);\n\s*const clean = DOMPurify\.sanitize\(dirty, \{ \.\.\.MD_PURIFY, RETURN_DOM: true \}\) as HTMLElement;/,
+    "the hook is installed before the first sanitize, and the profile is spread with RETURN_DOM");
+  assert.match(SAN, /keepOnlyInertCheckboxes\(clean\);\n\s*for \(const pass of postPasses\) pass\(clean\);\n\s*return clean;/, "the input post-pass, then every registered post-pass (the math fill), on the sanitized DOM before it is handed back");
+  const importers = sources.filter((f) => /from "dompurify"/.test(read(f)));
+  assert.deepEqual(importers, ["md-sanitize.ts"]);
+  assert.match(read("render.ts"), /import \{[^}]*\bsanitizeMd\b[^}]*\} from "\.\/md-sanitize";/);
+  assert.match(read("file-view.ts"), /import \{ sanitizeMd \} from "\.\/md-sanitize";/);
+  assert.equal((read("render.ts").match(/sanitizeMd\(/g) || []).length, 2, "md() and userMd()");
+  assert.equal((read("file-view.ts").match(/sanitizeMd\(/g) || []).length, 1, "mdBlock");
+});
+
+test("the math fill is registered as a sanitizeMd post-pass by the module that installs the grammar, so no renderer calls it by hand", () => {
+  const grammar = read("chat-md.ts");
+  assert.match(grammar, /import \{ mathBlock, mathInline, renderMathPlaceholders \} from "\.\/math";/);
+  assert.match(grammar, /import \{ registerMdPostPass \} from "\.\/md-sanitize";/);
+  assert.match(grammar, /^registerMdPostPass\(renderMathPlaceholders\);$/m);
+  assert.doesNotMatch(read("render.ts"), /renderMathPlaceholders\(|from "\.\/math"/, "render.ts renders no math of its own: the fill rides every sanitizeMd call");
+  assert.doesNotMatch(read("file-view.ts"), /renderMathPlaceholders|from "\.\/math"|from "\.\/chat-md"/, "the viewer imports no grammar: in the chat page the singleton carries it, and a bundle without it renders no math");
+});
+
+test("the feed bundle carries the sanitizer but neither the math grammar nor KaTeX: a bundle without the grammar has no fill", () => {
+  // What the import pins above promise, checked on the built graph: esbuild's metafile lists every module the feed
+  // entry pulls in. file-view.ts brings md-sanitize.ts (the viewer renders notes in the feed page too); chat-md.ts,
+  // math.ts and the katex package are the chat bundle's alone.
+  const EXT = process.cwd();                                      // npm test runs in vscode-extension
+  const esbuild = createRequire(path.join(EXT, "package.json"))("esbuild");   // the extension's esbuild, wherever this bundle was written
+  const r = esbuild.buildSync({
+    entryPoints: [path.join(UI, "feed.ts")], bundle: true, write: false, metafile: true, format: "iife", platform: "browser", target: "es2020",
+    nodePaths: [path.join(EXT, "node_modules")], external: ["*.png", "*.svg", "*.woff", "*.ttf", "../media/*.woff2"], logLevel: "silent",
+  });
+  const inputs = Object.keys(r.metafile.inputs as Record<string, unknown>).map((f) => f.replace(/\\/g, "/"));
+  assert.ok(inputs.some((f) => f.endsWith("ui/webview/md-sanitize.ts")), "the feed bundle sanitizes through md-sanitize.ts (via file-view.ts)");
+  assert.ok(inputs.some((f) => f.endsWith("ui/webview/file-view.ts")));
+  const stray = inputs.filter((f) => /ui\/webview\/(chat-md|math)\.ts$|node_modules\/katex\//.test(f));
+  assert.deepEqual(stray, [], "no grammar, no fill, no KaTeX in the feed bundle");
+});
+
+test("the submit backstop: one preventDefault listener on the viewer body in openFileView AND openUrlView, installed before any render swaps the body's children", () => {
+  const VIEW = read("file-view.ts");
+  const local = VIEW.split("export function openFileView(")[1].split("\nexport function ")[0];
+  const url = VIEW.split("export function openUrlView(")[1].split("\nexport function ")[0];
+  for (const [name, fn] of [["openFileView", local], ["openUrlView", url]] as const) {
+    assert.equal((fn.match(/body\.addEventListener\("submit", \(ev\) => \{ ev\.preventDefault\(\); \}\);/g) || []).length, 1, name + " installs the backstop once per open");
+    assert.ok(fn.indexOf('body.addEventListener("submit"') < fn.indexOf("body.replaceChildren("), name + ": installed before any render swaps the body's children");
+  }
+});
+
+test("contain: layout on .fileview-md in BOTH sheets, byte-equal, with the media caps and the table scroll; the rules are in the parity list", () => {
+  const rule = (css: string, head: string) => { const at = css.indexOf(head); assert.ok(at >= 0, head + " present"); return css.slice(at, css.indexOf("}", at) + 1); };
+  const chat = rule(read("styles.css"), ".fileview-md {"), feed = rule(read("feed.css"), ".fileview-md {");
+  assert.equal(chat, feed);
+  assert.match(chat, /contain: layout;/);
+  assert.doesNotMatch(chat, /contain: (paint|strict|content|size)/, "layout only: paint containment would clip the body's scroll and a table's own horizontal scroll");
+  const MEDIA = ":where(.fileview-md) svg, :where(.fileview-md) canvas, :where(.fileview-md) video {";
+  assert.equal(rule(read("styles.css"), MEDIA), rule(read("feed.css"), MEDIA));
+  assert.match(rule(read("styles.css"), MEDIA), /max-width: 100%;/);
+  // a table wider than the column scrolls on its own: under layout containment the body cannot scroll to it
+  const TABLE = ".fileview-md table {";
+  assert.equal(rule(read("styles.css"), TABLE), rule(read("feed.css"), TABLE));
+  assert.match(rule(read("styles.css"), TABLE), /display: block; width: max-content; max-width: 100%; overflow-x: auto;/);
+  const parity = read("fileview-parity.test.ts");
+  assert.match(parity, /"\.fileview-md \{"/);
+  assert.ok(parity.includes(JSON.stringify(MEDIA)), "the media cap is pinned byte-equal too");
+  assert.ok(parity.includes(JSON.stringify(TABLE)), "and the table rule");
+});
+
+// ── the documents ───────────────────────────────────────────────────────────────────────────────────
+
+/** A phrase as a document wraps it: any run of whitespace between words. */
+const prose = (words: string) => new RegExp(words.trim().split(/\s+/).map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("\\s+"));
+
+test("the guide says what a file's own HTML may do, in the terms the code enforces", () => {
+  const guide = fs.readFileSync(path.join(ROOT, "docs", "guide.md"), "utf8");
+  const at = guide.indexOf("**A file's own HTML.**");
+  assert.ok(at >= 0, "the guide has the paragraph");
+  const para = guide.slice(at, guide.indexOf("\n\n", at));
+  assert.match(para, /`<style>`/);
+  assert.match(para, /user-content-/);
+  assert.match(para, /`color` and `background-color`/);
+  assert.match(para, /`background=`/);
+  assert.match(para, prose("cannot be ticked"));
+  assert.doesNotMatch(para, /\u2014/, "no em dash");
+});
+
+test("SECURITY.md's output-sanitization bullet names KaTeX as the renderer that writes after DOMPurify, under trust: false", () => {
+  // KaTeX's markup used to be part of marked's output and went through DOMPurify with the rest. The fill now
+  // renders AFTER the sanitizer (renderMathPlaceholders writes katex.render's DOM into the sanitized body), so
+  // what keeps a formula from minting a link or a style is KaTeX's `trust: false`, not DOMPurify. SECURITY.md is
+  // the document the repository points security readers at; its bullet says so.
+  const security = fs.readFileSync(path.join(ROOT, "SECURITY.md"), "utf8");
+  const hardened = security.slice(security.indexOf("\n## What is already hardened\n"));
+  const at = hardened.indexOf("- **Output sanitization:**");
+  assert.ok(at >= 0, "SECURITY.md's hardened list has an Output sanitization bullet");
+  const rest = hardened.slice(at);
+  const end = rest.indexOf("\n- ", 1);
+  const bullet = end === -1 ? rest : rest.slice(0, end);
+  assert.match(bullet, /KaTeX/, "the bullet names the renderer that writes to the sanitized DOM after DOMPurify");
+  assert.match(bullet, prose("after DOMPurify has run"), "and says when it writes");
+  assert.match(bullet, /`trust: false`/, "and the option its safety rests on");
+  assert.match(bullet, prose("checked against the code by `ui/webview/md-sanitize-postpass-browser.test.ts`"), "and where that is checked, by path");
+  assert.doesNotMatch(bullet, /\u2014/, "the bullet's prose carries no em dash");
+  // the code has the boundary the bullet describes: DOMPurify first, the registered fill on its output, under the option
+  const san = read("md-sanitize.ts");
+  assert.ok(san.indexOf("DOMPurify.sanitize(dirty") < san.indexOf("for (const pass of postPasses) pass(clean);"), "the fill runs on the DOM DOMPurify has already returned");
+  assert.match(read("math.ts"), /trust: false/, "math.ts renders under trust: false");
+});

--- a/ui/webview/md-sanitize.ts
+++ b/ui/webview/md-sanitize.ts
@@ -1,0 +1,183 @@
+// ONE sanitizer for every piece of markdown the dashboard renders as HTML: the chat's md() and userMd()
+// (render.ts) and the file viewer's mdBlock (file-view.ts). The two used to spell the same DOMPurify
+// profile in two places, and that profile was DOMPurify's default html list, which keeps <style>, <form>,
+// <button>, <dialog>, inline `style`, `id`, `name` and the `background` attribute. A markdown file is
+// arbitrary bytes off a disk and a chat message is untrusted text, so the rules their HTML lives under sit
+// here, once, and both call sanitizeMd.
+//
+// What a note's or a message's HTML may do, modelled on GitHub's rules for a README (GitHub strips an inline
+// `style` whole and allows no inline SVG; both survive here in the narrowed form described below):
+//   • no <style> block, no <dialog>, and no form-associated element: a <style> blanked the whole viewer
+//     (`.fileview { display: none }`), and a `<form action=...><button>` navigated the pane's document to
+//     the action URL. style's text goes with it (DOMPurify's default FORBID_CONTENTS); a form's or a
+//     button's TEXT stays as prose (KEEP_CONTENT), so a note reads the same minus the control.
+//   • <input> survives ONLY as marked's task-list checkbox, `- [x] done` becomes <input checked disabled
+//     type=checkbox>: every other input goes, and a checkbox that lacks `disabled` gets it, so nothing in
+//     a note is a live control.
+//   • an author's id and name are PREFIXED `user-content-` (SANITIZE_NAMED_PROPS, the rule GitHub applies):
+//     a `<p id="tabs">` can no longer dress itself in the page's #tabs CSS or shadow getElementById for the
+//     page's own controls, and `<a name="install">` still exists under its prefixed name. An `href="#install"`
+//     is NOT rewritten to match: the chat's click delegate (render.ts) resolves a message's `#` click through
+//     userContentTarget below, since the browser's default lookup reads the bare name and finds nothing.
+//     Rewriting hrefs here would break the viewer's section links: its heading ids (`md-<slug>`, minted by
+//     mdBlock AFTER the sanitize) never gain the prefix, so a rewritten `#user-content-results` would name
+//     nothing.
+//   • an inline `style` keeps only `color` and `background-color` declarations whose value is a literal
+//     colour: coloured spans in existing notes and transcripts survive; positioning, sizing and layout never
+//     reach the page. Everything else in the attribute is dropped, and the attribute goes when nothing is
+//     left: colorOnlyStyle below is the whole grammar, applied by a DOMPurify uponSanitizeAttribute hook on
+//     every element, inline SVG included.
+//   • data-* never rides in (ALLOW_DATA_ATTR: false): both pages key their delegated actions off data-act.
+//   • the `background` attribute is forbidden outright (FORBID_ATTR): `<td background=URL>` makes the browser
+//     fetch the URL the moment the note renders, a tracking pixel with no click and no gate; DOMPurify's html
+//     list keeps it, GitHub's allowlist does not, and it has no safe value here. `bgcolor` fetches nothing and
+//     stays, as a colour-only inline style does.
+//   • no image map: `<map>`, `<area>` and `usemap` go (FORBID_TAGS, FORBID_ATTR), as GitHub drops them. The
+//     prefix rule renames `<map name="nav">` to user-content-nav and leaves `usemap="#nav"` as written, so no
+//     map an author writes could bind to its picture anyway, and an <area> is a link element neither page's
+//     link handling reaches. Dropped, the picture is inert prose.
+//   • html + svg profiles (KaTeX's stretchy glyphs used to come through here as inline <svg>; a note's own
+//     inline SVG still does), data: URIs on <img> (the CSP allows them; inline transcript images rely on them).
+//
+// What does NOT pass through here: KaTeX. Its layout is all inline style, which the colour-only rule would
+// strip, so the math extensions emit an inert placeholder and KaTeX is rendered into it on the sanitized
+// DOM afterwards (math.ts renderMathPlaceholders), as a POST-PASS this module runs at the end of sanitizeMd
+// for every caller: the module that installs the math grammar (chat-md.ts) registers the fill at load
+// (registerMdPostPass), so the chat's md() and userMd(), and the viewer's mdBlock when it runs inside the
+// chat page whose marked singleton carries that grammar, all render math, and a bundle without the grammar
+// (feed.js) never sees the pass or KaTeX. A renderer romp itself runs never goes through the sanitizer;
+// only what an author wrote does.
+import DOMPurify from "dompurify";
+import type { Config, DOMPurify as DOMPurifyInstance, UponSanitizeAttributeHookEvent } from "dompurify";
+
+/** Tags a note may not keep: the style sheet, the dialog, every form-associated element, and the image map. */
+export const MD_FORBID_TAGS: readonly string[] = [
+  "style", "dialog",
+  "form", "button", "select", "option", "optgroup", "textarea", "fieldset", "legend", "label", "datalist", "output", "meter", "progress",
+  "map", "area",
+];
+
+/** Attributes a note may not keep at all: `background`, a remote fetch on render with no safe value, and `usemap`, the
+ *  image map's binding (the map itself is forbidden above). Every other attribute the profiles allow either is safe as
+ *  written or is rewritten (id and name prefixed, style filtered). */
+export const MD_FORBID_ATTR: readonly string[] = ["background", "usemap"];
+
+/** The prefix SANITIZE_NAMED_PROPS puts on an author's id and name (DOMPurify's own constant is not exported). A
+ *  `#fragment` clicked in a chat message is looked up under it (userContentTarget below); the viewer's minted `md-`
+ *  heading ids are set after the sanitize and never carry it. */
+export const USER_CONTENT_PREFIX = "user-content-";
+
+/** The element an author's `#id` names in `root` after the sanitize: the first whose `id` is the prefixed spelling or
+ *  the bare one, else the first `<a name>` with either, in document order (the browser's own fragment rule, applied to
+ *  both spellings). The bare arm serves ids the sanitizer never saw: the page's own ids when `root` is the document
+ *  (what the browser's default would have scrolled to), and an author who typed the prefix. Nothing when neither is
+ *  found. The chat's click delegate (render.ts) reads it as is, the message's body first and then the document. */
+export function userContentTarget(root: ParentNode, id: string): Element | undefined {
+  const own = USER_CONTENT_PREFIX + id;
+  return Array.from(root.querySelectorAll("[id]")).find((e) => { const v = e.getAttribute("id"); return v === own || v === id; })
+    || Array.from(root.querySelectorAll("a[name]")).find((e) => { const v = e.getAttribute("name"); return v === own || v === id; });
+}
+
+/** The one profile. Spread `RETURN_DOM: true` onto it to take the sanitized <body> back (sanitizeMd does). */
+export const MD_PURIFY: Config = {
+  USE_PROFILES: { html: true, svg: true },
+  ADD_DATA_URI_TAGS: ["img"],
+  ALLOW_DATA_ATTR: false,
+  FORBID_TAGS: [...MD_FORBID_TAGS],
+  FORBID_ATTR: [...MD_FORBID_ATTR],
+  SANITIZE_NAMED_PROPS: true,
+};
+
+// ── the colour grammar ──────────────────────────────────────────────────────────────────────────────
+// A value is a literal colour when it is one of: a bare keyword (a named colour, `transparent`,
+// `currentcolor`, a CSS-wide keyword such as `inherit` or `unset`; an unknown word is a declaration the
+// browser ignores, never a function or a URL; a hyphenated word such as `revert-layer` fails the pattern),
+// `#` and 3 to 8 hex digits, or rgb()/rgba()/hsl()/hsla() whose arguments are 3 or 4 plain numbers or
+// percentages (an angle unit, deg/grad/rad/turn, is accepted on any argument by the one shared pattern,
+// though only an hsl hue can carry one and the browser discards an rgb() written with one; `none` is CSS
+// Color 4's missing component), separated by commas, spaces or a slash. Nothing else: no nested
+// parentheses (so no url(, var(, expression(, calc(), no `!important`, no quotes, no backslash escapes,
+// no comments.
+const KEYWORD = /^[a-z]+$/i;
+const HEX = /^#[0-9a-f]{3,8}$/i;
+const COLOR_FN = /^(rgba?|hsla?)\(([^()]*)\)$/i;
+const COLOR_ARG = /^(?:[+-]?(?:\d+\.?\d*|\.\d+)(?:%|deg|grad|rad|turn)?|none)$/i;
+const KEPT_PROPERTIES = new Set(["color", "background-color"]);
+
+/** Whether `v` (already trimmed) is a literal colour under the grammar above. */
+export function isLiteralColor(v: string): boolean {
+  if (KEYWORD.test(v) || HEX.test(v)) return true;
+  const m = COLOR_FN.exec(v);
+  if (!m) return false;
+  const args = m[2].trim().split(/\s*[,/]\s*|\s+/).filter((a) => a.length > 0);
+  return args.length >= 3 && args.length <= 4 && args.every((a) => COLOR_ARG.test(a));
+}
+
+/** The declarations of a `style` attribute that survive: `color` and `background-color` with a literal
+ *  colour, in their order, as `name: value` joined by `; `. Empty when nothing survives (the caller drops
+ *  the attribute). Splitting on `;` is safe because no surviving value can contain one. */
+export function colorOnlyStyle(style: string): string {
+  const kept: string[] = [];
+  for (const decl of style.split(";")) {
+    const at = decl.indexOf(":");
+    if (at < 0) continue;
+    const name = decl.slice(0, at).trim().toLowerCase();
+    const value = decl.slice(at + 1).trim();
+    if (!KEPT_PROPERTIES.has(name) || !value || !isLiteralColor(value)) continue;
+    kept.push(name + ": " + value);
+  }
+  return kept.join("; ");
+}
+
+/** The DOMPurify uponSanitizeAttribute hook body: rewrites a `style` attribute to its colour
+ *  declarations, drops it when none survive, and leaves every other attribute to DOMPurify. */
+export function styleAttributeHook(ev: Pick<UponSanitizeAttributeHookEvent, "attrName" | "attrValue" | "keepAttr">): void {
+  if (ev.attrName !== "style") return;
+  const kept = colorOnlyStyle(ev.attrValue);
+  if (kept) ev.attrValue = kept;
+  else ev.keepAttr = false;
+}
+
+let hooksInstalled = false;
+/** Install the style hook on the (module-global) DOMPurify instance, once. Idempotent: DOMPurify's hooks
+ *  are a list, and a second registration would run the same rewrite twice per attribute. `purify` is a
+ *  seam for the node tests, which have no window for the real instance to sanitize in. */
+export function installMdSanitizeHooks(purify: Pick<DOMPurifyInstance, "addHook"> = DOMPurify): void {
+  if (hooksInstalled) return;
+  hooksInstalled = true;
+  purify.addHook("uponSanitizeAttribute", (_node, ev) => { styleAttributeHook(ev); });
+}
+
+/** marked's task checkbox is the one control a note keeps, inert: every other <input> goes, and a
+ *  checkbox without `disabled` gets it. Runs on the sanitized DOM, after DOMPurify. */
+function keepOnlyInertCheckboxes(root: ParentNode): void {
+  root.querySelectorAll("input").forEach((node) => {
+    const input = node as HTMLInputElement;
+    if ((input.getAttribute("type") || "").toLowerCase() !== "checkbox") { input.remove(); return; }
+    if (!input.hasAttribute("disabled")) input.setAttribute("disabled", "");
+  });
+}
+
+const postPasses: Array<(root: ParentNode) => void> = [];
+/** Register a DOM pass sanitizeMd runs on every sanitized body before handing it back. For the module that installs a
+ *  marked extension whose output needs a render AFTER the sanitize (chat-md.ts: the math placeholders KaTeX fills,
+ *  math.ts renderMathPlaceholders), registered at load: the grammar and its fill travel together, so every sanitizeMd
+ *  caller in a bundle that parses with the grammar renders the same way (the chat's md() and userMd(); the viewer's
+ *  mdBlock when it runs inside the chat page, whose marked singleton carries the extensions), and a bundle that never
+ *  imports the module (feed.js) has neither the grammar nor the pass nor the library behind it. One mechanism, no
+ *  per-caller call to forget. Idempotent: a pass registered twice runs once. */
+export function registerMdPostPass(pass: (root: ParentNode) => void): void {
+  if (!postPasses.includes(pass)) postPasses.push(pass);
+}
+
+/** Sanitize marked's HTML under the profile above and return the sanitized <body>: its children are the
+ *  nodes to adopt (mdBlock) or its innerHTML the string to set (md, userMd), after any DOM post-pass of
+ *  the caller's own (PR links, heading ids). The registered passes (the math fill) have run by then. The
+ *  only DOMPurify.sanitize call in the dashboard's source. */
+export function sanitizeMd(dirty: string): HTMLElement {
+  installMdSanitizeHooks();
+  const clean = DOMPurify.sanitize(dirty, { ...MD_PURIFY, RETURN_DOM: true }) as HTMLElement;   // the sanitized <body>
+  keepOnlyInertCheckboxes(clean);
+  for (const pass of postPasses) pass(clean);
+  return clean;
+}

--- a/ui/webview/md-url-view.test.ts
+++ b/ui/webview/md-url-view.test.ts
@@ -16,6 +16,7 @@ import * as path from "node:path";
 const web = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
 const RENDER = web("render.ts");
 const VIEW = web("file-view.ts");
+const SANITIZE = web("md-sanitize.ts");   // the one sanitizer both md() and mdBlock call (sanitizeMd)
 const CHAT_CSS = web("styles.css");
 const FEED_CSS = web("feed.css");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
@@ -264,12 +265,12 @@ test("EVERY exit that stops short of consuming the body aborts this open's contr
 
 // ── 5. relative references inside the rendered document ──
 
-test("mdBlock takes the document's location and rewrites relative img/src and a/href AFTER DOMPurify", () => {
+test("mdBlock takes the document's location and rewrites relative img/src and a/href AFTER the sanitizer", () => {
   assert.match(VIEW, /type MdDocLoc = \{ kind: "url"; href: string \} \| \{ kind: "file"; path: string; sid: string \| null \};/);
   assert.match(VIEW, /function mdBlock\(text: string, doc\?: MdDocLoc\): HTMLElement \{/);
-  const sanitize = MD_FN.indexOf("DOMPurify.sanitize(");
+  const sanitize = MD_FN.indexOf("sanitizeMd(");
   const rewrite = MD_FN.indexOf("resolveDocRelative(");
-  assert.ok(sanitize > -1 && rewrite > sanitize, "sanitise first; the rewrite only ever sees what DOMPurify kept");
+  assert.ok(sanitize > -1 && rewrite > sanitize, "sanitise first; the rewrite only ever sees what the sanitizer kept");
   // the ATTRIBUTE, never the property — .src/.href are already resolved against the page (the wrong base)
   assert.match(MD_FN, /const src = img\.getAttribute\("src"\) \|\| "";/);
   assert.match(MD_FN, /const href = a\.getAttribute\("href"\) \|\| "";/);
@@ -390,14 +391,16 @@ test("URL mode: a 200 labelled text/html is refused as a web page, with the way 
 test("rendered markdown never carries data-* attributes into the page, in the viewer and in the chat alike", () => {
   // a document's or a message's raw HTML with data-act=\"stopRetrying\" would otherwise bubble to the
   // document-level delegate and interrupt the active session on a click
-  const sanitizes = (MD_FN.match(/DOMPurify\.sanitize\([^)]*\)/g) || []);
+  // both go through sanitizeMd (md-sanitize.ts), whose one profile forbids data-*
+  const sanitizes = (MD_FN.match(/sanitizeMd\([^)]*\)/g) || []);
   assert.equal(sanitizes.length, 1);
-  assert.match(sanitizes[0], /ALLOW_DATA_ATTR: false/);
+  assert.match(sanitizes[0], /sanitizeMd\(dirty\)/);
   const chatMd = (RENDER.split("function md(src: string, repo: string | null = prRepoFor()): string {")[1] || "").split("\nfunction ")[0];   // the signature carries the PR-link repo (pr-links.ts)
-  assert.match(chatMd, /DOMPurify\.sanitize\(dirty, \{ \.\.\.MD_PURIFY, RETURN_DOM: true \}\)/);
-  assert.match(RENDER, /const MD_PURIFY: Config = \{.*ALLOW_DATA_ATTR: false \};/, "the chat's shared sanitizer config forbids data-*");
+  assert.match(chatMd, /const clean = sanitizeMd\(dirty\);/);
+  assert.match(SANITIZE, /export const MD_PURIFY: Config = \{[\s\S]*?ALLOW_DATA_ATTR: false,[\s\S]*?\};/, "the shared sanitizer's profile forbids data-*");
+  assert.doesNotMatch(VIEW + RENDER, /ALLOW_DATA_ATTR|DOMPurify\.sanitize\(/, "neither caller spells a profile of its own");
   // the viewer's own stamps are set AFTER the sanitize, so they are unaffected
-  assert.ok(MD_FN.indexOf("DOMPurify.sanitize(") < MD_FN.indexOf('a.dataset.act = "fv-open"'));
+  assert.ok(MD_FN.indexOf("sanitizeMd(") < MD_FN.indexOf('a.dataset.act = "fv-open"'));
 });
 
 test("local file mode: a sibling link's #fragment lands after the first RENDERED paint, once", () => {

--- a/ui/webview/pr-links.test.ts
+++ b/ui/webview/pr-links.test.ts
@@ -613,8 +613,9 @@ test("the chat links inside md(): the sanitized tree is walked before it seriali
   assert.match(RENDER, /import \{ linkifyPrRefs, senderPrRepo, postalSenderHost \} from "\.\/pr-links";/);
   assert.match(RENDER, /function md\(src: string, repo: string \| null = prRepoFor\(\)\): string \{/);
   const mdFn = RENDER.match(/function md\(src: string[^\n]*?\): string \{[\s\S]*?\n\}/)?.[0] || "";
-  assert.match(mdFn, /RETURN_DOM: true \}\) as HTMLElement;[^\n]*\n\s*linkifyPrRefs\(clean, repo\);\s*\n\s*return clean\.innerHTML;/,
-    "DOMPurify's own serialization is replaced by ours, after the walk — the sanitizer's verdicts stand");
+  // sanitizeMd (md-sanitize.ts) hands back the sanitized <body>; the walk runs on it before our own serialization
+  assert.match(mdFn, /const clean = sanitizeMd\(dirty\);[^\n]*\n\s*linkifyPrRefs\(clean, repo\);\s*\n\s*return clean\.innerHTML;/,
+    "the sanitizer's own serialization is replaced by ours, after the walk: the sanitizer's verdicts stand");
   assert.match(RENDER, /const id = sid \?\? renderingOwnerSid \?\? renderingSid \?\? activeId;/, "the owning session, as relative paths resolve");
   assert.doesNotMatch(RENDER, /installPrLinkOpener/, "the chat's own a[href] delegate already opens every absolute-scheme anchor");
 });

--- a/ui/webview/render-math.test.ts
+++ b/ui/webview/render-math.test.ts
@@ -1,41 +1,79 @@
 // Behavior tests for the TeX math extension (math.ts). The delimiter rules are the
 // load-bearing part: in chat text a bare `$` means shell variables and prices far more often
-// than math, so the stay-literal cases matter as much as the rendered ones. marked and katex
-// both run for real here (plain JS, no DOM needed); DOMPurify compatibility is pinned at the
-// source level instead, same as render-sanitize.test.ts (no jsdom harness for the webview).
+// than math, so the stay-literal cases matter as much as the rendered ones. marked runs for
+// real here (plain JS, no DOM needed). The extension emits a PLACEHOLDER per formula, an
+// element carrying the TeX as text, and KaTeX renders into it AFTER the sanitizer
+// (renderMathPlaceholders, a DOM post-pass sanitizeMd runs), so what this file can execute is
+// the placeholder contract: which text becomes a formula, which stays prose, and what the
+// placeholder carries. That KaTeX's layout survives the sanitizer is executed in headless
+// Chromium over the real modules by md-sanitize-postpass-browser.test.ts (a fraction stacks, a
+// superscript is raised, the radical has height, and the rendered root is katex.render's own
+// output byte for byte). The wiring (math.ts, chat-md.ts, render.ts) is source-pinned below.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { Marked } from "marked";
-import { mathBlock, mathInline } from "./math";
+import katex from "katex";
+import { mathBlock, mathInline, mathPlaceholder, MATH_INLINE_CLASS, MATH_DISPLAY_CLASS } from "./math";
 
 const m = new Marked({ gfm: true, extensions: [mathBlock, mathInline] });
 const html = (src: string) => m.parse(src) as string;
-const hasMath = (s: string) => s.includes('class="katex"');
+const PLACEHOLDER = /<(span|div) class="(md-math-inline|md-math-display)">([\s\S]*?)<\/\1>/g;
+const unescape = (s: string) => s.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
+/** Every placeholder in marked's output, in order: its tag, its mode and the TeX it carries. */
+const formulas = (out: string) => Array.from(out.matchAll(PLACEHOLDER)).map((x) => ({ tag: x[1], display: x[2] === MATH_DISPLAY_CLASS, tex: unescape(x[3]) }));
+const hasMath = (s: string) => formulas(s).length > 0;
+// the options renderMathPlaceholders hands katex.render (pinned against math.ts below)
+const KATEX = { throwOnError: false, output: "html", trust: false } as const;
 
-// --- renders as math ---
+// --- becomes a formula: marked emits the placeholder, KaTeX does not run here ---
 
-test("inline $..$ renders KaTeX", () => {
+test("inline $..$ becomes an inline placeholder carrying the TeX", () => {
   const out = html("Euler: $e^{i\\pi}+1=0$ holds.");
-  assert.ok(hasMath(out));
-  assert.ok(!out.includes("$e^"), "raw TeX must not leak through");
+  assert.deepEqual(formulas(out), [{ tag: "span", display: false, tex: "e^{i\\pi}+1=0" }]);
+  assert.ok(!out.includes("$e^"), "the delimiters must not leak through");
+  assert.ok(!out.includes('class="katex"'), "KaTeX runs after the sanitizer, never inside marked");
+  assert.equal(MATH_INLINE_CLASS, "md-math-inline");
 });
 
-test("inline \\(..\\) renders KaTeX", () => {
-  assert.ok(hasMath(html("Ratio \\(\\tfrac{a}{b}\\) here.")));
+test("inline \\(..\\) becomes an inline placeholder", () => {
+  assert.deepEqual(formulas(html("Ratio \\(\\tfrac{a}{b}\\) here.")), [{ tag: "span", display: false, tex: "\\tfrac{a}{b}" }]);
 });
 
-test("$$..$$ and \\[..\\] render display math", () => {
-  assert.ok(html("Total: $$\\sum_i x_i$$ done.").includes("katex-display"));
-  assert.ok(html("\\[x^2\\]").includes("katex-display"));
+test("$$..$$ and \\[..\\] become display placeholders: a span inside a paragraph, a div for a paragraph of their own", () => {
+  assert.deepEqual(formulas(html("Total: $$\\sum_i x_i$$ done.")), [{ tag: "span", display: true, tex: "\\sum_i x_i" }]);
+  assert.deepEqual(formulas(html("\\[x^2\\]")), [{ tag: "div", display: true, tex: "x^2" }]);
+  assert.ok(!html("\\[x^2\\]").includes("<p>"), "the block form is not wrapped in a paragraph");
 });
 
 test("a multi-line $$ paragraph beats markdown's block rules", () => {
   // The "- x" line would become a <li> if block tokenization carved the formula up first.
   const out = html("$$\n- x\n$$");
-  assert.ok(out.includes("katex-display"));
+  assert.deepEqual(formulas(out), [{ tag: "div", display: true, tex: "- x" }]);
   assert.ok(!out.includes("<li>"), "list rule must not fire inside display math");
+});
+
+test("the TeX is text: markup inside a formula is escaped, never emitted as HTML", () => {
+  // The placeholder is the one place marked writes a formula, and the sanitizer sees it as an element
+  // with text; a formula can therefore never smuggle an element past it.
+  const out = html("$a<b \\& c>d$ and $<img src=x onerror=1>$");
+  assert.deepEqual(formulas(out).map((f) => f.tex), ["a<b \\& c>d", "<img src=x onerror=1>"]);
+  assert.ok(!out.includes("<img"), "escaped: the placeholder's text is not markup");
+  assert.ok(out.includes("&lt;img src=x onerror=1&gt;"));
+  assert.equal(mathPlaceholder("a<b", false, false), '<span class="md-math-inline">a&lt;b</span>');
+  assert.equal(mathPlaceholder("x", true, true), '<div class="md-math-display">x</div>');
+  assert.equal(mathPlaceholder("x", true, false), '<span class="md-math-display">x</span>', "display math inside a paragraph is a span: the placeholder stays in the flow it came from");
+});
+
+test("marked's output holds no KaTeX markup, no inline style and no svg: nothing for the colour-only style rule to strip", () => {
+  for (const src of ["$\\frac{a}{b}$", "$$\\sum_{i=0}^{n} i^2$$", "$\\sqrt{d}$", "$x^2$", "\\[\\int_0^1 f\\]"]) {
+    const out = html(src);
+    assert.ok(hasMath(out), "placeholder expected for " + src + ": " + out);
+    assert.doesNotMatch(out, /class="katex/, "no KaTeX markup before the sanitizer: " + out);
+    assert.doesNotMatch(out, /style=/, "no inline style before the sanitizer: " + out);
+    assert.doesNotMatch(out, /<svg/, "no svg before the sanitizer: " + out);
+  }
 });
 
 test("closing $ may touch trailing punctuation and emphasis", () => {
@@ -44,10 +82,13 @@ test("closing $ may touch trailing punctuation and emphasis", () => {
   assert.ok(strong.includes("<strong>") && hasMath(strong));
 });
 
-test("invalid TeX degrades to flagged output, never a throw", () => {
-  const out = html("bad: $\\frac{1}{$ end");
-  assert.equal(typeof out, "string");
-  assert.ok(out.includes("katex"), "katex error rendering expected");
+test("invalid TeX renders as flagged output under the options the post-pass uses, never a throw; trust: false mints no URL", () => {
+  // renderMathPlaceholders needs a DOM (katex.render); the same options through renderToString are
+  // KaTeX's same pipeline minus the node building, and the browser leg runs the real call.
+  const out = katex.renderToString("\\frac{1}{", { ...KATEX, displayMode: false });
+  assert.ok(out.includes("katex-error"), "throwOnError: false paints bad TeX as flagged source");
+  const untrusted = katex.renderToString("\\href{javascript:alert(1)}{x}", { ...KATEX, displayMode: false });
+  assert.ok(!untrusted.includes("<a ") && !untrusted.includes("javascript:"), "trust: false: no TeX command mints a URL");
 });
 
 // --- stays literal ---
@@ -95,25 +136,30 @@ test("render.ts wires the math extensions into marked, through the shared chat g
   // chat-md.ts owns the extension list (shared with the breaks:true user-text instance, so a user
   // message with math renders exactly as before); render.ts applies it to the singleton.
   const grammar = UI("chat-md.ts");
-  assert.match(grammar, /import \{ mathBlock, mathInline \} from "\.\/math";/);
+  assert.match(grammar, /import \{ mathBlock, mathInline, renderMathPlaceholders \} from "\.\/math";/);
   assert.match(grammar, /export const chatMdExtensions: MarkedExtension\[\] = \[delDoubleTilde, \{ extensions: \[mathBlock, mathInline\] \}\];/);
   const src = UI("render.ts");
   assert.match(src, /import \{ chatMdExtensions, userMdHtml \} from "\.\/chat-md";/);
   assert.match(src, /marked\.use\(\.\.\.chatMdExtensions\);/);
 });
 
-test("math.ts renders html-only output so md()'s DOMPurify profile passes it", () => {
-  // output: "html" means no MathML twin — but stretchy glyphs (\sqrt radicals, wide accents,
-  // extensible arrows) are still inline <svg> even in html mode, so the sanitizer allows
-  // DOMPurify's svg profile alongside html (the user 2026-08-19: $\sqrt{d}$ rendered as a bare
-  // serif "d" — the radical was sanitized away while its radicand survived).
-  assert.match(UI("math.ts"), /output: "html"/);
-  assert.match(UI("render.ts"), /USE_PROFILES: \{ html: true, svg: true \}/);
+test("math.ts renders KaTeX into the placeholders after the sanitizer, html-only, under trust: false", () => {
+  // output: "html" means no MathML twin. KaTeX's output no longer passes through DOMPurify at all: the
+  // fill writes katex.render's DOM into the sanitized body, so its inline styles and stretchy <svg>
+  // glyphs (\sqrt radicals, wide accents) reach the page whole, and trust: false is what keeps a
+  // formula from minting a link, an image or a style of the author's choosing. The sanitizer's svg
+  // profile stays for an author's own inline SVG.
+  const math = UI("math.ts");
+  assert.match(math, /export function renderMathPlaceholders\(root: ParentNode\): void \{/);
+  assert.match(math, /katex\.render\(tex, el, \{ displayMode: display, throwOnError: false, output: "html", trust: false \}\);/);
+  assert.doesNotMatch(math, /katex\.renderToString\(/, "the string renderer is gone: marked emits placeholders, the fill renders into the DOM");
+  assert.match(UI("md-sanitize.ts"), /USE_PROFILES: \{ html: true, svg: true \}/);
+  assert.doesNotMatch(UI("render.ts"), /USE_PROFILES/, "render.ts spells no profile of its own");
 });
 
-test("executed: \\sqrt really does emit inline svg — the glyph the sanitizer must keep", () => {
-  const out = html("norm grows like $\\sqrt{d}$ here.");
-  assert.ok(hasMath(out));
+test("executed: \\sqrt really does emit inline svg, the glyph the fill writes into the sanitized DOM", () => {
+  const out = katex.renderToString("\\sqrt{d}", { ...KATEX, displayMode: false });
+  assert.ok(out.includes('class="katex"'));
   assert.ok(out.includes("<svg"), "the radical is an inline svg even with output:html");
   assert.ok(out.includes("sqrt"), "KaTeX marks the construct");
 });

--- a/ui/webview/render-sanitize.test.ts
+++ b/ui/webview/render-sanitize.test.ts
@@ -5,24 +5,43 @@
 // `<img src=x onerror=...>` or `[x](javascript:...)` executes in the webview and
 // can postMessage the host to open files / drive sessions. There is no jsdom
 // harness for the chat renderer, so — like the other webview tests — pin it at
-// the source level (assert the sanitizer is wired into md()).
+// the source level (assert the sanitizer is wired into md()). The DOMPurify call
+// lives in md-sanitize.ts (sanitizeMd), one sanitizer shared with the file viewer's
+// mdBlock; md() and userMd() call it. What the sanitizer does is executed in
+// headless Chromium (md-sanitize-browser.test.ts, md-sanitize-postpass-browser.test.ts).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const VIEW = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "file-view.ts"), "utf8");
+const SANITIZE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "md-sanitize.ts"), "utf8");
 
 test("md() sanitizes marked output with DOMPurify before returning HTML", () => {
-  assert.match(RENDER, /import DOMPurify from "dompurify";/);
+  assert.match(RENDER, /import \{[^}]*\bsanitizeMd\b[^}]*\} from "\.\/md-sanitize";/);
+  assert.doesNotMatch(RENDER, /from "dompurify"|DOMPurify\.sanitize\(/, "render.ts holds no sanitizer of its own");
+  assert.match(SANITIZE, /import DOMPurify from "dompurify";/);
+  assert.match(SANITIZE, /export function sanitizeMd\(dirty: string\): HTMLElement \{[\s\S]*?DOMPurify\.sanitize\(dirty, /);
   // (the signature grew an optional repo parameter for PR links — pr-links.ts — so match it loosely)
   const mdFn = RENDER.match(/function md\(src: string[^\n]*?\): string \{[\s\S]*?\n\}/)?.[0] || "";
   assert.ok(mdFn, "md() function not found");
-  // marked is still used to parse, but its output must pass through DOMPurify.sanitize
+  // marked is still used to parse, but its output must pass through sanitizeMd (the DOMPurify call)
   assert.match(mdFn, /marked\.parse\(/);
-  assert.match(mdFn, /DOMPurify\.sanitize\(/);
+  assert.match(mdFn, /const clean = sanitizeMd\(dirty\);/);
   // the old, unsanitized `return marked.parse(src) as string;` must be gone
   assert.doesNotMatch(mdFn, /return\s+marked\.parse\(src\)\s+as\s+string;/);
+});
+
+test("the file viewer's mdBlock adopts the same sanitizer's output, and spells no profile of its own", () => {
+  assert.match(VIEW, /import \{ sanitizeMd \} from "\.\/md-sanitize";/);
+  assert.doesNotMatch(VIEW, /from "dompurify"|DOMPurify\.sanitize\(/, "the viewer holds no sanitizer of its own");
+  const mdBlock = VIEW.match(/function mdBlock\([^\n]*\{[\s\S]*?\n\}/)?.[0] || "";
+  assert.ok(mdBlock, "mdBlock not found");
+  assert.match(mdBlock, /marked\.parse\(/);
+  // the sanitized <body>'s children are adopted as they are (no re-parse of a serialized string)
+  assert.match(mdBlock, /box\.replaceChildren\(\.\.\.Array\.from\(sanitizeMd\(dirty\)\.childNodes\)\);/);
+  assert.doesNotMatch(mdBlock, /box\.innerHTML = /, "nothing reaches the viewer's innerHTML unsanitized");
 });
 
 test("dompurify is a declared dependency", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1,6 +1,5 @@
 import { marked } from "marked";
-import DOMPurify from "dompurify";
-import type { Config } from "dompurify";   // the one sanitizer profile both md() and userMd() share
+import { sanitizeMd, userContentTarget } from "./md-sanitize";   // the one sanitizer every markdown surface shares, and the lookup for a message's own `#` links
 import hljs from "highlight.js/lib/core";
 import bash from "highlight.js/lib/languages/bash";
 import python from "highlight.js/lib/languages/python";
@@ -1122,15 +1121,13 @@ function el(tag: string, cls?: string): HTMLElement {
   return e;
 }
 
-// ONE sanitizer profile for both renderers. svg profile too (the user 2026-08-19): KaTeX's html output
-// still draws STRETCHY glyphs — \sqrt radicals, wide accents, extensible arrows — as inline <svg><path>,
-// and the html-only profile silently ate them: $\sqrt{d}$ rendered as a bare serif "d", the radical gone.
-// DOMPurify's svg profile is still sanitized (no scripts, handlers, or foreignObject). Keep data: URIs on
-// <img> (the CSP allows them and inline transcript images rely on them).
-// ALLOW_DATA_ATTR: false (2026-09-07): transcript HTML must not mint data-* attributes — the chat's
-// document-level delegate keys every action off data-act, so a `<span data-act="stopRetrying">` in a
-// message would post an interrupt on a click. Nothing the renderer needs rides data-* through md().
-const MD_PURIFY: Config = { USE_PROFILES: { html: true, svg: true }, ADD_DATA_URI_TAGS: ["img"], ALLOW_DATA_ATTR: false };
+// ONE sanitizer for both renderers, shared with the file viewer: sanitizeMd in md-sanitize.ts holds the
+// profile (html + svg, data: URIs on <img>, no data-*, and rules modelled on GitHub's for a message's own
+// HTML: no <style>, no form controls, prefixed ids, colour-only inline styles) and returns the sanitized <body>
+// for the DOM walk below. KaTeX is rendered AFTER the sanitizer, into the inert placeholders the math
+// extensions emit (math.ts renderMathPlaceholders): its layout is all inline style, which the colour-only
+// rule would strip, so it never passes through DOMPurify; the fill is a post-pass sanitizeMd itself runs,
+// registered by chat-md.ts, the module that installs the grammar.
 
 function md(src: string, repo: string | null = prRepoFor()): string {
   // Transcript text (user prompts, assistant output, subagent reports, postal
@@ -1138,15 +1135,15 @@ function md(src: string, repo: string | null = prRepoFor()): string {
   // must be sanitized before it ever reaches .innerHTML — otherwise a payload
   // like `<img src=x onerror=...>` or `[x](javascript:...)` runs in the webview
   // (which can postMessage the host to open files / drive sessions). DOMPurify
-  // strips event-handler attributes and dangerous URL schemes (profile: MD_PURIFY).
+  // strips event-handler attributes and dangerous URL schemes (md-sanitize.ts).
   try {
     const dirty = marked.parse(src) as string;
-    // RETURN_DOM hands back the sanitized <body> instead of its innerHTML — the same nodes, ours to
-    // walk once before the serialization DOMPurify would otherwise have done itself: PR references
+    // sanitizeMd hands back the sanitized <body> instead of its innerHTML: the same nodes, ours to
+    // walk once before the serialization DOMPurify would otherwise have done itself. PR references
     // in the prose (`#123`, `PR #123`, `owner/repo#123`) become links to the session's repository
     // (pr-links.ts; the user 2026-09-06). Text inside code, pre or an existing anchor is skipped, so
     // the sanitizer's verdicts stand and a marked-autolinked GitHub URL is never wrapped twice.
-    const clean = DOMPurify.sanitize(dirty, { ...MD_PURIFY, RETURN_DOM: true }) as HTMLElement;   // the sanitized <body>
+    const clean = sanitizeMd(dirty);   // the sanitized <body>, its math rendered
     linkifyPrRefs(clean, repo);
     return clean.innerHTML;
   } catch { const d = document.createElement("div"); d.textContent = src; return d.innerHTML; }
@@ -1160,7 +1157,7 @@ function md(src: string, repo: string | null = prRepoFor()): string {
 // walk as md(): a `#123` the user typed links to the session's repository too.
 function userMd(src: string, repo: string | null = prRepoFor()): string {
   try {
-    const clean = DOMPurify.sanitize(userMdHtml(src), { ...MD_PURIFY, RETURN_DOM: true }) as HTMLElement;
+    const clean = sanitizeMd(userMdHtml(src));   // the sanitized <body>, its math rendered
     linkifyPrRefs(clean, repo);
     return clean.innerHTML;
   } catch { const d = document.createElement("div"); d.textContent = src; return d.innerHTML; }
@@ -1330,7 +1327,45 @@ document.addEventListener("click", (e) => {
   const a = (e.target as HTMLElement)?.closest?.("a[href]") as HTMLAnchorElement | null;
   if (!a) return;
   const href = a.getAttribute("href") || "";
-  if (!/^[a-z][a-z0-9+.-]*:/i.test(href)) return; // fragment/relative — leave alone
+  if (href.startsWith("#")) {
+    // An in-page anchor in a message (a footnote's back link, `[section](#install)` over the reply's own `<a name>`):
+    // the sanitizer prefixes every author id and name user-content- (md-sanitize.ts, GitHub's rule) and leaves the
+    // href as written, so the browser's default lookup, which reads the bare name, finds nothing and the click would
+    // die. Resolved here the way GitHub's page script does: the target is looked up under the prefix or bare
+    // (userContentTarget), in the message's own rendered body first (its note before a same-named element in an
+    // older message), then the whole document; found, it is revealed and scrolled into view and the default action
+    // cancelled (the hash stays as it was: the target is not a page location). Not found, the click is left to the
+    // browser, as it was. A modified click (ctrl, ⌘ or shift asked the browser for a tab or a window) keeps the
+    // browser's, the rule the .md-URL arm below applies. The bodies: `.md`, which every body md() and userMd()
+    // fill wears, and a comment thread's agent reply (commentMsgEl: `div.cmt-msg.agent`), the one body md() fills
+    // that does not; an anchor the page built itself carries a data-act and stands in neither. A link outside a
+    // message (the file viewer's own section links, fv-anchor) is not this handler's: the viewer lands those itself.
+    if (e.ctrlKey || e.metaKey || e.shiftKey) return;
+    const msg = a.hasAttribute("data-act") ? null : a.closest(".md, .cmt-msg.agent");
+    if (!msg) return;
+    let frag = href.slice(1);
+    try { frag = decodeURIComponent(frag); } catch { /* a malformed escape: the spelling as written */ }
+    const target = frag ? userContentTarget(msg, frag) || userContentTarget(document, frag) : undefined;
+    if (!target) return;
+    e.preventDefault();
+    // The browser's fragment navigation REVEALS the target before it scrolls (the HTML spec's ancestor revealing
+    // steps): every closed <details> whose content holds the target is opened, and a `hidden="until-found"` on the
+    // target or an ancestor is removed. scrollIntoView does neither, so the same steps run here, ahead of the
+    // scroll; both shapes pass the sanitizer (details, summary and hidden are kept). A target inside a details'
+    // own <summary> is in view already and opens nothing, as in the browser.
+    for (let n: Element | null = target; n; n = n.parentElement) {
+      if ((n.getAttribute("hidden") || "").toLowerCase() === "until-found") n.removeAttribute("hidden");
+      const p = n.parentElement;
+      if (p && p.localName === "details" && n.localName !== "summary" && !p.hasAttribute("open")) p.setAttribute("open", "");
+    }
+    // a target inside the transcript moves #content, so the move is the pane's own write (every mover of #content
+    // is a writeScroll, attributed); a target elsewhere on the page scrolls its own container the browser's way
+    const cont = document.getElementById("content");
+    if (cont && cont.contains(target)) scrollElInto(cont, target, "start", "section-link");
+    else target.scrollIntoView({ block: "start" });
+    return;
+  }
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(href)) return; // relative: leave alone
   e.preventDefault();
   e.stopPropagation();
   if (location.protocol === "http:" || location.protocol === "https:") {

--- a/ui/webview/scroll-movers.test.ts
+++ b/ui/webview/scroll-movers.test.ts
@@ -40,10 +40,15 @@ test("render.ts: every mover of #content is a writeScroll — scrollBy and scrol
   assert.match(RENDER, /scrollContentBy\(content, e\.key === "ArrowDown" \? NAV_SCROLL_STEP : -NAV_SCROLL_STEP, "key-nav"\);/, "the arrow keys");
   assert.match(RENDER, /scrollElInto\(content0, el0, "center", "land-on"\);/, "the sentence land");
   assert.match(RENDER, /const land = \(writer: string\) => \{ const c = document\.getElementById\("content"\); if \(c\) scrollElInto\(c, target, "start", writer\); \};\s*\n\s*const realign = \(\) => land\("land-realign"\);\s*\n\s*land\("land-on"\);/, "the deep-link land and its re-alignments");
-  // the scrollIntoView calls that remain are on OTHER scrollers (the tab strip, picker rows, the slash popup, the awaiting box)
+  // a message's own `#` link (the click delegate): inside the transcript the move is a writeScroll; a target that stands
+  // outside #content (a comment popover's reply, found through userContentTarget's document fallback) scrolls its own
+  // container the browser's way, and the #content arm is taken first
+  assert.match(RENDER, /if \(cont && cont\.contains\(target\)\) scrollElInto\(cont, target, "start", "section-link"\);\s*\n\s*else target\.scrollIntoView\(\{ block: "start" \}\);/, "the section link");
+  // the scrollIntoView calls that remain are on OTHER scrollers (the tab strip, picker rows, the slash popup, the awaiting
+  // box, and the section link's else arm above, which the #content test keeps off the transcript)
   const rest = RENDER.split("\n").filter((l) => /scrollIntoView\(/.test(l));
-  assert.equal(rest.length, 4, "four scrollIntoView calls remain, none on a #content child: " + rest.map((l) => l.trim().slice(0, 60)).join(" | "));
-  for (const l of rest) assert.doesNotMatch(l, /target|el0|realign/, l);
+  assert.equal(rest.length, 5, "five scrollIntoView calls remain, none on a #content child: " + rest.map((l) => l.trim().slice(0, 60)).join(" | "));
+  for (const l of rest) if (!/else target\.scrollIntoView/.test(l)) assert.doesNotMatch(l, /target|el0|realign/, l);
 });
 
 test("render.ts: a spacer re-size of the active view files a spacer row; the cap comes from localStorage", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3636,7 +3636,14 @@ body.filebrowse-open { overflow: hidden; }
    sheets — the .romp-acted precedent); font sizes reuse what this surface already wears (the page base,
    12px mono, the err-hint's 0.92em). Vars the feed sheet does not define carry the chat's literals as
    fallbacks (feed-css-vars.test.ts holds that line). */
-.fileview-md { padding: 14px 18px; max-width: 860px; overflow-wrap: anywhere; font-family: var(--font-prose); }
+/* contain: layout makes .fileview-md the containing block for any fixed or absolutely positioned descendant: an
+   element in a file that reaches `position: fixed` (a class of the page's it happens to wear; the sanitizer drops
+   an inline one) stays inside the note instead of covering the viewer's chrome. Layout only, not paint: the
+   body's vertical scroll is untouched. Content wider than .fileview-md becomes ink overflow the body cannot
+   scroll to, so the media rules below cap an <svg>, <canvas> or <video> at the column as `.fileview-md img`
+   already does, and the table rule below gives a table wider than the column a horizontal scroll of its own.
+   Pinned byte-equal in both sheets (fileview-parity.test.ts). */
+.fileview-md { padding: 14px 18px; max-width: 860px; overflow-wrap: anywhere; font-family: var(--font-prose); contain: layout; }
 .fileview-md > :first-child { margin-top: 0; }
 .fileview-md > :last-child { margin-bottom: 0; }
 .fileview-md p { margin: 0.5em 0; }
@@ -3669,10 +3676,22 @@ body.filebrowse-open { overflow: hidden; }
   font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
   color: var(--code-fg, #e1c08d); white-space: pre-wrap; overflow-wrap: anywhere;
 }
-.fileview-md table { border-collapse: collapse; margin: 0.6em 0; }
+/* A table wider than the column (a `nowrap` cell, many columns) scrolls sideways on its own, as on GitHub: a block
+   box shrink-wrapped to its content (width: max-content) and capped at the column, with the overflow scrollable.
+   Under contain: layout the body cannot scroll to what a table lets run past the column, so the table has to.
+   border-collapse is inherited by the anonymous table box the block wraps, so the cell borders still collapse. */
+.fileview-md table { border-collapse: collapse; margin: 0.6em 0; display: block; width: max-content; max-width: 100%; overflow-x: auto; }
 .fileview-md th, .fileview-md td { border: 1px solid var(--box-border); padding: 4px 10px; text-align: left; }
 .fileview-md th { background: var(--box-bg); }
 .fileview-md img { max-width: 100%; }
+/* Media a file draws itself (an inline <svg> diagram, a <canvas>, a <video>) fits the column the way an <img> does:
+   under contain: layout anything wider than .fileview-md is clipped at the body's edge and unreachable. :where() keeps
+   the selectors at element specificity, so KaTeX's own rules for the <svg> glyphs it draws inside a formula
+   (`.katex svg`, sized by its sheet) still outrank them. height: auto keeps a pixel-sized svg's or canvas's own
+   ratio (its viewBox, or its width and height) as the cap shrinks it; a percentage-width element is never shrunk by
+   the cap and keeps the author's height. */
+:where(.fileview-md) svg, :where(.fileview-md) canvas, :where(.fileview-md) video { max-width: 100%; }
+:where(.fileview-md :is(svg, canvas)[width]:not([width$="%"])) { height: auto; }
 
 /* ── the viewer's image + PDF bodies (a .png used to open as line-numbered mojibake). The <img>
    wears the lightbox image's own treatment (.romp-lightbox-img: capped, object-fit contain, the


### PR DESCRIPTION
## Symptom

Open a markdown file whose HTML carries a `<style>` block and the whole file viewer disappears: `.fileview { display: none }` written in the file applies to the page. A `position: fixed` div in the file covers the viewer's close button. A `<form action=...><button>` in the file takes the pane's document to the action URL on a click, and the chat behind it is gone until a reload. Less visibly: an author's `id` shadows the page's own ids (`<p id="tabs">`), an inline `style` sets any property, `<td background=URL>` fetches the URL the moment the file renders, and a text input or a select in a file is a live control. A chat message's HTML goes through the same profile, so the same holds in the transcript.

## Cause

The chat's `md()` and `userMd()` (render.ts) and the viewer's `mdBlock` (file-view.ts) each spell DOMPurify's default html profile. That profile is an XSS filter, not a layout boundary: it keeps `style`, `form`, `button`, `select`, `textarea`, `dialog`, inline `style`, `id`, `name` and the `background` attribute.

## Fix

One sanitizer module, `ui/webview/md-sanitize.ts`, replaces both spellings; `md()`, `userMd()` and `mdBlock` call `sanitizeMd`. The rules are modelled on the ones GitHub applies to a README (two departures: a colour-only inline `style` and inline SVG survive here, which GitHub strips):

- `<style>`, `<dialog>`, every form-associated element and image maps (`<map>`, `<area>`, `usemap`) are forbidden; a form's or button's text stays as prose (DOMPurify's `KEEP_CONTENT`).
- `<input>` survives only as marked's task checkbox, forced `disabled`; every other input goes.
- An author's `id` and `name` are prefixed `user-content-` (`SANITIZE_NAMED_PROPS`). The viewer's own `md-<slug>` heading ids are minted after the sanitize and never carry the prefix, so section links in a file still land.
- An inline `style` keeps only `color` and `background-color` declarations whose value is a literal colour (a keyword, `#hex`, or `rgb()`/`rgba()`/`hsl()`/`hsla()` over plain numbers); the attribute goes when nothing is left. An `uponSanitizeAttribute` hook, installed once.
- The `background` attribute is dropped.

KaTeX's layout is inline style, which the colour rule would strip, so the math extensions (math.ts) now emit an inert placeholder carrying the TeX as text, and chat-md.ts registers `renderMathPlaceholders` as a `sanitizeMd` post-pass: KaTeX renders into the sanitized DOM afterwards, under `trust: false` (KaTeX's default, spelled out so that enabling trust is a visible edit), and its output no longer passes through DOMPurify. Registering the fill with the grammar means every `sanitizeMd` caller in the chat bundle renders math (the viewer's `mdBlock` included, when it runs in the chat page) and the feed bundle, which has no grammar, has no fill and no KaTeX.

Prefixing breaks a message's own `#fragment` links (the browser looks up the bare name), so the chat's click delegate resolves them: the message's body first, then the document, under the prefix or bare (`userContentTarget`); a closed `<details>` or a `hidden="until-found"` ancestor above the target is opened as the browser's fragment navigation would; the default action is cancelled so the page's hash stays. A fragment that names nothing is left to the browser, as before, and so is a click with ctrl, cmd or shift held, the rule the .md-URL arm beside it already applies.

Backstops: each viewer body installs one `submit` `preventDefault` (`openFileView`, `openUrlView`), and `.fileview-md` takes `contain: layout` in both sheets, so an element that reaches `position: fixed` through a class of the page's stays inside the note. Containment turns content wider than the column into overflow the body cannot scroll to, so an inline `svg`, `canvas` or `video` is capped at the column, as `img` already was, and a table wider than the column gets a horizontal scroll of its own (`display: block; width: max-content; max-width: 100%; overflow-x: auto`, the README treatment); a table that fits is laid out as before.

`docs/guide.md` gains a paragraph on what a file's own HTML may do. `SECURITY.md`'s output-sanitization bullet names the profile and KaTeX as the one renderer that writes after DOMPurify.

Design notes: the hook is installed on the module-global DOMPurify instance and applies to every `sanitize` call in the bundle; `md-sanitize.ts` holds the only one, and the source pins keep it so. The colour rule narrows what existing notes render: `text-align`, `width` and `float` in an inline `style` are dropped; the `align` attribute marked emits for table cells and an image's `width`/`height` attributes survive. A table's `width="100%"` attribute yields to the `max-content` rule, as on GitHub.

## Tests

Executing, over the real code paths. The browser legs run in headless Chromium through playwright (already a devDependency) and skip with a stated reason where no playwright browser is installed, the way `tests/test_spend_modal_headless.py` skips without a playwright install. CI installs no browser today, so in CI the browser legs skip and the node tests and source pins run; a cached `npx playwright install chromium` step in the extension job would make the browser legs execute there, and is offered as a follow-up for the maintainers rather than a `.github/` change in this PR.

- `ui/webview/md-sanitize-browser.test.ts` (new): opens synthetic notes in the real viewer (`openFileView` and `openUrlView` over `file-view.ts`, under the real `styles.css`). Before the change: the note's `<style>` hides the viewer (the card is `display: none`); the form and button survive (2 controls, expected 0) and the submit navigates; four forbidden elements survive, the span keeps `font-size: 80px`, `#top` is unprefixed, the cell's `background` resolves to an image, `<map>`, `<area>` and `usemap` survive; `.fileview-md`'s `contain` is `none` and an injected `position: fixed; inset: 0` element covers the close button; a 3000px svg and a 2500px canvas run past the column, a `<td nowrap>` table has no scroll of its own; the URL viewer's body lets a submit through.
- `ui/webview/md-sanitize-postpass-browser.test.ts` (new): the chat pipeline (marked with the chat grammar, then `sanitizeMd`). Measures that a fraction stacks, a superscript is raised, the radical's svg has a nonzero size, a display sum stands at block level, and that the rendered root equals `katex.render`'s own output byte for byte; an author's style beside it keeps only its colour; a hand-written `\href{javascript:...}` placeholder mints no link; a message's `<style>` placed after a block (so the parser leaves it in the body) is gone; a hand-written checkbox is forced disabled; the post-pass registry runs a pass once however often it is registered. Before the change it fails to build: `./md-sanitize` does not exist.
- `ui/webview/md-sanitize-chat-fragment-browser.test.ts` (new): over the real `render.ts` bundle in the chat page skeleton, clicks a footnote's forward and back links, a link over the reply's own `<a name>`, a link into a closed `<details>`, a link into a `hidden="until-found"` box, a shift-click (left to the browser), and a link that names nothing; then the same through the pipeline with a duplicated id in an older message; then a session frame posted through the page's frame listener, so `render.ts`'s own `md()` renders the reply, whose id is prefixed and whose `#` link lands. Before the change: the delegate leaves the `#` click to the browser (`defaultPrevented` false, the hash changes) and the reply's id is unprefixed; the pipeline test fails to build.
- `ui/webview/md-sanitize.test.ts` (new, node): the colour grammar (accepted and rejected values), `colorOnlyStyle`, the hook body, the install guard, the profile's lists, a built-graph check that the feed bundle carries `md-sanitize.ts` but neither `chat-md.ts`, `math.ts` nor KaTeX, and the source pins (one `DOMPurify.sanitize` in the webview, both callers import `sanitizeMd`, the fill registered by chat-md.ts, the submit backstops, `contain: layout`, the media caps and the table rule byte-equal in both sheets, the two docs). Before the change it fails to build.
- Updated pins: `render-sanitize.test.ts` (both renderers call `sanitizeMd`; `mdBlock` adopts the sanitized children), `render-math.test.ts` (the placeholder contract replaces the KaTeX-in-marked assertions; KaTeX's own options pinned), `chat-md.test.ts`, `file-view.test.ts`, `fileview-parity.test.ts` (the `.fileview-md` rule, the media caps and the table rule join the byte-equal list), `md-url-view.test.ts` (the rewrite runs after `sanitizeMd`; the data-* rule now lives in the shared profile), `pr-links.test.ts` (the PR-link walk runs on `sanitizeMd`'s body), `scroll-movers.test.ts` (the section link's `#content` arm is a `writeScroll`; its else arm is the fifth `scrollIntoView`, never on a `#content` child). Each failed on the old shape before the change.

Each rule was also checked by removing it and watching an executing test go red: the media caps, the table rule, the map/area/usemap forbids, the `<style>` forbid (both legs), `md()`'s wiring, the modifier guard, the `<details>` and `until-found` reveals, `openUrlView`'s submit backstop, and the feed bundle's freedom from the grammar.

`npm run typecheck` clean; `npm run build` clean; full `npm test`: 3699 tests, 3699 pass, 0 fail, 0 skipped (the browser legs ran; they skip where no playwright browser is installed).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)