### PR TITLE
Bottom bar: an API health cell beside the usage readout, from the sessions' API errors, retries and the retry pause

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -624,3 +624,14 @@ themselves. The analytics modal in settings shows what you actually spent,
 separating your sessions from the judge pipeline. You can also reconfigure the
 judges from the gear: the high-volume indexing tier defaults to Haiku, and the
 judgment tier defaults to Sonnet.
+
+The bottom bar's **API** cell, a dot and a word, shows how the API is treating
+your sessions. Gray **ok** means no session is waiting on the API. Amber shows
+how many sessions are waiting and names the problem: **rate limited**,
+**overloaded**, **offline** (this machine cannot reach the API), or **errors**.
+Red **paused** means auto-retry and the judges are stopped, and says why: a
+usage limit, the monthly spend cap, or that you stopped them. Hover for the same
+reading with the waiting sessions listed. Click the cell, or press Enter on it,
+for the detail: each waiting session (click one to open that session), a button
+that stops auto-retry for every session while sessions are waiting and resumes
+it while paused, and links to the usage figures and the Log.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1374,6 +1374,62 @@ after it. The pre-restart state is not carried over: an empty ring is no
 evidence. A state file, or an entry in it, that cannot be read is skipped and
 logged, and never keeps the SDK backend from starting.
 
+### The bottom bar's indicator
+
+The dashboard's bottom bar carries an API cell (a dot and a word beside the
+usage readout) that is computed independently of this signal, from two things
+the kernel owns directly:
+
+- Each alive session's newest transcript API-error record, latched until the
+  session produces assistant output again (a user prompt does not clear it,
+  romp's own retry included), plus the live retrying state of SDK sessions.
+- The retry-pause file (`retry-paused.json` under the state directory). A
+  pause writes `paused`, `t` (when it began, the auto-resume floor) and its
+  `reason`: `limit`, `spend`, or none for a manual stop. A spend pause adds
+  `bills`, the billing the capped session was on (`login` or `key`); only
+  fresh assistant output from a session on that billing lifts it. Un-pausing
+  a spend pause, by that lift or by the Resume button, records `liftedAt`
+  (the time of the output record that lifted it, or of the Resume click) and
+  `supersedes` (the floor of the pause it cleared; informational, nothing
+  reads it); both ride every later write until a newer spend un-pause
+  replaces them, and a spend-limit record older than `liftedAt` engages
+  nothing, since the lift already ruled on it. A limit or manual un-pause
+  records neither. A limit pause lifts when the usage report stops naming an
+  account-wide window at 100%, a manual pause when any live session not
+  blocked on an API error writes to its transcript after the pause began.
+  When a limit pause lifts while a spend-limit record is standing, the file
+  reads unpaused for one cycle before the spend pause engages: each writer
+  rules on one signal per cycle, and the spend engage runs before the lift in
+  the pusher's order, so it sees a paused file and rules on the record the
+  next cycle.
+
+The kernel pushes the cell's frame to shell clients only when it changed, and
+again to a shell that sends `ready`:
+
+```json
+{"type": "apiHealth", "state": "ok | degraded | paused",
+ "cls": "429 | 529 | offline | errors | ''", "reason": "'' | limit | spend | manual",
+ "text": "<the rail's words>", "waiting": 0, "retrying": 0, "blocked": 0,
+ "since": 0, "tmux": 0, "seq": 0,
+ "sessions": [{"sid": "", "name": "", "color": null, "kind": "retrying | blocked",
+               "cls": "", "status": null, "since": 0, "suppressed": false}]}
+```
+
+`seq` counts the retry-pause file's writes since the kernel started. A press
+on the detail's pause button writes that file, so the frame that answers the
+press carries a moved `seq` whatever state it brings, and the shell clears
+the button's acknowledgment on it; a frame from before the press carries the
+old one. It is an event counter, not a clock, and restarts at 0 with the
+kernel. `waiting` is `retrying` plus `blocked`. `cls` is the plurality class
+over the affected sessions, ties resolved 429, then 529, then offline, then
+errors. `since` is the pause's time when paused, else the earliest affected
+session's event (a record's timestamp, or the retrying turn's start), else 0.
+`tmux` counts alive tmux-backed sessions, which the cell sees through their
+transcripts only. Every timestamp is an event's time, never the clock, so an
+unchanged world sends nothing. On-you failures (a too-long prompt, a spent
+model allowance, a dead credential, a refusal) are not counted; a spend cap is,
+and engages the `spend` pause in the same cycle.
+
 ## Where things live
 
 State is written under `${XDG_STATE_HOME:-~/.local/state}/romp/`. Transcripts

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7770,23 +7770,72 @@ def _retry_paused_on():
         return False
 
 
-def _set_retry_paused(paused, reason=""):
+# How many times this kernel wrote the pause file since boot: the apiHealth frame's `seq`. A press on the
+# bottom bar's detail pause button writes the file, and the frame that follows carries a moved seq even when
+# the cycle's auto-pause re-engaged the same state within the same second, so the shell can tell the frame
+# that answers its press from one that predates it (_LANDING_APIH_JS pendSeq). An event counter, never a
+# clock: two cycles over an unwritten file read the same seq.
+_RETRY_PAUSE_SEQ = [0]
+
+
+def _set_retry_paused(paused, reason="", bills="", lifted_at=None):
     # Record WHEN a pause began: the auto-resume floor. Only a successful response AFTER this instant proves
     # the API recovered (an old success from before the outage doesn't). No `t` when un-pausing.
     # `reason` (the user 2026-07-14): "spend" when a monthly spend cap auto-engaged the pause, so the card
-    # shows "raise your cap" instead of a reset countdown; "" for a manual Stop or a rate-window pause.
+    # shows "raise your cap" instead of a reset countdown; "limit" when an account-wide usage window did, so
+    # the bottom bar's API cell can name it without a clock comparison; "" for a manual Stop.
+    # `bills`: for a spend pause, the billing the capped session was on, "login" or "key" (_bills_login of its
+    # live row). The lift rule reads it (_auto_resume_retry): a cap is on ONE account, so only a session on
+    # that billing can show it serving again.
+    # `liftedAt` / `supersedes`: un-pausing a SPEND pause, by the lift rule or by the user's Resume, records
+    # the time of the EVIDENCE that lifted it and the floor (`t`) of the pause it cleared. That is the spend
+    # engage's stand-down rule (_spend_capped_session): a spendLimit record older than liftedAt was already
+    # outranked by the evidence that lifted the pause, and romp never clears such a record on its own (a spend
+    # cap is on-you: _fire_api_retry sends no retry; only a human prompt to the capped session clears
+    # _api_error), so re-engaging on it put the pause back the cycle after every lift, alternating at the
+    # streaming session's output cadence and settling ON once it idled. The memory rides every later write,
+    # paused or not, until a newer spend ruling replaces it: a limit pause that engages and lifts in between
+    # must not forget it. A limit or manual pause's un-pause records nothing (its evidence, the usage report
+    # or a transcript mtime, says nothing about a spend record), and an un-pause over an already-unpaused
+    # file keeps what it finds (the write moves seq only).
+    # `lifted_at` is the evidence's own time: for the lift rule, the `t` of the assistant output record that
+    # lifted the pause (_api_last_output_t), NOT the lift cycle's clock. The cycle runs up to a pusher period
+    # after the output, and a record from a SECOND capped session written in that gap (after the output,
+    # before the cycle) is new information the lift never saw; stamped with the cycle's time, the floor would
+    # have skipped it until that session's next attempt. The user's Resume passes none and records its own
+    # instant: the gesture is the evidence, and a record stamped in the same second reads as older (the CLI
+    # stamps whole seconds) and waits for that session's next attempt, since re-engaging over the gesture
+    # would be the worse error. `supersedes` is informational (the Log and a hand read of the file): nothing
+    # reads it.
+    try:
+        prev = json.loads((jd.STATE / "retry-paused.json").read_text())
+        if not isinstance(prev, dict):
+            prev = {}
+    except Exception:
+        prev = {}
     d = {"paused": bool(paused)}
     if paused:
         d["t"] = time.time()
         if reason:
             d["reason"] = reason
+        if bills:
+            d["bills"] = bills
+    elif prev.get("paused") and prev.get("reason") == "spend":
+        d["liftedAt"] = float(lifted_at) if lifted_at else time.time()
+        d["supersedes"] = float(prev.get("t") or 0)
+    if "liftedAt" not in d and prev.get("liftedAt"):
+        d["liftedAt"] = prev["liftedAt"]
+        d["supersedes"] = prev.get("supersedes", 0)
+    _RETRY_PAUSE_SEQ[0] += 1
     _atomic_write(jd.STATE / "retry-paused.json", json.dumps(d))
     _mark_views_dirty()   # the queued bubble renders this hold; every writer publishes the flip (review 2026-09-05)
 
 
 def _retry_pause_reason():
-    """Why the current global pause engaged ("spend" for a monthly spend cap), or "" (manual / rate
-    window). Rides the globalRetryPaused push so the card can name the cause."""
+    """Why the current global pause engaged ("spend" for a monthly spend cap, "limit" for a usage window),
+    or "" (manual). Rides the globalRetryPaused push so the card can name the cause; the API health frame
+    reads it too. A pause file written for a limit before the reason was recorded carries none and reads
+    manual."""
     try:
         return str(json.loads((jd.STATE / "retry-paused.json").read_text()).get("reason") or "")
     except Exception:
@@ -7799,6 +7848,42 @@ def _retry_pause_ts():
         return float(json.loads((jd.STATE / "retry-paused.json").read_text()).get("t") or 0)
     except Exception:
         return 0.0
+
+
+def _retry_pause_bills():
+    """Which billing the session that engaged the current SPEND pause was on, "login" or "key", or "" when
+    the file records none (a limit or manual pause, or a spend pause written before the billing was
+    recorded). _auto_resume_retry's spend rule reads it; "" there takes any session's fresh output."""
+    try:
+        return str(json.loads((jd.STATE / "retry-paused.json").read_text()).get("bills") or "")
+    except Exception:
+        return ""
+
+
+def _retry_pause_lifted_at():
+    """The time of the evidence that last un-paused a SPEND pause (the output record that lifted it, or the
+    user's Resume), or 0 when none is on record. The spend engage's stand-down floor: a spendLimit record
+    older than this was already outranked (_spend_capped_session). Survives later pauses and lifts of other
+    reasons (_set_retry_paused carries it). Assumes a monotone wall clock, as the pause floor `t` does: after
+    a backward clock step a record stamped in the corrected clock reads as older than the lift until the
+    clock passes it, and the lift rule's own `out_t > t` is suppressed the same way. Clamping this to now
+    would not help: every record's stamp is at or before now, so a record is older than min(liftedAt, now)
+    exactly when it is older than liftedAt. Only the record's identity, not its stamp, could order it against
+    the lift across a step."""
+    try:
+        return float(json.loads((jd.STATE / "retry-paused.json").read_text()).get("liftedAt") or 0)
+    except Exception:
+        return 0.0
+
+
+def _account_limited():
+    """The ACCOUNT-WIDE usage windows the report says are at 100% with their reset still ahead: the 5h and
+    7d keys of _usage().limited, never fable (model-scoped). The ONE authority for the limit pause's two
+    edges: _auto_pause_on_limit engages while this is non-empty and _auto_resume_retry lifts once it is
+    empty, so the pause holds exactly as long as the report says the limit does and lifts at the reset with
+    no session having to serve first. Raises what _usage raises; both callers treat no reading as no change."""
+    lim = (_usage() or {}).get("limited") or {}
+    return [k for k, v in lim.items() if v and k != "fable"]
 
 
 def _retry_resume_at():
@@ -7846,8 +7931,9 @@ def _auto_pause_on_limit():
     """Hitting an ACCOUNT-WIDE usage limit (5h Session or 7d Weekly at 100%) auto-engages the global retry-pause
     (the user 2026-07-01): retrying into a rate-limited account just burns failed requests, so stop the
     auto-retry AND the judges (both gate on this flag) until the window resets. _auto_resume_retry clears it the
-    moment a session serves a request again — which, while the account is genuinely limited, can't happen, so
-    the pause holds exactly as long as the limit does. Idempotent: only writes when it isn't already paused.
+    cycle the same report stops naming a limited window (the reset passed, or a fresh reading came in under
+    100%: _account_limited is the one authority for both edges), so the pause holds exactly as long as the
+    report says the limit does. Idempotent: only writes when it isn't already paused.
 
     Fable-5 is DELIBERATELY excluded (the user 2026-07-03): its window is MODEL-scoped (the included Fable-5
     weekly allowance), not account-wide, so exhausting it does NOT stop the account from serving the models romp
@@ -7858,29 +7944,46 @@ def _auto_pause_on_limit():
     'distilling', no background/summary). A Fable-only session that hits the wall is surfaced per-session
     (api-error → blocked), which is where a model-scoped limit belongs. fable=100% no longer lights the top
     banner either (the user 2026-07-04: it popped every refresh for the 7-day window and wasn't actionable) —
-    only the rail's passive third bar shows it (see _usage().limited); it pauses nothing and warns nothing."""
+    only the rail's passive third bar shows it (see _usage().limited); it pauses nothing and warns nothing.
+
+    No stand-down is needed on this edge: both edges read the report, so a re-engage after a lift needs a
+    reading that names a window again, never a record the lift already outranked. The spend twin acts on a
+    transcript record that outlives its lift, and stands down on it (_spend_capped_session's `after`)."""
     try:
-        u = _usage()
+        account = _account_limited()                     # 5h / 7d only: fable is model-scoped
     except Exception:
         return
-    lim = (u or {}).get("limited") or {}
-    account = [k for k, v in lim.items() if v and k != "fable"]     # 5h / 7d only — fable is model-scoped
     if account and not _retry_paused_on():
-        _set_retry_paused(True)
+        _set_retry_paused(True, reason="limit")     # latched at the event: the API cell's 'paused, usage limit'
+        #                                               (not re-derived from _retry_resume_at's clock compare)
         sys.stderr.write("retry-pause: auto-engaged — usage limit reached (%s) → auto-retry + judges paused until reset\n"
                          % ",".join(account))
         # no inline push: _set_retry_paused marked the views dirty and woke the pusher, whose next cycle
         # carries the flip in its globalRetryPaused frame (see _auto_resume_retry)
 
 
-def _spend_capped_session(now, tmux):
-    """The first alive session sitting blocked on a MONTHLY SPEND CAP error, or None. Account-wide by
-    nature (the cap is on the account, so every session hits it), so one is enough to pause everything."""
+def _spend_capped_session(now, tmux, after=0):
+    """The first alive session sitting blocked on a MONTHLY SPEND CAP error whose record is not older than
+    `after`, or None. Account-wide by nature (the cap is on the account, so every session hits it), so one is
+    enough to pause everything. `after` is the last spend lift's instant (_retry_pause_lifted_at): a record
+    written before it was already outranked by the output that lifted the pause (or by the user's Resume), and
+    a writer whose evidence predates the ruling stands down. A record at or after it is new information and
+    engages again. Compared as they are, no truncation: `after` is the lifting output's own `t` for the lift
+    rule (whole seconds, the CLI's stamp, like the record's), so a record in the same second as that output
+    reads as new, and the record that engaged the pause never ties (it predates the pause floor, which the
+    output postdates). Truncating both sides to whole seconds against a liftedAt stamped with the lift
+    CYCLE's clock would read a second capped session's record from the second before that cycle as stale
+    though it postdated the lift's evidence. A record with no readable time (t 0) is not proof of staleness
+    and counts."""
+    floor = float(after or 0)
     for s in _alive_sessions(now, tmux):
         p = s.get("path")
         if p:
             e = _api_error(p)
             if e and e.get("spendLimit"):
+                t = float(e.get("t") or 0)
+                if floor and 0 < t < floor:
+                    continue                             # already ruled on: the lift's evidence is newer
                 return s
     return None
 
@@ -7893,16 +7996,45 @@ def _auto_pause_on_spend_limit(now, tmux):
     (isApiErrorMessage → _api_error.spendLimit), not the usage report, because the cap is a BILLING limit
     the /usage windows don't carry. Pausing stops BOTH the auto-retry AND the judges (they gate on this
     flag) — correct, since a capped account fails every model call. _auto_resume_retry clears it the moment
-    a session serves a request again (which can't happen until the cap lifts), so it holds exactly as long
-    as the cap does. reason='spend' → the card shows 'raise your cap', not a reset countdown. Idempotent."""
+    a session on the capped billing serves a request again (which can't happen until the cap lifts), so it
+    holds exactly as long as the cap does. reason='spend' → the card shows 'raise your cap', not a reset
+    countdown. Idempotent.
+
+    Stand-down: the capped session's record outlives the lift. A spend cap is on-you, so romp sends it no
+    retry and only a human prompt to that session clears _api_error; the lift reads another session's output
+    on the same billing and leaves the record standing. Engaging on it again the next cycle put the pause
+    back after every lift (alternating at the streaming session's output cadence, then stuck ON once it
+    idled, gating the judges and the idle-queue drives until someone prompted the capped session). So the
+    engage reads the last spend lift's instant off the pause file (_retry_pause_lifted_at) and skips records
+    older than it; a NEW spendLimit record, written after the lift, engages with a new floor."""
     if _retry_paused_on():
         return
-    if _spend_capped_session(now, tmux) is not None:
-        _set_retry_paused(True, reason="spend")
-        sys.stderr.write("retry-pause: auto-engaged — monthly spend limit reached → auto-retry + judges "
-                         "paused until the cap is raised (claude.ai/settings/usage)\n")
+    capped = _spend_capped_session(now, tmux, after=_retry_pause_lifted_at())
+    if capped is not None:
+        # which billing the cap is on, from the capped session's live row: the lift rule accepts fresh output
+        # from that billing only, so a session on the other account cannot lift a cap it never hit and
+        # re-engage it here the next cycle (the pause file flapped every cycle in a login-plus-key install
+        # while one session streamed past the other's cap)
+        live = tmux if isinstance(tmux, dict) else {}
+        bills = "login" if _bills_login(live.get(str(capped.get("sid") or ""))) else "key"
+        _set_retry_paused(True, reason="spend", bills=bills)
+        sys.stderr.write("retry-pause: auto-engaged: monthly spend limit reached (%s billing); auto-retry + judges "
+                         "paused until the cap is raised (claude.ai/settings/usage)\n" % bills)
         # no inline push: _set_retry_paused marked the views dirty and woke the pusher, whose next cycle
         # carries the flip in its globalRetryPaused frame (see _auto_resume_retry)
+
+
+def _bills_login(tm):
+    """Whether a live-map row's session bills the machine LOGIN (the account a usage limit is on): the CLI's
+    own authLive report first, the registry's auth next; a row with neither (a tmux session, an SDK session
+    before its init landed) can only be billing the login when this machine holds no key at all
+    (_auth_key_present: an apiKeyHelper is configured), and is taken as billing a key otherwise. The spend
+    pause reads it at both edges (_auto_pause_on_spend_limit records the capped session's billing;
+    _auto_resume_retry's spend rule compares a candidate's against it)."""
+    a = str((tm or {}).get("authLive") or (tm or {}).get("auth") or "")
+    if a:
+        return a == "login"
+    return not _auth_key_present()
 
 
 def _auto_resume_retry(now, tmux):
@@ -7913,9 +8045,36 @@ def _auto_resume_retry(now, tmux):
     killed EVERY judge (the tier is gated on `not _retry_paused_on()`), turning the storm's fix into a
     permanent outage the user had to infer.
 
-    Event-based recovery signal: a live session that is NOT currently blocked on an API error AND has written
-    fresh transcript output since the pause began (mtime past the pause floor) is proof the account can serve
-    requests again. Clearing re-enables both auto-retry and the judges together.
+    Three lift rules, one per reason, each keyed on the event that engaged it:
+
+    - limit: the usage REPORT, the same reading that engaged it (_account_limited). The pause holds while
+      the report names a 5h/7d window at 100% with its reset ahead, and lifts the cycle it stops: the
+      reset passed, or a fresh reading came in under it. No session's output lifts it while the report
+      still reads limited. The mtime rule lifted it on any session's fresh transcript, and a key-billed
+      session's streaming (or a human prompt) flipped the file every cycle while the window held; a rule
+      keyed on a login-billed session's fresh assistant output could never fire after the reset: the login
+      sessions the limit blocked are the ones whose auto-retry this pause gates (_fire_api_retry), key-billed
+      sessions are rightly skipped, so the pause, the judges and the idle-queue drives stayed off until a
+      human prompted or clicked Resume. Output under a still-limited report is not a lift either: with extra
+      usage on, the login account is served at 100%, and a lift on that output was re-engaged the next
+      cycle, the pause file (so the bottom bar's API cell) flipping at the output cadence. A login turn's
+      END refreshes the report (get_usage rides turn ends; _usage_poll_tick every 15 min), which is how a
+      served account reaches this edge. A still-limited account whose reading was stale re-engages through
+      its next error record and the refreshed report, with a new floor.
+    - spend: fresh ASSISTANT output (_api_last_output_t, never the mtime a prompt moves too) from a live
+      session on the SAME billing the capped session was on (_retry_pause_bills, recorded at the engage;
+      the capped session itself qualifies once it serves). A cap is on one account, and in a login-plus-key
+      install a session on the other account streams straight through it: the old mtime rule counted that,
+      _auto_pause_on_spend_limit re-engaged the pause the next cycle while the capped session sat on its
+      record, and the file flipped every cycle. A file with no billing recorded takes any session's fresh
+      output. The lift leaves the capped session's record standing (nothing but a human prompt clears a
+      spend record), so the un-pause records the lifting output's own time as liftedAt (the evidence, not
+      the cycle's clock, so a record written between the two counts as new) and the engage stands down on
+      records older than it: one lift, no re-engage, until a NEW record.
+    - manual: any live session, not blocked on an API error, whose transcript mtime passed the pause floor
+      (the user's own words above, unchanged).
+
+    Clearing re-enables both auto-retry and the judges together.
 
     Delivery (the two auto-pause siblings above do the same): no inline push from this thread.
     _set_retry_paused ends in _mark_views_dirty, which stamps the dirty mark and sets _pusher_wake, so
@@ -7931,28 +8090,53 @@ def _auto_resume_retry(now, tmux):
     if not _retry_paused_on():
         return
     floor = _retry_pause_ts()
+    reason = _retry_pause_reason()
+    if reason == "limit":
+        try:
+            if _account_limited():
+                return                                   # the window holds: nothing a session writes outranks the report
+        except Exception:
+            return                                       # no reading: no change (the engage side reads nothing either)
+        _lift_retry_pause(now, "the usage window reset")
+        return
+    bills = _retry_pause_bills() if reason == "spend" else ""
+    live = tmux if isinstance(tmux, dict) else {}
     for s in _alive_sessions(now, tmux):
         path = s.get("path")
         if not path or _api_error(path):                 # still blocked on an API error → not proof of recovery
             continue
-        try:
-            fresh = os.stat(path).st_mtime > floor       # wrote something new since the pause → a served request
-        except OSError:
-            continue
+        evidence = None
+        if reason == "spend":
+            if bills and ("login" if _bills_login(live.get(str(s.get("sid") or ""))) else "key") != bills:
+                continue                                 # the other account: says nothing about this cap
+            out_t = _api_last_output_t(path)
+            fresh = out_t > floor                        # the API's own answer, after the pause
+            evidence = out_t                             # ... and the stand-down floor the un-pause records
+        else:
+            try:
+                fresh = os.stat(path).st_mtime > floor   # wrote something new since the pause → a served request
+            except OSError:
+                continue
         if fresh:
-            _set_retry_paused(False)
-            sys.stderr.write("retry-pause: auto-cleared — session %s recovered → judges + auto-retry resume\n"
-                             % s.get("sid", "?"))
-            try:                                         # recovery edge → re-arm cards the judges gave up on
-                rearmed = jd.rearm_failed_summaries(now)  # while degraded, so their summaries/briefs retry now
-                if rearmed:
-                    sys.stderr.write("distiller: re-armed %d given-up card(s) after recovery\n" % rearmed)
-                    _mark_views_dirty()                  # a store write the cards show, after the flag's stamp
-            except Exception:
-                sys.stderr.write("rearm-failed-summaries: %s\n" % traceback.format_exc())
-            # no inline push: _set_retry_paused marked the views dirty and woke the pusher; its next cycle
-            # carries globalRetryPaused=false (docstring)
+            _lift_retry_pause(now, "session %s recovered" % s.get("sid", "?"), lifted_at=evidence)
             return
+
+
+def _lift_retry_pause(now, why, lifted_at=None):
+    """Clear the global retry-pause on a recovery edge (_auto_resume_retry's three rules land here): the flag
+    flip and the re-arm of the cards the judges gave up on while degraded. No inline push and no wake of its
+    own: _set_retry_paused ends in _mark_views_dirty, which wakes the pusher, and its next cycle carries
+    globalRetryPaused=false (the caller's docstring). `lifted_at` is the spend rule's evidence time, recorded
+    as the file's liftedAt (_set_retry_paused); the other rules pass none."""
+    _set_retry_paused(False, lifted_at=lifted_at)
+    sys.stderr.write("retry-pause: auto-cleared (%s): judges + auto-retry resume\n" % why)
+    try:                                                 # recovery edge → re-arm cards the judges gave up on
+        rearmed = jd.rearm_failed_summaries(now)         # while degraded, so their summaries/briefs retry now
+        if rearmed:
+            sys.stderr.write("distiller: re-armed %d given-up card(s) after recovery\n" % rearmed)
+            _mark_views_dirty()                          # a store write the cards show, after the flag's stamp
+    except Exception:
+        sys.stderr.write("rearm-failed-summaries: %s\n" % traceback.format_exc())
 
 
 # ── Per-session auto-retry suppression (the user 2026-07-06) ───────────────────────────────────────
@@ -22718,6 +22902,7 @@ def _undelivered_wake_tail(path):
 
 
 _api_err_cache = {}           # path -> ((mtime, size), err|None)
+_api_last_failed_cache = {}   # path -> ((mtime, size), err|None, out_t): _api_last_failed's own (the latch)
 
 
 _SESSION_STAMP_CACHE = {}    # sid -> ((goals mtime,size, overrides mtime,size), ((gid, at, why, kind), stamped tops)) — see _session_stamp_read
@@ -24460,21 +24645,33 @@ def _spend_dialog_showing(pane):
 _API_ERR_TAIL_WINDOW = int(os.environ.get("ROMP_API_ERR_TAIL_WINDOW", "262144"))
 
 
-def _api_error_scan(path, start):
-    """One pass of _api_error's classification from byte `start` to EOF → (err, decided).
+def _api_error_pass(path, start):
+    """One pass from byte `start` to EOF answering BOTH transcript readers at once
+    -> (err, decided, latched, decided_latched, out_t).
 
-    The loop is _api_error's original whole-file scan, UNCHANGED (one dedent) except that each of its
-    three `err = ...` sites now also sets `decided`. That flag is the window's own proof of sufficiency:
-    True iff this pass saw a record that ASSIGNS the verdict (an isApiErrorMessage assistant record,
-    fresh assistant output, or a genuine user prompt) — exactly the record the whole-file scan's result
-    depends on, since everything before it is overwritten. False means the window started too late and
-    the caller must widen; True means this window's answer IS the whole file's answer.
+    err / decided are _api_error's. The loop is _api_error's original whole-file scan, changed only at its three
+    `err = ...` sites (each also sets `decided`, and the two assistant sites set `latched`, `decided_latched` and
+    `out_t`) and at the refusal branch, which marks both dicts. `decided` is the window's own proof of
+    sufficiency: True iff this pass saw a record that ASSIGNS the verdict (an isApiErrorMessage assistant
+    record, fresh assistant output, or a genuine user prompt), exactly the record the whole-file scan's result
+    depends on, since everything before it is overwritten. False means the window started too late and the
+    caller must widen; True means this window's answer IS the whole file's answer.
 
-    A non-zero `start` lands mid-line, so the first partial line is dropped. model_refusal_* records
-    land a few records AFTER the error they annotate and only mutate an err already set, so they need no
-    special handling: with their error out of window nothing is assigned, and the caller widens."""
+    latched / decided_latched are _api_last_failed's (the bottom bar's API health cell): the same verdict with
+    the user branch inert, so a genuine prompt neither clears nor decides it and an error record holds until
+    fresh ASSISTANT output, through romp's own injected RETRY_MSG and through a human prompt alike (neither is
+    information about the API; the API's answer is). An assistant record decides both, so decided_latched
+    implies decided. out_t is the newest assistant OUTPUT record's timestamp while that record is the newest
+    assistant record, else 0: the spend pause's recovery signal (_auto_resume_retry).
+
+    A non-zero `start` lands mid-line, so the first partial line is dropped. model_refusal_* records land a
+    few records AFTER the error they annotate and only mutate an err already set, so they need no special
+    handling: with their error out of window nothing is assigned, and the caller widens."""
     err = None
     decided = False
+    latched = None
+    decided_latched = False
+    out_t = 0
     with open(path, errors="replace") as f:
         if start > 0:
             f.seek(start)
@@ -24497,42 +24694,47 @@ def _api_error_scan(path, start):
                     # "prompt is too long" is NOT a transient API error (the user 2026-06-29): it means the
                     # context needs compacting → it's on YOU. Flag it so it (and only it) blocks; other API
                     # errors are transient (auto-retry recovers them) and stay in Working.
-                    decided = True
-                    err = {"text": text, "status": o.get("apiErrorStatus"),
-                           "category": o.get("error") or "unknown",
-                           # the error RECORD's identity — a new failed attempt writes a new record,
-                           # so this uuid IS the error episode (one auto-retry per episode, apiRetry)
-                           "uuid": o.get("uuid"),
-                           "tooLong": "too long" in text.lower(),
-                           # a spend cap is on YOU (raise it), like tooLong — but ALSO stops the
-                           # auto-retry entirely (no reset to wait out); see _auto_pause_on_spend_limit
-                           "spendLimit": _is_spend_limit(text),
-                           # a model's own allowance is spent — on YOU too (switch model / add
-                           # credits), and the auto-retry keeps running only because the window does
-                           # eventually reset; see _is_model_limit
-                           "modelLimit": _is_model_limit(text),
-                           # a dead credential (no login / refused key) — on YOU, never auto-retried;
-                           # see _is_auth_error (per-session auth, the user 2026-08-08)
-                           "authErr": _is_auth_error(text),
-                           # the error's parent = the refused/failed USER message — kept so the
-                           # system model_refusal_* record below can link itself to THIS episode
-                           "parentUuid": o.get("parentUuid"),
-                           # a safeguards refusal is deterministic on the same input — on YOU
-                           # (rewrite the ask or drop the thread), never auto-retried; see
-                           # _is_refusal_text, and the system-record event path below (the user
-                           # 2026-08-15, after one refused prompt drew 12 auto-retries in ~6min)
-                           "refusal": _is_refusal_text(text)}
+                    decided = decided_latched = True
+                    out_t = 0                             # the newest assistant record is a failure again
+                    err = latched = {"text": text, "status": o.get("apiErrorStatus"),
+                                     "category": o.get("error") or "unknown",
+                                     # the error RECORD's identity — a new failed attempt writes a new record,
+                                     # so this uuid IS the error episode (one auto-retry per episode, apiRetry)
+                                     "uuid": o.get("uuid"),
+                                     # the record's own time, the event stamp the API health frame's `since`
+                                     # carries (never the clock, so an unchanged world serializes identically)
+                                     "t": int(em.parse_z(o.get("timestamp")) or 0),
+                                     "tooLong": "too long" in text.lower(),
+                                     # a spend cap is on YOU (raise it), like tooLong — but ALSO stops the
+                                     # auto-retry entirely (no reset to wait out); see _auto_pause_on_spend_limit
+                                     "spendLimit": _is_spend_limit(text),
+                                     # a model's own allowance is spent — on YOU too (switch model / add
+                                     # credits), and the auto-retry keeps running only because the window does
+                                     # eventually reset; see _is_model_limit
+                                     "modelLimit": _is_model_limit(text),
+                                     # a dead credential (no login / refused key) — on YOU, never auto-retried;
+                                     # see _is_auth_error (per-session auth, the user 2026-08-08)
+                                     "authErr": _is_auth_error(text),
+                                     # the error's parent = the refused/failed USER message — kept so the
+                                     # system model_refusal_* record below can link itself to THIS episode
+                                     "parentUuid": o.get("parentUuid"),
+                                     # a safeguards refusal is deterministic on the same input — on YOU
+                                     # (rewrite the ask or drop the thread), never auto-retried; see
+                                     # _is_refusal_text, and the system-record event path below (the user
+                                     # 2026-08-15, after one refused prompt drew 12 auto-retries in ~6min)
+                                     "refusal": _is_refusal_text(text)}
                 elif (isinstance(c, list) and any(isinstance(b, dict)
                         and b.get("type") in ("text", "tool_use", "thinking") for b in c)) \
                         or (isinstance(c, str) and c.strip()):
-                    decided = True
-                    err = None                            # fresh assistant output → recovered
+                    decided = decided_latched = True
+                    err = latched = None                  # fresh assistant output → recovered
+                    out_t = int(em.parse_z(o.get("timestamp")) or 0)
             elif t == "user":
                 c = (o.get("message") or {}).get("content")
                 is_tool_result = isinstance(c, list) and any(
                     isinstance(b, dict) and b.get("type") == "tool_result" for b in c)
-                if not is_tool_result:                    # a genuine prompt (e.g. a retry) clears it
-                    decided = True
+                if not is_tool_result:                    # a genuine prompt (e.g. a retry) clears _api_error's
+                    decided = True                        # verdict and decides it; the latch ignores it
                     err = None
             elif t == "system" and o.get("subtype") in ("model_refusal_no_fallback",
                                                         "model_refusal_fallback"):
@@ -24545,9 +24747,62 @@ def _api_error_scan(path, start):
                 # parent in 2 of 13 refusal records of one storm — and deliberately not
                 # record-alone: the CLI also omits this record for some refusal errors, which is
                 # why the text signature above stays co-equal rather than a legacy fallback.
-                if err is not None and o.get("parentUuid") == err.get("parentUuid"):
-                    err["refusal"] = True
-    return err, decided
+                for d in (err, latched):                  # the same dict when both still hold the episode
+                    if d is not None and o.get("parentUuid") == d.get("parentUuid"):
+                        d["refusal"] = True
+    return err, decided, latched, decided_latched, out_t
+
+
+def _api_error_scan(path, start, user_clears=True):
+    """_api_error_pass for ONE reader -> (err, decided): _api_error's verdict by default, the latch's with
+    user_clears=False. The differential tests read the scan through this name; the kernel reads the pass."""
+    err, decided, latched, decided_latched, _ = _api_error_pass(path, start)
+    return (err, decided) if user_clears else (latched, decided_latched)
+
+
+def _api_stat_key(path):
+    """The (mtime, size) both transcript caches key on, or None when the file cannot be stat'ed."""
+    try:
+        st = os.stat(path)
+        return (st.st_mtime, st.st_size)
+    except OSError:
+        return None
+
+
+_API_UNDECIDED = object()   # _api_error_read's latch slot when the read stopped before an assistant record
+
+
+def _api_error_read(path, key, latch):
+    """The tail-first widening read behind BOTH readers, filling both caches from ONE pass: without it,
+    _api_last_failed would re-read and re-parse the same tail _api_error had just scanned, for every active
+    session, every cycle. `latch` names the verdict the caller needs decided: _api_error's decides at the
+    newest prompt or assistant record and keeps exactly the offsets it always read; the latch's needs an
+    assistant record. Whatever this read settled (or proved by reaching byte 0) is cached for both, so the
+    pusher's second question about the same transcript in the same cycle is a cache hit.
+    -> (err, latched, out_t); latched is _API_UNDECIDED when a non-latch read stopped before an assistant
+    record (the latch's own read then widens, rarely: a tail of prompts longer than the window)."""
+    size = key[1]
+    # TAIL-FIRST: the pusher calls this per session per push, and the old whole-file read cost
+    # O(transcript) on EVERY append — the same unamortized shape the assembly fold retired for the
+    # event-model parse, left behind here. Widen 4x until a pass reports it saw the deciding record.
+    win = max(1, _API_ERR_TAIL_WINDOW)   # a knob of 0 or less would never widen (0*4 stays 0): clamp, don't spin
+    while True:
+        start = size - win if win < size else 0
+        err, decided, latched, decided_latched, out_t = _api_error_pass(path, start)
+        whole = start <= 0
+        if whole or decided_latched or (decided and not latch):
+            break
+        win *= 4
+    if len(_api_err_cache) > 256:
+        _api_err_cache.clear()
+    _api_err_cache[path] = (key, err)                     # decided, or the whole file: final either way
+    if decided_latched or whole:
+        if len(_api_last_failed_cache) > 256:
+            _api_last_failed_cache.clear()
+        _api_last_failed_cache[path] = (key, latched, out_t)
+    else:
+        latched = _API_UNDECIDED
+    return err, latched, out_t
 
 
 def _api_error(path):
@@ -24557,37 +24812,57 @@ def _api_error(path):
     model_not_found) but that flag is the invariant, so detection is exact, not a text heuristic (the
     user 2026-06-16). The session is blocked iff such a record is the LAST productive thing in the
     transcript: a later genuine user prompt (a retry) or fresh assistant output (an internal retry that
-    succeeded) clears it. Returns {text,status,category} or None. Event-based; cached by (mtime,size)
-    like _parse, since build_session/build_feed call it per push."""
-    try:
-        st = os.stat(path)
-        key = (st.st_mtime, st.st_size)
-        size = st.st_size
-    except OSError:
-        key = None
-        size = 0
+    succeeded) clears it. Returns {text,status,category,...} or None. Event-based; cached by (mtime,size)
+    like _parse, since build_session/build_feed call it per push. One read serves this and the latch
+    (_api_error_read)."""
+    key = _api_stat_key(path)
     hit = _api_err_cache.get(path)
     if hit is not None and key is not None and hit[0] == key:
         return hit[1]
-    err = None
+    if key is None:
+        return None
     try:
-        # TAIL-FIRST: the pusher calls this per session per push, and the old whole-file read cost
-        # O(transcript) on EVERY append — the same unamortized shape the assembly fold retired for the
-        # event-model parse, left behind here. Widen 4x until a pass reports it saw the deciding record.
-        win = max(1, _API_ERR_TAIL_WINDOW)   # a knob of 0 or less would never widen (0*4 stays 0): clamp, don't spin
-        while True:
-            start = size - win if win < size else 0
-            err, decided = _api_error_scan(path, start)
-            if decided or start <= 0:
-                break
-            win *= 4
+        return _api_error_read(path, key, latch=False)[0]
     except OSError:
         return None
-    if key is not None:
-        if len(_api_err_cache) > 256:
-            _api_err_cache.clear()
-        _api_err_cache[path] = (key, err)
-    return err
+
+
+def _api_last_failed(path):
+    """The session's newest API error record if no ASSISTANT OUTPUT has followed it, else None: _api_error's
+    latched sibling (the bottom bar's API health cell). Same tail-first widening, its own (mtime, size)
+    cache, one difference: a user prompt does not clear the record. _api_error answers 'is this session
+    blocked right now', and a retry prompt rightly un-blocks it; but romp's own auto-retry IS a user prompt
+    (RETRY_MSG), so a count keyed on _api_error read '1 waiting', 'ok', '1 waiting' on every rung of
+    RETRY_BACKOFF during an outage. The API's own answer, output or a new error record, is the only event
+    that moves this. Returns the pass's err dict (with `t`, the record's time) or None."""
+    key = _api_stat_key(path)
+    hit = _api_last_failed_cache.get(path)
+    if hit is not None and key is not None and hit[0] == key:
+        return hit[1]
+    if key is None:
+        return None
+    try:
+        return _api_error_read(path, key, latch=True)[1]
+    except OSError:
+        return None
+
+
+def _api_last_output_t(path):
+    """The timestamp of the session's newest ASSISTANT OUTPUT record while that record is the newest
+    assistant record (the latch is clear), else 0: a user prompt is not output, a tool result is not output,
+    and an error record after it means no fresh answer stands. Kept beside the latch by the same read, so
+    the pusher pays nothing extra for it. The spend pause lifts on this (_auto_resume_retry), never on the
+    transcript's mtime, which a prompt moves too."""
+    key = _api_stat_key(path)
+    hit = _api_last_failed_cache.get(path)
+    if hit is not None and key is not None and hit[0] == key:
+        return hit[2]
+    if key is None:
+        return 0
+    try:
+        return _api_error_read(path, key, latch=True)[2]
+    except OSError:
+        return 0
 
 
 def _suppress_kernel_driven_ask(sid, ask, now=None):
@@ -40168,6 +40443,170 @@ def _badge_push(n):
     _send_to_app("shell", {"type": "badge", "n": n})
 
 
+# ── The bottom bar's API health cell: one glance answers 'is the API serving my sessions', beside the usage
+# readout. Built from what the kernel already owns: the merged live map's retrying state (the SDK api_retry
+# storm), each alive transcript's LATCHED newest API error (_api_last_failed) and the global retry-pause
+# file, never from the /api-health ratio machine (threshold-and-hold transitions evaluated at read time) and
+# never from a clock: every field moves on one named event (a retry frame, an isApiErrorMessage record,
+# fresh assistant output, a pause set or lifted, a session leaving the roster), so an unchanged world
+# serializes identically and sends nothing.
+#
+# States: ok; degraded, with a class word by plurality over the affected sessions, 429 rate limited /
+# 529 overloaded / offline (this machine cannot reach the API) / errors, and the count waiting
+# (retrying + stopped on an error record); paused, red, with the pause's latched reason (limit / spend /
+# manual), outranking every degraded reading since nothing retries and the judges are gated too.
+# On-you failures (tooLong / modelLimit / authErr / refusal) do NOT count: they already wear red on that
+# session's tab and card, and the cell answers for the API, not for the session. A spend cap counts,
+# and engages the spend pause in the same cycle anyway. The web shell's rail only, for now; the VS Code
+# strip twin (strip.ts apiCell's sibling, with a --st-retrying token) and the phone's Usage-modal section
+# (no rail on the phone) are named follow-ups.
+_APIH_TEXT = {                 # the ONE table of rail words: the rail, the detail header and the tests read `text`
+    "ok": "ok",
+    "429": "rate limited",
+    "529": "overloaded",
+    "offline": "offline",
+    "errors": "errors",
+    "limit": "paused · usage limit",
+    "spend": "paused · spend cap",
+    "manual": "paused by you",
+}
+_APIH_ORDER = ("429", "529", "offline", "errors")   # the fixed tie order for the plurality class
+
+
+def _apih_status(status):
+    """The wire's status as a positive int, or None (bools, blanks, zeros and non-digits are no status)."""
+    if isinstance(status, bool):
+        return None
+    if isinstance(status, (int, float)):
+        return int(status) if int(status) > 0 else None
+    if isinstance(status, str) and status.strip().isdigit():
+        return int(status.strip()) or None
+    return None
+
+
+def _apih_class(status, category="", network_down=None):
+    """One affected session's class for the rail: "429" | "529" | "offline" | "errors". A kernel-local
+    twin of sdk_backend.api_health_status_class collapsed to the four rail words (tests pin agreement on the
+    shared statuses): its 5xx / other / none all read "errors" here, except a no-status attempt the CLI
+    flagged is_network_down, which is this machine's connectivity, not the API: "offline". Only a retrying
+    row can say offline: a transcript error record carries no network flag."""
+    st = _apih_status(status)
+    if st is not None:
+        if st == 429:
+            return "429"
+        if st == 529:
+            return "529"
+        return "errors"
+    cat = str(category or "").strip().lower()
+    if cat == "rate_limit":
+        return "429"
+    if cat == "overloaded":
+        return "529"
+    if cat in ("server_error", "authentication_failed", "billing_error", "invalid_request"):
+        return "errors"
+    return "offline" if network_down is True else "errors"
+
+
+def _api_health_frame(now, tmux):
+    """The apiHealth shell frame for this cycle (the block comment above says what it reads). `tmux` is
+    the cycle's merged live map (Sessions.live()). Every timestamp is an event stamp, a record's time, the
+    storm turn's start (SdkSession.since moves once per fresh turn, not per attempt) or the pause's t, never
+    the clock, so two cycles over the same world return equal dicts and _api_health_push sends nothing.
+    Rows sort by (since, sid) so the roster's mtime order cannot reshuffle an unchanged world into a send.
+    Nothing from retryInfo but status and networkDown: attempt / retryAt tick per attempt. `seq` counts
+    pause-file writes, an event, so a write that put the same state back still yields a new frame."""
+    paused = _retry_paused_on()
+    reason = ""
+    pause_t = 0
+    if paused:
+        r = _retry_pause_reason()
+        reason = r if r in ("limit", "spend") else "manual"
+        pause_t = int(_retry_pause_ts() or 0)
+    rows = []
+    n_tmux = 0
+    live = tmux if isinstance(tmux, dict) else {}
+    for s in _alive_sessions(now, tmux):
+        sid = str(s.get("sid") or "")
+        if not sid:
+            continue
+        if Sessions.backend_for(sid) is _TMUX:
+            n_tmux += 1                                # transcript-only coverage: the detail says so
+        tm = live.get(sid) or {}
+        if tm.get("state") == "retrying":              # the SDK api_retry storm: set per frame, cleared
+            info = tm.get("retryInfo") if isinstance(tm.get("retryInfo"), dict) else {}   # when output resumes
+            status = info.get("status")
+            row = {"kind": "retrying", "cls": _apih_class(status, "", info.get("networkDown")),
+                   "since": int(tm.get("since") or 0)}
+        else:
+            path = s.get("path")
+            e = _api_last_failed(path) if path else None
+            if not e or e.get("tooLong") or e.get("modelLimit") or e.get("authErr") or e.get("refusal"):
+                continue                               # nothing latched, or an on-you failure (the session's own)
+            status = e.get("status")
+            # The word follows the LIVE state: a turn open on the retry prompt (romp's own, or a human's) with
+            # no api_retry frame yet, or a tmux session's whole internal retry, reads 'retrying', not
+            # 'stopped'. The latch only keeps the row counted; since stays the record's time.
+            kind = "retrying" if tm.get("state") == "working" else "blocked"
+            row = {"kind": kind, "cls": _apih_class(status, e.get("category"), None),
+                   "since": int(e.get("t") or 0)}
+        row.update({"sid": sid, "name": s.get("name") or sid[:8], "color": _name_color(sid),
+                    "status": _apih_status(status), "suppressed": _session_retry_suppressed(sid)})
+        rows.append(row)
+    rows.sort(key=lambda r: (r["since"], r["sid"]))
+    cls = ""
+    if rows:
+        counts = {}
+        for r in rows:
+            counts[r["cls"]] = counts.get(r["cls"], 0) + 1
+        cls = max(_APIH_ORDER, key=lambda c: (counts.get(c, 0), -_APIH_ORDER.index(c)))
+    n = len(rows)
+    if paused:
+        state = "paused"
+        text = _APIH_TEXT[reason] + (" · %d waiting" % n if n else "")
+        since = pause_t
+    elif rows:
+        state = "degraded"
+        text = "%s · %d waiting" % (_APIH_TEXT[cls], n)
+        since = min((r["since"] for r in rows if r["since"]), default=0)
+    else:
+        state, text, since = "ok", _APIH_TEXT["ok"], 0
+    return {"type": "apiHealth", "state": state, "cls": cls, "reason": reason, "text": text,
+            "waiting": n, "retrying": sum(1 for r in rows if r["kind"] == "retrying"),
+            "blocked": sum(1 for r in rows if r["kind"] == "blocked"),
+            "since": since, "tmux": n_tmux, "sessions": rows,
+            # the pause file's write count (_RETRY_PAUSE_SEQ): a press on the detail's pause button writes it,
+            # so the frame after the press differs from every frame before it even when the auto-pause put
+            # the same state back within the same second; the shell clears its acknowledgment on that
+            "seq": _RETRY_PAUSE_SEQ[0]}
+
+
+# The last apiHealth frame the shells heard, as its sorted serialization (None = nothing since boot): the
+# _BADGE_LAST pattern. The frame holds no clock, so the whole string is the change key.
+_APIH_LAST = [None]
+
+
+def _api_health_push(frame):
+    """Send the frame to every connected shell when it CHANGED, else nothing. No per-client repost (the
+    _send_client 60 s re-send would repeat an identical frame): a shell that connects gets the last frame
+    from the ready handler (_apih_resend)."""
+    s = json.dumps(frame, sort_keys=True)
+    if s == _APIH_LAST[0]:
+        return
+    _APIH_LAST[0] = s
+    _send_to_app("shell", frame)
+
+
+def _apih_resend(client):
+    """A shell that just sent `ready` paints its API cell from the last frame, verbatim, so an identical
+    frame cannot pulse the cell (the client diffs state and text before touching the DOM). Chat and pane
+    clients get nothing: only the shell owns the rail."""
+    if client.get("app") == "shell" and _APIH_LAST[0] is not None:
+        try:
+            client["send"](_APIH_LAST[0])
+        except Exception:
+            pass
+
+
 # ── Web Push: the same bell events, delivered to the phone (plans/ios-app.md proposal 2; the user
 # 2026-08-07, who wants "needs you" to reach them wherever they are, not just the kernel box's
 # desktop). A device opts in from the shell's bell (mobile tab bar → _LANDING_PUSH_JS): it
@@ -41150,6 +41589,10 @@ def _pusher_cycle_jobs(now, tmux, any_client):
         _auto_resume_retry(now, tmux)
     except Exception:
         sys.stderr.write("auto-resume-retry: %s\n" % traceback.format_exc())
+    try:                                  # the bottom bar's API health cell: built AFTER this cycle's pause
+        _api_health_push(_api_health_frame(now, tmux))   # decisions, every cycle (a connecting shell gets a
+    except Exception:                     # current frame), sent only when it changed
+        sys.stderr.write("api-health-frame: %s\n" % traceback.format_exc())
     try:                                  # a per-session interrupt-suppressed retry re-arms once that thread lands a clean turn
         _auto_resume_session_retry(now, tmux)
     except Exception:
@@ -42475,7 +42918,8 @@ if(window.__rompKeysClose&&window.__rompKeysClose()){closed=true;}
 else{var sp=document.getElementById('rsp-back');
 if(sp&&!sp.hidden&&window.__rompCloseSpend){window.__rompCloseSpend();closed=true;}
 else{var ru=document.getElementById('ru-back');
-if(ru&&ru.classList.contains('on')&&window.__rompUsageClose){window.__rompUsageClose();closed=true;}
+if(ru&&ru.classList.contains('on')&&window.__rompApiClose){window.__rompApiClose();closed=true;}
+else if(ru&&ru.classList.contains('on')&&window.__rompUsageClose){window.__rompUsageClose();closed=true;}
 else{var er=document.getElementById('rerr-back');
 if(er&&!er.hidden&&window.__rompCloseErrs){window.__rompCloseErrs();closed=true;}
 else{var bp=document.getElementById('rbell-back');
@@ -42877,6 +43321,7 @@ tip.style.top=Math.max(6,r.top-tip.offsetHeight-8)+'px';}
 // Pulls fresh first so the numbers aren't a stale boot snapshot; any tap or Escape dismisses.
 window.__rompUsagePanel=function(){
 function openIt(){var h=tipHTML();if(!h)return;
+try{window.__rompApiClose&&window.__rompApiClose();}catch(e){}   // one modal on #ru-back at a time (the API detail does the same)
 // the deeper level is one tap away here too (T247): the rail — and its click — do not exist on a
 // phone, and a compact view must never dead-end (progressive disclosure)
 tip.innerHTML=h+'<div class=ru-tip-more><button class=rsp-btn id=ru-bysession>By session \u2192</button></div>';   // its own row, the hover's button size (T247b review: inside .ru-tip-age it read as a 10px annotation at .55)
@@ -43192,6 +43637,166 @@ pull(false);                                     // fill on load, independent of
 // VERTICAL bars when the left rail ran out of height. The bars are HORIZONTAL in the bottom bar now and only
 // ~text-height tall, so they always fit — nothing to degrade.)
 window.addEventListener('message',function(e){var m=e.data;if(m&&m.romp==='usage')render(m.usage);});})();
+"""
+
+
+# The bottom bar's API health cell: one dot and one word beside the usage readout, painted from the kernel's
+# apiHealth shell push (_api_health_frame), the reading on hover, the detail with its actions pinned on click
+# (or Enter / Space: the cell is a keyboard button). It renders ONLY from the last pushed frame, no fetch, no
+# timer: the frame moves on events, and the cell repaints only when its state or text changed, so the ready
+# re-send of an identical frame cannot pulse it. The detail card is built in the usage tip's grammar and shares
+# its skin (#ah-tip sits beside #ru-tip in every selector) and its backdrop (#ru-back, one modal at a time).
+# The web shell's rail only, for now; the VS Code strip twin (strip.ts apiCell's sibling, with a --st-retrying
+# token) and the phone's Usage-modal section (no rail on the phone) are named follow-ups.
+_LANDING_APIH_JS = """
+(function(){var el=document.getElementById('rail-api');if(!el)return;
+var txt=el.querySelector('.ah-text');
+var tip=document.createElement('div');tip.id='ah-tip';tip.style.display='none';
+tip.setAttribute('role','dialog');tip.setAttribute('aria-label','API health');tip.setAttribute('aria-modal','true');tip.tabIndex=-1;document.body.appendChild(tip);
+var back=document.getElementById('ru-back');
+if(!back){back=document.createElement('div');back.id='ru-back';document.body.appendChild(back);}
+// LAST: the newest frame. pinned: the detail is the modal. held / dirty: a PRIMARY pointer is down over the detail
+// and a frame arrived meanwhile (painted on release). pending: a pause press awaiting the frame that answers it (1 =
+// stop sent, 0 = resume sent, null = none); pendSeq: the pause file's write count (frame.seq) when it was pressed,
+// so the frame that answers is the one whose seq moved. hint: the last failed send's reason, shown under the
+// button. lastX: where the hover anchored, so a re-anchor keeps its place. focusBack: where focus returns when the
+// detail closes.
+var LAST=null,pinned=false,held=false,dirty=false,pending=null,pendSeq=null,hint='',lastX=null,focusBack=null;
+function esc(s){return String(s).replace(/[&<>"]/g,function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];});}
+function hm(ep){return new Date(ep*1000).toTimeString().slice(0,5);}
+// The plain-words pause reasons and the ok line: the kernel's `text` is the headline, these say what it means.
+var PAUSE={limit:'Auto-retry and the judges are paused until your usage limit resets.',
+spend:'Auto-retry and the judges are paused: you have reached the monthly spend limit. Raise it at claude.ai/settings/usage.',
+manual:'Auto-retry and the judges are paused: you stopped them.'};
+var OK='No session is waiting on the API. Auto-retry and the judges are running.';
+var RESUME='Resume all auto-retries',STOP='Stop all auto-retries';   // the chat card's own words
+var NOTSENT='Not sent: the dashboard is disconnected. Try again.';
+var LOST='Connection lost before the answer arrived. When it is back, the button shows the current state.';
+function clsWords(r){if(r.cls==='429')return '429 rate limited';if(r.cls==='529')return '529 overloaded';
+if(r.cls==='offline')return 'offline';return 'error'+(r.status?' '+r.status:'');}
+// The pause control. A press is acknowledged at once (disabled, flipped label, .romp-acted) and STAYS so across
+// frames until the one that answers it: an in-flight pre-press frame must not repaint an enabled button.
+function btnHTML(m){if(pending!==null)return '<button class="ah-btn romp-acted" disabled data-act=pause data-val='+pending+'>'+(pending?RESUME:STOP)+'</button>';
+var v=m.state==='paused'?0:(m.waiting>0?1:-1);if(v<0)return '';
+return '<button class=ah-btn data-act=pause data-val='+v+'>'+(v?STOP:RESUME)+'</button>'+(hint?'<div class=ah-hint>'+esc(hint)+'</div>':'');}
+// A pinned row is a keyboard button too (role, tabindex; Enter / Space run it from the keydown below).
+function rowHTML(r,full){var bg=r.color&&r.color.bg?esc(r.color.bg):'';
+return '<div class="ru-tip-row ah-row'+(full?'':' ah-ro')+'"'+(full?' role=button tabindex=0 data-act=reveal data-sid="'+esc(r.sid)+'"':'')+'>'
++(bg?'<i class=ah-sw style="background:'+bg+'"></i><span class=ah-nm style="color:'+bg+'">':'<i class=ah-sw></i><span class=ah-nm>')+esc(r.name)+'</span>'
++'<span class=ah-desc>'+(r.kind==='retrying'?'retrying':'stopped')+' · '+clsWords(r)+(r.since?' · since '+hm(r.since):'')
++(r.suppressed?' · auto-retry off for this session (you interrupted it)':'')+'</span></div>';}
+// full=false is the HOVER: the same reading with no controls. The hover sits under pointer-events:none and hides
+// on mouseleave, so a button there could not be honored; the click is where the actions live.
+function html(m,full){var h='<div class=ru-tip-win><div class=ru-tip-name><span>API · this machine</span></div>'
++'<div class="ru-tip-row ah-head"><i class=ah-dot data-state='+esc(m.state)+'></i><span class=ah-word>'+esc(m.text)+'</span>'
++(m.since?'<span class=ah-since>since '+hm(m.since)+'</span>':'')+'</div>';
+if(m.state==='paused')h+='<div class=ah-line>'+(PAUSE[m.reason]||PAUSE.manual)+'</div>';
+else if(m.state==='ok')h+='<div class=ah-line>'+OK+'</div>';
+if(full)h+=btnHTML(m);
+h+='</div>';
+var rows=m.sessions||[];
+if(rows.length){h+='<div class=ru-tip-win><div class=ru-tip-name><span>Sessions waiting</span></div>';
+rows.forEach(function(r){h+=rowHTML(r,full);});h+='</div>';}
+if(m.tmux>0)h+='<div class="ru-tip-win ah-line">'+(m.tmux===1?'1 tmux session is seen through its transcript only':m.tmux+' tmux sessions are seen through their transcripts only')
++', so a retry in progress there shows only when it fails or recovers.</div>';
+if(full)h+='<div class="ru-tip-row ah-foot"><span class=ah-link role=button tabindex=0 data-act=usage>Usage and spend</span><span class=ah-link role=button tabindex=0 data-act=log>Log</span></div>';
+return h;}
+// The hover anchors above the rail, centered on the cursor, exactly as the usage tip's showTip does; a re-render
+// re-anchors from the same x, since new rows change the height and the tip hangs ABOVE the rail.
+function anchor(){var r=el.getBoundingClientRect();var x=(typeof lastX==='number')?lastX:(r.left+r.width/2);
+tip.style.left=Math.max(6,Math.min(window.innerWidth-tip.offsetWidth-6,x-tip.offsetWidth/2))+'px';
+tip.style.top=Math.max(6,r.top-tip.offsetHeight-8)+'px';}
+// A re-render replaces the card's nodes, so a focused control would fall to the page body and the next Tab would
+// leave the dialog: the same control (by act and sid) takes focus again in the new markup, else the card does.
+function focusKey(n){return (n&&n.getAttribute)?(n.getAttribute('data-act')||'')+'|'+(n.getAttribute('data-sid')||''):'';}
+function render(){if(!LAST)return;var a=document.activeElement,key=(pinned&&a&&a!==tip&&tip.contains(a))?focusKey(a):null;
+tip.innerHTML=html(LAST,pinned);if(!pinned)anchor();
+if(key!==null){var n=null,all=tip.querySelectorAll('[data-act]');for(var i=0;i<all.length;i++)if(focusKey(all[i])===key){n=all[i];break;}
+try{if(n)n.focus();if(!n||document.activeElement!==n)tip.focus();}catch(e){}}}
+function show(ev){if(!LAST)return;lastX=(ev&&typeof ev.clientX==='number')?ev.clientX:null;
+tip.classList.remove('ru-modal');tip.style.display='block';render();}
+function close(){tip.style.display='none';tip.classList.remove('ru-modal');back.classList.remove('on');pinned=false;
+window.__rompApiClose=null;if(back.onclick===close)back.onclick=null;
+var fb=focusBack;focusBack=null;try{(fb&&fb.focus?fb:el).focus();}catch(e){}}
+// A click PINS the detail as a centered modal over the dimmed dashboard (the usage modal's own backdrop and
+// pattern); Escape lands via _LANDING_ESC_JS (shell AND pane documents), the backdrop tap closes too. An open
+// usage modal is closed FIRST, explicitly: the two share #ru-back, and its one handler must belong to one modal.
+// Focus moves into the detail and comes back to the cell (or wherever it was) on close.
+function open(){if(!LAST)return;try{window.__rompUsageClose&&window.__rompUsageClose();}catch(e){}
+focusBack=document.activeElement;pinned=true;tip.classList.add('ru-modal');tip.style.left='';tip.style.top='';
+tip.style.display='block';render();back.classList.add('on');
+window.__rompApiClose=close;back.onclick=close;try{tip.focus();}catch(e){}}
+// The listeners sit on the STABLE #rail-api cell; __rompApiHealth writes its children, never the cell.
+el.addEventListener('mouseenter',function(ev){if(!pinned)show(ev);});
+el.addEventListener('mouseleave',function(){if(!pinned)tip.style.display='none';});
+el.addEventListener('click',function(){if(pinned)close();else open();});
+el.addEventListener('keydown',function(ev){if(ev.key==='Enter'||ev.key===' '){ev.preventDefault();if(pinned)close();else open();}});
+// Click-safe across a frame (ui/CLAUDE.md): a frame that lands while a pointer is DOWN over the detail is painted
+// on release, never under the press, so the pressed button survives to its click. A PRIMARY release inside the
+// detail is followed by the click, so the flush waits for it (a swap between mouseup and click would detach the
+// target); a release anywhere else flushes at once. Only a primary press arms the defer: no click follows a right
+// or middle button (auxclick and contextmenu do), so a frame deferred under one would stay unpainted until the
+// next frame changed something while the cell already showed the new world. Event-based, no timer.
+tip.addEventListener('pointerdown',function(ev){if(ev.button===0)held=true;});
+function flush(){if(dirty){dirty=false;if(tip.style.display==='block')render();}}
+function release(ev){if(!held)return;held=false;if(ev&&ev.type==='pointerup'&&ev.button===0&&ev.target&&tip.contains(ev.target))return;flush();}
+document.addEventListener('pointerup',release);
+document.addEventListener('pointercancel',release);
+// The detail's actions are DELEGATED on the stable #ah-tip node via data-act: a click, or Enter / Space on a
+// focused row or footer link (the button's own keys fire its click natively, so the key path skips it).
+function actOf(n){while(n&&n!==tip&&!(n.getAttribute&&n.getAttribute('data-act')))n=n.parentNode;return (n&&n!==tip)?n:null;}
+function run(t){var act=t.getAttribute('data-act');
+if(act==='pause'){var v=t.getAttribute('data-val')==='1';
+// focus moves to the dialog BEFORE the button is disabled: a disabled element cannot hold focus, so it would fall
+// to the page body, where the Tab trap below (a listener on the card) no longer sees the keys and a Shift+Tab
+// walks out of the aria-modal dialog. The card is where open() lands focus too; the answering frame's re-render
+// leaves it there (render restores a focused CONTROL only), and the first Tab reaches the first control.
+try{tip.focus();}catch(e){}
+t.disabled=true;t.textContent=v?RESUME:STOP;t.classList.add('romp-acted');pending=v?1:0;pendSeq=LAST?LAST.seq:null;hint='';   // acknowledged before any round trip
+// the shell socket carries the same op the chat card sends; the handler marks the views dirty, and the next
+// cycle's frame answers (its seq moved: the press wrote the pause file). A dead socket says so instead of a
+// silent no-op (fail loudly): the label and the un-pressed styling come back, and the reason sits under the button.
+if(!(window.__rompShellSend&&window.__rompShellSend({type:'setGlobalRetryPaused',value:v}))){pending=null;hint=NOTSENT;dirty=true;}}
+else if(act==='reveal'){var sid=t.getAttribute('data-sid')||'';
+// the feed's own session links post openSession (feed.ts openOrReviveSession) on a socket that carries this
+// dashboard's wid, and the shell socket carries it too (shellWS), so the kernel aims the focus at THIS
+// dashboard's chat alone (_reveal_chat_for), never at every open window's. No pane is toggled here, so nothing
+// about the layout is persisted.
+if(window.__rompShellSend&&window.__rompShellSend({type:'openSession',id:sid}))close();else{hint=NOTSENT;dirty=true;}}
+else if(act==='usage'){close();try{window.__rompUsagePanel&&window.__rompUsagePanel();}catch(e){}}
+else if(act==='log'){close();try{window.__rompOpenErrs&&window.__rompOpenErrs();}catch(e){}}}
+tip.addEventListener('click',function(ev){var t=actOf(ev.target);if(t)run(t);flush();});
+// Keyboard inside the dialog: Tab and Shift+Tab cycle within the card (a focus trap: the page behind a modal is
+// not where Tab should go; Escape is the way out, via _LANDING_ESC_JS). The card itself (tabindex -1) is where
+// focus lands on open, so the first Tab reaches the first control and the first Shift+Tab the last.
+function controls(){var out=[],all=tip.querySelectorAll('[tabindex="0"],button');for(var i=0;i<all.length;i++)if(!all[i].disabled)out.push(all[i]);return out;}
+tip.addEventListener('keydown',function(ev){if(!pinned)return;
+if(ev.key==='Tab'){var f=controls(),i=f.indexOf(document.activeElement);
+if(!f.length){ev.preventDefault();return;}
+if(ev.shiftKey){if(i<=0){ev.preventDefault();f[f.length-1].focus();}}
+else if(i<0||i===f.length-1){ev.preventDefault();f[0].focus();}
+return;}
+if(ev.key!=='Enter'&&ev.key!==' ')return;var t=actOf(ev.target);if(!t||t.tagName==='BUTTON')return;
+ev.preventDefault();run(t);flush();});
+// The shell socket closed (shellWS's onclose, before its redial). A press acknowledged on that socket can no longer be
+// answered: its frame would have come on the socket that died. The redial's ready handler re-sends the last frame
+// VERBATIM (_apih_resend), so a press the kernel never received would otherwise keep the button disabled and relabeled
+// across the reconnect, through closing and reopening the detail, until some unrelated pause write moved the seq.
+// So the acknowledgment clears here, with the reason under the button; if the kernel DID take the press, the re-sent
+// frame's seq has moved and it repaints the truth either way. Painted on release under a held pointer, like a frame.
+window.__rompApiSocketLost=function(){if(pending===null)return;pending=null;pendSeq=null;hint=LOST;
+if(tip.style.display!=='block')return;if(held){dirty=true;return;}render();};
+window.__rompApiHealth=function(m){if(!m||!m.state)return;LAST=m;hint='';   // a frame means the socket is alive
+// the frame that answers a press: the press wrote the pause file, so the kernel's seq moved past the one we saw (a
+// frame from before the press carries that one and keeps the acknowledgment). Whatever state it brings is the
+// truth the button reads, paused again included: a limit or spend pause re-engages within the cycle, and a rule
+// that cleared only on a frame whose state matched the press would leave a Resume disabled and mislabeled for the window.
+if(pending!==null&&(m.seq==null||m.seq!==pendSeq))pending=null;
+if(el.hidden)el.hidden=false;   // the first frame reveals the cell (a kernel that sends none shows nothing)
+if(el.getAttribute('data-state')!==m.state||txt.textContent!==m.text){el.setAttribute('data-state',m.state);txt.textContent=m.text;el.setAttribute('aria-label','API '+m.text);}
+if(tip.style.display!=='block')return;   // an open detail re-renders from the new frame, nothing else does
+if(held){dirty=true;return;}render();};
+})();
 """
 
 
@@ -43934,6 +44539,10 @@ function shellDiag(what,data){var m={type:'clientDiag',surface:'shell',what:what
 if(shellSock&&shellSock.readyState===1){try{shellSock.send(JSON.stringify(m));}catch(e){}}
 else if(diagQ.length<DIAGQ_MAX)diagQ.push(m);}
 window.__rompShellDiag=shellDiag;
+// the bottom bar's API health detail sends its ops (the pause button's setGlobalRetryPaused, a row's openSession)
+// on the shell socket, whose wid aims a reveal at THIS dashboard; false when no socket is open, so the button can
+// say so instead of dropping the op (_LANDING_APIH_JS). Reads shellSock, which each dial replaces.
+window.__rompShellSend=function(o){try{if(shellSock&&shellSock.readyState===1){shellSock.send(JSON.stringify(o));return true;}}catch(e){}return false;};
 function wid(){try{return sessionStorage.getItem('romp:wid')||'';}catch(e){return '';}}
 // Pin the shell to the TRUE visible viewport. body{height:100dvh} alone left a dead slab below the
 // Chat/Feed/Timeline bar on real Android Chrome — dvh didn't track the painted area (the user 2026-06-19).
@@ -44048,9 +44657,13 @@ try{(m.n?navigator.setAppBadge(m.n):navigator.clearAppBadge())['catch'](function
 // the master bell toggled somewhere (this tab included) — repaint ours from the kernel's word
 else if(m&&m.type==='notifyAll'&&window.__rompNotifyAllPaint)window.__rompNotifyAllPaint(!!m.on);
 else if(m&&m.type==='notifyTurns'&&window.__rompNotifyTurnsPaint)window.__rompNotifyTurnsPaint(!!m.on);
+// the bottom bar's API health cell: one frame, painted by _LANDING_APIH_JS (sent on change + on ready)
+else if(m&&m.type==='apiHealth'&&window.__rompApiHealth)window.__rompApiHealth(m);
 // the boot check found a newer romp release — raise the update banner on every open dashboard
 else if(m&&m.type==='updateAvail'&&window.__rompUpdateOffer)window.__rompUpdateOffer(m.cur||'',m.tag||'',m.drift||'',m.boot||'',m.state||'');};
-ws.onclose=function(){if(shellSock===ws)shellSock=null;setTimeout(shellWS,2000);};}catch(e){}}
+// the API health detail's pause acknowledgment rides this socket: a press it carried cannot be answered now (the
+// redial's ready re-sends the last frame verbatim), so the detail is told before the redial (_LANDING_APIH_JS)
+ws.onclose=function(){try{window.__rompApiSocketLost&&window.__rompApiSocketLost();}catch(e){}if(shellSock===ws)shellSock=null;setTimeout(shellWS,2000);};}catch(e){}}
 shellWS();
 var last='chat';try{var s=localStorage.getItem(KT);if(s&&F[s])last=s;}catch(e){}show(last);
 })();
@@ -45174,6 +45787,10 @@ def _landing():
             # a glance (used ahead of elapsed = burning too fast) — then the used-% readout. All inline on one row;
             # the windows sit side-by-side. Full detail (elapsed %, reset countdown, age) stays in the hover panel.
             "#rail-usage{flex:0 0 auto;display:flex;flex-direction:row;align-items:center;gap:16px}"
+            # renderRows empties the cell on a login-only machine (no bars, no spend); as a zero-width flex
+            # item it still paid .rail-scroll's gap on both sides, so the API cell beside it sat 28px from
+            # the pane buttons instead of 16px. Empty means gone.
+            "#rail-usage:empty{display:none}"
             ".ru-w{display:flex;flex-direction:row;align-items:center;gap:7px;cursor:default}"
             ".ru-name{font:600 10px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#9aa4ad;letter-spacing:.02em;white-space:nowrap}"
             ".ru-bars{display:flex;flex-direction:column;gap:2px;flex:0 0 auto}"   # used bar stacked over elapsed bar
@@ -45184,6 +45801,38 @@ def _landing():
             # the tooltip, labelled "last known" and faded, which is honest because it says what it is.
             ".ru-tip-row.ru-unk i{opacity:.3}.ru-tip-row.ru-unk .ru-tip-k,.ru-tip-row.ru-unk .ru-tip-v{color:#8a97a6}"
             ".ru-pct{font:600 10px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#cfe6ff;font-variant-numeric:tabular-nums;white-space:nowrap}"
+            # the API health cell. The dot wears STATUS hexes, never var(--accent): the label gray at .55 for
+            # ok (a healthy API costs no attention), the tab-retrying amber for degraded, the API-error red
+            # (--st-blocked-bg) for paused. The word is .ru-pct's declaration byte for byte (no new font
+            # size), in the label gray when ok and the bright value color otherwise. The same dot, keyed by
+            # its own data-state, heads the detail card.
+            # The cell ships with the hidden attribute and shows on its first frame (the markup below). The UA's
+            # [hidden]{display:none} loses to ANY author display rule, and .ru-w{display:flex} above is one, so
+            # without this author rule the rail would show a gray 'API ok' from page load, and forever on a
+            # kernel that never sends a frame (the #mtabs button[hidden] idiom).
+            "#rail-api[hidden]{display:none}"
+            ".ah-dot{width:7px;height:7px;border-radius:50%;background:#9aa4ad;opacity:.55;flex:0 0 auto}"
+            "#rail-api[data-state=degraded] .ah-dot,.ah-dot[data-state=degraded]{background:#e67e22;opacity:1}"
+            "#rail-api[data-state=paused] .ah-dot,.ah-dot[data-state=paused]{background:#e5484d;opacity:1}"
+            ".ah-text{font:600 10px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#cfe6ff;font-variant-numeric:tabular-nums;white-space:nowrap}"
+            "#rail-api[data-state=ok] .ah-text{color:#9aa4ad}"
+            "#rail-api{cursor:pointer;margin-left:4px}"
+            # the detail card's own rows, in the tip's font and palette (#ah-tip shares #ru-tip's skin below)
+            ".ah-head{gap:7px}.ah-word{font-weight:700;color:#e8eef5}.ah-since{opacity:.55;margin-left:auto}"
+            ".ah-line{margin-top:4px;max-width:340px}"
+            ".ah-btn{margin-top:6px;font:inherit;padding:3px 9px;border-radius:5px;border:1px solid #3a3a3a;background:#2a2a2a;color:#cfd6dd;cursor:pointer}"
+            ".ah-btn[disabled]{opacity:.55;cursor:default}#ah-tip .romp-acted{opacity:.6}"
+            ".ah-row{cursor:pointer;border-radius:4px;margin:2px -4px 0;padding:1px 4px}"
+            ".ah-row:hover{background:rgba(255,255,255,0.06)}"
+            ".ah-sw{width:8px;height:8px;border-radius:2px;background:#6b7a8c;flex:0 0 auto}"
+            ".ah-nm{font-weight:600}.ah-desc{opacity:.75}"
+            ".ah-foot{margin-top:7px;padding-top:5px;border-top:1px solid rgba(255,255,255,0.08);gap:12px}"
+            ".ah-link{cursor:pointer;color:var(--accent)}"
+            # a failed send's reason, under the button it restored; the hover's rows carry no action (.ah-ro),
+            # so no pointer and no hover wash; the pinned detail takes focus as a dialog without a ring on the card
+            ".ah-hint{margin-top:4px;opacity:.75;max-width:340px}"
+            ".ah-row.ah-ro{cursor:default}.ah-row.ah-ro:hover{background:transparent}"
+            "#ah-tip:focus{outline:none}"
             # ONE shared hover panel for BOTH windows (the user 2026-06-26): it reproduces exactly the used/
             # elapsed bars that used to sit under the timeline — per window, a "used" bar (selected colormap)
             # over an "elapsed" bar (slate) with the % + reset countdown, and nothing else (no prose).
@@ -45195,7 +45844,7 @@ def _landing():
             # #ru-tip is a hover tooltip, pointer-events:none) so the pane can actually scroll — which also
             # stops a tap on the panel itself falling through to the dismiss backdrop; only backdrop taps
             # (and Escape) close it now, the modal contract everywhere else on the dashboard.
-            "#ru-tip.ru-modal{left:50%!important;top:44%!important;transform:translate(-50%,-50%);max-width:92vw;"
+            "#ah-tip.ru-modal,#ru-tip.ru-modal{left:50%!important;top:44%!important;transform:translate(-50%,-50%);max-width:92vw;"
             "max-height:84vh;max-height:84dvh;overflow-y:auto;pointer-events:auto;"
             "box-shadow:0 12px 36px #000000aa}"
             # the dismiss backdrop for the mobile Usage modal: below the tip (z 300), above the panes; a tap
@@ -45255,10 +45904,10 @@ def _landing():
             "#rsp-tip{position:fixed;z-index:310;pointer-events:none;display:none;background:#1e1e1e;border:1px solid #3a3a3a;"
             "border-radius:6px;padding:5px 8px;color:#cfd6dd;font:500 11px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;"
             "box-shadow:0 5px 18px rgba(0,0,0,0.45)}#rsp-tip b{color:#e8eef5;font-weight:700}"
-            "#ru-tip{position:fixed;z-index:300;background:#1e1e1e;border:1px solid #3a3a3a;border-radius:7px;"
+            "#ah-tip,#ru-tip{position:fixed;z-index:300;background:#1e1e1e;border:1px solid #3a3a3a;border-radius:7px;"
             "padding:8px 10px;font:500 11px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#cfd6dd;"
             "box-shadow:0 5px 18px rgba(0,0,0,0.45);pointer-events:none;line-height:1.4}"
-            ".ru-tip-win{margin-bottom:8px}#ru-tip .ru-tip-win:last-child{margin-bottom:0}"
+            ".ru-tip-win{margin-bottom:8px}#ah-tip .ru-tip-win:last-child,#ru-tip .ru-tip-win:last-child{margin-bottom:0}"
             # Multi-host breakdown: one COLUMN per host, side by side (the user 2026-08-08 — not one
             # tall stack). flex-wrap lets the mobile modal (92vw cap) fold back to a stack on its own.
             ".ru-tip-cols{display:flex;gap:18px;align-items:flex-start;flex-wrap:wrap}"
@@ -45564,7 +46213,7 @@ def _landing():
             "body.theme-light #rnet-x{color:#5D574E}body.theme-light #rnet-x:hover{color:#1F1E1D}"
             "body.theme-light #rfleet-panel{background:#FFFFFF;border-color:rgba(0,0,0,0.12);color:#1F1E1D;"
             "box-shadow:0 12px 36px rgba(31,26,20,0.18)}"
-            "body.theme-light #ru-tip{background:#FFFFFF;border-color:rgba(0,0,0,0.12);color:#1F1E1D;"
+            "body.theme-light #ah-tip,body.theme-light #ru-tip{background:#FFFFFF;border-color:rgba(0,0,0,0.12);color:#1F1E1D;"
             "box-shadow:0 5px 18px rgba(31,26,20,0.18)}"
             # the usage modal's light steps (T247): same card + hairlines as the other light panels;
             # the data colors are the sessions' own and do not flip
@@ -45588,6 +46237,19 @@ def _landing():
             "body.theme-light .ru-tip-name{color:#1F1E1D}"
             "body.theme-light .ru-name{color:#5D574E}"
             "body.theme-light .ru-pct{color:#1F1E1D}"
+            "body.theme-light .ah-text{color:#1F1E1D}"
+            # the ok dot: the dark label gray at .55 blends into the light rail (about 1.4:1); the light label
+            # color at the same opacity keeps the glyph where the eye expects it. Scoped to the ok state: a
+            # bare `body.theme-light .ah-dot` (0,2,1) would outrank the detail's `.ah-dot[data-state=...]`
+            # state rules (0,2,0), and the card's headline dot would lose its amber and red in the light
+            # theme while the rail's id-scoped dot kept them
+            "body.theme-light #rail-api[data-state=ok] .ah-dot,body.theme-light .ah-dot[data-state=ok]{background:#5D574E}"
+            "body.theme-light #rail-api[data-state=ok] .ah-text{color:#5D574E}"
+            "body.theme-light .ah-word{color:#1F1E1D}"
+            "body.theme-light .ah-btn{background:#F1EAE2;border-color:rgba(0,0,0,0.12);color:#1F1E1D}"
+            "body.theme-light .ah-row:hover{background:rgba(0,0,0,0.05)}"
+            "body.theme-light .ah-row.ah-ro:hover{background:transparent}"
+            "body.theme-light .ah-foot{border-top-color:rgba(0,0,0,0.10)}"
             "body.theme-light .ru-track{background:rgba(0,0,0,0.10)}"
             "body.theme-light #mtabs{background:#E7DED2;border-top-color:#DCD2C4}"
             "body.theme-light #mtabs button{color:#5D574E}"
@@ -45656,6 +46318,15 @@ def _landing():
             # the Claude /usage rate-limit bars (Pro/Max): three compact vertical bar-pairs (used % colored +
             # elapsed % slate), %-label, full detail on hover — side-by-side in the bottom bar.
             "<div id=rail-usage data-keycmd=usage.open></div>"
+            # the API health cell: its own label, a 7px dot, one word, painted by _LANDING_APIH_JS from the
+            # kernel's apiHealth push. Ships HIDDEN: it shows on its first frame, so a kernel that never sends
+            # one shows nothing rather than a false ok. Its own element, not a child of #rail-usage (renderRows
+            # empties that one when there are no bars and no spend). No title (the rail's no-title rule); no
+            # data-keycmd yet. role=button + tabindex=0 make it a keyboard control (Enter / Space open the
+            # detail); aria-label follows the frame's text.
+            "<div id=rail-api class=\"ru-w ru-ah\" hidden role=button tabindex=0 aria-label=\"API ok\" data-state=ok>"
+            "<span class=ru-name>API</span>"
+            "<i class=ah-dot></i><span class=ah-text>ok</span></div>"
             "</div>"   # /.rail-scroll
             # refresh + network + settings, pinned to the far RIGHT (settings last), always visible:
             "<div class=rail-acts>"
@@ -45830,6 +46501,7 @@ def _landing():
             + ("<script src=/dist/age-color-global.js?v=%d></script>" % v) +
             "<script>" + _LANDING_ERRS_JS + "</script>"
             "<script>" + _LANDING_USAGE_JS.replace("__ROMP_LOADER__", json.dumps(_loader_inner())) + "</script>"
+            "<script>" + _LANDING_APIH_JS + "</script>"
             "<script>" + _LANDING_JS + "</script>"
             "<script>" + _LANDING_FOCUS_JS + "</script>"
             "<script>" + _LANDING_ESC_JS + "</script>"
@@ -48423,6 +49095,7 @@ class Handler(BaseHTTPRequestHandler):
                     client["send"](json.dumps({"type": "badge", "n": _BADGE_LAST[0]}))
                 except Exception:
                     pass
+            _apih_resend(client)          # and the bottom bar's API cell, from the last frame (same reason)
         elif msg and msg.get("type") == "setSessionFlag" and msg.get("id") and msg.get("flag"):
             # timeline lane gear → toggle a per-session view flag (e.g. hideFromFeed). Persisted +
             # re-broadcast so the feed drops/restores that session's cards immediately. The notify

--- a/tests/test_api_error_tail.py
+++ b/tests/test_api_error_tail.py
@@ -170,7 +170,7 @@ class ApiErrorTailWindow(unittest.TestCase):
         above also holds against a scan that always starts at byte 0, i.e. with the speedup silently gone."""
         p = self._write(recs)
         starts = []
-        real = km._api_error_scan
+        real = km._api_error_pass                       # the ONE pass both transcript readers share
 
         def recording(path, start):
             starts.append(start)
@@ -178,13 +178,14 @@ class ApiErrorTailWindow(unittest.TestCase):
                 raise AssertionError("the widen loop is not terminating: %r" % starts[:8])
             return real(path, start)
         saved = km._API_ERR_TAIL_WINDOW
-        km._api_error_scan = recording
+        km._api_error_pass = recording
         try:
             km._API_ERR_TAIL_WINDOW = window
             km._api_err_cache.clear()
+            km._api_last_failed_cache.clear()
             got = km._api_error(p)
         finally:
-            km._api_error_scan = real
+            km._api_error_pass = real
             km._API_ERR_TAIL_WINDOW = saved
         return starts, got, p
 
@@ -237,6 +238,222 @@ class ApiErrorTailWindow(unittest.TestCase):
         self.assertIsNotNone(first)
         self.assertIn(p, km._api_err_cache, "an unchanged (mtime,size) must stay cached")
         self.assertEqual(km._api_error(p), first)
+
+
+# ── _api_last_failed: the LATCH behind the bottom bar's API health cell ──────────────────────────────
+from datetime import datetime, timezone
+
+T_BASE = 1_700_000_000
+
+
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _ts_err_rec(t, status=500, category="server_error", text="API Error: 500 server_error"):
+    o = {"type": "assistant", "timestamp": _iso(t), "uuid": "aaaaaaaa-0000-0000-0000-00000000%04d" % (t - T_BASE),
+         "parentUuid": U_PROMPT, "isApiErrorMessage": True, "error": category,
+         "message": {"role": "assistant", "content": [{"type": "text", "text": text}]}}
+    if status is not None:
+        o["apiErrorStatus"] = status
+    return o
+
+
+def _ts_prompt_rec(t, text="try that again"):
+    return {"type": "user", "timestamp": _iso(t), "uuid": U_OTHER,
+            "message": {"role": "user", "content": text}}
+
+
+def _ts_out_rec(t):
+    return {"type": "assistant", "timestamp": _iso(t), "uuid": "aaaaaaaa-0000-0000-0000-0000000000ff",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "back on track"}]}}
+
+
+def _ts_tool_result_rec(t, i=0):
+    return {"type": "user", "timestamp": _iso(t), "uuid": "bbbbbbbb-0000-0000-0000-%012d" % i,
+            "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_%d" % i,
+                                                     "content": "ok"}]}}
+
+
+class ApiLastFailedLatch(unittest.TestCase):
+    """_api_last_failed is _api_error's latched sibling: an isApiErrorMessage record holds until ASSISTANT
+    OUTPUT follows it, through romp's own injected RETRY_MSG and through a human prompt alike, both of which
+    clear _api_error (a retry rightly un-blocks the session; it says nothing about the API). Same tail-first
+    widening, its own (mtime, size) cache; the scan's default keyword leaves _api_error's verdicts untouched."""
+
+    def setUp(self):
+        km._api_err_cache.clear()
+        km._api_last_failed_cache.clear()
+        self.td = tempfile.TemporaryDirectory()
+        self.p = os.path.join(self.td.name, "t.jsonl")
+        self._win = km._API_ERR_TAIL_WINDOW
+
+    def tearDown(self):
+        km._API_ERR_TAIL_WINDOW = self._win
+        km._api_err_cache.clear()
+        km._api_last_failed_cache.clear()
+        self.td.cleanup()
+
+    def _write(self, *recs):
+        with open(self.p, "w") as f:
+            f.write("\n".join(json.dumps(r) for r in recs) + "\n")
+
+    def _append(self, *recs):
+        with open(self.p, "a") as f:
+            f.write("\n".join(json.dumps(r) for r in recs) + "\n")
+
+    def test_romp_s_own_retry_prompt_clears_api_error_but_not_the_latch(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5, status=529, category="overloaded"),
+                    _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG))
+        self.assertIsNone(km._api_error(self.p), "the retry un-blocks the session")
+        e = km._api_last_failed(self.p)
+        self.assertIsNotNone(e, "the API has not answered yet: the record holds")
+        self.assertEqual((e["status"], e["category"], e["t"]), (529, "overloaded", T_BASE + 5))
+
+    def test_a_human_prompt_after_the_error_splits_the_same_way(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5), _ts_prompt_rec(T_BASE + 60, "please continue"))
+        self.assertIsNone(km._api_error(self.p))
+        e = km._api_last_failed(self.p)
+        self.assertEqual((e["status"], e["t"]), (500, T_BASE + 5))
+
+    def test_fresh_assistant_output_clears_both(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5), _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG),
+                    _ts_out_rec(T_BASE + 20))
+        self.assertIsNone(km._api_error(self.p))
+        self.assertIsNone(km._api_last_failed(self.p), "the API answered: the one event that clears the latch")
+
+    def test_a_tool_result_record_clears_neither(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5), _ts_tool_result_rec(T_BASE + 6))
+        self.assertIsNotNone(km._api_error(self.p))
+        self.assertIsNotNone(km._api_last_failed(self.p))
+
+    def test_a_newer_error_record_replaces_the_latched_one(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5, status=529, category="overloaded"),
+                    _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG), _ts_err_rec(T_BASE + 12, status=429, category="rate_limit"))
+        e = km._api_last_failed(self.p)
+        self.assertEqual((e["status"], e["t"]), (429, T_BASE + 12), "a new failed attempt is new information")
+
+    def test_the_on_you_flags_ride_the_latched_record(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5, status=400, category="invalid_request",
+                                                          text="API Error: 400 prompt is too long"),
+                    _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG))
+        self.assertTrue(km._api_last_failed(self.p)["tooLong"], "the frame excludes it by this flag")
+
+    def test_a_refusal_record_marks_the_latched_episode_too(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5, status=400, category="invalid_request"),
+                    _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG), _filler(1), _refusal_rec())
+        self.assertIsNone(km._api_error(self.p), "the prompt cleared the blocking verdict before the refusal record")
+        self.assertTrue(km._api_last_failed(self.p)["refusal"], "the latched record is the one the refusal annotates")
+
+    def test_the_cache_serves_an_unchanged_transcript_and_busts_on_a_size_change(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5))
+        e = km._api_last_failed(self.p)
+        self.assertEqual(e["status"], 500)
+        scan = km._api_error_pass
+        km._api_error_pass = lambda *a, **k: self.fail("an unchanged transcript is served from the cache")
+        try:
+            self.assertIs(km._api_last_failed(self.p), e)
+        finally:
+            km._api_error_pass = scan
+        self._append(_ts_out_rec(T_BASE + 20))                # the size moved: a fresh scan, a fresh answer
+        self.assertIsNone(km._api_last_failed(self.p))
+        self.assertIsNone(km._api_error(self.p), "the sibling reads the same fresh answer")
+
+    def test_the_two_caches_are_independent(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5), _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG))
+        self.assertIsNone(km._api_error(self.p))
+        self.assertIsNotNone(km._api_last_failed(self.p), "a cached None from _api_error is not this answer")
+        self.assertIn(self.p, km._api_err_cache)
+        self.assertIn(self.p, km._api_last_failed_cache)
+
+    def test_the_latch_widens_past_a_tail_of_prompts(self):
+        km._API_ERR_TAIL_WINDOW = 64                       # a window that ends inside the prompts
+        pad = "x" * 200
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5, status=529, category="overloaded"),
+                    *[_ts_prompt_rec(T_BASE + 10 + i, pad) for i in range(6)])
+        self.assertIsNone(km._api_error(self.p), "the default scan decides at the newest prompt")
+        e = km._api_last_failed(self.p)
+        self.assertEqual((e["status"], e["t"]), (529, T_BASE + 5), "the latch widened back to the assistant record")
+
+    def test_the_scan_stamps_the_record_time_and_reads_zero_without_one(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5))
+        err, decided = km._api_error_scan(self.p, 0)
+        self.assertEqual(err["t"], T_BASE + 5)
+        self._write(_prompt_rec(), _err_rec())             # the module's stamp-less records
+        err, _ = km._api_error_scan(self.p, 0)
+        self.assertEqual(err["t"], 0)
+
+    def test_the_default_keyword_is_the_old_scan(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5), _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG))
+        self.assertEqual(km._api_error_scan(self.p, 0), km._api_error_scan(self.p, 0, user_clears=True))
+        self.assertEqual(km._api_error_scan(self.p, 0), (None, True))
+        err, decided = km._api_error_scan(self.p, 0, user_clears=False)
+        self.assertEqual((err["status"], decided), (500, True))
+
+    def test_missing_file_is_none(self):
+        self.assertIsNone(km._api_last_failed(os.path.join(self.td.name, "absent.jsonl")))
+
+    # ── one pass answers both readers ──
+    def _recording(self, passes):
+        real = km._api_error_pass
+        km._api_error_pass = lambda path, start: passes.append(start) or real(path, start)
+        return real
+
+    def test_one_cycle_reads_the_tail_once_for_both_verdicts(self):
+        # Every pusher cycle asks _api_error (the spend-cap check, the feed build) and then _api_last_failed
+        # (the health frame) about the same transcript: one pass over the tail must answer both, in either
+        # order, or a streaming session pays two tail reads and two json parses per cycle on the one hot thread.
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5, status=529, category="overloaded"),
+                    _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG))
+        passes = []
+        real = self._recording(passes)
+        try:
+            self.assertIsNone(km._api_error(self.p))
+            self.assertEqual(km._api_last_failed(self.p)["status"], 529)
+            self.assertEqual(len(passes), 1, "the first read decided both verdicts: %r" % passes)
+            km._api_err_cache.clear()
+            km._api_last_failed_cache.clear()
+            del passes[:]
+            self.assertEqual(km._api_last_failed(self.p)["status"], 529)
+            self.assertIsNone(km._api_error(self.p))
+            self.assertEqual(len(passes), 1, "the other order too: %r" % passes)
+        finally:
+            km._api_error_pass = real
+
+    def test_a_read_that_did_not_reach_an_assistant_record_leaves_the_latch_to_its_own_widening(self):
+        # _api_error's window may decide at a prompt without seeing an assistant record; then it must NOT
+        # cache a latch verdict it never saw, and the latch's own read widens back to the assistant record
+        km._API_ERR_TAIL_WINDOW = 64
+        pad = "x" * 200
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5, status=529, category="overloaded"),
+                    *[_ts_prompt_rec(T_BASE + 10 + i, pad) for i in range(6)])
+        passes = []
+        real = self._recording(passes)
+        try:
+            self.assertIsNone(km._api_error(self.p))
+            self.assertNotIn(self.p, km._api_last_failed_cache, "no assistant record seen: no latch verdict cached")
+            n = len(passes)
+            self.assertEqual(km._api_last_failed(self.p)["status"], 529)
+            self.assertGreater(len(passes), n, "the latch widened on its own")
+            self.assertIsNone(km._api_error(self.p), "and _api_error's own cached verdict stands")
+        finally:
+            km._api_error_pass = real
+
+    def test_the_newest_output_record_s_time_is_kept_beside_the_latch(self):
+        # the spend pause's recovery signal (tests/test_retry_pause_autoresume.py): the time of the newest
+        # ASSISTANT OUTPUT record when it is the newest assistant record, else 0
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5), _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG),
+                    _ts_out_rec(T_BASE + 20))
+        self.assertEqual(km._api_last_output_t(self.p), T_BASE + 20)
+        self._append(_ts_prompt_rec(T_BASE + 30, "and now?"))
+        self.assertEqual(km._api_last_output_t(self.p), T_BASE + 20, "a prompt is not output")
+        self._append(_ts_tool_result_rec(T_BASE + 31))
+        self.assertEqual(km._api_last_output_t(self.p), T_BASE + 20, "nor is a tool result")
+        self._append(_ts_err_rec(T_BASE + 35))
+        self.assertEqual(km._api_last_output_t(self.p), 0, "an error after it: no fresh output stands")
+        self._write(_prompt_rec(), _out_rec())
+        self.assertEqual(km._api_last_output_t(self.p), 0, "a record without a timestamp reads 0")
+        self.assertEqual(km._api_last_output_t(os.path.join(self.td.name, "absent.jsonl")), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_api_health_browser.py
+++ b/tests/test_api_health_browser.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python3
+"""The bottom bar's API health cell, driven in a real browser.
+
+The shell page is kernel-served HTML with inline CSS and JS, so it has no jsdom harness: the source pins in
+tests/test_api_health_rail.py and tests/test_kernel_pane_rail.py hold the SHAPE, and this module holds the
+BEHAVIOR those pins approximate. A scratch copy of km._landing() is served from a temp directory over plain
+HTTP with no kernel behind it (every fetch 404s, which is exactly the pre-frame world the cell's hidden rule
+exists for), and playwright's chromium drives it: frames are handed to window.__rompApiHealth directly,
+presses are dispatched as pointer events, and the driver reports what the DOM did. The page's WebSocket is a
+shim installed before load: it never opens on its own, so the first two phases see the same never-connected
+socket a refused connection gives, without the real socket's close-and-redial every two seconds; the third
+phase opens it, feeds it frames, drops it and watches the redial, the way a kernel behind a dropped tunnel
+would. Skips LOUDLY without the extension's node deps or a browser (CI installs none), the way
+tests/test_awaiting_box_sync.py does.
+
+Synthetic only: an invented sid family, the notes-api demo's session names, no real data."""
+import functools
+import http.server
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+import unittest
+from importlib.machinery import SourceFileLoader
+
+# Hermetic state BEFORE the loads: they resolve their state root at import time, and only pytest runs
+# conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+EXT = os.path.join(os.path.dirname(HERE), "vscode-extension")
+km = SourceFileLoader("romp_kernel_apih_browser", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "77777777-aaaa-4bbb-8ccc-00000000000"     # + a digit: the rail test module's private synthetic family
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1200, height: 800 } });
+page.on("pageerror", () => {});                       // the scratch page has no kernel: its sockets and fetches fail
+// the WebSocket shim: every socket the page opens is recorded in window.__socks and does nothing until the driver
+// opens (__open), feeds (__msg) or drops (__drop) it. readyState follows the real constants.
+await page.addInitScript(() => {
+  function Fake(url) { this.url = String(url); this.readyState = 0; this.sent = []; this.onopen = this.onmessage = this.onclose = this.onerror = null;
+    (window.__socks = window.__socks || []).push(this); }
+  Fake.prototype.send = function (d) { if (this.readyState !== 1) throw new Error("not open"); this.sent.push(String(d)); };
+  Fake.prototype.close = function () { this.__drop(); };
+  Fake.prototype.__open = function () { this.readyState = 1; if (this.onopen) this.onopen({}); };
+  Fake.prototype.__msg = function (o) { if (this.onmessage) this.onmessage({ data: JSON.stringify(o) }); };
+  Fake.prototype.__drop = function () { if (this.readyState === 3) return; this.readyState = 3; if (this.onclose) this.onclose({}); };
+  Fake.CONNECTING = 0; Fake.OPEN = 1; Fake.CLOSING = 2; Fake.CLOSED = 3;
+  window.WebSocket = Fake;
+});
+await page.goto(cfg.url);
+await page.waitForFunction(() => typeof window.__rompApiHealth === "function", null, { timeout: 20000 });
+const R = await page.evaluate((SID) => {
+  const R = { err: {} };
+  window.__realShellSend = window.__rompShellSend;             // the page's own binding, before the steps stub it
+  const step = (name, fn) => { try { fn(); } catch (e) { R.err[name] = String(e && e.stack || e); } };
+  const el = document.getElementById("rail-api"), txt = el.querySelector(".ah-text");
+  const tip = () => document.getElementById("ah-tip");
+  const back = document.getElementById("ru-back");
+  const disp = (n) => getComputedStyle(n).display;
+  const row = (i) => ({ sid: SID + i, name: ["web", "api", "tests", "docs"][i], color: null, kind: "blocked",
+                        cls: "529", status: 529, since: 1700000000 + i, suppressed: false });
+  const frame = (over) => Object.assign({ type: "apiHealth", state: "degraded", cls: "529", reason: "",
+    text: "overloaded · 1 waiting", waiting: 1, retrying: 0, blocked: 1, since: 1700000000, tmux: 0,
+    sessions: [row(1)], seq: 1 }, over || {});
+  window.__frame = frame; window.__row = row;                 // the driver's later phases reuse them
+  const bg = (n) => n ? getComputedStyle(n).backgroundColor : "";
+  const btn = () => tip().querySelector("button[data-act=pause]");
+  // 1. before any frame: the cell is not displayed (the hidden attribute must beat .ru-w's display rule)
+  R.preFrameHidden = el.hidden;
+  R.preFrameDisplay = disp(el);
+  R.usageEmptyDisplay = disp(document.getElementById("rail-usage"));
+  R.role = el.getAttribute("role"); R.tabindex = el.getAttribute("tabindex");
+  // 2. the first frame reveals it and names the state for a screen reader
+  window.__rompApiHealth(frame());
+  R.firstFrameDisplay = disp(el); R.firstFrameText = txt.textContent; R.ariaLabel = el.getAttribute("aria-label");
+  step('hover', () => {
+  // 3. the hover surface is inert: no button, no data-act; a growing frame re-anchors it above the rail
+  el.dispatchEvent(new MouseEvent("mouseenter", { bubbles: false, clientX: el.getBoundingClientRect().left + 10 }));
+  R.hoverShown = tip().style.display === "block";
+  R.hoverButtons = tip().querySelectorAll("button").length;
+  R.hoverActs = tip().querySelectorAll("[data-act]").length;
+  const railTop = el.getBoundingClientRect().top;
+  const b1 = tip().getBoundingClientRect();
+  window.__rompApiHealth(frame({ text: "overloaded · 3 waiting", waiting: 3, blocked: 3, sessions: [row(1), row(2), row(3)] }));
+  const b2 = tip().getBoundingClientRect();
+  R.reanchor = { railTop, before: { top: b1.top, bottom: b1.bottom, h: b1.height }, after: { top: b2.top, bottom: b2.bottom, h: b2.height } };
+  el.dispatchEvent(new MouseEvent("mouseleave"));
+  R.hoverHidden = tip().style.display === "none";
+  });
+  step('keyboard', () => {
+  // 4. keyboard: Enter opens the pinned detail and moves focus into it; Escape closes and puts focus back
+  el.focus();
+  el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+  R.kbOpened = tip().style.display === "block" && tip().classList.contains("ru-modal") && back.classList.contains("on");
+  R.kbFocusInTip = tip().contains(document.activeElement);
+  R.tipRole = tip().getAttribute("role");
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+  R.kbClosed = tip().style.display === "none" && !back.classList.contains("on");
+  R.kbFocusBack = document.activeElement === el;
+  });
+  step('usage', () => {
+  // 5. an open usage modal is closed first, explicitly, so the shared backdrop never serves two modals
+  let usageClosed = false;
+  window.__rompUsageClose = () => { usageClosed = true; back.classList.remove("on"); window.__rompUsageClose = null; };
+  back.classList.add("on");
+  el.click();
+  R.usageClosedFirst = usageClosed && tip().style.display === "block" && tip().classList.contains("ru-modal");
+  });
+  step('clicksafe', () => {
+  // 6. click-safe across a frame: a press held on the button defers the re-render; the release flushes it
+  const sent = []; window.__rompShellSend = (o) => { sent.push(o); return true; };
+  const b0 = btn(); R.pinnedHasButton = !!b0;
+  b0.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+  window.__rompApiHealth(frame({ text: "overloaded · 2 waiting", waiting: 2, blocked: 2, sessions: [row(1), row(2)] }));
+  R.heldKeepsNode = document.contains(b0);
+  R.heldKeepsText = /3 waiting/.test(tip().textContent) && !/2 waiting/.test(tip().textContent);   // the pinned frame stays up
+  b0.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+  b0.click();                                          // the click lands on the button that was pressed
+  R.clickSent = sent.map((o) => o.type + ":" + String(o.value));
+  R.flushedOnClick = /2 waiting/.test(tip().textContent);
+  });
+  step('ack', () => {
+  // 7. the acknowledgment survives frames until one confirms the flip
+  const b1n = btn();
+  R.ack = { disabled: b1n.disabled, label: b1n.textContent, acted: b1n.classList.contains("romp-acted") };
+  window.__rompApiHealth(frame({ text: "overloaded · 2 waiting", waiting: 2, blocked: 2, since: 1700000005, sessions: [row(1), row(2)] }));
+  const b2n = btn();
+  R.ackHeld = { disabled: b2n.disabled, label: b2n.textContent, acted: b2n.classList.contains("romp-acted") };
+  window.__rompApiHealth(frame({ state: "paused", reason: "manual", text: "paused by you · 2 waiting", waiting: 2, blocked: 2, sessions: [row(1), row(2)], seq: 2 }));
+  const b3n = btn();
+  R.confirmed = { disabled: b3n.disabled, label: b3n.textContent, acted: b3n.classList.contains("romp-acted") };
+  });
+  step('resumeLimit', () => {
+  // 7b. Resume during a usage-limit pause: the kernel lifts, the limit re-engages within the cycle, and the frame
+  //     that answers is paused again with a new since and a moved seq. The button must read that truth (enabled
+  //     Resume), not hold a disabled 'Stop' for the rest of the window.
+  const sentR = []; window.__rompShellSend = (o) => { sentR.push(o); return true; };
+  window.__rompApiHealth(frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000010, seq: 5 }));
+  const br = btn(); R.resumeBefore = { disabled: br.disabled, label: br.textContent };
+  br.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+  br.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+  br.click();
+  R.resumeSent = sentR.map((o) => o.type + ":" + String(o.value));
+  const bp = btn(); R.resumePending = { disabled: bp.disabled, label: bp.textContent, acted: bp.classList.contains("romp-acted") };
+  window.__rompApiHealth(frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000010, seq: 5 }));
+  const bs = btn(); R.resumeSameSeq = { disabled: bs.disabled, label: bs.textContent, acted: bs.classList.contains("romp-acted") };
+  window.__rompApiHealth(frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000020, seq: 7 }));
+  const ba = btn(); R.resumeAfter = { disabled: ba.disabled, label: ba.textContent, acted: ba.classList.contains("romp-acted") };
+  R.resumeLine = (tip().querySelector(".ah-line") || {}).textContent || "";
+  // back to the paused world the ack step left, so the failed-send step below presses the same Resume it always did
+  window.__rompApiHealth(frame({ state: "paused", reason: "manual", text: "paused by you · 2 waiting", waiting: 2, blocked: 2, sessions: [row(1), row(2)], seq: 7 }));
+  });
+  step('failed', () => {
+  // 8. a failed send restores the label, drops the acted styling and says why
+  window.__rompShellSend = () => false;
+  const bf = btn();
+  bf.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+  bf.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+  bf.click();
+  const b4n = btn();
+  R.failed = { disabled: b4n.disabled, label: b4n.textContent, acted: b4n.classList.contains("romp-acted"),
+               hint: (tip().querySelector(".ah-hint") || {}).textContent || "" };
+  });
+  step('row', () => {
+  // 9. a session row opens that session the way the feed's own links do: openSession on the socket,
+  //    no pane toggle, nothing persisted
+  const sent2 = []; window.__rompShellSend = (o) => { sent2.push(o); return true; };
+  let toggled = 0; window.__rompPaneToggle = () => { toggled++; };
+  const r0 = tip().querySelector(".ah-row[data-act=reveal]");
+  R.rowHasAct = !!r0;
+  if (r0) { r0.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true })); r0.dispatchEvent(new PointerEvent("pointerup", { bubbles: true })); r0.click(); }
+  R.rowSent = sent2; R.rowToggled = toggled; R.rowClosed = tip().style.display === "none";
+  });
+  step('rowDead', () => {
+  // 9b. the same row through the page's OWN send while no socket is open (the shim never opened the one shellWS
+  //     dialed at load): the row says so under the button and the detail stays open. A frame first: it clears the
+  //     failed step's hint, so the hint read here is this row's own.
+  window.__rompShellSend = window.__realShellSend;
+  window.__rompApiHealth(frame({ state: "paused", reason: "manual", text: "paused by you · 2 waiting", waiting: 2, blocked: 2, sessions: [row(1), row(2)], seq: 7 }));
+  el.click();                                              // pin the detail again (the row step closed it)
+  const hintBefore = (tip().querySelector(".ah-hint") || {}).textContent || "";
+  const rd = tip().querySelector(".ah-row[data-act=reveal]");
+  rd.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true })); rd.dispatchEvent(new PointerEvent("pointerup", { bubbles: true })); rd.click();
+  R.rowDead = { hintBefore, open: tip().style.display === "block", hint: (tip().querySelector(".ah-hint") || {}).textContent || "" };
+  if (tip().style.display === "block") el.click();        // close it again (only if it is still open)
+  });
+  step('light', () => {
+  // 10. the light theme's ok dot
+  document.body.classList.add("theme-light");
+  window.__rompApiHealth(frame({ state: "ok", cls: "", text: "ok", waiting: 0, blocked: 0, since: 0, sessions: [] }));
+  R.lightDot = getComputedStyle(el.querySelector(".ah-dot")).backgroundColor;
+  R.lightDotOpacity = getComputedStyle(el.querySelector(".ah-dot")).opacity;
+  });
+  step('lightState', () => {
+  // 11. light theme, degraded and paused: the detail's headline dot wears the rail dot's color (a bare light rule
+  //     would outrank the state rules and paint it the label gray)
+  window.__rompApiHealth(frame({ seq: 8 }));
+  el.click();                                              // pin the detail (the row step closed it)
+  const head = () => tip().querySelector(".ah-head .ah-dot");
+  R.lightDegraded = { rail: bg(el.querySelector(".ah-dot")), head: bg(head()), headOpacity: getComputedStyle(head()).opacity };
+  window.__rompApiHealth(frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000010, seq: 8 }));
+  R.lightPaused = { rail: bg(el.querySelector(".ah-dot")), head: bg(head()) };
+  window.__rompApiHealth(frame({ state: "ok", cls: "", text: "ok", waiting: 0, blocked: 0, since: 0, sessions: [], seq: 8 }));
+  R.lightOkHead = { head: bg(head()), headOpacity: getComputedStyle(head()).opacity };
+  el.click();                                              // close it again
+  document.body.classList.remove("theme-light");
+  });
+  return R;
+}, cfg.sid);
+// phase 2: a real keyboard and a real mouse. Synthetic key events do not move focus, and a synthetic right button
+// fires no contextmenu, so these ride playwright's input instead of page.evaluate.
+R.err2 = {};
+const step2 = async (name, fn) => { try { await fn(); } catch (e) { R.err2[name] = String(e && e.stack || e); } };
+const active = () => page.evaluate(() => { const a = document.activeElement, t = document.getElementById("ah-tip");
+  return (a.tagName + (a.getAttribute("data-act") ? "." + a.getAttribute("data-act") : "") + (t.contains(a) ? "" : "!out")); });
+await step2('tab', async () => {
+  // 12. Tab cycles within the open dialog: button, row, Usage, Log, then the button again; Shift+Tab runs back
+  await page.evaluate(() => { window.__sent2 = []; window.__rompShellSend = (o) => { window.__sent2.push(o); return true; };
+    window.__usageOpened = 0; window.__rompUsagePanel = () => { window.__usageOpened++; };
+    window.__rompApiHealth(window.__frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000010, seq: 9 }));
+    document.getElementById("rail-api").focus(); });
+  await page.keyboard.press("Enter");
+  R.tabOpened = await page.evaluate(() => document.getElementById("ah-tip").classList.contains("ru-modal") && document.getElementById("ah-tip").contains(document.activeElement));
+  R.tabAria = await page.evaluate(() => document.getElementById("ah-tip").getAttribute("aria-modal"));
+  const seq = [];
+  for (let i = 0; i < 6; i++) { await page.keyboard.press("Tab"); seq.push(await active()); }
+  R.tabSeq = seq;
+  const back = [];
+  for (let i = 0; i < 3; i++) { await page.keyboard.press("Shift+Tab"); back.push(await active()); }
+  R.tabBack = back;
+});
+await step2('enterRow', async () => {
+  // 13. Enter on a focused row opens that session; the dialog closes
+  await page.evaluate(() => { const r = document.querySelector("#ah-tip .ah-row[data-act=reveal]"); r.focus(); });
+  R.rowFocused = await active();
+  await page.keyboard.press("Enter");
+  R.enterRowSent = await page.evaluate(() => window.__sent2.map((o) => o.type + ":" + o.id));
+  R.enterRowClosed = await page.evaluate(() => document.getElementById("ah-tip").style.display === "none");
+});
+await step2('enterUsage', async () => {
+  // 14. Space on the focused Usage link opens the usage modal; a frame while a row is focused keeps focus on it
+  await page.evaluate(() => { document.getElementById("rail-api").focus(); });
+  await page.keyboard.press("Enter");
+  await page.evaluate(() => { document.querySelector("#ah-tip .ah-row[data-act=reveal]").focus();
+    window.__rompApiHealth(window.__frame({ state: "paused", reason: "limit", text: "paused · usage limit · 2 waiting", waiting: 2, blocked: 2, since: 1700000010, seq: 9, sessions: [window.__row(1), window.__row(2)] })); });
+  R.focusAfterFrame = await active();
+  await page.evaluate(() => { document.querySelector("#ah-tip .ah-link[data-act=usage]").focus(); });
+  await page.keyboard.press("Space");
+  R.usageOpened = await page.evaluate(() => window.__usageOpened);
+  R.usageClosedTip = await page.evaluate(() => document.getElementById("ah-tip").style.display === "none");
+});
+await step2('rightButton', async () => {
+  // 15. a right-button press over the detail does not defer a frame (no click follows it). The scratch page has
+  //     no kernel, so the boot splash (#romp-boot, a full-window overlay) never clears and would take every real
+  //     mouse event: it goes first, and each press records that it landed on the card.
+  await page.evaluate(() => { const b = document.getElementById("romp-boot"); if (b) b.remove();
+    window.__rompApiHealth(window.__frame({ seq: 9 })); document.getElementById("rail-api").click(); });
+  const head = () => page.evaluate(() => { const r = document.querySelector("#ah-tip .ah-head").getBoundingClientRect(); return { x: r.left + 8, y: r.top + r.height / 2 }; });
+  const inside = (b) => page.evaluate(([x, y]) => document.getElementById("ah-tip").contains(document.elementFromPoint(x, y)), [b.x, b.y]);
+  const box = await head();
+  R.rightInside = await inside(box);
+  await page.mouse.move(box.x, box.y);
+  await page.mouse.down({ button: "right" });
+  await page.evaluate(() => { window.__rompApiHealth(window.__frame({ text: "overloaded · 5 waiting", waiting: 5, blocked: 5, seq: 9,
+    sessions: [1, 2, 3, 4].map(window.__row).concat([Object.assign(window.__row(1), { sid: "x5", name: "five" })]) })); });
+  R.rightHeldPainted = await page.evaluate(() => /5 waiting/.test(document.getElementById("ah-tip").textContent));
+  await page.mouse.up({ button: "right" });
+  R.rightReleasedPainted = await page.evaluate(() => /5 waiting/.test(document.getElementById("ah-tip").textContent));
+  // and the primary press still defers, then paints on release + click. The five-row frame grew the centered
+  // card, so the head moved: measure again.
+  const box2 = await head();
+  R.primaryInside = await inside(box2);
+  await page.mouse.move(box2.x, box2.y);
+  await page.mouse.down();
+  await page.evaluate(() => { window.__rompApiHealth(window.__frame({ text: "overloaded · 6 waiting", waiting: 6, blocked: 6, seq: 9,
+    sessions: [1, 2, 3, 4].map(window.__row).concat([Object.assign(window.__row(1), { sid: "x5", name: "five" }), Object.assign(window.__row(2), { sid: "x6", name: "six" })]) })); });
+  R.primaryHeldPainted = await page.evaluate(() => /6 waiting/.test(document.getElementById("ah-tip").textContent));
+  await page.mouse.up();
+  R.primaryReleasedPainted = await page.evaluate(() => /6 waiting/.test(document.getElementById("ah-tip").textContent));
+});
+await step2('pressFocus', async () => {
+  // 16. a keyboard press on the pause button: the button is disabled at once, and a disabled element cannot hold
+  //     focus, so focus would fall to BODY, where the card's Tab trap no longer sees the keys and a Shift+Tab walks
+  //     out of the aria-modal dialog. Focus moves to the card before the disable; the trap holds.
+  await page.evaluate(() => { document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    window.__sent3 = []; window.__rompShellSend = (o) => { window.__sent3.push(o); return true; };
+    window.__rompApiHealth(window.__frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000010, seq: 12 }));
+    document.getElementById("rail-api").focus(); });
+  await page.keyboard.press("Enter");
+  await page.keyboard.press("Tab");
+  R.pressFocusBefore = await active();
+  await page.keyboard.press("Space");
+  R.pressSent = await page.evaluate(() => window.__sent3.map((o) => o.type + ":" + String(o.value)));
+  R.pressFocusAfter = await active();
+  R.pressButton = await page.evaluate(() => { const b = document.querySelector("#ah-tip button[data-act=pause]"); return { disabled: b.disabled, label: b.textContent }; });
+  await page.keyboard.press("Shift+Tab");
+  R.pressShiftTab = await active();
+  await page.keyboard.press("Tab");
+  R.pressTabBack = await active();
+  await page.evaluate(() => { document.getElementById("ah-tip").focus();
+    window.__rompApiHealth(window.__frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000020, seq: 13 })); });
+  R.pressAnswerFocus = await active();
+  await page.keyboard.press("Tab");
+  R.pressAnswerTab = await active();
+  await page.keyboard.press("Escape");
+});
+// phase 3: the shell socket itself. The shim stands in for the kernel's end: the driver opens the socket shellWS
+// dialed at load, feeds it frames, presses through the REAL __rompShellSend, drops the socket and waits for the
+// redial. The shell's own client-diag rows may ride the same socket; only the frames the cell cares about are read.
+await step2('socket', async () => {
+  // 17. a press acknowledged on a socket that then dies: the redial's ready re-sends the last frame verbatim (same
+  //     seq), so nothing else would clear the acknowledgment; the close clears it and says why, the re-sent frame
+  //     repaints the truth, and the next press rides the new socket
+  const sock = (i) => page.evaluate((i) => { const s = window.__socks[i]; return s ? { url: s.url, state: s.readyState,
+    sent: s.sent.filter((d) => !/"clientDiag"/.test(d)) } : null; }, i);
+  const open = (i) => page.evaluate((i) => { window.__socks[i].__open(); }, i);
+  const drop = (i) => page.evaluate((i) => { window.__socks[i].__drop(); }, i);
+  const feed = (i, over) => page.evaluate(([i, over]) => { window.__socks[i].__msg(window.__frame(over)); }, [i, over]);
+  const redial = (n) => page.waitForFunction((n) => window.__socks.length >= n, n, { timeout: 8000 });
+  const press = () => page.evaluate(() => { const b = document.querySelector("#ah-tip button[data-act=pause]");
+    b.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true })); b.dispatchEvent(new PointerEvent("pointerup", { bubbles: true })); b.click(); });
+  const btnState = () => page.evaluate(() => { const b = document.querySelector("#ah-tip button[data-act=pause]"); const h = document.querySelector("#ah-tip .ah-hint");
+    return { disabled: b.disabled, label: b.textContent, acted: b.classList.contains("romp-acted"), hint: h ? h.textContent : "" }; });
+  const PAUSED = { state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000010, seq: 20 };
+  R.sockCount = await page.evaluate(() => window.__socks.length);
+  R.sock0 = await sock(0);
+  // the steps above replaced window.__rompShellSend with stubs; the page's own binding sends on the live shell socket
+  await page.evaluate(() => { window.__rompShellSend = window.__realShellSend; });
+  R.shellSendRestored = await page.evaluate(() => typeof window.__rompShellSend);
+  await drop(0);
+  await redial(2);
+  R.sockRedialed = await page.evaluate(() => window.__socks.length);
+  await open(1);
+  R.sock1Ready = (await sock(1)).sent;
+  await feed(1, PAUSED);
+  R.sockPainted = await page.evaluate(() => document.getElementById("rail-api").querySelector(".ah-text").textContent);
+  await page.evaluate(() => { document.getElementById("rail-api").click(); });
+  await press();
+  R.sockPressSent = (await sock(1)).sent;
+  R.sockAcked = await btnState();
+  await drop(1);
+  R.sockDropped = await btnState();
+  await press();                                           // no socket is open now: the page's own send refuses
+  R.sockDeadPress = await btnState();
+  await redial(3);
+  R.sock2 = await sock(2);
+  await open(2);
+  R.sock2Ready = (await sock(2)).sent;
+  await feed(2, PAUSED);                                   // the redial's ready re-sends the last frame verbatim
+  R.sockResent = await btnState();
+  await press();
+  R.sock2Sent = (await sock(2)).sent;
+  R.sock1After = (await sock(1)).sent;
+  // and the other outcome: the kernel DID take the press before the socket died, so the re-sent frame's seq has moved
+  await drop(2);
+  await redial(4);
+  await open(3);
+  await feed(3, { text: "overloaded · 1 waiting", seq: 21 });
+  R.sockMoved = await btnState();
+  await page.evaluate(() => { document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })); });
+});
+if (cfg.shots) await page.screenshot({ path: cfg.shots });
+fs.writeSync(1, "RESULT:" + JSON.stringify(R) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class _Quiet(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+
+class ServedCell(unittest.TestCase):
+    """One browser run over the scratch page; each test reads one facet of what it reported."""
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here): the served cell needs a browser")
+        cls.lab = tempfile.mkdtemp(prefix="apih-browser-")
+        # class cleanups run when setUpClass raises too (a failed driver), where tearDownClass would not
+        cls.addClassCleanup(shutil.rmtree, cls.lab, ignore_errors=True)
+        html = km._landing()
+        with open(os.path.join(cls.lab, "index.html"), "w") as f:
+            f.write(html if isinstance(html, str) else html.decode("utf-8"))
+        cls.srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), functools.partial(_Quiet, directory=cls.lab))
+        cls.addClassCleanup(cls.srv.server_close)
+        cls.thr = threading.Thread(target=cls.srv.serve_forever, daemon=True)
+        cls.thr.start()
+        cfg = os.path.join(cls.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"url": "http://127.0.0.1:%d/" % cls.srv.server_address[1], "sid": SID,
+                       "shots": os.environ.get("APIH_BROWSER_SHOT", "")}, f)
+        driver = os.path.join(cls.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        try:
+            p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=180,
+                               env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        finally:
+            cls.srv.shutdown()
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this machine: the served cell needs one (CI installs none)")
+        if p.returncode != 0:
+            raise AssertionError("driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        if line is None:
+            raise AssertionError("driver printed no result:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        cls.R = json.loads(line[len("RESULT:"):])
+
+    def test_the_cell_is_not_displayed_before_the_first_frame(self):
+        # the UA's [hidden]{display:none} loses to the author rule .ru-w{display:flex}, so without an author
+        # [hidden] rule the rail would show a gray 'API ok' from page load, and forever on a kernel that sends no frame
+        self.assertTrue(self.R["preFrameHidden"], "the markup ships the attribute")
+        self.assertEqual(self.R["preFrameDisplay"], "none", "and the attribute must actually hide it: %r" % self.R)
+        self.assertEqual(self.R["firstFrameDisplay"], "flex", "the first frame reveals the cell")
+        self.assertEqual(self.R["firstFrameText"], "overloaded · 1 waiting")
+
+    def test_the_driver_hit_no_script_error(self):
+        self.assertEqual(self.R["err"], {})
+
+    def test_the_light_theme_gives_the_ok_dot_the_label_color(self):
+        # .ah-dot's dark label gray at .55 blends into the light rail (about 1.4:1), so the ok glyph would vanish
+        self.assertEqual(self.R["lightDot"], "rgb(93, 87, 78)", "errors: %r" % self.R.get("err"))
+        self.assertEqual(self.R["lightDotOpacity"], "0.55")
+
+    def test_an_emptied_usage_cell_takes_no_gap(self):
+        # renderRows empties #rail-usage on a login-only machine; as a zero-width flex item it would still pay the
+        # scroll group's gap on both sides, so the API cell sat 28px from the pane buttons instead of 16px
+        self.assertEqual(self.R["usageEmptyDisplay"], "none")
+
+    def test_the_cell_is_a_keyboard_reachable_button_that_names_its_state(self):
+        self.assertEqual((self.R["role"], self.R["tabindex"]), ("button", "0"))
+        self.assertEqual(self.R["ariaLabel"], "API overloaded · 1 waiting")
+        self.assertTrue(self.R["kbOpened"], "Enter opens the pinned detail: %r" % self.R.get("err"))
+        self.assertTrue(self.R["kbFocusInTip"], "focus moves into the detail")
+        self.assertEqual(self.R["tipRole"], "dialog")
+        self.assertTrue(self.R["kbClosed"], "Escape closes it")
+        self.assertTrue(self.R["kbFocusBack"], "and focus returns to the cell")
+
+    def test_the_hover_tip_is_inert_and_re_anchors_when_a_frame_grows_it(self):
+        self.assertTrue(self.R["hoverShown"])
+        self.assertEqual((self.R["hoverButtons"], self.R["hoverActs"]), (0, 0), "no controls under pointer-events:none")
+        ra = self.R["reanchor"]
+        self.assertGreater(ra["after"]["h"], ra["before"]["h"], "three rows are taller than one: %r" % ra)
+        self.assertLessEqual(ra["after"]["bottom"], ra["railTop"] + 1, "the grown tip still hangs above the rail: %r" % ra)
+        self.assertTrue(self.R["hoverHidden"])
+
+    def test_an_open_usage_modal_is_closed_before_the_detail_opens(self):
+        self.assertTrue(self.R["usageClosedFirst"], "errors: %r" % self.R.get("err"))
+
+    def test_a_press_held_across_a_frame_still_lands_and_the_release_flushes_the_frame(self):
+        self.assertTrue(self.R["pinnedHasButton"])
+        self.assertTrue(self.R["heldKeepsNode"], "the pressed button must survive the frame: %r" % self.R.get("err"))
+        self.assertTrue(self.R["heldKeepsText"], "the re-render is deferred while the pointer is down")
+        self.assertEqual(self.R["clickSent"], ["setGlobalRetryPaused:true"], "the click landed on the pressed button")
+        self.assertTrue(self.R["flushedOnClick"], "the deferred frame is painted once the press is over")
+
+    def test_the_acknowledgment_holds_until_the_frame_that_answers_the_press(self):
+        acked = {"disabled": True, "label": "Resume all auto-retries", "acted": True}
+        self.assertEqual(self.R["ack"], acked)
+        self.assertEqual(self.R["ackHeld"], acked, "a frame from before the press (same seq) must not repaint an enabled Stop")
+        self.assertEqual(self.R["confirmed"], {"disabled": False, "label": "Resume all auto-retries", "acted": False})
+
+    def test_a_resume_during_a_usage_limit_pause_reads_the_truth_when_the_pause_re_engages(self):
+        # a rule that cleared the acknowledgment only on a frame whose state matched the press would leave the
+        # button disabled and reading 'Stop all auto-retries' for the rest of the window, since a limit pause
+        # re-engages within the cycle
+        self.assertEqual(self.R["resumeBefore"], {"disabled": False, "label": "Resume all auto-retries"}, "errors: %r" % self.R.get("err"))
+        self.assertEqual(self.R["resumeSent"], ["setGlobalRetryPaused:false"])
+        self.assertEqual(self.R["resumePending"], {"disabled": True, "label": "Stop all auto-retries", "acted": True})
+        self.assertEqual(self.R["resumeSameSeq"], {"disabled": True, "label": "Stop all auto-retries", "acted": True},
+                         "a frame carrying the seq we pressed on predates the press")
+        self.assertEqual(self.R["resumeAfter"], {"disabled": False, "label": "Resume all auto-retries", "acted": False},
+                         "the frame that answers (seq moved) re-enables the button with the truth: paused again")
+        self.assertEqual(self.R["resumeLine"], "Auto-retry and the judges are paused until your usage limit resets.")
+
+    def test_a_failed_send_restores_the_label_drops_the_acted_styling_and_says_why(self):
+        f = self.R["failed"]
+        self.assertEqual((f["disabled"], f["label"], f["acted"]), (False, "Resume all auto-retries", False), repr(f))
+        self.assertIn("Not sent", f["hint"])
+
+    def test_a_session_row_opens_that_session_the_way_the_feed_s_links_do(self):
+        self.assertTrue(self.R["rowHasAct"])
+        self.assertEqual(self.R["rowSent"], [{"type": "openSession", "id": SID + "1"}])
+        self.assertEqual(self.R["rowToggled"], 0, "no pane toggle, nothing persisted")
+        self.assertTrue(self.R["rowClosed"])
+
+    def test_a_row_on_a_dead_socket_says_so_and_keeps_the_detail_open(self):
+        # the page's own __rompShellSend, not a stub: no socket was ever opened, so it refuses and the row says why
+        self.assertEqual(self.R["rowDead"], {"hintBefore": "", "open": True, "hint": "Not sent: the dashboard is disconnected. Try again."},
+                         "errors: %r" % self.R.get("err"))
+
+    def test_the_light_theme_keeps_the_head_dot_s_state_colors(self):
+        # a bare light rule on the dot would outrank the state rules, so the detail's headline dot would read the
+        # label gray while the rail's id-scoped dot kept amber and red
+        amber, red, gray = "rgb(230, 126, 34)", "rgb(229, 72, 77)", "rgb(93, 87, 78)"
+        self.assertEqual(self.R["lightDegraded"], {"rail": amber, "head": amber, "headOpacity": "1"}, "errors: %r" % self.R.get("err"))
+        self.assertEqual(self.R["lightPaused"], {"rail": red, "head": red})
+        self.assertEqual(self.R["lightOkHead"], {"head": gray, "headOpacity": "0.55"})
+
+    def test_the_driver_s_second_phase_hit_no_error(self):
+        self.assertEqual(self.R["err2"], {})
+
+    def test_tab_cycles_within_the_open_dialog(self):
+        self.assertTrue(self.R["tabOpened"], "errors: %r" % self.R.get("err2"))
+        self.assertEqual(self.R["tabAria"], "true")
+        self.assertEqual(self.R["tabSeq"], ["BUTTON.pause", "DIV.reveal", "SPAN.usage", "SPAN.log", "BUTTON.pause", "DIV.reveal"])
+        self.assertEqual(self.R["tabBack"], ["BUTTON.pause", "SPAN.log", "SPAN.usage"])
+
+    def test_enter_on_a_row_opens_its_session_and_space_on_a_footer_link_runs_it(self):
+        self.assertEqual(self.R["rowFocused"], "DIV.reveal", "errors: %r" % self.R.get("err2"))
+        self.assertEqual(self.R["enterRowSent"], ["openSession:" + SID + "1"])
+        self.assertTrue(self.R["enterRowClosed"])
+        self.assertEqual(self.R["focusAfterFrame"], "DIV.reveal", "a frame re-renders the card; focus stays on the same row")
+        self.assertEqual(self.R["usageOpened"], 1)
+        self.assertTrue(self.R["usageClosedTip"])
+
+    def test_a_keyboard_press_on_the_pause_button_keeps_focus_inside_the_dialog(self):
+        self.assertEqual(self.R["pressFocusBefore"], "BUTTON.pause", "errors: %r" % self.R.get("err2"))
+        self.assertEqual(self.R["pressSent"], ["setGlobalRetryPaused:false"], "Space ran the button once")
+        self.assertEqual(self.R["pressButton"], {"disabled": True, "label": "Stop all auto-retries"}, "acknowledged")
+        self.assertEqual(self.R["pressFocusAfter"], "DIV", "focus is on the card, inside the dialog, not on BODY")
+        self.assertEqual(self.R["pressShiftTab"], "SPAN.log", "the trap still applies: Shift+Tab wraps to the last control")
+        self.assertEqual(self.R["pressTabBack"], "DIV.reveal", "Tab from the last control wraps to the first enabled one (the disabled button is skipped)")
+        self.assertEqual(self.R["pressAnswerFocus"], "DIV", "the answering frame's re-render leaves focus on the card")
+        self.assertEqual(self.R["pressAnswerTab"], "BUTTON.pause", "and the first Tab reaches the re-enabled button")
+
+    def test_the_driver_s_socket_phase_hit_no_error(self):
+        self.assertNotIn("socket", self.R["err2"], self.R["err2"].get("socket"))
+
+    def test_a_press_the_socket_lost_is_cleared_on_the_close_and_the_redial_repaints_the_truth(self):
+        # pending is cleared by a failed send or a frame with a moved seq; the redial's ready re-sends the last
+        # frame verbatim, so a press the kernel never received would keep the button disabled and relabeled across
+        # the reconnect until an unrelated pause write moved the seq
+        R = self.R
+        ready, pressed = '{"type":"ready"}', '{"type":"setGlobalRetryPaused","value":false}'
+        self.assertEqual(R["sockCount"], 1, "shellWS dialed once at load, and the shim let it stay unopened: %r" % R.get("err2"))
+        self.assertIn("/ws?app=shell", R["sock0"]["url"])
+        self.assertEqual(R["shellSendRestored"], "function", "the shell's own send survives the driver's stubs")
+        self.assertEqual(R["sockRedialed"], 2, "a close redials")
+        self.assertEqual(R["sock1Ready"], [ready], "the open sends ready")
+        self.assertEqual(R["sockPainted"], "paused · usage limit · 1 waiting", "a frame on the socket paints the cell")
+        self.assertEqual(R["sockPressSent"], [ready, pressed], "the press rode the real socket")
+        self.assertEqual(R["sockAcked"], {"disabled": True, "label": "Stop all auto-retries", "acted": True, "hint": ""})
+        self.assertEqual(R["sockDropped"], {"disabled": False, "label": "Resume all auto-retries", "acted": False,
+                                            "hint": "Connection lost before the answer arrived. When it is back, the button shows the current state."},
+                         "the close clears the acknowledgment and says why")
+        self.assertEqual(R["sockDeadPress"], {"disabled": False, "label": "Resume all auto-retries", "acted": False,
+                                              "hint": "Not sent: the dashboard is disconnected. Try again."},
+                         "a press while no socket is open: the shell's own send refuses (shellSock is null until the redial opens)")
+        self.assertIn("/ws?app=shell", R["sock2"]["url"])
+        self.assertEqual(R["sock2Ready"], [ready], "the redial sends ready")
+        self.assertEqual(R["sockResent"], {"disabled": False, "label": "Resume all auto-retries", "acted": False, "hint": ""},
+                         "the re-sent frame (same seq) repaints the truth and drops the hint")
+        self.assertEqual(R["sock2Sent"], [ready, pressed], "the next press rides the new socket")
+        self.assertEqual(R["sock1After"], [ready, pressed], "and nothing more reached the dead one")
+        self.assertEqual(R["sockMoved"], {"disabled": False, "label": "Stop all auto-retries", "acted": False, "hint": ""},
+                         "a re-sent frame with a moved seq (the kernel took the press) repaints that truth")
+
+    def test_only_a_primary_press_defers_a_frame(self):
+        self.assertTrue(self.R["rightInside"], "the right press landed on the card; errors: %r" % self.R.get("err2"))
+        self.assertTrue(self.R["rightHeldPainted"], "a right button arms nothing: the frame paints at once")
+        self.assertTrue(self.R["rightReleasedPainted"])
+        self.assertTrue(self.R["primaryInside"], "the primary press landed on the card")
+        self.assertFalse(self.R["primaryHeldPainted"], "the primary press still defers")
+        self.assertTrue(self.R["primaryReleasedPainted"], "and the release (outside any button, no click to wait for) paints it")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api_health_rail.py
+++ b/tests/test_api_health_rail.py
@@ -1,0 +1,615 @@
+#!/usr/bin/env python3
+"""The bottom bar's API health cell: one dot and one word beside the usage readout, answering 'is the API
+serving my sessions'. The kernel builds one apiHealth frame per pusher cycle from the merged live map's
+retrying state, each alive transcript's LATCHED newest API error (_api_last_failed) and the retry-pause
+file, and pushes it to the shells only when it changed; the shell paints the cell from the frame and builds
+the click detail from it, with no fetch and no timer.
+
+The rule these tests pin: every field moves on one named event and never on a clock, so two computes over
+the same world are byte-identical and send nothing. Synthetic fixtures only (a private synthetic sid family,
+the notes-api demo's web / api / tests names, no paths or error text in any frame)."""
+import inspect
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest import mock
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads: they resolve their state root at import time, and only pytest runs
+# conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_apih", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_apih", os.path.join(BIN, "..", "kernel", "sdk_backend.py")).load_module()
+
+# A PRIVATE synthetic sid family for this module (never the shared 11111111-2222 placeholder, never real).
+SID = ["77777777-aaaa-4bbb-8ccc-00000000000%d" % i for i in range(1, 6)]
+NAMES = ["web", "api", "tests", "docs", "build"]
+T_STORM = 1_700_000_000          # a storm turn's start (SdkSession.since, once per fresh turn)
+T_REC = 1_700_000_100            # an error record's own timestamp
+MDOT = "·"
+
+
+def _frame_keys():
+    return {"type", "state", "cls", "reason", "text", "waiting", "retrying", "blocked", "since", "tmux", "sessions", "seq"}
+
+
+class Reference(unittest.TestCase):
+    """docs/reference.md's subsection on the cell documents the frame and the pause file the code writes."""
+
+    def _section(self):
+        doc = Path(os.path.dirname(HERE), "docs", "reference.md").read_text()
+        i = doc.index("### The bottom bar's indicator")
+        return doc[i:doc.index("\n## ", i)]
+
+    def test_the_documented_frame_has_the_code_s_keys(self):
+        sec = self._section()
+        block = sec[sec.index("```json\n") + len("```json\n"):sec.index("\n```", sec.index("```json\n"))]
+        shape = json.loads(block)
+        self.assertEqual(set(shape), _frame_keys(), "the reference's frame block and _api_health_frame drift")
+        self.assertIn("`seq` counts the retry-pause file's writes", sec)
+
+    def test_the_pause_file_paragraph_names_every_field_the_code_writes(self):
+        sec = self._section()
+        for k in ("`paused`", "`t`", "`reason`", "`bills`", "`liftedAt`", "`supersedes`"):
+            self.assertIn(k, sec, k)
+        src = inspect.getsource(km._set_retry_paused)
+        for k in ("paused", "t", "reason", "bills", "liftedAt", "supersedes"):
+            self.assertIn('"%s"' % k, src, "the paragraph names a field the code does not write: " + k)
+
+
+class _Fixture(unittest.TestCase):
+    """Fixture sessions: `self.sess` is the alive roster, `self.live` the merged live map, `self.errs` the
+    latched error per transcript path. Everything the frame reads is patched at the module seam."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._state = km.jd.STATE
+        km.jd.STATE = Path(self.td.name)
+        self._alive = km._alive_sessions
+        self._last = km._api_last_failed
+        self._send = km._send_to_app
+        self._backend_for = km.Sessions.__dict__["backend_for"]
+        self._color = km._name_color
+        self.sess, self.live, self.errs, self.tmux_sids, self.colors = [], {}, {}, set(), {}
+        km._alive_sessions = lambda now, tmux: list(self.sess)
+        km._api_last_failed = lambda p: self.errs.get(p)
+        self.sent = []
+        km._send_to_app = lambda app, m: self.sent.append((app, m))
+        km.Sessions.backend_for = staticmethod(lambda sid: km._TMUX if sid in self.tmux_sids else object())
+        km._name_color = lambda sid: self.colors.get(sid)
+        km._APIH_LAST[0] = None
+        km._retry_suppress_cache.clear()
+
+    def tearDown(self):
+        km.jd.STATE = self._state
+        km._alive_sessions = self._alive
+        km._api_last_failed = self._last
+        km._send_to_app = self._send
+        km.Sessions.backend_for = self._backend_for
+        km._name_color = self._color
+        km._APIH_LAST[0] = None
+        km._retry_suppress_cache.clear()
+        self.td.cleanup()
+
+    def add(self, i, state="waiting", retry=None, err=None, since=T_STORM):
+        """One alive session: `retry` = a retryInfo dict puts it in the api_retry storm; `err` = the latched
+        error record's fields (status / category / t / the on-you flags)."""
+        path = os.path.join(self.td.name, NAMES[i] + ".jsonl")
+        self.sess.append({"sid": SID[i], "name": NAMES[i], "path": path, "anchor": "", "mtime": 0})
+        row = {"state": state, "since": since, "backend": "sdk"}
+        if retry is not None:
+            row["state"] = "retrying"
+            row["retryInfo"] = retry
+        self.live[SID[i]] = row
+        if err is not None:
+            e = {"status": None, "category": "unknown", "t": T_REC, "text": "", "uuid": "x",
+                 "tooLong": False, "spendLimit": False, "modelLimit": False, "authErr": False, "refusal": False}
+            e.update(err)
+            self.errs[path] = e
+        return SID[i]
+
+    def reset(self):
+        self.sess.clear()
+        self.live.clear()
+        self.errs.clear()
+
+    def frame(self, now=10):
+        return km._api_health_frame(now, self.live)
+
+
+class States(_Fixture):
+    def test_no_rows_and_no_pause_is_ok(self):
+        self.add(0)
+        f = self.frame()
+        self.assertEqual((f["state"], f["cls"], f["reason"], f["text"]), ("ok", "", "", "ok"))
+        self.assertEqual((f["waiting"], f["retrying"], f["blocked"], f["since"]), (0, 0, 0, 0))
+        self.assertEqual(f["sessions"], [])
+
+    def test_a_retrying_429_row_reads_rate_limited(self):
+        self.add(0, retry={"status": 429, "attempt": 2, "max": 10})
+        f = self.frame()
+        self.assertEqual((f["state"], f["cls"], f["text"]), ("degraded", "429", "rate limited %s 1 waiting" % MDOT))
+        self.assertEqual((f["waiting"], f["retrying"], f["blocked"]), (1, 1, 0))
+        self.assertEqual(f["sessions"][0]["kind"], "retrying")
+
+    def test_a_latched_529_record_reads_overloaded(self):
+        self.add(0, err={"status": 529, "category": "overloaded"})
+        f = self.frame()
+        self.assertEqual((f["state"], f["cls"], f["text"]), ("degraded", "529", "overloaded %s 1 waiting" % MDOT))
+        self.assertEqual((f["waiting"], f["retrying"], f["blocked"]), (1, 0, 1))
+        self.assertEqual(f["sessions"][0]["kind"], "blocked")
+
+    def test_network_down_with_no_status_reads_offline(self):
+        self.add(0, retry={"status": None, "networkDown": True})
+        f = self.frame()
+        self.assertEqual((f["cls"], f["text"]), ("offline", "offline %s 1 waiting" % MDOT))
+
+    def test_a_500_reads_errors(self):
+        self.add(0, err={"status": 500, "category": "server_error"})
+        f = self.frame()
+        self.assertEqual((f["cls"], f["text"]), ("errors", "errors %s 1 waiting" % MDOT))
+
+    def test_a_no_status_record_without_a_network_flag_reads_errors_not_offline(self):
+        # only a retrying row can say offline: a transcript record carries no network flag
+        self.add(0, err={"status": None, "category": "unknown"})
+        self.assertEqual(self.frame()["cls"], "errors")
+
+    def test_plurality_picks_the_most_common_class(self):
+        self.add(0, retry={"status": 429})
+        self.add(1, retry={"status": 429})
+        self.add(2, err={"status": 529, "category": "overloaded"})
+        f = self.frame()
+        self.assertEqual((f["cls"], f["text"]), ("429", "rate limited %s 3 waiting" % MDOT))
+
+    def test_ties_resolve_in_the_fixed_order(self):
+        self.add(0, retry={"status": 429})
+        self.add(1, err={"status": 529, "category": "overloaded"})
+        self.assertEqual(self.frame()["cls"], "429", "429 before 529")
+        self.reset()
+        self.add(0, err={"status": 529, "category": "overloaded"})
+        self.add(1, err={"status": 500, "category": "server_error"})
+        self.assertEqual(self.frame()["cls"], "529", "529 before errors")
+        self.reset()
+        self.add(0, retry={"status": None, "networkDown": True})
+        self.add(1, err={"status": 500, "category": "server_error"})
+        self.assertEqual(self.frame()["cls"], "offline", "offline before errors")
+
+    def test_on_you_failures_do_not_count(self):
+        for flag in ("tooLong", "modelLimit", "authErr", "refusal"):
+            self.reset()
+            self.add(0, err={"status": 400, "category": "invalid_request", flag: True})
+            f = self.frame()
+            self.assertEqual((f["state"], f["waiting"]), ("ok", 0), flag + " is the session's own, not the API's")
+
+    def test_a_spend_limit_record_counts(self):
+        self.add(0, err={"status": 400, "category": "billing_error", "spendLimit": True})
+        f = self.frame()
+        self.assertEqual((f["state"], f["cls"], f["waiting"]), ("degraded", "errors", 1))
+
+    def test_a_spend_pause_outranks_any_class(self):
+        self.add(0, retry={"status": 429})
+        self.add(1, retry={"status": 429})
+        km._set_retry_paused(True, reason="spend")
+        f = self.frame()
+        self.assertEqual((f["state"], f["reason"], f["text"]),
+                         ("paused", "spend", "paused %s spend cap %s 2 waiting" % (MDOT, MDOT)))
+        self.assertEqual(f["cls"], "429", "the class still rides along for the detail")
+
+    def test_a_limit_pause_names_the_usage_limit(self):
+        self.add(0, retry={"status": 429})
+        km._set_retry_paused(True, reason="limit")
+        f = self.frame()
+        self.assertEqual((f["state"], f["reason"], f["text"]),
+                         ("paused", "limit", "paused %s usage limit %s 1 waiting" % (MDOT, MDOT)))
+
+    def test_a_manual_pause_reads_paused_by_you(self):
+        self.add(0, err={"status": 500, "category": "server_error"})
+        km._set_retry_paused(True)
+        f = self.frame()
+        self.assertEqual((f["reason"], f["text"]), ("manual", "paused by you %s 1 waiting" % MDOT))
+
+    def test_a_pause_with_nothing_waiting_drops_the_count(self):
+        self.add(0)
+        km._set_retry_paused(True, reason="limit")
+        self.assertEqual(self.frame()["text"], "paused %s usage limit" % MDOT)
+        km._set_retry_paused(True, reason="spend")
+        self.assertEqual(self.frame()["text"], "paused %s spend cap" % MDOT)
+        km._set_retry_paused(True)
+        self.assertEqual(self.frame()["text"], "paused by you")
+
+    def test_a_suppressed_row_carries_suppressed_true(self):
+        sid = self.add(0, err={"status": 500, "category": "server_error"})
+        self.add(1, retry={"status": 429})
+        km._suppress_session_retry(sid)
+        rows = {r["sid"]: r for r in self.frame()["sessions"]}
+        self.assertTrue(rows[SID[0]]["suppressed"])
+        self.assertFalse(rows[SID[1]]["suppressed"])
+        self.assertEqual(self.frame()["waiting"], 2, "the interrupt says nothing about the API: still counted")
+
+    def test_tmux_backed_sessions_are_counted_for_the_coverage_line(self):
+        self.add(0)
+        self.add(1)
+        self.add(2, err={"status": 500, "category": "server_error"})
+        self.tmux_sids = {SID[1], SID[2]}
+        self.assertEqual(self.frame()["tmux"], 2)
+
+    def test_rows_carry_name_and_color(self):
+        self.colors[SID[0]] = {"bg": "#3366cc", "fg": "#ffffff"}
+        self.add(0, retry={"status": 429})
+        r = self.frame()["sessions"][0]
+        self.assertEqual((r["name"], r["color"]), ("web", {"bg": "#3366cc", "fg": "#ffffff"}))
+
+    def test_a_latched_row_reads_retrying_while_its_session_is_working(self):
+        # The retry prompt (romp's own, or a human's) was accepted and the turn is open, no api_retry frame yet;
+        # for a tmux session that is the whole internal retry. The word follows the live state; the latch only
+        # keeps the row counted, and its since stays the record's time.
+        self.add(0, state="working", err={"status": 529, "category": "overloaded"})
+        f = self.frame()
+        r = f["sessions"][0]
+        self.assertEqual((r["kind"], r["cls"], r["status"], r["since"]), ("retrying", "529", 529, T_REC))
+        self.assertEqual((f["waiting"], f["retrying"], f["blocked"], f["text"]),
+                         (1, 1, 0, "overloaded %s 1 waiting" % MDOT))
+        self.add(1, state="idle", err={"status": 529, "category": "overloaded"})
+        f = self.frame()
+        self.assertEqual([x["kind"] for x in f["sessions"]], ["retrying", "blocked"])
+        self.assertEqual((f["waiting"], f["retrying"], f["blocked"]), (2, 1, 1))
+
+    def test_a_string_status_on_the_wire_is_read_as_a_number(self):
+        self.add(0, retry={"status": "529"})
+        f = self.frame()
+        self.assertEqual((f["cls"], f["sessions"][0]["status"]), ("529", 529))
+
+
+class NoFlap(_Fixture):
+    def test_two_computes_over_the_same_world_are_byte_identical_and_send_once(self):
+        self.add(0, retry={"status": 429, "attempt": 3, "retryAt": 1_700_000_050.5})
+        self.add(1, err={"status": 500, "category": "server_error"})
+        f1 = self.frame(now=10)
+        km._api_health_push(f1)
+        f2 = self.frame(now=99_999)
+        km._api_health_push(f2)
+        self.assertEqual(json.dumps(f1, sort_keys=True), json.dumps(f2, sort_keys=True))
+        self.assertEqual(len(self.sent), 1, "an unchanged world sends nothing")
+        self.assertEqual(self.sent[0][0], "shell")
+
+    def test_attempt_and_retry_at_changes_move_nothing(self):
+        self.add(0, retry={"status": 429, "attempt": 3, "retryAt": 100.0, "error": "429 rate limited"})
+        km._api_health_push(self.frame())
+        self.live[SID[0]]["retryInfo"].update({"attempt": 4, "retryAt": 200.0, "error": "429 again"})
+        km._api_health_push(self.frame())
+        self.assertEqual(len(self.sent), 1, "per-attempt counters are not inputs")
+
+    def test_a_row_flipping_retrying_to_blocked_with_the_same_count_does_send(self):
+        self.add(0, retry={"status": 429})
+        km._api_health_push(self.frame())
+        self.live[SID[0]] = {"state": "waiting", "since": T_STORM}
+        self.errs[self.sess[0]["path"]] = {"status": 429, "category": "rate_limit", "t": T_REC,
+                                            "tooLong": False, "modelLimit": False, "authErr": False, "refusal": False}
+        km._api_health_push(self.frame())
+        self.assertEqual(len(self.sent), 2, "the storm gave up and left a record: new information")
+        self.assertEqual(self.sent[1][1]["waiting"], 1)
+        self.assertEqual((self.sent[1][1]["retrying"], self.sent[1][1]["blocked"]), (0, 1))
+
+    def test_a_pause_set_and_lifted_each_send_once(self):
+        self.add(0)
+        km._api_health_push(self.frame())
+        km._set_retry_paused(True, reason="limit")
+        km._api_health_push(self.frame())
+        km._api_health_push(self.frame())
+        km._set_retry_paused(False)
+        km._api_health_push(self.frame())
+        self.assertEqual([m["state"] for _, m in self.sent], ["ok", "paused", "ok"])
+
+    def test_since_is_the_event_stamp_never_the_clock(self):
+        self.add(0, retry={"status": 429}, since=T_STORM)
+        self.add(1, err={"status": 500, "category": "server_error", "t": T_REC})
+        f = self.frame(now=5_000_000_000)
+        self.assertEqual(f["since"], T_STORM, "the earliest affected event")
+        rows = {r["sid"]: r for r in f["sessions"]}
+        self.assertEqual(rows[SID[0]]["since"], T_STORM)
+        self.assertEqual(rows[SID[1]]["since"], T_REC)
+        km._set_retry_paused(True, reason="spend")
+        self.assertEqual(self.frame()["since"], int(km._retry_pause_ts()), "paused: the pause's own t")
+
+    def test_the_roster_order_cannot_reshuffle_an_unchanged_world(self):
+        self.add(0, retry={"status": 429})
+        self.add(1, err={"status": 500, "category": "server_error"})
+        km._api_health_push(self.frame())
+        self.sess.reverse()                              # a newer mtime moved a session up the roster
+        km._api_health_push(self.frame())
+        self.assertEqual(len(self.sent), 1)
+
+    def test_seq_moves_on_every_pause_write_and_only_then(self):
+        # a press on the detail's pause button writes the pause file; the frame after it must differ from every
+        # frame before it even when the cycle's auto-pause put the same state back, so the shell can clear its
+        # acknowledgment on the frame that answers the press
+        self.add(0, retry={"status": 429})
+        km._api_health_push(self.frame())
+        km._api_health_push(self.frame(now=99))
+        self.assertEqual(len(self.sent), 1, "no write: an unchanged world sends nothing")
+        seq0 = self.sent[0][1]["seq"]
+        km._set_retry_paused(False)                        # a Resume landing on an already-unpaused file
+        km._api_health_push(self.frame())
+        self.assertEqual(len(self.sent), 2, "the write is the event, whatever state it left")
+        self.assertEqual(self.sent[1][1]["seq"], seq0 + 1)
+        self.assertEqual((self.sent[1][1]["state"], self.sent[1][1]["text"]),
+                         (self.sent[0][1]["state"], self.sent[0][1]["text"]))
+        km._set_retry_paused(True, reason="limit")
+        km._set_retry_paused(False)
+        km._api_health_push(self.frame())
+        self.assertEqual(self.sent[2][1]["seq"], seq0 + 3, "every write counts, including one lifted within the cycle")
+
+    def test_the_ready_handler_resends_the_last_frame_to_a_shell_only(self):
+        # recording sinks on every client: _apih_resend guards the send with a try/except, so a sink that raised
+        # to fail the test would be swallowed by the very function under test
+        self.add(0, retry={"status": 429})
+        km._api_health_push(self.frame())
+        got, got_chat, got_feed = [], [], []
+        km._apih_resend({"app": "shell", "send": got.append})
+        km._apih_resend({"app": "chat", "send": got_chat.append})
+        km._apih_resend({"app": "feed", "send": got_feed.append})
+        self.assertEqual(len(got), 1)
+        self.assertEqual(json.loads(got[0]), self.sent[0][1], "verbatim: the client diffs state and text")
+        self.assertEqual((got_chat, got_feed), ([], []), "a chat or pane client owns no rail")
+
+    def test_nothing_to_resend_before_the_first_frame(self):
+        got = []
+        km._apih_resend({"app": "shell", "send": got.append})
+        self.assertEqual(got, [], "nothing sent since boot")
+
+
+class FrameShape(_Fixture):
+    def test_the_frame_and_its_rows_carry_exactly_the_documented_keys(self):
+        self.add(0, retry={"status": 429, "error": "the wire's text", "requestId": "req_x"})
+        self.add(1, err={"status": 500, "category": "server_error", "text": "API Error: 500"})
+        f = self.frame()
+        self.assertEqual(set(f), _frame_keys())
+        for r in f["sessions"]:
+            self.assertEqual(set(r), {"sid", "name", "color", "kind", "cls", "status", "since", "suppressed"})
+        s = json.dumps(f)
+        self.assertNotIn(".jsonl", s, "no path in any frame")
+        self.assertNotIn("API Error", s, "no error text in any frame")
+        self.assertNotIn("req_x", s)
+        self.assertNotIn("attempt", s)
+
+    def test_apih_class_agrees_with_the_backend_on_shared_statuses(self):
+        collapse = {"429": "429", "529": "529", "5xx": "errors", "other": "errors", "none": "errors"}
+        for status, cat in ((429, ""), (529, ""), (500, ""), (400, ""), (None, "rate_limit"), (None, "overloaded")):
+            self.assertEqual(km._apih_class(status, cat), collapse[sb.api_health_status_class(status, cat)],
+                             "status=%r category=%r" % (status, cat))
+        self.assertEqual(km._apih_class(None, "", True), "offline", "the one word the backend lacks")
+
+    def test_the_text_table_is_the_rail_s_words(self):
+        self.assertEqual(km._APIH_TEXT, {"ok": "ok", "429": "rate limited", "529": "overloaded", "offline": "offline",
+                                         "errors": "errors", "limit": "paused %s usage limit" % MDOT,
+                                         "spend": "paused %s spend cap" % MDOT, "manual": "paused by you"})
+        for v in km._APIH_TEXT.values():
+            self.assertNotIn("blocked", v)
+        self.assertEqual(km._APIH_ORDER, ("429", "529", "offline", "errors"))
+
+
+class Wiring(unittest.TestCase):
+    # the cycle's other jobs, stubbed quiet when the jobs block runs here (tests/test_wire_once_per_build.py's list)
+    OTHER_JOBS = ("_apply_pending_ops", "_push_all", "_turn_notify_tick", "_lift_spent_awaiting", "_death_sweep_tick",
+                  "_end_on_idle_sweep", "_deferral_sweep_tick", "_auto_nudge_tick", "_interrupt_block_tick",
+                  "_usage_poll_tick", "_auto_resume_session_retry", "_auto_retry_tick", "_idle_queue_drive_tick",
+                  "_clear_done_working_notes")
+
+    def test_the_frame_is_built_in_the_jobs_block_after_this_cycle_s_pause_decisions(self):
+        src = inspect.getsource(km._pusher_cycle_jobs)
+        self.assertIn("_api_health_push(_api_health_frame(now, tmux))", src)
+        self.assertLess(src.index("_auto_resume_retry(now, tmux)"), src.index("_api_health_push(_api_health_frame"))
+        self.assertNotIn("_api_health", inspect.getsource(km._cached_feed), "not gated by the feed's sig / rebuild floor")
+
+    def test_the_jobs_block_runs_the_frame_after_the_pause_decisions(self):
+        # the executing twin of the pin above: a frame built before _auto_resume_retry would carry the pause the
+        # same cycle lifts, so the cell would read paused one cycle late on every lift
+        order = []
+        quiet = {nm: (lambda *a, **k: None) for nm in self.OTHER_JOBS}
+        with mock.patch.multiple(km, **quiet), \
+                mock.patch.object(km, "_auto_pause_on_limit", side_effect=lambda: order.append("limit")), \
+                mock.patch.object(km, "_auto_pause_on_spend_limit", side_effect=lambda now, tmux: order.append("spend")), \
+                mock.patch.object(km, "_auto_resume_retry", side_effect=lambda now, tmux: order.append("resume")), \
+                mock.patch.object(km, "_api_health_frame", side_effect=lambda now, tmux: order.append("frame") or {"type": "apiHealth"}), \
+                mock.patch.object(km, "_api_health_push", side_effect=lambda f: order.append("push:" + f["type"])):
+            km._pusher_cycle_jobs(T_STORM, {}, True)
+        self.assertEqual(order, ["limit", "spend", "resume", "frame", "push:apiHealth"])
+
+    def test_the_ready_handler_resends_beside_the_badge(self):
+        src = Path(BIN, "romp-kernel").read_text()
+        i = src.index('client["send"](json.dumps({"type": "badge", "n": _BADGE_LAST[0]}))')
+        j = src.index("_apih_resend(client)", i)          # the CALL in the ready handler, after the def
+        self.assertLess(j - i, 400, "right beside the badge re-send, in the same ready branch")
+        self.assertIn("def _apih_resend(client):", src)
+
+    def test_auto_pause_on_limit_latches_reason_limit(self):
+        self.assertIn('_set_retry_paused(True, reason="limit")', inspect.getsource(km._auto_pause_on_limit))
+
+    def test_the_global_retry_paused_frame_still_carries_the_reason(self):
+        # the chat card's paused line reads `reason` off the globalRetryPaused frame (render.ts retryPausedText
+        # checks spend first and otherwise renders the resumeAt countdown, so a latched "limit" reason draws the
+        # countdown exactly as an unlabeled limit pause did); the latch changes the file, not the frame
+        src = Path(BIN, "romp-kernel").read_text()
+        self.assertIn('"reason": _retry_pause_reason()})', src)
+
+
+
+class Detail(unittest.TestCase):
+    """The click detail's content, pinned at source (no jsdom for the shell page); the served behaviour is
+    tests/test_api_health_browser.py."""
+
+    def setUp(self):
+        self.JS = km._LANDING_APIH_JS
+
+    def test_the_plain_words_sentences_are_present_verbatim(self):
+        for s in ("Auto-retry and the judges are paused until your usage limit resets.",
+                  "Auto-retry and the judges are paused: you have reached the monthly spend limit. Raise it at claude.ai/settings/usage.",
+                  "Auto-retry and the judges are paused: you stopped them.",
+                  "No session is waiting on the API. Auto-retry and the judges are running.",
+                  "API %s this machine" % MDOT, "Sessions waiting", "since "):
+            self.assertIn(s, self.JS)
+
+    def test_the_pause_button_is_the_chat_card_s_and_acknowledges_before_the_round_trip(self):
+        self.assertIn("'Resume all auto-retries'", self.JS)
+        self.assertIn("'Stop all auto-retries'", self.JS)
+        self.assertIn("{type:'setGlobalRetryPaused',value:v}", self.JS)
+        press = self.JS[self.JS.index("if(act==='pause')"):self.JS.index("else if(act==='reveal')")]
+        self.assertIn("t.disabled=true", press)
+        self.assertIn("t.textContent=v?RESUME:STOP", press)
+        self.assertIn("t.classList.add('romp-acted')", press)
+        self.assertLess(press.index("t.classList.add('romp-acted')"), press.index("__rompShellSend("), "acknowledged first")
+        self.assertIn("hint=NOTSENT", press, "a dead socket is said, not swallowed")
+        self.assertIn("var NOTSENT='Not sent: the dashboard is disconnected. Try again.';", self.JS)
+
+    def test_a_session_row_opens_that_session_the_way_the_feed_s_links_do(self):
+        # feed.ts openOrReviveSession posts openSession for a live session; the row does the same on the shell
+        # socket, toggles no pane and persists nothing about the layout
+        row = self.JS[self.JS.index("else if(act==='reveal')"):self.JS.index("else if(act==='usage')")]
+        self.assertIn("__rompShellSend({type:'openSession',id:sid})", row)
+        self.assertNotIn("__rompPaneToggle", self.JS, "never a pane toggle from the card")
+        self.assertNotIn("revealCard", self.JS)
+        self.assertIn("data-act=reveal data-sid=", self.JS)
+        self.assertIn("else{hint=NOTSENT;dirty=true;}", row, "a dead socket is said here too")
+
+    def test_the_coverage_line_appears_only_under_a_tmux_guard(self):
+        self.assertIn("if(m.tmux>0)h+=", self.JS)
+        self.assertIn("seen through their transcripts only", self.JS)
+        self.assertIn(", so a retry in progress there shows only when it fails or recovers.", self.JS)
+
+    def test_the_detail_renders_from_the_last_frame_only(self):
+        self.assertNotIn("fetch(", self.JS)
+        self.assertNotIn("setInterval", self.JS)
+        self.assertNotIn("setTimeout", self.JS)
+        self.assertIn("window.__rompApiHealth=function(m){", self.JS)
+        self.assertIn("LAST=m;", self.JS)
+
+    def test_the_cell_repaints_only_when_state_or_text_changed_and_shows_on_the_first_frame(self):
+        self.assertIn("if(el.hidden)el.hidden=false;", self.JS)
+        self.assertIn("if(el.getAttribute('data-state')!==m.state||txt.textContent!==m.text){el.setAttribute('data-state',m.state);"
+                      "txt.textContent=m.text;el.setAttribute('aria-label','API '+m.text);}", self.JS)
+        self.assertIn("if(tip.style.display!=='block')return;", self.JS)
+        self.assertIn("if(held){dirty=true;return;}render();};", self.JS)
+
+    def test_the_hover_renders_no_controls_and_the_pinned_detail_does(self):
+        self.assertIn("function html(m,full)", self.JS)
+        self.assertIn("if(full)h+=btnHTML(m);", self.JS)
+        self.assertIn("(full?' role=button tabindex=0 data-act=reveal data-sid=\"'+esc(r.sid)+'\"':'')", self.JS)
+        self.assertIn("if(full)h+='<div class=\"ru-tip-row ah-foot\">", self.JS)
+        self.assertIn("tip.innerHTML=html(LAST,pinned);", self.JS, "pinned = full; the hover = the reading only")
+
+    def test_a_frame_under_a_held_pointer_is_painted_on_release_never_under_the_press(self):
+        # only a PRIMARY press arms the defer: no click follows a right or middle button, so a frame deferred
+        # under one would stay unpainted until the next frame changed something
+        self.assertIn("tip.addEventListener('pointerdown',function(ev){if(ev.button===0)held=true;});", self.JS)
+        self.assertIn("document.addEventListener('pointerup',release);", self.JS)
+        self.assertIn("document.addEventListener('pointercancel',release);", self.JS)
+        self.assertIn("if(held){dirty=true;return;}render();", self.JS)
+        self.assertIn("ev.button===0&&ev.target&&tip.contains(ev.target))return;flush();}", self.JS,
+                      "a primary release inside waits for its click; any other release flushes")
+        self.assertIn("tip.addEventListener('click',function(ev){var t=actOf(ev.target);if(t)run(t);flush();});", self.JS,
+                      "the click handler flushes last")
+
+    def test_the_acknowledgment_holds_until_the_frame_that_answers_the_press(self):
+        # the frame's seq is the pause file's write count; the press writes it, so the frame after the press
+        # carries a moved seq whatever state it brings (paused again, when a limit or spend pause re-engaged
+        # within the cycle). A rule keyed on a matching state would leave a Resume during a usage-limit pause
+        # disabled and mislabeled for the rest of the window.
+        self.assertIn("pending=v?1:0;pendSeq=LAST?LAST.seq:null;", self.JS)
+        self.assertIn("if(pending!==null)return '<button class=\"ah-btn romp-acted\" disabled data-act=pause", self.JS)
+        self.assertIn("if(pending!==null&&(m.seq==null||m.seq!==pendSeq))pending=null;", self.JS)
+        self.assertNotIn("(pending===1)===(m.state==='paused')", self.JS, "no state matching")
+
+    def test_the_rows_and_footer_links_are_keyboard_buttons_inside_a_focus_trap(self):
+        self.assertIn("<span class=ah-link role=button tabindex=0 data-act=usage>Usage and spend</span>", self.JS)
+        self.assertIn("<span class=ah-link role=button tabindex=0 data-act=log>Log</span>", self.JS)
+        self.assertIn("tip.setAttribute('aria-modal','true')", self.JS)
+        self.assertIn("tip.addEventListener('keydown',function(ev){if(!pinned)return;", self.JS)
+        self.assertIn("if(ev.key==='Tab'){var f=controls(),i=f.indexOf(document.activeElement);", self.JS)
+        self.assertIn("if(ev.shiftKey){if(i<=0){ev.preventDefault();f[f.length-1].focus();}}", self.JS)
+        self.assertIn("else if(i<0||i===f.length-1){ev.preventDefault();f[0].focus();}", self.JS)
+        self.assertIn("if(ev.key!=='Enter'&&ev.key!==' ')return;var t=actOf(ev.target);if(!t||t.tagName==='BUTTON')return;", self.JS,
+                      "Enter / Space run a row or link; the button's own keys click it natively")
+        self.assertIn("ev.preventDefault();run(t);flush();});", self.JS)
+        # a re-render keeps focus on the same control, else the card: the trap must survive a frame
+        self.assertIn("key=(pinned&&a&&a!==tip&&tip.contains(a))?focusKey(a):null;", self.JS)
+        self.assertIn("try{if(n)n.focus();if(!n||document.activeElement!==n)tip.focus();}catch(e){}", self.JS)
+
+    def test_a_failed_send_restores_the_button_and_names_the_reason_under_it(self):
+        press = self.JS[self.JS.index("if(act==='pause')"):self.JS.index("else if(act==='reveal')")]
+        self.assertIn("{pending=null;hint=NOTSENT;dirty=true;}", press)
+        self.assertIn("(hint?'<div class=ah-hint>'+esc(hint)+'</div>':'')", self.JS)
+        self.assertIn("LAST=m;hint='';", self.JS, "a frame means the socket is alive: the notice retires")
+
+    def test_a_press_the_socket_lost_clears_on_the_close_and_says_why(self):
+        # the redial's ready re-sends the last frame verbatim, so a press the kernel never received would keep
+        # the button disabled and relabeled across the reconnect until an unrelated pause write moved the seq;
+        # the shell's onclose tells the detail, and the re-sent frame repaints the truth either way
+        self.assertIn("window.__rompApiSocketLost=function(){if(pending===null)return;pending=null;pendSeq=null;hint=LOST;", self.JS)
+        self.assertIn("var LOST='Connection lost before the answer arrived. When it is back, the button shows the current state.';", self.JS)
+        self.assertIn("hint=LOST;\nif(tip.style.display!=='block')return;if(held){dirty=true;return;}render();};", self.JS,
+                      "painted on release under a held pointer, like a frame")
+        html = km._landing()
+        self.assertIn("ws.onclose=function(){try{window.__rompApiSocketLost&&window.__rompApiSocketLost();}catch(e){}"
+                      "if(shellSock===ws)shellSock=null;setTimeout(shellWS,2000);};", html,
+                      "the shell socket's close tells the detail before the redial")
+
+    def test_focus_moves_to_the_card_before_the_pressed_button_is_disabled(self):
+        # a disabled element cannot hold focus: left on the button, focus fell to BODY, where the card's Tab trap
+        # no longer saw the keys and a Shift+Tab left the aria-modal dialog
+        press = self.JS[self.JS.index("if(act==='pause')"):self.JS.index("else if(act==='reveal')")]
+        self.assertIn("try{tip.focus();}catch(e){}", press)
+        self.assertLess(press.index("try{tip.focus();}catch(e){}"), press.index("t.disabled=true"), "focus first, then the disable")
+
+    def test_the_hover_re_anchors_after_a_re_render(self):
+        self.assertIn("tip.innerHTML=html(LAST,pinned);if(!pinned)anchor();", self.JS)
+        self.assertIn("tip.style.top=Math.max(6,r.top-tip.offsetHeight-8)+'px';}", self.JS)
+        self.assertIn("lastX=(ev&&typeof ev.clientX==='number')?ev.clientX:null;", self.JS)
+
+    def test_the_cell_is_a_keyboard_button_and_the_detail_takes_and_returns_focus(self):
+        self.assertIn("el.addEventListener('keydown',function(ev){if(ev.key==='Enter'||ev.key===' ')", self.JS)
+        self.assertIn("el.setAttribute('aria-label','API '+m.text)", self.JS)
+        self.assertIn("tip.setAttribute('role','dialog')", self.JS)
+        self.assertIn("focusBack=document.activeElement;", self.JS)
+        self.assertIn("try{tip.focus();}catch(e){}", self.JS)
+        self.assertIn("(fb&&fb.focus?fb:el).focus()", self.JS)
+
+    def test_each_modal_closes_the_other_first_so_the_shared_backdrop_serves_one(self):
+        self.assertIn("function open(){if(!LAST)return;try{window.__rompUsageClose&&window.__rompUsageClose();}catch(e){}", self.JS)
+        self.assertIn("try{window.__rompApiClose&&window.__rompApiClose();}catch(e){}", km._LANDING_USAGE_JS)
+
+    def test_actions_are_delegated_on_the_stable_tip_node(self):
+        self.assertIn("var el=document.getElementById('rail-api');", self.JS)
+        self.assertIn("el.addEventListener('click',function(){if(pinned)close();else open();});", self.JS)
+        self.assertNotIn("el.innerHTML", self.JS, "the frame handler writes the cell's children, never the cell")
+        self.assertIn("tip.addEventListener('click',function(ev){", self.JS)
+        self.assertEqual(self.JS.count("addEventListener('click'"), 2, "one on #rail-api, one on #ah-tip; none per row")
+        self.assertEqual(self.JS.count("addEventListener('keydown'"), 2, "one on #rail-api, one on #ah-tip; none per row")
+        self.assertEqual(self.JS.count("function run(t){var act=t.getAttribute('data-act');"), 1, "one action switch for click and key")
+        self.assertNotIn(".onclick=function", self.JS, "no per-row inline handlers")
+
+    def test_the_amber_state_is_never_called_blocked(self):
+        self.assertNotIn("'blocked'", self.JS)
+        self.assertIn("(r.kind==='retrying'?'retrying':'stopped')", self.JS, "the amber state is never called blocked")
+
+    def test_the_footer_reaches_the_usage_modal_and_the_log(self):
+        self.assertIn("data-act=usage>Usage and spend<", self.JS)
+        self.assertIn("data-act=log>Log<", self.JS)
+        self.assertIn("window.__rompUsagePanel&&window.__rompUsagePanel()", self.JS)
+        self.assertIn("window.__rompOpenErrs&&window.__rompOpenErrs()", self.JS)
+
+    def test_the_pinned_detail_wears_the_usage_modal_s_backdrop_and_escape_hook(self):
+        self.assertIn("tip.classList.add('ru-modal')", self.JS)
+        self.assertIn("back.classList.add('on')", self.JS)
+        self.assertIn("window.__rompApiClose=close;back.onclick=close;", self.JS)
+        self.assertIn("window.__rompApiClose=null;", self.JS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_apierror_working.py
+++ b/tests/test_kernel_apierror_working.py
@@ -2,7 +2,7 @@
 ⚠ chip and auto-retry recovers it. BUT an ON-YOU error floors the focus card to needs-input and gets the
 alarm-red tab: "prompt is too long" (compact needed), a monthly spend cap (raise it, the user 2026-07-14), or a
 spent MODEL allowance (switch model / add credits, the user 2026-08-01) — the spend cap ALSO stops auto-retry
-entirely (no reset to wait out). Source pins on _api_error + build_feed. The model-limit case has its own
+entirely (no reset to wait out). Source pins on _api_error_pass + build_feed. The model-limit case has its own
 behavioural file, tests/test_kernel_model_limit.py."""
 import inspect
 import os
@@ -23,9 +23,9 @@ km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_modu
 
 class ApiErrorWorking(unittest.TestCase):
     def test_api_error_carries_a_tooLong_flag(self):
-        # the classification lives in _api_error_scan since the tail-window split — _api_error is now the
-        # widening driver around it, so read the pair rather than pinning which half holds the flag
-        src = inspect.getsource(km._api_error) + inspect.getsource(km._api_error_scan)
+        # the classification lives in _api_error_pass, the one-pass scanner both _api_error and the latched
+        # _api_last_failed read through, so the pin reads that function
+        src = inspect.getsource(km._api_error_pass)
         self.assertIn('"tooLong": "too long" in text.lower()', src)
 
     def test_only_on_you_errors_floor_the_card_to_needs_input(self):
@@ -41,10 +41,9 @@ class ApiErrorWorking(unittest.TestCase):
         self.assertIn('or (col == "blocked" and not recheck and not rejudging))', src)
 
     def test_spend_cap_is_classified_and_floors_like_tooLong(self):
-        # a monthly spend cap is on you (raise it) AND never auto-retried — classified in _api_error, floored
-        # to needs-input, and badged with the raise-your-cap guidance (the user 2026-07-14).
-        self.assertIn('"spendLimit": _is_spend_limit(text)',
-                      inspect.getsource(km._api_error) + inspect.getsource(km._api_error_scan))
+        # a monthly spend cap is on you (raise it) AND never auto-retried: classified in _api_error_pass,
+        # floored to needs-input, and badged with the raise-your-cap guidance (the user 2026-07-14).
+        self.assertIn('"spendLimit": _is_spend_limit(text)', inspect.getsource(km._api_error_pass))
         bf = inspect.getsource(km.build_feed)
         self.assertIn('"spendLimit": bool(aerr.get("spendLimit"))', bf)
         self.assertIn("monthly spend limit — raise it at claude.ai/settings/usage", bf)

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -186,7 +186,8 @@ class LandingShell(unittest.TestCase):
         # script (_LANDING_REVEAL_JS) — its own script so a throw in the bell's cannot strand a tap;
         # +1 2026-09-08: the reload core (T265, _reload_core) ahead of the build-staleness banner script, which
         # registers as its refused fallback — its own script so a banner throw cannot take the reload with it
-        self.assertEqual(html.count("<script>"), 19)
+        # +1: the bottom bar's API health cell (_LANDING_APIH_JS), after the usage script whose backdrop it shares
+        self.assertEqual(html.count("<script>"), 20)
 
     def test_bottom_bar_is_text_only_and_compact(self):
         html = km._landing()

--- a/tests/test_kernel_model_limit.py
+++ b/tests/test_kernel_model_limit.py
@@ -155,7 +155,8 @@ class SurfacesPinTheOnYouTreatment(unittest.TestCase):
         # the 2026-07-03 flap: pausing the fleet on a model-scoped limit starved the judges, because
         # the account keeps serving and _auto_resume_retry cleared the pause every tick
         src = inspect.getsource(km._auto_pause_on_limit)
-        self.assertIn('k != "fable"', src, "account-wide windows only still gate the global pause")
+        self.assertIn("_account_limited()", src, "the engage reads the shared account-wide filter")
+        self.assertIn('k != "fable"', inspect.getsource(km._account_limited), "account-wide windows only still gate the global pause")
         self.assertNotIn("modelLimit", src)
 
 

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -8,6 +8,7 @@ Fleet/Outline is its OWN pane (no longer an overlay swapped inside the chat pane
 Source-level pin against km._landing().
 """
 import os
+import re
 import unittest
 from importlib.machinery import SourceFileLoader
 import tempfile
@@ -196,6 +197,123 @@ class PaneRailTest(unittest.TestCase):
         # the Outline (fleet) is a mobile TAB now, no longer desktop-only (the user 2026-07-11)
         self.assertNotIn("#fleet-pane{display:none!important}", self.html)
         self.assertIn("body[data-tab=timeline] .row{display:none}", self.html)   # timeline tab → band fills
+
+
+class ApiHealthCell(unittest.TestCase):
+    """The bottom bar's API health cell: a sibling of #rail-usage, painted from the kernel's apiHealth push by
+    _LANDING_APIH_JS (tests/test_api_health_rail.py covers the frame and the detail's content). Source-level
+    placement and styling pins against km._landing()."""
+
+    def setUp(self):
+        self.html = km._landing()
+
+    def test_the_cell_follows_the_usage_cell_inside_the_scroll_group(self):
+        i_usage, i_api, i_acts = (self.html.index(k) for k in ("id=rail-usage", "id=rail-api", "class=rail-acts"))
+        self.assertLess(i_usage, i_api, "right of the usage cell")
+        self.assertLess(i_api, i_acts, "inside .rail-scroll, before the pinned actions")
+        self.assertGreater(i_api, self.html.index("<div class=rail-scroll>"))
+
+    def test_the_cell_ships_hidden_with_its_own_label_a_dot_and_the_word(self):
+        tag = ('<div id=rail-api class="ru-w ru-ah" hidden role=button tabindex=0 aria-label="API ok" data-state=ok>'
+               '<span class=ru-name>API</span><i class=ah-dot></i><span class=ah-text>ok</span></div>')
+        self.assertTrue(tag in self.html, "the cell's markup: hidden, a keyboard button, its own label, a dot, the word")
+        tag = re.search(r"<div id=rail-api[^>]*>", self.html).group(0)
+        self.assertNotIn("title", tag, "the rail's no-title rule: the detail is the one hover surface")
+        self.assertNotIn("data-keycmd", tag, "no palette command yet")
+
+    def test_the_hidden_attribute_beats_the_rail_s_own_display_rule(self):
+        # The UA's [hidden]{display:none} loses to ANY author display rule, and .ru-w{display:flex} is one, so
+        # without this author rule the cell would show a gray 'API ok' from page load, and forever on a kernel
+        # that never sends a frame (the #mtabs button[hidden] idiom in the same stylesheet).
+        self.assertTrue(".ru-w{display:flex;" in self.html, "the author display rule the attribute must beat")
+        self.assertTrue("#rail-api[hidden]{display:none}" in self.html, "no author [hidden] rule for #rail-api")
+
+    def test_the_word_wears_the_usage_cell_s_exact_font(self):
+        pct = re.search(r"\.ru-pct\{([^}]*)\}", self.html).group(1)
+        txt = re.search(r"\.ah-text\{([^}]*)\}", self.html).group(1)
+        self.assertEqual(pct, txt, "byte for byte: no new font size on the rail")
+        self.assertIn("#rail-api[data-state=ok] .ah-text{color:#9aa4ad}", self.html, "ok in the label gray")
+        self.assertIn("body.theme-light .ah-text{color:#1F1E1D}", self.html)
+        self.assertIn("body.theme-light #rail-api[data-state=ok] .ah-text{color:#5D574E}", self.html)
+        self.assertIn("#rail-api{cursor:pointer;margin-left:4px}", self.html)
+
+    def test_the_dot_wears_status_hexes_never_the_accent(self):
+        self.assertIn(".ah-dot{width:7px;height:7px;border-radius:50%;background:#9aa4ad;opacity:.55;flex:0 0 auto}", self.html)
+        self.assertIn("#rail-api[data-state=degraded] .ah-dot,.ah-dot[data-state=degraded]{background:#e67e22;opacity:1}", self.html)
+        self.assertIn("#rail-api[data-state=paused] .ah-dot,.ah-dot[data-state=paused]{background:#e5484d;opacity:1}", self.html)
+        for rule in re.findall(r"[^{}]*\.ah-dot[^{}]*\{[^}]*\}", self.html):
+            self.assertNotIn("var(--accent)", rule, "status colors keep their own meaning")
+
+    def test_the_light_theme_keeps_the_ok_dot_visible_and_the_state_dots_their_colors(self):
+        # the dark label gray at .55 blends into the light rail; the light label color keeps the glyph. Scoped to
+        # the ok state: a bare `body.theme-light .ah-dot` (0,2,1) would outrank the detail's `.ah-dot[data-state=…]`
+        # rules (0,2,0), and the card's headline dot would lose its amber and red
+        self.assertTrue("body.theme-light #rail-api[data-state=ok] .ah-dot,body.theme-light .ah-dot[data-state=ok]{background:#5D574E}" in self.html,
+                        "the light override names the ok state")
+        self.assertNotIn("body.theme-light .ah-dot{", self.html, "no bare light rule on the dot")
+        self.assertNotIn("body.theme-light .ah-dot[data-state=degraded]", self.html, "the state rules are not restated per theme")
+
+    def test_the_shell_socket_carries_the_dashboard_s_wid_minted_before_it_connects(self):
+        # the detail's openSession rides the shell socket; with no wid on it the kernel's reveal would fall to the
+        # broadcast and every open dashboard's chat would switch (_reveal_chat_for)
+        js = km._LANDING_MOBILE_JS
+        self.assertIn("var ws=new WebSocket(proto+location.host+'/ws?app=shell&wid='+encodeURIComponent(wid()));", js)
+        mint = "sessionStorage.setItem('romp:wid'"
+        self.assertLess(self.html.index(mint), self.html.index("'/ws?app=shell&wid='"), "minted before the shell socket connects")
+
+    def test_an_emptied_usage_cell_collapses_its_gap(self):
+        # renderRows empties #rail-usage on a login-only machine; as a zero-width flex item it would still pay the
+        # scroll group's gap on both sides (28px to the API cell instead of 16px)
+        self.assertTrue("#rail-usage:empty{display:none}" in self.html, "the emptied cell must leave the flex flow")
+
+    def test_the_detail_shares_the_usage_tip_s_skin_and_backdrop(self):
+        self.assertIn("#ah-tip,#ru-tip{position:fixed", self.html)
+        self.assertIn("#ah-tip.ru-modal,#ru-tip.ru-modal{", self.html)
+        self.assertIn("body.theme-light #ah-tip,body.theme-light #ru-tip{", self.html)
+        self.assertIn("tip.id='ah-tip'", self.html)
+        self.assertIn("document.getElementById('ru-back')", km._LANDING_APIH_JS)
+
+    def test_the_shell_socket_routes_the_frame_and_escape_closes_the_detail_first(self):
+        self.assertIn("else if(m&&m.type==='apiHealth'&&window.__rompApiHealth)window.__rompApiHealth(m);", self.html)
+        self.assertIn("window.__rompShellSend=function(o)", self.html)
+        esc = km._LANDING_ESC_JS
+        self.assertLess(esc.index("__rompApiClose"), esc.index("__rompUsageClose"), "both ride #ru-back; the detail's hook is checked first")
+        self.assertIn("if(ru&&ru.classList.contains('on')&&window.__rompApiClose){window.__rompApiClose();closed=true;}", esc)
+
+    def test_the_cell_s_script_loads_after_the_usage_script_it_borrows_the_backdrop_from(self):
+        self.assertLess(self.html.index("getElementById('rail-usage')"), self.html.index("getElementById('rail-api')"))
+
+
+class ShellSocketIdentity(unittest.TestCase):
+    """A reveal the kernel answers to the shell's own op (the API detail's openSession) reaches the asking
+    dashboard alone, since the shell client carries its wid the way a feed pane's does. Synthetic clients; no
+    sockets."""
+
+    def _client(self, app, wid):
+        return {"app": app, "wid": wid, "alive": True, "send": lambda s, w=wid, a=app: self.sink.append((a, w))}
+
+    def setUp(self):
+        self.sink = []
+        self._saved = list(km._clients)
+        km._clients[:] = [self._client("chat", "win-A"), self._client("chat", "win-B"),
+                          self._client("shell", "win-A"), self._client("shell", "win-B"), self._client("feed", "win-A")]
+
+    def tearDown(self):
+        km._clients[:] = self._saved
+
+    def test_a_shell_client_with_a_wid_moves_its_own_dashboard_s_chat_only(self):
+        km._reveal_chat_for({"app": "shell", "wid": "win-A"}, {"type": "focus", "id": "s1"})
+        self.assertEqual(sorted(self.sink), [("chat", "win-A"), ("shell", "win-A")])
+
+    def test_a_shell_client_without_a_wid_still_broadcasts(self):
+        # an older shell page, or a browser with no sessionStorage: today's behavior, not silence
+        km._reveal_chat_for({"app": "shell", "wid": ""}, {"type": "focus", "id": "s1"})
+        self.assertEqual(sorted(w for a, w in self.sink if a == "chat"), ["win-A", "win-B"])
+
+    def test_the_open_session_op_hands_the_asking_client_to_the_router(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        i = src.index('msg.get("type") == "openSession" and msg.get("id")')
+        self.assertIn('_open_or_revive(msg["id"], live=bool(msg.get("live")), client=client)', src[i:i + 600])
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_usage_limit.py
+++ b/tests/test_kernel_usage_limit.py
@@ -171,6 +171,24 @@ class AutoPauseOnLimit(unittest.TestCase):
         km._auto_pause_on_limit()
         self.assertTrue(km._retry_paused_on(), "a real 5h/7d limit still engages the pause")
 
+    def test_the_pause_latches_reason_limit_at_the_event(self):
+        # the bottom bar's API health cell names the pause from the file's reason, never from _retry_resume_at's
+        # clock comparison (which would flip the word at the reset instant with no event)
+        fut = int(time.time()) + 3600
+        km._usage = lambda: {"limited": {"fiveHour": True, "sevenDay": False, "fable": False},
+                             "fiveHour": {"pct": 100, "resetsAt": fut}}
+        km._auto_pause_on_limit()
+        self.assertTrue(km._retry_paused_on())
+        self.assertEqual(km._retry_pause_reason(), "limit")
+        self.assertEqual(km._retry_resume_at(), fut, "the card's countdown is unchanged by the latched reason")
+        self.assertGreater(km._retry_pause_ts(), 0, "the pause's own t is the frame's `since`")
+
+    def test_an_already_paused_flag_keeps_its_reason(self):
+        km._set_retry_paused(True, reason="spend")
+        km._usage = lambda: {"limited": {"fiveHour": True, "sevenDay": False, "fable": False}}
+        km._auto_pause_on_limit()
+        self.assertEqual(km._retry_pause_reason(), "spend", "idempotent: the first cause stays on record")
+
 
 class AutoPauseOnSpendLimit(unittest.TestCase):
     """A monthly SPEND cap auto-engages the global retry-pause — the SPEND twin of AutoPauseOnLimit (the

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -467,7 +467,8 @@ class PusherRecords(unittest.TestCase):
             "_end_on_idle_sweep", "_deferral_sweep_tick", "_auto_nudge_tick", "_interrupt_block_tick",
             "_auto_pause_on_limit", "_usage_poll_tick", "_auto_pause_on_spend_limit", "_auto_resume_retry",
             "_auto_resume_session_retry", "_auto_retry_tick", "_idle_queue_drive_tick",
-            "_clear_done_working_notes", "_push_all")
+            "_clear_done_working_notes", "_push_all",
+            "_api_health_frame", "_api_health_push")   # the bottom bar's API cell
 
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()

--- a/tests/test_retry_pause_autoresume.py
+++ b/tests/test_retry_pause_autoresume.py
@@ -4,14 +4,22 @@ auto-retries" to calm the auto-retry + judge storm during an API / usage-limit o
 tier is gated on `not _retry_paused_on()`, so a pause that never clears silently kills EVERY judge for
 hours (the user 2026-06-30, who noted none of the judges were running and called it an API problem that should
 clear the second a successful non-API-error response arrives on any session). _auto_resume_retry
-clears it event-based: the first live session that is NOT blocked on an API error AND wrote fresh output
-since the pause began (mtime past the pause floor) proves the account can serve requests again.
+clears it event-based, one rule per reason: a MANUAL pause lifts on the first live session that is NOT
+blocked on an API error AND wrote fresh output since the pause began (mtime past the pause floor); a LIMIT
+pause lifts when the usage report stops naming an account-wide window at 100% (the same reading that engaged
+it); a SPEND pause lifts on fresh assistant output from a session on the billing the cap is on. The lift
+leaves the capped session's own record standing (only a human prompt clears a spend record), so the un-pause
+records its instant and the spend engage stands down on records older than it; a new record engages again.
 """
+import contextlib
+import inspect
+import io
 import json
 import os
 import tempfile
 import time
 import unittest
+from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
@@ -155,6 +163,574 @@ class RetryPauseAutoResume(unittest.TestCase):
         self.assertTrue(km._retry_paused_on())
         self.assertFalse(km._pusher_wake.is_set(), "still paused: nothing to deliver")
         self.assertEqual(km._views_dirty[0], floor)
+
+    # --- a spend record older than the last spend lift is already ruled on ---
+    def test_the_capped_session_lookup_skips_records_older_than_the_lift_and_keeps_the_rest(self):
+        sess = [{"sid": "s%d" % i, "path": str(self.dir / ("s%d.jsonl" % i))} for i in range(4)]
+        errs = {sess[0]["path"]: {"spendLimit": True, "t": 1000},        # a second before the lift's evidence: stale
+                sess[1]["path"]: {"spendLimit": False, "t": 1005},       # not a cap
+                sess[2]["path"]: {"spendLimit": True, "t": 0},           # no readable time: not proof of staleness
+                sess[3]["path"]: {"spendLimit": True, "t": 1001}}        # the evidence's own second: new
+        km._alive_sessions = lambda now, tmux: sess
+        km._api_error = lambda p: errs.get(p)
+        self.assertEqual(km._spend_capped_session(0, {})["sid"], "s0", "no lift on record: the first capped session")
+        # `after` is the lifting output's own stamp, whole seconds like the record's
+        self.assertEqual(km._spend_capped_session(0, {}, after=1001)["sid"], "s2", "1000 < 1001 is stale, 0 is unknown")
+        del errs[sess[2]["path"]]
+        self.assertEqual(km._spend_capped_session(0, {}, after=1001)["sid"], "s3", "a record in the evidence's second counts")
+        self.assertIsNone(km._spend_capped_session(0, {}, after=1001.7), "no truncation: 1001 is older than a Resume at 1001.7")
+        del errs[sess[3]["path"]]
+        self.assertIsNone(km._spend_capped_session(0, {}, after=1001), "every remaining record predates the lift")
+        self.assertEqual(km._retry_pause_lifted_at(), 0.0, "no file: nothing on record")
+
+    # --- the bottom bar's API health cell reads the pause and its lift off this same file ---
+    def test_the_api_health_frame_reads_paused_limit_then_ok_after_the_clear(self):
+        km._set_retry_paused(True, reason="limit")
+        floor = km._retry_pause_ts()
+        path = str(self.dir / "healthy.jsonl")
+        with open(path, "w") as f:
+            f.write(_out_line(floor + 5))                      # a login-billed session's answer after the pause
+        live = {"s1": {"state": "idle", "auth": "login", "backend": "sdk"}}
+        km._alive_sessions = lambda now, tmux: [{"sid": "s1", "name": "web", "path": path}]
+        km._api_error = lambda p: None
+        saved_backend, saved_usage = km.Sessions.__dict__["backend_for"], km._usage
+        km.Sessions.backend_for = staticmethod(lambda sid: object())
+        km._usage = lambda: {"limited": {"fiveHour": True}}
+        km._api_last_failed_cache.clear()
+        try:
+            f = km._api_health_frame(int(time.time()), live)
+            self.assertEqual((f["state"], f["reason"], f["text"]), ("paused", "limit", "paused · usage limit"))
+            self.assertEqual(f["since"], int(floor), "the pause's own t, not the clock")
+            km._auto_resume_retry(int(time.time()), live)
+            self.assertTrue(km._retry_paused_on(), "the report still names the window: the output lifts nothing")
+            km._usage = lambda: {"limited": {}}
+            km._auto_resume_retry(int(time.time()), live)
+            self.assertFalse(km._retry_paused_on())
+            f = km._api_health_frame(int(time.time()), live)
+            self.assertEqual((f["state"], f["reason"], f["text"], f["since"]), ("ok", "", "ok", 0))
+        finally:
+            km.Sessions.backend_for = saved_backend
+            km._usage = saved_usage
+            km._api_last_failed_cache.clear()
+
+
+# ── the lift rules, per reason, over real synthetic transcripts ──────────────────────────────────────
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _out_line(t):
+    return json.dumps({"type": "assistant", "uuid": "aaaaaaaa-0000-0000-0000-%012d" % int(t), "timestamp": _iso(t),
+                       "message": {"role": "assistant", "content": [{"type": "text", "text": "done"}]}}) + "\n"
+
+
+def _prompt_line(t, text="please continue"):
+    return json.dumps({"type": "user", "uuid": "bbbbbbbb-0000-0000-0000-%012d" % int(t), "timestamp": _iso(t),
+                       "message": {"role": "user", "content": [{"type": "text", "text": text}]}}) + "\n"
+
+
+SID_KEY = "88888888-aaaa-4bbb-8ccc-000000000001"     # a private synthetic family for this module
+SID_LOGIN = "88888888-aaaa-4bbb-8ccc-000000000002"
+
+
+def _err_line(t, text, status=400, category="billing_error"):
+    return json.dumps({"type": "assistant", "uuid": "cccccccc-0000-0000-0000-%012d" % int(t), "timestamp": _iso(t),
+                       "isApiErrorMessage": True, "apiErrorStatus": status, "error": category,
+                       "message": {"role": "assistant", "content": [{"type": "text", "text": text}]}}) + "\n"
+
+
+SPEND_TEXT = "API Error: 400 You have reached your monthly spend limit for this workspace."   # invented wording
+
+
+class _KernelClock:
+    """The kernel module's `time`, with time() reading no earlier than a floor the test sets: the pause floor
+    (and a Resume's liftedAt) are wall-clock writes while the transcripts here carry synthetic times ahead of
+    the clock, so a test that plays a second round (a new record, a second lift) moves the kernel's clock along
+    with its timeline. A floor at a round second makes every read exact. Everything else delegates to the real
+    module. At 0 (the default) the clock is the real one."""
+
+    def __init__(self):
+        self.floor = 0.0
+
+    def time(self):
+        return max(time.time(), self.floor)
+
+    def __getattr__(self, name):
+        return getattr(time, name)
+
+
+class _PauseFixture(unittest.TestCase):
+    """The pusher's pause jobs over real synthetic transcripts: _alive_sessions and the live map are the
+    module's own, _usage is the patched report, every frame goes to self.sent."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.dir = Path(self.td.name)
+        self._orig = (km.jd.STATE, km._alive_sessions, km._push_all, km.jd.rearm_failed_summaries, km._usage,
+                      km._send_to_app, km.Sessions.__dict__["backend_for"], km._auth_key_present, km.time)
+        self.clock = _KernelClock()
+        km.time = self.clock
+        km.jd.STATE = self.dir
+        km._push_all = lambda *a, **k: self.fail("a tick job built a push inline; it should wake the pusher")
+        km.jd.rearm_failed_summaries = lambda now, **k: 0
+        km._usage = lambda: {"limited": {"fiveHour": True}}    # the login account's window is at 100%
+        self.sent = []
+        km._send_to_app = lambda app, m: self.sent.append((app, m))
+        km.Sessions.backend_for = staticmethod(lambda sid: object())
+        km._auth_key_present = lambda: True                    # an apiKeyHelper is configured on this machine
+        km._APIH_LAST[0] = None
+        km._api_err_cache.clear()
+        km._api_last_failed_cache.clear()
+        self._was_set = km._pusher_wake.is_set()
+        km._pusher_wake.clear()
+        self.roster = []
+        km._alive_sessions = lambda now, tmux: list(self.roster)
+
+    def tearDown(self):
+        (km.jd.STATE, km._alive_sessions, km._push_all, km.jd.rearm_failed_summaries, km._usage,
+         km._send_to_app, km.Sessions.backend_for, km._auth_key_present, km.time) = self._orig
+        km._APIH_LAST[0] = None
+        km._api_err_cache.clear()
+        km._api_last_failed_cache.clear()
+        if self._was_set:
+            km._pusher_wake.set()
+        else:
+            km._pusher_wake.clear()
+        self.td.cleanup()
+
+    def _session(self, sid, name, auth, *lines):
+        """One alive session with a transcript of `lines`; returns (path, its live-map row)."""
+        p = self.dir / (name + ".jsonl")
+        p.write_text("".join(lines))
+        self.roster = [s for s in self.roster if s["sid"] != sid] + [{"sid": sid, "name": name, "path": str(p)}]
+        return str(p), {"state": "idle", "auth": auth, "authLive": auth, "backend": "sdk"}
+
+    def _append(self, path, line, t):
+        with open(path, "a") as f:
+            f.write(line)
+        os.utime(path, (t, t))
+
+    def _cycle(self, now, live):
+        # the pusher's jobs in their order: the limit engages, the spend cap engages, the resume check, the frame
+        km._auto_pause_on_limit()
+        km._auto_pause_on_spend_limit(now, live)
+        km._auto_resume_retry(now, live)
+        f = km._api_health_frame(now, live)
+        km._api_health_push(f)
+        return f["state"]
+
+    def _states(self):
+        return [m["state"] for a, m in self.sent]
+
+
+class LimitPauseLift(_PauseFixture):
+    """A usage-limit pause lifts on the same reading that engaged it: the usage report (_account_limited).
+    The mtime rule lifted it on ANY alive session's transcript mtime past the floor (a key-billed session's
+    streaming or a human prompt), and _auto_pause_on_limit re-engaged the next cycle while the window held:
+    the pause file, and the bottom bar's API cell, flipped every cycle. A rule keyed on a login-billed
+    session's fresh assistant output could never fire after the reset (the login sessions the limit blocked
+    are the ones the pause gates), so the pause would hold until a human acted. One authority for both edges:
+    no session's output lifts it while the report reads limited."""
+
+    def test_a_key_billed_session_s_output_during_a_limit_leaves_the_pause_and_the_frame_stable(self):
+        # a limited window, one key-billed session appending an answer every other cycle
+        now = time.time()
+        path, row = self._session(SID_KEY, "web", "key", _out_line(now - 60))
+        live = {SID_KEY: row}
+        states = []
+        for i in range(6):
+            if i % 2:
+                self._append(path, _out_line(now + i), now + i)
+            states.append(self._cycle(int(now) + i, live))
+        self.assertEqual(states, ["paused"] * 6, "a key-billed session's output says nothing about the login limit")
+        self.assertEqual(self._states(), ["paused"], "one frame: nothing about the API changed")
+        self.assertEqual(km._retry_pause_reason(), "limit")
+
+    def test_the_window_reset_lifts_it_once_with_no_login_output_while_a_key_session_streams(self):
+        # after the window rolls, nothing but a human could lift an output-keyed rule: a login session blocked on
+        # the limit cannot serve (its auto-retry is gated on this very pause), the key session is rightly skipped;
+        # the report clearing by its own clock must be the lift
+        now = time.time()
+        api_path, api_row = self._session(SID_LOGIN, "api", "login",
+                                          _out_line(now - 120), _err_line(now - 90, "API Error: 429 rate limited", 429, "rate_limit"))
+        web_path, web_row = self._session(SID_KEY, "web", "key", _out_line(now - 60))
+        live = {SID_LOGIN: api_row, SID_KEY: web_row}
+        states = []
+        for i in range(3):
+            self._append(web_path, _out_line(now + i), now + i)
+            states.append(self._cycle(int(now) + i, live))
+        self.assertEqual(states, ["paused"] * 3)
+        km._usage = lambda: {"limited": None}                  # the reset passed: the report no longer names a window
+        for i in range(3, 8):
+            self._append(web_path, _out_line(now + i), now + i)
+            states.append(self._cycle(int(now) + i, live))
+        self.assertEqual(states, ["paused"] * 3 + ["degraded"] * 5, "lifts the cycle the report clears; stays lifted")
+        self.assertFalse(km._retry_paused_on())
+        self.assertEqual(self._states(), ["paused", "degraded"], "each side of the lift sent once")
+        self.assertEqual(self.sent[-1][1]["waiting"], 1, "the login session still sits on its record: the auto-retry's turn now")
+        self.assertTrue(km._pusher_wake.is_set(), "the clear wakes the pusher; globalRetryPaused rides its push")
+
+    def test_login_output_under_a_still_limited_report_holds_the_pause_and_the_frame(self):
+        # with extra usage on, the login account is served at 100%: a lift on each output record would be
+        # re-engaged the next cycle, the pause file flipping at the output cadence. One authority: the report.
+        # A login turn's end refreshes it, and that is the edge that lifts.
+        now = time.time()
+        path, row = self._session(SID_LOGIN, "api", "login", _out_line(now - 60))
+        live = {SID_LOGIN: row}
+        states = []
+        for i in range(8):
+            self._append(path, _out_line(now + i), now + i)
+            states.append(self._cycle(int(now) + i, live))
+        self.assertEqual(states, ["paused"] * 8, "served output under a limited report is not the lift")
+        self.assertEqual(self._states(), ["paused"], "one frame across eight output records")
+        km._usage = lambda: {"limited": {}}                    # the refreshed report reads under 100%
+        self.assertEqual(self._cycle(int(now) + 8, live), "ok")
+        self.assertFalse(km._retry_paused_on())
+        self.assertEqual(self._states(), ["paused", "ok"])
+
+    def test_a_login_billed_session_s_fresh_assistant_output_lifts_it_once(self):
+        # the login account serves a request and its usage report catches up (a login turn's end refreshes it);
+        # the lift lands once, on the report
+        now = time.time()
+        path, row = self._session(SID_LOGIN, "api", "login", _out_line(now - 60))
+        live = {SID_LOGIN: row}
+        self.assertEqual(self._cycle(int(now), live), "paused")
+        floor = km._retry_pause_ts()
+        os.utime(path, (floor + 1, floor + 1))                 # a fresh mtime over OLD output
+        km._auto_resume_retry(int(now), live)
+        self.assertTrue(km._retry_paused_on(), "the report still reads limited: held")
+        self._append(path, _prompt_line(floor + 2), floor + 2)
+        km._auto_resume_retry(int(now), live)
+        self.assertTrue(km._retry_paused_on(), "a prompt is not the API's answer, and the report still reads limited")
+        self._append(path, _out_line(floor + 5), floor + 5)    # the login account served a request
+        km._usage = lambda: {"limited": {}}                    # and its usage report caught up
+        self.assertEqual(self._cycle(int(now) + 1, live), "ok")
+        self.assertFalse(km._retry_paused_on())
+        self.assertEqual(self._states(), ["paused", "ok"], "each side of the lift sent once")
+
+    def test_an_unreadable_report_changes_nothing(self):
+        now = time.time()
+        path, row = self._session(SID_LOGIN, "api", "login", _out_line(now - 60))
+        live = {SID_LOGIN: row}
+        self.assertEqual(self._cycle(int(now), live), "paused")
+
+        def boom():
+            raise RuntimeError("no report")
+        km._usage = boom
+        km._pusher_wake.clear()                                # the engage above woke the pusher; the check below must not
+        km._auto_resume_retry(int(now), live)
+        self.assertTrue(km._retry_paused_on(), "no reading: no change, as the engage side would not engage")
+        self.assertFalse(km._pusher_wake.is_set())
+
+    def test_the_engage_and_the_lift_read_the_same_filter(self):
+        km._usage = lambda: {"limited": {"fable": True}}
+        self.assertEqual(km._account_limited(), [], "fable is model-scoped: never an account limit")
+        km._usage = lambda: {"limited": {"fiveHour": False, "sevenDay": True, "fable": True}}
+        self.assertEqual(km._account_limited(), ["sevenDay"])
+        km._usage = lambda: None
+        self.assertEqual(km._account_limited(), [], "no report at all (a pure API-key host) reads as not limited")
+        src = inspect.getsource(km._auto_pause_on_limit) + inspect.getsource(km._auto_resume_retry)
+        self.assertEqual(src.count("_account_limited()"), 2, "both edges call the one filter")
+
+    def test_a_manual_pause_keeps_lifting_on_any_fresh_transcript(self):
+        km._usage = lambda: {"limited": {}}
+        now = time.time()
+        path, row = self._session(SID_KEY, "web", "key", _out_line(now - 60))
+        km._set_retry_paused(True)
+        floor = km._retry_pause_ts()
+        os.utime(path, (floor + 1, floor + 1))
+        km._auto_resume_retry(int(now), {SID_KEY: row})
+        self.assertFalse(km._retry_paused_on(), "the user's own stop: the mtime rule is unchanged")
+
+    def test_a_session_of_unknown_auth_bills_the_login_only_when_this_machine_holds_no_key(self):
+        km._auth_key_present = lambda: True
+        self.assertFalse(km._bills_login({"state": "idle"}), "a key on the machine: this session may be billing it")
+        self.assertFalse(km._bills_login(None))
+        km._auth_key_present = lambda: False
+        self.assertTrue(km._bills_login({"state": "idle"}), "no key anywhere: the login is the only account it can bill")
+        self.assertTrue(km._bills_login({"auth": "key", "authLive": "login"}), "the CLI's own live report wins")
+        self.assertFalse(km._bills_login({"auth": "key"}))
+
+
+class _SpendWorld(_PauseFixture):
+    """The spend classes' world: no usage window; 'web' bills the key and sits on its cap record, 'api' bills the
+    login and streams. A base with no tests of its own, so each class below is collected once."""
+
+    def setUp(self):
+        super().setUp()
+        km._usage = lambda: {"limited": None}                  # no usage window is involved
+        self.now = time.time()
+        self.web, web_row = self._session(SID_KEY, "web", "key", _out_line(self.now - 120), _err_line(self.now - 90, SPEND_TEXT))
+        self.api, api_row = self._session(SID_LOGIN, "api", "login", _out_line(self.now - 60))
+        self.live = {SID_KEY: web_row, SID_LOGIN: api_row}
+
+
+class SpendPauseLift(_SpendWorld):
+    """A spend pause lifts on fresh assistant output from a session on the billing the cap is on (recorded
+    at the engage: _retry_pause_bills), never from the other billing. The mtime rule it replaces counted a
+    session on the OTHER account streaming past the cap; _auto_pause_on_spend_limit re-engaged the next
+    cycle while the capped session sat on its record, and the pause file, so the cell, flipped every cycle.
+    The capped session itself qualifies once it serves again."""
+
+    def test_the_other_billing_s_output_leaves_the_pause_and_the_frame_stable(self):
+        states = []
+        for i in range(8):
+            self._append(self.api, _out_line(self.now + i), self.now + i)
+            states.append(self._cycle(int(self.now) + i, self.live))
+        self.assertEqual(states, ["paused"] * 8, "a login session's output says nothing about the key's cap")
+        self.assertEqual([(m["state"], m["text"]) for a, m in self.sent],
+                         [("paused", "paused · spend cap · 1 waiting")], "one frame across eight cycles")
+        self.assertEqual((km._retry_pause_reason(), km._retry_pause_bills()), ("spend", "key"))
+
+    def test_the_capped_session_s_own_output_lifts_it_once(self):
+        self.assertEqual(self._cycle(int(self.now), self.live), "paused")
+        floor = km._retry_pause_ts()
+        self._append(self.api, _out_line(floor + 1), floor + 1)   # the other billing, still
+        self.assertEqual(self._cycle(int(self.now) + 1, self.live), "paused")
+        self._append(self.web, _prompt_line(floor + 2, "retry"), floor + 2)   # romp's own retry prompt: not the answer
+        self.assertEqual(self._cycle(int(self.now) + 2, self.live), "paused")
+        self._append(self.web, _out_line(floor + 5), floor + 5)   # the cap was raised: the capped session served
+        self.assertEqual(self._cycle(int(self.now) + 3, self.live), "ok")
+        self.assertFalse(km._retry_paused_on())
+        self.assertEqual(self._states(), ["paused", "ok"], "each side of the lift sent once")
+
+    def test_a_second_session_on_the_capped_billing_lifts_it(self):
+        tests, tests_row = self._session("88888888-aaaa-4bbb-8ccc-000000000003", "tests", "key", _out_line(self.now - 60))
+        self.live["88888888-aaaa-4bbb-8ccc-000000000003"] = tests_row
+        self.assertEqual(self._cycle(int(self.now), self.live), "paused")
+        floor = km._retry_pause_ts()
+        self._append(tests, _out_line(floor + 3), floor + 3)   # the key account serves again, through another session
+        km._auto_resume_retry(int(self.now) + 1, self.live)
+        self.assertFalse(km._retry_paused_on(), "same billing as the cap: proof the account serves")
+
+    def test_a_cap_on_the_login_holds_against_key_output_and_lifts_on_login_output(self):
+        # roles swapped: the login session sits on the cap, the key session streams
+        web, web_row = self._session(SID_KEY, "web", "key", _out_line(self.now - 60))
+        api, api_row = self._session(SID_LOGIN, "api", "login", _out_line(self.now - 120), _err_line(self.now - 90, SPEND_TEXT))
+        live = {SID_KEY: web_row, SID_LOGIN: api_row}
+        states = []
+        for i in range(4):
+            self._append(web, _out_line(self.now + i), self.now + i)
+            states.append(self._cycle(int(self.now) + i, live))
+        self.assertEqual(states, ["paused"] * 4)
+        self.assertEqual(km._retry_pause_bills(), "login")
+        floor = km._retry_pause_ts()
+        self._append(api, _out_line(floor + 9), floor + 9)
+        self.assertEqual(self._cycle(int(self.now) + 4, live), "ok")
+
+    def test_a_pause_file_with_no_billing_takes_any_session_s_fresh_output_but_not_a_bare_mtime(self):
+        km._set_retry_paused(True, reason="spend")             # no billing recorded (a file another kernel wrote)
+        floor = km._retry_pause_ts()
+        os.utime(self.api, (floor + 1, floor + 1))
+        km._auto_resume_retry(int(self.now), self.live)
+        self.assertTrue(km._retry_paused_on(), "a fresh mtime over old output is not the API's answer")
+        self._append(self.api, _out_line(floor + 2), floor + 2)
+        km._auto_resume_retry(int(self.now), self.live)
+        self.assertFalse(km._retry_paused_on(), "with no billing on file, any session's fresh output lifts")
+
+    def test_the_pause_file_records_the_capped_billing_and_a_manual_pause_records_none(self):
+        self._cycle(int(self.now), self.live)
+        d = json.loads((self.dir / "retry-paused.json").read_text())
+        self.assertEqual((d["paused"], d["reason"], d["bills"]), (True, "spend", "key"))
+        self.assertIn("t", d)
+        km._set_retry_paused(True)
+        d = json.loads((self.dir / "retry-paused.json").read_text())
+        self.assertEqual(set(d), {"paused", "t"})
+        self.assertEqual(km._retry_pause_bills(), "")
+
+
+class SpendPauseStandDown(_SpendWorld):
+    """The lift leaves the capped session's own record standing: a spend cap is on-you, so romp sends it no
+    retry and only a human prompt to that session clears _api_error. An engage that read that record again
+    would put the pause back the cycle after every lift, so it alternated at the streaming session's output
+    cadence and settled ON once it idled, gating the judges and the idle-queue drives until someone prompted
+    the capped session. The un-pause of a spend pause records liftedAt and the floor it superseded, the memory
+    rides every later write, and the engage skips records older than it."""
+
+    SID_TESTS = "88888888-aaaa-4bbb-8ccc-000000000003"
+    SID_DOCS = "88888888-aaaa-4bbb-8ccc-000000000004"
+
+    def _tests_session(self):
+        tests, row = self._session(self.SID_TESTS, "tests", "key", _out_line(self.now - 60))
+        self.live[self.SID_TESTS] = row
+        return tests
+
+    def _file(self):
+        return json.loads((self.dir / "retry-paused.json").read_text())
+
+    def test_one_lift_no_re_engage_and_the_pause_off_once_the_streamer_idles(self):
+        # 'web' (key) sits on its cap record, 'tests' (key) streams one answer per cycle for six cycles after the
+        # lift, then idles for three. Without the stand-down the states alternated paused/degraded at the output
+        # cadence (four engages, three lifts) and were paused at the end.
+        tests = self._tests_session()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            states = [self._cycle(int(self.now), self.live)]
+            floor = km._retry_pause_ts()
+            for i in range(1, 7):
+                self._append(tests, _out_line(floor + i), floor + i)
+                states.append(self._cycle(int(self.now) + i, self.live))
+            for i in range(7, 10):
+                states.append(self._cycle(int(self.now) + i, self.live))
+        self.assertEqual(states, ["paused"] + ["degraded"] * 9, "one lift, and the stale record engages nothing")
+        self.assertFalse(km._retry_paused_on(), "OFF after the streamer idles")
+        self.assertEqual(self._states(), ["paused", "degraded"], "two frames: the engage and the lift")
+        self.assertEqual((err.getvalue().count("auto-engaged"), err.getvalue().count("auto-cleared")), (1, 1))
+        self.assertTrue(km._api_error(self.web), "the capped session's record still stands: only a human prompt clears it")
+        self.assertEqual(self.sent[-1][1]["waiting"], 1, "and the cell still counts it")
+
+    def test_a_new_spend_record_after_the_lift_engages_once(self):
+        tests = self._tests_session()
+        self.assertEqual(self._cycle(int(self.now), self.live), "paused")
+        floor = km._retry_pause_ts()
+        self._append(tests, _out_line(floor + 1), floor + 1)
+        self.assertEqual(self._cycle(int(self.now) + 1, self.live), "degraded")
+        self.assertEqual(self._cycle(int(self.now) + 2, self.live), "degraded")
+        # the user prompts 'web' and it fails on the cap again: a record written after the lift is new information
+        self._append(self.web, _prompt_line(floor + 3, "try once more"), floor + 3)
+        self.assertEqual(self._cycle(int(self.now) + 3, self.live), "degraded", "a prompt is not a new record")
+        self._append(self.web, _err_line(floor + 5, SPEND_TEXT), floor + 5)
+        self.clock.floor = floor + 5.5                         # the kernel's clock has reached the new record
+        states = [self._cycle(int(self.now) + 4 + i, self.live) for i in range(3)]
+        self.assertEqual(states, ["paused"] * 3, "engages once on the new record and holds")
+        self.assertEqual(self._states(), ["paused", "degraded", "paused"])
+        self.assertEqual((km._retry_pause_reason(), km._retry_pause_bills()), ("spend", "key"))
+        self.assertGreater(km._retry_pause_ts(), floor, "a new floor")
+        # a second round: the key account serves again, the new record is the stale one now
+        self._append(tests, _out_line(floor + 7), floor + 7)
+        self.clock.floor = floor + 7.5
+        states = [self._cycle(int(self.now) + 7 + i, self.live) for i in range(3)]
+        self.assertEqual(states, ["degraded"] * 3, "one lift again, and no re-engage on the second record either")
+        self.assertEqual(self._states(), ["paused", "degraded", "paused", "degraded"])
+
+    def test_a_second_session_s_record_from_the_second_before_the_lift_cycle_engages(self):
+        # liftedAt is the lifting OUTPUT's own time, not the lift cycle's clock. The timeline: 'web' (key) sits on
+        # its cap; 'tests' (key) serves at T+0.1 (the evidence); 'docs' (key) hits the cap at T+0.6; the pusher's
+        # lift cycle runs at T+1.2. The CLI stamps both records T, and a liftedAt of T+1.2 read in whole seconds
+        # (T+1) would skip docs' record, written after the evidence, until that session's next attempt.
+        tests = self._tests_session()
+        docs, docs_row = self._session(self.SID_DOCS, "docs", "key", _out_line(self.now - 60))
+        self.live[self.SID_DOCS] = docs_row
+        T = int(self.now) + 100                                # a round second ahead of the real clock: exact reads
+        self.clock.floor = T - 10
+        self.assertEqual(self._cycle(T - 10, self.live), "paused")
+        self.assertEqual(km._retry_pause_ts(), T - 10)
+        self._append(tests, _out_line(T + 0.1), T + 0.1)       # the key account serves again, stamped T
+        self._append(docs, _err_line(T + 0.6, SPEND_TEXT), T + 0.6)   # a second session hits the cap, stamped T
+        self.clock.floor = T + 1.2                             # the lift cycle runs in the next second
+        self.assertEqual(self._cycle(T + 1, self.live), "degraded", "the lift: the engage ran first, over a paused file")
+        self.assertEqual(self._file()["liftedAt"], T, "the evidence's own time, not the cycle's")
+        self.assertEqual(self.sent[-1][1]["waiting"], 2, "both records stand")
+        self.assertEqual(self._cycle(T + 1, self.live), "paused", "docs' record is not older than the evidence: new information")
+        self.assertEqual((km._retry_pause_reason(), km._retry_pause_bills(), km._retry_pause_ts()), ("spend", "key", T + 1.2))
+        self.assertEqual(self._cycle(T + 2, self.live), "paused", "and holds: tests' output predates the new floor")
+        self.assertEqual(self._states(), ["paused", "degraded", "paused"])
+
+    def test_the_memory_survives_a_limit_pause_that_engages_and_lifts_in_between(self):
+        # a single-slot memory dropped at the next write would let the limit lift hand the stale record back
+        tests = self._tests_session()
+        self.assertEqual(self._cycle(int(self.now), self.live), "paused")
+        floor = km._retry_pause_ts()
+        self._append(tests, _out_line(floor + 1), floor + 1)
+        self.assertEqual(self._cycle(int(self.now) + 1, self.live), "degraded")            # the spend lift
+        lifted = self._file()["liftedAt"]
+        km._usage = lambda: {"limited": {"fiveHour": True}}
+        self.assertEqual(self._cycle(int(self.now) + 2, self.live), "paused")              # the login window
+        self.assertEqual((km._retry_pause_reason(), self._file()["liftedAt"]), ("limit", lifted))
+        km._usage = lambda: {"limited": None}
+        states = [self._cycle(int(self.now) + 3 + i, self.live) for i in range(3)]
+        self.assertEqual(states, ["degraded"] * 3, "the limit lifts; the stale spend record engages nothing")
+        self.assertEqual(self._states(), ["paused", "degraded", "paused", "degraded"])
+        self.assertEqual(self._file()["liftedAt"], lifted)
+
+    def test_a_limit_lift_rules_on_no_spend_record(self):
+        # the login window is at 100% first; 'web' hits its cap during that pause; the report clears. The limit
+        # lift's evidence is the report, which says nothing about the cap, so the cap engages its own pause.
+        km._usage = lambda: {"limited": {"fiveHour": True}}
+        web, web_row = self._session(SID_KEY, "web", "key", _out_line(self.now - 120))    # not capped yet
+        self.assertEqual(self._cycle(int(self.now), self.live), "paused")
+        self.assertEqual(km._retry_pause_reason(), "limit")
+        floor = km._retry_pause_ts()
+        self._append(web, _err_line(floor + 1, SPEND_TEXT), floor + 1)
+        self.assertEqual(self._cycle(int(self.now) + 1, self.live), "paused")
+        km._usage = lambda: {"limited": None}
+        self.assertEqual(self._cycle(int(self.now) + 2, self.live), "degraded", "the limit lifts")
+        self.assertEqual(self._file(), {"paused": False}, "a limit lift records no spend ruling")
+        self.assertEqual(self._cycle(int(self.now) + 3, self.live), "paused", "the cap, never ruled on, pauses")
+        self.assertEqual((km._retry_pause_reason(), km._retry_pause_bills()), ("spend", "key"))
+
+    def test_the_user_s_resume_over_a_spend_pause_stands_until_a_new_record(self):
+        # the same stale record would undo the detail's Resume the next cycle (the setGlobalRetryPaused route
+        # writes the same un-pause): a user gesture is new information too
+        self.assertEqual(self._cycle(int(self.now), self.live), "paused")
+        floor = km._retry_pause_ts()
+        km._set_retry_paused(False)
+        states = [self._cycle(int(self.now) + 1 + i, self.live) for i in range(3)]
+        self.assertEqual(states, ["degraded"] * 3)
+        self.assertEqual(self._file()["supersedes"], floor)
+
+    def test_the_pause_file_remembers_the_spend_lift_across_later_writes(self):
+        tests = self._tests_session()
+        self._cycle(int(self.now), self.live)
+        floor = km._retry_pause_ts()
+        self._append(tests, _out_line(floor + 1), floor + 1)
+        self._cycle(int(self.now) + 1, self.live)
+        d = self._file()
+        self.assertEqual(set(d), {"paused", "liftedAt", "supersedes"})
+        self.assertEqual((d["paused"], d["supersedes"]), (False, floor), "supersedes: the floor of the pause it cleared")
+        lifted = d["liftedAt"]
+        self.assertEqual(lifted, int(floor + 1), "the lifting output's own time")
+        self.assertEqual(km._retry_pause_lifted_at(), lifted)
+        self.assertEqual((km._retry_pause_ts(), km._retry_pause_reason(), km._retry_pause_bills()), (0.0, "", ""))
+        km._set_retry_paused(False)                            # a Resume over an unpaused file keeps what it finds
+        self.assertEqual((self._file()["liftedAt"], self._file()["supersedes"]), (lifted, floor))
+        km._set_retry_paused(True, reason="limit")             # a later pause carries it
+        d = self._file()
+        self.assertEqual(set(d), {"paused", "t", "reason", "liftedAt", "supersedes"})
+        self.assertEqual(d["liftedAt"], lifted)
+        km._set_retry_paused(False)                            # and so does its lift
+        self.assertEqual(self._file()["liftedAt"], lifted)
+        km._set_retry_paused(True)                             # a manual pause carries it, and its un-pause too
+        km._set_retry_paused(False)
+        self.assertEqual(self._file()["liftedAt"], lifted)
+        (self.dir / "retry-paused.json").unlink()              # no memory on file: nothing is invented
+        km._set_retry_paused(True)
+        km._set_retry_paused(False)
+        self.assertEqual(self._file(), {"paused": False})
+        self.assertEqual(km._retry_pause_lifted_at(), 0.0)
+
+
+class PauseWriteSeq(_PauseFixture):
+    """The apiHealth frame's `seq` counts pause-file writes: the detail's pause button writes the file on a
+    press, and the frame that follows must differ from every frame before it even when the cycle's auto-pause
+    put the same state back, so the shell can clear its acknowledgment on the frame that answers the press
+    and read the truth (paused again) instead of holding a disabled, mislabeled button for the rest of the
+    window."""
+
+    def test_a_write_that_puts_the_same_state_back_still_yields_a_new_frame(self):
+        now = time.time()
+        path, row = self._session(SID_LOGIN, "api", "login", _out_line(now - 60))
+        live = {SID_LOGIN: row}
+        self.assertEqual(self._cycle(int(now), live), "paused")
+        seq0 = self.sent[-1][1]["seq"]
+        self.assertEqual(self._cycle(int(now) + 1, live), "paused")
+        self.assertEqual(len(self.sent), 1, "no write, no frame: two cycles over the same world are identical")
+        km._set_retry_paused(False)                            # the user pressed Resume during the window
+        self.assertEqual(self._cycle(int(now) + 2, live), "paused", "the limit re-engaged within the cycle")
+        self.assertEqual(len(self.sent), 2, "same state, but the press and the re-engage wrote the file")
+        self.assertEqual(self.sent[-1][1]["seq"], seq0 + 2)
+        self.assertEqual(km._retry_pause_reason(), "limit")
+
+    def test_seq_is_an_event_counter_not_a_clock(self):
+        self.roster = []
+        km._usage = lambda: {"limited": None}
+        f1 = km._api_health_frame(10, {})
+        f2 = km._api_health_frame(99_999, {})
+        self.assertEqual(json.dumps(f1, sort_keys=True), json.dumps(f2, sort_keys=True))
+        km._set_retry_paused(False)                            # a no-op write is still a write
+        f3 = km._api_health_frame(10, {})
+        self.assertEqual(f3["seq"], f1["seq"] + 1)
+        self.assertEqual((f3["state"], f3["text"]), (f1["state"], f1["text"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -869,10 +869,9 @@ class AuthErrorClass(unittest.TestCase):
 
     def test_it_is_an_on_you_class_end_to_end(self):
         import inspect
-        # the classification lives in _api_error_scan since the tail-window split; _api_error is the
-        # widening driver around it, so read the pair rather than pinning which half holds the flag
-        self.assertIn('"authErr": _is_auth_error(text)',
-                      inspect.getsource(km._api_error) + inspect.getsource(km._api_error_scan))
+        # the classification lives in _api_error_pass, the one-pass scanner both _api_error and the latched
+        # _api_last_failed read through, so the pin reads that function
+        self.assertIn('"authErr": _is_auth_error(text)', inspect.getsource(km._api_error_pass))
         self.assertIn('"apiAuthErr": bool(aerr and aerr.get("authErr"))', inspect.getsource(km.build_session))
         feed = inspect.getsource(km.build_feed)
         self.assertIn('aerr.get("authErr") or aerr.get("refusal"))))', feed, "the card floors to needs-you")

--- a/ui/webview/apierror-spend-limit.test.ts
+++ b/ui/webview/apierror-spend-limit.test.ts
@@ -55,3 +55,16 @@ test("the feed card badges a spent model allowance and HIDES Retry too", () => {
   assert.match(F, /modelLimit \? "⚠ Model limit"/);
   assert.match(F, /modelLimit\?: boolean/);
 });
+
+// The kernel latches a usage-limit pause as reason "limit" in the pause file (the bottom bar's API health cell
+// names the pause from it). The chat card's paused line is unchanged by that: retryPausedText branches on
+// === "spend" first and otherwise falls to the resumeAt countdown, so a "limit" reason renders the countdown
+// exactly as an unlabeled limit pause did. The kernel half (the frame still carries `reason`, the engage writes
+// "limit") is pinned in tests/test_api_health_rail.py's Wiring class.
+test("retryPausedText: spend first, then the resumeAt countdown (a 'limit' reason renders the countdown)", () => {
+  const fn = R.slice(R.indexOf("function retryPausedText()"), R.indexOf("function apiRetryTick()"));
+  assert.match(fn, /if \(globalRetryReason === "spend"\) return/);
+  assert.match(fn, /if \(globalRetryResumeAt\) \{/);
+  assert.ok(fn.indexOf('=== "spend"') < fn.indexOf("if (globalRetryResumeAt)"), "spend is checked before the countdown");
+  assert.doesNotMatch(fn, /"limit"/, "no reason-specific branch: the countdown IS the limit's rendering");
+});


### PR DESCRIPTION
An API health cell in the dashboard's bottom bar: one dot and one word beside the usage readout that say whether the API is serving your sessions (ok, how many are waiting and on what, or paused and why), with the reading on hover and a click detail that lists the waiting sessions and carries the Stop / Resume auto-retry button.

## Tier

Tier: feature

## Design

- **What it reads.** The cell reads what the kernel already owns: each alive session's latched newest API-error record, the live retrying state from the api_retry frames, and the retry-pause file. It does not read the `/api-health` ratio signal: that signal's states are threshold-and-hold transitions evaluated at read time, while the cell answers "is a session waiting on the API right now".
- **Moves on events, never on a clock.** Every field of the frame moves on one named event: a retry frame, an `isApiErrorMessage` record, fresh assistant output, a pause set or lifted, a session leaving the roster. Two computes over an unchanged world serialize identically and send nothing; rows sort by (since, sid) so roster order cannot cause a send. Per-attempt counters (attempt, retryAt) are not inputs.
- **The latch.** `_api_last_failed` is `_api_error`'s latched sibling: a user prompt does not clear it. romp's own auto-retry IS a user prompt (`RETRY_MSG`), so a count keyed on `_api_error` flapped "1 waiting / ok / 1 waiting" on every backoff rung. One tail pass (`_api_error_pass`) serves both readers, so the pusher's second question about a transcript in the same cycle is a cache hit. The pass keeps the original scan's loop and comments as written, changed only at the sites that assign a verdict. `_api_error_scan` stays as a shim for the existing differential tests, whose verdicts are unchanged.
- **What counts.** On-you failures (too long, model limit, dead credential, refusal) do not count: they already wear red on the session's own tab and card, and the cell answers for the API. A spend cap counts, and engages the spend pause in the same cycle.
- **Each pause lifts on the event that engaged it.** A limit pause lifts when the usage report stops naming an account-wide window (`_account_limited`, the engage's own filter). The mtime rule could flip the file every cycle on a key-billed session's output, and a rule keyed on a login session's output could never fire after the reset, since the blocked login sessions are the ones the pause gates. A spend pause records the capped session's billing and lifts on fresh assistant output from that billing only. A manual pause keeps the mtime rule.
- **The spend stand-down.** A spend cap is on-you, so the capped session's record outlives the lift. The un-pause records `liftedAt` (the lifting record's own time, not the cycle's clock) and the spend engage skips older records, so the pause no longer re-engages the cycle after every lift. `_auto_pause_on_limit` latches `reason="limit"` at the event so the cell names the pause without a clock comparison.
- **The billing of a row with no auth on record.** `_bills_login` reads the CLI's `authLive`, then the registry's `auth`; a row with neither (a tmux session, an SDK session before its init landed) bills the login only when no apiKeyHelper is configured on the machine (`_auth_key_present`), and is taken as key-billed otherwise. A spend pause engaged from such a row on a login-plus-helper machine therefore records `bills=key`.
- **`seq`.** It counts pause-file writes, so the frame that answers a press on the detail's pause button differs from every earlier frame whatever state it brings; the button's acknowledgment clears on the truth (paused again included), never on a matching-state guess.
- **Delivery.** Unchanged: `_set_retry_paused` marks the views dirty and the pusher's next cycle carries the flip. The frame is built after the cycle's pause decisions and sent only when it changed; a shell that sends `ready` gets the last frame verbatim, and the client diffs state and text before touching the DOM so a re-send cannot pulse the cell.
- **UI.** The word is `.ru-pct`'s declaration byte for byte (no new font size). The dot wears status hexes (the label gray, the tab-retrying amber, the API-error red), never the accent, which marks only the footer's links. The cell ships hidden and shows on its first frame, so a kernel that sends none shows nothing rather than a false ok. Progressive disclosure: one word on the rail, the reading on hover, actions only in the pinned detail.
- **Click-safe.** A frame that lands while a primary pointer is down over the detail is painted on release. A press is acknowledged before the round trip and stays disabled until the answering frame; a failed send restores the button and says why; a socket close clears a press that can no longer be answered and says so. The detail is an aria-modal dialog with a focus trap; focus moves to the card before the pressed button is disabled, since a disabled element cannot hold focus.
- **One modal at a time.** The detail shares `#ru-back` with the usage modal: opening either closes the other first, and Escape closes the API detail before the usage modal since both ride that backdrop.
- **Deliberately left out.** The VS Code strip twin (`strip.ts` apiCell's sibling) and the phone's usage-modal section (no rail on the phone) are follow-ups. A hover history of the cell's readings is a separate change. No palette command on the cell yet.
- **Where the pins live.** The shell page has no jsdom harness, so its source pins sit in the Python modules beside the behavior they approximate (`tests/test_api_health_rail.py`, `tests/test_kernel_pane_rail.py`); the one TypeScript addition pins `render.ts` only.

## Tests

Executing tests, and what each fails on before the change:

- `tests/test_api_health_rail.py` (new, 58): the frame's states, plurality and tie order, the on-you exclusion, the pause outranking, the no-flap rule (a byte-identical recompute sends once; attempt/retryAt changes move nothing; seq moves only on pause writes; a ready re-send reaches shells only, with recording sinks on every client since the send is guarded), the frame's exact keys and its agreement with `sdk_backend.api_health_status_class`, the wiring (the jobs block run with its other jobs stubbed builds the frame after the pause decisions, plus the source pin; the ready handler; `reason="limit"`), the docs subsection, and the detail's source. Before: `_api_health_frame`, `_api_health_push`, `_apih_resend`, `_LANDING_APIH_JS` and the reference subsection do not exist, and `_set_retry_paused` takes no `bills` or `lifted_at`.
- `tests/test_api_health_browser.py` (new, 21): a scratch copy of the shell page driven by playwright's chromium over a WebSocket shim: hidden before the first frame, keyboard button, hover re-anchor, one modal on the shared backdrop, a held press across a frame, the acknowledgment held until the answering seq, a failed send, a row and a pause press through the page's own send while no socket is open, a socket loss and redial, Tab cycling, primary-button-only defer, the light theme's dot colors. Before: the served page has no `window.__rompApiHealth`, so the driver times out. Skips without the extension's node deps or a browser (CI installs none); it ran here, and it removes its scratch directory.
- `tests/test_api_error_tail.py` `ApiLastFailedLatch` (new, 16): the latch holds through a user prompt and through `RETRY_MSG`, clears on assistant output, carries `t`, takes a refusal record's mark, shares one read with `_api_error`, widens past a tail of prompts, keeps its own cache. Before: `_api_last_failed`, `_api_last_output_t` and `_api_error_pass` do not exist, and the error dict carries no `t`. The existing differential tests keep passing through the `_api_error_scan` shim (their recorder now wraps `_api_error_pass`).
- `tests/test_retry_pause_autoresume.py` `LimitPauseLift`, `SpendPauseLift`, `SpendPauseStandDown`, `PauseWriteSeq` and two additions to the existing class (new, 25; the two spend classes share a fixture base, so each test is collected once): a limit pause lifts only when the report stops naming a window; a spend pause lifts on fresh assistant output from the recorded billing only, never the mtime, never the other account; `liftedAt` is the record's time; a stale spend record does not re-engage; seq per write. Before: a limit pause lifts on any transcript's mtime, a spend pause lifts on the other billing's output and re-engages the next cycle, the file records no `bills` or `liftedAt`. The existing `RetryPauseAutoResume` tests (the writer's dirty mark, no inline push) still pass.
- `tests/test_kernel_pane_rail.py` `ApiHealthCell` (new, 11): the cell's placement after `#rail-usage` inside `.rail-scroll`, the hidden markup and its author `[hidden]` rule, `.ah-text` equal to `.ru-pct` byte for byte, status hexes never the accent, the light theme's ok scoping, `#rail-usage:empty`, the shared `#ru-tip` skin, the shell-socket routing and the Escape order. Ten are red before: none of the markup, rules or routing exists. The eleventh, the shell socket's wid dial minted before it connects, passes before and after: it pins the existing dial the detail's row relies on. `ShellSocketIdentity` (3) passes before and after too: it pins the wid-scoped reveal.
- `tests/test_kernel_usage_limit.py` (2): the pause latches `reason=limit` at the event with the countdown unchanged (red before: the pause records no reason); an already-paused file keeps its reason (passes before and after: it pins the engage's existing idempotence).
- Pin adjustments that follow the change, red before it because they name what it adds: `tests/test_kernel_apierror_working.py` and `tests/test_session_auth.py` read the tail pass (`_api_error_pass`), `tests/test_kernel_model_limit.py` reads the shared filter (`_account_limited`), `tests/test_kernel_mobile.py` counts 20 scripts, and `tests/test_perf_stats.py`'s pusher job list gains `_api_health_frame` and `_api_health_push`. `ui/webview/apierror-spend-limit.test.ts` passes before and after by construction: it pins `render.ts` only (`retryPausedText` checks spend first and renders a limit reason as the countdown).

Full runs on the final tree: `pytest -n 8 tests/` 10311 passed, 40 skipped, 0 failed; `npm test` 3655 pass, 0 fail; `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)