### PR TITLE
Sessions & tags: one colour dot per tag row, folded pane filters, and a height budget that keeps the sessions on screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,3 +407,17 @@ times" bug. Every interactive control MUST therefore:
 Reuse `ui/webview/actions.ts` for any new dashboard control. (`.romp-acted` is
 defined in both `styles.css` and `feed.css` since the feed page loads only the
 latter.)
+
+### Designs must accommodate many tags and many sessions (user rule, 2026-09-09)
+Assume dozens of tags and dozens of sessions on every surface that lists them, and lay
+the surface out for that case, not for three. Per-item controls take ONE line: a tag row
+is its pill, its actions and one colour dot; a session row is its name, its [+] and its
+chips. Palettes, pane-by-tag matrices and any other per-item detail open on demand (a
+popover, a fold), never inline for every item at once. The working area keeps the space:
+the sections above it fold or cap their height and scroll within themselves, so the part
+the user came to act on (the sessions table in Sessions & tags) is never pushed under
+the fold. Triggered by that dialog with ten tags, where twelve inline swatches per row
+and a five-pane matrix of every tag filled the page and left two session rows showing.
+A change to a tag or session surface is checked against a fixture of thirty tags (the
+dialog's is `ui/timeline-tags-scale.test.ts`, with the measured layout in
+`ui/timeline-tags-scale-browser.test.ts`).

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -283,6 +283,38 @@ function lensLabel(l) {
   if (l.none) parts.push('no tags');
   return parts.join(' + ') || 'All';
 }
+// The folded "pane filters" line for one pane (the user 2026-09-09, whose ten tags made the open
+// matrix fill the dialog): All, no tags, or the tag names the lens shows in the USER'S tag order
+// (`order`, the union's, not the order the chips were clicked in), 'no tags' last as lensLabel puts
+// it, cut with a count past `max` names (six by default; Infinity for the full list a hover shows).
+// Only names the union lists (`order`, when given) count: a rename or a delete leaves the old name in
+// the lens (the kernel keeps unknown names by design), and a name the open matrix draws no chip for is
+// not one the folded line should claim either (review find, 2026-09-09). A lens left with none says so.
+function lensSummary(l, order, max) {
+  if (lensAll(l)) return 'All';
+  const idx = new Map((order || []).map((n, i) => [n, i]));
+  const at = (n) => (idx.has(n) ? idx.get(n) : idx.size);
+  const parts = (l.tags || []).filter((n) => !order || idx.has(n)).sort((a, b) => at(a) - at(b));
+  if (l.none) parts.push('no tags');
+  if (!parts.length) return 'none of the tags here';
+  const cap = max || 6;
+  if (parts.length <= cap) return parts.join(', ');
+  return parts.slice(0, cap).join(', ') + ' +' + (parts.length - cap) + ' more';
+}
+// The Sessions & tags dialog's "pane filters" fold: folded by default, and the choice holds for the
+// page lifetime (a module variable, the way modelChoicesRev does), not per open, so a user who opened
+// the matrix finds it open on the next look and one who left it folded is not shown it again.
+let paneFiltersOpen = false;
+// The tag table's share of the viewport in the Sessions & tags dialog: its natural height up to this,
+// scrolling within itself past it (the height budget is described where the table is built). 30vh over
+// 35vh (measured in Chromium at 1600 wide, thirty tags, forty sessions, filters folded; tag rows shown /
+// session rows shown): 1300px 14/18 against 16/16, 800px 8/7 against 10/5, 700px 7/4 against 8/4. The
+// sessions are the working area, so the two tag rows go; the one cost is that ten tags scroll at 800px
+// (8 of 10 shown) where 35vh showed all ten.
+const TAG_TABLE_CAP = '30vh';
+// The open pane-filter matrix's share: bounded and scrolling within itself, so many tags cannot push
+// the sessions off the card.
+const MATRIX_CAP = '25vh';
 // THIS surface's lens: the timeline keys on actives.timeline (per-surface selections, the user
 // 2026-08-25). A pre-lens blob (an older kernel, a client-held legacy shape) derives its lens from
 // the legacy scalar EXACTLY as the kernel normalizer seeds it — behavior migrates, not just shape:
@@ -924,7 +956,9 @@ function menuTop(anchor, menuH, viewH) {
   const below = anchor.bottom + 4;
   if (below + menuH <= viewH - 6) return below;
   const above = anchor.top - 4 - menuH;
-  if (above >= 6) return above;
+  // above must ALSO end on screen: an anchor rect that sits below the viewport (one translated into
+  // the wrong document, review find 2026-09-09) passed the >= 6 check and put the menu off the bottom
+  if (above >= 6 && above + menuH <= viewH - 6) return above;
   return Math.max(6, viewH - 6 - menuH);
 }
 // Translate a pane-local anchor rect into a host document's coordinates by summing the intervening
@@ -1093,6 +1127,9 @@ class TimelinePanel {
     this._localLens = null;      // {fields, reason}: a filter kept LOCAL because no kernel could save it (the Obsidian panel, kernel down): applied in _curViews, said in the Filter menu, cleared by the next lens write a kernel takes (_kernelViewsAnswer)
     this._viewsMenu = null;      // the Show-dropdown element, when open
     this._viewsDialog = null;    // the sessions/group dialog backdrop, when open
+    this._tagColorPop = null;    // the tag colour popover a dialog row's dot opens, when open
+    this._tagColorAnchor = null; // and the dot it hangs on, re-pointed when a repaint replaces the node
+    this._tagColorFocus = null;  // the row whose dot takes focus at the next repaint (after a pick)
     this._viewsDialogKey = null; // its Escape hook {doc, fn}, removed on every close path
     this._palette = [];          // group color choices (the kernel ships its palette on the payload)
     // "Collapse idle gaps" now lives in the SETTINGS dialog (romp:settings.collapseGaps), moved out of the
@@ -2991,7 +3028,17 @@ class TimelinePanel {
   // flip fix). The anchor rect is translated by the intervening iframes' offsets, moveTip-style. A
   // cross-origin parent (the VS Code webview) throws on frameElement access → fall back to our own
   // pane, which is exactly the pre-host behavior.
-  _menuHost(anchorRect) {
+  //
+  // `anchorEl` (optional): the anchor node. One that already lives in ANOTHER document needs no
+  // translation: the Sessions & tags dialog is adopted into the host document when it opens, so a
+  // node inside it, the colour dot the popover hangs on, measures in host coordinates already, and
+  // translating its rect again put the popover an iframe offset away from the dot, below the viewport
+  // in the web shell's bottom band (review find, 2026-09-09).
+  _menuHost(anchorRect, anchorEl) {
+    const own = anchorEl && anchorEl.ownerDocument;
+    if (own && own !== document) {
+      try { return { win: own.defaultView || window, doc: own, rect: anchorRect }; } catch (e) { /* fall through to the frame walk */ }
+    }
     if (this._tipWin && this._tipWin !== window) {
       try {
         const frames = [];
@@ -3961,6 +4008,7 @@ class TimelinePanel {
   _closeViewsMenu() { if (this._viewsMenu) { this._viewsMenu.remove(); this._viewsMenu = null; } }
   _closeViewsDialog() {
     if (!this._viewsDialog) return;
+    this._closeTagColorPop();   // the colour popover is the dialog's; it never outlives it
     this._viewsDialog.remove(); this._viewsDialog = null; this._viewsDialogBuild = null;
     this._tagEditErr = null;   // a notice the dialog showed was seen; it does not follow the user to the gear or the Filter menu
     this._tagNewDraft = null; this._tagNewInput = null;   // the join menu's draft dies with the dialog (_closeLaneMenu's rule)
@@ -3968,6 +4016,134 @@ class TimelinePanel {
       try { this._viewsDialogKey.doc.removeEventListener('keydown', this._viewsDialogKey.fn); } catch (e) {}
       this._viewsDialogKey = null;
     }
+  }
+
+  // The tag colour popover (the user 2026-09-09): the identity palette, opened from a tag row's colour
+  // dot in the Sessions & tags dialog, in place of the twelve swatches every row used to carry inline
+  // (which made each row three lines tall, so ten tags filled the page). The same swatches in the T164
+  // balanced split, the current one ringed and focused on open; a pick takes the route the inline
+  // swatches took (_editTagUnion color, then the dialog's repaint), so the optimistic copy, the ack and
+  // a refusal behave exactly as before. One popover at a time: opening another closes this one, and
+  // the dot toggles its own shut. It closes on the pick, on Escape (the dialog's key hook, which then
+  // leaves the dialog open) and on a press anywhere else on the dialog (the backdrop's pointerdown).
+  // It lives in the dot's own document beside the dialog, one z-index above it, placed like the
+  // menus: below the dot, flipped above when below cannot hold it (_placeTagColorPop). It closes
+  // rather than float when its dot moves under it: the tag table's scroll and the card's (build),
+  // and the host window's resize; a repaint that rebuilt the row re-places it on the new dot. Tab
+  // leaves it the way Escape does, and focus moving to another element closes it (review, 2026-09-09).
+  _openTagColorPop(tg, anchorEl) {
+    const key = unionKey(tg);
+    const reopen = !!(this._tagColorPop && this._tagColorPop._key === key);
+    this._closeTagColorPop();
+    if (reopen) return;
+    const pop = document.body.createDiv();
+    pop.setAttribute('style', 'position:fixed;z-index:1003;' + MENU_STYLE + 'padding:8px;');
+    pop.dataset.rompMenu = '1';   // the echo writers skip in-menu presses (T213)
+    pop._key = key;
+    pop.setAttribute('role', 'dialog');
+    pop.setAttribute('aria-label', 'colour of \u201c' + tg.name + '\u201d');
+    pop.addEventListener('click', (e) => e.stopPropagation());
+    const pal = this._palette && this._palette.length ? this._palette : [tg.color || MODEL_FG];
+    // balanced swatch rows: ceil-split (T164); a width-driven flex wrap gave arbitrary 5/5/2 runs
+    const cols = Math.ceil(pal.length / Math.ceil(pal.length / 6));
+    const grid = pop.createDiv();
+    grid.setAttribute('role', 'radiogroup');
+    grid.setAttribute('style', 'display:grid;grid-template-columns:repeat(' + cols + ',18px);gap:8px;align-items:center;');
+    const sws = [];
+    const known = pal.indexOf(tg.color) >= 0;
+    pal.forEach((c, i) => {
+      const sw = grid.createSpan();
+      const cur = c === tg.color;
+      sw.setAttribute('role', 'radio');
+      sw.setAttribute('aria-checked', cur ? 'true' : 'false');
+      sw.setAttribute('aria-label', c);
+      sw.setAttribute('tabindex', cur || (!known && i === 0) ? '0' : '-1');   // one tab stop; the arrows move it
+      // the current swatch wears an INNER ring (two inset shadows: the colour's own edge, then the ring),
+      // never an outline: an inline outline replaced the browser's focus ring, so focus on open (which
+      // lands on this very swatch) was indistinguishable from "current" (review find, 2026-09-09). The
+      // focus ring stays the browser's :focus-visible outline, outside the swatch.
+      sw.setAttribute('style', 'display:inline-block;width:18px;height:18px;border-radius:50%;cursor:pointer;background:' + c + ';'
+        + (cur ? 'box-shadow:inset 0 0 0 2px ' + c + ',inset 0 0 0 4px ' + MENU_FG + ';' : 'opacity:0.7;'));
+      if (!cur) {
+        sw.addEventListener('mouseenter', () => { sw.style.opacity = '1'; });
+        sw.addEventListener('mouseleave', () => { sw.style.opacity = '0.7'; });
+      }
+      const pick = () => {
+        this._closeTagColorPop();
+        this._tagColorFocus = key;   // the repaint puts focus back on this row's dot
+        // the tag as the dialog shows it NOW, not as it was when the popover opened: a repaint in
+        // between (an ack, a refusal) rebuilds the union objects
+        const now = viewTagUnion(this._curViews()).find((u) => unionKey(u) === key) || tg;
+        this._editTagUnion(now, { color: c });
+        if (this._viewsDialogBuild) this._viewsDialogBuild();
+      };
+      sw.addEventListener('click', pick);
+      sw.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); pick(); return; }
+        // Tab (either direction) leaves the palette the way Escape does: closed, focus back on the dot,
+        // which is the tab stop before and after it. Left alone, Tab moved focus out to the body and
+        // left the palette open with nothing focused inside it (review find, 2026-09-09).
+        if (e.key === 'Tab') { e.preventDefault(); this._closeTagColorPop(true); return; }
+        const step = e.key === 'ArrowRight' ? 1 : e.key === 'ArrowLeft' ? -1 : e.key === 'ArrowDown' ? cols : e.key === 'ArrowUp' ? -cols : 0;
+        if (!step) return;
+        e.preventDefault();
+        const j = Math.max(0, Math.min(sws.length - 1, i + step));
+        sws.forEach((s2, k) => s2.setAttribute('tabindex', k === j ? '0' : '-1'));
+        try { sws[j].focus(); } catch (e2) {}
+      });
+      sws.push(sw);
+    });
+    // focus that moved to another element outside the popover (not its dot, whose click toggles) closes
+    // it; a move within it (the arrows) or to nothing at all (the window losing focus) leaves it open
+    pop.addEventListener('focusout', (e) => {
+      const to = e.relatedTarget;
+      if (!to || this._tagColorPop !== pop || to === this._tagColorAnchor) return;
+      for (let n = to; n; n = n.parentNode) if (n === pop) return;
+      this._closeTagColorPop();
+    });
+    pop._minW = cols * 26 + 16;   // the width to clamp by before the first layout
+    this._tagColorPop = pop;
+    this._tagColorAnchor = anchorEl;
+    const h = this._placeTagColorPop(anchorEl);
+    // a resize re-centres the card and moves the dot with it: the popover closes rather than float
+    const onResize = () => this._closeTagColorPop();
+    try { h.win.addEventListener('resize', onResize); pop._resize = { win: h.win, fn: onResize }; } catch (e) {}
+    try { anchorEl.setAttribute('aria-expanded', 'true'); } catch (e) {}
+    const first = sws.find((s2) => s2.getAttribute('aria-checked') === 'true') || sws[0];
+    setTimeout(() => { try { first.focus(); } catch (e) {} }, 0);
+  }
+  // `refocus`: focus back on the dot (Escape). A pick refocuses through the repaint instead, and an
+  // outside press leaves focus where the press put it.
+  _closeTagColorPop(refocus) {
+    const pop = this._tagColorPop;
+    if (!pop) return;
+    if (pop._resize) { try { pop._resize.win.removeEventListener('resize', pop._resize.fn); } catch (e) {} }
+    pop.remove(); this._tagColorPop = null;
+    const a = this._tagColorAnchor; this._tagColorAnchor = null;
+    if (a) { try { a.setAttribute('aria-expanded', 'false'); if (refocus) a.focus(); } catch (e) {} }
+  }
+  // Place the open popover by its dot, in the dot's own document (_menuHost with the element, so a
+  // dot inside the host-adopted dialog is not translated a second time): on open, and again after a
+  // repaint rebuilt the row, whose place can change (a notice inserted above the table, a row added
+  // or removed above it). Records the dot's rect so the scroll listeners can tell a dot that moved
+  // (_tagColorPopMoved) from a scroll event that moved nothing (the repaint's scroll restore).
+  _placeTagColorPop(anchorEl) {
+    const pop = this._tagColorPop;
+    if (!pop) return null;
+    const rect = anchorEl.getBoundingClientRect();
+    const h = this._menuHost(rect, anchorEl);
+    if (pop.parentNode !== h.doc.body) h.doc.body.appendChild(pop);
+    const w = pop.offsetWidth || pop._minW || 0;
+    pop.style.left = Math.max(6, Math.min(Math.round(h.rect.left), (h.win.innerWidth || 9999) - w - 6)) + 'px';
+    pop.style.top = Math.round(menuTop(h.rect, pop.offsetHeight || 0, h.win.innerHeight || 9999)) + 'px';
+    pop._anchorAt = { left: rect.left, top: rect.top };
+    return h;
+  }
+  _tagColorPopMoved() {
+    const pop = this._tagColorPop, a = this._tagColorAnchor;
+    if (!pop || !a || !pop._anchorAt) return false;
+    const r = a.getBoundingClientRect();
+    return Math.abs(r.left - pop._anchorAt.left) > 0.5 || Math.abs(r.top - pop._anchorAt.top) > 0.5;
   }
 
   _openViewsMenu(anchorEl) {
@@ -4150,8 +4326,11 @@ class TimelinePanel {
     // MENU padding (4px), and in one style string the later declaration wins — with the paddings
     // stated first the dialog had been rendering 4px edges all along, which IS the claustrophobia
     // the user reported (2026-08-25); the 14px/22px in the source never applied.
+    // ...and it SCROLLS as a whole, never clips, when a page is shorter than its minimum content (the
+    // floors below: the sessions' four rows, the tag table's, the open matrix's), so nothing is ever out
+    // of reach (a phone held sideways clipped the search box and tag all, review find 2026-09-09).
     card.setAttribute('style', MENU_STYLE + 'box-sizing:border-box;width:min(1200px,90vw);max-height:90vh;'
-      + 'overflow:hidden;display:flex;flex-direction:column;padding:22px 26px;font-size:13px;');
+      + 'overflow-y:auto;overflow-x:hidden;display:flex;flex-direction:column;padding:22px 26px;font-size:13px;');
     card.addEventListener('click', (e) => e.stopPropagation());
     // the open [+] menu's key rides the INSTANCE (this._tagAddFor: sid, or '*' for the bulk bar)
     // so the shared join builder can close it from either surface — the dialog or the lane gear
@@ -4168,6 +4347,24 @@ class TimelinePanel {
         return [pre.toLowerCase(), s.name.slice(pre.length)];
       return [null, s.name || String(s.id || '').slice(0, 8)];
     };
+    // the tag table of the LAST build, read for its scroll before the rebuild tears it down (in build)
+    let tgridEl = null;
+    // the two floors, set by build once its rows are laid out (see each box's style), and the row heights
+    // the last build measured (kept across repaints: a query that hides every row has none to measure, and a
+    // build in a document without layout reads 0)
+    let tgridFloor = () => {}, gridFloor = () => {}, sessRowH = 0, tagRowH = 0;
+    // a grid row's rendered height: the tallest of its cells (align-items:center seats them in one track);
+    // 0 when nothing is laid out
+    const rowHeight = (cells) => {
+      let top = Infinity, bottom = -Infinity;
+      for (const c of cells) { const r = c.getBoundingClientRect(); top = Math.min(top, r.top); bottom = Math.max(bottom, r.bottom); }
+      return cells.length && bottom > top ? bottom - top : 0;
+    };
+    // a scroll under the open colour popover (the tag table's, or the card's on a short page) moves its
+    // dot away: the popover closes rather than float; a scroll event that moved nothing (the repaint's
+    // scroll restore) leaves it where it is (review find, 2026-09-09)
+    const scrolledUnderPop = () => { if (this._tagColorPopMoved()) this._closeTagColorPop(); };
+    card.addEventListener('scroll', scrolledUnderPop, { passive: true });
     const build = () => {
       // the open rename input's text and caret, read from the live element before it is torn down —
       // the `input` listener keeps the text current, but the caret can move without one (arrow keys)
@@ -4177,6 +4374,10 @@ class TimelinePanel {
         if (typeof live.selectionStart === 'number') { this._tagRenameDraft.selStart = live.selectionStart; this._tagRenameDraft.selEnd = live.selectionEnd; }
       }
       this._tagRenameInput = null;
+      // the tag table's scroll survives the repaint (a colour pick, an ack, a peer's edit snapped it to
+      // the top; review find 2026-09-09): read off the live table now, restored once the card is complete
+      const tgridTop = tgridEl ? (tgridEl.scrollTop || 0) : 0;
+      tgridEl = null;
       card.textContent = '';
       const v = this._curViews();
       // NAME-KEYED (user ruling 2026-08-24): whichever store's id opened this, the header is the
@@ -4202,7 +4403,7 @@ class TimelinePanel {
       // the actions: delete | rename | the color. The user's rationale: it reads clearly as
       // deleting/renaming THE TAG. All at the dialog's own scale (the few-sizes rule); remote-
       // homed tags still ride the v1 editTag route with its loud refusals. [+ New tag] is the
-      // table's FINAL ROW.
+      // card's row UNDER the table, outside its scroll (since 2026-09-09; it was the table's final row).
       {
         const capT = card.createDiv();
         capT.setAttribute('style', 'display:flex;align-items:center;gap:6px;margin:4px 0;');
@@ -4211,8 +4412,43 @@ class TimelinePanel {
         ct.setAttribute('style', 'font-size:0.82em;opacity:0.6;font-style:italic;white-space:nowrap;');
         capT.createDiv().setAttribute('style', 'height:1px;flex:1;background:' + HAIRLINE + ';');
         const tgrid = card.createDiv();
-        tgrid.setAttribute('style', 'display:grid;grid-template-columns:max-content max-content max-content 1fr;'
-          + 'column-gap:14px;row-gap:4px;align-items:center;margin:2px 0 6px;');
+        tgridEl = tgrid;
+        // THE HEIGHT BUDGET (the user 2026-09-09: with many tags the sections above the sessions took
+        // the page; the review's 800px and 700px pages, 2026-09-09). The table keeps its natural height
+        // up to a share of the viewport (TAG_TABLE_CAP) and scrolls within itself past that. When height
+        // runs out the sessions box gives way first (its flex-shrink is a thousandfold, so a table that
+        // fits is never squeezed while the sessions have room) but never below its floor of four rows;
+        // at that floor the table and the open filter matrix give way, the table down to three rows;
+        // and when the floors together outgrow the card, the card scrolls (overflow-y:auto) instead of
+        // clipping. The padding is room inside the clip for the pills' and the dots' rings (a scroll
+        // container clips its descendants' outlines); the negative margins keep the layout put.
+        // THE FLOOR is measured, not a constant (review find, 2026-09-09: a 22px-a-row constant left 6px
+        // of blank under one tag and cut the third of three rows by 7px, the row height being the font's):
+        // a table of at most three rows does not shrink at all (its natural height IS its rows: no blank,
+        // no scroll), and a taller one may shrink to three rows at its first row's rendered height, set
+        // once the rows are laid out (tgridFloor, at the end of build); no rows, no box and no padding. The
+        // row height is kept across builds (tagRowH): a build in a document without layout reads 0 and
+        // keeps the last floor rather than dropping to none.
+        // overflow-anchor:none: with scroll anchoring on, a reorder cue leaving the first partly clipped
+        // row moves that row's pill 2px and the browser shifts scrollTop by 2 to hold it, which with the
+        // drag's exact measurement re-admits the row, so the cue and the scroll oscillate every frame
+        // (traced in Chromium and Firefox); the cap's own scroll is unaffected.
+        const rowsN = viewTagUnion(v).length;
+        const tgridStyle = (floor) => 'display:grid;grid-template-columns:max-content max-content max-content 1fr;'
+          + 'column-gap:14px;row-gap:4px;align-items:center;'
+          + (rowsN ? 'padding:4px 0 4px 4px;margin:-2px 0 2px -4px;' : 'padding:0;margin:0;')
+          + (rowsN > 3 ? 'flex:0 1 auto;min-height:' + floor + 'px;' : 'flex:0 0 auto;')
+          + 'max-height:' + TAG_TABLE_CAP + ';overflow-y:auto;overflow-anchor:none;';
+        tgrid.setAttribute('style', tgridStyle(0));
+        tgridFloor = () => {
+          if (rowsN <= 3) return;
+          const cells = Array.from(tgrid.children).filter((c) => c._tname);
+          const kids = Array.from(tgrid.children);
+          const h = rowHeight(kids.slice(kids.indexOf(cells[0]), kids.indexOf(cells[1])));
+          if (h > 0) tagRowH = h;
+          if (tagRowH) tgrid.setAttribute('style', tgridStyle(Math.round((3 * tagRowH + 2 * 4) * 100) / 100));
+        };
+        tgrid.addEventListener('scroll', scrolledUnderPop, { passive: true });
         // `held`: the reason a gesture cannot be honoured here; the action renders disabled (dim, no
         // pointer, aria-disabled) wearing that reason as its tooltip, in place of a click that could
         // only end in the refusal notice (review find, 2026-09-08)
@@ -4228,6 +4464,9 @@ class TimelinePanel {
           a.setAttribute('title', title);
           return a;
         };
+        // the open colour popover's dot as this build drew it, when it drew one it can hang on (see the check
+        // after the loop)
+        let popDot = null;
         for (const tg of viewTagUnion(v)) {
           // a create still in flight (`pending`) is not editable and not draggable: its row wears
           // the placeholder id the ack replaces, and an op addressed by it would be refused as a tag
@@ -4260,20 +4499,53 @@ class TimelinePanel {
               try { pillCell.setPointerCapture(e.pointerId); } catch (e2) {}
               pillCell.style.opacity = '0.45';
               const clearCues = () => cells.forEach((c) => { c.style.borderTop = ''; c.style.borderBottom = ''; });
-              const onMove = (ev) => {
-                const ys = cells.map((c) => { const r = c.getBoundingClientRect(); return (r.top + r.bottom) / 2; });
-                let idx = ys.findIndex((y) => ev.clientY < y);
-                if (idx < 0) idx = cells.length - 1;
+              // THE CANDIDATES are the rows whose whole box, plus the 2px the cue adds, lies inside the
+              // table's visible box (the table scrolls now; review 2026-09-09, then with real pointer
+              // events: a row whose centre was inside the box but whose bottom edge was under the clip
+              // took the cue and the drop while the cue, a border on that very edge, painted under the
+              // clip, invisible). The held row itself counts as a candidate while any of it shows, so
+              // dragging a row cut by the edge past that edge leaves it where it is rather than ranking
+              // the whole row above it and moving it AGAINST the gesture. THE CUE COMES OFF FOR THE
+              // MEASUREMENT: the pill cell is the tallest of its row, so a cue on EITHER edge grows the
+              // cell 2px at the bottom and pushes every row under it 2px down (measured in both browsers;
+              // arithmetic on the cued cell alone judged a top-cued row 2px low and corrected no row under
+              // a cued row, so a stepped drag past the table's edge lost a last row with 2 to 4px of room
+              // and a top cue landed one row above the pointer). The border is cleared, the rects read,
+              // and the border put back in the same task, so nothing paints between; the table's
+              // overflow-anchor:none keeps the browser from scrolling to follow the 2px the lift moves.
+              // The rects are live, and the ranking re-runs with the last pointer y on the table's scroll
+              // (a wheel mid-drag fires no pointermove), so the rows scrolled into view take the cue and the
+              // drop; the drop itself re-ranks when the table has scrolled since the grab, for a scroll
+              // whose event has not landed yet.
+              let lastY = e.clientY;
+              const top0 = tgrid.scrollTop;
+              const rank = (y) => {
+                if (typeof y !== 'number') return;
+                const cuedEl = toIdx !== fromIdx ? cells[toIdx] : null, cuedSide = toIdx > fromIdx ? 'borderBottom' : 'borderTop';
+                if (cuedEl) cuedEl.style[cuedSide] = '';
+                const box = tgrid.getBoundingClientRect();
+                const shown = cells.map((c, i) => {
+                  const r = c.getBoundingClientRect();
+                  return { i, y: (r.top + r.bottom) / 2, whole: r.top >= box.top && r.bottom + 2 <= box.bottom, seen: r.bottom > box.top && r.top < box.bottom };
+                }).filter((p) => p.whole || (p.i === fromIdx && p.seen));
+                if (cuedEl) cuedEl.style[cuedSide] = '2px solid #9cd2ff';
+                if (!shown.length) return;
+                const hit = shown.find((p) => y < p.y);
+                const idx = hit ? hit.i : shown[shown.length - 1].i;
                 if (idx !== toIdx) {
                   toIdx = idx;
                   clearCues();
                   if (toIdx !== fromIdx) cells[toIdx].style[toIdx > fromIdx ? 'borderBottom' : 'borderTop'] = '2px solid #9cd2ff';
                 }
               };
+              const onMove = (ev) => { lastY = ev.clientY; rank(lastY); };
+              const onScroll = () => rank(lastY);
               const onUp = () => {
+                if (tgrid.scrollTop !== top0) rank(lastY);
                 pillCell.removeEventListener('pointermove', onMove);
                 pillCell.removeEventListener('pointerup', onUp);
                 pillCell.removeEventListener('pointercancel', onUp);
+                tgrid.removeEventListener('scroll', onScroll);
                 pillCell.style.opacity = '';
                 clearCues();
                 if (toIdx === fromIdx) return;
@@ -4288,6 +4560,7 @@ class TimelinePanel {
               pillCell.addEventListener('pointermove', onMove);
               pillCell.addEventListener('pointerup', onUp);
               pillCell.addEventListener('pointercancel', onUp);
+              tgrid.addEventListener('scroll', onScroll, { passive: true });
             });
           }
           if (this._tagEditorFor === unionKey(tg) && editable) {
@@ -4368,29 +4641,52 @@ class TimelinePanel {
             r.addEventListener('click', () => { this._tagEditorFor = this._tagEditorFor === unionKey(tg) ? null : unionKey(tg); this._tagRenameDraft = null; build(); });
             }
           }
-          // the color — the identity-palette swatches inline in the row's last column
+          // the colour: ONE dot wearing the tag's colour (the user 2026-09-09: the inline palette,
+          // twelve swatches per row, made every row three lines tall and ten tags filled the page).
+          // The palette opens on demand as a popover anchored to the dot (_openTagColorPop: click, or
+          // Enter / Space on it); a pick there takes the route the inline swatches took.
           const colCell = tgrid.createDiv();
-          // balanced swatch rows: ceil-split (T164) — width-driven flex wrap gave arbitrary 5/5/2
-          // runs; inline styles are this file's convention (it also runs inside Obsidian)
-          const swN = (this._palette && this._palette.length) || 1;
-          const swCols = Math.ceil(swN / Math.ceil(swN / 6));
-          colCell.setAttribute('style', 'display:grid;grid-template-columns:repeat(' + swCols
-            + ',14px);gap:6px;align-items:center;');
+          colCell.setAttribute('style', 'display:flex;align-items:center;');
           if (editable) {
-            if (held) { colCell.setAttribute('title', held); colCell.setAttribute('aria-disabled', 'true'); }
-            for (const c of (this._palette && this._palette.length ? this._palette : [tc])) {
-              const sw = colCell.createSpan();
-              sw.setAttribute('style', 'width:14px;height:14px;border-radius:50%;cursor:' + (held ? 'default' : 'pointer') + ';background:' + c + ';'
-                + (c === tg.color ? 'outline:2px solid #ffffff;outline-offset:1px;' : held ? 'opacity:0.35;' : 'opacity:0.7;'));
-              if (!held) sw.addEventListener('click', () => { this._editTagUnion(tg, { color: c }); build(); });
+            const dot = colCell.createSpan();
+            dot.dataset.tagDot = unionKey(tg);   // the popover's anchor, re-found after a repaint
+            dot.setAttribute('role', 'button');
+            dot.setAttribute('style', 'display:inline-block;width:14px;height:14px;border-radius:50%;background:' + tc + ';'
+              + (held ? 'cursor:default;opacity:0.35;' : 'cursor:pointer;'));
+            if (held) { dot.setAttribute('title', held); dot.setAttribute('aria-disabled', 'true'); }
+            else {
+              const open = !!(this._tagColorPop && this._tagColorPop._key === unionKey(tg));
+              dot.setAttribute('tabindex', '0');
+              dot.setAttribute('title', 'change the colour of \u201c' + tg.name + '\u201d');
+              dot.setAttribute('aria-haspopup', 'dialog');
+              dot.setAttribute('aria-expanded', open ? 'true' : 'false');
+              const ring = (c) => { dot.style.outline = c ? '2px solid ' + c : ''; dot.style.outlineOffset = c ? '2px' : ''; };
+              dot.addEventListener('mouseenter', () => ring(OUTLINE_FG));   // hover: the outline chrome
+              dot.addEventListener('mouseleave', () => ring(''));
+              dot.addEventListener('focus', () => ring(ACCENT));            // focus: the accent cue
+              dot.addEventListener('blur', () => ring(''));
+              dot.addEventListener('click', () => this._openTagColorPop(tg, dot));
+              dot.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this._openTagColorPop(tg, dot); } });
+              if (open) { this._tagColorAnchor = dot; popDot = dot; }   // this repaint replaced the node the popover hangs on
+              if (this._tagColorFocus === unionKey(tg)) {   // a pick closed the popover: focus lands back on the dot
+                this._tagColorFocus = null;
+                setTimeout(() => { try { dot.focus(); } catch (e) {} }, 0);
+              }
             }
           }
         }
-        // [+ New tag] — the table's final row, at the dialog's own scale. While a create is in flight
-        // the row reads "creating…" and takes no click (the 2026-09-05 review: a second
-        // click before the ack made a second tag); the ack's repaint brings the button back.
-        const ntRow = tgrid.createDiv();
-        ntRow.setAttribute('style', 'grid-column:1 / -1;');
+        // a repaint that drew no live dot for the popover's tag closes it: its row is gone (the tag deleted from
+        // another surface), or its dot is held now (a remote half landed with no bridge to reach it, so a pick
+        // could only be refused). Left open, the popover hung on the detached dot of the last build, whose rect
+        // is all zeros, and the re-place below read that as a place (review find, 2026-09-09)
+        if (this._tagColorPop && !popDot) this._closeTagColorPop();
+        // [+ New tag]: the row under the table, at the dialog's own scale, its own flex child rather than the
+        // table's last row, so it never scrolls under the table's fold (with ten tags at 800px the cap
+        // held exactly the ten rows and hid it, review find 2026-09-09). While a create is in flight the
+        // row reads "creating…" and takes no click (the 2026-09-05 review: a second click before the ack
+        // made a second tag); the ack's repaint brings the button back.
+        const ntRow = card.createDiv();
+        ntRow.setAttribute('style', 'flex:0 0 auto;margin:0 0 6px;');
         if (this._createInFlight()) {
           const busy = ntRow.createSpan({ text: 'creating…' });
           busy.setAttribute('style', 'display:inline-flex;align-items:center;justify-content:center;padding:1px 9px;'
@@ -4439,8 +4735,20 @@ class TimelinePanel {
         const capF = card.createDiv();
         capF.setAttribute('style', 'display:flex;align-items:center;gap:6px;margin:4px 0;');
         capF.createDiv().setAttribute('style', 'height:1px;flex:0 0 8px;background:' + HAIRLINE + ';');
-        const cf = capF.createSpan({ text: 'pane filters — what each pane shows' });
-        cf.setAttribute('style', 'font-size:0.82em;opacity:0.6;font-style:italic;white-space:nowrap;');
+        // the caption is the section's fold (the user 2026-09-09: five rows of every tag each, with ten
+        // tags, filled the dialog). Folded, the section is one summary line per pane; the caret opens
+        // the matrix. The choice holds for the page (paneFiltersOpen), not per open.
+        const cf = capF.createSpan({ text: 'pane filters — what each pane shows ' + (paneFiltersOpen ? '\u25BE' : '\u25B8') });
+        cf.setAttribute('style', 'font-size:0.82em;opacity:0.6;font-style:italic;white-space:nowrap;cursor:pointer;');
+        cf.setAttribute('role', 'button');
+        cf.setAttribute('tabindex', '0');
+        cf.setAttribute('aria-expanded', paneFiltersOpen ? 'true' : 'false');
+        cf.setAttribute('title', paneFiltersOpen ? 'fold the filters to a summary' : 'open the filters to change them');
+        cf.addEventListener('mouseenter', () => { cf.style.opacity = '1'; });
+        cf.addEventListener('mouseleave', () => { cf.style.opacity = '0.6'; });
+        const toggleFilters = () => { paneFiltersOpen = !paneFiltersOpen; build(); };
+        cf.addEventListener('click', toggleFilters);
+        cf.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleFilters(); } });
         capF.createDiv().setAttribute('style', 'height:1px;flex:1;background:' + HAIRLINE + ';');
         const acts = v.actives || {};
         const feedEcho = () => {
@@ -4465,35 +4773,66 @@ class TimelinePanel {
           build();
         };
         const rows = [['All surfaces', '*'], ['Chat', 'chat'], ['Sessions', 'timeline'], ['Outline', 'outline'], ['Feed', 'feed']];
-        for (const [label, key] of rows) {
-          const row = card.createDiv();
-          row.setAttribute('style', 'display:flex;align-items:center;gap:6px;margin:2px 0;flex-wrap:wrap;');
+        const paneRow = (label, key, parent) => {   // the label column both forms share, so folding moves nothing sideways
+          const row = (parent || card).createDiv();
+          row.setAttribute('style', 'display:flex;align-items:center;gap:6px;margin:2px 0;');
           const lb = row.createSpan({ text: label });
           lb.setAttribute('style', 'flex:0 0 88px;font-size:0.82em;opacity:0.6;font-style:italic;');
           if (key === 'feed') lb.setAttribute('title', "as last set from this dialog — the feed pane's own filter button may have changed it since");
-          const lens = lensFor(key);
-          const mixed = lens === null;
-          const base = mixed ? { all: true } : lens;
-          const pill = (text, selected, color, apply) => {
-            const c2 = color || MODEL_FG;
-            const s2 = row.createSpan({ text });
-            s2.setAttribute('style', 'cursor:pointer;padding:1px 8px;border-radius:9px;font-size:0.82em;'
-              + 'border:1px solid ' + c2 + ';color:' + c2 + ';'
-              + (selected ? 'background:' + SEL_BG + ';opacity:1;font-weight:650;' : 'background:transparent;opacity:0.6;'));
-            s2.addEventListener('mouseenter', () => { s2.style.opacity = '1'; });
-            s2.addEventListener('mouseleave', () => { if (!selected) s2.style.opacity = '0.6'; });
-            s2.addEventListener('click', apply);
-            return s2;
-          };
-          pill('All', !mixed && lensAll(base), null, () => applyFor(key, { all: true }));
-          pill('no tags', !mixed && !lensAll(base) && !!base.none, null, () => applyFor(key, lensToggle(base, 'none')));
-          for (const g of viewTagUnion(v))
-            pill(g.name, !mixed && !lensAll(base) && (base.tags || []).indexOf(g.name) >= 0, g.color || MODEL_FG,
-              () => applyFor(key, lensToggle(base, { tag: g.name })));
-          if (mixed) {
-            const mx = row.createSpan({ text: '(mixed)' });
-            mx.setAttribute('style', 'font-size:0.82em;opacity:0.5;font-style:italic;');
-            mx.setAttribute('title', 'the four panes currently hold different filters — picking here sets them all the same way');
+          return row;
+        };
+        if (!paneFiltersOpen) {
+          // FOLDED: one line per pane (the bulk row is a control, not a pane) saying what it shows, in
+          // the user's tag order, cut with a count when long; the full list is the hover
+          const order = viewTagUnion(v).map((g) => g.name);
+          for (const [label, key] of rows) {
+            if (key === '*') continue;
+            const row = paneRow(label, key);
+            const lens = lensFor(key);
+            const sm = row.createSpan({ text: lensSummary(lens, order) });
+            sm.setAttribute('style', 'font-size:0.82em;opacity:0.85;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;');
+            // the hover: the full list, plus the names the lens still carries that no tag here answers to
+            // (a rename or a delete leaves them behind; the open matrix draws no chip for them)
+            const gone = lens && !lensAll(lens) ? (lens.tags || []).filter((n) => order.indexOf(n) < 0) : [];
+            sm.setAttribute('title', lensSummary(lens, order, Infinity) + (!gone.length ? ''
+              : '; the filter also names ' + gone.join(', ') + ', and no tag here has ' + (gone.length > 1 ? 'those names' : 'that name') + ' now'));
+          }
+        } else {
+          // OPEN: the five rows in a cell of their own, bounded (MATRIX_CAP) and scrolling within itself,
+          // so thirty tags cannot push the sessions off the card (review find, 2026-09-09); it gives way
+          // with the tag table once the sessions are at their floor, and keeps two lines of its own
+          const mbox = card.createDiv();
+          mbox.setAttribute('style', 'flex:0 1 auto;min-height:52px;max-height:' + MATRIX_CAP + ';overflow-y:auto;overflow-x:hidden;');
+          for (const [label, key] of rows) {
+            const row = paneRow(label, key, mbox);
+            // the chips wrap inside their own cell, so a long row's second line starts under the first
+            // chip, not under the pane label (thirty tags wrap by design, not under pressure)
+            const cell = row.createDiv();
+            cell.setAttribute('style', 'display:flex;align-items:center;gap:6px;flex-wrap:wrap;flex:1 1 auto;min-width:0;');
+            const lens = lensFor(key);
+            const mixed = lens === null;
+            const base = mixed ? { all: true } : lens;
+            const pill = (text, selected, color, apply) => {
+              const c2 = color || MODEL_FG;
+              const s2 = cell.createSpan({ text });
+              s2.setAttribute('style', 'cursor:pointer;padding:1px 8px;border-radius:9px;font-size:0.82em;'
+                + 'border:1px solid ' + c2 + ';color:' + c2 + ';'
+                + (selected ? 'background:' + SEL_BG + ';opacity:1;font-weight:650;' : 'background:transparent;opacity:0.6;'));
+              s2.addEventListener('mouseenter', () => { s2.style.opacity = '1'; });
+              s2.addEventListener('mouseleave', () => { if (!selected) s2.style.opacity = '0.6'; });
+              s2.addEventListener('click', apply);
+              return s2;
+            };
+            pill('All', !mixed && lensAll(base), null, () => applyFor(key, { all: true }));
+            pill('no tags', !mixed && !lensAll(base) && !!base.none, null, () => applyFor(key, lensToggle(base, 'none')));
+            for (const g of viewTagUnion(v))
+              pill(g.name, !mixed && !lensAll(base) && (base.tags || []).indexOf(g.name) >= 0, g.color || MODEL_FG,
+                () => applyFor(key, lensToggle(base, { tag: g.name })));
+            if (mixed) {
+              const mx = cell.createSpan({ text: '(mixed)' });
+              mx.setAttribute('style', 'font-size:0.82em;opacity:0.5;font-style:italic;');
+              mx.setAttribute('title', 'the four panes currently hold different filters — picking here sets them all the same way');
+            }
           }
         }
       }
@@ -4530,7 +4869,34 @@ class TimelinePanel {
       const gridBox = card.createDiv();
       // the TABLE scrolls within the modal (the user 2026-08-25) — header, scope, tags, and the
       // bulk bar stay put; only the session rows pan (the .cmt-msgs overflow idiom family)
-      gridBox.setAttribute('style', 'flex:1 1 auto;min-height:0;overflow-y:auto;');
+      // it gives way FIRST when height runs out (the thousandfold flex-shrink: a tag table that fits is
+      // never squeezed while the sessions have room) and never below four rows, its floor: past it the
+      // tag table and the open matrix give way, and past their floors the card scrolls (review, 2026-09-09).
+      // The floor is sized under the rows there are: min(live, 4) rows at the SMALLEST rendered row height
+      // plus the gaps, set at the end of build (gridFloor). Review finds, 2026-09-09: a fixed 96px held 74px
+      // of blank over one live session; then the first row's height, times four, held 74px of blank again
+      // when that row's chips wrapped (a session in many tags at the phone shell's 351px card), so the
+      // smallest row sizes the floor: a wrapped row can make the box hold fewer whole rows, never blank. The
+      // LIVE count, not the search hits, so typing in the search box never moves the floor (on a short page
+      // the box stays put under a query; on a tall one it still shrinks to its hits, the content sizing it
+      // has always had); the rows are measured on an unfiltered build only (a query could leave the wrapped
+      // row alone on screen) and the height is kept across builds, so a build under a query, or in a
+      // document without layout, keeps the last measured floor.
+      const liveN = ((this.data && this.data.sessions) || []).filter((s) => s.live).length;
+      const gridStyle = (floor) => 'flex:1 1000 auto;min-height:' + floor + 'px;overflow-y:auto;';
+      gridBox.setAttribute('style', gridStyle(0));
+      gridFloor = () => {
+        const k = Math.min(liveN, 4);
+        const grid = gridBox.children[0];
+        const kids = grid ? Array.from(grid.children).filter((c) => !String(c.getAttribute('style') || '').startsWith('grid-column:1 / -1;')) : [];
+        const names = kids.filter((c) => c._sid);
+        if (!query.trim()) {
+          // a row's cells are the kids from its name cell up to the next row's
+          const hs = names.map((n, i) => rowHeight(kids.slice(kids.indexOf(n), names[i + 1] ? kids.indexOf(names[i + 1]) : kids.length))).filter((h) => h > 0);
+          if (hs.length) sessRowH = Math.min(...hs);
+        }
+        gridBox.setAttribute('style', gridStyle(k && sessRowH ? Math.round((k * sessRowH + (k - 1) * 3) * 100) / 100 : 0));
+      };
       const renderRows = () => {
         gridBox.textContent = '';
         const needle = query.trim().toLowerCase();
@@ -4628,15 +4994,40 @@ class TimelinePanel {
       renderRows();
       // a repaint mid-typing keeps the search box live: re-focus with the caret at the end
       if (query) { q.focus(); try { q.setSelectionRange(q.value.length, q.value.length); } catch (e) {} }
+      // the floors, off the rendered rows now that they are laid out (the card is in its final document
+      // before the first build: the open appends it to the host before building), before the scroll
+      // restore reads the final height
+      tgridFloor(); gridFloor();
+      // the tag table's scroll, restored now that the card is complete and the table has its final
+      // height (written earlier it lands against a taller table and clamps low); a table that no longer
+      // scrolls clamps it to 0 itself
+      if (tgridTop && tgridEl) tgridEl.scrollTop = tgridTop;
+      // the colour popover survived the repaint on a rebuilt dot: hang it on the dot's new place, or
+      // close it when the row is no longer inside the table's visible box (nothing on screen to hang on)
+      if (this._tagColorPop && this._tagColorAnchor && tgridEl) {
+        const r = this._tagColorAnchor.getBoundingClientRect(), b = tgridEl.getBoundingClientRect();
+        if (r.bottom > b.top && r.top < b.bottom) this._placeTagColorPop(this._tagColorAnchor); else this._closeTagColorPop();
+      }
     };
+    // the card is in its FINAL document before the first build: the floors are measured off the laid-out
+    // rows, and a card built in the pane's own document lays out at 90vw of the pane's viewport rather than
+    // the host's (review find, 2026-09-09: in a narrow same-origin frame the first floors were a frame's
+    // worth of wrapped rows until the first repaint; from a hidden pane they were 0)
+    const h = this._menuHost({ left: 0, top: 0, bottom: 0, right: 0 });
+    h.doc.body.appendChild(back);
     build();
     this._viewsDialogBuild = build;   // tagEditFailed repaints the open dialog with the refusal
-    const h = this._menuHost({ left: 0, top: 0, bottom: 0, right: 0 });
-    back.addEventListener('pointerdown', (e) => { if (e.target === back) this._closeViewsDialog(); });
-    const onKey = (e) => { if (e.key === 'Escape') this._closeViewsDialog(); };
+    back.addEventListener('pointerdown', (e) => {
+      // a press anywhere on the dialog outside the colour popover closes it (the popover lives beside
+      // the dialog in the host document, so its own presses never arrive here); a press on its own
+      // dot is left to the dot's click, which toggles it shut
+      if (this._tagColorPop && e.target !== this._tagColorAnchor) this._closeTagColorPop();
+      if (e.target === back) this._closeViewsDialog();
+    });
+    // Escape closes the colour popover first (focus back on its dot); the dialog goes on the next press
+    const onKey = (e) => { if (e.key === 'Escape') { if (this._tagColorPop) this._closeTagColorPop(true); else this._closeViewsDialog(); } };
     h.doc.addEventListener('keydown', onKey);
     this._viewsDialogKey = { doc: h.doc, fn: onKey };
-    h.doc.body.appendChild(back);
     this._viewsDialog = back;
   }
 
@@ -6361,4 +6752,4 @@ class TimelinePanel {
   body(s) { return s ? '<div class="b">' + s + '</div>' : ''; }
 }
 
-module.exports = { TimelinePanel, expandBar, expandBars, expandJudging, BAR_WIRE, JUDGING_WIRE, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText, menuTop, offsetRect, viewVisible, viewLabel, viewMoreCount, viewToggleMember, viewTagUnion, lensAll, lensToggle, lensVisible, lensLabel, timelineLens, loadModelChoices, MODEL_CHOICES };
+module.exports = { TimelinePanel, expandBar, expandBars, expandJudging, BAR_WIRE, JUDGING_WIRE, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText, menuTop, offsetRect, viewVisible, viewLabel, viewMoreCount, viewToggleMember, viewTagUnion, lensAll, lensToggle, lensVisible, lensLabel, lensSummary, timelineLens, loadModelChoices, MODEL_CHOICES };

--- a/ui/timeline-kernel-post.test.ts
+++ b/ui/timeline-kernel-post.test.ts
@@ -652,10 +652,16 @@ test("executed: a lens write in flight never lends the local lens to another wri
     // …and a CHAT pane-filter row in the tags dialog posts chat's new value with the store's timeline (F2, trace c)
     answers.push(echo(1003));
     panel._openViewsDialog(null);
+    // the pane filters open FOLDED to one summary line per pane since the many-tags change (2026-09-09); the
+    // chips this test clicks exist only in the open matrix, so open it through the caption's caret first
+    const filtersCap = walk(panel._viewsDialog).find((n) => n.tag === "span" && String(n.textContent).startsWith("pane filters"));
+    assert.ok(filtersCap && filtersCap._listeners.click, "the pane-filters caption folds and opens the matrix");
+    if (filtersCap._attrs["aria-expanded"] !== "true") filtersCap._listeners.click();
     const chatLabel = walk(panel._viewsDialog).find((n) => n.tag === "span" && n.textContent === "Chat");
     assert.ok(chatLabel, "the Chat pane-filter row");
-    const chatWeb = chatLabel.parentNode.children.find((n: any) => n.textContent === "web");
-    assert.ok(chatWeb && chatWeb._listeners.click, "its web pill");
+    // the chips sit in their own wrapping cell beside the label since the many-tags change, so search the row
+    const chatWeb = walk(chatLabel.parentNode).find((n: any) => n.textContent === "web" && n._listeners && n._listeners.click);
+    assert.ok(chatWeb, "its web pill");
     chatWeb._listeners.click();
     const chatPost = posts[3][1];
     assert.deepEqual(chatPost.views.actives, { chat: { tags: ["web"] }, timeline: { all: true }, outline: { all: true } },

--- a/ui/timeline-menu-place.test.ts
+++ b/ui/timeline-menu-place.test.ts
@@ -31,6 +31,15 @@ test("a band shorter than the menu clamps the top on-screen instead of vanishing
   assert.equal(menuTop({ top: 150, bottom: 166 }, 150, 170), 170 - 6 - 150);
 });
 
+test("an anchor that sits below the viewport is clamped on-screen, never hung above it off the bottom (review find, 2026-09-09)", () => {
+  // the flip-above branch returned any `above >= 6`, so an anchor rect below the viewport (one translated
+  // into the wrong document: the colour popover's dot, already in the host document) put the menu at
+  // anchor.top - 4 - menuH, entirely below the fold; above must also END on screen
+  assert.equal(menuTop({ top: 1346, bottom: 1360 }, 62, 1300), 1300 - 6 - 62);
+  // above still wins when it ends on screen
+  assert.equal(menuTop({ top: 1200, bottom: 1216 }, 140, 1300), 1200 - 4 - 140);
+});
+
 test("both the lane gear menu and the model/effort menu place through menuTop", () => {
   // the fix must cover BOTH fixed-position drop-downs; a bare `r.bottom + 4` is the bug's signature
   const opens = SRC.match(/menu\.style\.top = Math\.round\(menuTop\(h\.rect, menu\.offsetHeight \|\| 0, h\.win\.innerHeight \|\| 9999\)\)/g) || [];
@@ -59,7 +68,10 @@ test("offsetRect translates a pane-local anchor by each intervening frame's offs
 test("both menus append into the host document and read the host viewport", () => {
   const appends = SRC.match(/h\.doc\.body\.appendChild\(menu\)/g) || [];
   assert.equal(appends.length, 4, "expected _openMetaMenu, _openLaneMenu, _openViewsMenu and _openDisplayMenu to adopt into the host doc");
-  assert.match(SRC, /_menuHost\(anchorRect\)[\s\S]*?offsetRect\(anchorRect, frames\)/);
+  // re-aimed 2026-09-09: _menuHost also takes the anchor ELEMENT, so an anchor already living in another
+  // document (the host-adopted Sessions & tags dialog) is placed there untranslated (timeline-tags-scale)
+  assert.match(SRC, /_menuHost\(anchorRect, anchorEl\)[\s\S]*?offsetRect\(anchorRect, frames\)/);
+  assert.match(SRC, /const own = anchorEl && anchorEl\.ownerDocument;\n\s*if \(own && own !== document\) \{/, "an anchor in another document skips the frame walk");
   // the host page shows the menu now, so its clicks/Escape must close it (with pagehide cleanup)
   assert.match(SRC, /tipDoc\.addEventListener\('click', this\._onDocClick\)/);
   assert.match(SRC, /tipDoc\.addEventListener\('keydown', this\._onDocKey\)/);

--- a/ui/timeline-tagorder-drag.test.ts
+++ b/ui/timeline-tagorder-drag.test.ts
@@ -98,6 +98,9 @@ test("executed: dragging a tag pill writes tagOrder + re-sorts the local array; 
   assert.deepEqual(cells.map((c) => c._tname), ["alpha", "beta", "gamma", "remotepool"], "table renders the union order");
   // seat each cell at a distinct y so the drop math has real geometry
   cells.forEach((c, i) => { c._rect = { top: i * 30, bottom: i * 30 + 28, left: 0, right: 200, width: 200, height: 28 }; });
+  // ...inside the table's own box: since 2026-09-09 only rows inside it take the cue and the drop (the table
+  // scrolls with many tags; timeline-tags-scale.test.ts covers a drag past its edge)
+  cells[0].parentNode._rect = { top: 0, bottom: 200, left: 0, right: 800, width: 800, height: 200 };
   // grab REMOTEPOOL (index 3) and drop it between alpha and beta (index 1)
   const grab = cells[3];
   grab._listeners.pointerdown({ preventDefault() {}, pointerId: 7 });

--- a/ui/timeline-tags-scale-browser.test.ts
+++ b/ui/timeline-tags-scale-browser.test.ts
@@ -1,0 +1,814 @@
+// THE SESSIONS & TAGS DIALOG'S LAYOUT WITH MANY TAGS, MEASURED (the user 2026-09-09: with ten tags the tag
+// rows and the pane-filter matrix filled the dialog and "the sessions" showed two rows under the fold).
+// timeline-tags-scale.test.ts executes the behaviour over the fake DOM; nothing there measures a pixel. This
+// module mounts the real view file in a browser with thirty (or ten) tags and forty sessions, opens the
+// dialog and measures, in three legs per browser:
+//  1. the layout across pages: at 1300, 800 and 700px tall every tag row is one line (at most 32px), the tag
+//     table scrolls within itself under its 30vh cap, [+ New tag] sits under the table (never under its fold),
+//     the card never scrolls or clips as a whole, and the working area (the search box, "tag all", the session
+//     rows) stays on screen both folded and with the filter matrix open, whose cell keeps to 25vh, scrolls within
+//     itself when the page is short and clips the chips past its box (elementFromPoint finds no chip there, so
+//     none is printed over the sessions); at 800 a real pointer drag past the table's edge cues the last row with room for the
+//     cue, inside the box, and drops there, and a wheel mid-drag moves the cue and the drop to the rows it
+//     brings under the pointer, scrolled to the end a stepped drag below the table cues the last row, and a top
+//     cue on the first row scrolled 1.5px under the clip moves to the next row with the scroll unmoved and one
+//     scroll event (overflow-anchor:none); the floors are the rows' rendered height (one and three tags show no blank and no scroll, at 420 three tags
+//     keep three whole rows, the sessions box holds min(live, 4) rows and no blank, and four of the SMALLEST
+//     rows when the first session's chips wrap at a 390px page); on a phone held sideways (844x390, touch) the
+//     card scrolls as a whole (its rendered overflow-y is auto) instead of clipping;
+//  2. the colour popover and the table at 1300px: the pill of the tag the dialog was opened for keeps its ring
+//     inside the table's clip, Enter on a dot opens the popover with the current swatch focused (the browser's
+//     focus ring; the inner ring says "current"), Tab closes it back onto the dot, a table scroll that moves the
+//     dot closes it, a window resize closes it, the table's scroll survives a repaint (and clamps to 0 when the
+//     table no longer scrolls), and a repaint that pushes the rows down re-places the popover on its dot;
+//  3. framed shells: with the view in an iframe (offset into the page, or a 200px band at the page's foot) the
+//     dialog is adopted into the top document and the popover is placed by the dot's rect there, on screen,
+//     untranslated.
+// Skips LOUDLY per leg without a playwright browser (`npx playwright install chromium firefox` under
+// vscode-extension puts them on a machine). Synthetic names and ids only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+const requireCjs = createRequire(__filename);
+const EXT = process.cwd();                                        // npm test runs in vscode-extension
+const VIEW = fs.readFileSync(path.resolve(EXT, "..", "ui", "romp-timeline-view.js"), "utf8");
+let pw: any = null;
+try { pw = requireCjs("playwright"); } catch { pw = null; }
+
+// the kernel's timeline page, reduced to the view: the three Obsidian DOM helpers the panel expects on every
+// element (timeline-boot.ts installDomHelpers) and the module shim the page wraps the file in (kernel.py _timeline_body)
+const HELPERS = `var P=HTMLElement.prototype;
+if(!P.createEl)P.createEl=function(tag,o){var e=document.createElement(tag);if(o&&o.cls)e.className=o.cls;if(o&&o.text)e.textContent=o.text;this.appendChild(e);return e;};
+if(!P.createDiv)P.createDiv=function(o){return this.createEl('div',o);};if(!P.createSpan)P.createSpan=function(o){return this.createEl('span',o);};`;
+const PAGE = `<!DOCTYPE html><html><head><meta charset=utf-8><style>html,body{margin:0;background:#1e1e1e;color:#ccc;font:13px sans-serif}</style></head>
+<body><div id=host></div><script>${HELPERS}</script><script>var module={exports:{}};(function(module,exports){\n${VIEW}\n})(module,module.exports);
+var TimelinePanel=module.exports.TimelinePanel; window.panel = new TimelinePanel(document.getElementById('host'));</script></body></html>`;
+// two web-shell stand-ins hosting the view as an iframe: one offset into the page, one a 200px band at the
+// foot of a 1300px page (the shell's f-timeline band, where a popover translated twice fell off the bottom)
+const SHELL_OFFSET = `<!DOCTYPE html><html><body style="margin:0;background:#111"><iframe id=f-timeline src="/timeline" style="position:absolute;left:300px;top:400px;width:1000px;height:600px;border:0"></iframe></body></html>`;
+const SHELL_BAND = `<!DOCTYPE html><html><body style="margin:0;background:#111"><div style="height:1100px"></div><iframe id=f-timeline src="/timeline" style="display:block;width:100%;height:200px;border:0"></iframe></body></html>`;
+
+const PALETTE = ["#1EA1EB", "#54B204", "#4EA8A9", "#DD42FF", "#E87221", "#4EC9B0", "#E0AF68", "#F7768E", "#7AA2F7", "#9ECE6A", "#BB9AF7", "#FF9E64"];
+const now = 1_781_000_000;
+// the panel's data with `nTags` tags (tag-01, tag-02, ...) and `nSessions` sessions, the first `liveN` of them live;
+// `tagsOnS1` puts the first session in that many tags (its row's chips wrap on a narrow card)
+const dataFor = (nTags: number, nSessions = 40, liveN = nSessions, tagsOnS1 = 0) => {
+  const names = Array.from({ length: nTags }, (_, i) => "tag-" + String(i + 1).padStart(2, "0"));
+  return {
+    now, turns: {}, messages: [], judging: [], palette: PALETTE,
+    sessions: Array.from({ length: nSessions }, (_, i) => ({
+      id: "s" + (i + 1), name: "job-" + String(i + 1).padStart(2, "0"), color: PALETTE[i % 12], state: "working", live: i < liveN, model: "Opus", effort: "high",
+      context: 40, since: now - 60, awaiting: [], compacting: [], pendingMail: 0, compactions: [], faded: false, stale: false,
+    })),
+    views: {
+      active: "all", at: 100, seq: 1000,
+      actives: { chat: { tags: names.slice(0, 12) }, timeline: { all: true }, outline: { none: true } },
+      tags: names.map((name, i) => ({ id: "g" + (i + 1), name, color: PALETTE[i % 12], members: (i < 20 ? ["s" + (i + 1)] : []).concat(i > 0 && i < tagsOnS1 ? ["s1"] : []), mtime: 100 })),
+    },
+  };
+};
+const DATA = dataFor(30);
+
+// a scroll event is delivered asynchronously: two frames let it land before the next read
+const twoFrames = (page: any) => page.evaluate(() => new Promise<void>((res) => requestAnimationFrame(() => requestAnimationFrame(() => res()))));
+// the popover open with focus on its current swatch (the open focuses it a tick later), and the popover closed:
+// waited for as conditions, never as a fixed delay (a page under load delivers a tick or a resize late). `inTop`
+// reads the top document's focus, where a framed view's popover lives
+const popFocused = (target: any, inTop = false) => target.waitForFunction((inTop: boolean) => {
+  const p = (window as any).panel, doc = inTop ? (window.top as Window).document : document;
+  return !!p._tagColorPop && doc.activeElement === p._tagColorPop.querySelector("[aria-checked=true]");
+}, inTop);
+const popClosed = (page: any) => page.waitForFunction(() => (window as any).panel._tagColorPop === null);
+
+type MountOpts = { width?: number; height?: number; mobile?: boolean; nTags?: number; nSessions?: number; liveN?: number; tagsOnS1?: number };
+async function mount(browser: any, opts: MountOpts = {}) {
+  const { width = 1600, height = 1300, mobile = false, nTags = 30, nSessions = 40, liveN = nSessions, tagsOnS1 = 0 } = opts;
+  const errors: string[] = [];
+  // `mobile`: a phone held sideways. Touch, and the mobile layout viewport: both browsers lay a page without a
+  // viewport meta out at 980px wide and scale it to the screen, the way a phone renders it
+  const page = await browser.newPage(Object.assign({ viewport: { width, height } }, mobile ? { hasTouch: true, isMobile: true } : {}));
+  page.on("pageerror", (e: Error) => { errors.push(e.message); });
+  await page.route("http://romp.test/**", (route: any) => route.fulfill({ status: 200, contentType: "text/html; charset=utf-8", body: PAGE }));
+  await page.goto("http://romp.test/timeline");
+  await page.evaluate((data: any) => {
+    const p = (window as any).panel;
+    p.update(data);
+    p.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 1000 });
+    p._openViewsDialog(null);
+  }, dataFor(nTags, nSessions, liveN, tagsOnS1));
+  return { page, errors };
+}
+
+// the dialog's geometry, read off the live nodes: the card, the tag table, the open matrix's cell (null when
+// folded), the sessions box, the search box, "tag all", [+ New tag], the tag rows' pill cells and the session
+// rows' name cells. The boxes are found by their STRUCTURE (the sessions box is the sessions grid's parent, the
+// matrix cell the parent of the "All surfaces" row, which only the open matrix draws), never by the flex
+// declaration under test: a leg that found the box by "flex:1 1000 auto" crashed, rather than measured, when
+// that declaration changed (review find, 2026-09-09); the declarations come back as strings to assert on
+const measure = (page: any) => page.evaluate(() => {
+  const p = (window as any).panel;
+  const back = p._viewsDialog as HTMLElement;
+  const card = back.firstElementChild as HTMLElement;
+  const all = Array.from(card.querySelectorAll("*")) as HTMLElement[];
+  const byStyle = (pre: string) => all.find((n) => (n.getAttribute("style") || "").startsWith(pre));
+  const tgrid = byStyle("display:grid;grid-template-columns:max-content max-content max-content 1fr;")!;
+  const allLabel = all.find((n) => n.textContent === "All surfaces" && (n.getAttribute("style") || "").includes("flex:0 0 88px"));
+  const mbox = allLabel ? (allLabel.parentElement as HTMLElement).parentElement as HTMLElement : null;
+  const grid = byStyle("display:grid;grid-template-columns:max-content max-content 1fr;")!;
+  const gridBox = grid.parentElement as HTMLElement;
+  const search = card.querySelector("input[placeholder]") as HTMLElement;
+  const tagAll = all.find((n) => n.textContent === "tag all" && n.tagName === "SPAN")!;
+  const newTag = all.find((n) => n.textContent === "+ New tag" && n.tagName === "SPAN")!;
+  const r = (n: HTMLElement) => { const b = n.getBoundingClientRect(); return { top: b.top, bottom: b.bottom, left: b.left, right: b.right, height: b.height, width: b.width }; };
+  const inside = (n: HTMLElement, box: HTMLElement) => { const a = n.getBoundingClientRect(), b = box.getBoundingClientRect(); return a.top >= b.top - 0.5 && a.bottom <= b.bottom + 0.5 && a.height > 0; };
+  const pillCells = all.filter((n) => (n as any)._tname);
+  const nameCells = all.filter((n) => (n as any)._sid);
+  const dots = all.filter((n) => n.dataset.tagDot);
+  // a session row's TRACK: the extent of its cells (name, [+], chips), the kids from its name cell up to the next row's
+  const gkids = (Array.from(grid.children) as HTMLElement[]).filter((n) => !(n.getAttribute("style") || "").startsWith("grid-column:1 / -1;"));
+  const track = (i: number) => { const a = gkids.indexOf(nameCells[i]), b = nameCells[i + 1] ? gkids.indexOf(nameCells[i + 1]) : gkids.length; const rs = gkids.slice(a, b).map((n) => n.getBoundingClientRect()); return Math.max(...rs.map((r) => r.bottom)) - Math.min(...rs.map((r) => r.top)); };
+  return {
+    viewport: { w: window.innerWidth, h: window.innerHeight },
+    card: Object.assign(r(card), { scrollHeight: card.scrollHeight, clientHeight: card.clientHeight, scrollWidth: card.scrollWidth, clientWidth: card.clientWidth,
+      overflowY: getComputedStyle(card).overflowY, overflowX: getComputedStyle(card).overflowX }),
+    tgrid: Object.assign(r(tgrid), { scrollHeight: tgrid.scrollHeight, clientHeight: tgrid.clientHeight, overflowY: getComputedStyle(tgrid).overflowY }),
+    mbox: mbox ? Object.assign(r(mbox), { scrollHeight: mbox.scrollHeight, clientHeight: mbox.clientHeight, overflowY: getComputedStyle(mbox).overflowY, style: mbox.getAttribute("style") || "" }) : null,
+    gridBox: Object.assign(r(gridBox), { scrollHeight: gridBox.scrollHeight, clientHeight: gridBox.clientHeight, style: gridBox.getAttribute("style") || "",
+      minHeight: (gridBox.getAttribute("style") || "").match(/min-height:([\d.]+)px/)![1] }),
+    grid: r(grid),
+    search: Object.assign(r(search), { visible: inside(search, card) }),
+    tagAll: Object.assign(r(tagAll), { visible: inside(tagAll, card) }),
+    newTag: Object.assign(r(newTag), { visible: inside(newTag, card), underTable: newTag.getBoundingClientRect().top >= tgrid.getBoundingClientRect().bottom - 0.5 }),
+    tagRows: pillCells.length,
+    tagRowHeights: pillCells.map((n) => Math.round(n.getBoundingClientRect().height)),
+    tagRowsVisible: pillCells.filter((n) => inside(n, tgrid)).length,
+    // the room under the last tag row inside the table's box: its 4px bottom padding when nothing is blank
+    underLastTagRow: pillCells.length ? tgrid.getBoundingClientRect().bottom - Math.max(...pillCells.map((n) => n.getBoundingClientRect().bottom)) : null,
+    tgridMinHeight: ((tgrid.getAttribute("style") || "").match(/min-height:([\d.]+)px/) || [null, null])[1],
+    tgridFlex: ((tgrid.getAttribute("style") || "").match(/flex:([^;]+);/) || [null, ""])[1],
+    dots: dots.length, swatches: card.querySelectorAll("[role=radio]").length,
+    sessionRows: nameCells.length,
+    sessionRowsVisible: nameCells.filter((n) => inside(n, gridBox)).length,
+    sessionRowHeights: nameCells.slice(0, 3).map((n) => Math.round(n.getBoundingClientRect().height)),
+    sessionTracks: nameCells.slice(0, 4).map((_, i) => track(i)),
+    sessionPitch: nameCells.length > 1 ? nameCells[1].getBoundingClientRect().top - nameCells[0].getBoundingClientRect().top : 0,
+  };
+});
+
+// click the "pane filters" caption (folded opens the matrix, open folds it; the choice holds for the page) and
+// return the caret it shows afterwards
+const toggleFilters = (page: any) => page.evaluate(() => {
+  const card = ((window as any).panel._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+  const cap = () => Array.from(card.querySelectorAll("span")).find((n) => (n.textContent || "").startsWith("pane filters"))!;
+  cap().click();
+  return (cap().textContent || "").slice(-1);
+});
+// the open matrix: its chips, whether every chip lies inside the card's width, the number of chip lines, and
+// what the chips PAINT: a chip whose centre is inside the matrix cell's box is hit there (elementFromPoint
+// finds it), one whose centre is past the box is clipped by the cell and hit nowhere. A cell without its
+// bound and its own scroll let the chips print over the sessions table, and no geometry read caught it
+// (review find, 2026-09-09: the assertions read the cell's scrollHeight, which overflow of any kind grows)
+const matrix = (page: any) => page.evaluate(() => {
+  const card = ((window as any).panel._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+  const chips = Array.from(card.querySelectorAll("span")).filter((n) => (n.getAttribute("style") || "").startsWith("cursor:pointer;padding:1px 8px;border-radius:9px;"));
+  const cb = card.getBoundingClientRect();
+  const rows = new Set(chips.map((n) => Math.round(n.getBoundingClientRect().top)));
+  const allLabel = Array.from(card.querySelectorAll("span")).find((n) => n.textContent === "All surfaces" && (n.getAttribute("style") || "").includes("flex:0 0 88px"));
+  const mb = allLabel ? ((allLabel.parentElement as HTMLElement).parentElement as HTMLElement).getBoundingClientRect() : null;
+  let inBox = 0, inBoxHit = 0, outBox = 0, outBoxPainted = 0;
+  for (const c of chips) {
+    const b = c.getBoundingClientRect(), cx = (b.left + b.right) / 2, cy = (b.top + b.bottom) / 2;
+    const hit = document.elementFromPoint(cx, cy);
+    const painted = !!hit && c.contains(hit);
+    if (mb && cy >= mb.top && cy <= mb.bottom && cx >= mb.left && cx <= mb.right) { inBox++; if (painted) inBoxHit++; }
+    else { outBox++; if (painted) outBoxPainted++; }
+  }
+  return { chips: chips.length, withinWidth: chips.every((n) => { const b = n.getBoundingClientRect(); return b.left >= cb.left && b.right <= cb.right + 0.5; }), lines: rows.size,
+    inBox, inBoxHit, outBox, outBoxPainted };
+});
+
+// the working area on screen without scrolling the dialog: the card holds its content, the search box, "tag
+// all" and [+ New tag] are inside it, and at least `sessions` session rows and `tagRows` tag rows show
+function assertWorkingArea(m: any, label: string, want: { sessions: number; tagRows: number }) {
+  assert.ok(m.card.scrollHeight <= m.card.clientHeight + 1, label + ": the card holds its content without scroll: " + m.card.scrollHeight + " vs " + m.card.clientHeight);
+  assert.ok(m.search.visible, label + ": the search box is on screen (" + Math.round(m.search.top) + ".." + Math.round(m.search.bottom) + " in the card " + Math.round(m.card.top) + ".." + Math.round(m.card.bottom) + ")");
+  assert.ok(m.tagAll.visible, label + ": tag all is on screen (" + Math.round(m.tagAll.top) + ".." + Math.round(m.tagAll.bottom) + ")");
+  assert.ok(m.newTag.visible, label + ": New tag is on screen (" + Math.round(m.newTag.top) + ".." + Math.round(m.newTag.bottom) + ")");
+  assert.ok(m.sessionRowsVisible >= want.sessions, label + ": at least " + want.sessions + " session rows show without scrolling the dialog: " + m.sessionRowsVisible + " (box " + Math.round(m.gridBox.height) + "px, rows " + m.sessionRowHeights.join("/") + "px)");
+  assert.ok(m.tagRowsVisible >= want.tagRows, label + ": at least " + want.tagRows + " tag rows show before scrolling the table: " + m.tagRowsVisible + " (table " + Math.round(m.tgrid.height) + "px)");
+}
+
+// the tag table, re-found after a repaint (the build makes a new element)
+const TGRID_PRE = "display:grid;grid-template-columns:max-content max-content max-content 1fr;";
+
+// THE REORDER DRAG, with real pointer events. `grabPill` records the order writes (the page has no host, so the
+// hook is the write's only outlet), puts the mouse on a tag's pill and presses, and reads, BEFORE any cue is
+// drawn, the place of the last row with room for a cue (its box plus 2px inside the table's box; a cue
+// grows its cell 2px at the bottom and shifts the rows under it, so that place read with a cue drawn agreed with
+// whatever the shift had produced); `cueOf` reads the cue: which pill cell wears it (its place in the table as
+// drawn), on which edge, whether the cell, its 2px cue included, lies inside the table's box (a scroll container
+// clips at its box, so a cue outside it is not drawn), and the table's scroll
+const grabPill = async (page: any, name: string) => {
+  const at = await page.evaluate(({ pre, name }: { pre: string; name: string }) => {
+    const w = window as any;
+    w.__writes = w.__writes || [];
+    w.__rompTimelineSetViews = (v: any) => { w.__writes.push(JSON.parse(JSON.stringify(v))); };
+    const card = (w.panel._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+    const all = Array.from(card.querySelectorAll("*")) as HTMLElement[];
+    const tgrid = all.find((n) => (n.getAttribute("style") || "").startsWith(pre))!;
+    const cells = all.filter((n) => (n as any)._tname);
+    const pill = cells.find((n) => (n as any)._tname === name)!.firstElementChild as HTMLElement;
+    const b = pill.getBoundingClientRect(), t = tgrid.getBoundingClientRect();
+    let lastWithRoom = -1;
+    cells.forEach((c, k) => { const r = c.getBoundingClientRect(); if (r.top >= t.top - 0.01 && r.bottom + 2 <= t.bottom + 0.01) lastWithRoom = k; });
+    return { x: b.left + b.width / 2, y: b.top + b.height / 2, box: { top: t.top, bottom: t.bottom }, lastWithRoom, rows: cells.length, scrollTop: tgrid.scrollTop };
+  }, { pre: TGRID_PRE, name });
+  await page.mouse.move(at.x, at.y);
+  await page.mouse.down();
+  return at;
+};
+const cueOf = (page: any) => page.evaluate((pre: string) => {
+  const card = ((window as any).panel._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+  const all = Array.from(card.querySelectorAll("*")) as HTMLElement[];
+  const tgrid = all.find((n) => (n.getAttribute("style") || "").startsWith(pre))!;
+  const cells = all.filter((n) => (n as any)._tname);
+  const t = tgrid.getBoundingClientRect();
+  const i = cells.findIndex((c) => c.style.borderBottom || c.style.borderTop);
+  const r = i >= 0 ? cells[i].getBoundingClientRect() : null;
+  return { i, side: i < 0 ? "" : cells[i].style.borderBottom ? "bottom" : "top", cell: r ? { top: r.top, bottom: r.bottom } : null, box: { top: t.top, bottom: t.bottom },
+    inside: !!r && r.top >= t.top - 0.01 && r.bottom <= t.bottom + 0.01, scrollTop: tgrid.scrollTop, rows: cells.length };
+}, TGRID_PRE);
+// the table scrolled to its end, and the first row whole there (the row to grab for a drag at the end)
+const scrollTableToEnd = (page: any) => page.evaluate((pre: string) => {
+  const card = ((window as any).panel._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+  const all = Array.from(card.querySelectorAll("*")) as HTMLElement[];
+  const tgrid = all.find((n) => (n.getAttribute("style") || "").startsWith(pre))!;
+  tgrid.scrollTop = tgrid.scrollHeight - tgrid.clientHeight;
+  const t = tgrid.getBoundingClientRect();
+  const whole = all.filter((n) => (n as any)._tname).find((c) => { const r = c.getBoundingClientRect(); return r.top >= t.top - 0.01 && r.bottom + 2 <= t.bottom + 0.01; });
+  return { name: whole ? (whole as any)._tname as string : null, scrollTop: tgrid.scrollTop, max: tgrid.scrollHeight - tgrid.clientHeight };
+}, TGRID_PRE);
+// the table scrolled back to its start, and the rows with room for a cue there: the first (the row a top cue
+// lands on) and the last (the row to grab for a drag above the table)
+const scrollTableToStart = (page: any) => page.evaluate((pre: string) => {
+  const card = ((window as any).panel._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+  const all = Array.from(card.querySelectorAll("*")) as HTMLElement[];
+  const tgrid = all.find((n) => (n.getAttribute("style") || "").startsWith(pre))!;
+  tgrid.scrollTop = 0;
+  const t = tgrid.getBoundingClientRect();
+  const room = all.filter((n) => (n as any)._tname).map((c, k) => ({ k, name: (c as any)._tname as string, r: c.getBoundingClientRect() }))
+    .filter((p) => p.r.top >= t.top - 0.01 && p.r.bottom + 2 <= t.bottom + 0.01);
+  const last = room[room.length - 1];
+  return { firstWithRoom: room.length ? room[0].k : -1, lastWithRoom: last ? last.k : -1, name: last ? last.name : null, scrollTop: tgrid.scrollTop };
+}, TGRID_PRE);
+// with a cue drawn on row `i`, the table scrolled so that row's top edge sits 1.5px above the box (the row cut by
+// the clip, its cue with it); a counting scroll listener goes on the table first, and the scrollTop the browser
+// applied (an integer in both) comes back
+const scrollCuedRowUnderClip = (page: any, i: number) => page.evaluate(({ pre, i }: { pre: string; i: number }) => {
+  const w = window as any;
+  const card = (w.panel._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+  const all = Array.from(card.querySelectorAll("*")) as HTMLElement[];
+  const tgrid = all.find((n) => (n.getAttribute("style") || "").startsWith(pre))!;
+  const cell = all.filter((n) => (n as any)._tname)[i];
+  w.__tgridScrolls = 0;
+  tgrid.addEventListener("scroll", () => { w.__tgridScrolls++; }, { passive: true });
+  tgrid.scrollTop = tgrid.scrollTop + (cell.getBoundingClientRect().top - tgrid.getBoundingClientRect().top) + 1.5;
+  return tgrid.scrollTop as number;
+}, { pre: TGRID_PRE, i });
+const tgridScrolls = (page: any) => page.evaluate(() => (window as any).__tgridScrolls as number);
+const lastOrder = (page: any) => page.evaluate(() => { const w = (window as any).__writes || []; return w.length ? w[w.length - 1].tagOrder as string[] : null; });
+
+for (const name of ["chromium", "firefox"]) {
+  const launch = async (t: any) => {
+    if (!pw) { t.skip("playwright is not installed under vscode-extension; the browser legs need it"); return null; }
+    try { return await pw[name].launch(); }
+    catch (e) { t.skip("no playwright " + name + " on this machine; this leg needs it (npx playwright install " + name + "): " + String((e as Error).message).split("\n")[0]); return null; }
+  };
+
+  test(`in ${name}, the dialog across pages: 1300, 800 and 700px tall and a phone held sideways, folded and with the matrix open`, async (t) => {
+    const browser = await launch(t);
+    if (!browser) return;
+    try {
+      // 1600x1300, thirty tags: the page the user asked about
+      {
+        const { page, errors } = await mount(browser, { width: 1600, height: 1300, nTags: 30 });
+        const m = await measure(page);
+        assert.deepEqual(errors, [], "the view mounted and the dialog opened without a page error");
+        assert.equal(m.viewport.h, 1300);
+        // the tag rows: thirty, one line each
+        assert.equal(m.tagRows, 30); assert.equal(m.dots, 30); assert.equal(m.swatches, 0, "no inline swatch");
+        assert.ok(m.tagRowHeights.every((h: number) => h <= 32), "every tag row is one line (at most 32px): " + m.tagRowHeights.join(","));
+        // the tag table scrolls within itself and stays within its viewport share
+        assert.equal(m.tgrid.overflowY, "auto");
+        assert.ok(m.tgrid.scrollHeight > m.tgrid.clientHeight + 100, "thirty rows overflow the capped table, which scrolls them: " + m.tgrid.scrollHeight + " in " + m.tgrid.clientHeight);
+        // the cap bounds the content box; the 8px of vertical padding (room for the pills' rings inside the clip) sits outside it
+        assert.ok(m.tgrid.height <= 0.30 * m.viewport.h + 8 + 1, "the table takes at most 30vh plus its 8px padding: " + m.tgrid.height + " vs " + (0.30 * m.viewport.h + 8));
+        assert.ok(m.tagRowsVisible >= 8, "a useful number of tag rows shows before scrolling: " + m.tagRowsVisible);
+        // the card never scrolls or clips as a whole: its content fits its box
+        assert.ok(m.card.scrollHeight <= m.card.clientHeight + 1, "the card holds its content without scroll: " + m.card.scrollHeight + " vs " + m.card.clientHeight);
+        assert.ok(m.card.scrollWidth <= m.card.clientWidth + 1, "…and nothing overflows it sideways: " + m.card.scrollWidth + " vs " + m.card.clientWidth);
+        assert.ok(m.card.height <= 0.9 * m.viewport.h + 1, "the card keeps the 90vh ceiling: " + m.card.height);
+        // the working area: search, tag all and at least eight session rows on screen without scrolling the dialog
+        assert.ok(m.search.visible, "the search box is on screen: " + Math.round(m.search.top) + ".." + Math.round(m.search.bottom) + " in the card " + Math.round(m.card.top) + ".." + Math.round(m.card.bottom));
+        assert.ok(m.tagAll.visible, "tag all is on screen: " + Math.round(m.tagAll.top) + ".." + Math.round(m.tagAll.bottom));
+        assert.equal(m.sessionRows, 40);
+        assert.ok(m.sessionRowsVisible >= 8, "at least eight session rows show without scrolling the dialog: " + m.sessionRowsVisible + " (box " + Math.round(m.gridBox.height) + "px, rows " + m.sessionRowHeights.join("/") + "px)");
+        assert.ok(m.gridBox.bottom <= m.card.bottom + 0.5, "the sessions table ends inside the card; it scrolls the rest: " + m.gridBox.bottom + " vs " + m.card.bottom);
+        assert.match(m.gridBox.style, /^flex:1 1000 auto;min-height:[\d.]+px;overflow-y:auto;$/, "the sessions box gives way first (the thousandfold shrink) down to its floor: " + m.gridBox.style);
+        assert.equal(m.card.overflowY, "auto", "the card scrolls, never clips, past the floors");
+        // [+ New tag]: on screen, and under the table rather than its last row (thirty rows would scroll it under the fold)
+        assert.ok(m.newTag.visible, "New tag is on screen: " + Math.round(m.newTag.top) + ".." + Math.round(m.newTag.bottom) + " in the card " + Math.round(m.card.top) + ".." + Math.round(m.card.bottom));
+        assert.ok(m.newTag.underTable, "New tag sits under the table, not inside it: its top " + m.newTag.top + " vs the table's bottom " + m.tgrid.bottom);
+        // the filter matrix open: five rows of thirty-two chips wrap inside the card's width, and the card still fits
+        assert.equal(await toggleFilters(page), "▾");
+        const opened = await matrix(page);
+        assert.equal(opened.chips, 5 * 32, "All, no tags and thirty tags on each of five rows");
+        assert.ok(opened.withinWidth, "every chip lies inside the card's width (the rows wrap)");
+        assert.ok(opened.lines > 5, "thirty-two chips per row wrap onto more than one line at this width: " + opened.lines);
+        const after = await measure(page);
+        assert.ok(after.mbox, "the open matrix lives in a cell of its own");
+        assert.equal(after.mbox.style, "flex:0 1 auto;min-height:52px;max-height:25vh;overflow-y:auto;overflow-x:hidden;", "bounded to 25vh, scrolling within itself, giving way past the sessions' floor");
+        assert.equal(after.mbox.overflowY, "auto", "the cell's rendered overflow is a scroll");
+        assert.ok(after.mbox.bottom <= after.gridBox.top, "the cell ends above the sessions box: " + after.mbox.bottom + " vs " + after.gridBox.top);
+        assert.ok(after.card.scrollHeight <= after.card.clientHeight + 1, "the card still holds its content without scroll with the matrix open: " + after.card.scrollHeight + " vs " + after.card.clientHeight);
+        assert.ok(after.sessionRowsVisible >= 8, "the sessions keep at least eight rows on screen with the matrix open: " + after.sessionRowsVisible + " (box " + Math.round(after.gridBox.height) + "px, matrix " + Math.round(after.mbox.height) + "px)");
+        assert.ok(after.newTag.visible, "New tag stays on screen with the matrix open");
+        assert.equal(await toggleFilters(page), "▸");
+        assert.equal((await measure(page)).mbox, null, "folded again: no matrix cell");
+        assert.deepEqual(errors, []);
+        await page.close();
+      }
+      // 1600x800, thirty tags: the sessions give way first, down to their floor of four rows; the matrix's cell scrolls
+      {
+        const { page, errors } = await mount(browser, { width: 1600, height: 800, nTags: 30 });
+        const m = await measure(page);
+        assert.deepEqual(errors, []);
+        assert.equal(m.viewport.h, 800);
+        assertWorkingArea(m, "800px folded, thirty tags", { sessions: 4, tagRows: 5 });
+        // THE REORDER DRAG past the table's edge (review find, 2026-09-09, with real pointer events: at this
+        // height the row whose centre was inside the box but whose bottom edge was under the clip took the cue
+        // and the drop, and the cue, a border on that edge, painted under the clip, invisible): the cue sits on
+        // the last row with room for it, the cued cell lies inside the table's box cue included, and the drop
+        // lands where the cue is
+        const g1 = await grabPill(page, "tag-01");
+        await page.mouse.move(g1.x, g1.box.bottom + 60, { steps: 4 });
+        const c1 = await cueOf(page);
+        assert.ok(c1.i > 0, "800px: a drag 60px below the table draws a cue: " + JSON.stringify(c1));
+        assert.equal(c1.side, "bottom", "800px: the cue is the cell's bottom edge");
+        assert.ok(c1.inside, "800px: the cued cell, its 2px cue included, lies inside the table's box: cell " + c1.cell!.top + ".." + c1.cell!.bottom + " in " + c1.box.top + ".." + c1.box.bottom);
+        assert.equal(c1.i, g1.lastWithRoom, "800px: the cue sits on the LAST row with room for it, as read before any cue (a later row would be cut, or its cue would): row " + c1.i + " of " + c1.rows);
+        assert.ok(g1.lastWithRoom < g1.rows - 1, "800px: thirty rows overflow the table, so the last row with room is not the last row: " + g1.lastWithRoom);
+        await page.mouse.up();
+        const o1 = await lastOrder(page);
+        assert.ok(o1, "800px: the drop wrote the order");
+        assert.equal(o1!.indexOf("tag-01"), c1.i, "800px: the drop landed where the cue was drawn");
+        // a wheel mid-drag: no pointermove fires for a scroll, so the table's scroll re-ranks with the last
+        // pointer y, and the cue and the drop follow the row now under the pointer
+        const g2 = await grabPill(page, "tag-01");
+        const midY = (g2.box.top + g2.box.bottom) / 2;
+        await page.mouse.move(g2.x, midY, { steps: 3 });
+        const c2 = await cueOf(page);
+        assert.ok(c2.i >= 0 && c2.inside, "800px: the pointer at the table's middle cues a whole row: " + JSON.stringify(c2));
+        await page.mouse.wheel(0, 200);
+        await twoFrames(page);
+        const c3 = await cueOf(page);
+        assert.ok(c3.scrollTop > 100, "800px: the wheel scrolled the table under the held pill: " + c3.scrollTop);
+        assert.notEqual(c3.i, c2.i, "800px: the cue moved with the rows: row " + c2.i + " before the wheel, " + c3.i + " after");
+        assert.ok(c3.inside, "800px: the cued cell after the wheel lies inside the table's box: " + JSON.stringify(c3));
+        assert.ok(c3.cell!.top <= midY && c3.cell!.bottom + 30 >= midY, "800px: the cue is on the row under the pointer or its neighbour: cell " + c3.cell!.top + ".." + c3.cell!.bottom + ", pointer " + midY);
+        await page.mouse.up();
+        const o2 = await lastOrder(page);
+        assert.equal(o2!.indexOf("tag-01"), c3.i, "800px: the drop followed the rows the wheel brought under the pointer");
+        // scrolled to the END (the last row has the 4px padding of room; a stepped drag carried the cue over
+        // the rows above it, each cue pushing the last row 2px down, and measured with the cue drawn the last row
+        // lost its room, so in Firefox the drop landed one row short at every height): a whole row dragged 60px
+        // below the table in steps cues the LAST row and drops there
+        const end = await scrollTableToEnd(page);
+        await twoFrames(page);
+        assert.ok(end.name && end.scrollTop > 100 && end.scrollTop === end.max, "800px at the end: the table scrolled to its end: " + JSON.stringify(end));
+        const g4 = await grabPill(page, end.name!);
+        assert.equal(g4.lastWithRoom, g4.rows - 1, "800px at the end: the last row has room for a cue (the padding under it): " + JSON.stringify(g4));
+        await page.mouse.move(g4.x, g4.box.bottom + 60, { steps: 4 });
+        const c4 = await cueOf(page);
+        assert.equal(c4.i, c4.rows - 1, "800px at the end: a stepped drag past the table's edge cues the last row: " + JSON.stringify(c4));
+        assert.equal(c4.side, "bottom");
+        assert.ok(c4.inside, "800px at the end: the cued last row, its cue included, lies inside the box: " + JSON.stringify(c4));
+        await page.mouse.up();
+        const o4 = await lastOrder(page);
+        assert.equal(o4!.indexOf(end.name!), c4.rows - 1, "800px at the end: the drop put the row last");
+        // A CUED ROW SCROLLED UNDER THE TOP CLIP (the table's overflow-anchor:none had no test at first, and a view
+        // without it passed every leg). With scroll anchoring on, a top cue leaving the first partly clipped row
+        // moves that row's pill 2px, the browser shifts scrollTop by 2 to hold it, the lift's exact measurement
+        // re-admits the row, and the cue and the scroll oscillate: Chromium kept the cue on a row whose top edge,
+        // its cue with it, was under the clip, and Firefox fired a scroll event a frame at a standing scrollTop
+        // before settling. From the top, the last whole row held with the pointer 60px above the table cues the
+        // first row's top edge; the table then scrolled 1.5px past that row's top hands the cue to the next row,
+        // with the scroll exactly where it was put and one scroll event, and the drop lands at the cue
+        const start = await scrollTableToStart(page);
+        await twoFrames(page);
+        assert.ok(start.name && start.scrollTop === 0 && start.firstWithRoom >= 0 && start.lastWithRoom > start.firstWithRoom + 1, "800px from the top: the table at its start, a first whole row and a later one to grab: " + JSON.stringify(start));
+        const g5 = await grabPill(page, start.name!);
+        await page.mouse.move(g5.x, g5.box.top - 60, { steps: 3 });
+        const c5 = await cueOf(page);
+        assert.equal(c5.i, start.firstWithRoom, "800px from the top: a drag 60px above the table cues the first whole row: " + JSON.stringify(c5));
+        assert.equal(c5.side, "top", "800px from the top: the cue is the cell's top edge");
+        assert.ok(c5.inside, "800px from the top: the cued first row, its cue included, lies inside the box: " + JSON.stringify(c5));
+        const applied = await scrollCuedRowUnderClip(page, c5.i);
+        assert.ok(applied > 0, "800px from the top: the table scrolled the cued row under its clip: " + applied);
+        await twoFrames(page);
+        const c6 = await cueOf(page);
+        const scrolls = await tgridScrolls(page);
+        assert.equal(c6.i, c5.i + 1, "800px from the top, the cued row scrolled under the clip: the cue moves to the next row (with scroll anchoring on, the lift moved the row's pill and the browser moved the scroll to follow it, so the rows were read 2px off and the cue stayed on a row whose top edge, its cue with it, was under the clip): " + JSON.stringify(c6));
+        assert.equal(c6.side, "top", "800px from the top: the cue keeps to the top edge");
+        assert.ok(c6.inside, "800px from the top: the cued next row, its cue included, lies inside the box: " + JSON.stringify(c6));
+        assert.equal(c6.scrollTop, applied, "800px from the top: the scroll stays exactly where it was put, no anchoring shift (overflow-anchor:none): " + c6.scrollTop + " vs " + applied);
+        assert.equal(scrolls, 1, "800px from the top: one scroll event, the one the set fired (with anchoring on, Firefox fired one a frame at a standing scrollTop): " + scrolls);
+        await page.mouse.up();
+        const o5 = await lastOrder(page);
+        assert.equal(o5!.indexOf(start.name!), c6.i, "800px from the top: the drop landed where the cue was drawn after the scroll");
+        await page.evaluate((pre: string) => {
+          const card = ((window as any).panel._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+          (Array.from(card.querySelectorAll("*")) as HTMLElement[]).find((n) => (n.getAttribute("style") || "").startsWith(pre))!.scrollTop = 0;
+        }, TGRID_PRE);
+        await twoFrames(page);
+        assert.deepEqual(errors, [], "800px: no page error across the drag legs");
+        assert.equal(await toggleFilters(page), "▾");
+        const o = await measure(page);
+        assertWorkingArea(o, "800px open, thirty tags", { sessions: 4, tagRows: 3 });
+        assert.ok(o.mbox, "800px open: the matrix cell exists");
+        assert.ok(o.mbox.scrollHeight > o.mbox.clientHeight + 20, "800px open: the matrix's cell scrolls within itself: " + o.mbox.scrollHeight + " in " + o.mbox.clientHeight);
+        assert.equal(o.mbox.overflowY, "auto", "800px open: the cell's rendered overflow is a scroll, not visible");
+        assert.ok(o.mbox.clientHeight <= 0.25 * o.viewport.h + 1, "800px open: the cell keeps to 25vh: " + o.mbox.clientHeight + " vs " + 0.25 * o.viewport.h);
+        assert.ok(o.mbox.bottom <= o.gridBox.top, "800px open: the cell ends above the sessions box: " + o.mbox.bottom + " vs " + o.gridBox.top);
+        const painted = await matrix(page);
+        assert.ok(painted.inBox > 0 && painted.inBoxHit === painted.inBox, "800px open: every chip inside the cell's box is painted there: " + painted.inBoxHit + " of " + painted.inBox);
+        assert.ok(painted.outBox > 0, "800px open: chips past the cell's box, for the cell to clip: " + painted.outBox);
+        assert.equal(painted.outBoxPainted, 0, "800px open: no chip past the cell's box is painted (the cell clips them; without its bound and scroll they printed over the sessions): " + painted.outBoxPainted + " of " + painted.outBox);
+        assert.equal(await toggleFilters(page), "▸");
+        assert.deepEqual(errors, []);
+        await page.close();
+      }
+      // 1600x800, ten tags: the user's own count; the table's cap held exactly the ten rows and hid [+ New tag] as its last row
+      {
+        const { page, errors } = await mount(browser, { width: 1600, height: 800, nTags: 10 });
+        const m = await measure(page);
+        assert.deepEqual(errors, []);
+        assert.equal(m.tagRows, 10);
+        assertWorkingArea(m, "800px folded, ten tags", { sessions: 4, tagRows: 5 });
+        assert.ok(m.newTag.underTable, "800px, ten tags: New tag sits under the table: " + m.newTag.top + " vs " + m.tgrid.bottom);
+        assert.deepEqual(errors, []);
+        await page.close();
+      }
+      // 1600x700, thirty tags: the table and the open matrix give way down to their floors; nothing clips
+      {
+        const { page, errors } = await mount(browser, { width: 1600, height: 700, nTags: 30 });
+        const m = await measure(page);
+        assert.deepEqual(errors, []);
+        assert.equal(m.viewport.h, 700);
+        assertWorkingArea(m, "700px folded, thirty tags", { sessions: 4, tagRows: 3 });
+        assert.equal(await toggleFilters(page), "▾");
+        const o = await measure(page);
+        assertWorkingArea(o, "700px open, thirty tags", { sessions: 4, tagRows: 3 });
+        assert.ok(o.mbox, "700px open: the matrix cell exists");
+        assert.equal(o.mbox.overflowY, "auto", "700px open: the cell scrolls within itself");
+        assert.equal((await matrix(page)).outBoxPainted, 0, "700px open: no chip past the cell's box is painted");
+        assert.equal(await toggleFilters(page), "▸");
+        assert.deepEqual(errors, []);
+        await page.close();
+      }
+      // THE FLOORS, measured off the rendered rows (review find, 2026-09-09: a constant per row was not the
+      // row height, which is the font's: one tag showed 6px of blank, three rows at the floor lost 7px, one live
+      // session sat in a 96px box). At 1300 one tag and three tags show their rows and nothing else: no scroll,
+      // and under the last row only the table's own 4px padding
+      for (const nTags of [1, 3]) {
+        const { page, errors } = await mount(browser, { width: 1600, height: 1300, nTags });
+        const m = await measure(page);
+        assert.deepEqual(errors, []);
+        assert.equal(m.tagRowsVisible, nTags, nTags + " tag(s): every row whole");
+        assert.equal(m.tgridFlex, "0 0 auto", nTags + " tag(s): the table does not shrink; its rows are its height");
+        assert.equal(m.tgridMinHeight, null, nTags + " tag(s): no floor to be off by");
+        assert.ok(m.tgrid.scrollHeight <= m.tgrid.clientHeight + 0.5, nTags + " tag(s): no scroll: " + m.tgrid.scrollHeight + " in " + m.tgrid.clientHeight);
+        assert.ok(m.underLastTagRow! <= 4.5 && m.underLastTagRow! >= 3.5, nTags + " tag(s): under the last row only the 4px padding, no blank: " + m.underLastTagRow);
+        await page.close();
+      }
+      // at 420 with forty sessions the floors bind: three tags still show three whole rows and no scroll; thirty
+      // tags keep three whole rows (the floor is three rows at their rendered height, not a constant)
+      {
+        const { page, errors } = await mount(browser, { width: 1600, height: 420, nTags: 3 });
+        const m = await measure(page);
+        assert.deepEqual(errors, []);
+        assert.ok(m.card.scrollHeight > m.card.clientHeight, "420px, three tags: the page is short enough for the card to scroll (the floors bind): " + m.card.scrollHeight + " vs " + m.card.clientHeight);
+        assert.equal(m.tagRowsVisible, 3, "420px, three tags: three whole rows (table " + Math.round(m.tgrid.height) + "px)");
+        assert.ok(m.tgrid.scrollHeight <= m.tgrid.clientHeight + 0.5, "420px, three tags: no scroll: " + m.tgrid.scrollHeight + " in " + m.tgrid.clientHeight);
+        await page.close();
+      }
+      {
+        const { page, errors } = await mount(browser, { width: 1600, height: 420, nTags: 30 });
+        const m = await measure(page);
+        assert.deepEqual(errors, []);
+        assert.ok(m.tgrid.scrollHeight > m.tgrid.clientHeight, "420px, thirty tags: the table scrolls");
+        assert.equal(m.tagRowsVisible, 3, "420px, thirty tags: the floor holds exactly three whole rows (table " + Math.round(m.tgrid.height) + "px, floor " + m.tgridMinHeight + "px)");
+        assert.ok(Number(m.tgridMinHeight) >= 3 * 24 + 8 - 1 && Number(m.tgridMinHeight) <= 3 * 32 + 8, "420px, thirty tags: the floor is three rows at their rendered height: " + m.tgridMinHeight);
+        await page.close();
+      }
+      // the sessions box holds its live rows and no blank: none when none is live, one row for one, four for four
+      // or more (at 500 with thirty tags the floors bind, so the box sits at its floor)
+      // (two live of six: the floor counts the live sessions, not every session; by every session the box held four
+      // rows' worth over two rows of content)
+      for (const [liveN, nSessions, label] of [[0, 3, "none live of three"], [1, 1, "one live"], [2, 6, "two live of six"], [3, 3, "three live"], [4, 4, "four live"], [40, 40, "forty live"]] as Array<[number, number, string]>) {
+        const { page, errors } = await mount(browser, { width: 1600, height: 500, nTags: 30, nSessions, liveN });
+        const m = await measure(page);
+        assert.deepEqual(errors, []);
+        assert.equal(m.sessionRows, liveN, label + ": the live rows");
+        const want = Math.min(liveN, 4);
+        assert.equal(m.sessionRowsVisible, want, label + ": " + want + " whole rows in the box (box " + m.gridBox.height + "px, grid " + m.grid.height + "px)");
+        if (liveN === 0) assert.ok(m.gridBox.height <= 0.5, label + ": no row, no box: " + m.gridBox.height);
+        else if (liveN <= 4) assert.ok(Math.abs(m.gridBox.height - m.grid.height) <= 0.5, label + ": the box is exactly its rows, no blank and no clip: box " + m.gridBox.height + ", rows " + m.grid.height);
+        else assert.ok(Math.abs(m.gridBox.height - (4 * m.sessionPitch - 3)) <= 0.5, label + ": at its floor the box is four rows and their three 3px gaps: box " + m.gridBox.height + ", pitch " + m.sessionPitch);
+        assert.ok(m.search.visible && m.tagAll.visible, label + ": search and tag all inside the card");
+        await page.close();
+      }
+      // a first session whose chips WRAP (the floor was four times the FIRST row's height at first, so a wrapped first
+      // row put 74px of blank under four live sessions): at a 390px page the card is
+      // 351px wide and six tags on the first session wrap its chips onto a second line. The floor is four of the
+      // SMALLEST rows plus their gaps: on a tall page the box is its rows, and on a page short enough for the floors
+      // to bind the box sits at that floor, holding three whole rows (the wrapped one costs a row, never blank)
+      for (const [height, binds] of [[844, false], [400, true]] as Array<[number, boolean]>) {
+        const label = "390x" + height + ", the first session in six tags";
+        const { page, errors } = await mount(browser, { width: 390, height, nTags: 30, nSessions: 4, liveN: 4, tagsOnS1: 6 });
+        const m = await measure(page);
+        assert.deepEqual(errors, []);
+        assert.equal(m.sessionRows, 4);
+        assert.ok(m.card.width <= 352 && m.card.width >= 350, label + ": the card is 90vw, 351px: " + m.card.width);
+        assert.ok(m.sessionTracks[0] >= m.sessionTracks[1] + 10, label + ": the first row's chips wrapped, so its track is taller: " + m.sessionTracks.map((t: number) => Math.round(t * 10) / 10).join("/"));
+        const small = Math.min(...m.sessionTracks);
+        assert.ok(Math.abs(Number(m.gridBox.minHeight) - (4 * small + 9)) <= 0.1, label + ": the floor is four of the smallest rows and their three 3px gaps: " + m.gridBox.minHeight + " vs " + (4 * small + 9));
+        assert.ok(m.gridBox.height <= m.grid.height + 0.5, label + ": no blank under the rows: box " + m.gridBox.height + ", rows " + m.grid.height);
+        if (binds) {
+          assert.ok(m.card.scrollHeight > m.card.clientHeight, label + ": the floors bind (the card scrolls): " + m.card.scrollHeight + " vs " + m.card.clientHeight);
+          assert.ok(Math.abs(m.gridBox.height - Number(m.gridBox.minHeight)) <= 0.5, label + ": the box sits at its floor: " + m.gridBox.height + " vs " + m.gridBox.minHeight);
+          assert.equal(m.sessionRowsVisible, 3, label + ": three whole rows in a box of four small rows' worth (the wrapped row costs one)");
+        } else {
+          assert.ok(Math.abs(m.gridBox.height - m.grid.height) <= 0.5, label + ": the box is exactly its rows: box " + m.gridBox.height + ", rows " + m.grid.height);
+          assert.equal(m.sessionRowsVisible, 4, label + ": all four rows whole");
+        }
+        await page.close();
+      }
+      // 844x390, a phone held sideways: the floors outgrow the card, which scrolls as a whole instead of clipping
+      {
+        const { page, errors } = await mount(browser, { width: 844, height: 390, mobile: true, nTags: 30 });
+        const m = await measure(page);
+        assert.deepEqual(errors, []);
+        assert.ok(m.card.scrollHeight > m.card.clientHeight + 20, "phone: the card scrolls as a whole: " + m.card.scrollHeight + " vs " + m.card.clientHeight + " (viewport " + m.viewport.w + "x" + m.viewport.h + ")");
+        assert.ok(m.search.visible, "phone: the search box is inside the card's box: " + Math.round(m.search.top) + ".." + Math.round(m.search.bottom) + " in " + Math.round(m.card.top) + ".." + Math.round(m.card.bottom));
+        assert.ok(m.tagAll.visible, "phone: tag all is inside the card's box: " + Math.round(m.tagAll.top) + ".." + Math.round(m.tagAll.bottom));
+        assert.ok(m.newTag.visible, "phone: New tag is inside the card's box: " + Math.round(m.newTag.top) + ".." + Math.round(m.newTag.bottom));
+        assert.ok(m.tagRowsVisible >= 2, "phone: the table keeps at least two rows: " + m.tagRowsVisible + " (table " + Math.round(m.tgrid.height) + "px)");
+        // the card's overflow as rendered: a scroll (a card that clipped, overflow hidden, still takes a scrollTop
+        // written by a script, so the write below cannot tell the two apart; the computed style can)
+        assert.equal(m.card.overflowY, "auto", "phone: the card's rendered overflow-y is a scroll, not a clip");
+        assert.equal(m.card.overflowX, "hidden", "phone: ...and nothing scrolls sideways");
+        const scrolled = await page.evaluate((pre: string) => {
+          const card = ((window as any).panel._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+          card.scrollTop = card.scrollHeight;
+          const gridBox = (Array.from(card.querySelectorAll("*")) as HTMLElement[]).find((n) => (n.getAttribute("style") || "").startsWith(pre))!.parentElement as HTMLElement;
+          return { scrollTop: card.scrollTop, cardBottom: card.getBoundingClientRect().bottom, sessionsBottom: gridBox.getBoundingClientRect().bottom, sessionsHeight: gridBox.getBoundingClientRect().height };
+        }, "display:grid;grid-template-columns:max-content max-content 1fr;");
+        assert.ok(scrolled.scrollTop > 0, "phone: the card took the scroll: " + scrolled.scrollTop);
+        assert.ok(scrolled.sessionsBottom <= scrolled.cardBottom + 0.5, "phone: scrolled to the end, the sessions box is reachable inside the card: " + scrolled.sessionsBottom + " vs " + scrolled.cardBottom + " (box " + Math.round(scrolled.sessionsHeight) + "px)");
+        assert.deepEqual(errors, []);
+        await page.close();
+      }
+    } finally { await browser.close(); }
+  });
+
+  test(`in ${name}, the colour popover and the tag table at 1300px: the ring inside the clip, keyboard open and Tab, scroll, resize, scroll memory, repaint`, async (t) => {
+    const browser = await launch(t);
+    if (!browser) return;
+    try {
+      const { page, errors } = await mount(browser, { width: 1600, height: 1300, nTags: 30 });
+      // opened FOR a tag, its pill wears a ring 3px outside its box; the table's clip must spare it
+      const ring = await page.evaluate((pre: string) => {
+        const p = (window as any).panel;
+        p._openViewsDialog("g1");
+        const card = (p._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+        const all = Array.from(card.querySelectorAll("*")) as HTMLElement[];
+        const tgrid = all.find((n) => (n.getAttribute("style") || "").startsWith(pre))!;
+        const cell = all.find((n) => (n as any)._tname === "tag-01")!;
+        const pill = cell.firstElementChild as HTMLElement;
+        const b = pill.getBoundingClientRect(), tb = tgrid.getBoundingClientRect();
+        const out = { ringed: (pill.getAttribute("style") || "").indexOf("outline:1px solid") >= 0, offset: getComputedStyle(pill).outlineOffset, left: b.left - tb.left, top: b.top - tb.top };
+        p._openViewsDialog(null);
+        return out;
+      }, TGRID_PRE);
+      assert.ok(ring.ringed, "the pill of the tag the dialog was opened for wears the ring");
+      assert.equal(ring.offset, "2px");
+      assert.ok(ring.left >= 3, "the ringed pill sits at least 3px inside the table's left edge, so the clip spares its ring: " + ring.left);
+      assert.ok(ring.top >= 3, "…and at least 3px under the table's top edge: " + ring.top);
+      assert.deepEqual(errors, [], "the dialog opened for g1 and reopened plain without a page error");
+      // keyboard: Enter on the focused dot opens the popover on the current swatch, which wears the inner ring
+      // AND the browser's focus ring; Tab closes it and puts focus back on the dot
+      await page.evaluate(() => {
+        const card = ((window as any).panel._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+        (card.querySelector("[data-tag-dot='g1']") as HTMLElement).focus();
+      });
+      await page.keyboard.press("Enter");
+      await popFocused(page);   // the popover focuses its current swatch a tick after opening
+      const kb = await page.evaluate(() => {
+        const p = (window as any).panel;
+        const pop = p._tagColorPop as HTMLElement | null;
+        if (!pop) return { open: false, swatches: 0, focused: false, boxShadow: "", outlineStyle: "", inlineOutline: "", othersPlain: false };
+        const sws = Array.from(pop.querySelectorAll("[role=radio]")) as HTMLElement[];
+        const cur = pop.querySelector("[aria-checked=true]") as HTMLElement;
+        const cs = getComputedStyle(cur);
+        return { open: true, swatches: sws.length, focused: document.activeElement === cur, boxShadow: cs.boxShadow, outlineStyle: cs.outlineStyle, inlineOutline: cur.style.outline,
+          othersPlain: sws.filter((s) => s !== cur).every((s) => getComputedStyle(s).boxShadow === "none" && s.style.outline === "") };
+      });
+      assert.ok(kb.open, "Enter on the focused dot opens the popover");
+      assert.equal(kb.swatches, 12);
+      assert.ok(kb.focused, "the current swatch took focus");
+      assert.notEqual(kb.boxShadow, "none", "the current swatch wears the inner ring (two inset shadows): " + kb.boxShadow);
+      assert.equal(kb.inlineOutline, "", "…and no inline outline, which would replace the browser's focus ring");
+      assert.notEqual(kb.outlineStyle, "none", "the keyboard-focused swatch shows the browser's focus ring: outline-style " + JSON.stringify(kb.outlineStyle));
+      assert.ok(kb.othersPlain, "every other swatch: no box-shadow, no inline outline");
+      await page.keyboard.press("Tab");
+      const tabbed = await page.evaluate(() => {
+        const p = (window as any).panel;
+        const card = (p._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+        return { open: p._tagColorPop !== null, onDot: document.activeElement === card.querySelector("[data-tag-dot='g1']") };
+      });
+      assert.equal(tabbed.open, false, "Tab closes the popover");
+      assert.ok(tabbed.onDot, "…and puts focus back on the dot");
+      // the last row's dot: the popover placed on screen, one layer above the backdrop, the current swatch focused
+      const openOn = (key: string) => page.evaluate((k: string) => {
+        const card = ((window as any).panel._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+        const dot = card.querySelector("[data-tag-dot='" + k + "']") as HTMLElement;
+        dot.scrollIntoView();
+        dot.click();
+      }, key);
+      await openOn("g30");
+      await popFocused(page);
+      const popm = await page.evaluate(() => {
+        const p = (window as any).panel;
+        const card = (p._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+        const dot = card.querySelector("[data-tag-dot='g30']") as HTMLElement;
+        const pop = p._tagColorPop as HTMLElement | null;
+        if (!pop) return { open: false, swatches: 0, onScreen: false, nearDot: false, z: "", focused: false };
+        const b = pop.getBoundingClientRect();
+        const d = dot.getBoundingClientRect();
+        return { open: true, swatches: pop.querySelectorAll("[role=radio]").length, onScreen: b.top >= 0 && b.bottom <= window.innerHeight && b.left >= 0 && b.right <= window.innerWidth,
+          nearDot: Math.abs(b.top - d.bottom) <= 6 || Math.abs(d.top - b.bottom) <= 6, z: getComputedStyle(pop).zIndex, focused: document.activeElement === pop.querySelector("[aria-checked=true]") };
+      });
+      assert.ok(popm.open, "a click on the g30 dot opens the popover"); assert.equal(popm.swatches, 12);
+      assert.ok(popm.onScreen, "the popover is on screen");
+      assert.ok(popm.nearDot, "…anchored to its dot (below it, or above when below cannot hold it)");
+      assert.equal(popm.z, "1003");
+      assert.ok(popm.focused, "the current swatch took focus");
+      // a table scroll that moves the dot closes it (the table sits at its end after scrolling the last row into
+      // view, so the scroll goes up)
+      const scrolled = await page.evaluate((pre: string) => {
+        const card = ((window as any).panel._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+        const tgrid = (Array.from(card.querySelectorAll("*")) as HTMLElement[]).find((n) => (n.getAttribute("style") || "").startsWith(pre))!;
+        const before = tgrid.scrollTop;
+        tgrid.scrollTop = before - 120;
+        return { before, after: tgrid.scrollTop };
+      }, TGRID_PRE);
+      await twoFrames(page);
+      assert.notEqual(scrolled.after, scrolled.before, "the table scrolled: " + scrolled.before + " to " + scrolled.after);
+      assert.equal(await page.evaluate(() => (window as any).panel._tagColorPop === null), true, "a table scroll that moved the dot closed the popover");
+      // the host window's resize closes it
+      await openOn("g30");
+      await popFocused(page);
+      assert.equal(await page.evaluate(() => (window as any).panel._tagColorPop !== null), true, "reopened on g30");
+      await page.setViewportSize({ width: 1500, height: 1300 });
+      await popClosed(page);
+      assert.equal(await page.evaluate(() => (window as any).panel._tagColorPop === null), true, "the host window's resize closed the popover");
+      await page.setViewportSize({ width: 1600, height: 1300 });
+      // scroll memory: the table's scroll survives a repaint; a table that no longer scrolls clamps it to 0
+      const mem = await page.evaluate(({ data, pre }: { data: any; pre: string }) => {
+        const p = (window as any).panel;
+        const card = () => (p._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+        const find = () => (Array.from(card().querySelectorAll("*")) as HTMLElement[]).find((n) => (n.getAttribute("style") || "").startsWith(pre))!;
+        const rows = () => (Array.from(card().querySelectorAll("*")) as HTMLElement[]).filter((n) => (n as any)._tname).length;
+        const t1 = find();
+        t1.scrollTop = 200;
+        const got = t1.scrollTop;
+        p._viewsDialogBuild();
+        const t2 = find();
+        const kept = { newTable: t2 !== t1, got, after: t2.scrollTop };
+        p.update(Object.assign({}, data, { views: Object.assign({}, data.views, { seq: 1001, tags: data.views.tags.slice(0, 3) }) }));
+        p._viewsDialogBuild();
+        const t3 = find();
+        const three = { rows: rows(), scrollTop: t3.scrollTop, scrollHeight: t3.scrollHeight, clientHeight: t3.clientHeight };
+        p.update(Object.assign({}, data, { views: Object.assign({}, data.views, { seq: 1002 }) }));
+        p._viewsDialogBuild();
+        return { kept, three, rows30: rows() };
+      }, { data: DATA, pre: TGRID_PRE });
+      assert.ok(mem.kept.newTable, "the repaint built a new table");
+      assert.ok(mem.kept.got > 0, "the table took the scroll: " + mem.kept.got);
+      assert.ok(Math.abs(mem.kept.after - mem.kept.got) <= 1, "the table's scroll survives a repaint: " + mem.kept.got + " before, " + mem.kept.after + " after");
+      assert.equal(mem.three.rows, 3, "the three-tag frame was adopted");
+      assert.equal(mem.three.scrollTop, 0, "a table that no longer scrolls clamps its remembered scroll to 0: " + mem.three.scrollTop);
+      assert.ok(mem.three.scrollHeight <= mem.three.clientHeight + 1, "three rows do not scroll: " + mem.three.scrollHeight + " in " + mem.three.clientHeight);
+      assert.equal(mem.rows30, 30, "the thirty-tag frame was restored");
+      // a repaint that pushes the rows down (a notice above the table) re-places the popover on its rebuilt dot
+      await page.evaluate((pre: string) => {
+        const card = ((window as any).panel._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+        const tgrid = (Array.from(card.querySelectorAll("*")) as HTMLElement[]).find((n) => (n.getAttribute("style") || "").startsWith(pre))!;
+        tgrid.scrollTop = 0;
+      }, TGRID_PRE);
+      await twoFrames(page);
+      await page.evaluate(() => {
+        const card = ((window as any).panel._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+        (card.querySelector("[data-tag-dot='g3']") as HTMLElement).click();
+      });
+      await popFocused(page);
+      const re = await page.evaluate(() => {
+        const p = (window as any).panel;
+        const pop = p._tagColorPop as HTMLElement | null;
+        if (!pop) return { wasOpen: false, open: false, before: 0, after: 0, notice: false, gap: 0, sameNode: false };
+        const before = pop.getBoundingClientRect().top;
+        p._tagEditErr = { host: "", name: "", error: "synthetic refusal" };
+        p._viewsDialogBuild();
+        const card = (p._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
+        const notice = Array.from(card.querySelectorAll("span")).some((n) => (n.textContent || "").indexOf("synthetic refusal") >= 0);
+        const pop2 = p._tagColorPop as HTMLElement | null;
+        if (!pop2) return { wasOpen: true, open: false, before, after: 0, notice, gap: 0, sameNode: false };
+        const dot = card.querySelector("[data-tag-dot='g3']") as HTMLElement;
+        const b = pop2.getBoundingClientRect(), d = dot.getBoundingClientRect();
+        return { wasOpen: true, open: true, before, after: b.top, notice, gap: Math.min(Math.abs(b.top - d.bottom), Math.abs(d.top - b.bottom)), sameNode: pop2 === pop };
+      });
+      assert.ok(re.wasOpen, "a click on the g3 dot opened the popover");
+      assert.ok(re.notice, "the repaint drew the notice above the table");
+      assert.ok(re.open, "the popover survives a repaint that rebuilt its row");
+      assert.ok(re.sameNode, "…the same popover, re-placed");
+      assert.notEqual(re.after, re.before, "…moved with its dot: top " + re.before + " before the notice, " + re.after + " after");
+      assert.ok(re.gap <= 6, "…and hangs within 6px of the rebuilt dot: " + re.gap);
+      await page.evaluate(() => { const p = (window as any).panel; p._tagEditErr = null; p._viewsDialogBuild(); });
+      assert.deepEqual(errors, [], "no page error across the popover legs");
+    } finally { await browser.close(); }
+  });
+
+  test(`in ${name}, framed shells: the dialog is adopted into the top document and the popover hangs on the dot's rect there`, async (t) => {
+    const browser = await launch(t);
+    if (!browser) return;
+    try {
+      const shells: Array<[string, string, string]> = [
+        ["/shell-offset", SHELL_OFFSET, "the frame offset 300x400 into the page"],
+        ["/shell-band", SHELL_BAND, "the frame a 200px band at the foot of a 1300px page"],
+      ];
+      for (const [shellPath, html, label] of shells) {
+        const errors: string[] = [];
+        const page = await browser.newPage({ viewport: { width: 1600, height: 1300 } });
+        page.on("pageerror", (e: Error) => { errors.push(e.message); });
+        await page.route("http://romp.test/**", (route: any) => {
+          const url = String(route.request().url());
+          const body = url.endsWith("/timeline") ? PAGE : url.endsWith(shellPath) ? html : null;
+          if (body === null) return route.fulfill({ status: 404, contentType: "text/plain", body: "not here" });
+          return route.fulfill({ status: 200, contentType: "text/html; charset=utf-8", body });
+        });
+        await page.goto("http://romp.test" + shellPath);
+        const frame = page.frame({ url: /\/timeline$/ });
+        assert.ok(frame, label + ": the shell hosts the timeline frame");
+        await frame.waitForFunction(() => !!(window as any).panel);
+        const hosted = await frame.evaluate((data: any) => {
+          const p = (window as any).panel;
+          p.update(data);
+          p.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 1000 });
+          p._openViewsDialog(null);
+          return { framed: window !== window.top, inTop: (p._viewsDialog as HTMLElement).ownerDocument === (window.top as Window).document, frameH: window.innerHeight, topH: (window.top as Window).innerHeight };
+        }, DATA);
+        assert.ok(hosted.framed, label + ": the view runs in a child frame");
+        assert.ok(hosted.inTop, label + ": the dialog is adopted into the shell's document (frame " + hosted.frameH + "px tall in a " + hosted.topH + "px page)");
+        await frame.evaluate(() => {
+          const p = (window as any).panel;
+          ((p._viewsDialog as HTMLElement).querySelector("[data-tag-dot='g1']") as HTMLElement).click();
+        });
+        await popFocused(frame, true);
+        const fm = await frame.evaluate(() => {
+          const p = (window as any).panel;
+          const top = window.top as Window;
+          const pop = p._tagColorPop as HTMLElement | null;
+          const dot = (p._viewsDialog as HTMLElement).querySelector("[data-tag-dot='g1']") as HTMLElement;
+          const d = dot.getBoundingClientRect();
+          const rect = (b: DOMRect) => ({ top: b.top, bottom: b.bottom, left: b.left, right: b.right });
+          if (!pop) return { open: false, swatches: 0, pop: rect(d), dot: rect(d), view: { w: top.innerWidth, h: top.innerHeight }, inTop: false, focused: false };
+          return { open: true, swatches: pop.querySelectorAll("[role=radio]").length, pop: rect(pop.getBoundingClientRect()), dot: rect(d), view: { w: top.innerWidth, h: top.innerHeight },
+            inTop: pop.ownerDocument === top.document, focused: top.document.activeElement === pop.querySelector("[aria-checked=true]") };
+        });
+        assert.ok(fm.open, label + ": a click on the g1 dot opens the popover");
+        assert.equal(fm.swatches, 12);
+        const gap = Math.min(Math.abs(fm.pop.top - fm.dot.bottom), Math.abs(fm.dot.top - fm.pop.bottom));
+        assert.ok(gap <= 6, label + ": the popover hangs on the dot in the top document's coordinates: popover " + Math.round(fm.pop.top) + ".." + Math.round(fm.pop.bottom) + ", dot " + Math.round(fm.dot.top) + ".." + Math.round(fm.dot.bottom) + " (gap " + gap + ")");
+        assert.ok(fm.pop.top >= 0 && fm.pop.left >= 0 && fm.pop.bottom <= fm.view.h && fm.pop.right <= fm.view.w,
+          label + ": the popover is inside the top viewport " + fm.view.w + "x" + fm.view.h + ": " + Math.round(fm.pop.left) + "," + Math.round(fm.pop.top) + " to " + Math.round(fm.pop.right) + "," + Math.round(fm.pop.bottom));
+        assert.ok(fm.inTop, label + ": the popover lives in the top document");
+        assert.ok(fm.focused, label + ": the current swatch took focus in the top document");
+        assert.deepEqual(errors, [], label + ": no page error");
+        await page.close();
+      }
+    } finally { await browser.close(); }
+  });
+}

--- a/ui/timeline-tags-scale.test.ts
+++ b/ui/timeline-tags-scale.test.ts
@@ -1,0 +1,1086 @@
+// THE SESSIONS & TAGS DIALOG WITH MANY TAGS (the user 2026-09-09, whose ten tags filled the dialog: each
+// tag row carried the whole identity palette inline, twelve swatches in two rows, and "pane filters" was
+// a five-pane matrix of every tag, so "the sessions", the working area, showed two rows under the fold).
+// Now a tag row is one line (pill, delete, rename, ONE colour dot), the palette opens on demand as a
+// popover anchored to the dot, the filters fold to one summary line per pane (open on the caption's
+// caret, remembered for the page), the tag table caps its height and scrolls within itself, and the
+// sessions table takes the rest. The review of 2026-09-09 added: the popover placed in the dot's own
+// document and closing when its dot moves (a scroll under it, a resize) or when focus leaves it (Tab,
+// focusout), the current swatch marked apart from the focus ring, the table's scroll surviving a repaint,
+// a drag past the table's edge landing only on a visible row, the folded summary naming only tags that
+// exist, [+ New tag] under the table rather than inside its scroll, a held dot taking no click, the
+// pick re-resolving its tag by union key, a repaint that holds the popover's dot closing the popover, and
+// the popover placed untranslated in the dialog's own document when the view runs in a frame. EXECUTED
+// over the house fake-DOM shim with the real
+// TimelinePanel: the dialog is opened, the dot clicked, a swatch picked, and the posted write is the one
+// the inline swatches posted. Synthetic ids and names only.
+import { test, beforeEach } from "node:test";
+import * as assert from "node:assert/strict";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+// NEVER assert.equal / notEqual / deepEqual two shim nodes (or a node against null): on failure node's
+// assert appends an actual/expected diff that walks the node graph, and the parentNode/children cycles
+// make that walk grow without bound (a 30 GB stall and a nameless kill, review find 2026-09-09). Compare
+// identity with `same(a, b, msg)` below, or compare a projection (keys, text, attributes).
+// a node appended under another document's node is ADOPTED with its subtree, as a browser adopts it: its
+// ownerDocument is the new parent's (the dialog is appended to the host document before it is built, and
+// _menuHost reads the anchor's document to skip the frame translation for a node already living there)
+function adopt(n: any, doc: any) { n._ownerDoc = doc; for (const c of n.children || []) adopt(c, doc); }
+function makeNode(tag: string): any {
+  const n: any = {
+    tag, _attrs: {}, children: [] as any[], style: {}, dataset: {}, _text: "", parentNode: null, value: "",
+    _ownerDoc: null,
+    get ownerDocument() { return this._ownerDoc || g.document; },
+    set ownerDocument(d: any) { this._ownerDoc = d; },
+    get textContent() { return this._text; },
+    set textContent(v: any) { this._text = v == null ? "" : String(v); for (const c of this.children) c.parentNode = null; this.children.length = 0; },
+    classList: { _s: new Set<string>(), add(...a: string[]) { a.forEach((c) => this._s.add(c)); },
+      remove(...a: string[]) { a.forEach((c) => this._s.delete(c)); },
+      toggle(c: string, f?: boolean) { f ? this._s.add(c) : this._s.delete(c); }, contains(c: string) { return this._s.has(c); } },
+    setAttribute(k: string, v: any) { this._attrs[k] = v; }, getAttribute(k: string) { return this._attrs[k]; },
+    setAttributeNS(_n: any, k: string, v: any) { this._attrs[k] = v; }, removeAttribute(k: string) { delete this._attrs[k]; },
+    appendChild(c: any) {
+      if (c.parentNode) { const i = c.parentNode.children.indexOf(c); if (i >= 0) c.parentNode.children.splice(i, 1); }
+      c.parentNode = n; this.children.push(c);
+      if (c.ownerDocument !== n.ownerDocument) adopt(c, n.ownerDocument);
+      return c;
+    },
+    insertBefore(c: any, ref: any) {
+      c.parentNode = n; const i = this.children.indexOf(ref); i < 0 ? this.children.push(c) : this.children.splice(i, 0, c);
+      if (c.ownerDocument !== n.ownerDocument) adopt(c, n.ownerDocument);
+      return c;
+    },
+    removeChild(c: any) { const i = this.children.indexOf(c); if (i >= 0) { this.children.splice(i, 1); c.parentNode = null; } return c; },
+    get firstChild() { return this.children[0] || null; },
+    remove() { if (n.parentNode) n.parentNode.removeChild(n); },
+    // `_listeners[t]` is the listener added LAST and still registered; removal is by function, so a listener
+    // hung under another for a while (the drag's scroll re-rank under the popover's scroll closer) gives the
+    // slot back to the one that stays when it comes down
+    _listeners: {} as any, _stacks: {} as any,
+    addEventListener(t: string, fn: any) { (n._stacks[t] = n._stacks[t] || []).push(fn); n._listeners[t] = fn; },
+    removeEventListener(t: string, fn?: any) {
+      const a = n._stacks[t] || []; const i = fn ? a.indexOf(fn) : a.length - 1;
+      if (i >= 0) a.splice(i, 1);
+      if (a.length) n._listeners[t] = a[a.length - 1]; else delete n._listeners[t];
+    },
+    setPointerCapture() {}, releasePointerCapture() {},
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    // geometry is a test input: a node's own `_rect`, else the module-level `g.__rectOf(node)` hook (so a
+    // test can move a dot or a row without holding the node the rebuild will create), else one flat rect
+    getBoundingClientRect() { return n._rect || (g.__rectOf ? g.__rectOf(n) : null) || { width: 200, height: 20, left: 0, top: 0, right: 200, bottom: 20 }; },
+    // scrollTop clamps to `g.__scrollMax` (Infinity unless a test says the box no longer scrolls), as a
+    // browser clamps a write on a box whose content fits
+    _scrollTop: 0,
+    get scrollTop() { return this._scrollTop; },
+    set scrollTop(v: any) { const max = g.__scrollMax == null ? Infinity : g.__scrollMax; this._scrollTop = Math.max(0, Math.min(Number(v) || 0, max)); },
+    closest() { return null; },
+    // focus is OBSERVABLE: it records the active element on the fake document (the popover focuses the
+    // current swatch on open and the dot again on close)
+    focus() { g.document.activeElement = n; }, select() {},
+    setSelectionRange() {}, selectionStart: 0, selectionEnd: 0,
+    createEl(t: string, o: any) { const e = makeNode(t); if (o && o.cls) e.classList.add(o.cls); if (o && o.text) e.textContent = o.text; this.appendChild(e); return e; },
+    createDiv(o: any) { return this.createEl("div", o); }, createSpan(o: any) { return this.createEl("span", o); },
+  };
+  return n;
+}
+const g: any = global;
+g.document = {
+  createElement(t: string) { return t === "canvas" ? { getContext() { return { font: "", measureText(s: string) { return { width: (s ? s.length : 0) * 6 }; } }; } } : makeNode(t); },
+  createElementNS(_n: any, t: string) { return makeNode(t); },
+  createTextNode(text: string) { const n = makeNode("#text"); n.textContent = text; return n; },
+  body: makeNode("body"), documentElement: makeNode("html"), head: makeNode("head"),
+  getElementById() { return null; },
+  addEventListener() {}, removeEventListener() {},
+  activeElement: null,
+};
+// a real store, so the feed row's echo (romp:feedTags-set) is readable back the way the dialog reads it
+const stored: Record<string, string> = {};
+g.localStorage = { getItem: (k: string) => (k in stored ? stored[k] : null), setItem: (k: string, v: any) => { stored[k] = String(v); }, removeItem: (k: string) => { delete stored[k]; } };
+g.getComputedStyle = () => ({ backgroundColor: "rgb(30,30,30)", fontFamily: "sans-serif" });
+g.requestAnimationFrame = () => 0;
+g.setTimeout = (fn: any) => { try { fn(); } catch { /* focus on a fake node */ } return 0; };
+// the window's listeners are RECORDED (the popover hangs a resize closer on its window and takes it down on close)
+const winListeners: Record<string, any[]> = {};
+g.addEventListener = (t: string, fn: any) => { (winListeners[t] = winListeners[t] || []).push(fn); };
+g.removeEventListener = (t: string, fn: any) => { const a = winListeners[t] || []; const i = a.indexOf(fn); if (i >= 0) a.splice(i, 1); };
+g.matchMedia = () => ({ matches: false, addEventListener() {}, addListener() {} });
+g.window = g;
+g.innerWidth = 1400; g.innerHeight = 1300;
+
+// the two host bridges, recording every post (the ack test's shape)
+const posted: any[] = [];
+g.__rompTimelineSetViews = (v: any, writeId: string, edited: string[]) => posted.push({ kind: "views", v: JSON.parse(JSON.stringify(v)), writeId, edited });
+g.__rompTimelineTagEdit = (writeId: string, e: any) => posted.push({ kind: "tag", e: Object.assign({ writeId }, JSON.parse(JSON.stringify(e))) });
+
+const VIEW_PATH = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
+const { TimelinePanel, viewTagUnion, lensSummary } = createRequire(__filename)(VIEW_PATH);
+
+const now = 1_781_000_000;
+// the twelve identity colours the kernel serves (any twelve distinct hexes; the dialog draws what it is given)
+const PALETTE = ["#1EA1EB", "#54B204", "#4EA8A9", "#DD42FF", "#E87221", "#4EC9B0", "#E0AF68", "#F7768E", "#7AA2F7", "#9ECE6A", "#BB9AF7", "#FF9E64"];
+const sess = (id: string, name: string, color: string) => ({
+  id, name, color, state: "working", live: true, model: "Opus", effort: "high",
+  context: 40, since: now - 60, awaiting: [], compacting: [], pendingMail: 0, compactions: [], faded: false, stale: false,
+});
+const copy = (v: any) => JSON.parse(JSON.stringify(v));
+// three tags, each pane holding a different filter, so the folded summary has something to say
+const THREE = {
+  active: "all", at: 100, seq: 1000,
+  actives: { chat: { tags: ["gamma", "alpha"] }, timeline: { all: true }, outline: { none: true } },
+  tags: [
+    { id: "g1", name: "alpha", color: "#DD42FF", members: ["s1"], mtime: 100 },
+    { id: "g2", name: "beta", color: "#4EC9B0", members: ["s2"], mtime: 100 },
+    { id: "g3", name: "gamma", color: "#E0AF68", members: [], mtime: 100 },
+  ],
+};
+const THREE_SESSIONS = [sess("s1", "web", "#f7768e"), sess("s2", "api", "#7aa2f7"), sess("s3", "tests", "#9ece6a")];
+// thirty tags and forty sessions: the scale every tag or session surface is checked against (CLAUDE.md)
+const NAMES30 = Array.from({ length: 30 }, (_, i) => "t" + String(i + 1).padStart(2, "0"));
+const THIRTY = {
+  active: "all", at: 100, seq: 1000,
+  actives: { chat: { tags: NAMES30.slice().reverse() }, timeline: { all: true }, outline: { none: true } },
+  tags: NAMES30.map((name, i) => ({ id: "g" + (i + 1), name, color: PALETTE[i % PALETTE.length], members: i < 20 ? ["s" + (i + 1)] : [], mtime: 100 })),
+};
+const FORTY_SESSIONS = Array.from({ length: 40 }, (_, i) => sess("s" + (i + 1), "job-" + String(i + 1).padStart(2, "0"), PALETTE[i % PALETTE.length]));
+// a remote half of "beta", homed on another kernel (tagorder-drag's fixture shape)
+const REMOTE_BETA = { id: "TESTHOST-A:r1", host: "TESTHOST-A", name: "beta", color: "#7aa2f7", members: ["m1"] };
+
+function drawnPanel(views: any, sessions: any[]): any {
+  posted.length = 0;
+  const panel = new TimelinePanel(makeNode("div"));
+  panel.update({ now, sessions, turns: {}, messages: [], judging: [], views: copy(views), palette: PALETTE.slice() });
+  panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: views.seq });
+  return panel;
+}
+function walk(x: any, out: any[] = []): any[] { for (const c of x.children || []) { out.push(c); walk(c, out); } return out; }
+const textOf = (n: any): string => (n.textContent || "") + (n.children || []).map(textOf).join("");
+const styleOf = (n: any): string => String(n._attrs.style || "");
+// node identity, never assert.equal (see the shim's note)
+const same = (a: any, b: any, msg: string) => assert.ok(a === b, msg);
+const dots = (panel: any) => walk(panel._viewsDialog).filter((n) => n.dataset.tagDot);
+const dotFor = (panel: any, key: string) => dots(panel).find((n) => n.dataset.tagDot === key);
+const swatches = (pop: any) => walk(pop).filter((n) => n._attrs.role === "radio");
+// the popovers in the HOST document (the dialog's own body), beside the dialog rather than in it, by key
+const popsInBody = () => g.document.body.children.filter((n: any) => n._attrs.role === "dialog");
+const popKeys = () => popsInBody().map((p: any) => p._key);
+const caption = (panel: any) => walk(panel._viewsDialog).find((n) => String(n.textContent).startsWith("pane filters"));
+const TGRID_PRE = "display:grid;grid-template-columns:max-content max-content max-content 1fr;";
+const tgridOf = (panel: any) => walk(panel._viewsDialog).find((n) => styleOf(n).startsWith(TGRID_PRE));
+const cardOf = (panel: any) => panel._viewsDialog.children[0];
+// the filter pills by their own style signature (the session rows' tag chips share the radius, not the padding)
+const chips = (panel: any) => walk(panel._viewsDialog).filter((n) => styleOf(n).startsWith("cursor:pointer;padding:1px 8px;border-radius:9px;font-size:0.82em;"));
+// the folded summary: the pane label's row, [label, summary]
+const paneLines = (panel: any) => {
+  const out: Record<string, any> = {};
+  for (const row of walk(panel._viewsDialog)) {
+    const lb = row.children && row.children[0];
+    if (lb && ["All surfaces", "Chat", "Sessions", "Outline", "Feed"].includes(lb.textContent) && styleOf(lb).includes("flex:0 0 88px")) out[lb.textContent] = row;
+  }
+  return out;
+};
+function tagOps() { return posted.filter((p) => p.kind === "tag").map((p) => p.e); }
+function openDialog(views: any = THREE, sessions: any[] = THREE_SESSIONS) {
+  const panel = drawnPanel(views, sessions);
+  panel._openViewsDialog(null);
+  assert.ok(panel._viewsDialog, "the dialog opened");
+  return panel;
+}
+
+// one failure must not take the tests after it down with it (review find, 2026-09-09: a popover a failed
+// assertion left in the shared body failed three later tests on popsInBody()): before every test the body is
+// emptied, the window's listeners, the feed row's echo, the geometry hooks, the remote bridge, the frame
+// stand-ins and the recorded posts are reset, and the pane filters' page-lifetime fold is put back to folded
+// through a throwaway dialog (the module variable has no other door)
+beforeEach(() => {
+  for (const c of g.document.body.children) c.parentNode = null;
+  g.document.body.children.length = 0;
+  g.document.activeElement = null;
+  for (const k of Object.keys(winListeners)) delete winListeners[k];
+  delete stored["romp:feedTags-set"];
+  g.__rectOf = null; g.__scrollMax = undefined;
+  delete g.__rompTimelineEditTag;
+  delete g.frameElement; delete g.parent;
+  posted.length = 0;
+  const p = drawnPanel(THREE, THREE_SESSIONS);
+  p._openViewsDialog(null);
+  if (caption(p).textContent.endsWith(" \u25BE")) caption(p)._listeners.click();
+  p._closeViewsDialog();
+});
+
+test("executed: lensSummary says what a pane shows, in the user's tag order, only tags that exist, cut with a count when long", () => {
+  const order = ["alpha", "beta", "gamma"];
+  assert.equal(lensSummary({ all: true }, order), "All");
+  assert.equal(lensSummary(null, order), "All", "no lens yet reads as All, like lensAll");
+  assert.equal(lensSummary({ none: true }, order), "no tags");
+  assert.equal(lensSummary({ tags: ["gamma", "alpha"] }, order), "alpha, gamma", "the USER'S order, not the order the chips were clicked in");
+  assert.equal(lensSummary({ tags: ["beta"], none: true }, order), "beta, no tags", "'no tags' last, as lensLabel puts it");
+  // a name the union no longer lists (a rename or a delete left it in the lens) is not claimed: the open
+  // matrix draws no chip for it, so the two forms agree (review find, 2026-09-09)
+  assert.equal(lensSummary({ tags: ["zeta", "alpha"] }, order), "alpha", "a name the union no longer lists is left out");
+  assert.equal(lensSummary({ tags: ["zeta"] }, order), "none of the tags here", "a lens left with nothing says so: the pane shows nothing");
+  assert.equal(lensSummary({ tags: ["zeta"], none: true }, order), "no tags", "'no tags' still counts");
+  assert.equal(lensSummary({ tags: ["zeta", "alpha"] }), "zeta, alpha", "without an order there is nothing to filter by: every name, as given");
+  assert.equal(lensSummary({ tags: NAMES30.slice().reverse() }, NAMES30), "t01, t02, t03, t04, t05, t06 +24 more", "six names, then the count");
+  assert.equal(lensSummary({ tags: NAMES30.slice(0, 6) }, NAMES30), "t01, t02, t03, t04, t05, t06", "six is not long");
+  assert.equal(lensSummary({ tags: NAMES30.slice(0, 7) }, NAMES30, 3), "t01, t02, t03 +4 more", "the cut is a parameter");
+  assert.equal(lensSummary({ tags: NAMES30.slice().reverse() }, NAMES30, Infinity), NAMES30.join(", "), "Infinity: the full list (the hover)");
+});
+
+test("executed: a tag row is one line: the pill, delete, rename and ONE colour dot; no inline swatches anywhere; the height budget's boxes", () => {
+  const panel = openDialog();
+  const ds = dots(panel);
+  assert.deepEqual(ds.map((d) => d.dataset.tagDot), ["g1", "g2", "g3"], "one dot per tag row, keyed by the tag");
+  for (const [d, tg] of ds.map((d, i) => [d, THREE.tags[i]] as const)) {
+    assert.ok(styleOf(d).includes("background:" + tg.color + ";"), "the dot wears the tag's own colour");
+    assert.equal(d._attrs.role, "button");
+    assert.equal(d._attrs.tabindex, "0", "reachable by keyboard");
+    assert.equal(d._attrs["aria-haspopup"], "dialog");
+    assert.equal(d._attrs["aria-expanded"], "false");
+    assert.ok(String(d._attrs.title).includes(tg.name), "the hover names the tag");
+  }
+  assert.equal(walk(panel._viewsDialog).filter((n) => n._attrs.role === "radio").length, 0, "no swatch in any row");
+  assert.equal(popsInBody().length, 0, "...and no popover until a dot is clicked");
+  // the row still drags to reorder (the pill cell keeps its handle) and still carries delete and rename
+  const cells = walk(panel._viewsDialog).filter((n) => n._tname);
+  assert.deepEqual(cells.map((c) => c._tname), ["alpha", "beta", "gamma"]);
+  assert.ok(cells.every((c) => c._listeners.pointerdown), "the reorder drag stays on the pill");
+  assert.equal(walk(panel._viewsDialog).filter((n) => n.textContent === "delete").length, 3);
+  assert.equal(walk(panel._viewsDialog).filter((n) => n.textContent === "rename").length, 3);
+  // THE HEIGHT BUDGET (review, 2026-09-09): the table caps its share and scrolls within itself, gives way
+  // only once the sessions are at their floor, and keeps a floor of its own (three rows here, so it does not
+  // shrink at all: its natural height is its rows), with room inside the clip for the rings; the card
+  // scrolls past the floors. The floors' arithmetic is the next test's.
+  const tgrid = tgridOf(panel);
+  assert.ok(tgrid, "the tag table");
+  assert.ok(styleOf(tgrid).includes("padding:4px 0 4px 4px;margin:-2px 0 2px -4px;"), "room inside the scroll clip for the pills' and dots' rings, the layout unmoved");
+  assert.ok(styleOf(tgrid).includes("flex:0 0 auto;max-height:30vh;overflow-y:auto;overflow-anchor:none;"), "capped at 30vh, scrolling within, three rows never shrinking, and out of scroll anchoring (the drag's cue lift moves 2px of content the browser must not scroll to follow; the browser legs drive the case, this pins the token where CI runs): " + styleOf(tgrid));
+  assert.ok(!styleOf(tgrid).includes("min-height"), "three rows need no floor under them: their natural height is the floor");
+  assert.ok(tgrid._listeners.scroll, "the table's scroll is listened to (it closes the popover when the dot moves)");
+  const gridBox = walk(panel._viewsDialog).find((n) => styleOf(n).startsWith("flex:1 1000 auto;min-height:") && styleOf(n).endsWith("px;overflow-y:auto;"));
+  assert.ok(gridBox, "the sessions box gives way first (the thousandfold shrink) down to a floor under its rows");
+  const card = cardOf(panel);
+  assert.ok(styleOf(card).includes("max-height:90vh;overflow-y:auto;overflow-x:hidden;"), "the card scrolls as a whole past the floors instead of clipping");
+  assert.ok(card._listeners.scroll, "...and its scroll is listened to as well");
+  // [+ New tag] is the card's own child UNDER the table, never a row inside its scroll (review find F6)
+  const nt = walk(panel._viewsDialog).find((n) => n.textContent === "+ New tag");
+  assert.ok(nt, "the New tag row");
+  same(nt.parentNode.parentNode, card, "the row hangs on the card...");
+  assert.ok(!walk(tgrid).includes(nt), "...not in the table");
+  same(card.children[card.children.indexOf(tgrid) + 1], nt.parentNode, "directly under the table");
+  assert.ok(styleOf(nt.parentNode).startsWith("flex:0 0 auto;"), "a fixed row of the card: it never scrolls away");
+  panel._closeViewsDialog();
+});
+
+// the sessions grid, by its own style signature (the row cells' parent)
+const GRID_PRE = "display:grid;grid-template-columns:max-content max-content 1fr;";
+const gridOf = (panel: any) => walk(panel._viewsDialog).find((n) => styleOf(n).startsWith(GRID_PRE));
+const gridBoxOf = (panel: any) => gridOf(panel).parentNode;
+// a grid cell's row: the count of the row-leading cells among its siblings up to it (the `_tname` pill in the tag
+// table, the `_sid` name in the sessions grid), so a test places rows by index without holding the nodes a
+// rebuild replaces
+const rowIdx = (n: any, lead: string) => { let k = 0; for (const c of n.parentNode.children) { if (c[lead]) k++; if (c === n) break; } return k - 1; };
+// a tag row placed by its index: 24px tall at a 28px pitch (row-gap 4), every cell of the row in its track.
+// A later review find: one rect for every cell of the table let a floor measured off the WHOLE table (a thirty-row
+// floor, the table never shrinking) pass here, with only the browser legs, which skip on CI, to catch it
+const tagRect = (i: number) => ({ left: 0, top: 100 + 28 * i, right: 200, bottom: 124 + 28 * i, width: 200, height: 24 });
+
+test("executed: the floors are measured off the rendered rows: a table of at most three rows keeps its natural height, a taller one three rows' worth; the sessions box min(live, 4) rows, by the live count and not the search hits", () => {
+  // review find, 2026-09-09: a constant per row (22px, 24px) is not the row height, which is the font's:
+  // one tag showed 6px of blank under its row, three rows at the floor lost 7px of the third, one live
+  // session sat in a 96px box. GEOMETRY IS A TEST INPUT here: tag rows lay out 24px tall (row-gap 4), placed
+  // by their index (tagRect), session rows 18px (row-gap 3), every cell of a row seated in its track
+  g.__rectOf = (n: any) => {
+    const par = n.parentNode ? styleOf(n.parentNode) : "";
+    if (par.startsWith(TGRID_PRE)) return tagRect(rowIdx(n, "_tname"));
+    if (par.startsWith(GRID_PRE)) return { left: 0, top: 300, right: 200, bottom: 318, width: 200, height: 18 };
+    return null;
+  };
+  try {
+    // thirty tags: three rows' worth, 3 x 24 + 2 x 4, and the table may shrink to it
+    const p30 = openDialog(THIRTY, FORTY_SESSIONS);
+    assert.ok(styleOf(tgridOf(p30)).includes("flex:0 1 auto;min-height:80px;max-height:30vh;overflow-y:auto;overflow-anchor:none;"), "thirty rows: a floor of three at the rendered height, the table out of scroll anchoring: " + styleOf(tgridOf(p30)));
+    // forty live sessions: four rows' worth, 4 x 18 + 3 x 3
+    assert.equal(styleOf(gridBoxOf(p30)), "flex:1 1000 auto;min-height:81px;overflow-y:auto;", "forty live: a floor of four rows at the rendered height");
+    // typing a query that hides most rows, or every row, leaves the box as it was: the floor follows the live
+    // count, not the hits, so the box never resizes under the user's typing
+    const q = walk(p30._viewsDialog).find((n) => n.tag === "input" && n.placeholder === "search name or host…");
+    q.value = "job-01"; q._listeners.input();
+    assert.equal(walk(p30._viewsDialog).filter((n) => n._sid).length, 1, "one hit");
+    assert.equal(styleOf(gridBoxOf(p30)), "flex:1 1000 auto;min-height:81px;overflow-y:auto;", "one hit shown, the floor unchanged");
+    q.value = "nothing-here"; q._listeners.input();
+    assert.equal(walk(p30._viewsDialog).filter((n) => n._sid).length, 0, "no hit");
+    assert.equal(styleOf(gridBoxOf(p30)), "flex:1 1000 auto;min-height:81px;overflow-y:auto;", "no hit shown, the floor unchanged");
+    // a repaint with that query set has no row to measure: the row height the last build measured serves
+    p30._viewsDialogBuild();
+    assert.equal(walk(p30._viewsDialog).filter((n) => n._sid).length, 0, "the query survived the repaint, still no hit");
+    assert.equal(styleOf(gridBoxOf(p30)), "flex:1 1000 auto;min-height:81px;overflow-y:auto;", "a repaint with every row hidden keeps the four-row floor");
+    p30._closeViewsDialog();
+    // four tags: the first count that can shrink, to three rows' worth
+    const four = copy(THREE); four.tags = four.tags.concat([{ id: "g4", name: "delta", color: "#F7768E", members: [], mtime: 100 }]);
+    const p4 = openDialog(four);
+    assert.ok(styleOf(tgridOf(p4)).includes("flex:0 1 auto;min-height:80px;"), "four rows may shrink to three: " + styleOf(tgridOf(p4)));
+    p4._closeViewsDialog();
+    // three, one and no tags: the natural height, no floor to be off by; no tags, no box at all
+    for (const [n, label] of [[3, "three"], [1, "one"]] as Array<[number, string]>) {
+      const v = copy(THREE); v.tags = v.tags.slice(0, n);
+      const p = openDialog(v);
+      const st = styleOf(tgridOf(p));
+      assert.ok(st.includes("padding:4px 0 4px 4px;margin:-2px 0 2px -4px;flex:0 0 auto;max-height:30vh;"), label + ": natural height, no shrink: " + st);
+      assert.ok(!st.includes("min-height"), label + ": no floor");
+      p._closeViewsDialog();
+    }
+    const none = copy(THREE); none.tags = []; none.actives = { chat: { all: true }, timeline: { all: true }, outline: { none: true } };
+    const p0 = openDialog(none);
+    assert.ok(styleOf(tgridOf(p0)).includes("padding:0;margin:0;flex:0 0 auto;"), "no tags: no padding, so no empty box between the caption and New tag: " + styleOf(tgridOf(p0)));
+    assert.equal(walk(p0._viewsDialog).filter((n) => n._tname).length, 0);
+    assert.ok(walk(p0._viewsDialog).some((n) => n.textContent === "+ New tag"), "New tag is still shown");
+    p0._closeViewsDialog();
+    // the sessions floor by the live count: none live, one, three, four, five
+    const live = (k: number, total = k) => Array.from({ length: total }, (_, i) => Object.assign(sess("s" + (i + 1), "job-" + (i + 1), PALETTE[i]), { live: i < k }));
+    const floors: Array<[number, number, string]> = [[0, 0, "no sessions"], [1, 18, "one live"], [3, 60, "three live"], [4, 81, "four live"], [5, 81, "five live: four rows, the rest scroll"]];
+    for (const [k, px, label] of floors) {
+      const p = openDialog(THREE, live(k));
+      assert.equal(styleOf(gridBoxOf(p)), "flex:1 1000 auto;min-height:" + px + "px;overflow-y:auto;", label);
+      assert.equal(walk(p._viewsDialog).filter((n) => n._sid).length, k, label + ": the rows");
+      p._closeViewsDialog();
+    }
+    const pd = openDialog(THREE, live(0, 2));
+    assert.equal(styleOf(gridBoxOf(pd)), "flex:1 1000 auto;min-height:0px;overflow-y:auto;", "two sessions, none live: no row, no floor");
+    pd._closeViewsDialog();
+    // live beside dead: the floor counts the LIVE sessions, two rows' worth for two live of six (a floor by
+    // every session would hold four rows over two, 2 x 18 + 3 here, not 4 x 18 + 9)
+    const pm = openDialog(THREE, live(2, 6));
+    assert.equal(styleOf(gridBoxOf(pm)), "flex:1 1000 auto;min-height:39px;overflow-y:auto;", "two live of six: two rows' worth, not four");
+    assert.equal(walk(pm._viewsDialog).filter((n) => n._sid).length, 2, "two live of six: the two rows");
+    pm._closeViewsDialog();
+  } finally { g.__rectOf = null; }
+});
+
+test("executed: the dot opens the palette as a popover beside the dialog, the current swatch marked apart from the focus ring and focused", () => {
+  const panel = openDialog();
+  const dot = dotFor(panel, "g2");
+  dot._listeners.click();
+  const pop = panel._tagColorPop;
+  assert.ok(pop, "the popover is open");
+  assert.deepEqual(popKeys(), ["g2"], "it lives in the host document beside the dialog, not inside the card");
+  assert.ok(styleOf(pop).startsWith("position:fixed;z-index:1003;"), "one layer above the dialog's backdrop (1002)");
+  assert.ok(styleOf(pop).includes("font:12px/1.4"), "the shared menu vocabulary");
+  assert.equal(pop._key, "g2");
+  assert.equal(dot._attrs["aria-expanded"], "true");
+  const sws = swatches(pop);
+  assert.equal(sws.length, 12, "the same twelve swatches the rows carried inline");
+  assert.deepEqual(sws.map((s) => s._attrs["aria-label"]), PALETTE, "the kernel's palette, in its order");
+  const cur = sws.filter((s) => s._attrs["aria-checked"] === "true");
+  assert.equal(cur.length, 1, "exactly one current swatch");
+  assert.ok(styleOf(cur[0]).includes("background:#4EC9B0;"), "...the tag's colour");
+  // the current mark is an INNER ring (box-shadow), and no swatch sets an outline: the outline is the
+  // browser's focus ring, so focus on open (which lands here) reads apart from "current" (review, 2026-09-09)
+  assert.ok(styleOf(cur[0]).includes("box-shadow:inset 0 0 0 2px #4EC9B0,inset 0 0 0 4px "), "...ringed inside, in the menu text colour: " + styleOf(cur[0]));
+  assert.ok(sws.every((s) => !styleOf(s).includes("outline")), "no swatch replaces the browser's focus outline");
+  assert.ok(sws.filter((s) => s !== cur[0]).every((s) => !styleOf(s).includes("box-shadow")), "only the current swatch wears the ring");
+  same(g.document.activeElement, cur[0], "...and focused on open");
+  assert.deepEqual(sws.map((s) => s._attrs.tabindex), PALETTE.map((c) => (c === "#4EC9B0" ? "0" : "-1")), "one tab stop, on the current swatch");
+  assert.ok(styleOf(walk(pop).find((n) => n._attrs.role === "radiogroup")).includes("grid-template-columns:repeat(6,18px)"), "twelve swatches in two balanced rows of six (T164)");
+  // placed by the dot's rect in the dot's own document: below it (the flat shim rect: bottom 20, +4)
+  assert.equal(pop.style.top, "24px"); assert.equal(pop.style.left, "6px");
+  assert.deepEqual(pop._anchorAt, { left: 0, top: 0 }, "the dot's place is recorded, so a scroll can tell a moved dot from one that stayed");
+  panel._closeViewsDialog();
+});
+
+test("executed: a pick posts the SAME recolor the inline swatch posted, closes the popover, repaints, and puts focus back on the dot", () => {
+  const panel = openDialog();
+  const dot = dotFor(panel, "g1");
+  dot._listeners.click();
+  const sw = swatches(panel._tagColorPop).find((s) => s._attrs["aria-label"] === "#54B204");
+  sw._listeners.click();
+  // the write: a targeted recolor by tid, no name, one writeId (what timeline-views-ack.test.ts asserts of _editTagUnion color)
+  const ops = tagOps();
+  assert.equal(ops.length, 1, "one post for the pick");
+  assert.deepEqual([ops[0].op, ops[0].tid, ops[0].color, ops[0].name], ["recolor", "g1", "#54B204", undefined]);
+  assert.ok(typeof ops[0].writeId === "string" && ops[0].writeId, "the write carries its writeId for the ack");
+  assert.equal(posted.filter((p) => p.kind === "views").length, 0, "no whole-blob write");
+  // the optimistic copy shows the colour at once, held until the ack
+  assert.ok(panel._pendingViews, "the optimistic copy is pending");
+  assert.equal(panel._curViews().tags.find((t: any) => t.id === "g1").color, "#54B204");
+  same(panel._tagColorPop, null, "the popover closed on the pick");
+  assert.equal(popsInBody().length, 0);
+  // the dialog repainted: a fresh dot wearing the new colour, focused
+  const dot2 = dotFor(panel, "g1");
+  assert.ok(dot2 && dot2 !== dot, "the row was rebuilt");
+  assert.ok(styleOf(dot2).includes("background:#54B204;"), "the dot wears the picked colour");
+  same(g.document.activeElement, dot2, "focus is back on the dot, not lost in the removed popover");
+  assert.equal(dot2._attrs["aria-expanded"], "false");
+  // the ack settles it exactly as before
+  const S1 = copy(THREE); S1.seq = 1001; S1.at = 113; S1.tags[0].color = "#54B204"; S1.tags[0].mtime = 113;
+  panel.viewsAck({ type: "tagEditAck", writeId: ops[0].writeId, ok: true, seq: 1001, tid: "g1", views: copy(S1) });
+  same(panel._pendingViews, null, "the ack clears the optimistic copy");
+  assert.equal(panel._curViews().tags[0].color, "#54B204");
+  // a REFUSED pick reverts and says why, in the dialog
+  dotFor(panel, "g1")._listeners.click();
+  swatches(panel._tagColorPop).find((s) => s._attrs["aria-label"] === "#E87221")._listeners.click();
+  assert.equal(panel._curViews().tags[0].color, "#E87221", "optimistic");
+  const why = "that tag no longer exists";
+  panel.viewsAck({ type: "tagEditAck", writeId: tagOps()[1].writeId, ok: false, error: why, tid: "g1", seq: 1001, views: copy(S1) });
+  assert.equal(panel._curViews().tags[0].color, "#54B204", "the refused copy is dropped at once");
+  assert.ok(styleOf(dotFor(panel, "g1")).includes("background:#54B204;"), "the dot shows the store's truth");
+  const shown = walk(panel._viewsDialog).map(textOf).find((s) => s.startsWith("⚠ "));
+  assert.ok(shown && shown.startsWith("⚠ " + why), "the refusal shows in the dialog");
+  panel._closeViewsDialog();
+});
+
+test("executed: the pick re-resolves its tag by union key: a rename and a remote half landing while the popover is open are honoured by the pick", () => {
+  // the popover holds the union object as it was on open; a repaint in between rebuilds the unions, and
+  // a pick on the stale copy would skip a remote half that joined meanwhile (its fan-out reads g.remotes)
+  const panel = openDialog();
+  dotFor(panel, "g2")._listeners.click();
+  assert.equal(panel._tagColorPop._key, "g2");
+  const remoteCalls: any[] = [];
+  g.__rompTimelineEditTag = (m: any) => remoteCalls.push(m);   // the remote bridge appears (the shell's)
+  try {
+    // the frame: beta renamed to beta2 AND homed on a second kernel too; the dialog repaints on it
+    const F = copy(THREE); F.seq = 1001; F.tags[1].name = "beta2";
+    F.remoteTags = [Object.assign({}, REMOTE_BETA, { name: "beta2", color: "#4EC9B0" })];
+    panel.update({ now, sessions: THREE_SESSIONS, views: F });
+    panel._viewsDialogBuild();
+    assert.ok(panel._tagColorPop && panel._tagColorPop._key === "g2", "the popover survived the repaint on the same key");
+    assert.deepEqual(viewTagUnion(panel._curViews()).find((u: any) => u.localId === "g2").remotes.map((r: any) => r.host), ["TESTHOST-A"], "the union now has a remote half");
+    swatches(panel._tagColorPop).find((s) => s._attrs["aria-label"] === "#54B204")._listeners.click();
+    // the remote half is recoloured through the bridge, under the CURRENT name...
+    assert.equal(remoteCalls.length, 1, "the pick reached the half that joined while the popover was open (a stale copy would have skipped it)");
+    assert.deepEqual([remoteCalls[0].host, remoteCalls[0].name, remoteCalls[0].color, remoteCalls[0].rename, remoteCalls[0].delete], ["TESTHOST-A", "beta2", "#54B204", undefined, false]);
+    // ...and the local half by its tid, as before
+    const ops = tagOps();
+    assert.equal(ops.length, 1);
+    assert.deepEqual([ops[0].op, ops[0].tid, ops[0].color], ["recolor", "g2", "#54B204"]);
+    same(panel._tagColorPop, null, "closed on the pick");
+  } finally { delete g.__rompTimelineEditTag; }
+  panel._closeViewsDialog();
+});
+
+test("executed: a held dot (a remote half this host cannot reach, no bridge) wears the reason, is inert, and takes no click; its neighbour still opens", () => {
+  // no __rompTimelineEditTag on the fake window: _remoteBridge() is false, as in an Obsidian panel
+  assert.equal(typeof g.__rompTimelineEditTag, "undefined");
+  const V = copy(THREE); V.remoteTags = [copy(REMOTE_BETA)];
+  const panel = openDialog(V);
+  assert.equal(panel._remoteBridge(), false);
+  const held = dotFor(panel, "g2");
+  assert.ok(held, "beta's dot renders (dim), keyed by its local id");
+  assert.equal(held._attrs["aria-disabled"], "true");
+  assert.equal(held._attrs.title, panel._unreachableText(["TESTHOST-A"], true), "the refusal is its tooltip");
+  assert.equal(held._attrs.tabindex, undefined, "not a tab stop");
+  assert.equal(held._attrs["aria-haspopup"], undefined);
+  assert.ok(styleOf(held).includes("cursor:default;opacity:0.35;"), "dim, no pointer");
+  assert.equal(held._listeners.click, undefined, "no click opener");
+  assert.equal(held._listeners.keydown, undefined, "no keyboard opener");
+  assert.equal(popsInBody().length, 0);
+  // the same dialog's alpha (local only) is untouched by the held row
+  const live = dotFor(panel, "g1");
+  assert.equal(live._attrs.tabindex, "0");
+  live._listeners.click();
+  assert.deepEqual(popKeys(), ["g1"], "alpha's dot opens its popover");
+  assert.equal(tagOps().length, 0, "nothing was posted by any of this");
+  panel._closeViewsDialog();
+  assert.equal(popsInBody().length, 0);
+});
+
+test("executed: keyboard: Enter or Space on the dot opens; Space on a swatch picks; the arrows move the tab stop; Tab leaves like Escape", () => {
+  const panel = openDialog();
+  const dot = dotFor(panel, "g3");
+  let prevented = 0;
+  dot._listeners.keydown({ key: "Enter", preventDefault() { prevented++; } });
+  assert.ok(panel._tagColorPop, "Enter opens");
+  assert.equal(prevented, 1);
+  dot._listeners.keydown({ key: " ", preventDefault() { prevented++; } });
+  same(panel._tagColorPop, null, "Space on the dot while its popover is open toggles it shut");
+  dot._listeners.keydown({ key: " ", preventDefault() { prevented++; } });
+  assert.ok(panel._tagColorPop, "...and opens it again");
+  const sws = swatches(panel._tagColorPop);
+  const curIdx = PALETTE.indexOf("#E0AF68");
+  same(g.document.activeElement, sws[curIdx], "the current swatch has focus");
+  sws[curIdx]._listeners.keydown({ key: "ArrowRight", preventDefault() {} });
+  same(g.document.activeElement, sws[curIdx + 1], "ArrowRight moves focus");
+  assert.equal(sws[curIdx + 1]._attrs.tabindex, "0"); assert.equal(sws[curIdx]._attrs.tabindex, "-1");
+  sws[curIdx + 1]._listeners.keydown({ key: "ArrowDown", preventDefault() {} });
+  same(g.document.activeElement, sws[Math.min(11, curIdx + 7)], "ArrowDown moves a row (six per row)");
+  sws[curIdx + 1]._listeners.keydown({ key: "Home", preventDefault() { prevented = -1; } });
+  assert.notEqual(prevented, -1, "other keys pass through");
+  // Tab (either direction) leaves the palette the way Escape does: closed, focus back on the dot, which is
+  // the tab stop before and after it; left alone it moved focus to the body with the palette still open
+  // (review find, 2026-09-09)
+  sws[curIdx + 1]._listeners.keydown({ key: "Tab", preventDefault() { prevented = -2; } });
+  assert.equal(prevented, -2, "Tab is taken");
+  same(panel._tagColorPop, null, "...the popover closed");
+  same(g.document.activeElement, dot, "...and focus is on the dot");
+  assert.equal(dot._attrs["aria-expanded"], "false");
+  dot._listeners.keydown({ key: " ", preventDefault() {} });
+  swatches(panel._tagColorPop)[1]._listeners.keydown({ key: " ", preventDefault() {} });
+  const ops = tagOps();
+  assert.deepEqual([ops[0].op, ops[0].tid, ops[0].color], ["recolor", "g3", PALETTE[1]], "Space picks");
+  same(panel._tagColorPop, null, "closed on the pick");
+  panel._closeViewsDialog();
+});
+
+test("executed: focus leaving the popover for another element closes it; a move within it, to its dot, or to nothing leaves it open", () => {
+  const panel = openDialog();
+  const dot = dotFor(panel, "g2");
+  dot._listeners.click();
+  const pop = panel._tagColorPop;
+  assert.ok(pop._listeners.focusout, "the popover watches its focus");
+  const sws = swatches(pop);
+  pop._listeners.focusout({ relatedTarget: null });
+  assert.ok(panel._tagColorPop, "focus to nothing (the window losing focus) leaves it open");
+  pop._listeners.focusout({ relatedTarget: sws[3] });
+  assert.ok(panel._tagColorPop, "a move within the popover (the arrows) leaves it open");
+  pop._listeners.focusout({ relatedTarget: dot });
+  assert.ok(panel._tagColorPop, "a move to its own dot leaves it open (the dot's click toggles)");
+  const search = walk(panel._viewsDialog).find((n) => n.tag === "input" && n.placeholder === "search name or host…");
+  pop._listeners.focusout({ relatedTarget: search });
+  same(panel._tagColorPop, null, "focus that left for another element closes it");
+  assert.equal(popsInBody().length, 0);
+  assert.equal(dot._attrs["aria-expanded"], "false");
+  same(g.document.activeElement, sws.find((s) => s._attrs["aria-checked"] === "true"), "...without pulling focus back (it went where the user sent it)");
+  panel._closeViewsDialog();
+});
+
+test("executed: Escape closes the popover first (focus back on the dot) and the dialog only on the next press", () => {
+  const panel = openDialog();
+  const dot = dotFor(panel, "g1");
+  dot._listeners.click();
+  assert.ok(panel._tagColorPop);
+  panel._viewsDialogKey.fn({ key: "Escape" });
+  same(panel._tagColorPop, null, "the popover closed");
+  assert.equal(popsInBody().length, 0);
+  assert.ok(panel._viewsDialog, "the dialog is still open");
+  same(g.document.activeElement, dot, "focus returned to the dot");
+  assert.equal(dot._attrs["aria-expanded"], "false");
+  assert.equal(tagOps().length, 0, "nothing was written");
+  panel._viewsDialogKey.fn({ key: "Escape" });
+  same(panel._viewsDialog, null, "the second Escape closes the dialog");
+});
+
+test("executed: a press anywhere on the dialog outside the popover closes it; a press on its own dot leaves the toggle to the click; the backdrop closes both", () => {
+  const panel = openDialog();
+  const back = panel._viewsDialog;
+  const card = back.children[0];
+  const dot = dotFor(panel, "g2");
+  dot._listeners.click();
+  assert.ok(panel._tagColorPop);
+  back._listeners.pointerdown({ target: card });
+  same(panel._tagColorPop, null, "a press on the card (outside the popover) closes it");
+  assert.ok(panel._viewsDialog, "...and the dialog stays");
+  // the dot's own press: the popover stays for the click, which toggles it shut (no close-then-reopen)
+  dot._listeners.click();
+  assert.ok(panel._tagColorPop);
+  back._listeners.pointerdown({ target: dot });
+  assert.ok(panel._tagColorPop, "the anchor's press does not close it");
+  dot._listeners.click();
+  same(panel._tagColorPop, null, "...the click does");
+  // the backdrop: dialog and popover go together
+  dot._listeners.click();
+  back._listeners.pointerdown({ target: back });
+  same(panel._viewsDialog, null, "the backdrop press closes the dialog");
+  same(panel._tagColorPop, null, "...and the popover with it");
+  assert.equal(popsInBody().length, 0, "nothing is left in the host document");
+});
+
+test("executed: one popover at a time; closing the dialog any other way removes it too", () => {
+  const panel = openDialog();
+  dotFor(panel, "g1")._listeners.click();
+  const first = panel._tagColorPop;
+  dotFor(panel, "g2")._listeners.click();
+  assert.ok(panel._tagColorPop !== first, "the second dot's popover replaced the first");
+  assert.equal(panel._tagColorPop._key, "g2");
+  assert.deepEqual(popKeys(), ["g2"], "exactly one popover in the host document");
+  assert.equal(dotFor(panel, "g1")._attrs["aria-expanded"], "false");
+  assert.equal(dotFor(panel, "g2")._attrs["aria-expanded"], "true");
+  panel._closeViewsDialog();
+  same(panel._tagColorPop, null, "closed with the dialog");
+  assert.equal(popsInBody().length, 0);
+});
+
+test("executed: a scroll under the popover that moves its dot closes it; one that moved nothing leaves it; a resize closes it and takes its listener down", () => {
+  const panel = openDialog(THIRTY, FORTY_SESSIONS);
+  const tgrid = tgridOf(panel);
+  const resizeBefore = (winListeners.resize || []).length;
+  dotFor(panel, "g2")._listeners.click();
+  const pop = panel._tagColorPop;
+  assert.ok(pop);
+  const added = winListeners.resize.slice(resizeBefore);
+  assert.equal(added.length, 1, "the popover hung ONE resize closer on its window");
+  // the repaint's scroll restore fires a scroll event that moved nothing: the popover stays
+  tgrid._listeners.scroll();
+  same(panel._tagColorPop, pop, "a scroll event with the dot where it was leaves the popover");
+  // the user scrolls the table: the dot moves under the popover, which closes rather than float
+  g.__rectOf = (n: any) => (n.dataset && n.dataset.tagDot === "g2" ? { left: 0, top: -150, right: 14, bottom: -136, width: 14, height: 14 } : null);
+  try {
+    tgrid._listeners.scroll();
+    same(panel._tagColorPop, null, "the dot moved: closed");
+    assert.equal(popsInBody().length, 0);
+    assert.ok(!winListeners.resize.includes(added[0]), "...and the resize closer came down with it");
+    assert.equal(dotFor(panel, "g2")._attrs["aria-expanded"], "false");
+  } finally { g.__rectOf = null; }
+  // the card's own scroll (a short page scrolls the card as a whole) does the same
+  dotFor(panel, "g5")._listeners.click();
+  const card = cardOf(panel);
+  g.__rectOf = (n: any) => (n.dataset && n.dataset.tagDot === "g5" ? { left: 0, top: 80, right: 14, bottom: 94, width: 14, height: 14 } : null);
+  try { card._listeners.scroll(); same(panel._tagColorPop, null, "the card scrolled the dot away: closed"); } finally { g.__rectOf = null; }
+  // a resize re-centres the card: the popover closes through its own listener, which then comes down
+  dotFor(panel, "g7")._listeners.click();
+  const fn = winListeners.resize[winListeners.resize.length - 1];
+  assert.ok(fn && !added.includes(fn), "a fresh resize closer for the fresh popover");
+  fn();
+  same(panel._tagColorPop, null, "closed on resize");
+  assert.ok(!winListeners.resize.includes(fn), "the listener is gone");
+  assert.equal(winListeners.resize.length, resizeBefore, "no listener leaked across three opens");
+  panel._closeViewsDialog();
+});
+
+test("executed: a repaint keeps the popover on its row, re-placed under the rebuilt dot, and closes it when the row is gone or scrolled out of the table", () => {
+  const panel = openDialog();
+  const dot = dotFor(panel, "g2");
+  dot._listeners.click();
+  const pop = panel._tagColorPop;
+  assert.equal(pop.style.top, "24px");
+  // a refusal for ANOTHER row repaints the dialog; the rows have moved (a notice sits above the table now):
+  // the popover stays, hung on the rebuilt dot at its NEW place
+  g.__rectOf = (n: any) => {
+    if (n.dataset && n.dataset.tagDot === "g2") return { left: 100, top: 300, right: 114, bottom: 314, width: 14, height: 14 };
+    if (styleOf(n).startsWith(TGRID_PRE)) return { left: 0, top: 0, right: 800, bottom: 400, width: 800, height: 400 };   // the table's box holds the row
+    return null;
+  };
+  try {
+    panel._editTagUnion(viewTagUnion(panel._curViews()).find((u: any) => u.name === "alpha"), { color: "#1EA1EB" });
+    panel.viewsAck({ type: "tagEditAck", writeId: tagOps()[0].writeId, ok: false, error: "no", tid: "g1", seq: 1000, views: copy(THREE) });
+    same(panel._tagColorPop, pop, "the popover survived the repaint");
+    const dot2 = dotFor(panel, "g2");
+    assert.ok(dot2 !== dot, "the dialog was rebuilt");
+    same(panel._tagColorAnchor, dot2, "...and the popover hangs on the new dot");
+    assert.equal(dot2._attrs["aria-expanded"], "true", "which knows it is open");
+    assert.equal(pop.style.left, "100px"); assert.equal(pop.style.top, "318px");
+    assert.deepEqual(pop._anchorAt, { left: 100, top: 300 }, "placed by the new dot's rect, which is now the recorded place");
+  } finally { g.__rectOf = null; }
+  // a repaint whose rebuilt dot lies outside the table's visible box (its row scrolled out) closes it
+  g.__rectOf = (n: any) => {
+    if (n.dataset && n.dataset.tagDot === "g2") return { left: 0, top: 900, right: 14, bottom: 914, width: 14, height: 14 };
+    if (styleOf(n).startsWith(TGRID_PRE)) return { left: 0, top: 100, right: 800, bottom: 400, width: 800, height: 300 };
+    return null;
+  };
+  try {
+    panel._viewsDialogBuild();
+    same(panel._tagColorPop, null, "the dot is not in the table's visible box: nothing to hang on, closed");
+    assert.equal(popsInBody().length, 0);
+  } finally { g.__rectOf = null; }
+  // the tag deleted elsewhere: the frame that drops it, and the repaint that follows, close the popover with the row
+  dotFor(panel, "g2")._listeners.click();
+  assert.ok(panel._tagColorPop);
+  const gone = copy(THREE); gone.seq = 1002; gone.tags.splice(1, 1);
+  panel.update({ now, sessions: THREE_SESSIONS, views: gone });
+  assert.equal(panel._curViews().tags.length, 2, "the frame was adopted");
+  panel._viewsDialogBuild();
+  same(panel._tagColorPop, null, "no row, no popover");
+  panel._closeViewsDialog();
+});
+
+test("executed: a repaint that turns the popover's dot HELD (a remote half landed, no bridge to reach it) closes the popover rather than hang it on the last build's dot", () => {
+  // review find, 2026-09-09: the held branch drew a dot with no opener and never re-pointed the anchor, so the
+  // popover kept the detached dot of the last build, whose rect is all zeros; the re-place read those zeros
+  // against the table's box and, with the card scrolled so the box straddled y 0, put the popover at the
+  // viewport's corner. A pick from it could only be refused (the remote half is unreachable), so it closes
+  assert.equal(typeof g.__rompTimelineEditTag, "undefined", "no bridge on this window");
+  const panel = openDialog();
+  const dot = dotFor(panel, "g2");
+  dot._listeners.click();
+  assert.ok(panel._tagColorPop, "beta's popover is open");
+  const F = copy(THREE); F.seq = 1001; F.remoteTags = [copy(REMOTE_BETA)];   // beta gains a remote half
+  panel.update({ now, sessions: THREE_SESSIONS, views: F });
+  panel._viewsDialogBuild();
+  const held = dotFor(panel, "g2");
+  assert.ok(held && held !== dot, "the row was rebuilt");
+  assert.equal(held._attrs["aria-disabled"], "true", "...with a held dot");
+  same(panel._tagColorPop, null, "no live dot to hang on: the popover closed");
+  same(panel._tagColorAnchor, null, "...and nothing is kept of the last build's dot");
+  assert.equal(popsInBody().length, 0, "...and it left the document");
+  assert.equal(tagOps().length, 0, "nothing was written");
+  dotFor(panel, "g1")._listeners.click();
+  assert.deepEqual(popKeys(), ["g1"], "alpha's dot, local only, still opens");
+  panel._closeViewsDialog();
+});
+
+test("executed: in a framed shell the popover lives in the dialog's own document and is placed by the dot's rect there, untranslated; its resize closer is that window's", () => {
+  // review find, 2026-09-09: the dialog is adopted into the top same-origin document when it opens, so its
+  // dot already measures in that document's coordinates; _menuHost translating the rect a second time (the
+  // frame walk every menu opened from the pane needs) put the popover an iframe offset from its dot, below
+  // the viewport in a 200px band at the page's foot. Here the view runs in a frame offset 300x400 into the
+  // host page: the frame walk WOULD translate (window.frameElement is set, its parent the host window), and
+  // the popover must not be
+  const hostWin: any = { innerWidth: 1600, innerHeight: 1300, _listeners: {} as Record<string, any[]>,
+    addEventListener(t: string, fn: any) { (this._listeners[t] = this._listeners[t] || []).push(fn); },
+    removeEventListener(t: string, fn: any) { const a = this._listeners[t] || []; const i = a.indexOf(fn); if (i >= 0) a.splice(i, 1); } };
+  const hostDoc: any = { body: makeNode("body"), defaultView: hostWin, addEventListener() {}, removeEventListener() {}, activeElement: null };
+  hostDoc.body.ownerDocument = hostDoc;
+  hostWin.document = hostDoc;
+  const panel = drawnPanel(THREE, THREE_SESSIONS);
+  panel._tipWin = hostWin;   // the topmost same-origin window, as the tooltip host resolves it
+  g.frameElement = { getBoundingClientRect: () => ({ left: 300, top: 400, right: 1300, bottom: 1000, width: 1000, height: 600 }) };
+  g.parent = hostWin;
+  try {
+    panel._openViewsDialog(null);
+    same(panel._viewsDialog.parentNode, hostDoc.body, "the dialog hangs in the host document");
+    const dot = dotFor(panel, "g2");
+    same(dot.ownerDocument, hostDoc, "...and its dot was adopted there with it");
+    dot._listeners.click();
+    const pop = panel._tagColorPop;
+    assert.ok(pop, "the popover is open");
+    same(pop.parentNode, hostDoc.body, "it lives in the dialog's document, beside the dialog");
+    assert.equal(popsInBody().length, 0, "...not in the pane's");
+    assert.equal(pop.style.left, "6px", "placed by the dot's rect as measured, not the rect plus the frame's 300px offset");
+    assert.equal(pop.style.top, "24px", "...under the dot at its 20px bottom plus 4, not 400px lower");
+    assert.deepEqual(pop._anchorAt, { left: 0, top: 0 });
+    // the dot's window is the host's: the resize closer hangs there and comes down with the popover
+    const closers = hostWin._listeners.resize || [];
+    assert.equal(closers.length, 1, "one resize closer on the host window");
+    closers[0]();
+    same(panel._tagColorPop, null, "the host window's resize closed the popover");
+    assert.equal((hostWin._listeners.resize || []).length, 0, "...and took the closer down");
+    assert.equal(hostDoc.body.children.length, 1, "the dialog alone is left in the host body");
+    panel._closeViewsDialog();
+    assert.equal(hostDoc.body.children.length, 0, "closed, the dialog left the host document");
+  } finally { delete g.frameElement; delete g.parent; }
+});
+
+test("executed: the tag table's scroll survives a repaint, and is dropped when the table no longer scrolls", () => {
+  const panel = openDialog(THIRTY, FORTY_SESSIONS);
+  const tgrid = tgridOf(panel);
+  tgrid.scrollTop = 150;
+  assert.equal(tgrid.scrollTop, 150);
+  // a repaint from anywhere (a delete, a rename toggle, an ack, a peer's edit): the new table starts where the old one was
+  panel._viewsDialogBuild();
+  const tgrid2 = tgridOf(panel);
+  assert.ok(tgrid2 !== tgrid, "the table was rebuilt");
+  assert.equal(tgrid2.scrollTop, 150, "...at the same scroll");
+  // a colour pick repaints too: the offset holds through it
+  dotFor(panel, "g20")._listeners.click();
+  swatches(panel._tagColorPop)[0]._listeners.click();
+  assert.equal(tgridOf(panel).scrollTop, 150, "a pick keeps the user where they were working");
+  // the table no longer scrolls (a browser clamps the write): the offset is dropped
+  g.__scrollMax = 0;
+  try {
+    panel._viewsDialogBuild();
+    assert.equal(tgridOf(panel).scrollTop, 0, "nothing to scroll, nothing kept");
+  } finally { g.__scrollMax = undefined; }
+  panel._viewsDialogBuild();
+  assert.equal(tgridOf(panel).scrollTop, 0, "and it stays dropped: the offset is read off the live table, not remembered elsewhere");
+  panel._closeViewsDialog();
+});
+
+test("executed: a tag dragged past the table's edge drops on the last WHOLE row: a row cut by the clip, or without room for its cue, takes neither the cue nor the drop; a wheel mid-drag re-ranks", () => {
+  // the drop math ranks rows by their live rects, and only rows whose whole box plus the 2px cue lies inside
+  // the table's box are candidates (review 2026-09-09: the cue was drawn where the user could not see it and
+  // the drop wrote it; then, with real pointer events: the centre rule still let a row whose bottom edge
+  // was under the clip take the cue, which painted under the clip). Rows 24px tall at a 28px pitch (row i at
+  // 28i..28i+24, centre 28i+12, i the row's place in the table as drawn), scrolled by `scroll`; the table's
+  // box runs 0..`boxBottom`. THE CUE GROWS THE ROWS as the grid does (measured in both browsers): the
+  // cue is a 2px border on the cued cell's edge, and the pill cell is the tallest of its row, so a cue on
+  // EITHER edge grows that cell 2px at the BOTTOM and pushes every later row 2px down.
+  const panel = openDialog(THIRTY, FORTY_SESSIONS);
+  let scroll = 0, boxBottom = 200;
+  g.__rectOf = (n: any) => {
+    if (n._tname) {
+      const sibs = n.parentNode.children.filter((c: any) => c._tname);
+      const i = sibs.indexOf(n), cuedAt = sibs.findIndex((c: any) => c.style.borderTop || c.style.borderBottom);
+      const top = i * 28 - scroll + (cuedAt >= 0 && i > cuedAt ? 2 : 0), bottom = i * 28 + 24 - scroll + (cuedAt >= 0 && i >= cuedAt ? 2 : 0);
+      return { left: 0, top, right: 200, bottom, width: 200, height: bottom - top };
+    }
+    if (styleOf(n).startsWith(TGRID_PRE)) return { left: 0, top: 0, right: 800, bottom: boxBottom, width: 800, height: boxBottom };
+    return null;
+  };
+  const cells = () => walk(panel._viewsDialog).filter((n) => n._tname);
+  const order = () => cells().map((c) => c._tname);
+  const cued = () => cells().map((c, i) => (c.style.borderTop || c.style.borderBottom ? i + (c.style.borderTop ? "top" : "bottom") : "")).filter(Boolean);
+  const writes = () => posted.filter((p) => p.kind === "views");
+  const lastWrite = () => writes()[writes().length - 1].v.tagOrder;
+  // grab `name`, move through `ys`, run `mid` with the grab still held (the table and its scroll listener of
+  // the moment in hand), drop; returns the cue after each move. Every drag hangs its own scroll listener on
+  // the table and takes it down with the drop, leaving the popover's closer in place
+  const drag = (name: string, ys: number[], mid?: (t: any) => void): string[][] => {
+    const t = tgridOf(panel), closer = t._listeners.scroll;
+    const from = cells().find((c) => c._tname === name);
+    from._listeners.pointerdown({ preventDefault() {}, pointerId: 1, clientY: 0 });
+    assert.ok(t._listeners.scroll !== closer, "the drag listens to the table's scroll while it lasts");
+    const trace: string[][] = [];
+    for (const y of ys) { from._listeners.pointermove({ clientY: y }); trace.push(cued()); }
+    if (mid) mid(t);
+    from._listeners.pointerup();
+    same(t._listeners.scroll, closer, "the drag's scroll listener came down with the drop; the popover's closer stays");
+    assert.deepEqual(cued(), [], "no cue left behind");
+    return trace;
+  };
+  try {
+    assert.equal(cells().length, 30);
+    // box 0..200 holds rows 0..6 whole (row 6 at 168..192, its cue to 194): a pointer far below lands after row 6
+    drag("t01", [500], () => assert.deepEqual(cued(), ["6bottom"], "the cue sits on the last whole row"));
+    assert.equal(writes().length, 1, "one order write");
+    assert.equal(lastWrite().indexOf("t01"), 6, "t01 landed after the last whole row, not at the table's end");
+    assert.deepEqual(lastWrite().slice(0, 8), ["t02", "t03", "t04", "t05", "t06", "t07", "t01", "t08"]);
+    assert.deepEqual(order().slice(0, 8), ["t02", "t03", "t04", "t05", "t06", "t07", "t01", "t08"], "the table repainted in the new order");
+    // box 0..190: row 6 (168..192) straddles the bottom edge with its centre (180) inside. The old centre rule
+    // gave it the cue, a border on its bottom edge, 2px under the clip. Held and dragged down past the edge, it
+    // stays where it is (no write: the rows below are out of sight, and the whole row above is not what the
+    // gesture said); dragged onto by another row, it takes neither the cue nor the drop, row 5 does
+    boxBottom = 190;
+    drag("t01", [500], () => assert.deepEqual(cued(), [], "the held row, cut by the edge, is its own place: no cue"));
+    assert.equal(writes().length, 1, "…and no write");
+    drag("t02", [500], () => assert.deepEqual(cued(), ["5bottom"], "the straddling row is no candidate: the cue sits on the last whole row"));
+    assert.equal(writes().length, 2);
+    assert.equal(lastWrite().indexOf("t02"), 5, "the drop lands where the cue was drawn");
+    assert.deepEqual(order().slice(0, 8), ["t03", "t04", "t05", "t06", "t07", "t02", "t01", "t08"]);
+    // box 0..193: row 6 is inside the box but the 2px its cue adds under its edge is not: row 5 again
+    boxBottom = 193;
+    drag("t03", [500], () => assert.deepEqual(cued(), ["5bottom"], "a row without room for its cue is no candidate"));
+    assert.equal(writes().length, 3);
+    assert.equal(lastWrite().indexOf("t03"), 5);
+    assert.deepEqual(order().slice(0, 8), ["t04", "t05", "t06", "t07", "t02", "t03", "t01", "t08"]);
+    // the top edge: the table scrolled 10px (row 0 at -10..14, cut by the clip): a pointer above the table
+    // lands on row 1's top edge, whole, not on row 0's, under the clip
+    boxBottom = 200; scroll = 10;
+    drag("t07", [-80], () => assert.deepEqual(cued(), ["1top"], "the cue sits on the first whole row"));
+    assert.equal(writes().length, 4);
+    assert.equal(lastWrite().indexOf("t07"), 1, "…and the drop lands there");
+    assert.deepEqual(order().slice(0, 8), ["t04", "t07", "t05", "t06", "t02", "t03", "t01", "t08"]);
+    // a wheel mid-drag: a scroll fires no pointermove, so the table's scroll re-ranks with the last pointer y.
+    // The pointer at y 100 ranks row 4 (centre 124, the first past 100); the table scrolls 200 and row 11
+    // (centre 120 now) is the row under the pointer; the cue and the drop follow it
+    scroll = 0;
+    drag("t04", [100], (t) => {
+      assert.deepEqual(cued(), ["4bottom"], "before the wheel: the row under the pointer");
+      scroll = 200; t._listeners.scroll();
+      assert.deepEqual(cued(), ["11bottom"], "after the wheel: the row now under the pointer");
+    });
+    assert.equal(writes().length, 5);
+    assert.equal(lastWrite().indexOf("t04"), 11, "the drop follows the rows the wheel brought under the pointer");
+    assert.equal(order()[11], "t04");
+    // a scroll whose event has not landed by the drop (they arrive a frame late): the table's scrollTop says the
+    // rows moved, so the drop re-ranks on the live rects
+    scroll = 0;
+    drag("t07", [100], (t) => {
+      assert.deepEqual(cued(), ["4bottom"]);
+      scroll = 200; t.scrollTop = 200;   // the rows moved, no scroll event yet
+    });
+    assert.equal(writes().length, 6);
+    assert.equal(lastWrite().indexOf("t07"), 11, "the drop read the live rows");
+    // a grab and a release with no move and no scroll writes nothing (a click on the pill)
+    drag("t05", []);
+    assert.equal(writes().length, 6, "no move, no scroll: no write");
+    // THE CUE COMES OFF FOR THE MEASUREMENT (real pointer events in both browsers). Box 0..194: row 6
+    // (168..192, its cue to 194) is the last whole row, with exactly 2px of room. A stepped drag far below puts
+    // the cue on row 4 first (the row under the pointer at 100), which pushes row 6 to 170..194; measured with
+    // that cue drawn, row 6 had no room for its own and the cue and the drop landed one row short
+    scroll = 0; boxBottom = 194;
+    const a = order()[0];
+    assert.deepEqual(drag(a, [100, 500], () => assert.deepEqual(cued(), ["6bottom"], "the cue reaches the last whole row despite the cue it wore on the way")),
+      [["4bottom"], ["6bottom"]], "the cue moves from the row under the pointer to the last whole row");
+    assert.equal(writes().length, 7);
+    assert.equal(lastWrite().indexOf(a), 6, "the drop lands on the last whole row");
+    // a top cue: the held row scrolled under the bottom clip (row 12, none of it shows), the pointer in the upper
+    // half of row 6 three times. A top cue grows its cell at the BOTTOM too; judged as if the border grew it
+    // upward, row 6 lost its room on the second move and the cue settled one row above the pointer
+    const b = order()[12];
+    assert.deepEqual(drag(b, [172, 172, 172], () => assert.deepEqual(cued(), ["6top"])), [["6top"], ["6top"], ["6top"]],
+      "a top cue on the last whole row holds across further moves at the same place");
+    assert.equal(writes().length, 8);
+    assert.equal(lastWrite().indexOf(b), 6, "the drop lands on the pointed row, not the one above");
+    // THE HELD ROW'S OWN CANDIDACY: while any of it shows it counts, so cut in half by the top clip and dragged
+    // above the table it stays where it is (no cue, no write); scrolled entirely out of the box it does not
+    // count, and the visible rows decide: the first whole row above, the last whole row below
+    scroll = 12;   // row 0 at -12..12, half under the top clip
+    const c = order()[0];
+    assert.deepEqual(drag(c, [-80]), [[]], "half shown, the held row is its own place: no cue");
+    assert.equal(writes().length, 8, "...and no write");
+    scroll = 30;   // row 0 at -30..-6 (none shows), row 1 at -2..22 (cut), row 2 at 26..50 the first whole row
+    const d = order()[0];
+    assert.deepEqual(drag(d, [-80]), [["2bottom"]], "none of the held row shows: the first whole row takes the cue");
+    assert.equal(writes().length, 9);
+    assert.equal(lastWrite().indexOf(d), 2, "...and the drop");
+    scroll = 0;    // row 12 at 336..360, under the bottom clip; the pointer far below
+    const e = order()[12];
+    assert.deepEqual(drag(e, [500]), [["6top"]], "none of the held row shows: the last whole row takes the cue");
+    assert.equal(writes().length, 10);
+    assert.equal(lastWrite().indexOf(e), 6);
+  } finally { g.__rectOf = null; }
+  panel._closeViewsDialog();
+});
+
+test("executed: the floors' sources: four of the SMALLEST session rows when the first wraps, both floors kept through a build without layout, the first build in the host document", () => {
+  // review find, 2026-09-09. Session rows placed by their index (rowIdx: a cell's row is the count of name
+  // cells up to it in the grid); row 0 is 46.8px (its chips wrapped onto a second line), the rest 22.2px, 3px
+  // gaps. Tag rows by their index too, 24px at a 28px pitch
+  const sessRect = (i: number) => { const top = i === 0 ? 300 : 300 + 46.8 + 3 + (i - 1) * 25.2, h = i === 0 ? 46.8 : 22.2; return { left: 0, top, right: 200, bottom: top + h, width: 200, height: h }; };
+  g.__rectOf = (n: any) => {
+    const par = n.parentNode ? styleOf(n.parentNode) : "";
+    if (par.startsWith(TGRID_PRE)) return tagRect(rowIdx(n, "_tname"));
+    if (par.startsWith(GRID_PRE)) return sessRect(rowIdx(n, "_sid"));
+    return null;
+  };
+  try {
+    // (a) the sessions floor is four of the SMALLEST rows and their gaps (4 x 22.2 + 9), not four of the first:
+    // a wrapped first row can cost a whole row in the box, never leave blank under the rows
+    const p = openDialog(THIRTY, FORTY_SESSIONS);
+    assert.equal(styleOf(gridBoxOf(p)), "flex:1 1000 auto;min-height:97.8px;overflow-y:auto;", "four of the smallest rows, not four of the wrapped first");
+    // a query that leaves the wrapped row alone on screen does not move the floor (the rows are measured on
+    // unfiltered builds and the height kept), nor does a repaint under it or clearing it
+    const q = walk(p._viewsDialog).find((n) => n.tag === "input" && n.placeholder === "search name or host…");
+    q.value = "job-01"; q._listeners.input();
+    assert.equal(walk(p._viewsDialog).filter((n) => n._sid).length, 1, "one hit, the wrapped row");
+    assert.equal(styleOf(gridBoxOf(p)), "flex:1 1000 auto;min-height:97.8px;overflow-y:auto;", "the wrapped row alone on screen: the floor stays");
+    p._viewsDialogBuild();
+    assert.equal(styleOf(gridBoxOf(p)), "flex:1 1000 auto;min-height:97.8px;overflow-y:auto;", "...through a repaint under the query");
+    const q2 = walk(p._viewsDialog).find((n) => n.tag === "input" && n.placeholder === "search name or host…");   // the repaint's own input
+    q2.value = ""; q2._listeners.input();
+    assert.equal(walk(p._viewsDialog).filter((n) => n._sid).length, 40);
+    assert.equal(styleOf(gridBoxOf(p)), "flex:1 1000 auto;min-height:97.8px;overflow-y:auto;", "...and once cleared");
+    // (b) a build that reads no layout (the dialog's document not rendered: every rect 0) keeps BOTH floors the
+    // last build measured; the tag table's dropped to none before (min-height:0px, one row showing on a short page)
+    assert.ok(styleOf(tgridOf(p)).includes("min-height:80px;"), "the table's floor before: " + styleOf(tgridOf(p)));
+    g.__rectOf = (n: any) => {
+      const par = n.parentNode ? styleOf(n.parentNode) : "";
+      return par.startsWith(TGRID_PRE) || par.startsWith(GRID_PRE) ? { left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 } : null;
+    };
+    p._viewsDialogBuild();
+    assert.ok(styleOf(tgridOf(p)).includes("flex:0 1 auto;min-height:80px;"), "no layout to read: the table keeps its floor: " + styleOf(tgridOf(p)));
+    assert.equal(styleOf(gridBoxOf(p)), "flex:1 1000 auto;min-height:97.8px;overflow-y:auto;", "...and so does the sessions box");
+    p._closeViewsDialog();
+    // (c) the first build runs with the card already in its FINAL document (the host the dialog is adopted
+    // into), so its floors are measured where the card is laid out: rows measure 24px only under the host
+    // document's body here, 0 anywhere else, and the floor is set on the open, not on the first repaint
+    const hostDoc: any = { body: makeNode("body"), addEventListener() {}, removeEventListener() {}, activeElement: null };
+    const rootOf = (n: any) => { let r = n; while (r.parentNode) r = r.parentNode; return r; };
+    g.__rectOf = (n: any) => {
+      const par = n.parentNode ? styleOf(n.parentNode) : "";
+      if (!par.startsWith(TGRID_PRE)) return null;
+      return rootOf(n) === hostDoc.body ? tagRect(rowIdx(n, "_tname")) : { left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 };
+    };
+    const ph = drawnPanel(THIRTY, FORTY_SESSIONS);
+    ph._tipWin = { document: hostDoc };   // the topmost same-origin window, as the tooltip host resolves it
+    ph._openViewsDialog(null);
+    same(ph._viewsDialog.parentNode, hostDoc.body, "the dialog hangs in the host document");
+    assert.ok(styleOf(tgridOf(ph)).includes("flex:0 1 auto;min-height:80px;"), "the first build measured its rows in the host document: " + styleOf(tgridOf(ph)));
+    ph._closeViewsDialog();
+    assert.equal(hostDoc.body.children.length, 0, "closed, the dialog left the host document");
+  } finally { g.__rectOf = null; }
+});
+
+test("executed: pane filters render FOLDED, one summary line per pane in the user's tag order; the caret opens the matrix in its own bounded cell; the choice holds for the page", () => {
+  stored["romp:feedTags-set"] = JSON.stringify({ lens: { tags: ["beta"], none: true }, t: 1 });
+  const panel = openDialog();
+  const cap = caption(panel);
+  assert.ok(cap, "the section caption");
+  assert.ok(cap.textContent.endsWith(" ▸"), "folded: a right-pointing caret");
+  assert.equal(cap._attrs["aria-expanded"], "false");
+  assert.equal(cap._attrs.role, "button"); assert.equal(cap._attrs.tabindex, "0");
+  let lines = paneLines(panel);
+  assert.deepEqual(Object.keys(lines), ["Chat", "Sessions", "Outline", "Feed"], "one line per PANE; the bulk row is a control, not a pane");
+  const summary = (k: string) => lines[k].children[1].textContent;
+  assert.equal(summary("Chat"), "alpha, gamma", "the tags it shows, in the user's tag order (the lens lists gamma first)");
+  assert.equal(summary("Sessions"), "All");
+  assert.equal(summary("Outline"), "no tags");
+  assert.equal(summary("Feed"), "beta, no tags", "the feed row reads its echo");
+  assert.equal(lines.Chat.children[1]._attrs.title, "alpha, gamma", "the hover carries the full list");
+  assert.equal(chips(panel).length, 0, "no chip while folded");
+  const card = cardOf(panel);
+  assert.ok(Object.values(lines).every((row: any) => row.parentNode === card), "folded, the lines are the card's own fixed rows");
+  // the caret opens the matrix: five rows of All / no tags / every tag, in a cell of their own that keeps a
+  // bounded share and scrolls within it (review find, 2026-09-09: with thirty tags the open matrix pushed
+  // the sessions off the card at 800px)
+  cap._listeners.click();
+  const cap2 = caption(panel);
+  assert.ok(cap2.textContent.endsWith(" ▾"), "open: a down-pointing caret");
+  assert.equal(cap2._attrs["aria-expanded"], "true");
+  lines = paneLines(panel);
+  assert.deepEqual(Object.keys(lines), ["All surfaces", "Chat", "Sessions", "Outline", "Feed"]);
+  const mbox = lines["All surfaces"].parentNode;
+  assert.ok(Object.values(lines).every((row: any) => row.parentNode === mbox), "the five rows share one cell");
+  assert.equal(mbox.children.length, 5);
+  same(mbox.parentNode, cardOf(panel), "the cell is the card's flex child");
+  assert.equal(styleOf(mbox), "flex:0 1 auto;min-height:52px;max-height:25vh;overflow-y:auto;overflow-x:hidden;", "bounded, scrolling within, giving way past the sessions' floor, keeping two lines");
+  assert.equal(chips(panel).length, 5 * (2 + 3), "All, no tags and three tags on each of five rows");
+  assert.ok(walk(panel._viewsDialog).some((n) => n.textContent === "(mixed)"), "the panes differ, so the bulk row says so");
+  const cell = lines.Chat.children[1];
+  assert.ok(styleOf(cell).includes("flex-wrap:wrap;flex:1 1 auto;min-width:0;"), "the chips wrap inside their own cell, under the first chip");
+  assert.equal(cell.children.length, 5);
+  // a chip still edits its pane (the matrix is the same control it was)
+  const noTags = cell.children.find((n: any) => n.textContent === "no tags");
+  noTags._listeners.click();
+  const w = posted.filter((p) => p.kind === "views");
+  assert.equal(w.length, 1, "one whole-blob lens write");
+  assert.deepEqual(w[0].v.actives.chat, { none: true, tags: ["gamma", "alpha"] }, "toggled onto the chat lens");
+  // the choice holds for the page: a fresh open finds the matrix open
+  panel._closeViewsDialog();
+  panel._openViewsDialog(null);
+  assert.ok(caption(panel).textContent.endsWith(" ▾"), "still open on the next open");
+  assert.equal(chips(panel).length, 25);
+  // Enter on the caption folds it back (and leaves the module default for the tests that follow)
+  caption(panel)._listeners.keydown({ key: "Enter", preventDefault() {} });
+  assert.ok(caption(panel).textContent.endsWith(" ▸"));
+  assert.equal(chips(panel).length, 0);
+  panel._closeViewsDialog();
+  delete stored["romp:feedTags-set"];
+});
+
+test("executed: the folded summary names only tags that exist; a lens left with none says so, and the hover names what it still carries", () => {
+  // the kernel keeps unknown names in a lens by design, and a rename or a delete rewrites no lens: the
+  // folded line used to list the old name as a live filter while the open matrix had no chip for it
+  const V = copy(THREE);
+  V.actives = { chat: { tags: ["zeta", "alpha"] }, timeline: { tags: ["zeta"] }, outline: { tags: ["zeta"], none: true } };
+  const panel = openDialog(V);
+  const lines = paneLines(panel);
+  const line = (k: string) => lines[k].children[1];
+  assert.equal(line("Chat").textContent, "alpha", "the gone name is left out");
+  assert.equal(line("Chat")._attrs.title, "alpha; the filter also names zeta, and no tag here has that name now", "the hover says what the filter still carries");
+  assert.equal(line("Sessions").textContent, "none of the tags here", "a lens naming only gone tags says so (the pane shows nothing)");
+  assert.equal(line("Sessions")._attrs.title, "none of the tags here; the filter also names zeta, and no tag here has that name now");
+  assert.equal(line("Outline").textContent, "no tags", "'no tags' still counts");
+  assert.equal(line("Feed").textContent, "All", "an untouched pane");
+  assert.equal(line("Feed")._attrs.title, "All", "...with nothing to add");
+  // open, the matrix shows the same: no chip for zeta, alpha selected on Chat, nothing selected on Sessions
+  caption(panel)._listeners.click();
+  const open = paneLines(panel);
+  const sel = (k: string) => open[k].children[1].children.filter((c: any) => styleOf(c).includes("font-weight:650;")).map((c: any) => c.textContent);
+  assert.deepEqual(sel("Chat"), ["alpha"]);
+  assert.deepEqual(sel("Sessions"), [], "nothing selected: the same emptiness the folded line reports");
+  assert.ok(!walk(panel._viewsDialog).some((n) => n.textContent === "zeta"), "no chip anywhere for the gone name");
+  caption(panel)._listeners.click();
+  panel._closeViewsDialog();
+});
+
+test("executed: thirty tags and forty sessions: every row, every chip and the sessions section render; the summary cuts with a count", () => {
+  const panel = openDialog(THIRTY, FORTY_SESSIONS);
+  const dlg = panel._viewsDialog;
+  assert.deepEqual(walk(dlg).filter((n) => n._tname).map((n) => n._tname), NAMES30, "thirty one-line tag rows, in order");
+  assert.equal(dots(panel).length, 30, "one dot each");
+  assert.equal(walk(dlg).filter((n) => n._attrs.role === "radio").length, 0, "and not a swatch among them (360 before)");
+  const nt = walk(dlg).find((n) => n.textContent === "+ New tag");
+  assert.ok(nt, "the New tag row");
+  assert.ok(!walk(tgridOf(panel)).includes(nt), "...under the table, not inside its scroll");
+  assert.ok(/flex:0 1 auto;min-height:\d+px;/.test(styleOf(tgridOf(panel))), "the table's floor stays three rows however many there are (the floors test has the arithmetic): " + styleOf(tgridOf(panel)));
+  // folded filters: four lines, the long one cut
+  const lines = paneLines(panel);
+  assert.equal(lines.Chat.children[1].textContent, "t01, t02, t03, t04, t05, t06 +24 more");
+  assert.equal(lines.Chat.children[1]._attrs.title, NAMES30.join(", "), "the hover has all thirty");
+  assert.equal(lines.Sessions.children[1].textContent, "All");
+  // open: five rows of thirty-two chips
+  caption(panel)._listeners.click();
+  assert.equal(chips(panel).length, 5 * 32, "All, no tags and thirty tags on each of five rows");
+  caption(panel)._listeners.click();
+  assert.equal(chips(panel).length, 0);
+  // the sessions section: search, tag all, and every live session
+  assert.ok(walk(dlg).some((n) => n.tag === "input" && n.placeholder === "search name or host…"), "the search box");
+  assert.ok(walk(dlg).some((n) => n.textContent === "tag all"), "tag all");
+  assert.equal(walk(dlg).filter((n) => n._sid).length, 40, "forty session rows");
+  // the popover works on the last row too
+  dotFor(panel, "g30")._listeners.click();
+  assert.equal(swatches(panel._tagColorPop).length, 12);
+  swatches(panel._tagColorPop)[0]._listeners.click();
+  assert.deepEqual([tagOps()[0].op, tagOps()[0].tid, tagOps()[0].color], ["recolor", "g30", PALETTE[0]]);
+  panel._closeViewsDialog();
+});

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -298,16 +298,25 @@ test("the dialog sizes to the screen: 90% ceiling both axes, padded edges, wrap 
   // the card declarations come AFTER MENU_STYLE: the menu spec opens with ITS padding (4px), and
   // in one style string the later declaration wins — stated first, the dialog's padding had been
   // silently 4px all along (found by headless computed-style measurement, 2026-08-25)
-  assert.match(SRC, /MENU_STYLE \+ 'box-sizing:border-box;width:min\(1200px,90vw\);max-height:90vh;'\s*\n\s*\+ 'overflow:hidden;display:flex;flex-direction:column;padding:22px 26px;font-size:13px;'/,
+  // re-aimed 2026-09-09 (the many-tags change's review): the card scrolls as a whole, never clips,
+  // when a page is shorter than its sections' floors (a phone held sideways clipped the search box)
+  assert.match(SRC, /MENU_STYLE \+ 'box-sizing:border-box;width:min\(1200px,90vw\);max-height:90vh;'\s*\n\s*\+ 'overflow-y:auto;overflow-x:hidden;display:flex;flex-direction:column;padding:22px 26px;font-size:13px;'/,
     "the card's screen-sized border-box footprint + edge padding, declared after the menu spec");
   // wrap stays GRACEFUL, not needless: the wide card lays the rows out on their lines; these
-  // containers wrap only when the window genuinely narrows
-  assert.match(SRC, /row\.setAttribute\('style', 'display:flex;align-items:center;gap:6px;margin:2px 0;flex-wrap:wrap;'\);/,
-    "the five filter rows fold only under real pressure");
+  // containers wrap only when the window genuinely narrows. Re-aimed 2026-09-09 (the many-tags
+  // change): the filter chips wrap inside their own cell, so a long row's second line starts under
+  // the first chip rather than under the pane label; the row itself no longer wraps
+  assert.match(SRC, /cell\.setAttribute\('style', 'display:flex;align-items:center;gap:6px;flex-wrap:wrap;flex:1 1 auto;min-width:0;'\);/,
+    "the five filter rows' chips wrap within their own cell");
   assert.match(SRC, /chips\.setAttribute\('style', 'display:flex;gap:5px;flex-wrap:wrap;align-items:center;min-width:0;'\);/,
     "membership chip cells ditto");
-  assert.match(SRC, /gridBox\.setAttribute\('style', 'flex:1 1 auto;min-height:0;overflow-y:auto;'\);/,
-    "only the session rows pan when height runs out — the card itself never scrolls whole");
+  // re-aimed 2026-09-09 (the many-tags change's review): the sessions box gives way first when height
+  // runs out (the thousandfold flex-shrink) and never below its floor, min(live, 4) rows at the rendered
+  // row height (a fixed 96px left blank over one live session); past that floor the tag table and the
+  // open matrix give way, and past THEIR floors the card scrolls rather than clip (timeline-tags-scale)
+  assert.match(SRC, /const gridStyle = \(floor\) => 'flex:1 1000 auto;min-height:' \+ floor \+ 'px;overflow-y:auto;';/,
+    "the session rows pan within their box, which keeps a floor under its rows");
+  assert.match(SRC, /const k = Math\.min\(liveN, 4\);/, "…four rows at most, by the live count");
 });
 
 test("federation, NAME-KEYED (user ruling 2026-08-24): one name = one row/label/union — kernels are plumbing", () => {
@@ -425,7 +434,9 @@ test("executed: tagEditFailed reverts the optimistic copy and keeps the reason f
 test("federation v1+ruling source pins: header/chips route through the UNION dispatcher, loudly on failure", () => {
   // rename/recolor/delete fan out to EVERY home; chip ✕ removes everywhere; add prefers local
   assert.match(SRC, /this\._editTagUnion\(tg, \{ rename: nv2 \}\);/);
-  assert.match(SRC, /this\._editTagUnion\(tg, \{ color: c \}\); build\(\);/);
+  // the recolor rides the colour popover since 2026-09-09 (the many-tags change), which re-resolves the
+  // tag at pick time (`now`) and repaints through the dialog's build closure; the dispatcher is the same
+  assert.match(SRC, /this\._editTagUnion\(now, \{ color: c \}\);\n\s*if \(this\._viewsDialogBuild\) this\._viewsDialogBuild\(\);/);
   assert.match(SRC, /this\._editTagUnion\(tg, \{ delete: true \}\);/);
   assert.match(SRC, /this\._editTagUnion\(g, \{ remove: \[s\.id\] \}\); rebuild\(\);/);
   assert.match(SRC, /this\._editTagUnion\(g, \{ add: rowIds\.filter\(\(id\) => g\.members\.indexOf\(id\) < 0\) \}\); rebuild\(\);/);
@@ -613,8 +624,9 @@ test("a gesture the host cannot honour is DISABLED with the reason as its toolti
     "the disabled action: dim, no pointer, the reason as tooltip, no listeners");
   assert.match(SRC, /action\(del, 'delete', [^\n]*, held\);\n\s*if \(!held\) \{/, "delete's hover and click ride only when not held");
   assert.match(SRC, /action\(ren, 'rename', 'rename this tag \(everywhere it is defined\)', held\);\n\s*if \(!held\) \{/, "rename's too");
-  assert.match(SRC, /if \(held\) \{ colCell\.setAttribute\('title', held\); colCell\.setAttribute\('aria-disabled', 'true'\); \}/, "the swatch cell says why");
-  assert.match(SRC, /if \(!held\) sw\.addEventListener\('click', \(\) => \{ this\._editTagUnion\(tg, \{ color: c \}\); build\(\); \}\);/, "…and its swatches take no click");
+  // re-aimed 2026-09-09 (the many-tags change): the inline swatches became one colour dot that opens a
+  // popover; a held dot wears the reason and takes no click (its listeners ride the else branch)
+  assert.match(SRC, /if \(held\) \{ dot\.setAttribute\('title', held\); dot\.setAttribute\('aria-disabled', 'true'\); \}\n\s*else \{/, "the colour dot says why, and opens nothing");
   // the chip: a ✕ that would remove the pair from a remote half no bridge can reach is not drawn; the tooltip says why
   assert.match(SRC, /const homesHolding = \(g\.remotes \|\| \[\]\)\.filter\(\(rt\) => \(rt\.members \|\| \[\]\)\.indexOf\(s\.id\) >= 0\)\.map\(\(rt\) => rt\.host\);\n\s*if \(homesHolding\.length && !this\._remoteBridge\(\)\) \{/);
   assert.match(SRC, /ch\.setAttribute\('title', 'tagged "' \+ g\.name \+ '": ' \+ this\._unreachableText\(homesHolding, localHolds\)\);\n\s*ch\.setAttribute\('aria-disabled', 'true'\);\n\s*continue;/);
@@ -761,7 +773,7 @@ test("the corner grew two icon buttons and the menus split (the user 2026-08-25)
   assert.match(SRC, /item\('Configure tags…', \{ dim: true \}\)/, "one management entry");
   assert.ok(!/item\('New tag…', \{ dim: true \}\)/.test(SRC), "New tag left the menu…");
   assert.match(SRC, /text: '\+ New tag'/,
-    "…and lives in the tag TABLE's final row (the 18:17 revision — the bulk-bar copy died)");
+    "…and lives in the row under the tag table, outside its scroll (the 18:17 revision put it in the table's final row; the bulk-bar copy died)");
   assert.match(SRC, /apply\(lensToggle\(lens, \{ tag: g\.name \}\), false\)/,
     "tag rows TOGGLE and the menu stays open (repaint in place)");
   assert.match(SRC, /apply\(\{ all: true \}, true\)/, "All is a plain pick and closes");
@@ -779,8 +791,9 @@ test("dialog polish + reachable tag management (the user 2026-08-25)", () => {
   // the dialog reads at the page's 13px form scale (the menu 12px was the too-small complaint)
   assert.match(SRC, /padding:22px 26px;font-size:13px;'/,
     "the 13px form scale rides the card's own declarations (after MENU_STYLE, whose 4px padding they beat)");
-  // the session table scrolls WITHIN the modal — chrome stays put
-  assert.match(SRC, /gridBox\.setAttribute\('style', 'flex:1 1 auto;min-height:0;overflow-y:auto;'\)/);
+  // the session table scrolls WITHIN the modal; chrome stays put (its floor since 2026-09-09: up to four rows, measured)
+  assert.match(SRC, /gridBox\.setAttribute\('style', gridStyle\(0\)\);/);
+  assert.match(SRC, /gridBox\.setAttribute\('style', gridStyle\(k && sessRowH \? Math\.round\(\(k \* sessRowH \+ \(k - 1\) \* 3\) \* 100\) \/ 100 : 0\)\);/);
   // [+] is a rounded RECTANGLE in its own column between name and tags
   assert.match(SRC, /padding:1px 7px;'\n\s*\+ 'border-radius:5px;/, "the standard button anatomy, not a circle");
   assert.ok(!/width:17px;height:17px;'\n?\s*\+ 'border-radius:50%/.test(SRC), "the circle plus is gone");
@@ -790,21 +803,23 @@ test("dialog polish + reachable tag management (the user 2026-08-25)", () => {
   // tag management reachable from EVERY open: rows with rename/recolor/delete via the union dispatcher
   assert.match(SRC, /text: 'the tags'/);
   assert.match(SRC, /this\._editTagUnion\(tg, \{ delete: true \}\);\n\s*build\(\);/, "delete without a tag-scoped open");
-  assert.match(SRC, /this\._editTagUnion\(tg, \{ color: c \}\); build\(\);/, "the identity-palette recolor");
+  assert.match(SRC, /this\._editTagUnion\(now, \{ color: c \}\);/, "the identity-palette recolor (from the colour popover since 2026-09-09)");
 });
 
 test("the dialog redesign: tag TABLE with delete/rename/color actions, five filter rows (the user 2026-08-25, revised same day)", () => {
   // TAGS: a TABLE (the user's revision of the chip cloud) — each row the tag pill at normal size
-  // with NO ✕ on it, then delete | rename | color swatches as their own columns; delete wears the
-  // destructive convention (dim at rest, red on hover); [+ New tag] is the table's FINAL row
+  // with NO ✕ on it, then delete | rename | the colour dot as their own columns (the dot opens the
+  // palette as a popover since 2026-09-09, timeline-tags-scale.test.ts); delete wears the
+  // destructive convention (dim at rest, red on hover); [+ New tag] is the row UNDER the table (its own
+  // flex child since 2026-09-09, so the table's fold never hides it)
   assert.match(SRC, /grid-template-columns:max-content max-content max-content 1fr;/, "the tag table's four columns");
   assert.match(SRC, /the tag itself: the normal pill, NO ✕ — actions live beside it, never on it/);
   assert.match(SRC, /this\._tagEditorFor = this\._tagEditorFor === unionKey\(tg\) \? null : unionKey\(tg\);/,
     "rename toggles the pill into an input — keyed by the union's stable id, which survives the rename it makes");
   assert.match(SRC, /d\.style\.color = '#F85B5A'/, "delete goes red on hover — destructive, unlike membership ✕");
   assert.match(SRC, /DELETE the tag/, "the hover says what delete does");
-  assert.match(SRC, /text: '\+ New tag'/, "creation is the table's final row");
-  assert.match(SRC, /grid-column:1 \/ -1;/, "…spanning the table's full width");
+  assert.match(SRC, /text: '\+ New tag'/, "creation is the row under the table");
+  assert.match(SRC, /const ntRow = card\.createDiv\(\);/, "…its own flex child, outside the table's scroll");
   // FILTERS: five rows — All surfaces / Chat / Sessions / Outline / Feed (the pane names), each
   // the full lens vocabulary as pills editing ONLY its surface; All-surfaces fans to all four
   assert.match(SRC, /\[\['All surfaces', '\*'\], \['Chat', 'chat'\], \['Sessions', 'timeline'\], \['Outline', 'outline'\], \['Feed', 'feed'\]\]/);

--- a/ui/webview/menu-echo.test.ts
+++ b/ui/webview/menu-echo.test.ts
@@ -82,10 +82,18 @@ test("every pane document the dashboard composes carries the writer at load", ()
 test("every timeline menu marks itself for the writers' in-menu skip (T213)", () => {
   // an unmarked menu dies to its own echo the moment _menuHost lifts it into the shell document:
   // the count pin makes a NEW menu that forgets the mark fail here, not in the field
-  const creations = (TIMELINE.match(/\+ MENU_STYLE\);/g) || []).length;
+  // a menu is counted by its style string's `+ MENU_STYLE` whether the spec ENDS the string or a
+  // declaration of the menu's own follows it: the tag colour popover (2026-09-09) appends its 8px
+  // padding after the spec, because MENU_STYLE opens with the menu padding (4px) and in one style
+  // string the later declaration wins (the dialog card's comment tells the same story)
+  const creations = (TIMELINE.match(/\+ MENU_STYLE(?:\)|\s*\+\s*')/g) || []).length;
   const marks = (TIMELINE.match(/\.dataset\.rompMenu = '1'/g) || []).length;
-  assert.ok(creations >= 5, "the timeline's menus render through MENU_STYLE");
+  assert.ok(creations >= 6, "the timeline's menus render through MENU_STYLE (five menus and the colour popover)");
   assert.equal(marks, creations, "every MENU_STYLE menu carries data-romp-menu");
+  // the popover by name: it lives in the host document like the menus (_menuHost), so the shell's
+  // writer must see the mark or a press on a swatch echoes back and detaches it before its click
+  assert.match(TIMELINE, /z-index:1003;' \+ MENU_STYLE \+ 'padding:8px;'\);\s*\n\s*pop\.dataset\.rompMenu = '1';/,
+    "the tag colour popover marks itself the same way");
   assert.match(MENU, /menu\.dataset\.tagMenu = "1"/, "the shared menu marks itself too (its own key)");
   // both writers skip the marked subtrees with the SAME selector — one vocabulary, two mirrors
   for (const src2 of [MENU, TIMELINE])

--- a/ui/webview/tab-color-picker.test.ts
+++ b/ui/webview/tab-color-picker.test.ts
@@ -1,12 +1,75 @@
 // Right-click a tab → a color picker in the context menu: the romp identity palette as circles, the session's
 // current one ringed; clicking one recolors the session (the user 2026-06-29). Source pins against render.ts —
 // the menu builds DOM at right-click time, so a behavioral jsdom run isn't needed to lock the shape.
+// The T164 balanced split is ALSO the timeline's: its Sessions & tags dialog draws the same swatches, since
+// 2026-09-09 in the colour popover a tag row's dot opens, and that half runs EXECUTED over the house fake-DOM
+// shim with the real TimelinePanel (the shim as ui/timeline-tags-scale.test.ts carries it).
 import { test } from "node:test";
 import assert from "node:assert";
 import fs from "node:fs";
 import path from "node:path";
+import { createRequire } from "node:module";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+// ---- the house fake-DOM shim (ui/timeline-tags-scale.test.ts), installed before the view loads ----
+function makeNode(tag: string): any {
+  const n: any = {
+    tag, _attrs: {}, children: [] as any[], style: {}, dataset: {}, _text: "", parentNode: null, value: "",
+    get textContent() { return this._text; },
+    set textContent(v: any) { this._text = v == null ? "" : String(v); for (const c of this.children) c.parentNode = null; this.children.length = 0; },
+    classList: { _s: new Set<string>(), add(...a: string[]) { a.forEach((c) => this._s.add(c)); },
+      remove(...a: string[]) { a.forEach((c) => this._s.delete(c)); },
+      toggle(c: string, f?: boolean) { f ? this._s.add(c) : this._s.delete(c); }, contains(c: string) { return this._s.has(c); } },
+    setAttribute(k: string, v: any) { this._attrs[k] = v; }, getAttribute(k: string) { return this._attrs[k]; },
+    setAttributeNS(_n: any, k: string, v: any) { this._attrs[k] = v; }, removeAttribute(k: string) { delete this._attrs[k]; },
+    appendChild(c: any) {
+      if (c.parentNode) { const i = c.parentNode.children.indexOf(c); if (i >= 0) c.parentNode.children.splice(i, 1); }
+      c.parentNode = n; this.children.push(c); return c;
+    },
+    insertBefore(c: any, ref: any) { c.parentNode = n; const i = this.children.indexOf(ref); i < 0 ? this.children.push(c) : this.children.splice(i, 0, c); return c; },
+    removeChild(c: any) { const i = this.children.indexOf(c); if (i >= 0) { this.children.splice(i, 1); c.parentNode = null; } return c; },
+    get firstChild() { return this.children[0] || null; },
+    remove() { if (n.parentNode) n.parentNode.removeChild(n); },
+    _listeners: {} as any,
+    addEventListener(t: string, fn: any) { n._listeners[t] = fn; }, removeEventListener(t: string) { delete n._listeners[t]; },
+    setPointerCapture() {}, releasePointerCapture() {},
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    getBoundingClientRect() { return n._rect || { width: 200, height: 20, left: 0, top: 0, right: 200, bottom: 20 }; },
+    closest() { return null; },
+    focus() { g.document.activeElement = n; }, select() {},
+    setSelectionRange() {}, selectionStart: 0, selectionEnd: 0,
+    createEl(t: string, o: any) { const e = makeNode(t); if (o && o.cls) e.classList.add(o.cls); if (o && o.text) e.textContent = o.text; this.appendChild(e); return e; },
+    createDiv(o: any) { return this.createEl("div", o); }, createSpan(o: any) { return this.createEl("span", o); },
+  };
+  return n;
+}
+const g: any = global;
+g.document = {
+  createElement(t: string) { return t === "canvas" ? { getContext() { return { font: "", measureText(s: string) { return { width: (s ? s.length : 0) * 6 }; } }; } } : makeNode(t); },
+  createElementNS(_n: any, t: string) { return makeNode(t); },
+  createTextNode(text: string) { const n = makeNode("#text"); n.textContent = text; return n; },
+  body: makeNode("body"), documentElement: makeNode("html"), head: makeNode("head"),
+  getElementById() { return null; },
+  addEventListener() {}, removeEventListener() {},
+  activeElement: null,
+};
+const stored: Record<string, string> = {};
+g.localStorage = { getItem: (k: string) => (k in stored ? stored[k] : null), setItem: (k: string, v: any) => { stored[k] = String(v); }, removeItem: (k: string) => { delete stored[k]; } };
+g.getComputedStyle = () => ({ backgroundColor: "rgb(30,30,30)", fontFamily: "sans-serif" });
+g.requestAnimationFrame = () => 0;
+g.setTimeout = (fn: any) => { try { fn(); } catch { /* focus on a fake node */ } return 0; };
+g.addEventListener = () => {}; g.removeEventListener = () => {};
+g.matchMedia = () => ({ matches: false, addEventListener() {}, addListener() {} });
+g.window = g;
+g.innerWidth = 1400; g.innerHeight = 1300;
+// the two host bridges: present, so the dialog's tag rows are live (a row with no bridge is held, its dot inert)
+g.__rompTimelineSetViews = () => {};
+g.__rompTimelineTagEdit = () => {};
+const { TimelinePanel } = createRequire(__filename)(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"));
+function walk(x: any, out: any[] = []): any[] { for (const c of x.children || []) { out.push(c); walk(c, out); } return out; }
+const styleOf = (n: any): string => String(n._attrs.style || "");
+const now = 1_781_000_000;
 
 test("the palette is fetched once from the kernel /palette (the client doesn't own the palette list)", () => {
   assert.match(RENDER, /let paletteColors: string\[\] = \[\];/);
@@ -43,12 +106,41 @@ test("setSessionColor optimistically repaints and posts setSessionColor to the k
 });
 
 test("swatch grids balance their rows: ceil-split over a six-per-row cap (T164)", () => {
-  // 12 -> 6+6, 9 -> 5+4, 13 -> 7+6 — computed per render, CSS repeat(5) stays the no-JS fallback
+  // for n swatches, the fewest rows that keep each within six, split ceil-evenly: 12 -> 6+6, 9 -> 5+4,
+  // 13 -> 5+5+3 (three rows, since no row holds more than six), computed per render; the chat picker's
+  // CSS keeps repeat(5) as the no-JS fallback
   assert.match(RENDER, /const swRows = Math\.ceil\(paletteColors\.length \/ 6\)/);
   assert.match(RENDER, /repeat\(" \+ Math\.ceil\(paletteColors\.length \/ swRows\) \+ ", 18px\)"/);
-  const TIMELINE = fs.readFileSync(
-    path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
-  assert.match(TIMELINE, /Math\.ceil\(swN \/ Math\.ceil\(swN \/ 6\)\)/);
-  assert.match(TIMELINE, /grid-template-columns:repeat\(' \+ swCols/);
+  // the timeline's Sessions & tags dialog draws the same split. Until 2026-09-09 every tag row carried the
+  // swatches inline and two source pins read that code; the swatches moved into the colour popover a row's
+  // dot opens, so the split is now read off the popover's grid, EXECUTED: one tag, a palette of n colours,
+  // the dialog opened, the dot clicked, the grid's columns checked for the same counts as above plus the
+  // counts around the cap (seven splits 4+3, six and five stay one row)
+  const cases: Array<[number, number, string]> = [[12, 6, "6+6"], [9, 5, "5+4"], [13, 5, "5+5+3"], [7, 4, "4+3"], [6, 6, "one row of six"], [5, 5, "one row of five"]];
+  for (const [n, cols, shape] of cases) {
+    assert.equal(cols, Math.ceil(n / Math.ceil(n / 6)), n + " swatches: the expectation IS the ceil-split");
+    const pal = Array.from({ length: n }, (_, i) => "#" + String(i + 1).padStart(2, "0").repeat(3));   // n distinct hexes
+    const panel = new TimelinePanel(makeNode("div"));
+    const views = {
+      active: "all", at: 100, seq: 1000, actives: { chat: { all: true }, timeline: { all: true }, outline: { all: true } },
+      tags: [{ id: "g1", name: "alpha", color: pal[0], members: ["s1"], mtime: 100 }],
+    };
+    const s1 = { id: "s1", name: "web", color: pal[0], state: "working", live: true, model: "Opus", effort: "high",
+      context: 40, since: now - 60, awaiting: [], compacting: [], pendingMail: 0, compactions: [], faded: false, stale: false };
+    panel.update({ now, sessions: [s1], turns: {}, messages: [], judging: [], views, palette: pal.slice() });
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 1000 });
+    panel._openViewsDialog(null);
+    const dot = walk(panel._viewsDialog).find((x) => x.dataset.tagDot === "g1");
+    assert.ok(dot, n + " swatches: the tag row's colour dot");
+    dot._listeners.click();
+    const pop = panel._tagColorPop;
+    assert.ok(pop, n + " swatches: the popover opened");
+    assert.equal(walk(pop).filter((x) => x._attrs.role === "radio").length, n, n + " swatches drawn");
+    const grid = walk(pop).find((x) => x._attrs.role === "radiogroup");
+    assert.ok(grid, n + " swatches: the swatch grid");
+    assert.ok(styleOf(grid).includes("grid-template-columns:repeat(" + cols + ",18px);"),
+      n + " swatches read " + shape + " (repeat(" + cols + ")), got: " + styleOf(grid));
+    panel._closeViewsDialog();
+    assert.equal(g.document.body.children.filter((x: any) => x._attrs.role === "dialog").length, 0, "no popover left in the host document");
+  }
 });
-


### PR DESCRIPTION
The Sessions & tags dialog draws one colour dot per tag row (the palette opens as a popover), folds the pane filters to one summary line per pane, and keeps the sessions table on screen with a height budget, so a dialog with dozens of tags still shows the sessions the user came to act on.

## Tier

Tier: feature

## Why

With ten tags the dialog filled the page. Every tag row carried the whole identity palette inline (twelve swatches in two rows, about 38px for one bit of information), and the pane filters were a five-pane matrix of every tag, so the sessions table showed two rows below the visible area. The sessions are the working area; the sections above them should take one line per item and open their detail on demand.

## What changes

The change is two commits: the code and its tests in the first (`ui/romp-timeline-view.js`, inside the dialog and the two menu helpers it uses; nothing else in the file), the `CLAUDE.md` rule alone in the second.

- **A tag row is one line**: the pill (still the reorder handle), delete, rename, one colour dot wearing the tag's colour. Click, Enter or Space on the dot opens the identity palette as a popover (the same swatches in the same balanced split, the current one ringed and focused). A pick performs the same recolor write the inline swatches performed (`_editTagUnion` with `color`), re-resolving the tag by union key at pick time so a repaint between open and pick (an ack, a refusal, a rename, a remote half landing) cannot act on a stale object; the optimistic copy, the ack and the refusal paths are unchanged. A held dot (a remote half with no bridge) wears the reason and takes no click, as the held actions do.
- **Popover placement and lifetime**: it lives in the dot's own document, one z-index above the dialog's backdrop, placed by the dot's rect (below, or above when below cannot hold it). It closes on the pick, on Escape (the dialog closes on the next press), on a press anywhere else on the dialog (the anchor dot exempt, so its click toggles rather than close-and-reopen), when Tab or focus leaves it, when its dot moves (the table's scroll, the card's scroll, a window resize), and with the dialog. One popover at a time. A repaint re-places it under the rebuilt dot, or closes it when the row is gone, scrolled out of the table's box, or held now (a remote half landed with no bridge to reach it: a pick could only be refused, and left open the popover hung on the detached dot of the last build, whose rect is all zeros).
- **Two menu-helper changes** the popover needs: `_menuHost(anchorRect, anchorEl)` returns the anchor's own document untranslated when the anchor already lives outside `document` (the dialog is adopted into the host document when it opens; translating an adopted node's rect a second time put the popover an iframe offset from its dot, below the viewport in a 200px band). The optional parameter changes nothing for the existing menus, which pass no element. `menuTop` flips above only when the menu also ends on screen, else clamps; before, an anchor below the viewport passed the `above >= 6` check and the menu landed off the bottom.
- **Pane filters fold** to one summary line per pane (`lensSummary`): All, no tags, or the tag names in the user's tag order, cut with a count past six, naming only tags that still exist (a lens naming only gone tags reads "none of the tags here"; the hover lists everything plus the gone names). The caption's caret opens the full matrix in its own cell, bounded to 25vh and scrolling within itself, with the chips wrapping inside their own cell so a second line starts under the first chip. The open or folded choice holds for the page lifetime as a module variable (the same idiom as `modelChoicesRev`), deliberately not a persisted setting.
- **The height budget**: the tag table caps at 30vh and scrolls within itself. The sessions box carries `flex:1 1000 auto` so it gives way first when height runs out (flex distributes shrink by base size, so a plain 1:1 squeezed a tag table that fit), down to a floor of min(live, 4) rows; at that floor the table gives way to three rows and the open matrix to 52px; past those the card scrolls as a whole (`overflow-y:auto`) instead of clipping, so a phone held sideways can still reach the search box and "tag all". Both floors are measured off the rendered rows at the end of each build rather than set as constants: the row height is the font's, and a 22px-a-row constant left 6px of blank under one tag and cut the third of three rows. The sessions floor is min(live, 4) times the smallest rendered row (a first row whose chips wrap would otherwise leave blank), by the live count so typing in the search box never moves it; both heights persist across builds so a build under a query, or in a document without layout, keeps the last floor; the card is appended to its final document before the first build so the first measurement happens where it is laid out.
- **[+ New tag]** is a card child under the table, outside its scroll (with ten tags at 800px the cap held exactly the ten rows and hid it as the table's last row). The table's scrollTop is read before a repaint and restored once the card is complete.
- **The reorder drag over a table that scrolls**: only rows whose whole box plus the 2px cue lies inside the table's box take the cue and the drop (the cue is a border on the row's edge; an edge under the clip means an invisible cue); the held row counts while any of it shows; the table's scroll re-ranks with the last pointer y for the drag's duration (a wheel mid-drag fires no pointermove) and the drop re-ranks if the table scrolled since the grab; the cue comes off for each measurement and goes back in the same task (it grows the pill cell 2px and shifts the rows under it); the table carries `overflow-anchor:none` so scroll anchoring does not follow that 2px and oscillate.

The second commit adds a short rule to `CLAUDE.md` under the UI section: tag and session surfaces are laid out for dozens of items, per-item controls take one line, per-item detail opens on demand, the working area keeps the space, and a change to such a surface is checked against the thirty-tag fixture. It is its own commit so it can be reworded or dropped without touching the code.

## Measured

At every height measured the search box, "tag all" and [+ New tag] stay on screen and the card itself never scrolls. Chromium and Firefox at 1600 wide with thirty tags and forty sessions (tag rows shown / session rows shown without scrolling the dialog): 1300px tall 14 / 18 folded and 14 / 12 with the matrix open; 800px 8 / 7 folded (Firefox 6) and 8 / 4 open; 700px 7 / 4 folded and open; ten tags at 800px 8 / 7 (Firefox 6). 30vh was chosen over 35vh from the same measurement: it trades two tag rows for two session rows at 1300px and 800px, at the cost that ten tags scroll at 800px (8 of 10 shown).

## Not included

No change to `render.ts`, `styles.css`, `settings.ts` or `gear.js`. No persisted setting for the filters' fold. No docs change: nothing under `docs/` describes the dialog's layout. No test measures WebKit.

## Tests

- `ui/timeline-tags-scale.test.ts` (new): twenty-two cases executed over the fake-DOM shim with the real `TimelinePanel`, no source pins. `lensSummary`'s ordering, cut and gone-name handling; one dot per row and no inline swatch; the popover's open state, current swatch, the pick posting the same recolor write (op, tid, color, writeId) and its ack and refusal paths; the pick re-resolving after a rename and a remote half; a held dot taking no click; keyboard open, arrows, Tab, focusout, Escape order, presses on the card, the dot and the backdrop; one popover at a time; the scroll and resize closers and the repaint re-place; the table's scroll memory; the drag's candidate rule over a cue-aware rect model with a wheel mid-drag; folded and open filters and the page memory; thirty tags and forty sessions rendering. Two cases execute what only the browser legs reached before: a repaint that turns the popover's dot held closes the popover; and in a framed shell the popover lands in the dialog's own document, placed by the dot's rect untranslated, with its resize closer on that window (the shim's nodes carry an `ownerDocument`, adopted with the subtree on append as a browser adopts them, and the frame stand-ins are set so the frame walk would translate). The floors are measured over index-placed rows, so a floor read off the whole table fails, and two live sessions beside four dead ones give a two-row floor, so a floor by every session fails. The shim is reset before every case (the body emptied; the window's listeners, the feed row's echo, the geometry hooks and the recorded posts cleared; the filters' page-lifetime fold put back), so one failure cannot take the cases after it down. Before the change all twenty-two fail (`lensSummary is not a function`, no dot, no popover, the old styles).
- `ui/timeline-tags-scale-browser.test.ts` (new): three legs per browser in Chromium and Firefox, measuring the layout at 1300, 800 and 700px tall with thirty and ten tags, real pointer drags past the table's edge with a wheel mid-drag and a cued row scrolled under the clip, the floors at 420 and 500px (none, one, two of six, three, four and forty live) and with wrapped chips at a 390px page, a phone held sideways, the popover's ring and focus, Tab, scroll, resize, scroll memory and repaint, and two framed shells (an offset iframe and a 200px band at the page's foot). The card's and the matrix cell's overflow are read as rendered (`getComputedStyle`), not inferred from a scrollTop write, which a clipping box also takes; with the matrix open at 800px the cell keeps to 25vh and `elementFromPoint` finds every chip inside the cell's box and none past it, so a cell without its bound and scroll, whose chips print over the sessions table, fails here (63 of 64 chips past the box painted under that mutation). The sessions box and the matrix cell are found by structure (the sessions grid's parent, the "All surfaces" row's parent), and the flex declarations are asserted on the found boxes, so a change to a declaration is measured rather than crashing the leg. Waits are on conditions (the popover open with its current swatch focused; the popover closed after a resize), never fixed delays. Skips loudly per leg without a playwright browser; these ran locally (`npx playwright install chromium firefox` under `vscode-extension`, then `npm test`): 6 of 6 pass. Before the change all six fail (no sessions box floor to read; the ringed pill sits at 0px inside the table).
- Re-aimed pins: `ui/timeline-views-panel.test.ts` (the card's `overflow-y:auto`, the chips' wrapping cell, the sessions box's `gridStyle` floor and `min(liveN, 4)`, the recolor through `now`, the held dot, New tag under the table), `ui/timeline-menu-place.test.ts` (a new executed case: an anchor below the viewport clamps on screen, 1232 for the 1300px case where the old code returns 1280; the `_menuHost(anchorRect, anchorEl)` pin and its own-document branch), `ui/webview/menu-echo.test.ts` (counts the popover among the `MENU_STYLE` menus and pins its `data-romp-menu` mark), `ui/webview/tab-color-picker.test.ts` (two source pins on the inline swatch split replaced by an executed half: the dialog opened, the dot clicked, the popover grid's columns read for 12, 9, 13, 7, 6 and 5 swatches), `ui/timeline-kernel-post.test.ts` (opens the folded filters through the caption before clicking a chip; red before because the caption had no click listener). `ui/timeline-tagorder-drag.test.ts` seats its cells inside a table rect so the whole-row rule admits them; it passes before and after.
- Mutations checked red: the sessions floor counting every session (the fake-DOM floors case), the `_menuHost` own-document branch removed and the popover left in the pane's body (the fake-DOM framed case), the held-dot close reverted (the fake-DOM held case), the card `overflow:hidden`, the matrix cell without its bound and scroll, and the sessions box at `flex:1 1 auto` (the browser legs, by measurement).
- Full run under `vscode-extension`: `npm run typecheck` clean; `npm test` 3699 tests, 3699 pass, 0 fail, 0 skipped (browser legs included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)