### PR TITLE
The tmux backend sits behind a kernel setting, and the backends read Claude Code, Claude Code (tmux) and Codex (T288)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -242,21 +242,25 @@ did, so searching for the work finds the session that did it, months later.
 
 ### Session backends
 
-Sessions run on one of two backends, chosen per session:
+Sessions run on one of these backends, chosen per session:
 
-- **SDK (the default, strongly recommended).** The kernel manages the Claude
-  Code session through the Claude Agent SDK.
-- **tmux.** A Claude Code session running in a terminal inside tmux. Run
-  `romp new -t <name>` and that terminal session joins the interface like any other, so
-  you can work in the terminal directly and still see it in Romp. The cost is
-  that Romp has no direct connection to it: it reads what appears in the
-  terminal and on disk, and sends messages and nudges by injecting keystrokes.
-  That makes it less reliable and less responsive than the SDK, since scraping a
-  terminal has edge cases a real API does not, and updates wait on the
-  transcript reaching disk.
+- **Claude Code (the default, strongly recommended).** The kernel runs the
+  Claude Code session itself, through the Claude Agent SDK.
+- **Claude Code (tmux).** A Claude Code session running in a terminal inside
+  tmux. Run `romp new -t <name>` and that terminal session joins the interface
+  like any other, so you can work in the terminal directly and still see it in
+  Romp. The cost is that Romp has no direct connection to it: it reads what
+  appears in the terminal and on disk, and sends messages and nudges by
+  injecting keystrokes. That makes it less reliable and less responsive than
+  Claude Code itself, since scraping a terminal has edge cases a real API does
+  not, and updates wait on the transcript reaching disk. The new-session picker
+  and the gear's Default backend list offer it only while **Enable Claude Code
+  tmux backend** is on in the gear's Updates & debug section (off by default);
+  sessions already running on it keep working either way.
+- **Codex.** An OpenAI Codex agent; see [docs/codex.md](codex.md).
 
-The two backends interleave freely, so terminal sessions and SDK sessions sit
-side by side in the interface and message each other like any other pair.
+The backends interleave freely, so terminal sessions and Claude Code sessions
+sit side by side in the interface and message each other like any other pair.
 
 ## The Romp kernel (the back end)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -262,11 +262,11 @@ CLI's own picker), a value the kernel cannot vouch for (a typo), or a longer
 message that merely opens with the command goes to the CLI verbatim, and the
 chat shows the CLI's own reply.
 
-The two backends apply the change differently. An SDK session switches model
-live but reloads to apply a new effort: the chat shows "Reloading session…"
-and the effort badge shows switching-dots until the reload completes, and a
-session that is mid-turn reloads when the turn ends. A terminal (tmux) session
-gets the CLI's own command typed into its pane. `/model` there asks for a
+The backends apply the change differently. A Claude Code session switches
+model live but reloads to apply a new effort: the chat shows "Reloading
+session…" and the effort badge shows switching-dots until the reload completes,
+and a session that is mid-turn reloads when the turn ends. A Claude Code (tmux)
+session gets the CLI's own command typed into its pane. `/model` there asks for a
 confirmation, which the kernel accepts on your behalf so the pane is never
 left waiting on a keystroke the dashboard cannot send; `/effort` and `/fast`
 apply in place.
@@ -296,7 +296,7 @@ romp to hold no key). The per-session pick decides only whether the helper
 runs for that session.
 
 The new-session picker's **Billing** row states the case whenever the backend
-toggle says SDK: segmented buttons when the selected host offers both choices,
+toggle says Claude Code: segmented buttons when the selected host offers both choices,
 and with only one real choice, the same spot writes out which applies,
 `Login (name@example.com)` or `API key`. The key choice exists when Claude
 Code's settings for the kernel's working directory carry a helper; romp reads
@@ -445,7 +445,8 @@ For `./install.sh`:
 
 - `ROMP_NO_SERVICE=1` skips the login service.
 - `ROMP_NO_EXT=1` skips the VS Code / Cursor extension.
-- `ROMP_NO_SDK=1` skips the SDK backend's venv (tmux sessions still work).
+- `ROMP_NO_SDK=1` skips the Claude Code backend's Agent SDK venv (Claude Code
+  (tmux) sessions still work).
 
 For the one-line installer (`bootstrap.sh`), which passes all of the above
 through to `install.sh`:
@@ -468,6 +469,21 @@ through to `install.sh`:
   applies on the judges' next pass with no restart, wins over the variable,
   and follows to every connected machine like the other judge settings; its
   Default option clears the setting back to the variable, else 6.
+
+### Session backends
+
+- **Enable Claude Code tmux backend** (the gear's Updates & debug section; off
+  by default) decides whether the new-session picker and the gear's Default
+  backend list offer **Claude Code (tmux)**, a Claude Code session in a
+  terminal pane that Romp follows by reading the terminal. The setting gates
+  the offer alone: sessions already running on that backend keep working and
+  keep their label, `romp new -t` still works, and a saved default of Claude
+  Code (tmux) is set aside while the setting is off (new sessions use Claude
+  Code) and returns when it comes back. Like the judge settings, a change
+  applies at once, without a restart, and follows to every connected machine.
+  The backends read as **Claude Code** (the default), **Claude Code (tmux)**
+  and **Codex** everywhere: the picker, the gear, the tab tooltip's Backend
+  row.
 
 ### Ports
 
@@ -1460,5 +1476,5 @@ Effective immediately, no restart.
 `touch` to **enable**, `rm` to turn back off:
 
 - `~/.claude/romp-summarize-on`: the live tmux activity phrase. Off by default,
-  because it spends tokens on every turn and the SDK backend reports what a
-  session is doing without it.
+  because it spends tokens on every turn and the Claude Code backend reports
+  what a session is doing without it.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1036,6 +1036,7 @@ def _version_info():
             "commentModel": jd._state_str("comment-model", "session"),
             "commentEffort": jd._state_str("comment-effort", "session"),
             "commentFast": jd._state_str("comment-fast", "session"),
+            "tmuxBackend": jd._state_str("tmux-backend", "off"),   # T288: "on" offers Claude Code (tmux) in the picker and the gear
             # One dict with every kernel-side setting, lifted by a PEER kernel's /version poll onto its
             # /tunnels row so its gear can mark controls where machines disagree (the user 2026-08-14).
             # The top-level fields above stay: this tab's own gear and older kernels read those.
@@ -1054,7 +1055,8 @@ def _version_info():
                          "distillEffort": jd._state_str("distill-effort", "triage"),
                          "commentModel": jd._state_str("comment-model", "session"),
                          "commentEffort": jd._state_str("comment-effort", "session"),
-                         "commentFast": jd._state_str("comment-fast", "session")},
+                         "commentFast": jd._state_str("comment-fast", "session"),
+                         "tmuxBackend": jd._state_str("tmux-backend", "off")},
             # every gt-gated store's last-applied gesture stamp (epoch-ms ints, nothing path-shaped):
             # the gear stamps its next gesture above these instead of trusting the device clock.
             # Top-level, not lifted into /tunnels rows — a remote's newer stamp reaches the dashboard
@@ -12517,7 +12519,7 @@ def _fork_session_inner(parent_sid, cut_msg_uuid, new_name, now=None, client=Non
         return "session names use letters, digits, . _ - only."
     be = Sessions.backend_for(parent_sid)
     if not (hasattr(be, "fork") and _sdk_ready()):
-        return "fork needs the SDK backend — this session runs on tmux, so there is nothing to fork from."
+        return "fork needs a Claude Code session — this one runs in a terminal (Claude Code (tmux)), so there is nothing to fork from."
     now = now or time.time()
     sess = next((s for s in _sessions(now) if s["sid"] == parent_sid), None)
     if not sess:
@@ -13529,7 +13531,7 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", eff
     exact/name as usual; nothing kernel-side consumes meta beyond storing it."""
     be = Sessions.backend_for(parent_sid)
     if not (hasattr(be, "fork") and _sdk_ready()):
-        return "threads need the SDK backend; this session runs on tmux, so there is nothing to fork.", None
+        return "threads need a Claude Code session; this one runs in a terminal (Claude Code (tmux)), so there is nothing to fork.", None
     if not str(exact or "").strip() or not str(text or "").strip():
         return "nothing to send: highlight a passage and write a comment.", None
     now = now or time.time()
@@ -13627,7 +13629,7 @@ def _comment_reply(parent_sid, tid, text):
     relay carries only the new tail. Returns an error string or None."""
     be = Sessions.backend_for(parent_sid)
     if not hasattr(be, "fork"):
-        return "threads need the SDK backend."
+        return "threads need a Claude Code session."
     prior, th = _comment_update_if(parent_sid, tid, ("open", "merged"),
                                    status="open", lastSeenT=int(time.time()))
     if th is None:
@@ -13840,7 +13842,7 @@ def _comment_promote_inner(parent_sid, tid, new_name, now=None, client=None):
         return "session names use letters, digits, . _ - only."
     be = Sessions.backend_for(parent_sid)
     if not (hasattr(be, "promote_thread") and _sdk_ready()):
-        return "threads need the SDK backend."
+        return "threads need a Claude Code session."
     # LATCH first (status='promoting', a CAS under the lock): the seeding below takes real time on a
     # big parent transcript, and a resolve/delete landing inside that window used to read 'open',
     # win its status write, and kill the just-promoted board session. With the latch they refuse.
@@ -13998,8 +14000,8 @@ _SDK_PROMPT = Path(os.path.expanduser("~/.claude/romp-session-prompt.md"))
 # What a session-creation refusal says when the Agent SDK isn't provisioned. ONE string for the browser
 # toast and the `romp new` JSON, because they are the same sentence to the same person: nothing was
 # created, and here is the single command that fixes it. Names the remedy, not the missing module.
-SDK_SETUP_HINT = ("Session not created: romp's Agent SDK backend isn't installed. "
-                  "Run bin/romp-sdk-setup, then try again. (tmux sessions still work.)")
+SDK_SETUP_HINT = ("Session not created: the Claude Code backend's Agent SDK isn't installed. "
+                  "Run bin/romp-sdk-setup, then try again. (Claude Code (tmux) sessions still work.)")
 
 _sdk_backend = None   # None = not built yet, False = unavailable, else the SdkBackend
 _sdk_lock = threading.Lock()   # single-flight construction: the eager boot thread races handler
@@ -26216,7 +26218,7 @@ def _rewind_send(sid, user_uuid, text, now=None):
     injection is exactly the fragility the backend seam exists to avoid."""
     be = Sessions.backend_for(sid)
     if not hasattr(be, "rewind"):
-        return "editing past messages needs the SDK backend — this session runs in tmux (use Esc Esc in its terminal)"
+        return "editing past messages needs a Claude Code session — this one runs in a terminal (use Esc Esc there)"
     if _ops_gate(sid):
         return "the session is busy — wait for the current turn to finish, then edit"
     now = now or time.time()
@@ -26261,7 +26263,7 @@ def _rewind_rollback(sid, user_uuid, now=None):
     error string for the warn toast, or None."""
     be = Sessions.backend_for(sid)
     if not hasattr(be, "rollback"):
-        return "deleting past messages needs the SDK backend — this session runs in tmux (use Esc Esc in its terminal)"
+        return "deleting past messages needs a Claude Code session — this one runs in a terminal (use Esc Esc there)"
     # NO busy gate here (delete-while-busy, the user 2026-08-29): the backend decides — a bare
     # delete on an in-flight turn interrupts it and arms the rewind at the turn's actual end;
     # compacting and queued-strangers keep their honest refusals inside _arm_rewind.
@@ -37738,6 +37740,12 @@ def _set_distill_effort(v, gt=None): return _set_judge_state("distill-effort", v
 def _set_comment_model(v, gt=None):  return _set_judge_state("comment-model", v, _judge_model_values() | {"session", "default"}, gt=gt)
 def _set_comment_effort(v, gt=None): return _set_judge_state("comment-effort", v, _EFFORT_VALUES | {"session"}, gt=gt)
 def _set_comment_fast(v, gt=None):   return _set_judge_state("comment-fast", v, {"session", "on"}, gt=gt)
+# The tmux backend's OFFER (T288, the user 2026-09-09): "Claude Code (tmux)" appears in the + picker and the
+# gear's Default backend list only while this is "on"; off by default. It gates what the picker offers and
+# nothing else: an existing tmux session keeps working and keeps its label, `romp new -t` still works, the
+# ids and the protocol are unchanged. Rides the judge-knob machinery (validated, stamped, propagated to
+# every linked kernel: the 2026-08-14 gear rule, one value across machines).
+def _set_tmux_backend(v, gt=None):   return _set_judge_state("tmux-backend", v, {"on", "off"}, gt=gt)
 
 
 # The four judge-tier settings PROPAGATE: a pick made here follows to every linked kernel (the user
@@ -37761,7 +37769,8 @@ _JUDGE_SETTING_FIELDS = (("judgeModel", _set_judge_model), ("indexModel", _set_i
                          # settings follow to every machine (the 2026-08-14 gear rule), and
                          # /judge-settings is the tunnel-side propagation that already does it
                          ("commentModel", _set_comment_model), ("commentEffort", _set_comment_effort),
-                         ("commentFast", _set_comment_fast))
+                         ("commentFast", _set_comment_fast),
+                         ("tmuxBackend", _set_tmux_backend))   # T288: the tmux backend's offer, "on" | "off"
 
 # The per-field PICK STAMPS this leg carried from 2026-08-30 (each field's STATE-file mtime in a
 # body "stamps" dict, preserved by utime at the receiver — the distill-pick stomp fix) are
@@ -37812,7 +37821,8 @@ def _apply_judge_settings(body):
             "distillEffort": jd._state_str("distill-effort", "triage"),
             "commentModel": jd._state_str("comment-model", "session"),
             "commentEffort": jd._state_str("comment-effort", "session"),
-            "commentFast": jd._state_str("comment-fast", "session")}
+            "commentFast": jd._state_str("comment-fast", "session"),
+            "tmuxBackend": jd._state_str("tmux-backend", "off")}
 
 
 def _propagate_judge_settings(body):
@@ -38022,7 +38032,8 @@ def _adopt_peer_settings(host, rver):
 # frame and the gear's STALE_LABELS already share, so /version's settingsGt speaks the same one.
 _GT_STORES = ("auto-nudge", "compact-suggest", "file-editing", "update-mode", "thinking-summaries",
               "judge-model", "index-model", "judge-effort", "index-effort", "judge-concurrency",
-              "distill-model", "distill-effort", "comment-model", "comment-effort", "comment-fast")
+              "distill-model", "distill-effort", "comment-model", "comment-effort", "comment-fast",
+              "tmux-backend")
 
 
 def _setting_stored_gt(name):
@@ -47491,7 +47502,7 @@ class Handler(BaseHTTPRequestHandler):
                             _envbe = None
                         if not hasattr(_envbe, "set_env"):
                             return self._send(200, json.dumps({"ok": False, "error":
-                                'per-session env needs an SDK session — "%s" runs on tmux, whose CLI '
+                                'per-session env needs a Claude Code session — "%s" runs in a terminal, whose CLI '
                                 "reads the tmux server's environment" % nm}), "application/json")
                     extra = _apply_new_session_prefs(live[nm], b)
                     # the idempotent open never INHERITS (no creation event — the ruling), but an
@@ -47536,7 +47547,7 @@ class Handler(BaseHTTPRequestHandler):
                         # Codex thread runs on the shared app-server and has no per-session
                         # environment to take it — refuse, like the tmux arm, never a silent drop
                         return self._send(200, json.dumps({"ok": False, "error":
-                            "per-session env needs the SDK backend — a Codex session runs on the "
+                            "per-session env needs a Claude Code session — a Codex session runs on the "
                             "shared app-server and takes no per-session environment"}), "application/json")
                     # parent/tags ride the create like the SDK arm's (the tag store is backend-
                     # agnostic), so the echo below carries the same `tags` the CLI checks
@@ -47573,13 +47584,13 @@ class Handler(BaseHTTPRequestHandler):
                                       "application/json")
                 if env_req is not None:
                     return self._send(200, json.dumps({"ok": False, "error":
-                        "per-session env needs the SDK backend — a tmux session's CLI reads the "
+                        "per-session env needs a Claude Code session — a terminal session's CLI reads the "
                         "tmux server's environment"}), "application/json")
                 if psid or tags_req:
                     # a tmux spawn is threaded and its sid is unknown at ack time, so nothing here could
                     # tag it — refuse loudly rather than spawn it outside the group it was asked into
                     return self._send(200, json.dumps({"ok": False, "error":
-                        "tags and parent need an SDK or Codex session — a terminal session's id is not "
+                        "tags and parent need a Claude Code or Codex session — a terminal session's id is not "
                         "known until it starts"}), "application/json")
                 # the claim is taken on THIS thread (kind create), so a taken or in-flight name refuses
                 # the request that asked as a 409 — the launch itself runs threaded, as before
@@ -49033,7 +49044,7 @@ class Handler(BaseHTTPRequestHandler):
                     # a tmux spawn's sid is unknown at ack time — nothing could tag it (the /new
                     # contract) — refuse loudly, never a spawn outside its group
                     client["send"](json.dumps({"type": "warn", "text":
-                        "tags and parent need an SDK or Codex session — a terminal session's id is not known until it starts"}))
+                        "tags and parent need a Claude Code or Codex session — a terminal session's id is not known until it starts"}))
                 else:
                     refusal = _spawn_session_start(nm, cwd)   # claimed on THIS thread: the refusal reaches the asker
                     if refusal:
@@ -49063,6 +49074,9 @@ class Handler(BaseHTTPRequestHandler):
                                        # billing choices THIS host can offer a new session, with the
                                        # reason for any it cannot — the picker's Billing row (see _auth_avail)
                                        "authAvail": _auth_avail(),
+                                       # whether the + picker OFFERS Claude Code (tmux) (T288): the kernel
+                                       # setting, off by default; the Backend row follows this reply
+                                       "tmuxBackend": jd._state_str("tmux-backend", "off") == "on",
                                        # this machine's name (the identity peers see) — the picker's
                                        # Host row labels its this-machine option with it, so every
                                        # option is a machine by name (the user 2026-08-12)
@@ -49373,6 +49387,21 @@ class Handler(BaseHTTPRequestHandler):
             if _jgt is not None:
                 threading.Thread(target=_propagate_judge_settings,
                                  args=({"commentFast": str(msg["fast"]), "gt": _jgt},), daemon=True).start()
+            else:
+                _tell_stale_gesture(client, msg)
+        elif msg and msg.get("type") == "setTmuxBackend" and msg.get("enabled") is not None:
+            # gear "Enable Claude Code tmux backend" (T288): a checkbox, stored as on/off. The boolean is
+            # checked like every sibling's (_as_bool; the review's find: a truthy string would have read as
+            # on and fanned out to every kernel), and a malformed frame is refused with a warn, unwritten.
+            _tbe, ferr = _as_bool(msg.get("enabled"), "enabled")
+            if ferr:
+                _refuse_ws_flag(client, msg["type"], ferr, "enabled", msg.get("enabled"))
+                return
+            _tbv = "on" if _tbe else "off"
+            _jgt = _set_tmux_backend(_tbv, gt=_gesture_ms(msg))
+            if _jgt is not None:
+                threading.Thread(target=_propagate_judge_settings,
+                                 args=({"tmuxBackend": _tbv, "gt": _jgt},), daemon=True).start()
             else:
                 _tell_stale_gesture(client, msg)
         else:

--- a/tests/test_judge_settings_sync.py
+++ b/tests/test_judge_settings_sync.py
@@ -225,9 +225,10 @@ class OneHopNeverALoop(unittest.TestCase):
                      'args=({"distillEffort": str(msg["effort"]), "gt": _jgt},)',
                      'args=({"commentModel": str(msg["model"]), "gt": _jgt},)',
                      'args=({"commentEffort": str(msg["effort"]), "gt": _jgt},)',
-                     'args=({"commentFast": str(msg["fast"]), "gt": _jgt},)'):
+                     'args=({"commentFast": str(msg["fast"]), "gt": _jgt},)',
+                     'args=({"tmuxBackend": _tbv, "gt": _jgt},)'):   # T288
             self.assertIn(frag, self.src, frag)
-        self.assertGreaterEqual(self.src.count("if _jgt is not None:"), 10,
+        self.assertGreaterEqual(self.src.count("if _jgt is not None:"), 11,
                                 "every judge-tier fan-out is gated on the pick actually applying")
 
     def test_the_gear_copy_says_the_pick_follows(self):

--- a/tests/test_kernel_fork.py
+++ b/tests/test_kernel_fork.py
@@ -208,7 +208,7 @@ class ForkSessionOp(unittest.TestCase):
 
     def test_tmux_backend_refused(self):
         km.Sessions.backend_for = lambda sid: object()   # no .fork
-        self.assertIn("SDK backend", km._fork_session(PARENT, "", "api-fork") or "")
+        self.assertIn("needs a Claude Code session", km._fork_session(PARENT, "", "api-fork") or "")   # the backend's name since T288
 
     def test_seeding_precedes_the_backend_and_the_cut_resolves_like_a_rewind(self):
         self.assertIsNone(km._fork_session(PARENT, "u2", "api-fork"))

--- a/tests/test_kernel_session_flags.py
+++ b/tests/test_kernel_session_flags.py
@@ -854,6 +854,7 @@ class WsFlagsMustBeBooleans(unittest.TestCase):
             ("setFileEditing", "enabled", {}, km._file_editing_on, warn),
             ("setThinkingSummaries", "enabled", {}, km._thinking_summaries_on, warn),
             ("setConserve", "enabled", {}, km._conserve_on, warn),
+            ("setTmuxBackend", "enabled", {}, lambda: km.jd._state_str("tmux-backend", "off") == "on", warn),   # T288
             ("setGlobalRetryPaused", "value", {}, km._retry_paused_on, warn),
             ("setSessionFlag", "value", {"id": self.SID, "flag": "hideFromFeed"},
              lambda: km._session_flag(self.SID, "hideFromFeed"), lane),
@@ -940,6 +941,7 @@ class WsFlagsMustBeBooleans(unittest.TestCase):
         for field in ('msg.get("value")', 'msg.get("enabled")', 'msg.get("mkdir")', 'e.get("delete")',
                       'b.get("delete")', 'b.get("on")', 'b.get("mkdir")', 'body.get("on")', 'msg["enabled"]'):
             self.assertNotIn("bool(%s)" % field, src, "%s is checked by _as_bool, never coerced" % field)
+        self.assertNotIn('if msg.get("enabled") else', src, "a truthiness ternary is a coercion too (the T288 review's find)")
 
     def test_create_session_refuses_a_string_mkdir_before_touching_the_disk(self):
         calls = []

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -71,10 +71,19 @@ class SettingsSectionsTest(unittest.TestCase):
         self.assertIn("does NOT turn the judges on or off", h)
 
     def test_the_sdk_backend_is_labelled_plain_sdk(self):
-        # "SDK", not "SDK (headless)" (the user 2026-07-12): it drives the same full chat UI
+        # the backends as the user reads them (T288, the user 2026-09-09): "Claude Code" (the default, no
+        # qualifier — never "SDK" in copy a person reads), "Claude Code (tmux)", "Codex"
         h = _gear_src()
-        self.assertIn("<option value=sdk>SDK</option>", h)
+        self.assertIn("<option value=sdk>Claude Code</option><option value=tmux>Claude Code (tmux)</option><option value=codex>Codex</option>", h)
         self.assertNotIn("headless", h)
+        self.assertNotIn(">SDK<", h)
+        self.assertNotIn("SDK runs via", h)
+        self.assertNotIn("new SDK session", h)
+        # the tmux backend's offer: a checkbox in Updates & debug, off by default, stamped and propagated like the
+        # judge knobs; the Default backend list follows it in the same modal (paintBackendOffer)
+        self.assertTrue(h.index(">Updates & debug<") < h.index("id=rs-tmuxbackend") < h.index("id=rs-judges-index"))
+        self.assertIn("<b>Enable Claude Code tmux backend <span class=rs-mixed hidden></span></b>", h)
+        self.assertIn("id=rs-backend-note", h, "the sub-line that says a saved tmux default is set aside")
 
     def test_judge_rows_are_one_line_label_plus_picker(self):
         # label + picker share the line (the user 2026-07-12): nine .rs-jrow rows — six judge rows

--- a/tests/test_new_route_prefs.py
+++ b/tests/test_new_route_prefs.py
@@ -272,14 +272,14 @@ class NewRouteEnv(unittest.TestCase):
         code, body = self._post({"name": "opt", "dir": self.dir, "env": {"FEATURE_FLAG": "1"}})
         self.assertEqual(code, 200)
         self.assertFalse(body["ok"], "a session that can't take the env must say so, not drop it")
-        self.assertIn("SDK", body["error"])
+        self.assertIn("needs a Claude Code session", body["error"])   # the backend's name since T288
 
     def test_the_tmux_backend_refuses_env_outright(self):
         code, body = self._post({"name": "term1", "dir": self.dir,
                                  "backend": "tmux", "env": {"FEATURE_FLAG": "1"}})
         self.assertEqual(code, 200)
         self.assertFalse(body["ok"], "no tmux spawn, no env silently dropped")
-        self.assertIn("SDK", body["error"])
+        self.assertIn("needs a Claude Code session", body["error"])   # the backend's name since T288
         time.sleep(0.2)                       # the tmux spawn is threaded — give a regression a beat
         self.assertEqual(self.spawns, [], "the refusal must come BEFORE the spawn thread starts")
 
@@ -445,7 +445,7 @@ class NewRouteTags(unittest.TestCase):
         code, body = self._post({"name": "term1", "dir": self.dir, "backend": "tmux", "tags": ["pool"]})
         self.assertEqual(code, 200)
         self.assertFalse(body["ok"], "no tmux spawn with the tags silently dropped")
-        self.assertIn("SDK or Codex", body["error"])
+        self.assertIn("Claude Code or Codex", body["error"])
         code, body = self._post({"name": "term1", "dir": self.dir, "backend": "tmux", "parent": SID})
         self.assertFalse(body["ok"])
         time.sleep(0.2)
@@ -533,7 +533,7 @@ class NewRouteTags(unittest.TestCase):
         code, body = self._post({"name": "api", "dir": self.dir, "backend": "codex", "env": {"X": "1"}})
         self.assertEqual(code, 200)
         self.assertFalse(body["ok"], "no Codex spawn with the env silently dropped")
-        self.assertIn("SDK backend", body["error"])
+        self.assertIn("needs a Claude Code session", body["error"])
         self.assertEqual(self.created_codex, [], "the refusal comes before the spawn")
 
     def test_a_threads_name_answers_the_tags_ask_with_nothing_applied_and_the_reason(self):

--- a/tests/test_new_session_dir.py
+++ b/tests/test_new_session_dir.py
@@ -309,7 +309,7 @@ class CreateSessionTags(_Wire):
     def test_a_tmux_create_with_tags_refuses_instead_of_dropping_them(self):
         r = self.send({"type": "createSession", "name": "term1", "dir": self.tmp, "backend": "tmux", "tags": ["pool"]})
         self.assertEqual(r["type"], "warn")
-        self.assertIn("SDK or Codex", r["text"])
+        self.assertIn("Claude Code or Codex", r["text"])   # the backends' names since T288
         self.assertEqual(self.spawned, [], "no tmux spawn with the tags silently gone")
 
     def test_a_codex_create_takes_tags_and_a_parent_like_an_sdk_one(self):

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -795,7 +795,7 @@ class VersionReportsEveryStoredStamp(_Base):
     def test_a_fresh_install_reports_every_store_at_zero(self):
         gts = km._version_info()["settingsGt"]
         self.assertEqual(set(gts), set(km._GT_STORES), "one key per gt-gated store, no more, no less")
-        self.assertEqual(len(km._GT_STORES), 15, "five toggles/modes + ten judge-tier stores (judge-concurrency since T277)")
+        self.assertEqual(len(km._GT_STORES), 16, "five toggles/modes + eleven kernel-side stores (judge-concurrency since T277, tmux-backend since T288)")
         self.assertEqual(set(gts.values()), {0}, "nothing applied yet reads 0 — nothing to outrank")
         self.assertEqual(json.loads(json.dumps(gts)), gts, "plain JSON — ints, no paths, nothing to redact")
 
@@ -836,7 +836,8 @@ class VersionReportsEveryStoredStamp(_Base):
                  {"type": "setIndexEffort", "effort": "high"}, {"type": "setJudgeConcurrency", "value": "4"},
                  {"type": "setDistillModel", "model": "haiku"},
                  {"type": "setDistillEffort", "effort": "high"}, {"type": "setCommentModel", "model": "haiku"},
-                 {"type": "setCommentEffort", "effort": "high"}, {"type": "setCommentFast", "fast": "on"}]
+                 {"type": "setCommentEffort", "effort": "high"}, {"type": "setCommentFast", "fast": "on"},
+                 {"type": "setTmuxBackend", "enabled": True}]
         older = [{"type": "setAutoNudge", "enabled": True}, {"type": "setCompactSuggest", "enabled": False},
                  {"type": "setFileEditing", "enabled": False}, {"type": "setUpdateMode", "mode": "off"},
                  {"type": "setThinkingSummaries", "enabled": False}, {"type": "setJudgeModel", "model": "opus"},
@@ -844,14 +845,15 @@ class VersionReportsEveryStoredStamp(_Base):
                  {"type": "setIndexEffort", "effort": "low"}, {"type": "setJudgeConcurrency", "value": "2"},
                  {"type": "setDistillModel", "model": "triage"},
                  {"type": "setDistillEffort", "effort": "low"}, {"type": "setCommentModel", "model": "session"},
-                 {"type": "setCommentEffort", "effort": "session"}, {"type": "setCommentFast", "fast": "session"}]
+                 {"type": "setCommentEffort", "effort": "session"}, {"type": "setCommentFast", "fast": "session"},
+                 {"type": "setTmuxBackend", "enabled": False}]
         with contextlib.redirect_stderr(io.StringIO()):
             for n, o in zip(newer, older):
                 km.Handler._dispatch_ws(types.SimpleNamespace(), dict(n, gt=T_NEW), client)
                 km.Handler._dispatch_ws(types.SimpleNamespace(), dict(o, gt=T_OLD), client)
         named = {m["setting"] for m in sent if m.get("type") == "settingStale"}
         self.assertEqual(named, set(km._version_info()["settingsGt"]), "frames and the report share one vocabulary")
-        self.assertEqual(len(named), 15)   # ten judge-tier stores since T277
+        self.assertEqual(len(named), 16)   # eleven kernel-side stores since T288
 
 
 class ASkewedClockCannotLockTheStore(_Base):

--- a/tests/test_tmux_backend_setting.py
+++ b/tests/test_tmux_backend_setting.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""The tmux backend's OFFER is a kernel setting (T288, the user 2026-09-09): "Claude Code (tmux)" appears in the +
+picker and the gear's Default backend list only while STATE/tmux-backend reads "on"; it is off by default. It rides
+the judge-knob machinery: validated before it is written (only "on" / "off"), gesture-stamped, reported by /version
+(top level and the cross-machine settings dict), applied and acked by /judge-settings, propagated to every linked
+kernel from the socket op, and carried on the picker's sessionList reply as a boolean. The setting gates the OFFER
+alone: nothing here touches how a tmux session runs.
+
+Hermetic: STATE is a temp dir per test; the propagation thread runs inline; no sockets.
+"""
+import contextlib
+import io
+import json
+import os
+import shutil
+import tempfile
+import threading as _real_threading
+import types
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_tmuxbackend", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+T_OLD, T_NEW = 1_700_000_000_000, 1_700_000_360_000
+
+
+class _InlineThread:
+    def __init__(self, target=None, args=(), kwargs=None, daemon=None, name=None):
+        self._target, self._args, self._kwargs = target, args, (kwargs or {})
+    def start(self):
+        if self._target:
+            self._target(*self._args, **self._kwargs)
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self._saved_state = jd.STATE
+        self._td = tempfile.mkdtemp()
+        jd.STATE = Path(self._td)
+        jd._state_cache.clear()
+        self.propagated = []
+        self._saved_threading = km.threading
+        ns = {k: getattr(_real_threading, k) for k in dir(_real_threading) if not k.startswith("__")}
+        ns["Thread"] = _InlineThread   # the fan-out runs inline, so a test sees every propagation call at once
+        km.threading = types.SimpleNamespace(**ns)
+        self._saved_prop = km._propagate_judge_settings
+        km._propagate_judge_settings = lambda body: self.propagated.append(body)
+
+    def tearDown(self):
+        km._propagate_judge_settings = self._saved_prop
+        km.threading = self._saved_threading
+        jd.STATE = self._saved_state
+        jd._state_cache.clear()
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _ws(self, msg):
+        sent = []
+        client = {"send": lambda s: sent.append(json.loads(s)), "alive": True}
+        with contextlib.redirect_stderr(io.StringIO()):
+            km.Handler._dispatch_ws(types.SimpleNamespace(), msg, client)
+        return sent
+
+
+class Default(_Base):
+    def test_off_by_default_everywhere_it_is_read(self):
+        self.assertEqual(jd._state_str("tmux-backend", "off"), "off")
+        v = km._version_info()
+        self.assertEqual(v["tmuxBackend"], "off", "/version top level")
+        self.assertEqual(v["settings"]["tmuxBackend"], "off", "the cross-machine settings dict (the gear's mixed marks)")
+        self.assertIn("tmux-backend", v["settingsGt"], "its stamp rides with the other stores'")
+        self.assertEqual(km._apply_judge_settings({})["tmuxBackend"], "off", "the /judge-settings ack")
+        self.assertIn("tmuxBackend", dict(km._JUDGE_SETTING_FIELDS))
+        self.assertIn("tmux-backend", km._GT_STORES)
+        # the picker's sessionList reply: a boolean, False until the setting is on
+        reply = [m for m in self._ws({"type": "requestSessions"}) if m.get("type") == "sessionList"]
+        self.assertEqual(len(reply), 1)
+        self.assertIs(reply[0]["tmuxBackend"], False)
+
+
+class SetAndClear(_Base):
+    def test_only_on_and_off_are_stored(self):
+        self.assertIsNotNone(km._set_tmux_backend("on"))
+        self.assertEqual((jd.STATE / "tmux-backend").read_text(), "on")
+        self.assertEqual(km._version_info()["tmuxBackend"], "on")
+        for bad in ("yes", "true", "1", "", "ON"):
+            self.assertIsNone(km._set_tmux_backend(bad), "%r is refused unwritten" % bad)
+        self.assertEqual((jd.STATE / "tmux-backend").read_text(), "on", "the refused values wrote nothing")
+        self.assertIsNotNone(km._set_tmux_backend("off"))
+        self.assertEqual(km._version_info()["tmuxBackend"], "off")
+
+    def test_the_settings_route_applies_and_acks(self):
+        res = km._apply_judge_settings({"tmuxBackend": "on"})
+        self.assertEqual(res["tmuxBackend"], "on")
+        self.assertEqual(jd._state_str("tmux-backend", "off"), "on")
+        res = km._apply_judge_settings({"tmuxBackend": "maybe"})
+        self.assertEqual(res["tmuxBackend"], "on", "an invalid value is ignored and the ack shows what stands")
+        res = km._apply_judge_settings({"tmuxBackend": "off"})
+        self.assertEqual(res["tmuxBackend"], "off")
+
+    def test_the_socket_op_stores_on_off_propagates_and_orders_by_gesture(self):
+        # the gear's checkbox posts a boolean; the kernel stores on/off and fans the applied value out
+        self.assertEqual(self._ws({"type": "setTmuxBackend", "enabled": True, "gt": T_NEW}), [])
+        self.assertEqual(jd._state_str("tmux-backend", "off"), "on")
+        self.assertEqual(self.propagated, [{"tmuxBackend": "on", "gt": T_NEW}])
+        reply = [m for m in self._ws({"type": "requestSessions"}) if m.get("type") == "sessionList"]
+        self.assertIs(reply[0]["tmuxBackend"], True, "the picker's reply now offers it")
+        # an OLDER gesture stands down: nothing applied, nothing propagated, the delivering socket hears it
+        sent = self._ws({"type": "setTmuxBackend", "enabled": False, "gt": T_OLD})
+        self.assertEqual(jd._state_str("tmux-backend", "off"), "on")
+        self.assertEqual(len(self.propagated), 1)
+        self.assertEqual([m["setting"] for m in sent if m.get("type") == "settingStale"], ["tmux-backend"])
+        # a newer one applies and turns it off again
+        self._ws({"type": "setTmuxBackend", "enabled": False, "gt": T_NEW + 1})
+        self.assertEqual(jd._state_str("tmux-backend", "off"), "off")
+        self.assertEqual(self.propagated[-1], {"tmuxBackend": "off", "gt": T_NEW + 1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/auth-selector.test.ts
+++ b/ui/webview/auth-selector.test.ts
@@ -29,7 +29,7 @@ test("the picker's Billing row shows for SDK whenever availability is known", ()
   // (pickerBackendChoice reads the Backend row's chip alone since tab groups, 2026-09-04 — the Tags
   // row wears the same chip grammar, and a selected tag must never read as the backend)
   assert.match(RENDER, /const show = !pickMode && !!\(a && \(a\.login \|\| a\.key\)\) && pickerBackendChoice\(\) === "sdk";/);
-  assert.match(RENDER, /function pickerBackendChoice\(\): string \{\s*\n\s*const beSel = document\.querySelector\("#picker \.picker-backend:not\(\.picker-host\):not\(\.picker-auth\):not\(\.picker-tags\) \.picker-be-opt\.sel"\) as HTMLElement \| null;\s*\n\s*return beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend;/);
+  assert.match(RENDER, /function pickerBackendChoice\(\): string \{\s*\n\s*const beSel = document\.querySelector\("#picker \.picker-backend:not\(\.picker-host\):not\(\.picker-auth\):not\(\.picker-tags\) \.picker-be-opt\.sel"\) as HTMLElement \| null;\s*\n\s*return beSel\?\.dataset\.be \|\| effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);/);
   assert.match(RENDER, /const both = !!\(a!\.login && a!\.key\);/);
   assert.match(RENDER, /auWrap\.style\.display = "none";\s*\/\/ hidden until a sessionList reply carries authAvail/);
   assert.match(RENDER, /beWrap\.addEventListener\("click", \(\) => \{ syncPickerAuth\(\); syncPickerTags\(\); \}\);/);   // the Tags row follows the backend pick too (tab groups)

--- a/ui/webview/backend-names.test.ts
+++ b/ui/webview/backend-names.test.ts
@@ -1,0 +1,58 @@
+// The backends as the user reads them (T288, the user 2026-09-09): "Claude Code" (the default, no qualifier),
+// "Claude Code (tmux)" (offered only while the kernel setting is on) and "Codex"; the ids and the protocol are
+// unchanged. One module names them for the picker, the gear and the tooltip, so the surfaces cannot drift apart.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { BACKEND_LABEL, backendLabel, offeredBackends, effectiveDefaultBackend } from "./backend-names";
+
+const read = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", ...p), "utf8");
+const RENDER = read("ui", "webview", "render.ts");
+const GEAR = read("ui", "webview", "gear.js");
+
+test("the three names, and an unknown id reads as itself", () => {
+  assert.deepEqual(BACKEND_LABEL, { sdk: "Claude Code", tmux: "Claude Code (tmux)", codex: "Codex" });
+  assert.equal(backendLabel("sdk"), "Claude Code");
+  assert.equal(backendLabel("tmux"), "Claude Code (tmux)");
+  assert.equal(backendLabel("codex"), "Codex");
+  assert.equal(backendLabel("future"), "future", "never a lie, never blank");
+  assert.equal(backendLabel(null), "");
+  for (const label of Object.values(BACKEND_LABEL)) assert.doesNotMatch(label, /\bSDK\b/, "the word never reaches the user");
+});
+
+test("the offer: Claude Code (tmux) only while the setting is on; the default falls back to Claude Code", () => {
+  assert.deepEqual(offeredBackends(false), ["sdk", "codex"]);
+  assert.deepEqual(offeredBackends(true), ["sdk", "tmux", "codex"]);
+  assert.equal(effectiveDefaultBackend("tmux", false), "sdk", "a saved tmux default is set aside while the backend is off");
+  assert.equal(effectiveDefaultBackend("tmux", true), "tmux", "…and returns with the setting");
+  assert.equal(effectiveDefaultBackend("codex", false), "codex");
+  assert.equal(effectiveDefaultBackend("sdk", false), "sdk");
+  assert.equal(effectiveDefaultBackend(undefined, false), "sdk", "no preference is the default");
+  assert.equal(effectiveDefaultBackend("", true), "sdk");
+});
+
+test("no user-facing copy in the picker, the tooltip or the gear says SDK; every label comes from the shared names", () => {
+  // the picker toggles and the tooltip row read backendLabel; the gear's select spells the same three names
+  assert.match(RENDER, /mkBe\("sdk", backendLabel\("sdk"\)/);
+  assert.match(RENDER, /mkBe\("tmux", backendLabel\("tmux"\)/);
+  assert.match(RENDER, /mkBe\("codex", backendLabel\("codex"\)/);
+  assert.match(RENDER, /rows\.push\(\["Backend", backendLabel\(be\)\]\)/, "the tab tooltip's Backend row");
+  assert.match(GEAR, /<option value=sdk>Claude Code<\/option><option value=tmux>Claude Code \(tmux\)<\/option><option value=codex>Codex<\/option>/);
+  // the word "SDK" in a string a person reads: the picker tips, the tooltip row, the gear's HTML. Comments and
+  // identifiers (status.backend === "sdk", sdkOnly) are not copy; only quoted strings count here.
+  const pickerTips = [...RENDER.matchAll(/mkBe\("[a-z]+", backendLabel\("[a-z]+"\), "([^"]*)"\)/g)].map((m) => m[1]);
+  assert.equal(pickerTips.length, 3);
+  for (const tip of pickerTips) assert.doesNotMatch(tip, /\bSDK\b/, tip);
+  // …and every quoted string in the picker's builder (the Tags note among them, the review's find)
+  const picker = RENDER.slice(RENDER.indexOf('const beWrap = el("div", "picker-backend")'), RENDER.indexOf("actions.appendChild(newSess)"));
+  assert.ok(picker.length > 1000 && picker.length < 40000, "the picker's builder located");
+  for (const m of picker.matchAll(/"([^"\n]*)"|`([^`\n]*)`/g)) assert.doesNotMatch(m[1] || m[2] || "", /\bSDK\b/, (m[1] || m[2] || "").slice(0, 80));
+  // the kernel's own copy that names a backend to the user (warn toasts, refusals) reads the shared names too
+  const KERNEL = read("kernel", "kernel.py");
+  for (const phrase of ["needs the SDK backend", "need an SDK or Codex session", "needs an SDK session", "runs on tmux, so there is nothing", "tmux sessions still work"])
+    assert.ok(!KERNEL.includes(phrase), "kernel copy still says: " + phrase);
+  const gearHtml = GEAR.slice(0, GEAR.indexOf("var gclock") > 0 ? GEAR.length : GEAR.length);
+  const userStrings = [...gearHtml.matchAll(/'([^'\n]*<span class=rs-sub>[^'\n]*)'/g)].map((m) => m[1]);
+  for (const s of userStrings) assert.doesNotMatch(s, /\bSDK\b/, s.slice(0, 80));
+});

--- a/ui/webview/backend-names.ts
+++ b/ui/webview/backend-names.ts
@@ -1,0 +1,25 @@
+// The backends as the user reads them (T288, the user 2026-09-09): the internal ids ("sdk", "tmux", "codex") and
+// the kernel protocol are unchanged; every label a person sees comes from here, so the picker toggles, the
+// gear's Default backend list, the tab tooltip's Backend row and any chip agree. The default needs no
+// qualifier, so the word "SDK" appears in no user-facing copy: it is "Claude Code"; the terminal-driven
+// variant is "Claude Code (tmux)"; the OpenAI agent is "Codex".
+export type BackendId = "sdk" | "tmux" | "codex";
+export const BACKEND_LABEL: Readonly<Record<BackendId, string>> = { sdk: "Claude Code", tmux: "Claude Code (tmux)", codex: "Codex" };
+
+/** The label for a backend id; an unknown id reads as itself (never a lie, never blank). */
+export function backendLabel(be: string | null | undefined): string {
+  return (be && (BACKEND_LABEL as Record<string, string>)[be]) || String(be || "");
+}
+
+/** What the picker OFFERS: "Claude Code (tmux)" only while the kernel setting says so (off by default). The
+ *  setting gates the offer alone; an existing tmux session keeps working and keeps its label whatever it says. */
+export function offeredBackends(tmuxOn: boolean): BackendId[] {
+  return tmuxOn ? ["sdk", "tmux", "codex"] : ["sdk", "codex"];
+}
+
+/** The default a new session starts from: the saved preference when it is on offer, else Claude Code. A saved
+ *  default of tmux while the tmux backend is off is set aside, not erased: it returns when the setting comes back. */
+export function effectiveDefaultBackend(pref: string | null | undefined, tmuxOn: boolean): BackendId {
+  const p = (pref || "sdk") as BackendId;
+  return (offeredBackends(tmuxOn) as string[]).includes(p) ? p : "sdk";
+}

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -78,7 +78,8 @@ const KERNEL_SETTING = new Set(["setAutoNudge", "setJudgeModel", "setIndexModel"
                                 "setJudgeConcurrency",   // T277: the judges' pool width, one value across machines
                                 "setDistillModel", "setDistillEffort", "setFileEditing",
                                 "setCompactSuggest",
-                                "setCommentModel", "setCommentEffort", "setCommentFast"]);
+                                "setCommentModel", "setCommentEffort", "setCommentFast",
+                                "setTmuxBackend"]);   // T288: the tmux backend's offer, one value across machines
 
 /** Return a COPY of an inbound message with every session-id field prefixed by `host`. The local host
  *  ("") is the identity transform, so local messages are untouched. Unknown fields pass through. */

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -21,6 +21,7 @@
 // into the HTML before — /models was already the single source of truth).
 
 var gclock = require('./gesture-clock.js');   // every `gt` below is minted here (see that file)
+var BN = require('./backend-names.ts');   // the backends' user-facing names and the offer rule (T288)
 function kb() { return (typeof window !== 'undefined' && window.__rompKernelBase) || ''; }
 function ku(path) {
   var tok = (typeof window !== 'undefined' && window.__rompKernelToken) || '';
@@ -70,10 +71,10 @@ var GEAR_HTML =
   "<button id=rs-defaultdir-browse type=button style='flex:0 0 auto;cursor:pointer;background:var(--btn-bg, #2a2a2a);color:var(--fg, #ccc);border:1px solid var(--hairline, #3a3a3a);border-radius:5px;padding:3px 8px'>Browse…</button>" +
   '</div></span></div>' +
   "<div class='rs-row rs-sep' style='cursor:default'><span style='flex:1 1 auto'><b>Default backend</b>" +
-  '<span class=rs-sub>What the + button uses for a NEW session — tmux drives a terminal pane; SDK runs via the Agent SDK; Codex runs an OpenAI Codex agent (docs/codex.md). All kinds run side by side; this only sets the default.</span>' +
+  '<span class=rs-sub>What the + button uses for a NEW session. Claude Code runs the session through romp itself; Claude Code (tmux) drives a terminal pane and is on offer only while the tmux backend is enabled (Updates & debug); Codex runs an OpenAI Codex agent (docs/codex.md). All kinds run side by side; this only sets the default.</span>' +
   "<select id=rs-backend style='display:none'>" +
-  '<option value=sdk>SDK</option><option value=tmux>tmux (terminal)</option><option value=codex>Codex</option>' +
-  '</select></span></div>' +
+  '<option value=sdk>Claude Code</option><option value=tmux>Claude Code (tmux)</option><option value=codex>Codex</option>' +
+  '</select><span id=rs-backend-note class=rs-sub hidden></span></span></div>' +
   "<label class='rs-row rs-sep'><input type=checkbox id=rs-autonudge>" +
   '<span><b>Auto Nudge</b><span class=rs-mixed id=rs-autonudge-split hidden></span>' +
   '<span class=rs-sub id=rs-autonudge-sub>' + AUTONUDGE_SUB + '</span>' +
@@ -88,7 +89,7 @@ var GEAR_HTML =
   '</span></label>' +
   "<label class='rs-row'><input type=checkbox id=rs-thinksum>" +
   '<span><b>Thinking summaries</b>' +
-  '<span class=rs-sub>For every new SDK session, ask the API for reasoning summaries and show them in the chat, folded to two lines (click to expand). Compact transcript still hides them. If thinking was turned off for this install, this turns adaptive thinking on as well. A running session picks the change up at its next reconnect: an effort or billing switch, the first fast-mode opt-in, or a kernel restart. Switching the model applies live and does not reconnect. Off by default; this kernel keeps its own copy.</span>' +
+  '<span class=rs-sub>For every new Claude Code session, ask the API for reasoning summaries and show them in the chat, folded to two lines (click to expand). Compact transcript still hides them. If thinking was turned off for this install, this turns adaptive thinking on as well. A running session picks the change up at its next reconnect: an effort or billing switch, the first fast-mode opt-in, or a kernel restart. Switching the model applies live and does not reconnect. Off by default; this kernel keeps its own copy.</span>' +
   '</span></label>' +
   "<label class='rs-row'><input type=checkbox id=rs-fileedit>" +
   '<span><b>File editing</b><span class=rs-mixed hidden></span>' +
@@ -162,6 +163,10 @@ var GEAR_HTML =
   "<select id=rs-updates style='display:none'>" +
   '<option value=ask>Check and ask</option><option value=auto>Install automatically</option><option value=off>Off</option>' +
   '</select></span></div>' +
+  "<label class=rs-row><input type=checkbox id=rs-tmuxbackend>" +
+  '<span><b>Enable Claude Code tmux backend <span class=rs-mixed hidden></span></b>' +
+  '<span class=rs-sub>Offers Claude Code (tmux) in the + picker and the Default backend list: a Claude Code session in a terminal pane that romp follows by reading the terminal, less reliable than Claude Code itself. Off by default. Sessions already running on it keep working either way; this only sets what the picker offers. Follows to every connected machine\'s kernel.</span>' +
+  '</span></label>' +
   
   '<div class=rs-judges>' +
   '<label class=rs-row rs-half><input type=checkbox id=rs-judges-index>' +
@@ -232,6 +237,7 @@ function initGear(post) {
     dm = document.getElementById('rs-distillmodel'), de = document.getElementById('rs-distilleffort'),
     cmm = document.getElementById('rs-cmtmodel'), cme = document.getElementById('rs-cmteffort'),
     cmf = document.getElementById('rs-cmtfast'),
+    tb = document.getElementById('rs-tmuxbackend'), bkn = document.getElementById('rs-backend-note'),
     fe = document.getElementById('rs-fileedit'),
     ths = document.getElementById('rs-thinksum'),
     ans = document.getElementById('rs-autonudge-split'), asub = document.getElementById('rs-autonudge-sub');
@@ -724,6 +730,23 @@ function initGear(post) {
   if (cmm) cmm.addEventListener('change', function () { post({ type: 'setCommentModel', model: cmm.value, gt: gclock.stamp('comment-model') }); cmtFastGate(true); });
   if (cme) cme.addEventListener('change', function () { post({ type: 'setCommentEffort', effort: cme.value, gt: gclock.stamp('comment-effort') }); });
   if (cmf) cmf.addEventListener('change', function () { post({ type: 'setCommentFast', fast: cmf.checked ? 'on' : 'session', gt: gclock.stamp('comment-fast') }); });
+  // the tmux backend's offer (T288): a kernel setting like the judge knobs (stamped, propagated); the Default
+  // backend list repaints at once so the pick and the offer never disagree in the same modal
+  if (tb) tb.addEventListener('change', function () { post({ type: 'setTmuxBackend', enabled: tb.checked, gt: gclock.stamp('tmux-backend') }); paintBackendOffer(tb.checked); });
+  // "Claude Code (tmux)" is in the Default backend list only while the setting is on; a saved default of tmux
+  // while it is off is set aside (the select shows Claude Code and the note says so), never erased: it returns
+  // with the setting. The option is removed rather than hidden: the facade paints from sel.options.
+  function paintBackendOffer(on) {
+    if (!bk) return;
+    var opt = bk.querySelector('option[value=tmux]');
+    if (on && !opt) { opt = document.createElement('option'); opt.value = 'tmux'; opt.textContent = BN.backendLabel('tmux'); bk.insertBefore(opt, bk.querySelector('option[value=codex]')); }
+    else if (!on && opt) opt.remove();
+    var pref = load().backend || 'sdk', eff = BN.effectiveDefaultBackend(pref, on);
+    bk.value = eff;
+    if (bkn) { bkn.hidden = eff === pref; bkn.textContent = eff === pref ? '' : 'Your saved default, ' + BN.backendLabel(pref) + ', is set aside while the tmux backend is off; new sessions use ' + BN.backendLabel(eff) + '.'; }
+    repaintSelectPicks();
+  }
+  paintBackendOffer(tb ? tb.checked : false);   // the list assumes OFF until a kernel says on (the picker's rule), so the two never disagree on the offer
   // feed-colormap preview bar: a horizontal gradient of the SELECTED map's stops (mirrors render.ts COLORMAPS).
   var CMAPS = { aurora: [[84, 178, 4], [0, 180, 115], [35, 175, 156], [66, 169, 176], [25, 168, 201], [14, 164, 227], [74, 155, 241], [113, 145, 244], [144, 136, 240]],
     hawaii: [[140, 2, 115], [146, 46, 85], [151, 78, 62], [155, 111, 40], [156, 150, 28], [137, 189, 74], [107, 212, 142], [103, 233, 213], [179, 242, 253]],
@@ -761,7 +784,7 @@ function initGear(post) {
   if (plBtn) plBtn.addEventListener('click', function (e) { e.stopPropagation(); plBuild(); if (plList) plList.hidden = !plList.hidden; });
   document.addEventListener('click', function (e) { var w = document.getElementById('rs-pal');
     if (plList && !plList.hidden && w && !w.contains(e.target)) plList.hidden = true; });
-  if (bk) bk.addEventListener('change', function () { var s = load(); s.backend = bk.value; save(s); });   // webview-local pref read at createSession time
+  if (bk) bk.addEventListener('change', function () { var s = load(); s.backend = bk.value; save(s); paintBackendOffer(tb ? tb.checked : false); });   // webview-local pref read at createSession time; the set-aside note follows the new pick (T288)
   if (dd) dd.addEventListener('change', function () { var v = dd.value.trim(); var s = load(); s.defaultDir = v; save(s);
     post({ type: 'setDefaultDir', value: v }); });   // persist kernel-side: _default_create_dir reads this file FIRST
   var ddb = document.getElementById('rs-defaultdir-browse');
@@ -787,7 +810,7 @@ function initGear(post) {
     'index-model': 'Indexing model', 'index-effort': 'Indexing effort', 'judge-concurrency': 'Judge concurrency',
     'distill-model': 'Distilling model', 'distill-effort': 'Distilling effort',
     'comment-model': 'Comment model', 'comment-effort': 'Comment effort',
-    'comment-fast': 'Fast comment threads', 'thinking-summaries': 'Thinking summaries' };
+    'comment-fast': 'Fast comment threads', 'tmux-backend': 'Claude Code tmux backend', 'thinking-summaries': 'Thinking summaries' };
   // store name → the message type that sets it: the whitelist for the toast's Apply anyway (a frame
   // may re-issue the one setting it names, nothing else) and the completeness pin's map
   // (gear.test.ts checks every emitter stamps through the clock under its own store name)
@@ -796,7 +819,8 @@ function initGear(post) {
     'judge-model': 'setJudgeModel', 'judge-effort': 'setJudgeEffort',
     'index-model': 'setIndexModel', 'index-effort': 'setIndexEffort', 'judge-concurrency': 'setJudgeConcurrency',
     'distill-model': 'setDistillModel', 'distill-effort': 'setDistillEffort',
-    'comment-model': 'setCommentModel', 'comment-effort': 'setCommentEffort', 'comment-fast': 'setCommentFast' };
+    'comment-model': 'setCommentModel', 'comment-effort': 'setCommentEffort', 'comment-fast': 'setCommentFast',
+    'tmux-backend': 'setTmuxBackend' };
   // store name → the words its select shows for the sentinel options whose value is not the word. The
   // effort selects' Default is the EMPTY value (no effort flag), which read as no value at all, so a
   // refused Default pick drew the value-less copy and a plain Apply anyway — in the frozen-tab case, the
@@ -1070,7 +1094,7 @@ function initGear(post) {
     [['updateMode', upm], ['judgeModel', jm], ['judgeEffort', je], ['indexModel', im],
      ['indexEffort', ie], ['judgeConcurrency', jc], ['distillModel', dm], ['distillEffort', de], ['fileEditing', fe],
      ['compactSuggest', csg],
-     ['commentModel', cmm], ['commentEffort', cme], ['commentFast', cmf]].forEach(function (pair) {
+     ['commentModel', cmm], ['commentEffort', cme], ['commentFast', cmf], ['tmuxBackend', tb]].forEach(function (pair) {
       var key = pair[0], el = pair[1];
       if (!el) return;
       var row = el.closest ? el.closest('.rs-row') : null;
@@ -1115,6 +1139,7 @@ function initGear(post) {
     if (typeof v.commentModel === 'string') setShow(cmm, v.commentModel);   // RAW: "session" selects Same as the session
     if (typeof v.commentEffort === 'string') setShow(cme, v.commentEffort);
     if (cmf && typeof v.commentFast === 'string') cmf.checked = v.commentFast === 'on';
+    if (tb && typeof v.tmuxBackend === 'string') { tb.checked = v.tmuxBackend === 'on'; paintBackendOffer(tb.checked); }   // T288: the offer, then the list follows it
     cmtFastGate(false);
     if (dd && typeof v.defaultDir === 'string') dd.value = v.defaultDir;   // the kernel's persisted default is authoritative
     // Browse… draws on the KERNEL's screen, and a kernel with no desktop has none — the click used to
@@ -1162,7 +1187,7 @@ function initGear(post) {
     // settings-open, which is what un-hides #feed-pane when the feed is toggled off — measuring first
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
-    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); paintBackendOffer(tb ? tb.checked : false); if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   // The shortcuts row: the web shell (same-origin parent) gets the customize link — it opens the

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -45,7 +45,7 @@ test("every gear fetch routes through the kernel base + token (VS Code's webview
 test("the gear posts kernel ops through ONE shared channel (never re-acquires the VS Code API)", () => {
   assert.ok(!GEAR.includes("acquireVsCodeApi"), "a second acquire throws in a real webview");
   for (const op of ["setAutoNudge", "setJudgeModel", "setIndexModel", "setJudgeEffort", "setIndexEffort", "setJudgeConcurrency",
-    "setDistillModel", "setDistillEffort", "setCommentModel", "setCommentEffort", "setCommentFast",
+    "setDistillModel", "setDistillEffort", "setCommentModel", "setCommentEffort", "setCommentFast", "setTmuxBackend",
     "setFileEditing", "setColormap", "setPalette", "setDefaultDir", "browseDir"])
     assert.ok(GEAR.includes(`'${op}'`), `gear must post ${op}`);
 });

--- a/ui/webview/picker-backend.test.ts
+++ b/ui/webview/picker-backend.test.ts
@@ -1,5 +1,8 @@
-// A per-session backend picker on the + dialog (the user 2026-06-23): a tmux | SDK segmented toggle,
-// defaulting to the gear's Default backend but overridable for THIS new session. Source-pin over render.ts.
+// A per-session backend picker on the + dialog (the user 2026-06-23): a segmented toggle, defaulting to the
+// gear's Default backend but overridable for THIS new session. Since T288 (the user 2026-09-09) the toggles
+// read "Claude Code", "Claude Code (tmux)" and "Codex" from backend-names.ts, and "Claude Code (tmux)" is on
+// offer only while the kernel setting says so (off by default; the local sessionList reply carries it).
+// Source-pin over render.ts.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -8,20 +11,44 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
-test("the + dialog builds a SDK | tmux | Codex backend toggle, hidden in pick-mode", () => {
+test("the + dialog builds a Claude Code | Claude Code (tmux) | Codex backend toggle from the shared names, hidden in pick-mode", () => {
+  assert.match(RENDER, /import \{ backendLabel, effectiveDefaultBackend \} from "\.\/backend-names";/);
   assert.match(RENDER, /const beWrap = el\("div", "picker-backend"\)/);
-  assert.match(RENDER, /mkBe\("tmux", "tmux"/);
-  assert.match(RENDER, /mkBe\("sdk", "SDK"/);
-  assert.match(RENDER, /mkBe\("codex", "Codex"/);
+  assert.match(RENDER, /mkBe\("sdk", backendLabel\("sdk"\)/);
+  assert.match(RENDER, /mkBe\("tmux", backendLabel\("tmux"\)/);
+  assert.match(RENDER, /mkBe\("codex", backendLabel\("codex"\)/);
   assert.match(RENDER, /box\.appendChild\(beWrap\)/);
-  // hidden + reset to the gear default each open (overridable for this session)
+  // hidden + reset to the EFFECTIVE default each open (a saved tmux default while the backend is off → Claude Code)
   assert.match(RENDER, /beWrapEl\.style\.display = pick \? "none" : ""/);
-  assert.match(RENDER, /\.classList\.toggle\("sel", \(x as HTMLElement\)\.dataset\.be === def\)/);
+  assert.match(RENDER, /const def = effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);/);
+  assert.match(RENDER, /\.classList\.toggle\("sel", \(x as HTMLElement\)\.dataset\.be === def\)\);\s*\n\s*syncPickerBackends\(\);/, "the offer is applied on every open");
 });
 
-test("createSession uses the picked backend, falling back to the gear default", () => {
+test("the tmux toggle is on offer only while the kernel setting is on: absent when off, present when on (T288)", () => {
+  // the setting rides the LOCAL sessionList reply; assumed off until a kernel says on
+  assert.match(RENDER, /let kernelTmuxBackend = false;/);
+  assert.match(RENDER, /if \(typeof m\.tmuxBackend === "boolean" && !from\) \{ kernelTmuxBackend = m\.tmuxBackend; syncPickerBackends\(\); \}/);
+  const sync = RENDER.slice(RENDER.indexOf("function syncPickerBackends(): void {"), RENDER.indexOf("\n}\n", RENDER.indexOf("function syncPickerBackends(): void {")));
+  assert.match(sync, /const tmuxBtn = wrap\.querySelector\('\.picker-be-opt\[data-be="tmux"\]'\) as HTMLElement \| null;/);
+  assert.match(sync, /tmuxBtn\.style\.display = kernelTmuxBackend \? "" : "none";/, "off → the toggle is not shown; on → it is");
+  // the reply lands AFTER the open reset the row: the effective default is re-applied while the user has not
+  // picked this open (a saved tmux default lands once the toggle is on offer), and a selected toggle that went
+  // off offer always hands the selection back, so the create never sends a backend the picker does not show;
+  // an explicit pick made this open is never undone
+  assert.match(RENDER, /let pickerBackendPicked = false;/);
+  assert.match(RENDER, /b\.addEventListener\("click", \(\) => \{ pickerBackendPicked = true; beWrap\.querySelectorAll/, "a click is an explicit pick");
+  assert.match(RENDER, /pickerBackendPicked = false;   \/\/ a fresh open/, "each open forgets the last pick");
+  assert.match(sync, /const def = effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);\s*\n\s*const cur = wrap\.querySelector\("\.picker-be-opt\.sel"\) as HTMLElement \| null;\s*\n\s*if \(!pickerBackendPicked \|\| \(!kernelTmuxBackend && cur\?\.dataset\.be === "tmux"\)\) \{/);
+  assert.match(sync, /syncPickerAuth\(\); syncPickerTags\(\);/, "the Billing and Tags rows follow the new choice");
+  // the kernel's reply carries the setting as a boolean, off by default
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(KERNEL, /"tmuxBackend": jd\._state_str\("tmux-backend", "off"\) == "on",/, "the sessionList reply");
+});
+
+test("createSession uses the picked backend, falling back to the EFFECTIVE gear default", () => {
   assert.match(RENDER, /const beSel = beWrap\.querySelector\("\.picker-be-opt\.sel"\)/);
-  assert.match(RENDER, /const backend = beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend;/);
+  assert.match(RENDER, /const backend = beSel\?\.dataset\.be \|\| effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);/);
+  assert.match(RENDER, /return beSel\?\.dataset\.be \|\| effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);/, "pickerBackendChoice too");
   assert.match(RENDER, /startCreate\(\{ name, backend,/);
 });
 

--- a/ui/webview/picker-dir.test.ts
+++ b/ui/webview/picker-dir.test.ts
@@ -32,7 +32,7 @@ test("createSession carries the chosen dir, alongside name + backend", () => {
   // 2026-06-23). The whole request goes through startCreate, which remembers it so a missing directory
   // can be created and the SAME create re-sent (the user 2026-07-28).
   // (…and the Tags row's picks since tab groups, 2026-09-04 — omitted like auth when nothing is picked)
-  assert.match(RENDER, /const backend = beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend;/);
+  assert.match(RENDER, /const backend = beSel\?\.dataset\.be \|\| effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);/);   // the EFFECTIVE default since T288
   assert.match(RENDER, /startCreate\(\{ name, backend,\s*\n\s*dir: dirInput\.value\.trim\(\), host: hostSel, \.\.\.\(auth \? \{ auth \} : \{\}\), \.\.\.\(tags\.length \? \{ tags \} : \{\}\) \}\)/);
   assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "createSession", \.\.\.req/);
 });

--- a/ui/webview/render-settings.test.ts
+++ b/ui/webview/render-settings.test.ts
@@ -40,6 +40,6 @@ test("the chat has NO gear of its own — it only consumes the shared setting (g
 
 test("the + New session button sends the picker's backend toggle, defaulting to the gear's (the user 2026-06-23)", () => {
   // the per-session toggle wins; it RESETS to the gear default (read fresh via loadSettings()) on each open
-  assert.match(RENDER, /const backend = beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend;\s*\n[\s\S]{0,400}startCreate\(\{ name, backend,/);
-  assert.match(RENDER, /const def = loadSettings\(\)\.backend \|\| "tmux";/);   // toggle defaults to the gear setting
+  assert.match(RENDER, /const backend = beSel\?\.dataset\.be \|\| effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);\s*\n[\s\S]{0,400}startCreate\(\{ name, backend,/);
+  assert.match(RENDER, /const def = effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);/);   // toggle defaults to the gear setting, as offered (T288)
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -25,6 +25,7 @@ import { markerLabel, dayContext } from "./time-marker";
 import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
 import { senderKind, SenderKind } from "./sender-identity";
 import { loadSettings, onExternalSettingsChange, installSettingsSync, type RompSettings } from "./settings";
+import { backendLabel, effectiveDefaultBackend } from "./backend-names";
 import { delegate } from "./actions";
 import { awaitWord, awaitBreakdown, groupRows, GROUP_TITLE, workingFor, type AwaitRow } from "./spin-caption";
 import { isClearCmd, openTopTitles, clearConfirmDetail, endConfirmDetail } from "./clear-confirm";
@@ -5131,7 +5132,7 @@ function showTabTip(tab: HTMLElement, s: Session): void {
   if (s.status.effort) rows.push(["Effort", s.status.effort]);
   // Backend is a plain labelled FIELD now, under the others (the user 2026-07-08 — no longer a coloured
   // "SDK backend" badge at the top of the tooltip; it reads as one of the session's config fields).
-  if (be === "sdk" || be === "tmux" || be === "codex") rows.push(["Backend", be === "sdk" ? "SDK" : be === "codex" ? "Codex" : "tmux"]);
+  if (be === "sdk" || be === "tmux" || be === "codex") rows.push(["Backend", backendLabel(be)]);   // the shared names (T288); a tmux session keeps its label whatever the offer setting says
   // Billing: whether this tab bills the API key or the Claude login — and WHICH login account (the
   // user 2026-08-09: shown whenever the backend reports it, one-auth machines included; only a tmux
   // session, whose CLI env romp does not control, reports nothing). No key material, ever.
@@ -7047,6 +7048,15 @@ function dirPrefill(host: string): string {
 // The capability rides in on the local sessionList; assume yes until a kernel says otherwise, so an older
 // kernel that doesn't send it keeps the button it always had.
 let kernelNativeDialogs = true;
+// Whether the + picker OFFERS "Claude Code (tmux)" (T288, the user 2026-09-09): a kernel setting, off by default,
+// carried on the local sessionList reply. It gates the offer alone: an existing tmux session keeps working and
+// keeps its tooltip label whatever it says. Assumed off until a kernel says on (an older kernel sends none).
+let kernelTmuxBackend = false;
+// whether the user clicked a Backend toggle during THIS open of the picker: the sessionList reply, which lands after
+// the open reset the row, re-applies the effective default only while no explicit pick stands (the review's find:
+// a saved tmux default with the setting on landed on Claude Code on the first open, since the reset ran before
+// the reply said the toggle was on offer), and never undoes a pick the user made
+let pickerBackendPicked = false;
 
 // The two cases are shown differently, because one of them can change and the other cannot. A REMOTE host
 // is one click back to local, so the button stays in place, disabled, saying so. A kernel with no desktop
@@ -7090,7 +7100,27 @@ let pickerAuthAvail: AuthAvail | null = null;
 // same chip grammar, and a selected tag chip must never read as a backend)
 function pickerBackendChoice(): string {
   const beSel = document.querySelector("#picker .picker-backend:not(.picker-host):not(.picker-auth):not(.picker-tags) .picker-be-opt.sel") as HTMLElement | null;
-  return beSel?.dataset.be || loadSettings().backend;
+  return beSel?.dataset.be || effectiveDefaultBackend(loadSettings().backend, kernelTmuxBackend);
+}
+
+// The Backend row offers "Claude Code (tmux)" only while the kernel setting is on (T288): the toggle hides
+// otherwise, and a hidden toggle that was selected hands the selection to the effective default, so the create
+// can never send a backend the picker does not show. Re-run on every open and on the local sessionList reply.
+function syncPickerBackends(): void {
+  const wrap = document.querySelector("#picker .picker-backend:not(.picker-host):not(.picker-auth):not(.picker-tags)") as HTMLElement | null;
+  if (!wrap) return;
+  const tmuxBtn = wrap.querySelector('.picker-be-opt[data-be="tmux"]') as HTMLElement | null;
+  if (tmuxBtn) tmuxBtn.style.display = kernelTmuxBackend ? "" : "none";
+  // the effective default is re-applied while the user has not picked this open (so a saved tmux default lands
+  // once the reply says the toggle is on offer), and always when the selected toggle went off offer
+  const def = effectiveDefaultBackend(loadSettings().backend, kernelTmuxBackend);
+  const cur = wrap.querySelector(".picker-be-opt.sel") as HTMLElement | null;
+  if (!pickerBackendPicked || (!kernelTmuxBackend && cur?.dataset.be === "tmux")) {
+    if (cur?.dataset.be !== def) {
+      wrap.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.toggle("sel", (x as HTMLElement).dataset.be === def));
+      syncPickerAuth(); syncPickerTags();
+    }
+  }
 }
 
 // the backends whose create takes `tags`: the kernel applies parent/tags on an SDK or a Codex create
@@ -7404,12 +7434,14 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     const mkBe = (val: string, txt: string, tip: string) => {
       const b = el("button", "picker-be-opt") as HTMLButtonElement;
       b.type = "button"; b.textContent = txt; b.title = tip; b.dataset.be = val;
-      b.addEventListener("click", () => beWrap.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.toggle("sel", x === b)));
+      b.addEventListener("click", () => { pickerBackendPicked = true; beWrap.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.toggle("sel", x === b)); });
       return b;
     };
-    beWrap.append(beLabel, mkBe("sdk", "SDK", "Runs via the Claude Agent SDK."),   // not "headless" — same full chat UI (the user 2026-07-12)
-                  mkBe("tmux", "tmux", "Drives a real terminal pane (tmux)."),   // SDK first — the de-facto default (the user 2026-07-02)
-                  mkBe("codex", "Codex", "Runs an OpenAI Codex agent (the host needs romp-codex-setup + codex login)."));
+    // the labels come from backend-names.ts (T288): "Claude Code" (the default, no qualifier), "Claude Code (tmux)"
+    // (offered only while the kernel setting is on — syncPickerBackends), "Codex"; the ids are unchanged
+    beWrap.append(beLabel, mkBe("sdk", backendLabel("sdk"), "The default: romp runs the Claude Code session itself, with the same full chat."),   // first — the de-facto default (the user 2026-07-02)
+                  mkBe("tmux", backendLabel("tmux"), "Drives a Claude Code session in a real terminal pane (tmux); offered while the tmux backend is enabled in the gear."),
+                  mkBe("codex", backendLabel("codex"), "Runs an OpenAI Codex agent (the host needs romp-codex-setup + codex login)."));
     // the billing row exists only for SDK sessions, the Tags row only for backends whose create takes
     // tags (backendTakesTags) — re-decide both on every backend toggle
     beWrap.addEventListener("click", () => { syncPickerAuth(); syncPickerTags(); });
@@ -7443,7 +7475,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     const tgLabel = el("span", "picker-backend-label"); tgLabel.textContent = "Tags";
     tgWrap.appendChild(tgLabel);
     const tgNote = el("span", "picker-auth-fixed picker-tags-note");   // the Billing row's written-out text style
-    tgNote.textContent = "Tags apply to SDK and Codex sessions";
+    tgNote.textContent = `Tags apply to ${backendLabel("sdk")} and ${backendLabel("codex")} sessions`;   // the shared names (T288)
     tgNote.style.display = "none";
     tgWrap.appendChild(tgNote);
     // per-session HOST picker (federation, the user 2026-07-02): local | each attached SSH host — the new
@@ -7487,7 +7519,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
       // create as names; the owning kernel resolves them by name, minting a missing one like POST /tag.
       // SDK and Codex creates (backendTakesTags) — a tmux create carries none (the row is disabled for
       // it, and the kernel refuses tags on a terminal create)
-      const backend = beSel?.dataset.be || loadSettings().backend;
+      const backend = beSel?.dataset.be || effectiveDefaultBackend(loadSettings().backend, kernelTmuxBackend);
       const tags = backendTakesTags(backend)
         ? Array.from(tgWrap.querySelectorAll<HTMLElement>(".picker-be-opt.sel")).map((x) => x.dataset.tag || "").filter(Boolean)
         : [];
@@ -7546,8 +7578,10 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
   const beWrapEl = overlay.querySelector(".picker-backend:not(.picker-host):not(.picker-auth)") as HTMLElement | null;
   if (beWrapEl) {   // reset the backend toggle to the gear default each open (overridable for this session)
     beWrapEl.style.display = pick ? "none" : "";
-    const def = loadSettings().backend || "tmux";
+    pickerBackendPicked = false;   // a fresh open: the row follows the effective default until the user picks
+    const def = effectiveDefaultBackend(loadSettings().backend, kernelTmuxBackend);   // a saved tmux default while it is off → Claude Code
     beWrapEl.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.toggle("sel", (x as HTMLElement).dataset.be === def));
+    syncPickerBackends();
   }
   const auWrapEl = overlay.querySelector(".picker-auth") as HTMLElement | null;
   if (auWrapEl) {   // fresh open: forget last time's pick + availability; the local sessionList reply re-arms it
@@ -14838,6 +14872,9 @@ listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: M
       kernelNativeDialogs = m.nativeDialogs;
       applyBrowseState(pickerHost());
     }
+    // the tmux backend's offer (T288): the LOCAL kernel's setting; the Backend row follows it while the picker
+    // is on screen (the reply lands after the open), and an older kernel that sends none leaves the row as it was
+    if (typeof m.tmuxBackend === "boolean" && !from) { kernelTmuxBackend = m.tmuxBackend; syncPickerBackends(); }
     // the selected host's billing choices ride its own list reply — this is what arms (or hides) the
     // picker's Billing row (the user 2026-08-08); an older kernel sends none and the row stays away
     pickerAuthAvail = (m.authAvail && typeof m.authAvail === "object") ? m.authAvail : null;

--- a/ui/webview/tab-backend-tooltip.test.ts
+++ b/ui/webview/tab-backend-tooltip.test.ts
@@ -24,8 +24,9 @@ test("the tab tooltip is a custom DOM tooltip shown on hover, not a native title
 });
 
 test("backend is a plain labelled FIELD ROW under the others — no coloured top badge (the user 2026-07-08)", () => {
-  // it's just another "Backend: SDK|tmux|Codex" row alongside Branch/Mode/Model/Effort, not a bold coloured badge
-  assert.match(RENDER, /rows\.push\(\["Backend", be === "sdk" \? "SDK" : be === "codex" \? "Codex" : "tmux"\]\)/);
+  // it's just another "Backend: Claude Code | Claude Code (tmux) | Codex" row alongside Branch/Mode/Model/Effort, not a
+  // bold coloured badge; the names come from backend-names.ts (T288), so a tmux session keeps its label whatever the offer says
+  assert.match(RENDER, /rows\.push\(\["Backend", backendLabel\(be\)\]\)/);
   assert.doesNotMatch(RENDER, /"tab-tip-be"/, "no dedicated backend-badge element");
   assert.doesNotMatch(RENDER, /be === "tmux" \? "#54B204" : "#1EA1EB"/, "no per-backend colour on the tooltip");
   assert.doesNotMatch(CSS, /\.tab-tip-be \b/, "the badge's CSS rule is gone");

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -297,7 +297,7 @@ test("the picker's Tags row is for SDK and Codex sessions: disabled behind a not
   assert.match(sync, /wrap\.classList\.toggle\("disabled", !takes\);/);
   assert.match(sync, /\.forEach\(\(b\) => \{ b\.disabled = !takes; \}\);/);
   assert.match(sync, /note\.style\.display = takes \? "none" : "";/);
-  assert.match(RENDER, /tgNote\.textContent = "Tags apply to SDK and Codex sessions";/);
+  assert.match(RENDER, /tgNote\.textContent = `Tags apply to \$\{backendLabel\("sdk"\)\} and \$\{backendLabel\("codex"\)\} sessions`;/, "the shared names (T288)");
   assert.match(RENDER, /beWrap\.addEventListener\("click", \(\) => \{ syncPickerAuth\(\); syncPickerTags\(\); \}\);/, "re-decided on every backend toggle");
   assert.match(RENDER, /syncPickerTags\(\);\s+\/\/ the backend toggle was just reset/, "…and on every open, after the backend reset");
   assert.match(RENDER, /const tags = backendTakesTags\(backend\)\s*\n\s*\? Array\.from\(tgWrap\.querySelectorAll<HTMLElement>\("\.picker-be-opt\.sel"\)\)/,

--- a/ui/webview/thinking-summaries.test.ts
+++ b/ui/webview/thinking-summaries.test.ts
@@ -48,7 +48,7 @@ test("the gear has a Thinking summaries checkbox among the kernel-side toggles, 
     "…between Conserve memory and File editing, with the other kernel-side toggles");
   const row = GEAR.slice(at, at + 1200);
   assert.match(row, /<b>Thinking summaries<\/b>/);
-  assert.ok(/new SDK session/.test(row) && /running session picks the change up at its next reconnect/.test(row),
+  assert.ok(/new Claude Code session/.test(row) && /running session picks the change up at its next reconnect/.test(row),   // the backend's name since T288
     "the sub-copy is honest that a running session is not switched live");
   // …and names the events that actually reconnect one (sdk_backend's request_reconnect callers), never a
   // model switch: set_model applies live over the SDK control channel and reconnects nothing, so copy that


### PR DESCRIPTION
Retire the tmux backend behind a setting, and rename the backends the way the user reads them (the user, 2026-09-09).

**The setting.** "Enable Claude Code tmux backend" is a kernel setting (`STATE/tmux-backend`, `on`/`off`, off by default), a checkbox in the settings panel's Updates & debug section. It is built the way the judge knobs are: a validated setter (`on`/`off` only), gesture stamps and stale stand-down, `/version` (top level and the cross-machine `settings` dict, so the mixed marks work), `/judge-settings` apply and ack, the `setTmuxBackend` socket op with propagation to every linked kernel, and the stamp store list. The picker learns the value from the local `sessionList` reply (a boolean), so an older kernel that sends none leaves the row as it was.

**What it gates.** Only what the picker OFFERS. With the setting off, the new-session picker's Backend row hides the Claude Code (tmux) toggle and the gear's Default backend list drops that option; a saved default of tmux falls back to Claude Code, and the gear's sub-line says the saved pick is set aside (not erased: it returns with the setting). A selected tmux toggle that goes off offer while the picker is open hands the selection to the effective default, so a create can never send a backend the picker does not show. Existing tmux sessions keep working and keep their tooltip label whatever the setting says; `romp new -t` still works; the ids (`sdk`, `tmux`, `codex`) and the kernel protocol are unchanged.

**The names.** One module, `ui/webview/backend-names.ts`, names the backends for every surface: **Claude Code** (the default, no qualifier), **Claude Code (tmux)**, **Codex**. The picker toggles, the gear's select and its sub-lines, the tab tooltip's Backend row and the docs read from it; the word "SDK" appears in no user-facing copy.

**Tests.** `backend-names.test.ts` (executed: the labels, the offer rule, the fallback, and a scan that no picker tip or gear sub-line says SDK); `picker-backend.test.ts` follows the new labels and gains the gated case (the tmux toggle absent when off, present when on; the sessionList adoption; the effective default on open and at create); `tests/test_tmux_backend_setting.py` (default off in `/version`, the settings dict, the ack and the sessionList reply; only `on`/`off` stored; the route applies and acks; the socket op stores, propagates and stands down a stale gesture); the gear select pin and the Updates & debug placement in `test_kernel_settings_sections.py`; the settings-list pins (gesture order, fan-out fragment, federation set, gear op list) updated.

**From the adversarial review, folded in before arming.** The socket op validates its boolean like every sibling (`_as_bool`, a malformed frame refused with a warn and written nowhere; the boolean-flag test's cases gain it, and its source pin now also catches a truthiness ternary). The kernel's own user-facing copy that named a backend (fork, threads, past-message edits, per-session env, tags and parent, the Agent SDK setup hint) reads the shared names, pinned. The picker's Tags note reads the shared names, and the names test now scans every quoted string in the picker's builder. The picker re-applies the effective default when the session-list reply lands unless the user picked this open, so a saved tmux default with the setting on lands on the first open too, and an explicit pick is never undone. The gear assumes the setting off until `/version` says on (the picker's rule), so the two cannot disagree on the offer, and the set-aside note follows a new Default backend pick.

**Docs.** `docs/guide.md` Session backends renamed and the setting explained; `docs/reference.md` gains a Session backends row under Configuration and renames the backend where it named it.

**Screenshots** (the picker with the setting off and on, the gear's Updates & debug section and the Default backend row) are in the maintainer's `~/romp-shots/t288/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
