### PR TITLE
Spend: a connect seeds the watermarks from the transcript's last cost-state record

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -821,7 +821,7 @@ def cost_state_watermarks(o):
     return {"total": float(total), "tokens": tokens}
 
 
-def last_cost_state(path):
+def last_cost_state(path, scan_bytes: int = 8 << 20):
     """The resumed transcript's LAST `cost-state` record, as the watermarks a CLI that restores it would
     hold (cost_state_watermarks), or None when the file has no such record or cannot be read.
 
@@ -851,16 +851,19 @@ def last_cost_state(path):
 
     Scans BACKWARDS in 64 KB chunks (a line split by a chunk edge is carried into the earlier chunk and
     reassembled) and stops at the first hit, so a transcript that carries the record costs a chunk or
-    two, and one that never carried it costs one sequential read of the whole file, on the event loop
-    at connect time."""
+    two. The scan is BOUNDED to the last `scan_bytes` (8 MB by default; last_record_uuid's tail read has
+    the same reason: a transcript can be tens of MB and this runs on the event loop at every connect):
+    a record older than that is treated as absent, which is the answer the print-mode CLI gives for its
+    own counters today (it restores nothing), so the two sides still agree (review find, 2026-09-09)."""
     marker = b'"cost-state"'
     try:
         with open(path, "rb") as f:
             f.seek(0, os.SEEK_END)
             pos = f.tell()
+            floor = max(0, pos - int(scan_bytes))   # the oldest byte the bounded scan may reach
             carry = b""
-            while pos > 0:
-                step = min(pos, 1 << 16)
+            while pos > floor:
+                step = min(pos - floor, 1 << 16)
                 pos -= step
                 f.seek(pos)
                 chunk = f.read(step) + carry    # carry: the later chunk's first-line fragment, which this

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -786,6 +786,109 @@ def last_record_uuid(path, tail_bytes: int = 262144) -> str:
     return ""
 
 
+# The first result after a connect whose cost delta exceeds this is traced as an INFO line in the settle
+# (SdkSession._on_message), never a problem. On the CLI as probed (print mode, 2026-09-06) a resumed
+# process starts its counters at zero: a resume neither restores a cost-state record nor arms its writer.
+# So a first delta this large is the turn's own cost, recorded right, with nothing for the user to act
+# on; a problem row here would send them to check a figure that is correct. The trace is for the day a
+# CLI restores cost history in print mode: then a first result carries the whole history in
+# total_cost_usd, and the figure is wrong only if that restore and the connect-time seed read different
+# files (last_cost_state).
+SANE_TURN_USD = 200.0
+
+
+def cost_state_watermarks(o):
+    """The watermarks a CLI would hold after restoring the `cost-state` transcript record `o`, or None
+    when `o` is not one or its total is unusable: {"total": float, "tokens": {snake_case: int}}. The
+    tokens are the record's modelUsage summed per field across models into the four keys
+    SdkSession._turn_usage diffs against, the same sum it makes of a result's map; an absent or empty
+    map seeds no token watermarks."""
+    if not isinstance(o, dict) or o.get("type") != "cost-state":
+        return None
+    total = o.get("totalCostUSD")
+    if not isinstance(total, (int, float)) or not (0 <= total < float("inf")):
+        return None
+    tokens = {}
+    mu = o.get("modelUsage")
+    if isinstance(mu, dict) and mu:
+        tokens = {k: 0 for k, _ in SdkSession._USAGE_KEYS}
+        for m in mu.values():
+            if not isinstance(m, dict):
+                continue
+            for k, mk in SdkSession._USAGE_KEYS:
+                v = m.get(mk)
+                tokens[k] += int(v) if isinstance(v, (int, float)) else 0
+    return {"total": float(total), "tokens": tokens}
+
+
+def last_cost_state(path):
+    """The resumed transcript's LAST `cost-state` record, as the watermarks a CLI that restores it would
+    hold (cost_state_watermarks), or None when the file has no such record or cannot be read.
+
+    Why read it: the CLI has a restore path for this record. Its transcript loader files `cost-state`
+    as last-wins, its writer emits totalCostUSD and modelUsage, the two counters the settle diffs, and
+    a resume that restores the record sets both. Should a CLI restore them in print mode, the first
+    result after a reconnect would carry the whole session's history in total_cost_usd, and watermarks
+    reset to zero would record that history as one turn's spend; seeding from the same file the CLI
+    reads makes the first delta this turn's own work. The seed reads transcript_path(cwd, resume_sid)
+    and reads it again when init corrects the cwd (the CLI's own string keys its transcript path), with
+    the sid the CLI LOADED when that init also landed a new fsid, so the two sides open the same file
+    (SdkSession._seed_spend_watermarks).
+
+    What the CLI does today, as probed in print mode (2026-09-06): its writer runs only once the process
+    has claimed its cost state. The interactive TUI claims it at startup; a print-mode (SDK) process
+    claims it only through the /clear session-id rotation, and a print-mode resume claims nothing and
+    restores nothing. The /clear saver runs before the rotation, so the SECOND and later /clear in one
+    process appends a record to the conversation that /clear abandons; the conversation romp resumes
+    (the reg's lastSid, the current one) never carries one. So every seed today reads zero, and the
+    CLI's counters start at zero on the same resume: the two agree. The one way a record reaches a
+    resumed file is a lastSid left on an abandoned conversation (the kernel dying between the saver's
+    write and the init flip); the print-mode CLI still starts at zero there, and the shrunken-counter
+    rule records the first turn whole while its own total sits below the seed. The residual: a first
+    turn costlier than the whole recorded history is under-counted by the seed, and the same holds per
+    token field (_turn_usage diffs each field on its own), so a first turn whose count in one field
+    exceeds the recorded history's is under-counted in that field.
+
+    Scans BACKWARDS in 64 KB chunks (a line split by a chunk edge is carried into the earlier chunk and
+    reassembled) and stops at the first hit, so a transcript that carries the record costs a chunk or
+    two, and one that never carried it costs one sequential read of the whole file, on the event loop
+    at connect time."""
+    marker = b'"cost-state"'
+    try:
+        with open(path, "rb") as f:
+            f.seek(0, os.SEEK_END)
+            pos = f.tell()
+            carry = b""
+            while pos > 0:
+                step = min(pos, 1 << 16)
+                pos -= step
+                f.seek(pos)
+                chunk = f.read(step) + carry    # carry: the later chunk's first-line fragment, which this
+                #                                 chunk's last line continues into
+                head, nl, body = chunk.partition(b"\n")
+                if pos > 0:
+                    carry = head                # this chunk's first line is a fragment that completes in the
+                    #                             earlier chunk, so it travels there whole
+                    if not nl:
+                        continue                # no line boundary in this chunk at all
+                else:
+                    carry, body = b"", chunk    # the file's head: every line here is complete
+                if marker not in body:
+                    continue
+                for line in reversed(body.split(b"\n")):
+                    if marker not in line:
+                        continue
+                    try:
+                        rec = cost_state_watermarks(json.loads(line))
+                    except (ValueError, OverflowError, TypeError):
+                        continue                # not JSON, or a field no int() takes: skipped like an unusable total
+                    if rec is not None:
+                        return rec
+    except OSError:
+        return None
+    return None
+
+
 def rewind_disposition(rewind_to: str, rewind_leaf: str, leaf_now: str) -> str:
     """Should a (re)connect apply a pending conversation rewind? ONE-SHOT and event-guarded:
     "apply"  — a rewind is pending and the transcript's leaf is still the one recorded at
@@ -3806,6 +3909,9 @@ class SdkSession:
         #   total when the deltas were written (`usage: this.totalUsage`) and is the TURN's own total
         #   on the current CLI — diffing it under-counted every turn but the first (the user
         #   2026-09-06). Which counter is which, and the measurement: _turn_usage.
+        self._spend_first_result = False   # True from a connect until its first result settles: that result's
+        #   delta is checked against SANE_TURN_USD (an info-line trace; see the constant), and the init
+        #   handler may re-seed the watermarks while it is still True (a cwd correction; _seed_spend_watermarks)
         self._usage_fallback_noted = False  # the once-per-session line for a paid result whose modelUsage map
         #   is there but empty (usage_fallback_notice, the CLI cause); the SDK cause is said once per
         #   backend on its flag, _usage_fallback_sdk_noted (see _note_usage_fallback)
@@ -4826,8 +4932,8 @@ class SdkSession:
                     # create, the ready chip landing at 5-12s with the cycle).
                     self.backend._push_session(self.sid)
                     self._connected.set()   # the control channel exists from here (move() waits on this)
-                    self._last_cost_total = 0.0   # a fresh CLI process starts its cumulative cost at zero
-                    self._last_usage_totals = {}  # …and its cumulative token counters
+                    self._seed_spend_watermarks()   # a fresh CLI process starts its cumulative counters at
+                    #   zero, or at what it restores from the resumed transcript's cost-state record
                     # The CLI is demonstrably up, so any recorded launch failure is HISTORY — clear it
                     # here, at the proof, rather than on a timer. This is what lifts the usage-limit
                     # hold once the window resets: the next _ensure connects, the error record goes, and
@@ -5208,6 +5314,34 @@ class SdkSession:
         except Exception:
             pass    # a raising log callback: the count proceeds (the docstring's rule)
 
+    def _seed_spend_watermarks(self, resume_sid=None):
+        """Reset the spend watermarks for the CLI process a connect just started: zero for a fresh
+        process, or, when the resumed transcript carries a `cost-state` record, the counters that record
+        holds, because a CLI that restores them reports its first total_cost_usd as the whole session's
+        history plus this turn (last_cost_state has the full story, including why every seed reads zero
+        on the CLI as probed). Arms the first-result check either way. Called at connect, and again from
+        the init handler when the CLI's cwd corrects the registry's before any result has settled: the
+        transcript path is keyed on the cwd, so that is when the seed can have read the wrong file. That
+        second call is for a resumed session only (a fresh process has no loaded transcript to read), and
+        an init that ends a /clear skips it: the watermarks keep the zero the event set.
+        `resume_sid` names the transcript the CLI LOADED when that differs from self.resume_sid: the
+        init that corrects the cwd may in the same message have landed a new fsid, and the file a
+        restoring CLI took its counters from is the old one; the new fsid's file has no record yet."""
+        self._last_cost_total = 0.0   # a fresh CLI process starts its cumulative cost at zero
+        self._last_usage_totals = {}  # and its cumulative token counters
+        self._spend_first_result = True
+        sid = resume_sid or self.resume_sid
+        if not sid:
+            return
+        cs = last_cost_state(transcript_path(self.cwd, sid))
+        if not cs:
+            return
+        self._last_cost_total = cs["total"]
+        self._last_usage_totals = dict(cs["tokens"])
+        self.backend._log("spend: %s resumes a transcript with a cost-state record: watermarks seeded at its "
+                          "totals (cumulative $%.2f) so the first result records only this turn"
+                          % (self.name, cs["total"]), problem=False)
+
     async def _drain(self, client, AssistantMessage, ResultMessage, SystemMessage):
         """The receive loop. Every streamed message goes through _handle_stream_message, which keeps
         a handler's failure to that one message; what ends this loop is the STREAM ending — the CLI
@@ -5401,6 +5535,8 @@ class SdkSession:
             # rail's /usage bars — see _note_auth_source.
             self.backend._note_auth_source(self, d.get("apiKeySource"))
             fsid = d.get("session_id")
+            loaded_sid = self.resume_sid   # the transcript the CLI LOADED: a flip below moves resume_sid to the
+            #                                fsid it will WRITE, and the spend re-seed wants the former
             if fsid and fsid != self.resume_sid:
                 old = self.resume_sid
                 self.resume_sid = fsid
@@ -5416,6 +5552,8 @@ class SdkSession:
                     # rule in _turn_usage / the cost delta stays as the backstop for a reset we did not see.
                     self._last_cost_total = 0.0
                     self._last_usage_totals = {}
+                    loaded_sid = None   # zero IS the seed here: the cwd re-seed below stands down (the loaded
+                    #                     file may carry a record the /clear saver wrote as it abandoned it)
                 # A RESUME landing on a NEW fsid = a fresh-headed fork: record the old->new lineage
                 # (see append_resume_fork for the full story — the parser stitches the chain from it,
                 # the user 2026-08-14). A /clear's flip and a born-as-a-fork copy record nothing.
@@ -5442,6 +5580,15 @@ class SdkSession:
                 self.backend._log("sdk %s: adopting CLI cwd %r (registry had %r)" % (self.sid[:8], cli_cwd, self.cwd))
                 self.cwd = cli_cwd
                 self.backend._update_reg(self.sid, cwd=cli_cwd)
+                if loaded_sid and getattr(self, "_spend_first_result", False):   # getattr: __new__-built test doubles
+                    # The connect-time seed read the transcript under the REGISTRY's cwd; the CLI loaded the
+                    # one under ITS cwd (the same keying). No result has settled since the connect, so re-seed
+                    # from the file the CLI opened: a registry variant that holds no transcript left the seed
+                    # at zero for a file that carries a record, or the reverse. Never after a settle: resetting
+                    # the watermarks mid-process would count the cumulative counters whole again. The file the
+                    # CLI opened is the PRE-flip sid's: when this same init also landed a new fsid, resume_sid
+                    # now names the file the CLI will write, which holds no record yet.
+                    self._seed_spend_watermarks(resume_sid=loaded_sid)
             self.backend._poke()   # publish the model + permission-mode from init promptly: the snapshot reads
                                    # self.model, but with no poke the new model would wait out the 3s producer
                                    # backstop. NB: this init branch fires only once the FIRST turn arrives — the
@@ -5680,6 +5827,8 @@ class SdkSession:
                 if isinstance(total, (int, float)) and total > 0:
                     delta = total - self._last_cost_total if total >= self._last_cost_total else total
                     self._last_cost_total = float(total)
+                    first = getattr(self, "_spend_first_result", False)   # getattr: __new__-built test doubles
+                    self._spend_first_result = False   # the watermark moved: the process's first result is in
                     # the tokens: THIS turn's counts, from whichever result counter is a running total —
                     # the two are not the same kind (see _turn_usage; the flat `usage` is per-turn now)
                     turn_u = self._turn_usage(msg)
@@ -5689,6 +5838,19 @@ class SdkSession:
                     #   rail and the optimizer; a deliberate fork has no threadOf and bills itself)
                     #   + token readout; keyed = THIS session's init-reported auth, so the API sum stays
                     #   honest on a mixed host (see _record_spend)
+                    if first and delta > SANE_TURN_USD:
+                        # A first-after-connect delta above the mark: on the CLI as probed a resumed process
+                        # starts its counters at zero (SANE_TURN_USD), so this is the turn's own cost, recorded
+                        # as is and traced as an INFO line, not a problem: the figure is right and there is
+                        # nothing for the user to act on. It is wrong only if a CLI that restores cost history
+                        # read a different file than the connect-time seed (last_cost_state). After the record,
+                        # so a raising log callback costs the line and never the count.
+                        self.backend._log("spend: %s's first result after connect cost $%.2f, above %.0f USD for "
+                                          "one turn (the CLI's cumulative total: $%.2f). Recorded as is: a resumed "
+                                          "CLI process starts its cost at zero, so this is the turn's own cost. It "
+                                          "would be wrong only if a CLI that restores cost history read a different "
+                                          "transcript than the connect-time seed (last_cost_state)."
+                                          % (self.name, delta, SANE_TURN_USD, total), problem=False)
             finally:
                 # THE SETTLE — everything that makes the turn over for the kernel — runs whatever the
                 # bookkeeping above did (the rewind flags, the live-tail sweep, the refreshes, the spend

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -2965,10 +2965,13 @@ class SpendRecord(unittest.TestCase):
         self.assertIn("sid=self.thread_of or self.sid)   # the rail's spend", src,
                       "a comment THREAD bills its OWNING session (T144); a plain session bills itself "
                       "(T100's per-session attribution, completed)")
+        self.assertIn("self._seed_spend_watermarks()   # a fresh CLI process starts its cumulative counters at", src,
+                      "each connect resets both watermarks with its new process, or seeds them from the resumed "
+                      "transcript's cost-state record (the resume-guard tests below)")
         self.assertIn("self._last_cost_total = 0.0   # a fresh CLI process starts its cumulative cost at zero",
-                      src, "each connect resets the watermark with its new process")
-        self.assertIn("self._last_usage_totals = {}  # …and its cumulative token counters", src,
-                      "the token watermarks reset with the same new process")
+                      src, "the seed starts the cost watermark at zero")
+        self.assertIn("self._last_usage_totals = {}  # and its cumulative token counters", src,
+                      "and the token watermarks with it")
         with open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin", "romp-kernel")) as f:
             ksrc = f.read()
         self.assertIn('if o.get("apiKey") or (not _claude_account() and (jd.STATE / "spend.json").exists()):',
@@ -2976,9 +2979,9 @@ class SpendRecord(unittest.TestCase):
         self.assertIn('"spend": _spend_windows()', ksrc)
         self.assertIn("def _spend_windows(keyed_only=False):", ksrc)   # keyed_only: the mixed-host API sum (test_session_auth)
 
-    def _spend_session(self, sid="11111111-2222-3333-4444-bbbbbbbbbbbb", name="n"):
+    def _spend_session(self, sid="11111111-2222-3333-4444-bbbbbbbbbbbb", name="n", **reg):
         import asyncio
-        s = sb.SdkSession(self.be, {"sid": sid, "name": name, "cwd": "/tmp"})
+        s = sb.SdkSession(self.be, {"sid": sid, "name": name, "cwd": "/tmp", **reg})
         self.be._forward = lambda sess, msg: None
         self.be._turn_completed = lambda sid: None
         async def _noop(): pass
@@ -3212,6 +3215,274 @@ class SpendRecord(unittest.TestCase):
         k = json.loads(self.p.read_text())["days"][self._today()]["key"]
         self.assertEqual((k["tok"], k["tokIn"], k["tokOut"], k["tokCacheR"], k["tokCacheW"]), (1200, 100, 40, 1000, 60))
         self.assertEqual(k["turns"], 1, "the login turn is carried forward, not counted")
+
+    # ── the resume guard: a CLI that restores its cost counters on resume must not have the whole
+    # ── session's history recorded as one turn's spend
+    _FSID = "22222222-3333-4444-5555-dddddddddddd"
+
+    @staticmethod
+    def _cost_state(total, model_usage, fsid=_FSID):
+        """The CLI's `cost-state` transcript record: totalCostUSD and modelUsage, the two counters the
+        settle diffs, beside the duration fields the record also carries."""
+        return json.dumps({"type": "cost-state", "sessionId": fsid, "totalCostUSD": total,
+                           "totalAPIDuration": 1, "totalDuration": 2, "startTime": 3,
+                           "modelUsage": model_usage})
+
+    @staticmethod
+    def _costed(total, model_usage):
+        r = _ResultMessage()
+        r.total_cost_usd = total
+        r.model_usage = model_usage
+        r.usage = {"input_tokens": 9999}     # never read while the map is present: the map governs
+        return r
+
+    @staticmethod
+    def _init_of(s):
+        """Deliver an init SystemMessage to `s` the way the stream does (the class passed as the
+        SystemMessage type is the double's own, so isinstance holds)."""
+        class _Sys:
+            def __init__(self, data): self.subtype = "init"; self.data = data
+        def init(data):
+            async def go():
+                s._on_message(_Sys(data), _AssistantMessage, _ResultMessage, _Sys)
+                await asyncio.sleep(0)
+            asyncio.run(go())
+        return init
+
+    def _private_dir(self):
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        return td.name
+
+    def _resumed_session(self, transcript_lines, sid="11111111-2222-3333-4444-eeeeeeeeeeee", name="n"):
+        """A session whose reg resumes _FSID from self.d, with that transcript on disk under a private
+        CLAUDE_CONFIG_DIR (transcript_path reads the env at call time)."""
+        env = mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": self._private_dir()})
+        env.start()
+        self.addCleanup(env.stop)
+        p = Path(sb.transcript_path(self.d, self._FSID))
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("\n".join(transcript_lines) + "\n")
+        return self._spend_session(sid, name=name, cwd=self.d, lastSid=self._FSID)
+
+    def test_connect_seeds_the_watermarks_from_the_transcripts_last_cost_state(self):
+        """The CLI's transcript loader files `cost-state` as last-wins and its writer emits totalCostUSD
+        + modelUsage, the two counters the settle diffs. A CLI that restores them on resume reports its
+        first total_cost_usd as the WHOLE session's history plus this turn; watermarks at zero would
+        record that history as one turn's spend. Seeding from the record the CLI restores keeps the
+        first delta this turn's own."""
+        mu_old = {"claude-x": {"inputTokens": 400, "outputTokens": 40,
+                               "cacheReadInputTokens": 9000, "cacheCreationInputTokens": 100}}
+        mu = {"claude-x": {"inputTokens": 1000, "outputTokens": 200,
+                           "cacheReadInputTokens": 50000, "cacheCreationInputTokens": 3000}}
+        s, run, day = self._resumed_session([
+            json.dumps({"type": "user", "uuid": "u1", "message": {"role": "user", "content": "hello"}}),
+            self._cost_state(4.0, mu_old),                     # an earlier snapshot, superseded (last-wins)
+            json.dumps({"type": "assistant", "uuid": "a1", "message": {"role": "assistant", "content": []}}),
+            self._cost_state(12.5, mu),
+            json.dumps({"type": "last-prompt", "lastPrompt": "x"}),   # uuid-less trailers after it are fine
+        ])
+        lines = []
+        self.be._log_cb = lines.append
+        seeded = lambda: [l for l in lines if "watermarks seeded" in l]
+        s._seed_spend_watermarks()                             # the connect-time step
+        self.assertEqual(s._last_cost_total, 12.5, "the LAST record's total is the seed")
+        self.assertEqual(s._last_usage_totals, {"input_tokens": 1000, "output_tokens": 200,
+                                                "cache_read_input_tokens": 50000,
+                                                "cache_creation_input_tokens": 3000})
+        self.assertTrue(s._spend_first_result)
+        self.assertEqual(len(seeded()), 1, "the seed is said once, in the kernel log")
+        self.assertIn("12.50", seeded()[0])
+        self.assertEqual(self.be.problems(), [], "an info line, not a problem: nothing for the user to act on")
+        # the restoring CLI's first result: history + this turn. Only THIS turn lands.
+        run(self._costed(13.0, {"claude-x": {"inputTokens": 1500, "outputTokens": 260,
+                                             "cacheReadInputTokens": 50000, "cacheCreationInputTokens": 3000}}))
+        d = day()
+        self.assertAlmostEqual(d["usd"], 0.5)
+        self.assertEqual((d["tokIn"], d["tokOut"], d["tokCacheR"]), (500, 60, 0))
+        self.assertFalse(s._spend_first_result)
+        self.assertEqual(len(seeded()), 1, "the settle says nothing about the seed")
+        # a CLI that wrote the record but did NOT restore: its own first total sits below the seed, so the
+        # shrunken-counter rule records it whole. The common case stays right without knowing which CLI it is.
+        s._seed_spend_watermarks()
+        self.assertEqual(len(seeded()), 2, "each connect that seeds says so")
+        run(self._costed(0.7, {"claude-x": {"inputTokens": 300}}))
+        self.assertAlmostEqual(day()["usd"], 1.2)
+        self.assertEqual(day()["tokIn"], 800)
+        self.assertEqual(self.be.problems(), [])
+
+    def test_no_cost_state_record_and_no_resume_target_leave_the_watermarks_at_zero(self):
+        s, run, day = self._resumed_session([
+            json.dumps({"type": "user", "uuid": "u1", "message": {"role": "user", "content": "hello"}}),
+            json.dumps({"type": "assistant", "uuid": "a1", "message": {"role": "assistant", "content": [],
+                                                                        "usage": {"input_tokens": 5}}}),
+        ])
+        s._last_cost_total, s._last_usage_totals = 9.0, {"input_tokens": 9}   # stale from the old process
+        s._seed_spend_watermarks()
+        self.assertEqual((s._last_cost_total, s._last_usage_totals), (0.0, {}),
+                         "no record: a fresh process starts at zero, as every resume does on the CLI as probed")
+        run(self._costed(1.5, {"claude-x": {"inputTokens": 100}}))
+        self.assertAlmostEqual(day()["usd"], 1.5, msg="the first result is recorded whole")
+        self.assertEqual(day()["tokIn"], 100)
+        s.resume_sid = None                                    # no resume target at all
+        s._last_cost_total = 3.0
+        s._seed_spend_watermarks()
+        self.assertEqual((s._last_cost_total, s._last_usage_totals, s._spend_first_result), (0.0, {}, True))
+
+    def test_last_cost_state_reads_backwards_across_chunk_edges_and_takes_the_last_valid_record(self):
+        p = Path(self._private_dir()) / "t.jsonl"
+        filler = json.dumps({"type": "user", "uuid": "u", "message": {"role": "user", "content": "x" * 900}})
+        mu = {"m": {"inputTokens": 7, "outputTokens": 3}}
+        # a valid record early in the file, then ~200 KB with no marker: the scan walks several 64 KB
+        # chunks back to it. A later record with an unusable total is skipped, not taken as "none".
+        lines = [filler, self._cost_state(2.25, mu)] + [filler] * 220
+        lines.append(json.dumps({"type": "cost-state", "totalCostUSD": "not a number", "modelUsage": mu}))
+        p.write_text("\n".join(lines) + "\n")
+        self.assertEqual(sb.last_cost_state(str(p)), {"total": 2.25, "tokens": {
+            "input_tokens": 7, "output_tokens": 3, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0}})
+        # a record STRADDLING a chunk edge: the tail after it is 21 bytes short of a chunk, so the edge of
+        # the last chunk (read first) falls inside the record, whose two halves land in different chunks
+        rec = self._cost_state(5.5, mu)
+        head = "\n".join([filler] * 80) + "\n"
+        tail = "x" * ((1 << 16) - 22) + "\n"
+        p.write_text(head + rec + "\n" + tail)
+        size = p.stat().st_size
+        start = len(head.encode())
+        edge = size - (1 << 16)
+        self.assertTrue(start < edge < start + len(rec), "the premise: the chunk edge falls inside the record")
+        self.assertEqual(sb.last_cost_state(str(p))["total"], 5.5, "a line split by the chunk edge is reassembled")
+        # last-wins: two valid records take the later one; no trailing newline is fine
+        p.write_text(self._cost_state(1.0, mu) + "\n" + self._cost_state(9.0, {}))
+        self.assertEqual(sb.last_cost_state(str(p)), {"total": 9.0, "tokens": {}},
+                         "an empty modelUsage seeds no token watermarks")
+        # two models sum per field, the settle's own count of a result's map
+        p.write_text(self._cost_state(3.0, {"a": {"inputTokens": 5, "cacheReadInputTokens": 10},
+                                            "b": {"inputTokens": 6, "outputTokens": 1, "webSearchRequests": 4},
+                                            "c": "not a map"}) + "\n")
+        self.assertEqual(sb.last_cost_state(str(p))["tokens"], {
+            "input_tokens": 11, "output_tokens": 1, "cache_read_input_tokens": 10, "cache_creation_input_tokens": 0})
+        # a negative or non-finite total is unusable, like a non-number
+        p.write_text(self._cost_state(-1.0, mu) + "\n")
+        self.assertIsNone(sb.last_cost_state(str(p)))
+        p.write_text('{"type": "cost-state", "totalCostUSD": NaN, "modelUsage": {}}\n')
+        self.assertIsNone(sb.last_cost_state(str(p)))
+        p.write_text('{"type": "cost-state", "totalCostUSD": Infinity, "modelUsage": {}}\n')
+        self.assertIsNone(sb.last_cost_state(str(p)))
+        self.assertIsNone(sb.last_cost_state(str(p.parent / "missing.jsonl")))
+        p.write_text("")
+        self.assertIsNone(sb.last_cost_state(str(p)))
+        p.write_text(filler + "\n")
+        self.assertIsNone(sb.last_cost_state(str(p)), "no record: None, never a zero seed")
+
+    def test_a_first_result_after_connect_above_the_single_turn_mark_is_recorded_and_traced_as_info(self):
+        """On the CLI as probed a resumed process starts its cost counters at zero, so a first delta above
+        the mark is the turn's own cost: recorded as is and traced in the kernel log, NOT a problem (a
+        problem row for a right figure sends the user to check a record that is correct)."""
+        lines = []
+        self.be._log_cb = lines.append
+        traced = lambda: [l for l in lines if "first result after connect" in l]
+        s, run, day = self._spend_session()
+        s._seed_spend_watermarks()                             # no resume target: zero watermarks
+        run(self._costed(5.0, {"m": {"inputTokens": 10}}))
+        self.assertEqual(traced(), [], "an ordinary first turn says nothing")
+        s._seed_spend_watermarks()                             # a reconnect
+        run(self._costed(250.0, {"m": {"inputTokens": 20}}))
+        self.assertEqual(len(traced()), 1)
+        self.assertIn("250.00", traced()[0])
+        self.assertIn("Recorded as is", traced()[0])
+        self.assertEqual(self.be.problems(), [], "an info line: the figure is right, nothing to act on")
+        self.assertAlmostEqual(day()["usd"], 255.0, msg="recorded anyway; the record drops nothing")
+        run(self._costed(500.0, {"m": {"inputTokens": 30}}))   # a 250 USD delta on the NEXT result
+        self.assertEqual(len(traced()), 1, "only the FIRST result after a connect is checked")
+        self.assertAlmostEqual(day()["usd"], 505.0)
+
+    def test_init_correcting_the_cwd_re_seeds_the_watermarks_before_the_first_result(self):
+        """The connect-time seed reads the transcript under the REGISTRY's cwd; the CLI loads the one
+        under ITS cwd, which init reports (the same keying: transcript_path realpaths the string, so a
+        create-time variant such as a wrong case holds no transcript). Adopting the CLI's cwd re-seeds
+        from the file the CLI opened while no result has settled, and never afterwards: resetting the
+        watermarks mid-process would count the cumulative counters whole again."""
+        mu = {"m": {"inputTokens": 1000, "outputTokens": 200}}
+        s, run, day = self._resumed_session([self._cost_state(12.5, mu)])   # the record lives under self.d
+        variant = self._private_dir()
+        s.cwd = variant                                        # the registry's variant: no transcript there
+        sb.write_reg(self.d, s.sid, {"sid": s.sid, "name": "n", "cwd": variant, "alive": True, "lastSid": self._FSID})
+        s._seed_spend_watermarks()
+        self.assertEqual((s._last_cost_total, s._last_usage_totals), (0.0, {}), "nothing under the variant")
+        init = self._init_of(s)
+        init({"cwd": self.d, "session_id": self._FSID, "model": "claude-x"})
+        self.assertEqual(s.cwd, self.d)
+        self.assertEqual(sb.read_reg(self.d, s.sid)["cwd"], self.d)
+        self.assertEqual(s._last_cost_total, 12.5, "re-seeded from the file under the CLI's cwd")
+        self.assertEqual(s._last_usage_totals["input_tokens"], 1000)
+        self.assertTrue(s._spend_first_result)
+        run(self._costed(13.0, {"m": {"inputTokens": 1500, "outputTokens": 260}}))
+        self.assertAlmostEqual(day()["usd"], 0.5, msg="the first result records only this turn")
+        self.assertEqual(day()["tokIn"], 500)
+        # a cwd correction AFTER a settle (none is expected; the guard is the point) leaves them alone
+        init({"cwd": self._private_dir(), "session_id": self._FSID, "model": "claude-x"})
+        self.assertEqual(s._last_cost_total, 13.0, "no re-seed once a result has settled")
+        run(self._costed(13.2, {"m": {"inputTokens": 1600, "outputTokens": 260}}))
+        self.assertAlmostEqual(day()["usd"], 0.7)
+        self.assertEqual(day()["tokIn"], 600)
+
+    def test_an_init_that_lands_a_new_fsid_and_corrects_the_cwd_re_seeds_from_the_file_the_cli_loaded(self):
+        """One init can both land a NEW fsid (a resume the CLI continues under a fresh file; a rewind via
+        --resume-session-at is an in-place branch on the same fsid and never flips it) and correct the
+        cwd. The flip moves resume_sid to the file the CLI will WRITE, which holds no record yet; a CLI
+        that restores its counters took them from the file it LOADED, the old fsid's. The re-seed reads
+        that one."""
+        new_fsid = "33333333-4444-5555-6666-ffffffffffff"
+        mu = {"m": {"inputTokens": 1000, "outputTokens": 200}}
+        s, run, day = self._resumed_session([self._cost_state(12.5, mu)])   # the OLD fsid's record, under self.d
+        variant = self._private_dir()
+        s.cwd = variant                                        # the registry's variant: no transcript there
+        sb.write_reg(self.d, s.sid, {"sid": s.sid, "name": "n", "cwd": variant, "alive": True, "lastSid": self._FSID})
+        s._seed_spend_watermarks()
+        self.assertEqual(s._last_cost_total, 0.0, "nothing under the variant")
+        self._init_of(s)({"cwd": self.d, "session_id": new_fsid, "model": "claude-x"})
+        self.assertEqual((s.cwd, s.resume_sid), (self.d, new_fsid), "cwd adopted, fsid flipped")
+        self.assertEqual(sb.read_reg(self.d, s.sid)["lastSid"], new_fsid)
+        self.assertEqual(s._last_cost_total, 12.5, "re-seeded from the OLD fsid's file under the CLI's cwd")
+        self.assertEqual(s._last_usage_totals["input_tokens"], 1000)
+        run(self._costed(13.0, {"m": {"inputTokens": 1500, "outputTokens": 260}}))
+        self.assertAlmostEqual(day()["usd"], 0.5, msg="the restoring CLI's first result records only this turn")
+        self.assertEqual(day()["tokIn"], 500)
+        # a flip WITHOUT a cwd correction re-seeds nothing: the connect-time seed read the loaded file already
+        s2, _, _ = self._spend_session("11111111-2222-3333-4444-abababababab", name="n2", cwd=self.d, lastSid=self._FSID)
+        sb.write_reg(self.d, s2.sid, {"sid": s2.sid, "name": "n2", "cwd": self.d, "alive": True, "lastSid": self._FSID})
+        s2._seed_spend_watermarks()
+        self.assertEqual(s2._last_cost_total, 12.5)
+        # the record changes under the seed: a re-seed here would read 99.0
+        Path(sb.transcript_path(self.d, self._FSID)).write_text(self._cost_state(99.0, mu) + "\n")
+        self._init_of(s2)({"cwd": self.d, "session_id": new_fsid, "model": "claude-x"})
+        self.assertEqual((s2.resume_sid, s2._last_cost_total), (new_fsid, 12.5), "flipped, seed kept: not re-read")
+
+    def test_an_init_that_ends_a_clear_and_corrects_the_cwd_keeps_the_watermarks_at_zero(self):
+        """A /clear's init flip zeroes the watermarks on the event: the CLI zeroed its counters at that
+        instant. When the same init also corrects the cwd, the re-seed stands down. The file the CLI
+        loaded may carry a record (the CLI's writer appends one to the conversation a /clear abandons),
+        and seeding from it would hold the watermarks above counters that are at zero."""
+        mu = {"m": {"inputTokens": 1000, "outputTokens": 200}}
+        s, run, day = self._resumed_session([self._cost_state(12.5, mu)])
+        variant = self._private_dir()
+        s.cwd = variant
+        sb.write_reg(self.d, s.sid, {"sid": s.sid, "name": "n", "cwd": variant, "alive": True, "lastSid": self._FSID})
+        s._seed_spend_watermarks()
+        self.assertEqual(s._last_cost_total, 0.0)
+        new_fsid = "33333333-4444-5555-6666-ffffffffffff"
+        # planted so the stand-down is observable: a re-seed that fell back to the NEW fsid's file would read 7.0
+        p = Path(sb.transcript_path(self.d, new_fsid))
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(self._cost_state(7.0, mu, fsid=new_fsid) + "\n")
+        s._clearing = True                                     # a /clear was delivered on this connection...
+        self._init_of(s)({"cwd": self.d, "session_id": new_fsid, "model": "claude-x"})
+        self.assertEqual(s.cwd, self.d, "...and its init lands a new fsid under the CLI's cwd")
+        self.assertEqual((s._last_cost_total, s._last_usage_totals), (0.0, {}),
+                         "the clear's zero stands: neither the abandoned conversation's record nor the new file is read")
+        run(self._costed(13.0, {"m": {"inputTokens": 1500}}))
+        self.assertAlmostEqual(day()["usd"], 13.0, msg="the first post-clear turn is the whole counter")
+        self.assertEqual(day()["tokIn"], 1500)
 
 
 class RewindFiles(unittest.TestCase):


### PR DESCRIPTION
Follows #1192 (merged), which edited the same settle lines; this change is one commit on top of it.

## Symptom

No wrong figure has been seen: on the CLI as probed (print mode, 2026-09-06) a resume restores no cost-state record, so the connect-time seed this change adds reads zero, the CLI starts its counters at zero, and the spend record is unchanged. The change guards a restore path the CLI still carries. Its transcript loader files the `cost-state` record last-wins, its writer emits `totalCostUSD` and `modelUsage` (the two counters the settle diffs), and a resume that restores the record sets both. Should a print-mode resume restore them, the first result after a reconnect would carry the whole session's history in `total_cost_usd`, and the day's spend would gain that history as one turn.

## Cause

Every connect resets `_last_cost_total` and `_last_usage_totals` to zero, whatever the resumed transcript says a restoring CLI would hold. The init handler's cwd adoption changes the path the transcript lives under without re-reading it.

## Fix

- `last_cost_state(path)` returns the resumed transcript's last `cost-state` record as watermarks, `{"total": totalCostUSD, "tokens": modelUsage summed per field}` in the snake_case keys `_turn_usage` diffs against, or None. It scans backwards in 64 KB chunks, reassembles a line split by a chunk edge, and stops at the first valid record; `cost_state_watermarks(o)` validates one record (a negative or non-finite total is unusable) and does the sum. `_turn_usage` and the settle's token line are unchanged.
- `SdkSession._seed_spend_watermarks(resume_sid=None)` zeroes both watermarks, arms the first-result flag and, given a resume target whose transcript carries a record, seeds the totals from it and logs one info line. It replaces the two zero resets at connect.
- The init handler captures the sid the CLI loaded before the fsid flip and, inside the existing cwd adoption, re-seeds from that sid's file under the CLI's cwd while no result has settled. A fresh session has no loaded transcript and re-seeds nothing; a flip alone re-seeds nothing; an init that ends a /clear leaves the watermarks at the zero the event set.
- The settle consumes the first-result flag once the cost watermark moves. A first delta above `SANE_TURN_USD` (200) is recorded as is and traced as an info line after the spend is recorded, with `problem=False`: on the CLI as probed it is the turn's own cost, and a problem row would send the user to check a figure that is correct.

Residuals: a record the CLI wrote but did not restore (a lastSid left on the conversation a /clear abandoned) seeds watermarks the process never holds; the shrunken-counter rule records the first turn whole while its total sits below the seed, and a first turn costlier than the whole recorded history is under-counted by the seed. The same holds per token field: a first turn whose count in one field exceeds the recorded history's is under-counted in that field. A transcript with no record costs one sequential backwards read of the whole file at connect, on the event loop.

## Tests

All in `tests/test_sdk_backend.py`, class `SpendRecord`, red before the change: each fails on `AttributeError` because `_seed_spend_watermarks` and `last_cost_state` do not exist. With the watermarks at zero, the first case's result would record 13.0 USD and 1500 input tokens for a 0.5 USD turn.

- `test_connect_seeds_the_watermarks_from_the_transcripts_last_cost_state`: a transcript with a superseded record, a last record (12.5 USD) and a uuid-less trailer seeds 12.5 and its four token totals, said once as an info line with the problem ring empty; a result at 13.0 records 0.5 USD and 500/60/0 tokens and adds no line; a re-seed says so again, and a result at 0.7 (a CLI that did not restore) is recorded whole.
- `test_no_cost_state_record_and_no_resume_target_leave_the_watermarks_at_zero`: stale watermarks go to zero with a record-less transcript, the first result is recorded whole, and no resume target seeds nothing.
- `test_last_cost_state_reads_backwards_across_chunk_edges_and_takes_the_last_valid_record`: a record 200 KB from the tail behind an unusable one; a record straddling the chunk edge (the test asserts the edge falls inside it); last-wins; two models summed per field with a non-map entry skipped; negative, NaN and infinite totals; missing, empty and record-less files return None.
- `test_init_correcting_the_cwd_re_seeds_the_watermarks_before_the_first_result`: the seed under the registry's cwd variant reads zero; an init adopting the CLI's cwd re-seeds 12.5 and the first result records 0.5 USD; a cwd correction after a settle leaves the watermarks alone.
- `test_an_init_that_lands_a_new_fsid_and_corrects_the_cwd_re_seeds_from_the_file_the_cli_loaded`: the re-seed reads the old fsid's file under the CLI's cwd while the reg carries the new fsid; a flip without a cwd change keeps the seed while the record on disk changes to 99.0 under it (a re-seed would have read it).
- `test_an_init_that_ends_a_clear_and_corrects_the_cwd_keeps_the_watermarks_at_zero`: with `_clearing` set and a 7.0 record planted in the new fsid's file, the init's flip and cwd adoption leave zero (no file is read) and the first post-clear result is recorded whole.
- `test_a_first_result_after_connect_above_the_single_turn_mark_is_recorded_and_traced_as_info`: 5.0 says nothing; 250.0 after a reconnect is recorded and traced once with the problem ring empty; a 500.0 result next (a 250 USD delta) adds no line.
- `test_result_message_records_and_the_kernel_serves_it` (existing source pin): follows the seed call at the connect site. The connect path needs the SDK, which the suite runs without, so the call at that site is pinned by source text, as the two lines it replaces were.

Full suite: `pytest -q -n 8 tests/` on this head, twice: 10167 passed, 61 skipped, 0 failed (76 s and 78 s). Two runs of an earlier revision of this change each had nine failures in modules the change does not touch (`tests/test_sdk_live_rows.py`, `tests/test_api_health.py`, `tests/test_sdk_kernel.py`), a module-load ordering effect under xdist; each module passes alone.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)