### PR TITLE
Chat page: a Compact tabs and agents setting shrinks the tab strip and the background-work panel

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -141,6 +141,13 @@ not loaded yet.
 ![Clicking a skeleton tab puts up the loader until its transcript arrives](assets/guide/reconnect-skeleton-click.png){ width="32%" }
 ![The clicked tab, loaded](assets/guide/reconnect-skeleton-loaded.png){ width="32%" }
 
+**On a small screen.** To keep more of the transcript in view, turn on the gear's
+**Compact tabs and agents** setting. It tightens the rows in the background-work panel above the
+composer (the one headed **Awaiting** or **In the background**) and shows about four of its rows,
+scrolling for the rest; the cap lifts while a row's details are open. Where the tab strip is showing,
+it also shrinks the tabs and group headers; on a phone the session picker stands in for the strip, so
+there the setting tightens the panel alone. Like the other chat settings, it is per browser.
+
 ### The feed
 
 The feed is Romp's task-management layer: a card for each task. Romp's

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -4734,6 +4734,18 @@ class ViewBuilder(unittest.TestCase):
         self.assertIn("showBranch: false", _gear_src())               # load() default OFF, both branches
         self.assertNotIn("showBranch: true", _gear_src())             # the old default must not linger
 
+    def test_gear_has_compact_tabs_and_agents_toggle(self):
+        # the user 2026-09-08: a "Compact tabs and agents" checkbox in the Chat section shrinks the tab strip's
+        # tabs and group headers and tightens the rows of the background-work panel (one body class, styles.css
+        # body.dense-chrome, applied by dense-chrome.ts from render.ts). OFF by default: an explicit stored true
+        # opts in. It mirrors render.ts' loadSettings().denseChrome read, persisted in romp:settings.
+        self.assertIn("id=rs-dense", _gear_src())
+        self.assertIn("Compact tabs and agents", _gear_src())
+        self.assertIn("s.denseChrome = dn.checked", _gear_src())          # change → persist
+        self.assertIn("dn.checked = s.denseChrome === true", _gear_src())  # open → reflect (default OFF)
+        self.assertIn("denseChrome: false", _gear_src())              # load() default OFF (dense-chrome.test.ts counts both branches)
+        self.assertNotIn("denseChrome: true", _gear_src())
+
     def test_chat_body_has_an_explicit_send_button(self):
         # The web-dashboard composer (kernel _chat_body, a SECOND copy of vscode-extension/src/page-skeleton.chatBody)
         # carries an explicit send button beside 📎, so ⏎ isn't the only way to send (the user 2026-06-17).

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -46,7 +46,7 @@ class SettingsSectionsTest(unittest.TestCase):
                     "id=rs-conserve", "id=rs-thinksum", "id=rs-fileedit"):
             self.assertTrue(h.index(">Sessions<") < h.index(rid) < h.index(">Chat<"), rid)
         # Chat: transcript prefs AND the comment defaults (comments are part of the chat)
-        for rid in ("id=rs-compact", "id=rs-branch", "id=rs-striprows", "id=rs-cmtmodel", "id=rs-cmtfast"):
+        for rid in ("id=rs-compact", "id=rs-dense", "id=rs-branch", "id=rs-striprows", "id=rs-cmtmodel", "id=rs-cmtfast"):
             self.assertTrue(h.index(">Chat<") < h.index(rid) < h.index(">Sessions pane<"), rid)
         # Sessions pane, then Feed, then Colors
         self.assertTrue(h.index(">Sessions pane<") < h.index("id=rs-collapsegaps") < h.index(">Feed<"))

--- a/ui/webview/dense-chrome-layout.test.ts
+++ b/ui/webview/dense-chrome-layout.test.ts
@@ -1,0 +1,198 @@
+// COMPACT TABS AND AGENTS, measured. dense-chrome.test.ts pins the dense rules by their text; a pin cannot see a
+// rule that keeps its text and loses in the cascade (a later default outranking the guarded list cap) or a row
+// standing taller than its own rule says (#tabs stretches every item on a row to the tallest). So a real browser
+// lays out the strip and the panel markup render.ts builds (planStrip, renderBgTasks, bgRow) against the real
+// stylesheet, with body.dense-chrome off, on, on with a row's details open, and off again, and the numbers the
+// stylesheet's block comment states are asserted here. Runs only where a Playwright browser exists (CI installs
+// none) and SKIPS LOUDLY there, the queued-romp-layout.test.ts pattern; the CI-safe pins live in dense-chrome.test.ts.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const CSS_PATH = path.resolve(process.cwd(), "..", "ui", "webview", "styles.css");
+
+// the markup render.ts builds, reduced to the nodes the dense rules touch. The chip's inline style is tagChip's
+// (tag-menu.ts, inheritSize), the tag button's is tagMenuButton's, the arrow is agentOpenButton's svg.
+const ARROW = '<span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/></svg></span>';
+const CHIP = '<span class="tab-group-chip" style="display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;border:1px solid var(--dim);color:var(--dim);background:transparent;white-space:nowrap;">web</span>';
+const TAGBTN = '<button type="button" style="background:transparent;border:1px solid #3c3c3c;border-radius:6px;padding:4px 6px;cursor:pointer;color:#9aa0a6;display:inline-flex;align-items:center;"><svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M2 7.5 L7.5 2.5 H14 V9 L8.5 14 Z" stroke="currentColor" stroke-width="1.4"/></svg></button>';
+const tab = (id: string, label: string, cls = "") =>
+  `<div class="tab${cls}" id="${id}"><span class="tab-label">${label}</span><span class="tab-close">×</span></div>`;
+// a row as bgRow builds it: dot, label, the arrow on an agent row, the elapsed time, the caption, the row's caret
+const row = (id: string, status: string, caption: string, arrow: boolean) =>
+  `<div class="bg-task bg-${status}" id="${id}"><div class="bg-head"><span class="bg-dot"></span><span class="bg-sum">${id} on the notes-api tests</span>` +
+  `${arrow ? ARROW : ""}<span class="bg-since">· 2m</span><span class="bg-status">${caption}</span><span class="bg-caret">▸</span></div></div>`;
+const html = `<body style="margin:0;width:900px">
+<div id="tabbar"><div id="tabs">
+  <div class="tab-group-head" id="gh">${CHIP}<span class="tab-group-caret">▸</span><span class="tab-group-count">3</span></div>
+  ${tab("t1", "web", " active")}
+  ${tab("t2", '<span class="host-prefix" id="hp">TESTHOST:</span>api')}
+  <div class="tab-group-sep" id="sep"></div>
+  ${tab("t3", "tests")}
+  <div class="tab tab-add" id="add">+</div>
+  <span class="tab-tagbox" id="tagbox">${TAGBTN}<span class="tab-tagchips" style="display:inline-flex;gap:5px;align-items:center;margin-left:2px;"></span></span>
+</div></div>
+<div id="bg-tasks">
+  <div class="bg-fold-head open" id="bar"><span class="bg-caret">▾</span><span class="bg-dot"></span><span class="bg-fold-label">In the background · 5 agents · 1 command</span></div>
+  <div class="bg-list" id="list">
+    ${row("running", "running", "running", true)}
+    ${row("armed", "armed", "armed", true)}
+    ${row("completed", "completed", "completed", true)}
+    ${row("failed", "failed", "failed", true)}
+    ${row("timer", "waiting", "timer", false)}
+    ${row("flat", "running", "running", false)}
+  </div>
+</div>
+</body>`;
+
+type Snap = {
+  tab: number; tabPrefixed: number; head: number; add: number; tagbox: number; sepW: number; sepLine: number;
+  hostPrefixFs: number; closeFs: number; countFs: number;
+  panel: number; bar: number; list: number; listMax: string;
+  rowArrow: number; rowFlat: number; arrow: number;
+  status: Record<string, string>; sumFs: number; sinceFs: number;
+};
+type Measured = { off: Snap; on: Snap; onOpen: Snap; offAgain: Snap };
+
+// The measurement runs in a standalone driver process (the T225 served-test pattern): the test bundle is
+// CommonJS without top-level await, and esbuild must never try to bundle playwright itself.
+const DRIVER = `
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+let chromium;
+try { chromium = require("playwright").chromium; } catch (e) { process.exit(3); }
+let browser;
+try { browser = await chromium.launch(); } catch (e) { process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 900, height: 1100 } });
+await page.setContent(fs.readFileSync(process.env.HTML_PATH, "utf8"));
+await page.addStyleTag({ path: process.env.CSS_PATH });
+const out = await page.evaluate(() => {
+  const q = (sel) => document.querySelector(sel);
+  const h = (el) => el.getBoundingClientRect().height;
+  const cs = (el, prop) => getComputedStyle(el)[prop];
+  const fs = (el) => parseFloat(cs(el, "fontSize"));
+  const snap = () => {
+    const sep = q("#sep");
+    const status = {};
+    for (const id of ["running", "armed", "completed", "failed", "timer"]) status[id] = cs(q("#" + id + " .bg-status"), "display");
+    return {
+      tab: h(q("#t1")), tabPrefixed: h(q("#t2")), head: h(q("#gh")), add: h(q("#add")), tagbox: h(q("#tagbox")),
+      sepW: sep.getBoundingClientRect().width, sepLine: h(sep) - parseFloat(cs(sep, "paddingTop")) - parseFloat(cs(sep, "paddingBottom")),
+      hostPrefixFs: fs(q("#hp")), closeFs: fs(q("#t1 .tab-close")), countFs: fs(q("#gh .tab-group-count")),
+      panel: h(q("#bg-tasks")), bar: h(q("#bar")), list: h(q("#list")), listMax: cs(q("#list"), "maxHeight"),
+      rowArrow: h(q("#running")), rowFlat: h(q("#flat")), arrow: h(q("#running .bg-open-agent")),
+      status, sumFs: fs(q("#running .bg-sum")), sinceFs: fs(q("#running .bg-since")),
+    };
+  };
+  const off = snap();
+  document.body.classList.add("dense-chrome");
+  const on = snap();
+  // a row's details open: the class bgRow sets, and the detail block it appends under the head
+  const opened = q("#completed");
+  opened.classList.add("open");
+  const det = document.createElement("div"); det.className = "bg-detail";
+  const cmd = document.createElement("pre"); cmd.className = "bg-cmd"; cmd.textContent = "npm test"; det.appendChild(cmd);
+  const outp = document.createElement("pre"); outp.className = "bg-out"; outp.textContent = Array.from({ length: 12 }, (_, i) => "line " + i).join("\\n"); det.appendChild(outp);
+  opened.appendChild(det);
+  const onOpen = snap();
+  opened.classList.remove("open"); det.remove();
+  document.body.classList.remove("dense-chrome");
+  const offAgain = snap();
+  return { off, on, onOpen, offAgain };
+});
+if (process.env.SHOT) await page.screenshot({ path: process.env.SHOT, fullPage: true });
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\\n");
+await browser.close();
+process.exit(0);
+`;
+
+function measure(): Measured | null {
+  const os = require("node:os");
+  const cp = require("node:child_process");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "dense-chrome-layout-"));
+  const driver = path.join(dir, "driver.mjs"); fs.writeFileSync(driver, DRIVER);
+  const htmlPath = path.join(dir, "page.html"); fs.writeFileSync(htmlPath, html);
+  try {
+    const p = cp.spawnSync(process.execPath, [driver], { encoding: "utf8", timeout: 120000,   // the running node, never PATH
+      env: { ...process.env, EXT_PKG: path.resolve(process.cwd(), "package.json"), HTML_PATH: htmlPath, CSS_PATH: CSS_PATH,
+             SHOT: process.env.DENSE_CHROME_LAYOUT_SHOT || "" } });
+    if (p.status === 3) return null;                                  // no playwright / no browser here
+    if (p.status !== 0) throw new Error("layout driver failed: " + String(p.stderr || p.stdout || p.error || "").slice(-800));
+    const line = (p.stdout || "").split("\n").find((l: string) => l.startsWith("RESULT:"));
+    if (!line) throw new Error("layout driver printed no result: " + (p.stdout || "").slice(-400));
+    return JSON.parse(line.slice("RESULT:".length));
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+const m = measure();
+const skip = m ? false : "no Playwright browser here: the layout measurement needs one (CI installs none); the CI-safe source pins live in dense-chrome.test.ts";
+const near = (got: number, want: number, what: string, tol = 0.5) =>
+  assert.ok(Math.abs(got - want) <= tol, what + ": " + got.toFixed(2) + "px, wanted about " + want + "px");
+
+test("a tab is about 25px tall under the setting (32px by default); the + tab and the tag control follow it", { skip }, () => {
+  const { off, on } = m!;
+  near(off.tab, 32, "the default tab", 1);
+  near(on.tab, 25, "the dense tab"); near(on.tabPrefixed, 25, "a federated tab");
+  near(on.add, 25, "the + tab (its 18px line + 2 x 3px + 1px border)");
+  near(on.tagbox, 25, "the tag control's floor is the + tab's height, so its row stands no taller than the tabs' rows");
+});
+
+test("a group header stretches to its row's tabs, so it is the tab's height in both states", { skip }, () => {
+  // #tabs has align-items: stretch: on a row with tabs the header is as tall as the tabs, whatever its own
+  // padding says (about 31px on its own by default, 25px dense, the chip's 1.2 line inside the 0.82em header)
+  const { off, on } = m!;
+  near(off.head, off.tab, "default: header and tab share a height", 0.1);
+  near(on.head, on.tab, "dense: header and tab share a height", 0.1);
+  assert.equal(on.countFs, off.countFs, "the header's count keeps its size: the header rule sets none");
+});
+
+test("the untagged trail's divider keeps its half-row line at the default's width", { skip }, () => {
+  const { off, on } = m!;
+  assert.equal(on.sepW, off.sepW, "the width the tab drag's virtual layout measures is unchanged");
+  near(on.sepW, 13, "13px wide", 0.1);
+  near(on.sepLine, 13, "the 1px line's height under 6px gutters in a 25px row", 0.6);
+  near(off.sepLine, 16, "the default's line under 8px gutters in a 32px row", 1);
+});
+
+test("a federated tab's host prefix and the close glyph keep their rendered size under the smaller tab", { skip }, () => {
+  const { off, on } = m!;
+  near(on.hostPrefixFs, off.hostPrefixFs, "the host prefix renders at the default's size (0.92em inside 0.86em is the default 0.86em inside 0.92em)", 0.05);
+  assert.ok(on.hostPrefixFs >= 10, "at or above the 10px floor: " + on.hostPrefixFs.toFixed(2) + "px");
+  assert.ok(on.closeFs >= 10, "the close glyph stays above the floor: " + on.closeFs.toFixed(2) + "px");
+});
+
+test("the list is capped at 100px while every row is closed, and the cap lifts the moment a row's details open", { skip }, () => {
+  const { off, on, onOpen } = m!;
+  assert.equal(off.listMax, "none", "no cap by default: the panel's own min(50vh, 340px) is the bound");
+  assert.equal(on.listMax, "100px");
+  near(on.list, 100, "six dense rows scroll inside the cap");
+  assert.ok(off.list > 100, "the same rows stand taller than the cap by default: " + off.list.toFixed(1) + "px");
+  assert.equal(onOpen.listMax, "none", "an open row lifts the cap");
+  assert.ok(onOpen.list > 100, "the open row's details show inside the panel's bound, not a second scroll: " + onOpen.list.toFixed(1) + "px");
+  assert.ok(onOpen.panel <= 340, "the panel's own cap holds: " + onOpen.panel.toFixed(1) + "px");
+});
+
+test("a row is 24px with the open-transcript arrow, which keeps its 18px, and about 20px without", { skip }, () => {
+  const { off, on } = m!;
+  near(on.rowArrow, 24, "an agent row"); near(on.rowFlat, 20.3, "a row without the arrow");
+  assert.equal(on.arrow, off.arrow, "the arrow is untouched"); near(on.arrow, 18, "the arrow's 18px", 0.1);
+  assert.ok(off.rowArrow > 28 && off.rowFlat > 28, "the default rows: " + off.rowArrow.toFixed(1) + " / " + off.rowFlat.toFixed(1) + "px");
+  assert.ok(on.bar < off.bar, "the header bar loses vertical slack too: " + on.bar.toFixed(1) + " from " + off.bar.toFixed(1) + "px");
+});
+
+test("the status word hides where the dot already says it, and stays on a timer row; the row's sizes are the panel's own", { skip }, () => {
+  const { off, on } = m!;
+  for (const st of ["running", "armed", "completed", "failed"]) {
+    assert.equal(on.status[st], "none", st + ": the dot carries the status");
+    assert.notEqual(off.status[st], "none", st + ": shown by default");
+  }
+  assert.notEqual(on.status.timer, "none", "a timer's caption stays: its dot says only waiting");
+  assert.equal(on.sumFs, 11); near(off.sumFs, 11.96, "the default .bg-sum, 0.92em at the 13px base", 0.05);
+  assert.equal(on.sinceFs, 10); near(off.sinceFs, 10.66, "the default .bg-since, 0.82em at the 13px base", 0.05);
+});
+
+test("off again, every measurement is what it was before the class went on", { skip }, () => {
+  assert.deepEqual(m!.offAgain, m!.off, "the setting leaves no trace once off");
+});

--- a/ui/webview/dense-chrome.test.ts
+++ b/ui/webview/dense-chrome.test.ts
@@ -1,0 +1,239 @@
+// COMPACT TABS AND AGENTS (the user 2026-09-08: on a phone, the tab strip and the background-work panel left
+// about three lines of transcript in view): one boolean setting, off by default, applied as ONE body class by
+// a pure applier and answered by a scoped block in styles.css. Density only: no render path changes, and every
+// dense rule shadows a default that stays byte-identical. Executable where the logic is importable
+// (settings.ts, dense-chrome.ts); pinned at the source where it lives in a foreign host (gear.js, render.ts,
+// styles.css, docs/guide.md), the repo's convention (theme.test.ts, chat-scheme.test.ts); measured in a browser where
+// one exists (dense-chrome-layout.test.ts), which is where the rendered heights the rules add up to are asserted.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { DEFAULT_SETTINGS, type RompSettings } from "./settings";
+import { applyDenseChrome, DENSE_CHROME_CLASS } from "./dense-chrome";
+
+const read = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", ...p), "utf8");
+const CSS = read("ui", "webview", "styles.css");
+const FEED = read("ui", "webview", "feed.css");
+const RENDER = read("ui", "webview", "render.ts");
+const GEAR = read("ui", "webview", "gear.js");
+const GUIDE = read("docs", "guide.md");
+
+const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+// the FIRST rule for a selector at the start of a line: the default, written above the dense block
+const defaultRule = (sel: string) => {
+  const m = CSS.match(new RegExp("(?:^|\\n)" + esc(sel) + " \\{([^}]*)\\}"));
+  assert.ok(m, sel + " has a default rule");
+  return m![1];
+};
+const denseRule = (sel: string) => {
+  const m = CSS.match(new RegExp("\\nbody\\." + DENSE_CHROME_CLASS + " " + esc(sel) + " \\{([^}]*)\\}"));
+  assert.ok(m, sel + " has a dense rule under body." + DENSE_CHROME_CLASS);
+  return m![1];
+};
+const stripComments = (css: string) => css.replace(/\/\*[\s\S]*?\*\//g, "");
+// a pin over a whole file asserts a boolean, so a red pin prints its message and the pattern, not the file
+const has = (src: string, re: RegExp, what: string) => assert.ok(re.test(src), what + " (" + re.source + ")");
+const lacks = (src: string, re: RegExp, what: string) => assert.ok(!re.test(src), what + " (" + re.source + ")");
+
+test("executable: the applier toggles exactly one body class, on for true alone", () => {
+  const classes = new Set<string>();
+  const doc = { body: { classList: { toggle: (c: string, on: boolean) => { if (on) classes.add(c); else classes.delete(c); } } } } as unknown as Document;
+  applyDenseChrome(doc, { ...DEFAULT_SETTINGS, denseChrome: true });
+  assert.deepEqual([...classes], [DENSE_CHROME_CLASS], "on: the class is present");
+  applyDenseChrome(doc, { ...DEFAULT_SETTINGS, denseChrome: false });
+  assert.deepEqual([...classes], [], "off: the class is absent");
+  applyDenseChrome(doc, { ...DEFAULT_SETTINGS, denseChrome: true });
+  applyDenseChrome(doc, { ...DEFAULT_SETTINGS });
+  assert.deepEqual([...classes], [], "the default is off");
+  applyDenseChrome(doc, { ...DEFAULT_SETTINGS, denseChrome: "yes" as unknown as boolean });
+  assert.deepEqual([...classes], [], "junk in the store never densifies: only true is on");
+  const older = { ...DEFAULT_SETTINGS } as Partial<RompSettings>;
+  delete older.denseChrome;
+  classes.add(DENSE_CHROME_CLASS);
+  applyDenseChrome(doc, older as RompSettings);
+  assert.deepEqual([...classes], [], "a store from before the setting existed reads as off");
+});
+
+test("the chat applies the class beside the scheme and the theme, at startup and on every settings change", () => {
+  has(RENDER, /import \{ applyDenseChrome \} from "\.\/dense-chrome";/, "render.ts imports the applier");
+  const body = RENDER.slice(RENDER.indexOf("function applyChatScheme("), RENDER.indexOf("function setupSettings("));
+  assert.match(body, /applyDenseChrome\(document, s\);/, "one applier call inside applyChatScheme");
+  const theme = body.indexOf("applyTheme(document, s);"), dense = body.indexOf("applyDenseChrome(document, s);");
+  assert.ok(theme >= 0 && dense > theme, "after the theme applier: the scheme, the theme, then the density");
+  // the two moments applyChatScheme runs (chat-scheme.test.ts pins the same lines): the persisted pick at
+  // startup, and the same-document / cross-tab / cross-webview settings signal, which is how a gear flip
+  // repaints the strip and the panel at once (a body class, the cascade does the rest; no rebuild)
+  has(RENDER, /applyChatScheme\(settings\);   \/\/ the persisted pick applies at startup/, "applied at startup");
+  has(RENDER, /onExternalSettingsChange\(\(s\) => \{ settings = s; applyChatScheme\(s\);/, "applied on every settings change");
+});
+
+test("the gear row mirrors the other booleans: Chat section, save path, open-time fill, defaults mirror", () => {
+  const at = GEAR.indexOf("id=rs-dense");
+  assert.ok(at > 0, "the checkbox exists in the gear markup");
+  assert.ok(GEAR.indexOf(">Chat<") < at, "in the Chat section");
+  assert.ok(GEAR.indexOf("id=rs-compact") < at && at < GEAR.indexOf("id=rs-branch"), "between Compact transcript and Show git branch");
+  assert.ok(GEAR.includes("<b>Compact tabs and agents</b>"), "the label");
+  // the sub-line leads with the panel, which every layout has, then the strip, and says where the strip half
+  // does not apply: under the phone layout's media rule (kernel.py _CHAT_MOBILE_CSS) the session picker
+  // stands in for the strip, so a phone gets the panel half alone (the guide paragraph says the same)
+  const sub = GEAR.slice(at, GEAR.indexOf("id=rs-branch")).match(/<span class=rs-sub>([^<]*)<\/span>/)![1];
+  assert.ok(sub.indexOf("background-work panel") < sub.indexOf("tab strip"), "the panel first, then the strip");
+  assert.match(sub, /about four rows/); assert.match(sub, /session picker stands in for the strip/); assert.match(sub, /Off by default\.$/);
+  assert.ok(GEAR.includes("dn = document.getElementById('rs-dense')"), "the handle");
+  assert.ok(GEAR.includes("if (dn) dn.addEventListener('change', function () { var s = load(); s.denseChrome = dn.checked; save(s); });"),
+    "the save path: save() raises romp:settings and posts settingsSync, like every boolean here");
+  assert.ok(GEAR.includes("if (dn) dn.checked = s.denseChrome === true;"), "the open-time fill reads the store");
+  const load = GEAR.slice(GEAR.indexOf("function load()"), GEAR.indexOf("function tabCtxMode"));
+  assert.equal((load.match(/denseChrome: false/g) || []).length, 2, "both copies of the defaults mirror carry the default");
+  lacks(GEAR, /denseChrome: true/, "never on by default");
+});
+
+test("the dense rules exist under the class, with these exact values", () => {
+  const tab = denseRule(".tab");
+  assert.match(tab, /gap: 3px;/); assert.match(tab, /padding: 3px 5px;/); assert.match(tab, /font-size: 0\.86em;/);
+  assert.match(denseRule(".tab .host-prefix"), /font-size: 0\.92em;/,
+    "a federated tab's host prefix compensates for the smaller tab: 0.86 x 0.92 x 13 = 10.3px, the default's rendered size (the floor test below)");
+  const add = denseRule(".tab-add");
+  assert.match(add, /padding: 3px 8px;/);
+  assert.match(add, /font-size: 1\.1em;/, "the + keeps its glyph size: the dense .tab rule outranks .tab-add's own 1.1em, so it is restated");
+  assert.match(denseRule(".tab-tagbox"), /min-height: 25px;/, "the tag control's floor follows the dense + tab's rendered height (the arithmetic test below)");
+  const head = denseRule(".tab-group-head");
+  assert.match(head, /gap: 4px;/); assert.match(head, /padding: 3px 5px 3px 4px;/);
+  assert.doesNotMatch(head, /font-size/, "the group header keeps the surface's one sub-line size (0.82em); its count inherits it and stays legible");
+  const sep = denseRule(".tab-group-sep:not(.tab-group-break)");
+  assert.match(sep, /padding: 6px 6px;/, "the trail divider's gutters scale with the row, so its line keeps the default's half-row proportion");
+  assert.doesNotMatch(sep, /width|height|background/, "the width stays the default's 13px (dragslot's virtual layout measures it); only the gutters change");
+  lacks(CSS, /\nbody\.dense-chrome \.tab-group-break/, "the row break keeps no footprint, so no dense rule names it");
+  assert.match(denseRule("#bg-tasks"), /margin: 4px 10px 4px;/);
+  assert.match(denseRule(".bg-fold-head"), /padding: 5px 11px;/);
+  const list = denseRule(".bg-list");
+  assert.match(list, /padding: 2px 2px;/); assert.doesNotMatch(list, /max-height/, "the padding holds in both states; the cap is the guarded rule (the cap test below)");
+  assert.match(denseRule(".bg-list:not(:has(.bg-task.open))"), /max-height: 100px;/, "about four rows while no row's details are open; the inner scroll is the default rule's");
+  assert.match(denseRule(".bg-group-head"), /padding: 3px 9px 1px;/);
+  const row = denseRule(".bg-head");
+  assert.match(row, /gap: 6px;/); assert.match(row, /padding: 3px 9px;/); assert.match(row, /line-height: 1\.3;/);
+  assert.match(denseRule(".bg-sum"), /font-size: 11px;/);
+  assert.match(denseRule(".bg-since"), /font-size: 10px;/);
+});
+
+test("the dense list cap lifts while a row's details are open, so a command's output is never read through two nested scrolls", () => {
+  // the list is the panel's inner scroll (bg-tasks-layout.test.ts: flex 1 1 auto, overflow-y auto, bounded by
+  // the panel's own max-height). The dense cap holds it to about four rows while every row is closed; the
+  // :not(:has(.bg-task.open)) guard drops the cap the moment a row's details open, so the panel's own
+  // min(50vh, 340px) is the only bound on the open row's command and output blocks.
+  const dense = CSS.match(new RegExp("\\nbody\\." + DENSE_CHROME_CLASS + " \\.bg-list(:not\\(:has\\([^)]*\\)\\)) \\{ max-height: (\\d+)px; \\}"));
+  assert.ok(dense, "the dense list's cap is guarded");
+  assert.equal(dense![1], ":not(:has(.bg-task.open))", "the guard names the class bgRow sets on an open row with details");
+  assert.equal(dense![2], "100", "four dense rows (24px with the arrow) plus the list's 4px of padding");
+  has(RENDER, /\(tOpen && foldable \? " open" : ""\)/, "the open class is the renderer's, set only on a row with a command or output to show");
+  has(RENDER, /const rh = el\("div", "bg-head" \+ \(foldable \? "" : " bg-flat"\)\);/, "the row head");
+  has(RENDER, /row\.appendChild\(rh\);/, "the head is the row's direct child, the shape the status-word selectors read");
+  has(CSS, /\n#bg-tasks \{[^}]*max-height: min\(50vh, 340px\);/, "the panel's own cap bounds an open row's details");
+  assert.doesNotMatch(defaultRule(".bg-list"), /max-height/, "the default list carries no cap of its own; the panel's is the bound");
+});
+
+test("the dense tag control reserves the dense + tab's exact height: the arithmetic, from the stylesheet", () => {
+  // tag-mounts.test.ts recomputes the DEFAULT pair (the .tab-tagbox floor equals the + tab's line + padding +
+  // border) from the first .tab-add and .tab-tagbox rules; the dense pair is recomputed here from the dense
+  // padding, so neither floor can drift from its + tab alone. #tabs stretches every item on a row to the
+  // tallest, so a floor left at 31px would hold the row with the + and the tag control 6px above the 25px rows.
+  const addDefault = CSS.match(/\n\.tab-add \{[^}]*\}/)![0];
+  const lineH = Number(addDefault.match(/line-height: (\d+)px/)![1]);
+  assert.doesNotMatch(denseRule(".tab-add"), /line-height/, "the dense + keeps the default's line-height");
+  const padV = Number(denseRule(".tab-add").match(/padding: (\d+)px/)![1]);
+  const tabRule = CSS.match(/^\.tab \{[\s\S]*?\n\}/m)![0];
+  const borderV = tabRule.includes("border: 1px solid") && tabRule.includes("border-bottom: none") ? 1 : 2;
+  assert.doesNotMatch(denseRule(".tab"), /border/, "the dense tab keeps the default's border");
+  has(RENDER, /const add = el\("div", "tab tab-add"\);/, "the + is a .tab, so it wears the tab's border and the dense .tab rule");
+  const minH = Number(denseRule(".tab-tagbox").match(/min-height: (\d+)px/)![1]);
+  assert.equal(minH, lineH + padV * 2 + borderV, "the dense .tab-tagbox floor equals the dense + tab's rendered height");
+  assert.equal(minH, 25);
+});
+
+test("the trailing status word hides only where the dot already says it; the label and the arrow stay", () => {
+  const m = CSS.match(/\n(body\.dense-chrome \.bg-task\.bg-[a-z]+ > \.bg-head > \.bg-status,?\n?)+ \{ display: none; \}/);
+  assert.ok(m, "one rule hides .bg-status by row status");
+  const statuses = Array.from(m![0].matchAll(/\.bg-task\.bg-([a-z]+) >/g)).map((x) => x[1]).sort();
+  assert.deepEqual(statuses, ["armed", "completed", "failed", "running"],
+    "the four captions that repeat the dot (taskRowSpec / awaitRowSpec: caption === status); a timer's caption stays, its dot says only waiting");
+  assert.doesNotMatch(m![0], /bg-sum|bg-open-agent|tool-open-agent/, "the label and the open-transcript arrow are not touched");
+  // the captions are the row specs': each of the four is the row's own status word, and the timer's is not
+  has(RENDER, /return \{ id: t\.id, status, caption: status,/, "a tracked task's caption is its status");
+  has(RENDER, /status: "running", caption: "running",/, "an agent row's");
+  has(RENDER, /status: "armed", caption: "armed",/, "a watch row's");
+  has(RENDER, /status: "waiting", caption: it\.kind === "timer" \? "timer" : null,/, "a timer's caption is not its status");
+  // the render path is unchanged: the caption is still built for every row that has one
+  has(RENDER, /if \(t\.caption\) \{ const st = el\("span", "bg-status"\); st\.textContent = t\.caption; rh\.appendChild\(st\); \}/, "the caption is still built");
+});
+
+test("every dense rule is scoped to the body class, and the sheet's defaults are untouched", () => {
+  const code = stripComments(CSS);
+  for (const line of code.split("\n")) {
+    if (!line.includes(DENSE_CHROME_CLASS)) continue;
+    assert.match(line, new RegExp("^body\\." + DENSE_CHROME_CLASS + " "), "a dense line is a body-scoped selector: " + line.trim());
+  }
+  assert.doesNotMatch(FEED, /dense-chrome/, "the strip and the panel live in styles.css alone; the feed's sheet has no dense rule");
+  // the defaults, byte for byte the values the dense rules shadow
+  const tab = defaultRule(".tab");
+  assert.match(tab, /gap: 4px;/); assert.match(tab, /padding: 6px 7px; font-size: 0\.92em;/);
+  assert.match(defaultRule(".tab-add"), /font-size: 1\.1em; padding: 6px 10px;/);
+  assert.match(defaultRule(".host-prefix"), /font-size: 0\.86em;/);
+  assert.match(defaultRule(".tab-tagbox"), /min-height: 31px;/);
+  assert.match(defaultRule(".tab-group-sep:not(.tab-group-break)"), /width: 13px; padding: 8px 6px;/);
+  const head = defaultRule(".tab-group-head");
+  assert.match(head, /gap: 5px; padding: 6px 7px 6px 6px;/); assert.match(head, /font-size: 0\.82em;/);
+  assert.match(defaultRule("#bg-tasks"), /margin: 8px 10px 6px;/);
+  assert.match(defaultRule(".bg-fold-head"), /padding: 7px 11px;/);
+  assert.match(defaultRule(".bg-list"), /padding: 4px 2px;/);
+  assert.match(defaultRule(".bg-group-head"), /padding: 6px 9px 2px; font-size: 0\.72em;/);
+  assert.match(defaultRule(".bg-head"), /gap: 8px; padding: 5px 9px;/);
+  assert.match(defaultRule(".bg-sum"), /font-size: 0\.92em;/);
+  assert.match(defaultRule(".bg-since"), /font-size: 0\.82em;/);
+  // the defaults come first, so the tests that read a selector's first rule keep reading the default
+  // (tag-mounts.test.ts: .tab-add, .tab-tagbox; bg-tasks-layout.test.ts: #bg-tasks, .bg-fold-head, .bg-sum, .bg-head)
+  for (const sel of [".tab", ".tab-add", ".tab-tagbox", ".tab-group-head", ".tab-group-sep:not(.tab-group-break)", "#bg-tasks", ".bg-fold-head", ".bg-list", ".bg-group-head", ".bg-head", ".bg-sum", ".bg-since"]) {
+    assert.ok(CSS.indexOf("\n" + sel + " {") < CSS.indexOf("\nbody." + DENSE_CHROME_CLASS + " " + sel + " {"), sel + ": default before dense");
+  }
+  assert.ok(CSS.indexOf("\n.host-prefix {") < CSS.indexOf("\nbody." + DENSE_CHROME_CLASS + " .tab .host-prefix {"), ".host-prefix: default before dense");
+  assert.ok(CSS.indexOf("\n.bg-status {") < CSS.indexOf("\nbody." + DENSE_CHROME_CLASS + " .bg-task.bg-running"), ".bg-status: default before the dense hide");
+});
+
+test("the dense sizes are the sheet's own rungs and none is under the 10px floor", () => {
+  const block = stripComments(CSS.slice(CSS.indexOf("body." + DENSE_CHROME_CLASS + " .tab {")));
+  const sizes = Array.from(block.matchAll(/font-size: ([^;]+);/g)).map((m) => m[1]);
+  assert.deepEqual([...new Set(sizes)].sort(), ["0.86em", "0.92em", "1.1em", "10px", "11px"],
+    "0.86em and 0.92em are on the em ladder (css-vocab.test.ts); 1.1em is the +'s own, restated; 11px and 10px sit one step under the panel's 0.92em and 0.82em (11.96px and 10.66px at the 13px base)");
+  for (const s of sizes) {
+    const px = s.endsWith("em") ? parseFloat(s) * 13 : parseFloat(s);
+    assert.ok(px >= 10, s + " is at or above the 10px floor");
+  }
+  // nested em compounds: a child of the tab with its own em size renders at the dense tab's em times its own,
+  // which the declared sizes above never show. A federated tab's host prefix at its default 0.86em would render
+  // at 9.6px under the bare 0.86em tab. Every em-sized child render.ts puts inside a .tab: the label's host
+  // prefix (host-prefix.ts hostNameNodes) and the close glyph.
+  has(RENDER, /label\.replaceChildren\(\.\.\.hostNameNodes\(s\.name, id\)\);/, "the label's host prefix");
+  has(RENDER, /const close = el\("span", "tab-close"\);/, "the close glyph");
+  has(read("ui", "webview", "host-prefix.ts"), /h\.className = off \? "host-prefix off" : "host-prefix";/, "the prefix's class");
+  const em = (rule: string, what: string) => { const m = rule.match(/font-size: ([\d.]+)em;/); assert.ok(m, what + " has an em size"); return parseFloat(m![1]); };
+  const tabEm = em(denseRule(".tab"), "the dense tab");
+  for (const child of [".host-prefix", ".tab-close"]) {
+    const dense = CSS.match(new RegExp("\\nbody\\." + DENSE_CHROME_CLASS + " \\.tab " + esc(child) + " \\{([^}]*)\\}"));
+    const childEm = em(dense ? dense[1] : defaultRule(child), child);
+    const px = tabEm * childEm * 13;
+    assert.ok(px >= 10, child + " renders at " + px.toFixed(2) + "px inside a dense tab, at or above the 10px floor");
+  }
+  lacks(stripComments(CSS), /\n\.tab(?:[.:][^ {\n]*)? [^{\n]+\{[^}]*font-size: [\d.]+em/, "no other em-sized .tab descendant rule exists in the sheet (add it to the list above if one appears)");
+});
+
+test("the guide names the setting by its gear label, and its paragraph leads with the panel and qualifies the strip", () => {
+  has(GUIDE, /\*\*Compact tabs and agents\*\*/, "the gear label, bold like the other settings named there");
+  has(GUIDE, /about four/, "the cap in rows");
+  const at = GUIDE.indexOf("**Compact tabs and agents**");
+  assert.ok(GUIDE.indexOf("### The chat") < at && at < GUIDE.indexOf("### The feed"), "in the chat section, with the other chat settings");
+  const para = GUIDE.slice(GUIDE.lastIndexOf("\n\n", at), GUIDE.indexOf("\n\n", at));
+  assert.ok(para.indexOf("background-work panel") < para.indexOf("tab strip"),
+    "the panel first (every layout has it), then the strip, which the phone layout replaces with the session picker");
+  assert.match(para, /session picker stands in for the strip/);
+  assert.match(para, /lifts while a row's details are open/, "the cap's open-row lift is stated where the four rows are");
+});

--- a/ui/webview/dense-chrome.ts
+++ b/ui/webview/dense-chrome.ts
@@ -1,0 +1,15 @@
+// COMPACT TABS AND AGENTS (the gear's denseChrome setting; the user 2026-09-08: on a phone, the tab strip
+// and the background-work panel left about three lines of transcript in view). Density only: ONE body
+// class, `dense-chrome`, that styles.css's scoped block keys on for the strip's tabs and group headers and
+// the #bg-tasks panel's rows. The chat calls this beside applyTheme from applyChatScheme (render.ts), at
+// startup and on every settings change, so a gear flip repaints the strip and the panel at once through
+// the cascade, with no rebuild of either. Pure over the document it is handed, like theme.ts, so a test
+// can run it against a fake body. Absent or off, the class is removed and the page renders exactly as
+// before the setting existed.
+import type { RompSettings } from "./settings";
+
+export const DENSE_CHROME_CLASS = "dense-chrome";
+
+export function applyDenseChrome(doc: Document, s: RompSettings): void {
+  doc.body.classList.toggle(DENSE_CHROME_CLASS, s.denseChrome === true);
+}

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -100,6 +100,12 @@ var GEAR_HTML =
   '<span><b>Compact transcript</b>' +
   '<span class=rs-sub>Collapse each run of tool uses into one line and hide thinking blocks in the chat.</span>' +
   '</span></label>' +
+  // compact tabs and agents (the user 2026-09-08: on a phone, the strip and the background-work panel left about
+  // three lines of transcript in view): density only, a body class render.ts applies (dense-chrome.ts)
+  '<label class=rs-row><input type=checkbox id=rs-dense>' +
+  '<span><b>Compact tabs and agents</b>' +
+  '<span class=rs-sub>Keeps more of the transcript in view: tighter rows in the background-work panel under the transcript, which shows about four rows and scrolls for the rest, and smaller tabs and group headers in the tab strip. On a phone the session picker stands in for the strip, so there only the panel changes. Off by default.</span>' +
+  '</span></label>' +
   '<label class=rs-row><input type=checkbox id=rs-branch>' +
   '<span><b>Show git branch</b>' +
   "<span class=rs-sub>Show the session's git branch (when it's in a repo) in the chat bottom bar, beside the directory.</span>" +
@@ -232,6 +238,7 @@ function initGear(post) {
     dd = document.getElementById('rs-defaultdir'), gb = document.getElementById('rs-branch'),
     tc = document.getElementById('rs-tabctx'),
     sr = document.getElementById('rs-striprows'),
+    dn = document.getElementById('rs-dense'),
     cs = document.getElementById('rs-chatscheme'),
     tt = document.getElementById('rs-theme'),
     cg = document.getElementById('rs-collapsegaps'), ao = document.getElementById('rs-activeonly'),
@@ -247,7 +254,7 @@ function initGear(post) {
     fe = document.getElementById('rs-fileedit'),
     ths = document.getElementById('rs-thinksum'),
     ans = document.getElementById('rs-autonudge-split'), asub = document.getElementById('rs-autonudge-sub');
-  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', stripGroupRows: true, collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', stripGroupRows: true, collapseGaps: true, activeOnly: true }; } }
+  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', stripGroupRows: true, denseChrome: false, collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', stripGroupRows: true, denseChrome: false, collapseGaps: true, activeOnly: true }; } }
   // mirrors settings.ts tabCtxMode (this file can't import the TS module): the gauge shipped for a
   // few hours as a boolean toggle — false was an explicit hide, true the default nobody chose.
   function tabCtxMode(v) { return (v === 'always' || v === 'never') ? v : (v === false ? 'never' : 'over50'); }
@@ -268,6 +275,8 @@ function initGear(post) {
   if (gb) gb.addEventListener('change', function () { var s = load(); s.showBranch = gb.checked; save(s); });
   // one tag group per row in the tab strip (on by default); render.ts repaints the strip on the save
   if (sr) sr.addEventListener('change', function () { var s = load(); s.stripGroupRows = sr.checked; save(s); });
+  // compact tabs and agents (off by default): render.ts applies a body class on the save, and the strip and the panel repaint through the cascade
+  if (dn) dn.addEventListener('change', function () { var s = load(); s.denseChrome = dn.checked; save(s); });
   if (tc) tc.addEventListener('change', function () { var s = load(); s.tabCtx = tc.value; save(s); });
   // ── the settings' value-picker DROPDOWNS (T117, the user 2026-08-27, screenshot: the Chat
   // tabs and Text scheme pickers rendered every option always-expanded, and the description spans
@@ -1196,7 +1205,7 @@ function initGear(post) {
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
     try { if (window.parent !== window) window.parent.postMessage({ romp: 'logUnseenQuery' }, '*'); } catch (e) { /* no shell to ask */ }   // T290: the Open log count
-    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (sr) sr.checked = s.stripGroupRows !== false; if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); paintBackendOffer(tb ? tb.checked : false); if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (sr) sr.checked = s.stripGroupRows !== false; if (dn) dn.checked = s.denseChrome === true; if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); paintBackendOffer(tb ? tb.checked : false); if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   // The shortcuts row: the web shell (same-origin parent) gets the customize link — it opens the

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -15,6 +15,7 @@ import type { ParsedAsk } from "../ask-types";
 import { TABBAR_H_KEY, TABBAR_H_DEFAULT, clampTabbarH, parseTabbarH } from "./tabbar-resize";
 import { ctxFallbackColor, pickTone, readableRgb } from "./ctx-color";
 import { applyTheme } from "./theme";
+import { applyDenseChrome } from "./dense-chrome";
 import { SessionViews, viewVisible, viewsKey, revealIn, viewTagUnion, viewTags, type TagUnion, type SessionTag } from "./session-views";
 import { mintWriteId, ackOutcome, adoptViews, seqOf, capsAdopts, announcedSeq, announcedAfter, createInFlight, rederivePending, lensBlob, applyLensFields, type InflightWrite, type LensFields, type TagEditOp, type ViewsAck } from "./views-writes";
 import { lensVisible, surfaceLens } from "./tag-lens";
@@ -16311,6 +16312,10 @@ function applyChatScheme(s: RompSettings): void {
   // the overall theme (T113 promoted 2026-08-28): the shared applier toggles the strip-aesthetic
   // and light-theme classes from s.theme. Applies live — onExternalSettingsChange re-runs this.
   applyTheme(document, s);
+  // compact tabs and agents (the user 2026-09-08): a body class the strip's and the #bg-tasks panel's dense
+  // rules key on (styles.css body.dense-chrome). The same two moments as the scheme and the theme, so the
+  // gear's flip repaints both surfaces at once through the cascade; neither is rebuilt.
+  applyDenseChrome(document, s);
 }
 function setupSettings(): void {
   applyChatScheme(settings);   // the persisted pick applies at startup — it survives reloads

--- a/ui/webview/settings.test.ts
+++ b/ui/webview/settings.test.ts
@@ -92,3 +92,18 @@ test("an unknown key in storage is ignored, known keys still merge", () => {
   assert.equal(s.compact, true);
   assert.equal((s as any).future, 42, "merge is shallow — extra keys pass through harmlessly");
 });
+
+// Compact tabs and agents (the user 2026-09-08: on a phone, the tab strip and the background-work panel
+// left about three lines of transcript in view): OFF by default, so the strip and the panel render exactly
+// as before the setting existed until the gear opts in. Distinct from `compact`, the transcript's own
+// tidy-up (tool runs collapsed, thinking hidden). The class it drives is dense-chrome.test.ts's subject.
+test("Compact tabs and agents defaults OFF (the user 2026-09-08); the opt-in round-trips, and a store from before the key reads as off", () => {
+  assert.equal(DEFAULT_SETTINGS.denseChrome, false);
+  delete store["romp:settings"];
+  assert.equal(loadSettings().denseChrome, false, "a fresh install reads off");
+  saveSettings({ denseChrome: true });
+  assert.equal(loadSettings().denseChrome, true, "the opt-in survives a reload (localStorage)");
+  store["romp:settings"] = JSON.stringify({ compact: true });
+  assert.equal(loadSettings().denseChrome, false, "a store written before the key reads as off");
+  delete store["romp:settings"];
+});

--- a/ui/webview/settings.ts
+++ b/ui/webview/settings.ts
@@ -21,6 +21,7 @@ export interface RompSettings {
   chatScheme: ChatScheme;    // chat TEXT scheme (the user 2026-08-24): raises body-text contrast without collapsing the tool-dimmer-than-prose hierarchy. A scheme = a text-tier variable set (styles.css body.scheme-*); "default" applies nothing — today's values exactly.
   chatTabTheme: ChatTabTheme;   // LEGACY, derived (2026-08-28): the chat TAB STRIP's appearance (T113). Now computed from `theme` on every load/save ("classic" -> classic strip, anything else -> the yatharth strip) so older panes/extension builds keep working; never set it directly.
   theme: Theme;   // the OVERALL dashboard theme (the user 2026-08-27, promoting the tab-strip setting): "classic" = the pre-720 dark look; "yatharth" = dark + the contributed strip aesthetic (what chatTabTheme:"yatharth" was); "yatharth-light" = the warm light theme (body.theme-light + the yatharth strip). Migration: a store written before `theme` existed seeds it from chatTabTheme.
+  denseChrome: boolean;   // chat page: COMPACT TABS AND AGENTS (the user 2026-09-08: on a phone, the tab strip and the background-work panel left about three lines of transcript in view). Density only, as a body class (dense-chrome.ts applyDenseChrome, run with the scheme and theme appliers): smaller tabs and group headers in the strip, tighter rows in the #bg-tasks panel with its list capped at about four rows. OFF by default: the strip and the panel are unchanged until the gear opts in. Distinct from `compact`, the transcript's own tidy-up (tool runs collapsed, thinking hidden).
 }
 // Solarized LIGHT is deliberately absent (the user allowed skipping it): its text tiers are designed
 // for a paper-light ground and invert into mud on romp's dark canvas — an unreadable preset is worse
@@ -51,7 +52,7 @@ export function tabCtxMode(v: unknown): TabCtxMode {
 // hand-written "why" as their line; they show the distiller's summary instead (the why demotes to a hover).
 // compact defaults ON (the user 2026-07-14): a fresh install reads the tidy transcript
 // (thinking hidden, tool runs folded); the gear opts back into the full stream.
-export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, tabCtx: "over50", stripGroupRows: true, chatScheme: "default", chatTabTheme: "classic", theme: "classic" };
+export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, tabCtx: "over50", stripGroupRows: true, chatScheme: "default", chatTabTheme: "classic", theme: "classic", denseChrome: false };
 const KEY = "romp:settings";
 
 export function loadSettings(): RompSettings {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3814,3 +3814,62 @@ body.filebrowse-open { overflow: hidden; }
    Custom Highlight API (no DOM surgery — the turn list re-renders constantly). Accent-tinted like
    the focus family, never a status colour. */
 ::highlight(cite-span) { background-color: color-mix(in srgb, var(--accent) 30%, transparent); color: var(--text-bright); }
+
+/* COMPACT TABS AND AGENTS (the gear's denseChrome setting; the user 2026-09-08: on a phone, the tab strip and
+   the background-work panel left about three lines of transcript in view). Density only, under ONE body class
+   the settings applier toggles (dense-chrome.ts applyDenseChrome, run from applyChatScheme at startup and on
+   every settings change), so a gear flip repaints the strip and the panel at once through the cascade and
+   neither is rebuilt. Every rule here is scoped to body.dense-chrome and shadows a default written above; the
+   defaults themselves are untouched, and the trailing comment on each line records the value it shadows
+   (dense-chrome.test.ts pins both). Sizes reuse the sheet's own rungs: the tab's 0.86em is on the em ladder
+   (css-vocab.test.ts); the row's 11px and 10px sit one step under the panel's 0.92em and 0.82em (.bg-sum, .bg-since:
+   11.96px and 10.66px at the 13px base) and on the 10px floor. The group
+   header keeps its 0.82em: the next rung down, 0.72em, is 9.4px at the 13px base, under the 10px floor the
+   sheet's smallest labels sit at, and the sections wear one size (tab-groups.test.ts); its count inherits that
+   size and stays legible. Click targets after (dense-chrome-layout.test.ts measures them): a tab about 25px
+   tall (32px by default), and a group header the same, since #tabs stretches every item on a row to the tallest
+   (on its own it is about 25px, from 31px); a row about 20px (29px), or 24px with the open-transcript arrow,
+   which keeps its 18px. Off by default. Nothing here touches #tabbar itself: under the phone layout's media rule
+   (kernel.py _CHAT_MOBILE_CSS) the bar holds the session picker, not the strip, so on a phone only the panel
+   tightens. */
+body.dense-chrome .tab { gap: 3px; padding: 3px 5px; font-size: 0.86em; }              /* 4px; 6px 7px; 0.92em */
+/* a federated tab's host prefix is a 0.86em child of the label (host-prefix.ts hostNameNodes), so under the 0.86em tab
+   it would compound to 9.6px (0.86 x 0.86 x 13), under the 10px floor; 0.92em (on the ladder) puts it back at the
+   default's rendered 10.3px. The tab's other em child, .tab-close at 1.1em, stays above the floor on its own. */
+body.dense-chrome .tab .host-prefix { font-size: 0.92em; }                              /* 0.86em */
+/* the + keeps its glyph size: the dense .tab rule above (0,2,1) outranks .tab-add's own 1.1em (0,1,0), so the size
+   is restated; its height is still 25px because .tab-add pins its 18px line-height */
+body.dense-chrome .tab-add { padding: 3px 8px; font-size: 1.1em; }                      /* 6px 10px; 1.1em, restated */
+/* the tag control's floor is the + tab's rendered height, as by default (styles.css .tab-tagbox, tag-mounts.test.ts):
+   the 18px line + 2 x 3px dense padding + the 1px border; #tabs stretches every item on a row to the tallest, so
+   without this the row holding the + and the tag control would stay 31px beside 25px rows */
+body.dense-chrome .tab-tagbox { min-height: 25px; }                                     /* 31px */
+body.dense-chrome .tab-group-head { gap: 4px; padding: 3px 5px 3px 4px; }               /* 5px; 6px 7px 6px 6px */
+/* the untagged trail's divider (the inline layout, stripGroupRows off): its 1px line is the content area under fixed
+   gutters, so the 8px gutters sized for the 32px row would leave a 9px line in the 25px row; 6px keeps the default's
+   half-row proportion (about 13px). Scoped off the row break, which must keep no footprint; the width stays 13px,
+   so the tab drag's virtual layout (dragslot.ts) is unaffected */
+body.dense-chrome .tab-group-sep:not(.tab-group-break) { padding: 6px 6px; }            /* 8px 6px */
+/* the panel: the rows shrink; the header keeps its 12px, it is the panel's title */
+body.dense-chrome #bg-tasks { margin: 4px 10px 4px; }                                   /* 8px 10px 6px */
+body.dense-chrome .bg-fold-head { padding: 5px 11px; }                                  /* 7px 11px */
+/* the cap: about four rows while no row's details are open, the inner scroll .bg-list already has taking the rest.
+   Four 24px rows (3px + the 18px arrow + 3px; a row without the arrow is about 20px) plus the list's 4px of padding.
+   The :not(:has(.bg-task.open)) guard lifts the cap the moment a row's details open, so the panel's own
+   min(50vh, 340px) is the only bound on an open row and a command's output tail is never read through two nested
+   scrolls. The padding stays on the bare rule so it holds in both states. */
+body.dense-chrome .bg-list { padding: 2px 2px; }                                        /* 4px 2px */
+body.dense-chrome .bg-list:not(:has(.bg-task.open)) { max-height: 100px; }              /* no cap of its own; the panel's min(50vh, 340px) bounds it */
+body.dense-chrome .bg-group-head { padding: 3px 9px 1px; }                              /* 6px 9px 2px */
+body.dense-chrome .bg-head { gap: 6px; padding: 3px 9px; line-height: 1.3; }            /* 8px; 5px 9px; the body's 1.6 */
+body.dense-chrome .bg-sum { font-size: 11px; }                                          /* 0.92em */
+body.dense-chrome .bg-since { font-size: 10px; }                                        /* 0.82em */
+/* the trailing status word goes where the dot already says it: a row's caption IS its status (taskRowSpec and
+   awaitRowSpec: running, armed, completed, failed) and the dot wears that status's tint (.bg-task.bg-<status>
+   sets --bgt), so the word repeats the dot. A "timer" caption stays: its dot says only waiting. The label and
+   the open-transcript arrow stay. Hidden by the sheet, so the render path is unchanged and the word is back the
+   moment the setting goes off. */
+body.dense-chrome .bg-task.bg-running > .bg-head > .bg-status,
+body.dense-chrome .bg-task.bg-armed > .bg-head > .bg-status,
+body.dense-chrome .bg-task.bg-completed > .bg-head > .bg-status,
+body.dense-chrome .bg-task.bg-failed > .bg-head > .bg-status { display: none; }


### PR DESCRIPTION
Builds on #1168 (Tab strip: one tag group per row becomes a gear setting, on by default): both changes add a row to the gear's Chat section and edit the same one-line settings literals (DEFAULT_SETTINGS in settings.ts, load() and the open-time fill in gear.js) and the same closing paragraph of the guide's chat section, and one dense rule here scales the untagged trail's divider that #1168 introduces. This PR is one commit on top of #1168's head; the diff to review is that commit.

A "Compact tabs and agents" setting in the gear's Chat section, off by default, shrinks the tab strip's tabs and group headers and tightens the background-work panel under the transcript (its rows, and a cap of about four rows while none is open), so a small screen keeps more of the transcript in view. Density only: one body class from a pure applier and one scoped block at the end of styles.css; every default is byte-identical.

## Tier

Tier: feature

## Design

- Why a new key. `compact` is the transcript's own tidy-up (tool runs collapsed, thinking hidden) and defaults on; the density of the strip and the panel is a different choice with a different default (off), so it is its own boolean, `denseChrome`, stored per browser with the other chat settings in romp:settings. The kernel never sees it.
- One body class from a pure applier. dense-chrome.ts applyDenseChrome(doc, s) toggles body.dense-chrome on `=== true`; render.ts calls it from applyChatScheme after applyTheme, so it runs at startup and on every settings change, and a flip in another tab or pane repaints both surfaces through the cascade with no rebuild of the strip or the panel. Pure over the document it is handed, like theme.ts, so a test runs it against a fake body.
- Density only, defaults untouched. Every rule is scoped to body.dense-chrome in one block at the end of styles.css, each shadowing a default written above and recording the shadowed value in a trailing comment; no render path changes. Off, the page is exactly what it was before the setting existed. The block stays at the tail because tag-mounts.test.ts and bg-tasks-layout.test.ts read the FIRST match of .tab-add, .tab-tagbox, .bg-sum and .bg-head.
- Sizes reuse the sheet's rungs, no new font size. Tabs go 0.92em to 0.86em (both on the six-rung em ladder css-vocab.test.ts pins); the panel's rows take its own 11px and 10px (.bg-since, .bg-status). The group header keeps 0.82em: the next rung, 0.72em, is 9.4px at the 13px base, under the 10px floor the sheet's smallest labels sit at, and the sections wear one size (tab-groups.test.ts). A federated tab's host prefix is restated at 0.92em because 0.86em inside a 0.86em tab would compound to 9.6px; at 0.92em it keeps its 10.3px render. .tab-add restates its 1.1em because the dense .tab rule (0,2,1) outranks .tab-add's own (0,1,0).
- Click targets after, measured in a browser (dense-chrome-layout.test.ts). A tab 25px tall (32px by default); a group header the same, since #tabs stretches every item on a row to the tallest (on its own it is about 25px, from 31px); a panel row about 20px, or 24px with the open-transcript arrow, which keeps its 18px. The tag control's floor follows the + tab (18px line + 2 x 3px + 1px border = 25px), since #tabs stretches every item on a row to the tallest. Under the 24px touch floor on a coarse-pointer tablet wider than the phone layout is the opt-in trade the setting exists for; the row's arrow and the Stop button keep their sizes.
- The status word hides only where the dot already says it. A row's caption is its status (running, armed, completed, failed) and the dot wears that status's tint, so the word repeats the dot; a timer's caption stays because its dot says only waiting. Hidden by the sheet, so the word is back the moment the setting goes off.
- The list cap. About four rows (100px: four 24px rows plus the list's padding) while no row's details are open, using the inner scroll .bg-list already has; the rule carries :not(:has(.bg-task.open)) so an open row lifts the cap to the panel's own min(50vh, 340px) and a command's output tail is not read through two nested scrolls.
- #tabbar is untouched on purpose. Under the phone layout's media rule (pointer:coarse and max-width 1024px, kernel.py _CHAT_MOBILE_CSS) the kernel hides the strip and shows its session picker, so the strip rules apply wherever the strip shows and on a phone the setting tightens the panel alone. The gear's sub-line and the guide say so, leading with the panel.
- Deliberately left out: no change to the phone layout's own header or picker, no change to `compact`, no kernel change, and no render-path change; a denser transcript would be its own setting.

## Tests

- ui/webview/settings.test.ts: DEFAULT_SETTINGS.denseChrome is false, a fresh store reads off, saveSettings({denseChrome: true}) round-trips through localStorage, and a store from before the key reads off. Before the change the key is absent and the first assertion fails (undefined is not false).
- ui/webview/dense-chrome.test.ts: executing, the applier against a fake body adds the class for true alone and removes it for false, the default, junk, and a store from before the key; before the change the module does not exist and the test bundle fails to resolve it. Source pins in the same file (the theme.test.ts / chat-scheme.test.ts convention, each whole-file pin asserting a boolean so a red pin prints its message, not the file): render.ts imports the applier and calls it inside applyChatScheme after applyTheme; gear.js has the row between Compact transcript and Show git branch, the handle, the save path, the open-time fill, the default in both load() literals and never `denseChrome: true`; every dense rule with its exact value; every line naming the class is body-scoped; every shadowed default unchanged and before the block; the status-word rule covers exactly the four statuses and leaves .bg-sum and the arrow alone; the cap's guard and 100px; the tag control's 25px recomputed from the + tab's line, padding and border; every size a rung and no compounded em under 10px at the 13px base; feed.css has no dense rule; the guide names the setting by its gear label and leads with the panel.
- ui/webview/dense-chrome-layout.test.ts: measured, where a Playwright browser exists (CI installs none, so there it skips loudly, the queued-romp-layout.test.ts pattern). The strip and panel markup render.ts builds is laid out against the real stylesheet with the class off, on, on with a row's details open, and off again: the tab, the + tab, the tag control and the group header at 25px (32px off); the divider's width unchanged and its line 13px; the host prefix at the same 10.3px in both states; the list at 100px with every row closed and its cap gone with a row open, inside the panel's 340px; an agent row at 24px with its 18px arrow and a plain row at about 20px; the four status words hidden and the timer's shown; the label and elapsed sizes at 11px and 10px; and every measurement identical before the class went on and after it came off. It sees what the text pins cannot: a later default rule that outranks the guarded cap leaves every pin green and turns this test red.
- tests/test_kernel.py test_gear_has_compact_tabs_and_agents_toggle (the test_gear_has_show_git_branch_toggle convention) and tests/test_kernel_settings_sections.py (the row listed under Chat); both fail before the change on the missing id=rs-dense.
- Existing pins that stay green with the block at the tail: css-vocab (em ladder), tab-groups (one size across the .tab-group- rules), tag-mounts and bg-tasks-layout (first-match reads), theme, chat-scheme, tab-drag-live.
- Ran: npm run typecheck; the full npm test (3670 tests, 0 failures, 0 skipped); pytest tests/test_kernel_settings_sections.py plus the two gear pins in tests/test_kernel.py (11 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)