### PR TITLE
File viewer: rendered markdown in a document type scale, a centred 80-character measure, numbered fences with Copy, six more grammars, readable code comments, and a print sheet

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -73,6 +73,19 @@ lands on it. An image map (`<map>`, `usemap`) is dropped. The same rules apply t
 a chat message, where a link to an element's own `id` or `<a name>` lands on it under the
 prefix.
 
+**Text size and width.** The **A−** and **A+** buttons in the viewer's title bar make the
+text of any text file smaller or larger in fixed steps from 70% to 200%: a markdown file's
+Rendered and Raw views, the code view of every other text file, and a document opened from
+a link on the dashboard's own address. They appear wherever the viewer opens (over the chat
+or the feed), and not for a picture or a PDF, which have no text to size. Ctrl (or Cmd) and
+the mouse wheel over the text do the same. Once the size is off 100%, the percentage appears
+between the buttons; click it to go back. The choice is kept in this browser and applies to
+every file you open here. Prose keeps a readable line length that grows with the text size,
+and code blocks keep that width and wrap long lines. A table is as wide as its columns need,
+up to the width of the viewer, and scrolls sideways on its own beyond that; a table inside a
+quote or a list item stays within the prose width. Pictures shrink to fit, so the page is
+never wider than the viewer.
+
 **Opening a PDF.** A PDF the session mentions, or one you click in the file browser, opens
 inside the dashboard like an image: the chat's PDF card opens it full-view, a path or a
 file-browser row opens it in the file viewer. Cmd-click it instead (Ctrl on Windows and

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -56,7 +56,13 @@ file served from the dashboard's own address (a published report, an evidence do
 and links inside the document resolve relative to the document, so a `![fig](fig.png)`
 beside it shows, and a link to a sibling document opens in the same viewer. Links to files
 on other sites open in a new tab, as before — and a ctrl- or ⌘-click still opens the file in
-a tab.
+a tab. The document is set for reading: a sans face at a slightly larger size, headings in
+proportion, a centred column about 80 characters wide, and task lists, keyboard keys and
+aligned table columns as GitHub shows them. Every code block is numbered by line and carries a
+**Copy** button that copies the block as the file holds it, tabs included; fences labelled
+`rust`, `go`, `c`, `java`, `sql` or `toml` are highlighted, in addition to the languages the
+chat already knows. Printing the page while a rendered file is open prints the file alone,
+black on white, across as many pages as it needs.
 
 **A file's own HTML.** The Rendered view keeps the HTML a markdown file carries, under rules
 modelled on those GitHub applies to a README, so nothing in a file can move, hide or cover the

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -249,6 +249,18 @@ ghostty --working-directory={dir}   # Linux: Ghostty
 code {dir}                          # VS Code instead
 ```
 
+### The file viewer's per-browser choices
+
+The file viewer keeps two choices in the browser's own storage, not on the
+kernel, so they survive a kernel restart and apply wherever the viewer opens
+(over the chat or the feed, and for a document opened from a link on the
+dashboard's own address): the Rendered or Raw view of a markdown file
+(`romp:fileviewFmt`) and the text size (`romp:fileviewTextSize`, one of 70,
+80, 90, 100, 115, 130, 150, 175 or 200 percent, set by the **A−** / **A+**
+buttons or Ctrl/Cmd + wheel over the text). The size scales the prose, its
+headings, the code and the Raw view together, and the prose measure with
+them; a value outside the table reads as 100.
+
 ### Model and effort, from the statusline or a typed command
 
 Typing `/model X` or `/effort X` into the chat composer, or sending one with

--- a/ui/webview/code-block.test.ts
+++ b/ui/webview/code-block.test.ts
@@ -1,0 +1,411 @@
+// The shared code-block module (code-block.ts): the per-line rows and the Copy button every rendered fence wears, in the
+// chat and in the file viewer. The chat's highlight() (render.ts) and the viewer's mdBlock (file-view.ts) import the same
+// two functions; file-view.ts cannot import render.ts (render.ts imports it, and the feed bundle must not carry the chat),
+// so the module is their meeting point. Executed: the pure walk (wrapLinesHtml) over plain and highlighted lines, a span
+// straddling a newline, a trailing newline; wrapCodeLines over a code element (the rows, the digit count it writes for the
+// gutter); addCopyBtn over a DOM stand-in (one button, idempotent; the click and Space copy the text the caller gave it,
+// through the Clipboard API or the execCommand fallback; the acknowledgement lands on the button on screen of the fence
+// with the copied source, after a rebuild swapped the pressed one out). Pinned: the two callers' shapes, the bundle
+// boundary (file-view.ts and feed.ts import nothing from render.ts), the sheets' scoped copies byte-equal in styles.css
+// and feed.css with the counter reset on `.fileview-md pre code`, the six viewer grammars registered on the core by
+// viewer-grammars.ts (executed) and reached through file-view.ts, and the chat's auto-detection kept to its ten
+// (highlight-cache.ts AUTO_LANGUAGES, executed).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import hljs from "highlight.js/lib/core";
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const read = (f: string) => fs.readFileSync(path.join(UI, f), "utf8");
+const BLOCK = read("code-block.ts");
+const RENDER = read("render.ts");
+const VIEW = read("file-view.ts");
+const CHAT = read("styles.css");
+const FEED = read("feed.css");
+
+// ── a DOM stand-in: the members the module touches ─────────────────────────────────────────────────
+// A tree with classes, a style map, listeners, a small selector matcher (a class, a tag with a class, `:scope > .x`),
+// isConnected through the root, and a MutationObserver whose callbacks the test fires by hand.
+class El {
+  parentElement: El | null = null;
+  children: El[] = [];
+  type = ""; title = ""; textContent = "";
+  private classes = new Set<string>();
+  private props = new Map<string, string>();
+  private html = "";
+  private listeners = new Map<string, Array<(ev: any) => void>>();
+  constructor(public tagName: string) {}
+  get className(): string { return [...this.classes].join(" "); }
+  set className(v: string) { this.classes = new Set(v.split(/\s+/).filter(Boolean)); }
+  classList = {
+    add: (c: string) => { this.classes.add(c); },
+    remove: (c: string) => { this.classes.delete(c); },
+    toggle: (c: string, on: boolean) => { if (on) this.classes.add(c); else this.classes.delete(c); },
+    contains: (c: string) => this.classes.has(c),
+  };
+  style = {
+    setProperty: (k: string, v: string) => { this.props.set(k, v); },
+    getPropertyValue: (k: string) => this.props.get(k) ?? "",
+  };
+  /** innerHTML is a string: setting it parses nothing, and childElementCount counts the `.cl` rows the module wrote. */
+  get innerHTML(): string { return this.html; }
+  set innerHTML(v: string) { this.html = v; }
+  get childElementCount(): number { return this.children.length || (this.html.match(/<span class="cl">/g) || []).length; }
+  get isConnected(): boolean { let n: El | null = this; while (n.parentElement) n = n.parentElement; return n === docBody; }
+  appendChild(c: El): El { c.parentElement?.removeChild(c); c.parentElement = this; this.children.push(c); return c; }
+  removeChild(c: El): El { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); c.parentElement = null; return c; }
+  replaceChildren(...cs: El[]): void { for (const c of this.children.slice()) this.removeChild(c); for (const c of cs) this.appendChild(c); }
+  remove(): void { this.parentElement?.removeChild(this); }
+  private fits(part: string): boolean {
+    const m = /^([a-z]*)((?:\.[\w-]+)*)$/.exec(part);
+    if (!m) return false;
+    if (m[1] && m[1] !== this.tagName) return false;
+    return (m[2].match(/\.[\w-]+/g) || []).every((c) => this.classes.has(c.slice(1)));
+  }
+  querySelectorAll(sel: string): El[] {
+    const scoped = /^:scope > (.+)$/.exec(sel);
+    if (scoped) return this.children.filter((c) => c.fits(scoped[1]));
+    const out: El[] = [];
+    const walk = (n: El) => { for (const c of n.children) { if (c.fits(sel)) out.push(c); walk(c); } };
+    walk(this);
+    return out;
+  }
+  querySelector(sel: string): El | null { return this.querySelectorAll(sel)[0] ?? null; }
+  addEventListener(type: string, fn: (ev: any) => void): void { const l = this.listeners.get(type) || []; l.push(fn); this.listeners.set(type, l); }
+  /** Dispatch to this node's listeners; returns the event so the test reads defaultPrevented. */
+  fire(type: string, init: Record<string, unknown> = {}): { defaultPrevented: boolean; stopped: boolean } {
+    const ev: any = { type, defaultPrevented: false, stopped: false, ...init, preventDefault() { ev.defaultPrevented = true; }, stopPropagation() { ev.stopped = true; } };
+    for (const fn of this.listeners.get(type) || []) fn(ev);
+    return ev;
+  }
+}
+const docBody = new El("body");
+const observers: Array<{ roots: El[]; cb: () => void; live: boolean }> = [];
+class FakeMutationObserver {
+  private rec = { roots: [] as El[], cb: () => { /* set below */ }, live: true };
+  constructor(cb: () => void) { this.rec.cb = cb; observers.push(this.rec); }
+  observe(root: El): void { this.rec.roots.push(root); }
+  disconnect(): void { this.rec.live = false; }
+}
+/** Every live observer watching `root` runs, as a child-list change under it would make it. */
+const mutated = (root: El) => { for (const o of observers) if (o.live && o.roots.includes(root)) o.cb(); };
+const timers: Array<() => void> = [];
+let clipboard: ((text: string) => Promise<void>) | null = null;   // the Clipboard API of the moment; null = none (the fallback runs)
+const copied: string[] = [];                                        // what the Clipboard API received
+let execResult = true;                                              // what document.execCommand("copy") answers
+const execCalls: string[] = [];                                     // the textarea values the fallback selected
+(globalThis as any).document = {
+  body: docBody,
+  createElement: (tag: string) => new El(tag),
+  execCommand: (cmd: string) => { assert.equal(cmd, "copy"); return execResult; },
+};
+(globalThis as any).window = { setTimeout: (fn: () => void) => { timers.push(fn); return timers.length; } };
+(globalThis as any).MutationObserver = FakeMutationObserver;
+Object.defineProperty(globalThis, "navigator", { configurable: true, get: () => ({ clipboard: clipboard ? { writeText: clipboard } : undefined }) });
+// the fallback's textarea: value, focus, select; appended to and removed from the body
+const origCreate = (globalThis as any).document.createElement;
+(globalThis as any).document.createElement = (tag: string) => {
+  const e: any = origCreate(tag);
+  if (tag === "textarea") { e.value = ""; e.style = {}; e.focus = () => { /* nothing to focus */ }; e.select = () => { execCalls.push(e.value); }; }
+  return e;
+};
+/** Let the settled promise chain run: the copy's then, the acknowledgement's placement. */
+const settle = async () => { for (let i = 0; i < 4; i++) await new Promise<void>((r) => setImmediate(r)); };
+const runTimers = () => { for (const t of timers.splice(0)) t(); };
+const reset = () => { docBody.replaceChildren(); observers.length = 0; timers.length = 0; copied.length = 0; execCalls.length = 0; execResult = true; clipboard = (t) => { copied.push(t); return Promise.resolve(); }; };
+
+// the module is loaded after the stand-in is up: it reads document and navigator at call time, not at import, but the
+// import is kept below the globals for the same reason a page's script runs after its document exists
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const mod = require("./code-block") as typeof import("./code-block");
+const { wrapLinesHtml, wrapCodeLines, addCopyBtn, copyText } = mod;
+
+/** A fenced block as marked and the highlighter leave it: <pre><code> with the rows already cut, under `parent`. */
+const fence = (parent: El, source: string): { pre: El; code: El } => {
+  const pre = new El("pre"); const code = new El("code");
+  code.textContent = source; code.innerHTML = wrapLinesHtml(source);
+  pre.appendChild(code); parent.appendChild(pre);
+  return { pre, code };
+};
+const button = (pre: El): El => { const b = pre.querySelector(":scope > .code-copy"); assert.ok(b, "a Copy button on the fence"); return b!; };
+
+// ── the walk, executed ─────────────────────────────────────────────────────────────────────────────
+
+test("wrapLinesHtml: one row per line, the newlines dropped, a trailing newline not a row", () => {
+  assert.equal(wrapLinesHtml("a\nb\n"), '<span class="cl"><span class="ct">a</span></span><span class="cl"><span class="ct">b</span></span>');
+  assert.equal(wrapLinesHtml("a\n\nb"), '<span class="cl"><span class="ct">a</span></span><span class="cl"><span class="ct"></span></span><span class="cl"><span class="ct">b</span></span>', "a blank line is an empty row");
+  assert.equal(wrapLinesHtml("only"), '<span class="cl"><span class="ct">only</span></span>');
+  assert.equal(wrapLinesHtml(""), '<span class="cl"><span class="ct"></span></span>', "an empty block is one empty row (a single empty line is not a trailing newline)");
+  assert.equal(wrapLinesHtml("a\nb").indexOf("\n"), -1, "no newline survives: the row stands for its line and the sheet draws the number");
+});
+
+test("wrapLinesHtml: a highlighter span that straddles a newline is closed on its line and re-opened on the next", () => {
+  const html = '<span class="hljs-string">"one\ntwo"</span> x';
+  assert.equal(wrapLinesHtml(html), '<span class="cl"><span class="ct"><span class="hljs-string">"one</span></span></span><span class="cl"><span class="ct"><span class="hljs-string">two"</span> x</span></span>');
+  // nested: two open spans across the break, both re-opened in order
+  assert.equal(wrapLinesHtml('<span class="a"><span class="b">1\n2</span>3</span>'),
+    '<span class="cl"><span class="ct"><span class="a"><span class="b">1</span></span></span></span><span class="cl"><span class="ct"><span class="a"><span class="b">2</span>3</span></span></span>');
+});
+
+test("wrapCodeLines cuts the rows on the element and writes the digits of its last line number for the gutter's basis", () => {
+  const code = new El("code");
+  code.innerHTML = "a\nb\nc\n";
+  wrapCodeLines(code as unknown as HTMLElement);
+  assert.equal(code.innerHTML, wrapLinesHtml("a\nb\nc\n"));
+  assert.equal(code.childElementCount, 3);
+  assert.equal(code.style.getPropertyValue("--ln-digits"), "1", "three rows: one digit");
+  const long = new El("code");
+  long.innerHTML = Array.from({ length: 10000 }, (_, i) => "line " + i).join("\n");
+  wrapCodeLines(long as unknown as HTMLElement);
+  assert.equal(long.childElementCount, 10000);
+  assert.equal(long.style.getPropertyValue("--ln-digits"), "5", "ten thousand rows: five digits, so every row's gutter fits the last number");
+});
+
+// ── the Copy button, executed ──────────────────────────────────────────────────────────────────────
+
+test("addCopyBtn parks one Copy button on the <pre>, idempotent, and a click copies the text the caller gave it, not the on-screen rows", async () => {
+  reset();
+  const { pre } = fence(docBody, "x = 1\ny = 2\n");
+  addCopyBtn(pre as unknown as HTMLElement, "x = 1\ny = 2\n");
+  addCopyBtn(pre as unknown as HTMLElement, "x = 1\ny = 2\n");
+  assert.equal(pre.querySelectorAll(":scope > .code-copy").length, 1, "a second call adds nothing (a re-render runs it again)");
+  assert.ok(pre.classList.contains("has-copy"), "the pre wears has-copy: the sheet anchors the button to it");
+  const btn = button(pre);
+  assert.equal(btn.tagName, "button"); assert.equal(btn.type, "button"); assert.equal(btn.textContent, "Copy");
+  const ev = btn.fire("click");
+  assert.ok(ev.defaultPrevented && ev.stopped, "the click stays on the button: nothing above it acts on a Copy");
+  await settle();
+  assert.deepEqual(copied, ["x = 1\ny = 2\n"], "the caller's text, newlines and all");
+  assert.equal(btn.textContent, "Copied"); assert.ok(btn.classList.contains("copied"), "acknowledged at once, in green");
+  assert.equal(timers.length, 1, "one reset armed");
+  runTimers();
+  assert.equal(btn.textContent, "Copy"); assert.ok(!btn.classList.contains("copied"), "and back to Copy after the window");
+});
+
+test("copyText: the Clipboard API first; a refusal or no API falls back to a hidden textarea and execCommand, whose verdict is the answer", async () => {
+  reset();
+  assert.equal(await copyText("a"), true); assert.deepEqual(copied, ["a"]); assert.deepEqual(execCalls, []);
+  clipboard = () => Promise.reject(new Error("denied"));
+  assert.equal(await copyText("b"), true, "the API refused, the fallback copied"); assert.deepEqual(execCalls, ["b"]);
+  clipboard = null;
+  execResult = false;
+  assert.equal(await copyText("c"), false, "no API and the fallback failed"); assert.deepEqual(execCalls, ["b", "c"]);
+  assert.equal(docBody.children.length, 0, "the fallback's textarea never stays in the document");
+  // ...and the button says so
+  execResult = false; clipboard = null;
+  const { pre } = fence(docBody, "z");
+  addCopyBtn(pre as unknown as HTMLElement, "z");
+  button(pre).fire("click"); await settle();
+  assert.equal(button(pre).textContent, "Copy failed"); assert.ok(!button(pre).classList.contains("copied"));
+});
+
+test("Space copies on the keydown, once per press, with the key's default prevented on the keydown and the keyup; Enter is left to the button's own click", async () => {
+  reset();
+  const { pre } = fence(docBody, "s");
+  addCopyBtn(pre as unknown as HTMLElement, "s");
+  const btn = button(pre);
+  const down = btn.fire("keydown", { key: " ", repeat: false });
+  assert.ok(down.defaultPrevented, "the keydown's default (the :active press whose keyup would click) is prevented");
+  await settle();
+  assert.deepEqual(copied, ["s"], "the copy ran on the keydown");
+  const again = btn.fire("keydown", { key: " ", repeat: true });
+  assert.ok(again.defaultPrevented); await settle();
+  assert.deepEqual(copied, ["s"], "a held key's repeat copies nothing more");
+  const up = btn.fire("keyup", { key: " " });
+  assert.ok(up.defaultPrevented, "the keyup is prevented too, for an engine that would click on it anyway");
+  const enter = btn.fire("keydown", { key: "Enter", repeat: false });
+  assert.ok(!enter.defaultPrevented); await settle();
+  assert.deepEqual(copied, ["s"], "Enter's click is the button's own; the handler does nothing with it");
+  const other = btn.fire("keyup", { key: "Enter" });
+  assert.ok(!other.defaultPrevented);
+});
+
+test("the acknowledgement lands on the button on screen of the fence with the copied source: a rebuild that swapped the pressed fence out before the clipboard answered moves it to the replacement, by the fence's ordinal among fences of that source", async () => {
+  reset();
+  let release: () => void = () => { /* set by the clipboard below */ };
+  clipboard = (t) => { copied.push(t); return new Promise<void>((r) => { release = r; }); };
+  const host = new El("div"); docBody.appendChild(host);
+  // two fences of one source, one of another
+  const a1 = fence(host, "same\n"), a2 = fence(host, "same\n"), b = fence(host, "other\n");
+  for (const f of [a1, a2, b]) addCopyBtn(f.pre as unknown as HTMLElement, f.code.textContent);
+  button(a2.pre).fire("click");
+  await settle();
+  assert.equal(button(a2.pre).textContent, "Copy", "the clipboard has not answered yet");
+  // the surface rebuilds: a fresh render of the same document, with a new fence of the other source put first
+  const c = fence(new El("div"), "new\n"), n1 = fence(new El("div"), "same\n"), n2 = fence(new El("div"), "same\n"), nb = fence(new El("div"), "other\n");
+  for (const f of [c, n1, n2, nb]) addCopyBtn(f.pre as unknown as HTMLElement, f.code.textContent);
+  host.replaceChildren(c.pre, n1.pre, n2.pre, nb.pre);
+  assert.ok(!a2.pre.isConnected, "the pressed fence is out of the document");
+  release(); await settle();
+  assert.deepEqual(copied, ["same\n"]);
+  assert.equal(button(a2.pre).textContent, "Copy", "the detached button is not written to");
+  assert.equal(button(n2.pre).textContent, "Copied", "the second fence of that source on screen, the pressed one's ordinal, is acknowledged");
+  assert.equal(button(n1.pre).textContent, "Copy"); assert.equal(button(c.pre).textContent, "Copy"); assert.equal(button(nb.pre).textContent, "Copy");
+  // a swap inside the window carries the label on: another rebuild replaces the acknowledged fence
+  const m1 = fence(new El("div"), "same\n"), m2 = fence(new El("div"), "same\n");
+  for (const f of [m1, m2]) addCopyBtn(f.pre as unknown as HTMLElement, f.code.textContent);
+  host.replaceChildren(m1.pre, m2.pre);
+  mutated(host);
+  assert.equal(button(m2.pre).textContent, "Copied", "the observer on the ancestor's child list moved the label on the swap");
+  assert.equal(button(n2.pre).textContent, "Copied", "the detached one keeps what it had; nothing reads it");
+  runTimers();
+  assert.equal(button(m2.pre).textContent, "Copy", "the reset goes to the button last acknowledged");
+  assert.ok(observers.every((o) => !o.live), "the observers are disconnected when the window closes");
+});
+
+test("a rebuild that did not bring the fence back (its text rewritten, or the fence removed) acknowledges nothing, and never throws", async () => {
+  reset();
+  let release: () => void = () => { /* set below */ };
+  clipboard = (t) => { copied.push(t); return new Promise<void>((r) => { release = r; }); };
+  const host = new El("div"); docBody.appendChild(host);
+  const a = fence(host, "gone\n"); addCopyBtn(a.pre as unknown as HTMLElement, "gone\n");
+  button(a.pre).fire("click"); await settle();
+  const other = fence(new El("div"), "different\n"); addCopyBtn(other.pre as unknown as HTMLElement, "different\n");
+  host.replaceChildren(other.pre);
+  release(); await settle();
+  assert.equal(button(other.pre).textContent, "Copy", "a fence of another source is not the one whose text was copied");
+  assert.equal(button(a.pre).textContent, "Copy", "the detached button is not written to either");
+  runTimers();
+  // the whole surface gone: the walk stops under document.body
+  const b = fence(host, "x\n"); addCopyBtn(b.pre as unknown as HTMLElement, "x\n");
+  button(b.pre).fire("click"); await settle();
+  docBody.replaceChildren();
+  release(); await settle();
+  runTimers();
+});
+
+// ── the callers ────────────────────────────────────────────────────────────────────────────────────
+
+test("render.ts and file-view.ts import the two functions from the module; render.ts keeps no copy; the viewer never imports the chat", () => {
+  assert.match(RENDER, /^import \{ wrapCodeLines, addCopyBtn \} from "\.\/code-block";/m);
+  assert.match(VIEW, /^import \{ wrapCodeLines, addCopyBtn \} from "\.\/code-block";/m);
+  assert.doesNotMatch(RENDER, /^(export )?function (wrapCodeLines|addCopyBtn|copyText|fallbackCopy)\(/m, "the definitions moved");
+  assert.match(BLOCK, /^export function wrapLinesHtml\(html: string\): string/m);
+  assert.match(BLOCK, /^export function wrapCodeLines\(code: HTMLElement\): void/m);
+  assert.match(BLOCK, /^export function addCopyBtn\(pre: HTMLElement, raw: string\): void/m);
+  assert.match(BLOCK, /^export function copyText\(text: string\): Promise<boolean>/m);
+  assert.doesNotMatch(BLOCK, /from "\.\/render"|from "\.\/file-view"/, "the module imports neither caller");
+  for (const f of ["file-view.ts", "feed.ts", "code-block.ts", "viewer-grammars.ts", "fence-source.ts"]) {
+    assert.doesNotMatch(read(f), /from "\.\/render"/, f + " imports nothing from the chat (the feed bundle must not carry it)");
+  }
+});
+
+test("mdBlock: the raw text is captured before the highlight rewrite, a named registered language is highlighted (never guessed), then EVERY fence is wrapped and given Copy with the text the file holds", () => {
+  const fn = VIEW.slice(VIEW.indexOf("function mdBlock("), VIEW.indexOf("function imgBlock("));
+  const pass = fn.slice(fn.indexOf('box.querySelectorAll("pre code").forEach'));
+  assert.match(pass, /const raw = codeEl\.textContent \|\| "";/);
+  assert.ok(pass.indexOf("const raw = codeEl.textContent") < pass.indexOf("codeEl.innerHTML = hljs.highlight(raw"), "raw first, then the rewrite highlights that same string");
+  assert.match(pass, /if \(lang && hljs\.getLanguage\(lang\)\) \{/, "highlight only a named, registered language");
+  assert.doesNotMatch(VIEW, /hljs\.highlightAuto\(/, "no guessing in the viewer");
+  // the wrap and the Copy button sit OUTSIDE the language branch, so an unregistered or unnamed fence gets them too: the
+  // branch, cut from its head to its own closing brace, holds neither call, and the two calls are the callback's last
+  // statements, closing the forEach (a `}` before the wrap would also match the catch's, so the branch is read whole)
+  const branchAt = pass.indexOf("if (lang && hljs.getLanguage(lang)) {");
+  const branch = pass.slice(branchAt, pass.indexOf("\n    }\n", branchAt) + 7);
+  assert.match(branch, /^if \(lang && hljs\.getLanguage\(lang\)\) \{\n[\s\S]*\} catch \{ \/\* leave plain \*\/ \}\n    \}\n$/, "the language branch is read whole, head to its closing brace");
+  assert.doesNotMatch(branch, /wrapCodeLines|addCopyBtn/, "the language branch highlights only: no rows, no Copy inside it");
+  assert.match(pass, /\n    wrapCodeLines\(codeEl\);\n    if \(host\) addCopyBtn\(host, toCopy\);\n  \}\);/, "the rows and the Copy button are the callback's last statements, for every fence");
+  // what Copy copies is the fence's text as the FILE holds it (fence-source.ts): the raw text is marked's, its leading tabs
+  // already four spaces each; the queue is keyed by the raw text and consumed in document order, and a fence the module
+  // did not find in the file falls back to the raw text
+  assert.match(pass, /const queued = copySources\.get\(raw\);\n\s*const toCopy = \(queued && queued\.length \? queued\.shift\(\) : null\) \?\? raw;/, "Copy's text comes off the source queue, the raw text when the fence was not found");
+  assert.match(fn, /const copySources = fenceCopyQueue\(text, fences\);/, "the queue is built from the file and the code tokens the parse collected");
+  assert.match(fn, /if \(t\.type === "code"\) \{ const c = t as Tokens\.Code; fences\.push\(\{ text: c\.text, indented: c\.codeBlockStyle === "indented" \}\); \}/, "the parse's walkTokens collects every code token");
+  assert.match(fn, /const base = marked\.defaults\.walkTokens;/, "a walkTokens an extension put on the defaults still runs: per-call options replace, so it is chained");
+  assert.match(VIEW, /^import \{ fenceCopyQueue, type Fence \} from "\.\/fence-source";/m);
+  assert.ok(pass.indexOf("wrapCodeLines(codeEl)") > pass.indexOf('codeEl.classList.add("hljs")'), "the rows are cut after the highlight, as in the chat");
+  // the counter reset is the sheets' `.fileview-md pre code`, not `code.hljs`: a plain fence carries no hljs class
+  assert.ok(!/wrapCodeLines\(codeEl\);[\s\S]{0,80}classList\.add\("hljs"\)/.test(pass), "no hljs class is added to a plain fence for the counter's sake (the sheet resets on pre code)");
+  // a task item wears GitHub's class, stamped after the sanitize for the disabled checkbox marked emits as the item's first child
+  // (file-view-text-size.test.ts's browser leg runs the stamp over marked's own output, sanitized, in a real DOM)
+  assert.match(fn, /box\.querySelectorAll\('li > input\[type="checkbox"\]:first-child:disabled, li > p:first-child > input\[type="checkbox"\]:first-child:disabled'\)\.forEach\(\(input\) => \{\n\s*if \(input\.previousSibling\) return;/, "the task stamp's selector, then the first-node check: :first-child counts elements alone, and a checkbox after the item's text is not a task item");
+  assert.match(fn, /if \(li\) li\.classList\.add\("task-list-item"\);/);
+  assert.ok(fn.indexOf("sanitizeMd(dirty)") < fn.indexOf('li.classList.add("task-list-item")'), "stamped after the sanitize, so the class is never one the file wrote");
+});
+
+test("the chat's highlight() is unchanged in shape: raw first, the cache, the rows when lineNos, Copy on the <pre>", () => {
+  const hl = RENDER.slice(RENDER.indexOf("function highlight(container: HTMLElement"), RENDER.indexOf("function dot("));
+  assert.match(hl, /const raw = code\.textContent \|\| "";/);
+  assert.match(hl, /code\.innerHTML = highlightHtml\(hljs, lang, raw\);/);
+  assert.match(hl, /if \(lineNos\) wrapCodeLines\(code\);/);
+  assert.match(hl, /if \(pre && pre\.tagName === "PRE"\) addCopyBtn\(pre as HTMLElement, raw\);/);
+});
+
+// ── the sheets ─────────────────────────────────────────────────────────────────────────────────────
+
+const ruleOf = (css: string, head: string): string => { const at = css.indexOf(head); assert.ok(at >= 0, head + " present"); return css.slice(at, css.indexOf("}", at) + 1); };
+const decls = (rule: string): string[] => rule.slice(rule.indexOf("{") + 1, -1).split(";").map((d) => d.trim()).filter(Boolean);
+
+test("both sheets: the viewer's fences carry scoped copies of the chat's row and Copy rules, byte-equal, the counter reset and tab-size on `.fileview-md pre code`", () => {
+  const HEADS = [".fileview-md pre code .cl {", ".fileview-md pre code .cl::before {", ".fileview-md pre code .ct {", ".fileview-md pre code .ct::before {", ".fileview-md pre.has-copy {", ".fileview-md .code-copy {",
+    ".fileview-md pre.has-copy:hover .code-copy, .fileview-md .code-copy:focus-visible {", ".fileview-md .code-copy:hover {", ".fileview-md .code-copy.copied {"];
+  for (const head of HEADS) assert.equal(ruleOf(CHAT, head), ruleOf(FEED, head), head + " mirrors exactly");
+  for (const [name, css] of [["styles.css", CHAT], ["feed.css", FEED]] as const) {
+    const code = decls(ruleOf(css, ".fileview-md pre code {"));
+    assert.ok(code.includes("counter-reset: ln"), name + ": the line counter resets on every fence, hljs class or not");
+    assert.ok(code.includes("tab-size: 4"), name + ": tabs as the Raw view shows them");
+    assert.ok(decls(ruleOf(css, ".fileview-pre {")).includes("tab-size: 4"), name + ": ...which is 4");
+    // the copies are the chat's rules with the viewer's scope in front, declaration for declaration
+    assert.deepEqual(decls(ruleOf(css, ".fileview-md pre code .cl {")), decls(ruleOf(CHAT, "\npre code .cl {")), name + ": .cl is the chat's");
+    assert.deepEqual(decls(ruleOf(css, ".fileview-md pre code .cl::before {")), decls(ruleOf(CHAT, "\npre code .cl::before {")), name + ": the gutter is the chat's");
+    assert.deepEqual(decls(ruleOf(css, ".fileview-md pre code .ct {")), decls(ruleOf(CHAT, "\npre code .ct {")), name + ": .ct is the chat's");
+    // a blank line's row is the line-height (the .ct's ::before is a word joiner, the line box an empty .ct had none of), and
+    // the gutter's basis follows the fence's digit count, which wrapCodeLines writes on the code element
+    assert.deepEqual(decls(ruleOf(css, ".fileview-md pre code .ct::before {")), ['content: "\\2060"'], name + ": the .ct's ::before is the word joiner, U+2060 (zero width, unbreakable)");
+    assert.deepEqual(decls(ruleOf(css, ".fileview-md pre code .ct::before {")), decls(ruleOf(CHAT, "\npre code .ct::before {")), name + ": ...the chat's rule");
+    const gutter = decls(ruleOf(css, ".fileview-md pre code .cl::before {"));
+    assert.ok(gutter.includes("flex: 0 0 max(2.5em, calc(var(--ln-digits, 0) * 1ch + 0.05em))"), name + ": the gutter's basis is 2.5em or the fence's digits in ch, whichever is wider");
+    assert.ok(gutter.includes("line-height: 1") && gutter.includes("overflow-wrap: normal"), name + ": the gutter's line box is never taller than the text's, and a number never wraps");
+    const copy = decls(ruleOf(css, ".fileview-md .code-copy {"));
+    const chatCopy = decls(ruleOf(CHAT, "\n.code-copy {"));
+    assert.deepEqual(copy.filter((d) => !d.startsWith("background")), chatCopy.filter((d) => !d.startsWith("background")), name + ": the Copy button is the chat's, but for the tint's fallback");
+    assert.ok(copy.includes("background: var(--code-bg, rgba(217, 119, 87, 0.10))"), name + ": the code tint carries the chat's literal as its fallback (feed.css defines no --code-bg in :root)");
+    assert.match(css, /@media \(hover: none\) \{ \.fileview-md \.code-copy \{ opacity: 0\.8; \} \}/, name + ": touch keeps the button visible");
+  }
+  // every var() the feed's copies use resolves on the feed page (feed-css-vars.test.ts holds the whole sheet; this names the block)
+  const defined = new Set([...FEED.matchAll(/(--[a-zA-Z0-9-]+)\s*:/g)].map((m) => m[1]));
+  const block = FEED.slice(FEED.indexOf(".fileview-md pre code .cl {"), FEED.indexOf("@media (hover: none) { .fileview-md .code-copy"));
+  for (const m of block.matchAll(/var\(\s*(--[a-zA-Z0-9-]+)\s*\)/g)) assert.ok(defined.has(m[1]), "feed.css defines " + m[1] + " (a fallback-less var in the fence block)");
+});
+
+// ── the grammars ───────────────────────────────────────────────────────────────────────────────────
+
+test("viewer-grammars.ts registers six more grammars, with their aliases, on the bundle's one hljs core; file-view.ts imports it and the chat auto-detects among its ten only", () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { VIEWER_GRAMMARS } = require("./viewer-grammars") as typeof import("./viewer-grammars");
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { AUTO_LANGUAGES } = require("./highlight-cache") as typeof import("./highlight-cache");
+  assert.deepEqual(Object.keys(VIEWER_GRAMMARS).sort(), ["c", "go", "golang", "h", "ini", "java", "rs", "rust", "sql", "toml"].sort());
+  for (const name of ["rust", "rs", "go", "golang", "c", "h", "java", "sql", "toml", "ini"]) assert.ok(hljs.getLanguage(name), name + " is registered once the module is imported");
+  assert.equal(hljs.getLanguage("toml")!.name, "TOML, also INI", "toml is hljs's ini grammar (hljs ships no toml module; the two names register one grammar)");
+  assert.equal(hljs.getLanguage("ini")!.name, hljs.getLanguage("toml")!.name);
+  assert.equal(hljs.highlight("fn main() {}", { language: "rust" }).value.includes("hljs-keyword"), true, "the rust grammar tokenizes");
+  assert.equal(hljs.highlight("[section]\nkey = 1", { language: "toml" }).value.includes("hljs-"), true, "the toml alias tokenizes");
+  assert.match(VIEW, /^import "\.\/viewer-grammars";/m, "the viewer reaches the six (feed.ts imports file-view.ts; the chat bundle does too)");
+  assert.doesNotMatch(RENDER, /viewer-grammars/, "render.ts imports the module through file-view.ts, not on its own");
+  // the chat's ten, by the grammar imports in render.ts, are the auto-detection subset
+  const ten = [...RENDER.matchAll(/^import \w+ from "highlight\.js\/lib\/languages\/(\w+)";/gm)].map((m) => m[1]).sort();
+  assert.equal(ten.length, 10, "render.ts imports ten grammars: " + ten.join(","));
+  assert.deepEqual([...AUTO_LANGUAGES].sort(), ten, "AUTO_LANGUAGES is exactly the chat's ten");
+  assert.deepEqual([...VIEW.matchAll(/^import \w+ from "highlight\.js\/lib\/languages\/(\w+)";/gm)].map((m) => m[1]).sort(), ten, "file-view.ts registers the same ten itself; the six live in viewer-grammars.ts");
+});
+
+test("highlightHtml passes the ten-name subset to highlightAuto for an unlabeled fence, and names the grammar for a labeled one", () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { AUTO_LANGUAGES, highlightHtml, newHighlightCache } = require("./highlight-cache") as typeof import("./highlight-cache");
+  const seen: unknown[][] = [];
+  const hl = {
+    getLanguage: (n: string) => (n === "python" ? {} : undefined),
+    highlight: (raw: string, o: { language: string }) => { seen.push(["named", o.language]); return { value: "<n>" + raw + "</n>" }; },
+    highlightAuto: (raw: string, subset?: readonly string[]) => { seen.push(["auto", subset]); return { value: "<a>" + raw + "</a>" }; },
+  };
+  const c = newHighlightCache();
+  assert.equal(highlightHtml(hl, "python", "x = 1", c), "<n>x = 1</n>");
+  assert.equal(highlightHtml(hl, undefined, "x = 1", c), "<a>x = 1</a>");
+  assert.equal(highlightHtml(hl, "rust", "x = 1", c), "<a>x = 1</a>", "a language this fake does not know reads as unlabeled: the cache's key for it is the unlabeled one, so this is the entry above, a hit (in the chat bundle rust IS known, through file-view.ts)");
+  assert.deepEqual(seen, [["named", "python"], ["auto", AUTO_LANGUAGES]], "one auto-detection, with the subset");
+  assert.equal(seen[1][1], AUTO_LANGUAGES, "the very list, not a copy");
+  assert.equal(highlightHtml(hl, undefined, "y = 2", c), "<a>y = 2</a>");
+  assert.equal(seen.length, 3); assert.equal(seen[2][1], AUTO_LANGUAGES, "every auto-detection carries it");
+});

--- a/ui/webview/code-block.ts
+++ b/ui/webview/code-block.ts
@@ -1,0 +1,178 @@
+// Fenced code, dressed the same wherever it renders: the per-line rows that make a soft-wrap read distinctly from a real
+// newline (the user 2026-06-16) and the automatic Copy button (the user 2026-06-22). The chat's highlight() (render.ts)
+// and the file viewer's mdBlock (file-view.ts) both call these. The module exists because the two functions lived
+// module-private in render.ts and file-view.ts cannot import render.ts: render.ts imports file-view.ts, and the feed
+// bundle must not carry the chat. They moved here as they were; the chat's behaviour is unchanged.
+//
+//   - wrapLinesHtml is the pure walk: highlighted HTML split into lines, each wrapped in
+//     `<span class="cl"><span class="ct">...</span></span>`, an hljs span that straddles a newline re-opened on the next
+//     line so the markup stays valid. The NEWLINES ARE DROPPED: a row stands for its line and the CSS counter on .cl
+//     draws the number. Copy never reads the rows: its caller hands addCopyBtn the text to copy, settled before the
+//     rewrite. For the chat that is the code element's textContent as captured (render.ts highlight); for the viewer it is
+//     the fence's text as the FILE holds it (fence-source.ts: marked expanded the file's leading tabs to spaces before the
+//     textContent existed), the captured textContent only for a fence the module does not find in the file.
+//   - wrapCodeLines applies it to a code element and writes the digits of its last line number on the element
+//     (`--ln-digits`): the sheets' gutter basis reads it, so every row of a 10000-line block carries a five-digit gutter
+//     and the text column stays one line, where a basis a single row outgrew widened that row alone.
+//   - addCopyBtn parks a Copy button top-right of the <pre>, idempotent (a re-render can run it again), copying the text
+//     it was given: the on-screen textContent lost its newlines to the wrap and is not copy-safe.
+//   - copyText: the async Clipboard API with a hidden-textarea execCommand fallback.
+//
+// The Copy button's action stays on the button. Delegating it to a stable ancestor would change nothing for the one way
+// a press on it is lost, a surface that REPLACES the fence while the pointer is down: a pressed node removed before the
+// mouseup dispatches no click at all, to the button or to any ancestor. The chat does that with no gesture behind it: a
+// card re-renders on a kernel push, and a press on its fence's Copy can be under way when it does. The viewer's fences are
+// replaced only by the reader's own clicks (the Rendered/Raw toggle rebuilds the body, Reload the whole viewer), which
+// cannot overlap a press, but can fall between a press and the clipboard's answer. Two things follow:
+//   - A KEYBOARD press has the same window: a button's Space activation is native to the keyup (Enter's to the keydown),
+//     so a rebuild between the keydown and the keyup took the focused button and the keyup clicked nothing. Space acts on
+//     the KEYDOWN here, as Enter does, with the key's default prevented on the keydown (the button is never put :active
+//     by the key, so its keyup dispatches no click) and on the keyup; a held key's repeats copy nothing more.
+//   - The acknowledgement (the label reads Copied, or Copy failed, for about 1.2s) goes to the button ON SCREEN at the
+//     fence, not to the node the click closed over: the Clipboard API answers asynchronously, a rebuild inside that window
+//     swaps the fence and its button out, and a label written to the pressed node showed on nothing while the copy itself
+//     had succeeded. The fence is known by its SOURCE, the text its Copy copies: the button acknowledged is the one of the
+//     fenced block with the pressed fence's source under the nearest ancestor still in the document (the ancestors are
+//     read at the press, while the button is in the document), and a swap inside the window carries the label to the
+//     button that replaced it on the swap's own event (a MutationObserver on the ancestors' child lists, alive for the
+//     window). Of several fences with that source, the one at the pressed fence's ordinal among them, so a rebuild that
+//     put a fence above the pressed one, or removed the pressed one, never marks a neighbour. A fence the swap did not
+//     bring back, its text rewritten or the fence removed, has nothing to write on: the clipboard holds the text and no
+//     button on screen claims it; a surface swapped out whole (the viewer closed or replaced) is nothing to acknowledge
+//     on, so the walk stops under document.body. code-block.test.ts runs both over a DOM stand-in.
+//
+// The sheets: the chat's unscoped `pre code .cl` / `.ct` / `.code-copy` rules (styles.css) and the viewer's scoped
+// `.fileview-md` copies in styles.css and feed.css (the feed page loads only feed.css), byte-equal (code-block.test.ts,
+// fileview-parity.test.ts).
+
+const el = (tag: string, cls: string): HTMLElement => { const e = document.createElement(tag); e.className = cls; return e; };
+
+/** Highlighted HTML as per-line rows: `<span class="cl"><span class="ct">...</span></span>` per line, spans re-balanced
+ *  across the line break, the newlines dropped. A trailing newline is not a blank line. */
+export function wrapLinesHtml(html: string): string {
+  const lines = html.split("\n");
+  if (lines.length > 1 && lines[lines.length - 1] === "") lines.pop();   // a trailing newline isn't a blank line
+  let open: string[] = [];
+  return lines.map((ln) => {
+    const prefix = open.join("");
+    const re = /<span[^>]*>|<\/span>/g; let m; const stack = open.slice();
+    while ((m = re.exec(ln))) { if (m[0] === "</span>") stack.pop(); else stack.push(m[0]); }
+    const suffix = "</span>".repeat(Math.max(0, stack.length));
+    open = stack;
+    return `<span class="cl"><span class="ct">${prefix}${ln}${suffix}</span></span>`;
+  }).join("");
+}
+
+/** Wrap each logical line of a (highlighted or plain) code element in the rows above, and write the digits of its last
+ *  line number on the element (`--ln-digits`) for the sheets' gutter basis. The rows are the element's children, so
+ *  childElementCount is the line count; both callers wrap after any sanitize, so the inline property stands. */
+export function wrapCodeLines(code: HTMLElement): void {
+  code.innerHTML = wrapLinesHtml(code.innerHTML);
+  code.style.setProperty("--ln-digits", String(String(code.childElementCount).length));
+}
+
+// Copy text to the clipboard, falling back to a hidden-textarea execCommand when the async Clipboard API
+// is unavailable (it needs a secure context; localhost counts, but stay safe). Returns whether it copied.
+export function copyText(text: string): Promise<boolean> {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    return navigator.clipboard.writeText(text).then(() => true, () => fallbackCopy(text));
+  }
+  return Promise.resolve(fallbackCopy(text));
+}
+function fallbackCopy(text: string): boolean {
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text; ta.style.position = "fixed"; ta.style.top = "-9999px"; ta.style.opacity = "0";
+    document.body.appendChild(ta); ta.focus(); ta.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return ok;
+  } catch { return false; }
+}
+
+// The fence the press was on, for the acknowledgement after a swap (the header): its SOURCE, the text its Copy copies,
+// and under each ancestor below document.body its ordinal among the fenced blocks there with that source. After a swap
+// the first ancestor still in the document is the surface that kept its place, and the fenced block under it with the
+// pressed fence's source is the same fence wherever the rebuild moved it; the ordinal decides only between fences of one
+// source, which nothing else tells apart. The walk stops under document.body: a surface swapped out whole is nothing to
+// acknowledge on.
+type Slot = { source: string; at: { root: Element; nth: number }[] };
+const FENCED = "pre.has-copy";
+/** Each fenced block's source (what its Copy copies), keyed by the <pre> addCopyBtn dressed. */
+const SOURCES = new WeakMap<Element, string>();
+/** The fenced blocks under `root` whose source is `source`, in document order. */
+const sameSource = (root: Element, source: string): Element[] => Array.from(root.querySelectorAll(FENCED)).filter((p) => SOURCES.get(p) === source);
+function fenceSlot(pre: HTMLElement, source: string): Slot {
+  const at: Slot["at"] = [];
+  for (let a = pre.parentElement; a && a !== document.body; a = a.parentElement) {
+    at.push({ root: a, nth: sameSource(a, source).indexOf(pre) });
+  }
+  return { source, at };
+}
+/** The Copy button on screen for the slot: the pressed one while it is in the document, else the button of the fenced
+ *  block with the pressed fence's source under the nearest ancestor still in the document (of several, the one at the
+ *  pressed fence's ordinal among them, the last when fewer stand); null when no fence with that source stands there. */
+function shownButton(pressed: HTMLButtonElement, slot: Slot): HTMLButtonElement | null {
+  if (pressed.isConnected) return pressed;
+  const s = slot.at.find((x) => x.root.isConnected);
+  if (!s) return null;
+  const same = sameSource(s.root, slot.source);
+  const pre = same[Math.min(s.nth, same.length - 1)];
+  return pre ? (pre.querySelector(":scope > .code-copy") as HTMLButtonElement | null) : null;
+}
+/** The acknowledgement: Copied (green) or Copy failed on the button on screen for the slot for about 1.2s, then Copy
+ *  again. A swap inside the window moves the label to the button that replaced the acknowledged one, on the swap's own
+ *  event: the observer watches the child list of every ancestor in the slot (the swap replaces a child of one of them)
+ *  and is disconnected when the window closes. The reset goes to the button last acknowledged; if a swap took that one
+ *  too, the write lands on a detached node and the button on screen already reads Copy. */
+function acknowledge(pressed: HTMLButtonElement, slot: Slot, ok: boolean): void {
+  let shown: HTMLButtonElement | null = null;
+  const place = (): void => {
+    const b = shownButton(pressed, slot);
+    if (!b || b === shown) return;
+    shown = b;
+    b.textContent = ok ? "Copied" : "Copy failed";
+    b.classList.toggle("copied", ok);
+  };
+  const swaps = new MutationObserver(place);
+  for (const { root } of slot.at) swaps.observe(root, { childList: true });
+  place();
+  window.setTimeout(() => {
+    swaps.disconnect();
+    if (shown) { shown.textContent = "Copy"; shown.classList.remove("copied"); }
+  }, 1200);
+}
+
+// An automatic "Copy" button parked top-right of every rendered code block (the user 2026-06-22). The text to copy
+// is the caller's, closed over here and never read off the block: the on-screen markup adds a line-number gutter
+// and drops the newline joins, so its textContent would be wrong. The chat passes the textContent it captured
+// before the highlight rewrite; the viewer passes the fence's text as the file holds it (fence-source.ts), the
+// captured textContent only for a fence not found there (the header). Faint until the block is hovered; flips to
+// a green "Copied" for about 1.2s on success, on the button on screen of the fence with this one's source (acknowledge
+// above). Idempotent (highlight can re-run on a re-render).
+export function addCopyBtn(pre: HTMLElement, raw: string): void {
+  if (pre.querySelector(":scope > .code-copy")) return;
+  pre.classList.add("has-copy");
+  SOURCES.set(pre, raw);   // the fence's identity for the acknowledgement after a swap
+  const btn = el("button", "code-copy") as HTMLButtonElement;
+  btn.type = "button"; btn.textContent = "Copy"; btn.title = "copy this code block";
+  const copy = (): void => {
+    const slot = fenceSlot(pre, raw);   // read now, while the press found the button in the document
+    copyText(raw).then((ok) => acknowledge(btn, slot, ok));
+  };
+  btn.addEventListener("click", (ev) => {
+    ev.preventDefault(); ev.stopPropagation();
+    copy();
+  });
+  // Space on the keydown, not the native keyup (the header): the keydown's default prevented keeps the button out of
+  // :active for the key, so the keyup clicks nothing; the keyup's prevented too, for an engine that would click anyway.
+  // Repeats of a held key are the same press. Enter is left to the button: its click is on the keydown already.
+  btn.addEventListener("keydown", (ev) => {
+    if (ev.key !== " ") return;
+    ev.preventDefault();
+    if (ev.repeat) return;
+    copy();
+  });
+  btn.addEventListener("keyup", (ev) => { if (ev.key === " ") ev.preventDefault(); });
+  pre.appendChild(btn);
+}

--- a/ui/webview/codeblock-copy.test.ts
+++ b/ui/webview/codeblock-copy.test.ts
@@ -2,13 +2,15 @@
 // added inside highlight() — the one post-processor over `pre code` — so it covers ALL render paths
 // (assistant body, agent report, postal body, diffs) for free. The RAW source is captured BEFORE the
 // markup is rewritten (line-wrapping drops the \n joins, so the on-screen textContent isn't copy-safe).
-// No jsdom harness here — like codeblock-wrap.test.ts, pin the behaviour at the source level.
+// The button itself lives in code-block.ts, shared with the file viewer's fences (code-block.test.ts
+// executes it); this file pins the chat's wiring and the sheet at the source level, like codeblock-wrap.test.ts.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const BLOCK = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "code-block.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 const HL = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "highlight-cache.ts"), "utf8");
@@ -16,28 +18,36 @@ const HL = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "h
 test("highlight() captures the raw source then adds a Copy button to each <pre>", () => {
   // raw is captured BEFORE innerHTML is rewritten, and hljs highlights that same captured string — through
   // the (language, source) cache (highlight-cache.ts), which still names a grammar for a labeled fence and
-  // auto-detects an unlabeled one
+  // auto-detects an unlabeled one among the chat's ten grammars (the viewer registers more; the guess set is held)
   assert.match(RENDER, /const raw = code\.textContent \|\| "";/);
   assert.match(RENDER, /code\.innerHTML = highlightHtml\(hljs, lang, raw\);/);
   assert.match(HL, /hl\.highlight\(raw, \{ language: lang as string \}\)/);
-  assert.match(HL, /hl\.highlightAuto\(raw\)/);
-  // the button is added per code block, to its parent <pre>, with the captured raw
+  assert.match(HL, /hl\.highlightAuto\(raw, AUTO_LANGUAGES\)/);
+  // the button is added per code block, to its parent <pre>, with the captured raw; the function is the shared module's
+  assert.match(RENDER, /^import \{ wrapCodeLines, addCopyBtn \} from "\.\/code-block";/m);
   assert.match(RENDER, /if \(pre && pre\.tagName === "PRE"\) addCopyBtn\(pre as HTMLElement, raw\)/);
 });
 
-test("addCopyBtn builds a .code-copy button, is idempotent, and shows Copied feedback", () => {
-  assert.match(RENDER, /function addCopyBtn\(pre: HTMLElement, raw: string\)/);
-  assert.match(RENDER, /if \(pre\.querySelector\(":scope > \.code-copy"\)\) return;/);  // never doubles up on a re-render
-  assert.match(RENDER, /el\("button", "code-copy"\)/);
-  assert.match(RENDER, /copyText\(raw\)/);
-  assert.match(RENDER, /btn\.textContent = ok \? "Copied" : "Copy failed"/);
-  assert.match(RENDER, /btn\.classList\.toggle\("copied", ok\)/);
+test("addCopyBtn builds a .code-copy button, is idempotent, remembers the fence's source, and shows Copied feedback on the button on screen", () => {
+  assert.match(BLOCK, /export function addCopyBtn\(pre: HTMLElement, raw: string\): void/);
+  assert.match(BLOCK, /if \(pre\.querySelector\(":scope > \.code-copy"\)\) return;/);  // never doubles up on a re-render
+  assert.match(BLOCK, /el\("button", "code-copy"\)/);
+  assert.match(BLOCK, /SOURCES\.set\(pre, raw\);/);                                    // the fence's identity for the acknowledgement after a swap
+  assert.match(BLOCK, /copyText\(raw\)\.then\(\(ok\) => acknowledge\(btn, slot, ok\)\)/);
+  assert.match(BLOCK, /b\.textContent = ok \? "Copied" : "Copy failed"/);
+  assert.match(BLOCK, /b\.classList\.toggle\("copied", ok\)/);
+  // Space acts on the keydown like Enter: a re-render between the keydown and the native keyup click lost the press
+  assert.match(BLOCK, /btn\.addEventListener\("keydown", \(ev\) => \{\s*\n\s*if \(ev\.key !== " "\) return;\s*\n\s*ev\.preventDefault\(\);\s*\n\s*if \(ev\.repeat\) return;\s*\n\s*copy\(\);/);
+  assert.match(BLOCK, /btn\.addEventListener\("keyup", \(ev\) => \{ if \(ev\.key === " "\) ev\.preventDefault\(\); \}\);/);
+  assert.doesNotMatch(RENDER, /function addCopyBtn\(/, "render.ts keeps no copy of its own");
 });
 
 test("copyText uses the async Clipboard API with an execCommand fallback", () => {
-  assert.match(RENDER, /navigator\.clipboard\.writeText\(text\)/);
-  assert.match(RENDER, /function fallbackCopy\(text: string\)/);
-  assert.match(RENDER, /document\.execCommand\("copy"\)/);
+  assert.match(BLOCK, /export function copyText\(text: string\): Promise<boolean>/);
+  assert.match(BLOCK, /navigator\.clipboard\.writeText\(text\)/);
+  assert.match(BLOCK, /function fallbackCopy\(text: string\): boolean/);
+  assert.match(BLOCK, /document\.execCommand\("copy"\)/);
+  assert.doesNotMatch(RENDER, /function (copyText|fallbackCopy)\(/, "render.ts keeps no copy of its own");
 });
 
 test("the Copy button is styled: anchored top-right, faint until hover, green when copied", () => {

--- a/ui/webview/codeblock-wrap.test.ts
+++ b/ui/webview/codeblock-wrap.test.ts
@@ -7,6 +7,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const BLOCK = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "code-block.ts"), "utf8");   // the rows' home, shared with the file viewer
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 test("markdown code blocks wrap instead of scrolling sideways", () => {
@@ -19,9 +20,17 @@ test("wrapped code carries a subtle (faint) line-number gutter", () => {
   assert.match(CSS, /pre code \.cl::before \{[^}]*counter-increment: ln/);      // each .cl draws its number
   assert.match(CSS, /pre code \.cl::before \{[^}]*opacity: 0\.3/);              // "incognito" — faint
   assert.match(CSS, /pre code \.ct \{[^}]*white-space: pre-wrap/);             // the content wraps
-  // render splits each highlighted line into <span class=cl><span class=ct>…, re-opening straddling spans
-  assert.match(RENDER, /function wrapCodeLines/);
-  assert.match(RENDER, /class="cl"><span class="ct"/);
+  // the shared module splits each highlighted line into <span class=cl><span class=ct>…, re-opening straddling
+  // spans (code-block.test.ts executes the walk); the chat calls it for every fence when line numbers are on
+  assert.match(BLOCK, /export function wrapCodeLines/);
+  assert.match(BLOCK, /class="cl"><span class="ct"/);
+  assert.match(RENDER, /if \(lineNos\) wrapCodeLines\(code\);/);
+  assert.doesNotMatch(RENDER, /function wrapCodeLines/, "render.ts keeps no copy of its own");
+  // the gutter's basis grows with the fence's digit count (wrapCodeLines writes --ln-digits), its line box is never
+  // taller than the text's, and a blank row keeps the line-height through the word joiner in its empty cell
+  assert.match(CSS, /pre code \.cl::before \{[^}]*flex: 0 0 max\(2\.5em, calc\(var\(--ln-digits, 0\) \* 1ch \+ 0\.05em\)\)/);
+  assert.match(CSS, /pre code \.cl::before \{[^}]*line-height: 1;/);
+  assert.match(CSS, /pre code \.ct::before \{ content: "\\2060"; \}/);
 });
 
 test("Edit diffs render a two-column line-number gutter (the user 2026-06-29)", () => {

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1393,10 +1393,14 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   background: var(--bg, #1e1e1e); border: 1px solid var(--box-border); border-radius: var(--radius-modal);
   box-shadow: var(--shadow-modal); }
 body.fileview-open { overflow: hidden; }
-.fileview-bar { flex: 0 0 auto; display: flex; align-items: center; gap: 10px; min-width: 0;
+.fileview-bar { flex: 0 0 auto; display: flex; flex-wrap: wrap; align-items: center; gap: 6px 10px; min-width: 0;
   padding: 7px 10px; border-bottom: 1px solid var(--box-border); }
 /* Only the DIRECTORY may be truncated: the filename identifies the file, so it holds its width however
-   deep the path is, and the dimmed directory in front of it gives up room first. */
+   deep the path is, and the dimmed directory in front of it gives up room first. The bar WRAPS: the path
+   keeps at least 12em and the action row drops to a second line, right-aligned, when the two do not fit
+   side by side (the text-size control's three buttons pushed Download, Copy path and the close button off
+   the card below about 600px; .fileview is overflow: hidden, and a phone has no Escape). The wrap is the
+   bar's own: the two .fileview-bar rules after .fileview-acts below. */
 .fileview-name { flex: 1 1 auto; min-width: 0; font-size: 0.86em; color: var(--fg);
   display: flex; align-items: baseline; white-space: nowrap; }
 .fileview-dir { flex: 0 1 auto; min-width: 0; color: var(--dim);
@@ -1419,6 +1423,12 @@ body.fileview-open { overflow: hidden; }
   background: var(--overlay-10, rgba(255, 255, 255, 0.12)); color: var(--fg); user-select: none; }
 .fileview-sess .host-prefix { color: inherit; opacity: 0.75; }
 .fileview-acts { flex: 0 0 auto; display: flex; align-items: center; gap: 6px; }
+/* The wrap is the TITLE BAR's, not the classes': the file browser's action row (.fb-bar, file-browse.ts)
+   wears .fileview-acts outside any bar and keeps one line at every width (its crumb trail is what gives up
+   room), so the plain flex above holds there. Inside the bar the path keeps 12em and takes the rest of a
+   wide bar, and the action row shrinks and wraps to the right edge. */
+.fileview-bar .fileview-name { flex: 1 1 0; min-width: 12em; }
+.fileview-bar .fileview-acts { flex: 0 1 auto; min-width: 0; margin-left: auto; flex-wrap: wrap; justify-content: flex-end; }
 .fileview-btn { font: inherit; font-size: 0.82em; cursor: pointer; flex: 0 0 auto;
   padding: 3px 9px; border-radius: 6px; background: transparent; color: var(--fg);   /* T151: the one button rest */
   border: 1px solid var(--card-border);
@@ -1439,11 +1449,21 @@ a.fileview-btn { text-decoration: none; display: inline-flex; align-items: cente
    dimmed button and the loader's dots (.fileview-dot, the pane's own) where the caption will go — a slow
    check must read as a wait, not as the old no-button state nor as a verdict (the loading-state rule) */
 .fileview-gh-dots { display: inline-flex; align-items: center; gap: 4px; }
-/* no link: a real disabled button, greyed, hover inert — never hidden (an absent button read as
-   "broken" when the file was simply not committed yet, 2026-09-05) */
-.fileview-gh .fileview-btn:disabled { opacity: 0.55; cursor: default; }
-.fileview-gh .fileview-btn:disabled:hover { border-color: var(--card-border); color: var(--fg); background: transparent; }
-.fileview-gh .fileview-btn:disabled:active { transform: none; }
+/* a disabled bar button, greyed, hover inert: the GitHub unit's no-link state (a real disabled button, never
+   hidden: an absent button read as "broken" when the file was simply not committed yet, 2026-09-05), the
+   editor's Save while a save is in flight (disabled and reading "Saving…"), and the text-size control's ends
+   (A− at the smallest step, A+ at the largest; aria-disabled, so the button keeps the keyboard focus it holds
+   and the ring stays where the person left it). One treatment for every bar button, so neither an end nor a
+   save in progress reads as live under the pointer. */
+.fileview-btn:disabled, .fileview-btn[aria-disabled="true"] { opacity: 0.55; cursor: default; }
+.fileview-btn:disabled:hover, .fileview-btn[aria-disabled="true"]:hover { border-color: var(--card-border); color: var(--fg); background: transparent; }
+.fileview-btn:disabled:active, .fileview-btn[aria-disabled="true"]:active { transform: none; }
+/* the text-size readout between A− and A+ (file-view.ts textSizeControl): a slot of ONE width whatever it
+   says, and at the default (nothing to reset, nothing to say) an empty slot rather than none, so A− never
+   moves under the pointer when the readout appears after the first press. visibility, not display: the slot
+   stays, the button leaves the tab order. */
+.fileview-size-reset { min-width: 5.5em; box-sizing: border-box; text-align: center; font-variant-numeric: tabular-nums; }
+.fileview-size-reset.fileview-size-default { visibility: hidden; }
 /* a link whose branch is not on origin yet: dashed, the caption carries the note */
 a.fileview-gh-note { border-style: dashed; }
 .fileview-body { flex: 1 1 auto; min-height: 0; overflow: auto; }
@@ -1452,11 +1472,11 @@ a.fileview-gh-note { border-style: dashed; }
 .fileview-code { display: flex; align-items: flex-start; min-height: 100%; }
 .fileview-gutter { flex: 0 0 auto; position: sticky; left: 0; z-index: 1;
   padding: 10px 8px 10px 10px; text-align: right; user-select: none;
-  font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
+  font-family: var(--mono, ui-monospace, monospace); font-size: calc(12px * var(--fv-scale, 1)); line-height: 1.5;
   color: var(--dim); opacity: 0.55; background: var(--bg, #1e1e1e);
   border-right: 1px solid var(--box-border); white-space: pre; }
 .fileview-pre { flex: 1 1 auto; margin: 0; padding: 10px 12px;
-  font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
+  font-family: var(--mono, ui-monospace, monospace); font-size: calc(12px * var(--fv-scale, 1)); line-height: 1.5;
   white-space: pre; tab-size: 4; }
 .fileview-pre code { background: none; padding: 0; font: inherit; }
 /* a refusal explains itself in place, in the kernel's own words (too large — with the size and the
@@ -1504,6 +1524,32 @@ a.fileview-gh-note { border-style: dashed; }
 }
 .fileview-wrap .fv-ct { flex: 1 1 auto; min-width: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
 
+/* ── text size and measure (file-view.ts textSizeControl) ── The A− / A+ buttons and Ctrl/Cmd + wheel over the
+   body set `data-fv-text` on the viewer root to one of TEXT_SIZES; this table turns the step into the ONE
+   property the text views read, --fv-scale. Every text size below is a multiple of it, so the prose, its
+   headings (em of the prose), inline and fenced code, and the Raw view's rows and gutter scale together, and
+   the prose measure with them (the same characters per line at every size). Nothing else reads it: the title
+   bar, its buttons and the editor keep the page's size. Absent (a bundle without these rules) every fallback
+   reads as 1, today's sizes exactly. file-view-text-size.test.ts pins the table against TEXT_SIZES in both
+   sheets. The measure sits on the root's children, not the root: a table takes the viewer's width when its
+   columns need it (the root is fluid to the body), and a table wider than that scrolls on its own with
+   whole words kept (`overflow-wrap: normal` against the root's `anywhere`, which would crush every column to
+   fit), so the page never widens. Code blocks keep the measure and wrap their long lines (long lines always
+   soft-wrap): a short snippet has no use for a viewer-wide block beside 860px prose. The measure rule is written
+   at ZERO specificity (:where) so a picture's own cap below always beats it: a bare <img> line in a README is a
+   direct child of the root, and a plain :not() chain would tie `.fileview-md img` on specificity and leave the
+   winner to rule order; :where keeps the picture's cap the winner whatever the order, so a wide banner is never
+   laid out at the measure to scroll a narrow viewer sideways. A picture that is itself a block of the page takes
+   the measure AND the column, like an image paragraph (the `.fileview-md > :is(img, svg, canvas, video)` rule). */
+.fileview[data-fv-text="70"] { --fv-scale: 0.7; }
+.fileview[data-fv-text="80"] { --fv-scale: 0.8; }
+.fileview[data-fv-text="90"] { --fv-scale: 0.9; }
+.fileview[data-fv-text="100"] { --fv-scale: 1; }
+.fileview[data-fv-text="115"] { --fv-scale: 1.15; }
+.fileview[data-fv-text="130"] { --fv-scale: 1.3; }
+.fileview[data-fv-text="150"] { --fv-scale: 1.5; }
+.fileview[data-fv-text="175"] { --fv-scale: 1.75; }
+.fileview[data-fv-text="200"] { --fv-scale: 2; }
 /* Rendered markdown (the Raw ⇄ Rendered toggle; Rendered is the default — the user 2026-08-09).
    Typography mirrors the chat's .md block in styles.css, the reference aesthetic (one treatment, two
    sheets — the .romp-acted precedent); font sizes reuse what this surface already wears (the page base,
@@ -1515,8 +1561,10 @@ a.fileview-gh-note { border-style: dashed; }
    body's vertical scroll is untouched. Content wider than .fileview-md becomes ink overflow the body cannot
    scroll to, so the media rules below cap an <svg>, <canvas> or <video> at the column as `.fileview-md img`
    already does, and the table rule below gives a table wider than the column a horizontal scroll of its own.
-   Pinned byte-equal in both sheets (fileview-parity.test.ts). */
-.fileview-md { padding: 14px 18px; max-width: 860px; overflow-wrap: anywhere; font-family: var(--font-prose); contain: layout; }
+   The column is the root's own width, fluid to the viewer: the prose measure sits on the root's children (the
+   text-size block above). Pinned byte-equal in both sheets (fileview-parity.test.ts). */
+.fileview-md { padding: 14px 18px; overflow-wrap: anywhere; font-family: var(--font-prose); font-size: calc(1em * var(--fv-scale, 1)); contain: layout; }
+.fileview-md > :where(:not(table)) { max-width: calc(860px * var(--fv-scale, 1)); }
 .fileview-md > :first-child { margin-top: 0; }
 .fileview-md > :last-child { margin-bottom: 0; }
 .fileview-md p { margin: 0.5em 0; }
@@ -1551,14 +1599,15 @@ a.fileview-gh-note { border-style: dashed; }
 }
 .fileview-md pre code {
   background: none; padding: 0; display: block;
-  font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
+  font-family: var(--mono, ui-monospace, monospace); font-size: calc(12px * var(--fv-scale, 1)); line-height: 1.5;
   color: var(--code-fg, #e1c08d); white-space: pre-wrap; overflow-wrap: anywhere;
 }
 /* A table wider than the column (a `nowrap` cell, many columns) scrolls sideways on its own, as on GitHub: a block
    box shrink-wrapped to its content (width: max-content) and capped at the column, with the overflow scrollable.
    Under contain: layout the body cannot scroll to what a table lets run past the column, so the table has to.
-   border-collapse is inherited by the anonymous table box the block wraps, so the cell borders still collapse. */
-.fileview-md table { border-collapse: collapse; margin: 0.6em 0; display: block; width: max-content; max-width: 100%; overflow-x: auto; }
+   border-collapse is inherited by the anonymous table box the block wraps, so the cell borders still collapse.
+   overflow-wrap: normal keeps whole words against the root's `anywhere`, which would crush every column to fit. */
+.fileview-md table { border-collapse: collapse; margin: 0.6em 0; display: block; width: max-content; max-width: 100%; overflow-x: auto; overflow-wrap: normal; }
 .fileview-md th, .fileview-md td { border: 1px solid var(--box-border); padding: 4px 10px; text-align: left; }
 .fileview-md th { background: var(--box-bg, rgba(255, 255, 255, 0.03)); }
 .fileview-md img { max-width: 100%; }
@@ -1570,6 +1619,11 @@ a.fileview-gh-note { border-style: dashed; }
    the cap and keeps the author's height. */
 :where(.fileview-md) svg, :where(.fileview-md) canvas, :where(.fileview-md) video { max-width: 100%; }
 :where(.fileview-md :is(svg, canvas)[width]:not([width$="%"])) { height: auto; }
+/* a bare top-level medium (an <img> line in a README, an inline <svg>, <canvas> or <video> block: a direct child of
+   the root) takes the measure AND the column, like an image paragraph. Class-and-type specificity, so it outranks
+   both the general caps above and the :where measure; the measure alone (a class) would beat the element-level
+   media cap for a direct child and hold a wide diagram at 860px on a narrower viewer, clipped under contain: layout. */
+.fileview-md > :is(img, svg, canvas, video) { max-width: min(100%, calc(860px * var(--fv-scale, 1))); }
 
 /* ── the viewer's image + PDF bodies (a .png used to open as line-numbered mojibake). The <img>
    wears the lightbox image's own treatment (.romp-lightbox-img: capped, object-fit contain, the

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -39,7 +39,7 @@
   /* the hljs syntax palette, as tokens — mirrors styles.css byte-for-byte (one treatment, two
      sheets; file-view.test.ts pins the two identical). Raw hexes here were dark-only. */
   --hl-fg: #d8c6a8; --hl-kw: #c98a6a; --hl-str: #9fb878; --hl-num: #d4a36a;
-  --hl-cmt: #6f6a5f; --hl-title: #e1c08d; --hl-meta: #9a8f7a; --hl-attr: #cdaf7e;
+  --hl-cmt: #978f81; --hl-title: #e1c08d; --hl-meta: #9a8f7a; --hl-attr: #cdaf7e;   /* --hl-cmt raised from #6f6a5f (2.85:1 on a code block) to 4.79:1; theme-parity.test.ts holds the pair */
   --accent-fg: #0c1a2e;  /* dark text ON the accent (CLAUDE.md) — for the reverse-highlight on a selected toggle */
   --accent-wash: rgba(156, 210, 255, 0.12);  /* THE faint accent wash — mirrors styles.css; one alpha
                        behind every selected/hovered accent chrome */
@@ -108,7 +108,12 @@
   --check-bg: #1EA1EB;
 
   --sans: "Inter", var(--vscode-chat-font-family, var(--vscode-font-family, system-ui, -apple-system, "Segoe UI", sans-serif));
-  --font-prose: var(--sans);   /* the reading face (.fileview-md); mirrors styles.css :root — the light block re-points it */
+  --font-prose: var(--sans);   /* the assistant's reading face; mirrors styles.css :root, and the light block re-points it */
+  /* --font-doc is the file viewer's face for a rendered document (.fileview-md): sans in both themes. --color-scheme names
+     the theme to a form control a document carries (a task list's checkbox), so its checkbox is drawn for the page it sits on.
+     Mirrors styles.css. */
+  --font-doc: var(--sans);
+  --color-scheme: dark;
   --fs: var(--vscode-chat-font-size, 13px);
 }
 
@@ -144,7 +149,7 @@ body.theme-light {
   --code-bg: rgba(180, 83, 9, 0.08);
   --link: #1D63A8;   /* inked cobalt — clearly clickable, clearly not the error red (5.2:1 on the page) */
   --hl-fg: #3E3A35; --hl-kw: #A03509; --hl-str: #47720F; --hl-num: #915C0B;
-  --hl-cmt: #6E675C; --hl-title: #8C4A00; --hl-meta: #6E6455; --hl-attr: #7A5A20;
+  --hl-cmt: #67614f; --hl-title: #8C4A00; --hl-meta: #6E6455; --hl-attr: #7A5A20;   /* --hl-cmt from #6E675C (4.39:1 on a code block) to 4.86:1 */
   --box-bg: rgba(0, 0, 0, 0.03);
   --box-border: rgba(0, 0, 0, 0.12);
   --err: #B02A1C;
@@ -191,6 +196,8 @@ body.theme-light {
   --mono: var(--vscode-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
   --sans: "Space Grotesk", "Inter", var(--vscode-chat-font-family, var(--vscode-font-family, system-ui, -apple-system, "Segoe UI", sans-serif));
   --font-prose: var(--mono);   /* the user 2026-08-31, off the live preview: the serif read awful — assistant output goes MONO in light */
+  --font-doc: var(--sans);     /* a viewed document stays sans: the mono ruling was about chat output */
+  --color-scheme: light;
   --fs: var(--vscode-chat-font-size, 13px);
   /* the --vscode-* stand-ins: inline rules fall back through these (menus, inputs, widget cards) */
   --vscode-editor-background: #F1EAE2;
@@ -1528,19 +1535,10 @@ a.fileview-gh-note { border-style: dashed; }
    body set `data-fv-text` on the viewer root to one of TEXT_SIZES; this table turns the step into the ONE
    property the text views read, --fv-scale. Every text size below is a multiple of it, so the prose, its
    headings (em of the prose), inline and fenced code, and the Raw view's rows and gutter scale together, and
-   the prose measure with them (the same characters per line at every size). Nothing else reads it: the title
-   bar, its buttons and the editor keep the page's size. Absent (a bundle without these rules) every fallback
-   reads as 1, today's sizes exactly. file-view-text-size.test.ts pins the table against TEXT_SIZES in both
-   sheets. The measure sits on the root's children, not the root: a table takes the viewer's width when its
-   columns need it (the root is fluid to the body), and a table wider than that scrolls on its own with
-   whole words kept (`overflow-wrap: normal` against the root's `anywhere`, which would crush every column to
-   fit), so the page never widens. Code blocks keep the measure and wrap their long lines (long lines always
-   soft-wrap): a short snippet has no use for a viewer-wide block beside 860px prose. The measure rule is written
-   at ZERO specificity (:where) so a picture's own cap below always beats it: a bare <img> line in a README is a
-   direct child of the root, and a plain :not() chain would tie `.fileview-md img` on specificity and leave the
-   winner to rule order; :where keeps the picture's cap the winner whatever the order, so a wide banner is never
-   laid out at the measure to scroll a narrow viewer sideways. A picture that is itself a block of the page takes
-   the measure AND the column, like an image paragraph (the `.fileview-md > :is(img, svg, canvas, video)` rule). */
+   the prose measure with them (80 of the root's own ch, so the same characters per line at every size; the
+   Rendered markdown block below says how it is laid). Nothing else reads it: the title bar, its buttons and the
+   editor keep the page's size. Absent (a bundle without these rules) every fallback reads as 1, today's sizes
+   exactly. file-view-text-size.test.ts pins the table against TEXT_SIZES in both sheets and measures the layout. */
 .fileview[data-fv-text="70"] { --fv-scale: 0.7; }
 .fileview[data-fv-text="80"] { --fv-scale: 0.8; }
 .fileview[data-fv-text="90"] { --fv-scale: 0.9; }
@@ -1551,31 +1549,60 @@ a.fileview-gh-note { border-style: dashed; }
 .fileview[data-fv-text="175"] { --fv-scale: 1.75; }
 .fileview[data-fv-text="200"] { --fv-scale: 2; }
 /* Rendered markdown (the Raw ⇄ Rendered toggle; Rendered is the default — the user 2026-08-09).
-   Typography mirrors the chat's .md block in styles.css, the reference aesthetic (one treatment, two
-   sheets — the .romp-acted precedent); font sizes reuse what this surface already wears (the page base,
-   12px mono, the err-hint's 0.92em). Vars the feed sheet does not define carry the chat's literals as
-   fallbacks (feed-css-vars.test.ts holds that line). */
-/* contain: layout makes .fileview-md the containing block for any fixed or absolutely positioned descendant: an
-   element in a file that reaches `position: fixed` (a class of the page's it happens to wear; the sanitizer drops
-   an inline one) stays inside the note instead of covering the viewer's chrome. Layout only, not paint: the
-   body's vertical scroll is untouched. Content wider than .fileview-md becomes ink overflow the body cannot
-   scroll to, so the media rules below cap an <svg>, <canvas> or <video> at the column as `.fileview-md img`
-   already does, and the table rule below gives a table wider than the column a horizontal scroll of its own.
-   The column is the root's own width, fluid to the viewer: the prose measure sits on the root's children (the
-   text-size block above). Pinned byte-equal in both sheets (fileview-parity.test.ts). */
-.fileview-md { padding: 14px 18px; overflow-wrap: anywhere; font-family: var(--font-prose); font-size: calc(1em * var(--fv-scale, 1)); contain: layout; }
-.fileview-md > :where(:not(table)) { max-width: calc(860px * var(--fv-scale, 1)); }
+   A document's type scale, GitHub's: the prose at 1.15 times the page's size (14.95px at the 13px default) in the
+   document's own face, --font-doc (sans in both themes; --font-prose is the assistant's reading face, mono in the light
+   theme, and a README in mono reads as source); headings 2 / 1.5 / 1.25 / 1em with h5 and h6 dimmed and a rule under h1
+   and h2; a 2em list gutter; fenced code at 12px mono with the chat's per-line rows and Copy button; inline code and kbd
+   at 0.92 and 0.86em; the leading 1.5, declared on the root rather than inherited, since the chat's body is 1.6 and the
+   feed's 1.5, so the same document was a different height on the two surfaces. Vars the feed sheet does not define
+   carry the chat's literals as fallbacks (feed-css-vars.test.ts holds that line). One treatment, two sheets: the
+   .romp-acted precedent; fileview-parity.test.ts pins every head byte-equal.
+   The measure is 80 of the root's own ch, laid as inline padding rounded DOWN to whole pixels (a fractional left edge put
+   the text on sub-pixel positions where a drag selection stayed collapsed), centred, never under 18px; the plain calc()
+   is the fallback for an engine without round(), declared first. It replaces a fixed pixel cap, so the column is the
+   same characters wide at every text size. contain: layout makes the root the containing block for anything inside it
+   (an element in a file that reaches `position: fixed` through a class of the page's it happens to wear, the sanitizer
+   having dropped an inline one, stays inside the note instead of covering the viewer's chrome; layout only, not paint, so
+   the body's vertical scroll is untouched) and turns content wider than the root into ink overflow the body cannot scroll
+   to, so nothing a document carries widens the viewer: the img rule and the media rules below cap a picture, an inline
+   svg, a canvas or a video at the column, and a table wider than the column scrolls on its own (the table rules below).
+   --fv-body-w, the body's content width for a top-level table's cap (below), is registered non-inherited so a write to a
+   table restyles that table alone. */
+@property --fv-body-w { syntax: "*"; inherits: false; }
+.fileview-md { padding: 14px 18px; padding-inline: max(18px, calc((100% - 80ch) / 2)); padding-inline: max(18px, round(down, calc((100% - 80ch) / 2), 1px)); overflow-wrap: anywhere; font-family: var(--font-doc); font-size: calc(var(--fs) * 1.15 * var(--fv-scale, 1)); line-height: 1.5; contain: layout; }
 .fileview-md > :first-child { margin-top: 0; }
 .fileview-md > :last-child { margin-bottom: 0; }
 .fileview-md p { margin: 0.5em 0; }
-.fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4 {
-  font-weight: 600; color: var(--fg); margin: 1em 0 0.4em; line-height: 1.3; }
-.fileview-md h1 { font-size: 1.3em; } .fileview-md h2 { font-size: 1.15em; } .fileview-md h3 { font-size: 1.05em; }
+/* The heading ladder: h1 2em, h2 1.5em, h3 1.25em, h4 1em, h5 and h6 1em in the dim tier, weight 600, a rule under h1 and
+   h2. em of the prose, so the text-size control scales them with it. The margins are 1.5 above and 0.5 below every
+   heading in the PROSE's em whatever the heading's size: a heading's em is its own, so the larger levels divide by their
+   size to land on the same distance. */
+.fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4, .fileview-md h5, .fileview-md h6 {
+  font-weight: 600; color: var(--fg); margin: 1.5em 0 0.5em; line-height: 1.25; }
+.fileview-md h1 { font-size: 2em; margin: calc(1.5em / 2) 0 calc(0.5em / 2); }
+.fileview-md h2 { font-size: 1.5em; margin: calc(1.5em / 1.5) 0 calc(0.5em / 1.5); }
+.fileview-md h3 { font-size: 1.25em; margin: calc(1.5em / 1.25) 0 calc(0.5em / 1.25); }
+.fileview-md h4 { font-size: 1em; }
+.fileview-md h5, .fileview-md h6 { font-size: 1em; color: var(--dim); }
+.fileview-md h1, .fileview-md h2 { padding-bottom: 0.3em; border-bottom: 1px solid var(--box-border); }
 /* a heading an in-document link lands on (scrollIntoView) sits a breath below the title bar's hairline
    rather than flush against it — the bar's own 10px spacing */
 .fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4, .fileview-md h5, .fileview-md h6 { scroll-margin-top: 10px; }
-.fileview-md ul, .fileview-md ol { margin: 0.4em 0; padding-left: 1.4em; }
+.fileview-md ul, .fileview-md ol { margin: 0.4em 0; padding-left: 2em; }
 .fileview-md li { margin: 0.2em 0; }
+/* A task item (`- [ ] ...`): no bullet beside the checkbox (mdBlock stamps GitHub's task-list-item on the li after the
+   sanitize, for a disabled checkbox that is the item's first child, in a paragraph or not), the checkbox pulled into the
+   gutter where the bullet was, drawn for the theme the page wears (--color-scheme; without it a dark page draws a white
+   checkbox). The pull is measured against Chromium's disc, whose centre sits about 7px plus 0.45em before the item's text at
+   every size, and the checkbox is the control's own 13px, declared so the margin can centre it on that point. font-size:
+   inherit makes the em the prose's: a control's own em is the UA's 13.33px, which the text-size control never moves.
+   The size is a rule of its own, for every checkbox under a task item (a nested list's too). 0.2em after the checkbox plus the
+   source's own space puts the text on the plain items' text edge. No accent-color: marked emits every checkbox disabled, and
+   Chromium paints a disabled checkbox grey whatever accent is declared. */
+.fileview-md li.task-list-item { list-style: none; }
+.fileview-md li.task-list-item input { font-size: inherit; }
+.fileview-md li.task-list-item > input[type="checkbox"], .fileview-md li.task-list-item > p:first-child > input[type="checkbox"] {
+  width: 13px; height: 13px; margin: 0 0.2em 0.25em calc(-13px - 0.46em); vertical-align: middle; color-scheme: var(--color-scheme); }
 .fileview-md strong { color: var(--fg); font-weight: 600; }
 .fileview-md em { font-style: italic; }
 .fileview-md a { color: var(--link); text-decoration: none; }
@@ -1593,6 +1620,13 @@ a.fileview-gh-note { border-style: dashed; }
   color: var(--code-fg, #e1c08d); background: var(--code-bg, rgba(217, 119, 87, 0.10));
   padding: 0.12em 0.4em; border-radius: 4px;
 }
+/* <kbd>, a key: the settings modal's two tokens (gear.css reads them too), mono at 0.86em, a bottom shadow line for the
+   key's edge. */
+.fileview-md kbd {
+  display: inline-block; padding: 0.1em 0.4em; font-family: var(--mono, ui-monospace, monospace); font-size: 0.86em;
+  line-height: 1.3; color: var(--fg); vertical-align: middle; background: var(--kbd-bg); border: 1px solid var(--kbd-border);
+  border-radius: 3px; box-shadow: inset 0 -1px 0 var(--kbd-border);
+}
 .fileview-md pre {
   background: var(--box-bg, rgba(255, 255, 255, 0.03)); border: 1px solid var(--box-border);
   border-radius: 6px; padding: 11px 14px; margin: 0.6em 0; overflow-x: auto;
@@ -1601,15 +1635,65 @@ a.fileview-gh-note { border-style: dashed; }
   background: none; padding: 0; display: block;
   font-family: var(--mono, ui-monospace, monospace); font-size: calc(12px * var(--fv-scale, 1)); line-height: 1.5;
   color: var(--code-fg, #e1c08d); white-space: pre-wrap; overflow-wrap: anywhere;
+  tab-size: 4; counter-reset: ln;   /* tabs as the Raw view shows them (.fileview-pre); the line counter, for every fence (below) */
 }
-/* A table wider than the column (a `nowrap` cell, many columns) scrolls sideways on its own, as on GitHub: a block
-   box shrink-wrapped to its content (width: max-content) and capped at the column, with the overflow scrollable.
-   Under contain: layout the body cannot scroll to what a table lets run past the column, so the table has to.
-   border-collapse is inherited by the anonymous table box the block wraps, so the cell borders still collapse.
-   overflow-wrap: normal keeps whole words against the root's `anywhere`, which would crush every column to fit. */
+/* A fence's per-line rows and Copy button (code-block.ts, the chat's own): .cl is one logical line, .ct its wrapping
+   content, the number a CSS counter in ::before so a soft-wrap reads distinctly from a real newline and the numbers never
+   copy with the code. The counter resets on `.fileview-md pre code` above, not on `code.hljs` as the chat's does: mdBlock
+   wraps EVERY fence, and an unregistered language's fence carries no hljs class, so it would have gone on counting from
+   the block before. The Copy button is parked top-right, faint until the block is hovered, green on success. Scoped
+   copies of the chat's unscoped rules (styles.css), byte-equal in both sheets since the feed page loads only feed.css
+   (fileview-parity.test.ts, code-block.test.ts); the code tint carries the chat's literal as its fallback, since feed.css
+   defines no --code-bg in :root (feed-css-vars.test.ts). The gutter's own line-height is 1 and it never wraps, its basis
+   is 2.5em or the fence's digit count in ch (--ln-digits, written by wrapCodeLines), and the .ct's ::before is a word
+   joiner so a blank line's row is the line-height: the chat's rule says why each. */
+.fileview-md pre code .cl { display: flex; align-items: baseline; }
+.fileview-md pre code .cl::before {
+  counter-increment: ln; content: counter(ln);
+  flex: 0 0 max(2.5em, calc(var(--ln-digits, 0) * 1ch + 0.05em)); margin-right: 0.85em; text-align: right;
+  color: var(--dim); opacity: 0.32; user-select: none; font-size: 0.92em; line-height: 1; overflow-wrap: normal;
+}
+.fileview-md pre code .ct { flex: 1 1 auto; min-width: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
+.fileview-md pre code .ct::before { content: "\2060"; }
+.fileview-md pre.has-copy { position: relative; }
+.fileview-md .code-copy {
+  position: absolute; top: 6px; right: 6px; z-index: 1;
+  font-family: var(--sans); font-size: 11px; line-height: 1; padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--box-border); background: var(--code-bg, rgba(217, 119, 87, 0.10)); color: var(--dim);
+  cursor: pointer; opacity: 0; user-select: none;
+  transition: opacity 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.fileview-md pre.has-copy:hover .code-copy, .fileview-md .code-copy:focus-visible { opacity: 0.9; }
+.fileview-md .code-copy:hover { color: var(--fg); border-color: var(--dim); }
+.fileview-md .code-copy.copied { color: var(--green); border-color: var(--green); opacity: 1; }
+@media (hover: none) { .fileview-md .code-copy { opacity: 0.8; } }   /* touch: no hover state, so keep it visible */
+/* A table is a block as wide as its columns need, scrolling in its own box past its cap, whole words kept (overflow-wrap:
+   normal against the root's anywhere). A table inside a quote or a list item is capped at its container. A table of the
+   page's own (a direct child of the root) is capped at the BODY's width less the root's 18px inset, not the column's:
+   --fv-body-w is the body's content width as its ResizeObserver reports it (file-view.ts watchBodyWidth), written on
+   each top-level table and registered non-inherited above. A table no wider than the column sits at the column's left
+   edge with the prose, as on GitHub; one wider than the column grows out of it EVENLY, into both gutters, until it meets
+   the body's inset: the translate moves it left by half of what it exceeds the column by (a percentage in translate is
+   of the table's own width; half the body less the root's inline padding is half the column, the padding rounded down
+   here as the root rounds it, and the observer's width is the content box the root's 100% is, so the two agree to the
+   pixel; min() holds a narrower table still; the shift is rounded to whole pixels, as the measure is). Scrollable overflow
+   is computed from the transformed box, so the shifted table never makes the body scroll sideways; contain: layout on the
+   root is for anything else wider than the column (a fixed-width svg, an iframe), which it turns into ink overflow the
+   body cannot scroll to. Before the observer's first report, or with no ResizeObserver, the property is unset and both
+   declarations read the same stand-in, 100% plus the inset the cap takes back: the cap is then the column, and in the
+   translate, where 100% is the table's own width, the padding term is under 19px for any table the column holds and
+   rounds down to its 18px floor, so the shift is exactly none. border-collapse is inherited by the anonymous table box the
+   block wraps, so the cell borders still collapse. */
 .fileview-md table { border-collapse: collapse; margin: 0.6em 0; display: block; width: max-content; max-width: 100%; overflow-x: auto; overflow-wrap: normal; }
+.fileview-md > table { max-width: calc(var(--fv-body-w, calc(100% + 36px)) - 36px); translate: min(0px, round(calc(var(--fv-body-w, calc(100% + 36px)) / 2 - max(18px, round(down, (var(--fv-body-w, calc(100% + 36px)) - 80ch) / 2, 1px)) - 50%), 1px)); }
 .fileview-md th, .fileview-md td { border: 1px solid var(--box-border); padding: 4px 10px; text-align: left; }
-.fileview-md th { background: var(--box-bg, rgba(255, 255, 255, 0.03)); }
+.fileview-md th { font-weight: 600; background: var(--overlay-05); }
+.fileview-md tbody tr:nth-child(even) { background: var(--overlay-05); }
+/* marked writes a column's `:---:` / `---:` alignment as the cell's align attribute (DOMPurify keeps it); the rule above
+   overrode the presentational hint, so every cell read left */
+.fileview-md th[align="center"], .fileview-md td[align="center"] { text-align: center; }
+.fileview-md th[align="right"], .fileview-md td[align="right"] { text-align: right; }
+.fileview-md th[align="left"], .fileview-md td[align="left"] { text-align: left; }
 .fileview-md img { max-width: 100%; }
 /* Media a file draws itself (an inline <svg> diagram, a <canvas>, a <video>) fits the column the way an <img> does:
    under contain: layout anything wider than .fileview-md is clipped at the body's edge and unreachable. :where() keeps
@@ -1619,11 +1703,6 @@ a.fileview-gh-note { border-style: dashed; }
    the cap and keeps the author's height. */
 :where(.fileview-md) svg, :where(.fileview-md) canvas, :where(.fileview-md) video { max-width: 100%; }
 :where(.fileview-md :is(svg, canvas)[width]:not([width$="%"])) { height: auto; }
-/* a bare top-level medium (an <img> line in a README, an inline <svg>, <canvas> or <video> block: a direct child of
-   the root) takes the measure AND the column, like an image paragraph. Class-and-type specificity, so it outranks
-   both the general caps above and the :where measure; the measure alone (a class) would beat the element-level
-   media cap for a direct child and hold a wide diagram at 860px on a narrower viewer, clipped under contain: layout. */
-.fileview-md > :is(img, svg, canvas, video) { max-width: min(100%, calc(860px * var(--fv-scale, 1))); }
 
 /* ── the viewer's image + PDF bodies (a .png used to open as line-numbered mojibake). The <img>
    wears the lightbox image's own treatment (.romp-lightbox-img: capped, object-fit contain, the
@@ -1635,6 +1714,40 @@ a.fileview-gh-note { border-style: dashed; }
 .fileview-img { max-width: 100%; max-height: 82vh; object-fit: contain; border-radius: 8px;
   box-shadow: var(--shadow-modal); }
 .fileview-frame { display: block; width: 100%; height: 100%; border: 0; background: #fff; }
+
+/* ── print (Ctrl/Cmd + P while a rendered file is open): the file alone, black on white, across as many pages as it needs.
+   The dashboard's chrome behind the viewer is left out and the viewer's own title bar and Copy buttons with it; the page
+   and the card go white (both :root and body.fileview-open, so a served page's inline theme cannot paint the canvas grey)
+   and every fixed height and overflow that holds the card to one screen is released, so the document runs on to the
+   next page instead of being cut at the first. Tokens and gutters print in full black in the document and in the Raw
+   view (code.hljs and its spans under the body, the wrap mode's row numbers, the plain gutter); the task checkbox is drawn in
+   the light scheme whatever the page's theme; fills and washes go, borders turn black. A table is laid out as a table
+   again (display: block would let it scroll, and paper does not), and a table of the page's own keeps the screen's room,
+   the body less the root's inset, with the screen's shift into both gutters: the cap and the translate are restated in
+   container units, the body made a size container here (no script runs at print layout, so a unit the sheet resolves is
+   the one that holds). Byte-equal in styles.css and feed.css (fileview-parity.test.ts). */
+@media print {
+  :root, body.fileview-open { height: auto; overflow: visible; background: white; color: black; }
+  body.fileview-open { display: block; }
+  body.fileview-open > :not(#romp-fileview) { display: none; }
+  #romp-fileview { position: static; inset: auto; z-index: auto; display: block; background: none; }
+  .fileview { width: auto; height: auto; display: block; overflow: visible; background: white; color: black; border: 0; border-radius: 0; box-shadow: none; }
+  .fileview-bar, .fileview > .fileview-err, .fileview-md .code-copy { display: none; }
+  .fileview-body { overflow: visible; container-type: inline-size; }
+  .fileview-md, .fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4, .fileview-md h5, .fileview-md h6, .fileview-md strong,
+  .fileview-md blockquote, .fileview-md a, .fileview-md kbd, .fileview-md :not(pre) > code, .fileview-md pre code, .fileview-md pre code span,
+  .fileview-md pre code .cl::before { color: black; }
+  .fileview-md a { text-decoration: underline; }
+  .fileview-md li.task-list-item input[type="checkbox"] { color-scheme: light; }
+  .fileview-md :not(pre) > code, .fileview-md kbd, .fileview-md pre, .fileview-md th, .fileview-md tbody tr:nth-child(even) { background: none; }
+  .fileview-md pre, .fileview-md th, .fileview-md td, .fileview-md hr, .fileview-md blockquote, .fileview-md h1, .fileview-md h2, .fileview-md kbd { border-color: black; }
+  .fileview-md kbd { box-shadow: none; }
+  .fileview-body code.hljs, .fileview-body code.hljs span, .fileview-body .fv-cl::before, .fileview-gutter { color: black; }
+  .fileview-md pre code .cl::before, .fileview-body .fv-cl::before, .fileview-gutter { opacity: 1; }
+  .fileview-gutter { background: none; border-color: black; }
+  .fileview-md table { display: table; width: max-content; overflow: visible; overflow-wrap: anywhere; }
+  .fileview-md > table { max-width: calc(100cqi - 36px); translate: min(0px, round(calc(50cqi - max(18px, round(down, (100cqi - 80ch) / 2, 1px)) - 50%), 1px)); }
+}
 
 /* ---------- syntax highlighting (warm, restrained) ----------
    The hljs token palette, mirrored from styles.css (one treatment, two sheets — the .romp-acted

--- a/ui/webview/fence-source.ts
+++ b/ui/webview/fence-source.ts
@@ -1,0 +1,156 @@
+// A fence's text as the FILE holds it, for the viewer's Copy button. marked's lexer rewrites the source before it tokenizes
+// anything: CR and CRLF become LF (Lexer.lex), and every run of tabs that begins a line, after any spaces, becomes four
+// spaces a tab (Lexer.blockTokens, `^( *)(\t+)`), fences included. So a code token's `text`, the code element's textContent
+// and the `raw` string mdBlock captures from it all carry spaces where the file has tabs, and Copy on a Makefile recipe or a
+// tab-indented Go fence pasted back as spaces (make: "missing separator"); the Raw view of the same file shows the tabs. The
+// lexer keeps no offsets, so this module finds each code token's lines in marked's own view of the source and reads them
+// back through the rewrite:
+//   - an expanded tab whose four spaces all lie in the fence's content is a tab again;
+//   - one a container's indentation consumed part of (a tab-indented line inside a two-space list item: marked slices the
+//     item's indent off the expanded line) is the spaces that remain, which is what CommonMark makes of a partially consumed
+//     tab;
+//   - a tab marked never expanded (mid-line, or right after a quote's `> `, which the blockquote strips before its inner
+//     tokenization expands what is left) stays a tab.
+// A fence is found by its content lines: consecutive lines of marked's view each ending in the token's line, past a prefix of
+// spaces and quote markers (what the containers took), the line before them a fence opener (an indented code block has none
+// and is matched by its lines alone); a fence whose text is empty by its opener and closer, since marked's text is empty for
+// a fence of no lines and for one of a single blank line alike; fences are searched in document order, each from past the one
+// before. A fence not found (an author's construction this reading does not follow) is null, and the caller copies the
+// rendered text as before. Nothing here changes the parse: the source reaches marked untouched, and the rendered text is
+// untouched too; the display's four spaces measure a tab at the sheet's `tab-size: 4`. file-view-fence-source.test.ts runs
+// it over the real marked.
+
+/** marked's code token, as mdBlock collects it from walkTokens: the text, and whether it is an indented block (no fence lines). */
+export type Fence = { text: string; indented: boolean };
+
+/** marked's view of `source` (Lexer.lex and Lexer.blockTokens: CR and CRLF to LF, then a line's leading run of tabs to four
+ *  spaces a tab, one run per line, right after the line's leading spaces) and, for each character of the view, the index of
+ *  the source character it stands for; the four spaces of an expanded tab share the tab's. */
+export function markedView(source: string): { text: string; at: number[] } {
+  let text = "";
+  const at: number[] = [];
+  let i = 0;
+  for (;;) {
+    let e = i;
+    while (e < source.length && source[e] !== "\n" && source[e] !== "\r") e++;
+    let k = i;
+    while (k < e && source[k] === " ") k++;
+    let p = i;
+    if (k < e && source[k] === "\t") {
+      for (; p < k; p++) { text += " "; at.push(p); }
+      for (; p < e && source[p] === "\t"; p++) { text += "    "; at.push(p, p, p, p); }
+    }
+    for (; p < e; p++) { text += source[p]; at.push(p); }
+    if (e >= source.length) break;
+    text += "\n"; at.push(e);
+    i = e + (source[e] === "\r" && source[e + 1] === "\n" ? 2 : 1);
+  }
+  return { text, at };
+}
+
+/** A code element's textContent for a code token's text, before any highlight: marked's code renderer drops one trailing
+ *  newline and appends one. */
+export const renderedFenceText = (text: string): string => text.replace(/\n$/, "") + "\n";
+
+/** A fence opener as marked's view shows it, with whatever containers put before it on its line: spaces, quote markers, a
+ *  list marker with its space (a fence may open on a list item's first line). */
+const OPENER = /^(?:[ >]|[-*+][ \t]|\d{1,9}[.)][ \t])*(?:`{3,}|~{3,})/;
+/** A fence closer as marked's view shows it: the fence run, any more fence characters, spaces, and before it only what a
+ *  container puts there (spaces, quote markers; a list marker would open an item, not close a fence). */
+const CLOSER = /^[ >]*(?:`{3,}|~{3,})[`~]* *$/;
+/** The lexer's rewrite over one line, as an inner blockTokens (a quote's, a list item's) applies it to the text it was handed. */
+const expandLeading = (s: string): string => s.replace(/^( *)(\t+)/, (_, l: string, t: string) => l + "    ".repeat(t.length));
+
+/** Where the token's line `want` begins inside view line `line`: past the shortest prefix of spaces and quote markers from
+ *  which the rest of the line, its own leading tabs expanded as an inner tokenization would expand them, is `want`; -1 when
+ *  no such prefix exists. */
+function contentStart(line: string, want: string): number {
+  for (let b = 0; b <= line.length; b++) {
+    if (expandLeading(line.slice(b)) === want) return b;
+    if (line[b] !== " " && line[b] !== ">") break;
+  }
+  return -1;
+}
+
+/** The source text behind view indices [s, e): an expanded tab's spaces (they share a source index, and the source holds a
+ *  tab there) read as the tab when all four lie in the span and as the spaces that remain when the span begins inside them;
+ *  every other character as the view has it. */
+function readBack(view: { text: string; at: number[] }, source: string, s: number, e: number): string {
+  let out = "";
+  for (let i = s; i < e;) {
+    const a = view.at[i];
+    if (view.text[i] === " " && source[a] === "\t") {
+      let j = i + 1;
+      while (j < e && view.at[j] === a) j++;
+      out += j - i === 4 ? "\t" : " ".repeat(j - i);
+      i = j;
+    } else { out += view.text[i]; i++; }
+  }
+  return out;
+}
+
+/** For each code token, in document order, its text as the source holds it, in the renderer's shape (renderedFenceText), or
+ *  null when its lines were not found in marked's view of the source. */
+export function fenceSources(source: string, fences: Fence[]): (string | null)[] {
+  const view = markedView(source);
+  const lines: [number, number][] = [];
+  for (let s = 0, i = 0; i <= view.text.length; i++) {
+    if (i === view.text.length || view.text[i] === "\n") { lines.push([s, i]); s = i + 1; }
+  }
+  const lineText = (k: number): string => view.text.slice(lines[k][0], lines[k][1]);
+  const out: (string | null)[] = [];
+  let from = 0;
+  for (const f of fences) {
+    if (f.text === "") {
+      // marked's text is "" for a fence of no lines and for one of a single blank line alike (its content match is lazy, and
+      // the renderer's dropped newline is the lexer's too), and for an opener the file ends on (an unclosed fence runs to
+      // the end). Read as one blank content line, a fence of no lines would be searched past its own closer, and the first
+      // blank line after any opener-shaped line would match: the blank first line inside the next fence, whose lines then
+      // lay behind `from` and made it null, so its Copy pasted marked's spaces. So the empty text is matched as its lines
+      // are: an opener, then a closer, or a blank line and a closer, or a blank line the file ends on. (An indented block's
+      // text is never empty: the lexer takes blank lines as space before its code rule sees them.)
+      let end = -1;
+      for (let j = from; j < lines.length && end < 0; j++) {
+        if (j === 0 || !OPENER.test(lineText(j - 1))) continue;
+        if (CLOSER.test(lineText(j))) end = j + 1;
+        else if (contentStart(lineText(j), "") >= 0) {
+          if (j + 1 === lines.length) end = j + 1;
+          else if (CLOSER.test(lineText(j + 1))) end = j + 2;
+        }
+      }
+      if (end < 0) { out.push(null); continue; }
+      out.push(renderedFenceText(""));
+      from = end;
+      continue;
+    }
+    const want = f.text.split("\n");
+    let found = -1;
+    for (let j = from; j + want.length <= lines.length && found < 0; j++) {
+      if (!f.indented && (j === 0 || !OPENER.test(lineText(j - 1)))) continue;
+      let ok = true;
+      for (let i = 0; i < want.length && ok; i++) ok = contentStart(lineText(j + i), want[i]) >= 0;
+      if (ok) found = j;
+    }
+    if (found < 0) { out.push(null); continue; }
+    const got = want.map((w, i) => { const [s, e] = lines[found + i]; return readBack(view, source, s + contentStart(lineText(found + i), w), e); });
+    out.push(renderedFenceText(got.join("\n")));
+    from = found + want.length;
+  }
+  return out;
+}
+
+/** What mdBlock's fence pass consumes: for each rendered text (a code element's textContent before the highlight), the source
+ *  texts of the code tokens that render as it, in document order, null for one not found, so a code element takes the next
+ *  entry under its own text and identical fences stay in step. Empty when the source holds no tab and no CR: marked's view is
+ *  then the source itself and every token's text is already the file's. */
+export function fenceCopyQueue(source: string, fences: Fence[]): Map<string, (string | null)[]> {
+  const queue = new Map<string, (string | null)[]>();
+  if (!fences.length || !/[\t\r]/.test(source)) return queue;
+  const sources = fenceSources(source, fences);
+  fences.forEach((f, i) => {
+    const key = renderedFenceText(f.text);
+    const list = queue.get(key);
+    if (list) list.push(sources[i]); else queue.set(key, [sources[i]]);
+  });
+  return queue;
+}

--- a/ui/webview/file-view-fence-source.test.ts
+++ b/ui/webview/file-view-fence-source.test.ts
@@ -1,0 +1,139 @@
+// A fence's text as the file holds it, for the viewer's Copy button (fence-source.ts). marked's lexer turns every leading run
+// of tabs into four spaces a tab before it tokenizes, so a code token's text, and the code element's textContent mdBlock
+// copies from, carry spaces where the file has tabs: a Makefile recipe copied out of the rendered view pasted back with
+// spaces. The module reads each token's lines back out of the file through the rewrite. Exercised over the REAL marked: the
+// tokens come from marked.parse's walkTokens, the way mdBlock collects them, so the cases pin marked's own transformations
+// (the expansion, a list item's indent slice, a quote's stripped `> `, an indented block's four columns, CRLF) beside the
+// module's reading of them. Self-contained: marked and the module only. Synthetic documents throughout.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { marked } from "marked";
+import { fenceSources, fenceCopyQueue, markedView, renderedFenceText, type Fence } from "./fence-source";
+
+const F = "```";
+/** The code tokens of `src` in document order, as mdBlock's walkTokens collects them. */
+const tokens = (src: string): Fence[] => {
+  const out: Fence[] = [];
+  marked.parse(src, { walkTokens: (t) => { if (t.type === "code") { const c = t as { text: string; codeBlockStyle?: string }; out.push({ text: c.text, indented: c.codeBlockStyle === "indented" }); } } });
+  return out;
+};
+/** marked's own preprocessing, as its Lexer spells it: line endings to LF, then a line's leading tabs to four spaces each. */
+const markedOwn = (src: string): string => src.replace(/\r\n|\r/g, "\n").replace(/^( *)(\t+)/gm, (_, l: string, t: string) => l + "    ".repeat(t.length));
+
+test("markedView is marked's own preprocessing, character for character, and maps every character back to its source index", () => {
+  for (const src of ["plain\n", "\tone\n\t\ttwo\n", "  \tmixed\n", "a\tb\n", " \t \tafter a space\n", "crlf\r\n\tx\r\n", "lone\rcr\t\n", "", "\t", "x\n\n\t\n"]) {
+    const v = markedView(src);
+    assert.equal(v.text, markedOwn(src), JSON.stringify(src));
+    assert.equal(v.at.length, v.text.length, "one source index per view character");
+    for (let i = 0; i < v.text.length; i++) {
+      const c = src[v.at[i]];
+      assert.ok(v.text[i] === c || (v.text[i] === " " && c === "\t") || (v.text[i] === "\n" && c === "\r"), `${JSON.stringify(src)} at ${i}: ${JSON.stringify(v.text[i])} from ${JSON.stringify(c)}`);
+    }
+  }
+});
+
+test("a top-level fence: leading tabs come back as tabs, one and two deep; a mid-line tab was never touched; marked's own text has the spaces", () => {
+  const src = `# Build\n\n${F}makefile\nall:\n\tgo build ./...\n\t\techo done\na\tb\tc\n${F}\n\nTail.\n`;
+  const t = tokens(src);
+  assert.equal(t.length, 1);
+  assert.equal(t[0].text, "all:\n    go build ./...\n        echo done\na\tb\tc", "marked's text: four spaces a leading tab, the mid-line tabs kept");
+  assert.deepEqual(fenceSources(src, t), ["all:\n\tgo build ./...\n\t\techo done\na\tb\tc\n"]);
+});
+
+test("a fence inside a list item: a tab the item's indent left whole is a tab; one the indent consumed part of is the spaces that remain (CommonMark's partial tab)", () => {
+  // two-space indent, then a tab: marked slices the item's two columns off the six expanded spaces, the tab stands whole
+  const whole = `- item one\n\n  ${F}python\n  \treturn 1\n  ${F}\n\n- item two\n`;
+  assert.deepEqual(fenceSources(whole, tokens(whole)), ["\treturn 1\n"]);
+  // a tab alone as the item's indent: the item's two columns eat half of it, and two spaces remain
+  const partial = `- ${F}python\n\treturn 1\n\t${F}\n`;
+  const t = tokens(partial);
+  assert.equal(t[0].text, "  return 1", "marked: two of the tab's four spaces remain after the slice");
+  assert.deepEqual(fenceSources(partial, t), ["  return 1\n"]);
+  // an ordered item's three columns
+  const ordered = `1. ${F}\n   \tx\n   ${F}\n`;
+  assert.deepEqual(fenceSources(ordered, tokens(ordered)), ["\tx\n"]);
+});
+
+test("a fence inside a quote: a tab right after the `> ` was not leading to the lexer, the quote strips the `> `, the inner tokenization expands it; the source's tab is copied", () => {
+  const src = `> Quoted.\n>\n> ${F}\n> \tfoo\n> ${F}\n`;
+  const t = tokens(src);
+  assert.equal(t[0].text, "    foo");
+  assert.deepEqual(fenceSources(src, t), ["\tfoo\n"]);
+  // nested: a fence opening on a list item's first line inside a quote
+  const nested = `> - ${F}sh\n>   \techo hi\n>   ${F}\n`;
+  assert.deepEqual(fenceSources(nested, tokens(nested)), ["\techo hi\n"]);
+});
+
+test("CRLF endings: the lines come back joined with LF, as the rendered text is, with the tabs restored", () => {
+  const src = `${F}\r\nx\r\n\ty\r\n${F}\r\n`;
+  assert.deepEqual(fenceSources(src, tokens(src)), ["x\n\ty\n"]);
+});
+
+test("an indented code block: the four columns the block's indent takes are gone (a whole tab, or four spaces), a second tab is a tab", () => {
+  const src = `para\n\n\t\tfoo\n\tbar\n    baz\n\npara\n`;
+  const t = tokens(src);
+  assert.equal(t.length, 1); assert.equal(t[0].indented, true);
+  assert.equal(t[0].text, "    foo\nbar\nbaz");
+  assert.deepEqual(fenceSources(src, t), ["\tfoo\nbar\nbaz\n"]);
+});
+
+test("the renderer's shape: one trailing newline dropped and one appended, so the copy matches the rendered text but for the tabs; an empty fence is one newline", () => {
+  assert.equal(renderedFenceText("foo\n"), "foo\n");
+  assert.equal(renderedFenceText("foo"), "foo\n");
+  assert.equal(renderedFenceText(""), "\n");
+  const blank = `${F}\nfoo\n\n${F}\n`;
+  assert.deepEqual(fenceSources(blank, tokens(blank)), ["foo\n"], "a blank last line is the renderer's dropped newline");
+  const empty = `${F}\n${F}\n`;
+  assert.deepEqual(fenceSources(empty, tokens(empty)), ["\n"]);
+  // a fence whose leading whitespace is a space then a tab: the tab was leading (right after the spaces), and is whole
+  const spaceTab = `${F}\n \tfoo\n${F}\n`;
+  assert.equal(tokens(spaceTab)[0].text, "     foo");
+  assert.deepEqual(fenceSources(spaceTab, tokens(spaceTab)), [" \tfoo\n"]);
+});
+
+test("fences are matched in document order: two fences rendering the same four spaces copy a tab and four spaces respectively; a token not in the file is null", () => {
+  const src = `${F}\n\tx\n${F}\n\n${F}\n    x\n${F}\n`;
+  const t = tokens(src);
+  assert.equal(t[0].text, t[1].text, "the same rendered text");
+  assert.deepEqual(fenceSources(src, t), ["\tx\n", "    x\n"]);
+  assert.deepEqual(fenceSources(src, [{ text: "not in the file", indented: false }]), [null]);
+  // a token whose lines exist but never after a fence opener is not taken for a fence
+  assert.deepEqual(fenceSources("plain x\n", [{ text: "plain x", indented: false }]), [null]);
+});
+
+test("fenceCopyQueue: keyed by the rendered text, in document order, null for a fence not found; empty for a file without a tab or a CR (marked's view is the file)", () => {
+  const src = `${F}\n\tx\n${F}\n\n${F}\n    x\n${F}\n\n${F}\nplain\n${F}\n`;
+  const q = fenceCopyQueue(src, tokens(src));
+  assert.deepEqual(Array.from(q.keys()), ["    x\n", "plain\n"]);
+  assert.deepEqual(q.get("    x\n"), ["\tx\n", "    x\n"]);
+  assert.deepEqual(q.get("plain\n"), ["plain\n"]);
+  const clean = `${F}\n    x\n${F}\n`;
+  assert.equal(fenceCopyQueue(clean, tokens(clean)).size, 0, "no tab, no CR: nothing to read back");
+  assert.equal(fenceCopyQueue(src, []).size, 0, "no fences: nothing to queue");
+});
+
+test("an empty fence is matched as its opener and closer, so the fence after it is found: marked's text is empty for no line and for one blank line alike", () => {
+  // the closer directly followed by a fence whose first line is blank and whose second holds a tab: read as one blank
+  // line, the empty fence would match the py fence's blank first line, and the py fence, behind the cursor, would be null
+  const adjacent = `${F}\n${F}\n${F}py\n\n\tx = 1\n${F}\n`;
+  const t = tokens(adjacent);
+  assert.equal(t[0].text, "", "marked: a fence of no lines has the empty text");
+  assert.deepEqual(fenceSources(adjacent, t), ["\n", "\n\tx = 1\n"]);
+  assert.deepEqual(fenceCopyQueue(adjacent, t).get("\n    x = 1\n"), ["\n\tx = 1\n"], "Copy on the py fence pastes the tab");
+  // the closer directly followed by prose, the next fence in the usual blank-line style
+  const prose = `${F}\n${F}\nText.\n\n${F}py\n\tx = 1\n${F}\n\nMore.\n`;
+  assert.deepEqual(fenceSources(prose, tokens(prose)), ["\n", "\tx = 1\n"]);
+  // one blank line as the fence's content: the same empty text, the blank line is the fence's own
+  const blankLine = `${F}\n\n${F}\n${F}py\n\n\tx = 1\n${F}\n`;
+  assert.equal(tokens(blankLine)[0].text, "", "marked: a fence of one blank line has the empty text too");
+  assert.deepEqual(fenceSources(blankLine, tokens(blankLine)), ["\n", "\n\tx = 1\n"]);
+  // without a trailing newline the lone empty fence is found by its closer, not by a blank line after it
+  assert.deepEqual(fenceSources(`${F}\n${F}`, tokens(`${F}\n${F}`)), ["\n"]);
+  // an opener the file ends on: an unclosed fence runs to the end, and its text is empty
+  assert.deepEqual(fenceSources(`${F}\n`, tokens(`${F}\n`)), ["\n"]);
+  // inside a quote, the blank line a bare `>`; directly after another fence's closer
+  const quoted = `> ${F}\n>\n> ${F}\n> ${F}\n> \tq\n> ${F}\n`;
+  assert.deepEqual(fenceSources(quoted, tokens(quoted)), ["\n", "\tq\n"]);
+  const after = `${F}\nx\n${F}\n${F}\n${F}\n${F}py\n\n\ty\n${F}\n`;
+  assert.deepEqual(fenceSources(after, tokens(after)), ["x\n", "\n", "\n\ty\n"]);
+});

--- a/ui/webview/file-view-text-size.test.ts
+++ b/ui/webview/file-view-text-size.test.ts
@@ -1,0 +1,864 @@
+// The viewer's text size, and a rendered-markdown layout that follows the viewer's width. A− and A+ in the title
+// bar step every text view through a fixed table of sizes (70 to 200 percent): a markdown file's Rendered and Raw
+// views, every other text file's code view, the SVG Source view, and a document opened from a link on the
+// dashboard's own address. The percentage between them, shown once the size is off the default, is the reset;
+// Ctrl/Cmd + wheel over the body steps the same table. The chosen step rides the viewer root as data-fv-text and
+// the sheets turn it into the one property every text size reads (--fv-scale); it persists per browser like the
+// Rendered/Raw choice. Run FOR REAL over openFileView and openUrlView against a DOM stand-in (a tree, attributes
+// and dataset, bubbling events, a small selector matcher, localStorage, a fetch answering the kernel's headers),
+// plus pins over both sheets and an optional browser leg (headless Chromium through a child driver, skipped where
+// no browser is installed; CI installs none). Synthetic fixtures only.
+import { test, type TestContext } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const web = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const VIEW = web("file-view.ts");
+const SHEETS: ReadonlyArray<readonly [string, string]> = [["styles.css", web("styles.css")], ["feed.css", web("feed.css")]];
+
+// ── a DOM stand-in: the members the viewer touches, with a tree and bubbling events ─────────────────
+class Ev {
+  target: El | null = null;
+  currentTarget: El | null = null;
+  defaultPrevented = false;
+  stopped = false;
+  ctrlKey: boolean; metaKey: boolean; deltaY: number; deltaMode: number; key: string;
+  constructor(public type: string, init: { ctrlKey?: boolean; metaKey?: boolean; deltaY?: number; deltaMode?: number; key?: string } = {}) {
+    this.ctrlKey = !!init.ctrlKey; this.metaKey = !!init.metaKey;
+    this.deltaY = init.deltaY ?? 0; this.deltaMode = init.deltaMode ?? 0; this.key = init.key ?? "";
+  }
+  preventDefault(): void { this.defaultPrevented = true; }
+  stopPropagation(): void { this.stopped = true; }
+}
+type Listener = (ev: Ev) => void;
+type Part = { tag: string; id: string; classes: string[]; attrs: Array<[string, string | null]>; known: boolean };
+const kebab = (k: string) => k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+/** One compound selector (`tag#id.class[attr="v"]`); a shape the matcher does not know fits nothing. */
+function part(s: string): Part {
+  const m = /^([a-zA-Z][\w-]*|\*)?(#[\w-]+)?((?:\.[\w-]+)*)((?:\[[^\]]+\])*)$/.exec(s);
+  if (!m) return { tag: "", id: "", classes: [], attrs: [], known: false };
+  const attrs: Array<[string, string | null]> = [];
+  let known = true;
+  for (const a of m[4].match(/\[[^\]]+\]/g) || []) {
+    const am = /^\[([\w-]+)(?:="([^"]*)")?\]$/.exec(a);
+    if (am) attrs.push([am[1], am[2] ?? null]); else known = false;
+  }
+  return { tag: (m[1] || "").toLowerCase(), id: m[2] ? m[2].slice(1) : "", classes: (m[3].match(/\.[\w-]+/g) || []).map((c) => c.slice(1)), attrs, known };
+}
+class El {
+  parentNode: El | null = null;
+  childNodes: Array<El | string> = [];
+  title = ""; hidden = false; type = ""; disabled = false; tabIndex = -1; innerHTML = "";
+  href = ""; target = ""; rel = ""; spellcheck = true; value = ""; src = ""; alt = ""; download = "";
+  style: Record<string, string> = {};
+  onclick: ((ev: Ev) => void) | null = null;
+  private attrs = new Map<string, string>();
+  private listeners: Array<{ type: string; fn: Listener; once: boolean; passive: boolean | undefined }> = [];
+  constructor(public tagName: string) {}
+  get id(): string { return this.attrs.get("id") ?? ""; }
+  set id(v: string) { this.attrs.set("id", v); }
+  get className(): string { return this.attrs.get("class") ?? ""; }
+  set className(v: string) { this.attrs.set("class", v.trim()); }
+  private get classes(): string[] { return this.className.split(/\s+/).filter(Boolean); }
+  classList = {
+    add: (...c: string[]) => { const s = new Set(this.classes); for (const x of c) s.add(x); this.className = [...s].join(" "); },
+    remove: (...c: string[]) => { const s = new Set(this.classes); for (const x of c) s.delete(x); this.className = [...s].join(" "); },
+    toggle: (c: string, on?: boolean): boolean => { const want = on ?? !this.classes.includes(c); if (want) this.classList.add(c); else this.classList.remove(c); return want; },
+    contains: (c: string) => this.classes.includes(c),
+  };
+  /** data-* through dataset, the way the viewer writes its root attribute (camelCase to kebab-case, as the DOM does). */
+  dataset: Record<string, string | undefined> = new Proxy({} as Record<string, string | undefined>, {
+    get: (_, k) => this.attrs.get("data-" + kebab(String(k))),
+    set: (_, k, v) => { this.attrs.set("data-" + kebab(String(k)), String(v)); return true; },
+    has: (_, k) => this.attrs.has("data-" + kebab(String(k))),
+    deleteProperty: (_, k) => { this.attrs.delete("data-" + kebab(String(k))); return true; },
+  });
+  get textContent(): string { return this.childNodes.map((c) => (typeof c === "string" ? c : c.textContent)).join(""); }
+  set textContent(v: string) { this.replaceChildren(...(v === "" ? [] : [v])); }
+  /** Element children only, in order. */
+  get children(): El[] { return this.childNodes.filter((c): c is El => c instanceof El); }
+  get isConnected(): boolean { let n: El = this; while (n.parentNode) n = n.parentNode; return n === docBody; }
+  private adopt(c: El | string): void { if (c instanceof El) { c.remove(); c.parentNode = this; } }
+  appendChild<T extends El>(c: T): T { this.adopt(c); this.childNodes.push(c); return c; }
+  prepend(...cs: Array<El | string>): void { for (const c of cs) this.adopt(c); this.childNodes.unshift(...cs); }
+  insertBefore<T extends El>(c: T, ref: El | null): T {
+    if (ref && !this.childNodes.includes(ref)) throw new Error("insertBefore: the reference node is not a child of this node");
+    this.adopt(c);
+    const i = ref ? this.childNodes.indexOf(ref) : -1;
+    if (i < 0) this.childNodes.push(c); else this.childNodes.splice(i, 0, c);
+    return c;
+  }
+  replaceChildren(...cs: Array<El | string>): void {
+    for (const c of this.childNodes) if (c instanceof El) c.parentNode = null;
+    this.childNodes = [];
+    for (const c of cs) this.adopt(c);
+    this.childNodes = [...cs];
+  }
+  remove(): void {
+    const p = this.parentNode;
+    if (!p) return;
+    const i = p.childNodes.indexOf(this);
+    if (i >= 0) p.childNodes.splice(i, 1);
+    this.parentNode = null;
+  }
+  contains(n: El | null): boolean { for (let x: El | null = n; x; x = x.parentNode) if (x === this) return true; return false; }
+  setAttribute(k: string, v: string): void { this.attrs.set(k, v); }
+  removeAttribute(k: string): void { this.attrs.delete(k); }
+  getAttribute(k: string): string | null { return this.attrs.get(k) ?? null; }
+  hasAttribute(k: string): boolean { return this.attrs.has(k); }
+  addEventListener(type: string, fn: Listener, opts?: boolean | { once?: boolean; passive?: boolean; capture?: boolean }): void {
+    this.listeners.push({ type, fn, once: typeof opts === "object" && !!opts.once, passive: typeof opts === "object" ? opts.passive : undefined });
+  }
+  /** The `passive` option each listener of `type` on this element was registered with (undefined where none was given). */
+  passiveOf(type: string): Array<boolean | undefined> { return this.listeners.filter((l) => l.type === type).map((l) => l.passive); }
+  removeEventListener(type: string, fn: Listener): void { this.listeners = this.listeners.filter((l) => !(l.type === type && l.fn === fn)); }
+  /** Bubble `ev` from this element to the root: each element's listeners in registration order, then its onclick for a click. */
+  dispatchEvent(ev: Ev): boolean {
+    ev.target = this;
+    for (let n: El | null = this; n && !ev.stopped; n = n.parentNode) {
+      ev.currentTarget = n;
+      for (const l of n.listeners.slice()) {
+        if (l.type !== ev.type) continue;
+        if (l.once) n.listeners = n.listeners.filter((x) => x !== l);
+        l.fn.call(n, ev);
+      }
+      if (ev.type === "click" && n.onclick) n.onclick(ev);
+    }
+    return !ev.defaultPrevented;
+  }
+  click(): void { this.dispatchEvent(new Ev("click")); }
+  focus(): void { doc.activeElement = this; }
+  scrollIntoView(): void { /* inert */ }
+  private fits(p: Part): boolean {
+    if (!p.known) return false;
+    if (p.tag && p.tag !== "*" && p.tag !== this.tagName.toLowerCase()) return false;
+    if (p.id && p.id !== this.id) return false;
+    if (!p.classes.every((c) => this.classes.includes(c))) return false;
+    return p.attrs.every(([a, v]) => this.attrs.has(a) && (v === null || this.attrs.get(a) === v));
+  }
+  /** Comma groups of descendant chains, each link a compound. */
+  matches(sel: string): boolean {
+    return sel.split(",").some((group) => {
+      const chain = group.trim().split(/\s+/).filter(Boolean).map(part);
+      if (!chain.length || !this.fits(chain[chain.length - 1])) return false;
+      let k = chain.length - 2;
+      for (let a = this.parentNode; a && k >= 0; a = a.parentNode) if (a.fits(chain[k])) k--;
+      return k < 0;
+    });
+  }
+  closest(sel: string): El | null { for (let n: El | null = this; n; n = n.parentNode) if (n.matches(sel)) return n; return null; }
+  querySelectorAll(sel: string): El[] {
+    const out: El[] = [];
+    const walk = (n: El) => { for (const c of n.children) { if (c.matches(sel)) out.push(c); walk(c); } };
+    walk(this);
+    return out;
+  }
+  querySelector(sel: string): El | null { return this.querySelectorAll(sel)[0] ?? null; }
+}
+const docBody = new El("body");
+const docKeys: Listener[] = [];                  // the viewer's document keydown handlers, one per open
+const doc = {
+  body: docBody,
+  activeElement: null as El | null,
+  createElement: (tag: string) => new El(tag),
+  createTextNode: (s: string) => s,
+  getElementById: (id: string): El | null => docBody.querySelector("#" + id),
+  querySelectorAll: (sel: string): El[] => docBody.querySelectorAll(sel),   // no bundle <script src>: the editor chunk cannot load
+  addEventListener: (type: string, fn: Listener) => { if (type === "keydown") docKeys.push(fn); },
+  removeEventListener: (type: string, fn: Listener) => { const i = docKeys.indexOf(fn); if (i >= 0) docKeys.splice(i, 1); },
+};
+const win: any = new EventTarget();
+win.parent = win;
+win.confirm = () => true;                       // the discard ask, when a dirty buffer is about to go
+win.getSelection = () => null;
+const posted: unknown[] = [];                   // what the viewer posts to its own window: the quote seed
+win.postMessage = (m: unknown) => { posted.push(m); };
+(globalThis as any).window = win;
+(globalThis as any).document = doc;
+const store = new Map<string, string>();
+const writes: Array<[string, string]> = [];     // every localStorage write, so a no-op press is shown to store nothing
+(globalThis as any).localStorage = {
+  getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k: string, v: string) => { store.set(k, String(v)); writes.push([k, String(v)]); },
+  removeItem: (k: string) => { store.delete(k); },
+};
+
+// ── fixtures: a notes-api world, synthetic throughout ──────────────────────────────────────────────
+const SID = "77777777-8888-9999-aaaa-bbbbbbbbbbbb";
+const ROOT = "/tmp/notes-api";
+const REPORT = ROOT + "/docs/report.md";
+const APP = ROOT + "/src/app.py";
+const PLOT = ROOT + "/docs/plot.png";
+const PAPER = ROOT + "/docs/paper.pdf";
+const FIG = ROOT + "/docs/fig.svg";
+const DOC = "# Report\n\n## Findings\nThe api session cut p95 latency by 40%.\n\n| run | p95 |\n| --- | --- |\n| a | 120 |\n";
+const PY = "def main():\n    return 0\n";
+const SVG_XML = '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10"/></svg>';
+const HREF = "http://notes-api.test/reports/run-1/evidence.md";
+const URL_DOC = "# Evidence\n\nThe web session's report.\n";
+const MT = "1700000000000000000";
+const SIZE_KEY = "romp:fileviewTextSize";
+type Served = { bytes: string | Uint8Array; type: string };
+const disk: Record<string, Served> = {
+  [REPORT]: { bytes: DOC, type: "text/plain; charset=utf-8" },
+  [APP]: { bytes: PY, type: "text/plain; charset=utf-8" },
+  [PLOT]: { bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47]), type: "image/png" },
+  [PAPER]: { bytes: new Uint8Array([0x25, 0x50, 0x44, 0x46]), type: "application/pdf" },
+  [FIG]: { bytes: SVG_XML, type: "image/svg+xml" },
+};
+const fileReads: string[] = [];                 // every /file fetch by path: the quote seed's fresh read shows up here
+// The fetches the viewer makes: the kernel's /file (Content-Type is its verdict: text, a picture, a PDF, an SVG),
+// its /version (editing already allowed, so no consent popup), and a same-origin document for the URL viewer,
+// answered as a real Response so the streamed, capped read runs as it does in a browser.
+(globalThis as any).fetch = (url: string) => {
+  if (url.startsWith("/version")) return Promise.resolve({ json: () => Promise.resolve({ fileEditing: true }) });
+  if (/^https?:/.test(url)) return Promise.resolve(new Response(URL_DOC, { status: 200, headers: { "Content-Type": "text/markdown; charset=utf-8" } }));
+  const p = decodeURIComponent((/[?&]path=([^&]*)/.exec(url) || [])[1] || "");
+  fileReads.push(p);
+  const f = disk[p];
+  const headers = { get: (h: string) => (f ? (h === "Content-Type" ? f.type : h === "X-Romp-Mtime-Ns" ? MT : h === "X-Romp-Text-Utf8" ? "1" : null) : null) };
+  if (!f) return Promise.resolve({ ok: false, status: 404, headers, text: () => Promise.resolve("no such file: " + p) });
+  return Promise.resolve({
+    ok: true, status: 200, headers,
+    text: () => Promise.resolve(String(f.bytes)),
+    blob: () => Promise.resolve(new Blob([f.bytes as unknown as BlobPart], { type: f.type })),
+  });
+};
+/** Let every pending promise chain run: the fetch settles, a blob decodes, the editor chunk's rejection reaches its catch. */
+const settle = async () => { for (let i = 0; i < 8; i++) await new Promise<void>((r) => setImmediate(r)); };
+
+let bound: Promise<typeof import("./file-view")> | null = null;
+function view(): Promise<typeof import("./file-view")> {
+  if (!bound) bound = import("./file-view").then((fv) => { fv.initFileView(() => { /* the WS poster: nothing asks the kernel here */ }); return fv; });
+  return bound;
+}
+type Card = { fv: typeof import("./file-view"); wrap: El; root: El; bar: El; acts: El; body: El; down: El; reset: El; up: El; btn: (label: string) => El };
+/** The card up now, with the control's three buttons held by reference (they are built once per open). */
+function card(fv: typeof import("./file-view")): Card {
+  const wrap = doc.getElementById("romp-fileview");
+  assert.ok(wrap, "a viewer is up");
+  const root = wrap!.children[0];
+  assert.equal(root.className, "fileview");
+  const bar = root.children[0];
+  assert.equal(bar.className, "fileview-bar");
+  const body = root.children[root.children.length - 1];
+  assert.equal(body.className, "fileview-body");
+  const acts = bar.children.find((c) => c.classList.contains("fileview-acts"))!;
+  const btn = (label: string) => { const b = acts.children.find((c) => c.tagName === "button" && c.textContent === label); assert.ok(b, "the " + label + " button"); return b!; };
+  const reset = acts.children.find((c) => c.classList.contains("fileview-size-reset"));
+  assert.ok(reset, "the readout between A− and A+ (the reset)");
+  return { fv, wrap: wrap!, root, bar, acts, body, down: btn("A−"), reset: reset!, up: btn("A+"), btn };
+}
+/** Open `p` for the fixture session; `wait` lets the bytes land. The stored size is the caller's, set before the call. */
+async function openFile(t: TestContext, p: string, wait = true): Promise<Card> {
+  const fv = await view();
+  fv.openFileView(p, SID);
+  t.after(() => { fv.closeFileView(); store.clear(); });
+  if (wait) await settle();
+  return card(fv);
+}
+const size = (o: Card): string | null => o.root.getAttribute("data-fv-text");
+/** The readout's slot is empty at the default (the sheet hides this class by visibility): nothing to reset, nothing said. */
+const blank = (o: Card): boolean => o.reset.classList.contains("fileview-size-default");
+/** An end of the table: aria-disabled (dimmed by the sheet, focus kept), never the disabled property. */
+const atEnd = (b: El): boolean => b.getAttribute("aria-disabled") === "true";
+const wheel = (init: { dy: number; ctrl?: boolean; meta?: boolean; mode?: number }): Ev =>
+  new Ev("wheel", { ctrlKey: !!init.ctrl, metaKey: !!init.meta, deltaY: init.dy, deltaMode: init.mode ?? 0 });
+const labels = (acts: El): string[] => acts.children.map((c) => c.textContent);
+
+// ── the pure table ─────────────────────────────────────────────────────────────────────────────────
+
+test("TEXT_SIZES is a bounded, ascending table of percentages holding the default; stepTextSize walks it and clamps at both ends", async () => {
+  const { TEXT_SIZES, TEXT_SIZE_DEFAULT, stepTextSize } = await view();
+  assert.equal(TEXT_SIZES[0], 70); assert.equal(TEXT_SIZES[TEXT_SIZES.length - 1], 200);
+  assert.equal(TEXT_SIZE_DEFAULT, 100); assert.ok(TEXT_SIZES.includes(100), "the default is a step of the table");
+  for (let i = 1; i < TEXT_SIZES.length; i++) assert.ok(TEXT_SIZES[i] > TEXT_SIZES[i - 1], "ascending");
+  assert.equal(stepTextSize(100, 1), 115); assert.equal(stepTextSize(100, -1), 90);
+  assert.equal(stepTextSize(200, 1), 200, "the top clamps"); assert.equal(stepTextSize(70, -1), 70, "the bottom clamps");
+  assert.equal(stepTextSize(175, 1), 200); assert.equal(stepTextSize(80, -1), 70);
+  assert.equal(stepTextSize(123, 1), 115, "a value off the table steps from the default");
+  assert.equal(stepTextSize(123, -1), 90);
+  // every step is reachable from the default by presses, and the walk never leaves the table
+  let at = 100; const seen = new Set<number>([at]);
+  for (let i = 0; i < 20; i++) { at = stepTextSize(at, 1); seen.add(at); assert.ok(TEXT_SIZES.includes(at)); }
+  for (let i = 0; i < 20; i++) { at = stepTextSize(at, -1); seen.add(at); assert.ok(TEXT_SIZES.includes(at)); }
+  assert.equal(seen.size, TEXT_SIZES.length);
+});
+
+test("parseTextSize returns a stored step; absent, garbage, a size off the table or a multiplier read as the default", async () => {
+  const { parseTextSize } = await view();
+  assert.equal(parseTextSize("115"), 115); assert.equal(parseTextSize(" 200 "), 200); assert.equal(parseTextSize("70"), 70);
+  assert.equal(parseTextSize(null), 100); assert.equal(parseTextSize(undefined), 100); assert.equal(parseTextSize(""), 100);
+  assert.equal(parseTextSize("huge"), 100); assert.equal(parseTextSize('{"pct":115}'), 100);
+  assert.equal(parseTextSize("110"), 100, "a size the table does not hold is not invented");
+  assert.equal(parseTextSize("1.15"), 100, "a multiplier is not a percentage");
+  assert.equal(parseTextSize("-100"), 100); assert.equal(parseTextSize("1e9"), 100);
+});
+
+test("foldWheel: a notch is one step, a pinch's small deltas add up to one, a reversal starts over, lines and pages are normalized, wheel-up is larger", async () => {
+  const { foldWheel, WHEEL_STEP_PX } = await view();
+  assert.deepEqual(foldWheel({ deltaY: -100, deltaMode: 0 }, 0), { acc: 0, dir: 1 }, "a notch up (Chrome, about 100 pixels): larger at once");
+  assert.deepEqual(foldWheel({ deltaY: 100, deltaMode: 0 }, 0), { acc: 0, dir: -1 }, "a notch down: smaller");
+  assert.deepEqual(foldWheel({ deltaY: -3, deltaMode: 1 }, 0), { acc: 0, dir: 1 }, "three lines (deltaMode 1) is a notch");
+  assert.deepEqual(foldWheel({ deltaY: 1, deltaMode: 2 }, 0), { acc: 0, dir: -1 }, "a page (deltaMode 2) is more than a notch");
+  // a pinch reports as a burst of ctrlKey wheel events a few pixels each: the third crosses the threshold and the sum clears
+  let r = foldWheel({ deltaY: -15, deltaMode: 0 }, 0); assert.deepEqual(r, { acc: -15, dir: 0 });
+  r = foldWheel({ deltaY: -15, deltaMode: 0 }, r.acc); assert.deepEqual(r, { acc: -30, dir: 0 });
+  r = foldWheel({ deltaY: -15, deltaMode: 0 }, r.acc); assert.deepEqual(r, { acc: 0, dir: 1 });
+  assert.ok(WHEEL_STEP_PX > 30 && WHEEL_STEP_PX <= 100, "a notch is at least one step; a pinch's single event is not");
+  // a reversal does not pay off the other way's remainder first
+  r = foldWheel({ deltaY: -30, deltaMode: 0 }, 0); assert.equal(r.acc, -30);
+  r = foldWheel({ deltaY: 10, deltaMode: 0 }, r.acc); assert.deepEqual(r, { acc: 10, dir: 0 });
+  assert.deepEqual(foldWheel({ deltaY: 0, deltaMode: 0 }, -20), { acc: -20, dir: 0 }, "a horizontal-only event changes nothing");
+});
+
+// ── the control over the real openFileView ─────────────────────────────────────────────────────────
+
+test("a markdown file opens at the default: A− and A+ after the format toggles, the readout slot empty, the root at 100; each press steps, stores and acknowledges in the same tick; an end reads as reached and a press there changes nothing", async (t) => {
+  const { TEXT_SIZES } = await view();
+  const o = await openFile(t, REPORT);
+  assert.equal(size(o), "100", "the root carries the step the sheets read");
+  assert.equal(o.down.hidden, false); assert.equal(o.up.hidden, false);
+  assert.equal(o.reset.hidden, false, "the readout's slot is in the row from the start, so A− never moves when it fills");
+  assert.equal(blank(o), true, "nothing to reset at the default, so nothing is said: the slot is empty");
+  assert.equal(o.down.getAttribute("aria-label"), "Smaller text"); assert.equal(o.up.getAttribute("aria-label"), "Larger text");
+  const row = labels(o.acts);
+  assert.ok(row.indexOf("Raw") < row.indexOf("A−") && row.indexOf("A−") < row.indexOf("A+") && row.indexOf("A+") < row.indexOf("Edit"),
+    "the control sits after Rendered and Raw and before Edit: " + row.join(" | "));
+  assert.equal(o.acts.children.indexOf(o.reset), o.acts.children.indexOf(o.down) + 1, "the readout sits between A− and A+");
+  o.up.click();
+  assert.equal(size(o), "115", "one step, synchronously");
+  assert.equal(blank(o), false); assert.equal(o.reset.textContent, "115%", "the readout is the acknowledgement");
+  assert.equal(store.get(SIZE_KEY), "115", "stored as the percentage, under the viewer's own key");
+  o.down.click(); o.down.click();
+  assert.equal(size(o), "90"); assert.equal(o.reset.textContent, "90%"); assert.equal(store.get(SIZE_KEY), "90");
+  for (let i = 0; i < 12; i++) o.up.click();
+  assert.equal(size(o), "200", "clamped at the top however many presses");
+  assert.equal(atEnd(o.up), true, "the top end reads as reached: aria-disabled, which the sheet dims"); assert.equal(atEnd(o.down), false);
+  assert.equal(o.up.disabled, false, "never the disabled property: a button that disables under keyboard focus drops the focus");
+  let n = writes.length;
+  o.up.click();
+  assert.equal(size(o), "200"); assert.equal(writes.length, n, "a press on the end changes nothing and stores nothing");
+  for (let i = 0; i < 12; i++) o.down.click();
+  assert.equal(size(o), "70"); assert.equal(atEnd(o.down), true); assert.equal(atEnd(o.up), false); assert.equal(o.down.disabled, false);
+  n = writes.length;
+  o.down.click();
+  assert.equal(size(o), "70"); assert.equal(writes.length, n);
+  assert.equal(store.get(SIZE_KEY), String(TEXT_SIZES[0]));
+  assert.equal(o.down.className, "fileview-btn fileview-size", "wears the row's one button treatment");
+  assert.ok(o.reset.classList.contains("fileview-btn"), "the readout is a button: the reset");
+});
+
+test("the readout resets to the default and empties; a reset at the default stores nothing", async (t) => {
+  const o = await openFile(t, REPORT);
+  o.up.click(); o.up.click();
+  assert.equal(size(o), "130");
+  o.reset.click();
+  assert.equal(size(o), "100"); assert.equal(blank(o), true, "back at the default the slot empties"); assert.equal(store.get(SIZE_KEY), "100");
+  assert.equal(atEnd(o.up), false); assert.equal(atEnd(o.down), false);
+  const n = writes.length;
+  o.reset.click();
+  assert.equal(writes.length, n, "nothing changed, nothing stored");
+});
+
+test("persistence: the size survives a close and a fresh open, is on the root before the bytes land, and a foreign stored value opens at the default", async (t) => {
+  const first = await openFile(t, REPORT);
+  first.up.click(); first.up.click(); first.up.click();
+  assert.equal(size(first), "150");
+  first.fv.closeFileView();
+  assert.equal(doc.getElementById("romp-fileview"), null);
+  const again = await openFile(t, REPORT, false);                    // no settle: the loader still holds the body
+  assert.equal(size(again), "150", "the stored step is on the root at open, before the fetch, so the first paint is at size");
+  assert.equal(again.reset.textContent, "150%");
+  assert.equal(again.down.hidden, true); assert.equal(again.reset.hidden, true); assert.equal(again.up.hidden, true,
+    "the control waits for the bytes: whether this is a text file is the kernel's verdict, in the fetch's headers");
+  await settle();
+  assert.equal(size(again), "150", "the paint keeps it");
+  assert.equal(again.down.hidden, false); assert.equal(again.reset.hidden, false); assert.equal(blank(again), false);
+  again.fv.closeFileView();
+  store.set(SIZE_KEY, "purple");
+  const third = await openFile(t, REPORT);
+  assert.equal(size(third), "100", "a corrupt entry costs the preference, never the viewer");
+  assert.equal(blank(third), true);
+  third.fv.closeFileView();
+  store.set(SIZE_KEY, "80");
+  const fourth = await openFile(t, APP);
+  assert.equal(size(fourth), "80", "one size for every file this browser opens, a .py included");
+  assert.equal(fourth.down.hidden, false, "a non-markdown text file has the control: its code view scales too");
+  assert.equal(fourth.reset.textContent, "80%");
+});
+
+test("Ctrl/Cmd + wheel over the body steps the size and takes the gesture from the page zoom; a plain wheel scrolls; a pinch's deltas add up; the bar is not the text; a picture leaves the browser its zoom", async (t) => {
+  const o = await openFile(t, REPORT);
+  const md = o.body.querySelector(".fileview-md")!;
+  assert.ok(md, "the rendered body");
+  let ev = wheel({ dy: -100, ctrl: true });
+  md.dispatchEvent(ev);
+  assert.equal(size(o), "115", "a notch up with Ctrl: larger");
+  assert.equal(ev.defaultPrevented, true, "the page zoom is prevented: the gesture is the viewer's here");
+  ev = wheel({ dy: 100, meta: true });
+  md.dispatchEvent(ev);
+  assert.equal(size(o), "100", "Cmd works the same"); assert.equal(ev.defaultPrevented, true);
+  ev = wheel({ dy: -100 });
+  md.dispatchEvent(ev);
+  assert.equal(size(o), "100", "no modifier: not the gesture"); assert.equal(ev.defaultPrevented, false, "and the wheel scrolls as ever");
+  for (const dy of [-15, -15]) md.dispatchEvent(wheel({ dy, ctrl: true }));
+  assert.equal(size(o), "100", "a pinch's first events add up");
+  md.dispatchEvent(wheel({ dy: -15, ctrl: true }));
+  assert.equal(size(o), "115", "and the third crosses the threshold");
+  md.dispatchEvent(wheel({ dy: -3, ctrl: true, mode: 1 }));
+  assert.equal(size(o), "130", "three lines is a notch");
+  assert.equal(store.get(SIZE_KEY), "130", "the wheel stores like the buttons");
+  assert.equal(o.reset.textContent, "130%", "and the readout follows");
+  ev = wheel({ dy: -100, ctrl: true });
+  o.acts.dispatchEvent(ev);
+  assert.equal(size(o), "130", "a wheel over the action row is not the gesture"); assert.equal(ev.defaultPrevented, false);
+  o.fv.closeFileView(); store.delete(SIZE_KEY);
+  const pic = await openFile(t, PLOT);
+  ev = wheel({ dy: -100, ctrl: true });
+  pic.body.dispatchEvent(ev);
+  assert.equal(size(pic), "100", "a picture: nothing there reads the property");
+  assert.equal(ev.defaultPrevented, false, "not prevented: the page zoom stays the browser's");
+});
+
+test("click-safe: the three buttons are built once per open and never rebuilt by a paint; a Rendered/Raw flip and a step keep the same nodes", async (t) => {
+  const o = await openFile(t, REPORT);
+  const nodes = [o.down, o.reset, o.up];
+  o.btn("Raw").click();
+  assert.equal(o.body.children[0].className, "fileview-code", "the Raw paint");
+  assert.deepEqual([o.btn("A−"), o.acts.querySelector(".fileview-size-reset"), o.btn("A+")], nodes, "the same elements after the Raw paint");
+  o.up.click();
+  assert.deepEqual([o.btn("A−"), o.acts.querySelector(".fileview-size-reset"), o.btn("A+")], nodes, "and after a step");
+  assert.equal(size(o), "115", "the Raw view is scaled by the same property (.fileview-pre reads it)");
+  o.btn("Rendered").click();
+  assert.equal(size(o), "115", "the flip back keeps the size");
+  // source: the control is declared before renderBody, outside it, with direct listeners (the format toggles' idiom)
+  const at = (s: string) => { const i = VIEW.indexOf(s); assert.ok(i >= 0, s); return i; };
+  const openFn = VIEW.split("export function openFileView")[1].split("function offersDownload")[0];
+  assert.ok(openFn.indexOf("textSizeControl(") >= 0 && openFn.indexOf("textSizeControl(") < openFn.indexOf("const renderBody = () => {"), "built once per open, before the paint function");
+  const paint = openFn.slice(openFn.indexOf("const renderBody = () => {"), openFn.indexOf("\n  };", openFn.indexOf("const renderBody = () => {")));
+  assert.doesNotMatch(paint, /addEventListener/, "the paint function wires nothing: it only syncs the control's hidden state");
+  assert.match(paint, /\.sync\(\);/, "which it does, every paint");
+  assert.deepEqual(o.body.passiveOf("wheel"), [false], "the body's one wheel listener is non-passive, so the page zoom can be prevented");
+  assert.doesNotMatch(VIEW, /e\.key === "\+"|e\.key === "-"|e\.key === "="/, "no keyboard zoom chord: Ctrl+plus/minus stay the browser's");
+  assert.ok(at("function textSizeControl(") < at("export function openFileView"), "one builder, declared once, for both viewers");
+});
+
+test("the control is absent for a picture and a PDF, present for the SVG Source view, hidden in edit mode and back on exit", async (t) => {
+  const pic = await openFile(t, PLOT);
+  assert.equal(pic.down.hidden, true); assert.equal(pic.up.hidden, true); assert.equal(pic.reset.hidden, true, "a picture has no text to size");
+  pic.fv.closeFileView();
+  const pdf = await openFile(t, PAPER);
+  assert.equal(pdf.down.hidden, true); assert.equal(pdf.up.hidden, true); assert.equal(pdf.reset.hidden, true, "a PDF: the browser's viewer owns its text");
+  pdf.fv.closeFileView();
+  const svg = await openFile(t, FIG);
+  assert.equal(svg.down.hidden, true, "an SVG shown as a picture: no text yet");
+  svg.btn("Source").click();
+  await settle();
+  assert.equal(svg.body.children[0].className, "fileview-code", "the Source view is up");
+  assert.equal(svg.down.hidden, false); assert.equal(svg.up.hidden, false); assert.equal(svg.reset.hidden, false, "the Source view is a text view and has the control");
+  const ev = wheel({ dy: -100, ctrl: true });
+  svg.body.dispatchEvent(ev);
+  assert.equal(size(svg), "115", "and the wheel steps it"); assert.equal(ev.defaultPrevented, true);
+  svg.fv.closeFileView(); store.delete(SIZE_KEY);
+  store.set(SIZE_KEY, "115");
+  const o = await openFile(t, REPORT);
+  assert.equal(o.down.hidden, false); assert.equal(blank(o), false, "off the default, the readout says the size");
+  o.btn("Edit").click();
+  await settle();
+  assert.equal(o.btn("Cancel").hidden, false, "edit mode");
+  assert.equal(o.down.hidden, true); assert.equal(o.up.hidden, true); assert.equal(o.reset.hidden, true, "the editor keeps its own size");
+  const ev2 = wheel({ dy: -100, ctrl: true });
+  o.body.dispatchEvent(ev2);
+  assert.equal(size(o), "115", "the wheel stands down in edit mode"); assert.equal(ev2.defaultPrevented, false);
+  o.btn("Cancel").click();
+  assert.equal(o.btn("Cancel").hidden, true);
+  assert.equal(o.down.hidden, false); assert.equal(o.reset.hidden, false); assert.equal(o.up.hidden, false); assert.equal(blank(o), false, "back with the read view");
+});
+
+test("the control shows only once a text body is KNOWN: hidden beside the loader, shown when a text file's bytes land, never for a picture", async (t) => {
+  store.set(SIZE_KEY, "130");
+  const o = await openFile(t, REPORT, false);
+  assert.equal(o.down.hidden, true); assert.equal(o.up.hidden, true); assert.equal(o.reset.hidden, true, "the loader holds the body: not yet a text view");
+  assert.equal(size(o), "130", "the step is on the root already, so the first paint is at size");
+  await settle();
+  assert.equal(o.down.hidden, false); assert.equal(o.up.hidden, false); assert.equal(o.reset.hidden, false); assert.equal(o.reset.textContent, "130%");
+  o.fv.closeFileView();
+  const pic = await openFile(t, PLOT, false);
+  assert.equal(pic.down.hidden, true, "a picture: hidden for the load");
+  await settle();
+  assert.equal(pic.body.children[0].className, "fileview-imgbox", "the picture landed");
+  assert.equal(pic.down.hidden, true); assert.equal(pic.up.hidden, true); assert.equal(pic.reset.hidden, true, "and after it: nothing there reads the property");
+});
+
+test("a press on a bar control settles no selection: with a passage selected in the body, A+ steps the size and neither re-reads the file nor re-seeds the quote chip; a lift on the bar's path or padding still settles", async (t) => {
+  const composer = new El("textarea");             // this document holds the composer, so a selection seeds its chip
+  composer.id = "composer-input";
+  docBody.appendChild(composer);
+  t.after(() => { composer.remove(); win.getSelection = () => null; });
+  const o = await openFile(t, REPORT);
+  const md = o.body.querySelector(".fileview-md")!;
+  win.getSelection = () => ({ isCollapsed: false, anchorNode: md, toString: () => "cut p95 latency" });
+  const reads = () => fileReads.filter((p) => p === REPORT).length;
+  const seeds = () => posted.filter((m) => (m as { type?: string }).type === "editorSelection").length;
+  let r = reads(), s = seeds();
+  md.dispatchEvent(new Ev("mouseup"));
+  await settle();
+  assert.equal(reads(), r + 1, "a lift over the body settles the selection: the label's line is minted against a fresh read");
+  assert.equal(seeds(), s + 1, "and the quote chip is seeded");
+  r = reads(); s = seeds();
+  o.up.dispatchEvent(new Ev("mouseup")); o.up.click();
+  await settle();
+  assert.equal(size(o), "115", "the step happened");
+  assert.equal(reads(), r, "and the press on A+ read nothing"); assert.equal(seeds(), s, "and seeded nothing");
+  o.reset.dispatchEvent(new Ev("mouseup")); o.reset.click();
+  await settle();
+  assert.equal(size(o), "100"); assert.equal(reads(), r); assert.equal(seeds(), s);
+  o.btn("Raw").dispatchEvent(new Ev("mouseup"));
+  await settle();
+  assert.equal(reads(), r, "every button in the bar: the format toggles too");
+  // the overshoot: a drag that starts in the body and is released over the bar's path or its padding is a selection like any other
+  o.bar.children.find((c) => c.classList.contains("fileview-name"))!.dispatchEvent(new Ev("mouseup"));
+  await settle();
+  assert.equal(reads(), r + 1, "released over the bar's path, the drag settles: the gate is the control under the lift, not the bar");
+  assert.equal(seeds(), s + 1);
+  o.bar.dispatchEvent(new Ev("mouseup"));
+  await settle();
+  assert.equal(reads(), r + 2, "and the bar's own padding");
+  assert.equal(seeds(), s + 2);
+});
+
+// ── the URL viewer: the same size for a document opened from a link on the dashboard's own address ──
+
+test("openUrlView carries the stored step on its root and mounts the same control; a step there is the one size every document honours", async (t) => {
+  const fv = await view();
+  store.set(SIZE_KEY, "130");
+  fv.openUrlView(HREF);
+  t.after(() => { fv.closeFileView(); store.clear(); });
+  const o = card(fv);
+  assert.equal(size(o), "130", "the stored step is on the root before the document lands");
+  assert.equal(o.down.hidden, true); assert.equal(o.reset.hidden, true); assert.equal(o.up.hidden, true, "hidden beside the loader");
+  const row = labels(o.acts);
+  assert.ok(row.indexOf("Raw") < row.indexOf("A−") && row.indexOf("A+") < row.indexOf("Open ↗"), "after Rendered and Raw, before the link out: " + row.join(" | "));
+  await settle();
+  assert.equal(o.body.children[0].className, "fileview-md", "the document rendered");
+  assert.equal(o.down.hidden, false); assert.equal(o.reset.hidden, false); assert.equal(o.up.hidden, false);
+  assert.equal(o.reset.textContent, "130%"); assert.equal(blank(o), false);
+  o.up.click();
+  assert.equal(size(o), "150"); assert.equal(store.get(SIZE_KEY), "150", "stored under the same key as a local file's");
+  const ev = wheel({ dy: -100, ctrl: true });
+  o.body.querySelector(".fileview-md")!.dispatchEvent(ev);
+  assert.equal(size(o), "175", "Ctrl + wheel steps here too"); assert.equal(ev.defaultPrevented, true);
+  assert.deepEqual(o.body.passiveOf("wheel"), [false], "non-passive here too: the page zoom can be prevented");
+  const plain = wheel({ dy: -100 });
+  o.body.dispatchEvent(plain);
+  assert.equal(size(o), "175"); assert.equal(plain.defaultPrevented, false, "a plain wheel scrolls");
+  o.btn("Raw").click();
+  assert.equal(o.body.children[0].className, "fileview-code");
+  assert.deepEqual([o.btn("A−"), o.acts.querySelector(".fileview-size-reset"), o.btn("A+")], [o.down, o.reset, o.up], "the same nodes across the Raw paint");
+  fv.closeFileView();
+  const local = await openFile(t, REPORT);
+  assert.equal(size(local), "175", "a local file opened next honours the size the document set");
+});
+
+// ── the sheets: one property, read by every text size; the measure that follows the size ────────────
+
+/** The rule whose selector opens a line as `head`. */
+const ruleOf = (css: string, head: string): string => { const at = css.indexOf("\n" + head); assert.ok(at >= 0, head + " present"); return css.slice(at + 1, css.indexOf("}", at) + 1); };
+const decls = (rule: string): string[] => rule.slice(rule.indexOf("{") + 1, -1).split(";").map((d) => d.trim()).filter(Boolean);
+
+test("both sheets: the step table maps every TEXT_SIZES entry to --fv-scale on the viewer root and nothing else; exactly the text views read the one property", async () => {
+  const { TEXT_SIZES } = await view();
+  for (const [name, css] of SHEETS) {
+    for (const n of TEXT_SIZES) {
+      assert.deepEqual(decls(ruleOf(css, `.fileview[data-fv-text="${n}"] {`)), [`--fv-scale: ${n / 100}`], name + ": step " + n + " is exactly the property");
+    }
+    assert.equal((css.match(/\.fileview\[data-fv-text="\d+"\]/g) || []).length, TEXT_SIZES.length, name + ": no step the table does not hold");
+    assert.equal((css.match(/--fv-scale:/g) || []).length, TEXT_SIZES.length, name + ": nothing else sets the property");
+    // the readers: the prose (em of its parent, so the page's size times the scale), fenced code, the Raw view's rows and gutter
+    assert.ok(decls(ruleOf(css, ".fileview-md {")).includes("font-size: calc(1em * var(--fv-scale, 1))"), name + ": the prose reads it");
+    assert.ok(!decls(ruleOf(css, ".fileview-md {")).some((d) => d.startsWith("max-width")), name + ": the root is fluid to the viewer (the measure moved to its children)");
+    assert.ok(decls(ruleOf(css, ".fileview-md pre code {")).includes("font-size: calc(12px * var(--fv-scale, 1))"), name + ": fenced code reads it");
+    assert.ok(decls(ruleOf(css, ".fileview-pre {")).includes("font-size: calc(12px * var(--fv-scale, 1))"), name + ": the Raw rows read it");
+    assert.ok(decls(ruleOf(css, ".fileview-gutter {")).includes("font-size: calc(12px * var(--fv-scale, 1))"), name + ": the gutter reads it, in lockstep with the rows");
+    assert.ok(decls(ruleOf(css, ".fileview-md h1 {")).includes("font-size: 1.3em"), name + ": headings stay em of the prose, so they scale with it");
+    assert.ok(decls(ruleOf(css, ".fileview-md :not(pre) > code {")).includes("font-size: 0.92em"), name + ": inline code stays em of the prose");
+    assert.ok(decls(ruleOf(css, ".fileview-editor {")).includes("font-size: 12px"), name + ": the editor keeps the page's size");
+    assert.ok(decls(ruleOf(css, ".fileview-btn {")).includes("font-size: 0.82em"), name + ": the bar's buttons keep the page's size");
+    // no other rule reads the property: the title bar, its buttons and the editor keep the page's size
+    const readers = (css.match(/^[^\n{]*\{[^}]*var\(--fv-scale[^}]*\}/gm) || []).map((r) => r.slice(0, r.indexOf("{")).trim());
+    assert.deepEqual(readers.sort(), [".fileview-gutter", ".fileview-md", ".fileview-md > :where(:not(table))", ".fileview-md > :is(img, svg, canvas, video)", ".fileview-md pre code", ".fileview-pre"].sort(), name + ": the readers, exactly");
+  }
+});
+
+test("both sheets: the measure sits on the root's children at zero specificity and scales with the text; a table takes the viewer's width and scrolls on its own with whole words; a picture always fits; byte-equal across the sheets", () => {
+  for (const [name, css] of SHEETS) {
+    assert.deepEqual(decls(ruleOf(css, ".fileview-md > :where(:not(table)) {")), ["max-width: calc(860px * var(--fv-scale, 1))"], name + ": the measure, a max that grows with the size (the same characters per line at every step)");
+    // :where carries no specificity, so `.fileview-md img { max-width: 100% }` outranks it for a bare <img> line (a direct
+    // child of the root) whatever the order of the two rules; a plain :not() chain would tie the img rule on specificity
+    // and leave the winner to rule order. The media a file draws itself (svg, canvas, video) are capped at element
+    // specificity (`:where(.fileview-md) svg`), which the measure's class WOULD beat for a direct child, so the top-level
+    // cap names them with img: a wide inline diagram on a narrow viewer is the column, never 860px clipped under
+    // contain: layout.
+    assert.doesNotMatch(css, /\.fileview-md > :not\(/, name + ": the measure rule carries no specificity of its own");
+    assert.deepEqual(decls(ruleOf(css, ".fileview-md img {")), ["max-width: 100%"], name + ": a picture shrinks to its column");
+    assert.deepEqual(decls(ruleOf(css, ".fileview-md > :is(img, svg, canvas, video) {")), ["max-width: min(100%, calc(860px * var(--fv-scale, 1)))"], name + ": a bare top-level picture, or an inline svg, canvas or video block, takes the measure AND the column, like an image paragraph");
+    assert.ok(css.indexOf("\n.fileview-md img {") < css.indexOf("\n.fileview-md > :is(img, svg, canvas, video) {"), name + ": the top-level cap follows the general one, so it wins at equal specificity");
+    assert.deepEqual(decls(ruleOf(css, ":where(.fileview-md) svg, :where(.fileview-md) canvas, :where(.fileview-md) video {")), ["max-width: 100%"], name + ": the element-level media cap stands for a nested svg, canvas or video");
+    assert.deepEqual(decls(ruleOf(css, ".fileview-md table {")),
+      ["border-collapse: collapse", "margin: 0.6em 0", "display: block", "width: max-content", "max-width: 100%", "overflow-x: auto", "overflow-wrap: normal"],
+      name + ": a table is a block as wide as its columns need up to the viewer, scrolling inside beyond it, whole words kept");
+    assert.ok(decls(ruleOf(css, ".fileview-md {")).includes("overflow-wrap: anywhere"), name + ": prose still breaks an unbreakable string");
+    assert.ok(decls(ruleOf(css, ".fileview-md pre {")).includes("overflow-x: auto"), name + ": a code block scrolls on its own");
+    assert.ok(decls(ruleOf(css, ".fileview-md pre code {")).includes("white-space: pre-wrap"), name + ": and wraps first");
+  }
+  const [chat, feed] = SHEETS.map(([, css]) => css);
+  for (const head of [".fileview-md {", ".fileview-md > :where(:not(table)) {", ".fileview-md table {", ".fileview-md pre code {", ".fileview-pre {", ".fileview-gutter {", ".fileview-md img {", ".fileview-md > :is(img, svg, canvas, video) {"]) {
+    assert.equal(ruleOf(chat, head), ruleOf(feed, head), head + " mirrors exactly (the viewer mounts in both documents)");
+  }
+  const block = (css: string) => { const a = css.indexOf("/* ── text size and measure"); const b = css.indexOf("/* Rendered markdown ("); assert.ok(a >= 0 && b > a, "the step-table block precedes the prose block"); return css.slice(a, b); };
+  assert.ok(block(chat).length > 200, "the block with its rationale");
+  assert.equal(block(chat), block(feed), "the step table and its comment mirror exactly");
+});
+
+test("both sheets: the title bar wraps and its action row shrinks and wraps to the right edge while the bare classes stay as they were; a disabled or aria-disabled bar button is dimmed with an inert hover; the readout is a fixed slot, empty at the default", () => {
+  for (const [name, css] of SHEETS) {
+    const bar = decls(ruleOf(css, ".fileview-bar {"));
+    assert.ok(bar.includes("flex-wrap: wrap") && bar.includes("gap: 6px 10px"), name + ": the bar wraps, 6px between its lines");
+    assert.deepEqual(decls(ruleOf(css, ".fileview-bar .fileview-name {")), ["flex: 1 1 0", "min-width: 12em"], name + ": in the bar the path keeps 12em and takes the rest of a wide bar");
+    const nm = decls(ruleOf(css, ".fileview-name {"));
+    assert.ok(nm.includes("flex: 1 1 auto") && nm.includes("min-width: 0"), name + ": the class alone shrinks freely");
+    const barActs = decls(ruleOf(css, ".fileview-bar .fileview-acts {"));
+    for (const d of ["flex: 0 1 auto", "min-width: 0", "margin-left: auto", "flex-wrap: wrap", "justify-content: flex-end"]) assert.ok(barActs.includes(d), name + ": in the bar the action row " + d);
+    assert.deepEqual(decls(ruleOf(css, ".fileview-acts {")), ["flex: 0 0 auto", "display: flex", "align-items: center", "gap: 6px"], name + ": the class alone is one rigid row (the file browser's bar wears it outside any title bar)");
+    assert.ok(!decls(ruleOf(css, ".fb-bar {")).some((d) => d.startsWith("flex-wrap")), name + ": .fb-bar has no wrap of its own");
+    // one disabled dress for every bar button: the GitHub unit's no-link state (disabled) and the control's ends (aria-disabled)
+    assert.deepEqual(decls(ruleOf(css, '.fileview-btn:disabled, .fileview-btn[aria-disabled="true"] {')), ["opacity: 0.55", "cursor: default"], name + ": dimmed, default cursor");
+    assert.deepEqual(decls(ruleOf(css, '.fileview-btn:disabled:hover, .fileview-btn[aria-disabled="true"]:hover {')), ["border-color: var(--card-border)", "color: var(--fg)", "background: transparent"], name + ": the hover is inert (the rest colours, not the accent)");
+    assert.deepEqual(decls(ruleOf(css, '.fileview-btn:disabled:active, .fileview-btn[aria-disabled="true"]:active {')), ["transform: none"], name + ": no press pulse");
+    assert.doesNotMatch(css, /\.fileview-gh \.fileview-btn:disabled/, name + ": the GitHub unit's disabled rules are the bar's now, not its own");
+    // the readout: one width whatever it says, and an empty slot (not none) at the default
+    assert.deepEqual(decls(ruleOf(css, ".fileview-size-reset {")), ["min-width: 5.5em", "box-sizing: border-box", "text-align: center", "font-variant-numeric: tabular-nums"], name + ": a slot of one width");
+    assert.deepEqual(decls(ruleOf(css, ".fileview-size-reset.fileview-size-default {")), ["visibility: hidden"], name + ": the empty slot keeps its width and leaves the tab order");
+  }
+  const [chat, feed] = SHEETS.map(([, css]) => css);
+  for (const head of [".fileview-bar {", ".fileview-name {", ".fileview-acts {", ".fileview-bar .fileview-name {", ".fileview-bar .fileview-acts {",
+    '.fileview-btn:disabled, .fileview-btn[aria-disabled="true"] {', ".fileview-size-reset {", ".fileview-size-reset.fileview-size-default {"]) {
+    assert.equal(ruleOf(chat, head), ruleOf(feed, head), head + " mirrors exactly");
+  }
+});
+
+// ── the browser leg: a real layout over each sheet, through a child driver ─────────────────────────
+// The layout claims the sheet pins cannot show (the page never widens, a wide table scrolls on its own, a table in a
+// quote or a list item keeps the prose width, the action row drops below the path and the close button stays on the
+// card, A− and A+ hold still when the readout fills, the file browser's bar keeps one line) are
+// measured in headless Chromium. The measurement runs in a standalone driver (the test bundle is CommonJS without
+// top-level await, and esbuild must never try to bundle playwright); the driver exits 3 without playwright or a
+// browser, and the leg skips loudly there.
+const LONG = "unbreakable".repeat(6);
+const SVG = (w: number) => `data:image/svg+xml,${encodeURIComponent(`<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="120"><rect width="${w}" height="120" fill="#369"/></svg>`)}`;
+const ROWS = Array.from({ length: 3 }, (_, i) => `<tr><td>row ${i} alpha beta gamma delta</td><td>a fairly long cell of prose that keeps going on for a while</td><td>${LONG}</td><td>another long cell with many words in it to widen the table</td><td>five</td><td>six more text here</td></tr>`).join("");
+/** A six-column table whose columns want more than the prose measure: at the top level, inside a quote and inside a list item. */
+const TABLE = (id: string) => `<table id="${id}"><thead><tr><th>one</th><th>two</th><th>three</th><th>four</th><th>five</th><th>six</th></tr></thead><tbody>${ROWS}</tbody></table>`;
+const MD = `<h1 id="h1">Report</h1><p id="p">Prose ${"lorem ipsum ".repeat(40)}</p>
+${TABLE("t")}
+<blockquote id="bq"><p>A quoted note with a table of its own.</p>${TABLE("tq")}</blockquote>
+<ul><li>A first item.</li><li id="li">An item with a table of its own.${TABLE("tl")}</li></ul>
+<pre id="pre"><code>${"const x = 1; ".repeat(30)}</code></pre>
+<pre id="pre2"><code>const y = 2;</code></pre>
+<p id="lw">${"x".repeat(140)}</p>
+<p><img id="im" width="900" height="120" src="${SVG(900)}"></p>
+<img id="im2" width="1600" height="120" src="${SVG(1600)}">
+<svg id="sv" xmlns="http://www.w3.org/2000/svg" width="1600" height="120" viewBox="0 0 1600 120"><rect width="1600" height="120" fill="#693"/></svg>`;
+const sheet = (css: string) => `<!DOCTYPE html><html><head><meta charset="utf-8"><style>${css}</style></head>`;
+/** The modal as openFileView builds it, over a rendered markdown body. */
+const LAYOUT_PAGE = (css: string) => sheet(css) + `<body class="fileview-open"><div id="romp-fileview"><div class="fileview" id="root"><div class="fileview-bar"><div class="fileview-name"><span class="fileview-dir">/tmp/notes-api/docs/</span><span class="fileview-base">report.md</span></div><div class="fileview-acts"><button class="fileview-btn on">Rendered</button><button class="fileview-btn">Raw</button><button class="fileview-btn fileview-size">A−</button><button class="fileview-btn fileview-size fileview-size-reset fileview-size-default">100%</button><button class="fileview-btn fileview-size">A+</button><button class="fileview-btn fileview-close">✕</button></div></div>
+<div class="fileview-body" id="body"><div class="fileview-md" id="md">${MD}</div></div></div></div></body></html>`;
+const LAYOUT_MEASURE = `(() => {
+  const q = (s) => document.querySelector(s);
+  const w = (s) => q(s).getBoundingClientRect().width;
+  const fz = (s) => parseFloat(getComputedStyle(q(s)).fontSize);
+  const body = q("#body"), t = q("#t"), tq = q("#tq"), tl = q("#tl"), pre = q("#pre");
+  return { win: innerWidth, docScroll: document.documentElement.scrollWidth, bodyClient: body.clientWidth, bodyScroll: body.scrollWidth,
+    md: w("#md"), p: w("#p"), t: w("#t"), tClient: t.clientWidth, tScroll: t.scrollWidth, pre: w("#pre"), preClient: pre.clientWidth, preScroll: pre.scrollWidth,
+    bq: w("#bq"), tq: w("#tq"), tqClient: tq.clientWidth, tqScroll: tq.scrollWidth, li: w("#li"), tl: w("#tl"), tlClient: tl.clientWidth, tlScroll: tl.scrollWidth,
+    pre2: w("#pre2"), lw: w("#lw"), img: w("#im"), img2: w("#im2"), svg: w("#sv"), mdFont: fz("#md"), h1Font: fz("#h1"), codeFont: fz("#pre code") };
+})()`;
+/** The bar a kernel-answered markdown file shows: the format toggles, the control, Edit, the GitHub unit with its caption,
+ *  Download, Copy path and the close button, behind a deep path and a session chip. */
+const BAR_PAGE = (css: string) => sheet(css) + `<body class="fileview-open"><div id="romp-fileview"><div class="fileview" id="root"><div class="fileview-bar" id="bar"><div class="fileview-name" id="name"><span class="fileview-dir">/tmp/notes-api/services/api/internal/handlers/</span><span class="fileview-base">report.md</span></div><span class="fileview-sess">api</span><div class="fileview-acts" id="acts"><button class="fileview-btn on">Rendered</button><button class="fileview-btn">Raw</button><button class="fileview-btn fileview-size" id="down">A−</button><button class="fileview-btn fileview-size fileview-size-reset fileview-size-default" id="reset">100%</button><button class="fileview-btn fileview-size" id="up">A+</button><button class="fileview-btn">Edit</button><span class="fileview-gh"><span class="fileview-gh-why">not committed (staged only)</span><button class="fileview-btn" disabled>GitHub ↗</button></span><button class="fileview-btn">Download</button><button class="fileview-btn">Copy path</button><button class="fileview-btn fileview-close" id="close">✕</button></div></div>
+<div class="fileview-body" id="body"><div class="fileview-md"><p>Prose.</p></div></div></div></div></body></html>`;
+const BAR_MEASURE = `(() => {
+  const r = (id) => { const b = document.getElementById(id).getBoundingClientRect(); return { l: b.left, r: b.right, t: b.top, b: b.bottom, w: b.width }; };
+  const cs = (id) => getComputedStyle(document.getElementById(id));
+  return { win: innerWidth, card: r("root"), bar: r("bar"), name: r("name"), acts: r("acts"), close: r("close"), down: r("down"), up: r("up"), reset: r("reset"),
+    resetVis: cs("reset").visibility, nameFont: parseFloat(cs("name").fontSize), barPadRight: parseFloat(cs("bar").paddingRight) };
+})()`;
+const READOUT_ON = `(() => { const b = document.getElementById("reset"); b.classList.remove("fileview-size-default"); b.textContent = "115%"; })()`;
+const READOUT_OFF = `(() => { const b = document.getElementById("reset"); b.classList.add("fileview-size-default"); b.textContent = "100%"; })()`;
+/** The file browser's bar (file-browse.ts): the crumb trail and, wearing .fileview-acts outside any title bar, Hidden and the close button. */
+const CRUMBS = ["/", "tmp", "notes-api", "services", "api", "internal", "handlers", "v2", "tests", "fixtures", "golden"];
+const FB_PAGE = (css: string) => sheet(css) + `<body class="filebrowse-open"><div id="romp-filebrowse"><div class="filebrowse"><div class="fb-bar" id="fbbar"><div class="fb-crumbs" id="fb-crumbs">${CRUMBS.map((c, i) => (i ? '<span class="fb-crumb-sep">/</span>' : "") + '<span class="fb-crumb">' + c + "</span>").join("")}</div><div class="fileview-acts" id="acts"><button class="fileview-btn" id="hid">Hidden</button><button class="fileview-btn fileview-close" id="fbclose">✕</button></div></div><div class="fb-list"></div></div></div></body></html>`;
+const FB_MEASURE = `(() => {
+  const g = (id) => document.getElementById(id);
+  const bar = g("fbbar"), crumbs = g("fb-crumbs"), acts = g("acts"), hid = g("hid").getBoundingClientRect(), close = g("fbclose").getBoundingClientRect();
+  return { win: innerWidth, barH: bar.getBoundingClientRect().height, barOver: bar.scrollWidth - bar.clientWidth, hidTop: hid.top, closeTop: close.top, closeLeft: close.left, closeRight: close.right,
+    acts: acts.getBoundingClientRect().width, wrap: getComputedStyle(acts).flexWrap, crumbsClient: crumbs.clientWidth, crumbsScroll: crumbs.scrollWidth };
+})()`;
+type Step = { width?: number; size?: number; prep?: string; tag: string };
+type Case = { name: string; html: string; width: number; measure: string; steps: Step[] };
+type Rows = Record<string, { rows: Array<{ step: Step; got: any }>; errors: string[] }>;
+const step = (n: number) => `(() => { document.getElementById("root").dataset.fvText = "${n}"; })()`;
+function cases(): Case[] {
+  const out: Case[] = [];
+  for (const [name, css] of SHEETS) {
+    out.push({ name: "layout/" + name, html: LAYOUT_PAGE(css), width: 1000, measure: LAYOUT_MEASURE, steps: [
+      { size: 100, prep: step(100), tag: "@1000/100" }, { size: 150, prep: step(150), tag: "@1000/150" },
+      { width: 420, size: 100, prep: step(100), tag: "@420/100" }, { size: 150, prep: step(150), tag: "@420/150" },
+    ] });
+    const bar: Step[] = [];
+    for (const w of [380, 420, 480, 600, 1000, 1400]) { bar.push({ width: w, prep: READOUT_OFF, tag: "@" + w + " default" }); bar.push({ prep: READOUT_ON, tag: "@" + w + " readout" }); }
+    out.push({ name: "bar/" + name, html: BAR_PAGE(css), width: 1000, measure: BAR_MEASURE, steps: bar });
+    out.push({ name: "fb/" + name, html: FB_PAGE(css), width: 1000, measure: FB_MEASURE, steps: [1000, 480, 360, 320].map((w) => ({ width: w, tag: "@" + w })) });
+  }
+  return out;
+}
+// The driver: playwright out of the extension package's node_modules, exit 3 when it or a browser is missing.
+const DRIVER = `
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+let chromium;
+try { chromium = require("playwright").chromium; } catch (e) { process.exit(3); }
+let browser;
+try { browser = await chromium.launch(); } catch (e) { process.exit(3); }
+const spec = JSON.parse(fs.readFileSync(process.env.SPEC_PATH, "utf8"));
+const out = {};
+for (const c of spec) {
+  const page = await browser.newPage({ viewport: { width: c.width, height: 900 } });
+  const errors = [];
+  page.on("pageerror", (e) => { errors.push(e.message); });
+  await page.setContent(c.html);
+  const rows = [];
+  for (const s of c.steps) {
+    if (s.width) await page.setViewportSize({ width: s.width, height: 900 });
+    if (s.prep) await page.evaluate(s.prep);
+    rows.push({ step: s, got: await page.evaluate(c.measure) });
+  }
+  out[c.name] = { rows, errors };
+  await page.close();
+}
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\\n");
+await browser.close();
+process.exit(0);
+`;
+function measure(): Rows | null {
+  const os = require("node:os");
+  const cp = require("node:child_process");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fv-textsize-"));
+  const driver = path.join(dir, "driver.mjs"); fs.writeFileSync(driver, DRIVER);
+  const specPath = path.join(dir, "spec.json"); fs.writeFileSync(specPath, JSON.stringify(cases()));
+  try {
+    const p = cp.spawnSync(process.execPath, [driver], { encoding: "utf8", timeout: 180000, maxBuffer: 64 * 1024 * 1024,   // the running node, never PATH
+      env: { ...process.env, EXT_PKG: path.resolve(process.cwd(), "package.json"), SPEC_PATH: specPath } });
+    if (p.status === 3) return null;                                  // no playwright / no browser here
+    if (p.status !== 0) throw new Error("layout driver failed: " + String(p.stderr || p.stdout || p.error || "").slice(-800));
+    const line = (p.stdout || "").split("\n").find((l: string) => l.startsWith("RESULT:"));
+    if (!line) throw new Error("layout driver printed no result: " + (p.stdout || "").slice(-400));
+    return JSON.parse(line.slice("RESULT:".length));
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+const m = measure();
+const skip = m ? false : "no Playwright browser here (CI installs none); the layout claims rest on the sheet pins above";
+const near = (a: number, b: number, what: string) => assert.ok(Math.abs(a - b) < 1, what + ": " + a + " vs " + b);
+
+test("in a browser: the page never widens at 1000 and 420px, at 100% and 150%, in both sheets; prose and code keep the measure and the table takes the viewer while a table in a quote or a list item keeps the prose width; at 150% every text size and the measure grow together; narrow, a table scrolls on its own", { skip }, () => {
+  for (const [name] of SHEETS) {
+    const c = m!["layout/" + name];
+    assert.deepEqual(c.errors, [], name + ": no script error in the page");
+    const at = (tag: string) => c.rows.find((r) => r.step.tag === tag)!.got;
+    for (const r of c.rows) {
+      const l = r.got, cell = name + " " + r.step.tag;
+      assert.equal(l.bodyScroll, l.bodyClient, cell + ": the body does not scroll sideways");
+      assert.equal(l.docScroll, l.win, cell + ": the page is the window");
+      const col = l.bodyClient - 36 + 0.5;                            // the root's 18px padding a side
+      assert.ok(l.pre <= col && l.pre2 <= col && l.lw <= col && l.img <= col, cell + ": code, the long string and the image paragraph fit the column");
+      assert.ok(l.img2 <= col, cell + ": the bare <img> line fits the column too (" + l.img2 + " in " + (l.bodyClient - 36) + "): its own cap outranks the measure");
+      assert.ok(l.svg <= col, cell + ": a wide inline svg block, a direct child of the root, fits the column too (" + l.svg + " in " + (l.bodyClient - 36) + "): the top-level cap outranks the measure, which alone would beat the element-level media cap");
+      assert.ok(l.preScroll <= l.preClient + 1, cell + ": the long code line wraps inside its block");
+      near(l.md, l.bodyClient, cell + ": the root is the body's width");
+      assert.ok(l.bq <= l.p + 0.5 && l.tq <= l.bq + 0.5 && l.li <= l.p + 0.5 && l.tl <= l.li + 0.5,
+        cell + ": a quote and a list item keep the prose width and the table inside each keeps to it (quote " + l.bq + ", its table " + l.tq + "; item " + l.li + ", its table " + l.tl + "; prose " + l.p + ")");
+    }
+    const base = at("@1000/100"), big = at("@1000/150");
+    near(base.p, 860, name + " @1000/100: the prose measure is 860px at 100%");
+    near(base.pre, 860, name + " @1000/100: a code block keeps the measure"); near(base.pre2, 860, name + " @1000/100: a two-line snippet too, no viewer-wide block");
+    assert.ok(base.t > 860 && base.t <= base.bodyClient - 36 + 0.5, name + " @1000/100: the table takes the viewer (" + base.t + "), past the prose measure, inside the padding");
+    assert.equal(base.tScroll, base.tClient, name + " @1000/100: room enough, so the table does not scroll");
+    assert.ok(base.tq <= 860.5 && base.tl <= 860.5, name + " @1000/100: the same table in a quote (" + base.tq + ") or a list item (" + base.tl + ") keeps the prose measure while the top-level one takes the viewer");
+    assert.ok(base.img <= 860.5 && base.lw <= 860.5 && base.img2 <= 860.5 && base.svg <= 860.5, name + " @1000/100: both pictures, the inline svg and an unbreakable string stay in the measure");
+    assert.equal(base.codeFont, 12, name + " @100%: fenced code at 12px, the size it had");
+    near(base.h1Font, base.mdFont * 1.3, name + " @100%: the heading is 1.3em of the prose");
+    near(big.mdFont, base.mdFont * 1.5, name + " @150%: the prose"); near(big.h1Font, big.mdFont * 1.3, name + " @150%: the heading follows the prose"); assert.equal(big.codeFont, 18, name + " @150%: fenced code");
+    near(big.p, Math.min(1290, big.bodyClient - 36), name + " @1000/150: the measure is 860 times 1.5, capped by the viewer");
+    near(big.pre, big.p, name + " @1000/150: the code block's measure grows with the prose's");
+    for (const tag of ["@420/100", "@420/150"]) {
+      const l = at(tag), cell = name + " " + tag;
+      near(l.t, l.bodyClient - 36, cell + ": the table is the column");
+      assert.ok(l.tScroll > l.tClient + 100, cell + ": the unbreakable cell scrolls inside the table (" + l.tScroll + " in " + l.tClient + ")");
+      near(l.p, l.bodyClient - 36, cell + ": the prose follows the viewer below its measure");
+      near(l.img2, l.bodyClient - 36, cell + ": the wide banner is the column");
+      near(l.svg, l.bodyClient - 36, cell + ": the wide inline svg is the column");
+    }
+    for (const tag of ["@1000/150", "@420/100", "@420/150"]) {
+      const l = at(tag), cell = name + " " + tag;
+      assert.ok(l.tqScroll > l.tqClient + 100 && l.tlScroll > l.tlClient + 100,
+        cell + ": a nested table its quote or item cannot hold scrolls inside itself (" + l.tqScroll + " in " + l.tqClient + "; " + l.tlScroll + " in " + l.tlClient + ")");
+    }
+  }
+});
+
+test("in a browser: from 380 to 1400px in both modals the close button and every action stay on the card; the path keeps 12em and the action row ends at the bar's edge; up to 600px the row drops to the line below the path and at 1400 the two share a line; A− and A+ hold still when the readout fills after the first press", { skip }, () => {
+  for (const [name] of SHEETS) {
+    const c = m!["bar/" + name];
+    assert.deepEqual(c.errors, [], name + ": no script error in the page");
+    for (let i = 0; i < c.rows.length; i += 2) {
+      const off = c.rows[i].got, on = c.rows[i + 1].got, cell = name + " " + c.rows[i].step.tag.split(" ")[0];
+      for (const [g, what] of [[off, "at the default"], [on, "with the readout showing"]] as Array<[any, string]>) {
+        const inside = g.close.l >= g.card.l - 0.5 && g.close.r <= g.card.r + 0.5 && g.close.t >= g.card.t - 0.5 && g.close.b <= g.card.b + 0.5;
+        assert.ok(inside, cell + " " + what + ": the close button lies inside the card (close " + JSON.stringify(g.close) + ", card " + JSON.stringify(g.card) + ")");
+        assert.ok(g.name.w >= 12 * g.nameFont - 0.5, cell + " " + what + ": the path keeps 12em (" + g.name.w + "px at " + g.nameFont + "px)");
+        near(g.acts.r, g.bar.r - g.barPadRight, cell + " " + what + ": the action row ends at the bar's right edge");
+        // the bar's own wrap: three more buttons no longer fit beside a deep path below about 600px, so the row drops to
+        // the line below (the row's own wrap alone would keep it beside the path, squeezed into a column); wide, one line
+        if (g.win <= 600) assert.ok(g.acts.t >= g.name.b - 0.5, cell + " " + what + ": the action row is the line below the path (row top " + g.acts.t + ", path bottom " + g.name.b + ")");
+        if (g.win >= 1400) assert.ok(g.acts.t < g.name.b - 0.5 && g.acts.b > g.name.t + 0.5, cell + " " + what + ": room for both, so the path and the action row share a line");
+      }
+      assert.equal(off.resetVis, "hidden", cell + ": at the default the readout's slot is empty by visibility");
+      assert.ok(off.reset.w > 20, cell + ": and keeps its width (" + off.reset.w + "px)");
+      assert.equal(on.resetVis, "visible", cell + ": off the default the readout shows");
+      near(off.down.l, on.down.l, cell + ": A− does not move when the readout fills"); near(off.down.t, on.down.t, cell + ": A− stays on its line");
+      near(off.up.l, on.up.l, cell + ": A+ does not move when the readout fills"); near(off.up.t, on.up.t, cell + ": A+ stays on its line");
+    }
+  }
+});
+
+test("in a browser: the file browser's bar stays one line at 320, 360, 480 and 1000px in both sheets, its two buttons holding their width while the crumb trail gives up room", { skip }, () => {
+  for (const [name] of SHEETS) {
+    const c = m!["fb/" + name];
+    assert.deepEqual(c.errors, [], name + ": no script error in the page");
+    const wide = c.rows[0].got;
+    assert.equal(wide.win, 1000);
+    for (const r of c.rows) {
+      const g = r.got, cell = name + " " + r.step.tag;
+      assert.equal(g.hidTop, g.closeTop, cell + ": Hidden and the close button share a line");
+      near(g.barH, wide.barH, cell + ": the bar is the height it has at 1000px (one line, not two)");
+      near(g.acts, wide.acts, cell + ": the action row holds its width");
+      assert.equal(g.wrap, "nowrap", cell + ": the row does not wrap");
+      assert.ok(g.closeLeft >= 0 && g.closeRight <= g.win + 0.5, cell + ": the close button lies inside the window: x " + g.closeLeft + " to " + g.closeRight);
+      assert.equal(g.barOver, 0, cell + ": the bar overflows nothing");
+      if (g.win < 1000) assert.ok(g.crumbsScroll > g.crumbsClient, cell + ": the crumb trail is what gives up room (" + g.crumbsScroll + " in " + g.crumbsClient + ")");
+    }
+  }
+});

--- a/ui/webview/file-view-text-size.test.ts
+++ b/ui/webview/file-view-text-size.test.ts
@@ -12,6 +12,8 @@ import { test, type TestContext } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { createRequire } from "node:module";
+import { marked } from "marked";   // the browser leg renders a synthetic task list through the real marked for mdBlock's task stamp
 
 const web = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
 const VIEW = web("file-view.ts");
@@ -576,45 +578,56 @@ test("both sheets: the step table maps every TEXT_SIZES entry to --fv-scale on t
     }
     assert.equal((css.match(/\.fileview\[data-fv-text="\d+"\]/g) || []).length, TEXT_SIZES.length, name + ": no step the table does not hold");
     assert.equal((css.match(/--fv-scale:/g) || []).length, TEXT_SIZES.length, name + ": nothing else sets the property");
-    // the readers: the prose (em of its parent, so the page's size times the scale), fenced code, the Raw view's rows and gutter
-    assert.ok(decls(ruleOf(css, ".fileview-md {")).includes("font-size: calc(1em * var(--fv-scale, 1))"), name + ": the prose reads it");
-    assert.ok(!decls(ruleOf(css, ".fileview-md {")).some((d) => d.startsWith("max-width")), name + ": the root is fluid to the viewer (the measure moved to its children)");
+    // the readers: the prose (the page's size times the document's 1.15, times the scale), fenced code, the Raw view's rows and gutter
+    const root = decls(ruleOf(css, ".fileview-md {"));
+    assert.ok(root.includes("font-size: calc(var(--fs) * 1.15 * var(--fv-scale, 1))"), name + ": the prose reads it");
+    assert.ok(!root.some((d) => d.startsWith("max-width")), name + ": the root is fluid to the viewer (the measure is its inline padding)");
+    assert.ok(root.includes("padding-inline: max(18px, round(down, calc((100% - 80ch) / 2), 1px))"), name + ": the measure is 80 of the root's own ch, centred as whole-pixel padding, never under 18px");
+    const plain = root.indexOf("padding-inline: max(18px, calc((100% - 80ch) / 2))"), rounded = root.findIndex((d) => d.startsWith("padding-inline: max(18px, round("));
+    assert.ok(plain >= 0 && plain < rounded, name + ": a plain calc() fallback is declared first, for an engine without round()");
+    assert.ok(root.includes("line-height: 1.5") && root.includes("font-family: var(--font-doc)") && root.includes("contain: layout"), name + ": the leading and the face are the document's own, and nothing inside can widen the body");
     assert.ok(decls(ruleOf(css, ".fileview-md pre code {")).includes("font-size: calc(12px * var(--fv-scale, 1))"), name + ": fenced code reads it");
     assert.ok(decls(ruleOf(css, ".fileview-pre {")).includes("font-size: calc(12px * var(--fv-scale, 1))"), name + ": the Raw rows read it");
     assert.ok(decls(ruleOf(css, ".fileview-gutter {")).includes("font-size: calc(12px * var(--fv-scale, 1))"), name + ": the gutter reads it, in lockstep with the rows");
-    assert.ok(decls(ruleOf(css, ".fileview-md h1 {")).includes("font-size: 1.3em"), name + ": headings stay em of the prose, so they scale with it");
+    assert.ok(decls(ruleOf(css, ".fileview-md h1 {")).includes("font-size: 2em"), name + ": headings stay em of the prose, so they scale with it");
+    assert.ok(decls(ruleOf(css, ".fileview-md h2 {")).includes("font-size: 1.5em") && decls(ruleOf(css, ".fileview-md h3 {")).includes("font-size: 1.25em"), name + ": the ladder is 2 / 1.5 / 1.25 / 1em");
     assert.ok(decls(ruleOf(css, ".fileview-md :not(pre) > code {")).includes("font-size: 0.92em"), name + ": inline code stays em of the prose");
     assert.ok(decls(ruleOf(css, ".fileview-editor {")).includes("font-size: 12px"), name + ": the editor keeps the page's size");
     assert.ok(decls(ruleOf(css, ".fileview-btn {")).includes("font-size: 0.82em"), name + ": the bar's buttons keep the page's size");
     // no other rule reads the property: the title bar, its buttons and the editor keep the page's size
     const readers = (css.match(/^[^\n{]*\{[^}]*var\(--fv-scale[^}]*\}/gm) || []).map((r) => r.slice(0, r.indexOf("{")).trim());
-    assert.deepEqual(readers.sort(), [".fileview-gutter", ".fileview-md", ".fileview-md > :where(:not(table))", ".fileview-md > :is(img, svg, canvas, video)", ".fileview-md pre code", ".fileview-pre"].sort(), name + ": the readers, exactly");
+    assert.deepEqual(readers.sort(), [".fileview-gutter", ".fileview-md", ".fileview-md pre code", ".fileview-pre"].sort(), name + ": the readers, exactly");
   }
 });
 
-test("both sheets: the measure sits on the root's children at zero specificity and scales with the text; a table takes the viewer's width and scrolls on its own with whole words; a picture always fits; byte-equal across the sheets", () => {
+test("both sheets: the measure is the root's own inline padding; a table takes the body's width and scrolls on its own with whole words; a picture fits the column; byte-equal across the sheets", () => {
   for (const [name, css] of SHEETS) {
-    assert.deepEqual(decls(ruleOf(css, ".fileview-md > :where(:not(table)) {")), ["max-width: calc(860px * var(--fv-scale, 1))"], name + ": the measure, a max that grows with the size (the same characters per line at every step)");
-    // :where carries no specificity, so `.fileview-md img { max-width: 100% }` outranks it for a bare <img> line (a direct
-    // child of the root) whatever the order of the two rules; a plain :not() chain would tie the img rule on specificity
-    // and leave the winner to rule order. The media a file draws itself (svg, canvas, video) are capped at element
-    // specificity (`:where(.fileview-md) svg`), which the measure's class WOULD beat for a direct child, so the top-level
-    // cap names them with img: a wide inline diagram on a narrow viewer is the column, never 860px clipped under
-    // contain: layout.
-    assert.doesNotMatch(css, /\.fileview-md > :not\(/, name + ": the measure rule carries no specificity of its own");
-    assert.deepEqual(decls(ruleOf(css, ".fileview-md img {")), ["max-width: 100%"], name + ": a picture shrinks to its column");
-    assert.deepEqual(decls(ruleOf(css, ".fileview-md > :is(img, svg, canvas, video) {")), ["max-width: min(100%, calc(860px * var(--fv-scale, 1)))"], name + ": a bare top-level picture, or an inline svg, canvas or video block, takes the measure AND the column, like an image paragraph");
-    assert.ok(css.indexOf("\n.fileview-md img {") < css.indexOf("\n.fileview-md > :is(img, svg, canvas, video) {"), name + ": the top-level cap follows the general one, so it wins at equal specificity");
-    assert.deepEqual(decls(ruleOf(css, ":where(.fileview-md) svg, :where(.fileview-md) canvas, :where(.fileview-md) video {")), ["max-width: 100%"], name + ": the element-level media cap stands for a nested svg, canvas or video");
+    assert.doesNotMatch(css, /\.fileview-md > :where\(/, name + ": no per-child measure rule remains (the root's padding is the measure)");
+    assert.doesNotMatch(css, /\.fileview-md > :not\(/, name + ": nor a specificity-bearing one");
+    assert.doesNotMatch(css, /860px/, name + ": the fixed cap is gone");
+    assert.deepEqual(decls(ruleOf(css, ".fileview-md img {")), ["max-width: 100%"], name + ": a picture shrinks to its column (the root's content box)");
+    assert.deepEqual(decls(ruleOf(css, ":where(.fileview-md) svg, :where(.fileview-md) canvas, :where(.fileview-md) video {")), ["max-width: 100%"], name + ": the media a file draws itself (svg, canvas, video) shrink to the column too, at element specificity");
+    // with the column the root's own content box there is no measure for a top-level medium's cap to outrank: the general
+    // caps above hold a bare <img> line or an inline <svg> block, direct children of the root, to the column by themselves
+    assert.equal(css.indexOf("\n.fileview-md > img {"), -1, name + ": a bare top-level picture needs no rule of its own now that the column is the root's box");
+    assert.doesNotMatch(css, /\.fileview-md > :is\(img/, name + ": nor does a top-level svg, canvas or video block");
     assert.deepEqual(decls(ruleOf(css, ".fileview-md table {")),
       ["border-collapse: collapse", "margin: 0.6em 0", "display: block", "width: max-content", "max-width: 100%", "overflow-x: auto", "overflow-wrap: normal"],
-      name + ": a table is a block as wide as its columns need up to the viewer, scrolling inside beyond it, whole words kept");
+      name + ": a table is a block as wide as its columns need up to its container, scrolling inside beyond it, whole words kept");
+    // a table of the page's own may grow out of the column, evenly into both gutters, up to the body's content width less
+    // the root's 18px inset (--fv-body-w, written by the viewer's width observer on each top-level table); unset, both
+    // declarations read the column and the shift is none
+    const top = decls(ruleOf(css, ".fileview-md > table {"));
+    assert.equal(top[0], "max-width: calc(var(--fv-body-w, calc(100% + 36px)) - 36px)", name + ": the cap is the body less the inset, the column before the first report");
+    assert.equal(top[1], "translate: min(0px, round(calc(var(--fv-body-w, calc(100% + 36px)) / 2 - max(18px, round(down, (var(--fv-body-w, calc(100% + 36px)) - 80ch) / 2, 1px)) - 50%), 1px))", name + ": the shift left is half of what the table exceeds the column by, whole pixels, never right");
+    assert.equal(top.length, 2);
+    assert.match(css, /^@property --fv-body-w \{ syntax: "\*"; inherits: false; \}$/m, name + ": the property is registered non-inherited, so a write restyles the tables alone");
     assert.ok(decls(ruleOf(css, ".fileview-md {")).includes("overflow-wrap: anywhere"), name + ": prose still breaks an unbreakable string");
     assert.ok(decls(ruleOf(css, ".fileview-md pre {")).includes("overflow-x: auto"), name + ": a code block scrolls on its own");
     assert.ok(decls(ruleOf(css, ".fileview-md pre code {")).includes("white-space: pre-wrap"), name + ": and wraps first");
   }
   const [chat, feed] = SHEETS.map(([, css]) => css);
-  for (const head of [".fileview-md {", ".fileview-md > :where(:not(table)) {", ".fileview-md table {", ".fileview-md pre code {", ".fileview-pre {", ".fileview-gutter {", ".fileview-md img {", ".fileview-md > :is(img, svg, canvas, video) {"]) {
+  for (const head of [".fileview-md {", ".fileview-md table {", ".fileview-md > table {", ".fileview-md pre code {", ".fileview-pre {", ".fileview-gutter {", ".fileview-md img {"]) {
     assert.equal(ruleOf(chat, head), ruleOf(feed, head), head + " mirrors exactly (the viewer mounts in both documents)");
   }
   const block = (css: string) => { const a = css.indexOf("/* ── text size and measure"); const b = css.indexOf("/* Rendered markdown ("); assert.ok(a >= 0 && b > a, "the step-table block precedes the prose block"); return css.slice(a, b); };
@@ -656,17 +669,22 @@ test("both sheets: the title bar wraps and its action row shrinks and wraps to t
 // measured in headless Chromium. The measurement runs in a standalone driver (the test bundle is CommonJS without
 // top-level await, and esbuild must never try to bundle playwright); the driver exits 3 without playwright or a
 // browser, and the leg skips loudly there.
-const LONG = "unbreakable".repeat(6);
+const LONG = "unbreakable".repeat(5);   // wide enough to push the table past the column at 1000px, narrow enough that the body still holds it
 const SVG = (w: number) => `data:image/svg+xml,${encodeURIComponent(`<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="120"><rect width="${w}" height="120" fill="#369"/></svg>`)}`;
 const ROWS = Array.from({ length: 3 }, (_, i) => `<tr><td>row ${i} alpha beta gamma delta</td><td>a fairly long cell of prose that keeps going on for a while</td><td>${LONG}</td><td>another long cell with many words in it to widen the table</td><td>five</td><td>six more text here</td></tr>`).join("");
 /** A six-column table whose columns want more than the prose measure: at the top level, inside a quote and inside a list item. */
 const TABLE = (id: string) => `<table id="${id}"><thead><tr><th>one</th><th>two</th><th>three</th><th>four</th><th>five</th><th>six</th></tr></thead><tbody>${ROWS}</tbody></table>`;
-const MD = `<h1 id="h1">Report</h1><p id="p">Prose ${"lorem ipsum ".repeat(40)}</p>
+const ROW = (t: string) => `<span class="cl"><span class="ct">${t}</span></span>`;
+const MD = `<h1 id="h1">Report</h1><h2 id="h2">Findings</h2><h3 id="h3">Detail</h3><p id="p">Prose ${"lorem ipsum ".repeat(40)}</p>
 ${TABLE("t")}
 <blockquote id="bq"><p>A quoted note with a table of its own.</p>${TABLE("tq")}</blockquote>
 <ul><li>A first item.</li><li id="li">An item with a table of its own.${TABLE("tl")}</li></ul>
 <pre id="pre"><code>${"const x = 1; ".repeat(30)}</code></pre>
 <pre id="pre2"><code>const y = 2;</code></pre>
+<pre id="pre3"><code style="--ln-digits: 1">${ROW("a")}${ROW("")}${ROW("b")}</code></pre>
+<pre id="pre4"><code style="--ln-digits: 5">${ROW("a")}</code></pre>
+<pre id="pre5" class="has-copy"><code>z</code><button class="code-copy" id="copy">Copy</button></pre>
+<ul><li id="task" class="task-list-item"><input type="checkbox" disabled> A task</li></ul>
 <p id="lw">${"x".repeat(140)}</p>
 <p><img id="im" width="900" height="120" src="${SVG(900)}"></p>
 <img id="im2" width="1600" height="120" src="${SVG(1600)}">
@@ -679,11 +697,26 @@ const LAYOUT_MEASURE = `(() => {
   const q = (s) => document.querySelector(s);
   const w = (s) => q(s).getBoundingClientRect().width;
   const fz = (s) => parseFloat(getComputedStyle(q(s)).fontSize);
-  const body = q("#body"), t = q("#t"), tq = q("#tq"), tl = q("#tl"), pre = q("#pre");
+  const body = q("#body"), t = q("#t"), tq = q("#tq"), tl = q("#tl"), pre = q("#pre"), md = q("#md"), cs = getComputedStyle(md);
+  const probe = document.createElement("span"); probe.textContent = "0".repeat(80); probe.style.whiteSpace = "nowrap"; probe.style.position = "absolute";
+  md.appendChild(probe); const ch80 = probe.getBoundingClientRect().width; probe.remove();
+  const rows = Array.from(q("#pre3 code").children).map((r) => r.getBoundingClientRect().height);
+  const ctOff = (s) => q(s + " .ct").getBoundingClientRect().left - q(s + " code").getBoundingClientRect().left;
+  const r = (s) => q(s).getBoundingClientRect();
   return { win: innerWidth, docScroll: document.documentElement.scrollWidth, bodyClient: body.clientWidth, bodyScroll: body.scrollWidth,
+    padL: parseFloat(cs.paddingLeft), padR: parseFloat(cs.paddingRight), ch80, pLeft: r("#p").left, pRight: r("#p").right, tLeft: r("#t").left, tRight: r("#t").right,
+    h2Font: fz("#h2"), h3Font: fz("#h3"), rows, ct1: ctOff("#pre3"), ct5: ctOff("#pre4"),
+    taskStyle: getComputedStyle(q("#task")).listStyleType, taskScheme: getComputedStyle(q("#task input")).colorScheme,
     md: w("#md"), p: w("#p"), t: w("#t"), tClient: t.clientWidth, tScroll: t.scrollWidth, pre: w("#pre"), preClient: pre.clientWidth, preScroll: pre.scrollWidth,
     bq: w("#bq"), tq: w("#tq"), tqClient: tq.clientWidth, tqScroll: tq.scrollWidth, li: w("#li"), tl: w("#tl"), tlClient: tl.clientWidth, tlScroll: tl.scrollWidth,
     pre2: w("#pre2"), lw: w("#lw"), img: w("#im"), img2: w("#im2"), svg: w("#sv"), mdFont: fz("#md"), h1Font: fz("#h1"), codeFont: fz("#pre code") };
+})()`;
+/** The print sheet over the same page: what leaves, what turns black, what a table becomes. */
+const PRINT_MEASURE = `(() => {
+  const q = (s) => document.querySelector(s); const cs = (s) => getComputedStyle(q(s));
+  return { bar: cs(".fileview-bar").display, copy: cs("#copy").display, md: cs("#md").color, h1: cs("#h1").color, code: cs("#pre code").color, dim: cs("#h1").borderBottomColor,
+    table: cs("#t").display, bodyBg: getComputedStyle(document.body).backgroundColor, rootBg: getComputedStyle(document.documentElement).backgroundColor,
+    bodyOverflow: cs("#body").overflowY, scheme: cs("#task input").colorScheme, tWidth: q("#t").getBoundingClientRect().width, bodyW: q("#body").clientWidth, docH: document.documentElement.scrollHeight, winH: innerHeight };
 })()`;
 /** The bar a kernel-answered markdown file shows: the format toggles, the control, Edit, the GitHub unit with its caption,
  *  Download, Copy path and the close button, behind a deep path and a session chip. */
@@ -706,21 +739,60 @@ const FB_MEASURE = `(() => {
   return { win: innerWidth, barH: bar.getBoundingClientRect().height, barOver: bar.scrollWidth - bar.clientWidth, hidTop: hid.top, closeTop: close.top, closeLeft: close.left, closeRight: close.right,
     acts: acts.getBoundingClientRect().width, wrap: getComputedStyle(acts).flexWrap, crumbsClient: crumbs.clientWidth, crumbsScroll: crumbs.scrollWidth };
 })()`;
-type Step = { width?: number; size?: number; prep?: string; tag: string };
-type Case = { name: string; html: string; width: number; measure: string; steps: Step[] };
+// mdBlock's task stamp, run in the page over marked's own output for a synthetic document, sanitized as mdBlock sanitizes
+// it (the shared sanitizer, md-sanitize.ts, bundled from the source with esbuild and added to the page as a script; the
+// body it returns is adopted the way mdBlock adopts it) and then stamped by the statement lifted from mdBlock. marked
+// emits a task item's checkbox as the li's first node (inside its first paragraph in a loose list); a checkbox an author's
+// raw HTML puts after the item's text matches the stamp's :first-child selector (elements alone count) and must not make a
+// task item of the item. A tight list, a numbered one, a loose one (every item of a loose list is a paragraph, the mid-item
+// case included), an enabled box (the sanitizer makes it disabled before the stamp sees it, so it opens its item like
+// marked's own), a raw disabled box that opens its item, and an author's own class.
+const STAMP_MD = [
+  "- [ ] open task", "- [x] done task", "- plain item", '- text then <input type="checkbox" disabled> mid-item',
+  '- **bold** then <input type="checkbox" disabled> after bold', '- <input type="checkbox"> enabled first', '- <input type="checkbox" disabled> raw first',
+  "", "1. [ ] numbered task", "", "- [ ] loose task", "", "  with a second paragraph", "", '- loose text then <input type="checkbox" disabled> loose mid-item',
+  "", '<ul><li class="task-list-item"><input type="checkbox" disabled> an author item</li></ul>', "",
+].join("\n");
+/** The real sanitizer for the page: md-sanitize.ts and the DOMPurify under it, bundled from the source (esbuild and the
+ *  packages resolve from the extension package, as the test bundle itself was built), exposing sanitizeMd on the window. */
+function sanitizerJs(): string {
+  const requireExt = createRequire(path.resolve(process.cwd(), "package.json"));
+  const esbuild = requireExt("esbuild");
+  const r = esbuild.buildSync({
+    stdin: { contents: 'import { sanitizeMd } from "./md-sanitize"; (window as any).sanitizeMd = sanitizeMd;', resolveDir: path.resolve(process.cwd(), "..", "ui", "webview"), loader: "ts", sourcefile: "fv-textsize-sanitizer-entry.ts" },
+    bundle: true, write: false, format: "iife", platform: "browser", target: "es2020", nodePaths: [path.resolve(process.cwd(), "node_modules")], logLevel: "silent",
+  });
+  return r.outputFiles[0].text as string;
+}
+const STAMP_CODE = (() => { const at = VIEW.indexOf("box.querySelectorAll('li > input"); return at < 0 ? "" : VIEW.slice(at, VIEW.indexOf("\n  });", at) + 6); })();
+const STAMP_PAGE = (css: string) => sheet(css) + `<body class="fileview-open"><div id="romp-fileview"><div class="fileview" id="root"><div class="fileview-body" id="body"><div class="fileview-md" id="md"></div></div></div></div></body></html>`;
+const STAMP_PREP = `(() => { const box = document.getElementById("md"); box.replaceChildren(...Array.from(sanitizeMd(${JSON.stringify(marked.parse(STAMP_MD) as string)}).childNodes)); ${STAMP_CODE} })()`;
+const STAMP_MEASURE = `(() => Array.from(document.querySelectorAll("#md li")).map((li) => {
+  const input = li.querySelector("input"), lr = li.getBoundingClientRect();
+  return { text: (li.textContent || "").replace(/\\s+/g, " ").trim(), stamped: li.classList.contains("task-list-item"), bullet: getComputedStyle(li).listStyleType,
+    input: input ? { disabled: input.disabled, checked: input.checked, marginLeft: parseFloat(getComputedStyle(input).marginLeft), left: input.getBoundingClientRect().left - lr.left, scheme: getComputedStyle(input).colorScheme } : null };
+}))()`;
+type Step = { width?: number; size?: number; prep?: string; media?: string; measure?: string; tag: string };
+type Case = { name: string; html: string; width: number; measure: string; steps: Step[]; inline?: string[] };   // inline: script text added to the page after its HTML
 type Rows = Record<string, { rows: Array<{ step: Step; got: any }>; errors: string[] }>;
-const step = (n: number) => `(() => { document.getElementById("root").dataset.fvText = "${n}"; })()`;
+/** A step, and the body's content width written on each top-level table the way the viewer's width observer writes it
+ *  (file-view.ts watchBodyWidth: --fv-body-w on the tables themselves, after every paint and every width change); the
+ *  page here carries no script, so the prep stands in for the observer. */
+const step = (n: number) => `(() => { document.getElementById("root").dataset.fvText = "${n}"; const w = document.getElementById("body").clientWidth + "px"; for (const t of document.querySelectorAll("#md > table")) t.style.setProperty("--fv-body-w", w); })()`;
 function cases(): Case[] {
   const out: Case[] = [];
+  const sanitizer = sanitizerJs();
   for (const [name, css] of SHEETS) {
     out.push({ name: "layout/" + name, html: LAYOUT_PAGE(css), width: 1000, measure: LAYOUT_MEASURE, steps: [
       { size: 100, prep: step(100), tag: "@1000/100" }, { size: 150, prep: step(150), tag: "@1000/150" },
       { width: 420, size: 100, prep: step(100), tag: "@420/100" }, { size: 150, prep: step(150), tag: "@420/150" },
+      { width: 1000, size: 100, prep: step(100), media: "print", measure: PRINT_MEASURE, tag: "@1000 print" },
     ] });
     const bar: Step[] = [];
     for (const w of [380, 420, 480, 600, 1000, 1400]) { bar.push({ width: w, prep: READOUT_OFF, tag: "@" + w + " default" }); bar.push({ prep: READOUT_ON, tag: "@" + w + " readout" }); }
     out.push({ name: "bar/" + name, html: BAR_PAGE(css), width: 1000, measure: BAR_MEASURE, steps: bar });
     out.push({ name: "fb/" + name, html: FB_PAGE(css), width: 1000, measure: FB_MEASURE, steps: [1000, 480, 360, 320].map((w) => ({ width: w, tag: "@" + w })) });
+    out.push({ name: "stamp/" + name, html: STAMP_PAGE(css), width: 1000, measure: STAMP_MEASURE, inline: [sanitizer], steps: [{ prep: STAMP_PREP, tag: "stamp" }] });
   }
   return out;
 }
@@ -740,11 +812,13 @@ for (const c of spec) {
   const errors = [];
   page.on("pageerror", (e) => { errors.push(e.message); });
   await page.setContent(c.html);
+  for (const s of c.inline || []) await page.addScriptTag({ content: s });
   const rows = [];
   for (const s of c.steps) {
     if (s.width) await page.setViewportSize({ width: s.width, height: 900 });
     if (s.prep) await page.evaluate(s.prep);
-    rows.push({ step: s, got: await page.evaluate(c.measure) });
+    if (s.media) await page.emulateMedia({ media: s.media });
+    rows.push({ step: s, got: await page.evaluate(s.measure || c.measure) });
   }
   out[c.name] = { rows, errors };
   await page.close();
@@ -773,38 +847,60 @@ const m = measure();
 const skip = m ? false : "no Playwright browser here (CI installs none); the layout claims rest on the sheet pins above";
 const near = (a: number, b: number, what: string) => assert.ok(Math.abs(a - b) < 1, what + ": " + a + " vs " + b);
 
-test("in a browser: the page never widens at 1000 and 420px, at 100% and 150%, in both sheets; prose and code keep the measure and the table takes the viewer while a table in a quote or a list item keeps the prose width; at 150% every text size and the measure grow together; narrow, a table scrolls on its own", { skip }, () => {
+test("in a browser: the page never widens at 1000 and 420px, at 100% and 150%, in both sheets; prose and code keep the measure (80 of the root's ch, centred, whole pixels) and a table grows evenly out of the column up to the body while a table in a quote or a list item keeps the prose width; the heading ladder and the fence rows measure; at 150% every text size and the measure grow together; narrow, a table scrolls on its own; in print the file alone prints black on white", { skip }, () => {
   for (const [name] of SHEETS) {
     const c = m!["layout/" + name];
     assert.deepEqual(c.errors, [], name + ": no script error in the page");
     const at = (tag: string) => c.rows.find((r) => r.step.tag === tag)!.got;
-    for (const r of c.rows) {
+    for (const r of c.rows.filter((x) => !x.step.media)) {
       const l = r.got, cell = name + " " + r.step.tag;
       assert.equal(l.bodyScroll, l.bodyClient, cell + ": the body does not scroll sideways");
       assert.equal(l.docScroll, l.win, cell + ": the page is the window");
       const col = l.bodyClient - 36 + 0.5;                            // the root's 18px padding a side
       assert.ok(l.pre <= col && l.pre2 <= col && l.lw <= col && l.img <= col, cell + ": code, the long string and the image paragraph fit the column");
       assert.ok(l.img2 <= col, cell + ": the bare <img> line fits the column too (" + l.img2 + " in " + (l.bodyClient - 36) + "): its own cap outranks the measure");
-      assert.ok(l.svg <= col, cell + ": a wide inline svg block, a direct child of the root, fits the column too (" + l.svg + " in " + (l.bodyClient - 36) + "): the top-level cap outranks the measure, which alone would beat the element-level media cap");
+      assert.ok(l.svg <= col, cell + ": a wide inline svg block, a direct child of the root, fits the column too (" + l.svg + " in " + (l.bodyClient - 36) + "): the element-level media cap holds it to the root's content box");
       assert.ok(l.preScroll <= l.preClient + 1, cell + ": the long code line wraps inside its block");
       near(l.md, l.bodyClient, cell + ": the root is the body's width");
       assert.ok(l.bq <= l.p + 0.5 && l.tq <= l.bq + 0.5 && l.li <= l.p + 0.5 && l.tl <= l.li + 0.5,
         cell + ": a quote and a list item keep the prose width and the table inside each keeps to it (quote " + l.bq + ", its table " + l.tq + "; item " + l.li + ", its table " + l.tl + "; prose " + l.p + ")");
     }
     const base = at("@1000/100"), big = at("@1000/150");
-    near(base.p, 860, name + " @1000/100: the prose measure is 860px at 100%");
-    near(base.pre, 860, name + " @1000/100: a code block keeps the measure"); near(base.pre2, 860, name + " @1000/100: a two-line snippet too, no viewer-wide block");
-    assert.ok(base.t > 860 && base.t <= base.bodyClient - 36 + 0.5, name + " @1000/100: the table takes the viewer (" + base.t + "), past the prose measure, inside the padding");
+    for (const r of c.rows.filter((x) => !x.step.media)) {
+      const l = r.got, cell = name + " " + r.step.tag;
+      // the measure: 80 of the root's own ch, centred as inline padding rounded down to whole pixels, never under 18px; when the
+      // column cannot hold 80ch the padding is its 18px floor and the prose follows the viewer
+      const want = Math.min(l.ch80, l.bodyClient - 36);
+      assert.ok(l.p >= want - 0.5 && l.p <= want + 2.5, cell + ": the prose measure is 80ch or the column (" + l.p + ", 80ch " + l.ch80 + ", column " + (l.bodyClient - 36) + ")");
+      near(l.p, l.bodyClient - l.padL - l.padR, cell + ": the measure is the root's content box, laid as its inline padding");
+      assert.equal(l.padL, l.padR, cell + ": centred (" + l.padL + " / " + l.padR + ")");
+      assert.ok(Number.isInteger(l.padL) && l.padL >= 18, cell + ": whole pixels, never under 18px (" + l.padL + ")");
+      near(l.pre, l.p, cell + ": a code block keeps the measure"); near(l.pre2, l.p, cell + ": a two-line snippet too, no viewer-wide block");
+      assert.ok(l.tq <= l.p + 0.5 && l.tl <= l.p + 0.5, cell + ": the same table in a quote (" + l.tq + ") or a list item (" + l.tl + ") keeps the prose measure");
+      assert.ok(l.img <= l.p + 0.5 && l.lw <= l.p + 0.5 && l.img2 <= l.p + 0.5 && l.svg <= l.p + 0.5, cell + ": both pictures, the inline svg and an unbreakable string stay in the measure");
+      // the ladder, em of the prose: 2 / 1.5 / 1.25
+      near(l.h1Font, l.mdFont * 2, cell + ": h1 is 2em of the prose"); near(l.h2Font, l.mdFont * 1.5, cell + ": h2 is 1.5em"); near(l.h3Font, l.mdFont * 1.25, cell + ": h3 is 1.25em");
+      // the fence rows: a text row, a blank row and the last row are each one line-height of the code; the gutter's basis
+      // follows the fence's digit count (2.5em of the gutter's own 0.92em for one digit, plus the 0.85em gap)
+      assert.equal(l.rows.length, 3);
+      for (const h of l.rows) near(h, l.codeFont * 1.5, cell + ": a row is the code's line-height (" + l.rows.join(", ") + ")");
+      near(l.ct1, l.codeFont * 0.92 * 3.35, cell + ": the one-digit gutter is 2.5em plus the gap (" + l.ct1 + ")");
+      assert.ok(l.ct5 > l.ct1 + 3, cell + ": a five-digit fence's gutter is wider than a one-digit fence's (" + l.ct5 + " vs " + l.ct1 + ")");
+      // a task item: no bullet beside the box, the box drawn for the page's scheme (no theme class here: dark)
+      assert.equal(l.taskStyle, "none", cell + ": a task item has no bullet"); assert.equal(l.taskScheme, "dark", cell + ": the box follows the page's scheme");
+    }
+    // at 1000px and 100% the column holds 80ch with room to spare, and a table wider than the column grows out of it evenly
+    assert.ok(base.padL > 18, name + " @1000/100: room to spare (" + base.padL + "px a side)");
+    assert.ok(base.t > base.p + 1 && base.t <= base.bodyClient - 36 + 0.5, name + " @1000/100: the table grows out of the column (" + base.t + " past " + base.p + "), inside the body's inset");
     assert.equal(base.tScroll, base.tClient, name + " @1000/100: room enough, so the table does not scroll");
-    assert.ok(base.tq <= 860.5 && base.tl <= 860.5, name + " @1000/100: the same table in a quote (" + base.tq + ") or a list item (" + base.tl + ") keeps the prose measure while the top-level one takes the viewer");
-    assert.ok(base.img <= 860.5 && base.lw <= 860.5 && base.img2 <= 860.5 && base.svg <= 860.5, name + " @1000/100: both pictures, the inline svg and an unbreakable string stay in the measure");
+    assert.ok(Math.abs((base.pLeft - base.tLeft) - (base.tRight - base.pRight)) <= 1.5, name + " @1000/100: evenly into both gutters (" + (base.pLeft - base.tLeft) + " left, " + (base.tRight - base.pRight) + " right)");
+    assert.ok(Math.abs(base.mdFont - 13 * 1.15) < 0.05, name + " @100%: the prose is 1.15 times the page's 13px (" + base.mdFont + ")");
     assert.equal(base.codeFont, 12, name + " @100%: fenced code at 12px, the size it had");
-    near(base.h1Font, base.mdFont * 1.3, name + " @100%: the heading is 1.3em of the prose");
-    near(big.mdFont, base.mdFont * 1.5, name + " @150%: the prose"); near(big.h1Font, big.mdFont * 1.3, name + " @150%: the heading follows the prose"); assert.equal(big.codeFont, 18, name + " @150%: fenced code");
-    near(big.p, Math.min(1290, big.bodyClient - 36), name + " @1000/150: the measure is 860 times 1.5, capped by the viewer");
-    near(big.pre, big.p, name + " @1000/150: the code block's measure grows with the prose's");
+    near(big.mdFont, base.mdFont * 1.5, name + " @150%: the prose"); assert.equal(big.codeFont, 18, name + " @150%: fenced code");
+    assert.ok(big.ch80 > base.ch80 * 1.4, name + " @150%: the measure's unit grows with the text (" + big.ch80 + " from " + base.ch80 + ")");
     for (const tag of ["@420/100", "@420/150"]) {
       const l = at(tag), cell = name + " " + tag;
+      assert.equal(l.padL, 18, cell + ": the inset floor holds when the column cannot hold 80ch");
       near(l.t, l.bodyClient - 36, cell + ": the table is the column");
       assert.ok(l.tScroll > l.tClient + 100, cell + ": the unbreakable cell scrolls inside the table (" + l.tScroll + " in " + l.tClient + ")");
       near(l.p, l.bodyClient - 36, cell + ": the prose follows the viewer below its measure");
@@ -816,6 +912,14 @@ test("in a browser: the page never widens at 1000 and 420px, at 100% and 150%, i
       assert.ok(l.tqScroll > l.tqClient + 100 && l.tlScroll > l.tlClient + 100,
         cell + ": a nested table its quote or item cannot hold scrolls inside itself (" + l.tqScroll + " in " + l.tqClient + "; " + l.tlScroll + " in " + l.tlClient + ")");
     }
+    // print: the file alone, black on white, as many pages as it needs
+    const print = at("@1000 print"), cell = name + " print";
+    assert.equal(print.bar, "none", cell + ": the title bar leaves"); assert.equal(print.copy, "none", cell + ": the Copy buttons leave");
+    for (const [k, v] of Object.entries({ md: print.md, h1: print.h1, code: print.code, rule: print.dim })) assert.equal(v, "rgb(0, 0, 0)", cell + ": " + k + " in black");
+    assert.equal(print.bodyBg, "rgb(255, 255, 255)", cell + ": the page is white"); assert.equal(print.rootBg, "rgb(255, 255, 255)", cell + ": the canvas too");
+    assert.equal(print.table, "table", cell + ": a table is a table again"); assert.equal(print.scheme, "light", cell + ": the task box is drawn light");
+    assert.equal(print.bodyOverflow, "visible", cell + ": the body does not clip to one screen"); assert.ok(print.docH > print.winH, cell + ": the document runs past one window's height (" + print.docH + " over " + print.winH + ")");
+    assert.ok(print.tWidth > 0 && print.tWidth <= print.bodyW - 36 + 0.5, cell + ": the wide table keeps the body's room less the inset (" + print.tWidth + " in " + print.bodyW + ")");
   }
 });
 
@@ -859,6 +963,42 @@ test("in a browser: the file browser's bar stays one line at 320, 360, 480 and 1
       assert.ok(g.closeLeft >= 0 && g.closeRight <= g.win + 0.5, cell + ": the close button lies inside the window: x " + g.closeLeft + " to " + g.closeRight);
       assert.equal(g.barOver, 0, cell + ": the bar overflows nothing");
       if (g.win < 1000) assert.ok(g.crumbsScroll > g.crumbsClient, cell + ": the crumb trail is what gives up room (" + g.crumbsScroll + " in " + g.crumbsClient + ")");
+    }
+  }
+});
+
+test("in a browser: mdBlock's task stamp over marked's own output, sanitized as mdBlock sanitizes it, in both sheets: a disabled checkbox that opens its item (a tight list, a numbered one, a loose one's first paragraph, an author's raw box) makes a task item with no bullet and the box pulled into the gutter; an author's enabled box is made inert by the sanitizer and opens its item too; a box after the item's text leaves the item and its bullet as the file wrote them; an author's own class is kept", { skip }, () => {
+  assert.ok(STAMP_CODE, "the stamp statement is lifted from the source");
+  assert.match(VIEW, /box\.replaceChildren\(\.\.\.Array\.from\(sanitizeMd\(dirty\)\.childNodes\)\);/, "mdBlock adopts the shared sanitizer's body, as the page here does");
+  type Row = { text: string; stamped: boolean; bullet: string; input: { disabled: boolean; checked: boolean; marginLeft: number; left: number; scheme: string } | null };
+  for (const [name] of SHEETS) {
+    const c = m!["stamp/" + name];
+    assert.deepEqual(c.errors, [], name + ": no script error in the page");
+    const rows = c.rows[0].got as Row[];
+    assert.equal(rows.length, 11, name + ": every item of the document is in the page (" + rows.map((r) => r.text).join(" | ") + ")");
+    const item = (start: string) => { const r = rows.find((x) => x.text.startsWith(start)); assert.ok(r, name + ": an item starting " + JSON.stringify(start)); return r!; };
+    for (const start of ["open task", "done task", "numbered task", "loose task", "enabled first", "raw first", "an author item"]) {
+      const r = item(start), cell = name + " " + JSON.stringify(start);
+      assert.equal(r.stamped, true, cell + ": a task item");
+      assert.equal(r.bullet, "none", cell + ": no bullet beside the box");
+      assert.ok(r.input && r.input.disabled, cell + ": the disabled box survived the sanitize");
+      assert.ok(r.input!.marginLeft < -13, cell + ": the box is pulled into the gutter (" + r.input!.marginLeft + ")");
+      assert.ok(r.input!.left < 0, cell + ": the box sits before the item's edge, where the bullet was (" + r.input!.left + ")");
+      assert.equal(r.input!.scheme, "dark", cell + ": drawn for the page's scheme (no theme class here: dark)");
+    }
+    assert.equal(item("done task").input!.checked, true, name + ": a checked box stays checked");
+    // an author's enabled box is made inert by the sanitizer (md-sanitize.ts keeps marked's checkbox as the one control a note
+    // carries, disabled), so by the time the stamp runs it is a disabled box opening its item, and a task item like the rest
+    assert.equal(item("enabled first").input!.disabled, true, name + ": the sanitizer disabled the author's enabled box before the stamp");
+    for (const start of ["plain item", "text then", "bold then", "loose text then"]) {
+      const r = item(start), cell = name + " " + JSON.stringify(start);
+      assert.equal(r.stamped, false, cell + ": not a task item");
+      assert.equal(r.bullet, "disc", cell + ": the bullet stays");
+      if (start !== "plain item") {
+        assert.ok(r.input, cell + ": the sanitize kept the author's box");
+        assert.ok(r.input!.marginLeft >= 0 && r.input!.left >= 0, cell + ": the box keeps the control's own margin, inside the item, not pulled into the gutter (" + r.input!.marginLeft + ", " + r.input!.left + ")");
+        assert.ok(r.input!.left > 20, cell + ": the box sits after the item's text, where the file put it (" + r.input!.left + ")");
+      }
     }
   }
 });

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -156,6 +156,98 @@ test("composerWindow, executed: own composer → the same-origin shell's chat pa
   assert.equal(run(self, doc([])), null, "unframed and composer-less: nowhere to seed");
 });
 
+// executed: the body's width observer (watchBodyWidth), lifted from the source with its type annotations stripped (the
+// composerWindow lift above; a hand copy would drift), run over a fake ResizeObserver and stand-in nodes. Both sheets'
+// `.fileview-md > table` read --fv-body-w for a top-level table's cap and its shift into the gutters; what the function
+// promises them is run here: nothing before the first report, the body's content width on EACH TOP-LEVEL TABLE (never a
+// nested one, never the prose) after one, the same width on the fresh tables a paint brings (the returned stamp: mdBlock
+// rebuilds the root and no report follows a paint), a repeated width no write, one watch at a time, and no watch at all
+// without ResizeObserver.
+test("watchBodyWidth, executed: --fv-body-w lands on each top-level table after a report and, through the stamp, on a fresh root's tables; a nested table and the prose get nothing; a repeated width writes nothing; the next watch and the drop disconnect; no ResizeObserver, no writes", () => {
+  const head = "function watchBodyWidth(body: HTMLElement): () => void {";
+  const at = VIEW.indexOf("let dropWidthWatch: () => void = ");
+  const end = VIEW.indexOf("\n}\n", VIEW.indexOf(head, at)) + 3;
+  assert.ok(at >= 0 && VIEW.indexOf(head, at) > at && end > at, "watchBodyWidth and its module-level drop found, the drop first");
+  const js = VIEW.slice(at, end)
+    .replace(/: \(\) => void/g, "")                                    // the let's type and the function's return type
+    .replace("(body: HTMLElement)", "(body)")
+    .replace("const stamp = (): void =>", "const stamp = () =>")
+    .replace(/ as HTMLElement\)/g, ")");
+  assert.doesNotMatch(js, /HTMLElement|: void/, "every annotation the lift knows is gone (a new one needs its strip here)");
+  type Node = { tagName: string; className: string; children: Node[]; clientWidth: number; writes: number; style: { setProperty(k: string, v: string): void; getPropertyValue(k: string): string }; querySelector(sel: string): Node | null };
+  const node = (tagName: string, className = "", children: Node[] = []): Node => {
+    const props = new Map<string, string>();
+    const n: Node = { tagName, className, children, clientWidth: 0, writes: 0,
+      style: { setProperty: (k, v) => { props.set(k, v); n.writes++; }, getPropertyValue: (k) => props.get(k) ?? "" },
+      querySelector: (sel) => { const walk = (m: Node): Node | null => { for (const c of m.children) { if (c.className === sel.slice(1)) return c; const d = walk(c); if (d) return d; } return null; }; return walk(n); } };
+    return n;
+  };
+  type Rec = { cb: (entries: Array<{ contentRect: { width: number } }>) => void; targets: unknown[]; live: boolean };
+  const observers: Rec[] = [];
+  class FakeResizeObserver {
+    private rec: Rec;
+    constructor(cb: Rec["cb"]) { this.rec = { cb, targets: [], live: true }; observers.push(this.rec); }
+    observe(t: unknown): void { this.rec.targets.push(t); }
+    disconnect(): void { this.rec.live = false; }
+  }
+  const report = (entries: Array<{ contentRect: { width: number } }>) => { const live = observers.filter((o) => o.live); assert.equal(live.length, 1, "one live observer"); live[0].cb(entries); };
+  const run = new Function("ResizeObserver", js + "\nreturn { watchBodyWidth, drop: () => dropWidthWatch() };") as (ro: unknown) => { watchBodyWidth: (body: Node) => () => void; drop: () => void };
+  /** A rendered root as mdBlock leaves it: prose, a table inside a paragraph (as inside a quote or a list item), two top-level tables. */
+  const fresh = () => { const nested = node("TABLE"); const p = node("P", "", [nested]); const t1 = node("TABLE"); const t2 = node("TABLE"); return { md: node("DIV", "fileview-md", [p, t1, t2]), p, nested, t1, t2 }; };
+  const w = (n: Node) => n.style.getPropertyValue("--fv-body-w");
+  const lib = run(FakeResizeObserver);
+  let root = fresh();
+  const body = node("DIV", "fileview-body", [root.md]);
+  const stamp = lib.watchBodyWidth(body);
+  assert.equal(observers.length, 1); assert.deepEqual(observers[0].targets, [body], "the body is what the observer watches");
+  stamp();
+  assert.equal(w(root.t1) + w(root.t2), "", "before the first report nothing is written: the sheet's fallback holds (the cap is the column)");
+  report([{ contentRect: { width: 900 } }]);
+  assert.equal(w(root.t1), "900px"); assert.equal(w(root.t2), "900px");
+  assert.equal(w(root.nested), "", "a table inside a paragraph is not the document's own: it keeps the prose width");
+  assert.equal(w(root.p), "", "the prose is never written to (the property is non-inherited; a write there would reach nothing anyway)");
+  // a paint: mdBlock rebuilt the root, no report follows; renderBody's stamp writes the width last reported on the fresh tables
+  root = fresh(); body.children = [root.md];
+  assert.equal(w(root.t1), "", "a fresh root starts unset");
+  stamp();
+  assert.equal(w(root.t1), "900px"); assert.equal(w(root.t2), "900px"); assert.equal(w(root.nested), "");
+  // a report of the width already held is a no-op: a root rebuilt between the two reports is not touched by it
+  root = fresh(); body.children = [root.md];
+  report([{ contentRect: { width: 900 } }]);
+  assert.equal(w(root.t1), "", "a repeated width writes nothing");
+  report([{ contentRect: { width: 700 } }]);
+  assert.equal(w(root.t1), "700px"); assert.equal(w(root.t2), "700px");
+  assert.equal(root.t1.writes, 1, "one write per change");
+  // the last of a callback's entries is the newest; a callback with no entry reads the body itself
+  report([{ contentRect: { width: 300 } }, { contentRect: { width: 800 } }]);
+  assert.equal(w(root.t1), "800px", "the last of the entries is the width kept");
+  body.clientWidth = 640; report([]);
+  assert.equal(w(root.t1), "640px", "a callback with no entry reads the body's clientWidth");
+  // one watch at a time: the next open's watch drops the last, and the close drops the watch up
+  const body2 = node("DIV", "fileview-body", []);
+  lib.watchBodyWidth(body2);
+  assert.equal(observers[0].live, false, "the second watch disconnects the first observer");
+  assert.equal(observers.length, 2); assert.deepEqual(observers[1].targets, [body2]);
+  lib.drop();
+  assert.equal(observers[1].live, false, "the drop disconnects");
+  assert.doesNotThrow(() => lib.drop(), "a second drop is nothing to do");
+  // no ResizeObserver (a stand-in, an old engine): no observer, and the stamp writes nothing
+  const bare = run(undefined);
+  root = fresh(); const body3 = node("DIV", "fileview-body", [root.md]);
+  bare.watchBodyWidth(body3)();
+  assert.equal(observers.length, 2, "no observer was made"); assert.equal(w(root.t1) + w(root.t2), "", "nothing written: the sheet's fallback holds");
+});
+
+test("the width watch is wired: each viewer opens one on the body it builds, each rendered paint stamps the fresh root's tables, and the close drops it", () => {
+  const opens = VIEW.match(/const body = el\("div", "fileview-body"\);\n\s*const stampBodyWidth = watchBodyWidth\(body\);/g) || [];
+  assert.equal(opens.length, 2, "openFileView and openUrlView each watch their body as they build it");
+  assert.match(VIEW, /body\.replaceChildren\(rendered \? mdBlock\(text, \{ kind: "file", path, sid: sid \|\| null \}\) : codeBlock\(text, path, true\)\);\n\s*if \(rendered\) stampBodyWidth\(\);/, "openFileView: a rendered paint stamps its fresh tables (mdBlock rebuilt the root; no report follows a paint)");
+  assert.match(VIEW, /landFragment\(\);[^\n]*\n\s*if \(fmt\.md === "rendered"\) stampBodyWidth\(\);/, "openUrlView: the same, after the fragment lands");
+  const closeAt = VIEW.indexOf("export function closeFileView(): void {");
+  const close = VIEW.slice(closeAt, VIEW.indexOf("\n}\n", closeAt));
+  assert.match(close, /\n\s*dropWidthWatch\(\);/, "closeFileView drops the watch with the viewer");
+});
+
 test("it waits with the romp loader and fails with the kernel's own words, never a blank pane", () => {
   assert.match(VIEW, /romp-swirl-glyph\.svg/, "loading-state rule: the swirl goes up first");
   assert.match(VIEW, /fileview-dot/);
@@ -182,12 +274,20 @@ test("langFor maps known extensions and returns null rather than guessing", () =
     yaml: "yaml", yml: "yaml", sh: "bash", bash: "bash", zsh: "bash", bats: "bash",
     html: "xml", htm: "xml", xml: "xml", svg: "xml", vue: "xml", css: "css", scss: "css",
     md: "markdown", markdown: "markdown", diff: "diff", patch: "diff",
+    rs: "rust", go: "go", c: "c", h: "c", java: "java", sql: "sql", toml: "ini", ini: "ini",   // viewer-grammars.ts
   };
+  // the map above is the module's, row for row (a drift here is a drift in what a file opens as)
+  const src = VIEW.slice(VIEW.indexOf("const LANG: Record<string, string> = {"), VIEW.indexOf("};", VIEW.indexOf("const LANG: Record<string, string> = {")));
+  for (const [ext, lang] of Object.entries(LANG)) assert.match(src, new RegExp("\\b" + ext + ': "' + lang + '"'), ext + " is in file-view.ts's LANG");
+  assert.match(VIEW, /^import "\.\/viewer-grammars";/m, "the six grammars the new rows name are registered by the module the viewer imports");
   const langFor = (p: string): string | null => LANG[p.slice(p.lastIndexOf(".") + 1).toLowerCase()] || null;
   assert.equal(langFor("kernel/kernel.py"), "python");
   assert.equal(langFor("ui/webview/render.TS"), "typescript");   // case-insensitive
   assert.equal(langFor("notes.md"), "markdown");
-  for (const p of ["server.log", "Makefile", "a.conf", "data.csv", "x.rs"]) {
+  assert.equal(langFor("src/main.rs"), "rust");
+  assert.equal(langFor("Cargo.toml"), "ini", "toml is hljs's ini grammar");
+  assert.equal(langFor("include/api.h"), "c");
+  for (const p of ["server.log", "Makefile", "a.conf", "data.csv", "x.hs"]) {
     assert.equal(langFor(p), null, p + " has no registered grammar → plain, not a guess");
   }
   assert.doesNotMatch(VIEW, /hljs\.highlightAuto\(/, "auto-detection is what this map exists to avoid");
@@ -202,8 +302,8 @@ test("the hljs token palette lives in feed.css too, identical to the chat's", ()
   const STYLES = CHAT_CSS;
   // tokenized 2026-09-02 (the light theme re-inks the same names; theme-parity.test.ts holds the
   // token set + its contrast in both themes) — the dark :root values are the exact hexes these
-  // rules always carried: fg #d8c6a8, kw #c98a6a, str #9fb878, num #d4a36a, cmt #6f6a5f,
-  // title #e1c08d, meta #9a8f7a, attr #cdaf7e
+  // rules always carried: fg #d8c6a8, kw #c98a6a, str #9fb878, num #d4a36a, cmt #978f81 (raised from
+  // #6f6a5f, which sat at 2.85:1 on a code block), title #e1c08d, meta #9a8f7a, attr #cdaf7e
   const rules = [
     /\.hljs \{ color: var\(--hl-fg\); background: transparent; \}/,
     /\.hljs-keyword, \.hljs-built_in, \.hljs-literal, \.hljs-type \{ color: var\(--hl-kw\); \}/,
@@ -218,7 +318,7 @@ test("the hljs token palette lives in feed.css too, identical to the chat's", ()
     /\.hljs-addition \{ color: var\(--hl-str\); \}/,
     /\.hljs-deletion \{ color: var\(--err\); \}/,
     /--hl-fg: #d8c6a8; --hl-kw: #c98a6a; --hl-str: #9fb878; --hl-num: #d4a36a;/,
-    /--hl-cmt: #6f6a5f; --hl-title: #e1c08d; --hl-meta: #9a8f7a; --hl-attr: #cdaf7e;/,
+    /--hl-cmt: #978f81; --hl-title: #e1c08d; --hl-meta: #9a8f7a; --hl-attr: #cdaf7e;/,   // --hl-cmt raised to 4.79:1 on a code block (was #6f6a5f, 2.85:1); theme-parity.test.ts holds the pair
   ];
   for (const r of rules) {
     assert.match(FEED_CSS, r, "feed.css is missing a palette rule: " + r.source);
@@ -273,8 +373,14 @@ test("Raw ⇄ Rendered exists for markdown ONLY, and nothing reaches innerHTML u
   // a README's links open a NEW tab rather than navigating the hosting pane's document away
   assert.match(VIEW, /target = "_blank"/);
   assert.match(VIEW, /rel = "noopener"/);
-  // fenced blocks highlight only a NAMED, registered language — same no-guessing rule as langFor
-  assert.match(VIEW, /if \(!lang \|\| !hljs\.getLanguage\(lang\)\) return;/);
+  // fenced blocks highlight only a NAMED, registered language (the same no-guessing rule as langFor); then EVERY fence,
+  // named or not, gets the chat's rows and Copy (code-block.ts), Copy with the fence's text as the file holds it
+  // (fence-source.ts), the rendered text when the fence was not found there (code-block.test.ts pins the pass)
+  assert.match(VIEW, /if \(lang && hljs\.getLanguage\(lang\)\) \{/);
+  assert.match(VIEW, /^import \{ wrapCodeLines, addCopyBtn \} from "\.\/code-block";/m);
+  // the two calls close the forEach's callback, outside the language branch (indentation and the `});` anchor it there)
+  assert.match(VIEW, /\n    wrapCodeLines\(codeEl\);\n    if \(host\) addCopyBtn\(host, toCopy\);\n  \}\);/);
+  assert.match(VIEW, /const toCopy = \(queued && queued\.length \? queued\.shift\(\) : null\) \?\? raw;/);
   // the prose typography exists on BOTH sheets (the chat's .md block is the reference aesthetic)
   assert.match(FEED_CSS, /\.fileview-md \{/);
   assert.match(FEED_CSS, /\.fileview-md pre code \{/);

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -81,7 +81,9 @@ test("selecting in the viewer seeds the composer's editor chip — the editorSel
   // mouseup posts to the composer's window — this document's when it holds one (the browseFiles
   // precedent — no import cycle with render.ts), else the shell's chat pane (composerWindow, below) —
   // and render.ts's existing editorSelection handler owns the chip end to end
-  assert.match(VIEW, /box\.addEventListener\("mouseup", \(\) => \{/);
+  // the handler reads the event's target since the text-size control: a press on a title-bar button with a passage
+  // still selected in the body settles no selection (file-view-text-size.test.ts runs the gate)
+  assert.match(VIEW, /box\.addEventListener\("mouseup", \(ev\) => \{/);
   assert.match(VIEW, /seedTarget\.postMessage\(\{ type: "editorSelection", text: picked, sid: sid \|\| undefined, src: quoteSrcLabel\(path, doc, picked\) \}, "\*"\);/);
   // a collapsed or out-of-viewer selection seeds nothing, and CodeMirror selections are edits
   assert.match(VIEW, /if \(!sel \|\| sel\.isCollapsed \|\| !sel\.anchorNode \|\| !box\.contains\(sel\.anchorNode\)\) return;/);

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -16,7 +16,7 @@
 // BROWSER (file-browse.ts, feed bundle) opens files through this same viewer in the FEED document, so
 // whichever bundle imports it gets the identical modal.
 import hljs from "highlight.js/lib/core";
-import { marked } from "marked";
+import { marked, type Tokens } from "marked";
 import { sanitizeMd } from "./md-sanitize";
 import { hostOf, bareId, hostNameNodes } from "./host-prefix";
 import { fileUrl } from "./preview";
@@ -28,6 +28,9 @@ const gclock = require("./gesture-clock.js");   // the gesture clock every setti
 import { delegate } from "./actions";
 import { resolveDocRelative, joinDocPath, urlTitleParts, headingSlug, uniqueSlugs } from "./md-links";
 import { readTextCapped, overCapWords, settleUrlResponse } from "./capped-read";
+import { wrapCodeLines, addCopyBtn } from "./code-block";   // a fence's per-line rows and Copy button, the chat's own
+import { fenceCopyQueue, type Fence } from "./fence-source";   // what Copy copies: the fence's text as the file holds it, tabs and all
+import "./viewer-grammars";   // six more grammars for a viewed file, registered on the bundle's hljs core (rust, go, c, java, sql, toml)
 
 // hljs is registered per-bundle. Same language set (and grammar registrations) the chat's fence
 // highlighting uses, dup-guarded, so importing this module alongside render.ts costs nothing.
@@ -59,6 +62,7 @@ const LANG: Record<string, string> = {
   yaml: "yaml", yml: "yaml", sh: "bash", bash: "bash", zsh: "bash", bats: "bash",
   html: "xml", htm: "xml", xml: "xml", svg: "xml", vue: "xml", css: "css", scss: "css",
   md: "markdown", markdown: "markdown", diff: "diff", patch: "diff",
+  rs: "rust", go: "go", c: "c", h: "c", java: "java", sql: "sql", toml: "ini", ini: "ini",   // viewer-grammars.ts (toml is hljs's ini grammar)
 };
 
 function langFor(path: string): string | null {
@@ -295,6 +299,40 @@ function dropUrlRead(): void {
   }
 }
 
+// ── the body's content width, for the sheets ──────────────────────────────────────────────────────
+// A table of the rendered document's own (a direct child of the .fileview-md root) may grow past the prose column, up to
+// the body's content width less the root's inset (`.fileview-md > table` in both sheets reads --fv-body-w; the rule there
+// says how). The value is the body's content width as its ResizeObserver reports it (the layout's own event, never a
+// timer; a scrollbar's width is taken), written on EACH TOP-LEVEL TABLE rather than on the body it describes: the property
+// is registered non-inherited (`@property --fv-body-w { inherits: false }`), so a write restyles the tables alone and not
+// every node under the body, as a write to an inherited property on the body would. mdBlock rebuilds the root on every
+// paint and no report follows a paint, so renderBody stamps the fresh tables itself (the returned function)
+// with the width last reported; before the first report the property is unset and the sheet's fallback holds (the cap is
+// the column). Absent ResizeObserver (a stand-in, an old engine) nothing is written and the fallback holds. One watch at a
+// time: the next open, or the close, drops the last.
+let dropWidthWatch: () => void = () => { /* no watch up */ };
+function watchBodyWidth(body: HTMLElement): () => void {
+  dropWidthWatch();
+  let width = -1;                                      // the body's content width as last reported, -1 before the first report
+  const stamp = (): void => {
+    if (width < 0) return;
+    const md = body.querySelector(".fileview-md");
+    if (!md) return;
+    for (const n of Array.from(md.children)) if (n.tagName === "TABLE") (n as HTMLElement).style.setProperty("--fv-body-w", width + "px");
+  };
+  if (typeof ResizeObserver === "function") {
+    const ro = new ResizeObserver((entries) => {
+      const w = entries.length ? entries[entries.length - 1].contentRect.width : body.clientWidth;
+      if (w === width) return;
+      width = w;
+      stamp();
+    });
+    ro.observe(body);
+    dropWidthWatch = () => { ro.disconnect(); dropWidthWatch = () => { /* dropped */ }; };
+  }
+  return stamp;
+}
+
 // ── viewer action registry (the user 2026-08-22) ── INTERNAL SEAM, no compatibility promise:
 // reshape freely. Anything acting on the OPEN file declares itself here instead of hand-wiring into
 // openFileView's action row, where every file-viewer change used to collide. mount() runs once per
@@ -420,6 +458,7 @@ export function closeFileView(): void {
   gitHooks = null;                                     // a reply landing after the close decorates nothing
   dropMediaUrl();                                      // an image/PDF view's bytes leave with the viewer
   dropUrlRead();                                       // …and a URL view's in-flight read is cancelled
+  dropWidthWatch();                                    // …and the body's width watch (watchBodyWidth)
   wrap.remove();
   document.body.classList.remove("fileview-open");
 }
@@ -664,6 +703,7 @@ export function openFileView(path: string, sid?: string | null, frag?: string | 
   bar.appendChild(name); if (sess) bar.appendChild(sess); bar.appendChild(acts);
 
   const body = el("div", "fileview-body");
+  const stampBodyWidth = watchBodyWidth(body);        // the body's content width, for a top-level table's cap (the sheets read --fv-body-w)
   textSize.bindWheel(body);                    // Ctrl/Cmd + wheel over the text steps the size (textSizeControl)
   // A rendered document's RELATIVE links (`[notes](./notes.md)`, `[fig](plots/a.png)`) open the
   // sibling file in this same viewer — mdBlock stamps each one `data-act="fv-open"` with the joined
@@ -776,6 +816,7 @@ export function openFileView(path: string, sid?: string | null, frag?: string | 
     }
     if (text === null || editing) return;   // loading, or the textarea owns the body right now
     body.replaceChildren(rendered ? mdBlock(text, { kind: "file", path, sid: sid || null }) : codeBlock(text, path, true));
+    if (rendered) stampBodyWidth();           // a fresh root's tables take the width last reported (the property sits on the tables)
     if (rendered && pendingFrag) {
       const h = pendingFrag; pendingFrag = null;
       requestAnimationFrame(() => { if (wrap.isConnected) scrollToFragment(body, h); });
@@ -1126,6 +1167,7 @@ export function openUrlView(href: string): void {
   bar.appendChild(name); bar.appendChild(acts);
 
   const body = el("div", "fileview-body");
+  const stampBodyWidth = watchBodyWidth(body);        // the body's content width, for a top-level table's cap (the sheets read --fv-body-w)
   textSize.bindWheel(body);                            // Ctrl/Cmd + wheel over the text steps the size
   // In-document links land on their heading (mdBlock's fv-anchor stamp): one delegated listener, the
   // local viewer's pattern. No fv-open here — a URL document's sibling links are made absolute and
@@ -1164,6 +1206,7 @@ export function openUrlView(href: string): void {
       ? mdBlock(text, { kind: "url", href: loc })      // relative refs resolve against where it LIVES
       : codeBlock(text, parts.base, true));            // basename → langFor → markdown highlighting
     landFragment();                                    // after the paint, and only a rendered one lands
+    if (fmt.md === "rendered") stampBodyWidth();       // a fresh root's tables take the width last reported
   };
   renderBody();
 
@@ -1338,8 +1381,17 @@ type MdDocLoc = { kind: "url"; href: string } | { kind: "file"; path: string; si
 // the dashboard, and a README's <style>, form or fixed-positioned div must never reach the viewer's chrome.
 function mdBlock(text: string, doc?: MdDocLoc): HTMLElement {
   const box = el("div", "fileview-md");
+  const fences: Fence[] = [];                          // marked's code tokens in document order, for the fence pass's Copy (fence-source.ts)
   try {
-    const dirty = marked.parse(text) as string;
+    // The code tokens are collected as the parse walks them: the lexer expanded the file's leading tabs to spaces before
+    // it cut them, and the fence pass below reads each fence's text back out of the file for its Copy button
+    // (fence-source.ts). Handed to THIS parse only, so the chat's marked singleton learns nothing; a walkTokens an
+    // extension put on the defaults runs as well, since per-call options replace rather than compose.
+    const base = marked.defaults.walkTokens;
+    const dirty = marked.parse(text, { walkTokens: (t) => {
+      if (t.type === "code") { const c = t as Tokens.Code; fences.push({ text: c.text, indented: c.codeBlockStyle === "indented" }); }
+      if (base) void base.call(marked, t);
+    } }) as string;
     // The one sanitizer the chat's md() uses too (md-sanitize.ts): html + svg (a note's own inline SVG), no
     // data-* (a document's `<span data-act="stopRetrying">` would otherwise bubble to render.ts's
     // document-level delegate and interrupt the active session; review find on #958, 2026-09-07), and
@@ -1363,6 +1415,19 @@ function mdBlock(text: string, doc?: MdDocLoc): HTMLElement {
   const heads = Array.from(box.querySelectorAll("h1, h2, h3, h4, h5, h6")) as HTMLElement[];
   const slugs = uniqueSlugs(heads.map((h) => headingSlug(h.textContent || "")));
   heads.forEach((h, i) => { h.id = "md-" + slugs[i]; });
+  // A task item wears GitHub's class: marked emits the checkbox as the li's first node with no hook on the li (inside its
+  // first paragraph in a loose list), and the sheets' `li.task-list-item` rule drops the bullet that sat beside the box
+  // and pulls the box into the gutter. After the sanitize (md-sanitize.ts keeps marked's checkbox as the one control a
+  // note carries, and makes an author's enabled one disabled, so every box the stamp sees is inert), and only for a
+  // checkbox that is the item's FIRST NODE: :first-child counts elements alone, so a checkbox an author's raw HTML puts
+  // after the item's text (`- text then <input type="checkbox" disabled>`) matches the selector, and the previousSibling
+  // check leaves it, and its item's bullet, where the file put them. An author who writes the class on an li of their
+  // own, or a raw checkbox that opens an item, gets the same bullet-less item GitHub would give them.
+  box.querySelectorAll('li > input[type="checkbox"]:first-child:disabled, li > p:first-child > input[type="checkbox"]:first-child:disabled').forEach((input) => {
+    if (input.previousSibling) return;                 // text before the box: an author's checkbox mid-item, not a task item
+    const li = input.closest("li");
+    if (li) li.classList.add("task-list-item");
+  });
   if (doc) {
     box.querySelectorAll("img[src]").forEach((node) => {
       const img = node as HTMLImageElement;
@@ -1409,16 +1474,30 @@ function mdBlock(text: string, doc?: MdDocLoc): HTMLElement {
     a.target = "_blank";
     a.rel = "noopener";
   });
-  // Fenced blocks: highlight only a language the fence NAMES and this bundle registers — the same
-  // no-guessing rule as langFor; an unnamed block stays plain rather than being painted at random.
+  // Fenced blocks: highlight only a language the fence NAMES and this bundle registers (the same no-guessing rule as
+  // langFor; an unnamed block stays plain rather than being painted at random). Then, for EVERY fence, named or not, the
+  // chat's own dress (code-block.ts): the per-line rows that number the lines and make a soft-wrap read distinctly from a
+  // real newline, and the Copy button. Copy copies the fence's text AS THE FILE HOLDS IT (fence-source.ts, off the code
+  // tokens the parse collected): the raw text captured here is read before the rows drop the newlines, but after marked's
+  // lexer turned the file's leading tabs into four spaces each, so a Makefile recipe copied from the rendered text pasted
+  // back with spaces; a fence the module does not find in the file copies the raw text as before.
+  const copySources = fenceCopyQueue(text, fences);
   box.querySelectorAll("pre code").forEach((node) => {
     const codeEl = node as HTMLElement;
+    const raw = codeEl.textContent || "";
+    const pre = codeEl.parentElement;
+    const host = pre && pre.tagName === "PRE" ? pre : null;
+    const queued = copySources.get(raw);
+    const toCopy = (queued && queued.length ? queued.shift() : null) ?? raw;
     const lang = (codeEl.className.match(/language-([\w-]+)/) || [])[1];
-    if (!lang || !hljs.getLanguage(lang)) return;
-    try {
-      codeEl.innerHTML = hljs.highlight(codeEl.textContent || "", { language: lang }).value;
-      codeEl.classList.add("hljs");
-    } catch { /* leave plain */ }
+    if (lang && hljs.getLanguage(lang)) {
+      try {
+        codeEl.innerHTML = hljs.highlight(raw, { language: lang }).value;
+        codeEl.classList.add("hljs");
+      } catch { /* leave plain */ }
+    }
+    wrapCodeLines(codeEl);
+    if (host) addCopyBtn(host, toCopy);
   });
   return box;
 }

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -118,6 +118,112 @@ function el(tag: string, cls?: string): HTMLElement {
   return e;
 }
 
+// ── text size (A−, A+, Ctrl/Cmd + wheel) ───────────────────────────────────────────────────────────
+// The viewer's text sizes, as percentages of the page's own size: a FIXED table with ends, not a free
+// multiplier, so the buttons, the wheel and the stored value all land on the same few sizes and a size can
+// never run away. 100 is the default and leaves every size exactly as it was. The chosen step rides the
+// viewer root as `data-fv-text`, and the sheets turn it into the ONE property the text views read
+// (`--fv-scale`; the "text size and measure" block in styles.css and feed.css). Persisted like the
+// Rendered ⇄ Raw choice above: per browser, in localStorage, under its own key, and any malformed or
+// foreign value reads as the default (parseFmt's contract). The value stays a percentage, never a
+// multiplier, so the stored text and the readout say the same thing.
+export const TEXT_SIZES: readonly number[] = [70, 80, 90, 100, 115, 130, 150, 175, 200];
+export const TEXT_SIZE_DEFAULT = 100;
+const TEXT_SIZE_KEY = "romp:fileviewTextSize";
+/** A stored value back to a step of the table; anything else (absent, garbage, a size the table does not
+ *  hold, a multiplier) is the default, so a corrupt entry may cost the preference, never the viewer. */
+export function parseTextSize(raw: string | null | undefined): number {
+  const n = Number(raw ?? NaN);
+  return TEXT_SIZES.includes(n) ? n : TEXT_SIZE_DEFAULT;
+}
+/** The step next to `pct` in `dir`, clamped at the table's ends (from 200, +1 answers 200). A `pct` the table
+ *  does not hold (never stored, but the function is pure) steps from the default. */
+export function stepTextSize(pct: number, dir: 1 | -1): number {
+  const from = TEXT_SIZES.includes(pct) ? pct : TEXT_SIZE_DEFAULT;
+  const i = TEXT_SIZES.indexOf(from) + dir;
+  return TEXT_SIZES[Math.min(TEXT_SIZES.length - 1, Math.max(0, i))];
+}
+function loadTextSize(): number {
+  try { return parseTextSize(localStorage.getItem(TEXT_SIZE_KEY)); } catch { return TEXT_SIZE_DEFAULT; }
+}
+function saveTextSize(pct: number): void {
+  try { localStorage.setItem(TEXT_SIZE_KEY, String(pct)); } catch { /* storage full */ }
+}
+// Ctrl/Cmd + wheel over the text is the pointer's way to the same steps. A wheel notch is one event of about
+// 100 pixels (Chrome) or a few LINES (Firefox, deltaMode 1); a trackpad pinch, which browsers report as a
+// ctrlKey wheel, is a burst of events a few pixels each. Stepping once per event would run a pinch through
+// the whole table in a moment, so the deltas are SUMMED: normalized to pixels, added up, and a step is taken
+// each time the sum passes WHEEL_STEP_PX (then cleared); a change of direction clears it too, so a reversal
+// does not first pay off the other way's remainder. Pure over the event's fields, so the summing is testable:
+// `acc` is the running sum the caller keeps, `dir` the step to take now (0 for none). Events without the
+// modifier are not the gesture (the caller lets them scroll) and never reach this.
+export const WHEEL_STEP_PX = 40;
+export function foldWheel(e: { deltaY: number; deltaMode: number }, acc: number): { acc: number; dir: 0 | 1 | -1 } {
+  const px = e.deltaY * (e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? 400 : 1);   // lines and pages as pixels
+  if (px === 0) return { acc, dir: 0 };
+  const sum = acc !== 0 && Math.sign(acc) !== Math.sign(px) ? px : acc + px;         // a reversal starts over
+  if (Math.abs(sum) < WHEEL_STEP_PX) return { acc: sum, dir: 0 };
+  return { acc: 0, dir: sum < 0 ? 1 : -1 };                                           // wheel up is larger
+}
+// The control: A−, the current size as the reset between them, A+. Built once per open by BOTH viewers (a
+// file on disk and a document opened from a link on the dashboard's own address), so the two honour one
+// stored size and a step in either is kept for both. The readout is said only once the size is off the
+// default (at 100% there is nothing to reset and nothing to say), but its SLOT is there from the start: the
+// sheet empties it by visibility, not display, so neither A− nor A+ moves under the pointer when it fills
+// after the first press, and the empty slot leaves the tab order. An end of the table is said with
+// aria-disabled, not `disabled`: a button that disables under keyboard focus drops it (the ring would vanish
+// on the press that reached the end), while an aria-disabled one keeps the focus, wears the sheet's disabled
+// dress, and its press is the no-op set() already makes of a step to the size in force. The three hide until
+// `textShowing` says a text body is up: each viewer's renderBody calls sync() on every paint, the first of them
+// before the fetch, so the loader, a picture, a PDF and the editor never show them. Direct listeners are
+// click-safe here: the buttons are built once and never rebuilt by a paint (the format toggles' idiom), and
+// every press acknowledges in the same tick (the attribute, the readout, the dimmed end; the sheets reflow
+// from the attribute alone).
+function textSizeControl(root: HTMLElement, textShowing: () => boolean): { buttons: HTMLButtonElement[]; sync: () => void; bindWheel: (body: HTMLElement) => void } {
+  let pct = loadTextSize();
+  const down = el("button", "fileview-btn fileview-size") as HTMLButtonElement;
+  down.type = "button"; down.textContent = "A−"; down.title = "Smaller text (Ctrl/Cmd + wheel)";
+  down.setAttribute("aria-label", "Smaller text");
+  const reset = el("button", "fileview-btn fileview-size fileview-size-reset") as HTMLButtonElement;
+  reset.type = "button"; reset.title = "Reset the text size";
+  const up = el("button", "fileview-btn fileview-size") as HTMLButtonElement;
+  up.type = "button"; up.textContent = "A+"; up.title = "Larger text (Ctrl/Cmd + wheel)";
+  up.setAttribute("aria-label", "Larger text");
+  const buttons = [down, reset, up];
+  const atEnd = (b: HTMLButtonElement, end: boolean) => { if (end) b.setAttribute("aria-disabled", "true"); else b.removeAttribute("aria-disabled"); };
+  // the property on the root, and the control's own state, from pct
+  const apply = () => {
+    root.dataset.fvText = String(pct);
+    reset.textContent = pct + "%";
+    reset.setAttribute("aria-label", "Text size " + pct + "%, reset to " + TEXT_SIZE_DEFAULT + "%");
+    reset.classList.toggle("fileview-size-default", pct === TEXT_SIZE_DEFAULT);   // the empty slot
+    atEnd(down, pct === TEXT_SIZES[0]);
+    atEnd(up, pct === TEXT_SIZES[TEXT_SIZES.length - 1]);
+  };
+  apply();                                                    // on the root before the bytes land: the first paint is at size
+  // one step: store it and apply it; a step that changes nothing (an end of the table, a reset at the default) does nothing
+  const set = (n: number) => { if (n === pct) return; pct = n; saveTextSize(n); apply(); };
+  down.addEventListener("click", () => set(stepTextSize(pct, -1)));
+  up.addEventListener("click", () => set(stepTextSize(pct, 1)));
+  reset.addEventListener("click", () => set(TEXT_SIZE_DEFAULT));
+  // Ctrl/Cmd + wheel over the BODY (not the bar): the browser's page zoom is the same gesture, so it is taken
+  // over the viewer's text only, and only with the modifier held over a text body; a plain wheel scrolls as
+  // ever, and the keyboard's Ctrl+plus/minus stays the browser's. Non-passive, so the page zoom can be
+  // prevented; the summing is foldWheel's.
+  let acc = 0;
+  const bindWheel = (body: HTMLElement) => {
+    body.addEventListener("wheel", (e: WheelEvent) => {
+      if (!(e.ctrlKey || e.metaKey) || !textShowing()) return;
+      e.preventDefault();
+      const r = foldWheel(e, acc);
+      acc = r.acc;
+      if (r.dir) set(stepTextSize(pct, r.dir));
+    }, { passive: false });
+  };
+  const sync = () => { const hide = !textShowing(); for (const b of buttons) b.hidden = hide; };
+  return { buttons, sync, bindWheel };
+}
+
 // The romp loader (swirl + wordmark + three pulsing accent dots), per the loading-state rule: the
 // FIRST thing up on any wait, fading the instant real content lands. The viewer's earlier waits
 // build this markup inline; the URL viewer reaches for it here.
@@ -450,6 +556,16 @@ export function openFileView(path: string, sid?: string | null, frag?: string | 
       acts.appendChild(b);
     }
   }
+  // ── text size ── A− and A+ step every text view through TEXT_SIZES, Ctrl/Cmd + wheel over the body
+  // does the same, and the percentage between them (said once the size is off the default) is the reset;
+  // textSizeControl above has the shape. Shown over a TEXT view only: the editor does not hold the body,
+  // and the text the current view shows has landed (viewText: the fetch pipeline's text, or the decoded
+  // XML while the SVG Source view is up; a picture or a PDF frame leaves both null). The text lands with
+  // the kernel's Content-Type verdict, so a picture opened over a slow link never shows the control
+  // beside the loader and then takes it away.
+  const textShowing = (): boolean => !editing && viewText() !== null;
+  const textSize = textSizeControl(box, textShowing);
+  for (const b of textSize.buttons) acts.appendChild(b);
   // ── the SVG Source toggle ── an SVG is served (and shown) as an image, but it IS also XML worth
   // reading; the toggle swaps in the existing highlighted-code view (langFor maps svg → xml) built
   // from the SAME fetched bytes — no second request. Appears only once an image/svg+xml body landed.
@@ -548,6 +664,7 @@ export function openFileView(path: string, sid?: string | null, frag?: string | 
   bar.appendChild(name); if (sess) bar.appendChild(sess); bar.appendChild(acts);
 
   const body = el("div", "fileview-body");
+  textSize.bindWheel(body);                    // Ctrl/Cmd + wheel over the text steps the size (textSizeControl)
   // A rendered document's RELATIVE links (`[notes](./notes.md)`, `[fig](plots/a.png)`) open the
   // sibling file in this same viewer — mdBlock stamps each one `data-act="fv-open"` with the joined
   // path (joinDocPath) instead of a target the page would navigate to. One delegated listener on
@@ -635,6 +752,7 @@ export function openFileView(path: string, sid?: string | null, frag?: string | 
       b.hidden = editing;                       // format choices leave with edit mode; Save/Cancel own the bar
     }
     editBtn.hidden = editing || text === null || !isText || !mtimeNs;
+    textSize.sync();                          // the text-size control follows every paint: shown over a text view only
     saveBtn.hidden = !editing;
     cancelBtn.hidden = !editing;
     if (isImage || isPdf) {
@@ -671,8 +789,16 @@ export function openFileView(path: string, sid?: string | null, frag?: string | 
   // chip lands in the session the file was opened FOR even if the active tab changed while the
   // modal was up (the 2026-08-19 routing rule: the gesture's session, never activeId-at-gesture).
   let seedSeq = 0;                                 // last gesture wins if two fresh reads race
-  box.addEventListener("mouseup", () => {
+  box.addEventListener("mouseup", (ev) => {
     if (editing) return;   // CodeMirror selections are edit gestures, not quotes
+    // A press on a title-bar CONTROL (A−, A+, the readout, Raw, Copy path, the GitHub link) settles no
+    // selection: the mouseup lands on the button while a passage may still stand selected in the body,
+    // and the seed below would re-read the file and re-seed the quote chip on every step of the text
+    // size. The gate is the control under the lift, not the bar: a drag that starts in the body and is
+    // released over the bar's path or its padding (the overshoot when selecting back to a file's first
+    // line) is a selection like any other and settles.
+    const at = ev.target as Element | null;
+    if (at && bar.contains(at) && at.closest("button, a")) return;
     // No chip target reachable → no seed (the no-sink gating): the post would be dead air and the
     // label's fresh read dead work. The target is this document's composer (the chat-hosted viewer)
     // or, from a pane without one — the feed — the shell, which forwards the seed into the chat pane
@@ -969,6 +1095,10 @@ export function openUrlView(href: string): void {
     segBtns.push([mode, b]);
     acts.appendChild(b);
   }
+  // the text-size control the local viewer has (textSizeControl): a document opened from a link honours
+  // the same stored size as a file on disk, and a step here is kept for both
+  const textSize = textSizeControl(box, () => text !== null);
+  for (const b of textSize.buttons) acts.appendChild(b);
   // The way OUT to the URL itself, in a new tab — an anchor wearing the button treatment, the
   // GitHub link's dress: the browser owns the tab. It is also every failure pane's exit below.
   // data-new-tab: this href IS a same-origin .md, exactly what the chat's anchor delegate routes
@@ -996,6 +1126,7 @@ export function openUrlView(href: string): void {
   bar.appendChild(name); bar.appendChild(acts);
 
   const body = el("div", "fileview-body");
+  textSize.bindWheel(body);                            // Ctrl/Cmd + wheel over the text steps the size
   // In-document links land on their heading (mdBlock's fv-anchor stamp): one delegated listener, the
   // local viewer's pattern. No fv-open here — a URL document's sibling links are made absolute and
   // the chat's own anchor delegate routes them.
@@ -1027,6 +1158,7 @@ export function openUrlView(href: string): void {
       b.classList.toggle("on", on);
       b.setAttribute("aria-pressed", String(on));
     }
+    textSize.sync();                                   // shown once the document's text is up
     if (text === null) return;                         // the loader holds the body until the bytes land
     body.replaceChildren(fmt.md === "rendered"
       ? mdBlock(text, { kind: "url", href: loc })      // relative refs resolve against where it LIVES

--- a/ui/webview/fileview-chip.test.ts
+++ b/ui/webview/fileview-chip.test.ts
@@ -12,6 +12,7 @@ class El {
   id = ""; title = ""; hidden = false; type = ""; disabled = false; tabIndex = -1; innerHTML = "";
   href = ""; target = ""; rel = ""; spellcheck = true; isConnected = true;
   style: Record<string, string> = {};
+  dataset: Record<string, string> = {};      // the viewer's text size rides the root as data-fv-text (textSizeControl)
   childNodes: Array<El | string> = [];
   private attrs = new Map<string, string>();
   private classes = new Set<string>();

--- a/ui/webview/fileview-parity.test.ts
+++ b/ui/webview/fileview-parity.test.ts
@@ -2,13 +2,15 @@
 // loads styles.css alone and the feed page feed.css alone — so its dress is declared in BOTH sheets
 // (the .romp-acted / filebrowse precedent). The copies had already drifted once (feed.css lacked the
 // a.fileview-btn anchor rules, so the GitHub link rendered hrefless-underlined there, 2026-08-26).
-// This pins the shared chrome byte-equal so it cannot drift again. Rules that are deliberately
-// pane-specific (wrap mode, load cue, the md body's typography where the feed sheet carries a
-// fallback) are not pinned. The md body's own rule IS: its `contain: layout` is what keeps a
-// file's fixed-positioned element inside the note, and it has to hold in both documents, as do
-// the width caps on the media a file draws itself (svg, canvas, video), which under containment
-// would otherwise be clipped and unreachable, and the table rule that gives a wide table a
-// horizontal scroll of its own for the same reason.
+// This pins the shared chrome byte-equal so it cannot drift again, and with it the rendered document's
+// type scale (the .fileview-md heads below): every occurrence of a head, read at a line start, so a
+// head two rules share (the heading list carries the scale and, later, the landing margin) is compared
+// rule for rule, and a rule present in one sheet only is a failure, not a skip. The md body's root rule
+// is among them for more than its typography: its `contain: layout` is what keeps a file's
+// fixed-positioned element inside the note, and it has to hold in both documents, as do the width caps
+// on the media a file draws itself (svg, canvas, video), which under containment would otherwise be
+// clipped and unreachable, and the table rules that give a wide table a horizontal scroll of its own
+// for the same reason. Rules that are deliberately pane-specific (wrap mode, load cue) are not pinned.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -27,23 +29,70 @@ const RULES = [
   // one disabled dress for every bar button: the GitHub unit's no-link state and the text-size control's ends
   '.fileview-btn:disabled, .fileview-btn[aria-disabled="true"] {', '.fileview-btn:disabled:hover, .fileview-btn[aria-disabled="true"]:hover {',
   '.fileview-btn:disabled:active, .fileview-btn[aria-disabled="true"]:active {', ".fileview-size-reset {", ".fileview-size-reset.fileview-size-default {",
-  "a.fileview-gh-note {", ".fileview-body {", ".fileview-md {",
-  ":where(.fileview-md) svg, :where(.fileview-md) canvas, :where(.fileview-md) video {",
-  ':where(.fileview-md :is(svg, canvas)[width]:not([width$="%"])) {',
-  ".fileview-md table {",
+  "a.fileview-gh-note {", ".fileview-body {",
   ".fileview-cm {", ".fileview-cm .cm-editor {", ".fileview-editor {", ".fileview > .fileview-err {",
   ".fileview-dir-link {", ".fileview-dir-link:hover {",
   ".fileview-imgbox {", ".fileview-img {", ".fileview-frame {",
+  // the rendered document's type scale: the root (the face, the size, the leading, the measure), the heading ladder, the
+  // list gutter, a task item, kbd, fenced code with its rows and Copy, a table's fill, striping, alignment and break-out,
+  // and the caps on the media a file draws itself
+  "@property --fv-body-w {",
+  ".fileview-md {",
+  ".fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4, .fileview-md h5, .fileview-md h6 {",
+  ".fileview-md h1 {", ".fileview-md h2 {", ".fileview-md h3 {", ".fileview-md h4 {", ".fileview-md h5, .fileview-md h6 {",
+  ".fileview-md h1, .fileview-md h2 {",
+  ".fileview-md ul, .fileview-md ol {", ".fileview-md li {",
+  ".fileview-md li.task-list-item {", ".fileview-md li.task-list-item input {",
+  '.fileview-md li.task-list-item > input[type="checkbox"], .fileview-md li.task-list-item > p:first-child > input[type="checkbox"] {',
+  ".fileview-md kbd {", ".fileview-md :not(pre) > code {",
+  ".fileview-md pre {", ".fileview-md pre code {",
+  ".fileview-md pre code .cl {", ".fileview-md pre code .cl::before {", ".fileview-md pre code .ct {", ".fileview-md pre code .ct::before {",
+  ".fileview-md pre.has-copy {", ".fileview-md .code-copy {", ".fileview-md pre.has-copy:hover .code-copy, .fileview-md .code-copy:focus-visible {",
+  ".fileview-md .code-copy:hover {", ".fileview-md .code-copy.copied {",
+  ".fileview-md table {", ".fileview-md > table {", ".fileview-md th, .fileview-md td {", ".fileview-md th {", ".fileview-md tbody tr:nth-child(even) {",
+  '.fileview-md th[align="center"], .fileview-md td[align="center"] {', '.fileview-md th[align="right"], .fileview-md td[align="right"] {',
+  '.fileview-md th[align="left"], .fileview-md td[align="left"] {',
+  ".fileview-md img {",
+  // the caps on the media a file draws itself (svg, canvas, video): under contain: layout anything wider than the root is
+  // clipped and unreachable, so they have to hold in both documents
+  ":where(.fileview-md) svg, :where(.fileview-md) canvas, :where(.fileview-md) video {",
+  ':where(.fileview-md :is(svg, canvas)[width]:not([width$="%"])) {',
 ];
 
-function ruleOf(css: string, head: string): string {
-  const at = css.indexOf(head);
+/** Every rule whose selector opens a line as `head`, in sheet order; at least one, or the head is missing. */
+function rulesOf(css: string, head: string): string[] {
+  const out: string[] = [];
+  for (let at = css.indexOf("\n" + head); at >= 0; at = css.indexOf("\n" + head, at + 1)) out.push(css.slice(at + 1, css.indexOf("}", at) + 1));
+  assert.ok(out.length > 0, head + " present");
+  return out;
+}
+/** A block at-rule (`@media print {`), whole: from its head to the first close brace at a line start. */
+function blockOf(css: string, head: string): string {
+  const at = css.indexOf("\n" + head);
   assert.ok(at >= 0, head + " present");
-  return css.slice(at, css.indexOf("}", at) + 1);
+  return css.slice(at + 1, css.indexOf("\n}", at) + 2);
 }
 
-test("the viewer's shared chrome exists in BOTH sheets, byte-equal", () => {
+test("the viewer's shared chrome and the document's type scale exist in BOTH sheets, byte-equal, every occurrence of every head", () => {
   for (const head of RULES) {
-    assert.equal(ruleOf(CHAT, head), ruleOf(FEED, head), head + " mirrors exactly");
+    assert.deepEqual(rulesOf(CHAT, head), rulesOf(FEED, head), head + " mirrors exactly");
   }
+});
+
+test("the print sheet is one block in both sheets, byte-equal: the file alone, black on white", () => {
+  const print = blockOf(CHAT, "@media print {");
+  assert.equal(print, blockOf(FEED, "@media print {"), "@media print mirrors exactly");
+  assert.ok(print.length > 500, "the block with its rules");
+  assert.equal((CHAT.match(/^@media print \{/gm) || []).length, 1, "one print block in styles.css");
+  assert.equal((FEED.match(/^@media print \{/gm) || []).length, 1, "one print block in feed.css");
+  // the file alone: the title bar and the Copy buttons leave, the page and the card go white on black
+  assert.match(print, /\.fileview-bar, \.fileview > \.fileview-err, \.fileview-md \.code-copy \{ display: none; \}/);
+  assert.match(print, /:root, body\.fileview-open \{ height: auto; overflow: visible; background: white; color: black; \}/);
+  assert.match(print, /body\.fileview-open > :not\(#romp-fileview\) \{ display: none; \}/);
+  // the task box is drawn in the light scheme whatever the page's theme, and a table is a table again
+  assert.match(print, /\.fileview-md li\.task-list-item input\[type="checkbox"\] \{ color-scheme: light; \}/);
+  assert.match(print, /\.fileview-md table \{ display: table; width: max-content; overflow: visible; overflow-wrap: anywhere; \}/);
+  // the Raw view's gutter and tokens print in full black too
+  assert.match(print, /\.fileview-gutter/);
+  assert.match(print, /\.fileview-body code\.hljs, \.fileview-body code\.hljs span/);
 });

--- a/ui/webview/fileview-parity.test.ts
+++ b/ui/webview/fileview-parity.test.ts
@@ -20,10 +20,14 @@ const FEED = read("feed.css");
 
 const RULES = [
   "#romp-fileview {", ".fileview {", "body.fileview-open {", ".fileview-bar {", ".fileview-name {",
-  ".fileview-dir {", ".fileview-base {", ".fileview-sess {", ".fileview-sess .host-prefix {", ".fileview-acts {", ".fileview-btn {", ".fileview-btn:hover {",
+  ".fileview-dir {", ".fileview-base {", ".fileview-sess {", ".fileview-sess .host-prefix {", ".fileview-acts {",
+  ".fileview-bar .fileview-name {", ".fileview-bar .fileview-acts {",   // the bar's own wrap (scoped: the file browser's row wears .fileview-acts too)
+  ".fileview-btn {", ".fileview-btn:hover {",
   "a.fileview-btn {", ".fileview-gh {", ".fileview-gh-why {", ".fileview-gh-dots {",
-  ".fileview-gh .fileview-btn:disabled {", ".fileview-gh .fileview-btn:disabled:hover {",
-  ".fileview-gh .fileview-btn:disabled:active {", "a.fileview-gh-note {", ".fileview-body {", ".fileview-md {",
+  // one disabled dress for every bar button: the GitHub unit's no-link state and the text-size control's ends
+  '.fileview-btn:disabled, .fileview-btn[aria-disabled="true"] {', '.fileview-btn:disabled:hover, .fileview-btn[aria-disabled="true"]:hover {',
+  '.fileview-btn:disabled:active, .fileview-btn[aria-disabled="true"]:active {', ".fileview-size-reset {", ".fileview-size-reset.fileview-size-default {",
+  "a.fileview-gh-note {", ".fileview-body {", ".fileview-md {",
   ":where(.fileview-md) svg, :where(.fileview-md) canvas, :where(.fileview-md) video {",
   ':where(.fileview-md :is(svg, canvas)[width]:not([width$="%"])) {',
   ".fileview-md table {",

--- a/ui/webview/github-link.test.ts
+++ b/ui/webview/github-link.test.ts
@@ -222,11 +222,14 @@ test("the sheets dress the unit: the caption at button size, the disabled button
     const why = css.slice(css.indexOf(".fileview-gh-why {"), css.indexOf("}", css.indexOf(".fileview-gh-why {")));
     assert.doesNotMatch(why, /nowrap|ellipsis|overflow: hidden/, "the caption wraps; it is never cut");
     assert.match(css, /\.fileview-btn \{ font: inherit; font-size: 0\.82em;/);
-    assert.match(css, /\.fileview-gh \.fileview-btn:disabled \{ opacity: 0\.55; cursor: default; \}/);
-    assert.match(css, /\.fileview-gh \.fileview-btn:disabled:hover \{ border-color: var\(--card-border\); color: var\(--fg\); background: transparent; \}/);
-    assert.match(css, /\.fileview-gh \.fileview-btn:disabled:active \{ transform: none; \}/);
+    // the disabled dress is every bar button's since the text-size control's ends took it too; the unit's no-link
+    // button is a real disabled button under it
+    assert.match(css, /\.fileview-btn:disabled, \.fileview-btn\[aria-disabled="true"\] \{ opacity: 0\.55; cursor: default; \}/);
+    assert.match(css, /\.fileview-btn:disabled:hover, \.fileview-btn\[aria-disabled="true"\]:hover \{ border-color: var\(--card-border\); color: var\(--fg\); background: transparent; \}/);
+    assert.match(css, /\.fileview-btn:disabled:active, \.fileview-btn\[aria-disabled="true"\]:active \{ transform: none; \}/);
     assert.match(css, /a\.fileview-gh-note \{ border-style: dashed; \}/);
-    assert.doesNotMatch(css, /aria-disabled="true"\]/, "the disabled state is the button's own, not an aria bit on an anchor");
+    assert.doesNotMatch(css, /\.fileview-gh[^{\n]*aria-disabled|a\.fileview-btn[^{\n]*aria-disabled/,
+      "the unit's disabled state is the button's own, not an aria bit on an anchor (the text-size control's ends carry aria-disabled to keep the keyboard focus, and the shared rule dresses both)");
   }
 });
 

--- a/ui/webview/highlight-cache.ts
+++ b/ui/webview/highlight-cache.ts
@@ -8,11 +8,19 @@
 // grammar.
 // Bounded: at most CAP entries and about BUDGET characters of output, oldest out first (a Map keeps
 // insertion order; a hit is re-inserted so it counts as newest). Very large sources are not cached at all.
+//
+// Auto-detection guesses among AUTO_LANGUAGES, the ten grammars the chat registers (render.ts), not among every grammar
+// on the core: the file viewer registers six more (viewer-grammars.ts) and the chat bundle carries them through
+// file-view.ts, so without the subset an unlabeled fence would be tokenized against sixteen grammars, a slower tail and
+// different guesses.
 export interface Highlighter {
   getLanguage(name: string): unknown;
   highlight(raw: string, opts: { language: string }): { value: string };
-  highlightAuto(raw: string): { value: string };
+  highlightAuto(raw: string, languageSubset?: readonly string[]): { value: string };
 }
+
+/** The grammars an unlabeled chat fence is guessed among: the ten render.ts registers, by their registered names. */
+export const AUTO_LANGUAGES: readonly string[] = ["bash", "python", "javascript", "typescript", "json", "xml", "css", "markdown", "diff", "yaml"];
 
 export const CAP = 256;               // entries
 export const BUDGET = 4_000_000;      // characters of highlighted HTML held, all entries together
@@ -32,7 +40,7 @@ export function highlightHtml(hl: Highlighter, lang: string | undefined, raw: st
     cache.map.delete(key); cache.map.set(key, hit);   // newest again
     return hit;
   }
-  const html = known ? hl.highlight(raw, { language: lang as string }).value : hl.highlightAuto(raw).value;
+  const html = known ? hl.highlight(raw, { language: lang as string }).value : hl.highlightAuto(raw, AUTO_LANGUAGES).value;
   if (raw.length <= MAX_RAW) {
     cache.map.set(key, html); cache.chars += html.length;
     while (cache.map.size > CAP || (cache.chars > BUDGET && cache.map.size > 1)) {

--- a/ui/webview/md-sanitize-browser.test.ts
+++ b/ui/webview/md-sanitize-browser.test.ts
@@ -345,9 +345,11 @@ test("content wider than the column: an inline svg, canvas or video shrinks to t
       const box = (sel: string) => { const r = (md.querySelector(sel) as HTMLElement).getBoundingClientRect(); return { width: r.width, height: r.height }; };
       const table = md.querySelector(".fx-table") as HTMLElement;
       table.scrollLeft = 200;
+      const tr = table.getBoundingClientRect(), br = body.getBoundingClientRect();
       return {
         column, svg: box(".fx-svg"), canvas: box(".fx-canvas"), video: box(".fx-video"),
         tableClient: table.clientWidth, tableScroll: table.scrollWidth, tableOverflowX: getComputedStyle(table).overflowX, tableScrolled: table.scrollLeft,
+        tableInset: { left: tr.left - br.left, right: br.right - tr.right },
         cellBorders: getComputedStyle(md.querySelector(".fx-table td") as HTMLElement).borderLeftWidth,
         bodyClient: body.clientWidth, bodyScroll: body.scrollWidth,
       };
@@ -358,7 +360,11 @@ test("content wider than the column: an inline svg, canvas or video shrinks to t
     assert.ok(facts.canvas.width <= facts.column + 0.5 && facts.canvas.width > facts.column - 2, "the canvas fills the column, no wider: " + JSON.stringify(facts.canvas));
     near(facts.canvas.height, facts.canvas.width * 100 / 2500, "the canvas keeps its own ratio", 1.5);
     assert.ok(facts.video.width <= facts.column + 0.5, "the video is no wider than the column: " + JSON.stringify(facts.video));
-    assert.ok(facts.tableClient <= facts.column + 0.5, "the table's box is no wider than the column: " + facts.tableClient);
+    // a table of the page's own (a direct child of the root) may grow out of the prose column, evenly into both gutters, but
+    // never past the body's content width less the root's 18px inset (`.fileview-md > table`, both sheets; the cap is the
+    // column itself until the viewer's width observer has reported), so its box stays inside the body and nothing is clipped
+    assert.ok(facts.tableClient >= facts.column - 0.5 && facts.tableClient <= facts.bodyClient - 36 + 0.5, "the table's box is the column or wider, up to the body less the inset: " + facts.tableClient + " (column " + facts.column + ", body " + facts.bodyClient + ")");
+    assert.ok(facts.tableInset.left >= 18 - 0.5 && facts.tableInset.right >= 18 - 0.5, "the table's box keeps the root's inset on both sides of the body: " + JSON.stringify(facts.tableInset));
     assert.ok(facts.tableScroll > facts.tableClient + 100, "the table's content runs past its box: " + facts.tableScroll + " vs " + facts.tableClient);
     assert.equal(facts.tableOverflowX, "auto", "and the table scrolls it");
     assert.ok(facts.tableScrolled > 0, "the table did scroll: " + facts.tableScrolled);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -77,6 +77,7 @@ import { perfFrameHandler } from "./perf-telemetry";
 import { linkifyPrRefs, senderPrRepo, postalSenderHost } from "./pr-links";
 import { listenForFrames } from "./frame-listener";
 import { highlightHtml } from "./highlight-cache";
+import { wrapCodeLines, addCopyBtn } from "./code-block";   // a fence's per-line rows and Copy button, shared with the file viewer
 import { turnWorkedSecs as workedSecsOf, workedFooterPlan } from "./worked-footer";
 import { reconcileRewindPass, type RewindEvent } from "./rewind-reconcile";
 
@@ -1225,62 +1226,6 @@ function highlight(container: HTMLElement, lineNos = true) {
     const pre = code.parentElement;
     if (pre && pre.tagName === "PRE") addCopyBtn(pre as HTMLElement, raw);   // an automatic "Copy" button per block
   });
-}
-
-// Copy text to the clipboard, falling back to a hidden-textarea execCommand when the async Clipboard API
-// is unavailable (it needs a secure context — localhost counts, but stay safe). Returns whether it copied.
-function copyText(text: string): Promise<boolean> {
-  if (navigator.clipboard && navigator.clipboard.writeText) {
-    return navigator.clipboard.writeText(text).then(() => true, () => fallbackCopy(text));
-  }
-  return Promise.resolve(fallbackCopy(text));
-}
-function fallbackCopy(text: string): boolean {
-  try {
-    const ta = document.createElement("textarea");
-    ta.value = text; ta.style.position = "fixed"; ta.style.top = "-9999px"; ta.style.opacity = "0";
-    document.body.appendChild(ta); ta.focus(); ta.select();
-    const ok = document.execCommand("copy");
-    document.body.removeChild(ta);
-    return ok;
-  } catch { return false; }
-}
-
-// An automatic "Copy" button parked top-right of every rendered code block (the user 2026-06-22). The RAW
-// source is captured at highlight time and closed over — the on-screen markup adds a line-number gutter and
-// drops the newline joins, so copying its textContent would be wrong. Faint until the block is hovered;
-// flips to a green "Copied" for ~1.2s on success. Idempotent (highlight can re-run on a re-render).
-function addCopyBtn(pre: HTMLElement, raw: string) {
-  if (pre.querySelector(":scope > .code-copy")) return;
-  pre.classList.add("has-copy");
-  const btn = el("button", "code-copy") as HTMLButtonElement;
-  btn.type = "button"; btn.textContent = "Copy"; btn.title = "copy this code block";
-  btn.addEventListener("click", (ev) => {
-    ev.preventDefault(); ev.stopPropagation();
-    copyText(raw).then((ok) => {
-      btn.textContent = ok ? "Copied" : "Copy failed";
-      btn.classList.toggle("copied", ok);
-      window.setTimeout(() => { btn.textContent = "Copy"; btn.classList.remove("copied"); }, 1200);
-    });
-  });
-  pre.appendChild(btn);
-}
-
-// Wrap each logical line of (hljs-highlighted) code in <span class=cl><span class=ct>…</span></span>,
-// re-opening any hljs span that straddles a newline so the markup stays valid. A CSS counter on .cl
-// draws the subtle line numbers; .ct holds the wrapping content (the user 2026-06-16).
-function wrapCodeLines(code: HTMLElement) {
-  const lines = code.innerHTML.split("\n");
-  if (lines.length > 1 && lines[lines.length - 1] === "") lines.pop();   // a trailing newline isn't a blank line
-  let open: string[] = [];
-  code.innerHTML = lines.map((ln) => {
-    const prefix = open.join("");
-    const re = /<span[^>]*>|<\/span>/g; let m; const stack = open.slice();
-    while ((m = re.exec(ln))) { if (m[0] === "</span>") stack.pop(); else stack.push(m[0]); }
-    const suffix = "</span>".repeat(Math.max(0, stack.length));
-    open = stack;
-    return `<span class="cl"><span class="ct">${prefix}${ln}${suffix}</span></span>`;
-  }).join("");
 }
 
 function dot(kind: "green" | "ring" | "user" | "red" | "romp" | "working" | "tag"): HTMLElement { return el("span", "dot " + kind); }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3468,10 +3468,14 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
   background: var(--bg, #1e1e1e); border: 1px solid var(--box-border); border-radius: var(--radius-modal);
   box-shadow: var(--shadow-modal); }
 body.fileview-open { overflow: hidden; }
-.fileview-bar { flex: 0 0 auto; display: flex; align-items: center; gap: 10px; min-width: 0;
+.fileview-bar { flex: 0 0 auto; display: flex; flex-wrap: wrap; align-items: center; gap: 6px 10px; min-width: 0;
   padding: 7px 10px; border-bottom: 1px solid var(--box-border); }
 /* Only the DIRECTORY may be truncated: the filename identifies the file, so it holds its width however
-   deep the path is, and the dimmed directory in front of it gives up room first. */
+   deep the path is, and the dimmed directory in front of it gives up room first. The bar WRAPS: the path
+   keeps at least 12em and the action row drops to a second line, right-aligned, when the two do not fit
+   side by side (the text-size control's three buttons pushed Download, Copy path and the close button off
+   the card below about 600px; .fileview is overflow: hidden, and a phone has no Escape). The wrap is the
+   bar's own: the two .fileview-bar rules after .fileview-acts below. */
 .fileview-name { flex: 1 1 auto; min-width: 0; font-size: 0.86em; color: var(--fg);
   display: flex; align-items: baseline; white-space: nowrap; }
 .fileview-dir { flex: 0 1 auto; min-width: 0; color: var(--dim);
@@ -3494,6 +3498,12 @@ body.fileview-open { overflow: hidden; }
   background: var(--overlay-10, rgba(255, 255, 255, 0.12)); color: var(--fg); user-select: none; }
 .fileview-sess .host-prefix { color: inherit; opacity: 0.75; }
 .fileview-acts { flex: 0 0 auto; display: flex; align-items: center; gap: 6px; }
+/* The wrap is the TITLE BAR's, not the classes': the file browser's action row (.fb-bar, file-browse.ts)
+   wears .fileview-acts outside any bar and keeps one line at every width (its crumb trail is what gives up
+   room), so the plain flex above holds there. Inside the bar the path keeps 12em and takes the rest of a
+   wide bar, and the action row shrinks and wraps to the right edge. */
+.fileview-bar .fileview-name { flex: 1 1 0; min-width: 12em; }
+.fileview-bar .fileview-acts { flex: 0 1 auto; min-width: 0; margin-left: auto; flex-wrap: wrap; justify-content: flex-end; }
 .fileview-btn { font: inherit; font-size: 0.82em; cursor: pointer; flex: 0 0 auto;
   padding: 3px 9px; border-radius: 6px; background: transparent; color: var(--fg);   /* T151: the one button rest */
   border: 1px solid var(--card-border);
@@ -3514,11 +3524,21 @@ a.fileview-btn { text-decoration: none; display: inline-flex; align-items: cente
    dimmed button and the loader's dots (.fileview-dot, the pane's own) where the caption will go — a slow
    check must read as a wait, not as the old no-button state nor as a verdict (the loading-state rule) */
 .fileview-gh-dots { display: inline-flex; align-items: center; gap: 4px; }
-/* no link: a real disabled button, greyed, hover inert — never hidden (an absent button read as
-   "broken" when the file was simply not committed yet, 2026-09-05) */
-.fileview-gh .fileview-btn:disabled { opacity: 0.55; cursor: default; }
-.fileview-gh .fileview-btn:disabled:hover { border-color: var(--card-border); color: var(--fg); background: transparent; }
-.fileview-gh .fileview-btn:disabled:active { transform: none; }
+/* a disabled bar button, greyed, hover inert: the GitHub unit's no-link state (a real disabled button, never
+   hidden: an absent button read as "broken" when the file was simply not committed yet, 2026-09-05), the
+   editor's Save while a save is in flight (disabled and reading "Saving…"), and the text-size control's ends
+   (A− at the smallest step, A+ at the largest; aria-disabled, so the button keeps the keyboard focus it holds
+   and the ring stays where the person left it). One treatment for every bar button, so neither an end nor a
+   save in progress reads as live under the pointer. */
+.fileview-btn:disabled, .fileview-btn[aria-disabled="true"] { opacity: 0.55; cursor: default; }
+.fileview-btn:disabled:hover, .fileview-btn[aria-disabled="true"]:hover { border-color: var(--card-border); color: var(--fg); background: transparent; }
+.fileview-btn:disabled:active, .fileview-btn[aria-disabled="true"]:active { transform: none; }
+/* the text-size readout between A− and A+ (file-view.ts textSizeControl): a slot of ONE width whatever it
+   says, and at the default (nothing to reset, nothing to say) an empty slot rather than none, so A− never
+   moves under the pointer when the readout appears after the first press. visibility, not display: the slot
+   stays, the button leaves the tab order. */
+.fileview-size-reset { min-width: 5.5em; box-sizing: border-box; text-align: center; font-variant-numeric: tabular-nums; }
+.fileview-size-reset.fileview-size-default { visibility: hidden; }
 /* a link whose branch is not on origin yet: dashed, the caption carries the note */
 a.fileview-gh-note { border-style: dashed; }
 .fileview-body { flex: 1 1 auto; min-height: 0; overflow: auto; }
@@ -3586,11 +3606,11 @@ body.filebrowse-open { overflow: hidden; }
 .fileview-code { display: flex; align-items: flex-start; min-height: 100%; }
 .fileview-gutter { flex: 0 0 auto; position: sticky; left: 0; z-index: 1;
   padding: 10px 8px 10px 10px; text-align: right; user-select: none;
-  font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
+  font-family: var(--mono, ui-monospace, monospace); font-size: calc(12px * var(--fv-scale, 1)); line-height: 1.5;
   color: var(--dim); opacity: 0.55; background: var(--bg, #1e1e1e);
   border-right: 1px solid var(--box-border); white-space: pre; }
 .fileview-pre { flex: 1 1 auto; margin: 0; padding: 10px 12px;
-  font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
+  font-family: var(--mono, ui-monospace, monospace); font-size: calc(12px * var(--fv-scale, 1)); line-height: 1.5;
   white-space: pre; tab-size: 4; }
 .fileview-pre code { background: none; padding: 0; font: inherit; }
 /* a refusal explains itself in place, in the kernel's own words (too large — with the size and the
@@ -3638,6 +3658,32 @@ body.filebrowse-open { overflow: hidden; }
 }
 .fileview-wrap .fv-ct { flex: 1 1 auto; min-width: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
 
+/* ── text size and measure (file-view.ts textSizeControl) ── The A− / A+ buttons and Ctrl/Cmd + wheel over the
+   body set `data-fv-text` on the viewer root to one of TEXT_SIZES; this table turns the step into the ONE
+   property the text views read, --fv-scale. Every text size below is a multiple of it, so the prose, its
+   headings (em of the prose), inline and fenced code, and the Raw view's rows and gutter scale together, and
+   the prose measure with them (the same characters per line at every size). Nothing else reads it: the title
+   bar, its buttons and the editor keep the page's size. Absent (a bundle without these rules) every fallback
+   reads as 1, today's sizes exactly. file-view-text-size.test.ts pins the table against TEXT_SIZES in both
+   sheets. The measure sits on the root's children, not the root: a table takes the viewer's width when its
+   columns need it (the root is fluid to the body), and a table wider than that scrolls on its own with
+   whole words kept (`overflow-wrap: normal` against the root's `anywhere`, which would crush every column to
+   fit), so the page never widens. Code blocks keep the measure and wrap their long lines (long lines always
+   soft-wrap): a short snippet has no use for a viewer-wide block beside 860px prose. The measure rule is written
+   at ZERO specificity (:where) so a picture's own cap below always beats it: a bare <img> line in a README is a
+   direct child of the root, and a plain :not() chain would tie `.fileview-md img` on specificity and leave the
+   winner to rule order; :where keeps the picture's cap the winner whatever the order, so a wide banner is never
+   laid out at the measure to scroll a narrow viewer sideways. A picture that is itself a block of the page takes
+   the measure AND the column, like an image paragraph (the `.fileview-md > :is(img, svg, canvas, video)` rule). */
+.fileview[data-fv-text="70"] { --fv-scale: 0.7; }
+.fileview[data-fv-text="80"] { --fv-scale: 0.8; }
+.fileview[data-fv-text="90"] { --fv-scale: 0.9; }
+.fileview[data-fv-text="100"] { --fv-scale: 1; }
+.fileview[data-fv-text="115"] { --fv-scale: 1.15; }
+.fileview[data-fv-text="130"] { --fv-scale: 1.3; }
+.fileview[data-fv-text="150"] { --fv-scale: 1.5; }
+.fileview[data-fv-text="175"] { --fv-scale: 1.75; }
+.fileview[data-fv-text="200"] { --fv-scale: 2; }
 /* Rendered markdown (the Raw ⇄ Rendered toggle; Rendered is the default — the user 2026-08-09).
    Typography mirrors the chat's .md block in styles.css, the reference aesthetic (one treatment, two
    sheets — the .romp-acted precedent); font sizes reuse what this surface already wears (the page base,
@@ -3649,8 +3695,10 @@ body.filebrowse-open { overflow: hidden; }
    body's vertical scroll is untouched. Content wider than .fileview-md becomes ink overflow the body cannot
    scroll to, so the media rules below cap an <svg>, <canvas> or <video> at the column as `.fileview-md img`
    already does, and the table rule below gives a table wider than the column a horizontal scroll of its own.
-   Pinned byte-equal in both sheets (fileview-parity.test.ts). */
-.fileview-md { padding: 14px 18px; max-width: 860px; overflow-wrap: anywhere; font-family: var(--font-prose); contain: layout; }
+   The column is the root's own width, fluid to the viewer: the prose measure sits on the root's children (the
+   text-size block above). Pinned byte-equal in both sheets (fileview-parity.test.ts). */
+.fileview-md { padding: 14px 18px; overflow-wrap: anywhere; font-family: var(--font-prose); font-size: calc(1em * var(--fv-scale, 1)); contain: layout; }
+.fileview-md > :where(:not(table)) { max-width: calc(860px * var(--fv-scale, 1)); }
 .fileview-md > :first-child { margin-top: 0; }
 .fileview-md > :last-child { margin-bottom: 0; }
 .fileview-md p { margin: 0.5em 0; }
@@ -3680,14 +3728,15 @@ body.filebrowse-open { overflow: hidden; }
 }
 .fileview-md pre code {
   background: none; padding: 0; display: block;
-  font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
+  font-family: var(--mono, ui-monospace, monospace); font-size: calc(12px * var(--fv-scale, 1)); line-height: 1.5;
   color: var(--code-fg, #e1c08d); white-space: pre-wrap; overflow-wrap: anywhere;
 }
 /* A table wider than the column (a `nowrap` cell, many columns) scrolls sideways on its own, as on GitHub: a block
    box shrink-wrapped to its content (width: max-content) and capped at the column, with the overflow scrollable.
    Under contain: layout the body cannot scroll to what a table lets run past the column, so the table has to.
-   border-collapse is inherited by the anonymous table box the block wraps, so the cell borders still collapse. */
-.fileview-md table { border-collapse: collapse; margin: 0.6em 0; display: block; width: max-content; max-width: 100%; overflow-x: auto; }
+   border-collapse is inherited by the anonymous table box the block wraps, so the cell borders still collapse.
+   overflow-wrap: normal keeps whole words against the root's `anywhere`, which would crush every column to fit. */
+.fileview-md table { border-collapse: collapse; margin: 0.6em 0; display: block; width: max-content; max-width: 100%; overflow-x: auto; overflow-wrap: normal; }
 .fileview-md th, .fileview-md td { border: 1px solid var(--box-border); padding: 4px 10px; text-align: left; }
 .fileview-md th { background: var(--box-bg); }
 .fileview-md img { max-width: 100%; }
@@ -3699,6 +3748,11 @@ body.filebrowse-open { overflow: hidden; }
    the cap and keeps the author's height. */
 :where(.fileview-md) svg, :where(.fileview-md) canvas, :where(.fileview-md) video { max-width: 100%; }
 :where(.fileview-md :is(svg, canvas)[width]:not([width$="%"])) { height: auto; }
+/* a bare top-level medium (an <img> line in a README, an inline <svg>, <canvas> or <video> block: a direct child of
+   the root) takes the measure AND the column, like an image paragraph. Class-and-type specificity, so it outranks
+   both the general caps above and the :where measure; the measure alone (a class) would beat the element-level
+   media cap for a direct child and hold a wide diagram at 860px on a narrower viewer, clipped under contain: layout. */
+.fileview-md > :is(img, svg, canvas, video) { max-width: min(100%, calc(860px * var(--fv-scale, 1))); }
 
 /* ── the viewer's image + PDF bodies (a .png used to open as line-numbered mojibake). The <img>
    wears the lightbox image's own treatment (.romp-lightbox-img: capped, object-fit contain, the

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -81,7 +81,7 @@ body.scheme-solarized-dark {
      (as raw hexes the palette was dark-only — pale tan on #F1EAE2). Mirrored in feed.css (own
      :root) — the viewer mounts in both documents, and file-view.test.ts pins the two identical. */
   --hl-fg: #d8c6a8; --hl-kw: #c98a6a; --hl-str: #9fb878; --hl-num: #d4a36a;
-  --hl-cmt: #6f6a5f; --hl-title: #e1c08d; --hl-meta: #9a8f7a; --hl-attr: #cdaf7e;
+  --hl-cmt: #978f81; --hl-title: #e1c08d; --hl-meta: #9a8f7a; --hl-attr: #cdaf7e;   /* --hl-cmt raised from #6f6a5f (2.85:1 on a code block) to 4.79:1; theme-parity.test.ts holds the pair */
   --box-bg: rgba(255, 255, 255, 0.03);
   --box-border: var(--vscode-editorHoverWidget-border, rgba(255, 255, 255, 0.12));
   /* the feed's button hairline, MIRRORED byte-equal from feed.css --card-border (T141: the chat's
@@ -175,9 +175,14 @@ body.scheme-solarized-dark {
   --st-compacting-bg: #14b8a6; --st-compacting-fg: #ffffff;   /* teal — the compacting accent (text + compression bar) */
   --st-blocked-bg: #e5484d; --st-blocked-fg: #ffffff;   /* alarm red — session stopped on an API error */
 
-  /* the assistant's READING face (.assistant, .fileview-md): the UI face in dark; the light
-     theme swaps in the serif (Claude-desktop's reply-text feel) */
+  /* the assistant's READING face (.assistant): the UI face in dark, mono in light (the light block re-points it).
+     --font-doc is the file viewer's face for a rendered document (.fileview-md): sans in both themes, since the mono
+     ruling was about chat output and a README in mono reads as source. --color-scheme names the theme to a form
+     control a document carries (a task list's checkbox), so its checkbox is drawn for the page it sits on. Mirrored in
+     feed.css (own :root). */
   --font-prose: var(--sans);
+  --font-doc: var(--sans);
+  --color-scheme: dark;
   --mono: var(--vscode-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
   --sans: "Inter", var(--vscode-chat-font-family, var(--vscode-font-family, system-ui, -apple-system, "Segoe UI", sans-serif));
   --fs: var(--vscode-chat-font-size, 13px);
@@ -210,7 +215,7 @@ body.theme-light {
   --code-bg: rgba(180, 83, 9, 0.08);
   --link: #1D63A8;   /* inked cobalt — clearly clickable, clearly not the error red (5.2:1 on the page) */
   --hl-fg: #3E3A35; --hl-kw: #A03509; --hl-str: #47720F; --hl-num: #915C0B;
-  --hl-cmt: #6E675C; --hl-title: #8C4A00; --hl-meta: #6E6455; --hl-attr: #7A5A20;
+  --hl-cmt: #67614f; --hl-title: #8C4A00; --hl-meta: #6E6455; --hl-attr: #7A5A20;   /* --hl-cmt from #6E675C (4.39:1 on a code block) to 4.86:1 */
   --box-bg: rgba(0, 0, 0, 0.03);
   --box-border: rgba(0, 0, 0, 0.12);
   --err: #B02A1C;
@@ -257,6 +262,8 @@ body.theme-light {
   --mono: var(--vscode-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
   --sans: "Space Grotesk", "Inter", var(--vscode-chat-font-family, var(--vscode-font-family, system-ui, -apple-system, "Segoe UI", sans-serif));
   --font-prose: var(--mono);   /* the user 2026-08-31, off the live preview: the serif read awful — assistant output goes MONO in light */
+  --font-doc: var(--sans);     /* a viewed document stays sans: the mono ruling was about chat output */
+  --color-scheme: light;
   --fs: var(--vscode-chat-font-size, 13px);
   /* the --vscode-* stand-ins: inline rules fall back through these (menus, inputs, widget cards) */
   --vscode-editor-background: #F1EAE2;
@@ -2537,15 +2544,30 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
   white-space: pre-wrap; overflow-wrap: anywhere;   /* fallback wrap if line-numbering didn't run */
 }
 /* subtle line-number gutter on wrapped code blocks: .cl = one logical line, .ct = its wrapping content;
-   the counter sits faint to the left so a soft-wrap reads distinctly from a real newline (the user 2026-06-16) */
+   the counter sits faint to the left so a soft-wrap reads distinctly from a real newline (the user 2026-06-16).
+   The gutter's own line-height is 1: at 0.92em under align-items: baseline its line box hung further below the shared
+   baseline than the text's (Chromium floors the half-leading it puts above a line box, and the remainder goes below),
+   so every row was a fraction taller than the code's line-height. With line-height 1 the gutter's box is never taller
+   than the text's and the baselines are still shared. It never wraps either (overflow-wrap: normal against the code's
+   anywhere, which broke a four-digit number over two lines and doubled every row from line 1000 on). The basis is
+   2.5em, four digits, or the block's own digit count in ch (its zero glyph's advance, plus a twentieth of an em against
+   the layout unit's rounding): wrapCodeLines (code-block.ts) writes --ln-digits on the code element, the digits of its
+   last line number, so every row of a 10000-line block carries a five-digit gutter and the text column stays one line,
+   where a basis a single row outgrew widened that row alone and stepped its code to the right. A .ct with no text (a
+   blank line, or a blank line inside a token that spans lines, which leaves an empty hljs span) had no line box, so the
+   row was only the gutter's 0.92em tall; the .ct's ::before puts a word joiner (U+2060: zero width, no break before or
+   after it, not in the DOM's text) at the start of every line, so an empty .ct is one line-height with the text's
+   baseline and a text line is unchanged. The file viewer's fences carry the same declarations under .fileview-md (both
+   sheets; code-block.test.ts). */
 pre code.hljs { counter-reset: ln; }
 pre code .cl { display: flex; align-items: baseline; }
 pre code .cl::before {
   counter-increment: ln; content: counter(ln);
-  flex: 0 0 2.3em; margin-right: 0.85em; text-align: right;
-  color: var(--dim); opacity: 0.32; user-select: none; font-size: 0.92em;
+  flex: 0 0 max(2.5em, calc(var(--ln-digits, 0) * 1ch + 0.05em)); margin-right: 0.85em; text-align: right;
+  color: var(--dim); opacity: 0.32; user-select: none; font-size: 0.92em; line-height: 1; overflow-wrap: normal;
 }
 pre code .ct { flex: 1 1 auto; min-width: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
+pre code .ct::before { content: "\2060"; }
 /* automatic per-block Copy button (the user 2026-06-22): parked top-right, faint until the block is
    hovered, flips to a green "Copied" on success; position:relative on the pre anchors it. */
 pre.has-copy { position: relative; }
@@ -3662,19 +3684,10 @@ body.filebrowse-open { overflow: hidden; }
    body set `data-fv-text` on the viewer root to one of TEXT_SIZES; this table turns the step into the ONE
    property the text views read, --fv-scale. Every text size below is a multiple of it, so the prose, its
    headings (em of the prose), inline and fenced code, and the Raw view's rows and gutter scale together, and
-   the prose measure with them (the same characters per line at every size). Nothing else reads it: the title
-   bar, its buttons and the editor keep the page's size. Absent (a bundle without these rules) every fallback
-   reads as 1, today's sizes exactly. file-view-text-size.test.ts pins the table against TEXT_SIZES in both
-   sheets. The measure sits on the root's children, not the root: a table takes the viewer's width when its
-   columns need it (the root is fluid to the body), and a table wider than that scrolls on its own with
-   whole words kept (`overflow-wrap: normal` against the root's `anywhere`, which would crush every column to
-   fit), so the page never widens. Code blocks keep the measure and wrap their long lines (long lines always
-   soft-wrap): a short snippet has no use for a viewer-wide block beside 860px prose. The measure rule is written
-   at ZERO specificity (:where) so a picture's own cap below always beats it: a bare <img> line in a README is a
-   direct child of the root, and a plain :not() chain would tie `.fileview-md img` on specificity and leave the
-   winner to rule order; :where keeps the picture's cap the winner whatever the order, so a wide banner is never
-   laid out at the measure to scroll a narrow viewer sideways. A picture that is itself a block of the page takes
-   the measure AND the column, like an image paragraph (the `.fileview-md > :is(img, svg, canvas, video)` rule). */
+   the prose measure with them (80 of the root's own ch, so the same characters per line at every size; the
+   Rendered markdown block below says how it is laid). Nothing else reads it: the title bar, its buttons and the
+   editor keep the page's size. Absent (a bundle without these rules) every fallback reads as 1, today's sizes
+   exactly. file-view-text-size.test.ts pins the table against TEXT_SIZES in both sheets and measures the layout. */
 .fileview[data-fv-text="70"] { --fv-scale: 0.7; }
 .fileview[data-fv-text="80"] { --fv-scale: 0.8; }
 .fileview[data-fv-text="90"] { --fv-scale: 0.9; }
@@ -3685,31 +3698,60 @@ body.filebrowse-open { overflow: hidden; }
 .fileview[data-fv-text="175"] { --fv-scale: 1.75; }
 .fileview[data-fv-text="200"] { --fv-scale: 2; }
 /* Rendered markdown (the Raw ⇄ Rendered toggle; Rendered is the default — the user 2026-08-09).
-   Typography mirrors the chat's .md block in styles.css, the reference aesthetic (one treatment, two
-   sheets — the .romp-acted precedent); font sizes reuse what this surface already wears (the page base,
-   12px mono, the err-hint's 0.92em). Vars the feed sheet does not define carry the chat's literals as
-   fallbacks (feed-css-vars.test.ts holds that line). */
-/* contain: layout makes .fileview-md the containing block for any fixed or absolutely positioned descendant: an
-   element in a file that reaches `position: fixed` (a class of the page's it happens to wear; the sanitizer drops
-   an inline one) stays inside the note instead of covering the viewer's chrome. Layout only, not paint: the
-   body's vertical scroll is untouched. Content wider than .fileview-md becomes ink overflow the body cannot
-   scroll to, so the media rules below cap an <svg>, <canvas> or <video> at the column as `.fileview-md img`
-   already does, and the table rule below gives a table wider than the column a horizontal scroll of its own.
-   The column is the root's own width, fluid to the viewer: the prose measure sits on the root's children (the
-   text-size block above). Pinned byte-equal in both sheets (fileview-parity.test.ts). */
-.fileview-md { padding: 14px 18px; overflow-wrap: anywhere; font-family: var(--font-prose); font-size: calc(1em * var(--fv-scale, 1)); contain: layout; }
-.fileview-md > :where(:not(table)) { max-width: calc(860px * var(--fv-scale, 1)); }
+   A document's type scale, GitHub's: the prose at 1.15 times the page's size (14.95px at the 13px default) in the
+   document's own face, --font-doc (sans in both themes; --font-prose is the assistant's reading face, mono in the light
+   theme, and a README in mono reads as source); headings 2 / 1.5 / 1.25 / 1em with h5 and h6 dimmed and a rule under h1
+   and h2; a 2em list gutter; fenced code at 12px mono with the chat's per-line rows and Copy button; inline code and kbd
+   at 0.92 and 0.86em; the leading 1.5, declared on the root rather than inherited, since the chat's body is 1.6 and the
+   feed's 1.5, so the same document was a different height on the two surfaces. Vars the feed sheet does not define
+   carry the chat's literals as fallbacks (feed-css-vars.test.ts holds that line). One treatment, two sheets: the
+   .romp-acted precedent; fileview-parity.test.ts pins every head byte-equal.
+   The measure is 80 of the root's own ch, laid as inline padding rounded DOWN to whole pixels (a fractional left edge put
+   the text on sub-pixel positions where a drag selection stayed collapsed), centred, never under 18px; the plain calc()
+   is the fallback for an engine without round(), declared first. It replaces a fixed pixel cap, so the column is the
+   same characters wide at every text size. contain: layout makes the root the containing block for anything inside it
+   (an element in a file that reaches `position: fixed` through a class of the page's it happens to wear, the sanitizer
+   having dropped an inline one, stays inside the note instead of covering the viewer's chrome; layout only, not paint, so
+   the body's vertical scroll is untouched) and turns content wider than the root into ink overflow the body cannot scroll
+   to, so nothing a document carries widens the viewer: the img rule and the media rules below cap a picture, an inline
+   svg, a canvas or a video at the column, and a table wider than the column scrolls on its own (the table rules below).
+   --fv-body-w, the body's content width for a top-level table's cap (below), is registered non-inherited so a write to a
+   table restyles that table alone. */
+@property --fv-body-w { syntax: "*"; inherits: false; }
+.fileview-md { padding: 14px 18px; padding-inline: max(18px, calc((100% - 80ch) / 2)); padding-inline: max(18px, round(down, calc((100% - 80ch) / 2), 1px)); overflow-wrap: anywhere; font-family: var(--font-doc); font-size: calc(var(--fs) * 1.15 * var(--fv-scale, 1)); line-height: 1.5; contain: layout; }
 .fileview-md > :first-child { margin-top: 0; }
 .fileview-md > :last-child { margin-bottom: 0; }
 .fileview-md p { margin: 0.5em 0; }
-.fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4 {
-  font-weight: 600; color: var(--fg); margin: 1em 0 0.4em; line-height: 1.3; }
-.fileview-md h1 { font-size: 1.3em; } .fileview-md h2 { font-size: 1.15em; } .fileview-md h3 { font-size: 1.05em; }
+/* The heading ladder: h1 2em, h2 1.5em, h3 1.25em, h4 1em, h5 and h6 1em in the dim tier, weight 600, a rule under h1 and
+   h2. em of the prose, so the text-size control scales them with it. The margins are 1.5 above and 0.5 below every
+   heading in the PROSE's em whatever the heading's size: a heading's em is its own, so the larger levels divide by their
+   size to land on the same distance. */
+.fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4, .fileview-md h5, .fileview-md h6 {
+  font-weight: 600; color: var(--fg); margin: 1.5em 0 0.5em; line-height: 1.25; }
+.fileview-md h1 { font-size: 2em; margin: calc(1.5em / 2) 0 calc(0.5em / 2); }
+.fileview-md h2 { font-size: 1.5em; margin: calc(1.5em / 1.5) 0 calc(0.5em / 1.5); }
+.fileview-md h3 { font-size: 1.25em; margin: calc(1.5em / 1.25) 0 calc(0.5em / 1.25); }
+.fileview-md h4 { font-size: 1em; }
+.fileview-md h5, .fileview-md h6 { font-size: 1em; color: var(--dim); }
+.fileview-md h1, .fileview-md h2 { padding-bottom: 0.3em; border-bottom: 1px solid var(--box-border); }
 /* a heading an in-document link lands on (scrollIntoView) sits a breath below the title bar's hairline
    rather than flush against it — the bar's own 10px spacing */
 .fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4, .fileview-md h5, .fileview-md h6 { scroll-margin-top: 10px; }
-.fileview-md ul, .fileview-md ol { margin: 0.4em 0; padding-left: 1.4em; }
+.fileview-md ul, .fileview-md ol { margin: 0.4em 0; padding-left: 2em; }
 .fileview-md li { margin: 0.2em 0; }
+/* A task item (`- [ ] ...`): no bullet beside the checkbox (mdBlock stamps GitHub's task-list-item on the li after the
+   sanitize, for a disabled checkbox that is the item's first child, in a paragraph or not), the checkbox pulled into the
+   gutter where the bullet was, drawn for the theme the page wears (--color-scheme; without it a dark page draws a white
+   checkbox). The pull is measured against Chromium's disc, whose centre sits about 7px plus 0.45em before the item's text at
+   every size, and the checkbox is the control's own 13px, declared so the margin can centre it on that point. font-size:
+   inherit makes the em the prose's: a control's own em is the UA's 13.33px, which the text-size control never moves.
+   The size is a rule of its own, for every checkbox under a task item (a nested list's too). 0.2em after the checkbox plus the
+   source's own space puts the text on the plain items' text edge. No accent-color: marked emits every checkbox disabled, and
+   Chromium paints a disabled checkbox grey whatever accent is declared. */
+.fileview-md li.task-list-item { list-style: none; }
+.fileview-md li.task-list-item input { font-size: inherit; }
+.fileview-md li.task-list-item > input[type="checkbox"], .fileview-md li.task-list-item > p:first-child > input[type="checkbox"] {
+  width: 13px; height: 13px; margin: 0 0.2em 0.25em calc(-13px - 0.46em); vertical-align: middle; color-scheme: var(--color-scheme); }
 .fileview-md strong { color: var(--fg); font-weight: 600; }
 .fileview-md em { font-style: italic; }
 .fileview-md a { color: var(--link); text-decoration: none; }
@@ -3722,6 +3764,13 @@ body.filebrowse-open { overflow: hidden; }
   color: var(--code-fg, #e1c08d); background: var(--code-bg, rgba(217, 119, 87, 0.10));
   padding: 0.12em 0.4em; border-radius: 4px;
 }
+/* <kbd>, a key: the settings modal's two tokens (gear.css reads them too), mono at 0.86em, a bottom shadow line for the
+   key's edge. */
+.fileview-md kbd {
+  display: inline-block; padding: 0.1em 0.4em; font-family: var(--mono, ui-monospace, monospace); font-size: 0.86em;
+  line-height: 1.3; color: var(--fg); vertical-align: middle; background: var(--kbd-bg); border: 1px solid var(--kbd-border);
+  border-radius: 3px; box-shadow: inset 0 -1px 0 var(--kbd-border);
+}
 .fileview-md pre {
   background: var(--box-bg, rgba(255, 255, 255, 0.03)); border: 1px solid var(--box-border);
   border-radius: 6px; padding: 11px 14px; margin: 0.6em 0; overflow-x: auto;
@@ -3730,15 +3779,65 @@ body.filebrowse-open { overflow: hidden; }
   background: none; padding: 0; display: block;
   font-family: var(--mono, ui-monospace, monospace); font-size: calc(12px * var(--fv-scale, 1)); line-height: 1.5;
   color: var(--code-fg, #e1c08d); white-space: pre-wrap; overflow-wrap: anywhere;
+  tab-size: 4; counter-reset: ln;   /* tabs as the Raw view shows them (.fileview-pre); the line counter, for every fence (below) */
 }
-/* A table wider than the column (a `nowrap` cell, many columns) scrolls sideways on its own, as on GitHub: a block
-   box shrink-wrapped to its content (width: max-content) and capped at the column, with the overflow scrollable.
-   Under contain: layout the body cannot scroll to what a table lets run past the column, so the table has to.
-   border-collapse is inherited by the anonymous table box the block wraps, so the cell borders still collapse.
-   overflow-wrap: normal keeps whole words against the root's `anywhere`, which would crush every column to fit. */
+/* A fence's per-line rows and Copy button (code-block.ts, the chat's own): .cl is one logical line, .ct its wrapping
+   content, the number a CSS counter in ::before so a soft-wrap reads distinctly from a real newline and the numbers never
+   copy with the code. The counter resets on `.fileview-md pre code` above, not on `code.hljs` as the chat's does: mdBlock
+   wraps EVERY fence, and an unregistered language's fence carries no hljs class, so it would have gone on counting from
+   the block before. The Copy button is parked top-right, faint until the block is hovered, green on success. Scoped
+   copies of the chat's unscoped rules (styles.css), byte-equal in both sheets since the feed page loads only feed.css
+   (fileview-parity.test.ts, code-block.test.ts); the code tint carries the chat's literal as its fallback, since feed.css
+   defines no --code-bg in :root (feed-css-vars.test.ts). The gutter's own line-height is 1 and it never wraps, its basis
+   is 2.5em or the fence's digit count in ch (--ln-digits, written by wrapCodeLines), and the .ct's ::before is a word
+   joiner so a blank line's row is the line-height: the chat's rule says why each. */
+.fileview-md pre code .cl { display: flex; align-items: baseline; }
+.fileview-md pre code .cl::before {
+  counter-increment: ln; content: counter(ln);
+  flex: 0 0 max(2.5em, calc(var(--ln-digits, 0) * 1ch + 0.05em)); margin-right: 0.85em; text-align: right;
+  color: var(--dim); opacity: 0.32; user-select: none; font-size: 0.92em; line-height: 1; overflow-wrap: normal;
+}
+.fileview-md pre code .ct { flex: 1 1 auto; min-width: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
+.fileview-md pre code .ct::before { content: "\2060"; }
+.fileview-md pre.has-copy { position: relative; }
+.fileview-md .code-copy {
+  position: absolute; top: 6px; right: 6px; z-index: 1;
+  font-family: var(--sans); font-size: 11px; line-height: 1; padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--box-border); background: var(--code-bg, rgba(217, 119, 87, 0.10)); color: var(--dim);
+  cursor: pointer; opacity: 0; user-select: none;
+  transition: opacity 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.fileview-md pre.has-copy:hover .code-copy, .fileview-md .code-copy:focus-visible { opacity: 0.9; }
+.fileview-md .code-copy:hover { color: var(--fg); border-color: var(--dim); }
+.fileview-md .code-copy.copied { color: var(--green); border-color: var(--green); opacity: 1; }
+@media (hover: none) { .fileview-md .code-copy { opacity: 0.8; } }   /* touch: no hover state, so keep it visible */
+/* A table is a block as wide as its columns need, scrolling in its own box past its cap, whole words kept (overflow-wrap:
+   normal against the root's anywhere). A table inside a quote or a list item is capped at its container. A table of the
+   page's own (a direct child of the root) is capped at the BODY's width less the root's 18px inset, not the column's:
+   --fv-body-w is the body's content width as its ResizeObserver reports it (file-view.ts watchBodyWidth), written on
+   each top-level table and registered non-inherited above. A table no wider than the column sits at the column's left
+   edge with the prose, as on GitHub; one wider than the column grows out of it EVENLY, into both gutters, until it meets
+   the body's inset: the translate moves it left by half of what it exceeds the column by (a percentage in translate is
+   of the table's own width; half the body less the root's inline padding is half the column, the padding rounded down
+   here as the root rounds it, and the observer's width is the content box the root's 100% is, so the two agree to the
+   pixel; min() holds a narrower table still; the shift is rounded to whole pixels, as the measure is). Scrollable overflow
+   is computed from the transformed box, so the shifted table never makes the body scroll sideways; contain: layout on the
+   root is for anything else wider than the column (a fixed-width svg, an iframe), which it turns into ink overflow the
+   body cannot scroll to. Before the observer's first report, or with no ResizeObserver, the property is unset and both
+   declarations read the same stand-in, 100% plus the inset the cap takes back: the cap is then the column, and in the
+   translate, where 100% is the table's own width, the padding term is under 19px for any table the column holds and
+   rounds down to its 18px floor, so the shift is exactly none. border-collapse is inherited by the anonymous table box the
+   block wraps, so the cell borders still collapse. */
 .fileview-md table { border-collapse: collapse; margin: 0.6em 0; display: block; width: max-content; max-width: 100%; overflow-x: auto; overflow-wrap: normal; }
+.fileview-md > table { max-width: calc(var(--fv-body-w, calc(100% + 36px)) - 36px); translate: min(0px, round(calc(var(--fv-body-w, calc(100% + 36px)) / 2 - max(18px, round(down, (var(--fv-body-w, calc(100% + 36px)) - 80ch) / 2, 1px)) - 50%), 1px)); }
 .fileview-md th, .fileview-md td { border: 1px solid var(--box-border); padding: 4px 10px; text-align: left; }
-.fileview-md th { background: var(--box-bg); }
+.fileview-md th { font-weight: 600; background: var(--overlay-05); }
+.fileview-md tbody tr:nth-child(even) { background: var(--overlay-05); }
+/* marked writes a column's `:---:` / `---:` alignment as the cell's align attribute (DOMPurify keeps it); the rule above
+   overrode the presentational hint, so every cell read left */
+.fileview-md th[align="center"], .fileview-md td[align="center"] { text-align: center; }
+.fileview-md th[align="right"], .fileview-md td[align="right"] { text-align: right; }
+.fileview-md th[align="left"], .fileview-md td[align="left"] { text-align: left; }
 .fileview-md img { max-width: 100%; }
 /* Media a file draws itself (an inline <svg> diagram, a <canvas>, a <video>) fits the column the way an <img> does:
    under contain: layout anything wider than .fileview-md is clipped at the body's edge and unreachable. :where() keeps
@@ -3748,11 +3847,6 @@ body.filebrowse-open { overflow: hidden; }
    the cap and keeps the author's height. */
 :where(.fileview-md) svg, :where(.fileview-md) canvas, :where(.fileview-md) video { max-width: 100%; }
 :where(.fileview-md :is(svg, canvas)[width]:not([width$="%"])) { height: auto; }
-/* a bare top-level medium (an <img> line in a README, an inline <svg>, <canvas> or <video> block: a direct child of
-   the root) takes the measure AND the column, like an image paragraph. Class-and-type specificity, so it outranks
-   both the general caps above and the :where measure; the measure alone (a class) would beat the element-level
-   media cap for a direct child and hold a wide diagram at 860px on a narrower viewer, clipped under contain: layout. */
-.fileview-md > :is(img, svg, canvas, video) { max-width: min(100%, calc(860px * var(--fv-scale, 1))); }
 
 /* ── the viewer's image + PDF bodies (a .png used to open as line-numbered mojibake). The <img>
    wears the lightbox image's own treatment (.romp-lightbox-img: capped, object-fit contain, the
@@ -3764,6 +3858,40 @@ body.filebrowse-open { overflow: hidden; }
 .fileview-img { max-width: 100%; max-height: 82vh; object-fit: contain; border-radius: 8px;
   box-shadow: var(--shadow-modal); }
 .fileview-frame { display: block; width: 100%; height: 100%; border: 0; background: #fff; }
+
+/* ── print (Ctrl/Cmd + P while a rendered file is open): the file alone, black on white, across as many pages as it needs.
+   The dashboard's chrome behind the viewer is left out and the viewer's own title bar and Copy buttons with it; the page
+   and the card go white (both :root and body.fileview-open, so a served page's inline theme cannot paint the canvas grey)
+   and every fixed height and overflow that holds the card to one screen is released, so the document runs on to the
+   next page instead of being cut at the first. Tokens and gutters print in full black in the document and in the Raw
+   view (code.hljs and its spans under the body, the wrap mode's row numbers, the plain gutter); the task checkbox is drawn in
+   the light scheme whatever the page's theme; fills and washes go, borders turn black. A table is laid out as a table
+   again (display: block would let it scroll, and paper does not), and a table of the page's own keeps the screen's room,
+   the body less the root's inset, with the screen's shift into both gutters: the cap and the translate are restated in
+   container units, the body made a size container here (no script runs at print layout, so a unit the sheet resolves is
+   the one that holds). Byte-equal in styles.css and feed.css (fileview-parity.test.ts). */
+@media print {
+  :root, body.fileview-open { height: auto; overflow: visible; background: white; color: black; }
+  body.fileview-open { display: block; }
+  body.fileview-open > :not(#romp-fileview) { display: none; }
+  #romp-fileview { position: static; inset: auto; z-index: auto; display: block; background: none; }
+  .fileview { width: auto; height: auto; display: block; overflow: visible; background: white; color: black; border: 0; border-radius: 0; box-shadow: none; }
+  .fileview-bar, .fileview > .fileview-err, .fileview-md .code-copy { display: none; }
+  .fileview-body { overflow: visible; container-type: inline-size; }
+  .fileview-md, .fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4, .fileview-md h5, .fileview-md h6, .fileview-md strong,
+  .fileview-md blockquote, .fileview-md a, .fileview-md kbd, .fileview-md :not(pre) > code, .fileview-md pre code, .fileview-md pre code span,
+  .fileview-md pre code .cl::before { color: black; }
+  .fileview-md a { text-decoration: underline; }
+  .fileview-md li.task-list-item input[type="checkbox"] { color-scheme: light; }
+  .fileview-md :not(pre) > code, .fileview-md kbd, .fileview-md pre, .fileview-md th, .fileview-md tbody tr:nth-child(even) { background: none; }
+  .fileview-md pre, .fileview-md th, .fileview-md td, .fileview-md hr, .fileview-md blockquote, .fileview-md h1, .fileview-md h2, .fileview-md kbd { border-color: black; }
+  .fileview-md kbd { box-shadow: none; }
+  .fileview-body code.hljs, .fileview-body code.hljs span, .fileview-body .fv-cl::before, .fileview-gutter { color: black; }
+  .fileview-md pre code .cl::before, .fileview-body .fv-cl::before, .fileview-gutter { opacity: 1; }
+  .fileview-gutter { background: none; border-color: black; }
+  .fileview-md table { display: table; width: max-content; overflow: visible; overflow-wrap: anywhere; }
+  .fileview-md > table { max-width: calc(100cqi - 36px); translate: min(0px, round(calc(50cqi - max(18px, round(down, (100cqi - 80ch) / 2, 1px)) - 50%), 1px)); }
+}
 
 /* a MACHINE-sent message's notch (romp injections, ⚙-tagged sends — the same senderKind verdict the
    bubble wears): light gray, visibly quieter than the user's blue, so the scroll map separates "you

--- a/ui/webview/theme-parity.test.ts
+++ b/ui/webview/theme-parity.test.ts
@@ -68,7 +68,8 @@ const PAIRS: Array<[string, string, number]> = [
   ["--hl-kw", "--bg", 4.5],
   ["--hl-str", "--bg", 4.5],
   ["--hl-num", "--bg", 4.5],
-  ["--hl-cmt", "--bg", 3],          // comments are deliberately quiet — the dark set sits just above 3
+  ["--hl-cmt", "--bg", 3],          // comments are deliberately quiet
+  ["--hl-cmt", "--box-bg", 4.5],    // ...but readable on the code block they sit in (the fence's fill is --box-bg over --bg)
   ["--hl-title", "--bg", 4.5],
   ["--hl-meta", "--bg", 4.5],
   ["--hl-attr", "--bg", 4.5],

--- a/ui/webview/viewer-grammars.ts
+++ b/ui/webview/viewer-grammars.ts
@@ -1,0 +1,24 @@
+// Six more grammars for fenced code in a viewed file, beside the ten the chat and the viewer register: rust (alias rs),
+// go (golang), c (h), java, sql, and toml, which highlight.js ships no module for; its ini grammar is "TOML, also INI"
+// and declares the alias, so it is registered under both names. Registered on the bundle's one hljs core by this module,
+// which file-view.ts imports, so the feed bundle gains them through the viewer, and the chat bundle, which imports
+// file-view.ts, gains them too. The chat's auto-detection of an unlabeled fence keeps to its ten (highlight-cache.ts
+// AUTO_LANGUAGES): a chat tail's cost and its guesses do not change, and a fence in a reply labelled `rust` highlights as
+// one. Cost per bundle: about 18 KB minified, 6.5 KB gzipped. Nothing here is a viewer-only name: the aliases are the
+// grammars' own, spelled so `getLanguage("rs")` and `getLanguage("toml")` answer.
+import hljs from "highlight.js/lib/core";
+import rust from "highlight.js/lib/languages/rust";
+import go from "highlight.js/lib/languages/go";
+import c from "highlight.js/lib/languages/c";
+import java from "highlight.js/lib/languages/java";
+import sql from "highlight.js/lib/languages/sql";
+import ini from "highlight.js/lib/languages/ini";
+
+/** The six grammars, by every name a fence may use. */
+export const VIEWER_GRAMMARS: Record<string, unknown> = {
+  rust, rs: rust, go, golang: go, c, h: c, java, sql, ini, toml: ini,
+};
+
+for (const [name, lang] of Object.entries(VIEWER_GRAMMARS)) {
+  try { hljs.registerLanguage(name, lang as any); } catch { /* dup alias */ }
+}


### PR DESCRIPTION
A markdown file opened in the file viewer is set for reading: a document type scale on a centred 80-character measure, every code block numbered and given a Copy button, six more grammars, code comments that clear 4.5:1 on a code block, and a print sheet that prints the file alone. This change is stacked on the text-size control (#1194) and its diff is against that head: the type scale multiplies `--fv-scale`, the property that change introduced, so A+ and A- scale the prose, its headings, its fences and its column together.

## Tier

Tier: feature

## Builds on #1194

Every text size in the rendered document is a multiple of `--fv-scale`, and the measure is 80 of the root's own `ch`, so the two changes are one story for a reader. That change's per-child 860px measure and its top-level picture cap are replaced here by the root's padding (`.fileview-md img { max-width: 100% }` already caps a bare picture at the column once the measure is the root's padding), and its layout test is re-pinned and extended below. Until #1194 merges, this PR shows both commits; the second is this change.

## What changes for a reader

- The rendered document wears a document's type scale: a sans face (`--font-doc`, sans in both themes) at 1.15 times the page's size (14.95px at the default 13px), line-height 1.5, GitHub's heading ladder (2 / 1.5 / 1.25 / 1em, h5 and h6 dimmed, rules under h1 and h2), a 2em list gutter.
- The column is 80 characters of the document's own type, centred, never inset less than 18px; a pane too narrow for it lays the prose at the pane's width.
- A table no wider than the column sits with the prose; a wider one grows evenly into both gutters up to the body's width and scrolls inside itself beyond that; a table inside a quote or a list item keeps the prose width. Headers have a fill, even rows a tint, and a column aligned with `:---:` or `---:` is honoured.
- Task items lose the bullet beside the checkbox, and the checkbox is drawn for the page's theme. A checkbox an author's raw HTML puts after an item's text is left where the file put it, bullet and all. `<kbd>` is styled. Fences take tab-size 4.
- Every code block, labelled or not, has the chat's numbered rows and a Copy button. Copy copies the block as the file holds it: tabs come back as tabs (marked expands a leading tab to four spaces before the rendered text exists).
- Fences labelled rust, go, c, java, sql or toml are highlighted; the code view opens .rs, .go, .c, .h, .java, .sql, .toml and .ini highlighted too.
- Code comments are readable on a code block: `--hl-cmt` rises from 2.85:1 to 4.79:1 (dark) and from 4.39:1 to 4.86:1 (light).
- Ctrl/Cmd + P while a rendered file is open prints the file alone, black on white, across as many pages as it needs, tokens and gutters in full black, tables laid out as tables.

Three chat-visible changes ride along:

- The chat's gutter rule in styles.css changes. Its basis is `max(2.5em, digits in ch)` where it was a fixed 2.3em (the shared module writes `--ln-digits` on the code element, so a 10000-line block's rows share one text column; every chat code block's gutter is about 2px wider at 12px), its line box is `line-height: 1` with `overflow-wrap: normal`, and a blank row keeps its full height (a word joiner in the empty cell, `.ct::before`).
- The chat's code comments recolour with the raised `--hl-cmt`.
- A fence in a reply labelled rust, go, c, java, sql or toml now highlights by name, since the six grammars register on the core the chat bundle carries too; an unlabelled fence is still guessed among the chat's ten.

## Design

- **One shared module.** `wrapCodeLines` and `addCopyBtn` were module-private in render.ts, and file-view.ts cannot import render.ts (render.ts imports it, and the feed bundle must not carry the chat). code-block.ts is their meeting point; both callers use the same two functions and the chat's behaviour is unchanged.
- **`--font-doc` rather than `--font-prose`.** The mono ruling for the light theme was about assistant output; a README in mono reads as source. `--font-prose` is untouched.
- **1.15 and 1.5.** The prose is 1.15 times `--fs`, with line-height 1.5 set on the root, so the same document is the same height over the chat (whose body inherits 1.6) and over the feed (1.5). Inline code stays 0.92em, fenced code 12px, `<kbd>` takes the 0.86em both sheets already use for it elsewhere, and everything else is in em of the prose; the 1.15 factor is the one new constant, in the `.fileview-md` rule.
- **The measure is padding, rounded down.** 80ch as inline padding replaces the 860px cap, so the column is the same characters wide at every text size. The padding is rounded down to whole pixels: a fractional left edge put text on sub-pixel positions where a drag selection stayed collapsed. A plain `calc()` fallback precedes the `round()` form for an engine without it. `contain: layout` on the root turns anything else a document carries that is wider than the column (a fixed-width svg, an iframe) into ink overflow the body cannot scroll to.
- **The body's width is written on the tables.** A top-level table's cap is the body's content width less the root's inset, which the table's own percentages cannot reach (its 100% is the column). A ResizeObserver on the body writes it as `--fv-body-w` on each top-level table after every paint; the property is registered non-inherited with `@property`, so a write restyles the tables alone rather than every node under the body. Before the first report, or without ResizeObserver, the sheet's fallback holds and the cap is the column. The shifted table never scrolls the body: scrollable overflow is computed from the transformed box.
- **The task stamp reads the item's first node.** marked emits a task item's checkbox as the li's first node (inside its first paragraph in a loose list), with no hook on the li, so mdBlock stamps GitHub's `task-list-item` after the sanitize on a disabled checkbox that opens its item. `:first-child` counts elements alone, so the stamp also checks the checkbox has no previous sibling: a checkbox after an item's text keeps its place and its item keeps its bullet.
- **Copy reads the file rather than the DOM.** marked's lexer turns a line's leading tabs into four spaces each before it tokenizes, so the rendered text has spaces where the file has tabs. fence-source.ts maps marked's view of the source back to the file, character by character, and matches each code token's lines in document order; a fence it does not find copies the rendered text as before. Nothing about the parse changes.
- **Space acts on the keydown, and the acknowledgement finds its button by source.** A button's Space activation is native to the keyup, so a re-render between the keydown and the keyup lost the press; Space now acts on the keydown like Enter. The Clipboard API answers asynchronously, and the chat re-renders cards on kernel pushes, so a Copied label written to the pressed node could land on a detached one; the label is written to the button on screen of the fence with the copied source, and a swap inside the window moves it on (a MutationObserver on the ancestors, alive for the 1.2s window). The viewer's fences are replaced only by the reader's own clicks (the Rendered/Raw toggle, Reload), which can still fall between a press and the clipboard's answer.
- **The chat's auto-detection is held to ten.** The six new grammars register on the shared hljs core, which the chat bundle also carries, so `highlightAuto` would otherwise guess among sixteen: slower tails and different guesses. `highlightHtml` passes the chat's ten as a language subset. The six cost about 18 KB minified, 6.5 KB gzipped per bundle.
- **Where the print block sits.** After the viewer's image and PDF rules, in the viewer's own section of each sheet, not at the sheet's end.

Deliberately left out: any change to the chat's `.md` prose rules, to `--font-prose`, or to the Raw view's layout; a task checkbox accent (Chromium paints a disabled checkbox grey whatever accent is declared); a toml grammar of its own (highlight.js ships none; its ini grammar declares the toml alias).

## Tests

Written first; each fails on the sources before this change as noted. The harness has no HTML parser, so mdBlock is not executed under node: its fence pass and task stamp are pinned by source, and the stamp is executed in the browser leg below.

- `ui/webview/code-block.test.ts` (new). Executed over a DOM stand-in: `wrapLinesHtml` rows and the straddling-span rebalance; `wrapCodeLines` writes `--ln-digits`; `addCopyBtn` is idempotent, copies the caller's text on click, falls back to execCommand, acts on Space's keydown once per press, and lands the Copied label on the on-screen button of the fence with the copied source after a swap, by ordinal; the six grammars register with their aliases (against the real hljs); `highlightHtml` passes the ten-name subset. Pinned by source: render.ts and file-view.ts import the module and render.ts keeps no copy; the bundle boundary; mdBlock's fence pass (the language branch is read whole, head to closing brace, and holds neither call; the two calls close the forEach) and its task stamp (the selector, then the first-node check); both sheets' scoped row and Copy rules byte-equal. Before: the test bundle fails to resolve `./code-block` and `./viewer-grammars`.
- `ui/webview/file-view-fence-source.test.ts` (new; over the real marked): `markedView` maps every character; tabs come back at top level, in a list item (the partial tab), in a quote, with CRLF, in an indented block; the renderer's trailing-newline shape; document-order matching; `fenceCopyQueue`; the empty fence. Before: the test bundle fails to resolve `./fence-source`.
- `ui/webview/codeblock-copy.test.ts` and `ui/webview/codeblock-wrap.test.ts` (re-pinned onto code-block.ts and the gutter basis). Before: code-block.ts is absent.
- `ui/webview/file-view.test.ts` (re-pinned, plus two tests). The LANG map row for row, including rs, go, c, h, java, sql, toml and ini; `langFor("src/main.rs")` is rust; the `--hl-cmt` literal; the fence pass shape; the viewer-grammars import. `watchBodyWidth`, executed: lifted from the source (the suite's composerWindow lift) and run over a fake ResizeObserver and stand-in nodes: nothing before the first report; after one, the width on each top-level table and on neither a nested table nor the prose; the returned stamp writes it on a fresh root's tables; a repeated width writes nothing; the last of a callback's entries wins and an empty callback reads the body; the next watch and the drop disconnect; without ResizeObserver nothing is written. The wiring: both viewers watch the body they build, both rendered paints stamp the fresh root, the close drops the watch. Before: LANG lacks the eight rows, `--hl-cmt` is `#6f6a5f`, the fence pass returns on an unnamed fence, and `watchBodyWidth` does not exist.
- `ui/webview/theme-parity.test.ts`: the pair `--hl-cmt` on `--box-bg` at 4.5. Before: 2.85 dark, 4.39 light.
- `ui/webview/fileview-parity.test.ts`: the rule reader pins every occurrence of a head at a line start; the type-scale heads and the whole `@media print` block are added. Before: the heads are absent, and `.fileview-md th {` differs between the two sheets.
- `ui/webview/file-view-text-size.test.ts` (re-pinned): the root's font-size, its padding-inline with the fallback first, the reader list, the heading ladder, `.fileview-md > table`, no 860px anywhere. Its browser leg (headless Chromium through Playwright, skipped where none is installed) measures the 80ch measure and its whole-pixel centring at 1000 and 420px and at 100% and 150%, the even table break-out up to the body, the nested tables' width, the heading ratios, the fence rows (a blank row at full height; a five-digit gutter wider than a one-digit one), the task item's rules, and the print sheet (the bar and the Copy buttons gone, black ink, a white page, a table as a table, the body's overflow visible). A second browser case runs mdBlock's task stamp over marked's own output for a synthetic list (tight, numbered, loose, a raw checkbox opening an item, an author's own class, a checkbox after the item's text, one after bold text, an enabled one), sanitized in the page by DOMPurify with mdBlock's own options and stamped by the statement lifted from mdBlock: the opening checkboxes make task items with no bullet and the box in the gutter; the others leave the item and its bullet as the file wrote them. Before: the layout leg fails on the measure and the ladder; the stamp statement is absent.

Mutations checked red against these tests: the first-node check removed; each of the three width-watch hooks removed; the two fence calls moved inside the language branch; the observer stamping nested tables, dropping its same-width return, not dropping the last watch, and writing before the first report.

Runs on the committed head: `npm run typecheck` clean; `npm test` 3708 passed, 0 failed, with the browser legs running under a local Chromium; `node esbuild.js` builds. The browser leg is the only geometry measurement; CI installs no browser, so it skips there and the sheet pins carry the layout claims.

Restacked onto #1194's rebased head 62b5f6e7 (2026-09-09), which sits on main at 3f06288e. The shared markdown sanitizer that merged in between meets this change in `mdBlock` (the fence collection now feeds `sanitizeMd`, and the body is adopted the way the sanitizer does it) and in both sheets: the sanitizer's `contain: layout`, element-level media caps and table rule are kept, and the parent's top-level media-cap rule is dropped here because the measure is the root's padding, so the element-level caps alone hold a direct-child medium to the column. One sanitizer browser assertion was adapted: a top-level table may grow evenly into both gutters up to the body's 18px inset, as this change's own tests pin; its content still scrolls inside it and the body never scrolls sideways. Full `npm test` on the restacked head: 3790 passing, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
