### PR TITLE
API health indicator: the hover and detail carry a History section read from GET /api-health, and the aggregator owns the boot stamp

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -631,7 +631,11 @@ how many sessions are waiting and names the problem: **rate limited**,
 **overloaded**, **offline** (this machine cannot reach the API), or **errors**.
 Red **paused** means auto-retry and the judges are stopped, and says why: a
 usage limit, the monthly spend cap, or that you stopped them. Hover for the same
-reading with the waiting sessions listed. Click the cell, or press Enter on it,
+reading with the waiting sessions listed, and the history under it: the API's
+state over the last 1, 5 and 15 minutes (attempts, the 429 and 5xx shares,
+give-ups, sessions that retried) and the most recent state changes with how long
+each held. A kernel restart shows as its own line there, because the counts
+start over with the kernel. Click the cell, or press Enter on it,
 for the detail: each waiting session (click one to open that session), a button
 that stops auto-retry for every session while sessions are waiting and resumes
 it while paused, and links to the usage figures and the Log.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -624,3 +624,14 @@ themselves. The analytics modal in settings shows what you actually spent,
 separating your sessions from the judge pipeline. You can also reconfigure the
 judges from the gear: the high-volume indexing tier defaults to Haiku, and the
 judgment tier defaults to Sonnet.
+
+The bottom bar's **API** cell, a dot and a word, shows how the API is treating
+your sessions. Gray **ok** means no session is waiting on the API. Amber shows
+how many sessions are waiting and names the problem: **rate limited**,
+**overloaded**, **offline** (this machine cannot reach the API), or **errors**.
+Red **paused** means auto-retry and the judges are stopped, and says why: a
+usage limit, the monthly spend cap, or that you stopped them. Hover for the same
+reading with the waiting sessions listed. Click the cell, or press Enter on it,
+for the detail: each waiting session (click one to open that session), a button
+that stops auto-retry for every session while sessions are waiting and resumes
+it while paused, and links to the usage figures and the Log.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1141,8 +1141,13 @@ label the account digest itself, so a bucket can be matched to the log.
   is the response time. A clock step moves it; a reader that wants a freshness
   check a clock step cannot fake uses `seq`.
 - `bootId`, `bootAt`, `uptimeS`: the kernel process identity, the same id
-  `/version` and `X-Romp-Boot` carry. A changed `bootId` means a restart, and
-  the windows restarted with it.
+  `/version` and `X-Romp-Boot` carry. `bootAt` is the boot's stamp in this
+  signal: the kernel's start truncated to the millisecond, the precision of
+  every other stamp in the payload, or, when the previous kernel's last
+  transition overlaps the start, one millisecond past that row; every bucket
+  the boot seeded carries this same number as its `stateSince`, and so does
+  every row the boot filed. `/version`'s `started` is the whole-second boot
+  time. A changed `bootId` means a restart, and the windows restarted with it.
 - `complete`: true once the longest window (900 s) fits inside the uptime.
 - `seq`: count of ring events (attempts, successful responses and give-ups)
   ingested since boot. Monotonic within a boot: two reads with the same `seq`
@@ -1366,11 +1371,16 @@ tail, so it stays bounded however many transitions pass; per-request events
 are never written. The event ring itself is in memory only, so a restart
 empties the windows: `seq` restarts at 0, `bootId` changes, `complete` stays
 false until each window fits inside the new uptime, and every bucket the state
-file knows comes back `unknown` with `stateSince` at the boot time. For each
+file knows comes back `unknown` with `stateSince` at the boot's stamp. For each
 bucket whose persisted state was not already `unknown` the reload files
-`<state> -> unknown` at boot, so the transitions list is continuous across the
-restart, and the first read with enough evidence records `unknown -> <state>`
-after it. The pre-restart state is not carried over: an empty ring is no
+`<state> -> unknown` at that stamp, so the transitions list is continuous across
+the restart, and the first read with enough evidence records `unknown -> <state>`
+after it. The boot's stamp is the kernel's start truncated to the millisecond,
+or one millisecond past the newest transition the file carries when that one
+is not before the start (the previous kernel filed it after this one started,
+or the clock stepped), so the restart row is always the newest row; the payload
+serves that stamp as `bootAt`, and the kernel log says when it was moved. The
+pre-restart state is not carried over: an empty ring is no
 evidence. A state file, or an entry in it, that cannot be read is skipped and
 logged, and never keeps the SDK backend from starting.
 
@@ -1429,6 +1439,34 @@ transcripts only. Every timestamp is an event's time, never the clock, so an
 unchanged world sends nothing. On-you failures (a too-long prompt, a spent
 model allowance, a dead credential, a refusal) are not counted; a spend cap is,
 and engages the `spend` pause in the same cycle.
+
+The cell's hover and its click detail carry a **History** section read from
+this signal: the shell fetches `GET /api-health` when the hover or the detail
+opens, and again when a frame lands on an open one, authenticating with the
+dashboard's own cookie the way its other reads do. Nothing polls; the frame
+carries no history and is unchanged. The section shows `overall.state` with
+the worst bucket's `stateSince` and `why` (naming the bucket and the bucket
+count when there is more than one; a bucket the boot seeded is `unknown`
+since `bootAt`: the boot time or, when an older kernel's last row overlaps
+it, one millisecond past that row, because the backend seeds its `stateSince`
+with the stamp it serves as `bootAt`, the one the tail uses for the boot),
+one row per window from `config.windows` (`requests` plus `noStatus` as the
+attempts, saying how many of them had no status when there are any, `rate429`
+and `rate5xx` as percentages over the attempts with a status, `gaveUp`, and
+`sessionsRetrying` as the sessions that retried in the window; a window
+reads `no attempts` only when every one of those is zero; a window whose
+`complete` is false says how long the kernel has been up), up to six rows
+of `transitions` newest first with the state entered and how long it held
+(until the same bucket's next transition, `so far` for the current one; a
+hold from before `bootAt` ends at the boot, since every bucket comes back
+`unknown` at a restart), and the payload's `asOf`. A row the boot filed
+(`<state> -> unknown`, its `why` the restart reason) reads `kernel
+restarted`; where the tail crosses `bootAt` without such a row (the bucket
+was already `unknown` when the previous kernel stopped, so the boot filed
+nothing), a `kernel restarted` divider is inserted, and it takes none of the
+six slots. A read that fails (a non-2xx, no answer, or an answer without
+the signal's shape) shows one line saying so in place of the rows,
+never the previous numbers.
 
 ## Where things live
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1374,6 +1374,62 @@ after it. The pre-restart state is not carried over: an empty ring is no
 evidence. A state file, or an entry in it, that cannot be read is skipped and
 logged, and never keeps the SDK backend from starting.
 
+### The bottom bar's indicator
+
+The dashboard's bottom bar carries an API cell (a dot and a word beside the
+usage readout) that is computed independently of this signal, from two things
+the kernel owns directly:
+
+- Each alive session's newest transcript API-error record, latched until the
+  session produces assistant output again (a user prompt does not clear it,
+  romp's own retry included), plus the live retrying state of SDK sessions.
+- The retry-pause file (`retry-paused.json` under the state directory). A
+  pause writes `paused`, `t` (when it began, the auto-resume floor) and its
+  `reason`: `limit`, `spend`, or none for a manual stop. A spend pause adds
+  `bills`, the billing the capped session was on (`login` or `key`); only
+  fresh assistant output from a session on that billing lifts it. Un-pausing
+  a spend pause, by that lift or by the Resume button, records `liftedAt`
+  (the time of the output record that lifted it, or of the Resume click) and
+  `supersedes` (the floor of the pause it cleared; informational, nothing
+  reads it); both ride every later write until a newer spend un-pause
+  replaces them, and a spend-limit record older than `liftedAt` engages
+  nothing, since the lift already ruled on it. A limit or manual un-pause
+  records neither. A limit pause lifts when the usage report stops naming an
+  account-wide window at 100%, a manual pause when any live session not
+  blocked on an API error writes to its transcript after the pause began.
+  When a limit pause lifts while a spend-limit record is standing, the file
+  reads unpaused for one cycle before the spend pause engages: each writer
+  rules on one signal per cycle, and the spend engage runs before the lift in
+  the pusher's order, so it sees a paused file and rules on the record the
+  next cycle.
+
+The kernel pushes the cell's frame to shell clients only when it changed, and
+again to a shell that sends `ready`:
+
+```json
+{"type": "apiHealth", "state": "ok | degraded | paused",
+ "cls": "429 | 529 | offline | errors | ''", "reason": "'' | limit | spend | manual",
+ "text": "<the rail's words>", "waiting": 0, "retrying": 0, "blocked": 0,
+ "since": 0, "tmux": 0, "seq": 0,
+ "sessions": [{"sid": "", "name": "", "color": null, "kind": "retrying | blocked",
+               "cls": "", "status": null, "since": 0, "suppressed": false}]}
+```
+
+`seq` counts the retry-pause file's writes since the kernel started. A press
+on the detail's pause button writes that file, so the frame that answers the
+press carries a moved `seq` whatever state it brings, and the shell clears
+the button's acknowledgment on it; a frame from before the press carries the
+old one. It is an event counter, not a clock, and restarts at 0 with the
+kernel. `waiting` is `retrying` plus `blocked`. `cls` is the plurality class
+over the affected sessions, ties resolved 429, then 529, then offline, then
+errors. `since` is the pause's time when paused, else the earliest affected
+session's event (a record's timestamp, or the retrying turn's start), else 0.
+`tmux` counts alive tmux-backed sessions, which the cell sees through their
+transcripts only. Every timestamp is an event's time, never the clock, so an
+unchanged world sends nothing. On-you failures (a too-long prompt, a spent
+model allowance, a dead credential, a refusal) are not counted; a spend cap is,
+and engages the `spend` pause in the same cycle.
+
 ## Where things live
 
 State is written under `${XDG_STATE_HOME:-~/.local/state}/romp/`. Transcripts

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14273,7 +14273,17 @@ def _sdk_locked():
                 mcp_config=(str(_SDK_MCP) if _SDK_MCP.exists() else None),
                 append_prompt_path=(str(_SDK_PROMPT) if _SDK_PROMPT.exists() else None),
                 log=lambda m: sys.stderr.write("sdk-backend: %s\n" % m),
-                reconcile=True)   # boot reconcile: reap orphaned CLIs, resume cut turns, deliver persisted queues
+                reconcile=True,   # boot reconcile: reap orphaned CLIs, resume cut turns, deliver persisted queues
+                # the API-health aggregator's boot clock: this kernel's own _STARTED, which the aggregator
+                # truncates to the millisecond (the precision of every stamp in the payload) and serves as
+                # /api-health's bootAt, so a bucket the boot seeded is unknown since the kernel's own start
+                # and the hover's head, divider and restart row name one time (the aggregator's own clock would
+                # run seconds later: this backend is built after the boot's imports, migrations and warm-up).
+                # The float, never int(): truncated to the second boundary BEFORE the process started, the seed
+                # would sort under a row the previous kernel filed in that same second, and the tail would read
+                # the old kernel's last state as current above the restart row. /version's `started` is the
+                # same start in whole seconds.
+                boot_at=_STARTED)
             # a limit-shaped judge error envelope pokes ONE exact usage poll (get_usage rides turn
             # ends, so an idle fleet's usage.json goes stale — measured ~15h — and the rate gate is
             # only as good as that file); the backend picks any live login session to ask
@@ -43642,17 +43652,26 @@ window.addEventListener('message',function(e){var m=e.data;if(m&&m.romp==='usage
 
 # The bottom bar's API health cell: one dot and one word beside the usage readout, painted from the kernel's
 # apiHealth shell push (_api_health_frame), the reading on hover, the detail with its actions pinned on click
-# (or Enter / Space: the cell is a keyboard button). It renders ONLY from the last pushed frame, no fetch, no
-# timer: the frame moves on events, and the cell repaints only when its state or text changed, so the ready
-# re-send of an identical frame cannot pulse it. The detail card is built in the usage tip's grammar and shares
-# its skin (#ah-tip sits beside #ru-tip in every selector) and its backdrop (#ru-back, one modal at a time).
+# (or Enter / Space: the cell is a keyboard button). The cell and the frame's reading render ONLY from the last
+# pushed frame, no fetch, no timer: the frame moves on events, and the cell repaints only when its state or text
+# changed, so the ready re-send of an identical frame cannot pulse it. The hover's History section (the user
+# 2026-09-08, who wanted the cell's hover to carry some history the way the spend hover does) is the ONE read:
+# GET /api-health, the designed signal (docs/reference.md "The API-health signal"), fetched when the hover or the
+# detail opens and again when a frame lands on an open one. The signal derives its state at read time by design,
+# so the read is the observation; the frame stays byte-identical and its dedupe untouched. The detail card is
+# built in the usage tip's grammar and shares its skin (#ah-tip sits beside #ru-tip in every selector) and its
+# backdrop (#ru-back, one modal at a time).
 # The web shell's rail only, for now; the VS Code strip twin (strip.ts apiCell's sibling, with a --st-retrying
 # token) and the phone's Usage-modal section (no rail on the phone) are named follow-ups.
 _LANDING_APIH_JS = """
 (function(){var el=document.getElementById('rail-api');if(!el)return;
 var txt=el.querySelector('.ah-text');
 var tip=document.createElement('div');tip.id='ah-tip';tip.style.display='none';
-tip.setAttribute('role','dialog');tip.setAttribute('aria-label','API health');tip.setAttribute('aria-modal','true');tip.tabIndex=-1;document.body.appendChild(tip);
+tip.setAttribute('role','tooltip');tip.setAttribute('aria-label','API health');tip.tabIndex=-1;document.body.appendChild(tip);
+// what the cell is described by while the hover shows (aria-describedby): a SHORT visually-hidden summary, refreshed
+// when the read lands, never the tip's whole text (the tip runs to hundreds of characters of rows, and at focus time,
+// when assistive tech reads the description, it would be the loader's markup); Enter reaches the rest
+var desc=document.createElement('span');desc.id='ah-summary';desc.className='ah-vh';document.body.appendChild(desc);
 var back=document.getElementById('ru-back');
 if(!back){back=document.createElement('div');back.id='ru-back';document.body.appendChild(back);}
 // LAST: the newest frame. pinned: the detail is the modal. held / dirty: a PRIMARY pointer is down over the detail
@@ -43662,8 +43681,30 @@ if(!back){back=document.createElement('div');back.id='ru-back';document.body.app
 // button. lastX: where the hover anchored, so a re-anchor keeps its place. focusBack: where focus returns when the
 // detail closes.
 var LAST=null,pinned=false,held=false,dirty=false,pending=null,pendSeq=null,hint='',lastX=null,focusBack=null;
+// HIST: the last /api-health answer, {error} for a failed read, null before the first; histSeq keys the paint to the
+// newest read so an older answer landing last is dropped. skipFocus: the dialog's close refocuses the cell, and that
+// focus event must not pop the hover. winFocusEl: the element that held focus when the window's own focus event
+// fired, cleared on the next animation frame (an event, not a timer). When the window regains system focus the
+// browser re-dispatches focus on the active element in that same task (the cell keeps focus after Escape by
+// design), which is not the user reaching for the cell: the cell's focus is skipped only when the cell WAS that
+// element. Chromium fires the same window event whenever the focused FRAME changes, and the shell's panes are
+// iframes, so a Tab out of a pane onto the cell (its keyboard path here) arrives under the mark too; the recorded
+// element is then the document's body (the pane's host is cleared before the event fires), never the cell, and the
+// hover shows. No timer anywhere: the show is the event.
+var HIST=null,histSeq=0,skipFocus=false,winFocusEl=null;
+window.addEventListener('focus',function(){winFocusEl=document.activeElement;requestAnimationFrame(function(){winFocusEl=null;});});
+var RESTART_WHY='kernel restarted: the event ring is empty';   // sdk_backend.API_HEALTH_RESTART_WHY: the row the boot files
+var HIST_ROWS=6;
 function esc(s){return String(s).replace(/[&<>"]/g,function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];});}
 function hm(ep){return new Date(ep*1000).toTimeString().slice(0,5);}
+function hms(ep){return new Date(ep*1000).toTimeString().slice(0,8);}
+// a stamp from another day carries its date (a quiet tail can span days): '09-07 14:02'
+function hmd(ep){var d=new Date(ep*1000),n=new Date();if(d.toDateString()===n.toDateString())return hm(ep);
+return ('0'+(d.getMonth()+1)).slice(-2)+'-'+('0'+d.getDate()).slice(-2)+' '+hm(ep);}
+function dur(s){s=Math.max(0,Math.round(s));if(s<60)return s+' s';var m=Math.round(s/60);if(m<60)return m+' min';
+var h=Math.floor(m/60);m-=h*60;if(h<24)return h+' h'+(m?' '+m+' min':'');var d=Math.floor(h/24);h-=d*24;return d+' d'+(h?' '+h+' h':'');}
+function pct(r){return (r==null?0:Math.round(r*100))+'%';}
+function pl(n,w){n=n||0;return n+' '+w+(n===1?'':'s');}
 // The plain-words pause reasons and the ok line: the kernel's `text` is the headline, these say what it means.
 var PAUSE={limit:'Auto-retry and the judges are paused until your usage limit resets.',
 spend:'Auto-retry and the judges are paused: you have reached the monthly spend limit. Raise it at claude.ai/settings/usage.',
@@ -43685,6 +43726,84 @@ return '<div class="ru-tip-row ah-row'+(full?'':' ah-ro')+'"'+(full?' role=butto
 +(bg?'<i class=ah-sw style="background:'+bg+'"></i><span class=ah-nm style="color:'+bg+'">':'<i class=ah-sw></i><span class=ah-nm>')+esc(r.name)+'</span>'
 +'<span class=ah-desc>'+(r.kind==='retrying'?'retrying':'stopped')+' · '+clsWords(r)+(r.since?' · since '+hm(r.since):'')
 +(r.suppressed?' · auto-retry off for this session (you interrupted it)':'')+'</span></div>';}
+// -- History: GET /api-health at show time. The shell authenticates the way its other fetches do (the romp_token
+// cookie; a same-origin GET sends no Origin, which _origin_ok accepts). A failed read is said in the section, in
+// place of the rows: never stale numbers, never silence. Painted through the same held / dirty gate as a frame.
+// fresh=true (a show) drops the last answer first, so a hover never paints an earlier hover's numbers while its
+// own read is in flight. A frame on an open card re-reads behind the stamped answer the card shows, and a pin from
+// hidden behind the last hover's answer (its as-of says when it was read; the dots only before the first answer):
+// the card the user opened is not blanked for the read's duration, on purpose.
+function load(fresh){var n=++histSeq;if(fresh)HIST=null;
+fetch('/api-health',{cache:'no-store'}).then(function(r){if(!r.ok)throw new Error('HTTP '+r.status);return r.json();})
+.then(function(d){if(n!==histSeq)return;HIST=(d&&d.buckets)?d:{error:'malformed answer'};
+if(tip.style.display!=='block')return;if(held){dirty=true;return;}render();},
+function(e){if(n!==histSeq)return;HIST={error:String((e&&e.message)||e)};
+if(tip.style.display!=='block')return;if(held){dirty=true;return;}render();});}
+// a bucket's name for the card: its model family, plus its auth label when another bucket shares the family
+function bname(d,key){var b=(d.buckets||{})[key]||{},fam=b.family||key.split('|')[1]||key,dup=false;
+Object.keys(d.buckets||{}).forEach(function(k){if(k!==key&&((d.buckets[k]||{}).family||'')===fam)dup=true;});
+return dup?fam+' · '+(b.auth||key.split('|')[0]):fam;}
+// one window row in the spend hover's grammar: the label (with its caveat when the window outreaches the kernel's
+// uptime, the way the rolling month says 'complete since'), then the figures. The figures are the window's totals,
+// said in the window's tense ('retried', never 'retrying': the live set is the Sessions waiting list above).
+// `requests` counts attempts WITH a status and the shares are over it; a connection-level failure has none
+// (`noStatus`, outside that sum), so a window is quiet only when every count is zero, and its no-status attempts
+// are named when there are any (an offline window would otherwise read 'no attempts' and hide its give-ups). A mixed
+// window counts every attempt once and says how many of them had no status, with the shares' base named beside them:
+// '15 attempts, 7 of them without a status · 25% 429 · 0% 5xx of the other 8'.
+function winRow(w,c,up){var lab=(w%60===0?(w/60)+' min':w+' s');if(c&&c.complete===false&&typeof up==='number')lab+=' · kernel up '+dur(up);
+var v,rq=(c&&c.requests)||0,ns=(c&&c.noStatus)||0;if(!c||!(rq||ns||c.gaveUp||c.sessionsRetrying))v='no attempts';
+else{v=rq?(pl(rq+ns,'attempt')+(ns?', '+ns+' of them without a status':'')+' · '+pct(c.rate429)+' 429 · '+pct(c.rate5xx)+' 5xx'+(ns?' of the other '+(rq===1?'one':rq):'')):(pl(ns,'attempt')+' without a status');
+v+=' · '+(c.gaveUp||0)+' gave up · '+pl(c.sessionsRetrying,'session')+' retried';}
+return '<div class="ru-tip-row ah-hrow"><span class=ru-tip-k>'+esc(lab)+'</span><span class=ru-tip-v>'+esc(v)+'</span></div>';}
+// the newest HIST_ROWS transitions, newest first: the time, the state entered (with its bucket when there are
+// several), and how long it held (until the same bucket's next transition; 'so far' for the current one, a flag and
+// never a stamp comparison: the transition the hover's own read files carries that read's asOf as its time, and the
+// state it closed must not read 'so far' beside it). A row the boot filed says so; where the tail crosses this
+// kernel's bootAt with no such row shown above the crossing (the bucket was already unknown at shutdown, so the boot
+// filed nothing), a divider names the restart, and takes no slot: the cap counts transitions. Any restart row above
+// suppresses it, not only the one right above, so one restart is one mark whatever sits between. bootAt is the
+// backend's own seed stamp (the start to the millisecond, or one millisecond past a row the previous kernel filed at
+// or after it), so every restored row is before it and the restart rows sit at it. Every bucket comes back unknown
+// at a restart, so a hold from before the boot ends at the boot and is never 'so far'; a bucket the boot seeded
+// carries that same boot clock as its stateSince, so the head and the tail name one time. Never hidden.
+function transRows(d){var rows=(d.transitions||[]).slice().sort(function(a,b){return b.t-a.t;});
+var multi=Object.keys(d.buckets||{}).length>1,now=d.asOf,boot=d.bootAt,hasBoot=typeof boot==='number',out='',crossed=false,sawRestart=false,shown=0;
+for(var i=0;i<rows.length&&shown<HIST_ROWS;i++){var r=rows[i],restart=r.why===RESTART_WHY,pre=hasBoot&&r.t<boot;
+if(!crossed&&pre){crossed=true;
+if(!sawRestart){out+='<div class="ru-tip-row ah-hrow ah-boot"><span class=ru-tip-k>'+hmd(boot)+'</span><span class=ah-hword>kernel restarted</span></div>';}}
+var end=now,cur=true;for(var j=i-1;j>=0;j--)if(rows[j].bucket===r.bucket){end=rows[j].t;cur=false;break;}
+if(pre&&end>boot){end=boot;cur=false;}
+var word=(multi?bname(d,r.bucket)+' ':'')+r.to+(restart?' · kernel restarted':'');
+out+='<div class="ru-tip-row ah-hrow"><span class=ru-tip-k>'+hmd(r.t)+'</span><span class=ah-hword>'+esc(word)+'</span><span class=ru-tip-v>'+dur(end-r.t)+(cur?' so far':'')+'</span></div>';
+if(restart)sawRestart=true;shown++;}
+return out;}
+function histHTML(){var h='<div class="ru-tip-win ah-hist"><div class=ru-tip-name><span>History</span>'
++((HIST&&!HIST.error&&typeof HIST.asOf==='number')?'<span class=ru-tip-reset>as of '+hms(HIST.asOf)+'</span>':'')+'</div>';
+if(!HIST)return h+'<div class="rl-dots ah-wait"><i></i><i></i><i></i></div></div>';
+if(HIST.error)return h+'<div class="ah-line ah-err">Could not read the API history: '+esc(HIST.error)+'</div></div>';
+var d=HIST,ov=d.overall||{},key=ov.worstBucket,b=key?(d.buckets||{})[key]:null,nb=Object.keys(d.buckets||{}).length,st=ov.state||'unknown';
+// since is the bucket's stateSince as the backend files it: a bucket the boot seeded is unknown since the kernel's
+// own start (SdkBackend seeds the aggregator with the boot clock the payload serves as bootAt), so the head, the
+// tail's divider and the boot's row name one time with no branch here
+var since=b?b.stateSince:0;
+h+='<div class="ru-tip-row ah-head"><i class=ah-dot data-state='+esc(st)+'></i><span class=ah-word>'+esc(st)+'</span>'
++((nb>1&&b)?'<span class=ah-hsub>'+esc(bname(d,key))+' · worst of '+nb+' buckets</span>':'')
++(since?'<span class=ah-since>since '+hmd(since)+'</span>':'')+'</div>';
+if(b&&b.why)h+='<div class="ah-line ru-tip-reset">'+esc(b.why)+'</div>';
+if(!b)h+='<div class=ah-line>No API traffic seen'+(typeof d.bootAt==='number'?' since the kernel started at '+hmd(d.bootAt):' yet')+'.</div>';
+else ((d.config&&d.config.windows)||[60,300,900]).forEach(function(w){h+=winRow(w,(b.windows||{})[String(w)],d.uptimeS);});
+var tr=transRows(d);if(tr)h+='<div class="ru-tip-name ah-hname"><span>State changes</span></div>'+tr;
+return h+'</div>';}
+// the cell's description while the hover shows: the state word and its since, then how to reach the rest. Before the
+// answer lands it carries the state word the frame already put on the cell (assistive tech reads the description once,
+// at focus time, and the landed text replaces it with nothing to announce the change: a loading line with no state
+// word would leave a screen-reader user with none) and says the read is in flight; the landed line adds the since; a
+// failed read says so in the same words as the section's line
+function descText(){var tail=' Press Enter to open it.';if(!HIST)return 'History: '+((LAST&&LAST.text)||'unknown')+'. Reading the details.'+tail;
+if(HIST.error)return 'Could not read the API history: '+HIST.error+'.'+tail;
+var ov=HIST.overall||{},key=ov.worstBucket,b=key?(HIST.buckets||{})[key]:null;
+return 'History: '+(ov.state||'unknown')+((b&&b.stateSince)?' since '+hmd(b.stateSince):'')+'.'+tail;}
 // full=false is the HOVER: the same reading with no controls. The hover sits under pointer-events:none and hides
 // on mouseleave, so a button there could not be honored; the click is where the actions live.
 function html(m,full){var h='<div class=ru-tip-win><div class=ru-tip-name><span>API · this machine</span></div>'
@@ -43697,40 +43816,69 @@ h+='</div>';
 var rows=m.sessions||[];
 if(rows.length){h+='<div class=ru-tip-win><div class=ru-tip-name><span>Sessions waiting</span></div>';
 rows.forEach(function(r){h+=rowHTML(r,full);});h+='</div>';}
+h+=histHTML();
 if(m.tmux>0)h+='<div class="ru-tip-win ah-line">'+(m.tmux===1?'1 tmux session is seen through its transcript only':m.tmux+' tmux sessions are seen through their transcripts only')
 +', so a retry in progress there shows only when it fails or recovers.</div>';
 if(full)h+='<div class="ru-tip-row ah-foot"><span class=ah-link role=button tabindex=0 data-act=usage>Usage and spend</span><span class=ah-link role=button tabindex=0 data-act=log>Log</span></div>';
 return h;}
-// The hover anchors above the rail, centered on the cursor, exactly as the usage tip's showTip does; a re-render
-// re-anchors from the same x, since new rows change the height and the tip hangs ABOVE the rail.
+// The hover anchors above the rail, centered on the cursor, as the usage tip's showTip does; a re-render re-anchors
+// from the same x, since new rows change the height and the tip hangs ABOVE the rail. Measured AFTER a reset: a
+// fixed element's shrink-to-fit width is taken against where it last sat, so a tip measured at its old left comes
+// out narrower than its rows and sits flush with the viewport's edge (at 830 px wide: a wrapped row and no margin).
+// The height is capped to the room above the rail (6 px margin, 8 px gap; #ah-tip clips), so a short window clips
+// the section's oldest rows instead of clamping the top to 6 and spilling over the rail and the cell; open() clears
+// the cap, and the pinned card keeps .ru-modal's own scroll pane.
 function anchor(){var r=el.getBoundingClientRect();var x=(typeof lastX==='number')?lastX:(r.left+r.width/2);
-tip.style.left=Math.max(6,Math.min(window.innerWidth-tip.offsetWidth-6,x-tip.offsetWidth/2))+'px';
-tip.style.top=Math.max(6,r.top-tip.offsetHeight-8)+'px';}
+tip.style.left='0px';tip.style.top='0px';tip.style.maxHeight=Math.max(0,r.top-14)+'px';
+var w=tip.offsetWidth,h=tip.offsetHeight;
+tip.style.left=Math.max(6,Math.min(window.innerWidth-w-6,x-w/2))+'px';
+tip.style.top=Math.max(6,r.top-h-8)+'px';}
 // A re-render replaces the card's nodes, so a focused control would fall to the page body and the next Tab would
 // leave the dialog: the same control (by act and sid) takes focus again in the new markup, else the card does.
 function focusKey(n){return (n&&n.getAttribute)?(n.getAttribute('data-act')||'')+'|'+(n.getAttribute('data-sid')||''):'';}
 function render(){if(!LAST)return;var a=document.activeElement,key=(pinned&&a&&a!==tip&&tip.contains(a))?focusKey(a):null;
-tip.innerHTML=html(LAST,pinned);if(!pinned)anchor();
+tip.innerHTML=html(LAST,pinned);if(!pinned)anchor();desc.textContent=descText();
 if(key!==null){var n=null,all=tip.querySelectorAll('[data-act]');for(var i=0;i<all.length;i++)if(focusKey(all[i])===key){n=all[i];break;}
 try{if(n)n.focus();if(!n||document.activeElement!==n)tip.focus();}catch(e){}}}
+// The shown, unpinned tip is a TOOLTIP (the role, the cell described by the short summary, no aria-modal): a keyboard
+// user who Tabs onto the cell must not meet a modal dialog their focus sits outside of. open() makes it the dialog.
 function show(ev){if(!LAST)return;lastX=(ev&&typeof ev.clientX==='number')?ev.clientX:null;
-tip.classList.remove('ru-modal');tip.style.display='block';render();}
-function close(){tip.style.display='none';tip.classList.remove('ru-modal');back.classList.remove('on');pinned=false;
+tip.classList.remove('ru-modal');tip.setAttribute('role','tooltip');tip.removeAttribute('aria-modal');
+tip.style.display='block';el.setAttribute('aria-describedby','ah-summary');load(true);render();}
+function hide(){tip.style.display='none';el.removeAttribute('aria-describedby');}
+function close(){hide();tip.classList.remove('ru-modal');back.classList.remove('on');pinned=false;
 window.__rompApiClose=null;if(back.onclick===close)back.onclick=null;
-var fb=focusBack;focusBack=null;try{(fb&&fb.focus?fb:el).focus();}catch(e){}}
+// the refocus fires the cell's focus event, which would pop the hover right after Escape: skipFocus covers that one
+// call (the handler runs synchronously inside .focus(), so the flag is reset as soon as the call returns)
+var fb=focusBack;focusBack=null;skipFocus=true;try{(fb&&fb.focus?fb:el).focus();}catch(e){}skipFocus=false;}
 // A click PINS the detail as a centered modal over the dimmed dashboard (the usage modal's own backdrop and
 // pattern); Escape lands via _LANDING_ESC_JS (shell AND pane documents), the backdrop tap closes too. An open
 // usage modal is closed FIRST, explicitly: the two share #ru-back, and its one handler must belong to one modal.
-// Focus moves into the detail and comes back to the cell (or wherever it was) on close.
+// Focus moves into the detail and comes back to the cell (or wherever it was) on close. A pin reads only when the
+// tip was hidden: a hover's read, landed or in flight, is this same document, so a click after the pointer's
+// mouseenter (or a tap after its compat mouseenter) costs one read and keeps its answer.
 function open(){if(!LAST)return;try{window.__rompUsageClose&&window.__rompUsageClose();}catch(e){}
-focusBack=document.activeElement;pinned=true;tip.classList.add('ru-modal');tip.style.left='';tip.style.top='';
+var was=tip.style.display==='block';
+focusBack=document.activeElement;pinned=true;tip.classList.add('ru-modal');tip.style.left='';tip.style.top='';tip.style.maxHeight='';
+tip.setAttribute('role','dialog');tip.setAttribute('aria-modal','true');el.removeAttribute('aria-describedby');
 tip.style.display='block';render();back.classList.add('on');
-window.__rompApiClose=close;back.onclick=close;try{tip.focus();}catch(e){}}
+window.__rompApiClose=close;back.onclick=close;try{tip.focus();}catch(e){}if(!was)load();}
 // The listeners sit on the STABLE #rail-api cell; __rompApiHealth writes its children, never the cell.
-el.addEventListener('mouseenter',function(ev){if(!pinned)show(ev);});
-el.addEventListener('mouseleave',function(){if(!pinned)tip.style.display='none';});
+// a pointer arriving on a tip that focus already shows re-anchors it from the pointer and keeps its rows: the
+// document did not change, so no re-read and no flash to the loader's dots
+el.addEventListener('mouseenter',function(ev){if(pinned)return;
+if(tip.style.display==='block'){if(typeof ev.clientX==='number')lastX=ev.clientX;anchor();return;}show(ev);});
+el.addEventListener('mouseleave',function(){if(!pinned)hide();});
+// keyboard focus shows the hover as the pointer does (the tooltip pattern) and blur hides it; a pinned detail is
+// unmoved, a hover the pointer already opened is left where it anchored, and a focus the browser re-dispatches
+// because the window regained focus while the cell already held it (winFocusEl) is not the user reaching for the cell
+el.addEventListener('focus',function(){if(skipFocus||winFocusEl===el||pinned||tip.style.display==='block')return;show(null);});
+el.addEventListener('blur',function(){if(!pinned)hide();});
 el.addEventListener('click',function(){if(pinned)close();else open();});
-el.addEventListener('keydown',function(ev){if(ev.key==='Enter'||ev.key===' '){ev.preventDefault();if(pinned)close();else open();}});
+// Escape on the focused cell dismisses the hover that focus showed, without moving focus (content shown on focus
+// must be dismissible in place); the pinned dialog's Escape lands via _LANDING_ESC_JS, inert while no modal is on
+el.addEventListener('keydown',function(ev){if(ev.key==='Escape'){if(!pinned&&tip.style.display==='block'){ev.preventDefault();hide();}return;}
+if(ev.key==='Enter'||ev.key===' '){ev.preventDefault();if(pinned)close();else open();}});
 // Click-safe across a frame (ui/CLAUDE.md): a frame that lands while a pointer is DOWN over the detail is painted
 // on release, never under the press, so the pressed button survives to its click. A PRIMARY release inside the
 // detail is followed by the click, so the flush waits for it (a swap between mouseup and click would detach the
@@ -43795,6 +43943,7 @@ if(pending!==null&&(m.seq==null||m.seq!==pendSeq))pending=null;
 if(el.hidden)el.hidden=false;   // the first frame reveals the cell (a kernel that sends none shows nothing)
 if(el.getAttribute('data-state')!==m.state||txt.textContent!==m.text){el.setAttribute('data-state',m.state);txt.textContent=m.text;el.setAttribute('aria-label','API '+m.text);}
 if(tip.style.display!=='block')return;   // an open detail re-renders from the new frame, nothing else does
+load();   // and re-reads the history: the world changed
 if(held){dirty=true;return;}render();};
 })();
 """
@@ -45831,8 +45980,20 @@ def _landing():
             # a failed send's reason, under the button it restored; the hover's rows carry no action (.ah-ro),
             # so no pointer and no hover wash; the pinned detail takes focus as a dialog without a ring on the card
             ".ah-hint{margin-top:4px;opacity:.75;max-width:340px}"
+            # the History section: the signal's state dot in status hexes (never the accent), the transition rows'
+            # state word, the restart divider in italics, a failed read in a red that reads (#ef6b6f, about 5.5:1 on
+            # the tip: the API-error red #e5484d is 4.3:1 there, under the 4.5:1 text floor), and the loader's dots
+            # (.rl-dots, _LOADER_CSS) while the first answer is in flight. The hover clips at the height anchor()
+            # caps it to (the room above the rail): border-box, so the cap is the outline the user sees and not the
+            # content plus 18 px of padding and border; .ru-modal's own overflow-y:auto outranks the clip on the
+            # pinned card, which scrolls as before.
+            ".ah-dot[data-state=thrashing]{background:#e5484d;opacity:1}.ah-dot[data-state=recovering]{background:#e67e22;opacity:.7}"
+            ".ah-hword{opacity:.8}.ah-hsub{opacity:.55}.ah-boot .ah-hword{font-style:italic;opacity:.6}"
+            ".ah-hname{margin-top:6px}.ah-err{color:#ef6b6f}.ah-wait{margin:5px 0 2px}"
             ".ah-row.ah-ro{cursor:default}.ah-row.ah-ro:hover{background:transparent}"
-            "#ah-tip:focus{outline:none}"
+            "#ah-tip:focus{outline:none}#ah-tip{overflow:hidden;box-sizing:border-box}"
+            # the cell's short description for assistive tech (#ah-summary): present in the tree, off the screen
+            ".ah-vh{position:absolute;width:1px;height:1px;margin:-1px;padding:0;border:0;overflow:hidden;clip:rect(0 0 0 0);clip-path:inset(50%);white-space:nowrap}"
             # ONE shared hover panel for BOTH windows (the user 2026-06-26): it reproduces exactly the used/
             # elapsed bars that used to sit under the timeline — per window, a "used" bar (selected colormap)
             # over an "elapsed" bar (slate) with the % + reset countdown, and nothing else (no prose).
@@ -46243,7 +46404,13 @@ def _landing():
             # bare `body.theme-light .ah-dot` (0,2,1) would outrank the detail's `.ah-dot[data-state=...]`
             # state rules (0,2,0), and the card's headline dot would lose its amber and red in the light
             # theme while the rail's id-scoped dot kept them
-            "body.theme-light #rail-api[data-state=ok] .ah-dot,body.theme-light .ah-dot[data-state=ok]{background:#5D574E}"
+            # and the History head's dot for the signal's quiet states (healthy, unknown) is the same glyph: the base
+            # gray falls to about 1.6:1 on the white tip too
+            "body.theme-light #rail-api[data-state=ok] .ah-dot,body.theme-light .ah-dot[data-state=ok],"
+            "body.theme-light .ah-dot[data-state=healthy],body.theme-light .ah-dot[data-state=unknown]{background:#5D574E}"
+            # the failure line in the light theme's error-text red (styles.css --err #B02A1C, about 6.6:1 on white;
+            # the dark line's #ef6b6f is 3.0:1 there)
+            "body.theme-light .ah-err{color:#B02A1C}"
             "body.theme-light #rail-api[data-state=ok] .ah-text{color:#5D574E}"
             "body.theme-light .ah-word{color:#1F1E1D}"
             "body.theme-light .ah-btn{background:#F1EAE2;border-color:rgba(0,0,0,0.12);color:#1F1E1D}"
@@ -47342,7 +47509,14 @@ class Handler(BaseHTTPRequestHandler):
                 now = time.time()
                 out = fn(now, uptime_s=now - _STARTED)
                 out["bootId"] = _BOOT_ID
-                out["bootAt"] = int(_STARTED)
+                # bootAt rides the snapshot: the aggregator's boot_stamp, this kernel's _STARTED (passed at
+                # construction, _sdk_locked) truncated to the millisecond, the precision of every other stamp
+                # in the payload (asOf, transitions[].t, stateSince), or one millisecond past the newest
+                # transition the previous kernel left when that overlaps the start. The aggregator owns the
+                # number, so a bucket the boot seeded carries it as its stateSince and the restart row's t in
+                # every case, clamp or not (a stamp made here would be a second number whenever the clamp
+                # fired). /version's `started` is int(_STARTED), the same start in whole seconds:
+                # int(bootAt) == started unless the clamp moved the stamp.
                 # coverage's kernel half: tmux-backed sessions have no SDK stream and sit outside
                 # the signal — the count says how much of the machine the signal does not see. A null
                 # (never a silent 0) when the live enumeration fails. Codex-backed sessions are outside

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7770,23 +7770,72 @@ def _retry_paused_on():
         return False
 
 
-def _set_retry_paused(paused, reason=""):
+# How many times this kernel wrote the pause file since boot: the apiHealth frame's `seq`. A press on the
+# bottom bar's detail pause button writes the file, and the frame that follows carries a moved seq even when
+# the cycle's auto-pause re-engaged the same state within the same second, so the shell can tell the frame
+# that answers its press from one that predates it (_LANDING_APIH_JS pendSeq). An event counter, never a
+# clock: two cycles over an unwritten file read the same seq.
+_RETRY_PAUSE_SEQ = [0]
+
+
+def _set_retry_paused(paused, reason="", bills="", lifted_at=None):
     # Record WHEN a pause began: the auto-resume floor. Only a successful response AFTER this instant proves
     # the API recovered (an old success from before the outage doesn't). No `t` when un-pausing.
     # `reason` (the user 2026-07-14): "spend" when a monthly spend cap auto-engaged the pause, so the card
-    # shows "raise your cap" instead of a reset countdown; "" for a manual Stop or a rate-window pause.
+    # shows "raise your cap" instead of a reset countdown; "limit" when an account-wide usage window did, so
+    # the bottom bar's API cell can name it without a clock comparison; "" for a manual Stop.
+    # `bills`: for a spend pause, the billing the capped session was on, "login" or "key" (_bills_login of its
+    # live row). The lift rule reads it (_auto_resume_retry): a cap is on ONE account, so only a session on
+    # that billing can show it serving again.
+    # `liftedAt` / `supersedes`: un-pausing a SPEND pause, by the lift rule or by the user's Resume, records
+    # the time of the EVIDENCE that lifted it and the floor (`t`) of the pause it cleared. That is the spend
+    # engage's stand-down rule (_spend_capped_session): a spendLimit record older than liftedAt was already
+    # outranked by the evidence that lifted the pause, and romp never clears such a record on its own (a spend
+    # cap is on-you: _fire_api_retry sends no retry; only a human prompt to the capped session clears
+    # _api_error), so re-engaging on it put the pause back the cycle after every lift, alternating at the
+    # streaming session's output cadence and settling ON once it idled. The memory rides every later write,
+    # paused or not, until a newer spend ruling replaces it: a limit pause that engages and lifts in between
+    # must not forget it. A limit or manual pause's un-pause records nothing (its evidence, the usage report
+    # or a transcript mtime, says nothing about a spend record), and an un-pause over an already-unpaused
+    # file keeps what it finds (the write moves seq only).
+    # `lifted_at` is the evidence's own time: for the lift rule, the `t` of the assistant output record that
+    # lifted the pause (_api_last_output_t), NOT the lift cycle's clock. The cycle runs up to a pusher period
+    # after the output, and a record from a SECOND capped session written in that gap (after the output,
+    # before the cycle) is new information the lift never saw; stamped with the cycle's time, the floor would
+    # have skipped it until that session's next attempt. The user's Resume passes none and records its own
+    # instant: the gesture is the evidence, and a record stamped in the same second reads as older (the CLI
+    # stamps whole seconds) and waits for that session's next attempt, since re-engaging over the gesture
+    # would be the worse error. `supersedes` is informational (the Log and a hand read of the file): nothing
+    # reads it.
+    try:
+        prev = json.loads((jd.STATE / "retry-paused.json").read_text())
+        if not isinstance(prev, dict):
+            prev = {}
+    except Exception:
+        prev = {}
     d = {"paused": bool(paused)}
     if paused:
         d["t"] = time.time()
         if reason:
             d["reason"] = reason
+        if bills:
+            d["bills"] = bills
+    elif prev.get("paused") and prev.get("reason") == "spend":
+        d["liftedAt"] = float(lifted_at) if lifted_at else time.time()
+        d["supersedes"] = float(prev.get("t") or 0)
+    if "liftedAt" not in d and prev.get("liftedAt"):
+        d["liftedAt"] = prev["liftedAt"]
+        d["supersedes"] = prev.get("supersedes", 0)
+    _RETRY_PAUSE_SEQ[0] += 1
     _atomic_write(jd.STATE / "retry-paused.json", json.dumps(d))
     _mark_views_dirty()   # the queued bubble renders this hold; every writer publishes the flip (review 2026-09-05)
 
 
 def _retry_pause_reason():
-    """Why the current global pause engaged ("spend" for a monthly spend cap), or "" (manual / rate
-    window). Rides the globalRetryPaused push so the card can name the cause."""
+    """Why the current global pause engaged ("spend" for a monthly spend cap, "limit" for a usage window),
+    or "" (manual). Rides the globalRetryPaused push so the card can name the cause; the API health frame
+    reads it too. A pause file written for a limit before the reason was recorded carries none and reads
+    manual."""
     try:
         return str(json.loads((jd.STATE / "retry-paused.json").read_text()).get("reason") or "")
     except Exception:
@@ -7799,6 +7848,42 @@ def _retry_pause_ts():
         return float(json.loads((jd.STATE / "retry-paused.json").read_text()).get("t") or 0)
     except Exception:
         return 0.0
+
+
+def _retry_pause_bills():
+    """Which billing the session that engaged the current SPEND pause was on, "login" or "key", or "" when
+    the file records none (a limit or manual pause, or a spend pause written before the billing was
+    recorded). _auto_resume_retry's spend rule reads it; "" there takes any session's fresh output."""
+    try:
+        return str(json.loads((jd.STATE / "retry-paused.json").read_text()).get("bills") or "")
+    except Exception:
+        return ""
+
+
+def _retry_pause_lifted_at():
+    """The time of the evidence that last un-paused a SPEND pause (the output record that lifted it, or the
+    user's Resume), or 0 when none is on record. The spend engage's stand-down floor: a spendLimit record
+    older than this was already outranked (_spend_capped_session). Survives later pauses and lifts of other
+    reasons (_set_retry_paused carries it). Assumes a monotone wall clock, as the pause floor `t` does: after
+    a backward clock step a record stamped in the corrected clock reads as older than the lift until the
+    clock passes it, and the lift rule's own `out_t > t` is suppressed the same way. Clamping this to now
+    would not help: every record's stamp is at or before now, so a record is older than min(liftedAt, now)
+    exactly when it is older than liftedAt. Only the record's identity, not its stamp, could order it against
+    the lift across a step."""
+    try:
+        return float(json.loads((jd.STATE / "retry-paused.json").read_text()).get("liftedAt") or 0)
+    except Exception:
+        return 0.0
+
+
+def _account_limited():
+    """The ACCOUNT-WIDE usage windows the report says are at 100% with their reset still ahead: the 5h and
+    7d keys of _usage().limited, never fable (model-scoped). The ONE authority for the limit pause's two
+    edges: _auto_pause_on_limit engages while this is non-empty and _auto_resume_retry lifts once it is
+    empty, so the pause holds exactly as long as the report says the limit does and lifts at the reset with
+    no session having to serve first. Raises what _usage raises; both callers treat no reading as no change."""
+    lim = (_usage() or {}).get("limited") or {}
+    return [k for k, v in lim.items() if v and k != "fable"]
 
 
 def _retry_resume_at():
@@ -7846,8 +7931,9 @@ def _auto_pause_on_limit():
     """Hitting an ACCOUNT-WIDE usage limit (5h Session or 7d Weekly at 100%) auto-engages the global retry-pause
     (the user 2026-07-01): retrying into a rate-limited account just burns failed requests, so stop the
     auto-retry AND the judges (both gate on this flag) until the window resets. _auto_resume_retry clears it the
-    moment a session serves a request again — which, while the account is genuinely limited, can't happen, so
-    the pause holds exactly as long as the limit does. Idempotent: only writes when it isn't already paused.
+    cycle the same report stops naming a limited window (the reset passed, or a fresh reading came in under
+    100%: _account_limited is the one authority for both edges), so the pause holds exactly as long as the
+    report says the limit does. Idempotent: only writes when it isn't already paused.
 
     Fable-5 is DELIBERATELY excluded (the user 2026-07-03): its window is MODEL-scoped (the included Fable-5
     weekly allowance), not account-wide, so exhausting it does NOT stop the account from serving the models romp
@@ -7858,29 +7944,46 @@ def _auto_pause_on_limit():
     'distilling', no background/summary). A Fable-only session that hits the wall is surfaced per-session
     (api-error → blocked), which is where a model-scoped limit belongs. fable=100% no longer lights the top
     banner either (the user 2026-07-04: it popped every refresh for the 7-day window and wasn't actionable) —
-    only the rail's passive third bar shows it (see _usage().limited); it pauses nothing and warns nothing."""
+    only the rail's passive third bar shows it (see _usage().limited); it pauses nothing and warns nothing.
+
+    No stand-down is needed on this edge: both edges read the report, so a re-engage after a lift needs a
+    reading that names a window again, never a record the lift already outranked. The spend twin acts on a
+    transcript record that outlives its lift, and stands down on it (_spend_capped_session's `after`)."""
     try:
-        u = _usage()
+        account = _account_limited()                     # 5h / 7d only: fable is model-scoped
     except Exception:
         return
-    lim = (u or {}).get("limited") or {}
-    account = [k for k, v in lim.items() if v and k != "fable"]     # 5h / 7d only — fable is model-scoped
     if account and not _retry_paused_on():
-        _set_retry_paused(True)
+        _set_retry_paused(True, reason="limit")     # latched at the event: the API cell's 'paused, usage limit'
+        #                                               (not re-derived from _retry_resume_at's clock compare)
         sys.stderr.write("retry-pause: auto-engaged — usage limit reached (%s) → auto-retry + judges paused until reset\n"
                          % ",".join(account))
         # no inline push: _set_retry_paused marked the views dirty and woke the pusher, whose next cycle
         # carries the flip in its globalRetryPaused frame (see _auto_resume_retry)
 
 
-def _spend_capped_session(now, tmux):
-    """The first alive session sitting blocked on a MONTHLY SPEND CAP error, or None. Account-wide by
-    nature (the cap is on the account, so every session hits it), so one is enough to pause everything."""
+def _spend_capped_session(now, tmux, after=0):
+    """The first alive session sitting blocked on a MONTHLY SPEND CAP error whose record is not older than
+    `after`, or None. Account-wide by nature (the cap is on the account, so every session hits it), so one is
+    enough to pause everything. `after` is the last spend lift's instant (_retry_pause_lifted_at): a record
+    written before it was already outranked by the output that lifted the pause (or by the user's Resume), and
+    a writer whose evidence predates the ruling stands down. A record at or after it is new information and
+    engages again. Compared as they are, no truncation: `after` is the lifting output's own `t` for the lift
+    rule (whole seconds, the CLI's stamp, like the record's), so a record in the same second as that output
+    reads as new, and the record that engaged the pause never ties (it predates the pause floor, which the
+    output postdates). Truncating both sides to whole seconds against a liftedAt stamped with the lift
+    CYCLE's clock would read a second capped session's record from the second before that cycle as stale
+    though it postdated the lift's evidence. A record with no readable time (t 0) is not proof of staleness
+    and counts."""
+    floor = float(after or 0)
     for s in _alive_sessions(now, tmux):
         p = s.get("path")
         if p:
             e = _api_error(p)
             if e and e.get("spendLimit"):
+                t = float(e.get("t") or 0)
+                if floor and 0 < t < floor:
+                    continue                             # already ruled on: the lift's evidence is newer
                 return s
     return None
 
@@ -7893,16 +7996,45 @@ def _auto_pause_on_spend_limit(now, tmux):
     (isApiErrorMessage → _api_error.spendLimit), not the usage report, because the cap is a BILLING limit
     the /usage windows don't carry. Pausing stops BOTH the auto-retry AND the judges (they gate on this
     flag) — correct, since a capped account fails every model call. _auto_resume_retry clears it the moment
-    a session serves a request again (which can't happen until the cap lifts), so it holds exactly as long
-    as the cap does. reason='spend' → the card shows 'raise your cap', not a reset countdown. Idempotent."""
+    a session on the capped billing serves a request again (which can't happen until the cap lifts), so it
+    holds exactly as long as the cap does. reason='spend' → the card shows 'raise your cap', not a reset
+    countdown. Idempotent.
+
+    Stand-down: the capped session's record outlives the lift. A spend cap is on-you, so romp sends it no
+    retry and only a human prompt to that session clears _api_error; the lift reads another session's output
+    on the same billing and leaves the record standing. Engaging on it again the next cycle put the pause
+    back after every lift (alternating at the streaming session's output cadence, then stuck ON once it
+    idled, gating the judges and the idle-queue drives until someone prompted the capped session). So the
+    engage reads the last spend lift's instant off the pause file (_retry_pause_lifted_at) and skips records
+    older than it; a NEW spendLimit record, written after the lift, engages with a new floor."""
     if _retry_paused_on():
         return
-    if _spend_capped_session(now, tmux) is not None:
-        _set_retry_paused(True, reason="spend")
-        sys.stderr.write("retry-pause: auto-engaged — monthly spend limit reached → auto-retry + judges "
-                         "paused until the cap is raised (claude.ai/settings/usage)\n")
+    capped = _spend_capped_session(now, tmux, after=_retry_pause_lifted_at())
+    if capped is not None:
+        # which billing the cap is on, from the capped session's live row: the lift rule accepts fresh output
+        # from that billing only, so a session on the other account cannot lift a cap it never hit and
+        # re-engage it here the next cycle (the pause file flapped every cycle in a login-plus-key install
+        # while one session streamed past the other's cap)
+        live = tmux if isinstance(tmux, dict) else {}
+        bills = "login" if _bills_login(live.get(str(capped.get("sid") or ""))) else "key"
+        _set_retry_paused(True, reason="spend", bills=bills)
+        sys.stderr.write("retry-pause: auto-engaged: monthly spend limit reached (%s billing); auto-retry + judges "
+                         "paused until the cap is raised (claude.ai/settings/usage)\n" % bills)
         # no inline push: _set_retry_paused marked the views dirty and woke the pusher, whose next cycle
         # carries the flip in its globalRetryPaused frame (see _auto_resume_retry)
+
+
+def _bills_login(tm):
+    """Whether a live-map row's session bills the machine LOGIN (the account a usage limit is on): the CLI's
+    own authLive report first, the registry's auth next; a row with neither (a tmux session, an SDK session
+    before its init landed) can only be billing the login when this machine holds no key at all
+    (_auth_key_present: an apiKeyHelper is configured), and is taken as billing a key otherwise. The spend
+    pause reads it at both edges (_auto_pause_on_spend_limit records the capped session's billing;
+    _auto_resume_retry's spend rule compares a candidate's against it)."""
+    a = str((tm or {}).get("authLive") or (tm or {}).get("auth") or "")
+    if a:
+        return a == "login"
+    return not _auth_key_present()
 
 
 def _auto_resume_retry(now, tmux):
@@ -7913,9 +8045,36 @@ def _auto_resume_retry(now, tmux):
     killed EVERY judge (the tier is gated on `not _retry_paused_on()`), turning the storm's fix into a
     permanent outage the user had to infer.
 
-    Event-based recovery signal: a live session that is NOT currently blocked on an API error AND has written
-    fresh transcript output since the pause began (mtime past the pause floor) is proof the account can serve
-    requests again. Clearing re-enables both auto-retry and the judges together.
+    Three lift rules, one per reason, each keyed on the event that engaged it:
+
+    - limit: the usage REPORT, the same reading that engaged it (_account_limited). The pause holds while
+      the report names a 5h/7d window at 100% with its reset ahead, and lifts the cycle it stops: the
+      reset passed, or a fresh reading came in under it. No session's output lifts it while the report
+      still reads limited. The mtime rule lifted it on any session's fresh transcript, and a key-billed
+      session's streaming (or a human prompt) flipped the file every cycle while the window held; a rule
+      keyed on a login-billed session's fresh assistant output could never fire after the reset: the login
+      sessions the limit blocked are the ones whose auto-retry this pause gates (_fire_api_retry), key-billed
+      sessions are rightly skipped, so the pause, the judges and the idle-queue drives stayed off until a
+      human prompted or clicked Resume. Output under a still-limited report is not a lift either: with extra
+      usage on, the login account is served at 100%, and a lift on that output was re-engaged the next
+      cycle, the pause file (so the bottom bar's API cell) flipping at the output cadence. A login turn's
+      END refreshes the report (get_usage rides turn ends; _usage_poll_tick every 15 min), which is how a
+      served account reaches this edge. A still-limited account whose reading was stale re-engages through
+      its next error record and the refreshed report, with a new floor.
+    - spend: fresh ASSISTANT output (_api_last_output_t, never the mtime a prompt moves too) from a live
+      session on the SAME billing the capped session was on (_retry_pause_bills, recorded at the engage;
+      the capped session itself qualifies once it serves). A cap is on one account, and in a login-plus-key
+      install a session on the other account streams straight through it: the old mtime rule counted that,
+      _auto_pause_on_spend_limit re-engaged the pause the next cycle while the capped session sat on its
+      record, and the file flipped every cycle. A file with no billing recorded takes any session's fresh
+      output. The lift leaves the capped session's record standing (nothing but a human prompt clears a
+      spend record), so the un-pause records the lifting output's own time as liftedAt (the evidence, not
+      the cycle's clock, so a record written between the two counts as new) and the engage stands down on
+      records older than it: one lift, no re-engage, until a NEW record.
+    - manual: any live session, not blocked on an API error, whose transcript mtime passed the pause floor
+      (the user's own words above, unchanged).
+
+    Clearing re-enables both auto-retry and the judges together.
 
     Delivery (the two auto-pause siblings above do the same): no inline push from this thread.
     _set_retry_paused ends in _mark_views_dirty, which stamps the dirty mark and sets _pusher_wake, so
@@ -7931,28 +8090,53 @@ def _auto_resume_retry(now, tmux):
     if not _retry_paused_on():
         return
     floor = _retry_pause_ts()
+    reason = _retry_pause_reason()
+    if reason == "limit":
+        try:
+            if _account_limited():
+                return                                   # the window holds: nothing a session writes outranks the report
+        except Exception:
+            return                                       # no reading: no change (the engage side reads nothing either)
+        _lift_retry_pause(now, "the usage window reset")
+        return
+    bills = _retry_pause_bills() if reason == "spend" else ""
+    live = tmux if isinstance(tmux, dict) else {}
     for s in _alive_sessions(now, tmux):
         path = s.get("path")
         if not path or _api_error(path):                 # still blocked on an API error → not proof of recovery
             continue
-        try:
-            fresh = os.stat(path).st_mtime > floor       # wrote something new since the pause → a served request
-        except OSError:
-            continue
+        evidence = None
+        if reason == "spend":
+            if bills and ("login" if _bills_login(live.get(str(s.get("sid") or ""))) else "key") != bills:
+                continue                                 # the other account: says nothing about this cap
+            out_t = _api_last_output_t(path)
+            fresh = out_t > floor                        # the API's own answer, after the pause
+            evidence = out_t                             # ... and the stand-down floor the un-pause records
+        else:
+            try:
+                fresh = os.stat(path).st_mtime > floor   # wrote something new since the pause → a served request
+            except OSError:
+                continue
         if fresh:
-            _set_retry_paused(False)
-            sys.stderr.write("retry-pause: auto-cleared — session %s recovered → judges + auto-retry resume\n"
-                             % s.get("sid", "?"))
-            try:                                         # recovery edge → re-arm cards the judges gave up on
-                rearmed = jd.rearm_failed_summaries(now)  # while degraded, so their summaries/briefs retry now
-                if rearmed:
-                    sys.stderr.write("distiller: re-armed %d given-up card(s) after recovery\n" % rearmed)
-                    _mark_views_dirty()                  # a store write the cards show, after the flag's stamp
-            except Exception:
-                sys.stderr.write("rearm-failed-summaries: %s\n" % traceback.format_exc())
-            # no inline push: _set_retry_paused marked the views dirty and woke the pusher; its next cycle
-            # carries globalRetryPaused=false (docstring)
+            _lift_retry_pause(now, "session %s recovered" % s.get("sid", "?"), lifted_at=evidence)
             return
+
+
+def _lift_retry_pause(now, why, lifted_at=None):
+    """Clear the global retry-pause on a recovery edge (_auto_resume_retry's three rules land here): the flag
+    flip and the re-arm of the cards the judges gave up on while degraded. No inline push and no wake of its
+    own: _set_retry_paused ends in _mark_views_dirty, which wakes the pusher, and its next cycle carries
+    globalRetryPaused=false (the caller's docstring). `lifted_at` is the spend rule's evidence time, recorded
+    as the file's liftedAt (_set_retry_paused); the other rules pass none."""
+    _set_retry_paused(False, lifted_at=lifted_at)
+    sys.stderr.write("retry-pause: auto-cleared (%s): judges + auto-retry resume\n" % why)
+    try:                                                 # recovery edge → re-arm cards the judges gave up on
+        rearmed = jd.rearm_failed_summaries(now)         # while degraded, so their summaries/briefs retry now
+        if rearmed:
+            sys.stderr.write("distiller: re-armed %d given-up card(s) after recovery\n" % rearmed)
+            _mark_views_dirty()                          # a store write the cards show, after the flag's stamp
+    except Exception:
+        sys.stderr.write("rearm-failed-summaries: %s\n" % traceback.format_exc())
 
 
 # ── Per-session auto-retry suppression (the user 2026-07-06) ───────────────────────────────────────
@@ -22718,6 +22902,7 @@ def _undelivered_wake_tail(path):
 
 
 _api_err_cache = {}           # path -> ((mtime, size), err|None)
+_api_last_failed_cache = {}   # path -> ((mtime, size), err|None, out_t): _api_last_failed's own (the latch)
 
 
 _SESSION_STAMP_CACHE = {}    # sid -> ((goals mtime,size, overrides mtime,size), ((gid, at, why, kind), stamped tops)) — see _session_stamp_read
@@ -24460,21 +24645,33 @@ def _spend_dialog_showing(pane):
 _API_ERR_TAIL_WINDOW = int(os.environ.get("ROMP_API_ERR_TAIL_WINDOW", "262144"))
 
 
-def _api_error_scan(path, start):
-    """One pass of _api_error's classification from byte `start` to EOF → (err, decided).
+def _api_error_pass(path, start):
+    """One pass from byte `start` to EOF answering BOTH transcript readers at once
+    -> (err, decided, latched, decided_latched, out_t).
 
-    The loop is _api_error's original whole-file scan, UNCHANGED (one dedent) except that each of its
-    three `err = ...` sites now also sets `decided`. That flag is the window's own proof of sufficiency:
-    True iff this pass saw a record that ASSIGNS the verdict (an isApiErrorMessage assistant record,
-    fresh assistant output, or a genuine user prompt) — exactly the record the whole-file scan's result
-    depends on, since everything before it is overwritten. False means the window started too late and
-    the caller must widen; True means this window's answer IS the whole file's answer.
+    err / decided are _api_error's. The loop is _api_error's original whole-file scan, changed only at its three
+    `err = ...` sites (each also sets `decided`, and the two assistant sites set `latched`, `decided_latched` and
+    `out_t`) and at the refusal branch, which marks both dicts. `decided` is the window's own proof of
+    sufficiency: True iff this pass saw a record that ASSIGNS the verdict (an isApiErrorMessage assistant
+    record, fresh assistant output, or a genuine user prompt), exactly the record the whole-file scan's result
+    depends on, since everything before it is overwritten. False means the window started too late and the
+    caller must widen; True means this window's answer IS the whole file's answer.
 
-    A non-zero `start` lands mid-line, so the first partial line is dropped. model_refusal_* records
-    land a few records AFTER the error they annotate and only mutate an err already set, so they need no
-    special handling: with their error out of window nothing is assigned, and the caller widens."""
+    latched / decided_latched are _api_last_failed's (the bottom bar's API health cell): the same verdict with
+    the user branch inert, so a genuine prompt neither clears nor decides it and an error record holds until
+    fresh ASSISTANT output, through romp's own injected RETRY_MSG and through a human prompt alike (neither is
+    information about the API; the API's answer is). An assistant record decides both, so decided_latched
+    implies decided. out_t is the newest assistant OUTPUT record's timestamp while that record is the newest
+    assistant record, else 0: the spend pause's recovery signal (_auto_resume_retry).
+
+    A non-zero `start` lands mid-line, so the first partial line is dropped. model_refusal_* records land a
+    few records AFTER the error they annotate and only mutate an err already set, so they need no special
+    handling: with their error out of window nothing is assigned, and the caller widens."""
     err = None
     decided = False
+    latched = None
+    decided_latched = False
+    out_t = 0
     with open(path, errors="replace") as f:
         if start > 0:
             f.seek(start)
@@ -24497,42 +24694,47 @@ def _api_error_scan(path, start):
                     # "prompt is too long" is NOT a transient API error (the user 2026-06-29): it means the
                     # context needs compacting → it's on YOU. Flag it so it (and only it) blocks; other API
                     # errors are transient (auto-retry recovers them) and stay in Working.
-                    decided = True
-                    err = {"text": text, "status": o.get("apiErrorStatus"),
-                           "category": o.get("error") or "unknown",
-                           # the error RECORD's identity — a new failed attempt writes a new record,
-                           # so this uuid IS the error episode (one auto-retry per episode, apiRetry)
-                           "uuid": o.get("uuid"),
-                           "tooLong": "too long" in text.lower(),
-                           # a spend cap is on YOU (raise it), like tooLong — but ALSO stops the
-                           # auto-retry entirely (no reset to wait out); see _auto_pause_on_spend_limit
-                           "spendLimit": _is_spend_limit(text),
-                           # a model's own allowance is spent — on YOU too (switch model / add
-                           # credits), and the auto-retry keeps running only because the window does
-                           # eventually reset; see _is_model_limit
-                           "modelLimit": _is_model_limit(text),
-                           # a dead credential (no login / refused key) — on YOU, never auto-retried;
-                           # see _is_auth_error (per-session auth, the user 2026-08-08)
-                           "authErr": _is_auth_error(text),
-                           # the error's parent = the refused/failed USER message — kept so the
-                           # system model_refusal_* record below can link itself to THIS episode
-                           "parentUuid": o.get("parentUuid"),
-                           # a safeguards refusal is deterministic on the same input — on YOU
-                           # (rewrite the ask or drop the thread), never auto-retried; see
-                           # _is_refusal_text, and the system-record event path below (the user
-                           # 2026-08-15, after one refused prompt drew 12 auto-retries in ~6min)
-                           "refusal": _is_refusal_text(text)}
+                    decided = decided_latched = True
+                    out_t = 0                             # the newest assistant record is a failure again
+                    err = latched = {"text": text, "status": o.get("apiErrorStatus"),
+                                     "category": o.get("error") or "unknown",
+                                     # the error RECORD's identity — a new failed attempt writes a new record,
+                                     # so this uuid IS the error episode (one auto-retry per episode, apiRetry)
+                                     "uuid": o.get("uuid"),
+                                     # the record's own time, the event stamp the API health frame's `since`
+                                     # carries (never the clock, so an unchanged world serializes identically)
+                                     "t": int(em.parse_z(o.get("timestamp")) or 0),
+                                     "tooLong": "too long" in text.lower(),
+                                     # a spend cap is on YOU (raise it), like tooLong — but ALSO stops the
+                                     # auto-retry entirely (no reset to wait out); see _auto_pause_on_spend_limit
+                                     "spendLimit": _is_spend_limit(text),
+                                     # a model's own allowance is spent — on YOU too (switch model / add
+                                     # credits), and the auto-retry keeps running only because the window does
+                                     # eventually reset; see _is_model_limit
+                                     "modelLimit": _is_model_limit(text),
+                                     # a dead credential (no login / refused key) — on YOU, never auto-retried;
+                                     # see _is_auth_error (per-session auth, the user 2026-08-08)
+                                     "authErr": _is_auth_error(text),
+                                     # the error's parent = the refused/failed USER message — kept so the
+                                     # system model_refusal_* record below can link itself to THIS episode
+                                     "parentUuid": o.get("parentUuid"),
+                                     # a safeguards refusal is deterministic on the same input — on YOU
+                                     # (rewrite the ask or drop the thread), never auto-retried; see
+                                     # _is_refusal_text, and the system-record event path below (the user
+                                     # 2026-08-15, after one refused prompt drew 12 auto-retries in ~6min)
+                                     "refusal": _is_refusal_text(text)}
                 elif (isinstance(c, list) and any(isinstance(b, dict)
                         and b.get("type") in ("text", "tool_use", "thinking") for b in c)) \
                         or (isinstance(c, str) and c.strip()):
-                    decided = True
-                    err = None                            # fresh assistant output → recovered
+                    decided = decided_latched = True
+                    err = latched = None                  # fresh assistant output → recovered
+                    out_t = int(em.parse_z(o.get("timestamp")) or 0)
             elif t == "user":
                 c = (o.get("message") or {}).get("content")
                 is_tool_result = isinstance(c, list) and any(
                     isinstance(b, dict) and b.get("type") == "tool_result" for b in c)
-                if not is_tool_result:                    # a genuine prompt (e.g. a retry) clears it
-                    decided = True
+                if not is_tool_result:                    # a genuine prompt (e.g. a retry) clears _api_error's
+                    decided = True                        # verdict and decides it; the latch ignores it
                     err = None
             elif t == "system" and o.get("subtype") in ("model_refusal_no_fallback",
                                                         "model_refusal_fallback"):
@@ -24545,9 +24747,62 @@ def _api_error_scan(path, start):
                 # parent in 2 of 13 refusal records of one storm — and deliberately not
                 # record-alone: the CLI also omits this record for some refusal errors, which is
                 # why the text signature above stays co-equal rather than a legacy fallback.
-                if err is not None and o.get("parentUuid") == err.get("parentUuid"):
-                    err["refusal"] = True
-    return err, decided
+                for d in (err, latched):                  # the same dict when both still hold the episode
+                    if d is not None and o.get("parentUuid") == d.get("parentUuid"):
+                        d["refusal"] = True
+    return err, decided, latched, decided_latched, out_t
+
+
+def _api_error_scan(path, start, user_clears=True):
+    """_api_error_pass for ONE reader -> (err, decided): _api_error's verdict by default, the latch's with
+    user_clears=False. The differential tests read the scan through this name; the kernel reads the pass."""
+    err, decided, latched, decided_latched, _ = _api_error_pass(path, start)
+    return (err, decided) if user_clears else (latched, decided_latched)
+
+
+def _api_stat_key(path):
+    """The (mtime, size) both transcript caches key on, or None when the file cannot be stat'ed."""
+    try:
+        st = os.stat(path)
+        return (st.st_mtime, st.st_size)
+    except OSError:
+        return None
+
+
+_API_UNDECIDED = object()   # _api_error_read's latch slot when the read stopped before an assistant record
+
+
+def _api_error_read(path, key, latch):
+    """The tail-first widening read behind BOTH readers, filling both caches from ONE pass: without it,
+    _api_last_failed would re-read and re-parse the same tail _api_error had just scanned, for every active
+    session, every cycle. `latch` names the verdict the caller needs decided: _api_error's decides at the
+    newest prompt or assistant record and keeps exactly the offsets it always read; the latch's needs an
+    assistant record. Whatever this read settled (or proved by reaching byte 0) is cached for both, so the
+    pusher's second question about the same transcript in the same cycle is a cache hit.
+    -> (err, latched, out_t); latched is _API_UNDECIDED when a non-latch read stopped before an assistant
+    record (the latch's own read then widens, rarely: a tail of prompts longer than the window)."""
+    size = key[1]
+    # TAIL-FIRST: the pusher calls this per session per push, and the old whole-file read cost
+    # O(transcript) on EVERY append — the same unamortized shape the assembly fold retired for the
+    # event-model parse, left behind here. Widen 4x until a pass reports it saw the deciding record.
+    win = max(1, _API_ERR_TAIL_WINDOW)   # a knob of 0 or less would never widen (0*4 stays 0): clamp, don't spin
+    while True:
+        start = size - win if win < size else 0
+        err, decided, latched, decided_latched, out_t = _api_error_pass(path, start)
+        whole = start <= 0
+        if whole or decided_latched or (decided and not latch):
+            break
+        win *= 4
+    if len(_api_err_cache) > 256:
+        _api_err_cache.clear()
+    _api_err_cache[path] = (key, err)                     # decided, or the whole file: final either way
+    if decided_latched or whole:
+        if len(_api_last_failed_cache) > 256:
+            _api_last_failed_cache.clear()
+        _api_last_failed_cache[path] = (key, latched, out_t)
+    else:
+        latched = _API_UNDECIDED
+    return err, latched, out_t
 
 
 def _api_error(path):
@@ -24557,37 +24812,57 @@ def _api_error(path):
     model_not_found) but that flag is the invariant, so detection is exact, not a text heuristic (the
     user 2026-06-16). The session is blocked iff such a record is the LAST productive thing in the
     transcript: a later genuine user prompt (a retry) or fresh assistant output (an internal retry that
-    succeeded) clears it. Returns {text,status,category} or None. Event-based; cached by (mtime,size)
-    like _parse, since build_session/build_feed call it per push."""
-    try:
-        st = os.stat(path)
-        key = (st.st_mtime, st.st_size)
-        size = st.st_size
-    except OSError:
-        key = None
-        size = 0
+    succeeded) clears it. Returns {text,status,category,...} or None. Event-based; cached by (mtime,size)
+    like _parse, since build_session/build_feed call it per push. One read serves this and the latch
+    (_api_error_read)."""
+    key = _api_stat_key(path)
     hit = _api_err_cache.get(path)
     if hit is not None and key is not None and hit[0] == key:
         return hit[1]
-    err = None
+    if key is None:
+        return None
     try:
-        # TAIL-FIRST: the pusher calls this per session per push, and the old whole-file read cost
-        # O(transcript) on EVERY append — the same unamortized shape the assembly fold retired for the
-        # event-model parse, left behind here. Widen 4x until a pass reports it saw the deciding record.
-        win = max(1, _API_ERR_TAIL_WINDOW)   # a knob of 0 or less would never widen (0*4 stays 0): clamp, don't spin
-        while True:
-            start = size - win if win < size else 0
-            err, decided = _api_error_scan(path, start)
-            if decided or start <= 0:
-                break
-            win *= 4
+        return _api_error_read(path, key, latch=False)[0]
     except OSError:
         return None
-    if key is not None:
-        if len(_api_err_cache) > 256:
-            _api_err_cache.clear()
-        _api_err_cache[path] = (key, err)
-    return err
+
+
+def _api_last_failed(path):
+    """The session's newest API error record if no ASSISTANT OUTPUT has followed it, else None: _api_error's
+    latched sibling (the bottom bar's API health cell). Same tail-first widening, its own (mtime, size)
+    cache, one difference: a user prompt does not clear the record. _api_error answers 'is this session
+    blocked right now', and a retry prompt rightly un-blocks it; but romp's own auto-retry IS a user prompt
+    (RETRY_MSG), so a count keyed on _api_error read '1 waiting', 'ok', '1 waiting' on every rung of
+    RETRY_BACKOFF during an outage. The API's own answer, output or a new error record, is the only event
+    that moves this. Returns the pass's err dict (with `t`, the record's time) or None."""
+    key = _api_stat_key(path)
+    hit = _api_last_failed_cache.get(path)
+    if hit is not None and key is not None and hit[0] == key:
+        return hit[1]
+    if key is None:
+        return None
+    try:
+        return _api_error_read(path, key, latch=True)[1]
+    except OSError:
+        return None
+
+
+def _api_last_output_t(path):
+    """The timestamp of the session's newest ASSISTANT OUTPUT record while that record is the newest
+    assistant record (the latch is clear), else 0: a user prompt is not output, a tool result is not output,
+    and an error record after it means no fresh answer stands. Kept beside the latch by the same read, so
+    the pusher pays nothing extra for it. The spend pause lifts on this (_auto_resume_retry), never on the
+    transcript's mtime, which a prompt moves too."""
+    key = _api_stat_key(path)
+    hit = _api_last_failed_cache.get(path)
+    if hit is not None and key is not None and hit[0] == key:
+        return hit[2]
+    if key is None:
+        return 0
+    try:
+        return _api_error_read(path, key, latch=True)[2]
+    except OSError:
+        return 0
 
 
 def _suppress_kernel_driven_ask(sid, ask, now=None):
@@ -40168,6 +40443,170 @@ def _badge_push(n):
     _send_to_app("shell", {"type": "badge", "n": n})
 
 
+# ── The bottom bar's API health cell: one glance answers 'is the API serving my sessions', beside the usage
+# readout. Built from what the kernel already owns: the merged live map's retrying state (the SDK api_retry
+# storm), each alive transcript's LATCHED newest API error (_api_last_failed) and the global retry-pause
+# file, never from the /api-health ratio machine (threshold-and-hold transitions evaluated at read time) and
+# never from a clock: every field moves on one named event (a retry frame, an isApiErrorMessage record,
+# fresh assistant output, a pause set or lifted, a session leaving the roster), so an unchanged world
+# serializes identically and sends nothing.
+#
+# States: ok; degraded, with a class word by plurality over the affected sessions, 429 rate limited /
+# 529 overloaded / offline (this machine cannot reach the API) / errors, and the count waiting
+# (retrying + stopped on an error record); paused, red, with the pause's latched reason (limit / spend /
+# manual), outranking every degraded reading since nothing retries and the judges are gated too.
+# On-you failures (tooLong / modelLimit / authErr / refusal) do NOT count: they already wear red on that
+# session's tab and card, and the cell answers for the API, not for the session. A spend cap counts,
+# and engages the spend pause in the same cycle anyway. The web shell's rail only, for now; the VS Code
+# strip twin (strip.ts apiCell's sibling, with a --st-retrying token) and the phone's Usage-modal section
+# (no rail on the phone) are named follow-ups.
+_APIH_TEXT = {                 # the ONE table of rail words: the rail, the detail header and the tests read `text`
+    "ok": "ok",
+    "429": "rate limited",
+    "529": "overloaded",
+    "offline": "offline",
+    "errors": "errors",
+    "limit": "paused · usage limit",
+    "spend": "paused · spend cap",
+    "manual": "paused by you",
+}
+_APIH_ORDER = ("429", "529", "offline", "errors")   # the fixed tie order for the plurality class
+
+
+def _apih_status(status):
+    """The wire's status as a positive int, or None (bools, blanks, zeros and non-digits are no status)."""
+    if isinstance(status, bool):
+        return None
+    if isinstance(status, (int, float)):
+        return int(status) if int(status) > 0 else None
+    if isinstance(status, str) and status.strip().isdigit():
+        return int(status.strip()) or None
+    return None
+
+
+def _apih_class(status, category="", network_down=None):
+    """One affected session's class for the rail: "429" | "529" | "offline" | "errors". A kernel-local
+    twin of sdk_backend.api_health_status_class collapsed to the four rail words (tests pin agreement on the
+    shared statuses): its 5xx / other / none all read "errors" here, except a no-status attempt the CLI
+    flagged is_network_down, which is this machine's connectivity, not the API: "offline". Only a retrying
+    row can say offline: a transcript error record carries no network flag."""
+    st = _apih_status(status)
+    if st is not None:
+        if st == 429:
+            return "429"
+        if st == 529:
+            return "529"
+        return "errors"
+    cat = str(category or "").strip().lower()
+    if cat == "rate_limit":
+        return "429"
+    if cat == "overloaded":
+        return "529"
+    if cat in ("server_error", "authentication_failed", "billing_error", "invalid_request"):
+        return "errors"
+    return "offline" if network_down is True else "errors"
+
+
+def _api_health_frame(now, tmux):
+    """The apiHealth shell frame for this cycle (the block comment above says what it reads). `tmux` is
+    the cycle's merged live map (Sessions.live()). Every timestamp is an event stamp, a record's time, the
+    storm turn's start (SdkSession.since moves once per fresh turn, not per attempt) or the pause's t, never
+    the clock, so two cycles over the same world return equal dicts and _api_health_push sends nothing.
+    Rows sort by (since, sid) so the roster's mtime order cannot reshuffle an unchanged world into a send.
+    Nothing from retryInfo but status and networkDown: attempt / retryAt tick per attempt. `seq` counts
+    pause-file writes, an event, so a write that put the same state back still yields a new frame."""
+    paused = _retry_paused_on()
+    reason = ""
+    pause_t = 0
+    if paused:
+        r = _retry_pause_reason()
+        reason = r if r in ("limit", "spend") else "manual"
+        pause_t = int(_retry_pause_ts() or 0)
+    rows = []
+    n_tmux = 0
+    live = tmux if isinstance(tmux, dict) else {}
+    for s in _alive_sessions(now, tmux):
+        sid = str(s.get("sid") or "")
+        if not sid:
+            continue
+        if Sessions.backend_for(sid) is _TMUX:
+            n_tmux += 1                                # transcript-only coverage: the detail says so
+        tm = live.get(sid) or {}
+        if tm.get("state") == "retrying":              # the SDK api_retry storm: set per frame, cleared
+            info = tm.get("retryInfo") if isinstance(tm.get("retryInfo"), dict) else {}   # when output resumes
+            status = info.get("status")
+            row = {"kind": "retrying", "cls": _apih_class(status, "", info.get("networkDown")),
+                   "since": int(tm.get("since") or 0)}
+        else:
+            path = s.get("path")
+            e = _api_last_failed(path) if path else None
+            if not e or e.get("tooLong") or e.get("modelLimit") or e.get("authErr") or e.get("refusal"):
+                continue                               # nothing latched, or an on-you failure (the session's own)
+            status = e.get("status")
+            # The word follows the LIVE state: a turn open on the retry prompt (romp's own, or a human's) with
+            # no api_retry frame yet, or a tmux session's whole internal retry, reads 'retrying', not
+            # 'stopped'. The latch only keeps the row counted; since stays the record's time.
+            kind = "retrying" if tm.get("state") == "working" else "blocked"
+            row = {"kind": kind, "cls": _apih_class(status, e.get("category"), None),
+                   "since": int(e.get("t") or 0)}
+        row.update({"sid": sid, "name": s.get("name") or sid[:8], "color": _name_color(sid),
+                    "status": _apih_status(status), "suppressed": _session_retry_suppressed(sid)})
+        rows.append(row)
+    rows.sort(key=lambda r: (r["since"], r["sid"]))
+    cls = ""
+    if rows:
+        counts = {}
+        for r in rows:
+            counts[r["cls"]] = counts.get(r["cls"], 0) + 1
+        cls = max(_APIH_ORDER, key=lambda c: (counts.get(c, 0), -_APIH_ORDER.index(c)))
+    n = len(rows)
+    if paused:
+        state = "paused"
+        text = _APIH_TEXT[reason] + (" · %d waiting" % n if n else "")
+        since = pause_t
+    elif rows:
+        state = "degraded"
+        text = "%s · %d waiting" % (_APIH_TEXT[cls], n)
+        since = min((r["since"] for r in rows if r["since"]), default=0)
+    else:
+        state, text, since = "ok", _APIH_TEXT["ok"], 0
+    return {"type": "apiHealth", "state": state, "cls": cls, "reason": reason, "text": text,
+            "waiting": n, "retrying": sum(1 for r in rows if r["kind"] == "retrying"),
+            "blocked": sum(1 for r in rows if r["kind"] == "blocked"),
+            "since": since, "tmux": n_tmux, "sessions": rows,
+            # the pause file's write count (_RETRY_PAUSE_SEQ): a press on the detail's pause button writes it,
+            # so the frame after the press differs from every frame before it even when the auto-pause put
+            # the same state back within the same second; the shell clears its acknowledgment on that
+            "seq": _RETRY_PAUSE_SEQ[0]}
+
+
+# The last apiHealth frame the shells heard, as its sorted serialization (None = nothing since boot): the
+# _BADGE_LAST pattern. The frame holds no clock, so the whole string is the change key.
+_APIH_LAST = [None]
+
+
+def _api_health_push(frame):
+    """Send the frame to every connected shell when it CHANGED, else nothing. No per-client repost (the
+    _send_client 60 s re-send would repeat an identical frame): a shell that connects gets the last frame
+    from the ready handler (_apih_resend)."""
+    s = json.dumps(frame, sort_keys=True)
+    if s == _APIH_LAST[0]:
+        return
+    _APIH_LAST[0] = s
+    _send_to_app("shell", frame)
+
+
+def _apih_resend(client):
+    """A shell that just sent `ready` paints its API cell from the last frame, verbatim, so an identical
+    frame cannot pulse the cell (the client diffs state and text before touching the DOM). Chat and pane
+    clients get nothing: only the shell owns the rail."""
+    if client.get("app") == "shell" and _APIH_LAST[0] is not None:
+        try:
+            client["send"](_APIH_LAST[0])
+        except Exception:
+            pass
+
+
 # ── Web Push: the same bell events, delivered to the phone (plans/ios-app.md proposal 2; the user
 # 2026-08-07, who wants "needs you" to reach them wherever they are, not just the kernel box's
 # desktop). A device opts in from the shell's bell (mobile tab bar → _LANDING_PUSH_JS): it
@@ -41150,6 +41589,10 @@ def _pusher_cycle_jobs(now, tmux, any_client):
         _auto_resume_retry(now, tmux)
     except Exception:
         sys.stderr.write("auto-resume-retry: %s\n" % traceback.format_exc())
+    try:                                  # the bottom bar's API health cell: built AFTER this cycle's pause
+        _api_health_push(_api_health_frame(now, tmux))   # decisions, every cycle (a connecting shell gets a
+    except Exception:                     # current frame), sent only when it changed
+        sys.stderr.write("api-health-frame: %s\n" % traceback.format_exc())
     try:                                  # a per-session interrupt-suppressed retry re-arms once that thread lands a clean turn
         _auto_resume_session_retry(now, tmux)
     except Exception:
@@ -42475,7 +42918,8 @@ if(window.__rompKeysClose&&window.__rompKeysClose()){closed=true;}
 else{var sp=document.getElementById('rsp-back');
 if(sp&&!sp.hidden&&window.__rompCloseSpend){window.__rompCloseSpend();closed=true;}
 else{var ru=document.getElementById('ru-back');
-if(ru&&ru.classList.contains('on')&&window.__rompUsageClose){window.__rompUsageClose();closed=true;}
+if(ru&&ru.classList.contains('on')&&window.__rompApiClose){window.__rompApiClose();closed=true;}
+else if(ru&&ru.classList.contains('on')&&window.__rompUsageClose){window.__rompUsageClose();closed=true;}
 else{var er=document.getElementById('rerr-back');
 if(er&&!er.hidden&&window.__rompCloseErrs){window.__rompCloseErrs();closed=true;}
 else{var bp=document.getElementById('rbell-back');
@@ -42877,6 +43321,7 @@ tip.style.top=Math.max(6,r.top-tip.offsetHeight-8)+'px';}
 // Pulls fresh first so the numbers aren't a stale boot snapshot; any tap or Escape dismisses.
 window.__rompUsagePanel=function(){
 function openIt(){var h=tipHTML();if(!h)return;
+try{window.__rompApiClose&&window.__rompApiClose();}catch(e){}   // one modal on #ru-back at a time (the API detail does the same)
 // the deeper level is one tap away here too (T247): the rail — and its click — do not exist on a
 // phone, and a compact view must never dead-end (progressive disclosure)
 tip.innerHTML=h+'<div class=ru-tip-more><button class=rsp-btn id=ru-bysession>By session \u2192</button></div>';   // its own row, the hover's button size (T247b review: inside .ru-tip-age it read as a 10px annotation at .55)
@@ -43192,6 +43637,166 @@ pull(false);                                     // fill on load, independent of
 // VERTICAL bars when the left rail ran out of height. The bars are HORIZONTAL in the bottom bar now and only
 // ~text-height tall, so they always fit — nothing to degrade.)
 window.addEventListener('message',function(e){var m=e.data;if(m&&m.romp==='usage')render(m.usage);});})();
+"""
+
+
+# The bottom bar's API health cell: one dot and one word beside the usage readout, painted from the kernel's
+# apiHealth shell push (_api_health_frame), the reading on hover, the detail with its actions pinned on click
+# (or Enter / Space: the cell is a keyboard button). It renders ONLY from the last pushed frame, no fetch, no
+# timer: the frame moves on events, and the cell repaints only when its state or text changed, so the ready
+# re-send of an identical frame cannot pulse it. The detail card is built in the usage tip's grammar and shares
+# its skin (#ah-tip sits beside #ru-tip in every selector) and its backdrop (#ru-back, one modal at a time).
+# The web shell's rail only, for now; the VS Code strip twin (strip.ts apiCell's sibling, with a --st-retrying
+# token) and the phone's Usage-modal section (no rail on the phone) are named follow-ups.
+_LANDING_APIH_JS = """
+(function(){var el=document.getElementById('rail-api');if(!el)return;
+var txt=el.querySelector('.ah-text');
+var tip=document.createElement('div');tip.id='ah-tip';tip.style.display='none';
+tip.setAttribute('role','dialog');tip.setAttribute('aria-label','API health');tip.setAttribute('aria-modal','true');tip.tabIndex=-1;document.body.appendChild(tip);
+var back=document.getElementById('ru-back');
+if(!back){back=document.createElement('div');back.id='ru-back';document.body.appendChild(back);}
+// LAST: the newest frame. pinned: the detail is the modal. held / dirty: a PRIMARY pointer is down over the detail
+// and a frame arrived meanwhile (painted on release). pending: a pause press awaiting the frame that answers it (1 =
+// stop sent, 0 = resume sent, null = none); pendSeq: the pause file's write count (frame.seq) when it was pressed,
+// so the frame that answers is the one whose seq moved. hint: the last failed send's reason, shown under the
+// button. lastX: where the hover anchored, so a re-anchor keeps its place. focusBack: where focus returns when the
+// detail closes.
+var LAST=null,pinned=false,held=false,dirty=false,pending=null,pendSeq=null,hint='',lastX=null,focusBack=null;
+function esc(s){return String(s).replace(/[&<>"]/g,function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];});}
+function hm(ep){return new Date(ep*1000).toTimeString().slice(0,5);}
+// The plain-words pause reasons and the ok line: the kernel's `text` is the headline, these say what it means.
+var PAUSE={limit:'Auto-retry and the judges are paused until your usage limit resets.',
+spend:'Auto-retry and the judges are paused: you have reached the monthly spend limit. Raise it at claude.ai/settings/usage.',
+manual:'Auto-retry and the judges are paused: you stopped them.'};
+var OK='No session is waiting on the API. Auto-retry and the judges are running.';
+var RESUME='Resume all auto-retries',STOP='Stop all auto-retries';   // the chat card's own words
+var NOTSENT='Not sent: the dashboard is disconnected. Try again.';
+var LOST='Connection lost before the answer arrived. When it is back, the button shows the current state.';
+function clsWords(r){if(r.cls==='429')return '429 rate limited';if(r.cls==='529')return '529 overloaded';
+if(r.cls==='offline')return 'offline';return 'error'+(r.status?' '+r.status:'');}
+// The pause control. A press is acknowledged at once (disabled, flipped label, .romp-acted) and STAYS so across
+// frames until the one that answers it: an in-flight pre-press frame must not repaint an enabled button.
+function btnHTML(m){if(pending!==null)return '<button class="ah-btn romp-acted" disabled data-act=pause data-val='+pending+'>'+(pending?RESUME:STOP)+'</button>';
+var v=m.state==='paused'?0:(m.waiting>0?1:-1);if(v<0)return '';
+return '<button class=ah-btn data-act=pause data-val='+v+'>'+(v?STOP:RESUME)+'</button>'+(hint?'<div class=ah-hint>'+esc(hint)+'</div>':'');}
+// A pinned row is a keyboard button too (role, tabindex; Enter / Space run it from the keydown below).
+function rowHTML(r,full){var bg=r.color&&r.color.bg?esc(r.color.bg):'';
+return '<div class="ru-tip-row ah-row'+(full?'':' ah-ro')+'"'+(full?' role=button tabindex=0 data-act=reveal data-sid="'+esc(r.sid)+'"':'')+'>'
++(bg?'<i class=ah-sw style="background:'+bg+'"></i><span class=ah-nm style="color:'+bg+'">':'<i class=ah-sw></i><span class=ah-nm>')+esc(r.name)+'</span>'
++'<span class=ah-desc>'+(r.kind==='retrying'?'retrying':'stopped')+' · '+clsWords(r)+(r.since?' · since '+hm(r.since):'')
++(r.suppressed?' · auto-retry off for this session (you interrupted it)':'')+'</span></div>';}
+// full=false is the HOVER: the same reading with no controls. The hover sits under pointer-events:none and hides
+// on mouseleave, so a button there could not be honored; the click is where the actions live.
+function html(m,full){var h='<div class=ru-tip-win><div class=ru-tip-name><span>API · this machine</span></div>'
++'<div class="ru-tip-row ah-head"><i class=ah-dot data-state='+esc(m.state)+'></i><span class=ah-word>'+esc(m.text)+'</span>'
++(m.since?'<span class=ah-since>since '+hm(m.since)+'</span>':'')+'</div>';
+if(m.state==='paused')h+='<div class=ah-line>'+(PAUSE[m.reason]||PAUSE.manual)+'</div>';
+else if(m.state==='ok')h+='<div class=ah-line>'+OK+'</div>';
+if(full)h+=btnHTML(m);
+h+='</div>';
+var rows=m.sessions||[];
+if(rows.length){h+='<div class=ru-tip-win><div class=ru-tip-name><span>Sessions waiting</span></div>';
+rows.forEach(function(r){h+=rowHTML(r,full);});h+='</div>';}
+if(m.tmux>0)h+='<div class="ru-tip-win ah-line">'+(m.tmux===1?'1 tmux session is seen through its transcript only':m.tmux+' tmux sessions are seen through their transcripts only')
++', so a retry in progress there shows only when it fails or recovers.</div>';
+if(full)h+='<div class="ru-tip-row ah-foot"><span class=ah-link role=button tabindex=0 data-act=usage>Usage and spend</span><span class=ah-link role=button tabindex=0 data-act=log>Log</span></div>';
+return h;}
+// The hover anchors above the rail, centered on the cursor, exactly as the usage tip's showTip does; a re-render
+// re-anchors from the same x, since new rows change the height and the tip hangs ABOVE the rail.
+function anchor(){var r=el.getBoundingClientRect();var x=(typeof lastX==='number')?lastX:(r.left+r.width/2);
+tip.style.left=Math.max(6,Math.min(window.innerWidth-tip.offsetWidth-6,x-tip.offsetWidth/2))+'px';
+tip.style.top=Math.max(6,r.top-tip.offsetHeight-8)+'px';}
+// A re-render replaces the card's nodes, so a focused control would fall to the page body and the next Tab would
+// leave the dialog: the same control (by act and sid) takes focus again in the new markup, else the card does.
+function focusKey(n){return (n&&n.getAttribute)?(n.getAttribute('data-act')||'')+'|'+(n.getAttribute('data-sid')||''):'';}
+function render(){if(!LAST)return;var a=document.activeElement,key=(pinned&&a&&a!==tip&&tip.contains(a))?focusKey(a):null;
+tip.innerHTML=html(LAST,pinned);if(!pinned)anchor();
+if(key!==null){var n=null,all=tip.querySelectorAll('[data-act]');for(var i=0;i<all.length;i++)if(focusKey(all[i])===key){n=all[i];break;}
+try{if(n)n.focus();if(!n||document.activeElement!==n)tip.focus();}catch(e){}}}
+function show(ev){if(!LAST)return;lastX=(ev&&typeof ev.clientX==='number')?ev.clientX:null;
+tip.classList.remove('ru-modal');tip.style.display='block';render();}
+function close(){tip.style.display='none';tip.classList.remove('ru-modal');back.classList.remove('on');pinned=false;
+window.__rompApiClose=null;if(back.onclick===close)back.onclick=null;
+var fb=focusBack;focusBack=null;try{(fb&&fb.focus?fb:el).focus();}catch(e){}}
+// A click PINS the detail as a centered modal over the dimmed dashboard (the usage modal's own backdrop and
+// pattern); Escape lands via _LANDING_ESC_JS (shell AND pane documents), the backdrop tap closes too. An open
+// usage modal is closed FIRST, explicitly: the two share #ru-back, and its one handler must belong to one modal.
+// Focus moves into the detail and comes back to the cell (or wherever it was) on close.
+function open(){if(!LAST)return;try{window.__rompUsageClose&&window.__rompUsageClose();}catch(e){}
+focusBack=document.activeElement;pinned=true;tip.classList.add('ru-modal');tip.style.left='';tip.style.top='';
+tip.style.display='block';render();back.classList.add('on');
+window.__rompApiClose=close;back.onclick=close;try{tip.focus();}catch(e){}}
+// The listeners sit on the STABLE #rail-api cell; __rompApiHealth writes its children, never the cell.
+el.addEventListener('mouseenter',function(ev){if(!pinned)show(ev);});
+el.addEventListener('mouseleave',function(){if(!pinned)tip.style.display='none';});
+el.addEventListener('click',function(){if(pinned)close();else open();});
+el.addEventListener('keydown',function(ev){if(ev.key==='Enter'||ev.key===' '){ev.preventDefault();if(pinned)close();else open();}});
+// Click-safe across a frame (ui/CLAUDE.md): a frame that lands while a pointer is DOWN over the detail is painted
+// on release, never under the press, so the pressed button survives to its click. A PRIMARY release inside the
+// detail is followed by the click, so the flush waits for it (a swap between mouseup and click would detach the
+// target); a release anywhere else flushes at once. Only a primary press arms the defer: no click follows a right
+// or middle button (auxclick and contextmenu do), so a frame deferred under one would stay unpainted until the
+// next frame changed something while the cell already showed the new world. Event-based, no timer.
+tip.addEventListener('pointerdown',function(ev){if(ev.button===0)held=true;});
+function flush(){if(dirty){dirty=false;if(tip.style.display==='block')render();}}
+function release(ev){if(!held)return;held=false;if(ev&&ev.type==='pointerup'&&ev.button===0&&ev.target&&tip.contains(ev.target))return;flush();}
+document.addEventListener('pointerup',release);
+document.addEventListener('pointercancel',release);
+// The detail's actions are DELEGATED on the stable #ah-tip node via data-act: a click, or Enter / Space on a
+// focused row or footer link (the button's own keys fire its click natively, so the key path skips it).
+function actOf(n){while(n&&n!==tip&&!(n.getAttribute&&n.getAttribute('data-act')))n=n.parentNode;return (n&&n!==tip)?n:null;}
+function run(t){var act=t.getAttribute('data-act');
+if(act==='pause'){var v=t.getAttribute('data-val')==='1';
+// focus moves to the dialog BEFORE the button is disabled: a disabled element cannot hold focus, so it would fall
+// to the page body, where the Tab trap below (a listener on the card) no longer sees the keys and a Shift+Tab
+// walks out of the aria-modal dialog. The card is where open() lands focus too; the answering frame's re-render
+// leaves it there (render restores a focused CONTROL only), and the first Tab reaches the first control.
+try{tip.focus();}catch(e){}
+t.disabled=true;t.textContent=v?RESUME:STOP;t.classList.add('romp-acted');pending=v?1:0;pendSeq=LAST?LAST.seq:null;hint='';   // acknowledged before any round trip
+// the shell socket carries the same op the chat card sends; the handler marks the views dirty, and the next
+// cycle's frame answers (its seq moved: the press wrote the pause file). A dead socket says so instead of a
+// silent no-op (fail loudly): the label and the un-pressed styling come back, and the reason sits under the button.
+if(!(window.__rompShellSend&&window.__rompShellSend({type:'setGlobalRetryPaused',value:v}))){pending=null;hint=NOTSENT;dirty=true;}}
+else if(act==='reveal'){var sid=t.getAttribute('data-sid')||'';
+// the feed's own session links post openSession (feed.ts openOrReviveSession) on a socket that carries this
+// dashboard's wid, and the shell socket carries it too (shellWS), so the kernel aims the focus at THIS
+// dashboard's chat alone (_reveal_chat_for), never at every open window's. No pane is toggled here, so nothing
+// about the layout is persisted.
+if(window.__rompShellSend&&window.__rompShellSend({type:'openSession',id:sid}))close();else{hint=NOTSENT;dirty=true;}}
+else if(act==='usage'){close();try{window.__rompUsagePanel&&window.__rompUsagePanel();}catch(e){}}
+else if(act==='log'){close();try{window.__rompOpenErrs&&window.__rompOpenErrs();}catch(e){}}}
+tip.addEventListener('click',function(ev){var t=actOf(ev.target);if(t)run(t);flush();});
+// Keyboard inside the dialog: Tab and Shift+Tab cycle within the card (a focus trap: the page behind a modal is
+// not where Tab should go; Escape is the way out, via _LANDING_ESC_JS). The card itself (tabindex -1) is where
+// focus lands on open, so the first Tab reaches the first control and the first Shift+Tab the last.
+function controls(){var out=[],all=tip.querySelectorAll('[tabindex="0"],button');for(var i=0;i<all.length;i++)if(!all[i].disabled)out.push(all[i]);return out;}
+tip.addEventListener('keydown',function(ev){if(!pinned)return;
+if(ev.key==='Tab'){var f=controls(),i=f.indexOf(document.activeElement);
+if(!f.length){ev.preventDefault();return;}
+if(ev.shiftKey){if(i<=0){ev.preventDefault();f[f.length-1].focus();}}
+else if(i<0||i===f.length-1){ev.preventDefault();f[0].focus();}
+return;}
+if(ev.key!=='Enter'&&ev.key!==' ')return;var t=actOf(ev.target);if(!t||t.tagName==='BUTTON')return;
+ev.preventDefault();run(t);flush();});
+// The shell socket closed (shellWS's onclose, before its redial). A press acknowledged on that socket can no longer be
+// answered: its frame would have come on the socket that died. The redial's ready handler re-sends the last frame
+// VERBATIM (_apih_resend), so a press the kernel never received would otherwise keep the button disabled and relabeled
+// across the reconnect, through closing and reopening the detail, until some unrelated pause write moved the seq.
+// So the acknowledgment clears here, with the reason under the button; if the kernel DID take the press, the re-sent
+// frame's seq has moved and it repaints the truth either way. Painted on release under a held pointer, like a frame.
+window.__rompApiSocketLost=function(){if(pending===null)return;pending=null;pendSeq=null;hint=LOST;
+if(tip.style.display!=='block')return;if(held){dirty=true;return;}render();};
+window.__rompApiHealth=function(m){if(!m||!m.state)return;LAST=m;hint='';   // a frame means the socket is alive
+// the frame that answers a press: the press wrote the pause file, so the kernel's seq moved past the one we saw (a
+// frame from before the press carries that one and keeps the acknowledgment). Whatever state it brings is the
+// truth the button reads, paused again included: a limit or spend pause re-engages within the cycle, and a rule
+// that cleared only on a frame whose state matched the press would leave a Resume disabled and mislabeled for the window.
+if(pending!==null&&(m.seq==null||m.seq!==pendSeq))pending=null;
+if(el.hidden)el.hidden=false;   // the first frame reveals the cell (a kernel that sends none shows nothing)
+if(el.getAttribute('data-state')!==m.state||txt.textContent!==m.text){el.setAttribute('data-state',m.state);txt.textContent=m.text;el.setAttribute('aria-label','API '+m.text);}
+if(tip.style.display!=='block')return;   // an open detail re-renders from the new frame, nothing else does
+if(held){dirty=true;return;}render();};
+})();
 """
 
 
@@ -43934,6 +44539,10 @@ function shellDiag(what,data){var m={type:'clientDiag',surface:'shell',what:what
 if(shellSock&&shellSock.readyState===1){try{shellSock.send(JSON.stringify(m));}catch(e){}}
 else if(diagQ.length<DIAGQ_MAX)diagQ.push(m);}
 window.__rompShellDiag=shellDiag;
+// the bottom bar's API health detail sends its ops (the pause button's setGlobalRetryPaused, a row's openSession)
+// on the shell socket, whose wid aims a reveal at THIS dashboard; false when no socket is open, so the button can
+// say so instead of dropping the op (_LANDING_APIH_JS). Reads shellSock, which each dial replaces.
+window.__rompShellSend=function(o){try{if(shellSock&&shellSock.readyState===1){shellSock.send(JSON.stringify(o));return true;}}catch(e){}return false;};
 function wid(){try{return sessionStorage.getItem('romp:wid')||'';}catch(e){return '';}}
 // Pin the shell to the TRUE visible viewport. body{height:100dvh} alone left a dead slab below the
 // Chat/Feed/Timeline bar on real Android Chrome — dvh didn't track the painted area (the user 2026-06-19).
@@ -44048,9 +44657,13 @@ try{(m.n?navigator.setAppBadge(m.n):navigator.clearAppBadge())['catch'](function
 // the master bell toggled somewhere (this tab included) — repaint ours from the kernel's word
 else if(m&&m.type==='notifyAll'&&window.__rompNotifyAllPaint)window.__rompNotifyAllPaint(!!m.on);
 else if(m&&m.type==='notifyTurns'&&window.__rompNotifyTurnsPaint)window.__rompNotifyTurnsPaint(!!m.on);
+// the bottom bar's API health cell: one frame, painted by _LANDING_APIH_JS (sent on change + on ready)
+else if(m&&m.type==='apiHealth'&&window.__rompApiHealth)window.__rompApiHealth(m);
 // the boot check found a newer romp release — raise the update banner on every open dashboard
 else if(m&&m.type==='updateAvail'&&window.__rompUpdateOffer)window.__rompUpdateOffer(m.cur||'',m.tag||'',m.drift||'',m.boot||'',m.state||'');};
-ws.onclose=function(){if(shellSock===ws)shellSock=null;setTimeout(shellWS,2000);};}catch(e){}}
+// the API health detail's pause acknowledgment rides this socket: a press it carried cannot be answered now (the
+// redial's ready re-sends the last frame verbatim), so the detail is told before the redial (_LANDING_APIH_JS)
+ws.onclose=function(){try{window.__rompApiSocketLost&&window.__rompApiSocketLost();}catch(e){}if(shellSock===ws)shellSock=null;setTimeout(shellWS,2000);};}catch(e){}}
 shellWS();
 var last='chat';try{var s=localStorage.getItem(KT);if(s&&F[s])last=s;}catch(e){}show(last);
 })();
@@ -45174,6 +45787,10 @@ def _landing():
             # a glance (used ahead of elapsed = burning too fast) — then the used-% readout. All inline on one row;
             # the windows sit side-by-side. Full detail (elapsed %, reset countdown, age) stays in the hover panel.
             "#rail-usage{flex:0 0 auto;display:flex;flex-direction:row;align-items:center;gap:16px}"
+            # renderRows empties the cell on a login-only machine (no bars, no spend); as a zero-width flex
+            # item it still paid .rail-scroll's gap on both sides, so the API cell beside it sat 28px from
+            # the pane buttons instead of 16px. Empty means gone.
+            "#rail-usage:empty{display:none}"
             ".ru-w{display:flex;flex-direction:row;align-items:center;gap:7px;cursor:default}"
             ".ru-name{font:600 10px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#9aa4ad;letter-spacing:.02em;white-space:nowrap}"
             ".ru-bars{display:flex;flex-direction:column;gap:2px;flex:0 0 auto}"   # used bar stacked over elapsed bar
@@ -45184,6 +45801,38 @@ def _landing():
             # the tooltip, labelled "last known" and faded, which is honest because it says what it is.
             ".ru-tip-row.ru-unk i{opacity:.3}.ru-tip-row.ru-unk .ru-tip-k,.ru-tip-row.ru-unk .ru-tip-v{color:#8a97a6}"
             ".ru-pct{font:600 10px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#cfe6ff;font-variant-numeric:tabular-nums;white-space:nowrap}"
+            # the API health cell. The dot wears STATUS hexes, never var(--accent): the label gray at .55 for
+            # ok (a healthy API costs no attention), the tab-retrying amber for degraded, the API-error red
+            # (--st-blocked-bg) for paused. The word is .ru-pct's declaration byte for byte (no new font
+            # size), in the label gray when ok and the bright value color otherwise. The same dot, keyed by
+            # its own data-state, heads the detail card.
+            # The cell ships with the hidden attribute and shows on its first frame (the markup below). The UA's
+            # [hidden]{display:none} loses to ANY author display rule, and .ru-w{display:flex} above is one, so
+            # without this author rule the rail would show a gray 'API ok' from page load, and forever on a
+            # kernel that never sends a frame (the #mtabs button[hidden] idiom).
+            "#rail-api[hidden]{display:none}"
+            ".ah-dot{width:7px;height:7px;border-radius:50%;background:#9aa4ad;opacity:.55;flex:0 0 auto}"
+            "#rail-api[data-state=degraded] .ah-dot,.ah-dot[data-state=degraded]{background:#e67e22;opacity:1}"
+            "#rail-api[data-state=paused] .ah-dot,.ah-dot[data-state=paused]{background:#e5484d;opacity:1}"
+            ".ah-text{font:600 10px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#cfe6ff;font-variant-numeric:tabular-nums;white-space:nowrap}"
+            "#rail-api[data-state=ok] .ah-text{color:#9aa4ad}"
+            "#rail-api{cursor:pointer;margin-left:4px}"
+            # the detail card's own rows, in the tip's font and palette (#ah-tip shares #ru-tip's skin below)
+            ".ah-head{gap:7px}.ah-word{font-weight:700;color:#e8eef5}.ah-since{opacity:.55;margin-left:auto}"
+            ".ah-line{margin-top:4px;max-width:340px}"
+            ".ah-btn{margin-top:6px;font:inherit;padding:3px 9px;border-radius:5px;border:1px solid #3a3a3a;background:#2a2a2a;color:#cfd6dd;cursor:pointer}"
+            ".ah-btn[disabled]{opacity:.55;cursor:default}#ah-tip .romp-acted{opacity:.6}"
+            ".ah-row{cursor:pointer;border-radius:4px;margin:2px -4px 0;padding:1px 4px}"
+            ".ah-row:hover{background:rgba(255,255,255,0.06)}"
+            ".ah-sw{width:8px;height:8px;border-radius:2px;background:#6b7a8c;flex:0 0 auto}"
+            ".ah-nm{font-weight:600}.ah-desc{opacity:.75}"
+            ".ah-foot{margin-top:7px;padding-top:5px;border-top:1px solid rgba(255,255,255,0.08);gap:12px}"
+            ".ah-link{cursor:pointer;color:var(--accent)}"
+            # a failed send's reason, under the button it restored; the hover's rows carry no action (.ah-ro),
+            # so no pointer and no hover wash; the pinned detail takes focus as a dialog without a ring on the card
+            ".ah-hint{margin-top:4px;opacity:.75;max-width:340px}"
+            ".ah-row.ah-ro{cursor:default}.ah-row.ah-ro:hover{background:transparent}"
+            "#ah-tip:focus{outline:none}"
             # ONE shared hover panel for BOTH windows (the user 2026-06-26): it reproduces exactly the used/
             # elapsed bars that used to sit under the timeline — per window, a "used" bar (selected colormap)
             # over an "elapsed" bar (slate) with the % + reset countdown, and nothing else (no prose).
@@ -45195,7 +45844,7 @@ def _landing():
             # #ru-tip is a hover tooltip, pointer-events:none) so the pane can actually scroll — which also
             # stops a tap on the panel itself falling through to the dismiss backdrop; only backdrop taps
             # (and Escape) close it now, the modal contract everywhere else on the dashboard.
-            "#ru-tip.ru-modal{left:50%!important;top:44%!important;transform:translate(-50%,-50%);max-width:92vw;"
+            "#ah-tip.ru-modal,#ru-tip.ru-modal{left:50%!important;top:44%!important;transform:translate(-50%,-50%);max-width:92vw;"
             "max-height:84vh;max-height:84dvh;overflow-y:auto;pointer-events:auto;"
             "box-shadow:0 12px 36px #000000aa}"
             # the dismiss backdrop for the mobile Usage modal: below the tip (z 300), above the panes; a tap
@@ -45255,10 +45904,10 @@ def _landing():
             "#rsp-tip{position:fixed;z-index:310;pointer-events:none;display:none;background:#1e1e1e;border:1px solid #3a3a3a;"
             "border-radius:6px;padding:5px 8px;color:#cfd6dd;font:500 11px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;"
             "box-shadow:0 5px 18px rgba(0,0,0,0.45)}#rsp-tip b{color:#e8eef5;font-weight:700}"
-            "#ru-tip{position:fixed;z-index:300;background:#1e1e1e;border:1px solid #3a3a3a;border-radius:7px;"
+            "#ah-tip,#ru-tip{position:fixed;z-index:300;background:#1e1e1e;border:1px solid #3a3a3a;border-radius:7px;"
             "padding:8px 10px;font:500 11px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#cfd6dd;"
             "box-shadow:0 5px 18px rgba(0,0,0,0.45);pointer-events:none;line-height:1.4}"
-            ".ru-tip-win{margin-bottom:8px}#ru-tip .ru-tip-win:last-child{margin-bottom:0}"
+            ".ru-tip-win{margin-bottom:8px}#ah-tip .ru-tip-win:last-child,#ru-tip .ru-tip-win:last-child{margin-bottom:0}"
             # Multi-host breakdown: one COLUMN per host, side by side (the user 2026-08-08 — not one
             # tall stack). flex-wrap lets the mobile modal (92vw cap) fold back to a stack on its own.
             ".ru-tip-cols{display:flex;gap:18px;align-items:flex-start;flex-wrap:wrap}"
@@ -45564,7 +46213,7 @@ def _landing():
             "body.theme-light #rnet-x{color:#5D574E}body.theme-light #rnet-x:hover{color:#1F1E1D}"
             "body.theme-light #rfleet-panel{background:#FFFFFF;border-color:rgba(0,0,0,0.12);color:#1F1E1D;"
             "box-shadow:0 12px 36px rgba(31,26,20,0.18)}"
-            "body.theme-light #ru-tip{background:#FFFFFF;border-color:rgba(0,0,0,0.12);color:#1F1E1D;"
+            "body.theme-light #ah-tip,body.theme-light #ru-tip{background:#FFFFFF;border-color:rgba(0,0,0,0.12);color:#1F1E1D;"
             "box-shadow:0 5px 18px rgba(31,26,20,0.18)}"
             # the usage modal's light steps (T247): same card + hairlines as the other light panels;
             # the data colors are the sessions' own and do not flip
@@ -45588,6 +46237,19 @@ def _landing():
             "body.theme-light .ru-tip-name{color:#1F1E1D}"
             "body.theme-light .ru-name{color:#5D574E}"
             "body.theme-light .ru-pct{color:#1F1E1D}"
+            "body.theme-light .ah-text{color:#1F1E1D}"
+            # the ok dot: the dark label gray at .55 blends into the light rail (about 1.4:1); the light label
+            # color at the same opacity keeps the glyph where the eye expects it. Scoped to the ok state: a
+            # bare `body.theme-light .ah-dot` (0,2,1) would outrank the detail's `.ah-dot[data-state=...]`
+            # state rules (0,2,0), and the card's headline dot would lose its amber and red in the light
+            # theme while the rail's id-scoped dot kept them
+            "body.theme-light #rail-api[data-state=ok] .ah-dot,body.theme-light .ah-dot[data-state=ok]{background:#5D574E}"
+            "body.theme-light #rail-api[data-state=ok] .ah-text{color:#5D574E}"
+            "body.theme-light .ah-word{color:#1F1E1D}"
+            "body.theme-light .ah-btn{background:#F1EAE2;border-color:rgba(0,0,0,0.12);color:#1F1E1D}"
+            "body.theme-light .ah-row:hover{background:rgba(0,0,0,0.05)}"
+            "body.theme-light .ah-row.ah-ro:hover{background:transparent}"
+            "body.theme-light .ah-foot{border-top-color:rgba(0,0,0,0.10)}"
             "body.theme-light .ru-track{background:rgba(0,0,0,0.10)}"
             "body.theme-light #mtabs{background:#E7DED2;border-top-color:#DCD2C4}"
             "body.theme-light #mtabs button{color:#5D574E}"
@@ -45656,6 +46318,15 @@ def _landing():
             # the Claude /usage rate-limit bars (Pro/Max): three compact vertical bar-pairs (used % colored +
             # elapsed % slate), %-label, full detail on hover — side-by-side in the bottom bar.
             "<div id=rail-usage data-keycmd=usage.open></div>"
+            # the API health cell: its own label, a 7px dot, one word, painted by _LANDING_APIH_JS from the
+            # kernel's apiHealth push. Ships HIDDEN: it shows on its first frame, so a kernel that never sends
+            # one shows nothing rather than a false ok. Its own element, not a child of #rail-usage (renderRows
+            # empties that one when there are no bars and no spend). No title (the rail's no-title rule); no
+            # data-keycmd yet. role=button + tabindex=0 make it a keyboard control (Enter / Space open the
+            # detail); aria-label follows the frame's text.
+            "<div id=rail-api class=\"ru-w ru-ah\" hidden role=button tabindex=0 aria-label=\"API ok\" data-state=ok>"
+            "<span class=ru-name>API</span>"
+            "<i class=ah-dot></i><span class=ah-text>ok</span></div>"
             "</div>"   # /.rail-scroll
             # refresh + network + settings, pinned to the far RIGHT (settings last), always visible:
             "<div class=rail-acts>"
@@ -45830,6 +46501,7 @@ def _landing():
             + ("<script src=/dist/age-color-global.js?v=%d></script>" % v) +
             "<script>" + _LANDING_ERRS_JS + "</script>"
             "<script>" + _LANDING_USAGE_JS.replace("__ROMP_LOADER__", json.dumps(_loader_inner())) + "</script>"
+            "<script>" + _LANDING_APIH_JS + "</script>"
             "<script>" + _LANDING_JS + "</script>"
             "<script>" + _LANDING_FOCUS_JS + "</script>"
             "<script>" + _LANDING_ESC_JS + "</script>"
@@ -48423,6 +49095,7 @@ class Handler(BaseHTTPRequestHandler):
                     client["send"](json.dumps({"type": "badge", "n": _BADGE_LAST[0]}))
                 except Exception:
                     pass
+            _apih_resend(client)          # and the bottom bar's API cell, from the last frame (same reason)
         elif msg and msg.get("type") == "setSessionFlag" and msg.get("id") and msg.get("flag"):
             # timeline lane gear → toggle a per-session view flag (e.g. hideFromFeed). Persisted +
             # re-broadcast so the feed drops/restores that session's cards immediately. The notify

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -22,6 +22,7 @@ import difflib
 import errno
 import hashlib
 import json
+import math
 import os
 import re
 import shutil
@@ -2009,6 +2010,11 @@ class ApiHealth:
         self._last_state: dict = {}
         self._transitions: deque = deque(maxlen=API_HEALTH_TRANSITIONS_KEEP)   # the global tail, newest last
         self._by_bucket: dict = {}       # bucket key -> deque(maxlen=API_HEALTH_TRANSITIONS_KEEP): that bucket's own tail
+        # the boot's stamp in the signal: boot_at truncated to the millisecond, or one millisecond past the newest
+        # restored transition when that is not before it. Set by _seed; served as the payload's bootAt, and the
+        # stateSince of every bucket the boot seeded and the t of every row the boot filed carry the same number
+        # (a route stamping its own number would be a second one whenever the clamp fired)
+        self.boot_stamp = None
         self._seed(time.time() if boot_at is None else float(boot_at))
 
     # ---- labels ----
@@ -2146,17 +2152,24 @@ class ApiHealth:
 
     @staticmethod
     def _row_ok(r) -> bool:
-        """A persisted transition row: a dict with a non-empty string `bucket` and `to` and a numeric `t`."""
+        """A persisted transition row: a dict with a non-empty string `bucket` and `to` and a finite numeric `t`.
+        A `t` that is missing, null, a bool, a string, not finite, or an int no float can hold fails the row, so
+        the seed's max over the restored stamps never meets one (`float(r.get("t") or 0)` passed a null t, the max
+        then raised on it, and the outer guard dropped EVERY restored row and bucket, not the one; math.isfinite
+        converts an int to float first and RAISES OverflowError past about 309 digits instead of answering, and
+        json.loads reads a 400-digit integer literal as such an int, so the raise would leave this check for the
+        same outer guard, with the same loss)."""
         if not isinstance(r, dict):
             return False
-        b, to = r.get("bucket"), r.get("to")
+        b, to, t = r.get("bucket"), r.get("to"), r.get("t")
         if not (isinstance(b, str) and b and isinstance(to, str) and to):
             return False
-        try:
-            float(r.get("t") or 0)
-        except (TypeError, ValueError):
+        if not isinstance(t, (int, float)) or isinstance(t, bool):
             return False
-        return True
+        try:
+            return math.isfinite(t)
+        except OverflowError:       # an int beyond float range: not a stamp float(t) can read
+            return False
 
     def _seed(self, boot_at: float):
         """Restore the per-bucket (state, stateSince, why, evidence) and the transition tail from
@@ -2166,9 +2179,23 @@ class ApiHealth:
         list is continuous across the restart and the first read with enough evidence records
         `unknown -> <state>` after it. What the boot filed is written.
 
+        The seed is stamped at `boot_at` truncated to the millisecond (math.floor, never round: a start at
+        X.9996 would round to (X+1).000 while /version's `started` is int(X.9996) = X), or one millisecond past
+        the newest transition the file carries when that is not before it: a transition the previous kernel
+        filed after this one's start (the two overlapped, or the clock stepped) would otherwise sort ABOVE
+        the restart row in the tail and read as the current state, with the head saying unknown since the
+        boot. The clamp is logged once. The stamp is kept as `boot_stamp` and served as the payload's bootAt,
+        so bootAt, the stateSince of every bucket the boot seeded and the restart rows are one number in
+        every case, clamp or not.
+
         Never raises: this runs inside SdkBackend.__init__, and an exception here pinned the SDK backend
         unavailable for the kernel's whole life. A row that is not JSON, lacks its fields, or carries a
-        non-numeric `t` or a non-string `bucket` is skipped; the skips are logged once."""
+        missing, null, non-numeric or non-finite `t` (an int past float range included) or a non-string
+        `bucket` is skipped and counted; the skips are logged once, and the other rows are kept."""
+        # floor, so int(boot_stamp) == int(boot_at) (/version's started) whenever nothing is clamped: a float one step
+        # below a whole second multiplies to more than half an ulp below it, so the floor never lands on the next second
+        base = math.floor(boot_at * 1000) / 1000.0
+        self.boot_stamp = base
         try:
             rows, per, recs, bad = [], {}, {}, 0
             try:
@@ -2202,6 +2229,17 @@ class ApiHealth:
                         bad += 1
             if bad and self._log:
                 self._log("api-health: %d malformed row(s) skipped at boot (%s)" % (bad, API_HEALTH_STATE_FILE))
+            # one stamp, at the tail's millisecond precision, for the restart rows, the seeded since and the payload's
+            # bootAt: the boot itself, or one millisecond past the newest restored transition when that is not before
+            # the boot (every row passed _row_ok, so every t here is a finite number)
+            at = base
+            newest = max((float(r["t"]) for rs in [rows] + list(per.values()) for r in rs), default=None)
+            if newest is not None and newest >= at:
+                if self._log:
+                    self._log("api-health: the state file's newest transition (%.3f) is not before this boot (%.3f): "
+                              "seeding at %.3f so the restart row stays the newest" % (newest, at, newest + 0.001))
+                at = round(newest + 0.001, 3)
+            self.boot_stamp = at
             filed = False
             with self._lock:
                 self._transitions.extend(rows)
@@ -2213,11 +2251,11 @@ class ApiHealth:
                     fam = rec["family"] if isinstance(rec["family"], str) and rec["family"] else f
                     ev = {"window": None, "rate429": None, "rate5xx": None, "n": 0}
                     if rec["state"] != "unknown":
-                        self._file_locked({"t": round(boot_at, 3), "bucket": key, "auth": auth, "family": fam,
+                        self._file_locked({"t": at, "bucket": key, "auth": auth, "family": fam,
                                            "from": rec["state"], "to": "unknown", "why": API_HEALTH_RESTART_WHY,
                                            "evidence": ev})
                         filed = True
-                    self._last_state[key] = {"state": "unknown", "since": boot_at, "why": API_HEALTH_RESTART_WHY,
+                    self._last_state[key] = {"state": "unknown", "since": at, "why": API_HEALTH_RESTART_WHY,
                                              "evidence": ev, "auth": auth, "family": fam}
                 if filed:
                     self._write_state_locked()
@@ -2225,6 +2263,7 @@ class ApiHealth:
             if self._log:
                 self._log("api-health: state file unreadable (%s) — starting with no history" % e)
             self._last_state, self._transitions, self._by_bucket = {}, deque(maxlen=API_HEALTH_TRANSITIONS_KEEP), {}
+            self.boot_stamp = base           # nothing restored, so nothing to clamp past
 
     def _file_locked(self, row: dict):
         """Record one transition in both tails: the global one and its bucket's own. The bucket's tail is
@@ -2267,8 +2306,9 @@ class ApiHealth:
 
     # ---- the read ----
     def snapshot(self, now: float | None = None, uptime_s=None) -> dict:
-        """The /api-health payload minus boot identity (the kernel stamps bootId/bootAt from /version's
-        globals). Windows and states are computed here, from the ring and the last persisted
+        """The /api-health payload minus `bootId` (the kernel stamps that from /version's globals; `bootAt`
+        is this aggregator's `boot_stamp`, the number every seeded stateSince and every restart row
+        carry). Windows and states are computed here, from the ring and the last persisted
         (state, stateSince), at read time; the transitions a read finds are the events that rewrite
         the state file. Every KNOWN bucket is derived — one in the ring, or one the state file remembers
         whose events have all aged out: absent from the ring is `unknown`, filed at the read that found
@@ -2330,7 +2370,8 @@ class ApiHealth:
             if filed:
                 self._write_state_locked()       # once per read, after every bucket's record is current
             transitions = list(self._transitions)
-        return {"schema": API_HEALTH_SCHEMA, "asOf": round(now, 3), "uptimeS": None if uptime_s is None else round(uptime_s, 1),
+        return {"schema": API_HEALTH_SCHEMA, "asOf": round(now, 3), "bootAt": self.boot_stamp,
+                "uptimeS": None if uptime_s is None else round(uptime_s, 1),
                 "complete": None if uptime_s is None else bool(uptime_s >= max(cfg["windows"])),
                 "seq": seq, "lastEventAt": None if last_at is None else round(last_at, 3),
                 "rate429Basis": "attempts",
@@ -7011,7 +7052,7 @@ class SdkBackend:
     def __init__(self, state_dir, claude_bin: str, notify, poke=None, push=None,
                  push_session=None,
                  mcp_config: str | None = None, append_prompt_path: str | None = None,
-                 log=None, reconcile: bool = False):
+                 log=None, reconcile: bool = False, boot_at=None):
         self.state_dir = Path(state_dir)
         self.claude_bin = claude_bin
         self.thread_wake_model = None      # kernel-installed: model_id -> replacement or None, consulted
@@ -7083,7 +7124,11 @@ class SdkBackend:
         self._problem_lock = threading.Lock()
         # The /api-health aggregator (one ring, one lock; see ApiHealth). Fed from _on_message on each
         # session's thread, read by the kernel's route; the salt is minted lazily at the first label.
-        self.api_health = ApiHealth(self.state_dir, log=self._log)
+        # Seeded as of `boot_at`, the kernel's own start when the kernel passes it (the aggregator truncates
+        # it to the millisecond and serves the stamp as the payload's bootAt), else this construction's
+        # clock: the two run seconds apart, and a hover head naming one for a bucket the boot seeded while
+        # the tail's divider named the other would name two different minutes for one boot.
+        self.api_health = ApiHealth(self.state_dir, log=self._log, boot_at=boot_at)
         # The dependency check, done ONCE here: absent → every session this backend owns reports the same
         # launch error (launch_error), instead of each one silently dying at its own lazy import.
         self._sdk_missing = not sdk_importable()
@@ -8417,7 +8462,8 @@ class SdkBackend:
     def api_health_snapshot(self, now: float | None = None, uptime_s=None) -> dict:
         """The /api-health payload (ApiHealth.snapshot) plus what only the backend knows: how many SDK
         sessions it holds and how many are in a retry storm right now — the cheapest direct thrash
-        indicator, independent of the ratio thresholds. Boot identity is the kernel's to stamp."""
+        indicator, independent of the ratio thresholds. `bootId` is the kernel's to stamp; `bootAt` is
+        the aggregator's own boot stamp, already in the payload."""
         out = self.api_health.snapshot(now, uptime_s=uptime_s)
         with self._lock:
             sess = list(self.sessions.values())

--- a/tests/test_api_error_tail.py
+++ b/tests/test_api_error_tail.py
@@ -170,7 +170,7 @@ class ApiErrorTailWindow(unittest.TestCase):
         above also holds against a scan that always starts at byte 0, i.e. with the speedup silently gone."""
         p = self._write(recs)
         starts = []
-        real = km._api_error_scan
+        real = km._api_error_pass                       # the ONE pass both transcript readers share
 
         def recording(path, start):
             starts.append(start)
@@ -178,13 +178,14 @@ class ApiErrorTailWindow(unittest.TestCase):
                 raise AssertionError("the widen loop is not terminating: %r" % starts[:8])
             return real(path, start)
         saved = km._API_ERR_TAIL_WINDOW
-        km._api_error_scan = recording
+        km._api_error_pass = recording
         try:
             km._API_ERR_TAIL_WINDOW = window
             km._api_err_cache.clear()
+            km._api_last_failed_cache.clear()
             got = km._api_error(p)
         finally:
-            km._api_error_scan = real
+            km._api_error_pass = real
             km._API_ERR_TAIL_WINDOW = saved
         return starts, got, p
 
@@ -237,6 +238,222 @@ class ApiErrorTailWindow(unittest.TestCase):
         self.assertIsNotNone(first)
         self.assertIn(p, km._api_err_cache, "an unchanged (mtime,size) must stay cached")
         self.assertEqual(km._api_error(p), first)
+
+
+# ── _api_last_failed: the LATCH behind the bottom bar's API health cell ──────────────────────────────
+from datetime import datetime, timezone
+
+T_BASE = 1_700_000_000
+
+
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _ts_err_rec(t, status=500, category="server_error", text="API Error: 500 server_error"):
+    o = {"type": "assistant", "timestamp": _iso(t), "uuid": "aaaaaaaa-0000-0000-0000-00000000%04d" % (t - T_BASE),
+         "parentUuid": U_PROMPT, "isApiErrorMessage": True, "error": category,
+         "message": {"role": "assistant", "content": [{"type": "text", "text": text}]}}
+    if status is not None:
+        o["apiErrorStatus"] = status
+    return o
+
+
+def _ts_prompt_rec(t, text="try that again"):
+    return {"type": "user", "timestamp": _iso(t), "uuid": U_OTHER,
+            "message": {"role": "user", "content": text}}
+
+
+def _ts_out_rec(t):
+    return {"type": "assistant", "timestamp": _iso(t), "uuid": "aaaaaaaa-0000-0000-0000-0000000000ff",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "back on track"}]}}
+
+
+def _ts_tool_result_rec(t, i=0):
+    return {"type": "user", "timestamp": _iso(t), "uuid": "bbbbbbbb-0000-0000-0000-%012d" % i,
+            "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_%d" % i,
+                                                     "content": "ok"}]}}
+
+
+class ApiLastFailedLatch(unittest.TestCase):
+    """_api_last_failed is _api_error's latched sibling: an isApiErrorMessage record holds until ASSISTANT
+    OUTPUT follows it, through romp's own injected RETRY_MSG and through a human prompt alike, both of which
+    clear _api_error (a retry rightly un-blocks the session; it says nothing about the API). Same tail-first
+    widening, its own (mtime, size) cache; the scan's default keyword leaves _api_error's verdicts untouched."""
+
+    def setUp(self):
+        km._api_err_cache.clear()
+        km._api_last_failed_cache.clear()
+        self.td = tempfile.TemporaryDirectory()
+        self.p = os.path.join(self.td.name, "t.jsonl")
+        self._win = km._API_ERR_TAIL_WINDOW
+
+    def tearDown(self):
+        km._API_ERR_TAIL_WINDOW = self._win
+        km._api_err_cache.clear()
+        km._api_last_failed_cache.clear()
+        self.td.cleanup()
+
+    def _write(self, *recs):
+        with open(self.p, "w") as f:
+            f.write("\n".join(json.dumps(r) for r in recs) + "\n")
+
+    def _append(self, *recs):
+        with open(self.p, "a") as f:
+            f.write("\n".join(json.dumps(r) for r in recs) + "\n")
+
+    def test_romp_s_own_retry_prompt_clears_api_error_but_not_the_latch(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5, status=529, category="overloaded"),
+                    _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG))
+        self.assertIsNone(km._api_error(self.p), "the retry un-blocks the session")
+        e = km._api_last_failed(self.p)
+        self.assertIsNotNone(e, "the API has not answered yet: the record holds")
+        self.assertEqual((e["status"], e["category"], e["t"]), (529, "overloaded", T_BASE + 5))
+
+    def test_a_human_prompt_after_the_error_splits_the_same_way(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5), _ts_prompt_rec(T_BASE + 60, "please continue"))
+        self.assertIsNone(km._api_error(self.p))
+        e = km._api_last_failed(self.p)
+        self.assertEqual((e["status"], e["t"]), (500, T_BASE + 5))
+
+    def test_fresh_assistant_output_clears_both(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5), _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG),
+                    _ts_out_rec(T_BASE + 20))
+        self.assertIsNone(km._api_error(self.p))
+        self.assertIsNone(km._api_last_failed(self.p), "the API answered: the one event that clears the latch")
+
+    def test_a_tool_result_record_clears_neither(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5), _ts_tool_result_rec(T_BASE + 6))
+        self.assertIsNotNone(km._api_error(self.p))
+        self.assertIsNotNone(km._api_last_failed(self.p))
+
+    def test_a_newer_error_record_replaces_the_latched_one(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5, status=529, category="overloaded"),
+                    _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG), _ts_err_rec(T_BASE + 12, status=429, category="rate_limit"))
+        e = km._api_last_failed(self.p)
+        self.assertEqual((e["status"], e["t"]), (429, T_BASE + 12), "a new failed attempt is new information")
+
+    def test_the_on_you_flags_ride_the_latched_record(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5, status=400, category="invalid_request",
+                                                          text="API Error: 400 prompt is too long"),
+                    _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG))
+        self.assertTrue(km._api_last_failed(self.p)["tooLong"], "the frame excludes it by this flag")
+
+    def test_a_refusal_record_marks_the_latched_episode_too(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5, status=400, category="invalid_request"),
+                    _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG), _filler(1), _refusal_rec())
+        self.assertIsNone(km._api_error(self.p), "the prompt cleared the blocking verdict before the refusal record")
+        self.assertTrue(km._api_last_failed(self.p)["refusal"], "the latched record is the one the refusal annotates")
+
+    def test_the_cache_serves_an_unchanged_transcript_and_busts_on_a_size_change(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5))
+        e = km._api_last_failed(self.p)
+        self.assertEqual(e["status"], 500)
+        scan = km._api_error_pass
+        km._api_error_pass = lambda *a, **k: self.fail("an unchanged transcript is served from the cache")
+        try:
+            self.assertIs(km._api_last_failed(self.p), e)
+        finally:
+            km._api_error_pass = scan
+        self._append(_ts_out_rec(T_BASE + 20))                # the size moved: a fresh scan, a fresh answer
+        self.assertIsNone(km._api_last_failed(self.p))
+        self.assertIsNone(km._api_error(self.p), "the sibling reads the same fresh answer")
+
+    def test_the_two_caches_are_independent(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5), _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG))
+        self.assertIsNone(km._api_error(self.p))
+        self.assertIsNotNone(km._api_last_failed(self.p), "a cached None from _api_error is not this answer")
+        self.assertIn(self.p, km._api_err_cache)
+        self.assertIn(self.p, km._api_last_failed_cache)
+
+    def test_the_latch_widens_past_a_tail_of_prompts(self):
+        km._API_ERR_TAIL_WINDOW = 64                       # a window that ends inside the prompts
+        pad = "x" * 200
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5, status=529, category="overloaded"),
+                    *[_ts_prompt_rec(T_BASE + 10 + i, pad) for i in range(6)])
+        self.assertIsNone(km._api_error(self.p), "the default scan decides at the newest prompt")
+        e = km._api_last_failed(self.p)
+        self.assertEqual((e["status"], e["t"]), (529, T_BASE + 5), "the latch widened back to the assistant record")
+
+    def test_the_scan_stamps_the_record_time_and_reads_zero_without_one(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5))
+        err, decided = km._api_error_scan(self.p, 0)
+        self.assertEqual(err["t"], T_BASE + 5)
+        self._write(_prompt_rec(), _err_rec())             # the module's stamp-less records
+        err, _ = km._api_error_scan(self.p, 0)
+        self.assertEqual(err["t"], 0)
+
+    def test_the_default_keyword_is_the_old_scan(self):
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5), _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG))
+        self.assertEqual(km._api_error_scan(self.p, 0), km._api_error_scan(self.p, 0, user_clears=True))
+        self.assertEqual(km._api_error_scan(self.p, 0), (None, True))
+        err, decided = km._api_error_scan(self.p, 0, user_clears=False)
+        self.assertEqual((err["status"], decided), (500, True))
+
+    def test_missing_file_is_none(self):
+        self.assertIsNone(km._api_last_failed(os.path.join(self.td.name, "absent.jsonl")))
+
+    # ── one pass answers both readers ──
+    def _recording(self, passes):
+        real = km._api_error_pass
+        km._api_error_pass = lambda path, start: passes.append(start) or real(path, start)
+        return real
+
+    def test_one_cycle_reads_the_tail_once_for_both_verdicts(self):
+        # Every pusher cycle asks _api_error (the spend-cap check, the feed build) and then _api_last_failed
+        # (the health frame) about the same transcript: one pass over the tail must answer both, in either
+        # order, or a streaming session pays two tail reads and two json parses per cycle on the one hot thread.
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5, status=529, category="overloaded"),
+                    _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG))
+        passes = []
+        real = self._recording(passes)
+        try:
+            self.assertIsNone(km._api_error(self.p))
+            self.assertEqual(km._api_last_failed(self.p)["status"], 529)
+            self.assertEqual(len(passes), 1, "the first read decided both verdicts: %r" % passes)
+            km._api_err_cache.clear()
+            km._api_last_failed_cache.clear()
+            del passes[:]
+            self.assertEqual(km._api_last_failed(self.p)["status"], 529)
+            self.assertIsNone(km._api_error(self.p))
+            self.assertEqual(len(passes), 1, "the other order too: %r" % passes)
+        finally:
+            km._api_error_pass = real
+
+    def test_a_read_that_did_not_reach_an_assistant_record_leaves_the_latch_to_its_own_widening(self):
+        # _api_error's window may decide at a prompt without seeing an assistant record; then it must NOT
+        # cache a latch verdict it never saw, and the latch's own read widens back to the assistant record
+        km._API_ERR_TAIL_WINDOW = 64
+        pad = "x" * 200
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5, status=529, category="overloaded"),
+                    *[_ts_prompt_rec(T_BASE + 10 + i, pad) for i in range(6)])
+        passes = []
+        real = self._recording(passes)
+        try:
+            self.assertIsNone(km._api_error(self.p))
+            self.assertNotIn(self.p, km._api_last_failed_cache, "no assistant record seen: no latch verdict cached")
+            n = len(passes)
+            self.assertEqual(km._api_last_failed(self.p)["status"], 529)
+            self.assertGreater(len(passes), n, "the latch widened on its own")
+            self.assertIsNone(km._api_error(self.p), "and _api_error's own cached verdict stands")
+        finally:
+            km._api_error_pass = real
+
+    def test_the_newest_output_record_s_time_is_kept_beside_the_latch(self):
+        # the spend pause's recovery signal (tests/test_retry_pause_autoresume.py): the time of the newest
+        # ASSISTANT OUTPUT record when it is the newest assistant record, else 0
+        self._write(_ts_prompt_rec(T_BASE), _ts_err_rec(T_BASE + 5), _ts_prompt_rec(T_BASE + 9, km.RETRY_MSG),
+                    _ts_out_rec(T_BASE + 20))
+        self.assertEqual(km._api_last_output_t(self.p), T_BASE + 20)
+        self._append(_ts_prompt_rec(T_BASE + 30, "and now?"))
+        self.assertEqual(km._api_last_output_t(self.p), T_BASE + 20, "a prompt is not output")
+        self._append(_ts_tool_result_rec(T_BASE + 31))
+        self.assertEqual(km._api_last_output_t(self.p), T_BASE + 20, "nor is a tool result")
+        self._append(_ts_err_rec(T_BASE + 35))
+        self.assertEqual(km._api_last_output_t(self.p), 0, "an error after it: no fresh output stands")
+        self._write(_prompt_rec(), _out_rec())
+        self.assertEqual(km._api_last_output_t(self.p), 0, "a record without a timestamp reads 0")
+        self.assertEqual(km._api_last_output_t(os.path.join(self.td.name, "absent.jsonl")), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_api_health_browser.py
+++ b/tests/test_api_health_browser.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python3
+"""The bottom bar's API health cell, driven in a real browser.
+
+The shell page is kernel-served HTML with inline CSS and JS, so it has no jsdom harness: the source pins in
+tests/test_api_health_rail.py and tests/test_kernel_pane_rail.py hold the SHAPE, and this module holds the
+BEHAVIOR those pins approximate. A scratch copy of km._landing() is served from a temp directory over plain
+HTTP with no kernel behind it (every fetch 404s, which is exactly the pre-frame world the cell's hidden rule
+exists for), and playwright's chromium drives it: frames are handed to window.__rompApiHealth directly,
+presses are dispatched as pointer events, and the driver reports what the DOM did. The page's WebSocket is a
+shim installed before load: it never opens on its own, so the first two phases see the same never-connected
+socket a refused connection gives, without the real socket's close-and-redial every two seconds; the third
+phase opens it, feeds it frames, drops it and watches the redial, the way a kernel behind a dropped tunnel
+would. Skips LOUDLY without the extension's node deps or a browser (CI installs none), the way
+tests/test_awaiting_box_sync.py does.
+
+Synthetic only: an invented sid family, the notes-api demo's session names, no real data."""
+import functools
+import http.server
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+import unittest
+from importlib.machinery import SourceFileLoader
+
+# Hermetic state BEFORE the loads: they resolve their state root at import time, and only pytest runs
+# conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+EXT = os.path.join(os.path.dirname(HERE), "vscode-extension")
+km = SourceFileLoader("romp_kernel_apih_browser", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "77777777-aaaa-4bbb-8ccc-00000000000"     # + a digit: the rail test module's private synthetic family
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1200, height: 800 } });
+page.on("pageerror", () => {});                       // the scratch page has no kernel: its sockets and fetches fail
+// the WebSocket shim: every socket the page opens is recorded in window.__socks and does nothing until the driver
+// opens (__open), feeds (__msg) or drops (__drop) it. readyState follows the real constants.
+await page.addInitScript(() => {
+  function Fake(url) { this.url = String(url); this.readyState = 0; this.sent = []; this.onopen = this.onmessage = this.onclose = this.onerror = null;
+    (window.__socks = window.__socks || []).push(this); }
+  Fake.prototype.send = function (d) { if (this.readyState !== 1) throw new Error("not open"); this.sent.push(String(d)); };
+  Fake.prototype.close = function () { this.__drop(); };
+  Fake.prototype.__open = function () { this.readyState = 1; if (this.onopen) this.onopen({}); };
+  Fake.prototype.__msg = function (o) { if (this.onmessage) this.onmessage({ data: JSON.stringify(o) }); };
+  Fake.prototype.__drop = function () { if (this.readyState === 3) return; this.readyState = 3; if (this.onclose) this.onclose({}); };
+  Fake.CONNECTING = 0; Fake.OPEN = 1; Fake.CLOSING = 2; Fake.CLOSED = 3;
+  window.WebSocket = Fake;
+});
+await page.goto(cfg.url);
+await page.waitForFunction(() => typeof window.__rompApiHealth === "function", null, { timeout: 20000 });
+const R = await page.evaluate((SID) => {
+  const R = { err: {} };
+  window.__realShellSend = window.__rompShellSend;             // the page's own binding, before the steps stub it
+  const step = (name, fn) => { try { fn(); } catch (e) { R.err[name] = String(e && e.stack || e); } };
+  const el = document.getElementById("rail-api"), txt = el.querySelector(".ah-text");
+  const tip = () => document.getElementById("ah-tip");
+  const back = document.getElementById("ru-back");
+  const disp = (n) => getComputedStyle(n).display;
+  const row = (i) => ({ sid: SID + i, name: ["web", "api", "tests", "docs"][i], color: null, kind: "blocked",
+                        cls: "529", status: 529, since: 1700000000 + i, suppressed: false });
+  const frame = (over) => Object.assign({ type: "apiHealth", state: "degraded", cls: "529", reason: "",
+    text: "overloaded · 1 waiting", waiting: 1, retrying: 0, blocked: 1, since: 1700000000, tmux: 0,
+    sessions: [row(1)], seq: 1 }, over || {});
+  window.__frame = frame; window.__row = row;                 // the driver's later phases reuse them
+  const bg = (n) => n ? getComputedStyle(n).backgroundColor : "";
+  const btn = () => tip().querySelector("button[data-act=pause]");
+  // 1. before any frame: the cell is not displayed (the hidden attribute must beat .ru-w's display rule)
+  R.preFrameHidden = el.hidden;
+  R.preFrameDisplay = disp(el);
+  R.usageEmptyDisplay = disp(document.getElementById("rail-usage"));
+  R.role = el.getAttribute("role"); R.tabindex = el.getAttribute("tabindex");
+  // 2. the first frame reveals it and names the state for a screen reader
+  window.__rompApiHealth(frame());
+  R.firstFrameDisplay = disp(el); R.firstFrameText = txt.textContent; R.ariaLabel = el.getAttribute("aria-label");
+  step('hover', () => {
+  // 3. the hover surface is inert: no button, no data-act; a growing frame re-anchors it above the rail
+  el.dispatchEvent(new MouseEvent("mouseenter", { bubbles: false, clientX: el.getBoundingClientRect().left + 10 }));
+  R.hoverShown = tip().style.display === "block";
+  R.hoverButtons = tip().querySelectorAll("button").length;
+  R.hoverActs = tip().querySelectorAll("[data-act]").length;
+  const railTop = el.getBoundingClientRect().top;
+  const b1 = tip().getBoundingClientRect();
+  window.__rompApiHealth(frame({ text: "overloaded · 3 waiting", waiting: 3, blocked: 3, sessions: [row(1), row(2), row(3)] }));
+  const b2 = tip().getBoundingClientRect();
+  R.reanchor = { railTop, before: { top: b1.top, bottom: b1.bottom, h: b1.height }, after: { top: b2.top, bottom: b2.bottom, h: b2.height } };
+  el.dispatchEvent(new MouseEvent("mouseleave"));
+  R.hoverHidden = tip().style.display === "none";
+  });
+  step('keyboard', () => {
+  // 4. keyboard: Enter opens the pinned detail and moves focus into it; Escape closes and puts focus back
+  el.focus();
+  el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+  R.kbOpened = tip().style.display === "block" && tip().classList.contains("ru-modal") && back.classList.contains("on");
+  R.kbFocusInTip = tip().contains(document.activeElement);
+  R.tipRole = tip().getAttribute("role");
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+  R.kbClosed = tip().style.display === "none" && !back.classList.contains("on");
+  R.kbFocusBack = document.activeElement === el;
+  });
+  step('usage', () => {
+  // 5. an open usage modal is closed first, explicitly, so the shared backdrop never serves two modals
+  let usageClosed = false;
+  window.__rompUsageClose = () => { usageClosed = true; back.classList.remove("on"); window.__rompUsageClose = null; };
+  back.classList.add("on");
+  el.click();
+  R.usageClosedFirst = usageClosed && tip().style.display === "block" && tip().classList.contains("ru-modal");
+  });
+  step('clicksafe', () => {
+  // 6. click-safe across a frame: a press held on the button defers the re-render; the release flushes it
+  const sent = []; window.__rompShellSend = (o) => { sent.push(o); return true; };
+  const b0 = btn(); R.pinnedHasButton = !!b0;
+  b0.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+  window.__rompApiHealth(frame({ text: "overloaded · 2 waiting", waiting: 2, blocked: 2, sessions: [row(1), row(2)] }));
+  R.heldKeepsNode = document.contains(b0);
+  R.heldKeepsText = /3 waiting/.test(tip().textContent) && !/2 waiting/.test(tip().textContent);   // the pinned frame stays up
+  b0.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+  b0.click();                                          // the click lands on the button that was pressed
+  R.clickSent = sent.map((o) => o.type + ":" + String(o.value));
+  R.flushedOnClick = /2 waiting/.test(tip().textContent);
+  });
+  step('ack', () => {
+  // 7. the acknowledgment survives frames until one confirms the flip
+  const b1n = btn();
+  R.ack = { disabled: b1n.disabled, label: b1n.textContent, acted: b1n.classList.contains("romp-acted") };
+  window.__rompApiHealth(frame({ text: "overloaded · 2 waiting", waiting: 2, blocked: 2, since: 1700000005, sessions: [row(1), row(2)] }));
+  const b2n = btn();
+  R.ackHeld = { disabled: b2n.disabled, label: b2n.textContent, acted: b2n.classList.contains("romp-acted") };
+  window.__rompApiHealth(frame({ state: "paused", reason: "manual", text: "paused by you · 2 waiting", waiting: 2, blocked: 2, sessions: [row(1), row(2)], seq: 2 }));
+  const b3n = btn();
+  R.confirmed = { disabled: b3n.disabled, label: b3n.textContent, acted: b3n.classList.contains("romp-acted") };
+  });
+  step('resumeLimit', () => {
+  // 7b. Resume during a usage-limit pause: the kernel lifts, the limit re-engages within the cycle, and the frame
+  //     that answers is paused again with a new since and a moved seq. The button must read that truth (enabled
+  //     Resume), not hold a disabled 'Stop' for the rest of the window.
+  const sentR = []; window.__rompShellSend = (o) => { sentR.push(o); return true; };
+  window.__rompApiHealth(frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000010, seq: 5 }));
+  const br = btn(); R.resumeBefore = { disabled: br.disabled, label: br.textContent };
+  br.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+  br.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+  br.click();
+  R.resumeSent = sentR.map((o) => o.type + ":" + String(o.value));
+  const bp = btn(); R.resumePending = { disabled: bp.disabled, label: bp.textContent, acted: bp.classList.contains("romp-acted") };
+  window.__rompApiHealth(frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000010, seq: 5 }));
+  const bs = btn(); R.resumeSameSeq = { disabled: bs.disabled, label: bs.textContent, acted: bs.classList.contains("romp-acted") };
+  window.__rompApiHealth(frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000020, seq: 7 }));
+  const ba = btn(); R.resumeAfter = { disabled: ba.disabled, label: ba.textContent, acted: ba.classList.contains("romp-acted") };
+  R.resumeLine = (tip().querySelector(".ah-line") || {}).textContent || "";
+  // back to the paused world the ack step left, so the failed-send step below presses the same Resume it always did
+  window.__rompApiHealth(frame({ state: "paused", reason: "manual", text: "paused by you · 2 waiting", waiting: 2, blocked: 2, sessions: [row(1), row(2)], seq: 7 }));
+  });
+  step('failed', () => {
+  // 8. a failed send restores the label, drops the acted styling and says why
+  window.__rompShellSend = () => false;
+  const bf = btn();
+  bf.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+  bf.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+  bf.click();
+  const b4n = btn();
+  R.failed = { disabled: b4n.disabled, label: b4n.textContent, acted: b4n.classList.contains("romp-acted"),
+               hint: (tip().querySelector(".ah-hint") || {}).textContent || "" };
+  });
+  step('row', () => {
+  // 9. a session row opens that session the way the feed's own links do: openSession on the socket,
+  //    no pane toggle, nothing persisted
+  const sent2 = []; window.__rompShellSend = (o) => { sent2.push(o); return true; };
+  let toggled = 0; window.__rompPaneToggle = () => { toggled++; };
+  const r0 = tip().querySelector(".ah-row[data-act=reveal]");
+  R.rowHasAct = !!r0;
+  if (r0) { r0.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true })); r0.dispatchEvent(new PointerEvent("pointerup", { bubbles: true })); r0.click(); }
+  R.rowSent = sent2; R.rowToggled = toggled; R.rowClosed = tip().style.display === "none";
+  });
+  step('rowDead', () => {
+  // 9b. the same row through the page's OWN send while no socket is open (the shim never opened the one shellWS
+  //     dialed at load): the row says so under the button and the detail stays open. A frame first: it clears the
+  //     failed step's hint, so the hint read here is this row's own.
+  window.__rompShellSend = window.__realShellSend;
+  window.__rompApiHealth(frame({ state: "paused", reason: "manual", text: "paused by you · 2 waiting", waiting: 2, blocked: 2, sessions: [row(1), row(2)], seq: 7 }));
+  el.click();                                              // pin the detail again (the row step closed it)
+  const hintBefore = (tip().querySelector(".ah-hint") || {}).textContent || "";
+  const rd = tip().querySelector(".ah-row[data-act=reveal]");
+  rd.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true })); rd.dispatchEvent(new PointerEvent("pointerup", { bubbles: true })); rd.click();
+  R.rowDead = { hintBefore, open: tip().style.display === "block", hint: (tip().querySelector(".ah-hint") || {}).textContent || "" };
+  if (tip().style.display === "block") el.click();        // close it again (only if it is still open)
+  });
+  step('light', () => {
+  // 10. the light theme's ok dot
+  document.body.classList.add("theme-light");
+  window.__rompApiHealth(frame({ state: "ok", cls: "", text: "ok", waiting: 0, blocked: 0, since: 0, sessions: [] }));
+  R.lightDot = getComputedStyle(el.querySelector(".ah-dot")).backgroundColor;
+  R.lightDotOpacity = getComputedStyle(el.querySelector(".ah-dot")).opacity;
+  });
+  step('lightState', () => {
+  // 11. light theme, degraded and paused: the detail's headline dot wears the rail dot's color (a bare light rule
+  //     would outrank the state rules and paint it the label gray)
+  window.__rompApiHealth(frame({ seq: 8 }));
+  el.click();                                              // pin the detail (the row step closed it)
+  const head = () => tip().querySelector(".ah-head .ah-dot");
+  R.lightDegraded = { rail: bg(el.querySelector(".ah-dot")), head: bg(head()), headOpacity: getComputedStyle(head()).opacity };
+  window.__rompApiHealth(frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000010, seq: 8 }));
+  R.lightPaused = { rail: bg(el.querySelector(".ah-dot")), head: bg(head()) };
+  window.__rompApiHealth(frame({ state: "ok", cls: "", text: "ok", waiting: 0, blocked: 0, since: 0, sessions: [], seq: 8 }));
+  R.lightOkHead = { head: bg(head()), headOpacity: getComputedStyle(head()).opacity };
+  el.click();                                              // close it again
+  document.body.classList.remove("theme-light");
+  });
+  return R;
+}, cfg.sid);
+// phase 2: a real keyboard and a real mouse. Synthetic key events do not move focus, and a synthetic right button
+// fires no contextmenu, so these ride playwright's input instead of page.evaluate.
+R.err2 = {};
+const step2 = async (name, fn) => { try { await fn(); } catch (e) { R.err2[name] = String(e && e.stack || e); } };
+const active = () => page.evaluate(() => { const a = document.activeElement, t = document.getElementById("ah-tip");
+  return (a.tagName + (a.getAttribute("data-act") ? "." + a.getAttribute("data-act") : "") + (t.contains(a) ? "" : "!out")); });
+await step2('tab', async () => {
+  // 12. Tab cycles within the open dialog: button, row, Usage, Log, then the button again; Shift+Tab runs back
+  await page.evaluate(() => { window.__sent2 = []; window.__rompShellSend = (o) => { window.__sent2.push(o); return true; };
+    window.__usageOpened = 0; window.__rompUsagePanel = () => { window.__usageOpened++; };
+    window.__rompApiHealth(window.__frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000010, seq: 9 }));
+    document.getElementById("rail-api").focus(); });
+  await page.keyboard.press("Enter");
+  R.tabOpened = await page.evaluate(() => document.getElementById("ah-tip").classList.contains("ru-modal") && document.getElementById("ah-tip").contains(document.activeElement));
+  R.tabAria = await page.evaluate(() => document.getElementById("ah-tip").getAttribute("aria-modal"));
+  const seq = [];
+  for (let i = 0; i < 6; i++) { await page.keyboard.press("Tab"); seq.push(await active()); }
+  R.tabSeq = seq;
+  const back = [];
+  for (let i = 0; i < 3; i++) { await page.keyboard.press("Shift+Tab"); back.push(await active()); }
+  R.tabBack = back;
+});
+await step2('enterRow', async () => {
+  // 13. Enter on a focused row opens that session; the dialog closes
+  await page.evaluate(() => { const r = document.querySelector("#ah-tip .ah-row[data-act=reveal]"); r.focus(); });
+  R.rowFocused = await active();
+  await page.keyboard.press("Enter");
+  R.enterRowSent = await page.evaluate(() => window.__sent2.map((o) => o.type + ":" + o.id));
+  R.enterRowClosed = await page.evaluate(() => document.getElementById("ah-tip").style.display === "none");
+});
+await step2('enterUsage', async () => {
+  // 14. Space on the focused Usage link opens the usage modal; a frame while a row is focused keeps focus on it
+  await page.evaluate(() => { document.getElementById("rail-api").focus(); });
+  await page.keyboard.press("Enter");
+  await page.evaluate(() => { document.querySelector("#ah-tip .ah-row[data-act=reveal]").focus();
+    window.__rompApiHealth(window.__frame({ state: "paused", reason: "limit", text: "paused · usage limit · 2 waiting", waiting: 2, blocked: 2, since: 1700000010, seq: 9, sessions: [window.__row(1), window.__row(2)] })); });
+  R.focusAfterFrame = await active();
+  await page.evaluate(() => { document.querySelector("#ah-tip .ah-link[data-act=usage]").focus(); });
+  await page.keyboard.press("Space");
+  R.usageOpened = await page.evaluate(() => window.__usageOpened);
+  R.usageClosedTip = await page.evaluate(() => document.getElementById("ah-tip").style.display === "none");
+});
+await step2('rightButton', async () => {
+  // 15. a right-button press over the detail does not defer a frame (no click follows it). The scratch page has
+  //     no kernel, so the boot splash (#romp-boot, a full-window overlay) never clears and would take every real
+  //     mouse event: it goes first, and each press records that it landed on the card.
+  await page.evaluate(() => { const b = document.getElementById("romp-boot"); if (b) b.remove();
+    window.__rompApiHealth(window.__frame({ seq: 9 })); document.getElementById("rail-api").click(); });
+  const head = () => page.evaluate(() => { const r = document.querySelector("#ah-tip .ah-head").getBoundingClientRect(); return { x: r.left + 8, y: r.top + r.height / 2 }; });
+  const inside = (b) => page.evaluate(([x, y]) => document.getElementById("ah-tip").contains(document.elementFromPoint(x, y)), [b.x, b.y]);
+  const box = await head();
+  R.rightInside = await inside(box);
+  await page.mouse.move(box.x, box.y);
+  await page.mouse.down({ button: "right" });
+  await page.evaluate(() => { window.__rompApiHealth(window.__frame({ text: "overloaded · 5 waiting", waiting: 5, blocked: 5, seq: 9,
+    sessions: [1, 2, 3, 4].map(window.__row).concat([Object.assign(window.__row(1), { sid: "x5", name: "five" })]) })); });
+  R.rightHeldPainted = await page.evaluate(() => /5 waiting/.test(document.getElementById("ah-tip").textContent));
+  await page.mouse.up({ button: "right" });
+  R.rightReleasedPainted = await page.evaluate(() => /5 waiting/.test(document.getElementById("ah-tip").textContent));
+  // and the primary press still defers, then paints on release + click. The five-row frame grew the centered
+  // card, so the head moved: measure again.
+  const box2 = await head();
+  R.primaryInside = await inside(box2);
+  await page.mouse.move(box2.x, box2.y);
+  await page.mouse.down();
+  await page.evaluate(() => { window.__rompApiHealth(window.__frame({ text: "overloaded · 6 waiting", waiting: 6, blocked: 6, seq: 9,
+    sessions: [1, 2, 3, 4].map(window.__row).concat([Object.assign(window.__row(1), { sid: "x5", name: "five" }), Object.assign(window.__row(2), { sid: "x6", name: "six" })]) })); });
+  R.primaryHeldPainted = await page.evaluate(() => /6 waiting/.test(document.getElementById("ah-tip").textContent));
+  await page.mouse.up();
+  R.primaryReleasedPainted = await page.evaluate(() => /6 waiting/.test(document.getElementById("ah-tip").textContent));
+});
+await step2('pressFocus', async () => {
+  // 16. a keyboard press on the pause button: the button is disabled at once, and a disabled element cannot hold
+  //     focus, so focus would fall to BODY, where the card's Tab trap no longer sees the keys and a Shift+Tab walks
+  //     out of the aria-modal dialog. Focus moves to the card before the disable; the trap holds.
+  await page.evaluate(() => { document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    window.__sent3 = []; window.__rompShellSend = (o) => { window.__sent3.push(o); return true; };
+    window.__rompApiHealth(window.__frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000010, seq: 12 }));
+    document.getElementById("rail-api").focus(); });
+  await page.keyboard.press("Enter");
+  await page.keyboard.press("Tab");
+  R.pressFocusBefore = await active();
+  await page.keyboard.press("Space");
+  R.pressSent = await page.evaluate(() => window.__sent3.map((o) => o.type + ":" + String(o.value)));
+  R.pressFocusAfter = await active();
+  R.pressButton = await page.evaluate(() => { const b = document.querySelector("#ah-tip button[data-act=pause]"); return { disabled: b.disabled, label: b.textContent }; });
+  await page.keyboard.press("Shift+Tab");
+  R.pressShiftTab = await active();
+  await page.keyboard.press("Tab");
+  R.pressTabBack = await active();
+  await page.evaluate(() => { document.getElementById("ah-tip").focus();
+    window.__rompApiHealth(window.__frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000020, seq: 13 })); });
+  R.pressAnswerFocus = await active();
+  await page.keyboard.press("Tab");
+  R.pressAnswerTab = await active();
+  await page.keyboard.press("Escape");
+});
+// phase 3: the shell socket itself. The shim stands in for the kernel's end: the driver opens the socket shellWS
+// dialed at load, feeds it frames, presses through the REAL __rompShellSend, drops the socket and waits for the
+// redial. The shell's own client-diag rows may ride the same socket; only the frames the cell cares about are read.
+await step2('socket', async () => {
+  // 17. a press acknowledged on a socket that then dies: the redial's ready re-sends the last frame verbatim (same
+  //     seq), so nothing else would clear the acknowledgment; the close clears it and says why, the re-sent frame
+  //     repaints the truth, and the next press rides the new socket
+  const sock = (i) => page.evaluate((i) => { const s = window.__socks[i]; return s ? { url: s.url, state: s.readyState,
+    sent: s.sent.filter((d) => !/"clientDiag"/.test(d)) } : null; }, i);
+  const open = (i) => page.evaluate((i) => { window.__socks[i].__open(); }, i);
+  const drop = (i) => page.evaluate((i) => { window.__socks[i].__drop(); }, i);
+  const feed = (i, over) => page.evaluate(([i, over]) => { window.__socks[i].__msg(window.__frame(over)); }, [i, over]);
+  const redial = (n) => page.waitForFunction((n) => window.__socks.length >= n, n, { timeout: 8000 });
+  const press = () => page.evaluate(() => { const b = document.querySelector("#ah-tip button[data-act=pause]");
+    b.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true })); b.dispatchEvent(new PointerEvent("pointerup", { bubbles: true })); b.click(); });
+  const btnState = () => page.evaluate(() => { const b = document.querySelector("#ah-tip button[data-act=pause]"); const h = document.querySelector("#ah-tip .ah-hint");
+    return { disabled: b.disabled, label: b.textContent, acted: b.classList.contains("romp-acted"), hint: h ? h.textContent : "" }; });
+  const PAUSED = { state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000010, seq: 20 };
+  R.sockCount = await page.evaluate(() => window.__socks.length);
+  R.sock0 = await sock(0);
+  // the steps above replaced window.__rompShellSend with stubs; the page's own binding sends on the live shell socket
+  await page.evaluate(() => { window.__rompShellSend = window.__realShellSend; });
+  R.shellSendRestored = await page.evaluate(() => typeof window.__rompShellSend);
+  await drop(0);
+  await redial(2);
+  R.sockRedialed = await page.evaluate(() => window.__socks.length);
+  await open(1);
+  R.sock1Ready = (await sock(1)).sent;
+  await feed(1, PAUSED);
+  R.sockPainted = await page.evaluate(() => document.getElementById("rail-api").querySelector(".ah-text").textContent);
+  await page.evaluate(() => { document.getElementById("rail-api").click(); });
+  await press();
+  R.sockPressSent = (await sock(1)).sent;
+  R.sockAcked = await btnState();
+  await drop(1);
+  R.sockDropped = await btnState();
+  await press();                                           // no socket is open now: the page's own send refuses
+  R.sockDeadPress = await btnState();
+  await redial(3);
+  R.sock2 = await sock(2);
+  await open(2);
+  R.sock2Ready = (await sock(2)).sent;
+  await feed(2, PAUSED);                                   // the redial's ready re-sends the last frame verbatim
+  R.sockResent = await btnState();
+  await press();
+  R.sock2Sent = (await sock(2)).sent;
+  R.sock1After = (await sock(1)).sent;
+  // and the other outcome: the kernel DID take the press before the socket died, so the re-sent frame's seq has moved
+  await drop(2);
+  await redial(4);
+  await open(3);
+  await feed(3, { text: "overloaded · 1 waiting", seq: 21 });
+  R.sockMoved = await btnState();
+  await page.evaluate(() => { document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })); });
+});
+if (cfg.shots) await page.screenshot({ path: cfg.shots });
+fs.writeSync(1, "RESULT:" + JSON.stringify(R) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class _Quiet(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+
+class ServedCell(unittest.TestCase):
+    """One browser run over the scratch page; each test reads one facet of what it reported."""
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here): the served cell needs a browser")
+        cls.lab = tempfile.mkdtemp(prefix="apih-browser-")
+        # class cleanups run when setUpClass raises too (a failed driver), where tearDownClass would not
+        cls.addClassCleanup(shutil.rmtree, cls.lab, ignore_errors=True)
+        html = km._landing()
+        with open(os.path.join(cls.lab, "index.html"), "w") as f:
+            f.write(html if isinstance(html, str) else html.decode("utf-8"))
+        cls.srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), functools.partial(_Quiet, directory=cls.lab))
+        cls.addClassCleanup(cls.srv.server_close)
+        cls.thr = threading.Thread(target=cls.srv.serve_forever, daemon=True)
+        cls.thr.start()
+        cfg = os.path.join(cls.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"url": "http://127.0.0.1:%d/" % cls.srv.server_address[1], "sid": SID,
+                       "shots": os.environ.get("APIH_BROWSER_SHOT", "")}, f)
+        driver = os.path.join(cls.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        try:
+            p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=180,
+                               env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        finally:
+            cls.srv.shutdown()
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this machine: the served cell needs one (CI installs none)")
+        if p.returncode != 0:
+            raise AssertionError("driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        if line is None:
+            raise AssertionError("driver printed no result:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        cls.R = json.loads(line[len("RESULT:"):])
+
+    def test_the_cell_is_not_displayed_before_the_first_frame(self):
+        # the UA's [hidden]{display:none} loses to the author rule .ru-w{display:flex}, so without an author
+        # [hidden] rule the rail would show a gray 'API ok' from page load, and forever on a kernel that sends no frame
+        self.assertTrue(self.R["preFrameHidden"], "the markup ships the attribute")
+        self.assertEqual(self.R["preFrameDisplay"], "none", "and the attribute must actually hide it: %r" % self.R)
+        self.assertEqual(self.R["firstFrameDisplay"], "flex", "the first frame reveals the cell")
+        self.assertEqual(self.R["firstFrameText"], "overloaded · 1 waiting")
+
+    def test_the_driver_hit_no_script_error(self):
+        self.assertEqual(self.R["err"], {})
+
+    def test_the_light_theme_gives_the_ok_dot_the_label_color(self):
+        # .ah-dot's dark label gray at .55 blends into the light rail (about 1.4:1), so the ok glyph would vanish
+        self.assertEqual(self.R["lightDot"], "rgb(93, 87, 78)", "errors: %r" % self.R.get("err"))
+        self.assertEqual(self.R["lightDotOpacity"], "0.55")
+
+    def test_an_emptied_usage_cell_takes_no_gap(self):
+        # renderRows empties #rail-usage on a login-only machine; as a zero-width flex item it would still pay the
+        # scroll group's gap on both sides, so the API cell sat 28px from the pane buttons instead of 16px
+        self.assertEqual(self.R["usageEmptyDisplay"], "none")
+
+    def test_the_cell_is_a_keyboard_reachable_button_that_names_its_state(self):
+        self.assertEqual((self.R["role"], self.R["tabindex"]), ("button", "0"))
+        self.assertEqual(self.R["ariaLabel"], "API overloaded · 1 waiting")
+        self.assertTrue(self.R["kbOpened"], "Enter opens the pinned detail: %r" % self.R.get("err"))
+        self.assertTrue(self.R["kbFocusInTip"], "focus moves into the detail")
+        self.assertEqual(self.R["tipRole"], "dialog")
+        self.assertTrue(self.R["kbClosed"], "Escape closes it")
+        self.assertTrue(self.R["kbFocusBack"], "and focus returns to the cell")
+
+    def test_the_hover_tip_is_inert_and_re_anchors_when_a_frame_grows_it(self):
+        self.assertTrue(self.R["hoverShown"])
+        self.assertEqual((self.R["hoverButtons"], self.R["hoverActs"]), (0, 0), "no controls under pointer-events:none")
+        ra = self.R["reanchor"]
+        self.assertGreater(ra["after"]["h"], ra["before"]["h"], "three rows are taller than one: %r" % ra)
+        self.assertLessEqual(ra["after"]["bottom"], ra["railTop"] + 1, "the grown tip still hangs above the rail: %r" % ra)
+        self.assertTrue(self.R["hoverHidden"])
+
+    def test_an_open_usage_modal_is_closed_before_the_detail_opens(self):
+        self.assertTrue(self.R["usageClosedFirst"], "errors: %r" % self.R.get("err"))
+
+    def test_a_press_held_across_a_frame_still_lands_and_the_release_flushes_the_frame(self):
+        self.assertTrue(self.R["pinnedHasButton"])
+        self.assertTrue(self.R["heldKeepsNode"], "the pressed button must survive the frame: %r" % self.R.get("err"))
+        self.assertTrue(self.R["heldKeepsText"], "the re-render is deferred while the pointer is down")
+        self.assertEqual(self.R["clickSent"], ["setGlobalRetryPaused:true"], "the click landed on the pressed button")
+        self.assertTrue(self.R["flushedOnClick"], "the deferred frame is painted once the press is over")
+
+    def test_the_acknowledgment_holds_until_the_frame_that_answers_the_press(self):
+        acked = {"disabled": True, "label": "Resume all auto-retries", "acted": True}
+        self.assertEqual(self.R["ack"], acked)
+        self.assertEqual(self.R["ackHeld"], acked, "a frame from before the press (same seq) must not repaint an enabled Stop")
+        self.assertEqual(self.R["confirmed"], {"disabled": False, "label": "Resume all auto-retries", "acted": False})
+
+    def test_a_resume_during_a_usage_limit_pause_reads_the_truth_when_the_pause_re_engages(self):
+        # a rule that cleared the acknowledgment only on a frame whose state matched the press would leave the
+        # button disabled and reading 'Stop all auto-retries' for the rest of the window, since a limit pause
+        # re-engages within the cycle
+        self.assertEqual(self.R["resumeBefore"], {"disabled": False, "label": "Resume all auto-retries"}, "errors: %r" % self.R.get("err"))
+        self.assertEqual(self.R["resumeSent"], ["setGlobalRetryPaused:false"])
+        self.assertEqual(self.R["resumePending"], {"disabled": True, "label": "Stop all auto-retries", "acted": True})
+        self.assertEqual(self.R["resumeSameSeq"], {"disabled": True, "label": "Stop all auto-retries", "acted": True},
+                         "a frame carrying the seq we pressed on predates the press")
+        self.assertEqual(self.R["resumeAfter"], {"disabled": False, "label": "Resume all auto-retries", "acted": False},
+                         "the frame that answers (seq moved) re-enables the button with the truth: paused again")
+        self.assertEqual(self.R["resumeLine"], "Auto-retry and the judges are paused until your usage limit resets.")
+
+    def test_a_failed_send_restores_the_label_drops_the_acted_styling_and_says_why(self):
+        f = self.R["failed"]
+        self.assertEqual((f["disabled"], f["label"], f["acted"]), (False, "Resume all auto-retries", False), repr(f))
+        self.assertIn("Not sent", f["hint"])
+
+    def test_a_session_row_opens_that_session_the_way_the_feed_s_links_do(self):
+        self.assertTrue(self.R["rowHasAct"])
+        self.assertEqual(self.R["rowSent"], [{"type": "openSession", "id": SID + "1"}])
+        self.assertEqual(self.R["rowToggled"], 0, "no pane toggle, nothing persisted")
+        self.assertTrue(self.R["rowClosed"])
+
+    def test_a_row_on_a_dead_socket_says_so_and_keeps_the_detail_open(self):
+        # the page's own __rompShellSend, not a stub: no socket was ever opened, so it refuses and the row says why
+        self.assertEqual(self.R["rowDead"], {"hintBefore": "", "open": True, "hint": "Not sent: the dashboard is disconnected. Try again."},
+                         "errors: %r" % self.R.get("err"))
+
+    def test_the_light_theme_keeps_the_head_dot_s_state_colors(self):
+        # a bare light rule on the dot would outrank the state rules, so the detail's headline dot would read the
+        # label gray while the rail's id-scoped dot kept amber and red
+        amber, red, gray = "rgb(230, 126, 34)", "rgb(229, 72, 77)", "rgb(93, 87, 78)"
+        self.assertEqual(self.R["lightDegraded"], {"rail": amber, "head": amber, "headOpacity": "1"}, "errors: %r" % self.R.get("err"))
+        self.assertEqual(self.R["lightPaused"], {"rail": red, "head": red})
+        self.assertEqual(self.R["lightOkHead"], {"head": gray, "headOpacity": "0.55"})
+
+    def test_the_driver_s_second_phase_hit_no_error(self):
+        self.assertEqual(self.R["err2"], {})
+
+    def test_tab_cycles_within_the_open_dialog(self):
+        self.assertTrue(self.R["tabOpened"], "errors: %r" % self.R.get("err2"))
+        self.assertEqual(self.R["tabAria"], "true")
+        self.assertEqual(self.R["tabSeq"], ["BUTTON.pause", "DIV.reveal", "SPAN.usage", "SPAN.log", "BUTTON.pause", "DIV.reveal"])
+        self.assertEqual(self.R["tabBack"], ["BUTTON.pause", "SPAN.log", "SPAN.usage"])
+
+    def test_enter_on_a_row_opens_its_session_and_space_on_a_footer_link_runs_it(self):
+        self.assertEqual(self.R["rowFocused"], "DIV.reveal", "errors: %r" % self.R.get("err2"))
+        self.assertEqual(self.R["enterRowSent"], ["openSession:" + SID + "1"])
+        self.assertTrue(self.R["enterRowClosed"])
+        self.assertEqual(self.R["focusAfterFrame"], "DIV.reveal", "a frame re-renders the card; focus stays on the same row")
+        self.assertEqual(self.R["usageOpened"], 1)
+        self.assertTrue(self.R["usageClosedTip"])
+
+    def test_a_keyboard_press_on_the_pause_button_keeps_focus_inside_the_dialog(self):
+        self.assertEqual(self.R["pressFocusBefore"], "BUTTON.pause", "errors: %r" % self.R.get("err2"))
+        self.assertEqual(self.R["pressSent"], ["setGlobalRetryPaused:false"], "Space ran the button once")
+        self.assertEqual(self.R["pressButton"], {"disabled": True, "label": "Stop all auto-retries"}, "acknowledged")
+        self.assertEqual(self.R["pressFocusAfter"], "DIV", "focus is on the card, inside the dialog, not on BODY")
+        self.assertEqual(self.R["pressShiftTab"], "SPAN.log", "the trap still applies: Shift+Tab wraps to the last control")
+        self.assertEqual(self.R["pressTabBack"], "DIV.reveal", "Tab from the last control wraps to the first enabled one (the disabled button is skipped)")
+        self.assertEqual(self.R["pressAnswerFocus"], "DIV", "the answering frame's re-render leaves focus on the card")
+        self.assertEqual(self.R["pressAnswerTab"], "BUTTON.pause", "and the first Tab reaches the re-enabled button")
+
+    def test_the_driver_s_socket_phase_hit_no_error(self):
+        self.assertNotIn("socket", self.R["err2"], self.R["err2"].get("socket"))
+
+    def test_a_press_the_socket_lost_is_cleared_on_the_close_and_the_redial_repaints_the_truth(self):
+        # pending is cleared by a failed send or a frame with a moved seq; the redial's ready re-sends the last
+        # frame verbatim, so a press the kernel never received would keep the button disabled and relabeled across
+        # the reconnect until an unrelated pause write moved the seq
+        R = self.R
+        ready, pressed = '{"type":"ready"}', '{"type":"setGlobalRetryPaused","value":false}'
+        self.assertEqual(R["sockCount"], 1, "shellWS dialed once at load, and the shim let it stay unopened: %r" % R.get("err2"))
+        self.assertIn("/ws?app=shell", R["sock0"]["url"])
+        self.assertEqual(R["shellSendRestored"], "function", "the shell's own send survives the driver's stubs")
+        self.assertEqual(R["sockRedialed"], 2, "a close redials")
+        self.assertEqual(R["sock1Ready"], [ready], "the open sends ready")
+        self.assertEqual(R["sockPainted"], "paused · usage limit · 1 waiting", "a frame on the socket paints the cell")
+        self.assertEqual(R["sockPressSent"], [ready, pressed], "the press rode the real socket")
+        self.assertEqual(R["sockAcked"], {"disabled": True, "label": "Stop all auto-retries", "acted": True, "hint": ""})
+        self.assertEqual(R["sockDropped"], {"disabled": False, "label": "Resume all auto-retries", "acted": False,
+                                            "hint": "Connection lost before the answer arrived. When it is back, the button shows the current state."},
+                         "the close clears the acknowledgment and says why")
+        self.assertEqual(R["sockDeadPress"], {"disabled": False, "label": "Resume all auto-retries", "acted": False,
+                                              "hint": "Not sent: the dashboard is disconnected. Try again."},
+                         "a press while no socket is open: the shell's own send refuses (shellSock is null until the redial opens)")
+        self.assertIn("/ws?app=shell", R["sock2"]["url"])
+        self.assertEqual(R["sock2Ready"], [ready], "the redial sends ready")
+        self.assertEqual(R["sockResent"], {"disabled": False, "label": "Resume all auto-retries", "acted": False, "hint": ""},
+                         "the re-sent frame (same seq) repaints the truth and drops the hint")
+        self.assertEqual(R["sock2Sent"], [ready, pressed], "the next press rides the new socket")
+        self.assertEqual(R["sock1After"], [ready, pressed], "and nothing more reached the dead one")
+        self.assertEqual(R["sockMoved"], {"disabled": False, "label": "Stop all auto-retries", "acted": False, "hint": ""},
+                         "a re-sent frame with a moved seq (the kernel took the press) repaints that truth")
+
+    def test_only_a_primary_press_defers_a_frame(self):
+        self.assertTrue(self.R["rightInside"], "the right press landed on the card; errors: %r" % self.R.get("err2"))
+        self.assertTrue(self.R["rightHeldPainted"], "a right button arms nothing: the frame paints at once")
+        self.assertTrue(self.R["rightReleasedPainted"])
+        self.assertTrue(self.R["primaryInside"], "the primary press landed on the card")
+        self.assertFalse(self.R["primaryHeldPainted"], "the primary press still defers")
+        self.assertTrue(self.R["primaryReleasedPainted"], "and the release (outside any button, no click to wait for) paints it")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api_health_hover.py
+++ b/tests/test_api_health_hover.py
@@ -1,0 +1,788 @@
+#!/usr/bin/env python3
+"""The API cell's hover history (the user 2026-09-08, who wanted the cell's hover to carry some history the
+way the spend hover does). The rail's API cell hover and its click detail gain a History section that the
+shell reads from GET /api-health when they open: the signal's state with its since-time and reason, one row
+per window, the newest transitions with how long each state held, and a kernel restart shown as its own row
+or divider. The shell half is _LANDING_APIH_JS: tests/test_api_health_hover_browser.py drives it in Chromium,
+and the Script, Skin and Strip classes at the end of this module pin its source (kernel-inlined JavaScript is
+tested from the Python side); the rest of this module holds the KERNEL half: the payload the section reads,
+served through the real dispatcher on the credential the shell's fetch carries, and the kernel's own construction
+of the backend, run with the backend module swapped for a recorder.
+
+Rules pinned here: every field the section reads is in the payload; the transitions tail is bounded; a
+restart files the row whose reason the section matches, and a bucket already unknown files nothing (the
+section's bootAt divider covers that case, so the boundary is never hidden); the shell's cookie alone reads
+the route with no Origin header, which is what a same-origin GET fetch sends; the apiHealth frame carries no
+history and _api_health_push still sends nothing on an unchanged world, a route read in between included; the
+backend's aggregator is seeded with the kernel's own boot clock, so a bucket the boot seeded has one since-time
+in the head, the divider and the boot's row; that clock is the float, to the millisecond, and the seed is
+clamped past the restored tail, so the restart row is the newest row however close the previous kernel's last
+transition came to this start; the aggregator owns that stamp (truncated with floor, so its whole seconds are
+/version's started) and serves it as bootAt, so bootAt, the seeded stateSince and the restart row are one number
+clamp or not; and a restored row with a null t is skipped, never the whole history.
+
+Synthetic only: a private synthetic sid, invented key material assembled at run time, a fixed epoch."""
+import hashlib
+import inspect
+import io
+import json
+import math
+import os
+import re
+import tempfile
+import time
+import types
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+DOCS = os.path.join(os.path.dirname(HERE), "docs")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads: they resolve their state root at import time, and only pytest runs
+# conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_apih_hover", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_apih_hover", os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).load_module()
+
+SID = "88888888-aaaa-4bbb-8ccc-000000000001"     # this module's private synthetic sid
+KEY_MATERIAL = "test-key-material-" + "h" * 28    # invented; not shaped like any provider's key
+KEY_FP = hashlib.sha256(KEY_MATERIAL.encode()).hexdigest()[:12]   # a synthetic 12-hex identity for the label
+T0 = 1_756_800_000.0                              # a fixed synthetic epoch: the derivation is pure in `now`
+TOK = km.TOKEN
+JS = km._LANDING_APIH_JS
+
+
+def _hist():
+    """The History block of the cell's script, or '' before the section exists."""
+    i, j = JS.find("// -- History"), JS.find("// full=false is the HOVER")
+    return JS[i:j] if 0 <= i < j else ""
+
+
+HIST = _hist()
+
+
+def _storm(t_from, t_to, label, step=14.0):
+    """Attempts every `step` seconds, two of every five a 429 retry: 40%, past every enter threshold."""
+    out, t, i = [], t_from, 0
+    while t < t_to:
+        is429 = (i % 5) in (3, 4)
+        out.append(sb.AhEvent(t, label, "fable", "retry" if is429 else "ok", "429" if is429 else "ok",
+                              429 if is429 else None, SID, i // 20))
+        t += step
+        i += 1
+    return out
+
+
+def _label(ah):
+    return sb.api_health_auth_label("ANTHROPIC_API_KEY", salt=ah.salt(), key_fp=KEY_FP, launched_keyed=True)
+
+
+def _serve_get(path, headers=None):
+    """Drive the REAL do_GET dispatcher over a fake socket and return (status, body): the route's gate and
+    its body are what the shell's fetch meets, so the test asks the handler rather than the source."""
+    h = km.Handler.__new__(km.Handler)
+    h.client_address = ("127.0.0.1", 0)
+    h.headers = dict(headers or {})
+    h.path = path
+    h.command = "GET"
+    h.request_version = "HTTP/1.1"
+    h.wfile = io.BytesIO()
+    h.rfile = io.BytesIO()
+    h.close_connection = True
+    captured = {}
+    h.send_response = lambda code, *a: captured.__setitem__("status", code)
+    h.send_header = lambda k, v: None
+    h.end_headers = lambda: None
+    h.log_message = lambda *a: None
+    h.do_GET()
+    return captured.get("status"), h.wfile.getvalue().decode("utf-8", "replace")
+
+
+class _Backend:
+    """A stand-in SDK backend over a REAL aggregator on a scratch state dir, one storm in its ring."""
+
+    def __init__(self, storm=True):
+        self.ah = sb.ApiHealth(tempfile.mkdtemp(), boot_at=km._STARTED)     # seeded the way _sdk_locked seeds the live one
+        self.label = _label(self.ah)
+        if storm:
+            now = time.time()
+            for e in _storm(now - 600, now, self.label):
+                self.ah._push(e)
+
+    def api_health_snapshot(self, now=None, uptime_s=None):
+        out = self.ah.snapshot(now, uptime_s=uptime_s)
+        out["coverage"].update({"sdkSessionsLive": 1, "inTurn": 1, "retrying": 1})
+        return out
+
+
+class Payload(unittest.TestCase):
+    """What the section reads, from the aggregator's own snapshot."""
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.ah = sb.ApiHealth(self.d)
+        self.label = _label(self.ah)
+        self.key = self.label + "|fable"
+
+    def storm(self, lo, hi):
+        for e in _storm(lo, hi, self.label):
+            self.ah._push(e)
+
+    def test_the_worst_bucket_names_a_bucket_that_carries_since_why_and_the_windows(self):
+        self.storm(T0 - 600, T0)
+        snap = self.ah.snapshot(T0, uptime_s=100)
+        key = snap["overall"]["worstBucket"]
+        self.assertEqual(key, self.key)
+        self.assertIn(key, snap["buckets"], "the head row reads the bucket the roll-up names")
+        b = snap["buckets"][key]
+        self.assertEqual((snap["overall"]["state"], b["state"]), ("thrashing", "thrashing"))
+        self.assertEqual(b["stateSince"], T0, "since: the read that entered the state")
+        self.assertTrue(b["why"].startswith("rate429 over "), b["why"])
+        self.assertEqual(snap["config"]["windows"], [60, 300, 900], "the rows come from the config in force")
+        self.assertEqual(set(b["windows"]), {str(w) for w in snap["config"]["windows"]},
+                         "windows are keyed by the config's seconds, as strings")
+        for w in b["windows"].values():
+            for k in ("requests", "noStatus", "rate429", "rate5xx", "gaveUp", "sessionsRetrying", "complete"):
+                self.assertIn(k, w, k)
+        self.assertIs(b["windows"]["60"]["complete"], True)
+        self.assertIs(b["windows"]["900"]["complete"], False, "a window longer than the uptime says so")
+        self.assertEqual((snap["asOf"], snap["uptimeS"]), (T0, 100.0), "the as-of stamp and the uptime the caveat names")
+        self.assertIn("bootAt", snap, "the boot's stamp rides the snapshot itself")
+
+    def test_transition_rows_carry_the_fields_the_tail_renders_newest_last(self):
+        self.storm(T0 - 600, T0)
+        self.ah.snapshot(T0)
+        snap = self.ah.snapshot(T0 + 2000)          # past retention: the episode closes
+        rows = snap["transitions"]
+        self.assertEqual([(r["from"], r["to"]) for r in rows], [("unknown", "thrashing"), ("thrashing", "unknown")])
+        for r in rows:
+            self.assertLessEqual({"t", "bucket", "auth", "family", "from", "to", "why"}, set(r))
+            self.assertEqual(r["bucket"], self.key, "durations are computed per bucket, so every row names its own")
+        self.assertEqual([r["t"] for r in rows], sorted(r["t"] for r in rows), "newest last; the section sorts newest first")
+
+    def test_the_tail_is_bounded_however_many_transitions_pass(self):
+        for i in range(40):                          # two transitions per cycle: unknown -> thrashing -> unknown
+            base = T0 + i * 5000
+            self.storm(base - 600, base)
+            self.ah.snapshot(base)
+            snap = self.ah.snapshot(base + 2000)
+        self.assertEqual(len(snap["transitions"]), sb.API_HEALTH_TRANSITIONS_KEEP)
+        self.assertEqual(snap["transitions"][-1]["t"], T0 + 39 * 5000 + 2000, "the newest is kept")
+        m = re.search(r"var HIST_ROWS=(\d+);", JS)
+        self.assertIsNotNone(m, "the section caps its rows")
+        self.assertLessEqual(int(m.group(1)), sb.API_HEALTH_TRANSITIONS_KEEP, "the section shows a slice of the tail")
+        self.assertEqual(int(m.group(1)), 6, "about six rows: what fits the hover")
+
+    def test_a_restart_files_the_row_the_section_matches(self):
+        self.storm(T0 - 600, T0)
+        self.ah.snapshot(T0)
+        ah2 = sb.ApiHealth(self.d, boot_at=T0 + 30)
+        snap = ah2.snapshot(T0 + 31)
+        row = snap["transitions"][-1]
+        self.assertEqual((row["from"], row["to"], row["t"]), ("thrashing", "unknown", T0 + 30))
+        self.assertEqual(row["why"], sb.API_HEALTH_RESTART_WHY)
+        self.assertIn("var RESTART_WHY='%s';" % sb.API_HEALTH_RESTART_WHY, JS,
+                      "the section matches the boot's reason byte for byte")
+        self.assertIn("restart=r.why===RESTART_WHY", HIST)
+        self.assertIn("(restart?' · kernel restarted':'')", HIST, "and names the restart on the row")
+        self.assertEqual(snap["buckets"][self.key]["state"], "unknown", "no held pre-restart state")
+
+    def test_a_bucket_already_unknown_files_nothing_so_the_divider_is_keyed_on_boot_at(self):
+        self.storm(T0 - 600, T0)
+        self.ah.snapshot(T0)
+        self.ah.snapshot(T0 + 2000)                  # thrashing -> unknown before the stop
+        n = len(self.ah.snapshot(T0 + 2001)["transitions"])
+        ah2 = sb.ApiHealth(self.d, boot_at=T0 + 3000)
+        snap = ah2.snapshot(T0 + 3001)
+        self.assertEqual(len(snap["transitions"]), n, "already unknown: the boot files no row")
+        self.assertEqual(snap["bootAt"], T0 + 3000, "so the boundary rides the payload as bootAt")
+        # and the section keys the divider on it, since no row marks the boundary
+        self.assertIn("if(!crossed&&pre){crossed=true;", HIST)
+        self.assertIn("if(!sawRestart){out+='<div class=\"ru-tip-row ah-hrow ah-boot\">", HIST)
+        self.assertIn("<span class=ah-hword>kernel restarted</span>", HIST)
+        self.assertIn('"bootAt": self.boot_stamp', inspect.getsource(sb.ApiHealth.snapshot),
+                      "bootAt is the aggregator's own seed stamp, served in its snapshot")
+        self.assertNotIn('out["bootAt"]', inspect.getsource(km.Handler.do_GET), "the route stamps no second number")
+
+
+class OneClock(unittest.TestCase):
+    """The head's since, the boot's restart row and the payload's bootAt read ONE clock, the kernel's own start
+    (_STARTED), passed to the backend at construction. An aggregator seeding itself from its own clock ran seconds
+    after _STARTED (the backend is built after the boot's imports and warm-up), and a hover head that named that
+    clock for a bucket the boot seeded disagreed with a divider drawn at the kernel's start whenever the gap
+    straddled a minute. The clock is the FLOAT, to the millisecond the payload's stamps carry: int() sits on the
+    second boundary before the process started, under a row the previous kernel filed in that same second, and
+    the tail would read that row as current above the restart row. The seed is clamped one millisecond past a
+    restored row that is not before it, with one log line. The aggregator owns the stamp (ApiHealth.boot_stamp:
+    the start truncated to the millisecond with floor, or the clamp) and serves it as bootAt, so the route stamps
+    nothing of its own: bootAt, the seeded stateSince and the restart row are one number in the clamp case too."""
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        ah = sb.ApiHealth(self.d)
+        self.label = _label(ah)
+        self.key = self.label + "|fable"
+        for e in _storm(T0 - 600, T0, self.label):
+            ah._push(e)
+        ah.snapshot(T0)                              # thrashing, persisted: the next boot files thrashing -> unknown
+
+    def _check(self, snap, boot):
+        b = snap["buckets"][self.key]
+        row = snap["transitions"][-1]
+        self.assertEqual(b["stateSince"], boot, "the seeded since IS the boot clock")
+        self.assertEqual((row["t"], row["from"], row["to"], row["why"]), (boot, "thrashing", "unknown", sb.API_HEALTH_RESTART_WHY),
+                         "and so is the restart row's stamp")
+        self.assertEqual(snap["bootAt"], boot, "and so is the payload's bootAt")
+        self.assertEqual(b["state"], "unknown")
+        self.assertNotEqual(b["why"], sb.API_HEALTH_RESTART_WHY,
+                            "the read that served this payload wrote its own reason over the seed's, so the section can key nothing on it")
+
+    def test_the_aggregator_seeds_state_since_and_the_restart_row_from_boot_at(self):
+        snap = sb.ApiHealth(self.d, boot_at=T0 + 30).snapshot(T0 + 31)
+        self._check(snap, T0 + 30)
+
+    def test_the_backend_hands_its_boot_at_to_the_aggregator_and_the_route_stamps_no_second_number(self):
+        be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None, boot_at=T0 + 30)
+        self._check(be.api_health.snapshot(T0 + 31), T0 + 30)
+        self.assertIn('"bootAt": self.boot_stamp', inspect.getsource(sb.ApiHealth.snapshot))
+        self.assertNotIn('out["bootAt"]', inspect.getsource(km.Handler.do_GET))
+        # and the section reads stateSince alone: no why-keyed branch, nothing for it to be dead on
+        self.assertIn("var since=b?b.stateSince:0;", HIST)
+        self.assertNotIn("b.why===RESTART_WHY", HIST)
+
+    def test_the_kernel_builds_the_backend_with_its_own_start_as_boot_at(self):
+        """_sdk_locked run for real, with the backend module it loads swapped for a recorder: the construction passes
+        the kernel's _STARTED itself, the float, as boot_at. The names the construction reaches for (the module
+        loader, the path check, the catalog cache and refresh, the binary lookup, the boot mark, the problem report)
+        are stubbed for the call and put back; the kernel's singleton slot and the judge module's two wires too."""
+        built = []
+
+        class _Recorder:
+            def __init__(self, *a, **kw):
+                built.append(kw)
+
+        fake = types.SimpleNamespace(SdkBackend=_Recorder, startup_auth_env=lambda *a, **k: {})
+
+        class _Loader:
+            def __init__(self, name, path):
+                pass
+
+            def load_module(self):
+                return fake
+
+        names = ("_sdk_backend", "SourceFileLoader", "_ensure_sdk_on_path", "_load_model_catalog_cache",
+                 "_refresh_model_catalog", "_claude_bin", "_mark_boot", "_sdk_problem")
+        saved = {n: getattr(km, n) for n in names}
+        saved_jd = (km.jd._LOGIN_AUTH_ENV_FN, km.jd._USAGE_REFRESH_FN)
+        problems = []
+        try:
+            km._sdk_backend = None
+            km.SourceFileLoader = _Loader
+            km._ensure_sdk_on_path = lambda: True
+            km._load_model_catalog_cache = lambda: None
+            km._refresh_model_catalog = lambda why: None
+            km._claude_bin = lambda: "/bin/true"
+            km._mark_boot = lambda *a, **k: None
+            km._sdk_problem = problems.append
+            be = km._sdk_locked()
+        finally:
+            for n in names:
+                setattr(km, n, saved[n])
+            km.jd._LOGIN_AUTH_ENV_FN, km.jd._USAGE_REFRESH_FN = saved_jd
+        self.assertEqual(problems, [], "the construction ran clean")
+        self.assertEqual(len(built), 1, "one backend built")
+        self.assertIsInstance(be, _Recorder)
+        kw = built[0]
+        self.assertIn("boot_at", kw, "the kernel hands its start to the backend")
+        self.assertIs(kw["boot_at"], km._STARTED,
+                      "the kernel's own _STARTED, the float itself: never int(), never a clock read at construction")
+        self.assertIs(kw["reconcile"], True)
+
+    def test_a_backend_built_without_boot_at_seeds_from_its_own_clock_as_before(self):
+        before = time.time()
+        be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+        after = time.time()
+        stamp = be.api_health.boot_stamp
+        self.assertGreaterEqual(stamp, math.floor(before * 1000) / 1000.0)
+        self.assertLessEqual(stamp, after)
+        self.assertEqual(be.api_health.snapshot(after + 1)["bootAt"], stamp)
+
+    def test_the_route_serves_boot_at_state_since_and_the_restart_row_as_one_number(self):
+        be = self._seeded(self.d, km._STARTED, [])              # seeded the way _sdk_locked seeds the live one
+        out = self._route(be)
+        b = out["buckets"][self.key]
+        row = [r for r in out["transitions"] if r["why"] == sb.API_HEALTH_RESTART_WHY][-1]
+        self.assertEqual(out["bootAt"], be.ah.boot_stamp, "the aggregator's own stamp, served as bootAt")
+        self.assertLessEqual(out["bootAt"], km._STARTED)
+        self.assertLess(km._STARTED - out["bootAt"], 0.001, "the kernel's start truncated to the millisecond")
+        self.assertEqual(int(out["bootAt"]), int(km._STARTED),
+                         "/version's started: the same start in whole seconds (the restored tail is a year old: no clamp)")
+        self.assertEqual(b["stateSince"], out["bootAt"], "head since and bootAt: one number")
+        self.assertEqual(row["t"], out["bootAt"], "the restart row's stamp too")
+        self.assertEqual(out["bootId"], km._BOOT_ID, "bootId stays the route's, from /version's globals")
+
+    @staticmethod
+    def _seeded(d, boot, lines):
+        class _Seeded(_Backend):
+            def __init__(inner):
+                inner.ah = sb.ApiHealth(d, boot_at=boot, log=lines.append)
+        return _Seeded()
+
+    def _route(self, be):
+        saved = km._sdk
+        try:
+            km._sdk = lambda: be
+            status, body = _serve_get("/api-health", {"Cookie": "romp_token=" + TOK})
+        finally:
+            km._sdk = saved
+        self.assertEqual(status, 200, body[:200])
+        return json.loads(body)
+
+    def test_a_same_second_race_reads_one_stamp_in_the_head_the_divider_and_the_restart_row(self):
+        # the previous kernel's last read filed AFTER this kernel's start (it drains under SIGTERM while still serving
+        # and the manager respawns at once, or the clock stepped): the seed is clamped past that row, and bootAt IS the
+        # clamped stamp. A route stamping its own round(_STARTED, 3) put the head (stateSince) and the restart row at
+        # the clamped stamp while the divider read bootAt, and with a minute boundary inside the gap the head named one
+        # minute and the divider the one before
+        d, key = self._previous_kernel(km._STARTED + 0.2)
+        lines = []
+        be = self._seeded(d, km._STARTED, lines)
+        out = self._route(be)
+        b = out["buckets"][key]
+        row = [r for r in out["transitions"] if r["why"] == sb.API_HEALTH_RESTART_WHY][-1]
+        old = round(km._STARTED + 0.2, 3)
+        self.assertEqual(out["bootAt"], be.ah.boot_stamp, "bootAt is the seed's own stamp")
+        self.assertAlmostEqual(out["bootAt"], old + 0.001, delta=1e-6, msg="one millisecond past the previous kernel's row")
+        self.assertEqual(b["stateSince"], out["bootAt"], "the head's since")
+        self.assertEqual(row["t"], out["bootAt"], "the restart row")
+        self.assertEqual(row["t"], max(r["t"] for r in out["transitions"]), "the newest row")
+        self.assertIn(int(out["bootAt"]), (int(km._STARTED), int(km._STARTED) + 1),
+                      "the clamp may cross the second; /version's started stays int(_STARTED)")
+        self.assertEqual(len([ln for ln in lines if "not before this boot" in ln]), 1, lines)
+        # the section reads the three from these fields and nothing else, so they show one time
+        self.assertIn("var since=b?b.stateSince:0;", HIST)
+        self.assertIn("boot=d.bootAt,", HIST)
+        self.assertIn("<span class=ru-tip-k>'+hmd(boot)+'</span><span class=ah-hword>kernel restarted</span>", HIST)
+
+    def test_the_stamp_is_the_start_truncated_to_the_millisecond_so_its_whole_seconds_are_versions_started(self):
+        # floor, never round: a start at X.9996 rounds to (X+1).000 while /version's started is int(X.9996) = X, so
+        # int(bootAt) == started would fail for the boots whose fraction is .9995 or more. The floor never lands on
+        # the next second either: a float one step below a whole second multiplies to more than half an ulp below
+        # it, so the largest float under X+1 truncates to X.999
+        for x in (T0, T0 + 0.4, T0 + 0.9994, T0 + 0.9995, T0 + 0.9996, T0 + 0.9999,
+                  math.nextafter(T0 + 1, 0), math.nextafter(T0 + 2, 0), time.time()):
+            ah = sb.ApiHealth(tempfile.mkdtemp(), boot_at=x)
+            self.assertEqual(int(ah.boot_stamp), int(x), repr(x))
+            self.assertLessEqual(ah.boot_stamp, x, repr(x))
+            self.assertLess(x - ah.boot_stamp, 0.001, repr(x))
+            self.assertEqual(ah.boot_stamp, round(ah.boot_stamp, 3), "at the millisecond")
+            self.assertEqual(ah.snapshot(x + 1)["bootAt"], ah.boot_stamp, "served as bootAt")
+        self.assertEqual(sb.ApiHealth(tempfile.mkdtemp(), boot_at=T0 + 0.9996).boot_stamp, T0 + 0.999)
+        self.assertEqual(sb.ApiHealth(tempfile.mkdtemp(), boot_at=math.nextafter(T0 + 1, 0)).boot_stamp, T0 + 0.999)
+
+    def _previous_kernel(self, last_t):
+        """A state file as the previous kernel left it: its last read filed unknown -> thrashing at `last_t`."""
+        d = tempfile.mkdtemp()
+        ah = sb.ApiHealth(d)
+        label = _label(ah)
+        for e in _storm(last_t - 600, last_t, label):
+            ah._push(e)
+        ah.snapshot(last_t)
+        return d, label + "|fable"
+
+    def test_the_restart_row_is_the_newest_row_when_the_previous_kernel_filed_in_this_boot_s_second(self):
+        # the previous kernel drains under SIGTERM while still serving, and an open card's re-read filed a transition
+        # at T0 + 0.7; the manager respawned at once and this kernel's _STARTED is T0 + 0.9. int() of that is T0,
+        # BEFORE the row, and a seed there would sort under it: the tail would read the old kernel's thrashing as the
+        # current state above the restart row while the head said unknown since the boot
+        d, key = self._previous_kernel(T0 + 0.7)
+        lines = []
+        ah = sb.ApiHealth(d, boot_at=T0 + 0.9, log=lines.append)
+        snap = ah.snapshot(T0 + 1.5)
+        rows = snap["transitions"]
+        self.assertEqual(rows[-1]["why"], sb.API_HEALTH_RESTART_WHY)
+        self.assertEqual(ah.boot_stamp, T0 + 0.9, "the float boot, already at the millisecond")
+        self.assertEqual(rows[-1]["t"], ah.boot_stamp, "the restart row at the float boot")
+        self.assertEqual(snap["bootAt"], ah.boot_stamp, "served as bootAt")
+        self.assertEqual(rows[-1]["t"], max(r["t"] for r in rows), "the newest row in the tail")
+        self.assertAlmostEqual(rows[-2]["t"], T0 + 0.7, delta=1e-6)
+        self.assertGreater(rows[-2]["t"], int(T0 + 0.9), "an int seed would sit under this row")
+        b = snap["buckets"][key]
+        self.assertEqual(b["stateSince"], rows[-1]["t"], "the head's since and the row: one number")
+        self.assertEqual([ln for ln in lines if "not before this boot" in ln], [], "nothing to clamp: the boot is past the row")
+
+    def test_a_boot_not_past_the_restored_tail_seeds_one_millisecond_past_it_and_says_so_once(self):
+        # the previous kernel filed AFTER this one's start (the two overlapped, or the clock stepped back): the seed
+        # moves one millisecond past that row and the log says so once. Judged at the millisecond the tail is kept
+        # in: a boot anywhere inside the row's own millisecond truncates to it and is clamped; one in the next
+        # millisecond truncates to that and stamps there on its own
+        for boot, clamped in ((T0 + 0.65, True), (T0 + 0.7, True), (T0 + 0.7004, True), (T0 + 0.7009, True),
+                              (T0 + 0.701, False), (T0 + 0.7015, False)):
+            d, key = self._previous_kernel(T0 + 0.7)
+            lines = []
+            ah = sb.ApiHealth(d, boot_at=boot, log=lines.append)
+            snap = ah.snapshot(T0 + 2)
+            row, b = snap["transitions"][-1], snap["buckets"][key]
+            self.assertEqual(row["why"], sb.API_HEALTH_RESTART_WHY, boot)
+            self.assertAlmostEqual(row["t"], T0 + 0.701, delta=1e-6, msg=repr(boot))
+            self.assertEqual(row["t"], max(r["t"] for r in snap["transitions"]), "the restart row stays the newest")
+            self.assertEqual(b["stateSince"], row["t"], "one number: the head's since and the row")
+            self.assertEqual(snap["bootAt"], row["t"], "and bootAt, clamp or not: the aggregator's own stamp")
+            self.assertEqual(ah.boot_stamp, row["t"])
+            said = [ln for ln in lines if "not before this boot" in ln]
+            self.assertEqual(len(said), 1 if clamped else 0, (boot, lines))
+            if clamped:
+                self.assertIn("%.3f" % (T0 + 0.7), said[0])
+
+    def test_the_clamp_judges_the_per_bucket_tails_too(self):
+        # the global tail and each bucket's own tail are separate deques; a row in a bucket's tail alone (the global
+        # one bounded it away) still moves the seed
+        d, key = self._previous_kernel(T0 + 0.7)
+        p = Path(d, sb.API_HEALTH_STATE_FILE)
+        doc = json.loads(p.read_text())
+        doc["transitions"] = []                                # the global tail empty, the bucket's tail intact
+        p.write_text(json.dumps(doc))
+        lines = []
+        ah = sb.ApiHealth(d, boot_at=T0 + 0.7, log=lines.append)
+        self.assertAlmostEqual(ah.boot_stamp, T0 + 0.701, delta=1e-6)
+        self.assertEqual(len([ln for ln in lines if "not before this boot" in ln]), 1, lines)
+
+
+class StateFileRows(unittest.TestCase):
+    """A restored row the seed cannot stamp is skipped and counted, and never costs the other rows: the seed's max
+    over the restored stamps must never meet a t that is not a finite number (a null t passed the old check, the
+    max raised on it, and the outer guard would drop every bucket and transition the file held, with the file's
+    other rows sound)."""
+
+    def test_a_row_with_a_null_or_missing_t_is_skipped_and_the_rest_of_the_history_kept(self):
+        d = tempfile.mkdtemp()
+        ah = sb.ApiHealth(d)
+        label = _label(ah)
+        key = label + "|fable"
+        for e in _storm(T0 - 600, T0, label):
+            ah._push(e)
+        ah.snapshot(T0)                                        # unknown -> thrashing at T0, persisted
+        p = Path(d, sb.API_HEALTH_STATE_FILE)
+        doc = json.loads(p.read_text())
+        good = list(doc["transitions"])
+        self.assertEqual([(r["from"], r["to"], r["t"]) for r in good], [("unknown", "thrashing", T0)])
+        # a hand-edited file, or a row from a build that wrote t differently: null, missing, a string, a bool, NaN
+        bad = [dict(good[0], t=None), {k: v for k, v in good[0].items() if k != "t"}, dict(good[0], t="%.3f" % (T0 + 1)),
+               dict(good[0], t=True), dict(good[0], t=float("nan"))]
+        doc["transitions"] = [bad[0], good[0], bad[1], bad[2]]
+        doc["buckets"][key]["transitions"] = [bad[3], good[0], bad[4]]
+        p.write_text(json.dumps(doc))
+        lines = []
+        ah2 = sb.ApiHealth(d, boot_at=T0 + 10, log=lines.append)
+        snap = ah2.snapshot(T0 + 11)
+        self.assertEqual([ln for ln in lines if "unreadable" in ln], [], "the file is readable; five ROWS are not")
+        skipped = [ln for ln in lines if "malformed row(s) skipped" in ln]
+        self.assertEqual(len(skipped), 1, lines)
+        self.assertIn("5 malformed", skipped[0])
+        self.assertEqual(ah2.boot_stamp, T0 + 10, "nothing to clamp: every row the seed could stamp is before the boot")
+        self.assertEqual(snap["bootAt"], T0 + 10)
+        self.assertEqual([(r["from"], r["to"], r["t"]) for r in snap["transitions"]],
+                         [("unknown", "thrashing", T0), ("thrashing", "unknown", T0 + 10)],
+                         "the sound row kept, the restart row filed after it")
+        b = snap["buckets"][key]
+        self.assertEqual((b["state"], b["stateSince"]), ("unknown", T0 + 10), "the bucket came back")
+        self.assertEqual([r["t"] for r in b["transitions"]], [T0, T0 + 10], "its own tail too")
+        for r in bad:
+            self.assertFalse(sb.ApiHealth._row_ok(r), r)
+        self.assertTrue(sb.ApiHealth._row_ok(good[0]))
+        self.assertTrue(sb.ApiHealth._row_ok(dict(good[0], t=int(T0))), "an int stamp is a number")
+
+    def test_an_int_t_past_float_range_is_skipped_as_one_row_and_the_rest_of_the_history_kept(self):
+        """math.isfinite converts an int to float first and raises OverflowError past about 309 digits, and
+        json.loads reads a 400-digit integer literal as such an int (1e400 reads as inf, which the finite check
+        rejects on its own). The row is rejected, never raised on."""
+        d = tempfile.mkdtemp()
+        ah = sb.ApiHealth(d)
+        label = _label(ah)
+        key = label + "|fable"
+        for e in _storm(T0 - 600, T0, label):
+            ah._push(e)
+        ah.snapshot(T0)                                        # unknown -> thrashing at T0, persisted
+        p = Path(d, sb.API_HEALTH_STATE_FILE)
+        doc = json.loads(p.read_text())
+        good = list(doc["transitions"])
+        self.assertEqual([(r["from"], r["to"], r["t"]) for r in good], [("unknown", "thrashing", T0)])
+        huge = dict(good[0], t=10 ** 400)
+        doc["transitions"] = [good[0], huge]
+        p.write_text(json.dumps(doc))
+        back = json.loads(p.read_text())["transitions"][1]["t"]
+        self.assertIsInstance(back, int, "json reads the literal back as an int, not as inf")
+        with self.assertRaises(OverflowError):
+            float(back)
+        lines = []
+        ah2 = sb.ApiHealth(d, boot_at=T0 + 10, log=lines.append)
+        snap = ah2.snapshot(T0 + 11)
+        self.assertEqual([ln for ln in lines if "unreadable" in ln], [], "the file is readable; one ROW is not")
+        skipped = [ln for ln in lines if "malformed row(s) skipped" in ln]
+        self.assertEqual(len(skipped), 1, lines)
+        self.assertIn("1 malformed", skipped[0])
+        self.assertEqual(ah2.boot_stamp, T0 + 10, "nothing to clamp: the one row the seed could stamp is before the boot")
+        self.assertEqual(snap["bootAt"], T0 + 10)
+        self.assertEqual([(r["from"], r["to"], r["t"]) for r in snap["transitions"]],
+                         [("unknown", "thrashing", T0), ("thrashing", "unknown", T0 + 10)],
+                         "the sound row kept, the restart row filed after it")
+        b = snap["buckets"][key]
+        self.assertEqual((b["state"], b["stateSince"]), ("unknown", T0 + 10), "the bucket came back")
+        self.assertEqual([r["t"] for r in b["transitions"]], [T0, T0 + 10], "its own tail too")
+        self.assertFalse(sb.ApiHealth._row_ok(huge), "rejected as a row, no raise")
+        self.assertFalse(sb.ApiHealth._row_ok(dict(good[0], t=-(10 ** 400))), "the negative side too")
+        self.assertTrue(sb.ApiHealth._row_ok(dict(good[0], t=1e300)), "a large float the range holds is a number")
+
+
+class Route(unittest.TestCase):
+    """The route as the shell's fetch meets it: the real dispatcher, the credential the browser carries."""
+
+    def setUp(self):
+        self._saved = km._sdk
+        self.be = _Backend()
+        km._sdk = lambda: self.be
+
+    def tearDown(self):
+        km._sdk = self._saved
+
+    def test_the_route_serves_every_field_the_section_reads(self):
+        status, body = _serve_get("/api-health", {"X-Romp-Token": TOK})
+        self.assertEqual(status, 200)
+        out = json.loads(body)
+        for k in ("asOf", "bootAt", "uptimeS", "config", "overall", "buckets", "transitions"):
+            self.assertIn(k, out, k)
+        self.assertIsInstance(out["config"]["windows"], list)
+        self.assertIsInstance(out["bootAt"], float)
+        self.assertEqual(out["bootAt"], round(out["bootAt"], 3), "to the millisecond, as every stamp in the payload")
+        key = out["overall"]["worstBucket"]
+        self.assertIn(key, out["buckets"])
+        b = out["buckets"][key]
+        for k in ("state", "stateSince", "why", "windows", "family", "auth"):
+            self.assertIn(k, b, k)
+        self.assertEqual(set(b["windows"]), {str(w) for w in out["config"]["windows"]})
+
+    def test_the_cookie_alone_reads_it_with_no_origin_header_the_shell_s_fetch_shape(self):
+        # a same-origin GET fetch sends the romp_token cookie and NO Origin header; _origin_ok accepts an absent
+        # Origin, so this is exactly the credential the shell's fetch('/api-health') carries (kernel.py's own
+        # /usage/fleet read goes the same way). The header form the CLI uses is not what the shell sends.
+        status, body = _serve_get("/api-health", {"Cookie": "romp_token=" + TOK})
+        self.assertEqual(status, 200, body[:200])
+        self.assertIn("buckets", body)
+        status, body = _serve_get("/api-health", {"Cookie": "romp_token=" + TOK,
+                                                  "Origin": "http://evil.example", "Host": "127.0.0.1:%d" % km.PORT})
+        self.assertEqual(status, 403, "a cross-site page's cookie is refused")
+        self.assertIn("fetch('/api-health',{cache:'no-store'})", JS)
+        self.assertIn("fetch('/usage/fleet',{cache:'no-store'})", km._LANDING_USAGE_JS, "the same shape as the shell's other read")
+
+    def test_a_missing_backend_is_a_loud_503_that_the_section_shows_as_its_failure_line(self):
+        km._sdk = lambda: None
+        status, body = _serve_get("/api-health", {"Cookie": "romp_token=" + TOK})
+        self.assertEqual(status, 503)
+        self.assertIn("error", json.loads(body))
+        self.assertIn("if(!r.ok)throw new Error('HTTP '+r.status);", HIST, "a non-2xx is the failure, with its status")
+        self.assertIn("HIST={error:String((e&&e.message)||e)};", HIST)
+        self.assertIn("Could not read the API history: '+esc(HIST.error)", HIST)
+
+
+class FrameUnchanged(unittest.TestCase):
+    """The pushed frame carries no history, and the dedupe still sends nothing on an unchanged world."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._state, self._alive, self._send, self._sdk = km.jd.STATE, km._alive_sessions, km._send_to_app, km._sdk
+        km.jd.STATE = Path(self.td.name)
+        km._alive_sessions = lambda now, tmux: []
+        self.sent = []
+        km._send_to_app = lambda app, m: self.sent.append((app, m))
+        self.be = _Backend()
+        km._sdk = lambda: self.be
+        km._APIH_LAST[0] = None
+
+    def tearDown(self):
+        km.jd.STATE, km._alive_sessions, km._send_to_app, km._sdk = self._state, self._alive, self._send, self._sdk
+        km._APIH_LAST[0] = None
+        self.td.cleanup()
+
+    def test_the_frame_carries_no_history_and_an_unchanged_world_sends_once_across_a_read(self):
+        f1 = km._api_health_frame(10, {})
+        km._api_health_push(f1)
+        self.assertEqual(len(self.sent), 1)
+        self.assertEqual(set(f1), {"type", "state", "cls", "reason", "text", "waiting", "retrying", "blocked",
+                                   "since", "tmux", "sessions", "seq"}, "the documented keys, nothing added")
+        for k in ("windows", "transitions", "buckets", "history", "overall", "bootAt"):
+            self.assertNotIn(k, f1)
+        # a hover reads the route in between (the read files a transition: the storm classifies)
+        status, body = _serve_get("/api-health", {"Cookie": "romp_token=" + TOK})
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body)["overall"]["state"], "thrashing", "the read observed the storm")
+        f2 = km._api_health_frame(11, {})
+        self.assertEqual(f1, f2, "the world the frame reads did not change")
+        km._api_health_push(f2)
+        self.assertEqual(len(self.sent), 1, "byte-identical: nothing sent")
+
+
+class Docs(unittest.TestCase):
+    def _section(self):
+        doc = Path(DOCS, "reference.md").read_text()
+        i = doc.index("### The bottom bar's indicator")
+        return doc[i:doc.index("\n## ", i)]
+
+    def test_the_reference_describes_the_section_from_the_payload_s_fields(self):
+        sec = self._section()
+        self.assertIn("**History**", sec)
+        self.assertIn("`GET /api-health`", sec)
+        for k in ("`overall.state`", "`stateSince`", "`why`", "`config.windows`", "`requests`", "`rate429`", "`rate5xx`",
+                  "`gaveUp`", "`sessionsRetrying`", "`complete`", "`transitions`", "`asOf`", "`bootAt`"):
+            self.assertIn(k, sec, k)
+        self.assertIn("`kernel restarted`", sec)
+        self.assertIn("never the previous numbers", sec)
+        self.assertIn("Nothing polls", sec)
+
+    def test_the_reference_says_what_the_boot_stamp_is(self):
+        doc = re.sub(r"\s+", " ", Path(DOCS, "reference.md").read_text())
+        sec = re.sub(r"\s+", " ", self._section())
+        self.assertIn("a bucket the boot seeded is `unknown` since `bootAt`: the boot time or, when an older kernel's "
+                      "last row overlaps it, one millisecond past that row", sec)
+        self.assertIn("`bootAt` is the boot's stamp in this signal: the kernel's start truncated to the millisecond", doc)
+        self.assertIn("`/version`'s `started` is the whole-second boot time", doc)
+        self.assertIn("the payload serves that stamp as `bootAt`, and the kernel log says when it was moved", doc)
+
+    def test_the_guide_tells_the_user_what_the_hover_shows(self):
+        guide = Path(DOCS, "guide.md").read_text()
+        self.assertIn("the history under it", guide)
+        self.assertIn("last 1, 5 and 15 minutes", guide)
+        self.assertIn("A kernel restart shows as its own line there", guide)
+
+    def test_the_reference_names_the_three_failed_reads(self):
+        self.assertIn("A read that fails (a non-2xx, no answer, or an answer without the signal's shape) shows one line "
+                      "saying so in place of the rows, never the previous numbers.", re.sub(r"\s+", " ", self._section()),
+                      "the three cases the script reports as its failure line")
+
+
+class Script(unittest.TestCase):
+    """Source pins over the cell's script for what a reader wants named and the browser module cannot see as such:
+    the read's call sites, the no-timer rule, the paint gate, the tail's rules, the roles and the description. The
+    behaviours themselves execute in tests/test_api_health_hover_browser.py."""
+
+    def test_the_history_is_the_one_read_fired_by_the_show_the_open_from_hidden_and_a_frame_on_an_open_card(self):
+        self.assertTrue(HIST, "the cell's script carries a History block")
+        self.assertEqual(JS.count("fetch("), 1, "one read in the cell's script: the history's")
+        self.assertIn("function load(fresh){var n=++histSeq;if(fresh)HIST=null;", HIST)
+        self.assertIn("tip.style.display='block';el.setAttribute('aria-describedby','ah-summary');load(true);render();}", JS,
+                      "show drops the last answer and reads")
+        self.assertIn("var was=tip.style.display==='block';", JS)
+        self.assertIn("window.__rompApiClose=close;back.onclick=close;try{tip.focus();}catch(e){}if(!was)load();}", JS,
+                      "open reads when nothing was showing, behind the answer it has")
+        self.assertIn("if(tip.style.display==='block'){if(typeof ev.clientX==='number')lastX=ev.clientX;anchor();return;}show(ev);});", JS,
+                      "a pointer on a tip that focus shows re-anchors it and does not re-read")
+        self.assertIn("if(tip.style.display!=='block')return;   // an open detail re-renders from the new frame, nothing else does\nload();", JS,
+                      "a frame on an open card re-reads")
+
+    def test_no_timers_the_newest_read_wins_and_the_answer_paints_through_the_held_gate(self):
+        self.assertNotIn("setTimeout", JS)
+        self.assertNotIn("setInterval", JS)
+        self.assertIn("window.addEventListener('focus',function(){winFocusEl=document.activeElement;requestAnimationFrame(function(){winFocusEl=null;});});", JS,
+                      "the window-focus mark is cleared on the next animation frame, an event")
+        self.assertEqual(HIST.count("if(n!==histSeq)return;"), 2, "both arms of the read drop an answer a newer read superseded")
+        self.assertEqual(HIST.count("if(tip.style.display!=='block')return;if(held){dirty=true;return;}render();"), 2,
+                         "the answer repaints an open card only, and never under a held pointer")
+
+    def test_a_failed_read_is_one_line_in_place_of_the_rows(self):
+        self.assertIn("HIST=(d&&d.buckets)?d:{error:'malformed answer'};", HIST, "an answer without the signal's shape is a failure too")
+        self.assertIn("if(HIST.error)return h+'<div class=\"ah-line ah-err\">Could not read the API history: '+esc(HIST.error)+'</div></div>';", HIST,
+                      "the line stands where the rows would, and the function returns before any row")
+        self.assertIn("if(!HIST)return h+'<div class=\"rl-dots ah-wait\"><i></i><i></i><i></i></div></div>';", HIST,
+                      "before the first answer: the loader's dots")
+
+    def test_the_rows_wear_the_spend_hover_s_grammar(self):
+        self.assertIn("'<div class=\"ru-tip-win ah-hist\"><div class=ru-tip-name><span>History</span>'", HIST)
+        self.assertIn("'<span class=ru-tip-reset>as of '+hms(HIST.asOf)+'</span>'", HIST, "the payload's asOf on the heading")
+        self.assertIn("'<div class=\"ru-tip-row ah-head\"><i class=ah-dot data-state='+esc(st)+'></i><span class=ah-word>'+esc(st)+'</span>'", HIST)
+        self.assertIn("if(b&&b.why)h+='<div class=\"ah-line ru-tip-reset\">'+esc(b.why)+'</div>';", HIST, "the reason in the small annotation grammar")
+        self.assertIn("((d.config&&d.config.windows)||[60,300,900]).forEach(function(w){h+=winRow(w,(b.windows||{})[String(w)],d.uptimeS);});", HIST,
+                      "the windows come from the config in force")
+        self.assertIn("var lab=(w%60===0?(w/60)+' min':w+' s');if(c&&c.complete===false&&typeof up==='number')lab+=' · kernel up '+dur(up);", HIST)
+        self.assertIn("var v,rq=(c&&c.requests)||0,ns=(c&&c.noStatus)||0;if(!c||!(rq||ns||c.gaveUp||c.sessionsRetrying))v='no attempts';", HIST,
+                      "a window is quiet only when every count is zero")
+        self.assertIn("v+=' · '+(c.gaveUp||0)+' gave up · '+pl(c.sessionsRetrying,'session')+' retried';}", HIST)
+        self.assertNotIn("' retrying'", HIST, "no present-tense label on a windowed count")
+        self.assertIn("'<div class=\"ru-tip-row ah-hrow\"><span class=ru-tip-k>'+esc(lab)+'</span><span class=ru-tip-v>'+esc(v)+'</span></div>'", HIST,
+                      "the spend row's classes")
+        self.assertEqual(sb._AH_COUNTED, ("ok", "429", "529", "5xx", "other"),
+                         "requests excludes 'none', so requests plus noStatus counts every attempt once")
+        self.assertIn("rows.forEach(function(r){h+=rowHTML(r,full);});h+='</div>';}\nh+=histHTML();\nif(m.tmux>0)h+=", JS,
+                      "the section sits after the sessions waiting and before the tmux line, in hover and detail alike")
+
+    def test_the_tail_holds_six_rows_newest_first_each_state_s_hold_and_a_restart_never_hidden(self):
+        self.assertIn(".sort(function(a,b){return b.t-a.t;})", HIST, "newest first")
+        self.assertIn("var end=now,cur=true;for(var j=i-1;j>=0;j--)if(rows[j].bucket===r.bucket){end=rows[j].t;cur=false;break;}", HIST,
+                      "a state holds until the SAME bucket's next change")
+        self.assertIn("+dur(end-r.t)+(cur?' so far':'')+", HIST)
+        self.assertNotIn("end===now", HIST, "'so far' is a flag, never a stamp comparison")
+        self.assertIn("if(pre&&end>boot){end=boot;cur=false;}", HIST, "a hold from before the boot ends at the boot")
+        self.assertIn("pre=hasBoot&&r.t<boot;", HIST)
+        self.assertIn("if(restart)sawRestart=true;shown++;}", HIST, "any restart row above suppresses the divider")
+        self.assertEqual(HIST.count("shown++"), 1, "shown counts transition rows only: the divider takes no slot")
+        self.assertIn("var word=(multi?bname(d,r.bucket)+' ':'')+r.to", HIST, "a bucket is named only when there are several")
+        self.assertIn("return dup?fam+' · '+(b.auth||key.split('|')[0]):fam;}", HIST, "two of one family are told apart by auth")
+
+    def test_the_roles_follow_the_mode_and_the_cell_is_described_by_the_short_summary(self):
+        self.assertIn("el.addEventListener('focus',function(){if(skipFocus||winFocusEl===el||pinned||tip.style.display==='block')return;show(null);});", JS)
+        self.assertNotIn("winFocus=true", JS, "the mark is an element, not a flag")
+        self.assertIn("var desc=document.createElement('span');desc.id='ah-summary';desc.className='ah-vh';document.body.appendChild(desc);", JS)
+        self.assertIn("tip.innerHTML=html(LAST,pinned);if(!pinned)anchor();desc.textContent=descText();", JS, "refreshed on every render")
+        self.assertIn("function descText(){var tail=' Press Enter to open it.';if(!HIST)return 'History: '+((LAST&&LAST.text)||'unknown')+'. Reading the details.'+tail;", HIST)
+        self.assertIn("return 'History: '+(ov.state||'unknown')+((b&&b.stateSince)?' since '+hmd(b.stateSince):'')+'.'+tail;}", HIST)
+        self.assertNotIn("'aria-describedby','ah-tip'", JS, "the tip's whole text is never the description")
+        self.assertIn("tip.setAttribute('role','tooltip');tip.setAttribute('aria-label','API health');tip.tabIndex=-1;", JS, "created as a tooltip")
+        self.assertIn("tip.classList.remove('ru-modal');tip.setAttribute('role','tooltip');tip.removeAttribute('aria-modal');", JS, "show: tooltip")
+        self.assertIn("tip.setAttribute('role','dialog');tip.setAttribute('aria-modal','true');el.removeAttribute('aria-describedby');", JS, "open: dialog")
+        self.assertEqual(JS.count("'aria-modal'"), 2, "set by open, removed by show, nowhere else")
+        self.assertIn("function hide(){tip.style.display='none';el.removeAttribute('aria-describedby');}", JS)
+        self.assertIn("el.addEventListener('blur',function(){if(!pinned)hide();});", JS)
+        self.assertIn("skipFocus=true;try{(fb&&fb.focus?fb:el).focus();}catch(e){}skipFocus=false;}", JS,
+                      "the close's refocus fires the cell's focus event; the flag covers that one call")
+
+
+class Skin(unittest.TestCase):
+    """The section's CSS in the served page: status hexes and never the accent, the quiet row styles, the clip, and
+    no new font size. The two light-theme colours also execute in the browser module (the computed style)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = km._landing()
+
+    def test_the_dot_wears_status_hexes_never_the_accent_and_the_rows_are_quiet(self):
+        self.assertIn(".ah-dot[data-state=thrashing]{background:#e5484d;opacity:1}.ah-dot[data-state=recovering]{background:#e67e22;opacity:.7}", self.html)
+        rules = re.findall(r"[^{}]*\.ah-(?:dot|err)[^{}]*\{[^}]*\}", self.html)
+        self.assertGreater(len(rules), 3)
+        for rule in rules:
+            self.assertNotIn("var(--accent)", rule, rule)
+        self.assertIn(".ah-hword{opacity:.8}.ah-hsub{opacity:.55}.ah-boot .ah-hword{font-style:italic;opacity:.6}", self.html)
+        self.assertIn(".ah-hname{margin-top:6px}.ah-err{color:#ef6b6f}.ah-wait{margin:5px 0 2px}", self.html)
+        self.assertIn("body.theme-light .ah-err{color:#B02A1C}", self.html, "the light theme's error-text red")
+        self.assertIn(".ah-vh{position:absolute;width:1px;height:1px;margin:-1px;padding:0;border:0;overflow:hidden;clip:rect(0 0 0 0);clip-path:inset(50%);white-space:nowrap}", self.html)
+        self.assertIn(".rl-dots i{width:7px;height:7px;border-radius:50%;background:#9cd2ff;animation:rl-bnc", self.html, "the boot splash's dots stand in")
+
+    def test_the_hover_measures_after_a_reset_is_capped_to_the_room_above_the_rail_and_adds_no_font_size(self):
+        self.assertIn("tip.style.left='0px';tip.style.top='0px';tip.style.maxHeight=Math.max(0,r.top-14)+'px';\nvar w=tip.offsetWidth,h=tip.offsetHeight;", JS)
+        self.assertIn("tip.style.left='';tip.style.top='';tip.style.maxHeight='';", JS, "the pinned card clears the cap")
+        self.assertIn("#ah-tip{overflow:hidden;box-sizing:border-box}", self.html, "the hover clips at the cap")
+        self.assertNotIn("font-size", HIST, "no new font size: the reason and as-of reuse .ru-tip-reset")
+
+
+class Strip(unittest.TestCase):
+    def test_the_strip_has_no_api_cell_to_mirror_and_the_follow_up_is_named(self):
+        strip = Path(os.path.dirname(HERE), "ui", "webview", "strip.ts").read_text()
+        self.assertNotIn("rail-api", strip, "nothing in strip.ts renders the API health cell yet")
+        self.assertNotIn("apiHealth", strip)
+        self.assertIn("the VS Code strip twin (strip.ts", Path(os.path.dirname(HERE), "kernel", "kernel.py").read_text(),
+                      "the follow-up is named in the cell's header")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api_health_hover_browser.py
+++ b/tests/test_api_health_hover_browser.py
@@ -1,0 +1,997 @@
+#!/usr/bin/env python3
+"""The API cell's hover History section, driven in a real browser.
+
+The shell page is kernel-served HTML with inline CSS and JS, so it has no jsdom harness: the source pins in
+tests/test_api_health_hover.py hold the SHAPE and this module holds the BEHAVIOR. A scratch copy of
+km._landing() is served from a temp directory over plain HTTP by a handler that also answers GET /api-health
+with a synthetic signal (switchable between variants through /variant/<name>, so one page load exercises a
+storm, a quiet tail across a restart, an empty signal, two buckets of one family and of two, an offline
+window, a bucket the boot seeded, and tails longer than the cap); everything else 404s and the shell socket
+is a shim that never opens, as in tests/test_api_health_browser.py. Playwright's chromium drives it: a frame
+is handed to window.__rompApiHealth, the hover is opened by mouseenter / focus / Enter / click, and the driver
+reports what the DOM did and how many reads the page made. Skips LOUDLY without the extension's node deps or
+a browser (CI installs none).
+
+Executed here, beyond the rendering: the newest read wins a race, a fresh show drops the last answer, a pin
+after the hover reads once, the answer waits under a held pointer, the section's place between the sessions
+and the tmux line, the family-only bucket name, the dated stamp and the hour and day durations; Escape
+dismisses the focus-shown hover, tooltip and dialog roles by mode, a window-refocus does not pop the hover,
+and the geometry at 830 px wide and on a short window. The window-refocus trigger itself cannot be produced
+headless (bringToFront fires no window focus in Playwright's chromium), so that case drives the mechanism with
+synthetic window and cell focus events in one task. A real Tab out of an iframe onto the cell (the cell's
+keyboard path on the dashboard, where every pane is an iframe; Chromium fires focus on the top window for the
+frame change, in the cell's own task) shows the hover; the cell is described by a short summary, not the tip;
+a transition filed at asOf (the hover's own read) closes the state before it; a bucket the boot seeded reads
+one time in the head, the divider and the boot's row; a mixed window counts every attempt once and says how
+many had no status; the previous kernel's last row filed in the same second as this kernel's start sits UNDER
+the restart row; a row filed after the start sits under the clamped restart row with one restart mark, not a
+row and a divider; the cell's description at focus time, in the focus's own task, carries the state word the
+frame put on the cell, and the landed one its since; a hover after the pinned dialog closed is a tooltip again, not
+a dialog left over; the light theme's head dot and failure line are read from the computed style; the answer under a
+held pointer is waited for by the page's own count of parsed answers, never by a pause; the hover on a narrow window
+is first anchored flush at the right edge, so the measurement after the rows land is against the edge (the reset
+before it is what keeps the rows from wrapping).
+
+Synthetic only: invented bucket labels, a fixed shape, times relative to the run so the same-day clock words
+apply; no real data."""
+import functools
+import http.server
+import json
+import os
+import re
+import subprocess
+import tempfile
+import threading
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+# Hermetic state BEFORE the loads: they resolve their state root at import time, and only pytest runs
+# conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+EXT = os.path.join(os.path.dirname(HERE), "vscode-extension")
+km = SourceFileLoader("romp_kernel_apih_hover_browser", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_apih_hover_browser", os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).load_module()
+
+NOW = int(time.time())
+BOOT = NOW - 600
+BOOT_M = BOOT - (BOOT % 60) - 2     # a boot at :58 of a minute: the second-straddling case two clocks would split on
+RESTART = sb.API_HEALTH_RESTART_WHY
+# invented labels in the digest form (12 hex characters), never real material: low-entropy digits, so nothing
+# credential-shaped sits in this file, and every expected string below is built from these, never written out
+KEY = "key:" + "0" * 11 + "1" + "|fable"
+LOGIN = "login:" + "0" * 11 + "2" + "|fable"
+OTHER = "key:" + "0" * 11 + "3" + "|opus"
+AUTH, LAUTH = KEY.split("|")[0], LOGIN.split("|")[0]
+WHY = "rate429 over 300 s = 0.40, n = 20 (attempts)"
+FEW = "fewer than 10 attempts in every window"
+SID = "11111111-2222-4333-8444-000000000001"      # a placeholder sid for the frame's one waiting session
+
+
+def _win(requests, r429, r5xx, gave, sess, complete=True, no_status=0):
+    return {"complete": complete, "requests": requests, "ok": requests, "rateLimited": 0, "overloaded": 0,
+            "serverErrors": 0, "otherErrors": 0, "noStatus": no_status, "gaveUp": gave, "retries": 0,
+            "sessionsRetrying": sess, "turnsRetrying": sess, "rate429": r429, "rate5xx": r5xx}
+
+
+def _bucket(key, state, since, why, windows):
+    auth, fam = key.split("|")
+    return {"auth": auth, "family": fam, "state": state, "stateSince": since, "why": why, "windows": windows,
+            "evidence": None, "transitions": [], "lastError": None}
+
+
+def _tr(t, key, frm, to, why="x"):
+    auth, fam = key.split("|")
+    return {"t": t, "bucket": key, "auth": auth, "family": fam, "from": frm, "to": to, "why": why, "evidence": None}
+
+
+def _base(**over):
+    d = {"schema": 1, "asOf": NOW, "uptimeS": 600.0, "complete": False, "seq": 65, "lastEventAt": NOW - 3,
+         "rate429Basis": "attempts", "coverage": {"sidechainExcluded": True}, "config": {"windows": [60, 300, 900]},
+         "bootId": "4242.%d" % BOOT, "bootAt": BOOT, "overall": {"state": "unknown", "worstBucket": None},
+         "buckets": {}, "transitions": []}
+    d.update(over)
+    return d
+
+
+STORM_WINS = {"60": _win(4, 0.5, 0.0, 0, 1), "300": _win(20, 0.4, 0.0, 1, 2), "900": _win(45, 0.2, 0.02, 1, 2, complete=False)}
+QUIET_WINS = {"60": _win(0, None, None, 0, 0), "300": _win(0, None, None, 0, 0), "900": _win(0, None, None, 0, 0, complete=False)}
+
+
+def _chain(key, times_states):
+    """Transitions for one bucket from a list of (t, state entered), each from the previous state."""
+    out, prev = [], "unknown"
+    for t, st in times_states:
+        out.append(_tr(t, key, prev, st, FEW if st == "unknown" else "x"))
+        prev = st
+    return out
+
+
+PAYLOADS = {
+    # one bucket in a storm; the boot filed thrashing -> unknown, so the tail carries its own restart row
+    "storm": _base(overall={"state": "thrashing", "worstBucket": KEY},
+                   buckets={KEY: _bucket(KEY, "thrashing", NOW - 300, WHY, STORM_WINS)},
+                   transitions=[_tr(NOW - 3000, KEY, "unknown", "healthy"), _tr(NOW - 1200, KEY, "healthy", "thrashing"),
+                                _tr(BOOT + 1, KEY, "thrashing", "unknown", RESTART), _tr(NOW - 300, KEY, "unknown", "thrashing")]),
+    # the bucket was already unknown when the previous kernel stopped: the boot filed nothing, the tail crosses
+    # bootAt with no restart row, and the section must insert the divider
+    "quiet": _base(overall={"state": "healthy", "worstBucket": KEY},
+                   buckets={KEY: _bucket(KEY, "healthy", NOW - 100, None, {"60": _win(12, 0.0, 0.0, 0, 0), "300": _win(30, 0.0, 0.0, 0, 0), "900": _win(30, 0.0, 0.0, 0, 0, complete=False)})},
+                   transitions=[_tr(NOW - 4000, KEY, "unknown", "healthy"), _tr(NOW - 3500, KEY, "healthy", "unknown", FEW),
+                                _tr(NOW - 100, KEY, "unknown", "healthy")]),
+    # no traffic ever: no bucket, no tail
+    "empty": _base(),
+    # two buckets of one family: the head names the worst one and counts them
+    "two": _base(overall={"state": "thrashing", "worstBucket": KEY},
+                 buckets={KEY: _bucket(KEY, "thrashing", NOW - 300, WHY, STORM_WINS),
+                          LOGIN: _bucket(LOGIN, "healthy", NOW - 500, None, {"60": _win(0, None, None, 0, 0), "300": _win(11, 0.0, 0.0, 0, 0), "900": _win(11, 0.0, 0.0, 0, 0, complete=False)})},
+                 transitions=[_tr(NOW - 500, LOGIN, "unknown", "healthy"), _tr(NOW - 300, KEY, "unknown", "thrashing")]),
+    # two buckets of two families: named by family alone
+    "twoFam": _base(overall={"state": "thrashing", "worstBucket": KEY},
+                    buckets={KEY: _bucket(KEY, "thrashing", NOW - 300, WHY, STORM_WINS),
+                             OTHER: _bucket(OTHER, "healthy", NOW - 500, None, {"60": _win(11, 0.0, 0.0, 0, 0), "300": _win(11, 0.0, 0.0, 0, 0), "900": _win(11, 0.0, 0.0, 0, 0, complete=False)})},
+                    transitions=[_tr(NOW - 500, OTHER, "unknown", "healthy"), _tr(NOW - 300, KEY, "unknown", "thrashing")]),
+    # this machine cannot reach the API: every attempt fails at the connection level, so `requests` (attempts WITH
+    # a status) is 0 while noStatus, gaveUp and sessionsRetrying are not; the 5 min window mixes both kinds; the
+    # 15 min window is quiet
+    "offline": _base(overall={"state": "unknown", "worstBucket": KEY},
+                     buckets={KEY: _bucket(KEY, "unknown", NOW - 200, FEW, {"60": _win(0, None, None, 1, 2, no_status=5),
+                                                                          "300": _win(8, 0.25, 0.0, 1, 2, no_status=7),
+                                                                          "900": _win(0, None, None, 0, 0, complete=False)})},
+                     transitions=[_tr(NOW - 500, KEY, "unknown", "healthy"), _tr(NOW - 200, KEY, "healthy", "unknown", FEW)]),
+    # a bucket unknown since before the boot with nothing since: the boot found it unknown, filed no row and seeded
+    # its stateSince from the kernel's boot clock (bootAt itself; the backend is seeded with it); the read that
+    # served this payload replaced the seed's reason with its own, as the live route does (an unchanged unknown
+    # bucket carries why_unknown, never the restart reason); every hold in the tail is from a previous kernel life,
+    # more than a day old, so the stamps carry their date and the durations reach hours and days
+    "stale": _base(overall={"state": "unknown", "worstBucket": KEY},
+                   buckets={KEY: _bucket(KEY, "unknown", BOOT, FEW, QUIET_WINS)},
+                   transitions=_chain(KEY, [(NOW - 190000, "healthy"), (NOW - 183000, "degraded"), (NOW - 100000, "unknown")])),
+    # the bucket had traffic when the previous kernel stopped, so the boot filed its restart row; a boot at :58 of a
+    # minute, and nothing since: head since, the restart row's stamp and the pre-boot hold's end are one clock
+    "minute": _base(bootAt=BOOT_M, uptimeS=float(NOW - BOOT_M), overall={"state": "unknown", "worstBucket": KEY},
+                    buckets={KEY: _bucket(KEY, "unknown", BOOT_M, FEW, QUIET_WINS)},
+                    transitions=[_tr(NOW - 3000, KEY, "unknown", "healthy"), _tr(NOW - 1500, KEY, "healthy", "thrashing"),
+                                 _tr(BOOT_M, KEY, "thrashing", "unknown", RESTART)]),
+    # the previous kernel's last read filed a transition 0.2 s before this kernel's start (it drains under SIGTERM
+    # while still serving; the manager respawns at once), so the two sit in one second. bootAt is the start to the
+    # millisecond and the restart row is seeded at it: the row is the newest, the old row's hold ends at it, no
+    # divider (an int boot would sit before the old row, which would then read as the current state)
+    "inversion": _base(bootAt=BOOT + 0.9, uptimeS=float(NOW - (BOOT + 0.9)), overall={"state": "unknown", "worstBucket": KEY},
+                       buckets={KEY: _bucket(KEY, "unknown", BOOT + 0.9, FEW, QUIET_WINS)},
+                       transitions=[_tr(NOW - 3000, KEY, "unknown", "healthy"), _tr(NOW - 1500, KEY, "healthy", "thrashing"),
+                                    _tr(BOOT + 0.7, KEY, "thrashing", "healthy"), _tr(BOOT + 0.9, KEY, "healthy", "unknown", RESTART)]),
+    # the previous kernel filed AFTER this one's start (the two overlapped, or the clock stepped): the backend seeds
+    # the restart row one millisecond past that row and serves that stamp as bootAt, so the old row is the first
+    # pre-boot row, its hold ending at the restart row; one restart, one mark: the restart row above suppresses the
+    # divider at the crossing. uptimeS stays the kernel's own (_STARTED at BOOT + 0.9)
+    "clamped": _base(bootAt=BOOT + 0.951, uptimeS=float(NOW - (BOOT + 0.9)), overall={"state": "unknown", "worstBucket": KEY},
+                     buckets={KEY: _bucket(KEY, "unknown", BOOT + 0.951, FEW, QUIET_WINS)},
+                     transitions=[_tr(NOW - 3000, KEY, "unknown", "healthy"), _tr(NOW - 1500, KEY, "healthy", "thrashing"),
+                                  _tr(BOOT + 0.95, KEY, "thrashing", "healthy"), _tr(BOOT + 0.951, KEY, "healthy", "unknown", RESTART)]),
+    # the hover's own read filed a transition, so its t is asOf: the state it closed reads its duration, closed, and
+    # the new state is the one 'so far' (a flag, never a stamp comparison)
+    "ownread": _base(overall={"state": "thrashing", "worstBucket": KEY},
+                     buckets={KEY: _bucket(KEY, "thrashing", NOW, WHY, STORM_WINS)},
+                     transitions=[_tr(NOW - 500, KEY, "unknown", "healthy"), _tr(NOW, KEY, "healthy", "thrashing", WHY)]),
+    # eight transitions, six from before the boot (the bucket unknown at the stop: no restart row) and two after:
+    # the cap shows six transitions, and the divider is extra
+    "cap": _base(overall={"state": "degraded", "worstBucket": KEY},
+                 buckets={KEY: _bucket(KEY, "degraded", NOW - 200, "x", STORM_WINS)},
+                 transitions=_chain(KEY, [(NOW - 5000, "healthy"), (NOW - 4500, "degraded"), (NOW - 4000, "healthy"), (NOW - 3500, "thrashing"),
+                                          (NOW - 3000, "recovering"), (NOW - 2500, "unknown"), (NOW - 400, "healthy"), (NOW - 200, "degraded")])),
+    # eight transitions all after the boot: six rows and no divider
+    "capPost": _base(overall={"state": "healthy", "worstBucket": KEY},
+                     buckets={KEY: _bucket(KEY, "healthy", NOW - 70, "x", STORM_WINS)},
+                     transitions=_chain(KEY, [(NOW - 560, "healthy"), (NOW - 490, "degraded"), (NOW - 420, "healthy"), (NOW - 350, "thrashing"),
+                                              (NOW - 280, "recovering"), (NOW - 210, "healthy"), (NOW - 140, "degraded"), (NOW - 70, "healthy")])),
+}
+
+
+def _hm(t):
+    return time.strftime("%H:%M", time.localtime(t))
+
+
+def _min(s):
+    """dur()'s minute form for 60 s <= s < 3600 s: Math.round, which rounds a half up (Python's round would not)."""
+    return "%d min" % int(s / 60 + 0.5)
+
+
+def _dur(s):
+    """dur() under an hour: whole seconds first (Math.round), then '<n> s' under a minute, else Math.round minutes."""
+    s = int(s + 0.5)
+    return "%d s" % s if s < 60 else "%d min" % int(s / 60 + 0.5)
+
+
+def _hmd(t):
+    """The section's stamp: HH:MM today, else 'MM-DD HH:MM' (the browser runs on this machine's clock and zone)."""
+    lt, today = time.localtime(t), time.localtime(NOW)
+    hm = _hm(t)
+    return hm if (lt.tm_year, lt.tm_yday) == (today.tm_year, today.tm_yday) else time.strftime("%m-%d ", lt) + hm
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1200, height: 800 } });
+const R = { err: {}, pageErrors: [] };
+page.on("pageerror", (e) => { R.pageErrors.push(String(e && e.stack || e && e.message || e)); });
+// the WebSocket shim: the page's sockets never open (no kernel behind the scratch page), without the real
+// socket's close-and-redial noise
+await page.addInitScript(() => {
+  function Fake(url) { this.url = String(url); this.readyState = 0; this.sent = []; this.onopen = this.onmessage = this.onclose = this.onerror = null; }
+  Fake.prototype.send = function () { throw new Error("not open"); };
+  Fake.prototype.close = function () {};
+  Fake.CONNECTING = 0; Fake.OPEN = 1; Fake.CLOSING = 2; Fake.CLOSED = 3;
+  window.WebSocket = Fake;
+});
+await page.goto(cfg.url);
+await page.waitForFunction(() => typeof window.__rompApiHealth === "function", null, { timeout: 20000 });
+const step = async (name, fn) => { try { await fn(); } catch (e) { R.err[name] = String(e && e.stack || e); } };
+const ev = (fn, arg) => page.evaluate(fn, arg);
+const rows = () => ev(() => Array.from(document.querySelectorAll("#ah-tip .ah-hist .ah-hrow")).map((n) => ({
+  k: (n.querySelector(".ru-tip-k") || {}).textContent || "", w: n.querySelector(".ah-hword") ? n.querySelector(".ah-hword").textContent : null,
+  v: n.querySelector(".ru-tip-v") ? n.querySelector(".ru-tip-v").textContent : null, boot: n.classList.contains("ah-boot") })));
+const head = () => ev(() => { const h = document.querySelector("#ah-tip .ah-hist");
+  const q = (s) => { const n = h && h.querySelector(s); return n ? n.textContent : null; };
+  return { word: q(".ah-head .ah-word"), dot: h && h.querySelector(".ah-head .ah-dot") ? h.querySelector(".ah-head .ah-dot").getAttribute("data-state") : null,
+           since: q(".ah-since"), sub: q(".ah-hsub"), why: q(".ah-line.ru-tip-reset"), asOf: q(".ru-tip-name .ru-tip-reset"),
+           line: q(".ah-line:not(.ru-tip-reset):not(.ah-err)"), err: q(".ah-err"), wait: !!(h && h.querySelector(".ah-wait")),
+           names: Array.from(h ? h.querySelectorAll(".ru-tip-name span:first-child") : []).map((n) => n.textContent) }; });
+const shown = () => ev(() => document.getElementById("ah-tip").style.display === "block");
+// the colours the theme resolves to, read from the computed style of the head's dot and of the failure line
+const dotColor = () => ev(() => getComputedStyle(document.querySelector("#ah-tip .ah-hist .ah-head .ah-dot")).backgroundColor);
+const errColor = () => ev(() => getComputedStyle(document.querySelector("#ah-tip .ah-hist .ah-err")).color);
+const described = () => ev(() => document.getElementById("rail-api").getAttribute("aria-describedby"));
+// the tip's role and modal flag, whether focus sits inside it, and whether it is the centered card
+// #ah-summary is read null-safe so a page without it fails the description assertions alone, not every step
+const mode = () => ev(() => { const t = document.getElementById("ah-tip"), d = document.getElementById("ah-summary"), b = d ? d.getBoundingClientRect() : null;
+  return { role: t.getAttribute("role"), modal: t.getAttribute("aria-modal"),
+  focusInside: t.contains(document.activeElement), modalClass: t.classList.contains("ru-modal"), shown: t.style.display === "block",
+  described: document.getElementById("rail-api").getAttribute("aria-describedby"), activeIsCell: document.activeElement === document.getElementById("rail-api"),
+  descText: d ? d.textContent : null, descBox: b ? [b.width, b.height] : null, descInTree: !!d && document.body.contains(d) }; });
+const descOf = () => ev(() => { const d = document.getElementById("ah-summary"); return d ? d.textContent : null; });
+// the mouseenter and the look at what it painted are ONE task: the read fires on the show, so its answer cannot land
+// before this returns, and the loader state read here is what the user sees before the answer (a separate round trip
+// lets the local server answer in between, and the dots are already rows)
+const enter = () => ev(() => { const el = document.getElementById("rail-api"); el.dispatchEvent(new MouseEvent("mouseenter", { bubbles: false, clientX: el.getBoundingClientRect().left + 10 }));
+  return { wait: !!document.querySelector("#ah-tip .ah-hist .ah-wait"), described: el.getAttribute("aria-describedby"), fetchN: window.__fetchN,
+           rows: document.querySelectorAll("#ah-tip .ah-hist .ah-hrow").length, desc: (document.getElementById("ah-summary") || {}).textContent }; });
+const leave = () => ev(() => { document.getElementById("rail-api").dispatchEvent(new MouseEvent("mouseleave")); });
+const waitRows = () => page.waitForFunction(() => document.querySelectorAll("#ah-tip .ah-hist .ah-hrow").length > 0, null, { timeout: 8000 });
+const waitSel = (s) => page.waitForFunction((s) => !!document.querySelector(s), s, { timeout: 8000 });
+const variant = (v) => ev((v) => window.__realFetch("/variant/" + v).then((r) => r.text()), v);
+const fetchN = () => ev(() => window.__fetchN);
+const pause = (ms) => ev((ms) => new Promise((r) => setTimeout(r, ms)), ms);   // the driver's own wait, never the page's
+const frame = (over) => Object.assign({ type: "apiHealth", state: "ok", cls: "", reason: "", text: "ok", waiting: 0, retrying: 0, blocked: 0, since: 0, tmux: 0, sessions: [], seq: 1 }, over || {});
+// where the tip sits against the viewport and the cell, and whether any row wrapped or the tip clips
+const geo = () => ev(() => { const tip = document.getElementById("ah-tip"), t = tip.getBoundingClientRect(), c = document.getElementById("rail-api").getBoundingClientRect();
+  return { l: t.left, r: t.right, t: t.top, b: t.bottom, h: t.height, cellTop: c.top, iw: window.innerWidth, ih: window.innerHeight,
+           rowH: Array.from(document.querySelectorAll("#ah-tip .ah-hist .ah-hrow")).map((n) => n.getBoundingClientRect().height),
+           clipped: tip.scrollHeight > tip.clientHeight, maxH: tip.style.maxHeight }; });
+// the reads are counted through a wrapper on the page's fetch; the real fetch still runs. __fetchN counts reads at call
+// time; __doneN counts answers the page has PARSED (its r.json() settled, one microtask before the script files the
+// answer), so a step can wait for an answer to have landed in the script rather than for a fetch to have started.
+// __restoreFetch puts the wrapper back after a step swapped fetch out.
+await ev(() => { const real = window.fetch; window.__fetchN = 0; window.__doneN = 0; window.__realFetch = real;
+  window.__restoreFetch = function () { window.fetch = function (u) { const api = String(u).indexOf("/api-health") === 0; if (api) window.__fetchN++;
+    const p = real.apply(window, arguments);
+    return api ? p.then((r) => { const j = r.json.bind(r); r.json = () => j().then((d) => { window.__doneN++; return d; }); return r; }) : p; }; };
+  window.__restoreFetch(); });
+await ev((f) => { window.__rompApiHealth(f); }, frame());
+await step("storm", async () => {
+  // 1. the hover: the loader's dots first, the rows when the read lands; the cell is described by the tip
+  const first = await enter();
+  R.stormWaitFirst = first.wait; R.stormDescribed = first.described; R.stormFetchN0 = first.fetchN; R.stormDesc0 = first.desc;
+  await waitRows();
+  R.storm = { head: await head(), rows: await rows(), fetchN: await fetchN(), shown: await shown(), mode: await mode(), geo: await geo() };
+  await leave();
+  R.stormHidden = !(await shown()); R.stormDescribedAfter = await described();
+});
+// each later show is sampled the same way: a fresh show drops the last answer (the dots stand in again) and reads once
+const show = async (name) => { await variant(name); const e = await enter(); R[name + "Wait"] = e.wait; R[name + "Rows0"] = e.rows; };
+await step("quiet", async () => {
+  // 2. the tail crosses bootAt with no restart row: the divider; the hold from before the boot ends at the boot
+  await show("quiet"); await waitRows();
+  R.quiet = { head: await head(), rows: await rows() };
+  await leave();
+});
+await step("empty", async () => {
+  // 3. no bucket: the head says so, no rows
+  await show("empty"); await waitSel("#ah-tip .ah-hist .ah-line");
+  R.empty = { head: await head(), rows: await rows() };
+  await leave();
+});
+await step("two", async () => {
+  // 4. two buckets of one family: the head names the worst by family and auth and counts them
+  await show("two"); await waitRows();
+  R.two = { head: await head(), rows: await rows() };
+  await leave();
+});
+await step("twoFam", async () => {
+  // 5. two buckets of two families: named by family alone
+  await show("twoFam"); await waitRows();
+  R.twoFam = { head: await head(), rows: await rows() };
+  await leave();
+});
+await step("offline", async () => {
+  // 6. a window of no-status attempts names them with its give-ups and sessions; a mixed window names both; a
+  //    quiet window says no attempts
+  await show("offline"); await waitRows();
+  R.offline = { head: await head(), rows: await rows() };
+  await leave();
+});
+await step("stale", async () => {
+  // 7. a bucket the boot seeded: since the boot in the head, the divider at the boot, the pre-boot hold closed at
+  //    the boot and never 'so far'; dated stamps, hour and day durations
+  await show("stale"); await waitRows();
+  R.stale = { head: await head(), rows: await rows() };
+  await leave();
+  // 7b. the boot filed a restart row (traffic at the stop) at :58 of a minute: head since and the row's stamp agree
+  await show("minute"); await waitRows();
+  R.minute = { head: await head(), rows: await rows() };
+  await leave();
+});
+await step("inversion", async () => {
+  // 7d. the previous kernel's last row 0.2 s before the boot, the restart row at the boot: the restart row is the
+  //     newest, the old row closes at it, no divider; 7e. that row AFTER the boot and the restart row a millisecond
+  //     past it (the backend's clamp): still one restart mark
+  await show("inversion"); await waitRows();
+  R.inversion = { head: await head(), rows: await rows() };
+  await leave();
+  await show("clamped"); await waitRows();
+  R.clamped = { head: await head(), rows: await rows() };
+  await leave();
+});
+await step("ownread", async () => {
+  // 7c. a transition at t === asOf, the hover's own read: the closed state reads its duration, the new one 'so far'
+  await show("ownread"); await waitRows();
+  R.ownread = { head: await head(), rows: await rows() };
+  await leave();
+});
+await step("cap", async () => {
+  // 8. the cap counts transitions: six of them with the divider extra, six alone when nothing crosses the boot
+  await show("cap"); await waitRows();
+  R.cap = { rows: await rows() };
+  await leave();
+  await show("capPost"); await waitRows();
+  R.capPost = { rows: await rows() };
+  await leave();
+});
+await step("fail", async () => {
+  // 9. a failed read is one loud line in place of the rows: a non-2xx, a rejected fetch, a malformed answer
+  await ev(() => { window.fetch = () => Promise.resolve({ ok: false, status: 503 }); });
+  await enter(); await waitSel("#ah-tip .ah-err");
+  R.fail503 = { head: await head(), rows: await rows(), desc: await descOf(), errColor: await errColor() };
+  await leave();
+  await ev(() => { window.fetch = () => Promise.reject(new Error("Failed to fetch")); });
+  await enter(); await page.waitForFunction(() => /Failed to fetch/.test((document.querySelector("#ah-tip .ah-err") || {}).textContent || ""), null, { timeout: 8000 });
+  R.failReject = { head: await head(), rows: await rows() };
+  await leave();
+  await ev(() => { window.fetch = () => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) }); });
+  await enter(); await page.waitForFunction(() => /malformed/.test((document.querySelector("#ah-tip .ah-err") || {}).textContent || ""), null, { timeout: 8000 });
+  R.failMalformed = { head: await head(), rows: await rows() };
+  await leave();
+  // the real reads come back, and the next hover replaces the failure with the rows
+  await ev(() => { window.__restoreFetch(); });
+  await variant("storm"); await enter(); await waitRows();
+  R.recovered = { head: await head(), rows: await rows() };
+  await leave();
+});
+await step("theme", async () => {
+  // 9b. the light theme (body.theme-light, which the shell's theme reader toggles): the head's dot for the signal's
+  //     quiet states wears the light rail's dark gray, and the failure line the light error red, both read from the
+  //     COMPUTED style, so a dropped rule shows here and not only in a source pin
+  await ev(() => { document.body.classList.add("theme-light"); });
+  await show("quiet"); await waitRows(); R.lightHealthyDot = { word: (await head()).word, color: await dotColor() }; await leave();
+  await show("stale"); await waitRows(); R.lightUnknownDot = { word: (await head()).word, color: await dotColor() }; await leave();
+  await ev(() => { window.fetch = () => Promise.resolve({ ok: false, status: 503 }); });
+  await enter(); await waitSel("#ah-tip .ah-err"); R.lightErr = await errColor(); await leave();
+  await ev(() => { window.__restoreFetch(); document.body.classList.remove("theme-light"); });
+  await variant("storm");
+});
+await step("race", async () => {
+  // 10. two reads in flight (enter, leave, enter): the older answer landing first is dropped, the dots stay until
+  //     the newer one lands, and the newer one is what shows
+  await ev(async () => { const rf = window.__realFetch;
+    await rf("/variant/storm"); window.__A = await (await rf("/api-health")).json();
+    await rf("/variant/quiet"); window.__B = await (await rf("/api-health")).json();
+    window.__pend = []; window.fetch = () => new Promise((res) => { window.__pend.push(res); }); });
+  await enter(); await leave(); await enter();
+  R.racePending = await ev(() => window.__pend.length);
+  await ev(() => { window.__pend[0]({ ok: true, status: 200, json: () => Promise.resolve(window.__A) }); });
+  await pause(80);
+  R.raceAfterOld = await head();
+  await ev(() => { window.__pend[1]({ ok: true, status: 200, json: () => Promise.resolve(window.__B) }); });
+  await waitRows();
+  R.raceAfterNew = await head();
+  await leave();
+  await ev(() => { window.__restoreFetch(); });
+  await variant("storm");
+});
+await step("order", async () => {
+  // 11. with a waiting session and a tmux session in the frame, the section sits after Sessions waiting and
+  //     before the tmux line
+  await ev((f) => { window.__rompApiHealth(f); }, frame({ state: "degraded", cls: "429", text: "rate limited · 1 waiting", waiting: 1, retrying: 1, since: NOW_PLACEHOLDER, tmux: 1, seq: 1,
+    sessions: [{ sid: "SID_PLACEHOLDER", name: "web", color: null, kind: "retrying", cls: "429", status: 429, since: NOW_PLACEHOLDER, suppressed: false }] }));
+  await enter(); await waitRows();
+  R.order = await ev(() => Array.from(document.querySelectorAll("#ah-tip > .ru-tip-win")).map((w) => { const n = w.querySelector(".ru-tip-name span"); return n ? n.textContent : w.textContent.slice(0, 24); }));
+  await leave();
+  await ev((f) => { window.__rompApiHealth(f); }, frame());
+});
+await step("focus", async () => {
+  // 12. keyboard focus shows the hover as the pointer does; blur hides it. The focus and the look at the description
+  //     are ONE task: assistive tech reads the description at focus time, and what is there then is what the user
+  //     hears. A frame with a distinctive text stands on the cell first, so the word the description carries is
+  //     provably the frame's; frame() is put back after.
+  await ev((f) => { window.__rompApiHealth(f); }, frame({ state: "degraded", cls: "429", text: "rate limited · 1 waiting", waiting: 1, since: NOW_PLACEHOLDER }));
+  R.focusDesc0 = await ev(() => { document.getElementById("rail-api").focus(); return (document.getElementById("ah-summary") || {}).textContent; });
+  R.focusShown = await shown(); R.focusDescribed = await described(); R.focusMode = await mode();
+  await waitRows();
+  R.focusDesc = await descOf();
+  await ev(() => { document.getElementById("rail-api").blur(); });
+  R.blurHidden = !(await shown()); R.blurDescribed = await described();
+  await ev((f) => { window.__rompApiHealth(f); }, frame());
+  // 13. the pointer arriving on the tip focus already shows keeps its rows and does not re-read
+  await ev(() => { document.getElementById("rail-api").focus(); });
+  await waitRows();
+  const n0 = await fetchN();
+  const e = await enter();
+  R.focusEnter = { wait: e.wait, rows: e.rows, read: e.fetchN - n0 };
+  await pause(60);
+  R.focusEnterAfter = { fetchN: (await fetchN()) - n0, rows: (await rows()).length };
+  // 14. Escape dismisses the focus-shown hover without moving focus
+  await page.keyboard.press("Escape");
+  R.focusEsc = await mode();
+  // 15. the window regaining focus re-dispatches focus on the active element in the same task: not a show, not a
+  //     read (synthetic window and cell focus events, the trigger being unreachable headless); a focus that arrives
+  //     after the next frame is the user's, and shows
+  const n1 = await fetchN();
+  R.refocus = await ev(() => { const el = document.getElementById("rail-api");
+    window.dispatchEvent(new FocusEvent("focus")); el.dispatchEvent(new FocusEvent("focus"));
+    return { shown: document.getElementById("ah-tip").style.display === "block", fetchN: window.__fetchN }; });
+  R.refocus.read = R.refocus.fetchN - n1;
+  await ev(() => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r))));
+  R.refocusLater = await ev(() => { document.getElementById("rail-api").dispatchEvent(new FocusEvent("focus"));
+    return { shown: document.getElementById("ah-tip").style.display === "block", fetchN: window.__fetchN }; });
+  R.refocusLater.read = R.refocusLater.fetchN - n1;
+  await ev(() => { document.getElementById("rail-api").blur(); });
+});
+await step("frameTab", async () => {
+  // 15b. the cell's keyboard path on the dashboard, where every pane is an iframe: focus in a pane, Tab onto the cell.
+  //      Chromium fires focus on the TOP window for the frame change, in the same task as the cell's focus, so the
+  //      mark is set; the element it recorded is the body (the host is cleared before the event), not the cell, and
+  //      the hover shows and reads once. A scratch iframe with an input stands in for the pane, inserted right before
+  //      the cell so the Tab lands on it; removed after.
+  await ev(() => new Promise((res) => { const el = document.getElementById("rail-api"), f = document.createElement("iframe");
+    f.id = "lab-pane"; f.style.cssText = "width:1px;height:1px;border:0"; f.srcdoc = "<input id=lab-in>"; f.onload = () => res();
+    el.parentNode.insertBefore(f, el); }));
+  await ev(() => { window.__winLog = []; window.addEventListener("focus", () => { const a = document.activeElement; window.__winLog.push(a ? (a.id || a.tagName) : null); }); });
+  await page.frameLocator("#lab-pane").locator("#lab-in").focus();
+  R.frameTabFrom = await ev(() => document.activeElement ? document.activeElement.id : null);
+  const n = await fetchN();
+  await page.keyboard.press("Tab");
+  R.frameTab = await ev(() => ({ active: document.activeElement ? document.activeElement.id : null, shown: document.getElementById("ah-tip").style.display === "block",
+    described: document.getElementById("rail-api").getAttribute("aria-describedby"), winLog: window.__winLog.slice(), fetchN: window.__fetchN }));
+  R.frameTab.read = R.frameTab.fetchN - n;
+  await waitRows();
+  R.frameTabRows = (await rows()).length;
+  await ev(() => { document.getElementById("rail-api").blur(); document.getElementById("lab-pane").remove(); });
+});
+await step("keyboard", async () => {
+  // 16. Enter pins the detail with the section in it, as the dialog with focus inside, and reads nothing new (the
+  //     focus show's read is the same document); Escape closes, focus returns to the cell, and the hover does NOT
+  //     pop back from that refocus
+  await ev(() => { document.getElementById("rail-api").focus(); });
+  await waitRows();
+  R.kbFetchPre = await fetchN();
+  await page.keyboard.press("Enter");
+  R.kbFetchPost = await fetchN();
+  R.kbPinned = await ev(() => { const t = document.getElementById("ah-tip"); return t.style.display === "block" && t.classList.contains("ru-modal"); });
+  R.kbMode = await mode();
+  R.kbRows = (await rows()).length; R.kbHead = await head();
+  R.kbFetchBefore = await fetchN();
+  // 17. a frame landing on the open detail re-reads the history (the world changed)
+  await ev((f) => { window.__rompApiHealth(f); }, frame({ state: "degraded", cls: "529", text: "overloaded · 1 waiting", waiting: 1, blocked: 1, since: NOW_PLACEHOLDER, seq: 2 }));
+  await page.waitForFunction((n) => window.__fetchN > n, R.kbFetchBefore, { timeout: 8000 });
+  R.kbFetchAfter = await fetchN();
+  await page.keyboard.press("Escape");
+  R.escHidden = !(await shown());
+  R.escFocusBack = await ev(() => document.activeElement === document.getElementById("rail-api"));
+  await pause(120);    // a late answer or the refocus must not re-show it
+  R.escStillHidden = !(await shown()); R.escDescribed = await described();
+});
+await step("pin", async () => {
+  // 18. a click after the hover reads nothing new and keeps the hover's answer; a click with nothing showing reads
+  await ev(() => { document.getElementById("rail-api").blur(); });
+  await enter(); await waitRows();
+  const n0 = await fetchN();
+  await ev(() => { document.getElementById("rail-api").click(); });
+  R.pinAfterHover = { read: (await fetchN()) - n0, mode: await mode(), rows: (await rows()).length, wait: (await head()).wait };
+  await page.keyboard.press("Escape");
+  R.pinClosed = await mode();
+  // 18b. the hover after the dialog: close() leaves the hidden tip's role alone, so show() must put the tooltip role
+  //      back and drop aria-modal, or a keyboard user's next hover is announced as a modal dialog their focus sits outside
+  //      of. Focus is taken off whatever holds it first (the close's return to the body is a no-op focus() call, and the
+  //      browser moves focus off the hidden tip only at its next rendering update), so the hover starts from the body.
+  await ev(() => { const a = document.activeElement; if (a && a !== document.body && a.blur) a.blur(); });
+  await enter(); await waitRows();
+  R.hoverAfterDialog = await mode();
+  await leave();
+  const n1 = await fetchN();
+  await ev(() => { document.getElementById("rail-api").click(); });
+  R.pinFromHidden = { read: (await fetchN()) - n1, mode: await mode(), wait: (await head()).wait };
+  await waitRows();
+  // 19. an answer landing under a held primary pointer waits for the release. The wait is for the answer to have been
+  //     parsed by the page (__doneN), not for the fetch to have started: a slow answer would otherwise be read before
+  //     it landed, and the release would have nothing to paint
+  await ev(() => { document.getElementById("ah-tip").dispatchEvent(new PointerEvent("pointerdown", { button: 0, bubbles: true })); });
+  await variant("quiet");
+  const d0 = await ev(() => window.__doneN);
+  await ev((f) => { window.__rompApiHealth(f); }, frame({ seq: 3 }));
+  await page.waitForFunction((n) => window.__doneN > n, d0, { timeout: 8000 });
+  R.heldWord = (await head()).word;
+  await ev(() => { document.body.dispatchEvent(new PointerEvent("pointerup", { button: 0, bubbles: true })); });
+  R.releasedWord = (await head()).word;
+  await page.keyboard.press("Escape");
+  await ev(() => { document.getElementById("rail-api").blur(); });
+  await variant("storm");
+});
+await step("geometry", async () => {
+  // 20. the hover measures after a reset and is capped to the room above the rail: at 830 px wide it keeps its
+  //     margin and no row wraps; on a 280 px tall window it stays above the rail and clips instead of spilling.
+  //     Each size is a FRESH page: the shell lays the rail out once at load, so a resized viewport does not move it.
+  //     On the narrow page the pointer enters near the RIGHT edge, so the first anchor (the loader's narrow tip) sits
+  //     flush at the right margin and the re-render after the rows land is measured against that edge: without the
+  //     reset a fixed element's shrink-to-fit width is taken from where it last sat, and the rows wrap. The first
+  //     anchor's rectangle is recorded so the test can check that premise.
+  await enter(); await waitRows();
+  R.geoWide = await geo();
+  await leave();
+  const fresh = async (width, height, atEdge) => {
+    const p = await browser.newPage({ viewport: { width, height } });
+    await p.addInitScript(() => {
+      function Fake(url) { this.url = String(url); this.readyState = 0; this.onopen = this.onmessage = this.onclose = this.onerror = null; }
+      Fake.prototype.send = function () { throw new Error("not open"); }; Fake.prototype.close = function () {};
+      Fake.CONNECTING = 0; Fake.OPEN = 1; Fake.CLOSING = 2; Fake.CLOSED = 3; window.WebSocket = Fake; });
+    await p.goto(cfg.url);
+    await p.waitForFunction(() => typeof window.__rompApiHealth === "function", null, { timeout: 20000 });
+    await p.evaluate((f) => { window.__rompApiHealth(f); }, frame());
+    const first = await p.evaluate((atEdge) => { const el = document.getElementById("rail-api"), x = atEdge ? window.innerWidth - 10 : el.getBoundingClientRect().left + 10;
+      el.dispatchEvent(new MouseEvent("mouseenter", { clientX: x })); const t = document.getElementById("ah-tip").getBoundingClientRect();
+      return { x, l: t.left, r: t.right, w: t.width }; }, atEdge);
+    await p.waitForFunction(() => document.querySelectorAll("#ah-tip .ah-hist .ah-hrow").length > 0, null, { timeout: 8000 });
+    const g = await p.evaluate(() => { const tip = document.getElementById("ah-tip"), t = tip.getBoundingClientRect(), c = document.getElementById("rail-api").getBoundingClientRect();
+      return { l: t.left, r: t.right, t: t.top, b: t.bottom, h: t.height, w: t.width, cellTop: c.top, iw: window.innerWidth, ih: window.innerHeight,
+               rowH: Array.from(document.querySelectorAll("#ah-tip .ah-hist .ah-hrow")).map((n) => n.getBoundingClientRect().height),
+               clipped: tip.scrollHeight > tip.clientHeight, maxH: tip.style.maxHeight }; });
+    await p.close();
+    g.first = first;
+    return g;
+  };
+  R.geo830 = await fresh(830, 600, true);
+  R.geoShort = await fresh(1200, 280, false);
+});
+if (cfg.shots) await page.screenshot({ path: cfg.shots });
+fs.writeSync(1, "RESULT:" + JSON.stringify(R) + "\n");
+await browser.close();
+process.exit(0);
+""".replace("NOW_PLACEHOLDER", str(NOW - 30)).replace("SID_PLACEHOLDER", SID)
+
+
+class _Lab(http.server.SimpleHTTPRequestHandler):
+    """The scratch page's server: index.html from the temp dir, GET /api-health from PAYLOADS, /variant/<name>
+    switches which one; everything else the shell asks for 404s."""
+    variant = ["storm"]
+
+    def log_message(self, *a):
+        pass
+
+    def _json(self, obj):
+        body = json.dumps(obj).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        path = self.path.split("?", 1)[0]
+        if path == "/api-health":
+            return self._json(PAYLOADS[self.variant[0]])
+        if path.startswith("/variant/"):
+            name = path.rsplit("/", 1)[1]
+            if name in PAYLOADS:
+                self.variant[0] = name
+            return self._json({"variant": self.variant[0]})
+        return super().do_GET()
+
+
+class ServedHistory(unittest.TestCase):
+    """One browser run over the scratch page; each test reads one facet of what it reported."""
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here): the served hover needs a browser")
+        cls.lab = tempfile.mkdtemp(prefix="apih-hover-browser-")
+        html = km._landing()
+        with open(os.path.join(cls.lab, "index.html"), "w") as f:
+            f.write(html if isinstance(html, str) else html.decode("utf-8"))
+        _Lab.variant[0] = "storm"
+        cls.srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), functools.partial(_Lab, directory=cls.lab))
+        cls.thr = threading.Thread(target=cls.srv.serve_forever, daemon=True)
+        cls.thr.start()
+        cfg = os.path.join(cls.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"url": "http://127.0.0.1:%d/" % cls.srv.server_address[1],
+                       "shots": os.environ.get("APIH_HOVER_SHOT", "")}, f)
+        driver = os.path.join(cls.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        cls.srv.shutdown()
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this machine: the served hover needs one (CI installs none)")
+        if p.returncode != 0:
+            raise AssertionError("driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        if line is None:
+            raise AssertionError("driver printed no result:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        cls.R = json.loads(line[len("RESULT:"):])
+
+    def test_the_driver_hit_no_script_error(self):
+        self.assertEqual(self.R["err"], {})
+        # every page exception counts: a render-path TypeError names no 'api', and a step with no DOM wait after its
+        # read would otherwise pass over it
+        self.assertEqual(self.R["pageErrors"], [])
+
+    def test_the_hover_reads_the_route_once_shows_the_loader_first_and_describes_the_cell(self):
+        R = self.R
+        self.assertTrue(R["stormWaitFirst"], "the loader's dots stand in until the answer lands")
+        self.assertEqual(R["stormFetchN0"], 1, "one read per show, fired on the show")
+        self.assertEqual(R["stormDescribed"], "ah-summary", "described by the short summary, not the tip")
+        self.assertEqual(R["storm"]["fetchN"], 1)
+        self.assertTrue(R["storm"]["shown"])
+        self.assertFalse(R["storm"]["head"]["wait"], "the dots go when the rows arrive")
+        self.assertTrue(R["stormHidden"], "mouseleave hides the hover")
+        self.assertIsNone(R["stormDescribedAfter"], "and drops the description")
+
+    def test_a_fresh_show_drops_the_last_answer_and_the_newest_read_wins_a_race(self):
+        R = self.R
+        for name in ("quiet", "empty", "two", "twoFam", "offline", "stale", "minute", "inversion", "clamped", "ownread", "cap", "capPost"):
+            self.assertTrue(R[name + "Wait"], "%s: the dots stand in again, not the last hover's rows" % name)
+            self.assertEqual(R[name + "Rows0"], 0, name)
+        self.assertEqual(R["racePending"], 2, "enter, leave, enter: two reads in flight")
+        self.assertTrue(R["raceAfterOld"]["wait"], "the older answer landing first is dropped: the dots stay")
+        self.assertIsNone(R["raceAfterOld"]["word"])
+        self.assertEqual(R["raceAfterNew"]["word"], "healthy", "the newer read's answer is what shows")
+        self.assertFalse(R["raceAfterNew"]["wait"])
+
+    def test_the_storm_reads_as_state_since_why_windows_and_the_tail_with_its_restart_row(self):
+        h, rows = self.R["storm"]["head"], self.R["storm"]["rows"]
+        self.assertEqual((h["word"], h["dot"]), ("thrashing", "thrashing"))
+        self.assertEqual(h["since"], "since " + _hmd(NOW - 300))
+        self.assertEqual(h["why"], WHY)
+        self.assertIsNone(h["sub"], "one bucket: no bucket name, no count")
+        self.assertEqual(h["asOf"], "as of " + time.strftime("%H:%M:%S", time.localtime(NOW)))
+        self.assertEqual(h["names"], ["History", "State changes"])
+        wins = rows[:3]
+        self.assertEqual([r["k"] for r in wins], ["1 min", "5 min", "15 min · kernel up 10 min"],
+                         "the third window outreaches the uptime and says so")
+        self.assertEqual([r["v"] for r in wins],
+                         ["4 attempts · 50% 429 · 0% 5xx · 0 gave up · 1 session retried",
+                          "20 attempts · 40% 429 · 0% 5xx · 1 gave up · 2 sessions retried",
+                          "45 attempts · 20% 429 · 2% 5xx · 1 gave up · 2 sessions retried"],
+                         "the window's totals in the window's tense")
+        self.assertTrue(all(r["w"] is None and not r["boot"] for r in wins))
+        tail = rows[3:]
+        self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in tail],
+                         [(_hmd(NOW - 300), "thrashing", "5 min so far", False),
+                          (_hmd(BOOT + 1), "unknown · kernel restarted", "5 min", False),
+                          (_hmd(NOW - 1200), "thrashing", "10 min", False),
+                          (_hmd(NOW - 3000), "healthy", "30 min", False)],
+                         "newest first; each state held until the bucket's next change; the boot's own row names the restart, so no divider")
+
+    def test_a_tail_crossing_boot_at_without_a_restart_row_gets_the_divider_and_the_hold_ends_at_the_boot(self):
+        h, rows = self.R["quiet"]["head"], self.R["quiet"]["rows"]
+        self.assertEqual(h["word"], "healthy")
+        self.assertIsNone(h["why"], "no reason line when the bucket has none")
+        tail = rows[3:]
+        self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in tail],
+                         [(_hmd(NOW - 100), "healthy", "2 min so far", False),
+                          (_hmd(BOOT), "kernel restarted", None, True),
+                          (_hmd(NOW - 3500), "unknown", "48 min", False),
+                          (_hmd(NOW - 4000), "healthy", "8 min", False)],
+                         "the unknown from before the boot ended at the boot (every bucket comes back unknown), not at the next change")
+
+    def test_a_bucket_the_boot_seeded_reads_since_the_boot_in_the_head_and_the_tail_alike(self):
+        h, rows = self.R["stale"]["head"], self.R["stale"]["rows"]
+        self.assertEqual(h["word"], "unknown")
+        self.assertEqual(h["since"], "since " + _hmd(BOOT), "stateSince is the boot clock itself: the backend is seeded with it")
+        self.assertEqual(h["why"], FEW, "the read's own reason, as the live route serves it; the head keys on nothing in it")
+        self.assertEqual([r["v"] for r in rows[:3]], ["no attempts"] * 3)
+        tail = rows[3:]
+        self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in tail],
+                         [(_hmd(BOOT), "kernel restarted", None, True),
+                          (_hmd(NOW - 100000), "unknown", "1 d 3 h", False),
+                          (_hmd(NOW - 183000), "degraded", "23 h 3 min", False),
+                          (_hmd(NOW - 190000), "healthy", "1 h 57 min", False)],
+                         "the divider and the head name one time; the pre-boot unknown is closed at the boot, never 'so far'")
+        self.assertEqual(h["since"], "since " + tail[0]["k"], "head since == divider stamp")
+        self.assertTrue(all(" so far" not in (r["v"] or "") for r in tail), "no open-ended state for a bucket the boot seeded")
+        self.assertTrue(all(re.match(r"\d\d-\d\d \d\d:\d\d$", r["k"]) for r in tail[1:]), "stamps from another day carry their date")
+
+    def test_a_boot_at_58_seconds_reads_one_time_in_the_head_and_on_its_restart_row(self):
+        h, rows = self.R["minute"]["head"], self.R["minute"]["rows"]
+        self.assertEqual(h["word"], "unknown")
+        self.assertEqual(h["since"], "since " + _hmd(BOOT_M))
+        tail = rows[3:]
+        self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in tail],
+                         [(_hmd(BOOT_M), "unknown · kernel restarted", _min(NOW - BOOT_M) + " so far", False),
+                          (_hmd(NOW - 1500), "thrashing", _min(BOOT_M - (NOW - 1500)), False),
+                          (_hmd(NOW - 3000), "healthy", "25 min", False)],
+                         "the boot's own row names the restart (no divider); the pre-boot hold ends at the boot")
+        self.assertEqual(h["since"], "since " + tail[0]["k"], "head since == the restart row's stamp: one clock")
+        self.assertFalse(any(r["boot"] for r in tail))
+        self.assertEqual(BOOT_M % 60, 58, "the payload's boot sits two seconds before a minute boundary")
+
+    def test_the_restart_row_sorts_above_the_previous_kernel_s_last_row_filed_in_the_same_second(self):
+        h, rows = self.R["inversion"]["head"], self.R["inversion"]["rows"]
+        self.assertEqual(h["word"], "unknown")
+        self.assertEqual(h["since"], "since " + _hmd(BOOT + 0.9), "the seeded stateSince, the boot to the millisecond")
+        tail = rows[3:]
+        self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in tail],
+                         [(_hmd(BOOT + 0.9), "unknown · kernel restarted", _dur(NOW - (BOOT + 0.9)) + " so far", False),
+                          (_hmd(BOOT + 0.7), "healthy", "0 s", False),
+                          (_hmd(NOW - 1500), "thrashing", _dur(BOOT + 0.7 - (NOW - 1500)), False),
+                          (_hmd(NOW - 3000), "healthy", "25 min", False)],
+                         "the restart row is the newest; the previous kernel's last state closed at the restart, never 'so far'; "
+                         "the boot's own row names the restart, so no divider")
+        self.assertEqual(h["since"], "since " + tail[0]["k"], "head since == the restart row's stamp")
+        self.assertEqual(sum(1 for r in tail if " so far" in (r["v"] or "")), 1)
+        self.assertFalse(any(r["boot"] for r in tail))
+
+    def test_a_row_the_previous_kernel_filed_after_this_start_sits_under_the_clamped_restart_row_with_one_mark(self):
+        h, rows = self.R["clamped"]["head"], self.R["clamped"]["rows"]
+        self.assertEqual(h["since"], "since " + _hmd(BOOT + 0.951), "the head reads the clamped stamp, which is bootAt")
+        tail = rows[3:]
+        self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in tail],
+                         [(_hmd(BOOT + 0.951), "unknown · kernel restarted", _dur(NOW - (BOOT + 0.951)) + " so far", False),
+                          (_hmd(BOOT + 0.95), "healthy", "0 s", False),
+                          (_hmd(NOW - 1500), "thrashing", _dur(BOOT + 0.95 - (NOW - 1500)), False),
+                          (_hmd(NOW - 3000), "healthy", "25 min", False)],
+                         "the old row is the first pre-boot row (its hold ends at the restart row, one millisecond on); the row "
+                         "before it closed at the old row; the restart row above suppresses the divider: one restart, one mark")
+        self.assertEqual(h["since"], "since " + tail[0]["k"], "head since == the restart row's stamp == bootAt: one number")
+        self.assertFalse(any(r["boot"] for r in tail), "no divider under a shown restart row")
+        self.assertEqual(sum(1 for r in tail if "kernel restarted" in (r["w"] or "")), 1)
+
+    def test_a_transition_the_hover_s_own_read_filed_closes_the_state_before_it(self):
+        h, rows = self.R["ownread"]["head"], self.R["ownread"]["rows"]
+        self.assertEqual(h["since"], "since " + _hmd(NOW), "the state entered at this read's asOf")
+        tail = rows[3:]
+        self.assertEqual([(r["k"], r["w"], r["v"]) for r in tail],
+                         [(_hmd(NOW), "thrashing", "0 s so far"), (_hmd(NOW - 500), "healthy", "8 min")],
+                         "the closed state reads its duration with no 'so far' although its end is asOf; the new one is 'so far'")
+        self.assertEqual(sum(1 for r in tail if " so far" in r["v"]), 1)
+
+    def test_no_bucket_says_so_in_place_of_the_rows(self):
+        h, rows = self.R["empty"]["head"], self.R["empty"]["rows"]
+        self.assertEqual(h["word"], "unknown")
+        self.assertEqual(h["line"], "No API traffic seen since the kernel started at %s." % _hmd(BOOT))
+        self.assertEqual(rows, [])
+        self.assertIsNone(h["since"])
+
+    def test_two_buckets_of_one_family_are_told_apart_by_auth_and_counted(self):
+        h, rows = self.R["two"]["head"], self.R["two"]["rows"]
+        self.assertEqual(h["word"], "thrashing")
+        self.assertEqual(h["sub"], "fable · %s · worst of 2 buckets" % AUTH)
+        tail = rows[3:]
+        self.assertEqual([r["w"] for r in tail], ["fable · %s thrashing" % AUTH, "fable · %s healthy" % LAUTH])
+        self.assertEqual([r["v"] for r in tail], ["5 min so far", "8 min so far"], "each bucket's current state is its own 'so far'")
+
+    def test_two_buckets_of_two_families_are_named_by_family_alone(self):
+        h, rows = self.R["twoFam"]["head"], self.R["twoFam"]["rows"]
+        self.assertEqual(h["sub"], "fable · worst of 2 buckets")
+        self.assertEqual([r["w"] for r in rows[3:]], ["fable thrashing", "opus healthy"])
+
+    def test_an_offline_window_names_its_no_status_attempts_with_its_give_ups_and_sessions(self):
+        h, rows = self.R["offline"]["head"], self.R["offline"]["rows"]
+        self.assertEqual(h["word"], "unknown")
+        self.assertEqual([r["v"] for r in rows[:3]],
+                         ["5 attempts without a status · 1 gave up · 2 sessions retried",
+                          "15 attempts, 7 of them without a status · 25% 429 · 0% 5xx of the other 8 · 1 gave up · 2 sessions retried",
+                          "no attempts"],
+                         "never 'no attempts' while give-ups or sessions are non-zero; a mixed window counts every attempt once "
+                         "(requests 8 with a status plus 7 without: noStatus sits outside requests) and names the shares' base")
+
+    def test_the_cap_shows_six_transitions_with_the_divider_extra_and_six_without_one(self):
+        rows = self.R["cap"]["rows"][3:]
+        self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in rows],
+                         [(_hmd(NOW - 200), "degraded", "3 min so far", False),
+                          (_hmd(NOW - 400), "healthy", "3 min", False),
+                          (_hmd(BOOT), "kernel restarted", None, True),
+                          (_hmd(NOW - 2500), "unknown", "32 min", False),
+                          (_hmd(NOW - 3000), "recovering", "8 min", False),
+                          (_hmd(NOW - 3500), "thrashing", "8 min", False),
+                          (_hmd(NOW - 4000), "healthy", "8 min", False)],
+                         "six transitions and the divider, the two oldest changes cut")
+        self.assertEqual(sum(1 for r in rows if not r["boot"]), 6)
+        rows = self.R["capPost"]["rows"][3:]
+        self.assertEqual(len(rows), 6)
+        self.assertFalse(any(r["boot"] for r in rows), "nothing crosses the boot: no divider")
+        self.assertEqual([r["w"] for r in rows], ["healthy", "degraded", "healthy", "recovering", "thrashing", "healthy"])
+        self.assertEqual(rows[0]["v"], "1 min so far")
+
+    def test_a_failed_read_is_one_loud_line_and_never_the_previous_numbers(self):
+        R = self.R
+        self.assertEqual(R["fail503"]["head"]["err"], "Could not read the API history: HTTP 503")
+        self.assertEqual(R["fail503"]["rows"], [], "the rows the last hover showed are gone")
+        self.assertEqual(R["failReject"]["head"]["err"], "Could not read the API history: Failed to fetch")
+        self.assertEqual(R["failReject"]["rows"], [])
+        self.assertEqual(R["failMalformed"]["head"]["err"], "Could not read the API history: malformed answer")
+        self.assertIsNone(R["fail503"]["head"]["asOf"], "no as-of stamp on a failure")
+        self.assertEqual(R["recovered"]["head"]["word"], "thrashing", "the next successful read replaces the failure")
+        self.assertIsNone(R["recovered"]["head"]["err"])
+
+    def test_the_section_sits_between_the_sessions_waiting_and_the_tmux_line(self):
+        order = self.R["order"]
+        self.assertEqual(order[:3], ["API · this machine", "Sessions waiting", "History"])
+        self.assertTrue(order[3].startswith("1 tmux session is seen"), order)
+
+    def test_focus_shows_the_hover_and_blur_hides_it(self):
+        R = self.R
+        self.assertTrue(R["focusShown"])
+        self.assertEqual(R["focusDescribed"], "ah-summary")
+        self.assertTrue(R["blurHidden"])
+        self.assertIsNone(R["blurDescribed"])
+
+    def test_the_pointer_on_a_focus_shown_tip_keeps_its_rows_and_reads_nothing(self):
+        R = self.R
+        self.assertFalse(R["focusEnter"]["wait"], "no flash to the loader's dots")
+        self.assertGreater(R["focusEnter"]["rows"], 3, "the rows stay through the mouseenter")
+        self.assertEqual(R["focusEnter"]["read"], 0)
+        self.assertEqual(R["focusEnterAfter"]["fetchN"], 0, "and no read follows")
+        self.assertGreater(R["focusEnterAfter"]["rows"], 3)
+
+    def test_escape_dismisses_the_focus_shown_hover_without_moving_focus(self):
+        m = self.R["focusEsc"]
+        self.assertFalse(m["shown"])
+        self.assertIsNone(m["described"])
+        self.assertTrue(m["activeIsCell"], "focus stays on the cell")
+
+    def test_a_focus_the_window_regaining_focus_re_dispatches_does_not_pop_the_hover(self):
+        R = self.R
+        self.assertFalse(R["refocus"]["shown"], "the cell's focus in the window focus's own task, the cell already active, is not a show")
+        self.assertEqual(R["refocus"]["read"], 0, "and not a read")
+        self.assertTrue(R["refocusLater"]["shown"], "a focus after the next frame is the user's and shows")
+        self.assertEqual(R["refocusLater"]["read"], 1)
+
+    def test_a_tab_out_of_an_iframe_onto_the_cell_shows_the_hover(self):
+        R = self.R
+        self.assertEqual(R["frameTabFrom"], "lab-pane", "focus sat in the iframe (the top document's active element is its host)")
+        t = R["frameTab"]
+        self.assertEqual(t["active"], "rail-api", "one Tab lands on the cell")
+        self.assertGreaterEqual(len(t["winLog"]), 1, "Chromium fired focus on the top window for the frame change: the mark "
+                                "was set on this path, and it must not swallow the show")
+        self.assertNotIn("rail-api", t["winLog"], "the cell was not the active element at the window's event (the body is)")
+        self.assertTrue(t["shown"], "the hover shows: the recorded element was not the cell")
+        self.assertEqual(t["described"], "ah-summary")
+        self.assertEqual(t["read"], 1, "and reads once")
+        self.assertGreater(R["frameTabRows"], 3)
+
+    def test_the_shown_tip_is_a_tooltip_and_the_pinned_card_the_dialog(self):
+        R = self.R
+        for m in (R["storm"]["mode"], R["focusMode"], R["hoverAfterDialog"]):
+            self.assertEqual((m["role"], m["modal"], m["modalClass"]), ("tooltip", None, False),
+                             "a tooltip on every show, the hover after a pinned dialog closed included: the close leaves the "
+                             "hidden tip's role alone, so the show must put the tooltip role back and drop aria-modal")
+            self.assertEqual(m["described"], "ah-summary")
+            self.assertFalse(m["focusInside"])
+        self.assertTrue(R["hoverAfterDialog"]["shown"])
+        m = R["kbMode"]
+        self.assertEqual((m["role"], m["modal"], m["modalClass"]), ("dialog", "true", True))
+        self.assertTrue(m["focusInside"], "focus moves into the dialog")
+        self.assertIsNone(m["described"], "the dialog is not the cell's description")
+
+    def test_the_cell_is_described_by_a_short_summary_and_never_by_the_rows(self):
+        R = self.R
+        self.assertEqual(R["stormDesc0"], "History: ok. Reading the details. Press Enter to open it.",
+                         "before the answer: the state word the frame put on the cell and the read in flight, not the loader's markup")
+        m = R["storm"]["mode"]
+        d = m["descText"]
+        self.assertEqual(d, "History: thrashing since %s. Press Enter to open it." % _hmd(NOW - 300), "the state word, its since, how to reach the rest")
+        self.assertLess(len(d), 90, "bounded: a sentence, not the tip")
+        for w in ("attempts", "429", "5xx", "gave up", "retried", "kernel restarted", "as of", "State changes"):
+            self.assertNotIn(w, d, "no window row, no transition, no stamp in the description")
+        self.assertTrue(m["descInTree"])
+        self.assertLessEqual(max(m["descBox"]), 1.0, "visually hidden: one pixel or less each way")
+        self.assertEqual(R["fail503"]["desc"], "Could not read the API history: HTTP 503. Press Enter to open it.")
+        # at focus time, in the focus's own task (where assistive tech reads it), the description carries the state
+        # word the frame already put on the cell; the landed one carries the since
+        self.assertEqual(R["focusDesc0"], "History: rate limited · 1 waiting. Reading the details. Press Enter to open it.")
+        self.assertIn("rate limited", R["focusDesc0"], "the frame's own words, before any read")
+        self.assertEqual(R["focusDesc"], "History: thrashing since %s. Press Enter to open it." % _hmd(NOW - 300))
+        self.assertIn(" since ", R["focusDesc"])
+
+    def test_enter_pins_the_section_a_frame_re_reads_it_and_escape_does_not_re_pop_the_hover(self):
+        R = self.R
+        self.assertTrue(R["kbPinned"])
+        self.assertEqual(R["kbFetchPost"], R["kbFetchPre"], "the pin reads nothing new: the focus show's read is the same document")
+        self.assertGreater(R["kbRows"], 3)
+        self.assertEqual(R["kbHead"]["word"], "thrashing")
+        self.assertGreater(R["kbFetchAfter"], R["kbFetchBefore"], "a frame on the open detail re-reads the history")
+        self.assertTrue(R["escHidden"])
+        self.assertTrue(R["escFocusBack"], "focus returns to the cell")
+        self.assertTrue(R["escStillHidden"], "the refocus did not pop the hover back")
+        self.assertIsNone(R["escDescribed"])
+
+    def test_a_click_after_the_hover_reads_once_in_all_and_a_click_from_hidden_reads(self):
+        R = self.R
+        p = R["pinAfterHover"]
+        self.assertEqual(p["read"], 0, "the hover's read is the pin's document")
+        self.assertEqual((p["mode"]["role"], p["mode"]["modal"]), ("dialog", "true"))
+        self.assertGreater(p["rows"], 3, "and its rows are kept: no dots, no second wait")
+        self.assertFalse(p["wait"])
+        self.assertFalse(R["pinClosed"]["shown"], "Escape closed it (focus goes back to the body: the click came from there)")
+        q = R["pinFromHidden"]
+        self.assertEqual(q["read"], 1, "nothing was showing: the pin reads")
+        self.assertFalse(q["wait"], "and keeps the stamped answer it has until the read lands (the open never drops it)")
+        self.assertEqual(q["mode"]["role"], "dialog")
+
+    def test_an_answer_under_a_held_pointer_paints_on_release(self):
+        R = self.R
+        self.assertEqual(R["heldWord"], "thrashing", "the frame's re-read landed under the held pointer: not painted")
+        self.assertEqual(R["releasedWord"], "healthy", "the release paints it")
+
+    def test_the_light_theme_colours_the_quiet_head_dot_and_the_failure_line(self):
+        R = self.R
+        # the ok state's #5D574E on the head's dot for the signal's quiet states (the base gray #9aa4ad is about 1.6:1
+        # on the white tip), and the light error red #B02A1C on the failure line; the dark line keeps #ef6b6f
+        self.assertEqual((R["lightHealthyDot"]["word"], R["lightHealthyDot"]["color"]), ("healthy", "rgb(93, 87, 78)"))
+        self.assertEqual((R["lightUnknownDot"]["word"], R["lightUnknownDot"]["color"]), ("unknown", "rgb(93, 87, 78)"))
+        self.assertEqual(R["lightErr"], "rgb(176, 42, 28)", "the light theme's error-text red")
+        self.assertEqual(R["fail503"]["errColor"], "rgb(239, 107, 111)", "the dark tip's status red")
+
+    def test_the_hover_keeps_its_margin_at_830_wide_and_stays_above_the_rail_on_a_short_window(self):
+        g = self.R["geo830"]
+        self.assertEqual(g["iw"], 830)
+        # the premise: the pointer entered near the right edge and the loader's tip was first anchored flush at the right
+        # margin, so the measurement after the rows landed was taken against that edge
+        self.assertEqual(g["first"]["x"], 820)
+        self.assertGreaterEqual(g["first"]["r"], g["iw"] - 6 - 0.5, "the first anchor sat at the right margin")
+        self.assertGreater(g["first"]["l"], g["iw"] / 2, "in the right half of the window")
+        self.assertGreater(g["first"]["l"] + g["w"], g["iw"], "the tip's natural width did not fit to the right of where the first "
+                           "anchor sat, so a measurement taken there (no reset) would have been constrained and the rows wrapped")
+        self.assertLessEqual(g["r"], g["iw"] - 6 + 0.5, "the right margin holds")
+        self.assertGreaterEqual(g["l"], 5.5)
+        self.assertLessEqual(max(g["rowH"]), min(g["rowH"]) * 1.5, "no row wraps: the width was measured after the reset")
+        self.assertLessEqual(g["b"], g["cellTop"] - 8 + 0.5)
+        g = self.R["geoShort"]
+        self.assertEqual(g["ih"], 280)
+        self.assertGreaterEqual(g["t"], 5.5)
+        self.assertLessEqual(g["b"], g["cellTop"] - 8 + 0.5, "above the rail, never over it or the cell")
+        self.assertTrue(g["clipped"], "the section's oldest rows are clipped rather than spilled")
+        self.assertLessEqual(g["h"], g["cellTop"] - 14 + 0.5)
+        g = self.R["geoWide"]
+        self.assertFalse(g["clipped"], "1200x800: the whole section fits")
+        self.assertLessEqual(g["b"], g["cellTop"] - 8 + 0.5)
+        self.assertGreaterEqual(g["t"], 5.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api_health_rail.py
+++ b/tests/test_api_health_rail.py
@@ -1,0 +1,615 @@
+#!/usr/bin/env python3
+"""The bottom bar's API health cell: one dot and one word beside the usage readout, answering 'is the API
+serving my sessions'. The kernel builds one apiHealth frame per pusher cycle from the merged live map's
+retrying state, each alive transcript's LATCHED newest API error (_api_last_failed) and the retry-pause
+file, and pushes it to the shells only when it changed; the shell paints the cell from the frame and builds
+the click detail from it, with no fetch and no timer.
+
+The rule these tests pin: every field moves on one named event and never on a clock, so two computes over
+the same world are byte-identical and send nothing. Synthetic fixtures only (a private synthetic sid family,
+the notes-api demo's web / api / tests names, no paths or error text in any frame)."""
+import inspect
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest import mock
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads: they resolve their state root at import time, and only pytest runs
+# conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_apih", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_apih", os.path.join(BIN, "..", "kernel", "sdk_backend.py")).load_module()
+
+# A PRIVATE synthetic sid family for this module (never the shared 11111111-2222 placeholder, never real).
+SID = ["77777777-aaaa-4bbb-8ccc-00000000000%d" % i for i in range(1, 6)]
+NAMES = ["web", "api", "tests", "docs", "build"]
+T_STORM = 1_700_000_000          # a storm turn's start (SdkSession.since, once per fresh turn)
+T_REC = 1_700_000_100            # an error record's own timestamp
+MDOT = "·"
+
+
+def _frame_keys():
+    return {"type", "state", "cls", "reason", "text", "waiting", "retrying", "blocked", "since", "tmux", "sessions", "seq"}
+
+
+class Reference(unittest.TestCase):
+    """docs/reference.md's subsection on the cell documents the frame and the pause file the code writes."""
+
+    def _section(self):
+        doc = Path(os.path.dirname(HERE), "docs", "reference.md").read_text()
+        i = doc.index("### The bottom bar's indicator")
+        return doc[i:doc.index("\n## ", i)]
+
+    def test_the_documented_frame_has_the_code_s_keys(self):
+        sec = self._section()
+        block = sec[sec.index("```json\n") + len("```json\n"):sec.index("\n```", sec.index("```json\n"))]
+        shape = json.loads(block)
+        self.assertEqual(set(shape), _frame_keys(), "the reference's frame block and _api_health_frame drift")
+        self.assertIn("`seq` counts the retry-pause file's writes", sec)
+
+    def test_the_pause_file_paragraph_names_every_field_the_code_writes(self):
+        sec = self._section()
+        for k in ("`paused`", "`t`", "`reason`", "`bills`", "`liftedAt`", "`supersedes`"):
+            self.assertIn(k, sec, k)
+        src = inspect.getsource(km._set_retry_paused)
+        for k in ("paused", "t", "reason", "bills", "liftedAt", "supersedes"):
+            self.assertIn('"%s"' % k, src, "the paragraph names a field the code does not write: " + k)
+
+
+class _Fixture(unittest.TestCase):
+    """Fixture sessions: `self.sess` is the alive roster, `self.live` the merged live map, `self.errs` the
+    latched error per transcript path. Everything the frame reads is patched at the module seam."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._state = km.jd.STATE
+        km.jd.STATE = Path(self.td.name)
+        self._alive = km._alive_sessions
+        self._last = km._api_last_failed
+        self._send = km._send_to_app
+        self._backend_for = km.Sessions.__dict__["backend_for"]
+        self._color = km._name_color
+        self.sess, self.live, self.errs, self.tmux_sids, self.colors = [], {}, {}, set(), {}
+        km._alive_sessions = lambda now, tmux: list(self.sess)
+        km._api_last_failed = lambda p: self.errs.get(p)
+        self.sent = []
+        km._send_to_app = lambda app, m: self.sent.append((app, m))
+        km.Sessions.backend_for = staticmethod(lambda sid: km._TMUX if sid in self.tmux_sids else object())
+        km._name_color = lambda sid: self.colors.get(sid)
+        km._APIH_LAST[0] = None
+        km._retry_suppress_cache.clear()
+
+    def tearDown(self):
+        km.jd.STATE = self._state
+        km._alive_sessions = self._alive
+        km._api_last_failed = self._last
+        km._send_to_app = self._send
+        km.Sessions.backend_for = self._backend_for
+        km._name_color = self._color
+        km._APIH_LAST[0] = None
+        km._retry_suppress_cache.clear()
+        self.td.cleanup()
+
+    def add(self, i, state="waiting", retry=None, err=None, since=T_STORM):
+        """One alive session: `retry` = a retryInfo dict puts it in the api_retry storm; `err` = the latched
+        error record's fields (status / category / t / the on-you flags)."""
+        path = os.path.join(self.td.name, NAMES[i] + ".jsonl")
+        self.sess.append({"sid": SID[i], "name": NAMES[i], "path": path, "anchor": "", "mtime": 0})
+        row = {"state": state, "since": since, "backend": "sdk"}
+        if retry is not None:
+            row["state"] = "retrying"
+            row["retryInfo"] = retry
+        self.live[SID[i]] = row
+        if err is not None:
+            e = {"status": None, "category": "unknown", "t": T_REC, "text": "", "uuid": "x",
+                 "tooLong": False, "spendLimit": False, "modelLimit": False, "authErr": False, "refusal": False}
+            e.update(err)
+            self.errs[path] = e
+        return SID[i]
+
+    def reset(self):
+        self.sess.clear()
+        self.live.clear()
+        self.errs.clear()
+
+    def frame(self, now=10):
+        return km._api_health_frame(now, self.live)
+
+
+class States(_Fixture):
+    def test_no_rows_and_no_pause_is_ok(self):
+        self.add(0)
+        f = self.frame()
+        self.assertEqual((f["state"], f["cls"], f["reason"], f["text"]), ("ok", "", "", "ok"))
+        self.assertEqual((f["waiting"], f["retrying"], f["blocked"], f["since"]), (0, 0, 0, 0))
+        self.assertEqual(f["sessions"], [])
+
+    def test_a_retrying_429_row_reads_rate_limited(self):
+        self.add(0, retry={"status": 429, "attempt": 2, "max": 10})
+        f = self.frame()
+        self.assertEqual((f["state"], f["cls"], f["text"]), ("degraded", "429", "rate limited %s 1 waiting" % MDOT))
+        self.assertEqual((f["waiting"], f["retrying"], f["blocked"]), (1, 1, 0))
+        self.assertEqual(f["sessions"][0]["kind"], "retrying")
+
+    def test_a_latched_529_record_reads_overloaded(self):
+        self.add(0, err={"status": 529, "category": "overloaded"})
+        f = self.frame()
+        self.assertEqual((f["state"], f["cls"], f["text"]), ("degraded", "529", "overloaded %s 1 waiting" % MDOT))
+        self.assertEqual((f["waiting"], f["retrying"], f["blocked"]), (1, 0, 1))
+        self.assertEqual(f["sessions"][0]["kind"], "blocked")
+
+    def test_network_down_with_no_status_reads_offline(self):
+        self.add(0, retry={"status": None, "networkDown": True})
+        f = self.frame()
+        self.assertEqual((f["cls"], f["text"]), ("offline", "offline %s 1 waiting" % MDOT))
+
+    def test_a_500_reads_errors(self):
+        self.add(0, err={"status": 500, "category": "server_error"})
+        f = self.frame()
+        self.assertEqual((f["cls"], f["text"]), ("errors", "errors %s 1 waiting" % MDOT))
+
+    def test_a_no_status_record_without_a_network_flag_reads_errors_not_offline(self):
+        # only a retrying row can say offline: a transcript record carries no network flag
+        self.add(0, err={"status": None, "category": "unknown"})
+        self.assertEqual(self.frame()["cls"], "errors")
+
+    def test_plurality_picks_the_most_common_class(self):
+        self.add(0, retry={"status": 429})
+        self.add(1, retry={"status": 429})
+        self.add(2, err={"status": 529, "category": "overloaded"})
+        f = self.frame()
+        self.assertEqual((f["cls"], f["text"]), ("429", "rate limited %s 3 waiting" % MDOT))
+
+    def test_ties_resolve_in_the_fixed_order(self):
+        self.add(0, retry={"status": 429})
+        self.add(1, err={"status": 529, "category": "overloaded"})
+        self.assertEqual(self.frame()["cls"], "429", "429 before 529")
+        self.reset()
+        self.add(0, err={"status": 529, "category": "overloaded"})
+        self.add(1, err={"status": 500, "category": "server_error"})
+        self.assertEqual(self.frame()["cls"], "529", "529 before errors")
+        self.reset()
+        self.add(0, retry={"status": None, "networkDown": True})
+        self.add(1, err={"status": 500, "category": "server_error"})
+        self.assertEqual(self.frame()["cls"], "offline", "offline before errors")
+
+    def test_on_you_failures_do_not_count(self):
+        for flag in ("tooLong", "modelLimit", "authErr", "refusal"):
+            self.reset()
+            self.add(0, err={"status": 400, "category": "invalid_request", flag: True})
+            f = self.frame()
+            self.assertEqual((f["state"], f["waiting"]), ("ok", 0), flag + " is the session's own, not the API's")
+
+    def test_a_spend_limit_record_counts(self):
+        self.add(0, err={"status": 400, "category": "billing_error", "spendLimit": True})
+        f = self.frame()
+        self.assertEqual((f["state"], f["cls"], f["waiting"]), ("degraded", "errors", 1))
+
+    def test_a_spend_pause_outranks_any_class(self):
+        self.add(0, retry={"status": 429})
+        self.add(1, retry={"status": 429})
+        km._set_retry_paused(True, reason="spend")
+        f = self.frame()
+        self.assertEqual((f["state"], f["reason"], f["text"]),
+                         ("paused", "spend", "paused %s spend cap %s 2 waiting" % (MDOT, MDOT)))
+        self.assertEqual(f["cls"], "429", "the class still rides along for the detail")
+
+    def test_a_limit_pause_names_the_usage_limit(self):
+        self.add(0, retry={"status": 429})
+        km._set_retry_paused(True, reason="limit")
+        f = self.frame()
+        self.assertEqual((f["state"], f["reason"], f["text"]),
+                         ("paused", "limit", "paused %s usage limit %s 1 waiting" % (MDOT, MDOT)))
+
+    def test_a_manual_pause_reads_paused_by_you(self):
+        self.add(0, err={"status": 500, "category": "server_error"})
+        km._set_retry_paused(True)
+        f = self.frame()
+        self.assertEqual((f["reason"], f["text"]), ("manual", "paused by you %s 1 waiting" % MDOT))
+
+    def test_a_pause_with_nothing_waiting_drops_the_count(self):
+        self.add(0)
+        km._set_retry_paused(True, reason="limit")
+        self.assertEqual(self.frame()["text"], "paused %s usage limit" % MDOT)
+        km._set_retry_paused(True, reason="spend")
+        self.assertEqual(self.frame()["text"], "paused %s spend cap" % MDOT)
+        km._set_retry_paused(True)
+        self.assertEqual(self.frame()["text"], "paused by you")
+
+    def test_a_suppressed_row_carries_suppressed_true(self):
+        sid = self.add(0, err={"status": 500, "category": "server_error"})
+        self.add(1, retry={"status": 429})
+        km._suppress_session_retry(sid)
+        rows = {r["sid"]: r for r in self.frame()["sessions"]}
+        self.assertTrue(rows[SID[0]]["suppressed"])
+        self.assertFalse(rows[SID[1]]["suppressed"])
+        self.assertEqual(self.frame()["waiting"], 2, "the interrupt says nothing about the API: still counted")
+
+    def test_tmux_backed_sessions_are_counted_for_the_coverage_line(self):
+        self.add(0)
+        self.add(1)
+        self.add(2, err={"status": 500, "category": "server_error"})
+        self.tmux_sids = {SID[1], SID[2]}
+        self.assertEqual(self.frame()["tmux"], 2)
+
+    def test_rows_carry_name_and_color(self):
+        self.colors[SID[0]] = {"bg": "#3366cc", "fg": "#ffffff"}
+        self.add(0, retry={"status": 429})
+        r = self.frame()["sessions"][0]
+        self.assertEqual((r["name"], r["color"]), ("web", {"bg": "#3366cc", "fg": "#ffffff"}))
+
+    def test_a_latched_row_reads_retrying_while_its_session_is_working(self):
+        # The retry prompt (romp's own, or a human's) was accepted and the turn is open, no api_retry frame yet;
+        # for a tmux session that is the whole internal retry. The word follows the live state; the latch only
+        # keeps the row counted, and its since stays the record's time.
+        self.add(0, state="working", err={"status": 529, "category": "overloaded"})
+        f = self.frame()
+        r = f["sessions"][0]
+        self.assertEqual((r["kind"], r["cls"], r["status"], r["since"]), ("retrying", "529", 529, T_REC))
+        self.assertEqual((f["waiting"], f["retrying"], f["blocked"], f["text"]),
+                         (1, 1, 0, "overloaded %s 1 waiting" % MDOT))
+        self.add(1, state="idle", err={"status": 529, "category": "overloaded"})
+        f = self.frame()
+        self.assertEqual([x["kind"] for x in f["sessions"]], ["retrying", "blocked"])
+        self.assertEqual((f["waiting"], f["retrying"], f["blocked"]), (2, 1, 1))
+
+    def test_a_string_status_on_the_wire_is_read_as_a_number(self):
+        self.add(0, retry={"status": "529"})
+        f = self.frame()
+        self.assertEqual((f["cls"], f["sessions"][0]["status"]), ("529", 529))
+
+
+class NoFlap(_Fixture):
+    def test_two_computes_over_the_same_world_are_byte_identical_and_send_once(self):
+        self.add(0, retry={"status": 429, "attempt": 3, "retryAt": 1_700_000_050.5})
+        self.add(1, err={"status": 500, "category": "server_error"})
+        f1 = self.frame(now=10)
+        km._api_health_push(f1)
+        f2 = self.frame(now=99_999)
+        km._api_health_push(f2)
+        self.assertEqual(json.dumps(f1, sort_keys=True), json.dumps(f2, sort_keys=True))
+        self.assertEqual(len(self.sent), 1, "an unchanged world sends nothing")
+        self.assertEqual(self.sent[0][0], "shell")
+
+    def test_attempt_and_retry_at_changes_move_nothing(self):
+        self.add(0, retry={"status": 429, "attempt": 3, "retryAt": 100.0, "error": "429 rate limited"})
+        km._api_health_push(self.frame())
+        self.live[SID[0]]["retryInfo"].update({"attempt": 4, "retryAt": 200.0, "error": "429 again"})
+        km._api_health_push(self.frame())
+        self.assertEqual(len(self.sent), 1, "per-attempt counters are not inputs")
+
+    def test_a_row_flipping_retrying_to_blocked_with_the_same_count_does_send(self):
+        self.add(0, retry={"status": 429})
+        km._api_health_push(self.frame())
+        self.live[SID[0]] = {"state": "waiting", "since": T_STORM}
+        self.errs[self.sess[0]["path"]] = {"status": 429, "category": "rate_limit", "t": T_REC,
+                                            "tooLong": False, "modelLimit": False, "authErr": False, "refusal": False}
+        km._api_health_push(self.frame())
+        self.assertEqual(len(self.sent), 2, "the storm gave up and left a record: new information")
+        self.assertEqual(self.sent[1][1]["waiting"], 1)
+        self.assertEqual((self.sent[1][1]["retrying"], self.sent[1][1]["blocked"]), (0, 1))
+
+    def test_a_pause_set_and_lifted_each_send_once(self):
+        self.add(0)
+        km._api_health_push(self.frame())
+        km._set_retry_paused(True, reason="limit")
+        km._api_health_push(self.frame())
+        km._api_health_push(self.frame())
+        km._set_retry_paused(False)
+        km._api_health_push(self.frame())
+        self.assertEqual([m["state"] for _, m in self.sent], ["ok", "paused", "ok"])
+
+    def test_since_is_the_event_stamp_never_the_clock(self):
+        self.add(0, retry={"status": 429}, since=T_STORM)
+        self.add(1, err={"status": 500, "category": "server_error", "t": T_REC})
+        f = self.frame(now=5_000_000_000)
+        self.assertEqual(f["since"], T_STORM, "the earliest affected event")
+        rows = {r["sid"]: r for r in f["sessions"]}
+        self.assertEqual(rows[SID[0]]["since"], T_STORM)
+        self.assertEqual(rows[SID[1]]["since"], T_REC)
+        km._set_retry_paused(True, reason="spend")
+        self.assertEqual(self.frame()["since"], int(km._retry_pause_ts()), "paused: the pause's own t")
+
+    def test_the_roster_order_cannot_reshuffle_an_unchanged_world(self):
+        self.add(0, retry={"status": 429})
+        self.add(1, err={"status": 500, "category": "server_error"})
+        km._api_health_push(self.frame())
+        self.sess.reverse()                              # a newer mtime moved a session up the roster
+        km._api_health_push(self.frame())
+        self.assertEqual(len(self.sent), 1)
+
+    def test_seq_moves_on_every_pause_write_and_only_then(self):
+        # a press on the detail's pause button writes the pause file; the frame after it must differ from every
+        # frame before it even when the cycle's auto-pause put the same state back, so the shell can clear its
+        # acknowledgment on the frame that answers the press
+        self.add(0, retry={"status": 429})
+        km._api_health_push(self.frame())
+        km._api_health_push(self.frame(now=99))
+        self.assertEqual(len(self.sent), 1, "no write: an unchanged world sends nothing")
+        seq0 = self.sent[0][1]["seq"]
+        km._set_retry_paused(False)                        # a Resume landing on an already-unpaused file
+        km._api_health_push(self.frame())
+        self.assertEqual(len(self.sent), 2, "the write is the event, whatever state it left")
+        self.assertEqual(self.sent[1][1]["seq"], seq0 + 1)
+        self.assertEqual((self.sent[1][1]["state"], self.sent[1][1]["text"]),
+                         (self.sent[0][1]["state"], self.sent[0][1]["text"]))
+        km._set_retry_paused(True, reason="limit")
+        km._set_retry_paused(False)
+        km._api_health_push(self.frame())
+        self.assertEqual(self.sent[2][1]["seq"], seq0 + 3, "every write counts, including one lifted within the cycle")
+
+    def test_the_ready_handler_resends_the_last_frame_to_a_shell_only(self):
+        # recording sinks on every client: _apih_resend guards the send with a try/except, so a sink that raised
+        # to fail the test would be swallowed by the very function under test
+        self.add(0, retry={"status": 429})
+        km._api_health_push(self.frame())
+        got, got_chat, got_feed = [], [], []
+        km._apih_resend({"app": "shell", "send": got.append})
+        km._apih_resend({"app": "chat", "send": got_chat.append})
+        km._apih_resend({"app": "feed", "send": got_feed.append})
+        self.assertEqual(len(got), 1)
+        self.assertEqual(json.loads(got[0]), self.sent[0][1], "verbatim: the client diffs state and text")
+        self.assertEqual((got_chat, got_feed), ([], []), "a chat or pane client owns no rail")
+
+    def test_nothing_to_resend_before_the_first_frame(self):
+        got = []
+        km._apih_resend({"app": "shell", "send": got.append})
+        self.assertEqual(got, [], "nothing sent since boot")
+
+
+class FrameShape(_Fixture):
+    def test_the_frame_and_its_rows_carry_exactly_the_documented_keys(self):
+        self.add(0, retry={"status": 429, "error": "the wire's text", "requestId": "req_x"})
+        self.add(1, err={"status": 500, "category": "server_error", "text": "API Error: 500"})
+        f = self.frame()
+        self.assertEqual(set(f), _frame_keys())
+        for r in f["sessions"]:
+            self.assertEqual(set(r), {"sid", "name", "color", "kind", "cls", "status", "since", "suppressed"})
+        s = json.dumps(f)
+        self.assertNotIn(".jsonl", s, "no path in any frame")
+        self.assertNotIn("API Error", s, "no error text in any frame")
+        self.assertNotIn("req_x", s)
+        self.assertNotIn("attempt", s)
+
+    def test_apih_class_agrees_with_the_backend_on_shared_statuses(self):
+        collapse = {"429": "429", "529": "529", "5xx": "errors", "other": "errors", "none": "errors"}
+        for status, cat in ((429, ""), (529, ""), (500, ""), (400, ""), (None, "rate_limit"), (None, "overloaded")):
+            self.assertEqual(km._apih_class(status, cat), collapse[sb.api_health_status_class(status, cat)],
+                             "status=%r category=%r" % (status, cat))
+        self.assertEqual(km._apih_class(None, "", True), "offline", "the one word the backend lacks")
+
+    def test_the_text_table_is_the_rail_s_words(self):
+        self.assertEqual(km._APIH_TEXT, {"ok": "ok", "429": "rate limited", "529": "overloaded", "offline": "offline",
+                                         "errors": "errors", "limit": "paused %s usage limit" % MDOT,
+                                         "spend": "paused %s spend cap" % MDOT, "manual": "paused by you"})
+        for v in km._APIH_TEXT.values():
+            self.assertNotIn("blocked", v)
+        self.assertEqual(km._APIH_ORDER, ("429", "529", "offline", "errors"))
+
+
+class Wiring(unittest.TestCase):
+    # the cycle's other jobs, stubbed quiet when the jobs block runs here (tests/test_wire_once_per_build.py's list)
+    OTHER_JOBS = ("_apply_pending_ops", "_push_all", "_turn_notify_tick", "_lift_spent_awaiting", "_death_sweep_tick",
+                  "_end_on_idle_sweep", "_deferral_sweep_tick", "_auto_nudge_tick", "_interrupt_block_tick",
+                  "_usage_poll_tick", "_auto_resume_session_retry", "_auto_retry_tick", "_idle_queue_drive_tick",
+                  "_clear_done_working_notes")
+
+    def test_the_frame_is_built_in_the_jobs_block_after_this_cycle_s_pause_decisions(self):
+        src = inspect.getsource(km._pusher_cycle_jobs)
+        self.assertIn("_api_health_push(_api_health_frame(now, tmux))", src)
+        self.assertLess(src.index("_auto_resume_retry(now, tmux)"), src.index("_api_health_push(_api_health_frame"))
+        self.assertNotIn("_api_health", inspect.getsource(km._cached_feed), "not gated by the feed's sig / rebuild floor")
+
+    def test_the_jobs_block_runs_the_frame_after_the_pause_decisions(self):
+        # the executing twin of the pin above: a frame built before _auto_resume_retry would carry the pause the
+        # same cycle lifts, so the cell would read paused one cycle late on every lift
+        order = []
+        quiet = {nm: (lambda *a, **k: None) for nm in self.OTHER_JOBS}
+        with mock.patch.multiple(km, **quiet), \
+                mock.patch.object(km, "_auto_pause_on_limit", side_effect=lambda: order.append("limit")), \
+                mock.patch.object(km, "_auto_pause_on_spend_limit", side_effect=lambda now, tmux: order.append("spend")), \
+                mock.patch.object(km, "_auto_resume_retry", side_effect=lambda now, tmux: order.append("resume")), \
+                mock.patch.object(km, "_api_health_frame", side_effect=lambda now, tmux: order.append("frame") or {"type": "apiHealth"}), \
+                mock.patch.object(km, "_api_health_push", side_effect=lambda f: order.append("push:" + f["type"])):
+            km._pusher_cycle_jobs(T_STORM, {}, True)
+        self.assertEqual(order, ["limit", "spend", "resume", "frame", "push:apiHealth"])
+
+    def test_the_ready_handler_resends_beside_the_badge(self):
+        src = Path(BIN, "romp-kernel").read_text()
+        i = src.index('client["send"](json.dumps({"type": "badge", "n": _BADGE_LAST[0]}))')
+        j = src.index("_apih_resend(client)", i)          # the CALL in the ready handler, after the def
+        self.assertLess(j - i, 400, "right beside the badge re-send, in the same ready branch")
+        self.assertIn("def _apih_resend(client):", src)
+
+    def test_auto_pause_on_limit_latches_reason_limit(self):
+        self.assertIn('_set_retry_paused(True, reason="limit")', inspect.getsource(km._auto_pause_on_limit))
+
+    def test_the_global_retry_paused_frame_still_carries_the_reason(self):
+        # the chat card's paused line reads `reason` off the globalRetryPaused frame (render.ts retryPausedText
+        # checks spend first and otherwise renders the resumeAt countdown, so a latched "limit" reason draws the
+        # countdown exactly as an unlabeled limit pause did); the latch changes the file, not the frame
+        src = Path(BIN, "romp-kernel").read_text()
+        self.assertIn('"reason": _retry_pause_reason()})', src)
+
+
+
+class Detail(unittest.TestCase):
+    """The click detail's content, pinned at source (no jsdom for the shell page); the served behaviour is
+    tests/test_api_health_browser.py."""
+
+    def setUp(self):
+        self.JS = km._LANDING_APIH_JS
+
+    def test_the_plain_words_sentences_are_present_verbatim(self):
+        for s in ("Auto-retry and the judges are paused until your usage limit resets.",
+                  "Auto-retry and the judges are paused: you have reached the monthly spend limit. Raise it at claude.ai/settings/usage.",
+                  "Auto-retry and the judges are paused: you stopped them.",
+                  "No session is waiting on the API. Auto-retry and the judges are running.",
+                  "API %s this machine" % MDOT, "Sessions waiting", "since "):
+            self.assertIn(s, self.JS)
+
+    def test_the_pause_button_is_the_chat_card_s_and_acknowledges_before_the_round_trip(self):
+        self.assertIn("'Resume all auto-retries'", self.JS)
+        self.assertIn("'Stop all auto-retries'", self.JS)
+        self.assertIn("{type:'setGlobalRetryPaused',value:v}", self.JS)
+        press = self.JS[self.JS.index("if(act==='pause')"):self.JS.index("else if(act==='reveal')")]
+        self.assertIn("t.disabled=true", press)
+        self.assertIn("t.textContent=v?RESUME:STOP", press)
+        self.assertIn("t.classList.add('romp-acted')", press)
+        self.assertLess(press.index("t.classList.add('romp-acted')"), press.index("__rompShellSend("), "acknowledged first")
+        self.assertIn("hint=NOTSENT", press, "a dead socket is said, not swallowed")
+        self.assertIn("var NOTSENT='Not sent: the dashboard is disconnected. Try again.';", self.JS)
+
+    def test_a_session_row_opens_that_session_the_way_the_feed_s_links_do(self):
+        # feed.ts openOrReviveSession posts openSession for a live session; the row does the same on the shell
+        # socket, toggles no pane and persists nothing about the layout
+        row = self.JS[self.JS.index("else if(act==='reveal')"):self.JS.index("else if(act==='usage')")]
+        self.assertIn("__rompShellSend({type:'openSession',id:sid})", row)
+        self.assertNotIn("__rompPaneToggle", self.JS, "never a pane toggle from the card")
+        self.assertNotIn("revealCard", self.JS)
+        self.assertIn("data-act=reveal data-sid=", self.JS)
+        self.assertIn("else{hint=NOTSENT;dirty=true;}", row, "a dead socket is said here too")
+
+    def test_the_coverage_line_appears_only_under_a_tmux_guard(self):
+        self.assertIn("if(m.tmux>0)h+=", self.JS)
+        self.assertIn("seen through their transcripts only", self.JS)
+        self.assertIn(", so a retry in progress there shows only when it fails or recovers.", self.JS)
+
+    def test_the_detail_renders_from_the_last_frame_only(self):
+        self.assertNotIn("fetch(", self.JS)
+        self.assertNotIn("setInterval", self.JS)
+        self.assertNotIn("setTimeout", self.JS)
+        self.assertIn("window.__rompApiHealth=function(m){", self.JS)
+        self.assertIn("LAST=m;", self.JS)
+
+    def test_the_cell_repaints_only_when_state_or_text_changed_and_shows_on_the_first_frame(self):
+        self.assertIn("if(el.hidden)el.hidden=false;", self.JS)
+        self.assertIn("if(el.getAttribute('data-state')!==m.state||txt.textContent!==m.text){el.setAttribute('data-state',m.state);"
+                      "txt.textContent=m.text;el.setAttribute('aria-label','API '+m.text);}", self.JS)
+        self.assertIn("if(tip.style.display!=='block')return;", self.JS)
+        self.assertIn("if(held){dirty=true;return;}render();};", self.JS)
+
+    def test_the_hover_renders_no_controls_and_the_pinned_detail_does(self):
+        self.assertIn("function html(m,full)", self.JS)
+        self.assertIn("if(full)h+=btnHTML(m);", self.JS)
+        self.assertIn("(full?' role=button tabindex=0 data-act=reveal data-sid=\"'+esc(r.sid)+'\"':'')", self.JS)
+        self.assertIn("if(full)h+='<div class=\"ru-tip-row ah-foot\">", self.JS)
+        self.assertIn("tip.innerHTML=html(LAST,pinned);", self.JS, "pinned = full; the hover = the reading only")
+
+    def test_a_frame_under_a_held_pointer_is_painted_on_release_never_under_the_press(self):
+        # only a PRIMARY press arms the defer: no click follows a right or middle button, so a frame deferred
+        # under one would stay unpainted until the next frame changed something
+        self.assertIn("tip.addEventListener('pointerdown',function(ev){if(ev.button===0)held=true;});", self.JS)
+        self.assertIn("document.addEventListener('pointerup',release);", self.JS)
+        self.assertIn("document.addEventListener('pointercancel',release);", self.JS)
+        self.assertIn("if(held){dirty=true;return;}render();", self.JS)
+        self.assertIn("ev.button===0&&ev.target&&tip.contains(ev.target))return;flush();}", self.JS,
+                      "a primary release inside waits for its click; any other release flushes")
+        self.assertIn("tip.addEventListener('click',function(ev){var t=actOf(ev.target);if(t)run(t);flush();});", self.JS,
+                      "the click handler flushes last")
+
+    def test_the_acknowledgment_holds_until_the_frame_that_answers_the_press(self):
+        # the frame's seq is the pause file's write count; the press writes it, so the frame after the press
+        # carries a moved seq whatever state it brings (paused again, when a limit or spend pause re-engaged
+        # within the cycle). A rule keyed on a matching state would leave a Resume during a usage-limit pause
+        # disabled and mislabeled for the rest of the window.
+        self.assertIn("pending=v?1:0;pendSeq=LAST?LAST.seq:null;", self.JS)
+        self.assertIn("if(pending!==null)return '<button class=\"ah-btn romp-acted\" disabled data-act=pause", self.JS)
+        self.assertIn("if(pending!==null&&(m.seq==null||m.seq!==pendSeq))pending=null;", self.JS)
+        self.assertNotIn("(pending===1)===(m.state==='paused')", self.JS, "no state matching")
+
+    def test_the_rows_and_footer_links_are_keyboard_buttons_inside_a_focus_trap(self):
+        self.assertIn("<span class=ah-link role=button tabindex=0 data-act=usage>Usage and spend</span>", self.JS)
+        self.assertIn("<span class=ah-link role=button tabindex=0 data-act=log>Log</span>", self.JS)
+        self.assertIn("tip.setAttribute('aria-modal','true')", self.JS)
+        self.assertIn("tip.addEventListener('keydown',function(ev){if(!pinned)return;", self.JS)
+        self.assertIn("if(ev.key==='Tab'){var f=controls(),i=f.indexOf(document.activeElement);", self.JS)
+        self.assertIn("if(ev.shiftKey){if(i<=0){ev.preventDefault();f[f.length-1].focus();}}", self.JS)
+        self.assertIn("else if(i<0||i===f.length-1){ev.preventDefault();f[0].focus();}", self.JS)
+        self.assertIn("if(ev.key!=='Enter'&&ev.key!==' ')return;var t=actOf(ev.target);if(!t||t.tagName==='BUTTON')return;", self.JS,
+                      "Enter / Space run a row or link; the button's own keys click it natively")
+        self.assertIn("ev.preventDefault();run(t);flush();});", self.JS)
+        # a re-render keeps focus on the same control, else the card: the trap must survive a frame
+        self.assertIn("key=(pinned&&a&&a!==tip&&tip.contains(a))?focusKey(a):null;", self.JS)
+        self.assertIn("try{if(n)n.focus();if(!n||document.activeElement!==n)tip.focus();}catch(e){}", self.JS)
+
+    def test_a_failed_send_restores_the_button_and_names_the_reason_under_it(self):
+        press = self.JS[self.JS.index("if(act==='pause')"):self.JS.index("else if(act==='reveal')")]
+        self.assertIn("{pending=null;hint=NOTSENT;dirty=true;}", press)
+        self.assertIn("(hint?'<div class=ah-hint>'+esc(hint)+'</div>':'')", self.JS)
+        self.assertIn("LAST=m;hint='';", self.JS, "a frame means the socket is alive: the notice retires")
+
+    def test_a_press_the_socket_lost_clears_on_the_close_and_says_why(self):
+        # the redial's ready re-sends the last frame verbatim, so a press the kernel never received would keep
+        # the button disabled and relabeled across the reconnect until an unrelated pause write moved the seq;
+        # the shell's onclose tells the detail, and the re-sent frame repaints the truth either way
+        self.assertIn("window.__rompApiSocketLost=function(){if(pending===null)return;pending=null;pendSeq=null;hint=LOST;", self.JS)
+        self.assertIn("var LOST='Connection lost before the answer arrived. When it is back, the button shows the current state.';", self.JS)
+        self.assertIn("hint=LOST;\nif(tip.style.display!=='block')return;if(held){dirty=true;return;}render();};", self.JS,
+                      "painted on release under a held pointer, like a frame")
+        html = km._landing()
+        self.assertIn("ws.onclose=function(){try{window.__rompApiSocketLost&&window.__rompApiSocketLost();}catch(e){}"
+                      "if(shellSock===ws)shellSock=null;setTimeout(shellWS,2000);};", html,
+                      "the shell socket's close tells the detail before the redial")
+
+    def test_focus_moves_to_the_card_before_the_pressed_button_is_disabled(self):
+        # a disabled element cannot hold focus: left on the button, focus fell to BODY, where the card's Tab trap
+        # no longer saw the keys and a Shift+Tab left the aria-modal dialog
+        press = self.JS[self.JS.index("if(act==='pause')"):self.JS.index("else if(act==='reveal')")]
+        self.assertIn("try{tip.focus();}catch(e){}", press)
+        self.assertLess(press.index("try{tip.focus();}catch(e){}"), press.index("t.disabled=true"), "focus first, then the disable")
+
+    def test_the_hover_re_anchors_after_a_re_render(self):
+        self.assertIn("tip.innerHTML=html(LAST,pinned);if(!pinned)anchor();", self.JS)
+        self.assertIn("tip.style.top=Math.max(6,r.top-tip.offsetHeight-8)+'px';}", self.JS)
+        self.assertIn("lastX=(ev&&typeof ev.clientX==='number')?ev.clientX:null;", self.JS)
+
+    def test_the_cell_is_a_keyboard_button_and_the_detail_takes_and_returns_focus(self):
+        self.assertIn("el.addEventListener('keydown',function(ev){if(ev.key==='Enter'||ev.key===' ')", self.JS)
+        self.assertIn("el.setAttribute('aria-label','API '+m.text)", self.JS)
+        self.assertIn("tip.setAttribute('role','dialog')", self.JS)
+        self.assertIn("focusBack=document.activeElement;", self.JS)
+        self.assertIn("try{tip.focus();}catch(e){}", self.JS)
+        self.assertIn("(fb&&fb.focus?fb:el).focus()", self.JS)
+
+    def test_each_modal_closes_the_other_first_so_the_shared_backdrop_serves_one(self):
+        self.assertIn("function open(){if(!LAST)return;try{window.__rompUsageClose&&window.__rompUsageClose();}catch(e){}", self.JS)
+        self.assertIn("try{window.__rompApiClose&&window.__rompApiClose();}catch(e){}", km._LANDING_USAGE_JS)
+
+    def test_actions_are_delegated_on_the_stable_tip_node(self):
+        self.assertIn("var el=document.getElementById('rail-api');", self.JS)
+        self.assertIn("el.addEventListener('click',function(){if(pinned)close();else open();});", self.JS)
+        self.assertNotIn("el.innerHTML", self.JS, "the frame handler writes the cell's children, never the cell")
+        self.assertIn("tip.addEventListener('click',function(ev){", self.JS)
+        self.assertEqual(self.JS.count("addEventListener('click'"), 2, "one on #rail-api, one on #ah-tip; none per row")
+        self.assertEqual(self.JS.count("addEventListener('keydown'"), 2, "one on #rail-api, one on #ah-tip; none per row")
+        self.assertEqual(self.JS.count("function run(t){var act=t.getAttribute('data-act');"), 1, "one action switch for click and key")
+        self.assertNotIn(".onclick=function", self.JS, "no per-row inline handlers")
+
+    def test_the_amber_state_is_never_called_blocked(self):
+        self.assertNotIn("'blocked'", self.JS)
+        self.assertIn("(r.kind==='retrying'?'retrying':'stopped')", self.JS, "the amber state is never called blocked")
+
+    def test_the_footer_reaches_the_usage_modal_and_the_log(self):
+        self.assertIn("data-act=usage>Usage and spend<", self.JS)
+        self.assertIn("data-act=log>Log<", self.JS)
+        self.assertIn("window.__rompUsagePanel&&window.__rompUsagePanel()", self.JS)
+        self.assertIn("window.__rompOpenErrs&&window.__rompOpenErrs()", self.JS)
+
+    def test_the_pinned_detail_wears_the_usage_modal_s_backdrop_and_escape_hook(self):
+        self.assertIn("tip.classList.add('ru-modal')", self.JS)
+        self.assertIn("back.classList.add('on')", self.JS)
+        self.assertIn("window.__rompApiClose=close;back.onclick=close;", self.JS)
+        self.assertIn("window.__rompApiClose=null;", self.JS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api_health_rail.py
+++ b/tests/test_api_health_rail.py
@@ -483,8 +483,12 @@ class Detail(unittest.TestCase):
         self.assertIn("seen through their transcripts only", self.JS)
         self.assertIn(", so a retry in progress there shows only when it fails or recovers.", self.JS)
 
-    def test_the_detail_renders_from_the_last_frame_only(self):
-        self.assertNotIn("fetch(", self.JS)
+    def test_the_detail_renders_from_the_last_frame_and_the_history_is_the_one_read(self):
+        # the cell and the frame's reading render from the last frame only; the History section is the one fetch,
+        # GET /api-health at show time, and there is still no timer anywhere (test_api_health_hover.py holds the
+        # section's own pins)
+        self.assertEqual(self.JS.count("fetch("), 1, "one read: the history's")
+        self.assertIn("fetch('/api-health',{cache:'no-store'})", self.JS)
         self.assertNotIn("setInterval", self.JS)
         self.assertNotIn("setTimeout", self.JS)
         self.assertIn("window.__rompApiHealth=function(m){", self.JS)
@@ -569,11 +573,14 @@ class Detail(unittest.TestCase):
 
     def test_the_hover_re_anchors_after_a_re_render(self):
         self.assertIn("tip.innerHTML=html(LAST,pinned);if(!pinned)anchor();", self.JS)
-        self.assertIn("tip.style.top=Math.max(6,r.top-tip.offsetHeight-8)+'px';}", self.JS)
+        # measured after a reset (left 0, the height cap), then placed: a fixed element's shrink-to-fit width is
+        # taken against where it last sat, and the History rows make the tip wider than the frame's reading
+        self.assertIn("var w=tip.offsetWidth,h=tip.offsetHeight;\ntip.style.left=Math.max(6,Math.min(window.innerWidth-w-6,x-w/2))+'px';\ntip.style.top=Math.max(6,r.top-h-8)+'px';}", self.JS)
         self.assertIn("lastX=(ev&&typeof ev.clientX==='number')?ev.clientX:null;", self.JS)
 
     def test_the_cell_is_a_keyboard_button_and_the_detail_takes_and_returns_focus(self):
-        self.assertIn("el.addEventListener('keydown',function(ev){if(ev.key==='Enter'||ev.key===' ')", self.JS)
+        self.assertIn("el.addEventListener('keydown',function(ev){if(ev.key==='Escape')", self.JS)
+        self.assertIn("if(ev.key==='Enter'||ev.key===' '){ev.preventDefault();if(pinned)close();else open();}});", self.JS)
         self.assertIn("el.setAttribute('aria-label','API '+m.text)", self.JS)
         self.assertIn("tip.setAttribute('role','dialog')", self.JS)
         self.assertIn("focusBack=document.activeElement;", self.JS)

--- a/tests/test_kernel_apierror_working.py
+++ b/tests/test_kernel_apierror_working.py
@@ -2,7 +2,7 @@
 ⚠ chip and auto-retry recovers it. BUT an ON-YOU error floors the focus card to needs-input and gets the
 alarm-red tab: "prompt is too long" (compact needed), a monthly spend cap (raise it, the user 2026-07-14), or a
 spent MODEL allowance (switch model / add credits, the user 2026-08-01) — the spend cap ALSO stops auto-retry
-entirely (no reset to wait out). Source pins on _api_error + build_feed. The model-limit case has its own
+entirely (no reset to wait out). Source pins on _api_error_pass + build_feed. The model-limit case has its own
 behavioural file, tests/test_kernel_model_limit.py."""
 import inspect
 import os
@@ -23,9 +23,9 @@ km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_modu
 
 class ApiErrorWorking(unittest.TestCase):
     def test_api_error_carries_a_tooLong_flag(self):
-        # the classification lives in _api_error_scan since the tail-window split — _api_error is now the
-        # widening driver around it, so read the pair rather than pinning which half holds the flag
-        src = inspect.getsource(km._api_error) + inspect.getsource(km._api_error_scan)
+        # the classification lives in _api_error_pass, the one-pass scanner both _api_error and the latched
+        # _api_last_failed read through, so the pin reads that function
+        src = inspect.getsource(km._api_error_pass)
         self.assertIn('"tooLong": "too long" in text.lower()', src)
 
     def test_only_on_you_errors_floor_the_card_to_needs_input(self):
@@ -41,10 +41,9 @@ class ApiErrorWorking(unittest.TestCase):
         self.assertIn('or (col == "blocked" and not recheck and not rejudging))', src)
 
     def test_spend_cap_is_classified_and_floors_like_tooLong(self):
-        # a monthly spend cap is on you (raise it) AND never auto-retried — classified in _api_error, floored
-        # to needs-input, and badged with the raise-your-cap guidance (the user 2026-07-14).
-        self.assertIn('"spendLimit": _is_spend_limit(text)',
-                      inspect.getsource(km._api_error) + inspect.getsource(km._api_error_scan))
+        # a monthly spend cap is on you (raise it) AND never auto-retried: classified in _api_error_pass,
+        # floored to needs-input, and badged with the raise-your-cap guidance (the user 2026-07-14).
+        self.assertIn('"spendLimit": _is_spend_limit(text)', inspect.getsource(km._api_error_pass))
         bf = inspect.getsource(km.build_feed)
         self.assertIn('"spendLimit": bool(aerr.get("spendLimit"))', bf)
         self.assertIn("monthly spend limit — raise it at claude.ai/settings/usage", bf)

--- a/tests/test_kernel_auth_hardening.py
+++ b/tests/test_kernel_auth_hardening.py
@@ -653,7 +653,7 @@ class _ApiHealthBackend:
     served payload is the real shape and the leak checks have something to catch."""
 
     def __init__(self):
-        self.ah = sb.ApiHealth(tempfile.mkdtemp())
+        self.ah = sb.ApiHealth(tempfile.mkdtemp(), boot_at=km._STARTED)     # seeded the way _sdk_locked seeds the live one
         label = sb.api_health_auth_label("ANTHROPIC_API_KEY", salt=self.ah.salt(),
                                          key_fp=_AH_KEY_FP, launched_keyed=True)
         now = time.time()
@@ -750,7 +750,12 @@ class ApiHealthRouteGate(unittest.TestCase):
         v = km._version_info()
         self.assertEqual(out["bootId"], km._BOOT_ID)
         self.assertEqual(out["bootId"], v["boot"], "the same id /version and X-Romp-Boot carry — never a third")
-        self.assertEqual(out["bootAt"], v["started"])
+        self.assertEqual(out["bootAt"], self.be.ah.boot_stamp, "bootAt is the aggregator's own seed stamp")
+        self.assertEqual(int(out["bootAt"]), v["started"], "the same start: bootAt truncated to the millisecond (the payload's "
+                         "stamp precision, so a bucket the boot seeded carries the very number), started to the whole second; "
+                         "a fresh state dir, so nothing moved the stamp")
+        self.assertLessEqual(out["bootAt"], km._STARTED)
+        self.assertLess(km._STARTED - out["bootAt"], 0.001)
         self.assertAlmostEqual(out["uptimeS"], v["uptime_s"], delta=2.0)
         self.assertIsInstance(out["complete"], bool)
         self.assertEqual(out["complete"], out["uptimeS"] >= 900)

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -186,7 +186,8 @@ class LandingShell(unittest.TestCase):
         # script (_LANDING_REVEAL_JS) — its own script so a throw in the bell's cannot strand a tap;
         # +1 2026-09-08: the reload core (T265, _reload_core) ahead of the build-staleness banner script, which
         # registers as its refused fallback — its own script so a banner throw cannot take the reload with it
-        self.assertEqual(html.count("<script>"), 19)
+        # +1: the bottom bar's API health cell (_LANDING_APIH_JS), after the usage script whose backdrop it shares
+        self.assertEqual(html.count("<script>"), 20)
 
     def test_bottom_bar_is_text_only_and_compact(self):
         html = km._landing()

--- a/tests/test_kernel_model_limit.py
+++ b/tests/test_kernel_model_limit.py
@@ -155,7 +155,8 @@ class SurfacesPinTheOnYouTreatment(unittest.TestCase):
         # the 2026-07-03 flap: pausing the fleet on a model-scoped limit starved the judges, because
         # the account keeps serving and _auto_resume_retry cleared the pause every tick
         src = inspect.getsource(km._auto_pause_on_limit)
-        self.assertIn('k != "fable"', src, "account-wide windows only still gate the global pause")
+        self.assertIn("_account_limited()", src, "the engage reads the shared account-wide filter")
+        self.assertIn('k != "fable"', inspect.getsource(km._account_limited), "account-wide windows only still gate the global pause")
         self.assertNotIn("modelLimit", src)
 
 

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -247,9 +247,12 @@ class ApiHealthCell(unittest.TestCase):
     def test_the_light_theme_keeps_the_ok_dot_visible_and_the_state_dots_their_colors(self):
         # the dark label gray at .55 blends into the light rail; the light label color keeps the glyph. Scoped to
         # the ok state: a bare `body.theme-light .ah-dot` (0,2,1) would outrank the detail's `.ah-dot[data-state=…]`
-        # rules (0,2,0), and the card's headline dot would lose its amber and red
-        self.assertTrue("body.theme-light #rail-api[data-state=ok] .ah-dot,body.theme-light .ah-dot[data-state=ok]{background:#5D574E}" in self.html,
-                        "the light override names the ok state")
+        # rules (0,2,0), and the card's headline dot would lose its amber and red. The History head shows the signal's
+        # quiet states (healthy, unknown) with the same glyph, so the rule names them too (the base gray falls to
+        # about 1.6:1 on the white tip)
+        self.assertTrue("body.theme-light #rail-api[data-state=ok] .ah-dot,body.theme-light .ah-dot[data-state=ok],"
+                        "body.theme-light .ah-dot[data-state=healthy],body.theme-light .ah-dot[data-state=unknown]{background:#5D574E}" in self.html,
+                        "the light override names the ok state and the History head's quiet states")
         self.assertNotIn("body.theme-light .ah-dot{", self.html, "no bare light rule on the dot")
         self.assertNotIn("body.theme-light .ah-dot[data-state=degraded]", self.html, "the state rules are not restated per theme")
 

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -8,6 +8,7 @@ Fleet/Outline is its OWN pane (no longer an overlay swapped inside the chat pane
 Source-level pin against km._landing().
 """
 import os
+import re
 import unittest
 from importlib.machinery import SourceFileLoader
 import tempfile
@@ -196,6 +197,123 @@ class PaneRailTest(unittest.TestCase):
         # the Outline (fleet) is a mobile TAB now, no longer desktop-only (the user 2026-07-11)
         self.assertNotIn("#fleet-pane{display:none!important}", self.html)
         self.assertIn("body[data-tab=timeline] .row{display:none}", self.html)   # timeline tab → band fills
+
+
+class ApiHealthCell(unittest.TestCase):
+    """The bottom bar's API health cell: a sibling of #rail-usage, painted from the kernel's apiHealth push by
+    _LANDING_APIH_JS (tests/test_api_health_rail.py covers the frame and the detail's content). Source-level
+    placement and styling pins against km._landing()."""
+
+    def setUp(self):
+        self.html = km._landing()
+
+    def test_the_cell_follows_the_usage_cell_inside_the_scroll_group(self):
+        i_usage, i_api, i_acts = (self.html.index(k) for k in ("id=rail-usage", "id=rail-api", "class=rail-acts"))
+        self.assertLess(i_usage, i_api, "right of the usage cell")
+        self.assertLess(i_api, i_acts, "inside .rail-scroll, before the pinned actions")
+        self.assertGreater(i_api, self.html.index("<div class=rail-scroll>"))
+
+    def test_the_cell_ships_hidden_with_its_own_label_a_dot_and_the_word(self):
+        tag = ('<div id=rail-api class="ru-w ru-ah" hidden role=button tabindex=0 aria-label="API ok" data-state=ok>'
+               '<span class=ru-name>API</span><i class=ah-dot></i><span class=ah-text>ok</span></div>')
+        self.assertTrue(tag in self.html, "the cell's markup: hidden, a keyboard button, its own label, a dot, the word")
+        tag = re.search(r"<div id=rail-api[^>]*>", self.html).group(0)
+        self.assertNotIn("title", tag, "the rail's no-title rule: the detail is the one hover surface")
+        self.assertNotIn("data-keycmd", tag, "no palette command yet")
+
+    def test_the_hidden_attribute_beats_the_rail_s_own_display_rule(self):
+        # The UA's [hidden]{display:none} loses to ANY author display rule, and .ru-w{display:flex} is one, so
+        # without this author rule the cell would show a gray 'API ok' from page load, and forever on a kernel
+        # that never sends a frame (the #mtabs button[hidden] idiom in the same stylesheet).
+        self.assertTrue(".ru-w{display:flex;" in self.html, "the author display rule the attribute must beat")
+        self.assertTrue("#rail-api[hidden]{display:none}" in self.html, "no author [hidden] rule for #rail-api")
+
+    def test_the_word_wears_the_usage_cell_s_exact_font(self):
+        pct = re.search(r"\.ru-pct\{([^}]*)\}", self.html).group(1)
+        txt = re.search(r"\.ah-text\{([^}]*)\}", self.html).group(1)
+        self.assertEqual(pct, txt, "byte for byte: no new font size on the rail")
+        self.assertIn("#rail-api[data-state=ok] .ah-text{color:#9aa4ad}", self.html, "ok in the label gray")
+        self.assertIn("body.theme-light .ah-text{color:#1F1E1D}", self.html)
+        self.assertIn("body.theme-light #rail-api[data-state=ok] .ah-text{color:#5D574E}", self.html)
+        self.assertIn("#rail-api{cursor:pointer;margin-left:4px}", self.html)
+
+    def test_the_dot_wears_status_hexes_never_the_accent(self):
+        self.assertIn(".ah-dot{width:7px;height:7px;border-radius:50%;background:#9aa4ad;opacity:.55;flex:0 0 auto}", self.html)
+        self.assertIn("#rail-api[data-state=degraded] .ah-dot,.ah-dot[data-state=degraded]{background:#e67e22;opacity:1}", self.html)
+        self.assertIn("#rail-api[data-state=paused] .ah-dot,.ah-dot[data-state=paused]{background:#e5484d;opacity:1}", self.html)
+        for rule in re.findall(r"[^{}]*\.ah-dot[^{}]*\{[^}]*\}", self.html):
+            self.assertNotIn("var(--accent)", rule, "status colors keep their own meaning")
+
+    def test_the_light_theme_keeps_the_ok_dot_visible_and_the_state_dots_their_colors(self):
+        # the dark label gray at .55 blends into the light rail; the light label color keeps the glyph. Scoped to
+        # the ok state: a bare `body.theme-light .ah-dot` (0,2,1) would outrank the detail's `.ah-dot[data-state=…]`
+        # rules (0,2,0), and the card's headline dot would lose its amber and red
+        self.assertTrue("body.theme-light #rail-api[data-state=ok] .ah-dot,body.theme-light .ah-dot[data-state=ok]{background:#5D574E}" in self.html,
+                        "the light override names the ok state")
+        self.assertNotIn("body.theme-light .ah-dot{", self.html, "no bare light rule on the dot")
+        self.assertNotIn("body.theme-light .ah-dot[data-state=degraded]", self.html, "the state rules are not restated per theme")
+
+    def test_the_shell_socket_carries_the_dashboard_s_wid_minted_before_it_connects(self):
+        # the detail's openSession rides the shell socket; with no wid on it the kernel's reveal would fall to the
+        # broadcast and every open dashboard's chat would switch (_reveal_chat_for)
+        js = km._LANDING_MOBILE_JS
+        self.assertIn("var ws=new WebSocket(proto+location.host+'/ws?app=shell&wid='+encodeURIComponent(wid()));", js)
+        mint = "sessionStorage.setItem('romp:wid'"
+        self.assertLess(self.html.index(mint), self.html.index("'/ws?app=shell&wid='"), "minted before the shell socket connects")
+
+    def test_an_emptied_usage_cell_collapses_its_gap(self):
+        # renderRows empties #rail-usage on a login-only machine; as a zero-width flex item it would still pay the
+        # scroll group's gap on both sides (28px to the API cell instead of 16px)
+        self.assertTrue("#rail-usage:empty{display:none}" in self.html, "the emptied cell must leave the flex flow")
+
+    def test_the_detail_shares_the_usage_tip_s_skin_and_backdrop(self):
+        self.assertIn("#ah-tip,#ru-tip{position:fixed", self.html)
+        self.assertIn("#ah-tip.ru-modal,#ru-tip.ru-modal{", self.html)
+        self.assertIn("body.theme-light #ah-tip,body.theme-light #ru-tip{", self.html)
+        self.assertIn("tip.id='ah-tip'", self.html)
+        self.assertIn("document.getElementById('ru-back')", km._LANDING_APIH_JS)
+
+    def test_the_shell_socket_routes_the_frame_and_escape_closes_the_detail_first(self):
+        self.assertIn("else if(m&&m.type==='apiHealth'&&window.__rompApiHealth)window.__rompApiHealth(m);", self.html)
+        self.assertIn("window.__rompShellSend=function(o)", self.html)
+        esc = km._LANDING_ESC_JS
+        self.assertLess(esc.index("__rompApiClose"), esc.index("__rompUsageClose"), "both ride #ru-back; the detail's hook is checked first")
+        self.assertIn("if(ru&&ru.classList.contains('on')&&window.__rompApiClose){window.__rompApiClose();closed=true;}", esc)
+
+    def test_the_cell_s_script_loads_after_the_usage_script_it_borrows_the_backdrop_from(self):
+        self.assertLess(self.html.index("getElementById('rail-usage')"), self.html.index("getElementById('rail-api')"))
+
+
+class ShellSocketIdentity(unittest.TestCase):
+    """A reveal the kernel answers to the shell's own op (the API detail's openSession) reaches the asking
+    dashboard alone, since the shell client carries its wid the way a feed pane's does. Synthetic clients; no
+    sockets."""
+
+    def _client(self, app, wid):
+        return {"app": app, "wid": wid, "alive": True, "send": lambda s, w=wid, a=app: self.sink.append((a, w))}
+
+    def setUp(self):
+        self.sink = []
+        self._saved = list(km._clients)
+        km._clients[:] = [self._client("chat", "win-A"), self._client("chat", "win-B"),
+                          self._client("shell", "win-A"), self._client("shell", "win-B"), self._client("feed", "win-A")]
+
+    def tearDown(self):
+        km._clients[:] = self._saved
+
+    def test_a_shell_client_with_a_wid_moves_its_own_dashboard_s_chat_only(self):
+        km._reveal_chat_for({"app": "shell", "wid": "win-A"}, {"type": "focus", "id": "s1"})
+        self.assertEqual(sorted(self.sink), [("chat", "win-A"), ("shell", "win-A")])
+
+    def test_a_shell_client_without_a_wid_still_broadcasts(self):
+        # an older shell page, or a browser with no sessionStorage: today's behavior, not silence
+        km._reveal_chat_for({"app": "shell", "wid": ""}, {"type": "focus", "id": "s1"})
+        self.assertEqual(sorted(w for a, w in self.sink if a == "chat"), ["win-A", "win-B"])
+
+    def test_the_open_session_op_hands_the_asking_client_to_the_router(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        i = src.index('msg.get("type") == "openSession" and msg.get("id")')
+        self.assertIn('_open_or_revive(msg["id"], live=bool(msg.get("live")), client=client)', src[i:i + 600])
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_usage_limit.py
+++ b/tests/test_kernel_usage_limit.py
@@ -171,6 +171,24 @@ class AutoPauseOnLimit(unittest.TestCase):
         km._auto_pause_on_limit()
         self.assertTrue(km._retry_paused_on(), "a real 5h/7d limit still engages the pause")
 
+    def test_the_pause_latches_reason_limit_at_the_event(self):
+        # the bottom bar's API health cell names the pause from the file's reason, never from _retry_resume_at's
+        # clock comparison (which would flip the word at the reset instant with no event)
+        fut = int(time.time()) + 3600
+        km._usage = lambda: {"limited": {"fiveHour": True, "sevenDay": False, "fable": False},
+                             "fiveHour": {"pct": 100, "resetsAt": fut}}
+        km._auto_pause_on_limit()
+        self.assertTrue(km._retry_paused_on())
+        self.assertEqual(km._retry_pause_reason(), "limit")
+        self.assertEqual(km._retry_resume_at(), fut, "the card's countdown is unchanged by the latched reason")
+        self.assertGreater(km._retry_pause_ts(), 0, "the pause's own t is the frame's `since`")
+
+    def test_an_already_paused_flag_keeps_its_reason(self):
+        km._set_retry_paused(True, reason="spend")
+        km._usage = lambda: {"limited": {"fiveHour": True, "sevenDay": False, "fable": False}}
+        km._auto_pause_on_limit()
+        self.assertEqual(km._retry_pause_reason(), "spend", "idempotent: the first cause stays on record")
+
 
 class AutoPauseOnSpendLimit(unittest.TestCase):
     """A monthly SPEND cap auto-engages the global retry-pause — the SPEND twin of AutoPauseOnLimit (the

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -467,7 +467,8 @@ class PusherRecords(unittest.TestCase):
             "_end_on_idle_sweep", "_deferral_sweep_tick", "_auto_nudge_tick", "_interrupt_block_tick",
             "_auto_pause_on_limit", "_usage_poll_tick", "_auto_pause_on_spend_limit", "_auto_resume_retry",
             "_auto_resume_session_retry", "_auto_retry_tick", "_idle_queue_drive_tick",
-            "_clear_done_working_notes", "_push_all")
+            "_clear_done_working_notes", "_push_all",
+            "_api_health_frame", "_api_health_push")   # the bottom bar's API cell
 
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()

--- a/tests/test_retry_pause_autoresume.py
+++ b/tests/test_retry_pause_autoresume.py
@@ -4,14 +4,22 @@ auto-retries" to calm the auto-retry + judge storm during an API / usage-limit o
 tier is gated on `not _retry_paused_on()`, so a pause that never clears silently kills EVERY judge for
 hours (the user 2026-06-30, who noted none of the judges were running and called it an API problem that should
 clear the second a successful non-API-error response arrives on any session). _auto_resume_retry
-clears it event-based: the first live session that is NOT blocked on an API error AND wrote fresh output
-since the pause began (mtime past the pause floor) proves the account can serve requests again.
+clears it event-based, one rule per reason: a MANUAL pause lifts on the first live session that is NOT
+blocked on an API error AND wrote fresh output since the pause began (mtime past the pause floor); a LIMIT
+pause lifts when the usage report stops naming an account-wide window at 100% (the same reading that engaged
+it); a SPEND pause lifts on fresh assistant output from a session on the billing the cap is on. The lift
+leaves the capped session's own record standing (only a human prompt clears a spend record), so the un-pause
+records its instant and the spend engage stands down on records older than it; a new record engages again.
 """
+import contextlib
+import inspect
+import io
 import json
 import os
 import tempfile
 import time
 import unittest
+from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
@@ -155,6 +163,574 @@ class RetryPauseAutoResume(unittest.TestCase):
         self.assertTrue(km._retry_paused_on())
         self.assertFalse(km._pusher_wake.is_set(), "still paused: nothing to deliver")
         self.assertEqual(km._views_dirty[0], floor)
+
+    # --- a spend record older than the last spend lift is already ruled on ---
+    def test_the_capped_session_lookup_skips_records_older_than_the_lift_and_keeps_the_rest(self):
+        sess = [{"sid": "s%d" % i, "path": str(self.dir / ("s%d.jsonl" % i))} for i in range(4)]
+        errs = {sess[0]["path"]: {"spendLimit": True, "t": 1000},        # a second before the lift's evidence: stale
+                sess[1]["path"]: {"spendLimit": False, "t": 1005},       # not a cap
+                sess[2]["path"]: {"spendLimit": True, "t": 0},           # no readable time: not proof of staleness
+                sess[3]["path"]: {"spendLimit": True, "t": 1001}}        # the evidence's own second: new
+        km._alive_sessions = lambda now, tmux: sess
+        km._api_error = lambda p: errs.get(p)
+        self.assertEqual(km._spend_capped_session(0, {})["sid"], "s0", "no lift on record: the first capped session")
+        # `after` is the lifting output's own stamp, whole seconds like the record's
+        self.assertEqual(km._spend_capped_session(0, {}, after=1001)["sid"], "s2", "1000 < 1001 is stale, 0 is unknown")
+        del errs[sess[2]["path"]]
+        self.assertEqual(km._spend_capped_session(0, {}, after=1001)["sid"], "s3", "a record in the evidence's second counts")
+        self.assertIsNone(km._spend_capped_session(0, {}, after=1001.7), "no truncation: 1001 is older than a Resume at 1001.7")
+        del errs[sess[3]["path"]]
+        self.assertIsNone(km._spend_capped_session(0, {}, after=1001), "every remaining record predates the lift")
+        self.assertEqual(km._retry_pause_lifted_at(), 0.0, "no file: nothing on record")
+
+    # --- the bottom bar's API health cell reads the pause and its lift off this same file ---
+    def test_the_api_health_frame_reads_paused_limit_then_ok_after_the_clear(self):
+        km._set_retry_paused(True, reason="limit")
+        floor = km._retry_pause_ts()
+        path = str(self.dir / "healthy.jsonl")
+        with open(path, "w") as f:
+            f.write(_out_line(floor + 5))                      # a login-billed session's answer after the pause
+        live = {"s1": {"state": "idle", "auth": "login", "backend": "sdk"}}
+        km._alive_sessions = lambda now, tmux: [{"sid": "s1", "name": "web", "path": path}]
+        km._api_error = lambda p: None
+        saved_backend, saved_usage = km.Sessions.__dict__["backend_for"], km._usage
+        km.Sessions.backend_for = staticmethod(lambda sid: object())
+        km._usage = lambda: {"limited": {"fiveHour": True}}
+        km._api_last_failed_cache.clear()
+        try:
+            f = km._api_health_frame(int(time.time()), live)
+            self.assertEqual((f["state"], f["reason"], f["text"]), ("paused", "limit", "paused · usage limit"))
+            self.assertEqual(f["since"], int(floor), "the pause's own t, not the clock")
+            km._auto_resume_retry(int(time.time()), live)
+            self.assertTrue(km._retry_paused_on(), "the report still names the window: the output lifts nothing")
+            km._usage = lambda: {"limited": {}}
+            km._auto_resume_retry(int(time.time()), live)
+            self.assertFalse(km._retry_paused_on())
+            f = km._api_health_frame(int(time.time()), live)
+            self.assertEqual((f["state"], f["reason"], f["text"], f["since"]), ("ok", "", "ok", 0))
+        finally:
+            km.Sessions.backend_for = saved_backend
+            km._usage = saved_usage
+            km._api_last_failed_cache.clear()
+
+
+# ── the lift rules, per reason, over real synthetic transcripts ──────────────────────────────────────
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _out_line(t):
+    return json.dumps({"type": "assistant", "uuid": "aaaaaaaa-0000-0000-0000-%012d" % int(t), "timestamp": _iso(t),
+                       "message": {"role": "assistant", "content": [{"type": "text", "text": "done"}]}}) + "\n"
+
+
+def _prompt_line(t, text="please continue"):
+    return json.dumps({"type": "user", "uuid": "bbbbbbbb-0000-0000-0000-%012d" % int(t), "timestamp": _iso(t),
+                       "message": {"role": "user", "content": [{"type": "text", "text": text}]}}) + "\n"
+
+
+SID_KEY = "88888888-aaaa-4bbb-8ccc-000000000001"     # a private synthetic family for this module
+SID_LOGIN = "88888888-aaaa-4bbb-8ccc-000000000002"
+
+
+def _err_line(t, text, status=400, category="billing_error"):
+    return json.dumps({"type": "assistant", "uuid": "cccccccc-0000-0000-0000-%012d" % int(t), "timestamp": _iso(t),
+                       "isApiErrorMessage": True, "apiErrorStatus": status, "error": category,
+                       "message": {"role": "assistant", "content": [{"type": "text", "text": text}]}}) + "\n"
+
+
+SPEND_TEXT = "API Error: 400 You have reached your monthly spend limit for this workspace."   # invented wording
+
+
+class _KernelClock:
+    """The kernel module's `time`, with time() reading no earlier than a floor the test sets: the pause floor
+    (and a Resume's liftedAt) are wall-clock writes while the transcripts here carry synthetic times ahead of
+    the clock, so a test that plays a second round (a new record, a second lift) moves the kernel's clock along
+    with its timeline. A floor at a round second makes every read exact. Everything else delegates to the real
+    module. At 0 (the default) the clock is the real one."""
+
+    def __init__(self):
+        self.floor = 0.0
+
+    def time(self):
+        return max(time.time(), self.floor)
+
+    def __getattr__(self, name):
+        return getattr(time, name)
+
+
+class _PauseFixture(unittest.TestCase):
+    """The pusher's pause jobs over real synthetic transcripts: _alive_sessions and the live map are the
+    module's own, _usage is the patched report, every frame goes to self.sent."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.dir = Path(self.td.name)
+        self._orig = (km.jd.STATE, km._alive_sessions, km._push_all, km.jd.rearm_failed_summaries, km._usage,
+                      km._send_to_app, km.Sessions.__dict__["backend_for"], km._auth_key_present, km.time)
+        self.clock = _KernelClock()
+        km.time = self.clock
+        km.jd.STATE = self.dir
+        km._push_all = lambda *a, **k: self.fail("a tick job built a push inline; it should wake the pusher")
+        km.jd.rearm_failed_summaries = lambda now, **k: 0
+        km._usage = lambda: {"limited": {"fiveHour": True}}    # the login account's window is at 100%
+        self.sent = []
+        km._send_to_app = lambda app, m: self.sent.append((app, m))
+        km.Sessions.backend_for = staticmethod(lambda sid: object())
+        km._auth_key_present = lambda: True                    # an apiKeyHelper is configured on this machine
+        km._APIH_LAST[0] = None
+        km._api_err_cache.clear()
+        km._api_last_failed_cache.clear()
+        self._was_set = km._pusher_wake.is_set()
+        km._pusher_wake.clear()
+        self.roster = []
+        km._alive_sessions = lambda now, tmux: list(self.roster)
+
+    def tearDown(self):
+        (km.jd.STATE, km._alive_sessions, km._push_all, km.jd.rearm_failed_summaries, km._usage,
+         km._send_to_app, km.Sessions.backend_for, km._auth_key_present, km.time) = self._orig
+        km._APIH_LAST[0] = None
+        km._api_err_cache.clear()
+        km._api_last_failed_cache.clear()
+        if self._was_set:
+            km._pusher_wake.set()
+        else:
+            km._pusher_wake.clear()
+        self.td.cleanup()
+
+    def _session(self, sid, name, auth, *lines):
+        """One alive session with a transcript of `lines`; returns (path, its live-map row)."""
+        p = self.dir / (name + ".jsonl")
+        p.write_text("".join(lines))
+        self.roster = [s for s in self.roster if s["sid"] != sid] + [{"sid": sid, "name": name, "path": str(p)}]
+        return str(p), {"state": "idle", "auth": auth, "authLive": auth, "backend": "sdk"}
+
+    def _append(self, path, line, t):
+        with open(path, "a") as f:
+            f.write(line)
+        os.utime(path, (t, t))
+
+    def _cycle(self, now, live):
+        # the pusher's jobs in their order: the limit engages, the spend cap engages, the resume check, the frame
+        km._auto_pause_on_limit()
+        km._auto_pause_on_spend_limit(now, live)
+        km._auto_resume_retry(now, live)
+        f = km._api_health_frame(now, live)
+        km._api_health_push(f)
+        return f["state"]
+
+    def _states(self):
+        return [m["state"] for a, m in self.sent]
+
+
+class LimitPauseLift(_PauseFixture):
+    """A usage-limit pause lifts on the same reading that engaged it: the usage report (_account_limited).
+    The mtime rule lifted it on ANY alive session's transcript mtime past the floor (a key-billed session's
+    streaming or a human prompt), and _auto_pause_on_limit re-engaged the next cycle while the window held:
+    the pause file, and the bottom bar's API cell, flipped every cycle. A rule keyed on a login-billed
+    session's fresh assistant output could never fire after the reset (the login sessions the limit blocked
+    are the ones the pause gates), so the pause would hold until a human acted. One authority for both edges:
+    no session's output lifts it while the report reads limited."""
+
+    def test_a_key_billed_session_s_output_during_a_limit_leaves_the_pause_and_the_frame_stable(self):
+        # a limited window, one key-billed session appending an answer every other cycle
+        now = time.time()
+        path, row = self._session(SID_KEY, "web", "key", _out_line(now - 60))
+        live = {SID_KEY: row}
+        states = []
+        for i in range(6):
+            if i % 2:
+                self._append(path, _out_line(now + i), now + i)
+            states.append(self._cycle(int(now) + i, live))
+        self.assertEqual(states, ["paused"] * 6, "a key-billed session's output says nothing about the login limit")
+        self.assertEqual(self._states(), ["paused"], "one frame: nothing about the API changed")
+        self.assertEqual(km._retry_pause_reason(), "limit")
+
+    def test_the_window_reset_lifts_it_once_with_no_login_output_while_a_key_session_streams(self):
+        # after the window rolls, nothing but a human could lift an output-keyed rule: a login session blocked on
+        # the limit cannot serve (its auto-retry is gated on this very pause), the key session is rightly skipped;
+        # the report clearing by its own clock must be the lift
+        now = time.time()
+        api_path, api_row = self._session(SID_LOGIN, "api", "login",
+                                          _out_line(now - 120), _err_line(now - 90, "API Error: 429 rate limited", 429, "rate_limit"))
+        web_path, web_row = self._session(SID_KEY, "web", "key", _out_line(now - 60))
+        live = {SID_LOGIN: api_row, SID_KEY: web_row}
+        states = []
+        for i in range(3):
+            self._append(web_path, _out_line(now + i), now + i)
+            states.append(self._cycle(int(now) + i, live))
+        self.assertEqual(states, ["paused"] * 3)
+        km._usage = lambda: {"limited": None}                  # the reset passed: the report no longer names a window
+        for i in range(3, 8):
+            self._append(web_path, _out_line(now + i), now + i)
+            states.append(self._cycle(int(now) + i, live))
+        self.assertEqual(states, ["paused"] * 3 + ["degraded"] * 5, "lifts the cycle the report clears; stays lifted")
+        self.assertFalse(km._retry_paused_on())
+        self.assertEqual(self._states(), ["paused", "degraded"], "each side of the lift sent once")
+        self.assertEqual(self.sent[-1][1]["waiting"], 1, "the login session still sits on its record: the auto-retry's turn now")
+        self.assertTrue(km._pusher_wake.is_set(), "the clear wakes the pusher; globalRetryPaused rides its push")
+
+    def test_login_output_under_a_still_limited_report_holds_the_pause_and_the_frame(self):
+        # with extra usage on, the login account is served at 100%: a lift on each output record would be
+        # re-engaged the next cycle, the pause file flipping at the output cadence. One authority: the report.
+        # A login turn's end refreshes it, and that is the edge that lifts.
+        now = time.time()
+        path, row = self._session(SID_LOGIN, "api", "login", _out_line(now - 60))
+        live = {SID_LOGIN: row}
+        states = []
+        for i in range(8):
+            self._append(path, _out_line(now + i), now + i)
+            states.append(self._cycle(int(now) + i, live))
+        self.assertEqual(states, ["paused"] * 8, "served output under a limited report is not the lift")
+        self.assertEqual(self._states(), ["paused"], "one frame across eight output records")
+        km._usage = lambda: {"limited": {}}                    # the refreshed report reads under 100%
+        self.assertEqual(self._cycle(int(now) + 8, live), "ok")
+        self.assertFalse(km._retry_paused_on())
+        self.assertEqual(self._states(), ["paused", "ok"])
+
+    def test_a_login_billed_session_s_fresh_assistant_output_lifts_it_once(self):
+        # the login account serves a request and its usage report catches up (a login turn's end refreshes it);
+        # the lift lands once, on the report
+        now = time.time()
+        path, row = self._session(SID_LOGIN, "api", "login", _out_line(now - 60))
+        live = {SID_LOGIN: row}
+        self.assertEqual(self._cycle(int(now), live), "paused")
+        floor = km._retry_pause_ts()
+        os.utime(path, (floor + 1, floor + 1))                 # a fresh mtime over OLD output
+        km._auto_resume_retry(int(now), live)
+        self.assertTrue(km._retry_paused_on(), "the report still reads limited: held")
+        self._append(path, _prompt_line(floor + 2), floor + 2)
+        km._auto_resume_retry(int(now), live)
+        self.assertTrue(km._retry_paused_on(), "a prompt is not the API's answer, and the report still reads limited")
+        self._append(path, _out_line(floor + 5), floor + 5)    # the login account served a request
+        km._usage = lambda: {"limited": {}}                    # and its usage report caught up
+        self.assertEqual(self._cycle(int(now) + 1, live), "ok")
+        self.assertFalse(km._retry_paused_on())
+        self.assertEqual(self._states(), ["paused", "ok"], "each side of the lift sent once")
+
+    def test_an_unreadable_report_changes_nothing(self):
+        now = time.time()
+        path, row = self._session(SID_LOGIN, "api", "login", _out_line(now - 60))
+        live = {SID_LOGIN: row}
+        self.assertEqual(self._cycle(int(now), live), "paused")
+
+        def boom():
+            raise RuntimeError("no report")
+        km._usage = boom
+        km._pusher_wake.clear()                                # the engage above woke the pusher; the check below must not
+        km._auto_resume_retry(int(now), live)
+        self.assertTrue(km._retry_paused_on(), "no reading: no change, as the engage side would not engage")
+        self.assertFalse(km._pusher_wake.is_set())
+
+    def test_the_engage_and_the_lift_read_the_same_filter(self):
+        km._usage = lambda: {"limited": {"fable": True}}
+        self.assertEqual(km._account_limited(), [], "fable is model-scoped: never an account limit")
+        km._usage = lambda: {"limited": {"fiveHour": False, "sevenDay": True, "fable": True}}
+        self.assertEqual(km._account_limited(), ["sevenDay"])
+        km._usage = lambda: None
+        self.assertEqual(km._account_limited(), [], "no report at all (a pure API-key host) reads as not limited")
+        src = inspect.getsource(km._auto_pause_on_limit) + inspect.getsource(km._auto_resume_retry)
+        self.assertEqual(src.count("_account_limited()"), 2, "both edges call the one filter")
+
+    def test_a_manual_pause_keeps_lifting_on_any_fresh_transcript(self):
+        km._usage = lambda: {"limited": {}}
+        now = time.time()
+        path, row = self._session(SID_KEY, "web", "key", _out_line(now - 60))
+        km._set_retry_paused(True)
+        floor = km._retry_pause_ts()
+        os.utime(path, (floor + 1, floor + 1))
+        km._auto_resume_retry(int(now), {SID_KEY: row})
+        self.assertFalse(km._retry_paused_on(), "the user's own stop: the mtime rule is unchanged")
+
+    def test_a_session_of_unknown_auth_bills_the_login_only_when_this_machine_holds_no_key(self):
+        km._auth_key_present = lambda: True
+        self.assertFalse(km._bills_login({"state": "idle"}), "a key on the machine: this session may be billing it")
+        self.assertFalse(km._bills_login(None))
+        km._auth_key_present = lambda: False
+        self.assertTrue(km._bills_login({"state": "idle"}), "no key anywhere: the login is the only account it can bill")
+        self.assertTrue(km._bills_login({"auth": "key", "authLive": "login"}), "the CLI's own live report wins")
+        self.assertFalse(km._bills_login({"auth": "key"}))
+
+
+class _SpendWorld(_PauseFixture):
+    """The spend classes' world: no usage window; 'web' bills the key and sits on its cap record, 'api' bills the
+    login and streams. A base with no tests of its own, so each class below is collected once."""
+
+    def setUp(self):
+        super().setUp()
+        km._usage = lambda: {"limited": None}                  # no usage window is involved
+        self.now = time.time()
+        self.web, web_row = self._session(SID_KEY, "web", "key", _out_line(self.now - 120), _err_line(self.now - 90, SPEND_TEXT))
+        self.api, api_row = self._session(SID_LOGIN, "api", "login", _out_line(self.now - 60))
+        self.live = {SID_KEY: web_row, SID_LOGIN: api_row}
+
+
+class SpendPauseLift(_SpendWorld):
+    """A spend pause lifts on fresh assistant output from a session on the billing the cap is on (recorded
+    at the engage: _retry_pause_bills), never from the other billing. The mtime rule it replaces counted a
+    session on the OTHER account streaming past the cap; _auto_pause_on_spend_limit re-engaged the next
+    cycle while the capped session sat on its record, and the pause file, so the cell, flipped every cycle.
+    The capped session itself qualifies once it serves again."""
+
+    def test_the_other_billing_s_output_leaves_the_pause_and_the_frame_stable(self):
+        states = []
+        for i in range(8):
+            self._append(self.api, _out_line(self.now + i), self.now + i)
+            states.append(self._cycle(int(self.now) + i, self.live))
+        self.assertEqual(states, ["paused"] * 8, "a login session's output says nothing about the key's cap")
+        self.assertEqual([(m["state"], m["text"]) for a, m in self.sent],
+                         [("paused", "paused · spend cap · 1 waiting")], "one frame across eight cycles")
+        self.assertEqual((km._retry_pause_reason(), km._retry_pause_bills()), ("spend", "key"))
+
+    def test_the_capped_session_s_own_output_lifts_it_once(self):
+        self.assertEqual(self._cycle(int(self.now), self.live), "paused")
+        floor = km._retry_pause_ts()
+        self._append(self.api, _out_line(floor + 1), floor + 1)   # the other billing, still
+        self.assertEqual(self._cycle(int(self.now) + 1, self.live), "paused")
+        self._append(self.web, _prompt_line(floor + 2, "retry"), floor + 2)   # romp's own retry prompt: not the answer
+        self.assertEqual(self._cycle(int(self.now) + 2, self.live), "paused")
+        self._append(self.web, _out_line(floor + 5), floor + 5)   # the cap was raised: the capped session served
+        self.assertEqual(self._cycle(int(self.now) + 3, self.live), "ok")
+        self.assertFalse(km._retry_paused_on())
+        self.assertEqual(self._states(), ["paused", "ok"], "each side of the lift sent once")
+
+    def test_a_second_session_on_the_capped_billing_lifts_it(self):
+        tests, tests_row = self._session("88888888-aaaa-4bbb-8ccc-000000000003", "tests", "key", _out_line(self.now - 60))
+        self.live["88888888-aaaa-4bbb-8ccc-000000000003"] = tests_row
+        self.assertEqual(self._cycle(int(self.now), self.live), "paused")
+        floor = km._retry_pause_ts()
+        self._append(tests, _out_line(floor + 3), floor + 3)   # the key account serves again, through another session
+        km._auto_resume_retry(int(self.now) + 1, self.live)
+        self.assertFalse(km._retry_paused_on(), "same billing as the cap: proof the account serves")
+
+    def test_a_cap_on_the_login_holds_against_key_output_and_lifts_on_login_output(self):
+        # roles swapped: the login session sits on the cap, the key session streams
+        web, web_row = self._session(SID_KEY, "web", "key", _out_line(self.now - 60))
+        api, api_row = self._session(SID_LOGIN, "api", "login", _out_line(self.now - 120), _err_line(self.now - 90, SPEND_TEXT))
+        live = {SID_KEY: web_row, SID_LOGIN: api_row}
+        states = []
+        for i in range(4):
+            self._append(web, _out_line(self.now + i), self.now + i)
+            states.append(self._cycle(int(self.now) + i, live))
+        self.assertEqual(states, ["paused"] * 4)
+        self.assertEqual(km._retry_pause_bills(), "login")
+        floor = km._retry_pause_ts()
+        self._append(api, _out_line(floor + 9), floor + 9)
+        self.assertEqual(self._cycle(int(self.now) + 4, live), "ok")
+
+    def test_a_pause_file_with_no_billing_takes_any_session_s_fresh_output_but_not_a_bare_mtime(self):
+        km._set_retry_paused(True, reason="spend")             # no billing recorded (a file another kernel wrote)
+        floor = km._retry_pause_ts()
+        os.utime(self.api, (floor + 1, floor + 1))
+        km._auto_resume_retry(int(self.now), self.live)
+        self.assertTrue(km._retry_paused_on(), "a fresh mtime over old output is not the API's answer")
+        self._append(self.api, _out_line(floor + 2), floor + 2)
+        km._auto_resume_retry(int(self.now), self.live)
+        self.assertFalse(km._retry_paused_on(), "with no billing on file, any session's fresh output lifts")
+
+    def test_the_pause_file_records_the_capped_billing_and_a_manual_pause_records_none(self):
+        self._cycle(int(self.now), self.live)
+        d = json.loads((self.dir / "retry-paused.json").read_text())
+        self.assertEqual((d["paused"], d["reason"], d["bills"]), (True, "spend", "key"))
+        self.assertIn("t", d)
+        km._set_retry_paused(True)
+        d = json.loads((self.dir / "retry-paused.json").read_text())
+        self.assertEqual(set(d), {"paused", "t"})
+        self.assertEqual(km._retry_pause_bills(), "")
+
+
+class SpendPauseStandDown(_SpendWorld):
+    """The lift leaves the capped session's own record standing: a spend cap is on-you, so romp sends it no
+    retry and only a human prompt to that session clears _api_error. An engage that read that record again
+    would put the pause back the cycle after every lift, so it alternated at the streaming session's output
+    cadence and settled ON once it idled, gating the judges and the idle-queue drives until someone prompted
+    the capped session. The un-pause of a spend pause records liftedAt and the floor it superseded, the memory
+    rides every later write, and the engage skips records older than it."""
+
+    SID_TESTS = "88888888-aaaa-4bbb-8ccc-000000000003"
+    SID_DOCS = "88888888-aaaa-4bbb-8ccc-000000000004"
+
+    def _tests_session(self):
+        tests, row = self._session(self.SID_TESTS, "tests", "key", _out_line(self.now - 60))
+        self.live[self.SID_TESTS] = row
+        return tests
+
+    def _file(self):
+        return json.loads((self.dir / "retry-paused.json").read_text())
+
+    def test_one_lift_no_re_engage_and_the_pause_off_once_the_streamer_idles(self):
+        # 'web' (key) sits on its cap record, 'tests' (key) streams one answer per cycle for six cycles after the
+        # lift, then idles for three. Without the stand-down the states alternated paused/degraded at the output
+        # cadence (four engages, three lifts) and were paused at the end.
+        tests = self._tests_session()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            states = [self._cycle(int(self.now), self.live)]
+            floor = km._retry_pause_ts()
+            for i in range(1, 7):
+                self._append(tests, _out_line(floor + i), floor + i)
+                states.append(self._cycle(int(self.now) + i, self.live))
+            for i in range(7, 10):
+                states.append(self._cycle(int(self.now) + i, self.live))
+        self.assertEqual(states, ["paused"] + ["degraded"] * 9, "one lift, and the stale record engages nothing")
+        self.assertFalse(km._retry_paused_on(), "OFF after the streamer idles")
+        self.assertEqual(self._states(), ["paused", "degraded"], "two frames: the engage and the lift")
+        self.assertEqual((err.getvalue().count("auto-engaged"), err.getvalue().count("auto-cleared")), (1, 1))
+        self.assertTrue(km._api_error(self.web), "the capped session's record still stands: only a human prompt clears it")
+        self.assertEqual(self.sent[-1][1]["waiting"], 1, "and the cell still counts it")
+
+    def test_a_new_spend_record_after_the_lift_engages_once(self):
+        tests = self._tests_session()
+        self.assertEqual(self._cycle(int(self.now), self.live), "paused")
+        floor = km._retry_pause_ts()
+        self._append(tests, _out_line(floor + 1), floor + 1)
+        self.assertEqual(self._cycle(int(self.now) + 1, self.live), "degraded")
+        self.assertEqual(self._cycle(int(self.now) + 2, self.live), "degraded")
+        # the user prompts 'web' and it fails on the cap again: a record written after the lift is new information
+        self._append(self.web, _prompt_line(floor + 3, "try once more"), floor + 3)
+        self.assertEqual(self._cycle(int(self.now) + 3, self.live), "degraded", "a prompt is not a new record")
+        self._append(self.web, _err_line(floor + 5, SPEND_TEXT), floor + 5)
+        self.clock.floor = floor + 5.5                         # the kernel's clock has reached the new record
+        states = [self._cycle(int(self.now) + 4 + i, self.live) for i in range(3)]
+        self.assertEqual(states, ["paused"] * 3, "engages once on the new record and holds")
+        self.assertEqual(self._states(), ["paused", "degraded", "paused"])
+        self.assertEqual((km._retry_pause_reason(), km._retry_pause_bills()), ("spend", "key"))
+        self.assertGreater(km._retry_pause_ts(), floor, "a new floor")
+        # a second round: the key account serves again, the new record is the stale one now
+        self._append(tests, _out_line(floor + 7), floor + 7)
+        self.clock.floor = floor + 7.5
+        states = [self._cycle(int(self.now) + 7 + i, self.live) for i in range(3)]
+        self.assertEqual(states, ["degraded"] * 3, "one lift again, and no re-engage on the second record either")
+        self.assertEqual(self._states(), ["paused", "degraded", "paused", "degraded"])
+
+    def test_a_second_session_s_record_from_the_second_before_the_lift_cycle_engages(self):
+        # liftedAt is the lifting OUTPUT's own time, not the lift cycle's clock. The timeline: 'web' (key) sits on
+        # its cap; 'tests' (key) serves at T+0.1 (the evidence); 'docs' (key) hits the cap at T+0.6; the pusher's
+        # lift cycle runs at T+1.2. The CLI stamps both records T, and a liftedAt of T+1.2 read in whole seconds
+        # (T+1) would skip docs' record, written after the evidence, until that session's next attempt.
+        tests = self._tests_session()
+        docs, docs_row = self._session(self.SID_DOCS, "docs", "key", _out_line(self.now - 60))
+        self.live[self.SID_DOCS] = docs_row
+        T = int(self.now) + 100                                # a round second ahead of the real clock: exact reads
+        self.clock.floor = T - 10
+        self.assertEqual(self._cycle(T - 10, self.live), "paused")
+        self.assertEqual(km._retry_pause_ts(), T - 10)
+        self._append(tests, _out_line(T + 0.1), T + 0.1)       # the key account serves again, stamped T
+        self._append(docs, _err_line(T + 0.6, SPEND_TEXT), T + 0.6)   # a second session hits the cap, stamped T
+        self.clock.floor = T + 1.2                             # the lift cycle runs in the next second
+        self.assertEqual(self._cycle(T + 1, self.live), "degraded", "the lift: the engage ran first, over a paused file")
+        self.assertEqual(self._file()["liftedAt"], T, "the evidence's own time, not the cycle's")
+        self.assertEqual(self.sent[-1][1]["waiting"], 2, "both records stand")
+        self.assertEqual(self._cycle(T + 1, self.live), "paused", "docs' record is not older than the evidence: new information")
+        self.assertEqual((km._retry_pause_reason(), km._retry_pause_bills(), km._retry_pause_ts()), ("spend", "key", T + 1.2))
+        self.assertEqual(self._cycle(T + 2, self.live), "paused", "and holds: tests' output predates the new floor")
+        self.assertEqual(self._states(), ["paused", "degraded", "paused"])
+
+    def test_the_memory_survives_a_limit_pause_that_engages_and_lifts_in_between(self):
+        # a single-slot memory dropped at the next write would let the limit lift hand the stale record back
+        tests = self._tests_session()
+        self.assertEqual(self._cycle(int(self.now), self.live), "paused")
+        floor = km._retry_pause_ts()
+        self._append(tests, _out_line(floor + 1), floor + 1)
+        self.assertEqual(self._cycle(int(self.now) + 1, self.live), "degraded")            # the spend lift
+        lifted = self._file()["liftedAt"]
+        km._usage = lambda: {"limited": {"fiveHour": True}}
+        self.assertEqual(self._cycle(int(self.now) + 2, self.live), "paused")              # the login window
+        self.assertEqual((km._retry_pause_reason(), self._file()["liftedAt"]), ("limit", lifted))
+        km._usage = lambda: {"limited": None}
+        states = [self._cycle(int(self.now) + 3 + i, self.live) for i in range(3)]
+        self.assertEqual(states, ["degraded"] * 3, "the limit lifts; the stale spend record engages nothing")
+        self.assertEqual(self._states(), ["paused", "degraded", "paused", "degraded"])
+        self.assertEqual(self._file()["liftedAt"], lifted)
+
+    def test_a_limit_lift_rules_on_no_spend_record(self):
+        # the login window is at 100% first; 'web' hits its cap during that pause; the report clears. The limit
+        # lift's evidence is the report, which says nothing about the cap, so the cap engages its own pause.
+        km._usage = lambda: {"limited": {"fiveHour": True}}
+        web, web_row = self._session(SID_KEY, "web", "key", _out_line(self.now - 120))    # not capped yet
+        self.assertEqual(self._cycle(int(self.now), self.live), "paused")
+        self.assertEqual(km._retry_pause_reason(), "limit")
+        floor = km._retry_pause_ts()
+        self._append(web, _err_line(floor + 1, SPEND_TEXT), floor + 1)
+        self.assertEqual(self._cycle(int(self.now) + 1, self.live), "paused")
+        km._usage = lambda: {"limited": None}
+        self.assertEqual(self._cycle(int(self.now) + 2, self.live), "degraded", "the limit lifts")
+        self.assertEqual(self._file(), {"paused": False}, "a limit lift records no spend ruling")
+        self.assertEqual(self._cycle(int(self.now) + 3, self.live), "paused", "the cap, never ruled on, pauses")
+        self.assertEqual((km._retry_pause_reason(), km._retry_pause_bills()), ("spend", "key"))
+
+    def test_the_user_s_resume_over_a_spend_pause_stands_until_a_new_record(self):
+        # the same stale record would undo the detail's Resume the next cycle (the setGlobalRetryPaused route
+        # writes the same un-pause): a user gesture is new information too
+        self.assertEqual(self._cycle(int(self.now), self.live), "paused")
+        floor = km._retry_pause_ts()
+        km._set_retry_paused(False)
+        states = [self._cycle(int(self.now) + 1 + i, self.live) for i in range(3)]
+        self.assertEqual(states, ["degraded"] * 3)
+        self.assertEqual(self._file()["supersedes"], floor)
+
+    def test_the_pause_file_remembers_the_spend_lift_across_later_writes(self):
+        tests = self._tests_session()
+        self._cycle(int(self.now), self.live)
+        floor = km._retry_pause_ts()
+        self._append(tests, _out_line(floor + 1), floor + 1)
+        self._cycle(int(self.now) + 1, self.live)
+        d = self._file()
+        self.assertEqual(set(d), {"paused", "liftedAt", "supersedes"})
+        self.assertEqual((d["paused"], d["supersedes"]), (False, floor), "supersedes: the floor of the pause it cleared")
+        lifted = d["liftedAt"]
+        self.assertEqual(lifted, int(floor + 1), "the lifting output's own time")
+        self.assertEqual(km._retry_pause_lifted_at(), lifted)
+        self.assertEqual((km._retry_pause_ts(), km._retry_pause_reason(), km._retry_pause_bills()), (0.0, "", ""))
+        km._set_retry_paused(False)                            # a Resume over an unpaused file keeps what it finds
+        self.assertEqual((self._file()["liftedAt"], self._file()["supersedes"]), (lifted, floor))
+        km._set_retry_paused(True, reason="limit")             # a later pause carries it
+        d = self._file()
+        self.assertEqual(set(d), {"paused", "t", "reason", "liftedAt", "supersedes"})
+        self.assertEqual(d["liftedAt"], lifted)
+        km._set_retry_paused(False)                            # and so does its lift
+        self.assertEqual(self._file()["liftedAt"], lifted)
+        km._set_retry_paused(True)                             # a manual pause carries it, and its un-pause too
+        km._set_retry_paused(False)
+        self.assertEqual(self._file()["liftedAt"], lifted)
+        (self.dir / "retry-paused.json").unlink()              # no memory on file: nothing is invented
+        km._set_retry_paused(True)
+        km._set_retry_paused(False)
+        self.assertEqual(self._file(), {"paused": False})
+        self.assertEqual(km._retry_pause_lifted_at(), 0.0)
+
+
+class PauseWriteSeq(_PauseFixture):
+    """The apiHealth frame's `seq` counts pause-file writes: the detail's pause button writes the file on a
+    press, and the frame that follows must differ from every frame before it even when the cycle's auto-pause
+    put the same state back, so the shell can clear its acknowledgment on the frame that answers the press
+    and read the truth (paused again) instead of holding a disabled, mislabeled button for the rest of the
+    window."""
+
+    def test_a_write_that_puts_the_same_state_back_still_yields_a_new_frame(self):
+        now = time.time()
+        path, row = self._session(SID_LOGIN, "api", "login", _out_line(now - 60))
+        live = {SID_LOGIN: row}
+        self.assertEqual(self._cycle(int(now), live), "paused")
+        seq0 = self.sent[-1][1]["seq"]
+        self.assertEqual(self._cycle(int(now) + 1, live), "paused")
+        self.assertEqual(len(self.sent), 1, "no write, no frame: two cycles over the same world are identical")
+        km._set_retry_paused(False)                            # the user pressed Resume during the window
+        self.assertEqual(self._cycle(int(now) + 2, live), "paused", "the limit re-engaged within the cycle")
+        self.assertEqual(len(self.sent), 2, "same state, but the press and the re-engage wrote the file")
+        self.assertEqual(self.sent[-1][1]["seq"], seq0 + 2)
+        self.assertEqual(km._retry_pause_reason(), "limit")
+
+    def test_seq_is_an_event_counter_not_a_clock(self):
+        self.roster = []
+        km._usage = lambda: {"limited": None}
+        f1 = km._api_health_frame(10, {})
+        f2 = km._api_health_frame(99_999, {})
+        self.assertEqual(json.dumps(f1, sort_keys=True), json.dumps(f2, sort_keys=True))
+        km._set_retry_paused(False)                            # a no-op write is still a write
+        f3 = km._api_health_frame(10, {})
+        self.assertEqual(f3["seq"], f1["seq"] + 1)
+        self.assertEqual((f3["state"], f3["text"]), (f1["state"], f1["text"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -869,10 +869,9 @@ class AuthErrorClass(unittest.TestCase):
 
     def test_it_is_an_on_you_class_end_to_end(self):
         import inspect
-        # the classification lives in _api_error_scan since the tail-window split; _api_error is the
-        # widening driver around it, so read the pair rather than pinning which half holds the flag
-        self.assertIn('"authErr": _is_auth_error(text)',
-                      inspect.getsource(km._api_error) + inspect.getsource(km._api_error_scan))
+        # the classification lives in _api_error_pass, the one-pass scanner both _api_error and the latched
+        # _api_last_failed read through, so the pin reads that function
+        self.assertIn('"authErr": _is_auth_error(text)', inspect.getsource(km._api_error_pass))
         self.assertIn('"apiAuthErr": bool(aerr and aerr.get("authErr"))', inspect.getsource(km.build_session))
         feed = inspect.getsource(km.build_feed)
         self.assertIn('aerr.get("authErr") or aerr.get("refusal"))))', feed, "the card floors to needs-you")

--- a/ui/webview/apierror-spend-limit.test.ts
+++ b/ui/webview/apierror-spend-limit.test.ts
@@ -55,3 +55,16 @@ test("the feed card badges a spent model allowance and HIDES Retry too", () => {
   assert.match(F, /modelLimit \? "⚠ Model limit"/);
   assert.match(F, /modelLimit\?: boolean/);
 });
+
+// The kernel latches a usage-limit pause as reason "limit" in the pause file (the bottom bar's API health cell
+// names the pause from it). The chat card's paused line is unchanged by that: retryPausedText branches on
+// === "spend" first and otherwise falls to the resumeAt countdown, so a "limit" reason renders the countdown
+// exactly as an unlabeled limit pause did. The kernel half (the frame still carries `reason`, the engage writes
+// "limit") is pinned in tests/test_api_health_rail.py's Wiring class.
+test("retryPausedText: spend first, then the resumeAt countdown (a 'limit' reason renders the countdown)", () => {
+  const fn = R.slice(R.indexOf("function retryPausedText()"), R.indexOf("function apiRetryTick()"));
+  assert.match(fn, /if \(globalRetryReason === "spend"\) return/);
+  assert.match(fn, /if \(globalRetryResumeAt\) \{/);
+  assert.ok(fn.indexOf('=== "spend"') < fn.indexOf("if (globalRetryResumeAt)"), "spend is checked before the countdown");
+  assert.doesNotMatch(fn, /"limit"/, "no reason-specific branch: the countdown IS the limit's rendering");
+});


### PR DESCRIPTION
Builds on #1197 (the bottom bar's API health cell), whose body names a hover history of the cell as a separate change. The API cell's hover and click detail gain a History section read from `GET /api-health` when they open, and the backend's aggregator now owns the boot stamp it serves as `bootAt`, so the head, the divider and the restart row name one time. Every JS and CSS hunk here edits the cell's script and skin that PR introduces, the guide sentence extends its paragraph, and the hover tests import the cell's frame builder and push, so the diff to review is this branch against that PR's head; GitHub retargets it to `main` when #1197 merges.

The section shows the signal's state with its since-time and reason, one row per window (attempts, 429 and 5xx shares, give-ups, sessions that retried), the newest six state changes with how long each held, and a kernel restart as its own row or a divider. It reads the signal when it opens, with no poll and no timer, and a failed read shows one line in place of the rows.

## Tier

Tier: feature

## Design

- **Data source.** The hover reads `GET /api-health` at show time on the dashboard's own cookie (a same-origin GET sends no Origin, which `_origin_ok` accepts; no token in the call), the same shape as the shell's `/usage/fleet` read. It does not ride the pushed frame: the signal derives its state at read time by design, a frame would need a periodic snapshot, and its numbers would defeat the frame's byte-equality dedupe. The frame is unchanged, with no new keys; `romp api-health` and the hover show the same document.
- **No timers.** The show (mouseenter, focus, click, Enter/Space) is the event that reads; a frame landing on an open card re-reads; a read sequence number keys the paint to the newest answer; a fresh show drops the last answer so a hover never paints an earlier hover's numbers; a pin reads only when the tip was hidden, so hover-then-click costs one read, and a pin from hidden keeps the last hover's answer behind its read (its as-of says when it was read; the card the user opened is not blanked for the read's duration, and the dots stand in only before the first answer); an answer landing under a held primary pointer waits for the release, the frame's own gate.
- **One boot clock.** The aggregator owns `boot_stamp`: the kernel's `_STARTED` floored to the millisecond (the payload's stamp precision; floor, not round, so its whole seconds are `/version`'s `started`), clamped one millisecond past a restored transition that is not before it (the previous kernel filed after this one started, or the clock stepped; logged once), and served as `bootAt`. Every seeded `stateSince`, every restart row and `bootAt` are one number in every case, so the head, the divider and the restart row agree. `SdkBackend` takes `boot_at` and the kernel passes `_STARTED`; the route no longer stamps its own `int(_STARTED)`. **Contract change to flag:** `bootAt` becomes a millisecond float on the wire; `int(bootAt) == started` holds unless the clamp moved it. Nothing in `bin/romp` reads `bootAt` (`romp api-health` prints the payload verbatim); the reference documents the stamp.
- **Restart rendering.** A row the boot filed reads `unknown · kernel restarted`; where the tail crosses `bootAt` without one (the bucket was already unknown at the previous stop, so the boot filed nothing) a `kernel restarted` divider is inserted and takes none of the six slots; any restart row above suppresses it, so one restart is one mark and a restart is never hidden. A hold from before the boot ends at the boot, since every bucket comes back unknown at a restart; `so far` is a flag, never a stamp comparison, so the transition the hover's own read files (its `t` is `asOf`) still closes the state before it.
- **Window rows.** `requests` excludes no-status attempts in the aggregator, so a row counts every attempt once and names how many had no status with the shares' base beside them (`15 attempts, 7 of them without a status · 25% 429 · 0% 5xx of the other 8`); a window reads `no attempts` only when every count is zero; a window longer than the uptime carries `kernel up <duration>`. Figures are in the window's tense (`retried`); the live set is the Sessions waiting list above.
- **Failure is loud.** A non-2xx, no answer or an answer without the signal's shape shows one line in place of the rows, never the previous numbers, never silence; the loader's three dots stand in before the first answer.
- **Accessibility.** The shown tip is `role=tooltip` on every show, the hover after a pinned dialog closed included (the close leaves the hidden tip's role alone; the show puts the tooltip role back and drops `aria-modal`), and the cell is described by a short visually-hidden summary (`#ah-summary`: the state word, its since, how to open the rest), refreshed when the read lands and never the tip's whole text; before the answer it carries the state word the frame already put on the cell. The pinned card is the `aria-modal` dialog with focus inside. Focus shows, blur or Escape hides in place. A focus the browser re-dispatches on window refocus is skipped only when the cell already held focus at the window's event (recorded there, cleared on the next animation frame, no timer), so a Tab out of a pane iframe onto the cell still shows it.
- **Hardening found on the way.** `_row_ok` requires a finite numeric `t`: a null `t` used to pass, reach the seed's max and drop every restored row and bucket through the outer guard; an int past float range raised `OverflowError` inside `math.isfinite`. Both are now one skipped, counted row.
- **UI rules.** Progressive disclosure (state word and since in the head, windows and tail under, actions only on the pinned card); the section wears the spend hover's grammar and skin, no new font size (the reason and as-of reuse `.ru-tip-reset`); status hexes never the accent; the failure red meets 4.5:1 on both themes (`#ef6b6f` on the dark tip, the light theme's `--err #B02A1C`); the light-theme quiet-dot rule extends to `healthy` and `unknown`; the hover is measured after a reset (a fixed element's shrink-to-fit width is taken against where it last sat) and capped to the room above the rail, so a wide row keeps its margin and a short window clips instead of spilling over the rail.
- **Test lane.** The kernel-inlined script is tested from the Python side: its source pins sit in `tests/test_api_health_hover.py` (beside `tests/test_api_health_rail.py`'s existing pins) and its behaviour runs in Chromium in `tests/test_api_health_hover_browser.py`; no TypeScript test reads `kernel.py`.
- **Deliberately left out.** The VS Code strip twin (`strip.ts` has no API cell; the strip pin records the follow-up) and the phone's Usage-modal section.

## Tests

Executing tests, and what each fails on before the change:

- `tests/test_api_health_hover.py` (new, 34). Payload: the fields the section reads (worst bucket with `stateSince`, `why`, windows keyed by the config), transition rows newest last, the 50-row bound, the restart row's reason text, and a bucket already unknown filing nothing so the boundary rides `bootAt`. One clock: the aggregator seeds `stateSince` and the restart row from `boot_at`; `SdkBackend` hands it through; a backend built without it seeds from its own clock; the kernel's own construction of the backend, run with the backend module swapped for a recorder, passes `_STARTED` itself as `boot_at`; the real route serves `bootAt`, `stateSince` and the restart row as one number, plain and in a same-second race with the previous kernel's last row, with one log line; floor semantics across the second boundary; the clamp judged at the millisecond, a bucket's own tail included. State-file rows: null, missing, string, bool, NaN and an int past float range each skipped as one row with the rest kept. Route: the cookie alone with no Origin, a cross-site cookie refused, a 503 without a backend. Frame: no history rides it and an unchanged world sends once across a read. Docs: the section, the stamp, the three failed reads. Script pins: the read's call sites, no timers, the paint gate, the row grammar, the tail rules, the roles and the description, the CSS with no new font size, `strip.ts` has no API cell. Before the change: no `boot_stamp`, no `bootAt` in the snapshot, `_row_ok` passes a null `t`, no History block in the script, no docs; 31 red, 3 pass before and after (the transition rows' fields; the frame carries no history and dedupes across a read; the strip pin, which holds on #1197's head by construction).
- `tests/test_api_health_hover_browser.py` (new, 29). A scratch copy of the shell page is served with switchable synthetic `/api-health` payloads and driven by Playwright's chromium: one read per show with the loader first; race and fresh-show reset; the storm's head, windows and tail with its restart row; the divider and the pre-boot hold; a bucket the boot seeded and a boot at :58; same-second ordering and the clamped row; the `so far` flag at `asOf`; bucket naming by family and auth; offline and mixed windows; the six-row cap with and without a divider; the three failure lines; section order; focus, blur and Escape; the pointer on a focus-shown tip; the window-refocus re-dispatch; a real Tab out of an iframe; tooltip and dialog roles, the hover after the dialog closed a tooltip again; the short description at focus time and after the read; pin, frame re-read and Escape; click read counts; the held pointer, waited for by the page's own count of parsed answers, never a pause; the light theme's head dot and failure line read from the computed style; geometry at 830x600 (the pointer enters near the right edge, so the first anchor sits flush at the margin and the re-render after the rows land is measured against it) and at 1200x280. Any page error fails. Before the change the served page has no History section, so every wait times out: 29 red. Skips loudly without the extension's node deps or a browser; CI installs none, so this leg is not CI-verified: it ran locally at this head, 29 passed.
- `tests/test_api_health_rail.py` (3 pins rewritten): the cell script has exactly one fetch (the history's) and still no `setInterval`/`setTimeout`; `anchor()` measures after a reset; `keydown` handles Escape before Enter/Space. Green on #1197's head before, red until the hover's JS lands.
- `tests/test_kernel_auth_hardening.py`: `_ApiHealthBackend` seeds its aggregator from `_STARTED` the way `_sdk_locked` does, and `test_boot_identity_is_versions_own` reads `bootAt` as the aggregator's stamp with `int(bootAt) == started` (red before: the aggregator has no `boot_stamp` for the rewritten equality to read; the old `bootAt == started` equality would go red after the change, so the rewrite is part of it).
- `tests/test_kernel_pane_rail.py`: the light-theme ok-dot pin names `.ah-dot[data-state=healthy]` and `[data-state=unknown]` (red before).
- `tests/test_api_health.py` (existing, unchanged) stays green: the millisecond floor is exact on its seeds and no case seeds at or before a restored row.

Mutation checks on the final tree, each turning an executing test red (a source pin alongside): the anchor's left/top reset removed (the 830 px geometry case: the rows wrap), the show leaving the tip a dialog (the tooltip case after the dialog), the light-theme quiet-dot rule dropped and the light failure red dropped (the computed-style case), and `_sdk_locked` no longer passing `boot_at` (the recorder case).

Full runs on the final tree: `pytest -n 8 tests/` 10373 passed, 40 skipped, 0 failed; `npm test` 3655 pass, 0 fail; `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)