### PR TITLE
File viewer: URLs and file paths in a shown file are links

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -101,6 +101,37 @@ way a paper opens from OpenReview: full size, and it stays open beside the dashb
 you keep working. If the browser blocks that new tab, the PDF opens inside the dashboard
 instead; a PDF too large to show offers a download in its place.
 
+**Links in a file.** Wherever the viewer shows a file's text, the links in that text work. A
+web address opens in a new browser tab. A file path opens that file in the viewer, in place of
+the one you were reading: a relative path such as `docs/guide.md` is taken from the folder of
+the file you are reading, an absolute or `~/` path as written, on the machine of the session the
+file belongs to, and a line written after the path (`src/app.py:12`, or `src/app.py#L12`)
+scrolls the code view to that line. A Markdown file opens in its Raw view for that one open, since
+the Rendered view has no lines; your Raw/Rendered choice is unchanged. A line past the end of the
+file lands on the last line, with a notice saying so. In a Markdown file, a `[link](target)`
+follows the same two rules: a web target opens a tab, a file target opens the file (a host with a
+port, `127.0.0.1:3000` or `api.example.com:8443`, is neither, and says so). A link to a section
+of another file (`report.md#results`) opens that file at the section. A link to a section of the
+same document scrolls to it when the document has a heading or an anchor by that name
+(`<a name="install">` included), and otherwise says so when you hover it; it scrolls under every
+click, since a section of the shown file has no tab of its own. One click does one thing: a plain
+click acts in the dashboard, and a Cmd-click (Ctrl on Windows and Linux) or a middle-click opens
+the link in a browser tab of its own. Inside a file the test for a path is stricter than the one
+a chat message gets: a path links only when it has a slash and a file extension, starts on its
+own, at the start of a line or after a space, a quote, a bracket, a comma, a semicolon, an
+equals sign, a pipe or Markdown's `*` (so `$HOME/docs/a.md`, `@scope/pkg/index.js` and
+`C:/Users/x.txt` stay text), is not part of a web address, does not start with a site name
+(`www.example.org/docs/index.html`), and is not the package an `import` statement or a
+`require()` call names, whether the statement fits one line or its `from` starts the next (a
+relative import such as `./app.css` still links, and so does a path after the English word
+"from" in prose, unless that line holds nothing but `from` and the
+quoted path). After a `*` the path must be the whole emphasised text, closed by a `*` of its
+own: `*docs/a.md*` and `**./scripts/setup.sh**` link; a glob's `**/docs/a.md`, an operand's
+`w*h/img.size` and the first path in `**docs/a.md and docs/b.md**` stay text. Web addresses and
+paths found in the text wear a dotted underline that turns solid under the pointer; a Markdown
+link that names a file keeps the ordinary link look. Selecting text across a link works as
+before, and a click that lands while text is selected inside a link opens nothing.
+
 **Tags and groups.** A tag is a named, colored set of sessions; a session can be in
 several. Right-click a tab and open **Tags** to add or remove them. Tags filter every
 surface (the tag button in the strip narrows the tabs to the tags you pick), and they group

--- a/tests/test_path_links.py
+++ b/tests/test_path_links.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Chat file links are filesystem-VERIFIED, and shortened mentions are FIXED.
 
-The client linkifies path-shaped tokens by shape alone (render.ts CLICKABLE_PATH_RE), so a bare
+The client linkifies path-shaped tokens by shape alone (path-links.ts CLICKABLE_PATH_RE), so a bare
 `render.js` in a reply became a blue link that 404'd on click — the token resolved against the
 session's cwd, where no such file lives. The kernel is the machine with the filesystem, so at
 message-build time it resolves every shape-matched token in three tiers (exact stat; unique
@@ -192,7 +192,7 @@ class RepoListEdges(_Repo):
 
 
 class TokenizerParity(unittest.TestCase):
-    """The Python port and render.ts CLICKABLE_PATH_RE must agree on what a token IS — the map's keys
+    """The Python port and path-links.ts CLICKABLE_PATH_RE must agree on what a token IS — the map's keys
     are what the client looks up, so a tokenizer drift silently unlinks. The client side of the same
     fixture runs in chat-path-links.test.ts."""
 

--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -156,7 +156,7 @@ test("a verified relative path is previewable exactly like an absolute one — t
   // AND a bare filename both ride), previewKind is extension-only (relativity-blind), and both the
   // eager and the expanded render hand previewFull the SAME entry previewable carries — pin lookup
   // included, so a relative embed rides its own pin key ((pathPins || {})[p]).
-  assert.match(LINKS, /const open = isUri \? fileUriToPath\(tok\) : \(fixed \?\? tok\);/);   // the walk's open target (path-links.ts)…
+  assert.match(LINKS, /const target = isUri \? fileUriToPath\(tok\) : \(fixed \?\? tok\);\n\s*const open = opts && opts\.resolve \? opts\.resolve\(target\) : target;/);   // the walk's open target (path-links.ts; the chat passes no resolve)…
   assert.match(RENDER, /for \(const \{ el: link, open, verified \} of linkifyPathTokens\(root, pathLinks\)\) \{/);   // …is what the chat reads per hit
   assert.match(RENDER, /previewable\.push\(open\);/);
   assert.match(PREVIEW, /const ext = path\.slice\(path\.lastIndexOf\("\."\) \+ 1\)\.toLowerCase\(\);/);

--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -14,6 +14,7 @@ import * as path from "node:path";
 
 const PREVIEW = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "preview.ts"), "utf8");
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const LINKS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "path-links.ts"), "utf8");   // the matcher, lifted out of render.ts
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
@@ -48,7 +49,8 @@ test("a kernel-VERIFIED preview fails LOUDLY: a retry chip holds the figure's sp
     "a retry RESUMES from the bytes already received (kernel /file honors the suffix range)");
   // the render layer feeds the verdict: spacePaths and pathLinks hits are kernel-stat'd paths
   assert.match(RENDER, /const kernelVerified = new Set<string>\(\);/);
-  assert.match(RENDER, /if \(!isUri && typeof fixed === "string"\) kernelVerified\.add\(open\);/);
+  assert.match(LINKS, /verified: !isUri && typeof fixed === "string"/, "the walk (path-links.ts) says which hit the kernel fixed…");
+  assert.match(RENDER, /if \(verified\) kernelVerified\.add\(open\);/, "…and the chat feeds that verdict to the figure pass");
   assert.match(CSS, /\.path-full-retry \{ display: inline-flex;/, "visible chrome — the chip has chat-sheet css");
 });
 
@@ -154,7 +156,8 @@ test("a verified relative path is previewable exactly like an absolute one — t
   // AND a bare filename both ride), previewKind is extension-only (relativity-blind), and both the
   // eager and the expanded render hand previewFull the SAME entry previewable carries — pin lookup
   // included, so a relative embed rides its own pin key ((pathPins || {})[p]).
-  assert.match(RENDER, /const open = isUri \? fileUriToPath\(tok\) : \(fixed \?\? tok\);/);
+  assert.match(LINKS, /const open = isUri \? fileUriToPath\(tok\) : \(fixed \?\? tok\);/);   // the walk's open target (path-links.ts)…
+  assert.match(RENDER, /for \(const \{ el: link, open, verified \} of linkifyPathTokens\(root, pathLinks\)\) \{/);   // …is what the chat reads per hit
   assert.match(RENDER, /previewable\.push\(open\);/);
   assert.match(PREVIEW, /const ext = path\.slice\(path\.lastIndexOf\("\."\) \+ 1\)\.toLowerCase\(\);/);
   assert.match(RENDER, /previewFull\(p, renderingOwnerSid \?\? activeId, kernelVerified\.has\(p\), \(pathPins \|\| \{\}\)\[p\]\)/);

--- a/ui/webview/chat-path-links.test.ts
+++ b/ui/webview/chat-path-links.test.ts
@@ -32,15 +32,15 @@ test("the chat event carries the kernel's pathLinks verdict on user and assistan
 
 test("membership in pathLinks gates the link, and the map's value is the OPEN target", () => {
   // every existing shape gate stays — the map only ever narrows, never widens
-  assert.match(LINKS, /if \(!isUri && !looksLikeFilePath\(tok\) && !\(inCode && looksLikeBareFileName\(tok\)\)\) continue;/);
+  assert.match(LINKS, /if \(!isUri && !looksLikeFilePath\(tok\) && !\(span\.inCode && looksLikeBareFileName\(tok\)\)\) continue;/);
   assert.match(LINKS, /const fixed = !isUri && pathLinks \? pathLinks\[tok\] : undefined;/);
   assert.match(LINKS, /if \(!isUri && pathLinks && typeof fixed !== "string"\) continue;/);
   // the fixed target is what opens (and openPathLink titles it, so hover shows where a fix points);
   // with NO pathLinks key on the event (old kernel, cached payload) the token opens as written
-  assert.match(LINKS, /const open = isUri \? fileUriToPath\(tok\) : \(fixed \?\? tok\);/);
-  assert.match(LINKS, /const link = isUri \? fileUriLink\(tok\) : openPathLink\(tok, open, true\);/);
-  assert.match(LINKS, /frag\.appendChild\(link\);/);
-  assert.match(LINKS, /a\.title = "Open " \+ open;/);
+  assert.match(LINKS, /const target = isUri \? fileUriToPath\(tok\) : \(fixed \?\? tok\);\n\s*const open = opts && opts\.resolve \? opts\.resolve\(target\) : target;/, "the chat passes no resolve: a URI\'s own path, the fixed target or the token, as before");
+  assert.match(LINKS, /const link = openPathLink\(tok, open, !isUri\);/, "a URI is not a relative path; everything else is");
+  assert.match(LINKS, /list\.push\(\{ start, end: last, el: link \}\);/);
+  assert.match(LINKS, /a\.setAttribute\("title", "Open " \+ open\);/);
   // …and the chat binds the click per span, off the span's own data (the walk marks; render.ts acts)
   assert.match(RENDER, /const open = a\.dataset\.path \|\| "", relative = a\.dataset\.rel === "1";/);
   assert.match(RENDER, /for \(const \{ el: link, open, verified \} of linkifyPathTokens\(root, pathLinks\)\) \{\n\s*bindPathLink\(link\);/);
@@ -48,7 +48,7 @@ test("membership in pathLinks gates the link, and the map's value is the OPEN ta
 
 test("file:// URIs are explicit absolute paths — never gated on the map", () => {
   // both guards above test !isUri first, so a file:// token can't be dropped by the map…
-  assert.match(LINKS, /const isUri = \/\^file:\\\/\\\/\/i\.test\(tok\);/);
+  assert.match(LINKS, /const isUri = isFileUri\(tok\);/);   // a LOCAL file:// URI (an empty authority or localhost); file://host/x is prose
   // …and the kernel never puts file:// tokens in it
   assert.ok(KERNEL.includes('if not t.lower().startswith("file://")'), "kernel skips file:// tokens");
 });

--- a/ui/webview/chat-path-links.test.ts
+++ b/ui/webview/chat-path-links.test.ts
@@ -7,14 +7,16 @@
 // every shape gate it had and merely requires map membership; the map's value is what a click opens,
 // so a unique `sub/deep.py` mention opens the real kernel/sub/deep.py and hover shows that target.
 // Zero or several candidates → absent from the map → prose (a silently-wrong link is worse than no
-// link). render.ts has no jsdom harness → source pins + an executed tokenizer parity check over the
-// shared fixture (the kernel side runs the same fixture in tests/test_path_links.py).
+// link). The matcher lives in path-links.ts (lifted out of render.ts, which binds the click per span); neither
+// has a jsdom harness → source pins + an executed tokenizer parity check over the shared fixture (the kernel
+// side runs the same fixture in tests/test_path_links.py; the walk itself runs in path-links.test.ts).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const LINKS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "path-links.ts"), "utf8");   // the matcher, lifted out of render.ts
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 const VIEW = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "file-view.ts"), "utf8");
 
@@ -30,20 +32,23 @@ test("the chat event carries the kernel's pathLinks verdict on user and assistan
 
 test("membership in pathLinks gates the link, and the map's value is the OPEN target", () => {
   // every existing shape gate stays — the map only ever narrows, never widens
-  assert.match(RENDER, /if \(!isUri && !looksLikeFilePath\(tok\) && !\(inCode && looksLikeBareFileName\(tok\)\)\) continue;/);
-  assert.match(RENDER, /const fixed = !isUri && pathLinks \? pathLinks\[tok\] : undefined;/);
-  assert.match(RENDER, /if \(!isUri && pathLinks && typeof fixed !== "string"\) continue;/);
+  assert.match(LINKS, /if \(!isUri && !looksLikeFilePath\(tok\) && !\(inCode && looksLikeBareFileName\(tok\)\)\) continue;/);
+  assert.match(LINKS, /const fixed = !isUri && pathLinks \? pathLinks\[tok\] : undefined;/);
+  assert.match(LINKS, /if \(!isUri && pathLinks && typeof fixed !== "string"\) continue;/);
   // the fixed target is what opens (and openPathLink titles it, so hover shows where a fix points);
   // with NO pathLinks key on the event (old kernel, cached payload) the token opens as written
-  assert.match(RENDER, /const open = isUri \? fileUriToPath\(tok\) : \(fixed \?\? tok\);/);
-  assert.match(RENDER, /const link = isUri \? fileUriLink\(tok\) : openPathLink\(tok, open, true\);/);
-  assert.match(RENDER, /frag\.appendChild\(link\);/);
-  assert.match(RENDER, /a\.title = "Open " \+ open;/);
+  assert.match(LINKS, /const open = isUri \? fileUriToPath\(tok\) : \(fixed \?\? tok\);/);
+  assert.match(LINKS, /const link = isUri \? fileUriLink\(tok\) : openPathLink\(tok, open, true\);/);
+  assert.match(LINKS, /frag\.appendChild\(link\);/);
+  assert.match(LINKS, /a\.title = "Open " \+ open;/);
+  // …and the chat binds the click per span, off the span's own data (the walk marks; render.ts acts)
+  assert.match(RENDER, /const open = a\.dataset\.path \|\| "", relative = a\.dataset\.rel === "1";/);
+  assert.match(RENDER, /for \(const \{ el: link, open, verified \} of linkifyPathTokens\(root, pathLinks\)\) \{\n\s*bindPathLink\(link\);/);
 });
 
 test("file:// URIs are explicit absolute paths — never gated on the map", () => {
   // both guards above test !isUri first, so a file:// token can't be dropped by the map…
-  assert.match(RENDER, /const isUri = \/\^file:\\\/\\\/\/i\.test\(tok\);/);
+  assert.match(LINKS, /const isUri = \/\^file:\\\/\\\/\/i\.test\(tok\);/);
   // …and the kernel never puts file:// tokens in it
   assert.ok(KERNEL.includes('if not t.lower().startswith("file://")'), "kernel skips file:// tokens");
 });
@@ -72,11 +77,11 @@ test("the /file error bodies name the resolved path, and the viewer doesn't repe
 
 // executed: the Python tokenizer (_path_tokens) and CLICKABLE_PATH_RE must agree on what a token IS —
 // the map keys the kernel ships are what this client looks up, so drift silently unlinks. Same fixture
-// runs against the kernel in tests/test_path_links.py. The regex is EXTRACTED from render.ts, so this
+// runs against the kernel in tests/test_path_links.py. The regex is EXTRACTED from path-links.ts, so this
 // pins the real one, not a copy.
 test("tokenizer parity: the client regex over the shared fixture", () => {
-  const m = RENDER.match(/const CLICKABLE_PATH_RE = \/(.*)\/gi;/);
-  assert.ok(m, "CLICKABLE_PATH_RE found in render.ts");
+  const m = LINKS.match(/const CLICKABLE_PATH_RE = \/(.*)\/gi;/);
+  assert.ok(m, "CLICKABLE_PATH_RE found in path-links.ts");
   const fixture = JSON.parse(fs.readFileSync(
     path.resolve(process.cwd(), "..", "tests", "fixtures", "path_token_parity.json"), "utf8"));
   assert.ok(fixture.cases.length >= 10, "the fixture is the parity surface — keep it broad");

--- a/ui/webview/chat-relpath-link.test.ts
+++ b/ui/webview/chat-relpath-link.test.ts
@@ -18,11 +18,11 @@ test("the linkifier matches file:// URIs AND bare paths, and gates each token ki
   // one finder covers the file: scheme, the slashed-path alternative, and the bare-filename alternative
   assert.ok(LINKS.includes("const CLICKABLE_PATH_RE = /file:"), "regex still handles file:// URIs");
   assert.ok(LINKS.includes("[~.\\w\\-]"), "regex has the slashed-path alternative");
-  assert.match(LINKS, /if \(!isUri && !looksLikeFilePath\(tok\) && !\(inCode && looksLikeBareFileName\(tok\)\)\) continue;/);
+  assert.match(LINKS, /if \(!isUri && !looksLikeFilePath\(tok\) && !\(span\.inCode && looksLikeBareFileName\(tok\)\)\) continue;/);
   // the kernel's pathLinks verdict then narrows further, and its value is the OPEN target — pinned
   // in chat-path-links.test.ts; here we pin that the link opens `open`, whatever chose it
-  assert.match(LINKS, /const link = isUri \? fileUriLink\(tok\) : openPathLink\(tok, open, true\);/);
-  assert.match(LINKS, /frag\.appendChild\(link\);/);
+  assert.match(LINKS, /const link = openPathLink\(tok, open, !isUri\);/);
+  assert.match(LINKS, /list\.push\(\{ start, end: last, el: link \}\);/);
 });
 
 test("a relative path click carries the active session id so whoever resolves it uses that cwd", () => {
@@ -36,8 +36,8 @@ test("a relative path click carries the active session id so whoever resolves it
 });
 
 test("the cheap pre-filter keys on a slash — or, inside inline code, a dot", () => {
-  assert.match(LINKS, /if \(!text\.includes\("\/"\) && !\(inCode && text\.includes\("\."\)\)\) continue;/);
-  assert.match(LINKS, /const inCode = !!tn\.parentElement\?\.closest\("code"\);/);
+  assert.match(LINKS, /if \(!text\.includes\("\/"\) && !\(anyCode && text\.includes\("\."\)\)\) continue;/);
+  assert.match(LINKS, /inCode: !!p\?\.closest\("code"\)/);   // read per text node as the units are cut (textUnits)
 });
 
 // executed: mirror looksLikeFilePath EXACTLY to guard its precision (accept real paths, reject prose)

--- a/ui/webview/chat-relpath-link.test.ts
+++ b/ui/webview/chat-relpath-link.test.ts
@@ -4,35 +4,40 @@
 // relative link posts the ACTIVE session id so the kernel resolves it against that session's cwd (the repo the
 // agent runs in), not the kernel's launch cwd. Slash-less BARE filenames (`power2_watts.pdf`) link too, but
 // ONLY inside inline <code> and only with a KNOWN extension (the user 2026-07-17) — so backticked dotted
-// identifiers (`np.array`) stay prose. render.ts has no jsdom harness → source pins + executed replicas.
+// identifiers (`np.array`) stay prose. The matcher lives in path-links.ts (lifted out of render.ts, which binds
+// the click per span); no jsdom harness → source pins + executed replicas (the walk runs in path-links.test.ts).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const LINKS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "path-links.ts"), "utf8");   // the matcher, lifted out of render.ts
 
 test("the linkifier matches file:// URIs AND bare paths, and gates each token kind", () => {
   // one finder covers the file: scheme, the slashed-path alternative, and the bare-filename alternative
-  assert.ok(RENDER.includes("const CLICKABLE_PATH_RE = /file:"), "regex still handles file:// URIs");
-  assert.ok(RENDER.includes("[~.\\w\\-]"), "regex has the slashed-path alternative");
-  assert.match(RENDER, /if \(!isUri && !looksLikeFilePath\(tok\) && !\(inCode && looksLikeBareFileName\(tok\)\)\) continue;/);
+  assert.ok(LINKS.includes("const CLICKABLE_PATH_RE = /file:"), "regex still handles file:// URIs");
+  assert.ok(LINKS.includes("[~.\\w\\-]"), "regex has the slashed-path alternative");
+  assert.match(LINKS, /if \(!isUri && !looksLikeFilePath\(tok\) && !\(inCode && looksLikeBareFileName\(tok\)\)\) continue;/);
   // the kernel's pathLinks verdict then narrows further, and its value is the OPEN target — pinned
   // in chat-path-links.test.ts; here we pin that the link opens `open`, whatever chose it
-  assert.match(RENDER, /const link = isUri \? fileUriLink\(tok\) : openPathLink\(tok, open, true\);/);
-  assert.match(RENDER, /frag\.appendChild\(link\);/);
+  assert.match(LINKS, /const link = isUri \? fileUriLink\(tok\) : openPathLink\(tok, open, true\);/);
+  assert.match(LINKS, /frag\.appendChild\(link\);/);
 });
 
 test("a relative path click carries the active session id so whoever resolves it uses that cwd", () => {
-  assert.match(RENDER, /function openPathLink\(raw: string, open: string, relative = false\)/);
+  assert.match(LINKS, /function openPathLink\(raw: string, open: string, relative = false\)/);
+  assert.match(LINKS, /if \(relative\) a\.dataset\.rel = "1";/, "the span says it was a bare path (the module binds nothing)");
   // relative → send the session id; absolute/file:// → none needed. Both go through openPath, which
-  // picks the host (VS Code editor vs the feed pane's viewer) — see the openPath test below.
+  // picks the host (VS Code editor vs the feed pane's viewer) — see the openPath test below. render.ts
+  // reads the span's data and binds the click (bindPathLink).
+  assert.match(RENDER, /const open = a\.dataset\.path \|\| "", relative = a\.dataset\.rel === "1";/);
   assert.match(RENDER, /openPath\(open, relative \? activeId : null, e\);/);   // + the click itself: a modified click on a PDF takes a browser tab (pdf-new-tab.test.ts)
 });
 
 test("the cheap pre-filter keys on a slash — or, inside inline code, a dot", () => {
-  assert.match(RENDER, /if \(!text\.includes\("\/"\) && !\(inCode && text\.includes\("\."\)\)\) continue;/);
-  assert.match(RENDER, /const inCode = !!tn\.parentElement\?\.closest\("code"\);/);
+  assert.match(LINKS, /if \(!text\.includes\("\/"\) && !\(inCode && text\.includes\("\."\)\)\) continue;/);
+  assert.match(LINKS, /const inCode = !!tn\.parentElement\?\.closest\("code"\);/);
 });
 
 // executed: mirror looksLikeFilePath EXACTLY to guard its precision (accept real paths, reject prose)
@@ -56,8 +61,8 @@ test("looksLikeFilePath accepts real paths and rejects prose fractions/idioms", 
 
 // executed: mirror looksLikeBareFileName — a slash-less filename links only with a KNOWN extension
 test("looksLikeBareFileName accepts real filenames and rejects identifiers/versions", () => {
-  assert.match(RENDER, /function looksLikeBareFileName\(tok: string\): boolean/);
-  assert.match(RENDER, /BARE_FILE_EXTS\.has\(tok\.slice\(dot \+ 1\)\.toLowerCase\(\)\)/);
+  assert.match(LINKS, /function looksLikeBareFileName\(tok: string\): boolean/);
+  assert.match(LINKS, /BARE_FILE_EXTS\.has\(tok\.slice\(dot \+ 1\)\.toLowerCase\(\)\)/);
   const EXTS = new Set(["md", "py", "pdf", "csv", "png", "ts", "json", "sh"]);   // subset of BARE_FILE_EXTS
   const bare = (tok: string): boolean => {
     if (tok.includes("/") || tok.includes(":")) return false;
@@ -74,7 +79,7 @@ test("looksLikeBareFileName accepts real filenames and rejects identifiers/versi
     assert.equal(bare(p), false, p);
   }
   // the real BARE_FILE_EXTS covers the screenshot's extensions
-  const exts = RENDER.slice(RENDER.indexOf("const BARE_FILE_EXTS"), RENDER.indexOf("function looksLikeBareFileName"));
+  const exts = LINKS.slice(LINKS.indexOf("const BARE_FILE_EXTS"), LINKS.indexOf("function looksLikeBareFileName"));
   for (const e of ['"pdf"', '"csv"', '"py"', '"md"', '"png"']) assert.ok(exts.includes(e), e);
 });
 

--- a/ui/webview/chat-space-paths.test.ts
+++ b/ui/webview/chat-space-paths.test.ts
@@ -48,9 +48,9 @@ test("linkifyFileUris whole-links a verified span's entire inline-code content",
 test("the whole-span pass runs BEFORE the token walk, so the new link is skipped by it", () => {
   const fn = RENDER.slice(RENDER.indexOf("function linkifyFileUris("), RENDER.indexOf("function renderEvent("));
   const spanPass = fn.indexOf('root.querySelectorAll("code")');
-  const walk = fn.indexOf("createTreeWalker");
+  const walk = fn.indexOf("linkifyPathTokens(");   // the shared walk (path-links.ts), which skips text already inside a link
   assert.ok(spanPass >= 0 && walk >= 0 && spanPass < walk,
-    "code-span links land first; the token walker's closest('a') guard then leaves them alone");
+    "code-span links land first; the token walk's closest('a, .file-uri-link') guard then leaves them alone");
 });
 
 test("every message render threads its event's spacePaths through", () => {

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1535,6 +1535,22 @@ a.fileview-gh-note { border-style: dashed; }
   color: var(--dim); opacity: 0.55; user-select: none;
 }
 .fileview-wrap .fv-ct { flex: 1 1 auto; min-width: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
+/* Links inside a shown file (file-view-links.ts): a URL opens a new tab, a path opens in the viewer. Light by
+   design (the user 2026-09-07): the token keeps the colour the highlight gave it, under a faint dotted underline
+   that turns solid on hover; nothing else in the view changes. A Markdown link whose target is a file keeps the
+   link ink the other Markdown links wear. Neither is draggable (-webkit-user-drag: none, with draggable=false on the
+   anchor) and both are selectable (user-select: text; Chromium starts no selection inside a link without it), so a
+   press-drag inside a path link selects its text as on plain text, a press held on a URL anchor and then dragged
+   selects too (Chromium's rule for a link: an immediate drag on one selects nothing), and neither starts the browser's
+   link drag; a click that arrives with the selection open finds the viewer's listener and the chat's opener yielding
+   to it (path-links.ts selectionOpenIn). Mirrored in styles.css and feed.css (fileview-parity.test.ts). */
+.fileview-body .file-uri-link, .fileview-body .fv-url { color: inherit; cursor: pointer; text-decoration: underline dotted; text-decoration-color: color-mix(in srgb, currentColor 35%, transparent); text-underline-offset: 2px; -webkit-user-drag: none; user-select: text; }
+.fileview-body .file-uri-link:hover, .fileview-body .fv-url:hover { text-decoration: underline; text-decoration-color: currentColor; }
+.fileview-md a.file-uri-link { color: var(--link); text-decoration: none; }
+.fileview-md a.file-uri-link:hover { text-decoration: underline; }
+/* A Markdown link with no target the viewer can follow (the sanitizer removed it; a section this document does not
+   have): dead, and it says so, since the title holds the reason (file-view-links.ts DEAD_LINK_CLASS). */
+.fileview-md a.fv-dead { color: inherit; opacity: 0.7; text-decoration: underline dotted; cursor: help; }
 
 /* ── text size and measure (file-view.ts textSizeControl) ── The A− / A+ buttons and Ctrl/Cmd + wheel over the
    body set `data-fv-text` on the viewer root to one of TEXT_SIZES; this table turns the step into the ONE

--- a/ui/webview/file-uri-link.test.ts
+++ b/ui/webview/file-uri-link.test.ts
@@ -9,18 +9,20 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const LINKS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "path-links.ts"), "utf8");   // the matcher, lifted out of render.ts
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 test("a bare file:// URL becomes a clickable .file-uri-link that opens the file in the host app", () => {
   assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>\): void/);
-  assert.match(RENDER, /el\("span", "file-uri-link"\)/);
+  assert.match(LINKS, /el\("span", "file-uri-link"\)/);
   // clicking is ROUTED by openPath, never a blocked window.open(file://) — a file:// URI is absolute,
-  // so it takes the shared openPathLink's no-session-id branch
-  assert.match(RENDER, /function fileUriLink\(uri: string\): HTMLElement \{ return openPathLink\(uri, fileUriToPath\(uri\)\); \}/);
+  // so it takes the shared openPathLink's no-session-id branch (no data-rel on the span; render.ts's
+  // bindPathLink then sends no session id)
+  assert.match(LINKS, /function fileUriLink\(uri: string\): HTMLElement \{ return openPathLink\(uri, fileUriToPath\(uri\)\); \}/);
   assert.match(RENDER, /openPath\(open, relative \? activeId : null, e\);/);
   // the URL is turned into a real filesystem path: scheme stripped, percent-decoded
-  assert.match(RENDER, /\.replace\(\/\^file:/);
-  assert.match(RENDER, /decodeURIComponent\(p\)/);
+  assert.match(LINKS, /\.replace\(\/\^file:/);
+  assert.match(LINKS, /decodeURIComponent\(p\)/);
 });
 
 test("linkify runs on chat message bodies (assistant reply + user bubble + nudge full text) and nowhere else — never tool summaries", () => {
@@ -34,9 +36,9 @@ test("linkify runs on chat message bodies (assistant reply + user bubble + nudge
 
 test("linkify works inside INLINE backticks (agents backtick paths), skips only fenced code + existing links, trims trailing punctuation", () => {
   // inline <code> is NOT skipped — a `file://…` path in backticks still linkifies; only fenced <pre> + links are skipped
-  assert.match(RENDER, /closest\("a, \.file-uri-link, pre"\)/);
-  assert.doesNotMatch(RENDER, /closest\("a, \.file-uri-link, code, pre"\)/);
-  assert.match(RENDER, /tok = tok\.slice\(0, tok\.length - trail\[0\]\.length\)/);
+  assert.match(LINKS, /closest\("a, \.file-uri-link, pre"\)/);
+  assert.doesNotMatch(LINKS, /closest\("a, \.file-uri-link, code, pre"\)/);
+  assert.match(LINKS, /tok = tok\.slice\(0, tok\.length - trail\[0\]\.length\)/);
 });
 
 test(".file-uri-link is styled as a wrapping accent link", () => {

--- a/ui/webview/file-uri-link.test.ts
+++ b/ui/webview/file-uri-link.test.ts
@@ -21,7 +21,7 @@ test("a bare file:// URL becomes a clickable .file-uri-link that opens the file 
   assert.match(LINKS, /function fileUriLink\(uri: string\): HTMLElement \{ return openPathLink\(uri, fileUriToPath\(uri\)\); \}/);
   assert.match(RENDER, /openPath\(open, relative \? activeId : null, e\);/);
   // the URL is turned into a real filesystem path: scheme stripped, percent-decoded
-  assert.match(LINKS, /\.replace\(\/\^file:/);
+  assert.match(LINKS, /const FILE_URI_RE = \/\^file:\\\/\\\/\(\?:localhost\)\?\(\?=\\\/\)\/i;/, "a LOCAL URI: an empty authority or localhost; file://host/x names another machine and stays prose");
   assert.match(LINKS, /decodeURIComponent\(p\)/);
 });
 
@@ -36,8 +36,9 @@ test("linkify runs on chat message bodies (assistant reply + user bubble + nudge
 
 test("linkify works inside INLINE backticks (agents backtick paths), skips only fenced code + existing links, trims trailing punctuation", () => {
   // inline <code> is NOT skipped — a `file://…` path in backticks still linkifies; only fenced <pre> + links are skipped
-  assert.match(LINKS, /closest\("a, \.file-uri-link, pre"\)/);
-  assert.doesNotMatch(LINKS, /closest\("a, \.file-uri-link, code, pre"\)/);
+  assert.match(LINKS, /export const DEAD_TEXT = "a, \.file-uri-link, svg";/);
+  assert.match(LINKS, /const skip = opts && opts\.inPre \? DEAD_TEXT : DEAD_TEXT \+ ", pre";/, "the chat skips a link, an inline SVG and a fenced block; never inline code");
+  assert.doesNotMatch(LINKS, /DEAD_TEXT \+ ", code/);
   assert.match(LINKS, /tok = tok\.slice\(0, tok\.length - trail\[0\]\.length\)/);
 });
 

--- a/ui/webview/file-view-links-browser.test.ts
+++ b/ui/webview/file-view-links-browser.test.ts
@@ -1,0 +1,385 @@
+// Links inside a shown file, in a browser (file-view-links.ts): headless Chromium boots the viewer's real module,
+// opens synthetic files through it, and drives the mouse over the viewer's real DOM: the rows hljs built and the
+// pass marked, the body's click listener and its gesture, the fetch a path link causes, the line a `:30` link scrolls
+// to, the Raw view a markdown file takes for that open, the tab a URL anchor opens, and the clicks that must NOT open
+// anything. This is the leg no stand-in can stand in for: the browser decides where a press-drag-release sends its
+// click; DOMPurify decides which Markdown targets survive; hljs decides where a substitution span cuts a path. A
+// second page runs the chat's own capture-phase anchor opener (its source, lifted from render.ts and installed over
+// the same bundle) so both documents' routing is exercised, not pinned. Skips LOUDLY without a playwright browser
+// (CI installs none), as queued-romp-layout.test.ts does. Synthetic values only: the notes-api world under
+// /tmp/TESTHOST, a placeholder session id, example.invalid addresses.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+const requireCjs = createRequire(__filename);
+const EXT = process.cwd();                                        // npm test runs in vscode-extension
+const UI = path.resolve(EXT, "..", "ui", "webview");
+const SID = "11111111-2222-3333-4444-555555555555";
+const ROOT = "/tmp/TESTHOST/notes-api";
+const APP = ROOT + "/src/app.py";
+const GUIDE = ROOT + "/docs/guide.md";
+const NOTES = ROOT + "/docs/notes.md";
+const README = ROOT + "/README.md";
+const CONFIG = ROOT + "/src/data/config.json";
+const RUN = ROOT + "/scripts/run.sh";
+const URL_SETUP = "https://example.invalid/docs/setup.html";
+// the titles the module gives a dead link (file-view-links.ts), spelled here so this leg builds against a viewer that has none
+const DEAD_LINK_TITLE = "Not a link the viewer can follow: its target is neither a web address nor a file on the session's machine";
+const HOST_PORT_TITLE = "Not a link the viewer can follow: the target is a host with a port, not a file on the session's machine";
+const noSectionTitle = (id: string): string => "No heading or anchor named “" + id + "” in this document";
+
+const APP_TEXT = [
+  "# notes-api: see " + URL_SETUP + ", then ../docs/guide.md:30.",
+  "import json",
+  'cfg = json.load(open("data/config.json"))',
+  "from . import util  # and/or 24/7 x = 1/2.5 /api/users ./foo",
+  "readme = 'file:///tmp/TESTHOST/notes-api/README.md'",
+  "# see www.example.org/docs/index.html or git@github.invalid:user/repo.git",
+  'far = "file://evil.invalid/share/x.md"',
+  "",
+].join("\n");
+const GUIDE_TEXT = [
+  "# Guide", "",
+  "Read [the app](../src/app.py) and [the web](https://example.invalid/doc).",
+  "Bare ../src/app.py:3 links too, and https://example.invalid/prose is a URL.",
+  "docs/first.md starts a soft-broken line of the same paragraph, and a hard break follows  ",   // two trailing spaces: marked's <br>
+  "docs/second.md starts the line after the break.", "",
+  "Also [same](notes.md:7), [uri](file:///tmp/TESTHOST/notes-api/README.md), [far](file://evil.invalid/x.md), [q](?foo=1), [here](#section), [go](#top), [past](../src/app.py:400), [collide](#fileview-save-err), [install](#install), [api](api.example.com:8443), [spec](app.test.ts:12), [results](#results), [self](guide.md#install), [ip](127.0.0.1:3000).", "",
+  "A glob `**/docs/glob.md` or `src/**/x.md` links nothing, nor does an operand 2*docs/times.md or 3*w/h.px.", "",
+  'Copied from "docs/from.md", and the export "out/data.json" is stale.', "",   // the English from and export: prose that names files
+  "**docs/strong.md** and *docs/em.md*, then ​docs/zwsp.md after a zero-width space.", "",
+  '<svg width="200" height="30"><a href="https://example.invalid/s"><text y="11">svgweb</text></a><a href="x.md"><text x="60" y="11">svgfile</text></a><text y="26">label docs/label.md in the figure</text></svg>', "",
+  "```bash", "curl https://example.invalid/dl -o data/x.json", "docs/fence2.md", "  ./docs/fence3.md", "```", "",
+  ...Array.from({ length: 32 }, (_, i) => "line " + (i + 10) + "\n"),   // one paragraph each (a blank line between), so the rendered body scrolls
+  "## Results", "",                                // a heading: the viewer mints it the id md-results, and `#results` finds it by that slug
+  '<p id="top">Top</p>', "",                        // an author's id on an element that is not a heading
+  '<p id="fileview-save-err">Collide</p>', "",     // an author's id spelled like the viewer's own notice
+  '<a name="install"></a>', "", "## Install", "",   // the README idiom for a stable anchor: a named <a> above a heading
+  '<span class="file-uri-link" data-path="/tmp/TESTHOST/secret.txt" data-line="3">dressed</span>', "",   // a document's own element dressed as a path link: its data-* must never reach the page
+].join("\n");
+const NOTES_TEXT = Array.from({ length: 12 }, (_, i) => "note " + (i + 1)).join("\n") + "\n";
+// what a highlighter cuts: bash puts `$HOME` and `${ROOT}` in spans of their own; a URL a substitution cuts, with an absolute
+// path as a query value, stays text and its path is the URL's; a glob's tail after a star and an operand after one are text
+const RUN_TEXT = ["#!/bin/bash", 'cp "$HOME/docs/a.md" ./out/', "cat ${ROOT}/src/x.py", 'echo "see ./docs/b.md"', "curl https://example.invalid/q?x=/docs/a.md/$V",
+  "find . -path '**/docs/a.md'", "cp src/**/index.ts out/", "ls packages/*/package.json", "export DATA=/data", '# copied from "docs/c.md"', ""].join("\n");
+const FILES: Record<string, string> = { [APP]: APP_TEXT, [GUIDE]: GUIDE_TEXT, [NOTES]: NOTES_TEXT, [README]: "# notes-api\n", [CONFIG]: '{"a": 1}\n', [RUN]: RUN_TEXT };
+
+/** The viewer, bundled the way vscode-extension/esbuild.js builds the webview (in memory, nothing on disk), with its
+ *  openers handed to the page. */
+function viewerBundle(): string {
+  const esbuild = requireCjs("esbuild");
+  const r = esbuild.buildSync({
+    stdin: { contents: 'import { openFileView, initFileView } from "./file-view";\n(window as any).__romp = { openFileView, initFileView };\n', resolveDir: UI, loader: "ts", sourcefile: "viewer-probe.ts" },
+    bundle: true, write: false, format: "iife", platform: "browser", target: "es2020",
+    nodePaths: [path.join(EXT, "node_modules")], external: ["*.png", "*.svg", "*.woff", "*.ttf", "../media/*.woff2"], logLevel: "silent",
+  });
+  return r.outputFiles[0].text;
+}
+/** The chat document's OWN click handler, lifted from its source: render.ts's document-level anchor opener (capture
+ *  phase, window.open for a scheme href). Installed over the viewer bundle, so the viewer runs under it as it does in
+ *  the chat page. Every name the lifted handler uses that render.ts imports or declares at its top level must be one the
+ *  prelude defines: a missing one throws a ReferenceError at the first click that reaches its branch, and the leg then
+ *  reads a tab that never opens where the viewer did nothing wrong. */
+function chatHostBundle(): string {
+  const esbuild = requireCjs("esbuild");
+  const RENDER = fs.readFileSync(path.join(UI, "render.ts"), "utf8");
+  const head = 'document.addEventListener("click", (e) => {\n  const a = (e.target as HTMLElement)?.closest?.("a[href]") as HTMLAnchorElement | null;';
+  const start = RENDER.indexOf(head);
+  const end = RENDER.indexOf("}, true);", start) + "}, true);".length;
+  assert.ok(start > 0 && end > start, "render.ts's document-level anchor opener");
+  const lifted = RENDER.slice(start, end);
+  const prelude = 'import { selectionOpenIn } from "./path-links";\nimport { isMarkdownUrl } from "./md-links";\nimport { userContentTarget } from "./md-sanitize";\n'
+    + "const vscodeApi: { postMessage(m: unknown): void } | null = null;\n"
+    + "(window as any).__urlViews = [];\nconst openUrlView = (href: string): void => { (window as any).__urlViews.push(href); };\n"
+    // render.ts's attributed mover of #content; this page has no #content and the viewer's links sit outside a message body, so the fragment arm never reaches it
+    + 'const scrollElInto = (_content: HTMLElement, el: Element, block: "start" | "center" | "nearest"): void => { el.scrollIntoView({ block }); };\n';
+  // the check: the lifted code with comments and strings removed, its own locals set aside, a property read (`.name`) not counted
+  const code = lifted.replace(/\/\*[\s\S]*?\*\/|\/\/.*$|"(?:[^"\\\n]|\\.)*"|'(?:[^'\\\n]|\\.)*'|`(?:[^`\\]|\\.)*`/gm, (m) => (m[0] === "/" ? "" : '""'));
+  const locals = new Set(Array.from(code.matchAll(/\b(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)/g), (m) => m[1]));
+  const named = new Set<string>();
+  const addNamed = (list: string) => { for (const part of list.split(",")) { const name = part.trim().replace(/^type\s+/, "").split(/\s+as\s+/).pop()!.trim(); if (name) named.add(name); } };
+  for (const m of RENDER.matchAll(/^import (?!type\b)(?:([A-Za-z_$][\w$]*)\s*,?\s*)?(?:\* as ([A-Za-z_$][\w$]*)|\{([^}]*)\})?\s*from "[^"]+";/gm)) { if (m[1]) named.add(m[1]); if (m[2]) named.add(m[2]); if (m[3]) addNamed(m[3]); }
+  for (const m of RENDER.matchAll(/^(?:export )?(?:const|let|var|(?:async )?function\*?|class) ([A-Za-z_$][\w$]*)/gm)) named.add(m[1]);
+  const declared = new Set(Array.from(prelude.matchAll(/(?:^const |\{ )([A-Za-z_$][\w$]*)/gm), (m) => m[1]));
+  const free = Array.from(named).filter((n) => !locals.has(n) && !declared.has(n) && new RegExp("(?<![.\\w$])" + n.replace(/\$/g, "\\$") + "\\b").test(code));
+  assert.deepEqual(free, [], "render.ts's opener names these and the prelude defines none of them: import or define each in chatHostBundle, or the lifted handler throws where a click reaches it");
+  // a recorder on the window, after the host's own: a click that reaches it reached every document-level listener too
+  const ts = prelude + lifted + "\n(window as any).__windowClicks = [];\nwindow.addEventListener(\"click\", (e) => { (window as any).__windowClicks.push((e.target as HTMLElement).textContent); });\n";
+  const r = esbuild.buildSync({
+    stdin: { contents: ts, resolveDir: UI, loader: "ts", sourcefile: "chat-host.ts" },
+    bundle: true, write: false, format: "iife", platform: "browser", target: "es2020",
+    nodePaths: [path.join(EXT, "node_modules")], logLevel: "silent",
+  });
+  return r.outputFiles[0].text;
+}
+const PAGE = (host: "viewer" | "chat") => `<!DOCTYPE html><html><head><meta charset=utf-8><style>
+${fs.readFileSync(path.join(UI, "styles.css"), "utf8")}
+</style></head><body>${host === "chat" ? '<p id=chat-para><a href="https://example.invalid/pr">alpha beta gamma delta</a> is ready, and the prose after it runs on.</p>' : ""}
+<script src=/dist/viewer.js></script>
+<script>window.__posts = []; window.__romp.initFileView(function (m) { window.__posts.push(m); });</script>
+${host === "chat" ? "<script src=/dist/host.js></script>" : ""}</body></html>`;
+
+let pw: any = null;
+try { pw = requireCjs("playwright"); } catch { pw = null; }
+
+type Info = { text: string | null; path: string | undefined; line: string | undefined; frag: string | undefined; href: string | null; target: string | null; rel: string | null; cls: string; title: string | null; draggable: string | null };
+type Harness = {
+  page: any; ctx: any; served: string[]; errors: string[];
+  open: (p: string, opts?: { line?: number | null; frag?: string | null }) => Promise<void>;
+  linkInfo: (sel: string) => Promise<Info[]>; base: () => Promise<string | null>; newPages: () => any[]; rows: () => Promise<string[]>;
+  inView: (sel: string) => Promise<boolean>;
+  centerOffset: (sel: string) => Promise<{ d: number; h: number } | null>;
+};
+async function inBrowser(t: any, host: "viewer" | "chat", body: (h: Harness) => Promise<void>): Promise<void> {
+  if (!pw) { t.skip("playwright is not installed under vscode-extension: the browser leg needs it (CI installs no browsers)"); return; }
+  let browser: any;
+  try { browser = await pw.chromium.launch(); }
+  catch (e) { t.skip("no playwright browser on this machine, and the browser leg needs one (CI installs none): " + String((e as Error).message).split("\n")[0]); return; }
+  const errors: string[] = [];
+  const served: string[] = [];
+  const opened: any[] = [];
+  try {
+    const viewerJs = viewerBundle();
+    const hostJs = host === "chat" ? chatHostBundle() : "";
+    const ctx = await browser.newContext({ viewport: { width: 900, height: 600 } });
+    ctx.on("page", (p: any) => { opened.push(p); });
+    const page = await ctx.newPage();
+    opened.length = 0;                                             // the harness's own page is not an opened tab
+    page.on("pageerror", (e: Error) => { errors.push(e.message); });
+    await ctx.route("http://romp.test/**", (route: any) => {
+      const u = new URL(route.request().url());
+      const html = (b: string) => route.fulfill({ status: 200, contentType: "text/html; charset=utf-8", body: b });
+      const js = (b: string) => route.fulfill({ status: 200, contentType: "application/javascript", body: b });
+      if (u.pathname === "/page") return html(PAGE(host));
+      if (u.pathname === "/dist/viewer.js") return js(viewerJs);
+      if (u.pathname === "/dist/host.js") return js(hostJs);
+      if (u.pathname === "/file") {                                // the viewer's fetch: what the kernel would serve for a text file
+        const p = u.searchParams.get("path") || "";
+        served.push(p);
+        const text = FILES[p];
+        if (text === undefined) return route.fulfill({ status: 404, contentType: "text/plain; charset=utf-8", body: "not found: " + p });
+        return route.fulfill({ status: 200, contentType: "text/plain; charset=utf-8", headers: { "X-Romp-Mtime-Ns": "1", "X-Romp-Text-Utf8": "1" }, body: text });
+      }
+      return route.fulfill({ status: 404, body: "" });
+    });
+    await ctx.route("https://example.invalid/**", (route: any) => route.fulfill({ status: 200, contentType: "text/html; charset=utf-8", body: "<!DOCTYPE html><title>stub</title>" }));
+    await page.goto("http://romp.test/page");
+    const h: Harness = {
+      page, ctx, served, errors,
+      open: async (p, opts) => {
+        await page.evaluate(([p, sid, opts]: any[]) => { (window as any).__romp.openFileView(p, sid, opts); }, [p, SID, opts || undefined]);
+        await page.locator("#romp-fileview .fileview-body code.hljs .fv-cl, #romp-fileview .fileview-body .fileview-md").first().waitFor({ timeout: 10000 });
+      },
+      linkInfo: (sel) => page.evaluate((sel: string) => Array.from(document.querySelectorAll(sel)).map((e) => {
+        const x = e as HTMLElement;
+        return { text: x.textContent, path: x.dataset.path, line: x.dataset.line, frag: x.dataset.frag, href: x.getAttribute("href"), target: x.getAttribute("target"), rel: x.getAttribute("rel"),
+          cls: x.getAttribute("class") || "", title: x.getAttribute("title"), draggable: x.getAttribute("draggable") };
+      }), sel),
+      base: () => page.evaluate(() => document.querySelector("#romp-fileview .fileview-base")?.textContent ?? null),
+      newPages: () => opened,
+      rows: () => page.evaluate(() => Array.from(document.querySelectorAll("#romp-fileview code.hljs .fv-cl")).map((r) => r.textContent || "")),
+      inView: (sel) => page.evaluate((sel: string) => {
+        const el = document.querySelector(sel), body = document.querySelector("#romp-fileview .fileview-body");
+        if (!el || !body) return false;
+        const r = el.getBoundingClientRect(), b = body.getBoundingClientRect();
+        return r.top >= b.top - 1 && r.bottom <= b.bottom + 1;
+      }, sel),
+      centerOffset: (sel) => page.evaluate((sel: string) => {   // the element's centre against the body's, and its height
+        const el = document.querySelector(sel), body = document.querySelector("#romp-fileview .fileview-body");
+        if (!el || !body) return null;
+        const r = el.getBoundingClientRect(), b = body.getBoundingClientRect();
+        return { d: (r.top + r.bottom) / 2 - (b.top + b.bottom) / 2, h: r.height };
+      }, sel),
+    };
+    await body(h);
+    assert.deepEqual(errors, [], "no page errors");
+  } finally { await browser.close(); }
+}
+const linkTexts = (info: Info[]) => info.map((x) => x.text);
+/** A press-drag-release from the left edge of `fromSel` to the middle of `toSel` (the same element for a drag inside a
+ *  link): what selects text in a browser. */
+async function dragSelect(page: any, fromSel: string, toSel: string): Promise<void> {
+  const a = await page.locator(fromSel).first().boundingBox(), b = await page.locator(toSel).first().boundingBox();
+  assert.ok(a && b, "both ends of the drag are laid out");
+  await page.mouse.move(a.x + 1, a.y + a.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(b.x + b.width / 2, b.y + b.height / 2, { steps: 8 });
+  await page.mouse.up();
+}
+
+test("in a browser: the code view's real hljs rows carry the links (a URL anchor in a comment, path links resolved against the file, a :30 riding along), the highlight's substitution spans expose no fabricated path, and every row's text is the file's", async (t) => {
+  await inBrowser(t, "viewer", async (h) => {
+    await h.open(APP);
+    assert.deepEqual(await h.rows(), APP_TEXT.split("\n").slice(0, -1), "the rows read as the file's lines: the pass changed no character");
+    const urls = await h.linkInfo("#romp-fileview a.fv-url");
+    assert.deepEqual(urls.map((u) => [u.href, u.target, u.rel, u.draggable]), [[URL_SETUP, "_blank", "noopener noreferrer", "false"]]);
+    assert.equal(await h.page.evaluate(() => !!document.querySelector("#romp-fileview a.fv-url")!.closest(".hljs-comment")), true, "inside the highlight's own comment span");
+    const links = await h.linkInfo("#romp-fileview .file-uri-link");
+    assert.deepEqual(linkTexts(links), ["../docs/guide.md:30", "data/config.json", "file:///tmp/TESTHOST/notes-api/README.md"],
+      "and/or, 24/7, 1/2.5, /api/users, ./foo, the site, the git remote and the far file:// URI stay text");
+    assert.deepEqual(links.map((l) => [l.path, l.line]), [[GUIDE, "30"], [CONFIG, undefined], [README, undefined]]);
+    assert.ok(links.every((l) => l.cls.split(/\s+/).includes("file-uri-link") && l.title!.startsWith("Open ")));
+    assert.equal(await h.page.evaluate(() => !!document.querySelector('#romp-fileview .file-uri-link[data-path$="config.json"]')!.closest(".hljs-string")), true, "inside the highlight's string span, the quotes outside");
+    // the bash file: hljs cuts `"$HOME/docs/a.md"` and `${ROOT}/src/x.py` at the substitution, and the pass reads the LINE
+    await h.open(RUN);
+    assert.deepEqual(await h.rows(), RUN_TEXT.split("\n").slice(0, -1));
+    assert.deepEqual(linkTexts(await h.linkInfo("#romp-fileview .file-uri-link")), ["./docs/b.md", "docs/c.md"],
+      "no /docs/a.md or /src/x.py off a substitution's tail, no glob tail, no operand, no path inside the cut URL; the quoted path and the English from's file link");
+    assert.deepEqual(await h.linkInfo("#romp-fileview a.fv-url"), [], "a URL the highlight cut through is not one");
+  });
+});
+
+test("in a browser: a plain click on a path link opens that file in the viewer, in place; a :line link opens a markdown file in its Raw view for that open, with row 30 itself centred, and the saved preference untouched", async (t) => {
+  await inBrowser(t, "viewer", async (h) => {
+    await h.open(APP);
+    await h.page.locator('#romp-fileview .file-uri-link[data-path$="config.json"]').click();
+    await h.page.locator("#romp-fileview .fileview-base", { hasText: "config.json" }).waitFor({ timeout: 10000 });
+    assert.deepEqual(h.served, [APP, CONFIG], "the click fetched the resolved sibling, for this session");
+    assert.equal(await h.base(), "config.json");
+    // the :30 link: the guide opens Raw (the Rendered view has no rows), on line 30
+    await h.open(APP);
+    await h.page.locator('#romp-fileview .file-uri-link[data-line="30"]').click();
+    await h.page.locator("#romp-fileview .fileview-base", { hasText: "guide.md" }).waitFor({ timeout: 10000 });
+    await h.page.locator("#romp-fileview code.hljs .fv-cl").first().waitFor({ timeout: 10000 });
+    assert.equal(await h.page.evaluate(() => document.querySelector("#romp-fileview .fileview-btn.on")?.textContent), "Raw", "the Raw view, for this open");
+    assert.equal(await h.page.evaluate(() => localStorage.getItem("romp:fileviewFmt")), null, "the preference was never written");
+    // the row is scrolled to the body's centre (scrollIntoView block center), so the centred row is row 30 ITSELF: a
+    // neighbour would be a row's height off, and merely being in view would not tell them apart
+    const at = await h.centerOffset("#romp-fileview code.hljs .fv-cl:nth-child(30)");
+    assert.ok(at && Math.abs(at.d) <= at.h / 2 + 1, "row 30 is the centred row, not a neighbour: " + JSON.stringify(at));
+    assert.equal(await h.page.evaluate(() => !!document.getElementById("fileview-save-err")), false, "no notice: the line exists");
+  });
+});
+
+test("in a browser: the rendered Markdown's links are sorted after the real sanitizer (a same-directory name.ext:line and a local file:// target survive as path links, a far file:// and a host with a port are dead links that say why, a section link scrolls the document under a plain and a middle click, an author's id is read under the sanitizer's prefix, a document's own data-* never reach the page), and a line past the end says so", async (t) => {
+  await inBrowser(t, "viewer", async (h) => {
+    await h.open(GUIDE);
+    const byText = async (text: string): Promise<Info> => {
+      const all = await h.linkInfo("#romp-fileview .fileview-md a");
+      const hit = all.find((a) => a.text === text);
+      assert.ok(hit, "an anchor labelled " + text);
+      return hit!;
+    };
+    const same = await byText("same");
+    assert.equal(same.path, NOTES); assert.equal(same.line, "7"); assert.equal(same.href, null, "the href comes off a path link");
+    const uri = await byText("uri"); assert.equal(uri.path, README);
+    const far = await byText("far"); assert.equal(far.title, DEAD_LINK_TITLE); assert.equal(far.href, null); assert.ok(far.cls.includes("fv-dead"));
+    const ip = await byText("ip"); assert.equal(ip.title, HOST_PORT_TITLE); assert.equal(ip.href, null); assert.equal(ip.path, undefined);
+    const api = await byText("api"); assert.equal(api.title, DEAD_LINK_TITLE, "a letter-led host:port reads as a scheme to the sanitizer, which strips it first: the generic title");
+    const spec = await byText("spec"); assert.equal(spec.path, ROOT + "/docs/app.test.ts"); assert.equal(spec.line, "12");
+    const web = await byText("the web"); assert.equal(web.target, "_blank"); assert.equal(web.href, "https://example.invalid/doc");
+    const q = await byText("q"); assert.equal(q.target, "_blank"); assert.equal(q.href, "?foo=1");
+    const here = await byText("here"); assert.ok(here.cls.includes("fv-frag") && here.cls.includes("fv-dead")); assert.equal(here.title, noSectionTitle("section"));
+    for (const [label, frag] of [["results", "results"], ["go", "top"], ["install", "install"], ["collide", "fileview-save-err"]] as const) {
+      const a = await byText(label); assert.ok(a.cls.includes("fv-frag") && !a.cls.includes("fv-dead"), label + ": " + a.cls); assert.equal(a.frag, frag);
+    }
+    const self = await byText("self"); assert.equal(self.path, GUIDE); assert.equal(self.frag, "install");
+    // the sanitizer's verdict on an author's own id and name: prefixed user-content- (md-sanitize.ts); the links above are live because the lookup reads the prefix
+    assert.equal(await h.page.evaluate(() => [!!document.querySelector('#romp-fileview .fileview-md [id="user-content-top"]'), !!document.querySelector('#romp-fileview .fileview-md [id="top"]'), !!document.querySelector('#romp-fileview .fileview-md a[name="user-content-install"]')].join()), "true,false,true", "an author's id and name reach the DOM prefixed, and only prefixed");
+    // a document's own element dressed as a path link: the class survives, its data-* do not, so it names no file
+    assert.deepEqual((await h.linkInfo("#romp-fileview .fileview-md span.file-uri-link:not([data-path])")).map((d) => [d.text, d.path, d.line]), [["dressed", undefined, undefined]], "the sanitizer dropped data-path and data-line");
+    // the prose and the fence: bare paths under the viewer's gate, URLs as anchors, the SVG's label untouched and its anchors sorted
+    const spans = await h.linkInfo("#romp-fileview .fileview-md span.file-uri-link[data-path]");
+    assert.deepEqual(linkTexts(spans), ["../src/app.py:3", "docs/first.md", "docs/second.md", "docs/from.md", "out/data.json", "docs/strong.md", "docs/em.md", "docs/zwsp.md", "data/x.json", "docs/fence2.md", "./docs/fence3.md"],
+      "a soft-broken line's first path, the line after a <br>, the English from and export, emphasis, a zero-width space, the fence's lines; no glob, no operand, no SVG label");
+    assert.deepEqual((await h.linkInfo("#romp-fileview .fileview-md a.fv-url")).map((u) => u.href), ["https://example.invalid/dl"], "the fence's URL is the pass's; the prose's is marked's own autolink, not wrapped twice");
+    const prose = (await h.linkInfo("#romp-fileview .fileview-md a")).find((a) => a.href === "https://example.invalid/prose");
+    assert.ok(prose && prose.target === "_blank" && !prose.cls.includes("fv-url"), "marked's autolink, sorted as a web link");
+    const svgFile = await byText("svgfile"); assert.ok(svgFile.cls.includes("file-uri-link"), "an SVG <a> is marked through attributes"); assert.equal(svgFile.path, ROOT + "/docs/x.md");
+    const svgWeb = await byText("svgweb"); assert.equal(svgWeb.target, "_blank");
+    // a section link scrolls THIS document, never the page: the heading by its minted slug, an author's id spelled like the viewer's notice (under its prefix, so it is no longer the same id)
+    assert.equal(await h.inView("#romp-fileview #md-results"), false, "the heading starts out of view");
+    await h.page.locator("#romp-fileview .fileview-md a", { hasText: "results" }).first().click();
+    assert.equal(await h.inView("#romp-fileview #md-results"), true, "scrolled to the heading");
+    assert.equal(await h.page.evaluate(() => location.hash), "", "the page's own location did not move");
+    await h.page.locator("#romp-fileview .fileview-md a", { hasText: "collide" }).click();
+    assert.equal(await h.inView('#romp-fileview .fileview-md [id="user-content-fileview-save-err"]'), true, "the document's own element of that id, under the sanitizer's prefix, not the viewer's notice");
+    // a middle-click on a section link is this document's scroll too, to the named anchor, and no tab (the browser's own middle-click would open a second copy of the page)
+    await h.page.evaluate(() => { document.querySelector("#romp-fileview .fileview-body")!.scrollTop = 0; });
+    assert.equal(await h.inView("#romp-fileview #md-install"), false, "the last heading starts out of view");
+    await h.page.locator("#romp-fileview .fileview-md a", { hasText: "install" }).first().click({ button: "middle" });
+    assert.equal(await h.inView("#romp-fileview #md-install"), true, "the middle-click scrolled to the named anchor above the heading");
+    // the dressed span: a click on it opens nothing and fetches nothing (checked below, once the next fetch has landed)
+    const servedBefore = h.served.length;
+    await h.page.locator("#romp-fileview .fileview-md span.file-uri-link", { hasText: "dressed" }).click();
+    assert.equal(await h.base(), "guide.md", "the viewer stays on the guide");
+    // a line past the end: the file opens, lands on its last row, and the notice says so
+    await h.page.locator("#romp-fileview .fileview-md a", { hasText: "past" }).click();
+    await h.page.locator("#romp-fileview .fileview-base", { hasText: "app.py" }).waitFor({ timeout: 10000 });
+    await h.page.locator("#fileview-save-err").waitFor({ timeout: 10000 });
+    assert.match(await h.page.evaluate(() => document.getElementById("fileview-save-err")!.textContent || ""), /^Line 400 is past the end of this file, which has 7 lines; showing the last line\.$/);
+    assert.equal(await h.inView("#romp-fileview code.hljs .fv-cl:last-child"), true);
+    assert.deepEqual(h.served.slice(servedBefore), [APP], "the dressed span fetched nothing; the past link fetched the one file it named");
+    assert.equal(h.newPages().length, 0, "no click in this document opened a tab: the middle-click on the section link was this document's scroll alone");
+  });
+});
+
+test("in a browser: the gesture: a Cmd-click or a middle-click on a path link opens the file in a tab of its own off the /file route and leaves the viewer where it was; a plain click on a URL anchor opens the URL in a tab; a drag that selects text inside a link, or that runs into one, opens nothing", async (t) => {
+  await inBrowser(t, "viewer", async (h) => {
+    await h.open(APP);
+    const cfg = h.page.locator('#romp-fileview .file-uri-link[data-path$="config.json"]');
+    await Promise.all([h.ctx.waitForEvent("page", { timeout: 10000 }), cfg.click({ modifiers: ["Meta"] })]);
+    await Promise.all([h.ctx.waitForEvent("page", { timeout: 10000 }), cfg.click({ button: "middle" })]);
+    assert.equal(h.newPages().length, 2, "one tab per modified click");
+    for (const p of h.newPages()) assert.match(p.url(), /^http:\/\/romp\.test\/file\?path=%2Ftmp%2FTESTHOST%2Fnotes-api%2Fsrc%2Fdata%2Fconfig\.json&sid=/);
+    assert.equal(await h.base(), "app.py", "the viewer stays on the file it showed");
+    await Promise.all([h.ctx.waitForEvent("page", { timeout: 10000 }), h.page.locator("#romp-fileview a.fv-url").click()]);
+    assert.equal(h.newPages()[2].url(), URL_SETUP, "the URL anchor's own tab");
+    assert.equal(await h.base(), "app.py");
+    // a press-drag-release INSIDE the guide link (its left edge to its middle) selects its text, and the click that ends
+    // it (the press and the release both on the link, so the link is the click's target) opens nothing: the viewer's
+    // listener finds the selection open and yields
+    const before = h.served.length;
+    const guide30 = '#romp-fileview .file-uri-link[data-line="30"]';
+    await dragSelect(h.page, guide30, guide30);
+    const picked = await h.page.evaluate(() => String(window.getSelection()));
+    assert.ok(picked.length > 0 && "../docs/guide.md:30".includes(picked), "the drag selected text inside the link: " + JSON.stringify(picked));
+    assert.equal(await h.base(), "app.py", "the click that ended the drag opened nothing");
+    // a drag from the row's start into the link: the browser sends that click to the elements' common ancestor, so no
+    // link sees it, and nothing opens either way
+    await dragSelect(h.page, "#romp-fileview code.hljs .fv-cl:nth-child(1) .fv-ct", guide30);
+    assert.ok((await h.page.evaluate(() => String(window.getSelection()))).length > 0, "the drag selected text");
+    // the plain click after either drag does open: its press collapses the selection first
+    await cfg.click();
+    await h.page.locator("#romp-fileview .fileview-base", { hasText: "config.json" }).waitFor({ timeout: 10000 });
+    assert.deepEqual(h.served.slice(before), [CONFIG], "neither drag fetched anything; the click that followed fetched the one file it named");
+    assert.equal(h.newPages().length, 3);
+  });
+});
+
+test("in a browser, under the chat's own anchor opener: a triple-click on a chat paragraph then a click on its link opens one tab (a chat anchor is draggable, so the selection around it is no drag on it); a click on the viewer's URL anchor while text is selected inside it opens nothing, and the plain click after it opens one tab", async (t) => {
+  await inBrowser(t, "chat", async (h) => {
+    await h.page.locator("#chat-para").click({ clickCount: 3 });
+    assert.ok((await h.page.evaluate(() => String(window.getSelection()))).includes("alpha beta gamma delta"), "the paragraph is selected, the anchor's text inside it");
+    await Promise.all([h.ctx.waitForEvent("page", { timeout: 10000 }), h.page.locator("#chat-para a").click()]);
+    assert.equal(h.newPages().length, 1, "one tab, from the chat's opener alone");
+    assert.equal(h.newPages()[0].url(), "https://example.invalid/pr");
+    await h.open(APP);
+    // a selection inside the viewer's URL anchor, open when the click arrives: what a press held on the anchor and then
+    // dragged leaves (Chromium starts no selection under an immediate drag on a link, and the hold is a clock this leg
+    // does not read), so the selection is made by script, over the anchor's whole text (a press OUTSIDE the selected
+    // range collapses it at once, and the click lands on the anchor's middle); the capture-phase opener yields to it,
+    // and so does the viewer
+    await h.page.evaluate(() => { const tn = document.querySelector("#romp-fileview a.fv-url")!.firstChild as Text; window.getSelection()!.setBaseAndExtent(tn, 0, tn, tn.length); });
+    assert.equal(await h.page.evaluate(() => String(window.getSelection())), URL_SETUP, "the selection is the anchor's text");
+    await h.page.locator("#romp-fileview a.fv-url").click();
+    // the plain click after it, its press elsewhere having collapsed the selection, opens one tab, not two
+    await h.page.locator("#romp-fileview code.hljs .fv-cl:nth-child(2) .fv-ct").click();
+    await Promise.all([h.ctx.waitForEvent("page", { timeout: 10000 }), h.page.locator("#romp-fileview a.fv-url").click()]);
+    assert.equal(h.newPages().length, 2, "the click under the open selection opened nothing (the capture-phase opener yielded to it); the plain click opened one tab");
+    assert.equal(h.newPages()[1].url(), URL_SETUP);
+    // a plain click on a path link is not stopped: the document's own listeners still see it
+    await h.page.locator('#romp-fileview .file-uri-link[data-path$="config.json"]').click();
+    await h.page.locator("#romp-fileview .fileview-base", { hasText: "config.json" }).waitFor({ timeout: 10000 });
+    assert.ok((await h.page.evaluate(() => (window as any).__windowClicks as string[])).includes("data/config.json"), "the click went on to the window's listener");
+    // the viewer's own section links stay the viewer's under the chat's opener (its fragment arm reads a message's body, which the viewer is not in): the document scrolls, the page's location does not move
+    await h.open(GUIDE);
+    assert.equal(await h.inView('#romp-fileview .fileview-md [id="user-content-top"]'), false, "the author's element starts out of view");
+    await h.page.locator("#romp-fileview .fileview-md a", { hasText: "go" }).first().click();
+    assert.equal(await h.inView('#romp-fileview .fileview-md [id="user-content-top"]'), true, "the viewer landed its own section link, under the sanitizer's prefix");
+    assert.equal(await h.page.evaluate(() => location.hash), "", "the page's own location did not move");
+  });
+});

--- a/ui/webview/file-view-links.test.ts
+++ b/ui/webview/file-view-links.test.ts
@@ -1,0 +1,864 @@
+// Links inside a file the viewer shows (file-view-links.ts): URLs become anchors that open a new tab, paths become
+// the chat's path links resolved against the shown file, a Markdown link's target follows the same two rules, and the
+// text of every row reads exactly as the file's after the pass. The grammar and the pass run for real over a small DOM
+// stand-in (the path-links.test.ts idiom, grown to what the pass touches: elements with attributes, a selector engine
+// for closest and querySelectorAll, fragments). The viewer's wiring (where the pass runs, the body's listener and its
+// gesture, the line scroll, the sheets) is pinned at source; the browser leg, where the sanitizer, the highlighter and
+// the pointer are real, is file-view-links-browser.test.ts. Synthetic fixtures only: the notes-api world under
+// /tmp/TESTHOST, a placeholder session id, example.invalid addresses.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const read = (f: string) => fs.readFileSync(path.join(UI, f), "utf8");
+const VIEW = read("file-view.ts");
+const LINKS = read("path-links.ts");
+const MOD = read("file-view-links.ts");
+const RENDER = read("render.ts");
+const PREVIEW = read("preview.ts");
+const CHAT_CSS = read("styles.css");
+const FEED_CSS = read("feed.css");
+
+const SID = "11111111-2222-3333-4444-555555555555";
+const FILE = "/tmp/TESTHOST/notes-api/src/app.py";
+const DIR = "/tmp/TESTHOST/notes-api/src/";
+
+// ── a DOM stand-in: text nodes, elements with attributes, a selector engine, fragments ────────────
+type Compound = { tag: string | null; classes: string[]; attrs: Array<[string, string | null]> };
+function parseSel(sel: string): Compound[][] {
+  return sel.split(",").map((g) => g.trim()).filter(Boolean).map((g) => g.split(/\s+/).map((s) => {
+    const m = /^([a-zA-Z][\w-]*)?((?:\.[\w-]+)*)((?:\[[\w-]+(?:="[^"]*")?\])*)$/.exec(s);
+    if (!m) throw new Error("stand-in: unsupported selector " + s);
+    const classes = (m[2].match(/\.[\w-]+/g) || []).map((c) => c.slice(1));
+    const attrs: Array<[string, string | null]> = [];
+    for (const a of m[3].match(/\[[^\]]+\]/g) || []) { const am = /^\[([\w-]+)(?:="([^"]*)")?\]$/.exec(a)!; attrs.push([am[1], am[2] ?? null]); }
+    return { tag: m[1] ? m[1].toUpperCase() : null, classes, attrs };
+  }));
+}
+class Txt {
+  nodeType = 3;
+  parentNode: El | null = null;
+  constructor(public data: string) {}
+  get textContent(): string { return this.data; }
+  get parentElement(): El | null { return this.parentNode; }
+  get ownerDocument(): typeof doc { return doc; }
+  replaceWith(n: El | Txt | Frag): void {
+    const p = this.parentNode!;
+    const i = p.childNodes.indexOf(this);
+    const kids = n instanceof Frag ? n.childNodes.slice() : [n];
+    for (const k of kids) { if (k.parentNode) k.parentNode.removeChild(k); k.parentNode = p; }
+    p.childNodes.splice(i, 1, ...kids);
+    this.parentNode = null;
+  }
+}
+class Frag { childNodes: Array<El | Txt> = []; appendChild(c: El | Txt): void { this.childNodes.push(c); } }
+const kebab = (k: string) => k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+class El {
+  nodeType = 1;
+  tagName: string;
+  parentNode: El | null = null;
+  childNodes: Array<El | Txt> = [];
+  attrs = new Map<string, string>();
+  role: string | null = null;
+  onkeydown: unknown = null; onmousedown: unknown = null; onmouseup: unknown = null; onmouseleave: unknown = null; oncontextmenu: unknown = null; ondragstart: unknown = null;
+  constructor(tag: string) { this.tagName = tag.toUpperCase(); }
+  get ownerDocument(): typeof doc { return doc; }
+  get parentElement(): El | null { return this.parentNode; }
+  // reflected attributes, as the DOM has them
+  get className(): string { return this.attrs.get("class") || ""; } set className(v: string) { this.attrs.set("class", v); }
+  get title(): string { return this.attrs.get("title") || ""; } set title(v: string) { this.attrs.set("title", v); }
+  get href(): string { return this.attrs.get("href") || ""; } set href(v: string) { this.attrs.set("href", v); }
+  get target(): string { return this.attrs.get("target") || ""; } set target(v: string) { this.attrs.set("target", v); }
+  get rel(): string { return this.attrs.get("rel") || ""; } set rel(v: string) { this.attrs.set("rel", v); }
+  get tabIndex(): number { return this.attrs.has("tabindex") ? Number(this.attrs.get("tabindex")) : -1; } set tabIndex(v: number) { this.attrs.set("tabindex", String(v)); }
+  get classes(): string[] { return this.className.split(/\s+/).filter(Boolean); }
+  classList = { add: (...c: string[]) => { const s = new Set(this.classes); for (const x of c) s.add(x); this.className = [...s].join(" "); }, contains: (c: string) => this.classes.includes(c) };
+  dataset: Record<string, string> = new Proxy({} as Record<string, string>, {
+    get: (_, k) => this.attrs.get("data-" + kebab(String(k))) as string,
+    set: (_, k, v) => { this.attrs.set("data-" + kebab(String(k)), String(v)); return true; },
+    has: (_, k) => this.attrs.has("data-" + kebab(String(k))),
+  });
+  get textContent(): string { return this.childNodes.map((c) => c.textContent).join(""); }
+  set textContent(v: string) { for (const c of this.childNodes) c.parentNode = null; this.childNodes = []; if (v !== "") this.appendChild(new Txt(v)); }
+  private detach(n: El | Txt): void { const p = n.parentNode; if (p) { const i = p.childNodes.indexOf(n); if (i >= 0) p.childNodes.splice(i, 1); n.parentNode = null; } }
+  appendChild<T extends El | Txt>(n: T): T { this.detach(n); this.childNodes.push(n); n.parentNode = this; return n; }
+  insertBefore<T extends El | Txt>(n: T, ref: El | Txt | null): T {
+    if (!ref) return this.appendChild(n);
+    this.detach(n);
+    const i = this.childNodes.indexOf(ref);
+    this.childNodes.splice(i < 0 ? this.childNodes.length : i, 0, n); n.parentNode = this; return n;
+  }
+  removeChild<T extends El | Txt>(n: T): T { this.detach(n); return n; }
+  setAttribute(k: string, v: string): void { this.attrs.set(k, v); }
+  getAttribute(k: string): string | null { return this.attrs.has(k) ? (this.attrs.get(k) as string) : null; }
+  hasAttribute(k: string): boolean { return this.attrs.has(k); }
+  removeAttribute(k: string): void { this.attrs.delete(k); }
+  contains(n: El | Txt | null): boolean { for (let x: El | Txt | null = n; x; x = x.parentNode) if (x === this) return true; return false; }
+  private fits(c: Compound): boolean {
+    return (!c.tag || c.tag === this.tagName) && c.classes.every((k) => this.classes.includes(k))
+      && c.attrs.every(([a, v]) => this.attrs.has(a) && (v === null || this.attrs.get(a) === v));
+  }
+  matches(sel: string): boolean {
+    return parseSel(sel).some((chain) => {
+      if (!this.fits(chain[chain.length - 1])) return false;
+      let k = chain.length - 2;
+      for (let a: El | null = this.parentNode; a && k >= 0; a = a.parentNode) if (a.fits(chain[k])) k--;
+      return k < 0;
+    });
+  }
+  closest(sel: string): El | null { for (let x: El | null = this; x; x = x.parentNode) if (x.matches(sel)) return x; return null; }
+  querySelectorAll(sel: string): El[] {
+    const out: El[] = [];
+    const visit = (n: El) => { for (const c of n.childNodes) if (c instanceof El) { if (c.matches(sel)) out.push(c); visit(c); } };
+    visit(this);
+    return out;
+  }
+  querySelector(sel: string): El | null { return this.querySelectorAll(sel)[0] || null; }
+}
+function textNodesOf(root: El): Txt[] {
+  const out: Txt[] = [];
+  const walk = (n: El) => { for (const c of n.childNodes) { if (c instanceof Txt) out.push(c); else walk(c); } };
+  walk(root);
+  return out;
+}
+/** Document-order nodes under `root`, as a browser's tree walker answers: the text nodes, and the elements too when
+ *  SHOW_ELEMENT was asked for (textUnits asks, to see a <br> between two text nodes). */
+function walkNodes(root: El, what: number): Array<El | Txt> {
+  const out: Array<El | Txt> = [];
+  const walk = (n: El) => { for (const c of n.childNodes) { if (c instanceof Txt) { if (what & 4) out.push(c); } else { if (what & 1) out.push(c); walk(c); } } };
+  walk(root);
+  return out;
+}
+const doc = {
+  createElement: (tag: string) => new El(tag),
+  createTextNode: (s: string) => new Txt(s),
+  createDocumentFragment: () => new Frag(),
+  createTreeWalker: (root: El, what = 4) => { const nodes = walkNodes(root, what); let i = 0; return { nextNode: () => (i < nodes.length ? nodes[i++] : null) }; },
+  activeElement: null as El | null,
+};
+(globalThis as any).NodeFilter = { SHOW_ELEMENT: 1, SHOW_TEXT: 4 };
+(globalThis as any).document = doc;
+
+// ── builders: what codeBlock's DOM looks like (one .fv-cl row per line, hljs spans inside) ─────────
+const el = (tag: string, cls?: string, ...kids: Array<El | Txt | string>): El => {
+  const e = new El(tag); if (cls) e.className = cls;
+  for (const k of kids) e.appendChild(typeof k === "string" ? new Txt(k) : k);
+  return e;
+};
+const row = (...kids: Array<El | Txt | string>): El => el("span", "fv-cl", el("span", "fv-ct", ...kids));
+const code = (...rows: El[]): El => el("code", "hljs", ...rows);
+const links = (root: El) => root.querySelectorAll(".file-uri-link");
+const urls = (root: El) => root.querySelectorAll("a.fv-url");
+
+// ── the URL grammar ───────────────────────────────────────────────────────────────────────────────
+test("urlSegments: http and https URLs, trailing sentence punctuation left out, a paren balanced inside kept, one closing the sentence's not", async () => {
+  const { urlSegments } = await import("./file-view-links");
+  const hrefs = (s: string) => urlSegments(s).filter((x) => x.href).map((x) => x.href);
+  assert.deepEqual(hrefs("see https://example.invalid/a/b?x=1&y=2 now"), ["https://example.invalid/a/b?x=1&y=2"]);
+  assert.deepEqual(hrefs("plain http://example.invalid:8080/p too"), ["http://example.invalid:8080/p"]);
+  assert.deepEqual(hrefs("HTTPS://EXAMPLE.invalid/X"), ["HTTPS://EXAMPLE.invalid/X"], "the scheme's case is the browser's business");
+  assert.deepEqual(hrefs("ends https://example.invalid/a."), ["https://example.invalid/a"]);
+  assert.deepEqual(hrefs("ends https://example.invalid/a, then"), ["https://example.invalid/a"]);
+  assert.deepEqual(hrefs("ends https://example.invalid/a?q=1!?"), ["https://example.invalid/a?q=1"]);
+  assert.deepEqual(hrefs("(see https://example.invalid/a/b)"), ["https://example.invalid/a/b"], "the sentence's paren");
+  assert.deepEqual(hrefs("(see https://example.invalid/a/b)."), ["https://example.invalid/a/b"]);
+  assert.deepEqual(hrefs("https://example.invalid/wiki/Foo_(bar) x"), ["https://example.invalid/wiki/Foo_(bar)"], "a paren opened inside the URL closes inside it");
+  assert.deepEqual(hrefs("[https://example.invalid/a]"), ["https://example.invalid/a"]);
+  assert.deepEqual(hrefs("<https://example.invalid/a>"), ["https://example.invalid/a"], "an autolink's angle brackets");
+  assert.deepEqual(hrefs('url = "https://example.invalid/api/v1"'), ["https://example.invalid/api/v1"], "a quoted string in code");
+  assert.deepEqual(hrefs("url = 'https://example.invalid/x'; y = `https://example.invalid/z`"), ["https://example.invalid/x", "https://example.invalid/z"]);
+  // not URLs: a bare scheme, a scheme with no host, other schemes, a hostname alone
+  for (const s of ["https://", "http:// x", "https:///nohost", "ftp://example.invalid/a", "example.invalid/a/b.html", "file:///tmp/TESTHOST/a.md"]) {
+    assert.deepEqual(hrefs(s), [], s);
+  }
+  // the runs reassemble to the text, always
+  for (const s of ["a https://example.invalid/x) b http://y.invalid/z. c", "no urls here", "", "https://example.invalid/(a)(b))"]) {
+    assert.equal(urlSegments(s).map((x) => x.text).join(""), s, JSON.stringify(s));
+  }
+  assert.deepEqual(hrefs("https://example.invalid/(a)(b))"), ["https://example.invalid/(a)(b)"], "two balanced pairs kept, the extra closer left");
+});
+
+test("urlRanges: the [start, end) of each URL urlSegments would wrap, trailing punctuation left out; none in text without a scheme", async () => {
+  const { urlRanges, urlSegments } = await import("./file-view-links");
+  const t = "see https://example.invalid/a, then (https://example.invalid/b) and https://";
+  assert.deepEqual(urlRanges(t), [[4, 29], [37, 62]]);
+  for (const [s, e] of urlRanges(t)) assert.ok(urlSegments(t).some((x) => x.href === t.slice(s, e)), t.slice(s, e));
+  assert.deepEqual(urlRanges("docs/a.md and x=/docs/b.md"), []);
+});
+
+// ── the path gate and the resolution ─────────────────────────────────────────────────────────────
+test("viewerPathGate, the token alone: a slash and a letter-led extension on the last segment; anchored dotfiles; a hostname-shaped first segment and a `~user` home are refused", async () => {
+  const { viewerPathGate } = await import("./file-view-links");
+  for (const p of ["docs/a.md", "ui/webview/x.ts", "/tmp/TESTHOST/notes-api/a.py", "~/notes/plan.md", "./x.py", "../y.ts", "~/.zshrc", "./.env",
+                   "file:///tmp/TESTHOST/a.pdf", "file://localhost/tmp/TESTHOST/a.pdf", "a/b.h5", "img/photo.jpeg", "data/out.tar.gz", "src/mod.d.ts",
+                   "a.b/c.md", "notes.d/x.md"]) {
+    assert.equal(viewerPathGate(p), true, p);
+  }
+  for (const p of ["./foo", "/api/users", "/usr/bin", "~/code", "1/2.5", "and/or", "TCP/IP", "config/.env", "kernel.py", "a/b.123",
+                   "img/photo.jpeg2000x", "x/y", "react/jsx-runtime", "a/b.", "../", "./",
+                   "www.example.org/docs/index.html", "WWW.example.org/x.html", "example.com/index.html", "docs.example.invalid/a.md", "sub.example.co.uk/a/b.md",
+                   "~user/x.md", "~user/.zshrc"]) {
+    assert.equal(viewerPathGate(p), false, p);
+  }
+});
+
+test("viewerPathGate, with the line: a token glued to what stands before it (a substitution, a scope, a drive, a host) is not one; an unanchored token named by an import statement or a require call is not one, while the English from and export in prose name files; an opener (a quote, a bracket, whitespace of every kind, Markdown's * closed by a * after the path) or the line's start admits it; a glob's tail after a star, an operand after one and a hand-split import's specifier are refused", async () => {
+  const { viewerPathGate } = await import("./file-view-links");
+  const at = (text: string, tok: string) => ({ text, at: text.indexOf(tok) });
+  for (const [text, tok] of [
+    ['cp "$HOME/docs/a.md" ./out/', "HOME/docs/a.md"], ["cat ${ROOT}/src/x.py", "/src/x.py"], ["SRC = $(ROOT)/src/main.c", "/src/main.c"],
+    ["const s = `${dir}/out.json`;", "/out.json"], ['f"{base}/out.csv"', "/out.csv"], ["path: ${HOME}/notes/a.md", "/notes/a.md"],
+    ['import x from "@scope/pkg/dist/index.js";', "scope/pkg/dist/index.js"], ["C:/Users/x/file.txt", "/Users/x/file.txt"],
+    ["git clone git@github.invalid:user/repo.git", "user/repo.git"], ["a%s/x.md", "s/x.md"], ["x#/docs/a.md", "/docs/a.md"],
+    ['import b from "lodash/fp.js";', "lodash/fp.js"], ['const x = require("pkg/sub.js");', "pkg/sub.js"], ['export * from "pkg/sub.js";', "pkg/sub.js"],
+    ['import "pkg/x.css";', "pkg/x.css"], ["const m = await import('pkg/m.mjs');", "pkg/m.mjs"],
+    ['x = 1\nimport b from "lodash/fp.js";', "lodash/fp.js"], ['a\n  const m = require(  "pkg/m.js");', "pkg/m.js"], ['a\nexport * from\t"pkg/x.js";', "pkg/x.js"],
+    ['$import("pkg/y.js")', "pkg/y.js"],   // a non-word character before the keyword is a word boundary
+    // the statement forms: a keyword starting its line, a `from` whose line began with import or export, the `}` line of a multi-line import
+    ['  import "pkg/x.css";', "pkg/x.css"], ['import type { X } from "pkg/t.js";', "pkg/t.js"], ['export { a as b } from "pkg/x.js";', "pkg/x.js"],
+    ['} from "pkg/x.js";', "pkg/x.js"], ['import {\n  a,\n} from "pkg/x.js";', "pkg/x.js"], ['x = 1\n  } from "pkg/x.js";', "pkg/x.js"], ['require "pkg/x.rb"', "pkg/x.rb"],
+    // a multi-line import whose closing line carries names, or whose `from` starts a continuation line
+    ['import {\n  a, b } from "pkg/x.js";', "pkg/x.js"], ['import { a }\n  from "pkg/x.js";', "pkg/x.js"], ['export {\n  a,\n  b } from "pkg/x.js";', "pkg/x.js"],
+    ['import type {\n  T } from "pkg/t.js";', "pkg/t.js"], ['x = 1\nimport {\n  a,\n  b as c,\n  d } from "pkg/x.js";', "pkg/x.js"],
+    // a hand-split import whose `from` starts the next line, under a namespace, a default name alone, a star or a type list: the line is `from` and a specifier
+    ['import * as ns\n  from "pkg/ns.js";', "pkg/ns.js"], ['import React\n  from "react/def.js";', "react/def.js"], ['export *\n  from "pkg/star.js";', "pkg/star.js"], ['export type { T }\n  from "pkg/t.js"', "pkg/t.js"],
+    ["import * as ns\n  from 'pkg/ns.js'", "pkg/ns.js"], ['Copied\nthe text\nfrom "docs/a.md"', "docs/a.md"],   // the shape alone decides, so a prose line of exactly `from "…"` is the rule's one price
+    // a glob's tail after a star, and an operand after one: `*` opens a token only when it is not `/`-led and a closing `*` follows
+    ["find . -path '**/docs/a.md'", "/docs/a.md"], ["cp src/**/index.ts out/", "/index.ts"], ["ls packages/*/package.json", "/package.json"], ['"**/tsconfig.json"', "/tsconfig.json"],
+    ["x = '*/docs/a.md*'", "/docs/a.md"], ["area = w*h/img.size", "h/img.size"], ["echo 2*docs/times.md", "docs/times.md"], ["*docs/a.md", "docs/a.md"], ["a*docs/b.md, c", "docs/b.md"],
+    ["**/etc/hosts.txt**", "/etc/hosts.txt"],   // a `/`-led token after a star is a glob's tail whatever closes it
+    // emphasis that holds more than the path: the path glued to the opening star has no closing star of its own (a known limit)
+    ["**docs/a.md and docs/b.md**", "docs/a.md"], ["*docs/c.md (old)*", "docs/c.md"], ["*docs/a.md.*", "docs/a.md"],
+  ] as const) {
+    assert.equal(viewerPathGate(tok, at(text, tok)), false, text);
+  }
+  // glue the openers do not admit: a closing paren, a colon, a hash (the shapes above: `$(ROOT)/src/x.c`, `git@host:user/repo.git`, `x#/docs/a.md`)
+  for (const [text, tok] of [[")docs/a.md", "docs/a.md"], ["x:docs/a.md", "docs/a.md"], ["#docs/a.md", "docs/a.md"], ["]docs/a.md", "docs/a.md"]] as const) {
+    assert.equal(viewerPathGate(tok, at(text, tok)), false, JSON.stringify(text));
+  }
+  for (const [text, tok] of [
+    ['cp "docs/a.md" ./out/', "docs/a.md"], ["see docs/a.md here", "docs/a.md"], ["docs/a.md", "docs/a.md"], ["x=/docs/a.md", "/docs/a.md"],
+    ["(see /docs/a.md)", "/docs/a.md"], ["[docs/a.md]", "docs/a.md"], ['<img src="docs/a.png">', "docs/a.png"], ["a, docs/a.md", "docs/a.md"],
+    ["\tdocs/a.md", "docs/a.md"], ["a|docs/a.md", "docs/a.md"], ["{docs/a.md}", "docs/a.md"],
+    ['import s from "./app.css";', "./app.css"], ['import b from "../lib/util.js";', "../lib/util.js"], ['<script src="lib/x.js">', "lib/x.js"],
+    ["open(~/notes/a.md)", "~/notes/a.md"], ["readme = 'file:///tmp/TESTHOST/README.md'", "file:///tmp/TESTHOST/README.md"],
+    ["See the plan in\ndocs/plan.md", "docs/plan.md"], ["x = 1\ndocs/a.md", "docs/a.md"], ["a\r\ndocs/a.md", "docs/a.md"], ["then\u00a0docs/a.md", "docs/a.md"],   // a line break or a no-break space before it is whitespace
+    ['reimport("pkg/x.js")', "pkg/x.js"],                        // no word boundary before `import`: not the keyword
+    ['import b from\n"lodash/fp.js";', "lodash/fp.js"],          // the quote starts a new line: the look-behind is the line's, and no formatter writes this
+    // the English words: a quote from a file, a stale export, a `require` mid-sentence, a `from` that starts a line with no import before it
+    ['a quote from "docs/from.md" says', "docs/from.md"], ['the export "out/data.json" is stale', "out/data.json"], ['they require "docs/a.md" to exist', "docs/a.md"],
+    ['from "pkg/sub.py" import x', "pkg/sub.py"], ['Copied the text\nfrom "docs/a.md" and kept it', "docs/a.md"], ['const x = 1; import y from "pkg/x.js"', "pkg/x.js"],
+    // Markdown emphasis in the Raw view, and the spaces \s names beyond the ASCII ones, plus the zero-width space
+    ["*docs/a.md*", "docs/a.md"], ["**docs/a.md**", "docs/a.md"], ["*docs/a.md:12* then", "docs/a.md"], ["see **docs/a.md**.", "docs/a.md"],
+    // …around an anchored path too: no glob puts `./`, `../` or `~/` after its star
+    ["**./scripts/setup.sh** runs first", "./scripts/setup.sh"], ["then *../src/app.py* is read", "../src/app.py"], ["*~/notes/a.md*", "~/notes/a.md"], ["**./docs/a.md:12**", "./docs/a.md"],
+    // …and the second path of a span that holds two, opened by the space before it
+    ["**docs/a.md and docs/b.md**", "docs/b.md"],
+    // a whole statement above an English from in one unit (a fenced block): Python's import, a shell's export, a finished export
+    ['import os\n# adapted from "docs/a.md"', "docs/a.md"], ['export DATA=/data\n# copied from "docs/c.md"', "docs/c.md"], ['export const z = 2;\n// from "docs/d.md"', "docs/d.md"],
+    ['export function build() {\n  // ported from "docs/algo.md"', "docs/algo.md"], ['import numpy as np\nimport os\n# data from "data/raw.csv"', "data/raw.csv"],
+    // the English from with more after its path: Python's, a sentence's
+    ['x = 1\n\nfrom "pkg/sub.py" import y', "pkg/sub.py"], ['import "x.css";\nfrom "docs/a.md" we copied', "docs/a.md"], ['Copied\nthe text\nfrom "docs/a.md" too', "docs/a.md"],
+    ["\u200bdocs/a.md", "docs/a.md"], ["\fdocs/a.md", "docs/a.md"], ["\u2003docs/a.md", "docs/a.md"], ["\u2028docs/a.md", "docs/a.md"], ["\ufeffdocs/a.md", "docs/a.md"], ["\u3000docs/a.md", "docs/a.md"],
+  ] as const) {
+    assert.equal(viewerPathGate(tok, at(text, tok)), true, JSON.stringify(text));
+  }
+  // `_` is not an opener: the matcher's path arm takes an underscore into the token, so the gate never sees one before a token.
+  // `_docs/a.md_` is one token whose extension (`md_`) fails, and `_docs/a.md` names a folder called `_docs`
+  const { CLICKABLE_PATH_RE } = await import("./path-links");
+  assert.deepEqual("_docs/a.md_ and *docs/b.md*".match(CLICKABLE_PATH_RE), ["_docs/a.md_", "docs/b.md"], "the scanner's tokens");
+  assert.equal(viewerPathGate("_docs/a.md_"), false); assert.equal(viewerPathGate("_docs/a.md"), true);
+  assert.equal(viewerPathGate("docs/a.md", at("_docs/a.md_", "docs/a.md")), false, "and at the offset the walk never produces, the underscore is glue");
+  // a code view's rows are units of their own, and the `from` line's own shape decides: `from` and a quoted specifier alone
+  // (a `;` or not, either quote), or `} from "` with no quote before the brace; nothing above the line is read
+  for (const [text, tok] of [
+    ['  a, b } from "pkg/x.js";', "pkg/x.js"], ['  from "pkg/x.js";', "pkg/x.js"], ['  d } from "pkg/x.js";', "pkg/x.js"], ['} from "pkg/x.js";', "pkg/x.js"],
+    ['  { a, b } from "pkg/x.js";', "pkg/x.js"], ['  b } from "pkg/x.js";', "pkg/x.js"], ['  from "pkg/t.js";', "pkg/t.js"], ["  from 'pkg/t.js'", "pkg/t.js"], ["from\t'pkg/t.js' ;", "pkg/t.js"],
+    ["  h } from 'pkg/gap.js';", "pkg/gap.js"], ['  from "docs/a.md"', "docs/a.md"],   // wherever it stands: under a blank row, under nothing, in prose
+  ] as const) {
+    assert.equal(viewerPathGate(tok, at(text, tok)), false, text);
+  }
+  for (const [text, tok] of [
+    ['  from "docs/a.md" and kept it', "docs/a.md"], ['# adapted from "docs/a.md"', "docs/a.md"], ['# data from "data/raw.csv"', "data/raw.csv"], ['# copied from "docs/c.md"', "docs/c.md"],
+    ['// see from "docs/a.md"', "docs/a.md"], ['  // ported from "docs/algo.md"', "docs/algo.md"], ['# see from "docs/c.md"', "docs/c.md"], ['from "pkg/sub.py" import x', "pkg/sub.py"],
+    ['x = "}"; } from "docs/a.md"', "docs/a.md"],   // a quote before the brace: not an import's closing line
+  ] as const) {
+    assert.equal(viewerPathGate(tok, at(text, tok)), true, text);
+  }
+  // …and through the real walk over rows: the fixture's code view (a .fv-cl per line), the pass over the whole code element
+  const { linkifyFileText } = await import("./file-view-links");
+  const c = el("code", "hljs", el("span", "fv-cl", "import {"), el("span", "fv-cl", '  a, b } from "pkg/x.js";'), el("span", "fv-cl", "import { g }"), el("span", "fv-cl", '  from "pkg/y.js";'), el("span", "fv-cl", 'x = "docs/a.md"'));
+  linkifyFileText(c as unknown as HTMLElement, FILE);
+  assert.deepEqual(links(c).map((l) => l.textContent), ["docs/a.md"], "the two hand-split imports' specifiers stay text over rows, the quoted path links");
+  // …and over codeBlock's rows with BLANK rows among them (a .fv-cl whose .fv-ct holds no text node): each blank row is an
+  // empty unit to the walk, in its place; a whole statement above an English from opens nothing, and a hand-split import's
+  // specifier stays text past a blank row too
+  const { textUnits } = await import("./path-links");
+  const rowsWithBlanks = el("code", "hljs", row("import json"), row(), row('# see from "docs/c.md"'), row("import os"), row("import sys"), row('# adapted from "docs/a.md"'),
+    row("export DATA=/data"), row('# copied from "docs/b.md"'), row("import {"), row(), row('  a, b } from "pkg/gap.js";'), row("import {"), row('  a, b } from "pkg/x.js";'),
+    row("export const z = 2;"), row('// from "docs/d.md"'));
+  assert.deepEqual(textUnits(rowsWithBlanks as unknown as HTMLElement, ".fv-cl", "a").map((u) => u.text).slice(0, 3), ["import json", "", '# see from "docs/c.md"'], "the blank row is an empty unit in its place");
+  linkifyFileText(rowsWithBlanks as unknown as HTMLElement, FILE);
+  assert.deepEqual(links(rowsWithBlanks).map((l) => l.textContent), ["docs/c.md", "docs/a.md", "docs/b.md", "docs/d.md"],
+    "the prose paths link; both hand-split imports' specifiers stay text, a blank row between `import {` and its `} from` or not");
+  assert.equal(rowsWithBlanks.querySelectorAll(".fv-cl").length, 15, "no row added or lost");
+});
+
+test("the gate's look-behind is the current line's and bounded by what stands right before the token; an 8000-line fence links every line's path, the look-behinds summed reading less than the text once", async () => {
+  const { lookBehindStart, viewerPathGate, resolveViewerPath, LINE_UNITS } = await import("./file-view-links");
+  const { linkifyPathTokens } = await import("./path-links");
+  const lineStart = (text: string, at: number) => text.lastIndexOf("\n", at - 1) + 1;
+  for (const [text, tok] of [
+    ['import b from "lodash/fp.js";', "lodash/fp.js"], ['x = 1\nimport b from "lodash/fp.js";', "lodash/fp.js"], ['a\n  const m = require(  "pkg/m.js");', "pkg/m.js"],
+    ['import b from\n"lodash/fp.js";', "lodash/fp.js"], ['reimport("pkg/x.js")', "pkg/x.js"], ["x = 1\n" + " ".repeat(500) + '"docs/a.md"', "docs/a.md"],
+    ["docs/a.md", "docs/a.md"], ["\ndocs/a.md", "docs/a.md"], ['see "docs/a.md"', "docs/a.md"], ["x".repeat(3000) + '\n"docs/a.md"', "docs/a.md"],
+    ["x".repeat(3000) + '\na quote from "docs/a.md"', "docs/a.md"],   // a keyword: the line is read to its start (the head decides), and the line before it is not
+  ] as const) {
+    const at = text.lastIndexOf(tok);
+    const start = lookBehindStart(text, at);
+    assert.ok(start >= lineStart(text, at) && start <= at, "the window [" + start + ", " + at + ") lies inside the line starting at " + lineStart(text, at) + ": " + JSON.stringify(text.slice(-60)));
+    assert.ok(at - start <= 2 + 500 + 1 + 500 + 7, "bounded by the quote, the spaces, the paren and a keyword's width");
+  }
+  // one unit of 8000 lines (a fenced block, or the Raw view's one <code>), a path on each line in three shapes
+  const lines: string[] = [];
+  for (let i = 0; i < 8000; i++) lines.push(i % 3 === 0 ? "docs/f" + i + ".md" : i % 3 === 1 ? 'x = "docs/g' + i + '.md"' : 'y = require("./docs/h' + i + '.md")');
+  const text = lines.join("\n") + "\n";
+  const pre = el("pre", "", el("code", "language-python hljs", text));
+  let read = 0, tokens = 0;
+  linkifyPathTokens(pre as unknown as HTMLElement, undefined, {
+    inPre: true, lineSuffix: true, unit: LINE_UNITS, resolve: (tok) => resolveViewerPath(tok, FILE),
+    accept: (tok, ctx) => { tokens++; read += ctx.at - lookBehindStart(ctx.text, ctx.at); return viewerPathGate(tok, ctx); },
+  });
+  assert.equal(tokens, 8000, "every line's path reached the gate");
+  assert.equal(links(pre).length, 8000, "and linked: a path starting a line, a quoted one, an anchored one in a require");
+  assert.ok(read < text.length, "the look-behinds read " + read + " characters in all, over a text of " + text.length);
+  assert.equal(pre.textContent, text);
+  assert.equal(links(pre)[3].dataset.path, DIR + "docs/f3.md"); assert.equal(links(pre)[5].dataset.path, DIR + "docs/h5.md");
+});
+
+test("normalizePath and resolveViewerPath: `.` and `..` are resolved once, here; relative tokens join the shown file's directory; absolute, ~/ and local file:// pass through; a file with no directory joins nothing", async () => {
+  const { normalizePath, resolveViewerPath } = await import("./file-view-links");
+  for (const [p, want] of [["/a/b/../c.md", "/a/c.md"], ["/../x.md", "/x.md"], ["/a/./b//c.md", "/a/b/c.md"], ["~/a/../b.md", "~/b.md"], ["~/../x.md", "~/../x.md"],
+                           ["docs/../src/app.py", "src/app.py"], ["../../x.md", "../../x.md"], ["a/../../x.md", "../x.md"], ["./x.py", "x.py"], ["a/b/", "a/b/"], ["/", "/"],
+                           ["docs/a.md", "docs/a.md"], ["/tmp/TESTHOST/x.md", "/tmp/TESTHOST/x.md"], ["", ""]] as const) {
+    assert.equal(normalizePath(p), want, p);
+  }
+  assert.equal(resolveViewerPath("docs/a.md", FILE), DIR + "docs/a.md");
+  assert.equal(resolveViewerPath("./x.py", FILE), DIR + "x.py", "./ is resolved here");
+  assert.equal(resolveViewerPath("../y.ts", FILE), "/tmp/TESTHOST/notes-api/y.ts", ".. is resolved here: the title bar and the folder link see one spelling");
+  assert.equal(resolveViewerPath("/tmp/TESTHOST/other/../z.md", FILE), "/tmp/TESTHOST/z.md");
+  assert.equal(resolveViewerPath("~/notes/plan.md", FILE), "~/notes/plan.md", "the kernel expands ~ on the session's machine");
+  assert.equal(resolveViewerPath("file:///tmp/TESTHOST/a%20b.pdf", FILE), "/tmp/TESTHOST/a b.pdf", "a URI's own path, percent-decoded");
+  assert.equal(resolveViewerPath("file://localhost/tmp/TESTHOST/a.pdf", FILE), "/tmp/TESTHOST/a.pdf", "localhost is this machine");
+  assert.equal(resolveViewerPath("docs/a.md", "README.md"), "docs/a.md", "a file named without a directory: the token as written, for the session's cwd");
+  assert.equal(resolveViewerPath("a.md", "docs/README.md"), "docs/a.md", "a relative shown file keeps its relative directory");
+  assert.equal(resolveViewerPath("../a.md", "docs/README.md"), "a.md");
+});
+
+test("a file:// URI is a path only with an empty authority or localhost: file://host/path names another machine and is prose to the walk; a line after a URI is the line, not the path", async () => {
+  const { isFileUri, fileUriToPath } = await import("./path-links");
+  for (const u of ["file:///tmp/TESTHOST/a.md", "file://localhost/tmp/a.md", "FILE:///tmp/a.md", "file://LOCALHOST/x"]) assert.equal(isFileUri(u), true, u);
+  for (const u of ["file://evil.invalid/share/x.md", "file://TESTHOST/x.md", "file://localhost", "file:/x.md", "files:///x", "file://localhostx/y"]) assert.equal(isFileUri(u), false, u);
+  assert.equal(fileUriToPath("file://localhost/tmp/a%20b.md"), "/tmp/a b.md");
+  assert.equal(fileUriToPath("file://evil.invalid/share/x.md"), "file://evil.invalid/share/x.md", "not a local path: returned as written, never as a relative path");
+  const { linkifyFileText } = await import("./file-view-links");
+  const c = code(row('y = "file://evil.invalid/share/x.md"'), row("z = 'file:///tmp/TESTHOST/x.md:12'"), row("w = 'file://localhost/tmp/TESTHOST/y.md#L7'"), row("v = file:///tmp/TESTHOST/z.md:3:4 end"),
+    row("u = 'file:///tmp/TESTHOST/x/../y.md'"));
+  const before = c.childNodes.map((r) => r.textContent);
+  linkifyFileText(c as unknown as HTMLElement, FILE);
+  assert.deepEqual(c.childNodes.map((r) => r.textContent), before);
+  assert.deepEqual(links(c).map((x) => [x.textContent, x.dataset.path, x.dataset.line, x.title]), [
+    ["file:///tmp/TESTHOST/x.md:12", "/tmp/TESTHOST/x.md", "12", "Open /tmp/TESTHOST/x.md:12"],
+    ["file://localhost/tmp/TESTHOST/y.md#L7", "/tmp/TESTHOST/y.md", "7", "Open /tmp/TESTHOST/y.md:7"],
+    ["file:///tmp/TESTHOST/z.md:3:4", "/tmp/TESTHOST/z.md", "3", "Open /tmp/TESTHOST/z.md:3"],
+    ["file:///tmp/TESTHOST/x/../y.md", "/tmp/TESTHOST/y.md", undefined, "Open /tmp/TESTHOST/y.md"],
+  ], "the host-bearing URI stays text; the line rides in the link and off the path; a URI's path is normalized once, as a written path is (the viewer's resolve)");
+});
+
+// ── the pass over a code body ─────────────────────────────────────────────────────────────────────
+test("the pass, executed over codeBlock's rows: URLs in a comment become anchors, quoted paths become path links resolved against the file, :line rides in, prose and identifiers stay", async () => {
+  const { linkifyFileText } = await import("./file-view-links");
+  const c = code(
+    row(el("span", "hljs-comment", "# see https://example.invalid/docs/setup.html, then docs/guide.md:12.")),
+    row("cfg = open(", el("span", "hljs-string", '"data/config.json"'), ")"),
+    row("from . import util  # and/or 24/7 x = 1/2.5 /api/users ./foo"),
+    row("readme = ", el("span", "hljs-string", "'file:///tmp/TESTHOST/notes-api/README.md'")),
+    row("see ", el("span", "hljs-string", '"ui/x.ts#L7"'), " and ", el("span", "hljs-string", '"ui/y.ts:12abc"')),
+  );
+  const before = c.childNodes.map((r) => r.textContent);
+  linkifyFileText(c as unknown as HTMLElement, FILE);
+  // every row's text reads exactly as before: the pass adds elements around text and changes no character
+  assert.deepEqual(c.childNodes.map((r) => r.textContent), before);
+  // the URL: an anchor that opens a new tab, its text the URL without the sentence's comma, not draggable (a drag on it selects)
+  const a = urls(c);
+  assert.equal(a.length, 1);
+  assert.equal(a[0].textContent, "https://example.invalid/docs/setup.html");
+  assert.equal(a[0].href, "https://example.invalid/docs/setup.html");
+  assert.equal(a[0].target, "_blank"); assert.equal(a[0].rel, "noopener noreferrer");
+  assert.equal(a[0].title, "https://example.invalid/docs/setup.html");
+  assert.equal(a[0].getAttribute("draggable"), "false");
+  assert.equal(a[0].closest(".hljs-comment")!.className, "hljs-comment", "inside the highlight's own span");
+  assert.equal(links(a[0]).length, 0, "the URL's path-shaped tail is not a path link inside the anchor");
+  // the paths: the chat's span, the resolved target, the line
+  const l = links(c);
+  assert.deepEqual(l.map((x) => x.textContent), ["docs/guide.md:12", "data/config.json", "file:///tmp/TESTHOST/notes-api/README.md", "ui/x.ts#L7", "ui/y.ts"]);
+  assert.deepEqual(l.map((x) => x.dataset.path), [DIR + "docs/guide.md", DIR + "data/config.json", "/tmp/TESTHOST/notes-api/README.md", DIR + "ui/x.ts", DIR + "ui/y.ts"]);
+  assert.deepEqual(l.map((x) => x.dataset.line), ["12", undefined, undefined, "7", undefined]);
+  assert.equal(l[0].title, "Open " + DIR + "docs/guide.md:12");
+  assert.equal(l[1].title, "Open " + DIR + "data/config.json");
+  for (const x of l) { assert.equal(x.role, "link"); assert.equal(x.tabIndex, 0); assert.equal(typeof x.onmousedown, "function"); assert.equal(typeof x.onkeydown, "function"); }
+  assert.equal(l[1].parentNode!.textContent, '"data/config.json"', "the string's quotes stay outside the link, as text");
+  // `.` after :12 is the sentence's, left as text; `:12abc` is not a line, so ui/y.ts links alone and `:12abc"` stays text
+  assert.equal(textNodesOf(c.childNodes[0] as El).map((t) => t.data).pop(), ".");
+  assert.equal(textNodesOf(c.childNodes[4] as El).map((t) => t.data).pop(), ':12abc"');
+});
+
+test("the pass reads a line, not a node: a highlight's substitution span cannot turn a path's tail into an absolute link, a token the highlight cut through is left as it is, and so is a URL, whose path-shaped query value is the URL's and never a link", async () => {
+  const { linkifyFileText } = await import("./file-view-links");
+  // what hljs makes of `cp "$HOME/docs/a.md" ./out/` (bash), `${ROOT}/src/x.py`, `$(ROOT)/src/main.c` (makefile), a TS template
+  // literal, a Python f-string and a YAML value: the substitution in a span of its own, the path's tail in the node after it
+  const c = code(
+    row("cp ", el("span", "hljs-string", '"', el("span", "hljs-variable", "$HOME"), '/docs/a.md"'), " ./out/"),
+    row("cat ", el("span", "hljs-variable", "${ROOT}"), "/src/x.py"),
+    row("SRC = ", el("span", "hljs-variable", "$(ROOT)"), "/src/main.c"),
+    row("const s = ", el("span", "hljs-string", "`", el("span", "hljs-subst", "${dir}"), "/out.json`"), ";"),
+    row("p = ", el("span", "hljs-string", 'f"', el("span", "hljs-subst", "{base}"), '/out.csv"')),
+    row("path: ", el("span", "hljs-string", el("span", "hljs-variable", "${HOME}"), "/notes/a.md")),
+    row("x = ", el("span", "hljs-string", '"docs/'), el("span", "hljs-string", 'c.md"')),   // one token across two nodes: left as it is
+    row("see ", el("span", "hljs-string", '"docs/a.md"'), " and ", el("span", "hljs-comment", "# https://example.invalid/x")),
+    row("u = ", el("span", "hljs-string", "`https://example.invalid/", el("span", "hljs-subst", "${host}"), "/x`")),
+    row("q = ", el("span", "hljs-string", '"docs/b.md'), ":", el("span", "hljs-number", "12"), '"'),   // the line reference cut off the path: the path links, the line stays text
+    // a URL the substitution cuts, with an absolute path as a query value: bash's `$V` and a template's `${v}` in spans of their own
+    row("curl https://example.invalid/q?x=/docs/a.md/", el("span", "hljs-variable", "$V")),
+    row("const u = ", el("span", "hljs-string", "`https://example.invalid/q?x=/docs/a.md/", el("span", "hljs-subst", "${v}"), "`"), ";"),
+    row("ok https://example.invalid/w?x=/docs/a.md/ and docs/d.md"),                                   // the same URL whole: wrapped, and the path after it links
+  );
+  const before = c.childNodes.map((r) => r.textContent);
+  linkifyFileText(c as unknown as HTMLElement, FILE);
+  assert.deepEqual(c.childNodes.map((r) => r.textContent), before);
+  assert.deepEqual(links(c).map((x) => [x.textContent, x.dataset.path, x.dataset.line]), [["docs/a.md", DIR + "docs/a.md", undefined], ["docs/b.md", DIR + "docs/b.md", undefined], ["docs/d.md", DIR + "docs/d.md", undefined]],
+    "the three real paths; no fabricated /docs/a.md, /src/x.py, /src/main.c, /out.json, /out.csv or /notes/a.md, the cut docs/c.md stays text, and the /docs/a.md inside the two cut URLs is the URL's");
+  assert.deepEqual(urls(c).map((x) => x.href), ["https://example.invalid/x", "https://example.invalid/w?x=/docs/a.md/"], "a URL a substitution cuts through is not one; a whole one is");
+});
+
+test("the pass links nothing in text that is not a URL or a file: identifiers, imports, fractions, routes, folders, sites", async () => {
+  const { linkifyFileText } = await import("./file-view-links");
+  const c = code(
+    row("from . import util"), row("import x from \"react/jsx-runtime\""), row("import y from \"lodash/fp.js\""), row("x = 1/2.5 + a/b"), row("app.get(\"/api/users\")"),
+    row("cd /usr/bin && ls ~/code"), row("and/or read/write TCP/IP"), row("np.array(kernel.py)"), row("https://"),
+    row("see www.example.org/docs/index.html or example.com/index.html"), row("git clone git@github.invalid:user/repo.git"), row("C:/Users/x/file.txt"), row("cat ~user/x.md"),
+  );
+  const before = c.textContent;
+  linkifyFileText(c as unknown as HTMLElement, FILE);
+  assert.equal(links(c).length, 0); assert.equal(urls(c).length, 0);
+  assert.equal(c.textContent, before);
+});
+
+test("escaping: <, &, > and quotes around a link stay literal text; text inside an existing anchor is skipped; an empty body is a no-op", async () => {
+  const { linkifyFileText } = await import("./file-view-links");
+  const c = code(
+    row('if (a < b && c > "docs/a.md") go(https://example.invalid/x?a=1&b=2)'),
+    row(el("a", "", "docs/b.md and https://example.invalid/y")),      // an author's anchor: left as it is
+  );
+  const before = c.childNodes.map((r) => r.textContent);
+  linkifyFileText(c as unknown as HTMLElement, FILE);
+  assert.deepEqual(c.childNodes.map((r) => r.textContent), before);
+  const first = c.childNodes[0] as El;
+  const texts = textNodesOf(first).map((t) => t.data);
+  assert.deepEqual(texts, ['if (a < b && c > "', "docs/a.md", '") go(', "https://example.invalid/x?a=1&b=2", ")"]);
+  assert.equal(links(first).length, 1); assert.equal(urls(first).length, 1);
+  assert.equal(urls(first)[0].href, "https://example.invalid/x?a=1&b=2", "the & is a character of the URL, not an entity");
+  assert.equal(links(c.childNodes[1] as El).length + urls(c.childNodes[1] as El).length, 0, "the anchor's text is not re-linked");
+  const empty = el("code", "hljs");
+  linkifyFileText(empty as unknown as HTMLElement, FILE);
+  assert.equal(empty.childNodes.length, 0);
+});
+
+// ── Markdown links ────────────────────────────────────────────────────────────────────────────────
+test("viewerLinkTarget (marked's walkTokens, before the sanitizer): a same-directory `name.ext:12` and a local file:// URI take the form the sanitizer keeps; everything else is left as written; only link tokens are touched", async () => {
+  const { viewerLinkTarget, viewerWalkTokens } = await import("./file-view-links");
+  assert.equal(viewerLinkTarget("notes.md:7"), "./notes.md:7");
+  assert.equal(viewerLinkTarget("README.md:12:3"), "./README.md:12:3");
+  assert.equal(viewerLinkTarget("app.py:7#x"), "./app.py:7#x");
+  assert.equal(viewerLinkTarget("app.test.ts:12"), "./app.test.ts:12", "three labels, the last no top-level domain: a file");
+  assert.equal(viewerLinkTarget("archive.tar.gz:3"), "./archive.tar.gz:3");
+  for (const h of ["app.component.vue:3", "styles.module.less:5", "report.final.docx:3", "init.el:12", "notes.v2.md:7"]) assert.equal(viewerLinkTarget(h), "./" + h, "a file whether or not the chat knows its extension: " + h);
+  assert.equal(viewerLinkTarget("example.com:80"), "example.com:80", "a host by its top-level domain, whatever the label count: left as written, so the sanitizer removes it");
+  assert.equal(viewerLinkTarget("file:///tmp/TESTHOST/a.md"), "/tmp/TESTHOST/a.md");
+  assert.equal(viewerLinkTarget("file://localhost/tmp/TESTHOST/a.md"), "/tmp/TESTHOST/a.md");
+  for (const h of ["docs/a.md:7", "./a.md:7", "../a.md:7", "a.md#L7", "https://example.invalid/x", "mailto:someone@example.invalid", "tel:12345",
+                   "javascript:alert(1)", "file://evil.invalid/x.md", "Makefile:12", "#section", "?x=1", "notes.md", "",
+                   "api.example.com:8443", "www.example.invalid:80", "sub.example.co.uk:443", "www.md:1"]) {   // a host with a port: left as written, so the sanitizer removes it and the anchor says why
+    assert.equal(viewerLinkTarget(h), h, JSON.stringify(h));
+  }
+  const { isHostName } = await import("./file-view-links");
+  // by shape, whatever the label count: `www.`, a generic or reserved top-level domain, or a country code under a registry's second-level label
+  for (const n of ["api.example.com", "www.example.invalid", "sub.example.co.uk", "www.x", "a.b.dev", "example.com", "example.co", "docs.example.io", "x.internal", "bbc.co.uk", "example.com.au"]) assert.equal(isHostName(n), true, n);
+  // a file, whether or not the chat's bare-name gate knows the extension: a last label that is no top-level domain by shape
+  for (const n of ["notes.md", "app.test.ts", "archive.tar.gz", "jquery.min.js", "a_b.c.com", "x.y.py", "app.component.vue", "styles.module.less", "report.final.docx", "init.el", "notes.v2.md", "foo.uk", "a.b.uk"]) assert.equal(isHostName(n), false, n);
+  const tok = { type: "link", href: "notes.md:7" }; viewerWalkTokens(tok); assert.equal(tok.href, "./notes.md:7");
+  const img = { type: "image", href: "notes.md:7" }; viewerWalkTokens(img); assert.equal(img.href, "notes.md:7", "a figure's src is the viewer's figure resolver's business");
+});
+
+test("linkMarkdownAnchors: a URL target opens a tab, a file target becomes a path link on the anchor itself (label intact, path normalized), a query alone opens a tab, a fragment alone is the viewer's, a stripped target is a dead link that says why", async () => {
+  const { linkMarkdownAnchors, DEAD_LINK_TITLE, HOST_PORT_TITLE, noSectionTitle } = await import("./file-view-links");
+  const md = "/tmp/TESTHOST/notes-api/docs/guide.md";
+  const A = (href: string, ...kids: Array<El | string>) => { const a = el("a", "", ...kids); a.setAttribute("href", href); return a; };
+  const web = A("https://example.invalid/x", "web"), mail = A("mailto:someone@example.invalid", "mail"), proto = A("//example.invalid/p", "p");
+  const rel = A("../src/app.py", el("strong", "", "the"), " app"), enc = A("my%20notes.md", "notes"), abs = A("/tmp/TESTHOST/other.md", "abs");
+  const lineHash = A("../src/app.py#L12", "l12"), lineColon = A("../src/app.py:7", "l7"), same = A("./notes.md:7", "same"), query = A("a.md?x=1#top", "q");
+  const qOnly = A("?x=1", "qo"), frag = A("#section", "here"), fragHit = A("#top", "top"), dead = el("a", "", "dead"), named = el("a", "", "");
+  const sect = A("report.md#results", "sect"), ip = A("127.0.0.1:3000", "ip"), lh = A("localhost:8080", "lh");
+  // after the shared sanitizer an author's id or name reaches the DOM under its user-content- prefix (md-sanitize.ts); a link to either spelling is live
+  const pre = el("p", "", "Intro"); pre.setAttribute("id", "user-content-intro"); const preName = el("a", "", ""); preName.setAttribute("name", "user-content-usage");
+  const fragPre = A("#intro", "intro"), fragPreName = A("#usage", "usage");
+  named.setAttribute("name", "anchor");
+  const fragName = A("#anchor", "to the name");
+  const target = el("h2", "", "Top"); target.setAttribute("id", "top");
+  const box = el("div", "fileview-md", target, pre, preName, el("p", "", web, mail, proto, rel, enc, abs, lineHash, lineColon, same, query, qOnly, frag, fragHit, dead, named, fragName, sect, ip, lh, fragPre, fragPreName));
+  linkMarkdownAnchors(box as unknown as HTMLElement, md);
+  for (const a of [web, mail, proto]) { assert.equal(a.getAttribute("target"), "_blank", a.href); assert.equal(a.getAttribute("rel"), "noopener"); assert.equal(a.dataset.path, undefined); }
+  assert.equal(web.href, "https://example.invalid/x", "the href stays");
+  for (const a of [rel, enc, abs, lineHash, lineColon, same, query, sect]) {
+    assert.equal(a.getAttribute("href"), null, "the href comes off: the browser must not follow it");
+    assert.ok(a.dataset.path, "a path to open"); assert.equal(a.role, "link"); assert.equal(a.tabIndex, 0);
+    assert.ok(a.classes.includes("file-uri-link"), "the shared class on the anchor");
+    assert.equal(a.target, "", "not a tab");
+  }
+  assert.equal(rel.dataset.path, "/tmp/TESTHOST/notes-api/src/app.py", "resolved against the shown file and normalized");
+  assert.equal(rel.childNodes.length, 2); assert.equal((rel.childNodes[0] as El).tagName, "STRONG", "the label's nested formatting is kept");
+  assert.equal(rel.textContent, "the app");
+  assert.equal(enc.dataset.path, "/tmp/TESTHOST/notes-api/docs/my notes.md", "marked's percent-encoding undone");
+  assert.equal(abs.dataset.path, "/tmp/TESTHOST/other.md");
+  assert.equal(lineHash.dataset.path, "/tmp/TESTHOST/notes-api/src/app.py"); assert.equal(lineHash.dataset.line, "12");
+  assert.equal(lineHash.getAttribute("title"), "Open /tmp/TESTHOST/notes-api/src/app.py:12");
+  assert.equal(lineColon.dataset.line, "7");
+  assert.equal(same.dataset.path, "/tmp/TESTHOST/notes-api/docs/notes.md", "the same-directory target the hook prefixed with ./, resolved and normalized");
+  assert.equal(same.dataset.line, "7"); assert.equal(same.getAttribute("title"), "Open /tmp/TESTHOST/notes-api/docs/notes.md:7");
+  assert.equal(query.dataset.path, "/tmp/TESTHOST/notes-api/docs/a.md", "the query is dropped from the path");
+  assert.equal(query.dataset.line, undefined); assert.equal(query.dataset.frag, "top", "the fragment after the query is the section to land on"); assert.equal(query.getAttribute("title"), "Open /tmp/TESTHOST/notes-api/docs/a.md#top");
+  // a sibling's own #fragment rides the path link (data-frag) and lands once the file is open (file-view.ts openFileView's frag); a #L12 is the line instead
+  assert.equal(sect.dataset.path, "/tmp/TESTHOST/notes-api/docs/report.md"); assert.equal(sect.dataset.frag, "results"); assert.equal(sect.dataset.line, undefined);
+  assert.equal(sect.getAttribute("title"), "Open /tmp/TESTHOST/notes-api/docs/report.md#results");
+  assert.equal(lineHash.dataset.frag, undefined); assert.equal(same.dataset.frag, undefined);
+  // a host with a port whose target the sanitizer lets stand (no letter-led scheme): a dead link that says so, never a file named 127.0.0.1 at line 3000
+  for (const a of [ip, lh]) { assert.equal(a.getAttribute("href"), null, a.textContent); assert.equal(a.dataset.path, undefined); assert.ok(a.classes.includes("fv-dead"), a.className); assert.equal(a.getAttribute("title"), HOST_PORT_TITLE); }
+  // a query alone: a web-style link to the page's own address, a new tab, never this document
+  assert.equal(qOnly.getAttribute("href"), "?x=1"); assert.equal(qOnly.getAttribute("target"), "_blank"); assert.equal(qOnly.getAttribute("rel"), "noopener noreferrer"); assert.equal(qOnly.dataset.path, undefined);
+  // a fragment alone: the viewer's click; with no element of that id the link is dead and says so
+  assert.equal(frag.getAttribute("href"), "#section"); assert.ok(frag.classes.includes("fv-frag") && frag.classes.includes("fv-dead"), frag.className);
+  assert.equal(frag.dataset.frag, undefined); assert.equal(frag.getAttribute("title"), noSectionTitle("section"));
+  assert.ok(fragHit.classes.includes("fv-frag") && !fragHit.classes.includes("fv-dead"), fragHit.className);
+  assert.equal(fragHit.dataset.frag, "top"); assert.equal(fragHit.getAttribute("title"), "Go to top");
+  // a GitHub-style `<a name>` is a target too (the README idiom above a heading): live, by name
+  assert.ok(fragName.classes.includes("fv-frag") && !fragName.classes.includes("fv-dead"), fragName.className);
+  assert.equal(fragName.dataset.frag, "anchor"); assert.equal(fragName.getAttribute("title"), "Go to anchor");
+  const { fragmentTarget } = await import("./file-view-links");
+  assert.equal(fragmentTarget(box as unknown as HTMLElement, "anchor"), named); assert.equal(fragmentTarget(box as unknown as HTMLElement, "top"), target);
+  for (const [a, id, hit] of [[fragPre, "intro", pre], [fragPreName, "usage", preName]] as const) {
+    assert.ok(a.classes.includes("fv-frag") && !a.classes.includes("fv-dead"), id + ": live under the sanitizer's prefix: " + a.className);
+    assert.equal(a.dataset.frag, id); assert.equal(fragmentTarget(box as unknown as HTMLElement, id), hit, id + " is found under user-content-" + id);
+  }
+  assert.equal(fragmentTarget(box as unknown as HTMLElement, "user-content-intro"), pre, "the prefix as typed finds it too");
+  const both = el("div", "", el("a", "", ""), el("h2", "", "x")); (both.childNodes[0] as El).setAttribute("name", "dup"); (both.childNodes[1] as El).setAttribute("id", "dup");
+  assert.equal(fragmentTarget(both as unknown as HTMLElement, "dup"), both.childNodes[1], "an id wins over a name, as the browser's fragment rule has it");
+  assert.equal(fragmentTarget(box as unknown as HTMLElement, "nowhere"), undefined);
+  // a heading: the viewer mints `md-` + its slug (mdBlock), and the lookup reads the slug of the id asked for
+  const h2 = el("h2", "", "Evidence Results"); h2.setAttribute("id", "md-evidence-results");
+  const withH = el("div", "", h2);
+  for (const id of ["evidence-results", "Evidence Results"]) assert.equal(fragmentTarget(withH as unknown as HTMLElement, id), h2, id);
+  assert.equal(fragmentTarget(withH as unknown as HTMLElement, "md-evidence-results"), h2, "the minted id itself, by the id arm");
+  // an anchor the sanitizer stripped: dead, with the reason; a named target never was a link and is left alone
+  assert.ok(dead.classes.includes("fv-dead")); assert.equal(dead.getAttribute("title"), DEAD_LINK_TITLE);
+  assert.equal(named.getAttribute("class"), null); assert.equal(named.getAttribute("title"), null);
+});
+
+test("in a rendered body the prose's bare paths link under the viewer's gate, a fenced block's URL links, and inline code's bare filename does not", async () => {
+  const { linkifyFileText } = await import("./file-view-links");
+  const md = "/tmp/TESTHOST/notes-api/docs/guide.md";
+  const marked = el("a", "", "https://example.invalid/auto"); marked.setAttribute("href", "https://example.invalid/auto");
+  const box = el("div", "fileview-md",
+    el("p", "", "Read ../src/app.py:3 and ", el("code", "", "setup.py"), " then ", marked, "."),
+    el("pre", "", el("code", "language-bash hljs", "curl https://example.invalid/dl -o data/x.json")),
+  );
+  const before = box.textContent;
+  linkifyFileText(box as unknown as HTMLElement, md);
+  assert.equal(box.textContent, before);
+  const l = links(box);
+  assert.deepEqual(l.map((x) => x.textContent), ["../src/app.py:3", "data/x.json"], "the prose path with its line, the fenced block's path; not the backticked bare filename");
+  assert.equal(l[0].dataset.path, "/tmp/TESTHOST/notes-api/src/app.py"); assert.equal(l[0].dataset.line, "3");
+  assert.equal(l[1].dataset.path, "/tmp/TESTHOST/notes-api/docs/data/x.json");
+  const u = urls(box);
+  assert.deepEqual(u.map((x) => x.href), ["https://example.invalid/dl"], "the fenced block's URL; marked's own anchor is not wrapped twice");
+});
+
+test("a line break or a no-break space before a token is whitespace: a path starting a soft-broken line links, every line of a fenced block links, a list item's second line links, and the Raw view's one-unit code body links each line's path", async () => {
+  const { linkifyFileText } = await import("./file-view-links");
+  const md = "/tmp/TESTHOST/notes-api/docs/guide.md", MDDIR = "/tmp/TESTHOST/notes-api/docs/";
+  const box = el("div", "fileview-md",
+    el("p", "", "See the plan in\ndocs/plan.md and\r\ndocs/win.md, then\u00a0docs/nb.md."),
+    el("pre", "", el("code", "language-python hljs", "x = 1\ndocs/a.md\n  docs/b.md\n")),
+    el("ul", "", el("li", "", "first\ndocs/li.md")),
+  );
+  const before = box.textContent;
+  linkifyFileText(box as unknown as HTMLElement, md);
+  assert.equal(box.textContent, before);
+  assert.deepEqual(links(box).map((x) => [x.textContent, x.dataset.path]), [
+    ["docs/plan.md", MDDIR + "docs/plan.md"], ["docs/win.md", MDDIR + "docs/win.md"], ["docs/nb.md", MDDIR + "docs/nb.md"],
+    ["docs/a.md", MDDIR + "docs/a.md"], ["docs/b.md", MDDIR + "docs/b.md"], ["docs/li.md", MDDIR + "docs/li.md"],
+  ], "a path may start any line of a block, not only the first");
+  // the Raw view's other shape (codeBlock's gutter branch): the whole highlighted body in one <code>, its lines split by \n
+  const c = el("pre", "fileview-pre", el("code", "hljs", "x = 1\n", el("span", "hljs-string", "'docs/e.md'"), "\ndocs/f.md\n", el("span", "hljs-comment", "# see docs/g.md"), "\n"));
+  const raw = c.textContent;
+  linkifyFileText(c as unknown as HTMLElement, FILE);
+  assert.equal(c.textContent, raw);
+  assert.deepEqual(links(c).map((x) => [x.textContent, x.dataset.path]), [["docs/e.md", DIR + "docs/e.md"], ["docs/f.md", DIR + "docs/f.md"], ["docs/g.md", DIR + "docs/g.md"]]);
+});
+
+test("a <br> ends a unit: the path after it is read from its own line, never glued to the text before the break", async () => {
+  const { linkifyFileText } = await import("./file-view-links");
+  const { textUnits } = await import("./path-links");
+  const md = "/tmp/TESTHOST/notes-api/docs/guide.md", MDDIR = "/tmp/TESTHOST/notes-api/docs/";
+  const p1 = el("p", "", "a", el("br"), "docs/a.md");
+  assert.deepEqual(textUnits(p1 as unknown as HTMLElement, "p", "a").map((u) => u.text), ["a", "docs/a.md"], "two units, cut at the break");
+  const box = el("div", "fileview-md",
+    p1,
+    el("p", "", el("span", "", "x: docs/one.md"), el("br"), el("span", "", "docs/two.md"), el("br"), "https://example.invalid/z"),
+  );
+  const before = box.textContent;
+  linkifyFileText(box as unknown as HTMLElement, md);
+  assert.equal(box.textContent, before);
+  assert.deepEqual(links(box).map((x) => [x.textContent, x.dataset.path]), [["docs/a.md", MDDIR + "docs/a.md"], ["docs/one.md", MDDIR + "docs/one.md"], ["docs/two.md", MDDIR + "docs/two.md"]],
+    "read as one unit the first would be `adocs/a.md`, one token across two nodes, which the walk drops");
+  assert.deepEqual(urls(box).map((x) => x.href), ["https://example.invalid/z"]);
+});
+
+test("spanHolding over many spans finds the one holding a token (a binary search over the unit's spans): a row of a thousand highlighted strings links each path inside its own span", async () => {
+  const { linkifyFileText } = await import("./file-view-links");
+  const { spanHolding, textUnits } = await import("./path-links");
+  const kids: Array<El | string> = [];
+  for (let i = 0; i < 1000; i++) { kids.push(el("span", "hljs-string", '"docs/s' + i + '.md"')); kids.push(", "); }
+  const c = code(row(...kids));
+  linkifyFileText(c as unknown as HTMLElement, FILE);
+  const l = links(c);
+  assert.equal(l.length, 1000);
+  l.forEach((x, i) => { assert.equal(x.textContent, "docs/s" + i + ".md"); assert.equal(x.parentNode!.className, "hljs-string"); assert.equal(x.parentNode!.textContent, '"docs/s' + i + '.md"'); });
+  // the search itself: the span holding the start, whole and open; null across an edge or in a dead span; nothing off the end
+  const u = textUnits(el("p", "", "aa", el("a", "", "bb"), "cc", "dd") as unknown as HTMLElement, "p", "a")[0];
+  assert.equal(u.text, "aabbccdd"); assert.equal(u.spans.length, 4);
+  assert.equal(spanHolding(u, 0, 2), u.spans[0]); assert.equal(spanHolding(u, 4, 6), u.spans[2]); assert.equal(spanHolding(u, 7, 8), u.spans[3]);
+  assert.equal(spanHolding(u, 1, 3), null, "across an edge"); assert.equal(spanHolding(u, 2, 4), null, "inside the link: dead"); assert.equal(spanHolding(u, 8, 9), null); assert.equal(spanHolding(u, -1, 1), null);
+});
+
+test("a Markdown link whose file target resolves to no path is a dead link that says why, with no href to follow and no path to open: `[up](../)` from `docs/plan.md` points above the file's folder, `[here](./)` from `README.md` names the folder the file is in", async () => {
+  const { linkMarkdownAnchors, EMPTY_TARGET_TITLE, SELF_TARGET_TITLE, DEAD_LINK_TITLE, emptyTargetTitle, resolveViewerPath } = await import("./file-view-links");
+  const A = (href: string, ...kids: Array<El | string>) => { const a = el("a", "", ...kids); a.setAttribute("href", href); return a; };
+  const up = A("../", "up"), dot = A("..", "dot"), root = A("/", "root"), here = A("./", "here"), sib = A("../x.md", "sib");
+  const box = el("div", "fileview-md", el("p", "", up, dot, root, here, sib));
+  linkMarkdownAnchors(box as unknown as HTMLElement, "docs/plan.md");
+  for (const a of [up, dot]) {
+    assert.equal(a.getAttribute("href"), null, "the browser must not follow it"); assert.equal(a.dataset.path, undefined, "no silent click on an empty path");
+    assert.ok(a.classes.includes("fv-dead") && !a.classes.includes("file-uri-link"), a.className); assert.equal(a.getAttribute("title"), EMPTY_TARGET_TITLE);
+  }
+  assert.notEqual(EMPTY_TARGET_TITLE, DEAD_LINK_TITLE, "its own reason");
+  assert.equal(root.dataset.path, "/"); assert.equal(here.dataset.path, "docs/"); assert.equal(sib.dataset.path, "x.md", "a sibling folder's file above the shown one resolves fine");
+  // from a file named without a directory, `./`, `.` and `docs/../` name the folder the file is in: dead too, with that reason, not "above"
+  const selfHere = A("./", "here"), selfDot = A(".", "dot"), selfBack = A("docs/../", "back"), upRel = A("../", "up");
+  linkMarkdownAnchors(el("div", "fileview-md", el("p", "", selfHere, selfDot, selfBack, upRel)) as unknown as HTMLElement, "README.md");
+  for (const a of [selfHere, selfDot, selfBack]) {
+    assert.equal(a.getAttribute("href"), null); assert.equal(a.dataset.path, undefined);
+    assert.ok(a.classes.includes("fv-dead"), a.className); assert.equal(a.getAttribute("title"), SELF_TARGET_TITLE, a.textContent);
+  }
+  assert.notEqual(SELF_TARGET_TITLE, EMPTY_TARGET_TITLE); assert.match(SELF_TARGET_TITLE, /the folder this file is in/); assert.match(EMPTY_TARGET_TITLE, /above the folder/);
+  assert.equal(upRel.dataset.path, "../", "climbing out of a relative name keeps the `..`: a live link the kernel resolves");
+  // the rule behind the two titles: an empty resolution from a file with a directory can only have climbed above it; from one without, it is the folder itself
+  for (const [tok, file] of [["./", "README.md"], [".", "README.md"], ["docs/../", "README.md"], ["a/b/../../", "README.md"], ["../", "docs/plan.md"], ["..", "docs/plan.md"], ["./..", "docs/plan.md"], ["docs/../..", "docs/plan.md"]] as const) {
+    assert.equal(resolveViewerPath(tok, file), "", tok + " from " + file);
+  }
+  for (const [tok, file] of [["./", "docs/plan.md"], [".", "docs/plan.md"], ["docs/../", "docs/plan.md"], ["../", "README.md"], ["..", "README.md"]] as const) {
+    assert.notEqual(resolveViewerPath(tok, file), "", tok + " from " + file + " has a path");
+  }
+  assert.equal(emptyTargetTitle("README.md"), SELF_TARGET_TITLE); assert.equal(emptyTargetTitle("docs/plan.md"), EMPTY_TARGET_TITLE); assert.equal(emptyTargetTitle("/tmp/TESTHOST/a.md"), EMPTY_TARGET_TITLE);
+  const upAbs = A("../", "upAbs");
+  linkMarkdownAnchors(el("div", "fileview-md", el("p", "", upAbs)) as unknown as HTMLElement, "/tmp/TESTHOST/notes-api/docs/guide.md");
+  assert.equal(upAbs.dataset.path, "/tmp/TESTHOST/notes-api/", "from an absolute file the folder above has a name");
+});
+
+test("text inside an inline SVG is read but never marked: a path or a URL in a figure's label stays as written (an HTML element inserted into SVG text does not render), in the viewer's pass and in the chat's walk", async () => {
+  const { linkifyFileText } = await import("./file-view-links");
+  const { linkifyPathTokens } = await import("./path-links");
+  const md = "/tmp/TESTHOST/notes-api/docs/guide.md";
+  const label = el("text", "", "docs/a.md and https://example.invalid/x");
+  const box = el("div", "fileview-md", el("p", "", "see ", el("svg", "", el("g", "", label)), " and docs/b.md https://example.invalid/y"));
+  const before = box.textContent;
+  linkifyFileText(box as unknown as HTMLElement, md);
+  assert.equal(box.textContent, before);
+  assert.deepEqual(links(box).map((x) => x.textContent), ["docs/b.md"]);
+  assert.deepEqual(urls(box).map((x) => x.href), ["https://example.invalid/y"]);
+  assert.equal(label.childNodes.length, 1); assert.ok(label.childNodes[0] instanceof Txt, "the label is still one text node");
+  const chat = el("div", "md", el("p", "", el("svg", "", el("text", "", "docs/c.md")), " docs/d.md"));
+  linkifyPathTokens(chat as unknown as HTMLElement);
+  assert.deepEqual(links(chat).map((x) => [x.textContent, x.dataset.path]), [["docs/d.md", "docs/d.md"]], "the chat's walk skips the SVG too");
+});
+
+// ── the gesture helpers, executed ─────────────────────────────────────────────────────────────────
+test("wantsOwnTab reads a Cmd/Ctrl-click or the middle button; openFileTab opens the kernel's /file URL in a tab with the opener severed, reports a blocked popup, and stands down off the web", async () => {
+  const { wantsOwnTab, openFileTab, fileUrl } = await import("./preview");
+  assert.equal(wantsOwnTab({ metaKey: true }), true); assert.equal(wantsOwnTab({ ctrlKey: true }), true); assert.equal(wantsOwnTab({ button: 1 }), true);
+  assert.equal(wantsOwnTab({}), false); assert.equal(wantsOwnTab({ button: 0 }), false); assert.equal(wantsOwnTab(null), false); assert.equal(wantsOwnTab(undefined), false);
+  const g = globalThis as any;
+  const saved = { loc: g.location, win: g.window };
+  try {
+    const calls: unknown[][] = [];
+    const handle: { opener: unknown } = { opener: { theDashboard: true } };
+    g.location = { protocol: "https:" }; g.window = { open: (...a: unknown[]) => { calls.push(a); return handle; } };
+    assert.equal(openFileTab("/tmp/TESTHOST/notes-api/docs/guide.md", SID), true);
+    assert.deepEqual(calls, [[fileUrl("/tmp/TESTHOST/notes-api/docs/guide.md", SID), "_blank"]], "the same-origin file URL, a new tab, no noopener feature (it returns null even on success)");
+    assert.equal(calls[0][0], "/file?path=%2Ftmp%2FTESTHOST%2Fnotes-api%2Fdocs%2Fguide.md&sid=" + SID);
+    assert.equal(handle.opener, null, "severed on the handle: a link inside the opened file must not hold the dashboard");
+    g.window = { open: () => null };
+    assert.equal(openFileTab("/tmp/TESTHOST/x.md", SID), false, "blocked: the caller's viewer takes over");
+    let tried = false;
+    g.location = { protocol: "vscode-webview:" }; g.window = { open: () => { tried = true; return {}; } };
+    assert.equal(openFileTab("/tmp/TESTHOST/x.md", SID), false); assert.equal(tried, false, "the webview has no tabs and no kernel origin: never tried");
+  } finally { g.location = saved.loc; g.window = saved.win; }
+});
+
+// ── the viewer's wiring, at source ────────────────────────────────────────────────────────────────
+test("source: codeBlock and mdBlock run the one pass on the DOM they built; the markdown anchors are sorted before the fenced-block highlight and the text after it; marked's parse carries the link-target hook per call; the fallback is left bare", () => {
+  assert.match(VIEW, /import \{ linkifyFileText, linkMarkdownAnchors, viewerWalkTokens, fragmentTarget, URL_LINK_CLASS, FRAG_LINK_CLASS \} from "\.\/file-view-links";/);
+  const codeFn = VIEW.split("function codeBlock(text: string, path: string, wrapLines: boolean): HTMLElement {")[1].split("\n}\n")[0];
+  assert.match(codeFn, /code\.innerHTML = wrapNumberedHtml\(hl !== null \? hl : escapeHtml\(text\)\);\n\s*linkifyFileText\(code, path\);/, "the wrap branch: after the rows are in the DOM");
+  assert.match(codeFn, /if \(hl !== null\) code\.innerHTML = hl; else code\.textContent = text;\n\s*linkifyFileText\(code, path\);/, "the gutter branch too");
+  assert.doesNotMatch(codeFn, /linkifyFileText\(text|escapeHtml\(linkify/, "never over the HTML string");
+  // the viewer always builds the wrap view (each line its own .fv-cl row), which is what scrollToLine reads
+  const openFn = VIEW.split("export function openFileView(")[1].split("function offersDownload")[0];
+  assert.ok((openFn.match(/codeBlock\([^)]*\)/g) || []).every((c) => /, true\)$/.test(c)), "every codeBlock call in the viewer asks for wrap mode: " + (openFn.match(/codeBlock\([^)]*\)/g) || []).join(" | "));
+  const mdFn = VIEW.split("function mdBlock(text: string, doc?: MdDocLoc): HTMLElement {")[1].split("\n}\n")[0];
+  assert.match(mdFn, /const base = marked\.defaults\.walkTokens;\n\s*const dirty = marked\.parse\(text, \{ walkTokens: \(t\) => \{\n(?:\s*if \(t\.type === "code"\)[^\n]*\n)?\s*if \(doc && doc\.kind === "file"\) viewerWalkTokens\(t\);\n\s*if \(base\) void base\.call\(marked, t\);\n\s*\} \}\) as string;/,
+    "the hook rides on this parse alone (the per-call walkTokens that also collects the fences for Copy), and on the file kind's alone: the singleton is the chat's too, and a URL document has no directory for `notes.md:7`");
+  const anchorsAt = mdFn.indexOf("if (rendered) linkMarkdownAnchors(box, doc.path);");
+  const hlAt = mdFn.indexOf('box.querySelectorAll("pre code").forEach');
+  const textAt = mdFn.indexOf('if (rendered && doc && doc.kind === "file") linkifyFileText(box, doc.path);');
+  assert.ok(anchorsAt > 0 && hlAt > anchorsAt && textAt > hlAt && mdFn.indexOf("return box;") > textAt, "anchors → highlight → text, then return");
+  assert.match(mdFn, /box\.textContent = text;[^\n]*\n\s*rendered = false;/, "the fallback's bare text takes no links");
+  assert.ok(mdFn.indexOf('if (doc && doc.kind === "file") {') > 0 && mdFn.indexOf('if (doc && doc.kind === "file") {') < anchorsAt, "the file kind's anchors are sorted by the module");
+  assert.equal((mdFn.match(/querySelectorAll\("a\[href\]"\)/g) || []).length, 2, "the two a[href] loops are the URL kind's (resolution against the URL) and the no-file arm's (a tab, or an in-document fv-anchor): neither runs over a file's anchors");
+  assert.ok(mdFn.indexOf("sanitizeMd(") > 0 && mdFn.indexOf("sanitizeMd(") < anchorsAt, "marks are set AFTER the shared sanitizer ran (md-sanitize.ts, ALLOW_DATA_ATTR false): a document's own data-* never reaches the page");
+});
+
+test("source: the body's listener and its gesture: a drag-select opens nothing, a plain path click opens in the viewer and goes on to the document (a modified one stops and takes its own tab), a URL anchor is the browser's on a plain click, a section link scrolls the rendered document and never moves the page", () => {
+  const d = VIEW.split('body.addEventListener("click", (ev) => {')[1].split("\n  });\n")[0];
+  assert.match(d, /const x = linkOf\(ev\.target as Element \| null\);\n\s*if \(!x\) return;/);
+  assert.match(d, /if \(selectionOpenIn\(box\)\) \{ ev\.preventDefault\(\); return; \}/, "a drag-select that ended on the link opens nothing");
+  assert.ok(d.indexOf("selectionOpenIn(box)") < d.indexOf("openLink(x, ev)"), "the selection first, then the link");
+  // the one selection test, in path-links.ts, read by the viewer's listener and by the chat's capture-phase opener (which runs first)
+  assert.match(LINKS, /export function selectionOpenIn\(el: Node\): boolean \{\n\s*const sel = window\.getSelection\(\);\n\s*return !!sel && !sel\.isCollapsed && el\.contains\(sel\.anchorNode\);\n\}/);
+  const opener = RENDER.slice(RENDER.indexOf('document.addEventListener("click", (e) => {\n  const a = (e.target as HTMLElement)?.closest?.("a[href]")'), RENDER.indexOf("}, true);", RENDER.indexOf('closest?.("a[href]")')));
+  assert.match(opener, /if \(!a\) return;\n(?:\s*\/\/[^\n]*\n)*\s*if \(!a\.draggable && selectionOpenIn\(a\)\) \{ e\.preventDefault\(\); return; \}\n\s*const href = a\.getAttribute\("href"\) \|\| "";/,
+    "the chat's opener: for a non-draggable anchor only, the selection open inside it (the click that ends a drag-select: cancelled, never opened; a chat anchor is draggable and a selection left around it by a triple-click is not a drag on it), then the href");
+  assert.match(RENDER, /import \{ openPathLink, linkifyPathTokens, selectionOpenIn \} from "\.\/path-links";/);
+  assert.match(VIEW, /import \{ selectionOpenIn \} from "\.\/path-links";/);
+  assert.doesNotMatch(d, /getSelection|isCollapsed/, "no second spelling of the selection test in the listener");
+  assert.match(VIEW, /const linkOf = \(t: Element \| null\): HTMLElement \| null => \{\n\s*const x = t && typeof t\.closest === "function" \? t\.closest\("\.file-uri-link, a\." \+ URL_LINK_CLASS \+ ", a\." \+ FRAG_LINK_CLASS\) as HTMLElement \| null : null;\n\s*return x && body\.contains\(x\) \? x : null;/);
+  const o = VIEW.split("const openLink = (x: HTMLElement, ev: MouseEvent) => {")[1].split("\n  };\n")[0];
+  assert.match(o, /const own = wantsOwnTab\(ev\);/);
+  assert.match(o, /if \(x\.classList\.contains\(FRAG_LINK_CLASS\)\) \{[^\n]*\n\s*ev\.preventDefault\(\);\n(?:\s*\/\/[^\n]*\n)*\s*scrollToFragment\(body, x\.getAttribute\("href"\) \|\| ""\);\n\s*return;/,
+    "a section link: the rendered document's own headings, ids and named anchors (the viewer's chrome has ids of its own), this document's scroll or nothing, never the page's location");
+  assert.doesNotMatch(o, /querySelectorAll\("\[id\]"\)|getElementById/, "never the whole box, and never a lookup of its own: the one in file-view-links.ts");
+  assert.match(VIEW, /const target = fragmentTarget\(box\.querySelector\("\.fileview-md"\) \|\| box, frag\);/, "scrollToFragment (both viewers land through it): the rendered box, through the one lookup");
+  assert.match(MOD, /const hit = id \? fragmentTarget\(root, id\) : undefined;/, "mark time reads the same root, the .fileview-md box, through the one lookup");
+  assert.match(MOD, /export function fragmentTarget\(root: ParentNode, id: string\): Element \| undefined \{\n\s*return userContentTarget\(root, id\)\n\s*\|\| root\.querySelector\('\[id="md-' \+ headingSlug\(id\) \+ '"\]'\) \|\| undefined;/,
+    "an author's id or name, prefixed by the sanitizer or bare (md-sanitize.ts userContentTarget, the lookup the chat's # click reads too), then the heading whose slug it is (the viewer mints md-<slug> ids; md-url-view.test.ts)");
+  assert.match(MOD, /import \{ userContentTarget \} from "\.\/md-sanitize";/);
+  assert.match(o, /const p = x\.dataset\.path;\n\s*if \(!p\) \{[^\n]*\n\s*if \(!own\) return;[^\n]*\n\s*ev\.preventDefault\(\); ev\.stopPropagation\(\);[^\n]*\n\s*openUrlTab\(x\.getAttribute\("href"\) \|\| ""\);\n\s*return;/, "a URL anchor: plain is the browser's, modified is one tab from here");
+  assert.match(o, /ev\.preventDefault\(\);\n\s*if \(own\) \{\n\s*ev\.stopPropagation\(\);[^\n]*\n\s*if \(openFileTab\(p, sid \|\| null\)\) return;[^\n]*\n\s*\}\n\s*const ln = Number\(x\.dataset\.line\);\n\s*openFileView\(p, sid \|\| null, \{ line: ln > 0 \? ln : null, frag: x\.dataset\.frag \|\| null \}\);/,
+    "a path link: a modified click stops and takes its own tab (the viewer when the popup was blocked); a plain click opens in the viewer and is NOT stopped");
+  assert.equal((o.match(/stopPropagation/g) || []).length, 2, "two stops in openLink, both on the modified gesture: the URL anchor's and the path link's; a plain click goes on to the document's listeners");
+  assert.match(VIEW, /const openUrlTab = \(href: string\) => \{\n\s*if \(!href\) return;\n\s*if \(canPreview\(\)\) window\.open\(href, "_blank", "noopener,noreferrer"\);[^\n]*\n\s*else post\(\{ type: "openLink", href \}\);/, "render.ts's two openers, by host");
+  assert.match(VIEW, /body\.addEventListener\("mousedown", \(ev\) => \{\n\s*const x = ev\.button === 1 \? linkOf\(ev\.target as Element \| null\) : null;\n\s*if \(x && x\.dataset\.path\) ev\.preventDefault\(\);\n\s*\}\);/, "the middle press on a path link starts no autoscroll");
+  assert.match(VIEW, /body\.addEventListener\("auxclick", \(ev\) => \{\n\s*if \(ev\.button !== 1\) return;\n\s*const x = linkOf\(ev\.target as Element \| null\);\n\s*if \(x && \(x\.dataset\.path \|\| x\.classList\.contains\(FRAG_LINK_CLASS\)\)\) openLink\(x, ev\);\n\s*\}\);/,
+    "the middle-click on a path link is its own tab; on a section link it is this document's scroll (openLink's frag branch cancels the browser's tab at the page's URL plus the id); a URL anchor's is the browser's");
+  assert.match(VIEW, /import \{ openFileTab, canPreview \} from "\.\/preview";/, "on a line of its own beside the two preview imports file-view.test.ts pins");
+  // one listener per open, installed before any render can run (click-safe across the Rendered ⇄ Raw swaps that rebuild the body's children)
+  const openFn = VIEW.split("export function openFileView(")[1].split("function offersDownload")[0];
+  assert.equal((openFn.match(/body\.addEventListener\("click"/g) || []).length, 1);
+  assert.ok(openFn.indexOf('body.addEventListener("click"') < openFn.indexOf("const renderBody ="), "installed before any render can run");
+  assert.doesNotMatch(openFn, /delegate\(body/, "the delegate that served the sibling links is gone: the one listener sorts every link kind");
+  // a held Cmd/Ctrl rides from the keyboard into the click (path-links.ts)
+  assert.match(LINKS, /if \(e\.metaKey \|\| e\.ctrlKey\) a\.dispatchEvent\(new MouseEvent\("click", \{ bubbles: true, cancelable: true, metaKey: e\.metaKey, ctrlKey: e\.ctrlKey \}\)\);\n\s*else a\.click\(\);/);
+  // the gesture is the project's one rule, in preview.ts
+  assert.match(PREVIEW, /export function wantsOwnTab\(ev\?: \{ metaKey\?: boolean; ctrlKey\?: boolean; button\?: number \} \| null\): boolean \{\n\s*return !!ev && \(!!ev\.metaKey \|\| !!ev\.ctrlKey \|\| ev\.button === 1\);\n\}/);
+  assert.match(PREVIEW, /export function openFileTab\(path: string, sid\?: string \| null\): boolean \{\n\s*if \(!canPreview\(\)\) return false;\n\s*const w = window\.open\(fileUrl\(path, sid\), "_blank"\);\n\s*if \(!w\) return false;/);
+  assert.match(PREVIEW, /export function openPdfTab\(path: string, sid\?: string \| null\): boolean \{\n\s*if \(previewKind\(path\) !== "pdf"\) return false;\n\s*return openFileTab\(path, sid\);\n\}/, "the PDF opener is the file opener with the kind check in front");
+});
+
+test("source: a link's line scrolls the code view's row once the text lands, spent once; a line past the end says so in the viewer's notice and lands on the last row; a markdown file takes its Raw view for that open without saving the preference", () => {
+  assert.match(VIEW, /export function openFileView\(path: string, sid\?: string \| null, opts\?: \{ line\?: number \| null; frag\?: string \| null \}\): void \{/);
+  assert.match(VIEW, /const scrollToLine = \(n: number\) => \{\n\s*const rows = body\.querySelectorAll\("code\.hljs \.fv-cl"\);\n\s*if \(!rows\.length\) return;\n\s*if \(n > rows\.length\) noteBar\("Line " \+ n \+ " is past the end of this file, which has " \+ rows\.length \+ \(rows\.length === 1 \? " line" : " lines"\) \+ "; showing the last line\."\);\n\s*\(rows\[Math\.min\(Math\.max\(0, n - 1\), rows\.length - 1\)\] as HTMLElement\)\.scrollIntoView\(\{ block: "center" \}\);/);
+  assert.match(VIEW, /let pendingLine: number \| null = opts && typeof opts\.line === "number" && opts\.line > 0 \? Math\.floor\(opts\.line\) : null;/);
+  assert.match(VIEW, /text = t;\n\s*\/\/[^\n]*\n\s*if \(pendingLine !== null && isMd && fmt\.md === "rendered"\) fmt\.md = "raw";\n\s*renderBody\(\);\n\s*if \(pendingLine !== null\) \{ scrollToLine\(pendingLine\); pendingLine = null; \}/);
+  const landing = VIEW.split("text = t;\n")[1].split("}).catch(")[0];
+  assert.doesNotMatch(landing, /saveFmt/, "the Raw view for this open only: the preference is not written");
+  assert.match(VIEW, /let pendingFrag: string \| null = opts\?\.frag \|\| null;/, "a sibling link's #fragment lands after the first rendered paint, as before");
+});
+
+test("source: the shared walk's options, the line units and the anchor marker live in path-links.ts, defaults unchanged for the chat; the module writes attributes, never markup", () => {
+  assert.match(LINKS, /export interface PathLinkOptions \{\n\s*inPre\?: boolean;\n\s*accept\?: \(tok: string, ctx: \{ text: string; at: number \}\) => boolean;\n\s*resolve\?: \(tok: string\) => string;\n\s*lineSuffix\?: boolean;\n\s*unit\?: string;\n\}/);
+  assert.match(LINKS, /export function linkifyPathTokens\(root: HTMLElement, pathLinks\?: Record<string, string>, opts\?: PathLinkOptions\): PathLinkHit\[\] \{/);
+  assert.match(LINKS, /export const DEAD_TEXT = "a, \.file-uri-link, svg";/, "a link, and an inline SVG (an element put inside SVG text does not render)");
+  assert.match(LINKS, /const skip = opts && opts\.inPre \? DEAD_TEXT : DEAD_TEXT \+ ", pre";/, "the chat still skips fenced blocks");
+  assert.match(LINKS, /const walker = document\.createTreeWalker\(root, NodeFilter\.SHOW_ELEMENT \| NodeFilter\.SHOW_TEXT\);/, "the walk sees elements, to cut a unit at a <br>");
+  assert.match(LINKS, /if \(n\.nodeType === 1\) \{\n\s*const e = n as Element;\n\s*if \(\/\^br\$\/i\.test\(e\.tagName\)\) broke = true;\n\s*else if \(unit && e\.matches\(unit\) && e\.textContent === ""\) \{ units\.push\(\{ text: "", spans: \[\] \}\); cur = null; \}[^\n]*\n\s*continue;\n\s*\}/, "an element is a <br> (a unit ends) or an empty unit element (an empty unit, a code view's blank row); nothing else");
+  assert.doesNotMatch(LINKS, /text\.slice\(start \+ tok\.length\)/, "the line suffix is read in place, never off a slice of the rest of the unit (quadratic)");
+  assert.match(LINKS, /LINE_SUFFIX_AT_RE\.lastIndex = start \+ tok\.length; suffix = LINE_SUFFIX_AT_RE\.exec\(text\);/);
+  assert.match(LINKS, /const LINE_SUFFIX_AT_RE = new RegExp\(LINE_SUFFIX_RE\.source\.replace\(\/\^\\\^\/, ""\), "y"\);/, "cut from the one source");
+  assert.doesNotMatch(MOD, /ctx\.text\.slice\(0, ctx\.at\)/, "the gate never reads the unit's whole text before the token (quadratic over a fence)");
+  assert.match(MOD, /if \(!anchored && importLookBehind\(ctx\.text, ctx\.at\)\.isImport\) return false;/);
+  assert.match(MOD, /const OPENER_RE = \/\[\\s\\u200b"'`\(<\[\{=,;\|\*\\u201c\\u2018\\u00ab\]\/u;/, "every space \\s names, the zero-width space, and Markdown's asterisk are openers to the gate (the underscore never reaches it)");
+  assert.match(MOD, /const STAR_CLOSE_RE = \/\(\?::\\d\+\(\?::\\d\+\)\?\|#L\\d\+\(\?:-L\?\\d\+\)\?\)\?\\\*\/y;/, "the closing star, read in place (sticky) past a line suffix");
+  assert.match(MOD, /if \(before === "\*"\) \{\n(?:\s*\/\/[^\n]*\n)*\s*if \(tok\.startsWith\("\/"\)\) return false;\n\s*STAR_CLOSE_RE\.lastIndex = ctx\.at \+ tok\.length;\n\s*if \(!STAR_CLOSE_RE\.test\(ctx\.text\)\) return false;/, "a star opens a token that is not /-led and is closed by a star, and nothing else (an anchored ./, ../ or ~/ path is emphasis, not a glob's tail)");
+  assert.match(MOD, /const FROM_LINE_RE = \/\^\\s\*from\\s\*\(\?:"\[\^"\]\*"\|'\[\^'\]\*'\)\\s\*;\?\\s\*\$\/;/, "a continuation line is `from` and a quoted specifier, a `;` or not");
+  assert.match(MOD, /const CLOSING_FROM_RE = \/\^\[\^"'`\]\*\\\}\\s\*from\\s\*\["'\]\/;/, "or holds `} from \"` with no quote before the brace");
+  assert.match(LINKS, /else if \(unit && e\.matches\(unit\) && e\.textContent === ""\) \{ units\.push\(\{ text: "", spans: \[\] \}\); cur = null; \}/, "a unit element with no text is an empty unit in its place: the units are the code view's rows, blank ones included");
+  assert.doesNotMatch(MOD, /ctx\.text\.slice\(ctx\.at/, "the closer is read in place, never off a slice of the rest of the unit");
+  // the import look-behind reads the line's head only after a keyword stands before the quote, so a quote with none costs the quote, the spaces and one word
+  const lb = MOD.split("function importLookBehind(text: string, at: number)")[1].split("\n}\n")[0];
+  assert.ok(lb.indexOf("return { start: s, isImport: false }") < lb.indexOf("lastIndexOf(\"\\n\", s - 1)"), "no keyword: return before the line is read back");
+  assert.ok(lb.indexOf("if (call) return") < lb.indexOf("lastIndexOf(\"\\n\", s - 1)"), "a call: return before the line is read back");
+  assert.match(lb, /const isImport = word === "from" \? STATEMENT_HEAD_RE\.test\(head\) \|\| continuesImport\(lineOf\(text, lineStart, at\)\) : \/\^\\s\*\$\/\.test\(head\);/);
+  assert.match(MOD, /const lineEnd = text\.indexOf\("\\n", at\);\n\s*return text\.slice\(lineStart, lineEnd < 0 \? text\.length : lineEnd\);/, "a from's line is read forward to its break, bounded by the line as the look-behind is");
+  assert.match(LINKS, /opts\.accept\(tok, \{ text, at: start \}\)/, "the walk hands the gate the token's line and offset, and nothing above them");
+  assert.match(MOD, /const STATEMENT_HEAD_RE = \/\^\\s\*\(\?:import\|export\)\\b\/;/);
+  assert.match(LINKS, /for \(const u of textUnits\(root, opts && opts\.unit, skip\)\) \{/, "no unit: every node its own unit, the chat's walk as it was");
+  assert.match(LINKS, /const span = spanHolding\(u, start, start \+ tok\.length\);\n\s*if \(!span\) continue;/, "a token across a node's edge is left as it is");
+  assert.match(LINKS, /if \(!isUri && opts && opts\.accept && !opts\.accept\(tok, \{ text, at: start \}\)\) continue;/);
+  assert.match(LINKS, /if \(isUri && opts && opts\.lineSuffix\) \{ const tail = URI_LINE_TAIL_RE\.exec\(tok\); if \(tail\) tok = tok\.slice\(0, tail\.index\); \}/);
+  assert.match(LINKS, /export const LINE_SUFFIX_RE = \/\^\(\?::\(\\d\+\)\(\?::\\d\+\)\?\|#L\(\\d\+\)\(\?:-L\?\\d\+\)\?\)\(\?!\[\\w\/\]\)\/;/);
+  assert.match(LINKS, /export function markPathLink\(a: HTMLElement, open: string, relative = false\): HTMLElement \{\n\s*const cls = a\.getAttribute\("class"\) \|\| "";\n\s*if \(!\(" " \+ cls \+ " "\)\.includes\(" file-uri-link "\)\) a\.setAttribute\("class", \(cls \? cls \+ " " : ""\) \+ "file-uri-link"\);\n\s*a\.setAttribute\("title", "Open " \+ open\);/, "attributes, so an SVG <a> is marked too");
+  assert.match(LINKS, /const a = el\("span", "file-uri-link"\);\n\s*a\.textContent = raw;[^\n]*\n\s*return markPathLink\(a, open, relative\);/, "openPathLink mints and marks");
+  assert.match(MOD, /linkifyPathTokens\(root, undefined, \{\n\s*inPre: true,\n\s*accept: \(tok, ctx\) => !insideUrl\(ctx\) && viewerPathGate\(tok, ctx\),\n\s*resolve: \(tok\) => resolveViewerPath\(tok, filePath\),\n\s*lineSuffix: true,\n\s*unit: LINE_UNITS,\n\s*\}\);/, "the viewer runs the chat's walk under its own gate, a line at a time, and never inside a URL of the line");
+  assert.match(MOD, /if \(ctx\.text !== lineText\) \{ lineText = ctx\.text; lineUrls = \/https\?:\\\/\\\/\/i\.test\(ctx\.text\) \? urlRanges\(ctx\.text\) : \[\]; \}/, "the line's URLs are found once per line, not per token");
+  assert.match(MOD, /for \(const u of textUnits\(root, LINE_UNITS, DEAD_TEXT\)\) \{/, "the URL pass reads the same lines and skips the same text");
+  assert.match(MOD, /a\.setAttribute\("target", "_blank"\);\n\s*a\.setAttribute\("rel", "noopener"\);/);
+  assert.doesNotMatch(MOD, /innerHTML|outerHTML|insertAdjacentHTML/, "the module builds elements; it never writes markup");
+});
+
+test("the dress is light, and in both sheets: the token keeps its colour under a faint dotted underline, solid on hover; a Markdown file link keeps the link ink; a dead link says so", () => {
+  for (const [name, css] of [["styles.css", CHAT_CSS], ["feed.css", FEED_CSS]] as const) {
+    const rule = (head: string) => { const at = css.indexOf(head); assert.ok(at >= 0, name + ": " + head); return css.slice(at, css.indexOf("}", at) + 1); };
+    const base = rule(".fileview-body .file-uri-link, .fileview-body .fv-url {");
+    assert.match(base, /color: inherit;/, name + ": the highlight's colour stays");
+    assert.match(base, /text-decoration: underline dotted;/); assert.match(base, /text-decoration-color: color-mix\(in srgb, currentColor 35%, transparent\);/);
+    assert.match(base, /cursor: pointer;/);
+    assert.match(base, /-webkit-user-drag: none; user-select: text;/, "not draggable, and selectable: a press-drag on a link selects the text under it");
+    const hover = rule(".fileview-body .file-uri-link:hover, .fileview-body .fv-url:hover {");
+    assert.match(hover, /text-decoration: underline;/); assert.match(hover, /text-decoration-color: currentColor;/);
+    assert.match(rule(".fileview-md a.file-uri-link {"), /color: var\(--link\); text-decoration: none;/);
+    assert.match(rule(".fileview-md a.file-uri-link:hover {"), /text-decoration: underline;/);
+    assert.match(rule(".fileview-md a.fv-dead {"), /cursor: help;/);
+    assert.doesNotMatch(base + hover, /font-size|--[a-z-]+: /, "no new font size, no new token");
+  }
+});

--- a/ui/webview/file-view-links.ts
+++ b/ui/webview/file-view-links.ts
@@ -1,0 +1,459 @@
+// Links inside a file the viewer shows (the user 2026-09-07): an http(s) URL in the text opens in a new tab, a file
+// path opens in the viewer, and a Markdown link's target follows the same two rules. One pass over the TEXT NODES of
+// a body the viewer has already built, never over its HTML string: hljs's markup and the sanitizer's verdicts stand,
+// no raw file text is ever parsed as markup, and a row's text reads exactly as the file's after the pass (a selection
+// over a line with a link in it, and the quote chip it seeds, see the same characters). The pass ADDS elements around
+// runs of text and nothing else.
+//
+// The pass reads a LINE at a time, not a text node (path-links.ts textUnits, under LINE_UNITS: a code view's row, or a
+// rendered block whose own line breaks are whitespace to the gate): the highlight wraps a shell or template
+// substitution in a span of its own, so `"$HOME/docs/a.md"` reaches the DOM as three text nodes, and a walk over the
+// third alone would read `/docs/a.md` as an absolute path that was never written. Over the line's joined text the
+// token is `HOME/docs/a.md`, glued to the `$` before it, and the gate below refuses a token glued to anything but an
+// opener. A token the highlight cut through (its text in two nodes) is left as it is, never re-read as its pieces, and
+// so is a URL; a token inside a URL of its line is the URL's, wrapped or not (a cut URL stays text, and its query can
+// carry a path). Text inside an inline SVG is read but never marked (path-links.ts DEAD_TEXT): an HTML element
+// inserted into SVG text does not render.
+//
+// The path grammar is the chat's (path-links.ts: the one matcher, the one span), run with the walk's options for a
+// surface that is code rather than prose, plus one gate of its own, viewerPathGate. The chat has the kernel's stat
+// verdict to narrow its matches; this surface has no verdict and narrows by shape, and every false link is noise on
+// a surface the person reads for hours. The gate's grammar, in full (docs/guide.md says the same in the user's words):
+// a token links when it has a slash and its last segment has a letter-led extension of one to eight letters or digits
+// (a dotfile only under an anchored start: `/`, `./`, `../`, `~/`); it is not glued to the character before it (the
+// line's start, whitespace or an opener must precede it: a quote, a bracket, `=`, `,`, `;`, `|`, or Markdown's `*`
+// when the path is the whole emphasised text), which is what cuts `$HOME/docs/a.md`, `${dir}/out.json`,
+// `$(ROOT)/src/x.c`, `@scope/pkg/index.js`, `C:/Users/x/file.txt` and `git@host:user/repo.git` down to prose; it is
+// not inside a web address on its line; an unanchored token's first segment does not read as a hostname (`www.` or
+// dotted labels ending in two or more letters: `www.example.org/docs/index.html`, `example.com/index.html`); an
+// unanchored token is not the specifier an import statement or a require call names (`import x from
+// "lodash/fp.js"`, `require("pkg/sub.js")`; the English `from` in `Copied from "docs/a.md"` names a file); and a `~`
+// start is `~/` (`~user/x.md` names a home the kernel does not expand). A local file:// URI (an empty authority, or
+// `localhost`) links as written. A relative token resolves against the shown file's own directory (a file's mentions
+// are written from where the file is), an absolute or `~/` one passes to the kernel as written (it expands `~` and
+// reads the file's session's machine), and the resolved path is normalized once, here (`docs/../src/app.py` opens,
+// and is titled, as `src/app.py`). A `:12` written after a path (or GitHub's `#L12`) rides in the link and the
+// viewer scrolls to that line.
+//
+// What a click does is the viewer's (file-view.ts binds the body's listener: a path link opens the file in the
+// viewer, a URL anchor opens itself, a modified click opens either in a tab of its own). This module marks; it binds
+// no action.
+import { linkifyPathTokens, markPathLink, fileUriToPath, isFileUri, LINE_SUFFIX_RE, DEAD_TEXT, textUnits, spanHolding, rewriteSpan, type TextSpan } from "./path-links";
+import { headingSlug } from "./md-links";   // the slug the viewer mints heading ids from (`md-` + slug), so a section link finds its heading
+import { userContentTarget } from "./md-sanitize";   // an author's id or name, under the sanitizer's user-content- prefix or bare: the lookup the chat's `#` click reads too
+
+/** The URL anchors this module mints wear this class; the viewer's listener and the sheets key on it. */
+export const URL_LINK_CLASS = "fv-url";
+/** A Markdown link to a section of the shown document (`#install`): the viewer's listener scrolls to the target
+ *  when the document has one, and never lets the click move the hosting document. */
+export const FRAG_LINK_CLASS = "fv-frag";
+/** An anchor with no target the viewer can follow (the sanitizer removed it; a section the document does not
+ *  have): dressed as a dead link, with its title saying why (fail loudly, never a silent dead end). */
+export const DEAD_LINK_CLASS = "fv-dead";
+export const DEAD_LINK_TITLE = "Not a link the viewer can follow: its target is neither a web address nor a file on the session's machine";
+/** A `name:port` target whose name reads as a host (an IPv4 address, `localhost`, a hostname by shape): a host with
+ *  a port, which is neither a web address nor a file, said so in place of a file named after the host at a line
+ *  numbered after the port. */
+export const HOST_PORT_TITLE = "Not a link the viewer can follow: the target is a host with a port, not a file on the session's machine";
+/** A relative target that resolves to no path at all. From a file named with a directory (`docs/plan.md`) that is
+ *  `../` or `..`: a folder above the file's own, which the viewer cannot name and so cannot open. From a file named
+ *  without one (`README.md`, as a chat-relayed relative path opens it) it is `./`, `.` or `docs/../`: the folder the
+ *  file is in, which the name does not carry. The title says which. A target that climbs out of a relative name
+ *  (`../` from `README.md`) keeps its `..` and is a live link the kernel resolves. */
+export const EMPTY_TARGET_TITLE = "Not a link the viewer can follow: the target points above the folder this file is named in, so there is no path to open";
+export const SELF_TARGET_TITLE = "Not a link the viewer can follow: the target is the folder this file is in, and the file's name carries no folder, so there is no path to open";
+export const emptyTargetTitle = (filePath: string): string => (filePath.includes("/") ? EMPTY_TARGET_TITLE : SELF_TARGET_TITLE);
+export const noSectionTitle = (id: string): string => "No heading or anchor named \u201c" + id + "\u201d in this document";
+
+/** The elements whose text is one unit to the pass: a code view's row (.fv-cl), a rendered fenced block's row (.cl,
+ *  code-block.ts wrapCodeLines: the rows drop the fence's newlines, so the <pre> alone would read its lines as one), a
+ *  rendered block (a paragraph, a list item, a cell, a heading, a quote). Text under none of these is a unit of its own. */
+export const LINE_UNITS = ".fv-cl, .cl, p, li, td, th, dt, dd, h1, h2, h3, h4, h5, h6, pre, blockquote, caption, figcaption, summary";
+
+// An http(s) URL in running text: the scheme, then everything up to whitespace or a character no URL carries
+// unescaped in prose or code (a quote, an angle bracket, a backtick).
+const URL_RE = /https?:\/\/[^\s<>"'`]+/gi;
+// Sentence punctuation a URL is followed by, not part of: trimmed from the end, then a closing bracket that has no
+// opening partner inside the URL (`(see https://x.y/z)` ends before the paren; a Wikipedia-style
+// `https://x.y/Foo_(bar)` keeps its own).
+const URL_TRAIL = ".,;:!?'\"";
+const PAIRS: Record<string, string> = { ")": "(", "]": "[", "}": "{" };
+function trimUrl(u: string): string {
+  for (;;) {
+    const last = u[u.length - 1];
+    if (URL_TRAIL.includes(last)) { u = u.slice(0, -1); continue; }
+    const open = PAIRS[last];
+    if (open) {
+      let depth = 0;
+      for (const c of u) { if (c === open) depth++; else if (c === last) depth--; }
+      if (depth < 0) { u = u.slice(0, -1); continue; }   // one more closer than opener: it closes the sentence's bracket
+    }
+    return u;
+  }
+}
+/** `text` cut into runs, each a URL (`href` set) or plain text; the URLs trimmed of trailing punctuation. */
+export function urlSegments(text: string): Array<{ text: string; href?: string }> {
+  const out: Array<{ text: string; href?: string }> = [];
+  let last = 0;
+  URL_RE.lastIndex = 0;
+  for (let m: RegExpExecArray | null; (m = URL_RE.exec(text));) {
+    const u = trimUrl(m[0]);
+    if (!u || !/^https?:\/\/[^/?#]+/i.test(u)) { URL_RE.lastIndex = m.index + m[0].length; continue; }   // a bare scheme, no host
+    if (m.index > last) out.push({ text: text.slice(last, m.index) });
+    out.push({ text: u, href: u });
+    last = m.index + u.length;
+    URL_RE.lastIndex = last;
+  }
+  if (!out.length) return [{ text }];
+  if (last < text.length) out.push({ text: text.slice(last) });
+  return out;
+}
+/** The URLs in `text` as [start, end) ranges of it: exactly what urlSegments would wrap. */
+export function urlRanges(text: string): Array<[number, number]> {
+  const out: Array<[number, number]> = [];
+  let at = 0;
+  for (const s of urlSegments(text)) { if (s.href) out.push([at, at + s.text.length]); at += s.text.length; }
+  return out;
+}
+
+// The gate's pieces (the grammar is written out in the header). What may stand right before a token: nothing (the
+// line's start), whitespace, or an opener; a token glued to anything else is the tail of something the matcher cut
+// through. Whitespace is every character \s names, a line break and a no-break space among them (a rendered
+// paragraph, list item or fenced block is one unit of text with its line breaks inside it, so a path may start any
+// line of it), plus the zero-width space, which text pasted from a chat tool carries and \s leaves out. An asterisk
+// is Markdown emphasis in the Raw view (`**docs/a.md**`), the view a `:line` link lands in, and it opens a token
+// only when a closing asterisk follows the token and the token is not `/`-led (viewerPathGate, STAR_CLOSE_RE: a
+// glob's `**/docs/a.md` and an operand's `w*h/img.size` have no closer, and a glob's tail after its star begins
+// with `/`). Not `_`: the matcher's path arm takes an underscore into the token, so `_docs/a.md_` is one token the
+// extension test refuses and `_docs/a.md` names a folder called `_docs`; the gate never sees `_` before a token.
+// Not `)`, `]`, `:` or `#`: `$(ROOT)/src/x.c`, `git@host:user/repo.git` and `x#/docs/a.md` are glue.
+const OPENER_RE = /[\s\u200b"'`(<[{=,;|*\u201c\u2018\u00ab]/u;
+// The closing star emphasis puts after its path, read in place at the token's end (sticky); a `:12` or `#L12` may sit between.
+const STAR_CLOSE_RE = /(?::\d+(?::\d+)?|#L\d+(?:-L?\d+)?)?\*/y;
+const ANCHORED_RE = /^(?:~\/|\.{1,2}\/|\/)/;
+// a first segment that reads as a hostname
+const WWW_RE = /^www\./i;
+const HOST_RE = /^[a-z0-9-]+(?:\.[a-z0-9-]+)*\.[a-z]{2,}$/i;
+// The text before a bare specifier in an import: `import x from "`, `import "`, `export * from "`, `require("`,
+// `import("`. Read BACKWARDS from the token: the quote, the line's spaces, one paren, more spaces, then the word
+// before them, at most a keyword's width. A line break stops every step, so the window is the current line's, and
+// its length is bounded by what stands right before the token, never by the unit (a regex over the unit's text
+// before the token would slice the whole unit per token, quadratic over a fenced block). `from` and its quote on
+// different lines do not read as an import, which no formatter writes. The word alone is not the verdict: `from`
+// and `export` are English, and `Copied from "docs/a.md"` in a note names a file. The word counts when the
+// statement around it is code: a call (`require("…")`, `import("…")`), a keyword that starts its line (`import
+// "pkg/x.css"`), a `from` whose line began with `import` or `export` (`import x from "…"`, `export * from "…"`), or
+// a `from` on a line shaped as the continuation of an import opened above it (continuesImport, below). Only then is
+// the line read back to its start (and, for a `from`, forward to its end), so a quote with no keyword before it
+// still costs the quote, the spaces and one word.
+const IMPORT_WORDS = ["import", "export", "from", "require"];
+const KEYWORD_MAX = 7;                                   // `require`
+const STATEMENT_HEAD_RE = /^\s*(?:import|export)\b/;    // the line began an import or export statement
+// A line that continues an import opened on a line above it, told by its own shape and nothing else: the whole line
+// is `from` and a quoted specifier, a `;` after it or not (`  from "pkg/x.js";` under `import { a }`, `import * as
+// ns`, `import React`, `export *` or `export type { T }`), or it holds `} from "` with no quote before the brace
+// (`  a, b } from "pkg/x.js";` under `import {`; Prettier's own `} from "pkg/x.js";`). Reading the rows above such
+// a line for the import that opened it finds a shape it missed each time (a blank row between them, a default name
+// alone, `import * as ns`, `export *`): the line says enough by itself, and the one price is a prose line of exactly
+// `from "docs/a.md"`, which stays text. A `from` with more after its specifier is English wherever it stands: `from
+// "pkg/sub.py" import x`, `from "docs/a.md" and kept it`, `# adapted from "docs/a.md"` under `import os`.
+const FROM_LINE_RE = /^\s*from\s*(?:"[^"]*"|'[^']*')\s*;?\s*$/;
+const CLOSING_FROM_RE = /^[^"'`]*\}\s*from\s*["']/;
+const continuesImport = (line: string): boolean => FROM_LINE_RE.test(line) || CLOSING_FROM_RE.test(line);
+const isWordCh = (c: string): boolean => /[A-Za-z0-9_]/.test(c);
+const isLineSpace = (c: string): boolean => c === " " || c === "\t";
+function importLookBehind(text: string, at: number): { start: number; isImport: boolean } {
+  let i = at - 1;
+  if (i < 0 || !"\"'`".includes(text[i])) return { start: at, isImport: false };   // no quote before the token: nothing to read
+  i--;
+  while (i >= 0 && isLineSpace(text[i])) i--;
+  let call = false;
+  if (i >= 0 && text[i] === "(") { call = true; i--; while (i >= 0 && isLineSpace(text[i])) i--; }
+  const end = i + 1;
+  let s = end;
+  while (s > 0 && end - s < KEYWORD_MAX && isWordCh(text[s - 1])) s--;
+  const word = text.slice(s, end);
+  if (!IMPORT_WORDS.includes(word) || (s > 0 && isWordCh(text[s - 1]))) return { start: s, isImport: false };   // no keyword, or the tail of a longer word
+  if (call) return { start: s, isImport: word === "require" || word === "import" };                          // a call: code wherever it stands
+  const lineStart = text.lastIndexOf("\n", s - 1) + 1;
+  const head = text.slice(lineStart, s);                 // what the line holds before the keyword: an import clause, or prose
+  const isImport = word === "from" ? STATEMENT_HEAD_RE.test(head) || continuesImport(lineOf(text, lineStart, at)) : /^\s*$/.test(head);
+  return { start: lineStart, isImport };
+}
+// The line at `lineStart` through its break (or the text's end), read forward from `at`: bounded by the line, as the
+// look-behind is, so the pass stays linear over a fenced block.
+function lineOf(text: string, lineStart: number, at: number): string {
+  const lineEnd = text.indexOf("\n", at);
+  return text.slice(lineStart, lineEnd < 0 ? text.length : lineEnd);
+}
+/** Where the gate's look-behind for the token at `at` begins: the earliest index whose character it reads as text
+ *  (one more before it is looked at only as the keyword's word boundary). Never before the line's start. */
+export function lookBehindStart(text: string, at: number): number { return importLookBehind(text, at).start; }
+
+/** The viewer's gate over a token the shared shape gates passed; `ctx` is the line's text and the token's offset in
+ *  it (the walk hands both over), without which only the token's own shape is judged. */
+export function viewerPathGate(tok: string, ctx?: { text: string; at: number }): boolean {
+  if (isFileUri(tok)) return true;
+  if (!tok.includes("/")) return false;
+  if (tok.startsWith("~") && !tok.startsWith("~/")) return false;      // `~user/x.md`: a home the kernel does not expand
+  const base = tok.slice(tok.lastIndexOf("/") + 1);
+  const dot = base.lastIndexOf(".");
+  if (dot < 0 || !/^[A-Za-z][A-Za-z0-9]{0,7}$/.test(base.slice(dot + 1))) return false;
+  const anchored = ANCHORED_RE.test(tok);
+  if (dot === 0 && !anchored) return false;                            // a dotfile links under an anchored start only
+  if (!anchored) {
+    const first = tok.slice(0, tok.indexOf("/"));
+    if (WWW_RE.test(first) || HOST_RE.test(first)) return false;       // a site, not a folder
+  }
+  if (ctx) {
+    const before = ctx.at > 0 ? ctx.text[ctx.at - 1] : "";
+    if (before && !OPENER_RE.test(before)) return false;               // glued to a substitution, a scope, a drive, a host
+    if (before === "*") {
+      // Emphasis wraps its path in stars on both sides (`*docs/a.md*`, `**docs/a.md**`, `**./scripts/setup.sh**`, a
+      // `:line` inside them too). A `/`-led token after a star is a glob's tail (`**/docs/a.md`, `src/*/index.ts`,
+      // `packages/*/package.json`), and a token with no closing star is an operand (`w*h/img.size`, `2*docs/times.md`).
+      // The glob test is the leading slash, not the anchor: a glob's tail after its star always begins with `/`, and
+      // `*./`, `*../`, `*~/` are emphasis and nothing else.
+      if (tok.startsWith("/")) return false;
+      STAR_CLOSE_RE.lastIndex = ctx.at + tok.length;
+      if (!STAR_CLOSE_RE.test(ctx.text)) return false;
+    }
+    if (!anchored && importLookBehind(ctx.text, ctx.at).isImport) return false;   // a package specifier
+  }
+  return true;
+}
+
+/** `p` with its `.` and `..` segments resolved and doubled slashes dropped, lexically: `/a/b/../c.md` is `/a/c.md`,
+ *  `docs/../src/app.py` is `src/app.py`. A `..` above the root stays at the root; one above `~` or above a relative
+ *  path's start is kept (`~/../x.md`, `../../x.md`: the kernel resolves those against the session). */
+export function normalizePath(p: string): string {
+  const abs = p.startsWith("/");
+  const segs = p.split("/").filter((s, i, a) => s !== "." && (s !== "" || (i > 0 && i === a.length - 1)));   // a trailing "" keeps a directory's slash
+  const out: string[] = [];
+  for (const s of segs) {
+    if (s === "..") {
+      const top = out[out.length - 1];
+      if (out.length && top !== ".." && top !== "~") { out.pop(); continue; }
+      if (abs) continue;
+    }
+    out.push(s);
+  }
+  return (abs ? "/" : "") + out.join("/");
+}
+
+/** What a token in `filePath`'s text opens: a URI's own path; an absolute or `~/` path as written; a relative one
+ *  joined onto the shown file's directory (`""` for a file named without one, which then resolves against the
+ *  session's cwd on the kernel exactly as the file itself did). Normalized once, here. */
+export function resolveViewerPath(tok: string, filePath: string): string {
+  if (isFileUri(tok)) return normalizePath(fileUriToPath(tok));
+  if (tok.startsWith("/") || tok.startsWith("~/")) return normalizePath(tok);
+  return normalizePath(filePath.slice(0, filePath.lastIndexOf("/") + 1) + tok);
+}
+
+/** Mark the URLs in `root`'s text as anchors that open a new tab (target _blank, rel noopener noreferrer, the URL as
+ *  the title), a line at a time (LINE_UNITS). Text already inside a link, and a URL the highlight cut into two
+ *  nodes, are left alone. The anchors are not draggable (draggable=false here, `-webkit-user-drag: none` and
+ *  `user-select: text` in the sheets): a press-drag that starts on one selects the text under it, as it does on a
+ *  path link, instead of starting the browser's link drag; the click that ends the drag finds a selection open inside
+ *  the anchor, and every opener it reaches yields to that (path-links.ts selectionOpenIn: the viewer's listener, and
+ *  the chat's document-level opener, which runs first). Returns the anchors made. */
+export function linkifyUrls(root: HTMLElement): HTMLAnchorElement[] {
+  const made: HTMLAnchorElement[] = [];
+  const doc = root.ownerDocument || document;
+  for (const u of textUnits(root, LINE_UNITS, DEAD_TEXT)) {
+    if (!/https?:\/\//i.test(u.text)) continue;
+    const marks = new Map<TextSpan, Array<{ start: number; end: number; el: Node }>>();
+    let at = 0;
+    for (const s of urlSegments(u.text)) {
+      const start = at;
+      at += s.text.length;
+      if (!s.href) continue;
+      const span = spanHolding(u, start, at);
+      if (!span) continue;
+      const a = doc.createElement("a");
+      a.className = URL_LINK_CLASS;
+      a.href = s.href;
+      a.target = "_blank";
+      a.rel = "noopener noreferrer";
+      a.title = s.href;
+      a.setAttribute("draggable", "false");
+      a.textContent = s.text;
+      let list = marks.get(span);
+      if (!list) { list = []; marks.set(span, list); }
+      list.push({ start, end: at, el: a });
+      made.push(a);
+    }
+    for (const [span, list] of marks) rewriteSpan(u, span, list);
+  }
+  return made;
+}
+
+/** Every text node under `root`, document order, through childNodes alone (a stand-in without a tree walker
+ *  runs it as the browser does). */
+function textNodesOf(root: Node): Text[] {
+  const out: Text[] = [];
+  const visit = (n: Node) => {
+    for (const c of Array.from(n.childNodes || [])) { if (c.nodeType === 3) out.push(c as Text); else if (c.nodeType === 1) visit(c); }
+  };
+  visit(root);
+  return out;
+}
+
+/** The whole pass over a text body the viewer built (the code view's <code>, a rendered markdown box): URLs first,
+ *  then the shared path walk under the viewer's gate and resolution, both a line at a time. A wrapped URL is dead text
+ *  to the walk; one the highlight cut across two nodes stays text, and the walk over the line would then read a
+ *  path-shaped query value inside it as an absolute path (`https://x.y/q?x=/docs/a.md/$V`: hljs puts `$V` in a span
+ *  of its own), so the gate also refuses a token inside any URL of its line, wrapped or not. The line's URLs are
+ *  found once per line, not per token: the walk asks about a line's tokens in a row. A body with no text (a stand-in
+ *  that parses no HTML, an empty file) is left as it is. */
+export function linkifyFileText(root: HTMLElement, filePath: string): void {
+  if (!textNodesOf(root).length) return;
+  linkifyUrls(root);
+  let lineText: string | null = null, lineUrls: Array<[number, number]> = [];
+  const insideUrl = (ctx: { text: string; at: number }): boolean => {
+    if (ctx.text !== lineText) { lineText = ctx.text; lineUrls = /https?:\/\//i.test(ctx.text) ? urlRanges(ctx.text) : []; }
+    return lineUrls.some(([s, e]) => ctx.at >= s && ctx.at < e);
+  };
+  linkifyPathTokens(root, undefined, {
+    inPre: true,
+    accept: (tok, ctx) => !insideUrl(ctx) && viewerPathGate(tok, ctx),
+    resolve: (tok) => resolveViewerPath(tok, filePath),
+    lineSuffix: true,
+    unit: LINE_UNITS,
+  });
+}
+
+/** A Markdown link's destination, put in the form the sanitizer keeps and this module reads, BEFORE marked makes
+ *  the HTML (mdBlock hands viewerWalkTokens to marked). DOMPurify drops an href whose first segment holds a colon
+ *  (`notes.md:7` reads as a scheme) and one whose scheme is `file:`, and an anchor it stripped is a dead label the
+ *  module can no longer sort. So a same-directory `name.ext:12` becomes `./name.ext:12`, and a local file:// URI
+ *  becomes its path. Anything else is left as written: a real scheme is the browser's, and a URI on another host
+ *  is not a path (path-links.ts isFileUri); those the sanitizer still removes render as dead links that say why. */
+// `api.example.com:8443` has the `name.ext:N` shape and is a host with a port. Which names read as a host, by shape
+// alone (whether the file exists is unknowable here): `www.` first; or dotted labels that read as a hostname (HOST_RE,
+// the gate's own test) whose last label is a top-level domain, whatever the label count: one of the generic and
+// reserved TLDs below (`example.com`, `docs.example.io`, `x.internal`), or a two-letter country code under a
+// second-level label the registries use (`co.uk`, `com.au`, `ac.jp`: `sub.example.co.uk`). Everything else is a
+// file, whether or not the chat's bare-name gate knows its extension: `notes.md`, `app.test.ts`, `archive.tar.gz`,
+// `app.component.vue`, `styles.module.less`, `report.final.docx`, `init.el`. A host is left as written: the
+// sanitizer removes the target, and the anchor renders dead with the reason.
+const SAME_DIR_LINE_RE = /^([^/:?#]*\.[A-Za-z][A-Za-z0-9]{0,7}):\d+(?::\d+)?(?:[?#].*)?$/;
+const TLD_LIKE = new Set(["com", "net", "org", "edu", "gov", "mil", "int", "io", "dev", "app", "ai", "co", "info", "biz", "xyz", "cloud", "online", "site", "tech",
+                          "invalid", "test", "example", "local", "localhost", "internal", "arpa", "onion"]);
+const SECOND_LEVEL = new Set(["co", "com", "org", "net", "ac", "gov", "edu", "or", "ne", "go"]);
+export function isHostName(name: string): boolean {
+  if (WWW_RE.test(name)) return true;
+  if (!HOST_RE.test(name)) return false;
+  const labels = name.toLowerCase().split(".");
+  const last = labels[labels.length - 1];
+  return TLD_LIKE.has(last) || (last.length === 2 && labels.length >= 3 && SECOND_LEVEL.has(labels[labels.length - 2]));
+}
+const IPV4_RE = /^\d{1,3}(?:\.\d{1,3}){3}$/;
+const isHostWithPort = (name: string): boolean => IPV4_RE.test(name) || name.toLowerCase() === "localhost" || isHostName(name);
+export function viewerLinkTarget(href: string): string {
+  if (isFileUri(href)) return fileUriToPath(href);
+  const m = SAME_DIR_LINE_RE.exec(href);
+  if (m && !isHostName(m[1])) return "./" + href;
+  return href;
+}
+export function viewerWalkTokens(token: { type: string; href?: string | null }): void {
+  if (token.type === "link" && typeof token.href === "string") token.href = viewerLinkTarget(token.href);
+}
+
+/** The element a section link's `id` names in `root`. An author's own id or name reaches the DOM under the sanitizer's
+ *  `user-content-` prefix (md-sanitize.ts, the rule GitHub applies), so the lookup is the sanitizer's own: the first
+ *  element whose id is the prefixed spelling or the bare one, else the first `<a name>` with either (the README idiom
+ *  for a stable anchor, `<a name="install"></a>` above a heading, which marked passes through), in document order, as
+ *  a browser's fragment rule has it (userContentTarget, which the chat's `#` click reads too). Else the heading whose
+ *  slug it is: marked gives headings no ids, and the viewer mints one per heading as `md-` + its GitHub slug (mdBlock,
+ *  after the sanitize, so never prefixed), so `#Evidence Results`, `#evidence-results` and the percent-encoded spelling
+ *  all name md-evidence-results. Mark time and click time both ask here (file-view.ts scrollToFragment). */
+export function fragmentTarget(root: ParentNode, id: string): Element | undefined {
+  return userContentTarget(root, id)
+    || root.querySelector('[id="md-' + headingSlug(id) + '"]') || undefined;   // the slug's alphabet needs no escaping
+}
+
+const withClass = (a: Element, cls: string): void => {
+  const have = a.getAttribute("class") || "";
+  if (!(" " + have + " ").includes(" " + cls + " ")) a.setAttribute("class", (have ? have + " " : "") + cls);
+};
+
+/** A rendered Markdown link's target, sorted the way the text is: a scheme (http:, https:, mailto:, …) or a
+ *  protocol-relative `//host` opens a new tab, as the viewer always had it; a query alone (`?x=1`) is a web-style
+ *  link to the page's own address and opens a new tab too (the viewer's document is never navigated); a fragment
+ *  alone (`#section`) is the viewer's (FRAG_LINK_CLASS: the listener scrolls to the element with that id, or the
+ *  `<a name>` of that name, or the heading of that slug, when the document holds one, else the title says there is
+ *  none); anything else names a file, relative to the shown one, and the anchor becomes a path link (the shared shape
+ *  on its own <a>, so `[**bold** text](docs/x.md)` keeps its label). marked percent-encodes a destination
+ *  (`my%20notes.md`), so it is decoded first; a `#L12` or `:12` on the target is the line; any other `#fragment`
+ *  (`report.md#results`) rides as the section to land on once the file is open (data-frag); a `?query` is dropped
+ *  from the path. The href comes off a path link: a browser must not follow it, and the chat's document-level opener
+ *  reads only anchors with one. An anchor the sanitizer left without an href (a scheme it refuses, a file on another
+ *  host) is dressed dead with the reason in its title, unless it is a named target and never was a link; so is a
+ *  file target that resolves to no path (`[up](../)` from a file named without a directory). Every attribute is set
+ *  as one (an inline SVG's <a> has no target, rel, className or title property to write). */
+export function linkMarkdownAnchors(root: HTMLElement, filePath: string): void {
+  root.querySelectorAll("a").forEach((node) => {
+    const a = node as HTMLElement;
+    const href = a.getAttribute("href");
+    if (href === null) {
+      if (a.hasAttribute("name") || a.hasAttribute("id")) return;
+      withClass(a, DEAD_LINK_CLASS);
+      a.setAttribute("title", DEAD_LINK_TITLE);
+      return;
+    }
+    if (href.startsWith("#")) {
+      let id = href.slice(1);
+      try { id = decodeURIComponent(id); } catch { /* a malformed escape: the spelling as written */ }
+      const hit = id ? fragmentTarget(root, id) : undefined;
+      withClass(a, FRAG_LINK_CLASS);
+      if (hit) { a.dataset.frag = id; a.setAttribute("title", "Go to " + id); }
+      else { withClass(a, DEAD_LINK_CLASS); a.setAttribute("title", noSectionTitle(id)); }
+      return;
+    }
+    // `127.0.0.1:3000`, `localhost:8080`, `example.com:8443`: a host with a port, which reads as a scheme to the test
+    // below (and to the sanitizer, which removes all but the digit-led one; the IPv4 address would reach the path arm
+    // and link a file named 127.0.0.1 at line 3000). A hostname by shape, an IPv4 address or `localhost` before a
+    // port is a dead link that says so.
+    const hostPort = /^([^/?#:]+):\d+(?:[/?#]|$)/.exec(href);
+    if (hostPort && isHostWithPort(hostPort[1])) {
+      a.removeAttribute("href");
+      withClass(a, DEAD_LINK_CLASS);
+      a.setAttribute("title", HOST_PORT_TITLE);
+      return;
+    }
+    if (href.startsWith("//") || /^[a-z][a-z0-9+.-]*:/i.test(href)) {
+      a.setAttribute("target", "_blank");
+      a.setAttribute("rel", "noopener");
+      return;
+    }
+    let dest = href;
+    try { dest = decodeURI(href); } catch { /* a malformed escape: the spelling as written */ }
+    const cut = dest.search(/[?#]/);
+    const tail = cut >= 0 ? dest.slice(cut) : "";
+    let pathPart = cut >= 0 ? dest.slice(0, cut) : dest;
+    // a line on the path itself (`a.md:12`) or in the fragment (`a.md#L12`); any other fragment (`report.md#results`,
+    // after a `?query` or not) is the section to land on once the file is open
+    const hashAt = tail.indexOf("#");
+    const hash = hashAt >= 0 ? tail.slice(hashAt) : "";
+    let line: string | null = null, frag: string | null = null;
+    const colon = /:(\d+)(?::\d+)?$/.exec(pathPart);
+    if (colon) { line = colon[1]; pathPart = pathPart.slice(0, colon.index); }
+    else if (hash) { const m = LINE_SUFFIX_RE.exec(hash); if (m && m[2]) line = m[2]; else if (hash.length > 1) frag = hash.slice(1); }
+    if (!pathPart) {
+      a.setAttribute("target", "_blank");
+      a.setAttribute("rel", "noopener noreferrer");
+      return;
+    }
+    a.removeAttribute("href");                          // the browser must not follow it, whichever way it is dressed
+    const open = resolveViewerPath(pathPart, filePath);
+    if (!open) {                                        // `[up](../)` from `docs/plan.md`, `[here](./)` from `README.md`: no path to open, said so, never a silent click
+      withClass(a, DEAD_LINK_CLASS);
+      a.setAttribute("title", emptyTargetTitle(filePath));
+      return;
+    }
+    markPathLink(a, open, true);
+    if (line) { a.dataset.line = line; a.setAttribute("title", a.getAttribute("title") + ":" + line); }
+    else if (frag) { a.dataset.frag = frag; a.setAttribute("title", a.getAttribute("title") + "#" + frag); }
+  });
+}

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -796,7 +796,7 @@ test("the title bar carries a session chip resolved from the sid — never inven
   assert.match(openFn, /bar\.appendChild\(name\); if \(sess\) bar\.appendChild\(sess\); bar\.appendChild\(acts\);/,
     "between the path and the actions");
   // the signatures every opener and the relay pin depend on are exactly as they were
-  assert.match(VIEW, /export function openFileView\(path: string, sid\?: string \| null, frag\?: string \| null\): void \{/);   // frag: a sibling link's fragment lands after the render
+  assert.match(VIEW, /export function openFileView\(path: string, sid\?: string \| null, opts\?: \{ line\?: number \| null; frag\?: string \| null \}\): void \{/);   // frag: a sibling link's fragment lands after the render
   assert.match(VIEW, /export function initFileView\(poster: \(m: Record<string, unknown>\) => void\): void \{/);
 });
 

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -21,8 +21,11 @@ import { sanitizeMd } from "./md-sanitize";
 import { hostOf, bareId, hostNameNodes } from "./host-prefix";
 import { fileUrl } from "./preview";
 import { openPdfTab, wantsOwnTab } from "./preview";   // a PDF's own tab, and the gesture that asks for it
+import { openFileTab, canPreview } from "./preview";   // any file's own tab, for the links inside a shown file, and the web-vs-webview test
 import { kernelUrl } from "./media";
 import { quoteSrcLabel } from "./docreview";
+import { linkifyFileText, linkMarkdownAnchors, viewerWalkTokens, fragmentTarget, URL_LINK_CLASS, FRAG_LINK_CLASS } from "./file-view-links";
+import { selectionOpenIn } from "./path-links";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const gclock = require("./gesture-clock.js");   // the gesture clock every settings post stamps through
 import { delegate } from "./actions";
@@ -476,8 +479,12 @@ export function openFileClick(ev: MouseEvent | KeyboardEvent | null | undefined,
   openFileView(path, sid);
 }
 
-/** Show `path` in a modal over this pane. Re-opening replaces whatever is up — never stacks. */
-export function openFileView(path: string, sid?: string | null, frag?: string | null): void {
+/** Show `path` in a modal over this pane. Re-opening replaces whatever is up — never stacks.
+ *  `opts.line`: a line the open should show (a `path:12` link inside another file, file-view-links.ts): the code
+ *  view scrolls its row into view once the text lands; a markdown file opens in its Raw view for THIS open (the
+ *  Rendered view has no rows), without touching the saved preference.
+ *  `opts.frag`: a sibling link's `#fragment` (`[see](report.md#results)`) to land on after the first rendered paint. */
+export function openFileView(path: string, sid?: string | null, opts?: { line?: number | null; frag?: string | null }): void {
   // The replace path bypasses closeFileView, so it needs the same dirty ask: opening file B over an
   // edited-but-unsaved file A must not silently eat A's buffer.
   if (document.getElementById("romp-fileview") && closeGuard && !closeGuard()) return;
@@ -494,10 +501,10 @@ export function openFileView(path: string, sid?: string | null, frag?: string | 
   wrap.id = "romp-fileview";
   wrap.onclick = (ev) => { if (ev.target === wrap) closeFileView(); };
   const box = el("div", "fileview");
-  // A sibling link's `#fragment` (`[see](report.md#results)`, stamped data-frag by mdBlock) lands on
-  // its heading after the FIRST rendered paint — once; a Raw view has no ids to land on, so the
-  // landing waits for the Rendered toggle rather than being spent (review find on #958, 2026-09-07).
-  let pendingFrag: string | null = frag || null;
+  // A sibling link's `#fragment` (`[see](report.md#results)`: data-frag on the path link, file-view-links.ts
+  // linkMarkdownAnchors) lands on its heading after the FIRST rendered paint — once; a Raw view has no ids to
+  // land on, so the landing waits for the Rendered toggle rather than being spent (review find on #958, 2026-09-07).
+  let pendingFrag: string | null = opts?.frag || null;
   document.body.classList.add("fileview-open");
 
   const bar = el("div", "fileview-bar");
@@ -705,21 +712,80 @@ export function openFileView(path: string, sid?: string | null, frag?: string | 
   const body = el("div", "fileview-body");
   const stampBodyWidth = watchBodyWidth(body);        // the body's content width, for a top-level table's cap (the sheets read --fv-body-w)
   textSize.bindWheel(body);                    // Ctrl/Cmd + wheel over the text steps the size (textSizeControl)
-  // A rendered document's RELATIVE links (`[notes](./notes.md)`, `[fig](plots/a.png)`) open the
-  // sibling file in this same viewer — mdBlock stamps each one `data-act="fv-open"` with the joined
-  // path (joinDocPath) instead of a target the page would navigate to. One delegated listener on
-  // the body, installed once per open and keyed off data-act (actions.ts: click-safe across the
-  // Rendered ⇄ Raw swaps that rebuild the body's children, and the press flash acknowledges the
-  // click). The chat's document-level anchor delegate (render.ts) leaves scheme-less hrefs alone,
-  // so the click reaches here in the chat document and in the feed document alike.
-  delegate(body, {
-    "fv-open": (a, ev) => {
+  // Links inside the file (file-view-links.ts): a rendered document's RELATIVE links (`[notes](./notes.md)`,
+  // `[fig](plots/a.png)`) open the sibling file in this same viewer, its `[top](#evidence)` links land on their
+  // heading, and the URLs and paths written in the text (a code view's rows, a rendered block) are links too. ONE
+  // listener on the body reads every kind, installed once per open, so it is click-safe across the Rendered ⇄ Raw
+  // swaps that rebuild the body's children. The gesture is the project's (the PDF and folder rule, preview.ts
+  // wantsOwnTab): a PLAIN click acts inside the dashboard, and a Cmd/Ctrl-click or a middle-click opens the link in
+  // a tab of its own. Plain: a path link opens the file here, with this viewer's session (a relative path was
+  // already joined onto this file's directory at mark time; the kernel reads `~` and the session's machine); a URL
+  // anchor opens itself (target _blank) and is left to the browser (in the chat document its capture-phase opener
+  // takes it first, the same way); a section link scrolls to its target in this document, or does nothing where
+  // there is none (its title says so), and never moves the hosting document. Modified: a path link opens in the
+  // browser's own tab off the kernel's /file route (openFileTab; a blocked popup falls through to the viewer, so the
+  // file is never unreachable), a URL anchor in a tab from here. A PLAIN click is not stopped: it goes on to the
+  // document's own listeners (the feed's window listener that returns focus to the chat, the chat's menu closers).
+  // A click that arrives with a selection open inside the body (the click that ends a press-drag-release inside a
+  // path link, or a press held on a URL anchor and then dragged; a press on text collapses a selection first, so a
+  // plain click never sees one, and the next click after such a selection opens) opens nothing; the chat's
+  // capture-phase opener reads the same selection and yields too (path-links.ts selectionOpenIn). Enter or Space on a focused
+  // path link is its click (path-links.ts, with a held Cmd/Ctrl carried) and lands here too. The chat's
+  // document-level anchor delegate (render.ts) leaves an anchor with no href and a `#fragment` href alone, so those
+  // clicks reach here in the chat document and in the feed document alike.
+  const openUrlTab = (href: string) => {
+    if (!href) return;
+    if (canPreview()) window.open(href, "_blank", "noopener,noreferrer");   // the web dashboard: the browser's tab
+    else post({ type: "openLink", href });                                  // the VS Code webview: the host's openExternal
+  };
+  const linkOf = (t: Element | null): HTMLElement | null => {
+    const x = t && typeof t.closest === "function" ? t.closest(".file-uri-link, a." + URL_LINK_CLASS + ", a." + FRAG_LINK_CLASS) as HTMLElement | null : null;
+    return x && body.contains(x) ? x : null;
+  };
+  const openLink = (x: HTMLElement, ev: MouseEvent) => {
+    const own = wantsOwnTab(ev);
+    if (x.classList.contains(FRAG_LINK_CLASS)) {                // a section of this document: this document's scroll, never the page's
       ev.preventDefault();
-      const target = a.dataset.path;
-      if (target) openFileView(target, sid, a.dataset.frag || null);
-    },
-    // an in-document `[top](#evidence)` lands on its heading (mdBlock minted the ids) — never a tab
-    "fv-anchor": (a, ev) => { ev.preventDefault(); scrollToFragment(body, a.getAttribute("href") || ""); },
+      // the rendered document's own headings, ids and named anchors, as mark time read them (scrollToFragment, over
+      // the .fileview-md box through file-view-links.ts fragmentTarget): the viewer's chrome carries an id of its own
+      // (the notice), and a lookup over the whole box would scroll to that on a colliding name
+      scrollToFragment(body, x.getAttribute("href") || "");
+      return;
+    }
+    const p = x.dataset.path;
+    if (!p) {                                                    // the URL anchor
+      if (!own) return;                                          // a plain click: the browser's own open
+      ev.preventDefault(); ev.stopPropagation();                 // a modified one: one tab, from here
+      openUrlTab(x.getAttribute("href") || "");
+      return;
+    }
+    ev.preventDefault();
+    if (own) {
+      ev.stopPropagation();                                      // the modified click is the link's alone
+      if (openFileTab(p, sid || null)) return;                   // its own tab; a blocked popup falls through to the viewer
+    }
+    const ln = Number(x.dataset.line);
+    openFileView(p, sid || null, { line: ln > 0 ? ln : null, frag: x.dataset.frag || null });
+  };
+  body.addEventListener("click", (ev) => {
+    const x = linkOf(ev.target as Element | null);
+    if (!x) return;
+    if (selectionOpenIn(box)) { ev.preventDefault(); return; }   // a drag-select ended on the link
+    openLink(x, ev);
+  });
+  // The middle button: its press would start the browser's autoscroll on a path link (a span, unlike an anchor)
+  // and swallow the auxclick, so the press is cancelled there; the auxclick is the link's own tab. A URL anchor's
+  // middle-click is the browser's (it opens the href in a new tab itself), so neither listener touches one. A
+  // section link's middle-click is this document's scroll, as its plain click is: the browser's own would open a
+  // second copy of the hosting page at its URL plus the id, and a section of the shown file has no tab of its own.
+  body.addEventListener("mousedown", (ev) => {
+    const x = ev.button === 1 ? linkOf(ev.target as Element | null) : null;
+    if (x && x.dataset.path) ev.preventDefault();
+  });
+  body.addEventListener("auxclick", (ev) => {
+    if (ev.button !== 1) return;
+    const x = linkOf(ev.target as Element | null);
+    if (x && (x.dataset.path || x.classList.contains(FRAG_LINK_CLASS))) openLink(x, ev);
   });
   // A submit inside the body never navigates the pane's document. The sanitizer drops <form> and every
   // form control (md-sanitize.ts), so this is the backstop: a note's `<form action=...><button>` used to
@@ -1005,6 +1071,18 @@ export function openFileView(path: string, sid?: string | null, frag?: string | 
   };
   document.addEventListener("keydown", onKey);
 
+  // The row for a 1-based line of the code view, scrolled to the middle; `pendingLine` is the open's `line`, spent
+  // on the first text that lands (a Reload keeps the reader's place and does not scroll). A line past the end (a
+  // stale `x.py:400` in a file that shrank) lands on the last row AND says so in the viewer's notice: a silent
+  // landing on the wrong row would read as the file's truth.
+  const scrollToLine = (n: number) => {
+    const rows = body.querySelectorAll("code.hljs .fv-cl");
+    if (!rows.length) return;
+    if (n > rows.length) noteBar("Line " + n + " is past the end of this file, which has " + rows.length + (rows.length === 1 ? " line" : " lines") + "; showing the last line.");
+    (rows[Math.min(Math.max(0, n - 1), rows.length - 1)] as HTMLElement).scrollIntoView({ block: "center" });
+  };
+  let pendingLine: number | null = opts && typeof opts.line === "number" && opts.line > 0 ? Math.floor(opts.line) : null;
+
   fetch(fileUrl(path, sid), { cache: "no-store" }).then((r): Promise<string | Blob> => {
     // Every failure says WHY, in the pane, rather than leaving a blank one: the kernel distinguishes
     // "not a type I serve" from "too big" from "not text after all", and that is exactly what the
@@ -1041,7 +1119,10 @@ export function openFileView(path: string, sid?: string | null, frag?: string | 
       return;
     }
     text = t;
+    // a line the link named: the Raw view for this open (unsaved: the preference stays), then the row
+    if (pendingLine !== null && isMd && fmt.md === "rendered") fmt.md = "raw";
     renderBody();
+    if (pendingLine !== null) { scrollToLine(pendingLine); pendingLine = null; }
   }).catch((err) => {
     if (!document.getElementById("romp-fileview")) return;
     const why = el("div", "fileview-err");
@@ -1337,6 +1418,7 @@ function codeBlock(text: string, path: string, wrapLines: boolean): HTMLElement 
   if (wrapLines) {
     pre.classList.add("fileview-wrap");
     code.innerHTML = wrapNumberedHtml(hl !== null ? hl : escapeHtml(text));
+    linkifyFileText(code, path);   // URLs and paths in the text, on the DOM the highlight built (file-view-links.ts)
     pre.appendChild(code);
     wrap.appendChild(pre);
     return wrap;
@@ -1345,20 +1427,25 @@ function codeBlock(text: string, path: string, wrapLines: boolean): HTMLElement 
   gutter.textContent = lines.map((_, i) => String(i + 1)).join("\n");
   gutter.setAttribute("aria-hidden", "true");
   if (hl !== null) code.innerHTML = hl; else code.textContent = text;
+  linkifyFileText(code, path);   // the same pass on the gutter layout, which no caller in the viewer asks for (every call passes wrapLines)
   pre.appendChild(code);
   wrap.appendChild(gutter); wrap.appendChild(pre);
   return wrap;
 }
 
-// Land an in-document fragment on its heading. The fragment — as typed, percent-encoded or not —
-// slugs the same way the heading ids were minted, so `#Evidence%20Results`, `#evidence-results` and
-// `#Evidence Results` all find md-evidence-results inside THIS rendered box (never the page's own ids).
-// Nothing found → nothing happens: inert, never a scroll to the top and never a navigation.
+// Land an in-document fragment on its target. The fragment, as typed, percent-encoded or not, names an element
+// of the RENDERED document (the .fileview-md box under `box`, never the viewer's chrome around it, whose notice wears
+// an id of its own, and never the page's ids): an element with exactly that id, a GitHub-style `<a name>`, or a
+// heading, through the slug the heading ids were minted with, so `#Evidence%20Results`, `#evidence-results` and
+// `#Evidence Results` all find md-evidence-results (file-view-links.ts fragmentTarget is the one lookup; mark time
+// reads it too). Nothing found → nothing happens: inert, never a scroll to the top and never a navigation. Both
+// viewers land through here: the local one's section links and a sibling link's fragment, the URL one's fv-anchor
+// links and the URL's own hash.
 function scrollToFragment(box: HTMLElement, fragment: string): boolean {
   let frag = fragment.replace(/^#/, "");
   try { frag = decodeURIComponent(frag); } catch { /* a stray % — match the bytes as written */ }
   if (!frag) return false;
-  const target = box.querySelector('[id="md-' + headingSlug(frag) + '"]');   // the slug's alphabet needs no escaping
+  const target = fragmentTarget(box.querySelector(".fileview-md") || box, frag);
   if (!target) return false;
   target.scrollIntoView({ block: "start" });
   return true;
@@ -1382,14 +1469,22 @@ type MdDocLoc = { kind: "url"; href: string } | { kind: "file"; path: string; si
 function mdBlock(text: string, doc?: MdDocLoc): HTMLElement {
   const box = el("div", "fileview-md");
   const fences: Fence[] = [];                          // marked's code tokens in document order, for the fence pass's Copy (fence-source.ts)
+  let rendered = true;                                 // false on the fallback: the bare text, with nothing added to it
   try {
     // The code tokens are collected as the parse walks them: the lexer expanded the file's leading tabs to spaces before
     // it cut them, and the fence pass below reads each fence's text back out of the file for its Copy button
     // (fence-source.ts). Handed to THIS parse only, so the chat's marked singleton learns nothing; a walkTokens an
     // extension put on the defaults runs as well, since per-call options replace rather than compose.
+    // A link's destination is put in the form the sanitizer keeps BEFORE the HTML exists (file-view-links.ts
+    // viewerWalkTokens: `notes.md:7` reads as a scheme to DOMPurify, `file:///a.md` is a scheme it refuses, and an
+    // anchor it strips is a label nothing can sort afterwards). Handed to THIS parse only: the marked singleton is
+    // the chat's too, and the chat's anchors must not learn the viewer's forms. A walkTokens an extension put on
+    // the defaults runs as well: per-call options replace, not compose. The file kind's alone: a URL document has
+    // no directory for `notes.md:7` to sit in, and its links resolve against the URL below.
     const base = marked.defaults.walkTokens;
     const dirty = marked.parse(text, { walkTokens: (t) => {
       if (t.type === "code") { const c = t as Tokens.Code; fences.push({ text: c.text, indented: c.codeBlockStyle === "indented" }); }
+      if (doc && doc.kind === "file") viewerWalkTokens(t);
       if (base) void base.call(marked, t);
     } }) as string;
     // The one sanitizer the chat's md() uses too (md-sanitize.ts): html + svg (a note's own inline SVG), no
@@ -1397,11 +1492,13 @@ function mdBlock(text: string, doc?: MdDocLoc): HTMLElement {
     // document-level delegate and interrupt the active session; review find on #958, 2026-09-07), and
     // rules modelled on GitHub's for a note's own HTML: no <style>, no form controls, ids and names prefixed
     // user-content-, inline style reduced to its colours, no background attribute. The sanitized <body>'s
-    // children are adopted as they are, no re-parse. The viewer's own stamps (heading ids, fv-open,
-    // fv-anchor) are set AFTER this sanitize, so they are unaffected and never prefixed.
+    // children are adopted as they are, no re-parse. The viewer's own marks (heading ids, the file kind's path
+    // and section links, the URL kind's fv-anchor stamp) are set AFTER this sanitize, so they are unaffected and
+    // never prefixed; an author's own id or name is read under its prefix (file-view-links.ts fragmentTarget).
     box.replaceChildren(...Array.from(sanitizeMd(dirty).childNodes));
   } catch {
     box.textContent = text;                            // a marked bug must never cost the content
+    rendered = false;
   }
   // Relative references resolve against the DOCUMENT, after sanitisation (DOMPurify has already
   // dropped every dangerous scheme; what is left is either absolute — untouched — or relative to a
@@ -1411,7 +1508,9 @@ function mdBlock(text: string, doc?: MdDocLoc): HTMLElement {
   // Every heading gets an id first — marked 12 emits none, so a document's own `[top](#evidence)`
   // had nothing to land on. GitHub's slug (headingSlug, made unique in order by uniqueSlugs), and
   // PREFIXED `md-` on purpose: an unprefixed id="tabs" would dress a heading in the chat page's
-  // #tabs CSS and shadow getElementById("tabs") for the page's own controls.
+  // #tabs CSS and shadow getElementById("tabs") for the page's own controls. Both modes, before the
+  // anchors are sorted: a section link is live when its target is a heading, an element with that id
+  // or a named anchor (file-view-links.ts fragmentTarget reads all three).
   const heads = Array.from(box.querySelectorAll("h1, h2, h3, h4, h5, h6")) as HTMLElement[];
   const slugs = uniqueSlugs(heads.map((h) => headingSlug(h.textContent || "")));
   heads.forEach((h, i) => { h.id = "md-" + slugs[i]; });
@@ -1441,39 +1540,37 @@ function mdBlock(text: string, doc?: MdDocLoc): HTMLElement {
         img.setAttribute("src", fileUrl(joinDocPath(doc.path, src), doc.sid));
       }
     });
+  }
+  if (doc && doc.kind === "url") {
     box.querySelectorAll("a[href]").forEach((node) => {
       const a = node as HTMLAnchorElement;
       const href = a.getAttribute("href") || "";
       if (!href || href.startsWith("#") || /^[a-z][a-z0-9+.-]*:/i.test(href)) return;   // in-document, or already absolute
-      if (doc.kind === "url") {
-        // Absolute now, so the chat's document-level anchor delegate sees a scheme: a same-origin
-        // .md target opens in this viewer (isMarkdownUrl), everything else in a new tab.
-        a.setAttribute("href", resolveDocRelative(href, doc.href));
-      } else if (!href.startsWith("//")) {
-        // The sibling path rides data-act/data-path for openFileView's delegated body listener;
-        // the href stays as written (hover still shows where it goes) and no _blank is forced —
-        // the page would only 404 on it.
-        const joined = joinDocPath(doc.path, href);
-        a.dataset.act = "fv-open";
-        a.dataset.path = joined;
-        const hash = href.indexOf("#") >= 0 ? href.slice(href.indexOf("#")) : "";
-        if (hash.length > 1) a.dataset.frag = hash;          // `report.md#results`: the heading to land on, once open
-        a.title = joined;
-      }
+      // Absolute now, so the chat's document-level anchor delegate sees a scheme: a same-origin
+      // .md target opens in this viewer (isMarkdownUrl), everything else in a new tab.
+      a.setAttribute("href", resolveDocRelative(href, doc.href));
     });
   }
-  // Links open a NEW tab: the viewer lives inside the chat pane's document, and letting a README link
-  // navigate it away would silently eat the chat until a reload. Two kinds stay in the viewer: a local
-  // document's sibling links (stamped fv-open above), and IN-DOCUMENT `#fragment` links, which land on
-  // their heading through the body's delegated fv-anchor handler — a forced _blank on those opened a
-  // REAL tab at the chat page's own URL plus the fragment (found live, 2026-09-06).
-  box.querySelectorAll("a[href]").forEach((node) => {
-    const a = node as HTMLAnchorElement;
-    if (a.dataset.act === "fv-open") return;
-    if ((a.getAttribute("href") || "").startsWith("#")) { a.dataset.act = "fv-anchor"; return; }
-    a.target = "_blank";
-    a.rel = "noopener";
-  });
+  if (doc && doc.kind === "file") {
+    // A file on the session's disk: its links are sorted by file-view-links.ts (linkMarkdownAnchors). A link to the
+    // web opens a NEW tab: the viewer lives inside the chat pane's document, and letting a README link navigate it
+    // away would silently eat the chat until a reload. A link whose target is a file relative to this one becomes a
+    // path link that opens THAT file in the viewer (its `#fragment` or `:line` riding along); a section link
+    // (`#results`) is the viewer's scroll; a target the sanitizer removed is a dead link that says why.
+    if (rendered) linkMarkdownAnchors(box, doc.path);
+  } else {
+    // A URL document (openUrlView), or a caller with no location: links open a NEW tab, for the same reason. One
+    // kind stays in the viewer: an IN-DOCUMENT `#fragment` link, which lands on its heading through the body's
+    // delegated fv-anchor handler — a forced _blank on those opened a REAL tab at the chat page's own URL plus
+    // the fragment (found live, 2026-09-06). A URL document's sibling links are absolute by now, and the chat's
+    // own anchor delegate routes them (a same-origin .md back into the viewer).
+    box.querySelectorAll("a[href]").forEach((node) => {
+      const a = node as HTMLAnchorElement;
+      if ((a.getAttribute("href") || "").startsWith("#")) { a.dataset.act = "fv-anchor"; return; }
+      a.target = "_blank";
+      a.rel = "noopener";
+    });
+  }
   // Fenced blocks: highlight only a language the fence NAMES and this bundle registers (the same no-guessing rule as
   // langFor; an unnamed block stays plain rather than being painted at random). Then, for EVERY fence, named or not, the
   // chat's own dress (code-block.ts): the per-line rows that number the lines and make a soft-wrap read distinctly from a
@@ -1499,6 +1596,10 @@ function mdBlock(text: string, doc?: MdDocLoc): HTMLElement {
     wrapCodeLines(codeEl);
     if (host) addCopyBtn(host, toCopy);
   });
+  // URLs and paths written in the prose and the code blocks, after the highlight rewrote the blocks' markup
+  // (a pass before it would be undone). marked already made the prose's URLs anchors; text inside one is skipped.
+  // The fallback's bare text is left bare: it is the content and nothing else, which is that branch's promise.
+  if (rendered && doc && doc.kind === "file") linkifyFileText(box, doc.path);
   return box;
 }
 

--- a/ui/webview/fileview-parity.test.ts
+++ b/ui/webview/fileview-parity.test.ts
@@ -57,6 +57,9 @@ const RULES = [
   // clipped and unreachable, so they have to hold in both documents
   ":where(.fileview-md) svg, :where(.fileview-md) canvas, :where(.fileview-md) video {",
   ':where(.fileview-md :is(svg, canvas)[width]:not([width$="%"])) {',
+  // links inside a shown file (file-view-links.ts): the light dress on a URL anchor and a path link, the Markdown link that names a file, a dead link
+  ".fileview-body .file-uri-link, .fileview-body .fv-url {", ".fileview-body .file-uri-link:hover, .fileview-body .fv-url:hover {",
+  ".fileview-md a.file-uri-link {", ".fileview-md a.file-uri-link:hover {", ".fileview-md a.fv-dead {",
 ];
 
 /** Every rule whose selector opens a line as `head`, in sheet order; at least one, or the head is missing. */

--- a/ui/webview/md-url-view.test.ts
+++ b/ui/webview/md-url-view.test.ts
@@ -294,18 +294,21 @@ test("local file mode: a relative image is the sibling over the kernel's /file r
   assert.match(OPEN_FN, /mdBlock\(text, \{ kind: "file", path, sid: sid \|\| null \}\)/);
 });
 
-test("local file mode: a relative link opens the sibling in the viewer via ONE delegated data-act listener on the body", () => {
-  // the anchor carries the joined path as data, keeps its href for hover, and is not forced to _blank
-  assert.match(MD_FN, /const joined = joinDocPath\(doc\.path, href\);\s*\n\s*a\.dataset\.act = "fv-open";\s*\n\s*a\.dataset\.path = joined;\s*\n\s*const hash = href\.indexOf\("#"\) >= 0 \? href\.slice\(href\.indexOf\("#"\)\) : "";\s*\n\s*if \(hash\.length > 1\) a\.dataset\.frag = hash;[^\n]*\n\s*a\.title = joined;/,
-    "the joined path rides data-path and the link's own #fragment rides data-frag (review fold 2026-09-07)");
-  assert.match(MD_FN, /if \(a\.dataset\.act === "fv-open"\) return;/);
-  // …the delegate: actions.ts's delegate, installed once per open on the body (stable across the
-  // Rendered ⇄ Raw swaps that rebuild its children), preventDefault, then openFileView with this sid
-  assert.match(VIEW, /import \{ delegate \} from "\.\/actions";/);
-  assert.match(OPEN_FN, /delegate\(body, \{\s*\n\s*"fv-open": \(a, ev\) => \{\s*\n\s*ev\.preventDefault\(\);\s*\n\s*const target = a\.dataset\.path;\s*\n\s*if \(target\) openFileView\(target, sid, a\.dataset\.frag \|\| null\);/,
-    "the sibling opens in this viewer, for this sid, landing on its fragment");
-  assert.equal((OPEN_FN.match(/delegate\(body/g) || []).length, 1, "one listener per open, never in a render path");
-  assert.ok(OPEN_FN.indexOf("delegate(body") < OPEN_FN.indexOf("const renderBody ="), "installed before any render can run");
+test("local file mode: a relative link opens the sibling in the viewer via ONE listener on the body (the module sorts the anchors)", () => {
+  // the file kind's anchors are sorted by file-view-links.ts (linkMarkdownAnchors) AFTER the sanitize: a sibling target becomes a path
+  // link on the anchor itself (data-path the resolved path, data-frag its own #fragment, the href off so the page never follows it),
+  // a section link is the viewer's scroll, a stripped target is a dead link that says why (file-view-links.test.ts executes each)
+  assert.match(MD_FN, /if \(doc && doc\.kind === "file"\) \{\s*\n(?:\s*\/\/[^\n]*\n)*\s*if \(rendered\) linkMarkdownAnchors\(box, doc\.path\);/, "the module sorts a file's anchors");
+  assert.ok(MD_FN.indexOf("sanitizeMd(") < MD_FN.indexOf("linkMarkdownAnchors(box, doc.path)"), "after the sanitize, so a document's own data-* never reaches the page");
+  assert.doesNotMatch(MD_FN, /"fv-open"/, "no stamp of its own: the shared path-link shape (path-links.ts markPathLink) on the anchor");
+  // …the listener: ONE on the body, installed once per open (stable across the Rendered ⇄ Raw swaps that rebuild its children),
+  // preventDefault, then openFileView with this sid, the link's line and its fragment
+  assert.match(VIEW, /import \{ delegate \} from "\.\/actions";/, "the URL viewer keeps its delegate for fv-anchor");
+  assert.match(OPEN_FN, /openFileView\(p, sid \|\| null, \{ line: ln > 0 \? ln : null, frag: x\.dataset\.frag \|\| null \}\);/,
+    "the sibling opens in this viewer, for this sid, landing on its line or its fragment");
+  assert.equal((OPEN_FN.match(/body\.addEventListener\("click"/g) || []).length, 1, "one listener per open, never in a render path");
+  assert.ok(OPEN_FN.indexOf('body.addEventListener("click"') < OPEN_FN.indexOf("const renderBody ="), "installed before any render can run");
+  assert.doesNotMatch(OPEN_FN, /delegate\(body/, "the local viewer's delegate is gone: its one listener sorts every link kind");
   // the chat's document-level delegate ignores scheme-less hrefs, so the click reaches the body listener
   assert.match(HANDLER, /if \(!\/\^\[a-z\]\[a-z0-9\+\.-\]\*:\/i\.test\(href\)\) return;/);
 });
@@ -314,10 +317,10 @@ test("local file mode: a relative link opens the sibling in the viewer via ONE d
 
 test("every heading gets id=md-<slug> after sanitisation, in both modes (the md- prefix keeps the page's own ids and CSS out of it)", () => {
   assert.match(MD_FN, /const heads = Array\.from\(box\.querySelectorAll\("h1, h2, h3, h4, h5, h6"\)\) as HTMLElement\[\];\s*\n\s*const slugs = uniqueSlugs\(heads\.map\(\(h\) => headingSlug\(h\.textContent \|\| ""\)\)\);\s*\n\s*heads\.forEach\(\(h, i\) => \{ h\.id = "md-" \+ slugs\[i\]; \}\);/);
-  const sanitize = MD_FN.indexOf("DOMPurify.sanitize(");
+  const sanitize = MD_FN.indexOf("sanitizeMd(");
   const ids = MD_FN.indexOf('h.id = "md-"');
   const docGate = MD_FN.indexOf("if (doc) {");
-  assert.ok(sanitize < ids && ids < docGate, "after DOMPurify, and OUTSIDE the doc gate — every mode, every caller");
+  assert.ok(sanitize > 0 && sanitize < ids && ids < docGate, "after the sanitize, and OUTSIDE the doc gate: every mode, every caller");
   assert.match(MD_FN, /an unprefixed id="tabs" would dress a heading in the chat page's[\s\S]*?#tabs CSS and shadow getElementById\("tabs"\)/, "the prefix's reason is written down");
 });
 
@@ -326,7 +329,8 @@ test("a `#fragment` anchor is stamped fv-anchor and gets NO _blank; every other 
   // the fragment branch is in the UNCONDITIONAL loop — a document with no location still lands its own links
   const finalLoop = MD_FN.slice(MD_FN.lastIndexOf('box.querySelectorAll("a[href]")'));
   assert.ok(finalLoop.includes('a.dataset.act = "fv-anchor"'), "stamped in the final, doc-independent pass");
-  assert.ok(finalLoop.includes('if (a.dataset.act === "fv-open") return;'), "…which also leaves the sibling links alone");
+  assert.ok(MD_FN.indexOf("} else {\n") > 0 && MD_FN.indexOf('box.querySelectorAll("a[href]")', MD_FN.indexOf('if (doc && doc.kind === "file") {')) > MD_FN.indexOf("} else {", MD_FN.indexOf('if (doc && doc.kind === "file") {')),
+    "…and never runs over a file's anchors, which the module sorted in the other arm");
 });
 
 test("scrollToFragment: decode, slug, find md-<slug> inside THIS box, scrollIntoView; nothing found → inert", () => {
@@ -334,15 +338,15 @@ test("scrollToFragment: decode, slug, find md-<slug> inside THIS box, scrollInto
   assert.match(fn, /let frag = fragment\.replace\(\/\^#\/, ""\);/);
   assert.match(fn, /try \{ frag = decodeURIComponent\(frag\); \} catch \{/);
   assert.match(fn, /if \(!frag\) return false;/);
-  assert.match(fn, /const target = box\.querySelector\('\[id="md-' \+ headingSlug\(frag\) \+ '"\]'\);/, "the box, never document.getElementById");
+  assert.match(fn, /const target = fragmentTarget\(box\.querySelector\("\.fileview-md"\) \|\| box, frag\);/, "the rendered document inside the box, never document.getElementById: an id, an <a name>, or the heading whose slug it is (file-view-links.ts fragmentTarget)");
   assert.match(fn, /if \(!target\) return false;/);
   assert.match(fn, /target\.scrollIntoView\(\{ block: "start" \}\);/);
   assert.doesNotMatch(fn, /location\.|document\.getElementById|window\.open/);
 });
 
-test("both viewers handle fv-anchor in their body delegate: preventDefault, then scrollToFragment on the body", () => {
+test("both viewers land a section link on the body: the URL viewer through its fv-anchor delegate, the local one through its link listener", () => {
   const H = /"fv-anchor": \(a, ev\) => \{ ev\.preventDefault\(\); scrollToFragment\(body, a\.getAttribute\("href"\) \|\| ""\); \},/;
-  assert.match(OPEN_FN, H, "the local viewer's existing delegate gained the handler");
+  assert.match(OPEN_FN, /if \(x\.classList\.contains\(FRAG_LINK_CLASS\)\) \{[^\n]*\n\s*ev\.preventDefault\(\);\n(?:\s*\/\/[^\n]*\n)*\s*scrollToFragment\(body, x\.getAttribute\("href"\) \|\| ""\);/, "the local viewer's listener: a section link (file-view-links.ts FRAG_LINK_CLASS) is this document's scroll");
   assert.match(URL_FN, H, "the URL viewer installs its own delegate for it");
   assert.equal((URL_FN.match(/delegate\(body/g) || []).length, 1, "one listener per open");
   assert.ok(URL_FN.indexOf("delegate(body") < URL_FN.indexOf("const renderBody ="), "installed before any render can run");
@@ -399,12 +403,13 @@ test("rendered markdown never carries data-* attributes into the page, in the vi
   assert.match(chatMd, /const clean = sanitizeMd\(dirty\);/);
   assert.match(SANITIZE, /export const MD_PURIFY: Config = \{[\s\S]*?ALLOW_DATA_ATTR: false,[\s\S]*?\};/, "the shared sanitizer's profile forbids data-*");
   assert.doesNotMatch(VIEW + RENDER, /ALLOW_DATA_ATTR|DOMPurify\.sanitize\(/, "neither caller spells a profile of its own");
-  // the viewer's own stamps are set AFTER the sanitize, so they are unaffected
-  assert.ok(MD_FN.indexOf("sanitizeMd(") < MD_FN.indexOf('a.dataset.act = "fv-open"'));
+  // the viewer's own marks are set AFTER the sanitize, so they are unaffected
+  assert.ok(MD_FN.indexOf("sanitizeMd(") < MD_FN.indexOf("linkMarkdownAnchors(box, doc.path)"));
+  assert.ok(MD_FN.indexOf("sanitizeMd(") < MD_FN.indexOf('a.dataset.act = "fv-anchor"'));
 });
 
 test("local file mode: a sibling link's #fragment lands after the first RENDERED paint, once", () => {
-  assert.match(VIEW, /export function openFileView\(path: string, sid\?: string \| null, frag\?: string \| null\): void \{/);
-  assert.match(OPEN_FN, /let pendingFrag: string \| null = frag \|\| null;/);
+  assert.match(VIEW, /export function openFileView\(path: string, sid\?: string \| null, opts\?: \{ line\?: number \| null; frag\?: string \| null \}\): void \{/);
+  assert.match(OPEN_FN, /let pendingFrag: string \| null = opts\?\.frag \|\| null;/);
   assert.match(OPEN_FN, /if \(rendered && pendingFrag\) \{\s*\n\s*const h = pendingFrag; pendingFrag = null;\s*\n\s*requestAnimationFrame\(\(\) => \{ if \(wrap\.isConnected\) scrollToFragment\(body, h\); \}\);/);
 });

--- a/ui/webview/path-links.test.ts
+++ b/ui/webview/path-links.test.ts
@@ -3,6 +3,19 @@
 // message body, the shape gates, the trailing-punctuation trim, the kernel's pathLinks verdict narrowing the
 // links, and the span each hit is marked as. What a click does is the hosting document's (render.ts binds
 // openPath per span; chat-path-links.test.ts and chat-relpath-link.test.ts pin that wiring at source).
+//
+// Three promises beyond the matches, since the file viewer runs the same walk (file-view-links.ts):
+// 1. A link is a CONTROL from the keyboard too: the span is a tab stop announced as a link, Enter or Space clicks
+//    it, and a mouse press does not focus it (so a click leaves focus where a click on plain text leaves it).
+// 2. The walk costs time LINEAR in the text. CLICKABLE_PATH_RE run with the g flag restarts at every position
+//    and rescans an unbroken word run to its end each time: one slash plus a 40K-character run cost seconds per
+//    text node, and a viewer shows whole files. PathTokenScanner drives the same regex in linear time; the
+//    trailing-punctuation trim, quadratic for the same reason on a long token of dots, scans backwards. The
+//    regex's TEXT is the kernel's parity contract (tests/fixtures/path_token_parity.json), so what is pinned
+//    here is that the scanner finds exactly what the regex finds, from every start position, over fuzzed and
+//    adversarial texts.
+// 3. The text is read a UNIT at a time when a surface asks (PathLinkOptions.unit): a highlight's spans cut a
+//    line into several nodes, and a token is what the line says; a token a span cuts through is left as text.
 // Synthetic fixtures only: the notes-api demo world, a placeholder session id.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
@@ -47,7 +60,16 @@ class El {
   parentNode: El | null = null;
   childNodes: Array<El | Txt> = [];
   attrs = new Map<string, string>();
+  role: string | null = null;
+  onkeydown: ((e: unknown) => void) | null = null; onmousedown: ((e: unknown) => void) | null = null; onmouseup: ((e: unknown) => void) | null = null;
+  onmouseleave: ((e: unknown) => void) | null = null; oncontextmenu: ((e: unknown) => void) | null = null; ondragstart: ((e: unknown) => void) | null = null;
+  clicks = 0;
+  dispatched: unknown[] = [];
   constructor(tag: string) { this.tagName = tag.toUpperCase(); }
+  click(): void { this.clicks++; }
+  dispatchEvent(e: unknown): boolean { this.dispatched.push(e); return true; }
+  blur(): void { if (doc.activeElement === this) doc.activeElement = null; }
+  get tabIndex(): number { return this.attrs.has("tabindex") ? Number(this.attrs.get("tabindex")) : -1; } set tabIndex(v: number) { this.attrs.set("tabindex", String(v)); }
   get parentElement(): El | null { return this.parentNode; }
   get className(): string { return this.attrs.get("class") || ""; } set className(v: string) { this.attrs.set("class", v); }
   get title(): string { return this.attrs.get("title") || ""; } set title(v: string) { this.attrs.set("title", v); }
@@ -65,6 +87,7 @@ class El {
   setAttribute(k: string, v: string): void { this.attrs.set(k, v); }
   getAttribute(k: string): string | null { return this.attrs.has(k) ? (this.attrs.get(k) as string) : null; }
   hasAttribute(k: string): boolean { return this.attrs.has(k); }
+  removeAttribute(k: string): void { this.attrs.delete(k); }
   private fits(c: Compound): boolean {
     return (!c.tag || c.tag === this.tagName) && c.classes.every((k) => this.classes.includes(k))
       && c.attrs.every(([a, v]) => this.attrs.has(a) && (v === null || this.attrs.get(a) === v));
@@ -98,9 +121,17 @@ const doc = {
   createTextNode: (s: string) => new Txt(s),
   createDocumentFragment: () => new Frag(),
   createTreeWalker: (root: El, what = 4) => { const nodes = walkNodes(root, what); let i = 0; return { nextNode: () => (i < nodes.length ? nodes[i++] : null) }; },
+  activeElement: null as El | null,
 };
 (globalThis as any).NodeFilter = { SHOW_ELEMENT: 1, SHOW_TEXT: 4 };
 (globalThis as any).document = doc;
+(globalThis as any).MouseEvent = class { constructor(public type: string, public init: Record<string, unknown>) {} };
+// a keydown as the browser would deliver it to the span's own handler
+function press(a: El, key: string, mods: { metaKey?: boolean; ctrlKey?: boolean } = {}): boolean {
+  let prevented = false;
+  a.onkeydown!({ key, currentTarget: a, preventDefault: () => { prevented = true; }, ...mods });
+  return prevented;
+}
 
 const el = (tag: string, cls?: string, ...kids: Array<El | Txt | string>): El => {
   const e = new El(tag); if (cls) e.className = cls;
@@ -122,8 +153,63 @@ test("openPathLink marks a span: the raw text as written, the target in data-pat
   assert.deepEqual(shape(abs), ["/tmp/TESTHOST/a.md", "/tmp/TESTHOST/a.md", undefined, "Open /tmp/TESTHOST/a.md"]);
   const u = fileUriLink("file:///tmp/TESTHOST/a%20b.pdf") as unknown as El;
   assert.deepEqual(shape(u), ["file:///tmp/TESTHOST/a%20b.pdf", "/tmp/TESTHOST/a b.pdf", undefined, "Open /tmp/TESTHOST/a b.pdf"]);
-  // the module binds nothing: no handler on the span (render.ts's bindPathLink adds the click)
+  // the module binds no ACTION: no click handler on the span (render.ts's bindPathLink adds the click); its own handlers are about focus
   assert.equal((a as any).onclick, undefined);
+  assert.equal(a.tabIndex, 0, "a tab stop, like the <a> it stands in for"); assert.equal(a.role, "link");
+  for (const k of ["onkeydown", "onmousedown", "onmouseup", "onmouseleave", "oncontextmenu", "ondragstart"] as const) assert.equal(typeof a[k], "function", k);
+});
+
+test("a path link is a control from the keyboard: Enter or Space clicks it (the host's click, whoever bound it), other keys are left alone, and a held Cmd/Ctrl rides into the click as the same modifier", async () => {
+  const { openPathLink, fileUriLink } = await import("./path-links");
+  const a = openPathLink("docs/design.md", "docs/design.md", true) as unknown as El;
+  assert.equal(press(a, "Enter"), true, "Enter is consumed…");
+  assert.equal(a.clicks, 1, "…and becomes this span's click, which bubbles to whatever the host bound");
+  assert.equal(press(a, " "), true, "Space too, prevented so it does not also scroll the pane");
+  assert.equal(a.clicks, 2);
+  for (const k of ["Tab", "Escape", "a", "ArrowDown", "Shift"]) assert.equal(press(a, k), false, k + " is left to the browser");
+  assert.equal(a.clicks, 2, "no other key activates");
+  assert.equal(press(a, "Enter", { metaKey: true }), true);
+  assert.equal(a.clicks, 2, "element.click() carries no modifiers, so a modified key dispatches the click itself…");
+  assert.deepEqual(a.dispatched.map((e) => [(e as any).type, (e as any).init]), [["click", { bubbles: true, cancelable: true, metaKey: true, ctrlKey: undefined }]], "…with the modifier on it");
+  const u = fileUriLink("file:///tmp/TESTHOST/a.pdf") as unknown as El;
+  assert.equal(u.tabIndex, 0); assert.equal(u.role, "link"); press(u, "Enter"); assert.equal(u.clicks, 1, "every span the module mints takes the same route");
+});
+
+test("a mouse press does not focus a path link: the press drops the tab stop (and blurs a keyboard focus), the release brings it back, so a click leaves focus where a click on plain text leaves it", async () => {
+  const { openPathLink } = await import("./path-links");
+  const a = openPathLink("docs/a.md", "docs/a.md", true) as unknown as El;
+  a.onmousedown!({ currentTarget: a });
+  assert.equal(a.hasAttribute("tabindex"), false, "not focusable for the rest of this press: the browser's default focus finds no tab stop");
+  a.onmouseup!({ currentTarget: a });
+  assert.equal(a.tabIndex, 0, "back in the tab order once the press has ended on it");
+  for (const end of ["onmouseleave", "oncontextmenu", "ondragstart"] as const) {
+    a.onmousedown!({ currentTarget: a }); assert.equal(a.hasAttribute("tabindex"), false);
+    a[end]!({ currentTarget: a }); assert.equal(a.tabIndex, 0, end + " ends the press too (a drag away, a menu, a native drag)");
+  }
+  doc.activeElement = a;                          // focused by Tab, then pressed: the press ends the keyboard focus too
+  a.onmousedown!({ currentTarget: a });
+  assert.equal(doc.activeElement, null, "blurred by the press itself, since the browser fires no focus for an already-focused element");
+});
+
+test("markPathLink dresses an element the caller already has (a Markdown link's own <a>): the class is appended, the title and class are written as attributes (an SVG <a> has no such properties), the data and the handlers are the span's", async () => {
+  const { markPathLink } = await import("./path-links");
+  const a = new El("a"); a.className = "fancy"; a.appendChild(new Txt("the app"));
+  markPathLink(a as unknown as HTMLElement, "/tmp/TESTHOST/app.py", true);
+  assert.equal(a.getAttribute("class"), "fancy file-uri-link"); assert.equal(a.getAttribute("title"), "Open /tmp/TESTHOST/app.py");
+  assert.equal(a.dataset.path, "/tmp/TESTHOST/app.py"); assert.equal(a.dataset.rel, "1"); assert.equal(a.tabIndex, 0); assert.equal(a.role, "link");
+  markPathLink(a as unknown as HTMLElement, "/tmp/TESTHOST/app.py", true);
+  assert.equal(a.getAttribute("class"), "fancy file-uri-link", "marked twice wears the class once");
+  assert.equal(a.textContent, "the app", "the label is untouched");
+});
+
+test("a file:// URI is local with an empty authority or localhost only: file://host/path names another machine, is prose to the walk, and comes back from fileUriToPath as written", async () => {
+  const { isFileUri, fileUriToPath, linkifyPathTokens } = await import("./path-links");
+  for (const u of ["file:///tmp/TESTHOST/a.md", "file://localhost/tmp/a.md", "FILE:///tmp/a.md", "file://LOCALHOST/x"]) assert.equal(isFileUri(u), true, u);
+  for (const u of ["file://evil.invalid/share/x.md", "file://TESTHOST/x.md", "file://localhost", "file:/x.md", "files:///x", "file://localhostx/y"]) assert.equal(isFileUri(u), false, u);
+  assert.equal(fileUriToPath("file://localhost/tmp/a%20b.md"), "/tmp/a b.md");
+  assert.equal(fileUriToPath("file://evil.invalid/share/x.md"), "file://evil.invalid/share/x.md");
+  const p = el("p", "", "see file://evil.invalid/share/x.md and file:///tmp/TESTHOST/y.md");
+  assert.deepEqual(linkifyPathTokens(p as unknown as HTMLElement).map((h) => h.open), ["/tmp/TESTHOST/y.md"], "the far URI is not a relative path named after its host");
 });
 
 // ── the shape gates, on the real functions ────────────────────────────────────────────────────────
@@ -209,10 +295,10 @@ test("the resume rule: after a linked token the scan resumes right after it, so 
 // ── the module's contract with render.ts, at source ───────────────────────────────────────────────
 test("source: the module marks and binds nothing; render.ts binds the click and the middle button per span off the span's data, and reads the hits for its figure pass", () => {
   const RENDER = fs.readFileSync(path.join(UI, "render.ts"), "utf8");
-  assert.doesNotMatch(LINKS, /addEventListener|onclick|openPath\(|window\.open|postMessage/, "no action of its own");
-  assert.match(LINKS, /export function linkifyPathTokens\(root: HTMLElement, pathLinks\?: Record<string, string>\): PathLinkHit\[\] \{/);
+  assert.doesNotMatch(LINKS, /addEventListener|onclick|openPath\(|window\.open|postMessage|fetch\(/, "no action of its own: its handlers are about focus (keydown, the press)");
+  assert.match(LINKS, /export function linkifyPathTokens\(root: HTMLElement, pathLinks\?: Record<string, string>, opts\?: PathLinkOptions\): PathLinkHit\[\] \{/);
   assert.match(LINKS, /export interface PathLinkHit \{ el: HTMLElement; open: string; verified: boolean \}/);
-  assert.match(RENDER, /import \{ openPathLink, linkifyPathTokens \} from "\.\/path-links";/);
+  assert.match(RENDER, /import \{ openPathLink, linkifyPathTokens, selectionOpenIn \} from "\.\/path-links";/);
   assert.match(RENDER, /function bindPathLink\(a: HTMLElement\): HTMLElement \{\n\s*const open = a\.dataset\.path \|\| "", relative = a\.dataset\.rel === "1";\n\s*a\.addEventListener\("click", \(e\) => \{\n\s*e\.stopPropagation\(\);\n\s*openPath\(open, relative \? activeId : null, e\);\n\s*\}\);\n\s*onMiddleClick\(a, \(e\) => openPath\(open, relative \? activeId : null, e\)\);\n\s*return a;\n\}/);
   assert.match(RENDER, /const link = bindPathLink\(openPathLink\(tok, tok, true\)\);\n\s*code\.replaceChildren\(link\);/, "the kernel-verified spaced span takes the same binder");
   assert.match(RENDER, /for \(const \{ el: link, open, verified \} of linkifyPathTokens\(root, pathLinks\)\) \{\n\s*bindPathLink\(link\);\n\s*if \(verified\) kernelVerified\.add\(open\);/);
@@ -221,4 +307,159 @@ test("source: the module marks and binds nothing; render.ts binds the click and 
     assert.ok(!RENDER.includes(name), name + " is path-links.ts's alone");
     assert.ok(LINKS.includes(name), name + " in path-links.ts");
   }
+});
+
+// ── the linear driver for the regex ───────────────────────────────────────────────────────────────
+/** What CLICKABLE_PATH_RE.exec finds from `from` with the g flag: the reference the scanner must match exactly. */
+function regexNext(re: RegExp, text: string, from: number): [number, number] | null {
+  re.lastIndex = from;
+  const m = re.exec(text);
+  return m ? [m.index, m.index + m[0].length] : null;
+}
+async function scannerAgrees(text: string): Promise<void> {
+  const { PathTokenScanner, CLICKABLE_PATH_RE } = await import("./path-links");
+  const re = new RegExp(CLICKABLE_PATH_RE.source, "gi");
+  const scan = new PathTokenScanner(text);
+  for (let from = 0; from <= text.length; from++) {
+    assert.deepEqual(scan.next(from), regexNext(re, text, from), JSON.stringify(text.slice(0, 80)) + " from " + from);
+  }
+  // …and the walk's own use: successive calls that never move `from` backwards, resuming after each match
+  const s2 = new PathTokenScanner(text);
+  let from = 0, m: [number, number] | null;
+  while ((m = s2.next(from))) { assert.deepEqual(m, regexNext(re, text, from)); from = m[1]; }
+  assert.equal(regexNext(re, text, from), null);
+}
+
+test("the scanner's arms are cut from CLICKABLE_PATH_RE itself: three, sticky, the regex's own text", async () => {
+  const { CLICKABLE_PATH_RE } = await import("./path-links");
+  const arms = CLICKABLE_PATH_RE.source.split("|");
+  assert.equal(arms.length, 3);
+  assert.match(arms[0], /^file:/); assert.match(arms[1], /^\[~\.\\w\\-\]\*\\\//); assert.match(arms[2], /^\[\\w\\-\]/);
+  assert.match(LINKS, /const \[URI_ARM, PATH_ARM, BARE_ARM\] = CLICKABLE_PATH_RE\.source\.split\("\|"\)\.map\(\(arm\) => new RegExp\(arm, "iy"\)\);/);
+  assert.equal(CLICKABLE_PATH_RE.source, "file:\\/\\/\\/?[^\\s<>\"'`)]+|[~.\\w\\-]*\\/[~.\\w\\-/]*[\\w\\-]|[\\w\\-][\\w\\-.]*\\.[A-Za-z0-9]{1,8}", "the parity contract's text, unchanged by the lift");
+});
+
+test("the scanner finds exactly what the regex finds, from every start position: adversarial shapes", async () => {
+  for (const text of [
+    "", "/", "a/b.md", "see a/b.md and c/d.py.", "file:///tmp/x.md and file://h/y", "FILE:///X", "f", "ff", "fil", "file:",
+    "~/x", "./a", "../b/c", "a//b", "//", "a.b.c", ".md", "a.", "-a/b-", "_x/_y.z", "x/y/z/", "a b/c d.md e",
+    "1/2.5", "24/7", "and/or", "np.array", "0.4.293", "a.verylongextensionx", "a.b.c.d.e.f.g.h.i", "x/.hidden", "..", ".",
+    "α/β.md", "a/ß.py", "日本語/x.md", "a\tb/c.md", "a\nb/c.md", "(a/b.md)", "\"a/b.md\"", "`a/b.md`", "<a/b.md>", "[a/b.md]",
+    "x".repeat(50) + "/" + "y".repeat(50) + ".md", "-".repeat(30), ".".repeat(30), "/".repeat(30), "~".repeat(10) + "/x",
+    "f".repeat(20) + "ile:///a", "file:" + "/".repeat(10) + "a", "a/b.md:12", "a/b.md#L3", "http://x.y/z.html", "git@h:u/r.git",
+  ]) await scannerAgrees(text);
+});
+
+test("the scanner finds exactly what the regex finds, from every start position: fuzzed texts", async () => {
+  const alphabet = "abfz09_-./~ :\n\"'`()<>ile";
+  let seed = 12345;
+  const rnd = () => { seed = (seed * 1103515245 + 12345) & 0x7fffffff; return seed / 0x7fffffff; };
+  for (let i = 0; i < 300; i++) {
+    const n = 1 + Math.floor(rnd() * 40);
+    let t = "";
+    for (let j = 0; j < n; j++) t += alphabet[Math.floor(rnd() * alphabet.length)];
+    await scannerAgrees(t);
+  }
+});
+
+test("tokenizer parity: the scanner over the shared kernel fixture, on the walk's own loop (the trim, the resume after the trimmed token)", async () => {
+  const { PathTokenScanner, TRAILING_PUNCT_RE } = await import("./path-links");
+  const fixture = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), "..", "tests", "fixtures", "path_token_parity.json"), "utf8"));
+  for (const c of fixture.cases as { text: string; tokens: string[] }[]) {
+    const toks: string[] = [];
+    const scan = new PathTokenScanner(c.text);
+    let from = 0, m: [number, number] | null;
+    while ((m = scan.next(from))) {
+      const tok = c.text.slice(m[0], m[1]).replace(TRAILING_PUNCT_RE, "");
+      from = Math.max(m[0] + tok.length, from + 1);
+      if (tok && !toks.includes(tok)) toks.push(tok);
+    }
+    assert.deepEqual(toks, c.tokens, c.text);
+  }
+});
+
+test("the trailing-punctuation set has one source: the regex is built from the characters the trim scans, and the walk trims as before", async () => {
+  const { TRAILING_PUNCT, TRAILING_PUNCT_RE, linkifyPathTokens } = await import("./path-links");
+  assert.equal(TRAILING_PUNCT, ".,;:!?)]}>\"'`");
+  for (const ch of TRAILING_PUNCT) assert.match("a" + ch, TRAILING_PUNCT_RE, ch);
+  for (const ch of "a/_-~") assert.doesNotMatch("a" + ch, TRAILING_PUNCT_RE, ch);
+  assert.match(LINKS, /export const TRAILING_PUNCT_RE = new RegExp\("\[" \+ TRAILING_PUNCT\.replace\(\/\[\\\\\\\]\^-\]\/g, "\\\\\$&"\) \+ "\]\+\$"\);/);
+  const p = el("p", "", "see a/b.md.), then c/d.md!?'\"`");
+  linkifyPathTokens(p as unknown as HTMLElement);
+  assert.deepEqual(textNodesOf(p).map((t) => t.data), ["see ", "a/b.md", ".), then ", "c/d.md", "!?'\"`"]);
+});
+
+test("pathological inputs finish and match: a slash before a 40K run of hex, a 40K token of dots, a 40K separator line, a minified dump", async () => {
+  const { linkifyPathTokens, CLICKABLE_PATH_RE, PathTokenScanner } = await import("./path-links");
+  const re = new RegExp(CLICKABLE_PATH_RE.source, "gi");
+  for (const text of ["/" + "a1b2c3d4".repeat(5000), "/" + ".".repeat(40000), "-".repeat(40000) + "/x.md", "x/" + "_".repeat(40000), "var a=1;".repeat(5000) + "/a.b"]) {
+    const scan = new PathTokenScanner(text);
+    let from = 0, m: [number, number] | null;
+    while ((m = scan.next(from))) { assert.deepEqual(m, regexNext(re, text, from)); from = m[1]; }
+    assert.equal(regexNext(re, text, from), null);
+    const p = el("p", "", text);
+    linkifyPathTokens(p as unknown as HTMLElement);
+    assert.equal(p.textContent, text, "the text reads as before");
+  }
+});
+
+// ── the units: a line at a time, when a surface asks ──────────────────────────────────────────────
+test("textUnits: with no unit selector every text node is a unit of its own (the chat's walk); under a selector the nodes sharing a unit ancestor join into one text; a <br> ends a unit; an empty unit element is an empty unit in its place; dead and inCode are read per node", async () => {
+  const { textUnits, DEAD_TEXT } = await import("./path-links");
+  const p = el("p", "", "a ", el("span", "x", "b"), " c");
+  assert.deepEqual(textUnits(p as unknown as HTMLElement, undefined, DEAD_TEXT).map((u) => u.text), ["a ", "b", " c"], "no selector: node by node");
+  const joined = textUnits(p as unknown as HTMLElement, "p", DEAD_TEXT);
+  assert.equal(joined.length, 1); assert.equal(joined[0].text, "a b c");
+  assert.deepEqual(joined[0].spans.map((s) => [s.start, s.end, s.dead, s.inCode]), [[0, 2, false, false], [2, 3, false, false], [3, 5, false, false]]);
+  const rows = el("div", "", el("span", "fv-cl", el("span", "fv-ct", "one ", el("a", "", "docs/a.md"))), el("span", "fv-cl", el("span", "fv-ct")), el("span", "fv-cl", el("span", "fv-ct", el("code", "", "x.md"), " y", el("br"), "z")));
+  const units = textUnits(rows as unknown as HTMLElement, ".fv-cl", DEAD_TEXT);
+  assert.deepEqual(units.map((u) => u.text), ["one docs/a.md", "", "x.md y", "z"], "the second row is blank and stays a unit; the <br> cuts the third");
+  assert.deepEqual(units[0].spans.map((s) => s.dead), [false, true], "the anchor's text is dead to marking but read");
+  assert.deepEqual(units[2].spans.map((s) => s.inCode), [true, false]);
+});
+
+test("spanHolding and rewriteSpan: the span holding a range whole and open, null across an edge or in a dead span; a rewrite replaces one node with text and marks in order and changes no character", async () => {
+  const { textUnits, spanHolding, rewriteSpan, DEAD_TEXT } = await import("./path-links");
+  const p = el("p", "", "aa", el("a", "", "bb"), "ccdd");
+  const u = textUnits(p as unknown as HTMLElement, "p", DEAD_TEXT)[0];
+  assert.equal(u.text, "aabbccdd");
+  assert.equal(spanHolding(u, 0, 2), u.spans[0]); assert.equal(spanHolding(u, 4, 8), u.spans[2]); assert.equal(spanHolding(u, 6, 8), u.spans[2]);
+  assert.equal(spanHolding(u, 1, 3), null, "across an edge"); assert.equal(spanHolding(u, 2, 4), null, "in the link: dead"); assert.equal(spanHolding(u, 8, 9), null); assert.equal(spanHolding(u, -1, 1), null);
+  const m1 = el("b", "", "c"), m2 = el("i", "", "d");
+  rewriteSpan(u, u.spans[2], [{ start: 5, end: 6, el: m1 as unknown as Node }, { start: 7, end: 8, el: m2 as unknown as Node }]);
+  assert.equal(p.textContent, "aabbccdd");
+  assert.deepEqual(p.childNodes.map((c) => (c instanceof Txt ? c.data : (c as El).tagName + ":" + c.textContent)), ["aa", "A:bb", "c", "B:c", "d", "I:d"]);
+});
+
+test("the walk under the viewer's options: inPre reads a code body, unit joins a row's spans so a token the highlight cut through stays text while one held whole in a span links, accept and resolve are the surface's, lineSuffix rides a :12 into the link; without options the chat's walk is unchanged", async () => {
+  const { linkifyPathTokens } = await import("./path-links");
+  const row = (...kids: Array<El | string>) => el("span", "fv-cl", el("span", "fv-ct", ...kids));
+  const c = el("pre", "", el("code", "hljs",
+    row("cp ", el("span", "hljs-string", '"', el("span", "hljs-variable", "$HOME"), '/docs/a.md"')),
+    row("x = ", el("span", "hljs-string", '"docs/b.md:12"'), " and/or docs/c.md"),
+    row(el("span", "hljs-string", '"docs/'), el("span", "hljs-string", 'd.md"')),
+  ));
+  const seen: string[] = [];
+  const hits = linkifyPathTokens(c as unknown as HTMLElement, undefined, {
+    inPre: true, unit: ".fv-cl", lineSuffix: true,
+    accept: (tok, ctx) => { seen.push(tok + "@" + ctx.at + "/" + ctx.text.length); return tok !== "docs/c.md"; },
+    resolve: (tok) => "/tmp/TESTHOST/" + tok,
+  });
+  assert.deepEqual(seen, ["docs/b.md@5/35", "docs/c.md@26/35"],
+    "the gate sees a LINE's token and its offset in the line; the first row's HOME/docs/a.md (what the line says, never the /docs/a.md the substitution's tail alone would read) is cut across two nodes and refused by the span test before any gate; and/or fails the shape gate");
+  assert.deepEqual(hits.map((h) => h.open), ["/tmp/TESTHOST/docs/b.md"], "docs/c.md was refused by the surface's gate, the cut docs/d.md by the span test; the one link is resolved by the surface");
+  // a substitution that leaves the path's tail whole in its own node: the token is `/notes/a.md`, and the gate is handed the line, where it is glued to the brace
+  const glued = el("pre", "", el("code", "hljs", row("path: ", el("span", "hljs-string", el("span", "hljs-variable", "${HOME}"), "/notes/a.md"))));
+  const seen2: Array<[string, string]> = [];
+  linkifyPathTokens(glued as unknown as HTMLElement, undefined, { inPre: true, unit: ".fv-cl", accept: (tok, ctx) => { seen2.push([tok, ctx.text[ctx.at - 1]]); return false; } });
+  assert.deepEqual(seen2, [["/notes/a.md", "}"]], "the surface's gate reads the character before the token off the LINE, not the node");
+  const link = c.querySelectorAll(".file-uri-link")[0];
+  assert.equal(link.textContent, "docs/b.md:12"); assert.equal(link.dataset.line, "12"); assert.equal(link.title, "Open /tmp/TESTHOST/docs/b.md:12");
+  assert.equal(link.parentNode!.textContent, '"docs/b.md:12"', "inside the string span, the quotes outside");
+  assert.equal(c.textContent, 'cp "$HOME/docs/a.md"x = "docs/b.md:12" and/or docs/c.md"docs/d.md"');
+  // the chat's walk: no options, every node its own unit, <pre> skipped, no line suffix read
+  const chat = el("div", "", el("p", "", "see docs/e.md:12 now"), el("pre", "", el("code", "", "docs/f.md")));
+  const h2 = linkifyPathTokens(chat as unknown as HTMLElement);
+  assert.deepEqual(h2.map((h) => h.open), ["docs/e.md"]);
+  assert.deepEqual(textNodesOf(chat.childNodes[0] as El).map((t) => t.data), ["see ", "docs/e.md", ":12 now"], "the :12 stays prose in the chat");
 });

--- a/ui/webview/path-links.test.ts
+++ b/ui/webview/path-links.test.ts
@@ -1,0 +1,224 @@
+// The chat's path matcher, executed (path-links.ts). It lived inline in render.ts, whose only tests are source
+// pins; lifted into a module of its own it runs for real over a small DOM stand-in (no jsdom): the walk over a
+// message body, the shape gates, the trailing-punctuation trim, the kernel's pathLinks verdict narrowing the
+// links, and the span each hit is marked as. What a click does is the hosting document's (render.ts binds
+// openPath per span; chat-path-links.test.ts and chat-relpath-link.test.ts pin that wiring at source).
+// Synthetic fixtures only: the notes-api demo world, a placeholder session id.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const LINKS = fs.readFileSync(path.join(UI, "path-links.ts"), "utf8");
+
+// ── a DOM stand-in: text nodes, elements with attributes, a small selector engine, fragments ──────────
+type Compound = { tag: string | null; classes: string[]; attrs: Array<[string, string | null]> };
+function parseSel(sel: string): Compound[][] {
+  return sel.split(",").map((g) => g.trim()).filter(Boolean).map((g) => g.split(/\s+/).map((s) => {
+    const m = /^([a-zA-Z][\w-]*)?((?:\.[\w-]+)*)((?:\[[\w-]+(?:="[^"]*")?\])*)$/.exec(s);
+    if (!m) throw new Error("stand-in: unsupported selector " + s);
+    const classes = (m[2].match(/\.[\w-]+/g) || []).map((c) => c.slice(1));
+    const attrs: Array<[string, string | null]> = [];
+    for (const a of m[3].match(/\[[^\]]+\]/g) || []) { const am = /^\[([\w-]+)(?:="([^"]*)")?\]$/.exec(a)!; attrs.push([am[1], am[2] ?? null]); }
+    return { tag: m[1] ? m[1].toUpperCase() : null, classes, attrs };
+  }));
+}
+class Txt {
+  nodeType = 3;
+  parentNode: El | null = null;
+  constructor(public data: string) {}
+  get textContent(): string { return this.data; }
+  get parentElement(): El | null { return this.parentNode; }
+  replaceWith(n: El | Txt | Frag): void {
+    const p = this.parentNode!;
+    const i = p.childNodes.indexOf(this);
+    const kids = n instanceof Frag ? n.childNodes.slice() : [n];
+    for (const k of kids) { if (k.parentNode) k.parentNode.removeChild(k); k.parentNode = p; }
+    p.childNodes.splice(i, 1, ...kids);
+    this.parentNode = null;
+  }
+}
+class Frag { childNodes: Array<El | Txt> = []; appendChild(c: El | Txt): void { this.childNodes.push(c); } }
+const kebab = (k: string) => k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+class El {
+  nodeType = 1;
+  tagName: string;
+  parentNode: El | null = null;
+  childNodes: Array<El | Txt> = [];
+  attrs = new Map<string, string>();
+  constructor(tag: string) { this.tagName = tag.toUpperCase(); }
+  get parentElement(): El | null { return this.parentNode; }
+  get className(): string { return this.attrs.get("class") || ""; } set className(v: string) { this.attrs.set("class", v); }
+  get title(): string { return this.attrs.get("title") || ""; } set title(v: string) { this.attrs.set("title", v); }
+  get classes(): string[] { return this.className.split(/\s+/).filter(Boolean); }
+  dataset: Record<string, string> = new Proxy({} as Record<string, string>, {
+    get: (_, k) => this.attrs.get("data-" + kebab(String(k))) as string,
+    set: (_, k, v) => { this.attrs.set("data-" + kebab(String(k)), String(v)); return true; },
+    has: (_, k) => this.attrs.has("data-" + kebab(String(k))),
+  });
+  get textContent(): string { return this.childNodes.map((c) => c.textContent).join(""); }
+  set textContent(v: string) { for (const c of this.childNodes) c.parentNode = null; this.childNodes = []; if (v !== "") this.appendChild(new Txt(v)); }
+  private detach(n: El | Txt): void { const p = n.parentNode; if (p) { const i = p.childNodes.indexOf(n); if (i >= 0) p.childNodes.splice(i, 1); n.parentNode = null; } }
+  appendChild<T extends El | Txt>(n: T): T { this.detach(n); this.childNodes.push(n); n.parentNode = this; return n; }
+  removeChild<T extends El | Txt>(n: T): T { this.detach(n); return n; }
+  setAttribute(k: string, v: string): void { this.attrs.set(k, v); }
+  getAttribute(k: string): string | null { return this.attrs.has(k) ? (this.attrs.get(k) as string) : null; }
+  hasAttribute(k: string): boolean { return this.attrs.has(k); }
+  private fits(c: Compound): boolean {
+    return (!c.tag || c.tag === this.tagName) && c.classes.every((k) => this.classes.includes(k))
+      && c.attrs.every(([a, v]) => this.attrs.has(a) && (v === null || this.attrs.get(a) === v));
+  }
+  matches(sel: string): boolean {
+    return parseSel(sel).some((chain) => {
+      if (!this.fits(chain[chain.length - 1])) return false;
+      let k = chain.length - 2;
+      for (let a: El | null = this.parentNode; a && k >= 0; a = a.parentNode) if (a.fits(chain[k])) k--;
+      return k < 0;
+    });
+  }
+  closest(sel: string): El | null { for (let x: El | null = this; x; x = x.parentNode) if (x.matches(sel)) return x; return null; }
+  querySelectorAll(sel: string): El[] {
+    const out: El[] = [];
+    const visit = (n: El) => { for (const c of n.childNodes) if (c instanceof El) { if (c.matches(sel)) out.push(c); visit(c); } };
+    visit(this);
+    return out;
+  }
+}
+/** Document-order nodes under `root`, as a browser's tree walker answers them (SHOW_TEXT = 4, SHOW_ELEMENT = 1). */
+function walkNodes(root: El, what: number): Array<El | Txt> {
+  const out: Array<El | Txt> = [];
+  const walk = (n: El) => { for (const c of n.childNodes) { if (c instanceof Txt) { if (what & 4) out.push(c); } else { if (what & 1) out.push(c); walk(c); } } };
+  walk(root);
+  return out;
+}
+function textNodesOf(root: El): Txt[] { return walkNodes(root, 4) as Txt[]; }
+const doc = {
+  createElement: (tag: string) => new El(tag),
+  createTextNode: (s: string) => new Txt(s),
+  createDocumentFragment: () => new Frag(),
+  createTreeWalker: (root: El, what = 4) => { const nodes = walkNodes(root, what); let i = 0; return { nextNode: () => (i < nodes.length ? nodes[i++] : null) }; },
+};
+(globalThis as any).NodeFilter = { SHOW_ELEMENT: 1, SHOW_TEXT: 4 };
+(globalThis as any).document = doc;
+
+const el = (tag: string, cls?: string, ...kids: Array<El | Txt | string>): El => {
+  const e = new El(tag); if (cls) e.className = cls;
+  for (const k of kids) e.appendChild(typeof k === "string" ? new Txt(k) : k);
+  return e;
+};
+const links = (root: El) => root.querySelectorAll(".file-uri-link");
+const shape = (a: El) => [a.textContent, a.dataset.path, a.dataset.rel, a.title];
+
+// ── the span ──────────────────────────────────────────────────────────────────────────────────────
+test("openPathLink marks a span: the raw text as written, the target in data-path and the title, data-rel for a bare path; a file:// URI's link opens its decoded path and carries no data-rel", async () => {
+  const { openPathLink, fileUriLink } = await import("./path-links");
+  const a = openPathLink("design/foo.md", "design/foo.md", true) as unknown as El;
+  assert.equal(a.tagName, "SPAN"); assert.equal(a.className, "file-uri-link");
+  assert.deepEqual(shape(a), ["design/foo.md", "design/foo.md", "1", "Open design/foo.md"]);
+  const fixed = openPathLink("render.js", "ui/webview/render.js", true) as unknown as El;
+  assert.deepEqual(shape(fixed), ["render.js", "ui/webview/render.js", "1", "Open ui/webview/render.js"], "a shortened mention shows as written and opens the kernel's fixed target");
+  const abs = openPathLink("/tmp/TESTHOST/a.md", "/tmp/TESTHOST/a.md") as unknown as El;
+  assert.deepEqual(shape(abs), ["/tmp/TESTHOST/a.md", "/tmp/TESTHOST/a.md", undefined, "Open /tmp/TESTHOST/a.md"]);
+  const u = fileUriLink("file:///tmp/TESTHOST/a%20b.pdf") as unknown as El;
+  assert.deepEqual(shape(u), ["file:///tmp/TESTHOST/a%20b.pdf", "/tmp/TESTHOST/a b.pdf", undefined, "Open /tmp/TESTHOST/a b.pdf"]);
+  // the module binds nothing: no handler on the span (render.ts's bindPathLink adds the click)
+  assert.equal((a as any).onclick, undefined);
+});
+
+// ── the shape gates, on the real functions ────────────────────────────────────────────────────────
+test("looksLikeFilePath and looksLikeBareFileName: anchored starts and slashed paths with an extension link, prose fractions and idioms do not; a bare filename needs a known extension", async () => {
+  const { looksLikeFilePath, looksLikeBareFileName, fileUriToPath } = await import("./path-links");
+  for (const p of ["design/foo.md", "/abs/path", "~/x", "./rel", "../up", "a/b/c.py", "ui/webview/render.ts"]) assert.equal(looksLikeFilePath(p), true, p);
+  for (const p of ["and/or", "TCP/IP", "24/7", "read/write", "http://x/y", "a:b/c.md", "noslash.md", "src/lib"]) assert.equal(looksLikeFilePath(p), false, p);
+  for (const p of ["power2_watts.pdf", "report.md", "data.csv", "notes.MD"]) assert.equal(looksLikeBareFileName(p), true, p);
+  for (const p of ["np.array", "s.color", "0.4.293", ".md", "a/b.md", "x:y.md", "romp.kernelPort"]) assert.equal(looksLikeBareFileName(p), false, p);
+  assert.equal(fileUriToPath("file:///tmp/TESTHOST/a%20b.md"), "/tmp/TESTHOST/a b.md");
+  assert.equal(fileUriToPath("file:///tmp/TESTHOST/%zz.md"), "/tmp/TESTHOST/%zz.md", "a malformed escape is kept as written");
+});
+
+// ── the walk over a message body ──────────────────────────────────────────────────────────────────
+test("the walk over a chat body: slashed paths and file:// URIs become spans, prose stays, a sentence's closing punctuation is left as text, and the body's text reads exactly as before", async () => {
+  const { linkifyPathTokens } = await import("./path-links");
+  const p = el("p", "", "see design/foo.md. Then and/or 24/7, TCP/IP and (file:///tmp/TESTHOST/a%20b.pdf), then ui/webview/render.ts!");
+  const before = p.textContent;
+  const hits = linkifyPathTokens(p as unknown as HTMLElement);
+  assert.equal(p.textContent, before, "the pass adds elements around text and changes no character");
+  assert.deepEqual(links(p).map(shape), [
+    ["design/foo.md", "design/foo.md", "1", "Open design/foo.md"],
+    ["file:///tmp/TESTHOST/a%20b.pdf", "/tmp/TESTHOST/a b.pdf", undefined, "Open /tmp/TESTHOST/a b.pdf"],
+    ["ui/webview/render.ts", "ui/webview/render.ts", "1", "Open ui/webview/render.ts"],
+  ]);
+  assert.deepEqual(textNodesOf(p).map((t) => t.data), ["see ", "design/foo.md", ". Then and/or 24/7, TCP/IP and (", "file:///tmp/TESTHOST/a%20b.pdf", "), then ", "ui/webview/render.ts", "!"]);
+  // the hits, in document order, name the span and what it opens; nothing here was kernel-verified (no map)
+  assert.deepEqual(hits.map((h) => [h.open, h.verified, (h.el as unknown as El).textContent]), [["design/foo.md", false, "design/foo.md"], ["/tmp/TESTHOST/a b.pdf", false, "file:///tmp/TESTHOST/a%20b.pdf"], ["ui/webview/render.ts", false, "ui/webview/render.ts"]]);
+});
+
+test("inline code: a bare filename with a known extension links inside <code> only; a dotted identifier, a version and an unknown extension stay; prose never links a bare name", async () => {
+  const { linkifyPathTokens } = await import("./path-links");
+  const p = el("p", "", "wrote ", el("code", "", "power2_watts.pdf"), " and ", el("code", "", "np.array"), " and ", el("code", "", "0.4.293"), " and ", el("code", "", "out.xyz"), "; also report.md in prose");
+  const before = p.textContent;
+  linkifyPathTokens(p as unknown as HTMLElement);
+  assert.equal(p.textContent, before);
+  assert.deepEqual(links(p).map((a) => a.textContent), ["power2_watts.pdf"]);
+  assert.equal(links(p)[0].parentNode!.tagName, "CODE", "the link sits inside the code span");
+  assert.deepEqual(textNodesOf(p).map((t) => t.data).slice(-1), ["; also report.md in prose"], "a bare name in prose is not a link");
+});
+
+test("skipped text: inside an existing anchor, inside a span already linked, and inside a fenced <pre> block; a unit with no slash (and, in code, no dot) is not even scanned", async () => {
+  const { linkifyPathTokens, openPathLink } = await import("./path-links");
+  const already = openPathLink("docs/x.md", "docs/x.md", true) as unknown as El;
+  const p = el("div", "",
+    el("p", "", "a ", el("a", "", "docs/linked.md"), " b ", already, " c docs/free.md"),
+    el("pre", "", el("code", "", "cat docs/fenced.md")),
+    el("p", "", "no path here at all"),
+  );
+  const before = p.textContent;
+  const hits = linkifyPathTokens(p as unknown as HTMLElement);
+  assert.equal(p.textContent, before);
+  assert.deepEqual(hits.map((h) => h.open), ["docs/free.md"], "the anchor's, the linked span's and the fence's text are left as they are");
+  assert.equal(links(p).length, 2, "the span that was already a link, and the one new link");
+});
+
+test("the kernel's pathLinks verdict: with a map, a token links ONLY when it is a key and opens the map's value (verified); with no map, shape alone decides; a file:// URI is never gated on the map", async () => {
+  const { linkifyPathTokens } = await import("./path-links");
+  const text = "fix render.js and kernel/sub/deep.py, not a/dup.py; see file:///tmp/TESTHOST/z.md";
+  const gated = el("p", "", el("code", "", "render.js"), " " + text);
+  const hits = linkifyPathTokens(gated as unknown as HTMLElement, { "render.js": "ui/webview/render.js", "kernel/sub/deep.py": "kernel/sub/deep.py" });
+  assert.deepEqual(hits.map((h) => [h.open, h.verified]), [["ui/webview/render.js", true], ["kernel/sub/deep.py", true], ["/tmp/TESTHOST/z.md", false]],
+    "the backticked mention opens the fixed target (the bare name in prose fails the shape gate first: the map only ever narrows); a/dup.py, absent from the map (no such file, or several), stays prose; the URI rides regardless");
+  assert.deepEqual(links(gated).map(shape)[0], ["render.js", "ui/webview/render.js", "1", "Open ui/webview/render.js"], "shown as written, opens the real file, hover names it");
+  assert.equal(links(gated).length, 3);
+  // no map at all (an old kernel, a cached payload): every shape-passing token links as written, none verified
+  const free = el("p", "", text);
+  const h2 = linkifyPathTokens(free as unknown as HTMLElement);
+  assert.deepEqual(h2.map((h) => [h.open, h.verified]), [["kernel/sub/deep.py", false], ["a/dup.py", false], ["/tmp/TESTHOST/z.md", false]], "render.js has no slash and is not in code: prose either way");
+  // an EMPTY map is a verdict too: nothing links but the URI
+  const none = el("p", "", text);
+  assert.deepEqual(linkifyPathTokens(none as unknown as HTMLElement, {}).map((h) => h.open), ["/tmp/TESTHOST/z.md"]);
+});
+
+test("the resume rule: after a linked token the scan resumes right after it, so a token's trimmed punctuation and the text after it are read again as prose; a token that stays prose is skipped whole", async () => {
+  const { linkifyPathTokens } = await import("./path-links");
+  const p = el("p", "", "a/b.md,c/d.md; and/or e/f.md");
+  linkifyPathTokens(p as unknown as HTMLElement);
+  assert.deepEqual(links(p).map((a) => a.textContent), ["a/b.md", "c/d.md", "e/f.md"]);
+  assert.deepEqual(textNodesOf(p).map((t) => t.data), ["a/b.md", ",", "c/d.md", "; and/or ", "e/f.md"]);
+});
+
+// ── the module's contract with render.ts, at source ───────────────────────────────────────────────
+test("source: the module marks and binds nothing; render.ts binds the click and the middle button per span off the span's data, and reads the hits for its figure pass", () => {
+  const RENDER = fs.readFileSync(path.join(UI, "render.ts"), "utf8");
+  assert.doesNotMatch(LINKS, /addEventListener|onclick|openPath\(|window\.open|postMessage/, "no action of its own");
+  assert.match(LINKS, /export function linkifyPathTokens\(root: HTMLElement, pathLinks\?: Record<string, string>\): PathLinkHit\[\] \{/);
+  assert.match(LINKS, /export interface PathLinkHit \{ el: HTMLElement; open: string; verified: boolean \}/);
+  assert.match(RENDER, /import \{ openPathLink, linkifyPathTokens \} from "\.\/path-links";/);
+  assert.match(RENDER, /function bindPathLink\(a: HTMLElement\): HTMLElement \{\n\s*const open = a\.dataset\.path \|\| "", relative = a\.dataset\.rel === "1";\n\s*a\.addEventListener\("click", \(e\) => \{\n\s*e\.stopPropagation\(\);\n\s*openPath\(open, relative \? activeId : null, e\);\n\s*\}\);\n\s*onMiddleClick\(a, \(e\) => openPath\(open, relative \? activeId : null, e\)\);\n\s*return a;\n\}/);
+  assert.match(RENDER, /const link = bindPathLink\(openPathLink\(tok, tok, true\)\);\n\s*code\.replaceChildren\(link\);/, "the kernel-verified spaced span takes the same binder");
+  assert.match(RENDER, /for \(const \{ el: link, open, verified \} of linkifyPathTokens\(root, pathLinks\)\) \{\n\s*bindPathLink\(link\);\n\s*if \(verified\) kernelVerified\.add\(open\);/);
+  // the matcher lives in ONE place: render.ts no longer declares the regex or its gates
+  for (const name of ["CLICKABLE_PATH_RE", "function looksLikeFilePath", "function looksLikeBareFileName", "const BARE_FILE_EXTS", "function fileUriToPath", "function openPathLink", "function fileUriLink"]) {
+    assert.ok(!RENDER.includes(name), name + " is path-links.ts's alone");
+    assert.ok(LINKS.includes(name), name + " in path-links.ts");
+  }
+});

--- a/ui/webview/path-links.ts
+++ b/ui/webview/path-links.ts
@@ -1,0 +1,121 @@
+// The file-path matcher the chat's transcript links are made from, as a module any surface can import. It
+// lived inside render.ts, the chat's entry, which exports nothing, so a second surface that shows text with
+// paths in it could reach the matcher only by copying it, and two copies drift. Lifted, not copied: one regex,
+// one set of gates, one span shape, so the kernel's tokenizer parity (tests/fixtures/path_token_parity.json)
+// and the chat's link behaviour keep a single source.
+//
+// This module MATCHES and MARKS; it binds no action. Every link it emits is a `.file-uri-link` span carrying
+// data-path (what a click opens: for a shortened mention the kernel's fixed target, not the token) and
+// data-rel="1" when the token was a bare path rather than a file:// URI (so a resolver uses a session's cwd).
+// What a click does is the hosting document's call: render.ts binds openPath per span (the editor in VS Code,
+// the viewer on the web) and paints its figure previews from the hits. A document that cannot act on a click
+// should not call this: a link that does nothing is worse than text.
+
+function el(tag: string, cls?: string): HTMLElement { const e = document.createElement(tag); if (cls) e.className = cls; return e; }
+
+// A file:// URI → its local filesystem path: strip the scheme, percent-decode. file:///a/b → /a/b.
+export function fileUriToPath(uri: string): string {
+  let p = uri.replace(/^file:\/\//i, "");   // file:///Users/… → /Users/… (host is empty for file:///)
+  try { p = decodeURIComponent(p); } catch { /* malformed %-escape — use verbatim */ }
+  return p;
+}
+// A VERBATIM file link, marked for whoever hosts it. `raw` is shown as written (selectable/copyable in
+// place); `open` is what gets opened. A bare file:// can't be followed by the browser from the http
+// dashboard (blocked scheme) and a VS Code editor won't render a PDF, so it is routed, never navigated.
+// `relative` bare paths are resolved against a session's cwd by whoever opens them: a relative
+// `design/foo.md` is relative to the repo the agent runs in, not the kernel's cwd (the user 2026-07-06).
+export function openPathLink(raw: string, open: string, relative = false): HTMLElement {
+  const a = el("span", "file-uri-link");
+  a.textContent = raw;                       // shown exactly as written, selectable/copyable in place
+  a.title = "Open " + open;
+  a.dataset.path = open;
+  if (relative) a.dataset.rel = "1";
+  return a;
+}
+export function fileUriLink(uri: string): HTMLElement { return openPathLink(uri, fileUriToPath(uri)); }
+// Is this bare token (trailing punctuation already stripped) a file path worth linkifying? Requires a slash
+// and EITHER an absolute/anchored start (/, ~/, ./, ../) OR a file extension on the final segment — so
+// "and/or", "TCP/IP", "24/7", "read/write" stay as prose. URL-ish tokens (a ':' or '//') are rejected;
+// http(s) links are already <a> (skipped) — this just guards a rare un-autolinked one.
+export function looksLikeFilePath(tok: string): boolean {
+  if (tok.includes(":") || tok.includes("//") || !tok.includes("/")) return false;
+  if (/^(?:~\/|\.{1,2}\/|\/)/.test(tok)) return true;                        // absolute or anchored (/, ~/, ./, ../)
+  return /\.[A-Za-z0-9]{1,8}$/.test(tok.slice(tok.lastIndexOf("/") + 1));    // relative → the last segment has an extension
+}
+// A BARE filename (no slash — `power2_watts.pdf`) is linkified ONLY inside inline <code> (the user
+// 2026-07-17: a reply listing its output files wasn't clickable). Backticks are where agents put
+// filenames, and the KNOWN-extension gate keeps backticked dotted identifiers (`np.array`, `s.color`,
+// `romp.kernelPort`) and version numbers (`0.4.293`) reading as prose — an unknown extension stays text.
+export const BARE_FILE_EXTS = new Set([
+  "md", "txt", "rst", "py", "ts", "tsx", "js", "jsx", "mjs", "cjs", "json", "jsonl", "csv", "tsv",
+  "pdf", "png", "jpg", "jpeg", "gif", "svg", "webp", "html", "htm", "css", "scss", "sh", "bash", "zsh",
+  "bats", "yaml", "yml", "toml", "ini", "cfg", "conf", "xml", "ipynb", "rs", "go", "java", "c", "h",
+  "cpp", "hpp", "cc", "rb", "php", "sql", "log", "lock", "tex", "bib", "zip", "tar", "gz", "tgz",
+  "mp4", "mov", "mp3", "wav", "vsix", "plist", "diff", "patch",
+]);
+export function looksLikeBareFileName(tok: string): boolean {
+  if (tok.includes("/") || tok.includes(":")) return false;
+  const dot = tok.lastIndexOf(".");
+  if (dot <= 0) return false;                                                // needs a name before the extension
+  return BARE_FILE_EXTS.has(tok.slice(dot + 1).toLowerCase());
+}
+// One finder covers the file: scheme, the slashed-path alternative, and the bare-filename alternative.
+// The kernel's _path_tokens is a port of it (kernel.py), and both sides run the same fixture: a token
+// the kernel never saw is a verdict the client can never look up. Its TEXT is that contract.
+export const CLICKABLE_PATH_RE = /file:\/\/\/?[^\s<>"'`)]+|[~.\w\-]*\/[~.\w\-/]*[\w\-]|[\w\-][\w\-.]*\.[A-Za-z0-9]{1,8}/gi;
+
+/** One link the walk emitted: the span, what it opens, and whether the kernel stat'd that target this
+ *  build (a fixed mention). The chat's figure pass wants exactly these. */
+export interface PathLinkHit { el: HTMLElement; open: string; verified: boolean }
+
+// Mark bare file:// URLs AND bare file paths inside `root`'s text, a relative `design/foo.md` too,
+// resolved against a session's cwd by whoever opens it (the user 2026-07-06). marked doesn't autolink these
+// and DOMPurify strips the file: scheme, so without this they read as dead text. Inside INLINE <code> a
+// slash-less filename with a known extension marks too; only FENCED <pre> blocks and text already inside a
+// link are skipped. Text nodes only: an element the caller already made a link stays one. Trailing sentence
+// punctuation is left out, not swallowed.
+// `pathLinks` (the user 2026-08-09): the kernel's verdict on every path-shaped token in this text
+// (build_session's _path_links — tier 1 exact stat, tiers 2/3 a unique repo-list match that FIXES a
+// shortened mention to its real file). When the map is present, a token links ONLY if it's in the map,
+// and it opens the map's value — so `render.js` in prose stops 404ing, and hover shows the real target.
+// Every shape gate still applies; the map only ever narrows. No map at all (an old kernel, a cached
+// payload) keeps shape-only linking. file:// URIs are explicit absolute paths — never gated on the map.
+// Returns the hits in document order, so a caller's "first mention" is the walk's first.
+export function linkifyPathTokens(root: HTMLElement, pathLinks?: Record<string, string>): PathLinkHit[] {
+  const hits: PathLinkHit[] = [];
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const nodes: Text[] = [];
+  let n: Node | null;
+  while ((n = walker.nextNode())) nodes.push(n as Text);
+  for (const tn of nodes) {
+    if (tn.parentElement?.closest("a, .file-uri-link, pre")) continue;   // already a link, or a fenced code block
+    const inCode = !!tn.parentElement?.closest("code");                  // inline code — where bare filenames may link
+    const text = tn.data;
+    if (!text.includes("/") && !(inCode && text.includes("."))) continue;   // cheap pre-filter: no slash (and, in code, no dot) → nothing here
+    const re = new RegExp(CLICKABLE_PATH_RE.source, "gi");
+    const frag = document.createDocumentFragment();
+    let last = 0, any = false, m: RegExpExecArray | null;
+    while ((m = re.exec(text))) {
+      let tok = m[0];
+      const trail = tok.match(/[.,;:!?)\]}>"'`]+$/);   // don't grab a sentence's closing punctuation
+      if (trail) tok = tok.slice(0, tok.length - trail[0].length);
+      if (!tok) continue;
+      const isUri = /^file:\/\//i.test(tok);
+      if (!isUri && !looksLikeFilePath(tok) && !(inCode && looksLikeBareFileName(tok))) continue;   // "and/or", `np.array` etc. — leave as prose
+      const fixed = !isUri && pathLinks ? pathLinks[tok] : undefined;   // the kernel's verdict, when it rendered one
+      if (!isUri && pathLinks && typeof fixed !== "string") continue;   // checked against the filesystem: no such file (or several) → prose
+      if (m.index > last) frag.appendChild(document.createTextNode(text.slice(last, m.index)));
+      const open = isUri ? fileUriToPath(tok) : (fixed ?? tok);
+      const link = isUri ? fileUriLink(tok) : openPathLink(tok, open, true);
+      frag.appendChild(link);
+      hits.push({ el: link, open, verified: !isUri && typeof fixed === "string" });   // the kernel stat'd a fixed one this build
+      last = m.index + tok.length;
+      re.lastIndex = last;
+      any = true;
+    }
+    if (!any) continue;
+    if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
+    tn.replaceWith(frag);
+  }
+  return hits;
+}

--- a/ui/webview/path-links.ts
+++ b/ui/webview/path-links.ts
@@ -1,23 +1,75 @@
 // The file-path matcher the chat's transcript links are made from, as a module any surface can import. It
-// lived inside render.ts, the chat's entry, which exports nothing, so a second surface that shows text with
-// paths in it could reach the matcher only by copying it, and two copies drift. Lifted, not copied: one regex,
-// one set of gates, one span shape, so the kernel's tokenizer parity (tests/fixtures/path_token_parity.json)
-// and the chat's link behaviour keep a single source.
+// lived inside render.ts, the chat's entry, which exports nothing, so the file viewer (file-view.ts), which
+// shows text with paths in it, could reach the matcher only by copying it, and two copies drift. Lifted, not
+// copied: one regex, one set of gates, one span shape, so the kernel's tokenizer parity
+// (tests/fixtures/path_token_parity.json) and the chat's link behaviour keep a single source. The viewer runs
+// the same walk with options (PathLinkOptions, below) rather than a matcher of its own.
 //
-// This module MATCHES and MARKS; it binds no action. Every link it emits is a `.file-uri-link` span carrying
-// data-path (what a click opens: for a shortened mention the kernel's fixed target, not the token) and
-// data-rel="1" when the token was a bare path rather than a file:// URI (so a resolver uses a session's cwd).
-// What a click does is the hosting document's call: render.ts binds openPath per span (the editor in VS Code,
-// the viewer on the web) and paints its figure previews from the hits. A document that cannot act on a click
-// should not call this: a link that does nothing is worse than text.
+// This module MATCHES and MARKS; it binds no action. Every link it emits is a `.file-uri-link` element
+// carrying data-path (what a click opens: for a shortened mention the kernel's fixed target, not the token)
+// and data-rel="1" when the token was a bare path rather than a file:// URI (so a resolver uses a session's
+// cwd). What a click does is the hosting document's call: render.ts binds openPath per span (the editor in VS
+// Code, the viewer on the web) and paints its figure previews from the hits; the file viewer reads the clicks
+// on its body (file-view.ts). The listeners this module puts on a link are about focus, not the action: Enter
+// or Space on a focused link clicks it, so the host's click handler is reached from the keyboard too
+// (pathLinkKey), and a mouse press does not focus the link, so a click leaves focus where a click on plain
+// text leaves it (pathLinkPress / pathLinkRelease). A document that cannot act on a click should not call
+// this: a link that does nothing is worse than text.
 
 function el(tag: string, cls?: string): HTMLElement { const e = document.createElement(tag); if (cls) e.className = cls; return e; }
 
-// A file:// URI → its local filesystem path: strip the scheme, percent-decode. file:///a/b → /a/b.
+// A file:// URI that names a path on THIS machine: an empty authority (`file:///a/b`) or `localhost`
+// (`file://localhost/a/b`), then the path. `file://host/a/b` names a file on another host and is not a local
+// path: stripping its scheme used to leave `host/a/b`, a relative path the opener joined onto a session's cwd.
+// Such a token is prose to the walk, and fileUriToPath returns it as written.
+const FILE_URI_RE = /^file:\/\/(?:localhost)?(?=\/)/i;
+export function isFileUri(tok: string): boolean { return FILE_URI_RE.test(tok); }
+// A local file:// URI → its filesystem path: strip the scheme (and a `localhost`), percent-decode. file:///a/b → /a/b.
 export function fileUriToPath(uri: string): string {
-  let p = uri.replace(/^file:\/\//i, "");   // file:///Users/… → /Users/… (host is empty for file:///)
+  if (!isFileUri(uri)) return uri;           // not a local URI: nothing to strip (the callers gate on isFileUri)
+  let p = uri.replace(FILE_URI_RE, "");      // file:///Users/… → /Users/…
   try { p = decodeURIComponent(p); } catch { /* malformed %-escape — use verbatim */ }
   return p;
+}
+// A <span> is not a control: it has no tab stop and no activation key, so a keyboard user could reach a path
+// link only by leaving for the pointer. Enter or Space on a focused link clicks it; the click is still the
+// host's (render.ts's per-span binder, the viewer's body listener), this only gives the keyboard the route a
+// pointer has. Both keys, as the dashboard's other keyboard-activated rows take them (render.ts); Space is
+// prevented so it does not also scroll the pane. A Cmd/Ctrl held with the key rides into the click as the
+// same modifier, so a host that reads a modified click as "in a tab of its own" (the file viewer) hears it
+// from the keyboard too; element.click() carries no modifiers, so that case dispatches the click itself.
+function pathLinkKey(e: KeyboardEvent): void {
+  if (e.key !== "Enter" && e.key !== " ") return;
+  e.preventDefault();
+  const a = e.currentTarget as HTMLElement;
+  if (e.metaKey || e.ctrlKey) a.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, metaKey: e.metaKey, ctrlKey: e.ctrlKey }));
+  else a.click();
+}
+// A tab stop is focusable by the pointer too, and that is the one thing the plain span it replaced was not:
+// a mouse click left focus on the body, a click on a tabindex span leaves it on the link. The chat's keyboard
+// model reads the difference (Enter from the bare transcript, nothing focused, drops the cursor into the
+// message box; render.ts), and the viewer a click opens takes no focus, so after Escape closed it the next
+// Enter would find the link still focused and open the file AGAIN instead of the message box; a selection
+// dragged FROM a link would meet the same fate on Enter, and in Chromium the focus change itself ends that
+// drag's selection before it begins. So a mouse press does not focus the link at all: the browser focuses the
+// span as the mousedown's default action, run after its listeners, so the press drops the tabindex attribute
+// (a span without one is not focusable) and focus lands where a click on plain text puts it, the body, with
+// the click and the selection the press starts untouched. The attribute comes back on the events that end the
+// press on this span: mouseup (a click), mouseleave (a drag that goes on elsewhere), contextmenu and dragstart
+// (a menu or a native drag took the pointer, and the mouseup may never reach the page). Between them the link
+// is out of the tab order, for the length of a press; a keyboard focus meets no press and stays, and Enter and
+// Space then activate, as an <a> does. Not mousedown.preventDefault(), which would also keep a selection from
+// starting on the link (the text is meant to be selectable in place); not a blur on the focus event, which in
+// Chromium clears the selection the press made (a double-click's word). A span already focused (by Tab, then
+// clicked) is blurred by the press itself, since the browser fires no focus for it.
+function pathLinkPress(e: MouseEvent): void {
+  const a = e.currentTarget as HTMLElement;
+  a.removeAttribute("tabindex");                // not focusable for the rest of this press
+  if (document.activeElement === a) a.blur();   // the press ends a keyboard focus too: the browser would not re-focus it
+}
+function pathLinkRelease(e: Event): void {
+  const a = e.currentTarget as HTMLElement;
+  if (!a.hasAttribute("tabindex")) a.tabIndex = 0;
 }
 // A VERBATIM file link, marked for whoever hosts it. `raw` is shown as written (selectable/copyable in
 // place); `open` is what gets opened. A bare file:// can't be followed by the browser from the http
@@ -27,12 +79,41 @@ export function fileUriToPath(uri: string): string {
 export function openPathLink(raw: string, open: string, relative = false): HTMLElement {
   const a = el("span", "file-uri-link");
   a.textContent = raw;                       // shown exactly as written, selectable/copyable in place
-  a.title = "Open " + open;
+  return markPathLink(a, open, relative);
+}
+// The link's SHAPE on an element the caller already has: the class, the title, the tab stop, the keyboard and
+// pointer handlers, and the target's data. openPathLink mints a span and marks it; the file viewer marks a
+// Markdown link's own <a> (its label keeps its nested formatting) when the link's target is a file
+// (file-view-links.ts). The class is appended as a string so an element that already wears one keeps it. The
+// class and the title are written as ATTRIBUTES: on an SVG <a> (inline SVG in rendered Markdown keeps its
+// anchors through the sanitizer) `className` is a read-only animated string and `title` is no property at
+// all, so property writes would be silent no-ops there; setAttribute reaches both element kinds.
+export function markPathLink(a: HTMLElement, open: string, relative = false): HTMLElement {
+  const cls = a.getAttribute("class") || "";
+  if (!(" " + cls + " ").includes(" file-uri-link ")) a.setAttribute("class", (cls ? cls + " " : "") + "file-uri-link");
+  a.setAttribute("title", "Open " + open);
+  a.tabIndex = 0;                            // in the tab order, like the <a> it stands in for…
+  a.role = "link";                           // …and announced as one (the ARIA IDL attribute)
+  a.onkeydown = pathLinkKey;                 // Enter / Space → this span's click, whoever handles it
+  a.onmousedown = pathLinkPress;             // a mouse press does not focus it: the tabindex is off for the press…
+  a.onmouseup = a.onmouseleave = a.oncontextmenu = a.ondragstart = pathLinkRelease;   // …and back once the press has ended on this span
   a.dataset.path = open;
   if (relative) a.dataset.rel = "1";
   return a;
 }
 export function fileUriLink(uri: string): HTMLElement { return openPathLink(uri, fileUriToPath(uri)); }
+
+/** A selection left open inside `el` when a click arrives: the click ends a press-drag-release that selected
+ *  text (a press on text collapses the selection first, so a plain click never sees one), and the selection is
+ *  what the person gets, not the link under it. Every opener a link's click can reach reads this and yields:
+ *  the viewer's body listener over its box, and the chat's document-level anchor opener over the anchor itself,
+ *  which runs first, at the capture phase. In the viewer a press-drag inside a path link (a span) selects its text,
+ *  and so does a press held on a URL anchor before it drags (Chromium's rule for a link, which is not draggable
+ *  there: an immediate drag on one selects nothing); the chat's own anchors are draggable and send no such click. */
+export function selectionOpenIn(el: Node): boolean {
+  const sel = window.getSelection();
+  return !!sel && !sel.isCollapsed && el.contains(sel.anchorNode);
+}
 // Is this bare token (trailing punctuation already stripped) a file path worth linkifying? Requires a slash
 // and EITHER an absolute/anchored start (/, ~/, ./, ../) OR a file extension on the final segment — so
 // "and/or", "TCP/IP", "24/7", "read/write" stay as prose. URL-ish tokens (a ':' or '//') are rejected;
@@ -61,61 +142,242 @@ export function looksLikeBareFileName(tok: string): boolean {
 }
 // One finder covers the file: scheme, the slashed-path alternative, and the bare-filename alternative.
 // The kernel's _path_tokens is a port of it (kernel.py), and both sides run the same fixture: a token
-// the kernel never saw is a verdict the client can never look up. Its TEXT is that contract.
+// the kernel never saw is a verdict the client can never look up. Its TEXT is that contract; how it is
+// run is PathTokenScanner's business (below), since the g-flag loop it was written for is quadratic.
 export const CLICKABLE_PATH_RE = /file:\/\/\/?[^\s<>"'`)]+|[~.\w\-]*\/[~.\w\-/]*[\w\-]|[\w\-][\w\-.]*\.[A-Za-z0-9]{1,8}/gi;
+// Trailing sentence punctuation is left out of a token, not swallowed by it ("see a/b.md." links a/b.md).
+// The characters are the source; the regex is built from them.
+export const TRAILING_PUNCT = ".,;:!?)]}>\"'`";
+export const TRAILING_PUNCT_RE = new RegExp("[" + TRAILING_PUNCT.replace(/[\\\]^-]/g, "\\$&") + "]+$");
+// The token's trailing punctuation, found from the END. TRAILING_PUNCT_RE's `+$` is tried from every position
+// of the token and backs off one character at a time when the end is not there, which is quadratic on a long
+// token made of punctuation: a token of 40K dots and a slash (the path arm matches it whole) costs over a
+// second in the trim alone. Shaped like the regex's match, [the run] or null, because that is how the walk
+// reads it.
+function trailingPunct(tok: string): [string] | null {
+  let i = tok.length;
+  while (i > 0 && TRAILING_PUNCT.includes(tok[i - 1])) i--;
+  return i < tok.length ? [tok.slice(i)] : null;
+}
 
-/** One link the walk emitted: the span, what it opens, and whether the kernel stat'd that target this
+// ── a linear-time driver for CLICKABLE_PATH_RE ────────────────────────────────────────────────────
+// Run with the g flag, the engine restarts at every position, and on an unbroken run of word characters both
+// path arms scan to the run's end and back before failing: quadratic in the run's length. One slash plus a
+// 40K-character run of hex, words or dashes (a hash, a separator line, a minified dump) costs seconds, per text
+// node, on the main thread; the viewer shows whole files, where such lines are ordinary. The regex's text is
+// the kernel's parity contract and stays; this drives it in linear time. It tries the three arms in the
+// regex's own order at each position, as sticky regexes cut from the one source, and remembers what a failure
+// PROVES about the positions ahead:
+//   - the path arm `[~.\w\-]*\/[~.\w\-/]*[\w\-]` failing at i fails at every later position of the same run of
+//     [~.\w\-/] characters: the first slash it can reach from there is the same one or a later one, and the
+//     word character it needs after that slash is drawn from a smaller suffix of the run;
+//   - the bare arm `[\w\-][\w\-.]*\.[A-Za-z0-9]{1,8}` failing at i fails at every later position of the same
+//     run of [\w\-.] characters: the dot-then-alphanumeric it needs is drawn from a smaller suffix;
+//   - the URI arm starts only at an f or F, and its `file:` cannot lie inside either run (a colon is in
+//     neither class), so a dead run's positions are tried for it as cheaply as any other.
+// Each arm therefore scans a run at most once beyond its matches in it, and the text costs time linear in
+// its length. The matches are exactly the regex's: pinned by a differential test over the regex itself at
+// every start position, and by the kernel parity fixture (path-links.test.ts).
+const [URI_ARM, PATH_ARM, BARE_ARM] = CLICKABLE_PATH_RE.source.split("|").map((arm) => new RegExp(arm, "iy"));
+const isWordCh = (c: number): boolean => (c >= 48 && c <= 57) || (c >= 65 && c <= 90) || (c >= 97 && c <= 122) || c === 95;   // \w
+const isBareStartCh = (c: number): boolean => isWordCh(c) || c === 45;              // [\w\-]
+const isBareCh = (c: number): boolean => isBareStartCh(c) || c === 46;              // [\w\-.]
+const isPathCh = (c: number): boolean => isBareCh(c) || c === 126 || c === 47;      // [~.\w\-/]
+function runEnd(text: string, i: number, inRun: (c: number) => boolean): number {
+  while (i < text.length && inRun(text.charCodeAt(i))) i++;
+  return i;
+}
+export class PathTokenScanner {
+  private pathDead = 0;   // the path arm is proven to fail at every position before this one
+  private bareDead = 0;   // the bare arm likewise
+  constructor(private readonly text: string) {}
+  /** The first match at or after `from`, as [start, end): what CLICKABLE_PATH_RE.exec finds with
+   *  lastIndex = from, or null. Successive calls must not move `from` backwards. */
+  next(from: number): [number, number] | null {
+    const t = this.text, n = t.length;
+    for (let i = from; i < n; i++) {
+      const c = t.charCodeAt(i);
+      if (c === 0x66 || c === 0x46) {                       // f / F: the only characters a URI can start at
+        URI_ARM.lastIndex = i;
+        if (URI_ARM.test(t)) return [i, URI_ARM.lastIndex];
+      }
+      if (!isPathCh(c)) continue;                           // neither path arm can start here
+      if (i >= this.pathDead) {
+        PATH_ARM.lastIndex = i;
+        if (PATH_ARM.test(t)) return [i, PATH_ARM.lastIndex];
+        this.pathDead = runEnd(t, i, isPathCh);
+      }
+      if (isBareStartCh(c) && i >= this.bareDead) {
+        BARE_ARM.lastIndex = i;
+        if (BARE_ARM.test(t)) return [i, BARE_ARM.lastIndex];
+        this.bareDead = runEnd(t, i, isBareCh);
+      }
+    }
+    return null;
+  }
+}
+
+/** One link the walk emitted: the element, what it opens, and whether the kernel stat'd that target this
  *  build (a fixed mention). The chat's figure pass wants exactly these. */
 export interface PathLinkHit { el: HTMLElement; open: string; verified: boolean }
+
+// `opts` is how a surface whose text is not chat prose runs the same walk (the file viewer, file-view-links.ts).
+// `inPre` walks the text inside <pre> too (the viewer's code body IS one); `accept` narrows every non-URI token
+// that passed the shape gates (the kernel's map narrows a chat message the same way; a surface with no kernel
+// verdict brings its own gate), and is handed the text the token was found in and the token's offset there, so
+// a gate can read the token's line; `resolve` names what a token opens when the surface knows its own place
+// (the viewer joins a relative token onto the shown file's directory; a file:// URI's own path, absolute, passes
+// through it too); `lineSuffix` reads a `:12` (or GitHub's
+// `#L12`) right after a token into the link (data-line) instead of leaving it as prose, off a file:// URI too
+// (the URI arm's own grammar admits a colon, so the suffix rode inside the token there); `unit` names the
+// element whose text nodes are scanned as ONE string (the viewer's row: a highlight's spans cut a line's text
+// into several nodes, and a token is what the LINE says, never what one node says). Absent, the walk is
+// exactly the chat's.
+export interface PathLinkOptions {
+  inPre?: boolean;
+  accept?: (tok: string, ctx: { text: string; at: number }) => boolean;
+  resolve?: (tok: string) => string;
+  lineSuffix?: boolean;
+  unit?: string;
+}
+// A line reference written after a path: `path:12`, `path:12:4` (a column, dropped), `path#L12`, `path#L12-L20`
+// (a range; its first line). Not followed by a word character or a slash, so `x/a.md:12abc` keeps its prose.
+export const LINE_SUFFIX_RE = /^(?::(\d+)(?::\d+)?|#L(\d+)(?:-L?\d+)?)(?![\w/])/;
+// The same reference at the END of a token (a file:// URI took it into itself): where it starts.
+const URI_LINE_TAIL_RE = /(?::\d+(?::\d+)?|#L\d+(?:-L?\d+)?)$/;
+// The same reference AT a position of the unit's text (sticky, lastIndex set): read in place, so the walk never
+// slices the rest of the text per token, which is quadratic over a body that is one unit.
+const LINE_SUFFIX_AT_RE = new RegExp(LINE_SUFFIX_RE.source.replace(/^\^/, ""), "y");
+
+/** One text node's place in its unit's joined text. `dead`: inside a link (or, in the chat, a fenced block): the
+ *  scan READS it, so a token glued to it is seen whole, but never marks in it. */
+export interface TextSpan { tn: Text; start: number; end: number; dead: boolean; inCode: boolean }
+export interface TextUnit { text: string; spans: TextSpan[] }
+/** The ancestors whose text no walk marks in, whatever the surface: a link already made, and an inline SVG (an
+ *  HTML span or anchor put inside SVG text does not render, so a mark there would make the token vanish from the
+ *  figure). The text is still READ, so a token glued to it is seen whole. */
+export const DEAD_TEXT = "a, .file-uri-link, svg";
+/** The text under `root` cut into units: under `unit` (a selector), the consecutive text nodes sharing their
+ *  nearest such ancestor, joined; a node under none, or with no selector, is a unit of its own. A `<br>` ends a
+ *  unit too: it is a line break, and a token never crosses one (`a<br>docs/a.md` is not `adocs/a.md`). A unit
+ *  element with no text under it is an EMPTY unit, in its place: a code view's blank row is
+ *  `<span class=fv-cl><span class=fv-ct></span></span>`, and the units are the view's rows, blank ones included.
+ *  `skip` names the ancestors whose text is dead to marking. */
+export function textUnits(root: HTMLElement, unit: string | undefined, skip: string): TextUnit[] {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT);
+  const units: TextUnit[] = [];
+  let cur: Element | null = null;
+  let broke = false;                                    // a <br> passed since the last text node
+  let n: Node | null;
+  while ((n = walker.nextNode())) {
+    if (n.nodeType === 1) {
+      const e = n as Element;
+      if (/^br$/i.test(e.tagName)) broke = true;
+      else if (unit && e.matches(unit) && e.textContent === "") { units.push({ text: "", spans: [] }); cur = null; }   // a blank line; the text after it starts a unit of its own
+      continue;
+    }
+    const tn = n as Text;
+    const p = tn.parentElement;
+    const u = unit && p ? p.closest(unit) : null;
+    let last = units[units.length - 1];
+    if (!last || u === null || u !== cur || broke) { last = { text: "", spans: [] }; units.push(last); cur = u; }
+    broke = false;
+    const start = last.text.length;
+    last.text += tn.data;
+    last.spans.push({ tn, start, end: last.text.length, dead: !!p?.closest(skip), inCode: !!p?.closest("code") });
+  }
+  return units;
+}
+/** The span holding [start, end) whole and open to marking, else null: a match that crosses a node's edge (a
+ *  highlight span cut through it) or lies in a link is left as it is, never re-read as its pieces. A binary
+ *  search over the spans (they are in text order): a highlighted body is one unit of thousands of spans, and a
+ *  walk over them per token would be quadratic. */
+export function spanHolding(u: TextUnit, start: number, end: number): TextSpan | null {
+  const spans = u.spans;
+  let lo = 0, hi = spans.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1, s = spans[mid];
+    if (start < s.start) hi = mid - 1;
+    else if (start >= s.end) lo = mid + 1;
+    else return !s.dead && end <= s.end ? s : null;
+  }
+  return null;
+}
+/** Replace `span`'s text node with its text, the `marks` (each an element standing for [start, end) of the
+ *  unit's text, in order) in place of the ranges they cover. */
+export function rewriteSpan(u: TextUnit, span: TextSpan, marks: Array<{ start: number; end: number; el: Node }>): void {
+  const frag = document.createDocumentFragment();
+  let last = span.start;
+  for (const m of marks) {
+    if (m.start > last) frag.appendChild(document.createTextNode(u.text.slice(last, m.start)));
+    frag.appendChild(m.el);
+    last = m.end;
+  }
+  if (last < span.end) frag.appendChild(document.createTextNode(u.text.slice(last, span.end)));
+  span.tn.replaceWith(frag);
+}
 
 // Mark bare file:// URLs AND bare file paths inside `root`'s text, a relative `design/foo.md` too,
 // resolved against a session's cwd by whoever opens it (the user 2026-07-06). marked doesn't autolink these
 // and DOMPurify strips the file: scheme, so without this they read as dead text. Inside INLINE <code> a
-// slash-less filename with a known extension marks too; only FENCED <pre> blocks and text already inside a
-// link are skipped. Text nodes only: an element the caller already made a link stays one. Trailing sentence
-// punctuation is left out, not swallowed.
+// slash-less filename with a known extension marks too; only FENCED <pre> blocks, text already inside a link
+// and text inside an inline SVG (DEAD_TEXT) are skipped. Text nodes only: an element the caller already made
+// a link stays one. Trailing sentence punctuation is left out, not swallowed.
 // `pathLinks` (the user 2026-08-09): the kernel's verdict on every path-shaped token in this text
 // (build_session's _path_links — tier 1 exact stat, tiers 2/3 a unique repo-list match that FIXES a
 // shortened mention to its real file). When the map is present, a token links ONLY if it's in the map,
 // and it opens the map's value — so `render.js` in prose stops 404ing, and hover shows the real target.
 // Every shape gate still applies; the map only ever narrows. No map at all (an old kernel, a cached
-// payload) keeps shape-only linking. file:// URIs are explicit absolute paths — never gated on the map.
-// Returns the hits in document order, so a caller's "first mention" is the walk's first.
-export function linkifyPathTokens(root: HTMLElement, pathLinks?: Record<string, string>): PathLinkHit[] {
+// payload, a surface the kernel never judged) keeps shape-only linking. file:// URIs are explicit absolute
+// paths — never gated on the map. Returns the hits in document order, so a caller's "first mention" is the
+// walk's first.
+export function linkifyPathTokens(root: HTMLElement, pathLinks?: Record<string, string>, opts?: PathLinkOptions): PathLinkHit[] {
   const hits: PathLinkHit[] = [];
-  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
-  const nodes: Text[] = [];
-  let n: Node | null;
-  while ((n = walker.nextNode())) nodes.push(n as Text);
-  for (const tn of nodes) {
-    if (tn.parentElement?.closest("a, .file-uri-link, pre")) continue;   // already a link, or a fenced code block
-    const inCode = !!tn.parentElement?.closest("code");                  // inline code — where bare filenames may link
-    const text = tn.data;
-    if (!text.includes("/") && !(inCode && text.includes("."))) continue;   // cheap pre-filter: no slash (and, in code, no dot) → nothing here
-    const re = new RegExp(CLICKABLE_PATH_RE.source, "gi");
-    const frag = document.createDocumentFragment();
-    let last = 0, any = false, m: RegExpExecArray | null;
-    while ((m = re.exec(text))) {
-      let tok = m[0];
-      const trail = tok.match(/[.,;:!?)\]}>"'`]+$/);   // don't grab a sentence's closing punctuation
+  const skip = opts && opts.inPre ? DEAD_TEXT : DEAD_TEXT + ", pre";   // a link, an SVG, or (the chat) a fenced code block
+  for (const u of textUnits(root, opts && opts.unit, skip)) {
+    if (u.spans.every((s) => s.dead)) continue;
+    const text = u.text;
+    const anyCode = u.spans.some((s) => s.inCode && !s.dead);            // inline code: where bare filenames may link
+    if (!text.includes("/") && !(anyCode && text.includes("."))) continue;   // cheap pre-filter: no slash (and, in code, no dot) → nothing here
+    const scan = new PathTokenScanner(text);
+    const marks = new Map<TextSpan, Array<{ start: number; end: number; el: Node }>>();
+    let from = 0, m: [number, number] | null;
+    while ((m = scan.next(from))) {
+      const [start, end] = m;
+      from = end;                                   // a token that stays prose: the scan resumes after all of it
+      let tok = text.slice(start, end);
+      const trail = trailingPunct(tok);             // don't grab a sentence's closing punctuation
       if (trail) tok = tok.slice(0, tok.length - trail[0].length);
       if (!tok) continue;
-      const isUri = /^file:\/\//i.test(tok);
-      if (!isUri && !looksLikeFilePath(tok) && !(inCode && looksLikeBareFileName(tok))) continue;   // "and/or", `np.array` etc. — leave as prose
+      const isUri = isFileUri(tok);
+      // a line reference a URI token swallowed (`file:///a.md:12`) is the suffix, not the path, where the surface reads lines
+      if (isUri && opts && opts.lineSuffix) { const tail = URI_LINE_TAIL_RE.exec(tok); if (tail) tok = tok.slice(0, tail.index); }
+      const span = spanHolding(u, start, start + tok.length);
+      if (!span) continue;                          // across a node's edge, or inside a link: as it is
+      if (!isUri && !looksLikeFilePath(tok) && !(span.inCode && looksLikeBareFileName(tok))) continue;   // "and/or", `np.array` etc.: leave as prose
+      if (!isUri && opts && opts.accept && !opts.accept(tok, { text, at: start })) continue;   // the surface's own gate (the viewer's: an extension on the file)
       const fixed = !isUri && pathLinks ? pathLinks[tok] : undefined;   // the kernel's verdict, when it rendered one
       if (!isUri && pathLinks && typeof fixed !== "string") continue;   // checked against the filesystem: no such file (or several) → prose
-      if (m.index > last) frag.appendChild(document.createTextNode(text.slice(last, m.index)));
-      const open = isUri ? fileUriToPath(tok) : (fixed ?? tok);
-      const link = isUri ? fileUriLink(tok) : openPathLink(tok, open, true);
-      frag.appendChild(link);
+      // what the link opens: a URI's own path (absolute, percent-decoded), else the kernel's fixed target or the token;
+      // placed by the surface's resolve when it has one (the viewer normalizes a URI's path there as it does any
+      // absolute path, so `file:///a/b/../c.md` opens and is titled the same whichever way it was written)
+      const target = isUri ? fileUriToPath(tok) : (fixed ?? tok);
+      const open = opts && opts.resolve ? opts.resolve(target) : target;
+      const link = openPathLink(tok, open, !isUri);
+      // a line written after the token rides in the link when the surface reads lines (the viewer scrolls to it);
+      // one the highlight cut into another node stays prose
+      let suffix: RegExpExecArray | null = null;
+      if (opts && opts.lineSuffix) { LINE_SUFFIX_AT_RE.lastIndex = start + tok.length; suffix = LINE_SUFFIX_AT_RE.exec(text); }
+      if (suffix && start + tok.length + suffix[0].length > span.end) suffix = null;
+      if (suffix) { link.textContent = tok + suffix[0]; link.dataset.line = suffix[1] || suffix[2]; link.setAttribute("title", link.getAttribute("title") + ":" + link.dataset.line); }
+      const last = start + tok.length + (suffix ? suffix[0].length : 0);
+      let list = marks.get(span);
+      if (!list) { list = []; marks.set(span, list); }
+      list.push({ start, end: last, el: link });
       hits.push({ el: link, open, verified: !isUri && typeof fixed === "string" });   // the kernel stat'd a fixed one this build
-      last = m.index + tok.length;
-      re.lastIndex = last;
-      any = true;
+      from = last;                                  // a linked token: resume right after what was linked; its trimmed tail is prose
     }
-    if (!any) continue;
-    if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
-    tn.replaceWith(frag);
+    for (const [span, list] of marks) rewriteSpan(u, span, list);
   }
   return hits;
 }

--- a/ui/webview/pdf-new-tab.test.ts
+++ b/ui/webview/pdf-new-tab.test.ts
@@ -92,9 +92,12 @@ test("wiring: every click on a PDF carries its gesture; modified → the tab, pl
     "the middle PRESS is cancelled: autoscroll (Firefox, Edge) starts on mousedown and would swallow the auxclick");
   assert.match(pf, /box\.onauxclick = \(ev\) => \{ if \(ev\.button !== 1\) return; ev\.stopPropagation\(\); openPdf\(path, sid, ev\); \};/,
     "a middle-click reaches the card as auxclick, never as click");
-  // the opener itself: synchronous, two-argument window.open — the gesture and the handle both matter
-  const opener = PREVIEW.slice(PREVIEW.indexOf("export function openPdfTab"), PREVIEW.indexOf("export function openPdf("));
-  assert.match(opener, /if \(previewKind\(path\) !== "pdf" \|\| !canPreview\(\)\) return false;/, "the kind check is the opener's own");
+  // the opener itself: synchronous, two-argument window.open — the gesture and the handle both matter. The tab is openFileTab's
+  // (any file, off the kernel's /file route; the viewer's links go through it too), and openPdfTab puts the kind check in front
+  const pdf = PREVIEW.slice(PREVIEW.indexOf("export function openPdfTab"), PREVIEW.indexOf("export function openPdf("));
+  assert.match(pdf, /if \(previewKind\(path\) !== "pdf"\) return false;\n\s*return openFileTab\(path, sid\);/, "the kind check is the PDF opener's own; the tab is the file opener's");
+  const opener = PREVIEW.slice(PREVIEW.indexOf("export function openFileTab"), PREVIEW.indexOf("export function openPdfTab"));
+  assert.match(opener, /if \(!canPreview\(\)\) return false;/, "the web-only gate");
   assert.match(opener, /const w = window\.open\(fileUrl\(path, sid\), "_blank"\);/);
   assert.doesNotMatch(opener, /"noopener/, "the noopener FEATURE makes window.open return null on success — the block signal would be lost");
   assert.match(opener, /if \(!w\) return false;[^\n]*\n\s+try \{ w\.opener = null; \}/, "…so the link is severed on the handle instead, before anything else");
@@ -107,7 +110,13 @@ test("wiring: every click on a PDF carries its gesture; modified → the tab, pl
   assert.equal((BROWSE.match(/openFileView\(/g) || []).length, 0, "file-browse.ts opens files through openFileClick only");
   const view = VIEW.slice(VIEW.indexOf("export function openFileView("));
   const body = view.slice(0, view.indexOf("\n}\n"));
-  assert.doesNotMatch(body, /openPdfTab|wantsOwnTab/, "openFileView itself opens in-app, whatever the path");
+  assert.doesNotMatch(body, /openPdfTab/, "openFileView itself opens in-app, whatever the path");
+  // the ONE gesture read inside openFileView is its links' listener (a Cmd/Ctrl- or middle-click on a link inside the shown file takes
+  // its own tab, file-view-links.test.ts); the open of the viewer's own file reads none
+  const linksAt = body.indexOf("const openLink = (x: HTMLElement, ev: MouseEvent) => {");
+  assert.ok(linksAt > 0, "the links' listener");
+  assert.doesNotMatch(body.slice(0, linksAt), /wantsOwnTab\(/, "no gesture read before the links' listener");
+  assert.doesNotMatch(body.slice(body.indexOf('body.addEventListener("auxclick"', linksAt)), /wantsOwnTab\(/, "none after it");
   // the file browser's rows and the chat's path pills hand their gesture over, middle button included
   assert.match(BROWSE, /list\.addEventListener\("click", \(ev\) => \{[\s\S]*?onAct\(row, ev\);/);
   assert.match(BROWSE, /const fileRowOf = \(ev: MouseEvent\) => \{[\s\S]*?row\.dataset\.act === "file" \? row : null;/,

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -31,11 +31,29 @@ export function canPreview(): boolean {
 
 // Which click means "in a browser tab of its own"? The browser-wide idiom, so there is nothing new to
 // learn and no setting to find: a Cmd/Ctrl-click (the `click` event carries the modifier) or a
-// middle-button press (which arrives as `auxclick`, button 1). A plain click keeps a PDF inside the
-// dashboard exactly as an image opens (the user 2026-09-07, who wanted one opening rule for both); the
-// modifier is the one signal that the browser's own viewer, beside the dashboard, is what is wanted.
+// middle-button press (which arrives as `auxclick`, button 1). A plain click acts inside the dashboard
+// (the user 2026-09-07, who wanted one opening rule for every file: a plain click keeps a PDF inside the
+// dashboard exactly as an image opens; the modifier is the one signal that the browser's own tab, beside
+// the dashboard, is what is wanted). The PDF and folder gestures read this signal, and so do the links
+// inside a file the viewer shows (file-view.ts).
 export function wantsOwnTab(ev?: { metaKey?: boolean; ctrlKey?: boolean; button?: number } | null): boolean {
   return !!ev && (!!ev.metaKey || !!ev.ctrlKey || ev.button === 1);
+}
+
+// A file in the browser's OWN tab, on the gesture above: ONE window.open aimed at the kernel's /file URL, the
+// same-origin, cookie-authed route the viewer fetches from (a remote session's file relays exactly as the
+// viewer's fetch does), so the browser renders what the kernel serves: a PDF in its viewer, an image, a text
+// file as text. False when nothing opened, and the caller's in-app view takes over: the popup was blocked, or
+// this is the VS Code webview, whose sandbox has no tabs and no kernel origin (canPreview). The tab's opener is
+// severed on the handle: a link inside the opened file may navigate the tab to a foreign site, which must not
+// hold the dashboard. Not the `noopener` feature, which returns null even on success. The one opener behind
+// every own-tab gesture: the viewer's links hand it any file (file-view.ts), openPdfTab below hands it a PDF.
+export function openFileTab(path: string, sid?: string | null): boolean {
+  if (!canPreview()) return false;
+  const w = window.open(fileUrl(path, sid), "_blank");
+  if (!w) return false;                                   // blocked: the caller's in-app view takes over
+  try { w.opener = null; } catch { /* unreachable while the tab is our own initial page */ }
+  return true;
 }
 
 // LOADING CUE (the user 2026-07-31): a remote image's bytes arrive over the ssh tunnel, so for a
@@ -142,13 +160,11 @@ export function fileUrl(path: string, sid?: string | null): string {
 // there anyway (canPreview). The KIND check lives here, by extension — the only fact available inside
 // the gesture — so a caller passes any path and a non-PDF is simply "not mine" (false): the viewer's own
 // media branch keeps keying on the kernel's Content-Type verdict, never on an extension re-test
-// (file-view.test.ts pins that).
+// (file-view.test.ts pins that). The tab itself is openFileTab's (above): one window.open, one severed
+// opener, one blocked-popup verdict, shared with the viewer's links, which open any file that way.
 export function openPdfTab(path: string, sid?: string | null): boolean {
-  if (previewKind(path) !== "pdf" || !canPreview()) return false;
-  const w = window.open(fileUrl(path, sid), "_blank");
-  if (!w) return false;                                   // blocked: the caller's in-app view takes over
-  try { w.opener = null; } catch { /* unreachable while the tab is our own initial page */ }
-  return true;
+  if (previewKind(path) !== "pdf") return false;
+  return openFileTab(path, sid);
 }
 
 // The PDF card's click, with its gesture: a plain click opens the in-app lightbox, like an image; a

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -56,7 +56,7 @@ import { openFileClick } from "./file-view";                  // a clicked file 
 import { initFileView, setFileViewIdentity, hostStub } from "./file-view";
 import { openUrlView } from "./file-view";                 // the URL mode of the same viewer (md-url-view.test.ts)
 import { isMarkdownUrl } from "./md-links";
-import { openPathLink, linkifyPathTokens } from "./path-links";   // the path matcher the chat's links are made from (a shared module)
+import { openPathLink, linkifyPathTokens, selectionOpenIn } from "./path-links";   // the path matcher the chat's links are made from (a shared module)
 import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser is pane-local here now (the user 2026-08-24)
 import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
@@ -1301,6 +1301,14 @@ function preEl(text: string, scrollKey?: string): HTMLElement {
 document.addEventListener("click", (e) => {
   const a = (e.target as HTMLElement)?.closest?.("a[href]") as HTMLAnchorElement | null;
   if (!a) return;
+  // The click that ends a press-drag-release inside an anchor that is not draggable (the file viewer's URL anchors,
+  // which select like the text around them; file-view-links.ts): the drag selected text, and the selection is what
+  // the person gets, not the link. The viewer's own listener rules the same for its links, but this opener runs
+  // first, at the capture phase, and would open the tab as well. Read for a non-draggable anchor ONLY: a press on a
+  // draggable anchor (the chat's own, and a rendered document's web links) starts no selection and collapses none,
+  // so a selection left open around one by a triple-click on its paragraph is not a drag on it, and reading it
+  // would leave every click on that link dead until a click elsewhere.
+  if (!a.draggable && selectionOpenIn(a)) { e.preventDefault(); return; }
   const href = a.getAttribute("href") || "";
   if (href.startsWith("#")) {
     // An in-page anchor in a message (a footnote's back link, `[section](#install)` over the reply's own `<a name>`):

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -56,6 +56,7 @@ import { openFileClick } from "./file-view";                  // a clicked file 
 import { initFileView, setFileViewIdentity, hostStub } from "./file-view";
 import { openUrlView } from "./file-view";                 // the URL mode of the same viewer (md-url-view.test.ts)
 import { isMarkdownUrl } from "./md-links";
+import { openPathLink, linkifyPathTokens } from "./path-links";   // the path matcher the chat's links are made from (a shared module)
 import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser is pane-local here now (the user 2026-08-24)
 import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
@@ -1903,22 +1904,18 @@ function linkifyImgPaths(root: HTMLElement, paths: string[]): void {
   }
 }
 
-// A file:// URI → its local filesystem path: strip the scheme, percent-decode. file:///a/b → /a/b.
-function fileUriToPath(uri: string): string {
-  let p = uri.replace(/^file:\/\//i, "");   // file:///Users/… → /Users/… (host is empty for file:///)
-  try { p = decodeURIComponent(p); } catch { /* malformed %-escape — use verbatim */ }
-  return p;
-}
-// A clickable, VERBATIM file link — the SAME open-the-file path the caption/image links use (openPath:
-// the editor in VS Code, the feed pane's viewer on the web). `raw` is shown as written; `open` is what
-// gets opened. A bare file:// can't be followed by the browser from the http dashboard (blocked scheme)
-// and a VS Code editor won't render a PDF, so it's routed rather than navigated. `relative` bare paths
-// carry the active session id so whoever resolves them uses THAT session's cwd — a relative
-// `design/foo.md` is relative to the repo the agent runs in, not the kernel's cwd (the user 2026-07-06).
-function openPathLink(raw: string, open: string, relative = false): HTMLElement {
-  const a = el("span", "file-uri-link");
-  a.textContent = raw;                       // shown exactly as written, selectable/copyable in place
-  a.title = "Open " + open;
+// The path-token matcher (the regex, its shape gates, the trailing-punctuation trim and the span it emits)
+// lives in path-links.ts, a module any surface can import; this file exports nothing. That module marks and
+// binds nothing: every span it emits carries data-path (what a click opens) and, for a bare path rather than
+// a file:// URI, data-rel, and the hosting document decides what a click does. Here that is openPath, the
+// editor in VS Code and the viewer on the web, bound per span exactly as the chat always did, the middle
+// button included (onMiddleClick): a `relative` bare path (data-rel) carries the active session id so
+// whoever resolves it uses THAT session's cwd (a relative `design/foo.md` is relative to the repo the agent
+// runs in, not the kernel's cwd; the user 2026-07-06), and a file:// URI names an absolute path and sends
+// none. stopPropagation as before: a path inside a fold head or a card must open the file, not toggle its
+// container.
+function bindPathLink(a: HTMLElement): HTMLElement {
+  const open = a.dataset.path || "", relative = a.dataset.rel === "1";
   a.addEventListener("click", (e) => {
     e.stopPropagation();
     openPath(open, relative ? activeId : null, e);
@@ -1926,45 +1923,17 @@ function openPathLink(raw: string, open: string, relative = false): HTMLElement 
   onMiddleClick(a, (e) => openPath(open, relative ? activeId : null, e));
   return a;
 }
-function fileUriLink(uri: string): HTMLElement { return openPathLink(uri, fileUriToPath(uri)); }
-// Is this bare token (trailing punctuation already stripped) a file path worth linkifying? Requires a slash
-// and EITHER an absolute/anchored start (/, ~/, ./, ../) OR a file extension on the final segment — so
-// "and/or", "TCP/IP", "24/7", "read/write" stay as prose. URL-ish tokens (a ':' or '//') are rejected;
-// http(s) links are already <a> (skipped) — this just guards a rare un-autolinked one.
-function looksLikeFilePath(tok: string): boolean {
-  if (tok.includes(":") || tok.includes("//") || !tok.includes("/")) return false;
-  if (/^(?:~\/|\.{1,2}\/|\/)/.test(tok)) return true;                        // absolute or anchored (/, ~/, ./, ../)
-  return /\.[A-Za-z0-9]{1,8}$/.test(tok.slice(tok.lastIndexOf("/") + 1));    // relative → the last segment has an extension
-}
-// A BARE filename (no slash — `power2_watts.pdf`) is linkified ONLY inside inline <code> (the user
-// 2026-07-17: a reply listing its output files wasn't clickable). Backticks are where agents put
-// filenames, and the KNOWN-extension gate keeps backticked dotted identifiers (`np.array`, `s.color`,
-// `romp.kernelPort`) and version numbers (`0.4.293`) reading as prose — an unknown extension stays text.
-const BARE_FILE_EXTS = new Set([
-  "md", "txt", "rst", "py", "ts", "tsx", "js", "jsx", "mjs", "cjs", "json", "jsonl", "csv", "tsv",
-  "pdf", "png", "jpg", "jpeg", "gif", "svg", "webp", "html", "htm", "css", "scss", "sh", "bash", "zsh",
-  "bats", "yaml", "yml", "toml", "ini", "cfg", "conf", "xml", "ipynb", "rs", "go", "java", "c", "h",
-  "cpp", "hpp", "cc", "rb", "php", "sql", "log", "lock", "tex", "bib", "zip", "tar", "gz", "tgz",
-  "mp4", "mov", "mp3", "wav", "vsix", "plist", "diff", "patch",
-]);
-function looksLikeBareFileName(tok: string): boolean {
-  if (tok.includes("/") || tok.includes(":")) return false;
-  const dot = tok.lastIndexOf(".");
-  if (dot <= 0) return false;                                                // needs a name before the extension
-  return BARE_FILE_EXTS.has(tok.slice(dot + 1).toLowerCase());
-}
 // Make bare file:// URLs AND bare file paths inside a rendered CHAT message clickable (assistant replies +
 // your own bubbles) — a relative `design/foo.md` opens too, resolved against the session's cwd (the user
 // 2026-07-06). marked doesn't autolink these and DOMPurify strips the file: scheme, so without this they read
-// as dead text. Deliberately NOT applied to tool-use summaries. Linkifies inside INLINE <code> too — agents
-// routinely wrap a path in backticks; only FENCED <pre> blocks and text already inside a link are skipped.
-// Trailing sentence punctuation is left out, not swallowed.
-const CLICKABLE_PATH_RE = /file:\/\/\/?[^\s<>"'`)]+|[~.\w\-]*\/[~.\w\-/]*[\w\-]|[\w\-][\w\-.]*\.[A-Za-z0-9]{1,8}/gi;
+// as dead text. Deliberately NOT applied to tool-use summaries. The token walk itself is path-links.ts's
+// (linkifyPathTokens); what follows here is chat-only: the code-span URL pass, the kernel-verified spaced
+// spans, the click binding, and the figure previews.
 // `skipThumbs`: paths this turn ALREADY renders as full in-bubble images (a pasted screenshot's
 // ev.images) — they stay clickable links but are excluded from the mentioned-path thumbnail strip,
 // otherwise the same picture renders twice (the user 2026-07-10).
 // `spacePaths` (the user 2026-08-04): backticked filenames WITH SPACES that the KERNEL verified exist
-// (build_session's _space_paths — resolved like a click, existence-checked). The token regex below can
+// (build_session's _space_paths — resolved like a click, existence-checked). The token regex can
 // never span a space — in prose that boundary is what keeps ordinary text unlinked — so a note titled
 // `Moving from correlation to causal components.md` linkified only its last word. For exactly these
 // verified spans, the whole inline-code content becomes ONE link; the filesystem is the authority, so a
@@ -1973,9 +1942,10 @@ const CLICKABLE_PATH_RE = /file:\/\/\/?[^\s<>"'`)]+|[~.\w\-]*\/[~.\w\-/]*[\w\-]|
 // _path_links — tier 1 exact stat, tiers 2/3 a unique repo-list match that FIXES a shortened mention
 // to its real file). When the key is present, a token links ONLY if it's in the map, and it opens the
 // map's value — so `render.js` in prose stops 404ing, and hover shows the real target. Every shape
-// gate below still applies; the map only ever narrows. An event with NO pathLinks key at all (an old
+// gate still applies; the map only ever narrows. An event with NO pathLinks key at all (an old
 // kernel, a cached payload) keeps today's shape-only linking rather than unlinking history.
-// file:// URIs are explicit absolute paths — never gated on the map.
+// file:// URIs are explicit absolute paths — never gated on the map. (The gates and the map walk are
+// path-links.ts's; the map is threaded through to it.)
 function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: string[],
     pathLinks?: Record<string, string>, pathPins?: Record<string, string>): void {
   // A whole-backtick http(s) URL becomes a TAPPABLE link that still looks like code (the user
@@ -2004,7 +1974,7 @@ function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: 
       if (code.closest("a, .file-uri-link, pre")) continue;    // already linked, or a fenced block
       const tok = (code.textContent || "").trim();
       if (!verified.has(tok)) continue;
-      const link = openPathLink(tok, tok, true);
+      const link = bindPathLink(openPathLink(tok, tok, true));
       code.replaceChildren(link);                              // the <code> chrome stays; its content is the link
       kernelVerified.add(tok);
       if (previewKind(tok) && !previewable.includes(tok) && !(skipThumbs && skipThumbs.includes(tok))) {
@@ -2013,43 +1983,16 @@ function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: 
       }
     }
   }
-  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
-  const nodes: Text[] = [];
-  let n: Node | null;
-  while ((n = walker.nextNode())) nodes.push(n as Text);
-  for (const tn of nodes) {
-    if (tn.parentElement?.closest("a, .file-uri-link, pre")) continue;   // already a link, or a fenced code block
-    const inCode = !!tn.parentElement?.closest("code");                  // inline code — where bare filenames may link
-    const text = tn.data;
-    if (!text.includes("/") && !(inCode && text.includes("."))) continue;   // cheap pre-filter: no slash (and, in code, no dot) → nothing here
-    const re = new RegExp(CLICKABLE_PATH_RE.source, "gi");
-    const frag = document.createDocumentFragment();
-    let last = 0, any = false, m: RegExpExecArray | null;
-    while ((m = re.exec(text))) {
-      let tok = m[0];
-      const trail = tok.match(/[.,;:!?)\]}>"'`]+$/);   // don't grab a sentence's closing punctuation
-      if (trail) tok = tok.slice(0, tok.length - trail[0].length);
-      if (!tok) continue;
-      const isUri = /^file:\/\//i.test(tok);
-      if (!isUri && !looksLikeFilePath(tok) && !(inCode && looksLikeBareFileName(tok))) continue;   // "and/or", `np.array` etc. — leave as prose
-      const fixed = !isUri && pathLinks ? pathLinks[tok] : undefined;   // the kernel's verdict, when it rendered one
-      if (!isUri && pathLinks && typeof fixed !== "string") continue;   // checked against the filesystem: no such file (or several) → prose
-      if (m.index > last) frag.appendChild(document.createTextNode(text.slice(last, m.index)));
-      const open = isUri ? fileUriToPath(tok) : (fixed ?? tok);
-      const link = isUri ? fileUriLink(tok) : openPathLink(tok, open, true);
-      frag.appendChild(link);
-      if (!isUri && typeof fixed === "string") kernelVerified.add(open);   // the kernel stat'd it this build
-      if (previewKind(open) && !previewable.includes(open) && !(skipThumbs && skipThumbs.includes(open))) {
-        previewable.push(open);
-        mentionAt.set(open, link);
-      }
-      last = m.index + tok.length;
-      re.lastIndex = last;
-      any = true;
+  // The token walk is the shared one (path-links.ts linkifyPathTokens): it marks every path-shaped token, the
+  // kernel's pathLinks verdict narrowing it when the event carries one, and hands back the hits in document
+  // order; this document binds each click and reads the hits for the figure pass below.
+  for (const { el: link, open, verified } of linkifyPathTokens(root, pathLinks)) {
+    bindPathLink(link);
+    if (verified) kernelVerified.add(open);   // the kernel stat'd it this build
+    if (previewKind(open) && !previewable.includes(open) && !(skipThumbs && skipThumbs.includes(open))) {
+      previewable.push(open);
+      mentionAt.set(open, link);
     }
-    if (!any) continue;
-    if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
-    tn.replaceWith(frag);
   }
   // A mentioned image/PDF renders FULL-SIZE at its MENTION — the figure lands right after the
   // paragraph/list item that names it, like figures in a document (the user 2026-08-15, whose four

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3590,6 +3590,22 @@ body.filebrowse-open { overflow: hidden; }
   color: var(--dim); opacity: 0.55; user-select: none;
 }
 .fileview-wrap .fv-ct { flex: 1 1 auto; min-width: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
+/* Links inside a shown file (file-view-links.ts): a URL opens a new tab, a path opens in the viewer. Light by
+   design (the user 2026-09-07): the token keeps the colour the highlight gave it, under a faint dotted underline
+   that turns solid on hover; nothing else in the view changes. A Markdown link whose target is a file keeps the
+   link ink the other Markdown links wear. Neither is draggable (-webkit-user-drag: none, with draggable=false on the
+   anchor) and both are selectable (user-select: text; Chromium starts no selection inside a link without it), so a
+   press-drag inside a path link selects its text as on plain text, a press held on a URL anchor and then dragged
+   selects too (Chromium's rule for a link: an immediate drag on one selects nothing), and neither starts the browser's
+   link drag; a click that arrives with the selection open finds the viewer's listener and the chat's opener yielding
+   to it (path-links.ts selectionOpenIn). Mirrored in styles.css and feed.css (fileview-parity.test.ts). */
+.fileview-body .file-uri-link, .fileview-body .fv-url { color: inherit; cursor: pointer; text-decoration: underline dotted; text-decoration-color: color-mix(in srgb, currentColor 35%, transparent); text-underline-offset: 2px; -webkit-user-drag: none; user-select: text; }
+.fileview-body .file-uri-link:hover, .fileview-body .fv-url:hover { text-decoration: underline; text-decoration-color: currentColor; }
+.fileview-md a.file-uri-link { color: var(--link); text-decoration: none; }
+.fileview-md a.file-uri-link:hover { text-decoration: underline; }
+/* A Markdown link with no target the viewer can follow (the sanitizer removed it; a section this document does not
+   have): dead, and it says so, since the title holds the reason (file-view-links.ts DEAD_LINK_CLASS). */
+.fileview-md a.fv-dead { color: inherit; opacity: 0.7; text-decoration: underline dotted; cursor: help; }
 
 /* ── text size and measure (file-view.ts textSizeControl) ── The A− / A+ buttons and Ctrl/Cmd + wheel over the
    body set `data-fv-text` on the viewer root to one of TEXT_SIZES; this table turns the step into the ONE


### PR DESCRIPTION
Links inside a file the viewer shows: an http(s) URL in the text opens in a new tab, a file path opens that file in the viewer (a `:12` or `#L12` after it scrolls to the line), and a Markdown link's target follows the same two rules. The chat's path matcher moves into a shared module first, with no behaviour change, so both surfaces link paths from one grammar.

## Tier

Tier: feature

## Two commits

1. `Chat: the path matcher moves out of render.ts into path-links.ts, a module any surface can import`. A pure lift, no behaviour change: the regex, its shape gates, the trailing-punctuation trim and the span it emits move as they are; `linkifyPathTokens` walks a body's text nodes as the chat's walk did and hands back the hits in document order; every span carries `data-path` (and `data-rel` for a bare path) and binds no action; render.ts binds the click and the middle button per span off that data (`bindPathLink`) exactly as before and reads the hits for its figure pass. The source pins that read the matcher from render.ts now read it from path-links.ts; the tokenizer parity fixture is unchanged, the regex's text being unchanged. Typecheck and the full test run are green at this commit on its own.
2. `File viewer: URLs and file paths in a shown file are links`. The feature, described below.

## What the viewer does now

- An http(s) URL in a code view or in rendered prose is an anchor (`target=_blank`, `rel=noopener noreferrer`, the URL as its title).
- A file path opens that file in the viewer, in place: a relative path is joined onto the shown file's directory, an absolute or `~/` path passes as written for the kernel's `/file` route to resolve (`~` and the file's session's machine), and the result is normalized once (`docs/../src/app.py` opens and is titled `src/app.py`; a local `file:///a/b/../c.md` goes through the same resolve and is titled the same way). No kernel change: `_resolve_open_path` already does this.
- A `:12` or `#L12` after a path (or on a Markdown target) rides in the link; the viewer scrolls the code view to that row once the text lands, once, with the row centred. A Markdown file takes its Raw view for that open only; the saved Rendered/Raw preference is untouched. A line past the end lands on the last row and the viewer's notice says so rather than landing silently on the wrong row.
- In Markdown, `[text](target)` follows the same rules. A per-parse `walkTokens` hook (this parse only, never the marked singleton the chat shares) puts a same-directory `name.ext:12` and a local `file:///` URI in a form the sanitizer keeps; marks are set after `sanitizeMd` ran (md-sanitize.ts, `ALLOW_DATA_ATTR: false`), so a document's own `data-*` never reaches the page, and an element a document dresses in the link's class names no file. A `#section` link scrolls to an element with that id or an `<a name>` of that name, read under the sanitizer's `user-content-` prefix or bare (`userContentTarget`, the lookup the chat's `#` click reads too), or to a heading by its slug (the viewer's minted `md-` ids, set after the sanitize and never prefixed), in the rendered document only (never the viewer's chrome or the page), under a middle click too; when there is none the hover says so. A target the sanitizer removed, one that resolves to no path (`[up](../)` from a file named without a directory), or a host with a port (`127.0.0.1:3000`, `localhost:8080`, `api.example.com:8443`) renders as a dead link whose title says why: never a silent click, never a file named after a host. A Markdown link with a scheme keeps the `target=_blank` and `rel=noopener` it had; a query-only link (`?x=1`) opens a tab with `rel=noopener noreferrer`.
- The sibling links #958 taught the viewer keep what they had (they open in the viewer and land on their `#fragment`) and gain the line, the gesture and the dead-link verdicts. Their `fv-open` stamp and the body delegate are replaced by the shared path-link shape on the anchor and one body listener; md-url-view.test.ts's pins on that code are re-aimed, not deleted. The URL viewer's `fv-anchor` delegate is unchanged.

## Design

- **One grammar.** The viewer runs the chat's matcher with options (`inPre`, `accept`, `resolve`, `lineSuffix`, `unit`) under one extra gate, rather than a second matcher. The chat's behaviour is unchanged except for the three things stated at the end of this section.
- **The viewer's gate**, since this surface has no kernel stat verdict to narrow matches: a token links when it has a slash and a letter-led extension of one to eight letters or digits on its last segment (a dotfile only under `/`, `./`, `../`, `~/`); it is not glued to the character before it (line start, whitespace, or an opener: a quote, a bracket, `=`, `,`, `;`, `|`, or Markdown's `*` closed by a `*` after the path), so `$HOME/docs/a.md`, `${dir}/out.json`, `@scope/pkg/index.js`, `C:/Users/x.txt` and `git@host:user/repo.git` stay text; it is not inside a URL on its line; an unanchored first segment that reads as a hostname does not link; an unanchored token named by an import statement or a `require()`/`import()` call does not link, while the English `from` or `export` before a quoted path in prose does; a `~` start is `~/`. A local `file://` URI (empty authority or `localhost`) is a path; `file://host/path` is prose. The grammar is about 200 lines because every rule has a case that would otherwise link a path never written; the executable grammar tests are the record of those cases.
- **The pass changes no character.** It runs over the DOM the highlight and the sanitizer built, a line at a time (a code view's row, a rendered block; a `<br>` ends a unit), and only wraps runs of text, so selections and the quote chip over a line with a link keep working. A token a highlight span cuts into two nodes is left as text: a span around `$HOME` must never expose `/docs/a.md` as an absolute path. Text inside an inline SVG is read but never marked (an HTML element inside SVG text does not render).
- **Linear in the text.** The regex's g-flag loop is quadratic on a long run of word characters (one slash plus a 40K run of hex or dashes costs seconds), and a viewer shows whole files; `PathTokenScanner` drives the same regex in linear time, and a differential test pins that it finds exactly what the regex finds from every start position. The import look-behind is bounded to the line, the line suffix is read in place, and the span holding a token is found by binary search.
- **Gesture: the project's PDF rule** (`wantsOwnTab`). A plain click acts in the dashboard (a path opens in the viewer, a URL in a tab, a section scrolls); a Cmd/Ctrl-click or a middle-click opens the link in a browser tab of its own, a path off the kernel's `/file` route through a new `openFileTab` that `openPdfTab` now wraps (one `window.open` in the gesture, the opener severed by hand, a blocked popup falls through to the viewer). A click that arrives with text selected inside a link opens nothing, in the viewer's listener and in the chat's capture-phase anchor opener alike (`selectionOpenIn`, read for a non-draggable anchor only, so a triple-click on a chat paragraph does not deaden the link inside it); the next click, its press having collapsed the selection, opens. The viewer's anchors are not draggable and are selectable: a press-drag inside a path link selects its text as on plain text, a press held on a URL anchor and then dragged selects too (Chromium's rule for a link: an immediate drag on one selects nothing), and neither starts the browser's link drag.
- **Click-safe.** One listener on the viewer body, installed once per open and kept across Rendered/Raw swaps. A plain path click is not stopped, so the document's own listeners (the feed's focus return, menu closers) still run. Enter or Space on a focused path link is its click, with a held Cmd/Ctrl carried. A middle-click on a section link scrolls and opens no tab (the browser's own would open a second copy of the page).
- **Dress, progressive disclosure.** A token keeps the colour the highlight gave it under a faint dotted underline that turns solid on hover; a Markdown link that names a file keeps the ordinary link ink (`--link`); a dead link is dimmed with `cursor: help` and its reason in the title. No new font sizes, no new colour tokens, no loading state (the pass is synchronous on text that has already landed). Both sheets, byte-equal (fileview-parity.test.ts).
- **Security.** The `walkTokens` hook rewrites link targets before the sanitizer runs, and a local `file:///` target becomes a path; marks are set after `sanitizeMd` with its `ALLOW_DATA_ATTR: false`; the URL anchors the pass makes carry `rel=noopener noreferrer`, and a Markdown link with a scheme keeps its `rel=noopener`; `openFileTab` severs the opener; a dead anchor loses its href; a path link's href comes off, so the browser never follows it and the chat's opener never sees it.
- **The three chat-facing changes** the shared module brings: `file://host/path` no longer links as a relative path named after its host (it is prose); a path link is a tab stop that Enter or Space clicks, with a mouse press leaving focus where a click on plain text leaves it; and a path inside an inline SVG's text in a chat message stays text (an element inside SVG text does not render, so the span the old walk put there made the token vanish).

## Considered and not done

- A second matcher for the viewer: two grammars drift, and the kernel's parity fixture pins one regex.
- `joinDocPath` for Markdown targets: it keeps `..` above a relative start and decodes `%`; the viewer's `resolveViewerPath` normalizes once and is the one resolver for text tokens, URIs and Markdown targets alike, so a file is titled the same whichever way it was reached. `joinDocPath` still serves the figure sources.
- A lookup of its own for section links: the sanitizer's `userContentTarget` is the lookup the chat's `#` click already reads, so both surfaces resolve an author's id the same way.
- Left out on purpose: no back stack after following a link; no kernel existence check for a path (a `:line` into a file that shrank says so; a path that no longer exists gets the viewer's own not-found pane); the marked-failure fallback stays bare text.
- Known limits of the grammar: a `*`-wrapped span holding two paths links only the second; a letter-led `host:port` Markdown target is stripped by the sanitizer before the module runs, so its dead link carries the generic title; a two-letter country TLD without a registry label reads as a file; an extension on the TLD list (`Makefile.local:5`) reads as a host; a line holding only `from` and a quoted path has a hand-split import's shape and stays text.

## Tests

Each executing test below fails on the tree before the change as described; the pins re-aimed to the new shapes fail before it too.

- `ui/webview/file-view-links.test.ts` (new, 25 tests over a DOM stand-in): the URL segments and ranges; `viewerPathGate` alone (extensions, anchored dotfiles, hostnames, `~user`) and with the line (glue, openers, emphasis stars vs globs, imports and requires, hand-split imports, the English `from`); the bounded look-behind over an 8000-line fence; `normalizePath` and `resolveViewerPath`; the local `file://` arms, a URI's path normalized through the resolve; the pass over code rows (URLs, quoted paths, `:line`, prose left alone), the split-span fixture (no fabricated `/docs/a.md`), text that must not link, escaping; `viewerLinkTarget` and `isHostName`; `linkMarkdownAnchors` (URL, file, query-only, fragment, `<a name>`, an id and a name under the sanitizer's `user-content-` prefix, dead, host:port, empty `../`); soft breaks, `<br>`, a blank row, a thousand spans; SVG text; `wantsOwnTab` and `openFileTab` against a fake window; source pins on the viewer's wiring and both sheets. Before the change the module does not exist, so the test bundle fails to resolve it.
- `ui/webview/file-view-links-browser.test.ts` (new, 5 tests; headless Chromium over the real viewer module, plus a page running the chat's own anchor opener lifted from render.ts with a check that every name it uses is defined; skips loudly without a browser, as md-sanitize-browser.test.ts does): hljs's real rows and split spans; a plain click opening the sibling; the `:30` open landing Raw with row 30 itself centred (a neighbour is a row's height off) and the preference unwritten; the shared sanitizer's verdicts on Markdown targets, an author's id and name reaching the DOM prefixed and the section links that land on them, a document's own element dressed as a path link losing its `data-*` and opening nothing, a section link scrolling the document and not the page under a plain click and a middle click (no tab), the line-past-the-end notice; Cmd-click and middle-click tabs off `/file`, a URL anchor's tab; a press-drag inside a path link selecting its text and opening nothing, a drag from plain text into a link opening nothing; under the chat's opener a triple-click then a link click opening one tab, a click on the URL anchor with its text selected opening nothing and the next plain click one tab, and the viewer's own section link landing under the prefix. Before the change: no anchors and no path links in the viewer, a Markdown `[same](notes.md:7)` carries no path, a Cmd-click opens no tab. Removing either selection yield, landing the `:30` one row late, dropping the section arm's preventDefault, or reading section ids without the prefix each turns a browser test red.
- `ui/webview/path-links.test.ts` (new in the first commit, extended in the second): the span's shape, the shape gates on the real functions, the walk over a chat body, inline code, skipped text, the pathLinks verdict, the resume rule; the keyboard and press handlers; `markPathLink` on an anchor; the local-URI arm; the scanner's arms, the differential against the regex from every start position over adversarial and fuzzed texts, the parity fixture on the walk's own loop, the trailing-punctuation source, pathological inputs; `textUnits`, `spanHolding`, `rewriteSpan`; the walk under the viewer's options.
- `ui/webview/fileview-parity.test.ts`: the five link rules exist in styles.css and feed.css byte-equal (absent before).
- Re-aimed pins: `md-url-view.test.ts` (the file kind's anchors are the module's, one body listener, `scrollToFragment`'s lookup, the opts shape, the marks after `sanitizeMd`), `pdf-new-tab.test.ts` (`openPdfTab` wraps `openFileTab`; the viewer's own open reads no gesture), `file-view.test.ts`, and the chat pins in `chat-path-links`, `chat-relpath-link`, `chat-inline-preview`, `file-uri-link`, `chat-space-paths` (render.ts to path-links.ts in the first commit, the walk's options and its open target in the second); `tests/test_path_links.py` names the new home.

Runs: `npm run typecheck` clean at both commits; `npm test` 3714/3714 at the first commit and 3757/3757 at the second, 0 skipped (a Chromium is installed here, so the browser leg ran); `pytest tests/test_path_links.py` 20 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)