### PR TITLE
T290: the Log opens from the settings panel's Updates & debug section; the bottom bar keeps its few important controls

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -451,7 +451,7 @@ own a direct path; the dashboard is then a plain URL on your tailnet.
     Tunnels the extension still relays each whole view payload to the local
     window as it changes. It does not yet take the deltas the browser panes do.
     A pane that falls 16 MB behind is dropped and reconnects on its own; the
-    drop is logged in the kernel log and shows in the dashboard's bell, so a
+    drop is logged in the kernel log and shows in the Log (the settings panel's "Open log" button carries the unread count on the desktop; the phone's bottom bar reddens its bell), so a
     link that cannot keep up reads as what it is rather than as a flaky network.
 
 ### From your phone

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -74,7 +74,7 @@ completed); the feed just paints columns. (Reflected in `docs/judges.md`.)
   by the kernel, loudly: one `ws: dropping` line in the kernel log, written where
   the drop is decided so every send path is covered, naming the pane, the
   dashboard, the backlog and the push slot whose frame tipped the budget when a
-  push did; and a row in the dashboard's bell (at most five drop rows, none older
+  push did; and a row in the dashboard's Log (at most five drop rows, none older
   than an hour, so they never crowd out a backend problem). Every close the
   browser reports for a socket that opened leaves a `wsclose` breadcrumb (code,
   reason, socket age) in `client-diag.jsonl` (rotated to `.1` at 8 MB); a socket
@@ -559,11 +559,11 @@ or "(over the cap)". The quiet stderr line for kept tags the client did not
 edit carries the same kind of label on every tag, "(differing copy)" among
 them; until the 2026-09-05 review a kept differing copy was the one
 entry on it without a cause. Both notices bound their lists to fit the 240 characters
-the dashboard's bell shows, under the 300 the kernel serves (`SYNC_NOTICE_FIT`,
+the dashboard's Log shows, under the 300 the kernel serves (`SYNC_NOTICE_FIT`,
 `_notice_list`): as many entries as fit, then "and M more" for the rest, and
 when not even the first fits, the head alone, which carries the count. Until
 the 2026-09-05 review both notices put the cause clause and the
-remedy last, after one entry per tag, and with two or more tags the bell cut
+remedy last, after one entry per tag, and with two or more tags the Log cut
 them away. A file written
 outside the kernel (the timeline's Electron branch writes `timeline-views.json`
 itself, with the seq it holds) can carry a seq behind the last one served. By its own seq the writer

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -44954,7 +44954,7 @@ def _rdrift_block():
             + "<script>" + _RDRIFT_JS + "</script>")
 
 
-# The errors glyph, shared by the desktop rail and the mobile bar: a warning TRIANGLE (was a bell
+# The errors glyph, the mobile bar's glyph (the desktop rail's copy left with T290): a warning TRIANGLE (was a bell
 # until 2026-07-28 — the bell now means the session/card notification toggles, so the error center
 # wears the unambiguous trouble shape instead). The unread COUNT lives INSIDE the triangle (the user
 # 2026-07-28 — the old corner badge clipped): an svg <text> the errs JS drives (.rerr-n), digits 1-9,
@@ -45657,7 +45657,7 @@ def _landing():
             # usage-limit / judge-degraded — which got in the way): the bell in the bottom bar's action
             # cluster goes RED when an error lands; clicking it opens the Log as a centered modal
             # (the one panel treatment, the user 2026-08-08), newest first, per-row clear + Clear all.
-            "#rail-errs.has,#merr.has{color:#ff6b6b}"   # red bell = something unread / a live problem; no count badge (it clipped, and the number added nothing — the user 2026-07-27)
+            "#merr.has{color:#ff6b6b}"   # red bell = something unread / a live problem; no count badge (it clipped, and the number added nothing — the user 2026-07-27)
             # centered like every other panel (the user 2026-08-08: one modal treatment — centered card,
             # 0.55 dim, dashboard unchanged behind it; it used to sit bottom-right over the feed)
             "#rerr-back{position:fixed;inset:0;z-index:210;display:flex;align-items:center;justify-content:center;"

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -42536,7 +42536,7 @@ _LANDING_ERRS_JS = """
 back=document.getElementById('rerr-back'),list=document.getElementById('rerr-list'),
 clearBtn=document.getElementById('rerr-clear'),x=document.getElementById('rerr-x'),
 filtBar=document.getElementById('rerr-fgrid');
-if(!icon||!back||!list)return;
+if(!back||!list)return;   // the desktop bar carries no icon since T290; the panel and its openers stand without it
 var KEY='romp:notices',MAX=100,FKEY='romp:errFilters';
 function load(){try{var v=JSON.parse(localStorage.getItem(KEY)||'[]');return Array.isArray(v)?v:[];}catch(e){return[];}}
 var NOTES=load();
@@ -42650,7 +42650,7 @@ window.addEventListener('romp-panes',paint);
 // re-enabling its toggle re-reddens the bell if something happened while it was muted
 function open(){for(var i=0;i<NOTES.length;i++)if(kindOn(NOTES[i].kind))NOTES[i].seen=true;save();back.hidden=false;renderList();paint();}
 function close(){back.hidden=true;}
-icon.addEventListener('click',function(){back.hidden?open():close();});
+if(icon)icon.addEventListener('click',function(){back.hidden?open():close();});
 back.addEventListener('click',function(e){if(e.target===back)close();});
 if(x)x.addEventListener('click',close);
 if(clearBtn)clearBtn.addEventListener('click',function(){NOTES=[];save();renderList();paint();});
@@ -43404,6 +43404,8 @@ window.addEventListener('message',function(e){var m=e.data;if(m&&m.romp==='usage
 _LANDING_SETTINGS_JS = """
 (function(){window.addEventListener('message',function(e){var m=e.data;if(!m)return;
 if(m.romp==='settings')document.body.classList.toggle('settings-open',!!m.on);
+// the gear's "Open log" (T290): the settings modal closes itself first, then asks the shell for the Log panel
+if(m.romp==='openLog'&&window.__rompOpenErrs)window.__rompOpenErrs();
 // the /chat iframe's new-session picker asks the shell to lift it full-window (see body.picker-open CSS)
 if(m.romp==='picker')document.body.classList.toggle('picker-open',!!m.on);
 // "Browse files" from any pane surfaces the FILE BROWSER in the FEED pane, which is a different
@@ -45861,12 +45863,11 @@ def _landing():
             "</div>"   # /.rail-scroll
             # refresh + network + settings, pinned to the far RIGHT (settings last), always visible:
             "<div class=rail-acts>"
-            # the log's warning triangle (a bell until 2026-07-28 — the bell now means the
-            # notification toggles): monochrome outline like its neighbors; goes red with the unread
-            # count drawn INSIDE the triangle when an entry lands (see _ERRS_SVG + _LANDING_ERRS_JS).
-            "<div class=rail-act id=rail-errs data-keycmd=log.open title='Log — click to open' aria-label=Log>"
-            + _ERRS_SVG +
-            "</div>"
+            # The Log's opener LEFT this cluster (T290, the user 2026-09-09: the bar keeps only its few
+            # important controls): the Log opens from the gear's Updates & debug section ("Open log", which
+            # posts {romp:'openLog'} to the shell), from the command palette (log.open) and from the mobile
+            # bar's #merr, all through window.__rompOpenErrs. The desktop unread cue went with the element;
+            # _LANDING_ERRS_JS tolerates the missing icon (the mobile bar's #merr still paints its cue).
             # the refresh glyph is a REAL browser-style reload icon now (the user 2026-07-27: the ↻ text
             # glyph stopped at 11 o'clock and never read as refresh): a near-full circular arc sweeping
             # clockwise to 1 o'clock with the arrowhead there, drawn like its svg neighbors. QUOTED attrs.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -42563,7 +42563,12 @@ function paint(){var n=unseen();
 [icon,micon].forEach(function(el){if(!el)return;
 el.classList.toggle('has',n>0||(kindOn('conn')&&liveDown()));
 var t=el.querySelector('.rerr-n');if(t)t.textContent=n<=0?'!':(n>9?'+':String(n));});
-if(!back.hidden)renderList();}
+tell(n);if(!back.hidden)renderList();}
+// The bar's opener carried the unread count (T290 took it off the bar): the count now rides the gear's
+// "Open log" button, in the feed pane's document — told on every repaint and on the panel's own query.
+function tell(n){var f=document.getElementById('f-feed');
+try{f&&f.contentWindow&&f.contentWindow.postMessage({romp:'logUnseen',n:(n===undefined?unseen():n)},'*');}catch(e){}}
+window.addEventListener('message',function(e){var m=e.data;if(m&&m.romp==='logUnseenQuery')tell();});
 // each entry leads with the chip its card wears in the feed, so the vocabulary matches across surfaces
 var KINDS=['conn','limit','judge','warn','stalled','nudge','retry','apierror','sdk','sync','locate','cleared','refused','undelivered'];
 var KINDLBL={conn:'offline',limit:'limit',judge:'judge',warn:'warning',stalled:'stalled',

--- a/tests/test_error_center.py
+++ b/tests/test_error_center.py
@@ -287,7 +287,7 @@ class ErrorCenterWiring(unittest.TestCase):
         # "Log", not "Errors" (the user 2026-07-29): quiet informational kinds live here too, so the
         # old name oversold every entry as a problem. BOTH glyphs (rail + mobile) say what it is.
         self.assertIn("title='Log — click to open'", html)
-        self.assertEqual(html.count("title='Log — click to open'"), 2)
+        self.assertEqual(html.count("title='Log — click to open'"), 1, "the mobile bar's #merr only (T290)")
         self.assertIn("<div class=rerr-top>Log<span class=sp></span>", html)
         self.assertNotIn("aria-label=Errors", html)
         # the panel speaks the shared modal vocabulary (network panel / settings card), never the

--- a/tests/test_error_center.py
+++ b/tests/test_error_center.py
@@ -289,7 +289,7 @@ class ErrorCenterWiring(unittest.TestCase):
         self.assertIn("n<=0?'!'", html)
         self.assertNotIn("M8 2 C5.8 2 4.5 3.7", html, "the old bell path left the shell entirely")
         # "Log", not "Errors" (the user 2026-07-29): quiet informational kinds live here too, so the
-        # old name oversold every entry as a problem. BOTH glyphs (rail + mobile) say what it is.
+        # old name oversold every entry as a problem. the mobile glyph says what it is (the rail's copy left with T290).
         self.assertIn("title='Log — click to open'", html)
         self.assertEqual(html.count("title='Log — click to open'"), 1, "the mobile bar's #merr only (T290)")
         self.assertIn("<div class=rerr-top>Log<span class=sp></span>", html)

--- a/tests/test_error_center.py
+++ b/tests/test_error_center.py
@@ -145,7 +145,8 @@ const jumpRow = EL['rerr-list'].children[0];
 out.jump = { linky: jumpRow.className.indexOf('link') >= 0 };
 jumpRow.fire('click');
 out.jump.closed = EL['rerr-back'].hidden;
-out.jump.posted = POSTED[POSTED.length - 1] || null;
+out.jump.posted = POSTED.filter((m) => m.romp === 'revealCard').pop() || null;   // paint() also posts the unread count (T290)
+out.unseenPosts = POSTED.filter((m) => m.romp === 'logUnseen').map((m) => m.n);
 out.jump.toggles = TOGGLES.join('|');
 // …while a kernel-minted entry (no target) is not clickable
 out.plainRowLinky = EL['rerr-list'].children[1].className.indexOf('link') >= 0;
@@ -258,6 +259,9 @@ class ErrorCenterExecutes(unittest.TestCase):
         self.assertTrue(a["linky"], "a targeted entry renders as a link row")
         self.assertTrue(a["closed"], "the popover closes on jump")
         self.assertEqual(a["posted"], {"romp": "revealCard", "itemId": "TESTSID:g9", "sid": "TESTSID"})
+        # the unread count rides into the feed pane for the gear's Open log button (T290): the drop posted a 1,
+        # opening the Log (everything seen) posted a 0
+        self.assertIn(1, self.out["unseenPosts"]); self.assertIn(0, self.out["unseenPosts"])
         self.assertIn("feed:true", a["toggles"], "the feed pane is revealed for the jump")
         self.assertFalse(self.out["plainRowLinky"], "a kernel-minted entry with no target is not a link")
 

--- a/tests/test_error_center.py
+++ b/tests/test_error_center.py
@@ -270,13 +270,13 @@ class ErrorCenterExecutes(unittest.TestCase):
 class ErrorCenterWiring(unittest.TestCase):
     def test_the_shell_mounts_bell_popover_and_script(self):
         html = km._landing()
-        for pin in ("id=rail-errs", "id=rerr-back", "id=rerr-list", "id=rerr-clear", "id=merr"):
+        for pin in ("id=rerr-back", "id=rerr-list", "id=rerr-clear", "id=merr"):   # the desktop bar's opener left (T290)
             self.assertIn(pin, html)
         self.assertNotIn("rerr-badge", html)   # the CORNER badge clipped and is gone (the user 2026-07-27);
         # the count lives INSIDE the glyph (the user 2026-07-28): an svg <text> the JS drives,
         # reddening with the outline via fill=currentColor
         self.assertIn("<text class='rerr-n'", html)
-        self.assertEqual(html.count("class='rerr-n'"), 2, "rail + mobile, both from the ONE _ERRS_SVG")
+        self.assertEqual(html.count("class='rerr-n'"), 1, "the mobile bar's only, from the ONE _ERRS_SVG (the desktop bar's opener left, T290)")
         self.assertIn("n>9?'+':String(n)", html)
         # the errors glyph is a warning TRIANGLE since 2026-07-28 — the BELL shape now belongs to the
         # session/card notification toggles, so the error center must not wear it; when nothing is

--- a/tests/test_hotkey_hints.py
+++ b/tests/test_hotkey_hints.py
@@ -14,7 +14,8 @@ SRC = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py"), encoding=
 
 class HotkeyHints(unittest.TestCase):
     def test_every_rail_button_with_a_command_carries_its_id(self):
-        for el_id, cmd in [("rail-errs", "log.open"), ("rail-refresh", "kernel.restart"),
+        # the Log's opener left the rail (T290): log.open stays a palette command and the mobile bar's #merr
+        for el_id, cmd in [("rail-refresh", "kernel.restart"),
                            ("rail-net", "net.open"), ("rail-gear", "settings.open"),
                            ("rail-usage", "usage.open")]:
             self.assertRegex(SRC, "id=%s data-keycmd=%s|id=%s[^>]* data-keycmd=%s" % (el_id, cmd, el_id, cmd),

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -247,7 +247,10 @@ class DisconnectBanner(unittest.TestCase):
         # old fixed top banner is GONE (it got in the way, the user 2026-07-27)
         self.assertIn("var s=(m.state==='up')?'up':'down',prev=st[m.app];st[m.app]=s;", km._LANDING_ERRS_JS)
         land = inspect.getsource(km._landing)
-        self.assertIn("id=rail-errs", land, "the bell sits in the bottom bar's action cluster")
+        self.assertNotIn("id=rail-errs", land, "the Log's opener left the bottom bar's action cluster (T290): it opens from the gear")
+        self.assertIn("if(m.romp==='openLog'&&window.__rompOpenErrs)window.__rompOpenErrs();", km._LANDING_SETTINGS_JS,
+                      "the gear's Open log reaches the shell's panel")
+        self.assertIn("if(!back||!list)return;", km._LANDING_ERRS_JS, "the center's script stands without the bar icon")
         self.assertIn("id=rerr-back", land, "the popover backdrop is in the shell body")
         self.assertIn("_LANDING_ERRS_JS", land, "the center's script is injected into the shell")
         self.assertNotIn("id=romp-offline", land, "the top banner element is gone")

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -62,7 +62,8 @@ class SettingsSectionsTest(unittest.TestCase):
         self.assertLess(h.index(">Updates & debug<"), h.index("id=rs-judges-index"))
         self.assertLess(h.index(">Updates & debug<"), h.index("id=rs-judges-triage"))
         self.assertLess(h.index("id=rs-judges-triage"), h.index("id=ra-open"))
-        self.assertLess(h.index("id=ra-open"), h.index("id=rsver"), "version is the very bottom")
+        self.assertLess(h.index("id=ra-open"), h.index("id=rs-log-open"), "Open log is the section's last row (T290)")
+        self.assertLess(h.index("id=rs-log-open"), h.index("id=rsver"), "version is the very bottom")
         self.assertNotIn("id=rs-debug", h)   # the single Debug toggle is gone
         # the judge toggles read as a DEBUG *show* control, not an on/off for the judges (the user 2026-06-30):
         # labels lead with "Show", and the sub spells out that it doesn't enable/disable them

--- a/tests/test_log_opener_moved.py
+++ b/tests/test_log_opener_moved.py
@@ -44,13 +44,29 @@ class SourcePins(unittest.TestCase):
         self.assertIn("window.__rompOpenErrs=open;", km._LANDING_ERRS_JS)
 
     def test_the_gear_button_is_the_last_row_of_updates_and_debug_and_opens_the_shell_panel(self):
-        self.assertIn("<button id=rs-log-open class=ra-openbtn hidden>Open log</button>", GEAR, "the same button chrome as Token usage analytics")
+        self.assertIn("<button id=rs-log-open class=ra-openbtn hidden>Open log<span class=rs-log-n hidden></span></button>", GEAR, "the same button chrome as Token usage analytics")
         self.assertLess(GEAR.index("id=ra-open"), GEAR.index("id=rs-log-open"))
         self.assertLess(GEAR.index("id=rs-log-open"), GEAR.index("id=rsver"), "the section's last row, before the version block")
         self.assertIn("lg.onclick = function () { closeSettings(); try { window.parent.postMessage({ romp: 'openLog' }, '*'); }", GEAR,
                       "the modal closes first, then asks the shell (the panels never stack)")
         self.assertIn("lg.hidden = !web;", GEAR, "web shell only: VS Code's parent has no Log panel")
         self.assertIn("if(m.romp==='openLog'&&window.__rompOpenErrs)window.__rompOpenErrs();", km._LANDING_SETTINGS_JS)
+
+    def test_the_unread_count_rides_the_open_log_button(self):
+        # the bar's opener drew the unread count; with it gone the count travels to the gear's button (the manager's
+        # review nit, 2026-09-09): the shell posts it on every repaint and on the panel's query, the button renders
+        # "Open log · N" with the count in the triangle's red
+        k = open(os.path.join(ROOT, "kernel", "kernel.py"), encoding="utf-8").read()
+        g = open(os.path.join(ROOT, "ui", "webview", "gear.js"), encoding="utf-8").read()
+        css = open(os.path.join(ROOT, "ui", "webview", "gear.css"), encoding="utf-8").read()
+        self.assertIn("tell(n);if(!back.hidden)renderList();}", k, "paint() tells the feed pane")
+        self.assertIn("postMessage({romp:'logUnseen',n:(n===undefined?unseen():n)},'*')", k)
+        self.assertIn("if(m&&m.romp==='logUnseenQuery')tell();", k, "…and answers the panel's query")
+        self.assertIn("<button id=rs-log-open class=ra-openbtn hidden>Open log<span class=rs-log-n hidden></span></button>", g)
+        self.assertIn("if (m && m.romp === 'logUnseen') window.__rompSetLogCount(m.n);", g)
+        self.assertIn("lgn.textContent = n <= 0 ? '' : ' \\u00b7 ' + (n > 9 ? '9+' : String(n));", g)
+        self.assertIn("window.parent.postMessage({ romp: 'logUnseenQuery' }, '*');", g, "the panel asks when it opens")
+        self.assertIn(".rs-log-n { color: #ff6b6b; font-weight: 600; }", css, "the triangle's red, a status colour")
 
     def test_the_other_openers_are_unchanged(self):
         self.assertIn('registerCommand({ id: "log.open", title: "Open the log", run: () => { if (w.__rompOpenErrs) w.__rompOpenErrs(); } });', PALETTE)

--- a/tests/test_log_opener_moved.py
+++ b/tests/test_log_opener_moved.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""The Log opens from the gear, not the bottom bar (T290, the user 2026-09-09: the bar keeps only its few
+important controls). The desktop bar's action cluster no longer carries the Log's triangle; the settings panel's
+Updates & debug section ends with an "Open log" button that closes the modal and asks the shell for the Log panel
+({romp:'openLog'} → window.__rompOpenErrs), the same centered modal over the dimmed dashboard. The command
+palette's log.open and the mobile bar's #merr are unchanged; the Log's own behaviour is untouched.
+
+Two guards: SourcePins runs everywhere; ServedOpener boots the hermetic kernel, loads the dashboard, and drives
+the gear's button in the feed iframe (skips loudly without the extension deps or a Playwright browser).
+All fixtures synthetic.
+"""
+import inspect
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_logopener", os.path.join(BIN, "romp-kernel")).load_module()
+GEAR = open(os.path.join(ROOT, "ui", "webview", "gear.js")).read()
+PALETTE = open(os.path.join(ROOT, "ui", "webview", "palette-main.ts")).read()
+
+
+class SourcePins(unittest.TestCase):
+    def test_the_bar_no_longer_carries_the_opener_and_the_panel_still_stands(self):
+        land = inspect.getsource(km._landing)
+        self.assertNotIn("id=rail-errs", land, "the Log's triangle left the bottom bar's action cluster")
+        for keep in ("id=rail-refresh", "id=rail-net", "id=rail-gear", "id=rerr-back", "id=rerr-list", "id=rerr-clear"):
+            self.assertIn(keep, land, keep + " stays")
+        self.assertIn("if(!back||!list)return;", km._LANDING_ERRS_JS, "the center's script no longer needs the bar icon")
+        self.assertIn("if(icon)icon.addEventListener('click'", km._LANDING_ERRS_JS)
+        self.assertIn("window.__rompOpenErrs=open;", km._LANDING_ERRS_JS)
+
+    def test_the_gear_button_is_the_last_row_of_updates_and_debug_and_opens_the_shell_panel(self):
+        self.assertIn("<button id=rs-log-open class=ra-openbtn hidden>Open log</button>", GEAR, "the same button chrome as Token usage analytics")
+        self.assertLess(GEAR.index("id=ra-open"), GEAR.index("id=rs-log-open"))
+        self.assertLess(GEAR.index("id=rs-log-open"), GEAR.index("id=rsver"), "the section's last row, before the version block")
+        self.assertIn("lg.onclick = function () { closeSettings(); try { window.parent.postMessage({ romp: 'openLog' }, '*'); }", GEAR,
+                      "the modal closes first, then asks the shell (the panels never stack)")
+        self.assertIn("lg.hidden = !web;", GEAR, "web shell only: VS Code's parent has no Log panel")
+        self.assertIn("if(m.romp==='openLog'&&window.__rompOpenErrs)window.__rompOpenErrs();", km._LANDING_SETTINGS_JS)
+
+    def test_the_other_openers_are_unchanged(self):
+        self.assertIn('registerCommand({ id: "log.open", title: "Open the log", run: () => { if (w.__rompOpenErrs) w.__rompOpenErrs(); } });', PALETTE)
+        self.assertIn("data-act=errs data-keycmd=log.open", inspect.getsource(km._landing), "the mobile bar keeps its opener")
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 800 } });
+await page.goto(cfg.url);
+await page.waitForSelector("#rail-gear", { timeout: 20000 });
+const feed = page.frames().find((f) => f.url().includes("/feed"));
+if (!feed) { console.error("no feed frame"); process.exit(1); }
+await feed.waitForSelector(".rs-vermenu-btn", { state: "attached", timeout: 20000 });
+const before = await page.evaluate(() => ({ railErrs: !!document.getElementById("rail-errs"), logHidden: document.getElementById("rerr-back").hidden,
+  acts: Array.from(document.querySelectorAll(".rail-acts .rail-act")).map((e) => e.id) }));
+await feed.evaluate(() => window.postMessage({ romp: "openSettings" }, "*"));
+await feed.waitForSelector("#rsettings:not([hidden])", { timeout: 15000 });
+const btn = await feed.evaluate(() => { const b = document.getElementById("rs-log-open"); return { present: !!b, hidden: b ? b.hidden : null }; });
+await feed.click("#rs-log-open");
+await page.waitForFunction(() => !document.getElementById("rerr-back").hidden, null, { timeout: 8000 });
+const after = await page.evaluate(() => ({ logHidden: document.getElementById("rerr-back").hidden, settingsOpen: document.body.classList.contains("settings-open") }));
+const modal = await feed.evaluate(() => document.getElementById("rsettings").hidden);
+fs.writeSync(1, "RESULT:" + JSON.stringify({ before, btn, after, settingsHidden: modal }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedOpener(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        cls.lab = tempfile.mkdtemp(prefix="logopener-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        shutil.copytree(os.path.join(EXT, "dist"), dist)
+        state = os.path.join(cls.lab, "xdg", "romp")
+        os.makedirs(state, exist_ok=True)
+        cls.port = _free_port()
+        cls.token = "testtok-logopener"
+        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=os.path.join(cls.lab, "claude"),
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token, ROMP_KERNEL_PORT=str(cls.port),
+                   ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
+        env.pop("ROMP_STATE_DIR", None)
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(os.path.join(cls.lab, "kernel.log"), "w"),
+                                      stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_the_bar_has_no_opener_and_the_gear_button_opens_the_panel(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"url": "http://127.0.0.1:%d/?token=%s" % (self.port, self.token)}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        self.assertFalse(r["before"]["railErrs"], "no Log opener in the bottom bar: %r" % r["before"])
+        self.assertTrue(r["before"]["logHidden"], "the panel starts closed")
+        self.assertEqual(r["before"]["acts"], ["rail-refresh", "rail-net", "rail-bell", "rail-gear"], "the bar's action cluster keeps its few controls (the bell is present, hidden until it has something): %r" % r["before"]["acts"])
+        self.assertEqual(r["btn"], {"present": True, "hidden": False}, "the gear shows Open log in the web shell")
+        self.assertFalse(r["after"]["logHidden"], "the click opened the shell's Log panel")
+        self.assertFalse(r["after"]["settingsOpen"], "the settings modal closed first: the panels never stack")
+        self.assertTrue(r["settingsHidden"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/css-census.test.ts
+++ b/ui/webview/css-census.test.ts
@@ -33,7 +33,9 @@ const rawDims = (css: string) => {
 // EXACT counts, not ceilings (PR #763 item 7: a <= pin with slack lets new raw hexes arrive
 // unnoticed) — a count that moves in EITHER direction is a deliberate change to name here.
 const EXACT: Record<string, number> = {
-  "gear.css": 12,   // T226's shadows-onto-var(--shadow-menu), the .ra-li legend joining --text-soft, and the
+  "gear.css": 13,   // +1 (T290): .rs-log-n's #ff6b6b, the Log cue's red — a STATUS colour, byte-equal to the shell's
+                    // #merr.has, deliberately a literal (no sheet defines that red as a token). Before it: T226's
+                    // shadows-onto-var(--shadow-menu), the .ra-li legend joining --text-soft, and the
                     // .ra-openbtn slab joining --btn-bg (2026-09-02: it sat black with dark text in light)
   "strip.css": 8,
   "fleet-pane.css": 9,

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -190,3 +190,7 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
 #rs-login-modal .rs-login-card { background: var(--surface-raised, #252526); border: 1px solid rgba(255,255,255,0.12);
   border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.35); padding: 14px 16px;
   width: min(480px, calc(100vw - 48px)); }
+
+/* the Open log button's unread count (T290): the red the bar's triangle wore when something was unread —
+   a STATUS colour (the accent/status split), so it is the same literal on every surface */
+.rs-log-n { color: #ff6b6b; font-weight: 600; }

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -179,7 +179,8 @@ var GEAR_HTML =
   '</span></label>' +
   '</div>' +
   "<div class=rs-sep style='padding-top:8px'>" +
-  '<button id=ra-open class=ra-openbtn>Token usage analytics</button></div>' +
+  '<button id=ra-open class=ra-openbtn>Token usage analytics</button>' +
+  '<button id=rs-log-open class=ra-openbtn hidden>Open log</button></div>' +   // T290: the Log moved here from the bottom bar (web shell only)
   "<div class='rs-h rs-sep'>romp · version</div>" +
   '<div id=rsver>…</div></div></div>' +
   '<div id=rs-login-modal hidden>' +
@@ -1201,6 +1202,11 @@ function initGear(post) {
     if (vrow) vrow.hidden = web;
     var kb2 = document.getElementById('rs-keys-btn');
     if (kb2) kb2.onclick = function () { closeSettings(); try { window.parent.postMessage({ romp: 'openKeys' }, '*'); } catch (e) { /* no shell to ask */ } };
+    // "Open log" (T290, the user 2026-09-09): the Log left the bottom bar; this button, the last row of Updates &
+    // debug, opens the shell's Log panel (a centered modal over the dimmed dashboard, the panels rule). The modal
+    // closes first so the two never stack. Web shell only: VS Code's cross-origin parent has no Log panel.
+    var lg = document.getElementById('rs-log-open');
+    if (lg) { lg.hidden = !web; lg.onclick = function () { closeSettings(); try { window.parent.postMessage({ romp: 'openLog' }, '*'); } catch (e) { /* no shell to ask */ } }; }
   })();
   p.addEventListener('click', function (e) { if (e.target === p) closeSettings(); });   // click the dimmed backdrop (not the card) → close
   document.addEventListener('click', function (e) { if (!p.hidden && e.target !== g && !p.contains(e.target)) closeSettings(); });

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -180,7 +180,7 @@ var GEAR_HTML =
   '</div>' +
   "<div class=rs-sep style='padding-top:8px'>" +
   '<button id=ra-open class=ra-openbtn>Token usage analytics</button>' +
-  '<button id=rs-log-open class=ra-openbtn hidden>Open log</button></div>' +   // T290: the Log moved here from the bottom bar (web shell only)
+  '<button id=rs-log-open class=ra-openbtn hidden>Open log<span class=rs-log-n hidden></span></button></div>' +   // T290: the Log moved here from the bottom bar (web shell only); the span is the unread count
   "<div class='rs-h rs-sep'>romp · version</div>" +
   '<div id=rsver>…</div></div></div>' +
   '<div id=rs-login-modal hidden>' +
@@ -1188,6 +1188,7 @@ function initGear(post) {
     // settings-open, which is what un-hides #feed-pane when the feed is toggled off — measuring first
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
+    try { if (window.parent !== window) window.parent.postMessage({ romp: 'logUnseenQuery' }, '*'); } catch (e) { /* no shell to ask */ }   // T290: the Open log count
     p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); paintBackendOffer(tb ? tb.checked : false); if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
@@ -1207,6 +1208,16 @@ function initGear(post) {
     // closes first so the two never stack. Web shell only: VS Code's cross-origin parent has no Log panel.
     var lg = document.getElementById('rs-log-open');
     if (lg) { lg.hidden = !web; lg.onclick = function () { closeSettings(); try { window.parent.postMessage({ romp: 'openLog' }, '*'); } catch (e) { /* no shell to ask */ } }; }
+    // the unread count the bar's opener used to draw (T290): the shell posts {romp:'logUnseen', n} on every
+    // repaint of its Log and answers {romp:'logUnseenQuery'}; the label reads "Open log · N" (9+ past nine)
+    var lgn = lg ? lg.querySelector('.rs-log-n') : null;
+    window.__rompSetLogCount = function (n) {
+      if (!lgn) return;
+      n = Number(n) || 0;
+      lgn.hidden = n <= 0;
+      lgn.textContent = n <= 0 ? '' : ' \u00b7 ' + (n > 9 ? '9+' : String(n));
+    };
+    window.addEventListener('message', function (e) { var m = e.data; if (m && m.romp === 'logUnseen') window.__rompSetLogCount(m.n); });
   })();
   p.addEventListener('click', function (e) { if (e.target === p) closeSettings(); });   // click the dimmed backdrop (not the card) → close
   document.addEventListener('click', function (e) { if (!p.hidden && e.target !== g && !p.contains(e.target)) closeSettings(); });


### PR DESCRIPTION
The dashboard's bottom-right bar keeps only its few important controls; the Log's opener (the red triangle with the unread count) leaves it, and the Log opens from an "Open log" button at the bottom of the settings panel's "Updates & debug" section instead. Started by romp_ui, finished by romp_feed on the same branch.

**Design points**
- The bar (`.rail-acts` in the landing HTML) no longer carries `#rail-errs`. The Log script mounts without the icon; the panel, its entries, filters and the mobile bar's `#merr` cue are untouched.
- `gear.js`: "Open log" is the last row of Updates & debug, beside "Token usage analytics". It closes the settings modal first, then posts `{romp:'openLog'}` to the shell, which routes it to the one Log opener (`window.__rompOpenErrs`), so the Log opens as it always did: a centered modal over the dimmed, unchanged dashboard (the panels rule). Shown in the web shell only; VS Code's cross-origin parent has no Log panel.
- The command palette's `log.open` and the mobile bar's `#merr` are unchanged by design.
- The bar-level error signal is gone by the user's choice: the triangle's red cue and count no longer sit on the bottom bar (the mobile bar still paints its own). So that new errors stay discoverable one click away, the unread count rides the "Open log" button instead: the shell posts it into the feed pane on every repaint of its Log and on the panel's query, and the button reads "Open log · N" with the count in the same red the triangle used.

**Tests.** Pins that named the bar's controls and the gear section's rows follow (test_error_center, test_hotkey_hints, test_kernel_disconnect_banner, test_kernel_settings_sections). New `tests/test_log_opener_moved.py`: source pins plus a served Playwright guard that the bar has no opener, the gear button opens `#rerr-back`, and the settings modal closes first. Screenshots of the bar before and after and of the gear section are in the task report.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
