### PR TITLE
Figure previews: a link failure heals on the reconnect event only, and an attempt never changes the box's layout (T291)

### DIFF
--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -61,8 +61,10 @@ test("the failure chip narrates what happens next, escalates on repeat, and a re
   // while auto-retries remain the box KEEPS its loading persona (swirl + note, whole box tappable);
   // the ⚠ chip is the GIVE-UP state only (the user 2026-08-16, third report: state bouncing between
   // "trying" and "unavailable" on every retry cycle read as impatient even when it eventually loaded)
-  assert.match(pf, /if \(autoRetries > 0 \|\| transient\) \{\s*\n\s*if \(!transient\) autoRetries--;\s*\n\s*failedPreviews\.set\(box, \(\) => build\(true\)\);/);
-  assert.match(pf, /\+ " — retrying · tap to retry now";/);
+  // a LINK failure registers for the reconnect-class heal only, a real verdict spends the budget on the per-message heal (T291)
+  assert.match(pf, /if \(autoRetries > 0 \|\| transient\) \{[\s\S]*?if \(transient\) settledPreviews\.set\(box, \(\) => build\(true\)\);\s*\n\s*else \{ autoRetries--; failedPreviews\.set\(box, \(\) => build\(true\)\); \}/);
+  assert.match(pf, /\+ \(transient \? " — retries when the link is back · tap to retry now" : " — retrying · tap to retry now"\)\);/,   // set on the reused note; the link case says what will happen (T291)
+    "the note says what happens next: a retry on the link's return, or the bounded retrying");
   assert.match(pf, /wait\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); autoRetries = 3; ackTap\(ev\); build\(true\); \};/,
     "the whole retrying box is the tap target — a tap re-arms persistence and acknowledges");
   assert.match(pf, /"⚠ preview unavailable"\)\)\s*\n\s*\+ " — tap to retry";/,
@@ -79,16 +81,19 @@ test("the failure chip narrates what happens next, escalates on repeat, and a re
   assert.match(pf, /if \(!box\.isConnected\) return;/);
 });
 
-test("a failed preview heals on the next kernel push — the kernel-is-back event, not a tap or a timer", () => {
+test("a failed preview heals on the next kernel push (a link failure: on the reconnect event) — never a tap or a timer", () => {
   // the 2026-08-15 report: the fetch died in a converge-restart window, and delta-send never rebuilds
   // an old turn's DOM, so the chip sat until a human tapped it. Any incoming kernel message proves the
   // kernel is reachable again; no pushes arrive while it's down, so retry-on-push can't spam.
   const pf = PREVIEW.slice(PREVIEW.indexOf("export function previewFull"));
   assert.match(pf, /let autoRetries = 3;/, "bounded — a genuinely-dead file settles on the tap chip");
   // a failure naming the LINK, not the image, never spends the budget (the user 2026-08-17: the
-  // kernel-restart tunnel window burned all three attempts right before the link came back)
+  // kernel-restart tunnel window burned all three attempts right before the link came back) — and since
+  // T291 it waits for the reconnect-class event instead of re-attempting on every push (a dead link
+  // answered every push of a streaming session instantly, and each attempt moved the transcript)
   assert.match(pf, /const transient = \/tunnel to \.\* is not answering\|no attached host\|re-dialing\/i\.test\(lastErr\);/);
-  assert.match(pf, /if \(autoRetries > 0 \|\| transient\) \{\s*\n\s*if \(!transient\) autoRetries--;\s*\n\s*failedPreviews\.set\(box, \(\) => build\(true\)\);/);
+  // a LINK failure registers for the reconnect-class heal only, a real verdict spends the budget on the per-message heal (T291)
+  assert.match(pf, /if \(autoRetries > 0 \|\| transient\) \{[\s\S]*?if \(transient\) settledPreviews\.set\(box, \(\) => build\(true\)\);\s*\n\s*else \{ autoRetries--; failedPreviews\.set\(box, \(\) => build\(true\)\); \}/);
   assert.match(PREVIEW, /export function retryFailedPreviews\(\): void/);
   assert.match(PREVIEW, /if \(box\.isConnected\) rebuild\(\);/, "a re-rendered turn's fresh box supersedes the old");
   assert.match(RENDER, /retryFailedPreviews\(\);/, "called from the kernel message handler");

--- a/ui/webview/preview-retry-pace.test.ts
+++ b/ui/webview/preview-retry-pace.test.ts
@@ -1,0 +1,167 @@
+// A figure preview whose LINK is down never moves the transcript (T291, the user 2026-09-09). Two figures in a
+// remote session's transcript re-attempted on every kernel push while the laptop's relay to their host was
+// failing, and every attempt swapped the box between the one-line "fetching…" and the five-line failure note:
+// the transcript above the reader moved by four lines, ten times a second, for the length of the streaming
+// turn. previewFull is EXECUTED here over a minimal fake DOM and a stubbed fetch, driven through the same entry
+// points render.ts calls: retryFailedPreviews on every kernel message, refreshSettledPreviews on a reconnect.
+// Two rules under test: a link failure heals on the reconnect-class event only, never on a push; and an attempt
+// never changes the box's child structure (only the note's words may change, and only when they do).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const PREVIEW = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "preview.ts"), "utf8");
+const SID = "TESTHOST:11111111-2222-4333-8444-000000000291";
+const PATH = "/home/user/notes-api/plots/latency.png";
+
+// ── a minimal DOM: what previewFull touches, nothing more ──────────────────────────────────────────────────
+class FakeEl {
+  tag: string; children: FakeEl[] = []; parent: FakeEl | null = null; attrs: Record<string, string> = {};
+  style: Record<string, string> = {}; _cls = new Set<string>(); _text = ""; isConnected = true;
+  onclick: any = null; onerror: any = null; onmousedown: any = null; onauxclick: any = null; title = ""; src = ""; alt = ""; loading = ""; decoding = "";
+  listeners: Record<string, Function[]> = {};
+  constructor(tag: string) { this.tag = tag; }
+  get className(): string { return [...this._cls].join(" "); }
+  set className(v: string) { this._cls = new Set(v.split(/\s+/).filter(Boolean)); }
+  get classList() { const s = this._cls; return { add: (...c: string[]) => c.forEach((x) => s.add(x)), remove: (...c: string[]) => c.forEach((x) => s.delete(x)), contains: (c: string) => s.has(c), toggle: (c: string, on?: boolean) => { if (on === undefined) on = !s.has(c); on ? s.add(c) : s.delete(c); return on; } }; }
+  get textContent(): string { return this.children.length ? this.children.map((c) => c.textContent).join("") : this._text; }
+  set textContent(v: string) { this.children.forEach((c) => (c.parent = null)); this.children = []; this._text = v; }
+  appendChild(c: FakeEl): FakeEl { if (c.parent) c.parent.children = c.parent.children.filter((x) => x !== c); c.parent = this; this.children.push(c); return c; }
+  append(...cs: FakeEl[]) { cs.forEach((c) => this.appendChild(c)); }
+  remove() { if (this.parent) this.parent.children = this.parent.children.filter((x) => x !== this); this.parent = null; }
+  get firstElementChild(): FakeEl | null { return this.children[0] || null; }
+  querySelector(sel: string): FakeEl | null { const cls = sel.replace(/^\./, ""); const walk = (n: FakeEl): FakeEl | null => { for (const c of n.children) { if (c._cls.has(cls)) return c; const d = walk(c); if (d) return d; } return null; }; return walk(this); }
+  closest() { return null; }
+  addEventListener(t: string, fn: Function) { (this.listeners[t] = this.listeners[t] || []).push(fn); }
+  setAttribute(k: string, v: string) { this.attrs[k] = v; }
+  /** the structure a height depends on: tags, classes, text, display — one string to compare across attempts */
+  /** the classes that shape the box; path-retry-flash is a one-shot pulse animation (no size), left out */
+  cls(): string { return [...this._cls].filter((c) => c !== "path-retry-flash").sort().join("."); }
+  shape(): string { return `${this.tag}.${this.cls()}[${this.style.display || ""}]{${this.children.length ? this.children.map((c) => c.shape()).join(",") : JSON.stringify(this._text)}}`; }
+  /** the structure without the words: only the elements that are there */
+  bones(): string { return `${this.tag}.${this.cls()}(${this.children.map((c) => c.bones()).join(",")})`; }
+}
+(globalThis as any).document = { createElement: (t: string) => new FakeEl(t), addEventListener: () => {} };
+(globalThis as any).location = { protocol: "http:", origin: "http://127.0.0.1:1" };   // canPreview: the web dashboard
+(globalThis as any).window = (globalThis as any).window || {};
+
+let fetchCalls = 0;
+let fetchAnswer: () => Promise<any> = () => Promise.reject(new Error("no answer set"));
+(globalThis as any).fetch = (_url: string, _init?: any) => { fetchCalls++; return fetchAnswer(); };
+const failWith = (status: number, body: string) => () => Promise.resolve({ status, ok: false, headers: { get: () => null }, text: async () => body });
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const minted: FakeEl[] = [];
+async function armedBox(file = PATH) {   // a path per test: a resolved picture is memoized by URL for the page life
+  const P = await import("./preview");
+  for (const b of minted) b.isConnected = false;   // an earlier test's box is a re-rendered turn's: the drains drop it without a fetch
+  const box = P.previewFull(file, SID, true) as unknown as FakeEl;
+  minted.push(box);
+  assert.ok(box, "an image preview builds (verified: the kernel said the file exists)");
+  // the happy path's <img> failed to load: the first failure, no message from the server
+  const img = box.children.find((c) => c.tag === "img" && c._cls.has("path-full-img"))!;
+  assert.ok(img && img.onerror, "the plain <img> carries the onerror that hands the box to the retry machinery");
+  img.onerror();
+  await sleep(10);   // failAfterBeat(0): no beat on the first attempt
+  return { P, box };
+}
+
+test("a LINK failure heals on the reconnect-class event only: pushes make no attempt, and the box's structure never moves", async () => {
+  fetchCalls = 0;
+  const { P, box } = await armedBox();
+  const s0 = box.shape();
+  assert.match(s0, /path-full-wait/, "the wait persona is up after the first failure");
+  assert.match(s0, /connection dropped — retrying · tap to retry now/, "the first failure has no server text");
+  // the per-message heal makes ONE attempt (the budget's, this is not yet known to be a link failure)…
+  fetchAnswer = failWith(502, "tunnel to TESTHOST is not answering; re-dialing");
+  P.retryFailedPreviews();
+  await sleep(20);
+  assert.equal(fetchCalls, 1, "the attempt fetched once");
+  const boneAfterStart = box.bones();
+  await sleep(450);   // the retry beat (MIN_RETRY_SPIN_MS) before the failure is shown
+  const s1 = box.shape();
+  assert.equal(box.bones(), boneAfterStart, "the failed attempt kept every element: one wait, one swirl, one note");
+  assert.match(s1, /tunnel to TESTHOST is not answering; re-dialing — retries when the link is back · tap to retry now/, "the note carries the link's reason and says what will happen");
+  // …and now it IS a link failure: a streaming session pushing many messages makes NO further attempt and
+  // leaves the box byte-identical (no height change is possible without a DOM change → zero unitchange rows)
+  const before = fetchCalls;
+  for (let i = 0; i < 60; i++) { P.retryFailedPreviews(); if (i % 10 === 0) await sleep(5); }
+  await sleep(450);
+  assert.equal(fetchCalls, before, "sixty kernel messages, no attempt: the link's heal is the reconnect event");
+  assert.equal(box.shape(), s1, "the box did not change at all under the pushes");
+  // the reconnect-class event (romp:wsup / hostUp → refreshSettledPreviews) makes exactly one attempt…
+  P.refreshSettledPreviews();
+  await sleep(20);
+  assert.equal(fetchCalls, before + 1, "one attempt per reconnect");
+  assert.equal(box.bones(), boneAfterStart, "the running attempt kept the wait box and its note (no one-line 'fetching…' swap)");
+  assert.equal(box.shape(), s1, "the note's words stayed while the attempt ran");
+  await sleep(450);
+  assert.equal(box.shape(), s1, "the same failure again: nothing changed, not even the words");
+  // …and another reconnect after which the link works: the picture lands (the one legitimate layout change)
+  fetchAnswer = () => Promise.resolve({ status: 200, ok: true, headers: { get: (h: string) => (h === "Content-Length" ? "3" : null) },
+    body: { getReader: () => { let done = false; return { read: async () => done ? { done: true, value: undefined } : (done = true, { done: false, value: new Uint8Array([1, 2, 3]) }) }; } } });
+  (globalThis as any).URL = (globalThis as any).URL || {};
+  (globalThis as any).URL.createObjectURL = () => "blob:fake";
+  (globalThis as any).URL.revokeObjectURL = () => {};
+  (globalThis as any).Blob = class { constructor(public parts: any[], public opts: any) {} };
+  P.refreshSettledPreviews();
+  await sleep(30);
+  assert.match(box.shape(), /img\.path-full-img/, "the image replaced the wait box once the bytes arrived");
+});
+
+test("a NON-link failure keeps the bounded per-message budget, and even those attempts never change the structure", async () => {
+  fetchCalls = 0;
+  const { P, box } = await armedBox("/home/user/notes-api/plots/throughput.png");
+  fetchAnswer = failWith(404, "not found: the file is gone");
+  for (let round = 0; round < 3; round++) {
+    const calls = fetchCalls;
+    const before = box.shape();
+    P.retryFailedPreviews();
+    await sleep(20);
+    if (fetchCalls === calls) break;                  // the budget is spent: the settled chip took over
+    assert.equal(box.shape(), before, "attempt " + round + ": the wait box kept its elements AND its words while fetching (no one-line 'fetching…' swap)");
+    await sleep(450);
+  }
+  assert.match(box.shape(), /span\.path-full-retry\[\]\{"⚠ not found: the file is gone — tap to retry"\}/, "the budget spent on real verdicts settles on the tap chip");
+  // the settled chip's ONE new-evidence heal (the 2026-08-18 rule): pushes inside one beat make one attempt, and
+  // the chip keeps its shape while that attempt runs (the chip carries the words)
+  const settledBones = box.bones();
+  const calls = fetchCalls;
+  for (let i = 0; i < 30; i++) { P.retryFailedPreviews(); if (i % 10 === 0) await sleep(5); }
+  assert.equal(fetchCalls, calls + 1, "thirty pushes inside one beat: the one new-evidence heal, never one per push");
+  assert.equal(box.bones(), settledBones, "the chip kept its elements while the heal ran");
+  await sleep(450);
+  // that heal's failure is the last budgeted attempt: the chip carries the retrying words for one more cycle…
+  assert.match(box.shape(), /path-full-retry\[\]\{"not found: the file is gone — retrying · tap to retry now"\}/, "the chip carries the words: no new element, no swap");
+  P.retryFailedPreviews();
+  await sleep(470);
+  assert.equal(fetchCalls, calls + 2, "…which the next push spends");
+  assert.match(box.shape(), /span\.path-full-retry\[\]\{"⚠ not found: the file is gone — tap to retry"\}/, "the same verdict settles the chip again");
+  const settled = box.shape();
+  for (let i = 0; i < 30; i++) P.retryFailedPreviews();
+  await sleep(450);
+  assert.equal(fetchCalls, calls + 2, "the same verdict again is no new evidence: no further attempt");
+  assert.equal(box.shape(), settled, "and the chip does not move");
+  // a TAP re-arms the budget and brings the loading persona back at once: swirl + note, inside the same wait
+  const chip = box.querySelector("path-full-retry")!;
+  fetchAnswer = () => new Promise(() => {});          // an attempt that stays in flight
+  chip.onclick({ stopPropagation() {}, currentTarget: chip });
+  await sleep(20);
+  assert.match(box.shape(), /span\.path-full-wait\[\]\{img\.path-load-spin\[\]\{""\},span\.path-load-note\[\]\{"fetching…"\}\}/, "a tap shows the swirl and the note: the chip is the give-up state only");
+});
+
+test("the source keeps the two rules where the behaviour lives", () => {
+  assert.match(PREVIEW, /if \(transient\) settledPreviews\.set\(box, \(\) => build\(true\)\);\s*\n\s*else \{ autoRetries--; failedPreviews\.set\(box, \(\) => build\(true\)\); \}/,
+    "a link failure registers for the reconnect-class heal only; a real verdict spends the budget on the per-message heal");
+  assert.match(PREVIEW, /const waitBox = \(\): \{ wait: HTMLElement; note: HTMLElement \} => \{/, "one wait box reused across attempts");
+  assert.match(PREVIEW, /if \(autoRetries <= 1\) return \{ wait, note: chip \};\s*\n\s*chip\.remove\(\);/, "the chip carries the words for the one new-evidence heal; a re-armed budget gets the loading persona back");
+  // the PDF probe's 502 and a relay-URL markdown image wait for the reconnect-class heal too
+  assert.match(PREVIEW, /\(r\.status === 502 \? settledPreviews : failedPreviews\)\.set\(box, probe\);/);
+  assert.match(PREVIEW, /\(\/\\\/remote\\\/\[\^\/\]\+\\\/file\\b\/\.test\(src\) \? settledPreviews : failedPreviews\)\.set\(img, \(\) => \{/);
+  // a remote kernel's restart reopens the relay socket and fires neither romp:wsup nor hostUp: that event heals too
+  const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+  assert.match(RENDER, /window\.addEventListener\("romp:hostRelayUp", \(e\) => \{[\s\S]{0,600}?refreshSettledPreviews\(\);/);
+  assert.match(PREVIEW, /const \{ note \} = waitBox\(\);\s*\n\s*if \(!note\.textContent\) setNote\(note, got > 0 \? "resuming… "/, "an attempt keeps the note that is up");
+  assert.match(PREVIEW, /const setNote = \(note: HTMLElement, text: string\) => \{ if \(note\.textContent !== text\) note\.textContent = text; \};/, "the words change only when they do");
+});

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -450,8 +450,10 @@ export function previewFull(path: string, sid?: string | null, verified = false,
     // The hidden sentinel keeps the spot healable with zero visual noise when the mention really
     // is dead; a probe that later succeeds unhides the card in place.
     if (!verified) {
+      // a 502 is the relay's link verdict (HEAD carries no body to read): that one waits for the reconnect-class
+      // heal like an image's link failure (T291); any other miss keeps the per-message heal
       const probe = () => fetch(fileUrl(path, sid), { method: "HEAD" })
-        .then((r) => { if (r.ok) { box.style.display = ""; } else { box.style.display = "none"; failedPreviews.set(box, probe); } })
+        .then((r) => { if (r.ok) { box.style.display = ""; } else { box.style.display = "none"; (r.status === 502 ? settledPreviews : failedPreviews).set(box, probe); } })
         .catch(() => { box.style.display = "none"; failedPreviews.set(box, probe); });
       probe();
     }
@@ -482,6 +484,40 @@ export function previewFull(path: string, sid?: string | null, verified = false,
     let total = 0;
     let fetching = false;                            // one managed attempt at a time (a tap mid-fetch no-ops)
     let lastErr = "";                                // the newest attempt's server-side reason, shown verbatim
+    // The wait box is REUSED across attempts (T291, the user 2026-09-09: two figures on a remote session
+    // whose relay was failing re-attempted on every kernel push, and each attempt swapped the box between
+    // the one-line "fetching…" and the five-line failure note — the whole transcript above the reader
+    // moved by four lines, ten times a second, for the length of the streaming turn). One wait element,
+    // one swirl, one note, kept from attempt to attempt; only the note's TEXT changes, and only when the
+    // words do. An attempt therefore never changes the box's layout; the picture landing does.
+    const waitBox = (): { wait: HTMLElement; note: HTMLElement } => {
+      let wait = box.firstElementChild as HTMLElement | null;
+      if (!wait || !wait.classList.contains("path-full-wait")) wait = mkWait(box);
+      const chip = wait.querySelector(".path-full-retry") as HTMLElement | null;
+      if (chip) {
+        // the one new-evidence heal (autoRetries 1) keeps the chip's shape: the chip carries the words while it
+        // runs. A tap or a reconnect heal re-armed the budget (3): the loading persona returns, swirl and note,
+        // inside the same wait element (the 2026-08-16 rule: the chip is the give-up state only)
+        if (autoRetries <= 1) return { wait, note: chip };
+        chip.remove();
+      }
+      let spin = wait.querySelector(".path-load-spin") as HTMLImageElement | null;
+      if (!spin) {
+        spin = document.createElement("img");
+        spin.className = "path-load-spin";
+        spin.src = "/media/romp-swirl-glyph.svg";
+        spin.alt = "loading preview…";
+        wait.appendChild(spin);
+      }
+      let note = wait.querySelector(".path-load-note") as HTMLElement | null;
+      if (!note) {
+        note = document.createElement("span");
+        note.className = "path-load-note";
+        wait.appendChild(note);
+      }
+      return { wait, note };
+    };
+    const setNote = (note: HTMLElement, text: string) => { if (note.textContent !== text) note.textContent = text; };
     const showChip = () => {
       if (!box.isConnected) return;                  // the turn re-rendered; a fresh box owns this spot now
       // ONE continuous narrative while the machinery is still going (the user 2026-08-16, third
@@ -495,26 +531,26 @@ export function previewFull(path: string, sid?: string | null, verified = false,
       // kernel restart — the tunnel re-dial window produces instant "no attached host" 404s and
       // "tunnel not answering" 502s, and three of those spent the whole budget right before the link
       // came back). A failure that names the LINK, not the image, doesn't decrement: the preview
-      // keeps retrying on every kernel push until the tunnel is up, and only real verdicts — a true
-      // not-found from the owning kernel, a transfer that died with zero progress — spend attempts.
+      // re-attempts when the link itself comes back (the reconnect-class heal below, T291), and only
+      // real verdicts — a true not-found from the owning kernel, a transfer that died with zero
+      // progress — spend attempts.
       const transient = /tunnel to .* is not answering|no attached host|re-dialing/i.test(lastErr);
       if (autoRetries > 0 || transient) {
-        if (!transient) autoRetries--;
-        failedPreviews.set(box, () => build(true));
-        const wait = mkWait(box);
+        // A LINK failure heals on the reconnect-class event alone (T291): romp:wsup when this page's
+        // kernel socket comes back, hostUp when the federated tunnel does (the tunnel poll dispatches
+        // it on the down→up transition), romp:hostRelayUp when the host's relay socket reopens (a
+        // remote kernel's restart fires that one and neither of the others), never on the next kernel push. A streaming session pushes
+        // many times a second, and a dead link answered every one of those instantly: the per-push
+        // retry was the flicker. The budget stays untouched, as before; the tap still retries at once.
+        if (transient) settledPreviews.set(box, () => build(true));
+        else { autoRetries--; failedPreviews.set(box, () => build(true)); }
+        const { wait, note } = waitBox();
         wait.title = path + " — tap to retry now";
         wait.style.cursor = "pointer";
         wait.onclick = (ev) => { ev.stopPropagation(); autoRetries = 3; ackTap(ev); build(true); };   // a tap re-arms persistence
-        const spin = document.createElement("img");
-        spin.className = "path-load-spin";
-        spin.src = "/media/romp-swirl-glyph.svg";
-        spin.alt = "loading preview…";
-        const note = document.createElement("span");
-        note.className = "path-load-note";
-        note.textContent = (got > 0 ? "connection dropped at " + fmtBytes(got, total)
-                                    : lastErr || "connection dropped")
-                           + " — retrying · tap to retry now";
-        wait.append(spin, note);
+        setNote(note, (got > 0 ? "connection dropped at " + fmtBytes(got, total)
+                               : lastErr || "connection dropped")
+                      + (transient ? " — retries when the link is back · tap to retry now" : " — retrying · tap to retry now"));
         if (fails > 1) {
           note.classList.add("path-retry-flash");
           note.addEventListener("animationend", () => note.classList.remove("path-retry-flash"), { once: true });
@@ -645,15 +681,10 @@ export function previewFull(path: string, sid?: string | null, verified = false,
       if (fetching) return;
       fetching = true;
       const started = Date.now();
-      const wait = mkWait(box);
-      const spin = document.createElement("img");
-      spin.className = "path-load-spin";
-      spin.src = "/media/romp-swirl-glyph.svg";
-      spin.alt = "loading preview…";
-      const note = document.createElement("span");
-      note.className = "path-load-note";
-      note.textContent = got > 0 ? "resuming… " + fmtBytes(got, total) : "fetching…";
-      wait.append(spin, note);
+      // the wait box stays as it is while the attempt runs (T291): a note already up keeps its words, so a
+      // retry from a failure note does not shrink the box to one line and grow it back on the next failure
+      const { note } = waitBox();
+      if (!note.textContent) setNote(note, got > 0 ? "resuming… " + fmtBytes(got, total) : "fetching…");
       resumeFetch(note).then((objUrl) => {
         fetching = false;
         lastErr = "";
@@ -718,7 +749,9 @@ export function installMdImgHeal(): void {
     const src = img.src || "";
     if (!src || src.startsWith("data:")) return;     // a broken data: URI has no server to heal
     if (img.onerror || img.closest(".path-full")) return;   // the preview machinery retries its own
-    failedPreviews.set(img, () => {
+    // a relay URL (fileUrl builds /remote/<host>/file for a remote sid) failed on the LINK's account as
+    // likely as the image's: it waits for the reconnect-class heal (T291); a local src keeps the per-message one
+    (/\/remote\/[^/]+\/file\b/.test(src) ? settledPreviews : failedPreviews).set(img, () => {
       const u = img.src;
       img.removeAttribute("src");
       img.src = u;                                   // a fresh attempt; a repeat error re-registers here

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -13434,6 +13434,10 @@ window.addEventListener("romp:wsup", () => {
 window.addEventListener("romp:hostRelayUp", (e) => {
   const h = String((((e as CustomEvent).detail || {}) as any).host || "");
   if (h) reshipPendingUploads([h]);
+  // …and the figure previews parked on that host's link (T291): the relay socket's open is the reconnect-class
+  // event a remote kernel's restart produces (it fires neither romp:wsup nor hostUp), so settled previews
+  // make their one attempt here as well
+  refreshSettledPreviews();
   // …and the tab this pane is LOOKING AT, when that host owns it (T246, the user 2026-09-07): the relay's
   // open is the moment the remote kernel holds a FRESH client for this pane — after that kernel restarted,
   // one with no active tab at all. Its pusher keys only a client's active tab on the live change key (the


### PR DESCRIPTION
The chat transcript flickered on a remote session viewed through a failing relay (the user, 2026-09-09, on the laptop: the whole visible transcript shifted by about a hundred pixels and back, many times a second, for the length of a streaming turn). The scroll journal's `unitchange` rows named it: two assistant turns changing height by five and three text lines in step, up to ten times a second, with the thread's height flapping by their sum and Chrome's anchoring shifting the reader's text by the difference. Both turns hold a figure preview whose fetch fails through the relay.

**Root cause** (`ui/webview/preview.ts`, `previewFull`). A fetch failure whose text names the LINK ("tunnel to … is not answering", "no attached host", "re-dialing") was classed transient and retried for free on every kernel message (render.ts calls `retryFailedPreviews()` on each incoming message; a streaming session pushes per SDK event). Each attempt swapped the box's content: the managed attempt painted a fresh one-line "fetching…" wait, the instant failure painted a fresh multi-line "<reason> — retrying · tap to retry now" note, and the next message started over. Two layouts, alternating at the push rate, under a reader scrolled up.

**Fix, two parts, no new heuristic.**
- A link failure heals on the reconnect-class event only: `romp:wsup` when this page's kernel socket comes back, `hostUp` when the federated tunnel does (the tunnel poll already dispatches it on the down-to-up transition). It registers in `settledPreviews`, never in the per-message `failedPreviews`; the budget stays untouched as before, the tap still retries at once. A real verdict (a true not-found, a transfer that died with no progress) keeps the bounded per-message budget it always had.
- An attempt never changes the box's layout: one wait element, one swirl, one note, reused from attempt to attempt (`waitBox`); only the note's words change, and only when they do (`setNote`). A retry from a failure note no longer shrinks the box to one line and grows it back; a settled chip keeps its shape through its one new-evidence heal (the chip carries the words while the attempt runs).

**Pinned** (`ui/webview/preview-retry-pace.test.ts`, executed over a minimal fake DOM and a stubbed fetch, driving the entry points the way render.ts calls them): after a link failure, sixty kernel messages make no attempt and leave the box byte-identical (no DOM change, so no height change and no `unitchange` row); one reconnect event makes exactly one attempt, and the box's elements and words are unchanged while it runs and after the same failure; a later reconnect with the link up lands the picture; a non-link failure spends its bounded budget on the per-message heal with the wait box's elements unchanged across attempts, then settles on the tap chip, which pushes do not move either. The inline-preview pins follow the new branch and the reused note.

**From the adversarial review, folded in before arming.** The settled chip carries the words only for its one new-evidence heal; a tap or a reconnect heal, which re-arm the budget, bring the loading persona back (swirl and note, inside the same wait element), so the chip stays the give-up state alone. The link note says what will happen ("retries when the link is back · tap to retry now") instead of promising a retry it does not schedule. A remote kernel's restart reopens the relay socket and fires neither `romp:wsup` nor `hostUp`, so the relay-reopen event (`romp:hostRelayUp`) now drains the settled previews too. The PDF card's probe treats a 502 as the link's verdict and a markdown image on a relay URL waits for the reconnect-class heal likewise, so no path re-fetches through a dead relay on every push. Tests are text-sensitive per attempt, isolated per test, and pin the tap's persona and the relay-reopen heal.

**Residual, stated.** A relay failure while the tunnel row never leaves "up" (a request that timed out mid-transfer and the supervisor's next poll answered) has no reconnect-class event; the box waits for a tap, the next reconnect, or the turn's re-render. A kernel-side recovery counter on the tunnel row would close that gap; it is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
