### PR TITLE
Spend: the connect-time scan for the last cost-state record reads a long transcript line in linear time

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -821,7 +821,7 @@ def cost_state_watermarks(o):
     return {"total": float(total), "tokens": tokens}
 
 
-def last_cost_state(path, scan_bytes: int = 8 << 20):
+def last_cost_state(path, scan_bytes: int = 8 << 20, max_line: int = 4 << 20):
     """The resumed transcript's LAST `cost-state` record, as the watermarks a CLI that restores it would
     hold (cost_state_watermarks), or None when the file has no such record or cannot be read.
 
@@ -841,45 +841,66 @@ def last_cost_state(path, scan_bytes: int = 8 << 20):
     restores nothing. The /clear saver runs before the rotation, so the SECOND and later /clear in one
     process appends a record to the conversation that /clear abandons; the conversation romp resumes
     (the reg's lastSid, the current one) never carries one. So every seed today reads zero, and the
-    CLI's counters start at zero on the same resume: the two agree. The one way a record reaches a
-    resumed file is a lastSid left on an abandoned conversation (the kernel dying between the saver's
-    write and the init flip); the print-mode CLI still starts at zero there, and the shrunken-counter
-    rule records the first turn whole while its own total sits below the seed. The residual: a first
+    CLI's counters start at zero on the same resume: the two agree. A record reaches a resumed file two
+    ways: a lastSid left on an abandoned conversation (the kernel dying between the saver's write and
+    the init flip), and a transcript the interactive CLI wrote (its writer runs from startup) that romp
+    later resumes; the print-mode CLI still starts at zero in both, and the shrunken-counter rule
+    records the first turn whole while its own total sits below the seed. The residual: a first
     turn costlier than the whole recorded history is under-counted by the seed, and the same holds per
     token field (_turn_usage diffs each field on its own), so a first turn whose count in one field
     exceeds the recorded history's is under-counted in that field.
 
-    Scans BACKWARDS in 64 KB chunks (a line split by a chunk edge is carried into the earlier chunk and
-    reassembled) and stops at the first hit, so a transcript that carries the record costs a chunk or
-    two. The scan is BOUNDED to the last `scan_bytes` (8 MB by default; last_record_uuid's tail read has
-    the same reason: a transcript can be tens of MB and this runs on the event loop at every connect):
-    a record older than that is treated as absent, which is the answer the print-mode CLI gives for its
-    own counters today (it restores nothing), so the two sides still agree (review find, 2026-09-09)."""
+    Scans BACKWARDS in 64 KB chunks and stops at the first hit, so a transcript that carries the record
+    costs a chunk or two. A line split across chunks is reassembled ONCE, when the scan reaches the
+    newline before it: its pieces are kept in a list as the chunks arrive and joined there, so each byte
+    read is copied a fixed number of times however long the line is (concatenating the carried fragment
+    onto every chunk copied it once per chunk, quadratic in the line; review find, 2026-09-09). A line
+    longer than `max_line` (4 MB by default) is not a record, since a record is under 1 KB: its pieces
+    are dropped as they arrive and the line is skipped unjoined, which also bounds the memory the scan
+    holds by the cap rather than by the line. The scan is BOUNDED to the last `scan_bytes` (8 MB by
+    default; last_record_uuid's tail read has the same reason: a transcript can be tens of MB and this
+    runs on the event loop at every connect): a record older than that is treated as absent, which is
+    the answer the print-mode CLI gives for its own counters today (it restores nothing), so the two
+    sides still agree (review find, 2026-09-09); the line the bound cuts through is a fragment and is
+    never joined."""
     marker = b'"cost-state"'
     try:
         with open(path, "rb") as f:
             f.seek(0, os.SEEK_END)
             pos = f.tell()
             floor = max(0, pos - int(scan_bytes))   # the oldest byte the bounded scan may reach
-            carry = b""
+            frags = []          # the pieces read so far of the line the last chunk opened with, in file
+            #                     order (each chunk read is earlier in the file than the one before)
+            carried = 0         # that line's length so far, counted whether or not its pieces are kept: past
+            #                     max_line the line is not a record, so its pieces are dropped as they
+            #                     arrive and the line is skipped without a join
             while pos > floor:
                 step = min(pos - floor, 1 << 16)
                 pos -= step
                 f.seek(pos)
-                chunk = f.read(step) + carry    # carry: the later chunk's first-line fragment, which this
-                #                                 chunk's last line continues into
-                head, nl, body = chunk.partition(b"\n")
-                if pos > 0:
-                    carry = head                # this chunk's first line is a fragment that completes in the
-                    #                             earlier chunk, so it travels there whole
-                    if not nl:
-                        continue                # no line boundary in this chunk at all
+                parts = f.read(step).split(b"\n")   # leading piece, complete lines, trailing piece; ONE
+                #                                      element when the chunk holds no newline at all
+                lines = []                          # the lines this chunk completes, newest first
+                if len(parts) > 1:
+                    # the carried line begins after this chunk's last newline: its pieces are joined here
+                    if carried + len(parts[-1]) <= max_line:
+                        lines.append(b"".join([parts[-1]] + frags))
+                    lines.extend(reversed(parts[1:-1]))
+                    frags, carried = [], 0
+                if pos == 0:
+                    # the file's head: the leading piece is the start of the carried line, or all of it
+                    if carried + len(parts[0]) <= max_line:
+                        lines.append(b"".join([parts[0]] + frags))
                 else:
-                    carry, body = b"", chunk    # the file's head: every line here is complete
-                if marker not in body:
-                    continue
-                for line in reversed(body.split(b"\n")):
-                    if marker not in line:
+                    # the leading piece continues into the earlier chunk: carried, not copied, while the
+                    # line is short enough to be a record
+                    carried += len(parts[0])
+                    if carried <= max_line:
+                        frags.insert(0, parts[0])
+                    else:
+                        frags = []
+                for line in lines:
+                    if len(line) > max_line or marker not in line:
                         continue
                     try:
                         rec = cost_state_watermarks(json.loads(line))
@@ -3902,7 +3923,9 @@ class SdkSession:
         #   the bundle: the result event's total_cost_usd sits beside total_duration/lines counters),
         #   so spend folds the DELTA between results — folding the raw value re-added the whole
         #   session-so-far cost every turn (the user 2026-08-08, whose spend line was fiction). Reset
-        #   at each connect: a fresh CLI process starts its counter at zero.
+        #   at each connect to what the CLI process it starts holds: zero for a fresh process, or the
+        #   totals of the resumed transcript's last cost-state record when it carries one
+        #   (_seed_spend_watermarks, last_cost_state).
         self._last_usage_totals = {}  # the TOKEN watermarks — kept against the result's `model_usage`
         #   map (the CLI's modelUsage), the per-model counter the CLI documents as cumulative like
         #   total_cost_usd, same lifecycle, so each field folds as a delta exactly like the dollars.

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -17,6 +17,7 @@ import os
 import json
 import threading
 import time
+import tracemalloc
 import tempfile
 import unittest
 from contextlib import redirect_stderr
@@ -3373,6 +3374,166 @@ class SpendRecord(unittest.TestCase):
         self.assertIsNone(sb.last_cost_state(str(p)))
         p.write_text(filler + "\n")
         self.assertIsNone(sb.last_cost_state(str(p)), "no record: None, never a zero seed")
+
+    def _reads_through_a_stand_in(self, chunk_type=bytes):
+        """Route the module's `open` through a stand-in file object for this test: it records the length
+        of each read and hands the bytes back as `chunk_type`, so a test can see how the scan reads the
+        file and, with a bytes subclass, what the scan does to what it read. Restored at tearDown."""
+        reads, real_open = [], open
+
+        class Reader:
+            def __init__(self, f): self.f = f
+            def __enter__(self): return self
+            def __exit__(self, *exc): return self.f.__exit__(*exc)
+            def seek(self, *a): return self.f.seek(*a)
+            def tell(self): return self.f.tell()
+            def read(self, n=-1):
+                b = self.f.read(n)
+                reads.append(len(b))
+                return chunk_type(b)
+
+        patch = mock.patch.object(sb, "open", lambda p, *a, **k: Reader(real_open(p, *a, **k)), create=True)
+        patch.start()
+        self.addCleanup(patch.stop)
+        return reads
+
+    @staticmethod
+    def _line_of(length, **fields):
+        """A JSON line of exactly `length` bytes: `fields`, then a `pad` of x's that makes up the length."""
+        bare = json.dumps({**fields, "pad": ""})
+        return json.dumps({**fields, "pad": "x" * (length - len(bare))})
+
+    def _record_line(self, total, length, mu):
+        """A record-shaped line of exactly `length` bytes: last_cost_state takes it when it is short enough."""
+        return self._line_of(length, type="cost-state", sessionId=self._FSID, totalCostUSD=total, modelUsage=mu)
+
+    def test_last_cost_state_reassembles_a_long_line_and_finds_the_record_before_it(self):
+        """A transcript line is one JSON record, and a tool result can make one several MB long. The
+        scan walks such a line back to its first byte in 64 KB reads, covering the bounded tail once
+        and nothing more, reassembles it, and takes the record before it."""
+        p = Path(self._private_dir()) / "t.jsonl"
+        mu = {"m": {"inputTokens": 7, "outputTokens": 3}}
+        long_line = json.dumps({"type": "user", "uuid": "u", "message": {"role": "user", "content": "x" * (3 << 20)}})
+        after = json.dumps({"type": "last-prompt", "lastPrompt": "x"})
+        p.write_text(self._cost_state(2.25, mu) + "\n" + long_line + "\n" + after + "\n")
+        reads = self._reads_through_a_stand_in()
+        self.assertEqual(sb.last_cost_state(str(p))["total"], 2.25)
+        size = p.stat().st_size
+        self.assertEqual(sum(reads), size, "the whole file, under the 8 MB bound, is read once")
+        self.assertEqual(len(reads), -(-size // (1 << 16)), "in chunks of 64 KB, the head chunk shorter")
+        self.assertLessEqual(max(reads), 1 << 16)
+
+    def test_the_bound_reads_the_same_tail_and_drops_the_line_it_cuts_through(self):
+        """The scan reads the last `scan_bytes` of the file and nothing before them: a record older than
+        that is absent, and the line the bound cuts through is a fragment, never joined, so a record
+        whose first byte the bound lands on is absent too, and found once the bound reaches the newline
+        before it. This held before the pieces were collected in a list and holds after: a guard on the
+        range read."""
+        p = Path(self._private_dir()) / "t.jsonl"
+        mu = {"m": {"inputTokens": 7, "outputTokens": 3}}
+        filler = json.dumps({"type": "user", "uuid": "u", "message": {"role": "user", "content": "x" * 900}})
+        bound = 3 << 16
+        rec = self._cost_state(2.25, mu)
+        p.write_text(rec + "\n" + (filler + "\n") * 300)          # about 290 KB after the record
+        reads = self._reads_through_a_stand_in()
+        self.assertIsNone(sb.last_cost_state(str(p), scan_bytes=bound), "older than the bound: absent")
+        self.assertEqual(sum(reads), bound, "the last scan_bytes of the file, and no more")
+        # the bound lands exactly on the record's first byte: the record is the cut line, a fragment; one
+        # byte more reaches the newline before it, and the record is a whole line again
+        tail = self._line_of(bound - len(rec) - 2, type="user", uuid="u", message={"role": "user"})
+        p.write_text((filler + "\n") * 5 + rec + "\n" + tail + "\n")
+        self.assertIsNone(sb.last_cost_state(str(p), scan_bytes=bound))
+        self.assertEqual(sb.last_cost_state(str(p), scan_bytes=bound + 1)["total"], 2.25)
+
+    def test_a_line_longer_than_the_cap_is_not_a_record_and_the_earlier_record_wins(self):
+        """A cost-state record is under 1 KB. A line longer than last_cost_state's cap (4 MB) is skipped
+        without being reassembled, even when its text would parse as a record: the record before it
+        wins, and with none before it the answer is None, as for a file that has no record. The rule is
+        exact on the length, and the same for a line the scan reassembles from the pieces of many chunks
+        as for one whole inside a chunk: a line AT the cap is still a record, joined from its pieces in
+        file order, and one byte longer is skipped."""
+        p = Path(self._private_dir()) / "t.jsonl"
+        mu = {"m": {"inputTokens": 7, "outputTokens": 3}}
+        filler = json.dumps({"type": "user", "uuid": "u", "message": {"role": "user", "content": "x" * 900}})
+        cap = 4 << 20
+        huge = self._record_line(7.0, cap + (1 << 20), mu)        # record-shaped, well past the cap
+        p.write_text(self._cost_state(1.0, mu) + "\n" + huge + "\n")
+        self.assertEqual(sb.last_cost_state(str(p))["total"], 1.0, "the line past the cap is not a record")
+        p.write_text(huge + "\n")
+        self.assertIsNone(sb.last_cost_state(str(p)), "skipped without an exception; no record remains")
+        p.write_text(huge)                                    # the too-long line is the file's head, unterminated
+        self.assertIsNone(sb.last_cost_state(str(p)))
+        p.write_text(huge + "\n" + self._cost_state(3.0, mu) + "\n")
+        self.assertEqual(sb.last_cost_state(str(p))["total"], 3.0, "a record after it is taken as usual")
+        # exactly the cap, spanning about 65 chunks between two other lines: a record, reassembled from its
+        # pieces in file order (out of order it would not parse); one byte longer: skipped, and the record
+        # before it wins
+        for length, total in ((cap, 2.5), (cap + 1, 1.0)):
+            p.write_text(self._cost_state(1.0, mu) + "\n" + self._record_line(2.5, length, mu) + "\n" + filler + "\n")
+            self.assertEqual(sb.last_cost_state(str(p))["total"], total, f"a line of {length} bytes")
+        # the cap is the parameter. A record-shaped line the scan carries in three pieces, one per chunk
+        # (it begins on a chunk edge: the file's tail from its first byte is three chunks exactly), is a
+        # record at a cap of its own length and skipped at one byte less, where the record before it wins
+        three = self._record_line(6.0, 3 * (1 << 16) - 1, mu)
+        p.write_text(self._cost_state(1.0, mu) + "\n" + three + "\n")
+        self.assertEqual(sb.last_cost_state(str(p), max_line=len(three))["total"], 6.0)
+        self.assertEqual(sb.last_cost_state(str(p), max_line=len(three) - 1)["total"], 1.0)
+        # and for a line the scan never carries: the head piece alone in the file, and a line whole inside a
+        # chunk between two others
+        rec = self._cost_state(2.0, mu)
+        for text in (rec + "\n", filler + "\n" + rec + "\n" + filler + "\n"):
+            p.write_text(text)
+            self.assertEqual(sb.last_cost_state(str(p), max_line=len(rec))["total"], 2.0)
+            self.assertIsNone(sb.last_cost_state(str(p), max_line=len(rec) - 1))
+
+    def test_the_scan_copies_a_line_once_and_holds_at_most_the_cap_however_long_the_line(self):
+        """Linear by construction, pinned without a clock. The pieces of a line are collected as the
+        chunks arrive and joined once at the newline that opens the line, so no chunk is ever
+        concatenated onto the carried fragment (that copied the fragment again on every chunk, a cost
+        quadratic in the line). A line past the cap is dropped as it arrives, so on such a line the scan
+        holds at most the cap plus a few chunks at any moment; a reader that keeps the line, or re-copies
+        it per chunk, peaks at one to three times the 7 MB line here. A line one byte past the cap is
+        never joined either, though every piece of it was kept: joined, it would be held twice."""
+        p = Path(self._private_dir()) / "t.jsonl"
+        mu = {"m": {"inputTokens": 7, "outputTokens": 3}}
+        filler = json.dumps({"type": "user", "uuid": "u", "message": {"role": "user", "content": "x" * 900}})
+        adds = []
+
+        class Chunk(bytes):
+            """What the scan read, watching for a concatenation onto it."""
+            def __add__(self, other): adds.append(len(self) + len(other)); return bytes(self) + other
+            def __radd__(self, other): adds.append(len(self) + len(other)); return other + bytes(self)
+
+        reads = self._reads_through_a_stand_in(Chunk)
+
+        def scan():
+            """The scan's answer and the process's growth in bytes over it, measured from what the process
+            held as the scan began (a tracer already running, PYTHONTRACEMALLOC, then adds nothing)."""
+            tracing = tracemalloc.is_tracing()
+            if not tracing:
+                tracemalloc.start()
+            try:
+                tracemalloc.reset_peak()
+                held = tracemalloc.get_traced_memory()[0]
+                rec = sb.last_cost_state(str(p))
+                return rec, tracemalloc.get_traced_memory()[1] - held
+            finally:
+                if not tracing:
+                    tracemalloc.stop()
+
+        big = json.dumps({"type": "user", "uuid": "u", "message": {"role": "user", "content": "x" * (7 << 20)}})
+        p.write_text(self._cost_state(2.25, mu) + "\n" + big + "\n" + filler + "\n")
+        rec, peak = scan()
+        self.assertEqual(rec["total"], 2.25, "the record before the 7 MB line is found")
+        self.assertEqual(sum(reads), p.stat().st_size, "the range read is the same bounded tail")
+        self.assertEqual(adds, [], "no chunk is concatenated onto: a line's pieces are joined once")
+        self.assertLess(peak, (4 << 20) + (2 << 20), "held: the 4 MB cap plus chunks, never the 7 MB line")
+        over = self._record_line(7.0, (4 << 20) + 1, mu)
+        p.write_text(self._cost_state(2.25, mu) + "\n" + over + "\n" + filler + "\n")
+        rec, peak = scan()
+        self.assertEqual(rec["total"], 2.25, "one byte past the cap: not a record")
+        self.assertEqual(adds, [])
+        self.assertLess(peak, (4 << 20) + (2 << 20), "held: its pieces, and no joined line beside them")
 
     def test_a_first_result_after_connect_above_the_single_turn_mark_is_recorded_and_traced_as_info(self):
         """On the CLI as probed a resumed process starts its cost counters at zero, so a first delta above


### PR DESCRIPTION
Follows #1200 (merged), which seeds the spend watermarks at connect from the transcript's last cost-state record. The review record on that PR found the reader's cost quadratic in the length of a transcript line and named two docstring corrections; this PR makes those changes.

## Symptom

A resumed session's connect gets slower with the length of the longest line in the scanned part of its transcript, beyond the cost of the bytes scanned. Within the 8 MB bound the reader walks one long line in about a hundred 64 KB steps and copies the line so far at each step, on the event loop: a 7 MB line costs about a hundred growing copies and holds three copies of the line at its peak (21 MB measured). A transcript line is one JSON record, and a tool result can make one several MB long.

## Cause

`last_cost_state` reads backwards in 64 KB chunks and carries the fragment a chunk begins with into the earlier chunk by concatenation (`f.read(step) + carry`). The concatenation copies the whole carried fragment on every step, so a line spanning n chunks costs n copies of growing length, and the `partition` on the result copies the line once more.

## Fix

The reader keeps the pieces of the carried line in a list and joins them once, when it reaches the newline before the line, so each byte read is copied a fixed number of times. A line longer than 4 MB (`max_line`, a new keyword with that default; a record is under 1 KB) is not a record: the pieces of it past the cap are dropped as they arrive and the line is skipped without a join, so on such a line the scan holds at most the cap plus a chunk (4.07 MB on the same 7 MB line; 4.01 MB on a line one byte past the cap, whose pieces all fit under the cap and are still not joined). A record-shaped line just under the cap is joined and parsed as before and held about three times over at that moment, bounded by the cap. The state is a list of pieces and one running length: past the cap the length keeps counting while the pieces are dropped, and every join checks the length, so no separate flag is needed. The range of bytes read, the 8 MB `scan_bytes` bound and its floor are unchanged, and so are the answers: the last valid record wins, an unusable one is skipped, the line the bound cuts through is dropped as before, and a line longer than the cap is skipped wherever it sits. `_turn_usage` and the settle are untouched. The module's other backwards reader, `_lines_from_end`, keeps its per-block concatenation: its caller reads the last line and stops, so it is left alone here.

The two docstring corrections: `last_cost_state` names the second way a record reaches a resumed file (a transcript the interactive CLI wrote, whose writer runs from startup, that romp later resumes, with the same under-count), and the `_last_cost_total` comment says the connect seeds the watermark from that record rather than resetting it to zero.

## Tests

All in `tests/test_sdk_backend.py`, class `SpendRecord`, over the real `last_cost_state`. Three of them route the module's `open` through a stand-in file object that records each read and hands the bytes back; the patch is undone at tearDown.

- `test_last_cost_state_reassembles_a_long_line_and_finds_the_record_before_it`: a record, then a 3 MB line with no newline, then a trailer. The record is found; the reads sum to the file size, one read per 64 KB and none longer. Passes before the change too: it pins that the range read does not change.
- `test_the_bound_reads_the_same_tail_and_drops_the_line_it_cuts_through`: with `scan_bytes` at three chunks, a record followed by about 290 KB reads as absent and the reads sum to exactly `scan_bytes`; a file whose floor lands on a record's first byte reads as absent (the cut line is a fragment) and, with the bound one byte larger, yields that record. Passes before the change too: a guard on the bound, since the leftover pieces at the floor are what this change drops where the old reader dropped its carry.
- `test_a_line_longer_than_the_cap_is_not_a_record_and_the_earlier_record_wins`: a record-shaped line of 5 MB is skipped and the record before it wins; alone, or unterminated at the file's head, it yields None with no exception; a record after it is found. A record-shaped line of exactly 4 MB between two other lines (about 65 chunks) is found with its total, which pins the order the pieces are joined in (out of order it would not parse), and one byte longer it is skipped for the record before it. With `max_line` set to the length of a record-shaped line the scan carries in three pieces, that line is found, and at one byte less the earlier record wins; the same pair for a line whole inside a chunk and for the head piece alone in the file. Fails before the change on `7.0 != 1.0`: the old reader joins the whole line and takes it.
- `test_the_scan_copies_a_line_once_and_holds_at_most_the_cap_however_long_the_line`: over a record and a 7 MB line, the stand-in hands back a bytes subclass that records any concatenation onto it, and `tracemalloc` measures the process's growth over the scan, from what it held as the scan began (so a tracer already running, `PYTHONTRACEMALLOC`, adds nothing). The new reader records no concatenation and peaks under 6 MB (4.07 MB measured); a line one byte past the cap peaks the same (4.01 MB), which pins that the join is refused rather than made and discarded. The old reader fails on 113 recorded concatenations growing from 65536 bytes, and peaks at 21 MB. No timing assertion.

The existing chunk-edge test keeps passing. `tests/test_sdk_backend.py`: 245 passed, 35 skipped. Full suite (`pytest -q -n 8 tests/`): 10202 passed, 61 skipped, 1671 subtests passed, no failures, in 85 s.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)