### PR TITLE
Comments: a remote session's comment is named by the owning kernel, never by the viewer's decorated prefill

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13468,6 +13468,67 @@ def _comment_markers(sid):
 ANCHOR_LAG_ERR = "that message isn't in the transcript yet; try again in a moment"
 _parked_creates = []                       # [{sid,uuid,exact,text,name,model,effort,fast,color,tries}]
 _PARK_MAX_TRIES = 30                       # pusher cycles (~15-90s) — past this the record isn't coming
+# A create's IDENTITY (T289): (parent sid, anchor uuid, passage, text) -> the thread it made. A lag-parked
+# create is retried by BOTH the pusher (above) and the client (its frame-keyed re-post), and a popover
+# whose ack was lost sends its create again; the second copy used to collide on its explicit name and
+# come back as the create door's refusal toast (the user 2026-09-09, on a remote session), or — with the
+# name now left to the kernel's default — would mint a SECOND thread for one comment. The memo answers a
+# repeat with the SAME thread's ack, and a parked copy is parked once. Bounded (oldest out), in memory:
+# a kernel restart forgets it, and the client's re-post after one creates exactly once.
+_recent_creates = {}                       # (sid, uuid, exact, text) -> tid
+_RECENT_CREATES_MAX = 256
+# The two doors that can run one create — the WS handler on a server thread and _retry_parked_creates on
+# the pusher — reserve the identity under ONE lock before creating (review, 2026-09-09): the pusher sends
+# the chat frame before it retries parked creates, the client re-posts on that very frame, and with no
+# reservation both copies ran _comment_create before either was noted, minting twins (or, under an
+# explicit name, the create door's refusal the branch set out to remove). RLock: the helpers below take
+# it and so do their callers' compound steps.
+_create_lock = threading.RLock()
+_inflight_creates = set()                  # keys whose _comment_create is running right now, either door
+
+
+def _create_key(sid, uuid, exact, text):
+    return (str(sid), str(uuid), str(exact), str(text))
+
+
+def _note_create(key, tid):
+    with _create_lock:
+        _recent_creates[key] = tid
+        while len(_recent_creates) > _RECENT_CREATES_MAX:
+            _recent_creates.pop(next(iter(_recent_creates)), None)
+
+
+def _repeat_create_tid(key):
+    """The OPEN thread an identical create already made, else None. A resolved, merged or promoted thread
+    cannot take a message, so a same-worded comment after that is a new comment, never a swallowed repeat
+    (review, 2026-09-09); a deleted one is gone from the store and the memo forgets it."""
+    with _create_lock:
+        tid = _recent_creates.get(key)
+        row = _comment_thread(key[0], tid) if tid else None
+        if row and (row.get("status") or "open") == "open":
+            return tid
+        _recent_creates.pop(key, None)
+        return None
+
+
+def _reserve_create(key):
+    """Claim one create's identity for the caller, atomically: ("repeat", tid) when the same comment was
+    already made and its thread is open; ("busy", None) when another door is creating or holding it parked
+    right now; ("free", None) after marking it in flight — the caller must _release_create in a finally."""
+    with _create_lock:
+        again = _repeat_create_tid(key)
+        if again:
+            return "repeat", again
+        if key in _inflight_creates or any(_create_key(pk["sid"], pk["uuid"], pk["exact"], pk["text"]) == key
+                                           for pk in _parked_creates):
+            return "busy", None
+        _inflight_creates.add(key)
+        return "free", None
+
+
+def _release_create(key):
+    with _create_lock:
+        _inflight_creates.discard(key)
 
 
 def _retry_parked_creates():
@@ -13479,13 +13540,29 @@ def _retry_parked_creates():
     if not _parked_creates:
         return
     for pk in list(_parked_creates):
+        key = _create_key(pk["sid"], pk["uuid"], pk["exact"], pk["text"])
+        with _create_lock:
+            if _repeat_create_tid(key):            # the client's re-post already made it: the park is moot
+                if pk in _parked_creates:
+                    _parked_creates.remove(pk)
+                continue
+            if key in _inflight_creates:           # the WS door is creating it this instant: not twice
+                continue
+            _inflight_creates.add(key)
         pk["tries"] += 1
-        err, tid = _comment_create(pk["sid"], pk["uuid"], pk["exact"], pk["text"], name=pk["name"],
-                                   model=pk["model"], effort=pk["effort"], fast=pk.get("fast", ""),
-                                   color=pk["color"])
-        if err == ANCHOR_LAG_ERR and pk["tries"] < _PARK_MAX_TRIES:
-            continue
-        _parked_creates.remove(pk)
+        try:
+            err, tid = _comment_create(pk["sid"], pk["uuid"], pk["exact"], pk["text"], name=pk["name"],
+                                       model=pk["model"], effort=pk["effort"], fast=pk.get("fast", ""),
+                                       color=pk["color"])
+            with _create_lock:                     # note BEFORE the park is dropped: no gap where the
+                if not err:                        # identity is neither parked nor noted
+                    _note_create(key, tid)
+                if err == ANCHOR_LAG_ERR and pk["tries"] < _PARK_MAX_TRIES:
+                    continue
+                if pk in _parked_creates:
+                    _parked_creates.remove(pk)
+        finally:
+            _release_create(key)
         if not err:
             fr = _comments_frame(pk["sid"])
             with _clients_lock:
@@ -15250,25 +15327,54 @@ def _drive(msg, client):
         # Anchor a comment thread on a highlighted passage (the user 2026-08-13). LOUD on refusal; on
         # success a commentCreated ack names the new thread (the popover adopts exactly it — never a
         # guess) and the fresh {type:"comments"} frame rides straight back, ahead of the pusher cycle.
-        err, tid = _comment_create(sid, str(msg["uuid"]), str(msg["exact"]), str(msg["text"]),
-                                   name=str(msg.get("name") or ""),
-                                   model=str(msg.get("model") or ""), effort=str(msg.get("effort") or ""),
-                                   fast=str(msg.get("fast") or ""),
-                                   color=str(msg.get("color") or ""))
+        # A REPEAT of a create this kernel already completed (a client re-post after a lost ack or a
+        # parked copy that landed) is the same comment: answer with the same thread, never a twin (T289).
+        key = _create_key(sid, msg["uuid"], msg["exact"], msg["text"])
+        state, again = _reserve_create(key)
+        if state == "repeat":
+            sys.stderr.write("comment create repeated (%s): the same comment again, answered with thread %s\n"
+                             % (sid[:8], str(again)[:8]))   # a collapse is visible, never silent
+            fr = _comments_frame(sid)
+            if fr:
+                client["send"](json.dumps(fr))
+            client["send"](json.dumps({"type": "commentCreated", "id": sid, "tid": again, "uuid": str(msg["uuid"])}))
+            return True
+        if state == "busy":
+            # the other door holds this create (parked, or mid-create on the pusher): the typed transient
+            # nack keeps the popover's mark alive, and the pusher's success acks every chat client
+            client["send"](json.dumps({"type": "commentCreateFailed", "id": sid, "uuid": str(msg["uuid"]),
+                                       "transient": True, "text": ANCHOR_LAG_ERR}))
+            return True
+        try:
+            err, tid = _comment_create(sid, str(msg["uuid"]), str(msg["exact"]), str(msg["text"]),
+                                       name=str(msg.get("name") or ""),
+                                       model=str(msg.get("model") or ""), effort=str(msg.get("effort") or ""),
+                                       fast=str(msg.get("fast") or ""),
+                                       color=str(msg.get("color") or ""))
+            if not err:
+                _note_create(key, tid)
+        finally:
+            _release_create(key)
         if err:
             # a TRANSIENT refusal (the live-streamed reply's file flush lagging) PARKS the create —
             # the pusher retries it each cycle until the transcript catches up — and the typed nack
             # keeps the client's optimistic mark alive; no toast for plumbing the retry makes moot.
-            # Every real refusal stays loud (fail loudly).
+            # Every real refusal stays loud (fail loudly). Parked ONCE per create identity (T289): the
+            # client re-posts the same create on every frame while the nack stands.
             if err == ANCHOR_LAG_ERR:
-                _parked_creates.append({"sid": sid, "uuid": str(msg["uuid"]), "exact": str(msg["exact"]),
-                                        "text": str(msg["text"]), "name": str(msg.get("name") or ""),
-                                        "model": str(msg.get("model") or ""),
-                                        "effort": str(msg.get("effort") or ""),
-                                        "fast": str(msg.get("fast") or ""),
-                                        "color": str(msg.get("color") or ""), "tries": 0})
+                with _create_lock:
+                    if not any(_create_key(pk["sid"], pk["uuid"], pk["exact"], pk["text"]) == key for pk in _parked_creates):
+                        _parked_creates.append({"sid": sid, "uuid": str(msg["uuid"]), "exact": str(msg["exact"]),
+                                                "text": str(msg["text"]), "name": str(msg.get("name") or ""),
+                                                "model": str(msg.get("model") or ""),
+                                                "effort": str(msg.get("effort") or ""),
+                                                "fast": str(msg.get("fast") or ""),
+                                                "color": str(msg.get("color") or ""), "tries": 0})
             else:
                 client["send"](json.dumps({"type": "warn", "text": err}))
+                # the kernel log carries the refusal too (T289): a name refused at this door showed only
+                # as a toast on the viewer, and the refusing kernel's log held no trace of what the user saw
+                sys.stderr.write("comment create refused (%s, name %r): %s\n" % (sid[:8], str(msg.get("name") or "")[:80], err))
             client["send"](json.dumps({"type": "commentCreateFailed", "id": sid,
                                        "uuid": str(msg["uuid"]), "transient": err == ANCHOR_LAG_ERR,
                                        "text": err}))
@@ -15310,6 +15416,7 @@ def _drive(msg, client):
         err = _comment_promote(sid, str(msg["tid"]), str(msg["name"]), client=client)
         if err:
             client["send"](json.dumps({"type": "warn", "text": err}))
+            sys.stderr.write("comment promote refused (%s, name %r): %s\n" % (sid[:8], str(msg["name"])[:80], err))   # T289
     elif t == "endSession":
         sys.stderr.write("kill: %s via endSession WS op\n" % sid)   # kill attribution (the user 2026-07-16)
         be.kill(sid); _record_death(sid, int(time.time()), "kill")   # the one SDK event with no designed reviver
@@ -15322,7 +15429,9 @@ def _drive(msg, client):
         if not NAME_RE.match(new):
             client["send"](json.dumps({"type": "warn", "text": "session names use letters, digits, . _ - only."}))
         elif _thread_name_refusal(new, _thread_names()):     # a thread's name — never relabel onto it (T223)
-            client["send"](json.dumps({"type": "warn", "text": _thread_name_refusal(new, _thread_names())}))
+            _tref = _thread_name_refusal(new, _thread_names())
+            client["send"](json.dumps({"type": "warn", "text": _tref}))
+            sys.stderr.write("rename refused (%s, name %r): %s\n" % (sid[:8], new, _tref))   # T289: the log carries it too
         else:
             # the live-name check this op never had: _rename_claimed claims the name (kind rename)
             # before be.rename — a running session's name, or one being created right now, is refused

--- a/tests/test_comment_create_idempotent.py
+++ b/tests/test_comment_create_idempotent.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""T289: a comment CREATE is idempotent on its own identity (parent, anchor, passage, text).
+
+A create parked for transcript lag is retried by BOTH the kernel (the pusher's _retry_parked_creates) and
+the client (its frame-keyed re-post), and a create whose ack was lost is sent again by the popover; before
+this the second copy either collided on its explicit name and was refused with the create toast the user
+saw, or, with the name now left to the kernel, would have minted a SECOND thread for one comment. The
+kernel remembers each create it completed by (parent sid, anchor uuid, passage, text) and answers a repeat
+with the SAME thread's ack; a lag-parked create is parked once. SYNTHETIC fixtures."""
+import contextlib
+import io
+import json
+import os
+import shutil
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+PARENT = "aaaaaaaa-1111-2222-3333-444444444444"
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "promptSource": "typed",
+            "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
+                        "content": [{"type": "text", "text": text}]}}
+
+
+class FakeBackend:
+    def __init__(self):
+        self.calls = []
+
+    def fork(self, name, parent_sid, cut_uuid="", bg="", fg="", sid=None, thread_of="", model="", effort="", fast=""):
+        self.calls.append(("fork", name)); return sid
+
+    def connect(self, sid):
+        return True
+
+    def send(self, sid, text):
+        return True
+
+    def kill(self, sid):
+        return True
+
+    def rename(self, sid, name):
+        self.calls.append(("rename", name)); return True
+
+    def promote_thread(self, sid, name, bg="", fg=""):
+        self.calls.append(("promote", name)); return True
+
+
+class CreateIsIdempotent(unittest.TestCase):
+    def setUp(self):
+        self._saved = jd.STATE
+        self._saved_proj = jd.PROJECTS
+        self._td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self._td))
+        jd.PROJECTS = Path(self._td) / "projects"
+        jd._discover_cache.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+        km._thread_msgs_cache.clear()
+        self.now = int(time.time())
+        cdir = str(Path(self._td) / "work")
+        self.proj = jd._proj_dir(cdir)
+        self.proj.mkdir(parents=True, exist_ok=True)
+        jd.NAMES.mkdir(parents=True, exist_ok=True)
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        (jd.NAMES / PARENT).write_text("web\t%s\t\t\n" % cdir)   # the names row: the refusal names the parent by it
+        self.be = FakeBackend()
+        self._saved_fns = (km._sdk, km.Sessions.backend_for, km._sdk_ready, km._sessions, km._reveal_chat_for,
+                           km._push_session_now, km._tmux_sessions, km._kernel_knows)
+        km._sdk = lambda: None
+        km._kernel_knows = lambda sid: sid == PARENT     # the dispatcher's ownership guard is not under test
+        self._saved_km_names = km.NAMES
+        km.NAMES = jd.NAMES                              # the kernel's own binding of the names dir follows the rebind
+        km.Sessions.backend_for = staticmethod(lambda sid: self.be)
+        km._sdk_ready = lambda: True
+        km._tmux_sessions = lambda: {}
+        t = self.now - 600
+        p = self.proj / (PARENT + ".jsonl")
+        p.write_text("\n".join(json.dumps(r) for r in [
+            uline(t, "how should the notes-api retry loop back off?", "u1"),
+            aline(t + 5, "Use exponential backoff with a jitter of ten percent.", "a1", parent="u1")]) + "\n")
+        km._sessions = lambda now, window=None, forks=True: [
+            {"sid": PARENT, "name": "web", "path": str(p), "mtime": self.now}]
+        km._reveal_chat_for = lambda client, msg: None
+        km._push_session_now = lambda sid: None
+        self.sent = []
+        self.client = {"send": lambda s: self.sent.append(json.loads(s)), "app": "chat"}
+
+    def tearDown(self):
+        (km._sdk, km.Sessions.backend_for, km._sdk_ready, km._sessions, km._reveal_chat_for,
+         km._push_session_now, km._tmux_sessions, km._kernel_knows) = self._saved_fns
+        km.NAMES = self._saved_km_names
+        jd._rebind_state(self._saved)
+        jd.PROJECTS = self._saved_proj
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _drive(self, msg):
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            handled = km._drive(msg, self.client)
+        return handled, buf.getvalue()
+
+    def _warns(self):
+        return [f["text"] for f in self.sent if f.get("type") == "warn"]
+
+    def _create(self, text="Why jitter at all?", uuid="a1", name=""):
+        return self._drive({"type": "commentCreate", "id": PARENT, "uuid": uuid, "exact": "exponential backoff",
+                            "text": text, "name": name})
+
+    def _rows(self):
+        return km._load_comments(PARENT).get("threads") or []
+
+    def _acks(self):
+        return [f for f in self.sent if f.get("type") == "commentCreated"]
+
+    def test_the_same_create_twice_yields_one_thread_and_two_acks_naming_it(self):
+        self._create(); self._create()
+        self.assertEqual(len(self._rows()), 1, "one comment, one thread")
+        acks = self._acks()
+        self.assertEqual(len(acks), 2, "the repeat is answered, so the popover adopts the thread")
+        self.assertEqual(acks[0]["tid"], acks[1]["tid"])
+        self.assertEqual(self._warns(), [])
+
+    def test_a_different_comment_on_the_same_passage_is_a_second_thread(self):
+        self._create("Why jitter at all?"); self._create("And the cap?")
+        self.assertEqual(len(self._rows()), 2)
+        self.assertEqual(len({a["tid"] for a in self._acks()}), 2)
+
+    def test_a_lag_parked_create_is_parked_once(self):
+        # the anchor is not in the transcript yet: the create parks, the client hears a transient nack and
+        # re-posts on the next frame — the park must not double
+        km._parked_creates.clear()
+        self._create(uuid="a9"); self._create(uuid="a9")
+        nacks = [f for f in self.sent if f.get("type") == "commentCreateFailed"]
+        self.assertEqual(len(nacks), 2)
+        self.assertTrue(all(n["transient"] for n in nacks))
+        self.assertEqual(len(km._parked_creates), 1, "one parked copy for one create")
+        km._parked_creates.clear()
+
+    def test_a_parked_create_that_landed_answers_the_clients_repost_with_the_same_thread(self):
+        km._parked_creates.clear()
+        self._create(uuid="a9")
+        self.assertEqual(len(km._parked_creates), 1)
+        # the transcript catches up: the pusher's retry lands the thread
+        p = Path(km._sessions(0)[0]["path"])
+        with p.open("a") as fh:
+            fh.write(json.dumps(aline(self.now - 300, "Add a jitter to the backoff.", "a9", parent="a1")) + "\n")
+        km._retry_parked_creates()
+        self.assertEqual(km._parked_creates, [])
+        rows = self._rows()
+        self.assertEqual(len(rows), 1)
+        # the client's own re-post of the same create arrives a beat later: the same thread, no second one
+        self._create(uuid="a9")
+        self.assertEqual(len(self._rows()), 1, "the repeat is the same comment")
+        acks = self._acks()
+        self.assertTrue(acks and acks[-1]["tid"] == rows[0]["tid"], acks)
+        self.assertEqual(self._warns(), [])
+
+    def test_a_repost_arriving_while_the_pushers_retry_creates_is_not_a_second_thread(self):
+        # THE RACE (review, 2026-09-09): the pusher sends the chat frame before it retries parked creates,
+        # the client re-posts the create on that frame, and the re-post lands on a WS thread while the
+        # pusher's own create is in flight — neither copy is noted yet, so both minted. The identity must
+        # be reserved before the create runs, on both doors, and the pusher must consult the memo.
+        import threading
+        km._parked_creates.clear()
+        self._create(uuid="a9")                       # lag-parked (the anchor is not on disk yet)
+        self.assertEqual(len(km._parked_creates), 1)
+        p = Path(km._sessions(0)[0]["path"])
+        with p.open("a") as fh:
+            fh.write(json.dumps(aline(self.now - 300, "Add a jitter to the backoff.", "a9", parent="a1")) + "\n")
+        real = km._comment_create
+        seen = {"n": 0, "nested": None}
+
+        def racing(*a, **k):
+            seen["n"] += 1
+            if seen["n"] == 1:
+                # the pusher's create is in flight: the client's re-post arrives on another thread NOW
+                before = len(self.sent)
+                t = threading.Thread(target=lambda: self._create(uuid="a9"))
+                t.start(); t.join(10)
+                seen["nested"] = self.sent[before:]
+            return real(*a, **k)
+        km._comment_create = racing
+        try:
+            km._retry_parked_creates()
+        finally:
+            km._comment_create = real
+        self.assertEqual(seen["n"], 1, "the re-post never reached a second create: %r" % (seen["nested"],))
+        self.assertEqual(len(self._rows()), 1, "one comment, one thread")
+        kinds = [f.get("type") for f in (seen["nested"] or [])]
+        self.assertTrue("commentCreateFailed" in kinds or "commentCreated" in kinds,
+                        "the re-post is answered while the pusher's copy is in flight (a typed transient nack, or the ack): %r" % kinds)
+        self.assertEqual(km._parked_creates, [])
+        self.assertEqual(self._warns(), [])
+
+    def test_a_repeat_after_the_thread_was_resolved_is_a_new_comment_not_a_dropped_one(self):
+        # a resolved (or merged, or promoted) thread cannot take a message: answering a same-worded comment
+        # with its ack would drop the user's words silently (review, 2026-09-09)
+        self._create()
+        tid = self._acks()[0]["tid"]
+        self.assertIsNone(km._comment_resolve(PARENT, tid))
+        self._create()
+        rows = self._rows()
+        self.assertEqual(len(rows), 2, "a second, open thread for the re-asked comment")
+        self.assertEqual(self._warns(), [])
+
+    def test_an_answered_repeat_is_said_in_the_kernel_log(self):
+        self._create()
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            km._drive({"type": "commentCreate", "id": PARENT, "uuid": "a1", "exact": "exponential backoff",
+                       "text": "Why jitter at all?", "name": ""}, self.client)
+        self.assertIn("comment create repeated", buf.getvalue(), "a collapse is visible, never silent")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_comment_name_refusal_log.py
+++ b/tests/test_comment_name_refusal_log.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""T289 (the user 2026-09-09): a thread-NAME refusal at any door is a kernel log line, not only a toast.
+
+A comment on a remote session was refused as a create-by-name and neither kernel logged it: the create
+door answered the browser with a warn frame and a typed nack and wrote nothing, so the refusing kernel's
+log held no trace of the event the user saw. Every door that refuses a NAME (the comment create, the
+break-out, the rename) now also writes one stderr line naming the door, the session and the refusal.
+The handlers' frames are unchanged. SYNTHETIC fixtures (the test_comment_threads.py conventions)."""
+import contextlib
+import io
+import json
+import os
+import shutil
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+PARENT = "aaaaaaaa-1111-2222-3333-444444444444"
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "promptSource": "typed",
+            "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
+                        "content": [{"type": "text", "text": text}]}}
+
+
+class FakeBackend:
+    def __init__(self):
+        self.calls = []
+
+    def fork(self, name, parent_sid, cut_uuid="", bg="", fg="", sid=None, thread_of="", model="", effort="", fast=""):
+        self.calls.append(("fork", name)); return sid
+
+    def connect(self, sid):
+        return True
+
+    def send(self, sid, text):
+        return True
+
+    def kill(self, sid):
+        return True
+
+    def rename(self, sid, name):
+        self.calls.append(("rename", name)); return True
+
+    def promote_thread(self, sid, name, bg="", fg=""):
+        self.calls.append(("promote", name)); return True
+
+
+class NameRefusalsAreLogged(unittest.TestCase):
+    def setUp(self):
+        self._saved = jd.STATE
+        self._saved_proj = jd.PROJECTS
+        self._td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self._td))
+        jd.PROJECTS = Path(self._td) / "projects"
+        jd._discover_cache.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+        km._thread_msgs_cache.clear()
+        self.now = int(time.time())
+        cdir = str(Path(self._td) / "work")
+        self.proj = jd._proj_dir(cdir)
+        self.proj.mkdir(parents=True, exist_ok=True)
+        jd.NAMES.mkdir(parents=True, exist_ok=True)
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        (jd.NAMES / PARENT).write_text("web\t%s\t\t\n" % cdir)   # the names row: the refusal names the parent by it
+        self.be = FakeBackend()
+        self._saved_fns = (km._sdk, km.Sessions.backend_for, km._sdk_ready, km._sessions, km._reveal_chat_for,
+                           km._push_session_now, km._tmux_sessions, km._kernel_knows)
+        km._sdk = lambda: None
+        km._kernel_knows = lambda sid: sid == PARENT     # the dispatcher's ownership guard is not under test
+        self._saved_km_names = km.NAMES
+        km.NAMES = jd.NAMES                              # the kernel's own binding of the names dir follows the rebind
+        km.Sessions.backend_for = staticmethod(lambda sid: self.be)
+        km._sdk_ready = lambda: True
+        km._tmux_sessions = lambda: {}
+        t = self.now - 600
+        p = self.proj / (PARENT + ".jsonl")
+        p.write_text("\n".join(json.dumps(r) for r in [
+            uline(t, "how should the notes-api retry loop back off?", "u1"),
+            aline(t + 5, "Use exponential backoff with a jitter of ten percent.", "a1", parent="u1")]) + "\n")
+        km._sessions = lambda now, window=None, forks=True: [
+            {"sid": PARENT, "name": "web", "path": str(p), "mtime": self.now}]
+        km._reveal_chat_for = lambda client, msg: None
+        km._push_session_now = lambda sid: None
+        self.sent = []
+        self.client = {"send": lambda s: self.sent.append(json.loads(s)), "app": "chat"}
+
+    def tearDown(self):
+        (km._sdk, km.Sessions.backend_for, km._sdk_ready, km._sessions, km._reveal_chat_for,
+         km._push_session_now, km._tmux_sessions, km._kernel_knows) = self._saved_fns
+        km.NAMES = self._saved_km_names
+        jd._rebind_state(self._saved)
+        jd.PROJECTS = self._saved_proj
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _drive(self, msg):
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            handled = km._drive(msg, self.client)
+        return handled, buf.getvalue()
+
+    def _warns(self):
+        return [f["text"] for f in self.sent if f.get("type") == "warn"]
+
+    def test_a_create_under_a_taken_thread_name_is_refused_aloud_and_logged(self):
+        err, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why jitter at all?")
+        self.assertIsNone(err)
+        taken = km._comment_thread(PARENT, tid)["name"]
+        self.assertEqual(taken, "web-comment-1", "the kernel's own default: bare name, next number")
+        handled, log = self._drive({"type": "commentCreate", "id": PARENT, "uuid": "a1", "exact": "exponential backoff",
+                                    "text": "and the cap?", "name": taken})
+        self.assertTrue(handled)
+        self.assertTrue(any("is a comment thread of web" in w for w in self._warns()), self.sent)
+        nacks = [f for f in self.sent if f.get("type") == "commentCreateFailed"]
+        self.assertEqual(len(nacks), 1)
+        self.assertFalse(nacks[0]["transient"])
+        self.assertIn("comment create refused", log, "the kernel log names the event the user saw")
+        self.assertIn(PARENT[:8], log)
+        self.assertIn(taken, log)
+
+    def test_an_empty_name_takes_the_kernels_default_past_the_taken_one(self):
+        # the client's fix sends "" for an untouched prefill: the kernel numbers past every taken name
+        _, tid1 = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        handled, log = self._drive({"type": "commentCreate", "id": PARENT, "uuid": "a1", "exact": "exponential backoff",
+                                    "text": "and the cap?", "name": ""})
+        self.assertTrue(handled)
+        self.assertEqual(self._warns(), [])
+        acks = [f for f in self.sent if f.get("type") == "commentCreated"]
+        self.assertEqual(len(acks), 1)
+        self.assertEqual(km._comment_thread(PARENT, acks[0]["tid"])["name"], "web-comment-2")
+        self.assertNotIn("refused", log)
+
+    def test_a_break_out_under_a_taken_name_is_logged(self):
+        _, tid1 = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        _, tid2 = km._comment_create(PARENT, "a1", "exponential backoff", "And?")
+        taken = km._comment_thread(PARENT, tid1)["name"]
+        handled, log = self._drive({"type": "commentPromote", "id": PARENT, "tid": tid2, "name": taken})
+        self.assertTrue(handled)
+        self.assertTrue(self._warns(), self.sent)
+        self.assertIn("comment promote refused", log)
+        self.assertIn(taken, log)
+
+    def test_a_rename_onto_a_thread_name_is_logged(self):
+        _, tid1 = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        taken = km._comment_thread(PARENT, tid1)["name"]
+        handled, log = self._drive({"type": "renameSession", "id": PARENT, "name": taken})
+        self.assertTrue(handled)
+        self.assertTrue(any("is a comment thread of web" in w for w in self._warns()), self.sent)
+        self.assertIn("rename refused", log)
+        self.assertIn(taken, log)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_remote_comment_name_served.py
+++ b/tests/test_remote_comment_name_served.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""T289 (the user 2026-09-09): a comment on a REMOTE session's transcript was refused as a create-by-name.
+
+The comment dialog prefilled its name box from the viewer's DECORATED session name ("host:name", which
+federation prefixes on every session-bearing frame) sanitized to "host-name-comment-N", and sent that
+prefill as if the user had chosen it — so the owning kernel stored a thread named with the VIEWER's host
+label, and the next dialog with the same count collided with it and was refused. The executed guard drives
+the real /chat page of a hub kernel that has a SECOND hermetic kernel checked in as host TESTHOST (the same
+handshake a mobile machine's reverse forward makes, so no ssh): the remote session's transcript is opened
+from its host-prefixed tab, a passage is selected, the selection menu's Comment opens the dialog, and the
+dialog's send is captured at the socket. Asserted: the prefilled name wears the BARE session name (no host
+label) and the frame the dialog sends carries an EMPTY name (the owning kernel picks its default) on the
+remote relay socket, addressed by the parent's sid. Red on main: the prefill and the frame both read
+"TESTHOST-web-comment-1". The remote's own create door is not exercised to completion here (a hermetic
+kernel has no SDK to fork the thread), so the refusal toast itself is pinned at the kernel unit level
+(tests/test_comment_name_refusal_log.py). Skips LOUDLY without the extension deps or a Playwright browser.
+SYNTHETIC fixtures only (host TESTHOST, session web, the notes-api demo world)."""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+REPLY = "Use exponential backoff with a jitter of ten percent."
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 760 } });
+// capture every outbound frame at the socket, with the socket it left on; drop the create so nothing forks
+await page.addInitScript(() => {
+  const orig = WebSocket.prototype.send;
+  window.__frames = [];
+  WebSocket.prototype.send = function (d) {
+    try { const m = JSON.parse(d); if (m && m.type === "commentCreate") { window.__frames.push({ url: this.url, msg: m }); return; } } catch (e) {}
+    return orig.call(this, d);
+  };
+});
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+// the remote host's tab appears once the hub reports the check-in up and the relay socket is open
+const remoteTab = page.locator("#tabs .tab", { hasText: "TESTHOST" }).first();
+try { await remoteTab.waitFor({ timeout: 45000 }); }
+catch (e) {
+  const st = await page.evaluate(() => ({ tabs: (document.getElementById("tabs") || {}).textContent }));
+  console.error("no remote tab: " + JSON.stringify(st)); process.exit(1);
+}
+await remoteTab.click();
+await page.waitForFunction((t) => Array.from(document.querySelectorAll(".turn")).some((n) => (n.textContent || "").includes(t)), REPLY_PLACEHOLDER, { timeout: 30000 });
+await page.waitForTimeout(500);
+const info = await page.evaluate((t) => {
+  const turn = Array.from(document.querySelectorAll(".turn")).find((n) => (n.textContent || "").includes(t));
+  const md = turn.querySelector(".md") || turn;
+  const walker = document.createTreeWalker(md, NodeFilter.SHOW_TEXT);
+  let node = walker.nextNode();
+  while (node && !(node.textContent || "").includes("exponential")) node = walker.nextNode();
+  const sel = window.getSelection(); sel.removeAllRanges();
+  const r = document.createRange(); r.setStart(node, 0); r.setEnd(node, Math.min(node.textContent.length, 24)); sel.addRange(r);
+  const box = md.getBoundingClientRect();
+  const ev = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: box.left + 20, clientY: box.top + 10, button: 2 });
+  md.dispatchEvent(ev);
+  const items = Array.from(document.querySelectorAll(".ctx-menu .ctx-item")).map((i) => i.textContent);
+  return { selected: sel.toString(), items, tab: document.querySelector("#tabs .tab.active, #tabs .tab[aria-selected='true']")?.textContent || "" };
+}, REPLY_PLACEHOLDER);
+const comment = page.locator(".ctx-menu .ctx-item", { hasText: "Comment" }).first();
+try { await comment.waitFor({ timeout: 5000 }); } catch (e) { console.error("no Comment item: " + JSON.stringify(info)); process.exit(1); }
+await comment.click();
+await page.waitForSelector("#cmt-pop .cmt-name", { timeout: 10000 });
+const dialog = await page.evaluate(() => {
+  const box = document.querySelector("#cmt-pop .cmt-name");
+  return { value: box.value, prefill: box.dataset.prefill || null, title: (document.querySelector("#cmt-pop .cmt-title") || {}).textContent || "" };
+});
+await page.fill("#cmt-pop .cmt-input", "why jitter at all?");
+await page.press("#cmt-pop .cmt-input", "Enter");
+await page.waitForFunction(() => (window.__frames || []).length > 0, null, { timeout: 10000 });
+const frames = await page.evaluate(() => window.__frames);
+fs.writeSync(1, "RESULT:" + JSON.stringify({ info, dialog, frames }) + "\n");
+await browser.close();
+process.exit(0);
+""".replace("REPLY_PLACEHOLDER", json.dumps(REPLY))
+
+
+def _kernel(lab, name, port, token, records=None, sid=None):
+    """Boot one hermetic kernel: its own state root, dist, and (optionally) one session with a transcript."""
+    state = os.path.join(lab, name, "xdg", "romp")
+    claude = os.path.join(lab, name, "claude")
+    cwd = os.path.join(lab, name, "proj")
+    for d in ("names", "sdk", "states"):
+        os.makedirs(os.path.join(state, d), exist_ok=True)
+    os.makedirs(cwd, exist_ok=True)
+    Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+    if records is not None:
+        Path(state, "names", sid).write_text("web\t%s\t\t\n" % cwd)
+        Path(state, "sdk", sid + ".json").write_text(json.dumps(
+            {"sid": sid, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high",
+             "lastSid": sid, "alive": True, "model": "claude-opus-5", "liveModel": "Opus 5"}))
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in records))
+    env = dict(os.environ, XDG_STATE_HOME=os.path.join(lab, name, "xdg"), CLAUDE_CONFIG_DIR=claude,
+               ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=token,
+               ROMP_KERNEL_PORT=str(port), ROMP_DIST_DIR=os.path.join(lab, "dist"), ROMP_MODEL_CATALOG="off",
+               ROMP_HOST_NAME=name.upper(),
+               ROMP_POSTAL_PEERS="0")   # never the machine's shared postal bus (nor a bus spawned on its port)
+    for k in ("ROMP_STATE_DIR", "ROMP_API_KEY_CMD", "ANTHROPIC_API_KEY"):
+        env.pop(k, None)
+    log = os.path.join(lab, name + "-kernel.log")
+    proc = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(log, "w"), stderr=subprocess.STDOUT, env=env)
+    for _ in range(120):
+        try:
+            urllib.request.urlopen("http://127.0.0.1:%d/healthz" % port, timeout=1)
+            return proc, log
+        except Exception:
+            time.sleep(0.5)
+    proc.kill(); proc.wait()
+    raise unittest.SkipTest("hermetic kernel %s never served /healthz here" % name)
+
+
+class ServedRemoteCommentName(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls._boot()
+        except BaseException:          # a skip OR a failure: never leave a kernel or a lab behind
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def _boot(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        probe = subprocess.run(["node", "-e", "const p=require(process.argv[1]);process.stdout.write(p.chromium.executablePath())",
+                                os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
+        if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        cls.lab = tempfile.mkdtemp(prefix="remote-comment-name-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            shutil.rmtree(cls.lab, ignore_errors=True)
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        shutil.copytree(os.path.join(EXT, "dist"), os.path.join(cls.lab, "dist"))
+        cls.procs = []
+        t0 = int(time.time()) - 900
+        recs = [
+            {"type": "user", "timestamp": iso(t0), "uuid": "u1", "parentUuid": None, "promptSource": "typed", "sessionId": SID,
+             "message": {"role": "user", "content": "how should the notes-api retry loop back off?"}},
+            {"type": "assistant", "timestamp": iso(t0 + 5), "uuid": "a1", "parentUuid": "u1", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
+                         "content": [{"type": "text", "text": REPLY}]}},
+        ]
+        # the REMOTE kernel owns the session; the HUB has none of its own and shows the remote's through the relay
+        cls.rport, cls.rtoken = _free_port(), "testtok-remote"
+        cls.hport, cls.htoken = _free_port(), "testtok-hub"
+        try:
+            rp, cls.rlog = _kernel(cls.lab, "testhost", cls.rport, cls.rtoken, records=recs, sid=SID)
+            cls.procs.append(rp)
+            hp, cls.hlog = _kernel(cls.lab, "hub", cls.hport, cls.htoken)
+            cls.procs.append(hp)
+        except unittest.SkipTest:
+            cls.tearDownClass()
+            raise
+        # the check-in handshake a mobile machine makes through its reverse forward: the hub records the peer
+        # like an attached remote (no ssh of its own) and probes it on the port given — here the remote's own
+        body = json.dumps({"host": "TESTHOST", "kernelPort": cls.rport, "busPort": _free_port(), "token": cls.rtoken}).encode()
+        req = urllib.request.Request("http://127.0.0.1:%d/checkin?token=%s" % (cls.hport, cls.htoken), data=body,
+                                     headers={"Content-Type": "application/json"}, method="POST")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            ans = json.loads(resp.read().decode())
+        if not ans.get("ok"):
+            cls.tearDownClass()
+            raise unittest.SkipTest("the hub refused the check-in: %r" % ans)
+        # wait for the hub's supervisor to probe the peer and report it up (the browser dials only then)
+        for _ in range(60):
+            try:
+                with urllib.request.urlopen("http://127.0.0.1:%d/tunnels?token=%s" % (cls.hport, cls.htoken), timeout=3) as r2:
+                    rows = json.loads(r2.read().decode()).get("tunnels") or []
+            except Exception:
+                rows = []
+            row = next((t for t in rows if t.get("host") == "TESTHOST"), None)
+            if row and row.get("status") == "up" and row.get("hasToken"):
+                break
+            time.sleep(0.5)
+        else:
+            cls.tearDownClass()
+            raise unittest.SkipTest("the hub never reported the checked-in peer up: %r" % (rows,))
+
+    @classmethod
+    def tearDownClass(cls):
+        for p in getattr(cls, "procs", []):
+            try:
+                p.kill(); p.wait()
+            except Exception:
+                pass
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_a_comment_on_a_remote_session_prefills_the_bare_name_and_sends_an_empty_one_to_the_owner(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.hport, self.htoken)}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:]
+                         + "\nhub:\n" + open(self.hlog).read()[-1500:] + "\nremote:\n" + open(self.rlog).read()[-800:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        d, frames = r["dialog"], r["frames"]
+        self.assertEqual(d["title"], "New comment:", "the dialog is the CREATE dialog: %r" % r["info"])
+        self.assertEqual(d["value"], "web-comment-1", "the prefill wears the BARE session name, never the viewer's host label: %r" % d)
+        self.assertNotIn("TESTHOST", d["value"])
+        self.assertEqual(d["prefill"], d["value"], "the dialog remembers its prefill so an untouched one is sent as empty")
+        self.assertEqual(len(frames), 1, "one create left the page: %r" % frames)
+        fr = frames[0]
+        self.assertIn("/remote/TESTHOST/ws", fr["url"], "addressed to the OWNING kernel through its relay: %r" % fr["url"])
+        self.assertEqual(fr["msg"]["id"], SID, "the parent's sid, bare on the wire")
+        self.assertEqual(fr["msg"]["name"], "", "an untouched prefill is sent as an EMPTY name: the owner picks its default")
+        self.assertEqual(fr["msg"]["text"], "why jitter at all?")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/comment-name.test.ts
+++ b/ui/webview/comment-name.test.ts
@@ -1,0 +1,84 @@
+// T289 (the user 2026-09-09): a comment on a REMOTE session was refused as a create-by-name. The comment
+// dialog prefilled its name box from the viewer's DECORATED session name ("host:name", which federation
+// prefixes on every session-bearing frame) sanitized to "host-name", plus the viewer's own thread count,
+// and sent that prefill as if the user had chosen it — so the owning kernel stored a name wearing the
+// viewer's host label, and the next dialog (same count, after a deleted thread or a lost ack) collided
+// with it and was refused. The pure module owns the rule: the prefill is built from the BARE name
+// (host-prefix.ts, the rename dialog's 2026-08-02 idiom), and an UNTOUCHED prefill is sent as "" so the
+// kernel picks its own default (bare name, next free number). Executed tests on the module; source pins
+// on the dialogs that must use it.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { bareSessionName, defaultCommentName, defaultBreakoutName, defaultForkName, nameToSend } from "./comment-name";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const RSID = "TESTHOST:aaaaaaaa-1111-2222-3333-444444444444";
+const LSID = "aaaaaaaa-1111-2222-3333-444444444444";
+
+test("a remote session's bare name drops the viewer's host label; a local name is untouched", () => {
+  assert.equal(bareSessionName("TESTHOST:web", RSID), "web");
+  assert.equal(bareSessionName("web", LSID), "web");
+  // a name that merely CONTAINS a colon-like shape under a local sid is not a label (the sid is the marker)
+  assert.equal(bareSessionName("TESTHOST:web", LSID), "TESTHOST:web");
+});
+
+test("the comment prefill is <bare>-comment-<known+1>, sanitized, never wearing the host label", () => {
+  assert.equal(defaultCommentName("TESTHOST:web", RSID, 1), "web-comment-2");
+  assert.equal(defaultCommentName("web", LSID, 0), "web-comment-1");
+  assert.equal(defaultCommentName("my api", LSID, 2), "my-api-comment-3", "illegal characters become dashes");
+  assert.equal(defaultCommentName("", LSID, 0), "session-comment-1", "no name yet: the generic stem");
+  assert.doesNotMatch(defaultCommentName("TESTHOST:web", RSID, 4), /TESTHOST/);
+});
+
+test("the break-out and fork prefills use the bare name too", () => {
+  assert.equal(defaultBreakoutName("TESTHOST:web", RSID), "web-thread");
+  assert.equal(defaultBreakoutName("web", LSID), "web-thread");
+  assert.equal(defaultForkName("TESTHOST:web", RSID), "web-fork");
+  assert.equal(defaultForkName("web", LSID), "web-fork");
+});
+
+test("an untouched prefill is sent as an EMPTY name — the kernel's default is the kernel's to pick", () => {
+  assert.equal(nameToSend("web-comment-2", "web-comment-2"), "");
+  assert.equal(nameToSend("  web-comment-2 ", "web-comment-2"), "", "whitespace around the prefill is still untouched");
+  assert.equal(nameToSend("", "web-comment-2"), "", "an emptied box asks for the default as well");
+  assert.equal(nameToSend("why-jitter", "web-comment-2"), "why-jitter", "a typed name is the user's choice");
+});
+
+test("the comment dialog prefills through the module and sends nameToSend; the old inline stem is gone", () => {
+  const pop = RENDER.slice(RENDER.indexOf("function renderCommentPopover("));
+  const popBody = pop.slice(0, pop.indexOf("\nfunction ", 10));
+  assert.match(popBody, /defaultCommentName\(sess0\?\.name, sid, \(commentThreads\.get\(sid\) \|\| \[\]\)\.length\)/);
+  assert.match(popBody, /nameBox\.dataset\.prefill = prefill/, "the dialog remembers what it prefilled");
+  const send = RENDER.slice(RENDER.indexOf("function commentSendFromPop("));
+  const sendBody = send.slice(0, send.indexOf("\nfunction ", 10));
+  assert.match(sendBody, /nameToSend\(nameBox\?\.value \|\| "", nameBox\?\.dataset\.prefill \|\| ""\)/);
+  assert.doesNotMatch(RENDER, /\.replace\(\/\[\^A-Za-z0-9\._-\]\/g, "-"\)\s*\+ "-comment-"/, "no inline stem left");
+  // no dialog derives a kernel-side name from the DECORATED display name any more (review, 2026-09-09)
+  assert.doesNotMatch(RENDER, /\(sess0?\?\.name \|\| "session"\)\.replace\(/, "no decorated-name stem anywhere");
+  // the box says what it holds: a suggestion the kernel may renumber, not the thread's granted name
+  assert.match(RENDER, /nameBox\.title = "Suggested name; type to choose your own"/);
+});
+
+test("the fork dialog prefills through the module: a remote session's fork never wears the viewer's host label", () => {
+  // the same defect one dialog over (review, 2026-09-09): the fork name is REQUIRED non-empty, so a labelled
+  // prefill was always sent and the second fork of a remote session collided with the first
+  const fk = RENDER.slice(RENDER.indexOf("function showForkPrompt("));
+  const fkBody = fk.slice(0, fk.indexOf("\nfunction ", 10));
+  assert.match(fkBody, /const base = defaultForkName\(sess\?\.name, sid\);/);
+  assert.doesNotMatch(fkBody, /\.replace\(\/\[\^A-Za-z0-9\._-\]\/g, "-"\)/);
+});
+
+test("a typed name's draft dies with the ack, popover open or closed", () => {
+  // drafts are keyed by the anchor message; a typed name that outlived a closed popover resurfaced as the
+  // first thread's own (taken) name on the next comment on that message (review, 2026-09-09)
+  assert.match(RENDER, /if \(m\.uuid\) commentDrafts\.delete\("new:" \+ String\(m\.uuid\)\);\s*\n\s*if \(m\.uuid\) commentDrafts\.delete\("newname:" \+ String\(m\.uuid\)\);/);
+});
+
+test("the break-out dialog prefills through the module", () => {
+  const br = RENDER.slice(RENDER.indexOf("function showBreakoutPrompt("));
+  const brBody = br.slice(0, br.indexOf("\nfunction ", 10));
+  assert.match(brBody, /defaultBreakoutName\(sess\?\.name, sid\)/);
+  assert.doesNotMatch(brBody, /\+ "-thread"\)/, "no inline stem left");
+});

--- a/ui/webview/comment-name.ts
+++ b/ui/webview/comment-name.ts
@@ -1,0 +1,53 @@
+// The NAME rules of the dialogs that name a new session-side thing on a session's behalf — the comment, the
+// break-out and the fork (T289, the user 2026-09-09: a comment on a remote session was refused as a
+// create-by-name). Side-effect-free, like host-prefix.ts, so both the dashboard bundle and the node tests
+// can load it.
+//
+// A remote session surfaces on this viewer as "host:name": federation prefixes the display name the way
+// it prefixes the sid, and the "host:" part is THIS viewer's metadata, never part of the name the owning
+// kernel knows (host-prefix.ts, the rename dialog's rule since 2026-08-02). The dialog's prefill used the
+// decorated string sanitized to "host-name-comment-N", and sent it as the thread's name — so the owning
+// kernel stored a name wearing the viewer's host label, and the next dialog, prefilled with the same
+// count (the viewer's count regresses when a thread is deleted, and lags when a create's ack is lost),
+// collided with it and was refused. Two rules fix both halves:
+//   - the prefill is built from the BARE name (defaultCommentName / defaultBreakoutName);
+//   - an UNTOUCHED prefill is sent as "" (nameToSend): the kernel's default is the kernel's to pick — it
+//     counts its own threads and skips every taken name, which a viewer-side count cannot do.
+import { hostPrefix } from "./host-prefix";
+
+/** The session name the OWNING kernel knows: the display name with this viewer's "host:" label removed.
+ *  The sid is the marker (a bare uuid never carries a colon), so a local session's name is untouched even
+ *  when it happens to contain a colon-like shape. */
+export function bareSessionName(name: string | null | undefined, sid: string | null | undefined): string {
+  const nm = name || "";
+  const p = hostPrefix(nm, sid);
+  return p ? p.rest : nm;
+}
+
+function stem(name: string | null | undefined, sid: string | null | undefined): string {
+  return (bareSessionName(name, sid) || "session").replace(/[^A-Za-z0-9._-]/g, "-");
+}
+
+/** The comment dialog's prefill: <bare>-comment-<known+1>. A HINT of what the kernel will pick, shown so
+ *  the user can edit it; sent only when they did (nameToSend). */
+export function defaultCommentName(name: string | null | undefined, sid: string | null | undefined, knownThreads: number): string {
+  return stem(name, sid) + "-comment-" + (Math.max(0, knownThreads | 0) + 1);
+}
+
+/** The break-out dialog's prefill: <bare>-thread. */
+export function defaultBreakoutName(name: string | null | undefined, sid: string | null | undefined): string {
+  return stem(name, sid) + "-thread";
+}
+
+/** The fork dialog's prefill: <bare>-fork. The fork's name is required, so this one is always sent — which
+ *  is exactly why a labelled stem there always reached the owning kernel (review, 2026-09-09). */
+export function defaultForkName(name: string | null | undefined, sid: string | null | undefined): string {
+  return stem(name, sid) + "-fork";
+}
+
+/** What the dialog sends as the name: the user's typed name, or "" when the box still holds its prefill
+ *  (or nothing at all) — an empty name asks the owning kernel for its own default. */
+export function nameToSend(value: string | null | undefined, prefill: string): string {
+  const v = (value || "").trim();
+  return v === prefill.trim() ? "" : v;
+}

--- a/ui/webview/comment-remote-routing.test.ts
+++ b/ui/webview/comment-remote-routing.test.ts
@@ -1,0 +1,33 @@
+// T289: a follow-up in a REMOTE session's comment thread, and a comment create on a remote session, reach
+// the OWNING kernel by the parent's host-prefixed sid — the thread id and the name ride untouched, the sid
+// arrives bare. Pinned so the routing that was suspected (and found sound) stays sound.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { routeOutbound } from "./federation";
+
+const SID = "aaaaaaaa-1111-2222-3333-444444444444";
+const TID = "bbbbbbbb-1111-2222-3333-444444444444";
+
+test("commentReply for a remote thread routes to the parent's host by sid; tid and text untouched", () => {
+  const routes = routeOutbound({ type: "commentReply", id: "TESTHOST:" + SID, tid: TID, text: "and the cap?" });
+  assert.equal(routes.length, 1);
+  assert.equal(routes[0].host, "TESTHOST");
+  assert.deepEqual(routes[0].msg, { type: "commentReply", id: SID, tid: TID, text: "and the cap?" });
+});
+
+test("commentCreate for a remote session routes by sid and carries the name exactly as given", () => {
+  const routes = routeOutbound({ type: "commentCreate", id: "TESTHOST:" + SID, uuid: "u1", exact: "backoff",
+                                 text: "why jitter?", name: "", model: "", effort: "", fast: "", color: "" });
+  assert.equal(routes.length, 1);
+  assert.equal(routes[0].host, "TESTHOST");
+  assert.equal(routes[0].msg.id, SID);
+  assert.equal(routes[0].msg.name, "", "an empty name stays empty: the owning kernel picks its default");
+  assert.equal(routes[0].msg.uuid, "u1");
+});
+
+test("a local thread's reply stays local with a bare sid", () => {
+  const routes = routeOutbound({ type: "commentReply", id: SID, tid: TID, text: "x" });
+  assert.equal(routes.length, 1);
+  assert.equal(routes[0].host, "");
+  assert.equal(routes[0].msg.id, SID);
+});

--- a/ui/webview/comment-reply-landed.test.ts
+++ b/ui/webview/comment-reply-landed.test.ts
@@ -67,7 +67,7 @@ test("the client keys the green wash on the kernel's replyOwed; the gesture latc
   assert.match(KERNEL, /def _settle\(a\):/, "the stop's settle record is skipped when reading the landing");
   assert.match(KERNEL, /reply_owed = status == "open" and \(turn_open or queued > 0 or owes_first/);
   assert.match(RENDER, /else if \(m\.type === "commentSendFailed" && m\.tid\) \{\s*\n\s*cmtAwaitBase\.delete\(String\(m\.tid\)\);/, "a refused send releases its latch");
-  assert.match(RENDER, /unread: false, replyOwed: true, promotedName: "", msgs: \[\], name: nm \|\| "comment"/,
+  assert.match(RENDER, /unread: false, replyOwed: true, promotedName: "", msgs: \[\],\s*\n\s*name: nm \|\| nameBox\?\.dataset\.prefill \|\| "comment"/,
     "the synthetic thread owes its reply from the click");
   assert.match(COMMENTS, /replyOwed\?: boolean;/);
 });

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -347,7 +347,9 @@ test("the highlight is highlighter-YELLOW — never the selection blue — and o
 });
 
 test("the create dialog names the thread right there: prefilled <session>-comment-<N>, validated", () => {
-  assert.match(UI, /nameBox\.value = commentDrafts\.get\(nk\)\s*\n\s*\|\| \(\(sess0\?\.name \|\| "session"\)\.replace\(\/\[\^A-Za-z0-9._-\]\/g, "-"\)\s*\n\s*\+ "-comment-" \+ \(\(commentThreads\.get\(sid\) \|\| \[\]\)\.length \+ 1\)\);/);
+  // T289: the prefill is a HINT from the BARE session name (comment-name.ts), remembered on the box so an
+  // untouched one is sent as "" and the kernel picks its own default
+  assert.match(UI, /const prefill = defaultCommentName\(sess0\?\.name, sid, \(commentThreads\.get\(sid\) \|\| \[\]\)\.length\);\s*\n\s*nameBox\.dataset\.prefill = prefill;\s*\n\s*nameBox\.value = commentDrafts\.get\(nk\) \|\| prefill;/);
   // the name lives IN the header ("New comment: <name>"), the button says Comment, and the picks ride along
   assert.match(UI, /"New comment:"/);
   assert.match(UI, /if \(nameBox\) head\.append\(title, nameBox, closeBtn\);/);

--- a/ui/webview/fork-session.test.ts
+++ b/ui/webview/fork-session.test.ts
@@ -63,7 +63,8 @@ test("the fork button sits INLINE, right of the worked-seconds label — never i
 
 test("the modal defaults to <session>-fork and posts forkSession {id, uuid, name}", () => {
   assert.match(RENDER, /function showForkPrompt\(sid: string, uuid: string\): void \{/);
-  assert.match(RENDER, /input\.value = base \+ "-fork";/);
+  assert.match(RENDER, /const base = defaultForkName\(sess\?\.name, sid\);/);   // <bare session>-fork (T289: never the viewer's host label)
+  assert.match(RENDER, /input\.value = base;/);
   assert.match(RENDER, /if \(!\/\^\[A-Za-z0-9._-\]\+\$\/\.test\(name\)\) \{ input\.classList\.add\("bad"\); input\.focus\(\); return; \}/);
   assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "forkSession", id: sid, uuid, name \}\);/);
   // the instant acknowledgement is the provisional tab, name-joined like a picker create

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -58,6 +58,7 @@ import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser
 import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
 import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
+import { defaultCommentName, defaultBreakoutName, defaultForkName, nameToSend } from "./comment-name";
 import { followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow, followTailShrink } from "./scroll-keep";
 import { retainLiveOmitted } from "./tab-order";
 import { userTurnShows } from "./user-turn-content";
@@ -8081,7 +8082,7 @@ function moveFailedLocal(sid: string, name: string, text: string): void {
 // joined by NAME when the real session lands — exactly the picker-create flow.
 function showForkPrompt(sid: string, uuid: string): void {
   const sess = sessions.get(sid);
-  const base = (sess?.name || "session").replace(/[^A-Za-z0-9._-]/g, "-");
+  const base = defaultForkName(sess?.name, sid);   // the bare name: the host label is this viewer's (T289)
   document.getElementById("fork-prompt")?.remove();
   const overlay = el("div", "picker-overlay confirm-overlay"); overlay.id = "fork-prompt";
   const box = el("div", "picker-box confirm-box");
@@ -8091,7 +8092,7 @@ function showForkPrompt(sid: string, uuid: string): void {
     ? "A new session continues the conversation to just below this response; this one is untouched."
     : "A new session continues this whole conversation; this one is untouched.";
   const input = document.createElement("input");
-  input.type = "text"; input.className = "fork-name"; input.value = base + "-fork";
+  input.type = "text"; input.className = "fork-name"; input.value = base;
   input.setAttribute("autocapitalize", "off"); input.setAttribute("autocomplete", "off");
   input.setAttribute("autocorrect", "off"); input.setAttribute("spellcheck", "false");
   const actions = el("div", "confirm-actions");
@@ -8921,7 +8922,10 @@ function commentSendFromPop(pop: HTMLElement): void {
   const create = pendingCommentAnchor;
   if (create) {
     const nameBox = pop.querySelector(".cmt-name") as HTMLInputElement | null;
-    const nm = (nameBox?.value || "").trim();
+    // an UNTOUCHED prefill is sent as "" — the kernel picks its own default (bare name, next free number);
+    // only a name the user typed is theirs (T289: the prefill, sent as a chosen name, collided with the
+    // thread the same prefill had named before, and the owning kernel refused the create)
+    const nm = nameToSend(nameBox?.value || "", nameBox?.dataset.prefill || "");
     if (nm && !/^[A-Za-z0-9._-]+$/.test(nm)) { nameBox?.classList.add("bad"); nameBox?.focus(); return; }
     if (send) { send.disabled = true; send.classList.add("busy"); }   // ack before the round-trip (the ➤
     //                                       dims); the draft survives until commentCreated adopts the thread
@@ -8930,7 +8934,8 @@ function commentSendFromPop(pop: HTMLElement): void {
     // so its never-listed tid unwraps through the standard sweep the moment the real thread lands
     const synth: CommentThread = { tid: "pending:" + create.uuid, anchorUuid: create.uuid,
       exact: create.exact, status: "open", createdT: Date.now() / 1000, state: "working",
-      unread: false, replyOwed: true, promotedName: "", msgs: [], name: nm || "comment", color: create.color || "" };
+      unread: false, replyOwed: true, promotedName: "", msgs: [],
+      name: nm || nameBox?.dataset.prefill || "comment", color: create.color || "" };   // the hint, until the kernel's frame names it
     const cur0 = commentThreads.get(create.sid) || [];
     commentThreads.set(create.sid, [...cur0.filter((t) => t.tid !== synth.tid), synth]);
     cmtAwaitBase.set(synth.tid, { ...CMT_LATCH_ZERO });   // the SEND gesture latches the pulse — before any kernel round-trip (T102); released once a frame acknowledges the send (T237)
@@ -9004,7 +9009,10 @@ function renderCommentPopover(): void {
   if (create) {
     // the name lives IN the header — "New comment: <name>" — bold and editable right there (the
     // user 2026-08-17); prefilled <session>-comment-<N>, drafted under its own key so a refused
-    // create hands an edited name back too
+    // create hands an edited name back too. The prefill is a HINT built from the session's BARE name
+    // (a remote session displays as "host:name", and the host is this viewer's label, never part of
+    // the name the owning kernel knows — comment-name.ts); left untouched, it is sent as "" and the
+    // kernel picks its own default (T289).
     const nk = "newname:" + create.uuid;
     nameBox = document.createElement("input");
     nameBox.type = "text";
@@ -9013,10 +9021,10 @@ function renderCommentPopover(): void {
     nameBox.setAttribute("autocomplete", "off");
     nameBox.setAttribute("spellcheck", "false");
     const sess0 = sessions.get(sid);
-    nameBox.value = commentDrafts.get(nk)
-      || ((sess0?.name || "session").replace(/[^A-Za-z0-9._-]/g, "-")
-          + "-comment-" + ((commentThreads.get(sid) || []).length + 1));
-    nameBox.title = "The comment's name — edit it right here";
+    const prefill = defaultCommentName(sess0?.name, sid, (commentThreads.get(sid) || []).length);
+    nameBox.dataset.prefill = prefill;
+    nameBox.value = commentDrafts.get(nk) || prefill;
+    nameBox.title = "Suggested name; type to choose your own";
     if (create.color) nameBox.style.color = create.color;   // its identity color, distinct from the parent's
     const nb = nameBox;
     nb.addEventListener("input", () => { nb.classList.remove("bad"); commentDrafts.set(nk, nb.value); });
@@ -9329,7 +9337,7 @@ function renderCommentPopover(): void {
 function showBreakoutPrompt(sid: string, tid: string): void {
   const sess = sessions.get(sid);
   const thName = (commentThreads.get(sid) || []).find((t) => t.tid === tid)?.name || "";
-  const base = thName || ((sess?.name || "session").replace(/[^A-Za-z0-9._-]/g, "-") + "-thread");
+  const base = thName || defaultBreakoutName(sess?.name, sid);   // the bare name: the host label is this viewer's (T289)
   document.getElementById("fork-prompt")?.remove();
   const overlay = el("div", "picker-overlay confirm-overlay");
   overlay.id = "fork-prompt";
@@ -15312,6 +15320,9 @@ listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: M
   else if (m.type === "commentCreated" && m.id && m.tid) {
     if (m.uuid) cmtCreateInFlight.delete(String(m.uuid));   // the ack retires the retry hold
     if (m.uuid) commentDrafts.delete("new:" + String(m.uuid));
+    if (m.uuid) commentDrafts.delete("newname:" + String(m.uuid));   // a typed name dies with its ack even when the
+    //                                                                  popover closed first — else it resurfaces as a
+    //                                                                  TAKEN name on the next comment here (T289 review)
     if (pendingCommentAnchor && pendingCommentAnchor.sid === m.id) {
       const tid = String(m.tid);
       if ((commentThreads.get(String(m.id)) || []).some((t) => t.tid === tid)) adoptCommentThread(String(m.id), tid);


### PR DESCRIPTION
## What

A comment made on a REMOTE session's transcript (a session of another attached kernel, viewed through federation) could be refused with the create door's toast: `"<host>-<session>-comment-N" is a comment thread of <session> — open it from that session's comments, or pick another name`. The user saw it after typing what they took to be a follow-up in a thread, on a laptop viewing a devbox session.

Root cause (convicted in code and in the owning kernel's comments store): the comment dialog prefilled its name box from the viewer's DECORATED session name (`host:name`, which federation prefixes on every session-bearing frame) sanitized to `host-name-comment-N`, with N = the threads the VIEWER knew + 1, and sent that prefill as if the user had chosen it. The kernel treats any non-empty name as the user's explicit choice: it claims it verbatim (no host-label stripping, no numbering past a taken name) and refuses when taken. So the first comment stored a thread literally named with the viewer's host label, and the next dialog (the viewer's count regresses when a thread is deleted, and lags when a create's ack is lost, or after the dashboard reloads) prefilled the same name and was refused. The routing was never the defect: both `commentCreate` and `commentReply` carry the parent's host-prefixed sid and reach the owning kernel by it.

## The fix

- **Client (`ui/webview/comment-name.ts`, new; `ui/webview/render.ts`):** the prefill is built from the BARE session name (`host-prefix.ts`, the rename dialog's rule since 2026-08-02) for the comment, break-out and fork dialogs (the fork's name is required, so its labelled prefill was always sent: the same defect one dialog over, found in review); the comment dialog remembers what it prefilled, and an UNTOUCHED prefill is sent as `""`, so the owning kernel picks its own default (bare name, next free number). A typed name is still the user's choice; its draft now dies with the create's ack even when the popover closed first (it resurfaced as a taken name on the next comment on that message). The box is worded as a suggestion.
- **Kernel (`kernel/kernel.py`):** a comment create is idempotent on its identity (parent sid, anchor uuid, passage, text). Both doors that can run one create (the WebSocket handler on a server thread, the pusher's parked retry) reserve the identity under one lock before creating: a repeat of a completed create is answered with the SAME open thread's ack (and a kernel log line says so); a copy arriving while the other door holds the identity gets the typed transient nack, so the popover keeps its mark and adopts the thread from the pusher's ack; a lag-parked create is parked once. A repeat whose thread was resolved, merged or promoted is a NEW comment, never a swallowed one. This closes the second route into the same refusal the trace found: a create parked for transcript lag is retried by both the pusher and the client, and before this the second copy either collided on its explicit name or, with the name now left to the kernel, would have minted a duplicate thread. Every thread-name refusal at the create, break-out and rename doors now also writes a kernel log line (before, only a toast the viewer could miss, and the refusing kernel's log held no trace).

## Tests (red first)

- `ui/webview/comment-name.test.ts`: the pure rules (bare name, comment/break-out/fork prefills, untouched → empty) and pins that all three dialogs use them, that no decorated-name stem remains anywhere in render.ts, and that a typed name's draft dies with the ack.
- `ui/webview/comment-remote-routing.test.ts`: `commentReply` and `commentCreate` for a remote session route to the owning host by sid with tid and name untouched (the suspected routing, pinned sound).
- `tests/test_comment_name_refusal_log.py`: a create under a taken name is refused aloud AND logged; an empty name takes the kernel's default past the taken one; the break-out and rename doors log their name refusals.
- `tests/test_comment_create_idempotent.py`: the same create twice yields one thread and two acks naming it; a different comment on the same passage is a second thread; a lag-parked create is parked once; the client's re-post after a parked create landed is answered with the same thread; a re-post arriving on another thread WHILE the pusher's retry is creating does not mint a second thread (the race, red before the reservation); a repeat after the thread was resolved is a new comment; an answered repeat is logged.
- `tests/test_remote_comment_name_served.py` (both kernels run with the shared postal bus off and clean up on every exit path): a hub kernel with a second hermetic kernel checked in as host TESTHOST (the mobile handshake, no ssh); the real /chat page opens the remote session from its host-prefixed tab, selects a passage, opens Comment, and the send is captured at the socket: the prefill reads `web-comment-1` (main: `TESTHOST-web-comment-1`), and the frame carries an empty name on the `/remote/TESTHOST/ws` relay with the parent's bare sid.

Existing pins on the dialog's prefill line were updated to the new shape. Synthetic fixtures only.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
