### PR TITLE
Tunnel rows carry a recovery counter, and the dashboard treats a bump as the host coming back (T291b)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16628,7 +16628,40 @@ def _note_poll(r, answered):
         return False
     r["ok_polls"] = 0
     r["misses"] = int(r.get("misses") or 0) + 1
+    r["_poll_miss"] = True                           # a REAL silent poll: the recovery counter's evidence (T291b)
     return r["misses"] >= STALE_MISSES
+
+
+def _note_recovery(r, st):
+    """The row's RECOVERY counter (T291b, the user 2026-09-09): bumped once when a pass that ANSWERED finds
+    the row had missed polls, or was not up — the event a dashboard needs when a data-path request failed
+    through a link whose status never left "up" (a request that timed out mid-transfer, a re-dial the
+    supervisor's next poll answered): /tunnels serves it, and the dashboard's poll treats a change as the
+    host coming back (hostUp), so the previews parked on that link make their one attempt. Called once per
+    pass after `st` is final and before the pass overwrites the row's status.
+    Two guards from the review: (1) only a pass whose poll answered counts — after this pass's bookkeeping
+    that is exactly misses == 0 (a second silent poll under the stale bound keeps the row's "up" without
+    anyone answering, and must not read as a recovery); (2) a miss a DATA PATH preloaded (_demand_redial's
+    timeout) mints one bump until a real silent poll or a status change re-arms it, so a request that keeps
+    stalling on a healthy link cannot mint its own recovery, retry, stall, and mint again forever. A steady
+    healthy row never bumps; a fresh boot starts at 0 (the counter describes THIS process, like the poll run
+    counters, and is not saved). Returns whether it bumped."""
+    answered = st == "up" and int(r.get("misses") or 0) == 0
+    if not answered:
+        if st != "up":
+            r.pop("_demand_bumped", None)            # a status change re-arms the demand path
+        return False
+    real_miss = bool(r.pop("_poll_miss", False))
+    demand_miss = bool(r.pop("_demand_miss", False))
+    had_miss = real_miss or (demand_miss and not r.get("_demand_bumped"))
+    bumped = had_miss or r.get("status") != "up"
+    if bumped:
+        r["upSeq"] = int(r.get("upSeq") or 0) + 1
+    if bumped and demand_miss and not real_miss:
+        r["_demand_bumped"] = True                   # one demand-sourced bump until the link shows a real miss
+    if real_miss:
+        r.pop("_demand_bumped", None)
+    return bumped
 
 
 def _tunnel_established(r):
@@ -17980,7 +18013,16 @@ def _demand_redial(host, kind):
     finish — each user action buys at most one fresh dial, never a storm."""
     with _remotes_lock:
         r = _remotes.get(host)
-        if not r or r.get("checkin_peer"):
+        if not r:
+            return
+        if r.get("checkin_peer"):
+            # no ssh of ours to terminate or back off; but a starved request is still one silent poll's worth
+            # of evidence (T291b): the woken pass's answer bumps the recovery counter the same way it does
+            # for an ssh row, so a mobile's link that stayed "up" heals its parked previews too
+            if kind == "timeout":
+                r["misses"] = max(int(r.get("misses") or 0), STALE_MISSES - 1)
+                r["_demand_miss"] = True
+                _tunnel_wake.set()
             return
         alive = _tunnel_proc_alive(r)
         if kind == "refused" and alive and isinstance(r.get("restartExpected"), dict):
@@ -17997,6 +18039,7 @@ def _demand_redial(host, kind):
                 pass
         elif alive and kind == "timeout":
             r["misses"] = max(r.get("misses", 0), STALE_MISSES - 1)
+            r["_demand_miss"] = True                 # a data-path preload, not a real silent poll (T291b: one bump until a real miss)
     _tunnel_wake.set()
 
 
@@ -18147,7 +18190,9 @@ def _remote_public(r):
             "fails": int(r.get("fails") or 0), "nextTry": int(r.get("next_try") or 0),
             # not live: everything above derived from kernel_sha / the peer's declared tier is a memory of
             # the last successful exchange. lastOk is when that was (0 = never seen up this process).
-            "stale": stale, "lastOk": int(r.get("last_ok") or 0)}
+            "stale": stale, "lastOk": int(r.get("last_ok") or 0),
+            # the recovery counter (T291b): a change while "up" is a link that answered again after misses
+            "upSeq": int(r.get("upSeq") or 0)}
 
 
 _remotes_saved_sig = None   # signature of the last blob written — lets the supervisor save ONLY on a real
@@ -18164,6 +18209,8 @@ _NOT_SAVED = ("proc",       # the live Popen
               #               survive a kernel restart; the boot's first poll re-reads, the gate unstamped
               "misses",     # the poll run counters: they describe THIS connection, and a fresh boot
               "ok_polls",   # dials from scratch, so carrying them across would judge a link that is gone
+              "upSeq",      # the recovery counter (T291b): the same per-process story; the dashboard skips a first observation
+              "_poll_miss", "_demand_miss", "_demand_bumped",   # the counter's evidence marks: this process's, like misses
               "_checkin_refused")   # the mobile's memo of a hub refusing the name it declared: a boot is
 #                                     an event that re-arms the send (review find, 2026-09-08)
 
@@ -21281,6 +21328,7 @@ def _tunnel_supervisor():
                         elif silent:
                             # a miss, but not yet a run of them: say so and leave the link alone
                             st = r.get("status") or st
+                    _note_recovery(r, st)   # an answered pass after misses, or a not-up→up: the dashboard's hostUp (T291b)
                     if not (st == "down" and r.get("status") == "error") and not r.get("booting"):
                         # Every status CHANGE on the record, so an outage leaves a timeline instead of a
                         # single end-state to reason backwards from: when it flipped, what the end-to-end

--- a/tests/test_kernel_tunnel_truth.py
+++ b/tests/test_kernel_tunnel_truth.py
@@ -42,6 +42,103 @@ class TunnelStatus(unittest.TestCase):
         self.assertEqual(km._tunnel_status(False, False, False), "down")
 
 
+class RecoveryCounter(unittest.TestCase):
+    """T291b (the user 2026-09-09): a row's recovery counter bumps ONLY when a pass that ANSWERED finds the row
+    had missed polls (or was not up), never on a steady answered poll and never on a silent pass — the event a
+    dashboard turns into hostUp for the previews parked on a link whose status never left "up". A miss a data
+    path preloaded mints one bump until a real silent poll or a status change re-arms it (the review's find: a
+    request that keeps stalling must not mint its own recovery, retry, stall and mint again forever)."""
+
+    def _pass(self, r, answered, st="up"):
+        """One supervisor pass's bookkeeping in the ssh branch's order: the poll, then the recovery."""
+        km._note_poll(r, answered)
+        return km._note_recovery(r, st)
+
+    def test_a_steady_up_row_never_bumps(self):
+        r = {"host": "TESTHOST", "status": "up", "misses": 0}
+        for _ in range(5):
+            self.assertFalse(self._pass(r, answered=True))
+        self.assertEqual(int(r.get("upSeq") or 0), 0)
+
+    def test_a_real_miss_then_an_answer_bumps_once(self):
+        r = {"host": "TESTHOST", "status": "up", "misses": 0}
+        self.assertFalse(self._pass(r, answered=False), "a silent pass is not a recovery")   # misses 1, the row keeps "up"
+        self.assertFalse(self._pass(r, answered=False), "a SECOND silent pass under the stale bound is not one either")
+        self.assertNotIn("upSeq", r)
+        self.assertTrue(self._pass(r, answered=True), "the poll answered again: the recovery")
+        self.assertEqual(r["upSeq"], 1)
+        self.assertFalse(self._pass(r, answered=True), "the following steady pass does not bump again")
+        self.assertEqual(r["upSeq"], 1)
+
+    def test_a_demand_preload_bumps_once_until_a_real_miss_or_a_status_change_rearms_it(self):
+        # the relay's timed-out request preloads misses (_demand_redial "timeout"); the woken pass answers
+        r = {"host": "TESTHOST", "status": "up", "misses": 0}
+        r["misses"], r["_demand_miss"] = km.STALE_MISSES - 1, True
+        self.assertTrue(self._pass(r, answered=True))
+        self.assertEqual(r["upSeq"], 1)
+        # the same request stalls again on a link whose polls never missed: no second bump, no retry loop
+        r["misses"], r["_demand_miss"] = km.STALE_MISSES - 1, True
+        self.assertFalse(self._pass(r, answered=True), "a demand preload mints one bump until the link shows a real miss")
+        self.assertEqual(r["upSeq"], 1)
+        # a REAL silent poll re-arms it
+        self.assertFalse(self._pass(r, answered=False))
+        self.assertTrue(self._pass(r, answered=True))
+        self.assertEqual(r["upSeq"], 2)
+        r["misses"], r["_demand_miss"] = km.STALE_MISSES - 1, True
+        self.assertTrue(self._pass(r, answered=True), "re-armed: the next demand preload bumps again")
+        self.assertEqual(r["upSeq"], 3)
+        # …and so does a status change
+        r["misses"], r["_demand_miss"] = km.STALE_MISSES - 1, True
+        self.assertFalse(self._pass(r, answered=True))
+        km._note_recovery(r, "down")                           # the pass saw the link down
+        r["status"] = "down"
+        self.assertTrue(self._pass(r, answered=True), "back up: a recovery")
+        self.assertEqual(r["upSeq"], 4)
+
+    def test_a_not_up_row_coming_up_bumps_even_with_no_misses(self):
+        r = {"host": "TESTHOST", "status": "down", "misses": 0}   # a torn-down, redialed row: misses reset by the teardown
+        self.assertTrue(self._pass(r, answered=True))
+        self.assertEqual(r["upSeq"], 1)
+
+    def test_a_row_that_is_not_up_never_bumps(self):
+        r = {"host": "TESTHOST", "status": "up", "misses": 0}
+        km._note_poll(r, False)
+        for st in ("no-kernel", "down", "starting", "restarting"):
+            self.assertFalse(km._note_recovery(r, st), st)
+        self.assertNotIn("upSeq", r)
+
+    def test_a_checked_in_peers_timeout_preloads_the_miss_too(self):
+        saved = dict(km._remotes)
+        try:
+            km._remotes.clear()
+            km._remotes["TESTHOST"] = {"host": "TESTHOST", "checkin_peer": True, "proc": None, "status": "up", "misses": 0}
+            km._tunnel_wake.clear()
+            km._demand_redial("TESTHOST", "timeout")
+            r = km._remotes["TESTHOST"]
+            self.assertEqual(r["misses"], km.STALE_MISSES - 1, "the same evidence an ssh row's timeout files")
+            self.assertTrue(r.get("_demand_miss"))
+            self.assertTrue(km._tunnel_wake.is_set(), "the supervisor is woken to decide now")
+            # the checkin branch's bookkeeping: an answered poll, then the recovery
+            km._note_poll(r, True)
+            self.assertTrue(km._note_recovery(r, "up"))
+            self.assertEqual(r["upSeq"], 1)
+        finally:
+            km._remotes.clear(); km._remotes.update(saved); km._tunnel_wake.clear()
+
+    def test_the_tunnels_row_serves_it_and_the_store_never_saves_it(self):
+        for k in ("upSeq", "_poll_miss", "_demand_miss", "_demand_bumped"):
+            self.assertIn(k, km._NOT_SAVED, k + ": a per-process mark, like the poll run counters")
+        src = open(os.path.join(BIN, "romp-kernel"), encoding="utf-8").read()
+        self.assertIn('"upSeq": int(r.get("upSeq") or 0)}', src, "_remote_public serves the counter beside lastOk")
+        # the supervisor pass notes the recovery once st is final, against the PREVIOUS status
+        call = "_note_recovery(r, st)   # an answered pass after misses"   # the pass's call site, not the def
+        self.assertIn(call, src)
+        self.assertLess(src.index(call), src.index('r["status"] = st                   # keep a richer spawn-error label'),
+                        "noted before the pass overwrites the status")
+        self.assertIn('r["_poll_miss"] = True', src, "a real silent poll leaves its mark")
+        self.assertEqual(src.count('r["_demand_miss"] = True'), 2, "both the ssh row's and the checked-in peer's timeout preload")
+
+
 class ExpectedRestart(unittest.TestCase):
     """T238: a restart the DIALING side caused (its p2p update) must read as 'restarting after update',
     never as a dead far kernel — no red no-kernel, no terminated ssh, no backoff step — until the event

--- a/ui/webview/federation-reconnect.test.ts
+++ b/ui/webview/federation-reconnect.test.ts
@@ -448,6 +448,31 @@ test("a host that ATTACHES is pending from that moment: the poll re-emits the me
   }
 });
 
+test("the kernel's recovery counter bumping while a row reads up is a hostUp: one per bump, none on a first observation or a steady poll (T291b)", async () => {
+  const g: any = globalThis;
+  const hadFetch = "fetch" in g, prevFetch = g.fetch;
+  let seq = 4;
+  g.fetch = async () => ({ json: async () => ({ tunnels: [{ host: "TESTHOST", hasToken: true, localPort: 5, status: "up", upSeq: seq }] }) });
+  try {
+    await withManager(async (fm, emitted) => {
+      fm.app = "feed";
+      const hostUps = () => emitted.filter((m) => m && m.type === "hostUp");
+      await fm.poll();                                  // first observation: the counter is recorded, never fired
+      assert.equal(hostUps().length, 0, "a first observation is not a recovery");
+      await fm.poll();                                  // steady: same counter, same status
+      assert.equal(hostUps().length, 0, "a steady answered row fires nothing");
+      seq = 5;                                          // the kernel noted a miss-then-answer while the row stayed up
+      await fm.poll();
+      assert.deepEqual(hostUps().map((m) => m.hosts), [["TESTHOST"]], "one hostUp for the bump, the status never having left up");
+      await fm.poll();
+      assert.equal(hostUps().length, 1, "…and none for the same counter again");
+      fm.conns.get("TESTHOST").closed = true;
+    });
+  } finally {
+    if (hadFetch) g.fetch = prevFetch; else delete g.fetch;
+  }
+});
+
 test("…but never drops an EMPTY merged feed onto a page still waiting for its local kernel", async () => {
   const g: any = globalThis;
   const hadFetch = "fetch" in g, prevFetch = g.fetch;

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -794,6 +794,10 @@ export class FederationManager {
   private perHostTlBars: Record<string, any> = {}; // last timeline {type:"bars"} detail per host
   private hostSeq: string[] = [LOCAL]; // local first, then attach order — fixes the group order in the strip
   private downHosts = new Set<string>(); // attached, but its tunnel isn't up: what's on screen is a memory
+  // each host's recovery counter as last seen (/tunnels upSeq, T291b): the kernel bumps it when a row that had
+  // missed polls answers again, so a link that failed a request while its status never left "up" still has a
+  // recovery event; a change is treated as that host coming back (hostUp). A first observation is not a bump.
+  private upSeq = new Map<string, number>();
   private lastSeen: Record<string, number> = {}; // host -> epoch secs of its last `up` poll
   // the page's performance collector (ui/webview/perf-telemetry.ts), set by start(); inbound() times its own
   // merge and dispatch through it as fed:<type>, nested outside the pane's handler. Public so a test can hand
@@ -1413,6 +1417,14 @@ export class FederationManager {
     // state; the down→up transition is the exact moment the relay works again, so it dispatches
     // through the same message path and the heal fires with zero chat traffic.
     const recovered = [...this.downHosts].filter((h) => want.has(h) && !down.has(h));
+    // …and the kernel's recovery counter (T291b): a bump while the row reads "up" is a link that answered again
+    // after missing, which the status alone never showed; one hostUp per bump, never one per poll or per push
+    for (const [host, t] of want) {
+      const seq = Number(t.upSeq) || 0, prev = this.upSeq.get(host);
+      this.upSeq.set(host, seq);
+      if (prev !== undefined && seq !== prev && !down.has(host) && !recovered.includes(host)) recovered.push(host);
+    }
+    for (const host of [...this.upSeq.keys()]) if (!want.has(host)) this.upSeq.delete(host);
     if (recovered.length) window.dispatchEvent(new MessageEvent("message", { data: { type: "hostUp", hosts: recovered } }));
     this.downHosts = down;
     if (changed) window.dispatchEvent(new Event("romp-hosts"));   // panes repaint their disconnected marks

--- a/ui/webview/preview-retry-pace.test.ts
+++ b/ui/webview/preview-retry-pace.test.ts
@@ -151,6 +151,29 @@ test("a NON-link failure keeps the bounded per-message budget, and even those at
   assert.match(box.shape(), /span\.path-full-wait\[\]\{img\.path-load-spin\[\]\{""\},span\.path-load-note\[\]\{"fetching…"\}\}/, "a tap shows the swirl and the note: the chip is the give-up state only");
 });
 
+test("a link failure while the tunnel row never left up heals once on the recovery counter's hostUp (T291b)", async () => {
+  // the kernel bumps the row's upSeq when a row that had misses answers again; federation's poll turns the bump into
+  // hostUp; render.ts drains the settled previews on hostUp — so the parked box makes exactly one attempt
+  fetchCalls = 0;
+  const { P, box } = await armedBox("/home/user/notes-api/plots/queue-depth.png");
+  fetchAnswer = failWith(502, "tunnel to TESTHOST is not answering; re-dialing");
+  P.retryFailedPreviews(); await sleep(20); await sleep(450);   // the budget's one attempt names the link
+  const parked = box.shape();
+  assert.match(parked, /retries when the link is back/);
+  const before = fetchCalls;
+  for (let i = 0; i < 30; i++) P.retryFailedPreviews();
+  await sleep(450);
+  assert.equal(fetchCalls, before, "the status stayed up and pushes kept coming: no attempt");
+  P.refreshSettledPreviews();                                    // what the bump's hostUp runs (render.ts)
+  await sleep(20);
+  assert.equal(fetchCalls, before + 1, "the counter's hostUp: exactly one attempt");
+  assert.equal(box.shape(), parked, "the box did not move for it");
+  const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+  assert.match(FED, /if \(prev !== undefined && seq !== prev && !down\.has\(host\) && !recovered\.includes\(host\)\) recovered\.push\(host\);/, "a bump while up is a recovery");
+  const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+  assert.match(RENDER, /if \(m\.type === "hostUp"\) \{ refreshSettledPreviews\(\); healPathImgs\(\); \}/, "hostUp drains the settled previews");
+});
+
 test("the source keeps the two rules where the behaviour lives", () => {
   assert.match(PREVIEW, /if \(transient\) settledPreviews\.set\(box, \(\) => build\(true\)\);\s*\n\s*else \{ autoRetries--; failedPreviews\.set\(box, \(\) => build\(true\)\); \}/,
     "a link failure registers for the reconnect-class heal only; a real verdict spends the budget on the per-message heal");


### PR DESCRIPTION
Closes the residual the preview fix left stated: a figure preview whose fetch failed through a link that never left "up" (a request that timed out mid-transfer while the supervisor's next poll answered, or a re-dial that came back between two dashboard polls) had no reconnect-class event to heal on once link failures stopped riding the per-push retry.

**Kernel.** The supervisor pass notes a recovery on each tunnel row: `_note_recovery(r, st, had_miss)` bumps the row's `upSeq` once when a row that had missed polls (read before the pass's own bookkeeping), or was not up, is up at the end of the pass. A steady healthy row never bumps; the counter is per process and not saved (like the poll run counters). `/tunnels` serves `upSeq` beside `lastOk`.

**Dashboard.** Federation's tunnel poll remembers each host's counter; a change while the row reads up is treated as that host coming back and joins the same `hostUp` dispatch the down-to-up transition uses, so render.ts drains the settled previews once (they make their one attempt) and un-parks the path-image chips. One event per bump, none on a first observation or a steady poll; no per-push retry returns.

**Tests.** The kernel bump rule (`tests/test_kernel_tunnel_truth.py`: a steady row never bumps, a miss-then-answer bumps once and only once, a not-up row coming up bumps, a row that is not up never bumps, the row serves it and the store never saves it, the pass reads the misses before its bookkeeping and notes against the previous status); the dashboard poll (`federation-reconnect.test.ts`, executed: a first observation fires nothing, a steady poll nothing, a bump one `hostUp`, the same counter again nothing); the preview (`preview-retry-pace.test.ts`, executed: a link failure with the row staying up makes no attempt under thirty pushes and exactly one when the bump's `hostUp` drains the settled previews, with the box unmoved).

**From the adversarial review, folded in before arming.** The bump requires a pass whose poll ANSWERED (after the pass's bookkeeping, misses is zero): a second silent poll under the stale bound keeps the row's "up" without anyone answering and used to read as a recovery, which would have fired `hostUp` into a link the supervisor already knew was dying. A miss a data path preloaded (`_demand_redial`'s timeout) mints one bump until a real silent poll or a status change re-arms it, so a request that keeps stalling on a healthy link cannot mint its own recovery, retry, stall and mint again forever; a real silent poll leaves its own mark. A checked-in peer's timeout preloads the miss and wakes the supervisor like an ssh row's, so a mobile's link that stayed "up" heals its parked previews too. The kernel tests cover each: the second silent pass, the demand bound and its two re-arms, the checked-in peer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
