### PR TITLE
A refused clear, drop or undo names goals/<sid>.json in its dialog, not the absolute state path

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -30820,7 +30820,7 @@ def _mark_nodes_cleared(item_ids, value, src="user", why=None):
     for sid, ids in by_sid.items():
         store, fault = jd.load_goals_or_fault(sid)
         if fault is not None:
-            skipped[sid] = str(fault)                  # its row is filed; the flag cannot be written on a store we
+            skipped[sid] = _store_fault_copy(fault)    # its row is filed; the flag cannot be written on a store we
             continue                                   # cannot read (the view-level clear still holds), the other
         nodes = store.get("nodes", {})                 # sessions' clears proceed, and the CALLER answers the user
         touched = False                                # (a WS gesture reports the refusal to its own socket)
@@ -30869,7 +30869,7 @@ def _mark_nodes_cleared(item_ids, value, src="user", why=None):
         jd.rollup_status(store, closed)
         fault = jd.save_goals_or_fault(sid, store)
         if fault is not None:
-            skipped[sid] = str(fault)                  # the store read a moment ago and faults at its SAVE (the
+            skipped[sid] = _store_fault_copy(fault)    # the store read a moment ago and faults at its SAVE (the
             continue                                   # save path's own strict reads, or the publish itself): the
         #                                                flag did not land, and the caller answers the user exactly
         #                                                as for a load fault. Left to raise, an OSError out of a WS
@@ -31031,6 +31031,22 @@ def _delegation_linked_ids(item_ids):
             if isinstance(o, dict) and o.get("peer") and o.get("goalId") in _nodes(o.get("peer")):
                 out.add(o["goalId"])                                          # recipient → sender (the tracking node)
     return out
+
+
+def _store_fault_copy(fault):
+    """The USER'S copy of a goal-store fault: str(fault) with the state root taken out of every path it
+    names, so the feed's err dialog says goals/<sid>.json rather than the absolute path under the home
+    directory. The same rule _oserror_text applies to the frames it serves: an absolute state path has no
+    business in a pane, and a federated dashboard shows the pane on another machine's screen. The errno
+    text and the file name stay, so the user still learns what refused and which file (one with several
+    sessions knows which store refused; _oserror_text drops the path whole, which is right for a frame that
+    dedupes on its text and wrong for a dialog about one session's file). The judge-errors row the boundary
+    files (_file_store_fault) keeps the whole str(e): the path is diagnostic there. The strip is textual,
+    on the root as jd.STATE spells it; every loader builds its path from jd.GOALDIR, so that is the prefix
+    a fault carries, and a failed publish's rename names two (the temp file and its destination): both lose
+    it."""
+    text = str(fault) or type(fault).__name__
+    return text.replace(str(jd.STATE) + os.sep, "")
 
 
 def _gesture_store_refusal(client, gesture, skipped):
@@ -31298,9 +31314,9 @@ def _restore_goal_archive(item_ids):
                 continue
             store, fault = jd.load_goals_or_fault(sid)
             if fault is not None:
-                skipped[sid] = str(fault)              # its row is filed; the archive keeps these nodes (nothing is
-                continue                               # restored INTO a store we cannot read), the other sessions'
-            nodes = store.setdefault("nodes", {})      # restores proceed, and the caller answers the user
+                skipped[sid] = _store_fault_copy(fault) # its row is filed; the archive keeps these nodes (nothing is
+                continue                                # restored INTO a store we cannot read), the other sessions'
+            nodes = store.setdefault("nodes", {})       # restores proceed, and the caller answers the user
             status = store.setdefault("status", {})
             # Journal the payload FIRST (the user 2026-07-10): once the archive save below lands, these nodes
             # exist only in the live store's save — a stale triage-pass save racing it would drop them from
@@ -31331,11 +31347,11 @@ def _restore_goal_archive(item_ids):
             # land AFTER the undo reopen it records, or the fold consumes it and the card returns to Working.)
             fault = jd.save_goals_or_fault(sid, store)
             if fault is not None:
-                skipped[sid] = str(fault)              # the publish did not land (a save-path read fault, or the
-                continue                               # write itself), so the archive is NOT saved: it keeps these
-            #                                            nodes for the next Undo, whose restore journal row replays
-            #                                            idempotently; the caller answers the user (review find,
-            #                                            2026-09-08: left to raise, this dropped the WS client)
+                skipped[sid] = _store_fault_copy(fault) # the publish did not land (a save-path read fault, or the
+                continue                                # write itself), so the archive is NOT saved: it keeps these
+            #                                             nodes for the next Undo, whose restore journal row replays
+            #                                             idempotently; the caller answers the user (review find,
+            #                                             2026-09-08: left to raise, this dropped the WS client)
             jd.save_goal_archive(sid, arch)
             _compact_seen.pop(sid, None)               # force a re-stat next sweep (we just changed the live file)
     return skipped

--- a/tests/test_goal_store_fault_boundary.py
+++ b/tests/test_goal_store_fault_boundary.py
@@ -596,6 +596,35 @@ class GestureRefusal(_World):
         self.assertIn(gid, json.loads((jd.GOALARCHDIR / (A + ".json")).read_text())["nodes"],
                       "the archive still holds the card for a later undo")
 
+    def test_the_refusal_names_the_goals_file_relative_to_the_state_root(self):
+        """The dialog's copy of the fault says goals/<sid>.json, never the absolute path under the home
+        directory: an absolute state path has no business in a pane (the rule _oserror_text already states
+        for the frames it serves), and a federated dashboard shows the pane on another machine's screen.
+        The errno text and the file name stay, so the user still learns what refused and which session's
+        store. The judge-errors row keeps the whole path, which is diagnostic there."""
+        self._compacted(A, NOW - 10)
+        with _fault_on(self.a_file):
+            sent = self._dispatch({"type": "undoClear"})
+        errs = [m for m in sent if m.get("type") == "err"]
+        self.assertEqual([m.get("sid") for m in errs], [A])
+        self.assertNotIn(self.td.name, errs[0]["text"], "the state root is not shown")
+        self.assertIn("goals/%s.json" % A, errs[0]["text"], "the file is still named, relative to the state root")
+        self.assertIn("Input/output error", errs[0]["text"], "and so is the fault")
+        self.assertIn(str(self.a_file), self._rows("store-unreadable")[0]["note"],
+                      "the judge-errors row keeps the whole path: it is diagnostic there")
+
+    def test_the_fault_copy_keeps_the_errno_text_and_the_file_name(self):
+        """The copy is str(fault) with the state root taken out of EVERY path it names: a failed publish's
+        rename names two, the temp file and its destination. A fault with no text at all reads as its type."""
+        fault = OSError(errno.EIO, "Input/output error", str(self.a_file))
+        self.assertEqual(km._store_fault_copy(fault), "[Errno 5] Input/output error: 'goals/%s.json'" % A)
+        tmp = jd.GOALDIR / (A + ".json.tmp.1.2.3")
+        fault = OSError(errno.ENOENT, "No such file or directory", str(tmp), None, str(self.a_file))
+        self.assertEqual(km._store_fault_copy(fault),
+                         "[Errno 2] No such file or directory: 'goals/%s.json.tmp.1.2.3' -> 'goals/%s.json'" % (A, A),
+                         "the root leaves both paths, not only the first")
+        self.assertEqual(km._store_fault_copy(ValueError()), "ValueError")
+
     def test_a_sub_goal_drop_the_fault_skipped_answers_with_its_own_account(self):
         """The modal's Drop is sub-task-only, and a sub-goal row renders from the node FLAG alone
         (cleared.jsonl hides TOP cards only) — the very write the fault refused. So the whole-card
@@ -614,6 +643,7 @@ class GestureRefusal(_World):
         self.assertEqual([m.get("sid") for m in errs], [A])
         self.assertIn("sub-goal was not cleared", errs[0]["title"])
         self.assertIn("Input/output error", errs[0]["text"], "it says why")
+        self.assertNotIn(self.td.name, errs[0]["text"], "the file is named relative to the state root")
         self.assertIn("nothing changed there", errs[0]["text"], "what happened: nothing")
         self.assertIn("Try it again", errs[0]["text"], "the true remedy: a retry appends a fresh row and sets the flag")
         self.assertNotIn("copy", errs[0])
@@ -655,8 +685,11 @@ class GestureRefusal(_World):
 
     def _assert_clear_refusal(self, err, before):
         """The whole-card clear dialog says exactly what happened: the card is off the board (its
-        cleared.jsonl row landed) but the durable flag was not written into a goals file romp could not read."""
+        cleared.jsonl row landed) but the durable flag was not written into a goals file romp could not read,
+        named as goals/<sid>.json, never by its absolute path."""
         self.assertIn("Input/output error", err["text"], "it says why")
+        self.assertNotIn(self.td.name, err["text"], "the file is named relative to the state root")
+        self.assertIn("goals/%s.json" % A, err["text"])
         self.assertIn("off the board", err["text"], "what did happen")
         self.assertIn("not written", err["text"], "what did not")
         self.assertNotIn("copy", err, "`copy` is the USER'S undelivered text by contract; romp's prose never rides it")
@@ -845,6 +878,7 @@ class GestureRefusal(_World):
         self.assertEqual([m.get("sid") for m in errs], [A])
         self.assertIn("undo", errs[0]["title"])
         self.assertIn("No such file or directory", errs[0]["text"], "it says why: the publish that failed")
+        self.assertNotIn(self.td.name, errs[0]["text"], "the temp it could not write is named relative to the root")
         self.assertIn("not restored", errs[0]["text"])
         self.assertEqual(self._undo_rows(), [B + ":g1"], "only the id whose publish LANDED is journaled as undone")
         self.assertEqual(km._cleared_ids(), {A + ":g1": NOW - 10}, "A's ids remain the newest cleared batch")


### PR DESCRIPTION
## Symptom

The err dialog that answers a clear, a sub-goal drop or an undo refused by an unreadable or unwritable goals file shows that file's absolute path under the home directory. The quoted fault reads `[Errno 5] Input/output error: '<state root>/goals/<sid>.json'`, with the state root spelled out in full, on whatever screen the dashboard is on; a federated dashboard shows it on another machine's screen.

## Cause

The four `skipped[sid] = str(fault)` sites (the load fault and the save fault in `_mark_nodes_cleared` and in `_restore_goal_archive`) hand `str(fault)` to `_gesture_store_refusal`, which interpolates it into the dialog's text. The fault is the OSError the loaders return; its filename is the path the store was read from, built from `jd.GOALDIR`, so it is absolute. `_oserror_text` already states the rule for the frames it serves (an absolute state path has no business in a pane), but nothing applied it to the gesture refusals.

## Fix

A new helper in kernel/kernel.py, `_store_fault_copy(fault)`, returns `str(fault)` (the type name when the fault has no text) with `str(jd.STATE) + os.sep` removed wherever it occurs, and the four sites use it. The dialog now reads `[Errno 5] Input/output error: 'goals/<sid>.json'`: the errno text and the file name stay, so the user still learns what refused and which session's store. A fault that names two paths, a failed publish's rename of the temp file onto its destination, loses the root from both. The strip is textual; every loader builds its path from `jd.GOALDIR`, so that is the prefix a fault carries. The judge-errors row `_file_store_fault` writes is unchanged and keeps the whole path, which is diagnostic there.

Alternative considered: calling the existing `_oserror_text(fault)` at the four sites also removes the path, but drops the file name with it (errno and strerror only). That suits a frame that dedupes on its text; a dialog about one session's file needs the name, or a user with several sessions cannot tell which store refused. The helper keeps it.

## Tests

All in tests/test_goal_store_fault_boundary.py, class GestureRefusal. Six of them take a gesture through the real dispatcher with the store faulting and check the dialog's text; the seventh calls the helper.

- `_assert_clear_refusal`, the check shared by `test_a_card_clear_the_fault_skipped_answers_the_socket_that_asked`, `test_a_clear_all_answers_once_per_session_and_reads_true_for_several_cards` and `test_a_fault_at_the_save_step_of_a_clear_answers_the_socket_instead_of_dropping_it`, now asserts that the err text does not contain the temporary state root and still names `goals/<sid>.json`. That covers the load-fault and the save-fault site of `_mark_nodes_cleared` for both clear gestures. Before the change all three fail on the state root appearing in the text.
- `test_a_sub_goal_drop_the_fault_skipped_answers_with_its_own_account` gains the absence check for the drop's dialog (the load-fault site of `_mark_nodes_cleared`, reached through nodeOverride). Fails the same way before the change.
- `test_the_refusal_names_the_goals_file_relative_to_the_state_root` (new): an undo of a compacted card whose store faults at the load (the load-fault site of `_restore_goal_archive`). Asserts that the err text does not contain the state root, still names `goals/<sid>.json` and `Input/output error`, and that the `store-unreadable` judge-errors row keeps the whole path. Fails on the state root before the change.
- `test_a_publish_that_fails_at_the_undo_answers_and_leaves_the_ids_owed` gains the absence check for the failed publish's temporary file path (the save-fault site of `_restore_goal_archive`). Fails the same way before the change.
- `test_the_fault_copy_keeps_the_errno_text_and_the_file_name` (new): the helper's exact text for an EIO on the goals file, for an ENOENT naming both the publish's temp file and its destination (both lose the root), and the type-name fallback for a fault with no text. Fails with AttributeError before the change.

Reverting any one of the four sites to `str(fault)` fails at least one of these tests; a helper that strips only the first occurrence fails the two-path case.

Before the change: 7 failed, 23 passed in the module. After: 30 passed. Full suite (`pytest -q -n 8 tests/`): 10200 passed, 61 skipped, 1671 subtests passed in 73.47s, 0 failed.

## Tier

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)