### PR TITLE
State root: an empty XDG_STATE_HOME reads as unset in every Python reader, as the shell surfaces already do

### DIFF
--- a/cli/idle_dots.py
+++ b/cli/idle_dots.py
@@ -42,7 +42,8 @@ from pathlib import Path
 
 HOME    = Path.home()
 STATE   = Path(os.environ.get("ROMP_STATE_DIR")   # per-kernel state root override (plans/multi-kernel.md)
-               or Path(os.environ.get("XDG_STATE_HOME", str(HOME / ".local/state"))) / "romp")
+               or Path(os.environ.get("XDG_STATE_HOME") or str(HOME / ".local/state")) / "romp")
+# `or`, not a .get default: an empty XDG_STATE_HOME is unset (the note at kernel/event_model.py's STATE).
 PIDFILE = STATE / "idle-dots.pid"
 
 STALE_AFTER_SECS = 3600          # 1h — matches dashboard STALE_AFTER_SECS + timeline STALE

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -32,7 +32,10 @@ from pathlib import Path
 
 HOME     = Path.home()
 STATE    = Path(os.environ.get("ROMP_STATE_DIR")   # per-kernel state root override (plans/multi-kernel.md)
-                or Path(os.environ.get("XDG_STATE_HOME", str(HOME / ".local/state"))) / "romp")
+                or Path(os.environ.get("XDG_STATE_HOME") or str(HOME / ".local/state")) / "romp")
+# `or`, not a .get default: an EMPTY XDG_STATE_HOME is unset (the XDG spec, and every shell reader's
+# ${XDG_STATE_HOME:-...}). A .get default kept the empty string and made the root the RELATIVE path
+# romp under the process cwd, so the kernel and the shell surfaces used different roots.
 PROJECTS = Path(os.environ.get("CLAUDE_CONFIG_DIR") or str(HOME / ".claude")) / "projects"   # per-kernel Claude root (plans/multi-kernel.md phase 2)
 NAMES    = STATE / "names"
 STATES_DIR   = STATE / "states"

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -63,7 +63,8 @@ _cred = sys.modules.get("romp_credentials") or SourceFileLoader(
 
 HOME     = Path.home()
 STATE    = Path(os.environ.get("ROMP_STATE_DIR")   # per-kernel state root override (plans/multi-kernel.md)
-                or Path(os.environ.get("XDG_STATE_HOME", str(HOME / ".local/state"))) / "romp")
+                or Path(os.environ.get("XDG_STATE_HOME") or str(HOME / ".local/state")) / "romp")
+# `or`, not a .get default: an empty XDG_STATE_HOME is unset (the note at event_model.py's STATE).
 # Keep the romp state root private (0700): it holds session names, prompts,
 # captions, goals, and postal message bodies. The traverse bit on the root is
 # enough to block other local users from reading anything beneath it. Runs on

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -67,14 +67,16 @@ BASE = f"http://{HOST}:{PORT}"
 KERNEL_BASE = "http://127.0.0.1:%s" % os.environ.get("ROMP_KERNEL_PORT", "29855")  # the dashboard kernel — it owns the backend session query (tmux + SDK)
 
 STATE = Path(os.environ.get("ROMP_STATE_DIR")      # per-kernel state root override (plans/multi-kernel.md)
-             or Path(os.environ.get("XDG_STATE_HOME", str(Path.home() / ".local/state"))) / "romp") / "postal"
+             or Path(os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local/state")) / "romp") / "postal"
+# `or`, not a .get default, here and at NAMES_DIR: an empty XDG_STATE_HOME is unset (the note at
+# kernel/event_model.py's STATE).
 MAILROOT = STATE / "mail"
 MAILPENDING = STATE / "mail-pending"   # touch <sid> here IFF that session has unread mail in new/
 WARNED = STATE / "warned-undelivered"  # marker per msg-id we've already warned a sender is STILL UNDELIVERED (one-time)
 LOG = STATE / "server.log"
 PIDFILE = STATE / "server.pid"
 NAMES_DIR = Path(os.environ.get("ROMP_STATE_DIR")
-                 or Path(os.environ.get("XDG_STATE_HOME", str(Path.home() / ".local/state"))) / "romp") / "names"
+                 or Path(os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local/state")) / "romp") / "names"
 TLDIR = STATE.parent / "timeline"     # append-only logs for the timeline view (messages.jsonl)
 SESSION_FLAGS = STATE.parent / "session-flags.json"   # the kernel's per-session view flags {sid:{flag:true}}; we honour postalServiceOff (legacy: postalOff)
 

--- a/tests/smoke_codex_live.py
+++ b/tests/smoke_codex_live.py
@@ -25,7 +25,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 
 RUNTIME_STATE = Path(os.environ.get("ROMP_STATE_DIR") or
-                     str(Path(os.environ.get("XDG_STATE_HOME", str(Path.home() / ".local/state"))) / "romp"))
+                     str(Path(os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local/state")) / "romp"))
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)
 cb = SourceFileLoader("romp_codex_backend_live", os.path.join(ROOT, "kernel", "codex_backend.py")).load_module()

--- a/tests/test_state_dir_override.py
+++ b/tests/test_state_dir_override.py
@@ -27,21 +27,29 @@ PY_SURFACES = [
     ("kernel/judge.py", "STATE", ""),
     ("postal/postal_service.py", "STATE", "/postal"),
     ("postal/postal_service.py", "NAMES_DIR", "/names"),
+    ("cli/idle_dots.py", "STATE", ""),
+    # The live Codex smoke helper reads the root to find the installed Codex runtime before it
+    # rebinds XDG_STATE_HOME to a scratch dir; nothing else executes it, so it is a row here.
+    ("tests/smoke_codex_live.py", "RUNTIME_STATE", ""),
 ]
 
 
-def _derive(module, attr, env):
+def _derive(module, attr, env, cwd=None):
     """Import `module` in a SUBPROCESS with exactly `env` and print its `attr` path. A subprocess so
-    each case gets a fresh import (the constants bind at import time) and a clean environment."""
+    each case gets a fresh import (the constants bind at import time) and a clean environment.
+    `cwd` defaults to the checkout; a case that could resolve a RELATIVE root passes a temp dir, since
+    judge.py mkdirs its root at import and a regression must not litter the checkout. TMPDIR is the
+    case's temp home, so a module that mkdtemps at import (the smoke helper) leaves nothing behind."""
     code = ("import importlib.util\n"
             "spec = importlib.util.spec_from_file_location('m', %r)\n"
             "m = importlib.util.module_from_spec(spec)\n"
             "try:\n    spec.loader.exec_module(m)\n"
             "except SystemExit:\n    pass\n"
             "print(getattr(m, %r))\n" % (str(ROOT / module), attr))
-    full = {"PATH": os.environ.get("PATH", ""), "HOME": env.pop("_HOME"), **env}
+    home = env.pop("_HOME")
+    full = {"PATH": os.environ.get("PATH", ""), "HOME": home, "TMPDIR": home, **env}
     out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True,
-                         env=full, cwd=str(ROOT), timeout=60)
+                         env=full, cwd=str(cwd or ROOT), timeout=60)
     self_desc = "%s.%s with %s" % (module, attr, {k: v for k, v in full.items() if k != "PATH"})
     assert out.returncode == 0, "%s failed: %s" % (self_desc, out.stderr[-400:])
     return out.stdout.strip().splitlines()[-1]
@@ -63,6 +71,19 @@ class PythonSurfaces(unittest.TestCase):
                 got = _derive(module, attr, {"_HOME": td, "XDG_STATE_HOME": td + "/xdg"})
                 self.assertEqual(got, td + "/xdg/romp" + suffix,
                                  "%s.%s must keep the XDG derivation" % (module, attr))
+
+    def test_empty_xdg_state_home_is_unset(self):
+        # XDG_STATE_HOME present but EMPTY reads as unset: the XDG spec says so, and every shell
+        # surface's ${XDG_STATE_HOME:-...} already does. A .get default kept the empty string and made
+        # the root the RELATIVE path romp under the process cwd, so a kernel started with a blank
+        # XDG_STATE_HOME= line kept its state (and looked for the SDK venv) under its cwd while the
+        # shell surfaces used the home root.
+        with tempfile.TemporaryDirectory() as td:
+            for module, attr, suffix in PY_SURFACES:
+                with self.subTest(module=module, attr=attr):
+                    got = _derive(module, attr, {"_HOME": td, "XDG_STATE_HOME": ""}, cwd=td)
+                    self.assertEqual(got, td + "/.local/state/romp" + suffix,
+                                     "%s.%s must read an empty XDG_STATE_HOME as unset" % (module, attr))
 
 
 WRAPPED = "${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}"


### PR DESCRIPTION
## Symptom

A kernel started with a blank `XDG_STATE_HOME=` line (a service.env entry with no value) keeps its state under the relative path `romp` in its working directory, while romp-sdk-setup, which builds the SDK venv, romp-service, the hooks and the manager use `~/.local/state/romp`. As the user sees it: the SDK venv that romp-sdk-setup installed is reported as not installed, because the kernel looks for it under its own state root. The same split applies to postal mail and session names, to the idle-dots pidfile, and to the Codex runtime the live smoke helper looks up.

## Cause

Six state-root lines read `os.environ.get("XDG_STATE_HOME", default)`, which keeps an empty value; `Path("") / "romp"` is the relative path `romp`, so the root follows the process cwd (and judge.py creates and chmods that relative directory at import). The XDG base-directory spec reads an empty variable as unset. Every shell surface's `${XDG_STATE_HOME:-...}` and the manager's `||` already do, and cli/update.py and cli/spend_rebuild.py already use the `or` form, so these six lines were the only readers that disagreed: five runtime readers (postal/postal_service.py STATE and NAMES_DIR, kernel/event_model.py, kernel/judge.py, cli/idle_dots.py) and the hand-run tests/smoke_codex_live.py's RUNTIME_STATE.

## Fix

- The five runtime lines fall through with `or`: `Path(os.environ.get("XDG_STATE_HOME") or str(HOME / ".local/state")) / "romp"`. One note at event_model.py states the rule; the other sites point to it.
- tests/smoke_codex_live.py's RUNTIME_STATE takes the same one-line change. It was the last instance of the idiom in the tree, and it reads the root to find the installed Codex runtime (`ensure_codex_sdk(RUNTIME_STATE)`) before rebinding XDG_STATE_HOME to a scratch dir, so it had the same failure mode. Included, and covered by the test below.
- Behaviour change, deliberate: anyone with XDG_STATE_HOME set to the empty string had their Python-side state under `./romp` and their shell-side state under `~/.local/state/romp`. The Python readers now join the shell surfaces on the home root.

## Tests

- `tests/test_state_dir_override.py::PythonSurfaces::test_empty_xdg_state_home_is_unset` (new): imports each PY_SURFACES module in a subprocess with exactly `{PATH, HOME=<temp>, TMPDIR=<temp>, XDG_STATE_HOME=""}` and asserts `<temp>/.local/state/romp` plus the module's suffix, one subTest per surface so a regression names every affected reader. Before the change it fails on all six: event_model STATE, judge STATE, idle_dots STATE and the smoke helper's RUNTIME_STATE print `romp`, postal STATE prints `romp/postal`, postal NAMES_DIR prints `romp/names` (6 failed, 8 passed, exit 1). After the change all six print the absolute path under the temp home (8 passed, 6 subtests passed). Reverting any one of the six lines alone turns exactly that surface's subTest red.
- PY_SURFACES gains two rows, `("cli/idle_dots.py", "STATE", "")` and `("tests/smoke_codex_live.py", "RUNTIME_STATE", "")`, so the existing override and default cases cover those readers too. Both cases pass before and after the change; the empty case is the only red.
- `_derive` takes an optional `cwd` and the empty case passes the temp dir: judge.py mkdirs its root at import, so a regression creates `romp/` in the temp dir rather than in the checkout. `_derive` also sets TMPDIR to the case's temp home, since the smoke helper mkdtemps at import; the checkout and /tmp stay clean either way.
- Full suite (`pytest -n 8 tests/`) on this head: 10203 passed, 62 skipped, 1677 subtests passed in 70.97 s, no failures.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)