### PR TITLE
PR links: the boundary before a reference is judged over the rendered text, not per text node

### DIFF
--- a/ui/webview/pr-links.test.ts
+++ b/ui/webview/pr-links.test.ts
@@ -4,10 +4,12 @@
 // rule and the DOM applier are EXECUTED here (pr-links.ts is pure but for createElement/createTextNode,
 // which a small plain-object DOM stand-in provides); the wiring into render.ts's md(), feed.ts and
 // fleet.ts is pinned at the source, the way the other webview tests pin the chat renderer.
+// The chat's own markdown shapes come from marked, read into the same stand-in.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { Marked } from "marked";
 
 // ── a DOM stand-in: text and element nodes with the handful of members the applier touches ─────────
 class T {
@@ -289,6 +291,205 @@ test("text already inside a link is never wrapped again", () => {
 test("the chat's path links are skipped, so a docs/x.md#12-shaped path stays the path it is", () => {
   const p = el("p", cls(el("span", "docs/x.md#12"), "file-uri-link"), " and ", cls(el("span", el("code", "https://x/#1")), "url-code-link"));
   assert.equal(linkifyPrRefs(p as unknown as Node, REPO), 0);
+});
+
+test("the boundary is judged over the rendered text: a reference at the head of a text node follows the character before that node", () => {
+  // the pure rule, given the character that precedes the text in the run it was cut from: a word character
+  // or a slash glues, a boundary does not, and no character at all is the start of the run
+  const after = (text: string, before: string) => prRefSegments(text, REPO, before).filter((s) => s.href).map((s) => s.text);
+  assert.deepEqual(prRefSegments("#12 next", REPO, "d"), [{ text: "#12 next" }]);
+  assert.deepEqual(prRefSegments("#12 next", REPO, "/"), [{ text: "#12 next" }], "a slash is no boundary on its own");
+  assert.deepEqual(prRefSegments("#12 next", REPO, "-"), [{ text: "#12 next" }], "the ASCII hyphen ends a URL path or an identifier");
+  for (const b of [" ", "\n", "\t", "(", "[", "{", "<", ",", ";", ":", "\"", "'", "“", "‘", "«", "—", "–"]) assert.deepEqual(after("#12 next", b), ["#12"], JSON.stringify(b));
+  assert.deepEqual(after("#12 next", ""), ["#12"], "an empty before is the start of the run");
+  // `before` is one UTF-16 code unit: an emoji cut off at the node edge leaves a lone surrogate, no boundary;
+  // the one-node reading of the same text refuses it too, so the two agree
+  assert.deepEqual(prRefSegments("#12 next", REPO, "🎉".slice(-1)), [{ text: "#12 next" }], "a lone surrogate is no boundary");
+  assert.deepEqual(after("🎉#12 next", ""), [], "the one-node reading agrees");
+  assert.deepEqual(prRefSegments("#12 next", REPO, " a"), [{ text: "#12 next" }], "a longer string is never a boundary: the caller passes one character");
+  assert.deepEqual(prRefSegments("#12 next", REPO).filter((s) => s.href).map((s) => s.text), ["#12"], "the two-argument call is unchanged");
+  assert.deepEqual(after("PR #12 next", "d"), ["#12"], "a glued phrase: the bare reference inside it still follows a space, as the one-node reading of `dPR #12` does");
+  assert.deepEqual(after("example-org/other#4 and #5", "d"), ["#5"], "a glued cross-repo form is refused; the scan resumes after it");
+  assert.deepEqual(after("#12 and #13", "d"), ["#13"], "the scan resumes after the refused match");
+  assert.deepEqual(after("#12/#13 then #9", "d"), ["#9"], "a glued run links nothing: `/` is no boundary, so its later members cannot start a reference");
+  assert.deepEqual(after("#12", "x"), []);
+  assert.deepEqual(prRefSegments("#12", REPO, "x"), [{ text: "#12" }], "a refused text comes back whole");
+  // through the walk: a path link followed by its fragment in the next node, which is what a path pass that
+  // runs before this one leaves behind (the span stands in for that pass's output)
+  const split = el("p", "see ", cls(el("span", "docs/a.md"), "file-uri-link"), "#12 and #13");
+  assert.equal(linkifyPrRefs(split as unknown as Node, REPO), 1);
+  assert.deepEqual(anchors(split).map((a) => a.textContent), ["#13"]);
+  assert.equal(split.textContent, "see docs/a.md#12 and #13", "the text is unchanged");
+  const run = el("p", "check ", cls(el("span", "notes/plan.md"), "file-uri-link"), "#7/#8 then #9");
+  assert.equal(linkifyPrRefs(run as unknown as Node, REPO), 1);
+  assert.deepEqual(anchors(run).map((a) => a.textContent), ["#9"]);
+});
+
+test("an element's text ends the run too: #12 glued to <code>x</code> is no reference, #12 after a space is; an inline element with no text carries the run", () => {
+  // marked renders `docs/a.md`#12, **docs/a.md**#12 and [text](url)#12 as an element followed by a text
+  // node that begins `#12`; the start of that node is no boundary
+  const glued = el("p", "use ", el("code", "x"), "#12");
+  assert.equal(linkifyPrRefs(glued as unknown as Node, REPO), 0);
+  assert.equal(glued.html(), "<p>use <code>x</code>#12</p>");
+  const spaced = el("p", "use ", el("code", "x"), " #12");
+  assert.equal(linkifyPrRefs(spaced as unknown as Node, REPO), 1);
+  const a = el("a", "text"); a.href = "https://x/y";
+  const afterLink = el("p", "see ", a, "#12");
+  assert.equal(linkifyPrRefs(afterLink as unknown as Node, REPO), 0, "[text](url)#12");
+  const afterStrong = el("p", "read ", el("strong", "docs/a.md"), "#12 now");
+  assert.equal(linkifyPrRefs(afterStrong as unknown as Node, REPO), 0, "**docs/a.md**#12");
+  assert.equal(afterStrong.html(), "<p>read <strong>docs/a.md</strong>#12 now</p>");
+  // an empty INLINE element between (an <img>, an empty <span>) does not reset the run: the text before it decides
+  const img = el("p", "see ", cls(el("span", "docs/a.md"), "file-uri-link"), el("img"), "#12");
+  assert.equal(linkifyPrRefs(img as unknown as Node, REPO), 0);
+  const imgSpaced = el("p", "see docs ", el("img"), "#12");
+  assert.equal(linkifyPrRefs(imgSpaced as unknown as Node, REPO), 1);
+  const emptySpan = el("p", "docs", el("span"), "#12");
+  assert.equal(linkifyPrRefs(emptySpan as unknown as Node, REPO), 0);
+  // a SKIPPED element with no text (an empty <code>, a form control) carries the run the same way
+  for (const tag of ["code", "input"]) {
+    assert.equal(linkifyPrRefs(el("p", "docs", el(tag), "#12") as unknown as Node, REPO), 0, `an empty <${tag}> carries the run`);
+    assert.equal(linkifyPrRefs(el("p", "docs ", el(tag), "#12") as unknown as Node, REPO), 1, `an empty <${tag}> after a space`);
+  }
+  // a walked wrapper's text carries into the node after it, and the run before it carries into its first node
+  const wrapped = el("p", el("em", "see"), " #8 and ", el("strong", "ok"), "#9 and ", el("strong", "x"), " ", el("em", "#10"));
+  assert.equal(linkifyPrRefs(wrapped as unknown as Node, REPO), 2);
+  assert.deepEqual(anchors(wrapped).map((a) => a.textContent), ["#8", "#10"]);
+  const intoWrapper = el("p", "docs/a.md", el("em", "#12"));
+  assert.equal(linkifyPrRefs(intoWrapper as unknown as Node, REPO), 0, "a fragment inside a wrapper is glued to the text before the wrapper");
+  const nested = el("p", "see ", el("em", el("strong", "docs/a.md")), "#12 and ", el("em", el("strong", "x")), " #13");
+  assert.equal(linkifyPrRefs(nested as unknown as Node, REPO), 1, "the carry comes back out of nested wrappers");
+  assert.deepEqual(anchors(nested).map((a) => a.textContent), ["#13"]);
+  // a node that is neither text nor an element (a comment) renders nothing: the run is unbroken across it
+  class C { nodeType = 8; parentNode: E | null = null; constructor(public textContent: string) {} }
+  const commented = el("p", "docs", new C(" a note ") as unknown as E, "#12");
+  assert.equal(linkifyPrRefs(commented as unknown as Node, REPO), 0);
+  const commentedSpaced = el("p", "docs ", new C(" a note ") as unknown as E, "#12");
+  assert.equal(linkifyPrRefs(commentedSpaced as unknown as Node, REPO), 1);
+  // what FOLLOWS a reference is still judged per node: a `#12` that ends a wrapper links although the next
+  // node begins with letters, where the one-node reading of the same text refuses; outside this change
+  const trailing = el("p", "see ", el("em", "#12"), "abc");
+  assert.equal(linkifyPrRefs(trailing as unknown as Node, REPO), 1);
+  assert.deepEqual(prRefSegments("see #12abc", REPO), [{ text: "see #12abc" }]);
+});
+
+// ── marked's HTML read into the stand-in, so the chat's own markdown shapes run through the walk ─────
+const VOID_TAGS = new Set(["BR", "HR", "IMG", "INPUT", "WBR"]);
+const ENTITIES: Record<string, string> = { amp: "&", lt: "<", gt: ">", quot: "\"", "#39": "'" };
+const unescapeHtml = (s: string): string => s.replace(/&(amp|lt|gt|quot|#39);/g, (_, k: string) => ENTITIES[k]);
+/** tags and text only, the class attribute kept: enough for what marked emits */
+function fromHtml(html: string): E {
+  const root = new E("DIV");
+  let cur = root;
+  const re = /<\/([A-Za-z][\w-]*)\s*>|<([A-Za-z][\w-]*)([^>]*)>|([^<]+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html))) {
+    if (m[1]) { cur = cur.parentNode || root; continue; }
+    if (m[2]) {
+      const e = cur.appendChild(new E(m[2].toUpperCase()));
+      const c = /class="([^"]*)"/.exec(m[3] || "");
+      if (c) e.className = c[1];
+      if (!VOID_TAGS.has(e.tagName) && !/\/\s*$/.test(m[3] || "")) cur = e;
+      continue;
+    }
+    cur.appendChild(new T(unescapeHtml(m[4])));
+  }
+  return root;
+}
+/** a node list as tags and text: ["done", "BR", "#12 next"] */
+const shape = (e: E): string[] => e.childNodes.map((c) => (c instanceof T ? c.textContent : c.tagName));
+/** the links this module made, in order; an anchor marked wrote (`[text](url)`) is not one */
+const linked = (root: E): string[] => anchors(root).filter((a) => a.classList.contains(PR_LINK_CLASS)).map((a) => a.textContent);
+// the chat's options (render.ts md()); its extensions and the sanitizer play no part in the shapes read here,
+// and an instance of our own leaves the shared singleton as the other tests find it
+const chatMarked = new Marked({ gfm: true, breaks: false });
+const md = (src: string): E => fromHtml(chatMarked.parse(src) as string);
+
+test("a line or block edge is a boundary with no whitespace node: marked's hard-break <br>, abutting paragraphs, list items, table cells; an inline element with no text is not", () => {
+  // a GFM hard break (two trailing spaces, or a backslash): <br> with NO text node between it and the `#`
+  let root = md("done  \n#12 next");
+  assert.deepEqual(shape(root.childNodes[0] as E), ["done", "BR", "#12 next"], "marked's shape: no whitespace after the <br>");
+  assert.equal(linkifyPrRefs(root as unknown as Node, REPO), 1);
+  assert.deepEqual(linked(root), ["#12"]);
+  root = md("done\\\n#12 next");
+  assert.deepEqual((linkifyPrRefs(root as unknown as Node, REPO), linked(root)), ["#12"], "the backslash form");
+  root = md("done  \nPR #12 next");
+  assert.deepEqual((linkifyPrRefs(root as unknown as Node, REPO), linked(root)), ["PR #12"]);
+  root = md("done  \nexample-org/other#4 next");
+  assert.deepEqual((linkifyPrRefs(root as unknown as Node, REPO), linked(root)), ["example-org/other#4"]);
+  root = md("done  \n#12/#13 next");
+  assert.deepEqual((linkifyPrRefs(root as unknown as Node, REPO), linked(root)), ["#12", "#13"], "a run at the head of the line");
+  // the block shapes marked itself emits: a paragraph, a list item, a table cell, a heading, a quote, a fence, a rule
+  for (const src of ["done\n\n#12", "- fixed\n- #12", "| a | b |\n|---|---|\n| fix | #12 |", "## Status\n#12", "> #12", "```\nx\n```\n#12", "---\n#12"]) {
+    root = md(src);
+    assert.deepEqual((linkifyPrRefs(root as unknown as Node, REPO), linked(root)), ["#12"], JSON.stringify(src));
+  }
+  // the inline shapes marked cuts before a reference, from the chat's own markdown: inline code, emphasis, an explicit link
+  for (const src of ["`docs/a.md`#12", "**docs/a.md**#12", "*docs/a.md*#12", "[text](https://x/y)#12", "a <span>x</span>#12"]) {
+    root = md(src);
+    assert.equal(linkifyPrRefs(root as unknown as Node, REPO), 0, src);
+  }
+  for (const src of ["`docs/a.md` #12", "**done** #12", "[text](https://x/y) #12", "(**done**) #12"]) {
+    root = md(src);
+    assert.deepEqual((linkifyPrRefs(root as unknown as Node, REPO), linked(root)), ["#12"], src);
+  }
+  // marked separates blocks with a "\n" text node; a DOM whose blocks abut has the same boundary
+  const abutting: E[] = [
+    el("div", el("p", "done"), el("p", "#12")),
+    el("ul", el("li", "fixed"), el("li", "#12")),
+    el("li", "#12"),
+    el("tr", el("td", "fix"), el("td", "#12")),
+    el("div", el("h2", "Status"), el("p", "#12")),
+    el("div", el("p", "note"), el("blockquote", "#12")),
+    el("div", el("pre", "x"), "#12"),
+    el("div", "done", el("hr"), "#12"),
+    el("div", el("p", "done"), "#12"),
+    el("p", el("span", "docs"), el("br"), "#12"),
+    el("div", el("p", "x"), el("div", "#12")),
+    // block-display tags a message's raw HTML may carry: the carry stops at them too
+    el("li", "done", el("center", "#12")),
+    el("div", "done", el("legend", "#12")),
+    el("div", "done", el("dialog", "#12")),
+    el("div", el("center", "done"), "#12"),
+    el("div", "done", el("hgroup", "#12")),
+    el("div", el("details", el("summary", "more")), "#12"),
+  ];
+  for (const r of abutting) assert.deepEqual((linkifyPrRefs(r as unknown as Node, REPO), linked(r)), ["#12"], r.html());
+  // every tag on the module's block list (copied here, so a tag dropped from it fails its own row) is an edge on
+  // both sides: a `#12` at its head follows glued text, and text right after it starts a run of its own; a
+  // <pre> is code-like, so only its far side is checked
+  const blockTags = [
+    "br", "hr", "p", "pre", "blockquote", "ul", "ol", "li", "h1", "h2", "h3", "h4", "h5", "h6",
+    "table", "caption", "thead", "tbody", "tfoot", "tr", "td", "th",
+    "div", "dl", "dt", "dd", "section", "article", "header", "footer", "nav", "aside", "main",
+    "figure", "figcaption", "details", "summary", "form", "fieldset", "address",
+    "center", "legend", "dialog", "dir", "menu", "hgroup", "search",
+  ];
+  assert.equal(blockTags.length, 47);
+  for (const tag of blockTags) {
+    if (tag === "br" || tag === "hr") {
+      const r = el("div", "done", el(tag), "#12");
+      assert.deepEqual((linkifyPrRefs(r as unknown as Node, REPO), linked(r)), ["#12"], `<${tag}> between`);
+      continue;
+    }
+    if (tag !== "pre") {
+      const head = el("div", "done", el(tag, "#12"));
+      assert.deepEqual((linkifyPrRefs(head as unknown as Node, REPO), linked(head)), ["#12"], `<${tag}> starts a run`);
+    }
+    const tail = el("div", el(tag, "done"), "#12");
+    assert.deepEqual((linkifyPrRefs(tail as unknown as Node, REPO), linked(tail)), ["#12"], `<${tag}> ends a run`);
+  }
+  // a tag name is read case-insensitively, as the skip list always was
+  const lower = el("div", "done", new E("br"), "#12");
+  assert.deepEqual((linkifyPrRefs(lower as unknown as Node, REPO), linked(lower)), ["#12"]);
+  // the glue protections stay: a path span, an empty inline element, an empty walked wrapper, a fragment inside one
+  for (const r of [
+    el("p", "see ", cls(el("span", "docs/a.md"), "file-uri-link"), "#12"),
+    el("p", "docs", el("span"), "#12"),
+    el("p", "docs", el("img"), "#12"),
+    el("p", "docs", el("em", ""), "#12"),
+    el("p", "see docs/a.md", el("em", "#12")),
+  ]) assert.equal(linkifyPrRefs(r as unknown as Node, REPO), 0, r.html());
 });
 
 test("references inside emphasis and list items link (only anchors and code-like elements are opaque)", () => {

--- a/ui/webview/pr-links.ts
+++ b/ui/webview/pr-links.ts
@@ -46,6 +46,22 @@
 // word, a URL fragment or a color literal — `#1EA1EB` and `#0c1a2e` fail the number shape (hex letters
 // after the digits, or a leading zero; a PR number has neither). Typographic wrappers (<em>, <strong>,
 // <sup>) are walked: a `#13` in them is still a reference.
+//
+// The boundary is judged over the RENDERED text, not per text node. The markdown renderer, or a pass that
+// ran before this one, may cut one run of text into several nodes: inline code followed by a number
+// (`docs/a.md`#12 in a message) renders as <code>docs/a.md</code> and then a text node that begins `#12`,
+// and **docs/a.md**#12, [text](url)#12 and a path link (.file-uri-link) followed by its fragment have the
+// same shape. The start of such a node is no boundary. So the walk carries the last character of the text
+// before each node into it (a skipped element's text included), and a `#` at a node's head links only when
+// that character is one of the boundary characters above, or when nothing precedes it in the run. The
+// carry crosses INLINE elements only: an <img>, an empty <span>, an element with no text renders no
+// boundary, so the text before it decides. It resets at a line or block edge (BLOCK_TAGS below: <br>,
+// <hr>, <p>, <li>, a heading, a table cell, ...), where the rendered text has a boundary whether or not a
+// whitespace node sits there: marked renders a GFM hard break (`done` with two trailing spaces, then `#12`
+// on the next line) as `<p>done<br>#12</p>`, with no text between the <br> and the `#`, and `#12` links.
+// An element the list does not name is treated as inline, the safe default: a missed edge costs a link,
+// an invented one makes a wrong link.
+//
 // A session with no GitHub repository (`githubRepo` null: no repo, no origin, or an origin elsewhere)
 // links NOTHING, the cross-repo form included — the honest rendering is the plain text, never a
 // guessed host.
@@ -72,8 +88,11 @@ const DOT_TAIL = /\.$/;                        // `.`, `..`, `repo.`: inside the
 // which is what keeps `#12abc`, `#1EA1EB` and a `#12/x` path fragment out — the run is greedy and the
 // lookahead follows it, so `#12/#13/x` backtracks to nothing rather than to `#12`
 const RUN = "((?:/#" + NUM + ")*)";
+// the characters a reference may follow (the header's list); `^` stands for the start of the rendered text
+const BOUNDARY = "\\s(\\[{<,;:\"'“‘«—–";
+const BOUNDARY_RE = new RegExp("^[" + BOUNDARY + "]$");
 const REF_SRC =
-  "(^|[\\s(\\[{<,;:\"'“‘«—–])(?:" +
+  "(^|[" + BOUNDARY + "])(?:" +
   "(" + OWNER + ")/(" + REPO + ")#(" + NUM + ")" +
   "|(?:(?:PR|pull)\\s?#(" + NUM + ")|#(" + NUM + "))" + RUN +
   ")(?![\\w#/])";
@@ -100,8 +119,15 @@ export function prUrl(repo: string, n: string): string {
 }
 
 /** Split `text` into plain runs and PR-reference links against `repo`. Pure: no DOM. With no valid
- *  repo, or no reference in the text, the whole text comes back as one plain segment. */
-export function prRefSegments(text: string, repo: string | null | undefined): PrRefSegment[] {
+ *  repo, or no reference in the text, the whole text comes back as one plain segment. `before` is the
+ *  one character (a UTF-16 code unit, the DOM walk's `text.slice(-1)`) that precedes `text` in the run
+ *  it was cut from, "" (the default) when `text` starts the run: a match at the start of `text` counts
+ *  only when that character is a boundary (the header); a longer string never is one, and neither is
+ *  the lone surrogate an emoji ends in, which the one-node regex refuses too. A refused match is scanned
+ *  again from its second character, so a boundary inside it still counts (`d` then `PR #12` links the
+ *  `#12`, as the one-node reading of `dPR #12` does) while a glued run (`d` then `#12/#13`) links
+ *  nothing, `/` being no boundary. */
+export function prRefSegments(text: string, repo: string | null | undefined, before = ""): PrRefSegment[] {
   const r = validPrRepo(repo);
   if (!r || !text || text.indexOf("#") < 0) return [{ text }];
   const re = new RegExp(REF_SRC, "gi");
@@ -110,6 +136,7 @@ export function prRefSegments(text: string, repo: string | null | undefined): Pr
   while ((m = re.exec(text))) {
     const start = m.index + m[1].length;          // the boundary character stays plain text
     const end = m.index + m[0].length;
+    if (start === 0 && before && !BOUNDARY_RE.test(before)) { re.lastIndex = 1; continue; }   // glued to the text before this node: no boundary
     let target: string, n: string;
     if (m[4]) {
       // `a/..#12` and `a/repo.#12` are no repo; `docs/x.html#12` is a path's fragment — the scan resumes after either
@@ -138,9 +165,25 @@ export function prRefSegments(text: string, repo: string | null | undefined): Pr
 const CODE_LIKE = "a, code, pre, kbd, samp, var, tt";
 const SKIP_TAGS = new Set(["A", "CODE", "PRE", "KBD", "SAMP", "VAR", "TT", "SCRIPT", "STYLE", "TEXTAREA", "INPUT", "BUTTON", "SELECT", "OPTION", "SVG"]);
 const SKIP_CLASSES = ["file-uri-link", "url-code-link"];
+// Elements whose edges are line or block boundaries in the rendered text: the run of text the walk carries
+// ends at one and starts fresh after it (the header). These are HTML's block-level and line-breaking
+// elements, listed by how they render rather than by what the chat's sanitizer admits (md-sanitize.ts
+// strips form, fieldset, legend and dialog today and keeps their text), so the two lists move
+// independently. Everything not listed is inline, and an inline element with no text passes the run
+// through unchanged: the safe default, since a missed boundary costs a link and an invented one makes a
+// wrong link.
+const BLOCK_TAGS = new Set([
+  "BR", "HR", "P", "PRE", "BLOCKQUOTE", "UL", "OL", "LI", "H1", "H2", "H3", "H4", "H5", "H6",
+  "TABLE", "CAPTION", "THEAD", "TBODY", "TFOOT", "TR", "TD", "TH",
+  "DIV", "DL", "DT", "DD", "SECTION", "ARTICLE", "HEADER", "FOOTER", "NAV", "ASIDE", "MAIN",
+  "FIGURE", "FIGCAPTION", "DETAILS", "SUMMARY", "FORM", "FIELDSET", "ADDRESS",
+  "CENTER", "LEGEND", "DIALOG", "DIR", "MENU", "HGROUP", "SEARCH",
+]);
+
+const tagOf = (e: Element): string => String(e.tagName || "").toUpperCase();
 
 function skipElement(e: Element): boolean {
-  if (SKIP_TAGS.has(String(e.tagName || "").toUpperCase())) return true;
+  if (SKIP_TAGS.has(tagOf(e))) return true;
   const cl = e.classList;
   return !!cl && SKIP_CLASSES.some((k) => cl.contains(k));
 }
@@ -150,7 +193,11 @@ function skipElement(e: Element): boolean {
  *  existing anchors (SKIP_TAGS) and the chat's path links; a root that itself sits inside one of those
  *  is left alone. Returns the number of links made. A root whose whole text has no `#` — the common
  *  case — costs one native textContent read and no walk. Walks childNodes and edits through
- *  insertBefore/removeChild only, so a test's plain-object DOM stand-in runs it as the browser does. */
+ *  insertBefore/removeChild only, so a test's plain-object DOM stand-in runs it as the browser does.
+ *  The walk carries the last character of the text before each node (a skipped element's text counts,
+ *  an inline element with no text does not, and a line or block edge, BLOCK_TAGS, resets the run), so a
+ *  node's start is a boundary only when the rendered text has one there (the header: `docs/a.md` and
+ *  `#12` split across two nodes is still one path; `done<br>#12` is two lines). */
 export function linkifyPrRefs(root: Node | null | undefined, repo: string | null | undefined): number {
   const r = validPrRepo(repo);
   if (!r || !root) return 0;
@@ -158,22 +205,38 @@ export function linkifyPrRefs(root: Node | null | undefined, repo: string | null
   const rootEl = root as Element;
   if (root.nodeType === 1 && typeof rootEl.closest === "function" && rootEl.closest(CODE_LIKE)) return 0;
   let made = 0;
-  const visit = (node: Node): void => {
+  /** links the text under `node`, given the character before it; returns the character before whatever
+   *  follows: "" after a line or block edge, the way the root starts */
+  const visit = (node: Node, before: string): string => {
     const kids = Array.from(node.childNodes || []);   // snapshot: text children are replaced as we go
     for (const c of kids) {
-      if (c.nodeType === 3) { made += linkifyTextNode(c, r); continue; }
-      if (c.nodeType !== 1 || skipElement(c as Element)) continue;
-      visit(c);
+      if (c.nodeType === 3) {
+        const text = c.textContent || "";
+        made += linkifyTextNode(c, r, before);
+        if (text) before = text.slice(-1);
+        continue;
+      }
+      if (c.nodeType !== 1) continue;                  // a comment renders nothing: the run is unbroken
+      const e = c as Element;
+      const edge = BLOCK_TAGS.has(tagOf(e));
+      if (skipElement(e)) {
+        const text = e.textContent || "";
+        before = edge ? "" : text ? text.slice(-1) : before;
+        continue;
+      }
+      if (edge) { visit(e, ""); before = ""; }         // its text starts a line or block; so does whatever follows it
+      else before = visit(e, before);
     }
+    return before;
   };
-  visit(root);
+  visit(root, "");
   return made;
 }
 
-function linkifyTextNode(tn: Node, repo: string): number {
+function linkifyTextNode(tn: Node, repo: string, before: string): number {
   const text = tn.textContent || "";
   if (text.indexOf("#") < 0) return 0;
-  const segs = prRefSegments(text, repo);
+  const segs = prRefSegments(text, repo, before);
   if (!segs.some((s) => s.href)) return 0;
   const parent = tn.parentNode;
   if (!parent) return 0;


### PR DESCRIPTION
## Symptom

A `#12` written right after inline code, emphasis or a link in a chat message links to pull request 12 of the session's repository. `docs/a.md`#12 (the path in backticks), **docs/a.md**#12 and [text](https://x/y)#12 all do it: the path's fragment, or a number the writer glued to a word, becomes a link to an unrelated PR. A path link followed by its fragment has the same shape wherever a path pass runs before the PR pass.

## Cause

pr-links.ts requires a word boundary before a reference (the header's rule, from https://github.com/romp-on/romp/pull/1004), but the walk judged it per text node: REF_SRC accepts the start of the text (`^`) as a boundary, prRefSegments had no notion of what precedes its text, and visit() called linkifyTextNode on each text child with no carry across the element before it. marked renders each shape above as an element followed by a text node that begins `#12`, so the number sat at the start of its own node and passed. A bare URL is not a case: GFM's autolink swallows the fragment into one anchor.

## Fix

The general rule: a reference's boundary is judged over the rendered text, not per text node. Where the renderer or an earlier pass has cut one run of text into several nodes, the start of a node is no boundary; the character before it in the rendered text decides.

The instance:

- `prRefSegments(text, repo, before = "")` takes the one character that precedes `text` in its run ("" for the start of the run; the DOM walk passes `text.slice(-1)`, and a longer string is never a boundary). A match at the start of `text` counts only when `before` is a boundary character. A refused match is scanned again from its second character, so a boundary inside it still counts (`d` then `PR #12` links the bare `#12`, as the one-node reading of `dPR #12` does), while a glued run (`d` then `#12/#13`) links nothing, `/` being no boundary. The boundary class is one constant (`BOUNDARY`) shared by the regex and the single-character test, so the two cannot drift.
- `linkifyPrRefs`'s `visit(node, before)` carries the last character of the text before each node into it. A skipped element's text counts (a `<code>`, an `<a>`, a path link). The carry crosses inline elements only: an `<img>`, an empty `<span>`, an empty `<code>` or any other element with no text passes the run through, so the text before it decides. A comment node is ignored.
- `BLOCK_TAGS` (47 block-level and line-breaking tags) resets the carry at a line or block edge, where the rendered text has a boundary whether or not a whitespace node sits there. marked renders a GFM hard break as `<p>done<br>#12</p>` with no text between the `<br>` and the `#`; a carry without this reset would refuse that `#12`. The list follows how an element renders, not what the sanitizer admits (md-sanitize.ts strips form, fieldset, legend and dialog today and keeps their text). An element the list does not name is treated as inline, the safe default: a missed edge costs a link, an invented one makes a wrong link. Tag names are read case-insensitively, as the skip list has always read them.
- The public API is additive (an optional third parameter); no call site changes (the chat's `md()` and `userMd()`, the feed's `linkifyPrRefs` and `setLinkedText` callers, the outline's goal rows).

The rule has two limits, both pinned in the tests. `before` is one UTF-16 code unit, so an emoji directly before a split `#12` yields a lone surrogate, which is no boundary; the one-node regex refuses that shape too, so the two readings agree (no link). What follows a reference is still judged per node: a `#12` at the end of an emphasis with letters glued to it in the next node links as it did before; the trailing lookahead is outside this change.

Checked beyond the tests: 4000 random token strings, every cut point, four split shapes (adjacent text nodes, one or both halves inside a wrapper), 193k cases. The split reading equals the one-node reading except at the trailing side named above and at slash runs cut between their members (a shape marked never emits), which link fewer references, never more.

## Tests

`ui/webview/pr-links.test.ts`, three tests after "the chat's path links are skipped", all executing through the file's plain-object DOM stand-in; each fails on the unchanged source:

- "the boundary is judged over the rendered text: a reference at the head of a text node follows the character before that node": `prRefSegments` with the preceding character (a word character, `/` and `-` glue; every boundary character and the empty string do not; a lone surrogate is no boundary and the one-node reading of the same text agrees; a string longer than one character never is; the two-argument call is unchanged; a glued `PR #12` links its `#12`; a glued cross-repo form and a glued run are refused and the scan resumes), then a path-link span followed by `#12 and #13` through the walk, which links `#13` alone. Before: `prRefSegments("#12 next", REPO, "d")` links `#12`, the span case links both, and the third argument is a TypeScript error, so `npm run typecheck` is red as well.
- "an element's text ends the run too: #12 glued to <code>x</code> is no reference, #12 after a space is; an inline element with no text carries the run": `use <code>x</code>#12` links nothing and `use <code>x</code> #12` links once; the same after an `<a>` and a `<strong>`; an empty `<img>` or `<span>`, and an empty skipped `<code>` or `<input>`, carry the run; a walked wrapper's text carries out of it and the run before it carries in; nested wrappers; a comment node; the trailing side's limit (a `#12` ending an emphasis links although letters follow in the next node). Before: `use <code>x</code>#12` returns 1 and wraps `#12` in a pr-link anchor.
- "a line or block edge is a boundary with no whitespace node: marked's hard-break <br>, abutting paragraphs, list items, table cells; an inline element with no text is not": marked's HTML (a `Marked` instance with the chat's options, read into the stand-in by a tags-and-text reader) for the hard break, its shape pinned as `["done", "BR", "#12 next"]`, the backslash break, `PR #12` and `example-org/other#4` after a break, a run at the head of a line, the block shapes marked emits (paragraph, list item, table cell, heading, quote, fence, rule), the inline shapes it cuts before a number (inline code, strong, em, an explicit link, a raw span); then hand-built abutting blocks (p/p, li/li, td/td, h2/p, p/blockquote, pre then text, hr, br, div/div, center, legend, dialog, hgroup, details/summary), every one of the 47 block tags (the list copied into the test) as an edge on both sides (a `#12` at its head after glued text links, and text right after it starts a run; a `<pre>` is code-like, so its far side only), a lower-case tag name, and the glue protections. Before: the inline shapes link. Against a carry with no block-edge reset, the hard break stops linking; a tag dropped from the block list fails its own row.

`pr-links.test.ts`: 55 pass (52 before). `npm run typecheck`: clean. `npm test` in vscode-extension: 3750 tests pass, 0 fail (every bundled test under node --test).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)