### PR TITLE
esbuild.js: a failed rebuild leaves dist/ as it was, each bundle lands by rename, and the last stderr line names the cause

### DIFF
--- a/vscode-extension/esbuild.js
+++ b/vscode-extension/esbuild.js
@@ -113,6 +113,118 @@ function testBuild() {
   };
 }
 
+// Every bundle of a one-shot build (`node esbuild.js`, with or without --production) is built into memory and
+// dist/ is written only once ALL of them have built. esbuild writes each build()'s outputs as that build
+// finishes, so with the extension bundle first and the webview bundle second, a webview failure left
+// dist/extension.js rewritten and every webview bundle old.
+// The common failure has exactly that shape: a merge imports a package this checkout's node_modules predates
+// (the 2026-08-10 katex import broke every restart's rebuild for a day). The kernel's cache token is the
+// newest mtime under dist/, so the half-written dist bumped it: every open dashboard was told a newer build
+// existed and reloaded into the same stale bundles, and the kernel's drift pass then read dist as newer than
+// the sources it had just failed to build. A failed build now leaves dist/ byte-for-byte as it was, so "the
+// rebuild failed" and "dist is older than the sources" stay true together. Watch mode and the test build
+// write directly as before: a dev loop wants each rebuild on disk at once.
+//
+// Each output then reaches its served name by RENAME, not by a write into it. The kernel serves /dist/ from
+// this directory on other threads while it rebuilds, and a write into the served path truncates the file
+// first and fills it afterwards, so a request in that window got an empty or partial bundle (longest for
+// render.js, the largest output) and the page that loaded it ran a bundle cut mid-statement until a reload.
+// So each output is written whole to a hidden sibling in its own directory (`.<name>.tmp-<pid>-<n>`: the same
+// filesystem, so the rename is atomic; a name ending in neither .js nor .css nor .map, so the kernel's
+// newest-mtime token (dist/*.js) never counts it and its /dist route never types it) and then renamed over
+// the served name, and a reader gets the old bytes or the new, complete either way. Every output is staged
+// before any is renamed, so an fs error while staging (no space, a permission) removes the staged files and
+// leaves dist/ unchanged. A staging file an earlier run left behind (killed between its write and its rename)
+// is removed once that run's pid is gone, and kept while the pid runs: two builds on one dist/ each rename
+// their own.
+const STAGING = /^\..+\.tmp-(\d+)-\d+$/;
+
+function stagingPath(final, n) {
+  return path.join(path.dirname(final), "." + path.basename(final) + ".tmp-" + process.pid + "-" + n);
+}
+
+function pidRunning(pid) {
+  try { process.kill(pid, 0); return true; } catch (e) { return !(e && e.code === "ESRCH"); }
+}
+
+function removeStaleStaging(dir) {
+  for (const name of fs.readdirSync(dir)) {
+    const m = STAGING.exec(name);
+    if (m && !pidRunning(Number(m[1]))) fs.rmSync(path.join(dir, name), { force: true });
+  }
+}
+
+async function buildAll(configs) {
+  const results = [];
+  for (const cfg of configs) results.push(await esbuild.build({ ...cfg, write: false }));
+  const outputs = results.flatMap((r) => r.outputFiles);
+  for (const dir of new Set(outputs.map((f) => path.dirname(f.path)))) {
+    fs.mkdirSync(dir, { recursive: true });
+    removeStaleStaging(dir);
+  }
+  const staged = [];
+  try {
+    for (const f of outputs) {
+      const tmp = stagingPath(f.path, staged.length);
+      fs.writeFileSync(tmp, f.contents);
+      staged.push(tmp);
+    }
+    outputs.forEach((f, i) => fs.renameSync(staged[i], f.path));
+  } catch (e) {
+    for (const tmp of staged) fs.rmSync(tmp, { force: true });
+    throw e;
+  }
+  return outputs.map((f) => f.path);
+}
+
+// The LAST line on stderr is the one the kernel shows: its in-place rebuild puts the tail of this process's
+// stderr into the notice that tells the person the served UI is stale, and the tail of an esbuild
+// BuildFailure printed whole is its stack through esbuild's own transport (`at Socket.emit`,
+// `errors: [Getter/Setter]`), which names neither the failing import nor what to do about it. esbuild has
+// already printed each error with its code frame (logLevel "info"), so this names the cause in one line of
+// at most 300 characters (the kernel's tail: _rebuild_dist in kernel/kernel.py) and, for the common cause,
+// the fix: an unresolvable package, a bare specifier or a node_modules/ path that is not a file of this
+// checkout, is a dependency this node_modules lacks, and `npm install` is what fixes it. A relative import or
+// a syntax error gets its text and no npm install line. `untouched` names the output dir the failed build
+// left unchanged, when that is what failed.
+//
+// Every line goes out through `fit`: cut to 300 characters from the END, so the head (what failed, what is
+// unchanged) is what the kernel shows and the tail of the last clause is what goes. The parts are sized so a
+// plausible line fits whole (specifiers cut at 60, the text at 120, two named and the rest counted), so the
+// cut is reached only by a long text over a long location path (the location is never shortened, since a cut
+// path names no file) and by a non-esbuild error's message, which is whatever Node wrote. Without it, the
+// kernel's `[-300:]` drops the head instead (src/esbuild-failure-cap.test.ts).
+function failureSummary(e, untouched) {
+  const fit = (s) => s.length > 300 ? s.slice(0, 297) + "..." : s;
+  const errors = e && Array.isArray(e.errors) ? e.errors : null;
+  if (!errors) return fit("esbuild.js: build failed: " + (e && e.message ? e.message : String(e)));
+  const n = errors.length;
+  let line = "esbuild.js: build failed with " + n + (n === 1 ? " error" : " errors") +
+             (untouched ? "; " + untouched + " is unchanged" : "") + ".";
+  const unresolved = [];
+  for (const x of errors) {
+    const m = /^Could not resolve "([^"]+)"/.exec(x.text || "");
+    if (m) unresolved.push(m[1]);
+  }
+  const isDep = (spec) => spec.startsWith("node_modules/") ||
+    (!/^[./]/.test(spec) && !path.isAbsolute(spec) && !fs.existsSync(path.resolve(spec.split("/")[0])));
+  if (unresolved.length) {
+    const quote = (s) => JSON.stringify(s.length > 60 ? s.slice(0, 57) + "..." : s);
+    const shown = unresolved.slice(0, 2).map(quote).join(", ") +
+                  (unresolved.length > 2 ? " (+" + (unresolved.length - 2) + " more)" : "");
+    line += unresolved.some(isDep)
+      ? " Unresolved: " + shown +
+        ", not in this checkout's node_modules; run npm install in vscode-extension/ and rebuild."
+      : " Unresolved: " + shown + ".";
+  } else {
+    const x = errors[0];
+    const where = x.location && x.location.file ? " (" + x.location.file + ":" + x.location.line + ")" : "";
+    const text = (x.text || "").length > 120 ? (x.text || "").slice(0, 117) + "..." : (x.text || "");
+    line += " " + text + where;
+  }
+  return fit(line);
+}
+
 async function main() {
   if (tests) {
     // Clean out-tests/ first so a DELETED test source can't leave an orphaned .js behind that `node --test`
@@ -126,12 +238,21 @@ async function main() {
     await Promise.all([a.watch(), b.watch()]);
     console.log("watching…");
   } else {
-    await esbuild.build(extension);
-    await esbuild.build(webview);
+    await buildAll([extension, webview]);
   }
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+// Exported for the tests: src/esbuild-build.test.ts and its siblings drive buildAll and failureSummary against
+// synthetic entries and stub the real configs' entry points. The build runs only when this file is the script
+// (`node esbuild.js`), never on require.
+module.exports = { buildAll, failureSummary, extension, webview, testBuild };
+
+if (require.main === module) {
+  main().catch((e) => {
+    // Not an esbuild BuildFailure (an fs error, a bug here): its stack is the diagnosis, and esbuild
+    // printed nothing for it. A BuildFailure's errors are already on stderr with their code frames.
+    if (!(e && Array.isArray(e.errors))) console.error(e);
+    console.error(failureSummary(e, tests || watch ? null : "dist/"));
+    process.exit(1);
+  });
+}

--- a/vscode-extension/src/esbuild-build.test.ts
+++ b/vscode-extension/src/esbuild-build.test.ts
@@ -1,0 +1,281 @@
+// esbuild.js's write step and its failure line, driven against synthetic entries in a scratch dir and, end to
+// end, through `node esbuild.js` itself.
+//
+// The kernel rebuilds the served bundles in place by running `node esbuild.js` and, when that fails, puts the
+// last 300 characters of its stderr in the notice that says the UI is stale. Two properties of the script are
+// what that path relies on, and both break the same way when a merge imports a package this checkout's
+// node_modules predates (the shape of the 2026-08-10 katex failure, which broke every restart's rebuild for a
+// day):
+//   1. a failed build leaves dist/ exactly as it was. esbuild writes each build()'s outputs as that build
+//      finishes, so with the extension bundle built first and the webview bundle second, a webview failure left
+//      dist/extension.js rewritten and every webview bundle old: the kernel's cache token (newest mtime under
+//      dist/) jumped, every open dashboard got a reload prompt for a build that had not happened, and the drift
+//      pass read dist as newer than the sources it had just failed to build;
+//   2. the last stderr line names the cause and, for a missing package, the cure. A BuildFailure printed whole
+//      ends in its stack through esbuild's transport (`at Socket.emit`, `errors: [Getter/Setter]`), which is
+//      what a 300-character tail of it showed.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+// npm test runs in vscode-extension/, where esbuild.js lives. Required at run time rather than imported so
+// the bundler leaves it alone: it loads the real esbuild package (a native binary) from node_modules.
+const ESBUILD_JS = path.join(process.cwd(), "esbuild.js");
+const script = createRequire(__filename)(ESBUILD_JS);
+const { buildAll, failureSummary } = script;
+
+const MISSING_PKG = "no-such-package-for-this-test";
+// What the kernel shows: kernel/kernel.py's _rebuild_dist takes the stripped stderr's last 300 characters.
+const KERNEL_TAIL = 300;
+
+function scratch(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "romp-esbuild-"));
+}
+
+// A minimal browser bundle config in the shape of esbuild.js's own: bundled, silent (the test asserts on the
+// summary line, not esbuild's logger), outputs under <dir>/dist.
+function cfg(dir: string, entry: string, out: string, extra: Record<string, unknown> = {}) {
+  return { entryPoints: [path.join(dir, entry)], bundle: true, format: "iife", platform: "browser",
+           outfile: path.join(dir, "dist", out), logLevel: "silent", ...extra };
+}
+
+async function failureOf(p: Promise<unknown>): Promise<any> {
+  try { await p; } catch (e) { return e; }
+  throw new Error("expected the build to fail");
+}
+
+test("a failed build writes nothing: an earlier bundle that built is not written and a stale dist is untouched", async () => {
+  const d = scratch();
+  try {
+    fs.writeFileSync(path.join(d, "good.ts"), "export const n: number = 1;\nconsole.log(n);\n");
+    fs.writeFileSync(path.join(d, "bad.ts"), `import "${MISSING_PKG}";\n`);
+    // the failure's shape: dist holds an old build of the FIRST bundle, and the SECOND bundle fails
+    fs.mkdirSync(path.join(d, "dist"));
+    fs.writeFileSync(path.join(d, "dist", "good.js"), "OLD");
+    const oldTime = new Date("2026-01-01T00:00:00Z");
+    fs.utimesSync(path.join(d, "dist", "good.js"), oldTime, oldTime);
+
+    const e = await failureOf(buildAll([cfg(d, "good.ts", "good.js"), cfg(d, "bad.ts", "bad.js")]));
+    assert.ok(Array.isArray(e.errors) && e.errors.length === 1, "an esbuild BuildFailure with the one unresolved import");
+
+    assert.deepEqual(fs.readdirSync(path.join(d, "dist")), ["good.js"], "no new file under dist");
+    assert.equal(fs.readFileSync(path.join(d, "dist", "good.js"), "utf8"), "OLD", "the bundle that built was not written");
+    assert.equal(fs.statSync(path.join(d, "dist", "good.js")).mtime.getTime(), oldTime.getTime(),
+                 "its mtime stands: the kernel's cache token is the newest mtime under dist/, so a rewrite here " +
+                 "means a reload prompt for a build that did not happen");
+  } finally {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+});
+
+test("a build that succeeds writes every output of every bundle: code, sourcemaps, and file-loader assets in their subdir", async () => {
+  const d = scratch();
+  try {
+    fs.writeFileSync(path.join(d, "note.txt"), "asset\n");
+    fs.writeFileSync(path.join(d, "one.ts"), 'import u from "./note.txt";\nconsole.log(u);\n');
+    fs.writeFileSync(path.join(d, "two.ts"), "console.log(2);\n");
+    // the KaTeX-font shape: a `file` loader with assets under a subdirectory of dist (dist/fonts/ in the real build)
+    const withAsset = cfg(d, "one.ts", "one.js", { loader: { ".txt": "file" }, assetNames: "assets/[name]-[hash]", sourcemap: true });
+    const written: string[] = await buildAll([withAsset, cfg(d, "two.ts", "two.js", { sourcemap: true })]);
+
+    const dist = path.join(d, "dist");
+    for (const f of ["one.js", "one.js.map", "two.js", "two.js.map"]) {
+      assert.ok(fs.existsSync(path.join(dist, f)), f + " written");
+    }
+    const assets = fs.readdirSync(path.join(dist, "assets"));
+    assert.equal(assets.length, 1, "the asset landed in its subdirectory");
+    assert.ok(/^note-[A-Z0-9]+\.txt$/i.test(assets[0]), assets[0]);
+    assert.equal(fs.readFileSync(path.join(dist, "assets", assets[0]), "utf8"), "asset\n");
+    // the return value is the written paths, one per output file
+    const expected = ["one.js", "one.js.map", "two.js", "two.js.map", path.join("assets", assets[0])].map((f) => path.join(dist, f)).sort();
+    assert.deepEqual([...written].sort(), expected);
+    assert.ok(fs.readFileSync(path.join(dist, "two.js"), "utf8").includes("console.log(2)"), "the bundle is the built code");
+  } finally {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+});
+
+test("failureSummary: an unresolvable package names it and the npm install cure, in one line the kernel's tail can carry whole", async () => {
+  const d = scratch();
+  try {
+    fs.writeFileSync(path.join(d, "bad.ts"), `import "${MISSING_PKG}";\n`);
+    // both faces of a missing dependency: the source import of a bare specifier, and a node_modules/ path named
+    // as an entry point of its own. Two entry points, so outdir, as esbuild.js's webview config has.
+    const worker = "node_modules/" + MISSING_PKG + "/worker.mjs";   // 53 characters: under the 60-character cut, shown whole
+    const c = { ...cfg(d, "bad.ts", "bad.js"), outfile: undefined, outdir: path.join(d, "dist"),
+                entryPoints: [path.join(d, "bad.ts"), worker] };
+    const e = await failureOf(buildAll([c]));
+    assert.equal(e.errors.length, 2);
+
+    const line: string = failureSummary(e, "dist/");
+    assert.ok(!line.includes("\n"), "one line");
+    assert.ok(line.length <= KERNEL_TAIL, "the kernel shows the last 300 characters of stderr; the whole line must fit: " + line.length);
+    assert.ok(line.startsWith("esbuild.js: build failed with 2 errors; dist/ is unchanged."), line);
+    assert.ok(line.includes(`"${MISSING_PKG}"`), "names the package: " + line);
+    assert.ok(line.includes(`"${worker}"`), "names the worker path: " + line);
+    assert.ok(line.includes("npm install"), "names the cure: " + line);
+    assert.ok(!line.includes("Getter/Setter") && !line.includes(" at "), "no stack: " + line);
+  } finally {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+});
+
+test("failureSummary: a relative import that does not exist, or a syntax error, gets the error and no npm cure", async () => {
+  const d = scratch();
+  try {
+    fs.writeFileSync(path.join(d, "rel.ts"), 'import "./nowhere";\n');
+    const rel: string = failureSummary(await failureOf(buildAll([cfg(d, "rel.ts", "rel.js")])), "dist/");
+    assert.ok(rel.includes('"./nowhere"'), rel);
+    assert.ok(!rel.includes("npm install"), "a relative import is a source error, not a missing dependency: " + rel);
+
+    fs.writeFileSync(path.join(d, "syntax.ts"), "const = ;\n");
+    const syn: string = failureSummary(await failureOf(buildAll([cfg(d, "syntax.ts", "syntax.js")])), "dist/");
+    assert.ok(syn.startsWith("esbuild.js: build failed with 1 error; dist/ is unchanged."), syn);
+    assert.ok(syn.includes("syntax.ts:1"), "the error's location: " + syn);
+    assert.ok(!syn.includes("npm install"), syn);
+    assert.ok(syn.length <= KERNEL_TAIL);
+  } finally {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+});
+
+test("failureSummary: without the output-dir clause (watch and test modes), and for a non-esbuild error", () => {
+  const e = Object.assign(new Error("Build failed with 1 error"), { errors: [{ text: 'Could not resolve "./x"', location: null }], warnings: [] });
+  assert.equal(failureSummary(e, null), 'esbuild.js: build failed with 1 error. Unresolved: "./x".');
+  assert.equal(failureSummary(new Error("boom")), "esbuild.js: build failed: boom");
+});
+
+test("failureSummary stays within the kernel's 300-character tail: long specifiers are shortened, a long list is counted", () => {
+  const failure = (specs: string[]) => Object.assign(new Error("Build failed"), {
+    errors: specs.map((s) => ({ text: `Could not resolve "${s}"`, location: null })), warnings: [] });
+  const long = "node_modules/" + "a-very-long-package-name-".repeat(3) + "build/worker.mjs";
+  assert.ok(long.length > 60);
+  const one = failureSummary(failure([long]), "dist/");
+  assert.ok(one.includes('"' + long.slice(0, 57) + '..."'), "a long specifier is cut with an ellipsis: " + one);
+  assert.ok(one.includes("npm install"), one);
+  const many = failureSummary(failure(["p1", "p2", "p3", "p4", "p5"]), "dist/");
+  assert.ok(many.includes('"p1", "p2" (+3 more)'), "two named, the rest counted: " + many);
+  assert.ok(!many.includes('"p3"'), many);
+  for (const line of [one, many]) assert.ok(line.length <= KERNEL_TAIL && !line.includes("\n"), line);
+  // A bare specifier whose first segment is a directory of the cwd (src/ here, in vscode-extension/) is a
+  // source path that does not resolve, not a dependency this node_modules lacks: no npm install line.
+  assert.ok(fs.existsSync("src"), "the cwd is vscode-extension/, where src/ exists");
+  const local = failureSummary(failure(["src/nowhere"]), "dist/");
+  assert.ok(local.includes('"src/nowhere"') && !local.includes("npm install"), local);
+});
+
+test("requiring esbuild.js runs no build: main() runs only when the file is the script", () => {
+  // The tests above required the module and drove buildAll against scratch dirs. Had main() run on require, it
+  // would have built the real bundles into the real dist/ (seconds, and a dist mtime bump). Checked in a child
+  // whose cwd is an empty directory: a build started there fails on the missing src/extension.ts, prints, and
+  // exits 1; a require that runs nothing exits 0 in silence and leaves the directory empty.
+  const d = scratch();
+  try {
+    const r = spawnSync(process.execPath, ["-e", "require(process.argv[1])", "--", ESBUILD_JS], { cwd: d, encoding: "utf8" });
+    assert.equal(r.status, 0, "exit status (signal " + r.signal + "); stderr: " + r.stderr);
+    // No build ran: no esbuild report (its error marker, an output table under dist/) and no summary line. A
+    // notice the runtime itself might print on a require is not what this checks.
+    assert.ok(!/\[ERROR\]|Could not resolve|dist\/|esbuild\.js:/.test(r.stderr), "no build output: " + r.stderr);
+    assert.equal(r.stdout, "");
+    assert.deepEqual(fs.readdirSync(d), [], "nothing written");
+  } finally {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+  // and the require yields the pieces the tests drive and the real configs the end-to-end test below stubs
+  assert.equal(typeof buildAll, "function");
+  assert.equal(typeof failureSummary, "function");
+  assert.equal(script.extension.outfile, "dist/extension.js");
+  assert.equal(script.webview.outdir, "dist");
+  assert.equal(typeof script.testBuild, "function");
+});
+
+// A stub source tree for the script's real configs: every entry point it names, relative to a cwd that stands
+// in for vscode-extension/ (the webview entries reach up into ../ui/webview). The stubs are valid and import
+// nothing, so `node esbuild.js` builds them with the real settings (nodePaths, externals, the file loader).
+function stubTree(root: string): string {
+  const cwd = path.join(root, "vscode-extension");
+  const entries: string[] = [];
+  for (const c of [script.extension, script.webview]) {
+    for (const e of c.entryPoints) entries.push(typeof e === "string" ? e : e.in);
+  }
+  for (const rel of entries) {
+    const p = path.resolve(cwd, rel);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, rel.endsWith(".css") ? "body { margin: 0; }\n" : `console.log(${JSON.stringify(rel)});\n`);
+  }
+  return cwd;
+}
+
+function snapshot(dir: string): Record<string, [number, number]> {
+  const out: Record<string, [number, number]> = {};
+  const walk = (d: string) => {
+    for (const name of fs.readdirSync(d)) {
+      const p = path.join(d, name);
+      const st = fs.statSync(p);
+      if (st.isDirectory()) walk(p);
+      else out[path.relative(dir, p)] = [st.size, st.mtimeMs];
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+test("node esbuild.js, with and without --production: a webview failure after the extension bundle built leaves dist/ as it was and the kernel's tail carries the cause; a filesystem error prints its stack and then the line", () => {
+  const root = scratch();
+  try {
+    const cwd = stubTree(root);
+    const run = (...args: string[]) => spawnSync(process.execPath, [ESBUILD_JS, ...args], { cwd, encoding: "utf8" });
+
+    const ok = run();
+    assert.equal(ok.status, 0, "the stub tree builds: " + ok.stderr);
+    const dist = path.join(cwd, "dist");
+    assert.ok(fs.existsSync(path.join(dist, "extension.js")) && fs.existsSync(path.join(dist, "render.js")), fs.readdirSync(dist).join(","));
+    // the served build, aged so a rewrite of the same bytes still shows
+    const oldTime = new Date("2026-01-01T00:00:00Z");
+    for (const rel of Object.keys(snapshot(dist))) fs.utimesSync(path.join(dist, rel), oldTime, oldTime);
+    const before = snapshot(dist);
+
+    // the failure's shape: a webview source imports a package this node_modules does not have. Both ways the
+    // kernel runs the script take the same path: without --production (its in-place rebuild) and with it (its
+    // rebuild at boot, and the release build).
+    const render = path.resolve(cwd, "../ui/webview/render.ts");
+    const goodRender = fs.readFileSync(render, "utf8");
+    fs.appendFileSync(render, `import "${MISSING_PKG}";\n`);
+    for (const args of [[], ["--production"]]) {
+      const bad = run(...args);
+      assert.equal(bad.status, 1, "node esbuild.js " + args.join(" "));
+      assert.deepEqual(snapshot(dist), before,
+                       "every file under dist/ has its old size and mtime: the extension bundle that built was not written (" + args.join(" ") + ")");
+
+      const lines = bad.stderr.trim().split("\n");
+      const last = lines[lines.length - 1];
+      assert.ok(last.startsWith("esbuild.js: build failed with 1 error; dist/ is unchanged."), "the last line: " + last);
+      assert.ok(last.includes(`"${MISSING_PKG}"`) && last.includes("npm install"), last);
+      assert.ok(bad.stderr.includes("Could not resolve"), "esbuild's own report with its code frame still precedes it");
+      assert.ok(!bad.stderr.includes("Getter/Setter"), "the BuildFailure object is not printed");
+      const kernelShows = bad.stderr.trim().slice(-KERNEL_TAIL);
+      assert.ok(kernelShows.endsWith(last) && kernelShows.includes("esbuild.js: build failed"), "the kernel's tail carries the line whole: " + kernelShows);
+    }
+
+    // Not a BuildFailure: the sources build and the write step fails on the filesystem. A regular file in
+    // dist/'s place makes mkdirSync refuse with EEXIST before any output is staged, a refusal that takes no
+    // permission change to arrange. esbuild reported nothing, so the error is printed whole (its stack is the
+    // diagnosis) and the summary line still closes stderr.
+    fs.writeFileSync(render, goodRender);
+    fs.rmSync(dist, { recursive: true });
+    fs.writeFileSync(dist, "not a directory\n");
+    const fsErr = run();
+    assert.equal(fsErr.status, 1, "exit status (signal " + fsErr.signal + "); stderr: " + fsErr.stderr);
+    assert.ok(/\n\s+at /.test(fsErr.stderr), "the error's stack is printed: " + fsErr.stderr);
+    const fsLines = fsErr.stderr.trim().split("\n");
+    assert.ok(fsLines[fsLines.length - 1].startsWith("esbuild.js: build failed: EEXIST"), "the last line: " + fsLines[fsLines.length - 1]);
+    assert.equal(fs.readFileSync(dist, "utf8"), "not a directory\n", "what stood in dist/'s place is untouched");
+    assert.ok(fs.readdirSync(cwd).every((n) => !n.startsWith(".")), "nothing staged beside it: " + fs.readdirSync(cwd).join(","));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/vscode-extension/src/esbuild-failure-cap.test.ts
+++ b/vscode-extension/src/esbuild-failure-cap.test.ts
@@ -1,0 +1,124 @@
+// esbuild.js's failure line is cut to 300 characters from the END, so the kernel, which shows the last 300
+// characters of the script's stderr when its in-place rebuild fails, shows the head of the line (what failed,
+// what is unchanged) rather than the end of its last clause.
+//
+// esbuild-build.test.ts pins the line's content and asserts `length <= 300`, but every input it feeds keeps
+// the line under 300 before the cut (the longest is 248), so the cut itself needs its own cases: a script
+// without it passes that file. The line is sized so a plausible one fits whole; what reaches the cut is a
+// long error text over a long location path (the text is cut at 120, the path never is) and a non-esbuild
+// error's message, which the script does not compose. Both are driven here: the boundary (300 fits whole,
+// 301 is cut) over a synthetic esbuild error, the text's own cut at 120 over a short path, a REAL syntax error
+// under a deep synthetic directory tree, and a non-esbuild error with a long message.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+// npm test runs in vscode-extension/, where esbuild.js lives. Required at run time rather than imported so
+// the bundler leaves it alone: it loads the real esbuild package (a native binary) from node_modules.
+const ESBUILD_JS = path.join(process.cwd(), "esbuild.js");
+const { buildAll, failureSummary } = createRequire(__filename)(ESBUILD_JS);
+
+const HEAD = "esbuild.js: build failed with 1 error; dist/ is unchanged.";
+// What the kernel shows: kernel/kernel.py's _rebuild_dist takes the stripped stderr's last 300 characters.
+const KERNEL_TAIL = 300;
+const kernelShows = (stderrLine: string) => stderrLine.slice(-KERNEL_TAIL);
+
+// An esbuild BuildFailure's shape: the one error a syntax error yields, at a location in a file.
+function syntaxFailure(text: string, file: string) {
+  return Object.assign(new Error("Build failed with 1 error"), {
+    errors: [{ text, location: { file, line: 1, column: 6 } }], warnings: [] });
+}
+
+test("failureSummary's cut sits at 300: a line of 300 goes out whole, one of 301 is cut to 300 with an ellipsis and its head intact", () => {
+  // A 100-character text stays under the text's own 120 cut, so the line's length moves one for one with the
+  // path's: measure the line over a short path, then size the path to land on 300 exactly.
+  const text = "Expected a token here but found something else instead, which is not what this syntax allows ".padEnd(100, "x");
+  assert.equal(text.length, 100);
+  const lineFor = (pathLen: number): string =>
+    failureSummary(syntaxFailure(text, "../ui/webview/".padEnd(pathLen, "d")), "dist/");
+  const base = lineFor(14).length;
+  const fits = 14 + (300 - base);
+
+  const whole = lineFor(fits);
+  assert.equal(whole.length, 300, "a line of exactly 300 is the kernel's tail: shown whole");
+  assert.ok(!whole.endsWith("..."), "and not cut: " + whole.slice(-40));
+  assert.ok(whole.endsWith(":1)"), "its location closes the line: " + whole.slice(-40));
+
+  const cut = lineFor(fits + 1);
+  assert.equal(cut.length, 300, "one over is cut back to 300, not left for the kernel to cut from the front");
+  assert.ok(cut.endsWith("..."), "the cut is marked: " + cut.slice(-40));
+  assert.equal(cut.slice(0, 297), whole.slice(0, 297), "the cut takes the END: the first 297 characters are the line as composed");
+  assert.ok(cut.startsWith(HEAD + " " + text + " (../ui/webview/"), "the head reads whole: " + cut);
+  assert.ok(!cut.includes("\n"));
+
+  // The far side: a much longer path is cut the same way, and what the kernel shows IS the line.
+  const far = lineFor(600);
+  assert.equal(far.length, 300);
+  assert.ok(far.startsWith(HEAD), far);
+  assert.equal(kernelShows(far), far, "the kernel's tail carries the whole line");
+});
+
+test("failureSummary: an error text over 120 characters is cut to 117 and an ellipsis, and its location still closes the line", () => {
+  // The text is the one part of an esbuild error the line shortens (a location path is never cut: a cut path
+  // names no file), so a long text over a short path stays well under 300 and the text's own cut is what shows.
+  const text = "Unexpected token in an expression that goes on for long enough to pass the cut the text gets ".padEnd(200, "y");
+  assert.equal(text.length, 200);
+  const file = "../ui/webview/render.ts";
+  const line: string = failureSummary(syntaxFailure(text, file), "dist/");
+  assert.equal(line, HEAD + " " + text.slice(0, 117) + "... (" + file + ":1)");
+  assert.ok(!line.includes(text.slice(0, 118)), "the 118th character is gone: " + line);
+  assert.ok(line.length < 300, "well under the 300 cut, so this is the text's own: " + line.length);
+  // a text of exactly 120 goes out whole
+  const exact = text.slice(0, 120);
+  assert.equal(failureSummary(syntaxFailure(exact, file), "dist/"), HEAD + " " + exact + " (" + file + ":1)");
+});
+
+test("failureSummary: a real syntax error under a deep path is cut to 300 with its head intact; uncut, the kernel would drop the head", async () => {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), "romp-esbuild-cap-"));
+  try {
+    // esbuild names the file relative to the cwd (vscode-extension/), so the reported path carries the whole
+    // way down. Thirteen 20-character directories exceed 300 on their own; the exact length is not the point.
+    const deep = path.join(d, ...Array.from({ length: 13 }, (_, i) => `deeply-nested-dir-${String(i).padStart(2, "0")}`));
+    fs.mkdirSync(deep, { recursive: true });
+    fs.writeFileSync(path.join(deep, "syntax.ts"), "const = ;\n");
+    const c = { entryPoints: [path.join(deep, "syntax.ts")], bundle: true, format: "iife", platform: "browser",
+                outfile: path.join(d, "dist", "syntax.js"), logLevel: "silent" };
+    let e: any = null;
+    try { await buildAll([c]); } catch (x) { e = x; }
+    assert.ok(e && Array.isArray(e.errors) && e.errors.length === 1, "an esbuild BuildFailure with the one syntax error");
+    assert.ok(e.errors[0].location && e.errors[0].location.file.length > 250, "the location path is what makes the line long: " + e.errors[0].location.file);
+
+    const line: string = failureSummary(e, "dist/");
+    assert.equal(line.length, 300, "the line is the kernel's tail exactly: " + line.length);
+    assert.ok(line.startsWith(HEAD + " "), "what failed and what is unchanged read whole: " + line);
+    assert.ok(line.includes(" (") && line.includes("deeply-nested-dir-00"), "the location opens and names the tree's top: " + line);
+    assert.ok(line.endsWith("...") && !line.includes("\n"), line.slice(-40));
+    assert.equal(kernelShows(line), line);
+
+    // Why the cut is on the script's side: the same content uncut, through the kernel's tail, loses the head.
+    const uncut = HEAD + " " + e.errors[0].text + " (" + e.errors[0].location.file + ":1)";
+    assert.ok(uncut.length > 300);
+    assert.ok(!kernelShows(uncut).startsWith("esbuild.js"), "the tail of the uncut line starts mid-word: " + kernelShows(uncut).slice(0, 40));
+  } finally {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+});
+
+test("failureSummary: a non-esbuild error's message is cut the same way, so an fs error's head is what the kernel shows", () => {
+  // Not a BuildFailure: an fs error from the write step, or a bug in the script. Its message is Node's, so its
+  // length is not the script's to size; the cut is the one guard.
+  const long = "ENOENT: no such file or directory, open '" + "/a-long-synthetic-path".repeat(20) + "/dist/.render.js.tmp-1-2'";
+  assert.ok(long.length > 300);
+  const line: string = failureSummary(new Error(long));
+  assert.equal(line.length, 300);
+  assert.ok(line.startsWith("esbuild.js: build failed: ENOENT: no such file or directory, open '/a-long-synthetic-path"), line);
+  assert.ok(line.endsWith("..."), line.slice(-40));
+  assert.equal(kernelShows(line), line);
+  // A short one is untouched (its exact text is pinned in esbuild-build.test.ts); the boundary holds here too.
+  const exact = "x".repeat(300 - "esbuild.js: build failed: ".length);
+  assert.equal(failureSummary(new Error(exact)), "esbuild.js: build failed: " + exact);
+  assert.equal(failureSummary(new Error(exact + "y")).length, 300);
+});

--- a/vscode-extension/src/esbuild-write-rename.test.ts
+++ b/vscode-extension/src/esbuild-write-rename.test.ts
@@ -1,0 +1,173 @@
+// esbuild.js's write step: each output reaches dist/ by rename, so the kernel, which serves /dist/ from that
+// directory on other threads while it rebuilds, never sends a truncated bundle.
+//
+// An in-place write (truncate, then fill) gives a concurrent GET an empty or partial file for the length of
+// the write, longest for the largest output (render.js, over a megabyte); a page loaded in that window runs
+// a bundle cut mid-statement and stays broken until it is reloaded. These tests interpose on
+// fs.writeFileSync, the one call buildAll writes through, to read the served names in the middle of each
+// write; the staging names, the fs-error path and the removal of leftovers are pinned beside it.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+// The REAL fs module object, shared with esbuild.js. The bundled `import * as fs` is a namespace copy whose
+// properties are getters, so a patch on it would never reach the script under test.
+const req = createRequire(__filename);
+const fs: typeof import("node:fs") = req("fs");
+// npm test runs in vscode-extension/, where esbuild.js lives. Required at run time rather than imported so
+// the bundler leaves it alone: it loads the real esbuild package (a native binary) from node_modules.
+const ESBUILD_JS = path.join(process.cwd(), "esbuild.js");
+const { buildAll } = req(ESBUILD_JS);
+
+function scratch(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "romp-esbuild-rename-"));
+}
+
+// A minimal browser bundle config in the shape of esbuild.js's own: bundled, silent, output under <dir>/dist.
+function cfg(dir: string, entry: string, out: string) {
+  return { entryPoints: [path.join(dir, entry)], bundle: true, format: "iife", platform: "browser",
+           outfile: path.join(dir, "dist", out), logLevel: "silent" };
+}
+
+const isOutputWrite = (p: unknown, data: unknown) => typeof p === "string" && data instanceof Uint8Array;
+
+// Runs `run` with fs.writeFileSync replaced for output writes by a version that writes the bytes in two halves
+// and calls `between(target)` after the first: the moment at which an in-place write has truncated its file
+// and not yet refilled it. Returns the paths written through it, in order.
+async function withSplitWrites(between: (target: string) => void, run: () => Promise<void>): Promise<string[]> {
+  const real = fs.writeFileSync;
+  const targets: string[] = [];
+  (fs as any).writeFileSync = (p: any, data: any, opts?: any) => {
+    if (!isOutputWrite(p, data)) return real.call(fs, p, data, opts);
+    targets.push(p);
+    const fd = fs.openSync(p, "w");
+    try {
+      const half = Math.max(1, Math.floor(data.length / 2));
+      fs.writeSync(fd, data, 0, half);
+      between(p);
+      fs.writeSync(fd, data, half);
+    } finally {
+      fs.closeSync(fd);
+    }
+  };
+  try {
+    await run();
+  } finally {
+    (fs as any).writeFileSync = real;
+  }
+  return targets;
+}
+
+const OLD = "console.log('the old build, complete');\n";
+
+test("a reader of dist/ in the middle of a write sees the old file whole or the new one whole, never a partial file", async () => {
+  const d = scratch();
+  try {
+    fs.writeFileSync(path.join(d, "one.ts"), "console.log('one: the new build');\n");
+    fs.writeFileSync(path.join(d, "two.ts"), "console.log('two: the new build');\n");
+    const dist = path.join(d, "dist");
+    fs.mkdirSync(dist);
+    const one = path.join(dist, "one.js");
+    const two = path.join(dist, "two.js");
+    fs.writeFileSync(one, OLD);              // an existing bundle being replaced; two.js is a new output
+    // what the served names held at each mid-write moment, checked once the new bytes are known
+    const seen: Array<{ during: string; one: string; two: string | null }> = [];
+    const targets = await withSplitWrites((target) => {
+      seen.push({ during: path.basename(target),
+                  one: fs.readFileSync(one, "utf8"),
+                  two: fs.existsSync(two) ? fs.readFileSync(two, "utf8") : null });
+    }, async () => {
+      const written: string[] = await buildAll([cfg(d, "one.ts", "one.js"), cfg(d, "two.ts", "two.js")]);
+      assert.deepEqual([...written].sort(), [one, two], "the return value names the served paths");
+    });
+
+    const newOne = fs.readFileSync(one, "utf8");
+    const newTwo = fs.readFileSync(two, "utf8");
+    assert.ok(newOne.includes("one: the new build") && newTwo.includes("two: the new build"), "the new build landed");
+    assert.equal(seen.length, 2, "both outputs went through fs.writeFileSync, so both mid-write moments were observed");
+    for (const s of seen) {
+      assert.ok(s.one === OLD || s.one === newOne, "one.js during the write of " + s.during + ": " + JSON.stringify(s.one));
+      assert.ok(s.two === null || s.two === newTwo, "two.js during the write of " + s.during + ": " + JSON.stringify(s.two));
+    }
+    for (const t of targets) {
+      const name = path.basename(t);
+      assert.equal(path.dirname(t), dist, "staged in the destination's own directory, so the rename cannot cross a filesystem: " + t);
+      assert.ok(t !== one && t !== two, "the write never targets a served name: " + name);
+      assert.ok(name.startsWith("."), "a hidden name: " + name);
+      assert.ok(!/\.(js|css|map|svg|ttf|woff2?|png)$/.test(name),
+                "ends in none of the suffixes the kernel's newest-mtime token globs (dist/*.js) or its /dist route types: " + name);
+      assert.ok(name.includes(".tmp-" + process.pid + "-"), "carries this process's pid, which the removal of leftovers reads: " + name);
+    }
+    assert.deepEqual(fs.readdirSync(dist).sort(), ["one.js", "two.js"], "no staging file is left behind");
+  } finally {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+});
+
+test("an fs error while writing leaves dist/ byte-for-byte as it was, with no staging file behind", async () => {
+  const d = scratch();
+  try {
+    fs.writeFileSync(path.join(d, "one.ts"), "console.log(1);\n");
+    fs.writeFileSync(path.join(d, "two.ts"), "console.log(2);\n");
+    const dist = path.join(d, "dist");
+    fs.mkdirSync(dist);
+    const one = path.join(dist, "one.js");
+    fs.writeFileSync(one, OLD);
+    const oldTime = new Date("2026-01-01T00:00:00Z");
+    fs.utimesSync(one, oldTime, oldTime);
+
+    // the first output stages, the second meets a full disk
+    const real = fs.writeFileSync;
+    let writes = 0;
+    (fs as any).writeFileSync = (p: any, data: any, opts?: any) => {
+      if (isOutputWrite(p, data) && ++writes === 2) {
+        throw Object.assign(new Error("ENOSPC: no space left on device, write"), { code: "ENOSPC" });
+      }
+      return real.call(fs, p, data, opts);
+    };
+    let err: any = null;
+    try {
+      await buildAll([cfg(d, "one.ts", "one.js"), cfg(d, "two.ts", "two.js")]);
+    } catch (e) {
+      err = e;
+    } finally {
+      (fs as any).writeFileSync = real;
+    }
+    assert.equal(writes, 2, "the second staging write is where it failed");
+    assert.equal(err && err.code, "ENOSPC", "the fs error is what buildAll rejects with (main prints it as a non-esbuild failure)");
+    assert.deepEqual(fs.readdirSync(dist), ["one.js"], "the staged first output was removed, the second never appeared");
+    assert.equal(fs.readFileSync(one, "utf8"), OLD, "the served bundle is untouched");
+    assert.equal(fs.statSync(one).mtime.getTime(), oldTime.getTime(),
+                 "its mtime stands, so the kernel's cache token does not announce a build that did not land");
+  } finally {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+});
+
+test("a staging file left by a killed earlier run is removed; one that belongs to a running process is kept", async () => {
+  const d = scratch();
+  try {
+    fs.writeFileSync(path.join(d, "one.ts"), "console.log(1);\n");
+    const dist = path.join(d, "dist");
+    fs.mkdirSync(dist);
+    // a process that has exited: its pid is free, like the pid of a build the kernel's timeout killed
+    const gone = spawnSync(process.execPath, ["-e", "0"]).pid as number;
+    assert.ok(gone > 0);
+    const stale = ".one.js.tmp-" + gone + "-0";
+    // this process's own pid stands in for a second build running against the same dist/
+    const live = ".one.js.tmp-" + process.pid + "-99";
+    fs.writeFileSync(path.join(dist, stale), "partial");
+    fs.writeFileSync(path.join(dist, live), "partial");
+    // a hidden file that is not a staging file is nobody's to remove
+    fs.writeFileSync(path.join(dist, ".keep"), "");
+
+    await buildAll([cfg(d, "one.ts", "one.js")]);
+    assert.deepEqual(fs.readdirSync(dist).sort(), [".keep", live, "one.js"].sort());
+    assert.ok(fs.readFileSync(path.join(dist, "one.js"), "utf8").includes("console.log(1)"));
+  } finally {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Symptom

The kernel rebuilds the served bundles in place by running `node esbuild.js` (from `_rebuild_dist` for the converge and pre-restart paths, and from `_ensure_bundles` at boot). When that build fails on the webview bundle after the extension bundle has built, `dist/` is left half new: `dist/extension.js` rewritten, every webview bundle old. The kernel's cache token is the newest mtime under `dist/*.js`, so it jumps: every open dashboard is told a newer build exists and reloads into the same stale bundles, and the drift pass reads dist as newer than the sources it just failed to build. The notice that says the served UI is stale carries the last 300 characters of the script's stderr, which for an esbuild BuildFailure printed whole is its stack through esbuild's transport (`at Socket.emit`, `errors: [Getter/Setter]`); it names neither the failing import nor what to do about it. The common trigger is a merge that imports a package the checkout's `node_modules` predates, the shape of the katex failure of 2026-08-10 that `_ensure_bundles`' docstring records.

The same write has a second, smaller defect: each output was written into its served path in place, so a `/dist/` request served on another thread during the write got an empty or partial bundle, and the page that loaded it ran a bundle cut mid-statement until a reload.

## Cause

`main()` ran `esbuild.build(extension)` and then `esbuild.build(webview)`, each writing `dist/` as it finished, and `main().catch` printed the error object whole.

## Fix

`vscode-extension/esbuild.js` only; the kernel is untouched.

- `buildAll(configs)` builds every config with `write: false`, then writes each output whole to a hidden sibling in its own directory (`.<name>.tmp-<pid>-<n>`: the same filesystem, so the rename is atomic; a name the kernel's `dist/*.js` glob never matches and its `/dist` route never types) and renames it over the served name. An fs error while staging removes the staged files and rethrows, so `dist/` stays byte-for-byte as it was with its mtimes standing. A staging file left by an exited pid (a build killed between its write and its rename) is removed first; one owned by a running pid is kept, so two builds on one `dist/` each rename their own.
- The one-shot build (`node esbuild.js`, with or without `--production`) goes through `buildAll`. `--watch` and `--tests` write directly as before: a dev loop wants each rebuild on disk at once.
- `failureSummary(e, untouched)` composes the last stderr line: `esbuild.js: build failed with N error(s); dist/ is unchanged.` plus the unresolved specifiers (two named, the rest counted, each cut at 60) and, when one is a bare package or a `node_modules/` path, `not in this checkout's node_modules; run npm install in vscode-extension/ and rebuild.` A relative import, a path under a directory of the checkout (`src/nowhere`) or a syntax error gets its text (cut at 120) and location; a non-esbuild error gets its message. Every line is cut to 300 characters from the end (297 plus `...`), so the head is what the kernel's `[-300:]` shows. esbuild's own report with its code frames still precedes it (`logLevel: "info"` is unchanged); the BuildFailure object is no longer printed, a non-esbuild error still is, since esbuild printed nothing for it and its stack is the diagnosis.
- `main()` runs only under `require.main === module`; `buildAll`, `failureSummary`, `extension`, `webview` and `testBuild` are exported for the tests.

`write: false` holds every bundle in memory until all have built (a few MB, plus sourcemaps in a dev build); nothing changes on success. The 300 pairs with `_rebuild_dist`'s `.strip()[-300:]`; the served-page test classes under `tests/` read the same stderr at `[-200:]` into a SkipTest message, so a line near 300 loses its head there (the npm install cure at the end survives). Those classes each run `node esbuild.js` into the shared `dist/` and `copytree` it in `setUpClass`. CI runs pytest serially, so they are unaffected; two local `pytest -n` workers building at once now fail loudly with a `shutil.Error` on a staging file that vanished mid-copy, where before a truncated in-place bundle could be copied silently. A one-build-then-copy guard for those classes, or `ignore_patterns('.*.tmp-*')` at the copytree calls, is a follow-up if local xdist runs matter.

## Tests

Three new files under `vscode-extension/src`, run by `npm test` through the existing `src` entry of `testBuild()`. Every case fails on the previous script, which exports nothing and builds on require (`buildAll is not a function`; the child-process case exits 1 on a build started in an empty directory). Against a variant that adds the exports and the gate but keeps the two per-build writes, the write and summary cases fail on the defect itself: the first bundle's old bytes are replaced, the dist snapshot changes, the interposed write is never reached, no staging file is removed, and there is no summary line. Each stated cut and branch has a case that goes red when it is removed: the 120 text cut (removed, or moved to 1200), the cwd-directory clause of the npm install rule, the printing of a non-esbuild error, and the `--production` path through `buildAll`.

- `esbuild-build.test.ts` (8 cases) drives `buildAll` and `failureSummary` against synthetic entries in scratch dirs: a failed second bundle leaves the first bundle's old bytes and its 2026-01-01 mtime; a success writes code, sourcemaps and file-loader assets in their subdir and returns the written paths; the npm install line appears for a bare specifier and a `node_modules/` path and not for `./nowhere`, `src/nowhere` or a syntax error; long specifiers are cut at 60 and a long list is counted. A child process shows that requiring the script in an empty directory exits 0, reports no build and writes nothing. The last case runs `node esbuild.js` itself over a stub tree of the real configs' entry points: a webview import of a missing package after a good build, run without `--production` and again with it, leaves every file under `dist/` with its size and mtime and ends the stderr's last 300 characters in the summary line; then, with the sources good again and a regular file in `dist/`'s place, the write step fails with EEXIST, the error's stack is printed, the last line is `esbuild.js: build failed: EEXIST...`, and nothing is staged beside it.
- `esbuild-failure-cap.test.ts` (4 cases) pins the cuts: a composed line of 300 goes out whole, one of 301 comes back as 300 ending in `...` with its first 297 characters intact; a 200-character error text over a short path is cut to 117 and `...` with its location still closing the line, and a text of exactly 120 goes out whole; a real syntax error under a 13-deep directory whose location path alone exceeds 250 characters, where the uncut line through `slice(-300)` starts mid-word; a non-esbuild message over 300.
- `esbuild-write-rename.test.ts` (3 cases) replaces `fs.writeFileSync` for output writes with a two-half write that reads the served names between the halves: each read sees the old file whole or the new one whole; the staging names are hidden, in the destination's directory, end in none of the suffixes the kernel's `/dist` route types (`.js`, `.css`, `.map`, `.svg`, `.ttf`, `.woff`, `.woff2`, `.png`), carry the pid, and none is left behind. An ENOSPC on the second staging write leaves the old bytes and mtime and no staging file. A staging file whose pid has exited is removed, beside one whose pid runs and a `.keep` that is not a staging file, both kept.

Verification: `npm run typecheck` clean; the three files 15 of 15 (five consecutive runs); full `npm test` 3762 of 3762 passed in 15 s; `tests/test_bundle_build_mode.py` 7 passed (its pins on the minify flags are untouched).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)