### PR TITLE
Feed: a second user gesture in one judge pass replays onto a fresh snapshot copy, never in place on the copy an earlier read served

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -25490,7 +25490,8 @@ _judge_gen = [0]                                 # bumped when a producer pass C
 _goals_snap = [None]                             # {sid: store} while a judge pass is mid-flight, else None
 _goals_snap_at = [0.0]                           # when that snapshot's file reads STARTED (see _feed_goals)
 _goals_snap_done = {}                            # sid → the user-write mark already punched onto THIS snapshot
-_goals_snap_owned = set()                        # sids whose snapshot entry is THIS pass's private copy (copy-on-punch)
+_goals_snap_owned = set()                        # sids whose snapshot entry is THIS pass's private copy (copy-on-punch;
+#                                                  the punch counter's once-per-pass guard, not the copy's: see _feed_goals)
 _goals_snap_lock = threading.Lock()
 # STAT-KEYED STORE MEMO (2026-09-06). The snapshot used to json.loads EVERY goals/<fsid>.json at the
 # start of every pass — on one busy kernel 72 files of up to 1.3 MB, about 3% of its interpreter time
@@ -25653,18 +25654,22 @@ def _feed_goals(sid):
     ladder the judge already encodes (user > judges) applied to the view, and it is how a CLEAR has always
     behaved (cleared.jsonl is read live, outside the snapshot). Replay is idempotent, but rollup_status is
     not free, so a sid re-punches only when its mark MOVES — a second gesture in the same pass must land
-    too, which a plain already-done flag would have swallowed."""
+    too, which a plain already-done flag would have swallowed. Every replay lands on a fresh copy of the
+    snapshot entry: an object this function has served is a fixed value (COPY-ON-PUNCH below)."""
     with _goals_snap_lock:
         snap = _goals_snap[0]
         if snap is not None and sid in snap:
             store, mark = snap[sid], _user_goal_write.get(str(sid), 0.0)
             if mark >= _goals_snap_at[0] and _goals_snap_done.get(sid) != mark:
+                # COPY-ON-PUNCH, a fresh copy per gesture: the entry is the memo's object, shared with
+                # every later pass that finds the file unchanged, so the replay and rollup below land on
+                # a copy of it (the _apply_rewind_hold idiom). And an object this function has handed
+                # out is a fixed value: a reader that kept it, or keyed anything on its identity, must
+                # never see it change under it. So a second gesture in the same pass, and a retry after
+                # a failed replay, copy again instead of re-punching the first copy in place. One json
+                # round trip per gesture; `punch` counts the sids copied, once per pass each.
+                store = snap[sid] = json.loads(json.dumps(store))
                 if sid not in _goals_snap_owned:
-                    # COPY-ON-PUNCH: the entry is the memo's object, shared with every later pass that
-                    # finds the file unchanged, so the replay and rollup below must land on a copy of it
-                    # (the _apply_rewind_hold idiom). Once per pass per sid: a second gesture in the
-                    # same pass punches the copy this one made.
-                    store = snap[sid] = json.loads(json.dumps(store))
                     _goals_snap_owned.add(sid)
                     _goals_memo_stats["punch"] += 1
                 try:

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -5084,13 +5084,13 @@ class ViewBuilder(unittest.TestCase):
         card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
         self.assertEqual(card["column"], "needs_input", "no pass active → live read shows the block at once")
 
-    def _settled_store(self, *suffixes):
+    def _settled_store(self, *suffixes, sid=SID):
         # top goal(s) already SETTLED into Completed, each with the diary its flags were materialized from —
         # the state a card is in when the user replies to it
         suffixes = suffixes or ("gP",)
         nodes, status = {}, {}
         for sfx in suffixes:
-            g = "%s:%s" % (SID, sfx)
+            g = "%s:%s" % (sid, sfx)
             nodes[g] = {"id": g, "text": "the goal " + sfx, "parentId": None,
                         "nodeComplete": True, "blocked": False, "cleared": False, "trail": [],
                         "t": NOW - 100, "mt": NOW - 50, "doneWhy": "finished",
@@ -5098,8 +5098,8 @@ class ViewBuilder(unittest.TestCase):
                         "log": [{"ev_t": NOW - 50, "src": "closer", "kind": "done", "why": "finished", "at": NOW - 50},
                                 {"ev_t": NOW - 50, "src": "romp", "kind": "settle", "at": NOW - 50}]}
             status[g] = "completed"
-        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
-            "rompUuid": SID, "seq": len(nodes), "lastNode": list(nodes)[-1],
+        (jd.GOALDIR / (sid + ".json")).write_text(json.dumps({
+            "rompUuid": sid, "seq": len(nodes), "lastNode": list(nodes)[-1],
             "nodes": nodes, "placements": {}, "status": status}))
         return list(nodes) if len(nodes) > 1 else list(nodes)[0]
 
@@ -5254,8 +5254,9 @@ class ViewBuilder(unittest.TestCase):
         # unchanged, so the punch (the gesture's replay + rollup, both in place) must land on a copy:
         # otherwise the reopen would be baked into the object the NEXT pass serves for a file that does
         # not hold it. Contract: the memoized object always equals a fresh raw parse of its file
-        # version; the served copy carries the reopen; a second gesture in the same pass works the same
-        # copy; build_feed reads and never writes.
+        # version; the served copy carries the reopen; a second gesture in the same pass lands on a
+        # fresh copy, never on the copy an earlier read served (an object _feed_goals handed out is a
+        # fixed value); build_feed reads and never writes.
         g = self._settled_store()
         path = jd.GOALDIR / (SID + ".json")
         raw = json.loads(path.read_bytes())                # the version this pass memoizes
@@ -5276,7 +5277,9 @@ class ViewBuilder(unittest.TestCase):
             self.assertIs(km._feed_goals(SID), served, "later reads in the pass serve that one copy")
             self.assertTrue(jd.optimistic_followup(SID, g, text="and the null case", now=NOW + 1))
             km._note_user_goal_write(SID)
-            self.assertIs(km._feed_goals(SID), served, "a second gesture punches the copy already made")
+            served2 = km._feed_goals(SID)
+            self.assertIsNot(served2, served, "a second gesture lands on a fresh copy, never on the first in place")
+            self.assertEqual(served2["status"].get(g), "working", "…and that copy carries the second reopen")
             self.assertEqual(memo_obj, raw)
             card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
             self.assertEqual(card["column"], "working")
@@ -5289,6 +5292,46 @@ class ViewBuilder(unittest.TestCase):
             self.assertEqual(km._feed_goals(SID)["status"].get(g), "working")
         finally:
             km._end_goals_pass()
+
+    # Private to the fresh-copy test below: it mints a goal store and journals gestures against it.
+    FRESH_SID = "11111111-2222-3333-4444-fefefefefefe"
+
+    def test_a_second_gesture_in_the_same_pass_never_changes_the_copy_an_earlier_read_served(self):
+        # An object _feed_goals hands out is a fixed value: a reader that keeps it, or keys anything on
+        # its identity, must never see it change under it. A second gesture on the same sid inside one
+        # pass therefore replays onto a FRESH copy of the snapshot entry, not in place on the copy an
+        # earlier read served. Content tells the copies apart: the first carries the follow-up's reopen
+        # (nodeComplete cleared) and keeps it; the second carries the later resolve (nodeComplete set).
+        sid = self.FRESH_SID
+        g = self._settled_store(sid=sid)
+        path = jd.GOALDIR / (sid + ".json")
+        raw = json.loads(path.read_bytes())                # the version this pass memoizes
+        km._user_goal_write.pop(sid, None)
+        km._begin_goals_pass()
+        try:
+            memo_obj = km._goals_memo[0][str(path)][1]
+            punched = km._goals_memo_stats["punch"]
+            self.assertTrue(jd.optimistic_followup(sid, g, text="also handle the empty case", now=NOW))
+            km._note_user_goal_write(sid)                  # gesture 1: the reply reopens the goal
+            served1 = km._feed_goals(sid)
+            self.assertEqual(served1["status"].get(g), "working")
+            self.assertFalse(served1["nodes"][g].get("nodeComplete"), "the reply's reopen cleared the flag")
+            jd.append_override(sid, g, "resolve", NOW + 1)  # gesture 2: the user resolves it a second later
+            # The mark moves. Set by hand rather than by a second _note_user_goal_write so the fresh copy
+            # never rides on the clock advancing between two gestures.
+            km._user_goal_write[sid] = km._user_goal_write[sid] + 1.0
+            served2 = km._feed_goals(sid)
+            self.assertIsNot(served2, served1, "the second gesture lands on a fresh copy")
+            self.assertTrue(served2["nodes"][g].get("nodeComplete"), "…which carries the resolve")
+            self.assertFalse(served1["nodes"][g].get("nodeComplete"),
+                             "the copy the earlier read served has not changed under its holder")
+            self.assertEqual(memo_obj, raw, "the memoized object is still the raw parse")
+            self.assertEqual(km._goals_memo_stats["punch"] - punched, 1,
+                             "punch counts the sids copied, once per pass each")
+        finally:
+            km._end_goals_pass()
+            km._user_goal_write.pop(sid, None)
+            (jd._overrides_dir() / (sid + ".jsonl")).unlink(missing_ok=True)
 
     def test_a_store_that_does_not_decode_is_served_live_and_retried_only_when_it_changes(self):
         # A version that fails to decode stays out of the snapshot (the feed falls to live load_goals,
@@ -5703,7 +5746,7 @@ class ViewBuilder(unittest.TestCase):
             self.assertTrue(jd.optimistic_followup(SID, g, text="one more thing", now=NOW))
             km._note_user_goal_write(SID)
             d = deltas(lambda: (km._feed_goals(SID), km._feed_goals(SID)))
-            self.assertEqual(d["punch"], 1, "one copy per pass per sid, however many reads")
+            self.assertEqual(d["punch"], 1, "one punch per pass per sid, however many reads")
         finally:
             km._end_goals_pass()
 

--- a/tests/test_kernel_restore_flicker.py
+++ b/tests/test_kernel_restore_flicker.py
@@ -126,6 +126,7 @@ class RestoreReplyFlicker(unittest.TestCase):
     def test_a_failed_replay_does_not_burn_the_punch(self):
         # The punch marked itself done BEFORE replaying; one exception served the pre-gesture card
         # for the rest of the pass. Done is stamped on success only — the next read retries.
+        # The retry lands on a fresh copy: the object the failed read served is a fixed value.
         self._seed_archived_completed()
         kern._undo_clear()                             # live restore (completed on the board)
         kern._begin_goals_pass()
@@ -147,6 +148,9 @@ class RestoreReplyFlicker(unittest.TestCase):
             second = kern._feed_goals(SID)
             self.assertEqual(second["status"].get(GID), "working",
                              "the mark was not burned — the very next read retries and punches")
+            self.assertIsNot(second, first, "the retry replays onto a fresh copy, not onto the served one")
+            self.assertEqual(first["status"].get(GID), "completed",
+                             "what the failed read served has not changed under its holder")
         finally:
             jd._replay_overrides = real
 


### PR DESCRIPTION
## Symptom

Nothing renders wrong from this today; the PR closes an aliasing hazard. While a judge pass is in flight, `_feed_goals` serves the feed from the pass snapshot and replays the user's journaled gestures onto it. The first gesture on a session copies the snapshot entry before the replay (copy-on-punch); a second gesture in the same pass, or a retry after a failed replay, used to replay onto that first copy in place and hand back the same object. So an object `_feed_goals` had already served changed under its holder.

`build_feed` is the only caller and nothing keys on the served object's identity, which is why no card reads wrong now. The hazard becomes wrong rows the moment a reader keeps the served store by identity. The consumer this prepares for is a per-session feed memo: a session's rows kept under its served store's identity and served while that object stands. Without this change such a memo hits on the first copy and serves the pre-gesture rows for the rest of the pass, 30 to 80 s on a busy kernel (a resolve on an open sub after a follow-up would read open on the board while a fresh build read done).

## Cause

In `_feed_goals` the json round-trip copy sat inside the `if sid not in _goals_snap_owned:` guard, whose purpose is to keep the `punch` counter at one per session per pass. The guard therefore also gated the copy: only the first moved mark in a pass copied; every later one replayed in place on the copy an earlier read had served. The punch test pinned that behaviour: `assertIs(km._feed_goals(SID), served, "a second gesture punches the copy already made")`.

## Fix

`kernel/kernel.py`, `_feed_goals`: the copy statement moves out of the guard, so every moved mark (and every retry after a failed replay) lands on a fresh copy of the snapshot entry. The guard stays around `_goals_snap_owned.add(sid)` and the `punch` increment, so `punch` still counts sessions copied once per pass each. The counters test's assertion is unchanged and green; its message now says one punch per pass per sid where it said one copy. The COPY-ON-PUNCH comment, the docstring and the `_goals_snap_owned` comment now state the contract: an object `_feed_goals` has handed out is a fixed value. The memo's object is never mutated, as before, and `_feed_goals` keeps its one-value return.

Cost: one json round trip per gesture instead of one per session per pass. Gestures are user-rate events (one click each).

## Tests

- `tests/test_kernel.py::ViewBuilder::test_a_second_gesture_in_the_same_pass_never_changes_the_copy_an_earlier_read_served` (new): a follow-up and then a resolve on one settled goal inside one pass. Asserts the second read is a different object, that it carries the resolve (`nodeComplete` set), that the first served copy still carries only the reopen (`nodeComplete` cleared), that the memoized object still equals the raw parse of the file, and that `punch` moved by exactly one. Before the change it fails at the identity assertion: both reads are the same dict, mutated in place, and the first copy shows the resolve. It mints its store under its own sid through the class's `_settled_store` helper (which now takes a `sid` keyword; the default is unchanged), removes that sid's journal and mark afterwards, and moves the mark by hand for the second gesture so the test never depends on the clock advancing between two gestures.
- `tests/test_kernel.py::ViewBuilder::test_a_user_punch_copies_the_entry_and_never_mutates_the_memoized_store`: the standing pin on the second gesture flips from `assertIs` to `assertIsNot`, with a status assertion that the new copy carries the second reopen; the test's comment follows. Before the change it fails on the flipped assertion.
- `tests/test_kernel.py::ViewBuilder::test_the_memo_counters_and_report_follow_the_passes`: the `punch == 1` assertion is unchanged; only its message is reworded from "one copy per pass per sid" to "one punch per pass per sid". With the guard removed (punch counted per gesture) this test stays green, since it reads one gesture twice; the new test's punch assertion goes red (2 != 1).
- `tests/test_kernel_restore_flicker.py::RestoreReplyFlicker::test_a_failed_replay_does_not_burn_the_punch`: adds that the retry's read is a different object and that the object the failed read served still reads completed. Before the change it fails on the identity assertion.
- Full suite on the final tree: `pytest -q -n 8 tests/`, 10199 passed, 61 skipped, 1671 subtests passed, 0 failed (74 s).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)