### PR TITLE
Names records: a record that reads with no name is left alone by the kernel's writers, and bin/romp publishes the record atomically

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -107,7 +107,17 @@ _romp_record() {   # <sid> <name> <dir> [bg] [fg] — write/replace the map entr
     # users from reading anything beneath it (the traverse bit is enough).
     # Idempotent; best-effort.
     chmod 700 "${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}" 2>/dev/null || true
-    printf '%s\t%s\t%s\t%s\n' "$nm" "$dir" "$bg" "$fg" > "$ROMP_NAMES_DIR/$sid"
+    # Atomic: the line is written to a temp in the same directory and moved into place, one rename(2),
+    # so no reader ever sees the record empty or half-written. The kernel's names writers read the
+    # record while this hook rewrites it (its rename writer runs right after a live tmux rename; its
+    # color and palette writers touch any session's record) and publish their edit over what they
+    # read, so a truncate-then-write here cost the session its name and cwd. This is the one shell
+    # writer of a record (_romp_rename_record and _romp_free_title come through here). The temp is
+    # dot-prefixed, so _romp_free_title's glob and the resume picker's listing skip it; a failed write
+    # or move removes it.
+    local tmp="$ROMP_NAMES_DIR/.$sid.tmp.$$"
+    printf '%s\t%s\t%s\t%s\n' "$nm" "$dir" "$bg" "$fg" > "$tmp" && mv -f "$tmp" "$ROMP_NAMES_DIR/$sid" \
+        || { rm -f "$tmp"; return 1; }
 }
 
 _romp_rename_record() {   # <sid> <name> — update name, keep dir + identity color

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2258,19 +2258,67 @@ _MODEL_VALUES = {m["value"] for m in MODEL_CHOICES}
 _EFFORT_VALUES = {e["value"] for e in EFFORT_CHOICES}
 
 
+_NAMES_REREAD_S = 0.05   # the pause before the ONE re-read of a names record that read with no name (below)
+
+
+def _names_problem(text):
+    """A names-registry problem, reported where someone sees it: the kernel log AND the dashboard's error
+    center (the bell), the path SDK problems take (_sdk_problem). Never a silent degrade."""
+    sys.stderr.write("[names] %s\n" % text)
+    _sdk_problem("names registry: %s" % text)
+
+
+def _names_fields_for_edit(sid, what):
+    """The tab fields of names/<sid> for a read-edit-publish by one of the kernel's three writers of the
+    record (_set_name, _set_session_color, _set_palette), or None for a record that reads with NO NAME,
+    which is left exactly as it is. Every writer puts the name first, so an empty first field is never a
+    real record: it is another writer's window (a writer that truncates before it writes, as bin/romp's
+    record writer did, behind the tmux after-rename hook that races _set_name's synchronous publish
+    after a live rename) or a damaged file. Padded to four fields and published over, it cost the
+    session its name, cwd and colors while the edit reported success. One re-read after a short pause
+    (_NAMES_REREAD_S, paid only on an empty read; the window is a printf's worth of time) tells a window
+    from damage: a record whole on the second read is edited as usual; one still without a name is
+    reported, naming the sid and `what` went unwritten. A record that cannot be read RAISES
+    (FileNotFoundError when there is none): each caller keeps its own policy for that."""
+    text = (NAMES / str(sid)).read_text()
+    parts = text.rstrip("\n").split("\t")
+    if not parts[0]:
+        time.sleep(_NAMES_REREAD_S)
+        text = (NAMES / str(sid)).read_text()
+        parts = text.rstrip("\n").split("\t")
+        if not parts[0]:
+            _names_problem("names/%s reads with no name (%d bytes, twice); %s not written: the record is being "
+                           "rewritten, or is damaged" % (sid, len(text), what))
+            return None
+    return parts
+
+
+def _names_refusal(sid):
+    """Why a names write answered False, for a door's one-line reply: no record at all, or a record that
+    reads with no name (left alone and reported by _names_fields_for_edit)."""
+    if not (NAMES / str(sid)).exists():
+        return "no names record for that session — is it known to this kernel?"
+    return ("that session's names record reads with no name (being rewritten, or damaged); nothing written. "
+            "Try again, and see the kernel log")
+
+
 def _set_session_color(sid, bg):
     """Override a session's identity color: rewrite the names registry's bg (3rd field) + fg word (4th),
     preserving the name + cwd. Only a value from a known palette is accepted (its own palette supplies
-    the fg). Returns True on a real write. The dashboard reads color from here (_name_color) and a resume
+    the fg). Returns True on a real write; False for a record that cannot be read, and for one that
+    reads with no name (_names_fields_for_edit: left alone and reported, where a publish over it erased
+    the session's name and cwd). The dashboard reads color from here (_name_color) and a resume
     reuses it, so this is the durable store; the live tmux status bar (a separate @identity-bg) refreshes
     on the session's next resume."""
     if not pal.find(bg):
         return False
     try:
-        parts = (NAMES / sid).read_text().rstrip("\n").split("\t")
+        parts = _names_fields_for_edit(sid, "the color")
     except Exception:
         return False
-    name = parts[0] if parts else ""
+    if parts is None:
+        return False
+    name = parts[0]
     cwd = parts[1] if len(parts) > 1 else ""
     _atomic_write(NAMES / sid, "\t".join([name, cwd, bg, pal.fg_for(bg)]) + "\n")
     return True
@@ -2296,9 +2344,11 @@ def _set_palette(name):
         sids = []
     for sid in sids:
         try:
-            parts = (NAMES / sid).read_text().rstrip("\n").split("\t")
+            parts = _names_fields_for_edit(sid, "the palette recolor")
         except Exception:
             continue
+        if parts is None:
+            continue                # reads with no name: left alone and reported; the rest recolor
         loc = pal.find(parts[2]) if len(parts) > 2 else None
         if loc:
             # palettes may differ in LENGTH now (the romp set grows append-only, 2026-08-28): a
@@ -16403,8 +16453,13 @@ def _set_name(sid, name):
     Returns True once the file is published; a names/ entry that cannot be read (absent, or not text)
     or a publish that fails RAISES, the way _atomic_write already does — the old silent `return` on an
     unreadable entry, and the unchecked write, let _rename_session answer the accepted name over a
-    file it never rewrote, and the doors told the user "renamed" (fail loudly, 2026-09-08)."""
-    parts = (NAMES / sid).read_text().rstrip("\n").split("\t")
+    file it never rewrote, and the doors told the user "renamed" (fail loudly, 2026-09-08). A record that
+    reads with NO NAME is another writer's window or a damaged file (_names_fields_for_edit): it is left
+    exactly as it is and the rename RAISES naming the sid, so the doors say why it did not take; padded
+    and published over, it lost the session's cwd and colors while the doors said "renamed"."""
+    parts = _names_fields_for_edit(sid, "the name")     # absent or unreadable: the read raises through, as before
+    if parts is None:
+        raise RuntimeError("names/%s reads with no name, twice: being rewritten, or damaged; nothing written" % sid)
     parts += [""] * (4 - len(parts))
     parts[0] = name
     _atomic_write(NAMES / sid, "\t".join(parts[:4]) + "\n")   # atomic publish
@@ -47882,8 +47937,7 @@ class Handler(BaseHTTPRequestHandler):
                         '"%s" is not a swatch of any palette — GET /palette lists the choosable ones' % bg}),
                                       "application/json")
                 if not _set_session_color(tsid, bg):
-                    return self._send(200, json.dumps({"ok": False, "error":
-                        "no names record for that session — is it known to this kernel?"}),
+                    return self._send(200, json.dumps({"ok": False, "error": _names_refusal(tsid)}),
                                       "application/json")
                 _mark_views_dirty()
                 return self._send(200, json.dumps({"ok": True, "id": tsid, "bg": bg,

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -1281,6 +1281,44 @@ _stale_server_globals() {
     [[ "$output" == *"unknown option: -x"* ]]
 }
 
+@test "names map: the record writer publishes atomically, so a reader racing the rename hook never sees an empty record" {
+    # _romp_record (a launch, the after-rename hook, the title-freeing rewrite) fills a temp in the names
+    # directory and moves it into place. The kernel's names writers read the record while the hook
+    # rewrites it and publish their edit over what they read, so a writer that truncated before it wrote
+    # cost the session its name and cwd. A reader polling the record while the hook rewrites it forty
+    # times must never find it empty; the rename must land with the dir and colors intact, and every hook
+    # run must reach the writer (the mock tmux answers the sid and logs the send-keys that follows the
+    # write), so a hook that never writes cannot pass by leaving the seed alone. The temp is dot-prefixed:
+    # the `*` glob _romp_free_title walks the directory with must never see it, and none may be left behind.
+    cat > "$MOCK_DIR/tmux" << 'MOCK'
+#!/usr/bin/env bash
+echo "tmux $*" >> "$MOCK_LOG"
+if [[ "$1" == "show" && "$5" == "@romp-session-id" ]]; then echo aaaa1111-bbbb-2222-cccc-333333333333; fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/tmux"
+    ndir="$XDG_STATE_HOME/romp/names"
+    mkdir -p "$ndir"
+    f="$ndir/aaaa1111-bbbb-2222-cccc-333333333333"
+    printf 'stale\t%s\t#1EA1EB\twhite\n' "$WORK_DIR" > "$f"
+    # the writer: the rename hook, 40 times over; the reader: as many looks as fit meanwhile
+    ( for i in $(seq 1 40); do "$ROMP_SCRIPT" _renamed exp-web >/dev/null 2>&1; done ) &
+    wpid=$!
+    empty=0; reads=0; seen=0
+    while kill -0 "$wpid" 2>/dev/null; do
+        reads=$((reads + 1))
+        [ -s "$f" ] || empty=$((empty + 1))
+        for e in "$ndir"/*; do [ "$e" = "$f" ] || seen=$((seen + 1)); done   # the glob _romp_free_title walks
+    done
+    wait "$wpid"
+    [ "$reads" -gt 100 ]
+    [ "$empty" -eq 0 ]
+    [ "$seen" -eq 0 ]                                                      # the temp never shows to that glob
+    [ "$(grep -c '^tmux send-keys' "$MOCK_LOG")" -eq 40 ]                   # every hook run got past the writer
+    [ "$(cat "$f")" = "$(printf 'exp-web\t%s\t#1EA1EB\twhite' "$WORK_DIR")" ]   # the rename landed; dir and colors intact
+    [ "$(ls -A "$ndir" | grep -vc '^aaaa1111-bbbb-2222-cccc-333333333333$')" -eq 0 ]   # no temp left behind
+}
+
 @test "old-kernel spawn shape (--detach <name>) still works, silently" {
     # A kernel on pre-round-3 code spawns dashboard tmux sessions as `romp
     # --detach <name>` with stderr swallowed — the shape must keep working.

--- a/tests/test_color_route.py
+++ b/tests/test_color_route.py
@@ -5,6 +5,8 @@ one identity color without WS surgery. Only a swatch of a known palette is accep
 palette supplies the fg word), and a recolor is a names-registry write, so a dormant session
 recolors by sid just like /rename renames one. Drives the REAL Handler over HTTP (the
 test_new_route_prefs.py pattern). Synthetic only."""
+import contextlib
+import io
 import json
 import os
 import tempfile
@@ -123,6 +125,32 @@ class ColorRoute(unittest.TestCase):
         self.assertEqual(st, 400)
         st, r = self._post({"bg": "#54B204"})
         self.assertEqual(st, 400)
+
+
+    def test_a_record_that_reads_with_no_name_is_refused_with_the_cause_and_left_alone(self):
+        # before the guard: ok True, and the file read \t\t#54B204\tblack\n (name and cwd erased). A record
+        # whose first field is empty is another writer's window or a damaged file, never a real record:
+        # the writer leaves it alone, and the route says which of its two refusals this is
+        (self.names / SID).write_text("")
+        saved = list(km._SDK_BOOT_PROBLEMS)
+        self.addCleanup(lambda: km._SDK_BOOT_PROBLEMS.__setitem__(slice(None), saved))
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            st, r = self._post({"target": "web", "bg": "#54B204"})
+        self.assertEqual(st, 200)
+        self.assertFalse(r.get("ok"), r)
+        self.assertIn("reads with no name", r.get("error") or "", "the cause, not the absent-record question")
+        self.assertNotIn("no names record", r.get("error") or "")
+        self.assertEqual((self.names / SID).read_text(), "", "left byte for byte as it was")
+        self.assertFalse(self.dirty, "nothing to repaint")
+        self.assertIn(SID, err.getvalue(), "the log names the sid")
+
+    def test_an_absent_record_still_asks_if_the_session_is_known(self):
+        st, r = self._post({"target": SID2, "bg": "#54B204"})
+        self.assertFalse(r.get("ok"), r)
+        self.assertIn("no names record for that session", r.get("error") or "")
+        self.assertFalse((self.names / SID2).exists(), "no record is invented")
+        self.assertFalse(self.dirty)
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_names.py
+++ b/tests/test_kernel_names.py
@@ -1035,6 +1035,57 @@ class RenameFaultsThroughTheDoors(_Routes):
         self.assertNotIn("rewrites it later", log, "bin/romp's hook returns early on an absent entry: no false promise")
 
 
+    def _no_name_record(self):
+        """names/<SID> reads with no name: 0 bytes, another writer's window or a damaged file. The writer's
+        one re-read runs for real here (a short pause); the error-center ring is restored afterwards."""
+        (self.names / SID).write_text("")
+        saved = list(km._SDK_BOOT_PROBLEMS)
+        self.addCleanup(lambda: km._SDK_BOOT_PROBLEMS.__setitem__(slice(None), saved))
+
+    def test_a_dead_tab_rename_over_a_record_with_no_name_is_refused_with_the_cause(self):
+        # before the guard: 'renamed' != 'warn', and the file read web2\t\t\t\n (cwd and colors erased)
+        self.as_dead()
+        self._no_name_record()
+        f = self.ws()
+        self.assertEqual(f["type"], "warn", f)
+        self.assertIn("the rename did not take", f["text"])
+        self.assertIn("names/%s reads with no name" % SID, f["text"], "the cause, naming the record")
+        self.assertNotIn("is that session known", f["text"], "a record with no name is not an unknown session")
+        self.assertEqual((self.names / SID).read_text(), "", "left byte for byte as it was")
+        self.assertEqual(sorted(p.name for p in self.names.iterdir()), [SID], "no temp left behind")
+        self.assertIn(SID, self.err.getvalue(), "the log names the sid")
+        self.assertEqual(self.claims(), {}, "the claim is released")
+
+    def test_a_dead_tab_rename_over_a_record_with_no_name_answers_the_route_ok_false(self):
+        # before the guard: ok True, id SID, over a file rewritten as web2\t\t\t\n
+        self.as_dead()
+        self._no_name_record()
+        st, r = self.route(SID)                     # dead: no live name resolves, so the sid is the target
+        self.assertEqual(st, 200, r)
+        self.assertFalse(r.get("ok"), r)
+        self.assertIn("the rename did not take", r.get("error") or "")
+        self.assertIn("reads with no name", r.get("error") or "")
+        self.assertEqual((self.names / SID).read_text(), "")
+        self.assertEqual(self.claims(), {})
+
+    def test_a_live_rename_over_a_record_with_no_name_keeps_the_old_name_and_says_so(self):
+        # before the guard: 'renamed' != 'warn'; tmux renamed the session AND the kernel published
+        # web2\t\t\t\n, so the after-rename hook's own rewrite (which would have carried the whole record
+        # had the kernel left the file alone) landed on an unlinked inode
+        self.as_live()
+        self._no_name_record()
+        f = self.ws()
+        self.assertEqual(self.renamed, [("web", "web2")], "tmux renamed the session")
+        self.assertEqual(f["type"], "warn", f)
+        self.assertIn("was renamed, but its name on file could not be updated", f["text"])
+        self.assertIn("reads with no name", f["text"], "with the cause")
+        self.assertIn("until that write lands", f["text"], "the entry exists: the hook's rewrite lands")
+        self.assertNotIn("did not take", f["text"], "tmux did take it")
+        self.assertEqual((self.names / SID).read_text(), "", "nothing published over the record")
+        self.assertIn("the after-rename hook rewrites it later", self.err.getvalue())
+        self.assertEqual(self.claims(), {})
+
+
 class LockDiscipline(_Base):
     """The snapshot is taken OUTSIDE the claims lock by every caller; the check-and-insert is INSIDE it."""
 

--- a/tests/test_kernel_session_color.py
+++ b/tests/test_kernel_session_color.py
@@ -4,12 +4,15 @@ it to the names registry (bg + fg word, preserving name + cwd) and re-broadcasts
 colors picker switches the whole SET (STATE/palette): the kernel remaps every stored color to the same
 slot in the new set, rewrites the shell launcher's STATE/palette-colors mirror, and pushes. SYNTHETIC
 fixtures only (placeholder uuids, invented paths)."""
+import contextlib
 import inspect
+import io
 import os
 import tempfile
 import unittest
 from pathlib import Path
 from importlib.machinery import SourceFileLoader
+from unittest import mock
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -23,6 +26,8 @@ km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_modu
 
 SID = "11111111-2222-3333-4444-555555555555"
 SID2 = "22222222-3333-4444-5555-666666666666"
+NSID = "aaaa1111-bbbb-2222-cccc-333333333333"     # the NoNameRecordIsLeftAlone sandbox's own sids
+NSID2 = "dddd4444-eeee-5555-ffff-666666666666"
 
 
 class SessionColor(unittest.TestCase):
@@ -229,6 +234,124 @@ class HighSlotSwitches(SessionColor):
         i = zlib.crc32(sid.encode()) % len(bgs)
         self.assertGreaterEqual(i, 9)
         self.assertEqual((bg, fg), (bgs[i], fgs[i]), "the paired index holds past the old nine")
+
+
+class NoNameRecordIsLeftAlone(SessionColor):
+    """A names record whose FIRST field is empty is never a real record: every writer puts the name
+    first, so it is another writer's window (bin/romp's record writer truncated the file before it
+    wrote it; it publishes atomically now, but an older copy of it may still run the tmux rename
+    hook) or a damaged file. The kernel's three writers of the record (a rename, a recolor, a palette
+    switch) used to pad it to four fields and publish the edit over it, erasing the session's name,
+    cwd and colors for good while reporting success: the kernel's os.replace won over the other
+    writer's pending bytes. Each now re-reads once after a short pause and, if the record still has no
+    name, leaves it byte for byte as it was and reports the sid to the log and the dashboard's error
+    center. The pause is recorded, never slept; the sandbox has its own sids."""
+
+    def setUp(self):
+        super().setUp()
+        self._problems = list(km._SDK_BOOT_PROBLEMS)        # the error-center ring, restored in tearDown
+        del km._SDK_BOOT_PROBLEMS[:]
+
+    def tearDown(self):
+        km._SDK_BOOT_PROBLEMS[:] = self._problems
+        super().tearDown()
+
+    def _record_pauses(self, on_pause=None):
+        """The kernel's time.sleep recorded, not slept: the writer's one re-read pauses _NAMES_REREAD_S, and
+        `on_pause` stands in for the other writer landing its bytes meanwhile. The stub stands in for the
+        `time` name the kernel module reads, so a sleep by any other code in the process is neither
+        recorded nor answered with `on_pause`. Restored at cleanup."""
+        slept = []
+        real = km.time
+
+        class _Clock:
+            def __getattr__(self, k):
+                return getattr(real, k)
+
+            @staticmethod
+            def sleep(s):
+                slept.append(s)
+                if on_pause is not None:
+                    on_pause()
+        p = mock.patch.object(km, "time", _Clock())
+        p.start()
+        self.addCleanup(p.stop)
+        return slept
+
+    def test_a_record_that_reads_with_no_name_is_left_alone_and_reported(self):
+        # before the guard: the recolor answered True and the file read \t\t#54B204\tblack\n; the
+        # rename answered True and the file read api\t\t\t\n (cwd and colors gone, for every shape here)
+        slept = self._record_pauses()
+        for raw in ("", "\n", "\t/proj/TESTHOST/app\t#1EA1EB\twhite\n", "\t\t\t\n"):
+            for writer, call in (("color", lambda: km._set_session_color(NSID, "#54B204")),
+                                 ("name", lambda: km._set_name(NSID, "api"))):
+                with self.subTest(raw=raw.encode("unicode_escape").decode(), writer=writer):
+                    (self.names / NSID).write_text(raw)
+                    del slept[:]
+                    del km._SDK_BOOT_PROBLEMS[:]
+                    err = io.StringIO()
+                    with contextlib.redirect_stderr(err):
+                        if writer == "name":
+                            # the rename door's contract: a name that did not land RAISES, never a quiet True
+                            with self.assertRaises(RuntimeError) as cm:
+                                call()
+                            self.assertIn(NSID, str(cm.exception), "the raise names the sid")
+                            self.assertIn("no name", str(cm.exception))
+                        else:
+                            self.assertFalse(call(), "nothing was written")
+                    self.assertEqual((self.names / NSID).read_text(), raw, "the file is left byte for byte as it was")
+                    self.assertEqual(slept, [km._NAMES_REREAD_S], "exactly one re-read, after the short pause")
+                    self.assertIn(NSID, err.getvalue(), "the log line names the sid")
+                    self.assertIn("no name", err.getvalue())
+                    self.assertEqual(len(km._SDK_BOOT_PROBLEMS), 1, "one row reaches the dashboard's error center")
+                    self.assertIn(NSID, km._SDK_BOOT_PROBLEMS[0]["text"])
+        self.assertGreater(km._NAMES_REREAD_S, 0)
+        self.assertLessEqual(km._NAMES_REREAD_S, 0.25, "a printf's worth of window, not a wait the user notices")
+
+    def test_the_palette_switch_skips_a_record_with_no_name_and_recolors_the_rest(self):
+        # before the guard: the record with no name came back recolored, still with no name, and nothing
+        # was reported; a 0-byte record was skipped only because it had no third field to match
+        slept = self._record_pauses()
+        pb, pf = km.pal.colors("romp"), km.pal.fgs("romp")
+        skipped = "\t/proj/TESTHOST/app\t%s\t%s\n" % (pb[0], pf[0])   # a color the remap would otherwise move
+        (self.names / NSID).write_text(skipped)
+        (self.names / NSID2).write_text("api\t/proj/TESTHOST/svc\t%s\t%s\n" % (pb[1], pf[1]))
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertTrue(km._set_palette("phase"))
+        nb, nf = km.pal.colors("phase"), km.pal.fgs("phase")
+        self.assertEqual((self.names / NSID).read_text(), skipped, "the record with no name is left as it was")
+        self.assertEqual((self.names / NSID2).read_text().rstrip("\n").split("\t"),
+                         ["api", "/proj/TESTHOST/svc", nb[1], nf[1]], "the rest recolor")
+        self.assertEqual(slept, [km._NAMES_REREAD_S], "one re-read, for the one record with no name")
+        self.assertIn(NSID, err.getvalue(), "the log names the skipped sid")
+        self.assertEqual([NSID in r["text"] for r in km._SDK_BOOT_PROBLEMS], [True])
+
+    def test_the_re_read_catches_a_writer_that_was_mid_write(self):
+        # the window is a printf's worth of time: a record empty on the first read and whole on the second
+        # is a writer caught mid-write, and the edit lands on the whole record; nothing lost, nothing reported
+        whole = "web\t/proj/TESTHOST/app\t#1EA1EB\twhite\n"
+        slept = self._record_pauses(on_pause=lambda: (self.names / NSID).write_text(whole))
+        for writer, call, want in (
+                ("name", lambda: km._set_name(NSID, "api"), "api\t/proj/TESTHOST/app\t#1EA1EB\twhite\n"),
+                ("color", lambda: km._set_session_color(NSID, "#54B204"), "web\t/proj/TESTHOST/app\t#54B204\tblack\n")):
+            with self.subTest(writer=writer):
+                (self.names / NSID).write_text("")          # empty on the first read: the other writer's window
+                del slept[:]
+                err = io.StringIO()
+                with contextlib.redirect_stderr(err):
+                    self.assertTrue(call())
+                self.assertEqual((self.names / NSID).read_text(), want, "the edit lands on the whole record")
+                self.assertEqual(slept, [km._NAMES_REREAD_S])
+                self.assertEqual(err.getvalue(), "", "a caught window is not a problem")
+                self.assertEqual(km._SDK_BOOT_PROBLEMS, [])
+        # a record with a name and nothing else is a real (if old) record: padded and published as before.
+        # The guard keys on the NAME field, not on the field count, and pauses only on an empty read.
+        (self.names / NSID).write_text("web\n")
+        del slept[:]
+        self.assertTrue(km._set_name(NSID, "api"))
+        self.assertEqual((self.names / NSID).read_text(), "api\t\t\t\n")
+        self.assertEqual(slept, [], "no re-read for a record that has a name")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Symptom
A rename, a recolor or a palette switch erases a session's cwd and colors from the names registry and reports success. Afterwards the registry holds no directory for the session and its identity color is gone; after a rename it holds the new name and nothing else. The case that reaches it most directly is a tmux-backed session renamed from the dashboard, where the kernel and the tmux after-rename hook rewrite the same record at the same moment. Any session whose record reads as 0 bytes reaches it through a recolor or a palette switch.

## Cause
The kernel's three writers of `names/<sid>` (`_set_name`, `_set_session_color`, `_set_palette`) read the record, edit their field and publish the whole line. A record that reads as 0 bytes splits to `['']`; padded to four empty fields, it is published as `<name>\t\t\t\n` by the rename and `\t\t<bg>\t<fg>\n` by the recolor, and the palette writer rewrites any no-name record that carries a palette color. Two things produce the empty read:

- bin/romp's `_romp_record` wrote with `printf > file`: truncate, then write. It is the one shell writer of a record, behind the tmux `after-rename-session` hook (`romp _renamed`), every tmux launch and `_romp_free_title`'s rewrite of other sessions' records. Since https://github.com/romp-on/romp/pull/1066 the kernel publishes the name synchronously right after a live tmux rename, so `_set_name` and the hook rewrite the same file at once: the hook truncates, the kernel reads 0 bytes and its `os.replace` publishes `name\t\t\t`, and the hook's bytes land on the unlinked inode. Tmux-backed sessions reach this path (the tmux backend is a setting, off by default); the SDK and Codex backends rename through their own writers with in-memory fields and have no tmux session for the hook to fire on.
- A damaged 0-byte record, whoever wrote it. The recolor (`POST /color`, the tab's color picker) and the palette switch publish over it for any session, and a dead-tab rename of a sid no module backend owns reaches `_set_name` the same way.

https://github.com/romp-on/romp/pull/1138 made a names write that did not land raise, so the doors no longer say "renamed" over a file the kernel never rewrote. This is the remaining case: the kernel did rewrite the file, with empty fields.

## Fix
- `_names_fields_for_edit(sid, what)` reads the record for the three writers. Every writer puts the name first, so an empty first field is never a real record: it is another writer's window or a damaged file. One re-read after a short pause (`_NAMES_REREAD_S`, 50 ms, paid only on an empty read) tells the two apart: a record whole on the second read is edited as usual; one still without a name is left byte for byte as it was and reported through `_names_problem` to the kernel log and the dashboard's error center (`_sdk_problem`, the bell). A record that cannot be read raises through the helper, so each writer keeps its existing policy for that: the recolor answers False, the palette switch skips, the rename raises the real errno.
- Over a no-name record `_set_session_color` answers False, `_set_palette` skips the record and recolors the rest, and `_set_name` raises `RuntimeError` naming the sid. `_rename_claimed` and `_rename_session` are unchanged: a dead-tab rename says "the rename did not take" with the cause on both doors, and a live tmux rename says the session was renamed but its name on file could not be updated and keeps its old name until that write lands (true there: the hook's rewrite lands). The "is that session known" question stays reserved for an absent record.
- `POST /color` names which cause it hit (`_names_refusal`): the existing "no names record" text for an absent record, and "reads with no name (being rewritten, or damaged); nothing written" otherwise. The WS `setSessionColor` arm sends nothing on False, as before; the error-center row is what the dashboard shows.
- bin/romp `_romp_record` writes the line to `.$sid.tmp.$$` in the names directory and moves it into place with `mv -f`. A failed write or move removes the temp; that arm is cleanup for a full or read-only filesystem, and no test drives it. `_romp_rename_record` and `_romp_free_title` come through it unchanged. The dot prefix keeps the temp out of `_romp_free_title`'s glob and the picker's listing. The kernel's `NAMES.iterdir()` scanners apply no dot filter: they see the temp for the microseconds it exists, and a copy left by a kill between the write and the move reads to them as a phantom entry, the same class as the kernel's own `_atomic_write` temps and the module writers' `<sid>.tmp`.

## Tests
Every test executes the real code path and fails before the change:
- `tests/test_kernel_session_color.py` `NoNameRecordIsLeftAlone` (3 tests, 10 subtests; it extends the module's `SessionColor` fixture, so the class also re-runs that fixture's 11 tests, as `HighSlotSwitches` does). The recolor and the rename over four no-name shapes leave the file byte-identical, re-read exactly once, and report the sid to stderr and the error center (before: the recolor answered True and the file read `\t\t#54B204\tblack\n`; the rename answered True and it read `api\t\t\t\n`). The palette switch skips the no-name record and recolors the rest (before: recolored it, still nameless, unreported). The re-read catches a writer mid-write and the edit lands on the whole record (before: `api\t\t\t\n`); a name-only record `web\n` is still padded and published, so the guard keys on the name field, not on the field count. The kernel's pause is recorded through a stand-in for the module's `time` name, so a sleep by other code in the process is not counted.
- `tests/test_kernel_names.py` `RenameFaultsThroughTheDoors` (3 tests). A dead-tab rename over a 0-byte record answers `warn` with "the rename did not take" and the record's path on the WS door, and `ok: false` on `POST /rename` (before: `renamed`, file `web2\t\t\t\n`). A live rename answers "was renamed, but its name on file could not be updated ... until that write lands", with tmux renamed once and the file untouched (before: `renamed`).
- `tests/test_color_route.py` (2 tests). A 0-byte record gets the no-name refusal and is left alone (before: `ok: true`, file rewritten). An absent record still gets "no names record" (a control: passes before and after).
- `tests/romp.bats` "names map: the record writer publishes atomically, so a reader racing the rename hook never sees an empty record". The record is seeded under a stale name, and `romp _renamed` rewrites it forty times through a mock tmux while a reader polls it and walks the directory with the `*` glob `_romp_free_title` uses. The reader must never find the record empty, and the glob must never show anything but the record. Every hook run must reach the writer (forty `send-keys` in the mock's log), the record must end as the renamed line with the dir and colors intact, and no temp may be left. On the old writer it fails at the empty count in three of three runs; the truncate window is a printf's worth of time, so that leg is probabilistic by nature, and the kernel tests are the deterministic half. It also fails on a writer that copies through the temp instead of moving it (the empty count), on a temp without the dot prefix (the glob count, four of four runs), on a hook that never writes (the send-keys count) and on a writer pointed at another directory (the final content).

Full suite (`pytest -q -n 8 tests/` on the committed tree): 10221 passed, 62 skipped, 1681 subtests passed, 0 failed. Targeted: the three pytest modules 108 passed (10 subtests); `bats tests/romp.bats` 119 of 119.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)