### PR TITLE
Auto-reload: the notice raised as the last pending ship retires is shown again by the page that follows the reload

### DIFF
--- a/tests/test_ship_reship.py
+++ b/tests/test_ship_reship.py
@@ -16,7 +16,7 @@ The fix, both faces:
     the page, so the ship NAMES persist beside the drafts and the next load says LOUDLY what
     was lost — never a silent vanish.
 
-Two guards here:
+The guards here:
   * SourcePins — runs everywhere, CI included: the wiring above, pinned in the sources (the
     webview-side twins live in ui/webview/pending-attach.test.ts).
   * ServedWedge — the executed guard: boots the hermetic kernel, opens the real /chat page,
@@ -25,6 +25,10 @@ Two guards here:
     reconnect re-ships, the thumbnail lands, and the held send fires. Plus the regression leg:
     a normal ship+send against the restarted kernel behaves exactly as before. Skips LOUDLY
     when the extension deps or a playwright browser are absent (CI installs no browsers).
+  * NackNoticeSurvivesReload: the same wedge with the relaunched kernel unable to save the
+    re-shipped file. Its nack retires the last pending ship, which lets the restart's held
+    reload fire on the next task, and the notice the nack raised (the file was not saved, the
+    held message not sent) must be shown again by the fresh page, once.
 
 All fixtures synthetic.
 """
@@ -96,6 +100,21 @@ class SourcePins(unittest.TestCase):
     def test_a_reload_loss_is_loud_never_a_silent_vanish(self):
         self.assertIn("shipsInFlight: [...pendingShips.values()].flat().map((p) => p.name)", RENDER)
         self.assertIn("still uploading when this page reloaded, so it was NOT attached", RENDER)
+
+    def test_the_notices_on_screen_ride_the_cores_reload_and_are_shown_once(self):
+        # the nack is raised in the same task as the reload hold's ending event, just after endReloadHoldIfIdle (the
+        # dismissal of the last pending chip and the ack landing on another tab, just before it), one task before the
+        # owed reload fires, so the toast was never read and the loss toast above has nothing to say (shipsInFlight is
+        # already empty). The core's synchronous hook keeps the toasts on screen in this tab's sessionStorage and the
+        # fresh page shows them once, after the loss toast (reload-notices.ts); pagehide keeps the scroll record alone,
+        # so a load the user asks for replays nothing. NackNoticeSurvivesReload executes the nack's.
+        self.assertIn("(window as any).__rompPersistForReload = persistForReload;", RENDER)
+        self.assertIn("function persistForReload(): void { persistScrollForReload(); persistNoticesForReload(); }", RENDER)
+        self.assertIn('window.addEventListener("pagehide", persistScrollForReload);', RENDER)
+        self.assertIn('keepReloadNotices(sessionStorage, liveNotices(document.getElementById("warn-toasts")))', RENDER)
+        self.assertIn("for (const text of takeReloadNotices(sessionStorage)) warnToast(text);", RENDER)
+        self.assertLess(RENDER.index("shipsInFlight: [] });"), RENDER.index("takeReloadNotices(sessionStorage)"),
+                        "the loss toast first, then what the last page was saying")
 
 
 def _free_port():
@@ -443,6 +462,165 @@ class ReloadLossToast(_ShipLab):
                         "the lost upload must warn loudly on the next load — never a silent vanish: %r" % r)
         self.assertFalse(r["toastOnSecondLoad"],
                          "the loss record must clear with the toast — one warning, not one per load: %r" % r)
+
+
+DRIVER_NACK = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import { spawn } from "node:child_process";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 900 } });
+const out = {};
+const die = async (why) => {
+  fs.writeSync(1, "RESULT:" + JSON.stringify({ ...out, died: why }) + "\n");
+  await browser.close();
+  process.exit(0);
+};
+// a wait that hands back the page's answer, asked of whichever page is up: an evaluate mid-navigation throws and is
+// asked again of the page that follows (waitForFunction can reject when the navigation destroys the context it polls)
+const until = async (fn, arg, ms) => {
+  const t0 = Date.now();
+  for (;;) {
+    let v = false;
+    try { v = await page.evaluate(fn, arg); } catch (e) { /* mid-navigation */ }
+    if (v) return v;
+    if (Date.now() - t0 > ms) return false;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+};
+await page.goto(cfg.url);
+await page.waitForSelector("#composer-input", { timeout: 20000 });
+const tab = await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 }).catch(() => null);
+if (!tab) await die("no session tab: the lab seed never reached the chat payload");
+await page.waitForTimeout(500);   // let the shim's ws settle onto the live kernel
+// ServedWedge's stage: a ship on a live socket the stopped kernel never answers, the send held on the gate
+process.kill(cfg.kernelPid, "SIGSTOP");
+await page.setInputFiles("body > input[type=file]", cfg.file);
+await page.waitForSelector(".composer-file-pending", { timeout: 10000 }).catch(() => {});
+out.chipUpAfterShip = await page.locator(".composer-file-pending").count();
+await page.fill("#composer-input", cfg.msg);
+await page.click("#composer-send");
+await page.waitForSelector(".confirm-btn", { timeout: 10000 }).catch(() => {});
+const waitBtn = page.locator(".confirm-btn", { hasText: "Wait for the upload" });
+out.gateOffered = await waitBtn.count();
+if (out.gateOffered) await waitBtn.click();
+// two things on the OLD page before the kernel goes. A toast wearing the ephemeral mark, on screen as the core takes the
+// page: a stand-in with warnToast's shape (render.ts marks its own "Can't send yet" refusal the same way; this lab has
+// no unreachable host to raise it), which the fresh page must not repeat. And the latch: this document records the nack
+// toast the moment it appears, in sessionStorage, which survives the reload (the reload follows the nack by one task,
+// so nothing read from outside after the fact could see the old page's toasts).
+const bootBefore = await page.evaluate((probe) => {
+  window.__probe = 1;
+  let wt = document.getElementById("warn-toasts");
+  if (!wt) { wt = document.createElement("div"); wt.id = "warn-toasts"; document.body.appendChild(wt); }
+  const eph = document.createElement("div"); eph.className = "warn-toast"; eph.dataset.ephemeral = "1";
+  const msg = document.createElement("span"); msg.className = "warn-toast-msg"; msg.textContent = probe;
+  eph.appendChild(msg); wt.appendChild(eph);
+  sessionStorage.removeItem("probe:nackSeen");
+  const look = () => {
+    if (sessionStorage.getItem("probe:nackSeen")) return;
+    const toasts = document.getElementById("warn-toasts")?.textContent || "";
+    if (toasts.includes("couldn't be saved"))
+      sessionStorage.setItem("probe:nackSeen", JSON.stringify({ text: toasts,
+        ephemeralOnScreen: !!document.querySelector("#warn-toasts .warn-toast[data-ephemeral]"),
+        waiting: window.__rompReload ? window.__rompReload.waiting : null }));
+  };
+  new MutationObserver(look).observe(document.body, { childList: true, subtree: true, attributes: true, characterData: true });
+  setInterval(look, 20);
+  return window.__rompReload ? window.__rompReload.boot : null;
+}, cfg.probe);
+out.bootBefore = bootBefore;
+// the drops path becomes a regular file: the relaunched kernel's _save_dropped_file fails and it NACKs the re-ship
+fs.rmSync(cfg.drops, { recursive: true, force: true });
+fs.writeFileSync(cfg.drops, "not a directory");
+process.kill(cfg.kernelPid, "SIGKILL");
+const k2 = spawn(cfg.relaunch.cmd, [], { env: cfg.relaunch.env, detached: true,
+  stdio: ["ignore", fs.openSync(cfg.relaunch.log, "a"), fs.openSync(cfg.relaunch.log, "a")] });
+k2.unref();
+fs.writeSync(1, "KPID:" + k2.pid + "\n");
+// the OLD page saw the nack (the re-shipped file could not be saved); then the reload core's turn
+out.nackSeen = await until(() => JSON.parse(sessionStorage.getItem("probe:nackSeen") || "null"), null, 45000) || null;
+out.reloaded = await until((boot) => window.__probe !== 1 && !!window.__rompReload && window.__rompReload.boot !== boot, bootBefore, 30000);
+await page.waitForSelector("#composer-input", { timeout: 20000 }).catch(() => {});
+out.bootAfter = await page.evaluate(() => window.__rompReload ? window.__rompReload.boot : null).catch(() => null);
+// the FRESH page: the notice again (the replay runs as the bundle loads; the toast lives 12 s, so read it at once),
+// and every toast on it by itself, for the count
+out.freshToasts = await until(() => {
+  const t = document.getElementById("warn-toasts")?.textContent || "";
+  return t.includes("couldn't be saved") ? t : false;
+}, null, 5000) || (await page.evaluate(() => document.getElementById("warn-toasts")?.textContent || "").catch(() => null));
+out.freshList = await page.evaluate(() => Array.from(document.querySelectorAll("#warn-toasts .warn-toast-msg"), (n) => n.textContent || "")).catch(() => null);
+out.freshPending = await page.locator(".composer-file-pending").count();
+out.freshFiles = await page.locator(".composer-file").count();
+// one replay: the record leaves sessionStorage as the toasts are raised
+out.recordAfterReplay = await page.evaluate(() => sessionStorage.getItem("romp:reloadNotices")).catch(() => "unread");
+// a load the USER asks for, with the replayed toast still on screen: pagehide keeps the scroll record alone, so the
+// page that follows says nothing
+out.toastsBeforeNav = await page.locator("#warn-toasts .warn-toast").count();
+await page.goto(cfg.url);
+await page.waitForSelector("#composer-input", { timeout: 20000 });
+await page.waitForTimeout(800);
+out.secondLoadToasts = await page.evaluate(() => document.getElementById("warn-toasts")?.textContent || "");
+// the draft comes back one time after a load, once the tab has landed (restoreActiveDraftOnce): a wait, not a read
+out.inputAfterNav = await until(() => document.getElementById("composer-input")?.value || false, null, 15000);
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class NackNoticeSurvivesReload(_ShipLab):
+    """The reload core's restart reload follows the LAST pending ship's retirement: retirePendingShip ends the hold
+    (endReloadHoldIfIdle, __rompReload.ended()) and the core fires on the next task. The nack that retired the ship
+    raises its toast in the same handler, after the hold ended, so the notice (the file was not saved, the held
+    message NOT sent) was appended one task before the page went: never read, and the fresh page's loss toast had
+    nothing to say (shipsInFlight was already empty). A failed attachment and an unsent message went unannounced.
+    Now the core's synchronous hook keeps the toasts on screen in this tab's sessionStorage and the fresh page shows
+    them again once. The drops path is made a regular file before the relaunch so the re-ship's save fails and the
+    kernel nacks it (_save_dropped_file); the old page latches its toast in sessionStorage, which survives the
+    reload. A toast wearing the ephemeral mark is on screen too (a stand-in with warnToast's shape, since the lab has
+    no unreachable host for render.ts to raise its own), and the fresh page must not repeat it."""
+
+    def test_the_nack_of_the_last_ship_is_shown_again_by_the_fresh_page_once(self):
+        r = self._run_driver(DRIVER_NACK, {
+            "url": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
+            "kernelPid": self.kernel.pid,
+            "relaunch": {"cmd": os.path.join(BIN, "romp-kernel"),
+                         "env": {k: v for k, v in self.env.items()}, "log": self.klog},
+            "file": self.png, "msg": "hold this message for the upload that will not save",
+            "drops": os.path.join(self.state, "drops"),
+            "probe": "probe: an ephemeral notice, which the fresh page must not repeat"})
+        self.assertEqual(r["chipUpAfterShip"], 1, "the pending chip must be up after the ship: %r" % r)
+        self.assertEqual(r["gateOffered"], 1, "the ship gate must offer to wait for the upload: %r" % r)
+        # the old page: the re-ship was nacked, the toast named the file and the unsent message
+        self.assertTrue(r["nackSeen"], "the relaunched kernel must NACK the re-ship (drops is a file): %r (kernel log tail: %s)"
+                        % (r, Path(self.klog).read_text()[-500:]))
+        self.assertIn("shot.png couldn't be saved", r["nackSeen"]["text"])
+        self.assertIn("Your message was NOT sent", r["nackSeen"]["text"], "the held send did not fire without its file")
+        self.assertTrue(r["nackSeen"].get("ephemeralOnScreen"), "the toast wearing the ephemeral mark was on screen as the core took the page: %r" % r)
+        # then the reload the core owed (held while the ship awaited its answer)
+        self.assertTrue(r["reloaded"], "the reload core reloads once the ships settled: %r" % r)
+        self.assertNotEqual(r["bootAfter"], r["bootBefore"], "the fresh page carries the relaunched kernel's boot id: %r" % r)
+        # the heart of it: the fresh page says it again, once, and only that
+        self.assertIn("shot.png couldn't be saved", r["freshToasts"] or "",
+                      "the nack the reload wiped must be shown again by the fresh page: %r" % r)
+        self.assertIn("Your message was NOT sent", r["freshToasts"] or "", "with the unsent message named: %r" % r)
+        self.assertEqual(len([t for t in (r["freshList"] or []) if "couldn't be saved" in t]), 1,
+                         "shown again once, not once per raise: %r" % r)
+        self.assertNotIn("still uploading", r["freshToasts"] or "", "no loss toast over a ship that settled: %r" % r)
+        self.assertNotIn("probe:", r["freshToasts"] or "", "the toast wearing the ephemeral mark stays behind: %r" % r)
+        self.assertEqual([r["freshPending"], r["freshFiles"]], [0, 0], "no chip and no attachment over a file that was not saved: %r" % r)
+        # once: the record leaves sessionStorage with the replay, and a load the user asks for replays nothing
+        self.assertIsNone(r["recordAfterReplay"], "the replay takes the record out of sessionStorage: %r" % r)
+        self.assertGreaterEqual(r["toastsBeforeNav"], 1, "the replayed toast was on screen when the user navigated: %r" % r)
+        self.assertNotIn("couldn't be saved", r["secondLoadToasts"], "pagehide keeps the scroll record alone: nothing replayed: %r" % r)
+        # and the draft is still there to act on
+        self.assertEqual(r["inputAfterNav"], "hold this message for the upload that will not save", "the draft survives as before: %r" % r)
 
 
 if __name__ == "__main__":

--- a/ui/webview/reload-notices.test.ts
+++ b/ui/webview/reload-notices.test.ts
@@ -1,0 +1,132 @@
+// The notices a page is showing when the reload core takes it (reload-notices.ts). The core's restart reload follows
+// the last pending ship's retirement on the next task (render.ts endReloadHoldIfIdle, __rompReload.ended()), and the
+// nack, the dismissal or the other-tab ack raised in that same task is appended one task before the page goes: the
+// toast was never read, and the fresh page's loss toast reads shipsInFlight, which the retirement already emptied. So
+// render.ts keeps the
+// texts of the toasts on screen in this tab's sessionStorage on the core's synchronous hook and the fresh page shows
+// them once. The readings are pure and execute here; render.ts has import-time DOM side effects, so its wiring is
+// pinned to source the way reload-restore.test.ts pins the scroll record's. The served scenario (a nack on the last
+// ship across a kernel restart; the fresh page says it again, once) is tests/test_ship_reship.py
+// NackNoticeSurvivesReload. Synthetic only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { RELOAD_NOTICES_KEY, liveNotices, keepReloadNotices, takeReloadNotices } from "./reload-notices";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+const SEL = ".warn-toast:not([data-ephemeral]) .warn-toast-msg";
+const box = (texts: (string | null)[]) => ({
+  querySelectorAll: (sel: string) => { assert.equal(sel, SEL); return texts.map((t) => ({ textContent: t })); },
+});
+
+/** A sessionStorage stand-in: the three calls the module makes over a Map, with a log of them. */
+function fakeStore(init: Record<string, string> = {}) {
+  const m = new Map(Object.entries(init));
+  const calls: string[] = [];
+  return {
+    m, calls,
+    getItem: (k: string) => { calls.push("get " + k); return m.has(k) ? m.get(k)! : null; },
+    setItem: (k: string, v: string) => { calls.push("set " + k); m.set(k, v); },
+    removeItem: (k: string) => { calls.push("remove " + k); m.delete(k); },
+  };
+}
+
+test("the toasts on screen read as their texts, in order, blanks dropped; none without the container", () => {
+  assert.deepEqual(liveNotices(null), [], "the container is created by the first toast; none yet");
+  assert.deepEqual(liveNotices(undefined), []);
+  assert.deepEqual(liveNotices(box([])), []);
+  assert.deepEqual(liveNotices(box(["shot.png couldn't be saved on the kernel, so it was not attached. Your message was NOT sent.",
+                                    "  ", null, "The pending upload was dismissed. Your held message was NOT sent."])),
+    ["shot.png couldn't be saved on the kernel, so it was not attached. Your message was NOT sent.",
+     "The pending upload was dismissed. Your held message was NOT sent."]);
+  assert.deepEqual(liveNotices(box(["  padded  "])), ["padded"], "the text as the toast shows it");
+});
+
+test("the reading asks for the toasts without the ephemeral mark: a refusal about a state the fresh page shows for itself stays behind", () => {
+  // the staged sends' "Can't send yet" reports a state (the host unreachable, the tab still being created), which the
+  // fresh page shows for itself; render.ts marks that toast where it is raised and the selector skips the mark. The
+  // mark's effect on a real DOM is executed by tests/test_ship_reship.py NackNoticeSurvivesReload.
+  const asked: string[] = [];
+  assert.deepEqual(liveNotices({ querySelectorAll: (sel: string) => { asked.push(sel); return [{ textContent: "kept" }]; } }), ["kept"]);
+  assert.deepEqual(asked, [SEL]);
+});
+
+test("the record is kept only when there is something to say; a page with no toast clears a record left behind", () => {
+  const s = fakeStore();
+  keepReloadNotices(s, ["one", "two"]);
+  assert.deepEqual([...s.m.entries()], [[RELOAD_NOTICES_KEY, JSON.stringify(["one", "two"])]]);
+  assert.equal(RELOAD_NOTICES_KEY, "romp:reloadNotices", "this tab's sessionStorage, beside the scroll record's key");
+  // a reload the browser refused leaves the record in place; the next core reload with nothing on screen clears it
+  keepReloadNotices(s, []);
+  assert.equal(s.m.has(RELOAD_NOTICES_KEY), false, "cleared, not written empty");
+  assert.deepEqual(s.calls, ["set " + RELOAD_NOTICES_KEY, "remove " + RELOAD_NOTICES_KEY]);
+  keepReloadNotices(null, ["x"]);
+  keepReloadNotices(undefined, []);
+});
+
+test("the record comes out once: strings only, and the key is gone whatever it held", () => {
+  const s = fakeStore({ [RELOAD_NOTICES_KEY]: JSON.stringify(["one", "", 3, null, "two"]), other: "kept" });
+  assert.deepEqual(takeReloadNotices(s), ["one", "two"]);
+  assert.deepEqual([...s.m.keys()], ["other"], "the key is removed; nothing else is touched");
+  assert.deepEqual(takeReloadNotices(s), [], "a second take finds nothing");
+  assert.deepEqual(s.calls, ["get " + RELOAD_NOTICES_KEY, "remove " + RELOAD_NOTICES_KEY, "get " + RELOAD_NOTICES_KEY],
+    "no record, no removal");
+  for (const junk of ["not json", JSON.stringify("a string"), JSON.stringify({ a: 1 }), JSON.stringify(null), ""]) {
+    const j = fakeStore({ [RELOAD_NOTICES_KEY]: junk });
+    assert.deepEqual(takeReloadNotices(j), [], JSON.stringify(junk) + " reads as none");
+    assert.equal(j.m.has(RELOAD_NOTICES_KEY), false, JSON.stringify(junk) + " is still cleared");
+  }
+  assert.deepEqual(takeReloadNotices(null), []);
+  assert.deepEqual(takeReloadNotices(undefined), []);
+});
+
+test("kept on the page that reloads, taken on the page that follows: the same texts, then nothing", () => {
+  const s = fakeStore();
+  const texts = liveNotices(box(["shot.png couldn't be saved on the kernel, so it was not attached. Your message was NOT sent."]));
+  keepReloadNotices(s, texts);
+  assert.deepEqual(takeReloadNotices(s), texts);
+  assert.deepEqual(takeReloadNotices(s), []);
+});
+
+test("a store that refuses is left alone: nothing thrown from either side", () => {
+  const broken = {
+    getItem: () => { throw new Error("SecurityError"); },
+    setItem: () => { throw new Error("QuotaExceededError"); },
+    removeItem: () => { throw new Error("SecurityError"); },
+  };
+  assert.doesNotThrow(() => keepReloadNotices(broken, ["x"]));
+  assert.doesNotThrow(() => keepReloadNotices(broken, []));
+  assert.deepEqual(takeReloadNotices(broken), []);
+});
+
+// The wiring, pinned to source (render.ts executes nothing under node --test).
+test("render.ts: warnToast hands back its toast, and the send refusal about reachability is marked ephemeral where it is raised", () => {
+  assert.match(RENDER, /^function warnToast\(msg: string\): HTMLElement \{/m);
+  assert.match(RENDER, /setTimeout\(\(\) => t\.remove\(\), 12000\);\n\s*return t;/);
+  assert.match(RENDER, /^function ephemeralWarnToast\(msg: string\): void \{ warnToast\(msg\)\.dataset\.ephemeral = "1"; \}/m);
+  assert.equal((RENDER.match(/dataset\.ephemeral/g) || []).length, 1, "marked in one place");
+  assert.equal((RENDER.match(/ephemeralWarnToast\("Can't send yet — the session isn't reachable\. They stay staged\."\);/g) || []).length, 2,
+    "the staged sends' refusal at both of its sites (the strip's Send now and the empty send)");
+  assert.equal((RENDER.match(/ephemeralWarnToast\(/g) || []).length, 3, "the definition and the two sites");
+  // what the nack, the dismissal and the other-tab ack say stays true after the reload, so they ride it unmarked
+  assert.match(RENDER, /warnToast\(m\.name \+ " couldn't be saved on the kernel, so it was not attached/);
+  assert.match(RENDER, /warnToast\("The pending upload was dismissed — your held message was NOT sent\."\)/);
+  assert.match(RENDER, /warnToast\("attachments finished uploading on another tab — the held message was not sent; review it there\."\)/);
+});
+
+test("render.ts keeps the notices on the core's hook alone, pagehide keeps the scroll record alone, and the fresh page shows them once after the loss toast", () => {
+  assert.match(RENDER, /^import \{ liveNotices, keepReloadNotices, takeReloadNotices \} from "\.\/reload-notices";/m);
+  assert.match(RENDER, /^function persistNoticesForReload\(\): void \{\n\s*try \{ keepReloadNotices\(sessionStorage, liveNotices\(document\.getElementById\("warn-toasts"\)\)\); \} catch \{ \/\* ignore \*\/ \}\n\}/m);
+  // the core's synchronous hook writes both records; a navigation of the user's own (pagehide) writes the scroll record
+  // alone, so a load they asked for does not replay a toast they were already looking at
+  assert.match(RENDER, /^function persistForReload\(\): void \{ persistScrollForReload\(\); persistNoticesForReload\(\); \}[^\n]*\n\(window as any\)\.__rompPersistForReload = persistForReload;\nwindow\.addEventListener\("pagehide", persistScrollForReload\);/m);
+  assert.equal((RENDER.match(/persistNoticesForReload\(\)/g) || []).length, 2, "defined once, called from the core's hook alone");
+  const scroll = RENDER.match(/^function persistScrollForReload\(\): void \{([\s\S]*?)\n\}/m);
+  assert.ok(scroll && !scroll[1].includes("Notices"), "the scroll record is untouched");
+  // the replay follows the loss toast's block directly: the loss first, then what the last page was saying
+  assert.match(RENDER, /shipsInFlight: \[\] \}\);\n\s*\}\n\s*\}\n\} catch \{ \/\* ignore \*\/ \}\n(\/\/[^\n]*\n)*try \{ for \(const text of takeReloadNotices\(sessionStorage\)\) warnToast\(text\); \} catch \{ \/\* ignore \*\/ \}/);
+  assert.equal((RENDER.match(/takeReloadNotices\(/g) || []).length, 1, "consumed once, at load");
+  assert.equal((RENDER.match(/keepReloadNotices\(/g) || []).length, 1, "written from one place");
+});

--- a/ui/webview/reload-notices.ts
+++ b/ui/webview/reload-notices.ts
@@ -1,0 +1,72 @@
+// The warning toasts a page is showing when the reload core takes it (kernel.py _RELOAD_CORE_JS, window.__rompReload
+// on every kernel-served page). A warnToast is a DOM element that lives 12 s. The core's restart reload waits for the
+// chat pane's pending ships (T272: __rompPaneBusy answers 'upload' or 'held-send') and fires on the next task after the
+// pane says the hold is over (render.ts endReloadHoldIfIdle, __rompReload.ended()). The last pending ship's retirement
+// is that ending event, and three notices are raised in the same task as it, one task before the owed reload fires:
+// the kernel's nack of the ship (the file was not saved, so it was not attached; a message held on it was NOT sent),
+// raised just after endReloadHoldIfIdle; the dismissal of the last pending chip (the held message was NOT sent) and
+// the ack of the last ship landing on another tab (the held message was not sent), each raised just before it. Nobody
+// read them, and the fresh page's loss toast reads shipsInFlight, which the retirement had already emptied. A failed
+// attachment and an unsent message went unannounced.
+//
+// So render.ts keeps the texts of the toasts on screen in THIS tab's sessionStorage (like the scroll record: the
+// persisted webview state is localStorage on the served page, shared by every dashboard tab of the origin, and one
+// tab's nack must not replay in another) on the core's synchronous pre-reload hook alone (persistNoticesForReload,
+// from persistForReload, the function window.__rompPersistForReload names) and the fresh page shows them once, after
+// the loss toast. pagehide keeps the scroll record alone: a navigation of the user's own replays nothing, the way the
+// loss toast fires once and not on every load. A refusal that reports a state rather than an event is left out (the
+// staged sends' "Can't send yet": the session's host is unreachable, or its tab is still being created): the fresh
+// page shows that state for itself, so a replay would be redundant at best and stale at worst, and render.ts
+// ephemeralWarnToast marks it data-ephemeral for the reading to skip. The record is text only, on purpose: a toast
+// has no action beyond its dismissal today, and a future toast with one would replay as its words alone. Pure and
+// DOM-free so node --test executes both readings (reload-notices.test.ts); the served scenario is
+// tests/test_ship_reship.py NackNoticeSurvivesReload.
+
+/** This tab's sessionStorage key for the record (beside the scroll record's romp:reloadScroll). */
+export const RELOAD_NOTICES_KEY = "romp:reloadNotices";
+
+/** The toast container as the reading needs it: anything with querySelectorAll (a DOM element in the page). */
+export interface NoticeBox { querySelectorAll(selectors: string): ArrayLike<{ textContent: string | null }>; }
+
+/** The store as the record needs it: sessionStorage, or a stand-in in tests. */
+export interface NoticeStore {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/** The texts of the warning toasts on screen (#warn-toasts .warn-toast-msg, in DOM order), blanks dropped and the
+ *  toasts marked data-ephemeral skipped (a refusal about a state the fresh page shows for itself; see the note above);
+ *  none when the container was never created. */
+export function liveNotices(box: NoticeBox | null | undefined): string[] {
+  if (!box) return [];
+  return Array.from(box.querySelectorAll(".warn-toast:not([data-ephemeral]) .warn-toast-msg"),
+                    (n) => (n.textContent || "").trim()).filter((t) => !!t);
+}
+
+/** Keep `notices` for the page that follows. Nothing to say clears any record left behind (a reload the browser
+ *  refused leaves its record in place; the next core reload with nothing on screen clears it rather than replaying it)
+ *  rather than writing an empty one. A store that refuses (no storage in this context, quota) is left alone. */
+export function keepReloadNotices(store: NoticeStore | null | undefined, notices: string[]): void {
+  if (!store) return;
+  try {
+    if (notices.length) store.setItem(RELOAD_NOTICES_KEY, JSON.stringify(notices));
+    else store.removeItem(RELOAD_NOTICES_KEY);
+  } catch { /* ignore */ }
+}
+
+/** Take the kept notices out of the store, once: the non-empty strings of the record (anything else reads as none),
+ *  with the key removed whenever it is present, so a later load says nothing. */
+export function takeReloadNotices(store: NoticeStore | null | undefined): string[] {
+  if (!store) return [];
+  let raw: string | null = null;
+  try {
+    raw = store.getItem(RELOAD_NOTICES_KEY);
+    if (raw != null) store.removeItem(RELOAD_NOTICES_KEY);
+  } catch { return []; }
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === "string" && !!x) : [];
+  } catch { return []; }
+}

--- a/ui/webview/reload-restore.test.ts
+++ b/ui/webview/reload-restore.test.ts
@@ -38,7 +38,10 @@ test("where the restored land goes: bottom for follow mode, the anchor when hono
 
 test("render.ts persists SYNCHRONOUSLY for the reload core and on pagehide, into THIS tab's sessionStorage", () => {
   assert.match(RENDER, /import \{ reloadScrollRecord, takeReloadScroll, type ReloadScroll \} from "\.\/reload-restore";/);
-  assert.match(RENDER, /\(window as any\)\.__rompPersistForReload = persistScrollForReload;/);
+  // the core's hook writes the scroll record and then the notices on screen (reload-notices.test.ts pins that half);
+  // pagehide writes the scroll record alone
+  assert.match(RENDER, /^function persistForReload\(\): void \{ persistScrollForReload\(\); persistNoticesForReload\(\); \}/m);
+  assert.match(RENDER, /\(window as any\)\.__rompPersistForReload = persistForReload;/);
   assert.match(RENDER, /window\.addEventListener\("pagehide", persistScrollForReload\);/);
   const m = RENDER.match(/^function persistScrollForReload\(\): void \{([\s\S]*?)\n\}/m);
   assert.ok(m, "persistScrollForReload");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -42,6 +42,7 @@ import { StagedStack } from "./staged-messages";
 import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, newPending, reconcilePending, queuedCopyToHide, dropPending, bareGroupLabel, sentAtLabel } from "./send-pending";
 import { reconcileHeld, heldAsQueued, type HeldCopy, type HeldQueued, type HeldMemory } from "./queued-held";
 import { reloadHoldReason } from "./reload-hold";
+import { liveNotices, keepReloadNotices, takeReloadNotices } from "./reload-notices";
 import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional, focusResolvesProvisional } from "./provisional";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
@@ -10032,7 +10033,7 @@ function landToast(msg: string) {
 // acknowledgement). The Escape listener never stops propagation: clearing a toast is
 // additive noise-removal, not a key the rest of the UI loses — and overlay consumers
 // that capture Escape (the lightbox, the viewer) still peel first by construction.
-function warnToast(msg: string) {
+function warnToast(msg: string): HTMLElement {
   let box = document.getElementById("warn-toasts");
   if (!box) {
     box = el("div", "");
@@ -10057,7 +10058,17 @@ function warnToast(msg: string) {
   box.appendChild(t);
   setTimeout(() => t.classList.add("fade"), 11000);
   setTimeout(() => t.remove(), 12000);
+  return t;   // the toast, for a caller that marks it (ephemeralWarnToast)
 }
+// A toast the page that follows a reload must not repeat. The staged sends' refusal ("Can't send yet") reports a STATE:
+// the session's host is unreachable (hostIsDown, a remote host's tunnel) or its tab is still being created
+// (isProvisionalId). The fresh page shows that state for itself (the host mark and the staged strip; a provisional tab
+// does not survive a reload), so replayed by persistNoticesForReload it would be redundant at best and stale at worst.
+// The mark keeps it out of the replay (reload-notices.ts liveNotices reads only the toasts without it). Toasts that
+// report what HAPPENED to a send or a file stay unmarked, since what they say is as true after the reload as before:
+// the nack (the attachment was not saved, the held message not sent), the dismissal and the other-tab ack (the held
+// message not sent), the refusal on a disconnected host (this message was not sent and is still in the composer).
+function ephemeralWarnToast(msg: string): void { warnToast(msg).dataset.ephemeral = "1"; }
 
 // Tail-windowing (see the View comment): a fresh/rewound view renders only the
 // last WINDOW_TAIL events; scrolling within EXPAND_TRIGGER_PX of the top reveals
@@ -11057,7 +11068,21 @@ function persistScrollForReload(): void {
   const rec = reloadScrollRecord(activeId, content.scrollTop, stick, stick ? null : captureScrollAnchor(content, v));
   try { if (rec) sessionStorage.setItem(RELOAD_SCROLL_KEY, JSON.stringify(rec)); } catch { /* ignore */ }
 }
-(window as any).__rompPersistForReload = persistScrollForReload;
+// The warning toasts on screen when the CORE reloads the page. A toast is DOM only and lives 12 s, and the core's restart
+// reload follows the last pending ship's retirement on the next task (it held for the ship: __rompPaneBusy's 'upload' or
+// 'held-send', ended by endReloadHoldIfIdle), so the nack saying an attachment was not saved and the held message not
+// sent, or the dismissal of the last pending chip or the ack landing on another tab, each saying the message was not
+// sent, was appended one task before the page went and the fresh page's loss toast had nothing to say (shipsInFlight
+// was already empty). Their texts ride THIS tab's sessionStorage (reload-notices.ts; per tab for the scroll record's
+// reason) and the fresh page shows them again once,
+// after the loss toast. The core's synchronous hook alone writes them: a navigation of the user's own (pagehide) says
+// nothing twice, the way the loss toast fires once and not on every load (tests/test_ship_reship.py ReloadLossToast),
+// while the scroll record rides both as before.
+function persistNoticesForReload(): void {
+  try { keepReloadNotices(sessionStorage, liveNotices(document.getElementById("warn-toasts"))); } catch { /* ignore */ }
+}
+function persistForReload(): void { persistScrollForReload(); persistNoticesForReload(); }   // the core's hook: both records
+(window as any).__rompPersistForReload = persistForReload;
 window.addEventListener("pagehide", persistScrollForReload);
 
 function captureScrollAnchor(content: HTMLElement, v: View): { uuid: string; y: number } | null {
@@ -13546,6 +13571,10 @@ try {
     }
   }
 } catch { /* ignore */ }
+// The notices the last page was showing when the reload core took it (persistNoticesForReload): shown again once, after
+// the loss toast above, and the record taken out of sessionStorage in the same call so a later load says nothing (one
+// reload, one replay: the scroll record's idiom).
+try { for (const text of takeReloadNotices(sessionStorage)) warnToast(text); } catch { /* ignore */ }
 
 // Composer EDIT mode (per session): set when the user clicks a bubble's edit affordance — the composer
 // then sends a rewindSend (branch from just before that message) instead of a plain message. The chip
@@ -13613,7 +13642,7 @@ function renderStagedStrip(id: string | null): void {
   go.addEventListener("click", () => {
     if (!id) return;
     if (hostIsDown(id) || isProvisionalId(id)) {
-      warnToast("Can't send yet — the session isn't reachable. They stay staged.");
+      ephemeralWarnToast("Can't send yet — the session isn't reachable. They stay staged.");
       return;
     }
     flushStaged(id);
@@ -15434,7 +15463,7 @@ function setupComposer() {
     // an empty plain send with a staged stack = "go": release what's held, nothing new to add
     if (!typed && !(composerFiles.get(activeId) || []).length && stagedMsgs.count(activeId)) {
       if (hostIsDown(activeId) || isProvisionalId(activeId)) {
-        warnToast("Can't send yet — the session isn't reachable. They stay staged.");
+        ephemeralWarnToast("Can't send yet — the session isn't reachable. They stay staged.");
         return;
       }
       flushStaged(activeId);


### PR DESCRIPTION
## Symptom

A kernel restart during an upload can lose the notice that the upload failed. The dashboard reloads itself on a restart, and the chat pane holds that reload while a file is still shipping. When the relaunched kernel nacks the re-shipped file (it could not save it), the page shows the nack toast (the file couldn't be saved on the kernel, so it was not attached; your message was NOT sent) for a fraction of a second and then reloads. The fresh page shows no chip, no attachment and the draft back in the composer, and nothing says that the file was not saved or that the held message never went. The two other notices raised at the same moment go the same way: dismissing the last pending chip with a send held on it (the held message was NOT sent), and the last ship landing on another tab (the held message was not sent; review it there).

## Cause

The last pending ship's retirement is the event that ends the reload hold, and each of the three notices is raised in the same task as it. The dropSaveFailed handler in render.ts retires the ship, ends the hold (endReloadHoldIfIdle, which calls __rompReload.ended()) and raises the toast after that; the dismiss handler for the last pending chip and the other-tab ack raise theirs just before their own endReloadHoldIfIdle. ended() re-tries on a setTimeout(0), finds the pane idle and fires: persist(), then location.reload(). persist() runs window.__rompPersistForReload, which the page installs as persistScrollForReload: the scroll record alone. A warnToast is a DOM element that lives 12 s and dies with the page. The fresh page's loss toast reads shipsInFlight, which persistDrafts (called from retirePendingShip) had already emptied, so it has nothing to say.

## Fix

- New pure module ui/webview/reload-notices.ts. liveNotices(box) reads the texts of `#warn-toasts .warn-toast:not([data-ephemeral]) .warn-toast-msg` in DOM order, blanks dropped, none without the container. keepReloadNotices(store, texts) writes them under the sessionStorage key romp:reloadNotices, or removes the key when there is nothing to say (a reload the browser refused leaves its record behind; the next core reload with no toast on screen clears it rather than replaying it). takeReloadNotices(store) returns the non-empty strings and removes the key whenever it is present. A store that throws is left alone.
- render.ts: persistNoticesForReload() keeps the live toasts, and persistForReload() (the scroll record, then the notices) is installed as window.__rompPersistForReload. pagehide keeps persistScrollForReload alone, so a navigation of the user's own replays nothing; the loss toast fires once for the same reason. The load-time replay follows the lostShips block directly: the loss toast first, then what the last page was saying, with the record taken out in the same call.
- warnToast returns its element, and ephemeralWarnToast(msg) sets data-ephemeral on it. It replaces the one refusal that reports a state rather than an event, at both of its sites (the staged strip's Send now and the empty send that releases a staged stack): the refusal that says the session isn't reachable and the staged sends stay staged. Its predicate is hostIsDown (a remote host's tunnel) or isProvisionalId (a tab still being created), and the fresh page shows that state for itself (the host mark and the staged strip; a provisional tab does not survive a reload), so a replay would be redundant at best and stale at worst. Every toast that reports what happened to a send or a file stays unmarked, since what it says is as true after the reload as before: the nack, the dismissal and the other-tab ack (the three the reload wipes), the refusal at send time on a disconnected host (this message was not sent and is still in the composer), and the re-established-connection toast about a tag edit (a past event).
- Storage: the record rides sessionStorage like the scroll record, for the reason #1104 gave: the persisted webview state is localStorage on the served page, shared by every dashboard tab of the origin, so one tab's nack would replay in another. The record is text only: a toast has no action beyond its dismissal today, and a future toast with one would replay as its words alone (the module comment says so).
- No kernel change. No docs change: the docs carry no auto-reload prose to amend.

## Tests

- ui/webview/reload-notices.test.ts, 8 cases under node --test. Six execute the module: texts in order, blanks dropped, none without the container; the reading asks for the toasts without the ephemeral mark; a record is kept only when there is something to say, and a page with no toast clears one left behind; taken once, strings only, the key removed whatever it held, junk reads as none; kept then taken round trip; a refusing store throws nothing. Two pin the render.ts wiring the way reload-restore.test.ts pins the scroll record's: the hook, pagehide, the replay's place after the loss toast, the ephemeral mark at both of its sites, and the nack, the dismissal and the other-tab ack unmarked. Before the change the test bundle does not build: Could not resolve "./reload-notices".
- tests/test_ship_reship.py::NackNoticeSurvivesReload, served: a real Chromium against a real kernel through the module's existing _ShipLab. A file ships to a SIGSTOPped kernel and a send is held on the gate; a toast wearing the ephemeral mark is put on screen (a stand-in with warnToast's shape, since the lab has no unreachable host for the page to raise its own); the drops path is made a regular file and the kernel relaunched; the reconnect re-ships, the relaunched kernel nacks (_save_dropped_file fails), the held reload fires, and the fresh page's #warn-toasts is read at once. It asserts that the old page saw the nack with the marked toast on screen, the reload landed on the new boot id, the fresh page shows the nack exactly once and neither a loss toast nor the marked toast, the chip and the attachment are gone, the record left sessionStorage, a navigation of the user's own with the replayed toast still on screen replays nothing, and the draft is still in the composer. Before the change the old page shows the nack and the fresh page's toasts read as the empty string, where the assertion fails. With the hook set back to the scroll record alone, the selector without its ephemeral exclusion, or the replay raising each text twice, it fails at the corresponding assertion (each checked). It skips loudly without the extension deps or a browser, as ServedWedge and ReloadLossToast do. The dismissal and the other-tab ack are not executed: they ride the same reading and are pinned unmarked; the nack path is the one run.
- tests/test_ship_reship.py::SourcePins::test_the_notices_on_screen_ride_the_cores_reload_and_are_shown_once pins the hook, pagehide, the writer, the reader and the replay's place after the loss toast; red before the change.
- ui/webview/reload-restore.test.ts: the hook pin follows the code (persistForReload installed; pagehide still persistScrollForReload).
- At a62bdcb9: npm run typecheck clean; npm test 3755 pass, 0 fail; pytest tests/ -n 8: 10226 passed, 40 skipped, 0 failed. tests/test_ship_reship.py alone: 9 passed, three consecutive runs.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)