### PR TITLE
Markdown images that fail are parked, heal on the reconnect event off the DOM, and the page files its bundle build (T291c)

### DIFF
--- a/ui/webview/md-img-park.test.ts
+++ b/ui/webview/md-img-park.test.ts
@@ -1,0 +1,134 @@
+// A markdown-inline image whose fetch fails is PARKED, never re-set per message (T291c, the user 2026-09-09: three
+// captions in a remote session's transcript flipped on and off at the push rate; the 2026-08-24 heal re-set each failed
+// img's src on every kernel message, hiding the alt text while the reload ran and showing it again on the 404). The
+// heal is EXECUTED here over a minimal fake DOM: the capture-phase listener parks the img (no src, the alt text as a
+// stable caption); sixty pushes write the src zero times; the reconnect-class heal probes each parked URL once OFF the
+// DOM, a failed probe changes nothing, a successful one lands the picture on every parked img with that URL on the
+// page at that moment (a re-render during the probe included); a URL the kernel serves gets a bounded off-DOM probe on
+// the per-message path; and the chat's post-pass parks a re-rendered img with a remembered URL before the browser
+// fetches it. Every test builds its own state.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+class FakeEl {
+  tagName: string; attrs: Record<string, string> = {}; _cls = new Set<string>(); dataset: Record<string, string> = {};
+  isConnected = true; onerror: any = null; children: FakeEl[] = []; srcWrites = 0;
+  constructor(tag: string) { this.tagName = tag.toUpperCase(); }
+  get src(): string { return this.attrs.src || ""; }
+  set src(v: string) { this.srcWrites++; this.attrs.src = v; }   // a src write is a fetch, and hides the alt text until the response
+  get alt(): string { return this.attrs.alt || ""; }
+  set alt(v: string) { this.attrs.alt = v; }
+  hasAttribute(k: string) { return k in this.attrs; }
+  getAttribute(k: string) { return this.attrs[k] ?? null; }
+  setAttribute(k: string, v: string) { if (k === "src") this.srcWrites++; this.attrs[k] = v; }
+  removeAttribute(k: string) { if (k === "src") this.srcWrites++; delete this.attrs[k]; }
+  get classList() { const s = this._cls; return { add: (...c: string[]) => c.forEach((x) => s.add(x)), remove: (...c: string[]) => c.forEach((x) => s.delete(x)), contains: (c: string) => s.has(c) }; }
+  closest() { return null; }
+  querySelectorAll(sel: string): FakeEl[] { return sel === "img" ? this.children.filter((c) => c.tagName === "IMG") : []; }
+  shape(): string { return `${this.tagName}[${Object.entries(this.attrs).sort().map(([k, v]) => k + "=" + v).join(" ")}].${[...this._cls].sort().join(".")}{${JSON.stringify(this.dataset)}}`; }
+}
+const live: FakeEl[] = [];                            // what document.querySelectorAll sees
+let errorListener: ((e: any) => void) | null = null;
+(globalThis as any).document = {
+  addEventListener: (type: string, fn: any, capture?: boolean) => { if (type === "error") { assert.equal(capture, true, "capture phase"); errorListener = fn; } },
+  querySelectorAll: (sel: string) => (sel === "img.md-img-failed[data-md-src]" ? live.filter((e) => e.isConnected && e.tagName === "IMG" && e._cls.has("md-img-failed") && e.dataset.mdSrc) : []),
+  createElement: (t: string) => new FakeEl(t),
+};
+(globalThis as any).location = { protocol: "http:", origin: "http://127.0.0.1:1", href: "http://127.0.0.1:1/chat" };
+(globalThis as any).window = (globalThis as any).window || {};
+const probes: FakeEl[] = [];
+(globalThis as any).Image = class extends FakeEl { onload: any = null; constructor() { super("img"); probes.push(this); } };
+let fetchCalls = 0;
+(globalThis as any).fetch = () => { fetchCalls++; return Promise.reject(new Error("no fetch expected")); };
+
+const ORIGIN_URL = (n: string) => "http://127.0.0.1:1/home/user/notes-api/plots/" + n;   // a path the browser resolved against the page: no route serves it
+const SERVED_URL = "http://127.0.0.1:1/file?path=%2Fhome%2Fuser%2Fnotes-api%2Fplots%2Flatency.png&sid=11111111-2222-4333-8444-000000000001";
+function mdImg(url: string, alt: string): FakeEl { const img = new FakeEl("img"); img.src = url; img.alt = alt; img.srcWrites = 0; live.push(img); return img; }
+const fail = (img: FakeEl) => errorListener!({ target: img });
+async function fresh() { const P = await import("./preview"); P.installMdImgHeal(); assert.ok(errorListener); live.length = 0; probes.length = 0; return P; }
+
+test("a failed markdown image is parked: no src, the alt text stays, and sixty pushes write the src zero times", async () => {
+  const P = await fresh();
+  const a = mdImg(ORIGIN_URL("schematic.png"), "Schematic"), b = mdImg(ORIGIN_URL("queue.png"), "Queued bubble with pencil and cross, composer under the editing pill");
+  fail(a); fail(b);
+  assert.equal(a.hasAttribute("src"), false, "the src is gone: the browser fetches nothing and shows the alt text");
+  assert.equal(a.dataset.mdSrc, ORIGIN_URL("schematic.png"), "…the URL kept for the heal");
+  assert.ok(a._cls.has("md-img-failed"));
+  assert.equal(a.alt, "Schematic", "the caption is the alt text, untouched");
+  const sa = a.shape(), sb = b.shape();
+  a.srcWrites = 0; b.srcWrites = 0;
+  for (let i = 0; i < 60; i++) P.retryFailedPreviews();   // what render.ts runs on every kernel message
+  assert.equal(a.shape(), sa); assert.equal(b.shape(), sb);
+  assert.equal(a.srcWrites + b.srcWrites, 0, "no src write on a push: a write is a fetch and hides the alt text until the response");
+  assert.equal(probes.length, 0, "an origin-resolved path no route serves gets no probe either");
+  assert.equal(fetchCalls, 0);
+});
+
+test("the reconnect-class heal probes each parked URL once off the DOM; a failure changes nothing, a success lands the picture on every parked img on the page then", async () => {
+  const P = await fresh();
+  const a = mdImg(ORIGIN_URL("schematic.png"), "Schematic"), b = mdImg(ORIGIN_URL("queue.png"), "Queued bubble");
+  fail(a); fail(b);
+  const sa = a.shape();
+  P.refreshSettledPreviews();                        // romp:wsup / hostUp / romp:hostRelayUp all run this
+  assert.equal(probes.length, 2, "one detached probe per parked URL");
+  assert.deepEqual(probes.map((p) => p.src).sort(), [ORIGIN_URL("queue.png"), ORIGIN_URL("schematic.png")]);
+  probes.forEach((p) => p.onerror());
+  assert.equal(a.shape(), sa, "a failed probe leaves the parked caption exactly as it was");
+  probes.length = 0;
+  P.refreshSettledPreviews();
+  assert.equal(probes.length, 2, "the next reconnect probes again, once per URL");
+  // a re-render during the probe: the turn's fresh img is parked by the post-pass while the URL is still remembered
+  a.isConnected = false;
+  const root = new FakeEl("body"); const a2 = new FakeEl("img"); a2.src = ORIGIN_URL("schematic.png"); a2.alt = "Schematic"; root.children.push(a2);
+  P.mdImgPostPass(root as unknown as ParentNode);
+  assert.equal(a2.hasAttribute("src"), false, "the re-rendered img is parked before it fetches");
+  live.push(a2);
+  const pa = probes.find((p) => p.src === ORIGIN_URL("schematic.png"))!;
+  (pa as any).onload();
+  assert.equal(a2.src, ORIGIN_URL("schematic.png"), "the picture lands on the img that is on the page now, not on the snapshot's");
+  assert.equal(a2._cls.has("md-img-failed"), false);
+  assert.equal("mdSrc" in a2.dataset, false);
+  assert.equal(b.hasAttribute("src"), false, "the other URL, still down, stays parked");
+  // …and a URL that healed renders normally on the next re-render
+  const root2 = new FakeEl("body"); const fine = new FakeEl("img"); fine.src = ORIGIN_URL("schematic.png"); root2.children.push(fine);
+  P.mdImgPostPass(root2 as unknown as ParentNode);
+  assert.equal(fine.src, ORIGIN_URL("schematic.png"), "a healed URL is no longer parked at render");
+});
+
+test("a URL the kernel serves gets a BOUNDED off-DOM probe on the per-message path, then the reconnect heal alone", async () => {
+  const P = await fresh();
+  const s = mdImg(SERVED_URL, "Latency");
+  fail(s);
+  const parked = s.shape();
+  assert.equal(s.hasAttribute("src"), false, "parked like any other: the caption stands");
+  s.srcWrites = 0;
+  for (let round = 1; round <= 3; round++) {
+    P.retryFailedPreviews();
+    assert.equal(probes.length, round, "push " + round + ": one detached probe, the element untouched");
+    assert.equal(s.shape(), parked);
+    probes[probes.length - 1].onerror();
+  }
+  P.retryFailedPreviews(); P.retryFailedPreviews();
+  assert.equal(probes.length, 3, "the budget is spent: no more per-message probes");
+  assert.equal(s.srcWrites, 0, "the element's src was never written by an attempt");
+  P.refreshSettledPreviews();
+  assert.equal(probes.length, 4, "the reconnect-class heal still probes it");
+  (probes[3] as any).onload();
+  assert.equal(s.src, SERVED_URL, "…and the picture lands when the file is there");
+});
+
+test("render.ts installs the listener once, parks known-failed URLs on its OWN markdown output only, and files the page's bundle build once per load", () => {
+  assert.match(RENDER, /installMdImgHeal\(\);/);
+  assert.doesNotMatch(RENDER, /registerMdPostPass\(mdImgPostPass\)/, "never through the shared sanitizer: the file viewer rewrites its images' paths after the sanitize (the review's find)");
+  assert.equal((RENDER.match(/mdImgPostPass\(clean\);/g) || []).length, 2, "md() and userMd() park a known-failed image before the browser fetches it");
+  assert.match(RENDER, /linkifyPrRefs\(clean, repo\);\s*\n\s*mdImgPostPass\(clean\);[^\n]*\n\s*return clean\.innerHTML;/, "after the sanitize and the PR links, before the string leaves");
+  // the page-load row: the ?v= of the render.js script this page loaded, one row per load
+  assert.match(RENDER, /\.find\(\(u\) => \/\\\/dist\\\/render\\\.js\(\\\?\|\$\)\/\.test\(u\)\)/);
+  assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "clientDiag", surface: "chat", what: "pageload", data: \{ distVer: m \? Number\(m\[1\]\) : 0, path: location\.pathname \} \}\);/);
+  assert.match(CSS, /\.md-img-failed \{ display: inline; font-size: 0\.86em; font-style: italic; color: var\(--dim\); \}/, "the parked caption is styled like the load note");
+});

--- a/ui/webview/pr-links.test.ts
+++ b/ui/webview/pr-links.test.ts
@@ -815,7 +815,7 @@ test("the chat links inside md(): the sanitized tree is walked before it seriali
   assert.match(RENDER, /function md\(src: string, repo: string \| null = prRepoFor\(\)\): string \{/);
   const mdFn = RENDER.match(/function md\(src: string[^\n]*?\): string \{[\s\S]*?\n\}/)?.[0] || "";
   // sanitizeMd (md-sanitize.ts) hands back the sanitized <body>; the walk runs on it before our own serialization
-  assert.match(mdFn, /const clean = sanitizeMd\(dirty\);[^\n]*\n\s*linkifyPrRefs\(clean, repo\);\s*\n\s*return clean\.innerHTML;/,
+  assert.match(mdFn, /const clean = sanitizeMd\(dirty\);[^\n]*\n\s*linkifyPrRefs\(clean, repo\);\s*\n\s*mdImgPostPass\(clean\);[^\n]*\n\s*return clean\.innerHTML;/,
     "the sanitizer's own serialization is replaced by ours, after the walk: the sanitizer's verdicts stand");
   assert.match(RENDER, /const id = sid \?\? renderingOwnerSid \?\? renderingSid \?\? activeId;/, "the owning session, as relative paths resolve");
   assert.doesNotMatch(RENDER, /installPrLinkOpener/, "the chat's own a[href] delegate already opens every absolute-scheme anchor");

--- a/ui/webview/preview-core.test.ts
+++ b/ui/webview/preview-core.test.ts
@@ -47,7 +47,7 @@ test("chat: a mentioned image/PDF grows a FULL render at its mention, deduped an
   // (the user 2026-07-20: full renders replaced the 2026-07-08 thumbnails in the chat; the user
   // 2026-08-15: figures moved from a tail strip to the mentioning block —
   // chat-inline-preview.test.ts pins the placement shape)
-  assert.match(RENDER, /import \{ previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal, setLightboxNav, type LightboxNavEntry \} from "\.\/preview";/);
+  assert.match(RENDER, /import \{ previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal, mdImgPostPass, setLightboxNav, type LightboxNavEntry \} from "\.\/preview";/);
   assert.match(RENDER, /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) \{/, "collected while linkifying — same detection, no second regex pass; an in-bubble image never re-renders");
   assert.match(RENDER, /if \(previewable\.length\) \{/, "both surfaces now — VS Code images ride the host data-URL flow");
   assert.match(RENDER, /for \(const p of previewable\) renderFig\(p\);/,

--- a/ui/webview/preview-heal.test.ts
+++ b/ui/webview/preview-heal.test.ts
@@ -68,13 +68,17 @@ test("a settled chip re-registers for RECONNECT-class heals regardless of error 
   assert.match(PREVIEW, /settledPreviews\.delete\(box\);\s*\/\/ one attempt per registration; re-registers on error/);
 });
 
-test("markdown-inline <img> failures register through ONE capture-phase listener", () => {
+test("markdown-inline <img> failures are caught by ONE capture-phase listener and PARKED, never retried per message", () => {
   // DOMPurify strips inline handlers (correctly) and md() returns a string, so per-site onerror
   // wiring is impossible — a failed md img sat as a dead element in the cached DOM forever. Error
-  // events don't bubble but DO capture: one document-level listener covers every md img, skips the
-  // preview machinery's own imgs (they run budgets/resume/chips), and rides failedPreviews so every
-  // kernel message re-attempts.
+  // events don't bubble but DO capture: one document-level listener covers every md img and skips the
+  // preview machinery's own imgs (they run budgets/resume/chips). Since T291c the listener PARKS the
+  // image (no src, the alt text as a stable caption) and the reconnect-class heal probes it off the DOM;
+  // the per-message re-set of src flipped every caption on and off at the push rate.
   assert.match(PREVIEW, /export function installMdImgHeal\(\): void \{/);
+  assert.match(PREVIEW, /parkMdImg\(img, src\);\s*\n\s*if \(servedByKernel\(src\)\) \{/, "the listener parks; only a URL the kernel serves gets a bounded, off-DOM probe on the per-message path");
+  assert.doesNotMatch(PREVIEW, /img\.removeAttribute\("src"\);\s*\n\s*img\.src = u;/, "the per-message re-set of a failed img's src, the caption flip, is gone");
+  assert.match(PREVIEW, /export function refreshSettledPreviews\(\): void \{\s*\n\s*healMdImgs\(\);/, "the parked images ride the reconnect-class heal");
   assert.match(PREVIEW, /document\.addEventListener\("error", \(e\) => \{/);
   assert.match(PREVIEW, /\}, true\);\s*\n\}/, "capture phase — error events do not bubble");
   assert.match(PREVIEW, /if \(!src \|\| src\.startsWith\("data:"\)\) return;/, "a broken data: URI has no server to heal");

--- a/ui/webview/preview-retry-pace.test.ts
+++ b/ui/webview/preview-retry-pace.test.ts
@@ -42,7 +42,7 @@ class FakeEl {
   /** the structure without the words: only the elements that are there */
   bones(): string { return `${this.tag}.${this.cls()}(${this.children.map((c) => c.bones()).join(",")})`; }
 }
-(globalThis as any).document = { createElement: (t: string) => new FakeEl(t), addEventListener: () => {} };
+(globalThis as any).document = { createElement: (t: string) => new FakeEl(t), addEventListener: () => {}, querySelectorAll: () => [] };   // no parked markdown images here (md-img-park.test.ts drives those)
 (globalThis as any).location = { protocol: "http:", origin: "http://127.0.0.1:1" };   // canPreview: the web dashboard
 (globalThis as any).window = (globalThis as any).window || {};
 
@@ -181,7 +181,7 @@ test("the source keeps the two rules where the behaviour lives", () => {
   assert.match(PREVIEW, /if \(autoRetries <= 1\) return \{ wait, note: chip \};\s*\n\s*chip\.remove\(\);/, "the chip carries the words for the one new-evidence heal; a re-armed budget gets the loading persona back");
   // the PDF probe's 502 and a relay-URL markdown image wait for the reconnect-class heal too
   assert.match(PREVIEW, /\(r\.status === 502 \? settledPreviews : failedPreviews\)\.set\(box, probe\);/);
-  assert.match(PREVIEW, /\(\/\\\/remote\\\/\[\^\/\]\+\\\/file\\b\/\.test\(src\) \? settledPreviews : failedPreviews\)\.set\(img, \(\) => \{/);
+  assert.match(PREVIEW, /parkMdImg\(img, src\);/, "a markdown image that failed is parked, not registered for any per-message heal (T291c)");
   // a remote kernel's restart reopens the relay socket and fires neither romp:wsup nor hostUp: that event heals too
   const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
   assert.match(RENDER, /window\.addEventListener\("romp:hostRelayUp", \(e\) => \{[\s\S]{0,600}?refreshSettledPreviews\(\);/);

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -725,6 +725,7 @@ export function retryFailedPreviews(): void {
 // never by the per-message heal above, so a dead figure costs one fetch per reconnect, not per push.
 const settledPreviews = new Map<HTMLElement, () => void>();
 export function refreshSettledPreviews(): void {
+  healMdImgs();                                      // parked markdown images ride the same reconnect-class heal (T291c)
   if (!settledPreviews.size) return;
   for (const [box, rebuild] of Array.from(settledPreviews.entries())) {
     settledPreviews.delete(box);                     // one attempt per registration; re-registers on error
@@ -732,14 +733,77 @@ export function refreshSettledPreviews(): void {
   }
 }
 
-// Markdown-inline <img> (a figure pasted as markdown in a message body) had NO failure handling at
-// all: DOMPurify strips inline handlers (correctly — untrusted transcript HTML) and nothing
-// re-attached one, so a load that failed once sat as a dead element in the cached DOM until a send
-// re-rendered the turn (the user 2026-08-24). Error events don't bubble but DO capture: one
-// document-level capture listener covers every md() img on the page — no per-render wiring — and
-// registers the element in the same failedPreviews machinery, so every kernel message re-attempts
-// it. Previews' own <img>s are skipped: their machinery (budgets, resume, chips) owns those.
+// Markdown-inline <img> (a figure written as markdown in a message body): marked leaves `![fig](path)` as
+// <img src="path"> (the chat rewrites no image source), the browser resolves the path against the page's
+// origin, and the kernel answers 404, so the img fails and the browser shows its alt text. The 2026-08-24
+// heal re-set that img's src on every kernel message; each reset hid the alt text while the reload was in
+// flight and the 404 showed it again, so a streaming turn flipped every such caption on and off at the
+// push rate (T291c, the user 2026-09-09: three captions, two to four lines each, ten times a second). A
+// failed markdown image is PARKED instead: its src leaves (into data-md-src), the element wears
+// .md-img-failed, and the browser shows the alt text as a stable caption: no src, no fetch, nothing to
+// flip. No per-message path exists. The reconnect-class heal (refreshSettledPreviews: romp:wsup, hostUp,
+// romp:hostRelayUp) probes every parked URL once OFF the DOM with a detached Image: a failure changes
+// nothing on screen, a success lands the picture on every parked img with that URL. A URL that failed is
+// remembered for the page life, and the sanitizer post-pass (mdImgPostPass, registered by render.ts) parks
+// a re-rendered img with that URL BEFORE the browser fetches it, so a re-render of the same markdown
+// reuses the state instead of fetching, failing and flipping once more. DOMPurify strips inline handlers
+// (correctly), so the failures are caught by ONE document-level capture listener (error events do not
+// bubble but do capture); previews' own <img>s are skipped: their machinery (budgets, resume, chips) owns those.
+const mdImgFailed = new Set<string>();             // URLs that failed this page life: a re-render parks them before any fetch
 let mdImgHealOn = false;
+function parkMdImg(img: HTMLImageElement, url: string): void {
+  mdImgFailed.add(url);
+  img.dataset.mdSrc = url;
+  if (img.hasAttribute("src")) img.removeAttribute("src");   // no src: the browser shows the alt text and fetches nothing
+  img.classList.add("md-img-failed");
+}
+/** The chat's post-pass (render.ts runs it on md() and userMd() output after the sanitize, NEVER through the shared
+ *  sanitizer: the file viewer rewrites its images' paths to /file URLs after its own sanitize, and a park inside the
+ *  sanitizer removed the src that rewrite keys on, the review's find): an img whose URL is already known to fail is
+ *  parked at RENDER, before any fetch. */
+export function mdImgPostPass(root: ParentNode): void {
+  if (!mdImgFailed.size) return;
+  for (const img of Array.from(root.querySelectorAll("img")) as HTMLImageElement[]) {
+    const u = img.src || "";
+    if (u && mdImgFailed.has(u)) parkMdImg(img, u);
+  }
+}
+/** A URL the kernel actually answers (/file, a remote relay's /file, /media): a file an agent is still writing or a
+ *  relay behind a blip may come back with no reconnect event, so those get a BOUNDED probe on the per-message path
+ *  (three attempts, off the DOM, so the caption never moves for them); an origin-resolved path no route serves is
+ *  park-only, since nothing but a reconnect could change its answer. */
+function servedByKernel(u: string): boolean {
+  try {
+    const p = new URL(u, location.href).pathname;
+    return p === "/file" || /^\/remote\/[^/]+\/file$/.test(p) || p.startsWith("/media/");
+  } catch { return false; }
+}
+/** One detached probe of a parked URL. On load the picture lands on every parked img with that URL that is on the
+ *  page NOW, re-queried, not a snapshot: a re-render during the probe parks a fresh img, which a snapshot missed
+ *  (the review's find). On failure nothing on screen changes. */
+function probeMdImgUrl(u: string, onFail?: () => void): void {
+  const probe = new Image();
+  probe.onload = () => {
+    mdImgFailed.delete(u);                           // first: a rebuild from here on fetches normally
+    for (const img of Array.from(document.querySelectorAll("img.md-img-failed[data-md-src]")) as HTMLImageElement[]) {
+      if (img.dataset.mdSrc !== u || !img.isConnected) continue;
+      img.classList.remove("md-img-failed");
+      delete img.dataset.mdSrc;
+      img.src = u;                                   // the bytes are in the browser's cache: the picture lands
+    }
+  };
+  probe.onerror = () => { if (onFail) onFail(); };  // still down: the parked captions stay exactly as they are
+  probe.src = u;
+}
+/** The reconnect-class heal for parked markdown images: one detached probe per parked URL. */
+export function healMdImgs(): void {
+  const urls = new Set<string>();
+  for (const img of Array.from(document.querySelectorAll("img.md-img-failed[data-md-src]")) as HTMLImageElement[]) {
+    const u = img.dataset.mdSrc || "";
+    if (u) urls.add(u);
+  }
+  for (const u of urls) probeMdImgUrl(u);
+}
 export function installMdImgHeal(): void {
   if (mdImgHealOn) return;                           // ensure-once (the click-safety installation rule)
   mdImgHealOn = true;
@@ -749,12 +813,11 @@ export function installMdImgHeal(): void {
     const src = img.src || "";
     if (!src || src.startsWith("data:")) return;     // a broken data: URI has no server to heal
     if (img.onerror || img.closest(".path-full")) return;   // the preview machinery retries its own
-    // a relay URL (fileUrl builds /remote/<host>/file for a remote sid) failed on the LINK's account as
-    // likely as the image's: it waits for the reconnect-class heal (T291); a local src keeps the per-message one
-    (/\/remote\/[^/]+\/file\b/.test(src) ? settledPreviews : failedPreviews).set(img, () => {
-      const u = img.src;
-      img.removeAttribute("src");
-      img.src = u;                                   // a fresh attempt; a repeat error re-registers here
-    });
+    parkMdImg(img, src);
+    if (servedByKernel(src)) {                       // bounded and off the DOM: the caption never moves for it
+      let budget = 3;
+      const again = () => probeMdImgUrl(src, () => { if (--budget > 0) failedPreviews.set(img, again); });
+      failedPreviews.set(img, again);
+    }
   }, true);
 }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -50,7 +50,7 @@ import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, notifHead, type AgentNotif } from "./agent-notif";
 import { injectedHead, type InjectedSource } from "./injected-source";
 import { subTabId, isSubId, subParts, subLabel, gistLines, stepLines, stepsNote, agentFoldLabel, subHeadParts, openIconSvg, pinIconSvg, type SubMeta, type AgentGist, type AgentGistRow, type GistLine } from "./subagent-view";
-import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal, setLightboxNav, type LightboxNavEntry } from "./preview";
+import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal, mdImgPostPass, setLightboxNav, type LightboxNavEntry } from "./preview";
 import { openFileClick } from "./file-view";                  // a clicked file WITH its gesture (pdf-new-tab.test.ts)
 // initFileView rides its OWN line: the import above is pinned verbatim by file-view.test.ts
 import { initFileView, setFileViewIdentity, hostStub } from "./file-view";
@@ -1175,6 +1175,7 @@ function md(src: string, repo: string | null = prRepoFor()): string {
     // the sanitizer's verdicts stand and a marked-autolinked GitHub URL is never wrapped twice.
     const clean = sanitizeMd(dirty);   // the sanitized <body>, its math rendered
     linkifyPrRefs(clean, repo);
+    mdImgPostPass(clean);   // a markdown image whose URL failed this page life is parked before the browser fetches it (T291c)
     return clean.innerHTML;
   } catch { const d = document.createElement("div"); d.textContent = src; return d.innerHTML; }
 }
@@ -1189,6 +1190,7 @@ function userMd(src: string, repo: string | null = prRepoFor()): string {
   try {
     const clean = sanitizeMd(userMdHtml(src));   // the sanitized <body>, its math rendered
     linkifyPrRefs(clean, repo);
+    mdImgPostPass(clean);   // a markdown image whose URL failed this page life is parked before the browser fetches it (T291c)
     return clean.innerHTML;
   } catch { const d = document.createElement("div"); d.textContent = src; return d.innerHTML; }
 }
@@ -1804,7 +1806,16 @@ function healPathImgs(): void {
 // the page shim fires romp:wsup when THIS pane's kernel socket reconnects (kernel.py ws.onopen) —
 // the same kernel-is-back event a hostUp is for a federated tunnel; heal everything on it
 window.addEventListener("romp:wsup", () => { retryFailedPreviews(); refreshSettledPreviews(); healPathImgs(); });
-installMdImgHeal();   // markdown-inline <img> failures register for the per-message heal (capture-phase, once)
+installMdImgHeal();   // markdown-inline <img> failures are PARKED (capture-phase, once) and heal on the reconnect-class events (T291c);
+//                       md() and userMd() run mdImgPostPass on their own output, so a re-render parks a known-failed image before it fetches
+// The page's own bundle build, filed once per page load (T291c, the user's 2026-09-09 report could not tell the
+// page's build from the kernel's): the ?v= the kernel stamped on the render.js script this page loaded (the
+// dist_ver it served then; a VS Code webview loads the bundle without one and files 0).
+(() => {
+  const tag = Array.from(document.scripts).map((sc) => sc.getAttribute("src") || "").find((u) => /\/dist\/render\.js(\?|$)/.test(u)) || "";
+  const m = /[?&]v=(\d+)/.exec(tag);
+  vscodeApi?.postMessage({ type: "clientDiag", surface: "chat", what: "pageload", data: { distVer: m ? Number(m[1]) : 0, path: location.pathname } });
+})();
 
 // One image of a user turn: the picture (or its hydration chip) plus, when the
 // on-disk path is known, a caption line — the full absolute path (click → open),

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2999,6 +2999,9 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
   animation: path-load-spin 2.4s linear infinite; }   /* the calm mini-swirl spin, same as the awaiting glyphs */
 @keyframes path-load-spin { to { transform: rotate(-360deg); } }
 .path-img-loading { display: none; }   /* the <img> takes the spot the instant it has pixels */
+/* a markdown image whose fetch failed (T291c): parked with no src, so the browser shows the alt text as a stable
+   inline caption, dim and italic like the load note; nothing re-fetches it until a reconnect-class heal lands the picture */
+.md-img-failed { display: inline; font-size: 0.86em; font-style: italic; color: var(--dim); }
 @media (prefers-reduced-motion: reduce) { .path-load-spin { animation: none; } }
 /* the PDF card's label + filename (preview.ts previewFull's pdf branch) */
 .path-thumb-tag { font-size: 0.72em; font-weight: 700; letter-spacing: 0.04em; color: var(--accent); flex: 0 0 auto; }


### PR DESCRIPTION
The snapback persisted on the fixed bundle (the user restarted the laptop kernel and reloaded; the 3:46 PM recording shows three image captions appearing at the ends of three paragraphs and vanishing again, two to four lines each, matching the capture's ±41.6/62.4/83.2 px rows on three assistant turns). Those are markdown-inline images.

**Root cause.** marked leaves `![fig](path)` as `<img src="path">` (the chat rewrites no image source), the browser resolves the path against the page's origin, the kernel answers 404, and the markdown image heal (2026-08-24) re-set that img's `src` on every kernel message: while the reload ran the browser hid the alt text, on the 404 it showed it again, so a streaming turn flipped every such caption on and off at the push rate. The preview fix (1206) moved only relay URLs (`/remote/<host>/file`) off the per-message path; a path URL like these stayed on it, unbounded. Every re-render of the same markdown also minted a fresh img that fetched, failed and flipped once more.

**Fix.** A failed markdown image is PARKED, not retried: the capture-phase listener strips its `src` into `data-md-src`, marks it `md-img-failed`, remembers the URL for the page life, and the browser shows the alt text as a stable inline caption (no src, no fetch, nothing to flip). No per-message path exists for markdown images. The reconnect-class heal (`refreshSettledPreviews`, the same three events: `romp:wsup`, `hostUp`, `romp:hostRelayUp`) probes each parked URL once OFF the DOM with a detached `Image`: a failure changes nothing on screen; a success lands the picture on every parked img with that URL. A sanitizer post-pass (`mdImgPostPass`, registered by render.ts beside the listener) parks a re-rendered img whose URL is known to fail BEFORE the browser fetches it, so a re-render reuses the state.

**The page-load row.** The chat pane files one client-diag row per page load (`pageload`, `distVer`: the `?v=` the kernel stamped on the render.js script the page loaded, 0 in a VS Code webview) so the next report can tell the page's build from the kernel's.

**Tests.** `ui/webview/md-img-park.test.ts`, executed over a fake DOM: a failed image is parked with its caption intact and sixty pushes leave it byte-identical with no probe and no fetch; the reconnect heal probes once per URL off the DOM, a failed probe changes nothing, a successful one lands the picture and un-parks only that URL; the post-pass parks a remembered URL at render and leaves a healed one alone; render.ts installs the listener once, registers the post-pass and files the page-load row. The preview pins follow (no `failedPreviews` registration for markdown images; the heal rides `refreshSettledPreviews`).

**From the adversarial review, folded in before arming.** The park runs on the chat's own markdown only (`md()` and `userMd()` call the post-pass after the sanitize), never through the shared sanitizer: the file viewer rewrites its images' paths to `/file` URLs after its own sanitize, and a park inside the sanitizer removed the `src` that rewrite keys on. The heal re-queries the page on load instead of restoring a snapshot, so a turn re-rendered while the probe ran (its fresh img parked by the post-pass) gets the picture too. A URL the kernel actually serves (`/file`, a remote relay's `/file`, `/media`) gets a bounded probe on the per-message path, three attempts off the DOM so the caption never moves for them, then the reconnect-class heal alone; an origin-resolved path no route serves stays park-only. The tests count `src` writes (zero across sixty pushes; the old code wrote two per push), each builds its own state, and they cover the served-URL budget and the re-render during a probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
