### PR TITLE
Guide: a tag group's header shows the tag's color and name, then the chevron and the count, the order the strip builds (T284)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -101,7 +101,7 @@ surface (the tag button in the strip narrows the tabs to the tags you pick), and
 the tabs: as soon as any session carries a tag, the strip shows one section per tag, in your
 tag order, each with a header in the tag's color, and the untagged sessions after a divider
 at the end. A session with several tags appears under each of them; every copy is the same
-session (click either to open it, and closing either ends it). Each header shows a chevron, the tag's color, its name, and a
+session (click either to open it, and closing either ends it). Each header shows the tag's color and name, then a chevron and a
 member count. Click a header, or press Enter on it, to fold its section down to the header
 alone; the count then says how many tabs are folded away, and a small dot after it says when
 one of them is working or waiting on you (hover it for their names). To keep one tab visible

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -1747,3 +1747,16 @@ test("the guide states the every-tag rule (T264b)", () => {
   assert.match(GUIDE, /A session with several tags appears under each of them; every copy is the same\s+session/);
   assert.doesNotMatch(GUIDE, /sits under the first of them in your tag order/, "the retired home-tag sentence is gone");
 });
+
+test("the guide lists the header's parts in the built order: the tag's color and name, then the chevron and the count (T284)", () => {
+  assert.match(GUIDE, /Each header shows the tag's color and name, then a chevron and a\s+member count\./);
+  assert.doesNotMatch(GUIDE, /Each header shows a chevron, the tag's color/, "the pre-T284 caret-first sentence is gone");
+  // The guide names the parts in the order the builder appends them (the structure pin above), and that is
+  // the order the reader sees only while the header's flex row keeps DOM order: no rule on the header or on
+  // one of its parts may reorder them (order, flex-direction, a margin-left: auto push).
+  const rules = [...CSS.matchAll(/(?:^|\n)([^{}\n]*\.tab-group-(?:head|caret|chip|count|pip)[^{}\n]*)\{([^}]*)\}/g)];
+  assert.ok(rules.length >= 5, "the header's rules are read: " + rules.length);
+  for (const [, sel, body] of rules) {
+    assert.doesNotMatch(body, /(?:^|[\s;])order\s*:|flex-direction\s*:|margin-left\s*:\s*auto/, "no rule reorders the header: " + sel.trim());
+  }
+});


### PR DESCRIPTION
## Symptom
The guide's Tags and groups paragraph (docs/guide.md) says each section header in the tab strip "shows a chevron, the tag's color, its name, and a member count". The header a reader sees shows the tag's chip (its color and name) first, then the chevron and the count.

## Cause
#1185 (T284) reordered makeGroupHead in ui/webview/render.ts to append the chip, then the caret, then the count, then (while the section is collapsed) the pip, and pinned that order in ui/webview/tab-groups.test.ts and tests/test_tab_groups_rows.py. The guide sentence, written for the earlier caret-first layout, was not updated. .tab-group-head is a flex row and no rule on it or on its parts (styles.css) sets order, flex-direction or margin-left: auto, so DOM order is what the reader sees.

## Fix
The one sentence now reads: "Each header shows the tag's color and name, then a chevron and a member count." The rest of the paragraph (the count while collapsed, the small dot after it) already matches the header and is unchanged. No code, CSS or kernel change. The render.ts header comment's "color as a short bar" phrase is a code comment and is left for a code change.

#1168, and #1201 which builds on it and carries the same two hunks, also edit this paragraph: the sentence two lines above this one (the untagged sessions' own row) and the paragraph's closing sentence (where four lines are added), with the header sentence carried as context. None of the three changes the same sentence, so after the first of them merges the others need a one-line rebase of this hunk, with no wording to reconcile.

## Tests
- ui/webview/tab-groups.test.ts, "the guide lists the header's parts in the built order: the tag's color and name, then the chevron and the count (T284)", beside the every-tag-rule guide pin. Three checks: assert.match on the new sentence across its line wrap; assert.doesNotMatch on the caret-first phrasing; and, over every .tab-group-head, -caret, -chip, -count and -pip rule in styles.css, that none sets order, flex-direction or margin-left: auto, so the build order the guide names stays the order the reader sees. On the unchanged guide the match fails (57 tests, 56 pass, 1 fail). With the guide edited, an order: -1 added to .tab-group-caret fails the CSS check and no other test in the module; a flex-direction on .tab-group-head or a margin-left: auto on .tab-group-count fails it too; a border-radius added to .tab-group-count does not trip it. After the edit, 57 of 57 pass.
- npm run typecheck: clean. Full npm test: 3761 tests, 3761 pass, 0 fail.

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)