### PR TITLE
Re-green two node tests after tonight's merges (reply chips via liveSession; staged-list prelude stubs ephemeralWarnToast)

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -11198,7 +11198,7 @@ function dressReplyChip(b: HTMLButtonElement, dir: Dir, chip: ReadyChip | null):
 }
 function updateReplyChips(): void {
   const c = document.getElementById("content");
-  const s = activeId ? sessions.get(activeId) : null;
+  const s = activeId ? liveSession(activeId) : null;   // a skeleton tab's stale session shows no chips (skeleton-tabs-wiring.test.ts)
   const v = activeId ? views.get(activeId) : null;
   const H = c ? c.clientHeight : 0;
   const ready = activeId ? (commentThreads.get(activeId) || []).filter(isReplyReady) : [];

--- a/ui/webview/staged-list-cap.test.ts
+++ b/ui/webview/staged-list-cap.test.ts
@@ -95,6 +95,7 @@ function lift(): (hooks: Hooks) => Api {
     const persistDrafts = () => { H.persists++; };
     const hostIsDown = (id) => H.down.has(id); const isProvisionalId = (id) => H.provisional.has(id);
     const warnToast = (msg) => { H.toasts.push(msg); };
+    const ephemeralWarnToast = (msg) => { H.toasts.push(msg); };   // the slice's unreachable-session word is the ephemeral one
   `;
   const epilogue = `return { routeUserMessage, flushStaged, renderStagedStrip, stagedMsgs, stagedOpen, stagedCollapsed, stagedScroll };`;
   return new Function("HOOKS", prelude + js + epilogue) as (hooks: Hooks) => Api;


### PR DESCRIPTION
Two node tests fail on main after tonight's merges. The skeleton-tabs wiring test counts the sessions.get(activeId) reads in render.ts that may bypass liveSession (name reads and the fork-prompt gates) and expects four; the reply-ready change added a fifth in updateReplyChips, a display path that over a skeleton tab would paint chips from the stale pre-outage session, so that read now goes through liveSession(activeId). The staged-list cap test evals a slice of render.ts whose unreachable-session word became an ephemeralWarnToast call with the auto-reload notice change, which the test's prelude did not define; the prelude now stubs it into the same toast record as warnToast. Typecheck and the full node suite pass (3939 pass, 0 fail, 3 skipped).

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)