### PR TITLE
The awaiting lift decides on the shared read-only goal store and loads the writer's copy only when a lift is due

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1021,12 +1021,20 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   `plannerSkip` counts the sessions the outer gate let through, not every
   planner skip: an idle session stops at the outer gate and appears in neither
   `skipped` nor `planned`. Outside a pass frame (`romp-judge --plan`) the
-  outer gate stamps nothing, and the inner gate does the skipping. The
-  compaction sweep after each judge pass evicts from `pass` and `shared` the
-  entries of stores no session in the discover window owns, so both stay
-  bounded by the live board; the courier's and the planner's change-gate
-  tables are pruned to the sessions each pass discovers, and the evidence
-  gate's stamps are cleared at a fixed cap.
+  outer gate stamps nothing, and the inner gate does the skipping. `bgTops`
+  is the placed-launch memo behind the awaiting lift and the feed's
+  background-task classification, keyed on the parse object and the store
+  object: `hit` and `miss` (calls answered from the per-version map against
+  looked up), `resolve` (launch ids looked up on a miss, placed or not),
+  `walk` and `walk_neg` (transcript walks, and the walks that left a launch
+  unresolved: an upper bound on what a negative walk cache would save),
+  `idx_build` (placement indexes built, one per store object asked, a
+  writer's private copy included) and the gauge `entries` (sessions holding
+  a map). The compaction sweep after each judge pass evicts from `pass` and
+  `shared` the entries of stores no session in the discover window owns, so
+  both stay bounded by the live board; the courier's and the planner's
+  change-gate tables are pruned to the sessions each pass discovers, and the
+  evidence gate's stamps are cleared at a fixed cap.
 - `judge`: `passes`, `ms_sum`, `ms_last`, `ms_mean` (wall time; a pass waits
   on model calls), `cpu_ms_sum` (CPU time of the judge tier threads and every
   per-session worker they run; the workers' share is `cpu_ms_workers`).

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1021,20 +1021,28 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   `plannerSkip` counts the sessions the outer gate let through, not every
   planner skip: an idle session stops at the outer gate and appears in neither
   `skipped` nor `planned`. Outside a pass frame (`romp-judge --plan`) the
-  outer gate stamps nothing, and the inner gate does the skipping. `bgTops`
-  is the placed-launch memo behind the awaiting lift and the feed's
-  background-task classification, keyed on the parse object and the store
-  object: `hit` and `miss` (calls answered from the per-version map against
-  looked up), `resolve` (launch ids looked up on a miss, placed or not),
-  `walk` and `walk_neg` (transcript walks, and the walks that left a launch
-  unresolved: an upper bound on what a negative walk cache would save),
-  `idx_build` (placement indexes built, one per store object asked, a
-  writer's private copy included) and the gauge `entries` (sessions holding
-  a map). The compaction sweep after each judge pass evicts from `pass` and
-  `shared` the entries of stores no session in the discover window owns, so
-  both stay bounded by the live board; the courier's and the planner's
-  change-gate tables are pruned to the sessions each pass discovers, and the
-  evidence gate's stamps are cleared at a fixed cap.
+  outer gate stamps nothing, and the inner gate does the skipping. `liftGate`
+  is the awaiting lift's per-session inputs gate and two-phase read: `skip`
+  and `load` (session-cycles that took no store read against the ones that
+  read it, a probe on the shared read-only view), `shared` (probes the shared
+  cache answered), `writer` (session-ticks that loaded the writer's copy
+  because a lift was due) and `noop` (writer loads whose fresh decision filed
+  nothing, the store having moved between the probe and the load), and the
+  gauge `entries` (sessions remembered). `bgTops` is the placed-launch memo
+  behind the awaiting lift and the feed's background-task classification,
+  keyed on the parse object and the store object: `hit` and `miss` (calls
+  answered from the per-version map against looked up), `resolve` (launch ids
+  looked up on a miss, placed or not), `walk` and `walk_neg` (transcript
+  walks, and the walks that left a launch unresolved: an upper bound on what a
+  negative walk cache would save), `idx_build` (placement indexes built, one
+  per store object asked, a writer's private copy included) and the gauge
+  `entries` (sessions holding a map). The compaction sweep after each judge
+  pass evicts from `pass` and `shared` the entries of stores no session in the
+  discover window owns, so both stay bounded by the live board; the courier's
+  and the planner's change-gate tables are pruned to the sessions each pass
+  discovers, the evidence gate's stamps are cleared at a fixed cap, and the
+  awaiting lift's tick drops the gate's and the placed-launch memo's entries
+  of sessions that left the alive set.
 - `judge`: `passes`, `ms_sum`, `ms_last`, `ms_mean` (wall time; a pass waits
   on model calls), `cpu_ms_sum` (CPU time of the judge tier threads and every
   per-session worker they run; the workers' share is `cpu_ms_workers`).

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -399,7 +399,8 @@ class _PerfStats:
         for key, read in (("pass", _goals_memo_report), ("shared", jd.shared_store_stats),
                           ("chain", jd.chain_memo_stats), ("courierSkip", jd.courier_skip_stats),
                           ("backref", jd.backref_memo_stats), ("captions", jd.captions_memo_stats),
-                          ("goalArchive", jd.goal_archive_memo_stats), ("plannerSkip", jd.planner_skip_stats)):
+                          ("goalArchive", jd.goal_archive_memo_stats), ("plannerSkip", jd.planner_skip_stats),
+                          ("bgTops", _bg_tops_report)):
             try:
                 memos[key] = read()
             except Exception:
@@ -24012,68 +24013,158 @@ def _seg_of_tool_uses(ps, store, tool_ids):
     return found
 
 
-_BG_TOPS_CACHE = {}    # sid -> ((transcript stat, goals stat, overrides stat, tid tuple), {tid: top})
+_BG_TOPS_CACHE = {}    # sid -> (parse object, store object, {tid: top or None}), see _bg_placed_tops
+_PLACEMENT_IDX = {}    # sid -> (store object, {jd._seg_key(placement key): its first value in dict order})
+_bg_tops_stats = {"hit": 0, "miss": 0, "resolve": 0, "walk": 0, "walk_neg": 0, "idx_build": 0}
+_BG_TOPS_STATS_LOCK = threading.Lock()   # the counters are bumped from the pusher and the handler threads
 
 
-def _bg_placed_tops(sid, path, tids):
+def _bg_tops_bump(key, n=1):
+    with _BG_TOPS_STATS_LOCK:
+        _bg_tops_stats[key] += n
+
+
+def _bg_tops_report():
+    """The memo's counters plus its occupancy, for /perf (memos.bgTops): `hit` calls answered from the
+    per-version map, `miss` calls that looked up at least one tid, `resolve` tids looked up on a miss (placed
+    or not), `walk` transcript walks (_seg_of_tool_uses) and `walk_neg` the walks that left at least one
+    asked tid unresolved (an upper bound on what a negative walk cache would save: such a cache, keyed per
+    parse to stay exact, saves only the re-walks under one parse), `idx_build` placement indexes built (one
+    per store object asked, a writer's private copy included), and the gauge `entries` (sids holding a
+    map)."""
+    with _BG_TOPS_STATS_LOCK:
+        out = dict(_bg_tops_stats)
+    out["entries"] = len(_BG_TOPS_CACHE)
+    return out
+
+
+def _placement_index(placements):
+    """{jd._seg_key(k): v} over a store's placements, the FIRST key in dict order winning (setdefault): for
+    any looked-up key that normalizes to a seg key, exactly the value jd._placement_of's scan returns for
+    it, a None-valued retired entry included."""
+    idx = {}
+    for k, v in placements.items():
+        idx.setdefault(jd._seg_key(k), v)
+    return idx
+
+
+def _placed_via_index(placements, idx, seg_id):
+    """jd._placement_of(placements, seg_id) answered from _placement_index: the exact key when it is
+    present (its value, None included, the scan never runs), else the normalized key's first match."""
+    if seg_id in placements:
+        return placements[seg_id]
+    return idx.get(jd._seg_key(seg_id))
+
+
+def _bg_placed_tops(sid, path, tids, store=None):
     """{tid: owning top node id} for the live background-task launches the JUDGE has PLACED: launch
-    tool_use id → the transcript segment holding it (_seg_of_tool_uses via _task_seg_cache — a launch's
-    segment never changes) → the store's placement for that segment → the placed node's top ancestor.
+    tool_use id -> the transcript segment holding it (_seg_of_tool_uses via _task_seg_cache: a launch's
+    segment never changes) -> the store's placement for that segment, under the four suffixes
+    jd._placement_of accepts, read from a per-store index (_placement_index) -> the placed node's top
+    ancestor.
 
     A tid ABSENT from the result is a launch the judge hasn't spoken for yet (segment unparsed or
-    unplaced, no goal store, unreadable evidence) — the AWAITED-conservative default every consumer
-    keys on. Cached on the transcript + goal-store + override-journal file stats and the tid set (the
-    _session_stamp_read pattern): an idle session hits this every render, and load_goals is a full
-    read + override replay."""
+    unplaced, no goal store, unreadable evidence): the AWAITED-conservative default every consumer
+    keys on.
+
+    The answer is a function of (the parse object, the store object, the _task_seg_cache positives, which
+    rest on the standing "a launch's segment never changes" assumption), and the memo is keyed on exactly
+    those two objects: _BG_TOPS_CACHE[sid] = (ps, store, {tid: top or None}) holds every tid asked so far
+    under one (parse, store) pair, a hit iff both objects in hand ARE the entry's. Identity, not a stat: the
+    awaiting lift asks with every task id the transcript records and the feed with the live ids, a subset
+    that is often empty, so one map answers both and the feed's ask never evicts the lift's fill; and a
+    stat is not the version: a rewrite that keeps the mtime and the byte count is served stale under a
+    stat key, and a stat taken beside a read can describe a version the read did not see (a publish
+    between the two records one version's identity under another's placements, so a launch the closer
+    moved under another card still reads as this goal's own).
+    _parse returns one object per transcript version and load_goals_shared one FrozenStore per store
+    version, so identity is the version. `store`: the caller's own store (a caller deciding on a store
+    hands it in, so the placement it reads and the stamps it rules on come from one object); None reads
+    through load_goals_shared. A store that is not the shared cache's FrozenStore (no file, the cache off,
+    an unreadable journal, a writer's private copy) is computed on and never published as an entry.
+    _PLACEMENT_IDX[sid] = (store, index) is keyed on the store object alone, so the writer's copy misses it
+    harmlessly. While the shared cache is off (_SHARED_OFF: a reader wrote to a shared view, a judge-errors
+    row names the site, off until the kernel restarts) every store=None call is a full load_goals and
+    nothing is memoized; acceptable because that state is a loud error, not a mode the kernel runs in.
+
+    Threads: the pusher and the handler threads (build_session, _session_awaiting) both run this. An entry
+    is read into locals once, a fill builds a NEW dict from it and publishes a NEW tuple; nothing writes
+    into an entry in place, so a reader holding the old tuple keeps a consistent (ps, store, map). Entries
+    are dropped when a session asks with no live tids and the pinned parse is no longer the transcript's
+    current one (below: the pin the bound is for)."""
     sid = str(sid)
     tids = tuple(sorted(t for t in tids if t))
     if not tids or not path:
+        # Nothing to answer. The feed, chat and timeline builds ask here with an EMPTY live set for a
+        # session whose tasks all returned, several times per cycle, while the lift's ask (every task id
+        # the transcript records) is what filled the entry; evicting on every empty ask would make the lift
+        # miss every cycle and re-walk the transcript. Release the pinned parse only when it is no longer
+        # the transcript's current parse: _parse answers _parse_cache[path][1] on a hit, so an entry whose
+        # parse IS that object costs no memory beyond the parse every build holds anyway, and one whose
+        # parse is not (the transcript was re-parsed, or nothing is cached) is the stale pin the bound is
+        # for.
+        ent = _BG_TOPS_CACHE.get(sid)
+        cur = _parse_cache.get(path) if path else None
+        if ent is None or cur is None or ent[0] is not cur[1]:
+            _BG_TOPS_CACHE.pop(sid, None)
+            _PLACEMENT_IDX.pop(sid, None)
         return {}
     try:
-        st = os.stat(path)
-        tkey = (st.st_mtime, st.st_size)
-    except OSError:
-        tkey = None
-    try:
-        gs = (jd.GOALDIR / (sid + ".json")).stat()
-        gkey = (gs.st_mtime, gs.st_size)
-    except Exception:
-        return {}                                    # no store yet → nothing placed
-    try:
-        ostt = (jd._overrides_dir() / (sid + ".jsonl")).stat()
-        okey = (ostt.st_mtime, ostt.st_size)
-    except Exception:
-        okey = None                                  # no override journal is normal
-    key = (tkey, gkey, okey, tids)
-    hit = _BG_TOPS_CACHE.get(sid)
-    if hit and hit[0] == key:
-        return hit[1]
-    out = {}
-    try:
+        if store is None and not os.path.exists(str(jd.GOALDIR / (sid + ".json"))):
+            return {}                                # no store yet -> nothing placed: no parse, no fallback load
         ps = _parse(path, sid, time.time())
-        store = jd.load_goals(sid)
-        nodes = (store or {}).get("nodes") or {}
+        if store is None:
+            store = jd.load_goals_shared(sid)
+        ent = _BG_TOPS_CACHE.get(sid)
+        known = ent[2] if (ent is not None and ent[0] is ps and ent[1] is store) else None
+        if known is not None and all(t in known for t in tids):
+            _bg_tops_bump("hit")
+            return {t: known[t] for t in tids if known[t] is not None}
+        _bg_tops_bump("miss")
+        nodes = store.get("nodes") or {}
         placements = store.get("placements") or {}
-        need = [t for t in tids if (sid, t) not in _task_seg_cache]
+        shared = isinstance(store, jd.FrozenStore)
+        pidx = _PLACEMENT_IDX.get(sid)
+        if pidx is not None and pidx[0] is store:
+            idx = pidx[1]
+        else:
+            idx = _placement_index(placements)
+            _bg_tops_bump("idx_build")
+            if shared:
+                _PLACEMENT_IDX[sid] = (store, idx)
+        todo = tids if known is None else tuple(t for t in tids if t not in known)
+        need = [t for t in todo if (sid, t) not in _task_seg_cache]
         if need and ps and nodes:
-            for tid, sgid in _seg_of_tool_uses(ps, store, need).items():
+            found = _seg_of_tool_uses(ps, store, need)
+            for tid, sgid in found.items():
                 _task_seg_cache[(sid, tid)] = sgid
-        for tid in tids:
+            _bg_tops_bump("walk")
+            if len(found) < len(need):
+                _bg_tops_bump("walk_neg")
+        fill = dict(known) if known is not None else {}
+        for tid in todo:
+            fill[tid] = None
             sgid = _task_seg_cache.get((sid, tid))
             if not sgid:
-                continue                             # unresolvable launch → unplaced (see docstring)
-            nid = next((v for v in (jd._placement_of(placements, sgid + suf)
-                                    for suf in ("", "#live", "#p", "#d")) if v), None)
-            seen = set()                             # placed node → its top ancestor (cycle-guarded)
+                continue                             # unresolvable launch -> unplaced (see docstring)
+            nid = None
+            for suf in ("", "#live", "#p", "#d"):
+                v = _placed_via_index(placements, idx, sgid + suf)
+                if v:
+                    nid = v
+                    break
+            seen = set()                             # placed node -> its top ancestor (cycle-guarded)
             while nid in nodes and nodes[nid].get("parentId") is not None and nid not in seen:
                 seen.add(nid)
                 nid = nodes[nid]["parentId"]
             if nid in nodes:
-                out[tid] = nid
+                fill[tid] = nid
+        _bg_tops_bump("resolve", len(todo))
+        if shared:
+            _BG_TOPS_CACHE[sid] = (ps, store, fill)  # a new tuple, never a write into the old one
+        return {t: fill[t] for t in tids if fill[t] is not None}
     except Exception:
-        return {}                                    # unreadable evidence → nothing placed (conservative)
-    _BG_TOPS_CACHE[sid] = (key, out)
-    return out
+        return {}                                    # unreadable evidence -> nothing placed (conservative)
 
 
 def _bg_owner_tops(fsid, path, tasks):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -400,7 +400,7 @@ class _PerfStats:
                           ("chain", jd.chain_memo_stats), ("courierSkip", jd.courier_skip_stats),
                           ("backref", jd.backref_memo_stats), ("captions", jd.captions_memo_stats),
                           ("goalArchive", jd.goal_archive_memo_stats), ("plannerSkip", jd.planner_skip_stats),
-                          ("bgTops", _bg_tops_report)):
+                          ("liftGate", _lift_gate_report), ("bgTops", _bg_tops_report)):
             try:
                 memos[key] = read()
             except Exception:
@@ -9715,6 +9715,20 @@ def _sid_inputs_fp(sid, path, extra=()):
 
 
 _lift_seen = {}   # sid -> the inputs fingerprint the awaiting lift last ruled on — see _lift_spent_awaiting
+_lift_gate_stats = {"skip": 0, "load": 0, "shared": 0, "writer": 0, "noop": 0}   # /perf memos.liftGate, see _lift_gate_report
+
+
+def _lift_gate_report():
+    """The gate's counters plus its occupancy, for /perf: `skip` session-cycles that took no read, `load` the
+    ones that read the store (phase 1 of _lift_spent_awaiting), `shared` the phase-1 reads the shared
+    read-only cache answered (the rest were load_goals' own store: no file, an unreadable journal, the cache
+    off), `writer` the phase-2 writer loads: one per session-tick that loaded the writer's copy because a
+    lift was due (a tick filing two lifts on one session counts once; the `noop` ones count too), `noop`
+    the writer loads whose fresh decision filed nothing (the store moved between the probe and the load),
+    `entries` sids remembered."""
+    out = dict(_lift_gate_stats)
+    out["entries"] = len(_lift_seen)
+    return out
 
 
 def _lift_spent_awaiting(now, tmux):
@@ -9731,18 +9745,34 @@ def _lift_spent_awaiting(now, tmux):
     awaiting flavors are untouched: we lift only when this goal DID dispatch background work of its own by
     stamp time, every one of those has come back, and at least one came back AFTER the stamp's anchor —
     a return already sitting in a turn the stamping judge had audited can't be what the stamp waits on
-    (see the loop's _returned_after note, 2026-08-16). A stamp naming a CI run, a scheduled check-back or a
-    peer handoff owns no such dispatches, so it never matches and keeps its stamp — those still rely on the
-    6h awaiting wake (_wake_goal, in the nudge tick's goal walk), which is exactly the case a timer is the
-    only tool for. A kind=job stamp that DOES own dispatches (the standard shape: a watcher armed over an
-    external computation) lifts only on their REAL terminal records: a watcher dying with a restart or
+    (see _lift_decisions' _returned_after note, 2026-08-16). A stamp naming a CI run, a scheduled check-back
+    or a peer handoff owns no such dispatches, so it never matches and keeps its stamp — those still rely on
+    the 6h awaiting wake (_wake_goal, in the nudge tick's goal walk), which is exactly the case a timer is
+    the only tool for. A kind=job stamp that DOES own dispatches (the standard shape: a watcher armed over
+    an external computation) lifts only on their REAL terminal records: a watcher dying with a restart or
     expiring is the CARRIER going, not the job returning — before this, the watcher's silent death lifted
     the stamp while the slurm job ran on (the user 2026-08-15; the wake stays the backstop).
 
     Dormant sessions are skipped: their tasks died with their CLI, so the death notice is the truth there,
-    not a lift (same rule as _session_awaiting's source 0.75)."""
+    not a lift (same rule as _session_awaiting's source 0.75).
+
+    TWO-PHASE READ. Every rule lives in _lift_decisions, which decides and writes nothing. Phase 1 runs it
+    on the shared read-only view (jd.load_goals_shared_or_fault: one parse per store version for every
+    reader; the fingerprint is recorded before the probe, as before). Most stamped sessions end there: the
+    dispatch is still out, so nothing is due and no writer load happens. Before this, every alive session
+    whose fingerprint moved paid a private load_goals (a full read plus the journal replay) to decide
+    nothing. Phase 2 runs only when phase 1 found a lift due: the writer's copy is loaded
+    (jd.load_goals_or_fault), the decision is made AGAIN on that copy, and that second decision is what
+    record_verdict files and save_goals publishes, never the first. The frozen view is never written to and
+    never reaches save_goals (both would raise), and the copy a lift is written on is the copy it was
+    decided on: a writer that publishes between the probe and the load (the closer re-placing the deciding
+    launch under another card) costs one writer load that decides nothing (`noop`), never a lift from a
+    stale decision. After the loop, the gate entries and the placed-launch memo's entries of sids that
+    left the alive set are dropped: nothing to gate, nothing to place for."""
+    seen = set()
     for s in _alive_sessions(now, tmux):
         sid = s["sid"]
+        seen.add(sid)
         try:
             if tmux.get(sid) is None:                 # dormant → its tasks died with the CLI, don't rule
                 continue
@@ -9770,275 +9800,335 @@ def _lift_spent_awaiting(now, tmux):
                                          tuple(sorted((str(t.get("id") or ""), bool(em._bg_expired(t, now)))
                                                       for t in every if isinstance(t, dict) and t.get("status") == "running"))))
             if gate is not None and _lift_seen.get(sid) == gate:
-                continue
+                _lift_gate_stats["skip"] += 1
+                continue                              # the same inputs were ruled on last cycle
+            _lift_gate_stats["load"] += 1
             _lift_seen[sid] = gate                    # recorded now; a ruling that RAISES forgets it below,
-            store, fault = jd.load_goals_or_fault(sid)   # so the next cycle retries instead of skipping
-            if fault is not None:                     # its row is filed; forget the gate so the next cycle
-                _lift_seen.pop(sid, None)             # retries this session, and go on to the others
+            #                                           so the next cycle retries instead of skipping
+            # PHASE 1, the probe: the shared read-only view. A FrozenStore is the cache's answer; anything
+            # else is load_goals' own store handed through (no file, an unreadable journal, the cache off).
+            # A read FAULT (the file exists and did not read) comes back as (None, fault) through the
+            # boundary, its row filed once per episode: forget the gate so the next cycle retries this
+            # session, and go on to the others.
+            store, fault = jd.load_goals_shared_or_fault(sid)
+            if fault is not None:
+                _lift_seen.pop(sid, None)
                 continue
             if store.get("_unread"):                  # the store read but its journal did not (the mark):
                 _lift_seen.pop(sid, None)             # not a ruling on the files; the next cycle retries
-            nodes = store.get("nodes") or {}
-            stamped = [nd for nd in nodes.values()
-                       if nd.get("awaitingWhy") and nd.get("awaitingAt") and not nd.get("rolledUp")]
-            # A stamped node the roll-down folded under a RESOLVED ancestor: its card's story ended, but
-            # the stamp survives invisibly (every reader skips rolledUp) — lift it explicitly so the
-            # diary says why it went, instead of an unretired wait no surface can show (the user
-            # 2026-07-27). Guarded on the diary so an unmaterialized lift never re-fires each tick.
-            rolled = [nd for nd in nodes.values()
-                      if nd.get("awaitingWhy") and nd.get("rolledUp")
-                      and not _last_awaiting_is_lift(nd)]
+            if isinstance(store, jd.FrozenStore):
+                _lift_gate_stats["shared"] += 1
+            if not _lift_decisions(sid, s, store, now, tmux):
+                continue                              # nothing due (no candidate, or the common stamped case:
+                #                                       the dispatch still out): no writer load
+            # PHASE 2, the write: a fresh private copy, decided on again, and only its own decisions filed.
+            # The same boundary: a fault between the probe and this load forgets the gate and retries, and
+            # so does a copy that loaded without its journal (the mark, as on the probe above).
+            _lift_gate_stats["writer"] += 1
+            wstore, wfault = jd.load_goals_or_fault(sid)
+            if wfault is not None:
+                _lift_seen.pop(sid, None)
+                continue
+            if wstore.get("_unread"):
+                _lift_seen.pop(sid, None)
+            wnodes = wstore.get("nodes") or {}
             changed = False
-            for nd in rolled:
-                if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True):
-                    changed = True
-
-            def _top_of(x):
-                seen = set()
-                while x in nodes and nodes[x].get("parentId") is not None and x not in seen:
-                    seen.add(x); x = nodes[x]["parentId"]
-                return x
-            # SUPERSEDED PEER-WAIT LIFT (the user 2026-08-24): a peer's reply at/after a kind=peer (or
-            # kindless) stamp's WRITE time already ends that wait at every read — _goal_awaiting_stamp_full
-            # hides the stamp from the card and the chip, and the nudge walk (which reads the same
-            # predicate) then never arms the 6h wake. But that supersede was read-time only: it filed
-            # NOTHING, so the stamp sat invisibly forever — the closer was never re-nominated (its
-            # filed-since gate needs a diary row newer than closerLookT, and the newest row was the stamp
-            # itself), the plain-nudge fire gate read the RAW fields and vetoed every fire, and a LIVE
-            # session's Working card wore the quiet floor ("Paused — resumes when its wait ends")
-            # indefinitely — three live specimens on one board, one ~14h, breaking the recorded 2026-08-22
-            # promise that every Working card is nudged/woken until it lands (_dead_wait_block's docstring).
-            # File the lift the readers already act on: the reply is the wait's designed exact ending event
-            # (the reader's own rule), the lift row re-arms the closer's filed-since nomination (a re-audit
-            # can re-stamp a still-real wait with a fresh write time that out-orders the answer — the
-            # designed self-correction the read-only supersede promised but never delivered), and the
-            # ledger drop re-engages the nudge ladder exactly like the dispatch arms below. Peer-scoped
-            # exactly like the reader (job/agents/task/timer stamps stand through mail); DORMANT sessions
-            # never reach here (the sweep's own gate above) — the dead-wait conversion reads the stamp RAW
-            # on purpose (2026-08-23) and owns that ending.
-            answered = _peer_answered(sid)
-            for nd in (list(stamped) if answered[0] else ()):
-                reply_t = _peer_stamp_superseded(nd, answered)   # the superseding reply's time, or 0
-                if not reply_t:
+            for nid, top, drop_rec, end_ev in _lift_decisions(sid, s, wstore, now, tmux):
+                nd = wnodes.get(nid)
+                if nd is None:
                     continue
-                # the reply IS the evidence this lift rules on: journal it as the horizon, so a later
-                # closer assert on evidence newer than the reply stands whatever this row's arrival
-                if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True,
-                                     end_ev=reply_t):
+                # `end_ev` is the EVIDENCE HORIZON the decision ruled on (record_verdict end_ev, 2026-09-07:
+                # the superseding reply's time, the newest in-harness ending, the newest cited return; None
+                # for a rolled-up lift), journaled so a later closer assert on evidence newer than it stands
+                # whatever this row's arrival, and so the stand-down compares evidence to evidence
+                if jd.record_verdict(wstore, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True,
+                                     end_ev=end_ev):
                     changed = True
-                    stamped.remove(nd)
-                    _drop_auto_nudge_rec(_top_of(nd.get("id")))
-            if not stamped:
-                if changed:
-                    jd.rollup_status(store, False)
-                    jd.save_goals(sid, store)
-                    _mark_views_dirty()
-                continue
-            every = _bg_scan_all_cached(s["path"])
-            # the backend's lifecycle set (present-but-empty is AUTHORITATIVE — _bg_live_norm's own
-            # rule) and the CLI epoch it (re)started at: the restart-orphan reconciliation evidence
-            snap = tmux.get(sid) or {}
-            reg_ids = ({str(t.get("toolUseId") or "") for t in snap.get("bgTasks") or []
-                        if isinstance(t, dict)} if "bgTasks" in snap else None)
-            sp = _sdk_spawned_at(sid) or 0
-            # the launch ledger's stop tombstones (sdk_backend's bgLedgerEnded): a TaskStop suppresses
-            # the task notification, so the transcript never learns the Monitor ended — the hook did
-            tombs = ((_thread_reg(sid).get("bgLedgerEnded") or []) if reg_ids is not None else [])
-            if not every and reg_ids is None:
-                if changed:
-                    jd.rollup_status(store, False)
-                    jd.save_goals(sid, store)
-                    _mark_views_dirty()
-                continue
-            # RESTART-ORPHAN reconciliation (the user 2026-08-24): a kernel/backend restart kills
-            # tracked subagents and workflows WITH the claude process — the terminal record never
-            # lands, the transcript pairing shows them "running" forever, and the stamp orphaned
-            # (16h of "awaiting agents" over an empty registry, nothing reconciling). A
-            # transcript-"running" task ABSENT from a PRESENT lifecycle set died with its process;
-            # its return event IS the backend's (re)spawn — an exact event, not a timer. kind=job
-            # stays registry-blind below: the watcher dying is the carrier going, not the job
-            # returning.
-            dead = (set() if reg_ids is None else
-                    {t.get("id") for t in every
-                     if t.get("status") == "running" and t.get("id") and str(t.get("id")) not in reg_ids})
-            # a monitor past its recorded lifetime ceiling counts as RETURNED even with no terminal
-            # record (its CLI died mid-watch; the notification can never arrive) — see em._bg_expired
-            running = {t.get("id") for t in every
-                       if t.get("status") == "running" and not em._bg_expired(t, now)
-                       and t.get("id") not in dead}
-            # kind=job: expiry is not a return (see docstring) — only a real terminal record lifts
-            running_job = {t.get("id") for t in every if t.get("status") == "running"}
-            placed = _bg_placed_tops(sid, s["path"], [t.get("id") for t in every])
-            for nd in stamped:
-                born = nd.get("t") or 0
-                top = _top_of(nd.get("id"))
-                # The dispatches this goal owns. Placement is authoritative when the judge has spoken:
-                # a task placed under ANOTHER card can never retire this stamp (the user 2026-07-27:
-                # unrelated returns were lifting CI-wait stamps — one lifted the same minute it was
-                # re-asserted). The time window survives only for placement-unknown launches (the
-                # conservative pre-verdict shape): launched during the goal's life, at or before the
-                # stamp it explains — bounded by when that stamp was WRITTEN, not by its turn-trigger
-                # anchor, which the launches of that very turn all postdate (see _stamp_written_at).
-                horizon = _stamp_written_at(nd)
-                own = []
-                for t in every:
-                    p = placed.get(t.get("id"))
-                    if p is not None:
-                        if p == top:
-                            own.append(t)             # the goal's own thread, before OR after the stamp:
-                            #                           anything of its own still out keeps the wait honest
-                    elif born <= (t.get("t") or 0) <= horizon:
-                        own.append(t)
-                if not own:                           # nothing dispatched → not a background wait; leave it
-                    # …EXCEPT a stamp standing over an authoritatively EMPTY in-harness world: the
-                    # backend's lifecycle set present and empty, no live subagents, nothing running in
-                    # the transcript. Two shapes, one writer:
-                    #  - kind=agents (the user 2026-08-24): an agents-kind wait ends with task
-                    #    notifications, and with no dispatch recorded ANYWHERE no such event can ever
-                    #    arrive — the shape a closer mints when it misreads peer sessions as agents,
-                    #    orphaned for good the moment a restart clears the world it described. Same
-                    #    evidence-postdates-anchor rule as every lift: the (re)spawn must be newer than
-                    #    the stamp's anchor — or the transcript itself shows NOTHING running at all
-                    #    (2026-08-25 audit: the misread-peer-as-agents shape needs no respawn to prove
-                    #    the notification can never arrive; the pairing already did).
-                    #  - kind=task/job (2026-09-05): a closer stamped a top kind=job for a Monitor plus
-                    #    a background command the session ITSELF was running, the planner placed both
-                    #    launches on a sibling top, and this skip kept the stamp 17 hours over an empty
-                    #    registry with nothing pending anywhere (the wake below it never reached it —
-                    #    nudges off, top all-delegated). The deciding event is the LAST in-harness item
-                    #    ENDING after the stamp (_bg_ended_after: a terminal record, a Monitor's recorded
-                    #    ceiling, the launch ledger's stop tombstone, or the CLI respawn that killed
-                    #    everything) — a world already empty when the judge stamped is a wait on
-                    #    something the registry cannot see (a CI run), and stays the dead-man's. An
-                    #    ARMED kernel watch for this sid (a PR watch) is a carrier still running: its
-                    #    delivery is the ending, so the stamp stands. The owned-dispatch job rule below
-                    #    ("the watcher dying is the carrier going") is untouched: it needs a dispatch of
-                    #    the goal's OWN to protect, and this branch has none.
-                    _kind, _anchor0 = nd.get("awaitingKind"), nd.get("awaitingAt") or 0
-                    _empty = reg_ids is not None and not reg_ids and not snap.get("subagents") and not running
-                    # `_ended` = the newest in-harness ending this lift cites — its EVIDENCE HORIZON
-                    # (record_verdict end_ev, 2026-09-07). An agents lift resting on no recorded ending
-                    # at all (a stamp over a transcript where nothing ever ran, no respawn past the
-                    # anchor: the misread-peers-as-agents shape) rules "the authoritative registry shows
-                    # nothing running NOW and nothing ever ended", so the registry read's moment is what
-                    # it ruled through, the dead-man lift's own choice for the same shape of ruling
-                    # (_wake_goal), and journaled as read, never floored to the second: the gates compare
-                    # a horizon against raw evidence times, and int(now) disowned an assert triggered in
-                    # the read's own second. Journaling none instead (review find, 2026-09-08) left the gates
-                    # reading the row's anchor, which disowns nothing: a lagging closer's re-assert from a
-                    # segment triggered inside (anchor, lift) stood, the next pass re-lifted on the same
-                    # empty world, and every re-lift re-armed the nudge ladder: a permanent flap on no
-                    # new information, where main's arrival compare had suppressed the re-assert.
-                    _ended, _lift = 0, False
-                    if _empty and _kind == "agents" \
-                            and (sp > _anchor0 or not any(t.get("status") == "running" for t in every)):
-                        _ended = _bg_ended_after(every, tombs, sp, _anchor0, now, kind=_kind) or now
-                        _lift = True
-                    elif _empty and _kind in ("task", "job") and not _kernel_watch_armed(sid):
-                        # endings are measured from the stamp's WRITE time (_stamp_written_at), not
-                        # the audited turn's trigger: an item that returned mid-turn, before the
-                        # closer even wrote the stamp, is not the world emptying after it (review
-                        # find on #936, 2026-09-07)
-                        _ended = _bg_ended_after(every, tombs, sp, _stamp_written_at(nd), now, kind=_kind)
-                        _lift = bool(_ended)
-                    if _lift and jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now),
-                                                   lift=True, end_ev=_ended):
-                        changed = True
+                    if drop_rec:
+                        # The lift is NEW INFORMATION for the escalation ladder: the wait this goal's last
+                        # nudge/wake episode ended on has returned. Drop the goal's spent ledger record
+                        # (failed/moot/answered alike) so the next tick can re-engage — an idle session
+                        # never produces the genuine turn the arm-key dedup otherwise waits for, and a
+                        # latched record left its cards in Working forever (2026-08-16). Event-keyed and
+                        # bounded: record_verdict lifts a given stamp exactly once.
                         _drop_auto_nudge_rec(top)
-                    continue
-                live_set = running_job if nd.get("awaitingKind") == "job" else running
-                if any(t.get("id") in live_set for t in own):
-                    continue                          # at least one is genuinely still out
-                # The lift's event is a return the stamp was WAITING ON — one that landed after the
-                # stamp's ANCHOR (endT past the audited turn's trigger; a launch past it necessarily
-                # returned past it too; a kindless expiry "returns" at its recorded deadline). A
-                # dispatch already terminal in a turn the stamping judge had ALREADY AUDITED can't
-                # evidence the wait's end: the judge stamped knowing that completion, so the wait is
-                # about something else, and the goal keeps its stamp + 6h wake like any dispatch-less
-                # wait. The boundary is the anchor, NOT the write time (`horizon`): the write postdates
-                # the whole audited turn, so testing against it would also disown mid-turn and
-                # audit-lag returns the judge never saw (the suite pins those as lifting). Without
-                # this, a stamp about external cluster work lifted the same minute it was written off
-                # a workflow hours dead — and the lift row then MOOTED the nudge-failure evaluation,
-                # parking the card in Working with no reviver left (an idle experiment session,
-                # 2026-08-16).
-                _anchor = nd.get("awaitingAt") or 0
-
-                def _return_ev(t):
-                    # the evidence time of this dispatch's RETURN, the ONE conditioning both the "did
-                    # anything return after the anchor" test and the horizon this lift journals read
-                    # (review find, 2026-09-08: two hand-kept copies had drifted, and the older one still
-                    # counted an UNSPENT ceiling, so a dead watcher whose ceiling lay ahead lifted off a
-                    # horizon older than the anchor it retracted). A terminal record's endT; for a task
-                    # the pairing still shows running, the respawn that killed it (dead) or its recorded
-                    # ceiling once that has PASSED (expired); the launch as the floor (a launch past the
-                    # anchor returned past it). A ceiling that has not passed is never evidence: the
-                    # completion path leaves `deadline` in place, so a watcher that fired early carries a
-                    # FUTURE ceiling, and folding it unconditionally pushed the horizon past the clock;
-                    # a min() floor then journaled the tick time, arrival by another name.
-                    ev = max(t.get("endT") or 0, t.get("t") or 0)
-                    if t.get("status") == "running":
-                        if t.get("id") in dead:
-                            ev = max(ev, sp)
-                        if em._bg_expired(t, now):
-                            ev = max(ev, t.get("deadline") or 0)
-                    return ev
-
-                def _returned_after(t):
-                    return _return_ev(t) > _anchor
-                if not any(_returned_after(t) for t in own):
-                    continue
-                # THE STAND-DOWN RULE, joined (the 2026-08-19 audit): a writer whose evidence
-                # predates the diary yields — but only on a RE-ASSERT. The flap's signature is the
-                # closer re-affirming the wait AFTER a prior lift of this same stamp: everything
-                # this lift can cite (returns that preceded that lift) was already ruled on once,
-                # so lifting again off it produced the observed 2-3 second stamp↔lift flaps that
-                # reset the nudge ladder (fires 5s after a lift, three first-nudges in 21 minutes —
-                # the session had re-armed a watcher the ownership window cannot see). A FIRST
-                # stamp keeps the designed audit-lag lift: the write postdates the whole audited
-                # turn, and returns the judge never saw must still lift (the suite pins those).
-                _aw = [e for e in (nd.get("log") or []) if e.get("kind") == "awaiting"]
-                # the RE-ASSERT test asks about the diary's write order — was the wait re-affirmed after
-                # the lift was FILED — so arrival is the right timebase for these two…
-                _last_lift = max((e.get("at") or e.get("ev_t") or 0 for e in _aw if e.get("lift")), default=0)
-                _last_assert = max((e.get("at") or e.get("ev_t") or 0 for e in _aw if not e.get("lift")), default=0)
-                # …but the EVIDENCE test compares evidence to evidence: the newest return this lift can
-                # cite against the newest evidence any prior lift RULED ON (its journaled horizon,
-                # jd._wait_end_ev), never that lift's arrival. Read as arrival, a lift filed late for
-                # evidence up to T_ev claimed everything before its filing, so a return landing between
-                # T_ev and the filing was never citable and the stamp stayed on new information
-                # (2026-09-07). `<=`: a return AT the horizon is the very return that lift cited.
-                _horizon = max((jd._wait_end_ev(e) for e in _aw if e.get("lift")), default=0)
-                _evidence = max((_return_ev(t) for t in own), default=0)   # conditioned as _returned_after
-                if _last_lift and _last_assert > _last_lift and _evidence <= _horizon:
-                    continue                          # every citable return was already ruled on by that
-                    #                                   lift — re-lifting off it is the flap. A return
-                    #                                   NEWER than the last lift is new information even
-                    #                                   when the re-assert's WRITE postdates it by seconds:
-                    #                                   the closer's audit segment ended before the return
-                    #                                   landed (2026-08-25 audit — a watcher's stamp written
-                    #                                   17s after its merge notification stood 9.5h because
-                    #                                   write-time was read as the epistemic boundary)
-                # this lift's own horizon: the newest return it cites — the very `_evidence` the gate
-                # above measured, so what a lift journals is by construction what its stand-down compares
-                if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True,
-                                     end_ev=_evidence):
-                    changed = True
-                    # The lift is NEW INFORMATION for the escalation ladder: the wait this goal's last
-                    # nudge/wake episode ended on has returned. Drop the goal's spent ledger record
-                    # (failed/moot/answered alike) so the next tick can re-engage — an idle session
-                    # never produces the genuine turn the arm-key dedup otherwise waits for, and a
-                    # latched record left its cards in Working forever (2026-08-16). Event-keyed and
-                    # bounded: record_verdict lifts a given stamp exactly once.
-                    _drop_auto_nudge_rec(top)
-            if changed:
-                jd.rollup_status(store, False)
-                jd.save_goals(sid, store)
-                _mark_views_dirty()
-
+            if not changed:
+                _lift_gate_stats["noop"] += 1        # the store moved between the probe and the load
+                continue
+            jd.rollup_status(wstore, False)
+            jd.save_goals(sid, wstore)
+            _mark_views_dirty()
         except Exception:
             _lift_seen.pop(sid, None)                 # a raised ruling is not a ruling — re-run next cycle
             sys.stderr.write("awaiting-lift (session %s): %s\n" % (sid or "?", traceback.format_exc()))
+    for sid in [k for k in _lift_seen if k not in seen]:
+        del _lift_seen[sid]                           # the sid left the alive set: nothing to gate
+    for cache in (_BG_TOPS_CACHE, _PLACEMENT_IDX):    # ...and nothing to place for: release the pinned parse
+        for sid in list(cache):                       # list(): the handler threads fill these concurrently
+            if sid not in seen:
+                cache.pop(sid, None)
+
+
+def _lift_candidates(store):
+    """(stamped, rolled): the (node key, node) pairs one lift tick can rule on, from the store alone. The
+    KEY is what a decision names and what phase 2 resolves on the writer's copy, so a node whose `id`
+    field differs from its key is still found there rather than dropped as a no-op. `stamped` carries a
+    live awaiting stamp; `rolled` is a stamped node the roll-down left under a resolved ancestor whose
+    newest awaiting row is not yet a lift."""
+    nodes = store.get("nodes") or {}
+    stamped = [(nid, nd) for nid, nd in nodes.items()
+               if nd.get("awaitingWhy") and nd.get("awaitingAt") and not nd.get("rolledUp")]
+    # A stamped node the roll-down folded under a RESOLVED ancestor: its card's story ended, but the
+    # stamp survives invisibly (every reader skips rolledUp) — lift it explicitly so the diary says why
+    # it went, instead of an unretired wait no surface can show (the user 2026-07-27). Guarded on the
+    # diary so an unmaterialized lift never re-fires each tick.
+    rolled = [(nid, nd) for nid, nd in nodes.items()
+              if nd.get("awaitingWhy") and nd.get("rolledUp")
+              and not _last_awaiting_is_lift(nd)]
+    return stamped, rolled
+
+
+def _lift_decisions(sid, s, store, now, tmux):
+    """The lifts due for one alive session, decided on `store` and written NOWHERE: [(nid, top, drop_rec,
+    end_ev)], one per stamp the tick would retire. `top` is the node's top ancestor; `drop_rec` says whether
+    the goal's spent nudge record goes with the lift (the rolled-up arm drops none); `end_ev` is the
+    EVIDENCE HORIZON the decision ruled on (record_verdict end_ev: the superseding reply's time, the newest
+    in-harness ending, the newest cited return; None for a rolled-up lift, which cites no ending). Every rule
+    of the lift lives here, and the verdict gate is consulted read-only: jd.may_apply is exactly the gate
+    record_verdict asks before it appends, so a decision here is a record_verdict that would have returned
+    True. A decision is a function of (the store, the transcript's task pairing, the backend snapshot, the
+    postal wait maps, now) and of nothing this function writes, so _lift_spent_awaiting can run it on the
+    shared read-only view to learn whether a lift is due, then again on the writer's copy it loads, and file
+    the second run's decisions on that copy (the docstring there). Placement is read from the SAME store
+    object through _bg_placed_tops, so the stamps ruled on and the launches placed come from one version."""
+    out = []
+    nodes = store.get("nodes") or {}
+    stamped, rolled = _lift_candidates(store)
+    if not (stamped or rolled):
+        return out                                    # nothing to rule on: no peer read, no scan
+    for nid, nd in rolled:
+        if jd.may_apply(store, nd, "romp", "awaiting", _lift_ev_t(nd, now)):
+            out.append((nid, None, False, None))
+
+    def _top_of(x):
+        seen = set()
+        while x in nodes and nodes[x].get("parentId") is not None and x not in seen:
+            seen.add(x); x = nodes[x]["parentId"]
+        return x
+    # SUPERSEDED PEER-WAIT LIFT (the user 2026-08-24): a peer's reply at/after a kind=peer (or
+    # kindless) stamp's WRITE time already ends that wait at every read — _goal_awaiting_stamp_full
+    # hides the stamp from the card and the chip, and the nudge walk (which reads the same
+    # predicate) then never arms the 6h wake. But that supersede was read-time only: it filed
+    # NOTHING, so the stamp sat invisibly forever — the closer was never re-nominated (its
+    # filed-since gate needs a diary row newer than closerLookT, and the newest row was the stamp
+    # itself), the plain-nudge fire gate read the RAW fields and vetoed every fire, and a LIVE
+    # session's Working card wore the quiet floor ("Paused — resumes when its wait ends")
+    # indefinitely — three live specimens on one board, one ~14h, breaking the recorded 2026-08-22
+    # promise that every Working card is nudged/woken until it lands (_dead_wait_block's docstring).
+    # File the lift the readers already act on: the reply is the wait's designed exact ending event
+    # (the reader's own rule), the lift row re-arms the closer's filed-since nomination (a re-audit
+    # can re-stamp a still-real wait with a fresh write time that out-orders the answer — the
+    # designed self-correction the read-only supersede promised but never delivered), and the
+    # ledger drop re-engages the nudge ladder exactly like the dispatch arms below. Peer-scoped
+    # exactly like the reader (job/agents/task/timer stamps stand through mail); DORMANT sessions
+    # never reach here (the sweep's own gate) — the dead-wait conversion reads the stamp RAW
+    # on purpose (2026-08-23) and owns that ending.
+    answered = _peer_answered(sid)
+    for nid, nd in (list(stamped) if answered[0] else ()):
+        reply_t = _peer_stamp_superseded(nd, answered)   # the superseding reply's time, or 0
+        if not reply_t:
+            continue
+        # the reply IS the evidence this lift rules on: journal it as the horizon, so a later
+        # closer assert on evidence newer than the reply stands whatever this row's arrival
+        if jd.may_apply(store, nd, "romp", "awaiting", _lift_ev_t(nd, now)):
+            out.append((nid, _top_of(nid), True, reply_t))
+            stamped.remove((nid, nd))
+    if not stamped:
+        return out
+    every = _bg_scan_all_cached(s["path"])
+    # the backend's lifecycle set (present-but-empty is AUTHORITATIVE — _bg_live_norm's own
+    # rule) and the CLI epoch it (re)started at: the restart-orphan reconciliation evidence
+    snap = tmux.get(sid) or {}
+    reg_ids = ({str(t.get("toolUseId") or "") for t in snap.get("bgTasks") or []
+                if isinstance(t, dict)} if "bgTasks" in snap else None)
+    sp = _sdk_spawned_at(sid) or 0
+    # the launch ledger's stop tombstones (sdk_backend's bgLedgerEnded): a TaskStop suppresses
+    # the task notification, so the transcript never learns the Monitor ended — the hook did
+    tombs = ((_thread_reg(sid).get("bgLedgerEnded") or []) if reg_ids is not None else [])
+    if not every and reg_ids is None:
+        return out
+    # RESTART-ORPHAN reconciliation (the user 2026-08-24): a kernel/backend restart kills
+    # tracked subagents and workflows WITH the claude process — the terminal record never
+    # lands, the transcript pairing shows them "running" forever, and the stamp orphaned
+    # (16h of "awaiting agents" over an empty registry, nothing reconciling). A
+    # transcript-"running" task ABSENT from a PRESENT lifecycle set died with its process;
+    # its return event IS the backend's (re)spawn — an exact event, not a timer. kind=job
+    # stays registry-blind below: the watcher dying is the carrier going, not the job
+    # returning.
+    dead = (set() if reg_ids is None else
+            {t.get("id") for t in every
+             if t.get("status") == "running" and t.get("id") and str(t.get("id")) not in reg_ids})
+    # a monitor past its recorded lifetime ceiling counts as RETURNED even with no terminal
+    # record (its CLI died mid-watch; the notification can never arrive) — see em._bg_expired
+    running = {t.get("id") for t in every
+               if t.get("status") == "running" and not em._bg_expired(t, now)
+               and t.get("id") not in dead}
+    # kind=job: expiry is not a return (see docstring) — only a real terminal record lifts
+    running_job = {t.get("id") for t in every if t.get("status") == "running"}
+    placed = _bg_placed_tops(sid, s["path"], [t.get("id") for t in every], store=store)
+    for nid, nd in stamped:
+        born = nd.get("t") or 0
+        top = _top_of(nid)
+        # The dispatches this goal owns. Placement is authoritative when the judge has spoken:
+        # a task placed under ANOTHER card can never retire this stamp (the user 2026-07-27:
+        # unrelated returns were lifting CI-wait stamps — one lifted the same minute it was
+        # re-asserted). The time window survives only for placement-unknown launches (the
+        # conservative pre-verdict shape): launched during the goal's life, at or before the
+        # stamp it explains — bounded by when that stamp was WRITTEN, not by its turn-trigger
+        # anchor, which the launches of that very turn all postdate (see _stamp_written_at).
+        horizon = _stamp_written_at(nd)
+        own = []
+        for t in every:
+            p = placed.get(t.get("id"))
+            if p is not None:
+                if p == top:
+                    own.append(t)             # the goal's own thread, before OR after the stamp:
+                    #                           anything of its own still out keeps the wait honest
+            elif born <= (t.get("t") or 0) <= horizon:
+                own.append(t)
+        if not own:                           # nothing dispatched → not a background wait; leave it
+            # …EXCEPT a stamp standing over an authoritatively EMPTY in-harness world: the
+            # backend's lifecycle set present and empty, no live subagents, nothing running in
+            # the transcript. Two shapes, one writer:
+            #  - kind=agents (the user 2026-08-24): an agents-kind wait ends with task
+            #    notifications, and with no dispatch recorded ANYWHERE no such event can ever
+            #    arrive — the shape a closer mints when it misreads peer sessions as agents,
+            #    orphaned for good the moment a restart clears the world it described. Same
+            #    evidence-postdates-anchor rule as every lift: the (re)spawn must be newer than
+            #    the stamp's anchor — or the transcript itself shows NOTHING running at all
+            #    (2026-08-25 audit: the misread-peer-as-agents shape needs no respawn to prove
+            #    the notification can never arrive; the pairing already did).
+            #  - kind=task/job (2026-09-05): a closer stamped a top kind=job for a Monitor plus
+            #    a background command the session ITSELF was running, the planner placed both
+            #    launches on a sibling top, and this skip kept the stamp 17 hours over an empty
+            #    registry with nothing pending anywhere (the wake below it never reached it —
+            #    nudges off, top all-delegated). The deciding event is the LAST in-harness item
+            #    ENDING after the stamp (_bg_ended_after: a terminal record, a Monitor's recorded
+            #    ceiling, the launch ledger's stop tombstone, or the CLI respawn that killed
+            #    everything) — a world already empty when the judge stamped is a wait on
+            #    something the registry cannot see (a CI run), and stays the dead-man's. An
+            #    ARMED kernel watch for this sid (a PR watch) is a carrier still running: its
+            #    delivery is the ending, so the stamp stands. The owned-dispatch job rule below
+            #    ("the watcher dying is the carrier going") is untouched: it needs a dispatch of
+            #    the goal's OWN to protect, and this branch has none.
+            _kind, _anchor0 = nd.get("awaitingKind"), nd.get("awaitingAt") or 0
+            _empty = reg_ids is not None and not reg_ids and not snap.get("subagents") and not running
+            # `_ended` = the newest in-harness ending this lift cites — its EVIDENCE HORIZON
+            # (record_verdict end_ev, 2026-09-07). An agents lift resting on no recorded ending
+            # at all (a stamp over a transcript where nothing ever ran, no respawn past the
+            # anchor: the misread-peers-as-agents shape) rules "the authoritative registry shows
+            # nothing running NOW and nothing ever ended", so the registry read's moment is what
+            # it ruled through, the dead-man lift's own choice for the same shape of ruling
+            # (_wake_goal), and journaled as read, never floored to the second: the gates compare
+            # a horizon against raw evidence times, and int(now) disowned an assert triggered in
+            # the read's own second. Journaling none instead (review find, 2026-09-08) left the gates
+            # reading the row's anchor, which disowns nothing: a lagging closer's re-assert from a
+            # segment triggered inside (anchor, lift) stood, the next pass re-lifted on the same
+            # empty world, and every re-lift re-armed the nudge ladder: a permanent flap on no
+            # new information, where main's arrival compare had suppressed the re-assert.
+            _ended, _lift = 0, False
+            if _empty and _kind == "agents" \
+                    and (sp > _anchor0 or not any(t.get("status") == "running" for t in every)):
+                _ended = _bg_ended_after(every, tombs, sp, _anchor0, now, kind=_kind) or now
+                _lift = True
+            elif _empty and _kind in ("task", "job") and not _kernel_watch_armed(sid):
+                # endings are measured from the stamp's WRITE time (_stamp_written_at), not
+                # the audited turn's trigger: an item that returned mid-turn, before the
+                # closer even wrote the stamp, is not the world emptying after it (review
+                # find on #936, 2026-09-07)
+                _ended = _bg_ended_after(every, tombs, sp, _stamp_written_at(nd), now, kind=_kind)
+                _lift = bool(_ended)
+            if _lift and jd.may_apply(store, nd, "romp", "awaiting", _lift_ev_t(nd, now)):
+                out.append((nid, top, True, _ended))
+            continue
+        live_set = running_job if nd.get("awaitingKind") == "job" else running
+        if any(t.get("id") in live_set for t in own):
+            continue                          # at least one is genuinely still out
+        # The lift's event is a return the stamp was WAITING ON — one that landed after the
+        # stamp's ANCHOR (endT past the audited turn's trigger; a launch past it necessarily
+        # returned past it too; a kindless expiry "returns" at its recorded deadline). A
+        # dispatch already terminal in a turn the stamping judge had ALREADY AUDITED can't
+        # evidence the wait's end: the judge stamped knowing that completion, so the wait is
+        # about something else, and the goal keeps its stamp + 6h wake like any dispatch-less
+        # wait. The boundary is the anchor, NOT the write time (`horizon`): the write postdates
+        # the whole audited turn, so testing against it would also disown mid-turn and
+        # audit-lag returns the judge never saw (the suite pins those as lifting). Without
+        # this, a stamp about external cluster work lifted the same minute it was written off
+        # a workflow hours dead — and the lift row then MOOTED the nudge-failure evaluation,
+        # parking the card in Working with no reviver left (an idle experiment session,
+        # 2026-08-16).
+        _anchor = nd.get("awaitingAt") or 0
+
+        def _return_ev(t):
+            # the evidence time of this dispatch's RETURN, the ONE conditioning both the "did
+            # anything return after the anchor" test and the horizon this lift journals read
+            # (review find, 2026-09-08: two hand-kept copies had drifted, and the older one still
+            # counted an UNSPENT ceiling, so a dead watcher whose ceiling lay ahead lifted off a
+            # horizon older than the anchor it retracted). A terminal record's endT; for a task
+            # the pairing still shows running, the respawn that killed it (dead) or its recorded
+            # ceiling once that has PASSED (expired); the launch as the floor (a launch past the
+            # anchor returned past it). A ceiling that has not passed is never evidence: the
+            # completion path leaves `deadline` in place, so a watcher that fired early carries a
+            # FUTURE ceiling, and folding it unconditionally pushed the horizon past the clock;
+            # a min() floor then journaled the tick time, arrival by another name.
+            ev = max(t.get("endT") or 0, t.get("t") or 0)
+            if t.get("status") == "running":
+                if t.get("id") in dead:
+                    ev = max(ev, sp)
+                if em._bg_expired(t, now):
+                    ev = max(ev, t.get("deadline") or 0)
+            return ev
+
+        def _returned_after(t):
+            return _return_ev(t) > _anchor
+        if not any(_returned_after(t) for t in own):
+            continue
+        # THE STAND-DOWN RULE, joined (the 2026-08-19 audit): a writer whose evidence
+        # predates the diary yields — but only on a RE-ASSERT. The flap's signature is the
+        # closer re-affirming the wait AFTER a prior lift of this same stamp: everything
+        # this lift can cite (returns that preceded that lift) was already ruled on once,
+        # so lifting again off it produced the observed 2-3 second stamp↔lift flaps that
+        # reset the nudge ladder (fires 5s after a lift, three first-nudges in 21 minutes —
+        # the session had re-armed a watcher the ownership window cannot see). A FIRST
+        # stamp keeps the designed audit-lag lift: the write postdates the whole audited
+        # turn, and returns the judge never saw must still lift (the suite pins those).
+        _aw = [e for e in (nd.get("log") or []) if e.get("kind") == "awaiting"]
+        # the RE-ASSERT test asks about the diary's write order — was the wait re-affirmed after
+        # the lift was FILED — so arrival is the right timebase for these two…
+        _last_lift = max((e.get("at") or e.get("ev_t") or 0 for e in _aw if e.get("lift")), default=0)
+        _last_assert = max((e.get("at") or e.get("ev_t") or 0 for e in _aw if not e.get("lift")), default=0)
+        # …but the EVIDENCE test compares evidence to evidence: the newest return this lift can
+        # cite against the newest evidence any prior lift RULED ON (its journaled horizon,
+        # jd._wait_end_ev), never that lift's arrival. Read as arrival, a lift filed late for
+        # evidence up to T_ev claimed everything before its filing, so a return landing between
+        # T_ev and the filing was never citable and the stamp stayed on new information
+        # (2026-09-07). `<=`: a return AT the horizon is the very return that lift cited.
+        _horizon = max((jd._wait_end_ev(e) for e in _aw if e.get("lift")), default=0)
+        _evidence = max((_return_ev(t) for t in own), default=0)   # conditioned as _returned_after
+        if _last_lift and _last_assert > _last_lift and _evidence <= _horizon:
+            continue                          # every citable return was already ruled on by that
+            #                                   lift — re-lifting off it is the flap. A return
+            #                                   NEWER than the last lift is new information even
+            #                                   when the re-assert's WRITE postdates it by seconds:
+            #                                   the closer's audit segment ended before the return
+            #                                   landed (2026-08-25 audit — a watcher's stamp written
+            #                                   17s after its merge notification stood 9.5h because
+            #                                   write-time was read as the epistemic boundary)
+        # this lift's own horizon: the newest return it cites — the very `_evidence` the gate
+        # above measured, so what a lift journals is by construction what its stand-down compares
+        if jd.may_apply(store, nd, "romp", "awaiting", _lift_ev_t(nd, now)):
+            out.append((nid, top, True, _evidence))
+    return out
 
 
 _PREV_ALIVE = None                       # last tick's alive sids — a sid LEAVING is the death event
@@ -24091,7 +24181,8 @@ def _bg_placed_tops(sid, path, tids, store=None):
     is read into locals once, a fill builds a NEW dict from it and publishes a NEW tuple; nothing writes
     into an entry in place, so a reader holding the old tuple keeps a consistent (ps, store, map). Entries
     are dropped when a session asks with no live tids and the pinned parse is no longer the transcript's
-    current one (below: the pin the bound is for)."""
+    current one (below: the pin the bound is for), and when the sid leaves the alive set (the awaiting
+    lift's end-of-tick prune, _lift_spent_awaiting)."""
     sid = str(sid)
     tids = tuple(sorted(t for t in tids if t))
     if not tids or not path:

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1529,8 +1529,9 @@ class ViewBuilder(unittest.TestCase):
             "rompUuid": SID, "seq": 2, "lastNode": top, "nodes": nodes,
             "placements": placements, "status": status}))
         km._task_seg_cache.clear()
-        km._BG_TOPS_CACHE.clear()          # both classifier caches key on store/transcript file stats —
-        km._SESSION_STAMP_CACHE.clear()    # cleared so a same-stat rewrite can't serve a stale verdict
+        km._BG_TOPS_CACHE.clear()          # the launch-segment positives, the (parse, store)-keyed placement
+        km._SESSION_STAMP_CACHE.clear()    # memo and the stat-keyed stamp read: cleared so an earlier fixture's
+        #                                    answer under this sid, or a same-stat rewrite, serves nothing here
         saved = km._tmux_sessions
         km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
                                            "context": None, "compactPct": None, "color": None,

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -14,6 +14,13 @@ when the goal itself dispatched background work by stamp time and all of it came
 a CI run, a scheduled check-back or a peer handoff owns no such dispatches, never matches, and keeps its
 stamp (those remain the 6h backstop's job, the one case a timer is the only tool for).
 
+The tick reads in two phases: every rule is decided on the shared read-only store (jd.load_goals_shared,
+through the per-session boundary jd.load_goals_shared_or_fault) and written nowhere; the writer's copy
+(jd.load_goals, through jd.load_goals_or_fault) is loaded only when that decision found a lift due, decided
+on again, and only that second decision is filed. The LiftGate class counts the two loaders apart. Both
+boundaries answer (None, fault) for a store that exists and cannot be read, and the tick then forgets its
+inputs gate for the session and retries next cycle instead of ruling on an empty store.
+
 SYNTHETIC fixtures only: placeholder UUIDs, invented task descriptions.
 """
 import contextlib
@@ -61,6 +68,16 @@ def _notification(tid, t):
             "</task-notification>" % (tid, tid))
     return {"type": "user", "timestamp": _iso(t), "uuid": "n" + tid, "parentUuid": None,
             "message": {"role": "user", "content": body}}
+
+
+def _dispatch(tid, t):
+    """The assistant tool_use block that DISPATCHED a background agent: the record _seg_of_tool_uses
+    resolves a launch's segment from (the ack and the notification alone name no segment)."""
+    return {"type": "assistant", "timestamp": _iso(t), "uuid": "d" + tid, "parentUuid": None,
+            "message": {"role": "assistant", "content": [
+                {"type": "tool_use", "id": tid, "name": "Agent",
+                 "input": {"description": "a dispatched investigation", "prompt": "look into it",
+                           "run_in_background": True}}]}}
 
 
 def _monitor(tid, t, timeout_ms=300000):
@@ -274,7 +291,7 @@ class AwaitingLift(unittest.TestCase):
         self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
         self._seed(why="waiting on the release pipeline to go green, then will tag")
         saved = km._bg_placed_tops
-        km._bg_placed_tops = lambda sid, path, tids: {"t1": SID + ":gOTHER"}
+        km._bg_placed_tops = lambda sid, path, tids, store=None: {"t1": SID + ":gOTHER"}
         try:
             self._tick()
         finally:
@@ -285,7 +302,7 @@ class AwaitingLift(unittest.TestCase):
         self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
         self._seed()
         saved = km._bg_placed_tops
-        km._bg_placed_tops = lambda sid, path, tids: {"t1": self.gid}
+        km._bg_placed_tops = lambda sid, path, tids, store=None: {"t1": self.gid}
         try:
             self._tick()
         finally:
@@ -297,7 +314,7 @@ class AwaitingLift(unittest.TestCase):
         self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK), _launch("t2", STAMP + 50)])
         self._seed()
         saved = km._bg_placed_tops
-        km._bg_placed_tops = lambda sid, path, tids: {"t1": self.gid, "t2": self.gid}
+        km._bg_placed_tops = lambda sid, path, tids, store=None: {"t1": self.gid, "t2": self.gid}
         try:
             self._tick()
         finally:
@@ -720,7 +737,7 @@ class LiftHorizonJournaled(_HorizonBase):
         self.assertEqual(self._lifts()[-1].get("endEv"), BACK, "the respawn is the ending it cites")
         # the task/job shape (2026-09-05): every launch placed on a sibling top, the world emptied
         # after the stamp — the horizon is the newest terminal record
-        km._bg_placed_tops = lambda sid, path, tids: {t: self.other for t in tids}
+        km._bg_placed_tops = lambda sid, path, tids, store=None: {t: self.other for t in tids}
         self.spawn = STAMP - 50
         self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
         self._seed("job")
@@ -934,6 +951,545 @@ class LiftStandsDown(unittest.TestCase):
         self.assertIsNone(self._stamp(), "first-stamp audit-lag lift preserved")
 
 
+class LiftGate(unittest.TestCase):
+    """The inputs gate in front of the lift's store read (_sid_inputs_fp / _lift_seen) and the two-phase
+    read behind it. The ruling reads the store, the override journal, the transcript, the postal log and
+    the SDK reg, plus two live facts (the registry's task ids and subagent count, and whether each running
+    dispatch's deadline has passed), so a session whose fingerprint is unchanged since the last ruling is
+    skipped before the parse, stamped or not. Every writer moves an input (rename publishes, journal
+    appends, transcript records), so a lift happens on exactly the events it did before.
+
+    Behind the gate, phase 1 PROBES the shared read-only view (jd.load_goals_shared) and decides on it;
+    phase 2 loads the WRITER's copy (jd.load_goals) only when that decision found a lift due, decides again
+    on the copy, and files that decision. The two loaders are counted apart through wrappers: `_tick`
+    returns the WRITER loads a tick took and leaves the probe count in `self.last_probes`. A gated tick is
+    zero of both; a stamped session whose dispatch is still out is one probe and zero writer loads on the
+    tick that reads it, and gated after that until an input moves; a due lift is one probe and one writer
+    load. jd.load_goals_shared hands a read to load_goals when there is no store file, so an absent store
+    counts one writer-style load (the fallback, not a lift). In-place rewrites after a tick go through
+    save_goals, a journal append, or os.utime (coarse-mtime filesystems in CI)."""
+
+    def setUp(self):
+        AwaitingLift.setUp(self)
+        self.calls = []                                  # writer loads (jd.load_goals, fallbacks included)
+        self.probes = []                                 # shared probes (jd.load_goals_shared)
+        real = km.jd.load_goals
+        def counted(fsid):
+            self.calls.append(fsid)
+            return real(fsid)
+        km.jd.load_goals = counted
+        self.addCleanup(setattr, km.jd, "load_goals", real)
+        real_shared = km.jd.load_goals_shared
+        def probed(fsid):
+            self.probes.append(fsid)
+            return real_shared(fsid)
+        km.jd.load_goals_shared = probed
+        self.addCleanup(setattr, km.jd, "load_goals_shared", real_shared)
+        self.last_probes = 0
+        self.stats0 = km.jd.shared_store_stats()
+
+    def tearDown(self):
+        # THE POISON CANARY, for every test here: the probe reads the shared view and writes nothing to it,
+        # and the frozen store never reaches save_goals (either would switch the cache off and file a row)
+        st = km.jd.shared_store_stats()
+        self.assertEqual(st["poisoned"] - self.stats0["poisoned"], 0, "no write reached the shared view")
+        self.assertEqual(st["off"], 0, "the shared cache is still on")
+        AwaitingLift.tearDown(self)
+
+    _transcript = AwaitingLift._transcript
+    _seed = AwaitingLift._seed
+    _stamp = AwaitingLift._stamp
+
+    def _tick(self, now=BACK + 100, snap=None):
+        """One lift tick; returns how many WRITER loads it took and records the probes in last_probes."""
+        before, pbefore = len(self.calls), len(self.probes)
+        km._lift_spent_awaiting(now, {SID: ({"state": ""} if snap is None else snap)})
+        self.last_probes = len(self.probes) - pbefore
+        return len(self.calls) - before
+
+    def _lift_rows(self):
+        log = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())["nodes"][self.gid]["log"]
+        return [e for e in log if e.get("kind") == "awaiting" and e.get("lift")]
+
+    def _seed_unstamped(self, size=None):
+        """An unstamped store, written in place. `size` pads the node's text so the file is exactly that
+        many bytes: a same-size rewrite holds st_size still, so only the key's other components can move."""
+        nd = {"id": self.gid, "text": "a goal", "parentId": None, "nodeComplete": False,
+              "blocked": False, "cleared": False, "trail": [], "t": BORN, "mt": BORN, "log": []}
+        store = {"rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {self.gid: nd}}
+        if size is not None:
+            pad = size - len(json.dumps(store).encode())
+            self.assertGreaterEqual(pad, 0, "the stamped store must be the longer one")
+            nd["text"] += " " * pad                      # one ASCII byte per space, inside the JSON string
+            self.assertEqual(len(json.dumps(store).encode()), size)
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(store))
+
+    def _stamped_bytes(self):
+        """The bytes of a stamped store (the node _stamped_node builds), for a same-size rewrite."""
+        return json.dumps({"rompUuid": SID, "seq": 1, "placements": {}, "status": {},
+                           "nodes": {self.gid: self._stamped_node()}}).encode()
+
+    def _stamped_node(self, why="waiting on a dispatched investigation"):
+        return {"id": self.gid, "text": "a goal", "parentId": None, "nodeComplete": False,
+                "blocked": False, "cleared": False, "trail": [], "t": BORN, "mt": BORN,
+                "awaitingWhy": why, "awaitingAt": STAMP,
+                "log": [{"ev_t": STAMP, "src": "closer", "kind": "awaiting", "why": why, "at": STAMP}]}
+
+    def _returned_dispatch(self):
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+
+    # ---- the saving: an unchanged, unstamped session costs stats, not a parse ----
+    def test_an_unchanged_unstamped_store_is_probed_once(self):
+        self._returned_dispatch()
+        self._seed_unstamped()
+        skips = km._lift_gate_stats["skip"]
+        self.assertEqual(self._tick(), 0, "the first tick has to look, on the shared view: no writer load")
+        self.assertEqual(self.last_probes, 1)
+        self.assertEqual(self._tick(), 0, "same inputs as the last ruling: no read")
+        self.assertEqual(self.last_probes, 0)
+        self.assertEqual(self._tick(), 0)
+        self.assertEqual(self.last_probes, 0)
+        self.assertEqual(km._lift_gate_stats["skip"] - skips, 2, "the /perf counter saw both skips")
+        self.assertIn(SID, km._lift_seen, "the entry remembers the inputs it ruled on")
+
+    def test_a_missing_store_is_gated_until_it_appears(self):
+        self._returned_dispatch()
+        before = dict(km._lift_gate_stats)
+        self.assertEqual(self._tick(), 1)               # no file: the shared loader hands the read to
+        self.assertEqual(self.last_probes, 1)           #   load_goals, which answers a fresh empty store
+        after = km._lift_gate_stats
+        self.assertEqual((after["load"] - before["load"], after["shared"] - before["shared"]), (1, 0),
+                         "the read is counted; the shared cache did not answer it (load_goals' own store)")
+        self.assertEqual(self._tick(), 0, "still no file: the absent identity is a stable key")
+        self.assertEqual(self.last_probes, 0)
+        self._seed()                                     # the store is born stamped (a rename in production)
+        self.assertEqual(self._tick(), 1, "the store appeared: probed, a lift is due, one writer load")
+        self.assertIsNone(self._stamp(), "...and the lift proceeded exactly as without the gate")
+
+    # ---- every writer moves the key ----
+    def test_a_save_goals_publish_reloads(self):
+        self._returned_dispatch()
+        self._seed_unstamped()
+        self.assertEqual((self._tick(), self.last_probes), (0, 1))
+        self.assertEqual((self._tick(), self.last_probes), (0, 0))
+        store = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())
+        store["nodes"][self.gid] = self._stamped_node()
+        km.jd.save_goals(SID, store)                     # the closer's publish: a rename, new identity
+        self.assertEqual(self._tick(), 1, "the publish moved the store's identity: probed, a lift due, one writer load")
+        self.assertEqual(self.last_probes, 1)
+        self.assertIsNone(self._stamp(), "the returned dispatch lifts the fresh stamp")
+
+    def test_a_journal_restore_row_reloads_and_lifts(self):
+        self._returned_dispatch()
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
+            {"rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {}}))
+        self.assertEqual((self._tick(), self.last_probes), (0, 1))
+        self.assertEqual((self._tick(), self.last_probes), (0, 0))
+        # an undo-clear restore rides the journal with its node payload: a stamped node can come back
+        # through the replay alone, with the store file untouched
+        km.jd.append_restore(SID, {self.gid: self._stamped_node()}, {}, BACK + 50)
+        self.assertEqual(self._tick(), 1, "the journal grew: probed, the restored stamp is due, one writer load")
+        self.assertEqual(self.last_probes, 1)
+        nodes = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())["nodes"]
+        self.assertIn(self.gid, nodes, "the restored node was saved back")
+        self.assertIsNone(nodes[self.gid].get("awaitingWhy") or None, "...and its stamp lifted on the return")
+
+    def test_a_journal_block_row_reloads(self):
+        self._returned_dispatch()
+        self._seed_unstamped()
+        self.assertEqual((self._tick(), self.last_probes), (0, 1))
+        self.assertEqual((self._tick(), self.last_probes), (0, 0))
+        km.jd.append_block(SID, self.gid, "nudge", "a status ask went unanswered", BACK + 50)
+        self.assertEqual((self._tick(), self.last_probes), (0, 1),
+                         "a block row is a journal append: the key moved, probed again; nothing due")
+        self.assertEqual((self._tick(), self.last_probes), (0, 0), "nothing stamped after the replay either: gated again")
+
+    def test_a_journal_override_row_reloads(self):
+        self._returned_dispatch()
+        self._seed_unstamped()
+        self.assertEqual((self._tick(), self.last_probes), (0, 1))
+        self.assertEqual((self._tick(), self.last_probes), (0, 0))
+        km.jd.append_override(SID, self.gid, "resolve", BACK + 50)   # a user click's journal row
+        self.assertEqual((self._tick(), self.last_probes), (0, 1),
+                         "a user override is a journal append: the key moved, probed again; nothing due")
+        self.assertEqual((self._tick(), self.last_probes), (0, 0), "the replayed resolve stamps nothing: gated again")
+
+    def test_a_same_size_in_place_rewrite_reloads(self):
+        """st_mtime_ns is in the key: a rewrite that keeps the inode AND the byte count (the store's own
+        path opened for writing, stamped bytes exactly as long as the unstamped ones) still moves the
+        identity. The utime stands in for the clock on a coarse-mtime filesystem (CI)."""
+        self._returned_dispatch()
+        stamped = self._stamped_bytes()
+        self._seed_unstamped(size=len(stamped))
+        gp = km.jd.GOALDIR / (SID + ".json")
+        old = gp.stat()
+        self.assertEqual((self._tick(), self.last_probes), (0, 1))
+        self.assertEqual((self._tick(), self.last_probes), (0, 0))
+        gp.write_bytes(stamped)                          # same path, same inode, same byte count
+        os.utime(gp, ns=(old.st_atime_ns, old.st_mtime_ns + 1_000_000))
+        new = gp.stat()
+        self.assertEqual((new.st_ino, new.st_size), (old.st_ino, old.st_size), "only the mtime moved")
+        self.assertEqual(self._tick(), 1, "the mtime alone moved the identity: probed, a lift due, one writer load")
+        self.assertIsNone(self._stamp())
+
+    def test_a_same_size_rename_with_the_old_mtime_reloads(self):
+        """st_ino is in the key: a rename publish of the same byte count whose mtime is set back to the
+        old file's (a restored backup keeps its timestamps; save_goals publishes by rename) still moves
+        the identity."""
+        self._returned_dispatch()
+        stamped = self._stamped_bytes()
+        self._seed_unstamped(size=len(stamped))
+        gp = km.jd.GOALDIR / (SID + ".json")
+        old = gp.stat()
+        self.assertEqual((self._tick(), self.last_probes), (0, 1))
+        self.assertEqual((self._tick(), self.last_probes), (0, 0))
+        tmp = gp.with_name(gp.name + ".tmp")
+        tmp.write_bytes(stamped)
+        tmp.rename(gp)                                   # a new inode under the same path
+        os.utime(gp, ns=(old.st_atime_ns, old.st_mtime_ns))
+        new = gp.stat()
+        self.assertNotEqual(new.st_ino, old.st_ino, "the rename brought a new inode")
+        self.assertEqual((new.st_mtime_ns, new.st_size), (old.st_mtime_ns, old.st_size), "only the inode moved")
+        self.assertEqual(self._tick(), 1, "the inode alone moved the identity: probed, a lift due, one writer load")
+        self.assertIsNone(self._stamp())
+
+    # ---- a stamped store is gated on the same terms, and the tick that does read it decides on the
+    #      shared view alone ----
+    def test_a_stamped_store_with_unchanged_inputs_is_skipped_too(self):
+        self._transcript([_launch("t1", LAUNCH)])       # still out: the stamp stands
+        self._seed()
+        before = dict(km._lift_gate_stats)
+        self.assertEqual((self._tick(), self.last_probes), (0, 1),
+                         "the first tick has to look: one probe, nothing due, no writer load")
+        self.assertIsNotNone(self._stamp())
+        self.assertEqual((self._tick(), self.last_probes), (0, 0),
+                         "store, journal, transcript and live facts unchanged: same ruling, no read")
+        self.assertEqual((self._tick(), self.last_probes), (0, 0))
+        self.assertIsNotNone(self._stamp(), "the stamp stands through the skipped ticks")
+        after = km._lift_gate_stats
+        self.assertEqual(after["load"] - before["load"], 1, "one session-cycle read the store")
+        self.assertEqual(after["shared"] - before["shared"], 1, "...answered by the shared cache")
+        self.assertEqual(after["writer"] - before["writer"], 0, "...and none loaded the writer's copy")
+        self.assertEqual(after["noop"] - before["noop"], 0)
+        self.assertIn(SID, km._lift_seen)
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])   # the return lands: an input moved
+        self.assertEqual((self._tick(), self.last_probes), (1, 1),
+                         "a fingerprint input moved: probed, the lift is due, one writer load")
+        self.assertIsNone(self._stamp(), "...and the lift proceeded exactly as without the gate")
+
+    def test_a_due_lift_takes_one_writer_load_and_files_once(self):
+        self._returned_dispatch()
+        self._seed()
+        km._mark_auto_nudged(self.gid, "SOME-ARM-TURN", 3, at=BACK - 50)
+        d = dict(km._auto_nudge_data())
+        n = dict(d.get("nudged", {}))
+        n[self.gid] = dict(n[self.gid], moot=True)      # a spent record the lift erases (2026-08-16)
+        d["nudged"] = n
+        km._write_auto_nudge(d)
+        before = dict(km._lift_gate_stats)
+        self.assertEqual(self._tick(), 1, "the probe found the lift due: exactly one writer load")
+        self.assertEqual(self.last_probes, 1)
+        self.assertIsNone(self._stamp(), "...and it lifted")
+        self.assertEqual(len(self._lift_rows()), 1, "one lift row, filed on the writer's copy")
+        self.assertNotIn(self.gid, km._auto_nudge_data().get("nudged", {}), "the spent nudge record dropped once")
+        after = km._lift_gate_stats
+        self.assertEqual((after["writer"] - before["writer"], after["noop"] - before["noop"]), (1, 0))
+        self.assertEqual((self._tick(), self.last_probes), (0, 1),
+                         "the save moved the key: probed once more, nothing stamped, no writer load")
+        self.assertEqual((self._tick(), self.last_probes), (0, 0), "...then gated")
+        self.assertEqual(len(self._lift_rows()), 1, "the lift was filed exactly once")
+
+    def test_a_node_keyed_apart_from_its_id_field_still_lifts(self):
+        # a decision names the store's node KEY, which phase 2 resolves on the writer's copy; a node whose
+        # `id` field disagrees with its key (a hand-edited or migrated store) must not be dropped as a noop
+        self._returned_dispatch()
+        nd = dict(self._stamped_node(), id=SID + ":renamed")
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
+            {"rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {self.gid: nd}}))
+        before = dict(km._lift_gate_stats)
+        self.assertEqual((self._tick(), self.last_probes), (1, 1))
+        self.assertIsNone(self._stamp(), "found by key on the writer's copy: lifted")
+        self.assertEqual(km._lift_gate_stats["noop"] - before["noop"], 0)
+
+    def test_the_rolled_up_arm_lifts_with_one_writer_load(self):
+        self._transcript([])
+        nd = {"id": self.gid, "text": "a goal", "parentId": None, "nodeComplete": True,
+              "blocked": False, "cleared": False, "rolledUp": True, "trail": [], "t": BORN, "mt": BORN,
+              "awaitingWhy": "a wait the roll-down froze", "awaitingAt": STAMP,
+              "log": [{"ev_t": STAMP, "src": "closer", "kind": "awaiting",
+                       "why": "a wait the roll-down froze", "at": STAMP}]}
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
+            {"rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {self.gid: nd}}))
+        self.assertEqual((self._tick(), self.last_probes), (1, 1), "the frozen stamp is due: one writer load")
+        self.assertEqual(len(self._lift_rows()), 1)
+        self.assertEqual((self._tick(), self.last_probes), (0, 1), "diary-guarded: probed, nothing due")
+        self.assertEqual((self._tick(), self.last_probes), (0, 0), "...and no candidate, so gated")
+
+    def test_the_peer_superseded_arm_lifts_with_one_writer_load(self):
+        self._transcript([])
+        self._seed(why="waiting on the peer's answer", kind="peer")   # written at STAMP
+        saved = km._peer_answered
+        km._peer_answered = lambda sid: (BACK, {})       # the peer replied after the stamp was written
+        try:
+            self.assertEqual((self._tick(), self.last_probes), (1, 1), "the reply ended the wait: one writer load")
+            self.assertIsNone(self._stamp())
+            self.assertEqual(len(self._lift_rows()), 1)
+            self.assertEqual((self._tick(), self.last_probes), (0, 1))
+            self.assertEqual((self._tick(), self.last_probes), (0, 0))
+        finally:
+            km._peer_answered = saved
+
+    def test_the_empty_registry_arm_lifts_with_one_writer_load(self):
+        # the dispatch-less agents stamp over an authoritatively empty lifecycle set (RestartReconcile)
+        self._transcript([])
+        self._seed(why="workers still building the pieces; merges when they report", kind="agents")
+        saved = km._sdk_spawned_at
+        km._sdk_spawned_at = lambda sid: BACK             # the backend respawned after the stamp
+        try:
+            self.assertEqual(self._tick(snap={"state": "", "bgTasks": []}), 1, "the orphan is due: one writer load")
+            self.assertEqual(self.last_probes, 1)
+            self.assertIsNone(self._stamp())
+            self.assertEqual(self._tick(snap={"state": "", "bgTasks": []}), 0)
+        finally:
+            km._sdk_spawned_at = saved
+
+    def test_a_writer_racing_between_the_probe_and_the_load_costs_a_reload_never_a_wrong_lift(self):
+        """Phase 1 decides on the shared view; phase 2 decides AGAIN on the writer's copy and files only
+        that. A closer publishing between the two (here, placing the deciding launch under ANOTHER card,
+        which makes it not this goal's dispatch) must not have its verdict overridden by the probe's
+        stale decision: the writer load decides nothing (`noop`), the stamp stands, and the next tick's
+        probe (on the moved store) agrees."""
+        # chained through parentUuid: the parse walks the transcript graph from its leaf, so only a chained
+        # record reaches a segment (the scan-based fixtures elsewhere in this module need no chain)
+        recs = [_dispatch("t1", LAUNCH - 1), _launch("t1", LAUNCH), _notification("t1", BACK)]
+        for prev, rec in zip(recs, recs[1:]):
+            rec["parentUuid"] = prev["uuid"]
+        self._transcript(recs)
+        self._seed(why="waiting on the release pipeline to go green, then will tag")
+        ps = km._parse(self.path, SID, BACK + 100)
+        seg = km._seg_of_tool_uses(ps, {}, ["t1"])["t1"]  # the segment the dispatch resolves to
+        other = SID + ":gOTHER"
+        real = km.jd.load_goals                          # LiftGate's counting wrapper
+        raced = []
+        def racing(fsid):
+            if not raced:
+                raced.append(fsid)
+                pub = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())
+                pub["nodes"][other] = {"id": other, "text": "another goal", "parentId": None,
+                                       "nodeComplete": False, "blocked": False, "cleared": False,
+                                       "trail": [], "t": BORN, "mt": BORN, "log": []}
+                pub["placements"] = {seg: other}         # the closer places the launch under the other card
+                km.jd.save_goals(SID, pub)
+            return real(fsid)
+        km.jd.load_goals = racing
+        before = dict(km._lift_gate_stats)
+        self.assertEqual(self._tick(), 1, "the probe (pre-publish) found a lift due: one writer load")
+        self.assertEqual(len(raced), 1)
+        self.assertIsNotNone(self._stamp(), "the writer's copy places the launch elsewhere: no lift filed")
+        self.assertEqual(self._lift_rows(), [], "nothing filed from the stale decision")
+        after = km._lift_gate_stats
+        self.assertEqual((after["writer"] - before["writer"], after["noop"] - before["noop"]), (1, 1))
+        km.jd.load_goals = real
+        self.assertEqual((self._tick(), self.last_probes), (0, 1),
+                         "the publish moved the key: probed on the moved store, nothing due, no writer load")
+        self.assertIsNotNone(self._stamp(), "the other card's dispatch never retires this wait")
+
+    # ---- the verdict gate, read in phase 1: a lift record_verdict would refuse is decided nowhere ----
+    def _set_floor(self, t):
+        """A user follow-up on the card at `t` (followupAt): the verdict gate's evidence floor. A lift's
+        evidence time is the stamp's anchor (_lift_ev_t), so a floor past the anchor makes record_verdict
+        refuse the lift; phase 1 asks the same gate (jd.may_apply) and must decide nothing, so the writer's
+        copy is never loaded for a lift that would not file."""
+        gp = km.jd.GOALDIR / (SID + ".json")
+        store = json.loads(gp.read_text())
+        store["nodes"][self.gid]["followupAt"] = t
+        gp.write_text(json.dumps(store))
+
+    def _assert_refused_on_the_shared_view(self, snap=None):
+        before = dict(km._lift_gate_stats)
+        self.assertEqual((self._tick(snap=snap), self.last_probes), (0, 1),
+                         "the gate refuses the lift on the shared view: one probe, no writer load")
+        self.assertIsNotNone(self._stamp(), "the stamp stands")
+        self.assertEqual(self._lift_rows(), [], "nothing filed")
+        after = km._lift_gate_stats
+        self.assertEqual((after["writer"] - before["writer"], after["noop"] - before["noop"]), (0, 0),
+                         "no writer load, so no noop either: the refusal cost the probe alone")
+        self.assertEqual((self._tick(snap=snap), self.last_probes), (0, 0), "...and the session is gated")
+        # the two gates agree: record_verdict on the writer's copy refuses what phase 1 did not decide
+        w = km.jd.load_goals(SID)
+        nd = w["nodes"][self.gid]
+        self.assertFalse(km.jd.record_verdict(w, nd, "romp", "awaiting", km._lift_ev_t(nd, BACK + 100), lift=True))
+
+    def test_a_floor_refused_return_lift_is_decided_on_the_shared_view_and_costs_no_writer_load(self):
+        self._returned_dispatch()                        # the cited-return arm: the dispatch is back...
+        self._seed()
+        self._set_floor(STAMP + 10)                      # ...but the user followed up after the stamp
+        self._assert_refused_on_the_shared_view()
+
+    def test_a_floor_refused_rolled_up_lift_costs_no_writer_load(self):
+        self._transcript([])
+        why = "a wait the roll-down froze"
+        nd = dict(self._stamped_node(why), nodeComplete=True, rolledUp=True, followupAt=STAMP + 10)
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
+            {"rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {self.gid: nd}}))
+        self._assert_refused_on_the_shared_view()
+
+    def test_a_floor_refused_peer_superseded_lift_costs_no_writer_load(self):
+        self._transcript([])
+        self._seed(why="waiting on the peer's answer", kind="peer")
+        self._set_floor(STAMP + 10)
+        saved = km._peer_answered
+        km._peer_answered = lambda sid: (BACK, {})       # the peer replied after the stamp was written
+        try:
+            self._assert_refused_on_the_shared_view()
+        finally:
+            km._peer_answered = saved
+
+    def test_a_floor_refused_empty_registry_lift_costs_no_writer_load(self):
+        self._transcript([])
+        self._seed(why="workers still building the pieces; merges when they report", kind="agents")
+        self._set_floor(STAMP + 10)
+        saved = km._sdk_spawned_at
+        km._sdk_spawned_at = lambda sid: BACK             # the backend respawned after the stamp
+        try:
+            self._assert_refused_on_the_shared_view(snap={"state": "", "bgTasks": []})
+        finally:
+            km._sdk_spawned_at = saved
+
+    def test_a_dormant_session_is_not_gated_or_recorded(self):
+        self._seed_unstamped()
+        before = len(self.calls)
+        km._lift_spent_awaiting(BACK + 100, {SID: None})     # dormant: no tmux/SDK row for the sid
+        self.assertEqual(len(self.calls) - before, 0)
+        self.assertNotIn(SID, km._lift_seen, "dormant: skipped before the gate, nothing remembered")
+
+    def test_a_failed_probe_records_no_skip(self):
+        self._returned_dispatch()
+        self._seed_unstamped()
+        probed = km.jd.load_goals_shared
+        def boom(fsid):
+            self.probes.append(fsid)
+            raise RuntimeError("synthetic read failure")
+        km.jd.load_goals_shared = boom
+        with contextlib.redirect_stderr(io.StringIO()) as err:
+            self.assertEqual((self._tick(), self.last_probes), (0, 1))
+        self.assertIn("awaiting-lift", err.getvalue(), "the failure is reported, as before")
+        self.assertNotIn(SID, km._lift_seen, "an error is never cached as a skip")
+        km.jd.load_goals_shared = probed
+        self.assertEqual((self._tick(), self.last_probes), (0, 1), "the next tick retries the read")
+
+    # ---- a read that FAULTED, or a load that FELL BACK, is no better than a ruling that raised ----
+    def _read_fails_once(self, target):
+        """Patch the two reads of `target` so each raises OSError ONCE (the EMFILE/EIO shape a busy kernel
+        meets) and every later read is real: jd._disk_read, the shared loader's descriptor read (of the
+        store, or of the journal through _journal_read); and Path.read_text, load_goals' store read and
+        _replay_overrides' journal read. A STORE fault raises out of either loader (load_goals never answers
+        an empty store for a file it could not read) and the lift's boundary answers (None, fault); a
+        JOURNAL fault is handed from the shared loader to load_goals, whose replay skips the journal,
+        `_unread`-marked. Returns the counters of raised reads (`fired` in total, `disk` and `text`
+        apart)."""
+        real = Path.read_text
+        real_disk = km.jd._disk_read
+        state = {"fired": 0, "text": 0, "disk": 0}
+        def flaky(p, *a, **k):
+            if p == target and not state["text"]:
+                state["text"] += 1; state["fired"] += 1
+                raise OSError(errno.EMFILE, "synthetic: too many open files")
+            return real(p, *a, **k)
+        def flaky_disk(fd, path_s):
+            if path_s == str(target) and not state["disk"]:
+                state["disk"] += 1; state["fired"] += 1
+                raise OSError(errno.EMFILE, "synthetic: too many open files")
+            return real_disk(fd, path_s)
+        Path.read_text = flaky
+        km.jd._disk_read = flaky_disk
+        self.addCleanup(setattr, Path, "read_text", real)
+        self.addCleanup(setattr, km.jd, "_disk_read", real_disk)
+        return state
+
+    def test_a_faulting_store_read_is_not_cached_as_nothing_to_lift(self):
+        self._returned_dispatch()
+        self._seed()                                     # stamped, its dispatch returned: a lift is due
+        km.jd._STORE_FAULTS.pop(SID, None)
+        state = self._read_fails_once(km.jd.GOALDIR / (SID + ".json"))
+        with contextlib.redirect_stderr(io.StringIO()):
+            # the probe's descriptor read faulted: the shared loader raises (no read is handed to load_goals
+            # for a file that exists and did not read), the boundary answers (None, fault), and phase 2 never
+            # runs: one probe, zero writer loads, nothing written
+            self.assertEqual((self._tick(), self.last_probes), (0, 1))
+        self.assertEqual((state["disk"], state["text"]), (1, 0),
+                         "the probe met the fault; load_goals was never reached, its read is still armed")
+        state["text"] = 1                                # disarm the never-met writer read: the checks below read the file
+        self.assertIsNotNone(self._stamp(), "tick 1 read no store: no lift yet, and no empty store was written")
+        self.assertNotIn(SID, km._lift_seen, "a fault is not the files' content: no entry")
+        self.assertEqual((self._tick(), self.last_probes), (1, 1),
+                         "the file reads fine now and is unchanged: probed anyway, the lift is due, one writer load")
+        self.assertIsNone(self._stamp(), "...and the stamp lifts one cycle late, not never")
+        self.assertNotIn(SID, km.jd._STORE_FAULTS, "the successful read ended the fault episode")
+
+    def test_a_swallowed_journal_read_failure_is_not_cached_as_nothing_to_lift(self):
+        self._returned_dispatch()
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
+            {"rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {}}))
+        km.jd.append_restore(SID, {self.gid: self._stamped_node()}, {}, BACK + 50)
+        state = self._read_fails_once(km.jd._overrides_dir() / (SID + ".jsonl"))
+        with contextlib.redirect_stderr(io.StringIO()):
+            # the shared loader's journal read failed and handed the read to load_goals, whose replay
+            # logged history-unreadable and skipped the journal: the node never came back this tick
+            self.assertEqual((self._tick(), self.last_probes), (1, 1))
+        self.assertEqual(state["fired"], 2, "both loaders met the failure")
+        self.assertNotIn(SID, km._lift_seen, "the journal was not read: no entry")
+        self.assertEqual((self._tick(), self.last_probes), (1, 1),
+                         "the journal reads now, unchanged: probed anyway, the restored stamp is due, one writer load")
+        nodes = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())["nodes"]
+        self.assertIn(self.gid, nodes, "the restore replayed and the node was saved back")
+        self.assertIsNone(nodes[self.gid].get("awaitingWhy") or None, "...with its stamp lifted")
+
+    def test_entries_for_sids_that_left_the_alive_set_are_dropped(self):
+        self._seed_unstamped()
+        self._tick()
+        self.assertIn(SID, km._lift_seen)
+        km._alive_sessions = lambda now, tmux: []
+        self._tick()
+        self.assertNotIn(SID, km._lift_seen, "the sid left the alive set: its entry went with it")
+
+    def test_a_writer_racing_the_probe_costs_one_reload_never_a_wrong_skip(self):
+        """The key is stat-ed BEFORE the read. A closer that publishes a stamp while the probe is in flight
+        leaves an entry keyed on the pre-write files, so the next tick's key mismatches and the stamp is
+        found one cycle late. Keyed after the read, the entry would carry the writer's identity against
+        the pre-write store's empty answer, and the fresh stamp would be gated out of sight for good."""
+        self._returned_dispatch()
+        self._seed_unstamped()
+        probed = km.jd.load_goals_shared
+        raced = []
+        def racing(fsid):
+            store = probed(fsid)                        # the real read: the pre-write, unstamped store
+            if not raced:
+                raced.append(fsid)
+                pub = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())
+                pub["nodes"][self.gid] = self._stamped_node()
+                km.jd.save_goals(SID, pub)              # the closer publishes under the read: a rename
+            return store
+        km.jd.load_goals_shared = racing
+        self.assertEqual((self._tick(), self.last_probes), (0, 1), "tick 1 probed once and saw nothing to lift")
+        self.assertEqual(len(raced), 1)
+        self.assertIsNotNone(self._stamp(), "the racing publish's stamp stands after tick 1")
+        self.assertIn(SID, km._lift_seen, "the entry is keyed on the pre-write files")
+        km.jd.load_goals_shared = probed
+        self.assertEqual((self._tick(), self.last_probes), (1, 1), "tick 2: the files moved under the read, so it probes, and the lift is due")
+        self.assertIsNone(self._stamp(), "...and lifts the stamp one cycle late, never never")
+
+    def test_perf_reports_the_gate(self):
+        self._seed_unstamped()
+        self._tick(); self._tick()
+        lg = km._PERF_STATS.snapshot()["memos"]["liftGate"]
+        for k in ("skip", "load", "shared", "writer", "noop"):
+            self.assertEqual(lg[k], km._lift_gate_stats[k], k)
+        self.assertEqual(lg["entries"], len(km._lift_seen))
+        self.assertGreaterEqual(lg["skip"], 1)
+        self.assertGreaterEqual(lg["shared"], 1, "the probe read the shared view")
+
+
 class LiftKeepsLiveLedgerRecords(unittest.TestCase):
     """A lift drops only SPENT ledger records (failed/moot/answered latches — the 2026-08-16
     idle-in-Working fix). A LIVE mid-count record is the once-per-stall invariant itself: dropping
@@ -998,7 +1554,7 @@ class InHarnessWaitLift(unittest.TestCase):
         self.spawn = STAMP - 50                       # default: the CLI predates the stamp — no respawn story
         self.gid, self.other = self.PSID + ":g1", self.PSID + ":g2"
         # the planner placed every launch on the SIBLING top: this goal owns no dispatch
-        km._bg_placed_tops = lambda sid, path, tids: {t: self.other for t in tids}
+        km._bg_placed_tops = lambda sid, path, tids, store=None: {t: self.other for t in tids}
         self._saved_watches = list(km._pr_watches)
         km._SESSION_STAMP_CACHE.clear(); km._bgall_cache.clear(); km._bgtasks_cache.clear()
 

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -71,6 +71,15 @@ def _monitor(tid, t, timeout_ms=300000):
                 {"type": "tool_use", "id": tid, "name": "Monitor", "input": {"timeout_ms": timeout_ms}}]}}
 
 
+def _clear_placement_memos():
+    """The launch-placement memos key on (sid, tool_use id) and on object identity; the sid and the ids
+    repeat across tests, so a positive learned from one test's transcript must not answer the next. The
+    shared read-only cache is keyed per store path (a fresh tempdir each test) and compares bytes, so it
+    cannot serve a stale store; cleared anyway, with its off switch lifted, so no test starts poisoned."""
+    km._task_seg_cache.clear(); km._BG_TOPS_CACHE.clear(); km._PLACEMENT_IDX.clear()
+    km.jd._shared_clear()
+
+
 class AwaitingLift(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
@@ -84,15 +93,18 @@ class AwaitingLift(unittest.TestCase):
         km._alive_sessions = lambda now, tmux: [{"sid": SID, "path": self.path}]
         km._mark_views_dirty = lambda *a, **k: None
         km._SESSION_STAMP_CACHE.clear()
+        km._lift_seen.clear()          # stores are re-seeded in place under recycled tempdir inodes
         km._bgall_cache.clear()
         km._bgtasks_cache.clear()
+        _clear_placement_memos()
         self.gid = SID + ":g1"
 
     def tearDown(self):
         for k, v in self.saved.items():
             setattr(km, k, v)
         km.jd.STATE, km.jd.GOALDIR = self.saved_jd
-        km._SESSION_STAMP_CACHE.clear(); km._bgall_cache.clear(); km._bgtasks_cache.clear()
+        km._SESSION_STAMP_CACHE.clear(); km._lift_seen.clear(); km._bgall_cache.clear(); km._bgtasks_cache.clear()
+        _clear_placement_memos()
         self.td.cleanup()
 
     def _transcript(self, recs):

--- a/tests/test_kernel_bg_placed_tops.py
+++ b/tests/test_kernel_bg_placed_tops.py
@@ -10,7 +10,8 @@ lift's fill). Placements are read through a per-store index (_placement_index) t
 jd._placement_of's scan gives, for the four suffixes the walk tried. A store that is not the shared cache's
 FrozenStore (a writer's private copy, no file, the cache off) is computed on and never published. Entries
 are evicted when a session with no live ids asks after its transcript was re-parsed (the pinned parse is
-stale). SYNTHETIC fixtures only: placeholder sids, invented goal text and prompts."""
+stale) and when its sid leaves the alive set. SYNTHETIC fixtures only: placeholder sids, invented goal text
+and prompts."""
 import json
 import os
 import tempfile
@@ -330,6 +331,17 @@ class PlacedTops(unittest.TestCase):
         self.assertEqual(km._bg_placed_tops(SID, self.path, []), {})
         self.assertEqual((km._bg_tops_report()["entries"], SID in km._PLACEMENT_IDX), (0, False),
                          "no live launches and a stale pinned parse: the parse and index are released")
+
+    def test_the_lifts_end_of_tick_prune_evicts_a_sid_that_left_the_alive_set(self):
+        km._bg_placed_tops(SID, self.path, ["t1"])
+        self.assertEqual(km._bg_tops_report()["entries"], 1)
+        km._alive_sessions = lambda now, tmux: [{"sid": SID, "path": self.path}]
+        km._mark_views_dirty = lambda *a, **k: None
+        km._lift_spent_awaiting(NOW, {})                   # alive (dormant here): the entry stays
+        self.assertEqual(km._bg_tops_report()["entries"], 1)
+        km._alive_sessions = lambda now, tmux: []
+        km._lift_spent_awaiting(NOW, {})
+        self.assertEqual((km._bg_tops_report()["entries"], SID in km._PLACEMENT_IDX), (0, False))
 
     # ---- /perf ----
     def test_perf_reports_the_memo(self):

--- a/tests/test_kernel_bg_placed_tops.py
+++ b/tests/test_kernel_bg_placed_tops.py
@@ -1,0 +1,347 @@
+"""The placed-launch memo behind the awaiting lift and the feed's background-task classification:
+_bg_placed_tops answers {launch tool_use id: owning top} from the transcript segment holding the launch
+and the goal store's placement for it.
+
+The memo is keyed on OBJECT identity, not on a stat: _parse returns one object per transcript version and
+jd.load_goals_shared one FrozenStore per store version, so (parse object, store object) IS the version pair,
+and a per-sid map answers every launch id asked so far under that pair (the lift asks with every task id,
+the feed with the live ids, often none: one map answers both, and the feed's empty ask never evicts the
+lift's fill). Placements are read through a per-store index (_placement_index) that gives exactly what
+jd._placement_of's scan gives, for the four suffixes the walk tried. A store that is not the shared cache's
+FrozenStore (a writer's private copy, no file, the cache off) is computed on and never published. Entries
+are evicted when a session with no live ids asks after its transcript was re-parsed (the pinned parse is
+stale). SYNTHETIC fixtures only: placeholder sids, invented goal text and prompts."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads: they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_bgtops", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "77777777-1111-4222-8333-444444444401"   # private to this module (synthetic)
+NOW = 1781100000
+T0 = NOW - 3600
+TOP_A, SUB_A, TOP_B = SID + ":gA", SID + ":gA1", SID + ":gB"
+
+
+def _iso(ep):
+    import datetime
+    return datetime.datetime.fromtimestamp(ep, tz=datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _prompt(uuid, t, text):
+    return {"type": "user", "timestamp": _iso(t), "uuid": uuid, "parentUuid": None,
+            "message": {"role": "user", "content": text}}
+
+
+def _dispatch(tid, t):
+    """The assistant tool_use block that dispatched a background agent: the record a launch's segment
+    is resolved from."""
+    return {"type": "assistant", "timestamp": _iso(t), "uuid": "d" + tid, "parentUuid": None,
+            "message": {"role": "assistant", "content": [
+                {"type": "tool_use", "id": tid, "name": "Agent",
+                 "input": {"description": "an investigation", "prompt": "look", "run_in_background": True}}]}}
+
+
+def _ack(tid, t):
+    return {"type": "user", "timestamp": _iso(t), "uuid": "u" + tid, "parentUuid": None,
+            "toolUseResult": {"status": "async_launched", "description": "an investigation"},
+            "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": tid,
+                                                     "content": "launched"}]}}
+
+
+def _drift(seg_id, t="999"):
+    """The same segment as recorded by another consumer: a different middle t (see jd._seg_key)."""
+    parts = seg_id.split(":")
+    return parts[0] + ":" + t + ":" + parts[-1]
+
+
+def _node(nid, parent=None):
+    return {"id": nid, "text": "a goal", "parentId": parent, "nodeComplete": False, "blocked": False,
+            "cleared": False, "trail": [], "t": T0, "mt": T0, "log": []}
+
+
+class PlacedTops(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_state = jd.STATE
+        jd._rebind_state(Path(self.td.name))          # clears the shared cache and lifts any earlier off switch
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        self.saved = {nm: getattr(km, nm) for nm in ("_alive_sessions", "_mark_views_dirty")}
+        self.path = os.path.join(self.td.name, SID + ".jsonl")
+        # two prompts, two segments: t1 dispatched under the first, t2 and t3 under the second
+        self._transcript([_prompt("p1", T0, "start the first investigation"), _dispatch("t1", T0 + 10),
+                          _ack("t1", T0 + 11),
+                          _prompt("p2", T0 + 100, "and now the second one"), _dispatch("t2", T0 + 110),
+                          _ack("t2", T0 + 111), _dispatch("t3", T0 + 120), _ack("t3", T0 + 121)])
+        km._task_seg_cache.clear(); km._BG_TOPS_CACHE.clear(); km._PLACEMENT_IDX.clear()
+        ps = km._parse(self.path, SID, NOW)
+        segs = km._seg_of_tool_uses(ps, {}, ["t1", "t2", "t3"])
+        self.assertEqual(set(segs), {"t1", "t2", "t3"}, "precondition: every dispatch resolves to a segment")
+        self.seg1, self.seg2 = segs["t1"], segs["t2"]
+        self.assertEqual(segs["t3"], self.seg2, "t2 and t3 share the second segment")
+        km._task_seg_cache.clear()                    # the precondition's walk must not warm the test
+        # placements recorded under DRIFTED ids (another consumer's parse of the same segments)
+        self._save({_drift(self.seg1): SUB_A, _drift(self.seg2): TOP_B})
+        self.s0 = self._stats()
+
+    def tearDown(self):
+        for nm, v in self.saved.items():
+            setattr(km, nm, v)
+        km._task_seg_cache.clear(); km._BG_TOPS_CACHE.clear(); km._PLACEMENT_IDX.clear()
+        jd._rebind_state(self.saved_state)
+        self.td.cleanup()
+
+    def _transcript(self, recs):
+        """Records chained through parentUuid: the parse walks the transcript graph from its leaf."""
+        for prev, rec in zip(recs, recs[1:]):
+            rec["parentUuid"] = prev["uuid"]
+        with open(self.path, "w") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+
+    def _save(self, placements, extra_nodes=()):
+        nodes = {TOP_A: _node(TOP_A), SUB_A: _node(SUB_A, TOP_A), TOP_B: _node(TOP_B)}
+        for nd in extra_nodes:
+            nodes[nd["id"]] = nd
+        jd.save_goals(SID, {"rompUuid": SID, "seq": 1, "placementsV": jd.PLACEMENTS_V, "nodes": nodes,
+                            "placements": dict(placements), "status": {}})
+
+    def _stats(self):
+        return {"bg": km._bg_tops_report(), "sh": jd.shared_store_stats(), "io": jd.goal_io_stats()}
+
+    def _delta(self, block, key):
+        return self._stats()[block][key] - self.s0[block][key]
+
+    def _spy(self, name):
+        """Count the calls of jd.<name> for the rest of the test; the real function still runs."""
+        calls, real = [], getattr(jd, name)
+        setattr(jd, name, lambda fsid: (calls.append(fsid), real(fsid))[1])
+        self.addCleanup(setattr, jd, name, real)
+        return calls
+
+    # ---- one map for the lift's all-ids ask and the feed's live-ids ask ----
+    def test_the_lifts_all_ids_and_the_feeds_live_ids_share_one_read_and_one_walk(self):
+        writer = self._spy("load_goals")
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1", "t2", "t3"]),
+                         {"t1": TOP_A, "t2": TOP_B, "t3": TOP_B}, "sub-goal placement resolves to its top")
+        self.assertEqual((self._delta("bg", "miss"), self._delta("bg", "walk"), self._delta("bg", "idx_build"),
+                          self._delta("bg", "resolve")), (1, 1, 1, 3))
+        self.assertEqual(self._delta("sh", "miss"), 1, "the store parsed once, into the shared cache")
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t2"]), {"t2": TOP_B}, "the feed's live subset")
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1", "t2", "t3"]), {"t1": TOP_A, "t2": TOP_B, "t3": TOP_B})
+        self.assertEqual((self._delta("bg", "hit"), self._delta("bg", "walk"), self._delta("bg", "idx_build")), (2, 1, 1),
+                         "both later asks were answered from the map: no second walk, no second index")
+        self.assertEqual(self._delta("sh", "hit"), 2, "...and the two shared reads were cache hits")
+        self.assertEqual(writer, [], "the writer's loader was never asked")
+        self.assertEqual(self._delta("io", "loads"), 0, "no writer-style load anywhere")
+        self.assertEqual(km._bg_tops_report()["entries"], 1)
+        self.assertIsInstance(km._BG_TOPS_CACHE[SID][1], jd.FrozenStore, "the entry is keyed on the shared view")
+
+    def test_the_feeds_live_ids_ask_then_the_lifts_all_ids_ask_fill_one_map_incrementally(self):
+        # the other order: the feed asks first with the live ids, then the lift with every id the
+        # transcript records. The lift's ask resolves only the ids the map does not hold yet, under
+        # the same (parse, store) pair, and the feed's next ask is a hit on the widened map
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t2"]), {"t2": TOP_B})
+        self.assertEqual((self._delta("bg", "miss"), self._delta("bg", "resolve"), self._delta("bg", "walk")), (1, 1, 1))
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1", "t2", "t3"]), {"t1": TOP_A, "t2": TOP_B, "t3": TOP_B})
+        self.assertEqual((self._delta("bg", "miss"), self._delta("bg", "resolve"), self._delta("bg", "walk")), (2, 3, 2),
+                         "only the two ids the map lacked were resolved, with one walk for them")
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t2"]), {"t2": TOP_B})
+        self.assertEqual(self._delta("bg", "hit"), 1, "the feed's next ask is answered from the widened map")
+        self.assertEqual(km._bg_tops_report()["entries"], 1)
+
+    def test_a_fill_publishes_a_new_tuple_and_never_writes_into_the_old_map(self):
+        # the pusher and the handler threads both run this: a reader holding the entry it read keeps a
+        # consistent (parse, store, map), so a fill that widens the map copies it and publishes a new
+        # tuple under the same pair, and the old tuple is left as its holder read it
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1"]), {"t1": TOP_A})
+        ent1 = km._BG_TOPS_CACHE[SID]
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1", "t2"]), {"t1": TOP_A, "t2": TOP_B})
+        ent2 = km._BG_TOPS_CACHE[SID]
+        self.assertIsNot(ent2, ent1, "a fill publishes a new tuple")
+        self.assertIsNot(ent2[2], ent1[2], "...holding a new map")
+        self.assertEqual(set(ent1[2]), {"t1"}, "the old map is as its holder read it")
+        self.assertEqual(set(ent2[2]), {"t1", "t2"})
+        self.assertTrue(ent2[0] is ent1[0] and ent2[1] is ent1[1], "the same (parse, store) pair")
+
+    def test_an_unresolvable_launch_is_absent_and_the_walk_is_counted_negative(self):
+        out = km._bg_placed_tops(SID, self.path, ["t1", "t-never-dispatched"])
+        self.assertEqual(out, {"t1": TOP_A}, "a launch no segment holds is not in the answer (awaited-conservative)")
+        self.assertEqual((self._delta("bg", "walk"), self._delta("bg", "walk_neg")), (1, 1))
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1", "t-never-dispatched"]), {"t1": TOP_A})
+        self.assertEqual((self._delta("bg", "hit"), self._delta("bg", "walk")), (1, 1),
+                         "the None answer is in the map under this (parse, store): no walk repeats it")
+
+    # ---- the index equals the four-suffix scan ----
+    def test_the_indexed_lookup_equals_the_four_suffix_scan(self):
+        placements = {"u:100:h1": "n1",                    # plain
+                      "u:200:h2#live": "n2",               # a live-twin key
+                      "u:300:h3#p": None,                  # a RETIRED planned placement (None-valued)
+                      "u:301:h3#d": "n3",                  # ...and its decision-phase twin
+                      "u:400:h4": None, "u:401:h4": "n4",  # two drifted ids for one segment: first wins
+                      "odd-key": "n5",                     # a non-conforming id passes through _seg_key
+                      "u:500:h6#d": "n6"}
+        idx = km._placement_index(placements)
+        probes = ["u:100:h1", "u:150:h1", "u:200:h2", "u:250:h2", "u:300:h3", "u:350:h3", "u:400:h4",
+                  "u:401:h4",                           # the exact key that is NOT first in seg-key order
+                  "u:402:h4", "odd-key", "u:500:h6", "u:600:none", "u:300:h3#p", "u:301:h3#d"]
+        for seg in probes:
+            for suf in ("", "#live", "#p", "#d"):
+                self.assertEqual(km._placed_via_index(placements, idx, seg + suf),
+                                 jd._placement_of(placements, seg + suf), "%s%s: the scan's own answer" % (seg, suf))
+            scan = next((v for v in (jd._placement_of(placements, seg + suf)
+                                     for suf in ("", "#live", "#p", "#d")) if v), None)
+            via = None
+            for suf in ("", "#live", "#p", "#d"):
+                v = km._placed_via_index(placements, idx, seg + suf)
+                if v:
+                    via = v
+                    break
+            self.assertEqual(via, scan, "%s: the first truthy suffix match, as the walk picked it" % seg)
+        self.assertEqual(idx["u:h4"], None, "setdefault: the first drifted key's value stands, None included")
+        self.assertEqual(jd._placement_of(placements, "u:402:h4"), None, "...exactly as the scan answers")
+
+    # ---- versions: publishes, journal appends, a new parse ----
+    def test_a_save_goals_publish_moves_the_version_and_rebuilds_the_index_once(self):
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1"]), {"t1": TOP_A})
+        self._save({_drift(self.seg1): TOP_B, _drift(self.seg2): TOP_B})   # the closer re-places t1's segment
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1"]), {"t1": TOP_B}, "the new version's placement")
+        self.assertEqual((self._delta("bg", "miss"), self._delta("bg", "idx_build")), (2, 2))
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1"]), {"t1": TOP_B})
+        self.assertEqual((self._delta("bg", "hit"), self._delta("bg", "idx_build")), (1, 2), "one index per version")
+        self.assertEqual(km._bg_tops_report()["entries"], 1, "one entry per sid, the old version's replaced")
+
+    def test_a_journal_append_moves_the_version(self):
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1"]), {"t1": TOP_A})
+        jd.append_override(SID, TOP_B, "resolve", NOW)     # a user click: the journal grew, the store did not
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1"]), {"t1": TOP_A})
+        self.assertEqual(self._delta("bg", "miss"), 2, "a new store object: recomputed, same answer")
+        self.assertEqual(self._delta("bg", "walk"), 1, "the launch's segment is a positive: no second walk")
+
+    def test_a_new_parse_object_busts_the_map(self):
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1"]), {"t1": TOP_A})
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1"]), {"t1": TOP_A})
+        self.assertEqual(self._delta("bg", "hit"), 1)
+        with open(self.path, "a") as f:                    # the transcript grew: _parse returns a new object
+            f.write(json.dumps(_prompt("p3", T0 + 200, "one more thing")) + "\n")
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1"]), {"t1": TOP_A})
+        self.assertEqual(self._delta("bg", "miss"), 2, "the parse moved: recomputed under the new pair")
+        self.assertEqual(self._delta("bg", "idx_build"), 1, "...on the same store object: the index stands")
+        self.assertEqual(km._bg_tops_report()["entries"], 1)
+
+    # ---- the two races a stat key loses: identity, not a stat ----
+    def test_a_publish_between_a_read_and_the_ask_is_served_for_the_object_in_hand_then_fresh(self):
+        """A stat key taken after the read would file, for a publish landing between the two, the new
+        version's identity with the old placements, served until the store next moves (and the lift's
+        time window then claims another card's launch as its own). Keyed on the object, the answer is
+        the object's, and the next real read is a new object."""
+        f1 = jd.load_goals_shared(SID)                     # V1: t1's segment under SUB_A (top TOP_A)
+        self._save({_drift(self.seg1): TOP_B, _drift(self.seg2): TOP_B})   # V2 published under it
+        saved = jd.load_goals_shared
+        jd.load_goals_shared = lambda fsid: f1              # a reader still holding V1 asks
+        try:
+            self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1"]), {"t1": TOP_A}, "V1's answer, for V1")
+        finally:
+            jd.load_goals_shared = saved
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1"]), {"t1": TOP_B},
+                         "the real read is V2, a new object: V2's placement, not V1's memo")
+        self.assertEqual(self._delta("bg", "miss"), 2)
+
+    def test_a_same_identity_rewrite_is_served_fresh(self):
+        """A rewrite that keeps the inode, the byte count AND the mtime_ns (a compare_miss in the shared
+        cache) still moves the object: the new placement is served, where a stat key would have held."""
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1"]), {"t1": TOP_A})
+        gp = jd.GOALDIR / (SID + ".json")
+        old = gp.stat()
+        doc = json.loads(gp.read_text())
+        doc["placements"] = {_drift(self.seg1): TOP_B, _drift(self.seg2): TOP_B}   # same key lengths, other tops
+        data = json.dumps(doc, separators=(",", ":")).encode()
+        pad = old.st_size - len(data)
+        self.assertGreaterEqual(pad, 0)
+        gp.write_bytes(data + b" " * pad)               # same inode, same byte count
+        os.utime(gp, ns=(old.st_atime_ns, old.st_mtime_ns))
+        new = gp.stat()
+        self.assertEqual((new.st_ino, new.st_mtime_ns, new.st_size), (old.st_ino, old.st_mtime_ns, old.st_size))
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1"]), {"t1": TOP_B})
+        self.assertEqual(self._delta("sh", "compare_miss"), 1, "the shared cache saw the bytes move")
+
+    # ---- what is never published ----
+    def test_a_writer_copy_is_computed_on_and_never_published(self):
+        w = jd.load_goals(SID)
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1", "t2"], store=w), {"t1": TOP_A, "t2": TOP_B})
+        self.assertEqual(km._bg_tops_report()["entries"], 0, "a private copy is not a version: no entry")
+        self.assertNotIn(SID, km._PLACEMENT_IDX, "...and no index keyed on it")
+        self.assertEqual(self._delta("bg", "idx_build"), 1, "the index was built for the call")
+        self.assertEqual(self._delta("sh", "miss") + self._delta("sh", "hit"), 0, "the caller's store: no shared read")
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1"]), {"t1": TOP_A})
+        self.assertEqual(km._bg_tops_report()["entries"], 1, "the shared view's answer is published")
+        self.assertEqual(self._delta("bg", "walk"), 1, "the positives learned on the writer copy served the shared read")
+
+    def test_no_store_file_answers_nothing_and_publishes_nothing(self):
+        # a session with live tasks and no goal store yet (a new session, every render): one presence
+        # check, and neither a parse nor a load of either kind (the shared loader hands an absent file to
+        # load_goals, so reaching it would cost a fresh-store build per call)
+        os.unlink(jd.GOALDIR / (SID + ".json"))
+        km._parse_cache.pop(self.path, None)
+        writer, shared = self._spy("load_goals"), self._spy("load_goals_shared")
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1"]), {})
+        self.assertEqual(km._bg_tops_report()["entries"], 0)
+        self.assertEqual((writer, shared, self._delta("sh", "absent")), ([], [], 0), "no load of any kind")
+        self.assertNotIn(self.path, km._parse_cache, "no parse either")
+        self.assertEqual(self._delta("bg", "miss"), 0)
+
+    # ---- eviction ----
+    def test_an_empty_live_set_keeps_the_lifts_fill_while_the_parse_is_current(self):
+        # the lift asks with every task id; the feed's classification asks with the LIVE ids, none here
+        # (every task returned): that ask must not evict what the lift filled under the same parse
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1", "t2", "t3"]), {"t1": TOP_A, "t2": TOP_B, "t3": TOP_B})
+        self.assertEqual((self._delta("bg", "idx_build"), self._delta("bg", "walk")), (1, 1))
+        saved = km._tmux_sessions
+        km._tmux_sessions = lambda: {SID: {"state": "idle", "bgTasks": []}}   # live, no live tasks
+        try:
+            self.assertEqual(km._awaiting_task_descs(SID, self.path), [])
+        finally:
+            km._tmux_sessions = saved
+        self.assertEqual(km._bg_tops_report()["entries"], 1, "the empty ask kept the fill: the parse is current")
+        self.assertEqual(km._bg_placed_tops(SID, self.path, ["t1", "t2", "t3"]), {"t1": TOP_A, "t2": TOP_B, "t3": TOP_B})
+        self.assertEqual((self._delta("bg", "hit"), self._delta("bg", "idx_build"), self._delta("bg", "walk")), (1, 1, 1),
+                         "the lift's next ask is a hit: no index rebuilt, no transcript re-walked")
+
+    def test_empty_tids_evict_the_sessions_entries_once_the_pinned_parse_is_stale(self):
+        km._bg_placed_tops(SID, self.path, ["t1"])
+        self.assertEqual((km._bg_tops_report()["entries"], SID in km._PLACEMENT_IDX), (1, True))
+        self.assertEqual(km._bg_placed_tops(SID, self.path, []), {})
+        self.assertEqual(km._bg_tops_report()["entries"], 1, "the pinned parse is the current one: kept")
+        with open(self.path, "a") as f:                    # the transcript grew and a build re-parsed it
+            f.write(json.dumps(_prompt("p3", T0 + 200, "one more thing")) + "\n")
+        km._parse(self.path, SID, NOW)
+        self.assertEqual(km._bg_placed_tops(SID, self.path, []), {})
+        self.assertEqual((km._bg_tops_report()["entries"], SID in km._PLACEMENT_IDX), (0, False),
+                         "no live launches and a stale pinned parse: the parse and index are released")
+
+    # ---- /perf ----
+    def test_perf_reports_the_memo(self):
+        km._bg_placed_tops(SID, self.path, ["t1"])
+        km._bg_placed_tops(SID, self.path, ["t1"])
+        rep = km._PERF_STATS.snapshot()["memos"]["bgTops"]
+        self.assertEqual(set(rep), {"hit", "miss", "resolve", "walk", "walk_neg", "idx_build", "entries"})
+        self.assertEqual(rep["entries"], 1)
+        for k in ("hit", "miss", "resolve", "walk", "idx_build"):
+            self.assertEqual(rep[k], km._bg_tops_stats[k], k)
+        self.assertGreaterEqual(rep["hit"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_goal_cache_wiring.py
+++ b/tests/test_kernel_goal_cache_wiring.py
@@ -65,9 +65,14 @@ WIRED = {"_open_top_goal": 1, "_deferral_sweep_tick": 1, "_session_stamp_read": 
          "_msg_sum_scan_session": 1,
          "_bg_placed_tops": 1}   # the placed-launch memo: the shared view, or the store the caller hands in
 WIRED_BOUNDARY = {"build_feed": 1, "build_session": 2, "build_timeline": 1}
-# NOT wired, on purpose: the awaiting-lift job does a probe-then-write two-phase read, and the feed's pass
-# snapshot has its own memo (_feed_goals stays on the writer's loader, bare or behind load_goals_or_fault).
-UNWIRED = ("_lift_spent_awaiting", "_feed_goals")
+# TWO-PHASE: the awaiting-lift job takes one shared PROBE (through the boundary: a fault forgets the gate so
+# the next tick retries) and one writer load only when the probe found a lift due (jd.load_goals_or_fault,
+# the same boundary around the writer's loader); the decision body (_lift_decisions) loads nothing and
+# writes nothing.
+TWO_PHASE = {"_lift_spent_awaiting": (1, 1)}
+# NOT wired, on purpose: the feed's pass snapshot has its own memo (_feed_goals stays on the writer's
+# loader, bare or behind load_goals_or_fault).
+UNWIRED = ("_feed_goals",)
 
 
 class WiringPins(unittest.TestCase):
@@ -83,13 +88,36 @@ class WiringPins(unittest.TestCase):
             self.assertEqual(src.count("jd.load_goals(") + src.count("jd.load_goals_or_fault("), 0,
                              "%s: the boundary reads the shared view, not the writer's loader" % name)
 
-    def test_the_writers_and_the_two_phase_readers_stay_on_load_goals(self):
+    def test_the_feeds_pass_snapshot_stays_on_load_goals(self):
         for name in UNWIRED:
             src = inspect.getsource(getattr(km, name))
             self.assertEqual(src.count("jd.load_goals_shared(") + src.count("jd.load_goals_shared_or_fault("), 0,
                              "%s: not wired" % name)
             self.assertGreaterEqual(src.count("jd.load_goals(") + src.count("jd.load_goals_or_fault("), 1,
                                     "%s: still the writer's loader, bare or behind the boundary" % name)
+
+    def test_the_awaiting_lift_probes_the_shared_view_and_loads_the_writers_copy_once(self):
+        for name, (shared, writer) in TWO_PHASE.items():
+            src = inspect.getsource(getattr(km, name))
+            self.assertEqual(src.count("jd.load_goals_shared_or_fault("), shared, "%s: the phase-1 probe" % name)
+            self.assertEqual(src.count("jd.load_goals_or_fault("), writer, "%s: the phase-2 writer load" % name)
+            self.assertEqual(src.count("jd.load_goals_shared(") + src.count("jd.load_goals("), 0,
+                             "%s: no bare load outside the boundary" % name)
+
+    def test_the_lifts_decision_body_loads_nothing_and_writes_nothing(self):
+        # every rule of the lift is decided here, on whichever store the caller hands in (the shared view
+        # in phase 1, the writer's copy in phase 2); the verdict gate is read through jd.may_apply only
+        src = inspect.getsource(km._lift_decisions)
+        for needle in ("jd.load_goals(", "jd.load_goals_shared(", "jd.load_goals_or_fault(",
+                       "jd.load_goals_shared_or_fault(", "record_verdict(", "save_goals(",
+                       "rollup_status(", "_drop_auto_nudge_rec("):
+            self.assertEqual(src.count(needle), 0, "_lift_decisions: %s" % needle)
+        self.assertEqual(src.count("jd.may_apply("), 4,
+                         "the read-only gate, once per arm: rolled-up, peer-superseded, empty-registry, cited-return")
+        # ...and it is the gate record_verdict consults before it appends, so a decision here is a
+        # record_verdict that would have returned True (LiftGate's floor cases run the two side by side)
+        self.assertIn("may_apply(", inspect.getsource(km.jd.record_verdict),
+                      "record_verdict asks may_apply: phase 1 decides through the gate phase 2 files through")
 
     def test_bg_placed_tops_keys_on_objects_not_on_a_stat(self):
         # the per-version map is keyed on the parse and store OBJECTS in hand (a stat taken after the

--- a/tests/test_kernel_goal_cache_wiring.py
+++ b/tests/test_kernel_goal_cache_wiring.py
@@ -62,12 +62,12 @@ def _tm():
 # (load_goals_shared_or_fault), so one session's unreadable store costs that session's goal-derived data
 # and files one row per fault episode, never the frame.
 WIRED = {"_open_top_goal": 1, "_deferral_sweep_tick": 1, "_session_stamp_read": 1, "_owned_yield_why": 1,
-         "_msg_sum_scan_session": 1}
+         "_msg_sum_scan_session": 1,
+         "_bg_placed_tops": 1}   # the placed-launch memo: the shared view, or the store the caller hands in
 WIRED_BOUNDARY = {"build_feed": 1, "build_session": 2, "build_timeline": 1}
-# NOT wired, on purpose: the awaiting-lift job and the background-placement reader do a probe-then-write
-# two-phase read, and the feed's pass snapshot has its own memo (_feed_goals stays on the writer's loader,
-# bare or behind load_goals_or_fault).
-UNWIRED = ("_lift_spent_awaiting", "_bg_placed_tops", "_feed_goals")
+# NOT wired, on purpose: the awaiting-lift job does a probe-then-write two-phase read, and the feed's pass
+# snapshot has its own memo (_feed_goals stays on the writer's loader, bare or behind load_goals_or_fault).
+UNWIRED = ("_lift_spent_awaiting", "_feed_goals")
 
 
 class WiringPins(unittest.TestCase):
@@ -90,6 +90,15 @@ class WiringPins(unittest.TestCase):
                              "%s: not wired" % name)
             self.assertGreaterEqual(src.count("jd.load_goals(") + src.count("jd.load_goals_or_fault("), 1,
                                     "%s: still the writer's loader, bare or behind the boundary" % name)
+
+    def test_bg_placed_tops_keys_on_objects_not_on_a_stat(self):
+        # the per-version map is keyed on the parse and store OBJECTS in hand (a stat taken after the
+        # read can describe a version the read did not see); no stat is taken here. The one presence
+        # check (os.path.exists on the store file, an absent store answering nothing without a parse or
+        # a load) is not a key and is allowed.
+        src = inspect.getsource(km._bg_placed_tops)
+        self.assertEqual(src.count(".stat()"), 0)
+        self.assertEqual(src.count("os.stat("), 0)
 
     def test_the_compaction_sweep_evicts_the_caches_absent_paths(self):
         src = inspect.getsource(km._compact_goal_stores)

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -115,7 +115,12 @@ class Collector(unittest.TestCase):
         self.assertIn("cpu_ms_workers", snap["judge"])
         self.assertEqual(set(snap["goals"]), {"loads", "saves", "writes"}, "read through jd.goal_io_stats")
         # the three identity memos' readers land here (review find, 2026-09-08: they had no consumer)
-        self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate", "cleared", "courierSkip", "backref", "captions", "goalArchive", "plannerSkip"})
+        self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate", "cleared", "courierSkip", "backref", "captions", "goalArchive", "plannerSkip",
+                                              "bgTops"})
+        self.assertEqual(set(snap["memos"]["bgTops"]), {"hit", "miss", "resolve", "walk", "walk_neg", "idx_build", "entries"},
+                         "the placed-launch memo (_bg_placed_tops): counters plus its occupancy")
+        for k, v in snap["memos"]["bgTops"].items():
+            self.assertIsInstance(v, int, k)
         self.assertEqual(set(snap["memos"]["plannerSkip"]), {"skipped", "planned", "recorded"})
         self.assertEqual(set(snap["memos"]["captions"]), {"served", "parsed"})
         self.assertEqual(set(snap["memos"]["goalArchive"]), {"served", "loaded"})

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -116,10 +116,15 @@ class Collector(unittest.TestCase):
         self.assertEqual(set(snap["goals"]), {"loads", "saves", "writes"}, "read through jd.goal_io_stats")
         # the three identity memos' readers land here (review find, 2026-09-08: they had no consumer)
         self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate", "cleared", "courierSkip", "backref", "captions", "goalArchive", "plannerSkip",
-                                              "bgTops"})
+                                              "bgTops", "liftGate"})
         self.assertEqual(set(snap["memos"]["bgTops"]), {"hit", "miss", "resolve", "walk", "walk_neg", "idx_build", "entries"},
                          "the placed-launch memo (_bg_placed_tops): counters plus its occupancy")
         for k, v in snap["memos"]["bgTops"].items():
+            self.assertIsInstance(v, int, k)
+        self.assertEqual(set(snap["memos"]["liftGate"]), {"skip", "load", "shared", "writer", "noop", "entries"},
+                         "the awaiting-lift gate: session-cycles skipped vs read, the probes the shared cache "
+                         "answered, the writer loads and the ones that filed nothing, plus its occupancy")
+        for k, v in snap["memos"]["liftGate"].items():
             self.assertIsInstance(v, int, k)
         self.assertEqual(set(snap["memos"]["plannerSkip"]), {"skipped", "planned", "recorded"})
         self.assertEqual(set(snap["memos"]["captions"]), {"served", "parsed"})

--- a/tests/test_stage0_log_readers.py
+++ b/tests/test_stage0_log_readers.py
@@ -732,9 +732,9 @@ class PerCycleStoreReadersAreCached(_StateSandbox):
         jd.GOALDIR.mkdir(parents=True, exist_ok=True)
         gpath = jd.GOALDIR / (sid + ".json")
         gpath.write_text(json.dumps({"rompUuid": sid, "seq": 0, "nodes": {}, "placements": {}, "status": {}}))
-        loads = []
-        real = jd.load_goals
-        jd.load_goals = lambda fsid: (loads.append(fsid), real(fsid))[1]
+        loads = []                                         # the tick's store reads: the shared-view probe
+        real = jd.load_goals_shared
+        jd.load_goals_shared = lambda fsid: (loads.append(fsid), real(fsid))[1]
         saved_alive = km._alive_sessions
         km._alive_sessions = lambda now, tmux: [{"sid": sid, "path": str(gpath)}]
         tmux = {sid: {"state": "waiting", "bgTasks": []}}
@@ -746,7 +746,7 @@ class PerCycleStoreReadersAreCached(_StateSandbox):
             km._lift_spent_awaiting(NOW, tmux)
             km._lift_spent_awaiting(NOW + 1, tmux)
             km._lift_spent_awaiting(NOW + 2, tmux)
-            self.assertEqual(loads, [sid], "one load while nothing recorded moved")
+            self.assertEqual(loads, [sid], "one read while nothing recorded moved")
             tmp = gpath.with_suffix(".tmp")                  # published the way save_goals publishes: tmp + replace
             tmp.write_text(json.dumps({"rompUuid": sid, "seq": 1, "nodes": {}, "placements": {}, "status": {}, "note": "longer"}))
             os.replace(tmp, gpath)
@@ -768,7 +768,7 @@ class PerCycleStoreReadersAreCached(_StateSandbox):
             km._lift_spent_awaiting(NOW + 100 + 122, tmux)
             self.assertEqual(len(loads), 6, "…once")
             boom = [True]
-            jd.load_goals = lambda fsid: (loads.append(fsid), (_ for _ in ()).throw(RuntimeError("torn read")) if boom[0] else real(fsid))[1]
+            jd.load_goals_shared = lambda fsid: (loads.append(fsid), (_ for _ in ()).throw(RuntimeError("torn read")) if boom[0] else real(fsid))[1]
             scan.append({"id": "toolu_2", "status": "running", "t": NOW + 300})
             km._lift_spent_awaiting(NOW + 300, tmux)      # the ruling raises → not a ruling
             self.assertEqual(len(loads), 7)
@@ -776,7 +776,7 @@ class PerCycleStoreReadersAreCached(_StateSandbox):
             km._lift_spent_awaiting(NOW + 301, tmux)      # …so the next cycle retries on the same inputs
             self.assertEqual(len(loads), 8, "a raised ruling is retried, not skipped")
         finally:
-            jd.load_goals = real; km._alive_sessions = saved_alive; km._bg_scan_all_cached = saved_scan; km._lift_seen.pop(sid, None)
+            jd.load_goals_shared = real; km._alive_sessions = saved_alive; km._bg_scan_all_cached = saved_scan; km._lift_seen.pop(sid, None)
             try: os.unlink(gpath)
             except OSError: pass
 


### PR DESCRIPTION
Two commits, in dependency order: the placed-launch memo first (`_bg_placed_tops`), then the two-phase awaiting lift that hands it the store it decides on.

## Symptom

On a board with several live sessions carrying awaiting stamps, the kernel reads each of those sessions' goal store from disk and replays its override journal on every pusher cycle whose inputs moved, and nearly every one of those reads files nothing: the dispatch the stamp waits on is still out. Beside it, the placed-launch resolver behind the lift and the feed's background-task chips re-loads the same store privately whenever the lift and the feed ask about different launch ids, which they do every cycle. Nothing on the board looks wrong; the pusher thread spends its time deciding nothing. Both sites are listed as `UNWIRED` by `tests/test_kernel_goal_cache_wiring.py`, left on the writer's loader when the shared read-only store cache landed.

## Cause

`_lift_spent_awaiting` had one inline body that loaded through `jd.load_goals_or_fault` (the writer's loader) and filed verdicts in four arms of the same loop. The only store it could decide on was a private mutable copy, so every session whose fingerprint moved paid the full load before the rules could say "nothing due".

`_bg_placed_tops` kept one cache slot per session, keyed on the transcript, store and journal stats plus the exact tuple of launch ids asked. The lift asks with every task id the transcript records and the feed with the live ids (often none), so each ask evicted the other's fill, and every miss called `jd.load_goals`. The stat key was also a weak version: a rewrite that keeps the mtime and the byte count did not move it (the old answer was served until the file next moved), and since it was taken before the load, a publish landing between the two paired the old identity with the new placements for one cycle.

## Fix

Commit 1, `_bg_placed_tops(sid, path, tids, store=None)`. It reads through `jd.load_goals_shared`, or the store the caller hands in, and keeps per session one map of every launch id asked so far under one (parse object, store object) pair. A hit requires both objects in hand to be the entry's own. `_parse` returns one object per transcript version and `load_goals_shared` one `FrozenStore` per store version, so identity is the version and no stat is taken. Placements are resolved through a per-store index of `jd._seg_key`-normalized keys built with `setdefault`, which answers what `jd._placement_of`'s scan answered for each of the four suffixes, None-valued retired entries included. An absent store file answers nothing after one presence check (no parse, no fallback load). A store that is not the shared cache's `FrozenStore` (a writer's private copy, no file, the cache off) is computed on and never published. A fill copies the map it extends and publishes a new tuple, never writing into an entry, since the pusher and the handler threads both run this; the counters sit behind a lock. An ask with no live ids releases the entry only when its pinned parse is no longer the transcript's current one. Callers are unchanged. `/perf` gains `memos.bgTops` (`hit`, `miss`, `resolve`, `walk`, `walk_neg`, `idx_build`, `entries`). A negative walk cache was priced and not built: phase 2 re-walks the transcript once per due lift for launch ids no segment resolves (positives are cached in `_task_seg_cache`, negatives are not), and `walk_neg` counts the upper bound on what such a cache would save.

Commit 2, the two-phase lift. The `_sid_inputs_fp` / `_lift_seen` gate is unchanged. Behind it, phase 1 probes the shared view through `jd.load_goals_shared_or_fault` and runs the whole decision body, moved into `_lift_decisions`, which consults the verdict gate read-only through `jd.may_apply` and writes nothing, returning `(node key, top, drop_rec, end_ev)` per lift due. The probe sits behind the same per-session boundary as before: a fault forgets the gate and the next cycle retries, and a store whose journal did not read forgets it too. An empty list ends the session's tick, as a save-less tick did before. Phase 2 runs only when a lift is due: the writer's copy is loaded through `jd.load_goals_or_fault`, `_lift_decisions` runs again on that copy, and only its own decisions are filed with `record_verdict` on the node the key names, the spent nudge record dropped where flagged, then `rollup_status` and `save_goals` as before. The frozen view is never written to and never reaches `save_goals`. A writer publishing between the probe and the load (the closer re-placing the deciding launch under another card) costs one writer load that files nothing, counted as `noop`, never a lift from the stale decision. Placement inside a decision is read from the store being decided on (`store=store`), so the stamps ruled on and the launches placed come from one version. Phase 1 rests on `jd.may_apply` being the gate `record_verdict` consults before it appends, which it is today: `test_the_lifts_decision_body_loads_nothing_and_writes_nothing` pins the call, and the four floor cases below run `record_verdict` on the writer's copy beside phase 1's decision. A later change there that bypassed `may_apply` would make phase 1 decide a lift that phase 2 refuses, a `noop` and one wasted load, never a wrong lift.

The rule body moved verbatim. A whitespace-normalized diff of the removed inline body against `_lift_decisions` shows only the extraction's substitutions: the two candidate lists in `_lift_candidates` and one early return when the store has no candidate (so the candidate scan runs once per probed session), `record_verdict(...)` to `jd.may_apply(...)` plus an append in the four arms, the three `changed`/save blocks to `return out`, the node key where the id field was read (`_top_of(nid)`, `stamped.remove((nid, nd))`), `store=store` on the placement ask, the nudge-record drop moved to phase 2 with its comment, and one comment losing the word "above". The `or now` agents horizon, the `_return_ev` shape and the `end_ev` journaling are as they were.

Also in commit 2: after the loop, `_lift_seen` entries for sids that left the alive set are dropped (nothing pruned them before; bounded by the session count, so a leak rather than a bug), and so are the placed-launch memo's entries for those sids. `/perf` gains `memos.liftGate` (`skip`, `load`, `shared`, `writer`, `noop`, `entries`); `docs/reference.md` describes both memos.

The gain was measured once and no test asserts a timing. On a copy of a live state directory with 31 sessions, three of them stamped with their dispatches still out, the lift tick's steady cost per pusher cycle went from 20.8 ms with three writer loads to 6.5 ms with none, timed around the `_lift_spent_awaiting` call in `_pusher_cycle_jobs`. The check anyone can run on their own board is `GET /perf`: `memos.liftGate.writer` stays at zero while no lift is due, and `memos.bgTops.hit` grows while `miss` does not once the lift and the feed have each asked once.

Not included: the inputs fingerprint does not stat the goals archive, so a restore row whose node sits in the archive is re-examined only when another input moves; unchanged here. The 3-argument `_bg_placed_tops` stubs in `tests/test_kernel_bg_tasks.py` and `tests/test_kernel_owned_yield_awaiting.py` are reached through `_bg_pending` and `_bg_split`, never with `store=`, and are left as they are.

## Tests

Every test below runs the real code paths and fails on the tree without its commit, with one exception named where it appears.

Commit 1, `tests/test_kernel_bg_placed_tops.py` (new, `PlacedTops`, 15 cases here and 16 with commit 2), over a synthetic two-segment transcript and a store whose placements are recorded under drifted segment ids. On the tree before the change the module errors at setUp, since the memo names do not exist; the cases then pin:
- the lift's all-ids ask and the feed's live-ids ask share one shared read and one walk, with the writer-loader spy left empty (the old one-slot cache missed on the second ask and called `jd.load_goals`); in the other order, the lift's ask after the feed's resolves only the two ids the map lacked, with one walk for them, and the feed's next ask is a hit;
- a fill publishes a new tuple holding a new map, and the old tuple's map is as its holder read it (red when a fill writes into the map it found);
- an unresolvable launch is absent and its walk counted negative, and the None answer is memoized under the pair;
- the indexed lookup equals the four-suffix scan for plain, live-twin, retired (None-valued), drifted and non-conforming keys, the exact key that is not first in seg-key order among them (red when the exact-key branch is dropped);
- a `save_goals` publish, a journal append and a new parse object each move the version, with one index per store object;
- a publish between a read and the ask is served for the object in hand and then fresh; a same-identity rewrite (same inode, byte count and mtime) is served fresh;
- a writer's copy is computed on and never published (a TypeError before: no `store` parameter); an absent store file costs no load of either kind and no parse;
- an empty live set keeps the fill while the parse is current and releases it once the parse is stale; `/perf` reports the memo.

`tests/test_kernel_goal_cache_wiring.py`: `_bg_placed_tops` moves to the wired set (0 shared loads before), and a pin that no stat is taken in it. `tests/test_perf_stats.py`: the `bgTops` key set (missing before). `tests/test_kernel.py`: a comment on the cache clears.

Commit 2, `tests/test_kernel_awaiting_lift.py`, new class `LiftGate` (26 cases), counting `jd.load_goals` (writer) and `jd.load_goals_shared` (probe) apart, with the shared cache's poison canary checked in every tearDown. On the tree with commit 1 alone, 25 of the 26 fail; the exception is the dormant-session case, which pins behaviour the change keeps (a dormant session is skipped before the gate and nothing is remembered for it):
- an unchanged unstamped store is probed once then gated; a stamped store with its dispatch still out costs one probe and no writer load on the tick that reads it, then is gated until an input moves, and lifts on the return (before: one writer load and zero probes, `(1, 0)` against `(0, 1)`);
- a due lift takes one probe and one writer load and files one lift row, dropping the spent nudge record once;
- the rolled-up, peer-superseded and empty-registry arms each take one writer load; a node keyed apart from its id field still lifts (found by key on the writer's copy);
- a lift the verdict gate refuses, in each of the four arms (a user follow-up after the stamp, `followupAt` past the stamp's anchor, is the evidence floor `record_verdict` applies to a lift), is decided on the shared view and costs no writer load: one probe, the stamp stands, no row, `writer` and `noop` unchanged, the session gated on the next tick, and `record_verdict` on the writer's copy refuses the same lift (red when any arm decides without `jd.may_apply`: a wasted writer load and a `noop` per tick);
- a writer racing the probe costs one reload and never a wrong skip; a writer racing between the probe and the load costs one reload counted `noop` and never a wrong lift;
- a save publish, a journal restore row, a block row, an override row, a same-size in-place rewrite and a same-size rename with the old mtime each move the key;
- a missing store is gated until it appears, its first read counted under `load` and not under `shared` (red when `shared` counts every probe); a faulting store read and a swallowed journal read are not cached as nothing to lift; a failed probe records no skip; a dormant session is neither gated nor recorded; a sid that left the alive set loses its gate entry (kept before); `/perf` reports the gate.

`tests/test_kernel_goal_cache_wiring.py`: the two-phase pin (one `jd.load_goals_shared_or_fault(`, one `jd.load_goals_or_fault(`, no bare load in `_lift_spent_awaiting`; 0 and 1 before), and the pin that `_lift_decisions` loads nothing, writes nothing and asks `jd.may_apply` exactly four times (one per arm; the name did not exist before) and that `record_verdict` asks `may_apply`. `tests/test_kernel_bg_placed_tops.py`: the end-of-tick prune evicts a sid that left the alive set (kept before). `tests/test_perf_stats.py`: the `liftGate` key set. `tests/test_stage0_log_readers.py`: the counted loader becomes `jd.load_goals_shared`, which the tick's store read now is (counting `jd.load_goals` there reads 0 after the change). The five 3-argument `_bg_placed_tops` stub lambdas on the lift's path accept `store=None`; `LiftGateFallback` keeps counting `jd.load_goals` unchanged, since the unreadable-journal case still reaches it through the shared loader's hand-off.

Targeted modules on the final tree (`pytest -q -n 6`): `tests/test_kernel_awaiting_lift.py tests/test_kernel_bg_placed_tops.py tests/test_kernel_goal_cache_wiring.py tests/test_perf_stats.py tests/test_stage0_log_readers.py tests/test_kernel_bg_tasks.py tests/test_kernel_owned_yield_awaiting.py tests/test_wake_answer_files_under_shared_view.py tests/test_goal_store_fault_boundary.py tests/test_kernel_bg_tasks_stale.py tests/test_wake_deadman_toggle.py tests/test_paused_matrix.py tests/test_kernel_tick_jobs_under_frame.py tests/test_kernel.py`: 833 passed, 1 failed. The failure, `tests/test_kernel.py::ServeSecurity::test_restart_error_echo_is_bounded_and_keeps_its_explanation`, reads the restart door's body parser and nothing this change touches; it passed alone on the same tree, and it passed in the full run below.

Full suite on the final tree (`pytest -q -n 8 tests/`): 10570 passed, 85 skipped, 0 failed, 1688 subtests passed.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)