### PR TITLE
Extension suite: main green again after six merges landed on older mains

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -11198,7 +11198,7 @@ function dressReplyChip(b: HTMLButtonElement, dir: Dir, chip: ReadyChip | null):
 }
 function updateReplyChips(): void {
   const c = document.getElementById("content");
-  const s = activeId ? sessions.get(activeId) : null;
+  const s = activeId ? liveSession(activeId) : null;   // a display path: a skeleton tab's stale session draws no chips
   const v = activeId ? views.get(activeId) : null;
   const H = c ? c.clientHeight : 0;
   const ready = activeId ? (commentThreads.get(activeId) || []).filter(isReplyReady) : [];

--- a/ui/webview/staged-list-cap.test.ts
+++ b/ui/webview/staged-list-cap.test.ts
@@ -95,6 +95,7 @@ function lift(): (hooks: Hooks) => Api {
     const persistDrafts = () => { H.persists++; };
     const hostIsDown = (id) => H.down.has(id); const isProvisionalId = (id) => H.provisional.has(id);
     const warnToast = (msg) => { H.toasts.push(msg); };
+    const ephemeralWarnToast = (msg) => { H.toasts.push(msg); };   // the unreachable-session word rides the ephemeral toast (reload-notices)
   `;
   const epilogue = `return { routeUserMessage, flushStaged, renderStagedStrip, stagedMsgs, stagedOpen, stagedCollapsed, stagedScroll };`;
   return new Function("HOOKS", prelude + js + epilogue) as (hooks: Hooks) => Api;


### PR DESCRIPTION
## What

Main's extension job has been red since 4:13 PM PT (2026-09-09): six PRs, each green against an older main, met on main and broke two tests together. Every PR is blocked on it.

- **`ui/webview/skeleton-tabs-wiring.test.ts`**: the pin counts bare `sessions.get(activeId)` reads and requires every ACTIVE-tab display path to read through `liveSession` (a skeleton tab's stale session is never displayed). The reply-ready merge added a bare read in `updateReplyChips`, which measures the active pane and draws the reply chips from the session's events, a display path. Fixed in the CODE: it reads through `liveSession` now, so a skeleton tab draws no chips from a stale session. The pin's count stays 4.
- **`ui/webview/staged-list-cap.test.ts`**: the test runs render.ts's staged-stack functions under a harness that stubs the identifiers they reach. The notice-vocabulary merge made the unreachable-session word an `ephemeralWarnToast` (`reload-notices.ts`), which the harness did not stub (ReferenceError). The harness now stubs it beside `warnToast`, into the same toasts the test reads.

Both reproduce on a pristine upstream/main checkout. Verified here: the two tests, then the whole extension suite plus typecheck and the whole Python suite.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
