### PR TITLE
Feed: the hover-freeze tells the hovered session header apart by column, not by session alone

### DIFF
--- a/ui/webview/feed-freeze.test.ts
+++ b/ui/webview/feed-freeze.test.ts
@@ -166,8 +166,10 @@ test("badges wear the header conventions: accent adds, block-red removes, the co
   // painted on the build-once column heads and the data-fsid-stamped session headers; cleared when quiet
   assert.match(FEED, /put\(document\.querySelector\("\.feed-col\.col-" \+ key \+ " \.feed-col-head"\), d\.cols\[key\]\);/);
   assert.match(FEED, /h\.setAttribute\("data-fsid", e\.sid\);/);
-  assert.match(FEED, /const c = groupedNow \? d\.sess\[sid\] : undefined;\s*if \(sid !== hoveredSid\) \{ put\(h, c\); return; \}/,
-    "every header but the hovered one carries its in-row badge (the hovered one's floats — T285)");
+  assert.match(FEED, /if \(h\.getAttribute\("data-fcol"\) !== e\.col\) h\.setAttribute\("data-fcol", e\.col\);/,
+    "the column stamp beside the sid, compare-first like it: the two together are the row the hover key names");
+  assert.match(FEED, /const c = groupedNow \? d\.sess\[sid\] : undefined;\s*if \(sessFreezeKey\(h\) !== hoveredHead\) \{ put\(h, c\); return; \}/,
+    "every header but the hovered ROW carries its in-row badge (the hovered one's floats, T285); the same session's header in another column is not the hovered row");
   assert.match(FEED, /document\.querySelectorAll\("\.freeze-badge"\)\.forEach\(\(n\) => n\.remove\(\)\);/,
     "nothing pending → every badge comes off");
   // local renders while frozen re-sync the hints, so a rebuilt board never strands a stale count
@@ -179,8 +181,8 @@ test("a session header row holds the same gate a card holds: a push while it is 
   // the row (name, caret, Clear all inside it) enters and leaves the freeze by the session it stands for
   assert.match(head, /h\.addEventListener\("mouseenter", \(\) => freezeEnter\(sessFreezeKey\(h\)\)\);/, "hovering the header row arms the gate");
   assert.match(head, /h\.addEventListener\("mouseleave", \(\) => freezeLeave\(sessFreezeKey\(h\)\)\);/, "leaving it releases (the flush follows)");
-  assert.match(FEED, /function sessFreezeKey\(h: HTMLElement\): string \{ return "h:" \+ \(h\.getAttribute\("data-fsid"\) \|\| ""\); \}/,
-    "keyed by the data-fsid stamp read at event time — the row's identity across re-homing renders");
+  assert.match(FEED, /function sessFreezeKey\(h: HTMLElement\): string \{\s*return "h:" \+ \(h\.getAttribute\("data-fcol"\) \|\| ""\) \+ ":" \+ \(h\.getAttribute\("data-fsid"\) \|\| ""\);\s*\}/,
+    "keyed by the data-fcol and data-fsid stamps read at event time: the (column, session) row's identity across re-homing renders");
   // the payload path is ONE gate for both holders: while any freeze key is set, the payload is queued and
   // NOTHING renders — so updateSessHead never runs and the hovered row (its Clear all included) stands
   const gate = FEED.slice(FEED.indexOf('if (m.type === "feed") {'), FEED.indexOf('} else if (m.type === "hoverCards") {'));
@@ -200,8 +202,8 @@ test("a session header row holds the same gate a card holds: a push while it is 
   // badge lands after the auto-margin Clear all and slides it out from under the pointer, the very click loss
   // this hold prevents. The hovered header's badge floats: body-mounted, pointer-inert, its row's rect untouched.
   const paint = FEED.slice(FEED.indexOf("function paintFreezeBadges(): void {"), FEED.indexOf("// ── CARD KEYBOARD SCOPE"));
-  assert.match(paint, /const hoveredSid = freezeKey && freezeKey\.startsWith\("h:"\) \? freezeKey\.slice\(2\) : null;/);
-  assert.match(paint, /if \(sid !== hoveredSid\) \{ put\(h, c\); return; \}\s*put\(h, undefined\);/, "every other header keeps its in-row badge; the hovered one carries none");
+  assert.match(paint, /const hoveredHead = freezeKey && freezeKey\.startsWith\("h:"\) \? freezeKey : null;/, "the whole key, never the sid alone");
+  assert.match(paint, /if \(sessFreezeKey\(h\) !== hoveredHead\) \{ put\(h, c\); return; \}\s*put\(h, undefined\);/, "every other header keeps its in-row badge; the hovered row carries none");
   assert.match(paint, /headNote\.id = "freeze-headnote"; document\.body\.appendChild\(headNote\);/, "…its hint is body-mounted");
   assert.match(paint, /headNote\.style\.top = Math\.round\(r\.bottom \+ 2\) \+ "px";/, "…placed just under the row, right-aligned");
   assert.match(CSS, /#freeze-headnote \{ position: fixed; z-index: 6; pointer-events: none;/, "pointer-inert, like the card's self-note");

--- a/ui/webview/feed-render-incremental.test.ts
+++ b/ui/webview/feed-render-incremental.test.ts
@@ -873,14 +873,87 @@ test("a session header's name nodes are minted only when what they show changes:
   assert.equal((body.querySelector(`.feed-sess-head[data-fsid="${WEB}"]`) as any)._name.textContent, "web-2");
 });
 
-test("a header's data-fsid is written only when it differs", async () => {
+test("a header's data-fsid and data-fcol are written only when they differ", async () => {
   const heads = () => body.querySelectorAll(".feed-sess-head").filter((h) => !h.classList.contains("sess-exit"));
   const same = frame([{ ...g1, name: "web-2" }, card("g2")._it, card("g3")._it]);   // the objects the cards were painted from
   await dispatch(same);
-  const before = heads().map((h) => [h.getAttribute("data-fsid"), h.ac]);
+  const stamps = () => heads().map((h) => [h.getAttribute("data-fsid"), h.getAttribute("data-fcol"), h.ac]);
+  const before = stamps();
   assert.equal(before.length, 3);
+  assert.deepEqual(before.map((s) => s[1]), heads().map((h) => h.parentNode!.id.replace(/^col-|-list$/g, "")), "each header is stamped with the column it heads");
   await dispatch(same); await dispatch(same);
-  assert.deepEqual(heads().map((h) => [h.getAttribute("data-fsid"), h.ac]), before, "an unchanged sid is compared and not re-set");
+  assert.deepEqual(stamps(), before, "an unchanged sid or column is compared and not re-set");
+});
+
+test("a hovered session header is one (column, session) row: the same session's header in another column keeps its in-row badge and the floating hint sits under the hovered row", async () => {
+  // grouped mode keys a header per (column, session), so a session with cards in two columns has two header
+  // rows, both stamped with its sid. The hover-freeze painter found the hovered row by sid alone, so the twin in
+  // the other column took the hovered branch too: its in-row badge was stripped, and the one floating hint was
+  // re-placed under it (the last twin in document order), away from the row the pointer is on.
+  const g1b = cardOf("g1b", WEB, "web", "#3366cc", "Check the notes-api health route", "needs_input");
+  const g1c = cardOf("g1c", WEB, "web", "#3366cc", "Ship the notes-api health route", "completed");
+  const four = [g1, g1b, card("g2")._it, card("g3")._it];
+  await dispatch(frame(four));
+  const heads = () => body.querySelectorAll(`.feed-sess-head[data-fsid="${WEB}"]`).filter((h) => !h.classList.contains("sess-exit"));
+  assert.deepEqual(heads().map((h) => h.parentNode!.id), ["col-asks-list", "col-needsInput-list"], "web heads a run in Working and one in Blocked");
+  const [hw, hb] = heads();
+  const badged = (h: El) => h.children.some((c) => c.classList.contains("freeze-badge"));
+  // the stand-in's rects derive from the parent list's id, so the two rows sit at different rights; the hint's
+  // position says which row it was placed under
+  const rightOf = (h: El) => (win.innerWidth - h.getBoundingClientRect().right) + "px";
+  assert.notEqual(rightOf(hw), rightOf(hb));
+  hw.dispatchEvent(new Event("mouseenter"));                     // the pointer rests on the Working row
+  await dispatch(frame([...four, g1c]));                         // a push while it is held: one more web card, in Completed
+  try {
+    assert.equal(card("g1c"), null, "the payload is queued, not rendered");
+    assert.ok(badged(hb), "the same session's Blocked header carries its in-row badge");
+    assert.ok(!badged(hw), "never inside the hovered row");
+    const note = body.byId("freeze-headnote");
+    assert.ok(note, "the hovered row's hint floats");
+    assert.equal(note!.style.right, rightOf(hw), "right-aligned under the hovered row, not under its twin");
+  } finally {
+    hw.dispatchEvent(new Event("mouseleave"));                   // release: the queued payload applies (on a failure too,
+    await settle();                                              // so the next test never inherits a held gate)
+  }
+  assert.ok(card("g1c"), "the queued frame applied on release");
+  assert.equal(body.byId("freeze-headnote"), null, "nothing pending: the hint comes off with the badges");
+  await dispatch(frame([g1, card("g2")._it, card("g3")._it]));   // the three-card world back
+  mock.timers.tick(700);                                          // the Blocked and Completed headers finish their exit
+});
+
+test("a hovered header's gate releases through its ghost: a Clear that takes the row out from under the pointer re-keys it, and the ghost's mouseleave still applies the queued frame", async () => {
+  // a Clear on a run's last card starts the header's exit in the same click, with no render in between: the
+  // element is re-keyed to a tombstone (x:N) while the pointer is still on it, and no render heal has run.
+  // Its mouseleave must compute the key its mouseenter stored, or the gate stays held until a later local
+  // render or a window blur. The stamps the key is read from survive the re-key; the data-key does not.
+  const ha = body.querySelector(`.feed-sess-head[data-fsid="${API}"]`)!;   // api heads one run: its one card, g2
+  assert.ok(!ha.classList.contains("sess-exit"));
+  const stamps = () => [ha.getAttribute("data-fcol"), ha.getAttribute("data-fsid")];
+  const before = stamps();
+  assert.equal(before[0], ha.parentNode!.id.replace(/^col-|-list$/g, ""), "stamped with the column it heads");
+  const g2it = card("g2")._it;                                   // the object g2 was painted from (its column too)
+  const g1d = cardOf("g1d", WEB, "web", "#3366cc", "Document the notes-api health route", "working");
+  ha.dispatchEvent(new Event("mouseenter"));                     // the pointer rests on api's header row
+  try {
+    await dispatch(frame([g1, g2it, card("g3")._it, g1d]));      // a push while it is held: one more web card
+    assert.equal(card("g1d"), null, "the payload is queued");
+    card("g2")._clr.onclick(ev);                                 // Clear api's last card: its header leaves with it
+    assert.ok(ha.classList.contains("sess-exit"), "the header ghosts in the same click");
+    assert.match(ha.dataset.key!, /^x:\d+$/, "re-keyed to a tombstone while still under the pointer");
+    assert.deepEqual(stamps(), before, "the stamps stay");
+    assert.equal(card("g1d"), null, "the clear itself is not a release");
+    ha.dispatchEvent(new Event("mouseleave"));                   // the pointer leaves the ghost
+    await settle();
+    assert.ok(card("g1d"), "the ghost's mouseleave released the gate: the queued frame applied");
+  } finally {                                                    // on a failure too, so the next test inherits neither
+    win.dispatchEvent(new Event("blur"));                        // a held gate (the backstop release) nor a cleared g2
+    await settle();
+    mock.timers.tick(700);                                        // the cleared card's collapse and the ghost's exit end
+    await dispatch(frame([g1, card("g3")._it]));                  // the kernel confirms the clear (g2 absent)
+    await dispatch(frame([g1, g2it, card("g3")._it]));            // g2 back where it was, under a fresh api header
+  }
+  assert.equal(body.querySelectorAll(".sess-exit").length, 0);
+  assert.ok(card("g2"));
 });
 
 test("a header re-mints its name nodes when its host's link goes down or comes back, and only then", async () => {

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3577,13 +3577,20 @@ function makeSessHead(): HTMLElement {
   h.addEventListener("mouseleave", () => freezeLeave(sessFreezeKey(h)));
   return h;
 }
-/** The hover-freeze key a session header holds: "h:<sid>", read from the data-fsid stamp at event time (grouped
- *  mode re-homes and re-stamps headers across renders; the stamp is the row's identity). */
-function sessFreezeKey(h: HTMLElement): string { return "h:" + (h.getAttribute("data-fsid") || ""); }
+/** The hover-freeze key a session header holds: "h:<column>:<sid>", read from the data-fcol and data-fsid stamps at
+ *  event time (grouped mode re-homes and re-stamps headers across renders; the stamps are the row's identity). The
+ *  key names the (column, session) ROW, the identity reconcileCol keys the element by, not the session alone: a
+ *  session heads a run in every column it has cards in, and the badge painter must tell the hovered row from that
+ *  session's headers in the other columns. */
+function sessFreezeKey(h: HTMLElement): string {
+  return "h:" + (h.getAttribute("data-fcol") || "") + ":" + (h.getAttribute("data-fsid") || "");
+}
 function updateSessHead(h: HTMLElement, e: Entry & { kind: "sess" }): void {
-  // the hover-freeze badge painter finds headers by sid; compare first, like the labels below — the DOM's
-  // change-an-attribute steps queue a mutation record for a same-value write too
+  // the hover-freeze key and its badge painter read the row's session and column from these stamps (sessFreezeKey);
+  // compare first, like the labels below: the DOM's change-an-attribute steps queue a mutation record for a
+  // same-value write too
   if (h.getAttribute("data-fsid") !== e.sid) h.setAttribute("data-fsid", e.sid);
+  if (h.getAttribute("data-fcol") !== e.col) h.setAttribute("data-fcol", e.col);
   const nm = (h as any)._name as HTMLElement;
   // the name nodes are minted only when what they show changes: headers repaint every render (they are not
   // behind the per-card update gate), and each mint is a Text-node replacement — the same reason cards are
@@ -5363,13 +5370,15 @@ function paintFreezeBadges(): void {
   // auto-margin Clear all and slides that button out from under the pointer — the click loss the header
   // hold exists to prevent, caused by the hold's own hint. That row's badge floats instead: body-mounted,
   // pointer-inert, right-aligned just under the row (the self-note idiom), so the row's rect stands.
-  const hoveredSid = freezeKey && freezeKey.startsWith("h:") ? freezeKey.slice(2) : null;
+  // The hovered row is ONE (column, session) header, matched by its whole key: a session with cards in two
+  // columns heads a run in each, and the other column's header keeps its in-row badge and never gets the float.
+  const hoveredHead = freezeKey && freezeKey.startsWith("h:") ? freezeKey : null;
   let headNote = document.getElementById("freeze-headnote") as HTMLElement | null;
   let floated = false;
   document.querySelectorAll<HTMLElement>(".feed-sess-head").forEach((h) => {
     const sid = h.getAttribute("data-fsid") || "";
     const c = groupedNow ? d.sess[sid] : undefined;
-    if (sid !== hoveredSid) { put(h, c); return; }
+    if (sessFreezeKey(h) !== hoveredHead) { put(h, c); return; }
     put(h, undefined);                                   // never inside the hovered row
     if (!c || (!c.add && !c.del)) return;
     if (!headNote) { headNote = el("div", "freeze-badge"); headNote.id = "freeze-headnote"; document.body.appendChild(headNote); }


### PR DESCRIPTION
## Symptom

In grouped mode, rest the pointer on a session's header row in one column while that session also has cards in another column, and let a push arrive while the row is held. The deferred-churn hints paint wrong: the session's header in the other column shows no +N/-N badge at all, and the floating hint (the +N count with its mouse-away note) is drawn under that other header instead of under the row the pointer is on. Only sessions with cards in two or more columns are affected; single-column sessions behave as #1188 intended.

## Cause

`reconcileCol` keys a grouped session header per (column, sid): one session heads a run in every column it has cards in, so such a session has two header elements, and `updateSessHead` stamps both with the same `data-fsid`. The header's hover-freeze key (`sessFreezeKey`, from #1188) named the session only (`"h:<sid>"`), and `paintFreezeBadges` compared each header's sid to the hovered sid. Every header of the hovered session therefore took the hovered branch: its in-row badge was removed (`put(h, undefined)`) and the single `#freeze-headnote` was re-positioned under it, so the last twin in document order won the float and the twin lost its badge.

## Fix

Three edits in `ui/webview/feed.ts`, on the shapes #1188 introduced:

- `updateSessHead` stamps the column beside the sid, compare-first like the sid: `if (h.getAttribute("data-fcol") !== e.col) h.setAttribute("data-fcol", e.col);` (`e.col` is already in the header Entry).
- `sessFreezeKey` names the (column, session) row: `"h:" + data-fcol + ":" + data-fsid`, still read from the stamps at event time. The stamps survive the re-key an exiting header gets (`startSessHeadExit` sets `data-key` to `x:N`), so a ghost's mouseleave computes the key its mouseenter stored and releases the gate; a key derived from `data-key` would not, and the second test below holds that.
- `paintFreezeBadges` keeps the whole key (`hoveredHead = freezeKey` when it starts with `"h:"`) and compares `sessFreezeKey(h) !== hoveredHead`, so exactly one live header is the hovered row; every other header, the same session's twins included, keeps its in-row badge. The float's creation, placement and removal are unchanged.

Other readers of an `"h:"` key (`cardElByKey` via `selfKey`, and the keyboard-scope Tab entry path) query `[data-key="a:<key>"]` and return null for a header key before and after. No CSS or kernel change.

## Tests

- `ui/webview/feed-render-incremental.test.ts`, new: "a hovered session header is one (column, session) row: the same session's header in another column keeps its in-row badge and the floating hint sits under the hovered row". It boots `feed.ts` under the file's DOM stand-in, renders one session with a card in Working and one in Blocked (two headers with the same `data-fsid`), dispatches `mouseenter` on the Working header, dispatches a feed frame adding a Completed card of that session, and asserts: the payload is queued; the Blocked header carries a `.freeze-badge` child; the hovered header carries none; `#freeze-headnote` exists and its `style.right` equals the hovered row's right offset (the stand-in gives the two rows distinct rects). It then releases on `mouseleave` and asserts the queued frame applied and the note came off. Before the change it fails on the Blocked header's missing badge (expected true, actual false); with that assertion skipped it fails on the note's position (`710px`, the Blocked row, where `770px`, the Working row, is expected).
- `ui/webview/feed-render-incremental.test.ts`, new: "a hovered header's gate releases through its ghost: a Clear that takes the row out from under the pointer re-keys it, and the ghost's mouseleave still applies the queued frame". With the pointer on a session's header and a frame queued behind it, it clicks Clear on that session's one card: `dressHeaderIfLast` starts the header's exit in the same click, with no render between, so the element under the pointer is re-keyed to `x:N` and gains `.sess-exit` while its `data-fcol` and `data-fsid` stamps are unchanged. It then dispatches `mouseleave` on the ghost and asserts the queued frame applied. On the unchanged code it fails on the column stamp (no `data-fcol` is written there); with this change's `sessFreezeKey` derived from `data-key` instead of the stamps, it fails on the release (the queued frame stays queued).
- Both new tests release the gate in a `finally`, so a failure never leaks a held gate into the next test of this shared-world file; the second restores its world there too, so a failure leaves no cleared card behind either.
- `ui/webview/feed-render-incremental.test.ts`, extended: "a header's data-fsid and data-fcol are written only when they differ" now checks that each header's `data-fcol` is the column of the list it sits in and that three renders of one frame re-set neither stamp. Fails before the change on the missing column stamp.
- `ui/webview/feed-freeze.test.ts`: the pins on `sessFreezeKey`'s body, the hovered compare and the `hoveredSid` line are re-aimed at the new shapes, and a pin for the compare-first `data-fcol` write sits beside the `data-fsid` one.
- Targeted run after the change: `node --test` over the two files, 51 tests, 51 pass, twice more for determinism. `npm run typecheck` clean.
- Full `npm test` on this head (2d5bfeb8): 3913 tests, 3911 pass. The two failures are the two tests that were red on main from 02d96006 until #1226 (the liveSession read count in `skeleton-tabs-wiring.test.ts` and the Send-now test's lifted prelude in `staged-list-cap.test.ts`); neither file is touched here, and the two files this change touches pass in full.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)