### PR TITLE
Override replay: a same-second re-clear or re-undo replays over a snapshot that already holds the earlier gesture

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -4267,7 +4267,12 @@ def _replay_overrides(fsid, store, lines=None):
     a card reply in the same second are two gestures, and the old >= guard silently dropped the
     reply's replay, bouncing the card back mid-pass). Judge events do not cancel a replay: the user
     event is appended anyway and the fold's authority rules arbitrate. `block` keeps at-or-after: a
-    user reply in the same second as a nudge stamp genuinely answers it.
+    user reply in the same second as a nudge stamp genuinely answers it. The two seal ops (clear,
+    unclear) do not read a same-kind twin as their own write: a clear, an undo and a clear can share
+    one second, and the first clear's survival says nothing about the last one. Of a node's clear and
+    unclear rows in one second only the LAST acts (`last_seal_at`; an earlier one was superseded within
+    that second), and it asks whether the node's NEWEST seal at that second already is its op
+    (`_newest_seal` below).
 
     `lines`: the journal's lines when the caller has already read them (load_goals_shared reads the
     journal from a descriptor it also takes the file's identity from, so the replayed rows and the key
@@ -4291,13 +4296,15 @@ def _replay_overrides(fsid, store, lines=None):
     applied = False                                    # any write → load_goals re-runs rollup (one truth)
     arch_nodes = None                                  # the archive is read once, only if a restore entry needs it
     last_seal = {}                                     # node -> the LAST clear/unclear row's op, in journal order: a
-    for ln in lines:                                   # clear, undo and clear inside one second are settled by the rows'
-        try:                                           # order, not by their integer seconds (review find, 2026-09-09)
-            ev0 = json.loads(ln)
+    last_seal_at = {}                                  # clear, undo and clear inside one second are settled by the rows'
+    for ln in lines:                                   # order, not by their integer seconds (review find, 2026-09-09).
+        try:                                           # last_seal_at: (node, t) -> the last such row's op AT THAT SECOND;
+            ev0 = json.loads(ln)                       # an earlier row of the second stands down (see the arms)
         except ValueError:
             continue
         if ev0.get("op") in ("clear", "unclear") and ev0.get("node"):
             last_seal[ev0["node"]] = ev0["op"]
+            last_seal_at[(ev0["node"], int(ev0.get("t") or 0))] = ev0["op"]
     for ln in lines:
         try:
             ev = json.loads(ln)
@@ -4353,6 +4360,22 @@ def _replay_overrides(fsid, store, lines=None):
             # ev_t, same flag signature (msg/undo stored only when True — an absent key reads False)
             return any(e.get("kind") == kind and int(e.get("ev_t") or 0) == t
                        and all(bool(e.get(k)) == v for k, v in flags.items()) for e in uev)
+        def _newest_seal():                            # the node's newest user seal AT THIS SECOND, in _fold_node's
+            # order ((ev_t, at), ties in log order): "clear", "reopen" (an undo-clear), or None when the
+            # second holds neither. The clear and unclear arms ask this in place of a same-kind twin, and only
+            # from the second's LAST journal row (last_seal_at): a pass that loaded the store after an undo and
+            # saved after the re-clear left the log holding the first clear and its undo at the second all three
+            # gestures share, and the re-clear's row then read that first clear as its own survived write and
+            # skipped, so the store kept the card uncleared while cleared.jsonl hid it; the mirror (undo, clear,
+            # undo inside one second, the snapshot taken after the re-clear) kept the flag on a card cleared.jsonl
+            # had released, which no Undo could reach (2026-09-09). The newest seal says whether the second's last
+            # word is in the log already (survived, or re-recorded by an earlier row of the same second this
+            # load); the last row re-records it when not, and the next load finds the write and skips. An
+            # EARLIER row of the second never acts: read on its own it would take the later row's write for a
+            # missing one of its own and re-record a word the second did not end on.
+            seals = [e for e in uev if int(e.get("ev_t") or 0) == t
+                     and (e.get("kind") == "clear" or (e.get("kind") == "reopen" and e.get("undo")))]
+            return sorted(seals, key=lambda e: int(e.get("at") or 0))[-1].get("kind") if seals else None
         if op == "resolve":
             if nd.get("nodeComplete") or later or _twin("done"):
                 continue
@@ -4379,9 +4402,13 @@ def _replay_overrides(fsid, store, lines=None):
             # reopen (e.g. the card reply seconds after the restore) must NOT eat it, so `later` is
             # deliberately not consulted. was_done mirrors _mark_nodes_cleared: re-settle a completed
             # top so the restored card returns to Completed, not Working.
-            if _twin("reopen", undo=True) or last_seal.get(ev.get("node")) == "clear" or any(
+            if last_seal_at.get((ev.get("node"), t)) != "unclear" or _newest_seal() == "reopen" \
+                    or last_seal.get(ev.get("node")) == "clear" or any(
                     e.get("kind") == "clear" and int(e.get("ev_t") or 0) > t for e in uev):
-                continue                               # survived, re-dismissed by a LATER row (journal order, 2026-09-09), or since
+                continue                               # superseded by a later row of its own second, this second's
+                #                                        last word is an undo already (survived, or an earlier
+                #                                        same-second row's replay), re-dismissed by a LATER row (journal
+                #                                        order, 2026-09-09), or re-cleared since
             was_done = nd.get("parentId") is None and (
                 store.get("status", {}).get(ev.get("node")) == "completed" or nd.get("nodeComplete"))
             if record_verdict(store, nd, "user", "reopen", t, why="undo clear", undo=True):
@@ -4392,12 +4419,15 @@ def _replay_overrides(fsid, store, lines=None):
             # The cross-off (_mark_nodes_cleared value=True, append_clear), replayed so a store a racing pass
             # save clobbered re-seals exactly as the live one did (2026-09-09; the unclear arm's mirror).
             # Voided by a LATER undo: a strictly-later user reopen (the undo-clear's own verdict, or its
-            # replayed "unclear" row) outranks this entry; the twin check keeps the survived write as is.
-            if nd.get("cleared") or _twin("clear") or last_seal.get(ev.get("node")) != "clear" \
+            # replayed "unclear" row) outranks this entry; the newest-seal check keeps a survived write as is.
+            if nd.get("cleared") or last_seal_at.get((ev.get("node"), t)) != "clear" or _newest_seal() == "clear" \
+                    or last_seal.get(ev.get("node")) != "clear" \
                     or any(e.get("kind") == "reopen" and int(e.get("ev_t") or 0) > t for e in uev):
-                continue                               # sealed already, survived, undone by a LATER row (the undo's
-                #                                        unclear row follows its clear row in the journal, whatever the
-                #                                        seconds say), or reopened strictly later by another gesture
+                continue                               # sealed already, superseded by a later row of its own second,
+                #                                        this second's last word is a clear already, undone by a LATER
+                #                                        row (the undo's unclear row follows its clear row in the
+                #                                        journal, whatever the seconds say), or reopened strictly later
+                #                                        by another gesture
             if record_verdict(store, nd, ev.get("src") or "user", "clear", t,
                               why=ev.get("why") or "cleared from the feed"):
                 applied = True

--- a/tests/test_kernel_goal_compaction.py
+++ b/tests/test_kernel_goal_compaction.py
@@ -196,19 +196,20 @@ class ClearedLedgerIsAuthoritativeAcrossTheCompaction(unittest.TestCase):
         km._CLEARED_MEMO["slot"] = None
         shutil.rmtree(self._td, ignore_errors=True)
 
-    def _completed_top(self, n, with_child=False):
+    def _completed_top(self, n, with_child=False, sid=SID):
         """A completed top the way a real one is: its completion is a done verdict in its log (rollup derives
-        nodeComplete from the log, so a bare flag would not survive a load)."""
-        nodes = {self.g(n): _node(self.g(n), None, t=100, mt=100)}
+        nodeComplete from the log, so a bare flag would not survive a load). `sid`: the session it lives in."""
+        g = lambda x: "%s:%s" % (sid, x)
+        nodes = {g(n): _node(g(n), None, t=100, mt=100)}
         if with_child:
-            nodes[self.g(n + "a")] = _node(self.g(n + "a"), self.g(n), t=100, mt=100)
-        store = jd._guard_nodes({"rompUuid": SID, "seq": 1, "lastNode": self.g(n), "nodes": nodes,
-                                 "status": {}, "placements": {self.g(n) + "seg": self.g(n)}})
+            nodes[g(n + "a")] = _node(g(n + "a"), g(n), t=100, mt=100)
+        store = jd._guard_nodes({"rompUuid": sid, "seq": 1, "lastNode": g(n), "nodes": nodes,
+                                 "status": {}, "placements": {g(n) + "seg": g(n)}})
         for nid in list(nodes):
             jd.record_verdict(store, store["nodes"][nid], "closer", "done", 100, why="shipped")
         jd.rollup_status(store, True)
-        jd.save_goals(SID, store)
-        self.assertEqual(jd.load_goals(SID)["status"].get(self.g(n)), "completed", "premise: a completed top")
+        jd.save_goals(sid, store)
+        self.assertEqual(jd.load_goals(sid)["status"].get(g(n)), "completed", "premise: a completed top")
         return store
 
     def _fresh_process(self):
@@ -218,9 +219,9 @@ class ClearedLedgerIsAuthoritativeAcrossTheCompaction(unittest.TestCase):
         jd._GOALARCH_MEMO.clear()
         jd._shared_clear()
 
-    def _clobber_with(self, snapshot):
+    def _clobber_with(self, snapshot, sid=SID):
         """A pass save from a pre-clear snapshot: the store file loses the verdict and the flag."""
-        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(snapshot))
+        (jd.GOALDIR / (sid + ".json")).write_text(json.dumps(snapshot))
         jd._shared_clear()
 
     def test_the_users_sequence_clear_clobber_compact_restart_the_card_stays_cleared(self):
@@ -283,6 +284,219 @@ class ClearedLedgerIsAuthoritativeAcrossTheCompaction(unittest.TestCase):
         km._undo_clear()
         self._clobber_with(snapshot)
         self.assertFalse(jd.load_goals(SID)["nodes"][self.g("g8")].get("cleared"), "the last row, an undo, wins")
+
+    # The tests below put two or three gestures in one second and take the pass's snapshot where the log already
+    # holds a write at the second a lost gesture replays into. They mint their goals under a sid of their own, so
+    # the rows they journal and the goals they mint are theirs alone.
+    SEAL_SID = "11111111-2222-3333-4444-999999999910"
+
+    def _seal_rows(self, sid, n):
+        """The node's clear/unclear journal rows, in order, as (op, t)."""
+        g = "%s:%s" % (sid, n)
+        rows = [json.loads(l) for l in (jd._overrides_dir() / (sid + ".jsonl")).read_text().splitlines()]
+        return [(r["op"], r["t"]) for r in rows if r.get("node") == g and r["op"] in ("clear", "unclear")]
+
+    def _user_seals(self, store, sid, n):
+        """The node's user clear and undo-reopen verdicts, in log order, as kinds."""
+        log = store["nodes"]["%s:%s" % (sid, n)].get("log") or []
+        return [e["kind"] for e in log if e.get("src") == "user"
+                and (e.get("kind") == "clear" or (e.get("kind") == "reopen" and e.get("undo")))]
+
+    def test_a_same_second_re_clear_replays_over_a_snapshot_taken_after_the_undo(self):
+        # the same-second test above takes its snapshot before the first clear, so the first row's replay
+        # supplies the clear and the third row skips on the flag. A pass that loaded the store AFTER the undo
+        # holds the first clear and its undo already, at the second all three gestures share: the re-clear's
+        # row then found a user clear at its own second in the log (the first one, survived) and skipped as if
+        # it were its own write, so the re-clear was lost and the store read the card uncleared while
+        # cleared.jsonl hid it
+        sid, g = self.SEAL_SID, "%s:%s" % (self.SEAL_SID, "g9")
+        self._completed_top("g9", sid=sid)
+        with mock.patch("time.time", return_value=1_000_000.0):          # one second for all three gestures
+            km._clear_all([g])
+            km._undo_clear()
+            snapshot = json.loads((jd.GOALDIR / (sid + ".json")).read_text())
+            km._clear_all([g])
+        self.assertEqual([op for op, _ in self._seal_rows(sid, "g9")], ["clear", "unclear", "clear"],
+                         "premise: three rows, journal order")
+        self.assertEqual(len({t for _, t in self._seal_rows(sid, "g9")}), 1, "premise: one second")
+        self.assertEqual(self._user_seals(snapshot, sid, "g9"), ["clear", "reopen"],
+                         "premise: the snapshot holds the first clear and its undo")
+        self.assertFalse(snapshot["nodes"][g].get("cleared"), "premise: the snapshot reads the card uncleared")
+        self._clobber_with(snapshot, sid=sid)
+        st = jd.load_goals(sid)
+        self.assertTrue(st["nodes"][g].get("cleared"),
+                        "the last row, a clear, wins over a snapshot that holds the first clear and its undo")
+        self.assertEqual(self._user_seals(st, sid, "g9"), ["clear", "reopen", "clear"], "the re-clear is re-recorded once")
+        # idempotent: a save and a reload add nothing
+        jd.save_goals(sid, st)
+        jd._shared_clear()
+        again = jd.load_goals(sid)
+        self.assertTrue(again["nodes"][g].get("cleared"))
+        self.assertEqual(self._user_seals(again, sid, "g9"), ["clear", "reopen", "clear"], "one row added, not one per load")
+
+    def test_a_same_second_re_undo_replays_over_a_snapshot_taken_after_the_re_clear(self):
+        # the mirror: clear, then undo, clear and undo inside one second, with the pass's snapshot taken after
+        # the re-clear. The last undo's row found an undo at its own second in the log (the first undo,
+        # survived) and skipped; the flag stayed set while cleared.jsonl said undone, so the feed hid the card,
+        # the compaction archived it flagged, and no Undo could reach it
+        sid, g = self.SEAL_SID, "%s:%s" % (self.SEAL_SID, "g10")
+        self._completed_top("g10", sid=sid)
+        with mock.patch("time.time", return_value=999_000.0):
+            km._clear_all([g])
+        with mock.patch("time.time", return_value=1_000_000.0):          # one second for the next three
+            km._undo_clear()
+            km._clear_all([g])
+            snapshot = json.loads((jd.GOALDIR / (sid + ".json")).read_text())
+            km._undo_clear()
+        self.assertEqual([op for op, _ in self._seal_rows(sid, "g10")], ["clear", "unclear", "clear", "unclear"],
+                         "premise: four rows, journal order")
+        self.assertEqual(len({t for _, t in self._seal_rows(sid, "g10")[1:]}), 1, "premise: the last three share a second")
+        self.assertEqual(self._user_seals(snapshot, sid, "g10"), ["clear", "reopen", "clear"],
+                         "premise: the snapshot holds the first clear, its undo and the re-clear")
+        self.assertTrue(snapshot["nodes"][g].get("cleared"), "premise: the snapshot reads the card cleared")
+        self.assertNotIn(g, km._cleared_ids(), "premise: cleared.jsonl says undone")
+        self._clobber_with(snapshot, sid=sid)
+        st = jd.load_goals(sid)
+        self.assertFalse(st["nodes"][g].get("cleared"),
+                         "the last row, an undo, wins over a snapshot that holds the re-clear")
+        self.assertEqual(self._user_seals(st, sid, "g10"), ["clear", "reopen", "clear", "reopen"],
+                         "the undo is re-recorded once")
+        self.assertEqual(st["status"].get(g), "completed", "the card comes back to Completed, not Working")
+        jd.save_goals(sid, st)
+        jd._shared_clear()
+        again = jd.load_goals(sid)
+        self.assertFalse(again["nodes"][g].get("cleared"))
+        self.assertEqual(self._user_seals(again, sid, "g10"), ["clear", "reopen", "clear", "reopen"],
+                         "one row added, not one per load")
+
+    def test_two_same_second_undos_around_a_skipped_re_clear_record_one_reopen(self):
+        # the pass's snapshot taken after the FIRST clear this time, before the same-second undo, clear and
+        # undo. The journal's last word for the node is the undo, so the re-clear between the two undos never
+        # replays; both undo rows may act (the second's last word is an undo, their op), and the later one must
+        # find the first's replayed reopen already standing for it and record nothing. A second reopen with no
+        # clear before it would open the node, and the completed top would come back Working. (Green before and
+        # after the arms changed: it pins the shape a same-second count of same-kind writes would break.)
+        sid, g = self.SEAL_SID, "%s:%s" % (self.SEAL_SID, "g11")
+        self._completed_top("g11", sid=sid)
+        with mock.patch("time.time", return_value=999_000.0):
+            km._clear_all([g])
+        snapshot = json.loads((jd.GOALDIR / (sid + ".json")).read_text())
+        with mock.patch("time.time", return_value=1_000_000.0):
+            km._undo_clear()
+            km._clear_all([g])
+            km._undo_clear()
+        self.assertEqual([op for op, _ in self._seal_rows(sid, "g11")], ["clear", "unclear", "clear", "unclear"])
+        self.assertEqual(self._user_seals(snapshot, sid, "g11"), ["clear"],
+                         "premise: the snapshot holds the first clear only")
+        self._clobber_with(snapshot, sid=sid)
+        st = jd.load_goals(sid)
+        self.assertFalse(st["nodes"][g].get("cleared"), "the last row, an undo, wins")
+        self.assertEqual(self._user_seals(st, sid, "g11"), ["clear", "reopen"],
+                         "one reopen restores what the clear displaced; the second undo adds none")
+        self.assertEqual(st["status"].get(g), "completed", "the card comes back to Completed, not Working")
+
+    def test_an_undo_a_second_after_a_same_second_undo_and_re_clear_replays_once(self):
+        # the undo and the re-clear share a second, the pass's snapshot is taken after the re-clear, and the
+        # last undo lands a second later. The shared second's undo row is superseded by the re-clear row that
+        # follows it in the journal and must stand down whatever the log holds: read on its own it finds the
+        # second's newest seal is a clear, not its op, and re-records a reopen the second did not end on; the
+        # later undo's reopen then follows a reopen instead of a clear, finds nothing to restore, and the
+        # completed top comes back Working
+        sid, g = self.SEAL_SID, "%s:%s" % (self.SEAL_SID, "g12")
+        self._completed_top("g12", sid=sid)
+        with mock.patch("time.time", return_value=999_000.0):
+            km._clear_all([g])
+        with mock.patch("time.time", return_value=1_000_000.0):
+            km._undo_clear()
+            km._clear_all([g])
+        snapshot = json.loads((jd.GOALDIR / (sid + ".json")).read_text())
+        with mock.patch("time.time", return_value=1_000_001.0):
+            km._undo_clear()
+        self.assertEqual(self._seal_rows(sid, "g12"),
+                         [("clear", 999_000), ("unclear", 1_000_000), ("clear", 1_000_000), ("unclear", 1_000_001)])
+        self.assertEqual(self._user_seals(snapshot, sid, "g12"), ["clear", "reopen", "clear"],
+                         "premise: the snapshot holds every gesture but the last undo")
+        self._clobber_with(snapshot, sid=sid)
+        st = jd.load_goals(sid)
+        self.assertFalse(st["nodes"][g].get("cleared"), "the last row, an undo, wins")
+        self.assertEqual(self._user_seals(st, sid, "g12"), ["clear", "reopen", "clear", "reopen"],
+                         "one reopen, for the undo the snapshot lacks; the superseded undo row adds none")
+        self.assertEqual([e["ev_t"] for e in st["nodes"][g]["log"] if e.get("src") == "user" and e.get("undo")],
+                         [1_000_000, 1_000_001], "the re-recorded reopen carries the last undo's second")
+        self.assertEqual(st["status"].get(g), "completed", "the card comes back to Completed, not Working")
+
+    def test_an_undo_a_second_after_a_same_second_undo_and_re_clear_over_a_snapshot_taken_before_them(self):
+        # the same gestures with the snapshot taken after the first clear, so the shared second's undo and
+        # re-clear are both lost. The re-clear never replays (the journal's last word is an undo), and the
+        # shared second's undo row must stand down for the same reason as above: replayed, its reopen would pair
+        # with the first clear and leave the later undo's reopen with nothing to restore
+        sid, g = self.SEAL_SID, "%s:%s" % (self.SEAL_SID, "g13")
+        self._completed_top("g13", sid=sid)
+        with mock.patch("time.time", return_value=999_000.0):
+            km._clear_all([g])
+        snapshot = json.loads((jd.GOALDIR / (sid + ".json")).read_text())
+        with mock.patch("time.time", return_value=1_000_000.0):
+            km._undo_clear()
+            km._clear_all([g])
+        with mock.patch("time.time", return_value=1_000_001.0):
+            km._undo_clear()
+        self.assertEqual([op for op, _ in self._seal_rows(sid, "g13")], ["clear", "unclear", "clear", "unclear"])
+        self.assertEqual(self._user_seals(snapshot, sid, "g13"), ["clear"], "premise: the snapshot holds the first clear only")
+        self._clobber_with(snapshot, sid=sid)
+        st = jd.load_goals(sid)
+        self.assertFalse(st["nodes"][g].get("cleared"), "the last row, an undo, wins")
+        self.assertEqual(self._user_seals(st, sid, "g13"), ["clear", "reopen"], "one reopen restores what the clear displaced")
+        self.assertEqual(st["status"].get(g), "completed", "the card comes back to Completed, not Working")
+
+    def test_a_re_clear_a_second_after_a_same_second_clear_and_undo_carries_its_own_second(self):
+        # the clear and the undo share a second, the snapshot is taken after the undo, and the re-clear lands a
+        # second later. The first clear's row is superseded by the undo row of its second and must stand down:
+        # read on its own it finds the second's newest seal is a reopen and re-records a clear stamped with the
+        # first second, the re-clear's own row then skips on the flag, and the verdict carries the wrong evidence
+        # time (a verdict filed between the undo and the re-clear would sort after it) as a second (ev_t, src,
+        # kind) twin of the first clear
+        sid, g = self.SEAL_SID, "%s:%s" % (self.SEAL_SID, "g14")
+        self._completed_top("g14", sid=sid)
+        with mock.patch("time.time", return_value=1_000_000.0):
+            km._clear_all([g])
+            km._undo_clear()
+        snapshot = json.loads((jd.GOALDIR / (sid + ".json")).read_text())
+        with mock.patch("time.time", return_value=1_000_001.0):
+            km._clear_all([g])
+        self.assertEqual(self._seal_rows(sid, "g14"), [("clear", 1_000_000), ("unclear", 1_000_000), ("clear", 1_000_001)])
+        self.assertEqual(self._user_seals(snapshot, sid, "g14"), ["clear", "reopen"],
+                         "premise: the snapshot holds the first clear and its undo")
+        self._clobber_with(snapshot, sid=sid)
+        st = jd.load_goals(sid)
+        self.assertTrue(st["nodes"][g].get("cleared"), "the last row, a clear, wins")
+        self.assertEqual([e["ev_t"] for e in st["nodes"][g]["log"] if e.get("src") == "user" and e.get("kind") == "clear"],
+                         [1_000_000, 1_000_001], "the re-recorded clear carries the re-clear's second, not the first clear's")
+
+    def test_a_stale_pass_save_rebases_the_re_clear_away_and_the_next_load_re_seals(self):
+        # the designed save path, not a raw overwrite: a pass that loaded the store after the undo publishes
+        # after the re-clear, and save_goals rebases its copy onto the disk it did not write. The rebase keys
+        # verdict identity on (ev_t, src, kind), so the re-clear, a second (T, user, clear), collapses into the
+        # first clear and the published store reads the card uncleared; the replay re-seals it on the next load,
+        # as it does over a clobbered store
+        sid, g = self.SEAL_SID, "%s:%s" % (self.SEAL_SID, "g15")
+        self._completed_top("g15", sid=sid)
+        with mock.patch("time.time", return_value=1_000_000.0):
+            km._clear_all([g])
+            km._undo_clear()
+            stale = jd.load_goals(sid)                                  # the pass's copy, held across its model call
+            km._clear_all([g])
+        self.assertEqual([op for op, _ in self._seal_rows(sid, "g15")], ["clear", "unclear", "clear"])
+        self.assertTrue(json.loads((jd.GOALDIR / (sid + ".json")).read_text())["nodes"][g].get("cleared"),
+                        "premise: the live re-clear landed")
+        jd.save_goals(sid, stale)                                       # the pass publishes: the revision moved, so it rebases
+        raw = json.loads((jd.GOALDIR / (sid + ".json")).read_text())
+        self.assertEqual(self._user_seals(raw, sid, "g15"), ["clear", "reopen"],
+                         "premise: the rebase collapsed the re-clear into the first clear")
+        self.assertFalse(raw["nodes"][g].get("cleared"), "premise: the published store reads the card uncleared")
+        jd._shared_clear()
+        st = jd.load_goals(sid)
+        self.assertTrue(st["nodes"][g].get("cleared"), "the next load re-seals the card")
+        self.assertEqual(self._user_seals(st, sid, "g15"), ["clear", "reopen", "clear"], "the re-clear is re-recorded once")
 
     def test_the_feed_payload_carries_the_ledgers_foreign_ids_for_the_merged_board(self):
         # the viewer's ledger over remote rows (review find, 2026-09-09): ids the local ledger clears whose


### PR DESCRIPTION
## Symptom

A card cleared, undone and cleared again within one second can come back uncleared in its goal store: a triage pass that loaded the store after the undo saves over the re-clear, the store then reads the card uncleared while cleared.jsonl hides it, and the flag and the verdict stay wrong until the next compaction re-seals the root. The mirror shape (clear, then undo, clear and undo within one second, with the pass's snapshot taken after the re-clear) keeps the flag on a card cleared.jsonl has released: the feed hides it, the compaction archives it flagged, the archive projection keeps the flag, and no Undo can reach it.

## Cause

#1187 journals the clear and #1190 settles same-second clear and unclear rows by journal order (`last_seal`). Both arms still asked whether ANY same-kind user write at the row's second survived (`_twin`), which reads an earlier same-second sibling's write as the row's own. Over a snapshot taken after the undo (log: clear T, undo-reopen T; cleared false), the re-clear's row found the first clear at T and skipped, so nothing re-sealed the card. Over a snapshot taken after the re-clear (log: clear T0, undo-reopen T, clear T; cleared true), the last undo's row found the first undo at T and skipped. #1190's same-second test takes its snapshot before the first clear, where the first row's replay supplies the clear and the third row skips on the flag, so the after-undo half had no red test there.

The loss reaches the store through `save_goals` as well as through a raw overwrite: `_rebase_onto_disk` keys verdict identity on (ev_t, src, kind), so a pass that loaded the store after the undo and publishes after the re-clear rebases the re-clear away as a duplicate of the first clear (the third test below).

## Fix

`kernel/judge.py`, `_replay_overrides`, the clear and unclear arms:

- Of a node's clear and unclear rows in one second only the last acts. The pre-scan that fills `last_seal` also fills `last_seal_at`, (node, second) to the last such row's op at that second; a row whose op is not that entry was superseded within its second and skips, whatever the log holds.
- The acting row asks `_newest_seal()` in place of `_twin`: the node's newest user clear or undo-reopen at that second, in `_fold_node`'s order. When the second's last word is in the log already (survived, or re-recorded by an earlier row of the same second in this load) the row skips; when not, it re-records it, and the next load finds the write and skips. One row added per lost gesture, none after that.

`nd.get("cleared")`, `last_seal`, the strictly-later guards, `record_verdict`, and the resolve, followup, move and block arms are unchanged.

The last-row rule is what keeps the newest-seal check from regressing two shapes that stand today. An undo and a re-clear in one second followed by an undo a second later, over a snapshot taken after the re-clear: read on its own, the superseded undo row finds the second's newest seal is a clear and re-records a reopen the second did not end on; the later undo's reopen then follows a reopen instead of a clear, finds nothing to restore, and a completed top comes back Working. A clear and an undo in one second followed by a re-clear a second later, over a snapshot taken after the undo: the superseded clear row re-records a clear stamped with the first second, and the re-clear's own row skips on the flag. A count of surviving same-kind writes against the row's ordinal was considered and rejected: two undo rows of one second around a re-clear that never replays would record two reopens (the seventh test below fails under it).

Not changed here: a clear whose undo follows it in the journal never replays over a snapshot that predates both (`last_seal` reads the node's last word as the undo), so the undo's reopen finds no clear to restore from and a completed top comes back Working, with the flag correctly off. That is the `last_seal` skip's own shape, the same before and after this change.

## Tests

`tests/test_kernel_goal_compaction.py`, class `ClearedLedgerIsAuthoritativeAcrossTheCompaction`, under a sid of its own. `time.time` is pinned so the gestures share a second where the shape needs it: the journal `t` and the verdict `ev_t` and `at` all read it, so the premise does not depend on the wall clock (#1190's test assumes its three gestures land inside one second).

Red before this change:

- `test_a_same_second_re_clear_replays_over_a_snapshot_taken_after_the_undo`: clear, undo, snapshot, clear; overwrite, load. Fails with `AssertionError: False is not true : the last row, a clear, wins over a snapshot that holds the first clear and its undo`. Also asserts the log gains exactly one clear row and a further save and load add none.
- `test_a_same_second_re_undo_replays_over_a_snapshot_taken_after_the_re_clear`: clear at an earlier second; then undo, clear, snapshot, undo; overwrite, load. Fails with `AssertionError: True is not false : the last row, an undo, wins over a snapshot that holds the re-clear`. Also asserts exactly one reopen row added, none on a further load, and the top's status back to completed.
- `test_a_stale_pass_save_rebases_the_re_clear_away_and_the_next_load_re_seals`: clear, undo, a pass loads its copy, clear; the pass publishes through `save_goals` (premise asserted: the published log holds the first clear and its undo and the card reads uncleared); load. Fails with `AssertionError: False is not true : the next load re-seals the card`.
- `test_an_undo_a_second_after_a_same_second_undo_and_re_clear_over_a_snapshot_taken_before_them`: clear at an earlier second, snapshot; undo and clear in one second; undo a second later; overwrite, load. Fails with `Lists differ: ['clear', 'reopen', 'reopen'] != ['clear', 'reopen']`, the top Working.

Green before this change, red under the newest-seal check without the last-row rule (checked by dropping the `last_seal_at` guards):

- `test_an_undo_a_second_after_a_same_second_undo_and_re_clear_replays_once`: the same gestures with the snapshot taken after the re-clear; asserts one reopen added, at the last undo's second, and the top back to completed.
- `test_a_re_clear_a_second_after_a_same_second_clear_and_undo_carries_its_own_second`: clear and undo in one second, snapshot, clear a second later; asserts the re-recorded clear carries the re-clear's second.

Green before and after:

- `test_two_same_second_undos_around_a_skipped_re_clear_record_one_reopen`: clear at an earlier second, snapshot, then undo, clear, undo in one second; asserts one reopen and the top completed. Under the rejected count it fails with `['clear', 'reopen', 'reopen'] != ['clear', 'reopen']`.

Replacing `_newest_seal()` with `_twin` while keeping the last-row rule turns the first three red again. The helpers `_completed_top` and `_clobber_with` take a `sid` keyword with the old default; the existing tests in the class are untouched.

Targeted run: the seventeen test modules that exercise the replay, the clear path or the undo path, 778 passed. Full suite: `pytest -q -n 8 tests/`, 10572 passed, 115 skipped, 1688 subtests passed.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)