### PR TITLE
Compaction: a re-sealed cleared top leaves Show completed, as a top cleared on the live card does

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -31758,6 +31758,11 @@ def _compact_goal_store(fsid):
         except Exception:
             closed = False
         jd.rollup_status(store, closed)
+        # the rollup builds a fresh status dict and REPLACES store["status"] (judge.py rollup_status); the copy
+        # below pops from the dict the store holds now, so the archive gets the re-sealed root's cleared, as it
+        # does when the clear lands on the live card, and the live store keeps no entry for a node it no longer
+        # holds (the pre-rollup dict gave the archive completed, which kept the top listed under Show completed)
+        status = store.get("status", {})
     with jd._GOAL_ARCH_LOCK:                            # the archive is a blind RMW — see the lock's note
         arch = jd.load_goal_archive(fsid)
         a_nodes = arch.setdefault("nodes", {})

--- a/tests/test_kernel_goal_compaction.py
+++ b/tests/test_kernel_goal_compaction.py
@@ -316,7 +316,16 @@ class ClearedLedgerIsAuthoritativeAcrossTheCompaction(unittest.TestCase):
         self.assertEqual(km._compact_goal_store(SID), 1)
         arch = json.loads((jd.GOALARCHDIR / (SID + ".json")).read_text())
         self.assertTrue(arch["nodes"][self.g("g4")]["cleared"], "stamped before the copy")
-        self.assertEqual(arch["status"][self.g("g4")], "completed", "the status is history, untouched")
+        # the re-seal's rollup replaces the store's status dict, and the copy reads the replaced one, as it does
+        # when the clear lands on the live card (a clear after a done rolls up to cleared): the archive gets the
+        # rolled-up value, the live file keeps no entry for a node it no longer holds, and Show completed does
+        # not list the top (the pre-reseal copy read completed, which kept it listed, struck through)
+        self.assertEqual(arch["status"][self.g("g4")], "cleared", "the rolled-up status moves with the node")
+        live = json.loads((jd.GOALDIR / (SID + ".json")).read_text())      # the raw file: a load's replay may re-roll
+        self.assertNotIn(self.g("g4"), live.get("status", {}), "no status for a node the live store no longer holds")
+        self._fresh_process()
+        self.assertEqual([n["id"] for n in km._fleet_archived_tops(SID)], [],
+                         "a cleared top is not a completed one: nothing for Show completed to list")
 
     def test_the_projection_reads_the_ledger_over_the_copied_flag_after_its_cache(self):
         jd.GOALARCHDIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Symptom

After the compaction moved a top the user had cleared, the top stayed listed under Show completed, struck through, when its clear had survived only in cleared.jsonl (a racing pass save had erased the verdict and the flag, and the row predates the journal). A clear that lands on the live card takes the top off that list, and #1187, which added the re-seal, states that outcome: the rollup turns the status to cleared and drops the completion flag, so the top leaves the completed projection.

## Cause

`_compact_goal_store` binds `status = store.get("status", {})` before the re-seal. For a root that cleared.jsonl clears and whose flag is gone, it re-seals the root through the diary and calls `jd.rollup_status(store, closed)`. `rollup_status` builds a fresh dict and replaces `store["status"]`; it does not mutate the one bound earlier. The copy loop that follows still popped from the earlier dict, so:

- the archive received the pre-reseal `"completed"`, the value that keeps an archived top listed in `_fleet_archived_tops` (after the re-seal the root's `nodeComplete` is False, so only the copied status listed it, and the row rendered struck through);
- the store's replaced dict kept `root: "cleared"` for a node no longer in `nodes`, and `save_goals` persisted that entry.

The rewind archiver (`archive_goal_nodes` in kernel/judge.py) pops first and re-rolls after, so only the compaction had the order wrong.

## Fix

One line in `_compact_goal_store`: after `jd.rollup_status(store, closed)`, rebind `status = store.get("status", {})` so the copy pops from the dict the store holds now. The archive carries `"cleared"` for the re-sealed root, as the ordinary clear path copies it, and the live status has no entry for the moved node.

The change covers compactions from now on. An archive the compaction wrote before it keeps the copied `"completed"` for such a root, since nothing rewrites an archived status; that top stays listed until the user restores it and clears it again.

## Tests

`tests/test_kernel_goal_compaction.py`, `ClearedLedgerIsAuthoritativeAcrossTheCompaction.test_the_compaction_stamps_a_root_only_the_ledger_clears`, amended over the same setup (a completed top, a clear row in cleared.jsonl with no flag and no journal row, one node moved):

- `arch["status"][g4] == "cleared"`: before the change it read `"completed"` (the assertion the test carried until now, which pinned the pre-reseal copy against the outcome #1187 describes).
- the raw live file's `status` has no entry for the moved root: before the change it held `g4: "cleared"` for a node the store no longer had. This assertion fails on its own if the rebind is replaced by a copy of the rolled-up dict (the archive then reads `"cleared"` while the live entry stays).
- after the in-process memos drop, `_fleet_archived_tops(SID)` returns no rows: before the change it listed the root with done=True and cleared=True, the struck-through row under Show completed.

Full suite on 9df3a878 (`pytest -q -n 8 tests/`): 10565 passed, 115 skipped, 0 failed, 1688 subtests passed.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)