### PR TITLE
Tests: a served lab's cfg.json carries only the environment the relaunched kernel needs, never the runner's whole environment

### DIFF
--- a/tests/test_dashboard_reload_served.py
+++ b/tests/test_dashboard_reload_served.py
@@ -32,6 +32,11 @@ BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
 SID = "11111111-2222-4333-8444-000000000201"
 
+import sys
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the served lab's cfg.relaunch stanza (the module, not its classes:
+#                                   an imported TestCase would be collected here a second time)
+
 
 def _free_port():
     s = socket.socket()
@@ -201,6 +206,9 @@ class ServedAutoReload(unittest.TestCase):
                        ROMP_TMUX_SOCKET="romp-autoreload-%d" % cls.port)
         cls.env.pop("ROMP_STATE_DIR", None)
         cls.env.pop("ANTHROPIC_API_KEY", None)
+        # a stand-in for a key the runner's shell carries: the lab's kernel gets it by process environment with the
+        # rest of the runner's, and the cfg.json the driver reads must never carry it
+        cls.env["RUNNER_SECRET_PROBE"] = "abc"
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
                                       stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=cls.env)
@@ -234,7 +242,14 @@ class ServedAutoReload(unittest.TestCase):
         with open(cfg, "w") as f:
             json.dump({"url": "http://127.0.0.1:%d/?token=%s" % (self.port, self.token),
                        "kernelPid": self.kernel.pid, "bumpFile": self.bump_file,
-                       "relaunch": {"cmd": os.path.join(BIN, "romp-kernel"), "env": self.env, "log": self.klog}}, f)
+                       "relaunch": _lab.relaunch_cfg(self.env, self.klog)}, f)
+        # the file carries only what the driver and the relaunched kernel need: the probe the lab planted in its
+        # kernel's environment (checked first, so the file check cannot pass without it) must not be in it (names
+        # only in the report, never the values)
+        self.assertIn("RUNNER_SECRET_PROBE", sorted(self.env), "the lab plants the probe in its kernel's environment")
+        written = json.loads(Path(cfg).read_text(encoding="utf-8"))
+        self.assertNotIn("RUNNER_SECRET_PROBE", sorted(written["relaunch"]["env"]),
+                         "the lab's cfg.json carries a variable of the runner's environment the relaunch does not need")
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
             f.write(DRIVER)

--- a/tests/test_ship_reship.py
+++ b/tests/test_ship_reship.py
@@ -29,6 +29,11 @@ The guards here:
     re-shipped file. Its nack retires the last pending ship, which lets the restart's held
     reload fire on the next task, and the notice the nack raised (the file was not saved, the
     held message not sent) must be shown again by the fresh page, once.
+  * RelaunchEnv, which runs everywhere: the relaunch stanza the lab writes to its cfg.json for the
+    driver's relaunch of the kernel carries only the environment the relaunched kernel needs, never
+    the runner's whole environment (a runner variable planted as a probe is absent; the lab's own
+    names, the run's private roots and its git isolation present); the served legs check the
+    written file itself.
 
 All fixtures synthetic.
 """
@@ -44,6 +49,7 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
@@ -123,6 +129,32 @@ def _free_port():
     p = s.getsockname()[1]
     s.close()
     return p
+
+
+# The environment the driver hands the kernel it relaunches rides the lab's cfg.json, a file, so it carries only
+# the names the relaunched kernel needs here: ROMP_* and XDG_*, CLAUDE_CONFIG_DIR, PATH (bin/romp-kernel runs under
+# `env python3`) and HOME, plus what tests/conftest.py sets for every child of the run: TMPDIR and TMUX_TMPDIR, the
+# private roots its temp files and its tmux server live under, and GIT_CONFIG_GLOBAL and GIT_CONFIG_NOSYSTEM, which
+# keep the kernel's boot-time git (the build sha, the release-tag probe) off the developer's git configuration.
+# Never the runner's whole environment: on a machine whose shells carry API keys, a copy of os.environ in that file
+# holds them for the run. The lab's own kernel is started from this process and gets its environment by process,
+# as any child does; only what goes to the file is narrowed.
+RELAUNCH_ENV_PREFIXES = ("ROMP_", "XDG_")
+RELAUNCH_ENV_NAMES = frozenset(("CLAUDE_CONFIG_DIR", "PATH", "HOME", "TMPDIR", "TMUX_TMPDIR",
+                                "GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM"))
+
+
+def relaunch_env(env):
+    """The part of a lab kernel's environment `env` that a served lab writes to its cfg.json for the driver's
+    relaunch of the kernel."""
+    return {k: v for k, v in env.items() if k.startswith(RELAUNCH_ENV_PREFIXES) or k in RELAUNCH_ENV_NAMES}
+
+
+def relaunch_cfg(env, klog):
+    """cfg.relaunch, the stanza a served lab writes for the driver's relaunch of the kernel it kills: the command,
+    relaunch_env() of the lab kernel's environment `env`, and the log `klog` the first kernel writes. Both served
+    labs write their stanza through this, so RelaunchEnv covers what reaches the file."""
+    return {"cmd": os.path.join(BIN, "romp-kernel"), "env": relaunch_env(env), "log": klog}
 
 
 DRIVER = r"""
@@ -292,14 +324,10 @@ class _ShipLab(unittest.TestCase):
         Path(cls.png).write_bytes(PNG)
         cls.port = _free_port()
         cls.token = "testtok-reship"
-        cls.env = dict(os.environ,
-                       XDG_STATE_HOME=os.path.join(cls.lab, "xdg"),
-                       CLAUDE_CONFIG_DIR=claude,
-                       ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1",
-                       ROMP_SERVE_TOKEN=cls.token, ROMP_KERNEL_PORT=str(cls.port),
-                       ROMP_DIST_DIR=dist,
-                       ROMP_MODEL_CATALOG="off")   # hermetic: the T222 catalog fetch must never reach the network
-        cls.env.pop("ROMP_STATE_DIR", None)
+        cls.env = cls.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
+        # a stand-in for a key the runner's shell carries: the lab's kernel gets it by process environment with the
+        # rest of the runner's, and _run_driver checks that the cfg.json the driver reads never does
+        cls.env["RUNNER_SECRET_PROBE"] = "abc"
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
                                       stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=cls.env)
@@ -314,6 +342,21 @@ class _ShipLab(unittest.TestCase):
         else:
             cls.kernel.kill()
             raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @staticmethod
+    def kernel_env(lab, claude, dist, port, token):
+        """The lab kernel's environment: the runner's, with the lab's roots and seams over it. The kernel the lab
+        starts gets it by process; the driver's relaunch gets relaunch_env() of it, through the stanza
+        relaunch_cfg() writes to the lab's cfg.json."""
+        env = dict(os.environ,
+                   XDG_STATE_HOME=os.path.join(lab, "xdg"),
+                   CLAUDE_CONFIG_DIR=claude,
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1",
+                   ROMP_SERVE_TOKEN=token, ROMP_KERNEL_PORT=str(port),
+                   ROMP_DIST_DIR=dist,
+                   ROMP_MODEL_CATALOG="off")   # hermetic: the T222 catalog fetch must never reach the network
+        env.pop("ROMP_STATE_DIR", None)
+        return env
 
     @classmethod
     def tearDownClass(cls):
@@ -332,6 +375,13 @@ class _ShipLab(unittest.TestCase):
         cfg = os.path.join(self.lab, "cfg.json")
         with open(cfg, "w") as f:
             json.dump(cfg_obj, f)
+        # the file carries only what the driver and the relaunched kernel need: the probe the lab planted in its
+        # kernel's environment (checked first, so the file check cannot pass without it) must not be in it (names
+        # only in the report, never the values)
+        self.assertIn("RUNNER_SECRET_PROBE", sorted(self.env), "the lab plants the probe in its kernel's environment")
+        written = json.loads(Path(cfg).read_text(encoding="utf-8"))
+        self.assertNotIn("RUNNER_SECRET_PROBE", sorted(written.get("relaunch", {}).get("env", {})),
+                         "the lab's cfg.json carries a variable of the runner's environment the relaunch does not need")
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
             f.write(driver_src)
@@ -361,13 +411,45 @@ class _ShipLab(unittest.TestCase):
         return r
 
 
+class RelaunchEnv(unittest.TestCase):
+    """The relaunch stanza a served lab writes to its cfg.json for the driver's relaunch of the kernel carries only
+    the environment the relaunched kernel needs, never the runner's whole environment: on a machine whose shells
+    carry API keys, a copy of os.environ in that file holds them for the run. No kernel and no browser, so this
+    runs everywhere; the served legs check the written file itself (_run_driver)."""
+
+    def test_a_runner_variable_never_reaches_the_relaunch_env_and_the_kernels_names_do(self):
+        lab = os.path.join(os.sep, "lab")
+        # the runner's shell: a stand-in for a key it carries, a live kernel's state export (it outranks the XDG root,
+        # and the lab removes it) and the floor tests/conftest.py sets for the run's children, planted here so the
+        # test asserts on values it chose rather than on conftest having set them
+        runner = {"RUNNER_SECRET_PROBE": "abc",
+                  "ROMP_STATE_DIR": os.path.join(lab, "live"),
+                  "TMPDIR": os.path.join(lab, "tmp"), "TMUX_TMPDIR": os.path.join(lab, "tmux"),
+                  "GIT_CONFIG_GLOBAL": os.path.join(lab, "gitconfig"), "GIT_CONFIG_NOSYSTEM": "1"}
+        with mock.patch.dict(os.environ, runner):
+            env = _ShipLab.kernel_env(lab, os.path.join(lab, "claude"), os.path.join(lab, "dist"), 4321, "testtok")
+        self.assertIn("RUNNER_SECRET_PROBE", sorted(env), "the lab's own kernel inherits the runner's environment, by process")
+        cfg = relaunch_cfg(env, os.path.join(lab, "kernel.log"))
+        self.assertEqual(cfg["cmd"], os.path.join(BIN, "romp-kernel"))
+        self.assertEqual(cfg["log"], os.path.join(lab, "kernel.log"))
+        out = cfg["env"]
+        names = sorted(out)
+        self.assertNotIn("RUNNER_SECRET_PROBE", names, "the relaunch reads the file: a runner variable must not be in it")
+        self.assertNotIn("ROMP_STATE_DIR", names, "a live kernel's export outranks the XDG root; the lab removes it")
+        for name in ("XDG_STATE_HOME", "CLAUDE_CONFIG_DIR", "ROMP_MANAGER_PORT", "ROMP_KERNEL_NO_OPEN", "ROMP_SERVE_TOKEN",
+                     "ROMP_KERNEL_PORT", "ROMP_DIST_DIR", "ROMP_MODEL_CATALOG", "PATH", "HOME"):
+            self.assertIn(name, names, "the relaunched kernel needs %s" % name)
+        self.assertEqual(out["XDG_STATE_HOME"], os.path.join(lab, "xdg"))
+        self.assertEqual(out["ROMP_KERNEL_PORT"], "4321")
+        for name in ("TMPDIR", "TMUX_TMPDIR", "GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM"):
+            self.assertEqual(out.get(name), runner[name], "the run's %s reaches the relaunched kernel" % name)
+
+
 class ServedWedge(_ShipLab):
     def test_restart_between_ship_and_ack_reships_heals_and_releases_the_held_send(self):
         r = self._run_driver(DRIVER, {
             "url": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
-            "kernelPid": self.kernel.pid,
-            "relaunch": {"cmd": os.path.join(BIN, "romp-kernel"),
-                         "env": {k: v for k, v in self.env.items()}, "log": self.klog},
+            "kernelPid": self.kernel.pid, "relaunch": relaunch_cfg(self.env, self.klog),
             "file": self.png, "msg": "hold this message for the upload T215",
             "msg2": "a normal send after the restart T215",
             "shots": os.environ.get("SHIP_RESHIP_SHOTS", "")})
@@ -589,9 +671,7 @@ class NackNoticeSurvivesReload(_ShipLab):
     def test_the_nack_of_the_last_ship_is_shown_again_by_the_fresh_page_once(self):
         r = self._run_driver(DRIVER_NACK, {
             "url": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
-            "kernelPid": self.kernel.pid,
-            "relaunch": {"cmd": os.path.join(BIN, "romp-kernel"),
-                         "env": {k: v for k, v in self.env.items()}, "log": self.klog},
+            "kernelPid": self.kernel.pid, "relaunch": relaunch_cfg(self.env, self.klog),
             "file": self.png, "msg": "hold this message for the upload that will not save",
             "drops": os.path.join(self.state, "drops"),
             "probe": "probe: an ephemeral notice, which the fresh page must not repeat"})


### PR DESCRIPTION
## Symptom

Running tests/test_ship_reship.py or tests/test_dashboard_reload_served.py on a machine whose shells carry API keys leaves those keys in a temp file for the run. Both labs kill their hermetic kernel from the browser driver and start it again, and the driver reads the kernel's environment from the lab's cfg.json; that file held the runner's whole environment.

## Cause

Each lab builds its kernel's environment as a copy of os.environ with the lab's roots and seams over it, which is right for the kernel the lab starts from the test process (a child gets its environment by process). The same mapping was written whole into cfg.json's relaunch.env for the driver's child_process.spawn.

## Fix

tests/test_ship_reship.py gains relaunch_env(env), the part of a lab kernel's environment the relaunched kernel needs: the ROMP_* and XDG_* names, CLAUDE_CONFIG_DIR, PATH (bin/romp-kernel runs under `env python3`) and HOME, plus what tests/conftest.py sets for every child of the run: TMPDIR and TMUX_TMPDIR, the private roots its temp files and tmux server live under, and GIT_CONFIG_GLOBAL and GIT_CONFIG_NOSYSTEM, which keep the kernel's boot-time git (the build sha, the release-tag probe) off the developer's git configuration. relaunch_cfg(env, klog) builds the cfg.relaunch stanza (the command, relaunch_env of the environment, the log), and both labs write their stanza through it: the ship lab builds its kernel's environment in kernel_env, and the dashboard lab imports the module. The lab's own kernel still gets the full environment by process, and what the relaunched kernel does with its environment is unchanged; only what goes to the file is narrowed.

## Tests

- tests/test_ship_reship.py RelaunchEnv (no kernel, no browser; runs everywhere): plants RUNNER_SECRET_PROBE=abc (a stand-in for a key in the runner's shell), ROMP_STATE_DIR (a live kernel's export, which the lab removes) and synthetic TMPDIR, TMUX_TMPDIR, GIT_CONFIG_GLOBAL and GIT_CONFIG_NOSYSTEM values in os.environ, builds the lab's kernel environment through kernel_env and its stanza through relaunch_cfg, and asserts: the probe is in the kernel's environment (the process path) and absent from the stanza's; ROMP_STATE_DIR absent; the kernel's names present (XDG_STATE_HOME, CLAUDE_CONFIG_DIR, the ROMP_* seams with the manager-port floor among them, PATH, HOME) with the lab's values; the four conftest names present with the planted values; the stanza's command and log. Before the change it fails on the absent kernel_env. Each of these mutations turns it red at the assertion that names it: dropping TMPDIR and TMUX_TMPDIR, or the two GIT_CONFIG names, from the kept list; removing the ROMP_STATE_DIR pop from kernel_env; relaunch_cfg handing the whole environment; relaunch_env returning the whole environment.
- The served legs (ServedWedge and NackNoticeSurvivesReload in test_ship_reship.py, ServedAutoReload in test_dashboard_reload_served.py): each lab plants the probe in its kernel's environment, and the writer asserts the probe is in that environment and then absent from the cfg.json it wrote, before the driver runs; a failure lists names only, never values. Before the change all three fail at the file check, the whole environment being in the file; deleting either lab's probe plant fails its leg at the first assertion. After the change they pass with the narrowed environment, run locally against Chromium (the relaunched kernel serves the page, the re-ship heals, the reload fires): 11 passed for the two modules.
- Full suite (pytest -n 8 tests/): 10772 passed, 41 skipped, 0 failed (1688 subtests) in 161 s, run on the final tree after the rebase onto the current main; the served legs are among the passes here, where a browser is present.

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)