### PR TITLE
Comments: a second comment in the same words on the same passage makes a second thread, not a second ack on the first

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13700,16 +13700,23 @@ def _comment_markers(sid):
 # alone starves; the client's frame-keyed re-post stays as the belt for a kernel restart that loses
 # this in-memory park). The typed transient nack keeps the client's optimistic mark alive meanwhile.
 ANCHOR_LAG_ERR = "that message isn't in the transcript yet; try again in a moment"
-_parked_creates = []                       # [{sid,uuid,exact,text,name,model,effort,fast,color,tries}]
+_parked_creates = []                       # [{sid,uuid,exact,text,name,model,effort,fast,color,createId,tries}]
 _PARK_MAX_TRIES = 30                       # pusher cycles (~15-90s) — past this the record isn't coming
-# A create's IDENTITY (T289): (parent sid, anchor uuid, passage, text) -> the thread it made. A lag-parked
-# create is retried by BOTH the pusher (above) and the client (its frame-keyed re-post), and a popover
-# whose ack was lost sends its create again; the second copy used to collide on its explicit name and
-# come back as the create door's refusal toast (the user 2026-09-09, on a remote session), or — with the
-# name now left to the kernel's default — would mint a SECOND thread for one comment. The memo answers a
-# repeat with the SAME thread's ack, and a parked copy is parked once. Bounded (oldest out), in memory:
-# a kernel restart forgets it, and the client's re-post after one creates exactly once.
-_recent_creates = {}                       # (sid, uuid, exact, text) -> tid
+# A create's IDENTITY (T289): the client's createId, minted by the popover at the send gesture and carried
+# by every re-post of it, under the parent sid -> the thread it made. A lag-parked create is retried by
+# BOTH the pusher (above) and the client (its frame-keyed re-post), and a popover whose ack was lost sends
+# its create again; the second copy used to collide on its explicit name and come back as the create
+# door's refusal toast (the user 2026-09-09, on a remote session), or, with the name now left to the
+# kernel's default, would mint a SECOND thread for one comment. The memo answers a repeat with the SAME
+# thread's ack, and a parked copy is parked once. The first cut keyed on the words (parent sid, anchor
+# uuid, passage, text), and so also answered a DELIBERATE second comment in the same words on the same
+# passage with the first thread: two acks, the second name nowhere on disk (review, 2026-09-09). The id
+# keys on the gesture instead; a frame from a client that sends none still keys on its words. A comment
+# the user posts again by hand while the first is still parked (after a viewer reload, or after the viewer
+# gave up at its own attempt bound) is a new gesture and lands as a second thread: a visible duplicate
+# the user can delete, where the words key lost the second comment silently. Bounded (oldest out), in
+# memory: a kernel restart forgets it, and the client's re-post after one creates exactly once.
+_recent_creates = {}                       # (sid, createId) or (sid, uuid, exact, text) -> tid
 _RECENT_CREATES_MAX = 256
 # The two doors that can run one create — the WS handler on a server thread and _retry_parked_creates on
 # the pusher — reserve the identity under ONE lock before creating (review, 2026-09-09): the pusher sends
@@ -13721,8 +13728,18 @@ _create_lock = threading.RLock()
 _inflight_creates = set()                  # keys whose _comment_create is running right now, either door
 
 
-def _create_key(sid, uuid, exact, text):
+def _create_key(sid, uuid, exact, text, create_id=""):
+    """What one create is remembered by: the gesture's own id when the frame carries one (a fresh comment
+    in the same words is a new id, a re-post is the same one), else its words. The two shapes never meet:
+    a stamped frame is not a repeat of an unstamped one, nor the other way round."""
+    cid = str(create_id or "")
+    if cid:
+        return (str(sid), cid)
     return (str(sid), str(uuid), str(exact), str(text))
+
+
+def _parked_key(pk):
+    return _create_key(pk["sid"], pk["uuid"], pk["exact"], pk["text"], pk.get("createId", ""))
 
 
 def _note_create(key, tid):
@@ -13753,8 +13770,7 @@ def _reserve_create(key):
         again = _repeat_create_tid(key)
         if again:
             return "repeat", again
-        if key in _inflight_creates or any(_create_key(pk["sid"], pk["uuid"], pk["exact"], pk["text"]) == key
-                                           for pk in _parked_creates):
+        if key in _inflight_creates or any(_parked_key(pk) == key for pk in _parked_creates):
             return "busy", None
         _inflight_creates.add(key)
         return "free", None
@@ -13774,7 +13790,7 @@ def _retry_parked_creates():
     if not _parked_creates:
         return
     for pk in list(_parked_creates):
-        key = _create_key(pk["sid"], pk["uuid"], pk["exact"], pk["text"])
+        key = _parked_key(pk)
         with _create_lock:
             if _repeat_create_tid(key):            # the client's re-post already made it: the park is moot
                 if pk in _parked_creates:
@@ -15573,7 +15589,9 @@ def _drive(msg, client):
         # guess) and the fresh {type:"comments"} frame rides straight back, ahead of the pusher cycle.
         # A REPEAT of a create this kernel already completed (a client re-post after a lost ack or a
         # parked copy that landed) is the same comment: answer with the same thread, never a twin (T289).
-        key = _create_key(sid, msg["uuid"], msg["exact"], msg["text"])
+        # The repeat is known by the createId the popover minted at the send gesture, so a second comment
+        # in the same words on the same passage, a new id, is a new thread (review, 2026-09-09).
+        key = _create_key(sid, msg["uuid"], msg["exact"], msg["text"], msg.get("createId") or "")
         state, again = _reserve_create(key)
         if state == "repeat":
             sys.stderr.write("comment create repeated (%s): the same comment again, answered with thread %s\n"
@@ -15607,13 +15625,14 @@ def _drive(msg, client):
             # client re-posts the same create on every frame while the nack stands.
             if err == ANCHOR_LAG_ERR:
                 with _create_lock:
-                    if not any(_create_key(pk["sid"], pk["uuid"], pk["exact"], pk["text"]) == key for pk in _parked_creates):
+                    if not any(_parked_key(pk) == key for pk in _parked_creates):
                         _parked_creates.append({"sid": sid, "uuid": str(msg["uuid"]), "exact": str(msg["exact"]),
                                                 "text": str(msg["text"]), "name": str(msg.get("name") or ""),
                                                 "model": str(msg.get("model") or ""),
                                                 "effort": str(msg.get("effort") or ""),
                                                 "fast": str(msg.get("fast") or ""),
-                                                "color": str(msg.get("color") or ""), "tries": 0})
+                                                "color": str(msg.get("color") or ""),
+                                                "createId": str(msg.get("createId") or ""), "tries": 0})
             else:
                 client["send"](json.dumps({"type": "warn", "text": err}))
                 # the kernel log carries the refusal too (T289): a name refused at this door showed only

--- a/tests/test_comment_create_idempotent.py
+++ b/tests/test_comment_create_idempotent.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
-"""T289: a comment CREATE is idempotent on its own identity (parent, anchor, passage, text).
+"""T289: a comment CREATE is idempotent on its own identity.
 
 A create parked for transcript lag is retried by BOTH the kernel (the pusher's _retry_parked_creates) and
 the client (its frame-keyed re-post), and a create whose ack was lost is sent again by the popover; before
 this the second copy either collided on its explicit name and was refused with the create toast the user
 saw, or, with the name now left to the kernel, would have minted a SECOND thread for one comment. The
-kernel remembers each create it completed by (parent sid, anchor uuid, passage, text) and answers a repeat
-with the SAME thread's ack; a lag-parked create is parked once. SYNTHETIC fixtures."""
+kernel remembers each create it completed and answers a repeat with the SAME thread's ack; a lag-parked
+create is parked once.
+
+The identity is the client's createId when the frame carries one: the popover mints it at the send gesture
+and every re-post of that gesture carries the same one, so a repeat is exactly a frame with an id the kernel
+has seen. Keyed on the words instead (parent sid, anchor uuid, passage, text), the memo also swallowed a
+DELIBERATE second comment in the same words on the same passage: one thread, two acks, the second name
+nowhere on disk (review of the memo, 2026-09-09). A frame without a createId still keys on the words.
+SYNTHETIC fixtures."""
 import contextlib
 import io
 import json
@@ -128,9 +135,12 @@ class CreateIsIdempotent(unittest.TestCase):
     def _warns(self):
         return [f["text"] for f in self.sent if f.get("type") == "warn"]
 
-    def _create(self, text="Why jitter at all?", uuid="a1", name=""):
-        return self._drive({"type": "commentCreate", "id": PARENT, "uuid": uuid, "exact": "exponential backoff",
-                            "text": text, "name": name})
+    def _create(self, text="Why jitter at all?", uuid="a1", name="", create_id=None):
+        msg = {"type": "commentCreate", "id": PARENT, "uuid": uuid, "exact": "exponential backoff",
+               "text": text, "name": name}
+        if create_id is not None:
+            msg["createId"] = create_id                 # the client's per-gesture stamp (absent from an older client)
+        return self._drive(msg)
 
     def _rows(self):
         return km._load_comments(PARENT).get("threads") or []
@@ -228,6 +238,134 @@ class CreateIsIdempotent(unittest.TestCase):
         rows = self._rows()
         self.assertEqual(len(rows), 2, "a second, open thread for the re-asked comment")
         self.assertEqual(self._warns(), [])
+
+    def test_a_fresh_gesture_in_the_same_words_on_the_same_passage_is_a_second_thread(self):
+        # the user posts a comment, takes the ack, and posts the SAME words on the same passage again under
+        # another name: two gestures, two comments. Keyed on the words alone the memo answered the second
+        # with the first thread's ack, and the second name was nowhere on disk (review, 2026-09-09).
+        self._create(name="first-look", create_id="g-1111")
+        first = self._acks()[-1]["tid"]
+        self._create(name="second-look", create_id="g-2222")
+        rows = self._rows()
+        self.assertEqual(len(rows), 2, "two gestures are two comments, whatever their words")
+        self.assertEqual(sorted(r["name"] for r in rows), ["first-look", "second-look"], "both names on disk")
+        acks = self._acks()
+        self.assertEqual(len(acks), 2)
+        self.assertNotEqual(acks[1]["tid"], first, "the second ack names the second thread")
+        self.assertEqual(self._warns(), [])
+
+    def test_a_retried_frame_with_the_same_create_id_is_one_thread_answered_twice(self):
+        # the re-post side of the same rule: a frame the client sends again (a lost ack, a lag retry) carries
+        # the id it minted at the gesture, and the kernel answers it with the thread that gesture made
+        self._create(create_id="g-1111"); self._create(create_id="g-1111")
+        self.assertEqual(len(self._rows()), 1, "one gesture, one thread")
+        acks = self._acks()
+        self.assertEqual(len(acks), 2, "the repeat is answered, so the popover adopts the thread")
+        self.assertEqual(acks[0]["tid"], acks[1]["tid"])
+        self.assertEqual(self._warns(), [])
+
+    def test_a_fresh_gesture_after_a_parked_create_landed_is_a_second_thread_and_its_repost_is_not(self):
+        # the parked copy carries the gesture's id through the pusher's retry: the client's re-post of THAT
+        # gesture is the same comment, and a new gesture in the same words a moment later is a new one
+        km._parked_creates.clear()
+        self._create(uuid="a9", create_id="g-1111")
+        self.assertEqual(len(km._parked_creates), 1)
+        p = Path(km._sessions(0)[0]["path"])
+        with p.open("a") as fh:
+            fh.write(json.dumps(aline(self.now - 300, "Add a jitter to the backoff.", "a9", parent="a1")) + "\n")
+        km._retry_parked_creates()
+        self.assertEqual(km._parked_creates, [])
+        landed = self._rows()
+        self.assertEqual(len(landed), 1)
+        self._create(uuid="a9", create_id="g-1111")   # the client's own re-post of the parked gesture
+        self.assertEqual(len(self._rows()), 1, "the re-post is the same comment")
+        self.assertEqual(self._acks()[-1]["tid"], landed[0]["tid"])
+        self._create(uuid="a9", create_id="g-2222")   # a new gesture, same words, same passage
+        rows = self._rows()
+        self.assertEqual(len(rows), 2, "a fresh gesture is a second thread")
+        self.assertNotEqual(self._acks()[-1]["tid"], landed[0]["tid"])
+        self.assertEqual(self._warns(), [])
+
+    def test_two_gestures_in_the_same_words_are_both_parked_while_the_anchor_lags(self):
+        # two comments posted before the anchor reached the transcript park separately and land as two
+        # threads; the same gesture posted twice still parks once
+        km._parked_creates.clear()
+        self._create(uuid="a9", create_id="g-1111"); self._create(uuid="a9", create_id="g-1111")
+        self.assertEqual(len(km._parked_creates), 1, "one parked copy for one gesture")
+        self._create(uuid="a9", create_id="g-2222")
+        self.assertEqual(len(km._parked_creates), 2, "a second gesture is its own parked create")
+        nacks = [f for f in self.sent if f.get("type") == "commentCreateFailed"]
+        self.assertEqual(len(nacks), 3)
+        self.assertTrue(all(n["transient"] for n in nacks))
+        p = Path(km._sessions(0)[0]["path"])
+        with p.open("a") as fh:
+            fh.write(json.dumps(aline(self.now - 300, "Add a jitter to the backoff.", "a9", parent="a1")) + "\n")
+        km._retry_parked_creates()
+        self.assertEqual(km._parked_creates, [])
+        self.assertEqual(len(self._rows()), 2, "both gestures landed as threads")
+        self.assertEqual(self._warns(), [])
+
+    def test_a_frame_without_a_create_id_still_keys_on_the_words(self):
+        # an older client sends no id: the words identity stands for it, and a stamped frame in the same
+        # words is not answered from the words memo (nor the other way round)
+        self._create(); self._create()
+        self.assertEqual(len(self._rows()), 1)
+        self._create(create_id="g-1111")
+        self.assertEqual(len(self._rows()), 2, "a stamped gesture is not a repeat of an unstamped one")
+        self._create()
+        self.assertEqual(len(self._rows()), 2, "and the unstamped repeat still answers from its own memo")
+        self.assertEqual(self._warns(), [])
+
+    def test_a_repost_of_a_parked_gesture_is_refused_at_the_door_before_the_create_runs(self):
+        # the busy nack for a re-post of a parked gesture comes from the reservation, which finds the parked
+        # copy by the gesture's id, so the create never runs a second time (compared by its words instead, a
+        # stamped re-post would go free, re-run the create into the lag and rely on the park-once check)
+        km._parked_creates.clear()
+        self._create(uuid="a9", create_id="g-1111")
+        self.assertEqual(len(km._parked_creates), 1)
+        real = km._comment_create
+        calls = []
+
+        def counting(*a, **k):
+            calls.append(a)
+            return real(*a, **k)
+        km._comment_create = counting
+        try:
+            self._create(uuid="a9", create_id="g-1111")
+        finally:
+            km._comment_create = real
+        self.assertEqual(calls, [], "the re-post is busy at the door; no second create")
+        nacks = [f for f in self.sent if f.get("type") == "commentCreateFailed"]
+        self.assertEqual(len(nacks), 2)
+        self.assertTrue(all(n["transient"] for n in nacks))
+        self.assertEqual(len(km._parked_creates), 1)
+        km._parked_creates.clear()
+
+    def test_a_repost_landing_between_the_doors_release_and_its_park_is_parked_once(self):
+        # the door releases its reservation before it parks, and the park-once check covers that window: a
+        # re-post of the same gesture on another server thread lands in it, runs the create into the lag and
+        # parks first; this door then finds that parked copy by the gesture's id and parks no twin (the other
+        # door runs whole inside the window here, in place of a second thread, so the order is exact)
+        km._parked_creates.clear()
+        real = km._release_create
+        raced = []
+
+        def release_then_race(key):
+            real(key)
+            if not raced:
+                raced.append(key)
+                self._create(uuid="a9", create_id="g-1111")
+        km._release_create = release_then_race
+        try:
+            self._create(uuid="a9", create_id="g-1111")
+        finally:
+            km._release_create = real
+        self.assertEqual(len(raced), 1)
+        self.assertEqual(len(km._parked_creates), 1, "one parked copy for one gesture, whichever door parked it")
+        nacks = [f for f in self.sent if f.get("type") == "commentCreateFailed"]
+        self.assertEqual(len(nacks), 2)
+        self.assertTrue(all(n["transient"] for n in nacks))
+        km._parked_creates.clear()
 
     def test_an_answered_repeat_is_said_in_the_kernel_log(self):
         self._create()

--- a/ui/webview/comment-remote-routing.test.ts
+++ b/ui/webview/comment-remote-routing.test.ts
@@ -17,12 +17,14 @@ test("commentReply for a remote thread routes to the parent's host by sid; tid a
 
 test("commentCreate for a remote session routes by sid and carries the name exactly as given", () => {
   const routes = routeOutbound({ type: "commentCreate", id: "TESTHOST:" + SID, uuid: "u1", exact: "backoff",
-                                 text: "why jitter?", name: "", model: "", effort: "", fast: "", color: "" });
+                                 text: "why jitter?", name: "", model: "", effort: "", fast: "", color: "",
+                                 createId: "k1x2y3z4" });
   assert.equal(routes.length, 1);
   assert.equal(routes[0].host, "TESTHOST");
   assert.equal(routes[0].msg.id, SID);
   assert.equal(routes[0].msg.name, "", "an empty name stays empty: the owning kernel picks its default");
   assert.equal(routes[0].msg.uuid, "u1");
+  assert.equal(routes[0].msg.createId, "k1x2y3z4", "the gesture's id reaches the owning kernel, which keys its repeat memo on it");
 });
 
 test("a local thread's reply stays local with a bare sid", () => {

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -6,7 +6,7 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { threadsByAnchor, threadBusy, threadStuck, replyOwed, agentCount, findExact, findAnchorRange, sliceRanges, prunePending,
-         type CommentThread } from "./comments";
+         newCommentCreate, commentCreateFrame, type CommentThread, type CommentCreate } from "./comments";
 import { compactDisplay } from "./compact";
 
 const th = (over: Partial<CommentThread>): CommentThread => ({
@@ -281,8 +281,11 @@ test("the create dialog pre-reads the kernel's default-comment trio and shows it
 test("fast rides the create end to end, resolved dialog > setting > inherit at the kernel", () => {
   // the chip is offered only where the effective model could run fast (no control that only toasts)
   assert.match(UI, /if \(canFast\(create\.model \|\| setDef\("model"\) \|\| st\?\.model \|\| ""\)\) metaRight\.append\(mkSel\("fast"\)\);/);
-  assert.match(UI, /fast: create\.fast \|\| "", color: create\.color \|\| "" \}\);/);
-  assert.match(UI, /fast: c\.fast, color: c\.color \}\);/);   // the in-flight retry keeps the pick (unchanged by the 2026-08-30 eager-all round)
+  // the dialog's picks ride the held create (newCommentCreate reads anchor.fast) and every frame built from it,
+  // the send's and the in-flight retry's alike; the builder is driven directly by the create-identity tests below
+  assert.match(UI, /const held = newCommentCreate\(create, text, nm\)/);
+  assert.match(UI, /vscodeApi\.postMessage\(commentCreateFrame\(held\)\)/);
+  assert.match(UI, /vscodeApi\?\.postMessage\(commentCreateFrame\(c\)\)/);
   assert.match(KERNEL, /def _comment_launch_prefs\(model="", effort="", fast=""\):/);
   assert.match(KERNEL, /model, effort, fast = _comment_launch_prefs\(model, effort, fast\)/);
   assert.match(KERNEL, /fast=str\(msg\.get\("fast"\) or ""\)/);       // the ws op hands it through…
@@ -358,7 +361,7 @@ test("the create dialog names the thread right there: prefilled <session>-commen
   assert.match(UI, /"New comment:"/);
   assert.match(UI, /if \(nameBox\) head\.append\(title, nameBox, closeBtn\);/);
   assert.match(UI, /send\.setAttribute\("aria-label", create \? "Comment" : "Send"\);/);   // the ➤ carries the word
-  assert.match(UI, /text, name: nm, model: create\.model \|\| "", effort: create\.effort \|\| "",\s*\n\s*fast: create\.fast \|\| "", color: create\.color \|\| ""/);
+  assert.match(UI, /const held = newCommentCreate\(create, text, nm\);\s*\n\s*vscodeApi\.postMessage\(commentCreateFrame\(held\)\);/);   // the anchor's picks ride the held create
   // the comment's own model/effort selectors reuse the statusline's /models-fed choices + menu skin
   assert.match(UI, /const metaRow = el\("div", "statusline cmt-meta-row"\);/);   // the chat statusline dress (2026-08-25 parity)
   assert.match(UI, /META_CHOICES\[kind\]/);
@@ -624,7 +627,7 @@ test("a create refused by parse lag holds its mark and retries on the frame even
   assert.match(KERNELSRC, /_retry_parked_creates\(\)   # lag-parked comment creates ride every pusher cycle \(T106\)/);
   assert.match(KERNELSRC, /_PARK_MAX_TRIES = 30/);
   // the client holds the payload at send and re-posts when a session frame proves the parse caught up
-  assert.match(UI, /cmtCreateInFlight\.set\(create\.uuid, \{ sid: create\.sid,/);
+  assert.match(UI, /cmtCreateInFlight\.set\(create\.uuid, held\);/);   // the held create is the stamped one the send posted
   assert.match(UI, /retryCmtCreates\(String\(msg\.id \|\| ""\)\);\s+\/\/ a session frame = the kernel re-parsed/);
   assert.match(UI, /const CMT_CREATE_MAX_TRIES = 12;/);
   // the ack retires the hold; a REAL refusal drops the synth honestly
@@ -702,4 +705,102 @@ test("a contentless open thread NEVER renders blank — the loader stays past th
   assert.match(body, /const slow = !cmtBootHolds\(th\.tid\);/);
   assert.match(body, /still opening — the thread's session is taking longer than usual…/);
   assert.match(body, /opening the thread…/);
+});
+
+// ── the create's identity: one id per send gesture, the same one on every re-post ─────────────────
+// The kernel remembers each create it completed and answers a repeat of it with the same thread's ack.
+// Keyed on the words (anchor, passage, text) that memo also swallowed a DELIBERATE second comment in the
+// same words on the same passage (review, 2026-09-09). The client stamps the gesture instead: the popover
+// mints a createId at the send and every re-post of that gesture carries it, so a repeat is a frame with
+// an id the kernel has seen and a fresh gesture never is.
+const ANCHOR = { sid: "aaaaaaaa-1111-2222-3333-444444444444", uuid: "a1", exact: "exponential backoff",
+                 model: "", effort: "", fast: "", color: "" };
+
+test("a send gesture mints its own create id; a second gesture in the same words on the same passage gets another", () => {
+  const first = newCommentCreate(ANCHOR, "fix this", "");
+  const second = newCommentCreate(ANCHOR, "fix this", "");
+  assert.ok(first.createId.length > 0, "the gesture is stamped");
+  assert.notEqual(first.createId, second.createId, "two gestures, two ids, whatever their words");
+  assert.equal(first.tries, 0, "the retry count starts at the send");
+});
+
+test("the create frame carries the id, and a re-post of the held create is the same frame", () => {
+  const held = newCommentCreate({ ...ANCHOR, model: "claude-opus-5", effort: "high", fast: "on", color: "#112233" },
+                                "why jitter?", "why-jitter");
+  const sent = commentCreateFrame(held);
+  assert.deepEqual(sent, { type: "commentCreate", id: ANCHOR.sid, uuid: "a1", exact: "exponential backoff",
+                           text: "why jitter?", name: "why-jitter", model: "claude-opus-5", effort: "high",
+                           fast: "on", color: "#112233", createId: held.createId });
+  held.tries++;                                                   // a transient nack armed the retry
+  assert.deepEqual(commentCreateFrame(held), sent, "a retry is the same gesture: the same id, the same words");
+});
+
+test("an anchor with no picks sends empty picks and an empty name for the kernel's default", () => {
+  const held = newCommentCreate({ sid: ANCHOR.sid, uuid: "a1", exact: "exponential backoff" }, "fix this", "");
+  const sent = commentCreateFrame(held);
+  assert.equal(sent.name, "");
+  assert.equal(sent.model, ""); assert.equal(sent.effort, ""); assert.equal(sent.fast, ""); assert.equal(sent.color, "");
+});
+
+test("the popover's send and its frame-keyed retry both post the held create's frame", () => {
+  const send = UI.slice(UI.indexOf("function commentSendFromPop("));
+  const sendBody = send.slice(0, send.indexOf("\nfunction ", 10));
+  assert.match(sendBody, /const held = newCommentCreate\(create, text, nm\)/, "the send mints the gesture's id");
+  assert.match(sendBody, /vscodeApi\.postMessage\(commentCreateFrame\(held\)\)/);
+  assert.match(sendBody, /cmtCreateInFlight\.set\(create\.uuid, held\)/, "the hold IS the stamped create");
+  const retry = UI.slice(UI.indexOf("function retryCmtCreates("));
+  const retryBody = retry.slice(0, retry.indexOf("\nfunction ", 10));
+  assert.match(retryBody, /vscodeApi\?\.postMessage\(commentCreateFrame\(c\)\)/, "the retry re-sends the held frame, id included");
+  assert.doesNotMatch(UI, /type: "commentCreate", id:/, "no hand-built create frame remains");
+});
+
+// ── executed: the frame-keyed retry (retryCmtCreates, lifted from render.ts) re-posts the held create's own frame ──
+function liftRetry(held: CommentCreate[]) {
+  const start = UI.indexOf("function retryCmtCreates(sid: string): void {");
+  assert.ok(start > 0, "the frame-keyed retry lives in retryCmtCreates");
+  const src = UI.slice(start, UI.indexOf("\n}\n", start) + 3).replace("(sid: string): void {", "(sid) {");
+  const boundM = /const CMT_CREATE_MAX_TRIES = (\d+);/.exec(UI);
+  assert.ok(boundM, "the attempt bound is a named constant");
+  const bound = Number(boundM[1]);
+  const posted: ReturnType<typeof commentCreateFrame>[] = [];
+  const dropped: string[] = [];
+  const toasts: string[] = [];
+  const prelude = `
+    const CMT_CREATE_MAX_TRIES = ${bound};
+    const vscodeApi = { postMessage: (m) => posted.push(m) };
+    const dropSynthThread = (sid, u) => dropped.push(u);
+    const warnToast = (t) => toasts.push(t);`;
+  const cmtCreateInFlight = new Map(held.map((c) => [c.uuid, c] as [string, CommentCreate]));
+  const fn = new Function("cmtCreateInFlight", "commentCreateFrame", "posted", "dropped", "toasts", "sid",
+                          prelude + "\n" + src + "\nretryCmtCreates(sid);");
+  return { run: (sid: string) => { fn(cmtCreateInFlight, commentCreateFrame, posted, dropped, toasts, sid); },
+           posted, dropped, toasts, bound };
+}
+
+test("the frame-keyed retry re-posts the held create's own frame: the id minted at the send, on every re-post", () => {
+  const held = newCommentCreate(ANCHOR, "fix this", "fix-this");
+  const stamped = held.createId;
+  held.tries = 1;                                                 // the transient nack armed the retry
+  const other = newCommentCreate({ ...ANCHOR, sid: "bbbbbbbb-1111-2222-3333-444444444444", uuid: "b1" }, "and here", "");
+  other.tries = 1;
+  const { run, posted, dropped, toasts } = liftRetry([held, other]);
+  run(ANCHOR.sid); run(ANCHOR.sid);                               // two session frames for the sid: two re-posts
+  assert.equal(posted.length, 2, "one re-post per frame, for this sid's create alone");
+  assert.deepEqual(posted.map((f) => f.createId), [stamped, stamped],
+                   "a re-post is the same gesture: the kernel answers it with the thread it made, never a twin");
+  assert.deepEqual(posted, [commentCreateFrame(held), commentCreateFrame(held)], "the held frame, whole, each time");
+  assert.equal(held.tries, 3);
+  assert.equal(other.tries, 1, "another session's create waits for its own frame");
+  assert.deepEqual([dropped, toasts], [[], []]);
+});
+
+test("a create the send has not heard back on is not re-posted, and one past the attempt bound is dropped with the toast", () => {
+  const fresh = newCommentCreate(ANCHOR, "fix this", "");           // tries 0: the send's own frame is out
+  const spent = newCommentCreate({ ...ANCHOR, uuid: "a2" }, "and this", "");
+  const lift = liftRetry([fresh, spent]);
+  spent.tries = lift.bound + 1;
+  lift.run(ANCHOR.sid);
+  assert.deepEqual(lift.posted, [], "the retry waits for a transient nack, and gives up past the bound");
+  assert.deepEqual(lift.dropped, ["a2"]);
+  assert.equal(lift.toasts.length, 1);
 });

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -183,3 +183,37 @@ export function prunePending(pending: { text: string; t: number }[], msgs: Comme
     return true;
   });
 }
+
+/** A comment create as the client holds it from the send gesture until the kernel answers it: the
+ *  anchor, the words, the dialog's picks, the gesture's own id and how many times a transient refusal
+ *  has had it re-posted. The kernel answers a repeat of a create it completed with the same thread's
+ *  ack (a lost ack, a lag-parked copy that landed before the client's re-post reached it), and it tells
+ *  a repeat from a fresh comment by this id: two gestures in the same words on the same passage are
+ *  two comments, and a memo keyed on the words alone answered the second with the first thread and
+ *  wrote its name nowhere (review, 2026-09-09). */
+export type CommentCreate = { sid: string; uuid: string; exact: string; text: string; name: string;
+  model: string; effort: string; fast: string; color: string; createId: string; tries: number };
+
+/** One id per send gesture: the moment and a random tail, in the same shape as a provisional tab's id.
+ *  Random, not a counter: a reloaded viewer starts its counters over, and the kernel's memo outlives it. */
+export function mintCreateId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2);
+}
+
+/** The create a send gesture holds: stamped with a fresh id, picks defaulted to "" (the kernel's
+ *  default-comment settings, then the parent's), the retry count at zero. */
+export function newCommentCreate(anchor: { sid: string; uuid: string; exact: string; model?: string; effort?: string;
+                                           fast?: string; color?: string },
+                                 text: string, name: string): CommentCreate {
+  return { sid: anchor.sid, uuid: anchor.uuid, exact: anchor.exact, text, name, model: anchor.model || "",
+           effort: anchor.effort || "", fast: anchor.fast || "", color: anchor.color || "",
+           createId: mintCreateId(), tries: 0 };
+}
+
+/** The commentCreate frame for a held create: the send and every re-post of it build the same one, so
+ *  the kernel sees one id for one gesture. */
+export function commentCreateFrame(c: CommentCreate): { type: "commentCreate"; id: string; uuid: string; exact: string;
+    text: string; name: string; model: string; effort: string; fast: string; color: string; createId: string } {
+  return { type: "commentCreate", id: c.sid, uuid: c.uuid, exact: c.exact, text: c.text, name: c.name,
+           model: c.model, effort: c.effort, fast: c.fast, color: c.color, createId: c.createId };
+}

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -75,7 +75,8 @@ import { durLabel } from "./duration";
 import { apiErrorReason } from "./api-error-reason";
 import { chatMdExtensions, userMdHtml } from "./chat-md";
 import { setTip, pruneTip } from "./tip";
-import { agentCount, replyOwed, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
+import { agentCount, replyOwed, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, newCommentCreate, commentCreateFrame,
+         type CommentThread, type CommentCreate } from "./comments";
 import { isReplyReady, placeMark, placeWindowed, readyChips, replyLine, chipLabel, chipTip, chipAria, type Dir, type ReadyMark, type ReadyChip } from "./reply-ready";
 import { dragSlotIndex } from "./dragslot";
 import { perfFrameHandler } from "./perf-telemetry";
@@ -8068,8 +8069,11 @@ function cmtLatchReleased(t: CommentThread, base: CmtLatch): boolean {
 // send; a TRANSIENT nack keeps the optimistic mark + latch alive and the create RE-POSTS when the
 // next session frame for the sid arrives (frames are built from the kernel's parse — a new frame IS
 // the parse catching up). Bounded by attempts, not time; a real refusal or the ack drops the hold.
-const cmtCreateInFlight = new Map<string, { sid: string; uuid: string; exact: string; text: string;
-  name: string; model: string; effort: string; fast: string; color: string; tries: number }>();
+// Keyed by the anchor: one create at a time per passage on this viewer. The held create carries the id
+// the send gesture minted, and every re-post sends it again (commentCreateFrame): the kernel answers a
+// repeat of a create it completed with the same thread, and tells a repeat from a fresh comment in the
+// same words by that id.
+const cmtCreateInFlight = new Map<string, CommentCreate>();
 const CMT_CREATE_MAX_TRIES = 12;
 
 function retryCmtCreates(sid: string): void {
@@ -8082,8 +8086,7 @@ function retryCmtCreates(sid: string): void {
       continue;
     }
     c.tries++;
-    vscodeApi?.postMessage({ type: "commentCreate", id: c.sid, uuid: c.uuid, exact: c.exact,
-      text: c.text, name: c.name, model: c.model, effort: c.effort, fast: c.fast, color: c.color });
+    vscodeApi?.postMessage(commentCreateFrame(c));         // the same gesture again: the same id
   }
 }
 
@@ -8832,12 +8835,10 @@ function commentSendFromPop(pop: HTMLElement): void {
     commentThreads.set(create.sid, [...cur0.filter((t) => t.tid !== synth.tid), synth]);
     cmtAwaitBase.set(synth.tid, { ...CMT_LATCH_ZERO });   // the SEND gesture latches the pulse — before any kernel round-trip (T102); released once a frame acknowledges the send (T237)
     applyCommentMarks(create.sid);
-    vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact,
-      text, name: nm, model: create.model || "", effort: create.effort || "",
-      fast: create.fast || "", color: create.color || "" });
-    cmtCreateInFlight.set(create.uuid, { sid: create.sid, uuid: create.uuid, exact: create.exact,
-      text, name: nm, model: create.model || "", effort: create.effort || "",
-      fast: create.fast || "", color: create.color || "", tries: 0 });
+    // the gesture is stamped once, here; the hold re-posts the same frame while a transient nack stands
+    const held = newCommentCreate(create, text, nm);
+    vscodeApi.postMessage(commentCreateFrame(held));
+    cmtCreateInFlight.set(create.uuid, held);
     return;
   }
   const cur = openCommentThread();


### PR DESCRIPTION
## Symptom

Post a comment on a passage and take the ack. Post the same words on the same passage again, under another name. No second thread appears: the popover adopts the first thread again, and the second name is written nowhere. The viewer shows no toast; only the kernel log says `comment create repeated`. The post-merge record on #1208 reports this as a follow-up on main.

## Cause

The create memo from #1208 (T289) keys a create on its words, `(parent sid, anchor uuid, passage, text)`, and answers any identical create on an open thread until 256 later creates or a kernel restart. The words cannot tell a re-post of one create (a lost ack; a lag-parked copy that landed before the client's re-post reached the kernel) from a fresh comment that happens to repeat them, so the memo swallows the deliberate second comment.

## Fix

The popover stamps each send gesture with a `createId`, and every re-post of that gesture carries the same one: a repeat arrives with an id the kernel has seen, a fresh gesture with a new one.

- `ui/webview/comments.ts`: `CommentCreate`, `mintCreateId` (the moment and a random tail, the provisional tab id's shape; random rather than a counter because a reloaded viewer restarts its counters while the kernel's memo stands), `newCommentCreate` (the held create, stamped, picks defaulted to `""`), `commentCreateFrame` (the frame the send and every re-post build).
- `ui/webview/render.ts`: the send mints the held create, posts its frame and holds it; the frame-keyed retry re-posts the held frame; `cmtCreateInFlight` holds `CommentCreate` rows.
- `kernel/kernel.py`: `_create_key` takes the id and keys on `(parent sid, createId)` when the frame carries one, else on the words as before; `_parked_key` reads a parked copy's key; the WS door, the reservation, the park-once check and the pusher's retry all key on it, and a parked copy carries the id. A frame without an id (a client that sends none) still keys on its words, and the two shapes never meet. The repeat rule is otherwise unchanged: the memo answers only an open thread, and the busy nack and the park-once check stand.
- The federation route passes the field through untouched, as it does every field, so a comment on a remote session reaches the owning kernel stamped.

One case moves the other way: a comment the user posts again by hand while the first is still parked (after a viewer reload, which loses the in-memory hold, or after the viewer gave up at `CMT_CREATE_MAX_TRIES` while the kernel's park at `_PARK_MAX_TRIES` is still alive) is a new gesture and lands as a second thread once the anchor arrives. The words key answered that re-post busy and collapsed both into one thread. The duplicate is visible and the user can delete it; the collapsed second comment was lost silently. The parked-copies test below covers the kernel side of this case.

The alternative considered was a memo bounded to the create's in-flight and parked lifecycle, cleared once the ack has gone out. It was not taken: the memo exists for the re-post that arrives after the ack (the client re-posts on the frame the pusher sent before it retried the parked copy, and a lost ack is re-sent on the next frame), so an ack-bounded memo would mint twins in the cases the memo was built for, and no lifecycle bound tells a late re-post from a fresh gesture. The gesture's own id does, and the client already keys its hold per gesture (one create per anchor at a time), so the stamp extends how it identifies the create today.

## Tests

`tests/test_comment_create_idempotent.py`, seven added (14 in the module). Four are red before the change:

- `test_a_fresh_gesture_in_the_same_words_on_the_same_passage_is_a_second_thread`: two gestures, two ids, same words, two names; before, `1 != 2` (one thread, two acks, the second name nowhere on disk).
- `test_a_fresh_gesture_after_a_parked_create_landed_is_a_second_thread_and_its_repost_is_not`: the parked copy carries the id through the pusher's retry; the re-post is the same thread and a fresh gesture is a second one; before, `1 != 2` on the fresh gesture.
- `test_two_gestures_in_the_same_words_are_both_parked_while_the_anchor_lags`: two gestures park separately and land as two threads, the same gesture parks once; before, `1 != 2` on the second parked copy.
- `test_a_frame_without_a_create_id_still_keys_on_the_words`: the words identity stands for an unstamped frame and never meets a stamped one; before, `1 != 2` (the stamped gesture was answered from the words memo).

Three pin the guards around the id (green before and after; each goes red under the named change to the kernel):

- `test_a_retried_frame_with_the_same_create_id_is_one_thread_answered_twice`: the re-post side, one thread and two acks naming it.
- `test_a_repost_of_a_parked_gesture_is_refused_at_the_door_before_the_create_runs`: a spy on `_comment_create` sees no second call for a re-post of a parked stamped gesture; red if the reservation compares parked copies by their words (the re-post would run the create again and be saved only by the park-once check).
- `test_a_repost_landing_between_the_doors_release_and_its_park_is_parked_once`: the door releases its reservation before it parks, and a re-post of the same gesture that runs whole in that window parks first; this door then parks no twin. Red if the park-once check compares by the words.

`ui/webview/comments.test.ts`, six added (75 in the bundle): `newCommentCreate` and `commentCreateFrame` executed (two gestures in the same words get two ids; the frame carries the id and the picks, and a retry is the same frame; empty picks and an empty name stay empty); `retryCmtCreates` lifted from render.ts and run against a stubbed `vscodeApi` (every re-post carries the id minted at the send and is the held frame whole, red if the retry re-mints the id; a create with no transient nack yet is not re-posted; one past the attempt bound is dropped with the toast); the send site pinned. The pins on the old inline frames in three tests are retargeted. `ui/webview/comment-remote-routing.test.ts`: the id rides the route untouched. Before the change the test bundle fails to build on the two missing exports.

Targeted on this tree: the module 14 passed; the six comment bundles 121/121; `tsc --noEmit` clean.

Full suite on this tree (this commit on a7fd4ac3): pytest `-n 8` over `tests/`, 10647 passed, 40 skipped, 0 failed, 1688 subtests passed. `npm test` 3948 tests, 3948 pass, 0 fail; `npm run typecheck` clean.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)