### PR TITLE
Tests: the live session-move test borrows the operator's apiKeyHelper under pytest again

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,14 @@ os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel exports this to its sess
 # not reach a test either) before any test module loads, and re-asserted per test below so a
 # module-level pop or write in one test file cannot erase it for the run. A test that needs its own
 # Claude root sets the variable in setUp, after the fixture, exactly as the ones that do already do.
+# The location the run was handed is saved FIRST, before the floor replaces it: the one opt-in live
+# test that borrows the operator's apiKeyHelper command from their own settings
+# (tests/test_session_move_live.py) reads it through ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR. Captured
+# after the floor it would name the run's empty temp dir, and that test would skip as "no auth"
+# while its skip message still named the borrow. setdefault, so an xdist worker keeps the
+# controller's value rather than re-reading an environment the controller has already floored.
+os.environ.setdefault("ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR",
+                      os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~/.claude"))
 _CLAUDE_CONFIG = tempfile.mkdtemp(prefix="romp-tests-claude-")
 os.environ["CLAUDE_CONFIG_DIR"] = _CLAUDE_CONFIG
 
@@ -451,6 +459,9 @@ _ENV_VALUE_PATH_NAMES = frozenset((
     "PWD", "OLDPWD", "HOME", "PATH", "TMPDIR", "SHELL", "VIRTUAL_ENV", "PYTHONPATH", "LS_COLORS",
     "ROMP_SERVICE_ENV_FILE", "ROMP_SERVICE_ENV", "ROMP_DIR", "ROMP_STATE_DIR", "ROMP_CLAUDE_BIN",
     "ROMP_SYSTEMD_DIR", "ROMP_LAUNCHD_DIR", "CLAUDE_CONFIG_DIR", "TMUX_TMPDIR", "ROMP_TESTS_SYSTEM_TMPDIR",
+    # the Claude settings dir conftest saved ahead of its CLAUDE_CONFIG_DIR floor (above), for the live
+    # move test: a path a failure report may quote, like CLAUDE_CONFIG_DIR beside it
+    "ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR",
     # GitHub Actions: the runner's workspace and tool cache, and the interpreter prefix setup-python
     # exports under six names (every stdlib and site-packages frame of a CI traceback is under it)
     "GITHUB_WORKSPACE", "RUNNER_WORKSPACE", "RUNNER_TEMP", "RUNNER_TOOL_CACHE", "pythonLocation",

--- a/tests/test_claude_config_floor.py
+++ b/tests/test_claude_config_floor.py
@@ -7,10 +7,17 @@ patching jd.PROJECTS wrote synthetic-sid directories under the developer's real 
 run's private temp root before any test module loads, and re-asserts it before every test, so a
 module-level pop or write in one test file cannot erase the floor for the rest of the run; a test
 that needs its own Claude root sets the variable in setUp, which runs after the fixture, as before.
+The location the run was handed is saved first, under ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR, for the one
+opt-in test that borrows the operator's apiKeyHelper command from their own settings
+(tests/test_session_move_live.py); captured after the floor it would name the empty floor dir.
 
 Source pins in the style of test_supervised_floor.py, the floor observed from inside a test, from a
-module loaded under it, and from a subprocess whose shell exports a value of its own."""
+module loaded under it, and from a subprocess whose shell exports a value of its own; the saved
+location observed from inside a test, from a subprocess whose shell exports the root it saves, and
+from one whose shell already carries a saved value."""
+import importlib.util
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -24,6 +31,19 @@ ROOT = os.path.dirname(HERE)
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+
+# Run by a child pytest under conftest (`-p tests.conftest`) whose shell exports synthetic Claude roots:
+# one generated test, which passes only if the child's saved value is the one the case expects of that
+# shell while CLAUDE_CONFIG_DIR is the floor, neither root the shell exported.
+SAVED_LOCATION_CASE = '''\
+import os
+
+
+def test_the_saved_location_is_the_expected_one_and_the_floor_is_neither_exported_root():
+    expected, exported = %r, %r
+    assert os.environ["ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR"] == expected
+    assert os.environ["CLAUDE_CONFIG_DIR"] not in exported
+'''
 
 
 def _under_the_run_root(path):
@@ -67,6 +87,68 @@ class ClaudeConfigFloor(unittest.TestCase):
                            env=env, capture_output=True, text=True, timeout=180, cwd=ROOT)
         self.assertEqual(r.returncode, 0, r.stdout[-800:] + r.stderr[-400:])
         self.assertNotIn("synthetic-claude-root-not-a-floor", r.stdout)
+
+    def test_the_location_the_run_was_handed_is_saved_for_the_live_move_test(self):
+        """tests/test_session_move_live.py borrows the operator's apiKeyHelper command from their own
+        settings, which the floor hides from every test; conftest saves the location the run was handed
+        under ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR before the floor replaces it. Observed from inside a test:
+        set, and never the floor. Not asserted: which path it is, since a nested pytest run whose shell
+        carries the outer run's value keeps it (the floor-override case in this module runs that way;
+        the last two cases here pin the keeping)."""
+        saved = os.environ.get("ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR")
+        self.assertTrue(saved, "the pre-floor Claude settings dir is saved for every test")
+        floor = os.path.realpath(os.environ["CLAUDE_CONFIG_DIR"])
+        self.assertNotEqual(os.path.realpath(saved), floor, "the saved location is not the floor")
+        self.assertFalse(os.path.realpath(saved).startswith(floor + os.sep), "and not inside it")
+
+    def _saved_location_seen_by_a_child(self, shell, expected, extra=()):
+        """Runs SAVED_LOCATION_CASE under a child pytest that loads conftest as a plugin. `shell` is
+        what the child's shell exports on top of this process's environment, with the saved value
+        cleared unless `shell` carries one; `expected` is the saved value the generated test asserts;
+        `extra` is appended to the child's command line."""
+        case = tempfile.mkdtemp(prefix="romp-claude-floor-case-")
+        self.addCleanup(shutil.rmtree, case, ignore_errors=True)
+        with open(os.path.join(case, "test_saved_location.py"), "w") as f:
+            f.write(SAVED_LOCATION_CASE % (expected, tuple(shell.values())))
+        env = dict(os.environ, PYTHONDONTWRITEBYTECODE="1")
+        for var in ("ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR", "PYTEST_ADDOPTS", "PYTEST_PLUGINS",
+                    "PYTEST_DISABLE_PLUGIN_AUTOLOAD", "PYTEST_CURRENT_TEST", "PYTEST_XDIST_WORKER",
+                    "PYTEST_XDIST_WORKER_COUNT"):
+            env.pop(var, None)
+        env.update(shell)
+        r = subprocess.run([sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", "-p", "tests.conftest",
+                            *extra, os.path.join(case, "test_saved_location.py")],
+                           env=env, capture_output=True, text=True, timeout=180, cwd=ROOT)
+        self.assertEqual(r.returncode, 0, r.stdout[-800:] + r.stderr[-400:])
+        self.assertIn("1 passed", r.stdout)
+
+    def test_the_saved_location_is_the_root_the_shell_exported_before_the_floor(self):
+        """The save must come BEFORE the floor: a child pytest whose shell exports a synthetic Claude root
+        and carries no saved value of its own passes the generated test only if the saved value is that
+        root while CLAUDE_CONFIG_DIR is the floor. Captured after the floor, the saved value would be the
+        floor itself, and the live move test would skip for want of auth on every machine."""
+        handed = os.path.join(tempfile.gettempdir(), "synthetic-claude-root-handed-to-the-run")
+        self._saved_location_seen_by_a_child({"CLAUDE_CONFIG_DIR": handed}, expected=handed)
+
+    def test_a_saved_value_the_shell_already_carries_survives_the_import(self):
+        """An xdist worker imports conftest in an environment the controller has already floored and
+        stamped with its saved value; the worker must keep that value (the save is a setdefault) rather
+        than record CLAUDE_CONFIG_DIR, by then the controller's empty floor, as the location the run was
+        handed. A child pytest whose shell carries a saved value and a different CLAUDE_CONFIG_DIR passes
+        the generated test only if the saved value is the one it was handed; a plain assignment would
+        record the other root."""
+        preset = os.path.join(tempfile.gettempdir(), "synthetic-claude-root-saved-by-the-controller")
+        other = os.path.join(tempfile.gettempdir(), "synthetic-claude-root-floored-by-the-controller")
+        self._saved_location_seen_by_a_child(
+            {"ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR": preset, "CLAUDE_CONFIG_DIR": other}, expected=preset)
+
+    @unittest.skipUnless(importlib.util.find_spec("xdist"), "pytest-xdist not installed")
+    def test_an_xdist_worker_keeps_the_saved_location_the_controller_recorded(self):
+        """The case above, run for real: the child under -n 2 imports conftest once in the controller
+        and again in a worker whose environment the controller has already floored and stamped, and the
+        generated test, run in the worker, still sees the root the shell handed the controller."""
+        handed = os.path.join(tempfile.gettempdir(), "synthetic-claude-root-handed-to-the-run")
+        self._saved_location_seen_by_a_child({"CLAUDE_CONFIG_DIR": handed}, expected=handed, extra=("-n", "2"))
 
 
 if __name__ == "__main__":

--- a/tests/test_env_value_redaction.py
+++ b/tests/test_env_value_redaction.py
@@ -198,13 +198,17 @@ class RedactionRule(_WithConftest):
                # traceback quotes
                "GITHUB_WORKSPACE": p, "RUNNER_TEMP": p, "RUNNER_TOOL_CACHE": p, "pythonLocation": p,
                "Python_ROOT_DIR": p, "Python3_ROOT_DIR": p, "LD_LIBRARY_PATH": p, "PKG_CONFIG_PATH": p,
-               "XDG_DATA_DIRS": p + os.pathsep + p}
+               "XDG_DATA_DIRS": p + os.pathsep + p,
+               # conftest's record of the Claude settings dir the run was handed, saved ahead of its floor
+               "ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR": p}
         self.assertEqual(self.cf.env_values_to_redact(env), set(), "a traceback quotes these paths")
         env = {"PWD_TOKEN": p, "ANTHROPIC_PWD": p, "MY_SECRET_PATH": p}
         self.assertEqual(self.cf.env_values_to_redact(env), {p}, "a credential-shaped name is never exempt")
         self.assertTrue(self.cf.env_value_qualifies("SOME_TOKEN", p))
         self.assertFalse(self.cf.env_value_qualifies("TMUX_TMPDIR", p),
                          "the private tmux socket dir conftest mints is a path a failure may quote")
+        self.assertFalse(self.cf.env_value_qualifies("ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR", p),
+                         "the pre-floor settings dir is a path a failure report may quote")
 
     def test_pytests_own_bookkeeping_names_are_exempt(self):
         # pytest writes PYTEST_CURRENT_TEST (`<node id> (setup|call|teardown)`) for every phase of

--- a/tests/test_session_move_live.py
+++ b/tests/test_session_move_live.py
@@ -20,6 +20,8 @@ suite's floors (conftest's ROMP_CLAUDE_BIN=/bin/false) exist to prevent by defau
     settings as their apiKeyHelper; or, failing both, the `apiKeyHelper` from the user's OWN Claude
     Code settings ($CLAUDE_CONFIG_DIR/settings.json, default ~/.claude/settings.json), copied into
     the hermetic settings as-is (the hermetic dir sees none of the operator's own settings otherwise).
+    Under pytest the suite's conftest floors CLAUDE_CONFIG_DIR to an empty dir for every test and saves
+    the real location in ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR, which the borrow reads first.
     Either way the helper COMMAND travels, never a key, and this test writes no key to a file.
 CI has none of these and skips cleanly. Synthetic content throughout (an invented sid, an invented
 codeword, temp folders)."""
@@ -111,9 +113,12 @@ def _sdk_python():
 def _user_api_key_helper(config_dir=None):
     """The `apiKeyHelper` command from the user's own Claude Code settings ("" when there is none): the
     hermetic config dir borrows the COMMAND, so the child authenticates exactly the way the user's real
-    sessions do. Never a key: this test writes none to disk. `config_dir` defaults to
-    $CLAUDE_CONFIG_DIR, else ~/.claude."""
-    d = config_dir or os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~/.claude")
+    sessions do. Never a key: this test writes none to disk. `config_dir` defaults to the user's real
+    config dir: under pytest the suite's conftest floors $CLAUDE_CONFIG_DIR to an empty dir and saves the
+    real location in $ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR, so that is read first; else $CLAUDE_CONFIG_DIR,
+    else ~/.claude."""
+    d = (config_dir or os.environ.get("ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR") or os.environ.get("CLAUDE_CONFIG_DIR")
+         or os.path.expanduser("~/.claude"))
     try:
         with open(os.path.join(d, "settings.json")) as f:
             v = json.load(f).get("apiKeyHelper")
@@ -174,9 +179,12 @@ class UserApiKeyHelper(unittest.TestCase):
 
 class ApiKeyHelperPrecedence(unittest.TestCase):
     """The helper the hermetic settings get (always-run; the live class stays opt-in): the explicit
-    $ROMP_MOVE_LIVE_API_KEY_HELPER wins; else the command borrowed from $CLAUDE_CONFIG_DIR/settings.json;
+    $ROMP_MOVE_LIVE_API_KEY_HELPER wins; else the command borrowed from the real config dir the suite's
+    conftest saved in $ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR; else from $CLAUDE_CONFIG_DIR/settings.json;
     else from ~/.claude/settings.json; "" when none names one. HOME and CLAUDE_CONFIG_DIR point at temp
-    dirs throughout, so nothing here reads the operator's own settings."""
+    dirs throughout and the saved real location is cleared, or pointed at a temp dir, inside every patch
+    (under pytest it names the operator's own ~/.claude), so nothing here reads the operator's own
+    settings."""
 
     def setUp(self):
         self.td = tempfile.mkdtemp(prefix="romp-move-live-prec-")
@@ -193,12 +201,14 @@ class ApiKeyHelperPrecedence(unittest.TestCase):
         cfg = self._settings("cfg", "/opt/example/borrowed --print")
         with mock.patch.dict(os.environ, {"HOME": os.path.join(self.td, "home"), "CLAUDE_CONFIG_DIR": cfg,
                                           "ROMP_MOVE_LIVE_API_KEY_HELPER": "/opt/example/explicit"}):
+            os.environ.pop("ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR", None)
             self.assertEqual(_api_key_helper(), "/opt/example/explicit")
 
     def test_without_the_env_var_the_borrowed_command_is_used(self):
         cfg = self._settings("cfg", "/opt/example/borrowed --print")
         with mock.patch.dict(os.environ, {"HOME": os.path.join(self.td, "home"), "CLAUDE_CONFIG_DIR": cfg}):
             os.environ.pop("ROMP_MOVE_LIVE_API_KEY_HELPER", None)
+            os.environ.pop("ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR", None)
             self.assertEqual(_api_key_helper(), "/opt/example/borrowed --print")
             self.assertEqual(_user_api_key_helper(), "/opt/example/borrowed --print", "no argument: $CLAUDE_CONFIG_DIR")
 
@@ -208,6 +218,7 @@ class ApiKeyHelperPrecedence(unittest.TestCase):
         with mock.patch.dict(os.environ, {"HOME": home}):
             os.environ.pop("CLAUDE_CONFIG_DIR", None)
             os.environ.pop("ROMP_MOVE_LIVE_API_KEY_HELPER", None)
+            os.environ.pop("ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR", None)
             self.assertEqual(_user_api_key_helper(), "/opt/example/home-helper")
             self.assertEqual(_api_key_helper(), "/opt/example/home-helper")
 
@@ -215,7 +226,21 @@ class ApiKeyHelperPrecedence(unittest.TestCase):
         with mock.patch.dict(os.environ, {"HOME": os.path.join(self.td, "empty"),
                                           "CLAUDE_CONFIG_DIR": os.path.join(self.td, "absent")}):
             os.environ.pop("ROMP_MOVE_LIVE_API_KEY_HELPER", None)
+            os.environ.pop("ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR", None)
             self.assertEqual(_api_key_helper(), "")
+
+    def test_the_saved_real_config_dir_outranks_the_floored_one(self):
+        # conftest floors CLAUDE_CONFIG_DIR to an empty dir for every test and saves the location the
+        # run was handed in ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR; the live run borrows from the saved
+        # location, else it could never find the operator's helper under pytest
+        real = self._settings("real", "/opt/example/real-helper")
+        floor = self._settings("floor", "/opt/example/floored-helper")
+        with mock.patch.dict(os.environ, {"HOME": os.path.join(self.td, "home"), "CLAUDE_CONFIG_DIR": floor,
+                                          "ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR": real}):
+            os.environ.pop("ROMP_MOVE_LIVE_API_KEY_HELPER", None)
+            self.assertEqual(_user_api_key_helper(), "/opt/example/real-helper")
+            self.assertEqual(_api_key_helper(), "/opt/example/real-helper")
+            self.assertEqual(_user_api_key_helper(floor), "/opt/example/floored-helper", "an explicit dir still wins")
 
 
 @unittest.skipIf(_skip_reason(), _skip_reason())


### PR DESCRIPTION
## Symptom

The live session-move test (`tests/test_session_move_live.py`, opt-in under `ROMP_MOVE_LIVE=1`) authenticates its hermetic config dir with the `apiKeyHelper` command borrowed from the operator's own Claude Code settings when neither `ANTHROPIC_API_KEY` nor `ROMP_MOVE_LIVE_API_KEY_HELPER` is set (#946). Under pytest that route cannot work: on a machine whose settings name a helper, `ROMP_MOVE_LIVE=1 pytest tests/test_session_move_live.py -k LiveSetCwd -rs` skips with "no Claude Code auth for a hermetic config dir", while the skip message still lists "an apiKeyHelper in your Claude Code settings" as a way in. The class is opt-in, so nothing went red.

## Cause

#1065 floors `CLAUDE_CONFIG_DIR` to an empty temp directory for every test (so no test resolves the real `~/.claude`) and re-asserts it per test, and conftest scrubs `ANTHROPIC_API_KEY`. `_user_api_key_helper` read `CLAUDE_CONFIG_DIR`, so under pytest it read the floor's empty directory, found no settings, and returned "". Of the three routes the skip message names, only the explicit `ROMP_MOVE_LIVE_API_KEY_HELPER` could still work.

## Fix

Four test files change; no romp code does.

- `tests/conftest.py`: the location the run was handed is saved under `ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR` immediately before the floor replaces it (captured after the floor, the saved value would be the floor itself). It is a `setdefault`, so an xdist worker keeps the controller's value rather than re-reading an environment the controller has already floored; the floor module's last two cases pin that. The name joins `_ENV_VALUE_PATH_NAMES` beside `CLAUDE_CONFIG_DIR`, a path a failure report may quote; an existing path is exempt already, so the entry matters only where the saved path does not exist.
- `tests/test_session_move_live.py`: `_user_api_key_helper` reads the saved location first, then `CLAUDE_CONFIG_DIR`, then `~/.claude`; an explicit `config_dir` argument still wins. The four existing `ApiKeyHelperPrecedence` tests clear the saved value inside their `mock.patch.dict`, since under pytest it names the operator's own settings and those tests must read only their temp dirs. The docstrings say where the value comes from.

Two choices:

- The borrow stays, rather than the explicit `ROMP_MOVE_LIVE_API_KEY_HELPER` becoming the only route: #946's point was a borrow that works wherever Claude Code is configured, and the skip message still describes it. This restores it under the floor.
- The new variable gets no per-test re-assert fixture: nothing pops the name outside a `mock.patch.dict`, which restores it, and a test that did would only make the live class skip. The floor's fixture guards a variable romp code reads at import; nothing in romp reads this one.

The saved value is a path under the operator's home. Nothing writes it to a file, and this PR does not quote it.

## Tests

Each of these fails on the base and passes with the change:

- `tests/test_session_move_live.py::ApiKeyHelperPrecedence::test_the_saved_real_config_dir_outranks_the_floored_one`: a "real" and a "floor" settings dir, `CLAUDE_CONFIG_DIR` at the floor and the saved variable at the real one; `_user_api_key_helper()` and `_api_key_helper()` return the real helper, and an explicit `config_dir` still wins. Before: `'/opt/example/floored-helper' != '/opt/example/real-helper'`.
- `tests/test_claude_config_floor.py::ClaudeConfigFloor::test_the_location_the_run_was_handed_is_saved_for_the_live_move_test`: the variable is set for every test and is neither the floor nor inside it. Before: not set. It does not assert which path it is, since a nested pytest run whose shell carries the outer run's value keeps it (the module's floor-override case runs that way).
- `tests/test_claude_config_floor.py::ClaudeConfigFloor::test_the_saved_location_is_the_root_the_shell_exported_before_the_floor`: a child pytest under `-p tests.conftest` whose shell exports a synthetic Claude root and carries no saved value runs one generated test, which passes only if the saved value is that root while `CLAUDE_CONFIG_DIR` is the floor. Before: `KeyError: 'ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR'` in the child.
- `tests/test_claude_config_floor.py::ClaudeConfigFloor::test_an_xdist_worker_keeps_the_saved_location_the_controller_recorded`: the same child under `-n 2`, so the generated test runs in a worker whose environment the controller has already floored and stamped, and it still sees the handed root. Skipped where pytest-xdist is not installed (CI installs none). Before: the same `KeyError`, in the worker.
- `tests/test_env_value_redaction.py::RedactionRule::test_path_valued_shell_names_are_exempt_unless_credential_shaped`: the name is in the exempt-by-name mapping and `env_value_qualifies` is false for it. Before: `env_values_to_redact` returned the path.

One more pins the `setdefault` rather than the base's defect, and passes on the base, which never touches the variable:

- `tests/test_claude_config_floor.py::ClaudeConfigFloor::test_a_saved_value_the_shell_already_carries_survives_the_import`: the child's shell carries a saved value and a different `CLAUDE_CONFIG_DIR`; the generated test passes only if the saved value is the one handed in and `CLAUDE_CONFIG_DIR` is neither root. With the `setdefault` replaced by a plain assignment, this test fails (the child records the other root) and so does the xdist case (the worker records the controller's floor); the other new tests stay green under that change. Unlike the xdist case it needs no pytest-xdist, so it runs on CI.

Targeted run of `tests/test_session_move_live.py tests/test_env_value_redaction.py tests/test_claude_config_floor.py tests/test_key_source_floor.py tests/test_supervised_floor.py tests/test_state_isolation_order.py tests/test_tempdir_hygiene.py`: 93 passed, 1 skipped (the opt-in live class).

Full suite (`pytest -q -n 8 tests/`): 10570 passed, 115 skipped, 0 failed, 1688 subtests passed

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)