### PR TITLE
Tunnel rows: the recovery counter bumps once per Start, not once per answered poll under its hold (T291b)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17145,12 +17145,18 @@ def _note_recovery(r, st):
     timeout) mints one bump until a real silent poll or a status change re-arms it, so a request that keeps
     stalling on a healthy link cannot mint its own recovery, retry, stall, and mint again forever. A steady
     healthy row never bumps; a fresh boot starts at 0 (the counter describes THIS process, like the poll run
-    counters, and is not saved). Returns whether it bumped."""
+    counters, and is not saved). A Start in flight (`booting`, _start_remote's hold) owns the row's phase: the
+    pass skips its status write under the hold, so the row keeps reading "starting" however many polls answer
+    meanwhile, and every answered pass would count as a not-up row coming up and bump again (1, 2, 3, then
+    once more as the hold cleared). No pass under the hold bumps; the first answered pass after it clears
+    finds the row not up and bumps once, the one recovery of that Start. Returns whether it bumped."""
     answered = st == "up" and int(r.get("misses") or 0) == 0
     if not answered:
         if st != "up":
             r.pop("_demand_bumped", None)            # a status change re-arms the demand path
         return False
+    if r.get("booting"):
+        return False                                 # a Start hold: the pass after it clears bumps once (see above)
     real_miss = bool(r.pop("_poll_miss", False))
     demand_miss = bool(r.pop("_demand_miss", False))
     had_miss = real_miss or (demand_miss and not r.get("_demand_bumped"))

--- a/tests/test_kernel_tunnel_truth.py
+++ b/tests/test_kernel_tunnel_truth.py
@@ -100,6 +100,77 @@ class RecoveryCounter(unittest.TestCase):
         self.assertTrue(self._pass(r, answered=True))
         self.assertEqual(r["upSeq"], 1)
 
+    def test_a_start_hold_bumps_once_when_it_clears(self):
+        """_start_remote holds the row at "starting" (`booting`) while it updates and boots the far kernel, and the
+        pass skips its status write under the hold, so the row never reads "up" however many polls answer
+        meanwhile. Without a guard every answered pass under the hold looks like a not-up row coming up and bumps
+        again (1, 2, then 3 as the hold clears); the contract is one bump per recovery, when the hold clears."""
+        r = {"host": "TESTHOST", "status": "starting", "misses": 0, "booting": True}
+        self.assertFalse(self._pass(r, answered=True), "an answered pass under the hold is not the recovery")
+        self.assertFalse(self._pass(r, answered=True), "nor the next one: the hold owns the row's phase")
+        self.assertEqual(int(r.get("upSeq") or 0), 0, "no bump while the Start is in flight")
+        r["booting"] = False                    # the boot landed: the hold clears; the row still reads "starting"
+        self.assertTrue(self._pass(r, answered=True), "the first answered pass after the hold: the one recovery")
+        self.assertEqual(r["upSeq"], 1)
+        r["status"] = "up"                      # that pass's status write, no longer held
+        self.assertFalse(self._pass(r, answered=True), "steady afterwards")
+        self.assertEqual(r["upSeq"], 1)
+
+    def test_a_silent_poll_under_a_start_hold_mints_no_second_bump(self):
+        # the far kernel restarts under the hold (the update leg), so a poll or two go silent and leave the
+        # _poll_miss mark; the hold spends no mark, and the pass after the hold spends it in the SAME bump the
+        # not-up row coming up mints
+        r = {"host": "TESTHOST", "status": "starting", "misses": 0, "booting": True}
+        self.assertFalse(self._pass(r, answered=True))
+        self.assertFalse(self._pass(r, answered=False, st="starting"), "a silent pass under the hold keeps the held status")
+        self.assertFalse(self._pass(r, answered=True), "answered again, still under the hold")
+        self.assertEqual(int(r.get("upSeq") or 0), 0)
+        self.assertTrue(r.get("_poll_miss"), "the mark waits for the pass after the hold")
+        r["booting"] = False
+        self.assertTrue(self._pass(r, answered=True))
+        self.assertEqual(r["upSeq"], 1, "one recovery for the whole Start, whatever the polls did under it")
+        self.assertNotIn("_poll_miss", r, "spent in that bump")
+        r["status"] = "up"
+        self.assertFalse(self._pass(r, answered=True))
+        self.assertEqual(r["upSeq"], 1)
+
+    def test_a_demand_mark_survives_the_hold_and_latches_in_the_one_bump(self):
+        """The guard defers the counter's bookkeeping, it does not discard it. A request that stalled just before
+        the Start left the demand mark (its woken pass found no kernel, which spends no mark, and Start was
+        pressed); the passes under the hold leave it too, so the bump after the hold spends it and latches the
+        demand path the way the first answered pass would have without the hold: the same request stalling again
+        on the healthy link mints no second bump, until a real silent poll re-arms it."""
+        r = {"host": "TESTHOST", "status": "starting", "misses": 0, "booting": True, "_demand_miss": True}
+        self.assertFalse(self._pass(r, answered=True))
+        self.assertFalse(self._pass(r, answered=True))
+        self.assertTrue(r.get("_demand_miss"), "the mark waits for the pass after the hold")
+        r["booting"] = False
+        self.assertTrue(self._pass(r, answered=True))
+        self.assertEqual(r["upSeq"], 1)
+        r["status"] = "up"
+        r["misses"], r["_demand_miss"] = km.STALE_MISSES - 1, True       # the same request stalls again
+        self.assertFalse(self._pass(r, answered=True), "the demand path latched in the recovery bump")
+        self.assertEqual(r["upSeq"], 1)
+        self.assertFalse(self._pass(r, answered=False))                    # a real silent poll re-arms it
+        self.assertTrue(self._pass(r, answered=True))
+        self.assertEqual(r["upSeq"], 2)
+
+    def test_a_not_up_probe_under_the_hold_still_rearms_the_demand_path(self):
+        """The guard sits after the not-answered branch: a probe the far kernel refuses under the hold (the update
+        leg restarts it) re-arms the demand path the way it does off the hold, so a Start asked of a row whose
+        demand path had latched does not carry the latch across the restart. Green before the guard existed; it
+        pins the path the guard leaves alone."""
+        r = {"host": "TESTHOST", "status": "starting", "misses": 0, "booting": True, "_demand_bumped": True}
+        self.assertFalse(self._pass(r, answered=True, st="no-kernel"), "a refusal is an answered probe that is not up")
+        self.assertNotIn("_demand_bumped", r, "re-armed under the hold, as off it")
+        r["booting"] = False
+        self.assertTrue(self._pass(r, answered=True))
+        self.assertEqual(r["upSeq"], 1)
+        r["status"] = "up"
+        r["misses"], r["_demand_miss"] = km.STALE_MISSES - 1, True
+        self.assertTrue(self._pass(r, answered=True), "re-armed: the next demand preload bumps")
+        self.assertEqual(r["upSeq"], 2)
+
     def test_a_row_that_is_not_up_never_bumps(self):
         r = {"host": "TESTHOST", "status": "up", "misses": 0}
         km._note_poll(r, False)


### PR DESCRIPTION
## Symptom

During a Start (the popover's button on a no-kernel row), the row's recovery counter (`upSeq`, served on `/tunnels`) climbs by one on every supervisor pass whose poll answers while the Start is in flight, then once more when the hold clears: 1, 2, 3, 4 for one Start. The contract in `_note_recovery`'s docstring (#1209) is one bump per recovery. The dashboard is not affected today: `/tunnels` serves the row as `starting` while the hold stands, and federation's poll turns a counter change into `hostUp` only while the row reads `up`, so the user still sees one `hostUp` per Start. This is a defect in the counter's own contract, and a reader of `/tunnels` that does not apply the dashboard's status filter would see a recovery per poll.

## Cause

`_start_remote` holds the row at `status: starting` with `booting: True` while it updates and boots the far kernel, and the supervisor pass skips its status write under the hold (the `not r.get("booting")` guard) so the row does not flicker red mid-Start. The pass still runs `_note_recovery(r, st)` every tick, after `_note_poll` and before the status write. To the counter, an answered pass on a row whose status is not `up` is a not-up row coming up, and the held status never becomes `up`, so each answered pass under the hold bumps again.

For the record: #1209's body names an older `_note_recovery(r, st, had_miss)` with a pre-bookkeeping read of the misses; the merged function is `_note_recovery(r, st)`, called after `_note_poll`, reading the `_poll_miss` mark a silent pass leaves. This change is against the merged shape.

## Fix

`_note_recovery` returns without bumping while `r["booting"]` is set; the first answered pass after the hold clears finds the row not up and bumps once, the one recovery of that Start. The guard defers the counter's bookkeeping rather than discarding it: it sits after the not-answered branch, so a probe the far kernel refuses under the hold re-arms the demand path as it does off the hold, and it leaves the `_poll_miss` and `_demand_miss` marks on the row, so the pass after the hold spends them in its one bump, and a demand mark latches the demand path there as the first answered pass would have without the hold. The docstring carries the clause. Two guard lines and the docstring in `kernel/kernel.py`; no change to the call site, the `/tunnels` field or the dashboard.

## Tests

`tests/test_kernel_tunnel_truth.py`, class `RecoveryCounter`, through the class's `_pass` helper (the pass's order: `_note_poll`, then `_note_recovery`), with the status write held as the pass holds it:

- `test_a_start_hold_bumps_once_when_it_clears`: `booting` held across two answered passes, `upSeq` stays 0; the hold clears; the next answered pass bumps to 1; the steady pass after the status write does not bump. Before the change it fails on its first assertion: the first answered pass under the hold bumps (the unchanged code reads 1, 2, then 3 across the same passes).
- `test_a_silent_poll_under_a_start_hold_mints_no_second_bump`: answered, silent (the held status handed to `_note_recovery`, as the pass does on a silent poll), answered again under the hold: none bumps, and the `_poll_miss` mark the silent poll left is still on the row; the pass after the hold bumps once and spends it. Before the change it fails on its first assertion, for the same reason. A guard that spent the marks under the hold fails the mark assertion.
- `test_a_demand_mark_survives_the_hold_and_latches_in_the_one_bump`: a `_demand_miss` mark on the row when the Start begins (a request stalled, its woken pass found no kernel, which spends no mark, and Start was pressed) survives two answered passes under the hold; the bump after the hold spends it and latches the demand path, so the same request stalling again on the healthy link mints no second bump, and a real silent poll re-arms it. Before the change it fails on its first assertion (the first answered pass under the hold spends the mark and bumps). A guard that spent the marks under the hold mints the second bump.
- `test_a_not_up_probe_under_the_hold_still_rearms_the_demand_path`: a refused probe under the hold (`no-kernel`, an answered probe that is not up) pops `_demand_bumped` as it does off the hold, and the next demand mark after the hold bumps again. Green on the unchanged kernel: it pins the path the guard leaves alone, and a guard placed ahead of the not-answered branch fails it.

Red on the unchanged kernel with these tests: `tests/test_kernel_tunnel_truth.py` 3 failed, 30 passed. Green after: 65 passed across `tests/test_kernel_tunnel_truth.py`, `tests/test_kernel_remote_start.py` and `tests/test_remotes_stale_and_persist.py`. Full suite on this head (`pytest -q -n 8 tests/`): 10725 passed, 118 skipped, 0 failed, 1688 subtests passed.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)