### PR TITLE
Timeline: a live lane's segment part is derived once and served while its inputs stand

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1058,7 +1058,17 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   sessions that left the alive set. The interrupt tick drops from `intrMarks`
   and `statesOverlay` the entries of sessions outside its alive set each
   cycle; the `statesOverlay` cache is also cleared whole above 256 entries, a
-  drop `evict` does not count and `entries` shows.
+  drop `evict` does not count and `entries` shows. `lanes` is the timeline's
+  per-lane segment memo: a live lane's bars, segment ends, last activity,
+  compaction markers and judging marks, held while its parsed transcript and
+  goal store are the previous build's objects and its captions file, archive
+  file, branch clip and the host's recorded suspensions stand. One outcome per
+  live lane per bars build: `hit`, `miss`, `live_tail` (a live tail was merged,
+  so the lane was derived and not held), `complain_skip` (the parse or a stage
+  failed) and `unshared_skip` (a private store with content); `evict` and the
+  gauge `entries`; `segs_hit` and `segs_miss` count the segments served and
+  derived. `dead_serve`, `dead_miss` and `dead_failed_serve` are the dead-lane
+  memo's outcomes on the same block, so one block carries every lane.
 - `judge`: `passes`, `ms_sum`, `ms_last`, `ms_mean` (wall time; a pass waits
   on model calls), `cpu_ms_sum` (CPU time of the judge tier threads and every
   per-session worker they run; the workers' share is `cpu_ms_workers`).

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -407,7 +407,8 @@ class _PerfStats:
                           ("backref", jd.backref_memo_stats), ("captions", jd.captions_memo_stats),
                           ("goalArchive", jd.goal_archive_memo_stats), ("plannerSkip", jd.planner_skip_stats),
                           ("liftGate", _lift_gate_report), ("bgTops", _bg_tops_report),
-                          ("intrMarks", _intr_marks_memo_report), ("statesOverlay", _states_overlay_report)):
+                          ("intrMarks", _intr_marks_memo_report), ("statesOverlay", _states_overlay_report),
+                          ("lanes", _lanes_memo_report)):   # the timeline's per-lane segment memo, live lanes; the dead lanes beside
             try:
                 memos[key] = read()
             except Exception:
@@ -36428,6 +36429,260 @@ def _dead_lane_marks(marks, t0):
     return [{k: v for k, v in m.items() if k != "_h"} for m in marks if m.get("_h", 0) >= t0]
 
 
+# ── the LIVE-lane memo: a live lane's SEGMENT part (its bars, segment ends, work end, compaction markers and its
+# judging marks, unfiltered) is derived once and served while every input it read stands. The dead-lane memo
+# above serves the dead lanes; the live lanes still walked every turn of every lane on every bars build, although
+# between two builds most live lanes had not changed either (a board of dozens of lanes has one or two writing).
+# Everything else on the lane (the chip, the awaiting overlay, the intervals, the flags, comments, episodes, the
+# branch endpoint) is derived per build as before. The inputs, each in the key:
+#   session   the object after _parse and _merge_live_atoms, by IDENTITY, held in the entry so the identity cannot
+#             be recycled (_parse returns the cached object for an unchanged transcript and states file; the merge
+#             returns it unchanged when there is no live tail). The loop reads its turns (t, end, ended, trigger,
+#             atoms). A live tail (the merge returned a new object) is derived and not held, since it is a new
+#             object every build (live_tail).
+#   goals     the store the loop reads seams from (_segs_seam) and nodes from (_derive_judging_marks): a FrozenStore
+#             by identity (load_goals_shared serves one per file version, so a publish or a journal append is a new
+#             object); a store with neither seams nor nodes, or None after a fault, as "empty", since the two
+#             fields read are empty whatever its identity; any other private store is not held (unshared_skip: a
+#             mutable store could change under the entry).
+#   captions  _stat_key of captions/<sid>.jsonl, taken by build_timeline BEFORE _captions reads the file (_captions
+#             builds a new dict per call, so the file is the input). Stat before read: a row appended between the
+#             two is read by this build and held under the OLD key, so the next build's stat misses and derives
+#             again; a stat after the read would hold the old rows under the new key and serve them stale until
+#             another input moved. No file and no rows as "empty"; rows read with no file to stat (it appeared
+#             between the two) are derived and not held.
+#   live      an open bar needs a live lane (turn_open). True on every call (a dead lane never reaches this memo);
+#             kept in the key as the derivation's input.
+#   bft       the branch clip, the fork time while the parent's lane is in the build and None otherwise
+#             (build_timeline's branch_of); it drops the copied pre-branch segments and boundaries.
+#   downtime  tuple(_downtime): _awake_spans excises the host's suspensions and _suspended_after closes a turn
+#             stranded before one. The tuple, not the length: a different nap of the same count re-cuts the bars
+#             (the dead-lane key carries the same tuple).
+#   archive   jd._file_key of STATE/archive/<sid>.json (the archiver mark's file), taken BEFORE the derivation
+#             reads it; a sentinel (the stat failed) matches nothing and nothing is stored under it.
+#   sid       the entry's key; the bars and marks carry it.
+# NOT inputs: the clock. The horizon (now - TL_HORIZON) and JUDGE_CAP_LIMIT are applied per build by
+# _judging_assemble, and nothing else in the segment part reads a time. A lane whose parse failed, or whose seams
+# or marks stage complained (the derivation's own try/excepts), is derived and not held (complain_skip). The held
+# bars are shared by identity into every later build's turns[sid], the bars wire cache and the delta parts, none
+# of which writes to them (_bind_message_execs mutates the messages only; _timeline_skeleton copies the frame),
+# and the held marks into `semantic`, which _run_judging only reads. Entries are dropped for lanes outside a full
+# build's lane set (_lanes_forget) and past _LANES_MEMO_MAX, the least recently served first; an entry whose parse
+# object is no longer the build's is dropped when seen, since it cannot hit again and it holds that parse; the
+# dead-lane populate pops a lane's entry when the lane dies (the entry holds the parse the populate releases). One
+# lock around get, put, evict and the counters; the derivation runs unlocked, so two threads deriving one lane both
+# store an exact entry and the last wins.
+_lanes_memo = {}          # sid -> (session, goals_obj, caps_key, key, value, prompts); value = _lane_segments' tuple,
+#                           prompts its full_prompts map (T278b)
+_LANES_MEMO_MAX = 256
+_lanes_stats = {"hit": 0, "miss": 0, "live_tail": 0, "complain_skip": 0, "unshared_skip": 0, "evict": 0,
+                "segs_hit": 0, "segs_miss": 0,
+                # the DEAD lanes of a bars build, counted by build_timeline (this memo never sees one): served from
+                # _dead_lane_memo (dead_serve), derived through _lane_segments (dead_miss: cached after, unless the
+                # store faulted, the transcript could not be stat'd or a stage complained), or served as the empty
+                # lane a failed parse was cached as (dead_failed_serve). Disjoint: their sum is the dead lanes of
+                # every bars build.
+                "dead_serve": 0, "dead_miss": 0, "dead_failed_serve": 0}
+_LANES_LOCK = threading.Lock()
+
+
+def _lanes_memo_report():
+    """The memo's counters plus its occupancy, for /perf (memos.lanes). hit, miss, live_tail, complain_skip,
+    unshared_skip, evict, entries, segs_hit and segs_miss are the LIVE lanes'; dead_serve, dead_miss and
+    dead_failed_serve are the dead lanes' (build_timeline counts them here, so one block carries every lane)."""
+    with _LANES_LOCK:
+        out = dict(_lanes_stats)
+        out["entries"] = len(_lanes_memo)
+    return out
+
+
+def _lanes_forget(keep):
+    """Drop the entries for lanes outside `keep`, a full build's lane set (the sids build_timeline drew).
+    Iterates a key snapshot under the lock; a connect-push build on another thread may insert concurrently."""
+    with _LANES_LOCK:
+        gone = [k for k in _lanes_memo if k not in keep]
+        for k in gone:
+            _lanes_memo.pop(k, None)
+        if gone:
+            _lanes_stats["evict"] += len(gone)
+
+
+def _lane_segments(sid, session, goals, caps, live, bft, full_prompts=None):
+    """The SEGMENT part of one timeline lane: the turn loop build_timeline ran inline, moved here so the per-lane
+    memo (_lane_memo; the comment above _lanes_memo names every input) can hold its result: (bars, seg_ends,
+    last_t, compactions, cap_marks, other_marks, nsegs, complained). bars are the lane's wire bars in turn order
+    (the compact shape below, every default omitted); seg_ends maps a segment's start t to its work-END t; last_t
+    is the lane's last awake activity (its `since` when the liveness snapshot has none); compactions are the
+    compact_boundary markers; cap_marks and other_marks are this lane's judging marks, unfiltered
+    (_derive_judging_marks); nsegs counts the segments visited (the cost a memo hit saves); complained is True
+    when the seams or the marks stage failed, or a mark carries a time the assembly could not compare, and
+    _bars_complain said so; such a lane is not memoized. No clock is read here. `full_prompts`, when given,
+    receives each segment's WHOLE prompt under its bar id (T278b): the bar carries the wire form (_wire_prompt,
+    the first line capped) and _bind_message_execs's sender heuristic reads the whole text through this map; a
+    memo that serves the bars serves the map beside them."""
+    if full_prompts is None:
+        full_prompts = {}
+    st_turns = session["turns"]
+    bars, last_t, seg_ends, nsegs, complained = [], None, {}, 0, False   # seg_ends: seg-start t → work-END t (for completion marks)
+    for ti, turn in enumerate(st_turns):
+        turn_open = (live and ti == len(st_turns) - 1 and not turn["ended"]
+                     and not any(x["type"] == "idle" for x in turn["atoms"])
+                     and not _suspended_after(turn["end"]))   # dead lane (live False) or pre-sleep freeze → not an open bar
+        try:
+            segs = _segs_seam(turn, goals)
+        except Exception as e:
+            # a malformed goals row must cost the SEAMS, not the lane's bars (2026-08-18: any
+            # exception here used to abort the whole bars frame after the skeleton had shipped)
+            _bars_complain(sid, "seams", e)
+            complained = True
+            try:
+                segs = em.segments(turn)
+            except Exception:
+                segs = []
+        for si, seg in enumerate(segs):
+            if bft and (seg.get("end") or seg["t"]) <= bft:
+                continue                                       # copied pre-branch history — the parent's lane owns it
+            nsegs += 1
+            # A bar must not span a host sleep. EXCISE every suspension inside the segment → one bar per
+            # awake stretch, so work done AFTER the lid reopened isn't erased (the user 2026-06-22). The
+            # asleep gaps between pieces read as idle (and collapse under 'collapse gaps'). The segment's
+            # atom times go in too: an awake stretch with NO activity in it is a dark-wake sliver, not
+            # work, and drawing it redrew this segment's summary all night long (the user 2026-07-23).
+            spans = _awake_spans(seg["t"], seg["end"], [a.get("t") for a in seg["atoms"]])
+            last_t = max(last_t or 0, spans[-1][1])            # the true work END (last awake activity) — drives the lane `since`
+            seg_ends[seg["t"]] = spans[-1][1]                  # a completion mark lands at its segment's END (after the work)
+            cap = _seg_work_caption(caps, seg["id"])       # WORK caption (the bar) — drift-safe
+            msg_cap = _seg_caption(caps, seg["id"])    # MESSAGE caption (the dot) — gist of the ask, ready early; drift-safe
+            work_uuid, reply_uuid = _seg_anchors(seg["atoms"])
+            full_prompts[seg["id"]] = full_prompt = _seg_prompt(seg)
+            trig = next((x for x in seg["atoms"] if x.get("uuid") == seg.get("trigger")), None)
+            author = (trig or {}).get("author")
+            src = "queued" if isinstance(author, dict) else "typed"
+            for sj, (bstart, bend) in enumerate(spans):
+                # THE WIRE BAR (T278c): three long keys the delta path, the federation merge and the
+                # kernel's own readers need by name (id, start, end), then the rest under one-letter keys
+                # with every default OMITTED (a false flag, an empty list or caption, the "typed" source):
+                # 8,577 bars carried 1.1 MB of key names and 0.9 MB of defaults in a 12 MB frame. The view
+                # expands a bar once at its boundary (expandBars in ui/romp-timeline-view.js, the twin of
+                # _BAR_WIRE below, drift-guarded by tests) so every reader keeps its long names.
+                # promptId = the prompt atom (the DOT), workId = the first work atom (the BAR) — so a chat
+                # message-hover lights only the dot and a work-hover only the bar (dotLit/barLit in the view).
+                # The wire prompt (T278b): the first line, capped; the tip shows 90 chars of it and nothing
+                # else reads it. tid (= the lane key), uuid (= promptId) and workUuid (= workId) left the
+                # wire in T278b: the view reads the lane key, promptId and workId instead.
+                bar = {"id": seg["id"], "start": bstart, "end": bend}
+                if seg.get("trigger"):
+                    bar["p"] = seg.get("trigger")
+                if work_uuid:
+                    bar["w"] = work_uuid
+                if reply_uuid:
+                    bar["r"] = reply_uuid
+                q = _wire_prompt(full_prompt)
+                if q:
+                    bar["q"] = q
+                if cap:
+                    bar["c"] = cap
+                if msg_cap:
+                    bar["m"] = msg_cap
+                if src != "typed":
+                    bar["s"] = src
+                mids = _seg_mids(seg)
+                if mids:
+                    bar["d"] = mids
+                if turn_open and si == len(segs) - 1 and sj == len(spans) - 1 and bend == seg["end"]:
+                    bar["u"] = True                        # open: the live turn's last piece
+                if sj > 0:
+                    bar["t"] = True                        # a post-sleep continuation piece: NO new prompt dot
+                if (trig or {}).get("rompAuto"):
+                    bar["a"] = True                        # an AUTO-nudge specifically → the tip captions it 'romp · nudge'
+                if author == "romp":
+                    # ANY romp-authored prompt (auto-nudge, Nudge button, auto-retry — author 'romp' via
+                    # ROMP_INJECT_RE) wears the romp logo on its dot (the user 2026-07-16: an auto-retry
+                    # whose dot had drawn as a human prompt instead of wearing the logo), mirroring the chat's 2026-07-05 rule
+                    bar["o"] = True
+                bars.append(bar)
+    try:
+        cap_marks, other_marks = _derive_judging_marks(sid, caps, goals, seg_ends) if goals is not None else ([], [])
+        # The horizon comparisons run in _judging_assemble, per build, outside this lane's guard; the one-pass form
+        # compared every time here and a malformed time (a string t on a captions row, a non-numeric groupOp.t,
+        # ev_t, distilledMt, briefedMt or archive t) cost this lane its marks. The same here, before the lane can
+        # be memoized: a time the assembly could not compare is a failed marks stage, not a frame lost on every
+        # build until the data changes.
+        if (any(not isinstance(m["t"], (int, float)) for m in cap_marks)
+                or any(not isinstance(ft, (int, float)) for ft, _m in other_marks)):
+            raise TypeError("a judging mark carries a non-numeric time")
+    except Exception as e:
+        _bars_complain(sid, "judging-marks", e)   # this lane loses its marks, the frame ships
+        complained = True
+        cap_marks, other_marks = [], []
+    compactions = [{"t": a["t"]} for turn in st_turns for a in turn["atoms"]
+                   if a.get("type") == "system" and a.get("subtype") == "compact_boundary" and a.get("t")
+                   and not (bft and a["t"] <= bft)]           # copied boundaries stay on the parent's lane
+    return bars, seg_ends, last_t, compactions, cap_marks, other_marks, nsegs, complained
+
+
+def _lane_memo(sid, parsed, session, goals, caps, cap_key, live, bft, parse_ok=True, full_prompts=None):
+    """_lane_segments through the per-lane memo (the comment above _lanes_memo names every input): the six
+    pieces build_timeline reads, bars, seg_ends, last_t, compactions, cap_marks and other_marks, served from the
+    lane's entry when its inputs are the previous build's and derived otherwise. LIVE lanes only: build_timeline
+    serves a dead lane from the dead-lane memo and derives a dead miss with _lane_segments directly, so `live` is
+    True on every call here. `parsed` is the _parse object and `session` the one after _merge_live_atoms, the
+    same object unless a live tail was merged; `cap_key` is the captions file's _stat_key taken before _captions
+    read it (None when the file could not be stat'd); `parse_ok` is False when the parse failed and `session` is the
+    empty stand-in. `full_prompts` (T278b) receives the lane's whole prompts by bar id, on a hit from the entry and on
+    a miss from the derivation, so the binder reads them either way."""
+    if isinstance(goals, jd.FrozenStore):
+        gobj, gtag = goals, "shared"
+    elif goals is None or (not goals.get("seams") and not goals.get("nodes")):
+        gobj, gtag = None, "empty"   # None: the store FAULTED (build_timeline complained); no seams, no marks
+    else:
+        gobj, gtag = None, None
+    if cap_key is not None:
+        ckey = cap_key
+    elif not caps:
+        ckey = "empty"
+    else:
+        ckey = None                  # rows read with no file to stat: this build's rows have no key, not held
+    arch_key = jd._file_key(str(jd.STATE / "archive" / (sid + ".json")))   # BEFORE the derivation reads it
+    key = (live, bft, tuple(_downtime), gtag, arch_key)
+    if not parse_ok:
+        skip = "complain_skip"
+    elif session is not parsed:
+        skip = "live_tail"
+    elif gtag is None:
+        skip = "unshared_skip"
+    else:
+        skip = None
+    with _LANES_LOCK:
+        ent = _lanes_memo.get(sid)
+        if ent is not None:
+            if skip is None and ent[0] is session and ent[1] is gobj and ent[2] == ckey and ent[3] == key:
+                _lanes_memo.pop(sid, None)                    # a served entry is a USED entry (LRU reinsert)
+                _lanes_memo[sid] = ent
+                _lanes_stats["hit"] += 1
+                _lanes_stats["segs_hit"] += ent[4][6]
+                if full_prompts is not None:
+                    full_prompts.update(ent[5])            # the memoized lane's full prompts, for the binder (T278b)
+                return ent[4][:6]
+            if ent[0] is not parsed:
+                _lanes_memo.pop(sid, None)                    # its parse object is no longer the build's: it cannot hit again
+    lane_prompts = {}
+    value = _lane_segments(sid, session, goals, caps, live, bft, lane_prompts)
+    if full_prompts is not None:
+        full_prompts.update(lane_prompts)
+    outcome = skip or ("complain_skip" if value[7] else "miss")
+    with _LANES_LOCK:
+        _lanes_stats[outcome] += 1
+        _lanes_stats["segs_miss"] += value[6]
+        if outcome == "miss" and ckey is not None and (arch_key is None or isinstance(arch_key, tuple)):
+            _lanes_memo.pop(sid, None)
+            while len(_lanes_memo) >= _LANES_MEMO_MAX:
+                _lanes_memo.pop(next(iter(_lanes_memo)))      # the least recently served goes first, never the whole memo
+                _lanes_stats["evict"] += 1
+            _lanes_memo[sid] = (session, gobj, ckey, key, value, lane_prompts)
+    return value[:6]
+
+
 _session_tok_cache = {}   # transcript path -> ((mtime, size), [(t, in, out, cache_w, cache_r, model), ...]): one
 #                           token row per API RESPONSE (message.id) in THAT file. The main transcript and each
 #                           subagent transcript cache separately, so a file that moved re-parses itself alone
@@ -37036,6 +37291,7 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
         goals, gfault = jd.load_goals_shared_or_fault(sid)   # read-only view (seams + judging marks); a FAULT (row
         if gfault is not None:                       # filed) → None: this lane renders without goal-derived data
             _bars_complain(sid, "goals", gfault)     # (blocked state, seams, marks) and the frame ships for every other lane
+        parse_ok = True                              # False below when the parse raised (the live-lane memo does not hold such a lane)
         # a DEAD lane's parse-derived parts are served from the memo while every input they read stands
         # (see _dead_lane_memo); a goals fault is never cached (the lane's marks are missing, loudly)
         lane_key = _dead_lane_key(sid, s["path"], branch_of.get(sid)) if (with_bars and not live and gfault is None) else None
@@ -37046,12 +37302,17 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
             cached = lane_hit[1]
             session = None; caps = {}; st_turns = []; open_now = False
             _VIEW_STATS["laneServe"] = _VIEW_STATS.get("laneServe", 0) + 1
+            with _LANES_LOCK:                             # the dead lanes' outcomes ride memos.lanes beside the live lanes' (_lanes_stats)
+                _lanes_stats["dead_failed_serve" if cached.get("failed") else "dead_serve"] += 1
+            full_prompts.update(cached.get("prompts") or {})   # the memoized lane's full prompts, for the binder (T278b)
         elif with_bars:
             try:
                 session = _parse(s["path"], sid, now)
             except Exception as e:
                 _bars_complain(sid, "parse", e)           # a lane with zero bars must SAY why
                 session = {"turns": []}
+                parse_ok = False
+            parsed = session                              # the parse object, the live-lane memo's key (_lane_memo)
             if live:
                 # Merge the LIVE TAIL like the chat does (the user 2026-07-02): a /model change streams the
                 # CLI's confirmation as a live command atom, but the CLI persists no transcript record until
@@ -37063,6 +37324,7 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
                     session = _merge_live_atoms(session, sid)
                 except Exception as e:
                     _bars_complain(sid, "live-merge", e)  # disk-only bars from here — say so
+            cap_key = _stat_key(jd.CAPDIR / (sid + ".jsonl")) if live else None   # the memo's captions key, BEFORE the read (_lanes_memo's comment)
             caps = _captions(sid)
             st_turns = session["turns"]
             open_now = _session_working(st_turns)         # WORKING from the event model — the one shared signal
@@ -37114,130 +37376,71 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
                        and not _session_flag(sid, "hideFromFeed"))
             state = "needsInput" if blocked else "idle"   # muted → no awaiting/background-task badge on the lane
             aw_open = open_now                          # unused (awaitingBg is None for a dead lane) — kept defined
-        bars, last_t, seg_ends = [], None, {}            # seg_ends: seg-start t → work-END t (for completion marks)
-        if lane_hit is not None:
-            bars, last_t = cached["bars"], cached["last_t"]
-            full_prompts.update(cached.get("prompts") or {})   # the memoized lane's full prompts, for the binder (T278b)
-        for ti, turn in enumerate(st_turns):
-            turn_open = (live and ti == len(st_turns) - 1 and not turn["ended"]
-                         and not any(x["type"] == "idle" for x in turn["atoms"])
-                         and not _suspended_after(turn["end"]))   # dead lane (live False) or pre-sleep freeze → not an open bar
-            try:
-                segs = _segs_seam(turn, goals)
-            except Exception as e:
-                # a malformed goals row must cost the SEAMS, not the lane's bars (2026-08-18: any
-                # exception here used to abort the whole bars frame after the skeleton had shipped)
-                _bars_complain(sid, "seams", e)
-                try:
-                    segs = em.segments(turn)
-                except Exception:
-                    segs = []
-            _bft = (branch_of.get(sid) or {}).get("t")
-            for si, seg in enumerate(segs):
-                if _bft and (seg.get("end") or seg["t"]) <= _bft:
-                    continue                                       # copied pre-branch history — the parent's lane owns it
-                # A bar must not span a host sleep. EXCISE every suspension inside the segment → one bar per
-                # awake stretch, so work done AFTER the lid reopened isn't erased (the user 2026-06-22). The
-                # asleep gaps between pieces read as idle (and collapse under 'collapse gaps'). The segment's
-                # atom times go in too: an awake stretch with NO activity in it is a dark-wake sliver, not
-                # work, and drawing it redrew this segment's summary all night long (the user 2026-07-23).
-                spans = _awake_spans(seg["t"], seg["end"], [a.get("t") for a in seg["atoms"]])
-                last_t = max(last_t or 0, spans[-1][1])            # the true work END (last awake activity) — drives the lane `since`
-                seg_ends[seg["t"]] = spans[-1][1]                  # a completion mark lands at its segment's END (after the work)
-                if not with_bars:
-                    continue                                       # SKELETON: lane `since` needs last_t, but not the bar dicts/captions
-                cap = _seg_work_caption(caps, seg["id"])       # WORK caption (the bar) — drift-safe
-                msg_cap = _seg_caption(caps, seg["id"])    # MESSAGE caption (the dot) — gist of the ask, ready early; drift-safe
-                work_uuid, reply_uuid = _seg_anchors(seg["atoms"])
-                full_prompts[seg["id"]] = full_prompt = _seg_prompt(seg)
-                trig = next((x for x in seg["atoms"] if x.get("uuid") == seg.get("trigger")), None)
-                author = (trig or {}).get("author")
-                src = "queued" if isinstance(author, dict) else "typed"
-                for sj, (bstart, bend) in enumerate(spans):
-                    # THE WIRE BAR (T278c): three long keys the delta path, the federation merge and the
-                    # kernel's own readers need by name (id, start, end), then the rest under one-letter keys
-                    # with every default OMITTED (a false flag, an empty list or caption, the "typed" source):
-                    # 8,577 bars carried 1.1 MB of key names and 0.9 MB of defaults in a 12 MB frame. The view
-                    # expands a bar once at its boundary (expandBars in ui/romp-timeline-view.js, the twin of
-                    # _BAR_WIRE below, drift-guarded by tests) so every reader keeps its long names.
-                    # promptId = the prompt atom (the DOT), workId = the first work atom (the BAR) — so a chat
-                    # message-hover lights only the dot and a work-hover only the bar (dotLit/barLit in the view).
-                    # The wire prompt (T278b): the first line, capped; the tip shows 90 chars of it and nothing
-                    # else reads it. tid (= the lane key), uuid (= promptId) and workUuid (= workId) left the
-                    # wire in T278b: the view reads the lane key, promptId and workId instead.
-                    bar = {"id": seg["id"], "start": bstart, "end": bend}
-                    if seg.get("trigger"):
-                        bar["p"] = seg.get("trigger")
-                    if work_uuid:
-                        bar["w"] = work_uuid
-                    if reply_uuid:
-                        bar["r"] = reply_uuid
-                    q = _wire_prompt(full_prompt)
-                    if q:
-                        bar["q"] = q
-                    if cap:
-                        bar["c"] = cap
-                    if msg_cap:
-                        bar["m"] = msg_cap
-                    if src != "typed":
-                        bar["s"] = src
-                    mids = _seg_mids(seg)
-                    if mids:
-                        bar["d"] = mids
-                    if turn_open and si == len(segs) - 1 and sj == len(spans) - 1 and bend == seg["end"]:
-                        bar["u"] = True                        # open: the live turn's last piece
-                    if sj > 0:
-                        bar["t"] = True                        # a post-sleep continuation piece: NO new prompt dot
-                    if (trig or {}).get("rompAuto"):
-                        bar["a"] = True                        # an AUTO-nudge specifically → the tip captions it 'romp · nudge'
-                    if author == "romp":
-                        # ANY romp-authored prompt (auto-nudge, Nudge button, auto-retry — author 'romp' via
-                        # ROMP_INJECT_RE) wears the romp logo on its dot (the user 2026-07-16: an auto-retry
-                        # whose dot had drawn as a human prompt instead of wearing the logo), mirroring the chat's 2026-07-05 rule
-                        bar["o"] = True
-                    bars.append(bar)
-        if not with_bars and last_t is None:
-            try:
-                last_t = os.stat(s["path"]).st_mtime     # lane `since` ≈ the transcript's last write (last activity), no parse
-            except OSError:
-                pass
         _bft = (branch_of.get(sid) or {}).get("t")
         if lane_hit is not None:
+            # served from the DEAD-LANE memo (above): the segment part is the cached one, byte for byte, and the marks
+            # are filtered per build on their stamped compare value (_dead_lane_marks)
+            bars, last_t, compactions = cached["bars"], cached["last_t"], cached["compactions"]
             turns[sid] = bars
             semantic.extend(_dead_lane_marks(cached["marks"], now - TL_HORIZON))
-            compactions = cached["compactions"]
-        elif with_bars:
+        elif not with_bars:
+            # SKELETON: no bars, no marks, no memo (a cold live-first connect, and a connect over a stale cache;
+            # neither reads nor evicts here). The lane's `since` falls back to the transcript's last write (last
+            # activity), with no parse.
+            compactions = []
+            try:
+                last_t = os.stat(s["path"]).st_mtime
+            except OSError:
+                last_t = None
+        else:
+            # The SEGMENT part of the lane: the turn loop that makes the bars, seg_ends, last_t and the compaction
+            # markers, plus this lane's judging marks (_lane_segments). A LIVE lane's comes through the per-lane memo
+            # (_lane_memo; _lanes_memo's comment names every input in the key): a lane whose inputs are the previous
+            # build's objects costs a lookup. A DEAD lane's is derived here directly (a dead MISS: the dead-lane memo
+            # above did not serve it) and cached there under its stat key below, so the per-lane memo never stores an
+            # entry the populate would pop at once and never counts a dead lane as its miss. The badge row below is
+            # per build.
+            if live:
+                bars, seg_ends, last_t, compactions, cap_marks, other_marks = _lane_memo(
+                    sid, parsed, session, goals, caps, cap_key, live, _bft, parse_ok, full_prompts)
+            else:
+                value = _lane_segments(sid, session, goals, caps, live, _bft, full_prompts)
+                bars, seg_ends, last_t, compactions, cap_marks, other_marks = value[:6]
+                with _LANES_LOCK:
+                    _lanes_stats["dead_miss"] += 1
+                if value[7]:
+                    lane_key = None                        # a lane whose seams or marks stage complained is derived
+                    #                                          every build and never cached (as one whose marks failed was)
             turns[sid] = bars
             marks = []
             try:
-                if goals is not None:
-                    # a dead lane's marks are derived ONCE at horizon 0 and stamped, so the memo can filter
+                if lane_key is not None:
+                    # a dead lane's marks are assembled ONCE at horizon 0 and stamped, so the dead-lane memo can filter
                     # them per build on exactly the value this call would have compared (_dead_lane_marks)
-                    if lane_key is not None:
-                        _derive_judging(sid, caps, goals, 0, marks, seg_ends, stamp=True)
-                        semantic.extend(_dead_lane_marks(marks, now - TL_HORIZON))
-                    else:
-                        _derive_judging(sid, caps, goals, now - TL_HORIZON, semantic, seg_ends)
+                    _judging_assemble(cap_marks, other_marks, 0, marks, stamp=True)
+                    semantic.extend(_dead_lane_marks(marks, now - TL_HORIZON))
+                else:
+                    _judging_assemble(cap_marks, other_marks, now - TL_HORIZON, semantic)   # the horizon is the build's
             except Exception as e:
                 _bars_complain(sid, "judging-marks", e)   # this lane loses its marks, the frame ships
                 lane_key = None                            # never cache a lane whose marks failed
-            compactions = [{"t": a["t"]} for turn in st_turns for a in turn["atoms"]
-                           if a.get("type") == "system" and a.get("subtype") == "compact_boundary" and a.get("t")
-                           and not (_bft and a["t"] <= _bft)]       # copied boundaries stay on the parent's lane
             if lane_key is not None:
                 if len(_dead_lane_memo) > _DEAD_LANE_MEMO_MAX:      # bounded by the lane window; evict oldest-inserted
                     _dead_lane_memo.pop(next(iter(_dead_lane_memo)))
                 _dead_lane_memo[sid] = (lane_key, {"bars": bars, "compactions": compactions, "last_t": last_t, "marks": marks,
+                                                   # a parse that raised is cached as the empty lane it drew (a dead
+                                                   # transcript has no writer); the flag keeps its serves apart on /perf
+                                                   "failed": not parse_ok,
                                                    # the lane's full prompts (T278b): the binder's sender heuristic reads
                                                    # them, and a lane can die within an hour of a message it received
                                                    "prompts": {b["id"]: full_prompts[b["id"]] for b in bars if b["id"] in full_prompts}})
                 # the parse has done its work for this dead lane: drop it (the RSS lever); a lane that moves
-                # re-parses once, and a session that revives is parsed by its chat build as before
+                # re-parses once, and a session that revives is parsed by its chat build as before. The live-lane
+                # memo's entry from the lane's live days goes with it: its key is that parse object, so it cannot
+                # hit again and would hold the parse the pop just released
                 _parse_cache.pop(s["path"], None)
-        else:
-            compactions = [{"t": a["t"]} for turn in st_turns for a in turn["atoms"]
-                           if a.get("type") == "system" and a.get("subtype") == "compact_boundary" and a.get("t")
-                           and not (_bft and a["t"] <= _bft)]       # copied boundaries stay on the parent's lane
+                with _LANES_LOCK:
+                    _lanes_memo.pop(sid, None)
         # Idle fade: the SAME rule the chat tab uses (ready + idle > 1h — see the `faded` beside the chat
         # chip), keyed on the DERIVED chip `state` computed above, not the raw tmux state. The old form read
         # tmux's vocabulary and counted "waiting" as active — but "waiting" IS the post-turn idle state, so
@@ -37294,6 +37497,11 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
             "hideFromFeed": _session_flag(sid, "hideFromFeed"),    # lane checkbox → mute from feed (timeline-only)
             "postalServiceOff": _session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"),  # lane mailbox → isolate from the Romp Postal Service (bin/romp-postal-service)
             "notify": _notify_session_effective(sid)})   # lane bell, EFFECTIVE (override, else the master default) → OS notification when this session's work blocks on you / completes (the user 2026-07-28)
+    if with_bars and not live_only:
+        # the live-lane memo releases the lanes that left the timeline here: a full build's lane set (live sessions
+        # plus the dead lanes inside the 12 h window, dismissed dead lanes dropped) is the set this build read. A
+        # skeleton or live-only build reads a subset of the lanes and so must not evict on it.
+        _lanes_forget(set(id2name))
     if with_bars:
         # Each with_bars-only stage is guarded ALONE (2026-08-18): the pusher sends the cheap lane
         # SKELETON before this heavy build, and its shared try used to abort the WHOLE bars frame on

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36266,20 +36266,35 @@ def _derive_judging(sid, caps, goals, t0, out, seg_ends=None, stamp=False):
     trailing AFTER it — reading as if the judge ran before the work (the user 2026-06-19). `seg_ends`
     maps each segment's start t → its work-END t; a completion mark resolves through it to land just
     after the bar, where the work actually finished. CREATION marks (mint/sub) + captions stay at the
-    start — a goal IS born when asked. Absent seg_ends (e.g. unit tests) → the old mt placement."""
-    # `stamp` (the dead-lane memo, 2026-09-08): every mark carries the value the horizon test compared
-    # under the private key "_h", so a lane cached once with t0 = 0 can be filtered later on exactly that
-    # value (the diary and distiller marks are COMPARED on their evidence time but EMITTED at the segment's
-    # work end, so a filter on the emitted `t` would not be the same set); _dead_lane_marks strips it.
-    def mark(h, m):
-        if stamp:
-            m["_h"] = h
-        out.append(m)
+    start — a goal IS born when asked. Absent seg_ends (e.g. unit tests) → the old mt placement.
+
+    Two halves: _derive_judging_marks derives every mark with no clock in hand, so the timeline's per-lane
+    memo can hold the result, and _judging_assemble applies the horizon t0 and the caption cap per build.
+    Together they emit exactly what this function emitted in one pass. `stamp` (the dead-lane memo,
+    2026-09-08): every mark carries the value the horizon test compared under the private key "_h", so a
+    lane cached once with t0 = 0 can be filtered later on exactly that value (the diary and distiller marks
+    are COMPARED on their evidence time but EMITTED at the segment's work end, so a filter on the emitted
+    `t` would not be the same set); _dead_lane_marks strips it."""
+    cap_marks, other_marks = _derive_judging_marks(sid, caps, goals, seg_ends)
+    _judging_assemble(cap_marks, other_marks, t0, out, stamp=stamp)
+
+
+def _derive_judging_marks(sid, caps, goals, seg_ends=None):
+    """This session's judging marks UNFILTERED by the timeline horizon: (cap_marks, other_marks). cap_marks
+    are the captioner's marks in caption-time order, one per caption row carrying a t (a row without one is
+    dropped here, as the one-pass form dropped it). other_marks are [(filter_t, mark)] pairs for every other
+    judge in the order the one-pass form emitted them (nodes in store order, the archiver last), each paired
+    with the time the horizon is compared against: the mark's own t for a mint, plant, group or index mark,
+    the diary event's ev_t for a done, block or close, distilledMt or briefedMt for the distiller's two
+    marks. That time differs from the mark's plotted t whenever seg_ends moved a completion to its
+    segment's work end, which is why the pair is kept rather than re-derived from the mark. A synth diary
+    row is dropped here (its skip never depended on the horizon). Reads caps, goals["nodes"] and
+    STATE/archive/<sid>.json, and no clock: the horizon and JUDGE_CAP_LIMIT belong to _judging_assemble."""
     endt = (lambda tt: seg_ends.get(tt, tt)) if seg_ends else (lambda tt: tt)   # completion → its segment's work-END
-    caps_in = sorted((c for c in caps.values() if c.get("t") and c["t"] >= t0), key=lambda c: c["t"])
-    for c in caps_in[-JUDGE_CAP_LIMIT:]:
-        mark(c["t"], {"judge": "captioner", "sid": sid, "t": c["t"],
-                      "kind": c.get("grain", "segment"), "text": c.get("caption", "")})
+    caps_in = sorted((c for c in caps.values() if c.get("t")), key=lambda c: c["t"])
+    cap_marks = [{"judge": "captioner", "sid": sid, "t": c["t"],
+                  "kind": c.get("grain", "segment"), "text": c.get("caption", "")} for c in caps_in]
+    out = []
     for n in goals.get("nodes", {}).values():
         t = n.get("t")
         if not t:
@@ -36287,57 +36302,75 @@ def _derive_judging(sid, caps, goals, t0, out, seg_ends=None, stamp=False):
         text = n.get("text", "")
         mt = n.get("mt") or t
         go = n.get("groupOp")
-        if isinstance(go, dict) and (go.get("t") or 0) >= t0:
+        if isinstance(go, dict):
             # the grouper's surviving housekeeping (T103): merge/split/retitle append no diary
             # events by design, so the lane keys on the apply-time structure stamp — additive
             # beside the node's own mint/plant mark (a merged survivor is both)
-            mark(go["t"], {"judge": "grouper", "sid": sid, "t": go["t"],
-                           "kind": go.get("kind") or "group", "text": text})
+            out.append((go.get("t") or 0, {"judge": "grouper", "sid": sid, "t": go.get("t"),
+                                           "kind": go.get("kind") or "group", "text": text}))
         if n.get("origin"):                                   # courier planted it from a peer's handoff
-            if t >= t0:
-                mark(t, {"judge": "courier", "sid": sid, "t": t, "kind": "plant", "text": text})
+            out.append((t, {"judge": "courier", "sid": sid, "t": t, "kind": "plant", "text": text}))
         elif n.get("umbrella"):                               # ARCHIVED-history rendering only (T101
             # retired every umbrella mint; live containers dissolve each rollup) — an archived
             # pre-T101 container still shows the grouper mark it earned
-            if mt >= t0:
-                mark(mt, {"judge": "grouper", "sid": sid, "t": mt, "kind": "group", "text": text})
-        elif t >= t0:                                         # planner placed it (top = mint, else a step)
-            mark(t, {"judge": "planner", "sid": sid, "t": t,
-                     "kind": ("mint" if not n.get("parentId") else "sub"), "text": text})
+            out.append((mt, {"judge": "grouper", "sid": sid, "t": mt, "kind": "group", "text": text}))
+        else:                                                 # planner placed it (top = mint, else a step)
+            out.append((t, {"judge": "planner", "sid": sid, "t": t,
+                            "kind": ("mint" if not n.get("parentId") else "sub"), "text": text}))
         # done/block attribution reads the DIARY now (P3.4 2026-07-07): the event's src field IS the
         # provenance (negComplete/negBlock flags retired), each verdict gets its own mark at its own
         # evidence time, and reconstructed (synth) history never fakes a judging mark.
         for _e in (n.get("log") or []):
-            if _e.get("synth") or (_e.get("ev_t") or 0) < t0:
+            if _e.get("synth"):
                 continue
             if _e.get("src") in ("planner", "closer") and _e.get("kind") in ("done", "block"):
-                mark(_e["ev_t"], {"judge": _e["src"] if _e["src"] == "planner" else "closer", "sid": sid,
-                                  "t": endt(_e["ev_t"]),
-                                  "kind": ("done" if _e["src"] == "planner" else "close") if _e["kind"] == "done" else "block",
-                                  "text": _e.get("why") or text})
+                out.append((_e.get("ev_t") or 0,
+                            {"judge": _e["src"] if _e["src"] == "planner" else "closer", "sid": sid,
+                             "t": endt(_e.get("ev_t")),
+                             "kind": ("done" if _e["src"] == "planner" else "close") if _e["kind"] == "done" else "block",
+                             "text": _e.get("why") or text}))
         # distiller — key takeaway on a completed top goal. distilledMt == the goal's completion mt (the
         # completing segment's START); endt() lands the mark at that segment's work-END, just after the bar.
         # (The distiller LLM runs a pass later; the mark shows the work it summarizes, aligned to that work's
         # finish, not the judge's wall-clock run. A first sweep over the backlog still back-dates to old
         # completions, expected — the user 2026-06-17.)
-        if n.get("distilledMt") and n["distilledMt"] >= t0:
-            mark(n["distilledMt"], {"judge": "distiller", "sid": sid, "t": endt(n["distilledMt"]), "kind": "distill",
-                                    "text": n.get("summary") or text})
+        if n.get("distilledMt"):
+            out.append((n["distilledMt"], {"judge": "distiller", "sid": sid, "t": endt(n["distilledMt"]),
+                                           "kind": "distill", "text": n.get("summary") or text}))
         # block-distiller — the DECISION BRIEF on a BLOCKED top (briefedMt), the done-distiller's twin run
         # in the same pass. Same distiller row, a distinct kind ("brief"). Without this the brief popped up
         # on the card but left NO mark on the timeline, so the distiller row read as dead whenever the
         # recent work was blocks rather than completions (the user 2026-06-18). Lands at the block segment's
         # work-END via endt(), like the other completion marks.
-        if n.get("briefedMt") and n["briefedMt"] >= t0:
-            mark(n["briefedMt"], {"judge": "distiller", "sid": sid, "t": endt(n["briefedMt"]), "kind": "brief",
-                                  "text": n.get("blockSummary") or text})
+        if n.get("briefedMt"):
+            out.append((n["briefedMt"], {"judge": "distiller", "sid": sid, "t": endt(n["briefedMt"]),
+                                         "kind": "brief", "text": n.get("blockSummary") or text}))
     try:                                                      # archiver — the headline/abstract refresh
         arch = json.loads((jd.STATE / "archive" / (sid + ".json")).read_text(errors="replace"))
-        if arch.get("t") and arch["t"] >= t0:
-            mark(arch["t"], {"judge": "archiver", "sid": sid, "t": arch["t"], "kind": "index",
-                             "text": arch.get("headline", "")})
+        if arch.get("t"):
+            out.append((arch["t"], {"judge": "archiver", "sid": sid, "t": arch["t"], "kind": "index",
+                                    "text": arch.get("headline", "")}))
     except (OSError, ValueError):
         pass
+    return cap_marks, out
+
+
+def _judging_assemble(cap_marks, other_marks, t0, out, stamp=False):
+    """Append the marks _derive_judging_marks derived, filtered on the horizon t0 as the one-pass form
+    filtered them: the captioner's marks at or after t0 and, of those, the newest JUDGE_CAP_LIMIT (the marks
+    are in t order, so the tail is the newest); then every other mark whose filter time is at or after t0,
+    in derivation order. Runs per build (the horizon moves with the clock; JUDGE_CAP_LIMIT is read here,
+    not at derivation), on a memo hit as on a miss. With `stamp` (the dead-lane memo, _derive_judging's
+    docstring) every appended mark is a COPY carrying its filter time under "_h": a copy, because the pairs
+    are the per-lane memo's, shared by identity into every unstamped build's `semantic`, and the stamp must
+    never reach the wire (_dead_lane_marks strips it)."""
+    kept = [m for m in cap_marks if m["t"] >= t0]
+    if stamp:
+        out.extend(dict(m, _h=m["t"]) for m in kept[-JUDGE_CAP_LIMIT:])
+        out.extend(dict(m, _h=ft) for ft, m in other_marks if ft >= t0)
+        return
+    out.extend(kept[-JUDGE_CAP_LIMIT:])
+    out.extend(m for ft, m in other_marks if ft >= t0)
 
 
 # ── the DEAD-LANE memo (2026-09-08): a timeline lane whose session is dead is re-derived only when an

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -42687,10 +42687,11 @@ def _consume_pending_reveal(client):
 
 def _cached_timeline(now, tmux, sig, connect=False):
     e = _built_timeline
-    if e[1] is not None and (connect or _timeline_cache_fresh(sig)):
+    built = e[1]                # one read: the pusher assigns _built_timeline[:] on its thread while a connect reads here
+    if built is not None and (connect or _timeline_cache_fresh(sig)):
         _VIEW_STATS["tlServe"] += 1
         _PERF_STATS.build("timeline", True)
-        return e[1]
+        return built
     _VIEW_STATS["tlBuild"] += 1
     started = time.time()
     _t0 = time.monotonic()

--- a/tests/test_kernel_goal_cache_wiring.py
+++ b/tests/test_kernel_goal_cache_wiring.py
@@ -143,7 +143,8 @@ class SharedViewInBuilds(unittest.TestCase):
         self.td = tempfile.TemporaryDirectory()
         self.saved_state = jd.STATE
         jd._rebind_state(Path(self.td.name))         # clears the cache and lifts any earlier off switch
-        self.saved = {nm: getattr(km, nm) for nm in ("_timeline_sessions", "_derive_judging")}
+        self.saved = {nm: getattr(km, nm) for nm in ("_timeline_sessions", "_derive_judging_marks")}
+        km._lanes_memo.clear()                        # a lane the timeline memo holds never reaches the spy below
         for i, sid in enumerate(SIDS):
             s = {"rompUuid": sid, "seq": 0, "placementsV": jd.PLACEMENTS_V, "nodes": {},
                  "placements": {}, "status": {}}
@@ -262,7 +263,7 @@ class SharedViewInBuilds(unittest.TestCase):
     def test_the_store_a_wired_site_works_on_is_the_frozen_shared_view(self):
         seen, raised = [], []
 
-        def spy(sid, caps, goals, t0, out, seg_ends=None):
+        def spy(sid, caps, goals, seg_ends=None):
             seen.append(goals)
             for attempt in (lambda: goals["status"].__setitem__("x", "y"),
                             lambda: goals["nodes"][sid + ":g1"]["log"].append({"kind": "done"}),
@@ -271,8 +272,8 @@ class SharedViewInBuilds(unittest.TestCase):
                     attempt()
                 except jd.FrozenStoreError:
                     raised.append(1)
-            return self.saved["_derive_judging"](sid, caps, goals, t0, out, seg_ends)
-        km._derive_judging = spy
+            return self.saved["_derive_judging_marks"](sid, caps, goals, seg_ends)
+        km._derive_judging_marks = spy
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
             tl = km.build_timeline(NOW, {}, with_bars=True)
@@ -296,7 +297,7 @@ class SharedViewInBuilds(unittest.TestCase):
         self.assertEqual(jd.load_goals(SIDS[1])["nodes"][SIDS[1] + ":g1"]["text"], "Goal 1",
                          "a write on a fallback store reached no file")
         # the board keeps rendering: the next build's loads take load_goals (private, mutable) and succeed
-        km._derive_judging = self.saved["_derive_judging"]
+        km._derive_judging_marks = self.saved["_derive_judging_marks"]
         km.build_timeline(NOW, {}, with_bars=True)
         self.assertEqual(self._delta("fallback"), 2 * len(SIDS) - 1)
 

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -116,7 +116,7 @@ class Collector(unittest.TestCase):
         self.assertEqual(set(snap["goals"]), {"loads", "saves", "writes"}, "read through jd.goal_io_stats")
         # the three identity memos' readers land here (review find, 2026-09-08: they had no consumer)
         self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate", "cleared", "courierSkip", "backref", "captions", "goalArchive", "plannerSkip",
-                                              "bgTops", "liftGate", "intrMarks", "statesOverlay"})
+                                              "bgTops", "liftGate", "intrMarks", "statesOverlay", "lanes"})
         self.assertEqual(set(snap["memos"]["bgTops"]), {"hit", "miss", "resolve", "walk", "walk_neg", "idx_build", "entries"},
                          "the placed-launch memo (_bg_placed_tops): counters plus its occupancy")
         for k, v in snap["memos"]["bgTops"].items():
@@ -135,6 +135,10 @@ class Collector(unittest.TestCase):
         for blk in ("intrMarks", "statesOverlay"):
             for k, v in snap["memos"][blk].items():
                 self.assertIsInstance(v, int, "%s.%s" % (blk, k))
+        self.assertEqual(set(snap["memos"]["lanes"]), {"hit", "miss", "live_tail", "complain_skip", "unshared_skip", "evict", "entries",
+                                                     "segs_hit", "segs_miss", "dead_serve", "dead_miss", "dead_failed_serve"},
+                         "the timeline's per-lane segment memo: one outcome per live lane per bars build, the dead lanes beside")
+        self.assertTrue(all(type(v) is int for v in snap["memos"]["lanes"].values()))
         self.assertEqual(set(snap["memos"]["plannerSkip"]), {"skipped", "planned", "recorded"})
         self.assertEqual(set(snap["memos"]["captions"]), {"served", "parsed"})
         self.assertEqual(set(snap["memos"]["goalArchive"]), {"served", "loaded"})

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -615,6 +615,34 @@ class PusherRecords(unittest.TestCase):
         self.assertEqual(after["push"], before["push"])
         self.assertGreaterEqual(after["jobs"], before["jobs"])
 
+    def test_a_connect_serves_the_build_it_tested_when_the_cache_is_replaced_between_its_reads(self):
+        # _cached_timeline tested the cached payload and returned it as two reads of the shared list while the
+        # pusher thread assigns _built_timeline[:] on a rebuild; a connect on the handler thread whose two reads
+        # straddled that assignment returned the replacement build, not the one its freshness test saw. One read.
+        class Swapped(list):
+            """_built_timeline with the pusher's `_built_timeline[:] = [...]` landing between two reads of the
+            payload slot: the first read answers the build, every later one the replacement."""
+            def __init__(self, entry, later):
+                super().__init__(entry)
+                self.reads, self.later = 0, later
+
+            def __getitem__(self, i):
+                if i == 1:
+                    self.reads += 1
+                    if self.reads > 1:
+                        return self.later
+                return list.__getitem__(self, i)
+        built = {"type": "timeline", "now": 1.0, "turns": {}, "judging": {}, "messages": []}
+        replacement = {"type": "timeline", "now": 2.0, "turns": {}, "judging": {}, "messages": []}
+        real = km._built_timeline
+        km._built_timeline = Swapped(["sig-a", built, 5.0, 4.0], replacement)   # the pusher replaced the build between the two reads
+        self.addCleanup(setattr, km, "_built_timeline", real)
+        km.build_timeline = lambda *a, **k: (_ for _ in ()).throw(AssertionError("a connect never rebuilds"))
+        served = km._VIEW_STATS["tlServe"]
+        self.assertIs(km._cached_timeline(int(time.time()), {}, "sig-b", connect=True), built,
+                      "the connect gets the build its freshness test saw, not the replacement that landed under it")
+        self.assertEqual(km._VIEW_STATS["tlServe"], served + 1)
+
     def test_feed_and_timeline_builds_count_cached_and_rebuilt(self):
         km.build_feed = lambda now, tmux: {"working": [], "items": []}
         km.build_timeline = lambda now, tmux, **kw: {"turns": [], "judging": [], "messages": [], "now": now}

--- a/tests/test_timeline_bars_resilience.py
+++ b/tests/test_timeline_bars_resilience.py
@@ -73,7 +73,9 @@ class RunJudgingFeed(unittest.TestCase):
 
 class FrameNeverSilentlyDies(unittest.TestCase):
     def test_every_bars_stage_degrades_alone_and_loudly(self):
-        src = inspect.getsource(km.build_timeline)
+        # the per-lane seams and marks stages live in _lane_segments (the lane memo's derivation); the parse, the
+        # live merge, the store read and the global stages stay in build_timeline
+        src = inspect.getsource(km.build_timeline) + inspect.getsource(km._lane_segments)
         # the per-lane parse swallow SAYS why a lane has no bars
         self.assertIn('_bars_complain(sid, "parse", e)', src)
         self.assertIn('_bars_complain(sid, "live-merge", e)', src)

--- a/tests/test_timeline_lane_memo.py
+++ b/tests/test_timeline_lane_memo.py
@@ -14,7 +14,10 @@ liveness snapshot is empty.
 
 DerivationSplit, below the dead-lane classes, covers the judging derivation's split from the horizon assembly
 (_derive_judging_marks and _judging_assemble against a private copy of the one-pass form as the oracle); it sits
-in this module because the dead-lane memo's stamped marks are that split's other caller."""
+in this module because the dead-lane memo's stamped marks are that split's other caller. The classes on
+LaneMemoBase cover the LIVE-lane memo, which shares the lane loop and the /perf block with the dead-lane memo: a
+fresh state root per test through jd._rebind_state, one live lane, and private synthetic sids because those
+classes mint goal stores."""
 import ast
 import inspect
 import io
@@ -520,6 +523,783 @@ class DerivationSplit(unittest.TestCase):
         names = {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
         self.assertFalse(names & {"now", "time", "TL_HORIZON", "JUDGE_CAP_LIMIT"}, repr(names))
         self.assertIn("JUDGE_CAP_LIMIT", inspect.getsource(km._judging_assemble), "the cap is read at assembly")
+
+
+# ── the LIVE-lane memo: a live lane's segment part is derived once and served while its inputs stand ──
+def _tmux_row(since):
+    return {"state": "waiting", "since": since, "model": "", "effort": "", "context": None,
+            "compactPct": None, "color": "#336699", "mode": ""}
+
+
+def _zero(stats):
+    for k in list(stats):
+        stats[k] = 0
+
+
+class LaneMemoBase(unittest.TestCase):
+    """A fresh state root per test (jd._rebind_state, so each test's shared store view is its own and its
+    override journal dies with the root), the memos emptied, one LIVE lane with one finished turn. The band
+    carries this build's own artifact marks (_run_judging stubbed to hand them through), read from the frame's
+    compact per-lane judging map (j = judge, kd = kind, x = text)."""
+
+    def setUp(self):
+        self._saved_state, self._saved_proj, self._saved_names = km.jd.STATE, km.jd.PROJECTS, km.NAMES
+        self._td = tempfile.mkdtemp()
+        km.jd._rebind_state(Path(self._td))
+        km.jd.PROJECTS = Path(self._td) / "projects"
+        km.NAMES = km.jd.NAMES
+        km.jd._discover_cache.clear(); km.jd._PARSE_CACHE.clear(); km.jd._CHAIN_MEMO.clear()
+        km._parse_cache.clear(); km._BARS_COMPLAINED.clear()
+        km._dead_lane_memo.clear(); km._delta_entry_memo.clear()
+        km._downtime[:] = []
+        self._saved = {nm: getattr(km, nm) for nm in (
+            "_sdk", "_run_judging", "TL_HORIZON", "JUDGE_CAP_LIMIT", "_LANES_MEMO_MAX", "_lane_segments", "_segs_seam",
+            "_derive_judging_marks", "_judging_assemble", "_captions", "_parse", "_merge_live_atoms", "_bind_message_execs")}
+        self._saved_backend = km.Sessions.backend_for
+        self._saved_file_key = km.jd._file_key
+        km._lanes_memo.clear(); _zero(km._lanes_stats)
+        km._sdk = lambda: None
+        km._run_judging = lambda t0, alive, semantic: [dict(m) for m in semantic]
+        self.now = int(time.time())
+        self.t0 = self.now - 600
+        self.cdir = str(Path(self._td) / "work")
+        self.proj = km.jd._proj_dir(self.cdir)
+        self.proj.mkdir(parents=True, exist_ok=True)
+        km.jd.NAMES.mkdir(parents=True, exist_ok=True)
+        self.recs = [_rec("user", self.t0, "u1", None, "make the retry loop back off"),
+                     _rec("assistant", self.t0 + 20, "a1", "u1", "Added exponential backoff.")]
+        self.add_lane(LIVE_SID, "web", self.recs)
+
+    def tearDown(self):
+        for nm, v in self._saved.items():
+            setattr(km, nm, v)
+        km.Sessions.backend_for = self._saved_backend
+        km.jd._file_key = self._saved_file_key
+        km.jd._SHARED_OFF[0] = False
+        km._lanes_memo.clear(); _zero(km._lanes_stats)
+        km._dead_lane_memo.clear(); km._downtime[:] = []
+        km.jd._rebind_state(self._saved_state)
+        km.jd.PROJECTS = self._saved_proj
+        km.NAMES = self._saved_names
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    # fixtures
+    def tpath(self, sid=LIVE_SID):
+        return self.proj / (sid + ".jsonl")
+
+    def add_lane(self, sid, name, recs):
+        (km.jd.NAMES / sid).write_text("%s\t%s\n" % (name, self.cdir))
+        self.tpath(sid).write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        km.jd._discover_cache.clear()
+
+    def append_records(self, recs, sid=LIVE_SID):
+        with self.tpath(sid).open("a") as f:
+            f.write("".join(json.dumps(r) + "\n" for r in recs))
+
+    def seg_id(self, sid=LIVE_SID):
+        p = str(self.tpath(sid))
+        session = km.em.parse_session(p, rompuuid=sid, candidate_files=[p], now=self.now)
+        return km.em.segments(session["turns"][0])[0]["id"]
+
+    def mint_store(self, sid=LIVE_SID, text="Back off the retries", t=None):
+        """A store with one minted top, published by save_goals: a FrozenStore from load_goals_shared after."""
+        s = km.jd.load_goals(sid)
+        km.jd.apply_plan(s, "s1", t or self.t0, [{"do": "mint", "why": "x", "text": text}], [])
+        km.jd.rollup_status(s, session_closed=False)
+        km.jd.save_goals(sid, s)
+        return s
+
+    def write_archive(self, t, headline, sid=LIVE_SID):
+        km.jd.ARCHDIR.mkdir(parents=True, exist_ok=True)
+        (km.jd.ARCHDIR / (sid + ".json")).write_text(json.dumps({"t": t, "headline": headline}))
+
+    def tmux(self, *sids):
+        return {s: _tmux_row(self.now - 100) for s in sids}
+
+    def build(self, tmux=None, with_bars=True, live_only=False, now=None):
+        return km.build_timeline(self.now if now is None else now, self.tmux(LIVE_SID) if tmux is None else tmux,
+                                 with_bars=with_bars, live_only=live_only)
+
+    def stats(self):
+        return km._lanes_memo_report()
+
+    def outcomes(self):
+        st = self.stats()
+        return {k: st[k] for k in ("hit", "miss", "live_tail", "complain_skip", "unshared_skip")}
+
+    def dead(self):
+        st = self.stats()
+        return {k: st[k] for k in ("dead_serve", "dead_miss", "dead_failed_serve")}
+
+    def lane(self, tl, sid=LIVE_SID):
+        return next(l for l in tl["sessions"] if l["id"] == sid)
+
+    def marks(self, tl, sid=LIVE_SID, judge=None):
+        return [m for m in tl["judging"].get(sid, []) if judge is None or m["j"] == judge]
+
+    def spy_segments(self):
+        calls, real = [], km._lane_segments
+
+        def spy(*a, **k):
+            calls.append(a[0])
+            return real(*a, **k)
+        km._lane_segments = spy
+        return calls
+
+
+class HitsAndEquality(LaneMemoBase):
+    def test_an_unchanged_live_lane_is_served_and_equals_the_uncached_loop(self):
+        km.jd.append_caption(LIVE_SID, self.seg_id(), "segment", self.t0, "Added backoff")
+        self.mint_store()
+        self.write_archive(self.now - 50, "retry loop")
+        seams, real_seams = [], km._segs_seam
+        km._segs_seam = lambda turn, store: (seams.append(1), real_seams(turn, store))[1]
+        tl1 = self.build()
+        self.assertEqual(len(seams), 1, "the first build walks the lane's turns")
+        tl2 = self.build()
+        self.assertEqual(len(seams), 1, "the second build walks nothing: a lookup served the lane")
+        self.assertEqual(self.outcomes(), {"hit": 1, "miss": 1, "live_tail": 0, "complain_skip": 0, "unshared_skip": 0})
+        self.assertIs(tl2["turns"][LIVE_SID], tl1["turns"][LIVE_SID], "the same bars list rides into turns[sid]")
+        self.assertTrue(all(a is b for a, b in zip(tl1["turns"][LIVE_SID], tl2["turns"][LIVE_SID])), "and the same bar dicts")
+        # what the memo served is what the uncached loop returns now, on the same objects
+        session = km._parse(str(self.tpath()), LIVE_SID, self.now)
+        goals = km.jd.load_goals_shared(LIVE_SID)
+        caps = km._captions(LIVE_SID)
+        bars, seg_ends, last_t, compactions, cap_marks, other_marks, nsegs, complained = km._lane_segments(
+            LIVE_SID, session, goals, caps, True, None)
+        self.assertEqual(json.dumps(tl2["turns"][LIVE_SID]), json.dumps(bars))
+        self.assertEqual(set(bars[0]), {"id", "start", "end", "p", "w", "r", "q", "c"}, "the compact wire bar, defaults omitted")
+        self.assertEqual(json.dumps(tl2["sessions"]), json.dumps(tl1["sessions"]), "the badge row, per build, agrees")
+        self.assertEqual(json.dumps(tl2["judging"]), json.dumps(tl1["judging"]))
+        want = []
+        km._derive_judging(LIVE_SID, caps, goals, self.now - km.TL_HORIZON, want, seg_ends)
+        self.assertEqual([(m["j"], m["x"]) for m in self.marks(tl2)], [(m["judge"], m["text"]) for m in want],
+                         "the marks on a hit are the derivation's")
+        self.assertEqual({m["j"] for m in self.marks(tl2)}, {"captioner", "planner", "archiver"})
+        self.assertEqual(self.lane(tl2)["since"], self.now - 100, "a live lane's since is the liveness snapshot's")
+        st = self.stats()
+        self.assertEqual((st["segs_hit"], st["segs_miss"], st["entries"], nsegs), (1, 1, 1, 1))
+
+    def test_a_hit_lane_still_runs_the_parse_the_merge_and_the_captions_read(self):
+        counts = {"parse": 0, "merge": 0, "caps": 0}
+        real_parse, real_merge, real_caps = self._saved["_parse"], self._saved["_merge_live_atoms"], self._saved["_captions"]
+        km._parse = lambda *a, **k: (counts.__setitem__("parse", counts["parse"] + 1), real_parse(*a, **k))[1]
+        km._merge_live_atoms = lambda *a, **k: (counts.__setitem__("merge", counts["merge"] + 1), real_merge(*a, **k))[1]
+        km._captions = lambda *a, **k: (counts.__setitem__("caps", counts["caps"] + 1), real_caps(*a, **k))[1]
+        self.build(); self.build()
+        self.assertEqual(self.outcomes()["hit"], 1)
+        self.assertEqual(counts, {"parse": 2, "merge": 2, "caps": 2},
+                         "the chip reads the merged parse and the captions are the key's input: a hit skips only the loop")
+
+    def test_the_held_bars_survive_the_postal_join_unchanged(self):
+        tl = self.build()
+        before = json.dumps(tl["turns"][LIVE_SID])
+        km._bind_message_execs([{"id": "m1", "toId": LIVE_SID, "from": "api", "sent": self.t0 - 5, "pending": True}],
+                               tl["turns"], {})
+        self.assertEqual(json.dumps(tl["turns"][LIVE_SID]), before, "_bind_message_execs writes to the messages only")
+        tl2 = self.build()
+        self.assertIs(tl2["turns"][LIVE_SID], tl["turns"][LIVE_SID])
+        self.assertEqual(json.dumps(tl2["turns"][LIVE_SID]), before)
+
+    def test_the_badge_row_is_per_build_on_a_hit(self):
+        tl1 = self.build()
+        self.assertFalse(self.lane(tl1)["postalServiceOff"])
+        km._set_session_flag(LIVE_SID, "postalServiceOff", True)
+        tl2 = self.build()
+        self.assertEqual(self.outcomes()["hit"], 1, "a flag is a badge-row input, not a segment input")
+        self.assertTrue(self.lane(tl2)["postalServiceOff"], "and the row carries it at once")
+
+    def test_a_hit_hands_the_binder_the_whole_prompts(self):
+        # T278b: a bar carries the first line of its prompt, capped, and the binder's sender heuristic reads the WHOLE
+        # text through the builder's prompts map, so a delivery that names its sender on a later line binds. The memo
+        # serves the map beside the bars; without it every served build would bind on the first line alone.
+        self.add_lane(LIVE_SID, "web", [_rec("user", self.t0, "u1", None, "make the retry loop back off\nfrom api: the cap is two minutes"),
+                                         _rec("assistant", self.t0 + 20, "a1", "u1", "Added exponential backoff.")])
+        handed, real = [], self._saved["_bind_message_execs"]
+        km._bind_message_execs = lambda messages, turns, prompts=None: (handed.append(prompts), real(messages, turns, prompts))[1]
+        self.build()
+        tl2 = self.build()
+        self.assertEqual(self.outcomes()["hit"], 1)
+        bar = tl2["turns"][LIVE_SID][0]
+        self.assertEqual(bar["q"], "make the retry loop back off", "the wire carries the first line")
+        self.assertEqual(handed[1].get(bar["id"]), "make the retry loop back off\nfrom api: the cap is two minutes",
+                         "the served build hands the binder the whole prompt")
+        self.assertEqual(handed[1], handed[0])
+        msg = {"id": "m1", "toId": LIVE_SID, "from": "api", "fromOrig": "api", "sent": self.t0 - 5, "pending": True}
+        real([msg], tl2["turns"], handed[1])
+        self.assertEqual((msg["exec"], msg["pending"]), (bar["start"], False), "the sender named on the second line binds")
+        bare = {"id": "m2", "toId": LIVE_SID, "from": "api", "fromOrig": "api", "sent": self.t0 - 5, "pending": True}
+        real([bare], tl2["turns"], {})
+        self.assertTrue(bare["pending"], "the first line alone does not name the sender")
+
+    def test_the_judging_band_reader_leaves_the_held_marks_unchanged(self):
+        # the held marks ride into `semantic`, which _run_judging reads for its gloss text and never writes to: the
+        # real reader runs over a hit here (the usage log under this root is empty, so the band it builds is bare)
+        self.mint_store()
+        km.jd.append_caption(LIVE_SID, self.seg_id(), "segment", self.t0, "Added backoff")
+        self.build()
+        before = json.dumps(km._lanes_memo[LIVE_SID][4][4:6])
+        self.assertIn("Added backoff", before)
+        km._run_judging = self._saved["_run_judging"]
+        tl = self.build()
+        self.assertEqual(self.outcomes()["hit"], 1)
+        self.assertEqual(json.dumps(km._lanes_memo[LIVE_SID][4][4:6]), before, "the reader wrote nothing into the held marks")
+        self.assertEqual(self.marks(tl), [], "the band is the usage log's, empty under this root")
+
+    def test_two_threads_deriving_one_lane_leave_one_exact_entry(self):
+        # the derivation runs unlocked; the lock covers get, put, evict and the counters, so two builds that miss
+        # together both store an exact entry and the last wins. The parse cache is warmed first so both threads
+        # derive from ONE parse object: two concurrent misses in _parse each store their own, and the entry that
+        # survives can hold the object _parse_cache did not, which the next build drops and derives once more. With
+        # one parse object the next build's serve is this memo's property, not the parse cache's race.
+        km._parse(str(self.tpath()), LIVE_SID, self.now)
+        gate = threading.Barrier(2)
+        frames, errors = [], []
+
+        def run():
+            try:
+                gate.wait(5)
+                frames.append(self.build())
+            except Exception as e:      # a raise in a thread would otherwise be silent
+                errors.append(e)
+        ts = [threading.Thread(target=run) for _ in range(2)]
+        for t in ts:
+            t.start()
+        for t in ts:
+            t.join(30)
+        self.assertEqual(errors, [])
+        self.assertEqual(len(frames), 2)
+        self.assertEqual(self.stats()["entries"], 1)
+        self.assertEqual(json.dumps(frames[0]["turns"]), json.dumps(frames[1]["turns"]))
+        st = self.outcomes()
+        self.assertEqual(st["hit"] + st["miss"], 2, "both missed, or the second found the first's entry: either is exact")
+        tl = self.build()
+        self.assertEqual(self.outcomes()["hit"], st["hit"] + 1, "the next build is served from the surviving entry")
+        self.assertEqual(json.dumps(tl["turns"]), json.dumps(frames[0]["turns"]))
+
+
+class EveryInputBusts(LaneMemoBase):
+    """One test per input in the memo's key: change only that input, observe a miss and the new content."""
+
+    def test_a_transcript_append_moves_the_parse_object(self):
+        tl1 = self.build()
+        self.append_records([_rec("user", self.t0 + 100, "u2", "a1", "and cap the delay"),
+                             _rec("assistant", self.t0 + 120, "a2", "u2", "Capped at two minutes.")])
+        tl2 = self.build()
+        self.assertEqual(self.outcomes()["miss"], 2)
+        self.assertEqual(len(tl1["turns"][LIVE_SID]), 1)
+        self.assertEqual(len(tl2["turns"][LIVE_SID]), 2, "the appended turn is a second bar")
+        self.assertEqual(self.stats()["entries"], 1, "the new entry replaced the old")
+
+    def test_a_states_write_moves_the_parse_object(self):
+        # the states log is read into the parse (idle atoms) and sits in _parse's key
+        self.build()
+        (km.jd.STATE / "states").mkdir(exist_ok=True)
+        (km.jd.STATE / "states" / (LIVE_SID + ".jsonl")).write_text(json.dumps({"t": self.t0 + 30, "state": "waiting"}) + "\n")
+        self.build()
+        self.assertEqual(self.outcomes()["miss"], 2)
+
+    def test_a_store_publish_is_a_new_frozen_store(self):
+        self.mint_store(text="First goal")
+        tl1 = self.build()
+        self.assertEqual([m["x"] for m in self.marks(tl1, judge="planner")], ["First goal"])
+        s = km.jd.load_goals(LIVE_SID)
+        km.jd.apply_plan(s, "s2", self.t0 + 100, [{"do": "mint", "why": "x", "text": "Second goal"}], [])
+        km.jd.rollup_status(s, session_closed=False)
+        km.jd.save_goals(LIVE_SID, s)
+        tl2 = self.build()
+        self.assertEqual(self.outcomes()["miss"], 2)
+        self.assertEqual(sorted(m["x"] for m in self.marks(tl2, judge="planner")), ["First goal", "Second goal"])
+
+    def test_a_journal_append_is_a_new_store_version(self):
+        s = self.mint_store()
+        nid = next(iter(s["nodes"]))
+        self.build()
+        km.jd.append_block(LIVE_SID, nid, "nudge", "no answer to the status ask", self.now)
+        self.build()
+        self.assertEqual(self.outcomes(), {"hit": 0, "miss": 2, "live_tail": 0, "complain_skip": 0, "unshared_skip": 0})
+
+    def test_a_captions_append_moves_the_captions_key(self):
+        seg = self.seg_id()
+        km.jd.append_caption(LIVE_SID, seg, "segment", self.t0, "first summary")
+        tl1 = self.build()
+        self.assertEqual(tl1["turns"][LIVE_SID][0]["c"], "first summary")
+        km.jd.append_caption(LIVE_SID, seg, "segment", self.t0, "second summary")
+        tl2 = self.build()
+        self.assertEqual(self.outcomes()["miss"], 2)
+        self.assertEqual(tl2["turns"][LIVE_SID][0]["c"], "second summary")
+        self.assertEqual([m["x"] for m in self.marks(tl2, judge="captioner")], ["second summary"])
+
+    def test_a_caption_landing_between_the_stat_and_the_read_misses_on_the_next_build(self):
+        # The captions key is the file's stat taken BEFORE _captions reads it. A row that lands between the two is
+        # read by this build and held under the old key, so the next build's stat misses and shows it; a stat taken
+        # after the read would hold the old rows under the new key and serve the stale caption until another input moved.
+        seg = self.seg_id()
+        km.jd.append_caption(LIVE_SID, seg, "segment", self.t0, "first summary")
+        real, landed = self._saved["_captions"], []
+
+        def late_row(fsid):
+            caps = real(fsid)
+            if not landed:
+                landed.append(1)
+                km.jd.append_caption(fsid, seg, "segment", self.t0, "landed after the read")
+            return caps
+        km._captions = late_row
+        tl1 = self.build()
+        self.assertEqual(tl1["turns"][LIVE_SID][0]["c"], "first summary", "this build read the file before the row landed")
+        tl2 = self.build()
+        self.assertEqual(self.outcomes()["miss"], 2, "the file's stat moved: the lane misses")
+        self.assertEqual(tl2["turns"][LIVE_SID][0]["c"], "landed after the read")
+        self.assertEqual([m["x"] for m in self.marks(tl2, judge="captioner")], ["landed after the read"])
+        self.build()
+        self.assertEqual(self.outcomes()["hit"], 1, "and holds again once the key and the rows agree")
+
+    def test_an_archive_rewrite_moves_the_archive_key(self):
+        self.write_archive(self.now - 50, "retry loop")
+        tl1 = self.build()
+        self.assertEqual([m["x"] for m in self.marks(tl1, judge="archiver")], ["retry loop"])
+        self.write_archive(self.now - 40, "retry loop with a two minute cap")
+        tl2 = self.build()
+        self.assertEqual(self.outcomes()["miss"], 2)
+        self.assertEqual([(m["t"], m["x"]) for m in self.marks(tl2, judge="archiver")],
+                         [(self.now - 40, "retry loop with a two minute cap")])
+
+    def test_an_archive_appearing_after_a_build_misses(self):
+        tl1 = self.build()
+        self.assertEqual(self.marks(tl1, judge="archiver"), [])
+        self.write_archive(self.now - 50, "retry loop")
+        tl2 = self.build()
+        self.assertEqual(self.outcomes()["miss"], 2)
+        self.assertEqual(len(self.marks(tl2, judge="archiver")), 1)
+
+    def test_a_host_suspension_moves_the_downtime_tuple(self):
+        self.build()
+        km._downtime.append((self.now - 20000, self.now - 19000))        # a sleep outside every segment: the same bars,
+        self.build()                                                     # a different key
+        self.assertEqual(self.outcomes()["miss"], 2)
+        km._downtime[:] = [(self.now - 20000, self.now - 19000)]         # the same content rebound: the same key
+        self.build()
+        self.assertEqual(self.outcomes()["hit"], 1)
+        km._downtime[:] = [(self.now - 20000, self.now - 18000)]         # a slice-assign moves it too
+        self.build()
+        self.assertEqual(self.outcomes()["miss"], 3)
+        self.assertEqual(self.stats()["entries"], 1)
+
+    def test_a_suspension_inside_the_segment_splits_the_bar_on_the_next_build(self):
+        self.build()
+        km._downtime[:] = [(self.t0 + 5, self.t0 + 10)]
+        tl = self.build()
+        self.assertEqual(self.outcomes()["miss"], 2)
+        self.assertEqual(len(tl["turns"][LIVE_SID]), 2, "the bar is cut at the nap on the very next build")
+        self.assertTrue(tl["turns"][LIVE_SID][1].get("t"), "the second piece is a continuation: no new prompt dot")
+
+    def test_liveness_is_in_the_key_and_a_dead_lane_leaves_this_memo(self):
+        self.build(tmux=self.tmux(LIVE_SID))
+        tl = self.build(tmux={})                                         # the process ended: a dead lane in the window
+        self.assertFalse(self.lane(tl)["live"])
+        # a dead lane is the dead-lane memo's: derived once by _lane_segments directly (dead_miss) and handed to it,
+        # whose populate drops the entry this memo held from the lane's live days (it keys on the parse the
+        # dead-lane memo lets go of)
+        self.assertEqual(self.outcomes()["miss"], 1, "one miss, the live build's")
+        self.assertEqual(self.dead(), {"dead_serve": 0, "dead_miss": 1, "dead_failed_serve": 0})
+        self.assertIn(LIVE_SID, km._dead_lane_memo, "the dead build handed the lane to the dead-lane memo")
+        self.assertNotIn(LIVE_SID, km._lanes_memo, "and this memo dropped the entry from the lane's live days")
+        self.assertFalse(any(p.endswith("/" + LIVE_SID + ".jsonl") for p in km._parse_cache), "so the parse can go")
+        served = km._VIEW_STATS.get("laneServe", 0)
+        self.build(tmux={})
+        self.assertEqual(km._VIEW_STATS.get("laneServe", 0), served + 1, "a dead-lane serve still counts under views")
+        self.assertEqual(self.dead()["dead_serve"], 1, "and on this block beside it")
+        self.assertEqual(self.outcomes(), {"hit": 0, "miss": 1, "live_tail": 0, "complain_skip": 0, "unshared_skip": 0})
+
+    def test_an_open_turn_reads_open_only_on_a_live_lane(self):
+        self.append_records([_rec("user", self.t0 + 100, "u2", "a1", "keep going"),
+                             {"type": "assistant", "timestamp": _iso(self.t0 + 110), "uuid": "a2", "parentUuid": "u2",
+                              "message": {"role": "assistant", "stop_reason": None,
+                                          "content": [{"type": "tool_use", "id": "t1", "name": "Bash", "input": {}}]}}])
+        tl_live = self.build(tmux=self.tmux(LIVE_SID))
+        tl_dead = self.build(tmux={})
+        self.assertEqual(self.outcomes()["miss"], 1, "the live build's; the dead build is derived outside this memo")
+        self.assertEqual(self.dead()["dead_miss"], 1)
+        self.assertTrue(tl_live["turns"][LIVE_SID][-1].get("u"), "the live turn's last piece is open")
+        self.assertNotIn("u", tl_dead["turns"][LIVE_SID][-1], "a dead lane never draws an open bar")
+
+    def fork_fixture(self):
+        """A parent lane and a child forked from it at fork_t: the child's transcript carries the parent's history
+        verbatim, and the backend reports the fork. Returns fork_t."""
+        fork_t = self.now - 300
+        shared = [_rec("user", self.now - 600, "u1", None, "how should the retry loop back off?"),
+                  _rec("assistant", self.now - 580, "a1", "u1", "Use exponential backoff."),
+                  # a compaction inside the copied history, and a turn whose work ends AT the fork time: the
+                  # parent's while its lane is in the build (the clip is `<=`), the child's own once it leaves
+                  {"type": "system", "subtype": "compact_boundary", "uuid": "cb1", "parentUuid": None,
+                   "logicalParentUuid": "a1", "timestamp": _iso(self.now - 500), "compactMetadata": {"trigger": "auto"}},
+                  _rec("user", fork_t - 20, "u2", "cb1", "and the cap?"),
+                  _rec("assistant", fork_t, "a2", "u2", "Two minutes.")]
+        own = [_rec("user", fork_t + 60, "u9", "a2", "and inside the fork?"),
+               _rec("assistant", fork_t + 80, "a9", "u9", "Cap the delay at two minutes.")]
+        self.add_lane(LIVE_PARENT, "parent", shared)
+        self.add_lane(LIVE_CHILD, "child", shared + own)
+        kids = {LIVE_PARENT: [{"sid": LIVE_CHILD, "name": "child", "cut": "a2", "t": fork_t}]}
+
+        class FakeBe:
+            def fork_children(self):
+                return kids
+
+            def owns(self, sid):
+                return False
+
+            def pending_cut(self, sid):
+                return ""
+
+            def __getattr__(self, name):
+                return lambda *a, **k: None
+        km._sdk = lambda: FakeBe()
+        return fork_t
+
+    def test_a_parent_lane_leaving_the_build_moves_a_live_childs_branch_clip(self):
+        fork_t = self.fork_fixture()
+        tl1 = self.build(tmux=self.tmux(LIVE_SID, LIVE_PARENT, LIVE_CHILD))
+        self.assertIn(fork_t, [b["end"] for b in tl1["turns"][LIVE_PARENT]], "the parent draws the turn that ends at the fork time")
+        self.assertEqual([c["t"] for c in self.lane(tl1, LIVE_PARENT)["compactions"]], [self.now - 500], "and its compaction marker")
+        self.assertTrue(all(b["start"] > fork_t for b in tl1["turns"][LIVE_CHILD]),
+                        "clipped while the parent is a lane, the turn ending AT the fork time included")
+        self.assertEqual(self.lane(tl1, LIVE_CHILD)["compactions"], [], "the copied boundary is the parent's marker")
+        self.assertEqual(self.outcomes()["miss"], 3)
+        self.build(tmux=self.tmux(LIVE_SID, LIVE_PARENT, LIVE_CHILD))
+        self.assertEqual(self.outcomes()["hit"], 3)
+        (km.jd.NAMES / LIVE_PARENT).unlink()                             # the parent leaves the build: no name, no row
+        km.jd._discover_cache.clear()
+        tl3 = self.build(tmux=self.tmux(LIVE_SID, LIVE_CHILD))
+        self.assertEqual(self.outcomes()["miss"], 4, "the child's clip moved: one more miss")
+        self.assertEqual(self.outcomes()["hit"], 4, "the other lane still hits")
+        self.assertTrue(any(b["start"] < fork_t for b in tl3["turns"][LIVE_CHILD]), "the whole story, the parent gone")
+        self.assertEqual([c["t"] for c in self.lane(tl3, LIVE_CHILD)["compactions"]], [self.now - 500],
+                         "the copied boundary is the child's marker now")
+        self.assertEqual(self.stats()["evict"], 1, "the parent's entry left with its lane")
+        self.assertEqual(self.stats()["entries"], 2)
+
+
+class NotHeld(LaneMemoBase):
+    def test_a_live_tail_is_derived_and_not_held(self):
+        fresh = {"type": "assistant", "uuid": "live-1", "t": self.t0 + 40, "session_id": LIVE_SID, "fsid": None,
+                 "parentUuid": "a1", "message": {"role": "assistant", "stop_reason": None,
+                                                 "content": [{"type": "text", "text": "Streaming a reply."}]}}
+
+        class FakeBE:
+            def live_atoms(self, sid):
+                return [dict(fresh)]
+
+            def prune_live(self, *a, **k):
+                pass
+        km.Sessions.backend_for = lambda sid: FakeBE()
+        tl1 = self.build()
+        tl2 = self.build()
+        self.assertEqual(self.outcomes(), {"hit": 0, "miss": 0, "live_tail": 2, "complain_skip": 0, "unshared_skip": 0})
+        self.assertEqual(self.stats()["entries"], 0, "a merged tail is a new object every build: nothing to hold")
+        self.assertEqual(tl1["turns"][LIVE_SID][0]["end"], self.t0 + 40, "the live atom extends the bar")
+        self.assertIsNot(tl2["turns"][LIVE_SID], tl1["turns"][LIVE_SID])
+
+    def test_a_failed_parse_is_derived_says_so_once_and_is_not_held(self):
+        km._parse = lambda path, sid, now: (_ for _ in ()).throw(OSError("unreadable"))
+        err = io.StringIO()
+        with redirect_stderr(err):
+            tl = self.build(); self.build()
+        self.assertEqual(self.outcomes()["complain_skip"], 2)
+        self.assertEqual(self.stats()["entries"], 0)
+        self.assertEqual(tl["turns"][LIVE_SID], [])
+        self.assertEqual(err.getvalue().count("parse failed"), 1)
+
+    def test_a_private_store_with_content_is_not_held(self):
+        self.mint_store()
+        km.jd._SHARED_OFF[0] = True                                      # the shared cache is off: load_goals' private store
+        try:
+            tl = self.build(); self.build()
+            self.assertEqual(self.outcomes(), {"hit": 0, "miss": 0, "live_tail": 0, "complain_skip": 0, "unshared_skip": 2})
+            self.assertEqual(self.stats()["entries"], 0)
+            self.assertEqual(len(self.marks(tl, judge="planner")), 1, "derived all the same")
+        finally:
+            km.jd._SHARED_OFF[0] = False
+
+    def test_a_lane_without_a_store_hits_under_the_empty_rule(self):
+        self.assertFalse((km.jd.GOALDIR / (LIVE_SID + ".json")).exists())
+        self.build(); self.build()
+        self.assertEqual(self.outcomes()["hit"], 1, "no seams, no nodes: the store's identity does not matter")
+        self.mint_store()
+        self.build()
+        self.assertEqual(self.outcomes()["miss"], 2, "a published store is a new input")
+
+    def test_a_lane_without_captions_hits_under_the_empty_rule(self):
+        self.assertFalse((km.jd.CAPDIR / (LIVE_SID + ".jsonl")).exists())
+        self.build(); self.build()
+        self.assertEqual(self.outcomes()["hit"], 1)
+        self.assertEqual(self.stats()["entries"], 1)
+
+    def test_a_complaining_seams_stage_is_not_held(self):
+        km._segs_seam = lambda turn, store: (_ for _ in ()).throw(ValueError("malformed seam"))
+        err = io.StringIO()
+        with redirect_stderr(err):
+            tl = self.build(); self.build()
+        self.assertEqual(self.outcomes(), {"hit": 0, "miss": 0, "live_tail": 0, "complain_skip": 2, "unshared_skip": 0})
+        self.assertEqual(self.stats()["entries"], 0)
+        self.assertEqual(len(tl["turns"][LIVE_SID]), 1, "the seams fell back to the plain segments; the bar still draws")
+        self.assertIn("seams failed", err.getvalue())
+
+    def test_a_complaining_marks_stage_is_not_held(self):
+        km._derive_judging_marks = lambda *a, **k: (_ for _ in ()).throw(KeyError("t"))
+        err = io.StringIO()
+        with redirect_stderr(err):
+            tl = self.build(); self.build()
+        self.assertEqual(self.outcomes()["complain_skip"], 2)
+        self.assertEqual(self.stats()["entries"], 0)
+        self.assertEqual(len(tl["turns"][LIVE_SID]), 1)
+        self.assertEqual(self.marks(tl), [], "this lane lost its marks; the frame shipped")
+        self.assertIn("judging-marks failed", err.getvalue())
+
+    def test_a_caption_row_with_a_string_time_costs_the_marks_not_the_frame(self):
+        # the horizon comparisons run at assembly, outside the lane's guard; a time they cannot compare fails the
+        # marks stage at derivation (not held, the lane says so) instead of raising out of build_timeline every build
+        seg = self.seg_id()
+        km.jd.CAPDIR.mkdir(parents=True, exist_ok=True)
+        (km.jd.CAPDIR / (LIVE_SID + ".jsonl")).write_text(
+            json.dumps({"id": seg, "grain": "segment", "t": "not a number", "caption": "typed time"}) + "\n")
+        err = io.StringIO()
+        with redirect_stderr(err):
+            tl1 = self.build()
+            tl2 = self.build()
+        for tl in (tl1, tl2):
+            self.assertEqual(len(tl["turns"][LIVE_SID]), 1, "the lane is drawn")
+            self.assertEqual(tl["turns"][LIVE_SID][0]["c"], "typed time", "the caption itself still serves the bar")
+            self.assertEqual(self.marks(tl), [], "the lane is mark-less")
+        self.assertEqual(self.outcomes()["complain_skip"], 2, "not held: the miss and the following build both derive")
+        self.assertEqual(self.stats()["entries"], 0)
+        self.assertIn("judging-marks failed", err.getvalue())
+
+    def test_an_archive_with_a_string_time_costs_the_marks_not_the_frame(self):
+        km.jd.ARCHDIR.mkdir(parents=True, exist_ok=True)
+        (km.jd.ARCHDIR / (LIVE_SID + ".json")).write_text(json.dumps({"t": "soon", "headline": "h"}))
+        err = io.StringIO()
+        with redirect_stderr(err):
+            tl1 = self.build()
+            tl2 = self.build()
+        for tl in (tl1, tl2):
+            self.assertEqual(len(tl["turns"][LIVE_SID]), 1)
+            self.assertEqual(self.marks(tl), [])
+        self.assertEqual(self.outcomes()["complain_skip"], 2)
+        self.assertIn("judging-marks failed", err.getvalue())
+
+    def test_the_assembly_is_guarded_per_lane_at_its_call_site(self):
+        km._judging_assemble = lambda *a, **k: (_ for _ in ()).throw(TypeError("unorderable"))
+        err = io.StringIO()
+        with redirect_stderr(err):
+            tl = self.build()
+        self.assertEqual(len(tl["turns"][LIVE_SID]), 1, "the frame ships with the lane's bars")
+        self.assertEqual(self.marks(tl), [])
+        self.assertIn("judging-marks failed", err.getvalue())
+
+    def test_captions_read_with_no_file_to_stat_are_derived_and_not_held(self):
+        # the captions key is the file's stat taken before the read; rows read when that stat found no file (the
+        # file appeared between the two) have no key this build can hold them under, so the lane is derived and not
+        # held, and the next build, whose stat sees the file, holds it
+        seg, real, landed = self.seg_id(), self._saved["_captions"], []
+
+        def appears_before_the_read(fsid):
+            if not landed:
+                landed.append(1)
+                km.jd.append_caption(fsid, seg, "segment", self.t0, "landed between the stat and the read")
+            return real(fsid)
+        km._captions = appears_before_the_read
+        tl1 = self.build()
+        self.assertEqual(tl1["turns"][LIVE_SID][0]["c"], "landed between the stat and the read", "this build read the row")
+        self.assertEqual((self.outcomes()["miss"], self.stats()["entries"]), (1, 0), "and had no key to hold it under")
+        self.build()
+        self.assertEqual((self.outcomes()["miss"], self.stats()["entries"]), (2, 1), "the next build's stat sees the file: held")
+        self.build()
+        self.assertEqual(self.outcomes()["hit"], 1)
+
+    def test_a_failed_archive_stat_stores_nothing(self):
+        real = self._saved_file_key
+        arch = str(km.jd.STATE / "archive" / (LIVE_SID + ".json"))
+        km.jd._file_key = lambda p: object() if p == arch else real(p)
+        self.build(); self.build()
+        self.assertEqual(self.outcomes()["miss"], 2, "a sentinel matches nothing")
+        self.assertEqual(self.stats()["entries"], 0, "and nothing is stored under it")
+
+    def test_the_skeleton_build_bypasses_the_memo(self):
+        self.build(with_bars=False)
+        self.assertEqual(self.outcomes(), {"hit": 0, "miss": 0, "live_tail": 0, "complain_skip": 0, "unshared_skip": 0})
+        self.assertEqual(self.stats()["entries"], 0)
+        self.build(with_bars=True)
+        self.assertEqual(self.outcomes()["miss"], 1)
+        self.build(with_bars=False)
+        self.assertEqual(self.outcomes(), {"hit": 0, "miss": 1, "live_tail": 0, "complain_skip": 0, "unshared_skip": 0})
+        self.assertEqual(self.stats()["entries"], 1, "a skeleton neither reads nor evicts")
+
+
+class ClockAtAssembly(LaneMemoBase):
+    def test_a_caption_row_without_a_time_is_dropped_on_a_hit_as_on_a_miss(self):
+        seg = self.seg_id()
+        km.jd.CAPDIR.mkdir(parents=True, exist_ok=True)
+        (km.jd.CAPDIR / (LIVE_SID + ".jsonl")).write_text(
+            json.dumps({"id": seg + "#p", "grain": "prompt", "caption": "no time on this row"}) + "\n"
+            + json.dumps({"id": seg, "grain": "segment", "t": self.t0, "caption": "timed"}) + "\n")
+        tl1 = self.build()
+        tl2 = self.build()
+        self.assertEqual(self.outcomes()["hit"], 1)
+        for tl in (tl1, tl2):
+            self.assertEqual([m["x"] for m in self.marks(tl, judge="captioner")], ["timed"])
+            self.assertEqual(tl["turns"][LIVE_SID][0]["m"], "no time on this row", "the caption itself still serves the dot")
+
+    def test_the_horizon_applies_per_build_on_a_hit(self):
+        km.jd.append_caption(LIVE_SID, self.seg_id(), "segment", self.now - 3000, "an older caption")
+        tl1 = self.build()
+        self.assertEqual(len(self.marks(tl1, judge="captioner")), 1)
+        km.TL_HORIZON = 1000                                             # the horizon moves past the mark
+        tl2 = self.build()
+        self.assertEqual(self.outcomes()["hit"], 1, "no re-derivation: the horizon is applied at assembly")
+        self.assertEqual(self.marks(tl2, judge="captioner"), [])
+
+    def test_the_caption_cap_applies_per_build_on_a_hit(self):
+        seg = self.seg_id()
+        for i in range(3):
+            km.jd.append_caption(LIVE_SID, seg + ("" if i == 0 else "#p%d" % i), "segment", self.t0 + i, "caption %d" % i)
+        tl1 = self.build()
+        self.assertEqual(len(self.marks(tl1, judge="captioner")), 3)
+        km.JUDGE_CAP_LIMIT = 1
+        tl2 = self.build()
+        self.assertEqual(self.outcomes()["hit"], 1)
+        self.assertEqual([m["x"] for m in self.marks(tl2, judge="captioner")], ["caption 2"], "the newest survives the cap")
+
+    def test_the_segment_derivation_reads_no_clock(self):
+        class NoClock:
+            def time(self):
+                raise AssertionError("the derivation read the clock")
+
+            def __getattr__(self, name):
+                return getattr(time, name)
+        self.mint_store()
+        km.jd.append_caption(LIVE_SID, self.seg_id(), "segment", self.t0, "Added backoff")
+        session = km._parse(str(self.tpath()), LIVE_SID, self.now)
+        goals, caps = km.jd.load_goals_shared(LIVE_SID), km._captions(LIVE_SID)
+        real = km.time
+        km.time = NoClock()
+        try:
+            value = km._lane_segments(LIVE_SID, session, goals, caps, True, None)
+        finally:
+            km.time = real
+        self.assertEqual((len(value[0]), value[6], value[7]), (1, 1, False))
+        self.assertTrue(value[4] and value[5], "the marks came out unfiltered")
+        tree = ast.parse(inspect.getsource(km._lane_segments))
+        names = {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
+        self.assertFalse(names & {"now", "time", "TL_HORIZON", "JUDGE_CAP_LIMIT"}, repr(names))
+
+
+class Eviction(LaneMemoBase):
+    def test_entries_leave_with_their_lanes_and_a_live_only_build_evicts_nothing(self):
+        self.add_lane(LIVE_SID2, "api", self.recs)
+        self.build(tmux=self.tmux(LIVE_SID, LIVE_SID2))
+        self.assertEqual(self.stats()["entries"], 2)
+        self.build(tmux=self.tmux(LIVE_SID), live_only=True)            # LIVE_SID2 is not in a live-only build
+        self.assertEqual(self.stats()["entries"], 2, "a live-only build reads a subset of the lanes and must not evict")
+        self.assertEqual(self.stats()["evict"], 0)
+        (km.jd.NAMES / LIVE_SID2).unlink()
+        km.jd._discover_cache.clear()
+        self.build(tmux=self.tmux(LIVE_SID))
+        self.assertEqual(self.stats()["entries"], 1)
+        self.assertEqual(self.stats()["evict"], 1)
+        self.assertEqual(set(km._lanes_memo), {LIVE_SID})
+
+    def test_the_memo_is_bounded_least_recently_served_first(self):
+        self.add_lane(LIVE_SID2, "api", self.recs)
+        km._LANES_MEMO_MAX = 2
+        self.build(tmux=self.tmux(LIVE_SID, LIVE_SID2))                 # both held
+        self.assertEqual(set(km._lanes_memo), {LIVE_SID, LIVE_SID2})
+        first = next(iter(km._lanes_memo))                               # the FIRST inserted, whichever lane the build drew first
+        self.build(tmux=self.tmux(first), live_only=True)                # served: the most recently served, though inserted first
+        self.assertEqual(self.outcomes()["hit"], 1)
+        self.add_lane(LIVE_SID3, "tests", self.recs)
+        self.build(tmux=self.tmux(LIVE_SID3), live_only=True)
+        self.assertEqual(set(km._lanes_memo), {first, LIVE_SID3},
+                         "the least recently SERVED went, not the first inserted; the served lane stayed")
+        self.assertEqual(self.stats()["evict"], 1)
+        self.assertEqual(self.stats()["entries"], 2)
+
+    def test_an_entry_whose_parse_is_no_longer_the_builds_is_dropped_when_seen(self):
+        self.build()
+        self.assertEqual(self.stats()["entries"], 1)
+        self.append_records([_rec("user", self.t0 + 100, "u2", "a1", "and cap the delay")])   # a new parse object
+        km._parse = lambda path, sid, now: (_ for _ in ()).throw(OSError("unreadable"))   # and the parse fails
+        with redirect_stderr(io.StringIO()):
+            self.build()
+        self.assertEqual(self.stats()["entries"], 0, "the old entry held a parse the build no longer has")
+
+
+class DeadLanesOnTheSameBlock(LaneMemoBase):
+    """A dead lane bypasses the live-lane memo: derived by _lane_segments directly on a miss and cached in the
+    dead-lane memo; its outcomes ride the same /perf block so one block carries every lane."""
+
+    def dead_build(self):
+        return self.build(tmux={})
+
+    def test_a_dead_miss_leaves_this_memo_and_the_parse_cache_empty_and_is_not_a_miss_here(self):
+        calls = self.spy_segments()
+        tl = self.dead_build()
+        self.assertEqual(calls, [LIVE_SID], "derived directly")
+        self.assertFalse(self.lane(tl)["live"])
+        self.assertEqual(self.outcomes(), {"hit": 0, "miss": 0, "live_tail": 0, "complain_skip": 0, "unshared_skip": 0})
+        self.assertEqual(self.dead(), {"dead_serve": 0, "dead_miss": 1, "dead_failed_serve": 0})
+        self.assertNotIn(LIVE_SID, km._lanes_memo)
+        self.assertIn(LIVE_SID, km._dead_lane_memo)
+        self.assertFalse(km._dead_lane_memo[LIVE_SID][1]["failed"])
+        self.assertFalse(any(p.endswith("/" + LIVE_SID + ".jsonl") for p in km._parse_cache))
+        self.dead_build()
+        self.assertEqual(calls, [LIVE_SID], "served from the dead-lane memo")
+        self.assertEqual(self.dead()["dead_serve"], 1)
+
+    def test_a_failed_dead_parse_is_served_as_failed_until_the_stat_moves(self):
+        parses, failing, real = [], [True], self._saved["_parse"]
+
+        def parse(path, sid, now):
+            parses.append(path)
+            if failing[0]:
+                raise OSError("unreadable")
+            return real(path, sid, now)
+        km._parse = parse
+        with redirect_stderr(io.StringIO()):
+            tl1 = self.dead_build()
+            tl2 = self.dead_build()
+        self.assertEqual(len(parses), 1, "parsed once: the failed parse is cached as the empty lane")
+        self.assertEqual((tl1["turns"][LIVE_SID], tl2["turns"][LIVE_SID]), ([], []))
+        self.assertTrue(km._dead_lane_memo[LIVE_SID][1]["failed"])
+        self.assertEqual(self.dead(), {"dead_serve": 0, "dead_miss": 1, "dead_failed_serve": 1})
+        failing[0] = False
+        move_ctime(self.tpath())
+        tl3 = self.dead_build()
+        self.assertEqual(len(parses), 2, "the transcript's stat moved: parsed again")
+        self.assertEqual(len(tl3["turns"][LIVE_SID]), 1)
+        self.dead_build()
+        self.assertEqual(self.dead(), {"dead_serve": 1, "dead_miss": 2, "dead_failed_serve": 1})
+        self.assertEqual(self.outcomes()["complain_skip"], 0, "a dead lane's failure is not this memo's outcome")
+
+    def test_a_complaining_dead_lane_is_derived_every_build_and_not_cached(self):
+        km._segs_seam = lambda turn, store: (_ for _ in ()).throw(ValueError("malformed seam"))
+        with redirect_stderr(io.StringIO()):
+            self.dead_build(); self.dead_build()
+        self.assertNotIn(LIVE_SID, km._dead_lane_memo)
+        self.assertEqual(self.dead(), {"dead_serve": 0, "dead_miss": 2, "dead_failed_serve": 0})
+
+
+class PerfWiring(LaneMemoBase):
+    def test_the_memo_reports_under_perf_memos_lanes(self):
+        self.build(); self.build()
+        blk = km._PERF_STATS.snapshot()["memos"]["lanes"]
+        self.assertEqual(set(blk), {"hit", "miss", "live_tail", "complain_skip", "unshared_skip", "evict", "entries",
+                                    "segs_hit", "segs_miss", "dead_serve", "dead_miss", "dead_failed_serve"})
+        self.assertEqual((blk["hit"], blk["miss"], blk["entries"], blk["segs_hit"], blk["segs_miss"]), (1, 1, 1, 1, 1))
+        self.assertEqual((blk["dead_serve"], blk["dead_miss"], blk["dead_failed_serve"]), (0, 0, 0), "live lanes only so far")
+        self.build(tmux={}); self.build(tmux={})
+        blk = km._PERF_STATS.snapshot()["memos"]["lanes"]
+        self.assertEqual((blk["dead_serve"], blk["dead_miss"], blk["dead_failed_serve"]), (1, 1, 0), "the dead lanes ride the same block")
+        self.assertEqual((blk["hit"], blk["miss"]), (1, 1), "and leave the live counters alone")
 
 
 if __name__ == "__main__":

--- a/tests/test_timeline_lane_memo.py
+++ b/tests/test_timeline_lane_memo.py
@@ -10,11 +10,19 @@ derived once at horizon zero, stamped with the value the horizon test compares, 
 exactly that. The bars encoder reuses the strings of entry objects it already encoded.
 
 Synthetic transcript, states and captions under a temp root; a placeholder sid; the lane is dead because the
-liveness snapshot is empty."""
+liveness snapshot is empty.
+
+DerivationSplit, below the dead-lane classes, covers the judging derivation's split from the horizon assembly
+(_derive_judging_marks and _judging_assemble against a private copy of the one-pass form as the oracle); it sits
+in this module because the dead-lane memo's stamped marks are that split's other caller."""
+import ast
+import inspect
 import io
 import json
 import os
+import shutil
 import tempfile
+import threading
 import time
 import unittest
 from contextlib import redirect_stderr
@@ -334,6 +342,184 @@ class EntryEncodeMemo(unittest.TestCase):
     def test_the_wire_fill_hands_the_collection_key_down(self):
         import inspect
         self.assertIn("_delta_split(kind, value, memo_key=(ftype, name))", inspect.getsource(km._delta_parts))
+
+
+# ── the judging derivation split (_derive_judging_marks + _judging_assemble): what the one-pass form emitted ──
+LIVE_SID = "44444444-5555-6666-7777-888888888801"      # private synthetic sids: the classes below mint goal stores, and a
+LIVE_SID2 = "44444444-5555-6666-7777-888888888802"     # store minted under the shared placeholder sid can be re-flagged by
+LIVE_PARENT = "44444444-5555-6666-7777-888888888803"   # another module's journaled overrides (load_goals replays them)
+LIVE_CHILD = "44444444-5555-6666-7777-888888888804"
+LIVE_SID3 = "44444444-5555-6666-7777-888888888805"
+
+
+def _one_pass_judging(sid, caps, goals, t0, out, seg_ends=None):
+    """_derive_judging as it stood in one pass, before the derivation was split from the horizon assembly: the
+    equality oracle for DerivationSplit (the horizon compared inline, the caption cap taken inline)."""
+    endt = (lambda tt: seg_ends.get(tt, tt)) if seg_ends else (lambda tt: tt)
+    caps_in = sorted((c for c in caps.values() if c.get("t") and c["t"] >= t0), key=lambda c: c["t"])
+    for c in caps_in[-km.JUDGE_CAP_LIMIT:]:
+        out.append({"judge": "captioner", "sid": sid, "t": c["t"],
+                    "kind": c.get("grain", "segment"), "text": c.get("caption", "")})
+    for n in goals.get("nodes", {}).values():
+        t = n.get("t")
+        if not t:
+            continue
+        text = n.get("text", "")
+        mt = n.get("mt") or t
+        go = n.get("groupOp")
+        if isinstance(go, dict) and (go.get("t") or 0) >= t0:
+            out.append({"judge": "grouper", "sid": sid, "t": go["t"],
+                        "kind": go.get("kind") or "group", "text": text})
+        if n.get("origin"):
+            if t >= t0:
+                out.append({"judge": "courier", "sid": sid, "t": t, "kind": "plant", "text": text})
+        elif n.get("umbrella"):
+            if mt >= t0:
+                out.append({"judge": "grouper", "sid": sid, "t": mt, "kind": "group", "text": text})
+        elif t >= t0:
+            out.append({"judge": "planner", "sid": sid, "t": t,
+                        "kind": ("mint" if not n.get("parentId") else "sub"), "text": text})
+        for _e in (n.get("log") or []):
+            if _e.get("synth") or (_e.get("ev_t") or 0) < t0:
+                continue
+            if _e.get("src") in ("planner", "closer") and _e.get("kind") in ("done", "block"):
+                out.append({"judge": _e["src"] if _e["src"] == "planner" else "closer", "sid": sid,
+                            "t": endt(_e["ev_t"]),
+                            "kind": ("done" if _e["src"] == "planner" else "close") if _e["kind"] == "done" else "block",
+                            "text": _e.get("why") or text})
+        if n.get("distilledMt") and n["distilledMt"] >= t0:
+            out.append({"judge": "distiller", "sid": sid, "t": endt(n["distilledMt"]), "kind": "distill",
+                        "text": n.get("summary") or text})
+        if n.get("briefedMt") and n["briefedMt"] >= t0:
+            out.append({"judge": "distiller", "sid": sid, "t": endt(n["briefedMt"]), "kind": "brief",
+                        "text": n.get("blockSummary") or text})
+    try:
+        arch = json.loads((km.jd.STATE / "archive" / (sid + ".json")).read_text(errors="replace"))
+        if arch.get("t") and arch["t"] >= t0:
+            out.append({"judge": "archiver", "sid": sid, "t": arch["t"], "kind": "index",
+                        "text": arch.get("headline", "")})
+    except (OSError, ValueError):
+        pass
+
+
+class DerivationSplit(unittest.TestCase):
+    """_derive_judging_marks derives every mark with no horizon and no clock; _judging_assemble applies the horizon
+    and the caption cap per build. Together they emit what the one-pass form emitted, mark for mark, at every
+    horizon, and the wrapper _derive_judging still answers its callers."""
+
+    def setUp(self):
+        self._saved_state = km.jd.STATE
+        self._td = tempfile.mkdtemp()
+        km.jd._rebind_state(Path(self._td))
+        self.now = 1_781_100_000
+
+    def tearDown(self):
+        km.jd._rebind_state(self._saved_state)
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def fixture(self, timeless=False):
+        now = self.now
+        caps = {"c%d" % i: {"id": "c%d" % i, "grain": "segment" if i % 2 else "turn", "t": now - 9000 + i * 100,
+                            "caption": "c%d" % i} for i in range(km.JUDGE_CAP_LIMIT + 10)}
+        caps["tie"] = {"id": "tie", "grain": "segment", "t": now - 9000 + 100, "caption": "tie"}   # an equal t: stable order
+        caps["none"] = {"id": "none", "grain": "segment", "caption": "no t"}
+        nodes = {
+            "g1": {"id": "g1", "parentId": None, "t": now - 8000, "mt": now - 7000, "text": "Top",
+                   "log": [{"src": "planner", "kind": "done", "ev_t": now - 7000, "why": "shipped"},
+                           {"src": "closer", "kind": "done", "ev_t": now - 6500},
+                           {"src": "closer", "kind": "block", "ev_t": now - 6000, "why": "waiting"},
+                           {"src": "planner", "kind": "done", "ev_t": now - 5000, "synth": True},
+                           {"src": "user", "kind": "done", "ev_t": now - 4000}],
+                   "distilledMt": now - 7000, "summary": "the takeaway", "briefedMt": now - 6000, "blockSummary": "the brief"},
+            "g2": {"id": "g2", "parentId": "g1", "t": now - 7500, "text": "Step"},
+            "g3": {"id": "g3", "parentId": None, "t": now - 3000, "text": "Planted", "origin": {"peer": "x"}},
+            "g4": {"id": "g4", "parentId": None, "t": now - 2000, "mt": now - 1500, "text": "Umbrella", "umbrella": True},
+            "g5": {"id": "g5", "parentId": None, "t": now - 1000, "text": "Merged", "groupOp": {"t": now - 900, "kind": "merge"}},
+            "g6": {"id": "g6", "parentId": None, "text": "no t"},
+        }
+        if timeless:
+            nodes["g7"] = {"id": "g7", "parentId": None, "t": now - 500, "text": "timeless op", "groupOp": {"kind": "retitle"},
+                           "log": [{"src": "planner", "kind": "done"}]}
+        km.jd.ARCHDIR.mkdir(parents=True, exist_ok=True)
+        (km.jd.ARCHDIR / (LIVE_SID + ".json")).write_text(json.dumps({"t": now - 300, "headline": "h"}))
+        seg_ends = {now - 7000: now - 6900, now - 6000: now - 5900}
+        return caps, {"nodes": nodes}, seg_ends
+
+    def test_equal_to_the_one_pass_form_at_every_horizon(self):
+        caps, goals, seg_ends = self.fixture()
+        # now-6950 and now-5950 fall inside a completion's evidence-to-work-end window (seg_ends moves now-7000 to
+        # now-6900 and now-6000 to now-5900): a filter on the plotted time instead of the evidence time shows there
+        for t0 in (0, self.now - 100000, self.now - 6950, self.now - 6500, self.now - 6000, self.now - 5950,
+                   self.now - 1000, self.now - 250, self.now + 1):
+            for se in (seg_ends, None):
+                want, got = [], []
+                _one_pass_judging(LIVE_SID, caps, goals, t0, want, se)
+                km._derive_judging(LIVE_SID, caps, goals, t0, got, se)
+                self.assertEqual(json.dumps(got), json.dumps(want), "t0=%r seg_ends=%r" % (t0, se))
+                cap_marks, other = km._derive_judging_marks(LIVE_SID, caps, goals, se)
+                out = []
+                km._judging_assemble(cap_marks, other, t0, out)
+                self.assertEqual(json.dumps(out), json.dumps(want))
+        self.assertEqual(len([m for m in want if m["judge"] == "captioner"]), 0, "the last horizon dropped every caption")
+
+    def test_a_timeless_group_op_or_diary_row_is_dropped_as_the_one_pass_form_dropped_it(self):
+        caps, goals, seg_ends = self.fixture(timeless=True)
+        for t0 in (self.now - 100000, self.now - 250):
+            want, got = [], []
+            _one_pass_judging(LIVE_SID, caps, goals, t0, want, seg_ends)
+            km._derive_judging(LIVE_SID, caps, goals, t0, got, seg_ends)
+            self.assertEqual(json.dumps(got), json.dumps(want))
+            self.assertFalse(any(m["kind"] == "retitle" for m in got))
+
+    def test_the_marks_are_derived_once_and_filtered_per_horizon(self):
+        caps, goals, seg_ends = self.fixture()
+        cap_marks, other = km._derive_judging_marks(LIVE_SID, caps, goals, seg_ends)
+        self.assertEqual(len(cap_marks), km.JUDGE_CAP_LIMIT + 11, "every timed caption, no cap yet")
+        self.assertEqual([m["t"] for m in cap_marks], sorted(m["t"] for m in cap_marks))
+        fts = [ft for ft, m in other]
+        self.assertIn(self.now - 7000, fts, "a completion's filter time is the diary's ev_t")
+        done = next(m for ft, m in other if m["judge"] == "planner" and m["kind"] == "done")
+        self.assertEqual(done["t"], self.now - 6900, "while its plotted t is the segment's work end")
+        out = []
+        km._judging_assemble(cap_marks, other, self.now - 6950, out)      # a horizon between the two
+        kinds = {(m["judge"], m["kind"]) for m in out}
+        self.assertNotIn(("planner", "done"), kinds, "filtered on the evidence time (before the horizon), not the plotted end")
+        self.assertNotIn(("distiller", "distill"), kinds, "the distiller's mark likewise (distilledMt before the horizon)")
+        self.assertIn(("closer", "close"), kinds, "a completion whose evidence is after the horizon stays")
+
+    def test_the_stamped_assembly_copies_the_shared_marks(self):
+        # the pairs are a memo's objects, shared into every unstamped build: the stamp lands on copies only
+        caps, goals, seg_ends = self.fixture()
+        cap_marks, other = km._derive_judging_marks(LIVE_SID, caps, goals, seg_ends)
+        stamped = []
+        km._judging_assemble(cap_marks, other, 0, stamped, stamp=True)
+        self.assertTrue(stamped and all("_h" in m for m in stamped))
+        self.assertFalse(any("_h" in m for m in cap_marks) or any("_h" in m for ft, m in other), "the memo's marks stay clean")
+        self.assertFalse(any(any(s is m for m in cap_marks) or any(s is m for ft, m in other) for s in stamped))
+        for t0 in (self.now - 6500, self.now - 250):
+            fresh = []
+            km._judging_assemble(cap_marks, other, t0, fresh)
+            self.assertEqual(km._dead_lane_marks(stamped, t0), fresh, "filtered on the stamp: the fresh assembly at %d" % t0)
+
+    def test_the_derivation_reads_no_clock(self):
+        class NoClock:
+            def time(self):
+                raise AssertionError("the derivation read the clock")
+
+            def __getattr__(self, name):
+                return getattr(time, name)
+        caps, goals, seg_ends = self.fixture()
+        real = km.time
+        km.time = NoClock()
+        try:
+            cap_marks, other = km._derive_judging_marks(LIVE_SID, caps, goals, seg_ends)
+        finally:
+            km.time = real
+        self.assertTrue(cap_marks and other)
+        tree = ast.parse(inspect.getsource(km._derive_judging_marks))
+        names = {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
+        self.assertFalse(names & {"now", "time", "TL_HORIZON", "JUDGE_CAP_LIMIT"}, repr(names))
+        self.assertIn("JUDGE_CAP_LIMIT", inspect.getsource(km._judging_assemble), "the cap is read at assembly")
 
 
 if __name__ == "__main__":

--- a/ui/timeline-lineage.test.ts
+++ b/ui/timeline-lineage.test.ts
@@ -33,7 +33,8 @@ test("the kernel serves lineage per lane and clips the copied history only while
   assert.match(KERNEL, /"branch": branch_of\.get\(sid\),/);
   assert.match(KERNEL, /"comments": _comment_markers\(sid\),/);
   assert.match(KERNEL, /if _psid not in id2name:\s*\n\s*continue/, "parent lane present is the connector AND clip condition");
-  assert.match(KERNEL, /if _bft and \(seg\.get\("end"\) or seg\["t"\]\) <= _bft:\s*\n\s*continue/);
+  // the clip runs in the lane's segment derivation (_lane_segments), which takes the fork time as `bft`
+  assert.match(KERNEL, /if bft and \(seg\.get\("end"\) or seg\["t"\]\) <= bft:\s*\n\s*continue/);
   assert.match(KERNEL, /def _comment_markers\(sid\):/);
   // a promoted thread is a session (branch connector), not a square
   assert.match(KERNEL, /not in \("open", "resolved"\):\s*\n\s*continue/);


### PR DESCRIPTION
## Symptom

Every bars build re-derived every live lane's segment part: the seam-aware segmentation, the awake-span excision, the caption lookups, the compact bar dicts and the judging marks were computed again for each live lane on each build, although between two builds most live lanes had not changed (a board of dozens of lanes has one or two writing at a time). The dead lanes have been served from their memo since #1131 and #1175; the live lanes, the ones being watched, paid the whole loop every cycle. Measured on an earlier form of this change (the same memo over long-key bars, with the captions keyed by object identity) on a 31-session state copy: the bars build fell from 477 ms to 93 ms at full hit, and a 30-build replay at the pusher's cadence served 99.3% of live lanes after the first build.

## Cause

`build_timeline` ran the per-lane turn loop inline with no memo for a live lane (the dead-lane memo is gated on `not live`), and `_derive_judging` applied the horizon inline beside the derivation, so nothing clock-free existed to hold across builds.

## Fix

Three commits, each droppable from the tail.

**1. The judging marks are derived apart from the horizon (a pure refactor).** `_derive_judging_marks(sid, caps, goals, seg_ends=None)` returns `(cap_marks, other_marks)` with no clock: the captioner's marks in caption-time order and `[(filter_t, mark)]` pairs for every other judge, each carrying the value the one-pass form compared against the horizon (the diary event's `ev_t` for a done, block or close; `distilledMt` or `briefedMt` for the distiller; the mark's own t otherwise), kept beside the mark because `seg_ends` moves a completion's plotted t to its segment's work end. `_judging_assemble(cap_marks, other_marks, t0, out, stamp=False)` applies the horizon and `JUDGE_CAP_LIMIT` per build; with `stamp` it appends copies carrying `_h`, since the pairs may be a memo's shared objects. `_derive_judging` is the two-line composition and keeps every caller, the dead-lane memo's stamped call included.

**2. The live-lane memo.** The inline loop moves to `_lane_segments(sid, session, goals, caps, live, bft, full_prompts=None)`, which emits the compact wire bar exactly as the loop did (the `BarLiteral` and bars-wire pins pass unchanged), derives the marks through `_derive_judging_marks` under the lane's own guard, and raises when a mark carries a non-numeric time, so a malformed row costs the lane its marks once per build and never the frame. `_lane_memo(sid, parsed, session, goals, caps, cap_key, live, bft, parse_ok, full_prompts)` serves a live lane's segment part from `_lanes_memo` while its inputs are the previous build's:

- the parse object by identity, after the live merge (`_parse` returns the cached object for an unchanged transcript and states file; a merged live tail is a new object and is derived, `live_tail`);
- the goal store by identity when a `FrozenStore`, or as "empty" when it has neither seams nor nodes (a private store with content is derived and not held, `unshared_skip`);
- the captions file's `_stat_key`, taken in `build_timeline` before `_captions` reads it. `_captions` builds a new dict per call, so the file is the input; stat before read means a row landing between the two is held under the old key and misses on the next build, never served stale (a stat after the read would hold the old rows under the new key). Rows read when the stat found no file have no key to be held under: derived, not held, and held on the next build;
- the branch clip, `tuple(_downtime)` and the archive's `_file_key`, taken before the derivation (a stat sentinel matches nothing and stores nothing).

A lane whose parse failed or whose seams or marks stage complained is derived and not held (`complain_skip`). The horizon and the caption cap are applied per build by `_judging_assemble`, on a hit as on a miss; the dead-lane path assembles its stamped marks the same way. A hit hands the binder the lane's whole prompts from the entry (T278b), so a delivery that names its sender on a later line of the prompt binds on a served build as on a derived one. Entries leave with a full build's lane set (`_lanes_forget`; a skeleton or live-only build evicts nothing), past 256 the least recently served first, when the parse object is no longer the build's, and when the dead-lane populate takes the lane (the entry holds the parse the populate releases). One lock covers get, put, evict and the counters; the derivation runs unlocked, so two threads deriving one lane both store an exact entry and the last wins; when both derived from one parse object the next build is served, otherwise it derives once more and holds again. The held bars and marks are shared by identity into `turns`, the bars wire cache, the delta parts and `semantic`; at this base none of those writes to them (`_bind_message_execs` mutates the messages only, `_timeline_skeleton` copies the frame, `_run_judging` reads, `_expand_bar` builds a new dict).

A dead miss is derived by `_lane_segments` directly and cached in the dead-lane memo, with a `failed` flag on a parse that raised. One dead-lane rule changes: a dead lane whose seams stage complained is derived every build and not cached, as a lane whose marks stage failed already was (the inline loop cached it after a seams complaint, so a malformed goals row was said once and then served). The populate also pops the live memo's entry. `_VIEW_STATS["laneServe"]` keeps counting a dead-lane serve under `views`. `GET /perf` gains `memos.lanes`: `hit`, `miss`, `live_tail`, `complain_skip`, `unshared_skip`, `evict`, `entries`, `segs_hit`, `segs_miss` for the live lanes and, so one block carries every lane, `dead_serve`, `dead_miss`, `dead_failed_serve` (`views.laneServe` counts a dead-lane serve whether or not its parse raised, so it equals `dead_serve` plus `dead_failed_serve`; retiring the older counter is a separate call). docs/reference.md describes the block.

**3. `_cached_timeline` reads the payload slot once.** It tested `e[1]` and returned `e[1]` as two reads of the shared list while the pusher assigns `_built_timeline[:]` on its thread, so a connect whose reads straddled the assignment was handed the replacement build, not the one its freshness test had seen.

Not changed: what a frame contains (a served lane is the rebuilt lane, byte for byte; the badge row is derived per build as before), the rebuild cadence, and the skeleton build, which still loads every lane's store (gating that load to dead lanes was left out: `tests/test_goal_store_fault_boundary.py` pins that a live lane's skeleton files the store fault row).

Pins moved: the frozen-view spy in `tests/test_kernel_goal_cache_wiring.py` aims at `_derive_judging_marks`; the stage pins in `tests/test_timeline_bars_resilience.py` read `build_timeline` and `_lane_segments`; `ui/timeline-lineage.test.ts` reads the clip's `bft` (no new kernel-text pin in TypeScript; the clip's behaviour, its `<=` boundary included, is pinned in Python).

## Tests

Each test was run on the sources before its commit first and failed as stated.

Commit 1, `tests/test_timeline_lane_memo.py` (DerivationSplit, 5 tests): a private copy of the one-pass form is the oracle; the wrapper and the two halves equal it at nine horizons, two of them inside a completion's evidence-to-work-end window, with and without `seg_ends` over a store carrying a planner mint and sub, a courier plant, an umbrella, a grouper op, done/block/close diary rows, a synth row, a `distilledMt` and a `briefedMt`, plus an archive and more captions than the cap; a timeless group op or diary row is dropped as before; the marks come out once with their filter times and the completion's plotted t at the work end, and an assembly at a horizon between the two drops the completion and keeps a later one; the stamped assembly copies and leaves the derived marks clean; the derivation reads no clock (the module's `time` patched to raise). Red: 4 of 5 with `AttributeError: _derive_judging_marks` (the wrapper-only case passed already). A mutation that filters the diary marks on the plotted work end instead of `ev_t` fails two of them.

Commit 2, `tests/test_timeline_lane_memo.py` (a LaneMemoBase fixture with a fresh state root per test and one live lane under a private synthetic sid; 44 tests in seven classes). Red on the tree before the commit: every one of the 44 at the fixture, which clears `_lanes_memo` and saves `_LANES_MEMO_MAX` (`AttributeError`). With those fixture references guarded for the measurement, the reds were `AttributeError: _lanes_memo_report` and `_lane_segments` in the bodies, `KeyError: 'failed'` on the dead entry, `KeyError: 'lanes'` on the snapshot, the guard's stderr line absent, and the behavioural cases: the seam stage ran on the second build (`2 != 1`), the second frame's bars list `is not` the first, a complaining dead lane was cached.

- HitsAndEquality: an unchanged live lane is served without walking its turns, with the same bars list and bar objects in `turns`, equal to the uncached derivation and to `_derive_judging`'s marks, hit 1 miss 1; a hit still runs the parse, the merge and the captions read; the held bars survive the postal join; the badge row changes on a hit; a hit hands the binder the whole two-line prompt and the sender named on its second line binds, where the wire's first line alone does not; the real judging band reader over a hit leaves the held marks unchanged; two threads deriving one lane from one parse object leave one exact entry and the next build is served (a `Barrier`, no timing).
- EveryInputBusts, one per key input: a transcript append, a states write, a store publish, a journal append, a captions append, a caption landing between the stat and the read (misses on the next build, holds again after), an archive rewrite and an archive appearing, a host suspension (a rebind of the same content hits), a suspension inside the segment splitting the bar on the next build, liveness (a lane going dead is derived once outside this memo, handed to the dead-lane memo, its live entry and parse dropped, then served with `laneServe` and `dead_serve` both counting), an open turn open only on a live lane, the branch clip moving for a live child when the parent leaves the build (a compaction inside the copied history and a turn whose work ends exactly at the fork time are the parent's while its lane is in the build and the child's after).
- NotHeld: a live tail, a failed parse (one stderr line), a private store with content, a complaining seams stage, a complaining marks stage, a caption row or an archive with a string time (the lane keeps its bars and loses its marks on both builds), a failed archive stat, captions read when the stat found no file (held on the next build); an empty store and an empty captions file hit under the empty rule; the skeleton build bypasses the memo; the assembly is guarded at its call site.
- ClockAtAssembly: a t-less caption is dropped on a hit as on a miss; the horizon and the caption cap apply per build on a hit; `_lane_segments` reads no clock.
- Eviction: with the lane set and not on a live-only build; least recently served first at the bound (the first-inserted entry is served, so insertion order and serve order differ); an entry whose parse is no longer the build's.
- DeadLanesOnTheSameBlock: a dead miss leaves this memo and the parse cache empty and counts `dead_miss`; a failed dead parse serves as `dead_failed_serve` until the transcript's stat moves; a complaining dead lane is derived every build and not cached.
- PerfWiring: `memos.lanes` on the snapshot with the live and dead counters apart.
- `tests/test_perf_stats.py`: the memos key set gains `lanes` with its twelve integer keys (red: `KeyError: 'lanes'`). `tests/test_kernel_goal_cache_wiring.py`: the spy re-aim (red: `AttributeError: _lanes_memo` in setUp). `tests/test_timeline_bars_resilience.py`: the stage pins over both functions (red: `AttributeError: _lane_segments`). `ui/timeline-lineage.test.ts`: the clip regex (red: `not ok 3`).

Mutations each caught by a named test: the LRU reinsert on a hit removed, the compaction markers not clipped at the fork time, the clip's `<=` made `<`, the prompts map not filled on a hit, the captions rows read with no file to stat held under the empty key, a seams complaint no longer blocking the dead-lane cache.

Commit 3, `tests/test_perf_stats.py` (PusherRecords): `_built_timeline` is replaced by a list whose payload slot answers the build on its first read and a replacement build after; a connect returns the build it tested, counts the serve and never rebuilds. Red: the replacement came back.

Full runs on the final tree: `pytest -n 8 tests/`: 10882 passed, 41 skipped, 1688 subtests passed, 151 s, no failures. `npm run typecheck` clean; `npm test`: 4052 pass, 0 fail; `node --test` on the lineage and bars-wire bundles: 3 and 6 pass.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
