### PR TITLE
Undo clear: an undo-reopen with nothing to restore leaves the state as it stands, so a completed top comes back completed, not Working

### DIFF
--- a/docs/goal-state.md
+++ b/docs/goal-state.md
@@ -47,7 +47,9 @@ Sort events by evidence time (`ev_t`; arrival `at` breaks ties) and replay:
   clears.
 - **Snapshots**: provisional flips restore what they displaced. A `clear`
   snapshots the state it covers, and an undo-reopen restores it, so a
-  cleared completed card comes back completed, never "open". A msg-reopen
+  cleared completed card comes back completed, never "open". An
+  undo-reopen with nothing to restore (its clear lost, or a second undo
+  for one clear) leaves the state as it stands. A msg-reopen
   (the optimistic flip when you reply to a card) snapshots too, and a
   planner `dismiss` (the pivot verdict: that reply started its own thread)
   restores the original state and settle stamp. The pivot's new goal is its

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -9090,7 +9090,8 @@ def _fold_node(nd):
     #                                       verdict: "that reply wasn't about this goal") restores it
     clear_snap = None                     # symmetric snapshot at `clear`: an undo-reopen restores the state
     #                                       the cross-off displaced (a cleared COMPLETED card comes back
-    #                                       completed, never "open"), instead of blindly opening
+    #                                       completed, never "open"), instead of blindly opening; an undo
+    #                                       with nothing to restore leaves the state as it stands
     for e in sorted(nd.get("log") or [], key=lambda e: (e.get("ev_t") or 0, e.get("at") or 0)):
         src, kind, t = e.get("src"), e.get("kind"), e.get("ev_t") or 0
         if kind == "reopen":
@@ -9105,9 +9106,17 @@ def _fold_node(nd):
                 # assert's own `t >= floor` equality-lands rule below: within one turn the reopen is the
                 # trigger, the wait is how the turn ENDED.
                 awaiting_why = awaiting_at = awaiting_kind = awaiting_peers = None
-            if e.get("undo") and clear_snap is not None:
-                state, cur_settle, prev_settle = clear_snap      # restore what the cross-off displaced
-                clear_snap = None
+            if e.get("undo"):
+                if clear_snap is not None:
+                    state, cur_settle, prev_settle = clear_snap  # restore what the cross-off displaced
+                    clear_snap = None
+                # An undo-reopen with NO clear before it has nothing to restore and is a state no-op: it
+                # asserts nothing about doneness, so a completed top stays done and its settle stands. Two
+                # shapes reach here (2026-09-10): a second undo row for one clear, when a same-second re-clear
+                # collapsed into the first clear as a rebase twin while both undo-reopens were kept; and an
+                # undo whose clear never landed, when a clear and its undo were both lost to a pass save and
+                # only the undo replays (the journal's last word). Both used to fall through to "open" like a
+                # plain reopen, and the completed top came back Working. The user's floor still advances.
                 if src == "user":
                     floor = max(floor, t)
                 continue
@@ -9116,8 +9125,7 @@ def _fold_node(nd):
             state = "open"
             if src == "user":
                 floor = max(floor, t)
-                if not e.get("undo"):     # an undo-clear restores; it asserts nothing about doneness
-                    held = True
+                held = True               # a user's plain reopen; an undo-clear left the loop body above
             if e.get("msg"):
                 pending = True
             if cur_settle is not None:    # this reopen ends a settled episode → its settle becomes the

--- a/tests/test_judge_guarded_node.py
+++ b/tests/test_judge_guarded_node.py
@@ -111,6 +111,41 @@ class TheNewKinds(unittest.TestCase):
         self.assertEqual(f["state"], "done", "a cleared COMPLETED card comes back completed, never 'open'")
         self.assertFalse(f["held"], "an undo asserts nothing about doneness — no held-open")
 
+    def test_an_undo_reopen_with_nothing_to_restore_is_a_state_no_op(self):
+        # an undo-reopen restores the state its clear displaced; one that finds no clear before it (a second
+        # undo row for one clear after a lost re-clear, or an undo whose clear never landed) has nothing to
+        # restore and must leave the state as it stands: a completed card stays done, its settle stamp
+        # stands, and the user's floor still advances. Before, it fell through to "open" like a plain
+        # reopen, and the completed top came back Working
+        log = [{"ev_t": T, "src": "closer", "kind": "done", "why": "shipped", "at": T},
+               {"ev_t": T + 2, "src": "romp", "kind": "settle", "at": T + 2},
+               {"ev_t": T + 5, "src": "user", "kind": "clear", "at": T + 5},
+               {"ev_t": T + 10, "src": "user", "kind": "reopen", "undo": True, "at": T + 10},
+               {"ev_t": T + 20, "src": "user", "kind": "reopen", "undo": True, "at": T + 20}]
+        f = self._fold(log)
+        self.assertEqual(f["state"], "done", "the second undo finds nothing to restore and changes nothing")
+        self.assertFalse(f["held"], "an undo asserts nothing about doneness, so no held-open")
+        self.assertEqual(f["settledAt"], T + 2, "the settle the first undo restored still stands")
+        self.assertEqual(f["floor"], T + 20, "the user's floor advances to the undo all the same")
+        log = [{"ev_t": T, "src": "closer", "kind": "done", "why": "shipped", "at": T},
+               {"ev_t": T + 2, "src": "romp", "kind": "settle", "at": T + 2},
+               {"ev_t": T + 10, "src": "user", "kind": "reopen", "undo": True, "at": T + 10}]
+        f = self._fold(log)
+        self.assertEqual(f["state"], "done", "an undo whose clear never landed changes nothing")
+        self.assertFalse(f["held"])
+        self.assertEqual((f["settledAt"], f["floor"]), (T + 2, T + 10))
+        # a done node never reports held (_fold_node masks it at its return), so the two cases above cannot
+        # tell an undo that holds from one that does not. On a node no verdict has landed on the state is
+        # "open" and held reaches the return unmasked: a clear, its undo and a second undo leave the node
+        # open and NOT held, with the floor at the last undo (green before the fix too; it pins that the
+        # no-op branch, like the restore, never turns an undo into a user's plain reopen)
+        log = [{"ev_t": T + 5, "src": "user", "kind": "clear", "at": T + 5},
+               {"ev_t": T + 10, "src": "user", "kind": "reopen", "undo": True, "at": T + 10},
+               {"ev_t": T + 20, "src": "user", "kind": "reopen", "undo": True, "at": T + 20}]
+        f = self._fold(log)
+        self.assertEqual((f["state"], f["held"], f["floor"]), ("open", False, T + 20),
+                         "an undo never holds the node open, whether or not it had a clear to restore")
+
     def test_any_judge_event_answers_held_and_pending(self):
         log = [{"ev_t": T, "src": "closer", "kind": "done", "at": T},
                {"ev_t": T + 10, "src": "user", "kind": "reopen", "msg": True, "at": T + 10}]

--- a/tests/test_kernel_goal_compaction.py
+++ b/tests/test_kernel_goal_compaction.py
@@ -498,6 +498,75 @@ class ClearedLedgerIsAuthoritativeAcrossTheCompaction(unittest.TestCase):
         self.assertTrue(st["nodes"][g].get("cleared"), "the next load re-seals the card")
         self.assertEqual(self._user_seals(st, sid, "g15"), ["clear", "reopen", "clear"], "the re-clear is re-recorded once")
 
+    def test_a_stale_pass_save_that_collapses_the_re_clear_leaves_the_top_completed(self):
+        # the pass's copy is taken after the FIRST clear this time, and the user undoes, re-clears and undoes
+        # again before it publishes. The rebase keeps the disk rows the copy lacks by (ev_t, src, kind): the
+        # re-clear is a twin of the copy's clear and collapses, and both undo-reopens are kept, so the
+        # published log holds clear, reopen, reopen. The last gesture is an undo, so the card is live
+        # and uncleared, as it should be; but the second reopen finds no clear to restore, and _fold_node must
+        # leave the completed top completed rather than open it into Working. The replay cannot heal it:
+        # every row's word is in the log already, so nothing is re-recorded on the next load
+        sid, g = self.SEAL_SID, "%s:%s" % (self.SEAL_SID, "g16")
+        self._completed_top("g16", sid=sid)
+        with mock.patch("time.time", return_value=1_000_000.0):          # one second for all four gestures
+            km._clear_all([g])
+            stale = jd.load_goals(sid)                                  # the pass's copy: the first clear only
+            km._undo_clear()
+            km._clear_all([g])
+            km._undo_clear()
+        self.assertEqual([op for op, _ in self._seal_rows(sid, "g16")], ["clear", "unclear", "clear", "unclear"],
+                         "premise: four rows, journal order")
+        self.assertEqual(self._user_seals(stale, sid, "g16"), ["clear"], "premise: the copy holds the first clear only")
+        live = json.loads((jd.GOALDIR / (sid + ".json")).read_text())
+        self.assertFalse(live["nodes"][g].get("cleared"), "premise: the live store reads the card undone")
+        self.assertEqual(live["status"].get(g), "completed", "premise: ...and the top completed")
+        jd.save_goals(sid, stale)                                       # the pass publishes: the revision moved, so it rebases
+        raw = json.loads((jd.GOALDIR / (sid + ".json")).read_text())
+        self.assertEqual(self._user_seals(raw, sid, "g16"), ["clear", "reopen", "reopen"],
+                         "premise: the rebase collapsed the re-clear into the first clear and kept both undos")
+        self.assertFalse(raw["nodes"][g].get("cleared"), "the last gesture is an undo: the card is live")
+        self.assertEqual(raw["status"].get(g), "completed",
+                         "the second undo has nothing to restore and leaves the completed top completed")
+        jd._shared_clear()
+        st = jd.load_goals(sid)
+        self.assertFalse(st["nodes"][g].get("cleared"))
+        self.assertEqual(st["status"].get(g), "completed", "the next load reads it completed too")
+        self.assertEqual(self._user_seals(st, sid, "g16"), ["clear", "reopen", "reopen"],
+                         "the replay re-records nothing: every row's word is in the log")
+        jd.save_goals(sid, st)
+        jd._shared_clear()
+        again = jd.load_goals(sid)
+        self.assertEqual(again["status"].get(g), "completed")
+        self.assertEqual(self._user_seals(again, sid, "g16"), ["clear", "reopen", "reopen"],
+                         "a further save and load add no row")
+
+    def test_an_undo_over_a_snapshot_taken_before_its_clear_leaves_the_top_completed(self):
+        # a clear and its undo a second apart, both lost to a pass save from a snapshot taken before either.
+        # The journal's last word is the undo, so the clear row never replays; the unclear row re-records its
+        # reopen, which then stands with no clear before it. Nothing to restore: the completed top must stay
+        # completed and uncleared, not come back Working
+        sid, g = self.SEAL_SID, "%s:%s" % (self.SEAL_SID, "g17")
+        self._completed_top("g17", sid=sid)
+        snapshot = json.loads((jd.GOALDIR / (sid + ".json")).read_text())
+        with mock.patch("time.time", return_value=1_000_000.0):
+            km._clear_all([g])
+        with mock.patch("time.time", return_value=1_000_001.0):
+            km._undo_clear()
+        self.assertEqual(self._seal_rows(sid, "g17"), [("clear", 1_000_000), ("unclear", 1_000_001)])
+        self.assertEqual(self._user_seals(snapshot, sid, "g17"), [], "premise: the snapshot predates both gestures")
+        self.assertEqual(snapshot["status"].get(g), "completed", "premise: a completed top")
+        self._clobber_with(snapshot, sid=sid)
+        st = jd.load_goals(sid)
+        self.assertFalse(st["nodes"][g].get("cleared"), "the last row, an undo, wins")
+        self.assertEqual(self._user_seals(st, sid, "g17"), ["reopen"],
+                         "the clear never replays; the undo's reopen is re-recorded on its own")
+        self.assertEqual(st["status"].get(g), "completed", "the card comes back to Completed, not Working")
+        jd.save_goals(sid, st)
+        jd._shared_clear()
+        again = jd.load_goals(sid)
+        self.assertEqual(again["status"].get(g), "completed")
+        self.assertEqual(self._user_seals(again, sid, "g17"), ["reopen"], "a further save and load add no row")
+
     def test_the_feed_payload_carries_the_ledgers_foreign_ids_for_the_merged_board(self):
         # the viewer's ledger over remote rows (review find, 2026-09-09): ids the local ledger clears whose
         # session has no store and no archive here ride the payload, bare, for the client merge to apply


### PR DESCRIPTION
Follows the merged #1233 (the same-second replay fix): its test helpers (`SEAL_SID`, `_completed_top(sid=)`, `_seal_rows`, `_user_seals`) and the replay behaviour the second test depends on live there, and its body names the raw-snapshot shape below as not changed there.

## Symptom

A completed top the user cleared, undid, cleared again and undid, all inside one second, comes back in Working rather than Completed: uncleared, as it should be, but no longer completed. It happens when a triage pass that loaded the store after the first clear publishes afterwards through `save_goals`. The same happens when a clear and its undo, a second apart, are both lost to a pass save from a snapshot taken before either. Neither heals on a reload: the next load re-records nothing, and a further save and load add nothing.

## Cause

Two shapes put an undo-reopen into a node's log with no clear before it:

- `_rebase_onto_disk` keys verdict identity on (ev_t, src, kind) and filters the disk's rows against the writer's log only, never against each other. With the pass's copy holding the first clear at T, the disk's re-clear (T, user, clear) is a twin and drops, while both undo-reopens (T, user, reopen) are kept: the published log reads clear, reopen, reopen.
- Over a snapshot that predates a clear and its undo, the journal's last word for the node is the undo, so the clear row never replays (`last_seal`); the unclear row re-records its reopen on its own. #1233's body names this shape as unchanged there.

In `_fold_node` the undo branch restored the snapshot its clear took only when one stood (`e.get("undo") and clear_snap is not None`). With none, the row fell through to the plain reopen's path: state "open", the settle ended, and `rollup_status` filed the top as working. The override replay cannot heal either shape: every row's word is already in the log (`_newest_seal` and `last_seal` both skip), so nothing re-records and the published "working" stands.

## Fix

`kernel/judge.py`, `_fold_node`: the undo branch short-circuits whether or not a snapshot stands. With one it restores it as before; with none it changes nothing: the state, the settle stamp and `held` stay as they are, and the user's floor still advances. The plain reopen's `held` line drops its undo check, which no undo row reaches now.

Why this is the right reading of the log: an undo asserts nothing about doneness (the existing comment), and by the two writers' gates an undo-reopen that meets no clear is exactly a lost clear or a second undo for one clear. The live undo (`_mark_nodes_cleared`) records a reopen only when the flag was on, the replay's unclear arm only when the journal's last word for the node is not a clear, and `migrate_store` gives a legacy cleared node a synthesized clear. A node whose log was capped (`logTrunc`) with its clear dropped hands `_fold_node` the rows of the unit test's no-clear case (done, settle, undo-reopen) and now reads its state from them instead of opening, which is the intended reading.

Why not a dedup of the disk's rows against each other in `_rebase_onto_disk`: it would collapse the second reopen only when both undos share a second (with the last undo a second later the identities differ, the clear rows still never replay, and the top still opens), the raw-snapshot shape has no rebase at all, and it would change the dedup for every verdict kind (two same-second romp settles are legitimate rows today).

Not changed: `_rebase_onto_disk`, `_replay_overrides`, `record_verdict`, the kernel's writers, and the sort key (the shuffle-invariance property stands). `docs/goal-state.md` gains one clause.

## Tests

The first three cases below are red before this change and green after.

- `tests/test_judge_guarded_node.py`, `TheNewKinds.test_an_undo_reopen_with_nothing_to_restore_is_a_state_no_op`: over the real `_fold_node`, a log of done, settle, clear, undo-reopen, undo-reopen leaves the state done with the settle stamp and the floor at the last undo, and a log of done, settle, undo-reopen with no clear does the same. Fails before with `AssertionError: 'open' != 'done'`. A third case in the same test, on a node no verdict has landed on (clear, undo-reopen, undo-reopen), pins that the undo never holds the node open: a done node's `held` is masked at `_fold_node`'s return, so this is the shape where a branch that set `held` would show. It is green before the change too; a mutation that sets `held` in the undo branch fails it.
- `tests/test_kernel_goal_compaction.py`, in the class #1233's same-second tests live in, under its own sid with `time.time` pinned to one second: `test_a_stale_pass_save_that_collapses_the_re_clear_leaves_the_top_completed`. Clear, a pass loads its copy, undo, clear, undo; the pass publishes through `save_goals`. Premises asserted: four journal rows in order, the copy holding the first clear only, the live store completed and uncleared before the publish, the published log clear, reopen, reopen with the card uncleared. Fails before at the published store's status with `AssertionError: 'working' != 'completed'`; also asserts the next load reads it completed and re-records nothing, and a further save and load add no row.
- Same class, `test_an_undo_over_a_snapshot_taken_before_its_clear_leaves_the_top_completed`: clear at T, undo at T+1, overwrite with a snapshot taken before both, load. Premises: the two journal rows, the snapshot holding no seal and a completed top. Asserts the card uncleared, exactly one reopen re-recorded, and the status completed (fails before with `AssertionError: 'working' != 'completed'`); a further save and load add no row.

Mutation checks on the new branch, each run against the two test modules: ending the settle, skipping the floor advance, opening the node, and setting `held` for a user undo each fail at least one case above; restoring the plain reopen's `if not e.get("undo")` check changes nothing (it is dead code now).

Targeted run after the change: test_judge_guarded_node, test_kernel_goal_compaction, test_kernel_undo_restore_completed, test_ask_unit_cards, test_event_model_golden, test_reopen_next_word, test_kernel_goal_cache_wiring and test_judge_verdict_log (the verdict-log module), 209 passed. Full suite: `pytest -q -n 8 tests/`, 10758 passed, 118 skipped, 1688 subtests passed.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)