### PR TITLE
Show completed: a cleared archived top whose only completion is a copied status leaves the list

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -29609,7 +29609,9 @@ def _fleet_archived_tops(sid, cap=20):
     hierarchy, not just show a flat row (the user 2026-06-29). The Fleet filters depth==0 for the roots and
     merges the rest into its node map. "Completed" top = explicitly nodeComplete, rolled up to status
     'completed', or carries a distiller takeaway (summary). mtime-cached on the archive file (changes only on
-    a sweep), so this is ~free on the feed hot path. Caps the number of TOPS (each keeps its full subtree)."""
+    a sweep), so this is ~free on the feed hot path. Caps the number of TOPS (each keeps its full subtree).
+    A cleared top whose only completion is that copied status leaves the list (_ledger_cleared_overlay drops
+    it: a stale copy of a clear, not a completion)."""
     p = jd.GOALARCHDIR / (sid + ".json")
     try:
         mt = p.stat().st_mtime
@@ -29674,16 +29676,35 @@ def _ledger_cleared_overlay(rows):
     """The archive projection with cleared.jsonl applied over the node flags (2026-09-09): an archived top the
     ledger clears reads cleared whatever its copied flag says (a racing pass save could have erased it), and
     its subtree follows, the roll-down the live tree's top-only cross-off has. Applied AFTER the mtime cache,
-    so a clear that lands later than the archive's last write shows on the next build."""
+    so a clear that lands later than the archive's last write shows on the next build.
+
+    A cleared root whose only completion is the copied status is DROPPED with its subtree, not marked. A cleared
+    flag rolls up to status cleared (rollup_status gives it precedence), so a copied "completed" beside a clear
+    is a stale copy: a compaction that copied the status dict bound before its re-seal's rollup (the re-seal's
+    clear verdict leaves nodeComplete False, so the copied status was the root's only completion); or a
+    completion the rollup derived without a verdict (an umbrella, a settled store) whose root the ledger then
+    cleared, among them a root whose flag a pass save erased before compactions re-sealed such a root (a root
+    with its own done verdict keeps nodeComplete through that erasure and stays listed, struck through). A
+    clear on the live card rolls such a top to cleared before the copy and it never qualifies; this
+    reads an older archive the same way. A root completed by its own verdict (nodeComplete) stays listed and
+    reads cleared; a root that carries a distiller takeaway qualifies through the summary and stays listed, as
+    it does after a live-card clear. Read from the projection's fields: at depth 0 `derived` means the copied
+    status or a summary, never an ancestor (a root has none), so derived with no summary is status-only. The
+    drop sits behind the early return, so it acts only while the ledger holds a live row; every such root has
+    its own (the re-seal requires it, an undo removes the row and restores the node, nothing prunes the file),
+    and a ledger emptied by hand leaves the root listed struck through. The subtree drop relies on the flat
+    list's order (a root, then its descendants, up to the next depth-0 row), the invariant the roll-down reads."""
     vc = _cleared_ids()
     if not vc:
         return rows
-    out, root_cleared = [], False
+    out, root_cleared, drop = [], False, False
     for n in rows:
         if n.get("depth") == 0:
             root_cleared = bool(n.get("cleared")) or n.get("id") in vc
-            out.append(dict(n, cleared=root_cleared) if root_cleared != bool(n.get("cleared")) else n)
-        else:
+            drop = root_cleared and bool(n.get("derived")) and not (n.get("summary") or "").strip()
+            if not drop:
+                out.append(dict(n, cleared=root_cleared) if root_cleared != bool(n.get("cleared")) else n)
+        elif not drop:                                   # a dropped root's descendants follow it; they go with it
             c = bool(n.get("cleared")) or n.get("id") in vc or root_cleared
             out.append(dict(n, cleared=c) if c != bool(n.get("cleared")) else n)
     return out

--- a/tests/test_kernel_goal_compaction.py
+++ b/tests/test_kernel_goal_compaction.py
@@ -344,6 +344,77 @@ class ClearedLedgerIsAuthoritativeAcrossTheCompaction(unittest.TestCase):
         self.assertTrue(second[self.g("g5a")]["cleared"], "and rolls down to the subtree")
         self.assertFalse(first[self.g("g5")]["cleared"], "the cached rows themselves are not mutated")
 
+    def test_an_archive_from_before_the_reseal_fix_does_not_list_a_status_only_root_the_ledger_clears(self):
+        # the archive shape an older compaction wrote for a root only the ledger cleared: the re-seal's clear verdict
+        # set the flag and left nodeComplete False, and the copy took the status dict bound before the rollup,
+        # "completed" (the rollup gives a cleared flag precedence, so that pair is a stale copy by construction);
+        # nothing rewrites an archived status, and the root's ledger row persists. g11 is the control: completed
+        # by its own verdict, then cleared, the shape the previous test pins as listed and struck through.
+        jd.GOALARCHDIR.mkdir(parents=True, exist_ok=True)
+        (jd.GOALARCHDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID,
+            "nodes": {self.g("g10"): _node(self.g("g10"), None, cleared=True, t=100, mt=100),
+                      self.g("g10a"): _node(self.g("g10a"), self.g("g10"), cleared=True, t=100, mt=100),
+                      self.g("g11"): _node(self.g("g11"), None, nodeComplete=True, t=100, mt=100)},
+            "status": {self.g("g10"): "completed", self.g("g11"): "completed"}}))
+        first = km._fleet_archived_tops(SID)
+        self.assertEqual({n["id"] for n in first if n["depth"] == 0}, {self.g("g10"), self.g("g11")},
+                         "premise: with an empty ledger both roots list on the copied values, and the cache is primed")
+        with (jd.STATE / "cleared.jsonl").open("a") as f:                  # the rows every such root has
+            for n in ("g10", "g11"):
+                f.write(json.dumps({"id": self.g(n), "t": 200, "op": "clear"}) + "\n")
+        km._CLEARED_MEMO["slot"] = None
+        second = km._fleet_archived_tops(SID)
+        self.assertEqual([n["id"] for n in second], [self.g("g11")],
+                         "a root whose only completion is a copied status the ledger clears is a stale copy of a "
+                         "clear: gone from Show completed, its subtree with it")
+        self.assertTrue(second[0]["cleared"], "a root completed by its own verdict keeps its struck-through row")
+        self.assertIn(self.g("g10"), {n["id"] for n in first}, "the cached rows themselves are not mutated")
+        self._fresh_process()
+        self.assertEqual([n["id"] for n in km._fleet_archived_tops(SID)], [self.g("g11")],
+                         "the uncached projection agrees")
+
+    def test_only_a_status_only_root_is_dropped_a_takeaway_or_its_own_verdict_keeps_the_row(self):
+        # five shapes side by side, newest first in the flat list. g12: the flag a pass save erased, the copied
+        # status "completed", the ledger row the clear left (the shape from before the compaction re-sealed such
+        # a root), a whitespace summary (no takeaway, as the qualification reads it): status-only, dropped with
+        # its child. g13: cleared, no status, a distiller takeaway written before the clear: it qualifies through
+        # the summary and stays listed struck through, as it does when the clear lands on the live card. g14:
+        # completed by its own verdict, nothing clears it: listed, not cleared, its child intact, so the drop
+        # ends at the next root. g15: a copied "completed" and nothing clearing it, no flag, no row: listed with
+        # its child while the ledger holds other rows (the drop is for CLEARED status-only roots). g16: the
+        # copied flag on, a copied "completed", no ledger row: dropped with its child on the flag alone, and
+        # the drop of the last root runs to the end of the list.
+        jd.GOALARCHDIR.mkdir(parents=True, exist_ok=True)
+        (jd.GOALARCHDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID,
+            "nodes": {self.g("g12"): _node(self.g("g12"), None, summary="  ", t=300, mt=300),
+                      self.g("g12a"): _node(self.g("g12a"), self.g("g12"), t=300, mt=300),
+                      self.g("g13"): _node(self.g("g13"), None, cleared=True, summary="what shipped", t=200, mt=200),
+                      self.g("g14"): _node(self.g("g14"), None, nodeComplete=True, t=100, mt=100),
+                      self.g("g14a"): _node(self.g("g14a"), self.g("g14"), nodeComplete=True, t=100, mt=100),
+                      self.g("g15"): _node(self.g("g15"), None, t=50, mt=50),
+                      self.g("g15a"): _node(self.g("g15a"), self.g("g15"), t=50, mt=50),
+                      self.g("g16"): _node(self.g("g16"), None, cleared=True, t=25, mt=25),
+                      self.g("g16a"): _node(self.g("g16a"), self.g("g16"), cleared=True, t=25, mt=25)},
+            "status": {self.g("g12"): "completed", self.g("g14"): "completed",
+                       self.g("g15"): "completed", self.g("g16"): "completed"}}))
+        with (jd.STATE / "cleared.jsonl").open("a") as f:                  # the rows the two clears left
+            for n in ("g12", "g13"):
+                f.write(json.dumps({"id": self.g(n), "t": 400, "op": "clear"}) + "\n")
+        km._CLEARED_MEMO["slot"] = None
+        rows = km._fleet_archived_tops(SID)
+        self.assertEqual([n["id"] for n in rows],
+                         [self.g("g13"), self.g("g14"), self.g("g14a"), self.g("g15"), self.g("g15a")],
+                         "the cleared status-only roots and their children are gone; the takeaway root, the verdict "
+                         "root and the uncleared status-only root stay")
+        by = {n["id"]: n for n in rows}
+        self.assertTrue(by[self.g("g13")]["cleared"], "a cleared root with a takeaway lists struck through")
+        self.assertFalse(by[self.g("g14")]["cleared"] or by[self.g("g14a")]["cleared"],
+                         "an uncleared root and its subtree are untouched by the drop before them")
+        self.assertFalse(by[self.g("g15")]["cleared"] or by[self.g("g15a")]["cleared"],
+                         "a status-only root nothing clears stays listed, not cleared, while the ledger holds other rows")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Builds on #1234 (https://github.com/romp-on/romp/pull/1234, merged): this branch is cut from its head and adds one commit; the change to review is the last commit. #1234 fixed the compaction's copy from then on and named what it left: an archive the compaction wrote before it keeps the copied "completed" for a root only cleared.jsonl cleared, so that top stays listed until restored and cleared again. This closes that.

## Symptom

Under Show completed, a top the user cleared stays listed, struck through, with its subtree, when the compaction archived it before #1234: its clear survived only in cleared.jsonl, the compaction re-sealed the root and copied the pre-rollup "completed". The same row appears for a completion the rollup derived without a verdict (an umbrella, a settled store) whose root the ledger later cleared, among them a root whose completion was derived and whose flag a pass save erased before compactions re-sealed such roots (copied "completed", flag off, ledger row present); a root with its own done verdict keeps nodeComplete through that erasure and is not this case. A clear on the live card takes such a top off the list; #1187 states that as the intended outcome.

## Cause

`_fleet_archived_tops` qualifies an archived root by nodeComplete, a copied status of "completed", or a summary, and `_ledger_cleared_overlay` only marks a cleared root (and its subtree) cleared; it never drops a row. A re-sealed root's nodeComplete is False (the clear verdict's derivation), so the copied "completed" was its only qualification, and the overlay left it listed as done and cleared: the struck-through row. Nothing rewrites an archived status, nothing prunes the ledger, so the row persisted on every build.

## Fix

In `_ledger_cleared_overlay`, a depth-0 row that is cleared (copied flag or ledger row), whose `done` is derived, and that carries no summary (whitespace counts as none, as the qualification reads it) is dropped, and the descendant rows that follow it in the flat list go with it. The docstring carries the reasoning: a cleared flag rolls up to status cleared (`rollup_status` gives it precedence), so a copied "completed" beside a clear is a stale copy, not a completion; a live-card clear would have rolled the top to cleared before the copy and it would never have qualified. At depth 0 `derived` means the copied status or a summary and never an ancestor, so derived with no summary is status-only. The drop sits behind the overlay's existing early return, so it acts only while the ledger holds a live row; every such root has its own (the re-seal requires it, an undo removes the row and restores the node, nothing prunes the file). No payload field, no archive rewrite, no cache change; the cached rows are read, never mutated. One sentence at the end of `_fleet_archived_tops`'s docstring names the exclusion.

Two design points, stated so the choice is visible:

- A root completed by its own verdict (nodeComplete) that the ledger clears keeps the behaviour #1187 pinned: listed, struck through, subtree rolled down. #1187's body says a cleared completed top leaves the completed projection altogether; this change narrows to roots whose only completion is the copied status, so that test stays as written. One consequence: a clear taken from Show completed on an already archived top (ledger-only, since no live node exists) now has two outcomes by completion source: a verdict-completed root is struck through, a rollup-completed one (an umbrella, a settled store) disappears. Dropping every cleared archived root would match #1187's sentence literally, make the two agree, and change that test; say so if that is the preferred reading.
- A cleared top that carries a distiller takeaway stays listed, struck through, on every path today: `_distill_session` stamps completed tops and skips cleared ones, so a takeaway written before the clear persists, and the top qualifies through its summary whatever its status. That holds for older archives and for a live-card clear after #1234 (whose test's top has no summary). This change leaves that case as it is, so the archive matches the live-card path; the second test pins it. Dropping such tops would change the qualification rule itself, a separate decision.

Known limit: the drop runs after the projection's cap (`topids[:cap]`, cached by archive mtime), so a session whose most recent capped tops are all stale copies shows fewer rows than the cap while older completions stay behind it. Before this change those slots held the struck-through rows, so nothing visible is lost; moving the drop ahead of the cap would put the ledger in the cache key, a separate change.

## Tests

`tests/test_kernel_goal_compaction.py`, `ClearedLedgerIsAuthoritativeAcrossTheCompaction`, two methods appended after the class's last test:

- `test_an_archive_from_before_the_reseal_fix_does_not_list_a_status_only_root_the_ledger_clears`: writes the older archive shape directly (root g10 with the flag on, nodeComplete False and status "completed"; its child g10a; a control root g11 with nodeComplete True and status "completed"), reads the projection with an empty ledger (both roots list; the cache is primed), appends clear rows for both roots, and reads again cached and then with every in-process memo dropped. Asserts only g11 lists and reads cleared; g10 and g10a are gone; the first read's rows still hold g10 (the cached rows are not mutated). Before the change the second read lists g10, g10a and g11, g10 with done True and cleared True: the struck-through row.
- `test_only_a_status_only_root_is_dropped_a_takeaway_or_its_own_verdict_keeps_the_row`: five roots newest first: g12 with the flag off, status "completed", a whitespace summary and a ledger row (the erased-flag shape), with a child; g13 cleared with a summary and no status; g14 with nodeComplete True, nothing clearing it, with a child; g15 with status "completed", no flag and no ledger row, with a child; g16 with the flag on, status "completed" and no ledger row, with a child. Asserts the rows are exactly g13, g14, g14a, g15, g15a; g13 reads cleared; g14, g14a, g15 and g15a do not. Before the change the rows begin with g12 and g12a and end with g16 and g16a. g15 pins the cleared condition itself (an uncleared status-only root stays listed while the ledger holds other rows); g16 pins the copied-flag arm (dropped with no ledger row, and the drop of the last root runs to the end of the list); g12's whitespace summary pins that whitespace is not a takeaway.

Both fail before the change on the parent commit's `kernel/kernel.py` and pass after it. Three mutants of the drop condition (the cleared factor removed, the copied flag ignored, the whitespace strip removed) each fail the second test. The existing pins pass unchanged: `test_the_projection_reads_the_ledger_over_the_copied_flag_after_its_cache` (a nodeComplete root the ledger clears stays listed, cleared), `tests/test_fleet_archived_tops.py::test_status_completed_counts_as_done` and `test_mtime_cached` (both run with an empty ledger and pin the overlay's early return: the cached list object is returned as is).

Full suite on 6a83506e (pytest -q -n 8 tests/): 10566 passed, 115 skipped, 1 failed, 1688 subtests passed. The one failure, `tests/test_kernel_webpush.py::LandingRevealOffers::test_no_offer_for_the_session_already_in_front`, passes alone on the same tree and reads none of the two functions this change touches (the landing-reveal offer of the push notifier; a parallel-ordering interaction inside that module).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)