### PR TITLE
Timeline: the live edge glides in 0.15 px moves, the loop waking only when there is a move to make

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -511,14 +511,19 @@ const MAX_INTERP_AHEAD = 150;  // seconds the edge may glide past the last data.
                                // the kernel's 60 s repost of an unchanged frame (a quiet board sends nothing
                                // sooner, since 2026-09-04 the skeleton dedups too), so a healthy kernel never
                                // stalls the edge; a dead one is announced by the socket, not by this cap
-// The live edge advances in whole-pixel steps: the loop looks once the edge could have moved this far at the
-// current zoom (see _liveWaitMs, 100-2000 ms between looks) and moves the plot then — one translate on the
-// plot group plus a width per live-edge rider (_tickTranslate), where a look used to rebuild the whole SVG.
-// Before the pacing it was 0.15 px on every animation frame: a full rebuild about twice a second at a one-hour
-// window, on the main thread every pane shares, which is what a chat tab click waited behind (measured
-// 2026-09-04). A smoother glide is now a pacing choice (a smaller step, a shorter sleep), not a rebuild cost;
-// the pacing stays at a whole pixel.
+// Two guards pace the live edge (see _tickLive). LIVE_MIN_PX paces the look that must REBUILD: a build that left
+// the tick no plot group to translate (a glyph rides the live edge) looks again once the edge could have moved a
+// whole pixel at the current zoom (_liveWaitMs, 100-2000 ms between looks) and redraws then. Before the pacing it
+// was 0.15 px on every animation frame: a full rebuild about twice a second at a one-hour window, on the main
+// thread every pane shares, which is what a chat tab click waited behind (measured 2026-09-04).
 const LIVE_MIN_PX = 1;
+// TICK_MIN_PX paces the TRANSLATE (_tickTranslate: one transform write on the plot group the build left, plus a
+// width per live-edge rider): the loop looks again once the edge could have moved this far (_tickWaitMs), which at
+// a narrow window is the next animation frame and at a wide one a short sleep, and the look writes the frame once
+// the edge has moved at least this far. Small, so the glide is smooth at high zoom (a move every frame); above zero,
+// so a zoomed-out edge sleeps between the moves (at a one-hour window, a move about once or twice a second). A glide
+// is a smaller step and a shorter sleep, not a rebuild cost; the rebuild keeps its whole pixel.
+const TICK_MIN_PX = 0.15;
 function perfNow() { return (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now(); }
 function interpNow(baseSec, baseMs, nowMs, live, maxAheadSec) {
   if (!live || baseMs == null) return baseSec;
@@ -1891,10 +1896,11 @@ class TimelinePanel {
   // node (no offsetParent) so the loop doesn't spin for an invisible pane. False-negative just degrades
   // to per-poll redraw (no interpolation), never breaks.
   _isVisible() {
-    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return false;
+    if (this._tabHidden()) return false;
     const w = this.wrap;
     return !!(w && w.offsetParent !== null);
   }
+  _tabHidden() { return typeof document !== 'undefined' && document.visibilityState === 'hidden'; }
   // Out of sight, for the PAINT hold in update()/applyBars() (2026-09-07)? Says "hidden" only for a reason
   // whose RELEASE event is wired: the tab's visibilityState always (visibilitychange); the pane's own layout
   // (offsetParent null — a display:none iframe, a hidden Obsidian leaf) only where the IntersectionObserver
@@ -1943,13 +1949,15 @@ class TimelinePanel {
   // Arm the rAF loop (no-op if already running or not currently live+visible). Re-armed each poll by
   // update(), so even after the loop self-stops it returns within one poll once we're live again. NOT
   // called from draw() — draw() runs inside the tick, and re-arming there would double the loop.
-  // The live-follow loop: a look (a translate if the edge moved LIVE_MIN_PX, a draw where a translate cannot
-  // express the frame; see _tickLive), then a sleep sized to the edge's speed, then the next look on an
-  // animation frame. Restarted by update()/applyBars() (each frame re-paces it: a pending sleep computed for
-  // the old zoom or data is dropped), by gestures, and by the pointer release when a look was skipped under a
-  // held pointer. Hidden pane: the loop STOPS (its old 2 s sleep re-entered _isVisible()'s forced offsetParent
-  // layout every wake, for a pane nobody could see — 2026-09-07) and the paint hold's release
-  // (_releasePaintHold) re-arms it; not live-following: it stops until a gesture pins the edge again.
+  // The live-follow loop: a look (a translate if the edge moved TICK_MIN_PX, a draw where a translate cannot
+  // express the frame; see _tickLive), then a sleep sized to the edge's speed, then the next look on an animation
+  // frame: TICK_MIN_PX's worth while the build left a plot group to translate (_tickWaitMs, within a frame at a
+  // narrow window), a whole pixel's when the look had to rebuild and got no handle (_liveWaitMs). Restarted by
+  // update()/applyBars() (each frame re-paces it: a pending sleep computed for the old zoom or data is dropped), by
+  // gestures, and by the pointer release when a look was skipped under a held pointer. Hidden pane: the loop STOPS
+  // (its old 2 s sleep re-entered _isVisible()'s forced offsetParent layout every wake, for a pane nobody could
+  // see, 2026-09-07) and the paint hold's release (_releasePaintHold) re-arms it; not live-following: it stops
+  // until a gesture pins the edge again.
   _startLiveTick() {
     if (!this._liveFollowing() || !this._isVisible()) return;
     if (this._liveRAF != null) return;                                        // a look is already imminent
@@ -1959,29 +1967,49 @@ class TimelinePanel {
   _sleep(ms) {
     this._liveTO = setTimeout(() => { this._liveTO = null; this._liveRAF = requestAnimationFrame(() => this._tickLive()); }, ms);
   }
-  // How long until the live edge has moved LIVE_MIN_PX at the current zoom — the loop sleeps exactly that
-  // long between looks instead of waking every animation frame. A look is a translate now (_tickTranslate; it
-  // was a full redraw) and the pacing is unchanged: at a one-hour window over a few hundred px that is a look
-  // every several seconds, not two a second; and the sleeping loop touches no layout (the old per-frame
-  // _isVisible() read forced one — measured 2026-09-04: ~40% of the main thread on an idle four-pane
-  // dashboard, on the thread the chat pane's clicks share).
+  // How long until the live edge has moved LIVE_MIN_PX at the current zoom: the loop sleeps exactly that long
+  // between looks that must REBUILD (the build left no plot group to translate; see _tickLive) instead of
+  // rebuilding on every animation frame. At a one-hour window over a few hundred px that is a rebuild every
+  // several seconds, not two a second; and the sleeping loop touches no layout (the old per-frame _isVisible()
+  // read forced one, measured 2026-09-04: ~40% of the main thread on an idle four-pane dashboard, on the thread
+  // the chat pane's clicks share). A look with a plot group is a translate, paced by _tickWaitMs.
   _liveWaitMs() {
     const g = this._geom;
     if (!g || !g.winSec || !g.plotW) return 1000;
     const pxPerSec = g.plotW / g.winSec;
     return Math.max(100, Math.min(2000, Math.round(LIVE_MIN_PX / Math.max(pxPerSec, 1e-6) * 1000)));
   }
+  // How long until the live edge has moved TICK_MIN_PX at the current zoom: the sleep between translate looks, a
+  // smaller step and a shorter sleep than the rebuild's, with nothing touched in between. Under a frame at a narrow
+  // window (a one-minute window over 1300 px: 7 ms), so the look lands on the next animation frame and the edge
+  // glides every frame; about 70 ms at ten minutes over that width; about 0.4 s at an hour. Where the edge does not
+  // move on screen the rebuild's wait applies: inside a collapsed trailing gap, and once the clock has reached the
+  // interpolation cap (MAX_INTERP_AHEAD: a kernel quiet that long has stopped the edge until the next frame, which
+  // re-anchors the clock and re-paces the loop), so a stopped edge is not looked at every frame.
+  _tickWaitMs() {
+    const g = this._geom, tp = this._tickPlot;
+    if (!g || !g.winSec || !g.plotW || (tp && tp.trailing)) return this._liveWaitMs();
+    if (this._nowBaseMs != null && perfNow() - this._nowBaseMs >= MAX_INTERP_AHEAD * 1000) return this._liveWaitMs();
+    return Math.min(2000, Math.round(TICK_MIN_PX / Math.max(g.plotW / g.winSec, 1e-6) * 1000));
+  }
   _tickLive() {
     this._liveRAF = null; this._liveTO = null;
     if (!this._liveFollowing() || !this.data) return;          // gate closed → stop; a gesture or a frame re-arms
-    if (!this._isVisible()) return;                             // hidden pane: stop; _releasePaintHold re-arms when it shows (no 2 s layout poll)
+    // Can the pane be seen? Once the wrap's IntersectionObserver has spoken, its last word (_paneIntersecting) and
+    // the tab's state answer without a layout read: a translate look can run on every animation frame, and
+    // _isVisible()'s offsetParent read forces a style recalc or a layout whenever the tree is dirty (a lane's
+    // working pulse dirties style every frame). A pane out of view stops the loop as a hidden one always did, and
+    // the observer's next word re-arms it (_releasePaintHold). Without the observer, or before its first word, the
+    // read the loop always made.
+    if (this._paneIntersecting !== null) { if (!this._paneIntersecting || this._tabHidden()) return; }
+    else if (!this._isVisible()) return;                        // hidden pane: stop; _releasePaintHold re-arms when it shows (no 2 s layout poll)
     // Click-safe: don't rebuild the SVG under a pressed pointer (a click in progress). The release event
     // (_release) restarts the loop — no polling for it. See the constructor.
     if (this._pointerHeld) { this._liveResume = true; return; }
     const g = this._geom, nowS = this._liveNow();
     // The look MOVES the view, it does not rebuild it: the last full build left a plot group and its live-edge
     // riders (draw(), `_tickPlot`), and advancing the edge is one transform write on that group plus a width write
-    // per rider — _tickTranslate, which also owns the LIVE_MIN_PX guard, in COMPRESSED movement (inside a
+    // per rider: _tickTranslate, which also owns the sub-pixel guard (TICK_MIN_PX), in COMPRESSED movement (inside a
     // collapsed trailing gap the edge does not move on screen at all, where a real-seconds guard redrew for
     // nothing). The full draw() stays for what a translate cannot express — no build yet, a glyph riding the live
     // edge, the next gridline entering the window, a drift into the gutter, never for the clock's advance. A
@@ -1994,10 +2022,14 @@ class TimelinePanel {
     if (!g || this._lastLiveNow == null) this.draw();
     else if (!tp || !tp.g || !tp.g.parentNode) { if ((nowS - this._lastLiveNow) / g.winSec * g.plotW >= LIVE_MIN_PX) this.draw(); }
     else if (!this._tickTranslate(nowS)) this.draw();
-    this._sleep(this._liveWaitMs());
+    // The next look, after a sleep sized to the edge's speed. With a plot group to translate: TICK_MIN_PX's worth
+    // (_tickWaitMs; within a frame at a narrow window, so the edge glides every frame there). With none (a glyph
+    // rides the live edge, so the next look must rebuild too): a whole pixel's (_liveWaitMs), so a rebuild never
+    // runs on every frame.
+    this._sleep(this._tickPlot ? this._tickWaitMs() : this._liveWaitMs());
   }
   // Advance the live edge to `nowS` by moving the plot group (see draw()'s plot group and `_tickPlot`). Returns
-  // true when the frame is expressed — including the no-op of a sub-LIVE_MIN_PX move, or no movement in
+  // true when the frame is expressed, including the no-op of a sub-TICK_MIN_PX move, or no movement in
   // compressed time (a collapsed trailing gap) — and false when only a full draw() can: no handle (the loader, or
   // a glyph riding the live edge was drawn); the clock has reached the next axis gridline (`nextTick`: nothing is
   // pre-drawn outside the window, so an entering gridline and its clock ARE a rebuild, and the build dated the
@@ -2005,8 +2037,8 @@ class TimelinePanel {
   // it every 60 s, so a quiet board would otherwise show a stale axis for up to a minute); or the drift since the
   // build has reached the gutter gap (no frame has rebuilt since — a quiet or disconnected kernel). The window
   // geometry the handlers read (_geom's cT0/t0/t1, the held right edge) follows the move, so a pan or a focus
-  // jump begun between builds starts from what is on screen, and the hover re-arms as after a rebuild: the
-  // content moved under a pointer that did not.
+  // jump begun between builds starts from what is on screen, and the hover re-arms once per whole pixel of drift,
+  // as after a rebuild: the content moved under a pointer that did not.
   _tickTranslate(nowS) {
     const tp = this._tickPlot, g = this._geom;
     if (!tp || !g || !tp.g || !tp.g.parentNode) return false;
@@ -2015,7 +2047,8 @@ class TimelinePanel {
     const px = dc * tp.k;
     if (px < 0 || px >= tp.maxDrift) return false;
     this._lastLiveNow = nowS;
-    if (Math.abs(px - tp.applied) < LIVE_MIN_PX) return true;   // the sub-pixel guard: nothing visible to write yet
+    if (Math.abs(px - tp.applied) < TICK_MIN_PX) return true;   // the sub-pixel guard: nothing visible to write yet
+    const prev = tp.applied;
     tp.applied = px;
     tp.g.setAttribute('transform', 'translate(' + (-px) + ' 0)');
     for (const r of tp.riders) { if (r.fn) r.fn(px); else r.el.setAttribute(r.attr, Math.max(r.min || 0, r.base + px)); }   // the build's floor applies to the grown extent, so the frame matches a full draw
@@ -2025,7 +2058,9 @@ class TimelinePanel {
     }
     g.cT0 = tp.cT0 + dc; g.t0 = g.decompress(g.cT0); g.t1 = g.decompress(g.cT0 + g.winSec);
     this._holdReal = g.t1;
-    this._rehover();
+    // The hover re-arm is a hit test (elementFromPoint, a forced layout right after the writes above): once per
+    // whole pixel of drift, the rate the paced look had, not once per frame at a narrow window.
+    if (Math.floor(px) !== Math.floor(prev)) this._rehover();
     return true;
   }
   _stopLiveTick() {

--- a/ui/timeline-live-tick.test.ts
+++ b/ui/timeline-live-tick.test.ts
@@ -3,7 +3,9 @@
 // layout each time (about 40% of the shared main thread on an IDLE dashboard), rebuilt the whole SVG once
 // the edge had crept 0.15 px, and inside each rebuild compared every turn against every message. The chat pane's tab clicks share
 // that thread, so every one of these landed on the user as click lag. Like the other timeline tests,
-// the wiring is pinned at the source level, and the pure helper is run.
+// the wiring is pinned at the source level, and the pure helpers are run. The look is a translate now
+// (timeline-transform-tick.test.ts executes it): a look with a plot group sleeps only until the edge could have moved
+// TICK_MIN_PX (_tickWaitMs, within a frame at a narrow window), and the look that must rebuild keeps the whole pixel.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -11,11 +13,12 @@ import * as path from "node:path";
 
 const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
 
-test("the live tick sleeps until the edge has moved a whole pixel, instead of waking every frame", () => {
+test("the rebuild look sleeps until the edge has moved a whole pixel; a translate look sleeps until it has moved TICK_MIN_PX", () => {
   assert.match(SRC, /const LIVE_MIN_PX = 1;/);
+  assert.match(SRC, /const TICK_MIN_PX = 0.15;/);
   assert.match(SRC, /_liveWaitMs\(\) \{[\s\S]*?const pxPerSec = g\.plotW \/ g\.winSec;/);
   assert.match(SRC, /_sleep\(ms\) \{\n\s*this\._liveTO = setTimeout\(\(\) => \{ this\._liveTO = null; this\._liveRAF = requestAnimationFrame\(\(\) => this\._tickLive\(\)\); \}, ms\);/);
-  assert.match(SRC, /this\._sleep\(this\._liveWaitMs\(\)\);/);
+  assert.match(SRC, /this\._sleep\(this\._tickPlot \? this\._tickWaitMs\(\) : this\._liveWaitMs\(\)\);/, "a plot group to translate: TICK_MIN_PX's worth; none: the whole pixel's");
   assert.match(SRC, /_stopLiveTick\(\) \{[\s\S]*?clearTimeout\(this\._liveTO\)/, "stopping the loop clears the sleep too");
   assert.match(SRC, /_startLiveTick\(\) \{[\s\S]*?if \(this\._liveRAF != null\) return;[\s\S]*?if \(this\._liveTO != null\) \{ clearTimeout\(this\._liveTO\); this\._liveTO = null; \}/,
     "a restart re-paces a pending sleep (a zoom or a frame changed the geometry) but never doubles an imminent look");
@@ -31,6 +34,24 @@ test("the live wait is bounded and scales with the zoom", () => {
   assert.equal(at(600, 900), 667, "a ten-minute window over 900 px: two thirds of a second");
   assert.equal(at(60, 1800), 100, "zoomed right in: never faster than ten looks a second");
   assert.equal(fn.call({ _geom: null }), 1000, "no geometry yet: a plain second");
+});
+
+test("the translate's wait is TICK_MIN_PX's worth: within a frame at a narrow window, a short sleep at a wide one, the rebuild's inside a trailing gap", () => {
+  const m = /  _tickWaitMs\(\) \{([\s\S]*?)\n  \}/.exec(SRC);
+  assert.ok(m, "the translate's pacing helper exists");
+  const TICK_MIN_PX = 0.15, MAX_INTERP_AHEAD = 150, NOW_MS = 1_000_000;
+  const fn = new Function("TICK_MIN_PX", "MAX_INTERP_AHEAD", "perfNow", "return function(){" + m![1] + "}")(TICK_MIN_PX, MAX_INTERP_AHEAD, () => NOW_MS) as () => number;
+  const at = (winSec: number, plotW: number, trailing = false, sinceFrameMs = 0) =>
+    fn.call({ _geom: { winSec, plotW }, _tickPlot: { trailing }, _nowBaseMs: NOW_MS - sinceFrameMs, _liveWaitMs: () => 777 });
+  assert.equal(at(60, 1300), 7, "a one-minute window over 1300 px: 7 ms, under a frame, so the next animation frame");
+  assert.equal(at(600, 1300), 69, "a ten-minute window: about 70 ms, a dozen moves a second");
+  assert.equal(at(3600, 1300), 415, "a one-hour window: about twice a second");
+  assert.equal(at(43200, 450), 2000, "zoomed right out: capped at two seconds, like the rebuild's wait");
+  assert.equal(at(600, 1300, true), 777, "inside a collapsed trailing gap the edge does not move: the rebuild's wait");
+  assert.equal(at(600, 1300, false, 149_000), 69, "a kernel quiet for 149 s: the edge still glides toward the cap");
+  assert.equal(at(600, 1300, false, 150_000), 777, "at the interpolation cap (150 s) the edge stands still: the rebuild's wait");
+  assert.equal(at(60, 1300, false, 400_000), 777, "and stays so however narrow the window, until the next frame re-anchors the clock");
+  assert.equal(fn.call({ _geom: null, _tickPlot: null, _liveWaitMs: () => 777 }), 777, "no geometry yet: the rebuild's wait");
 });
 
 // (A skeleton and its bars frame are two draws: update()/applyBars() draw synchronously while the pane can be

--- a/ui/timeline-transform-tick.test.ts
+++ b/ui/timeline-transform-tick.test.ts
@@ -97,7 +97,7 @@ test("a tick moves the plot group by a transform and creates no element; the ope
   const closedBar = plotOf(panel).children.find((c: any) => c.tag === "rect" && c._attrs.fill === "#7aa2f7" && widthOf(c) !== w0 && !tp.riders.some((r: any) => r.el === c));
   assert.ok(closedBar, "a closed bar is in the plot group and is not a rider");
   const cw0 = widthOf(closedBar);
-  advance(panel, 10);   // a whole pixel and a half at this zoom: past LIVE_MIN_PX
+  advance(panel, 10);   // a whole pixel and a half at this zoom: well past TICK_MIN_PX
   const before = created;
   tick(panel);
   assert.equal(created, before, "the tick created no element: no rebuild");
@@ -112,8 +112,8 @@ test("a tick moves the plot group by a transform and creates no element; the ope
   assert.equal(panel._holdReal, panel._geom.t1);
 });
 
-test("a move under LIVE_MIN_PX writes nothing; the translate is measured from the build, not the last tick", () => {
-  const panel = livePanel(liveData(), 43200);   // 12 h: 0.1 s is far under a pixel
+test("a move under TICK_MIN_PX writes nothing; the translate is measured from the build, not the last tick", () => {
+  const panel = livePanel(liveData(), 43200);   // 12 h: 0.1 s is a thousandth of a pixel, far under the guard
   advance(panel, 0.1);
   const before = created;
   tick(panel);
@@ -343,16 +343,18 @@ test("a gridline entering the window gets its full draw: the tick translates unt
   assert.equal(panel._tickPlot.applied, 0);
 });
 
-test("sub-pixel looks add up: the drift is measured from the build, not the last look, so the edge advances once they reach a pixel", () => {
-  // a 12 h window: a 5 s look is a fraction of a pixel, under LIVE_MIN_PX every time. Re-basing the drift on each
-  // look would leave the edge stuck at any zoom where one look is under a pixel; measured from the build, the
-  // looks accumulate and the first whose drift reaches a pixel writes it.
+test("sub-pixel looks add up: the drift is measured from the build, not the last look, so the edge advances once they reach the guard", () => {
+  // a 12 h window: a 5 s look is a sixteenth of a pixel, under the translate's guard (TICK_MIN_PX, 0.15 px) every
+  // time. Re-basing the drift on each look would leave the edge stuck at any zoom where one look is under the
+  // guard; measured from the build, the looks accumulate and the first whose drift since the last write reaches
+  // the guard writes it.
+  const GUARD = 0.15;
   const panel = livePanel(liveData(), 43200);
   const tp = panel._tickPlot, step = 5 * panel._geom.plotW / panel._geom.winSec;   // px per 5 s look
-  assert.ok(step < 0.2, "one look is well under a pixel: " + step);
-  const expected: number[] = [];   // the writes a drift measured from the build makes: each the first look a pixel past the last write
-  for (let i = 1, last = 0; i <= 20; i++) { const d = i * step; if (d - last >= 1 - 1e-9) { expected.push(d); last = d; } }
-  assert.ok(expected.length >= 1, "20 looks reach a pixel at this zoom");
+  assert.ok(step < GUARD, "one look is under the guard, so no single look writes: " + step);
+  const expected: number[] = [];   // the writes a drift measured from the build makes: each the first look a guard's worth past the last write
+  for (let i = 1, last = 0; i <= 20; i++) { const d = i * step; if (d - last >= GUARD - 1e-9) { expected.push(d); last = d; } }
+  assert.ok(expected.length >= 3, "20 looks cross the guard several times at this zoom: " + expected.length);
   const before = created, writes: number[] = [];
   for (let i = 1; i <= 20; i++) {
     advance(panel, 5 * i);
@@ -360,7 +362,7 @@ test("sub-pixel looks add up: the drift is measured from the build, not the last
     if (tp.applied !== (writes.length ? writes[writes.length - 1] : 0)) writes.push(tp.applied);
   }
   assert.equal(created, before, "no look rebuilt");
-  assert.ok(tp.applied >= 1, "the looks added up and the edge moved: applied " + tp.applied);
+  assert.ok(tp.applied >= 1, "the looks added up and the edge moved a whole pixel: applied " + tp.applied);
   assert.equal(writes.length, expected.length, "writes: " + writes.join(", ") + " vs " + expected.join(", "));
   writes.forEach((w, i) => assert.ok(Math.abs(w - expected[i]) < 0.05, "write " + i + ": " + w + " vs " + expected[i]));
   assert.equal(plotOf(panel).getAttribute("transform"), "translate(" + (-tp.applied) + " 0)");
@@ -470,4 +472,155 @@ test("the focus pulse's step stops once a rebuild detached its group", () => {
   } finally {
     g.requestAnimationFrame = raf;
   }
+});
+
+// The glide: a translate look sleeps only until the edge could have moved TICK_MIN_PX (within a frame at a narrow
+// window, so the next animation frame; the rebuild look keeps its whole-pixel sleep), and writes the frame once the
+// edge has moved that far, so at a ten-minute window the edge moves about a dozen times a second by 0.15 px instead
+// of stepping a whole pixel about twice a second. Two costs a look this frequent would otherwise pay are tested with
+// it: the visibility check reads the observer's word, not layout, and the hover re-arm (a hit test) runs once per
+// whole pixel of drift.
+test("a translate look sleeps TICK_MIN_PX's worth: within a frame at a one-minute window, a fraction of a second at ten; a look the build left no handle for sleeps the whole pixel", () => {
+  const waits: number[] = [];
+  const panel = livePanel(liveData(), 600);
+  panel._sleep = (ms: number) => { waits.push(ms); };
+  advance(panel, 1.5);   // about 1.35 px at this zoom: past a whole pixel, well under the drift cap
+  const before = created;
+  panel._tickLive();
+  assert.equal(created, before, "the look was a translate");
+  assert.ok(panel._tickPlot.applied >= 1, "applied " + panel._tickPlot.applied);
+  const want = Math.round(0.15 * panel._geom.winSec / panel._geom.plotW * 1000);   // ms per 0.15 px at this zoom
+  assert.ok(want > 100 && want < 300, "a ten-minute window over this plot: about a sixth of a second per 0.15 px: " + want);
+  assert.deepEqual(waits, [want], "the next look comes when the edge could have moved TICK_MIN_PX, not a whole pixel");
+  assert.ok(want < panel._liveWaitMs(), "shorter than the rebuild's wait: " + panel._liveWaitMs());
+  // a one-minute window: 0.15 px is under a frame, so the look is on the next animation frame
+  const narrow = livePanel(liveData(), 60);
+  const nwaits: number[] = []; narrow._sleep = (ms: number) => { nwaits.push(ms); };
+  advance(narrow, 0.05);   // about half a pixel
+  narrow._tickLive();
+  assert.ok(narrow._tickPlot.applied > 0.15 && narrow._tickPlot.applied < 1, "a sub-pixel translate: " + narrow._tickPlot.applied);
+  assert.equal(nwaits.length, 1);
+  assert.ok(nwaits[0] <= 17, "within a frame: " + nwaits[0] + " ms");
+  // a build that left no handle (a glyph rides the live edge): the look is a full draw or nothing, and the next
+  // look waits a whole pixel's worth (_liveWaitMs), as before
+  const data = liveData();
+  data.messages = [{ id: "m1", fromId: SID2, toId: SID1, from: "api", to: "web", sent: NOW - 100, exec: NOW - 100, pending: true, text: "please review" }];
+  const held: any = new TimelinePanel(makeNode("div"));
+  held._lockNow = true; held._pinned = true; held._winSec = 600; held.fitted = true;
+  held.update(data);
+  assert.equal(held._tickPlot, null, "no handle");
+  const hwaits: number[] = []; held._sleep = (ms: number) => { hwaits.push(ms); };
+  advance(held, 1.5);
+  held._tickLive();
+  assert.deepEqual(hwaits, [held._liveWaitMs()], "the rebuild look sleeps the whole pixel");
+  assert.ok(hwaits[0] > want, hwaits[0] + " vs " + want);
+});
+
+test("at a ten-minute window a fraction of a second is a visible move: the translate is written under a pixel", () => {
+  const panel = livePanel(liveData(), 600);
+  const tp = panel._tickPlot;
+  advance(panel, 0.6);
+  const want = 0.6 * panel._geom.plotW / panel._geom.winSec;
+  assert.ok(want > 0.3 && want < 1, "the move is a fraction of a pixel: " + want);
+  const before = created;
+  tick(panel);
+  assert.equal(created, before, "a translate, not a rebuild");
+  assert.ok(tp.applied >= 0.15 && tp.applied < 1 && Math.abs(tp.applied - want) < 0.05, "written under a pixel: " + tp.applied + " vs " + want);
+  assert.equal(plotOf(panel).getAttribute("transform"), "translate(" + (-tp.applied) + " 0)");
+  // under the guard nothing is written: at a wide window the edge idles between the frames that move it
+  const wide = livePanel(liveData(), 43200);   // 12 h: a 5 s look is about a sixteenth of a pixel
+  advance(wide, 5);
+  tick(wide);
+  assert.equal(wide._tickPlot.applied, 0, "under TICK_MIN_PX: no write");
+  assert.equal(plotOf(wide).getAttribute("transform"), undefined);
+});
+
+test("a translate look reads no layout once the pane's observer has spoken: its word gates the look and re-arms the loop", () => {
+  const savedIO = g.IntersectionObserver, raf = g.requestAnimationFrame;
+  let io: any = null;
+  g.IntersectionObserver = class { cb: any; constructor(cb: any) { this.cb = cb; io = this; } observe() {} disconnect() {} };
+  let armed = 0;
+  try {
+    const panel = livePanel(liveData(), 600);
+    assert.ok(panel._io && io, "the wrap is observed");
+    let reads = 0;
+    Object.defineProperty(panel.wrap, "offsetParent", { get() { reads++; return {}; }, configurable: true });
+    const sleeps: number[] = []; panel._sleep = (ms: number) => { sleeps.push(ms); };
+    g.requestAnimationFrame = () => { armed++; return 1; };
+    // before the observer's first word the look reads offsetParent, as it always did
+    advance(panel, 0.6); panel._tickLive();
+    assert.equal(reads, 1, "no word yet: the one read");
+    assert.equal(sleeps.length, 1, "a translate: the next look is scheduled");
+    // the observer speaks: from here a look reads no layout
+    io.cb([{ isIntersecting: true }]);
+    reads = 0; sleeps.length = 0;
+    for (let i = 1; i <= 5; i++) { advance(panel, 0.6 + 0.3 * i); panel._tickLive(); }
+    assert.equal(reads, 0, "five translate looks, no layout read");
+    assert.equal(sleeps.length, 5, "each scheduled the next look");
+    assert.ok(panel._tickPlot.applied > 1, "and the edge moved: " + panel._tickPlot.applied);
+    // a hidden tab, the word still saying in view: the look stops without a read, as the hidden branch always did
+    sleeps.length = 0; let applied = panel._tickPlot.applied;
+    g.document.visibilityState = "hidden";
+    advance(panel, 2.3); panel._tickLive();
+    assert.equal(sleeps.length, 0, "hidden tab: no next look scheduled");
+    assert.equal(panel._tickPlot.applied, applied, "nothing written for a tab nobody sees");
+    assert.equal(reads, 0, "and no layout read to find that out");
+    delete g.document.visibilityState;
+    // out of view (display:none, scrolled away): the look stops without a read; the observer's next word re-arms it
+    io.cb([{ isIntersecting: false }]);
+    sleeps.length = 0; applied = panel._tickPlot.applied;
+    advance(panel, 2.5); panel._tickLive();
+    assert.equal(sleeps.length, 0, "stopped: no next look scheduled");
+    assert.equal(panel._tickPlot.applied, applied, "nothing written for a pane nobody sees");
+    assert.equal(reads, 0, "and no layout read to find that out");
+    armed = 0;
+    io.cb([{ isIntersecting: true }]);
+    assert.equal(armed, 1, "back in view: the release re-armed the loop");
+  } finally { g.IntersectionObserver = savedIO; g.requestAnimationFrame = raf; delete g.document.visibilityState; }
+});
+
+test("the hover re-arms once per whole pixel of drift, not on every sub-pixel write", () => {
+  const panel = livePanel(liveData(), 600);
+  const tp = panel._tickPlot;
+  let hits = 0;
+  panel._ptr = { x: 500, y: 40 };
+  panel.svg.ownerDocument = { elementFromPoint: () => { hits++; return null; } };
+  const step = 0.3, looks = 10;   // 3 s: about 2.7 px, under the drift cap
+  assert.ok(looks * step * panel._geom.plotW / panel._geom.winSec < tp.maxDrift, "the run stays under the drift cap");
+  let writes = 0, last = 0, crossings = 0;
+  const before = created;
+  for (let i = 1; i <= looks; i++) {
+    advance(panel, step * i);
+    tick(panel);
+    if (tp.applied !== last) { writes++; if (Math.floor(tp.applied) !== Math.floor(last)) crossings++; last = tp.applied; }
+  }
+  assert.equal(created, before, "every look a translate");
+  assert.equal(writes, looks, "every look wrote: each is about a quarter of a pixel, past TICK_MIN_PX");
+  assert.ok(crossings >= 2, "the drift crossed two whole pixels: " + last);
+  assert.equal(hits, crossings, "one hit test per whole pixel crossed, none for the sub-pixel writes between");
+});
+
+test("once the clock has reached the interpolation cap the edge stands still, and the translate look sleeps the rebuild's wait, not TICK_MIN_PX's", () => {
+  const waits: number[] = [];
+  const panel = livePanel(liveData(), 600);
+  panel._sleep = (ms: number) => { waits.push(ms); };
+  const glide = Math.round(0.15 * panel._geom.winSec / panel._geom.plotW * 1000);   // the translate's sleep while the edge moves
+  advance(panel, 200);   // a kernel quiet for longer than the cap (150 s): the edge has stopped at it
+  const before = created;
+  panel._tickLive();     // the drift since the build is far past the drift cap: this look is a full draw
+  assert.ok(created > before, "the look rebuilt");
+  assert.deepEqual(waits, [panel._liveWaitMs()], "a still edge: the rebuild's wait, not " + glide);
+  waits.length = 0;
+  const applied = panel._tickPlot.applied, before2 = created;
+  panel._tickLive();
+  assert.equal(created, before2, "a translate look");
+  assert.equal(panel._tickPlot.applied, applied, "nothing to write: the edge is at the cap");
+  assert.deepEqual(waits, [panel._liveWaitMs()], "and it sleeps the rebuild's wait, not TICK_MIN_PX's worth (" + glide + ")");
+  assert.ok(waits[0] > glide);
+  // the next frame re-anchors the clock: the edge moves again and the look sleeps TICK_MIN_PX's worth
+  panel.update(liveData(NOW + 200)); panel._stopLiveTick();
+  waits.length = 0;
+  advance(panel, 0.6); panel._tickLive();
+  assert.ok(panel._tickPlot.applied > 0.15, "moving again: " + panel._tickPlot.applied);
+  assert.deepEqual(waits, [glide], "the glide's sleep");
 });


### PR DESCRIPTION
The timeline's live edge moves in 0.15 px steps, as often as every animation frame at a narrow window, instead of stepping a whole pixel once or twice a second at a ten-minute window; the loop still sleeps between moves, waking only when the edge has a move to make, and the look that must rebuild the SVG keeps its whole-pixel pace.

## Tier

Tier: feature

## Why

Under the whole-pixel pacing the now-line and the open bars jump a pixel about twice a second at a ten-minute window, where the live edge moves about two pixels a second over a thousand pixels, and several times a second at a one-minute window. The step comes from `LIVE_MIN_PX = 1`, which paces the live-follow loop and guards the translate look alike. The pacing was set when a look rebuilt the whole SVG; the translate tick (#1060) kept it, and its message called a smoother glide a separate change. This is that change.

## What changes

One commit: `ui/romp-timeline-view.js` inside the live-follow loop and its visibility check, plus its two tests.

- **Two guards, two paces.** `TICK_MIN_PX = 0.15` guards the translate look (`_tickTranslate` writes the frame once the edge has moved that far) and paces it: `_tickWaitMs` is the time the edge takes to move 0.15 px at the current zoom, a few ms at a one-minute window (so the look lands on the next animation frame and the edge glides every frame), about 70 ms at ten minutes over 1300 px, about 0.4 s at an hour, capped at 2 s like the rebuild's wait. `LIVE_MIN_PX = 1` and `_liveWaitMs` keep pacing the look that must rebuild (a build that left no plot group because a glyph rides the live edge), so a rebuild never runs more often than it did; the review guard on that path from #1060 stays. Where the edge does not move on screen the translate look takes the rebuild's wait too: inside a collapsed trailing gap, and once the clock has reached the interpolation cap (`MAX_INTERP_AHEAD`, a kernel quiet for 150 s), until the next frame re-anchors the clock and re-paces the loop; so a stopped edge is not looked at every frame. The loop's tail is one line: `this._sleep(this._tickPlot ? this._tickWaitMs() : this._liveWaitMs())`.
- **The per-look visibility check reads no layout.** A look can now run on every animation frame, and `_isVisible()`'s `offsetParent` read forces a style recalc or a layout whenever the tree is dirty; a working lane's pulse animation dirties style every frame, so the read cost about 100 to 150 us per look in the measurement below (about 240 with four documents). Once the wrap's IntersectionObserver has spoken, `_tickLive` reads its last word (`_paneIntersecting`, the field the pane already keeps for its hidden word, set in its observer callback) and the tab's `visibilityState` instead. A pane out of view (display:none, or scrolled away) or a hidden tab stops the loop as a hidden pane always did, and the observer's next word re-arms it through `_releasePaintHold`. Before the first word, and in a host without the observer, the read the loop always made. `_startLiveTick` (per poll) and `_hiddenForPaint` (the paint hold) are unchanged.
- **The hover re-arm runs once per whole pixel of drift.** `_rehover` is an `elementFromPoint` hit test, which forces a layout right after the translate's writes; under the whole-pixel pacing it ran once per look. It now runs when the drift crosses a whole pixel, the same rate, instead of once per 0.15 px write.

Considered and not done: a loop that runs the translate look on every animation frame while a plot group exists (the "per-frame" column below). It gives the same glide, but wakes 62 times a second at every zoom, including a one-hour window where it writes 2.5 times a second, and the `LIVE_MIN_PX` comment already described a glide as a smaller step and a shorter sleep, which is what this change does. Also not done: reading the observer's word for the paint hold or for `_startLiveTick` (the hold's criteria are unchanged), any change to the drift cap, the gridline hand-back or the no-handle rebuild path, and any browser-side test (the DOM stand-in executes the loop; the browser measurement below is a one-off probe, not a test).

## Measured

At a ten-minute window this change moves the edge 12 times a second by 0.15 to 0.18 px where it moved twice a second by a pixel, wakes the loop only that often, reads no layout per look, and keeps the hover re-arm at 2.2 hit tests a second under a pointer; a loop that looks on every animation frame gives the same glide at 62 wakes a second, a forced style recalc per wake and, under a pointer, a forced layout per write. The table has the figures.

Headless Chromium (Playwright) over the view alone, a synthetic board of 17 lanes (5 working, their open bars riding the edge, 16 past messages), 1600x900, live-following, 10 s windows after a 1.5 s warm-up. A CDP trace (`devtools.timeline` with stacks) counts layouts and marks the ones invoked from script as forced; CDP Performance metrics give script, style and task ms per second; counters wrapped around `_isVisible`, `elementFromPoint`, `_tickTranslate` and `_tickLive` count the loop's own work. Three variants: **before** (main), **per-frame** (the translate look on every animation frame with the 0.15 px guard and no other change: what a naive glide costs), and **this change**. Medians of 3 runs at the ten-minute window and 2 at the others; the machine carried other work during the runs (load average 9 to 19), so the ms/s figures vary by about 10 ms/s between runs, the counts do not. The runs were taken on the main this branch was first cut from; the loop's region of the view is unchanged between that main and the current base. The interpolation-cap wait was added after the runs and engages in none of them (no run is quiet for 150 s).

| window | pointer | variant | wakes/s | moves/s | layout reads/s | hit tests/s | forced layouts/s | layouts/s | script ms/s | task ms/s | long tasks/s |
|---|---|---|---|---|---|---|---|---|---|---|---|
| 1 min | off | before | 8.9 | 6.8 | 8.9 | 0 | 4.2 | 12.8 | 7.1 | 41 | 0 |
| 1 min | off | per-frame | 62.7 | 60.2 | 62.7 | 0 | 4.8 | 64.9 | 15.2 | 80 | 0 |
| 1 min | off | this change | 62.6 | 60.1 | 0 | 0 | 4.8 | 64.7 | 14.9 | 82 | 0 |
| 10 min | off | before | 2.2 | 2 | 2.2 | 0 | 0.4 | 2.6 | 2 | 40 | 0 |
| 10 min | off | per-frame | 62.2 | 12.3 | 62.2 | 0 | 0.5 | 12.6 | 14.1 | 81 | 0 |
| 10 min | off | this change | 12.3 | 12.1 | 0 | 0 | 0.4 | 12.5 | 4.4 | 72 | 0 |
| 10 min | on | before | 2.2 | 2 | 2.2 | 2.2 | 2.5 | 2.6 | 2.6 | 44 | 0 |
| 10 min | on | per-frame | 62.4 | 12.4 | 62.4 | 12.6 | 12.6 | 12.6 | 12.3 | 64 | 0 |
| 10 min | on | this change | 12.4 | 12.2 | 0 | 2.2 | 2.6 | 12.5 | 5.9 | 69 | 0 |
| 1 h | off | before | 0.5 | 0.2 | 0.5 | 0 | 0 | 0.2 | 0.2 | 54 | 0 |
| 1 h | off | per-frame | 61.8 | 2.5 | 61.8 | 0 | 0 | 2.4 | 12.5 | 68 | 0.1 |
| 1 h | off | this change | 2.5 | 2.5 | 0 | 0 | 0 | 2.4 | 0.6 | 53 | 0 |
| 1 h | on | before | 0.5 | 0.2 | 0.5 | 0.2 | 0.2 | 0.2 | 0.3 | 53 | 0 |
| 1 h | on | per-frame | 62.1 | 2.4 | 62.1 | 2.4 | 2.4 | 2.4 | 9.1 | 62 | 0 |
| 1 h | on | this change | 2.5 | 2.5 | 0 | 0.4 | 0.4 | 2.4 | 0.8 | 57 | 0 |

The plot is 1304 px wide in these runs. Wakes are `_tickLive` calls; moves are translate writes; layout reads are `_isVisible()` calls (each an `offsetParent` read); hit tests are `elementFromPoint` calls; forced layouts are the trace's Layout events invoked from script; the 1 min "before" row's forced layouts are the full draws its drift cap hands back to every 0.4 s, the same in every variant. The per-frame loop with this change's two mitigations was measured too: it keeps the 62 wakes a second at every window and 8.1 ms/s of script at ten minutes, 5.8 at an hour, which is what the sleep sized to the step removes.

Reading the table:
- At an hour the edge moves 2.5 times a second; at a minute every frame. The loop wakes at the rate it moves, where the per-frame loop wakes 62 times a second at every window.
- The per-frame loop's `offsetParent` read forced a style recalc on every look (62 a second, about 100 to 150 us each: 8 to 12 ms/s of script). This change makes no layout read per look.
- With the pointer resting over the plot, the per-frame loop's hover re-arm forced a layout per write (12.6 a second at ten minutes, 1.9 ms/s); this change makes 2.2 a second, as before.
- Layouts that are not forced are the frame's own, one per write (12.6 a second at ten minutes, about 1.7 ms/s), the cost of moving the plot group that often; style time is unchanged (the pulse animation's); no long task in any run of this change.
- Four panes (a shell of four same-origin iframes each holding the board, pointer on one): at the shell's 504 px plots and a ten-minute window, single runs: before 2.6 wakes/s, 2.6 layout reads/s, 2.8 ms/s of script, 11.7 ms/s of style, 115 ms/s of task time; per-frame 184 wakes/s, 184 layout reads/s, 54.6 ms/s of script, 13.8 ms/s of style, 186 ms/s of task time (each read about 240 us with four documents); this change 16.8 wakes/s, 0 layout reads/s, 5.4 ms/s of script, 12.1 ms/s of style, 119 ms/s of task time. The pointer leg registered no hit tests in the shell for any variant, so the shell run measures nothing about the hover re-arm.

## Not included

No change to `ui/webview`, to the kernel, or to docs (nothing under `docs/` describes the loop's pacing). No persisted setting: the step is a constant, as the whole pixel was.

## Tests

- `ui/timeline-transform-tick.test.ts`, five new cases executed over the DOM stand-in with the real `TimelinePanel`:
  - *a translate look sleeps TICK_MIN_PX's worth: within a frame at a one-minute window, a fraction of a second at ten; a look the build left no handle for sleeps the whole pixel*. Before: the translate look sleeps the whole pixel's worth (1111 ms at the stand-in's ten-minute window, not 167).
  - *at a ten-minute window a fraction of a second is a visible move: the translate is written under a pixel*. Before: a 0.6 s advance (about 0.54 px) writes nothing; a 5 s advance at a 12 h window still writes nothing after.
  - *a translate look reads no layout once the pane's observer has spoken: its word gates the look and re-arms the loop*. A counting `offsetParent` getter on the wrap and a fake observer: one read before the first word, zero over five translate looks after it; a hidden tab stops the loop without a read; the word `false` stops it without a read and `true` re-arms it. Before: every look reads, and the word gates nothing. Dropping the tab check from the observer branch fails this case.
  - *the hover re-arms once per whole pixel of drift, not on every sub-pixel write*. Ten quarter-pixel looks under a tracked pointer: ten writes, two whole-pixel crossings, two hit tests. Before: two of the ten looks write (the case fails on the write count); a per-frame glide without the bound makes ten hit tests.
  - *once the clock has reached the interpolation cap the edge stands still, and the translate look sleeps the rebuild's wait, not TICK_MIN_PX's*. A 200 s advance at a ten-minute window: the look after the cap-forced rebuild, and the translate look after it, both sleep `_liveWaitMs()` (1111 ms here) with nothing written; a fresh frame re-anchors the clock and the next look sleeps 167 ms again. Without the cap check the translate look sleeps 167 ms with the edge stopped.
  - *sub-pixel looks add up* now expects the writes a 0.15 px guard makes over twenty 5 s looks at a 12 h window (six; before: one), and *a move under TICK_MIN_PX writes nothing* is the retitled whole-pixel case. *a look the build left no handle for still honours LIVE_MIN_PX* is unchanged and green: the rebuild path keeps its guard.
- `ui/timeline-live-tick.test.ts`: the pacing case pins `TICK_MIN_PX` and the loop's tail; a new case runs `_tickWaitMs` out of the source: 7 ms at a one-minute window over 1300 px, 69 at ten minutes, 415 at an hour, the 2 s cap when zoomed out, the rebuild's wait inside a trailing gap, without geometry, and once the clock is 150 s past its anchor (69 ms at 149 s).
- Before the change 8 of the 30 cases in the two files fail (the six `timeline-transform-tick` cases named above, and `timeline-live-tick`'s pacing pin and `_tickWaitMs` cases), 22 pass; after, 30 pass. All 30 `ui/timeline-*.test.ts` files: 346 pass, including `ui/timeline-hidden-hold.test.ts`, whose pins on `_tickLive`'s hidden branch and `_hiddenForPaint` hold. `npm run typecheck` clean. `npm test` under `vscode-extension` on this branch (main at 82dd9e9c plus this commit): 4058 tests, 4058 pass, 0 fail, 0 skipped, the browser legs included (a Playwright Chromium is installed on the machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
