### PR TITLE
Markdown images: the served-URL probe budget follows the URL, so a turn re-rendered while it streams keeps its three attempts, and the reconnect heal probes every remembered URL

### DIFF
--- a/ui/webview/md-img-park.test.ts
+++ b/ui/webview/md-img-park.test.ts
@@ -5,8 +5,13 @@
 // stable caption); sixty pushes write the src zero times; the reconnect-class heal probes each parked URL once OFF the
 // DOM, a failed probe changes nothing, a successful one lands the picture on every parked img with that URL on the
 // page at that moment (a re-render during the probe included); a URL the kernel serves gets a bounded off-DOM probe on
-// the per-message path; and the chat's post-pass parks a re-rendered img with a remembered URL before the browser
-// fetches it. Every test builds its own state.
+// the per-message path, and that budget rides the URL, so a turn re-rendered on every push while it streams still gets
+// its three probes, a second img with the URL failing midway starts nothing over, a load clears the budget with the
+// memory (the URL failing again later starts afresh), and a heal that lands while a probe is pending is not undone by
+// that probe's failure; the reconnect-class heal probes every remembered URL, on the page or not (a turn evicted from
+// the rendered window, a closed tab); and the chat's post-pass parks a re-rendered img with a remembered URL before the
+// browser fetches it. The module remembers failed URLs for the page life, so fresh() heals every remembered URL off
+// the DOM through the public reconnect path before each test: every test starts with an empty memory.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -47,10 +52,18 @@ let fetchCalls = 0;
 (globalThis as any).fetch = () => { fetchCalls++; return Promise.reject(new Error("no fetch expected")); };
 
 const ORIGIN_URL = (n: string) => "http://127.0.0.1:1/home/user/notes-api/plots/" + n;   // a path the browser resolved against the page: no route serves it
-const SERVED_URL = "http://127.0.0.1:1/file?path=%2Fhome%2Fuser%2Fnotes-api%2Fplots%2Flatency.png&sid=11111111-2222-4333-8444-000000000001";
+const servedUrl = (n: string) => "http://127.0.0.1:1/file?path=%2Fhome%2Fuser%2Fnotes-api%2Fplots%2F" + n + "&sid=11111111-2222-4333-8444-000000000001";   // a URL the kernel answers
+const SERVED_URL = servedUrl("latency.png");
 function mdImg(url: string, alt: string): FakeEl { const img = new FakeEl("img"); img.src = url; img.alt = alt; img.srcWrites = 0; live.push(img); return img; }
 const fail = (img: FakeEl) => errorListener!({ target: img });
-async function fresh() { const P = await import("./preview"); P.installMdImgHeal(); assert.ok(errorListener); live.length = 0; probes.length = 0; return P; }
+async function fresh() {
+  const P = await import("./preview"); P.installMdImgHeal(); assert.ok(errorListener);
+  live.length = 0; probes.length = 0;
+  // the module remembers every failed URL for the page life; the reconnect heal probes each remembered URL off the DOM,
+  // and a load forgets it, so one heal with every probe answered clears the memory an earlier test left behind
+  P.refreshSettledPreviews(); for (const p of probes) (p as any).onload(); probes.length = 0;
+  return P;
+}
 
 test("a failed markdown image is parked: no src, the alt text stays, and sixty pushes write the src zero times", async () => {
   const P = await fresh();
@@ -120,6 +133,120 @@ test("a URL the kernel serves gets a BOUNDED off-DOM probe on the per-message pa
   assert.equal(probes.length, 4, "the reconnect-class heal still probes it");
   (probes[3] as any).onload();
   assert.equal(s.src, SERVED_URL, "…and the picture lands when the file is there");
+});
+
+test("a served URL's budget follows the URL: a turn rebuilt on every push while it streams still gets three probes, one per push", async () => {
+  // a streaming assistant turn is re-rendered on every push (the tail path removes the turn's nodes and rebuilds them),
+  // so the img that failed is detached by the time the next push arrives and the post-pass parks a fresh one; the
+  // budget must not die with the element
+  const P = await fresh();
+  const url = servedUrl("throughput.png");
+  let cur = mdImg(url, "Throughput");
+  let twin: FakeEl | null = null;
+  fail(cur);
+  for (let round = 1; round <= 3; round++) {
+    P.retryFailedPreviews();
+    assert.equal(probes.length, round, "push " + round + ": one detached probe");
+    P.retryFailedPreviews();
+    assert.equal(probes.length, round, "a push while that probe is pending fires no second one for the URL");
+    // the streaming re-render: the old img leaves the page, the post-pass parks the fresh one before any fetch
+    cur.isConnected = false;
+    const root = new FakeEl("body"); const next = new FakeEl("img"); next.src = url; next.alt = "Throughput"; root.children.push(next);
+    P.mdImgPostPass(root as unknown as ParentNode);
+    assert.equal(next.hasAttribute("src"), false, "the fresh img is parked at render");
+    next.srcWrites = 0; live.push(next); cur = next;
+    probes[probes.length - 1].onerror();
+    assert.equal(cur.srcWrites, 0, "a failed probe never touches the img on the page");
+    if (round === 2) {
+      // a second img with the URL, rendered before the first failure (the same figure in another view), fails now: the
+      // URL keeps the one attempt it has left rather than starting over at three
+      twin = mdImg(url, "Throughput"); fail(twin);
+      assert.equal(twin.hasAttribute("src"), false, "parked like the first");
+    }
+  }
+  P.retryFailedPreviews(); P.retryFailedPreviews();
+  assert.equal(probes.length, 3, "the budget is spent: no more per-message probes");
+  P.refreshSettledPreviews();
+  assert.equal(probes.length, 4, "the reconnect-class heal still probes it");
+  (probes[3] as any).onload();
+  assert.equal(cur.src, url, "the picture lands on the img that is on the page now");
+  assert.equal(cur.srcWrites, 1);
+  assert.equal(twin!.src, url, "…and on every other parked img with the URL");
+});
+
+test("a per-message probe that loads lands the picture on the img on the page now and clears the URL's budget with its memory; the URL failing again later starts afresh", async () => {
+  const P = await fresh();
+  const url = servedUrl("progress.png");
+  let cur = mdImg(url, "Progress");
+  fail(cur);
+  P.retryFailedPreviews();
+  assert.equal(probes.length, 1, "push 1: one detached probe");
+  // the streaming re-render while the probe is in flight: the old img leaves the page, the fresh one is parked at render
+  cur.isConnected = false;
+  const root = new FakeEl("body"); const next = new FakeEl("img"); next.src = url; next.alt = "Progress"; root.children.push(next);
+  P.mdImgPostPass(root as unknown as ParentNode);
+  assert.equal(next.hasAttribute("src"), false, "the fresh img is parked at render");
+  next.srcWrites = 0; live.push(next); cur = next;
+  (probes[0] as any).onload();                       // the file is there now
+  assert.equal(cur.src, url, "the picture lands on the img that is on the page now");
+  assert.equal(cur.srcWrites, 1);
+  assert.equal(cur._cls.has("md-img-failed"), false);
+  P.retryFailedPreviews(); P.retryFailedPreviews();
+  assert.equal(probes.length, 1, "a healed URL has no pending budget: the next pushes probe nothing");
+  P.refreshSettledPreviews();
+  assert.equal(probes.length, 1, "…and the reconnect heal has forgotten it");
+  // the same URL fails again later (a relay blip, a file moved away): the listener arms three attempts afresh and the
+  // first fires on the next push, nothing of the healed round lingering
+  const again = mdImg(url, "Progress");
+  fail(again);
+  assert.equal(again.hasAttribute("src"), false, "parked again");
+  P.retryFailedPreviews();
+  assert.equal(probes.length, 2, "the URL failing again later gets its per-message probe afresh");
+  assert.equal(probes[1].src, url);
+});
+
+test("a reconnect heal that lands while a per-message probe is pending stands: the stale failure re-arms nothing for the healed URL", async () => {
+  const P = await fresh();
+  const url = servedUrl("burndown.png");
+  const s = mdImg(url, "Burndown");
+  fail(s);
+  s.srcWrites = 0;
+  P.retryFailedPreviews();
+  assert.equal(probes.length, 1, "push 1: the per-message probe is in flight");
+  P.refreshSettledPreviews();                        // the socket came back meanwhile
+  assert.equal(probes.length, 2, "the reconnect heal probes the URL too");
+  (probes[1] as any).onload();                       // the reconnect probe answers first: healed
+  assert.equal(s.src, url, "the picture lands");
+  probes[0].onerror();                               // the older per-message probe's failure arrives afterwards
+  assert.equal(s.src, url, "a stale failure changes nothing on the page");
+  assert.equal(s.srcWrites, 1);
+  P.retryFailedPreviews(); P.retryFailedPreviews();
+  assert.equal(probes.length, 2, "the stale failure re-armed no attempt for a healed URL: the next pushes probe nothing");
+  P.refreshSettledPreviews();
+  assert.equal(probes.length, 2, "…and the reconnect heal has forgotten it");
+});
+
+test("the reconnect-class heal probes a remembered URL whose turn is outside the rendered window", async () => {
+  // the turn left the rendered window (or its tab was closed), so no parked img with the URL is on the page; the
+  // URL is still remembered, and until it heals a scroll-back parks the re-rendered img again for the page life
+  const P = await fresh();
+  const a = mdImg(ORIGIN_URL("evicted.png"), "Evicted");
+  fail(a);
+  a.isConnected = false;
+  P.refreshSettledPreviews();
+  assert.equal(probes.length, 1, "the URL is remembered even with no parked img on the page");
+  assert.equal(probes[0].src, ORIGIN_URL("evicted.png"));
+  probes[0].onerror();
+  probes.length = 0;
+  P.refreshSettledPreviews();
+  assert.equal(probes.length, 1, "still down: the next reconnect probes it again");
+  (probes[0] as any).onload();
+  const root = new FakeEl("body"); const back = new FakeEl("img"); back.src = ORIGIN_URL("evicted.png"); root.children.push(back);
+  P.mdImgPostPass(root as unknown as ParentNode);
+  assert.equal(back.src, ORIGIN_URL("evicted.png"), "on scroll-back the healed URL renders normally");
+  probes.length = 0;
+  P.refreshSettledPreviews();
+  assert.equal(probes.length, 0, "a healed URL is forgotten: the next reconnect has nothing to probe");
 });
 
 test("render.ts installs the listener once, parks known-failed URLs on its OWN markdown output only, and files the page's bundle build once per load", () => {

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -729,6 +729,7 @@ export function previewFull(path: string, sid?: string | null, verified = false,
 // as the manual path and the backstop once a box's bounded auto-retries are spent).
 const failedPreviews = new Map<HTMLElement, () => void>();
 export function retryFailedPreviews(): void {
+  retryMdImgProbes();                                // parked markdown images with attempts left (T291c): the budget rides the URL
   if (!failedPreviews.size) return;
   for (const [box, rebuild] of Array.from(failedPreviews.entries())) {
     failedPreviews.delete(box);                      // one attempt per registration; re-registers on error
@@ -757,15 +758,20 @@ export function refreshSettledPreviews(): void {
 // push rate (T291c, the user 2026-09-09: three captions, two to four lines each, ten times a second). A
 // failed markdown image is PARKED instead: its src leaves (into data-md-src), the element wears
 // .md-img-failed, and the browser shows the alt text as a stable caption: no src, no fetch, nothing to
-// flip. No per-message path exists. The reconnect-class heal (refreshSettledPreviews: romp:wsup, hostUp,
-// romp:hostRelayUp) probes every parked URL once OFF the DOM with a detached Image: a failure changes
-// nothing on screen, a success lands the picture on every parked img with that URL. A URL that failed is
-// remembered for the page life, and the sanitizer post-pass (mdImgPostPass, registered by render.ts) parks
-// a re-rendered img with that URL BEFORE the browser fetches it, so a re-render of the same markdown
-// reuses the state instead of fetching, failing and flipping once more. DOMPurify strips inline handlers
+// flip. No per-message path touches the img on the page: a URL the kernel serves gets a bounded probe OFF the
+// DOM (servedByKernel and retryMdImgProbes, below), every other parked URL waits for a reconnect. A URL that
+// failed is remembered for the page life, and the reconnect-class heal (refreshSettledPreviews: romp:wsup,
+// hostUp, romp:hostRelayUp) probes every remembered URL once OFF the DOM with a detached Image, whether or not
+// an img with it is on the page (a turn evicted from the rendered window, a closed tab): a failure changes
+// nothing on screen, a success lands the picture on every parked img with that URL. The sanitizer post-pass
+// (mdImgPostPass, registered by render.ts) parks a re-rendered img with a remembered URL BEFORE the browser
+// fetches it, so a re-render of the same markdown reuses the state instead of fetching, failing and flipping
+// once more. DOMPurify strips inline handlers
 // (correctly), so the failures are caught by ONE document-level capture listener (error events do not
 // bubble but do capture); previews' own <img>s are skipped: their machinery (budgets, resume, chips) owns those.
 const mdImgFailed = new Set<string>();             // URLs that failed this page life: a re-render parks them before any fetch
+const mdImgProbe = new Map<string, number>();      // served URLs with per-message attempts left: the budget rides the URL, not the img
+const mdImgProbing = new Set<string>();            // served URLs with a per-message probe in flight: one at a time per URL
 let mdImgHealOn = false;
 function parkMdImg(img: HTMLImageElement, url: string): void {
   mdImgFailed.add(url);
@@ -786,7 +792,9 @@ export function mdImgPostPass(root: ParentNode): void {
 }
 /** A URL the kernel actually answers (/file, a remote relay's /file, /media): a file an agent is still writing or a
  *  relay behind a blip may come back with no reconnect event, so those get a BOUNDED probe on the per-message path
- *  (three attempts, off the DOM, so the caption never moves for them); an origin-resolved path no route serves is
+ *  (three attempts, off the DOM, so the caption never moves for them). The budget is keyed on the URL, not on the img
+ *  that failed: a streaming turn is re-rendered on every push, so that img is off the page by the next push and the
+ *  post-pass has parked a fresh one, which inherits the attempts left. An origin-resolved path no route serves is
  *  park-only, since nothing but a reconnect could change its answer. */
 function servedByKernel(u: string): boolean {
   try {
@@ -801,6 +809,7 @@ function probeMdImgUrl(u: string, onFail?: () => void): void {
   const probe = new Image();
   probe.onload = () => {
     mdImgFailed.delete(u);                           // first: a rebuild from here on fetches normally
+    mdImgProbe.delete(u); mdImgProbing.delete(u);    // a healed URL has no pending budget
     for (const img of Array.from(document.querySelectorAll("img.md-img-failed[data-md-src]")) as HTMLImageElement[]) {
       if (img.dataset.mdSrc !== u || !img.isConnected) continue;
       img.classList.remove("md-img-failed");
@@ -811,9 +820,27 @@ function probeMdImgUrl(u: string, onFail?: () => void): void {
   probe.onerror = () => { if (onFail) onFail(); };  // still down: the parked captions stay exactly as they are
   probe.src = u;
 }
-/** The reconnect-class heal for parked markdown images: one detached probe per parked URL. */
+/** The per-message path for the served URLs with attempts left: one detached probe per URL per push, the next armed
+ *  only once the previous has failed (a push while it is pending fires nothing), whatever img carries the URL now and
+ *  whether or not one is on the page (the probe is off the DOM; a load re-queries the page). Run from
+ *  retryFailedPreviews, so it rides the kernel-message event like the figure previews' own retries. */
+function retryMdImgProbes(): void {
+  for (const [u, left] of Array.from(mdImgProbe.entries())) {
+    if (mdImgProbing.has(u)) continue;
+    mdImgProbing.add(u);
+    probeMdImgUrl(u, () => {
+      mdImgProbing.delete(u);
+      if (left > 1 && mdImgFailed.has(u)) mdImgProbe.set(u, left - 1);   // still down: one attempt spent
+      else mdImgProbe.delete(u);                                          // spent (or healed meanwhile): the reconnect heal alone from here
+    });
+  }
+}
+/** The reconnect-class heal for parked markdown images: one detached probe per remembered URL. The remembered set is
+ *  the source, since a URL whose turn left the rendered window or whose tab was closed has no img on the page, and a
+ *  re-render would park it again for the page life; the page's parked imgs are read too, for one parked under a URL
+ *  the memory no longer holds. */
 export function healMdImgs(): void {
-  const urls = new Set<string>();
+  const urls = new Set<string>(mdImgFailed);
   for (const img of Array.from(document.querySelectorAll("img.md-img-failed[data-md-src]")) as HTMLImageElement[]) {
     const u = img.dataset.mdSrc || "";
     if (u) urls.add(u);
@@ -831,9 +858,7 @@ export function installMdImgHeal(): void {
     if (img.onerror || img.closest(".path-full")) return;   // the preview machinery retries its own
     parkMdImg(img, src);
     if (servedByKernel(src)) {                       // bounded and off the DOM: the caption never moves for it
-      let budget = 3;
-      const again = () => probeMdImgUrl(src, () => { if (--budget > 0) failedPreviews.set(img, again); });
-      failedPreviews.set(img, again);
+      if (!mdImgProbe.has(src)) mdImgProbe.set(src, 3);   // the budget rides the URL: a re-rendered turn inherits what is left
     }
   }, true);
 }


### PR DESCRIPTION
## Symptom

A markdown image of a file an agent is still writing (a `/file` URL the kernel serves) fails while its turn streams, and its caption stays parked after one off-DOM probe instead of the three that #1222 promised for that case (its comment on `servedByKernel`: a file an agent is still writing may come back with no reconnect event, so it gets three bounded attempts on the per-message path). Nothing re-probes it until a reconnect-class event, though the file was finished a moment later.

Two related gaps come with it. A parked image whose turn has left the rendered window, or whose tab was closed, is never probed on a reconnect: its URL stays remembered for the page life, so scrolling back parks it again and the picture never lands. And a per-message probe that fails after a reconnect has already healed its URL re-arms an attempt, so the next push probes the healed URL once more.

## Cause

In #1222 the three-attempt budget is a closure over the img element that failed, registered in `failedPreviews` under that element. A streaming turn is re-rendered on every push: the tail path removes the turn's nodes and rebuilds them, so the element is off the page by the next push, `retryFailedPreviews` drops its entry unrun, and `mdImgPostPass` parks the fresh img with no budget. Trace for a served URL that 404s while its turn streams: error, park, budget 3; push 1 runs the probe (the img is still on the page); the re-render parks a fresh img; the probe fails and re-registers the old img, now detached; push 2 drops the entry. One probe in all.

`healMdImgs` collected URLs from the parked imgs on the page only, so a remembered URL with no img on the page was skipped. And the closure re-registered its img on every failure, whether or not the URL had healed meanwhile.

## Fix

`ui/webview/preview.ts`: the budget is keyed on the URL. `mdImgProbe` maps a served URL to the attempts left and `mdImgProbing` holds the URLs with a probe in flight, beside `mdImgFailed`. The capture listener still parks the img, and for a served URL arms three attempts when the URL has none. `retryFailedPreviews` first drains those budgets (`retryMdImgProbes`): one detached probe per URL per push, the next armed only once the previous has failed and only while the URL is still remembered, whatever img carries the URL now and whether or not one is on the page (the probe is off the DOM; a load re-queries the page, as before). A load clears the URL's budget along with its memory. `healMdImgs` seeds its URL set with `mdImgFailed` and still reads the page's parked imgs, so a reconnect probes the union. No markdown image is registered in `failedPreviews` any more; the figure previews' own registrations are untouched.

One behavior change to note: a reconnect-class event (romp:wsup, hostUp, romp:hostRelayUp) now probes every URL that failed during the page life, including URLs with no parked img on the page (turns evicted from the rendered window, closed tabs). It is one detached probe per distinct URL per event, and the events are rare.

## Tests

`ui/webview/md-img-park.test.ts`, executed over the file's fake DOM. Three cases fail before the change:

- "a served URL's budget follows the URL: a turn rebuilt on every push while it streams still gets three probes, one per push": fails before the change at push 2 with `probes.length` 1, not 2. It also asserts that a push while a probe is pending fires no second probe for the URL, that a failed probe never writes the img on the page, that a second img with the URL failing after push 2 keeps the one attempt left rather than re-arming three (three probes in all, not four), and that the reconnect heal then lands the picture on every img on the page with the URL.
- "the reconnect-class heal probes a remembered URL whose turn is outside the rendered window": fails before the change at its first assertion with `probes.length` 0. It also asserts the next reconnect probes the URL again while it is down, that a scroll-back renders the healed URL normally, and that a healed URL is not probed again.
- "a reconnect heal that lands while a per-message probe is pending stands: the stale failure re-arms nothing for the healed URL": fails before the change with 3 probes for 2 (the closure re-registered its img and the next push probed the healed URL).

One case passes before the change and pins the new bookkeeping: "a per-message probe that loads lands the picture on the img on the page now and clears the URL's budget with its memory; the URL failing again later starts afresh". Dropping either deletion from the load handler turns it red (a budget left behind fires a probe for a healed URL on the next push; an in-flight mark left behind blocks the URL's per-message probes for the page life).

`fresh()` now clears the module's memory through the public reconnect path (`refreshSettledPreviews` with every probe answered by a load) instead of resetting only the fake's arrays, and the header describes that. It is required once `healMdImgs` reads `mdImgFailed`: without it the existing bounded-probe case counts a URL left over from an earlier case (5 probes, not 4), checked by disabling the reset once.

The module: 8 of 8 pass with the change, 5 of 8 before. The source pins on this code are unchanged and pass: preview-heal (6), preview-retry-pace (4), chat-inline-preview (14), preview-core (5), heal-on-hostup (6), pr-links (55). `npm run typecheck` is clean.

Full `node --test` run over the built test bundle on this head: 4043 tests, 4043 pass, 0 fail.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)