### PR TITLE
Auto-reload: the refusal on a tab whose create failed and the queued edit's send refusal do not come back either

### DIFF
--- a/ui/webview/provisional.test.ts
+++ b/ui/webview/provisional.test.ts
@@ -110,8 +110,9 @@ test("creating a session opens the provisional tab instead of a modal", () => {
 test("a send on a provisional tab is HELD, not posted to a session that doesn't exist", () => {
   assert.match(RENDER, /provisionalQueue\.push\(text\);\s*\n\s*registerOptimistic\(sid, text, attached\.filter\(\(p\) => previewKind\(p\) === "img"\)\);/,
     "the dashed bubble goes up now — with its dragged-image thumbnails — romp has it, it is not delivered");
-  // a FAILED tab has no pending spawn to queue onto: refuse loudly, the box keeps the only copy
-  assert.match(RENDER, /if \(sid !== provisionalId\) \{\s*\n\s*warnToast\("“" \+ \(sessions\.get\(sid\)\?\.name \|\| "this session"\)/);
+  // a FAILED tab has no pending spawn to queue onto: refuse loudly, the box keeps the only copy. The refusal reports
+  // a state the page after a reload does not have, so it is ephemeral (executed in reload-notices.test.ts)
+  assert.match(RENDER, /if \(sid !== provisionalId\) \{\s*\n\s*ephemeralWarnToast\("“" \+ \(sessions\.get\(sid\)\?\.name \|\| "this session"\)/);
 });
 
 test("adoption flushes the held messages FOR REAL and carries the draft across", () => {

--- a/ui/webview/reload-notices.test.ts
+++ b/ui/webview/reload-notices.test.ts
@@ -5,15 +5,17 @@
 // render.ts keeps the texts of the toasts on screen in this tab's sessionStorage on the core's synchronous hook and the
 // fresh page shows them once. The readings are pure and execute here. render.ts has import-time DOM side effects, so
 // its wiring is pinned to source the way reload-restore.test.ts pins the scroll record's, and the toast family with the
-// refusals that report a state is lifted out of it and executed over a fake DOM the way chat-exact-tail-exec.test.ts
-// lifts chatTail. The served scenario (a nack on the last ship across a kernel restart; the fresh page says it again,
-// once) is tests/test_ship_reship.py NackNoticeSurvivesReload. Synthetic only.
+// refusals that report a state (the staging refusals, the branch jump's, the send into a tab whose create failed, the
+// queued edit's send on a session that cannot be reached) is lifted out of it and executed over a fake DOM the way
+// chat-exact-tail-exec.test.ts lifts chatTail. The served scenario (a nack on the last ship across a kernel restart; the
+// fresh page says it again, once) is tests/test_ship_reship.py NackNoticeSurvivesReload. Synthetic only.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { createRequire } from "node:module";
 import { RELOAD_NOTICES_KEY, liveNotices, keepReloadNotices, takeReloadNotices } from "./reload-notices";
+import { mintProvisionalId, isProvisionalId } from "./provisional";
 
 const requireCjs = createRequire(__filename);
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
@@ -48,8 +50,9 @@ test("the toasts on screen read as their texts, in order, blanks dropped; none w
 
 test("the reading asks for the toasts without the ephemeral mark: a refusal about a state the fresh page shows for itself stays behind", () => {
   // a refusal that reports a state (the staged sends' "Can't send yet": the host unreachable, the tab still being
-  // created; the staging refusals; the branch jump to a session not on this dashboard) is about something the fresh
-  // page shows for itself or no longer has; render.ts marks those toasts where they are raised (executed below) and the
+  // created; the send into a tab whose create failed; the queued edit's send on a session that cannot be reached; the
+  // staging refusals; the branch jump to a session not on this dashboard) is about something the fresh page shows for
+  // itself or no longer has; render.ts marks those toasts where they are raised (executed below) and the
   // selector skips the mark. The mark's effect on a real DOM is executed by tests/test_ship_reship.py
   // NackNoticeSurvivesReload.
   const asked: string[] = [];
@@ -143,32 +146,44 @@ function fakeDocument() {
 }
 
 /** The page state the lifted closures read: the composer (a typed draft, its citations, a picker waiting, an edit in
- *  progress to a past message or to a queued one, attachments) and the session roster, with what each gesture did
+ *  progress to a past message or to a queued one, attachments), the session roster, the reach of the active session's
+ *  host (hostDown) and the active tab when it is provisional (tab: "pending", a create still in flight, so its id is the
+ *  pending provisional id; "failed", a create that failed, so no create is pending), with what each gesture did
  *  recorded. The toasts' timers are recorded and not run, so a toast stays on screen for the reading. */
-function pageWorld(state: { ask?: "custom" | "text" | null; edit?: boolean; queuedEdit?: boolean; files?: string[]; sessions?: string[] }) {
+function pageWorld(state: { ask?: "custom" | "text" | null; edit?: boolean; queuedEdit?: boolean; files?: string[]; sessions?: string[];
+                            hostDown?: boolean; tab?: "pending" | "failed" }) {
+  const activeId = state.tab ? mintProvisionalId("web") : "web";
+  const roster = (state.sessions || []).map((id): [string, { id: string; name: string }] => [id, { id, name: id }]);
+  if (state.tab) roster.push([activeId, { id: activeId, name: "web" }]);
   return {
     FakeEl, document: fakeDocument(), timers: [] as number[],
-    activeId: "web", ta: { value: "what did the tests say", style: {} as Record<string, string> },
+    activeId, ta: { value: "what did the tests say", style: {} as Record<string, string> },
     composerCitations: new Map<string, { quote?: string }[]>(), ask: state.ask ?? null,
-    composerEdits: new Map<string, { uuid: string; orig: string }>(state.edit ? [["web", { uuid: "e1", orig: "the old text" }]] : []),
-    queuedEdits: new Map<string, { md: string }>(state.queuedEdit ? [["web", { md: "the queued text" }]] : []),
-    composerFiles: new Map<string, string[]>(state.files ? [["web", state.files]] : []),
+    composerEdits: new Map<string, { uuid: string; orig: string }>(state.edit ? [[activeId, { uuid: "e1", orig: "the old text" }]] : []),
+    queuedEdits: new Map<string, { md: string }>(state.queuedEdit ? [[activeId, { md: "the queued text" }]] : []),
+    composerFiles: new Map<string, string[]>(state.files ? [[activeId, state.files]] : []),
     staged: [] as [string, unknown][], persists: 0,
-    sessions: new Map<string, { id: string }>((state.sessions || []).map((id): [string, { id: string }] => [id, { id }])),
+    sessions: new Map<string, { id: string; name: string }>(roster),
     activated: [] as [string, string | undefined][],
+    hostDown: !!state.hostDown, posted: [] as { type: string }[], editsApplied: 0,
+    isProvisionalId, provisionalId: state.tab === "pending" ? activeId : null, provisionalQueue: [] as string[],
   };
 }
 type World = ReturnType<typeof pageWorld>;
-type Lifted = { stageComposer: () => void; branchjump: (elx: { dataset: Record<string, string> }) => void; warnToast: (msg: string) => FakeEl };
+type Lifted = { stageComposer: () => void; branchjump: (elx: { dataset: Record<string, string> }) => void; warnToast: (msg: string) => FakeEl;
+                provisionalSend: (sid: string, text: string, attached: string[]) => void; queuedEditSend: (typed: string) => void };
 
 /** warnToast and ephemeralWarnToast; stageComposer (the composer's staging, whose refusals say a picker is waiting on
- *  the composer, an edit is in progress to a past or a queued message, attachments are on the composer); and the branch
- *  jump's delegated handler (whose refusal says the session is not on this dashboard), lifted from render.ts and run
- *  over the world. */
+ *  the composer, an edit is in progress to a past or a queued message, attachments are on the composer); the branch
+ *  jump's delegated handler (whose refusal says the session is not on this dashboard); the provisional branch of the
+ *  send's deliver (whose refusal says the tab's session never started); and the send's queued-edit branch (whose
+ *  refusal says the session cannot be reached, so the edit was not sent), lifted from render.ts and run over the world. */
 function liftToastSites(): (w: World) => Lifted {
   const toasts = liftBetween("function warnToast(msg: string): HTMLElement {", "// Tail-windowing (see the View comment)");
   const stage = liftBetween("const stageComposer = () => {", "const sendComposer = (");
   const jump = liftBetween("branchjump: (elx) => {", "// a below-response fork spot", (ts) => "const handlers = {\n" + ts + "};");
+  const send = liftBetween("if (isProvisionalId(sid)) {", "lastSent.set(activeId, text);", (ts) => "const provisionalSend = (sid, text, attached) => {\n" + ts + "};");
+  const qsend = liftBetween("const qedit = queuedEdits.get(activeId);", "const sid = activeId;   // the session this send", (ts) => "const queuedEditSend = (typed) => {\n" + ts + "};");
   const prelude = `
     const W = WORLD;
     const document = W.document;
@@ -189,8 +204,18 @@ function liftToastSites(): (w: World) => Lifted {
     const renderStagedStrip = () => {};
     const sessions = W.sessions;
     const setActive = (sid, cut) => { W.activated.push([sid, cut]); };
+    const isProvisionalId = W.isProvisionalId, provisionalId = W.provisionalId, provisionalQueue = W.provisionalQueue;
+    const registerOptimistic = () => {}, previewKind = () => null, renderComposerFiles = () => {};
+    const sendOnShip = new Set(), histWalk = new Map();
+    const hostIsDown = () => W.hostDown;
+    const vscodeApi = { postMessage: (m) => { W.posted.push(m); } };
+    const SLASH_CMD_RE = /^[/][A-Za-z]/;   // a template literal: the real regex's escaped slash would not survive it
+    const pendingEditRestores = new Map();
+    const applyQueuedEditLocally = () => { W.editsApplied++; };
+    const restoreHeldDraft = () => {};
   `;
-  return new Function("WORLD", prelude + toasts + stage + jump + "\nreturn { stageComposer, branchjump: handlers.branchjump, warnToast };") as (w: World) => Lifted;
+  return new Function("WORLD", prelude + toasts + stage + jump + send + qsend
+    + "\nreturn { stageComposer, branchjump: handlers.branchjump, warnToast, provisionalSend, queuedEditSend };") as (w: World) => Lifted;
 }
 
 function page(state: Parameters<typeof pageWorld>[0]) {
@@ -217,7 +242,8 @@ test("staging with nothing owning the composer stages: the lifted composer is th
 // screen for the person at the page and refuses the gesture; the reading skips it, because the fresh page shows that
 // state for itself (the picker, the attachments and the roster come back from the kernel and the persisted drafts) or
 // no longer has it (an edit in progress, to a past message or to a queued one, lives in memory alone, so a replay would
-// report an edit the fresh page has not got).
+// report an edit the fresh page has not got, and its "send again" would post the words as a new message; a provisional
+// tab does not survive a reload, so a replay would name a session the fresh page does not show).
 const STATE_REFUSALS: { name: string; state: Parameters<typeof pageWorld>[0]; raise: (p: Page) => void; text: string; refused: (p: Page) => void }[] = [
   { name: "staging while a picker waits on the composer", state: { ask: "text" }, raise: (p) => p.stageComposer(),
     text: "A picker is waiting on this box", refused: (p) => assert.deepEqual(p.W.staged, [], "nothing staged") },
@@ -229,6 +255,20 @@ const STATE_REFUSALS: { name: string; state: Parameters<typeof pageWorld>[0]; ra
     text: "Attachments can't be staged", refused: (p) => assert.deepEqual(p.W.staged, [], "nothing staged") },
   { name: "a branch jump to a session not on this dashboard", state: { sessions: ["web"] }, raise: (p) => p.branchjump({ dataset: { sid: "api" } }),
     text: "That session isn't on this dashboard right now.", refused: (p) => assert.deepEqual(p.W.activated, [], "no switch") },
+  { name: "a send into a tab whose create failed", state: { tab: "failed" }, raise: (p) => p.provisionalSend(p.W.activeId, p.W.ta.value, []),
+    text: "“web” never started, so there's nowhere to send this.", refused: (p) => assert.deepEqual(p.W.provisionalQueue, [], "nothing queued") },
+  { name: "a queued edit sent while the session's host is unreachable", state: { queuedEdit: true, hostDown: true }, raise: (p) => p.queuedEditSend(p.W.ta.value),
+    text: "Can't reach the session right now, so the edit wasn't sent.", refused: (p) => {
+      assert.deepEqual(p.W.posted.map((m) => m.type), ["redial"], "a re-dial is asked for and no edit is posted");
+      assert.ok(p.W.queuedEdits.has(p.W.activeId), "the edit is still in progress");
+      assert.equal(p.W.editsApplied, 0, "the queued bubble keeps its words");
+    } },
+  { name: "a queued edit sent on a tab still being created", state: { queuedEdit: true, tab: "pending" }, raise: (p) => p.queuedEditSend(p.W.ta.value),
+    text: "Can't reach the session right now, so the edit wasn't sent.", refused: (p) => {
+      assert.deepEqual(p.W.posted, [], "nothing is posted: there is no kernel session to re-dial or to edit");
+      assert.ok(p.W.queuedEdits.has(p.W.activeId), "the edit is still in progress");
+      assert.equal(p.W.editsApplied, 0, "the queued bubble keeps its words");
+    } },
 ];
 for (const r of STATE_REFUSALS) {
   test(r.name + ": the refusal is on screen and refuses, and the reading skips it", () => {
@@ -266,8 +306,14 @@ test("render.ts: warnToast hands back its toast, and the refusals about a state 
   assert.match(RENDER, /if \(queuedEdits\.has\(activeId\)\) \{ ephemeralWarnToast\("This edit replaces a queued message\. Send it normally\."\); return; \}/);
   assert.match(RENDER, /if \(\(composerFiles\.get\(activeId\) \|\| \[\]\)\.length\) \{ ephemeralWarnToast\("Attachments can't be staged/);
   assert.match(RENDER, /if \(!sessions\.get\(sid\)\) \{ ephemeralWarnToast\("That session isn't on this dashboard right now\."\); return; \}/);
-  assert.equal((RENDER.match(/ephemeralWarnToast\(/g) || []).length, 8, "the definition, the two reachability sites and the five state refusals");
-  // what the nack, the dismissal and the other-tab ack say stays true after the reload, so they ride it unmarked
+  // the send into a tab whose create failed (a provisional tab does not survive a reload) and the queued edit's send on
+  // a session that cannot be reached (the edit lives in memory alone): states the fresh page no longer has
+  assert.match(RENDER, /if \(sid !== provisionalId\) \{\n\s*ephemeralWarnToast\("“" \+ \(sessions\.get\(sid\)\?\.name \|\| "this session"\) \+ "” never started, so there's "/);
+  assert.match(RENDER, /if \(hostIsDown\(activeId\) \|\| isProvisionalId\(activeId\)\) \{\n\s*if \(hostIsDown\(activeId\)\) vscodeApi\?\.postMessage\(\{ type: "redial"[^\n]*\n\s*ephemeralWarnToast\("Can't reach the session right now, so the edit wasn't sent\./);
+  assert.equal((RENDER.match(/ephemeralWarnToast\(/g) || []).length, 10, "the definition, the two reachability sites and the seven state refusals");
+  // what the nack, the dismissal, the other-tab ack and the plain send's refusal on a disconnected host say stays true
+  // after the reload (the message is in the box on the fresh page too, and a send there sends it), so they ride it unmarked
+  assert.match(RENDER, /warnToast\(host \+ " is disconnected, so this wasn't sent\. It's still in the box/);
   assert.match(RENDER, /warnToast\(m\.name \+ " couldn't be saved on the kernel, so it was not attached/);
   assert.match(RENDER, /warnToast\("The pending upload was dismissed — your held message was NOT sent\."\)/);
   assert.match(RENDER, /warnToast\("attachments finished uploading on another tab — the held message was not sent; review it there\."\)/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9952,18 +9952,21 @@ function warnToast(msg: string): HTMLElement {
 }
 // A toast the page that follows a reload must not repeat: a refusal that reports a STATE rather than an event. The
 // staged sends' "Can't send yet" says the session's host is unreachable (hostIsDown, a remote host's tunnel) or its tab
-// is still being created (isProvisionalId); the staging refusals (stageComposer) say a picker is waiting on the
-// composer, an edit is in progress (to a past message, or to a queued one) or attachments are on the composer; the
-// branch jump's refusal (branchjump) says the session is not on this dashboard. The fresh page shows each state for
-// itself (the host mark and the staged strip; the picker, the attachments and the roster come back from the kernel and
-// the persisted drafts) or no longer has it (a provisional tab does not survive a reload; composerEdits and queuedEdits
-// are in memory alone, so no edit is in progress on a fresh page), so kept by persistNoticesForReload and shown again by
-// the page that follows, it would be redundant at best and false at worst. The mark keeps it out of the replay
-// (reload-notices.ts liveNotices reads only the toasts without it).
+// is still being created (isProvisionalId); the send into a tab whose create failed (sendComposer's deliver) says the
+// session never started; the queued edit's send (sendComposer, ahead of deliver) says the session cannot be reached, so
+// the edit was not sent; the staging refusals (stageComposer) say a picker is waiting on the composer, an edit is in
+// progress (to a past message, or to a queued one) or attachments are on the composer; the branch jump's refusal
+// (branchjump) says the session is not on this dashboard. The fresh page shows each state for itself (the host mark and
+// the staged strip; the picker, the attachments and the roster come back from the kernel and the persisted drafts) or no
+// longer has it (a provisional tab, pending or failed, does not survive a reload; composerEdits and queuedEdits are in
+// memory alone, so no edit is in progress on a fresh page, and a "send again" there would post the words as a new
+// message), so kept by persistNoticesForReload and shown again by the page that follows, it would be redundant at best
+// and false at worst. The mark keeps it out of the replay (reload-notices.ts liveNotices reads only the toasts without
+// it).
 // Toasts that report what HAPPENED to a send or a file stay unmarked, since what they say is as true after the reload
 // as before: the nack (the attachment was not saved, the held message not sent), the dismissal and the other-tab ack
-// (the held message not sent), the refusal on a disconnected host (this message was not sent and is still in the
-// composer).
+// (the held message not sent), the plain send's refusal on a disconnected host (this message was not sent and is still
+// in the composer, where the fresh page's persisted draft keeps it, and a send there sends it).
 function ephemeralWarnToast(msg: string): void { warnToast(msg).dataset.ephemeral = "1"; }
 
 // Tail-windowing (see the View comment): a fresh/rewound view renders only the
@@ -15805,9 +15808,12 @@ function setupComposer() {
       // message: the kernel would deliver it as text, skipping the routing every typed command gets (the
       // fire-alone park, the /model and /effort setters, the /clear confirm below), so the kernel refuses it
       // too; this mirror keeps the words in the box instead of round-tripping them.
+      // The refusal reports a state (an edit in progress on a session that cannot be reached), and the edit is in
+      // memory alone: on the page that follows a reload no edit is in progress and "send again" would post the
+      // words as a new message, so it does not ride one (ephemeralWarnToast).
       if (hostIsDown(activeId) || isProvisionalId(activeId)) {
         if (hostIsDown(activeId)) vscodeApi?.postMessage({ type: "redial", host: String(activeId).slice(0, String(activeId).indexOf(":")) });
-        warnToast("Can't reach the session right now, so the edit wasn't sent. It's still in the box: send again when the link is back.");
+        ephemeralWarnToast("Can't reach the session right now, so the edit wasn't sent. It's still in the box: send again when the link is back.");
         return;
       }
       if (SLASH_CMD_RE.test(typed)) { warnToast("A queued message cannot become a command. Cancel it with its ✕ and type the command."); return; }
@@ -15843,8 +15849,11 @@ function setupComposer() {
       if (isProvisionalId(sid)) {
         // a FAILED create's tab: there is no pending spawn to queue onto, and never a session to send
         // to — refuse loudly and leave the text exactly where it is (the box is the only copy)
+        // The refusal reports a state (a tab with no session behind it) that the page following a
+        // reload does not have, since a provisional tab does not survive one, so it does not ride one
+        // (ephemeralWarnToast).
         if (sid !== provisionalId) {
-          warnToast("“" + (sessions.get(sid)?.name || "this session") + "” never started, so there's "
+          ephemeralWarnToast("“" + (sessions.get(sid)?.name || "this session") + "” never started, so there's "
             + "nowhere to send this. It stays in the box — create the session again to use it.");
           return;
         }


### PR DESCRIPTION
Follow-up to #1227 (merged): its review named one refusal in `sendComposer` that still rode the reload, and a second sits beside it.

## Symptom

A send into a tab whose create failed is refused with a toast saying the session never started, and the words stay in the box. When the reload after a kernel restart takes the page inside the toast's twelve seconds, the fresh page shows the toast again, naming a tab it does not have.

A queued edit sent while the session cannot be reached (its host is down, or its tab is still being created) is refused with a toast saying the edit was not sent and to send again when the link is back. Shown again by the fresh page, it asks the user to send again an edit that page no longer has, and a send there would post the words as a new message behind the unchanged queued one.

## Cause

Both refusals were plain `warnToast`s, so `persistNoticesForReload` kept them and the fresh page replayed them. Both report a state rather than an event: the provisional tab and the queued edit (`provisionalId`, `failedProvisionals`, `queuedEdits`) live in memory alone, so the fresh page has neither, and the replay is false.

The review named the never-started refusal. The queued edit's refusal sits beside it in `sendComposer` and reads as a state too. The plain send's refusal on a disconnected host stays unmarked because the message it speaks of is in the box on the fresh page too, and a send there sends it. The queued edit's "send again" cannot do what it says on a page with no edit in progress. The `isProvisionalId` half of its guard is reachable through the pencil on the dashed bubble of a tab still being created, so the same toast is raised on a provisional tab too.

## Fix

`ui/webview/render.ts`: the never-started refusal in `sendComposer`'s `deliver` and the queued edit's refusal ahead of it are raised through `ephemeralWarnToast`, each with a comment at the site; the census above `ephemeralWarnToast` lists them with the other state refusals and names the plain send's disconnected-host refusal as the unmarked one. Nothing else changes; the `stageComposer` refusals #1227 marked are untouched.

## Tests

`ui/webview/reload-notices.test.ts` lifts the provisional branch of the send's `deliver` and the send's queued-edit branch out of `render.ts` (between stable anchors, the file's pattern) and executes them over the fake DOM. Three cases join the state-refusals table:

- a send into a tab whose create failed: the toast is on screen, nothing is queued, the draft stays, `liveNotices` skips it;
- a queued edit sent while the session's host is unreachable: the toast is on screen, a re-dial is posted and no edit, the edit is still in progress, the draft stays, `liveNotices` skips it;
- a queued edit sent on a tab still being created: the same, with nothing posted.

Before the change each fails at the reading: `liveNotices` returns the refusal's text (18 tests, 14 pass, 4 fail). The source-pin test matches both sites through `ephemeralWarnToast`, pins the disconnected-host refusal as a plain `warnToast`, and counts ten `ephemeralWarnToast` sites (eight before this change, so it fails on the old count). `ui/webview/provisional.test.ts`: its pin of the never-started site follows the swap.

Full `npm test` on this head: 4055 tests, 0 failing (4033 in the main leg and 22 in ui/timeline-tags-scale.test.ts run alone as a second leg; both legs exit 0). `npm run typecheck` clean.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)