### PR TITLE
Tests: the settings-dir save's home fallback has its own child case

### DIFF
--- a/tests/test_claude_config_floor.py
+++ b/tests/test_claude_config_floor.py
@@ -13,8 +13,9 @@ opt-in test that borrows the operator's apiKeyHelper command from their own sett
 
 Source pins in the style of test_supervised_floor.py, the floor observed from inside a test, from a
 module loaded under it, and from a subprocess whose shell exports a value of its own; the saved
-location observed from inside a test, from a subprocess whose shell exports the root it saves, and
-from one whose shell already carries a saved value."""
+location observed from inside a test, from a subprocess whose shell exports the root it saves, from
+one whose shell exports no root and is handed the settings dir under a synthetic HOME, and from one
+whose shell already carries a saved value."""
 import importlib.util
 import os
 import shutil
@@ -32,16 +33,18 @@ os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 
-# Run by a child pytest under conftest (`-p tests.conftest`) whose shell exports synthetic Claude roots:
-# one generated test, which passes only if the child's saved value is the one the case expects of that
-# shell while CLAUDE_CONFIG_DIR is the floor, neither root the shell exported.
+# Run by a child pytest under conftest (`-p tests.conftest`) whose shell exports synthetic Claude roots,
+# or a synthetic HOME and no root: one generated test, which passes only if the child's saved value is
+# the one the case expects of that shell and CLAUDE_CONFIG_DIR is the floor, which is neither the saved
+# value nor anything the shell exported.
 SAVED_LOCATION_CASE = '''\
 import os
 
 
-def test_the_saved_location_is_the_expected_one_and_the_floor_is_neither_exported_root():
+def test_the_saved_location_is_the_expected_one_and_the_floor_is_neither_it_nor_anything_exported():
     expected, exported = %r, %r
     assert os.environ["ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR"] == expected
+    assert os.environ["CLAUDE_CONFIG_DIR"] != expected
     assert os.environ["CLAUDE_CONFIG_DIR"] not in exported
 '''
 
@@ -103,19 +106,25 @@ class ClaudeConfigFloor(unittest.TestCase):
 
     def _saved_location_seen_by_a_child(self, shell, expected, extra=()):
         """Runs SAVED_LOCATION_CASE under a child pytest that loads conftest as a plugin. `shell` is
-        what the child's shell exports on top of this process's environment, with the saved value
-        cleared unless `shell` carries one; `expected` is the saved value the generated test asserts;
-        `extra` is appended to the child's command line."""
+        what the child's shell exports on top of this process's environment (a None value clears that
+        variable from the child's shell instead), with the saved value cleared unless `shell` carries
+        one; `expected` is the saved value the generated test asserts; `extra` is appended to the
+        child's command line."""
+        exported = tuple(value for value in shell.values() if value is not None)
         case = tempfile.mkdtemp(prefix="romp-claude-floor-case-")
         self.addCleanup(shutil.rmtree, case, ignore_errors=True)
         with open(os.path.join(case, "test_saved_location.py"), "w") as f:
-            f.write(SAVED_LOCATION_CASE % (expected, tuple(shell.values())))
+            f.write(SAVED_LOCATION_CASE % (expected, exported))
         env = dict(os.environ, PYTHONDONTWRITEBYTECODE="1")
         for var in ("ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR", "PYTEST_ADDOPTS", "PYTEST_PLUGINS",
                     "PYTEST_DISABLE_PLUGIN_AUTOLOAD", "PYTEST_CURRENT_TEST", "PYTEST_XDIST_WORKER",
                     "PYTEST_XDIST_WORKER_COUNT"):
             env.pop(var, None)
-        env.update(shell)
+        for var, value in shell.items():
+            if value is None:
+                env.pop(var, None)
+            else:
+                env[var] = value
         r = subprocess.run([sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", "-p", "tests.conftest",
                             *extra, os.path.join(case, "test_saved_location.py")],
                            env=env, capture_output=True, text=True, timeout=180, cwd=ROOT)
@@ -129,6 +138,20 @@ class ClaudeConfigFloor(unittest.TestCase):
         floor itself, and the live move test would skip for want of auth on every machine."""
         handed = os.path.join(tempfile.gettempdir(), "synthetic-claude-root-handed-to-the-run")
         self._saved_location_seen_by_a_child({"CLAUDE_CONFIG_DIR": handed}, expected=handed)
+
+    def test_the_saved_location_is_the_home_settings_dir_when_the_shell_exports_no_root(self):
+        """A shell that exports no CLAUDE_CONFIG_DIR at all (a developer's, and CI's) is handed the
+        default settings dir, .claude under HOME, and the save must record that one: a child pytest
+        whose shell carries no root and a synthetic HOME passes the generated test only if the saved
+        value is that home's .claude and CLAUDE_CONFIG_DIR is neither that value nor the home. A conftest
+        that floored HOME ahead of the save, or saved after the CLAUDE_CONFIG_DIR floor, would record a
+        run-private directory instead, and the live move test would skip for want of auth on every
+        machine that never exported the variable; one that never floored a shell exporting no root
+        would leave CLAUDE_CONFIG_DIR at the saved value."""
+        home = tempfile.mkdtemp(prefix="romp-claude-floor-home-")
+        self.addCleanup(shutil.rmtree, home, ignore_errors=True)
+        self._saved_location_seen_by_a_child({"CLAUDE_CONFIG_DIR": None, "HOME": home},
+                                             expected=os.path.join(home, ".claude"))
 
     def test_a_saved_value_the_shell_already_carries_survives_the_import(self):
         """An xdist worker imports conftest in an environment the controller has already floored and


### PR DESCRIPTION
Builds on #1237 (the settings dir the run was handed, saved ahead of the CLAUDE_CONFIG_DIR floor for the live session-move test); this branch is stacked on it, and the change to review is the last commit.

## Symptom

No user-visible symptom today. The gap is that a later conftest edit that floored HOME ahead of the save would go unnoticed: the saved location would become a run-private directory, the live session-move test would skip for want of auth on every machine that never exported CLAUDE_CONFIG_DIR, and the module's cases would stay green.

## Cause

All three child-pytest cases in tests/test_claude_config_floor.py export CLAUDE_CONFIG_DIR: one checks that the save comes before the floor, two that a saved value the shell already carries survives the import (one of them under -n 2). The save's other branch, .claude under HOME when the shell exports no root (the developer's and CI's case), had no case. The review of #1237 asked for one.

## Fix

One more case in the same idiom, test_the_saved_location_is_the_home_settings_dir_when_the_shell_exports_no_root: the child pytest's shell has CLAUDE_CONFIG_DIR cleared and HOME set to a synthetic temp dir, and the generated test passes only if ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR is that home's .claude and CLAUDE_CONFIG_DIR is neither that value nor the home. The generated test gains the assertion that CLAUDE_CONFIG_DIR is not the saved value, for every case: the exported-root case already had the saved value among the exported values it checks, and without the assertion the new case could not tell a floor from no floor (a conftest that left CLAUDE_CONFIG_DIR at ~/.claude under the synthetic HOME would have passed it).

The helper _saved_location_seen_by_a_child treats a None value as "clear this variable from the child's shell" and leaves it out of the values the generated test checks the floor against. The module docstring and the generated case's comment and name mention the new case and the added assertion. Tests only; tests/conftest.py is unchanged.

## Tests

- tests/test_claude_config_floor.py::ClaudeConfigFloor::test_the_saved_location_is_the_home_settings_dir_when_the_shell_exports_no_root: a guard, green on the current conftest. Its red was shown by mutation in a scratch copy of the tree, each mutation applied to tests/conftest.py alone:
  - a HOME floor (os.environ["HOME"] = tempfile.mkdtemp(...)) inserted ahead of the save: the case fails (the saved value is the floored home's .claude, not the synthetic home's) while the existing exported-root case passes;
  - the save moved below the CLAUDE_CONFIG_DIR floor: both cases fail (the saved value is the floor);
  - the floor set to the saved value, or to ~/.claude, or left unset when the shell exports no root: the case fails on the added assertion that CLAUDE_CONFIG_DIR is not the saved value, and stays green with that assertion removed.
- The module: 9 passed (8 before).
- The meta-tests that scan test sources (tests/test_judge_parse_cache.py, tests/test_postal_marker_form.py, tests/test_state_isolation_order.py): 7 passed.
- Full suite on this tree (`pytest -n 6 tests/`): 10571 passed, 115 skipped, 0 failed, 1688 subtests passed.

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)