### PR TITLE
Usage modal: a hover crosshair over the spend chart, and the middle range is 7 days over 168 hourly buckets (T293)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -44731,21 +44731,25 @@ rows.sort(function(a,b){return (b.v-a.v)||(a.si-b.si);});var top=rows.slice(0,ca
 if(pin>=0&&more>0&&!top.some(function(r){return r.si===pin;})){var p=null;rows.forEach(function(r){if(r.si===pin)p=r;});if(p){top.push(p);more--;}}return {rows:top,more:more,total:total};}
 function spDot(s){return s.kind==='unattributed'?'#8a97a6':s.kind==='other'?SP_OTHER:spColor(s);}   // the hatch's stroke stands in for its texture
 function spTipBox(){if(!spTip){spTip=document.createElement('div');spTip.id='rsp-tip';document.body.appendChild(spTip);}spTip.textContent='';return spTip;}
-// below and to the right of the pointer (the stamp sits at the chart's top, so the two never meet), to its left near
-// the right edge and above it near the bottom, kept inside the viewport; the box takes no pointer events
-function spTipPlace(x,y){spTip.style.display='block';var w=spTip.offsetWidth,hh=spTip.offsetHeight,left=x+14,top=y+18;if(left+w+6>window.innerWidth)left=x-14-w;if(top+hh+6>window.innerHeight)top=y-18-hh;
+// below and to the right of the pointer, to its left near the right edge; when nothing fits below, above the CHART
+// (rect, the svg's box) rather than the pointer, so the box stays clear of the stamp at the chart's top (review find:
+// a pointer-anchored flip landed a six-row box on the stamp in a short window); only a viewport too short for either
+// falls back to the pointer, and the header repeats the stamp's text. The box takes no pointer events
+function spTipPlace(x,y,rect){spTip.style.display='block';var w=spTip.offsetWidth,hh=spTip.offsetHeight,left=x+14,top=y+18;if(left+w+6>window.innerWidth)left=x-14-w;
+if(top+hh+6>window.innerHeight){var above=(rect?rect.top:y)-hh-6;top=above>=6?above:y-18-hh;}
 spTip.style.left=Math.max(6,left)+'px';spTip.style.top=Math.max(6,top)+'px';}
 // the bucket tooltip: the total leads (the other measure and the stamp follow), then a row per session — a dot in the
 // stack's colour, the name (user data: textContent), the value — the hovered bar's row emphasised, the fold line last
-function spBucketTipShow(x,y,head,total,top,stacks,many,meas,i,pin,fmt){var box=spTipBox(),h=document.createElement('div');h.className='rsp-tip-h';
+function spBucketTipShow(x,y,head,total,top,stacks,many,meas,i,pin,fmt,rect){var box=spTipBox(),h=document.createElement('div');h.className='rsp-tip-h';
 var b=document.createElement('b');b.textContent=total;h.appendChild(b);h.appendChild(document.createTextNode(' \u00b7 '+head));box.appendChild(h);
 top.rows.forEach(function(r){var s=stacks[r.si],row=document.createElement('div');row.className='rsp-tip-row'+(r.si===pin?' on':'');
 var dot=document.createElement('i');dot.style.background=spDot(s);row.appendChild(dot);var nm=document.createElement('span');nm.textContent=spStackText(s,many,meas,i);row.appendChild(nm);
 var v=document.createElement('b');v.textContent=fmt(r.v);row.appendChild(v);box.appendChild(row);});
 if(top.more>0||!top.rows.length){var m=document.createElement('div');m.className='rsp-tip-more';m.textContent=top.rows.length?'+'+top.more+' more':'nothing recorded';box.appendChild(m);}
-spTipPlace(x,y);}
+spTipPlace(x,y,rect);}
 function spTipHide(){if(spTip)spTip.style.display='none';}
-function renderChart(){var box=document.getElementById('rsp-chart');if(!box||!SP.data)return;
+// a rebuild (a resize under a still pointer, a toggle) takes the tooltip down with the svg it described (review find)
+function renderChart(){spTipHide();var box=document.getElementById('rsp-chart');if(!box||!SP.data)return;
 var d=SP.data,ser=spSeries(d),meas=SP.measure;
 if(!ser||!ser.keys||!ser.keys.length){box.innerHTML='<div class=rsp-note>No history yet.</div>';return;}
 var stacks=spStacks(d,ser,spRows(d)),n=ser.keys.length,W=Math.max(320,box.clientWidth||600),H=200;
@@ -44808,10 +44812,11 @@ var range=SP.range==='day'?'hours':SP.range,other=meas==='usd'?'tok':'usd',ofmt=
 var xhHide=function(){xh.style.display='none';stamp.style.display='none';spTipHide();};
 svgEl.onpointermove=function(e){var r=svgEl.getBoundingClientRect(),i=spBucketAt(e.clientX-r.left,r.width,n);if(i<0){xhHide();return;}
 var cx=(i+0.5)*slot,pct=cx/W*100;xh.setAttribute('x1',cx.toFixed(1));xh.setAttribute('x2',cx.toFixed(1));xh.style.display='';
-var st=spStamp(ser.keys[i],range);stamp.textContent=st;stamp.style.left=pct.toFixed(1)+'%';stamp.className='rsp-xh-stamp'+(pct>70?' flip':'');stamp.style.display='';
+var st=spStamp(ser.keys[i],range);stamp.textContent=st;stamp.className='rsp-xh-stamp';stamp.style.left='max('+pct.toFixed(1)+'%,24px)';stamp.style.display='';
+if(cx/W*r.width+6+stamp.offsetWidth>r.width)stamp.classList.add('flip');   // decided in pixels (the stamp's width is fixed, the chart's is not); the 24px floor keeps it off the ceiling label
 var t=e.target,pin=(t&&t.classList&&t.classList.contains('rsp-seg'))?+t.getAttribute('data-s'):-1;
 var top=spBucketTop(stacks,meas,i,SP_TIP_ROWS,pin),ot=0;for(var s=0;s<stacks.length;s++)ot+=(stacks[s][other]&&stacks[s][other][i])||0;
-spBucketTipShow(e.clientX,e.clientY,ofmt(ot)+' \u00b7 '+st,fmt(top.total),top,stacks,many,meas,i,pin,fmt);};
+spBucketTipShow(e.clientX,e.clientY,ofmt(ot)+' \u00b7 '+st,fmt(top.total),top,stacks,many,meas,i,pin,fmt,r);};
 svgEl.onpointerleave=xhHide;}
 var spResizeRaf=0;
 window.addEventListener('resize',function(){if(!(SP.open&&SP.data)||spResizeRaf)return;

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -44559,10 +44559,12 @@ function spMany(d){return spHosts(d).length>1;}
 // rule the strip uses, so the two cannot drift) and the quiet .host-prefix — no swatch
 function spTitle(s,many){return '<span class="tab-label colored" style="--chip-bg:'+spColor(s)+'">'+(many&&s.host?'<span class=host-prefix>'+esc(s.host)+':</span>':'')+esc(spName(s))+'</span>';}
 // ── T247g (the user 2026-09-08): three ranges, and "merge by tag"
-// the series for the range: "1 day" is the hourly series' last 24 buckets (the ledger holds hours and
-// days; a day is a slice of the hours, never a third ledger)
-function spSeries(d){var ser=d[SP.range==='day'?'hours':SP.range];if(!ser)return null;if(SP.range!=='day')return ser;
-var n=(ser.keys||[]).length,cut=Math.max(0,n-24);
+// the series for the range: "1 day" is the hourly series' last 24 buckets and "7 days" its last 168 (T293, the
+// user 2026-09-09; the ledger holds 192 hours, a day of slack past the view, and 90 days; a range is a slice of
+// the hours, never a third ledger); the daily range is the ledger's series whole
+var SP_RANGE_BUCKETS={day:24,hours:168};
+function spSeries(d){var ser=d[SP.range==='day'?'hours':SP.range];if(!ser)return null;var keep=SP_RANGE_BUCKETS[SP.range];return keep?spTail(ser,keep):ser;}
+function spTail(ser,keep){var n=(ser.keys||[]).length,cut=Math.max(0,n-keep);
 return {keys:(ser.keys||[]).slice(cut),epochs:(ser.epochs||[]).slice(cut),stacks:(ser.stacks||[]).map(function(s){var o={};for(var k in s)o[k]=s[k];o.usd=(s.usd||[]).slice(cut);o.tok=(s.tok||[]).slice(cut);
 if(s.hosts){o.hosts={};Object.keys(s.hosts).forEach(function(h){o.hosts[h]={usd:(s.hosts[h].usd||[]).slice(cut),tok:(s.hosts[h].tok||[]).slice(cut)};});}return o;})};}
 // the rows: the ordered sessions, or — merged by tag — one row per tag holding sessions here (named
@@ -44673,7 +44675,7 @@ h+='<div class=rsp-sec id=rsp-totals>'+totalsHTML(d)+'</div>';
 h+='<div class=rsp-sec><div class=ru-tip-name><span>Spend over time</span></div>'
 +'<div class=rsp-ctl>'
 +'<button class="rsp-btn'+(SP.range==='day'?' on':'')+'" data-act=range:day>1 day \u00b7 by hour</button>'
-+'<button class="rsp-btn'+(SP.range==='hours'?' on':'')+'" data-act=range:hours>8 days \u00b7 by hour</button>'
++'<button class="rsp-btn'+(SP.range==='hours'?' on':'')+'" data-act=range:hours>7 days \u00b7 by hour</button>'
 +'<button class="rsp-btn'+(SP.range==='days'?' on':'')+'" data-act=range:days>90 days \u00b7 by day</button>'
 +'<span class=rsp-gap></span>'
 +'<button class="rsp-btn'+(SP.measure==='usd'?' on':'')+'" data-act=measure:usd>dollars</button>'
@@ -44713,18 +44715,36 @@ function spStackText(s,many,meas,i){if(s.kind==='tag')return s.name;if(s.kind===
 if(s.kind==='unattributed'&&many&&s.hosts){var parts=[];Object.keys(s.hosts).forEach(function(hn){var v=(s.hosts[hn][meas]||[])[i]||0;if(v>0)parts.push(hn+' '+(meas==='usd'?fmtUsd(v):fmtTok(Math.round(v))));});
 return 'unattributed'+(parts.length?' ('+parts.join(', ')+')':'');}
 return spStackName(s);}
-function spTipShow(x,y,name,val,sub){if(!spTip){spTip=document.createElement('div');spTip.id='rsp-tip';document.body.appendChild(spTip);}
-// values lead, labels follow; built with textContent — a session name is user data
-spTip.textContent='';var b=document.createElement('b');b.textContent=val;spTip.appendChild(b);
-spTip.appendChild(document.createTextNode(' \u00b7 '+name+' \u00b7 '+sub));
-spTip.style.display='block';
-var w=spTip.offsetWidth,hh=spTip.offsetHeight;
-spTip.style.left=Math.max(6,Math.min(window.innerWidth-w-6,x+12))+'px';
-spTip.style.top=Math.max(6,(y-hh-12))+'px';}
+// ── T293 (the user 2026-09-09): the hover crosshair and the bucket tooltip
+var SP_DOW=['Sun','Mon','Tue','Wed','Thu','Fri','Sat'],SP_MON=['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+var SP_TIP_ROWS=6;   // the tooltip lists the bucket's top several sessions, then folds the rest into one "+N more" line
+// the pointer's bucket: its offset over the chart's rendered width, discretised to the view's own buckets; -1 outside
+function spBucketAt(px,width,n){if(!(width>0)||!(n>0)||!(px>=0)||px>=width)return -1;return Math.min(n-1,Math.floor(px/width*n));}
+// the stamp: the bucket in words — "Wed Sep 9, 3 PM" for an hour, "Wed Sep 9" for a day — read off the KEY (the recorder's
+// local time, like every label here; the zone note says when the viewer's differs); a key it cannot read is shown as it is
+function spStamp(k,range){k=String(k);var y=+k.slice(0,4),mo=+k.slice(5,7),d=+k.slice(8,10);if(!(y>0&&mo>=1&&mo<=12&&d>=1&&d<=31)||k.charAt(4)!=='-'||k.charAt(7)!=='-')return k;
+var s=SP_DOW[new Date(y,mo-1,d).getDay()]+' '+SP_MON[mo-1]+' '+d;if(range!=='hours')return k.length===10?s:k;if(k.length!==13||k.charAt(10)!=='T')return k;var h=+k.slice(11,13);return (h>=0&&h<=23)?s+', '+(h%12===0?12:h%12)+' '+(h<12?'AM':'PM'):k;}
+// the bucket's sessions in spend order (ties keep stack order), zeros dropped, the top `cap` kept and the rest counted;
+// the hovered stack (pin, a stack index) is always listed even past the cap, so the bar under the pointer is named
+function spBucketTop(stacks,meas,i,cap,pin){var rows=[],total=0;for(var s=0;s<stacks.length;s++){var v=(stacks[s][meas]&&stacks[s][meas][i])||0;if(v>0){rows.push({si:s,v:v});total+=v;}}
+rows.sort(function(a,b){return (b.v-a.v)||(a.si-b.si);});var top=rows.slice(0,cap),more=rows.length-top.length;
+if(pin>=0&&more>0&&!top.some(function(r){return r.si===pin;})){var p=null;rows.forEach(function(r){if(r.si===pin)p=r;});if(p){top.push(p);more--;}}return {rows:top,more:more,total:total};}
+function spDot(s){return s.kind==='unattributed'?'#8a97a6':s.kind==='other'?SP_OTHER:spColor(s);}   // the hatch's stroke stands in for its texture
+function spTipBox(){if(!spTip){spTip=document.createElement('div');spTip.id='rsp-tip';document.body.appendChild(spTip);}spTip.textContent='';return spTip;}
+// below and to the right of the pointer (the stamp sits at the chart's top, so the two never meet), to its left near
+// the right edge and above it near the bottom, kept inside the viewport; the box takes no pointer events
+function spTipPlace(x,y){spTip.style.display='block';var w=spTip.offsetWidth,hh=spTip.offsetHeight,left=x+14,top=y+18;if(left+w+6>window.innerWidth)left=x-14-w;if(top+hh+6>window.innerHeight)top=y-18-hh;
+spTip.style.left=Math.max(6,left)+'px';spTip.style.top=Math.max(6,top)+'px';}
+// the bucket tooltip: the total leads (the other measure and the stamp follow), then a row per session — a dot in the
+// stack's colour, the name (user data: textContent), the value — the hovered bar's row emphasised, the fold line last
+function spBucketTipShow(x,y,head,total,top,stacks,many,meas,i,pin,fmt){var box=spTipBox(),h=document.createElement('div');h.className='rsp-tip-h';
+var b=document.createElement('b');b.textContent=total;h.appendChild(b);h.appendChild(document.createTextNode(' \u00b7 '+head));box.appendChild(h);
+top.rows.forEach(function(r){var s=stacks[r.si],row=document.createElement('div');row.className='rsp-tip-row'+(r.si===pin?' on':'');
+var dot=document.createElement('i');dot.style.background=spDot(s);row.appendChild(dot);var nm=document.createElement('span');nm.textContent=spStackText(s,many,meas,i);row.appendChild(nm);
+var v=document.createElement('b');v.textContent=fmt(r.v);row.appendChild(v);box.appendChild(row);});
+if(top.more>0||!top.rows.length){var m=document.createElement('div');m.className='rsp-tip-more';m.textContent=top.rows.length?'+'+top.more+' more':'nothing recorded';box.appendChild(m);}
+spTipPlace(x,y);}
 function spTipHide(){if(spTip)spTip.style.display='none';}
-function spBucketLabel(k,range){if(range==='hours'){var m=/^(\\d{4})-(\\d\\d)-(\\d\\d)T(\\d\\d)$/.exec(k);
-return m?(Number(m[2])+'/'+Number(m[3])+' '+m[4]+':00\u2013'+(('0'+((Number(m[4])+1)%24)).slice(-2))+':00'):k;}
-var n=/^(\\d{4})-(\\d\\d)-(\\d\\d)$/.exec(k);return n?(Number(n[2])+'/'+Number(n[3])):k;}
 function renderChart(){var box=document.getElementById('rsp-chart');if(!box||!SP.data)return;
 var d=SP.data,ser=spSeries(d),meas=SP.measure;
 if(!ser||!ser.keys||!ser.keys.length){box.innerHTML='<div class=rsp-note>No history yet.</div>';return;}
@@ -44776,13 +44796,23 @@ if(typeof d.tzOffsetMin==='number'&&d.tzOffsetMin!==mine)tzNote+='<div class=rsp
 var offs={};spHosts(d).forEach(function(x){offs[String(x.tzOffsetMin)]=1;});
 if(Object.keys(offs).length>1)tzNote+='<div class=rsp-note>Hourly buckets are aligned by clock time across machines; daily buckets follow each machine\u2019s own calendar day.</div>';
 box.innerHTML=svg+ylab+'<div class=ru-tip-gx>'+xlab+'</div>'+tzNote;
-// the per-segment hover: session · value · bucket, the mark itself the hit target
+// the hover (T293, the user 2026-09-09): a crosshair at the pointer's bucket — a hairline inside the svg and a stamp
+// naming the bucket in words — with the bucket's sessions in spend order in the tooltip; over a bar the same box, that
+// bar's row emphasised (one shape, so nothing flips as the pointer crosses a bar's edge). Both marks take no pointer
+// events and sit out of the flow (an svg line, an absolutely placed stamp), so nothing moves under the pointer; all
+// three leave with it. Keyboard and touch gain nothing and lose nothing: only pointermove and pointerleave are read.
 var svgEl=box.querySelector('svg');if(!svgEl)return;
-svgEl.onpointermove=function(e){var t=e.target;if(!t||!t.classList||!t.classList.contains('rsp-seg')){spTipHide();return;}
-var i=+t.getAttribute('data-i'),si=+t.getAttribute('data-s'),s=stacks[si];if(!s)return;
-var v=(s[meas]&&s[meas][i])||0,o=(s[meas==='usd'?'tok':'usd']&&s[meas==='usd'?'tok':'usd'][i])||0;
-spTipShow(e.clientX,e.clientY,spStackText(s,many,meas,i),fmt(v),(meas==='usd'?fmtTok(Math.round(o))+' tok':fmtUsd(o))+' \u00b7 '+spBucketLabel(ser.keys[i],SP.range==='day'?'hours':SP.range));};
-svgEl.onpointerleave=spTipHide;}
+var xh=document.createElementNS('http://www.w3.org/2000/svg','line');xh.setAttribute('class','rsp-xh');xh.setAttribute('y1','0');xh.setAttribute('y2',String(H));xh.style.display='none';svgEl.appendChild(xh);
+var stamp=document.createElement('div');stamp.className='rsp-xh-stamp';stamp.style.display='none';box.appendChild(stamp);
+var range=SP.range==='day'?'hours':SP.range,other=meas==='usd'?'tok':'usd',ofmt=function(v){return meas==='usd'?fmtTok(Math.round(v))+' tok':fmtUsd(v);};
+var xhHide=function(){xh.style.display='none';stamp.style.display='none';spTipHide();};
+svgEl.onpointermove=function(e){var r=svgEl.getBoundingClientRect(),i=spBucketAt(e.clientX-r.left,r.width,n);if(i<0){xhHide();return;}
+var cx=(i+0.5)*slot,pct=cx/W*100;xh.setAttribute('x1',cx.toFixed(1));xh.setAttribute('x2',cx.toFixed(1));xh.style.display='';
+var st=spStamp(ser.keys[i],range);stamp.textContent=st;stamp.style.left=pct.toFixed(1)+'%';stamp.className='rsp-xh-stamp'+(pct>70?' flip':'');stamp.style.display='';
+var t=e.target,pin=(t&&t.classList&&t.classList.contains('rsp-seg'))?+t.getAttribute('data-s'):-1;
+var top=spBucketTop(stacks,meas,i,SP_TIP_ROWS,pin),ot=0;for(var s=0;s<stacks.length;s++)ot+=(stacks[s][other]&&stacks[s][other][i])||0;
+spBucketTipShow(e.clientX,e.clientY,ofmt(ot)+' \u00b7 '+st,fmt(top.total),top,stacks,many,meas,i,pin,fmt);};
+svgEl.onpointerleave=xhHide;}
 var spResizeRaf=0;
 window.addEventListener('resize',function(){if(!(SP.open&&SP.data)||spResizeRaf)return;
 spResizeRaf=requestAnimationFrame(function(){spResizeRaf=0;if(SP.open&&SP.data){renderChart();spSizePane();}});});
@@ -47210,9 +47240,19 @@ def _landing():
             "#rsp-chart{position:relative}.rsp-svg{display:block;width:100%;background:rgba(255,255,255,0.04);border-radius:3px}"
             ".rsp-grid{stroke:rgba(255,255,255,0.10);stroke-width:1}"
             ".rsp-seg{cursor:pointer}.rsp-seg:hover{filter:brightness(1.18)}"
+            # T293: the crosshair — a hairline in the svg and a stamp out of the flow, both pointer-inert (nothing moves
+            # under the pointer); the stamp wears the surface's 10px annotation size (the notes' and the hint's)
+            ".rsp-xh{stroke:rgba(255,255,255,0.45);stroke-width:1;pointer-events:none}"
+            ".rsp-xh-stamp{position:absolute;top:4px;transform:translateX(6px);font-size:10px;line-height:1;padding:3px 5px;border-radius:3px;"
+            "background:rgba(30,30,30,0.88);color:#cfd6dd;pointer-events:none;white-space:nowrap}.rsp-xh-stamp.flip{transform:translateX(calc(-100% - 6px))}"
             "#rsp-tip{position:fixed;z-index:310;pointer-events:none;display:none;background:#1e1e1e;border:1px solid #3a3a3a;"
             "border-radius:6px;padding:5px 8px;color:#cfd6dd;font:500 11px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;"
             "box-shadow:0 5px 18px rgba(0,0,0,0.45)}#rsp-tip b{color:#e8eef5;font-weight:700}"
+            # T293: the bucket tooltip's rows — a dot in the stack's colour, the name (clipped, never wrapping), the value;
+            # the hovered bar's row emphasised; the fold line quiet
+            ".rsp-tip-h{margin-bottom:3px}.rsp-tip-row{display:flex;align-items:center;gap:6px;line-height:1.5}.rsp-tip-row i{flex:none;width:8px;height:8px;border-radius:2px}"
+            ".rsp-tip-row span{flex:1;min-width:0;max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}"
+            ".rsp-tip-row.on span{color:#e8eef5;font-weight:700}.rsp-tip-more{opacity:.6;margin-top:2px}"
             "#ah-tip,#ru-tip{position:fixed;z-index:300;background:#1e1e1e;border:1px solid #3a3a3a;border-radius:7px;"
             "padding:8px 10px;font:500 11px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#cfd6dd;"
             "box-shadow:0 5px 18px rgba(0,0,0,0.45);pointer-events:none;line-height:1.4}"
@@ -47549,6 +47589,8 @@ def _landing():
             "body.theme-light .rsp-svg{background:rgba(0,0,0,0.04)}body.theme-light .rsp-grid{stroke:rgba(0,0,0,0.10)}"
             "body.theme-light #rsp-tip{background:#FFFFFF;border-color:rgba(0,0,0,0.12);color:#1F1E1D;"
             "box-shadow:0 5px 18px rgba(31,26,20,0.18)}body.theme-light #rsp-tip b{color:#1F1E1D}"
+            "body.theme-light .rsp-xh{stroke:rgba(0,0,0,0.40)}body.theme-light .rsp-xh-stamp{background:rgba(255,255,255,0.92);color:#1F1E1D}"
+            "body.theme-light .rsp-tip-row.on span{color:#1F1E1D}"
             "body.theme-light .ru-tip-name{color:#1F1E1D}"
             "body.theme-light .ru-name{color:#5D574E}"
             "body.theme-light .ru-pct{color:#1F1E1D}"

--- a/tests/spend_modal_headless.js
+++ b/tests/spend_modal_headless.js
@@ -44,6 +44,39 @@ const { chromium } = require('playwright');
     railOpacity: getComputedStyle(document.getElementById('rail-usage')).opacity,
   }));
   if (shots) { await pg.screenshot({ path: shots + '-dark.png' }); const ch = await pg.$('#rsp-chart'); if (ch) await ch.screenshot({ path: shots + '-chart.png' }); }
+  // T293: the crosshair. Hover the chart clear of every bar (its top 2px: the tallest bar stops at the 6px pad) at a
+  // fraction of its width and read the hairline, the stamp and the tooltip's rows; the marks must take no pointer
+  // events and move nothing under the pointer
+  const hBefore = await pg.evaluate(() => document.getElementById('rsp-chart').getBoundingClientRect().height);
+  const week = await pg.evaluate(() => ({ label: document.querySelector('#rsp-panel [data-act="range:hours"]').textContent }));
+  const xhProbe = async (fx, fy) => {
+    const r = await pg.evaluate(() => { const s = document.querySelector('#rsp-chart svg'); s.scrollIntoView({ block: 'center' }); const b = s.getBoundingClientRect(); return { x: b.x, y: b.y, w: b.width, h: b.height }; });
+    await pg.mouse.move(r.x + r.w * fx, r.y + r.h * fy);
+    await pg.waitForTimeout(60);
+    return pg.evaluate(() => {
+      const line = document.querySelector('#rsp-chart .rsp-xh'), st = document.querySelector('#rsp-chart .rsp-xh-stamp'), t = document.getElementById('rsp-tip');
+      const rows = t ? Array.from(t.querySelectorAll('.rsp-tip-row')).map((r) => ({ name: r.querySelector('span').textContent, v: r.querySelector('b').textContent, dot: r.querySelector('i').style.backgroundColor, on: r.classList.contains('on') })) : [];
+      const more = t && t.querySelector('.rsp-tip-more'); const head = t && t.querySelector('.rsp-tip-h');
+      return { lineShown: !!line && line.style.display !== 'none', x1: line ? line.getAttribute('x1') : null, stamp: st ? st.textContent : null, stampShown: !!st && st.style.display !== 'none',
+        flip: !!st && st.classList.contains('flip'), lineInert: line ? getComputedStyle(line).pointerEvents : null, stampInert: st ? getComputedStyle(st).pointerEvents : null,
+        stampFont: st ? getComputedStyle(st).fontSize : null, tipShown: !!t && t.style.display === 'block', tipInert: t ? getComputedStyle(t).pointerEvents : null,
+        head: head ? head.textContent : null, rows, more: more ? more.textContent : null, chartH: document.getElementById('rsp-chart').getBoundingClientRect().height };
+    });
+  };
+  const xh = await xhProbe(0.69, 0.01);   // a recorded bucket: the fixture's ledger holds the last 60 hours of the 168
+  if (shots) { await pg.screenshot({ path: shots + '-xh-7day-dark.png' }); await pg.evaluate(() => document.body.classList.add('theme-light')); await pg.waitForTimeout(120); await pg.screenshot({ path: shots + '-xh-7day-light.png' }); await pg.evaluate(() => document.body.classList.remove('theme-light')); }
+  const xhRight = await xhProbe(0.9, 0.01);   // another bucket: the line follows; near the right edge the stamp flips to its left
+  xh.movedX1 = xhRight.x1; xh.flip = xhRight.flip;
+  await pg.mouse.move(5, 400); await pg.waitForTimeout(60);
+  const xhAfter = await pg.evaluate(() => { const line = document.querySelector('#rsp-chart .rsp-xh'), st = document.querySelector('#rsp-chart .rsp-xh-stamp'), t = document.getElementById('rsp-tip'); return { line: line ? line.style.display : null, stamp: st ? st.style.display : null, tip: t ? t.style.display : null }; });
+  // the 1-day view: an hourly stamp too; then back to the 7-day view the rest of the run expects
+  await pg.click('#rsp-panel [data-act="range:day"]');
+  await pg.waitForFunction(() => document.querySelector('#rsp-panel [data-act="range:day"]').classList.contains('on'), null, { timeout: 5000 });
+  const xhDay = await xhProbe(0.5, 0.01);
+  if (shots) { await pg.screenshot({ path: shots + '-xh-1day-dark.png' }); await pg.evaluate(() => document.body.classList.add('theme-light')); await pg.waitForTimeout(120); await pg.screenshot({ path: shots + '-xh-1day-light.png' }); await pg.evaluate(() => document.body.classList.remove('theme-light')); }
+  await pg.mouse.move(5, 400);
+  await pg.click('#rsp-panel [data-act="range:hours"]');
+  await pg.waitForFunction(() => document.querySelector('#rsp-panel [data-act="range:hours"]').classList.contains('on'), null, { timeout: 5000 });
   // T247f: "your order"
   await pg.click('#rsp-panel [data-act="order:yours"]');
   await pg.waitForFunction(() => document.querySelector('#rsp-panel [data-act="order:yours"]').classList.contains('on'), null, { timeout: 5000 });
@@ -73,6 +106,8 @@ const { chromium } = require('playwright');
     ylabels: Array.from(document.querySelectorAll('#rsp-chart .ru-tip-gy')).map((e) => e.textContent),
     xlabels: Array.from(document.querySelectorAll('#rsp-chart .ru-tip-gx span')).map((e) => e.textContent),
   }));
+  const xhDays = await xhProbe(0.9, 0.01);   // T293: the daily view's stamp is a date; dozens of sessions fold into one line
+  await pg.mouse.move(5, 400); await pg.waitForTimeout(60);
   // hover the TALLEST segment (a sliver has no reliable hit box); measured in the page, scrolled into view
   const bb = await pg.evaluate(() => {
     let best = null;
@@ -88,6 +123,7 @@ const { chromium } = require('playwright');
   await pg.mouse.move(bb2.x + bb2.width / 2, bb2.y + bb2.height / 2);
   await pg.waitForFunction(() => { const t = document.getElementById('rsp-tip'); return t && t.style.display === 'block'; }, null, { timeout: 5000 });
   const tip = await pg.evaluate(() => document.getElementById('rsp-tip').textContent);
+  const tipOn = await pg.evaluate(() => { const on = document.querySelector('#rsp-tip .rsp-tip-row.on span'); const line = document.querySelector('#rsp-chart .rsp-xh'); return { name: on ? on.textContent : null, lineShown: !!line && line.style.display !== 'none' }; });
   if (shots) await pg.screenshot({ path: shots + '-days-tokens.png' });
   await pg.mouse.move(5, 5);
   if (shots) {
@@ -158,7 +194,7 @@ const { chromium } = require('playwright');
     const names = [];
     for (const [, p] of byIdx) { const r = p.getBoundingClientRect(); if (r.height < 1) continue;
       p.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientX: r.x + r.width / 2, clientY: r.y + r.height / 2 }));
-      const t = document.getElementById('rsp-tip'); if (t && t.style.display === 'block') { const parts = t.textContent.split(' · '); names.push((parts[1] || '').trim()); } }
+      const t = document.getElementById('rsp-tip'); if (t && t.style.display === 'block') { const on = t.querySelector('.rsp-tip-row.on span'); names.push(on ? on.textContent.trim() : ''); } }
     const t = document.getElementById('rsp-tip'); if (t) t.style.display = 'none';
     return names;
   });
@@ -197,6 +233,6 @@ const { chromium } = require('playwright');
     first: (document.querySelector('#rsp-panel .rsp-tbl tbody tr') || {}).textContent || '' }));
   await pg.click('#rsp-panel [data-act="order:spend"]');   // restore the default for whoever runs next
   const mobile = { railHidden, panelOpened: true, modalOpened: true, btn, panelHint , persisted };
-  console.log(JSON.stringify({ merge, yourOrder, hoverHint, hiddenBefore, loaderSeen, out, days, tip, hiddenAfter, hiddenAfterTap, hiddenAfterDrag, lightErr, lightBtn, dim, timeout, mobile, errs }));
+  console.log(JSON.stringify({ merge, yourOrder, hoverHint, hiddenBefore, loaderSeen, out, days, tip, tipOn, xh, xhAfter, xhDay, xhDays, week, hBefore, hiddenAfter, hiddenAfterTap, hiddenAfterDrag, lightErr, lightBtn, dim, timeout, mobile, errs }));
   await b.close();
 })().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/spend_modal_headless.js
+++ b/tests/spend_modal_headless.js
@@ -39,7 +39,7 @@ const { chromium } = require('playwright');
     backdrop: getComputedStyle(document.getElementById('rsp-back')).backgroundColor,
     windows: Array.from(document.querySelectorAll('#rsp-panel .ru-tip-fleetspend .ru-tip-row .ru-tip-k')).map((e) => e.textContent),
     notes: Array.from(document.querySelectorAll('#rsp-panel .rsp-note')).map((e) => e.textContent),
-    xlabels: Array.from(document.querySelectorAll('#rsp-chart .ru-tip-gx span')).map((e) => e.textContent).join(''),
+    xlabels: Array.from(document.querySelectorAll('#rsp-chart .ru-tip-gx span')).map((e) => e.textContent),
     ylabels: Array.from(document.querySelectorAll('#rsp-chart .ru-tip-gy')).map((e) => e.textContent),
     railOpacity: getComputedStyle(document.getElementById('rail-usage')).opacity,
   }));
@@ -49,8 +49,8 @@ const { chromium } = require('playwright');
   // events and move nothing under the pointer
   const hBefore = await pg.evaluate(() => document.getElementById('rsp-chart').getBoundingClientRect().height);
   const week = await pg.evaluate(() => ({ label: document.querySelector('#rsp-panel [data-act="range:hours"]').textContent }));
-  const xhProbe = async (fx, fy) => {
-    const r = await pg.evaluate(() => { const s = document.querySelector('#rsp-chart svg'); s.scrollIntoView({ block: 'center' }); const b = s.getBoundingClientRect(); return { x: b.x, y: b.y, w: b.width, h: b.height }; });
+  const xhProbe = async (fx, fy, scroll) => {
+    const r = await pg.evaluate((scroll) => { const s = document.querySelector('#rsp-chart svg'); if (scroll === 'top') document.getElementById('rsp-panel').scrollTop = 0; else s.scrollIntoView({ block: 'center' }); const b = s.getBoundingClientRect(); return { x: b.x, y: b.y, w: b.width, h: b.height }; }, scroll || 'center');
     await pg.mouse.move(r.x + r.w * fx, r.y + r.h * fy);
     await pg.waitForTimeout(60);
     return pg.evaluate(() => {
@@ -60,13 +60,18 @@ const { chromium } = require('playwright');
       return { lineShown: !!line && line.style.display !== 'none', x1: line ? line.getAttribute('x1') : null, stamp: st ? st.textContent : null, stampShown: !!st && st.style.display !== 'none',
         flip: !!st && st.classList.contains('flip'), lineInert: line ? getComputedStyle(line).pointerEvents : null, stampInert: st ? getComputedStyle(st).pointerEvents : null,
         stampFont: st ? getComputedStyle(st).fontSize : null, tipShown: !!t && t.style.display === 'block', tipInert: t ? getComputedStyle(t).pointerEvents : null,
-        head: head ? head.textContent : null, rows, more: more ? more.textContent : null, chartH: document.getElementById('rsp-chart').getBoundingClientRect().height };
+        head: head ? head.textContent : null, rows, more: more ? more.textContent : null, chartH: document.getElementById('rsp-chart').getBoundingClientRect().height,
+        stampLeft: st ? st.getBoundingClientRect().left : null, gyRight: (() => { const g = document.querySelector('#rsp-chart .ru-tip-gy'); return g ? g.getBoundingClientRect().right : null; })(),
+        tipRect: t ? (() => { const b = t.getBoundingClientRect(); return { top: b.top, bottom: b.bottom, left: b.left, right: b.right }; })() : null,
+        stampRect: st ? (() => { const b = st.getBoundingClientRect(); return { top: b.top, bottom: b.bottom, left: b.left, right: b.right }; })() : null };
     });
   };
   const xh = await xhProbe(0.69, 0.01);   // a recorded bucket: the fixture's ledger holds the last 60 hours of the 168
   if (shots) { await pg.screenshot({ path: shots + '-xh-7day-dark.png' }); await pg.evaluate(() => document.body.classList.add('theme-light')); await pg.waitForTimeout(120); await pg.screenshot({ path: shots + '-xh-7day-light.png' }); await pg.evaluate(() => document.body.classList.remove('theme-light')); }
   const xhRight = await xhProbe(0.9, 0.01);   // another bucket: the line follows; near the right edge the stamp flips to its left
   xh.movedX1 = xhRight.x1; xh.flip = xhRight.flip;
+  const xhLeft = await xhProbe(0.005, 0.01);   // the first bucket: unflipped, and the stamp starts past the ceiling label
+  xh.flipLeft = xhLeft.flip; xh.stampLeft = xhLeft.stampLeft; xh.gyRight = xhLeft.gyRight;
   await pg.mouse.move(5, 400); await pg.waitForTimeout(60);
   const xhAfter = await pg.evaluate(() => { const line = document.querySelector('#rsp-chart .rsp-xh'), st = document.querySelector('#rsp-chart .rsp-xh-stamp'), t = document.getElementById('rsp-tip'); return { line: line ? line.style.display : null, stamp: st ? st.style.display : null, tip: t ? t.style.display : null }; });
   // the 1-day view: an hourly stamp too; then back to the 7-day view the rest of the run expects
@@ -74,6 +79,9 @@ const { chromium } = require('playwright');
   await pg.waitForFunction(() => document.querySelector('#rsp-panel [data-act="range:day"]').classList.contains('on'), null, { timeout: 5000 });
   const xhDay = await xhProbe(0.5, 0.01);
   if (shots) { await pg.screenshot({ path: shots + '-xh-1day-dark.png' }); await pg.evaluate(() => document.body.classList.add('theme-light')); await pg.waitForTimeout(120); await pg.screenshot({ path: shots + '-xh-1day-light.png' }); await pg.evaluate(() => document.body.classList.remove('theme-light')); }
+  await pg.setViewportSize({ width: 1200, height: 820 }); await pg.waitForTimeout(250);   // a rebuild under a still pointer takes the tooltip down with the svg
+  const afterResize = await pg.evaluate(() => { const t = document.getElementById('rsp-tip'), line = document.querySelector('#rsp-chart .rsp-xh'), st = document.querySelector('#rsp-chart .rsp-xh-stamp'); return { tip: t ? t.style.display : null, line: line ? line.style.display : null, stamp: st ? st.style.display : null }; });
+  await pg.setViewportSize({ width: 1280, height: 820 }); await pg.waitForTimeout(250);
   await pg.mouse.move(5, 400);
   await pg.click('#rsp-panel [data-act="range:hours"]');
   await pg.waitForFunction(() => document.querySelector('#rsp-panel [data-act="range:hours"]').classList.contains('on'), null, { timeout: 5000 });
@@ -108,6 +116,11 @@ const { chromium } = require('playwright');
   }));
   const xhDays = await xhProbe(0.9, 0.01);   // T293: the daily view's stamp is a date; dozens of sessions fold into one line
   await pg.mouse.move(5, 400); await pg.waitForTimeout(60);
+  // a short window with the card unscrolled: no room below the pointer, so the box goes above the CHART, clear of the stamp (review find)
+  await pg.setViewportSize({ width: 1280, height: 600 }); await pg.waitForTimeout(250);
+  const xhShort = await xhProbe(0.9, 0.85, 'top');
+  await pg.mouse.move(5, 5); await pg.waitForTimeout(60);
+  await pg.setViewportSize({ width: 1280, height: 820 }); await pg.waitForTimeout(250);
   // hover the TALLEST segment (a sliver has no reliable hit box); measured in the page, scrolled into view
   const bb = await pg.evaluate(() => {
     let best = null;
@@ -233,6 +246,6 @@ const { chromium } = require('playwright');
     first: (document.querySelector('#rsp-panel .rsp-tbl tbody tr') || {}).textContent || '' }));
   await pg.click('#rsp-panel [data-act="order:spend"]');   // restore the default for whoever runs next
   const mobile = { railHidden, panelOpened: true, modalOpened: true, btn, panelHint , persisted };
-  console.log(JSON.stringify({ merge, yourOrder, hoverHint, hiddenBefore, loaderSeen, out, days, tip, tipOn, xh, xhAfter, xhDay, xhDays, week, hBefore, hiddenAfter, hiddenAfterTap, hiddenAfterDrag, lightErr, lightBtn, dim, timeout, mobile, errs }));
+  console.log(JSON.stringify({ merge, yourOrder, hoverHint, hiddenBefore, loaderSeen, out, days, tip, tipOn, xh, xhAfter, xhDay, xhDays, xhShort, afterResize, week, hBefore, hiddenAfter, hiddenAfterTap, hiddenAfterDrag, lightErr, lightBtn, dim, timeout, mobile, errs }));
   await b.close();
 })().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/test_spend_detail.py
+++ b/tests/test_spend_detail.py
@@ -276,7 +276,7 @@ class SpendDetail(unittest.TestCase):
         # T247b review find: the recorder rounds the bucket sum and each sid's sum independently (6
         # places), so a fully attributed bucket can carry a +1e-6..+6e-6 dollar residue with zero token
         # residue — 28 of 113 live hour buckets did — and the presence test on the unrounded residues
-        # hung a hatched "unattributed" chip with no bars on the 8-day view. Below the rounding grain
+        # hung a hatched "unattributed" chip with no bars on the hourly view. Below the rounding grain
         # a residue is zero: no stack, no row.
         hours, days = {}, {}
         for n in range(0, 40):
@@ -646,8 +646,9 @@ class SpendDetail(unittest.TestCase):
         self.assertIn("stamp.className='rsp-xh-stamp'", js)
         self.assertIn("svgEl.onpointerleave=xhHide;", js, "the line, the stamp and the tooltip leave with the pointer")
         self.assertIn(".rsp-xh{stroke:rgba(255,255,255,0.45);stroke-width:1;pointer-events:none}", html)
-        self.assertIn(".rsp-xh-stamp{position:absolute;", html)
-        self.assertIn("pointer-events:none;white-space:nowrap}", html, "the stamp takes no pointer events")
+        self.assertIn(".rsp-xh-stamp{position:absolute;top:4px;transform:translateX(6px);font-size:10px;line-height:1;padding:3px 5px;border-radius:3px;"
+                      "background:rgba(30,30,30,0.88);color:#cfd6dd;pointer-events:none;white-space:nowrap}", html,
+                      "the stamp: out of the flow, the surface's 10px annotation size, no pointer events")
         self.assertIn("body.theme-light .rsp-xh{", html, "a light step for the hairline")
         self.assertIn("body.theme-light .rsp-xh-stamp{", html, "…and for the stamp")
         self.assertIn(".rsp-tip-row i{", html, "a row's dot wears its stack's colour")

--- a/tests/test_spend_detail.py
+++ b/tests/test_spend_detail.py
@@ -631,11 +631,27 @@ class SpendDetail(unittest.TestCase):
         self.assertIn("var SP_PREFS_KEY='romp:spendModal';", js)
         # T247g: three ranges and the merge toggle, persisted with the rest
         self.assertIn('data-act=range:day>1 day ', js)
-        self.assertIn('data-act=range:hours>8 days ', js)
+        self.assertIn('data-act=range:hours>7 days ', js)   # T293: 7 days over 168 hourly buckets (the ledger's 192 keep a day of slack)
+        self.assertNotIn('8 days', js)
         self.assertIn('data-act=range:days>90 days ', js)
         self.assertIn('data-act=merge:toggle>merge by tag</button>', js)
         self.assertIn("JSON.stringify({range:SP.range,measure:SP.measure,order:SP.order,merge:SP.merge})", js)
         self.assertIn("localStorage.getItem('romp:vieworder')", js, "the viewer's arrangement is the strip's own key")
+        # T293 (the user 2026-09-09): the hover crosshair — a pointer-inert hairline inside the svg at the pointer's
+        # bucket, a stamp naming the bucket in words placed out of the flow (nothing moves under the pointer), and the
+        # tooltip listing that bucket's sessions in spend order; all three leave with the pointer. The pure functions
+        # are executed by ui/webview/spend-crosshair.test.ts; the served-page test hovers the real chart.
+        self.assertIn("var SP_RANGE_BUCKETS={day:24,hours:168};", js)
+        self.assertIn("xh.setAttribute('class','rsp-xh');", js)
+        self.assertIn("stamp.className='rsp-xh-stamp'", js)
+        self.assertIn("svgEl.onpointerleave=xhHide;", js, "the line, the stamp and the tooltip leave with the pointer")
+        self.assertIn(".rsp-xh{stroke:rgba(255,255,255,0.45);stroke-width:1;pointer-events:none}", html)
+        self.assertIn(".rsp-xh-stamp{position:absolute;", html)
+        self.assertIn("pointer-events:none;white-space:nowrap}", html, "the stamp takes no pointer events")
+        self.assertIn("body.theme-light .rsp-xh{", html, "a light step for the hairline")
+        self.assertIn("body.theme-light .rsp-xh-stamp{", html, "…and for the stamp")
+        self.assertIn(".rsp-tip-row i{", html, "a row's dot wears its stack's colour")
+        self.assertNotIn("function spTipShow(", js, "the one-segment tip is gone: the bucket tooltip serves a bar too")
         # the landing page loads no stylesheet, so the strip's two rules are inlined as a TWIN; this pins the
         # twin's declarations against the source so the two cannot drift
         import re as _re

--- a/tests/test_spend_modal_headless.py
+++ b/tests/test_spend_modal_headless.py
@@ -211,6 +211,39 @@ class SpendModalServed(unittest.TestCase):
         self.assertTrue(o["days"]["segs"] > 0 and not o["days"]["ylabels"][0].startswith("$"), "tokens on the toggle")
         self.assertTrue(any("/" in x for x in o["days"]["xlabels"]), "date labels on the daily range")
         self.assertIn("·", o["tip"], "a segment hover names value · session · bucket")
+        # T293 (the user 2026-09-09): the crosshair. Hovering the chart clear of every bar draws the hairline at the
+        # pointer's bucket and a stamp in words; the tooltip lists that bucket's sessions in spend order in their stack
+        # colours; over a bar the same box names the bar's session on its emphasised row; the marks take no pointer
+        # events, move nothing under the pointer, and leave with it
+        xh = o["xh"]
+        self.assertTrue(xh["lineShown"] and xh["stampShown"] and xh["tipShown"], xh)
+        self.assertRegex(xh["stamp"], r"^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) [A-Z][a-z]{2} \d{1,2}, \d{1,2} (AM|PM)$")
+        self.assertIn(xh["stamp"], xh["head"], "the tooltip's header carries the stamp")
+        self.assertTrue(xh["head"].startswith("$"), "the bucket's total leads: " + xh["head"])
+        self.assertGreaterEqual(len(xh["rows"]), 2, xh["rows"])
+        vals = [int(r["v"].replace("$", "").replace(",", "")) for r in xh["rows"] if r["v"].startswith("$")]
+        self.assertEqual(vals, sorted(vals, reverse=True), "spend order: " + json.dumps(xh["rows"]))
+        self.assertTrue(all(r["dot"] for r in xh["rows"]), "every row wears its stack's colour")
+        self.assertFalse(any(r["on"] for r in xh["rows"]), "no bar under the pointer, no emphasised row")
+        self.assertEqual((xh["lineInert"], xh["stampInert"], xh["tipInert"]), ("none", "none", "none"), "pointer-inert marks")
+        self.assertEqual(xh["stampFont"], "10px", "the surface's annotation size")
+        self.assertEqual(xh["chartH"], o["hBefore"], "nothing moves under the pointer")
+        self.assertNotEqual(xh["movedX1"], xh["x1"], "the line follows the pointer to another bucket")
+        self.assertTrue(xh["flip"], "near the right edge the stamp sits to the line's left")
+        self.assertEqual(o["xhAfter"], {"line": "none", "stamp": "none", "tip": "none"}, "all three leave with the pointer")
+        # the middle range is 7 days: the label, and seven local midnights on the axis (192 hours carried eight)
+        self.assertEqual(o["week"]["label"], "7 days · by hour")
+        self.assertEqual(len(o["out"]["xlabels"]), 7, o["out"]["xlabels"])
+        # the 1-day view stamps hours too; the 90-day view stamps dates and folds dozens of sessions into one line
+        self.assertRegex(o["xhDay"]["stamp"], r", \d{1,2} (AM|PM)$")
+        self.assertTrue(o["xhDay"]["tipShown"], o["xhDay"])
+        xd = o["xhDays"]
+        self.assertRegex(xd["stamp"], r"^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) [A-Z][a-z]{2} \d{1,2}$")
+        self.assertEqual(len(xd["rows"]), 6, "the top several: " + json.dumps(xd["rows"]))
+        self.assertRegex(xd["more"] or "", r"^\+\d+ more$")
+        # over a bar: the same box with the bar's row emphasised and named, the line still up
+        self.assertTrue(o["tipOn"]["name"], o["tipOn"])
+        self.assertTrue(o["tipOn"]["lineShown"])
         self.assertTrue(o["hiddenAfter"], "Escape closes it")
         self.assertTrue(o["hiddenAfterTap"], "a backdrop tap closes it")
         self.assertFalse(o["hiddenAfterDrag"], "…but a drag-select that ends over the backdrop does not (review find)")

--- a/tests/test_spend_modal_headless.py
+++ b/tests/test_spend_modal_headless.py
@@ -8,6 +8,7 @@ LOUDLY without a playwright: set ROMP_PLAYWRIGHT_NODE_PATH to a node_modules hol
 not; this is the maintainer's screenshot harness too — pass ROMP_SHOTS=<path-prefix> for PNGs)."""
 import json
 import os
+import re
 import subprocess
 import tempfile
 import threading
@@ -210,7 +211,7 @@ class SpendModalServed(unittest.TestCase):
         self.assertTrue(o["out"]["xlabels"], "weekday initials at the ledger's midnights")
         self.assertTrue(o["days"]["segs"] > 0 and not o["days"]["ylabels"][0].startswith("$"), "tokens on the toggle")
         self.assertTrue(any("/" in x for x in o["days"]["xlabels"]), "date labels on the daily range")
-        self.assertIn("·", o["tip"], "a segment hover names value · session · bucket")
+        self.assertIn("·", o["tip"], "the bucket tooltip's header reads total · other measure · stamp")
         # T293 (the user 2026-09-09): the crosshair. Hovering the chart clear of every bar draws the hairline at the
         # pointer's bucket and a stamp in words; the tooltip lists that bucket's sessions in spend order in their stack
         # colours; over a bar the same box names the bar's session on its emphasised row; the marks take no pointer
@@ -221,8 +222,10 @@ class SpendModalServed(unittest.TestCase):
         self.assertIn(xh["stamp"], xh["head"], "the tooltip's header carries the stamp")
         self.assertTrue(xh["head"].startswith("$"), "the bucket's total leads: " + xh["head"])
         self.assertGreaterEqual(len(xh["rows"]), 2, xh["rows"])
-        vals = [int(r["v"].replace("$", "").replace(",", "")) for r in xh["rows"] if r["v"].startswith("$")]
-        self.assertEqual(vals, sorted(vals, reverse=True), "spend order: " + json.dumps(xh["rows"]))
+        def _num(s):   # fmtTok's three-significant-figure spelling: 480k, 96.0k, 1.00k, 1.2M
+            m = re.match(r"^([\d.]+)([kMB]?)$", s.replace(",", "").strip())
+            self.assertIsNotNone(m, s)
+            return float(m.group(1)) * {"": 1, "k": 1e3, "M": 1e6, "B": 1e9}[m.group(2)]
         self.assertTrue(all(r["dot"] for r in xh["rows"]), "every row wears its stack's colour")
         self.assertFalse(any(r["on"] for r in xh["rows"]), "no bar under the pointer, no emphasised row")
         self.assertEqual((xh["lineInert"], xh["stampInert"], xh["tipInert"]), ("none", "none", "none"), "pointer-inert marks")
@@ -230,8 +233,14 @@ class SpendModalServed(unittest.TestCase):
         self.assertEqual(xh["chartH"], o["hBefore"], "nothing moves under the pointer")
         self.assertNotEqual(xh["movedX1"], xh["x1"], "the line follows the pointer to another bucket")
         self.assertTrue(xh["flip"], "near the right edge the stamp sits to the line's left")
+        self.assertFalse(xh["flipLeft"], "…and at the first bucket to its right")
+        self.assertGreaterEqual(xh["stampLeft"], xh["gyRight"], "the stamp starts past the ceiling label, never over it (review find)")
+        self.assertEqual(o["afterResize"], {"tip": "none", "line": "none", "stamp": "none"}, "a rebuild under a still pointer takes all three down (review find)")
         self.assertEqual(o["xhAfter"], {"line": "none", "stamp": "none", "tip": "none"}, "all three leave with the pointer")
-        # the middle range is 7 days: the label, and seven local midnights on the axis (192 hours carried eight)
+        # the middle range is 7 days: the label, and seven local midnights on the axis (192 hours carried eight). The
+        # fixture's NOW is 15:30 local and the keys are the recorder's local hours, so the 168-hour tail holds seven T00
+        # keys in any zone whose clock change falls at 1-3 AM; a zone that springs forward AT midnight would drop one:
+        # the runner's zone, not the code, is what this pin assumes
         self.assertEqual(o["week"]["label"], "7 days · by hour")
         self.assertEqual(len(o["out"]["xlabels"]), 7, o["out"]["xlabels"])
         # the 1-day view stamps hours too; the 90-day view stamps dates and folds dozens of sessions into one line
@@ -241,6 +250,14 @@ class SpendModalServed(unittest.TestCase):
         self.assertRegex(xd["stamp"], r"^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) [A-Z][a-z]{2} \d{1,2}$")
         self.assertEqual(len(xd["rows"]), 6, "the top several: " + json.dumps(xd["rows"]))
         self.assertRegex(xd["more"] or "", r"^\+\d+ more$")
+        tv = [_num(r["v"]) for r in xd["rows"]]
+        self.assertEqual(tv, sorted(tv, reverse=True), "spend order: " + json.dumps(xd["rows"]))
+        self.assertGreater(tv[0], tv[-1], "rows whose values differ, so the order pin can fail (review find: the hourly rows tied at $1)")
+        # a short window: with no room below the pointer the box goes above the chart, never over the stamp
+        xs = o["xhShort"]
+        self.assertTrue(xs["tipShown"] and xs["stampShown"], xs)
+        tr, sr = xs["tipRect"], xs["stampRect"]
+        self.assertLess(tr["bottom"], sr["top"], "the box sits above the chart, clear of the stamp: " + json.dumps({"tip": tr, "stamp": sr}))
         # over a bar: the same box with the bar's row emphasised and named, the line still up
         self.assertTrue(o["tipOn"]["name"], o["tipOn"])
         self.assertTrue(o["tipOn"]["lineShown"])

--- a/ui/webview/spend-crosshair.test.ts
+++ b/ui/webview/spend-crosshair.test.ts
@@ -1,0 +1,147 @@
+// T293 (the user 2026-09-09): the usage modal's spend chart grows a hover crosshair — a hairline at the pointer's
+// bucket, a stamp naming the bucket in words, and a tooltip listing the bucket's sessions in spend order — and its
+// middle range becomes "7 days · by hour" over 168 hourly buckets (the ledger's 192 keep a day of slack). The
+// landing page loads no webview bundle, so the pieces live inside kernel.py's _LANDING_USAGE_JS as pure functions;
+// this test runs them from the source (the file text is a Python string, so an extracted line may carry no
+// backslash escape) and pins the range rename and that a pick persisted by the old 8-day button reads as 7 days.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
+const USAGE_JS = KERNEL.split('_LANDING_USAGE_JS = """')[1].split('"""')[0];
+const LINES = USAGE_JS.split("\n");
+
+/** the line starting with `start`, plus `extra` following lines (a function that wraps) */
+function block(start: string, extra = 0): string {
+  const i = LINES.findIndex((l) => l.startsWith(start));
+  assert.ok(i >= 0, "the landing JS carries a line starting " + JSON.stringify(start));
+  const src = LINES.slice(i, i + 1 + extra).join("\n");
+  assert.ok(!src.includes("\\"), "no backslash escape in an extracted block (the file text is a Python string): " + start);
+  return src;
+}
+
+function pure(): { spBucketAt: (px: number, width: number, n: number) => number; spStamp: (k: string, range: string) => string;
+  spBucketTop: (stacks: any[], meas: string, i: number, cap: number, pin: number) => { rows: Array<{ si: number; v: number }>; more: number; total: number };
+  SP_RANGE_BUCKETS: Record<string, number>; SP_TIP_ROWS: number } {
+  const src = [block("var SP_DOW="), block("function spBucketAt("), block("function spStamp(", 1), block("function spBucketTop(", 2),
+    block("var SP_RANGE_BUCKETS="), block("var SP_TIP_ROWS=")].join("\n");
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  return new Function(src + "\n; return {spBucketAt:spBucketAt,spStamp:spStamp,spBucketTop:spBucketTop,SP_RANGE_BUCKETS:SP_RANGE_BUCKETS,SP_TIP_ROWS:SP_TIP_ROWS};")();
+}
+
+test("the pointer's bucket: a pixel offset over the chart's width maps onto one of n buckets, and outside is -1", () => {
+  const { spBucketAt } = pure();
+  assert.equal(spBucketAt(0, 600, 24), 0);
+  assert.equal(spBucketAt(24.9, 600, 24), 0);
+  assert.equal(spBucketAt(25, 600, 24), 1, "the second bucket starts at 1/24 of the width");
+  assert.equal(spBucketAt(599.9, 600, 24), 23);
+  assert.equal(spBucketAt(300, 600, 168), 84);
+  assert.equal(spBucketAt(599.99, 600, 90), 89, "never past the last bucket");
+  assert.equal(spBucketAt(-0.1, 600, 24), -1, "left of the chart");
+  assert.equal(spBucketAt(600, 600, 24), -1, "the right edge is outside");
+  assert.equal(spBucketAt(10, 0, 24), -1, "no width, no bucket");
+  assert.equal(spBucketAt(10, 600, 0), -1, "no buckets, no bucket");
+  assert.equal(spBucketAt(NaN, 600, 24), -1);
+});
+
+test("the stamp: an hourly key reads like a calendar entry with a 12-hour clock, a daily key without the hour", () => {
+  const { spStamp } = pure();
+  // 2026-09-09 is a Wednesday; the weekday comes from the calendar date, so it does not depend on the zone
+  assert.equal(spStamp("2026-09-09T15", "hours"), "Wed Sep 9, 3 PM");
+  assert.equal(spStamp("2026-09-09T00", "hours"), "Wed Sep 9, 12 AM");
+  assert.equal(spStamp("2026-09-09T12", "hours"), "Wed Sep 9, 12 PM");
+  assert.equal(spStamp("2026-09-09T23", "hours"), "Wed Sep 9, 11 PM");
+  assert.equal(spStamp("2026-09-09T09", "hours"), "Wed Sep 9, 9 AM");
+  assert.equal(spStamp("2026-01-01T06", "hours"), "Thu Jan 1, 6 AM");
+  assert.equal(spStamp("2026-09-09", "days"), "Wed Sep 9");
+  assert.equal(spStamp("2026-12-25", "days"), "Fri Dec 25");
+  // a key the stamp cannot read is shown as it is, never dressed up (fail loudly)
+  assert.equal(spStamp("nope", "hours"), "nope");
+  assert.equal(spStamp("2026-09-09", "hours"), "2026-09-09", "a day key in an hourly view");
+  assert.equal(spStamp("2026-09-09T15", "days"), "2026-09-09T15", "an hour key in the daily view");
+  assert.equal(spStamp("2026-13-01", "days"), "2026-13-01");
+  assert.equal(spStamp("2026-09-09T24", "hours"), "2026-09-09T24");
+  assert.equal(spStamp("", "days"), "");
+});
+
+test("the bucket's sessions: spend order, zeros dropped, capped with the rest counted, the hovered stack always listed", () => {
+  const { spBucketTop } = pure();
+  const stacks = [
+    { name: "a", usd: [1, 5], tok: [10, 50] },
+    { name: "b", usd: [0, 3] },
+    { name: "c", usd: [2, 8] },
+    { name: "d", usd: [0, 0] },
+    { name: "e", usd: [0, 1] },
+  ];
+  assert.deepEqual(spBucketTop(stacks, "usd", 1, 2, -1), { rows: [{ si: 2, v: 8 }, { si: 0, v: 5 }], more: 2, total: 17 });
+  assert.deepEqual(spBucketTop(stacks, "usd", 1, 2, 4), { rows: [{ si: 2, v: 8 }, { si: 0, v: 5 }, { si: 4, v: 1 }], more: 1, total: 17 },
+    "the hovered stack beyond the cap joins the list and leaves the fold");
+  assert.deepEqual(spBucketTop(stacks, "usd", 1, 2, 2), { rows: [{ si: 2, v: 8 }, { si: 0, v: 5 }], more: 2, total: 17 },
+    "a hovered stack already listed is not listed twice");
+  assert.deepEqual(spBucketTop(stacks, "usd", 1, 2, 3), { rows: [{ si: 2, v: 8 }, { si: 0, v: 5 }], more: 2, total: 17 },
+    "a hovered stack with nothing in the bucket adds no row");
+  assert.deepEqual(spBucketTop(stacks, "usd", 0, 6, -1), { rows: [{ si: 2, v: 2 }, { si: 0, v: 1 }], more: 0, total: 3 }, "zeros are not rows");
+  assert.deepEqual(spBucketTop(stacks, "usd", 1, 10, -1).more, 0, "a cap above the count folds nothing");
+  assert.deepEqual(spBucketTop(stacks, "tok", 1, 6, -1), { rows: [{ si: 0, v: 50 }], more: 0, total: 50 }, "a stack without the measure counts as zero");
+  assert.deepEqual(spBucketTop([{ usd: [2] }, { usd: [2] }, { usd: [3] }], "usd", 0, 6, -1).rows, [{ si: 2, v: 3 }, { si: 0, v: 2 }, { si: 1, v: 2 }],
+    "ties keep the stack order");
+  assert.deepEqual(spBucketTop([], "usd", 0, 6, -1), { rows: [], more: 0, total: 0 });
+});
+
+test("the middle range is 7 days over the hourly ledger's last 168 buckets; 1 day is its last 24; 90 days is whole", () => {
+  const { SP_RANGE_BUCKETS, SP_TIP_ROWS } = pure();
+  assert.deepEqual(SP_RANGE_BUCKETS, { day: 24, hours: 168 });
+  assert.ok(SP_TIP_ROWS >= 4 && SP_TIP_ROWS <= 8, "the tooltip lists the top several, then folds: " + SP_TIP_ROWS);
+  assert.ok(USAGE_JS.includes('data-act=range:hours>7 days \\u00b7 by hour</button>'), "the button says 7 days");
+  assert.ok(!USAGE_JS.includes("8 days"), "no 8-day wording survives in the modal");
+  assert.ok(KERNEL.includes("_SERIES_HOURS = 192"), "the ledger keeps 192 hours: a day of slack past the view");
+  // spSeries executed: the range's tail of a 192-key series
+  const src = [block("var SP_RANGE_BUCKETS="), block("function spSeries(d){"), block("function spTail(ser,keep){", 2)].join("\n");
+  const series = (range: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    const spSeries = new Function("SP", src + "\n; return spSeries;")({ range });
+    const keys = Array.from({ length: 192 }, (_, i) => "k" + i);
+    const d = { hours: { keys, epochs: keys.map((_, i) => 1000 + i),
+      stacks: [{ kind: "sid", sid: "s1", usd: keys.map((_, i) => i), tok: keys.map((_, i) => i * 10), hosts: { A: { usd: keys.map(() => 1), tok: keys.map(() => 2) } } }] },
+      days: { keys: ["d1", "d2"], stacks: [{ usd: [1, 2], tok: [3, 4] }] } };
+    return { d, out: spSeries(d) };
+  };
+  const week = series("hours");
+  assert.equal(week.out.keys.length, 168);
+  assert.equal(week.out.keys[0], "k24", "the LAST 168: the oldest day falls off");
+  assert.equal(week.out.keys[167], "k191");
+  assert.deepEqual(week.out.epochs.slice(0, 2), [1024, 1025]);
+  assert.equal(week.out.stacks[0].usd[0], 24, "every stack is cut with the keys");
+  assert.equal(week.out.stacks[0].tok.length, 168);
+  assert.equal(week.out.stacks[0].hosts.A.usd.length, 168, "a per-host split is cut too");
+  assert.equal(week.out.stacks[0].sid, "s1", "the stack's other fields ride along");
+  const day = series("day");
+  assert.equal(day.out.keys.length, 24);
+  assert.equal(day.out.keys[0], "k168");
+  const days = series("days");
+  assert.equal(days.out, days.d.days, "the daily range is the ledger's series itself");
+  assert.equal(series("hours").d.hours.keys.length, 192, "the input is not cut in place");
+});
+
+test("a persisted pick from the old 8-day button reads as the 7-day view: the stored value is unchanged, its meaning is the new range", () => {
+  const src = [block("var SP={"), block("var SP_PREFS_KEY="), block("function spLoadPrefs(){"), block("var SP_RANGE_BUCKETS=")].join("\n");
+  const load = (stored: any) => {
+    const ls = { getItem: (k: string) => (k === "romp:spendModal" ? JSON.stringify(stored) : null) };
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    return new Function("localStorage", src + "\n; spLoadPrefs(); return {SP:SP,buckets:SP_RANGE_BUCKETS[SP.range]};")(ls);
+  };
+  const old = load({ range: "hours", measure: "usd", order: "spend", merge: false });   // what the 8-day button wrote
+  assert.equal(old.SP.range, "hours");
+  assert.equal(old.buckets, 168, "…and that value now selects 168 hourly buckets");
+  assert.equal(load({ range: "day" }).buckets, 24);
+  assert.equal(load({ range: "days" }).buckets, undefined, "the daily range is uncut");
+  assert.equal(load({ range: "week" }).SP.range, "hours", "an unknown value falls back to the default, the 7-day view");
+  assert.equal(load({}).SP.range, "hours", "no stored range: the default is the 7-day view");
+  // the label the stored value selects
+  const btn = /data-act=range:hours>([^<]+)<\/button>/.exec(USAGE_JS);
+  assert.ok(btn, "the hours button");
+  assert.equal(btn![1], "7 days \\u00b7 by hour");
+});


### PR DESCRIPTION
Two changes to the usage modal's spend chart (T293).

**A hover crosshair.** Moving the pointer over the chart draws a hairline at the pointer's bucket and a stamp beside it naming the bucket in words: "Wed Sep 9, 3 PM" for an hourly bucket, "Wed Sep 9" for a daily one. The tooltip lists that bucket's sessions in spend order, each with a dot in its stack's colour and its value, the top six and then one "+N more" line. The bucket is the view's own: an hour in the 1-day and 7-day views, a day in the 90-day view.

**The middle range is "7 days · by hour"** over the hourly ledger's last 168 buckets. The ledger still keeps 192 hours, a day of slack past the view. The persisted preference value is unchanged, so a pick made under the old "8 days" label reads as the 7-day view with no rewrite.

Design points:
- **Over a bar, the same tooltip.** The one-segment tip is gone; a bar's hover shows the bucket box with that bar's row emphasised (and always listed, even past the fold). One shape, so nothing flips as the pointer crosses a bar's edge, and the bar's own reading is still there on its row. The header carries the bucket's total in the active measure, the other measure, and the stamp.
- **Pointer-inert, no layout change.** The hairline is an svg line and the stamp an absolutely placed element inside the chart box; the tooltip is the existing fixed box. All three take no pointer events, none is in the flow, so nothing moves under the pointer. They leave on pointerleave. Keyboard and touch gain nothing and lose nothing: only pointermove and pointerleave are read.
- **The stamp is read off the bucket KEY**, the recorder's local time, like every label on this chart; the existing zone note says when the viewer's clock differs. The tooltip sits below and to the right of the pointer (to its left near the right edge); when nothing fits below it goes above the CHART rather than the pointer, so it stays clear of the stamp at the chart's top, and only a window too short for either falls back to the pointer (the header repeats the stamp's text). The stamp flips to the line's left when it would run past the chart's right edge, decided in pixels, and a 24px floor keeps it off the y-axis ceiling label over the first buckets.
- **Pure functions, executed.** The bucket for a pointer offset, the stamp per view, and the top sessions of a bucket are plain functions in the landing script; `ui/webview/spend-crosshair.test.ts` runs them from the source, along with the range table, `spSeries` on a 192-key synthetic series, and `spLoadPrefs` against a stored pick from the old button.
- **Sizes and colours already on the surface.** The stamp wears the modal's 10px annotation size; the tooltip rows inherit the tip's 11px; the hairline and stamp have light-theme steps beside the tip's. An unattributed stack's dot is the hatch's stroke colour, "other" its neutral.

Tests: the node test above; `tests/test_spend_detail.py` pins the wiring and the rename; the headless served-page test (`tests/spend_modal_headless.js`, `tests/test_spend_modal_headless.py`) hovers the real chart in all three views and reads the line, the stamp, the rows, the fold, the pointer-inertness, the unchanged chart height, and that all three leave with the pointer; it also pins seven local midnights on the 7-day axis (192 hours carried eight).

Screenshots (served page, dark and light, 1-day and 7-day views): taken with the headless harness under `ROMP_SHOTS`.

**Review** (lean, 14 agents: four lenses over the branch diff, two skeptics per finding). Four confirmed, all fixed in the second commit: the short-window flip covered the stamp (now above the chart, pinned in a 600px window); the served order pin compared two rows that both rendered "$1" and could not fail (now the daily probe's token values, which differ); the stamp covered the ceiling label over the first buckets (a 24px floor, pinned at the first bucket); and a duplicate of the first. One plausible, a fixed 70% flip threshold on narrow charts, which one skeptic could not reproduce; fixed anyway by deciding the flip in pixels. Of eleven low items left unverified by the cap, the real cheap ones are folded: a rebuild hides the tooltip (pinned by a resize probe), the x-label pin counts labels rather than characters, two stale assertion messages and a stale test comment reworded, the stamp's CSS pin anchored to its rule, the seven-midnights pin's runner-zone assumption documented.
