### PR TITLE
The comment ring you click opens the thread that owns the ring, and an unread rail tick paints above a read one

### DIFF
--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -47,6 +47,21 @@ export function threadsByAnchor(threads: CommentThread[]): Map<string, CommentTh
   return by;
 }
 
+/** Which thread a click on a comment mark opens, given the mark CHAIN under the pointer — the clicked
+ *  mark first, then each enclosing mark outward. Marks nest when two threads anchor to the same passage
+ *  (the user 2026-09-10, who commented on one selection twice within seconds): ensureCommentMark re-finds
+ *  the identical range for the second thread and wraps its <mark> inside the first's, and the store's
+ *  order makes the EARLIER thread the outer one. The delegate hands the click to the innermost mark, so
+ *  the outer thread's needs-you ring could never be opened from its own ring: its unread never cleared
+ *  and the reply-ready chip stayed lit. The rule: the innermost UNREAD mark when any is (the ring under
+ *  the pointer belongs to it; two rings, the newest is the one under the finger), else the innermost,
+ *  as before. Null for an empty chain. */
+export function pickMarkToOpen(chain: { tid: string; unread: boolean }[]): string | null {
+  if (!chain.length) return null;
+  const ring = chain.find((m) => m.unread);
+  return (ring || chain[0]).tid;
+}
+
 /** The thread session is mid-turn — the popover shows its thinking dots. */
 export function threadBusy(state: string): boolean {
   return state === "working" || state === "retrying" || state === "compacting";

--- a/ui/webview/nested-marks.test.ts
+++ b/ui/webview/nested-marks.test.ts
@@ -1,0 +1,63 @@
+// Two threads on the SAME passage (the user 2026-09-10, who commented on one selection twice, seconds
+// apart): ensureCommentMark re-finds the identical range for the second thread and wraps its <mark>
+// INSIDE the first's, so the earlier thread's mark is the outer one. A click lands on the innermost
+// element and the body delegate takes the nearest [data-act] — the INNER (later) thread — so the outer
+// thread's needs-you ring could never be opened from its own ring: its unread never cleared and the
+// reply-ready chip stayed lit. The scroll rail had the same fault: two ticks at one `top`, the last
+// painted (read) covering the unread one. Fix: the ring you click opens the thread that owns the
+// ring (a pure pick over the mark chain, innermost first), and an unread tick stacks above its read
+// siblings. Pins: the pick's behaviour, cmtopen's use of it, the tick's stacking. Synthetic tids.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pickMarkToOpen } from "./comments";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+const inner = { tid: "t-later", unread: false };
+const outer = { tid: "t-earlier", unread: false };
+
+test("inner read + outer unread → the outer: the ring under the pointer belongs to the outer thread", () => {
+  assert.equal(pickMarkToOpen([inner, { ...outer, unread: true }]), "t-earlier");
+});
+
+test("both read → the inner, as before: the nearest mark to the click", () => {
+  assert.equal(pickMarkToOpen([inner, outer]), "t-later");
+});
+
+test("both unread → the inner: the newest ring is the one under the finger", () => {
+  assert.equal(pickMarkToOpen([{ ...inner, unread: true }, { ...outer, unread: true }]), "t-later");
+});
+
+test("a single mark opens itself, read or not; an empty chain opens nothing", () => {
+  assert.equal(pickMarkToOpen([inner]), "t-later");
+  assert.equal(pickMarkToOpen([{ ...inner, unread: true }]), "t-later");
+  assert.equal(pickMarkToOpen([]), null);
+});
+
+test("three deep: the innermost UNREAD wins over an outer unread and a read one in between", () => {
+  assert.equal(pickMarkToOpen([{ tid: "c", unread: false }, { tid: "b", unread: true }, { tid: "a", unread: true }]), "b");
+});
+
+test("cmtopen walks the mark chain from the clicked mark up and opens the pick — the unread bit read from the thread store", () => {
+  const at = RENDER.indexOf("cmtopen: (elx) => {");
+  assert.ok(at > 0, "the handler exists, still delegated on the body (comments.test.ts pins the shape)");
+  const handler = RENDER.slice(at, RENDER.indexOf("cmtclose:", at));
+  assert.match(handler, /pickMarkToOpen\(/, "the pick is the pure helper, not an inline heuristic");
+  assert.match(handler, /markChain\(elx/, "the chain starts at the clicked (innermost) mark");
+  const chain = RENDER.slice(RENDER.indexOf("function markChain("), RENDER.indexOf("\n}\n", RENDER.indexOf("function markChain(")));
+  assert.match(chain, /closest\("mark\.cmt-hl"\)/, "each step is the next enclosing mark");
+  assert.match(chain, /commentThreads\.get\(/, "unread comes from the thread store, the source the ring is painted from");
+  assert.match(chain, /!!th\?\.unread && th\.status === "open"/, "the same predicate styleCommentMark paints the ring with");
+  assert.doesNotMatch(handler, /elx\.dataset\.tid;/, "the clicked element's own tid is no longer the answer");
+});
+
+test("an unread rail tick stacks above read siblings at the same top — the covered ring was the rail's face of the bug", () => {
+  const rule = CSS.match(/\.cmt-tick\.unread \{[^}]*\}/)?.[0] || "";
+  assert.ok(rule, "the unread tick rule exists");
+  assert.match(rule, /z-index: 1;/, "explicit stacking: siblings share position: absolute inside the rail, so paint order is DOM order without it");
+  const base = CSS.match(/\.cmt-tick \{[^}]*\}/)?.[0] || "";
+  assert.doesNotMatch(base, /z-index/, "the read tick keeps the default level — only the unread one lifts");
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -78,7 +78,7 @@ import { apiErrorReason } from "./api-error-reason";
 import { chatMdExtensions, userMdHtml } from "./chat-md";
 import { setTip, pruneTip } from "./tip";
 import { agentCount, replyOwed, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, newCommentCreate, commentCreateFrame,
-         type CommentThread, type CommentCreate } from "./comments";
+         pickMarkToOpen, type CommentThread, type CommentCreate } from "./comments";
 import { isReplyReady, placeMark, placeWindowed, readyChips, replyLine, chipLabel, chipTip, chipAria, type Dir, type ReadyMark, type ReadyChip } from "./reply-ready";
 import { dragSlotIndex } from "./dragslot";
 import { perfFrameHandler } from "./perf-telemetry";
@@ -8408,6 +8408,25 @@ function styleCommentMark(m: HTMLElement, th: CommentThread): void {
     : "thread: click to open";
 }
 
+/** The marks under a click, innermost first: the clicked mark, then each enclosing mark.cmt-hl outward.
+ *  Two threads on the same passage NEST (the user 2026-09-10: one selection commented on twice within
+ *  seconds; ensureCommentMark re-finds the identical range and wraps the second mark inside the first),
+ *  and the delegate hands the click to the innermost — so cmtopen picks over the whole chain
+ *  (pickMarkToOpen), with each mark's unread bit read from the thread store, the source styleCommentMark
+ *  paints the ring from, so the ring you click is the thread that opens. */
+function markChain(start: HTMLElement, sid: string): { el: HTMLElement; tid: string; unread: boolean }[] {
+  const threads = commentThreads.get(sid) || [];
+  const out: { el: HTMLElement; tid: string; unread: boolean }[] = [];
+  for (let m = start.closest("mark.cmt-hl") as HTMLElement | null; m;
+       m = (m.parentElement?.closest("mark.cmt-hl") as HTMLElement | null) || null) {
+    const tid = m.dataset.tid;
+    if (!tid) continue;
+    const th = threads.find((t) => t.tid === tid);
+    out.push({ el: m, tid, unread: !!th?.unread && th.status === "open" });
+  }
+  return out;
+}
+
 /** The comment's identity color (the user 2026-08-17): one of the session palette's colors,
  *  DISTINCT from the parent session's and, where the palette allows, from every open tab's —
  *  the same standing-out rule _pick_identity_color applies to new sessions, decided client-side
@@ -16723,9 +16742,14 @@ setupSettings();
     // every popover BUTTON below: the popover's conversation refreshes on comments frames, and a
     // per-render listener would eat the mid-press click (the click-safety rule).
     cmtopen: (elx) => {
-      const tid = elx.dataset.tid;
-      if (!tid || !activeId) return;
-      const r = elx.getBoundingClientRect();
+      if (!activeId) return;
+      // the ring you click opens the thread that owns the ring (the user 2026-09-10): two threads on one
+      // passage nest their marks, the delegate lands on the innermost, and the outer thread's unread ring
+      // could never be opened from itself — pick over the chain instead (markChain / pickMarkToOpen)
+      const chain = markChain(elx, activeId);
+      const tid = pickMarkToOpen(chain);
+      if (!tid) return;
+      const r = (chain.find((m) => m.tid === tid)?.el || elx).getBoundingClientRect();
       openCommentPopover(activeId, tid, Math.min(r.left, window.innerWidth - 380), r.bottom + 6);
     },
     cmtclose: () => closeCommentPop(),

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -207,7 +207,8 @@ test("a reply dot sits at its anchor's position in the notches' own frame, over 
 
 test("the dot is the comment's landed colour; UNREAD shouts; keyed on the kernel's bit on an open thread", () => {
   assert.match(CSS, /\.cmt-tick \{\s*\n\s*position: absolute; right: 1px; width: 8px; height: 4px;[\s\S]{0,120}background: var\(--cmt-hl\);/, "the landed token, never a raw hex");
-  assert.match(CSS, /\.cmt-tick\.unread \{ width: 10px; height: 6px; right: 0; opacity: 1;\s*\n\s*box-shadow: 0 0 0 1\.5px var\(--bg\), 0 0 0 3px color-mix\(in srgb, var\(--cmt-hl\) 85%, transparent\); \}/);
+  assert.match(CSS, /\.cmt-tick\.unread \{ width: 10px; height: 6px; right: 0; opacity: 1; z-index: 1;\s*\n\s*box-shadow: 0 0 0 1\.5px var\(--bg\), 0 0 0 3px color-mix\(in srgb, var\(--cmt-hl\) 85%, transparent\); \}/,
+    "…and lifted above a read sibling at the same top (nested-marks.test.ts)");
   assert.match(RAIL, /\+ \(th\.unread && th\.status === "open" \? " unread" : ""\)/, "the same predicate the mark's ring and the reply chips read");
   assert.match(RAIL, /\+ ":" \+ \(t\.th\.unread \? 1 : 0\)/, "the unread bit rides the signature: a reply landing repaints the dot");
   assert.match(CSS, /\.cmt-tick\.busy \{ background: var\(--st-awaitbg-bg\); \}/, "a reply still being written is green here as on the mark");

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3389,8 +3389,10 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 .cmt-tick:hover { opacity: 1; }
 .cmt-tick.resolved { opacity: 0.3; }
 /* an UNREAD thread's tick shouts (the user 2026-08-23): full width, taller, double-ringed — the old
-   faint glow read as a rendering artifact, not as "new here" */
-.cmt-tick.unread { width: 10px; height: 6px; right: 0; opacity: 1;
+   faint glow read as a rendering artifact, not as "new here". It also stacks ABOVE its read siblings:
+   two threads on one passage share a `top`, and the later-painted read tick covered the unread one
+   (the user 2026-09-10) */
+.cmt-tick.unread { width: 10px; height: 6px; right: 0; opacity: 1; z-index: 1;
   box-shadow: 0 0 0 1.5px var(--bg), 0 0 0 3px color-mix(in srgb, var(--cmt-hl) 85%, transparent); }
 /* a WRITING thread's tick wears the same await-green as the passage (the user 2026-08-24: the
    marching-ants crawl — the "spinning dots" — is retired; the state COLOR is the in-flight cue,


### PR DESCRIPTION
Tier: fix

Two comment threads anchored to the identical passage (one selection commented on twice within seconds) nest their marks: `ensureCommentMark` re-finds the same range for the second thread and wraps its `<mark>` inside the first's, and store order makes the EARLIER thread the outer one. The body delegate takes the innermost `[data-act]`, so `cmtopen` always opened the inner (later) thread and posted `commentSeen` for it alone; the outer thread's needs-you ring could never be opened from its own ring, its `unread` never cleared, and the reply-ready chip (#1119) stayed lit. The scroll rail had the same face: two ticks at one `top`, the last painted (read) covering the unread one, with no stacking level on `.cmt-tick.unread`.

**Fix**
- `cmtopen` walks the mark chain from the clicked mark outward (`markChain`, unread read from the thread store, the source the ring is painted from) and picks through a pure helper, `pickMarkToOpen` (`ui/webview/comments.ts`): the innermost UNREAD mark when any is, else the innermost as before. So inner read + outer unread opens the outer; both read opens the inner; both unread opens the inner (the newest ring is the one under the finger); a single mark opens itself.
- `.cmt-tick.unread { z-index: 1 }` so an unread tick paints above read siblings at the same `top`.

**Tests (fail first)**: `ui/webview/nested-marks.test.ts` drives the helper over every chain shape, pins `cmtopen`'s use of it and the store-read predicate, and pins the tick's stacking; the byte pin in `scroll-marks.test.ts` on the unread tick rule grows the new declaration.

`npm run typecheck && npm test && npm run build` green locally apart from one pre-existing playwright-only KaTeX layout test that fails identically on pristine `origin/main` here (headless font metrics; CI installs no browser and skips it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
