### PR TITLE
The reply-ready chip opens the thread it lands on, which is what marks the reply read

### DIFF
--- a/ui/webview/comment-mark.test.ts
+++ b/ui/webview/comment-mark.test.ts
@@ -47,10 +47,12 @@ test("unread is the kernel's bit on an open thread, cleared by opening the threa
   assert.match(RENDER, /m\.classList\.toggle\("unread", !!th\.unread && th\.status === "open"\);/);
   assert.match(RENDER, /if \(th\) th\.unread = false;\s*\/\/ optimistic; the kernel's watermark reconciles/);
   assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "commentSeen", id: sid, tid \}\);/);
-  // the reply chips' click never touches it (reply-ready.test.ts pins the handler); the state has ONE clearer
+  // the reply chips' click OPENS the thread (the user 2026-09-10; reply-ready.test.ts pins the handler) and
+  // that open is the one clearer — the chip itself never writes the bit
   const at = RENDER.indexOf("replyjump: (elx) => {");
   assert.ok(at > 0, "the chip's click handler exists");
   const click = RENDER.slice(at, RENDER.indexOf("new ResizeObserver(updateReplyChips)", at));
+  assert.match(click, /openCommentPopover\(activeId, tid\);/, "the chip reaches the bit only through the thread's open");
   assert.doesNotMatch(click, /"commentSeen"|\.unread = false/);
 });
 

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -11163,8 +11163,10 @@ window.addEventListener("resize", updateJumpBtn);
 // isReplyReady: the mark's own .unread rule) whose marks sit wholly above / below the viewport; a mark on
 // screen counts in neither. Each chip exists only while its count is > 0. Click = land the NEAREST one in
 // that direction through the chat's own scroll-to-uuid route (scrollToAnchor → landOn's one flash, the rail
-// tick's and the notch's route) and pulse the mark itself — and NOT mark it read: opening the thread does,
-// as today. Same dress and home as #jump-bottom (body-level, fixed, bottom-left, the menu-card vocabulary),
+// tick's and the notch's route), pulse the mark itself, and OPEN its thread (the user 2026-09-10: the reply
+// lives in the popover, and stopping at the mark left a second click — one that, on two threads sharing a
+// passage, could open the wrong thread). The open is what marks it read, through openCommentPopover, the bit's
+// one clearer. Same dress and home as #jump-bottom (body-level, fixed, bottom-left, the menu-card vocabulary),
 // placed by measurement over the jump chip's slot so the three never overlap. The box is created once and
 // its two chips update IN PLACE (label, tip, data-tid/uuid), so a re-render can never eat a click (the
 // delegate rides the stable box). Every input is an event the chat already listens for: the jump chip's
@@ -11256,7 +11258,12 @@ function updateReplyChips(): void {
           const m = views.get(activeId)?.el.querySelector(`mark.cmt-hl[data-tid="${cssEscape(tid)}"]`) as HTMLElement | null;
           if (m) flash(m);                     // …and the mark itself pulses once (.romp-acted) — the thing you came for
         }
-        // deliberately NO commentSeen here: the chip brings you to the reply; reading it is opening the thread
+        // …and the thread opens (the user 2026-09-10): the reply is in the popover, so landing on the mark and
+        // stopping handed you a second click. By tid, not from the mark — the popover's geometry is fixed and
+        // this must not hang on the landing (an anchor the route could not scroll to still shows its reply).
+        // Opening is what marks it read: openCommentPopover's optimistic drop + commentSeen, the bit's ONE
+        // clearer, so the chip's count falls by the thread it opened and nothing here writes the bit itself.
+        openCommentPopover(activeId, tid);
       },
     });
     if (typeof ResizeObserver === "function") new ResizeObserver(updateReplyChips).observe(c);   // a pane measuring 0 drops the chips

--- a/ui/webview/reply-ready.test.ts
+++ b/ui/webview/reply-ready.test.ts
@@ -1,8 +1,9 @@
 // Replies ready (the user 2026-09-08): a reply lands on a comment you scrolled away from and you forget to
 // come back. Two chips stacked over the go-to-bottom chip — "↑ 2 replies unread" / "↓ 1 reply unread" —
 // count the unread landed replies whose marks sit wholly above / below the viewport; a click lands the
-// nearest one in that direction through the chat's own scroll-to-uuid route and does NOT mark it read
-// (opening the thread does, as today). The pure half (reply-ready.ts) is driven behaviorally; the
+// nearest one in that direction through the chat's own scroll-to-uuid route and OPENS its thread, which is
+// what marks it read (the user 2026-09-10: until then the chip only brought you to the mark and left you a
+// second click to reach the reply). The pure half (reply-ready.ts) is driven behaviorally; the
 // render.ts / CSS wiring is pinned at the source (no jsdom harness for the renderers — the repo
 // convention). Synthetic text only.
 import { test } from "node:test";
@@ -168,13 +169,25 @@ test("every input is an event the chat already listens for — no timers, no pol
   assert.match(UPDATE, /if \(sig === replyChipSig\) return;/, "a signature skips unchanged paints (pure scrolls do no DOM work)");
 });
 
-test("click = the chat's own scroll-to-uuid landing + one pulse on the mark; the thread is NOT marked read", () => {
+test("click = the chat's own scroll-to-uuid landing + one pulse on the mark, then the thread OPENS — which is what marks it read", () => {
+  // WHY the open (the user 2026-09-10): the chip's job is to get you to the reply, and the reply lives in the
+  // thread's popover, not on the mark — landing on the mark and stopping handed you a second click, and that
+  // click (on nested marks, #1249) could open the wrong thread. Opening goes through openCommentPopover, the
+  // ONE clearer of unread (its optimistic drop + commentSeen), so the chip's count falls by the thread it
+  // opened and nothing here writes the bit itself.
   assert.match(CLICK, /flashedAnchor = null;/, "fresh navigation → landOn's one flash, the tick's and the notch's route");
   assert.match(CLICK, /if \(scrollToAnchor\(uuid\)\) \{/);
   assert.match(CLICK, /applyCommentMarks\(activeId\);/, "a re-windowed anchor turn gets its highlight back before the pulse");
   assert.match(CLICK, /if \(m\) flash\(m\);/, "the mark itself pulses (.romp-acted)");
-  assert.doesNotMatch(CLICK, /"commentSeen"|openCommentPopover\(|\.unread = false/, "reading the reply is opening the thread — the chip only brings you to it");
+  assert.match(CLICK, /openCommentPopover\(activeId, tid\);/, "opens the thread the chip named, by tid — the popover's geometry is fixed, no click point needed");
+  assert.doesNotMatch(CLICK, /"commentSeen"|\.unread = false/, "the bit keeps its ONE clearer (openCommentPopover); the chip never writes it directly");
   assert.doesNotMatch(CLICK, /scrollTop =|scrollBy|scrollIntoView/, "never pixel arithmetic — the uuid route only");
+  // the open does not hang on the landing: an anchor the route could not scroll to (windowed out, an older-history
+  // fetch pending) still gets its reply shown — the open sits AFTER the scroll block, outside it
+  const scrollBlock = CLICK.indexOf("if (scrollToAnchor(uuid)) {");
+  const scrollEnd = CLICK.indexOf("\n        }", scrollBlock);
+  assert.ok(scrollBlock > 0 && scrollEnd > scrollBlock, "the scroll block is where the test expects it");
+  assert.ok(CLICK.indexOf("openCommentPopover(activeId, tid);") > scrollEnd, "the open follows the scroll block unconditionally");
 });
 
 test("the chips stack OVER the jump chip in its slot: same bottom measure, lifted by the jump chip's real height while it shows", () => {


### PR DESCRIPTION
Tier: fix

Follow-up to #1119 and companion to #1249. The reply-ready chip scrolled to the nearest unread mark, pulsed it and stopped, deliberately posting no `commentSeen`: reading the reply meant a second click on the mark. That second click is the one #1249 fixes (nested marks on a twice-commented passage opened the wrong thread), and it is a click the chip can spare the user: the reply lives in the thread's popover, so opening it is the natural completion of the jump.

**Change**: `replyjump` now opens the thread by tid through `openCommentPopover` after the scroll and the pulse, so `commentSeen` posts, the ring drops and the chip's count falls by the thread it opened. The open does not hang on the landing (an anchor the route could not scroll to still shows its reply). The unread bit keeps its ONE clearer; the chip never writes it directly.

**Tests (fail first)**: `reply-ready.test.ts`'s click pin now requires the open (with the why) and its place after the scroll block; `comment-mark.test.ts`'s one-clearer pin requires the chip to reach the bit only through `openCommentPopover`.

`npm run typecheck && npm test && npm run build` green locally apart from the same pre-existing playwright-only KaTeX layout test noted on #1249 (fails identically on pristine `origin/main`; CI skips it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
