### PR TITLE
Chat build: memoize the fixed costs a rebuild repeats, and name the tab and the input behind each rebuild in /perf

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -1248,7 +1248,19 @@ print("stages    jobs %s   push %s  (chat %s  feed %s  timeline %s  send %s)"
 parts = []
 for k in ("chat", "feed", "timeline", "feedJson"):     # feedJson: GET /feed.json's own reads, apart from the pusher's feed
     built, cached, ms = dl("builds", k, "built"), dl("builds", k, "cached"), dl("builds", k, "ms")
-    parts.append("%s %d built / %d cached%s" % (k, built, cached, (" (%.0f ms avg)" % (ms / built)) if built else ""))
+    split = ""
+    if k == "chat":
+        # the chat builder's attribution: rebuilds of the watched tab against background tabs whose signature
+        # moved, then per signature component the background rebuilds it caused; a kernel from before the
+        # split reports neither field and prints the line as before
+        active, bg = dl("builds", k, "active_built"), dl("builds", k, "bg_built")
+        if active or bg:
+            labels = sorted(((b.get("builds") or {}).get("chat") or {}).get("bg_miss") or {})
+            causes = ", ".join("%s %d" % (lab, dl("builds", k, "bg_miss", lab)) for lab in labels
+                               if dl("builds", k, "bg_miss", lab))
+            split = "; %d watched, %d background%s" % (active, bg, (": " + causes) if causes else "")
+    parts.append("%s %d built / %d cached%s"
+                 % (k, built, cached, (" (%.0f ms avg%s)" % (ms / built, split)) if built else ""))
 print("builds    " + "   ".join(parts))
 parts = []
 for kind in ("full", "delta", "deduped"):

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1078,7 +1078,7 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   gauge `entries`; `segs_hit` and `segs_miss` count the segments served and
   derived. `dead_serve`, `dead_miss` and `dead_failed_serve` are the dead-lane
   memo's outcomes on the same block, so one block carries every lane.
-  Three memos cover the chat build's per-build fixed costs, each keyed on the
+  Four memos cover the chat build's per-build fixed costs, each keyed on the
   inputs it reads and evicted by the pusher with the tab set (a comment thread
   built this cycle is kept, like its fold prefix). `chatMergeSets` is the
   live-tail merge's memo of the sets it derives from a parsed transcript (the
@@ -1104,7 +1104,11 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   live atoms: the last turn's segments differ from the parse's),
   `bypass_hold` (an armed rewind hold filters a store copy per build),
   `bypass_empty` (a store with no nodes), `evict` (entries dropped for tabs
-  no longer shown) and the gauge `entries`.
+  no longer shown) and the gauge `entries`. `chatFoldTasks` is the per-turn
+  memo of the transcript's task fold, keyed per session on each turn's atoms
+  list and fingerprint: `hit` and `miss` count turns served from the memo
+  against turns scanned, so a build of a working session with one moved turn
+  is one miss, plus the gauge `entries` (sessions held).
 - `judge`: `passes`, `ms_sum`, `ms_last`, `ms_mean` (wall time; a pass waits
   on model calls), `cpu_ms_sum` (CPU time of the judge tier threads and every
   per-session worker they run; the workers' share is `cpu_ms_workers`).

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -973,6 +973,15 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   `push.*` stages count every push, including the one a connecting page gets,
   so they can add up to more than `push`.
 - `builds`: `chat`, `feed`, `timeline`, each with `cached`, `built`, `ms`.
+  `chat` also carries `active_built` and `bg_built` (rebuilds of the watched
+  tab, served while its exact key holds, against rebuilds of a background tab
+  whose signature moved) and `bg_miss`, a map from each labelled component of
+  the chat-build signature (`transcript`, `states`, `judge_gen`, `tasks`,
+  `cut`, `row`, plus `cold` for a tab with no cached build and `nosig` for
+  one whose signature could not be taken) to the background rebuilds it
+  caused. A rebuild with several moved components counts under each, so the
+  map's sum can exceed `bg_built`. `romp perf` prints the split and the
+  non-zero causes after the chat average.
 - `sends`: `full`, `delta`, `deduped`, each a map from slot name (`chat`,
   `feed`, `bars`, `taborder`, ...) to `count` and `bytes`. A deduplicated frame
   was built and compared, then not sent.
@@ -1069,6 +1078,33 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   gauge `entries`; `segs_hit` and `segs_miss` count the segments served and
   derived. `dead_serve`, `dead_miss` and `dead_failed_serve` are the dead-lane
   memo's outcomes on the same block, so one block carries every lane.
+  Three memos cover the chat build's per-build fixed costs, each keyed on the
+  inputs it reads and evicted by the pusher with the tab set (a comment thread
+  built this cycle is kept, like its fold prefix). `chatMergeSets` is the
+  live-tail merge's memo of the sets it derives from a parsed transcript (the
+  uuids and user texts the transcript already holds, and the newest human
+  turn's time), one entry per session keyed on the parsed session object's
+  identity and shared by the chat, feed and timeline builds of one cycle:
+  `hit` and `miss` (merges served against derived) and the gauge `entries`
+  (a session neither shown as a tab nor alive is dropped). `chatPostal` is
+  the chat fold's memo of a tab's sealed postal cards, keyed on the values
+  the cards embed from outside the transcript (the message log's identity
+  and, per card, its caption and its peer's name and colour): `gate` (gate
+  checks that re-hydrated a tab's sealed cards because one of those values
+  moved, or because the entry was sealed outside the pusher's names snapshot
+  and had to be verified), `hit` (checks that verified the sealed cards from
+  their recorded values without hydrating), and `commit_new` (raw postal
+  events hydrated at fold commits; each is hydrated once, when it is first
+  sealed). Before this memo every judge pass re-hydrated every tab's sealed
+  cards, although a caption is the only judge-written value a card carries.
+  `chatLedger` is the chat build's memo of a session's goal-tree walk and
+  live roots, keyed on the parsed transcript's identity, the store's
+  identity and seams, `cleared.jsonl`'s identity and the warm-anchor table's
+  per-session revision: `hit` and `miss`, `bypass_live` (a build that merged
+  live atoms: the last turn's segments differ from the parse's),
+  `bypass_hold` (an armed rewind hold filters a store copy per build),
+  `bypass_empty` (a store with no nodes), `evict` (entries dropped for tabs
+  no longer shown) and the gauge `entries`.
 - `judge`: `passes`, `ms_sum`, `ms_last`, `ms_mean` (wall time; a pass waits
   on model calls), `cpu_ms_sum` (CPU time of the judge tier threads and every
   per-session worker they run; the workers' share is `cpu_ms_workers`).

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -210,7 +210,14 @@ class _PerfStats:
       builds                       chat / feed / timeline / feedJson -> {cached, built, ms}: served
                                    from the build cache vs rebuilt, and the rebuild time. feedJson is
                                    GET /feed.json's own reads (_pure_feed), kept apart from `feed`,
-                                   the pusher's (review find, 2026-09-08)
+                                   the pusher's (review find, 2026-09-08). chat also carries
+                                   active_built / bg_built (rebuilds of the watched tab, served while
+                                   its exact key holds, against rebuilds of a background tab whose
+                                   signature moved) and bg_miss {transcript, states, judge_gen, tasks,
+                                   cut, row, cold, nosig}: per labelled _chat_build_sig component, the
+                                   background rebuilds it caused (one count per differing component,
+                                   so the sum can exceed bg_built; cold = no cached build, nosig = no
+                                   signature could be taken); see build_chat
       sends                        full / delta / deduped -> {slot: {count, bytes}} per dedup-slot
                                    name (chat, feed, bars, taborder, ...; at most SLOTS names, the rest
                                    under "other"). A deduped frame was built and compared, not sent
@@ -226,7 +233,18 @@ class _PerfStats:
                                    interrupt-marks memo (_intr_marks_memo_report: hit, miss, evict,
                                    entries) and the awaiting overlay's states-log fold
                                    (_states_overlay_report: hit, append, refold, fail, evict,
-                                   entries), both trimmed to the interrupt tick's alive set each cycle
+                                   entries), both trimmed to the interrupt tick's alive set each cycle;
+                                   the chat build's fixed-cost memos: chatMergeSets (the live merge's
+                                   transcript-side sets, one entry per sid on the parsed session's
+                                   identity, see _merge_tx_sets) -> hit / miss and the gauge entries;
+                                   chatPostal (the chat fold's sealed postal cards, keyed on the values
+                                   they embed, see _postal_card_deps) -> gate (gate checks that
+                                   re-hydrated a tab's sealed cards), hit (checks that verified them
+                                   from their recorded values), commit_new (raw postal events hydrated
+                                   at fold commits, each once); chatLedger (build_session's goal-tree
+                                   walk and live roots per sid, see _ledger_memo) -> hit / miss,
+                                   bypass_live (live atoms merged), bypass_hold (a rewind hold armed),
+                                   bypass_empty (a store with no nodes), evict, and the gauge entries
       judge                        passes (one per _producer pass), ms_sum / ms_last / ms_mean (wall:
                                    a pass is a join over the tier threads, so this is mostly model
                                    latency), cpu_ms_sum (CPU: the two tier threads' own time, from
@@ -250,6 +268,9 @@ class _PerfStats:
     SLOTS = 32
     STAGES = ("jobs", "push", "push.chat", "push.feed", "push.timeline", "push.send")
     BUILDS = ("chat", "feed", "timeline", "feedJson", "thread")
+    # builds.chat's bg_miss labels: _chat_build_sig's components (the transcript and states sections, then
+    # _CHAT_SIG_TAIL), a tab with no cached build, and a tab whose signature could not be taken
+    CHAT_MISS = ("transcript", "states", "judge_gen", "tasks", "cut", "row", "cold", "nosig")
     SEND_KINDS = ("full", "delta", "deduped")
 
     def __init__(self):
@@ -266,6 +287,8 @@ class _PerfStats:
             self.ring = collections.deque(maxlen=self.RING)
             self.stages = {k: 0.0 for k in self.STAGES}
             self.builds = {k: {"cached": 0, "built": 0, "ms": 0.0} for k in self.BUILDS}
+            self.builds["chat"].update({"active_built": 0, "bg_built": 0,
+                                        "bg_miss": {k: 0 for k in self.CHAT_MISS}})   # see build_chat
             self.sends = {k: {} for k in self.SEND_KINDS}
             self.judge = {"passes": 0, "ms_sum": 0.0, "ms_last": 0.0, "cpu_ms_sum": 0.0}
             self.http = {}
@@ -318,6 +341,30 @@ class _PerfStats:
             else:
                 b["built"] += 1
                 b["ms"] += dt * 1000.0
+
+    def build_chat(self, cached, dt=0.0, active=False, miss=()):
+        """The chat builder's record: build("chat", ...) plus who paid and why. A rebuild counts under
+        active_built (the watched tab) or bg_built (a background tab whose signature moved), and a
+        background rebuild adds one to bg_miss[label] for EVERY labelled _chat_build_sig component that
+        differed from the cached signature (`miss`, from _chat_sig_miss), so the sum over bg_miss can
+        exceed bg_built when several inputs moved together. `cold` is a tab with no cached build, `nosig`
+        one whose signature could not be taken (no transcript path). Before this the counter said how
+        many chat builds ran and not which tab or which input drove them."""
+        ms = dt * 1000.0
+        with self.lock:
+            b = self.builds["chat"]
+            if cached:
+                b["cached"] += 1
+                return
+            b["built"] += 1
+            b["ms"] += ms
+            if active:
+                b["active_built"] += 1
+                return
+            b["bg_built"] += 1
+            bm = b["bg_miss"]
+            for lab in miss:
+                bm[lab] = bm.get(lab, 0) + 1
 
     def send(self, key, kind, nbytes):
         slot = key[0] if isinstance(key, tuple) else key
@@ -376,6 +423,7 @@ class _PerfStats:
             pusher = dict(self.pusher)
             stages = dict(self.stages)
             builds = {k: dict(v) for k, v in self.builds.items()}
+            builds["chat"]["bg_miss"] = dict(self.builds["chat"]["bg_miss"])   # the nested map: a copy too
             sends = {k: {sl: {"count": e[0], "bytes": e[1]} for sl, e in d.items()}
                      for k, d in self.sends.items()}
             judge = dict(self.judge)
@@ -408,7 +456,11 @@ class _PerfStats:
                           ("goalArchive", jd.goal_archive_memo_stats), ("plannerSkip", jd.planner_skip_stats),
                           ("liftGate", _lift_gate_report), ("bgTops", _bg_tops_report),
                           ("intrMarks", _intr_marks_memo_report), ("statesOverlay", _states_overlay_report),
-                          ("lanes", _lanes_memo_report)):   # the timeline's per-lane segment memo, live lanes; the dead lanes beside
+                          ("lanes", _lanes_memo_report),   # the timeline's per-lane segment memo, live lanes; the dead lanes beside
+                          # the chat build's fixed-cost memos (2026-09-09): the live merge's transcript-side
+                          # sets, the fold's sealed postal cards, the ledger's goal-tree walk
+                          ("chatMergeSets", _merge_sets_report), ("chatPostal", _chat_postal_report),
+                          ("chatLedger", _ledger_memo_report)):
             try:
                 memos[key] = read()
             except Exception:
@@ -25919,11 +25971,19 @@ def _POSTAL_UNRESOLVED_RESET():
     _POSTAL_UNRESOLVED["suppressed"] = 0
 
 
-def _hydrate_postal(events, index, sid=None):
+def _hydrate_postal(events, index, sid=None, captions=None):
     """Replace postal traffic with clean cards: a send_message tool (or `romp mail send` Bash) → an
     OUTGOING card; a user event (or a MAIL READER's output — see _reads_mail) carrying romp-msg-id
     marker(s) addressed to `sid` → INCOMING card(s) with the clean body from the log. Anything not
-    fully resolved passes through unchanged."""
+    fully resolved passes through unchanged.
+
+    `captions`: a zero-argument callable returning the {msg id: caption} map, or None for
+    _msg_summaries() on first need. build_session hands its hydrations (the fold gate's check, the tail
+    pass, the commit) one shared getter, so they read ONE map and the fold entry records exactly the
+    captions its cards embed; a caption appended between two of them would otherwise be embedded by one
+    hydration and recorded by another. Per-event independent: hydrate(A + B) == hydrate(A) + hydrate(B)
+    (pinned in tests/test_postal_hydrate_scope.py), which is what lets the fold's commit hydrate only the
+    raw events new since the seal (2026-09-09)."""
     out = []
     # {id: Haiku caption} → show the ≤9-word caption, not the verbose body. Computed LAZILY (the user
     # 2026-07-03: "startup is slow"): _msg_summaries() re-scans the WHOLE fleet's captioned transcripts,
@@ -25933,7 +25993,7 @@ def _hydrate_postal(events, index, sid=None):
     _bodies = [None]   # the index's body map, fetched on the first outgoing card (none → never)
     def caption_for(mid):
         if _msgsum[0] is None:
-            _msgsum[0] = _msg_summaries()
+            _msgsum[0] = captions() if captions is not None else _msg_summaries()
         return _msgsum[0].get(mid)
     def enrich_out(card, ev):
         # OUTGOING gist (the user 2026-07-25): the sender's card used to show a raw body prefix while the
@@ -26030,6 +26090,45 @@ def _hydrate_postal(events, index, sid=None):
                     _POSTAL_UNRESOLVED["suppressed"] += 1
         out.append(ev)
     return out
+
+
+_chat_postal_stats = {"gate": 0, "hit": 0, "commit_new": 0}   # /perf memos.chatPostal, see _postal_card_deps
+
+
+def _chat_postal_report():
+    """/perf memos.chatPostal: `gate`, fold-gate checks that re-hydrated a tab's sealed postal cards (the log
+    or a value a card embeds moved, or the entry was unverified); `hit`, checks that verified the sealed
+    cards from their recorded values without hydrating; `commit_new`, raw postal events hydrated at fold
+    commits, each once (the sealed ones are reused)."""
+    return dict(_chat_postal_stats)
+
+
+def _postal_card_deps(cards, index, captions):
+    """What the fold's sealed postal cards EMBED from outside the transcript, read from the same objects a
+    re-hydration in this build would read: per card its mid, the caption under that mid, and its peer's
+    identity (the sender's name and colour for an incoming card, the recipient's colour for an outgoing
+    one); a raw event that did not hydrate contributes None, its rendering depending on the log alone,
+    which the gate keys beside this by the log's identity (_chat_postal_key). Everything else a card
+    carries comes from the raw event or the log row. `captions` is the build's caption-map getter and is
+    called only when a card carries a mid, so a tab whose cards join no caption never pays for the map.
+    The gate re-hydrates when this tuple moved: O(cards) dict lookups instead of a whole-list re-hydration
+    on every judge pass, which was the gate's rule while the judge generation was its key (2026-09-09)."""
+    deps = []
+    _map = [None]                                    # the caption map, fetched once on the first mid
+    for c in cards:
+        if c.get("kind") != "postal-service":
+            deps.append(None)
+            continue
+        mid = c.get("mid")
+        if mid and _map[0] is None:
+            _map[0] = captions()
+        cap = _map[0].get(mid) if mid else None
+        if c.get("direction") == "in":
+            fid = ((index.get(mid) or {}).get("fromId") or "") if mid else ""
+            deps.append((mid, cap, _name_of(fid) if fid else None, _name_color(fid) if fid else None))
+        else:
+            deps.append((mid, cap, _name_color_by_name(c.get("peer") or "")))
+    return tuple(deps)
 
 
 def _tasks_base():
@@ -26805,6 +26904,14 @@ def _chat_fold_count(key):
         return _CHAT_FOLD_STATS[key]
 
 
+def _chat_memo_bump(stats, key, n=1):
+    """One increment of a chat-build memo's counter (_merge_sets_stats, _chat_postal_stats, _ledger_memo_stats)
+    under the same lock as the fold's counters, for the same reason: the pusher, the WS handlers and the
+    backends all build, and a bare += from two threads loses counts. Never called with the lock held."""
+    with _chat_fold_lock:
+        stats[key] = stats.get(key, 0) + n
+
+
 def _chat_fold_demote(reason):
     """Count WHY a build could not reuse its cached prefix (g:<reason>) — the hit-rate diagnosis
     this cache lives or dies by, mirroring event_model._asm_demote."""
@@ -26889,6 +26996,21 @@ def _chat_postal_key():
         return None
 _prev_chat_ledger = {}                           # sid → the previous build's ledger (so a delta carries it only when changed)
 
+# The ledger memo (2026-09-09): build_session's goal-tree walk and live roots per sid, keyed on every input
+# of the walk (the ledger section of build_session lists them). A background tab rebuilt for a moved input
+# the walk does not read (a states row, a task-store write, the judge generation) used to walk its goal tree
+# again over the same parse and the same store; the memo serves the walk's rows while those inputs stand.
+_ledger_memo = {}                                # sid → (key, parsed, gstore, tree, live_roots); parsed and gstore held by identity
+_ledger_memo_stats = {"hit": 0, "miss": 0, "bypass_live": 0, "bypass_hold": 0, "bypass_empty": 0, "evict": 0}
+
+
+def _ledger_memo_report():
+    """/perf memos.chatLedger: hit / miss (ledgers served from the memo vs walked), bypass_live (builds that
+    merged live atoms: the last turn's segments differ from the parse's), bypass_hold (an armed rewind hold
+    filters a store copy per build), bypass_empty (a store with no nodes: nothing to walk, nothing to keep),
+    evict (entries the pusher dropped for tabs no longer shown) and the gauge entries."""
+    return dict(_ledger_memo_stats, entries=len(_ledger_memo))
+
 # Wire tail-windowing (the user 2026-06-25, who found startup slow): delta-send already trims STEADY-STATE pushes,
 # but a FRESH connect still got every open tab's WHOLE transcript (the 42MB active session + the others) —
 # tens of MB transferred + parsed before the dashboard settled. So a full send now ships only the last
@@ -26965,7 +27087,9 @@ def _chat_build_sig(sess, tm=None):
     the truth (review 2026-09-05). What still lags for a BACKGROUND tab until one of those inputs moves: the
     side files only the active key stats (watches, usage, cleared cards, notify cards) — acceptable for a tab
     the user isn't looking at; it is rebuilt the moment it becomes the active one. Returns None (→ never
-    cache, always rebuild) if the session has no transcript path or it can't be stat'd."""
+    cache, always rebuild) if the session has no transcript path or it can't be stat'd. The row is one
+    component either way (None when the caller hands none), so every position of the tuple has a label
+    (_chat_sig_labels) and a background rebuild can be attributed to the components that moved."""
     path = sess.get("path")
     if not path:
         return None
@@ -26997,14 +27121,54 @@ def _chat_build_sig(sess, tm=None):
     # tail until the file next changes. Cheap: live SDK sessions answer from memory, no I/O.
     _be = _sdk()
     sig.append(_be.pending_cut(sess.get("sid") or "") if _be else "")
-    if tm is not None:
-        t = tm
-        sig.append((t.get("state"), t.get("model"), t.get("context"), t.get("effort"), t.get("mode"), t.get("fast"), t.get("since"),
-                    len(t.get("subagents") or ()), len(t.get("bgTasks") or ()), bool(t.get("interrupting")),
-                    bool(t.get("modelPending")), bool(t.get("effortPending")), bool(t.get("authPending")),
-                    int(t.get("retryCount") or 0), bool(t.get("connected")), bool(t.get("spawning")),
-                    t.get("auth"), t.get("authLive")))
+    # the push's row for this sid (its live facts), ONE component either way so the tail keeps a fixed
+    # length for _chat_sig_labels: None when the push has no row for the sid (2026-09-09)
+    t = tm
+    sig.append(None if t is None else
+               (t.get("state"), t.get("model"), t.get("context"), t.get("effort"), t.get("mode"), t.get("fast"), t.get("since"),
+                len(t.get("subagents") or ()), len(t.get("bgTasks") or ()), bool(t.get("interrupting")),
+                bool(t.get("modelPending")), bool(t.get("effortPending")), bool(t.get("authPending")),
+                int(t.get("retryCount") or 0), bool(t.get("connected")), bool(t.get("spawning")),
+                t.get("auth"), t.get("authLive")))
     return tuple(sig)
+
+
+# The labels of _chat_build_sig's components after the two transcript values and the per-states-file pairs,
+# in append order. The sig stays a flat tuple (its callers compare it whole), so the labels are derived from
+# the tuple's SHAPE: the states section is the only one whose length varies (one or two files, two values
+# each); the head and the tail are fixed. A component appended to _chat_build_sig must be appended here too
+# and to _PerfStats.CHAT_MISS; tests/test_chat_fixed_cost_memos.py pins the three against each other.
+_CHAT_SIG_TAIL = ("judge_gen", "tasks", "cut", "row")
+
+
+def _chat_sig_labels(sig):
+    """One label per position of a _chat_build_sig tuple (see _CHAT_SIG_TAIL)."""
+    n_states = len(sig) - 2 - len(_CHAT_SIG_TAIL)
+    return ("transcript", "transcript") + ("states",) * max(n_states, 0) + _CHAT_SIG_TAIL
+
+
+def _chat_sig_miss(old, new):
+    """Why a background tab rebuilt: the sorted labels of every _chat_build_sig component that differs
+    between the cached signature `old` and the fresh one `new` (the bg_miss attribution under builds.chat
+    in /perf). No cached build is ("cold",); a fresh signature of None (no transcript path, or one that
+    cannot be stat'd) is ("nosig",). Signatures of different lengths differ in their states section (the
+    session's anchor appeared or went), so that label is set and the fixed head and tail are compared from
+    their own ends."""
+    if new is None:
+        return ("nosig",)
+    if old is None:
+        return ("cold",)
+    labels = _chat_sig_labels(new)
+    if len(old) == len(new):
+        return tuple(sorted({labels[i] for i in range(len(new)) if old[i] != new[i]}))
+    out = {"states"}
+    for i in range(2):                                 # the head: the transcript's (mtime, size)
+        if old[i] != new[i]:
+            out.add(labels[i])
+    for j in range(1, len(_CHAT_SIG_TAIL) + 1):        # the tail, aligned from the end
+        if old[-j] != new[-j]:
+            out.add(_CHAT_SIG_TAIL[-j])
+    return tuple(sorted(out))
 
 
 def _parse(path, sid, now):
@@ -30063,6 +30227,55 @@ def _sendvis_diag(sid):
     return out
 
 
+_merge_sets_memo = {}                            # sid → (parsed session object, its sets): see _merge_tx_sets
+_merge_sets_stats = {"hit": 0, "miss": 0}        # /perf memos.chatMergeSets
+_MERGE_SETS_MAX = 512                            # bounded by the sessions alive; the oldest entry goes first
+
+
+def _merge_sets_report():
+    """/perf memos.chatMergeSets: the counters plus the entries held (one per sid merged since start, less the
+    pusher's eviction of sids neither shown as a tab nor alive)."""
+    return dict(_merge_sets_stats, entries=len(_merge_sets_memo))
+
+
+def _merge_tx_sets(session, sid):
+    """The transcript-side sets _merge_live_atoms derives from the parsed session, memoized per sid on the
+    session OBJECT's identity: (tx_uuids, tx_text_uuids, tx_texts, tx_text_t, human_floor). Inputs: the
+    atoms under session["turns"], and nothing else. The callers pass the parse cache's object
+    (build_session's `parsed`, build_feed's _parse_cached row, build_timeline's _parse result), which
+    _parse hands back unchanged while the transcript's (mtime, size, cut, states) key holds and replaces
+    on any change, so identity stands for content; a live-merged copy is this function's consumer and is
+    never passed in. The entry holds the session object, so an id cannot be recycled onto a new parse,
+    and one entry per sid serves the chat, feed and timeline builds of one cycle, which merge the same
+    object. Every build used to derive the five from every atom of the parse. The three sets are frozen:
+    the callers and the backends' prune_live only read them, and an in-place write would corrupt every
+    later hit, so a write raises instead; tx_text_t stays a dict because sdk_backend.prune_live dispatches
+    on isinstance(dict) (2026-09-09)."""
+    ent = _merge_sets_memo.get(sid)
+    if ent is not None and ent[0] is session:
+        _chat_memo_bump(_merge_sets_stats, "hit")
+        return ent[1]
+    _chat_memo_bump(_merge_sets_stats, "miss")
+    turns = session["turns"]
+    tx_uuids = frozenset(a.get("uuid") for turn in turns for a in turn["atoms"] if a.get("uuid"))
+    tx_text_uuids = frozenset(a.get("uuid") for turn in turns for a in turn["atoms"]
+                              if a.get("uuid") and _atom_prose_chars(a) > 0)
+    # text → the NEWEST record time carrying it: prune_live retires an echo by text only through a record
+    # written at or after the echo's send (T237b A); the plain set keeps the display dedup in the caller
+    tx_texts, tx_text_t = set(), {}
+    for turn in turns:
+        for a in turn["atoms"]:
+            for t in _atom_user_texts(a):
+                tx_texts.add(t)
+                tx_text_t[t] = max(tx_text_t.get(t, 0), float(a.get("t") or 0))
+    sets = (tx_uuids, tx_text_uuids, frozenset(tx_texts), tx_text_t, _human_turn_floor(session))
+    _merge_sets_memo.pop(sid, None)
+    while len(_merge_sets_memo) >= _MERGE_SETS_MAX:
+        _merge_sets_memo.pop(next(iter(_merge_sets_memo)))   # oldest-inserted first, one at a time, never clear-at-cap
+    _merge_sets_memo[sid] = (session, sets)
+    return sets
+
+
 def _merge_live_atoms(session, sid, shown_texts=()):
     """Merge in-memory LIVE-TAIL atoms into the parsed session, AHEAD of the transcript on disk, so messages
     appear instantly (the stream / a composer send leads the disk write). NON-MUTATING — `session` is the
@@ -30082,7 +30295,10 @@ def _merge_live_atoms(session, sid, shown_texts=()):
     live = be.live_atoms(sid)
     if not live:
         return session
-    tx_uuids = {a.get("uuid") for turn in session["turns"] for a in turn["atoms"] if a.get("uuid")}
+    # The transcript-side sets come from the per-sid memo (_merge_tx_sets): a function of the parsed
+    # session alone, which the parse cache hands back as the same object until the transcript changes,
+    # and which every build of a cycle (chat, feed, timeline) used to derive again from every atom.
+    tx_uuids, tx_text_uuids, tx_texts, tx_text_t, human_floor = _merge_tx_sets(session, sid)
     # A TEXTLESS disk twin must not land a texty live atom (the user 2026-07-28): on some model+tool
     # combinations (observed: fable-5 replying before an AskUserQuestion) the CLI persists the reply
     # text that streamed before the tool call as an EMPTY thinking record under the SAME uuid. The
@@ -30091,21 +30307,12 @@ def _merge_live_atoms(session, sid, shown_texts=()):
     # those uuids: the live text stays visible until settle, where the orphan-reply salvage makes it
     # durable (event_model._orphan_replies interleaves it back; its dedup is text-aware for the same
     # reason). Self-neutralizing: a twin that DOES carry the text lands the atom exactly as before.
-    tx_text_uuids = {a.get("uuid") for turn in session["turns"] for a in turn["atoms"]
-                     if a.get("uuid") and _atom_prose_chars(a) > 0}
     live_text_uuids = {a.get("uuid") for a in live
                        if not a.get("_echo_text") and not a.get("command")
                        and _atom_prose_chars(a) > 0}
-    tx_uuids -= (live_text_uuids - tx_text_uuids)
-    tx_texts = {t for turn in session["turns"] for a in turn["atoms"] for t in _atom_user_texts(a)}
-    # text → the NEWEST record time carrying it: prune_live retires an echo by text only through a record
-    # written at or after the echo's send (T237b A) — the plain set above keeps the display dedup below
-    tx_text_t = {}
-    for turn in session["turns"]:
-        for a in turn["atoms"]:
-            for t in _atom_user_texts(a):
-                tx_text_t[t] = max(tx_text_t.get(t, 0), float(a.get("t") or 0))
-    human_floor = _human_turn_floor(session)
+    withheld = live_text_uuids - tx_text_uuids
+    if withheld:
+        tx_uuids = tx_uuids - withheld           # a NEW set: the memoized one is shared with every later build
     be.prune_live(sid, tx_uuids, tx_text_t, human_floor)
     hide = tx_texts | {sb.echo_text_key(t) for t in shown_texts if t}    # transcript dups + already-shown queued msgs
     # `live` was snapshotted before the prune, so each of prune_live's three exits has its paint-side twin
@@ -30592,6 +30799,20 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
     _pref_len = 0
     _seams_sig = json.dumps((_bs_store or {}).get("seams") or [], sort_keys=True, default=str)
     _pk = _chat_postal_key()
+    # ONE postal index and ONE caption map per build: the fold gate's check, the tail pass and the commit
+    # hydrate against the same objects, so the entry records exactly the values its cards embed (a caption
+    # appended between two of them would otherwise be embedded by one hydration and recorded by another).
+    # The map is the cycle's on the pusher thread (_msg_summaries_scoped); a handler thread fetches its own.
+    _pidx = _postal_index()
+    _msum_slot = [None]
+    def _msum():
+        if _msum_slot[0] is None:
+            _msum_slot[0] = _msg_summaries_scoped()
+        return _msum_slot[0]
+    # The sealed cards' recorded values are trusted only when this build read names from the pusher's
+    # cycle snapshot (_live_scope.names): a handler-thread build reads the registry per card, so the values
+    # it embeds and the values it would record are two reads, not one. Such a build records None.
+    _scoped = getattr(_live_scope, "names", None) is not None
     if path_override:
         _chat_fold_count("bypass")
     elif _n_pref > 0:
@@ -30649,16 +30870,30 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
                         if _ot in _tail_texts or any(dt.startswith(_ot) or _ot.startswith(dt) for dt in _tail_texts):
                             _fold_why = "orphan"      # a new reply retires an interleaved orphan in the prefix
                             break
-            if _fold_why is None and _fe["postal_raw"] and (_pk != _fe["postal_key"] or _judge_gen[0] != _fe["judge_gen"]):
-                # re-hydrate just the sealed RAW postal events against the current index and captions; a
-                # different card means the prefix must be rebuilt. Every card, not only the pending ones
-                # (review find 2026-09-03): the judge writes a LIVE caption under an id it later overwrites
-                # with the final one, and a peer's colour can change — a card sealed complete was frozen
-                _cards = _hydrate_postal(list(_fe["postal_raw"]), _postal_index(), sid)
-                if _cards != _fe["postal_cards"]:
-                    _fold_why = "postal"
+            if _fold_why is None and _fe["postal_raw"]:
+                # The sealed postal cards are keyed on the VALUES they embed from outside the transcript
+                # (2026-09-09): the log's identity (_pk, the index memo's own key) and, per card, its caption
+                # and its peer's name and colour, read from the same index and caption map a re-hydration in
+                # this build would read (_postal_card_deps). They used to be re-hydrated on every judge pass
+                # (_judge_gen), although the only judge-written input a card embeds is its caption: every
+                # tab's whole sealed list, on every pass that moved any store. A deps tuple of None is an
+                # entry sealed outside the pusher's names scope (see _scoped): unverified, so it re-hydrates
+                # once here and is recorded by this build if it is scoped.
+                _deps = _fe.get("postal_deps")
+                if _pk != _fe["postal_key"] or _deps is None or _postal_card_deps(_fe["postal_cards"], _pidx, _msum) != _deps:
+                    # re-hydrate just the sealed RAW postal events against the current index and captions; a
+                    # different card means the prefix must be rebuilt. Every card, not only the pending ones
+                    # (review find 2026-09-03): the judge writes a LIVE caption under an id it later overwrites
+                    # with the final one, and a peer's colour can change — a card sealed complete was frozen
+                    _chat_memo_bump(_chat_postal_stats, "gate")
+                    _cards = _hydrate_postal(list(_fe["postal_raw"]), _pidx, sid, captions=_msum)
+                    if _cards != _fe["postal_cards"]:
+                        _fold_why = "postal"
+                    else:
+                        _fe["postal_key"] = _pk         # the values observed NOW, never a fresh read at the commit
+                        _fe["postal_deps"] = _postal_card_deps(_cards, _pidx, _msum) if _scoped else None
                 else:
-                    _fe["postal_key"], _fe["judge_gen"] = _pk, _judge_gen[0]
+                    _chat_memo_bump(_chat_postal_stats, "hit")
             if _fold_why is None and _fe["task_outs"]:
                 # a sealed task-notification card carries its output file's tail: a file that grew, appeared
                 # or vanished since the seal renders differently (review find 2026-09-03), so re-stat each
@@ -31103,7 +31338,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
         _raw_turn[id(_ev)] = _ti
         if _ev.get("uuid") and _ev["uuid"] not in _raw_turn:
             _raw_turn[_ev["uuid"]] = _ti
-    events = _hydrate_postal(events, _postal_index(), sid)   # swap postal traffic for clean in/out cards (no boilerplate)
+    events = _hydrate_postal(events, _pidx, sid, captions=_msum)   # swap postal traffic for clean in/out cards (no boilerplate)
     _stamp_interrupt_causes(events)                     # a restart/crash resume notice names the seam's cause
     for ev in events:
         # tlId = the timeline atom a chat hover lights: a message/prompt → the DOT (segment promptId),
@@ -31150,8 +31385,26 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
                 _cur = _tsnap[_np][0] if _np in _tsnap else _fe["cursors"]
                 _lt, _lm = (_tsnap[_np][1], _tsnap[_np][2]) if _np in _tsnap else (_fe["last_t"], _fe["last_model"])
                 _raw_new = [_e for _e in _raw_tail if _raw_turn.get(id(_e), _fk) < _np]
-                _praw = (list(_fe["postal_raw"]) if _fold_ok else []) + [_e for _e in _raw_new if _chat_postal_relevant(_e)]
-                _pcards = _hydrate_postal(list(_praw), _postal_index(), sid) if _praw else []
+                _praw_new = [_e for _e in _raw_new if _chat_postal_relevant(_e)]
+                _praw = (list(_fe["postal_raw"]) if _fold_ok else []) + _praw_new
+                # Only the raw events NEW since the seal are hydrated here: the gate above verified the sealed
+                # cards (or re-hydrated them and found them equal) against the same index and caption map,
+                # and _hydrate_postal is per-event independent, so sealed + hydrate(new) == hydrate(all).
+                _pcards_new = _hydrate_postal(list(_praw_new), _pidx, sid, captions=_msum) if _praw_new else []
+                if _praw_new:
+                    _chat_memo_bump(_chat_postal_stats, "commit_new", len(_praw_new))
+                _pcards = (list(_fe["postal_cards"]) if _fold_ok else []) + _pcards_new
+                # The values the entry's cards embed (_postal_card_deps): the sealed part as the gate observed
+                # it, the new part read now from the objects the new cards were just built from. None
+                # (unverified; the next scoped build re-hydrates once) when the sealed part was unverified, or
+                # when this build hydrated anything outside the pusher's names scope.
+                _pdeps_sealed = _fe.get("postal_deps") if _fold_ok else ()
+                if not _praw:
+                    _pdeps = ()
+                elif _pdeps_sealed is None or (_praw_new and not _scoped):
+                    _pdeps = None
+                else:
+                    _pdeps = tuple(_pdeps_sealed) + _postal_card_deps(_pcards_new, _pidx, _msum)
                 _plp = list(_fe["pl_pending"]) if _fold_ok else []
                 _touts = list(_fe["task_outs"]) if _fold_ok else []
                 for _e in _newpart:
@@ -31196,7 +31449,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
                                     + [(_e.get("md") or "").strip() for _e in _newpart if _e.get("orphaned")],
                     "open_tools": _open_tools, "skill_unfilled": _skill_unf,
                     "postal_raw": _praw, "postal_cards": _pcards,
-                    "postal_key": _pk, "judge_gen": _judge_gen[0], "pl_pending": _plp,
+                    "postal_key": _pk, "postal_deps": _pdeps, "pl_pending": _plp,
                     "task_outs": _touts,
                     # the sealed Agent cards, for _chat_agents_moved: (toolUseId, agentId, pending) —
                     # pending = a background launch sealed without its report (the ack stands as output)
@@ -31446,129 +31699,167 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
     #                                            doomed asks for the whole armed window while the
     #                                            feed hid them (the "one chokepoint" premise was
     #                                            false; the window is unbounded on a bare delete)
-    gnodes = gstore.get("nodes", {}) if gstore is not None else {}
-    gstatus = gstore.get("status", {}) if gstore is not None else {}
-    gcleared = _cleared_ids()
-    gkids = {}
-    for _gid, _gn in gnodes.items():
-        gkids.setdefault(_gn.get("parentId"), []).append(_gid)
-    g_agent_open = _agent_open_set(gnodes, gkids)   # authoritative-open subtree → never 'done' (mirrors build_feed / the judge)
-    focus = gstore.get("lastNode") if gstore is not None else None
-    tree = []
+    # ── the ledger memo (2026-09-09): the tree walk and the live roots below are a function of exactly these
+    # inputs, each in the key or held by identity: the parse (seg_trig and seg_work come from it; by the parsed
+    # object's identity, and only while no live atoms were merged, since the merge reshapes the last turn's
+    # segments); the store's seams (_seams_sig, from the store this build's seg maps were cut with: the
+    # build loads the store twice, once at the top for the seg ids and once here for the nodes, and a
+    # publish landing between the two loads pairs the old seams' seg maps with the new store object, so
+    # the seams stay a key component beside the store's identity or that build's tree would serve next
+    # build); the store itself (by identity: load_goals_shared hands back one frozen object until the
+    # store, its override journal or its archive changes; a rewind hold filters a copy per build, so a
+    # held sid bypasses; a store with no nodes has nothing to walk and bypasses too); cleared.jsonl (its
+    # stat, taken BEFORE _cleared_ids reads it: a row
+    # landing between the two pairs an old key with new content, one extra miss next build, never a stale
+    # hit); and the warm-anchor table's per-sid revision (_node_anchor_rev, read BEFORE the walk and stored
+    # as read: a resolve another build lands during the walk bumps it after this read, so the next build
+    # misses instead of serving the pre-resolve tree). jd.junk_quote, _agent_open_set and the seg helpers are
+    # pure over those inputs; _session_flag (the mute) is applied after the memo, live. A background tab
+    # rebuilt for an input the walk never reads (a states row, the task store, the judge generation) used to
+    # walk its whole goal tree again; counters ride /perf under memos.chatLedger.
+    _ck = _stat_key(jd.STATE / "cleared.jsonl")
+    _lkey, _lhit = None, None
+    if session is not parsed:
+        _chat_memo_bump(_ledger_memo_stats, "bypass_live")
+    elif _rewind_hold_get(sid):
+        _chat_memo_bump(_ledger_memo_stats, "bypass_hold")
+    elif not (gstore and gstore.get("nodes")):
+        _chat_memo_bump(_ledger_memo_stats, "bypass_empty")
+    else:
+        _lkey = (_seams_sig, _ck, _node_anchor_rev.get(sid, 0))
+        _lent = _ledger_memo.get(sid)
+        if _lent is not None and _lent[0] == _lkey and _lent[1] is parsed and _lent[2] is gstore:
+            _lhit = _lent
+    if _lhit is not None:
+        _chat_memo_bump(_ledger_memo_stats, "hit")
+        tree, _live_roots = _lhit[3], _lhit[4]       # the memo's own lists: the ledger slices them, nothing writes a row
+    else:
+        gnodes = gstore.get("nodes", {}) if gstore is not None else {}
+        gstatus = gstore.get("status", {}) if gstore is not None else {}
+        gcleared = _cleared_ids()
+        gkids = {}
+        for _gid, _gn in gnodes.items():
+            gkids.setdefault(_gn.get("parentId"), []).append(_gid)
+        g_agent_open = _agent_open_set(gnodes, gkids)   # authoritative-open subtree → never 'done' (mirrors build_feed / the judge)
+        focus = gstore.get("lastNode") if gstore is not None else None
+        tree = []
 
-    def _cleared(cid):
-        cn = gnodes.get(cid)
-        return bool(cn) and (cn.get("cleared") or cid in gcleared or gstatus.get(cid) == "cleared")
+        def _cleared(cid):
+            cn = gnodes.get(cid)
+            return bool(cn) and (cn.get("cleared") or cid in gcleared or gstatus.get(cid) == "cleared")
 
-    # VERDICTS ONLY (the user 2026-07-15; was roll-UP since 2026-06-16): a node shows done if it's
-    # explicitly nodeComplete (a judge/agent/user verdict, or the roll-down cache under a verdicted
-    # ancestor). CLEARED is a SEPARATE axis, not a flavor of done (the user 2026-07-26: the box means
-    # done, and only done — a cleared-but-unfinished node keeps its open ring; the strike + chip say
-    # dismissed). The old derived arm — all children done ⇒ dimmed ✓ on the parent — painted an
-    # authored-looking check on a goal nobody ruled done (children are filed prerequisites/retries,
-    # not a promised breakdown: the load-testing card's unrun experiment wore a ✓ because its "retry
-    # the connection" child closed). The judge-side twin (rollup_status is_complete's bottom-up arm)
-    # is gone the same way; the closer now RULES such nodes via _subtree_done_candidates, so an
-    # honest check appears when the verdict lands.
-    _dmemo = {}
-    def _subtree_done(nid):
-        if nid in _dmemo:
-            return _dmemo[nid]
-        nd = gnodes.get(nid)
-        if not nd:
-            _dmemo[nid] = False
-            return False
-        res = bool(nd.get("nodeComplete"))
-        if not res and nd.get("umbrella"):             # ARCHIVED pre-T101 container (mints retired; live
-            # ones dissolve every rollup) — history still renders structurally-complete: the
-            # mint asserted "this node IS its children"; cleared kids are out of the closure either
-            # way (neither done nor holding it open), mirroring build_feed's _closure_done
-            kids = [c for c in gkids.get(nid, []) if not _cleared(c)]
-            res = bool(kids) and not nd.get("blocked") and all(_subtree_done(c) for c in kids)
-        _dmemo[nid] = res
-        return res
+        # VERDICTS ONLY (the user 2026-07-15; was roll-UP since 2026-06-16): a node shows done if it's
+        # explicitly nodeComplete (a judge/agent/user verdict, or the roll-down cache under a verdicted
+        # ancestor). CLEARED is a SEPARATE axis, not a flavor of done (the user 2026-07-26: the box means
+        # done, and only done — a cleared-but-unfinished node keeps its open ring; the strike + chip say
+        # dismissed). The old derived arm — all children done ⇒ dimmed ✓ on the parent — painted an
+        # authored-looking check on a goal nobody ruled done (children are filed prerequisites/retries,
+        # not a promised breakdown: the load-testing card's unrun experiment wore a ✓ because its "retry
+        # the connection" child closed). The judge-side twin (rollup_status is_complete's bottom-up arm)
+        # is gone the same way; the closer now RULES such nodes via _subtree_done_candidates, so an
+        # honest check appears when the verdict lands.
+        _dmemo = {}
+        def _subtree_done(nid):
+            if nid in _dmemo:
+                return _dmemo[nid]
+            nd = gnodes.get(nid)
+            if not nd:
+                _dmemo[nid] = False
+                return False
+            res = bool(nd.get("nodeComplete"))
+            if not res and nd.get("umbrella"):             # ARCHIVED pre-T101 container (mints retired; live
+                # ones dissolve every rollup) — history still renders structurally-complete: the
+                # mint asserted "this node IS its children"; cleared kids are out of the closure either
+                # way (neither done nor holding it open), mirroring build_feed's _closure_done
+                kids = [c for c in gkids.get(nid, []) if not _cleared(c)]
+                res = bool(kids) and not nd.get("blocked") and all(_subtree_done(c) for c in kids)
+            _dmemo[nid] = res
+            return res
 
-    # mt = node last-modified (the judge writes it on create / amend / done / block); fall back to t for
-    # pre-rename nodes. Recency orders the tree (top goals + children freshest-first) and picks the single
-    # most-recently-CHANGED node; the render marks it → and auto-expands the path (onpath) down to it.
-    def _mt(cid):
-        cn = gnodes.get(cid) or {}
-        return cn.get("mt", cn.get("t", 0))
-    _smemo = {}
-    def _submax(cid):
-        if cid in _smemo:
-            return _smemo[cid]
-        m = _mt(cid)
-        for c in gkids.get(cid, []):
-            m = max(m, _submax(c))
-        _smemo[cid] = m
-        return m
-    # ONE "here" marker (the user 2026-06-17): the highlight (current) and the → arrow (recent) mark the SAME
-    # node now — the working cursor, lastNode/focus. They used to be computed DIFFERENTLY — the highlight from
-    # the stored lastNode pointer, the arrow from the node with the freshest mt — so nothing forced them onto
-    # the same node, and they read as two competing "current" claims when a re-touched older node out-stamped
-    # the cursor. Keying the arrow + the auto-expand path to focus collapses them to one. (_submax above is the
-    # tree-ORDERING key — still mt-based, unchanged.)
-    recent = focus
-    onpath = set()                                         # the marked node + its ancestors → the render auto-expands
-    _p = recent
-    while _p:
-        onpath.add(_p)
-        _p = gnodes.get(_p, {}).get("parentId")
+        # mt = node last-modified (the judge writes it on create / amend / done / block); fall back to t for
+        # pre-rename nodes. Recency orders the tree (top goals + children freshest-first) and picks the single
+        # most-recently-CHANGED node; the render marks it → and auto-expands the path (onpath) down to it.
+        def _mt(cid):
+            cn = gnodes.get(cid) or {}
+            return cn.get("mt", cn.get("t", 0))
+        _smemo = {}
+        def _submax(cid):
+            if cid in _smemo:
+                return _smemo[cid]
+            m = _mt(cid)
+            for c in gkids.get(cid, []):
+                m = max(m, _submax(c))
+            _smemo[cid] = m
+            return m
+        # ONE "here" marker (the user 2026-06-17): the highlight (current) and the → arrow (recent) mark the SAME
+        # node now — the working cursor, lastNode/focus. They used to be computed DIFFERENTLY — the highlight from
+        # the stored lastNode pointer, the arrow from the node with the freshest mt — so nothing forced them onto
+        # the same node, and they read as two competing "current" claims when a re-touched older node out-stamped
+        # the cursor. Keying the arrow + the auto-expand path to focus collapses them to one. (_submax above is the
+        # tree-ORDERING key — still mt-based, unchanged.)
+        recent = focus
+        onpath = set()                                         # the marked node + its ancestors → the render auto-expands
+        _p = recent
+        while _p:
+            onpath.add(_p)
+            _p = gnodes.get(_p, {}).get("parentId")
 
-    # Emit the FULL goal tree — every node, with its child ids — so the RENDER can fold / expand at ANY
-    # level (the user 2026-06-16): completed / cleared nodes fold by default, the recent path + open work
-    # expand. Pruning moved to the render; the kernel just supplies the structure + done / derived /
-    # cleared / recent / onpath flags. Cleared nodes are INCLUDED now (shown faded), not skipped.
-    def _twalk(nid, depth, ancestor_done=False, ancestor_cleared=False):
-        nd = gnodes.get(nid)
-        if not nd:
-            return
-        # cleared rolls DOWN (replacing the old cleared→done roll-down): dismissing a parent dismisses
-        # its subtree, so the children fade + strike with it instead of sitting as live-looking open
-        # rings under a struck parent — while every box keeps meaning done (the user 2026-07-26).
-        clr = _cleared(nid) or ancestor_cleared
-        # AUTHORITATIVE-open override (the user 2026-07-01): an open agent to-do item — or an umbrella holding
-        # one — is never 'done' here either, so the ledger matches the feed + the judge (see _agent_open_set).
-        # A CLEARED node is still dismissed (the strike + chip carry that), so the override only applies live.
-        aopen = (nid in g_agent_open) and not clr
-        explicit = bool(nd.get("nodeComplete")) and not aopen
-        # done rolls BOTH ways, like the ask-tree flatten() (the user 2026-06-16): a node under a done
-        # parent is derived-done too (roll-DOWN via ancestor_done), not just when its own subtree is done
-        # (roll-UP via _subtree_done). So a completed subtree reads as all-dimmed-✓, instead of a child
-        # showing ○ under a done top. CLEARED no longer counts as done for any of this (the user
-        # 2026-07-26: the box means done) — a dismissed-unfinished node keeps its ring under the strike.
-        derived = (not explicit) and (not aopen) and (_subtree_done(nid) or ancestor_done)
-        kids = sorted(gkids.get(nid, []), key=_submax, reverse=True)
-        # EXACT deep-link anchors (the user 2026-06-19): a ledger TOC click lands on the precise chat turn
-        # BY UUID — the SAME anchors build_feed gives its cards — so the ledger and the feed for one node
-        # land identically, replacing the ledger's old nearest-time landing. promptAnchorUuid → the minting
-        # user message (text zone); anchorUuid → the newest trail segment (mark + time zones).
-        _pa, _wa = _node_anchor_uuids(nd, seg_trig, seg_work)
-        tree.append({"id": nid, "text": nd["text"], "depth": depth,
-                     "done": explicit or derived, "derived": derived, "cleared": clr,
-                     "blocked": bool(nd.get("blocked")), "t": nd["t"],
-                     # mt = the segment where this node was last touched (resolved/blocked) — the click-
-                     # to-jump nav lands done/blocked goals on their mt (the assistant turn that finished
-                     # them), open goals on t (where they began). Matches build_feed (the user 2026-06-16).
-                     "mt": nd.get("mt", nd["t"]), "current": nid == focus,
-                     "onpath": nid in onpath,
-                     "promptAnchorUuid": _pa, "anchorUuid": _wa,
-                     # the distiller's takeaway (done) / the block-distiller's decision brief (blocked),
-                     # null until produced — the ledger row's ⊕ expander reveals it inline (the user 2026-06-21)
-                     "summary": nd.get("summary"), "blockSummary": nd.get("blockSummary"),
-                     "children": [c for c in kids if c in gnodes]})
-        for c in kids:
-            _twalk(c, depth + 1, ancestor_done=explicit or derived, ancestor_cleared=clr)
-    for _rid in sorted(gkids.get(None, []), key=_submax, reverse=True):
-        _twalk(_rid, 0)
-    # "Recent" for the tab-hover (the user 2026-06-30): the up-to-5 most-recently-touched TOP-level tasks across
-    # the LIVE store AND the archive, REGARDLESS of status (done / blocked / cleared) — so a session whose tops
-    # were all crossed off still lists the last 5 things it did, not just its summary. Roots only (tasks, not
-    # steps). The live tree usually holds ≤1 open top; the rest are cleared+archived, hence the archive merge.
-    _live_roots = [{"text": nd["text"], "t": nd.get("mt", nd.get("t", 0))}
-                   for nid, nd in gnodes.items()
-                   if nd.get("parentId") is None and (nd.get("text") or "").strip()]
+        # Emit the FULL goal tree — every node, with its child ids — so the RENDER can fold / expand at ANY
+        # level (the user 2026-06-16): completed / cleared nodes fold by default, the recent path + open work
+        # expand. Pruning moved to the render; the kernel just supplies the structure + done / derived /
+        # cleared / recent / onpath flags. Cleared nodes are INCLUDED now (shown faded), not skipped.
+        def _twalk(nid, depth, ancestor_done=False, ancestor_cleared=False):
+            nd = gnodes.get(nid)
+            if not nd:
+                return
+            # cleared rolls DOWN (replacing the old cleared→done roll-down): dismissing a parent dismisses
+            # its subtree, so the children fade + strike with it instead of sitting as live-looking open
+            # rings under a struck parent — while every box keeps meaning done (the user 2026-07-26).
+            clr = _cleared(nid) or ancestor_cleared
+            # AUTHORITATIVE-open override (the user 2026-07-01): an open agent to-do item — or an umbrella holding
+            # one — is never 'done' here either, so the ledger matches the feed + the judge (see _agent_open_set).
+            # A CLEARED node is still dismissed (the strike + chip carry that), so the override only applies live.
+            aopen = (nid in g_agent_open) and not clr
+            explicit = bool(nd.get("nodeComplete")) and not aopen
+            # done rolls BOTH ways, like the ask-tree flatten() (the user 2026-06-16): a node under a done
+            # parent is derived-done too (roll-DOWN via ancestor_done), not just when its own subtree is done
+            # (roll-UP via _subtree_done). So a completed subtree reads as all-dimmed-✓, instead of a child
+            # showing ○ under a done top. CLEARED no longer counts as done for any of this (the user
+            # 2026-07-26: the box means done) — a dismissed-unfinished node keeps its ring under the strike.
+            derived = (not explicit) and (not aopen) and (_subtree_done(nid) or ancestor_done)
+            kids = sorted(gkids.get(nid, []), key=_submax, reverse=True)
+            # EXACT deep-link anchors (the user 2026-06-19): a ledger TOC click lands on the precise chat turn
+            # BY UUID — the SAME anchors build_feed gives its cards — so the ledger and the feed for one node
+            # land identically, replacing the ledger's old nearest-time landing. promptAnchorUuid → the minting
+            # user message (text zone); anchorUuid → the newest trail segment (mark + time zones).
+            _pa, _wa = _node_anchor_uuids(nd, seg_trig, seg_work, sid=sid)
+            tree.append({"id": nid, "text": nd["text"], "depth": depth,
+                         "done": explicit or derived, "derived": derived, "cleared": clr,
+                         "blocked": bool(nd.get("blocked")), "t": nd["t"],
+                         # mt = the segment where this node was last touched (resolved/blocked) — the click-
+                         # to-jump nav lands done/blocked goals on their mt (the assistant turn that finished
+                         # them), open goals on t (where they began). Matches build_feed (the user 2026-06-16).
+                         "mt": nd.get("mt", nd["t"]), "current": nid == focus,
+                         "onpath": nid in onpath,
+                         "promptAnchorUuid": _pa, "anchorUuid": _wa,
+                         # the distiller's takeaway (done) / the block-distiller's decision brief (blocked),
+                         # null until produced — the ledger row's ⊕ expander reveals it inline (the user 2026-06-21)
+                         "summary": nd.get("summary"), "blockSummary": nd.get("blockSummary"),
+                         "children": [c for c in kids if c in gnodes]})
+            for c in kids:
+                _twalk(c, depth + 1, ancestor_done=explicit or derived, ancestor_cleared=clr)
+        for _rid in sorted(gkids.get(None, []), key=_submax, reverse=True):
+            _twalk(_rid, 0)
+        # "Recent" for the tab-hover (the user 2026-06-30): the up-to-5 most-recently-touched TOP-level tasks across
+        # the LIVE store AND the archive, REGARDLESS of status (done / blocked / cleared) — so a session whose tops
+        # were all crossed off still lists the last 5 things it did, not just its summary. Roots only (tasks, not
+        # steps). The live tree usually holds ≤1 open top; the rest are cleared+archived, hence the archive merge.
+        _live_roots = [{"text": nd["text"], "t": nd.get("mt", nd.get("t", 0))}
+                       for nid, nd in gnodes.items()
+                       if nd.get("parentId") is None and (nd.get("text") or "").strip()]
+        if _lkey is not None:
+            _chat_memo_bump(_ledger_memo_stats, "miss")
+            _ledger_memo[sid] = (_lkey, parsed, gstore, tree, _live_roots)
     recent_tops = sorted(_live_roots + _archive_roots(sid), key=lambda r: r["t"] or 0, reverse=True)[:5]
     if _session_flag(sid, "hideFromFeed"):       # muted → out of task tracking: the ledger shows no goal tree / current task
         tree, current, recent_tops = [], None, []
@@ -35552,6 +35843,38 @@ def _msg_sum_scan_session(sid, path, now):
     return sub
 
 
+def _msg_sum_key(s):
+    """The key of one session's _msg_summaries submap: every input _msg_sum_scan_session reads, by identity,
+    stat'd BEFORE the scan. The parse's own key (the transcript's (mtime, size), falling back to discovery's
+    row mtime when the file cannot be stat'd; the backend's pending cut; the states file's (mtime, size)),
+    the session's captions/<sid>.jsonl as (st_mtime_ns, st_size) (the captions its segments join to) and its
+    goal store's identity (jd._store_identity: the store, its override journal and its archive, each
+    (ino, mtime_ns, size) or None; the seams decide which segment a message id belongs to). The key was the
+    transcript's mtime alone before 2026-09-09: a caption the judge wrote after the segment's last transcript
+    record never reached the union until the session's next turn, and a seam change never did.
+    Stat-then-read: a write landing between the stat and the scan pairs an old key with new content, which
+    is one extra rescan on the next call, never a stale hit."""
+    sid, path = s["sid"], s["path"]
+    try:
+        st = os.stat(path)
+        tx = (st.st_mtime, st.st_size)
+    except OSError:
+        tx = (s.get("mtime"), None)
+    _be = _sdk()
+    cut = _be.pending_cut(sid) if _be else ""
+    try:
+        ss = os.stat(jd.STATE / "states" / (sid + ".jsonl"))
+        states = (ss.st_mtime, ss.st_size)
+    except OSError:
+        states = None
+    try:
+        cs = os.stat(jd.CAPDIR / (sid + ".jsonl"))
+        caps = (cs.st_mtime_ns, cs.st_size)
+    except OSError:
+        caps = None
+    return (tx, cut, states, caps, jd._store_identity(sid)[1:])
+
+
 def _msg_summaries():
     """{msg id: caption} — the caption of the recipient segment a peer message triggered. Join the
     msgId (its `romp-msg-id` marker, via _seg_mids) to the segment that bore it, then to that segment's
@@ -35561,28 +35884,30 @@ def _msg_summaries():
     PER-SESSION incremental cache (the user 2026-07-03, who found startup slow and opening each session slow). The
     old memo keyed the WHOLE map on the fleet's (path, mtime) signature — so ANY session writing (a busy
     fleet is always writing) invalidated it and every build_session re-scanned all ~15 transcripts, ~1.2s
-    per chat-open. Now each session's submap is cached against its OWN mtime: a build re-scans only the
-    sessions that actually changed (usually just the one being viewed) and unions the rest from cache. The
-    parses are _parse-mtime-cached too, so an unchanged session costs nothing."""
+    per chat-open. Now each session's submap is cached against its OWN inputs (_msg_sum_key: the parse's
+    key and the captions file and goal store the scan joins through): a build re-scans only the sessions
+    whose inputs changed (usually just the one being viewed) and unions the rest from cache. The parses are
+    _parse-cached too, so an unchanged session costs nothing but the key's stats."""
     now = time.time()
     try:
         sess = _sessions(now)
     except Exception:
         return _msg_sum_cache.get("map", {})
-    per = _msg_sum_cache.setdefault("per", {})       # sid -> (mtime, submap)
+    per = _msg_sum_cache.setdefault("per", {})       # sid -> (key, submap)
     live = set()
     dirty = False
     for s in sess:
         sid = s["sid"]
         live.add(sid)
         ent = per.get(sid)
-        if ent and ent[0] == s["mtime"]:             # unchanged since last scan → reuse its submap
+        key = _msg_sum_key(s)                        # taken BEFORE the scan (see _msg_sum_key)
+        if ent and ent[0] == key:                    # unchanged since last scan → reuse its submap
             continue
         try:
             sub = _msg_sum_scan_session(sid, s["path"], now)
         except Exception:
             sub = ent[1] if ent else {}              # keep last-known on a transient error
-        per[sid] = (s["mtime"], sub)
+        per[sid] = (key, sub)
         dirty = True
     for sid in [k for k in per if k not in live]:    # forget dead sessions so `per` can't grow unbounded
         del per[sid]
@@ -35593,6 +35918,28 @@ def _msg_summaries():
             m.update(sub)
         _msg_sum_cache["map"] = m
     return _msg_sum_cache["map"]
+
+
+_MSGSUM_UNSET = object()                          # the cycle slot's "not fetched yet" mark (_msg_summaries_scoped)
+
+
+def _msg_summaries_scoped():
+    """_msg_summaries() once per pusher cycle. _pusher_cycle opens _live_scope.msgsum as a one-slot list
+    holding _MSGSUM_UNSET (thread-confined, the _live_scope.names idiom); the first build of the cycle
+    that needs the caption map fetches it into the slot and every later build of the cycle reads the
+    slot, so the fold gate's per-card caption check (_postal_card_deps) is one threading.local read per
+    build and _msg_sum_key's stats (a handful of files per discovered session) run once per cycle instead
+    of once per build. The timeline's postal connectors (_postal_messages) read the same slot, so a cycle
+    that rebuilds the timeline too fetches the map once. Within a cycle the map is the cycle's snapshot: a
+    caption appended mid-cycle is seen next cycle, the staleness every _live_scope memo tolerates by
+    construction (see _sessions). A thread with no scope, a handler-thread build, takes the direct path
+    (2026-09-09)."""
+    slot = getattr(_live_scope, "msgsum", None)
+    if slot is None:
+        return _msg_summaries()
+    if slot[0] is _MSGSUM_UNSET:
+        slot[0] = _msg_summaries()
+    return slot[0]
 
 
 _postal_log_cache = {}        # messages.jsonl -> _fold_records entry; every timeline rebuild used to re-parse the whole log
@@ -35631,7 +35978,8 @@ def _postal_messages(now, alive_sids, id2name, live_sids=None):
     if not sent:
         return []
     cutoff, out = now - TL_HORIZON, []
-    msgsum = _msg_summaries()                           # {id: Haiku caption} → the timeline shows it over the raw body
+    msgsum = _msg_summaries_scoped()                    # {id: Haiku caption} → the timeline shows it over the raw body;
+    #                                                     the pusher's cycle slot, shared with the chat builds (2026-09-09)
     tanchors = _thread_anchors(alive_sids)              # {tid: (parent sid, anchorT, name)} — thread mail's home
     for mid, e in sent.items():
         f, t, st = e.get("from_id"), e.get("to_id"), e.get("t")
@@ -36009,9 +36357,13 @@ def _node_log_rows(nd, seg_work, cap=8):
 
 
 _node_anchor_last = {}   # node id → its last WARM-resolved (prompt, work) anchors — see _node_anchor_uuids
+_node_anchor_rev = {}    # sid → how many times _node_anchor_last CHANGED for a node resolved under that sid: the
+#                          ledger memo's key for the table (build_session). Bumped AFTER the entry is written,
+#                          so a reader that took the rev before its walk and stored it misses on the next build
+#                          whenever a resolve landed during the walk, and can never serve the pre-resolve tree.
 
 
-def _node_anchor_uuids(nd, seg_trig, seg_work):
+def _node_anchor_uuids(nd, seg_trig, seg_work, sid=None):
     """(promptAnchorUuid, anchorUuid) — the EXACT chat .turn[data-uuid]s a goal node's ledger/feed zones
     deep-link to. promptAnchorUuid = the MINTING segment's trigger (the user message that asked — the
     text/title zones for DONE nodes, landing on the user turn). anchorUuid = the WORK anchor (reply
@@ -36042,7 +36394,13 @@ def _node_anchor_uuids(nd, seg_trig, seg_work):
     (_node_anchor_last, per kernel run) and a cold/missed one serves, in order: the remembered warm
     anchor (exact — at worst one resolve behind), the node's stored summaryAnchor (the distiller's
     validated citation, the same fallback family as build_feed's card-level cold fix), else None — the
-    honest-fail toast stays for the truly unanchorable."""
+    honest-fail toast stays for the truly unanchorable.
+
+    `sid`: the session whose build resolves this node. A warm resolve that CHANGES the table's entry bumps
+    _node_anchor_rev[sid] after the write, so build_session's ledger memo, which keys on the rev it read
+    before its walk, misses on the next build instead of serving a tree whose cold nodes read an older
+    entry (2026-09-09). Node ids are bare (g1, g2), so a resolve under one session names the same key as
+    another session's node of the same id; that collision predates the rev and is not widened by it."""
     trail = nd.get("trail") or []
     anchor_seg = trail[-1] if trail else None
     prompt = nd.get("promptUuid") or seg_trig.get(_seg_key(trail[0] if trail else None))
@@ -36051,8 +36409,10 @@ def _node_anchor_uuids(nd, seg_trig, seg_work):
     work = seg_work.get(_seg_key(anchor_seg))
     nid = nd.get("id")
     if work is not None:
-        if nid:
-            _node_anchor_last[nid] = (prompt, work)
+        if nid and _node_anchor_last.get(nid) != (prompt, work):
+            _node_anchor_last[nid] = (prompt, work)      # the entry first, then the revision (see _node_anchor_rev)
+            if sid is not None:
+                _node_anchor_rev[sid] = _node_anchor_rev.get(sid, 0) + 1
     else:
         held = _node_anchor_last.get(nid) if nid else None
         if held:
@@ -40881,7 +41241,7 @@ def _push(targets, connect=False, tmux=None):
                     m, ms, asig, started = hit[1], hit[2], hit[3], hit[4]   # unchanged → reuse, no reshape/serialize
                     _VIEW_STATS["chatServeActive" if is_active else "chatServeBg"] += 1
                     _perf("chatbuild", sid=str(s["sid"])[:8], cached=1, ms=0, active=int(is_active))
-                    _PERF_STATS.build("chat", True)
+                    _PERF_STATS.build_chat(True)
                 else:
                     _VIEW_STATS["chatBuildActive" if is_active else "chatBuildBg"] += 1
                     started = time.time()                # the _views_dirty floor for this build (start-keyed)
@@ -40909,10 +41269,14 @@ def _push(targets, connect=False, tmux=None):
                     # session pays on every single push. If chat ever feels slow again, this number and
                     # the deduped= on the matching send say which half is at fault.
                     _dt = time.monotonic() - _t0
-                    _PERF_STATS.build("chat", False, _dt)
+                    # WHY a background tab rebuilt (2026-09-09): the labelled _chat_build_sig components that
+                    # moved against the cached signature, so /perf can say which input drives the background
+                    # rebuilds; the watched tab rebuilds on its exact key and is counted, not attributed
+                    _miss = () if is_active else _chat_sig_miss(hit[0] if hit is not None else None, sig)
+                    _PERF_STATS.build_chat(False, _dt, active=is_active, miss=_miss)
                     if _PERF:                            # the keyword values below cost lookups; skip them when off
                         _perf("chatbuild", sid=str(s["sid"])[:8], cached=0, active=int(is_active),
-                              ms=round(_dt * 1000, 1),
+                              ms=round(_dt * 1000, 1), miss=",".join(_miss),
                               events=(len(m.get("events") or []) if m else 0),
                               fold=_chat_fold_last_info().get("fold", 0), k=_chat_fold_last_info().get("k", 0),
                               prefix=_chat_fold_last_info().get("prefix", 0),   # events reused from the sealed prefix
@@ -40981,6 +41345,17 @@ def _push(targets, connect=False, tmux=None):
                 for sid in list(_chat_fold):
                     if sid not in keep:
                         _chat_fold.pop(sid, None)
+            # …and the chat build's fixed-cost memos on the same keep set (2026-09-09), outside the lock the
+            # bumps take: the ledger walk of a tab no longer shown (a thread this cycle built stays, like its
+            # fold prefix), and the live-merge sets of a sid neither kept nor alive (the feed and timeline
+            # merge every alive session, tab or not)
+            for sid in list(_ledger_memo):
+                if sid not in keep:
+                    _ledger_memo.pop(sid, None)
+                    _chat_memo_bump(_ledger_memo_stats, "evict")
+            for sid in list(_merge_sets_memo):
+                if sid not in keep and sid not in tmux:
+                    _merge_sets_memo.pop(sid, None)
             _retry_parked_creates()   # lag-parked comment creates ride every pusher cycle (T106)
             # COMMENT THREADS: one {type:"comments"} frame per session that has ever had one (its
             # comments/ store exists — an ~free stat for everyone else). Each frame rides its OWN
@@ -42891,6 +43266,8 @@ def _pusher_cycle():
         #                                         forks); the wide walk under ("wide", window)): ~35 sweeps
         #                                         per cycle became one
         _live_scope.auth = {}                   # …and the cycle's billing-availability memo (_auth_avail_status)
+        _live_scope.msgsum = [_MSGSUM_UNSET]    # …and the cycle's caption-map slot (_msg_summaries_scoped): the
+        #                                       first chat build that needs the map fetches it, the rest read it
         _live_scope.names = _names_snapshot()   # …and the cycle's NAMES snapshot, same idiom: the name/
         #                                       cwd/color helpers otherwise re-read the registry per path
         #                                       token and per postal card (~38% of pusher wall, py-spy
@@ -42903,6 +43280,7 @@ def _pusher_cycle():
         _live_scope.paths = None
         _live_scope.sessions = None
         _live_scope.auth = None
+        _live_scope.msgsum = None
         _PERF_STATS.cycle(time.monotonic() - _t_cycle, time.thread_time() - _c_cycle,
                           idle=(_PERF_STATS.marks(), jd._GOAL_IO["saves"], jd._GOAL_IO["writes"]) == _m_cycle)
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -244,7 +244,9 @@ class _PerfStats:
                                    at fold commits, each once); chatLedger (build_session's goal-tree
                                    walk and live roots per sid, see _ledger_memo) -> hit / miss,
                                    bypass_live (live atoms merged), bypass_hold (a rewind hold armed),
-                                   bypass_empty (a store with no nodes), evict, and the gauge entries
+                                   bypass_empty (a store with no nodes), evict, and the gauge entries;
+                                   chatFoldTasks (the per-turn task fold, see _fold_tasks) -> hit /
+                                   miss counted per TURN and the gauge entries (sids held)
       judge                        passes (one per _producer pass), ms_sum / ms_last / ms_mean (wall:
                                    a pass is a join over the tier threads, so this is mostly model
                                    latency), cpu_ms_sum (CPU: the two tier threads' own time, from
@@ -458,9 +460,9 @@ class _PerfStats:
                           ("intrMarks", _intr_marks_memo_report), ("statesOverlay", _states_overlay_report),
                           ("lanes", _lanes_memo_report),   # the timeline's per-lane segment memo, live lanes; the dead lanes beside
                           # the chat build's fixed-cost memos (2026-09-09): the live merge's transcript-side
-                          # sets, the fold's sealed postal cards, the ledger's goal-tree walk
+                          # sets, the fold's sealed postal cards, the ledger's goal-tree walk, the task fold
                           ("chatMergeSets", _merge_sets_report), ("chatPostal", _chat_postal_report),
-                          ("chatLedger", _ledger_memo_report)):
+                          ("chatLedger", _ledger_memo_report), ("chatFoldTasks", _task_fold_report)):
             try:
                 memos[key] = read()
             except Exception:
@@ -26342,69 +26344,114 @@ def _read_task_store(fsid, fold=None):
     return [dict(t) for t in out]
 
 
-def _fold_tasks(session):
+_task_fold_memo = {}                             # sid → {id(turn atoms): (atoms, fp, partial)}: see _fold_tasks
+_task_fold_stats = {"hit": 0, "miss": 0}         # /perf memos.chatFoldTasks, per TURN: served from the memo vs scanned
+
+
+def _task_fold_report():
+    """/perf memos.chatFoldTasks: hit / miss count TURNS (served from the memo vs scanned; a build of an N-turn
+    session with one moved turn is N-1 hits and 1 miss) and the gauge entries (sids held)."""
+    return dict(_task_fold_stats, entries=len(_task_fold_memo))
+
+
+def _fold_tasks_turn(atoms):
+    """One turn's share of _fold_tasks, pure over its atoms: (results, rejected, ops). results: tool_use_id →
+    the content of the turn's tool_result blocks (a TaskCreate's carries 'Task #N'); rejected: the
+    tool_use_ids whose result came back is_error (the CLI refused the call: nothing created, nothing moved);
+    ops: the turn's TaskCreate and TaskUpdate tool_use blocks in order, as (name, input, tool_use_id)."""
+    results, rejected, ops = {}, set(), []
+    for a in atoms:
+        if a.get("type") == "user":
+            for b in (a.get("message") or {}).get("content", []) or []:
+                if isinstance(b, dict) and b.get("type") == "tool_result" and b.get("tool_use_id"):
+                    results[b["tool_use_id"]] = b.get("content")
+                    if b.get("is_error"):
+                        rejected.add(b["tool_use_id"])
+        elif a.get("type") == "assistant":
+            for b in (a.get("message") or {}).get("content", []) or []:
+                if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("name") in ("TaskCreate", "TaskUpdate"):
+                    ops.append((b["name"], b.get("input") or {}, b.get("id")))
+    return results, rejected, ops
+
+
+def _fold_tasks(session, sid=None):
     """Fold a session's TaskCreate/TaskUpdate tool calls into ONE checklist — the FALLBACK for _read_task_store
     when a session has no live task store (mirrors the old TS transcript.foldTasks the Python rewrite dropped).
     Task id = the number in TaskCreate's RESULT text ('Task #N created…'); status rides each TaskUpdate
     {taskId,status} the CLI accepted. NOTE this is lossy — it can't see a completion a subagent wrote only to the store (see
     _read_task_store). Returns the tasks in creation
     order, or None if there were none. The webview renders this as a todo card (kind:'todo') and hides the
-    raw Task* calls (ACK_TOOLS) — so the kernel emits the folded card and skips the raw tool events."""
-    out = {}                                              # tool_use_id → result content (a TaskCreate's carries 'Task #N')
-    rejected = set()                                      # tool_use_ids whose result came back is_error
+    raw Task* calls (ACK_TOOLS), so the kernel emits the folded card and skips the raw tool events.
+
+    PER-TURN MEMO (2026-09-09). The scan over a turn's atoms is pure over those atoms (_fold_tasks_turn), so
+    each turn's partial is kept per `sid` keyed on its atoms list's identity (held) plus _chat_turn_fp, the
+    fingerprint the chat fold trusts for a turn's atoms; the fingerprint guards an in-place change to a held
+    list. A parse of any kind mints new turn dicts and atoms lists, so the memo serves the builds over the
+    parse cache's object and the live merge's copy of it, which carries a new atoms list for its last turn
+    only: a build of a long working transcript scans one turn instead of every turn, which every build used
+    to do. The combine over the partials (the result join, the ops replay) runs in full on every call and
+    returns a fresh list, so a caller may keep or alter the result without reaching the memo. No sid: no
+    memo (a direct call)."""
+    prev = _task_fold_memo.get(sid) if sid is not None else None
+    cur, parts = {}, []
     for turn in session["turns"]:
-        for a in turn["atoms"]:
-            if a.get("type") != "user":
-                continue
-            for b in (a.get("message") or {}).get("content", []) or []:
-                if isinstance(b, dict) and b.get("type") == "tool_result" and b.get("tool_use_id"):
-                    out[b["tool_use_id"]] = b.get("content")
-                    if b.get("is_error"):
-                        rejected.add(b["tool_use_id"])
+        atoms = turn["atoms"]
+        fp = _chat_turn_fp(turn)
+        ent = prev.get(id(atoms)) if prev else None
+        if ent is not None and ent[0] is atoms and ent[1] == fp:
+            _chat_memo_bump(_task_fold_stats, "hit")
+            part = ent[2]
+        else:
+            _chat_memo_bump(_task_fold_stats, "miss")
+            part = _fold_tasks_turn(atoms)
+        if sid is not None:
+            cur[id(atoms)] = (atoms, fp, part)
+        parts.append(part)
+    if sid is not None:
+        _task_fold_memo[sid] = cur                   # only this session's current turns: the memo shrinks with a rewrite
+    out = {}                                          # tool_use_id → result content (a TaskCreate's carries 'Task #N')
+    rejected = set()                                  # tool_use_ids whose result came back is_error
+    for results, rej, _ops in parts:
+        out.update(results)
+        rejected |= rej
     tasks, order = {}, 0
-    for turn in session["turns"]:
-        for a in turn["atoms"]:
-            if a.get("type") != "assistant":
-                continue
-            for b in (a.get("message") or {}).get("content", []) or []:
-                if not isinstance(b, dict) or b.get("type") != "tool_use":
+    for _results, _rejected, ops in parts:
+        for name, inp, bid in ops:
+            if name == "TaskCreate":
+                # A TaskCreate the CLI REJECTED is not a checklist item. A malformed call — no `subject`
+                # ({agent_hint, prompt}), or a {tasks: [...]} batch — draws a paired tool_result with
+                # is_error set and an InputValidationError naming the missing field: nothing was created,
+                # nothing launched, and nothing renders it (the chat skips every raw TaskCreate row).
+                # Folded as a pending task it gave a session whose only TaskCreate was rejected a phantom
+                # open item, which tripped the card's "can't read the task store" error the moment the
+                # store was unresolvable. The skip keys on the result's is_error — the event that says no
+                # task exists — not on the input's key names, which would miss every other rejected
+                # shape. A create whose result has not landed yet still folds under its creation-order
+                # id, as before.
+                if bid in rejected:
                     continue
-                inp = b.get("input") or {}
-                if b.get("name") == "TaskCreate":
-                    # A TaskCreate the CLI REJECTED is not a checklist item. A malformed call — no `subject`
-                    # ({agent_hint, prompt}), or a {tasks: [...]} batch — draws a paired tool_result with
-                    # is_error set and an InputValidationError naming the missing field: nothing was created,
-                    # nothing launched, and nothing renders it (the chat skips every raw TaskCreate row).
-                    # Folded as a pending task it gave a session whose only TaskCreate was rejected a phantom
-                    # open item, which tripped the card's "can't read the task store" error the moment the
-                    # store was unresolvable. The skip keys on the result's is_error — the event that says no
-                    # task exists — not on the input's key names, which would miss every other rejected
-                    # shape. A create whose result has not landed yet still folds under its creation-order
-                    # id, as before.
-                    if b.get("id") in rejected:
-                        continue
-                    # Only a TaskCreate's result is ever read, so only it is encoded, here, to the same text
-                    # the regex saw when every result was encoded up front. Encoding every Bash and Read
-                    # output (list-shaped ones, image blocks) for a value nothing read was 0.3% of the pusher
-                    # (cProfile of the push thread on a loaded kernel, 2026-09-06).
-                    r = out.get(b.get("id"), "")
-                    m = re.search(r"Task #(\d+)", (r if isinstance(r, str) else json.dumps(r)) or "")
-                    tid = m.group(1) if m else "c%d" % order
-                    af = inp.get("activeForm")
-                    tasks[tid] = {"_order": order, "id": tid, "subject": str(inp.get("subject") or ""),
-                                  "activeForm": str(af) if af else None, "status": "pending"}
-                    order += 1
-                elif b.get("name") == "TaskUpdate":
-                    # A TaskUpdate the CLI REJECTED — its paired tool_result carries is_error (a status value
-                    # outside its set, a transition it refused) — wrote nothing to the store, so it moves no
-                    # checklist item; applied, the refused status stood in for the store's. Keyed on the
-                    # result's is_error like the TaskCreate skip above, so this fold and event_model's
-                    # declared_plan stay identical. An update whose result has not landed still applies.
-                    if b.get("id") in rejected:
-                        continue
-                    t = tasks.get(str(inp.get("taskId", "")))
-                    if t:
-                        t["status"] = str(inp.get("status") or t["status"])
+                # Only a TaskCreate's result is ever read, so only it is encoded, here, to the same text
+                # the regex saw when every result was encoded up front. Encoding every Bash and Read
+                # output (list-shaped ones, image blocks) for a value nothing read was 0.3% of the pusher
+                # (cProfile of the push thread on a loaded kernel, 2026-09-06).
+                r = out.get(bid, "")
+                m = re.search(r"Task #(\d+)", (r if isinstance(r, str) else json.dumps(r)) or "")
+                tid = m.group(1) if m else "c%d" % order
+                af = inp.get("activeForm")
+                tasks[tid] = {"_order": order, "id": tid, "subject": str(inp.get("subject") or ""),
+                              "activeForm": str(af) if af else None, "status": "pending"}
+                order += 1
+            else:                                     # TaskUpdate
+                # A TaskUpdate the CLI REJECTED — its paired tool_result carries is_error (a status value
+                # outside its set, a transition it refused) — wrote nothing to the store, so it moves no
+                # checklist item; applied, the refused status stood in for the store's. Keyed on the
+                # result's is_error like the TaskCreate skip above, so this fold and event_model's
+                # declared_plan stay identical. An update whose result has not landed still applies.
+                if bid in rejected:
+                    continue
+                t = tasks.get(str(inp.get("taskId", "")))
+                if t:
+                    t["status"] = str(inp.get("status") or t["status"])
     if not tasks:
         return None
     ordered = sorted(tasks.values(), key=lambda t: t["_order"])
@@ -31479,7 +31526,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
     # error worth alarming on. Only while work is OUTSTANDING does a card show at all — a fully
     # completed/cancelled list isn't a live to-do (the user 2026-06-10).
     _fsid = os.path.basename(sess["path"]).rsplit(".", 1)[0] if sess.get("path") else ""
-    fold = _fold_tasks(session)                       # the transcript's own task record — feeds the store
+    fold = _fold_tasks(session, sid)                  # the transcript's own task record: feeds the store
     todo = _read_task_store(_fsid, fold)              # content join for team-named interactive stores
     if todo is None:                                  # authoritative store unreadable — never silently fold
         if fold and any(t["status"] not in ("completed", "cancelled") for t in fold):
@@ -41346,13 +41393,16 @@ def _push(targets, connect=False, tmux=None):
                     if sid not in keep:
                         _chat_fold.pop(sid, None)
             # …and the chat build's fixed-cost memos on the same keep set (2026-09-09), outside the lock the
-            # bumps take: the ledger walk of a tab no longer shown (a thread this cycle built stays, like its
-            # fold prefix), and the live-merge sets of a sid neither kept nor alive (the feed and timeline
-            # merge every alive session, tab or not)
+            # bumps take: the ledger walk and the task fold of a tab no longer shown (a thread this cycle built
+            # stays, like its fold prefix), and the live-merge sets of a sid neither kept nor alive (the feed
+            # and timeline merge every alive session, tab or not)
             for sid in list(_ledger_memo):
                 if sid not in keep:
                     _ledger_memo.pop(sid, None)
                     _chat_memo_bump(_ledger_memo_stats, "evict")
+            for sid in list(_task_fold_memo):
+                if sid not in keep:
+                    _task_fold_memo.pop(sid, None)
             for sid in list(_merge_sets_memo):
                 if sid not in keep and sid not in tmux:
                     _merge_sets_memo.pop(sid, None)

--- a/tests/romp-perf.bats
+++ b/tests/romp-perf.bats
@@ -33,7 +33,8 @@ setup() {
     export SNAP_C="$TEST_DIR/c.json"
     # A and B: the same kernel process ten seconds apart. Over the window: 20 cycles, 60 wakes, 6 s of
     # cycle time (4 s of it in push, 3 s of that in the chat block), 300 ms of pusher CPU and 50 ms of
-    # judge CPU inside 500 ms of process CPU, 2 chat rebuilds against 18 cache hits, 1 MB sent as chat
+    # judge CPU inside 500 ms of process CPU, 2 chat rebuilds (one of the watched tab, one of a background
+    # tab whose judge_gen component moved) against 18 cache hits, 1 MB sent as chat
     # full frames, one GET /feed.json build (150 ms) against 4 of its cache hits, 100 goal loads, 2 judge
     # passes totalling 2400 ms, 5 /tick requests and 3 WebSocket connects. B's lifetime figures (cycle_ms_max 900, ms_mean 1012.5) differ from the window's
     # (ring max 700, mean 1200) so a line printing the wrong one is caught.
@@ -44,7 +45,7 @@ setup() {
             "cycle_ms_max": 900.0, "cycle_ms_last": 200.0, "cycle_cpu_ms_sum": 10000.0,
             "cycle_ms_p50": 180.0, "cycle_ms_p90": 400.0, "cycle_ms_ring_max": 900.0, "ring_n": 100},
  "stages_ms": {"jobs": 5000.0, "push": 20000.0, "push.chat": 15000.0, "push.feed": 3000.0, "push.timeline": 1000.0, "push.send": 500.0},
- "builds": {"chat": {"cached": 80, "built": 20, "ms": 800.0}, "feed": {"cached": 90, "built": 10, "ms": 5000.0}, "timeline": {"cached": 95, "built": 5, "ms": 4000.0}, "feedJson": {"cached": 5, "built": 1, "ms": 300.0}},
+ "builds": {"chat": {"cached": 80, "built": 20, "ms": 800.0, "active_built": 12, "bg_built": 8, "bg_miss": {"transcript": 5, "states": 2, "judge_gen": 1, "tasks": 0, "cut": 0, "row": 0, "cold": 1, "nosig": 0}}, "feed": {"cached": 90, "built": 10, "ms": 5000.0}, "timeline": {"cached": 95, "built": 5, "ms": 4000.0}, "feedJson": {"cached": 5, "built": 1, "ms": 300.0}},
  "sends": {"full": {"chat": {"count": 10, "bytes": 1000000}}, "delta": {"chat": {"count": 100, "bytes": 50000}}, "deduped": {"feed": {"count": 90, "bytes": 9000000}}},
  "goals": {"loads": 1000, "saves": 200, "writes": 50},
  "judge": {"passes": 30, "ms_sum": 30000.0, "ms_last": 1000.0, "ms_mean": 1000.0, "cpu_ms_sum": 2000.0, "cpu_ms_workers": 1500.0},
@@ -57,7 +58,7 @@ JSON
             "cycle_ms_max": 900.0, "cycle_ms_last": 250.0, "cycle_cpu_ms_sum": 10300.0,
             "cycle_ms_p50": 190.0, "cycle_ms_p90": 420.0, "cycle_ms_ring_max": 700.0, "ring_n": 120},
  "stages_ms": {"jobs": 6000.0, "push": 24000.0, "push.chat": 18000.0, "push.feed": 3600.0, "push.timeline": 1200.0, "push.send": 600.0},
- "builds": {"chat": {"cached": 98, "built": 22, "ms": 880.0}, "feed": {"cached": 108, "built": 12, "ms": 6000.0}, "timeline": {"cached": 114, "built": 6, "ms": 4800.0}, "feedJson": {"cached": 9, "built": 2, "ms": 450.0}},
+ "builds": {"chat": {"cached": 98, "built": 22, "ms": 880.0, "active_built": 13, "bg_built": 9, "bg_miss": {"transcript": 5, "states": 2, "judge_gen": 2, "tasks": 0, "cut": 0, "row": 0, "cold": 1, "nosig": 0}}, "feed": {"cached": 108, "built": 12, "ms": 6000.0}, "timeline": {"cached": 114, "built": 6, "ms": 4800.0}, "feedJson": {"cached": 9, "built": 2, "ms": 450.0}},
  "sends": {"full": {"chat": {"count": 12, "bytes": 2048576}}, "delta": {"chat": {"count": 120, "bytes": 60000}}, "deduped": {"feed": {"count": 108, "bytes": 10800000}}},
  "goals": {"loads": 1100, "saves": 220, "writes": 55},
  "judge": {"passes": 32, "ms_sum": 32400.0, "ms_last": 1200.0, "ms_mean": 1012.5, "cpu_ms_sum": 2050.0, "cpu_ms_workers": 1540.0},
@@ -128,7 +129,9 @@ teardown() { rm -rf "$TEST_DIR"; }
 @test "romp perf: builds, sends, goals, judge and http lines carry the window's deltas" {
     run "$ROMP_SCRIPT" perf --interval 0
     [ "$status" -eq 0 ]
-    [[ "$output" == *"chat 2 built / 18 cached (40 ms avg)"* ]]
+    # the chat line's split: the watched tab's rebuild against the background one's, and per signature
+    # component the background rebuilds it caused (only the non-zero causes; judge_gen moved once in the window)
+    [[ "$output" == *"chat 2 built / 18 cached (40 ms avg; 1 watched, 1 background: judge_gen 1)"* ]]
     # GET /feed.json's own reads print beside the pusher's feed, never folded into it (review find, 2026-09-08)
     [[ "$output" == *"feedJson 1 built / 4 cached (150 ms avg)"* ]]
     [[ "$output" == *"full 102 KB/s (chat 2 frames 102 KB/s)"* ]]        # 1048576 bytes over 10 s, bytes beside the count

--- a/tests/test_chat_fixed_cost_memos.py
+++ b/tests/test_chat_fixed_cost_memos.py
@@ -143,6 +143,7 @@ class Collector(unittest.TestCase):
         self.assertEqual(set(snap["chatMergeSets"]), {"hit", "miss", "entries"})
         self.assertEqual(set(snap["chatPostal"]), {"gate", "hit", "commit_new"})
         self.assertEqual(set(snap["chatLedger"]), {"hit", "miss", "bypass_live", "bypass_hold", "bypass_empty", "evict", "entries"})
+        self.assertEqual(set(snap["chatFoldTasks"]), {"hit", "miss", "entries"})
 
 
 class MemoBump(unittest.TestCase):
@@ -323,6 +324,22 @@ class TwoTabAttribution(unittest.TestCase):
         finally:
             for sid in (stray, thread, SID_B):
                 km._ledger_memo.pop(sid, None)
+
+    def test_the_sweep_drops_the_task_fold_memo_on_the_same_keep_set(self):
+        stray = "66666666-7777-8888-9999-aaaaaaaaaaa9"
+        thread = "66666666-7777-8888-9999-aaaaaaaaaaa7"
+        for sid in (stray, thread, SID_B):
+            km._task_fold_memo[sid] = {}
+        km._thread_fold_keep[1].add(thread)
+        try:
+            km._push([self.chat, self.tl])
+            self.assertNotIn(stray, km._task_fold_memo, "the task fold memo of a tab no longer shown is evicted")
+            self.assertIn(SID_B, km._task_fold_memo, "a shown tab's entry stays")
+            self.assertIn(thread, km._task_fold_memo, "this cycle's thread stays")
+            self.assertEqual(km._task_fold_report()["entries"], len(km._task_fold_memo))
+        finally:
+            for sid in (stray, thread, SID_B):
+                km._task_fold_memo.pop(sid, None)
 
 
 # ── the live merge's transcript-side sets ────────────────────────────────────────────────────────
@@ -1188,6 +1205,125 @@ class LedgerMemo(unittest.TestCase):
         self.assertEqual((m["ledger"]["tree"], m["ledger"]["recent"], m["ledger"]["current"]), ([], [], None))
         self.assertEqual(self._delta(s), {"hit": 1}, "the mute is applied after the memo, live")
         self.assertEqual(len(km._ledger_memo[SID_A][3]), 3, "the memo keeps the walk for an unmute")
+
+
+class TaskFold(unittest.TestCase):
+    """_fold_tasks' per-turn partials, memoized per sid on each turn's atoms list identity and fingerprint:
+    a build over the parse cache's object rescans only the turn the live merge replaced."""
+
+    T = 1781100000
+
+    def setUp(self):
+        self._saved = (dict(km._task_fold_memo), dict(km._task_fold_stats), os.environ.get("CLAUDE_CONFIG_DIR"))
+        km._task_fold_memo.clear()
+        for k in km._task_fold_stats:
+            km._task_fold_stats[k] = 0
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        os.environ["CLAUDE_CONFIG_DIR"] = td.name              # no real task store is read
+
+    def tearDown(self):
+        km._task_fold_memo.clear(); km._task_fold_memo.update(self._saved[0])
+        km._task_fold_stats.clear(); km._task_fold_stats.update(self._saved[1])
+        if self._saved[2] is None:
+            os.environ.pop("CLAUDE_CONFIG_DIR", None)
+        else:
+            os.environ["CLAUDE_CONFIG_DIR"] = self._saved[2]
+
+    def _turn(self, i, create=None, update=None, rejected=False):
+        T = self.T + 100 * i
+        atoms = [{"type": "user", "uuid": "u%d" % i, "t": T, "author": "human",
+                  "message": {"role": "user", "content": [{"type": "text", "text": "step %d" % i}]}}]
+        content, results = [], []
+        if create:
+            content.append({"type": "tool_use", "id": "tu_c%d" % i, "name": "TaskCreate",
+                            "input": {"subject": create[0], "activeForm": create[1]}})
+            results.append({"type": "tool_result", "tool_use_id": "tu_c%d" % i,
+                            "content": "InputValidationError: subject is required" if rejected else "Task #%d created" % (i + 1),
+                            **({"is_error": True} if rejected else {})})
+        if update:
+            content.append({"type": "tool_use", "id": "tu_u%d" % i, "name": "TaskUpdate",
+                            "input": {"taskId": update[0], "status": update[1]}})
+        content.append({"type": "tool_use", "id": "tu_b%d" % i, "name": "Bash", "input": {"command": "uv run pytest -q"}})
+        results.append({"type": "tool_result", "tool_use_id": "tu_b%d" % i, "content": "ok"})
+        atoms.append({"type": "assistant", "uuid": "a%d" % i, "t": T + 10, "message": {"role": "assistant", "content": content}})
+        atoms.append({"type": "user", "uuid": "r%d" % i, "t": T + 20, "message": {"role": "user", "content": results}})
+        return {"id": "t%d" % i, "trigger": "u%d" % i, "t": T, "end": T + 20, "ended": True, "atoms": atoms}
+
+    def _session(self):
+        return {"turns": [self._turn(0, create=("write the tests", "Writing the tests")),
+                          self._turn(1, create=("run the suite", "Running the suite")),
+                          self._turn(2, update=("1", "completed"))]}
+
+    EXPECTED = [{"id": "1", "subject": "write the tests", "activeForm": "Writing the tests", "status": "completed"},
+                {"id": "2", "subject": "run the suite", "activeForm": "Running the suite", "status": "pending"}]
+
+    def test_identity_hits_a_new_parse_misses_and_a_live_merge_misses_the_last_turn_only(self):
+        sess = self._session()
+        self.assertEqual(km._fold_tasks(sess), self.EXPECTED, "no sid: the unmemoized fold")
+        self.assertEqual(km._task_fold_stats, {"hit": 0, "miss": 3}, "a direct call scans and memoizes nothing")
+        self.assertEqual(km._task_fold_report()["entries"], 0)
+        got = km._fold_tasks(sess, SID_A)
+        self.assertEqual(got, self.EXPECTED)
+        self.assertEqual(km._task_fold_stats, {"hit": 0, "miss": 6})
+        got2 = km._fold_tasks(sess, SID_A)
+        self.assertEqual(got2, self.EXPECTED)
+        self.assertIsNot(got2, got, "a fresh list per call")
+        self.assertEqual(km._task_fold_stats, {"hit": 3, "miss": 6}, "the same turns: every turn served")
+        merged = dict(sess, turns=[dict(t) for t in sess["turns"]])       # _merge_live_atoms' shape
+        merged["turns"][-1]["atoms"] = list(merged["turns"][-1]["atoms"]) + [
+            {"type": "assistant", "uuid": "live", "t": self.T + 999,
+             "message": {"role": "assistant", "content": [{"type": "text", "text": "streaming"}]}}]
+        self.assertEqual(km._fold_tasks(merged, SID_A), self.EXPECTED)
+        self.assertEqual(km._task_fold_stats, {"hit": 5, "miss": 7}, "a live merge: the last turn scanned, the rest served")
+        fresh = json.loads(json.dumps(sess))                              # a re-parse: new atom lists
+        self.assertEqual(km._fold_tasks(fresh, SID_A), self.EXPECTED)
+        self.assertEqual(km._task_fold_stats, {"hit": 5, "miss": 10})
+        self.assertEqual(km._task_fold_report(), {"hit": 5, "miss": 10, "entries": 1})
+        self.assertIsNone(km._fold_tasks({"turns": []}, SID_A), "no turns: no checklist")
+
+    def test_a_turn_that_grew_in_place_is_rescanned(self):
+        sess = self._session()
+        km._fold_tasks(sess, SID_A)
+        sess["turns"][1]["atoms"].append({"type": "assistant", "uuid": "a1b", "t": self.T + 150, "message": {
+            "role": "assistant", "content": [{"type": "tool_use", "id": "tu_u1b", "name": "TaskUpdate",
+                                              "input": {"taskId": "2", "status": "in_progress"}}]}})
+        got = km._fold_tasks(sess, SID_A)
+        self.assertEqual(got[1]["status"], "in_progress", "the appended update is folded")
+        self.assertEqual(km._task_fold_stats, {"hit": 2, "miss": 4}, "the grown turn's fingerprint moved")
+
+    def test_a_rejected_create_and_a_result_in_a_later_turn_fold_as_before(self):
+        # the combine runs over every turn's partial in order, so a result that lands in a later turn than its
+        # call still names the task, and a rejected create is still no item (the unmemoized rules)
+        sess = {"turns": [self._turn(0, create=("write the tests", "Writing the tests")),
+                          self._turn(1, create=("a malformed create", None), rejected=True),
+                          self._turn(2, update=("1", "in_progress"))]}
+        self.assertEqual(km._fold_tasks(sess, SID_A), km._fold_tasks(sess),
+                         "memoized and direct folds agree")
+        self.assertEqual([t["id"] for t in km._fold_tasks(sess, SID_A)], ["1"], "the rejected create is no item")
+        self.assertEqual(km._fold_tasks(sess, SID_A)[0]["status"], "in_progress")
+
+    def test_the_result_is_not_the_memo_and_the_store_reader_leaves_it_unchanged(self):
+        sess = self._session()
+        got = km._fold_tasks(sess, SID_A)
+        before = json.dumps(got)
+        self.assertIsNone(km._read_task_store("no-such-fsid-" + SID_A[:8], got), "no store dir: the loud None")
+        self.assertEqual(json.dumps(got), before, "the reader alters nothing")
+        got[0]["status"] = "cancelled"                                    # a caller altering its copy
+        self.assertEqual(km._fold_tasks(sess, SID_A)[0]["status"], "completed", "the memo is untouched")
+
+    def test_build_session_hands_its_sid_to_the_fold(self):
+        w = World(SID_A)
+        seen = []
+        real = km._fold_tasks
+        km._fold_tasks = lambda session, sid=None: (seen.append(sid) or None)
+        try:
+            w.append(w.turn(0))
+            w.build()
+        finally:
+            km._fold_tasks = real
+            w.close()
+        self.assertEqual(seen, [SID_A], "the memo is keyed on the session the build is for")
 
 
 if __name__ == "__main__":

--- a/tests/test_chat_fixed_cost_memos.py
+++ b/tests/test_chat_fixed_cost_memos.py
@@ -1,0 +1,1194 @@
+#!/usr/bin/env python3
+"""The chat build's per-build fixed costs, memoized on the inputs they read, and the counters that say
+where a chat rebuild came from.
+
+Every chat build used to re-derive four things whose inputs had not moved: the live merge's
+transcript-side sets (every atom of the parse, per build, for the chat, feed and timeline builds of
+one cycle), the sealed postal cards (re-hydrated on every judge pass although a caption is the only
+judge-written value a card embeds), the ledger's goal-tree walk (per build, over the same parse and
+store), and, in its own commit, the task fold (every turn's atoms, per build). builds.chat in GET /perf
+counted rebuilds without saying whether the watched tab or a background one paid, or which input moved.
+
+The tests drive the real code paths: _PerfStats, the real _push over two tabs, _merge_live_atoms with a
+recording backend, build_session over a synthetic session in a rebound state root, and _msg_summaries
+over stubbed discovery rows. Synthetic fixtures only: private placeholder sids (these tests mint goals,
+so never the shared placeholder), invented text, TESTHOST, the notes-api demo world."""
+import json
+import os
+import re
+import tempfile
+import threading
+import time
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the load: the kernel resolves its state root at import time, and only pytest runs
+# conftest's floor (a bare unittest run would otherwise write real state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_chat_memos", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd                                       # the kernel's own judge module
+
+# PRIVATE synthetic sids: these tests mint goal stores, and the shared placeholder sid's override journal
+# is replayed onto every store minted under it (CLAUDE.md, goal-store fixtures).
+SID_A = "66666666-7777-8888-9999-aaaaaaaaaaa1"
+SID_B = "66666666-7777-8888-9999-aaaaaaaaaaa2"
+PEER = "66666666-7777-8888-9999-aaaaaaaaaaa3"
+MID = "1788400000.100_1.TESTHOST"
+
+
+def _clear_memos():
+    """Every chat-build memo this module fills, emptied; a name absent on a tree without the memos is skipped."""
+    for name in ("_chat_fold", "_ledger_memo", "_task_fold_memo", "_node_anchor_last", "_node_anchor_rev",
+                 "_merge_sets_memo", "_tmux_echo"):
+        d = getattr(km, name, None)
+        if isinstance(d, dict):
+            d.clear()
+
+
+# ── the signature's labels and the chat writer ───────────────────────────────────────────────────
+class SigLabels(unittest.TestCase):
+    """_chat_build_sig is a flat tuple; a background rebuild is attributed to the components that moved, by
+    position: two transcript values, two per states file, then the fixed tail. The row the push hands over
+    is one slot either way (None without a row), so the tail has one shape and every position a label."""
+
+    def setUp(self):
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        self.tmp = td.name
+        self.tx = Path(self.tmp) / (SID_A + ".jsonl")
+        self.tx.write_text('{"type": "user"}\n')
+        self.sess = {"sid": SID_A, "path": str(self.tx), "anchor": SID_A}
+        self.saved = km._sdk
+        km._sdk = lambda: None
+
+    def tearDown(self):
+        km._sdk = self.saved
+
+    def test_a_real_signature_has_one_label_per_position_and_a_row_slot_either_way(self):
+        sig = km._chat_build_sig(self.sess)
+        self.assertEqual(km._CHAT_SIG_TAIL, ("judge_gen", "tasks", "cut", "row"))
+        self.assertEqual(km._chat_sig_labels(sig), ("transcript", "transcript", "states", "states") + km._CHAT_SIG_TAIL,
+                         "one states file: the fsid is the anchor")
+        self.assertEqual(len(sig), 8)
+        self.assertIsNone(sig[-1], "no row handed over: the slot is None, so the tail keeps one shape")
+        self.assertEqual(km._chat_build_sig(self.sess), sig, "stable while nothing moved")
+        row = {"state": "idle", "model": "m", "context": 10, "effort": "e", "mode": None, "fast": False, "since": 1,
+               "subagents": [], "bgTasks": [], "connected": True}
+        sig2 = km._chat_build_sig(self.sess, row)
+        self.assertEqual(len(sig2), len(sig))
+        self.assertEqual(km._chat_sig_miss(sig, sig2), ("row",), "the row handed over is the row component")
+        forked = dict(self.sess, anchor=SID_B)                # a forked lane stats two states files
+        sig3 = km._chat_build_sig(forked)
+        self.assertEqual(km._chat_sig_labels(sig3), ("transcript", "transcript") + ("states",) * 4 + km._CHAT_SIG_TAIL)
+        self.assertEqual(km._PerfStats.CHAT_MISS, ("transcript", "states") + km._CHAT_SIG_TAIL + ("cold", "nosig"))
+        self.assertIsNone(km._chat_build_sig({"sid": SID_A, "path": ""}), "no path: no signature")
+
+    def test_each_moved_component_is_named_and_a_reshaped_key_names_the_states_section(self):
+        base = ("mt", "sz", "smt", "ssz", 3, ("fp",), "", None)
+        labels = km._chat_sig_labels(base)
+        for i, lab in enumerate(labels):
+            new = list(base)
+            new[i] = "changed"
+            self.assertEqual(km._chat_sig_miss(base, tuple(new)), (lab,), lab)
+        self.assertEqual(km._chat_sig_miss(base, base), (), "an equal signature is no miss")
+        self.assertEqual(km._chat_sig_miss(None, base), ("cold",), "no cached build")
+        self.assertEqual(km._chat_sig_miss(base, None), ("nosig",), "no signature could be taken")
+        two = list(base)
+        two[0], two[4] = "x", 4
+        self.assertEqual(km._chat_sig_miss(base, tuple(two)), ("judge_gen", "transcript"),
+                         "several moved components are each named, sorted")
+        # the anchor appeared: the states section grew by one file, the tail still compares from its end
+        grown = ("mt", "sz", "smt", "ssz", "amt", "asz", 4, ("fp",), "", None)
+        self.assertEqual(km._chat_sig_miss(base, grown), ("judge_gen", "states"))
+        self.assertEqual(km._chat_sig_miss(base, ("mt2", "sz", "smt", "ssz", "amt", "asz", 3, ("fp",), "", None)),
+                         ("states", "transcript"))
+
+
+class Collector(unittest.TestCase):
+    """_PerfStats.build_chat: the chat kind's writer, splitting the watched tab's rebuilds from the
+    background tabs' and naming what moved for each background rebuild."""
+
+    def test_build_chat_splits_active_from_background_and_attributes_the_latter(self):
+        st = km._PerfStats()
+        st.build_chat(True)
+        st.build_chat(False, 0.010, active=True)
+        st.build_chat(False, 0.020, active=False, miss=("judge_gen",))
+        st.build_chat(False, 0.030, active=False, miss=("states", "transcript"))
+        st.build_chat(False, 0.005, active=False, miss=("cold",))
+        c = st.snapshot()["builds"]["chat"]
+        self.assertEqual((c["cached"], c["built"], c["active_built"], c["bg_built"]), (1, 4, 1, 3))
+        self.assertAlmostEqual(c["ms"], 65.0)
+        self.assertEqual({k: v for k, v in c["bg_miss"].items() if v},
+                         {"judge_gen": 1, "states": 1, "transcript": 1, "cold": 1},
+                         "one count per moved component: the two-component miss counts under both")
+        self.assertEqual(set(c["bg_miss"]), set(km._PerfStats.CHAT_MISS))
+        st.build_chat(False, 0.001, miss=("cold",))
+        self.assertEqual(c["bg_miss"]["cold"], 1, "the snapshot is a copy; a later write does not move it")
+        s = st.snapshot()["builds"]
+        self.assertEqual(set(s["timeline"]), {"cached", "built", "ms"}, "no split on the other kinds")
+        json.dumps(s)
+        st.build("chat", False, 0.001)                        # the plain writer still serves the kind, unattributed
+        c2 = st.snapshot()["builds"]["chat"]
+        self.assertEqual((c2["built"], c2["active_built"] + c2["bg_built"]), (6, 5))
+
+    def test_the_four_memos_report_under_memos(self):
+        snap = km._PerfStats().snapshot()["memos"]
+        self.assertEqual(set(snap["chatMergeSets"]), {"hit", "miss", "entries"})
+        self.assertEqual(set(snap["chatPostal"]), {"gate", "hit", "commit_new"})
+        self.assertEqual(set(snap["chatLedger"]), {"hit", "miss", "bypass_live", "bypass_hold", "bypass_empty", "evict", "entries"})
+
+
+class MemoBump(unittest.TestCase):
+    """The memos' counters are bumped under the chat fold's lock: the pusher, the WS handlers and the
+    backends all build, and a bare increment from two threads loses counts."""
+
+    def test_concurrent_bumps_land_exactly(self):
+        stats, n, per = {"hit": 0}, 8, 2000
+        gate = threading.Barrier(n)
+
+        def run():
+            gate.wait()
+            for _ in range(per):
+                km._chat_memo_bump(stats, "hit")
+        threads = [threading.Thread(target=run) for _ in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(stats["hit"], n * per)
+        km._chat_memo_bump(stats, "new", 3)
+        self.assertEqual(stats["new"], 3, "a missing key starts at zero; n adds n")
+
+    def test_the_bump_waits_on_the_fold_caches_lock(self):
+        stats, done = {"hit": 0}, threading.Event()
+        with km._chat_fold_lock:
+            t = threading.Thread(target=lambda: (km._chat_memo_bump(stats, "hit"), done.set()))
+            t.start()
+            t.join(0.2)
+            self.assertEqual(stats["hit"], 0, "held: the bump has not landed")
+        done.wait(5)
+        self.assertEqual(stats["hit"], 1, "released: it lands")
+
+
+# ── the real push over two tabs ──────────────────────────────────────────────────────────────────
+class TwoTabAttribution(unittest.TestCase):
+    """_push over two tabs, one watched: a rebuild counts under active_built or bg_built, and a background
+    rebuild names the component that moved. The sweep at the end of the chat block drops the memos of
+    tabs no longer shown (keeping this cycle's comment threads, like the fold prefixes)."""
+
+    STUBS = ("NAMES", "_tmux_sessions", "_live_names", "_chat_tab_sessions", "build_session",
+             "_cached_feed", "_cached_timeline", "build_timeline", "_fleet_view_sig", "_comments_frame",
+             "_retry_parked_creates")
+
+    def setUp(self):
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        self.tmp = td.name
+        names = Path(self.tmp) / "names"
+        names.mkdir()
+        for sid, nm in ((SID_A, "web"), (SID_B, "api")):
+            (names / sid).write_text("%s\t/proj/TESTHOST/app\t#1EA1EB\twhite\n" % nm)
+        self.tx = {sid: Path(self.tmp) / (sid + ".jsonl") for sid in (SID_A, SID_B)}
+        for p in self.tx.values():
+            p.write_text('{"type": "user"}\n')                 # exists: _chat_build_sig is a real signature
+        self.saved = {nm: getattr(km, nm) for nm in self.STUBS}
+        self.saved_state = (jd.STATE, dict(km._built_chat), dict(km._prev_chat_events),
+                            dict(km._prev_chat_ledger), list(km._last_tab_order), km._judge_gen[0],
+                            [set(km._thread_fold_keep[0]), set(km._thread_fold_keep[1])])
+        jd._rebind_state(Path(self.tmp) / "state")
+        for d in (jd.STATESDIR, jd.GOALDIR):
+            d.mkdir(parents=True, exist_ok=True)
+        km.NAMES = names
+        self.tmux = {}
+        km._tmux_sessions = lambda: dict(self.tmux)
+        km._live_names = lambda tm: {"web": SID_A, "api": SID_B}
+        km._chat_tab_sessions = lambda now, tmux: [{"sid": s, "name": n, "path": str(self.tx[s]), "anchor": s}
+                                                  for s, n in ((SID_A, "web"), (SID_B, "api"))]
+        km.build_session = self._build_session
+        km._cached_feed = lambda now, tmux, sig, connect=False: {"working": [], "awaiting": [], "now": now}
+        km._cached_timeline = lambda now, tmux, sig, connect=False: {"turns": {}, "judging": [], "messages": [], "now": now}
+        km.build_timeline = lambda now, tmux, **kw: {"lanes": [], "now": now}
+        km._fleet_view_sig = lambda now, tmux: {"probe": 1}
+        km._comments_frame = lambda sid, tmux: None
+        km._retry_parked_creates = lambda: None
+        km._built_chat.clear(); km._prev_chat_events.clear(); km._prev_chat_ledger.clear()
+        self.built = []
+        self.chat = {"app": "chat", "alive": True, "sent": {}, "active": SID_A, "send": lambda s: None}
+        self.tl = {"app": "timeline", "alive": True, "sent": {}, "send": lambda s: None}
+
+    def tearDown(self):
+        for nm, v in self.saved.items():
+            setattr(km, nm, v)
+        st, bc, pe, pl, lo, jg, keep = self.saved_state
+        jd._rebind_state(st)
+        km._built_chat.clear(); km._built_chat.update(bc)
+        km._prev_chat_events.clear(); km._prev_chat_events.update(pe)
+        km._prev_chat_ledger.clear(); km._prev_chat_ledger.update(pl)
+        km._last_tab_order[:] = lo
+        km._judge_gen[0] = jg
+        km._thread_fold_keep[0], km._thread_fold_keep[1] = keep
+
+    def _build_session(self, sid, now, tmux):
+        self.built.append(sid)
+        return {"type": "session", "id": sid, "name": "x", "events": [{"uuid": "e1", "type": "user"}],
+                "ledger": None, "status": {"state": "waiting"}, "color": None}
+
+    @staticmethod
+    def _chat():
+        return km._PERF_STATS.snapshot()["builds"]["chat"]
+
+    @staticmethod
+    def _delta(before, after):
+        d = {k: after[k] - before[k] for k in ("cached", "built", "active_built", "bg_built")}
+        d["bg_miss"] = {k: v - before["bg_miss"][k] for k, v in after["bg_miss"].items() if v - before["bg_miss"][k]}
+        return d
+
+    def test_active_background_and_the_named_cause_of_each_background_rebuild(self):
+        c0 = self._chat()
+        km._push([self.chat, self.tl])
+        c1 = self._chat()
+        self.assertEqual(sorted(self.built), sorted([SID_A, SID_B]))
+        self.assertEqual(self._delta(c0, c1), {"cached": 0, "built": 2, "active_built": 1, "bg_built": 1,
+                                               "bg_miss": {"cold": 1}}, "first cycle: the background tab is cold")
+        km._push([self.chat, self.tl])
+        c2 = self._chat()
+        self.assertEqual(self._delta(c1, c2), {"cached": 2, "built": 0, "active_built": 0, "bg_built": 0, "bg_miss": {}},
+                         "nothing moved: both tabs are served, the watched one on its exact key")
+        with open(self.tx[SID_B], "a") as f:
+            f.write('{"type": "assistant"}\n')
+        km._push([self.chat, self.tl])
+        c3 = self._chat()
+        self.assertEqual(self._delta(c2, c3), {"cached": 1, "built": 1, "active_built": 0, "bg_built": 1,
+                                               "bg_miss": {"transcript": 1}},
+                         "the background tab's transcript grew; the watched one is served")
+        km._judge_gen[0] += 1
+        km._push([self.chat, self.tl])
+        c4 = self._chat()
+        self.assertEqual(self._delta(c3, c4)["bg_miss"], {"judge_gen": 1},
+                         "a judge pass that changed a store rebuilds the background tab under judge_gen")
+        self.assertEqual(self._delta(c3, c4)["bg_built"], 1)
+        with open(jd.STATESDIR / (SID_B + ".jsonl"), "a") as f:
+            f.write('{"t": 1, "state": "idle"}\n')
+        km._push([self.chat, self.tl])
+        c5 = self._chat()
+        self.assertEqual(self._delta(c4, c5), {"cached": 1, "built": 1, "active_built": 0, "bg_built": 1,
+                                               "bg_miss": {"states": 1}}, "the background tab's states file grew")
+        km._push([self.chat, self.tl])
+        c6 = self._chat()
+        self.assertEqual(self._delta(c5, c6), {"cached": 2, "built": 0, "active_built": 0, "bg_built": 0, "bg_miss": {}},
+                         "both are served again once nothing moves")
+        with open(self.tx[SID_A], "a") as f:
+            f.write('{"type": "assistant"}\n')
+        km._push([self.chat, self.tl])
+        c7 = self._chat()
+        self.assertEqual(self._delta(c6, c7), {"cached": 1, "built": 1, "active_built": 1, "bg_built": 0, "bg_miss": {}},
+                         "the watched tab's own transcript grew: it rebuilds, under active_built, unattributed")
+
+    def test_the_sweep_drops_the_merge_sets_of_a_sid_neither_shown_nor_alive(self):
+        stray = "66666666-7777-8888-9999-aaaaaaaaaaa9"
+        alive = "66666666-7777-8888-9999-aaaaaaaaaaa8"
+        self.tmux = {alive: {"state": "idle"}}
+        for sid in (stray, alive, SID_B):
+            km._merge_sets_memo[sid] = ({"turns": []}, ())
+        try:
+            km._push([self.chat, self.tl])
+            self.assertNotIn(stray, km._merge_sets_memo, "a sid that is neither a tab nor alive is evicted")
+            self.assertIn(SID_B, km._merge_sets_memo, "a shown tab's entry stays")
+            self.assertIn(alive, km._merge_sets_memo, "an alive session's entry stays: the feed and timeline merge it")
+        finally:
+            for sid in (stray, alive, SID_B):
+                km._merge_sets_memo.pop(sid, None)
+
+    def test_the_sweep_drops_the_ledger_memo_of_a_tab_no_longer_shown_and_keeps_this_cycles_threads(self):
+        stray = "66666666-7777-8888-9999-aaaaaaaaaaa9"
+        thread = "66666666-7777-8888-9999-aaaaaaaaaaa7"
+        for sid in (stray, thread, SID_B):
+            km._ledger_memo[sid] = (("seams", None, 0), {"turns": []}, {"nodes": {}}, [], [])
+        km._thread_fold_keep[1].add(thread)                   # a comment thread built this cycle
+        evict0 = km._ledger_memo_stats["evict"]
+        try:
+            km._push([self.chat, self.tl])
+            self.assertNotIn(stray, km._ledger_memo, "the ledger memo of a tab no longer shown is evicted")
+            self.assertIn(SID_B, km._ledger_memo, "a shown tab's entry stays")
+            self.assertIn(thread, km._ledger_memo, "this cycle's thread stays, like its fold prefix")
+            self.assertEqual(km._ledger_memo_stats["evict"], evict0 + 1, "one eviction counted")
+            self.assertEqual(km._ledger_memo_report()["entries"], len(km._ledger_memo))
+        finally:
+            for sid in (stray, thread, SID_B):
+                km._ledger_memo.pop(sid, None)
+
+
+# ── the live merge's transcript-side sets ────────────────────────────────────────────────────────
+class MergeSets(unittest.TestCase):
+    """_merge_tx_sets: the sets _merge_live_atoms derives from the parsed session, memoized per sid on the
+    session object's identity; the same object hits, a fresh parse misses, and the memoized sets are never
+    written by a merge or by the backend's prune."""
+
+    T = 1781100000
+
+    def setUp(self):
+        self._saved = (km.Sessions.__dict__["backend_for"], dict(km._merge_sets_memo), dict(km._merge_sets_stats))
+        km._merge_sets_memo.clear()
+        for k in km._merge_sets_stats:
+            km._merge_sets_stats[k] = 0
+        self.calls, self.live = [], []
+        test = self
+
+        class Fake:
+            def live_atoms(self, sid):
+                return list(test.live)
+
+            def prune_live(self, sid, tx_uuids, tx_user_texts=(), human_floor=0):
+                test.calls.append((tx_uuids, tx_user_texts, human_floor))
+        km.Sessions.backend_for = staticmethod(lambda sid: Fake())
+
+    def tearDown(self):
+        km.Sessions.backend_for = self._saved[0]
+        km._merge_sets_memo.clear(); km._merge_sets_memo.update(self._saved[1])
+        km._merge_sets_stats.clear(); km._merge_sets_stats.update(self._saved[2])
+
+    @staticmethod
+    def _user(text, uid, t, author="human"):
+        return {"type": "user", "uuid": uid, "t": t, "author": author,
+                "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+
+    @staticmethod
+    def _assistant(uid, t, text=None):
+        content = ([{"type": "text", "text": text}] if text is not None
+                   else [{"type": "thinking", "thinking": "", "signature": "sig"}])   # a textless twin
+        return {"type": "assistant", "uuid": uid, "t": t, "message": {"role": "assistant", "content": content}}
+
+    def _session(self):
+        T = self.T
+        return {"turns": [
+            {"id": "t1", "trigger": "u1", "t": T, "end": T + 10, "ended": True,
+             "atoms": [self._user("tighten the notes-api search", "u1", T), self._assistant("a1", T + 10, "Done.")]},
+            {"id": "t2", "trigger": "u2", "t": T + 20, "end": T + 30, "ended": True,
+             "atoms": [self._user("ok", "u2", T + 20), self._user("ok", "u2b", T + 25),
+                       self._assistant("a2", T + 30)]}]}
+
+    def _unmemoized(self, session):
+        """The derivation as _merge_live_atoms wrote it before the memo, over the same helpers."""
+        tx_uuids = {a.get("uuid") for turn in session["turns"] for a in turn["atoms"] if a.get("uuid")}
+        tx_text_uuids = {a.get("uuid") for turn in session["turns"] for a in turn["atoms"]
+                         if a.get("uuid") and km._atom_prose_chars(a) > 0}
+        tx_texts = {t for turn in session["turns"] for a in turn["atoms"] for t in km._atom_user_texts(a)}
+        tx_text_t = {}
+        for turn in session["turns"]:
+            for a in turn["atoms"]:
+                for t in km._atom_user_texts(a):
+                    tx_text_t[t] = max(tx_text_t.get(t, 0), float(a.get("t") or 0))
+        return (tx_uuids, tx_text_uuids, tx_texts, tx_text_t, km._human_turn_floor(session))
+
+    def test_the_same_object_hits_a_fresh_parse_misses_and_sids_do_not_share(self):
+        sess = self._session()
+        s1 = km._merge_tx_sets(sess, SID_A)
+        self.assertEqual((km._merge_sets_stats["hit"], km._merge_sets_stats["miss"]), (0, 1))
+        self.assertIs(km._merge_tx_sets(sess, SID_A), s1, "the same parsed object: served, not derived")
+        self.assertEqual((km._merge_sets_stats["hit"], km._merge_sets_stats["miss"]), (1, 1))
+        again = self._session()                                     # equal content, a new parse object
+        s2 = km._merge_tx_sets(again, SID_A)
+        self.assertIsNot(s2, s1)
+        self.assertEqual(s2, s1, "a re-parse of the same transcript derives the same sets")
+        self.assertEqual(km._merge_sets_stats["miss"], 2)
+        km._merge_tx_sets(again, SID_B)                             # another sid, the same object: its own entry
+        self.assertEqual(km._merge_sets_stats["miss"], 3)
+        self.assertEqual(km._merge_sets_report(), {"hit": 1, "miss": 3, "entries": 2})
+
+    def test_the_sets_equal_the_unmemoized_derivation_and_the_three_sets_are_frozen(self):
+        sess = self._session()
+        got = km._merge_tx_sets(sess, SID_A)
+        self.assertEqual(tuple(got), self._unmemoized(sess))
+        self.assertEqual(got[0], {"u1", "a1", "u2", "u2b", "a2"})
+        self.assertNotIn("a2", got[1], "the textless twin is not a text uuid")
+        self.assertEqual(got[3]["ok"], self.T + 25, "a repeated text keeps its newest record time")
+        self.assertEqual(got[4], self.T + 25)
+        for i in range(3):
+            self.assertIsInstance(got[i], frozenset, "set %d is frozen: a write raises instead of corrupting later hits" % i)
+        self.assertIsInstance(got[3], dict, "tx_text_t stays a dict: the SDK backend's prune dispatches on isinstance(dict)")
+
+    def test_a_merge_hands_prune_live_the_memoized_sets_and_a_withheld_uuid_makes_a_new_set(self):
+        sess = self._session()
+        sets = km._merge_tx_sets(sess, SID_A)
+        # a live reply streaming under the textless twin's uuid: withheld from the prune, so the text stays
+        self.live = [{"type": "assistant", "uuid": "a2", "t": self.T + 30,
+                      "message": {"role": "assistant", "content": [{"type": "text", "text": "the explanation"}]}}]
+        merged = km._merge_live_atoms(sess, SID_A)
+        tx_uuids, tx_text_t, floor = self.calls[-1]
+        self.assertEqual(tx_uuids, sets[0] - {"a2"})
+        self.assertIsNot(tx_uuids, sets[0])
+        self.assertIn("a2", sets[0], "the memoized set is unchanged by the withholding")
+        self.assertIs(tx_text_t, sets[3])
+        self.assertEqual(floor, sets[4])
+        self.assertIn("the explanation", json.dumps(merged["turns"][-1]["atoms"]), "the live text is shown")
+        self.assertIs(km._merge_tx_sets(sess, SID_A), sets, "and the entry still serves")
+        # a live atom whose disk twin carries text: nothing withheld, the memoized set itself is handed over
+        self.live = [{"type": "assistant", "uuid": "a1", "t": self.T + 10,
+                      "message": {"role": "assistant", "content": [{"type": "text", "text": "Done."}]}}]
+        km._merge_live_atoms(sess, SID_A)
+        self.assertIs(self.calls[-1][0], sets[0])
+        self.assertEqual(sets, km._merge_tx_sets(sess, SID_A), "prune_live wrote into nothing")
+        self.assertEqual(km._merge_sets_stats["miss"], 1)
+
+    def test_no_live_atoms_skips_the_sets(self):
+        sess = self._session()
+        self.assertIs(km._merge_live_atoms(sess, SID_A), sess)
+        self.assertEqual(km._merge_sets_stats, {"hit": 0, "miss": 0})
+
+    def test_the_memo_is_bounded_one_eviction_at_a_time(self):
+        sess = self._session()
+        for i in range(km._MERGE_SETS_MAX + 3):
+            km._merge_tx_sets(sess, "sid-%d" % i)
+        self.assertEqual(len(km._merge_sets_memo), km._MERGE_SETS_MAX)
+        self.assertNotIn("sid-0", km._merge_sets_memo, "the oldest entry went first")
+        self.assertIn("sid-%d" % (km._MERGE_SETS_MAX + 2), km._merge_sets_memo)
+
+
+# ── the sealed postal cards' values and the caption map ──────────────────────────────────────────
+class PostalCardDeps(unittest.TestCase):
+    """_postal_card_deps: per sealed card, exactly the values it embeds from outside the transcript."""
+
+    def setUp(self):
+        self._names = getattr(km._live_scope, "names", None)
+        km._live_scope.names = {PEER: ["api", "/tmp/notes-api", "#abcdef"]}
+
+    def tearDown(self):
+        km._live_scope.names = self._names
+
+    def test_each_embedded_value_is_a_component_and_nothing_else_is(self):
+        index = {MID: {"id": MID, "from": "api", "fromId": PEER, "toId": SID_A, "body": "b",
+                       "kind": "coordinate", "t": 1, "park": False}}
+        colour = {"bg": "#abcdef", "fg": "#ffffff"}
+        cards = [{"kind": "postal-service", "direction": "in", "peer": "api", "mid": MID, "summary": "cap", "body": "b"},
+                 {"kind": "postal-service", "direction": "out", "peer": "api", "mid": MID, "body": "b"},
+                 {"kind": "postal-service", "direction": "out", "peer": "tests", "body": "no row joined"},
+                 {"kind": "tool", "name": "Bash", "output": "a raw event that did not hydrate"}]
+        calls = []
+
+        def caps():
+            calls.append(1)
+            return {MID: "cap"}
+        deps = km._postal_card_deps(cards, index, caps)
+        self.assertEqual(deps, ((MID, "cap", "api", colour), (MID, "cap", colour), (None, None, None), None))
+        self.assertEqual(len(calls), 1, "the caption map is fetched once, and only because a card carries a mid")
+        km._live_scope.names = {PEER: ["api", "/tmp/notes-api", "#000000"]}      # the sender's colour
+        self.assertNotEqual(km._postal_card_deps(cards, index, caps), deps)
+        km._live_scope.names = {PEER: ["renamed", "/tmp/notes-api", "#abcdef"]}  # the sender's name
+        self.assertNotEqual(km._postal_card_deps(cards, index, caps), deps)
+        km._live_scope.names = {PEER: ["api", "/tmp/notes-api", "#abcdef"]}
+        self.assertNotEqual(km._postal_card_deps(cards, index, lambda: {MID: "other"}), deps, "the caption")
+        self.assertEqual(km._postal_card_deps(cards, index, caps), deps, "the same inputs, the same tuple")
+        self.assertEqual(km._postal_card_deps([cards[2], cards[3]], index, lambda: self.fail("no mid, no map")),
+                         ((None, None, None), None))
+
+
+class MsgSummariesKey(unittest.TestCase):
+    """_msg_summaries' per-session submap is keyed on every input its scan reads: the parse's key (the
+    transcript's stat, the pending cut, the states file), the captions file and the goal store (the
+    store, its override journal, its archive)."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_state = jd.STATE
+        jd._rebind_state(Path(self.td.name))
+        self.saved = (km._sessions, km._msg_sum_scan_session, dict(km._msg_sum_cache), km._sdk)
+        km._msg_sum_cache.clear()
+        km._sdk = lambda: None
+        self.scanned = []
+        km._msg_sum_scan_session = lambda sid, path, now: (self.scanned.append(sid) or {sid + ":m": "cap"})
+        self.rows = [{"sid": SID_A, "name": "web", "path": "/x/a", "mtime": 100},
+                     {"sid": SID_B, "name": "api", "path": "/x/b", "mtime": 100}]
+        km._sessions = lambda now: list(self.rows)
+        for d in (jd.CAPDIR, jd.GOALDIR, jd.GOALARCHDIR, jd._overrides_dir(), jd.STATESDIR):
+            d.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        km._sessions, km._msg_sum_scan_session = self.saved[:2]
+        km._msg_sum_cache.clear(); km._msg_sum_cache.update(self.saved[2])
+        km._sdk = self.saved[3]
+        jd._rebind_state(self.saved_state)
+        self.td.cleanup()
+
+    def _scan(self):
+        self.scanned.clear()
+        km._msg_summaries()
+        return list(self.scanned)
+
+    def test_each_input_change_rescans_that_session_only_and_unchanged_inputs_rescan_nothing(self):
+        self.assertEqual(sorted(self._scan()), sorted([SID_A, SID_B]), "the first call scans everything")
+        self.assertEqual(self._scan(), [], "unchanged inputs: no rescan")
+        (jd.CAPDIR / (SID_A + ".jsonl")).write_text(json.dumps({"id": "seg", "caption": "c"}) + "\n")
+        self.assertEqual(self._scan(), [SID_A], "a caption written with no transcript change rescans its session")
+        self.assertEqual(self._scan(), [])
+        (jd.GOALDIR / (SID_B + ".json")).write_text(json.dumps({"nodes": {}, "status": {}, "seams": [1]}))
+        self.assertEqual(self._scan(), [SID_B], "a store publish (its seams) rescans its session")
+        with open(jd._overrides_dir() / (SID_B + ".jsonl"), "a") as f:
+            f.write('{"op": "reopen"}\n')
+        self.assertEqual(self._scan(), [SID_B], "a journaled user gesture rescans its session")
+        (jd.GOALARCHDIR / (SID_A + ".json")).write_text("{}")
+        self.assertEqual(self._scan(), [SID_A], "an archive write rescans its session")
+        self.rows[0] = {**self.rows[0], "mtime": 200}
+        self.assertEqual(self._scan(), [SID_A], "the row's mtime still keys when the transcript cannot be stat'd")
+        (jd.STATESDIR / (SID_B + ".jsonl")).write_text('{"state": "idle", "t": 1}\n')
+        self.assertEqual(self._scan(), [SID_B], "a states row (an idle atom in the parse) rescans its session")
+        self.assertEqual(self._scan(), [])
+        self.assertEqual(km._msg_summaries(), {SID_A + ":m": "cap", SID_B + ":m": "cap"})
+
+    def test_the_transcripts_size_and_the_pending_cut_key_too(self):
+        tx = Path(self.td.name) / "a.jsonl"
+        tx.write_text('{"type": "user"}\n')
+        self.rows[0] = {**self.rows[0], "path": str(tx)}
+        cut = {"value": ""}
+
+        class Fake:
+            def pending_cut(self, sid):
+                return cut["value"] if sid == SID_A else ""
+        km._sdk = lambda: Fake()
+        self._scan()
+        self.assertEqual(self._scan(), [])
+        with open(tx, "a") as f:
+            f.write('{"type": "assistant"}\n')                 # the size moves even where the mtime's clock does not
+        self.assertEqual(self._scan(), [SID_A], "the transcript's size keys")
+        cut["value"] = "uuid-of-the-cut"                     # a pending chat delete changes the parse with no file change
+        self.assertEqual(self._scan(), [SID_A], "the backend's pending cut keys")
+        self.assertEqual(self._scan(), [])
+
+    def test_the_key_is_taken_before_the_scan(self):
+        # a caption appended while the scan runs pairs the OLD key with the new content: one more rescan on
+        # the next call, never a stale hit. Proven by writing the caption from inside the scan.
+        def scanning(sid, path, now):
+            self.scanned.append(sid)
+            if sid == SID_A and not (jd.CAPDIR / (SID_A + ".jsonl")).exists():
+                (jd.CAPDIR / (SID_A + ".jsonl")).write_text(json.dumps({"id": "seg", "caption": "c"}) + "\n")
+            return {sid + ":m": "cap"}
+        km._msg_sum_scan_session = scanning
+        self._scan()
+        self.assertEqual(self._scan(), [SID_A], "the write that landed mid-scan is seen on the next call")
+        self.assertEqual(self._scan(), [])
+
+
+class CycleCaptionSlot(unittest.TestCase):
+    """The caption map is fetched once per pusher cycle: _pusher_cycle opens a slot on the cycle's scope,
+    the first build that needs the map fills it, later builds of the cycle read it, the timeline's postal
+    connectors read the same slot, and the finally closes it. A thread with no cycle scope (a connect
+    push) reads the map directly."""
+
+    def setUp(self):
+        self.saved = (km._tmux_sessions, km._pusher_cycle_jobs, km._msg_summaries, jd.STATE,
+                      dict(km._postal_log_cache))
+        self.fetched = []
+        km._tmux_sessions = lambda: {}
+        km._msg_summaries = lambda: (self.fetched.append(1) or {MID: "cap"})
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        jd._rebind_state(Path(td.name))                      # the timeline's postal log lives under the state root
+        km._postal_log_cache.clear()
+
+    def tearDown(self):
+        km._tmux_sessions, km._pusher_cycle_jobs, km._msg_summaries, state, log = self.saved
+        jd._rebind_state(state)
+        km._postal_log_cache.clear(); km._postal_log_cache.update(log)
+        km._live_scope.msgsum = None
+
+    def _connectors(self, now):
+        return km._postal_messages(now, {SID_A, PEER}, {SID_A: "web", PEER: "api"})
+
+    def test_reads_within_one_cycle_fetch_once_and_the_slot_closes_with_the_cycle(self):
+        seen = []
+
+        def jobs(now, tmux, any_client):
+            seen.append(getattr(km._live_scope, "msgsum", None))
+            first = km._msg_summaries_scoped()
+            for _ in range(4):
+                self.assertIs(km._msg_summaries_scoped(), first, "the cycle's map, not a fresh fetch")
+        km._pusher_cycle_jobs = jobs
+        km._pusher_cycle()
+        self.assertEqual(len(seen), 1)
+        self.assertIsNotNone(seen[0], "the slot was open during the jobs")
+        self.assertEqual(len(self.fetched), 1, "one fetch for the whole cycle")
+        self.assertIsNone(getattr(km._live_scope, "msgsum", None), "closed with the cycle")
+        for _ in range(3):
+            km._msg_summaries_scoped()                          # no scope: the direct path
+        self.assertEqual(len(self.fetched), 4, "three direct reads fetch three times")
+
+    def test_the_slot_closes_when_the_jobs_raise(self):
+        seen = []
+
+        def jobs(now, tmux, any_client):
+            seen.append(getattr(km._live_scope, "msgsum", None))
+            raise RuntimeError("a job failed")
+        km._pusher_cycle_jobs = jobs
+        with self.assertRaises(RuntimeError):
+            km._pusher_cycle()
+        self.assertEqual(len(seen), 1)
+        self.assertIsNotNone(seen[0], "the slot was open during the jobs")
+        self.assertIsNone(getattr(km._live_scope, "msgsum", None), "closed by the finally")
+
+    def test_the_timelines_postal_connectors_read_the_cycles_map(self):
+        now = int(time.time())
+        jd.MESSAGES.parent.mkdir(parents=True, exist_ok=True)
+        jd.MESSAGES.write_text(json.dumps({"ev": "sent", "id": MID, "from": "api", "from_id": PEER, "to_id": SID_A,
+                                           "body": "the api tests are green now", "kind": "coordinate",
+                                           "t": now - 60}) + "\n")
+        rows = []
+
+        def jobs(now_, tmux, any_client):
+            km._msg_summaries_scoped()                          # a chat build fetched the cycle's map
+            rows.append(self._connectors(now))                  # the timeline build's connectors, twice
+            rows.append(self._connectors(now))
+        km._pusher_cycle_jobs = jobs
+        km._pusher_cycle()
+        self.assertEqual(len(self.fetched), 1, "the connectors read the cycle's map, not a fresh fetch")
+        self.assertEqual([r[0]["summary"] for r in rows], ["cap", "cap"], "each connector carries the caption")
+        self._connectors(now)
+        self.assertEqual(len(self.fetched), 2, "no scope: the direct path")
+
+
+# ── build_session over a synthetic session ───────────────────────────────────────────────────────
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent, "promptSource": "typed",
+            "message": {"role": "user", "content": text}, "cwd": "/tmp/notes-api", "version": "2.1.0", "gitBranch": "main"}
+
+
+def _aline(t, text, uuid, parent, tool=None, stop="end_turn"):
+    content = [{"type": "text", "text": text}]
+    if tool:
+        content.append({"type": "tool_use", "id": "tu_%s" % uuid, "name": tool, "input": {"command": "uv run pytest -q"}})
+    return {"type": "assistant", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "model": "claude-sonnet-4", "content": content, "stop_reason": stop},
+            "cwd": "/tmp/notes-api", "version": "2.1.0", "gitBranch": "main"}
+
+
+def _trline(t, tool_use_id, uuid, parent, content="ok\n"):
+    return {"type": "user", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": tool_use_id, "content": content}]}}
+
+
+class World:
+    """A synthetic session build_session can build: names/ + projects/<cdir>/<sid>.jsonl under a state root
+    the kernel's judge module is rebound to (tests/test_chat_fold.py's Sess, reduced), plus a goal-store
+    writer and a postal log. The tmux path: the live tail is the kernel's own echo store."""
+
+    def __init__(self, sid):
+        self.sid = sid
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self.cdir = td / "launchdir"
+        self.cdir.mkdir()
+        proj = td / "projects"
+        pdir = proj / re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(self.cdir)))
+        pdir.mkdir(parents=True)
+        self.tpath = pdir / (sid + ".jsonl")
+        self.tpath.write_text("")
+        self.saved_state = jd.STATE
+        self.saved = (jd.PROJECTS, km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD, km._msg_summaries, km._sdk,
+                      os.environ.get("CLAUDE_CONFIG_DIR"))
+        jd._rebind_state(td)                              # names, goals, captions, archive, states, messages: all under td
+        jd.PROJECTS = proj
+        jd.NAMES.mkdir(parents=True, exist_ok=True)
+        (jd.NAMES / sid).write_text("web\t%s\t#abcdef\n" % str(self.cdir))
+        km.NAMES = jd.NAMES
+        km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
+        self.now = int(time.time())                       # discovery keys on the real clock
+        self.t = self.now - 3 * 86400
+        self.tm = {sid: {"state": "working", "since": self.now - 100, "model": "", "effort": "",
+                         "context": None, "compactPct": None, "color": None}}
+        km._tmux_sessions = lambda: self.tm
+        km._msg_summaries = lambda: {}
+        km._sdk = lambda: None
+        os.environ["CLAUDE_CONFIG_DIR"] = str(td / "claude")   # no real task store is read
+        _clear_memos()
+        km._parse_cache.clear(); km._PATH_LINK_CACHE.clear(); km._SPACE_PATH_CACHE.clear()
+        km._postal_index_memo[0] = None
+        if isinstance(jd._discover_cache, dict):
+            jd._discover_cache.clear()
+        self.n = 0
+        self.last = None
+
+    def close(self):
+        km._rewind_hold_clear(self.sid)
+        (jd.PROJECTS, km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD, km._msg_summaries, km._sdk, cfg) = self.saved
+        if cfg is None:
+            os.environ.pop("CLAUDE_CONFIG_DIR", None)
+        else:
+            os.environ["CLAUDE_CONFIG_DIR"] = cfg
+        jd._rebind_state(self.saved_state)
+        _clear_memos()
+        km._parse_cache.clear()
+        km._postal_index_memo[0] = None
+        self.td.cleanup()
+
+    def uid(self):
+        self.n += 1
+        return "bbbbbbbb-0000-0000-0000-%012d" % self.n
+
+    def tick(self, dt=5):
+        self.t += dt
+        return self.t
+
+    def turn(self, i):
+        """One complete turn: prompt, one Bash round (use + result), a closing reply."""
+        u = self.uid()
+        recs = [_uline(self.tick(), "step %d: tighten the notes-api search" % i, u, self.last)]
+        a = self.uid()
+        recs.append(_aline(self.tick(), "Round %d: adjusting `search.py`." % i, a, u, tool="Bash", stop="tool_use"))
+        r = self.uid()
+        recs.append(_trline(self.tick(), "tu_%s" % a, r, a))
+        b = self.uid()
+        recs.append(_aline(self.tick(), "Step %d done." % i, b, r))
+        self.last = b
+        return recs
+
+    def append(self, recs):
+        with open(self.tpath, "a") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+        os.utime(self.tpath, None)
+
+    def store(self, nodes, seams=None, last=None):
+        """Publish goals/<sid>.json by rename, as save_goals does."""
+        p = jd.GOALDIR / (self.sid + ".json")
+        p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = p.with_name(p.name + ".tmp")
+        tmp.write_text(json.dumps({"nodes": nodes, "status": {}, "seams": seams or [], "lastNode": last}))
+        os.replace(tmp, p)
+
+    def nodes(self, n, trail=(), parent=None):
+        return {"g%d" % i: {"id": "g%d" % i, "text": "goal %d" % i, "t": self.t + i, "mt": self.t + i,
+                            "parentId": parent, "trail": list(trail)} for i in range(1, n + 1)}
+
+    def postal_log(self, rows):
+        jd.MESSAGES.parent.mkdir(parents=True, exist_ok=True)
+        with open(jd.MESSAGES, "a") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+
+    def build(self, scoped=True):
+        """build_session under the pusher's names scope (as _pusher_cycle sets it); scoped=False is a
+        handler-thread build, which reads the registry per card."""
+        if scoped:
+            km._live_scope.names = km._names_snapshot()
+        try:
+            return km.build_session(self.sid, self.now, self.tm)
+        finally:
+            km._live_scope.names = None
+
+
+def _dump(m):
+    return json.dumps(m, sort_keys=True, default=str)
+
+
+class PostalGate(unittest.TestCase):
+    """The fold gate keys a tab's sealed postal cards on the values they embed (the log's identity and, per
+    card, its caption and its peer's name and colour), not on the judge generation: a judge pass that
+    moved none of them re-hydrates nothing, a caption change re-hydrates exactly the sealed cards, and the
+    commit hydrates only the raw events new since the seal."""
+
+    def setUp(self):
+        self.w = World(SID_A)
+        self.caps = {}
+        km._msg_summaries = lambda: dict(self.caps)
+        self.w.postal_log([{"ev": "sent", "id": MID, "from": "api", "from_id": PEER, "to_id": SID_A,
+                            "body": "the api tests are green now", "kind": "coordinate", "t": self.w.t}])
+        self.judge_gen = km._judge_gen[0]
+
+    def tearDown(self):
+        km._judge_gen[0] = self.judge_gen
+        self.w.close()
+
+    def _incoming(self):
+        """One sealed incoming card: a delivered peer message, the reply, then a complete turn after it."""
+        w = self.w
+        u = w.uid()
+        w.append([_uline(w.tick(), "<!-- romp-msg-id: %s -->\nthe api tests are green now" % MID, u, w.last)])
+        a = w.uid()
+        w.append([_aline(w.tick(), "Noted, thanks.", a, u)])
+        w.last = a
+        w.append(w.turn(2))
+
+    def _spy(self):
+        """Every _hydrate_postal call build_session makes from here on, as the event lists it was handed."""
+        calls = []
+        orig = km._hydrate_postal
+
+        def counting(events, *a, **kw):
+            calls.append(list(events))
+            return orig(events, *a, **kw)
+        km._hydrate_postal = counting
+        self.addCleanup(setattr, km, "_hydrate_postal", orig)
+        return calls
+
+    @staticmethod
+    def _card(m):
+        return next(ev for ev in m["events"] if ev.get("kind") == "postal-service")
+
+    @staticmethod
+    def _stats():
+        # zeros on a tree without the counters, so the behavioural assertions run first
+        return dict(getattr(km, "_chat_postal_stats", None) or {"gate": 0, "hit": 0, "commit_new": 0})
+
+    def test_a_judge_pass_that_moved_no_caption_leaves_the_sealed_card_alone(self):
+        w = self.w
+        self.caps[MID] = "api: tests green"
+        w.append(w.turn(0))
+        self._incoming()
+        m = w.build()
+        self.assertEqual(self._card(m)["summary"], "api: tests green")
+        w.build()                                                  # warm: the card is sealed in the prefix
+        raw = km._chat_fold_get(SID_A)["postal_raw"]
+        self.assertEqual(len(raw), 1, "the marker event rides the entry raw")
+        calls = self._spy()
+        s0 = self._stats()
+        km._judge_gen[0] += 1                                      # a judge pass: some store moved
+        m2 = w.build()
+        self.assertEqual([any(e is raw[0] for e in c) for c in calls], [False],
+                         "one hydration, the tail pass: the sealed card was neither re-hydrated by the gate "
+                         "nor hydrated again at the commit")
+        self.assertEqual(self._card(m2)["summary"], "api: tests green")
+        s1 = self._stats()
+        self.assertEqual((s1["gate"] - s0["gate"], s1["hit"] - s0["hit"], s1["commit_new"] - s0["commit_new"]), (0, 1, 0))
+        # equivalence with a cold build stands
+        km._chat_fold.clear()
+        self.assertEqual(_dump(w.build()), _dump(m2))
+
+    def test_a_caption_change_re_hydrates_exactly_the_sealed_card_and_refreshes_it(self):
+        w = self.w
+        self.caps[MID] = "api: tests green (live)"
+        w.append(w.turn(0))
+        self._incoming()
+        w.build()
+        w.build()
+        entry = km._chat_fold_get(SID_A)
+        self.assertEqual(entry["postal_deps"], ((MID, "api: tests green (live)", None, None),),
+                         "the entry records the values its card embeds: mid, caption, the sender's name and colour")
+        raw = entry["postal_raw"]
+        calls = self._spy()
+        s0 = self._stats()
+        n0 = km._CHAT_FOLD_STATS.get("g:postal", 0)
+        self.caps[MID] = "api: tests green"                       # the final caption lands
+        m = w.build()
+        self.assertEqual(self._card(m)["summary"], "api: tests green")
+        self.assertEqual([any(e is raw[0] for e in c) for c in calls][0], True, "the gate re-hydrated the sealed card")
+        self.assertEqual(km._chat_postal_stats["gate"] - s0["gate"], 1)
+        self.assertGreater(km._CHAT_FOLD_STATS.get("g:postal", 0), n0, "a different card demotes the prefix")
+        self.assertEqual(km._chat_fold_get(SID_A)["postal_deps"], ((MID, "api: tests green", None, None),))
+        km._chat_fold.clear()
+        self.assertEqual(_dump(w.build()), _dump(m), "equal to a cold build")
+
+    def test_a_peers_colour_refreshes_the_sealed_card_and_a_caption_for_another_message_does_not(self):
+        w = self.w
+        self.caps[MID] = "api: tests green"
+        w.append(w.turn(0))
+        self._incoming()
+        w.build()
+        m = w.build()
+        self.assertIsNone(self._card(m).get("color"), "the sender has no registry entry yet")
+        s0 = self._stats()
+        self.caps["1788400000.200_2.TESTHOST"] = "api: something else"
+        w.build()
+        self.assertEqual((km._chat_postal_stats["gate"] - s0["gate"], km._chat_postal_stats["hit"] - s0["hit"]), (0, 1),
+                         "a caption for another message moves nothing this card embeds")
+        (jd.NAMES / PEER).write_text("api\t%s\t#123456\n" % str(w.cdir))
+        m2 = w.build()
+        self.assertEqual(self._card(m2).get("color"), {"bg": "#123456", "fg": "#ffffff"})
+        self.assertEqual(km._chat_postal_stats["gate"] - s0["gate"], 1, "the sender's colour is a value the card embeds")
+        self.assertEqual(km._chat_fold_get(SID_A)["postal_deps"],
+                         ((MID, "api: tests green", "api", {"bg": "#123456", "fg": "#ffffff"}),))
+
+    def test_a_build_outside_the_names_scope_seals_unverified_and_the_next_scoped_build_verifies_once(self):
+        # a handler-thread build (a connect push) reads the registry per card, so the values it embeds and
+        # the values it would record are two reads: it records None, and the pusher's next build, which reads
+        # one snapshot, re-hydrates once and records what it saw
+        w = self.w
+        self.caps[MID] = "api: tests green"
+        w.append(w.turn(0))
+        self._incoming()
+        w.build(scoped=False)
+        w.build(scoped=False)
+        self.assertIsNone(km._chat_fold_get(SID_A)["postal_deps"], "sealed unverified")
+        s0 = self._stats()
+        w.build()
+        self.assertEqual((km._chat_postal_stats["gate"] - s0["gate"], km._chat_postal_stats["hit"] - s0["hit"]), (1, 0),
+                         "the scoped build re-hydrated once")
+        self.assertIsNotNone(km._chat_fold_get(SID_A)["postal_deps"])
+        w.build()
+        self.assertEqual((km._chat_postal_stats["gate"] - s0["gate"], km._chat_postal_stats["hit"] - s0["hit"]), (1, 1),
+                         "and from then on the recorded values verify it")
+
+    def test_the_commit_hydrates_only_the_raw_events_new_since_the_seal(self):
+        w = self.w
+        self.caps[MID] = "api: tests green"
+        w.append(w.turn(0))
+        self._incoming()
+        w.build()
+        w.build()
+        s0 = self._stats()
+        calls = self._spy()
+        # a second delivery of the same message id, then a turn to seal it behind
+        u = w.uid()
+        w.append([_uline(w.tick(), "<!-- romp-msg-id: %s -->\nthe api tests are green now" % MID, u, w.last)])
+        a = w.uid()
+        w.append([_aline(w.tick(), "Seen.", a, u)])
+        w.last = a
+        w.append(w.turn(4))
+        m = w.build()
+        self.assertEqual(len([e for e in m["events"] if e.get("kind") == "postal-service"]), 2)
+        self.assertEqual(km._chat_postal_stats["commit_new"] - s0["commit_new"], 1,
+                         "one raw event was new since the seal, and one was hydrated at the commit")
+        raw = km._chat_fold_get(SID_A)["postal_raw"]
+        self.assertEqual(len(raw), 2)
+        commit_calls = [c for c in calls if c and any(e is raw[1] for e in c) and len(c) == 1]
+        self.assertEqual(len(commit_calls), 1, "the commit's hydration carried the new raw event alone")
+        km._chat_fold.clear()
+        self.assertEqual(_dump(w.build()), _dump(m), "equal to a cold build")
+
+
+class LedgerMemo(unittest.TestCase):
+    """The goal-tree walk and the live roots, memoized per session on every input of the walk: the parsed
+    transcript (by identity, with no live atoms merged), the store (by identity) and its seams,
+    cleared.jsonl (its stat, taken before the read) and the warm-anchor table's per-session revision."""
+
+    def setUp(self):
+        self.w = World(SID_A)
+        self.w.append(self.w.turn(0))
+        self.w.append(self.w.turn(1))
+
+    def tearDown(self):
+        self.w.close()
+
+    @staticmethod
+    def _stats():
+        return dict(km._ledger_memo_stats)
+
+    @staticmethod
+    def _delta(before):
+        now = km._ledger_memo_stats
+        return {k: now[k] - before[k] for k in now if now[k] != before[k]}
+
+    def test_unchanged_inputs_hit_and_each_input_change_misses_once(self):
+        w = self.w
+        s = self._stats()
+        self.assertEqual(w.build()["ledger"]["tree"], [])
+        self.assertEqual(self._delta(s), {"bypass_empty": 1}, "no store: nothing to walk, nothing to keep")
+        w.store(w.nodes(3))
+        s = self._stats()
+        m = w.build()
+        self.assertEqual([r["id"] for r in m["ledger"]["tree"]], ["g3", "g2", "g1"], "freshest first")
+        self.assertEqual(self._delta(s), {"miss": 1})
+        s = self._stats()
+        m2 = w.build()
+        self.assertEqual(self._delta(s), {"hit": 1})
+        self.assertEqual(_dump(m2["ledger"]), _dump(m["ledger"]))
+        km._ledger_memo.clear()
+        self.assertEqual(_dump(w.build()["ledger"]), _dump(m["ledger"]), "the served ledger equals a fresh walk")
+        # a store publish
+        w.store(w.nodes(4))
+        s = self._stats()
+        self.assertEqual(len(w.build()["ledger"]["tree"]), 4)
+        self.assertEqual(self._delta(s), {"miss": 1})
+        # a journaled user gesture (the shared store's identity carries its override journal)
+        jd._overrides_dir().mkdir(parents=True, exist_ok=True)
+        with open(jd._overrides_dir() / (SID_A + ".jsonl"), "a") as f:
+            f.write(json.dumps({"op": "resolve", "node": "absent", "t": w.now}) + "\n")
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"miss": 1})
+        # a clear
+        with open(jd.STATE / "cleared.jsonl", "a") as f:
+            f.write(json.dumps({"id": "g1", "t": w.now}) + "\n")
+        s = self._stats()
+        m = w.build()
+        self.assertEqual(self._delta(s), {"miss": 1})
+        self.assertTrue(next(r for r in m["ledger"]["tree"] if r["id"] == "g1")["cleared"])
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"hit": 1})
+        # a transcript append: a new parse
+        w.append(w.turn(2))
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"miss": 1})
+        # a seam change (the seg ids of every turn after it)
+        w.store(w.nodes(4), seams=[{"segs": ["no-such-seg"], "t": w.t - 30, "top": "g1", "text": "seam"}])
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"miss": 1})
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"hit": 1})
+        self.assertEqual(km._ledger_memo_report()["entries"], 1)
+
+    def test_a_rewind_hold_and_a_live_merge_bypass(self):
+        w = self.w
+        w.store(w.nodes(2))
+        w.build()
+        km._rewind_hold_set(SID_A, w.t + 3, "")
+        try:
+            s = self._stats()
+            self.assertEqual(len(w.build()["ledger"]["tree"]), 2)
+            self.assertEqual(self._delta(s), {"bypass_hold": 1})
+        finally:
+            km._rewind_hold_clear(SID_A)
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"hit": 1}, "the hold gone, the earlier entry serves")
+        km._tmux_echo_add(SID_A, "one more thing")           # a live atom merged into the last turn
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"bypass_live": 1})
+
+    def test_a_warm_anchor_learned_for_this_sessions_node_misses_once_and_another_sessions_does_not(self):
+        w = self.w
+        w.store(w.nodes(2))
+        w.build()
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"hit": 1})
+        km._node_anchor_uuids({"id": "g9", "trail": ["s1"]}, {"s1": "u-1"}, {"s1": "a-1"}, sid=SID_B)
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"hit": 1}, "another session's revision is not this key")
+        km._node_anchor_uuids({"id": "g1", "trail": ["s1"]}, {"s1": "u-1"}, {"s1": "a-1"}, sid=SID_A)
+        s = self._stats()
+        m = w.build()
+        self.assertEqual(self._delta(s), {"miss": 1})
+        self.assertEqual(next(r for r in m["ledger"]["tree"] if r["id"] == "g1")["anchorUuid"], "a-1",
+                         "the cold node now reads the warm anchor the table holds")
+        km._node_anchor_uuids({"id": "g1", "trail": ["s1"]}, {"s1": "u-1"}, {"s1": "a-1"}, sid=SID_A)
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"hit": 1}, "the same resolve again changes no entry: no bump")
+        km._node_anchor_uuids({"id": "g1", "trail": ["s1"]}, {"s1": "u-1"}, {"s1": "a-1"})
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"hit": 1}, "a resolve with no session names no revision")
+
+    def test_a_resolve_landing_during_the_walk_misses_next_build_never_a_stale_hit(self):
+        w = self.w
+        w.store(w.nodes(2))
+        w.build()
+        w.store(w.nodes(3))                                 # the next build walks
+        real, fired = km._node_anchor_uuids, []
+
+        def racing(nd, trig, work, sid=None):
+            if not fired:                                    # a peer build's resolve lands after this build read the rev
+                fired.append(1)
+                km._node_anchor_rev[SID_A] = km._node_anchor_rev.get(SID_A, 0) + 1
+            return real(nd, trig, work, sid=sid)
+        km._node_anchor_uuids = racing
+        try:
+            s = self._stats()
+            w.build()
+            self.assertEqual(self._delta(s), {"miss": 1})
+        finally:
+            km._node_anchor_uuids = real
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"miss": 1}, "the stored revision predates the racing bump: a miss")
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"hit": 1})
+
+    def test_a_warm_resolve_writes_the_table_entry_before_it_bumps_the_revision(self):
+        # A build reads the revision before its walk and stores it. Were the bump to land first, a build
+        # reading the revision between the bump and the entry write would store the new revision against a
+        # walk over the old entry and serve it next build; so the entry is written first.
+        revs_at_write = []
+
+        class Recording(dict):
+            def __setitem__(self, k, v):
+                revs_at_write.append(km._node_anchor_rev.get(SID_A, 0))
+                dict.__setitem__(self, k, v)
+        real = km._node_anchor_last
+        km._node_anchor_last = Recording()
+        self.addCleanup(setattr, km, "_node_anchor_last", real)
+        before = km._node_anchor_rev.get(SID_A, 0)
+        km._node_anchor_uuids({"id": "g7", "trail": ["s1"]}, {"s1": "u-1"}, {"s1": "a-1"}, sid=SID_A)
+        self.assertEqual(revs_at_write, [before], "the entry landed while the revision still read the old value")
+        self.assertEqual(km._node_anchor_rev.get(SID_A, 0), before + 1)
+        self.assertEqual(km._node_anchor_last["g7"], ("u-1", "a-1"))
+
+    def test_a_store_published_between_the_builds_two_loads_misses_next_build(self):
+        # build_session loads the store twice: at the top, for the seams its seg maps are cut with, and at
+        # the ledger, for the nodes it walks. A publish landing between the two pairs the old seams' maps
+        # with the new store object; the seams in the key make the next build, whose maps come from the new
+        # seams, miss instead of serving that tree on the new store's identity.
+        w = self.w
+        w.store(w.nodes(2))
+        w.build()
+        real, calls = jd.load_goals_shared_or_fault, []
+
+        def racing(sid):
+            calls.append(sid)
+            if len(calls) == 2:                                  # between the two loads: a publish with new seams
+                w.store(w.nodes(3), seams=[{"segs": ["no-such-seg"], "t": w.t - 30, "top": "g1", "text": "seam"}])
+            return real(sid)
+        jd.load_goals_shared_or_fault = racing
+        try:
+            s = self._stats()
+            m = w.build()
+        finally:
+            jd.load_goals_shared_or_fault = real
+        self.assertEqual(calls, [SID_A, SID_A], "the seg maps' load, then the ledger's")
+        self.assertEqual(self._delta(s), {"miss": 1})
+        self.assertEqual(len(m["ledger"]["tree"]), 3, "the walk read the new store's nodes")
+        s = self._stats()
+        m2 = w.build()
+        self.assertEqual(self._delta(s), {"miss": 1}, "the stored walk was cut with the old seams: not this build's key")
+        km._ledger_memo.clear()
+        self.assertEqual(_dump(w.build()["ledger"]), _dump(m2["ledger"]), "the served ledger equals a fresh walk")
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"hit": 1})
+
+    def test_a_clear_landing_during_the_walk_misses_next_build(self):
+        # cleared.jsonl is stat'd BEFORE it is read: a row appended between the two pairs the old key with
+        # the new set, so the next build misses instead of serving a set the file has moved past
+        w = self.w
+        w.store(w.nodes(2))
+        real = km._cleared_ids
+
+        def racing():
+            with open(jd.STATE / "cleared.jsonl", "a") as f:
+                f.write(json.dumps({"id": "g2", "t": w.now}) + "\n")
+            km._cleared_ids = real
+            return real()
+        km._cleared_ids = racing
+        try:
+            s = self._stats()
+            w.build()
+            self.assertEqual(self._delta(s), {"miss": 1})
+        finally:
+            km._cleared_ids = real
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"miss": 1}, "the key taken before the read predates the row")
+        s = self._stats()
+        w.build()
+        self.assertEqual(self._delta(s), {"hit": 1})
+
+    def test_a_muted_tab_still_ships_no_tree(self):
+        w = self.w
+        w.store(w.nodes(3))
+        w.build()
+        (jd.STATE / "session-flags.json").write_text(json.dumps({SID_A: {"hideFromFeed": True}}))
+        s = self._stats()
+        m = w.build()
+        self.assertEqual((m["ledger"]["tree"], m["ledger"]["recent"], m["ledger"]["current"]), ([], [], None))
+        self.assertEqual(self._delta(s), {"hit": 1}, "the mute is applied after the memo, live")
+        self.assertEqual(len(km._ledger_memo[SID_A][3]), 3, "the memo keeps the walk for an unmute")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_chat_fold.py
+++ b/tests/test_chat_fold.py
@@ -142,7 +142,12 @@ class Sess:
         os.utime(self.tpath, None)
 
     def build(self, mod=None):
-        return (mod or km).build_session(SID, self.now, self.tm)
+        m = mod or km
+        m._live_scope.names = m._names_snapshot()   # the pusher's names scope, as _pusher_cycle sets it: the fold's
+        try:                                        # sealed postal cards are verified from it (a build without the
+            return m.build_session(SID, self.now, self.tm)   # scope seals them unverified, see PostalCards)
+        finally:
+            m._live_scope.names = None
 
 
 def _dump(m):
@@ -410,7 +415,10 @@ class PostalCards(_Fold):
 
     def test_a_caption_rewritten_after_the_seal_refreshes_the_card(self):
         # the judge writes a LIVE caption under an id it later overwrites with the final one: a card
-        # sealed complete between the two must not keep the live gloss forever
+        # sealed complete between the two must not keep the live gloss forever. The caption is one of the
+        # values the sealed cards are keyed on (2026-09-09), so the card refreshes from the caption's change
+        # in _msg_summaries() alone: no judge generation is bumped here, and no transcript, log or states
+        # file changes
         s = self.s
         self._log()
         caps = {self.MID: "peer: tests green (live)"}
@@ -423,14 +431,16 @@ class PostalCards(_Fold):
         inc = self.equiv("card sealed with the live caption")
         card = next(ev for ev in inc["events"] if ev.get("kind") == "postal-service")
         self.assertEqual(card.get("summary"), "peer: tests green (live)")
+        self.assertEqual(km._chat_fold_get(SID)["postal_deps"], ((self.MID, "peer: tests green (live)", None, None),),
+                         "the entry records the values its card embeds: mid, caption, the sender's name and colour")
         caps[self.MID] = "peer: api tests green"          # the FINAL caption lands
-        for m in MODS:
-            m._judge_gen[0] += 1
-        n0 = km._CHAT_FOLD_STATS.get("g:postal", 0)
+        n0, g0 = km._CHAT_FOLD_STATS.get("g:postal", 0), km._chat_postal_stats["gate"]
         inc2 = self.equiv("caption rewritten")
         self.assertGreater(km._CHAT_FOLD_STATS.get("g:postal", 0), n0)
+        self.assertGreater(km._chat_postal_stats["gate"], g0, "the gate re-hydrated the sealed card")
         card2 = next(ev for ev in inc2["events"] if ev.get("kind") == "postal-service")
         self.assertEqual(card2.get("summary"), "peer: api tests green")
+        self.assertEqual(km._chat_fold_get(SID)["postal_deps"], ((self.MID, "peer: api tests green", None, None),))
 
     # ── the seal keeps only REAL postal Bash events raw (2026-09-06) ──────────────────────────────────
     def _bash_turn(self, i, command, result="ok\n"):
@@ -445,9 +455,9 @@ class PostalCards(_Fold):
         """Every _hydrate_postal call build_session makes from here on, as the event lists it was handed."""
         calls = []
         orig = km._hydrate_postal
-        def counting(events, index, sid=None):
+        def counting(events, index, sid=None, captions=None):
             calls.append(list(events))
-            return orig(events, index, sid)
+            return orig(events, index, sid, captions=captions)
         km._hydrate_postal = counting
         self.addCleanup(setattr, km, "_hydrate_postal", orig)
         return calls
@@ -498,12 +508,13 @@ class PostalCards(_Fold):
         self.assertEqual(len(calls), 2, "a judge pass with nothing postal sealed adds no hydration")
         self.assertEqual(km._CHAT_FOLD_STATS.get("g:postal", 0), n_postal, "and filed no postal demotion")
 
-    def test_a_bash_send_stays_raw_and_is_rehydrated_when_the_judges_run(self):
+    def test_a_bash_send_stays_raw_and_is_rehydrated_when_the_log_moves(self):
         # The `romp mail send` twin of the caption-rewrite test above: the send is the one Bash event the
-        # seal keeps raw in this transcript, and a judge pass re-hydrates exactly it, so its card can pick up the recipient's
-        # caption. The card's caption itself is pinned at the hydrator level (PostalRelevance): build_session
-        # stores a Bash input as JSON, which _cli_send_card does not unwrap, so no card renders here (a
-        # limit that predates this change and is not widened by it).
+        # seal keeps raw. Its rendering depends on the message log alone (no card renders here: build_session
+        # stores a Bash input as JSON, which _cli_send_card does not unwrap, a limit that predates this
+        # change), so a judge pass re-hydrates nothing and a log append re-hydrates exactly it. The commit
+        # reuses the sealed cards and hydrates only raw events new since the seal, so a warm build makes one
+        # hydration, the tail pass (it made two before, the second over the whole sealed raw list).
         s = self.s
         self._log()
         for m in MODS:
@@ -518,17 +529,26 @@ class PostalCards(_Fold):
         self.assertEqual(len(raw), 1, "the send, and only the send, rides the entry raw")
         self.assertEqual((raw[0]["kind"], raw[0]["name"]), ("tool", "Bash"))
         self.assertIsNotNone(km._cli_send_match(raw[0]), "kept by the matcher the card renders from")
+        self.assertEqual(km._chat_fold_get(SID)["postal_deps"], (None,), "a raw event that did not hydrate: the log alone")
         calls = self._count_hydrate()
+        h0, g0, c0 = km._chat_postal_stats["hit"], km._chat_postal_stats["gate"], km._chat_postal_stats["commit_new"]
         s.build()
-        # the tail pass, plus the re-commit hydrating the entry's raw list (the send alone)
-        self.assertEqual([len(c) == 1 and c[0] is raw[0] for c in calls], [False, True])
+        self.assertEqual(len(calls), 1, "the tail pass only: the commit reuses the sealed cards")
+        self.assertEqual((km._chat_postal_stats["hit"], km._chat_postal_stats["gate"], km._chat_postal_stats["commit_new"]),
+                         (h0 + 1, g0, c0))
         for m in MODS:
             m._judge_gen[0] += 1
         s.build()
-        # the gate re-hydrates the sealed send against the new captions, then the tail pass and the re-commit
-        self.assertEqual([len(c) == 1 and c[0] is raw[0] for c in calls[2:]], [True, False, True])
-        self.assertEqual(len(calls), 5)
-
+        self.assertEqual(len(calls), 2, "a judge pass re-hydrates nothing: the send embeds no judge-written value")
+        self.assertEqual((km._chat_postal_stats["hit"], km._chat_postal_stats["gate"]), (h0 + 2, g0))
+        # the log gains a row: the index the send would join moved, so the sealed send is re-hydrated
+        with open(jd.STATE / "timeline" / "messages.jsonl", "a") as f:
+            f.write(json.dumps({"ev": "sent", "id": self.MID + "b", "from": "web", "from_id": SID, "to_id": self.PEER,
+                                "body": "the api tests are green now", "kind": "coordinate", "t": s.t}) + "\n")
+        s.build()
+        self.assertEqual([len(c) == 1 and c[0] is raw[0] for c in calls[2:]], [True, False], "the gate, then the tail pass")
+        self.assertEqual((km._chat_postal_stats["hit"], km._chat_postal_stats["gate"]), (h0 + 2, g0 + 1))
+        self.assertEqual(km._chat_postal_stats["commit_new"], c0, "nothing new was sealed, so nothing new was hydrated")
 
 class PostalRelevance(_Fold):
     """_chat_postal_relevant decides what the fold keeps raw; _hydrate_postal decides what renders. The

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -347,7 +347,7 @@ class ViewBuilder(unittest.TestCase):
                       {"id": "3", "subject": "c", "activeForm": None, "status": "pending"}]
         saved = (km._read_task_store, km._fold_tasks)
         km._read_task_store = lambda fsid, fold=None: [dict(t) for t in live_store]
-        km._fold_tasks = lambda session: [dict(t) for t in stale_fold]
+        km._fold_tasks = lambda session, sid=None: [dict(t) for t in stale_fold]
         try:
             todo = next(e for e in km.build_session(SID, NOW)["events"] if e["kind"] == "todo")
         finally:
@@ -362,7 +362,7 @@ class ViewBuilder(unittest.TestCase):
         # ERROR — it does NOT quietly show the lossy fold (which could be wrong, the whole bug).
         saved = (km._read_task_store, km._fold_tasks)
         km._read_task_store = lambda fsid, fold=None: None            # store unreadable
-        km._fold_tasks = lambda session: [{"id": "1", "subject": "a", "activeForm": None, "status": "pending"}]
+        km._fold_tasks = lambda session, sid=None: [{"id": "1", "subject": "a", "activeForm": None, "status": "pending"}]
         try:
             todo = next(e for e in km.build_session(SID, NOW)["events"] if e["kind"] == "todo")
         finally:
@@ -374,7 +374,7 @@ class ViewBuilder(unittest.TestCase):
         # a done/absent list is a non-event — an unreadable store there is not worth alarming on, so no card.
         saved = (km._read_task_store, km._fold_tasks)
         km._read_task_store = lambda fsid, fold=None: None
-        km._fold_tasks = lambda session: [{"id": "1", "subject": "a", "activeForm": None, "status": "completed"}]
+        km._fold_tasks = lambda session, sid=None: [{"id": "1", "subject": "a", "activeForm": None, "status": "completed"}]
         try:
             kinds = [e["kind"] for e in km.build_session(SID, NOW)["events"]]
         finally:
@@ -386,7 +386,7 @@ class ViewBuilder(unittest.TestCase):
         # stale transcript fold — no card, and NO error (the store was read fine, it's just empty).
         saved = (km._read_task_store, km._fold_tasks)
         km._read_task_store = lambda fsid, fold=None: []              # authoritative-empty (cleared / none)
-        km._fold_tasks = lambda session: [{"id": "1", "subject": "a", "activeForm": None, "status": "pending"}]
+        km._fold_tasks = lambda session, sid=None: [{"id": "1", "subject": "a", "activeForm": None, "status": "pending"}]
         try:
             kinds = [e["kind"] for e in km.build_session(SID, NOW)["events"]]
         finally:
@@ -445,11 +445,11 @@ class ViewBuilder(unittest.TestCase):
         saved = (km._read_task_store, km._fold_tasks)
         km._read_task_store = lambda fsid, fold=None: None            # store unresolvable, as in the repro
         try:
-            km._fold_tasks = lambda session: real_fold(bg)
+            km._fold_tasks = lambda session, sid=None: real_fold(bg)
             kinds = [e["kind"] for e in km.build_session(SID, NOW)["events"]]
-            km._fold_tasks = lambda session: real_fold(batch)
+            km._fold_tasks = lambda session, sid=None: real_fold(batch)
             kinds_batch = [e["kind"] for e in km.build_session(SID, NOW)["events"]]
-            km._fold_tasks = lambda session: real_fold(mixed)
+            km._fold_tasks = lambda session, sid=None: real_fold(mixed)
             todo = [e for e in km.build_session(SID, NOW)["events"] if e["kind"] == "todo"]
         finally:
             (km._read_task_store, km._fold_tasks) = saved

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -117,7 +117,7 @@ class Collector(unittest.TestCase):
         # the three identity memos' readers land here (review find, 2026-09-08: they had no consumer)
         self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate", "cleared", "courierSkip", "backref", "captions", "goalArchive", "plannerSkip",
                                               "bgTops", "liftGate", "intrMarks", "statesOverlay", "lanes",
-                                              "chatMergeSets", "chatPostal", "chatLedger"})   # the chat build's fixed-cost memos (2026-09-09)
+                                              "chatMergeSets", "chatPostal", "chatLedger", "chatFoldTasks"})   # the chat build's fixed-cost memos (2026-09-09)
         self.assertEqual(set(snap["memos"]["bgTops"]), {"hit", "miss", "resolve", "walk", "walk_neg", "idx_build", "entries"},
                          "the placed-launch memo (_bg_placed_tops): counters plus its occupancy")
         for k, v in snap["memos"]["bgTops"].items():
@@ -143,6 +143,7 @@ class Collector(unittest.TestCase):
         self.assertEqual(set(snap["memos"]["chatMergeSets"]), {"hit", "miss", "entries"})
         self.assertEqual(set(snap["memos"]["chatPostal"]), {"gate", "hit", "commit_new"})
         self.assertEqual(set(snap["memos"]["chatLedger"]), {"hit", "miss", "bypass_live", "bypass_hold", "bypass_empty", "evict", "entries"})
+        self.assertEqual(set(snap["memos"]["chatFoldTasks"]), {"hit", "miss", "entries"})
         self.assertEqual(set(snap["memos"]["plannerSkip"]), {"skipped", "planned", "recorded"})
         self.assertEqual(set(snap["memos"]["captions"]), {"served", "parsed"})
         self.assertEqual(set(snap["memos"]["goalArchive"]), {"served", "loaded"})

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -116,7 +116,8 @@ class Collector(unittest.TestCase):
         self.assertEqual(set(snap["goals"]), {"loads", "saves", "writes"}, "read through jd.goal_io_stats")
         # the three identity memos' readers land here (review find, 2026-09-08: they had no consumer)
         self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate", "cleared", "courierSkip", "backref", "captions", "goalArchive", "plannerSkip",
-                                              "bgTops", "liftGate", "intrMarks", "statesOverlay", "lanes"})
+                                              "bgTops", "liftGate", "intrMarks", "statesOverlay", "lanes",
+                                              "chatMergeSets", "chatPostal", "chatLedger"})   # the chat build's fixed-cost memos (2026-09-09)
         self.assertEqual(set(snap["memos"]["bgTops"]), {"hit", "miss", "resolve", "walk", "walk_neg", "idx_build", "entries"},
                          "the placed-launch memo (_bg_placed_tops): counters plus its occupancy")
         for k, v in snap["memos"]["bgTops"].items():
@@ -139,6 +140,9 @@ class Collector(unittest.TestCase):
                                                      "segs_hit", "segs_miss", "dead_serve", "dead_miss", "dead_failed_serve"},
                          "the timeline's per-lane segment memo: one outcome per live lane per bars build, the dead lanes beside")
         self.assertTrue(all(type(v) is int for v in snap["memos"]["lanes"].values()))
+        self.assertEqual(set(snap["memos"]["chatMergeSets"]), {"hit", "miss", "entries"})
+        self.assertEqual(set(snap["memos"]["chatPostal"]), {"gate", "hit", "commit_new"})
+        self.assertEqual(set(snap["memos"]["chatLedger"]), {"hit", "miss", "bypass_live", "bypass_hold", "bypass_empty", "evict", "entries"})
         self.assertEqual(set(snap["memos"]["plannerSkip"]), {"skipped", "planned", "recorded"})
         self.assertEqual(set(snap["memos"]["captions"]), {"served", "parsed"})
         self.assertEqual(set(snap["memos"]["goalArchive"]), {"served", "loaded"})
@@ -193,7 +197,10 @@ class Collector(unittest.TestCase):
         snap = self.st.snapshot()
         self.assertAlmostEqual(snap["stages_ms"]["push.chat"], 750.0)
         self.assertAlmostEqual(snap["stages_ms"]["jobs"], 100.0)
-        self.assertEqual(snap["builds"]["chat"], {"cached": 1, "built": 1, "ms": 40.0})
+        # chat also carries the watched/background split and the per-component attribution (2026-09-09); the
+        # plain writer counts the build and attributes nothing
+        self.assertEqual(snap["builds"]["chat"], {"cached": 1, "built": 1, "ms": 40.0, "active_built": 0, "bg_built": 0,
+                                                  "bg_miss": {k: 0 for k in km._PerfStats.CHAT_MISS}})
         self.assertEqual(snap["builds"]["feed"]["built"], 1)
         self.assertEqual(snap["builds"]["timeline"], {"cached": 0, "built": 0, "ms": 0.0})
         self.assertEqual(snap["judge"]["passes"], 2)

--- a/tests/test_postal_hydrate_scope.py
+++ b/tests/test_postal_hydrate_scope.py
@@ -17,7 +17,6 @@ A genuine multi-message drain must still hydrate EVERY id, so that stays covered
 
 SYNTHETIC fixtures only: invented sessions (notes-api's web/api/tests), placeholder UUIDs, TESTHOST.
 """
-import inspect
 import io
 import json
 import os
@@ -217,9 +216,91 @@ class HydrateRecipient(unittest.TestCase):
                          "no sid to compare against → no recipient check (direct callers)")
 
     def test_build_session_passes_its_sid_in(self):
-        # Without the wiring the recipient check is dead code in the only caller that matters.
-        self.assertIn("_hydrate_postal(events, _postal_index(), sid)",
-                      inspect.getsource(km.build_session))
+        # Without the wiring the recipient check is dead code in the only caller that matters: a spy on the
+        # hydrator records the sid every hydration build_session makes carries (the tail pass at least).
+        seen = []
+        real = km._hydrate_postal
+
+        def spy(events, index, sid=None, captions=None):
+            seen.append(sid)
+            return real(events, index, sid, captions=captions)
+        km._hydrate_postal = spy
+        self.addCleanup(setattr, km, "_hydrate_postal", real)
+        saved = (km._sessions, km._tmux_sessions, km._msg_summaries)
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        tx = os.path.join(td.name, ME + ".jsonl")
+        with open(tx, "w") as f:
+            f.write(json.dumps({"type": "user", "uuid": "u1", "timestamp": "2026-09-01T10:00:00.000Z",
+                                "message": {"role": "user", "content": "hello"}}) + "\n")
+        km._sessions = lambda now, **kw: [{"sid": ME, "name": "web", "anchor": ME, "path": tx, "mtime": 1}]
+        km._tmux_sessions = lambda: {}
+        km._msg_summaries = lambda: {}
+        try:
+            km.build_session(ME, 1700000000, {})
+        finally:
+            km._sessions, km._tmux_sessions, km._msg_summaries = saved
+        self.assertTrue(seen, "build_session hydrated at least once")
+        self.assertEqual(set(seen), {ME}, "every hydration carried the session's own sid")
+
+
+class HydrateIndependence(unittest.TestCase):
+    """hydrate(A + B) == hydrate(A) + hydrate(B). The chat fold's commit hydrates only the raw postal events
+    new since its seal and prepends the sealed cards (2026-09-09); that equals a hydration of the whole list
+    only while hydration carries no state from one event to the next. Pinned over the four event shapes: an
+    outgoing send, a resolved incoming id, an unresolved id, a plain Bash row, split at every position."""
+
+    M_OUT = "1700000009.77777_88888.TESTHOST"
+
+    def setUp(self):
+        km._POSTAL_UNRESOLVED_RESET()
+
+    def _events(self):
+        return [tool("mcp__romp-postal-service__send_message", "Delivered to 'api'.",
+                     input=json.dumps({"to": "api", "body": "taking the deploy"}), ts="2026-09-07T10:00:00.000Z"),
+                user("mail: " + MARKER % M1),
+                user("look at this: " + MARKER % M3),        # no row: passes through, ids kept
+                bash("uv run pytest -q", "ok")]
+
+    def _index(self):
+        out_row = dict(row(self.M_OUT, PEER, body="taking the deploy"), fromId=ME)   # the send's own log row
+        return {M1: row(M1, ME), self.M_OUT: out_row}
+
+    def test_every_split_equals_the_whole(self):
+        evs, idx = self._events(), self._index()
+        caps = lambda: {M1: "api: the deploy is handed over", self.M_OUT: "web: taking the deploy"}
+        err, saved = io.StringIO(), km.sys.stderr
+        km.sys.stderr = err
+        try:
+            whole = km._hydrate_postal(list(evs), idx, ME, captions=caps)
+            for k in range(len(evs) + 1):
+                split = (km._hydrate_postal(evs[:k], idx, ME, captions=caps)
+                         + km._hydrate_postal(evs[k:], idx, ME, captions=caps))
+                self.assertEqual(split, whole, "split at %d" % k)
+        finally:
+            km.sys.stderr = saved
+        self.assertEqual([(e["kind"], e.get("direction")) for e in whole],
+                         [("postal-service", "out"), ("postal-service", "in"), ("user", None), ("tool", None)])
+        self.assertEqual(whole[0].get("summary"), "web: taking the deploy", "the send joined its row and caption")
+        self.assertEqual(whole[1]["summary"], "api: the deploy is handed over")
+        self.assertEqual(whole[2]["mids"], [M3])
+
+    def test_the_captions_getter_stands_in_for_msg_summaries_and_is_read_once(self):
+        calls = []
+
+        def caps():
+            calls.append(1)
+            return {M1: "cap"}
+        saved = km._msg_summaries
+        km._msg_summaries = lambda: self.fail("_msg_summaries must not be read when a getter is given")
+        try:
+            out = km._hydrate_postal([user(MARKER % M1), user(MARKER % M1)], {M1: row(M1, ME)}, ME, captions=caps)
+        finally:
+            km._msg_summaries = saved
+        self.assertEqual([e["summary"] for e in out], ["cap", "cap"])
+        self.assertEqual(len(calls), 1, "fetched once per hydration, on first need")
+        self.assertEqual(km._hydrate_postal([bash("ls", "ok")], {}, ME, captions=lambda: self.fail("no card, no map")),
+                         [bash("ls", "ok")])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Symptom

`romp perf` reports chat rebuilds as one number. On a kernel with many tabs open it cannot say whether the watched tab or the background tabs are rebuilding, or which input moved, so a rebuild storm has no attribution.

Each background rebuild also costs more than its trigger warrants. A judge pass that changed any store rebuilds every background tab (the judge generation is a component of the tab's signature), and that rebuild re-derives work whose own inputs did not move: the live merge's transcript-side sets over every atom of the parse (and again for the feed and the timeline builds of the same cycle), every sealed postal card re-hydrated although no caption moved, the ledger's goal-tree walk over the same parse and store, and the task fold over every turn's atoms. On a quiet board those re-derivations are most of what a background rebuild does.

## Cause

Four per-build costs had no memo although each is a pure function of inputs that rarely move between builds, the caption map's key missed two of its inputs, and the chat counter had no split:

- `_merge_live_atoms` derived `tx_uuids`, `tx_text_uuids`, `tx_texts`, `tx_text_t` and the human floor from every atom, per call; the chat, feed and timeline builds of one cycle each called it on the same parse object.
- The chat fold's postal gate keyed the sealed cards on `_judge_gen`, so any judge pass re-hydrated the tab's whole sealed raw list. A caption is the only judge-written value a card embeds; the rest comes from the raw event and the message log. The commit then hydrated the whole raw list again.
- `_msg_summaries` keyed each session's caption submap on the transcript mtime alone: a caption written after a segment's last transcript record did not reach the map until the session's next turn, and a seam change never did.
- The ledger's goal-tree walk ran on every build over the same parse, store, cleared set and anchor table.
- `_fold_tasks` scanned every turn twice per build, although a build over the parse cache's object changes at most the last turn (the live merge replaces its atoms list).
- `_PerfStats.build("chat", ...)` filed `cached`, `built`, `ms` only.

## Fix

Two commits, each one mechanism with its tests; the second can be dropped on its own. About 2,450 changed lines against the current main (+2,189, -267, `git diff --numstat`), 62% of them tests.

Commit 1, the memos and the counters:

- `_PerfStats.build_chat(cached, dt, active, miss)` at the pusher's serve site. `builds.chat` gains `active_built`, `bg_built` and `bg_miss`, a map from each labelled component of `_chat_build_sig` (`transcript`, `states`, `judge_gen`, `tasks`, `cut`, `row`, plus `cold` and `nosig`) to the background rebuilds it caused. `_chat_sig_miss` derives the labels from the tuple's shape, so the signature stays the flat tuple its callers compare; the push's row is one component either way (`None` without a row), so the tail has one shape. `romp perf` prints the split and the non-zero causes after the chat average. The watched tab's rebuilds are counted, not attributed.
- `_merge_tx_sets(session, sid)`: the five transcript-side values per sid, keyed on the parsed object's identity (the entry holds the object, so an id cannot be recycled onto a new parse), the three sets frozen; a withheld uuid builds a new set instead of subtracting in place. One entry serves the chat, feed and timeline builds of a cycle. Bounded at 512, oldest first, one at a time.
- The postal gate keys the sealed cards on the values they embed: the log's identity (`_chat_postal_key`) and, per card, its caption and its peer's name and colour (`_postal_card_deps`), read from one postal index and one caption map per build, which `build_session` hands to its hydrations as a getter (`_hydrate_postal(..., captions=)`). The commit reuses the sealed cards and hydrates only the raw events new since the seal; `_hydrate_postal` is per-event independent, which the tests pin. A build outside the pusher's names snapshot (a connect push on a handler thread) records its values as unverified, and the next scoped build re-hydrates once and records what it saw. `_msg_summaries` is re-keyed per session on the parse's key (transcript stat, pending cut, states file), the captions file and the goal store's identity (`jd._store_identity`), and read once per pusher cycle through a `_live_scope.msgsum` slot (`_msg_summaries_scoped`) that `_pusher_cycle` opens and its `finally` closes; the chat builds and the timeline's postal connectors (`_postal_messages`) read the same slot. The key's stats (the transcript, the states file, the captions file, the store's three files) therefore run once per cycle, and only in a cycle where some tab's sealed card carries a message id or the timeline rebuilds, since the map is fetched on first need. For a session the SDK backend does not hold live, the pending-cut component reads that session's registry file (the cut lives there): one small JSON read per dormant session per fetch, the same read `_parse` makes for a session it builds.
- The ledger memo: `build_session` keeps the goal-tree walk and the live roots per sid, keyed on the parsed object and the shared store object (both by identity; the shared store is frozen and replaced on any file change), the seams, `cleared.jsonl`'s stat taken before the read, and a per-sid warm-anchor revision (`_node_anchor_rev`, bumped after `_node_anchor_uuids` changes a table entry, read before the walk, so a resolve landing during the walk misses the next build rather than serving the pre-resolve tree). The seams stay a component beside the store's identity because the build loads the store twice, once at the top for the seg ids and once at the ledger for the nodes: a publish landing between the two loads pairs the old seams' seg maps with the new store object, and the next build, whose maps come from the new seams, has to miss. Bypassed for a live-merged parse, an armed rewind hold and an empty store. `_node_anchor_uuids` takes `sid=None`; the feed's three-argument call and its webview pin are unchanged.
- The pusher evicts the memos on the same keep set as the fold prefixes (the shown tabs plus this cycle's comment threads); the merge sets also stay for any alive session, since the feed and timeline merge every alive session. The counters bump under `_chat_fold_lock` (`_chat_memo_bump`).
- Counters under `memos.chatMergeSets`, `memos.chatPostal`, `memos.chatLedger`; `docs/reference.md` describes them.

Commit 2, the task fold: `_fold_tasks(session, sid=None)` splits into `_fold_tasks_turn(atoms)` (pure over one turn: results, rejected ids, ops) and a combine. The per-turn partials are kept per sid on the atoms list's identity plus `_chat_turn_fp`, the fingerprint the chat fold already trusts for a turn. A parse of any kind mints new turn dicts and atoms lists, so the memo serves builds over the parse cache's object and over the live merge's copy of it (which replaces the last turn's list only); the fingerprint guards against an in-place change to a held list. The combine runs in full and returns a fresh list. A call with no sid scans and memoizes nothing, so every direct caller keeps its meaning; `build_session` passes its sid. Counted per turn under `memos.chatFoldTasks`. The seven one-argument `_fold_tasks` stubs in `tests/test_kernel.py` take the `sid` keyword. #994 (user todos) stubs `_fold_tasks` with a one-argument lambda in `tests/test_user_todos.py`; whichever of the two lands second makes that a one-line edit.

Scope: these memos serve a build whose parse, store and log stand while another input moved. Today that is every background tab on every judge pass, states row and task-store write. A later change that replaces the judge generation in the signature with per-session store identities would remove most of those background rebuilds; the memos then serve mainly the watched tab's builds between transcript writes (a live-tail change over one parse), and the counters say what that is worth.

Measured with the script below on this head, a synthetic session under a temporary state root, medians of 25 runs, milliseconds (the machine carried other load, so the absolute figures vary between runs; the direction of every row held across three runs):

| | 200 turns | 1000 turns |
|---|---|---|
| task fold, every turn / one merged turn | 0.57 / 0.28 | 4.74 / 1.53 |
| live-merge sets, derived / served | 1.25 / 0.001 | 7.59 / 0.001 |
| 50 sealed postal cards, re-hydrated / values check | 0.14 / 0.04 | 0.13 / 0.04 |
| `build_session` over a warm prefix (300 nodes), ledger walked / served | 4.6 / 2.7 | 7.3 / 4.9 |

The two per-atom scans (the sets and the fold) grow with the transcript; the sets are derived up to three times per cycle per alive session. Nothing on the board changes: the tests compare a memoized build with a cold one at every step.

<details>
<summary>The measurement script (standalone; `python3 bench.py <repo root> [turns] [nodes] [cards]`)</summary>

```python
#!/usr/bin/env python3
"""A standalone measurement of the four chat-build costs this change memoizes, cold against warm, over a
synthetic session under a temporary state root. Usage: python3 bench.py <repo root> [turns] [nodes] [cards].
Prints medians in milliseconds. Nothing here is a test; the figures are for a PR body."""
import json
import os
import re
import statistics
import sys
import tempfile
import time
from datetime import datetime, timezone
from importlib.machinery import SourceFileLoader
from pathlib import Path

ROOT = sys.argv[1]
TURNS = int(sys.argv[2]) if len(sys.argv) > 2 else 200
NODES = int(sys.argv[3]) if len(sys.argv) > 3 else 300
CARDS = int(sys.argv[4]) if len(sys.argv) > 4 else 50
REPS = 25

os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
os.environ.pop("ROMP_STATE_DIR", None)
os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
os.environ.setdefault("ROMP_SERVE_TOKEN", "bench-token-DO-NOT-USE")
km = SourceFileLoader("romp_kernel_bench", os.path.join(ROOT, "bin", "romp-kernel")).load_module()
jd = km.jd

SID = "66666666-7777-8888-9999-bbbbbbbbbbb1"
PEER = "66666666-7777-8888-9999-bbbbbbbbbbb2"


def iso(t):
    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")


td = Path(tempfile.mkdtemp())
cdir = td / "launchdir"; cdir.mkdir()
proj = td / "projects"
pdir = proj / re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir))); pdir.mkdir(parents=True)
tpath = pdir / (SID + ".jsonl")
jd._rebind_state(td)
jd.PROJECTS = proj
jd.NAMES.mkdir(parents=True, exist_ok=True)
(jd.NAMES / SID).write_text("web\t%s\t#abcdef\n" % cdir)
(jd.NAMES / PEER).write_text("api\t%s\t#123456\n" % cdir)
km.NAMES = jd.NAMES
km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
os.environ["CLAUDE_CONFIG_DIR"] = str(td / "claude")
now = int(time.time())
t0 = now - 3 * 86400
tm = {SID: {"state": "working", "since": now - 100, "model": "", "effort": "", "context": None, "compactPct": None, "color": None}}
km._tmux_sessions = lambda: tm
km._sdk = lambda: None

# the postal log: CARDS messages delivered to this session
mids = ["1788400000.%03d_1.TESTHOST" % i for i in range(CARDS)]
jd.MESSAGES.parent.mkdir(parents=True, exist_ok=True)
with open(jd.MESSAGES, "w") as f:
    for i, mid in enumerate(mids):
        f.write(json.dumps({"ev": "sent", "id": mid, "from": "api", "from_id": PEER, "to_id": SID,
                            "body": "message %d about the deploy" % i, "kind": "coordinate", "t": t0 + i}) + "\n")
caps = {mid: "api: message %d" % i for i, mid in enumerate(mids)}
km._msg_summaries = lambda: dict(caps)

# the transcript: TURNS complete turns, a TaskCreate every 10th, a delivered message every TURNS/CARDS-th
n = [0]
def uid():
    n[0] += 1
    return "bbbbbbbb-0000-0000-0000-%012d" % n[0]
t = [t0]
def tick():
    t[0] += 5
    return t[0]
last = [None]
recs = []
step = max(1, TURNS // CARDS)
for i in range(TURNS):
    u = uid()
    text = "step %d: tighten the notes-api search" % i
    if i % step == 0 and i // step < CARDS:
        text = "<!-- romp-msg-id: %s -->\nmessage %d about the deploy" % (mids[i // step], i // step)
    recs.append({"type": "user", "timestamp": iso(tick()), "uuid": u, "parentUuid": last[0], "promptSource": "typed",
                 "message": {"role": "user", "content": text}, "cwd": "/tmp/notes-api", "version": "2.1.0", "gitBranch": "main"})
    a = uid()
    content = [{"type": "text", "text": "Round %d." % i}]
    if i % 10 == 0:
        content.append({"type": "tool_use", "id": "tu_c%s" % a, "name": "TaskCreate",
                        "input": {"subject": "task %d" % i, "activeForm": "Doing task %d" % i}})
    content.append({"type": "tool_use", "id": "tu_%s" % a, "name": "Bash", "input": {"command": "uv run pytest -q"}})
    recs.append({"type": "assistant", "timestamp": iso(tick()), "uuid": a, "parentUuid": u,
                 "message": {"role": "assistant", "model": "claude-sonnet-4", "content": content, "stop_reason": "tool_use"},
                 "cwd": "/tmp/notes-api", "version": "2.1.0", "gitBranch": "main"})
    r = uid()
    results = [{"type": "tool_result", "tool_use_id": "tu_%s" % a, "content": "ok\n"}]
    if i % 10 == 0:
        results.insert(0, {"type": "tool_result", "tool_use_id": "tu_c%s" % a, "content": "Task #%d created" % (i // 10 + 1)})
    recs.append({"type": "user", "timestamp": iso(tick()), "uuid": r, "parentUuid": a,
                 "message": {"role": "user", "content": results}})
    b = uid()
    recs.append({"type": "assistant", "timestamp": iso(tick()), "uuid": b, "parentUuid": r,
                 "message": {"role": "assistant", "model": "claude-sonnet-4", "content": [{"type": "text", "text": "Step %d done." % i}],
                             "stop_reason": "end_turn"}, "cwd": "/tmp/notes-api", "version": "2.1.0", "gitBranch": "main"})
    last[0] = b
with open(tpath, "w") as f:
    for r in recs:
        f.write(json.dumps(r) + "\n")

parsed = km._parse(str(tpath), SID, now)
seg = km._segs_seam(parsed["turns"][0], {})[0]
nodes = {"g%d" % i: {"id": "g%d" % i, "text": "goal %d" % i, "t": t0 + i, "mt": t0 + i,
                      "parentId": None if i % 5 == 0 else "g%d" % (i - i % 5), "trail": [seg["id"]]} for i in range(NODES)}
p = jd.GOALDIR / (SID + ".json"); p.parent.mkdir(parents=True, exist_ok=True)
tmp = p.with_name(p.name + ".tmp"); tmp.write_text(json.dumps({"nodes": nodes, "status": {}, "seams": [], "lastNode": None})); os.replace(tmp, p)


def med(fn, reps=REPS):
    xs = []
    for _ in range(reps):
        a = time.perf_counter(); fn(); xs.append((time.perf_counter() - a) * 1000.0)
    return statistics.median(xs)


def build():
    km._live_scope.names = km._names_snapshot()
    try:
        return km.build_session(SID, now, tm)
    finally:
        km._live_scope.names = None


# warm everything: fold prefix, memos, parse
for _ in range(3):
    build()
m = build()
assert len([e for e in m["events"] if e.get("kind") == "postal-service"]) == CARDS, "cards did not render"
assert len(m["ledger"]["tree"]) == 80

# 1. the task fold: every turn (a direct call, the old per-build cost) vs one live-merged last turn
merged = dict(parsed, turns=[dict(x) for x in parsed["turns"]])
merged["turns"][-1] = dict(merged["turns"][-1], atoms=list(merged["turns"][-1]["atoms"]))
km._fold_tasks(parsed, SID)
fold_cold = med(lambda: km._fold_tasks(parsed))
fold_warm = med(lambda: km._fold_tasks(merged, SID))

# 2. the live merge's sets: derived vs served
def derive():
    km._merge_sets_memo.pop(SID, None)
    km._merge_tx_sets(parsed, SID)
sets_cold = med(derive)
sets_warm = med(lambda: km._merge_tx_sets(parsed, SID))

# 3. the sealed postal cards: a re-hydration of the sealed list vs the values check
entry = km._chat_fold_get(SID)
raw, cards = entry["postal_raw"], entry["postal_cards"]
assert len(raw) == CARDS, len(raw)
km._live_scope.names = km._names_snapshot()
idx = km._postal_index()
msum = lambda: dict(caps)
gate_old = med(lambda: km._hydrate_postal(list(raw), idx, SID, captions=msum))
gate_new = med(lambda: km._postal_card_deps(cards, idx, msum))
km._live_scope.names = None

# 4. the whole build_session over the warm prefix: the ledger memo cleared before each build vs held
def build_cleared():
    km._ledger_memo.clear()
    build()
led_cold = med(build_cleared, 15)
led_warm = med(build, 15)

print("synthetic session: %d turns, %d goal nodes, %d sealed postal cards; medians of %d runs, ms" % (TURNS, NODES, CARDS, REPS))
print("task fold           every turn %.2f    one merged turn %.2f" % (fold_cold, fold_warm))
print("live-merge sets     derived %.2f       served %.3f" % (sets_cold, sets_warm))
print("sealed postal cards re-hydrated %.2f   values check %.2f" % (gate_old, gate_new))
print("build_session (warm prefix)  ledger walked %.1f   ledger served %.1f" % (led_cold, led_warm))
```

</details>

## Tests

`tests/test_chat_fixed_cost_memos.py` (new, 40 cases), every one red on the tree before its commit: all 40 on the base, and on the commit-1 tree the 7 that commit 2 adds or extends (the five `TaskFold` cases, the four-memos report and the task-fold eviction):

- `SigLabels`: a real `_chat_build_sig` has one label per position and a row slot either way; every moved component is named, a reshaped key names the states section (fails before: `_chat_sig_labels` and `_chat_sig_miss` do not exist).
- `Collector`: `build_chat` splits watched from background and attributes the latter; the snapshot is a copy; the four memos report under `memos` (fails before: `build_chat` does not exist; `KeyError` on the memo keys).
- `MemoBump`: concurrent bumps land exactly; the bump waits on `_chat_fold_lock` (fails before: no `_chat_memo_bump`).
- `TwoTabAttribution`: the real `_push` over two tabs, one watched: first cycle `active_built 1, bg_built 1, bg_miss cold 1`; nothing moved: both served; the background transcript, a judge pass, the background states file each rebuild it under their label; the watched tab's own growth counts under `active_built`. The eviction of the merge sets (a sid neither shown nor alive), the ledger memo and the task fold memo (a tab no longer shown; this cycle's thread kept) (fails before: `KeyError: active_built`; the memos do not exist).
- `MergeSets`: the same parsed object hits, a fresh parse misses, sids do not share; the sets equal the unmemoized derivation and the three sets are frozen; a merge hands `prune_live` the memoized sets and a withheld uuid makes a new set; no live atoms skip the memo; the memo is bounded one eviction at a time (fails before: `_merge_tx_sets` does not exist).
- `PostalCardDeps`: each embedded value is a component and nothing else is; the caption map is fetched once and only for a card with a mid.
- `MsgSummariesKey`: a caption write, a store publish, a journal row, an archive write, a states row, the transcript's size and the pending cut each rescan that session alone; unchanged inputs rescan nothing; the key is taken before the scan (fails before: a caption write with no mtime change rescans nothing).
- `CycleCaptionSlot`: reads within one `_pusher_cycle` fetch the map once and the slot closes with the cycle; the slot is open while the jobs run and closed when they raise; the timeline's postal connectors inside a cycle read the cycle's map and fetch nothing new, and outside a cycle they read the map directly (fails before: no slot, `_msg_summaries_scoped` does not exist).
- `PostalGate`, over `build_session` on a synthetic session with a delivered message: a judge pass that moved no caption leaves the sealed card alone (a spy on `_hydrate_postal` sees the tail pass only; fails before: the gate re-hydrated the sealed raw list and the commit hydrated it again); a caption change re-hydrates exactly the sealed card and refreshes it; a peer's colour refreshes it while a caption for another message does not; a build outside the names scope seals unverified and the next scoped build verifies once; the commit hydrates only the raw events new since the seal. Each compares against a cold build.
- `LedgerMemo`: unchanged inputs hit and the served ledger equals a fresh walk; a store publish, a journal row, a clear, a transcript append and a seam change each miss once; a rewind hold and a live merge bypass; a warm anchor learned for this session's node misses once and another session's does not; a resolve landing during the walk misses the next build, never a stale hit; a warm resolve writes the table entry before it bumps the revision (a dict subclass records the revision at the write); a store published between the build's two loads misses the next build (a stub on `jd.load_goals_shared_or_fault` publishes new seams between them); a clear landing during the walk misses the next build; a muted tab still ships no tree (fails before: `_ledger_memo_stats` does not exist).
- `TaskFold` (commit 2): the same object serves every turn, a live merge rescans the last turn alone, a re-parse rescans all; a turn grown in place is rescanned; a rejected create and a late result fold as before; the result is a fresh list and the store reader leaves it unchanged; `build_session` hands its sid to the fold (fails before: `TypeError` on the two-argument call).

Four reversions of the mechanism, made one at a time with the tests in place, each go red: dropping the seams from the ledger key (one case), bumping the revision before the table write (one), reading the caption map directly from the timeline (one), and not opening the cycle slot (three).

Existing modules: `tests/test_chat_fold.py`'s postal cases follow the new contract (the caption's change alone refreshes the card, a judge pass re-hydrates a sealed send no longer, a log append does, the commit hydrates the tail pass only); `tests/test_postal_hydrate_scope.py` checks `build_session`'s sid through a spy on the hydrator instead of the call's source text and pins the per-event independence (`hydrate(A + B) == hydrate(A) + hydrate(B)` at every split, and the captions getter read once); `tests/test_perf_stats.py` and `tests/romp-perf.bats` carry the new fields; `tests/test_kernel.py`'s seven stubs take `sid=None`.

Targeted runs on this head: `tests/test_chat_fixed_cost_memos.py` (40), `tests/test_chat_fold.py`, `tests/test_postal_hydrate_scope.py`, `tests/test_perf_stats.py`, `tests/test_perf_bench.py`, `tests/test_stage0_log_readers.py`, `tests/test_chat_delta_resync.py`, `tests/test_kernel_rewind.py`, `tests/test_kernel_tool_result_scan.py`, `tests/test_judge_authoritative_plan_sync.py`, `tests/test_pusher_change_gates.py`, `tests/test_kernel_awaiting_lift.py`, `tests/test_kernel_bg_placed_tops.py`, `tests/test_kernel_goal_cache_wiring.py`: 458 passed; `tests/test_kernel.py`'s fold, todo and push-cache cases: 24 passed; `tests/romp-perf.bats` 15 of 15.

Full suite on this head (`pytest -q -n 8 tests/`): 10876 passed, 118 skipped, 0 failed, 76 s. No webview file changes, so the TypeScript lane is untouched.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)