### PR TITLE
Awaiting overlay: a departed session's unreadable states file is named once per episode, not once per rebuild

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -24457,7 +24457,8 @@ def _states_awaiting_overlay(sid):
 
 _states_overlay_cache = {}    # str(states path) -> _fold_records entry over (last overlay row or None, working_after)
 _states_overlay_stats = {"hit": 0, "append": 0, "refold": 0, "fail": 0, "evict": 0}
-_states_overlay_failed = set()   # paths whose last read failed on a file that exists: one stderr line per episode
+_states_overlay_failed = set()   # paths whose last read failed on a file that exists: one stderr line per episode;
+#                                  cleared whole above 256 paths (_states_overlay_on), never per departed path
 _STATES_OVERLAY_LOCK = threading.Lock()   # the counters are bumped from the pusher, the connect-time builds on WS
 #                                           threads and GET /sessions at once, so a bare `+= 1` is a read-modify-write
 #                                           across threads (the _INTR_MARKS_STATS_LOCK precedent). The cache dict
@@ -24493,11 +24494,18 @@ def _states_overlay_on(path_s, kind):
     """The fold's `on` for one states file: count the path the fold took, and on "fail" (the file exists and
     could not be stat'ed, opened or read; the fold answered the empty state and memoized nothing) write one
     stderr line per episode, so a failed read is told apart from a rewrite in GET /perf and in the log. A
-    later good fold of the same file ends the episode. Cheap on purpose, since it runs inside every fold:
-    one locked increment, and the set is touched only on a failure or while an episode is open."""
+    later good fold of the same file ends the episode, and no per-path event does: the interrupt tick's forget
+    (_states_overlay_forget) leaves the set alone, since a departed session's file is still read. The set is
+    instead cleared whole above 256 paths, the fold cache's own bound (fold_records), so a path stranded by a
+    session whose file is never read again cannot pin it forever; a whole clear ends every open episode at
+    once, so a still-unreadable file is named a second time after it, exactly as the fold cache re-folds
+    after its clear. Cheap on purpose, since it runs inside every fold: one locked increment, and the set is
+    touched only on a failure or while an episode is open."""
     _states_overlay_bump(kind)
     if kind == "fail":
         with _STATES_OVERLAY_LOCK:
+            if len(_states_overlay_failed) > 256:          # the fold cache's cap: a stranded path cannot pin the set
+                _states_overlay_failed.clear()
             first = path_s not in _states_overlay_failed
             _states_overlay_failed.add(path_s)
         if first:
@@ -24510,24 +24518,21 @@ def _states_overlay_on(path_s, kind):
 
 def _states_overlay_forget(alive):
     """Drop the fold entries of sessions outside `alive` (the interrupt tick's alive set, once per cycle): the
-    readers of this overlay are the chips and lanes of live sessions, so a session leaving the alive set is
-    the event that retires its entry, the same event that releases its interrupt-marks entries. Iterates a
-    key snapshot: a connect-time build on a WS thread may insert concurrently. The records stay in the event
-    model's LRU reader; a later read of a departed session's file re-folds them without re-reading the file.
-    A departed path also loses its open-fail episode, if any, straight out of `_states_overlay_failed`: a
-    fail always pops the cache entry too (fold_records), so a path whose LAST read before it left the alive
-    set failed is never IN the cache for this loop to reach, and nothing else reads a departed session's
-    file again to end the episode the ordinary way. `_states_overlay_failed` has no cap of its own (unlike
-    the cache's 256-entry clear-whole), so a path stranded there would sit forever otherwise."""
+    readers of this overlay are mostly the chips and lanes of live sessions, so a session leaving the alive
+    set is the event that retires its entry, the same event that releases its interrupt-marks entries.
+    Iterates a key snapshot: a connect-time build on a WS thread may insert concurrently. The records stay in
+    the event model's LRU reader; a later read of a departed session's file re-folds them without re-reading
+    the file.
+    The fail latch (`_states_overlay_failed`) is not touched here: a departed session's file is still read,
+    by build_session for a dead session kept open as a read-only tab and for the scroll-back handler, and by
+    GET /classify for any sid, so a discard here would name the same open episode again on the next of those
+    reads, against the one-line-per-episode contract; the set is bounded by its own cap in _states_overlay_on
+    instead."""
     keep = {str(jd.STATE / "states" / ("%s.jsonl" % sid)) for sid in alive}
     n = 0
     for k in list(_states_overlay_cache):
         if k not in keep and _states_overlay_cache.pop(k, None) is not None:
             n += 1
-    with _STATES_OVERLAY_LOCK:
-        for k in list(_states_overlay_failed):
-            if k not in keep:
-                _states_overlay_failed.discard(k)
     if n:
         _states_overlay_bump("evict", n)
 

--- a/tests/test_states_overlay_fold.py
+++ b/tests/test_states_overlay_fold.py
@@ -260,11 +260,12 @@ class OverlayFold(_State):
         km._states_overlay_forget({SID})
         self.assertEqual(km._states_overlay_report()["evict"], 1, "nothing left to drop: no count")
 
-    def test_forget_also_drops_a_departed_sids_stranded_failed_episode(self):
-        # A read that fails pops the cache entry (fold_records), so a sid whose LAST read before it left the
-        # alive set failed sits only in _states_overlay_failed, never in _states_overlay_cache: the loop
-        # over the cache alone would never reach it, and nothing else reads a departed sid's file again to
-        # end the episode the ordinary way.
+    def test_a_departed_sids_open_episode_survives_the_forget_and_is_named_once(self):
+        # A fail pops the cache entry (fold_records), so a sid whose read failed sits only in
+        # _states_overlay_failed. Its file is still read after the sid leaves the alive set: build_session
+        # serves a dead session kept open as a read-only tab and the scroll-back handler for any sid, and
+        # GET /classify answers for any sid, none of them gated on liveness. The stderr line is one per
+        # episode for every reader, so the forget must not reset the latch; only a good read ends the episode.
         self.check([{"t": 100, "awaiting": True, "why": "x"}], {"t": 100, "awaiting": True, "why": "x"})
         # the shared reader serves an UNCHANGED file's records on an identity hit without opening it, so a
         # permission flip alone is not a read attempt: the file grows first, then becomes unreadable
@@ -273,14 +274,51 @@ class OverlayFold(_State):
         try:
             if os.access(self.states_path(), os.R_OK):
                 self.skipTest("this user reads through mode 000 (root)")
-            self.assertIsNone(km._states_awaiting_overlay(SID), "the read failed: no overlay")
+            err = io.StringIO()
+            with redirect_stderr(err):
+                self.assertIsNone(km._states_awaiting_overlay(SID), "the read failed: no overlay")
+                km._states_overlay_forget(set())              # SID leaves the alive set with the episode open
+                self.assertIsNone(km._states_awaiting_overlay(SID), "a kept-open tab's rebuild reads it again")
+                km._states_overlay_forget(set())              # the next tick's forget
+                self.assertIsNone(km._states_awaiting_overlay(SID))
+            self.assertEqual(err.getvalue().count("unreadable"), 1,
+                             "one stderr line per episode, whatever the forget did between the reads")
+            st = km._states_overlay_report()
+            self.assertEqual((st["fail"], st["entries"]), (3, 0), "every read counted, none memoized")
+            self.assertIn(str(self.states_path()), km._states_overlay_failed, "the forget leaves the open episode alone")
         finally:
             os.chmod(self.states_path(), 0o644)
-        self.assertIn(str(self.states_path()), km._states_overlay_failed, "the open episode is recorded")
-        self.assertNotIn(str(self.states_path()), km._states_overlay_cache, "a fail pops the cache entry too")
-        km._states_overlay_forget(set())                       # SID leaves the alive set with the episode still open
-        self.assertNotIn(str(self.states_path()), km._states_overlay_failed,
-                         "forget retires the stranded episode along with the cache entry")
+        self.assertEqual(km._states_awaiting_overlay(SID), ref_overlay(SID), "readable again: the walk's answer")
+        self.assertNotIn(str(self.states_path()), km._states_overlay_failed, "a good read ends the episode")
+
+    def test_the_failed_set_is_cleared_whole_above_its_cap(self):
+        # The forget leaves a departed sid's path in the set, so the set is bounded the way the fold cache is:
+        # cleared whole above 256 paths (fold_records), never per path. At 256 nothing is cleared.
+        seeded = {os.path.join(self.td, "states", "cap-%d.jsonl" % i) for i in range(256)}
+        with km._STATES_OVERLAY_LOCK:
+            km._states_overlay_failed.update(seeded)
+        self.check([{"t": 100, "awaiting": True, "why": "x"}], {"t": 100, "awaiting": True, "why": "x"})
+        self.append_state({"t": 200, "state": "idle"})
+        os.chmod(self.states_path(), 0)
+        try:
+            if os.access(self.states_path(), os.R_OK):
+                self.skipTest("this user reads through mode 000 (root)")
+            err = io.StringIO()
+            with redirect_stderr(err):
+                self.assertIsNone(km._states_awaiting_overlay(SID))
+            self.assertEqual(km._states_overlay_failed, seeded | {str(self.states_path())},
+                             "256 paths is the cap, not above it: nothing cleared, the failing path enters")
+            self.assertEqual(err.getvalue().count("unreadable"), 1)
+            # 257 paths now: the next fail clears the set whole, and a clear ends every open episode at once,
+            # so the same unreadable file is named a second time on that read, as the fold cache re-folds
+            # after its own clear
+            with redirect_stderr(err):
+                self.assertIsNone(km._states_awaiting_overlay(SID))
+            self.assertEqual(km._states_overlay_failed, {str(self.states_path())},
+                             "above the cap the set is cleared whole, then the failing path re-enters")
+            self.assertEqual(err.getvalue().count("unreadable"), 2, "the clear ended the episode; the next fail opens one")
+        finally:
+            os.chmod(self.states_path(), 0o644)
 
     def test_the_report_has_the_documented_shape(self):
         st = km._states_overlay_report()
@@ -407,6 +445,38 @@ class InterruptTickRetires(unittest.TestCase):
             km._has_tmux = saved
         self.assertEqual(km._states_overlay_cache, {}, "the live session left: its entry goes")
         self.assertEqual(km._states_overlay_report()["entries"], 0)
+
+    def test_the_tick_leaves_a_departed_sids_open_fail_episode_alone(self):
+        # A dead session's states file is still read after the tick drops its fold entry: build_session
+        # serves a dead session kept open as a read-only tab and the scroll-back handler for any sid, and
+        # GET /classify answers for any sid, none of them gated on liveness. The stderr line is one per
+        # episode for every reader, so the tick's forget must not reset the latch for a sid outside its alive
+        # set; a good read is what ends the episode.
+        self._write_states(DEAD, [{"t": T0, "awaiting": True, "why": "a build"}])
+        self.assertEqual(km._states_awaiting_overlay(DEAD), {"t": T0, "awaiting": True, "why": "a build"})
+        dead_path = jd.STATE / "states" / (DEAD + ".jsonl")
+        # the shared reader serves an UNCHANGED file's records on an identity hit without opening it, so a
+        # permission flip alone is not a read attempt: the file grows first, then becomes unreadable
+        with open(dead_path, "a") as f:
+            f.write(json.dumps({"t": T0 + 1, "state": "idle"}) + "\n")
+        os.chmod(dead_path, 0)
+        try:
+            if os.access(dead_path, os.R_OK):
+                self.skipTest("this user reads through mode 000 (root)")
+            err = io.StringIO()
+            with redirect_stderr(err):
+                self.assertIsNone(km._states_awaiting_overlay(DEAD), "the read failed: no overlay")
+            self.assertEqual(err.getvalue().count("unreadable"), 1, "the episode opens with one line")
+            km._interrupt_block_tick(NOW, self.tmux)                    # DEAD is outside the tick's alive set
+            self.assertIn(str(dead_path), km._states_overlay_failed, "the forget leaves the open episode alone")
+            with redirect_stderr(err):
+                self.assertIsNone(km._states_awaiting_overlay(DEAD), "a kept-open tab's rebuild reads it again")
+            self.assertEqual(err.getvalue().count("unreadable"), 1, "the second read names nothing: the episode is open")
+        finally:
+            os.chmod(dead_path, 0o644)
+        self.assertEqual(km._states_awaiting_overlay(DEAD), {"t": T0, "awaiting": True, "why": "a build"},
+                         "readable again: folded from record 0")
+        self.assertNotIn(str(dead_path), km._states_overlay_failed, "a good read ends the episode")
 
 
 class IntrMarksReport(unittest.TestCase):


### PR DESCRIPTION
## Symptom

When a session that has ended has a states file that exists but cannot be read, the kernel's stderr names it again on every rebuild that follows an interrupt tick, instead of once per unreadable episode, the contract stated in `_states_overlay_on`'s docstring and docs/reference.md. The file is still read after the session ends: by build_session when the session is kept open as a read-only tab or scrolled back with loadOlder, and by GET /classify for any sid. The awaiting chip's answer is the same either way (None on a failed read); the defect is log noise.

The rate is the reader's cadence: a background tab rebuilds when the judge generation or the task store moves, the active tab on any dirty mark, and loadOlder and GET /classify read per request, so one line per read that follows a tick's forget, at most one per cycle. The repeated failures need the shared reader's entry absent (after a kernel restart, an eviction, or a change to the file since its last good read), since an unchanged file is served from the reader's cache without being opened.

## Cause

The review-fix commit 21de3fc1 in #1228 made `_states_overlay_forget` discard a departed session's path from `_states_overlay_failed`, the once-per-episode latch, on the reasoning that nothing reads a departed session's file again. The three readers above do, none of them gated on liveness. The first read after the discard found the latch empty and wrote the line again.

## Fix

`_states_overlay_forget` leaves the latch alone. The set is bounded the way the fold cache is: `_states_overlay_on` clears it whole above 256 paths, under the lock it already holds on the fail branch, so a path stranded by a session whose file is never read again cannot pin it. A whole clear ends every open episode at once, so a still-unreadable file is named a second time after a clear, as the fold cache re-folds after its own clear. No per-path event but a good read ends an episode. The docstrings of both functions and the set's trailing comment say so; docs/reference.md already states once per episode and needs no change.

A liveness gate at build_session's `_session_awaiting` call was considered and rejected: it changes the chip's answer for a dead kept-open tab (a stale awaiting row would stop showing), covers neither loadOlder nor GET /classify, and moves a contract that belongs to the latch into its callers. The latch-side fix keeps once per episode for every reader, live or dead.

## Tests

tests/test_states_overlay_fold.py, each red on the unchanged kernel:

- `OverlayFold.test_a_departed_sids_open_episode_survives_the_forget_and_is_named_once` replaces `test_forget_also_drops_a_departed_sids_stranded_failed_episode` from 21de3fc1, which pinned the discard this change removes. It memoizes a readable file, appends a row and chmods it to 0 (so the next read is attempted rather than served from the reader's cache), reads three times with `_states_overlay_forget(set())` between the reads, and expects one "unreadable" stderr line, three fail counts, no memoized entry, and the path still in the latch; readable again, the overlay answers and the path leaves the set. Before: `3 != 1`.
- `OverlayFold.test_the_failed_set_is_cleared_whole_above_its_cap` seeds 256 synthetic paths into the latch, the cap itself, and runs the same recipe twice. The first failed read adds the failing path with nothing cleared (257 paths, one line), so 256 is the cap and not above it; the second clears the set whole down to that one path and, the clear having ended the episode, writes a second line for the same file. Before: the second read left all 257 paths in the set.
- `InterruptTickRetires.test_the_tick_leaves_a_departed_sids_open_fail_episode_alone` runs the real `_interrupt_block_tick` with the dead sid outside its alive set after a failed read and expects the path kept in the latch and the following read silent. Before: the path was gone from the set.

All three use the module's existing guard and skip for a user who reads through mode 000 (root). Changing the cap's `>` to `>=`, removing the cap lines, raising the cap, or checking `first` ahead of the clear fails the second test; restoring the discard loop fails the first and third.

Full suite (`pytest -n 6 tests/`): 10757 passed, 118 skipped, 1688 subtests passed.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)