### PR TITLE
Feed: the session header's Clear all releases the hover-freeze gate the way a card's Clear does

### DIFF
--- a/ui/webview/feed-render-incremental.test.ts
+++ b/ui/webview/feed-render-incremental.test.ts
@@ -903,8 +903,8 @@ test("a hovered session header is one (column, session) row: the same session's 
   const rightOf = (h: El) => (win.innerWidth - h.getBoundingClientRect().right) + "px";
   assert.notEqual(rightOf(hw), rightOf(hb));
   hw.dispatchEvent(new Event("mouseenter"));                     // the pointer rests on the Working row
-  await dispatch(frame([...four, g1c]));                         // a push while it is held: one more web card, in Completed
   try {
+    await dispatch(frame([...four, g1c]));                       // a push while it is held: one more web card, in Completed
     assert.equal(card("g1c"), null, "the payload is queued, not rendered");
     assert.ok(badged(hb), "the same session's Blocked header carries its in-row badge");
     assert.ok(!badged(hw), "never inside the hovered row");
@@ -945,6 +945,50 @@ test("a hovered header's gate releases through its ghost: a Clear that takes the
     ha.dispatchEvent(new Event("mouseleave"));                   // the pointer leaves the ghost
     await settle();
     assert.ok(card("g1d"), "the ghost's mouseleave released the gate: the queued frame applied");
+  } finally {                                                    // on a failure too, so the next test inherits neither
+    win.dispatchEvent(new Event("blur"));                        // a held gate (the backstop release) nor a cleared g2
+    await settle();
+    mock.timers.tick(700);                                        // the cleared card's collapse and the ghost's exit end
+    await dispatch(frame([g1, card("g3")._it]));                  // the kernel confirms the clear (g2 absent)
+    await dispatch(frame([g1, g2it, card("g3")._it]));            // g2 back where it was, under a fresh api header
+  }
+  assert.equal(body.querySelectorAll(".sess-exit").length, 0);
+  assert.ok(card("g2"));
+});
+
+test("a session header's Clear all releases the gate its row holds: the queued frame applies from the click, with no pointer leave and no render", async () => {
+  // Clear all sits on the header row, so the pointer that clicks it is resting on the row, and the row holds the
+  // hover-freeze gate from its mouseenter. The click turns the row into a pointer-inert ghost (reduced motion
+  // removes it outright), and neither fires a mouseleave of its own; a card's Clear dispatches a synthetic
+  // mouseleave for exactly this reason. Without the header's own dispatch, the kernel's confirmation of the
+  // clear and every push behind it stayed queued until a later local render healed the stale hold, or a
+  // window blur. No timer advances before the release is asserted: the 180 ms finalize's render would heal
+  // the hold on its own (the stand-in's :hover matches nothing), and the point is the click, not the heal.
+  const ha = body.querySelector(`.feed-sess-head[data-fsid="${API}"]`)!;   // api heads one run: its one card, g2
+  assert.ok(!ha.classList.contains("sess-exit"));
+  const g2it = card("g2")._it;                                   // the object g2 was painted from (its column too)
+  const g1d = cardOf("g1d", WEB, "web", "#3366cc", "Document the notes-api health route", "working");
+  ha.dispatchEvent(new Event("mouseenter"));                     // the pointer rests on api's header row, over its Clear all
+  try {
+    await dispatch(frame([g1, g2it, card("g3")._it, g1d]));      // a push while it is held: one more web card
+    assert.equal(card("g1d"), null, "the payload is queued");
+    // the click takes the path a real one takes: the delegate on the stable columns root, with the row's Clear
+    // all as its target. The stand-in's events do not bubble, so the click is dispatched on the root with the
+    // button shadowing its target; the delegate resolves the button by its data-act and reads its data-fsid.
+    const cols = body.byId("feed-cols")!;
+    const btn = (ha as any)._clear as El;
+    const postedBefore = posted.length;
+    const click = new Event("click");
+    Object.defineProperty(click, "target", { value: btn });
+    cols.dispatchEvent(click);
+    const clears = posted.slice(postedBefore).filter((m) => m.type === "askClearMany");
+    assert.deepEqual(clears.map((m) => [m.sid, m.itemIds]), [[API, ["g2"]]], "the click cleared the session's one card");
+    assert.ok(card("g2").classList.contains("dismissing"));
+    assert.ok(ha.classList.contains("sess-exit"), "the header ghosts in the same click");
+    assert.equal(card("g1d"), null, "the release waits for the click's own handlers to finish");
+    await settle();                                                // the flush is a microtask after the click's handlers
+    assert.ok(card("g1d"), "the click released the gate: the queued frame applied with no pointer leave and no render");
+    assert.equal(body.byId("freeze-headnote"), null, "nothing pending: the hint came off");
   } finally {                                                    // on a failure too, so the next test inherits neither
     win.dispatchEvent(new Event("blur"));                        // a held gate (the backstop release) nor a cleared g2
     await settle();

--- a/ui/webview/feed-sess-clear.test.ts
+++ b/ui/webview/feed-sess-clear.test.ts
@@ -62,7 +62,8 @@ test("one click, one Undo batch on the client AND on the kernel, through the gro
     "ONE kernel batch: N askClear posts stamped N batches and the kernel's Undo restored only the last");
   assert.doesNotMatch(fn, /type: "askClear",/, "no per-member posts");
   assert.match(fn, /c\.dispatchEvent\(new MouseEvent\("mouseleave"\)\); c\.classList\.add\("dismissing"\);/, "flush the hover highlight, animate out");
-  assert.match(fn, /if \(head\.getAttribute\("data-fsid"\) === sid\) startSessHeadExit\(key, head\);/, "every column's header leaves with its run, one motion");
+  assert.match(fn, /if \(head\.getAttribute\("data-fsid"\) === sid\) \{ head\.dispatchEvent\(new MouseEvent\("mouseleave"\)\); startSessHeadExit\(key, head\); \}/,
+    "every column's header leaves with its run, one motion; the row's hover-freeze gate is released by the click, as a card's is");
   assert.match(fn, /setTimeout\(\(\) => \{[\s\S]*stillOurs\(\) && c\.classList\.contains\("dismissing"\)[\s\S]*dropDismissed\(ids\.filter\(\(id\) => pendingCleared\.has\(id\)\)\);\s*\n\s*\}, 180\);/,
     "finalize after the 180ms exit only what is still ours and still dismissing; drop only ids still pending (an Undo inside the window keeps its cards)");
   assert.doesNotMatch(fn, /confirm\(/, "no confirm dialog: Undo is the safety net");

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -4393,7 +4393,12 @@ function clearSessionCards(sid: string): void {
     if (turns.has(tid) && ((g as any)._g as AskGroup | undefined)?.sid === sid) leaving.push([g, () => groupEls.get(tid) === g, () => groupEls.delete(tid)]);
   }
   for (const [c] of leaving) { c.dispatchEvent(new MouseEvent("mouseleave")); c.classList.add("dismissing"); }
-  for (const [key, head] of Array.from(sessHeadEls)) if (head.getAttribute("data-fsid") === sid) startSessHeadExit(key, head);
+  // The header row holds the hover-freeze gate too, and its Clear all sits on the row: the pointer that clicked it
+  // is resting on the row by construction. The ghost is pointer-inert (and reduced motion removes the row outright),
+  // so no mouseleave of its own ever fires; dispatch the synthetic one, as the card loop above does, so the release
+  // comes from the click and the kernel's confirmation of the clear applies at once instead of queueing behind
+  // the hold. freezeLeave ignores a key it does not hold, so the session's headers in the other columns are safe.
+  for (const [key, head] of Array.from(sessHeadEls)) if (head.getAttribute("data-fsid") === sid) { head.dispatchEvent(new MouseEvent("mouseleave")); startSessHeadExit(key, head); }
   clearedStack.push(members.slice());   // one batch: one Undo brings the whole session back
   for (const m of members) pendingCleared.add(m.itemId);
   vscodeApi?.postMessage({ type: "askClearMany", itemIds: ids, sid });   // ONE kernel batch (see above)


### PR DESCRIPTION
## Symptom

In grouped mode, with the pointer resting on a session header row, clicking the row's Clear all starts the cards' exit and ghosts the row, but the next push does not apply. The kernel's confirmation of the clear, and every frame behind it, shows as pending on the headers until something else releases the hold: the local render of the 180 ms finalize, and only when no card is under the pointer, or a window blur. Under reduced motion the row is removed outright, so the release cannot come before that render.

## Cause

A header row holds the hover-freeze gate from its mouseenter (T285), keyed `h:<col>:<sid>`, and releases it on its own mouseleave. `clearSessionCards` dispatches a synthetic mouseleave on each leaving card, whose key is the card's own, and hands every header of the session straight to `startSessHeadExit`. `freezeLeave` releases only the key it holds, so the card dispatches leave the header's key held; the ghost is pointer-inert (`.sess-exit`, or removed under reduced motion), so no mouseleave of its own ever fires. A card's Clear has dispatched a synthetic mouseleave for this reason since 2026-07-03; the header path lacked it.

## Fix

`clearSessionCards` dispatches a synthetic mouseleave on every header of the session before starting its exit, the way the card loop just above it does. The release comes from the click: the flush's microtask applies the queued frame after the click's own handlers finish, so `pendingCleared` and the `askClearMany` post precede the render, as on the card path. `freezeLeave` ignores a key it does not hold, so the session's headers in the other columns are unaffected. The dispatch stays out of `startSessHeadExit`, which serves two other callers where the pointer is not on the row: `reconcileCol`'s render-time header exits, where the stale-freeze heal at the end of the render already covers a hovered element the render removed, and `dressHeaderIfLast` on a card's Clear, where the pointer is on the card and the card's own synthetic mouseleave releases the key it holds. The release belongs beside the card loop's, in the gesture that ghosts the row.

## Tests

- `ui/webview/feed-render-incremental.test.ts`, new case "a session header's Clear all releases the gate its row holds: the queued frame applies from the click, with no pointer leave and no render". With the pointer on the api session's header row and a push queued behind the hold, the row's Clear all is clicked through the delegate on the columns root (the stand-in's events do not bubble, so the click is dispatched on the root with the button shadowing its target). It asserts one `askClearMany` post for the session's card, the ghosted row, the frame still queued until the click's handlers finish, then the queued card rendered and the pending hint gone, with no timer advanced (the 180 ms finalize's render would heal the hold by itself). Before the change it fails on "the click released the gate: the queued frame applied with no pointer leave and no render": the queued card is still absent after the microtasks settle.
- Same file, the header badge test: its held-gate dispatch moves inside the `try`, so a throw there still reaches the release in its `finally` (noted in the review of #1232).
- `ui/webview/feed-sess-clear.test.ts`: the source pin on the header loop follows the new text; before the change it fails on the loop's old text.
- `npm run typecheck` clean. Full `npm test` over the built bundles: 4043 pass, 0 fail (4021 in the main run, 22 in the timeline-tags-scale file, run alone).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)