### PR TITLE
Markdown images: a stale probe failure leaves a fresh budget and a newer probe alone

### DIFF
--- a/ui/webview/md-img-park.test.ts
+++ b/ui/webview/md-img-park.test.ts
@@ -8,7 +8,9 @@
 // the per-message path, and that budget rides the URL, so a turn re-rendered on every push while it streams still gets
 // its three probes, a second img with the URL failing midway starts nothing over, a load clears the budget with the
 // memory (the URL failing again later starts afresh), and a heal that lands while a probe is pending is not undone by
-// that probe's failure; the reconnect-class heal probes every remembered URL, on the page or not (a turn evicted from
+// that probe's failure, nor does that probe's failure, arriving after the URL has failed AGAIN, shorten or delete
+// the fresh budget or clear a newer probe's in-flight mark (a failure counts only for the probe whose token
+// is current); the reconnect-class heal probes every remembered URL, on the page or not (a turn evicted from
 // the rendered window, a closed tab); and the chat's post-pass parks a re-rendered img with a remembered URL before the
 // browser fetches it. The module remembers failed URLs for the page life, so fresh() heals every remembered URL off
 // the DOM through the public reconnect path before each test: every test starts with an empty memory.
@@ -224,6 +226,81 @@ test("a reconnect heal that lands while a per-message probe is pending stands: t
   assert.equal(probes.length, 2, "the stale failure re-armed no attempt for a healed URL: the next pushes probe nothing");
   P.refreshSettledPreviews();
   assert.equal(probes.length, 2, "…and the reconnect heal has forgotten it");
+});
+
+// The stale-failure race (the review's find on the budget change): a reconnect heal loads the URL while a per-message
+// probe is pending, the URL fails AGAIN before that probe's error arrives (the file moved away, a relay blipped), and
+// the listener arms three attempts afresh. The stale error then belongs to a probe a load already retired: it must spend
+// none of the fresh attempts and clear no newer probe's in-flight mark. Its `left` is the OLD budget's, so applying it
+// deleted the fresh budget outright (one attempt left at fire time) or cut it to two (three left), and its delete of the
+// in-flight mark let the next push fire a second probe for a URL whose newer probe was still pending.
+
+test("a stale failure from a probe fired with the last attempt does not delete the budget the URL's re-fail armed afresh", async () => {
+  const P = await fresh();
+  const url = servedUrl("heatmap.png");
+  const s = mdImg(url, "Heatmap");
+  fail(s);
+  P.retryFailedPreviews(); probes[0].onerror();      // attempt one spent
+  P.retryFailedPreviews(); probes[1].onerror();      // attempt two spent
+  P.retryFailedPreviews();                           // the last attempt's probe is in flight
+  assert.equal(probes.length, 3);
+  P.refreshSettledPreviews();                        // the socket came back meanwhile
+  assert.equal(probes.length, 4, "the reconnect heal probes the URL too");
+  (probes[3] as any).onload();                       // the reconnect probe answers first: healed, the picture lands
+  assert.equal(s.src, url);
+  fail(s);                                           // the URL fails again: three attempts afresh
+  assert.equal(s.hasAttribute("src"), false, "parked again");
+  probes[2].onerror();                               // the older per-message probe's failure arrives only now
+  P.retryFailedPreviews();
+  assert.equal(probes.length, 5, "the fresh budget survives the stale failure: the next push probes");
+  probes[4].onerror();
+  P.retryFailedPreviews(); probes[5].onerror();
+  P.retryFailedPreviews(); probes[6].onerror();
+  P.retryFailedPreviews(); P.retryFailedPreviews();
+  assert.equal(probes.length, 7, "the fresh budget was a full three: the stale failure spent none of them");
+});
+
+test("a stale failure from a probe fired with three attempts does not shorten the budget the URL's re-fail armed afresh", async () => {
+  const P = await fresh();
+  const url = servedUrl("flamegraph.png");
+  const s = mdImg(url, "Flame graph");
+  fail(s);
+  P.retryFailedPreviews();                           // the first probe is in flight with all three attempts
+  assert.equal(probes.length, 1);
+  P.refreshSettledPreviews();
+  (probes[1] as any).onload();                       // the reconnect probe answers first: healed
+  assert.equal(s.src, url);
+  fail(s);                                           // the URL fails again: three attempts afresh
+  probes[0].onerror();                               // the older per-message probe's failure arrives only now
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    P.retryFailedPreviews();
+    assert.equal(probes.length, 2 + attempt, "push " + attempt + " after the re-fail: one probe, the fresh budget intact");
+    probes[probes.length - 1].onerror();
+  }
+  P.retryFailedPreviews(); P.retryFailedPreviews();
+  assert.equal(probes.length, 5, "three attempts after the re-fail, then spent");
+});
+
+test("a stale failure does not clear a newer probe's in-flight mark: no two probes for one URL overlap", async () => {
+  const P = await fresh();
+  const url = servedUrl("waterfall.png");
+  const s = mdImg(url, "Waterfall");
+  fail(s);
+  P.retryFailedPreviews();                           // the first probe is in flight
+  P.refreshSettledPreviews();
+  (probes[1] as any).onload();                       // the reconnect probe answers first: healed
+  assert.equal(s.src, url);
+  fail(s);                                           // the URL fails again: three attempts afresh
+  P.retryFailedPreviews();                           // the fresh budget's first probe is in flight
+  assert.equal(probes.length, 3);
+  probes[0].onerror();                               // the older probe's failure arrives while the newer one is pending
+  P.retryFailedPreviews(); P.retryFailedPreviews();
+  assert.equal(probes.length, 3, "a push while the newer probe is pending fires no second probe for the URL");
+  probes[2].onerror();                               // the newer probe fails: one fresh attempt spent
+  P.retryFailedPreviews(); probes[3].onerror();
+  P.retryFailedPreviews(); probes[4].onerror();
+  P.retryFailedPreviews(); P.retryFailedPreviews();
+  assert.equal(probes.length, 5, "the fresh budget ran its three attempts, one probe at a time");
 });
 
 test("the reconnect-class heal probes a remembered URL whose turn is outside the rendered window", async () => {

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -771,7 +771,8 @@ export function refreshSettledPreviews(): void {
 // bubble but do capture); previews' own <img>s are skipped: their machinery (budgets, resume, chips) owns those.
 const mdImgFailed = new Set<string>();             // URLs that failed this page life: a re-render parks them before any fetch
 const mdImgProbe = new Map<string, number>();      // served URLs with per-message attempts left: the budget rides the URL, not the img
-const mdImgProbing = new Set<string>();            // served URLs with a per-message probe in flight: one at a time per URL
+const mdImgProbing = new Map<string, number>();    // served URLs with a per-message probe in flight, by that probe's token: one at a time per URL
+let mdImgProbeSeq = 0;                             // the tokens: a failure counts only for the probe whose token is still the URL's
 let mdImgHealOn = false;
 function parkMdImg(img: HTMLImageElement, url: string): void {
   mdImgFailed.add(url);
@@ -823,15 +824,20 @@ function probeMdImgUrl(u: string, onFail?: () => void): void {
 /** The per-message path for the served URLs with attempts left: one detached probe per URL per push, the next armed
  *  only once the previous has failed (a push while it is pending fires nothing), whatever img carries the URL now and
  *  whether or not one is on the page (the probe is off the DOM; a load re-queries the page). Run from
- *  retryFailedPreviews, so it rides the kernel-message event like the figure previews' own retries. */
+ *  retryFailedPreviews, so it rides the kernel-message event like the figure previews' own retries. Each probe holds a
+ *  token, and its failure counts only while that token is still the URL's: a load of the URL by any probe retires it,
+ *  and the URL may since have failed again with a fresh budget and a newer probe in flight, so a stale failure spends
+ *  nothing and clears nothing (a bare in-flight check is not enough: the newer probe has re-marked the URL). */
 function retryMdImgProbes(): void {
   for (const [u, left] of Array.from(mdImgProbe.entries())) {
     if (mdImgProbing.has(u)) continue;
-    mdImgProbing.add(u);
+    const token = ++mdImgProbeSeq;
+    mdImgProbing.set(u, token);
     probeMdImgUrl(u, () => {
+      if (mdImgProbing.get(u) !== token) return;   // retired by a load meanwhile: the fresh budget and any newer probe stand
       mdImgProbing.delete(u);
-      if (left > 1 && mdImgFailed.has(u)) mdImgProbe.set(u, left - 1);   // still down: one attempt spent
-      else mdImgProbe.delete(u);                                          // spent (or healed meanwhile): the reconnect heal alone from here
+      if (left > 1) mdImgProbe.set(u, left - 1);    // still down: one attempt spent
+      else mdImgProbe.delete(u);                     // spent: the reconnect heal alone from here
     });
   }
 }


### PR DESCRIPTION
## Symptom
A markdown image the kernel serves (a `/file` or `/media` URL) fails, its per-message probe is in flight, a reconnect heal loads the URL, and then the URL fails again before that probe's error arrives (the file moved away, a relay blipped). The second failure arms three attempts afresh, but the late error takes them: one push later the image probes nothing, or once or twice instead of three times, and its caption waits for the next reconnect. The same late error can also let two probes for one URL overlap.

## Cause
`retryMdImgProbes` (`ui/webview/preview.ts`, from #1245) marked a URL in flight in a Set, and its failure callback applied the attempts-left it captured at fire time, with a check of the failed-URL memory standing in for "was this probe retired". A load of the URL by any probe clears the in-flight mark and the memory, and the URL's next failure re-arms both, so the stale error passed the memory check with the OLD count: it deleted the fresh budget (one attempt left at fire time) or cut it to two (three left), and its delete of the in-flight mark let the next push fire a second probe while the newer one was pending. A bare "still in flight" check is not enough either: the newer probe has re-marked the URL.

## Fix
`mdImgProbing` is a `Map<string, number>` from URL to the token of the probe in flight. Each probe `retryMdImgProbes` fires takes a fresh token, and its failure callback returns first when the URL's token is no longer its own, so a stale failure spends nothing and clears nothing. The memory check goes, since the token check covers it: the only path that forgets a URL is a load, and a load retires the in-flight token. The load path is unchanged (it deletes the URL from the map as it did from the set).

Two limits stay as they were, on purpose: a per-message probe that never settles keeps its URL marked in flight until some probe of it loads (a failing reconnect probe passes no failure callback, so it never clears the mark), and the failed-URL memory is page-life and uncapped.

## Tests
Three new cases in `ui/webview/md-img-park.test.ts`, each executed over the file's fake DOM through the public paths (`retryFailedPreviews`, `refreshSettledPreviews`, the capture-phase error listener), each red before the change:
- a stale failure from a probe fired with the last attempt does not delete the budget the URL's re-fail armed afresh: fails before on "the fresh budget survives the stale failure: the next push probes" (4 probes, expected 5)
- a stale failure from a probe fired with three attempts does not shorten the budget the URL's re-fail armed afresh: fails before on "push 3 after the re-fail: one probe, the fresh budget intact" (4, expected 5)
- a stale failure does not clear a newer probe's in-flight mark: no two probes for one URL overlap: fails before on "a push while the newer probe is pending fires no second probe for the URL" (4, expected 3)

A bare in-flight check in place of the token check (return when the URL has no probe in flight) turns only the third case red: the newer probe has re-marked the URL, so the stale failure passes it and shortens the fresh budget as it clears the mark. Removing the token check turns all three red, with the existing heal-while-pending case (the token check now covers what the removed memory check did).

The file's eight existing cases stay green (11 of 11 after). `npm run typecheck` clean. Full `npm test` on this head: 4070 tests, 4070 pass, 0 fail.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)