### PR TITLE
Tests: the comment-create tests start from empty create memos

### DIFF
--- a/tests/test_comment_create_idempotent.py
+++ b/tests/test_comment_create_idempotent.py
@@ -89,6 +89,15 @@ class CreateIsIdempotent(unittest.TestCase):
         jd._discover_cache.clear()
         jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         km._thread_msgs_cache.clear()
+        # the create memos start empty as well (review, 2026-09-09): the tests reuse the same create ids
+        # under one parent sid, so an id a previous test noted would name a thread id this test's fresh
+        # store can hold too, and a fresh gesture here would be answered as a repeat; random thread ids
+        # keep that from happening by chance today, and the clears make the order not matter. The noted
+        # creates are the memo a passing test leaves behind; the in-flight set and the parked list are
+        # empty at the end of every passing test, so their clears keep a test that failed part-way from
+        # failing the next one too. Under the lock every writer of the three memos takes.
+        with km._create_lock:
+            km._recent_creates.clear(); km._inflight_creates.clear(); km._parked_creates.clear()
         self.now = int(time.time())
         cdir = str(Path(self._td) / "work")
         self.proj = jd._proj_dir(cdir)


### PR DESCRIPTION
Builds on #1236 (merged). The tests it added in tests/test_comment_create_idempotent.py keep the kernel's create memos across tests; this clears them in setUp. Tests only, nine added lines, no kernel change.

## Symptom

Nothing visible: the module passes today in every order. A review of #1236 found that setUp clears km._thread_msgs_cache but not the three create memos (km._recent_creates, km._inflight_creates, km._parked_creates), while the tests reuse the same create ids (g-1111, g-2222) and the same words under one parent sid. The module is order-independent by chance: thread ids are random uuid4s, so a thread id an earlier test noted is never a thread in the next test's fresh store.

## Cause

_repeat_create_tid answers a create whose key is in _recent_creates with the noted thread when that thread is open in the store. The key is (parent sid, create id), the same from one test to the next; only the noted thread id differs, and only because random uuid4s do not collide. If an earlier test's noted thread id appeared in a later test's store, that test's fresh gesture would be answered as a repeat: one thread where its assertion expects two. _recent_creates is the memo a passing test leaves behind; _inflight_creates is emptied by _release_create in every door's finally and _parked_creates is empty at the end of every passing test, so those two carry content only after a test fails part-way.

## Fix

setUp clears the three memos beside the existing cache clear, under km._create_lock, the lock every writer of the memos takes, with a comment saying why. The _recent_creates clear removes the dependence on random ids; the other two keep a test that failed part-way (a copy left parked) from failing the next one too. This is isolation, not a behaviour fix: no kernel code changes and no assertion changes.

## Tests

The hazard was shown in a scratch run, not kept: the module's test class with uuid4 stubbed so each test's first thread takes the same id (uuid.UUID(int=1), then 2, and so on), run against the module before and after this change. Two ordered scratch tests: the first posts create id g-1111; the second, in its own fresh store, posts a first thread with g-2222 and then a fresh gesture with g-1111 and expects two threads. Before the change the second fails with `1 != 2 : a fresh gesture is a second thread`, and under the same stub three of the module's own tests fail the same way (test_a_frame_without_a_create_id_still_keys_on_the_words, test_a_fresh_gesture_after_a_parked_create_landed_is_a_second_thread_and_its_repost_is_not, test_a_fresh_gesture_in_the_same_words_on_the_same_passage_is_a_second_thread): 4 failed, 12 passed. After the change, same stub: 16 passed. With only the _recent_creates clear removed the same four fail again; with only that clear kept all 16 pass, which is why the body calls the other two clears defensive.

Without the stub the module passes before and after in default, reverse and two seeded shuffled orders (14 passed each); the stub is what makes the carried memo visible.

Full suite (pytest -n 6): 10572 passed, 115 skipped, 0 failed.

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)