### PR TITLE
The turn-finished push buzzes only for turns the human opened

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -632,10 +632,12 @@ switches indented under it, and a button:
   main switch off, the row says the device is set up but nothing arrives until
   the main switch is on.
 - **Also when a turn finishes**, also under it, adds a notification every time
-  any session finishes a turn, with the session's name and the first line of
-  what it said. With many sessions running this is a lot of buzzing, so it is
-  off unless you want it. A turn that ends by asking you something buzzes once,
-  not twice.
+  any session finishes a turn you started, with the session's name and the
+  first line of what it said. Turns a session starts on its own, such as
+  reacting to one of its background agents finishing, or to a reminder, stay
+  quiet: nothing there was waiting on you. With many sessions running this is
+  still a lot of buzzing, so it is off unless you want it. A turn that ends by
+  asking you something buzzes once, not twice.
 - **Send a test notification** sends one notification to the device you are
   holding, whatever the switches say, and prints the push service's answer under
   the button, so you can see at once whether the phone is set up or why it is

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -42375,24 +42375,47 @@ def _push_forward(events):
 # event yields on the phone (the desktop notice and the badge still fire — they are not the buzz).
 # Bell events never yield to EACH OTHER: two cards of one session moving in one build buzz twice,
 # exactly as before this rule existed.
+#
+# THE HUMAN'S TURNS ONLY (2026-09-10): a session running background subagents gets a harness-injected
+# user-role turn per completion (the task notification — origin.kind "task-notification"), reacts to
+# it, and that reaction's Stop stamps lastStopAt like any other end — ten buzzes in fifty minutes from
+# one coordinating session, none about anything the user had asked at that moment. The Stop hook stamps
+# WHO opened the turn beside the settle (lastTurnOpener, sdk_backend `_stop_hook`, from the two places
+# a turn can open: the feeder's pop — a fed text, the human's unless it carries the romp-injected
+# marker — and a stamped user atom the CLI streams while idle), and the tick skips an end whose opener
+# is not the human WITHOUT spending the buzz claim, so a bell event that turn raises keeps its buzz. A
+# registry without the field (an older ledger, a tmux session) reads as the human's: a missing fact
+# never drops the user's buzz.
 _TURN_PREV = {}      # sid -> turn-end key at the last tick; absent = baseline pending
 _PUSH_BUZZED = {}    # sid -> (turn-end key, "turn"|"bell") of the last phone buzz filed for it
 _TURN_BODY_CAP = 120
 
 
-def _turn_end_key(sid):
+def _turn_end_key(sid, reg=None):
     """The session's newest TURN-END as an opaque key, 0 when there is no settle evidence. Like
     _settle_event_key, the Stop hook's lastStopAt is primary; the fallback is stricter — only a
     STOPPED states/ transition ('waiting'/'idle') counts, because _last_state also moves when a
-    turn STARTS and a start must never read as an end here."""
+    turn STARTS and a start must never read as an end here. `reg`: the session's registry entry
+    when the caller already holds one (the tick reads it ONCE for this and the opener beside it)."""
     try:
-        t = int((_thread_reg(sid) or {}).get("lastStopAt") or 0)
+        t = int((reg if reg is not None else _thread_reg(sid) or {}).get("lastStopAt") or 0)
     except Exception:
         t = 0
     if t:
         return t
     val, vt = _last_natural_state(sid)          # the session's own settle — never the idle romp wrote for a Stop press
     return (vt or 0) if val in ("waiting", "idle") else 0
+
+
+def _turn_opener(reg):
+    """Who opened the turn `lastStopAt` closed, off the registry entry the Stop hook stamps it on
+    beside the settle: "human" (the composer's words, a queued message, a typed follow-up) or
+    "injected" (a harness-injected task notification / scheduled prompt / peer message, or romp's own
+    nudge, follow-up, notice or relayed mail). Anything else — the field absent (an older ledger, a
+    tmux session) or a value the hook never writes — reads "human": a missing fact never drops the
+    user's buzz."""
+    v = (reg or {}).get("lastTurnOpener") if isinstance(reg, dict) else None
+    return v if v in ("human", "injected") else "human"
 
 
 
@@ -42423,20 +42446,27 @@ def _first_line(text, cap=_TURN_BODY_CAP):
 
 def _turn_notify_tick(now, tmux):
     """One pusher-cycle pass over the live sessions: a session whose turn-end key MOVED since the
-    last pass finished a turn. Fires only with both switches on and the session unmuted; every
-    sighting advances the memo regardless, so switching the row on later never replays old ends."""
+    last pass finished a turn. Fires only with both switches on, the session unmuted, and the turn
+    the HUMAN's (_turn_opener — a subagent's task notification or a nudge opening a turn is not news
+    to them); every sighting advances the memo regardless, so switching the row on later never
+    replays old ends and a silent end is never replayed either."""
     fired = []
     for s in _alive_sessions(now, tmux):
         sid = str(s.get("sid") or "")
         if not sid:
             continue
-        key = _turn_end_key(sid)
+        reg = _thread_reg(sid)                           # one read: the settle and its opener are one Stop-hook write
+        key = _turn_end_key(sid, reg)
         prev = _TURN_PREV.get(sid)
         _TURN_PREV[sid] = key
         if prev is None or key == prev or not key:
             continue                                     # baseline / nothing new / no settle evidence
         if not (_notify_all_on() and _notify_turns_on() and _notify_session_effective(sid)):
             continue
+        if _turn_opener(reg) != "human":
+            continue                                     # the CLI or romp opened this turn (a subagent's task notification,
+            #                                              a scheduled prompt, a nudge): nobody asked the user anything, so
+            #                                              nothing to buzz about — and no claim spent, the bell event's is its own
         if not _buzz_claim(sid, key, "turn"):
             continue                                     # a bell event already buzzed for this turn end
         body = _first_line(_last_assistant_text(s.get("path") or "")) or "finished a turn"

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2614,6 +2614,16 @@ CRASH_RESUME_NUDGE = (
     "<!-- romp-gist: resumed after its process died mid-turn -->")
 
 
+def fed_text_opener(text: str) -> str:
+    """Who a text we FEED the CLI speaks for: "injected" when it carries the romp-injected marker (a nudge,
+    a follow-up romp wrote, a restart or rename notice, relayed mail, the retry line: everything romp puts
+    into a session on its own), "human" otherwise (the composer's words, a queued message, a typed
+    follow-up, a button's /command). The COMMENT FORM only, the rule send()'s echo authoring and the event
+    model's ROMP_INJECT_RE follow: prose that merely mentions the marker is the user's. Feeds the turn-
+    opener stamp (SdkSession._note_turn_opener), whose reader is the kernel's turn-finished push."""
+    return "injected" if "<!-- romp-injected -->" in (text or "") else "human"
+
+
 # A CLI that cannot even START says so on the way out — and the ONE cause that reliably does this is the
 # account being out of usage: `claude` refuses the handshake and exits with the limit in its own words
 # ("You've hit your session limit · resets 1:10pm (America/Los_Angeles)"). romp used to swallow that
@@ -3870,6 +3880,16 @@ class SdkSession:
         # _cli_working mirrors the last lifecycle state we persisted so the live stream can re-assert
         # 'working' if a stamp ever falls behind actual output, with no reliance on feed-vs-result counting.
         self._cli_working = False
+        # WHO OPENED the turn in flight — "human" (any fed text without the romp-injected marker: the
+        # composer's words, a queued message, a typed follow-up, a button's /command) or "injected" (romp's
+        # own feed — a nudge, a follow-up, a restart notice, relayed mail — or a turn the CLI opened by
+        # itself: a background task's notification, a scheduled prompt, a peer's channel message, told by
+        # the streamed record's origin stamp). None until an open is seen. Set at the two places a turn can
+        # open (the feeder's pop; _forward's stamped user atom while idle — see _note_turn_opener), stamped
+        # beside lastStopAt by the Stop hook as lastTurnOpener, and read by the kernel's turn-finished push,
+        # which buzzes the phone for the human's turns only (the user 2026-09-10: ten buzzes in fifty minutes
+        # from one session reacting, turn after turn, to its own background subagents' completions).
+        self._turn_opener = None
         self._skill_tool_ids = set()   # Skill tool_use ids seen on THIS stream → classify their injected
         #                                instructions payload (parent_tool_use_id link) as a skillMd atom
         self.since = 0
@@ -5008,6 +5028,7 @@ class SdkSession:
                     self.since = int(time.time())    # a new turn starts now (mid-turn forwards keep the turn's clock)
                     self._interrupted = False        # a fresh turn → clear any stale interrupt flag
                     self._intr_level = 0             #   ...and its escalation episode (a new stop starts polite)
+                self._note_turn_opener(fed_text_opener(item), fresh)   # who this turn is for (the Stop hook stamps it)
                 if item.startswith(RENAME_PING_HEAD):
                     self._ping_feeding = True       # hold feeds until this turn's first streamed message
                 self._mark("working")
@@ -5354,6 +5375,17 @@ class SdkSession:
             return "\n".join(self._stderr_tail)
         except Exception:
             return ""
+
+    def _note_turn_opener(self, opener: str, fresh: bool) -> None:
+        """Record who opened, or joined, the turn in flight (see _turn_opener in __init__). A HUMAN text
+        always makes the turn theirs: from idle it opens one; mid-turn the CLI splices it in at the next
+        tool boundary and answers it there, so the person asked during the turn and its end IS news to
+        them. An INJECTED opener counts only from idle (`fresh`): a nudge fed into the human's running turn,
+        or a task notification the CLI folds into it, does not take the turn from them. Never reset at the
+        settle: the next open overwrites, and the Stop hook (which runs BEFORE the ResultMessage) reads the
+        turn it is closing."""
+        if fresh or opener == "human":
+            self._turn_opener = opener
 
     def _mark(self, state: str) -> None:
         """Persist a lifecycle STATE to states/<sid>.jsonl AND track whether the CLI is producing.
@@ -6362,9 +6394,14 @@ class SdkSession:
             self.backend._log("stop hook (%s): bg-ledger reconcile failed: %s" % (self.name, e))
         # The turn-end EVENT itself, durable and kernel-readable (2026-08-29, for the nudge layer's
         # memo re-arm and any consumer that needs "this session settled a turn at T" as a fact
-        # rather than an inference from transcript mtimes — romp_cards' round keys on it).
+        # rather than an inference from transcript mtimes — romp_cards' round keys on it). Beside it,
+        # in the SAME write so a reader never pairs one turn's settle with another's opener, WHO opened
+        # the turn (2026-09-10, see _turn_opener): the kernel's turn-finished push buzzes the phone for
+        # the human's turns only. No open seen (a session object born mid-turn at a kernel restart, a
+        # CLI that stamps no origin) reads "human" — fail OPEN on the buzz, never silently drop it.
         try:
-            self.backend._update_reg(self.sid, lastStopAt=int(time.time()))
+            self.backend._update_reg(self.sid, lastStopAt=int(time.time()),
+                                     lastTurnOpener=getattr(self, "_turn_opener", None) or "human")
         except Exception:
             pass
         # delete-while-busy: the turn this delete interrupted has ENDED — complete the arm here,
@@ -11454,6 +11491,17 @@ class SdkBackend:
             self._touch_live(sess.sid)
         if vanished:
             self._note_live_tail_race("_evict_live_overflow")
+        # A user atom the CLI streams WHILE IDLE, wearing an injected provenance stamp, is a turn the CLI
+        # opened by itself — a background task's notification, a scheduled prompt, a peer's channel
+        # message — never the composer's words: a fed text is not replayed on the stream
+        # (replay-user-messages stays off, see _options), so its opener was noted at the feeder's pop.
+        # Only the CLI's own stamp says so (atom["origin"], msg_to_atom); a stamp-less user atom (a tool
+        # result) or a "human" stamp says nothing. Judged BEFORE the working re-assert below, and only
+        # while nothing is in flight: the same stamp arriving mid-turn is a splice into the running turn,
+        # which keeps its opener (see SdkSession._note_turn_opener).
+        okind = (atom.get("origin") or {}).get("kind") if atom.get("type") == "user" else None
+        if okind and okind != "human" and not getattr(sess, "inflight", 0) and not sess._cli_working:
+            sess._note_turn_opener("injected", True)
         # The stream is the AUTHORITATIVE busy signal: a genuine WORK atom (streamed assistant/tool
         # output — not an input echo, not a /model-style command line) means the CLI is producing RIGHT
         # NOW, so re-assert 'working' if a prior state write settled ahead of it (e.g. a separate turn

--- a/tests/test_kernel_notify_popover.py
+++ b/tests/test_kernel_notify_popover.py
@@ -18,7 +18,10 @@ What these pin, by layer:
   * the turn-finished push — _turn_notify_tick fires on a session's turn-end KEY moving (the Stop
     hook's lastStopAt, or a STOPPED states/ transition), only with the master AND the switch on
     and the session unmuted, with a silent first-sight baseline; the event travels to trusted
-    peers the bell-event way.
+    peers the bell-event way. Since 2026-09-10 it fires for the HUMAN's turns only: the Stop hook
+    stamps who opened the turn beside the settle (lastTurnOpener, sdk_backend) and an end the CLI
+    or romp opened by itself (a subagent's task notification, a scheduled prompt, a peer's message,
+    a nudge) is skipped without spending the buzz claim; a registry without the field reads human.
   * the one-buzz-per-turn-end rule — _buzz_claim: the bell event and the turn push both claim
     (sid, turn-end key); the first to file buzzes and the other yields; bell events never
     suppress each other; a sid-less event always passes.
@@ -28,6 +31,7 @@ What these pin, by layer:
 
 Synthetic only: placeholder sids, the notes-api demo sessions (web/api), invented reply text.
 """
+import asyncio
 import io
 import json
 import os
@@ -53,6 +57,8 @@ jd.STATE = Path(_STATE_TD.name)
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 km = SourceFileLoader("romp_kernel_notify_popover", os.path.join(BIN, "romp-kernel")).load_module()
+# the SDK backend, for the Stop hook's half of the turn-opener stamp (TurnOpenerStamp)
+sb = SourceFileLoader("romp_sdk_backend_turn_opener", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 SID_WEB = "11111111-2222-4333-8444-555555555501"
 SID_API = "11111111-2222-4333-8444-555555555502"
@@ -514,11 +520,15 @@ class RemoteNames(unittest.TestCase):
         self.assertIsNone(km._remote_name_of("nohost", SID_WEB))
 
 
-def _stamp_stop(sid, t):
-    """The Stop hook's ledger stamp — the SDK session's authoritative turn-end fact."""
+def _stamp_stop(sid, t, opener=None):
+    """The Stop hook's ledger stamp — the SDK session's authoritative turn-end fact. `opener` is the
+    lastTurnOpener the hook stamps beside it (2026-09-10); None leaves the field off, an older ledger's shape."""
     d = jd.STATE / "sdk"
     d.mkdir(parents=True, exist_ok=True)
-    (d / (sid + ".json")).write_text(json.dumps({"lastStopAt": int(t)}))
+    reg = {"lastStopAt": int(t)}
+    if opener is not None:
+        reg["lastTurnOpener"] = opener
+    (d / (sid + ".json")).write_text(json.dumps(reg))
 
 
 def _append_state(sid, state, t):
@@ -673,6 +683,251 @@ class TurnFinishedPush(unittest.TestCase):
         self.assertIn("_turn_notify_tick(now, tmux)", src)
         self.assertLess(src.index("_push_all(tmux=tmux)"), src.index("_turn_notify_tick(now, tmux)"),
                         "the feed builds first, so a same-settle bell event files its buzz first")
+
+
+class TurnOpenerGate(unittest.TestCase):
+    """The turn-finished push buzzes for the HUMAN's turns only (2026-09-10). A session running background
+    subagents gets a harness-injected user-role turn per completion (the task notification), reacts to it,
+    and that reaction's Stop stamped lastStopAt like any other end: ten buzzes in fifty minutes from one
+    coordinating session, none about anything the user had asked at that moment. The Stop hook now stamps
+    WHO opened the turn beside the settle (lastTurnOpener, sdk_backend) and the tick skips an end whose
+    opener is not the human — without spending the buzz claim, so a bell event that turn raises keeps its
+    buzz. A registry without the field (an older ledger, a tmux session) reads as the human's: a missing
+    fact never drops the user's buzz."""
+
+    def setUp(self):
+        _reset_store()
+        for p in (jd.STATE / "sdk", jd.STATE / "states"):
+            for f in p.glob("*") if p.exists() else []:
+                f.unlink()
+        km._set_notify_all(True)
+        km._set_notify_turns(True)
+        self.path = _transcript(SID_WEB, "The report is in; folding it into the plan.")
+        self.alive = [{"sid": SID_WEB, "name": "web", "path": self.path}]
+
+    def tearDown(self):
+        km._set_notify_all(False)
+        km._set_notify_turns(False)
+
+    def _tick(self):
+        pushed = []
+        with mock.patch.object(km, "_alive_sessions", return_value=self.alive), \
+             mock.patch.object(km, "_push_notify", side_effect=lambda *a, **k: pushed.append((a, k))), \
+             mock.patch.object(km, "_push_forward"):
+            fired = km._turn_notify_tick(time.time(), {SID_WEB: {"state": "waiting"}})
+        return fired, pushed
+
+    def test_a_turn_the_human_opened_buzzes_as_before(self):
+        _stamp_stop(SID_WEB, 1000, opener="human")
+        self._tick()                                                   # the baseline sighting
+        _stamp_stop(SID_WEB, 1001, opener="human")
+        fired, pushed = self._tick()
+        self.assertEqual(len(fired), 1)
+        self.assertEqual(pushed[0][0], ("Romp: web", "The report is in; folding it into the plan.", SID_WEB))
+
+    def test_a_turn_a_task_notification_opened_is_silent_and_spends_no_claim(self):
+        _stamp_stop(SID_WEB, 1000, opener="human")
+        self._tick()
+        _stamp_stop(SID_WEB, 1001, opener="injected")             # a subagent's completion, reacted to
+        fired, pushed = self._tick()
+        self.assertEqual((fired, pushed), ([], []), "nobody asked the user anything: no buzz")
+        self.assertNotIn(SID_WEB, km._PUSH_BUZZED, "the claim is untouched…")
+        self.assertTrue(km._buzz_claim(SID_WEB, 1001, "bell"), "…so a bell event that turn raises still buzzes")
+
+    def test_the_memo_advances_past_silent_ends_and_the_next_human_end_fires_once(self):
+        _stamp_stop(SID_WEB, 1000, opener="human")
+        self._tick()
+        for t in (1001, 1002, 1003):                                   # three completions, three reactions
+            _stamp_stop(SID_WEB, t, opener="injected")
+            self.assertEqual(self._tick()[0], [], t)
+        _stamp_stop(SID_WEB, 1004, opener="human")
+        self.assertEqual(len(self._tick()[0]), 1, "the human's next turn buzzes once; the silent ends never replay")
+        self.assertEqual(self._tick()[0], [])
+
+    def test_an_older_registry_without_the_field_is_the_humans(self):
+        _stamp_stop(SID_WEB, 1000)
+        self._tick()
+        _stamp_stop(SID_WEB, 1001)                                     # a pre-field ledger: lastStopAt alone
+        self.assertNotIn("lastTurnOpener", km._thread_reg(SID_WEB))
+        self.assertEqual(len(self._tick()[0]), 1, "a missing fact never drops the user's buzz")
+
+    def test_a_value_the_hook_never_writes_reads_as_the_humans(self):
+        _stamp_stop(SID_WEB, 1000, opener="human")
+        self._tick()
+        _stamp_stop(SID_WEB, 1001, opener=7)
+        self.assertEqual(len(self._tick()[0]), 1)
+        self.assertEqual(km._turn_opener({"lastTurnOpener": "injected"}), "injected")
+        self.assertEqual(km._turn_opener({"lastTurnOpener": "human"}), "human")
+        for junk in ({}, {"lastTurnOpener": None}, {"lastTurnOpener": "peer"}, None):
+            self.assertEqual(km._turn_opener(junk), "human", junk)
+
+    def test_the_opener_and_the_settle_come_off_one_registry_read_and_the_gate_precedes_the_claim(self):
+        # the pair is ONE Stop-hook write; reading the file twice could pair an older settle with a
+        # newer turn's opener (a lost buzz on the race)
+        import inspect
+        src = inspect.getsource(km._turn_notify_tick)
+        self.assertIn("reg = _thread_reg(sid)", src)
+        self.assertIn("_turn_end_key(sid, reg)", src)
+        self.assertLess(src.index("_turn_opener(reg)"), src.index('_buzz_claim(sid, key, "turn")'),
+                        "the gate sits before the claim, so a silent end spends nothing")
+
+
+class TurnOpenerStamp(unittest.TestCase):
+    """The backend's half of the gate: who opened the turn is a fact the session learns at the two moments a
+    turn can open — the feeder's POP (a fed text: the human's words, or romp's own marker-carrying nudge /
+    follow-up / restart notice / relayed mail) and a user atom the CLI STREAMS WHILE IDLE (a turn the CLI
+    opened by itself: a background task's notification, a scheduled prompt, a peer's channel message, told
+    by its origin stamp; a fed text is never replayed on the stream). The Stop hook stamps it beside
+    lastStopAt in the same write. Synthetic throughout: the notes-api demo session, invented prompt text."""
+
+    NUDGE = "Where does this stand?\n\n<!-- romp-injected --><!-- romp-auto -->"
+    NOTIF = "[SYSTEM NOTIFICATION - NOT USER INPUT]\n\n<task-notification>done</task-notification>"
+
+    class _TextBlock:
+        def __init__(self, text):
+            self.text = text
+
+    class _UserMessage:
+        def __init__(self, content, origin=None, uuid="u-1"):
+            self.content, self.uuid, self.tool_use_result, self.origin = content, uuid, None, origin
+
+    _TextBlock.__name__ = "TextBlock"
+    _UserMessage.__name__ = "UserMessage"
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.be, self.sess = self._session(self.d)
+
+    def _session(self, state_dir):
+        be = sb.SdkBackend(state_dir, "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None)
+        sb.write_reg(Path(state_dir), SID_WEB, {"sid": SID_WEB, "name": "web", "cwd": "/tmp", "alive": True})
+        return be, sb.SdkSession(be, sb.read_reg(Path(state_dir), SID_WEB))
+
+    def _streamed(self, origin, text=NOTIF, be=None, sess=None):
+        be, sess = be or self.be, sess or self.sess
+        be._forward(sess, self._UserMessage([self._TextBlock(text)], origin=origin, uuid="u-%d" % time.time_ns()))
+
+    def _stop(self):
+        asyncio.run(self.sess._stop_hook({}, None, None))
+        return sb.read_reg(Path(self.d), SID_WEB) or {}
+
+    def _idle(self):
+        self.sess.inflight = 0
+        self.sess._cli_working = False
+
+    def test_fed_text_opener_reads_the_marker_in_its_comment_form_only(self):
+        self.assertEqual(sb.fed_text_opener("fix the login redirect"), "human")
+        self.assertEqual(sb.fed_text_opener("/compact"), "human")                 # the user's own button
+        self.assertEqual(sb.fed_text_opener(self.NUDGE), "injected")
+        self.assertEqual(sb.fed_text_opener(sb.RENAME_PING_HEAD + " to x"), "injected")
+        self.assertEqual(sb.fed_text_opener("a typed note that mentions romp-injected in prose"), "human",
+                         "the comment form only, the rule send()'s echo authoring follows")
+        self.assertEqual(sb.fed_text_opener(""), "human")
+
+    def test_the_humans_text_opens_the_turn_as_theirs_and_the_stop_stamps_it_beside_the_settle(self):
+        self.sess._note_turn_opener(sb.fed_text_opener("fix the login redirect"), True)
+        reg = self._stop()
+        self.assertEqual(reg["lastTurnOpener"], "human")
+        self.assertAlmostEqual(reg["lastStopAt"], time.time(), delta=30)
+
+    def test_a_nudge_fed_from_idle_opens_an_injected_turn(self):
+        self.sess._note_turn_opener(sb.fed_text_opener(self.NUDGE), True)
+        self.assertEqual(self._stop()["lastTurnOpener"], "injected")
+
+    def test_a_nudge_folded_into_the_humans_turn_leaves_it_theirs(self):
+        self.sess._note_turn_opener("human", True)
+        self.sess._note_turn_opener(sb.fed_text_opener(self.NUDGE), False)     # mid-turn: the CLI splices it in
+        self.assertEqual(self._stop()["lastTurnOpener"], "human")
+
+    def test_the_humans_message_spliced_into_an_injected_turn_makes_it_theirs(self):
+        # the person asked during it and is answered in it, so the turn's end IS news to them
+        self.sess._note_turn_opener("injected", True)
+        self.sess._note_turn_opener(sb.fed_text_opener("and the tests?"), False)
+        self.assertEqual(self._stop()["lastTurnOpener"], "human")
+
+    def test_a_task_notification_streamed_while_idle_opens_an_injected_turn(self):
+        self.sess._note_turn_opener("human", True)      # the previous turn, the human's…
+        self._idle()                                    # …settled
+        self._streamed({"kind": "task-notification"})
+        self.assertEqual(self.sess._turn_opener, "injected")
+        self.assertTrue(self.sess._cli_working, "the atom still re-asserts working, as before")
+        self.assertEqual(self._stop()["lastTurnOpener"], "injected")
+
+    def test_a_peers_message_and_a_scheduled_prompt_streamed_while_idle_are_injected_too(self):
+        for origin in ({"kind": "peer", "name": "api"},
+                       {"kind": "task-notification", "subkind": "peer-send-message"},
+                       {"kind": "task-notification", "subkind": "scheduled-trigger"},
+                       {"kind": "auto-continuation"}):
+            self.sess._turn_opener = "human"
+            self._idle()
+            self._streamed(origin)
+            self.assertEqual(self.sess._turn_opener, "injected", origin)
+
+    def test_a_notification_spliced_into_the_humans_turn_does_not_take_it(self):
+        self.sess._note_turn_opener("human", True)
+        self.sess.inflight = 1                           # the human's text is in flight
+        self.sess._cli_working = True
+        self._streamed({"kind": "task-notification"})
+        self.assertEqual(self.sess._turn_opener, "human")
+
+    def test_a_stamp_less_or_human_stamped_user_atom_says_nothing(self):
+        self.sess._note_turn_opener("human", True)
+        self._idle()
+        self._streamed(None, text="hello there")
+        self._streamed({"kind": "human"}, text="hello again")
+        self.assertEqual(self.sess._turn_opener, "human")
+
+    def test_no_open_seen_stamps_the_humans(self):
+        # a fresh session object (a kernel restart mid-turn), or a CLI that stamps no origin: fail OPEN
+        # on the buzz — a missing fact never drops the user's
+        self.assertIsNone(self.sess._turn_opener)
+        self.assertEqual(self._stop()["lastTurnOpener"], "human")
+
+    def test_the_feeder_notes_the_opener_at_the_pop(self):
+        import inspect
+        src = inspect.getsource(sb.SdkSession._amain)
+        self.assertIn("self._note_turn_opener(fed_text_opener(item), fresh)", src)
+        self.assertLess(src.index("fresh = item is not None"), src.index("self._note_turn_opener("),
+                        "fresh (from idle, not mid-turn) is decided under the lock first")
+
+    def test_end_to_end_the_kernel_buzzes_for_the_humans_turn_and_not_the_nudged_or_notified_ones(self):
+        # the backend's Stop hook writes the same STATE/sdk/<sid>.json the kernel's tick reads
+        _reset_store()
+        for p in (jd.STATE / "sdk", jd.STATE / "states"):
+            for f in p.glob("*") if p.exists() else []:
+                f.unlink()
+        km._set_notify_all(True)
+        km._set_notify_turns(True)
+        self.addCleanup(lambda: (km._set_notify_all(False), km._set_notify_turns(False)))
+        be, sess = self._session(str(jd.STATE))
+        alive = [{"sid": SID_WEB, "name": "web", "path": _transcript(SID_WEB, "Folded the report in.")}]
+
+        def stop_at(t):
+            with mock.patch("time.time", return_value=float(t)):
+                asyncio.run(sess._stop_hook({}, None, None))
+            sess._mark("waiting")                                      # the settle that follows the Stop
+
+        def tick():
+            with mock.patch.object(km, "_alive_sessions", return_value=alive), \
+                 mock.patch.object(km, "_push_notify"), mock.patch.object(km, "_push_forward"):
+                return km._turn_notify_tick(time.time(), {SID_WEB: {"state": "waiting"}})
+
+        sess._note_turn_opener(sb.fed_text_opener("start on the login flow"), True)
+        stop_at(2000)
+        tick()                                                         # the baseline sighting
+        self.assertEqual(km._thread_reg(SID_WEB)["lastTurnOpener"], "human")
+        # a subagent finished: the CLI opens the turn itself, the session reacts, the Stop stamps
+        self._streamed({"kind": "task-notification"}, be=be, sess=sess)
+        stop_at(2001)
+        self.assertEqual(tick(), [], "the reaction's end is not news to the user")
+        # romp's own nudge, fed from idle
+        sess._note_turn_opener(sb.fed_text_opener(self.NUDGE), True)
+        stop_at(2002)
+        self.assertEqual(tick(), [])
+        # the human's next message
+        sess._note_turn_opener(sb.fed_text_opener("ship it"), True)
+        stop_at(2003)
+        self.assertEqual([f["body"] for f in tick()], ["Folded the report in."])
 
 
 class FirstLine(unittest.TestCase):


### PR DESCRIPTION
Tier: fix

## The bug (2026-09-10)
With the bell's "Also when a turn finishes" switch on, `_turn_notify_tick` pushed on EVERY turn end. A session running background subagents ends a turn per completion: the CLI injects the task notification as a user-role turn (`origin.kind == "task-notification"`), the session reacts, and its Stop stamped `lastStopAt` like any other end. One coordinating session buzzed the phone ten times in fifty minutes about work nobody had asked it about at that moment.

## The fix
A turn-finished push fires only for a turn the human opened.
- **Who opened the turn is learned where a turn opens** (`kernel/sdk_backend.py`): at the feeder's pop, a fed text is the human's unless it carries the romp-injected marker (`fed_text_opener`: nudges, follow-ups romp wrote, restart/rename notices, relayed mail, the retry line are injected); in `_forward`, a user atom the CLI streams while nothing is in flight, wearing an injected origin stamp (task-notification, peer, scheduled-trigger, auto-continuation), is a turn the CLI opened by itself (fed texts are not replayed on the stream). A human message the CLI splices into a running turn makes it theirs; an injected splice into the human's turn does not take it from them (`SdkSession._note_turn_opener`).
- **The Stop hook stamps it beside the settle** in the same `_update_reg` write: `lastTurnOpener: "human" | "injected"`. Verified: `lastStopAt` is written only by `_stop_hook`; `SubagentStop` never stamps it.
- **The tick gates on it** (`kernel/kernel.py` `_turn_notify_tick`): one registry read for the settle and its opener; a non-human end is skipped BEFORE `_buzz_claim`, so a bell event that turn raises keeps its buzz. A registry without the field (older ledger, tmux) or a session that saw no open reads as the human's: a missing fact never drops the user's buzz.
- The master + turns switches, `_notify_session_effective` and `_buzz_claim` are unchanged. The guide's row text says which turns buzz.

## Tests (fail first)
`tests/test_kernel_notify_popover.py`:
- `TurnOpenerGate`: a human-opened end buzzes as before; a task-notification-opened end is silent and spends no claim (the bell event still can); silent ends advance the memo and the next human end fires once; an older registry without the field, or a value the hook never writes, reads human; the gate reads one registry entry and precedes the claim.
- `TurnOpenerStamp`: `fed_text_opener` (comment form only); a fed human text / nudge from idle; a nudge folded into the human's turn; a human message spliced into an injected turn; a task notification, a peer's message and a scheduled prompt streamed while idle; a notification spliced mid-turn; stamp-less / human-stamped atoms; no open seen stamps human; the feeder notes the opener at the pop; end to end from the backend's Stop hook into the kernel's tick.

Full Python suite green: 10,849 passed, 121 skipped, 0 failed (five foreground chunks). One pre-existing wall-clock flake seen once in `test_kernel_webpush.py::LandingRevealOffers` (`ageS` 6 vs 5), unrelated to this diff and not reproducing on the full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
