### PR TITLE
Chat: a pending bubble's ✕ drops the entry that owns its id, never the first same-text entry pressed in the same millisecond

### DIFF
--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -258,10 +258,13 @@ it with the send, the kernel parks the copy under it (the parked op's fourth slo
 or queues it under it, and the ✕ names it, so the kernel cancels exactly the copy
 the bubble stands for, never a same-text neighbour by index or body. That holds
 wherever the copy carries the id: a parked send on any backend, and the SDK
-route's queue. A copy without one (the tmux route's queue, which the CLI holds)
-is still cancelled by index and body. Every copy the kernel queues itself (mail,
-a nudge, a re-delivery) is still minted an id where it enters the backend's
-queue. The CLI extracts
+route's queue. A copy whose ✕ names no id (an op the kernel parked itself, such
+as a nudge or a re-delivery; a ✕ from an older client) is still cancelled by
+index and body. The tmux route's queue, which the CLI holds, has no ✕ at all:
+`TmuxBackend` has no `unqueue`, so `build_session` ships those copies
+`cancelable: false` and the chat draws no ✕ for them. Every copy the kernel
+queues itself (mail, a nudge, a re-delivery) is still minted an id where it
+enters the backend's queue. The CLI extracts
 no image paths on the stream-json route (its only image-path test belongs to the
 interactive composer's paste handler), so an image path in an SDK send lands as
 typed and the echo's text matches. `_path_bearing` and the extension set it tests

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -28683,7 +28683,8 @@ def _is_slash_command(text):
 # "echo:" + hex, so isKernelEchoUuid on the client, the landed-record stamp's echo skip (build_session), the
 # re-queue's prefix test (sdk_backend _enqueue_with_id) and the echo-in-queue reading (_echo_queued_in) all
 # treat it as the kernel's. Bounded: the kernel mints 32 hex digits (uuid4().hex); a client id is admitted in
-# the same shape, never an arbitrary string that would ride the wire, the mirror and every chip.
+# the same shape, never an arbitrary string that would ride the wire, the mirror and every chip. Matched whole
+# (fullmatch): `$` alone admits a trailing newline, and an id with one is held nowhere, so it would be taken.
 _CLIENT_QID_RE = re.compile(r"^echo:[0-9a-f]{16,64}$")
 
 
@@ -28691,7 +28692,7 @@ def _wire_qid(msg):
     """The copy id a ws message names (`qid`), or None when it carries none or one in another form. A cancel's
     id only has to be looked up (an unknown id is the honest miss), so the shape is all a cancel checks."""
     q = msg.get("qid") if isinstance(msg, dict) else None
-    return q if isinstance(q, str) and _CLIENT_QID_RE.match(q) else None
+    return q if isinstance(q, str) and _CLIENT_QID_RE.fullmatch(q) else None
 
 
 def _client_qid(msg, sid, be):

--- a/tests/test_queued_copy_identity.py
+++ b/tests/test_queued_copy_identity.py
@@ -25,6 +25,8 @@ queue:
 
 SYNTHETIC fixtures only: a private synthetic sid, the notes-api demo world, hostname-free.
 """
+import contextlib
+import io
 import json
 import os
 import tempfile
@@ -365,7 +367,8 @@ class TheSdkQueueTakesTheClientsId(unittest.TestCase):
     """SdkBackend.send takes the id the client minted at the press and unqueue removes a copy BY that id: of two
     same-text copies the one named leaves, and its echo (keyed by the same id) goes with it while the other's stays.
     The handler's shape check reads this backend's queue and live echoes, so an id the session already holds is
-    refused and the kernel mints instead."""
+    refused and the kernel mints instead; a queue read or a live-echo read that raises refuses too, and the line it
+    logs names the session alone."""
 
     def setUp(self):
         self.w = _World()
@@ -414,9 +417,40 @@ class TheSdkQueueTakesTheClientsId(unittest.TestCase):
         self.assertEqual(km._client_qid({"qid": fresh}, SID, self.w.be), fresh)
         self.assertIsNone(km._client_qid({"qid": queued}, SID, self.w.be), "held by the queue")
         self.assertIsNone(km._client_qid({"qid": fed}, SID, self.w.be), "held by a live echo (fed, not landed)")
-        for bad in ("", "s-1", "echo:", "echo:" + "F" * 32, "echo:" + "f" * 8, "echo:" + "f" * 70, 7, None):
+        for bad in ("", "s-1", "echo:", "echo:" + "F" * 32, "echo:" + "f" * 8, "echo:" + "f" * 70, "echo:" + "f" * 32 + "\n", 7, None):
             self.assertIsNone(km._client_qid({"qid": bad}, SID, self.w.be), repr(bad))
         self.assertIsNone(km._client_qid({}, SID, self.w.be))
+
+    def test_the_handler_refuses_a_fresh_id_when_the_hold_cannot_be_checked_and_names_the_sid_only(self):
+        # fails toward the kernel's own id: a queue read or a live-echo read that raises is taken as "held", the
+        # client's id is refused, and the stderr line names the session and nothing the client sent (the id, the words)
+        fresh = "echo:" + "f" * 32
+        msg = {"qid": fresh, "md": "private words"}
+
+        def boom(*a, **k):
+            raise RuntimeError("queue unreadable")
+
+        real_meta, real_atoms = self.w.be.pending_queued_meta, self.w.be.live_atoms
+        try:
+            self.w.be.pending_queued_meta = boom
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertIsNone(km._client_qid(msg, SID, self.w.be), "the queue could not be read")
+            self.assertIn(SID, err.getvalue())
+            self.assertNotIn(fresh, err.getvalue())
+            self.assertNotIn("private words", err.getvalue())
+            self.w.be.pending_queued_meta = lambda sid: []
+            self.w.be.live_atoms = boom
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertIsNone(km._client_qid(msg, SID, self.w.be), "the live echoes could not be read")
+            self.assertIn(SID, err.getvalue())
+            self.assertNotIn(fresh, err.getvalue())
+            self.assertNotIn("private words", err.getvalue())
+            self.assertNotIn("queue unreadable", err.getvalue(), "the fault's text is not the line's either")
+        finally:
+            self.w.be.pending_queued_meta, self.w.be.live_atoms = real_meta, real_atoms
+        self.assertEqual(km._client_qid(msg, SID, self.w.be), fresh, "the same id is taken once both reads answer")
 
 
 class TheTmuxQueueCarriesStamps(unittest.TestCase):

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -768,6 +768,27 @@ test("newPending mints the send's id at the press, in the kernel's echo form, un
   assert.deepEqual(list, [p]);
 });
 
+test("our bubble's ✕ carries the press time AND the id: the id decides, never the first same-text entry pressed in the same millisecond", () => {
+  // two same-text sends registered in one synchronous loop can share a Date.now() stamp and differ only by id:
+  // flushStaged posts each staged slash command and goal-cited item as its own send, and adoptProvisional posts each
+  // text a new session's tab held the same way. The ✕ on OUR bubble rides both (data-qts and data-qid), and the id is
+  // the identity.
+  const p = newPending("x", undefined, T0), q = newPending("x", undefined, T0);
+  assert.notEqual(p.qid, q.qid);
+  const list = [p, q];
+  assert.equal(dropPending(list, "x", T0, q.qid), q, "our bubble's ✕ carries the press time and the id: the id decides, never the first entry with the text and the millisecond");
+  assert.deepEqual(list, [p]);
+  assert.equal(dropPending(list, "x", T0, q.qid), undefined, "an id no entry owns removes nothing, not the same-text neighbour pressed in the same millisecond");
+  assert.deepEqual(list, [p]);
+  // the cancel the kernel answers names the same id, so the entry the client drops is the copy the kernel removes
+  // (an id-first drop that misses leaves the neighbour for ITS own ✕); an id-less bubble, older data, still names
+  // its entry by the press time and the text, never a same-text neighbour pressed at another time
+  const r = newPending("x", undefined, T0 + 1);
+  list.push(r);
+  assert.equal(dropPending(list, "x", T0), p);
+  assert.deepEqual(list, [r]);
+});
+
 test("the ✕ on a kernel copy the kernel identified otherwise drops the send it covered by text on the last push, and nothing when it covered none of ours", () => {
   const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
   const [p1, p2] = press(tail, "ok", "ok");

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -69,7 +69,8 @@ export type PendingSend = {
   text: string;        // the sent body, byte for byte — what the kernel echoes and the transcript lands
   body: string;        // `text` minus its image paths, whitespace-collapsed: an image send lands with the
                        //   paths rewritten to "[Image #N]" and stripped, so `text` itself can never match
-  ts: number;          // press time (ms) — the bubble's identity (the ✕ names it), never a lifetime
+  ts: number;          // press time (ms), never a lifetime: a ✕ that carries no id names its entry by it and the text
+                       //   (dropPending); the identity is `qid`, and a ✕ that carries one is read by it first
   at?: SendBase;       // the send's place in the events (stamped by the first reconcile after the press)
   late?: boolean;      // the press found NO resident frame for the session (a placeholder tab, still
                        //   loading), so the stamp is taken at the first frame — which may already hold this
@@ -495,23 +496,31 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
   return r;
 }
 
-/** The entry a ✕ on a pending bubble removes: the one the bubble NAMES (`ts`, ridden on the ✕ as
- *  data-qts); or, for a ✕ on the KERNEL's own queued/parked copy, the entry that owns the copy's id
- *  (T252c), else the entry that copy covered by text on the last push (`cover`: a kernel that minted its
- *  own id for our send), and a copy wearing an id that neither is names another client's send, or the
- *  kernel's own, and removes nothing of ours; or, for a kernel copy with no id, the first pending send
- *  with that text, the one the kernel's first copy covers. Same-text entries carry different states (lost, received), and the
- *  first-with-the-text lookup the ✕ used for every bubble dropped the wrong one from a "not confirmed ·
- *  sending…" pair: the next push brought the dismissed bubble back and the other was gone without a
- *  gesture (2026-09-06 review, round 3). Returns the removed entry; undefined when none matched — a bubble
- *  whose entry a push already retired removes nothing, never a neighbour with the same text. */
+/** The entry a ✕ on a pending bubble removes. The id decides first, whenever the ✕ carries one (`qid`, ridden
+ *  as data-qid on OUR bubble and on the KERNEL's own queued/parked copy alike): the entry that owns the id
+ *  (T252c), else the entry that copy covered by text on the last push (`cover`: a kernel that minted its own
+ *  id for our send); an id that is neither names another client's send, or the kernel's own, and removes
+ *  nothing of ours, even when a same-text entry shares the ✕'s `ts`. The press time is not the identity: two
+ *  same-text sends registered in one synchronous loop share it when registerOptimistic's wall-clock reads, one
+ *  per send, fall in one millisecond (flushStaged posts each staged slash command and goal-cited item as its
+ *  own send; adoptProvisional posts each text a new session's tab held the same way), and reading `ts` and
+ *  text first made the ✕ on the second drop the FIRST, while the cancel it posted named the second's id and
+ *  the kernel removed exactly that copy: the client and the kernel then disagreed about which copy remained,
+ *  the survivor's bubble hid the other copy, and the next ✕ was answered with the miss. Only a ✕ that names
+ *  no id falls to the older readings: an id-less bubble (older data; newPending always mints one) names its
+ *  entry by `ts` and text, and an id-less kernel copy drops the first pending send with that text, the one
+ *  the kernel's first copy covers. Same-text entries carry different states (lost, received), and the
+ *  first-with-the-text lookup the ✕ once used for every bubble dropped the wrong one from a "not confirmed ·
+ *  sending…" pair: the next push brought the dismissed bubble back and the other was gone without a gesture
+ *  (2026-09-06 review). Returns the removed entry; undefined when none matched: a bubble whose entry a push
+ *  already retired removes nothing, never a neighbour with the same text. */
 export function dropPending(list: PendingSend[], text: string, ts?: number, qid?: string): PendingSend | undefined {
   let i = -1;
-  if (ts !== undefined) i = list.findIndex((p) => p.ts === ts && p.text === text);
-  else if (qid) {
+  if (qid) {
     i = list.findIndex((p) => p.qid === qid);
     if (i < 0) i = list.findIndex((p) => p.cover === qid);
-  } else i = list.findIndex((p) => p.text === text);
+  } else if (ts !== undefined) i = list.findIndex((p) => p.ts === ts && p.text === text);
+  else i = list.findIndex((p) => p.text === text);
   return i >= 0 ? list.splice(i, 1)[0] : undefined;
 }
 


### PR DESCRIPTION
## Symptom

Send the same text twice in one go (two staged items with the same text, each posted as its own send: a slash command, or an item with a goal cite; or two identical texts typed into a new session's tab before the kernel created it) and press ✕ on the second bubble: the first bubble disappears instead. On the next push the surviving bubble hides the kernel's copy of the first send; a second ✕ on it is answered with the too-late toast and the composer restore is reverted; a third ✕, on the kernel's own copy, cancels it. This is the follow-up recorded on #1224 after its merge.

## Cause

`dropPending` (ui/webview/send-pending.ts) read the press time and the text before the id: the `ts !== undefined` branch came first, and the id branch ran only for a ✕ with no press time. Our bubble's ✕ carries both (`data-qts` and `data-qid`, set in render.ts from the entry), and `registerOptimistic` stamps `Date.now()` once per send, so two same-text sends registered in one synchronous loop can share the stamp and differ only by id (`flushStaged` posts each staged slash command and goal-cited item as its own send; `adoptProvisional` posts each text a new session's tab held the same way). `findIndex` returned the first entry, while the cancel the same handler posts named the second's id and the kernel removed that copy and no other (`_cancel_parked` and `unqueue` look the id up; neither relocates by body). The client and the kernel then disagreed about which copy remained: the survivor's id was nowhere in the next frame, `cover` took the leftover copy by text, `hideQueuedCopy` hid it behind the survivor's bubble, and the next ✕ posted an id neither queue held.

## Fix

`dropPending` resolves the id first whenever the ✕ carries one: the entry that owns it, else the entry that copy covered by text on the last push. An id neither owns removes nothing, even when a same-text entry shares the ✕'s press time: that entry is another send, with its own ✕. A ✕ with no id keeps the older readings, by press time and text for an id-less bubble (older data; `newPending` always mints an id) and by text for an id-less kernel copy. The docstring says why, and the `PendingSend.ts` field comment now says the same (it had called the press time the bubble's identity). No caller changes: the qx handler already passes both, and the source pins in send-pending.test.ts hold.

Three corrections in the same files:

- `_wire_qid` (kernel/kernel.py) matches the id shape with `fullmatch`. With `match`, `$` admitted `"echo:" + 32 hex + "\n"`; held nowhere, that id was returned by `_client_qid` and would have ridden the parked op, the mirror and every chip. The comment above `_CLIENT_QID_RE` notes it.
- `_client_qid`'s refusal when the hold cannot be checked (a queue read or a live-echo read that raises) had no test. It has one now.
- docs/read-side.md said the tmux route's CLI-held copies are cancelled by index and body. They have no ✕ at all: `TmuxBackend` has no `unqueue`, so `build_session` ships them `cancelable: false` and the chat draws none. The index-and-body path belongs to a copy whose ✕ names no id (an op the kernel parked itself, a ✕ from an older client), and the sentence now says so.

Not in this change: the ✎ on a queued bubble. `applyQueuedEditLocally` retargets by press time and text, and the edit wire and the kernel's `editQueued` arms carry no id, so a client-only retarget cannot make the client and the kernel agree on which copy changed. That is the edit by id the #1224 body names as the natural continuation. render.ts is untouched: its two comments that describe the press-time-first order (above `mk`, and in the qx handler) are stale by one clause and can move with the edit-by-id change; #994 and #1126, both open, touch that file.

## Tests

- ui/webview/send-pending.test.ts, new test: two same-text entries share the press stamp; the ✕ carrying the stamp and the id drops the entry that owns the id; the same id again removes nothing, not the same-text neighbour; an id-less ✕ still names its entry by stamp and text and leaves a same-text neighbour pressed at another time. Before the change the first assertion fails, `dropPending` returns the first entry (1 fail, 38 pass in the file); after, 39 pass.
- tests/test_queued_copy_identity.py: the bad-id tuple in `test_the_handler_takes_a_fresh_id_in_the_echo_form_and_refuses_one_the_session_holds` gains `"echo:" + "f" * 32 + "\n"`. Before the change `_client_qid` returns it and the `assertIsNone` fails (1 failed, 24 passed in the module); after, 25 passed.
- tests/test_queued_copy_identity.py, new test `test_the_handler_refuses_a_fresh_id_when_the_hold_cannot_be_checked_and_names_the_sid_only`: on a real SdkBackend, a `pending_queued_meta` that raises, then one that answers `[]` with a `live_atoms` that raises, each refuse a fresh id; the stderr line names the sid and neither the id, the message text nor the fault's text; once both reads answer, the same id is taken. Green before the change: a guard for the branch.
- Full runs on the branch: pytest 10833 passed, 41 skipped; `npm run typecheck` clean; `npm test` 4053 pass, 0 fail.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)