### PR TITLE
Held input echoes: a slash or skill command's echo retires on the transcript's command wrapper record

### DIFF
--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -283,9 +283,14 @@ reads the whole file. The found verdict is recorded on the echo (`_landed`), and
 `prune_live` and the chat merge retire the echo on it without a text match, so a
 found echo always has an exit and a later boot never re-scans it. Every by-text
 comparison of an echo against a record (the guard's scan, `prune_live`'s retire, the
-kernel's `_atom_user_texts` and its folds, and the tmux echo's prune
-`_tmux_echo_prune`) uses one key, `echo_text_key` in `session_backend.py`: outer
-whitespace stripped, nothing else.
+kernel's `_atom_user_texts` and its folds, the fed-copy pairing `qids_for_landing`, and
+the tmux echo's prune `_tmux_echo_prune`) uses the two keys in `session_backend.py`:
+`echo_text_key` (outer whitespace stripped, nothing else) and, for a slash send,
+`command_text_key` (the tokens joined by single spaces). The second exists because the
+CLI records a slash or skill command as its `<command-name>` wrapper, which parses to
+`/name args` with one space whatever the sender typed between the name and the
+arguments; both sides key a slash-shaped text both ways, so the scan and the prune
+agree on the same records.
 
 **The ledger is a table of contents** (pure projection of captions + archive):
 - top: the archiver's one-sentence headline for the session,

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13704,11 +13704,12 @@ def _comments_frame(sid, tmux=None):
                 # deliberate re-send repeat earlier texts, which read as "already in the transcript" and hid a
                 # send the CLI still held (round-5 review). A `dropped` echo (the backend adjudicated the send
                 # LOST — a reconnect with it in flight; the popover shows "never delivered") owes nothing.
-                user_atoms = [a for tr in turns for a in (tr.get("atoms") or []) if a.get("type") == "user"]
+                user_atoms = [(float(a.get("t") or 0), set(_atom_user_texts(a)))       # (stamp, its texts), built once per frame
+                              for tr in turns for a in (tr.get("atoms") or []) if a.get("type") == "user"]
                 def _landed(e):
-                    et = sb.echo_text_key(e.get("_echo_text"))
+                    keys = set(sb.echo_keys(e.get("_echo_text")))     # the plain key and, for a slash send, its words
                     since = float(e.get("t") or 0)                     # the send's own stamp: the record the CLI writes for
-                    return any(et in _atom_user_texts(a) for a in user_atoms if float(a.get("t") or 0) >= since)   # it is at or after it
+                    return any(t >= since and not keys.isdisjoint(texts) for t, texts in user_atoms)   # it is at or after it
                 floor = _human_turn_floor({"turns": turns}) if turns else 0
                 # `_landed` on the atom: the backend's boot/spawn scan read the landing off the transcript
                 # itself (sdk_backend._mark_dropped_echoes) — delivered, so nothing is held for it
@@ -29896,7 +29897,14 @@ def _atom_user_texts(a):
     sdk_backend.prune_live floors no echo (2026-09-06; before that the floor was narrowed to path-bearing
     echoes, 2026-07-20), so a genuinely dropped send stays visible. Per-block EXACT match, never a
     substring test: a bundled block is the very string that was
-    echoed, so this retires the delivered nudge without ever guessing about containment."""
+    echoed, so this retires the delivered nudge without ever guessing about containment.
+
+    A slash-shaped text also yields its command key (sb.command_text_key: the tokens joined by single
+    spaces). The CLI records a slash or skill send as a wrapper record, which the event model reads as a
+    command atom whose text is "/name args" with one space, whatever the sender typed between the name and
+    the arguments; the typed echo meets that atom under the command key whatever whitespace it carried
+    (2026-09-10). The backend's _landed_texts adds the same key to the raw records its landing scan reads,
+    so the two agree."""
     if a.get("type") != "user":
         return ()
     out = []
@@ -29910,7 +29918,22 @@ def _atom_user_texts(a):
                 t = sb.echo_text_key(b.get("text") or "")
                 if t and t != joined:
                     out.append(t)
+    for t in list(out):
+        ck = sb.command_text_key(t)
+        if ck and ck not in out:
+            out.append(ck)
     return tuple(out)
+
+
+def _echo_landed_in(text, tx_texts):
+    """Is an echo's text among `tx_texts`, the keys _atom_user_texts built? Under either of its keys
+    (sb.echo_keys: the plain key, and the command key when the echo is a slash send, whose record parses
+    to "/name args", which equals the typed text only when the typed whitespace already matches; the sets
+    carry that form). The membership test every kernel-side echo reader uses: build_session's queued
+    count, _merge_live_atoms' display dedup and _tmux_echo_prune; the thread's held count (_comments_frame)
+    asks the same keys against per-atom sets it builds once per frame. The SDK backend's prune_live and its
+    landing scan ask the same keys on their side."""
+    return any(k in tx_texts for k in sb.echo_keys(text))
 
 
 # Optimistic input echo for TMUX sends. The SDK backend echoes a composer message instantly via its own
@@ -29945,8 +29968,7 @@ def _tmux_echo_prune(sid, tx_uuids, tx_texts):
         return
 
     def _landed(a):
-        et = sb.echo_text_key(a.get("_echo_text"))
-        return a.get("uuid") in tx_uuids or (et and et in tx_texts)
+        return a.get("uuid") in tx_uuids or _echo_landed_in(a.get("_echo_text"), tx_texts)
     for k in [k for k, a in d.items() if _landed(a)]:
         d.pop(k, None)
     if not d:
@@ -30113,7 +30135,7 @@ def _merge_live_atoms(session, sid, shown_texts=()):
     # scan read the record off the transcript — the prune just retired it, and painting it once more would
     # show a delivered message as a pending bubble for one build)
     fresh = [a for a in live if a.get("uuid") not in tx_uuids
-             and not (a.get("_echo_text") and (a.get("_landed") or sb.echo_text_key(a["_echo_text"]) in hide))]
+             and not (a.get("_echo_text") and (a.get("_landed") or _echo_landed_in(a["_echo_text"], hide)))]
     if not fresh:
         return session
     # Reopen the turn ONLY for genuine live ASSISTANT work (a streaming reply), never for a lone input echo.
@@ -30509,7 +30531,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
         echo_floor = _human_turn_floor(parsed)
         for a in be.live_atoms(sid):
             et = sb.echo_text_key(a.get("_echo_text"))
-            if et and et not in already and et not in tx_user and not _echo_overtaken(a, echo_floor):
+            if et and et not in already and not _echo_landed_in(et, tx_user) and not _echo_overtaken(a, echo_floor):
                 queued = queued + [et]; already.add(et)
     session = parsed if path_override else _merge_live_atoms(parsed, sid, shown_texts=queued)
     events, by_tool = [], {}                  # by_tool: tool_use_id → its tool event (fill output later)
@@ -33867,13 +33889,14 @@ def build_feed(now, tmux=None):
             # clear its store-backed flag. Cards move on new information, never on activity boundaries.
             #
             # NO ECHO ARM (the user 2026-07-22): the flip used to ALSO ride the backend send-echo
-            # (echo_send_t), for a sub-second flip before the turn's atom lands in the cached parse. But a
-            # composer slash-command echo never retires — its expanded transcript form ("<command-name>…")
-            # doesn't text-match the raw echo, and the parser skips it from the human floor — so the stale
-            # echo pinned rejudging TRUE forever: the card sat in Working, idle, invisible to the nudge
-            # (which reads the still-blocked store). The latch arms only off the PARSE's plain-reply turn
-            # (a real transcript atom, never the echo), and the watermark clear is judge-driven, so the
-            # stranded-echo failure stays impossible.
+            # (echo_send_t), for a sub-second flip before the turn's atom lands in the cached parse. At the
+            # time a composer slash-command echo never retired (its transcript form is the "<command-name>"
+            # wrapper, which did not text-match the raw echo; since 2026-09-10 the echo lands under
+            # sb.command_text_key, see _echo_landed_in), and the parser skips it from the human floor, so
+            # the stale echo pinned rejudging TRUE forever: the card sat in Working, idle, invisible to the
+            # nudge (which reads the still-blocked store). The latch arms only off the PARSE's plain-reply
+            # turn (a real transcript atom, never the echo), and the watermark clear is judge-driven, so
+            # the stranded-echo failure stays impossible whatever an echo does.
             # The watermark that bounds the latch is the one covering THE BLOCK THE CARD SURFACES —
             # a descendant's, when the block rolled up (_block_check_floor above; the user 2026-07-31).
             _bct = _block_check_floor(nid)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -52,15 +52,18 @@ _pal = _SFL("romp_palette", str(Path(__file__).resolve().parent / "palette.py"))
 # the module reads Claude Code's apiKeyHelper for the kernel's two calls and checks the boot environment.
 _cred = sys.modules.get("romp_credentials") or _SFL(
     "romp_credentials", str(Path(__file__).resolve().parent / "credentials.py")).load_module()
-# The by-text KEY RULE (session_backend.echo_text_key): the one normalization under which an input echo's
-# text is compared with a transcript record's, shared with the kernel's _atom_user_texts so the landing
-# scan below can never find what prune_live cannot retire. The kernel's own copy of that module when it
-# is loaded (the same idiom as _cred above); otherwise the file is loaded under its OWN module name:
-# the kernel loads it as romp_session_backend and TmuxBackend subclasses that copy's ABC, and
-# re-executing the source into that module object would rebind the class out from under the subclass.
-echo_text_key = (sys.modules.get("romp_session_backend") or _SFL(
-    "romp_session_backend_keys", str(Path(__file__).resolve().parent / "session_backend.py")).load_module()
-).echo_text_key
+# The by-text KEY RULES (session_backend.echo_text_key, and command_text_key for a slash send): the one
+# normalization under which an input echo's text is compared with a transcript record's, shared with the
+# kernel's _atom_user_texts so the landing scan below can never find what prune_live cannot retire. The
+# kernel's own copy of that module when it is loaded (the same idiom as _cred above); otherwise the file
+# is loaded under its OWN module name: the kernel loads it as romp_session_backend and TmuxBackend
+# subclasses that copy's ABC, and re-executing the source into that module object would rebind the class
+# out from under the subclass.
+_keys = (sys.modules.get("romp_session_backend") or _SFL(
+    "romp_session_backend_keys", str(Path(__file__).resolve().parent / "session_backend.py")).load_module())
+echo_text_key = _keys.echo_text_key
+command_text_key = _keys.command_text_key
+echo_keys = _keys.echo_keys                  # both keys of a text, the "either key" rule written once
 
 
 def _bin_on_path_env(environ) -> dict:
@@ -972,6 +975,25 @@ _SKILL_MD_CAP = 16000
 _IMG_ECHO_RE = re.compile(r"^\[Image:[^\]]*\]$")
 
 
+def _command_invocation(text):
+    """(name, display) for a slash-command WRAPPER record's text, or None. `name` is the <command-name>
+    value with its leading slash; `display` is the "/name args" the file adapter and msg_to_atom show for
+    it (the arguments outer-stripped, one space between). The tag is read anchored, or anywhere inside a
+    record that BEGINS with a command wrapper (_CMD_WRAP_RE), never from prose that quotes it. Read by
+    msg_to_atom for the live atom and by _landed_texts for the landing scan, so the scan finds a slash
+    send under exactly the text the kernel's prune retires its echo by."""
+    mcmd = _COMMAND_NAME_RE.match(text) or (_COMMAND_NAME_ANY_RE.search(text)
+                                            if _CMD_WRAP_RE.match(text) else None)
+    if not mcmd:
+        return None
+    name = mcmd.group(1).strip() or "/?"
+    if not name.startswith("/"):
+        name = "/" + name
+    margs = _COMMAND_ARGS_RE.search(text)
+    args = (margs.group(1).strip() if margs else "")
+    return name, name + ((" " + args) if args else "")
+
+
 def _note_skill_tool_ids(atom, ids):
     """Collect Skill tool_use block ids from a streamed ASSISTANT atom into `ids` — the live twin's
     anchor set for the newer skill-instructions shape (2026-07-10): the payload UserMessage carries
@@ -1035,15 +1057,9 @@ def msg_to_atom(msg, sid, fsid, t, skill_tool_ids=()):
             return None
         text = " ".join(b.get("text", "") for b in content
                         if isinstance(b, dict) and b.get("type") == "text")
-        mcmd = _COMMAND_NAME_RE.match(text) or (_COMMAND_NAME_ANY_RE.search(text)
-                                                if _CMD_WRAP_RE.match(text) else None)
-        if mcmd:                                     # the command INVOCATION → the command-flagged user atom
-            name = mcmd.group(1).strip() or "/?"
-            if not name.startswith("/"):
-                name = "/" + name
-            margs = _COMMAND_ARGS_RE.search(text)
-            args = (margs.group(1).strip() if margs else "")
-            disp = name + ((" " + args) if args else "")
+        cmd = _command_invocation(text)
+        if cmd:                                      # the command INVOCATION → the command-flagged user atom
+            name, disp = cmd
             return {"type": "user", "uuid": u, "session_id": sid, "t": t, "fsid": fsid, "parentUuid": None,
                     "author": "human", "command": name,
                     "message": {"role": "user", "content": [{"type": "text", "text": disp}]}}
@@ -4178,7 +4194,14 @@ class SdkSession:
         same-text landing — the review of the first cut). Memoised per record uuid, so every rebuild answers
         the same. The kernel's own ECHO atom is refused outright (its uuid is the copy's id, minted at the
         send): it is the visible copy between the feed and the CLI's record, and asked as a landing it took
-        the fed entry the real landing needed."""
+        the fed entry the real landing needed.
+
+        A slash send is paired under command_text_key as well (2026-09-10): its record is the CLI's
+        wrapper, which the kernel reads as "/name args" with one space, whatever the sender typed between
+        the name and the arguments, so the fed copy's typed text equals it only when its whitespace
+        already matches. Without the second key the landing of a copy typed with a newline before the
+        arguments carried no id, and the chat's own pending bubble, which retires by id once it has
+        latched the copy's, stayed at the tail after the command had run."""
         if not uuid_ or str(uuid_).startswith("echo:"):
             return [None] * len(texts)
         with self._lock:
@@ -4186,10 +4209,10 @@ class SdkSession:
                 return list(self._landed_qid[uuid_])
             hits = []
             for text in texts:
-                key = echo_text_key(text)
+                keys = set(echo_keys(text))            # the plain key and, for a slash send, its words
                 hit = None
                 for i, f in enumerate(self._fed_meta):
-                    if echo_text_key(f["text"]) != key:
+                    if keys.isdisjoint(echo_keys(f["text"])):
                         continue
                     if t is not None and float(t) < f["t"] - 2:
                         continue                           # stamped before the feed: not this copy's landing
@@ -7132,7 +7155,13 @@ def _landed_texts(rec: dict) -> set:
     each text block: romp bundles its injected messages as several blocks in one record). Two record
     shapes carry user text: a native USER record, and the queued_command ATTACHMENT a mid-turn splice
     leaves, whose prompt is a plain string or a content-block list (the SDK injection path; event_model
-    reads it the same way). Anything else → empty."""
+    reads it the same way). Anything else → empty.
+
+    A slash send's own record is the WRAPPER the CLI writes for it (<command-name>, <command-args>), never
+    the typed text: it lands the send as the "/name args" the event model reads it as (_command_invocation,
+    the same reading msg_to_atom gives the live atom). Every text here also yields its slash-send key
+    (command_text_key), as the kernel's _atom_user_texts does, so the scan and the prune agree on the same
+    records (2026-09-10)."""
     out: set = set()
     typ = rec.get("type")
     if typ == "user":
@@ -7157,6 +7186,14 @@ def _landed_texts(rec: dict) -> set:
         cb = echo_text_key(b)
         if cb:
             out.add(cb)
+    if typ == "user":
+        cmd = _command_invocation(" ".join(blocks))
+        if cmd:
+            out.add(echo_text_key(cmd[1]))
+    for k in list(out):
+        ck = command_text_key(k)
+        if ck:
+            out.add(ck)
     return out
 
 
@@ -9585,6 +9622,11 @@ class SdkBackend:
         # substring also matched CONTENT that merely mentions the marker — a typed follow-up quoting a
         # card summary about romp-injected echoed as a GRAY romp card.
         injected = "<!-- romp-injected -->" in text
+        # No `command` flag, even for a typed slash command: that flag marks the CLI's OWN feedback atoms
+        # (msg_to_atom's streamed wrapper and stdout, _ack_cmd_chip's picker chip), which owe no landing,
+        # are retired by the human floor, never mirrored across a restart, never flagged lost or
+        # re-delivered. A typed slash send is a message the CLI takes and records (as its wrapper), so its
+        # echo keeps the full lifecycle and lands under command_text_key; flagging it would hide its loss.
         echo = {
             "type": "user", "uuid": key, "session_id": sid, "t": sent_t, "parentUuid": None,
             "author": "romp" if injected else "human", "_echo_text": text,
@@ -9843,7 +9885,11 @@ class SdkBackend:
         echo_text_key's, the same rule the kernel's _atom_user_texts keys prune_live's by-text retire
         with, so a found echo is always one the prune can retire: the joined text or any one text block
         EQUAL to the send — never a substring, or a found-but-never-pruned echo would ride the tail
-        forever. `off` / `fsid` are the echo's send-time transcript mark (_transcript_mark): the file's
+        forever. A slash send is matched under command_text_key as well (its words; the kernel keys the
+        parsed command atom the same way): its own record is the CLI's wrapper, which _landed_texts reads
+        as the "/name args" the event model shows, never as the typed text, so until 2026-09-10 a typed
+        "/name" followed by a newline and its arguments read as never landed here and was re-delivered at
+        the next spawn, running the command twice. `off` / `fsid` are the echo's send-time transcript mark (_transcript_mark): the file's
         byte size when the send was made, and the fsid it was measured on. The scan starts THERE — every
         record that can land this send is at or after it, however much the session wrote afterwards —
         rather than at a fixed distance from EOF, which read a landed send whose record sat more than
@@ -9858,7 +9904,9 @@ class SdkBackend:
             reg = read_reg(self.state_dir, sid) or {}
             cur = str(reg.get("lastSid") or sid)
             path = transcript_path(reg.get("cwd") or "", cur)
-            want = echo_text_key(text)
+            # the plain key and, for a slash send, its words (echo_keys): the send's own record is the
+            # CLI's wrapper, which _landed_texts reads as "/name args" the way the kernel's prune does
+            want = set(echo_keys(text))
             floor = int(t or 0)
             start = 0
             if (isinstance(off, int) and not isinstance(off, bool) and fsid is not None
@@ -9873,7 +9921,7 @@ class SdkBackend:
                         rec = json.loads(raw.decode(errors="replace"))
                     except ValueError:
                         continue
-                    if not isinstance(rec, dict) or want not in _landed_texts(rec):
+                    if not isinstance(rec, dict) or not (want & _landed_texts(rec)):
                         continue
                     ts = _record_epoch(rec.get("timestamp"))
                     if floor and ts is not None and ts < floor:
@@ -11534,7 +11582,11 @@ class SdkBackend:
         The by-text comparison is keyed by echo_text_key on BOTH sides (2026-09-06): the kernel builds
         `tx_user_texts` from _atom_user_texts, and the echo's text is keyed the same way here — before,
         the raw text was compared against stripped keys, so an echo whose text carried a trailing
-        newline never retired. An echo the boot/spawn scan already FOUND (`_landed`, recorded by
+        newline never retired. A slash send is compared under command_text_key too (2026-09-10): the CLI
+        records it as a wrapper whose parsed atom reads "/name args" with one space, whatever the sender
+        typed between the name and the arguments, and the kernel keys that atom both ways; without this a
+        typed echo whose whitespace differed from that form (a newline before the arguments) never
+        retired, though its turn ran. An echo the boot/spawn scan already FOUND (`_landed`, recorded by
         _mark_dropped_echoes from a direct read of the transcript and mirrored to the reg) retires
         without the comparison at all: that is its exit when the two texts cannot meet, since a found
         echo is neither flagged nor dismissable.
@@ -11552,12 +11604,14 @@ class SdkBackend:
         # held. A plain set (older callers) keeps the unfloored match.
         text_t = tx_user_texts if isinstance(tx_user_texts, dict) else None
         def _by_text(a, et):
-            key = echo_text_key(et)
-            if not key:
+            # the plain key and, for a slash send, its words (echo_keys): the CLI records the send as a
+            # wrapper whose parsed atom reads "/name args", and the kernel keys that atom both ways
+            keys = echo_keys(et)
+            if not keys:
                 return False
             if text_t is None:
-                return key in tx_user_texts
-            return key in text_t and float(text_t[key] or 0) >= float(a.get("t") or 0)
+                return any(k in tx_user_texts for k in keys)
+            return any(k in text_t and float(text_t[k] or 0) >= float(a.get("t") or 0) for k in keys)
         echo_removed = False
         vanished = 0
         with self._live_lock:

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -26,6 +26,7 @@ A backend that genuinely cannot do an op returns the documented empty value (Fal
 than raising, so callers never need to know which backend they hold.
 """
 from __future__ import annotations
+import re
 from abc import ABC, abstractmethod
 
 
@@ -42,6 +43,56 @@ def echo_text_key(text) -> str:
     the data needs: the CLI stores user text verbatim (checked against recorded SDK transcripts,
     2026-09-06 — double spaces, bare CRs and line-trailing blanks all preserved). Not a str → ""."""
     return text.strip() if isinstance(text, str) else ""
+
+
+# A command-name-shaped token: a slash, then characters with no further slash or whitespace ("/deploy",
+# "/plugin:skill"). A path ("/tmp/build.log") has a further slash and is not one; a message that starts
+# with a path keeps the plain rule alone.
+_COMMAND_TOKEN_RE = re.compile(r"^/[^/\s]+$")
+
+
+def command_text_key(text) -> str:
+    """The second rule, for a SLASH-COMMAND send only: the text's whitespace-delimited tokens joined by
+    single spaces, or "" when the first token is not command-name-shaped (_COMMAND_TOKEN_RE; a plain
+    message has no command key). Claude Code records a slash send as a wrapper (<command-name>,
+    <command-args>) and, for a skill, the skill body as a second record: the wrapper is the record it
+    always writes, and a verbatim copy of the typed text is not guaranteed (some CLI versions also write a
+    raw twin record, which matches under echo_text_key when present). The event model reads the wrapper
+    back as a command atom whose text is "/name args" with ONE space between them, whatever whitespace
+    the sender typed there. So a send like "/deploy \\n\\nstaging now" never met its own record under
+    echo_text_key: the chat kept the sending bubble forever while the turn ran, and the boot/spawn scan,
+    which reads the raw records, called the send lost and re-delivered it (reported from a live dashboard,
+    2026-09-10). The match is the same words in the same order: the whitespace the CLI drops between the
+    name and the arguments, or reflows inside them, never decides, and a different command or different
+    arguments never lands the echo. Every reader that compares under echo_text_key compares under this
+    key too, on BOTH sides: the kernel's _atom_user_texts adds it for each slash-shaped record text, the
+    backend's _landed_texts does the same (and, for a wrapper record, adds the "/name args" the event
+    model would read), and the echo side asks for either key through echo_keys (kernel._echo_landed_in,
+    SdkBackend.prune_live, _text_landed and qids_for_landing). Not a str → "". The common case, a text
+    that does not start with a slash, is settled before any split: this runs for every user text on
+    every build."""
+    if not isinstance(text, str):
+        return ""
+    s = text.lstrip()
+    if not s.startswith("/"):
+        return ""
+    toks = s.split()
+    if not _COMMAND_TOKEN_RE.match(toks[0]):
+        return ""
+    return " ".join(toks)
+
+
+def echo_keys(text) -> tuple:
+    """The keys an echo's text is looked up under: echo_text_key, and command_text_key when the text is a
+    slash send. Empty and duplicate keys dropped, so a plain text yields one key and a slash send one or
+    two. The one place the "either key" rule is written; every echo-side reader (kernel._echo_landed_in
+    and the thread's held count, SdkBackend.prune_live, _text_landed, qids_for_landing) reads it from
+    here, and two texts match when their key tuples intersect."""
+    keys = []
+    for k in (echo_text_key(text), command_text_key(text)):
+        if k and k not in keys:
+            keys.append(k)
+    return tuple(keys)
 
 
 class SessionBackend(ABC):

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -787,6 +787,34 @@ class ThreadProjection(CommentBase):
         finally:
             self._State.live = []
 
+    def test_a_slash_sends_echo_is_landed_by_its_wrapper_record(self):
+        # a slash or skill command typed into the composer: the CLI records it as a <command-name> wrapper
+        # (no verbatim copy of the typed text), which parses to "/deploy staging now" with one space where
+        # the sender typed a space and two newlines. The held count reads the landing off that record;
+        # before, the echo was held forever and the thread owed a reply that had already come. The record
+        # lands in the SAME second as the send: a strictly later human turn would read the echo as
+        # overtaken (a loss, not held) whatever its text, and this case is about the landing rule alone.
+        t = self.now - 500
+        self._seed_thread(seen=self.now)
+        recs = self._thread_side(aline(t + 120, "Jitter prevents thundering herds.", "ca1", parent="cu1"))
+        echo = {"type": "user", "author": "human", "t": t + 130, "uuid": "echo:1", "_echo_text": "/deploy \n\nstaging now"}
+        wrap = lambda args: ("<command-message>deploy</command-message>\n<command-name>/deploy</command-name>\n"
+                             "<command-args>%s</command-args>\n<skill-format>true</skill-format>" % args)
+        try:
+            self._State.live = [echo]
+            th = self._frame_thread(recs, state="")
+            self.assertEqual(th["queued"], 1, "held until its record lands")
+            th = self._frame_thread(recs + [uline(t + 130, wrap("staging now"), "cc1", parent="ca1", meta=True),
+                                            aline(t + 140, "Deploying staging now.", "ca2", parent="cc1")], state="")
+            self.assertEqual(th["queued"], 0, "the wrapper record is this send's landing")
+            self.assertFalse(th["replyOwed"])
+            self._State.live = [echo]
+            th = self._frame_thread(recs + [uline(t + 130, wrap("production now"), "cc1", parent="ca1", meta=True),
+                                            aline(t + 140, "Deploying production now.", "ca2", parent="cc1")], state="")
+            self.assertEqual(th["queued"], 1, "another command's record is not this send's landing")
+        finally:
+            self._State.live = []
+
     def test_a_dropped_echo_and_a_repeat_text_send_are_read_right(self):
         # round-5 review, two faults in the echo fold: (1) an echo the backend flagged `dropped` (the send was
         # LOST on a reconnect; the popover shows "never delivered") counted as held → green forever; (2) an

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1365,6 +1365,35 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(len(lost), 1, "it stays on screen — the loss must not vanish silently")
         self.assertTrue(lost[0].get("undelivered"), "and reads as never delivered, with the dismiss affordance")
 
+    def test_tmux_slash_sends_echo_is_not_counted_as_queued_once_its_wrapper_record_lands(self):
+        # A slash or skill command typed while the session is busy: the CLI records it as a <command-name>
+        # wrapper (no verbatim copy of the typed text), which parses to "/deploy staging now" with one space
+        # where the sender typed a space and two newlines. The queued count reads the landing off that record
+        # under the command key; before, the echo counted as queued for as long as the turn ran. The record lands
+        # in the SAME second as the send: a strictly later human turn would settle the echo as overtaken (a
+        # loss, not a queued message) whatever its text, and this case is about the count's landing rule.
+        typed = "/deploy \n\nstaging now"
+        wrap = ("<command-message>deploy</command-message>\n<command-name>/deploy</command-name>\n"
+                "<command-args>staging now</command-args>\n<skill-format>true</skill-format>")
+        with self.tpath.open("a") as f:
+            f.write(json.dumps(dict(uline(NOW - 10, wrap, "uCmd", parent="a2"), isMeta=True, promptId="p1")) + "\n")
+            f.write(json.dumps(aline(NOW - 5, "Deploying staging now.", "aCmd", "uCmd", tools=("Bash",), stop="tool_use")) + "\n")
+        km._parse_cache.clear()
+        self.assertTrue(km._session_working(km._parse(str(self.tpath), SID, NOW)["turns"]),
+                        "precondition: the turn the command started is still running, so an unlanded echo counts as queued")
+        km._tmux_echo.pop(SID, None)
+        km._tmux_echo_add(SID, typed)
+        for echo_atom in km._tmux_echo[SID].values():
+            echo_atom["t"] = NOW - 10                    # sent in the second its record landed
+        try:
+            events = km.build_session(SID, NOW)["events"]
+        finally:
+            km._tmux_echo.pop(SID, None)
+        qmsgs = [m["md"] for e in events if e["kind"] == "queued" for m in e["texts"]]
+        self.assertNotIn(typed, qmsgs, "the wrapper record is this send's landing: nothing waits in the queue")
+        shown = [e.get("md") for e in events if e["kind"] == "user" and e.get("md") in (typed, "/deploy staging now")]
+        self.assertEqual(shown, ["/deploy staging now"], "the command shows once, as its record, never as a pending echo")
+
     def test_tmux_send_while_IDLE_echoes_as_a_sent_bubble_not_queued(self):
         # the gate: when the session is IDLE (default fixture ends on an ended turn), the SAME echo is a
         # genuine sent message — it shows as a solid user bubble, never the dotted queued indicator.

--- a/tests/test_kernel_fed_echo_absorbed.py
+++ b/tests/test_kernel_fed_echo_absorbed.py
@@ -354,7 +354,11 @@ class OneTextRuleAcrossKernelAndBackend(unittest.TestCase):
     2026-09-06 the scan collapsed whitespace, the kernel stripped, and the prune compared raw — three
     rules, so a trailing-newline send was found yet never retired. One function now, imported by both
     modules; the property tested here is that the scan's match set for a record IS the kernel's key set
-    for the same record, and that an echo the scan would find retires through the real merge."""
+    for the same record, and that an echo the scan would find retires through the real merge. A raw
+    command WRAPPER record (<command-name>, <command-args>) is the one designed exception and is not
+    listed: the kernel keys the PARSED command atom, while the scan reads the raw record and derives the
+    same "/name args" itself (sdk_backend._command_invocation); that agreement is pinned through the real
+    parse in test_kernel_slash_echo_retire.BackendScanAgrees."""
 
     def setUp(self):
         self.w = _World()
@@ -382,6 +386,11 @@ class OneTextRuleAcrossKernelAndBackend(unittest.TestCase):
             uline(T0, "a\r\nb", "u9"),                                                  # a bare CR, preserved
             uline(T0, [{"type": "text", "text": "solo"}], "u9"),
             uline(T0, [{"type": "tool_result", "tool_use_id": "t", "content": "ok"}], "u9"),
+            uline(T0, "/deploy  staging\nnow", "u9"),                                   # slash-shaped: both add the command key
+            uline(T0, [{"type": "text", "text": "/deploy staging"}, {"type": "text", "text": "/rollback \n now"}], "u9"),
+            uline(T0, "/tmp/notes-api/api.py  is broken", "u9"),                         # a path: a plain message, no command key
+            # not listed: a raw <command-name> WRAPPER record. The kernel keys the parsed command atom and the
+            # scan derives "/name args" from the raw record itself (the class docstring; BackendScanAgrees pins it).
         ]
         for rec in recs:
             self.assertEqual(sb._landed_texts(rec), set(km._atom_user_texts(rec)), json.dumps(rec)[:120])

--- a/tests/test_kernel_slash_echo_retire.py
+++ b/tests/test_kernel_slash_echo_retire.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""A slash or skill command typed into the composer keeps its "sending" bubble although the turn runs
+(reported from a live dashboard, 2026-09-10). Claude Code records a slash send as a wrapper record
+(<command-message>, <command-name>, <command-args>) and, for a skill, a second record with the skill
+body; a verbatim copy of the typed text is not guaranteed. The event model reads the wrapper back as a
+command atom whose text is "/name args" with ONE space between the name and the args, whatever the sender
+typed there. The input echo holds the typed text, and the by-text landing rule is outer-strip only, so a
+send like "/deploy \\n\\nstaging now" never met its own record: the kernel's prune kept the echo forever,
+the backend's boot/spawn scan, which reads the raw records, called the send lost and RE-DELIVERED it, so
+the command ran twice after a kernel restart, and the fed-copy pairing left the landed event without the
+copy's id, so the chat's own pending bubble stayed as well.
+
+session_backend.command_text_key is the shared rule for slash-shaped texts: the whitespace-delimited
+tokens joined by single spaces, applied to the echo AND to the record on both paths (the kernel's
+_atom_user_texts and the backend's _landed_texts), so the two agree on the same records. The plain rule
+(echo_text_key) is unchanged for every other text. SYNTHETIC fixtures only: an invented command, a private
+synthetic sid, the notes-api demo domain."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads: they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_slash_echo", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_slash_echo", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+em = km.em
+
+SID = "3b5d7f9a-2c4e-4a6b-8d0f-1e3a5c7b9d2f"   # private synthetic sid (goal-store fixtures rule)
+TMUX_SID = "4c6e8a0b-3d5f-4b7c-9e1a-2f4b6d8c0e3a"
+T0 = 1_800_000_000
+NOW = T0 + 3600
+
+# The typed send: a space and two newlines between the command and its arguments.
+TYPED = "/deploy \n\nstaging now"
+
+
+def wrapper(name, args, order="message-first", skill=True):
+    """The record Claude Code writes for a slash send. A skill writes <command-message> first and marks
+    the record with <skill-format>; a built-in writes <command-name> first. Neither carries the typed
+    whitespace between the name and the arguments."""
+    tags = ["<command-message>%s</command-message>" % name.lstrip("/"),
+            "<command-name>%s</command-name>" % name]
+    if order == "name-first":
+        tags.reverse()
+    if args:
+        tags.append("<command-args>%s</command-args>" % args)
+    if skill:
+        tags.append("<skill-format>true</skill-format>")
+    return "\n".join(tags)
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None, meta=False, prompt_id=None):
+    r = {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+         "promptSource": "sdk", "message": {"role": "user", "content": text}}
+    if meta:
+        r["isMeta"] = True
+    if prompt_id:
+        r["promptId"] = prompt_id
+    return r
+
+
+def aline(t, text, uuid, parent, stop="end_turn"):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}], "stop_reason": stop}}
+
+
+def exchange():
+    """An earlier exchange, then the slash send's records: the wrapper and the skill body (both isMeta,
+    one promptId, no raw copy of the typed text anywhere), then the reply the command produced."""
+    return [uline(T0, "tighten the notes-api search", "u1"),
+            aline(T0 + 10, "Done.", "a1", "u1")]
+
+
+def slash_records(wrap, t=T0 + 100):
+    return [uline(t, wrap, "u2", "a1", meta=True, prompt_id="p1"),
+            uline(t, "Base directory for this skill: /tmp/notes-api/.claude/skills/deploy\n\nDeploy the service.",
+                  "u3", "u2", meta=True, prompt_id="p1"),
+            aline(t + 30, "Deploying staging now.", "a2", "u3")]
+
+
+class _World:
+    """A real SdkBackend bound as the kernel's backend, owning SID, with a thread-less SdkSession."""
+
+    def __init__(self):
+        self.td = tempfile.TemporaryDirectory()
+        root = Path(self.td.name)
+        (root / "sdk").mkdir()
+        self.cwd = root / "proj"; self.cwd.mkdir()
+        os.environ["CLAUDE_CONFIG_DIR"] = str(root / "claude")
+        self.tpath = Path(sb.transcript_path(str(self.cwd), SID))
+        self.tpath.parent.mkdir(parents=True, exist_ok=True)
+        self.tpath.write_text("")
+        self.be = sb.SdkBackend(str(root), "/bin/true", lambda *a, **k: None)
+        reg = {"sid": SID, "name": "web", "mode": "acceptEdits", "alive": True,
+               "cwd": str(self.cwd), "lastSid": SID}
+        sb.write_reg(self.be.state_dir, SID, reg)
+        self.s = sb.SdkSession(self.be, dict(reg))
+        self.be.sessions[SID] = self.s
+        self.saved = km._sdk
+        km._sdk = lambda: self.be
+
+    def close(self):
+        km._sdk = self.saved
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+        self.td.cleanup()
+
+    def write(self, recs):
+        self.tpath.write_text("".join(json.dumps(r) + "\n" for r in recs))
+
+    def parse(self):
+        return em.parse_session(str(self.tpath), rompuuid=SID, candidate_files=[str(self.tpath)],
+                                postal_log=[], now=NOW, sdk_human=True)
+
+    def echo(self, text, t):
+        key = "echo:slash"
+        self.be._live[SID] = {key: {"type": "user", "uuid": key, "session_id": SID, "t": t,
+                                     "parentUuid": None, "author": "human", "_echo_text": text,
+                                     "message": {"role": "user", "content": [{"type": "text", "text": text}]}}}
+        return key
+
+
+def _texts(session):
+    return [t for turn in session["turns"] for a in turn["atoms"] for t in km._atom_user_texts(a)]
+
+
+class TheSharedKey(unittest.TestCase):
+    """command_text_key: one rule, read by the kernel and the backend, for slash-shaped texts only."""
+
+    def test_a_slash_send_keys_to_its_words(self):
+        for mod in (km.sb, sb):
+            self.assertEqual(mod.command_text_key(TYPED), "/deploy staging now")
+            self.assertEqual(mod.command_text_key("  /deploy   staging\nnow \n"), "/deploy staging now")
+            self.assertEqual(mod.command_text_key("/deploy"), "/deploy")
+            self.assertEqual(mod.command_text_key("/plugin:skill  review the draft"), "/plugin:skill review the draft")
+
+    def test_anything_else_has_no_command_key(self):
+        for mod in (km.sb, sb):
+            self.assertEqual(mod.command_text_key("deploy \n\nstaging now"), "")
+            self.assertEqual(mod.command_text_key("/"), "")
+            self.assertEqual(mod.command_text_key(""), "")
+            self.assertEqual(mod.command_text_key(None), "")
+            # a message that starts with a PATH is a plain message: its first token has a further slash
+            self.assertEqual(mod.command_text_key("/tmp/build.log\n\nlook at this"), "")
+            self.assertEqual(mod.command_text_key("/tmp/notes-api/api.py is broken"), "")
+
+    def test_the_plain_rule_is_unchanged(self):
+        # outer whitespace stripped, nothing else: a plain send's internal whitespace still decides
+        self.assertEqual(km.sb.echo_text_key(TYPED), TYPED)
+        self.assertEqual(km.sb.echo_text_key("deploy \n\nstaging now\n"), "deploy \n\nstaging now")
+
+    def test_echo_keys_is_the_either_key_rule(self):
+        for mod in (km.sb, sb):
+            self.assertEqual(mod.echo_keys(TYPED), (TYPED, "/deploy staging now"))
+            self.assertEqual(mod.echo_keys("/deploy staging now"), ("/deploy staging now",), "one key when the two agree")
+            self.assertEqual(mod.echo_keys(" deploy staging now\n"), ("deploy staging now",))
+            self.assertEqual(mod.echo_keys(""), ())
+            self.assertEqual(mod.echo_keys(None), ())
+
+
+class WrapperReadingMatchesTheEventModel(unittest.TestCase):
+    """sdk_backend._command_invocation gives the landing scan (and the live atom) the "/name args" the event
+    model's file adapter gives the parsed command atom. The two are separate code; the scan is right only
+    while they agree, so they are compared on every wrapper shape the CLI writes."""
+
+    def setUp(self):
+        self.w = _World()
+
+    def tearDown(self):
+        self.w.close()
+
+    def test_every_wrapper_shape_reads_the_same_on_both_sides(self):
+        shapes = [wrapper("/deploy", "staging now"), wrapper("/deploy", "staging now", "name-first", skill=False),
+                  wrapper("/deploy", ""), wrapper("deploy", "staging now"),   # a name written without its slash
+                  wrapper("/deploy", "staging\n  now\nplease"),               # arguments over several lines
+                  "<command-name>/deploy</command-name>\n<command-message>deploy</command-message>\n<command-args>  staging now  </command-args>"]
+        for wrap in shapes:
+            with self.subTest(wrap=wrap.splitlines()[:3]):
+                self.w.write(exchange() + slash_records(wrap))
+                atoms = [a for t in self.w.parse()["turns"] for a in t["atoms"] if a.get("command")]
+                self.assertEqual(len(atoms), 1)
+                name, disp = sb._command_invocation(wrap)
+                self.assertEqual(atoms[0]["command"], name)
+                self.assertEqual(atoms[0]["message"]["content"][0]["text"], disp)
+                self.assertIn(km.sb.echo_text_key(disp), sb._landed_texts({"type": "user", "message": {"role": "user", "content": wrap}}))
+
+    def test_prose_that_quotes_a_tag_is_not_an_invocation(self):
+        self.assertIsNone(sb._command_invocation("the CLI writes a <command-name>/deploy</command-name> record, why?"))
+
+
+class KernelRetire(unittest.TestCase):
+    """The chat's path: build_session's _merge_live_atoms hands prune_live the parsed record texts."""
+
+    def setUp(self):
+        self.w = _World()
+        self.assertIs(km.Sessions.backend_for(SID), self.w.be)
+
+    def tearDown(self):
+        self.w.close()
+
+    def test_the_wrapper_record_retires_the_typed_echo(self):
+        for order in ("message-first", "name-first"):
+            with self.subTest(order=order):
+                self.w.write(exchange() + slash_records(wrapper("/deploy", "staging now", order)))
+                key = self.w.echo(TYPED, T0 + 95)
+                merged = km._merge_live_atoms(self.w.parse(), SID)
+                self.assertNotIn(key, self.w.be._live.get(SID, {}),
+                                 "the send's own record landed after the send: the echo retires")
+                self.assertEqual(_texts(merged).count("/deploy staging now"), 1, "the command shows once")
+                self.assertNotIn(TYPED, _texts(merged), "…and never as a second, pending bubble")
+
+    def test_arguments_with_irregular_whitespace_land_under_the_shared_key(self):
+        # the record's parsed text keeps whatever the sender typed INSIDE the arguments, so it can differ from
+        # the typed text there as well as between the name and the arguments: both sides key the record's text
+        # too, and the same words land whatever the spacing on either side. The scan agrees with the prune.
+        typed = "/deploy\nstaging  now"
+        self.w.write(exchange() + slash_records(wrapper("/deploy", "staging  now")))
+        key = self.w.echo(typed, T0 + 95)
+        self.assertIs(self.w.be._text_landed(SID, typed, T0 + 95), True)
+        merged = km._merge_live_atoms(self.w.parse(), SID)
+        self.assertNotIn(key, self.w.be._live.get(SID, {}), "the record's words are the echo's words")
+        self.assertEqual(_texts(merged).count("/deploy staging  now"), 1, "the command shows once, as its record")
+        self.assertNotIn(typed, _texts(merged))
+
+    def test_a_wrapper_for_another_command_or_other_args_keeps_it(self):
+        for other in (wrapper("/rollback", "staging now"), wrapper("/deploy", "production now"),
+                      wrapper("/deploy", "staging"), wrapper("/deploy", "")):
+            with self.subTest(other=other.splitlines()[:3]):
+                self.w.write(exchange() + slash_records(other))
+                key = self.w.echo(TYPED, T0 + 95)
+                km._merge_live_atoms(self.w.parse(), SID)
+                self.assertIn(key, self.w.be._live.get(SID, {}),
+                              "a different command's record is not this send's landing")
+
+    def test_a_wrapper_written_before_the_send_keeps_it(self):
+        # the record must be at or after the send: a re-send of an earlier command waits for its own record
+        self.w.write(exchange() + slash_records(wrapper("/deploy", "staging now"), t=T0 + 50))
+        key = self.w.echo(TYPED, T0 + 95)
+        km._merge_live_atoms(self.w.parse(), SID)
+        self.assertIn(key, self.w.be._live.get(SID, {}))
+
+    def test_a_plain_send_still_needs_its_exact_text(self):
+        # the collapse is for slash sends only: a plain message differing in whitespace is not a landing
+        self.w.write(exchange() + [uline(T0 + 100, "deploy  staging now", "u2", "a1"),
+                                   aline(T0 + 130, "ok", "a2", "u2")])
+        key = self.w.echo("deploy staging now", T0 + 95)
+        km._merge_live_atoms(self.w.parse(), SID)
+        self.assertIn(key, self.w.be._live.get(SID, {}))
+
+
+class BackendScanAgrees(unittest.TestCase):
+    """The backend's boot/spawn scan reads the RAW records; it must give the kernel's verdict on the same
+    ones, or a restart re-delivers a command that already ran."""
+
+    def setUp(self):
+        self.w = _World()
+
+    def tearDown(self):
+        self.w.close()
+
+    def test_the_scan_finds_the_send_in_its_wrapper_record(self):
+        self.w.write(exchange() + slash_records(wrapper("/deploy", "staging now")))
+        self.assertIs(self.w.be._text_landed(SID, TYPED, T0 + 95), True)
+
+    def test_the_scan_agrees_with_the_kernel_on_every_record(self):
+        cases = [(wrapper("/deploy", "staging now"), True), (wrapper("/deploy", "staging now", "name-first"), True),
+                 (wrapper("/rollback", "staging now"), False), (wrapper("/deploy", "production now"), False),
+                 (wrapper("/deploy", ""), False)]
+        for wrap, expect in cases:
+            with self.subTest(wrap=wrap.splitlines()[:3]):
+                self.w.write(exchange() + slash_records(wrap))
+                key = self.w.echo(TYPED, T0 + 95)
+                scan = self.w.be._text_landed(SID, TYPED, T0 + 95)
+                km._merge_live_atoms(self.w.parse(), SID)
+                kernel = key not in self.w.be._live.get(SID, {})
+                self.assertEqual((scan, kernel), (expect, expect))
+
+    def test_a_restart_does_not_run_the_command_twice(self):
+        # the spawn-time marking: the echo is un-pruned (the previous kernel died before a build), the
+        # queue is empty, the wrapper is on disk. The scan must find it: the verdict is `_landed`, nothing
+        # is re-queued and nothing is flagged lost.
+        self.w.write(exchange() + slash_records(wrapper("/deploy", "staging now")))
+        key = self.w.echo(TYPED, T0 + 95)
+        self.w.be._mark_dropped_echoes(SID, [])
+        echo = self.w.be._live[SID][key]
+        self.assertTrue(echo.get("_landed"), "the scan read the landing off the wrapper record")
+        self.assertFalse(echo.get("dropped"))
+        self.assertEqual(self.w.s.pending(), [], "never re-delivered: the command already ran")
+
+
+class LandingCarriesTheCopysId(unittest.TestCase):
+    """The chat's own pending bubble retires by IDENTITY once it has latched the copy's id: the kernel
+    stamps a landed user event with the id of the fed copy whose text it carries (qids_for_landing). The
+    wrapper's parsed text must pair with the typed copy, or the sender's bubble outlives the command."""
+
+    def setUp(self):
+        self.w = _World()
+
+    def tearDown(self):
+        self.w.close()
+
+    def _fed(self, text, qid="echo:slash"):
+        self.w.s._fed_meta.append({"qid": qid, "qts": None, "text": text, "t": T0 + 95})
+
+    def test_the_wrappers_parsed_text_pairs_with_the_typed_copy(self):
+        self._fed(TYPED)
+        self.assertEqual(self.w.s.qids_for_landing("u2", ["/deploy staging now"], T0 + 100), ["echo:slash"])
+        self.assertEqual(self.w.s._fed_meta, [], "the copy's entry is spent by its landing")
+
+    def test_another_command_does_not_spend_the_copy(self):
+        self._fed(TYPED)
+        self.assertEqual(self.w.s.qids_for_landing("u2", ["/deploy production now"], T0 + 100), [None])
+        self.assertEqual(self.w.s.qids_for_landing("u3", ["/rollback staging now"], T0 + 100), [None])
+        self.assertEqual(len(self.w.s._fed_meta), 1, "the typed copy still waits for its own landing")
+
+    def test_a_plain_copy_still_pairs_by_its_exact_text(self):
+        self._fed("deploy staging now", qid="echo:plain")
+        self.assertEqual(self.w.s.qids_for_landing("u2", ["deploy  staging now"], T0 + 100), [None])
+        self.assertEqual(self.w.s.qids_for_landing("u3", ["deploy staging now"], T0 + 100), ["echo:plain"])
+
+
+class TmuxEchoAgrees(unittest.TestCase):
+    """The tmux route's echo prune reads the same kernel-built texts."""
+
+    def tearDown(self):
+        km._tmux_echo.pop(TMUX_SID, None)
+
+    def _tx_texts(self, disp):
+        # the texts build_session hands the prune, from the command atom the event model reads the wrapper as
+        atom = {"type": "user", "uuid": "u2", "session_id": TMUX_SID, "t": T0 + 100, "author": "human",
+                "command": "/deploy", "message": {"role": "user", "content": [{"type": "text", "text": disp}]}}
+        return set(km._atom_user_texts(atom))
+
+    def test_the_parsed_command_atom_retires_the_typed_echo(self):
+        km._tmux_echo_add(TMUX_SID, TYPED)
+        self.assertEqual(len(km._tmux_echo_atoms(TMUX_SID)), 1)
+        km._tmux_echo_prune(TMUX_SID, set(), self._tx_texts("/deploy staging now"))
+        self.assertEqual(km._tmux_echo_atoms(TMUX_SID), [], "the command atom's text lands the typed echo")
+
+    def test_another_commands_atom_keeps_it(self):
+        km._tmux_echo_add(TMUX_SID, TYPED)
+        km._tmux_echo_prune(TMUX_SID, set(), self._tx_texts("/deploy production now"))
+        self.assertEqual(len(km._tmux_echo_atoms(TMUX_SID)), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_queued_copy_identity.py
+++ b/tests/test_queued_copy_identity.py
@@ -291,6 +291,34 @@ class TheChatCarriesTheIds(unittest.TestCase):
         landed = [e for e in m["events"] if e.get("kind") == "user" and e.get("md") == fed_text and not str(e.get("uuid", "")).startswith("echo:")]
         self.assertEqual([e.get("qid") for e in landed], [qid])
 
+    def test_a_slash_sends_wrapper_record_carries_the_typed_copys_id(self):
+        # A slash or skill command typed into the composer with its arguments on the next line: the CLI
+        # records it as a <command-name> wrapper (no verbatim copy of the typed text), which the kernel reads
+        # as "/deploy staging now" with one space. The chat's own pending bubble retires by id once it has
+        # latched the copy's, so the landed event must carry it although the texts differ in whitespace;
+        # and the kernel's echo, the other visible copy, retires on the same record (2026-09-10).
+        live = self.w.now - T0
+        self.w.write(RUNNING, shift=live)
+        typed = "/deploy \n\nstaging now"
+        self.assertTrue(self.w.be.send(SID, typed))
+        [qid] = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
+        with self.w.s._lock:
+            self.w.s._pop_for_feed_locked()
+        wrap = ("<command-message>deploy</command-message>\n<command-name>/deploy</command-name>\n"
+                "<command-args>staging now</command-args>\n<skill-format>true</skill-format>")
+        recs = RUNNING + [dict(uline(T0 + 55, wrap, "c1", "tr1"), isMeta=True, promptId="p1"),
+                          dict(uline(T0 + 55, "Base directory for this skill: /tmp/notes-api/.claude/skills/deploy\n\nDeploy the service.",
+                                     "c2", "c1"), isMeta=True, promptId="p1"),
+                          aline(T0 + 75, "Deploying staging now.", "a3", "c2")]
+        self.w.write(recs, shift=live)
+        m = self.w.build()
+        landed = [e for e in m["events"] if e.get("kind") == "user" and e.get("md") == "/deploy staging now"
+                  and not str(e.get("uuid", "")).startswith("echo:")]
+        self.assertEqual([e.get("qid") for e in landed], [qid], "the wrapper's event carries the typed copy's id")
+        echoes = [e for e in m["events"] if str(e.get("uuid", "")).startswith("echo:")]
+        self.assertEqual(echoes, [], "the kernel's echo retired on the same record")
+        self.assertNotIn(SID, self.w.be._live, "…and left the live store")
+
     def test_a_two_block_record_carries_both_copies_ids(self):
         live = self.w.now - T0
         self.w.write(RUNNING, shift=live)


### PR DESCRIPTION
## Symptom

A slash or skill command typed into the chat composer with its arguments on the line below keeps its "sending" bubble after the turn has run and replied, on every client, until the bubble is dismissed by hand. After a kernel restart the send is delivered again and the command runs twice. Reported from a live dashboard.

## Cause

Every landing check compares the echo's typed text with a transcript record's text under one key, `echo_text_key` (outer whitespace stripped, nothing else), and a slash send's record never carries the typed text. Claude Code records the send as a wrapper (`<command-message>`, `<command-name>`, `<command-args>`; a skill adds `<skill-format>` and a second record with the skill body). A verbatim copy is not guaranteed: some CLI versions write a raw twin record beside the wrapper, which the event model already drops as an invocation echo, and the reported transcript carried none. The event model reads the wrapper as a command atom whose text is `/name args`, with one space between the name and the arguments.

So `/deploy`, a newline, `staging now` never met `/deploy staging now`, and four readers failed at once:

- the kernel's prune (`prune_live`, through `_merge_live_atoms`) kept the echo, so the chat showed the pending bubble;
- the thread's held count (`_comments_frame`, `_landed`) kept owing a reply;
- the backend's boot and spawn scan (`_text_landed`) reads the raw records, where the wrapper's text equals no typed text at all, so it called the send lost and re-queued it, and the next spawn ran the command again;
- the fed-copy pairing (`qids_for_landing`) left the landed event without the copy's id, so the chat's own pending bubble, which retires by id, stayed too.

Measured on the unchanged sources with the new module's fixtures: the backend scan found no slash send of any shape; the kernel prune retired a typed command only when its whitespace already equalled the parsed form (`/deploy staging now` on one line) and kept `/deploy  staging now` and `/deploy` + newline + `staging now`.

Carrying the composer's press id through to the record would identify the send exactly, but the transcript never records it. Matching the wrapper's parsed form is the practical route.

## Fix

`session_backend.command_text_key` is a second key rule for slash sends: the whitespace-delimited tokens joined by single spaces, applied only when the first token is command-name-shaped (a slash, then no further slash or whitespace; a message that starts with a path keeps the plain rule). The same words in the same order match; a different command or different arguments never do. `echo_keys` returns the plain key and, for a slash send, the command key; it is the one place the either-key rule is written. Both live in `session_backend.py` because that module already holds the shared key rule (`sdk_backend.py` imports `echo_text_key` from there so the scan can never find what the prune cannot retire).

Both sides key both ways:

- Kernel: `_atom_user_texts` adds the command key for a slash-shaped record text. `_echo_landed_in` asks for either key at `build_session`'s queued count, `_merge_live_atoms`' display dedup and `_tmux_echo_prune`; `_comments_frame`'s held count asks the same keys against per-atom sets built once per frame.
- Backend: `_landed_texts` reads a wrapper record as the `/name args` the event model shows (`_command_invocation`, shared with `msg_to_atom`, which built the same string inline before) and adds the command key to every text; `_text_landed`, `prune_live` and `qids_for_landing` ask for either key.

The `command` flag stays off a typed send's echo; this PR explains it rather than changes it. The flag marks the CLI's own feedback atoms (the streamed wrapper and stdout, the picker chip), which owe no landing and are never flagged lost or re-delivered. A typed slash send is a message the CLI takes and records, so its echo keeps the full lifecycle, and flagging it would hide its loss. A comment at the echo's construction in `send` says so.

The rejudging latch in `build_feed` is unchanged: it arms off the parsed reply turn, never the echo, so a stranded echo cannot pin it either way; its comment now points at the new key. The Codex backend is unchanged: its echo readers (`_rec_texts`, its `prune_live`) compare under the plain key alone, and no wrapper reading exists for its records. `docs/read-side.md` names the second key where it described the one-key rule.

## Tests

`tests/test_kernel_slash_echo_retire.py` is new: 19 tests (four of them iterate subtests) over the real code paths, with synthetic fixtures (an invented `/deploy` command, a private synthetic sid, the notes-api demo domain). On the unchanged sources pytest reports 19 failures (9 tests and 10 subtests) and 10 passes: the 7 negative and plain-text cases that pin what the rule must not do, and the 3 parents of failing subtests.

- `TheSharedKey` (4): the key rule on both modules' copies. Three fail before on `AttributeError` (`command_text_key` and `echo_keys` do not exist); `test_the_plain_rule_is_unchanged` passes before and after.
- `WrapperReadingMatchesTheEventModel` (2): `_command_invocation` agrees with the event model's parse on six wrapper shapes (both tag orders, no args, a name without its slash, multi-line args, padded args), and prose quoting a tag is not an invocation. Both fail before: the helper does not exist.
- `KernelRetire` (5): the wrapper record retires the typed echo through `_merge_live_atoms`, in both tag orders (fails before: the echo stays). Arguments typed with irregular whitespace (`/deploy`, newline, `staging  now`, against a record whose arguments read `staging  now`) land on both sides, the scan and the prune (fails before: the scan misses, the echo stays). Another command, other args, no args, a wrapper written before the send, and a plain send differing in whitespace all keep the echo (pass before and after).
- `BackendScanAgrees` (3): `_text_landed` finds the send in its wrapper record; the scan and the kernel prune give the same verdict on five records; `_mark_dropped_echoes` at spawn marks the echo `_landed` and re-queues nothing. Before: the scan finds nothing, both positive records read as unlanded on both sides, and the spawn scan re-queues the send.
- `LandingCarriesTheCopysId` (3): `qids_for_landing` pairs the wrapper's parsed text with the typed copy (fails before: `[None]`). Another command does not spend the copy, and a plain copy still pairs by exact text (pass before and after).
- `TmuxEchoAgrees` (2): `_tmux_echo_prune` on the parsed command atom's texts retires the typed echo (fails before); another command's atom keeps it.

Cases added to existing modules:

- `tests/test_kernel.py::ViewBuilder::test_tmux_slash_sends_echo_is_not_counted_as_queued_once_its_wrapper_record_lands`: `build_session`'s queued count for a busy tmux-owned session, a typed `/deploy`, newline, `staging now` echo, and its wrapper record landing in the same second. Fails before: the typed text is listed under the queued indicator. That count runs only for a backend without `unqueue`, so none of the SDK-side cases reach it.
- `tests/test_comment_threads.py::ThreadProjection::test_a_slash_sends_echo_is_landed_by_its_wrapper_record`: the thread's held count reads the landing off the wrapper record, and another command's record is not this send's landing. Fails before: `queued` stays 1 after the record.
- `tests/test_queued_copy_identity.py::TheChatCarriesTheIds::test_a_slash_sends_wrapper_record_carries_the_typed_copys_id`: a real `send` through the backend, then the wrapper and skill-body records on disk. The landed event carries the typed copy's id and the echo leaves the live store. Fails before: the landed event's `qid` is None.
- `tests/test_kernel_fed_echo_absorbed.py::OneTextRuleAcrossKernelAndBackend`: three slash-shaped records join the scan-vs-prune parity pin (a command with irregular whitespace, two command blocks in one record, a path-leading message). This pin passes before and after; it holds the two sides to the same key set. A raw wrapper record is not in its list by design (the kernel keys the parsed command atom, the scan derives `/name args` from the raw record itself; `BackendScanAgrees` pins that agreement through the real parse), and the class docstring says so.

Each key site is held by a test that goes red when that site alone is reverted to the plain key: the queued count by the `test_kernel.py` case, the record-side key in either module by the irregular-whitespace case, with the parity pin excluded from the run.

Full suite: `pytest -q -n 6 tests/` on this head (tree `ca0759f5`): 10856 passed, 118 skipped, 0 failed, 1705 subtests passed (99 s, xdist 6 workers).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)