### PR TITLE
Tests: a lab kernel starts from a list of names, never a copy of the runner's environment, with a postal bus of its own that is never started

### DIFF
--- a/tests/test_awaiting_box_sync.py
+++ b/tests/test_awaiting_box_sync.py
@@ -28,6 +28,7 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -37,6 +38,9 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
 
 RENDER = open(os.path.join(ROOT, "ui", "webview", "render.ts")).read()
 
@@ -162,11 +166,7 @@ class ServedSync(unittest.TestCase):
                                     "stop_reason": "end_turn"}}) + "\n")
         cls.port = _free_port()
         cls.token = "testtok-awaitsync"
-        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
-                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist,
-                   ROMP_MODEL_CATALOG="off")   # hermetic: never reach the network
-        env.pop("ROMP_STATE_DIR", None)
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
                                       stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)

--- a/tests/test_dashboard_reload_served.py
+++ b/tests/test_dashboard_reload_served.py
@@ -34,8 +34,8 @@ SID = "11111111-2222-4333-8444-000000000201"
 
 import sys
 sys.path.insert(0, HERE)
-import test_ship_reship as _lab   # noqa: E402  the served lab's cfg.relaunch stanza (the module, not its classes:
-#                                   an imported TestCase would be collected here a second time)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment and the cfg.relaunch stanza (the module,
+#                                   not its classes: an imported TestCase would be collected here a second time)
 
 
 def _free_port():
@@ -196,18 +196,11 @@ class ServedAutoReload(unittest.TestCase):
         Path(proj, SID + ".jsonl").write_text(_transcript(cwd, 60))   # long: overflows the pane several times over
         cls.port = _free_port()
         cls.token = "testtok-autoreload"
-        cls.env = dict(os.environ,
-                       XDG_STATE_HOME=os.path.join(cls.lab, "xdg"),
-                       CLAUDE_CONFIG_DIR=claude,
-                       ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1",
-                       ROMP_SERVE_TOKEN=cls.token, ROMP_KERNEL_PORT=str(cls.port),
-                       ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off",
-                       ROMP_WS_KEEPALIVE="2",                       # the dv rides the keepalive: keep the wait short
-                       ROMP_TMUX_SOCKET="romp-autoreload-%d" % cls.port)
-        cls.env.pop("ROMP_STATE_DIR", None)
-        cls.env.pop("ANTHROPIC_API_KEY", None)
-        # a stand-in for a key the runner's shell carries: the lab's kernel gets it by process environment with the
-        # rest of the runner's, and the cfg.json the driver reads must never carry it
+        cls.env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token,
+                                  ROMP_WS_KEEPALIVE="2",                       # the dv rides the keepalive: keep the wait short
+                                  ROMP_TMUX_SOCKET="romp-autoreload-%d" % cls.port)
+        # a name outside the relaunch list, planted in the lab kernel's environment so the check on the cfg.json the
+        # driver reads has something the file must not carry
         cls.env["RUNNER_SECRET_PROBE"] = "abc"
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
@@ -249,7 +242,7 @@ class ServedAutoReload(unittest.TestCase):
         self.assertIn("RUNNER_SECRET_PROBE", sorted(self.env), "the lab plants the probe in its kernel's environment")
         written = json.loads(Path(cfg).read_text(encoding="utf-8"))
         self.assertNotIn("RUNNER_SECRET_PROBE", sorted(written["relaunch"]["env"]),
-                         "the lab's cfg.json carries a variable of the runner's environment the relaunch does not need")
+                         "the lab's cfg.json carries a name of the lab kernel's environment outside the relaunch list")
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
             f.write(DRIVER)

--- a/tests/test_feed_hover_border_static.py
+++ b/tests/test_feed_hover_border_static.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -25,6 +26,9 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
 
 SID = "aaaaaaaa-1111-2222-3333-888888888888"
 TOP = "dddddddd-1111-2222-3333-000000000001"
@@ -103,10 +107,7 @@ class ServedHoverKeepsTextStill(unittest.TestCase):
         os.makedirs(os.path.join(cls.lab, "xdg", "romp"), exist_ok=True)
         cls.port = _free_port()
         cls.token = "testtok-feedhover"
-        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=os.path.join(cls.lab, "claude"),
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
-                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
-        env.pop("ROMP_STATE_DIR", None)
+        env = _lab.kernel_env(cls.lab, os.path.join(cls.lab, "claude"), dist, cls.port, cls.token)
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
                                       stdout=open(os.path.join(cls.lab, "kernel.log"), "w"), stderr=subprocess.STDOUT, env=env)
         import urllib.request

--- a/tests/test_feed_thread_fold_columns.py
+++ b/tests/test_feed_thread_fold_columns.py
@@ -19,6 +19,7 @@ import os
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -27,6 +28,9 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
 
 SID = "aaaaaaaa-1111-2222-3333-777777777777"
 BLOCKED = "cccccccc-1111-2222-3333-000000000001"
@@ -192,10 +196,7 @@ class ServedFoldIsPerColumn(unittest.TestCase):
         os.makedirs(state, exist_ok=True)
         cls.port = _free_port()
         cls.token = "testtok-feedfold"
-        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=os.path.join(cls.lab, "claude"),
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
-                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
-        env.pop("ROMP_STATE_DIR", None)
+        env = _lab.kernel_env(cls.lab, os.path.join(cls.lab, "claude"), dist, cls.port, cls.token)
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
                                       stdout=open(os.path.join(cls.lab, "kernel.log"), "w"), stderr=subprocess.STDOUT, env=env)
         import urllib.request

--- a/tests/test_gear_select_matrix.py
+++ b/tests/test_gear_select_matrix.py
@@ -30,6 +30,7 @@ import os
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -40,6 +41,9 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
 # Hermetic state BEFORE the load — bin/romp-kernel resolves its state root at import time, and only
 # pytest runs conftest's floor (a bare unittest run otherwise writes REAL state).
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
@@ -159,14 +163,7 @@ class ServedMatrix(unittest.TestCase):
         os.makedirs(cls.state, exist_ok=True)
         cls.port = _free_port()
         cls.token = "testtok-matrix"
-        env = dict(os.environ,
-                   XDG_STATE_HOME=os.path.join(cls.lab, "xdg"),
-                   CLAUDE_CONFIG_DIR=os.path.join(cls.lab, "claude"),
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1",
-                   ROMP_SERVE_TOKEN=cls.token, ROMP_KERNEL_PORT=str(cls.port),
-                   ROMP_DIST_DIR=dist,
-                   ROMP_MODEL_CATALOG="off")   # hermetic: the T222 catalog fetch must never reach the network
-        env.pop("ROMP_STATE_DIR", None)
+        env = _lab.kernel_env(cls.lab, os.path.join(cls.lab, "claude"), dist, cls.port, cls.token)
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
                                       stdout=open(os.path.join(cls.lab, "kernel.log"), "w"),
                                       stderr=subprocess.STDOUT, env=env)

--- a/tests/test_log_opener_moved.py
+++ b/tests/test_log_opener_moved.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -24,6 +25,9 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
@@ -126,10 +130,7 @@ class ServedOpener(unittest.TestCase):
         os.makedirs(state, exist_ok=True)
         cls.port = _free_port()
         cls.token = "testtok-logopener"
-        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=os.path.join(cls.lab, "claude"),
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token, ROMP_KERNEL_PORT=str(cls.port),
-                   ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
-        env.pop("ROMP_STATE_DIR", None)
+        env = _lab.kernel_env(cls.lab, os.path.join(cls.lab, "claude"), dist, cls.port, cls.token)
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(os.path.join(cls.lab, "kernel.log"), "w"),
                                       stderr=subprocess.STDOUT, env=env)
         import urllib.request

--- a/tests/test_notification_tap_resume_browser.py
+++ b/tests/test_notification_tap_resume_browser.py
@@ -48,6 +48,7 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -57,6 +58,9 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
 
 SID_A = "aaaaaaaa-1111-2222-3333-444444444444"   # web: the session in front when the phone buzzes
 SID_B = "bbbbbbbb-1111-2222-3333-444444444444"   # api: the session that buzzed — where the tap must land
@@ -250,11 +254,7 @@ class ServedTapResume(unittest.TestCase):
             Path(proj, sid + ".jsonl").write_text(_transcript(sid, prompt, reply))   # a CLOSED turn: nothing to resume
         cls.port = _free_port()
         cls.token = "testtok-tapresume"
-        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
-                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist,
-                   ROMP_MODEL_CATALOG="off")   # hermetic: never reach the network
-        env.pop("ROMP_STATE_DIR", None)
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
         cls.klog_path = os.path.join(cls.lab, "kernel.log")
         cls.klog = open(cls.klog_path, "w")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=cls.klog, stderr=subprocess.STDOUT, env=env)

--- a/tests/test_paste_to_focus_browser.py
+++ b/tests/test_paste_to_focus_browser.py
@@ -21,6 +21,7 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -30,6 +31,9 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
 
 SID = "aaaaaaaa-1111-2222-3333-444444444444"
 REPLY = "The web session finished the notes-api login flow and every test passes now. Next up is the password reset path."
@@ -158,11 +162,7 @@ class ServedPaste(unittest.TestCase):
                                     "stop_reason": "end_turn"}}) + "\n")
         cls.port = _free_port()
         cls.token = "testtok-pastefocus"
-        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
-                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist,
-                   ROMP_MODEL_CATALOG="off")   # hermetic: never reach the network
-        env.pop("ROMP_STATE_DIR", None)
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
         cls.klog = open(os.path.join(cls.lab, "kernel.log"), "w")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
                                       stdout=cls.klog, stderr=subprocess.STDOUT, env=env)

--- a/tests/test_pending_at_tail.py
+++ b/tests/test_pending_at_tail.py
@@ -26,6 +26,7 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -36,6 +37,9 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
 
 SID = "aaaaaaaa-1111-2222-3333-444444444444"
 TEXT = "and also update the docstring"
@@ -211,11 +215,7 @@ class ServedPendingAtTail(unittest.TestCase):
                        "sessionId": SID, "attachment": {"type": "queued_command", "prompt": TEXT}}
         cls.port = _free_port()
         cls.token = "testtok-pendinginplace"
-        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
-                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
-        for k in ("ROMP_STATE_DIR", "ROMP_API_KEY_CMD", "ANTHROPIC_API_KEY"):
-            env.pop(k, None)
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
                                       stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)

--- a/tests/test_pending_bubble_stable.py
+++ b/tests/test_pending_bubble_stable.py
@@ -20,6 +20,7 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -30,6 +31,9 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
 
 SID = "aaaaaaaa-1111-2222-3333-444444444444"
 TEXT = "and also update the docstring"
@@ -227,11 +231,7 @@ class ServedPendingBubbleStable(unittest.TestCase):
                        "sessionId": SID, "attachment": {"type": "queued_command", "prompt": TEXT}}
         cls.port = _free_port()
         cls.token = "testtok-pendingstable"
-        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
-                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
-        for k in ("ROMP_STATE_DIR", "ROMP_API_KEY_CMD", "ANTHROPIC_API_KEY"):
-            env.pop(k, None)
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
                                       stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)

--- a/tests/test_queued_copy_held.py
+++ b/tests/test_queued_copy_held.py
@@ -22,6 +22,7 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -32,6 +33,9 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
 
 SID = "aaaaaaaa-1111-2222-3333-444444444444"
 TEXT = "and also update the docstring"
@@ -202,11 +206,7 @@ class ServedQueuedCopyHeld(unittest.TestCase):
                        "sessionId": SID, "attachment": {"type": "queued_command", "prompt": TEXT}}
         cls.port = _free_port()
         cls.token = "testtok-queuedheld"
-        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
-                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
-        for k in ("ROMP_STATE_DIR", "ROMP_API_KEY_CMD", "ANTHROPIC_API_KEY"):
-            env.pop(k, None)
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
                                       stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)

--- a/tests/test_refusal_notice_served.py
+++ b/tests/test_refusal_notice_served.py
@@ -17,6 +17,7 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -27,6 +28,9 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
 
 SID = "aaaaaaaa-1111-2222-3333-444444444444"
 NOTICE = ("The model's safeguards flagged this message. Switched to a fallback model. "
@@ -171,11 +175,7 @@ class ServedRefusalNotice(unittest.TestCase):
         Path(cls.transcript).write_text("".join(json.dumps(r) + "\n" for r in refusal_turn_records(t0)))
         cls.port = _free_port()
         cls.token = "testtok-refusalnotice"
-        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
-                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
-        for k in ("ROMP_STATE_DIR", "ROMP_API_KEY_CMD", "ANTHROPIC_API_KEY"):
-            env.pop(k, None)
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
                                       stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)

--- a/tests/test_remote_comment_name_served.py
+++ b/tests/test_remote_comment_name_served.py
@@ -21,6 +21,7 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -32,6 +33,9 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
 
 SID = "aaaaaaaa-1111-2222-3333-444444444444"
 REPLY = "Use exponential backoff with a jitter of ten percent."
@@ -129,13 +133,8 @@ def _kernel(lab, name, port, token, records=None, sid=None):
         proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
         os.makedirs(proj, exist_ok=True)
         Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in records))
-    env = dict(os.environ, XDG_STATE_HOME=os.path.join(lab, name, "xdg"), CLAUDE_CONFIG_DIR=claude,
-               ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=token,
-               ROMP_KERNEL_PORT=str(port), ROMP_DIST_DIR=os.path.join(lab, "dist"), ROMP_MODEL_CATALOG="off",
-               ROMP_HOST_NAME=name.upper(),
-               ROMP_POSTAL_PEERS="0")   # never the machine's shared postal bus (nor a bus spawned on its port)
-    for k in ("ROMP_STATE_DIR", "ROMP_API_KEY_CMD", "ANTHROPIC_API_KEY"):
-        env.pop(k, None)
+    env = _lab.kernel_env(os.path.join(lab, name), claude, os.path.join(lab, "dist"), port, token,
+                          ROMP_HOST_NAME=name.upper())
     log = os.path.join(lab, name + "-kernel.log")
     proc = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(log, "w"), stderr=subprocess.STDOUT, env=env)
     for _ in range(120):

--- a/tests/test_scroll_marks_click.py
+++ b/tests/test_scroll_marks_click.py
@@ -22,6 +22,7 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -31,6 +32,9 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
 
 SID = "aaaaaaaa-1111-2222-3333-555555555555"
 PROMPTS = 40                                       # long exchanges — the scroller's world (all resident: well under the kernel's WIRE_TAIL)
@@ -207,10 +211,7 @@ class ServedNotchClickJumps(unittest.TestCase):
         Path(proj, SID + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
         cls.port = _free_port()
         cls.token = "testtok-notchclick"
-        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
-                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
-        env.pop("ROMP_STATE_DIR", None)
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
                                       stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)

--- a/tests/test_scroll_marks_growth.py
+++ b/tests/test_scroll_marks_growth.py
@@ -28,6 +28,7 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -37,6 +38,9 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
 
 SID = "aaaaaaaa-1111-2222-3333-444444444444"
 
@@ -171,10 +175,7 @@ class ServedNotchFollowsGrowth(unittest.TestCase):
         Path(proj, SID + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
         cls.port = _free_port()
         cls.token = "testtok-notchgrowth"
-        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
-                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
-        env.pop("ROMP_STATE_DIR", None)
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
                                       stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)

--- a/tests/test_ship_reship.py
+++ b/tests/test_ship_reship.py
@@ -29,11 +29,15 @@ The guards here:
     re-shipped file. Its nack retires the last pending ship, which lets the restart's held
     reload fire on the next task, and the notice the nack raised (the file was not saved, the
     held message not sent) must be shown again by the fresh page, once.
+  * LabKernelEnv, which runs everywhere: a lab kernel's environment is built from names (kernel_env,
+    which every lab that boots a kernel uses), never from a copy of the runner's: a live kernel's
+    exports planted in the runner (ROMP_MANAGER_PID, ROMP_SERVE_HOST, its sid) are absent, the run's
+    floor and the lab's own names present, and the lab kernel's postal bus is a port of its own that
+    is never started.
   * RelaunchEnv, which runs everywhere: the relaunch stanza the lab writes to its cfg.json for the
-    driver's relaunch of the kernel carries only the environment the relaunched kernel needs, never
-    the runner's whole environment (a runner variable planted as a probe is absent; the lab's own
-    names, the run's private roots and its git isolation present); the served legs check the
-    written file itself.
+    driver's relaunch of the kernel carries only the names the relaunched kernel needs (a name
+    planted in the lab kernel's environment as a probe is absent; the lab's own names, the run's
+    private roots and its git isolation present); the served legs check the written file itself.
 
 All fixtures synthetic.
 """
@@ -131,17 +135,45 @@ def _free_port():
     return p
 
 
-# The environment the driver hands the kernel it relaunches rides the lab's cfg.json, a file, so it carries only
-# the names the relaunched kernel needs here: ROMP_* and XDG_*, CLAUDE_CONFIG_DIR, PATH (bin/romp-kernel runs under
-# `env python3`) and HOME, plus what tests/conftest.py sets for every child of the run: TMPDIR and TMUX_TMPDIR, the
-# private roots its temp files and its tmux server live under, and GIT_CONFIG_GLOBAL and GIT_CONFIG_NOSYSTEM, which
-# keep the kernel's boot-time git (the build sha, the release-tag probe) off the developer's git configuration.
-# Never the runner's whole environment: on a machine whose shells carry API keys, a copy of os.environ in that file
-# holds them for the run. The lab's own kernel is started from this process and gets its environment by process,
-# as any child does; only what goes to the file is narrowed.
+# A lab kernel's environment is built from names (kernel_env), never from a copy of the runner's. A run from a
+# session on a machine running romp carries the live kernel's exports, and a lab kernel that inherited them exited
+# when the live manager restarted (ROMP_MANAGER_PID, which kernel.py's _parent_watch reads), bound where the live
+# kernel serves (ROMP_SERVE_HOST) and, with no ROMP_POSTAL_PORT of its own, dialled the machine's postal bus at boot
+# (kernel.py's _ensure_postal_bus), or on a machine with none started a detached bus nothing stops. From the runner a
+# lab kernel takes PATH (bin/romp-kernel runs under `env python3`) and HOME, the XDG_* names (kernel/credentials.py
+# resolves the service.env default under XDG_CONFIG_HOME) and, of what tests/conftest.py sets for every child of the
+# run, TMPDIR and TMUX_TMPDIR, the private roots its temp files and its tmux server live under, GIT_CONFIG_GLOBAL and
+# GIT_CONFIG_NOSYSTEM, which keep the kernel's boot-time git (the build sha, the release-tag probe) off the
+# developer's git configuration, and the four ROMP_ names of its floor the lab does not set itself:
+# ROMP_SERVICE_ENV_FILE and ROMP_SERVICE_ENV (no real service.env), ROMP_CLAUDE_BIN (no real claude CLI) and
+# ROMP_CLI_SCOPE (no systemd-run). The lab's own names go over those, and a postal bus of its own: ROMP_POSTAL_PORT
+# at a free port with ROMP_POSTAL_PEERS=0 and ROMP_POSTAL_CLIENT_ONLY=1, so the kernel's boot-time ensure starts
+# nothing there (client-only applies in the legacy singleton scheme alone, postal_service.is_client_only).
+# The environment the driver hands the kernel it relaunches rides the lab's cfg.json, a file, so it is narrowed once
+# more (relaunch_env) to the ROMP_* and XDG_* names, CLAUDE_CONFIG_DIR, PATH and HOME and the four conftest names:
+# never anything else a lab put in its kernel's environment, such as the probe the served legs plant.
 RELAUNCH_ENV_PREFIXES = ("ROMP_", "XDG_")
 RELAUNCH_ENV_NAMES = frozenset(("CLAUDE_CONFIG_DIR", "PATH", "HOME", "TMPDIR", "TMUX_TMPDIR",
                                 "GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM"))
+KERNEL_ENV_NAMES = RELAUNCH_ENV_NAMES | frozenset(("ROMP_SERVICE_ENV_FILE", "ROMP_SERVICE_ENV",
+                                                    "ROMP_CLAUDE_BIN", "ROMP_CLI_SCOPE"))
+
+
+def kernel_env(lab, claude, dist, port, token, **seams):
+    """A lab kernel's environment: the runner's KERNEL_ENV_NAMES and XDG_* names; over them the lab's roots
+    (XDG_STATE_HOME under `lab`, CLAUDE_CONFIG_DIR `claude`, ROMP_DIST_DIR `dist`), its serve `port` and `token`, the
+    seams every lab kernel runs with, a postal bus of its own that is never started, and any `seams` the lab adds
+    by name. The kernel the lab starts gets it by process; the driver's relaunch gets relaunch_env() of it, through
+    the stanza relaunch_cfg() writes to the lab's cfg.json."""
+    env = {k: v for k, v in os.environ.items() if k in KERNEL_ENV_NAMES or k.startswith("XDG_")}
+    env.update(XDG_STATE_HOME=os.path.join(lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
+               ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1",
+               ROMP_SERVE_TOKEN=token, ROMP_KERNEL_PORT=str(port),
+               ROMP_DIST_DIR=dist,
+               ROMP_MODEL_CATALOG="off",     # hermetic: the T222 catalog fetch must never reach the network
+               ROMP_POSTAL_PORT=str(_free_port()), ROMP_POSTAL_PEERS="0", ROMP_POSTAL_CLIENT_ONLY="1")
+    env.update(seams)
+    return env
 
 
 def relaunch_env(env):
@@ -324,9 +356,9 @@ class _ShipLab(unittest.TestCase):
         Path(cls.png).write_bytes(PNG)
         cls.port = _free_port()
         cls.token = "testtok-reship"
-        cls.env = cls.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
-        # a stand-in for a key the runner's shell carries: the lab's kernel gets it by process environment with the
-        # rest of the runner's, and _run_driver checks that the cfg.json the driver reads never does
+        cls.env = kernel_env(cls.lab, claude, dist, cls.port, cls.token)
+        # a name outside the relaunch list, planted in the lab kernel's environment so _run_driver's check on the
+        # cfg.json the driver reads has something the file must not carry
         cls.env["RUNNER_SECRET_PROBE"] = "abc"
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
@@ -342,21 +374,6 @@ class _ShipLab(unittest.TestCase):
         else:
             cls.kernel.kill()
             raise unittest.SkipTest("hermetic kernel never served /healthz here")
-
-    @staticmethod
-    def kernel_env(lab, claude, dist, port, token):
-        """The lab kernel's environment: the runner's, with the lab's roots and seams over it. The kernel the lab
-        starts gets it by process; the driver's relaunch gets relaunch_env() of it, through the stanza
-        relaunch_cfg() writes to the lab's cfg.json."""
-        env = dict(os.environ,
-                   XDG_STATE_HOME=os.path.join(lab, "xdg"),
-                   CLAUDE_CONFIG_DIR=claude,
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1",
-                   ROMP_SERVE_TOKEN=token, ROMP_KERNEL_PORT=str(port),
-                   ROMP_DIST_DIR=dist,
-                   ROMP_MODEL_CATALOG="off")   # hermetic: the T222 catalog fetch must never reach the network
-        env.pop("ROMP_STATE_DIR", None)
-        return env
 
     @classmethod
     def tearDownClass(cls):
@@ -381,7 +398,7 @@ class _ShipLab(unittest.TestCase):
         self.assertIn("RUNNER_SECRET_PROBE", sorted(self.env), "the lab plants the probe in its kernel's environment")
         written = json.loads(Path(cfg).read_text(encoding="utf-8"))
         self.assertNotIn("RUNNER_SECRET_PROBE", sorted(written.get("relaunch", {}).get("env", {})),
-                         "the lab's cfg.json carries a variable of the runner's environment the relaunch does not need")
+                         "the lab's cfg.json carries a name of the lab kernel's environment outside the relaunch list")
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
             f.write(driver_src)
@@ -413,29 +430,28 @@ class _ShipLab(unittest.TestCase):
 
 class RelaunchEnv(unittest.TestCase):
     """The relaunch stanza a served lab writes to its cfg.json for the driver's relaunch of the kernel carries only
-    the environment the relaunched kernel needs, never the runner's whole environment: on a machine whose shells
-    carry API keys, a copy of os.environ in that file holds them for the run. No kernel and no browser, so this
-    runs everywhere; the served legs check the written file itself (_run_driver)."""
+    the names the relaunched kernel needs, never anything else a lab put in its kernel's environment: the file
+    holds it for the run. No kernel and no browser, so this runs everywhere; the served legs check the written file
+    itself (_run_driver)."""
 
-    def test_a_runner_variable_never_reaches_the_relaunch_env_and_the_kernels_names_do(self):
+    def test_a_planted_name_never_reaches_the_relaunch_env_and_the_kernels_names_do(self):
         lab = os.path.join(os.sep, "lab")
-        # the runner's shell: a stand-in for a key it carries, a live kernel's state export (it outranks the XDG root,
-        # and the lab removes it) and the floor tests/conftest.py sets for the run's children, planted here so the
-        # test asserts on values it chose rather than on conftest having set them
-        runner = {"RUNNER_SECRET_PROBE": "abc",
-                  "ROMP_STATE_DIR": os.path.join(lab, "live"),
+        # the runner's shell: a live kernel's state export (it outranks the XDG root; kernel_env never takes it) and
+        # the floor tests/conftest.py sets for the run's children, planted here so the test asserts on values it
+        # chose rather than on conftest having set them
+        runner = {"ROMP_STATE_DIR": os.path.join(lab, "live"),
                   "TMPDIR": os.path.join(lab, "tmp"), "TMUX_TMPDIR": os.path.join(lab, "tmux"),
                   "GIT_CONFIG_GLOBAL": os.path.join(lab, "gitconfig"), "GIT_CONFIG_NOSYSTEM": "1"}
         with mock.patch.dict(os.environ, runner):
-            env = _ShipLab.kernel_env(lab, os.path.join(lab, "claude"), os.path.join(lab, "dist"), 4321, "testtok")
-        self.assertIn("RUNNER_SECRET_PROBE", sorted(env), "the lab's own kernel inherits the runner's environment, by process")
+            env = kernel_env(lab, os.path.join(lab, "claude"), os.path.join(lab, "dist"), 4321, "testtok")
+        env["RUNNER_SECRET_PROBE"] = "abc"       # a name outside the relaunch list, planted as the served labs do
         cfg = relaunch_cfg(env, os.path.join(lab, "kernel.log"))
         self.assertEqual(cfg["cmd"], os.path.join(BIN, "romp-kernel"))
         self.assertEqual(cfg["log"], os.path.join(lab, "kernel.log"))
         out = cfg["env"]
         names = sorted(out)
-        self.assertNotIn("RUNNER_SECRET_PROBE", names, "the relaunch reads the file: a runner variable must not be in it")
-        self.assertNotIn("ROMP_STATE_DIR", names, "a live kernel's export outranks the XDG root; the lab removes it")
+        self.assertNotIn("RUNNER_SECRET_PROBE", names, "the relaunch reads the file: a name outside the list must not be in it")
+        self.assertNotIn("ROMP_STATE_DIR", names, "a live kernel's export outranks the XDG root; kernel_env never takes it")
         for name in ("XDG_STATE_HOME", "CLAUDE_CONFIG_DIR", "ROMP_MANAGER_PORT", "ROMP_KERNEL_NO_OPEN", "ROMP_SERVE_TOKEN",
                      "ROMP_KERNEL_PORT", "ROMP_DIST_DIR", "ROMP_MODEL_CATALOG", "PATH", "HOME"):
             self.assertIn(name, names, "the relaunched kernel needs %s" % name)
@@ -443,6 +459,80 @@ class RelaunchEnv(unittest.TestCase):
         self.assertEqual(out["ROMP_KERNEL_PORT"], "4321")
         for name in ("TMPDIR", "TMUX_TMPDIR", "GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM"):
             self.assertEqual(out.get(name), runner[name], "the run's %s reaches the relaunched kernel" % name)
+
+
+class LabKernelEnv(unittest.TestCase):
+    """A lab kernel's environment is built from names (kernel_env), never from a copy of the runner's. A run from a
+    session on a machine running romp carries the live kernel's exports, and a lab kernel that inherited them exited
+    when the live manager restarted (ROMP_MANAGER_PID), bound where the live kernel serves (ROMP_SERVE_HOST) and,
+    with no ROMP_POSTAL_PORT of its own, dialled the machine's postal bus at boot, or on a machine with none started
+    a detached bus nothing stops. No kernel and no browser, so this runs everywhere; every lab that boots a kernel
+    builds its environment through the same function."""
+
+    LAB = os.path.join(os.sep, "lab")
+    # the floor tests/conftest.py sets for the run's children, planted so the test asserts on values it chose
+    # rather than on conftest having set them
+    FLOOR = {"ROMP_SERVICE_ENV_FILE": os.path.join(LAB, "no-such-service.env"),
+             "ROMP_SERVICE_ENV": os.path.join(LAB, "no-such-service.env"),
+             "ROMP_CLAUDE_BIN": "/bin/false", "ROMP_CLI_SCOPE": "0",
+             "TMPDIR": os.path.join(LAB, "tmp"), "TMUX_TMPDIR": os.path.join(LAB, "tmux"),
+             "GIT_CONFIG_GLOBAL": os.path.join(LAB, "gitconfig"), "GIT_CONFIG_NOSYSTEM": "1"}
+    # an XDG_ name of the runner's: a lab kernel takes the XDG_* names (kernel/credentials.py resolves the service.env
+    # default under XDG_CONFIG_HOME); XDG_STATE_HOME is the one XDG_ name the lab sets itself
+    XDG = {"XDG_CONFIG_HOME": os.path.join(LAB, "config")}
+    # a live kernel's exports as a session's shell carries them, and a stand-in for a key the shell carries
+    LIVE = {"ROMP_MANAGER_PID": "4242", "ROMP_SERVE_HOST": "0.0.0.0", "ROMP_STATE_DIR": os.path.join(LAB, "live"),
+            "ROMP_SID": "cccccccc-1111-2222-3333-444444444444", "ROMP_SESSION_NAME": "web", "ROMP_SUPERVISED": "1",
+            "RUNNER_SECRET_PROBE": "abc"}
+    # what the lab itself puts in: its roots, the serve seams, and a postal bus of its own that is never started
+    OWN = {"XDG_STATE_HOME": os.path.join(LAB, "xdg"), "CLAUDE_CONFIG_DIR": os.path.join(LAB, "claude"),
+           "ROMP_MANAGER_PORT": "1", "ROMP_KERNEL_NO_OPEN": "1", "ROMP_SERVE_TOKEN": "testtok",
+           "ROMP_KERNEL_PORT": "4321", "ROMP_DIST_DIR": os.path.join(LAB, "dist"), "ROMP_MODEL_CATALOG": "off",
+           "ROMP_POSTAL_PEERS": "0", "ROMP_POSTAL_CLIENT_ONLY": "1"}
+    # the port a kernel with no ROMP_POSTAL_PORT of its own dials: the machine's bus, when a session's shell names it
+    MACHINE_BUS_PORT = "25302"
+
+    def _env(self, runner, **seams):
+        with mock.patch.dict(os.environ, runner):
+            if "ROMP_POSTAL_PORT" not in runner:
+                os.environ.pop("ROMP_POSTAL_PORT", None)
+            return kernel_env(self.LAB, os.path.join(self.LAB, "claude"), os.path.join(self.LAB, "dist"), 4321,
+                              "testtok", **seams)
+
+    def test_a_live_kernels_exports_never_reach_a_lab_kernel_and_the_floor_and_its_own_names_do(self):
+        env = self._env({**self.FLOOR, **self.XDG, **self.LIVE, "ROMP_POSTAL_PORT": self.MACHINE_BUS_PORT})
+        names = sorted(env)
+        for name in self.LIVE:
+            self.assertNotIn(name, names, "a live kernel's %s must never reach a lab kernel" % name)
+        for name, value in self.OWN.items():
+            self.assertEqual(env.get(name), value, "the lab's own %s" % name)
+        for name, value in {**self.FLOOR, **self.XDG}.items():
+            self.assertEqual(env.get(name), value, "the runner's %s reaches the lab kernel" % name)
+        for name in ("PATH", "HOME"):
+            self.assertIn(name, names, "the lab kernel needs %s" % name)
+        # every ROMP_ name is the lab's own or the run's floor: nothing else of the runner's
+        self.assertEqual({k for k in env if k.startswith("ROMP_")} - set(self.OWN) - set(self.FLOOR), {"ROMP_POSTAL_PORT"},
+                         "a ROMP_ name of the runner's reached the lab kernel")
+
+    def test_the_lab_kernels_postal_bus_is_a_port_of_its_own_and_is_never_started(self):
+        env = self._env({**self.FLOOR, "ROMP_POSTAL_PORT": self.MACHINE_BUS_PORT})
+        self.assertTrue(env.get("ROMP_POSTAL_PORT", "").isdigit(), "a bus port of its own: %r" % env.get("ROMP_POSTAL_PORT"))
+        self.assertNotEqual(env["ROMP_POSTAL_PORT"], self.MACHINE_BUS_PORT, "the machine's bus, never")
+        env = self._env(self.FLOOR)      # the runner names no bus at all: the lab kernel still gets one of its own
+        self.assertTrue(env.get("ROMP_POSTAL_PORT", "").isdigit(), "a bus port of its own: %r" % env.get("ROMP_POSTAL_PORT"))
+        self.assertNotEqual(env["ROMP_POSTAL_PORT"], self.MACHINE_BUS_PORT, "the default is the machine's bus")
+        # client-only applies in the legacy singleton scheme alone (postal_service.is_client_only), so both names go
+        # in: the kernel's boot-time ensure then starts nothing on that port
+        self.assertEqual((env["ROMP_POSTAL_PEERS"], env["ROMP_POSTAL_CLIENT_ONLY"]), ("0", "1"))
+
+    def test_a_labs_own_seams_go_over_the_names(self):
+        # names of the lab's own (ROMP_WS_KEEPALIVE, ROMP_HOST_NAME), one kernel_env sets for every lab
+        # (ROMP_KERNEL_NO_OPEN) and one of the run's floor (ROMP_CLI_SCOPE): the seam wins each time
+        env = self._env(self.FLOOR, ROMP_WS_KEEPALIVE="2", ROMP_HOST_NAME="TESTHOST", ROMP_KERNEL_NO_OPEN="0",
+                        ROMP_CLI_SCOPE="1")
+        self.assertEqual((env["ROMP_WS_KEEPALIVE"], env["ROMP_HOST_NAME"]), ("2", "TESTHOST"))
+        self.assertEqual((env["ROMP_KERNEL_NO_OPEN"], env["ROMP_CLI_SCOPE"]), ("0", "1"),
+                         "a seam goes over a name kernel_env sets for every lab and over the run's floor")
 
 
 class ServedWedge(_ShipLab):

--- a/tests/test_tab_groups_rows.py
+++ b/tests/test_tab_groups_rows.py
@@ -26,6 +26,7 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -35,6 +36,9 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
 
 # name → (sid, tags) ; the web tag is wide enough to wrap at a 640px viewport; "archived" folds by default;
 # web-search carries TWO tags and appears under both (T264b: tags are equivalent, no home tag)
@@ -168,10 +172,7 @@ class ServedGroupsOnOwnLines(unittest.TestCase):
         Path(cls.state, "timeline-views.json").write_text(json.dumps({"tags": tags, "tagOrder": [t[1] for t in TAGS]}))
         cls.port = _free_port()
         cls.token = "testtok-tabrows"
-        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
-                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
-        env.pop("ROMP_STATE_DIR", None)
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
                                       stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)


### PR DESCRIPTION
Builds on #1235 (merged), which narrowed what a served lab writes to its cfg.json for the driver's relaunch of the kernel (`relaunch_env`). This change narrows what the lab's own kernel starts with, one layer out, and gives every lab kernel a postal bus of its own.

## Symptom

Run the browser tests from a shell on a machine that is running romp (a session's shell, or one that carries the kernel's exports) and the hermetic lab kernels misbehave in three ways. A lab kernel exits in the middle of a test when the live manager restarts: it inherited ROMP_MANAGER_PID, which the kernel's `_parent_watch` treats as its own supervisor. A lab kernel binds where the live kernel serves (ROMP_SERVE_HOST), which need not be loopback. And each lab kernel's boot-time `romp-postal-service ensure` runs against the machine's bus port: on a machine with a bus, the lab kernel dials the live bus from then on; on one without, ensure starts a detached bus that no tearDown stops. The remote-comment lab set ROMP_POSTAL_PEERS=0 with a comment saying it stays off the machine's bus; that value only selects the legacy singleton scheme, and ensure still started a bus on the default port.

## Cause

Sixteen served test modules built their lab kernel's environment as `dict(os.environ, ...)` with the lab's roots and seams over it, popping ROMP_STATE_DIR and, in some, two key names, and the ship lab's `_ShipLab.kernel_env` did the same. Everything else in the runner's environment reached the lab kernel: the live kernel's ROMP_MANAGER_PID, ROMP_SERVE_HOST, ROMP_SID and ROMP_SESSION_NAME, its ROMP_POSTAL_PORT (or, with none, the default 25302), and whatever else the shell carried. `postal_service.is_client_only` returns False whenever `peers_on()` is true, and ROMP_POSTAL_PEERS=0 alone leaves ROMP_POSTAL_CLIENT_ONLY unset, so `ensure()` fell through to starting a bus.

## Fix

One function, `kernel_env` in tests/test_ship_reship.py beside `relaunch_env`, builds every lab kernel's environment from names. From the runner it takes PATH and HOME, the XDG_* names (kernel/credentials.py resolves the service.env default under XDG_CONFIG_HOME) and, of what tests/conftest.py sets for every child of the run, TMPDIR and TMUX_TMPDIR, GIT_CONFIG_GLOBAL and GIT_CONFIG_NOSYSTEM, and the four ROMP_ names of its floor the lab does not set itself (ROMP_SERVICE_ENV_FILE and ROMP_SERVICE_ENV, ROMP_CLAUDE_BIN, ROMP_CLI_SCOPE). Over those go the lab's roots and seams, any seams a lab adds by keyword, and a postal bus of its own: ROMP_POSTAL_PORT at a free port with ROMP_POSTAL_PEERS=0 and ROMP_POSTAL_CLIENT_ONLY=1 (both names, because client-only applies in the legacy scheme alone), so the kernel's boot-time ensure pings the private port and returns without starting anything. The seventeen modules that boot a kernel call it; their pops of ROMP_STATE_DIR and the key names go, since nothing beyond the list is taken. `relaunch_env` is unchanged; the probe the served labs plant for its cfg.json check is now planted in the lab kernel's environment directly, since the runner's no longer reaches it.

## Tests

- `LabKernelEnv` in tests/test_ship_reship.py (no kernel, no browser, runs everywhere) plants in os.environ a live kernel's exports (ROMP_MANAGER_PID, ROMP_SERVE_HOST, ROMP_STATE_DIR, ROMP_SID, ROMP_SESSION_NAME, ROMP_SUPERVISED), a synthetic RUNNER_SECRET_PROBE, the conftest floor, an XDG_CONFIG_HOME of the runner's and the machine's bus port, then builds a lab kernel's environment. Three tests: none of the exports or the probe is present, the floor, the runner's XDG_CONFIG_HOME and the lab's own names are, and every ROMP_ name is the lab's or the floor's; ROMP_POSTAL_PORT is a port of its own, with the runner naming the machine's bus and with the runner naming none, next to ROMP_POSTAL_PEERS=0 and ROMP_POSTAL_CLIENT_ONLY=1; a lab's own seams go over the names, including a name kernel_env sets for every lab (ROMP_KERNEL_NO_OPEN) and one of the floor (ROMP_CLI_SCOPE). Before the change all three fail: the module-level function is absent, and run against the earlier `_ShipLab.kernel_env` they fail on ROMP_MANAGER_PID present, ROMP_POSTAL_PORT equal to 25302, and the keyword seams rejected. Each clause of the helper has a case that fails without it: dropping the XDG_* pass-through fails the first test, and applying the seams before the lab's names fails the third.
- `RelaunchEnv` keeps its assertions and now plants its probe in the lab kernel's environment, as the served labs do.
- The seventeen kernel-booting modules ran locally against Chromium, serially: 43 passed, no skips. Under parallel workers their dist copies can hit the race `copy_dist` (#1238) fixes on main after this branch's base; it runs before `kernel_env` is called.
- A served lab whose kernel never serves /healthz skips rather than fails, so a module that went back to copying the runner's environment would read as skips on a machine running romp, not as a failure; `LabKernelEnv` is the executing check, on the helper itself.
- Full suite on this tree (six workers): 10774 passed, 41 skipped, 1 failed: `tests/test_ship_reship.py::ServedWedge::test_restart_between_ship_and_ack_reships_heals_and_releases_the_held_send`, the Chromium restart-heal leg, on `reloadHeldWhileBusy` None with the kernel healed and the reload fired. It passes alone on this tree (4 of 4 runs) and in the serial run above, and it is known to fail under load on main without this change; the environment path it drives (boot, kill, relaunch from the written env, heal) succeeded.

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)