### PR TITLE
Timeline: a live lane whose goal store faulted is derived, not served from the memo

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36482,9 +36482,10 @@ def _dead_lane_marks(marks, t0):
 #             object every build (live_tail).
 #   goals     the store the loop reads seams from (_segs_seam) and nodes from (_derive_judging_marks): a FrozenStore
 #             by identity (load_goals_shared serves one per file version, so a publish or a journal append is a new
-#             object); a store with neither seams nor nodes, or None after a fault, as "empty", since the two
-#             fields read are empty whatever its identity; any other private store is not held (unshared_skip: a
-#             mutable store could change under the entry).
+#             object); a store with neither seams nor nodes as "empty", since the two fields read are empty
+#             whatever its identity; any other private store is not held (unshared_skip: a mutable store could
+#             change under the entry). None after a fault is derived and not held (complain_skip): the derivation
+#             skips the marks for it, so it is not the empty store, and a skip compares and stores no key.
 #   captions  _stat_key of captions/<sid>.jsonl, taken by build_timeline BEFORE _captions reads the file (_captions
 #             builds a new dict per call, so the file is the input). Stat before read: a row appended between the
 #             two is read by this build and held under the OLD key, so the next build's stat misses and derives
@@ -36502,16 +36503,16 @@ def _dead_lane_marks(marks, t0):
 #             reads it; a sentinel (the stat failed) matches nothing and nothing is stored under it.
 #   sid       the entry's key; the bars and marks carry it.
 # NOT inputs: the clock. The horizon (now - TL_HORIZON) and JUDGE_CAP_LIMIT are applied per build by
-# _judging_assemble, and nothing else in the segment part reads a time. A lane whose parse failed, or whose seams
-# or marks stage complained (the derivation's own try/excepts), is derived and not held (complain_skip). The held
-# bars are shared by identity into every later build's turns[sid], the bars wire cache and the delta parts, none
-# of which writes to them (_bind_message_execs mutates the messages only; _timeline_skeleton copies the frame),
-# and the held marks into `semantic`, which _run_judging only reads. Entries are dropped for lanes outside a full
-# build's lane set (_lanes_forget) and past _LANES_MEMO_MAX, the least recently served first; an entry whose parse
-# object is no longer the build's is dropped when seen, since it cannot hit again and it holds that parse; the
-# dead-lane populate pops a lane's entry when the lane dies (the entry holds the parse the populate releases). One
-# lock around get, put, evict and the counters; the derivation runs unlocked, so two threads deriving one lane both
-# store an exact entry and the last wins.
+# _judging_assemble, and nothing else in the segment part reads a time. A lane whose parse failed, whose goal store
+# faulted, or whose seams or marks stage complained (the derivation's own try/excepts), is derived and not held
+# (complain_skip). The held bars are shared by identity into every later build's turns[sid], the bars wire cache
+# and the delta parts, none of which writes to them (_bind_message_execs mutates the messages only;
+# _timeline_skeleton copies the frame), and the held marks into `semantic`, which _run_judging only reads. Entries
+# are dropped for lanes outside a full build's lane set (_lanes_forget) and past _LANES_MEMO_MAX, the least
+# recently served first; an entry whose parse object is no longer the build's is dropped when seen, since it cannot
+# hit again and it holds that parse; the dead-lane populate pops a lane's entry when the lane dies (the entry holds
+# the parse the populate releases). One lock around get, put, evict and the counters; the derivation runs unlocked,
+# so two threads deriving one lane both store an exact entry and the last wins.
 _lanes_memo = {}          # sid -> (session, goals_obj, caps_key, key, value, prompts); value = _lane_segments' tuple,
 #                           prompts its full_prompts map (T278b)
 _LANES_MEMO_MAX = 256
@@ -36669,12 +36670,18 @@ def _lane_memo(sid, parsed, session, goals, caps, cap_key, live, bft, parse_ok=T
     True on every call here. `parsed` is the _parse object and `session` the one after _merge_live_atoms, the
     same object unless a live tail was merged; `cap_key` is the captions file's _stat_key taken before _captions
     read it (None when the file could not be stat'd); `parse_ok` is False when the parse failed and `session` is the
-    empty stand-in. `full_prompts` (T278b) receives the lane's whole prompts by bar id, on a hit from the entry and on
-    a miss from the derivation, so the binder reads them either way."""
+    empty stand-in; `goals` is None when the store faulted (build_timeline complained), and such a lane is derived and
+    not held, as the dead-lane path derives and never caches one. `full_prompts` (T278b) receives the lane's whole
+    prompts by bar id, on a hit from the entry and on a miss from the derivation, so the binder reads them either way."""
     if isinstance(goals, jd.FrozenStore):
         gobj, gtag = goals, "shared"
     elif goals is None or (not goals.get("seams") and not goals.get("nodes")):
-        gobj, gtag = None, "empty"   # None: the store FAULTED (build_timeline complained); no seams, no marks
+        gobj, gtag = None, "empty"   # no seams, no nodes: the two fields read are empty whatever the store's identity.
+        #                              None (the store FAULTED: build_timeline complained) lands here too and is a skip
+        #                              below, so its key is never compared and never stored: _lane_segments derives NO
+        #                              marks for None while the empty store still yields the captioner's and the
+        #                              archiver's, and held under one key, a lane across a fault was served the other
+        #                              side's marks (review find on the memo, 2026-09-09)
     else:
         gobj, gtag = None, None
     if cap_key is not None:
@@ -36685,8 +36692,8 @@ def _lane_memo(sid, parsed, session, goals, caps, cap_key, live, bft, parse_ok=T
         ckey = None                  # rows read with no file to stat: this build's rows have no key, not held
     arch_key = jd._file_key(str(jd.STATE / "archive" / (sid + ".json")))   # BEFORE the derivation reads it
     key = (live, bft, tuple(_downtime), gtag, arch_key)
-    if not parse_ok:
-        skip = "complain_skip"
+    if not parse_ok or goals is None:
+        skip = "complain_skip"       # the parse or the goals stage complained: derived, said so, not held
     elif session is not parsed:
         skip = "live_tail"
     elif gtag is None:

--- a/tests/test_timeline_lane_memo.py
+++ b/tests/test_timeline_lane_memo.py
@@ -1028,6 +1028,64 @@ class NotHeld(LaneMemoBase):
         self.build()
         self.assertEqual(self.outcomes()["miss"], 2, "a published store is a new input")
 
+    def test_a_faulted_store_is_derived_and_not_held(self):
+        """A store that cannot be read (goals None: build_timeline complained) shares no key with the lane that has
+        no store: _lane_segments derives NO marks for None, while the empty store still yields the captioner's and
+        the archiver's. Both keyed as "empty" once, so a lane whose unreadable store was then removed was served the
+        faulted build's empty marks until another input moved. A faulted store is derived and not held (the goals
+        stage complained: complain_skip), and the lane without a store derives on the next build."""
+        self.write_archive(self.now - 50, "retry loop")
+        store = km.jd.GOALDIR / (LIVE_SID + ".json")
+        store.parent.mkdir(parents=True, exist_ok=True)
+        store.write_text(json.dumps({"nodes": {}, "status": {}}))
+        store.chmod(0)                                 # unreadable: load_goals_shared raises, the boundary answers None
+        err = io.StringIO()
+        try:
+            with redirect_stderr(err):
+                tl1 = self.build()
+        finally:
+            store.chmod(0o600)
+        self.assertIn("goals failed", err.getvalue())
+        self.assertEqual(self.marks(tl1), [], "a faulted store: the lane's marks are missing, loudly")
+        self.assertEqual(self.outcomes(), {"hit": 0, "miss": 0, "live_tail": 0, "complain_skip": 1, "unshared_skip": 0})
+        self.assertEqual(self.stats()["entries"], 0)
+        store.unlink()                                 # no store now: load_goals' fresh private store, the empty key
+        tl2 = self.build()
+        self.assertEqual([m["x"] for m in self.marks(tl2, judge="archiver")], ["retry loop"],
+                         "derived, not served the faulted build's marks: the archiver's mark is this lane's")
+        self.assertEqual(self.outcomes(), {"hit": 0, "miss": 1, "live_tail": 0, "complain_skip": 1, "unshared_skip": 0})
+
+    def test_a_held_lane_whose_store_faults_is_derived(self):
+        """The reverse transition: a lane held with no store (the archiver's mark in its entry) whose store then
+        appears unreadable is derived, as a fresh derivation of a faulted store is (no marks), and not served the
+        entry's marks; the entry stands, and serves again once the store reads as absent."""
+        self.write_archive(self.now - 50, "retry loop")
+        tl1 = self.build()
+        self.assertEqual([m["x"] for m in self.marks(tl1, judge="archiver")], ["retry loop"])
+        self.assertEqual(self.stats()["entries"], 1)
+        store = km.jd.GOALDIR / (LIVE_SID + ".json")
+        store.parent.mkdir(parents=True, exist_ok=True)
+        store.write_text(json.dumps({"nodes": {}, "status": {}}))
+        store.chmod(0)
+        err = io.StringIO()
+        try:
+            with redirect_stderr(err):
+                tl2 = self.build()
+        finally:
+            store.chmod(0o600)
+        self.assertIn("goals failed", err.getvalue())
+        self.assertEqual(self.marks(tl2), [], "the store faulted: derived without marks, never the held entry's")
+        self.assertEqual(self.outcomes(), {"hit": 0, "miss": 1, "live_tail": 0, "complain_skip": 1, "unshared_skip": 0})
+        self.assertEqual(self.stats()["entries"], 1, "a skip stores nothing and drops nothing")
+        store.unlink()
+        tl3 = self.build()
+        self.assertEqual([m["x"] for m in self.marks(tl3, judge="archiver")], ["retry loop"],
+                         "no store again: the standing entry serves, and it equals a fresh derivation")
+        self.assertEqual(self.outcomes()["hit"], 1)
+        self.assertEqual(json.dumps(tl3["judging"][LIVE_SID]), json.dumps(tl1["judging"][LIVE_SID]),
+                         "the served frame is the first build's derivation, on the same inputs")
+        self.assertEqual(json.dumps(tl3["turns"][LIVE_SID]), json.dumps(tl1["turns"][LIVE_SID]))
+
     def test_a_lane_without_captions_hits_under_the_empty_rule(self):
         self.assertFalse((km.jd.CAPDIR / (LIVE_SID + ".jsonl")).exists())
         self.build(); self.build()


### PR DESCRIPTION
Follow-up to #1241, from its review: the finding that a faulted goal store and a store with no file shared one key in the live-lane memo.

## Symptom

A live lane whose goal store could not be read and was then removed, or whose missing store appeared unreadable, kept the wrong judging marks in its band until its transcript, captions, archive or store moved: the archiver's and the captioner's marks stayed missing after the store was gone, or stayed shown while it could not be read. One lane's judging band only; healed by the next transcript append.

## Cause

`_lane_memo` keyed a faulted store (`goals` None, after `build_timeline` complained) and a store with neither seams nor nodes both as `"empty"`, on the reasoning that the two fields read are empty either way. But `_lane_segments` derives no marks at all for None (`_derive_judging_marks` is not called), while for the empty store it still derives the captioner's marks from the captions file and the archiver's from the archive. A lane held across the transition hit the entry the other side had stored and was served its marks.

## Fix

In `_lane_memo` (kernel/kernel.py), a faulted store is a skip: derived and not held, counted under `complain_skip` (the goals stage complained, as `_bars_complain` says; the counter set on `/perf` `memos.lanes` is unchanged). Its key stays the empty store's, and a skip never compares or stores a key, so the shared key no longer reaches the memo; the comment on that arm, the input comment above `_lanes_memo` and the function's docstring say so. The dead-lane path already derives a faulted lane every build and never caches it; the live path now does the same. docs/reference.md's description of `complain_skip` (the parse or a stage failed) already covers it.

## Tests

Two on the `LaneMemoBase` fixture in tests/test_timeline_lane_memo.py (`NotHeld`), both faulting the store through the real loader (an unreadable goals file), with an archive written so the two derivations differ:

- `test_a_faulted_store_is_derived_and_not_held`: the store unreadable, then removed. Before the change the faulted build counted a miss and stored an entry ({'miss': 1, 'complain_skip': 0}), and the store-less build was served it with no archiver mark ([] where ['retry loop'] is derived). After: one `complain_skip`, no entry, and the store-less build derives the archiver's mark.
- `test_a_held_lane_whose_store_faults_is_derived`: a lane held with no store, whose store then appears unreadable. Before the change the faulted build was served the entry's archiver mark. After: derived without marks, one `complain_skip`, the entry stands, and once the store reads as absent again the entry serves a frame equal to the first build's derivation (the lane's judging and turns compared as JSON).

Full pytest on this head (`pytest -n 6 tests/`): 10836 passed, 118 skipped, 0 failed, 1688 subtests passed.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)