### PR TITLE
The notified-cards snapshot persists, so a kernel restart re-announces nothing and the same card in the same column is announced once

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -645,6 +645,13 @@ switches indented under it, and a button:
   switch off, the answer adds that real notifications will not arrive until it
   is on.
 
+A restart of the kernel (an update deploys one) announces nothing by itself.
+What Romp has told you about is written down beside its other state, so the
+cards already waiting on you or already finished when it comes back stay
+quiet. A card that stops needing you and then needs you again is announced
+once, not at every turn, unless you acted on the card in between (answered
+it, resolved it, crossed it off) or it finished in the meantime.
+
 The handler that answers a tap lives on the phone, and the phone refreshes it
 whenever you open the app and whenever a notification arrives. If a tap ever
 opens Romp on the wrong session, close the app from the app switcher and open

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5970,20 +5970,24 @@ def _set_notify_session(sid, value):
         _write_state_json(jd.STATE / "session-flags.json", json.dumps(cur, sort_keys=True))
 
 
-def _prune_notify_cards(live_ids):
-    """Drop armed ids whose card is no longer in the feed (cleared/archived — the id never comes back).
-    Called from the feed-diff detector, so the write happens only on the event of a card leaving.
-    The reserved keys (the master, the turn-finished switch) are not cards and never prune; values
-    are kept as stored (False = a mute)."""
+def _prune_notify_cards(live_ids, gone_ids=()):
+    """Drop armed ids whose card is no longer in the feed (cleared/archived — the id never comes back),
+    and the `gone_ids` a caller names outright. Called from the feed-diff detector, so the write happens
+    only on the event of a card leaving; and from the compaction sweep (_notify_prev_forget_gone), which
+    has no build in hand, so it passes `live_ids` None (nothing pruned by absence) and names as `gone_ids`
+    the cards it just forgot from the notified snapshot: a session gone for good takes its cards' mutes
+    with it. The reserved keys (the master, the turn-finished switch) are not cards and never prune;
+    values are kept as stored (False = a mute)."""
     try:
         cur = _notify_cards_proved()   # PROVED: a fault must not prune against a fabricated {} and then
         #                                write the truncation over the user's real bell overrides
     except _StateUnreadable as e:
         _note_state_fault(e)                         # loud once per episode, not per pass
         return
-    gone = [i for i in cur if i not in live_ids and i not in _NOTIFY_RESERVED]
+    gone = {i for i in cur if i not in _NOTIFY_RESERVED
+            and (i in gone_ids or (live_ids is not None and i not in live_ids))}
     if gone:
-        kept = {i: cur[i] for i in cur if i in live_ids or i in _NOTIFY_RESERVED}
+        kept = {i: cur[i] for i in cur if i not in gone}
         try:
             _write_state_json(jd.STATE / "notify-cards.json", json.dumps(kept, sort_keys=True))
         except _StateUnwritable:
@@ -32414,6 +32418,7 @@ def _compact_goal_stores():
         jd._shared_evict_absent()                      # ...and the shared read-only views of removed stores
     except Exception:
         pass
+    owned = None                                   # the discovered sessions' sids, once the walk below lands
     try:
         # ...and, for the two memos that hold PARSED stores, the entries of stores no discovered session
         # owns: neither had a cap (review find, 2026-09-08). discover is cached behind the transcript
@@ -32424,6 +32429,15 @@ def _compact_goal_stores():
         _goals_memo_evict_unowned(owned)
     except Exception:
         sys.stderr.write("compact: memo eviction: %s\n" % traceback.format_exc())
+    if owned is not None:
+        try:
+            # ...and the notified-cards snapshot's entries for sessions GONE for good: neither alive, nor in
+            # that discover window, nor a dead tab kept open, the bound session-order.json wears. The build
+            # forgets a card only when its session renders without it, which such a session never does
+            # again (review find on the persist, 2026-09-10). Same rule as above: no owner list, no gone.
+            _notify_prev_forget_gone(owned)
+        except Exception:
+            sys.stderr.write("compact: notified snapshot: %s\n" % traceback.format_exc())
     try:
         paths = glob.glob(str(jd.GOALDIR / "*.json"))
     except Exception:
@@ -41730,12 +41744,19 @@ def _pure_feed(now, tmux):
 # STATE/notify-prev.json — {card id: {"column", "sid"}} for every stable card in a notified column, the
 # small subset the diff needs — written when it changes, read once at the first build of a life to seed
 # the memory. Two rules follow from the mechanism:
-#   * a card is forgotten (in memory and on disk) only when ITS OWN SESSION rendered this build without
-#     it — cleared, archived, folded away: the id never comes back. A session that did not render at
-#     all (not yet revived, dead, off the board) says nothing about its cards, so they stay remembered
-#     and its revival is silent. The roster is the build's `sessions` rows (the live tab strip, minus
-#     the dead read-only tabs the user kept open, which render no cards) plus the sessions the rendered
-#     cards themselves name. The bell overrides' prune rides the same event: a remembered card is not gone.
+#   * a card is forgotten (in memory and on disk) on one of TWO events. The build forgets it when ITS OWN
+#     SESSION rendered this build without it — cleared, archived, folded away: the id never comes back.
+#     A session that did not render at all (not yet revived, dead, off the board) says nothing about its
+#     cards, so they stay remembered and its revival is silent. The roster is the build's `sessions`
+#     rows (the live tab strip, minus the dead read-only tabs the user kept open, which render no cards)
+#     plus the sessions the rendered cards themselves name. The compaction sweep after each judge pass
+#     forgets it when its session is GONE for good: neither alive, nor with a transcript still in the
+#     discover window, nor a dead tab kept open (_notify_prev_forget_gone, the bound session-order.json
+#     already wears). Such a session never renders again, so the build alone kept its cards forever (a
+#     card cleared from the dashboard while its session was dead left the board without that session
+#     ever rendering without it). So the store holds the live board's notified cards plus those of the
+#     dead sessions still in the discover window, and no more. The bell overrides' prune rides both
+#     events: a remembered card is not gone, and a forgotten card's mutes go with it.
 #   * the FIRST boot of an install with no file yet seeds from the current board SILENTLY — announcing
 #     every card sitting in the columns of an existing install would be the very storm this fixes — and
 #     the next life is fully event-true. A card missing from an EXISTING file that sits in a notified
@@ -41768,6 +41789,10 @@ _NOTIFY_COLUMNS = ("needs_input", "completed")
 _NOTIFY_PREV = [None]
 _NOTIFY_PREV_DISK = [None]    # what notify-prev.json last held: a write happens only when the snapshot changes
 _NOTIFY_PREV_WRITE_FAULT = [None]   # the last write failure's text — said once per episode; a landed write clears it
+# The snapshot has two writers since the sweep's bound: the pusher's build (_feed_notifications, read to
+# swap) and the producer's compaction sweep (_notify_prev_forget_gone). Each holds this for its whole
+# read-modify-write, so neither publishes a snapshot built from the other's superseded one.
+_notify_prev_lock = threading.Lock()
 
 
 def _notify_prev_path():
@@ -41876,6 +41901,37 @@ def _notify_prev_write(snap):
     _NOTIFY_PREV_DISK[0] = snap
 
 
+def _notify_prev_forget_gone(owned):
+    """The compaction sweep's bound on the snapshot (review find on the persist, 2026-09-10): forget, in
+    memory and on disk, every remembered card whose session is GONE for good, and drop its bell overrides
+    with it. Gone means what it means for session-order.json (_gc_session_order): neither alive, nor with
+    a transcript still in the discover window (`owned`, the sweep's own discover set), nor a dead tab the
+    user kept open. The build forgets a card only when its session RENDERS without it, and a session
+    gone for good never renders again: its worktree deleted, never revived, its card cleared from the
+    dashboard while it was dead (a clear reads the goal store, not the session). So the build alone kept
+    such cards forever, and the bell store, pruned against the snapshot since the persist, kept their
+    mutes with them. A session merely dead-but-in-window keeps its cards remembered, so its revival
+    stays silent; the discover window slides forward only, so a forgotten card never flickers back.
+    Nothing to do before this life's first build: the file is not in memory yet, the first build seeds
+    it, and the next sweep bounds it. Returns how many cards were forgotten."""
+    if not _NOTIFY_PREV[0]:
+        return 0
+    known = set(_tmux_sessions()) | set(owned) | set(_kept_open)   # outside the lock: liveness may ask tmux
+    with _notify_prev_lock:
+        prev = _NOTIFY_PREV[0]
+        gone = {i for i, e in (prev or {}).items() if e.get("sid") not in known}
+        if not gone:
+            return 0
+        kept = {i: e for i, e in prev.items() if i not in gone}
+        _NOTIFY_PREV[0] = kept
+        _notify_prev_write(kept)
+        _prune_notify_cards(None, gone_ids=gone)     # a forgotten card's mutes go with it
+    sids = {prev[i].get("sid") for i in gone}
+    sys.stderr.write("[notify] forgot %d card%s of %d session%s gone for good\n"
+                     % (len(gone), "" if len(gone) == 1 else "s", len(sids), "" if len(sids) == 1 else "s"))
+    return len(gone)
+
+
 def _notify_title(name, needs_you=False):
     """The ONE title every notification wears — desktop, phone, test push, and a relayed event as
     its origin composed it (the user 2026-09-09, whose phone found the notifications too busy: a
@@ -41918,6 +41974,12 @@ def _feed_notifications(feed):
     can land ON the session that fired (the user 2026-08-08, whose first real push opened the app on a
     different session); itemId joined it 2026-09-06 so the same tap can also scroll the feed to the card
     itself."""
+    with _notify_prev_lock:                          # read to swap as one step: the sweep prunes the same snapshot
+        return _feed_notifications_diff(feed)
+
+
+def _feed_notifications_diff(feed):
+    """The diff itself, under the snapshot's lock (see _notify_prev_lock)."""
     prev = _NOTIFY_PREV[0]
     first_boot = False
     if prev is None:                                 # the first build of this kernel life
@@ -41937,7 +41999,8 @@ def _feed_notifications(feed):
     # render no cards), plus whichever session a rendered card names
     roster = ({str(s.get("sid") or "") for s in (feed.get("sessions") or []) if isinstance(s, dict)}
               - set(_kept_open)) | {str(a.get("sid") or "") for a in cur.values()}
-    nxt = {i: e for i, e in prev.items() if i not in cur and e.get("sid") not in roster}   # unrendered: remembered
+    nxt = {i: e for i, e in prev.items() if i not in cur and e.get("sid") not in roster}   # unrendered: remembered,
+    #                                                until the sweep finds the session gone for good (_notify_prev_forget_gone)
     now_t = int(feed.get("now") or time.time())   # the build's own moment: wall clock, like the journal's t
     entered = []                                     # (itemId, card, column, entry): the cards that ENTERED a column
     for iid, a in cur.items():

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3418,7 +3418,7 @@ _atomic_lock = threading.Lock()
 _atomic_seq = [0]
 
 
-def _write_state_json(path, text, note=True):
+def _write_state_json(path, text, note=True, mode=None):
     """The ONE write door for the small JSON state files (session-flags, session-order, notify-cards,
     timeline-views): _atomic_write, with the publish's OSError turned into
     _StateUnwritable and the fault filed ONCE per episode on the path's registry (_note_state_fault, the
@@ -3430,10 +3430,11 @@ def _write_state_json(path, text, note=True):
     `note=False` raises the same _StateUnwritable but files NO notice and opens no write-fault episode:
     for a write that is housekeeping rather than a gesture (the views reader's re-stamp on read), where
     a failure is a log line the caller writes itself and the first GESTURE that fails is what the user
-    hears about (the views store's 2026-09-05 rule; the flags, order and bell stores never pass it)."""
+    hears about (the views store's 2026-09-05 rule; the flags, order and bell stores never pass it).
+    `mode` reaches _atomic_write: the notified-cards snapshot (notify-prev.json) publishes at 0600."""
     path = Path(path)
     try:
-        _atomic_write(path, text)
+        _atomic_write(path, text, mode=mode)
     except OSError as e:
         exc = _StateUnwritable(path, "write failed: %s" % _errno_text(e))
         if note:
@@ -41715,11 +41716,164 @@ def _pure_feed(now, tmux):
 # The master bell (bottom-right → notify-cards.json "*"), a session's bell (timeline lane / tab menu →
 # session-flags "notify") or a card's bell (right-click → notify-cards.json) arm OS-level notifications
 # — resolved most-specific-wins by _notify_card_effective — fired when an armed card ENTERS needs_input
-# (blocked on you) or completed. Detection diffs each fresh feed build against the previous one — the exact event
-# the columns move on, no separate heuristic — and the FIRST build after a kernel start is a silent
-# baseline: existing state is status, not news (the same policy as extension.ts freshNeedsYou). A card
-# re-entering needs_input later (a new block after an answer) notifies again by construction.
-_NOTIFY_PREV = [None]   # itemId -> column at the last build; None = baseline pending
+# (blocked on you) or completed. Detection diffs each fresh feed build against the remembered snapshot —
+# the exact event the columns move on, no separate heuristic. A card re-entering needs_input later (a
+# new block after an answer) notifies again by construction.
+#
+# THE SNAPSHOT PERSISTS (2026-09-10). _NOTIFY_PREV used to live in memory alone, and the first build of
+# a kernel life was a silent baseline (existing state is status, not news). But the sessions come back
+# one at a time after a restart — the SDK backend revives them — so that baseline saw a partial board,
+# and every card a later-revived session brought with it "appeared" already in needs_input or completed
+# and was announced AGAIN, on every restart. Auto-update restarts the kernel on every deploy; one
+# evening's ~8 restarts turned 8 cards into 30 phone pushes, one card twelve times. The event is the
+# card ENTERING the column, and a restart is not that event. So the snapshot lives in
+# STATE/notify-prev.json — {card id: {"column", "sid"}} for every stable card in a notified column, the
+# small subset the diff needs — written when it changes, read once at the first build of a life to seed
+# the memory. Two rules follow from the mechanism:
+#   * a card is forgotten (in memory and on disk) only when ITS OWN SESSION rendered this build without
+#     it — cleared, archived, folded away: the id never comes back. A session that did not render at
+#     all (not yet revived, dead, off the board) says nothing about its cards, so they stay remembered
+#     and its revival is silent. The roster is the build's `sessions` rows (the live tab strip, minus
+#     the dead read-only tabs the user kept open, which render no cards) plus the sessions the rendered
+#     cards themselves name. The bell overrides' prune rides the same event: a remembered card is not gone.
+#   * the FIRST boot of an install with no file yet seeds from the current board SILENTLY — announcing
+#     every card sitting in the columns of an existing install would be the very storm this fixes — and
+#     the next life is fully event-true. A card missing from an EXISTING file that sits in a notified
+#     column at boot is announced, once: it entered while no kernel was watching.
+#
+# THE SAME (CARD, COLUMN) IS ANNOUNCED ONCE (2026-09-10, the second half of the same night's ledger): a
+# card on a busy coordinating session left needs_input and came back at every turn end — the judges
+# re-filing the block, the unblocker's re-examination — with nothing from the user in between, and each
+# re-entry pushed again: one card, twelve pushes, no restart involved. Leaving a column and coming back
+# is not new information for the user unless something happened in between that is, so each entry
+# records the column it was last ANNOUNCED for (`announced`, with `announcedAt`) and a re-entry into
+# that same column is silent, with two exceptions, both from authoritative records:
+#   * the card was announced in the OTHER notified column since — needs_input → completed →
+#     needs_input is three distinct announcements; needs_input → working → needs_input is one;
+#   * the USER acted on the card since it was last announced — a resolve, a targeted reply, a cross-off
+#     or its undo, a re-distill — read from the per-session override journal (overrides/<sid>.jsonl),
+#     the durable record of every user gesture on a goal that load_goals replays; never the kernel's own
+#     rows there (a nudge/interrupt block, a romp-authored clear). A plain reply in the thread is not a
+#     gesture on the card and is not journaled, so a re-block after one stays silent: the user is in
+#     that thread already, and the board shows the card.
+# A working card keeps its announced mark in the store until its session renders without it, so the
+# rule holds across a restart too. The silent first-boot seed counts as told (the user has the board).
+# The desktop notice and the phone push both iterate the list this diff returns, so the one gate covers
+# both legs; _buzz_claim's one-buzz-per-turn-end rule sits after it, unchanged.
+_NOTIFY_COLUMNS = ("needs_input", "completed")
+# itemId -> {"sid", "column" (the notified column the card was last SEEN in, None while it sits in
+# working), "announced" (the column last announced, None if never), "announcedAt" (seconds)}; the
+# store holds a card while it is in a notified column or carries an announced mark. None = this life's
+# first build pending.
+_NOTIFY_PREV = [None]
+_NOTIFY_PREV_DISK = [None]    # what notify-prev.json last held: a write happens only when the snapshot changes
+_NOTIFY_PREV_WRITE_FAULT = [None]   # the last write failure's text — said once per episode; a landed write clears it
+
+
+def _notify_prev_path():
+    return jd.STATE / "notify-prev.json"        # resolved per call: tests redirect jd.STATE
+
+
+def _notify_prev_load():
+    """The snapshot the last kernel life left, or None when the install has none yet (a first boot: the
+    caller seeds silently). A file that exists but cannot be read, or torn bytes (moved aside by
+    _read_state_json, the evidence kept), reads as None too, with a [notify] line: this store is
+    bookkeeping the life rebuilds on its own, and treating it as absent costs one silent seed where a
+    raise would take the pusher down. Entries not of the shape _notify_prev_entry checks are skipped
+    and counted — an entry we cannot read is no memory of the card."""
+    p = _notify_prev_path()
+    try:
+        raw = _read_state_json(p, expect=dict)
+    except _StateUnreadable as e:
+        sys.stderr.write("[notify] %s — seeding silently from the current board instead\n" % e)
+        return None
+    if raw is None:
+        return None
+    out, bad = {}, 0
+    for iid, ent in raw.items():
+        ent = _notify_prev_entry(ent)
+        if ent is not None:
+            out[str(iid)] = ent
+        else:
+            bad += 1
+    if bad:
+        sys.stderr.write("[notify] %s: %d entr%s of an unknown shape skipped\n"
+                         % (p.name, bad, "y" if bad == 1 else "ies"))
+    return out
+
+
+def _notify_prev_entry(ent):
+    """One store entry, checked field by field, or None for a shape none of our writers produce: sid a
+    string; column a notified column or None (the card sits in working with an announced mark);
+    announced a notified column or None; announcedAt a number or None; and at least one of column /
+    announced set, else there is nothing to remember."""
+    if not isinstance(ent, dict) or not isinstance(ent.get("sid"), str):
+        return None
+    col, ann, at = ent.get("column"), ent.get("announced"), ent.get("announcedAt")
+    if col not in _NOTIFY_COLUMNS and col is not None:
+        return None
+    if ann not in _NOTIFY_COLUMNS and ann is not None:
+        return None
+    if at is not None and not isinstance(at, (int, float)):
+        return None
+    if col is None and ann is None:
+        return None
+    return {"sid": ent["sid"], "column": col, "announced": ann, "announcedAt": int(at) if at is not None else None}
+
+
+def _notify_user_acted_since(sid, iid, since):
+    """Did the user act ON this card after `since` (seconds)? Read from the per-session override journal
+    (overrides/<sid>.jsonl) — the durable, append-only record of every user gesture on a goal, the one
+    load_goals replays: a resolve, a targeted reply (followup), a cross-off or its undo, a re-distill.
+    The kernel's own rows there do not count: a nudge/interrupt `block`, a romp-authored `clear`
+    (src other than user), a `restore` payload (its `unclear` twin carries the gesture). Read on a
+    candidate re-entry only, so the cost is one small file per flap, never per build. A journal that
+    exists but cannot be read answers no, with a [notify] line — the silent side is the safe one here."""
+    if not sid:
+        return False
+    try:
+        _, lines = jd._journal_read(sid)
+    except OSError as e:
+        sys.stderr.write("[notify] overrides/%s.jsonl unreadable (%s) — reading the card as not acted on\n"
+                         % (sid, _errno_text(e)))
+        return False
+    for ln in lines:
+        try:
+            row = json.loads(ln)
+        except ValueError:
+            continue
+        if not isinstance(row, dict) or row.get("node") != iid:
+            continue
+        try:
+            t = int(row.get("t") or 0)
+        except (TypeError, ValueError):
+            continue
+        if t <= int(since or 0):
+            continue
+        op = row.get("op")
+        if op == "block" or (op == "clear" and row.get("src") != "user"):
+            continue
+        return True
+    return False
+
+
+def _notify_prev_write(snap):
+    """Publish the snapshot when it differs from what the file last held (a build that changes nothing
+    writes nothing). 0600 — no other reader needs it — through the one atomic write door. A failure
+    is a [notify] line once per episode, not the dashboard's not-saved notice (this is bookkeeping,
+    not a gesture the user is waiting on), and the next build retries."""
+    if snap == _NOTIFY_PREV_DISK[0]:
+        return
+    try:
+        _write_state_json(_notify_prev_path(), json.dumps(snap, sort_keys=True), note=False, mode=0o600)
+    except _StateUnwritable as e:
+        text = str(e)
+        if _NOTIFY_PREV_WRITE_FAULT[0] != text:
+            _NOTIFY_PREV_WRITE_FAULT[0] = text
+            sys.stderr.write("[notify] %s — the next kernel life may announce these cards again\n" % text)
+        return
+    _NOTIFY_PREV_WRITE_FAULT[0] = None
+    _NOTIFY_PREV_DISK[0] = snap
 
 
 def _notify_title(name, needs_you=False):
@@ -41754,36 +41908,72 @@ def _system_notify(title, body):
 
 
 def _feed_notifications(feed):
-    """Diff this feed build against the last; return [(title, body, sid, itemId)] for every ARMED
-    card that newly entered needs_input or completed (including a card appearing already there —
-    work can surface blocked). Also advances the prev map and prunes armed ids whose card left the
-    feed. sid rides along so a push notification's tap can land ON the session that fired (the
-    user 2026-08-08, whose first real push opened the app on a different session); itemId joined
-    it 2026-09-06 so the same tap can also scroll the feed to the card itself."""
+    """Diff this feed build against the remembered snapshot; return [(title, body, sid, itemId)] for
+    every ARMED card that newly entered needs_input or completed — including a card appearing already
+    there in a session that rendered before without it (work can surface blocked), but NOT a card a
+    restart or a revival brings back in the column it was last announced in, and NOT a re-entry into
+    the column the card was last announced for unless the other column was announced since or the user
+    acted on the card since (the persisted snapshot above). Also advances the snapshot, in memory and
+    on disk, and prunes armed ids whose card left the feed. sid rides along so a push notification's tap
+    can land ON the session that fired (the user 2026-08-08, whose first real push opened the app on a
+    different session); itemId joined it 2026-09-06 so the same tap can also scroll the feed to the card
+    itself."""
     prev = _NOTIFY_PREV[0]
+    first_boot = False
+    if prev is None:                                 # the first build of this kernel life
+        prev = _notify_prev_load()
+        first_boot = prev is None
+        if first_boot:
+            prev = {}
+        else:
+            sys.stderr.write("[notify] seeded %d cards from disk\n" % len(prev))
+        _NOTIFY_PREV_DISK[0] = None if first_boot else dict(prev)
     cur = {}
     for a in feed.get("asks") or []:
         if a.get("provisional"):
             continue                                 # placeholder churn — not a stable card yet
         cur[str(a.get("itemId"))] = a
-    _NOTIFY_PREV[0] = {i: a.get("column") for i, a in cur.items()}
-    _prune_notify_cards(set(cur))
-    if prev is None:
-        return []                                    # baseline: existing state is status, not news
-    cards = _notify_cards()
-    out = []
+    # the sessions that RENDERED this build: the live roster minus the dead read-only tabs (they
+    # render no cards), plus whichever session a rendered card names
+    roster = ({str(s.get("sid") or "") for s in (feed.get("sessions") or []) if isinstance(s, dict)}
+              - set(_kept_open)) | {str(a.get("sid") or "") for a in cur.values()}
+    nxt = {i: e for i, e in prev.items() if i not in cur and e.get("sid") not in roster}   # unrendered: remembered
+    now_t = int(feed.get("now") or time.time())   # the build's own moment: wall clock, like the journal's t
+    entered = []                                     # (itemId, card, column, entry): the cards that ENTERED a column
     for iid, a in cur.items():
-        col = a.get("column")
-        if col not in ("needs_input", "completed") or prev.get(iid) == col:
-            continue
-        if not _notify_card_effective(cards, iid, str(a.get("sid") or "")):
-            continue
-        needs_you = col == "needs_input"                # the card's column: the authoritative state, not the words
-        what = "Needs you" if needs_you else "Completed"
-        txt = str(a.get("text") or "").strip()
-        out.append((_notify_title(a.get("name") or "session", needs_you),
-                    "%s: %s" % (what, txt[:140] if txt else "a task changed state"),
-                    str(a.get("sid") or ""), iid))
+        col, sid, ent = a.get("column"), str(a.get("sid") or ""), prev.get(iid)
+        if col in _NOTIFY_COLUMNS:
+            e = {"sid": sid, "column": col,
+                 "announced": ent.get("announced") if ent else None,
+                 "announcedAt": ent.get("announcedAt") if ent else None}
+            nxt[iid] = e
+            if first_boot:
+                e["announced"], e["announcedAt"] = col, now_t     # the seed counts as told: the user has the board
+            elif ent is None or ent.get("column") != col:
+                entered.append((iid, a, col, e))
+        elif ent is not None and ent.get("announced"):
+            # in working now, but announced before: the mark is what keeps a return to that column silent
+            nxt[iid] = {"sid": sid, "column": None, "announced": ent["announced"], "announcedAt": ent.get("announcedAt")}
+    out = []
+    if not first_boot:
+        cards = _notify_cards()
+        for iid, a, col, e in entered:
+            if not _notify_card_effective(cards, iid, e["sid"]):
+                continue
+            if e["announced"] == col and not _notify_user_acted_since(e["sid"], iid, e["announcedAt"]):
+                continue                             # the same (card, column), told already, nothing of the user's since
+            e["announced"], e["announcedAt"] = col, now_t
+            needs_you = col == "needs_input"            # the card's column: the authoritative state, not the words
+            what = "Needs you" if needs_you else "Completed"
+            txt = str(a.get("text") or "").strip()
+            out.append((_notify_title(a.get("name") or "session", needs_you),
+                        "%s: %s" % (what, txt[:140] if txt else "a task changed state"),
+                        e["sid"], iid))
+    _NOTIFY_PREV[0] = nxt
+    _notify_prev_write(nxt)                          # after the marks: the file records what was told
+    _prune_notify_cards(set(cur) | set(nxt))         # a card still remembered is not gone
+    if first_boot:
+        sys.stderr.write("[notify] no snapshot on disk — seeded %d cards from the board silently\n" % len(nxt))
     return out
 
 

--- a/tests/test_notify_bells.py
+++ b/tests/test_notify_bells.py
@@ -284,7 +284,8 @@ class NotifyTitle(unittest.TestCase):
         # _notify_title; no producer composes a "romp: …" title of its own, and the relay no longer
         # rewrites the title it is handed (it used to graft "romp: <origin>:" onto it)
         import inspect
-        for fn in (km._feed_notifications, km._turn_notify_tick, km._push_test):
+        # the card leg's body lives in _feed_notifications_diff (the wrapper only takes the snapshot's lock)
+        for fn in (km._feed_notifications_diff, km._turn_notify_tick, km._push_test):
             self.assertIn("_notify_title(", inspect.getsource(fn), fn.__name__)
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertNotIn('"romp: %s"', src, "no producer composes a title of its own")

--- a/tests/test_notify_bells.py
+++ b/tests/test_notify_bells.py
@@ -5,8 +5,9 @@ session-flags "notify") and a per-card bell (feed card right-click → notify-ca
 notifications, resolved most-specific-wins (card > session > master) — so the master on means every
 task notifies and the per-item bells read as mutes. Fired when an armed card ENTERS needs_input
 (blocked on you) or completed. Detection diffs each fresh feed build against the previous one — the
-exact event the columns move on — and the first build after a kernel start is a silent baseline
-(existing state is status, not news). Synthetic ids/names only."""
+exact event the columns move on — against a snapshot that persists across kernel lives
+(tests/test_notify_prev_persist.py): an install's very first build is a silent baseline (existing
+state is status, not news), and a restart re-announces nothing. Synthetic ids/names only."""
 import json
 import os
 import sys
@@ -137,7 +138,7 @@ class FeedNotifications(unittest.TestCase):
     def test_the_first_build_is_a_silent_baseline(self):
         km._set_session_flag("TESTSID", "notify", True)
         out = km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input")))
-        self.assertEqual(out, [], "existing state on start is status, not news (freshNeedsYou policy)")
+        self.assertEqual(out, [], "an install's first build, no snapshot yet: status, not news (freshNeedsYou policy)")
 
     def test_a_session_armed_card_entering_needs_input_notifies(self):
         km._set_session_flag("TESTSID", "notify", True)
@@ -186,13 +187,18 @@ class FeedNotifications(unittest.TestCase):
         out = km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input")))
         self.assertEqual(out, [], "still blocked is not news — only the ENTRY event notifies")
 
-    def test_reblocking_after_an_answer_notifies_again(self):
+    def test_reblocking_without_a_gesture_on_the_card_is_one_announcement(self):
+        # 2026-09-10: a card that leaves needs_input and comes back is not news unless something of
+        # the user's happened on the card in between (a journaled gesture — tests/test_notify_prev_persist.py
+        # has the exception) or the other column was announced since; the judges re-filing a block at
+        # every turn end of a busy session pushed one card twelve times
         km._set_session_flag("TESTSID", "notify", True)
         km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "working")))
-        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input")))
-        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "working")))     # answered
+        first = km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input")))
+        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "working")))     # the judges lifted it
         out = km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input")))
-        self.assertEqual(len(out), 1, "a NEW block after the answer is a new event")
+        self.assertEqual(len(first), 1)
+        self.assertEqual(out, [], "the same card in the same column, told already: silent")
 
     def test_a_card_appearing_already_blocked_notifies(self):
         km._set_session_flag("TESTSID", "notify", True)

--- a/tests/test_notify_prev_persist.py
+++ b/tests/test_notify_prev_persist.py
@@ -13,7 +13,10 @@ The snapshot now persists to STATE/notify-prev.json ({card id: {sid, column, ann
 announcedAt}}: the notified column the card was last seen in, and the column it was last announced
 for), seeds _NOTIFY_PREV at the first build of a life, and a card is forgotten only when its own
 session rendered without it: a session that did not render at all (not yet revived, dead) says
-nothing about its cards. The same night's ledger showed the other half: one card on a busy session
+nothing about its cards. The compaction sweep after each judge pass bounds the store the way
+session-order.json is bounded: a session neither alive, nor in the discover window, nor kept open is
+gone for good and never renders again, so the sweep forgets its cards, mutes and all (the build alone
+kept them forever). The same night's ledger showed the other half: one card on a busy session
 re-entering needs_input at every turn end with nothing from the user in between, pushed twelve times
 — so the same (card, column) pair is announced once, unless the other column was announced since or
 the user acted on the card since (the override journal). Both the desktop notice and the phone push
@@ -320,6 +323,39 @@ class PruneAndWriteDiscipline(_Base):
         self.boot(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
         self.assertEqual(self.disk(), {WEB + ":g1": _entry("completed", WEB),
                                        API + ":g1": _entry("needs_input", API)})
+
+    def test_the_compaction_sweep_forgets_the_cards_of_a_session_gone_for_good(self):
+        # The build forgets a card only when its session renders without it, and a session gone for good
+        # (worktree deleted, never revived, its card cleared while it was dead) never renders again: the
+        # file grew by its cards forever. The compaction sweep bounds the snapshot the way _gc_session_order
+        # bounds session-order.json: alive, or a transcript still in the discover window, or a dead tab
+        # kept open, else forgotten, mutes and all. A dead session still in the window keeps its cards
+        # remembered, so its revival stays silent.
+        GONE = "11111111-2222-4333-8444-555555555503"
+        KEPT = "11111111-2222-4333-8444-555555555504"
+        km._set_notify_card(GONE + ":g1", False, GONE)            # a mute the user set on the gone session's card
+        km._set_notify_card(API + ":g1", False, API)              # ...and one on api's, which stays
+        self.seed_disk({WEB + ":g1": _entry("completed", WEB), API + ":g1": _entry("needs_input", API),
+                        GONE + ":g1": _entry("needs_input", GONE), KEPT + ":g1": _entry("completed", KEPT)})
+        self.boot(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        saved = jd.discover, km._tmux_sessions
+        jd.discover = lambda now, window=None, forks=True: [(API, "/dev/null", None, "api")]   # api: dead, in the window
+        km._tmux_sessions = lambda: {WEB: {}}                     # web: alive
+        km._kept_open.add(KEPT)                                   # kept: a dead tab the user kept open
+        err = io.StringIO()
+        try:
+            with redirect_stderr(err):
+                km._compact_goal_stores()
+        finally:
+            jd.discover, km._tmux_sessions = saved
+            km._kept_open.discard(KEPT)
+        expect = {WEB + ":g1": _entry("completed", WEB), API + ":g1": _entry("needs_input", API),
+                  KEPT + ":g1": _entry("completed", KEPT)}
+        self.assertEqual(km._NOTIFY_PREV[0], expect, "gone from memory; alive, in-window and kept-open stay")
+        self.assertEqual(self.disk(), expect, "...and from the file")
+        self.assertIn("[notify] forgot 1 card of 1 session gone for good", err.getvalue())
+        self.assertNotIn(GONE + ":g1", km._notify_cards(), "its mute went with it")
+        self.assertEqual(km._notify_cards().get(API + ":g1"), False, "api has not rendered: the mute stays")
 
     def test_the_roster_falls_back_to_the_cards_own_sessions(self):
         # a payload with no `sessions` rows (the older fixtures): a session with a card rendered

--- a/tests/test_notify_prev_persist.py
+++ b/tests/test_notify_prev_persist.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""The notified snapshot survives a kernel restart (2026-09-10).
+
+The bells diff each fresh feed build against the previous one, and _NOTIFY_PREV lived in memory
+alone, so every kernel life began with an empty memory. The first build after a start was a silent
+baseline, but the sessions come back one at a time after a restart (the SDK backend revives them),
+so that baseline saw a partial board, and every card a later-revived session brought with it
+"appeared" already in needs_input or completed and was announced again. Auto-update restarts the
+kernel on every deploy; one evening's ~8 restarts turned 8 cards into 30 phone pushes, one card
+pushed 12 times.
+
+The snapshot now persists to STATE/notify-prev.json ({card id: {sid, column, announced,
+announcedAt}}: the notified column the card was last seen in, and the column it was last announced
+for), seeds _NOTIFY_PREV at the first build of a life, and a card is forgotten only when its own
+session rendered without it: a session that did not render at all (not yet revived, dead) says
+nothing about its cards. The same night's ledger showed the other half: one card on a busy session
+re-entering needs_input at every turn end with nothing from the user in between, pushed twelve times
+— so the same (card, column) pair is announced once, unless the other column was announced since or
+the user acted on the card since (the override journal). Both the desktop notice and the phone push
+read this one gate. Synthetic ids and names only (the notes-api demo sessions)."""
+import io
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_notify_prev", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+WEB = "11111111-2222-4333-8444-555555555501"
+API = "11111111-2222-4333-8444-555555555502"
+
+
+def _card(iid, sid, col, text="Fix the login flow", name="web", **kw):
+    d = {"itemId": iid, "sid": sid, "name": name, "column": col, "text": text}
+    d.update(kw)
+    return d
+
+
+def _feed(*cards, sessions=None, now=None):
+    """A feed build. `sessions` is the board's live roster (build_feed's `sessions` rows); a
+    session listed there rendered this build, whether or not it has a card. Omitted, the roster is
+    whatever the cards themselves name. `now` is the build's moment (seconds), the clock an
+    announcement is stamped with."""
+    d = {"type": "feed", "asks": [dict(c) for c in cards]}
+    if sessions is not None:
+        d["sessions"] = [{"sid": s, "name": "s"} for s in sessions]
+    if now is not None:
+        d["now"] = now
+    return d
+
+
+def _entry(col, sid, announced="same", at=1_000):
+    """A store entry as the last life wrote it: seen in `col`, announced for `announced` (the column
+    itself by default — a card in a notified column was told when it got there) at `at`."""
+    return {"sid": sid, "column": col, "announced": col if announced == "same" else announced,
+            "announcedAt": at if (announced == "same" or announced is not None) else None}
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd._rebind_state(Path(self.td.name))         # the override journal lives beside the goals: rebind, not assign
+        km._notify_cards_cache.clear()
+        km._flags_cache.clear()
+        km._NOTIFY_PREV[0] = None                    # a fresh kernel life
+        km._set_notify_all(True)                     # the master bell: every card notifies
+
+    def tearDown(self):
+        jd._rebind_state(self.saved)
+        km._NOTIFY_PREV[0] = None
+        self.td.cleanup()
+
+    def path(self):
+        return jd.STATE / "notify-prev.json"
+
+    def disk(self):
+        return json.loads(self.path().read_text())
+
+    def seed_disk(self, entries):
+        self.path().write_text(json.dumps(entries))
+
+    def boot(self, feed):
+        """The first build of a kernel life, with its stderr trail."""
+        km._NOTIFY_PREV[0] = None
+        err = io.StringIO()
+        with redirect_stderr(err):
+            out = km._feed_notifications(feed)
+        return out, err.getvalue()
+
+
+class PersistedSnapshotGatesTheBoot(_Base):
+    def test_a_card_persisted_as_notified_is_silent_at_boot(self):
+        self.seed_disk({WEB + ":g1": _entry("completed", WEB)})
+        out, err = self.boot(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        self.assertEqual(out, [], "the card was announced in the last life; a restart is not the card entering")
+        self.assertIn("[notify] seeded 1 cards from disk", err)
+
+    def test_a_card_missing_from_the_snapshot_is_announced_once(self):
+        # the card entered the column while no kernel was watching: real news, said once
+        self.seed_disk({WEB + ":g1": _entry("completed", WEB)})
+        out, _ = self.boot(_feed(_card(WEB + ":g1", WEB, "completed"),
+                                 _card(WEB + ":g2", WEB, "needs_input", text="Pick the auth library"),
+                                 sessions=[WEB]))
+        self.assertEqual([o[3] for o in out], [WEB + ":g2"])
+        self.assertEqual(out[0][0], "Romp needs you: web")
+        d = self.disk()
+        self.assertEqual(d[WEB + ":g1"], _entry("completed", WEB))
+        self.assertEqual((d[WEB + ":g2"]["column"], d[WEB + ":g2"]["announced"]), ("needs_input", "needs_input"),
+                         "the new entry lands on disk in the same build that announces it, marked told")
+        again = km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "completed"),
+                                             _card(WEB + ":g2", WEB, "needs_input"), sessions=[WEB]))
+        self.assertEqual(again, [], "holding the column is not news")
+
+    def test_a_column_change_across_a_restart_is_news(self):
+        self.seed_disk({WEB + ":g1": _entry("completed", WEB)})
+        out, _ = self.boot(_feed(_card(WEB + ":g1", WEB, "needs_input"), sessions=[WEB]))
+        self.assertEqual(len(out), 1, "completed at the last sight, blocked now: the card ENTERED needs_input")
+        self.assertEqual(self.disk()[WEB + ":g1"]["announced"], "needs_input")
+
+    def test_a_restart_does_not_re_announce_what_this_life_announced(self):
+        # life 1: first boot, then a card completes → one announcement, written to disk
+        self.boot(_feed(_card(WEB + ":g1", WEB, "working"), sessions=[WEB]))
+        out = km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        self.assertEqual(len(out), 1)
+        self.assertEqual(self.disk()[WEB + ":g1"]["column"], "completed")
+        # life 2: the same board — nothing entered anything
+        out, _ = self.boot(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        self.assertEqual(out, [], "a restart re-announced every card sitting in the notified columns")
+        out = km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        self.assertEqual(out, [])
+
+    def test_sessions_reviving_one_at_a_time_after_a_restart_do_not_re_announce(self):
+        """THE measured storm: the first build after a restart sees only the sessions revived so
+        far; the rest bring their cards a build or two later, already in needs_input/completed.
+        A session that did not render says nothing about its cards — they stay remembered."""
+        self.seed_disk({WEB + ":g1": _entry("completed", WEB), API + ":g1": _entry("needs_input", API)})
+        # build 1: only web is back
+        out, _ = self.boot(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        self.assertEqual(out, [])
+        self.assertIn(API + ":g1", self.disk(), "api has not rendered yet — its card is not gone")
+        # build 2: api revives with its blocked card
+        out = km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "completed"),
+                                           _card(API + ":g1", API, "needs_input", name="api"),
+                                           sessions=[WEB, API]))
+        self.assertEqual(out, [], "the card was announced in the last life; reviving is not entering")
+        # and a kernel that dies between those two builds leaves a snapshot the next life can trust
+        out, _ = self.boot(_feed(_card(WEB + ":g1", WEB, "completed"),
+                                 _card(API + ":g1", API, "needs_input", name="api"), sessions=[WEB, API]))
+        self.assertEqual(out, [])
+
+    def test_a_card_never_told_that_re_blocks_is_announced(self):
+        # remembered in needs_input but never announced (its bell was off when it got there)
+        self.seed_disk({WEB + ":g1": _entry("needs_input", WEB, announced=None)})
+        self.boot(_feed(_card(WEB + ":g1", WEB, "working"), sessions=[WEB]))
+        self.assertEqual(self.disk(), {}, "a working card with nothing announced is nothing to remember")
+        out = km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "needs_input"), sessions=[WEB]))
+        self.assertEqual(len(out), 1, "the first time the user hears of this (card, column)")
+
+
+class TheSamePairIsAnnouncedOnce(_Base):
+    """A card that leaves a column and comes back is not news unless the other column was announced
+    since or the user acted on the card since (the override journal)."""
+
+    def _journal(self, sid, node, op, t, **kw):
+        d = jd._overrides_dir()
+        d.mkdir(parents=True, exist_ok=True)
+        with (d / (sid + ".jsonl")).open("a") as f:
+            f.write(json.dumps({"node": node, "op": op, "t": t, **kw}) + "\n")
+
+    def _flap(self, iid, sid, col, name="web", now=None):
+        """One round trip: the card leaves `col` for working and comes back (the return at `now`).
+        Returns the announcements the return produced."""
+        km._feed_notifications(_feed(_card(iid, sid, "working", name=name), sessions=[sid], now=now))
+        return km._feed_notifications(_feed(_card(iid, sid, col, name=name), sessions=[sid], now=now))
+
+    def test_the_flap_announces_once(self):
+        self.boot(_feed(_card(WEB + ":g1", WEB, "working"), sessions=[WEB]))
+        first = km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "needs_input"), sessions=[WEB]))
+        self.assertEqual(len(first), 1)
+        for _ in range(12):
+            self.assertEqual(self._flap(WEB + ":g1", WEB, "needs_input"), [],
+                             "the judges re-filing the same block at every turn end: told once, not twelve times")
+        self.assertEqual(self.disk()[WEB + ":g1"]["announced"], "needs_input")
+
+    def test_each_column_change_announces(self):
+        self.boot(_feed(_card(WEB + ":g1", WEB, "working"), sessions=[WEB]))
+        n = 0
+        for col in ("needs_input", "completed", "needs_input"):
+            n += len(km._feed_notifications(_feed(_card(WEB + ":g1", WEB, col), sessions=[WEB])))
+        self.assertEqual(n, 3, "needs_input → completed → needs_input is three distinct announcements")
+
+    def test_a_working_card_keeps_its_mark_across_a_restart(self):
+        self.boot(_feed(_card(WEB + ":g1", WEB, "working"), sessions=[WEB]))
+        km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "needs_input"), sessions=[WEB]))
+        km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "working"), sessions=[WEB]))
+        self.assertEqual(self.disk()[WEB + ":g1"], {"sid": WEB, "column": None, "announced": "needs_input",
+                                                    "announcedAt": self.disk()[WEB + ":g1"]["announcedAt"]})
+        out, _ = self.boot(_feed(_card(WEB + ":g1", WEB, "working"), sessions=[WEB]))
+        self.assertEqual(out, [])
+        out = km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "needs_input"), sessions=[WEB]))
+        self.assertEqual(out, [], "the mark survived the restart: the same pair stays silent")
+
+    def test_a_user_gesture_on_the_card_makes_the_re_entry_news(self):
+        T = 1_700_000_000                                              # an explicit clock: the build's `now`
+        self.boot(_feed(_card(WEB + ":g1", WEB, "working"), sessions=[WEB], now=T))
+        km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "needs_input"), sessions=[WEB], now=T + 10))
+        self.assertEqual(self.disk()[WEB + ":g1"]["announcedAt"], T + 10, "stamped with the build's moment")
+        self._journal(WEB, WEB + ":g1", "followup", T + 15)          # the user's targeted reply on the card
+        out = self._flap(WEB + ":g1", WEB, "needs_input", now=T + 20)
+        self.assertEqual(len(out), 1, "the user answered; a new block after that is news")
+        self.assertEqual(self._flap(WEB + ":g1", WEB, "needs_input", now=T + 30), [],
+                         "…and told once again, not per turn end")
+        clock = T + 30
+        for op in ("resolve", "unclear", "redistill"):
+            self._journal(WEB, WEB + ":g1", op, clock + 5)
+            clock += 10
+            self.assertEqual(len(self._flap(WEB + ":g1", WEB, "needs_input", now=clock)), 1, op)
+
+    def test_the_kernels_own_journal_rows_are_not_the_users(self):
+        T = 1_700_000_000
+        self.boot(_feed(_card(WEB + ":g1", WEB, "working"), sessions=[WEB], now=T))
+        km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "needs_input"), sessions=[WEB], now=T + 10))
+        self._journal(WEB, WEB + ":g1", "block", T + 15, src="nudge", why="stalled")
+        self._journal(WEB, WEB + ":g1", "clear", T + 16, src="romp", why="episode boundary")
+        self._journal(WEB, WEB + ":g2", "resolve", T + 17)          # a sibling card's gesture
+        self._journal(WEB, WEB + ":g1", "resolve", T + 5)           # a gesture from BEFORE the announcement
+        self._journal(WEB, WEB + ":g1", "resolve", T + 10)          # …and one in the announcement's own second
+        self.assertEqual(self._flap(WEB + ":g1", WEB, "needs_input", now=T + 20), [])
+        self._journal(WEB, WEB + ":g1", "clear", T + 25, src="user", why="cleared from the feed")
+        self.assertEqual(len(self._flap(WEB + ":g1", WEB, "needs_input", now=T + 30)), 1,
+                         "the user's own cross-off counts")
+
+    def test_the_seed_counts_as_told(self):
+        out, _ = self.boot(_feed(_card(WEB + ":g1", WEB, "needs_input"), sessions=[WEB]))
+        self.assertEqual(out, [])
+        self.assertEqual(self._flap(WEB + ":g1", WEB, "needs_input"), [], "the user has the board: not news")
+
+    def test_a_muted_entry_leaves_no_mark(self):
+        km._set_notify_card(WEB + ":g1", False, WEB)
+        self.boot(_feed(_card(WEB + ":g1", WEB, "working"), sessions=[WEB]))
+        self.assertEqual(km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "needs_input"), sessions=[WEB])), [])
+        self.assertIsNone(self.disk()[WEB + ":g1"]["announced"], "nothing was told")
+        km._set_notify_card(WEB + ":g1", True, WEB)
+        self.assertEqual(len(self._flap(WEB + ":g1", WEB, "needs_input")), 1, "armed now: the first telling")
+
+    def test_an_unreadable_journal_reads_as_not_acted_on(self):
+        self.boot(_feed(_card(WEB + ":g1", WEB, "working"), sessions=[WEB]))
+        km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "needs_input"), sessions=[WEB]))
+        real = jd._journal_read
+
+        def eio(sid):
+            raise OSError(5, "Input/output error")
+        jd._journal_read = eio
+        err = io.StringIO()
+        try:
+            with redirect_stderr(err):
+                out = self._flap(WEB + ":g1", WEB, "needs_input")
+        finally:
+            jd._journal_read = real
+        self.assertEqual(out, [], "the silent side is the safe one")
+        self.assertIn("[notify]", err.getvalue())
+
+
+class FirstBootSeedsSilently(_Base):
+    def test_no_file_means_seed_from_the_board_and_announce_nothing(self):
+        out, err = self.boot(_feed(_card(WEB + ":g1", WEB, "completed"),
+                                   _card(API + ":g1", API, "needs_input", name="api"),
+                                   _card(API + ":g2", API, "working", name="api"), sessions=[WEB, API]))
+        self.assertEqual(out, [], "an existing install's history is status, not news: no storm on the first boot")
+        d = self.disk()
+        self.assertEqual(sorted(d), [WEB + ":g1", API + ":g1"])
+        self.assertEqual((d[WEB + ":g1"]["column"], d[WEB + ":g1"]["announced"]), ("completed", "completed"),
+                         "the seed counts as told: the user has the board")
+        self.assertIn("[notify]", err)
+        self.assertNotIn("from disk", err)
+        # the next life is fully event-true: a fresh entry is announced, the seeded ones stay quiet
+        out, _ = self.boot(_feed(_card(WEB + ":g1", WEB, "completed"),
+                                 _card(API + ":g1", API, "needs_input", name="api"),
+                                 _card(API + ":g2", API, "completed", name="api"), sessions=[WEB, API]))
+        self.assertEqual([o[3] for o in out], [API + ":g2"])
+
+    def test_an_empty_first_board_still_marks_the_install_seeded(self):
+        out, _ = self.boot(_feed(sessions=[]))
+        self.assertEqual(out, [])
+        self.assertEqual(self.disk(), {}, "the file's existence is what says 'seeded'")
+        out = km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "needs_input"), sessions=[WEB]))
+        self.assertEqual(len(out), 1, "work can SURFACE blocked — appearing there is entering there")
+
+
+class PruneAndWriteDiscipline(_Base):
+    def test_a_card_gone_from_its_rendered_session_is_pruned(self):
+        self.seed_disk({WEB + ":g1": _entry("completed", WEB), WEB + ":g2": _entry("completed", WEB)})
+        self.boot(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        self.assertEqual(self.disk(), {WEB + ":g1": _entry("completed", WEB)},
+                         "web rendered without g2: cleared/archived — the id never comes back")
+
+    def test_a_sessions_last_card_leaving_prunes_too(self):
+        self.seed_disk({WEB + ":g1": _entry("completed", WEB)})
+        self.boot(_feed(sessions=[WEB]))                 # web is on the board with no card left
+        self.assertEqual(self.disk(), {})
+
+    def test_a_session_not_on_the_board_keeps_its_cards(self):
+        self.seed_disk({WEB + ":g1": _entry("completed", WEB), API + ":g1": _entry("needs_input", API)})
+        self.boot(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        self.assertEqual(self.disk(), {WEB + ":g1": _entry("completed", WEB),
+                                       API + ":g1": _entry("needs_input", API)})
+
+    def test_the_roster_falls_back_to_the_cards_own_sessions(self):
+        # a payload with no `sessions` rows (the older fixtures): a session with a card rendered
+        self.seed_disk({WEB + ":g1": _entry("completed", WEB), WEB + ":g2": _entry("completed", WEB)})
+        self.boot(_feed(_card(WEB + ":g1", WEB, "completed")))
+        self.assertEqual(self.disk(), {WEB + ":g1": _entry("completed", WEB)})
+
+    def test_an_unchanged_snapshot_is_not_rewritten(self):
+        self.seed_disk({WEB + ":g1": _entry("completed", WEB)})
+        self.boot(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        p = self.path()
+        before = p.stat().st_mtime_ns
+        km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        km._feed_notifications(_feed(_card(WEB + ":g1", WEB, "completed"),
+                                     _card(WEB + ":g2", WEB, "working"), sessions=[WEB]))
+        self.assertEqual(p.stat().st_mtime_ns, before, "a build that changes nothing writes nothing")
+
+    def test_the_file_is_private_and_published_atomically(self):
+        self.boot(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        mode = stat.S_IMODE(self.path().stat().st_mode)
+        self.assertEqual(mode, 0o600)
+        self.assertEqual([p.name for p in Path(self.td.name).glob("notify-prev.json.tmp*")], [],
+                         "no temp file left beside the published one")
+
+    def test_provisional_placeholders_never_enter_the_snapshot(self):
+        self.boot(_feed(_card("provisional:" + WEB, WEB, "needs_input", provisional=True), sessions=[WEB]))
+        self.assertEqual(self.disk(), {})
+
+    def test_a_remembered_cards_bell_override_survives_its_sessions_absence(self):
+        # the bell store's prune rides the same event: a card we still remember is not gone
+        km._set_notify_card(API + ":g1", False, API)          # a mute the user set on api's blocked card
+        self.seed_disk({API + ":g1": _entry("needs_input", API)})
+        self.boot(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        self.assertEqual(km._notify_cards().get(API + ":g1"), False, "api has not rendered: the mute stays")
+        self.boot(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB, API]))
+        self.assertNotIn(API + ":g1", km._notify_cards(), "api rendered without it: pruned as before")
+
+
+class CorruptOrUnreadableSnapshot(_Base):
+    def test_garbage_is_treated_as_absent_with_a_loud_line(self):
+        self.path().write_text("{not json")
+        out, err = self.boot(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        self.assertEqual(out, [], "treated as a first boot: a silent seed, never a crash")
+        self.assertIn("[notify]", err)
+        d = self.disk()
+        self.assertEqual((sorted(d), d[WEB + ":g1"]["column"]), ([WEB + ":g1"], "completed"), "a valid file replaces it")
+        self.assertTrue([p for p in Path(self.td.name).glob("notify-prev.json.corrupt-*")],
+                        "the bad bytes are moved aside, never deleted")
+
+    def test_a_wrong_shape_is_treated_as_absent(self):
+        self.path().write_text(json.dumps([WEB + ":g1"]))
+        out, err = self.boot(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        self.assertEqual(out, [])
+        self.assertIn("[notify]", err)
+
+    def test_malformed_entries_are_skipped_not_fatal(self):
+        self.seed_disk({WEB + ":g1": _entry("completed", WEB), WEB + ":g2": "completed", WEB + ":g3": 7,
+                        WEB + ":g4": {"column": "working", "sid": WEB},
+                        WEB + ":g5": {"column": None, "announced": None, "sid": WEB}})
+        out, err = self.boot(_feed(_card(WEB + ":g1", WEB, "completed"),
+                                   _card(WEB + ":g2", WEB, "completed"), sessions=[WEB]))
+        self.assertEqual([o[3] for o in out], [WEB + ":g2"], "an entry we could not read is no memory of the card")
+        self.assertIn("[notify] seeded 1 cards from disk", err)
+
+    def test_an_unreadable_file_is_treated_as_absent_with_a_loud_line(self):
+        self.seed_disk({WEB + ":g1": _entry("completed", WEB)})
+        real = Path.read_bytes
+        target = str(self.path())
+
+        def eio(p, *a, **k):
+            if str(p) == target:
+                raise OSError(5, "Input/output error")
+            return real(p, *a, **k)
+        Path.read_bytes = eio
+        try:
+            out, err = self.boot(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        finally:
+            Path.read_bytes = real
+        self.assertEqual(out, [])
+        self.assertIn("[notify]", err)
+        self.assertIn("notify-prev.json", err)
+
+    def test_a_failed_write_is_a_log_line_not_a_crash(self):
+        saved = km._atomic_write
+
+        def boom(path, text, mode=None):
+            raise OSError(28, "No space left on device")
+        km._atomic_write = boom
+        try:
+            out, err = self.boot(_feed(_card(WEB + ":g1", WEB, "completed"), sessions=[WEB]))
+        finally:
+            km._atomic_write = saved
+        self.assertEqual(out, [])
+        self.assertIn("[notify]", err)
+        self.assertIn("No space left", err)
+
+
+class BothLegsReadTheOneGate(unittest.TestCase):
+    def test_desktop_and_phone_legs_iterate_the_same_fired_list(self):
+        src = Path(os.path.join(BIN, "romp-kernel")).resolve().read_text()
+        self.assertIn("_fired = _feed_notifications(feed)", src)
+        self.assertIn("for _t, _b, _sid, _iid in _fired:", src)
+        self.assertIn("_system_notify(_t, _b)", src)
+        self.assertIn('_push_notify(_t, _b, _sid, _badge, kind="card", card_id=_iid', src)
+        calls = [ln for ln in src.splitlines()
+                 if re.search(r"_feed_notifications\(", ln) and not ln.lstrip().startswith(("#", "def "))]
+        self.assertEqual(len(calls), 1, "one diff, one gate — never a second: %r" % calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Tier: fix

## The bug (measured live 2026-09-10)

`_feed_notifications` diffed each feed build against an in-memory `{card id: column}` snapshot, with the first build of a kernel life a silent baseline. Sessions revive one at a time after a restart, so that baseline saw a partial board, and every card a later-revived session brought back "appeared" already in `needs_input` or `completed` and pushed again, on every restart (auto-update restarts the kernel on every deploy): ~8 restarts turned 8 cards into 30 phone pushes in fifty minutes. The same ledger showed the other half: one card on a busy coordinating session re-entering `needs_input` at every turn end (the judges re-filing its block) with nothing from the user in between, pushed twelve times.

## The fix

- **The snapshot persists**: `STATE/notify-prev.json`, `{card id: {sid, column, announced, announcedAt}}` (0600, atomic via `_write_state_json`, written only when it changes). It seeds `_NOTIFY_PREV` at the first build of a life, and the boot logs `[notify] seeded N cards from disk`.
- **Boot rule**: a card sitting in the column it was last seen in is silent (a restart is not the card entering). A card missing from an existing file that sits in a notified column is announced once (it entered while no kernel watched). A first boot with NO file seeds silently from the board and announces nothing (announcing an existing install's history would be the very storm); the next life is event-true. A corrupt or unreadable file reads as absent, loudly, never a crash.
- **Prune on the card's own event**: a card is forgotten only when its OWN session rendered without it (cleared/archived). A session that did not render (not yet revived, dead) says nothing about its cards, so a revival is silent and the file cannot grow past the live board plus unrevived sessions' cards. The bell overrides' prune rides the same event, so a remembered card's mute survives its session's absence.
- **The same (card, column) is announced once**: each entry records the column it was last announced for; a re-entry into that column is silent unless the OTHER notified column was announced since (`needs_input → completed → needs_input` is three announcements; `needs_input → working → needs_input` is one) or the user acted on the card since, read from the per-session override journal (`overrides/<sid>.jsonl`: resolve, followup, unclear, redistill, a user `clear`); the kernel's own rows there (nudge/interrupt `block`, romp-authored `clear`) do not count. A plain reply in the thread is not journaled and does not count: the user is in that thread already. A working card keeps its mark until its session renders without it, so the rule holds across restarts; the silent first-boot seed counts as told.
- Both the desktop `_system_notify` leg and the phone `_push_notify` leg iterate the one list the diff returns; `_buzz_claim`'s one-buzz-per-turn-end rule is unchanged.

## Tests

New `tests/test_notify_prev_persist.py` (30 tests; fail before the fix): persisted snapshot silent at boot, a new entry announced once and written, restart simulation, sessions reviving one at a time, first boot seeds silently, pruning only on the session's render, retained unrendered sessions, unchanged snapshot not rewritten, 0600 + atomic, provisional placeholders excluded, bell override survives the absence, corrupt / wrong-shape / malformed-entry / unreadable / unwritable file handling, the flap announces once, each column change announces, the mark survives a restart, a user gesture makes the re-entry news, kernel rows are not the user's, the seed counts as told, a muted entry leaves no mark, an unreadable journal reads as not acted on, and a source pin that both legs read one gate. `tests/test_notify_bells.py`'s round-trip test now pins the once-per-column rule.

Suite: `tests/test_[a-f]*` 2073 passed; `[g-m]` 4993 passed (1 pre-existing wall-clock flake in `test_kernel_webpush.py::LandingRevealOffers`, fails 3/3 on unpatched `origin/main`); `[n-s]` 2802 passed, 14 failed (identical set on unpatched `origin/main`: observability/pr_watch/post_push ordering); `[t-z]` 842 passed, 136 failed (identical on `origin/main`, the known ordering issue). Every failing file passes in isolation on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
