### PR TITLE
Tests: the live-order stability check feeds the second liveness read newest-first, and the session-order module docstring paraphrases the user

### DIFF
--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6598,8 +6598,10 @@ class ViewBuilder(unittest.TestCase):
         try:
             km._alive_sessions = lambda now, tmux: [{"sid": "A", "mtime": 100}, {"sid": "B", "mtime": 50}]
             first = [s["sid"] for s in km._timeline_sessions(NOW, {}, live_only=True)]
-            # B now becomes the most-recently-active (its mtime jumps past A) — the order must NOT change
-            km._alive_sessions = lambda now, tmux: [{"sid": "A", "mtime": 100}, {"sid": "B", "mtime": 999}]
+            # B now becomes the most-recently-active (its mtime jumps past A), so the liveness read comes back
+            # newest-first, B ahead of A, the way _sessions sorts it. The saved order must win over that input
+            # order: a reader that handed the read through unsorted would return [B, A] here.
+            km._alive_sessions = lambda now, tmux: [{"sid": "B", "mtime": 999}, {"sid": "A", "mtime": 100}]
             second = [s["sid"] for s in km._timeline_sessions(NOW, {}, live_only=True)]
             self.assertEqual(first, ["A", "B"], "new sessions frozen newest-active-first, once")
             self.assertEqual(second, first, "activity (mtime) must not reorder existing lanes/tabs")

--- a/tests/test_kernel_order.py
+++ b/tests/test_kernel_order.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Session order (chat tabs + timeline lanes) is a PURE function of session-order.json — it must NEVER
-auto-reshuffle on activity (mtime / status / death), only a user drag reorders (the user 2026-06-24:
-"the only thing that should reorder them is the user clicking and dragging").
+auto-reshuffle on activity (mtime / status / death), only a user drag reorders (the user 2026-06-24, who
+wanted no other trigger).
 
 Pins bin/romp-kernel's _ordered / _chat_tab_sessions / _timeline_sessions and the
 non-destructive _merge_session_order. Synthetic fleet only: placeholder UUIDs, no real session data.


### PR DESCRIPTION
## Symptom

None today. The first change closes the gap the post-merge review of #1240 (https://github.com/romp-on/romp/pull/1240) named: `test_live_order_is_stable_under_activity` in `tests/test_kernel.py` says it pins that a session's activity does not reorder timeline lanes or chat tabs, yet a reader that skipped the shared order on the live-only timeline path, or on the chat tabs, passed it. The second applies CLAUDE.md's paraphrase rule to the module docstring of `tests/test_kernel_order.py`, which quoted the user verbatim in its attribution.

## Cause

The test fed both `_alive_sessions` stubs in the same input order, `[A, B]`, and only moved B's mtime between them. `_ordered` appends newcomers in input order and sorts by the saved order, so with both reads already in `[A, B]` order a reader that returned the liveness read as it came also gave `first == second == ["A", "B"]`, and the chat-tabs assertion read the same `[A, B]` stub. Under a live-only timeline reader that skipped `_ordered`, the stability test stayed green and only `test_session_order_roundtrip_and_sort` (saved order `[b, a, c]`, fed a liveness read of `[a, b, c]`) went red; under a chat-tabs reader that skipped it, the stability test again stayed green while the roundtrip test, `test_dead_chat_tab_keeps_its_slot` (`tests/test_kernel.py`) and `test_relaunch_transfers_the_slot_across_a_chat_push_gc` (`tests/test_kernel_order.py`) went red.

## Fix

- `tests/test_kernel.py`: the second stub lists B first, in mtime order (`[{"sid": "B", "mtime": 999}, {"sid": "A", "mtime": 100}]`), the order a liveness read has in production (`_sessions` sorts newest transcript first and `_alive_sessions` filters that list). `second == first` now holds only when `_ordered` restores the saved slots, and the chat-tabs assertion reads the same reordered stub. The first stub and the three assertions are unchanged; the comment above the stub says why the read comes back newest-first.
- `tests/test_kernel_order.py`: the attribution reads `(the user 2026-06-24, who wanted no other trigger)`, qualifying the clause before it, `only a user drag reorders`.

Not in this PR: the same utterance is quoted in `_ordered`'s docstring in `kernel/kernel.py`, and dozens of other quoted attributions stand across the tree (kernel, webview, tests). This PR is tests-only and leaves them; paraphrasing them all is a separate decision.

## Tests

Kernel code is unchanged, so the tightened test passes on this tree as on its base. The discrimination it adds is shown by mutating `kernel/kernel.py` in the working tree, reverted before the commit; each mutant was run against the base test file and against this one:

- `_timeline_sessions(live_only=True)` returning the liveness read unsorted (`return live` for `return _ordered(live)`): the test passed before this change; after it, it fails at the `second == first` assertion with `Lists differ: ['B', 'A'] != ['A', 'B']`. Across `test_kernel.py`, `test_kernel_order.py`, `test_kernel_tabs_first.py` and `test_kernel_timeline_split.py` the only other failure under this mutant is the roundtrip test, before and after.
- `_chat_tab_sessions` returning `live + dead_kept` unsorted: the test passed before this change; after it, it fails at the chat-tabs assertion with the same diff. The roundtrip test, `test_dead_chat_tab_keeps_its_slot` and the relaunch case in `test_kernel_order.py` fail under this mutant before and after.
- `_ordered` skipping its `_write_session_order` call: both ViewBuilder order tests passed before this change; after it, the stability test fails at `second == first` with the same diff, while the roundtrip test, which writes the order file itself, stays green. The `_ordered`-direct cases in `test_kernel_order.py` pin the persist separately and fail under this mutant before and after.
- `test_session_order_roundtrip_and_sort` fails under the first two mutants before and after this change (`['a', 'b', 'c'] != ['b', 'a', 'c']`), so the shared-order property was pinned already; the change makes the stability test check what its docstring says by itself.

The docstring change has no executing test: the repository has no test for the paraphrase rule, and this PR adds none.

Targeted, on the unmutated tree: the two `test_kernel.py` cases with `tests/test_kernel_order.py` and `tests/test_kernel_tabs_first.py`, 48 passed. Full suite (`pytest -q -n 6 tests/`): 10834 passed, 118 skipped, 0 failed, 1688 subtests passed. Re-checked on the current main (2cf461440) with this change cherry-picked: the targeted set passes and all three mutants turn the stability test red the same way.

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)