### PR TITLE
Tests: the raw-copytree guard reads each test module's call tree, and tests/README.md records the copy_dist rule

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -108,6 +108,14 @@ the developer's git configuration (CI has none), and the env identity outranks
 exports its own `GIT_AUTHOR_*` after the floor. `tests/test_tempdir_hygiene.py`
 and `tests/git-hermetic.bats` pin all of it.
 
+**A served-page class copies the built `vscode-extension/dist/` with
+`tests.dist_copy.copy_dist`, never `shutil.copytree`.** Under `pytest -n` a
+sibling class's build renames or removes its staging files
+(`.<name>.tmp-<pid>-<n>`, `stagingPath` in `esbuild.js`) between the listing
+and the copy, and a plain copytree raises `shutil.Error` before the class's
+first test; `copy_dist` skips that shape. `tests/test_dist_copy_staging.py`
+pins the copy and refuses a raw copytree of dist in any test module.
+
 **No test report shows a process-environment value or a credential-shaped
 token.** An assertion whose container is an environment mapping prints the
 whole mapping when it fails (`assertNotIn("X", os.environ)` renders every

--- a/tests/test_dist_copy_staging.py
+++ b/tests/test_dist_copy_staging.py
@@ -14,10 +14,12 @@ copied; one removed after the listing (a stand-in for os.scandir removes it once
 taken) fails a plain copytree, the defect, and not copy_dist; and every name the script's own
 STAGING pattern matches is skipped while the served names are kept, a hidden name of another shape
 among them, the pattern read from the script so the copy's shape cannot drift from the script's
-unnoticed. A guard closes the module: no test module copies the built dist/ with a plain copytree,
-since the race fails no test of the class that does until a parallel run lands on it. All fixtures
-synthetic.
+unnoticed. A guard closes the module, reading each test module's call tree: none copies the built
+dist/ with a plain copytree, reached as an attribute, by the bare name or by an imported alias and
+however its arguments nest, since the race fails no test of the class that does until a parallel run
+lands on it. All fixtures synthetic.
 """
+import ast
 import glob
 import os
 import re
@@ -154,22 +156,124 @@ class StagingFilesAreNotCopied(unittest.TestCase):
         self.assertEqual(_files(dst), sorted(SERVED + [hidden]))
 
 
+def raw_dist_copies(text, filename="<test module>"):
+    """The (line, source) of every copytree call in a test module's `text` whose arguments name dist.
+
+    A module whose text lacks the token holds no such call and is not parsed, so the guard's cost over
+    every test module stays at a text scan's. The rest are read as a call tree: a call of `copytree` as
+    an attribute of whatever it is reached through (shutil, shutil under another name, an object holding
+    it), of the name `copytree` itself, or of a name `from shutil import copytree as ...` binds, wherever
+    the call sits and however deeply its arguments nest. The source of every argument and keyword value
+    is searched for "dist" in any case, so a path bound to a name such as DIST is caught with the
+    literal. A string holding a call is not a call. Hits come in line order; text that carries the token
+    and does not parse raises SyntaxError under `filename`.
+    """
+    if "copytree" not in text:
+        return []
+    tree = ast.parse(text, filename)
+    names = {"copytree"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "shutil":
+            names.update(a.asname for a in node.names if a.name == "copytree" and a.asname)
+    hits = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            if func.attr != "copytree":
+                continue
+        elif isinstance(func, ast.Name):
+            if func.id not in names:
+                continue
+        else:
+            continue
+        values = node.args + [k.value for k in node.keywords]
+        arguments = " ".join(ast.get_source_segment(text, v) or "" for v in values)
+        if "dist" in arguments.lower():
+            hits.append((node.lineno, ast.get_source_segment(text, node)))
+    return sorted(hits)
+
+
+def raw_dist_copies_under(directory):
+    """The roster of raw dist copies in every test_*.py under `directory`: `module:line: call`, in path order."""
+    raw = []
+    for p in sorted(glob.glob(os.path.join(directory, "test_*.py"))):
+        with open(p, encoding="utf-8") as f:
+            text = f.read()
+        for line, source in raw_dist_copies(text, p):
+            raw.append("%s:%d: %s" % (os.path.basename(p), line, source))
+    return raw
+
+
 class EveryTestModuleCopiesTheBuiltDistThroughCopyDist(unittest.TestCase):
     """A guard. The race is between two classes' builds and lands on a plain copy in about one parallel run in
     two, so a class that copies the built dist/ with shutil.copytree itself fails no test until a run lands
-    on it. This reads the test modules and refuses a copytree call that names dist."""
+    on it. This reads each test module's call tree and refuses a copytree call whose arguments name dist,
+    however the arguments nest, whether the call is reached as an attribute, by name or by an imported
+    alias."""
 
     def test_no_test_module_copies_dist_with_a_plain_copytree(self):
-        raw = []
-        for p in sorted(glob.glob(os.path.join(HERE, "test_*.py"))):
-            with open(p, encoding="utf-8") as f:
-                text = f.read()
-            # a call and its arguments, one level of nested parentheses deep (os.path.join(EXT, "dist"))
-            for m in re.finditer(r"copytree\(((?:[^()]|\([^()]*\))*)\)", text):
-                if "dist" in m.group(1):
-                    raw.append("%s:%d: %s" % (os.path.basename(p), text.count("\n", 0, m.start()) + 1, m.group(0)))
+        raw = raw_dist_copies_under(HERE)
         self.assertEqual(raw, [], "copy the built dist/ with tests.dist_copy.copy_dist, which skips a "
                                   "concurrent build's staging files:\n" + "\n".join(raw))
+
+    def test_the_scan_reads_a_nested_call_an_aliased_import_and_a_module_alias(self):
+        # Synthetic modules. The function's name is spelled in two pieces so that this module holds no
+        # copytree call that names dist for a reader of its raw text; the scan reads calls, and a string
+        # holding one (the last clean module) is not a call.
+        ct = "copy" + "tree"
+        raw = [
+            'import shutil\nshutil.%s(os.path.join(EXT, "dist"), dist)' % ct,
+            'import shutil\nshutil.%s(os.path.join(os.path.dirname(EXT), "dist"), dist)' % ct,
+            'import shutil\nshutil.%s(\n    os.path.join(EXT, "dist"),\n    os.path.join(cls.lab, "dist"),\n)' % ct,
+            'import shutil\nshutil.%s(src=os.path.join(EXT, "dist"), dst=dist)' % ct,
+            'import shutil\nshutil.%s(built, os.path.join(cls.lab, "dist"))' % ct,
+            'from shutil import %s as ct\nct(os.path.join(EXT, "dist"), dist)' % ct,
+            'from shutil import *\n%s(os.path.join(EXT, "dist"), dist)' % ct,
+            'import shutil as sh\nsh.%s(os.path.join(EXT, "dist"), dist)' % ct,
+            'DIST = os.path.join(EXT, "dist")\nshutil.%s(DIST, dst)' % ct,
+        ]
+        clean = [
+            'from tests.dist_copy import copy_dist\ncopy_dist(os.path.join(EXT, "dist"), dist)',
+            'import shutil\nshutil.%s(main, backup, symlinks=True)' % ct,
+            'import shutil\nshutil.%s(src, dst, ignore=shutil.ignore_patterns(".*.tmp-*"))' % ct,
+            'from unittest import mock\nmock.patch.object(shutil, "%s", side_effect=vanished)' % ct,
+            'text = \'shutil.%s(os.path.join(EXT, "dist"), dist)\'' % ct,
+        ]
+        # every raw module: one hit, at the call's first line (the second line of each); every clean one: none
+        lines = {text: [line for line, _source in raw_dist_copies(text)] for text in raw + clean}
+        self.maxDiff = None
+        self.assertEqual(lines, {**{text: [2] for text in raw}, **{text: [] for text in clean}})
+        # the roster's source is the call as written, from the module's name to the closing parenthesis
+        self.assertEqual(raw_dist_copies(raw[2]), [(2, raw[2].split("\n", 1)[1])])
+        # wherever the call sits, and in line order: a call inside a function is read, and listed before
+        # the module-level call below it (a walk of the tree reaches the shallower call first)
+        nested = 'import shutil\ndef build():\n    shutil.%s(src, "dist")\nshutil.%s(EXT + "/dist", dst)' % (ct, ct)
+        self.assertEqual([line for line, _source in raw_dist_copies(nested)], [3, 4])
+        # a module whose text lacks the token is not parsed: unparseable text without it is not this
+        # guard's to refuse, and text with it that does not parse fails under the module's name
+        self.assertEqual(raw_dist_copies("def ("), [])
+        with self.assertRaises(SyntaxError) as cm:
+            raw_dist_copies("shutil.%s(" % ct, "test_x.py")
+        self.assertEqual(cm.exception.filename, "test_x.py")
+
+    def test_the_walk_names_the_module_line_and_call_of_a_raw_copy(self):
+        # a scratch tests directory: one module routes its copy through copy_dist, one copies with a
+        # two-level plain call inside setUpClass; the roster names the second by module, line and call
+        ct = "copy" + "tree"
+        d = tempfile.mkdtemp(prefix="dist-guard-")
+        self.addCleanup(shutil.rmtree, d)
+        call = 'shutil.%s(os.path.join(os.path.dirname(EXT), "dist"), cls.dist)' % ct
+        modules = {
+            "test_routed.py": 'from tests.dist_copy import copy_dist\n\n\ndef setUpClass(cls):\n'
+                              '    copy_dist(os.path.join(EXT, "dist"), cls.dist)\n',
+            "test_served.py": 'import os\nimport shutil\n\n\ndef setUpClass(cls):\n    %s\n' % call,
+        }
+        for name, text in modules.items():
+            with open(os.path.join(d, name), "w", encoding="utf-8") as f:
+                f.write(text)
+        self.assertEqual(raw_dist_copies_under(d), ["test_served.py:6: " + call])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Symptom

A served-page test class that copies the built `vscode-extension/dist/` with a plain `shutil.copytree` passes the guard in `tests/test_dist_copy_staging.py` when the call's arguments nest two levels deep (`os.path.join(os.path.dirname(EXT), "dist")`), when the function is imported under another name (`from shutil import copytree as ct`), or when the path sits in a name such as `DIST`. Under `pytest -n` such a class still errors in `setUpClass` on a concurrent build's staging file, which is what the guard exists to refuse before a parallel run lands on it. Separately, the conventions section of `tests/README.md` records the hermetic temp and git rules and the report redaction, each with the test that pins it, and not the `copy_dist` rule, so a new class's author learns it only from the guard's failure (the follow-up recorded on #1238).

## Cause

The guard matched each module's raw text against a regular expression that accepted one level of nested parentheses, anchored on the literal `copytree(`, and looked for `"dist"` case-sensitively. A second level of nesting breaks the match and `re.finditer` skips the whole call; an alias never carries the anchor; `DIST` fails the case.

## Fix

`raw_dist_copies(text, filename)` reads the module's call tree with `ast`: a call of `copytree` as an attribute of whatever it is reached through, of the name itself, or of an alias `from shutil import copytree as ...` binds is a hit when the source of any argument or keyword value names dist in any case, wherever the call sits and however its arguments nest; hits come in line order. The walk over `tests/test_*.py` is `raw_dist_copies_under(directory)`, whose roster names the module, the call's first line and the call as written. A module whose text lacks the token is not parsed, so the guard over the 626 test modules costs 0.10 s against the text scan's 0.03 s (one machine; the three modules that carry the token are parsed); text that carries the token and does not parse raises `SyntaxError` under the module's name (collection fails on such a module first anyway). A string holding a call is not a call, so the guard module's own synthetic snippets do not trip it. Case-insensitive `dist` is a choice: it catches a name-bound `DIST`, and no `copytree` call under `tests/` names anything else containing the letters. An assignment alias (`ct = shutil.copytree`) and a `getattr` call are outside the scan, and the docstrings say what it reads. `tests/README.md` gains one paragraph in the conventions section, in the section's form: the rule, the race behind it, and the test that pins it.

## Tests

- `tests/test_dist_copy_staging.py::EveryTestModuleCopiesTheBuiltDistThroughCopyDist::test_the_scan_reads_a_nested_call_an_aliased_import_and_a_module_alias` (new) runs `raw_dist_copies` over synthetic modules assembled at run time. Nine raw shapes (one-level, two-level, multi-line, keyword-argument, destination-only, aliased import, star import, module alias, name-bound `DIST`) each yield one hit at the call's line; five clean ones (a `copy_dist` call, a `copytree` without dist, one with `ignore=`, a `mock.patch.object` naming `copytree`, a string holding a call) yield none; the roster's source is the call as written; a call inside a function and a module-level call below it come back in line order; text without the token is not parsed (`def (` yields `[]`), and text with it that does not parse raises `SyntaxError` carrying the given filename. Before the change: `NameError` on `raw_dist_copies`. With the regex scan extracted under that name: the two-level, aliased-import and name-bound modules yield `[]` where `[2]` is expected, the string yields `[1]`, and no `SyntaxError` is raised.
- `test_the_walk_names_the_module_line_and_call_of_a_raw_copy` (new) writes a routed module and a module with a two-level plain call inside `setUpClass` into a scratch directory and reads `raw_dist_copies_under` over it: the roster is exactly `test_served.py:6: <the call>`. Under the regex scan the roster is empty.
- `test_no_test_module_copies_dist_with_a_plain_copytree` (existing, green before and after; the tree holds no raw copy). Mutations, each reverted: a two-level `shutil.copytree(os.path.join(os.path.dirname(...), "dist"), dist)` at `tests/test_ship_reship.py:293` and `from shutil import copytree as ct` with `ct(...)` at `tests/test_remote_comment_name_served.py:177` both pass the previous guard (traced with its regex) and are each named with file, line and call by the new one. Scanner mutations (keyword values dropped, first argument only, prefilter removed, walk never calling the scanner, hits unsorted, filename not passed to the parser, case-sensitive dist, from-import aliases ignored, bare-name calls ignored) each turn one of the new cases red.
- The module also passes under Python 3.10 and 3.14 via `unittest`; `tests/test_tempdir_hygiene.py`, which reads every test file, passes on the changed tree.
- Full run on this head (`pytest -n 6 tests/`): 10836 passed, 118 skipped, 0 failed, 1688 subtests passed

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)