### PR TITLE
A subagent's own background work nests under its row in the Awaiting box, so the session's count is what the session itself waits on

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -23698,17 +23698,23 @@ _AWAIT_ITEM_KINDS = ("agents", "commands", "watches", "peer", "timer")       # t
 _AWAIT_ITEM_LEGACY_KIND = {"agents": "agents", "commands": "task", "watches": "job", "peer": "peer", "timer": "timer"}
 
 
-def _awaiting_item(kind, iid, label, since, agent_id=None, detail=None):
-    """One awaited row: {kind, id, label, since} plus agentId (an agent row — the open-transcript arrow)
-    and detail (a watch's predicate) only when known, so every row without them is byte-identical to the
-    minimal shape. `since` is the row's OWN event time (a dispatch stamp, a hook's start, a watch's
-    registration) or None — never wall-clock now (the user 2026-08-23)."""
+def _awaiting_item(kind, iid, label, since, agent_id=None, detail=None, stoppable=False):
+    """One awaited row: {kind, id, label, since} plus agentId (an agent row — the open-transcript arrow),
+    detail (a watch's predicate) and stoppable (the row is a task in the SDK's live lifecycle set, so its
+    id is one the stop_task control request resolves — the box offers Stop on it even when the parent
+    transcript never saw the launch, as it never does for a subagent's own command; 2026-09-10) only when
+    known, so every row without them is byte-identical to the minimal shape. A row may also grow `waits`
+    (_awaiting_nest): the rows the thing it names is in turn waiting on. `since` is the row's OWN event
+    time (a dispatch stamp, a hook's start, a watch's registration) or None — never wall-clock now (the
+    user 2026-08-23)."""
     assert kind in _AWAIT_ITEM_KINDS, kind
     it = {"kind": kind, "id": str(iid or ""), "label": str(label or "").strip(), "since": (int(since) if since else None)}
     if agent_id:
         it["agentId"] = str(agent_id)
     if detail:
         it["detail"] = str(detail)
+    if stoppable:
+        it["stoppable"] = True
     return it
 
 
@@ -23811,6 +23817,7 @@ def _awaiting_live_rows(sid, path, live):
     pending = _bg_pending(sid, path, tasks) if tasks else []
     pending_tids = {t.get("tid") for t in pending}
     meta = None   # the subagents sidecar map, read once and only if an agent launch lacks its agentId
+    cmd_owner = {}   # command row id → the launch ledger's ACTING agent (the hook's agent_id), when it recorded one
     for t in tasks:
         # Sources 0.5/0.75 — a NEW row is added only for a PENDING task (launch not yet placed); a placed
         # launch's story belongs to the judge's verdicts (see the docstring's 0.5 entry for the full
@@ -23823,9 +23830,13 @@ def _awaiting_live_rows(sid, path, live):
         # as two groups, never "task".
         is_pending = t.get("tid") in pending_tids
         is_agent = _bg_is_agent(t.get("type"))
+        stoppable = bool(t.get("stoppable"))
         if not is_agent:
             if is_pending:
-                commands.append(_awaiting_item("commands", t.get("tid") or "", t.get("desc") or "background command", t.get("t")))
+                commands.append(_awaiting_item("commands", t.get("tid") or "", t.get("desc") or "background command", t.get("t"),
+                                               stoppable=stoppable))
+                if t.get("agentId"):
+                    cmd_owner[commands[-1]["id"]] = str(t["agentId"])   # a shell launched by a subagent (the ledger's acting agent)
             continue
         aid = t.get("agentId")
         if not aid and path and t.get("tid"):
@@ -23841,15 +23852,106 @@ def _awaiting_live_rows(sid, path, live):
             hit["label"] = t.get("desc") or hit["label"]
             if t.get("t") and (not hit.get("since") or int(t["t"]) < hit["since"]):
                 hit["since"] = int(t["t"])
+            if stoppable:
+                hit["stoppable"] = True
             continue
         if is_pending:   # unmatched by the hook set: a new row only while its launch is still unplaced
-            agents.append(_awaiting_item("agents", t.get("tid") or "", t.get("desc") or "background agent", t.get("t"), agent_id=aid))
+            agents.append(_awaiting_item("agents", t.get("tid") or "", t.get("desc") or "background agent", t.get("t"), agent_id=aid,
+                                         stoppable=stoppable))
+    # What a SUBAGENT itself waits on nests under the agent's row (2026-09-10) — the session waits on the
+    # agent, the agent on its command — so the top level counts only what the session itself waits on.
+    agents, commands = _awaiting_nest(agents, commands, cmd_owner, path)
     # Source 0.9 — ARMED KERNEL WATCHES this session registered (`romp watch --cmd` / `romp watch-pr`):
     # kernel-owned and restart-proof like the rows themselves, event-true at both ends (armed at
     # registration, cleared when the predicate fires or the watch cancels/times out). The user's rule
     # (2026-08-30): ANY awaited thing shows — an idle session holding only a watch used to read plain
     # ready, its wait visible nowhere but `romp watch --list`.
     return agents, commands, _watch_awaiting(sid)
+
+
+def _awaiting_nest(agents, commands, cmd_owner, path):
+    """Move every row a live SUBAGENT owns out of the top level and under that agent's row as `waits` →
+    (top-level agents, top-level commands). Claude Code keeps ONE task list per session, so a background
+    command a subagent launches registers under the parent, and the box listed it beside the agent as a
+    second thing the session waited on ("Awaiting 2 · 1 agent · 1 command" for a session running one agent
+    whose test chunk was the command — the user 2026-09-10, who wants the top level to count what the
+    session itself waits on and the agent's row to show what the agent in turn waits on). Ownership is
+    read from designed sources, exact or not at all — never a guess:
+      - a COMMAND's owner is the launch ledger's acting agent (`cmd_owner`: the PostToolUse hook's
+        agent_id, which the SDK documents as present only when the hook fires inside a subagent — the one
+        reliable attribution when several agents' hooks interleave), else the one live agent whose OWN
+        transcript holds the launch's tool_use block (_agent_launch_ids: the file the CLI writes for the
+        agent, append-folded; the parent's transcript never contains a subagent's calls, so a hit there
+        is exact);
+      - a nested AGENT's owner is its sidecar's parentAgentId when the CLI wrote one, else the one live
+        agent whose transcript holds its launch's tool_use id (the row's id from the stream, or the
+        sidecar's toolUseId for a hook-only row).
+    A row whose owner is unknown, or names an agent that is not a live row (it finished; its command
+    outlived it), stays top-level. An owner chain that loops (malformed data) is left flat. Rows move by
+    reference, so a chain nests to any depth (A's waits hold B, B's hold B's command); the client shows one
+    level and counts the deeper ones in the label. `waits` is ordered like the top level (agents, then
+    commands) and present only when non-empty, so every other row keeps the minimal shape. Nothing here
+    is read unless there is a live agent row to attribute to: a session with no agents costs no file read."""
+    by_agent = {}
+    for it in agents:
+        aid = it.get("agentId")
+        if aid and aid not in by_agent:
+            by_agent[aid] = it
+    if not by_agent:
+        return agents, commands
+    launch_sets = {}   # agentId → the launch tool_use ids in that agent's own transcript (read lazily, once)
+
+    def launches(aid):
+        if aid not in launch_sets:
+            ap = _subagent_file(path, aid) if path else None
+            launch_sets[aid] = _agent_launch_ids(ap) if ap else set()
+        return launch_sets[aid]
+
+    def owner_by_transcript(tuid, exclude=None):
+        if not tuid:
+            return None
+        hits = [a for a in by_agent if a != exclude and tuid in launches(a)]
+        return hits[0] if len(hits) == 1 else None   # exactly one agent's file names the launch, or nobody does
+
+    owned = {}   # id(row) → owner agentId
+    for it in commands:
+        o = cmd_owner.get(it["id"])
+        if o is None:
+            o = owner_by_transcript(it["id"])
+        if o in by_agent:
+            owned[id(it)] = o
+    inv_meta = None
+    agent_owner = {}
+    for aid, it in by_agent.items():
+        if inv_meta is None:
+            inv_meta = {v["agentId"]: dict(v, toolUseId=k) for k, v in (_subagent_meta_map(path) if path else {}).items()}
+        m = inv_meta.get(aid) or {}
+        o = m.get("parentAgentId")
+        if not o:
+            tuid = it["id"] if it["id"] and it["id"] != aid else m.get("toolUseId")
+            o = owner_by_transcript(tuid, exclude=aid)
+        if o and o != aid and o in by_agent:
+            agent_owner[aid] = o
+    for aid in list(agent_owner):
+        seen, cur = set(), aid       # a loop (A owns B owns A) can only come from malformed data: leave it flat
+        while cur in agent_owner and cur not in seen:
+            seen.add(cur)
+            cur = agent_owner[cur]
+        if cur in seen:
+            for a in seen:
+                agent_owner.pop(a, None)
+    for aid, o in agent_owner.items():
+        owned[id(by_agent[aid])] = o
+    if not owned:
+        return agents, commands
+    for it in agents + commands:
+        o = owned.get(id(it))
+        if o:
+            by_agent[o].setdefault("waits", []).append(it)
+    for it in by_agent.values():
+        if it.get("waits"):
+            it["waits"].sort(key=lambda w: _AWAIT_ITEM_KINDS.index(w["kind"]))   # stable: agents, then commands
+    return [a for a in agents if id(a) not in owned], [c for c in commands if id(c) not in owned]
 
 
 def _session_background_items(sid, path):
@@ -24078,7 +24180,8 @@ def _bg_live_norm(sid, path):
                 continue
             kind = str(t.get("type") or "")
             row = {"tid": t.get("toolUseId"), "desc": _agent_task_label(t.get("desc"), kind),
-                   "t": int(t.get("since") or 0), "type": kind}
+                   "t": int(t.get("since") or 0), "type": kind,
+                   "stoppable": True}   # a lifecycle-set task: stop_task resolves its id (request_stop_task takes either form)
             e = led.get(str(t.get("toolUseId")))
             if e and e.get("deadlineEpoch"):
                 row["deadline"] = float(e["deadlineEpoch"])
@@ -24863,7 +24966,7 @@ def _subagents_dir(path):
 
 
 def _subagent_meta_map(path):
-    """toolUseId → {agentId, agentType, description, spawnDepth} for every agent-*.meta.json beside the
+    """toolUseId → {agentId, agentType, description, spawnDepth, parentAgentId} for every agent-*.meta.json beside the
     transcript at `path`, cached on the DIRECTORY's mtime (a sidecar landing changes it — a stat, never a
     timer). {} when the directory does not exist (older CLIs wrote no subagent files)."""
     d = _subagents_dir(path)
@@ -24894,7 +24997,8 @@ def _subagent_meta_map(path):
             continue
         out[str(meta["toolUseId"])] = {"agentId": aid, "agentType": meta.get("agentType") or "",
                                        "description": meta.get("description") or "",
-                                       "spawnDepth": meta.get("spawnDepth")}
+                                       "spawnDepth": meta.get("spawnDepth"),
+                                       "parentAgentId": meta.get("parentAgentId") or None}   # optional: a nested agent's launcher (_awaiting_nest)
     if len(_SUBAGENT_META_CACHE) > 256:
         _SUBAGENT_META_CACHE.clear()
     _SUBAGENT_META_CACHE[str(d)] = (key, out)
@@ -24965,6 +25069,42 @@ def _gist_step(state, o):
                                                          "desc": _tool_gist_desc(b.get("name"), b.get("input")),
                                                          "ts": ts}])[-SUBAGENT_STEPS_CAP:]
     return state
+
+
+_AGENT_LAUNCH_IDS_CACHE = {}    # agent jsonl path -> em.fold_records entry: the tool_use ids of the launches the agent itself made
+
+
+def _launch_ids_fresh():
+    return set()
+
+
+def _launch_ids_step(state, o):
+    """Collect the tool_use ids of the LAUNCH-shaped calls in a subagent's own transcript — a
+    run_in_background Bash, a Monitor, an Agent/Task (background by default) — the ids the session's task
+    list carries for the agent's own background work. A few ids per agent, never the whole call list."""
+    if o.get("type") != "assistant":
+        return state
+    c = (o.get("message") or {}).get("content")
+    if isinstance(c, list):
+        for b in c:
+            if not (isinstance(b, dict) and b.get("type") == "tool_use" and b.get("id")):
+                continue
+            nm = b.get("name")
+            inp = b.get("input") if isinstance(b.get("input"), dict) else {}
+            if nm in ("Agent", "Task", "Monitor") or (nm == "Bash" and inp.get("run_in_background")):
+                state.add(str(b["id"]))
+    return state
+
+
+def _agent_launch_ids(agent_path):
+    """The launch tool_use ids in one agent's own file (_launch_ids_step), folded append-incrementally like
+    the head's steps (a growing file steps only its new records; an unchanged one costs a stat). The
+    transcript half of _awaiting_nest's attribution: a background command whose tool_use id is in THIS
+    file was launched by THIS agent. set() when unreadable."""
+    try:
+        return em.fold_records(_AGENT_LAUNCH_IDS_CACHE, str(agent_path), _launch_ids_fresh, _launch_ids_step)
+    except Exception:
+        return set()
 
 
 def _agent_steps(agent_path):

--- a/tests/test_awaiting_box_sync.py
+++ b/tests/test_awaiting_box_sync.py
@@ -52,7 +52,11 @@ class SourcePins(unittest.TestCase):
         for fn in ("function chatTail(msg: any) {", "function update(msg: any) {", "function statusOnly(msg: any) {"):
             body = RENDER.split(fn)[1].split("\n}")[0]
             self.assertIn("const before = awaitKey(s.status);", body, fn)
-            self.assertIn("if (awaitKey(s.status) !== before) renderBgTasks();", body, fn)
+            # since 2026-09-10 the box render goes through awaitChanged(sid), which also re-renders the subagent
+            # viewer's header when the active tab is a viewer into this session (its "waiting on" tail reads the
+            # parent's nested rows) — the call sits after the active/inactive branch so a viewer tab reaches it
+            self.assertIn("if (awaitKey(s.status) !== before) awaitChanged(msg.id);", body, fn)
+        self.assertIn("function awaitChanged(sid: string): void {\n  if (sid === activeId) renderBgTasks();", RENDER)
 
     def test_the_chip_and_the_gist_agree_in_number_from_one_count(self):
         # since slice 2 (plans/subagent-transcripts.md, 2026-09-05) the ONE rule is awaitWord: the kernel's

--- a/tests/test_awaiting_rows.py
+++ b/tests/test_awaiting_rows.py
@@ -14,7 +14,9 @@ several kinds at once make kind "mixed" (jd.AWAIT_KINDS) with count = every row.
 Synthetic inputs only; sources stubbed like test_awaiting_count.
 """
 import inspect
+import json
 import os
+import shutil
 import tempfile
 import unittest
 from importlib.machinery import SourceFileLoader
@@ -318,6 +320,169 @@ class MixedKind(unittest.TestCase):
         finally:
             km._states_awaiting_overlay, km._tmux_sessions = saved
         self.assertEqual((aw["kind"], aw["count"], aw["items"]), ("mixed", 3, []))
+
+
+class NestedWaits(unittest.TestCase):
+    """A subagent's OWN background work nests under the agent's row (the user 2026-09-10, who saw a session
+    running one background agent read "Awaiting 2 · 1 agent · 1 command" — the command was a test chunk the
+    AGENT had launched, registered under the parent because Claude Code keeps one task list per session).
+    The session waits on the agent; the agent waits on the command. So the top level counts only what the
+    session itself waits on, and an agent row carries what that agent in turn waits on as `waits`.
+
+    Attribution is exact or nothing: the launch ledger's acting agent (the PostToolUse hook's agent_id,
+    which the SDK documents as present only inside a subagent) first; else the agent's own transcript
+    naming the launch's tool_use id; a row neither source attributes stays top-level. Synthetic files:
+    placeholder sid, invented agent ids, the notes-api demo domain."""
+    A1, A2 = "a1111111111111111", "a2222222222222222"
+
+    def setUp(self):
+        self._saved = {n: getattr(km, n) for n in
+                       ("_tmux_sessions", "_bg_live_norm", "_bg_pending", "_states_awaiting_overlay",
+                        "_owned_yield_why", "_session_stamp_full", "_session_delegated_why",
+                        "_session_delegated_identities", "_watches", "_pr_watches")}
+        km._bg_pending = lambda sid, path, tasks: tasks
+        km._states_awaiting_overlay = lambda sid: None
+        km._owned_yield_why = lambda sid, path: None
+        km._session_stamp_full = lambda sid: (None, 0, None, None, ())
+        km._session_delegated_why = lambda sid: None
+        km._session_delegated_identities = lambda sid: []
+        km._watches, km._pr_watches = [], []
+        self.tmp = tempfile.mkdtemp()
+        self.path = os.path.join(self.tmp, "parent.jsonl")
+        self._write(self.path, [])
+        km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "general-purpose", "since": 100, "agentId": self.A1}]}}
+
+    def tearDown(self):
+        for n, f in self._saved.items():
+            setattr(km, n, f)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    @staticmethod
+    def _write(path, rows):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+
+    @staticmethod
+    def _bash(tid, desc):
+        return {"type": "assistant", "timestamp": "2026-09-10T10:00:00.000Z", "message": {"content": [
+            {"type": "tool_use", "id": tid, "name": "Bash",
+             "input": {"run_in_background": True, "command": "uv run pytest tests/test_parser.py -q", "description": desc}}]}}
+
+    @staticmethod
+    def _agent_call(tid, desc):
+        return {"type": "assistant", "timestamp": "2026-09-10T10:00:01.000Z", "message": {"content": [
+            {"type": "tool_use", "id": tid, "name": "Agent",
+             "input": {"description": desc, "prompt": "audit the retries", "subagent_type": "general-purpose"}}]}}
+
+    def _agent_file(self, aid):
+        return os.path.join(self.tmp, "parent", "subagents", "agent-%s.jsonl" % aid)
+
+    def _rows(self, cmd_owner=None, with_cmd=True):
+        rows = [{"tid": "tu_agent1", "desc": "map the parser", "t": 95, "type": "local_agent", "agentId": self.A1}]
+        if with_cmd:
+            c = {"tid": "tu_bash1", "desc": "run the parser test chunk", "t": 130, "type": "local_bash"}
+            if cmd_owner:
+                c["agentId"] = cmd_owner      # the ledger's ACTING agent (the hook's agent_id)
+            rows.append(c)
+        km._bg_live_norm = lambda sid, path: rows
+
+    def test_a_command_the_ledger_attributes_to_a_live_agent_nests_under_it(self):
+        self._rows(cmd_owner=self.A1)
+        aw = km._session_awaiting(SID, self.path, True)
+        self.assertEqual((aw["kind"], aw["count"]), ("agents", 1), "the session waits on ONE thing: the agent")
+        self.assertEqual(aw["why"], "1 background agent still working", "the single-agent sentence, unchanged")
+        self.assertEqual(aw["tasks"], ["map the parser"], "the legacy descriptions list the top level only")
+        self.assertEqual(aw["items"], [{"kind": "agents", "id": "tu_agent1", "label": "map the parser", "since": 95,
+                                        "agentId": self.A1,
+                                        "waits": [{"kind": "commands", "id": "tu_bash1", "label": "run the parser test chunk",
+                                                   "since": 130}]}])
+
+    def test_a_command_named_only_by_the_agents_own_transcript_nests_by_the_transcript_join(self):
+        # no ledger entry (the reg was unreadable at the hook's instant, say): the agent's own file names the launch
+        self._write(self._agent_file(self.A1), [self._bash("tu_bash1", "run the parser test chunk")])
+        self._rows()
+        aw = km._session_awaiting(SID, self.path, True)
+        self.assertEqual((aw["kind"], aw["count"]), ("agents", 1))
+        self.assertEqual([w["id"] for w in aw["items"][0]["waits"]], ["tu_bash1"])
+
+    def test_a_command_the_session_itself_launched_stays_top_level(self):
+        # the SAME launch id in the PARENT transcript, and the agent's file names something else: two rows, mixed
+        self._write(self.path, [self._bash("tu_bash1", "run the parser test chunk")])
+        self._write(self._agent_file(self.A1), [self._bash("tu_other", "grep the fixtures")])
+        self._rows()
+        aw = km._session_awaiting(SID, self.path, True)
+        self.assertEqual((aw["kind"], aw["count"]), ("mixed", 2))
+        self.assertEqual([it["kind"] for it in aw["items"]], ["agents", "commands"])
+        self.assertNotIn("waits", aw["items"][0])
+        self.assertEqual(aw["why"], "waiting on 1 background agent and 1 background command")
+
+    def test_an_unattributable_command_stays_top_level_never_a_guess(self):
+        # no ledger owner, no transcript names it, one live agent that COULD have launched it: still top-level
+        self._write(self._agent_file(self.A1), [self._bash("tu_other", "grep the fixtures")])
+        self._rows()
+        aw = km._session_awaiting(SID, self.path, True)
+        self.assertEqual((aw["kind"], aw["count"]), ("mixed", 2))
+        self.assertNotIn("waits", aw["items"][0])
+
+    def test_a_ledger_owner_that_is_not_a_live_row_leaves_the_command_top_level(self):
+        # the ledger names an agent nobody lists (it finished; its command outlived it): nothing to nest under
+        self._rows(cmd_owner=self.A2)
+        aw = km._session_awaiting(SID, self.path, True)
+        self.assertEqual((aw["kind"], aw["count"]), ("mixed", 2))
+        self.assertNotIn("waits", aw["items"][0])
+
+    def test_a_nested_agent_nests_under_its_launcher_one_level_per_row(self):
+        # A launched B (B's launch tool_use is in A's file); B launched the command (the ledger's acting agent):
+        # the session waits on A; A waits on B; B waits on the command — each nested under its owner
+        km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "general-purpose", "since": 100, "agentId": self.A1},
+                                                         {"type": "general-purpose", "since": 110, "agentId": self.A2}]}}
+        self._write(self._agent_file(self.A1), [self._agent_call("tu_agent2", "audit the retries")])
+        km._bg_live_norm = lambda sid, path: [
+            {"tid": "tu_agent1", "desc": "map the parser", "t": 95, "type": "local_agent", "agentId": self.A1},
+            {"tid": "tu_agent2", "desc": "audit the retries", "t": 108, "type": "local_agent", "agentId": self.A2},
+            {"tid": "tu_bash1", "desc": "run the retry suite", "t": 130, "type": "local_bash", "agentId": self.A2}]
+        aw = km._session_awaiting(SID, self.path, True)
+        self.assertEqual((aw["kind"], aw["count"], aw["why"]), ("agents", 1, "1 background agent still working"))
+        top = aw["items"]
+        self.assertEqual([it["id"] for it in top], ["tu_agent1"])
+        self.assertEqual([w["id"] for w in top[0]["waits"]], ["tu_agent2"])
+        self.assertEqual([w["id"] for w in top[0]["waits"][0]["waits"]], ["tu_bash1"])
+        self.assertEqual(aw["tasks"], ["map the parser"])
+
+    def test_a_nested_agent_with_a_sidecar_parent_needs_no_transcript(self):
+        # the sidecar's parentAgentId (an optional key the CLI writes) is the designed link when present
+        km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "general-purpose", "since": 100, "agentId": self.A1},
+                                                         {"type": "general-purpose", "since": 110, "agentId": self.A2}]}}
+        self._write(self._agent_file(self.A2), [])
+        with open(os.path.join(self.tmp, "parent", "subagents", "agent-%s.meta.json" % self.A2), "w") as f:
+            json.dump({"agentType": "general-purpose", "description": "audit the retries", "spawnDepth": 2,
+                       "toolUseId": "tu_agent2", "parentAgentId": self.A1}, f)
+        self._rows(with_cmd=False)
+        aw = km._session_awaiting(SID, self.path, True)
+        self.assertEqual([it["id"] for it in aw["items"]], ["tu_agent1"])
+        self.assertEqual([w.get("agentId") for w in aw["items"][0]["waits"]], [self.A2])
+        self.assertEqual(aw["count"], 1)
+
+    def test_the_turn_agnostic_read_nests_the_same_way(self):
+        self._rows(cmd_owner=self.A1)
+        idle = km._session_awaiting(SID, self.path, True)["items"]
+        self.assertIsNone(km._session_awaiting(SID, self.path, False))
+        self.assertEqual(km._session_background_items(SID, self.path), idle, "mid-turn the box lists the same nested rows")
+        self.assertEqual(km._awaiting_items_payload(None, SID, self.path), idle)
+
+    def test_without_agents_no_transcript_is_read(self):
+        # the join is only ever consulted with a live agent to attribute to — a plain command costs nothing extra
+        km._tmux_sessions = lambda: {SID: {}}
+        km._bg_live_norm = lambda sid, path: [{"tid": "tu_bash1", "desc": "build the docs", "t": 130, "type": "local_bash"}]
+        saved = km._agent_launch_ids
+        km._agent_launch_ids = lambda p: (_ for _ in ()).throw(AssertionError("read a transcript with no agent to attribute to"))
+        try:
+            aw = km._session_awaiting(SID, self.path, True)
+        finally:
+            km._agent_launch_ids = saved
+        self.assertEqual((aw["kind"], aw["count"]), ("task", 1))
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1852,7 +1852,8 @@ class ViewBuilder(unittest.TestCase):
             # source 0.5: the live bg-task set — one task shows its description verbatim (a COMMAND row;
             # the sentence says "command" since slice 2)
             desc = "20-minute timer for campaign-start check"
-            cmd_row = {"kind": "commands", "id": "tu_bg", "label": desc, "since": T0 + 9}
+            cmd_row = {"kind": "commands", "id": "tu_bg", "label": desc, "since": T0 + 9,
+                       "stoppable": True}   # a lifecycle-set row: stop_task resolves its id (2026-09-10)
             km._tmux_sessions = lambda: {SID: {"bgTasks": [timer]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
                              {"kind": "task", "since": T0 + 9,   # the dispatch stamp (the user 2026-08-23)

--- a/tests/test_kernel_awaiting_merge.py
+++ b/tests/test_kernel_awaiting_merge.py
@@ -75,7 +75,8 @@ class MergeCarriesBgTasks(unittest.TestCase):
         self.assertEqual(why, {"kind": "task", "since": 1,   # the dispatch stamp → the chips' elapsed readout (the user 2026-08-23)
                                "why": "waiting on a background command: 20-minute timer for campaign-start check",   # "command" since slice 2 (2026-09-05)
                                "count": 1,
-                               "items": [{"kind": "commands", "id": "tu1", "label": "20-minute timer for campaign-start check", "since": 1}],   # the one awaited row
+                               "items": [{"kind": "commands", "id": "tu1", "label": "20-minute timer for campaign-start check", "since": 1,
+                                          "stoppable": True}],   # the one awaited row; stoppable = a lifecycle-set task (2026-09-10)
                                "tasks": ["20-minute timer for campaign-start check"]})
 
 

--- a/tests/test_kernel_bg_tasks.py
+++ b/tests/test_kernel_bg_tasks.py
@@ -604,6 +604,43 @@ class OneRowPerAgentAcrossTheHookAndTheStream(unittest.TestCase):
                           ("toolu_03", None, "Running the docs build")],
                          "only an AGENT row's desc wears the CLI's prefix; a shell task's description is the user's own words")
 
+    def test_a_subagents_own_command_nests_under_the_agent_by_the_ledgers_acting_agent(self):
+        # 2026-09-10, on the REAL _bg_live_norm: one live agent whose background test chunk registered under
+        # the parent's task list (one list per session). The launch ledger's entry for the Bash carries the
+        # hook's agent_id (the acting agent), so the command is the AGENT's wait, nested under its row and
+        # stoppable (a lifecycle-set task); the session's own count is one agent, breakdown "1 agent".
+        saved_reg = km._thread_reg
+        km._thread_reg = lambda sid: {"bgLedger": [{"tid": "b3333", "toolUseId": "toolu_03", "tool": "bash",
+                                                    "desc": "run the parser test chunk", "armedAt": 110,
+                                                    "agentId": self.A1, "src": "hook"}]}
+        try:
+            self._snap([{"type": "general-purpose", "since": 100, "agentId": self.A1}],
+                       [{"toolUseId": "toolu_01", "taskId": self.A1, "type": "local_agent", "since": 98,
+                         "desc": "Running Check the exporter for banned words", "lastTool": ""},
+                        {"toolUseId": "toolu_03", "taskId": "b3333", "type": "local_bash", "since": 110,
+                         "desc": "run the parser test chunk", "lastTool": ""}])
+            aw = km._session_awaiting(self.SID, None, True)
+        finally:
+            km._thread_reg = saved_reg
+        self.assertEqual((aw["kind"], aw["count"], aw["why"]), ("agents", 1, "1 background agent still working"))
+        self.assertEqual(aw["items"], [{"kind": "agents", "id": "toolu_01", "label": "Check the exporter for banned words",
+                                        "since": 98, "agentId": self.A1, "stoppable": True,
+                                        "waits": [{"kind": "commands", "id": "toolu_03", "label": "run the parser test chunk",
+                                                   "since": 110, "stoppable": True}]}])
+        self.assertEqual(aw["tasks"], ["Check the exporter for banned words"])
+
+    def test_a_command_with_no_ledger_owner_and_no_agent_file_stays_beside_the_agent(self):
+        # the same two tasks, the ledger silent and no transcript to consult (path None): never a guess
+        self._snap([{"type": "general-purpose", "since": 100, "agentId": self.A1}],
+                   [{"toolUseId": "toolu_01", "taskId": self.A1, "type": "local_agent", "since": 98,
+                     "desc": "Running Check the exporter for banned words", "lastTool": ""},
+                    {"toolUseId": "toolu_03", "taskId": "b3333", "type": "local_bash", "since": 110,
+                     "desc": "run the parser test chunk", "lastTool": ""}])
+        aw = km._session_awaiting(self.SID, None, True)
+        self.assertEqual((aw["kind"], aw["count"]), ("mixed", 2))
+        self.assertEqual([it["kind"] for it in aw["items"]], ["agents", "commands"])
+        self.assertTrue(all(it.get("stoppable") for it in aw["items"]), "every lifecycle-set row is stoppable")
+
     def test_the_transcript_scan_path_carries_the_acks_agent_id(self):
         # source 0.75 (a live CLI with no lifecycle set — tmux): the async ack names the agent; the row
         # must carry it so the same join works there

--- a/tools/ui-verify/fixtures/awaiting-rows-chat.html
+++ b/tools/ui-verify/fixtures/awaiting-rows-chat.html
@@ -1,7 +1,13 @@
 <!-- SYNTHETIC fixture: the chat pane's #bg-tasks box in the MIXED case (plans/subagent-transcripts.md
      slice 2, 2026-09-05), in BOTH turn states (2026-09-06), one above the other — the same four rows grouped
      by kind under small dim headers (Agents / Commands / Watches), each row wearing its own kind's affordances
-     (the agent rows' open-transcript arrow + Stop, the command row's Stop + fold caret, the watch row's Cancel):
+     (the agent rows' open-transcript arrow + Stop, the command row's Stop + fold caret, the watch row's Cancel).
+     NESTED waits (2026-09-10): under the first agent, what THAT agent is itself waiting on — its own background
+     test chunk and a subagent of its own — as indented sub-rows in the same vocabulary, the first led by a small
+     dim "waiting on", the second by its blank twin (dots aligned); the nested agent's own deeper wait is counted
+     in its label ("· waiting on 1 command") rather than drawn. The header still reads 4: the top level counts
+     what the SESSION waits on; the nested rows are the agent's. Stop rides the nested rows (stoppable: the
+     lifecycle set's task), no fold caret (no tracked task lends an output tail).
        * IDLE: the box wears the await-green border and dot, the header reads "Awaiting 4 · 2 agents · 1 command
          · 1 watch", the idle note closes the list, and the statusline beneath carries the Awaiting chip as a
          BUTTON reading "Awaiting 4".
@@ -15,10 +21,10 @@
      dispatch description (no agent type, no "Running " prefix: the status word beside it already says
      running), with the open-transcript arrow. The small uppercase captions between the two are fixture-only.
        tools/ui-verify/shot.sh --css ui/webview/styles.css --body tools/ui-verify/fixtures/awaiting-rows-chat.html \
-           --out /tmp/awaiting-shots/chat-dark.png --size 760x700 --extra-css 'body{background:var(--bg);padding-top:10px}'
+           --out /tmp/awaiting-shots/chat-dark.png --size 760x820 --extra-css 'body{background:var(--bg);padding-top:10px}'
        …and with --body-class "theme-light chat-theme-<name>" for the light theme. The height matters: the
        box caps at min(50vh, 340px), so each box needs ~270px of viewport to show whole (the idle box's natural
-       height is ~262px, the working one ~240px); 700px shows both as a real pane would.
+       height is ~262px, the working one ~240px; the two nested rows add ~30px each); 820px shows both as a real pane would.
 -->
 <div id="content" style="flex:0 0 auto"></div>
 <div style="padding:2px 12px 0;font-size:10px;line-height:1.6;letter-spacing:.04em;text-transform:uppercase;font-weight:600;color:var(--dim)">idle — the chip reads Awaiting</div>
@@ -28,6 +34,12 @@
     <div class="bg-group-head">Agents</div>
     <div class="bg-task bg-running">
       <div class="bg-head" data-act="bg-toggle"><span class="bg-dot"></span><span class="bg-sum">Map the notes-api parser</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 12m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button><span class="bg-caret">▸</span></div>
+    </div>
+    <div class="bg-task bg-running bg-sub">
+      <div class="bg-head bg-flat"><span class="bg-waits-on">waiting on</span><span class="bg-dot"></span><span class="bg-sum">Run the parser test chunk</span><span class="bg-since">· 3m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button></div>
+    </div>
+    <div class="bg-task bg-running bg-sub">
+      <div class="bg-head bg-flat"><span class="bg-waits-on bg-waits-blank"></span><span class="bg-dot"></span><span class="bg-sum">Check the fixture loader</span><span class="bg-deeper">· waiting on 1 command</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 1m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button></div>
     </div>
     <div class="bg-task bg-running">
       <div class="bg-head bg-flat"><span class="bg-dot"></span><span class="bg-sum">Audit the exporter's retries</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 4m</span><span class="bg-status">running</span></div>
@@ -53,6 +65,12 @@
     <div class="bg-group-head">Agents</div>
     <div class="bg-task bg-running">
       <div class="bg-head" data-act="bg-toggle"><span class="bg-dot"></span><span class="bg-sum">Map the notes-api parser</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 12m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button><span class="bg-caret">▸</span></div>
+    </div>
+    <div class="bg-task bg-running bg-sub">
+      <div class="bg-head bg-flat"><span class="bg-waits-on">waiting on</span><span class="bg-dot"></span><span class="bg-sum">Run the parser test chunk</span><span class="bg-since">· 3m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button></div>
+    </div>
+    <div class="bg-task bg-running bg-sub">
+      <div class="bg-head bg-flat"><span class="bg-waits-on bg-waits-blank"></span><span class="bg-dot"></span><span class="bg-sum">Check the fixture loader</span><span class="bg-deeper">· waiting on 1 command</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 1m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button></div>
     </div>
     <div class="bg-task bg-running">
       <div class="bg-head bg-flat"><span class="bg-dot"></span><span class="bg-sum">Audit the exporter's retries</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 4m</span><span class="bg-status">running</span></div>

--- a/tools/ui-verify/fixtures/awaiting-rows-feed.html
+++ b/tools/ui-verify/fixtures/awaiting-rows-feed.html
@@ -1,10 +1,13 @@
 <!-- SYNTHETIC fixture: a feed card whose Awaiting pill is pressed open on a MIXED wait
      (plans/subagent-transcripts.md slice 2, 2026-09-05): the pill reads "Awaiting 4 · 12m" and the
      checklist spot lists the awaited rows grouped under small dim headers (Agents / Commands / Watches),
-     labels only, the mini swirl as each row's mark. Invented content (notes-api demo domain), the DOM
-     class for class as applySections' renderTree emits it.
+     labels only, the mini swirl as each row's mark. NESTED waits (2026-09-10): under the first agent, what
+     that agent is itself waiting on — indented sub-rows, the first led by a dim "waiting on", the second by
+     its blank twin; a nested agent's own deeper wait counted in its label. The pill still reads 4 (the top
+     level). Invented content (notes-api demo domain), the DOM class for class as applySections' renderTree
+     emits it.
        tools/ui-verify/shot.sh --css ui/webview/feed.css --body tools/ui-verify/fixtures/awaiting-rows-feed.html \
-           --out /tmp/awaiting-shots/feed-dark.png --size 520x300 --extra-css '#feed-list { min-height: 260px; }'
+           --out /tmp/awaiting-shots/feed-dark.png --size 520x340 --extra-css '#feed-list { min-height: 300px; }'
 -->
 <div id="feed-head"></div>
 <div id="feed-list">
@@ -22,6 +25,8 @@
           <div class="fask-checklist">
             <div class="ftask-group">Agents</div>
             <div class="fcheck ftask"><span class="fcheck-tri empty"></span><span class="fcheck-mark"><span class="fask-awaiting-swirl ftask-swirl"></span></span><span class="fcheck-text">Map the notes-api parser</span></div>
+            <div class="fcheck ftask ftask-sub"><span class="ftask-waits-on">waiting on</span><span class="fcheck-tri empty"></span><span class="fcheck-mark"><span class="fask-awaiting-swirl ftask-swirl"></span></span><span class="fcheck-text">Run the parser test chunk</span></div>
+            <div class="fcheck ftask ftask-sub"><span class="ftask-waits-on ftask-waits-blank"></span><span class="fcheck-tri empty"></span><span class="fcheck-mark"><span class="fask-awaiting-swirl ftask-swirl"></span></span><span class="fcheck-text">Check the fixture loader<span class="ftask-deeper"> · waiting on 1 command</span></span></div>
             <div class="fcheck ftask"><span class="fcheck-tri empty"></span><span class="fcheck-mark"><span class="fask-awaiting-swirl ftask-swirl"></span></span><span class="fcheck-text">Audit the exporter's retries</span></div>
             <div class="ftask-group">Commands</div>
             <div class="fcheck ftask"><span class="fcheck-tri empty"></span><span class="fcheck-mark"><span class="fask-awaiting-swirl ftask-swirl"></span></span><span class="fcheck-text">Build the docs site</span></div>

--- a/ui/webview/awaiting-box-sync.test.ts
+++ b/ui/webview/awaiting-box-sync.test.ts
@@ -35,16 +35,20 @@ test("a status-only frame re-renders the awaiting box when its fields change —
   assert.match(tail, /const before = awaitKey\(s\.status\);\s*\n\s*if \(msg\.status\) s\.status = msg\.status;/);
   // (2026-09-07: the active tab's repaint is scheduled per animation frame — scheduleAppendActive carries
   // appendActive + renderLedger — while the awaited-agents box still keys on THIS frame's status change)
-  assert.match(tail, /scheduleAppendActive\(\);[\s\S]{0,900}?if \(awaitKey\(s\.status\) !== before\) renderBgTasks\(\);/,
+  // (2026-09-10: the render goes through awaitChanged(sid) — the box for the active session, plus the subagent
+  // viewer's header when the active tab is a viewer INTO this session, whose "waiting on" tail reads the parent's
+  // nested rows — and the call sits after the active/inactive branch so a viewer tab reaches it)
+  assert.match(tail, /scheduleAppendActive\(\);[\s\S]{0,3000}?if \(awaitKey\(s\.status\) !== before\) awaitChanged\(msg\.id\);/,
     "the box renders from the SAME chatTail frame that flipped the chip");
+  assert.match(RENDER, /function awaitChanged\(sid: string\): void \{\s*\n\s*if \(sid === activeId\) renderBgTasks\(\);/);
   // the `update` delta and the host-side status frame render it the same way
   const upd = RENDER.split("function update(msg: any) {")[1].split("\n}")[0];
   assert.match(upd, /const before = awaitKey\(s\.status\);\s*\n\s*s\.status = msg\.status \|\| s\.status;/);
-  assert.match(upd, /if \(awaitKey\(s\.status\) !== before\) renderBgTasks\(\);/);
+  assert.match(upd, /if \(awaitKey\(s\.status\) !== before\) awaitChanged\(msg\.id\);/);
   const body = RENDER.split("function statusOnly(msg: any) {")[1].split("\n}")[0];
   assert.match(body, /const before = awaitKey\(s\.status\);/);
   assert.match(body, /if \(msg\.id === activeId\) \{\s*\n\s*updateStatusline\(\);/, "the chip repaint stays");
-  assert.match(body, /if \(awaitKey\(s\.status\) !== before\) renderBgTasks\(\);/);
+  assert.match(body, /if \(awaitKey\(s\.status\) !== before\) awaitChanged\(msg\.id\);/);
   // …and the kernel's delta carries the full status the box reads from
   assert.match(KERNEL, /tail = \{"type": "chatTail", "id": sid, "from": change_from,\s*\n\s*"events": evs\[change_from:\], "total": total, "status": m\.get\("status"\)\}/);
 });
@@ -72,7 +76,7 @@ test("the chip and the box gist take the kind word from ONE count (T225 rider)",
   // gist and the feed pill from the kernel's kind + count + the awaited ROWS — "agent" for one, "3
   // agents" for several, the bare number when the kinds are mixed. kindWord stays underneath for a
   // payload with no rows (an older kernel), so the count still decides the number there.
-  assert.match(RENDER, /import \{ awaitWord, awaitBreakdown, groupRows, GROUP_TITLE, workingFor, type AwaitRow \} from "\.\/spin-caption";/);
+  assert.match(RENDER, /import \{ awaitWord, awaitBreakdown, groupRows, rowIds, waitsNote, GROUP_TITLE, workingFor, type AwaitRow \} from "\.\/spin-caption";/);   // + the nested-wait helpers (2026-09-10)
   assert.match(RENDER, /awaitingCount\?: number \| null;/, "the Status shape carries the kernel's count");
   assert.match(RENDER, /awaitingItems\?: AwaitRow\[\];/, "…and the rows (slice 2)");
   assert.match(RENDER, /const chipWord = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, chipItems\);/);
@@ -80,7 +84,7 @@ test("the chip and the box gist take the kind word from ONE count (T225 rider)",
   assert.match(RENDER, /const word = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, items\);/);   // `s` is narrowed by the one renderer's gate since 2026-09-06 (no `s!`)
   assert.match(RENDER, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace/);
   // the feed pill and the spin caption derive their word the same way
-  assert.match(FEED, /import \{ spinFor, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);
+  assert.match(FEED, /import \{ spinFor, awaitWord, groupRows, waitsNote, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);
   assert.match(FEED, /const pillWord = awaitWord\(awKind, \(it\.awaiting && it\.awaiting\.count\) \?\? taskRows\.length, taskRows\);/);
   assert.match(SPIN, /const word = kindWord\(aw\.kind, aw\.count\);/);
   assert.match(SPIN, /export function kindWord\(kind: string \| null \| undefined, count: number \| null \| undefined\): string \{/);

--- a/ui/webview/awaiting-rows.test.ts
+++ b/ui/webview/awaiting-rows.test.ts
@@ -20,7 +20,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { awaitWord, awaitBreakdown, groupRows, rowWord, kindWord, spinFor, GROUP_TITLE, ROW_KIND_OF_LEGACY,
-         type AwaitRow } from "./spin-caption";
+         flattenWaits, rowIds, agentRowOf, waitsNote, type AwaitRow } from "./spin-caption";
+import { subWaitTail } from "./subagent-view";
 
 const W = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
 const RENDER = W("render.ts");
@@ -152,9 +153,12 @@ test("the box groups the rows by kind, headers only when more than one group sho
 
 test("per-kind affordances on ONE row shape: agent → arrow + Stop; command → output fold + Stop; watch → armed-since + Cancel", () => {
   const spec = RENDER.split("function awaitRowSpec(")[1].split("\nfunction ")[0];
-  assert.match(spec, /if \(it\.kind === "agents"\) \{[\s\S]*?agentId: it\.agentId \|\| \(tracked && tracked\.agentId\) \|\| null[\s\S]*?stopId: running \? tracked!\.id : null[\s\S]*?output: null \};/,
+  // (2026-09-10: Stop's handle is computed once above the kind branches — the tracked task's id while it runs,
+  // else the row's own id when the kernel marks it stoppable — so the branches carry the one `stopId`)
+  assert.match(spec, /const stopId = running \? tracked!\.id : \(it\.stoppable && id \? id : null\);/);
+  assert.match(spec, /if \(it\.kind === "agents"\) \{[\s\S]*?agentId: it\.agentId \|\| \(tracked && tracked\.agentId\) \|\| null[\s\S]*?stopId, command[\s\S]*?output: null \};/,
     "an agent row: the arrow's id, Stop while its launch is live, NO output tail (its file is the transcript)");
-  assert.match(spec, /if \(it\.kind === "commands"\) \{[\s\S]*?stopId: running \? tracked!\.id : null[\s\S]*?output: tracked \? \(tracked\.output \|\| "\(no output captured\)"\) : null \};/);
+  assert.match(spec, /if \(it\.kind === "commands"\) \{[\s\S]*?stopId, command[\s\S]*?output: tracked \? \(tracked\.output \|\| "\(no output captured\)"\) : null \};/);
   assert.match(spec, /if \(it\.kind === "watches"\) \{[\s\S]*?status: "armed", caption: "armed"[\s\S]*?watchId: it\.watchId \|\| null, command: it\.detail \|\| null \};/);
   assert.match(spec, /if \(it\.kind === "peer"\) \{[\s\S]*?peer: peerByName\.get\(it\.label \|\| ""\) \|\| null \};/);
   const row = RENDER.split("function bgRow(")[1].split("\nfunction ")[0];
@@ -240,7 +244,7 @@ test("ONE renderer: the grouped rows render whenever rows exist, idle or not; th
   // the same row renderer for every row in either state — tracked tasks still lend the command rows their
   // output tail and Stop handle (awaitRowSpec's `tracked`), and list on their own when the wait names none
   assert.match(body, /const taskById = new Map<string, BgTask>\(tasks\.map\(\(t\) => \[t\.id, t\]\)\);/);
-  assert.match(body, /for \(const it of g\.rows\) list\.appendChild\(bgRow\(awaitRowSpec\(it, taskById\.get\(it\.id \|\| ""\), peerByName\), sid\)\);/);
+  assert.match(body, /for \(const it of g\.rows\) \{\s*list\.appendChild\(bgRow\(awaitRowSpec\(it, taskById\.get\(it\.id \|\| ""\), peerByName\), sid\)\);/);   // the loop is a block since 2026-09-10 (each agent row's nested waits follow it)
   assert.match(body, /for \(const t of leftovers\) list\.appendChild\(bgRow\(taskRowSpec\(t, awaited\.has\(t\.id\)\), sid\)\);/);
   // the awaited outline keys on the wait / the awaited ids' presence as before — never the chip state
   assert.match(body, /host\.classList\.toggle\("bg-awaited", !!why \|\| tasks\.some\(\(t\) => awaited\.has\(t\.id\)\)\);/);
@@ -296,4 +300,98 @@ test("the user-visible words are agent / command / watch / <peer> / timer; the k
   assert.doesNotMatch(KERNEL.split("def _awaiting_from_items")[1].split("\ndef ")[0], /background task/, "the collapse word is gone from the derived sentences");
   // the state formula that MOVES a card/chip is untouched: awaiting still keys on awaiting_why alone
   assert.match(KERNEL, /"awaitingBg" if awaiting_why else "ready"\)/);
+});
+
+// --- nested waits (2026-09-10): what an awaited agent is ITSELF waiting on ---------------------------------
+// Seen live: a session running ONE background agent read "Awaiting 2 · 1 agent · 1 command" — the command was
+// a test chunk the AGENT had launched (Claude Code keeps one task list per session, so it registered under the
+// parent). The user wants the top level to count what the session itself waits on ("Awaiting 1 · 1 agent") and
+// the agent's row to show, nested beneath it, what the agent in turn waits on. The kernel ships that as `waits`
+// on the agent row (kernel _awaiting_nest); every count and word here reads the top level alone.
+const SUB_CMD: AwaitRow = { kind: "commands", id: "b_chunk", label: "run the parser test chunk", since: 130, stoppable: true };
+const SUB_AGENT: AwaitRow = { kind: "agents", id: "tu_inner", label: "check the fixture loader", since: 140, agentId: "a2222222222222222",
+                              waits: [{ kind: "commands", id: "b_inner", label: "grep the fixtures", since: 150 }] };
+const NESTED: AwaitRow = { ...agent("map the parser"), waits: [SUB_CMD, SUB_AGENT] };
+
+test("the top level counts what the SESSION waits on: one agent with nested waits reads 'agent' / '1 agent', never 2", () => {
+  assert.equal(awaitWord("agents", 1, [NESTED]), "agent");
+  assert.equal(awaitBreakdown([NESTED]), "1 agent", "the breakdown never descends into waits");
+  assert.deepEqual(groupRows([NESTED]).map((g) => g.kind), ["agents"], "no Commands group from a nested command");
+});
+
+test("flattenWaits / rowIds reach every nested level, so a tracked task named by an agent's wait is not a leftover", () => {
+  assert.deepEqual(flattenWaits([NESTED]).map((r) => r.id), ["tu_map the parser", "b_chunk", "tu_inner", "b_inner"]);
+  assert.deepEqual([...rowIds([NESTED])].sort(), ["b_chunk", "b_inner", "tu_inner", "tu_map the parser"]);
+  assert.deepEqual(flattenWaits(null), []);
+});
+
+test("waitsNote: one wait → its label; several → the breakdown; deeper levels are counted, not dropped", () => {
+  assert.equal(waitsNote(SUB_AGENT), "grep the fixtures", "a single nested wait is named");
+  assert.equal(waitsNote(NESTED), "1 agent · 2 commands", "the agent's own command, the nested agent and ITS command — the level the box does not draw still counts");
+  assert.equal(waitsNote(SUB_CMD), "");
+  assert.equal(waitsNote(null), "");
+  assert.equal(waitsNote({ kind: "agents", id: "x", waits: [{ kind: "commands", id: "y" }] }), "command", "a label-less wait falls to its kind's word");
+});
+
+test("agentRowOf finds an agent at the top level or nested under another", () => {
+  assert.equal(agentRowOf([NESTED], "a0123456789abcdef"), NESTED);
+  assert.equal(agentRowOf([NESTED], "a2222222222222222"), SUB_AGENT);
+  assert.equal(agentRowOf([NESTED], "a9999999999999999"), undefined);
+  assert.equal(agentRowOf([NESTED], null), undefined);
+});
+
+test("the subagent viewer's header tail reads the PARENT's rows: '· waiting on <label>' while running, nothing finished", () => {
+  assert.equal(subWaitTail(true, [NESTED], "a2222222222222222"), "waiting on grep the fixtures");
+  assert.equal(subWaitTail(true, [NESTED], "a0123456789abcdef"), "waiting on 1 agent · 2 commands");
+  assert.equal(subWaitTail(false, [NESTED], "a2222222222222222"), "", "a finished agent waits on nothing, whatever a stale row says");
+  assert.equal(subWaitTail(true, [agent("plain")], "a0123456789abcdef"), "", "no waits → no tail");
+  assert.match(RENDER, /const tail = subWaitTail\(s\.sub\.running, liveSession\(s\.sub\.parentId\)\?\.status\.awaitingItems, s\.sub\.agentId\)/,
+               "renderSubHead reads the parent session's awaitingItems — the same rows the box draws");
+  assert.match(RENDER, /if \(a && a\.sub && a\.sub\.parentId === sid\) renderSubHead\(\);/, "the header re-renders when the parent's awaited fields change");
+  assert.equal((RENDER.match(/if \(awaitKey\(s\.status\) !== before\) awaitChanged\(msg\.id\);/g) || []).length, 3,
+               "every status-bearing frame path (full, tail, status-only) goes through awaitChanged");
+  assert.ok(STYLES.includes(".sub-head-waits {"), "the tail's own class");
+});
+
+test("the box draws an agent's waits as indented sub-rows in the SAME row vocabulary, 'waiting on' leading the first", () => {
+  // the sub-row loop sits under each agent row, inside the group loop — never a group of its own
+  assert.match(RENDER, /const waits = \(it\.waits \|\| \[\]\)\.filter\(\(w\) => w && w\.kind\);\s*waits\.forEach\(\(w, i\) => \{\s*const spec = awaitRowSpec\(w, taskById\.get\(w\.id \|\| ""\), peerByName\);\s*spec\.sub = i === 0 \? "first" : "rest";\s*spec\.deeper = waitsNote\(w\) \|\| null;\s*list\.appendChild\(bgRow\(spec, sid\)\);/,
+               "each wait is a bgRow from the same awaitRowSpec (dot · label · elapsed · STATUS · Stop), marked sub");
+  assert.match(RENDER, /sub\?: "first" \| "rest" \| null;/, "the spec's sub marker");
+  assert.match(RENDER, /const on = el\("span", "bg-waits-on" \+ \(t\.sub === "first" \? "" : " bg-waits-blank"\)\);\s*on\.textContent = t\.sub === "first" \? "waiting on" : "";/,
+               "the small dim label on the first sub-row; a blank twin on the rest so the dots align");
+  assert.match(RENDER, /\(t\.sub \? " bg-sub" : ""\)/, "the sub-row class (the indent)");
+  assert.match(RENDER, /dp\.textContent = "· waiting on " \+ t\.deeper;/, "a sub-row with waits of its own counts them in its label");
+  assert.ok(STYLES.includes(".bg-task.bg-sub > .bg-head { padding-left: 24px; }"), "indented under the agent");
+  assert.match(STYLES, /\.bg-waits-on \{[^}]*font-size: 0\.72em;[^}]*text-transform: uppercase;/, "the label rung .bg-status / .bg-group-head wear — no new font size");
+  assert.match(STYLES, /\.bg-deeper \{[^}]*font-size: 0\.82em;/, "the meta rung, like .bg-since");
+  assert.doesNotMatch(STYLES.match(/\.bg-waits-on \{[^}]*\}/)![0], /#[0-9a-fA-F]{3,6}/, "tokens, never hex");
+});
+
+test("the header and the chip count the top level only: the breakdown reads `items`, and nested ids still keep their tracked task out of 'Also running'", () => {
+  assert.match(RENDER, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ awaitBreakdown\(items\);/, "the mixed header's breakdown is the top-level rows");
+  assert.match(RENDER, /const word = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, items\);/, "the header word: top-level rows + the kernel's top-level count");
+  assert.match(RENDER, /const itemIds = rowIds\(items\);/, "a task an agent's wait names is named, not a leftover");
+});
+
+test("Stop rides a row the kernel marks stoppable even with no tracked task — a subagent's own command is never tracked", () => {
+  assert.match(RENDER, /const stopId = running \? tracked!\.id : \(it\.stoppable && id \? id : null\);/);
+  assert.match(KERNEL, /"stoppable": True\}\s*# a lifecycle-set task: stop_task resolves its id/, "the kernel marks lifecycle-set rows");
+  assert.match(KERNEL, /def _awaiting_nest\(agents, commands, cmd_owner, path\):/, "the kernel's nesting step");
+  assert.match(KERNEL, /agents, commands = _awaiting_nest\(agents, commands, cmd_owner, path\)/, "…applied to the live rows both turn states read");
+});
+
+test("the feed pill's list nests the same way: indented sub-rows, 'waiting on' on the first, deeper waits counted", () => {
+  assert.match(FEED, /const taskRow = \(r: AwaitRow, sub: "first" \| "rest" \| null\): HTMLElement => \{/);
+  assert.match(FEED, /\(\(r\.waits \|\| \[\]\)\.filter\(\(w\) => w && w\.kind\)\)\.forEach\(\(w, i\) => cl\.appendChild\(taskRow\(w, i === 0 \? "first" : "rest"\)\)\);/);
+  assert.match(FEED, /on\.textContent = sub === "first" \? "waiting on" : "";/);
+  assert.match(FEED, /dp\.textContent = " · waiting on " \+ deeper;/);
+  assert.ok(FEEDCSS.includes(".fcheck.ftask-sub { padding-left: 1.2em; }"));
+  assert.match(FEEDCSS, /\.ftask-waits-on \{[^}]*font-size: 0\.72em;/, "the .ftask-group rung");
+  assert.match(FEED, /const pillWord = awaitWord\(awKind, \(it\.awaiting && it\.awaiting\.count\) \?\? taskRows\.length, taskRows\);/, "the pill word reads the top-level rows + count");
+});
+
+test("the timeline's word reads the kernel's top-level count alone — a nested wait never reaches it", () => {
+  assert.match(TL, /label: 'Awaiting' \+ tlAwaitSuffix\(s\.awaitingKind, s\.awaitingCount\)/);
+  assert.doesNotMatch(TL, /awaitingItems|\.waits\b/, "the lane reads no rows at all: awaitingCount is computed from the top level in the kernel");
 });

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -93,7 +93,7 @@ test("the awaiting WHY lives in the background box, not the statusline (the user
   assert.match(RENDER, /chip-awaiting-" \+ \(s\.status\.awaitingKind \|\| "untyped"\)/);
   assert.match(RENDER, /if \(descs\.length > 1\)/);   // the no-rows fallback lists the legacy descriptions only when there are several
   assert.match(RENDER, /bg-await-note/);
-  assert.match(RENDER, /stopId: running \? tracked!\.id : null/);
+  assert.match(RENDER, /const stopId = running \? tracked!\.id : \(it\.stoppable && id \? id : null\);/);   // (2026-09-10: computed once above the kind branches; a kernel-marked stoppable row offers Stop without a tracked task)
   assert.match(RENDER, /return \{ id, status: "armed", caption: "armed", label: it\.label \|\| "a watch", since: it\.since,\s*\n\s*watchId: it\.watchId \|\| null, command: it\.detail \|\| null \};/, "a watch row: Cancel when the kernel has a handle, never Stop");
   assert.match(STYLES, /\.bg-fold-head\.bg-await \{ --bgt: var\(--st-awaitbg-bg\); \}/);
 });

--- a/ui/webview/chat-exact-tail-exec.test.ts
+++ b/ui/webview/chat-exact-tail-exec.test.ts
@@ -48,6 +48,7 @@ function liftChatTail(): (hooks: TailHooks) => TailApi {
     const scheduleRenderTabs = () => { H.tabRenders++; };
     const scheduleAppendActive = () => { H.appends++; };
     const renderBgTasks = () => { H.bgRenders++; };
+    const awaitChanged = (_sid) => { H.bgRenders++; };   // 2026-09-10: the tail calls this (box + a viewer's header); it counts as the box render
     const schedulePrebuild = () => { H.prebuilds++; };
   `;
   const epilogue = `

--- a/ui/webview/chat-tail-repaint.test.ts
+++ b/ui/webview/chat-tail-repaint.test.ts
@@ -18,7 +18,11 @@ test("a tail for the active tab schedules ONE repaint per frame instead of paint
   assert.match(active, /scheduleAppendActive\(\);/);
   assert.doesNotMatch(active, /\bappendActive\(\);/, "no inline appendActive on the tail path any more");
   assert.doesNotMatch(active, /\brenderLedger\(\);/, "the ledger paint rides the scheduled frame");
-  assert.match(active, /if \(awaitKey\(s\.status\) !== before\) renderBgTasks\(\);/, "the awaited-agents box still keys on the SAME frame's status change");
+  // (2026-09-10: the render moved just past the active/inactive branch, as awaitChanged(sid) — the box for the
+  // active session, and the subagent viewer's header when the active tab is a viewer into this one — so a viewer
+  // tab, for which msg.id !== activeId, reaches it too; still keyed on THIS frame's status change)
+  assert.match(tail, /\n  \}\n  if \(awaitKey\(s\.status\) !== before\) awaitChanged\(msg\.id\);/, "the awaited-agents box still keys on the SAME frame's status change");
+  assert.doesNotMatch(active, /renderBgTasks\(\)/, "…and no inline box render on the active branch");
 });
 
 test("the scheduler mirrors scheduleRenderTabs: one pending frame, then appendActive + renderLedger", () => {

--- a/ui/webview/feed-awaiting-swirl.test.ts
+++ b/ui/webview/feed-awaiting-swirl.test.ts
@@ -21,7 +21,7 @@ test("the swirl element is built in the body, right after the distiller line, an
 });
 
 test("the swirl is driven by spinFor's caption — shown when there is one, else hidden", () => {
-  assert.match(FEED, /import \{ spinFor, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);   // the rows' vocabulary too (slice 2)
+  assert.match(FEED, /import \{ spinFor, awaitWord, groupRows, waitsNote, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);   // the rows' vocabulary too (slice 2)
   assert.match(FEED, /const spin = spinFor\(it, distillPending\(dCompleted, dBlocked, it\.summary, it\.blockSummary, !!it\.blocked\),/);
   assert.match(FEED, /const spinCaption = spin\.caption, spinTip = spin\.tip, awaitingBg = spin\.awaitingBg;/);
   assert.match(FEED, /import \{ distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote \} from "\.\/distiller-line";/);
@@ -48,7 +48,7 @@ test("a bg-task wait wears the compact 'Awaiting task' pill that expands the tas
   assert.match(FEED, /pillLbl\.append\(\.\.\.durNodes\(it\.awaiting && it\.awaiting\.since\)\);\s*\/\/ the waited time, live/);   // appended after the (possibly coloured) word since slice 2
   assert.match(FEED, /taskBtn\.onclick = pick\("tasks"\);/);
   // expanded rows render in the checklist spot, same view as Sub-goals, the swirl as each row's mark
-  assert.match(FEED, /if \(choice === "tasks"\) \{[\s\S]*?el\("div", "fcheck ftask"\)[\s\S]*?ftask-swirl/);
+  assert.match(FEED, /if \(choice === "tasks"\) \{[\s\S]*?el\("div", "fcheck ftask" \+ \(sub \? " ftask-sub" : ""\)\)[\s\S]*?ftask-swirl/);   // + the nested-row marker (2026-09-10)
   assert.match(CSS, /\.fask-taskbtn \{ display: inline-flex/);
   assert.match(CSS, /\.ftask-swirl\.fask-awaiting-swirl/);
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -634,6 +634,12 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    .fmodal-warn-cap vocabulary, shown only when more than one group is on the card */
 .ftask-group { font-size: 0.72em; text-transform: uppercase; letter-spacing: 0.06em; color: var(--dim); margin: 4px 0 1px; }
 .ftask-group:first-child { margin-top: 1px; }
+/* NESTED rows (2026-09-10): what an awaited agent is itself waiting on, indented under its row; the first
+   led by a small dim "waiting on" (the .ftask-group rung), the rest by its blank twin so the marks align;
+   a nested row's own deeper waits are counted in .ftask-deeper (dim, same size as the text). */
+.fcheck.ftask-sub { padding-left: 1.2em; }
+.ftask-waits-on { flex: 0 0 auto; width: 5.4em; text-align: right; font-size: 0.72em; text-transform: uppercase; letter-spacing: 0.06em; color: var(--dim); white-space: nowrap; align-self: center; }
+.ftask-deeper { color: var(--dim); }
 
 /* "Followed up" — optimistic reopen pending the judge's re-file (judges delegation, 2026-06-17); blue pill */
 .fask-followedup { flex: 0 0 auto; font-size: 0.66em; font-weight: 700; letter-spacing: 0.04em;

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -15,7 +15,7 @@ import { delegate } from "./actions";
 import { paintHeld, paintReleased, publishPaneHidden } from "./paint-gate";
 import { linkifyPrRefs, setLinkedText, senderPrRepo, installPrLinkOpener } from "./pr-links";
 import { cardInputsKey, cardNeedsUpdate, type GateEnv } from "./feed-card-gate";
-import { spinFor, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow } from "./spin-caption";
+import { spinFor, awaitWord, groupRows, waitsNote, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { searchMatches, searchSids } from "./feed-search";
 import { TagLens, lensAll, lensLabel, lensVisible, lensUnions } from "./tag-lens";
@@ -1725,29 +1725,40 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
       // shows (agents / commands / watches / peers), labels only — the chat's box carries the controls
       const groups = groupRows(taskRows);
       const peerByName = new Map(pillPeers.map((p) => [p.name, p]));
+      // one row; `sub` = a NESTED row (what the agent above it is itself waiting on, kernel `waits`,
+      // 2026-09-10): indented, the first under its agent led by a small dim "waiting on", the rest by its
+      // blank twin so the marks align; a nested row with waits of its own says their count in its label —
+      // one level drawn, like the chat's box. Labels only here; the chat box carries the controls.
+      const taskRow = (r: AwaitRow, sub: "first" | "rest" | null): HTMLElement => {
+        const row = el("div", "fcheck ftask" + (sub ? " ftask-sub" : ""));
+        if (sub) { const on = el("span", "ftask-waits-on" + (sub === "first" ? "" : " ftask-waits-blank")); on.textContent = sub === "first" ? "waiting on" : ""; row.appendChild(on); }
+        const tri = el("span", "fcheck-tri empty");
+        const mark = el("span", "fcheck-mark");
+        mark.appendChild(el("span", "fask-awaiting-swirl ftask-swirl"));
+        const txt = el("span", "fcheck-text");
+        const p = r.kind === "peer" ? peerByName.get(r.label || "") : undefined;
+        if (p) {
+          // a peer row names the session the way the awaiting box does: identity colour, quiet host prefix,
+          // click opens the session (the standard session-chip gesture)
+          txt.replaceChildren(...hostPartsNodes(p.host, p.name));
+          if (p.color && p.color.bg) txt.style.color = p.color.bg;
+          if (p.sid) {
+            const sid = p.sid;
+            txt.title = "waiting on " + p.name + " — click opens the session";
+            txt.style.cursor = "pointer";
+            txt.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "openSession", id: sid }); };
+          }
+        } else txt.textContent = r.label || r.kind;
+        const deeper = sub ? waitsNote(r) : "";
+        if (deeper) { const dp = el("span", "ftask-deeper"); dp.textContent = " · waiting on " + deeper; txt.appendChild(dp); }
+        row.append(tri, mark, txt);
+        return row;
+      };
       for (const g of groups) {
         if (groups.length > 1) { const gh = el("div", "ftask-group"); gh.textContent = GROUP_TITLE[g.kind] || "Other"; cl.appendChild(gh); }
         for (const r of g.rows) {
-          const row = el("div", "fcheck ftask");
-          const tri = el("span", "fcheck-tri empty");
-          const mark = el("span", "fcheck-mark");
-          mark.appendChild(el("span", "fask-awaiting-swirl ftask-swirl"));
-          const txt = el("span", "fcheck-text");
-          const p = r.kind === "peer" ? peerByName.get(r.label || "") : undefined;
-          if (p) {
-            // a peer row names the session the way the awaiting box does: identity colour, quiet host prefix,
-            // click opens the session (the standard session-chip gesture)
-            txt.replaceChildren(...hostPartsNodes(p.host, p.name));
-            if (p.color && p.color.bg) txt.style.color = p.color.bg;
-            if (p.sid) {
-              const sid = p.sid;
-              txt.title = "waiting on " + p.name + " — click opens the session";
-              txt.style.cursor = "pointer";
-              txt.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "openSession", id: sid }); };
-            }
-          } else txt.textContent = r.label || r.kind;
-          row.append(tri, mark, txt);
-          cl.appendChild(row);
+          cl.appendChild(taskRow(r, null));
+          ((r.waits || []).filter((w) => w && w.kind)).forEach((w, i) => cl.appendChild(taskRow(w, i === 0 ? "first" : "rest")));
         }
       }
       cl.style.display = cl.children.length ? "" : "none";

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -28,7 +28,7 @@ import { loadSettings, onExternalSettingsChange, installSettingsSync, type RompS
 import { backendLabel, effectiveDefaultBackend } from "./backend-names";
 import { delegate } from "./actions";
 import { flash } from "./actions";   // its own line: the import above is pinned verbatim by click-safe.test.ts (the file-view precedent)
-import { awaitWord, awaitBreakdown, groupRows, GROUP_TITLE, workingFor, type AwaitRow } from "./spin-caption";
+import { awaitWord, awaitBreakdown, groupRows, rowIds, waitsNote, GROUP_TITLE, workingFor, type AwaitRow } from "./spin-caption";
 import { isClearCmd, openTopTitles, clearConfirmDetail, endConfirmDetail } from "./clear-confirm";
 import { prebuildPlan, type ViewState } from "./prebuild";
 import { newSkeletonState, applyTabOrderSkeleton, onStatus, onFull, onDismiss, onSocketUp, nextPrefetch, renderKind } from "./skeleton-tabs";
@@ -50,7 +50,7 @@ import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, notifHead, type AgentNotif } from "./agent-notif";
 import { injectedHead, type InjectedSource } from "./injected-source";
-import { subTabId, isSubId, subParts, subLabel, gistLines, stepLines, stepsNote, agentFoldLabel, subHeadParts, openIconSvg, pinIconSvg, type SubMeta, type AgentGist, type AgentGistRow, type GistLine } from "./subagent-view";
+import { subTabId, isSubId, subParts, subLabel, gistLines, stepLines, stepsNote, agentFoldLabel, subHeadParts, subWaitTail, openIconSvg, pinIconSvg, type SubMeta, type AgentGist, type AgentGistRow, type GistLine } from "./subagent-view";
 import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal, mdImgPostPass, setLightboxNav, type LightboxNavEntry } from "./preview";
 import { openFileClick } from "./file-view";                  // a clicked file WITH its gesture (pdf-new-tab.test.ts)
 // initFileView rides its OWN line: the import above is pinned verbatim by file-view.test.ts
@@ -11865,6 +11865,10 @@ function renderSubHead(): void {
   const parts = subHeadParts(s.sub.meta, s.sub.running);
   const typ = el("span", "sub-head-type"); typ.textContent = "· " + parts.type; line.appendChild(typ);
   const state = el("span", "sub-head-state " + parts.state); state.textContent = "· " + parts.state; line.appendChild(state);
+  // what the agent is itself waiting on (2026-09-10), from the PARENT's awaited rows — the same nested
+  // `waits` its box draws under this agent's row; re-rendered when those rows change (awaitChanged)
+  const tail = subWaitTail(s.sub.running, liveSession(s.sub.parentId)?.status.awaitingItems, s.sub.agentId);
+  if (tail) { const w = el("span", "sub-head-waits"); w.textContent = "· " + tail; line.appendChild(w); }
   const pin = el("span", "sub-head-pin" + (pinnedSubs.has(s.id) ? " pinned" : ""));
   pin.dataset.act = "pinSubagent"; pin.dataset.id = s.id;
   pin.innerHTML = pinIconSvg();
@@ -11904,7 +11908,7 @@ function renderBgTasks() {
   const open = openFolds.has("bgfold:" + sid);
   const groups = groupRows(items);
   const awPeers = s.status.awaitingPeers || [];
-  const itemIds = new Set<string>(items.map((it) => it.id || "").filter(Boolean));
+  const itemIds = rowIds(items);   // the rows AND what nests under them (an agent's own waits name their tasks too)
   const leftovers = tasks.filter((t) => !itemIds.has(t.id));   // tracked tasks the wait does not name (services)
   // the header dot: await-green while waiting, like the chip; otherwise the worst tracked status, so a
   // failed task is glanceable while collapsed (running-yellow when nothing tracked has failed)
@@ -11967,7 +11971,21 @@ function renderBgTasks() {
   const list = el("div", "bg-list");
   for (const g of groups) {
     if (headers) { const gh = el("div", "bg-group-head"); gh.textContent = GROUP_TITLE[g.kind] || "Other"; list.appendChild(gh); }
-    for (const it of g.rows) list.appendChild(bgRow(awaitRowSpec(it, taskById.get(it.id || ""), peerByName), sid));
+    for (const it of g.rows) {
+      list.appendChild(bgRow(awaitRowSpec(it, taskById.get(it.id || ""), peerByName), sid));
+      // what THIS row's agent is in turn waiting on (kernel `waits`, 2026-09-10): its own background commands
+      // or subagents, as indented sub-rows in the same row vocabulary — dot · label · elapsed · STATUS · Stop
+      // — under a small dim "waiting on" on the first. ONE level is drawn; a sub-row with waits of its own
+      // says so in its label ("· waiting on 1 command") rather than opening a third indent. The header and
+      // the chip never count these: the session waits on the agent, the agent waits on them.
+      const waits = (it.waits || []).filter((w) => w && w.kind);
+      waits.forEach((w, i) => {
+        const spec = awaitRowSpec(w, taskById.get(w.id || ""), peerByName);
+        spec.sub = i === 0 ? "first" : "rest";
+        spec.deeper = waitsNote(w) || null;
+        list.appendChild(bgRow(spec, sid));
+      });
+    }
   }
   if (leftovers.length) {
     if (headers) { const gh = el("div", "bg-group-head"); gh.textContent = BG_LEFTOVER_TITLE; list.appendChild(gh); }
@@ -12006,6 +12024,8 @@ interface BgRowSpec {
   command?: string | null;    // the fold: an agent's prompt, a command's command line, a watch's predicate
   output?: string | null;     // the fold: a command's output tail (never an agent's — its output file IS the transcript; the arrow is the way in)
   peer?: PeerIdent | null;    // a peer row: the name in identity colour
+  sub?: "first" | "rest" | null;   // a NESTED row — what the agent above it waits on (2026-09-10): indented; "first" wears the "waiting on" label, "rest" its blank twin so the dots align
+  deeper?: string | null;     // a nested row that has waits of its own: their count, said in the label ("waiting on 1 command") — the box draws one level
 }
 
 function taskRowSpec(t: BgTask, awaited: boolean): BgRowSpec {
@@ -12020,15 +12040,20 @@ function taskRowSpec(t: BgTask, awaited: boolean): BgRowSpec {
 function awaitRowSpec(it: AwaitRow, tracked: BgTask | undefined, peerByName: Map<string, PeerIdent>): BgRowSpec {
   const running = !!tracked && (tracked.status || "running") === "running";
   const id = it.id || it.agentId || "";
+  // Stop's handle: the tracked task's id while it runs, else the row's own id when the kernel marks the row
+  // stoppable (a task in the SDK's live lifecycle set — stop_task resolves that id; 2026-09-10). A subagent's
+  // own command is never a tracked task (the parent transcript never saw its launch), so without the flag
+  // the nested rows would have no Stop at all.
+  const stopId = running ? tracked!.id : (it.stoppable && id ? id : null);
   if (it.kind === "agents") {
     return { id, status: "running", caption: "running", label: it.label || (tracked && tracked.summary) || "background agent",
              agentId: it.agentId || (tracked && tracked.agentId) || null, since: it.since,
-             stopId: running ? tracked!.id : null, command: (tracked && tracked.command) || null, output: null };
+             stopId, command: (tracked && tracked.command) || null, output: null };
   }
   if (it.kind === "commands") {
     const status = (tracked && tracked.status) || "running";
     return { id, status, caption: status, label: it.label || (tracked && tracked.summary) || "background command", since: it.since,
-             stopId: running ? tracked!.id : null, command: (tracked && tracked.command) || null,
+             stopId, command: (tracked && tracked.command) || null,
              output: tracked ? (tracked.output || "(no output captured)") : null };
   }
   if (it.kind === "watches") {
@@ -12044,9 +12069,16 @@ function awaitRowSpec(it: AwaitRow, tracked: BgTask | undefined, peerByName: Map
 function bgRow(t: BgRowSpec, sid: string): HTMLElement {
   const tOpen = openFolds.has("bgrow:" + t.id);
   const foldable = !!(t.command || t.output);
-  const row = el("div", "bg-task bg-" + (t.status || "running") + (t.awaited ? " bg-awaited" : "") + (tOpen && foldable ? " open" : ""));
+  const row = el("div", "bg-task bg-" + (t.status || "running") + (t.awaited ? " bg-awaited" : "") + (t.sub ? " bg-sub" : "") + (tOpen && foldable ? " open" : ""));
   const rh = el("div", "bg-head" + (foldable ? "" : " bg-flat"));
   if (foldable) { rh.dataset.act = "bg-toggle"; rh.dataset.id = t.id; }   // the row header toggles; clicks in the detail body don't collapse it
+  if (t.sub) {
+    // a NESTED row: the small dim "waiting on" leads the first sub-row; the rest carry its blank twin (same
+    // width) so every sub-row's dot sits on one line under the agent above
+    const on = el("span", "bg-waits-on" + (t.sub === "first" ? "" : " bg-waits-blank"));
+    on.textContent = t.sub === "first" ? "waiting on" : "";
+    rh.appendChild(on);
+  }
   rh.appendChild(el("span", "bg-dot"));
   const sum = el("span", "bg-sum");
   if (t.peer) {
@@ -12055,6 +12087,10 @@ function bgRow(t: BgRowSpec, sid: string): HTMLElement {
     if (t.peer.color && t.peer.color.bg) sum.style.color = t.peer.color.bg;
   } else sum.textContent = t.label || "Background task";
   rh.appendChild(sum);
+  if (t.deeper) {
+    // the level the box does not draw, counted in words (the meta rung, like the elapsed time)
+    const dp = el("span", "bg-deeper"); dp.textContent = "· waiting on " + t.deeper; rh.appendChild(dp);
+  }
   if (t.agentId) {
     // an AGENT row: the same open-transcript arrow the Agent tool head wears (plans/subagent-transcripts.md).
     // Nested inside the bg-toggle row; the body delegate's closest-[data-act] lookup finds the arrow first,
@@ -14703,12 +14739,12 @@ function update(msg: any) {
   if (msg.id === activeId) {
     appendActive();
     renderLedger(); // refresh the summary box (ages + any new items) as the active session works
-    if (awaitKey(s.status) !== before) renderBgTasks();   // the box rides the chip's own frame (T225; see chatTail)
   } else {
     const v = views.get(msg.id);
     if (v) v.stale = true; // re-render its current turn when it's next shown
     schedulePrebuild(); // rebuild the now-stale off-screen view in idle, before the user switches to it
   }
+  if (awaitKey(s.status) !== before) awaitChanged(msg.id);   // the box rides the chip's own frame (T225; see chatTail)
 }
 
 // DELTA-send (the user 2026-06-25): the kernel keeps the whole transcript resident in the browser but, once
@@ -14823,7 +14859,6 @@ function chatTail(msg: any) {
     // rendered only from the full-session path, so the chip read "Awaiting agents" with no box until a
     // transcript change happened to send a full frame (31s+ in the user's shot; never, in the quiet lab).
     // Render the box from the SAME frame, keyed on the awaited fields CHANGING — never on the per-second ticks.
-    if (awaitKey(s.status) !== before) renderBgTasks();
   } else {
     // The SAME rule as the active tab: repaint from the exact changed point. Marking the view stale routed
     // the idle rebuild — and, when idle never came, the click itself — through a full 80-unit window
@@ -14839,6 +14874,7 @@ function chatTail(msg: any) {
     }
     schedulePrebuild(); // rebuild the now-stale off-screen view in idle, before the user switches to it (an incremental repaint now)
   }
+  if (awaitKey(s.status) !== before) awaitChanged(msg.id);   // (see the comment above: the box, keyed on the awaited fields changing)
 }
 
 // Older history streaming in from a loadOlder request (scroll-back past the loaded tail, the user 2026-06-25).
@@ -14927,6 +14963,16 @@ function requestOlder(sid: string, v: View, content: HTMLElement): void {
 // The awaiting fields the #bg-tasks box renders from (renderBgTasks — the header words, the rows, the awaited-row outline) — one
 // key per status, so a status-only frame re-renders the box exactly when THESE change (the chip's own
 // flip is one of them) and never on the per-second ticks that touch nothing the box shows.
+// The awaited fields of session `sid` changed (awaitKey moved on a frame): re-render what reads them — the
+// active pane's box, and the subagent viewer's header when the active tab is a viewer INTO that session
+// (its "· waiting on …" tail reads the parent's nested rows, 2026-09-10). The box renders only for the
+// active real session (renderBgTasks reads activeId), so calling it for a viewer tab is a no-op.
+function awaitChanged(sid: string): void {
+  if (sid === activeId) renderBgTasks();
+  const a = activeId ? liveSession(activeId) : null;
+  if (a && a.sub && a.sub.parentId === sid) renderSubHead();
+}
+
 function awaitKey(st: Status | undefined): string {
   if (!st) return "";
   return JSON.stringify([st.state, st.awaitingWhy || "", st.awaitingKind || "", st.awaitingCount ?? null,
@@ -14951,8 +14997,8 @@ function statusOnly(msg: any) {
     // this one payload, but the box was rendered only by the full-session frame path, so a status-only
     // flip to Awaiting left the chip on and the box absent until the next transcript change or tab
     // switch (31s+ observed). Same frame, same data — re-render the box when its fields changed.
-    if (awaitKey(s.status) !== before) renderBgTasks();
   }
+  if (awaitKey(s.status) !== before) awaitChanged(msg.id);
 }
 
 // The ✕'s own path: drop the tab now, THEN remember the close (see closingTabs). The order matters and

--- a/ui/webview/spin-caption.test.ts
+++ b/ui/webview/spin-caption.test.ts
@@ -167,7 +167,7 @@ test("a settled card displaced to Working loses its line but never its caption",
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
 test("feed.ts routes the card's swirl through spinFor and keeps no inline copy of the ladder", () => {
-  assert.match(FEED, /import \{ spinFor, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);   // slice 2: the rows' vocabulary rides the same import
+  assert.match(FEED, /import \{ spinFor, awaitWord, groupRows, waitsNote, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);   // slice 2: the rows' vocabulary rides the same import
   // the elapsed readout reaches the OTHER two awaiting surfaces through the same helper: the
   // "Awaiting task" pill and the "Awaiting <peer>" chip (the user 2026-08-23). That helper is durNodes —
   // waitedSuffix's rule (" · " + the duration for a known start, nothing otherwise) rendered as a stamped

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -42,6 +42,13 @@
 export interface AwaitRow {
   kind: string; id?: string; label?: string; since?: number | null;
   agentId?: string | null; detail?: string | null; watchId?: string | null;
+  /** the row is a task in the SDK's live lifecycle set — stop_task resolves its id, so Stop is offered
+   *  even when no tracked task (the parent transcript's scan) lends a handle (2026-09-10) */
+  stoppable?: boolean | null;
+  /** what the thing this row names is ITSELF waiting on (kernel _awaiting_nest, 2026-09-10): a subagent's
+   *  own background commands, or its own subagents (which may nest again). The top level lists only what
+   *  the session itself waits on; every count and word on the surfaces reads the top level alone. */
+  waits?: AwaitRow[] | null;
 }
 
 /** The card fields the ladder reads. Structural, so the test can pass plain objects. */
@@ -141,9 +148,43 @@ export function groupRows(items: readonly AwaitRow[] | null | undefined): { kind
   return out;
 }
 
-/** "2 agents · 1 command · 1 watch" — the tooltip breakdown; "" with no rows. */
+/** "2 agents · 1 command · 1 watch" — the tooltip breakdown; "" with no rows. Reads the rows it is given
+ *  and nothing beneath them: fed the top level, it counts what the session itself waits on. */
 export function awaitBreakdown(items: readonly AwaitRow[] | null | undefined): string {
   return groupRows(items).map((g) => g.rows.length + " " + rowWord(g.kind, g.rows.length)).join(" · ");
+}
+
+// ── nested waits (2026-09-10): what an awaited agent is in turn waiting on ────────────────────────────
+/** Every row beneath these, depth-first: a row's waits, their waits, and so on. */
+export function flattenWaits(items: readonly AwaitRow[] | null | undefined): AwaitRow[] {
+  const out: AwaitRow[] = [];
+  const walk = (rows: readonly AwaitRow[] | null | undefined) => {
+    for (const r of rows || []) { if (!r) continue; out.push(r); walk(r.waits); }
+  };
+  walk(items);
+  return out;
+}
+
+/** The ids of the rows AND of everything nested under them — the set a tracked task must be in to count
+ *  as "named by the wait" rather than an unrelated leftover. */
+export function rowIds(items: readonly AwaitRow[] | null | undefined): Set<string> {
+  return new Set(flattenWaits(items).map((r) => r.id || "").filter(Boolean));
+}
+
+/** The agent row for `agentId` anywhere in the rows — top level or nested under another agent. */
+export function agentRowOf(items: readonly AwaitRow[] | null | undefined, agentId: string | null | undefined): AwaitRow | undefined {
+  if (!agentId) return undefined;
+  return flattenWaits(items).find((r) => r.kind === "agents" && r.agentId === agentId);
+}
+
+/** The words for what ONE row is waiting on, in the row vocabulary: a single wait → its label ("run the
+ *  parser test chunk"); several → the breakdown ("2 commands", "1 agent · 1 command"); "" with none.
+ *  Counts EVERYTHING beneath the row, so a level the box does not draw is still said. */
+export function waitsNote(row: AwaitRow | null | undefined): string {
+  const all = flattenWaits(row && row.waits);
+  if (!all.length) return "";
+  if (all.length === 1) return (all[0].label || "").trim() || rowWord(all[0].kind, 1);
+  return awaitBreakdown(all);
 }
 
 /** The text after "Awaiting" on the chat chip, the box gist and the feed pill — ONE rule (the user

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -974,6 +974,14 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 .bg-await-why { font-size: 0.92em; color: var(--fg); margin: 4px 0 0; }
 .bg-await-task { font-size: 0.92em; color: var(--dim); margin-top: 3px; }
 .bg-await-note { font-size: 0.82em; color: var(--dim); opacity: .8; margin-top: 6px; }
+/* NESTED rows (2026-09-10): what the agent above is itself waiting on — indented under its row, led by a
+   small dim "waiting on" on the first sub-row (the label rung .bg-status / .bg-group-head wear) and its
+   blank twin on the rest, one fixed width so every sub-row's dot lines up; a sub-row with waits of its
+   own counts them in .bg-deeper (the meta rung, like .bg-since). One level is drawn. */
+.bg-task.bg-sub > .bg-head { padding-left: 24px; }
+.bg-waits-on { flex: 0 0 auto; width: 72px; text-align: right; font-size: 0.72em; text-transform: uppercase; letter-spacing: .06em; font-weight: 600; color: var(--dim); white-space: nowrap; }
+.bg-deeper { flex: 0 0 auto; font-size: 0.82em; color: var(--dim); white-space: nowrap; }
+.sub-head-waits { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }   /* the viewer header's "· waiting on …" tail */
 
 #footer {
   position: relative;   /* anchors #composer-resize on the top-edge divider */

--- a/ui/webview/subagent-view.ts
+++ b/ui/webview/subagent-view.ts
@@ -11,6 +11,8 @@
 // hostOf(parentId) for free. The suffix never reaches the kernel as a session id (openSubagent carries
 // the parent id + agentId), and a bare "/agent/" cannot occur in a uuid or a host name.
 
+import { agentRowOf, waitsNote, type AwaitRow } from "./spin-caption";
+
 export const SUB_SEP = "/agent/";
 
 export function subTabId(parentId: string, agentId: string): string { return parentId + SUB_SEP + agentId; }
@@ -113,6 +115,16 @@ export function agentFoldLabel(o: { stepsTotal?: number | null; reportLines?: nu
 // name is rendered by the caller as a link (hostNameNodes), so this returns the pieces, not a string.
 export function subHeadParts(meta: SubMeta | null | undefined, running: boolean): { type: string; state: "running" | "finished" } {
   return { type: (meta?.agentType || "").trim() || "agent", state: running ? "running" : "finished" };
+}
+
+// The header's "· waiting on <what>" tail (2026-09-10): what this agent is itself waiting on, read from the
+// PARENT session's awaited rows — the same nested `waits` the parent's box draws under the agent's row —
+// so the viewer and the box can never disagree. Only while the agent runs: a finished agent waits on
+// nothing, whatever a stale row says. "" when the parent lists no waits for it.
+export function subWaitTail(running: boolean, parentItems: readonly AwaitRow[] | null | undefined, agentId: string | null | undefined): string {
+  if (!running) return "";
+  const note = waitsNote(agentRowOf(parentItems, agentId));
+  return note ? "waiting on " + note : "";
 }
 
 // The two line icons, in the house style every glyph in render.ts wears (16-unit viewBox, currentColor

--- a/ui/webview/tab-switch-lag.test.ts
+++ b/ui/webview/tab-switch-lag.test.ts
@@ -14,7 +14,8 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 const chatTail = /^function chatTail\([\s\S]*?\n\}/m.exec(RENDER)![0];
 
 test("a background tab's tail lowers `rendered` to the changed point instead of marking the view stale", () => {
-  const bg = /\} else \{\n([\s\S]*?)\n  \}\n\}$/.exec(chatTail)![1];
+  // (the one line after the branch is the awaited-fields render, awaitChanged — 2026-09-10)
+  const bg = /\} else \{\n([\s\S]*?)\n  \}\n(?:  if \(awaitKey\(s\.status\) !== before\) awaitChanged\(msg\.id\);[^\n]*\n)?\}$/.exec(chatTail)![1];
   assert.match(bg, /v\.rendered = Math\.min\(v\.rendered, from\);/);
   assert.match(bg, /const atTail = \(v\.winEnd \?\? Infinity\) >= \(v\.unitTotal \?\? 0\);\n\s*if \(shrank \|\| \(!atTail && from < \(v\.winEnd \?\? 0\)\)\) v\.stale = true;/,
     "a truncation, or a change inside a scrolled-away window, still needs the window rebuilt");


### PR DESCRIPTION
Tier: feature

**Seen live 2026-09-10.** A session running one background subagent read "Awaiting 2 · 1 agent · 1 command". The command was a background test chunk the *subagent* had launched: Claude Code keeps one task list per session, so it registered under the parent, and romp listed it beside the agent as a second thing the session itself waited on. Now the top level counts what the session waits on ("Awaiting 1 · 1 agent"), and the agent's row shows, nested beneath it, what that agent is in turn waiting on.

## Design points

- **Attribution is exact or nothing.** A command's owner is the launch ledger's acting agent (`bgLedger[].agentId` = the PostToolUse hook's `agent_id`, which the SDK documents as present only when the hook fires inside a subagent). When the ledger is silent, the fallback is the one live agent whose *own* transcript (`…/subagents/agent-<id>.jsonl`) holds the launch's `tool_use` block, folded append-incrementally like the Agent head's steps (`_agent_launch_ids`). A nested agent's owner is its sidecar's `parentAgentId` when the CLI wrote one, else the same transcript join on its launch id. A row neither source attributes, or whose owner is not a live row, stays top-level — never a guess. No transcript is read unless there is a live agent to attribute to. `TaskStartedMessage` carries no parent link (checked in the installed SDK), so the hook's `agent_id` is the designed source.
- **Wire shape.** Agent rows may carry `waits: [{kind, id, label, since, agentId?, stoppable?, waits?}]`, present only when non-empty; a chain nests to any depth by reference. Top-level `kind` / `count` / `why` / `since` / `tasks` derive from the top-level rows alone, so the single-agent sentence and every card's timing are unchanged. Lifecycle-set rows also carry `stoppable: true` (the SDK's `stop_task` resolves their id) — a subagent's command is never a tracked task, so without it the nested rows would have had no Stop.
- **Chat box.** An agent row's waits render as indented sub-rows in the same row vocabulary (dot · label · elapsed · STATUS · Stop), a small dim "waiting on" on the first sub-row and its blank twin on the rest so the dots align; one level drawn, a sub-row's own deeper waits counted in its label ("· waiting on 1 command"). Header, chip and breakdown read the top level only. Nested ids count as "named" so their tracked task never falls to "Also running".
- **Feed pill** list nests the same way (labels only, indented, "waiting on" on the first). **Timeline** word reads the kernel's top-level count, as it always did.
- **Subagent viewer** header gains "· waiting on <label>" while the agent runs, read from the *parent's* `awaitingItems` (so the viewer and the box can never disagree), re-rendered through `awaitChanged(sid)` — the one helper the three status-bearing frame paths now call (box for the active session + the viewer's header when the active tab is a viewer into that session).

## Screenshots (in words; `tools/ui-verify/fixtures/awaiting-rows-{chat,feed}.html`, both themes)

Chat, idle and working boxes: under "Map the notes-api parser ↗ · 12m RUNNING [Stop]" sit two indented sub-rows — "WAITING ON ● Run the parser test chunk · 3m RUNNING [Stop]" and, dots aligned beneath it, "● Check the fixture loader · waiting on 1 command ↗ · 1m RUNNING [Stop]". The header still reads "Awaiting 4 · 2 agents · 1 command · 1 watch" (the top level), the chip "Awaiting 4". Light theme identical in its own palette. Feed card: the pressed pill "Awaiting 4 · 12m" with the same two rows indented under the first agent.

## Tests

- Kernel: `tests/test_awaiting_rows.py::NestedWaits` (ledger owner → nested, count 1, kind agents, the single-agent why byte-identical; transcript-join owner → nested; the same id in the PARENT transcript → top-level, count 2 mixed; unattributable → top-level; owner not a live row → top-level; nested agent via transcript and via sidecar parentAgentId; the turn-agnostic read nests identically; no transcript read without an agent). `tests/test_kernel_bg_tasks.py` pins it on the real `_bg_live_norm` with the ledger. Re-pinned: `test_kernel.py`, `test_kernel_awaiting_merge.py` (a lifecycle-set command row carries `stoppable`), `test_awaiting_box_sync.py` (the `awaitChanged` call).
- UI: `awaiting-rows.test.ts` (+10: the label rules executed on nested rows, `flattenWaits`/`rowIds`/`agentRowOf`/`waitsNote`/`subWaitTail`, and source pins for the box, feed, timeline, CSS tokens). Re-pinned in `awaiting-box-sync`, `awaiting-state`, `bg-tasks-layout` (my nested-row CSS moved below the `.bg-*` row rules so its first-`.bg-head`-match pin holds), `chat-exact-tail-exec` (an `awaitChanged` stub), `chat-tail-repaint`, `feed-awaiting-swirl`, `spin-caption`, `tab-switch-lag`.
- Runs: targeted Python files green (463); Python suite by chunks — a–k 6810 passed / 0 failed after re-pins; l–s only the pre-existing `ServedTapResume` legs; t–z's `test_tag_route.py` / `test_tab_meta_push.py` failures are the pre-existing ordering issue (both files green alone). Webview: `npm run typecheck` clean, `npm test` 4073/4077 with the one failure `md-sanitize-postpass-browser` KaTeX geometry, which fails byte-identically on untouched origin/main; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
