### PR TITLE
Tunnel rows: a Start whose step raises releases the row's hold instead of leaving it set until a kernel restart

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21634,7 +21634,9 @@ def _start_remote(host):
       2. If the kernel still isn't answering (the up-to-date path), _start_remote_kernel + the same
          port wait attach's bootstrap uses.
     Refreshes the stored token after boot (a first-ever kernel just wrote its serve-token).
-    Returns (ok, detail); mirrors _update_remote's contract."""
+    Returns (ok, detail); mirrors _update_remote's contract. An exception that escapes any step after the
+    hold is set releases the hold through _fail (the row reads no-kernel, the failure as its detail) and
+    propagates."""
     host = str(host or "").strip()
     if not host:
         return False, "no host"
@@ -21651,28 +21653,42 @@ def _start_remote(host):
             if rr:
                 rr["status"], rr["detail"], rr["booting"] = "no-kernel", detail, False
         return False, detail
-    ok, detail = _update_remote(host)
-    if not ok:
-        return _fail(detail)
-    if not _remote_kernel_up(host, kport):
-        # the already-up-to-date path: nothing synced, so _update_remote (re)started nothing
-        started, d2 = _start_remote_kernel(host)
-        if not started:
-            return _fail(d2)
-        detail = detail + " + started the kernel"
-    deadline = time.time() + _BOOT_WAIT_S
-    while time.time() < deadline and not _remote_kernel_up(host, kport):
-        time.sleep(1.0)
-    if not _remote_kernel_up(host, kport):
-        return _fail("started romp on %s but its kernel port never answered — check its kernel.log" % host)
-    token = _fetch_remote_token(host)
-    with _remotes_lock:
-        rr = _remotes.get(host)
-        if rr and token:
-            rr["token"] = token
-        if rr:
-            rr["detail"], rr["booting"] = "", False   # healthy — the supervisor's next poll flips it to 'up'
-    return True, detail
+    try:
+        ok, detail = _update_remote(host)
+        if not ok:
+            return _fail(detail)
+        if not _remote_kernel_up(host, kport):
+            # the already-up-to-date path: nothing synced, so _update_remote (re)started nothing
+            started, d2 = _start_remote_kernel(host)
+            if not started:
+                return _fail(d2)
+            detail = detail + " + started the kernel"
+        deadline = time.time() + _BOOT_WAIT_S
+        while time.time() < deadline and not _remote_kernel_up(host, kport):
+            time.sleep(1.0)
+        if not _remote_kernel_up(host, kport):
+            return _fail("started romp on %s but its kernel port never answered — check its kernel.log" % host)
+        token = _fetch_remote_token(host)
+        with _remotes_lock:
+            rr = _remotes.get(host)
+            if rr and token:
+                rr["token"] = token
+            if rr:
+                rr["detail"], rr["booting"] = "", False   # healthy — the supervisor's next poll flips it to 'up'
+        return True, detail
+    except BaseException as e:
+        # Every planned failure returns through _fail and success clears the hold above; this is the exit
+        # nothing planned for. The hold must not outlive the call: while it stands the supervisor skips
+        # its status write, the no-kernel hint and (T291b) the recovery counter, so an escaped exception
+        # left the row unable to read up or no-kernel again, with no Start button and, while the label
+        # read starting, the popover's fast poll running, until a kernel restart's load reset freed it.
+        # Through _fail, not a bare flag clear: with only `booting` cleared the next pass writes
+        # no-kernel but keeps the stale "updating + starting the kernel" detail (a specific detail
+        # survives the hint), so the row parks the failure the way every other failed Start does. The
+        # route's answer is unchanged.
+        what = str(e).strip()[:160]
+        _fail("Start on %s failed unexpectedly (%s)%s" % (host, type(e).__name__, ": " + what if what else ""))
+        raise
 
 
 def _tunnel_supervisor():

--- a/tests/test_kernel_remote_start.py
+++ b/tests/test_kernel_remote_start.py
@@ -103,6 +103,71 @@ class StartRemote(unittest.TestCase):
         self.assertEqual(seen["status"], "starting", "the popover shows the boot phase, not stale no-kernel")
         self.assertTrue(seen["booting"])
 
+    def test_an_escaped_exception_releases_the_hold_and_parks_the_failure(self):
+        # Every planned failure returns through _fail; an exception a step lets escape is the exit
+        # nothing planned for. The hold must not outlive the call: while it stands the supervisor
+        # skips its status write and the no-kernel hint, so the row never reads up or no-kernel again,
+        # no rendered row shows a Start button, and only a kernel restart's load reset frees it.
+        def boom(h):
+            raise RuntimeError("stand-in step failed")
+        km._update_remote = boom
+        with self.assertRaises(RuntimeError):
+            km._start_remote(HOST)              # the exception still propagates to the route
+        r = km._remotes[HOST]
+        self.assertFalse(r["booting"], "the hold must not outlive the call")
+        self.assertEqual(r["status"], "no-kernel", "the row reads the settled state, so the popover shows Start again")
+        self.assertEqual(r["detail"], "Start on %s failed unexpectedly (RuntimeError): stand-in step failed" % HOST,
+                         "the popover row carries the failure, like every failed Start")
+        self.assertEqual(self.started, [], "the boot leg never ran; the update leg raised first")
+
+    def test_the_recovery_counter_moves_on_the_first_answered_pass_after_an_escaped_exception(self):
+        # _note_recovery skips its bump under the hold (T291b), so a hold left standing also froze the
+        # row's recovery counter; once the hold is released the first answered pass on the not-up row
+        # bumps once, the one recovery of that Start
+        def boom(h):
+            raise RuntimeError("stand-in step failed")
+        km._update_remote = boom
+        with self.assertRaises(RuntimeError):
+            km._start_remote(HOST)
+        r = km._remotes[HOST]
+        r["misses"] = 0
+        self.assertTrue(km._note_recovery(r, "up"), "no hold left standing to freeze the recovery counter")
+        self.assertEqual(r["upSeq"], 1)
+
+    def test_an_escaped_exception_in_the_boot_leg_releases_the_hold_too(self):
+        km._update_remote = lambda h: (True, "already up to date (abc1234)")
+        def boom(h):
+            raise RuntimeError()                # no message: the detail ends at the type
+        km._start_remote_kernel = boom          # kernel_up stays False, so the boot leg runs
+        with self.assertRaises(RuntimeError):
+            km._start_remote(HOST)
+        r = km._remotes[HOST]
+        self.assertFalse(r["booting"])
+        self.assertEqual(r["status"], "no-kernel")
+        self.assertEqual(r["detail"], "Start on %s failed unexpectedly (RuntimeError)" % HOST)
+
+    def test_an_exit_that_is_not_an_exception_releases_the_hold_too(self):
+        # except BaseException, not Exception: a SystemExit or KeyboardInterrupt in the handler thread
+        # releases the hold the same way, and the parked detail names the type
+        def boom(h):
+            raise SystemExit("stand-in exit")
+        km._update_remote = boom
+        with self.assertRaises(SystemExit):
+            km._start_remote(HOST)
+        r = km._remotes[HOST]
+        self.assertFalse(r["booting"], "the hold must not outlive a non-Exception exit either")
+        self.assertEqual(r["status"], "no-kernel")
+        self.assertEqual(r["detail"], "Start on %s failed unexpectedly (SystemExit): stand-in exit" % HOST)
+
+    def test_a_long_failure_message_is_stripped_and_cut_in_the_parked_detail(self):
+        def boom(h):
+            raise RuntimeError("  " + "x" * 400 + "  ")
+        km._update_remote = boom
+        with self.assertRaises(RuntimeError):
+            km._start_remote(HOST)
+        self.assertEqual(km._remotes[HOST]["detail"],
+                         "Start on %s failed unexpectedly (RuntimeError): %s" % (HOST, "x" * 160))
+
 
 class SupervisorRespectsBoot(unittest.TestCase):
     def test_supervisor_defers_to_an_in_flight_start(self):


### PR DESCRIPTION
## Symptom

A Start on a no-kernel tunnel row (the popover's button) whose update or boot step raised an exception left the row stuck until a kernel restart. The row kept reading "starting" with "updating + starting the kernel" as its detail, never returned to up or no-kernel, showed no Start button on any later render (the click handler's Retry relabel lasts only until the next refresh, which rebuilds the list and renders Start only on no-kernel rows), kept the popover's 600 ms fast poll running for as long as the label read starting, and its recovery counter (upSeq) stayed still. The click itself got the generic alert "Start on <host> failed to reach the kernel." with nothing naming the failure. A tunnel death meanwhile relabelled the row down or error, still with no Start button; a kernel restart's load reset was the only way back.

No live raise path is known: every ssh seam in both legs catches Exception and returns a value. My merge notes on #1239 recorded the missing guarantee as pre-existing, so this PR closes a gap, not a reproduced outage.

## Cause

`_start_remote` sets the row's hold (`booting`, with status "starting") and, before this change, released it on two exits only: every planned failure returns through the nested `_fail`, which writes no-kernel with the failure as the detail and clears the flag, and the success tail clears it after the token refresh. An exception escaping any step between them left the hold set, and nothing else in the process clears it; the load-time reset runs only across a kernel restart. Three readers defer to the hold, which is why the row froze rather than healed: the supervisor pass skips its status write and the no-kernel hint while it stands, so the poll's no-kernel never reached the row, and since #1239 `_note_recovery` skips its bump. The route (`POST /tunnels/start`) has no exception handler of its own, so `do_POST`'s catch-all answered 500 with a text/plain traceback, which the popover's `r.json()` cannot parse, hence the generic alert.

## Fix

The body of `_start_remote` after the hold is set runs in a `try`; an `except BaseException` routes the exception through `_fail`, so the row reads no-kernel with "Start on <host> failed unexpectedly (<type>): <message>" as its detail (the message stripped and cut at 160 characters, and the ": <message>" tail omitted when the exception carries none), and re-raises, so the route's answer is unchanged. Two choices in it:

- Through `_fail` rather than clearing the flag alone. With only `booting` cleared, the next pass writes no-kernel but keeps the stale "updating + starting the kernel" text, because the pass keeps a specific parked failure over its generic hint until the row heals (its 2026-07-11 rule, so a refused update's reason stays visible). Parking the failure text makes the row read like every other failed Start, and the row's detail is where the user reads what went wrong, since the alert cannot show it.
- `BaseException`, so the release has a `finally`'s coverage: a SystemExit or KeyboardInterrupt in the handler thread releases the hold too, and the detail names the exception type. The alternative is `except Exception` plus a `finally` that clears the flag, at the cost of the failure text.

The ordinary returns and the success tail are unchanged, re-indented into the try (`git diff -w` shows the added lines alone). The `_fail` call runs after every `with _remotes_lock` block in the body has exited, so it takes the plain lock safely. One docstring sentence. No change to `_note_recovery`, the supervisor, the route or the popover.

## Tests

tests/test_kernel_remote_start.py, class StartRemote (synthetic host, every ssh seam stubbed, run under pytest). Five executing tests over the real `_start_remote`, each red on the unchanged kernel:

- `test_an_escaped_exception_releases_the_hold_and_parks_the_failure`: a stand-in update step raises `RuntimeError("stand-in step failed")`. The exception propagates, the hold is released, the row reads no-kernel with the exact detail "Start on TESTHOST failed unexpectedly (RuntimeError): stand-in step failed", and the boot leg never ran. Before the change: `AssertionError: True is not false : the hold must not outlive the call`.
- `test_the_recovery_counter_moves_on_the_first_answered_pass_after_an_escaped_exception`: the same raise, then `_note_recovery(r, "up")` bumps upSeq to 1. Before the change: `False is not true : no hold left standing to freeze the recovery counter` (the #1239 guard returns early under the hold).
- `test_an_escaped_exception_in_the_boot_leg_releases_the_hold_too`: the update leg reports up to date and a stand-in boot step raises a `RuntimeError()` with no message; the hold is released, the row reads no-kernel, and the detail ends at the type, "Start on TESTHOST failed unexpectedly (RuntimeError)". Before the change: `True is not false` on the hold.
- `test_an_exit_that_is_not_an_exception_releases_the_hold_too`: the stand-in update step raises `SystemExit("stand-in exit")`; it propagates, the hold is released, the row reads no-kernel and the detail names the type. Red under `except Exception` as well as before the change: `True is not false : the hold must not outlive a non-Exception exit either`.
- `test_a_long_failure_message_is_stripped_and_cut_in_the_parked_detail`: a 400-character message with surrounding whitespace is parked stripped and cut at 160 characters. Before the change: the detail still reads "updating + starting the kernel".

Each detail assertion is an exact match, so dropping the type name, the message, the strip or the cap from the parked text fails a test. Module: 20 passed (15 before, plus these five). tests/test_kernel_tunnel_truth.py (the #1239 tests): 33 passed, unchanged. Full pytest on this head: 10840 passed, 118 skipped, 1688 subtests passed, 0 failed (96 s, -n 6).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)