### PR TITLE
Merged board: a clear only the viewer holds drops a remote archived top whose only completion is a copied status

### DIFF
--- a/ui/webview/federation-cleared-overlay.test.ts
+++ b/ui/webview/federation-cleared-overlay.test.ts
@@ -1,6 +1,7 @@
 // The viewer's ledger over remote rows (review find, 2026-09-09): a remote kernel's feed and archive projection read
 // only their own cleared.jsonl, so an id the LOCAL ledger clears for a remote card (clearedForeign on the local
-// payload, bare) must drop that remote ask/item and read that remote archived top cleared, subtree with it, while
+// payload, bare) must drop that remote ask/item and read that remote archived top cleared, subtree with it (a top
+// whose only completion is the copied status leaves the list instead, as the owning kernel's overlay drops it), while
 // local rows and untouched remote rows pass through exactly as before. Same harness as feed-clock-anchor.test.ts.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
@@ -53,4 +54,51 @@ test("the overlay is pure over the rows it is given and ignores junk ids", () =>
   assert.equal(merged.asks.length, 0);
   assert.equal(ledgers[0].ledger.archivedTops[0].cleared, true);
   applyViewerClears(merged, ledgers, undefined);   // no ids: a no-op
+});
+
+test("a foreign clear of a remote archived top whose only completion is a copied status drops the row and its subtree; a verdict or a takeaway keeps it", () => {
+  // The rows carry the archive projection's own fields: at depth 0 `derived` means the copied status or a summary,
+  // never an ancestor, so derived with a blank summary is a root whose only completion is the copied status. The
+  // owning kernel's overlay drops such a root, subtree with it, when its cleared rows name it; a clear that only the
+  // viewer's rows hold must read the same way on the merged board, not leave the row listed struck through.
+  const row = (id: string, depth: number, derived: boolean, summary: string | null, cleared = false) =>
+    ({ id: SID + ":" + id, depth, cleared, done: true, derived, summary });
+  const rows = () => [
+    row("g1", 0, true, null), row("g1a", 1, true, null),        // status-only, named: dropped with its child
+    row("g2", 0, false, null), row("g2a", 1, true, null),       // its own verdict, named: stays, reads cleared
+    row("g3", 0, true, "kept the takeaway"),                    // a takeaway, named: stays, reads cleared
+    row("g4", 0, true, "   "), row("g4a", 1, true, null),       // whitespace is not a takeaway: dropped
+    row("g5", 0, true, null), row("g5a", 1, true, null),        // status-only, NOT named: untouched
+    row("g6", 0, true, null, true), row("g6a", 1, true, null),  // status-only, its copied flag already on, not named:
+    //                                                             dropped too (the copied-flag arm of the kernel's rule)
+  ];
+  const remote = { type: "feed", now: 100, asks: [], items: [],
+    ledgers: [{ sid: A, name: "HOSTA:api", ledger: { tree: [], archivedTops: rows() } }] };
+  const localTops = rows();
+  const local = { type: "feed", now: 7, asks: [], items: [],
+    ledgers: [{ sid: SID, name: "api", ledger: { tree: [], archivedTops: localTops } }],
+    clearedForeign: [SID + ":g1", SID + ":g2", SID + ":g3", SID + ":g4"] };
+  const merged = mergeHostFeeds({ "": local, HOSTA: remote }, ["", "HOSTA"]);
+  const tops = merged.ledgers.find((l: any) => l.sid === A).ledger.archivedTops;
+  assert.deepEqual(tops.map((n: any) => [n.id.split(":").pop(), n.cleared]),
+    [["g2", true], ["g2a", true], ["g3", true], ["g5", false], ["g5a", false]],
+    "g1, g4 and g6 leave with their children; g2 (its own verdict) and g3 (a takeaway) stay and read cleared; g5 is untouched");
+  const own = remote.ledgers[0].ledger.archivedTops;
+  assert.equal(own.length, 11, "the host payload's own rows are not removed");
+  assert.deepEqual([own[0].id.split(":").pop(), own[0].cleared], ["g1", false], "the host payload's own rows are not mutated");
+  const localOut = merged.ledgers.find((l: any) => l.sid === SID).ledger.archivedTops;
+  assert.equal(localOut, localTops, "a LOCAL entry of the same shape passes through as is: the local kernel already applied its own rows");
+});
+
+test("a drop with nothing else to mark still takes effect: the entry is rebuilt with the row and its subtree gone", () => {
+  // The reported case alone: one status-only remote top the viewer's ids name and no other row to mark. The rebuild
+  // has to follow from the drop itself, or the host payload's rows pass through by reference and the row stays listed.
+  const tops = [{ id: SID + ":g1", depth: 0, cleared: false, done: true, derived: true, summary: null },
+                { id: SID + ":g1a", depth: 1, cleared: false, done: true, derived: true, summary: null }];
+  const entry = { sid: A, ledger: { tree: [], archivedTops: tops } };
+  const ledgers = [entry];
+  applyViewerClears({ asks: [], items: [] }, ledgers, [SID + ":g1"]);
+  assert.deepEqual(ledgers[0].ledger.archivedTops, [], "the root and its child are gone");
+  assert.notEqual(ledgers[0], entry, "a fresh entry replaced the host payload's own object");
+  assert.equal(tops.length, 2, "the host payload's own rows are not mutated");
 });

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -401,8 +401,12 @@ export function mergeHostOrder(perHost: Record<string, readonly string[]>, hostS
  *  Absent `arrivedAt` (a caller with no wire), no `nowAt` is set and the pane anchors on its own arrival. */
 /** Apply the viewer's foreign cleared ids (bare, from the local payload) over REMOTE rows of a merged feed:
  *  remote asks/items they name are dropped; remote archived tops they name read cleared, rolled down to the
- *  subtree (the live tree's top-only cross-off). Rewrites `merged.asks`/`merged.items` and each remote ledger
- *  entry's archivedTops with fresh row objects; the host payloads' own rows are not mutated. No-op without ids. */
+ *  subtree (the live tree's top-only cross-off), except a cleared top whose only completion is the copied
+ *  status, which leaves the list with its subtree, as the owning kernel's overlay (_ledger_cleared_overlay)
+ *  drops it: a cleared flag rolls up to status cleared, so a copied "completed" beside a clear is a stale copy,
+ *  not a completion. A top with its own verdict (`derived` false) or a takeaway (a non-blank `summary`) stays
+ *  listed and reads cleared. Rewrites `merged.asks`/`merged.items` and each remote ledger entry's archivedTops
+ *  with fresh row objects; the host payloads' own rows are not mutated. No-op without ids. */
 export function applyViewerClears(merged: any, ledgers: any[], clearedForeign: any): void {
   const foreign = new Set<string>(Array.isArray(clearedForeign) ? clearedForeign.filter((x: any) => typeof x === "string") : []);
   if (!foreign.size) return;
@@ -417,14 +421,23 @@ export function applyViewerClears(merged: any, ledgers: any[], clearedForeign: a
     if (!l || !remote(l.sid)) return;
     const tops = l.ledger?.archivedTops;
     if (!Array.isArray(tops) || !tops.length) return;
-    let rootCleared = false, changed = false;
-    const out = tops.map((n: any) => {
-      if (n?.depth === 0) rootCleared = !!n.cleared || (typeof n.id === "string" && foreign.has(n.id));
+    let rootCleared = false, drop = false, changed = false;
+    const out: any[] = [];
+    for (const n of tops) {
+      if (n?.depth === 0) {
+        rootCleared = !!n.cleared || (typeof n.id === "string" && foreign.has(n.id));
+        // The owning kernel's rule, read from the same projection fields: at depth 0 `derived` means the copied
+        // status or a summary, never an ancestor (a root has none), so derived with a blank summary is a root
+        // whose only completion is the copied status. Cleared, it is dropped rather than marked; the viewer's
+        // ids stand in for the rows the owning kernel's own overlay would have read, so the outcome matches.
+        drop = rootCleared && !!n.derived && !String(n.summary || "").trim();
+      }
+      if (drop) { changed = true; continue; }   // a dropped root's descendants follow it in the flat list; they go with it
       const c = !!n?.cleared || (typeof n?.id === "string" && foreign.has(n.id)) || (n?.depth !== 0 && rootCleared);
-      if (c === !!n?.cleared) return n;
+      if (c === !!n?.cleared) { out.push(n); continue; }
       changed = true;
-      return { ...n, cleared: c };
-    });
+      out.push({ ...n, cleared: c });
+    }
     // a fresh ENTRY too, never the host payload's own object: the merge pushed those by reference
     if (changed) ledgers[i] = { ...l, ledger: { ...l.ledger, archivedTops: out } };
   });
@@ -500,8 +513,11 @@ export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly s
   // gesture taken while the owner was unreachable, a ledger copied between machines, an older client). The
   // local payload carries those ids (kernel: clearedForeign, bare); a remote ask or item they name is
   // dropped, and a remote archived top they name reads cleared, its subtree with it, exactly as the owning
-  // kernel's own overlay would have read them. Local rows are untouched: the local kernel already applied
-  // its ledger to them.
+  // kernel's own overlay would have read them: a cleared top whose only completion is the copied status
+  // leaves the list with its subtree (the kernel's _ledger_cleared_overlay drops it, since a cleared flag
+  // rolls up to status cleared and the copied "completed" is a stale copy); one with its own verdict or a
+  // takeaway stays listed, struck through. Local rows are untouched: the local kernel already applied its
+  // ledger to them.
   applyViewerClears(merged, ledgers, local.clearedForeign);
   if (anyLedgers) merged.ledgers = ledgers;
   else delete merged.ledgers;


### PR DESCRIPTION
## Symptom

On a board that merges several kernels, under Show completed, a remote top named by the viewer's own cleared.jsonl stays listed, struck through, with its subtree, when its only completion is the copied "completed" status. The same top, cleared through the owning kernel, leaves the list since #1243 (https://github.com/romp-on/romp/pull/1243). The two disagree whenever the clear reached the viewer's cleared.jsonl and not the owning kernel's: a cleared.jsonl copied between machines, a session whose goal store moved to another machine, an older client. A current client routes a remote card's clear to the owning kernel (or drops it with a notice when that kernel is unreachable), so the case is narrow; when it holds, nothing forwards the clear, and the row persists on every build.

## Cause

`applyViewerClears` in `ui/webview/federation.ts` (the viewer's cleared ids over remote rows, #1190 https://github.com/romp-on/romp/pull/1190, with #1195 https://github.com/romp-on/romp/pull/1195 for the row's sid) marks a remote archived top the viewer's ids name as cleared and rolls the flag down its subtree; it never removes a row. `_ledger_cleared_overlay` in `kernel/kernel.py` (#1243) drops a cleared depth-0 row whose `done` is derived and whose summary is blank, with the descendants that follow it. The call-site comment promises the rows read exactly as the owning kernel's own overlay would have read them; after #1243 that no longer held.

## Fix

`applyViewerClears` applies the same rule over the remote rows, from the projection fields the frame already carries (`derived`, `summary`, `cleared`): at depth 0, `rootCleared` is the row's copied flag or a foreign id, as before, and `drop = rootCleared && !!n.derived && !String(n.summary || "").trim()`. A dropped root and every non-depth-0 row that follows it (its subtree, the flat-list order the roll-down already reads) leave the list; otherwise the mark-and-roll-down is unchanged. The entry is still rebuilt fresh, so the host payload's own rows are never mutated. The doc comment and the call-site comment carry the reasoning from #1243: a cleared flag rolls up to status cleared, so a copied "completed" beside a clear is a stale copy, not a completion; a root with its own verdict (`derived` false) or a takeaway (a non-blank `summary`) stays listed and reads cleared. No type, payload or kernel change.

Two points, stated so the choice is visible:

- The drop reads `rootCleared`, which includes the remote row's own copied flag, as the kernel's `root_cleared` does; the viewer's ids stand in for entries the owning kernel's cleared.jsonl would have held, and the existing `if (!foreign.size) return` plays the part of the kernel's empty-file early return. So while the viewer holds any foreign id, a status-only row that reached the merged board struck through by its own flag (from an owning kernel older than #1243, or one whose cleared.jsonl is empty) also leaves the list, which is what a current owning kernel with those entries would show. Gating the drop on the viewer's ids alone would leave that row struck through; the reported case drops under either.
- #1243's review recommends widening the kernel rule to the literal #1187 reading (drop every cleared archived root without a takeaway, whatever its completion source). If that lands, this condition widens the same way (the `derived` factor goes in both), or the two overlays disagree again.

## Tests

`ui/webview/federation-cleared-overlay.test.ts`, two cases appended.

The first, "a foreign clear of a remote archived top whose only completion is a copied status drops the row and its subtree; a verdict or a takeaway keeps it": a remote frame carries six roots, every one `done: true`: g1 (`derived: true`, no summary) with a child; g2 (`derived: false`) with a child; g3 (`derived: true`, a takeaway); g4 (`derived: true`, a whitespace summary) with a child; g5 (`derived: true`, no summary) with a child; g6 (`derived: true`, no summary, its copied `cleared` flag already on) with a child. The local payload names g1 to g4. Through `mergeHostFeeds` the remote entry's rows must be exactly g2 and g2a (cleared), g3 (cleared), g5 and g5a (uncleared); the remote payload's own eleven rows must be untouched (g1 first, cleared false); a local entry of the same shape must pass through as the same object. Before the change the assertion fails with eleven rows led by g1 and g1a, cleared, and g4, g4a, g6 and g6a cleared: the struck-through rows.

The second, "a drop with nothing else to mark still takes effect: the entry is rebuilt with the row and its subtree gone": `applyViewerClears` over one entry of a status-only root and its child, with the root the only id named, must leave the entry's `archivedTops` empty, replace the entry object, and leave the two original rows in place. Before the change it fails with both rows present and cleared. It pins the rebuild the drop alone has to cause: without it the entry passes through by reference and the row stays listed, uncleared, which the first case cannot see because its other marks rebuild the entry anyway.

Four mutants of the drop arm each fail the file: the `derived` factor removed (three cases fail, since the existing fixtures carry no `derived`), the trim removed (g4 and g4a stay), the subtree skip removed (g1a, g4a and g6a stay in the first case, g1a in the second), and the drop taken without setting `changed` (the second case: both rows stay, uncleared). The three existing cases pass unchanged, as does `routing-clear-ids.test.ts`.

`npm run typecheck` clean. Full `npm test` on the head (`node --test` over every bundle, with the timeline-tags-scale file run alone as a second leg): 4069 tests, 4069 pass, 0 fail.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)