### PR TITLE
Auto-reload: the plain send's refusal on a disconnected host does not come back on the page that follows the reload either

### DIFF
--- a/ui/webview/reload-notices.test.ts
+++ b/ui/webview/reload-notices.test.ts
@@ -5,10 +5,11 @@
 // render.ts keeps the texts of the toasts on screen in this tab's sessionStorage on the core's synchronous hook and the
 // fresh page shows them once. The readings are pure and execute here. render.ts has import-time DOM side effects, so
 // its wiring is pinned to source the way reload-restore.test.ts pins the scroll record's, and the toast family with the
-// refusals that report a state (the staging refusals, the branch jump's, the send into a tab whose create failed, the
-// queued edit's send on a session that cannot be reached) is lifted out of it and executed over a fake DOM the way
-// chat-exact-tail-exec.test.ts lifts chatTail. The served scenario (a nack on the last ship across a kernel restart; the
-// fresh page says it again, once) is tests/test_ship_reship.py NackNoticeSurvivesReload. Synthetic only.
+// refusals that report a state (the staging refusals, the branch jump's, the send on a disconnected host, the send into
+// a tab whose create failed, the queued edit's send on a session that cannot be reached) is lifted out of it and
+// executed over a fake DOM the way chat-exact-tail-exec.test.ts lifts chatTail. The served scenario (a nack on the last
+// ship across a kernel restart; the fresh page says it again, once) is tests/test_ship_reship.py
+// NackNoticeSurvivesReload. Synthetic only.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -50,11 +51,11 @@ test("the toasts on screen read as their texts, in order, blanks dropped; none w
 
 test("the reading asks for the toasts without the ephemeral mark: a refusal about a state the fresh page shows for itself stays behind", () => {
   // a refusal that reports a state (the staged sends' "Can't send yet": the host unreachable, the tab still being
-  // created; the send into a tab whose create failed; the queued edit's send on a session that cannot be reached; the
-  // staging refusals; the branch jump to a session not on this dashboard) is about something the fresh page shows for
-  // itself or no longer has; render.ts marks those toasts where they are raised (executed below) and the
-  // selector skips the mark. The mark's effect on a real DOM is executed by tests/test_ship_reship.py
-  // NackNoticeSurvivesReload.
+  // created; the plain send on a disconnected host; the send into a tab whose create failed; the queued edit's send on
+  // a session that cannot be reached; the staging refusals; the branch jump to a session not on this dashboard) is
+  // about something the fresh page shows for itself or no longer has; render.ts marks those toasts where they are
+  // raised (executed below) and the selector skips the mark. The mark's effect on a real DOM is executed by
+  // tests/test_ship_reship.py NackNoticeSurvivesReload.
   const asked: string[] = [];
   assert.deepEqual(liveNotices({ querySelectorAll: (sel: string) => { asked.push(sel); return [{ textContent: "kept" }]; } }), ["kept"]);
   assert.deepEqual(asked, [SEL]);
@@ -147,14 +148,16 @@ function fakeDocument() {
 
 /** The page state the lifted closures read: the composer (a typed draft, its citations, a picker waiting, an edit in
  *  progress to a past message or to a queued one, attachments), the session roster, the reach of the active session's
- *  host (hostDown) and the active tab when it is provisional (tab: "pending", a create still in flight, so its id is the
- *  pending provisional id; "failed", a create that failed, so no create is pending), with what each gesture did
- *  recorded. The toasts' timers are recorded and not run, so a toast stays on screen for the reading. */
+ *  host (hostDown), whether the active session lives on another host (remote: its id wears the host prefix, lab:web,
+ *  the shape the disconnected-host refusal names the host from) and the active tab when it is provisional (tab:
+ *  "pending", a create still in flight, so its id is the pending provisional id; "failed", a create that failed, so no
+ *  create is pending), with what each gesture did recorded. The toasts' timers are recorded and not run, so a toast
+ *  stays on screen for the reading. */
 function pageWorld(state: { ask?: "custom" | "text" | null; edit?: boolean; queuedEdit?: boolean; files?: string[]; sessions?: string[];
-                            hostDown?: boolean; tab?: "pending" | "failed" }) {
-  const activeId = state.tab ? mintProvisionalId("web") : "web";
+                            hostDown?: boolean; remote?: boolean; tab?: "pending" | "failed" }) {
+  const activeId = state.tab ? mintProvisionalId("web") : state.remote ? "lab:web" : "web";
   const roster = (state.sessions || []).map((id): [string, { id: string; name: string }] => [id, { id, name: id }]);
-  if (state.tab) roster.push([activeId, { id: activeId, name: "web" }]);
+  if (state.tab || state.remote) roster.push([activeId, { id: activeId, name: "web" }]);
   return {
     FakeEl, document: fakeDocument(), timers: [] as number[],
     activeId, ta: { value: "what did the tests say", style: {} as Record<string, string> },
@@ -167,22 +170,26 @@ function pageWorld(state: { ask?: "custom" | "text" | null; edit?: boolean; queu
     activated: [] as [string, string | undefined][],
     hostDown: !!state.hostDown, posted: [] as { type: string }[], editsApplied: 0,
     isProvisionalId, provisionalId: state.tab === "pending" ? activeId : null, provisionalQueue: [] as string[],
+    lastSent: new Map<string, string>(),
   };
 }
 type World = ReturnType<typeof pageWorld>;
 type Lifted = { stageComposer: () => void; branchjump: (elx: { dataset: Record<string, string> }) => void; warnToast: (msg: string) => FakeEl;
-                provisionalSend: (sid: string, text: string, attached: string[]) => void; queuedEditSend: (typed: string) => void };
+                deliver: (sid: string, text: string, attached: string[]) => void; queuedEditSend: (typed: string) => void };
 
 /** warnToast and ephemeralWarnToast; stageComposer (the composer's staging, whose refusals say a picker is waiting on
  *  the composer, an edit is in progress to a past or a queued message, attachments are on the composer); the branch
- *  jump's delegated handler (whose refusal says the session is not on this dashboard); the provisional branch of the
- *  send's deliver (whose refusal says the tab's session never started); and the send's queued-edit branch (whose
- *  refusal says the session cannot be reached, so the edit was not sent), lifted from render.ts and run over the world. */
+ *  jump's delegated handler (whose refusal says the session is not on this dashboard); the refusing head of the send's
+ *  deliver (the disconnected-host branch, whose refusal says the host is disconnected and asks for a re-dial, and the
+ *  provisional branch, whose refusal says the tab's session never started), through the first step of a send that
+ *  passed both guards (lastSent remembers the text), so a refusal that fell through would show as a remembered send;
+ *  and the send's queued-edit branch (whose refusal says the session cannot be reached, so the edit was not sent),
+ *  lifted from render.ts and run over the world. */
 function liftToastSites(): (w: World) => Lifted {
   const toasts = liftBetween("function warnToast(msg: string): HTMLElement {", "// Tail-windowing (see the View comment)");
   const stage = liftBetween("const stageComposer = () => {", "const sendComposer = (");
   const jump = liftBetween("branchjump: (elx) => {", "// a below-response fork spot", (ts) => "const handlers = {\n" + ts + "};");
-  const send = liftBetween("if (isProvisionalId(sid)) {", "lastSent.set(activeId, text);", (ts) => "const provisionalSend = (sid, text, attached) => {\n" + ts + "};");
+  const send = liftBetween("if (hostIsDown(sid)) {", "// The STAGED run and this message go together", (ts) => "const deliver = (sid, text, attached) => {\n" + ts + "};");
   const qsend = liftBetween("const qedit = queuedEdits.get(activeId);", "const sid = activeId;   // the session this send", (ts) => "const queuedEditSend = (typed) => {\n" + ts + "};");
   const prelude = `
     const W = WORLD;
@@ -205,6 +212,7 @@ function liftToastSites(): (w: World) => Lifted {
     const sessions = W.sessions;
     const setActive = (sid, cut) => { W.activated.push([sid, cut]); };
     const isProvisionalId = W.isProvisionalId, provisionalId = W.provisionalId, provisionalQueue = W.provisionalQueue;
+    const lastSent = W.lastSent;
     const registerOptimistic = () => {}, previewKind = () => null, renderComposerFiles = () => {};
     const sendOnShip = new Set(), histWalk = new Map();
     const hostIsDown = () => W.hostDown;
@@ -215,7 +223,7 @@ function liftToastSites(): (w: World) => Lifted {
     const restoreHeldDraft = () => {};
   `;
   return new Function("WORLD", prelude + toasts + stage + jump + send + qsend
-    + "\nreturn { stageComposer, branchjump: handlers.branchjump, warnToast, provisionalSend, queuedEditSend };") as (w: World) => Lifted;
+    + "\nreturn { stageComposer, branchjump: handlers.branchjump, warnToast, deliver, queuedEditSend };") as (w: World) => Lifted;
 }
 
 function page(state: Parameters<typeof pageWorld>[0]) {
@@ -240,10 +248,12 @@ test("staging with nothing owning the composer stages: the lifted composer is th
 
 // The refusals that report a STATE rather than an event, raised through their real code paths. Each puts its toast on
 // screen for the person at the page and refuses the gesture; the reading skips it, because the fresh page shows that
-// state for itself (the picker, the attachments and the roster come back from the kernel and the persisted drafts) or
-// no longer has it (an edit in progress, to a past message or to a queued one, lives in memory alone, so a replay would
-// report an edit the fresh page has not got, and its "send again" would post the words as a new message; a provisional
-// tab does not survive a reload, so a replay would name a session the fresh page does not show).
+// state for itself (the picker, the attachments and the roster come back from the kernel and the persisted drafts; the
+// host's reach comes back from the kernel's tunnel health and is shown as the tab mark and the transcript foot, and the
+// re-dial the disconnected-host refusal speaks of is posted by the gesture, never by a replay) or no longer has it (an
+// edit in progress, to a past message or to a queued one, lives in memory alone, so a replay would report an edit the
+// fresh page has not got, and its "send again" would post the words as a new message; a provisional tab does not
+// survive a reload, so a replay would name a session the fresh page does not show).
 const STATE_REFUSALS: { name: string; state: Parameters<typeof pageWorld>[0]; raise: (p: Page) => void; text: string; refused: (p: Page) => void }[] = [
   { name: "staging while a picker waits on the composer", state: { ask: "text" }, raise: (p) => p.stageComposer(),
     text: "A picker is waiting on this box", refused: (p) => assert.deepEqual(p.W.staged, [], "nothing staged") },
@@ -255,8 +265,17 @@ const STATE_REFUSALS: { name: string; state: Parameters<typeof pageWorld>[0]; ra
     text: "Attachments can't be staged", refused: (p) => assert.deepEqual(p.W.staged, [], "nothing staged") },
   { name: "a branch jump to a session not on this dashboard", state: { sessions: ["web"] }, raise: (p) => p.branchjump({ dataset: { sid: "api" } }),
     text: "That session isn't on this dashboard right now.", refused: (p) => assert.deepEqual(p.W.activated, [], "no switch") },
-  { name: "a send into a tab whose create failed", state: { tab: "failed" }, raise: (p) => p.provisionalSend(p.W.activeId, p.W.ta.value, []),
-    text: "“web” never started, so there's nowhere to send this.", refused: (p) => assert.deepEqual(p.W.provisionalQueue, [], "nothing queued") },
+  { name: "a send while the session's host is unreachable", state: { remote: true, hostDown: true }, raise: (p) => p.deliver(p.W.activeId, p.W.ta.value, []),
+    text: "lab is disconnected, so this wasn't sent.", refused: (p) => {
+      assert.deepEqual(p.W.posted.map((m) => m.type), ["redial"], "a re-dial of the host is asked for and nothing is sent");
+      assert.deepEqual(p.W.provisionalQueue, [], "nothing queued");
+      assert.equal(p.W.lastSent.size, 0, "nothing was remembered as sent");
+    } },
+  { name: "a send into a tab whose create failed", state: { tab: "failed" }, raise: (p) => p.deliver(p.W.activeId, p.W.ta.value, []),
+    text: "“web” never started, so there's nowhere to send this.", refused: (p) => {
+      assert.deepEqual(p.W.provisionalQueue, [], "nothing queued");
+      assert.equal(p.W.lastSent.size, 0, "nothing was remembered as sent");
+    } },
   { name: "a queued edit sent while the session's host is unreachable", state: { queuedEdit: true, hostDown: true }, raise: (p) => p.queuedEditSend(p.W.ta.value),
     text: "Can't reach the session right now, so the edit wasn't sent.", refused: (p) => {
       assert.deepEqual(p.W.posted.map((m) => m.type), ["redial"], "a re-dial is asked for and no edit is posted");
@@ -310,10 +329,12 @@ test("render.ts: warnToast hands back its toast, and the refusals about a state 
   // a session that cannot be reached (the edit lives in memory alone): states the fresh page no longer has
   assert.match(RENDER, /if \(sid !== provisionalId\) \{\n\s*ephemeralWarnToast\("“" \+ \(sessions\.get\(sid\)\?\.name \|\| "this session"\) \+ "” never started, so there's "/);
   assert.match(RENDER, /if \(hostIsDown\(activeId\) \|\| isProvisionalId\(activeId\)\) \{\n\s*if \(hostIsDown\(activeId\)\) vscodeApi\?\.postMessage\(\{ type: "redial"[^\n]*\n\s*ephemeralWarnToast\("Can't reach the session right now, so the edit wasn't sent\./);
-  assert.equal((RENDER.match(/ephemeralWarnToast\(/g) || []).length, 10, "the definition, the two reachability sites and the seven state refusals");
-  // what the nack, the dismissal, the other-tab ack and the plain send's refusal on a disconnected host say stays true
-  // after the reload (the message is in the box on the fresh page too, and a send there sends it), so they ride it unmarked
-  assert.match(RENDER, /warnToast\(host \+ " is disconnected, so this wasn't sent\. It's still in the box/);
+  // the plain send's refusal on a disconnected host: the host's reach is a state the fresh page reads from the kernel's
+  // tunnel health (the tab mark, the transcript foot), and the re-dial that makes "re-dialing now" true is posted by
+  // the gesture, never by a replay
+  assert.match(RENDER, /if \(hostIsDown\(sid\)\) \{\n\s*const host = String\(sid\)\.slice\(0, String\(sid\)\.indexOf\(":"\)\);\n(\s*\/\/[^\n]*\n)*\s*vscodeApi\?\.postMessage\(\{ type: "redial", host \}\);\n(\s*\/\/[^\n]*\n)*\s*ephemeralWarnToast\(host \+ " is disconnected, so this wasn't sent\. It's still in the box/);
+  assert.equal((RENDER.match(/ephemeralWarnToast\(/g) || []).length, 11, "the definition, the two reachability sites and the eight state refusals");
+  // what the nack, the dismissal and the other-tab ack say stays true after the reload, so they ride it unmarked
   assert.match(RENDER, /warnToast\(m\.name \+ " couldn't be saved on the kernel, so it was not attached/);
   assert.match(RENDER, /warnToast\("The pending upload was dismissed — your held message was NOT sent\."\)/);
   assert.match(RENDER, /warnToast\("attachments finished uploading on another tab — the held message was not sent; review it there\."\)/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9972,21 +9972,23 @@ function warnToast(msg: string): HTMLElement {
 }
 // A toast the page that follows a reload must not repeat: a refusal that reports a STATE rather than an event. The
 // staged sends' "Can't send yet" says the session's host is unreachable (hostIsDown, a remote host's tunnel) or its tab
-// is still being created (isProvisionalId); the send into a tab whose create failed (sendComposer's deliver) says the
-// session never started; the queued edit's send (sendComposer, ahead of deliver) says the session cannot be reached, so
-// the edit was not sent; the staging refusals (stageComposer) say a picker is waiting on the composer, an edit is in
-// progress (to a past message, or to a queued one) or attachments are on the composer; the branch jump's refusal
-// (branchjump) says the session is not on this dashboard. The fresh page shows each state for itself (the host mark and
-// the staged strip; the picker, the attachments and the roster come back from the kernel and the persisted drafts) or no
-// longer has it (a provisional tab, pending or failed, does not survive a reload; composerEdits and queuedEdits are in
-// memory alone, so no edit is in progress on a fresh page, and a "send again" there would post the words as a new
-// message), so kept by persistNoticesForReload and shown again by the page that follows, it would be redundant at best
-// and false at worst. The mark keeps it out of the replay (reload-notices.ts liveNotices reads only the toasts without
-// it).
+// is still being created (isProvisionalId); the plain send's refusal on a disconnected host (sendComposer's deliver)
+// says the same host is unreachable and that romp is re-dialing it; the send into a tab whose create failed (deliver
+// too) says the session never started; the queued edit's send (sendComposer, ahead of deliver) says the session cannot
+// be reached, so the edit was not sent; the staging refusals (stageComposer) say a picker is waiting on the composer,
+// an edit is in progress (to a past message, or to a queued one) or attachments are on the composer; the branch jump's
+// refusal (branchjump) says the session is not on this dashboard. The fresh page shows each state for itself (the host
+// mark and the transcript foot, from the kernel's tunnel health, which the page reads afresh into a disconnected set
+// that starts empty; the staged strip; the picker, the attachments and the roster come back from the kernel and the
+// persisted drafts, the refused message among them) or no longer has it (a provisional tab, pending or failed, does not
+// survive a reload; composerEdits and queuedEdits are in memory alone, so no edit is in progress on a fresh page, and a
+// "send again" there would post the words as a new message), so kept by persistNoticesForReload and shown again by the
+// page that follows, it would be redundant at best and false at worst; a replay also posts no redial, so the
+// disconnected-host refusal's "re-dialing now" would not be true there. The mark keeps it out of the replay
+// (reload-notices.ts liveNotices reads only the toasts without it).
 // Toasts that report what HAPPENED to a send or a file stay unmarked, since what they say is as true after the reload
 // as before: the nack (the attachment was not saved, the held message not sent), the dismissal and the other-tab ack
-// (the held message not sent), the plain send's refusal on a disconnected host (this message was not sent and is still
-// in the composer, where the fresh page's persisted draft keeps it, and a send there sends it).
+// (the held message not sent).
 function ephemeralWarnToast(msg: string): void { warnToast(msg).dataset.ephemeral = "1"; }
 
 // Tail-windowing (see the View comment): a fresh/rewound view renders only the
@@ -15876,7 +15878,11 @@ function setupComposer() {
         // the refusal itself is DEMAND: ask the kernel to re-dial that host's tunnel right now,
         // so "romp is re-dialing" below is literally true at the moment it is read (2026-08-16)
         vscodeApi?.postMessage({ type: "redial", host });
-        warnToast(host + " is disconnected, so this wasn't sent. It's still in the box — romp is "
+        // The refusal reports a state (the host's reach): the page that follows a reload reads it from the kernel's
+        // tunnel health and shows it as the tab mark and the transcript foot, a replay posts no redial to make
+        // "re-dialing now" true, and the message is in the persisted draft. So it does not ride one
+        // (ephemeralWarnToast).
+        ephemeralWarnToast(host + " is disconnected, so this wasn't sent. It's still in the box — romp is "
           + "re-dialing the link now; send again when it's back.");
         return;
       }


### PR DESCRIPTION
Follow-up to #1227 and #1246 (both merged), which marked the refusals that report a state so the page that follows a restart's reload does not repeat them, and named this one as the refusal that stays unmarked. This PR argues the other way, and marks it.

## Symptom

A send to a session whose host is disconnected is refused with a toast: the host is disconnected, so this wasn't sent; the message is still in the composer, romp is re-dialing the link, send again when it's back. When a kernel restart's reload takes the page inside the toast's twelve seconds, the fresh page shows the toast again. The reload waits while the composer is focused with text in it, so the case is a send refused, the composer left, and the restart's reload inside the twelve seconds. At that moment the fresh page shows every host as connected: no tab mark, no transcript foot. The toast says a host is disconnected on a page that shows no such thing, and says romp is re-dialing when nothing on that page asked for a re-dial.

## Cause

The refusal is a plain `warnToast`, so `persistNoticesForReload` keeps it and the fresh page replays it at module load.

#1227 and #1246 left it unmarked on the reading that what it says stays true after the reload: the message was not sent, it is still in the composer, and a send there sends it. That holds for one of the toast's three claims. The other two are claims about a state.

- "The host is disconnected" is the state the staged sends' "Can't send yet" reports, on the same `hostIsDown` predicate, and that refusal is marked at both of its sites. `hostIsDown` reads the federation manager's disconnected set, which starts empty on a fresh page and has one writer, the page's poll of the kernel's `/tunnels`. The replay runs at module load, before the first poll, so it tells a page that shows every host as up that one of them is disconnected. Once the poll lands the toast is redundant (the host is still down, and the tab mark and the transcript foot say so) or false (the kernel that restarted dials every attached host as it comes up, so a link that was dead on this side comes back once that dial completes).
- "Romp is re-dialing the link now" is made true by the `redial` the refusal posts as it is raised. A replay posts none.
- The event claim, that the message was not sent and is still in the composer, is shown by the composer for itself: the input listener persists the draft and `restoreActiveDraftOnce` puts it back on the fresh page. That is the reason #1227 gave for marking the picker, attachment and roster refusals: the fresh page shows the state, so a replayed toast repeats it.

So the refusal reports a state, by the standard the census above `ephemeralWarnToast` already applies, and belongs with the marked ones.

## Fix

`ui/webview/render.ts`: the disconnected-host branch of `sendComposer`'s `deliver` raises its refusal through `ephemeralWarnToast`, with a comment at the site. The census above `ephemeralWarnToast` lists it with the other state refusals, says what the fresh page shows for itself (the host mark and the transcript foot, from the kernel's tunnel health, which the page reads afresh; the persisted draft, with the refused message in it) and that a replay posts no redial; the unmarked list keeps the nack, the dismissal and the other-tab ack. The toast's text and the `redial` it posts do not change; the `stageComposer` and `sendComposer` refusals #1227 and #1246 marked are untouched. No change to `reload-notices.ts`, the kernel or the docs.

Behaviour change: this one toast no longer comes back on the page that follows a reload inside its twelve seconds.

## Tests

`ui/webview/reload-notices.test.ts`, 19 cases under `node --test` (18 before):

- The lifted slice of the send's `deliver` now starts at its disconnected-host branch (`if (hostIsDown(sid)) {`, unique in the file) instead of the provisional branch, and runs through the first step of a send that passed both guards (`lastSent.set`, which remembers the text for a Ctrl+C restore), so a refusal that fell through would show as a remembered send. The page world gains a `remote` option that puts the active session on a host (`lab:web`), so the refusal has a host to name, and a `lastSent` map.
- One row joins the state-refusals table, "a send while the session's host is unreachable": the toast is on screen and starts with "lab is disconnected, so this wasn't sent.", a `redial` is posted and nothing else, nothing is queued, nothing is remembered as sent, the draft stays where it was, and `liveNotices` skips it. Before the change it fails at the reading, which returns the refusal's full text. With the `return` after the marked toast removed it fails on the remembered send (a variant that passed before the slice ran through `lastSent`). The "send into a tab whose create failed" row gains the same remembered-send check.
- The source-pin test matches the site through `ephemeralWarnToast`, tied to the branch head and the `redial` it posts, and counts eleven `ephemeralWarnToast` sites (the definition, the two reachability sites and the eight state refusals). Before the change it fails on the site pin and on the count (ten).
- `ui/webview/host-offline-ux.test.ts` pins the toast's text without the function name and is unchanged; `provisional.test.ts`, `queued-edit.test.ts` and `staged-list-cap.test.ts`, which pin neighbouring sites, pass unchanged (43 cases).

On this head: `npm run typecheck` clean; full `npm test` 4091 tests, 0 failing (4069 in the main leg and 22 in `ui/timeline-tags-scale.test.ts` run alone as a second leg; both legs exit 0).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)