### PR TITLE
The pre-push hook reads each symlink's target in a pushed tip, which git grep skips

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -11,7 +11,8 @@
 # Two checks per pushed ref, both about what THIS push changes on the remote:
 #
 #   the tip's tree    the content the push exposes. A banned string anywhere in
-#                     it refuses the push.
+#                     it, in a regular file or a symlink's target, refuses the
+#                     push.
 #   each new commit   the lines it ADDS: against its parent, or for a merge the
 #                     lines in none of its parents. A string introduced in an
 #                     intermediate commit and removed by a later one is still
@@ -81,10 +82,12 @@ rev_range() {   # <local_sha> <remote_sha> → a rev-list argument list
 # was clean (the #968 review). In a combined diff every content line carries one
 # column per parent, and a line in no parent has a `+` in each; -c also omits a
 # file that matches any parent outright, which holds no such line. -M keeps a
-# rename from re-adding every line of the file. The path comes from the
-# `+++ b/<path>` header, read only between a `diff --git` or `diff --combined`
-# line and the first hunk: inside a hunk, a line that begins with `+++ ` is added
-# content (`++ b/x` as written) and belongs to the current file.
+# rename from re-adding every line of the file. A new symlink shows up here too:
+# a link's target is its blob content, so it is an added line. The path comes
+# from the `+++ b/<path>` header, read only between a `diff --git` or
+# `diff --combined` line and the first hunk: inside a hunk, a line that begins
+# with `+++ ` is added content (`++ b/x` as written) and belongs to the current
+# file.
 added_lines() {   # <rev>
     local n
     n=$(git rev-list --parents -n 1 "$1" | awk '{ print NF - 1 }')
@@ -107,6 +110,28 @@ while read -r local_ref local_sha _remote_ref remote_sha; do
         echo "romp pre-push: the tip of $local_ref (${local_sha:0:10}) would publish a personal identifier in:" >&2
         echo "$hits" | sed "s/^$local_sha:/  /" >&2
         blocked=1
+    fi
+
+    # The tip's symlinks. git grep reads regular-file blobs only, so a link whose
+    # TARGET holds a string is invisible to the grep above. A committed link's
+    # target is its blob content, so read each 120000 entry's blob itself. Not
+    # hypothetical: a `node_modules -> /home/<user>/code/romp/...` link, made to
+    # run the extension tests in a worktree and swept up by a broad `git add`,
+    # reached a public branch past a git grep of its tree, and a reviewer found
+    # it, not the hook. An ls-tree line is "<mode> <type> <sha>\t<path>". A blob
+    # that cannot be read counts as empty: under set -e a failed substitution
+    # would end the hook with no message, before its verdict on everything else.
+    if links=$(git ls-tree -r "$local_sha" 2>/dev/null | grep '^120000 '); then
+        while IFS= read -r link; do
+            blob=${link#* * }; blob=${blob%%[[:space:]]*}
+            link_path=${link#*$'\t'}
+            target=$(git cat-file -p "$blob" 2>/dev/null) || target=""
+            if printf '%s' "$target" | grep -qi -F "${grep_args[@]}"; then
+                echo "romp pre-push: the tip of $local_ref (${local_sha:0:10}) would publish a personal identifier" >&2
+                echo "  in the SYMLINK TARGET of $link_path -> $target" >&2
+                blocked=1
+            fi
+        done <<< "$links"
     fi
 
     # The lines each commit new to the remote adds.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,8 +57,9 @@ This repo may go public; assume every commit is permanent and world-readable.
   `notes-api` with `web`/`api`/`tests` sessions) rather than inventing per-test
   worlds.
 - Two machine-local backstops enforce this, neither a substitute for the rule:
-  the `.githooks/pre-push` hook greps each pushed ref's TIP tree, plus the lines
-  every commit new to every fetched remote ADDS, for the strings in
+  the `.githooks/pre-push` hook greps each pushed ref's TIP tree (regular files
+  and symlink targets), plus the lines every commit new to every fetched remote
+  ADDS, for the strings in
   `~/.config/romp/private-strings.txt` (absent file → no-op, so contributors
   are unaffected; it reads pushed shas, not the working tree, so it arms every
   worktree — a working-tree scan missed a leak pushed from a peer worktree on

--- a/tests/pre-push-hook.bats
+++ b/tests/pre-push-hook.bats
@@ -14,6 +14,11 @@
 # one is, even if a later commit removed it again. install-sh.bats exercises the
 # hook through a real `git push`; this file feeds it ref lines directly, so it
 # can model a remote and its remote-tracking refs the way a clone has them.
+#
+# The tip scan reads symlink TARGETS as well as regular files: git grep reads
+# regular-file blobs only, and a committed link's target is its blob content, so
+# a link pointing into a home directory is a leak the grep pass alone cannot see.
+# The added-lines pass sees a NEW link the way it sees any added line.
 
 ROMP_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 HOOK="$ROMP_DIR/.githooks/pre-push"
@@ -95,13 +100,30 @@ branch_inheriting_mains_leak() {
 }
 
 # ...and main redacts the leak (pushed), and the branch merges main: its own
-# earlier commit still has the leaky tree, but its tip is clean.
-main_redacts_and_branch_merges() {
+# earlier commit still has the leaky tree, but its tip is clean. The leak is
+# leak.txt unless a path is given.
+main_redacts_and_branch_merges() {   # [<path>]
     git -C "$REPO" checkout -q main
-    remove_file leak.txt "redact"
+    remove_file "${1:-leak.txt}" "redact"
     git -C "$REPO" push -q origin main
     git -C "$REPO" checkout -q feature
     git -C "$REPO" merge -q -m "merge main" main
+}
+
+# The same shape with a SYMLINK: main commits and pushes a link whose target is
+# a home path (a node_modules link made to run tests in a worktree, swept up by
+# a broad `git add`), and a branch cut from there inherits it. Leaves HEAD on
+# the branch; main has not yet removed the link.
+branch_inheriting_mains_symlink_leak() {
+    add_remote
+    commit_file base.txt "notes-api" "base"
+    ln -s /home/zzsynthuser/code/romp/vscode-extension/node_modules "$REPO/node_modules"
+    git -C "$REPO" add node_modules
+    git -C "$REPO" commit -qm "symlink leak"
+    LEAK_SHA="$(git -C "$REPO" rev-parse HEAD)"
+    git -C "$REPO" push -q origin main
+    git -C "$REPO" checkout -q -b feature
+    commit_file web.txt "the web session's work" "branch work"
 }
 
 @test "a clean commit passes" {
@@ -191,6 +213,94 @@ main_redacts_and_branch_merges() {
     [[ "$output" == *"ADDS a personal identifier"* ]]
     [[ "$output" == *"api.txt"* ]]
     [[ "$output" != *"leak.txt"* ]]       # main's commits were skipped, not re-flagged
+}
+
+# ── symlinks ──────────────────────────────────────────────────────────────
+# A committed symlink is a blob holding its target, and git grep reads
+# regular-file blobs only, so the tip pass reads each link's target itself. A
+# link into a home directory, made to run tests in a worktree and swept up by a
+# broad `git add`, reached a public branch while a git grep of its tree saw it
+# clean. The repo's own bin/ links are relative and must not trip it.
+
+@test "a branch that only INHERITED main's SYMLINK leak passes once its tip merged the removal" {
+    branch_inheriting_mains_symlink_leak
+    main_redacts_and_branch_merges node_modules
+    run_hook
+    [ "$status" -eq 0 ]
+}
+
+@test "the same branch is refused while its TIP still carries an inherited SYMLINK leak" {
+    branch_inheriting_mains_symlink_leak
+    run_hook
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"the tip of refs/heads/main"* ]]   # named as the tip, not as an introduction
+    [[ "$output" == *"SYMLINK TARGET"* ]]
+    [[ "$output" == *"node_modules -> /home/zzsynthuser/"* ]]
+    [[ "$output" != *"ADDS"* ]]                          # main published the link; the branch added nothing
+    [[ "$output" == *"merge the main that has since redacted it"* ]]
+}
+
+@test "a RELATIVE symlink with no identifier passes" {
+    # the repo's own bin/romp-* links have this shape
+    mkdir -p "$REPO/kernel" "$REPO/bin"
+    printf '%s\n' "x" > "$REPO/kernel/kernel.py"
+    ln -s ../kernel/kernel.py "$REPO/bin/romp-kernel"
+    git -C "$REPO" add kernel bin
+    git -C "$REPO" commit -qm "relative link"
+    run_hook
+    [ "$status" -eq 0 ]
+}
+
+@test "a NEW symlink at the tip is named with its link and target, by both passes" {
+    ln -s /home/ZZSynthUser/notes "$REPO/notes-link"      # mixed case: matched case-insensitively, like a file
+    git -C "$REPO" add notes-link
+    git -C "$REPO" commit -qm "symlink leak"
+    leak_sha="$(git -C "$REPO" rev-parse HEAD)"
+    run_hook
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"SYMLINK TARGET of notes-link -> /home/ZZSynthUser/notes"* ]]   # the tip pass
+    [[ "$output" == *"commit ${leak_sha:0:10} ADDS a personal identifier"* ]]   # and the commit that added it, as for a regular file
+    [[ "$output" == *"  notes-link"* ]]
+}
+
+@test "an identifier in an INTERMEDIATE commit's SYMLINK TARGET is caught by the added-lines pass" {
+    ln -s /home/zzsynthuser/x "$REPO/bad"
+    git -C "$REPO" add bad
+    git -C "$REPO" commit -qm "leak"
+    leak_sha="$(git -C "$REPO" rev-parse HEAD)"
+    remove_file bad "remove it"                   # tip is clean; history is not
+    run_hook
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"commit ${leak_sha:0:10} ADDS a personal identifier"* ]]   # a new link's target is an added line of that path
+    [[ "$output" == *"  bad"* ]]
+    [[ "$output" != *"SYMLINK TARGET"* ]]        # the tip has no link left to name
+}
+
+@test "a dot in a denylist entry matches only a dot, in a file and in a symlink target" {
+    # A hostname's dots are text, not "any character": every pass greps the
+    # denylist as fixed strings, the symlink pass the same as the other two.
+    printf 'nas.zzsynth.invalid\n' > "$STRINGS"
+    commit_file mounts.txt "share on /mnt/nasXzzsynthXinvalid/" "near miss in a file"
+    ln -s /mnt/nasXzzsynthXinvalid/share "$REPO/share"
+    git -C "$REPO" add share
+    git -C "$REPO" commit -qm "near miss in a link"
+    run_hook
+    [ "$status" -eq 0 ]
+}
+
+@test "a symlink whose blob cannot be read does not end the hook before its verdict" {
+    # Under set -e a failed `target=$(git cat-file ...)` would exit the hook with
+    # no message; such a link counts as empty and the other findings still print.
+    commit_file leak.txt "home is /home/zzsynthuser/code" "leak"
+    ln -s ../elsewhere "$REPO/link"
+    git -C "$REPO" add link
+    git -C "$REPO" commit -qm "link"
+    blob="$(git -C "$REPO" rev-parse HEAD:link)"
+    rm "$REPO/.git/objects/${blob:0:2}/${blob:2}"   # loose in a fresh repo; ls-tree still lists the entry
+    run_hook
+    [ "$status" -eq 1 ]                              # the hook's refusal; a set -e death exits 128
+    [[ "$output" == *"leak.txt"* ]]
+    [[ "$output" == *"BLOCKED"* ]]                   # the verdict was reached
 }
 
 # ── two remotes: a fork and the project it forked from ────────────────────


### PR DESCRIPTION
## Symptom

A branch whose tip carries a symlink pointing into a home directory pushes clean when the commit that added the link is already on a remote. The suite's tip case shows the asymmetry: a branch cut from main while main carried `leak.txt` holding such a path, before main redacted it, is refused at the tip and told to merge the main that carries the redaction; the same branch with a `node_modules -> /home/<user>/...` link in place of the file passes. The hook's header promises that a banned string anywhere in the tip's tree refuses the push, and for a symlink that was not true. The #968 body listed it as a limit.

## Cause

The tip pass is `git grep -i -I -l -F ... "$local_sha"`, and git grep reads regular-file blobs only. A committed symlink is a blob whose content is its target, so the grep never opens it. The added-lines pass does see a NEW link (`git diff-tree -p` prints `new file mode 120000` and the target as an added line), which is why a new link on a new branch is caught today. Not caught: a link the tip inherits from a commit some remote already has, and a link whose string entered the denylist after it was pushed.

## Fix

After the tip grep and before the added-lines loop, the hook lists the tip's `120000` entries with `git ls-tree -r`, reads each target with `git cat-file -p`, and on a match refuses the push with a tip line of the same shape as a regular file's, followed by `  in the SYMLINK TARGET of <path> -> <target>`.

- The read is `target=$(git cat-file -p "$blob" 2>/dev/null) || target=""`: under `set -e` a failed substitution would end the hook with no message, before its verdict on everything else. Such a link counts as empty; a test removes a link's loose object and checks that the verdict still prints.
- The ls-tree line (`<mode> <type> <sha>\t<path>`) is parsed with parameter expansion rather than `--format`, which needs a newer git; every construct is bash 3.2.
- One `cat-file` per link per pushed ref. The repo carries fourteen relative `bin/` links; they hold no home path and pass (checked over the real tree with a denylist).
- A new link at the tip of a new ref is reported twice, by the tip pass and by the ADDS pass, the way a regular-file leak is today; a test asserts both lines so the double report is deliberate.
- The header's tip line reads "in a regular file or a symlink's target"; the `added_lines` comment says a new link is an added line; CLAUDE.md's sentence on the hook gains "(regular files and symlink targets)".

## Tests

`tests/pre-push-hook.bats`: seven cases on the file's inline setup and helpers, plus a `branch_inheriting_mains_symlink_leak` helper mirroring `branch_inheriting_mains_leak`; `main_redacts_and_branch_merges` takes an optional path (default `leak.txt`) so the symlink twin reuses it. Every target is synthetic (`/home/zzsynthuser/...`, `/mnt/nas...`).

- "a branch that only INHERITED main's SYMLINK leak passes once its tip merged the removal": green before and after; pins the no-false-refusal side.
- "the same branch is refused while its TIP still carries an inherited SYMLINK leak": the symlink twin of the existing inherited-leak case. Before the change the hook exits 0 (fails at `[ "$status" -ne 0 ]`); after, refused naming `the tip of refs/heads/main`, `SYMLINK TARGET`, `node_modules -> /home/zzsynthuser/` and the merge-main remedy, with no `ADDS` line.
- "a RELATIVE symlink with no identifier passes": green before and after; the repo's own `bin/` links have this shape.
- "a NEW symlink at the tip is named with its link and target, by both passes": the target is mixed case (`/home/ZZSynthUser/notes`). Before the change the push is refused by the ADDS pass alone (fails at the `SYMLINK TARGET of notes-link -> ...` assertion); after, both lines appear. Dropping `-i` from the new grep fails this case.
- "an identifier in an INTERMEDIATE commit's SYMLINK TARGET is caught by the added-lines pass": green before and after; pins the ADDS coverage the comment claims, and that the tip names no link.
- "a dot in a denylist entry matches only a dot, in a file and in a symlink target": a denylist of `nas.zzsynth.invalid` against `/mnt/nasXzzsynthXinvalid/share` in a file and in a link passes. Green before and after; dropping `-F` from the new grep fails it.
- "a symlink whose blob cannot be read does not end the hook before its verdict": a leak in `leak.txt` plus a link whose loose object is removed; the hook exits 1 with `BLOCKED` and `leak.txt` named. Green before and after; without the `|| target=""` guard the hook exits 128 after the first tip line and the case fails.

Before: 2 of 22 fail. After: 22/22. `tests/install-sh.bats` (the hook installer and its real-push cases) 29/29. shellcheck clean at warning level. A real `git push` to a bare remote with the hook installed refuses the inheriting branch with the link named, and accepts it once the link is removed.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)