### PR TITLE
Chat: a late stamp reads an event that names the send as this send's, whatever its stamp

### DIFF
--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -17,7 +17,9 @@
 // bubble's own entry; (13) a stamp taken late reads the events' own times. Round 4: (14) a late stamp
 // presumes the frame's newest queued copy of its text is its own (the queued bubble carries no stamp).
 // T252c gave every kernel copy an id; now (15) the id is the CLIENT's, minted at the press and posted with the
-// send, so the kernel's copies wear it from their first appearance and nothing is latched by text.
+// send, so the kernel's copies wear it from their first appearance and nothing is latched by text. And (16) at
+// a late stamp an event that NAMES the send (wears its id) is this send's whatever its stamp: the id outranks
+// the clock.
 // The decisions are executed through send-pending.ts; the DOM half is pinned in render.ts/styles.css.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
@@ -658,6 +660,91 @@ test("two back-to-back sends the CLI took as ONE record retire both bubbles; a t
   // the same counting for the kernel's copies: a record of several sends is never an echo (one text each)
   assert.equal(provisionalIn({ kind: "user", md: "continue continue", uuid: "echo:1", blocks: ["continue", "continue"] }, { ...list[0], qid: undefined }), true,
     "…but were one ever shipped with blocks, its copies would be read the same way (by text: the entry's own id shows nowhere in it, the view reconcilePending reads such a push with)");
+});
+
+// ── (16) at a late stamp the send's id outranks the clock ────────────────────────────────────────
+
+test("a late stamp reads an event that NAMES the send as this send's, whatever its stamp: a client clock ahead of the kernel", () => {
+  const isoAt = (s: number) => new Date(s * 1000).toISOString();   // kernel.py iso(t): ISO-8601 UTC, whole seconds
+  const pressMs = T0 + 200;                                          // the press, on the client's clock
+  const S = Math.floor(pressMs / 1000);
+  const late = (): PendingSend => ({ ...newPending(TEXT, undefined, pressMs), late: true });   // registerOptimistic, no resident session
+  const step: TailEvent = { kind: "assistant", md: "…", uuid: "a1", ts: isoAt(S - 10) };
+  // The client's clock runs a second ahead of the kernel's, so the kernel stamps this send's own records at
+  // S - 1, BEFORE the press's second: read by stamp alone, every one of them is background. Each record below
+  // wears the send's id (newPending minted it, so the echo's uuid is built from the entry), and the id decides.
+  // (a) the kernel's echo, whose uuid IS the id
+  let list = [late()];
+  let p = list[0];
+  let r = reconcilePending([step, { kind: "user", md: TEXT, uuid: p.qid!, ts: isoAt(S - 1) }], list);
+  assert.deepEqual(p.at?.seen, [], "the echo wears this send's id: not background, whatever its stamp");
+  assert.equal(p.at?.after, "a1");
+  assert.deepEqual([r.inject.length, r.echoHide], [1, [1]], "the echo covers ours and is hidden: one bubble, not two");
+  assert.equal(p.received, true, "the kernel has this send");
+  // (b) the landed atom, wearing the id
+  list = [late()]; p = list[0];
+  r = reconcilePending([step, { kind: "user", md: TEXT, uuid: "u-landed", ts: isoAt(S - 1), qid: p.qid }], list);
+  assert.equal(p.at?.after, "a1", "the send's own landing is not its anchor");
+  assert.deepEqual(r.landed.map((l) => l.idx), [1], "it is the landing: the bubble ends, instead of never ending");
+  // (c) the same, with a reply after it stamped inside the same skew
+  list = [late()]; p = list[0];
+  r = reconcilePending([step, { kind: "user", md: TEXT, uuid: "u-landed", ts: isoAt(S - 1), qid: p.qid }, { kind: "assistant", md: "done", uuid: "a2", ts: isoAt(S - 1) }], list);
+  assert.equal(p.at?.after, "a1", "nothing at or after the send's own record anchors it, whatever its stamp");
+  assert.deepEqual(r.landed.map((l) => l.idx), [1]);
+  // (d) the landing as the frame's only event
+  list = [late()]; p = list[0];
+  r = reconcilePending([{ kind: "user", md: TEXT, uuid: "u-landed", ts: isoAt(S - 1), qid: p.qid }], list);
+  assert.equal(p.at?.after, null, "no anchor: the frame holds nothing before the send");
+  assert.deepEqual(r.landed.map((l) => l.idx), [0]);
+  // (e) a record of several sends, one of whose blocks wears the id
+  list = [late()]; p = list[0];
+  r = reconcilePending([step, { kind: "user", md: TEXT + " " + TEXT, blocks: [TEXT, TEXT], qids: [p.qid!, "echo:" + "f".repeat(32)], uuid: "uXY", ts: isoAt(S - 1) }], list);
+  assert.equal(p.at?.after, "a1");
+  assert.deepEqual(r.landed.map((l) => l.idx), [1]);
+  // (f) the kernel's never-delivered verdict: the echo wearing the id, flagged
+  list = [late()]; p = list[0];
+  r = reconcilePending([step, { kind: "user", md: TEXT, uuid: p.qid!, ts: isoAt(S - 1), undelivered: true }], list);
+  assert.deepEqual(r.lost, [p], "the verdict on this send is read, not filed as an old bubble");
+  // (g) a same-text record AFTER the one that names the send, stamped inside the same skew, is after the
+  // send too: neither background nor the anchor
+  list = [late()]; p = list[0];
+  r = reconcilePending([step, { kind: "user", md: TEXT, uuid: "u-landed", ts: isoAt(S - 1), qid: p.qid }, { kind: "user", md: TEXT, uuid: "u-after", ts: isoAt(S - 1) }], list);
+  assert.equal(p.at?.after, "a1");
+  assert.deepEqual(p.at?.seen, [], "nothing from the send's own record on is background, whatever its stamp");
+  assert.deepEqual(r.landed.map((l) => l.idx), [1]);
+  // (h) two records naming the send (the kernel shows one per send; the rule is stated for the first): the
+  // FIRST bounds the frame
+  list = [late()]; p = list[0];
+  r = reconcilePending([step, { kind: "user", md: TEXT, uuid: p.qid!, ts: isoAt(S - 1) }, { kind: "user", md: TEXT, uuid: "u-landed", ts: isoAt(S - 1), qid: p.qid }], list);
+  assert.equal(p.at?.after, "a1");
+  assert.deepEqual(p.at?.seen, [], "the first record naming the send bounds the background, not the last");
+  // The stamp bound still decides for a record that carries no id, or another send's, and for an entry
+  // that names nothing:
+  // (i) a same-text record wearing ANOTHER send's id, stamped early, is background by text
+  list = [late()]; p = list[0];
+  r = reconcilePending([step, { kind: "user", md: TEXT, uuid: "u-other", ts: isoAt(S - 1), qid: "echo:" + "e".repeat(32) }], list);
+  assert.equal(p.at?.after, "u-other");
+  assert.deepEqual(p.at?.seen, ["u-other"]);
+  assert.deepEqual([r.keep.length, r.inject.length], [1, 1]);
+  // (j) an id-less record stamped early (an older kernel, the tmux route) is background
+  list = [late()]; p = list[0];
+  r = reconcilePending([step, { kind: "user", md: TEXT, uuid: "u-old", ts: isoAt(S - 1) }], list);
+  assert.equal(p.at?.after, "u-old");
+  assert.deepEqual(p.at?.seen, ["u-old"]);
+  assert.deepEqual([r.keep.length, r.inject.length], [1, 1]);
+  // (k) only the kernel's USER records name the send: every event carries a uuid, and one of another kind
+  // that wore the id (no kernel event does) would neither bound the frame nor anchor the send
+  list = [late()]; p = list[0];
+  r = reconcilePending([step, { kind: "assistant", md: "…", uuid: p.qid!, ts: isoAt(S - 5) }, { kind: "user", md: TEXT, uuid: "u-old", ts: isoAt(S - 1) }], list);
+  assert.equal(p.at?.after, "u-old", "an event of another kind names nothing: the stamp bound alone decides");
+  assert.deepEqual(p.at?.seen, ["u-old"]);
+  // (l) an entry with no id (older data; newPending always mints one) names nothing: a same-text id-less
+  // record stamped early is background for it, never its landing
+  list = [{ ...late(), qid: undefined }]; p = list[0];
+  r = reconcilePending([step, { kind: "user", md: TEXT, uuid: "u-old", ts: isoAt(S - 1) }], list);
+  assert.equal(p.at?.after, "u-old", "an entry with no id names nothing: the stamp bound alone decides");
+  assert.deepEqual(p.at?.seen, ["u-old"]);
+  assert.equal(r.keep.length, 1);
 });
 
 // ── (T252c, second review) identity decides where the frame SHOWS it; text decides where it does not ──────

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -19,7 +19,7 @@ import { markerLabel } from "./time-marker";
 // proves the kernel RECEIVED that one send (`received`, attributed per send like a landing). Nothing here
 // reads a clock for a press-time entry: the frame resident at the press is older than the send by
 // construction, so its anchor is recorded by identity; only a LATE stamp (stampBase) compares stamps to
-// order events.
+// order events, and there an event that wears the send's id outranks its stamp.
 //
 // WHERE THE BUBBLE IS DRAWN is not decided here (T252d, the user 2026-09-08): render.ts appends every
 // pending send as one bare group at the TAIL, below every event the kernel has shown, in send order — and
@@ -239,6 +239,12 @@ const eventSecond = (e: TailEvent): number | null => {
   return isNaN(ms) ? null : Math.floor(ms / 1000);
 };
 
+/** Does a user event NAME the send: wear its id? The kernel's echo atom, delivered or flagged never-delivered
+ *  (its uuid IS the id); the landed atom (`qid`); a record of several sends one of whose blocks is this one
+ *  (`qids`). Never for an entry with no id. */
+const namesSend = (e: TailEvent, qid: string | undefined): boolean =>
+  !!qid && e.kind === "user" && (e.uuid === qid || e.qid === qid || (Array.isArray(e.qids) && e.qids.includes(qid)));
+
 /** Where this send sits among the kernel's events, read once at the first reconcile after the press.
  *
  *  At a PRESS-TIME stamp (the normal path) everything resident predates the send by construction — the
@@ -271,26 +277,39 @@ const eventSecond = (e: TailEvent): number | null => {
  *  transcript record, at or after that (T237b), and both reach the client as `ts = iso(t)`. The bound
  *  holds when the two clocks agree to the second: exactly for a client on the kernel's machine (the
  *  VS Code webview, the served page there), and for a phone as well as its clock is set. A client
- *  running BEHIND the kernel reads an older identical message stamped inside the skew as this send's;
- *  one running AHEAD reads this send's own copy as background, which is the pre-fix reading. The bound
- *  is confined to the late stamp because that is the only stamp that can meet the send's own records,
- *  and because at a press-time stamp it could only misfire (an identical message that landed within
- *  the press's second would read as this send's). */
+ *  running BEHIND the kernel reads an older identical message stamped inside the skew as this send's.
+ *  THE ID OUTRANKS THE CLOCK: the first user event that NAMES the send (namesSend: the echo, whose uuid
+ *  is the id; the landed atom, whose qid or qids carry it) is this send's whatever its stamp, and the
+ *  kernel showed the send there, so it and every event after it are after the send: the anchor is looked
+ *  for below it only, and none of them is background. Without this, a client running AHEAD of the kernel
+ *  read this send's own echo as background (our dashed bubble beside the kernel's echo until the landing;
+ *  a never-delivered verdict that never ended the bubble) and its own landing as its anchor (a bubble
+ *  that never ended). Below the first event that names the send, and throughout a frame that names it
+ *  nowhere, the stamp bound decides as before for records that carry no id (an older kernel, the tmux
+ *  route) or another send's id. The bound is confined to the late stamp because that is the only stamp
+ *  that can meet the send's own records, and because at a press-time stamp it could only misfire (an
+ *  identical message that landed within the press's second would read as this send's). */
 export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.late ? 1 : 0): SendBase {
   const pressS = p.late ? Math.floor(p.ts / 1000) : Infinity;
   const beforeSend = (e: TailEvent): boolean => { const s = eventSecond(e); return s === null || s < pressS; };
+  // where the kernel first shows the send: a user event wearing its id (namesSend). The send is at least that
+  // old, so nothing from there on can be its anchor, whatever the stamps say (the id outranks the clock, above)
+  let firstNamed = events.length;
+  for (let i = 0; i < events.length; i++) if (namesSend(events[i], p.qid)) { firstNamed = i; break; }
   let after: string | null = null;
-  for (let i = events.length - 1; i >= 0; i--) if (stableUuid(events[i]) && beforeSend(events[i])) { after = events[i].uuid!; break; }
+  for (let i = firstNamed - 1; i >= 0; i--) if (stableUuid(events[i]) && beforeSend(events[i])) { after = events[i].uuid!; break; }
   const seen: string[] = [];
   let queued = 0;
-  // background is read by TEXT: nothing the frame held at the press can wear this send's id (minted at that
-  // press), and the text path, which reads any push where the id shows nowhere, must find these copies spoken
-  // for; read by id, an older echo or an older verdict after the anchor was background for no one, and the
-  // first push covered or retired the new send with it
+  // background is read by TEXT, below the first event that names the send: at a press-time stamp nothing the
+  // frame holds can wear this send's id (minted at that press), and at a late stamp the events from the one that
+  // names it on are the send's own or after it; the text path, which reads any push where the id shows nowhere,
+  // must find these copies spoken for; read by id, an older echo or an older verdict after the anchor was
+  // background for no one, and the first push covered or retired the new send with it
   const pv: PendingSend = { ...p, qid: undefined };
-  for (const e of events) {
+  for (let i = 0; i < events.length; i++) {
+    const e = events[i];
     if (e.kind === "queued") { queued += queuedCopies(e, pv); continue; }
-    if (e.kind !== "user" || !e.uuid || isOptimisticUuid(e.uuid) || !beforeSend(e)) continue;
+    if (e.kind !== "user" || !e.uuid || isOptimisticUuid(e.uuid) || !beforeSend(e) || i >= firstNamed) continue;
     const n = copiesIn(e, pv);
     for (let k = 0; k < n; k++) seen.push(e.uuid);   // once per COPY: a record of several sends is several
   }


### PR DESCRIPTION
## Symptom

On a client whose clock runs ahead of the kernel's, a send pressed against a tab with no resident frame (a placeholder tab whose payload is still loading, or a provisional tab whose session does not exist yet) misreads its own records on the first frame. The user sees the kernel's echo and our dashed bubble both drawn until the landing (the message twice), or the kernel's never-delivered bubble beside ours still saying "sending", or, when the first frame already holds the landing, a bubble that never ends.

## Cause

A late stamp (`stampBase` in `ui/webview/send-pending.ts`) orders events by the kernel's stamps against the press's second: an event stamped before that second is background, and the last stable one among them is the anchor. The kernel stamps the send's own echo at its receipt and the landed atom at the CLI's record, both on the kernel's clock, so a client a second ahead (or a press that crosses a second boundary) puts those stamps before the press's second. The stamp then filed the send's own echo in `seen`, and the id path in `reconcilePending` read that echo as spoken for, so it covered nothing and the never-delivered verdict on it counted for nothing; and it took the landed atom, or a reply after it, as the anchor, so the landing sat before the scan and nothing could retire the bubble. The docblock named this cost as accepted, from before the frame could name the send. Since the press mints the id, the frame does name it: the echo's uuid is the id, and the landed atom carries it as `qid` or `qids`.

## Fix

`namesSend(e, qid)` says whether a user event names the send: its uuid is the id (the echo, delivered or flagged never-delivered), its `qid` is the id, or its `qids` include it; never for an entry with no id. `stampBase` finds the first such event: the anchor is looked for below it only, and the background loop skips it and every event after it, whatever their stamps. Queued groups keep their count and the queued presumption. Below that event, and throughout a frame that names the send nowhere, a record that carries no id (an older kernel, the tmux route) or another send's id is still read by stamp, as before. The header and the docblock state the rule; the accepted-cost sentence is gone. Two files change, `send-pending.ts` and its test; the `PendingSend` type and `dropPending` are untouched.

## Tests

`ui/webview/send-pending.test.ts`, section 16: one test over the pure module (no DOM) with the client's press a second after the kernel's stamps. Each record wears the send's id, built from the entry's `qid`.

- (a) the echo: `seen` is `[]`, the echo is hidden for our bubble (`echoHide` `[1]`, one inject), `received` is set. Before the change `seen` lists the echo's id, `echoHide` is `[]` and `received` is unset.
- (b) the landed atom: anchor `a1`, landed `[1]`. Before: anchor `u-landed`, nothing landed, the bubble kept.
- (c) the landed atom with a reply after it: anchor `a1`, landed `[1]`. Before: anchor `a2`, nothing landed.
- (d) the landing as the frame's only event: anchor `null`, landed `[0]`. Before: anchor `u-landed`, nothing landed.
- (e) a record of several sends with one block wearing the id: anchor `a1`, landed `[1]`. Before: anchor `uXY`, nothing landed.
- (f) the never-delivered echo: `lost` is the entry. Before: `lost` is `[]`, the bubble kept.
- (g) a same-text id-less record after the landed atom, stamped inside the same skew: anchor `a1`, `seen` `[]`, landed `[1]`. This pins that every event from the naming one on is after the send: a variant that skips only the naming event lists `u-after` in `seen`.
- (h) two records naming the send, the echo and then the landed atom: anchor `a1`, `seen` `[]`. This pins that the first one bounds the frame: a variant that takes the last lists the echo's id in `seen`.
- Guards, green before and after the change: (i) a same-text record wearing another send's id, stamped early, is background by text (anchor and `seen` name it, one bubble kept); (j) an id-less record stamped early, likewise; (k) an event of another kind wearing the id neither bounds the frame nor anchors the send (anchor `u-old`); (l) an entry with no id names nothing, so an early id-less same-text record is background for it and not its landing (anchor `u-old`, one bubble kept). Dropping the `kind` guard from `namesSend` turns (k) red; dropping the `qid` guard turns (l) red.

Red on the unchanged source at (a): `seen` deepEqual `[]` fails with the echo's id. Green with the change; the guards and the existing section-13 test (a foreign echo at the press's second) stay green throughout.

`npm run typecheck`: clean. Full `npm test`: 4092 tests, 0 failures (4070 in the main run plus the 22 of the timeline-tags-scale test run alone).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)