### PR TITLE
Tests: the relaunch stanza a served lab writes drops the run's own ROMP_TESTS_ names, and a live session's identity never reaches a relaunched lab kernel

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -148,5 +148,36 @@ One it leaves alone keeps pytest's own rendering.
 `tests/test_env_value_redaction.py` pins the rule, the write-time capture,
 the patterns, the scrub's cost and the hook end to end.
 
+**A lab kernel's environment is built from a list of names, and the file a
+relaunch reads from carries a shorter list.** Every module that boots a hermetic
+kernel (`bin/romp-kernel` under a lab's own `XDG_STATE_HOME`,
+`CLAUDE_CONFIG_DIR` and `ROMP_DIST_DIR`, at a free port with a synthetic serve
+token) builds its environment with `kernel_env` in `tests/test_ship_reship.py`,
+never from a copy of the runner's. A run from a shell on a machine running romp
+carries the live kernel's exports, and a lab kernel that inherited them exited
+when the live manager restarted (`ROMP_MANAGER_PID`, the kernel's parent-death
+watchdog), bound where the live kernel serves (`ROMP_SERVE_HOST`) and dialled
+the machine's postal bus, or started one that nothing stops. From the runner
+`kernel_env` takes `PATH`, `HOME`, the `XDG_*` names and, of the floor
+`tests/conftest.py` sets for the run's children, `TMPDIR`, `TMUX_TMPDIR`,
+`GIT_CONFIG_GLOBAL`, `GIT_CONFIG_NOSYSTEM`, `ROMP_SERVICE_ENV_FILE`,
+`ROMP_SERVICE_ENV`, `ROMP_CLAUDE_BIN` and `ROMP_CLI_SCOPE`; over those go the
+lab's roots and seams, any seam the lab adds by keyword, and a postal bus of its
+own that is never started (`ROMP_POSTAL_PORT` at a free port,
+`ROMP_POSTAL_PEERS=0`, `ROMP_POSTAL_CLIENT_ONLY=1`). The served labs whose
+driver kills and relaunches the kernel (`test_ship_reship.py`,
+`test_dashboard_reload_served.py`) write the relaunch's command, environment and
+log to the lab's `cfg.json` through `relaunch_cfg`, and the environment in that
+file is narrowed once more by `relaunch_env`: the `ROMP_*` and `XDG_*` names,
+`CLAUDE_CONFIG_DIR`, `PATH`, `HOME`, `TMPDIR`, `TMUX_TMPDIR`,
+`GIT_CONFIG_GLOBAL` and `GIT_CONFIG_NOSYSTEM`, less the `ROMP_TESTS_*` names,
+which conftest exports for the run's own tests (such as
+`ROMP_TESTS_SYSTEM_TMPDIR` above) and no kernel reads. Nothing else a lab put in
+its kernel's environment reaches the file; each served lab plants a probe name
+in that environment and checks the written file for its absence. To give a lab
+kernel another name of the runner's, add the name to the list with its reason
+beside it. `LabKernelEnv` and `RelaunchEnv` in `tests/test_ship_reship.py` pin
+both functions; the served legs check the file itself.
+
 `fixtures/` must stay SYNTHETIC: invented prompts, placeholder UUIDs, hostname
 `TESTHOST` — never real session data.

--- a/tests/test_ship_reship.py
+++ b/tests/test_ship_reship.py
@@ -36,8 +36,10 @@ The guards here:
     is never started.
   * RelaunchEnv, which runs everywhere: the relaunch stanza the lab writes to its cfg.json for the
     driver's relaunch of the kernel carries only the names the relaunched kernel needs (a name
-    planted in the lab kernel's environment as a probe is absent; the lab's own names, the run's
-    private roots and its git isolation present); the served legs check the written file itself.
+    planted in the lab kernel's environment as a probe is absent, and so is a ROMP_TESTS_ name, the
+    run's own, wherever it came from; a live session's identity and manager pid in the runner reach
+    neither the lab kernel nor the file; the lab's own names, the run's private roots and its git
+    isolation present); the served legs check the written file itself.
 
 All fixtures synthetic.
 """
@@ -153,8 +155,11 @@ def _free_port():
 # nothing there (client-only applies in the legacy singleton scheme alone, postal_service.is_client_only).
 # The environment the driver hands the kernel it relaunches rides the lab's cfg.json, a file, so it is narrowed once
 # more (relaunch_env) to the ROMP_* and XDG_* names, CLAUDE_CONFIG_DIR, PATH and HOME and the four conftest names:
-# never anything else a lab put in its kernel's environment, such as the probe the served legs plant.
+# never anything else a lab put in its kernel's environment, such as the probe the served legs plant, and never a
+# ROMP_TESTS_* name, the prefix tests/conftest.py exports the run's own names under (ROMP_TESTS_SYSTEM_TMPDIR): no
+# kernel reads one, so a lab kernel's environment carries one only if the lab put it there, and the file never does.
 RELAUNCH_ENV_PREFIXES = ("ROMP_", "XDG_")
+RELAUNCH_ENV_EXCLUDED_PREFIXES = ("ROMP_TESTS_",)
 RELAUNCH_ENV_NAMES = frozenset(("CLAUDE_CONFIG_DIR", "PATH", "HOME", "TMPDIR", "TMUX_TMPDIR",
                                 "GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM"))
 KERNEL_ENV_NAMES = RELAUNCH_ENV_NAMES | frozenset(("ROMP_SERVICE_ENV_FILE", "ROMP_SERVICE_ENV",
@@ -180,8 +185,11 @@ def kernel_env(lab, claude, dist, port, token, **seams):
 
 def relaunch_env(env):
     """The part of a lab kernel's environment `env` that a served lab writes to its cfg.json for the driver's
-    relaunch of the kernel."""
-    return {k: v for k, v in env.items() if k.startswith(RELAUNCH_ENV_PREFIXES) or k in RELAUNCH_ENV_NAMES}
+    relaunch of the kernel: the RELAUNCH_ENV_PREFIXES names and RELAUNCH_ENV_NAMES, less the ROMP_TESTS_* names
+    (RELAUNCH_ENV_EXCLUDED_PREFIXES), which are the run's own and which no kernel reads."""
+    return {k: v for k, v in env.items()
+            if (k.startswith(RELAUNCH_ENV_PREFIXES) or k in RELAUNCH_ENV_NAMES)
+            and not k.startswith(RELAUNCH_ENV_EXCLUDED_PREFIXES)}
 
 
 def relaunch_cfg(env, klog):
@@ -461,6 +469,33 @@ class RelaunchEnv(unittest.TestCase):
         self.assertEqual(out["ROMP_KERNEL_PORT"], "4321")
         for name in ("TMPDIR", "TMUX_TMPDIR", "GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM"):
             self.assertEqual(out.get(name), runner[name], "the run's %s reaches the relaunched kernel" % name)
+
+    def test_a_live_sessions_identity_and_the_runs_own_names_never_reach_the_relaunch_env(self):
+        lab = os.path.join(os.sep, "lab")
+        # the runner's shell on a machine running romp: the live manager's pid (kernel.py's _parent_watch exits the
+        # kernel when it dies, so a relaunched lab kernel that carried it exited with a live manager restart), the
+        # session's identity (ROMP_SID, ROMP_SESSION_NAME) and the serve chain's ROMP_BIN, and a name under the
+        # prefix tests/conftest.py exports the run's own names under (ROMP_TESTS_SYSTEM_TMPDIR), which no kernel reads
+        identity = {"ROMP_MANAGER_PID": "12345", "ROMP_SID": "cccccccc-1111-2222-3333-444444444444",
+                    "ROMP_SESSION_NAME": "web", "ROMP_BIN": os.path.join(lab, "bin", "romp")}
+        runner = dict(identity, ROMP_TESTS_PROBE=os.path.join(lab, "probe"))
+        with mock.patch.dict(os.environ, runner):
+            env = kernel_env(lab, os.path.join(lab, "claude"), os.path.join(lab, "dist"), 4321, "testtok")
+        names = sorted(env)
+        for name in runner:
+            self.assertNotIn(name, names, "the runner's %s must never reach a lab kernel" % name)
+        self.assertEqual([k for k in names if k.startswith("ROMP_TESTS_")], [],
+                         "a ROMP_TESTS_ name of the run reached the lab kernel")
+        # the same ROMP_TESTS_ name put in the lab kernel's environment by the lab itself, the way the served labs
+        # plant their probe: it is the run's own, so the file the relaunch reads must not carry it either
+        env["ROMP_TESTS_PROBE"] = os.path.join(lab, "probe")
+        written = sorted(relaunch_cfg(env, os.path.join(lab, "kernel.log"))["env"])
+        self.assertNotIn("ROMP_TESTS_PROBE", written,
+                         "a ROMP_TESTS_ name is the run's own: the relaunched kernel reads none, the file must not carry one")
+        for name in identity:
+            self.assertNotIn(name, written, "the runner's %s must never reach the relaunched kernel" % name)
+        for name in ("ROMP_KERNEL_PORT", "ROMP_SERVE_TOKEN", "ROMP_DIST_DIR", "ROMP_MODEL_CATALOG", "ROMP_POSTAL_PORT"):
+            self.assertIn(name, written, "the lab's own %s still reaches the relaunched kernel" % name)
 
 
 class LabKernelEnv(unittest.TestCase):


### PR DESCRIPTION
Follows #1262 (merged), which has `kernel_env` build a lab kernel's environment from a list of names. Two review records asked for it. The review of #1235 (merged), which narrowed what a served lab writes to its cfg.json for the driver's relaunch of the kernel (`relaunch_env`), asked for the live manager's pid to go from that file and from the relaunched kernel once the list landed. The review of #1237 (merged), which had tests/conftest.py export `ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR`, a path under the operator's home, asked `relaunch_env` to exclude `ROMP_TESTS_*`, since the `ROMP_` prefix it keeps would carry that name into the file. With the list in place, the pid and the rest of a live session's identity cannot reach a lab kernel from the runner, so `kernel_env` has nothing to pop. This change pins that at the relaunch end and adds the `ROMP_TESTS_` exclusion.

## Symptom

Run the browser tests from a shell on a machine running romp. Before lab kernels started from a list of names, the `ROMP_` prefix that `relaunch_env` keeps carried the live manager's pid (`ROMP_MANAGER_PID`, which the kernel's `_parent_watch` reads) into a served lab's cfg.json and into the kernel the driver relaunched from it, and that kernel exited when the live manager restarted. The same prefix carried the run's own names into the file and the relaunched kernel: tests/conftest.py exports `ROMP_TESTS_SYSTEM_TMPDIR` (the system temp dir it recorded before redirecting) and `ROMP_TESTS_REAL_CLAUDE_CONFIG_DIR` (the operator's Claude config dir, a path under their home), and no kernel reads a `ROMP_TESTS_` name.

## Cause

`kernel_env` (#1262) takes from the runner only `PATH`, `HOME`, the `XDG_*` names and the conftest floor, so `ROMP_MANAGER_PID`, `ROMP_SID`, `ROMP_SESSION_NAME`, `ROMP_BIN` and the `ROMP_TESTS_*` names no longer reach a lab kernel, and `relaunch_env` is handed nothing the lab kernel's environment did not hold. `relaunch_env` still kept every `ROMP_` name of that environment, so a `ROMP_TESTS_` name a lab put there would ride into the file. No lab puts one there today (the served labs plant their probe under another name), so on this tree the exclusion drops nothing; it applies to the next lab that does.

## Fix

`relaunch_env` excludes the `ROMP_TESTS_` prefix (`RELAUNCH_ENV_EXCLUDED_PREFIXES`, beside `RELAUNCH_ENV_PREFIXES`): those names are the run's own and no kernel reads one, so the written stanza never carries one wherever it came from. `kernel_env` is unchanged: the four identity names are not on its list, so there is nothing to pop. The comment over the name lists, `relaunch_env`'s docstring and the module docstring say so. tests/README.md's hermetic section gains a paragraph recording the convention: every module that boots a lab kernel builds its environment with `kernel_env`, the served labs write the relaunch stanza through `relaunch_cfg`, what each takes from the runner and why, the `ROMP_TESTS_` exclusion, the probe each served lab plants and checks the written file for, and the two classes that pin it.

## Tests

- `RelaunchEnv::test_a_live_sessions_identity_and_the_runs_own_names_never_reach_the_relaunch_env` in tests/test_ship_reship.py (no kernel, no browser, runs everywhere) plants `ROMP_MANAGER_PID`, `ROMP_SID`, `ROMP_SESSION_NAME`, `ROMP_BIN` and a `ROMP_TESTS_PROBE` path in `os.environ`, builds a lab kernel's environment through `kernel_env`, and asserts none of the five is in it and no `ROMP_TESTS_` name of the run is. It then plants the same `ROMP_TESTS_PROBE` in the lab kernel's environment directly and asserts the stanza `relaunch_cfg` writes carries neither it nor any of the four identity names, while the lab's own `ROMP_` names (port, token, dist, catalog, postal port) stay. Before the change it fails on `'ROMP_TESTS_PROBE' unexpectedly found in [...]`, names only in the report. The assertions on the four identity names pass before and after: #1262's list keeps them out at the first step, and this test pins that at the relaunch end (with `kernel_env` changed to copy the runner's `ROMP_` names, it fails on `ROMP_MANAGER_PID` reaching the lab kernel).
- The existing `RelaunchEnv` and `LabKernelEnv` cases are unchanged and pass.
- The two served modules, tests/test_ship_reship.py and tests/test_dashboard_reload_served.py, which write the stanza and relaunch the kernel from it, ran against Chromium on this tree: 15 passed, no skips.
- Full suite on this tree (six workers, the served modules running against Chromium): 10992 passed, 41 skipped, 0 failed, 1705 subtests passed.

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)