### PR TITLE
Tests: bats suites that start the real manager isolate their state root, and the suite floors poison the kernel and serve ports beside the manager port

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -45,7 +45,16 @@ Every bug fix or feature change lands with a test (repo rule). Five suites:
   (`ROMP_CLI_SCOPE_MEMORY_MAX` and the others): the kernel hands them to every
   session's CLI and a tool shell inherits them, so a suite run from a session on
   a self-hosted install would otherwise see them at every backend construction
-  and in every exact argv pin.
+  and in every exact argv pin. `conftest.py` and `__init__.py` set
+  `ROMP_MANAGER_PORT`, `ROMP_KERNEL_PORT` and `ROMP_SERVE_PORT` to a dead port
+  (never unset: to every reader an absent variable means the live default), so
+  no test dials a live manager or kernel through an inherited value.
+  Any suite that starts the real `bin/romp-manager` also gives it a state
+  root of its own before its first `@test` (`unset ROMP_STATE_DIR` plus
+  `export XDG_STATE_HOME="$TEST_DIR/state"`, or an exported
+  `ROMP_STATE_DIR`), since the manager boots from its state root's
+  `kernels.json` and reads the serve token there; `bats-state-isolation.bats`
+  is the ratchet.
   Any test whose subject binds a loopback port picks it with `load
   free-port` + `free_port VAR...`, never a literal: a literal shared by two
   files collided within one run (`romp-manager-ensure.bats` once used

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -67,3 +67,9 @@ os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")
 # thread method ends a hung run that way), so a hung run leaves this dir beside the root.
 STATE_DIR = os.environ["XDG_STATE_HOME"]
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+# No unittest run may reach a REAL manager or kernel either: the same three ports conftest.py poisons
+# for pytest (its comment has the readers and the incident). Set to a dead port, never popped: every
+# reader maps an absent variable to the default port, which on a machine running romp is the live one.
+os.environ["ROMP_MANAGER_PORT"] = "1"
+os.environ["ROMP_KERNEL_PORT"] = "1"
+os.environ["ROMP_SERVE_PORT"] = "1"

--- a/tests/bats-state-isolation.bats
+++ b/tests/bats-state-isolation.bats
@@ -1,0 +1,338 @@
+#!/usr/bin/env bats
+
+# Every bats suite that starts the REAL bin/romp-manager gives it a state root of its own. The
+# manager's STATE_ROOT is ROMP_STATE_DIR || XDG_STATE_HOME/romp || ~/.local/state/romp, and a suite
+# whose setup() sets neither hands the manager the developer's live root: `up` loads that root's
+# kernels.json and spawns one child per registered kernel (the suite's fake launcher, with the
+# registry entry's stateDir as its ROMP_STATE_DIR: specEnv), and the drain poll's token comes from
+# that root's serve-token (kernelToken). The manager writes nothing there and dials no live kernel,
+# so the leak is silent: the suite passes while a fake kernel runs for every kernel registered on the
+# machine. This is the ratchet for the bats side, as tests/test_state_isolation_order.py is for the
+# pytest modules: the isolation lines must be present in each such suite, before its first @test
+# (setup() runs before every test; a floor set inside one test leaves the others on the live root).
+#
+# The two lines, as the suites spell them:
+#     unset ROMP_STATE_DIR                    # a profiled kernel's sessions inherit it; it outranks the XDG floor
+#     export XDG_STATE_HOME="$TEST_DIR/state"  # or another path under a shell variable
+# A suite that instead exports ROMP_STATE_DIR to such a path satisfies both, and so do the equivalent
+# spellings: `X="$TEST_DIR/..."` on one line with an `export X` on another, or the assignment unquoted.
+# The check reads the line's shape, not where the path resolves: every suite today uses `$TEST_DIR`, or
+# `$HOME` after re-exporting HOME under its test directory (tests/romp.bats); a variable left pointing
+# at a live path would pass it. A helper the suite `load`s counts as part of the suite, both ways: a floor
+# set in a helper's function isolates, and a helper that starts the manager makes the suite one that
+# does. Any spelling of the load counts (`load name`, `load "$BATS_TEST_DIRNAME/name"`, `source`),
+# and a helper's own loads are read in turn.
+
+TESTS="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+
+setup() { SYN="$(mktemp -d)"; }   # the self-checks' synthetic suites, removed whether or not the check passes
+teardown() { rm -rf "$SYN"; }
+
+# The helper files a suite brings in, one per line, nothing for a suite that loads none: every `load`
+# (bats resolves `load name` to name, else name.bash, beside the suite; a path as given when absolute),
+# `source` and `.` line, with `$BATS_TEST_DIRNAME` or `${BATS_TEST_DIRNAME}` in the argument expanded
+# to the suite's directory, and each helper's own such lines read in turn, every file once (a helper
+# that loads a second helper, or two helpers that load each other, is read as one chain).
+loaded_helpers() {   # $1 suite
+    local _seen="|"
+    _helpers_of "$1" "$1"
+    return 0
+}
+_helpers_of() {   # $1 suite, $2 the file whose load lines to read; appends to the caller's _seen
+    local dir name f
+    dir="$(dirname "$1")"
+    while IFS= read -r name; do
+        name="${name%\"}"; name="${name#\"}"; name="${name%\'}"; name="${name#\'}"
+        [ -n "$name" ] || continue
+        name="${name//\$\{BATS_TEST_DIRNAME\}/$dir}"; name="${name//\$BATS_TEST_DIRNAME/$dir}"
+        case "$name" in /*) ;; *) name="$dir/$name" ;; esac
+        for f in "$name" "$name.bash"; do
+            [ -f "$f" ] || continue
+            case "$_seen" in
+                *"|$f|"*) ;;                                  # already listed: a loop, or two loaders
+                *) _seen="$_seen$f|"; printf '%s\n' "$f"; _helpers_of "$1" "$f" ;;
+            esac
+            break
+        done
+    done < <(sed -nE 's/^[[:space:]]*(load|source|\.)[[:space:]]+([^[:space:]]+).*/\2/p' "$2")
+    return 0
+}
+
+# A suite "starts the manager" when it, or a helper it loads, resolves the repository's own binary for
+# execution: a path climbing from the tests directory (`.../bin" && pwd)/romp-manager"` or
+# `../bin/romp-manager"`), or `"$<VAR>/.../romp-manager"` where a command starts: the line's first word
+# or the word after `;`, `&&`, `||`, `|`, `(`, `{`, `then`, `do` or `else`, with any `VAR=value`
+# prefixes and a `node`, `run`, `exec`, `nohup`, `env` or `timeout N` in front. Comment lines do not
+# count, and neither do stand-ins written under a test directory (`"$MOCK_DIR/romp-manager"` or
+# `"$TEST_DIR/bin/romp-manager"` as a heredoc or printf target, a chmod operand, or the value of
+# ROMP_MANAGER_BIN: none is a command, and a path under a test directory never climbs to `../bin`;
+# tests/romp-refresh-audit.bats drives bin/romp against such a stand-in and starts no manager), nor a
+# line that only talks about the binary (TALK_ONLY_RE: a grep, an assert, a `[[ ]]` or `[ ]` test
+# naming it in an operand; tests/romp-uninstall.bats greps its uninstaller for a pkill pattern that
+# names the binary). A new spelling of the real binary is added to MANAGER_START_RE with the suite
+# that introduces it, and the suite to the exact list below.
+CMD_START='(^|[;&|({]|[[:space:]](then|do|else))[[:space:]]*(([A-Za-z_][A-Za-z_0-9]*=("[^"]*"|[^[:space:]]*)|node|run( -[^[:space:]]+)*|exec|nohup|env|timeout[[:space:]]+[0-9]+[smh]?)[[:space:]]+)*'
+MANAGER_START_RE='(pwd\)/romp-manager"|\.\./bin/romp-manager"|'"$CMD_START"'"\$\{?[A-Za-z_][A-Za-z_0-9]*\}?(/[^/"[:space:]]+)*/romp-manager"([[:space:]]|$))'
+TALK_ONLY_RE='^[[:space:]]*(run[[:space:]]+(-[^[:space:]]+[[:space:]]+)*)?(grep|egrep|fgrep|assert[A-Za-z_]*|refute[A-Za-z_]*|test|\[\[?|!)([[:space:]]|$)'
+
+suite_text() {   # $1 suite: the suite plus every helper it loads, comment and talk-only lines dropped
+    local f
+    grep -Ev '^[[:space:]]*#' "$1" | grep -Ev "$TALK_ONLY_RE"
+    while IFS= read -r f; do grep -Ev '^[[:space:]]*#' "$f" | grep -Ev "$TALK_ONLY_RE"; done < <(loaded_helpers "$1")
+    return 0
+}
+
+# The suite's text is collected whole and matched after, never piped into `grep -q`: that grep stops at
+# its first hit, and a writer still behind it then meets EPIPE. Silent while SIGPIPE kills the writer,
+# but a runner that starts every child with SIGPIPE ignored (GitHub Actions does) has each such grep
+# print `grep: write error: Broken pipe`, which `run` collects into $output beside the paths.
+manager_suites() {
+    local f text
+    for f in "$TESTS"/*.bats; do
+        [ "$(basename "$f")" = "$(basename "$BATS_TEST_FILENAME")" ] && continue   # this file quotes the pattern in its self-checks
+        text="$(suite_text "$f")"
+        if grep -Eq "$MANAGER_START_RE" <<<"$text"; then
+            printf '%s\n' "$f"
+        fi
+    done
+    return 0
+}
+
+before_first_test() { sed -n '1,/^@test /p' "$1"; }
+
+# What a suite runs before its first @test: its own head plus every loaded helper, whole (a helper's
+# functions run from setup()).
+suite_head() {   # $1 suite
+    local f
+    before_first_test "$1"
+    while IFS= read -r f; do cat "$f"; done < <(loaded_helpers "$1")
+    return 0
+}
+
+# Whether `text` assigns VAR to a path under a shell variable and exports it: `export VAR="$..."` (other
+# assignments may share the line), or `VAR="$..."` with an `export VAR` elsewhere (same line after a
+# `;`, or its own line). The quote is optional.
+assigned_and_exported() {   # $1 VAR, $2 text
+    grep -Eq "^[[:space:]]*export[[:space:]]+([A-Za-z_][A-Za-z_0-9]*(=[^[:space:]]*)?[[:space:]]+)*$1=\"?\\\$" <<<"$2" && return 0
+    grep -Eq "^[[:space:]]*$1=\"?\\\$" <<<"$2" \
+        && grep -Eq "(^|;)[[:space:]]*export[[:space:]]+([A-Za-z_][A-Za-z_0-9]*[[:space:]]+)*$1([[:space:]]|;|$)" <<<"$2"
+}
+
+# One line per missing isolation line for a suite, nothing when it is isolated.
+isolation_problems() {   # $1 suite
+    local head
+    head="$(suite_head "$1")"
+    if ! grep -Eq '^[[:space:]]*unset[[:space:]]+([A-Za-z_][A-Za-z_0-9]*[[:space:]]+)*ROMP_STATE_DIR([[:space:]]|;|$)' <<<"$head" \
+       && ! assigned_and_exported ROMP_STATE_DIR "$head"; then
+        echo "$(basename "$1"): neither 'unset ROMP_STATE_DIR' nor an export of it to a test path before the first @test"
+    fi
+    if ! assigned_and_exported XDG_STATE_HOME "$head" && ! assigned_and_exported ROMP_STATE_DIR "$head"; then
+        echo "$(basename "$1"): no 'export XDG_STATE_HOME=\"\$TEST_DIR/...\"' (or ROMP_STATE_DIR) before the first @test"
+    fi
+    return 0
+}
+
+@test "the detector finds exactly the suites known to start a manager (a regex drift cannot pass vacuously, or list a mention)" {
+    # the list is exact, not a floor: a suite that only names the binary in a grep pattern or an assert
+    # (tests/romp-uninstall.bats), or drives bin/romp against a stand-in under its test directory
+    # (tests/romp-refresh-audit.bats), must not appear. A new suite that starts the real manager is
+    # added here, with its isolation lines.
+    run manager_suites
+    [ "$status" -eq 0 ]
+    local expected
+    # romp-manager-tmux-scope.bats starts the real manager to read where its tmux server lands, and
+    # floors its state root with an exported ROMP_STATE_DIR in setup().
+    expected="$(printf '%s\n' "$TESTS/romp-manager-ensure.bats" "$TESTS/romp-manager-origin.bats" \
+        "$TESTS/romp-manager-tmux-scope.bats" "$TESTS/romp.bats" | LC_ALL=C sort)"
+    [ "$(printf '%s\n' "$output" | LC_ALL=C sort)" = "$expected" ]
+}
+
+@test "every suite that starts the real manager isolates its state root before its first @test" {
+    local f bad=()
+    while IFS= read -r f; do
+        while IFS= read -r line; do bad+=("$line"); done < <(isolation_problems "$f")
+    done < <(manager_suites)
+    if [ "${#bad[@]}" -ne 0 ]; then
+        printf 'These suites start a real bin/romp-manager without a state root of their own; it would boot\n' >&2
+        printf 'from the live kernels.json, one fake kernel per registered kernel, and read the live serve-token:\n' >&2
+        printf '  %s\n' "${bad[@]}" >&2
+        return 1
+    fi
+}
+
+# The self-checks below build synthetic suites line by line: a `@test` at column 0 inside a heredoc
+# here would register with bats as a test of THIS file.
+
+@test "the ratchet itself rejects a suite that starts a manager on the live root" {
+    # the detector must see it and the rule must fail it, else a regex drift would make the test above
+    # pass with nothing checked
+    local d="$SYN"
+    printf '%s\n' '#!/usr/bin/env bats' 'setup() {' '    TEST_DIR="$(mktemp -d)"' \
+        '    MGR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"' '}' \
+        '@'"test \"starts one\" { node \"\$MGR\" up; }" > "$d/leaky.bats"
+    grep -q '^@test ' "$d/leaky.bats"                          # the fixture has a real first test line
+    TESTS="$d" run manager_suites
+    [ "$output" = "$d/leaky.bats" ]
+    run isolation_problems "$d/leaky.bats"
+    [ "${#lines[@]}" -eq 2 ]
+    [[ "${lines[0]}" == "leaky.bats: neither 'unset ROMP_STATE_DIR'"* ]]
+    [[ "${lines[1]}" == "leaky.bats: no 'export XDG_STATE_HOME"* ]]
+}
+
+@test "a manager started through a loaded helper is seen, and the helper's missing floor is reported" {
+    # the suite file alone never names the binary: the helper resolves and starts it
+    local d="$SYN"
+    printf '%s\n' '# a helper that starts the real manager' 'start_mgr() {' \
+        '    MGR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"' \
+        '    node "$MGR" up &' '}' > "$d/mgr-helper.bash"
+    printf '%s\n' '#!/usr/bin/env bats' 'load mgr-helper' 'setup() {' '    TEST_DIR="$(mktemp -d)"' \
+        '    start_mgr' '}' '@'"test \"starts one\" { true; }" > "$d/viahelper.bats"
+    run loaded_helpers "$d/viahelper.bats"
+    [ "$output" = "$d/mgr-helper.bash" ]
+    TESTS="$d" run manager_suites
+    [ "$output" = "$d/viahelper.bats" ]
+    run isolation_problems "$d/viahelper.bats"
+    [ "${#lines[@]}" -eq 2 ]
+}
+
+@test "a floor set in a loaded helper, in the equivalent spellings, isolates the suite" {
+    # the assignment and the export on separate lines, the unset with a second variable: all accepted
+    local d="$SYN"
+    printf '%s\n' 'state_floor() {' '    unset OTHER_VAR ROMP_STATE_DIR' \
+        '    XDG_STATE_HOME="$TEST_DIR/state"; export XDG_STATE_HOME' '}' > "$d/floor.bash"
+    printf '%s\n' '#!/usr/bin/env bats' 'load floor' 'setup() {' '    TEST_DIR="$(mktemp -d)"' \
+        '    state_floor' \
+        '    MGR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"' '}' \
+        '@'"test \"starts one\" { node \"\$MGR\" up; }" > "$d/isolated.bats"
+    TESTS="$d" run manager_suites
+    [ "$output" = "$d/isolated.bats" ]
+    run isolation_problems "$d/isolated.bats"
+    [ -z "$output" ]
+    # and the other accepted spelling: ROMP_STATE_DIR exported to a test path, unquoted, no XDG line
+    printf '%s\n' '#!/usr/bin/env bats' 'setup() {' '    TEST_DIR="$(mktemp -d)"' \
+        '    ROMP_STATE_DIR=$TEST_DIR/state' '    export ROMP_STATE_DIR' \
+        '    MGR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"' '}' \
+        '@'"test \"starts one\" { node \"\$MGR\" up; }" > "$d/rompdir.bats"
+    run isolation_problems "$d/rompdir.bats"
+    [ -z "$output" ]
+}
+
+@test "a floor set only inside a test, or only mentioned in a comment, does not isolate the suite" {
+    local d="$SYN"
+    printf '%s\n' '#!/usr/bin/env bats' '# export XDG_STATE_HOME="$TEST_DIR/state" would go here' 'setup() {' \
+        '    TEST_DIR="$(mktemp -d)"' \
+        '    MGR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"' '}' \
+        '@'"test \"starts one\" {" '    unset ROMP_STATE_DIR' '    export XDG_STATE_HOME="$TEST_DIR/state"' \
+        '    node "$MGR" up' '}' > "$d/late.bats"
+    # the two lines are shaped exactly as a setup() would carry them, one per line: only the cut at the
+    # first @test keeps them out of the suite head
+    TESTS="$d" run manager_suites
+    [ "$output" = "$d/late.bats" ]
+    run isolation_problems "$d/late.bats"
+    [ "${#lines[@]}" -eq 2 ]
+}
+
+@test "a helper loaded as \"\$BATS_TEST_DIRNAME/name\" or sourced is read, and so are a helper's own loads" {
+    local d="$SYN"
+    # via-dirname: the common bats spelling for a helper beside the suite; the suite alone never names the binary
+    printf '%s\n' 'start_mgr() {' '    MGR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"' \
+        '    node "$MGR" up &' '}' > "$d/h-dirname.bash"
+    printf '%s\n' '#!/usr/bin/env bats' 'load "$BATS_TEST_DIRNAME/h-dirname"' 'setup() {' '    TEST_DIR="$(mktemp -d)"' \
+        '    start_mgr' '}' '@'"test \"starts one\" { true; }" > "$d/via-dirname.bats"
+    run loaded_helpers "$d/via-dirname.bats"
+    [ "$output" = "$d/h-dirname.bash" ]
+    # via-source: the same helper brought in with `source`, by its full name
+    printf '%s\n' '#!/usr/bin/env bats' 'source "${BATS_TEST_DIRNAME}/h-dirname.bash"' 'setup() {' \
+        '    TEST_DIR="$(mktemp -d)"' '    start_mgr' '}' '@'"test \"starts one\" { true; }" > "$d/via-source.bats"
+    run loaded_helpers "$d/via-source.bats"
+    [ "$output" = "$d/h-dirname.bash" ]
+    # via-chain: the suite loads h-outer, h-outer loads h-inner (which loads h-outer back: a loop), h-inner
+    # starts the manager; the unquoted ${...} spelling
+    printf '%s\n' 'load h-inner' 'outer() { inner; }' > "$d/h-outer.bash"
+    printf '%s\n' 'load h-outer' 'inner() {' '    MGR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"' \
+        '    node "$MGR" up &' '}' > "$d/h-inner.bash"
+    printf '%s\n' '#!/usr/bin/env bats' 'load ${BATS_TEST_DIRNAME}/h-outer' 'setup() {' '    TEST_DIR="$(mktemp -d)"' \
+        '    outer' '}' '@'"test \"starts one\" { true; }" > "$d/via-chain.bats"
+    run loaded_helpers "$d/via-chain.bats"
+    [ "${#lines[@]}" -eq 2 ]                                   # each file once, the loop notwithstanding
+    [ "${lines[0]}" = "$d/h-outer.bash" ]
+    [ "${lines[1]}" = "$d/h-inner.bash" ]
+    TESTS="$d" run manager_suites
+    [ "$(printf '%s\n' "$output" | LC_ALL=C sort)" = "$(printf '%s\n' "$d/via-chain.bats" "$d/via-dirname.bats" "$d/via-source.bats" | LC_ALL=C sort)" ]
+    for f in via-dirname via-source via-chain; do
+        run isolation_problems "$d/$f.bats"
+        [ "${#lines[@]}" -eq 2 ]
+    done
+}
+
+@test "a node-less exec of the resolved binary, the ../bin spelling and a path under a root variable are seen; a text-only mention or a stand-in is not" {
+    local d="$SYN"
+    # direct: the file is executable with a node shebang, so `"$BIN/romp-manager" up` starts it (after an
+    # env prefix, here); nothing else on the line names the path
+    printf '%s\n' '#!/usr/bin/env bats' 'BIN="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)"' 'setup() {' \
+        '    TEST_DIR="$(mktemp -d)"' '    ROMP_SERVE_BIN="$TEST_DIR/fake" "$BIN/romp-manager" up &' '}' \
+        '@'"test \"starts one\" { true; }" > "$d/direct.bats"
+    # dotdot: the binary resolved by climbing from the tests directory without a cd/pwd, then run by name
+    printf '%s\n' '#!/usr/bin/env bats' 'setup() {' '    TEST_DIR="$(mktemp -d)"' \
+        '    MGR="$BATS_TEST_DIRNAME/../bin/romp-manager"' '}' \
+        '@'"test \"starts one\" { node \"\$MGR\" up; }" > "$d/dotdot.bats"
+    # depth: the binary run through a variable holding the repository root, the path climbing from there
+    printf '%s\n' '#!/usr/bin/env bats' 'ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"' 'setup() {' \
+        '    TEST_DIR="$(mktemp -d)"' '    node "$ROOT/bin/romp-manager" up &' '}' \
+        '@'"test \"starts one\" { true; }" > "$d/depth.bats"
+    # greponly: every spelling of the real path, each as the operand of a grep, a test or an assert
+    printf '%s\n' '#!/usr/bin/env bats' 'setup() { TEST_DIR="$(mktemp -d)"; }' \
+        '@'"test \"talks only\" {" \
+        "    grep -q 'pkill -f \"\\\$ROMP_DIR/bin/romp-manager\"' \"\$TEST_DIR/uninstall\"" \
+        '    [[ "$output" == *"/bin/romp-manager"* ]]' \
+        '    run grep -c "node \"$BIN/romp-manager\"" "$TEST_DIR/log"' \
+        '    assert_output --partial "$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"' \
+        '}' > "$d/greponly.bats"
+    grep -qF 'pkill -f "\$ROMP_DIR/bin/romp-manager"' "$d/greponly.bats"   # the fixture carries the real spelling
+    # mock: a heredoc target and a ROMP_MANAGER_BIN export under a test directory, neither a command
+    printf '%s\n' '#!/usr/bin/env bats' 'setup() {' '    MOCK_DIR="$(mktemp -d)"' \
+        '    cat > "$MOCK_DIR/romp-manager" <<MOCK' 'exit 0' 'MOCK' '    chmod +x "$MOCK_DIR/romp-manager"' \
+        '    export ROMP_MANAGER_BIN="$MOCK_DIR/romp-manager"' '}' \
+        '@'"test \"mocks one\" { true; }" > "$d/mock.bats"
+    # standin: the same under a bin/ directory inside the test directory, written by printf, made executable
+    # and handed to bin/romp as ROMP_MANAGER_BIN (the shape of tests/romp-refresh-audit.bats); the suite
+    # then runs bin/romp itself, resolved by climbing from the tests directory
+    printf '%s\n' '#!/usr/bin/env bats' 'setup() {' '    TEST_DIR="$(mktemp -d)"' '    mkdir -p "$TEST_DIR/bin"' \
+        '    printf '"'"'#!/usr/bin/env bash\nexit 0\n'"'"' > "$TEST_DIR/bin/romp-manager"' \
+        '    chmod +x "$TEST_DIR/bin/romp-manager" "$TEST_DIR/bin/romp-postal-service"' \
+        '    export ROMP_MANAGER_BIN="$TEST_DIR/bin/romp-manager"' \
+        '    ROMP="$BATS_TEST_DIRNAME/../bin/romp"' '}' \
+        '@'"test \"drives romp against the stand-in\" { run \"\$ROMP\" refresh --quiet; }" > "$d/standin.bats"
+    grep -qF '"$TEST_DIR/bin/romp-manager"' "$d/standin.bats"             # the fixture carries the stand-in path
+    TESTS="$d" run manager_suites
+    [ "$(printf '%s\n' "$output" | LC_ALL=C sort)" = "$(printf '%s\n' "$d/depth.bats" "$d/direct.bats" "$d/dotdot.bats" | LC_ALL=C sort)" ]
+    for f in direct dotdot depth; do
+        run isolation_problems "$d/$f.bats"
+        [ "${#lines[@]}" -eq 2 ]
+    done
+}
+
+@test "the detector prints only paths when SIGPIPE is ignored, as the GitHub Actions runner leaves it for every child" {
+    # `suite_text "$f" | grep -Eq ...` let grep stop at the first hit while the greps behind it were
+    # still writing. With SIGPIPE at its default they die silently; ignored (the runner's host process
+    # starts each step so, and the disposition survives exec), each one meets EPIPE and prints
+    # `grep: write error: Broken pipe`, which `run` collects into $output beside the paths. The shape
+    # that met it every time: a suite that matches on its own and then loads a helper, so a writer is
+    # still to come after the match.
+    local d="$SYN"
+    printf '%s\n' 'state_floor() { unset ROMP_STATE_DIR; export XDG_STATE_HOME="$TEST_DIR/state"; }' > "$d/floor.bash"
+    printf '%s\n' '#!/usr/bin/env bats' 'load floor' 'setup() {' '    TEST_DIR="$(mktemp -d)"' '    state_floor' \
+        '    MGR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"' '}' \
+        '@'"test \"starts one\" { node \"\$MGR\" up; }" > "$d/isolated.bats"
+    local plain ignored
+    run manager_suites
+    plain="$output"
+    trap '' PIPE                                               # inherited by run's subshell and every grep
+    TESTS="$d" run manager_suites
+    [ "$output" = "$d/isolated.bats" ]
+    run manager_suites
+    ignored="$output"
+    trap - PIPE
+    [ -n "$plain" ]
+    [ "$ignored" = "$plain" ]                                  # the same list either way, nothing beside it
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,14 @@ os.environ["CLAUDE_CONFIG_DIR"] = _CLAUDE_CONFIG
 # but _run_main_update maps absent to the DEFAULT port — the live one — so only a dead value is
 # safe against every consumer. Import-time, so collection-time code is floored too.
 os.environ["ROMP_MANAGER_PORT"] = "1"
+# The kernel's port, both spellings, for the same reason: kernel/kernel.py resolves PORT from
+# ROMP_KERNEL_PORT at import and postal/postal_service.py builds KERNEL_BASE from it at import, bin/romp
+# reads it in every kernel subcommand and hooks/romp-wake.sh at every wake, and bin/romp-manager reads
+# ROMP_SERVE_PORT first; each maps an absent variable to the DEFAULT port, the live kernel's, so a test
+# that dials "the kernel" through an inherited or absent value reaches the developer's own. A test that
+# starts a kernel of its own passes the port it picked, as the ones that do already do.
+os.environ["ROMP_KERNEL_PORT"] = "1"
+os.environ["ROMP_SERVE_PORT"] = "1"
 
 # No test may read the REAL service.env (2026-09-04; the reason changed on 2026-09-08): the kernel's boot
 # check (kernel/credentials.py) reads the manager env file for retired provider lines, so on a machine whose
@@ -220,8 +228,12 @@ def _dead_manager_port():
     """The import-time poison above covers collection, but a module-level env write in a test file
     ALSO executes during collection — so one module's write (or pop) would otherwise hold for the
     entire run phase, erasing the floor for every test after it. Re-assert per test: no
-    module-level write can outlive collection against this."""
+    module-level write can outlive collection against this. The kernel's port, both spellings, is
+    re-asserted the same way; a test that needs a port of its own sets it in setUp or passes it
+    to the process it starts."""
     os.environ["ROMP_MANAGER_PORT"] = "1"
+    os.environ["ROMP_KERNEL_PORT"] = "1"
+    os.environ["ROMP_SERVE_PORT"] = "1"
     yield
 
 

--- a/tests/romp-manager-ensure.bats
+++ b/tests/romp-manager-ensure.bats
@@ -30,6 +30,14 @@ FAKE
     chmod +x "$BIN/tmux"
     export PATH="$BIN:$PATH"
     tmux_private_socket_dir "$TEST_DIR"   # also floors ROMP_CLI_SCOPE=0: no real scope on the user manager
+    # The manager's state root is private too. With neither variable set STATE_ROOT is the live
+    # ~/.local/state/romp, and `up` boots from that root's kernels.json: the fake launcher below runs
+    # once per kernel registered there, each handed the registry entry's stateDir, and the drain
+    # poll's token is read from that root's serve-token. ROMP_STATE_DIR outranks the XDG floor and a
+    # profiled kernel's sessions inherit it, so it is dropped, not shadowed (tests/bats-state-isolation.bats
+    # keeps both lines in every suite that starts the real manager).
+    unset ROMP_STATE_DIR
+    export XDG_STATE_HOME="$TEST_DIR/state"; mkdir -p "$XDG_STATE_HOME"
     # Fake kernel launcher: stay alive without binding a real port (we assert on the
     # manager's control endpoint, not a live kernel).
     FAKE="$TEST_DIR/fake-serve"

--- a/tests/romp-manager-origin.bats
+++ b/tests/romp-manager-origin.bats
@@ -21,6 +21,13 @@ setup() {
     chmod +x "$BIN/tmux"
     export PATH="$BIN:$PATH"
     tmux_private_socket_dir "$TEST_DIR"   # also floors ROMP_CLI_SCOPE=0: no real scope on the user manager
+    # The manager's state root is private too: with neither variable set, `up` boots from the live
+    # ~/.local/state/romp's kernels.json (the fake launcher below, once per kernel registered there,
+    # each handed that entry's stateDir) and the drain poll's token comes from the live serve-token.
+    # ROMP_STATE_DIR outranks the XDG floor and a profiled kernel's sessions inherit it, so it is
+    # dropped, not shadowed (tests/bats-state-isolation.bats keeps both lines in every such suite).
+    unset ROMP_STATE_DIR
+    export XDG_STATE_HOME="$TEST_DIR/state"; mkdir -p "$XDG_STATE_HOME"
     # Fake kernel launcher: stays alive without binding a real port.
     FAKE="$TEST_DIR/fake-serve"
     printf '#!/usr/bin/env bash\nexec sleep 30\n' > "$FAKE"

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -111,6 +111,9 @@ MOCK
     # names map under XDG_STATE_HOME (was polluting the REAL state dir).
     export HOME="$TEST_DIR/home"
     export XDG_STATE_HOME="$HOME/.local/state"
+    # ROMP_STATE_DIR outranks that floor, and a profiled kernel's sessions inherit it: the real managers
+    # the romp-manager tests start would boot from that root's kernels.json (tests/bats-state-isolation.bats).
+    unset ROMP_STATE_DIR
     mkdir -p "$HOME"
     cd "$WORK_DIR"
 }

--- a/tests/test_state_isolation_order.py
+++ b/tests/test_state_isolation_order.py
@@ -55,8 +55,29 @@ LOAD_CALLS = {"SourceFileLoader", "spec_from_file_location", "exec_module", "imp
               "__import__"}
 
 
+# The ports the suite floors poison to a dead value (never popped: to every reader an absent variable
+# means the live default), in tests/conftest.py for pytest and tests/__init__.py for unittest runs.
+DEAD_PORTS = ("ROMP_MANAGER_PORT", "ROMP_KERNEL_PORT", "ROMP_SERVE_PORT")
+
+
 def _is_environ_attr(node):
     return isinstance(node, ast.Attribute) and node.attr == "environ"
+
+
+def _sets_env_to(stmt, name, value):
+    """Is `stmt` the statement os.environ[name] = value? (Set, not setdefault.)"""
+    if not (isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Constant) and stmt.value.value == value):
+        return False
+    return any(isinstance(t, ast.Subscript) and _is_environ_attr(t.value)
+               and isinstance(t.slice, ast.Constant) and t.slice.value == name for t in stmt.targets)
+
+
+def _is_autouse_fixture(fn):
+    """Is `fn` decorated @pytest.fixture(autouse=True)?"""
+    return any(isinstance(d, ast.Call) and isinstance(d.func, ast.Attribute) and d.func.attr == "fixture"
+               and any(kw.arg == "autouse" and isinstance(kw.value, ast.Constant) and kw.value.value is True
+                       for kw in d.keywords)
+               for d in fn.decorator_list)
 
 
 def _environ_key(node):
@@ -129,13 +150,65 @@ class StateIsolationOrder(unittest.TestCase):
     def test_the_suite_wide_floors_stay_in_place(self):
         # The suspenders: conftest.py (pytest) and __init__.py (unittest package runs) each set the
         # XDG floor and drop an inherited ROMP_STATE_DIR override. Pin them so neither is silently
-        # deleted or loses the pop.
+        # deleted or loses the pop. The same two files poison the manager's control port and the
+        # kernel's port (both spellings) to a dead value: to every reader an ABSENT variable means the
+        # live default (bin/romp-manager's control port; kernel.py's PORT, postal_service.py's
+        # KERNEL_BASE, bin/romp's per-subcommand port and hooks/romp-wake.sh all default to 29855), so
+        # a pop is not safe and only a set value is. Pinned on the source, as the floors above are:
+        # every module is collected before any test runs, and several set the same values at import,
+        # so a run-time read cannot tell the import-time floor from a module's own set. conftest.py's
+        # two halves are pinned apart, as tests/test_cli_scope_floor.py pins the cli-scope floor: the
+        # module-level statement covers collection, and the autouse fixture's re-assert covers the run
+        # phase against a module-level write in a test file (which also executes at collection).
+        bodies = {}
         for fn in ("conftest.py", "__init__.py"):
             src = open(os.path.join(HERE, fn)).read()
             self.assertIn('os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp', src,
                           "%s must keep the temp XDG_STATE_HOME floor" % fn)
             self.assertIn('os.environ.pop("ROMP_STATE_DIR", None)', src,
                           "%s must keep dropping an inherited ROMP_STATE_DIR override" % fn)
+            bodies[fn] = ast.parse(src, filename=fn).body
+            for var in DEAD_PORTS:
+                self.assertTrue(any(_sets_env_to(stmt, var, "1") for stmt in bodies[fn]),
+                                '%s must set os.environ["%s"] = "1" at module level: absent means the live default'
+                                % (fn, var))
+        fixtures = [node for node in bodies["conftest.py"]
+                    if isinstance(node, ast.FunctionDef) and _is_autouse_fixture(node)]
+        self.assertTrue(fixtures, "conftest.py has no autouse fixtures at all")
+        for var in DEAD_PORTS:
+            self.assertTrue(any(any(_sets_env_to(stmt, var, "1") for stmt in fx.body) for fx in fixtures),
+                            'no autouse fixture in conftest.py re-asserts os.environ["%s"] = "1": one test '
+                            "module's import-time write would otherwise hold for every test after it" % var)
+
+
+class DeadPortsHoldPerTest(unittest.TestCase):
+    """The run-time half of the port floor, under pytest only: conftest.py's autouse fixture writes the
+    three dead ports before every test, so a value a test file writes at module or class level cannot
+    outlive collection or class setup. setUpClass writes a second dead port; pytest sets a class up
+    before its function-scoped fixtures run, so the fixture's re-assert lands between that write and the
+    read below, which therefore tells the fixture from any module's own import-time set (the source pins
+    above cannot). A bare unittest run has no fixture and nothing to check, so the test skips there."""
+    OTHER_DEAD_PORT = "2"   # any value but the floor's shows the re-assert; a dead one dials nothing if it is missing
+
+    @classmethod
+    def setUpClass(cls):
+        cls._saved = {var: os.environ.get(var) for var in DEAD_PORTS}
+        for var in DEAD_PORTS:
+            os.environ[var] = cls.OTHER_DEAD_PORT
+
+    @classmethod
+    def tearDownClass(cls):
+        for var, val in cls._saved.items():
+            if val is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = val
+
+    def test_the_dead_ports_hold_while_this_test_runs(self):
+        if "PYTEST_CURRENT_TEST" not in os.environ:
+            self.skipTest("conftest.py's per-test re-assert exists under pytest only")
+        for var in DEAD_PORTS:
+            self.assertEqual(os.environ.get(var), "1", "%s is not re-asserted per test" % var)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Symptom

On a machine that runs romp, a bats run of `tests/romp-manager-ensure.bats` or `tests/romp-manager-origin.bats` starts one fake kernel per kernel registered in the live `~/.local/state/romp/kernels.json`, each with that registry entry's `stateDir` in its environment, and its drain polls read the live `serve-token`. The suites pass either way, so nothing shows. From a shell of a profiled kernel's session, the three manager tests in `tests/romp.bats` do the same through the inherited `ROMP_STATE_DIR`. Under pytest, a test that dials the kernel through an inherited or absent `ROMP_KERNEL_PORT` or `ROMP_SERVE_PORT` reaches the developer's live kernel, and a `python -m unittest tests.test_x` run has no port floor at all, the manager's included.

## Cause

`bin/romp-manager` resolves `STATE_ROOT` as `ROMP_STATE_DIR || XDG_STATE_HOME/romp || ~/.local/state/romp`; `up` loads `STATE_ROOT/kernels.json` and calls `spawnKernel` per spec, `specEnv` hands each child the spec's `stateDir`, and `kernelToken` reads `STATE_ROOT/serve-token`. The manager writes nothing there and dials no live kernel, which is why the leak is silent. The two manager suites set neither variable in `setup()`, and `romp.bats` exports `XDG_STATE_HOME` under its fixture HOME but never unsets `ROMP_STATE_DIR`, which outranks it (a profiled kernel's sessions inherit it).

On the pytest side `tests/conftest.py` poisons `ROMP_MANAGER_PORT` only. `kernel/kernel.py` (`PORT`) and `postal/postal_service.py` (`KERNEL_BASE`) resolve `ROMP_KERNEL_PORT` at import, `bin/romp` reads it in every kernel subcommand, `hooks/romp-wake.sh` at every wake, and `bin/romp-manager` reads `ROMP_SERVE_PORT` first; each maps an absent variable to the live default 29855, so a pop is not safe and only a set value is. `tests/__init__.py`, the floor for unittest runs, poisons no port.

## Fix

Tests only.

- `tests/romp-manager-ensure.bats`, `tests/romp-manager-origin.bats`: `unset ROMP_STATE_DIR` and `export XDG_STATE_HOME="$TEST_DIR/state"` in `setup()`, beside the tmux socket isolation, with the reason in a comment.
- `tests/romp.bats`: `unset ROMP_STATE_DIR` beside the existing `XDG_STATE_HOME` export.
- `tests/conftest.py`: `ROMP_KERNEL_PORT` and `ROMP_SERVE_PORT` set to `"1"` at import beside the manager port, and the autouse fixture re-asserts all three per test (a module-level write in a test file also runs at collection and would otherwise hold for the rest of the run). A test that needs a port of its own sets it in setUp or passes it to the process it starts, as the ones that start a kernel already do.
- `tests/__init__.py`: the three ports set to `"1"` for `python -m unittest` runs.
- `tests/README.md`: two sentences.

## Tests

- New `tests/bats-state-isolation.bats` (9 tests), the ratchet for the bats side as `tests/test_state_isolation_order.py` is for the pytest modules. It resolves every `load`, `source` and `.` spelling (`load name`, `load "$BATS_TEST_DIRNAME/name"`, `source ...`) and each helper's own loads, every file once. A suite starts the manager when it, or a helper it loads, executes the repository's own `bin/romp-manager`: a path climbing from the tests directory (`pwd)/romp-manager"` or `../bin/romp-manager"`), or a `"$VAR/.../romp-manager"` of any depth under the variable where a command starts, with `VAR=value`, `node`, `run`, `exec`, `nohup`, `env` and `timeout N` prefixes allowed. Comment lines and lines that only talk about the binary (a grep, an assert, a `[[ ]]` or `[ ]` operand) are dropped, and a stand-in under a test directory does not match, so `romp-refresh-audit.bats`, which drives `bin/romp` against a fake `$TEST_DIR/bin/romp-manager`, is not listed. Each detected suite must carry both isolation lines before its first `@test`, in the suite head or a loaded helper; equivalent spellings are accepted (an exported `ROMP_STATE_DIR` under a shell variable, the assignment and `export` on separate lines, the unset with a second variable), and the check reads the line's shape, not where the path resolves, as the header says. The detected list is pinned exactly (`romp-manager-ensure`, `romp-manager-origin`, `romp-manager-tmux-scope`, `romp.bats`), so a regex drift can neither pass vacuously nor list a mention. Seven self-checks run the rule and the detector over synthetic suites written in `setup()` and removed in `teardown()` whether or not the check passes: a leaky suite; a manager started through a loaded helper; floors set in a helper; a floor written inside the first test body on its own lines (shaped as `setup()` would carry it, so only the cut at the first `@test` keeps it out) or only in a comment; `$BATS_TEST_DIRNAME`, `source` and chained (looping) loads; a node-less exec, the `../bin` spelling and a path under a root variable (`node "$ROOT/bin/romp-manager"`) beside grep-only mentions, the heredoc mock and the refresh-audit stand-in shape; and the SIGPIPE-ignored runner (the suite text is collected whole and matched after, never piped into `grep -q`, which on a runner that starts children with SIGPIPE ignored prints `grep: write error: Broken pipe` into `$output`). Red before the setup changes: 8 of 9 pass and the rule test fails listing five lines, both lines for each manager suite and the unset for `romp.bats`; the detector test is green on the unchanged tree, so the red is the rule, not the detector. Three drifts checked by hand each turn one self-check red: returning the whole file instead of the head cut fails the in-test-floor check, dropping the depth group from the regex fails the root-variable check, and a regex that matches nothing fails the exact-list test and leaves no synthetic directory behind. One spelling the detector does not see: a real binary assigned through a variable rooted somewhere other than the tests directory and then run as `node "$MGR"`; the header says a new spelling is added to the regex with the suite that introduces it. No suite on the tree spells it that way.
- `tests/test_state_isolation_order.py::test_the_suite_wide_floors_stay_in_place` reads `conftest.py` and `__init__.py` as ASTs and pins each half of the port floor apart, as `tests/test_cli_scope_floor.py` does for the cli-scope floor: a module-level statement `os.environ["<VAR>"] = "1"` for each of the three ports in both files, and in `conftest.py` an autouse fixture whose body re-asserts each. Red before the `conftest.py` and `__init__.py` changes (`conftest.py must set os.environ["ROMP_KERNEL_PORT"] = "1" at module level`), and red alone when the import-time statement is removed with the fixture's copy kept, when the fixture's re-asserts are removed with the import-time statement kept, or when the fixture loses `autouse=True`. The import-time half is a source pin by design, as the file's XDG and pop pins are: every module is collected before any test runs and several set the same values at import, so a run-time read cannot tell that floor from a module's own set.
- New `tests/test_state_isolation_order.py::DeadPortsHoldPerTest`, the run-time half of the fixture claim: `setUpClass` writes a second dead port to the three variables and the test reads `"1"` back, a value only the fixture's per-test re-assert can produce (pytest sets a class up before its function-scoped fixtures run). The saved values are restored in `tearDownClass`, and the test skips under a bare unittest run, which has no fixture. Red on the unchanged `conftest.py` (`ROMP_KERNEL_PORT is not re-asserted per test`) and under each fixture mutation above; green on this tree, alone and in the full run.
- Green after the change: `bats tests/bats-state-isolation.bats` 9/9, `bats tests/romp-manager-ensure.bats` 7/7, `bats tests/romp-manager-origin.bats` 1/1, `bats tests/romp.bats` 119/119; `pytest tests/test_state_isolation_order.py tests/test_tempdir_hygiene.py tests/test_cli_scope_floor.py` 25 passed, 63 subtests; `python -m unittest tests.test_state_isolation_order` 2 passed, 1 skipped, and after `import tests` the three ports read `1` with `ROMP_STATE_DIR` absent.
- Full pytest suite on this tree (`-n 6`, the served modules running against Chromium): 10957 passed, 41 skipped, 0 failed, 1688 subtests passed. The import-time poison changes what every test sees, and every module that starts a kernel or a server sets its own ports.
- Leak checked by hand against a scratch state root seeded with a synthetic `kernels.json` (one aux entry, placeholder paths): a manager started the way the suites start it, with that root inherited through `ROMP_STATE_DIR`, listed the synthetic kernel in `/status` beside `main`; with the two isolation lines it listed `main` only.

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)