### PR TITLE
The pre-push hook runs gitleaks over the commits a push publishes, refusing a credential the way it refuses an identifier

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
-# romp pre-push hook: refuse to publish a commit that carries a personal identifier.
+# romp pre-push hook: refuse to publish a commit that carries a personal
+# identifier or a credential.
 #
-# The repo may go public and history is permanent, so this reads the COMMITS
-# BEING PUSHED (not the working tree) for the strings in
-# ~/.config/romp/private-strings.txt — one banned string per line, `#` comments
-# and blank lines ignored, matched case-insensitively. With no such file it
-# exits 0 and stays out of your way, so on a clone that never set one up (any
-# contributor's machine) it is a no-op.
+# The repo may go public and history is permanent, so both scans read the
+# COMMITS BEING PUSHED (not the working tree). Two scanners, because they catch
+# opposite kinds of thing:
 #
-# Two checks per pushed ref, both about what THIS push changes on the remote:
+#   identifiers   strings only YOU can enumerate (names, hostnames, vault
+#                 names), read from ~/.config/romp/private-strings.txt: one
+#                 banned string per line, `#` comments and blank lines ignored,
+#                 matched case-insensitively. With no such file the scan stays
+#                 out of your way, so on a clone that never set one up (any
+#                 contributor's machine) it is a no-op.
+#   credentials   strings NOBODY can enumerate in advance (a token's text is
+#                 unknown until it leaks), matched by gitleaks' rules, tuned by
+#                 the repo's .gitleaks.toml. With no gitleaks binary the scan
+#                 prints a notice and stands down.
+#
+# The identifier scan makes two checks per pushed ref, both about what THIS
+# push changes on the remote:
 #
 #   the tip's tree    the content the push exposes. A banned string anywhere in
 #                     it, in a regular file or a symlink's target, refuses the
@@ -25,29 +35,28 @@
 #                     them all, over files the branch never touched, when the
 #                     only exposure any of them could add is its tip.
 #
+# The credential scan reads the same new commits, each merge by its
+# first-parent diff, and refuses the push on a hit. A range this clone cannot
+# resolve (a force-push over a remote tip nobody fetched) sends both scans over
+# everything the pushed tip reaches.
+#
 # Why pushed commits rather than a working-tree scan: the hook is symlinked into
 # the SHARED git hooks dir (by install.sh), so it fires from every worktree —
 # but a working-tree scan is only as good as the tree you happen to push from,
 # and an untracked scanner script exists in only one worktree. Reading the
 # denylist from $HOME and reading the pushed shas arms every worktree equally.
 #
-# Bypass a false positive with `git push --no-verify`.
+# Env: ROMP_PRIVATE_STRINGS (denylist path), ROMP_GITLEAKS (scanner binary),
+# ROMP_NO_GITLEAKS=1 (skip the credential scan and its notice).
+# Bypass a false positive from either scan with `git push --no-verify`.
 set -euo pipefail
 
-strings_file="${ROMP_PRIVATE_STRINGS:-${XDG_CONFIG_HOME:-$HOME/.config}/romp/private-strings.txt}"
-[ -f "$strings_file" ] || exit 0
-
-# Banned strings: strip comments and surrounding whitespace, drop blanks.
-grep_args=()
-while IFS= read -r line; do
-    line="${line%%#*}"
-    line="${line#"${line%%[![:space:]]*}"}"
-    line="${line%"${line##*[![:space:]]}"}"
-    [ -n "$line" ] && grep_args+=(-e "$line")
-done < "$strings_file"
-[ ${#grep_args[@]} -gt 0 ] || exit 0
-
+# git feeds the ref list on stdin and both scans need it, so read it once.
+refs="$(cat)"
 zero=0000000000000000000000000000000000000000
+blocked_ids=0
+blocked_creds=0
+failed_scan=0
 
 # The commits THIS push publishes for one ref: what no remote already has.
 # "Already has" means reachable from the remote ref's current value or from ANY
@@ -100,60 +109,158 @@ added_lines() {   # <rev>
         !hdr && substr($0, 1, n) == plus { print f "\t" substr($0, n + 1) }'
 }
 
-blocked=0
-while read -r local_ref local_sha _remote_ref remote_sha; do
-    [ -n "${local_sha:-}" ] || continue
-    [ "$local_sha" = "$zero" ] && continue          # deleting a remote ref pushes nothing
+# ── identifiers ───────────────────────────────────────────────────────────
+scan_identifiers() {
+    local strings_file line grep_args local_ref local_sha _remote_ref remote_sha
+    local hits links link blob link_path target revs rev
+    strings_file="${ROMP_PRIVATE_STRINGS:-${XDG_CONFIG_HOME:-$HOME/.config}/romp/private-strings.txt}"
+    [ -f "$strings_file" ] || return 0
 
-    # The tip's tree. -I skips binaries; -l lists files.
-    if hits=$(git grep -i -I -l -F "${grep_args[@]}" "$local_sha" -- 2>/dev/null) && [ -n "$hits" ]; then
-        echo "romp pre-push: the tip of $local_ref (${local_sha:0:10}) would publish a personal identifier in:" >&2
-        echo "$hits" | sed "s/^$local_sha:/  /" >&2
-        blocked=1
-    fi
+    # Banned strings: strip comments and surrounding whitespace, drop blanks.
+    grep_args=()
+    while IFS= read -r line; do
+        line="${line%%#*}"
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        [ -n "$line" ] && grep_args+=(-e "$line")
+    done < "$strings_file"
+    [ ${#grep_args[@]} -gt 0 ] || return 0
 
-    # The tip's symlinks. git grep reads regular-file blobs only, so a link whose
-    # TARGET holds a string is invisible to the grep above. A committed link's
-    # target is its blob content, so read each 120000 entry's blob itself. Not
-    # hypothetical: a `node_modules -> /home/<user>/code/romp/...` link, made to
-    # run the extension tests in a worktree and swept up by a broad `git add`,
-    # reached a public branch past a git grep of its tree, and a reviewer found
-    # it, not the hook. An ls-tree line is "<mode> <type> <sha>\t<path>". A blob
-    # that cannot be read counts as empty: under set -e a failed substitution
-    # would end the hook with no message, before its verdict on everything else.
-    if links=$(git ls-tree -r "$local_sha" 2>/dev/null | grep '^120000 '); then
-        while IFS= read -r link; do
-            blob=${link#* * }; blob=${blob%%[[:space:]]*}
-            link_path=${link#*$'\t'}
-            target=$(git cat-file -p "$blob" 2>/dev/null) || target=""
-            if printf '%s' "$target" | grep -qi -F "${grep_args[@]}"; then
-                echo "romp pre-push: the tip of $local_ref (${local_sha:0:10}) would publish a personal identifier" >&2
-                echo "  in the SYMLINK TARGET of $link_path -> $target" >&2
-                blocked=1
-            fi
-        done <<< "$links"
-    fi
+    while read -r local_ref local_sha _remote_ref remote_sha; do
+        [ -n "${local_sha:-}" ] || continue
+        [ "$local_sha" = "$zero" ] && continue          # deleting a remote ref pushes nothing
 
-    # The lines each commit new to the remote adds.
-    # shellcheck disable=SC2046  # the range is deliberately word-split
-    revs=$(git rev-list $(rev_range "$local_sha" "$remote_sha") 2>/dev/null \
-           || git rev-list "$local_sha")
-    for rev in $revs; do
-        if hits=$(added_lines "$rev" | grep -i -F "${grep_args[@]}" | cut -f1 | sort -u) && [ -n "$hits" ]; then
-            echo "romp pre-push: commit ${rev:0:10} ADDS a personal identifier in:" >&2
-            echo "$hits" | sed 's/^/  /' >&2
-            blocked=1
+        # The tip's tree. -I skips binaries; -l lists files.
+        if hits=$(git grep -i -I -l -F "${grep_args[@]}" "$local_sha" -- 2>/dev/null) && [ -n "$hits" ]; then
+            echo "romp pre-push: the tip of $local_ref (${local_sha:0:10}) would publish a personal identifier in:" >&2
+            echo "$hits" | sed "s/^$local_sha:/  /" >&2
+            blocked_ids=1
         fi
-    done
-done
 
-if [ "$blocked" -ne 0 ]; then
-    echo "" >&2
-    echo "romp pre-push: BLOCKED — a banned string from $strings_file is in a pushed commit." >&2
-    echo "  Replace it with synthetic data (see CONTRIBUTING.md), then push again." >&2
-    echo "  If the string is only in an INTERMEDIATE commit, squash or rewrite the branch." >&2
-    echo "  If the tip only INHERITS a string an older commit added, merge the main that has since redacted it." >&2
-    echo "  If the named commit is already on some remote, this clone has not fetched it: fetch, then push again." >&2
+        # The tip's symlinks. git grep reads regular-file blobs only, so a link whose
+        # TARGET holds a string is invisible to the grep above. A committed link's
+        # target is its blob content, so read each 120000 entry's blob itself. Not
+        # hypothetical: a `node_modules -> /home/<user>/code/romp/...` link, made to
+        # run the extension tests in a worktree and swept up by a broad `git add`,
+        # reached a public branch past a git grep of its tree, and a reviewer found
+        # it, not the hook. An ls-tree line is "<mode> <type> <sha>\t<path>". A blob
+        # that cannot be read counts as empty: under set -e a failed substitution
+        # would end the hook with no message, before its verdict on everything else.
+        if links=$(git ls-tree -r "$local_sha" 2>/dev/null | grep '^120000 '); then
+            while IFS= read -r link; do
+                blob=${link#* * }; blob=${blob%%[[:space:]]*}
+                link_path=${link#*$'\t'}
+                target=$(git cat-file -p "$blob" 2>/dev/null) || target=""
+                if printf '%s' "$target" | grep -qi -F "${grep_args[@]}"; then
+                    echo "romp pre-push: the tip of $local_ref (${local_sha:0:10}) would publish a personal identifier" >&2
+                    echo "  in the SYMLINK TARGET of $link_path -> $target" >&2
+                    blocked_ids=1
+                fi
+            done <<< "$links"
+        fi
+
+        # The lines each commit new to the remote adds.
+        # shellcheck disable=SC2046  # the range is deliberately word-split
+        revs=$(git rev-list $(rev_range "$local_sha" "$remote_sha") 2>/dev/null \
+               || git rev-list "$local_sha")
+        for rev in $revs; do
+            if hits=$(added_lines "$rev" | grep -i -F "${grep_args[@]}" | cut -f1 | sort -u) && [ -n "$hits" ]; then
+                echo "romp pre-push: commit ${rev:0:10} ADDS a personal identifier in:" >&2
+                echo "$hits" | sed 's/^/  /' >&2
+                blocked_ids=1
+            fi
+        done
+    done <<< "$refs"
+
+    if [ "$blocked_ids" -ne 0 ]; then
+        echo "" >&2
+        echo "romp pre-push: BLOCKED — a banned string from $strings_file is in a pushed commit." >&2
+        echo "  Replace it with synthetic data (see CONTRIBUTING.md), then push again." >&2
+        echo "  If the string is only in an INTERMEDIATE commit, squash or rewrite the branch." >&2
+        echo "  If the tip only INHERITS a string an older commit added, merge the main that has since redacted it." >&2
+        echo "  If the named commit is already on some remote, this clone has not fetched it: fetch, then push again." >&2
+    fi
+}
+
+# ── credentials ───────────────────────────────────────────────────────────
+# gitleaks (ROMP_GITLEAKS, else the first on PATH) over the commits this push
+# publishes: the same range per ref as the identifier scan, so a secret that is
+# already on a remote does not refuse every later push, and a secret in an
+# intermediate commit whose tip is clean is still caught.
+scan_credentials() {
+    [ -n "${ROMP_NO_GITLEAKS:-}" ] && return 0
+
+    local gl root cfg range rc _local_ref local_sha _remote_ref remote_sha
+    gl="${ROMP_GITLEAKS:-$(command -v gitleaks || true)}"
+    if [ -z "$gl" ] || [ ! -x "$gl" ]; then
+        # Loud rather than silent, but not a blocker: requiring an install to
+        # push would break every clone that never wanted the scanner.
+        echo "romp pre-push: gitleaks not installed, pushing WITHOUT a secret scan." >&2
+        echo "  Install it (brew install gitleaks, or a release binary named by ROMP_GITLEAKS), or set ROMP_NO_GITLEAKS=1 to silence this." >&2
+        return 0
+    fi
+
+    root="$(git rev-parse --show-toplevel)"
+    # The repo's rules, named explicitly: without --config gitleaks reads a
+    # GITLEAKS_CONFIG from the environment before the source root, so a
+    # developer's own config (for a pre-commit hook of theirs, say) would
+    # replace the repo's. A tree without the file scans under the default rules.
+    cfg=()
+    [ -f "$root/.gitleaks.toml" ] && cfg=(--config "$root/.gitleaks.toml")
+
+    while read -r _local_ref local_sha _remote_ref remote_sha; do
+        [ -n "${local_sha:-}" ] || continue
+        [ "$local_sha" = "$zero" ] && continue      # deleting a remote ref pushes nothing
+        # The range has to resolve in THIS clone before gitleaks sees it: handed
+        # a sha git cannot find (a force-push over a remote tip nobody fetched),
+        # gitleaks logs git's error, scans no commits and exits 0, and the push
+        # would go out unscanned. The identifier scan falls back to everything
+        # the pushed tip reaches; so does this one.
+        range="$(rev_range "$local_sha" "$remote_sha")"
+        # shellcheck disable=SC2086  # the range is deliberately word-split
+        git rev-list $range >/dev/null 2>&1 || range="$local_sha"
+        # -v prints the file, line and rule; without it gitleaks reports only a
+        # COUNT, which says a push was refused but not what to fix. --redact
+        # keeps the secret itself out of terminal scrollback: the location is
+        # what a fix needs, and the value has to be rotated anyway.
+        # --exit-code 2 tells a finding apart from gitleaks failing (exit 1: an
+        # unreadable config, say). Both refuse the push, with different advice.
+        # --diff-merges=first-parent: `gitleaks git` runs `git log -p`, which
+        # shows NO diff for a merge commit by default, so a secret introduced
+        # during a conflict resolution (in neither parent, only the merge tree)
+        # would be scanned by nothing. The first-parent diff of each merge
+        # surfaces exactly that content; non-merges are unaffected.
+        # ${cfg[@]+...}: an empty array expands to nothing under set -u in
+        # every bash, the 3.2 that macOS ships included.
+        rc=0
+        "$gl" git "$root" --no-banner --redact -v --exit-code 2 ${cfg[@]+"${cfg[@]}"} \
+            --log-opts="$range --diff-merges=first-parent" >&2 || rc=$?
+        case $rc in
+            0) ;;
+            2) blocked_creds=1 ;;
+            *) failed_scan=1 ;;
+        esac
+    done <<< "$refs"
+
+    if [ "$blocked_creds" -ne 0 ]; then
+        echo "" >&2
+        echo "romp pre-push: BLOCKED. gitleaks found a credential in a pushed commit." >&2
+        echo "  Treat it as compromised the moment it exists in a commit: ROTATE it, then remove it." >&2
+        echo "  Removing it in a NEW commit is not enough; the old commit still carries it." >&2
+        echo "  A false positive belongs in .gitleaks.toml, narrowly, with a reason." >&2
+    fi
+    if [ "$failed_scan" -ne 0 ]; then
+        echo "" >&2
+        echo "romp pre-push: BLOCKED. gitleaks could not scan; its error is above." >&2
+        echo "  The push is refused rather than published unscanned. Fix the scanner or its config, or set ROMP_NO_GITLEAKS=1 for one push." >&2
+    fi
+}
+
+scan_identifiers
+scan_credentials
+
+# Both scans have reported; one bypass line, then the verdict.
+if [ "$blocked_ids" -ne 0 ] || [ "$blocked_creds" -ne 0 ] || [ "$failed_scan" -ne 0 ]; then
     echo "  To bypass for one push (you are sure it is fine): git push --no-verify" >&2
     exit 1
 fi

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,28 @@
+# gitleaks config: the secret scanner's rules for this repo.
+#
+# The privacy rule in CLAUDE.md is about identifiers a human recognises (names,
+# hostnames, real transcripts) and is enforced by the pre-push denylist. This is
+# the other half: credentials, which no denylist can anticipate because nobody
+# knows a token's text until it leaks. gitleaks runs over every PUSHED commit in
+# .githooks/pre-push, reading this file.
+#
+# Start from gitleaks' own rule set and only ever SUBTRACT from it here, with a
+# reason. An allowlist is a standing claim that a match is not a credential; a
+# wrong one is invisible forever after, so keep each entry as narrow as the
+# thing it excuses: an exact value beats a pattern, a pattern beats a path, and
+# a whole-path exclusion is almost never right (it silences the scanner for
+# every future line in that file too).
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = """
+RFC 6455's own example Sec-WebSocket-Key. The WebSocket handshake key is a
+client nonce the protocol requires to be random, so it trips the entropy rule in
+generic-api-key; but this exact string is the base64 of "the sample nonce",
+published in the RFC, and it is what the kernel's handshake tests hand a fake
+request. Allowlisted by exact value, so a real high-entropy key on the same line
+is still caught. ANCHORED (^...$): unanchored, this would also excuse any secret
+that merely CONTAINS the nonce as a substring.
+"""
+regexes = ['''^dGhlIHNhbXBsZSBub25jZQ==$''']

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,32 @@ This repo may go public; assume every commit is permanent and world-readable.
   text only, so screenshots and recordings under `docs/assets/` must be
   eyeballed for on-screen session content before release.
 
+### Credentials: the pre-push hook runs gitleaks over every pushed commit
+The rule above is about identifiers a human can enumerate. Credentials are the
+other half and cannot work that way: nobody knows a token's text until it leaks,
+so there is no list to write. **gitleaks** covers them: `.githooks/pre-push`
+runs it over the commits a push would publish (a merge by its first-parent diff,
+so a secret typed into a conflict resolution is read too) and refuses the push
+on a hit. No gitleaks on the machine means a loud notice and no scan (requiring
+an install to push would break every clone that never asked for it); a gitleaks
+that fails to run refuses the push and says so. `ROMP_NO_GITLEAKS=1` skips the
+scan, `ROMP_GITLEAKS` points at a binary. This is the same hook as the
+identifier scan and both report before it refuses, so one push tells you about
+both. Three things follow for anyone touching this:
+- **A hit means rotate, not amend.** A credential that reached a commit is
+  compromised from that moment; removing it in a later commit leaves it in the
+  old one, and on a repo that may go public that is a published secret. Rotate
+  first, then clean the history.
+- **Excuse a false positive narrowly, in `.gitleaks.toml`, with a reason**: an
+  exact value, never a path. A path exclusion silences the scanner for every
+  future line in that file. There is one entry today (RFC 6455's published
+  example WebSocket key, which the kernel's handshake tests use), allowlisted by
+  value so a real key on the same line is still caught.
+- **Do not write a credential-shaped literal into a test fixture.** The scanner
+  reads this repo too, so a longhand fake token flags the very test that proves
+  the scanner works; assemble probes at run time, as
+  `tests/gitleaks-config.bats` does.
+
 ## Worktrees — work on an isolated worktree by default (user rule, 2026-06-29)
 Do ALL non-trivial work on its own git worktree, not the shared main tree — concurrent
 peer sessions clobber/commit each other's uncommitted edits in the shared tree (a peer's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,12 @@ bats tests/*.bats          # the shell surfaces (hooks, postal, manager)
 cd vscode-extension && npm ci && npm test
 ```
 
+`tests/gitleaks-config.bats` checks the secret-scanning rules in `.gitleaks.toml`
+against the real scanner and skips itself when `gitleaks` is not installed
+(`brew install gitleaks`, or a release binary; `ROMP_GITLEAKS` names one that is
+not on `PATH`). Installing it also arms the credential half of the `pre-push`
+hook, which is worth having before you push anything.
+
 The Python and shell suites are also the CI gate, across Python 3.10 to 3.13 on
 Linux; the macOS cells run on demand from the Actions tab (they are billed even
 on a public repo, so they are not part of the per-push matrix).

--- a/tests/gitleaks-config.bats
+++ b/tests/gitleaks-config.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+
+# .gitleaks.toml and the credential scan, exercised against the REAL scanner
+# (tests/install-sh.bats stubs it, because what it tests there is the hook's
+# wiring; what is under test here is the config itself, and what a push through
+# the hook looks like when gitleaks really runs, which a stub cannot check).
+#
+# Skipped when gitleaks is not installed, so a clone that never wanted the
+# scanner still runs a green suite. ROMP_GITLEAKS names a binary that is not on
+# PATH, as it does for the hook.
+#
+# Nothing in this file may contain a credential-shaped literal: gitleaks scans
+# this repo, and a fixture secret written out longhand would flag the very test
+# that proves the scanner works. The probes below are assembled at run time and
+# only ever exist in a temp file.
+
+ROMP_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+load git-hermetic
+
+setup() {
+    git_hermetic
+    GL="${ROMP_GITLEAKS:-$(command -v gitleaks || true)}"
+    if [ -z "$GL" ] || [ ! -x "$GL" ]; then skip "gitleaks not installed"; fi
+    TEST_DIR="$(mktemp -d)"
+    CFG="$ROMP_DIR/.gitleaks.toml"
+}
+
+teardown() { rm -rf "${TEST_DIR:-}"; }
+
+# Exit 2 is a finding, 1 is gitleaks failing (an unreadable config, say), so a
+# case that expects a finding cannot pass on a scanner that never scanned.
+scan() { "$GL" dir "$TEST_DIR" --no-banner --redact --exit-code 2 --config "$CFG"; }
+
+# ghp_ + 36 chars, assembled so the literal never lives in a tracked file.
+probe_token() { printf 'gh%s_%s%s' p "$(printf '0123456789%.0s' 1 2 3)" abcdef; }
+
+@test "the config parses and the committed tree is clean" {
+    # HEAD's tracked content, not the working tree: a scratch file or an ignored
+    # build product in a developer's clone is not the repo's to answer for.
+    mkdir "$TEST_DIR/tree"
+    git -C "$ROMP_DIR" archive HEAD | tar -x -C "$TEST_DIR/tree"
+    run "$GL" dir "$TEST_DIR/tree" --no-banner --redact --exit-code 2 --config "$CFG"
+    [ "$status" -eq 0 ]
+}
+
+@test "every commit in this branch's history is clean" {
+    # Each merge by its first-parent diff, as the hook scans it.
+    run "$GL" git "$ROMP_DIR" --no-banner --redact --exit-code 2 --config "$CFG" \
+        --log-opts="HEAD --diff-merges=first-parent"
+    [ "$status" -eq 0 ]
+}
+
+@test "a planted credential is caught" {
+    printf 'token = "%s"\n' "$(probe_token)" > "$TEST_DIR/probe.py"
+    run scan
+    [ "$status" -eq 2 ]
+}
+
+@test "a secret introduced only in a merge commit is caught by the history scan" {
+    # `gitleaks git` runs `git log -p`, which shows NO diff for a merge commit by default, so a
+    # credential added during a conflict resolution (present in neither parent, only the merge
+    # tree) is scanned by nothing. The hook passes --diff-merges=first-parent to close that; this
+    # proves the flag actually surfaces the secret, against the real scanner.
+    R="$TEST_DIR/repo"; mkdir -p "$R"
+    git -C "$R" init -q
+    git -C "$R" symbolic-ref HEAD refs/heads/main     # whatever init.defaultBranch says
+    echo base > "$R/base"; git -C "$R" add -A && git -C "$R" commit -qm base
+    git -C "$R" checkout -q -b side; echo sideline > "$R/s"; git -C "$R" add -A && git -C "$R" commit -qm side
+    git -C "$R" checkout -q main
+    echo mainline > "$R/m"; git -C "$R" add -A && git -C "$R" commit -qm main
+    git -C "$R" merge -q --no-commit side
+    # the secret lands ONLY in the merge tree, assembled at run time, never a tracked literal
+    printf 'token = "%s"\n' "$(probe_token)" > "$R/evil.py"
+    git -C "$R" add -A && git -C "$R" commit -qm "merge (evil)"
+
+    # Default log-opts (the gap): the merge diff is never shown, so the secret is missed. A
+    # scanner that shows merge diffs on its own makes the flag redundant, not wrong, so that is
+    # a skip, not a failure.
+    run "$GL" git "$R" --no-banner --redact --exit-code 2 --config "$CFG" --log-opts=--all
+    [ "$status" -ne 1 ]
+    [ "$status" -eq 0 ] || skip "this gitleaks reads merge diffs by default; the flag is redundant here"
+    # With the flag the hook passes, the first-parent diff surfaces it and the scan refuses.
+    run "$GL" git "$R" --no-banner --redact --exit-code 2 --config "$CFG" \
+        --log-opts="--all --diff-merges=first-parent"
+    [ "$status" -eq 2 ]
+}
+
+@test "RFC 6455's example WebSocket key is excused" {
+    # The handshake nonce the kernel's tests hand a fake request. High entropy by
+    # protocol design, published in the RFC, not a credential.
+    printf 'headers = {"Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ=="}\n' > "$TEST_DIR/probe.py"
+    run scan
+    [ "$status" -eq 0 ]
+}
+
+@test "the excuse is the EXACT nonce: a secret that merely contains it still trips" {
+    # Unanchored, the allowlist regex forgives any secret with the nonce as a substring. Anchored
+    # (^...$) it excuses only the one published value. Assembled from pieces at run time: the nonce
+    # itself is the excused value (fine to appear), but the full SUPERSTRING as one tracked literal
+    # would, correctly, trip the scan of this very repo.
+    printf 'api_key = "%s%s%s"\n' "dGhlIHNhbXBsZSBub25jZQ==" "Zk8vQ2xhdWRl" "U2VjcmV0OTk5" > "$TEST_DIR/probe.py"
+    run scan
+    [ "$status" -eq 2 ]
+}
+
+@test "the excuse is the value, not the header: another WebSocket key still trips" {
+    # The narrowness that makes the allowlist safe: it forgives one published
+    # string, not every line that mentions Sec-WebSocket-Key. Halves, because a
+    # whole one written here would trip the scan of this very repo.
+    printf 'headers = {"Sec-WebSocket-Key": "%s%s"}\n' "9kLm2QpXvTz7" "RbNc4WdY1A==" > "$TEST_DIR/probe.py"
+    run scan
+    [ "$status" -eq 2 ]
+}
+
+# ── the hook, with the real scanner ────────────────────────────────────────
+# A clone with the hook installed and a bare remote, pushed to for real. No
+# denylist (the identifier scan stands down) and no .gitleaks.toml (default
+# rules): what is under test is the hook running gitleaks, not the config.
+hook_repo() {
+    export XDG_CONFIG_HOME="$TEST_DIR/cfg"
+    export ROMP_GITLEAKS="$GL"
+    unset ROMP_NO_GITLEAKS
+    git init -q "$TEST_DIR/remote.git" --bare
+    WORK="$TEST_DIR/work"
+    git init -q "$WORK"
+    git -C "$WORK" symbolic-ref HEAD refs/heads/main
+    mkdir -p "$WORK/.git/hooks"
+    cp "$ROMP_DIR/.githooks/pre-push" "$WORK/.git/hooks/pre-push"
+    git -C "$WORK" remote add origin "$TEST_DIR/remote.git"
+    echo base > "$WORK/base.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm base
+    git -C "$WORK" push -q origin HEAD:main
+}
+
+@test "through the hook: a pushed credential is refused, its file named, its value redacted" {
+    hook_repo
+    printf 'token = "%s"\n' "$(probe_token)" > "$WORK/probe.py"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm probe
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"gitleaks found a credential"* ]]
+    [[ "$output" == *"probe.py"* ]]              # -v: the file to fix
+    [[ "$output" == *"github-pat"* ]]            # and the rule that matched
+    [[ "$output" != *"$(probe_token)"* ]]        # --redact: the value stays out of the terminal
+    [ "$(git -C "$TEST_DIR/remote.git" rev-parse main)" != "$(git -C "$WORK" rev-parse HEAD)" ]
+}
+
+@test "through the hook: a force-push over a remote tip this clone never fetched is refused" {
+    # Another clone moves the branch; this one force-pushes a secret without
+    # fetching. gitleaks handed a range with a sha it cannot resolve scans no
+    # commits and exits 0, so the hook has to fall back to a range it can.
+    hook_repo
+    git clone -q -b main "$TEST_DIR/remote.git" "$TEST_DIR/other"
+    echo other > "$TEST_DIR/other/other.txt"
+    git -C "$TEST_DIR/other" add -A && git -C "$TEST_DIR/other" commit -qm other
+    git -C "$TEST_DIR/other" push -q origin HEAD:main
+    printf 'token = "%s"\n' "$(probe_token)" > "$WORK/probe.py"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm probe
+    run git -C "$WORK" push --force origin HEAD:main
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"gitleaks found a credential"* ]]
+    [ "$(git -C "$TEST_DIR/remote.git" rev-parse main)" = "$(git -C "$TEST_DIR/other" rev-parse HEAD)" ]
+}

--- a/tests/install-sh.bats
+++ b/tests/install-sh.bats
@@ -317,6 +317,10 @@ PY
 # remote, with a SYNTHETIC denylist (never a real identifier) via XDG_CONFIG_HOME.
 setup_hook_repo() {
     export XDG_CONFIG_HOME="$TEST_DIR/cfg"
+    # Pin the credential half OFF for the identifier tests: whether the machine
+    # happens to have gitleaks on PATH must not change what they assert. The
+    # gitleaks tests below turn it back on with a stub.
+    export ROMP_NO_GITLEAKS=1
     mkdir -p "$XDG_CONFIG_HOME/romp"
     printf '# synthetic denylist\n\nZZBANNEDZZ\n' > "$XDG_CONFIG_HOME/romp/private-strings.txt"
     git init -q "$TEST_DIR/remote.git" --bare
@@ -393,6 +397,253 @@ setup_hook_repo() {
     git -C "$WORK" add -A && git -C "$WORK" commit -qm leak
     run git -C "$WORK" push origin HEAD:main
     [ "$status" -eq 0 ]
+}
+
+# ── the credential half of the same hook (gitleaks) ───────────────────────
+# A denylist can only catch strings you can enumerate, and nobody can enumerate
+# a token before it leaks, so the hook also runs gitleaks over the pushed
+# commits. These tests stub the scanner via ROMP_GITLEAKS: what is under test is
+# the hook's wiring (which commits it hands over, what it does with the verdict),
+# not gitleaks' own rules, and a stub keeps the suite deterministic on a machine
+# that has never installed it. The rules and .gitleaks.toml are exercised for
+# real in tests/gitleaks-config.bats.
+
+setup_gitleaks_stub() {   # <exit-code>: records its args, then exits that code
+    # 0 is a clean scan; 2 is a finding (the hook asks gitleaks to report one so,
+    # apart from its own failures); 1 is gitleaks failing.
+    unset ROMP_NO_GITLEAKS
+    GL_ARGS="$TEST_DIR/gitleaks.args"
+    export ROMP_GITLEAKS="$TEST_DIR/gitleaks-stub"
+    cat > "$ROMP_GITLEAKS" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> "$GL_ARGS"
+echo "stub scanner ran" >&2
+exit $1
+EOF
+    chmod +x "$ROMP_GITLEAKS"
+}
+
+@test "pre-push hook: a credential found in a pushed commit blocks the push" {
+    setup_hook_repo
+    setup_gitleaks_stub 2
+    echo "whatever" > "$WORK/f.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm work
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"BLOCKED"* ]]
+    # The advice has to say rotate: a secret in a commit is already compromised,
+    # and deleting it in a later commit does not un-publish it.
+    [[ "$output" == *"ROTATE"* ]]
+}
+
+@test "pre-push hook: a scanner that fails refuses the push and says so, not that it found something" {
+    # gitleaks exits 1 when it cannot run (an unreadable config, say) and 2, at
+    # the hook's asking, on a finding. Publishing unscanned would be the silent
+    # failure the scan exists to prevent, so a failure refuses too; but the
+    # advice is to fix the scanner, not to rotate a credential nobody found.
+    setup_hook_repo
+    setup_gitleaks_stub 1
+    echo "whatever" > "$WORK/f.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm work
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"BLOCKED"* ]]
+    [[ "$output" == *"could not scan"* ]]
+    [[ "$output" != *"ROTATE"* ]]
+    [[ "$output" == *"git push --no-verify"* ]]
+}
+
+@test "pre-push hook: a credential is still refused on a clone with NO denylist" {
+    # Any contributor's clone: no private-strings file. The identifier scan has
+    # nothing to read there and stands down; the credential scan must run all
+    # the same, so a hook that ends when the denylist is missing is wrong.
+    setup_hook_repo
+    rm "$XDG_CONFIG_HOME/romp/private-strings.txt"
+    setup_gitleaks_stub 2
+    echo "whatever" > "$WORK/f.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm work
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"gitleaks found a credential"* ]]
+    [ -f "$GL_ARGS" ]      # the scanner really ran
+}
+
+@test "pre-push hook: a credential is still refused when the denylist bans nothing" {
+    # The other way the identifier scan stands down: a file of comments and blanks.
+    setup_hook_repo
+    printf '# just a comment\n\n   \n' > "$XDG_CONFIG_HOME/romp/private-strings.txt"
+    setup_gitleaks_stub 2
+    echo "whatever" > "$WORK/f.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm work
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"gitleaks found a credential"* ]]
+}
+
+@test "pre-push hook: a clean scan lets the push through" {
+    setup_hook_repo
+    setup_gitleaks_stub 0
+    echo "whatever" > "$WORK/f.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm work
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -eq 0 ]
+    [ -f "$GL_ARGS" ]      # it really did run
+    # --redact keeps the value out of the terminal, -v names the file, line and
+    # rule (without it gitleaks prints a count). tests/gitleaks-config.bats
+    # checks both against the real scanner; this pins the wiring.
+    [[ "$(cat "$GL_ARGS")" == *"--redact -v"* ]]
+    [[ "$(cat "$GL_ARGS")" != *"--config"* ]]   # no .gitleaks.toml in this repo: default rules
+}
+
+@test "pre-push hook: the repo's .gitleaks.toml is handed to the scanner by name" {
+    # Explicit, not left to gitleaks' own lookup: with no --config it reads a
+    # GITLEAKS_CONFIG from the environment before the source root, and a
+    # developer's own config would replace the repo's rules.
+    setup_hook_repo
+    setup_gitleaks_stub 0
+    printf '[extend]\nuseDefault = true\n' > "$WORK/.gitleaks.toml"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm rules
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -eq 0 ]
+    root="$(git -C "$WORK" rev-parse --show-toplevel)"
+    [[ "$(cat "$GL_ARGS")" == *"--config $root/.gitleaks.toml"* ]]
+}
+
+@test "pre-push hook: only the commits being pushed are handed to the scanner" {
+    # The same rule the identifier scan follows: a secret that already escaped
+    # must not block every later push, and the tip alone is not what ships.
+    setup_hook_repo
+    setup_gitleaks_stub 0
+    echo "old" > "$WORK/old.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm old
+    git -C "$WORK" push --no-verify -q origin HEAD:main
+    old_sha="$(git -C "$WORK" rev-parse HEAD)"
+    echo "new" > "$WORK/new.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm new
+    new_sha="$(git -C "$WORK" rev-parse HEAD)"
+
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -eq 0 ]
+    # The hook hands gitleaks the range the identifier scan walks: the pushed
+    # tip, minus every ref any fetched remote already has and the remote's old
+    # tip (see rev_range in the hook).
+    [[ "$(cat "$GL_ARGS")" == *"--log-opts=$new_sha --not --remotes $old_sha"* ]]
+}
+
+@test "pre-push hook: the scan asks git to show merge-commit diffs" {
+    # `gitleaks git` runs `git log -p`, which shows NO diff for a merge commit by default, so a
+    # secret introduced only in a conflict resolution would be handed to the scanner as empty. The
+    # hook must pass --diff-merges=first-parent so merge content is actually scanned. Wiring only;
+    # the real "the secret is caught" proof is in gitleaks-config.bats against real gitleaks.
+    setup_hook_repo
+    setup_gitleaks_stub 0
+    echo "whatever" > "$WORK/f.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm work
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$GL_ARGS")" == *"--diff-merges=first-parent"* ]]
+}
+
+@test "pre-push hook: a brand-new branch is scanned from its first commit" {
+    setup_hook_repo
+    setup_gitleaks_stub 0
+    echo "first" > "$WORK/f.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm first
+    sha="$(git -C "$WORK" rev-parse HEAD)"
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$GL_ARGS")" == *"--log-opts=$sha --not --remotes"* ]]
+}
+
+@test "pre-push hook: a force-push over a remote tip this clone never fetched still scans" {
+    # Another clone moves the branch; this one force-pushes without fetching,
+    # so the remote's tip is a sha git cannot find here. gitleaks handed that
+    # range logs git's error, scans no commits and exits 0, and a secret in the
+    # push would go out unscanned. The hook falls back the way the identifier
+    # scan does, to everything the pushed tip reaches: the unknown sha is not
+    # in what the scanner is given.
+    setup_hook_repo
+    setup_gitleaks_stub 0
+    echo "base" > "$WORK/base.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm base
+    git -C "$WORK" push --no-verify -q origin HEAD:main
+    git clone -q -b main "$TEST_DIR/remote.git" "$TEST_DIR/other"
+    echo "other" > "$TEST_DIR/other/other.txt"
+    git -C "$TEST_DIR/other" add -A && git -C "$TEST_DIR/other" commit -qm other
+    git -C "$TEST_DIR/other" push -q origin HEAD:main
+    other_sha="$(git -C "$TEST_DIR/other" rev-parse HEAD)"
+    echo "mine" > "$WORK/mine.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm mine
+    sha="$(git -C "$WORK" rev-parse HEAD)"
+    run git -C "$WORK" push --force origin HEAD:main
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$GL_ARGS")" == *"--log-opts=$sha --diff-merges=first-parent"* ]]
+    [[ "$(cat "$GL_ARGS")" != *"$other_sha"* ]]
+}
+
+@test "pre-push hook: deleting a remote branch consults no scanner" {
+    # A deletion pushes nothing (the local sha is all zeros); handing that to
+    # gitleaks would only make it log a git error and scan nothing.
+    setup_hook_repo
+    setup_gitleaks_stub 0
+    echo "whatever" > "$WORK/f.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm work
+    git -C "$WORK" push --no-verify -q origin HEAD:feat
+    run git -C "$WORK" push origin :feat
+    [ "$status" -eq 0 ]
+    [ ! -e "$GL_ARGS" ]
+}
+
+@test "pre-push hook: no gitleaks installed says so out loud and still pushes" {
+    # Requiring an install to push would break every clone that never asked for
+    # the scanner. Loud, not blocking.
+    setup_hook_repo
+    unset ROMP_NO_GITLEAKS
+    echo "whatever" > "$WORK/f.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm work
+    ROMP_GITLEAKS="$TEST_DIR/not-a-binary" run git -C "$WORK" push origin HEAD:main
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"gitleaks not installed"* ]]
+    [[ "$output" == *"WITHOUT a secret scan"* ]]
+}
+
+@test "pre-push hook: ROMP_NO_GITLEAKS=1 silences the scan and its notice" {
+    setup_hook_repo
+    setup_gitleaks_stub 2                 # a scanner that WOULD refuse, if consulted
+    export ROMP_NO_GITLEAKS=1             # the pin setup_hook_repo sets; the stub helper unset it
+    echo "whatever" > "$WORK/f.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm work
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -eq 0 ]
+    [ ! -e "$GL_ARGS" ]                   # never consulted
+    [[ "$output" != *"secret scan"* ]]    # and no notice about one
+    [[ "$output" != *"romp pre-push"* ]]  # a clean push under the pin says nothing at all
+}
+
+@test "pre-push hook: --no-verify bypasses the credential block too" {
+    setup_hook_repo
+    setup_gitleaks_stub 2
+    echo "whatever" > "$WORK/f.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm work
+    run git -C "$WORK" push --no-verify origin HEAD:main
+    [ "$status" -eq 0 ]
+}
+
+@test "pre-push hook: both scanners report before the push is refused" {
+    # One push, two findings: the developer should learn about both in one go
+    # rather than fixing the identifier, pushing again, and meeting the secret.
+    setup_hook_repo
+    setup_gitleaks_stub 2
+    printf 'leak ZZBANNEDZZ here\n' > "$WORK/leak.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm leak
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"personal identifier"* ]]
+    [[ "$output" == *"gitleaks found a credential"* ]]
+    # One bypass line, after both verdicts.
+    [ "$(grep -c -- 'git push --no-verify' <<<"$output")" -eq 1 ]
+    [[ "${output##*personal identifier}" == *"git push --no-verify"* ]]
+    [[ "${output##*gitleaks found a credential}" == *"git push --no-verify"* ]]
 }
 
 # ─── Claude Code version notice ──────────────────────────────────────

--- a/tests/pre-push-hook.bats
+++ b/tests/pre-push-hook.bats
@@ -47,6 +47,7 @@ setup() {
     printf '# synthetic\nzzsynthuser\nTESTHOST\n' > "$STRINGS"
 
     export ROMP_PRIVATE_STRINGS="$STRINGS"
+    export ROMP_NO_GITLEAKS=1          # the credential half has its own test file
 }
 
 teardown() { rm -rf "${TEST_DIR:-}"; }


### PR DESCRIPTION
The pre-push hook gains a second scan: gitleaks over every commit a push publishes, merge commits read by their first-parent diff, so a credential is refused at push time the way a listed identifier already is. Follows #1271 (merged), whose symlink pass in the tip scan the wrapper here encloses.

## Why

A credential committed to this repo pushes through the hook today. The hook reads pushed commits for the strings in a machine's private-strings denylist, and a denylist can name identifiers but never a token: a token's text is unknown until it leaks. The repo may go public, where a key in any commit is published from the moment it lands, and a key removed in a later commit is still in the old one.

What the scan covers:

- Every commit the push publishes. The range per ref is the one the identifier scan already walks (`rev_range`: the pushed tip, minus what any fetched remote holds and the remote's old tip), so a secret in an intermediate commit whose tip is clean is caught, and a secret that already reached a remote does not refuse every later push; it is rotated. A range this clone cannot resolve (a force-push over a remote tip nobody fetched) falls back to everything the pushed tip reaches, as the identifier scan's does. Without that, gitleaks handed the unresolvable range logs git's error, scans no commits, exits 0, and the secret goes out unscanned.
- Merge commits, by their first-parent diff. `gitleaks git` runs `git log -p`, which shows no diff for a merge by default, so a secret typed into a conflict resolution, present in neither parent, would be scanned by nothing. `--diff-merges=first-parent` surfaces that content; non-merges are unaffected. `tests/gitleaks-config.bats` proves the flag surfaces a merge-only secret against the real scanner.
- Both scans report before one refusal. A push with an identifier and a credential names both, then prints one bypass line.

`tests/git-hermetic.bash` notes a gitleaks pre-commit hook already running on one development machine; this is the same scan at push time, carried by the repo, so every clone that installs gitleaks gets it. No CI job runs the scanner: the bats cases here run wherever the suite runs, with a stub, and the cases that need the real scanner skip themselves where it is not installed. Every document in this change says the hook scans at push time.

## Design

- **The identifier code is wrapped unchanged.** `scan_identifiers()` is the existing loop, the symlink pass included, indented into a function; its two early `exit 0`s (no denylist file, a denylist that bans nothing) became `return 0`. Every contributor's clone has no denylist, so a credential scan appended after those exits would never run there. Two tests pin it: a credential is refused with no denylist, and with a denylist that bans nothing.
- **An absent scanner prints a notice and lets the push through.** Requiring an install to push would break every clone that never asked for the scanner. `ROMP_NO_GITLEAKS=1` skips the scan and the notice; `ROMP_GITLEAKS` names a binary that is not on `PATH`. The two bats files that drive the identifier scan pin `ROMP_NO_GITLEAKS=1`, so their results do not depend on what a machine has installed.
- **A scanner that fails refuses the push, and says that.** gitleaks exits 1 when it cannot run (an unreadable config, say); the hook asks for exit 2 on a finding (`--exit-code 2`), so the two are told apart. Both refuse, because publishing unscanned is the silent failure the scan exists to prevent, but the advice differs: rotate for a finding, fix the scanner (or `ROMP_NO_GITLEAKS=1` for one push) for a failure.
- **A finding names the file, line and rule; the value is redacted.** `--redact` keeps the secret out of scrollback, and `-v` prints the location, without which gitleaks reports only a count. The refusal says rotate, then remove.
- **The repo's rules are passed by name.** Without `--config`, gitleaks reads a `GITLEAKS_CONFIG` from the environment before the source root's `.gitleaks.toml`, so a developer's own config (for a pre-commit hook of theirs) would replace the repo's rules. A tree without the file scans under the default rules.
- **One allowlist entry, by exact anchored value.** `.gitleaks.toml` extends the default rules and subtracts only RFC 6455's published example `Sec-WebSocket-Key`, which the kernel's handshake tests hand a fake request and which trips the generic-api-key entropy rule at four sites (three existing tests and the new bats probe). Anchored `^...$`, so a key on the same line, or a secret that merely contains the nonce, still trips; a path exclusion would silence the scanner for every future line in that file. Under default rules those four are the only findings in the tree; with the config, the committed tree and every commit in this branch's history scan clean.
- **No credential-shaped literal in a fixture.** The config tests assemble their probe tokens at run time, since a longhand fake token would flag the very test that proves the scanner works. CLAUDE.md records the rule, with rotate-not-amend and excuse-by-value.
- **Considered and left out.** Scanning the working tree: a push publishes commits, and the identifier scan moved off the tree for the same reason. Failing the push when gitleaks is absent: breaks clones that never opted in. Pinning a gitleaks version in the hook: whatever is installed runs, and the config tests are the arbiter of the rules. A CI job: a separate change.

## Tests

Each test executes the real code path and is red before the change.

- `tests/install-sh.bats`, a credential section that stubs the scanner through `ROMP_GITLEAKS` and pushes to a bare remote for real: a finding (stub exit 2) refuses with BLOCKED and ROTATE; a scanner failure (exit 1) refuses saying it could not scan, without the rotate advice; a credential is refused on a clone with no denylist (the hook before this change exits 0 before any scan) and with a denylist that bans nothing; a clean scan pushes, with `--redact -v` passed and no `--config` when the repo has no `.gitleaks.toml`; the repo's `.gitleaks.toml` is passed by name when it exists; only the commits being pushed are handed over, as `--log-opts=<tip> --not --remotes <old>`; `--diff-merges=first-parent` is passed; a new branch is scanned from its first commit; a force-push over a remote tip this clone never fetched hands the scanner the tip alone, not the unresolvable sha; deleting a remote branch consults no scanner; `ROMP_GITLEAKS` at a non-binary prints the notice and pushes; `ROMP_NO_GITLEAKS=1` leaves a configured stub unconsulted; `--no-verify` bypasses; one push with an identifier and a credential reports both, then exactly one bypass line, after both verdicts. Before: 12 of 44 fail (the `ROMP_NO_GITLEAKS`, `--no-verify` and branch-deletion cases pass vacuously, no scan having run at all). After: 44/44.
- `tests/gitleaks-config.bats`, against the real scanner, skipping when none is installed, with a finding asserted as exit 2 so a scanner that failed to load the config cannot pass a case for it: the config parses and the committed tree (`git archive HEAD`) is clean; every commit in this branch's history is clean; an assembled `ghp_` token is caught; a secret present only in a merge commit is caught with `--diff-merges=first-parent` (the default scan's miss is a skip, not a failure, on a scanner that reads merge diffs by itself); the nonce is excused; a superstring of the nonce, and another WebSocket key, still trip. Through the installed hook with the real scanner: a pushed token is refused with its file and rule named and its value redacted, and a force-push over an unfetched remote tip is refused with the remote left where the other clone put it. Before: 9 of 9 fail (no config file, no scan in the hook). After: 9/9, under gitleaks 8.28.0 and 8.30.1.
- `tests/pre-push-hook.bats`: 22/22 before and after; its setup now pins `ROMP_NO_GITLEAKS=1`.

`shellcheck -S warning .githooks/pre-push` is clean. Removing any one of `--redact -v`, the `--config` line, the zero-sha skip, the range fallback or the exit-code split, or printing a second bypass line, turns exactly its test red. The hook run by hand on this commit, with a real denylist and the real scanner, passes.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
